### PR TITLE
Build Chromium from source

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/cups_allow_deprecated.patch
+++ b/pkgs/applications/networking/browsers/chromium/cups_allow_deprecated.patch
@@ -1,0 +1,14 @@
+diff --git a/printing/printing.gyp b/printing/printing.gyp
+index 19fa1b2..f11d76e 100644
+--- a/printing/printing.gyp
++++ b/printing/printing.gyp
+@@ -26,6 +26,9 @@
+       'include_dirs': [
+         '..',
+       ],
++      'cflags': [
++        '-Wno-deprecated-declarations',
++      ],
+       'sources': [
+         'backend/print_backend.cc',
+         'backend/print_backend.h',

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -8,7 +8,7 @@
 , v8, xdg_utils, yasm, zlib
 
 , python, perl, pkgconfig
-, nspr, udev
+, nspr, nss, udev
 , utillinux, alsaLib
 , gcc, bison, gperf
 , krb5
@@ -17,6 +17,7 @@
 
 , useSELinux ? false
 , naclSupport ? false
+, useOpenSSL ? true
 , gnomeKeyringSupport ? false
 , useProprietaryCodecs ? false
 }:
@@ -59,7 +60,7 @@ let
     bzip2 ffmpeg flac # harfbuzz
     icu libevent expat libjpeg
     libpng libwebp libxml2 libxslt # skia
-    speex sqlite openssl # stlport
+    speex sqlite # stlport
     v8 xdg_utils yasm zlib
   ];
 
@@ -78,6 +79,7 @@ in stdenv.mkDerivation rec {
     which makeWrapper
     python perl pkgconfig
     nspr udev
+    (if useOpenSSL then openssl else nss)
     utillinux alsaLib
     gcc bison gperf
     krb5
@@ -85,7 +87,7 @@ in stdenv.mkDerivation rec {
     libXScrnSaver libXcursor
   ] ++ stdenv.lib.optional gnomeKeyringSupport libgnome_keyring;
 
-  opensslPatches = openssl.patches;
+  opensslPatches = stdenv.lib.optional useOpenSSL openssl.patches;
 
   prePatch = "patchShebangs .";
 
@@ -101,7 +103,7 @@ in stdenv.mkDerivation rec {
     proprietary_codecs = false;
     use_gnome_keyring = gnomeKeyringSupport;
     disable_nacl = !naclSupport;
-    use_openssl = true;
+    use_openssl = useOpenSSL;
     selinux = useSELinux;
     use_cups = false;
   } // stdenv.lib.optionalAttrs (stdenv.system == "x86_64-linux") {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -25,7 +25,7 @@ let
     useOpenSSL = true;
     enableGnomeSupport = false;
     gnomeKeyringSupport = false;
-    useProprietaryCodecs = false;
+    useProprietaryCodecs = true;
     enableCUPS = false;
   };
 
@@ -41,7 +41,6 @@ let
 
   gypFlagsUseSystemLibs = {
     use_system_bzip2 = true;
-    use_system_ffmpeg = false; # FIXME: libavformat...
     use_system_flac = true;
     use_system_harfbuzz = false; # TODO
     use_system_icu = false; # FIXME: wrong version!
@@ -63,7 +62,7 @@ let
   };
 
   defaultDependencies = [
-    bzip2 ffmpeg flac # harfbuzz
+    bzip2 flac # harfbuzz
     icu libevent expat libjpeg
     libpng libwebp libxml2 libxslt # skia
     speex sqlite # stlport
@@ -117,6 +116,10 @@ in stdenv.mkDerivation rec {
     use_openssl = config.useOpenSSL;
     selinux = config.useSELinux;
     use_cups = config.enableCUPS;
+  } // stdenv.lib.optionalAttrs config.useProprietaryCodecs {
+    # enable support for the H.264 codec
+    proprietary_codecs = true;
+    ffmpeg_branding = "Chrome";
   } // stdenv.lib.optionalAttrs (stdenv.system == "x86_64-linux") {
     target_arch = "x64";
   } // stdenv.lib.optionalAttrs (stdenv.system == "i686-linux") {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,17 +1,15 @@
