### PR TITLE
Extend compiler wrapper scripts to allow compilation of "/dev/null" input.

### DIFF
--- a/pkgs/build-support/clang-wrapper/utils.sh
+++ b/pkgs/build-support/clang-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/build-support/gcc-cross-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-cross-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/build-support/gcc-upc-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-upc-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/build-support/gcc-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"


### PR DESCRIPTION
This feature sounds crazy, but it is used in some configure scripts (e.g. xbmc).
This patch causes an almost complete rebuild of Nixpkgs.

Patch submitted by Jan Malakhovski oxij@oxij.org.
