### PR TITLE
New version of Xpra from the fork

### DIFF
--- a/pkgs/development/interpreters/cython/default.nix
+++ b/pkgs/development/interpreters/cython/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, python, pkgconfig }:
+
+stdenv.mkDerivation {
+  name = "cython-0.16";
+
+  src = fetchurl {
+    url = http://www.cython.org/release/Cython-0.16.tar.gz;
+    sha256 = "1yz6jwv25xx5mbr2nm4l7mi65gvpm63dzi3vrw73p51wbpy525lp";
+  };
+
+  buildPhase = "python setup.py build --build-base $out";
+
+  installPhase = "python setup.py install --prefix=$out";
+
+  buildInputs = [ python pkgconfig ];
+
+  meta = {
+    description = "An interpreter to help writing C extensions for Python";
+  };
+}

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, python, cython
-, pygtk, pygobject, pycairo, xlibs, gtk
+, pygtk, pygobject, pycairo, notify, xlibs, gtk
 , ffmpeg, x264, libvpx, makeWrapper}:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,6 +1,8 @@
-{stdenv, fetchurl, pkgconfig, python, cython, pygtk, xlibs, gtk, ffmpeg, x264, libvpx, makeWrapper}:
+{ stdenv, fetchurl, pkgconfig, python, cython
+, pygtk, pygobject, pycairo, xlibs, gtk
+, ffmpeg, x264, libvpx, makeWrapper}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "xpra-0.3.2";
   
   src = fetchurl {
@@ -8,8 +10,10 @@ stdenv.mkDerivation {
     sha256 = "1s1z6r0r78qvf59ci3vxammjz7lj5m64jyk0bfn7yxd5jl3sy41y";
   };
 
+  buildNativeInputs = [ cython ];
+
   buildInputs = [
-    pkgconfig python cython pygtk gtk ffmpeg x264 libvpx makeWrapper
+    pkgconfig python pygtk gtk ffmpeg x264 libvpx makeWrapper
     xlibs.inputproto xlibs.libXcomposite xlibs.libXdamage xlibs.libXtst
   ];
 
@@ -19,13 +23,20 @@ stdenv.mkDerivation {
     ./do-build
   '';
 
+  pythonPaths = [
+    "$out/lib/python"
+    "$(toPythonPath ${pygtk})/gtk-2.0"
+  ] ++ map (i: "$(toPythonPath ${i})") [
+    pygobject pycairo notify
+  ];
+
   installPhase = ''
     mkdir -p $out
     cp -r install/* $out
 
     for i in $(cd $out/bin && ls); do
         wrapProgram $out/bin/$i \
-            --set PYTHONPATH "$out/lib/python:$(toPythonPath ${pygtk})/gtk-2.0:$PYTHONPATH" \
+            --set PYTHONPATH "${stdenv.lib.concatStringsSep ":" pythonPaths}" \
             --prefix PATH : "${xlibs.xauth}/bin:${xlibs.xorgserver}/bin:${xlibs.xmodmap}/bin"
     done
   '';

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,17 +1,15 @@
-{stdenv, fetchurl, pkgconfig, python, pyrex, pygtk, xlibs, gtk, makeWrapper}:
+{stdenv, fetchurl, pkgconfig, python, cython, pygtk, xlibs, gtk, ffmpeg, x264, libvpx, makeWrapper}:
 
 stdenv.mkDerivation {
-  name = "xpra-0.0.3";
+  name = "xpra-0.3.2";
   
   src = fetchurl {
-    url = http://partiwm.org/static/downloads/parti-all-0.0.3.tar.gz;
-    sha256 = "17inksd4cc7mba2vfs17gz1yk3h6x6wf06pm3hcbs5scq8rr5bkp";
+    url = http://xpra.org/src/xpra-0.3.2.tar.bz2;
+    sha256 = "1s1z6r0r78qvf59ci3vxammjz7lj5m64jyk0bfn7yxd5jl3sy41y";
   };
 
-  #src = /home/eelco/Dev/nixpkgs/parti-all-0.0.3;
-
   buildInputs = [
-    pkgconfig python pyrex pygtk gtk makeWrapper
+    pkgconfig python cython pygtk gtk ffmpeg x264 libvpx makeWrapper
     xlibs.inputproto xlibs.libXcomposite xlibs.libXdamage xlibs.libXtst
   ];
 
@@ -33,7 +31,7 @@ stdenv.mkDerivation {
   '';
   
   meta = {
-    homepage = http://partiwm.org/wiki/xpra;
+    homepage = http://xpra.org/;
     description = "Persistent remote applications for X";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1777,6 +1777,8 @@ let
 
   cmucl_binary = callPackage ../development/compilers/cmucl/binary.nix { };
 
+  cython = callPackage ../development/interpreters/cython { };
+
   dylan = callPackage ../development/compilers/gwydion-dylan {
     dylan = callPackage ../development/compilers/gwydion-dylan/binary.nix {  };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7683,7 +7683,9 @@ let
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix {
   };
 
-  xpra = callPackage ../tools/X11/xpra { };
+  xpra = callPackage ../tools/X11/xpra {
+    inherit (pythonPackages) notify;
+  };
 
   xscreensaver = callPackage ../misc/screensavers/xscreensaver {
     inherit (gnome) libglade;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7683,9 +7683,7 @@ let
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix {
   };
 
-  xpra = callPackage ../tools/X11/xpra {
-    pyrex = pyrex095;
-  };
+  xpra = callPackage ../tools/X11/xpra { };
 
   xscreensaver = callPackage ../misc/screensavers/xscreensaver {
     inherit (gnome) libglade;


### PR DESCRIPTION
This is because the original version is no longer in development, as stated on
the website at http://code.google.com/p/partiwm/wiki/xpra:

"This project is in deep hibernation; I haven't had time to devote for several
years now. If you are looking for xpra, you may prefer Antoine Martin's fork,
which receives more support. It is available at: http://xpra.org/"

So I guess its safe to switch over to that fork.
