### PR TITLE
w3m package fix (second attempt)

### DIFF
--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   configureFlags = "--with-ssl=${openssl} --with-gc=${boehmgc}";
 
   preConfigure = ''
+    substituteInPlace ./configure --replace "/lib /usr/lib /usr/local/lib /usr/ucblib /usr/ccslib /usr/ccs/lib /lib64 /usr/lib64" /no-such-path
     substituteInPlace ./configure --replace /usr /no-such-path
   '';
 


### PR DESCRIPTION
The configure script picks up libbsd.so from the host machine.
It uses simple find command to locate the file, but the linker
can not use it.

The fix replace the search path to /no-such-path
