### PR TITLE
Curl bug makes nix all mental. One-line fix.

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -10,11 +10,11 @@ assert sslSupport -> openssl != null;
 assert scpSupport -> libssh2 != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.22.0";
+  name = "curl-7.26.0";
 
   src = fetchurl {
     url = "http://curl.haxx.se/download/${name}.tar.bz2";
-    sha256 = "04ji7v06f33y6plvikwj283ad6fxxxjpm7as9xw25c924f3dm85x";
+    sha256 = "0snj41knvy4xbfirr88l9gq5zjzz0mwlmq0mxbfgqszb2qpjdvgw";
   };
 
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains


### PR DESCRIPTION
Solves a hideous bug which affects lots of things including nix-env.
The question now is, how to rebuild everything that depends directly or indirectly on curl?

More about the underlying bug and its resolution here:
    http://comments.gmane.org/gmane.comp.web.curl.library/33285

Bug looks like this:

```
curl google.com
curl: (7) Failed to connect to 74.125.224.35: Invalid argument
```
