### PR TITLE
Update VirtualBox to version 4.1.18.

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -8,7 +8,7 @@
 
 with stdenv.lib;
 
-let version = "4.1.16"; in
+let version = "4.1.18"; in
 
 stdenv.mkDerivation {
   name = "virtualbox-${version}-${kernel.version}";
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "0kl21wqz822qgdcilfail5qqgsbhgzixwbbwpkmsh6670jc4jw5n";
+    sha256 = "e650e4fdc23581b9edc0e5d5705cc596c76796851ebf65ccda0edb8e413fa3b7";
   };
 
   buildInputs =

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, lib, patchelf, cdrkit, kernel, which, makeWrapper
 , libX11, libXt, libXext, libXmu, libXcomposite, libXfixes, libXrandr, libXcursor}:
 
-let version = "4.1.16"; in
+let version = "4.1.18"; in
 
 stdenv.mkDerivation {
   name = "VirtualBox-GuestAdditions-${version}";
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "1f2p26cg005xc6vi9dbim0macv60d8k8nq20rk7awrbghfib5imm";
+    sha256 = "1zsjh4q71ny10s2zaxnaw4w3bs961c21xv6dd6zpwhnbimlhlrqb";
   };
   KERN_DIR = "${kernel}/lib/modules/*/build";
   buildInputs = [ patchelf cdrkit makeWrapper ];


### PR DESCRIPTION
This should make #15 obsolete, as those patches were cherry-picked from
upstream.