-{ stdenv, getConfig, fetchurl, fetchsvn, makeWrapper, which
+{ stdenv, getConfig, fetchurl, makeWrapper, which
 
 # default dependencies
-, bzip2, ffmpeg, flac
+, bzip2, flac, speex
 , libevent, expat, libjpeg
 , libpng, libxml2, libxslt
-, speex, sqlite
-, v8, xdg_utils, yasm, zlib
+, xdg_utils, yasm, zlib
 
 , python, perl, pkgconfig
-, nspr, udev
+, nspr, udev, krb5
 , utillinux, alsaLib
 , gcc, bison, gperf
-, krb5
 , glib, gtk, dbus_glib
 , libXScrnSaver, libXcursor, mesa
 
@@ -61,20 +59,19 @@ let
     use_system_yasm = true;
     use_system_zlib = true;
 
-    use_system_harfbuzz = false; # TODO
-    use_system_icu = false; # FIXME: wrong version!
+    use_system_harfbuzz = false;
+    use_system_icu = false;
     use_system_libwebp = false; # See chromium issue #133161
-    use_system_skia = false; # TODO
-    use_system_sqlite = false; # FIXME
-    use_system_v8 = false; # TODO...
+    use_system_skia = false;
+    use_system_sqlite = false; # See chromium issue #22208
+    use_system_v8 = false;
   };
 
   defaultDependencies = [
-    bzip2 flac
+    bzip2 flac speex
     libevent expat libjpeg
     libpng libxml2 libxslt
-    speex sqlite
-    v8 xdg_utils yasm zlib
+    xdg_utils yasm zlib
   ];
 
 in stdenv.mkDerivation rec {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -64,7 +64,8 @@ let
   ];
 
 in stdenv.mkDerivation rec {
-  name = "chromium-${version}";
+  name = "${packageName}-${version}";
+  packageName = "chromium";
 
   version = sourceInfo.version;
 
@@ -119,24 +120,24 @@ in stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -vp "$out/libexec/chrome"
-    cp -v "out/${buildType}/"*.pak "$out/libexec/chrome/"
-    cp -vR "out/${buildType}/locales" "out/${buildType}/resources" "$out/libexec/chrome/"
+    mkdir -vp "$out/libexec/${packageName}"
+    cp -v "out/${buildType}/"*.pak "$out/libexec/${packageName}/"
+    cp -vR "out/${buildType}/locales" "out/${buildType}/resources" "$out/libexec/${packageName}/"
 
-    cp -v "out/${buildType}/chrome" "$out/libexec/chrome/chrome"
+    cp -v "out/${buildType}/chrome" "$out/libexec/${packageName}/${packageName}"
 
     mkdir -vp "$out/bin"
-    makeWrapper "$out/libexec/chrome/chrome" "$out/bin/chrome"
+    makeWrapper "$out/libexec/${packageName}/${packageName}" "$out/bin/${packageName}"
 
     mkdir -vp "$out/share/man/man1"
-    cp -v "out/${buildType}/chrome.1" "$out/share/man/man1/chrome.1"
+    cp -v "out/${buildType}/chrome.1" "$out/share/man/man1/${packageName}.1"
 
     for icon_file in chrome/app/theme/chromium/product_logo_*[0-9].png; do
       num_and_suffix="''${icon_file##*logo_}"
       icon_size="''${num_and_suffix%.*}"
       logo_output_path="$out/share/icons/hicolor/''${icon_size}x''${icon_size}/apps"
       mkdir -vp "$logo_output_path"
-      cp -v "$icon_file" "$logo_output_path/chrome.png"
+      cp -v "$icon_file" "$logo_output_path/${packageName}.png"
     done
   '';
 

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -18,6 +18,7 @@
 , useSELinux ? false
 , naclSupport ? false
 , useOpenSSL ? true
+, enableGnomeSupport ? false
 , gnomeKeyringSupport ? false
 , useProprietaryCodecs ? false
 }:
@@ -83,9 +84,10 @@ in stdenv.mkDerivation rec {
     utillinux alsaLib
     gcc bison gperf
     krb5
-    glib gtk gconf libgcrypt dbus_glib
+    glib gtk dbus_glib
     libXScrnSaver libXcursor
-  ] ++ stdenv.lib.optional gnomeKeyringSupport libgnome_keyring;
+  ] ++ stdenv.lib.optional gnomeKeyringSupport libgnome_keyring
+    ++ stdenv.lib.optionals enableGnomeSupport [ gconf libgcrypt ];
 
   opensslPatches = stdenv.lib.optional useOpenSSL openssl.patches;
 
