### PR TITLE
Compile glibc without -fstack-protector.

### DIFF
--- a/pkgs/development/libraries/glibc/2.13/common.nix
+++ b/pkgs/development/libraries/glibc/2.13/common.nix
@@ -103,6 +103,7 @@ stdenv.mkDerivation ({
     "--enable-add-ons"
     "--sysconfdir=/etc"
     "--localedir=/var/run/current-system/sw/lib/locale"
+    "libc_cv_ssp=no"
     (if kernelHeaders != null
      then "--with-headers=${kernelHeaders}/include"
      else "--without-headers")

--- a/pkgs/development/libraries/glibc/2.14/common.nix
+++ b/pkgs/development/libraries/glibc/2.14/common.nix
@@ -97,6 +97,7 @@ stdenv.mkDerivation ({
     "--enable-add-ons"
     "--sysconfdir=/etc"
     "--localedir=/var/run/current-system/sw/lib/locale"
+    "libc_cv_ssp=no"
     (if kernelHeaders != null
      then "--with-headers=${kernelHeaders}/include"
      else "--without-headers")


### PR DESCRIPTION
At least until NixOS fully supports -fstack-protector it's better to turn it off
at the moment, as previous successful builds didn't include it either.
