### PR TITLE
Fix Ardour 3 

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6281,6 +6281,7 @@ let
 
   ardour3 =  lowPrio (callPackage ../applications/audio/ardour/ardour3.nix {
     inherit (gnome) libgnomecanvas libgnomecanvasmm;
+    boost = boost149;
   });
 
   arora = callPackage ../applications/networking/browsers/arora { };


### PR DESCRIPTION
Pinning the version of boost to 1.49 because compilation fails with 1.5:

http://hydra.nixos.org/build/2737557

I don't know where to look to try to fix this, perhaps it is a problem upstream, but this is a beta version of Ardour anyway so I think it's OK to wait until there is a release to see if we need to investigate further.