@@ -102,6 +104,8 @@ in stdenv.mkDerivation rec {
     linux_use_gold_flags = false;
     proprietary_codecs = false;
     use_gnome_keyring = gnomeKeyringSupport;
+    use_gconf = enableGnomeSupport;
+    use_gio = enableGnomeSupport;
     disable_nacl = !naclSupport;
     use_openssl = useOpenSSL;
     selinux = useSELinux;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,62 +1,87 @@
-{ GConf, alsaLib, bzip2, cairo, cups, dbus, dbus_glib, expat
-, fetchurl, ffmpeg, fontconfig, freetype, libX11, libXfixes
-, glib, gtk, gdk_pixbuf, pango
-, libXScrnSaver, libXdamage, libXext, libXrender, libXt, libXtst, libXcomposite
-, libgcrypt, libjpeg, libpng, makeWrapper, nspr, nss, patchelf
-, stdenv, unzip, zlib, pam, pcre, udev }:
+{ stdenv, fetchurl, fetchsvn
+, python, perl, pkgconfig
+, nspr, nss, udev, bzip2
+, utillinux, alsaLib
+, gcc, bison, gperf
+, krb5
+, glib, gtk, gconf, libgcrypt, libgnome_keyring, dbus_glib
+, libXScrnSaver, libXcursor
 
-assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" ;
+, useSELinux ? false
+, naclSupport ? false
+, gnomeKeyringSupport ? false
+, useProprietaryCodecs ? false
+}:
 
-stdenv.mkDerivation rec {
-  name = "chromium-19.0.1061.0-pre${version}";
+let
+  mkGypFlags = with stdenv.lib; let
+    sanitize = value:
+      if value == true then "1"
+      else if value == false then "0"
+      else "${value}";
+    toFlag = key: value: "-D${key}=${sanitize value}";
+  in attrs: concatStringsSep " " (attrValues (mapAttrs toFlag attrs));
 
-  # To determine the latest revision, get
-  # ‘http://commondatastorage.googleapis.com/chromium-browser-continuous/Linux/LAST_CHANGE’.
-  # For the version number, see ‘about:version’.
-  version = "124950";
-  
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "http://commondatastorage.googleapis.com/chromium-browser-continuous/Linux_x64/${version}/chrome-linux.zip";
-        sha256 = "4472bf584a96e477e2c17f96d4452dd41f4f34ac3d6a9bb4c845cf15d8db0c73";
-      }
-    else if stdenv.system == "i686-linux" then
-      fetchurl {
-        url = "http://commondatastorage.googleapis.com/chromium-browser-continuous/Linux/${version}/chrome-linux.zip";
-        sha256 = "6e8a49d9917ee26b67d14cd10b85711c3b9382864197ba02b3cfe8e636d3d69c";
-      }
-    else throw "Chromium is not supported on this platform.";
+in stdenv.mkDerivation rec {
+  name = "chromium-${version}";
 
-  phases = "unpackPhase installPhase";
+  version = "21.0.1171.0";
 
-  buildInputs = [ makeWrapper unzip ];
+  src = fetchurl {
+    url = "http://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.bz2";
+    sha256 = "3fd9b2d8895750a4435a585b9c2dc7d34b583c6470ba67eb6ea6c2579f126377";
+  };
 
-  libPath =
-    stdenv.lib.makeLibraryPath
-       [ GConf alsaLib bzip2 cairo cups dbus dbus_glib expat
-         ffmpeg fontconfig freetype libX11 libXScrnSaver libXfixes libXcomposite
-         libXdamage libXext libXrender libXt libXtst libgcrypt libjpeg
-         libpng nspr stdenv.gcc.gcc zlib stdenv.gcc.libc
-         glib gtk gdk_pixbuf pango
-         pam udev
-       ];
+  buildInputs = [
+    python perl pkgconfig
+    nspr nss udev bzip2
+    utillinux alsaLib
+    gcc bison gperf
+    krb5
+    glib gtk gconf libgcrypt dbus_glib
+    libXScrnSaver libXcursor
+  ] ++ stdenv.lib.optional gnomeKeyringSupport libgnome_keyring;
 
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/libexec/chrome
+  prePatch = "patchShebangs .";
 
-    cp -R * $out/libexec/chrome
+  gypFlags = mkGypFlags {
+    linux_use_gold_binary = false;
+    linux_use_gold_flags = false;
+    proprietary_codecs = false;
+    use_gnome_keyring = gnomeKeyringSupport;
+    disable_nacl = !naclSupport;
+    use_cups = false;
+  };
 
-    strip $out/libexec/chrome/chrome
-    
-    ${patchelf}/bin/patchelf \
-      --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath}:$out/lib:${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib \
-      $out/libexec/chrome/chrome
+  /* TODO:
+  use_system_bzip2 = true;
+  use_system_ffmpeg = true;
+  use_system_flac = true;
+  use_system_harfbuzz = true;
+  use_system_icu = true;
+  use_system_libevent = true;
+  use_system_libexpat = true;
+  use_system_libjpeg = true;
+  use_system_libpng = true;
+  use_system_libwebp = true;
+  use_system_libxml = true;
+  use_system_skia = true;
+  use_system_speex = true;
+  use_system_sqlite = true;
+  use_system_ssl = true;
+  use_system_stlport = true;
+  use_system_v8 = true;
+  use_system_xdg_utils = true;
+  use_system_yasm = true;
+  use_system_zlib = true;
+  */
 
-    makeWrapper $out/libexec/chrome/chrome $out/bin/chrome \
-      --prefix LD_LIBRARY_PATH : "${pcre}/lib:${nss}/lib"
+  configurePhase = ''
+    python build/gyp_chromium --depth $(pwd) ${gypFlags}
+  '';
+
+  buildPhase = ''
+    make CC=${gcc}/bin/gcc BUILDTYPE=Release library=shared_library chrome chrome_sandbox
   '';
 
   meta =  with stdenv.lib; {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -14,6 +14,8 @@
 }:
 
 let
+  sourceInfo = import ./source.nix;
+
   mkGypFlags = with stdenv.lib; let
     sanitize = value:
       if value == true then "1"
@@ -25,11 +27,11 @@ let
 in stdenv.mkDerivation rec {
   name = "chromium-${version}";
 
-  version = "21.0.1171.0";
+  version = sourceInfo.version;
 
   src = fetchurl {
-    url = "http://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.bz2";
-    sha256 = "3fd9b2d8895750a4435a585b9c2dc7d34b583c6470ba67eb6ea6c2579f126377";
+    url = sourceInfo.url;
+    sha256 = sourceInfo.sha256;
   };
 
   buildInputs = [

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,20 +1,26 @@
 { stdenv, getConfig, fetchurl, fetchsvn, makeWrapper, which
 
 # default dependencies
-, bzip2, ffmpeg, flac #, harfbuzz
-, icu, libevent, expat, libjpeg
-, libpng, libwebp, libxml2, libxslt #, skia
-, speex, sqlite, openssl #, stlport
+, bzip2, ffmpeg, flac
+, libevent, expat, libjpeg
+, libpng, libxml2, libxslt
+, speex, sqlite
 , v8, xdg_utils, yasm, zlib
 
 , python, perl, pkgconfig
-, nspr, nss, udev
+, nspr, udev
 , utillinux, alsaLib
 , gcc, bison, gperf
 , krb5
-, glib, gtk, gconf, libgcrypt, libgnome_keyring, dbus_glib
+, glib, gtk, dbus_glib
 , libXScrnSaver, libXcursor, mesa
-, libselinux
+
+# optional dependencies
+, libgnome_keyring # gnomeKeyringSupport
+, gconf # enableGnomeSupport
+, libgcrypt # enableGnomeSupport || enableCUPS
+, nss, openssl # useOpenSSL
+, libselinux # useSELinux
 }:
 
 let
@@ -43,30 +49,31 @@ let
   gypFlagsUseSystemLibs = {
     use_system_bzip2 = true;
     use_system_flac = true;
-    use_system_harfbuzz = false; # TODO
-    use_system_icu = false; # FIXME: wrong version!
     use_system_libevent = true;
     use_system_libexpat = true;
     use_system_libjpeg = true;
     use_system_libpng = true;
-    use_system_libwebp = false; # See chromium issue #133161
     use_system_libxml = true;
-    use_system_skia = false; # TODO
     use_system_speex = true;
-    use_system_sqlite = false; # FIXME
     use_system_ssl = true;
     use_system_stlport = true;
-    use_system_v8 = false; # TODO...
     use_system_xdg_utils = true;
     use_system_yasm = true;
     use_system_zlib = true;
+
+    use_system_harfbuzz = false; # TODO
+    use_system_icu = false; # FIXME: wrong version!
+    use_system_libwebp = false; # See chromium issue #133161
+    use_system_skia = false; # TODO
+    use_system_sqlite = false; # FIXME
+    use_system_v8 = false; # TODO...
   };
 
   defaultDependencies = [
-    bzip2 flac # harfbuzz
-    icu libevent expat libjpeg
-    libpng libwebp libxml2 libxslt # skia
-    speex sqlite # stlport
+    bzip2 flac
+    libevent expat libjpeg
+    libpng libxml2 libxslt
+    speex sqlite
     v8 xdg_utils yasm zlib
   ];
 

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -14,6 +14,7 @@
 , krb5
 , glib, gtk, gconf, libgcrypt, libgnome_keyring, dbus_glib
 , libXScrnSaver, libXcursor, mesa
+, libselinux
 }:
 
 let
@@ -92,6 +93,7 @@ in stdenv.mkDerivation rec {
     libXScrnSaver libXcursor mesa
   ] ++ stdenv.lib.optional config.gnomeKeyringSupport libgnome_keyring
     ++ stdenv.lib.optionals config.enableGnomeSupport [ gconf libgcrypt ]
+    ++ stdenv.lib.optional config.useSELinux libselinux
     ++ stdenv.lib.optional config.enableCUPS libgcrypt;
 
   opensslPatches = stdenv.lib.optional config.useOpenSSL openssl.patches;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -139,18 +139,28 @@ in stdenv.mkDerivation rec {
 
   buildType = "Release";
 
+  enableParallelBuilding = true;
+
   configurePhase = ''
     python build/gyp_chromium --depth "$(pwd)" ${gypFlags}
   '';
 
-  extraBuildFlags = let
+  makeFlags = let
     CC = "${gcc}/bin/gcc";
     CXX = "${gcc}/bin/g++";
-  in "CC=\"${CC}\" CXX=\"${CXX}\" CC.host=\"${CC}\" CXX.host=\"${CXX}\" LINK.host=\"${CXX}\"";
+  in [
+    "CC=${CC}"
+    "CXX=${CXX}"
+    "CC.host=${CC}"
+    "CXX.host=${CXX}"
+    "LINK.host=${CXX}"
+  ];
 
-  buildPhase = ''
-    make ${extraBuildFlags} BUILDTYPE=${buildType} library=shared_library chrome
-  '';
+  buildFlags = [
+    "BUILDTYPE=${buildType}"
+    "library=shared_library"
+    "chrome"
+  ];
 
   installPhase = ''
     mkdir -vp "$out/libexec/${packageName}"

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchsvn, makeWrapper
+{ stdenv, fetchurl, fetchsvn, makeWrapper, which
 , python, perl, pkgconfig
 , nspr, nss, udev, bzip2
 , utillinux, alsaLib
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    makeWrapper
+    which makeWrapper
     python perl pkgconfig
     nspr nss udev bzip2
     utillinux alsaLib

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -85,9 +85,15 @@ in stdenv.mkDerivation rec {
     libXScrnSaver libXcursor
   ] ++ stdenv.lib.optional gnomeKeyringSupport libgnome_keyring;
 
+  opensslPatches = openssl.patches;
+
   prePatch = "patchShebangs .";
 
   patches = stdenv.lib.optional (!useSELinux) ./enable_seccomp.patch;
+
+  postPatch = stdenv.lib.optionalString useOpenSSL ''
+    cat $opensslPatches | patch -p1 -d third_party/openssl/openssl
+  '';
 
   gypFlags = mkGypFlags (gypFlagsUseSystemLibs // {
     linux_use_gold_binary = false;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -47,12 +47,15 @@ in stdenv.mkDerivation rec {
 
   prePatch = "patchShebangs .";
 
+  patches = stdenv.lib.optional (!useSELinux) ./enable_seccomp.patch;
+
   gypFlags = mkGypFlags ({
     linux_use_gold_binary = false;
     linux_use_gold_flags = false;
     proprietary_codecs = false;
     use_gnome_keyring = gnomeKeyringSupport;
     disable_nacl = !naclSupport;
+    selinux = useSELinux;
     use_cups = false;
   } // stdenv.lib.optionalAttrs (stdenv.system == "x86_64-linux") {
     target_arch = "x64";
@@ -95,7 +98,7 @@ in stdenv.mkDerivation rec {
   in "CC=\"${CC}\" CXX=\"${CXX}\" CC.host=\"${CC}\" CXX.host=\"${CXX}\" LINK.host=\"${CXX}\"";
 
   buildPhase = ''
-    make ${extraBuildFlags} BUILDTYPE=${buildType} library=shared_library chrome chrome_sandbox
+    make ${extraBuildFlags} BUILDTYPE=${buildType} library=shared_library chrome
   '';
 
   installPhase = ''

--- a/pkgs/applications/networking/browsers/chromium/enable_seccomp.patch
+++ b/pkgs/applications/networking/browsers/chromium/enable_seccomp.patch
@@ -1,0 +1,20 @@
+diff --git a/content/common/seccomp_sandbox.h b/content/common/seccomp_sandbox.h
+index a07d6f3..a622a35 100644
+--- a/content/common/seccomp_sandbox.h
++++ b/content/common/seccomp_sandbox.h
+@@ -29,15 +29,9 @@ static bool SeccompSandboxEnabled() {
+   // TODO(evan): turn on for release too once we've flushed out all the bugs,
+   // allowing us to delete this file entirely and just rely on the "disabled"
+   // switch.
+-#ifdef NDEBUG
+-  // Off by default; allow turning on with a switch.
+-  return CommandLine::ForCurrentProcess()->HasSwitch(
+-      switches::kEnableSeccompSandbox);
+-#else
+   // On by default; allow turning off with a switch.
+   return !CommandLine::ForCurrentProcess()->HasSwitch(
+       switches::kDisableSeccompSandbox);
+-#endif  // NDEBUG
+ }
+ #endif  // SECCOMP_SANDBOX
+ 

--- a/pkgs/applications/networking/browsers/chromium/pulseaudio_array_bounds.patch
+++ b/pkgs/applications/networking/browsers/chromium/pulseaudio_array_bounds.patch
@@ -1,0 +1,12 @@
+diff --git a/media/media.gyp b/media/media.gyp
+index 2a8c6c6..66ca767 100644
+--- a/media/media.gyp
++++ b/media/media.gyp
+@@ -399,6 +399,7 @@
+             ['use_pulseaudio == 1', {
+               'cflags': [
+                 '<!@(pkg-config --cflags libpulse)',
++                '-Wno-array-bounds',
+               ],
+               'link_settings': {
+                 'libraries': [

--- a/pkgs/applications/networking/browsers/chromium/source.nix
+++ b/pkgs/applications/networking/browsers/chromium/source.nix
@@ -1,5 +1,5 @@
 {
-  version = "21.0.1174.1";
-  url = "http://commondatastorage.googleapis.com/chromium-browser-official/chromium-21.0.1174.1.tar.bz2";
-  sha256 = "00jd3lzdbxm4rlqvxf0wfz9pvsza85rhlb0pzdzrdjy45kn06a75";
+  version = "21.0.1179.1";
+  url = "http://commondatastorage.googleapis.com/chromium-browser-official/chromium-21.0.1179.1.tar.bz2";
+  sha256 = "1ynm1dv8nwjg6a0absid1g3r62y0mpb74pmal8g9nmqb92rlkdnc";
 }

--- a/pkgs/applications/networking/browsers/chromium/source.nix
+++ b/pkgs/applications/networking/browsers/chromium/source.nix
@@ -1,0 +1,5 @@
+{
+  version = "21.0.1174.1";
+  url = "http://commondatastorage.googleapis.com/chromium-browser-official/chromium-21.0.1174.1.tar.bz2";
+  sha256 = "00jd3lzdbxm4rlqvxf0wfz9pvsza85rhlb0pzdzrdjy45kn06a75";
+}

--- a/pkgs/applications/networking/browsers/chromium/update.sh
+++ b/pkgs/applications/networking/browsers/chromium/update.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+bucket_url="http://commondatastorage.googleapis.com/chromium-browser-official/";
+
+get_newest_version()
+{
+    curl -s "$bucket_url" | sed -ne ' H;/<[Kk][Ee][Yy]>chromium-[^<]*</h;${
+    g;s/^.*<Key>chromium-\([^<.]\+\(\.[^<.]\+\)\+\)\.tar\.bz2<.*$/\1/p
+    }';
+}
+
+cd "$(dirname "$0")";
+
+version="$(get_newest_version)";
+
+if [ -e source.nix ]; then
+    oldver="$(sed -n 's/^ *version *= *"\([^"]\+\)".*$/\1/p' source.nix)";
+    if [ "x$oldver" = "x$version" ]; then
+        echo "Already the newest version: $version" >&2;
+        exit 1;
+    fi;
+fi;
+
+url="${bucket_url%/}/chromium-$version.tar.bz2";
+
+sha256="$(nix-prefetch-url "$url")";
+
+cat > source.nix <<EOF
+{
+  version = "$version";
+  url = "$url";
+  sha256 = "$sha256";
+}
+EOF

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6328,13 +6328,13 @@ let
     xulrunner = firefox36Pkgs.xulrunner;
   };
 
-  chrome = lowPrio (callPackage ../applications/networking/browsers/chromium {
+  chromium = lowPrio (callPackage ../applications/networking/browsers/chromium {
     gconf = gnome.GConf;
   });
 
   chromeWrapper = wrapFirefox
-    { browser = chrome; browserName = "chrome"; desktopName = "Chrome";
-      icon = "${chrome}/libexec/chrome/product_logo_48.png";
+    { browser = chromium; browserName = chromium.packageName; desktopName = "Chromium";
+      icon = "${chromium}/share/icons/hicolor/48x48/apps/${chromium.packageName}.png";
     };
 
   cinelerra = callPackage ../applications/video/cinelerra { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6329,8 +6329,7 @@ let
   };
 
   chrome = lowPrio (callPackage ../applications/networking/browsers/chromium {
-    inherit (gnome) GConf;
-    libpng = libpng12;
+    gconf = gnome.GConf;
   });
 
   chromeWrapper = wrapFirefox


### PR DESCRIPTION
NixOS currently uses the binary release of Chromium.
With these changes, it should no longer be the case.

Everything is working so far, except NaCl, which is is disabled for now.
It didn't work in the previous binary release version, so I guess noone should be unhappy about it.
Though getting it to work is on my todo list, at the very latest when I want to play around with it again... someday.

Plus a few dependencies are the bundled one with chromium, as they contain too many patches to allow for nice integration into nixpkgs, but those that would break functional purity are used from nixpkgs.
