### PR TITLE
Digestive functors snap

### DIFF
--- a/pkgs/development/libraries/haskell/digestive-functors-snap/default.nix
+++ b/pkgs/development/libraries/haskell/digestive-functors-snap/default.nix
@@ -1,0 +1,14 @@
+{ cabal, digestiveFunctors, filepath, mtl, snapCore, text }:
+
+cabal.mkDerivation (self: {
+  pname = "digestive-functors-snap";
+  version = "0.5.0.0";
+  sha256 = "01lbd42rsryzqzra8ax22iw6c9fyv5az8q7dkdi6yyfxdq976l0x";
+  buildDepends = [ digestiveFunctors filepath mtl snapCore text ];
+  meta = {
+    homepage = "http://github.com/jaspervdj/digestive-functors";
+    description = "Snap backend for the digestive-functors library";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/digestive-functors/default.nix
+++ b/pkgs/development/libraries/haskell/digestive-functors/default.nix
@@ -1,0 +1,14 @@
+{ cabal, mtl, text }:
+
+cabal.mkDerivation (self: {
+  pname = "digestive-functors";
+  version = "0.5.0.2";
+  sha256 = "1phakcljl6ri2p9lfzjnn001jw0inyxa5zd7lp2k9lhq1yq0byb0";
+  buildDepends = [ mtl text ];
+  meta = {
+    homepage = "http://github.com/jaspervdj/digestive-functors";
+    description = "A practical formlet library";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -626,7 +626,6 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   digestiveFunctors = callPackage ../development/libraries/haskell/digestive-functors {};
 
-
   digestiveFunctorsSnap = callPackage ../development/libraries/haskell/digestive-functors-snap {};
 
   dimensional = callPackage ../development/libraries/haskell/dimensional {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -624,6 +624,11 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
     inherit (pkgs) zlib;
   };
 
+  digestiveFunctors = callPackage ../development/libraries/haskell/digestive-functors {};
+
+
+  digestiveFunctorsSnap = callPackage ../development/libraries/haskell/digestive-functors-snap {};
+
   dimensional = callPackage ../development/libraries/haskell/dimensional {};
 
   directoryTree = callPackage ../development/libraries/haskell/directory-tree {};


### PR DESCRIPTION
Add two packages haskell-digestive-functors-snap and haskell-digestive-functors as generated by cabal2nix. Built locally.
