### PR TITLE
Add JuicyPixels Haskell package

### DIFF
--- a/pkgs/development/libraries/haskell/JuicyPixels/default.nix
+++ b/pkgs/development/libraries/haskell/JuicyPixels/default.nix
@@ -1,0 +1,18 @@
+{ cabal, cereal, deepseq, mtl, primitive, transformers, vector
+, zlib
+}:
+
+cabal.mkDerivation (self: {
+  pname = "JuicyPixels";
+  version = "1.3";
+  sha256 = "07wljfag4ylw16wdi7znjb61pfihdik5d7p4h2lmz6xirm4mjzrm";
+  buildDepends = [
+    cereal deepseq mtl primitive transformers vector zlib
+  ];
+  meta = {
+    homepage = "https://github.com/Twinside/Juicy.Pixels";
+    description = "Picture loading/serialization (in png, jpeg and bitmap)";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -936,6 +936,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   ivor = callPackage ../development/libraries/haskell/ivor {};
 
+  JuicyPixels = callPackage ../development/libraries/haskell/JuicyPixels {};
+
   jpeg = callPackage ../development/libraries/haskell/jpeg {};
 
   JsContracts = callPackage ../development/libraries/haskell/JsContracts {


### PR DESCRIPTION
The Nix expression is generated by cabal2nix and it builds fine on my local machine, GHC 7.4.1 on recent i686 NixOS.
