### PR TITLE
dbus: Merge dbus-library, dbus-tools and dbus-daemon into a single package

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telepathy/kde/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/kde/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchgit, telepathy_qt, kdelibs, kde_workspace, gettext, dbus_libs
+{ stdenv, fetchurl, fetchgit, telepathy_qt, kdelibs, kde_workspace, gettext, dbus
 , pkgconfigUpstream , qt_gstreamer, telepathy_glib, telepathy_logger, qjson, flex, bison }:
 
 let
@@ -8,7 +8,7 @@ let
 
   overrides = {
     telepathy_logger_qt = x : x // {
-      NIX_CFLAGS_COMPILE = "-I${dbus_libs}/include/dbus-1.0";
+      NIX_CFLAGS_COMPILE = "-I${dbus}/include/dbus-1.0";
     };
   };
 

--- a/pkgs/desktops/e17/e_dbus/default.nix
+++ b/pkgs/desktops/e17/e_dbus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, zlib, libjpeg, expat, ecore, eina, evas
-, dbus_libs }:
+, dbus }:
 stdenv.mkDerivation rec {
   name = "e_dbus-${version}";
   version = "1.2.0-alpha";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1kky76v7yydsjihgi1hbwpyqhdmbxmxj2dw4p7kiqbl67dmsjhxg";
   };
   buildInputs = [ pkgconfig zlib libjpeg expat ecore eina evas ];
-  propagatedBuildInputs = [ dbus_libs ];
+  propagatedBuildInputs = [ dbus ];
   configureFlags = ''
     --disable-edbus-test
     --disable-edbus-test-client

--- a/pkgs/desktops/gnome-2/desktop/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gnome-keyring/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "02r9gv3a4a705jf3h7c0bizn33c73wz0iw2500m7z291nrnmqkmj";
   };
   
-  buildInputs = [ dbus.libs libgcrypt pam python gtk GConf libgnome_keyring ];
+  buildInputs = [ dbus libgcrypt pam python gtk GConf libgnome_keyring ];
 
   propagatedBuildInputs = [ glib libtasn1 ];
 

--- a/pkgs/desktops/gnome-2/desktop/gvfs/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gvfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, dbus_libs, samba, libarchive, fuse, libgphoto2
+{ stdenv, fetchurl, pkgconfig, dbus, samba, libarchive, fuse, libgphoto2
 , libcdio, libxml2, libtool, glib, intltool, GConf, libgnome_keyring, libsoup
 , udev, avahi}:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ glib dbus_libs udev samba libarchive fuse libgphoto2 libcdio libxml2 GConf
+    [ glib dbus udev samba libarchive fuse libgphoto2 libcdio libxml2 GConf
       libgnome_keyring libsoup avahi libtool
     ];
 

--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, dbus_glib, glib, ORBit2, libxml2
-, polkit, intltool, dbus_libs, gtk }:
+, polkit, intltool, dbus, gtk }:
 
 stdenv.mkDerivation {
   name = "GConf-2.32.4";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "09ch709cb9fniwc4221xgkq0jf0x0lxs814sqig8p2dcll0llvzk";
   };
 
-  buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 polkit gtk ];
+  buildInputs = [ ORBit2 dbus dbus_glib libxml2 polkit gtk ];
   propagatedBuildInputs = [ glib ];
 
   buildNativeInputs = [ pkgconfig intltool ];

--- a/pkgs/desktops/xfce-4.8/support/gvfs.nix
+++ b/pkgs/desktops/xfce-4.8/support/gvfs.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0895ac8f6d416e1b15433b6b6b68eb119c6e8b04fdb66db665d684355ef89345";
   };
 
-  buildInputs = [ pkgconfig glib dbus.libs intltool udev libgdu ];
+  buildInputs = [ pkgconfig glib dbus intltool udev libgdu ];
 
   meta = {
     description = "Virtual Filesystem support library (for Xfce)";

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, expat, libX11, libICE, libSM, useX11 ? true }:
 
-let
+stdenv.mkDerivation rec {
+  name = "dbus-all-${version}";
   version = "1.4.16";
 
   src = fetchurl {
@@ -10,56 +11,26 @@ let
 
   patches = [ ./ignore-missing-includedirs.patch ];
 
-  configureFlags = "--localstatedir=/var --sysconfdir=/etc --with-session-socket-dir=/tmp";
+  buildNativeInputs = [ pkgconfig ];
 
-in rec {
+  buildInputs = [ expat ]
+    ++ stdenv.lib.optionals useX11 [ libX11 libICE libSM ];
 
-  libs = stdenv.mkDerivation {
-    name = "dbus-library-" + version;
+  configureFlags = [
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--with-session-socket-dir=/tmp"
+  ];
 
-    buildNativeInputs = [ pkgconfig ];
+  preConfigure = ''
+    sed -i '/mkinstalldirs.*localstatedir/d' bus/Makefile.in
+    substituteInPlace tools/Makefile.in --replace 'install-localstatelibDATA:' 'disabled:'
+  '';
 
-    buildInputs = [ expat ];
+  # Enable X11 autolaunch support in libdbus.  This doesn't actually
+  # depend on X11 (it just execs dbus-launch in dbus),
+  # contrary to what the configure script demands.
+  NIX_CFLAGS_COMPILE = "-DDBUS_ENABLE_X11_AUTOLAUNCH=1";
 
-    inherit src patches configureFlags;
-
-    preConfigure =
-      ''
-        sed -i '/mkinstalldirs.*localstatedir/d' bus/Makefile.in
-        sed -i '/SUBDIRS/s/ tools//' Makefile.in
-      '';
-
-    # Enable X11 autolaunch support in libdbus.  This doesn't actually
-    # depend on X11 (it just execs dbus-launch in dbus.tools),
-    # contrary to what the configure script demands.
-    NIX_CFLAGS_COMPILE = "-DDBUS_ENABLE_X11_AUTOLAUNCH=1";
-
-    installFlags = "sysconfdir=$(out)/etc";
-  };
-
-  tools = stdenv.mkDerivation {
-    name = "dbus-tools-" + version;
-
-    inherit src patches;
-
-    configureFlags = "${configureFlags} --with-dbus-daemondir=${daemon}/bin";
-
-    buildNativeInputs = [ pkgconfig ];
-
-    buildInputs = [ expat libs ]
-      ++ stdenv.lib.optionals useX11 [ libX11 libICE libSM ];
-
-    NIX_LDFLAGS = "-ldbus-1";
-
-    preConfigure =
-      ''
-        sed -i 's@$(top_builddir)/dbus/libdbus-1.la@@' tools/Makefile.in
-        substituteInPlace tools/Makefile.in --replace 'install-localstatelibDATA:' 'disabled:'
-      '';
-
-    postConfigure = "cd tools";
-  };
-
-  # I'm too lazy to separate daemon and libs now.
-  daemon = libs;
+  installFlags = "sysconfdir=$(out)/etc";
 }

--- a/pkgs/development/libraries/libgnome-keyring/3.x.nix
+++ b/pkgs/development/libraries/libgnome-keyring/3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, dbus_libs, libgcrypt, pkgconfig,
+{ stdenv, fetchurl, glib, dbus, libgcrypt, pkgconfig,
 intltool }:
 
 stdenv.mkDerivation {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "1cxd2vb1lzm8smq1q45dsn13s6kdqdb60lashdk7hwv035xy9jrb";
   };
 
-  propagatedBuildInputs = [ glib dbus_libs libgcrypt ];
+  propagatedBuildInputs = [ glib dbus libgcrypt ];
   buildNativeInputs = [ pkgconfig intltool ];
 
   meta = {

--- a/pkgs/development/libraries/libgnome-keyring/default.nix
+++ b/pkgs/development/libraries/libgnome-keyring/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, dbus_libs, libgcrypt, pkgconfig,
+{ stdenv, fetchurl, glib, dbus, libgcrypt, pkgconfig,
 intltool }:
 
 stdenv.mkDerivation {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "030gka96kzqg1r19b4xrmac89hf1xj1kr5p461yvbzfxh46qqf2n";
   };
 
-  propagatedBuildInputs = [ glib dbus_libs libgcrypt ];
+  propagatedBuildInputs = [ glib dbus libgcrypt ];
   buildNativeInputs = [ pkgconfig intltool ];
 
   meta = {

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ndh7wpm9qh12vm5avjrq2xv1j681j9qq6j2fyj6a2shl67dp687";
   };
 
-  buildInputs = [ pkgconfig dbus.libs dbus_glib gtk glib ];
+  buildInputs = [ pkgconfig dbus dbus_glib gtk glib ];
 
   meta = {
     homepage = http://galago-project.org/;

--- a/pkgs/development/libraries/policykit/default.nix
+++ b/pkgs/development/libraries/policykit/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig glib dbus_glib pam intltool gettext libxslt ];
 
-  propagatedBuildInputs = [ expat dbus.libs ];
+  propagatedBuildInputs = [ expat dbus ];
 
   configureFlags = "--localstatedir=/var --sysconfdir=/etc";
 

--- a/pkgs/development/libraries/qt-4.x/4.7/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.7/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     libXmu
     libXv
     openssl
-    dbus.libs
+    dbus
     cups
     pkgconfig
     libXext

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
                               stdenv.lib.platforms.mesaPlatforms)
          mesa)
     ++ (stdenv.lib.optional (buildWebkit || buildMultimedia) alsaLib)
-    ++ [ zlib libpng openssl dbus.libs freetype fontconfig glib ]
+    ++ [ zlib libpng openssl dbus freetype fontconfig glib ]
     ++ (stdenv.lib.optionals (buildWebkit || buildMultimedia)
         [ gstreamer gst_plugins_base ]);
 

--- a/pkgs/development/libraries/strigi/default.nix
+++ b/pkgs/development/libraries/strigi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, qt4, perl, bzip2, libxml2, exiv2
-, clucene_core, fam, zlib, dbus_tools, pkgconfig
+, clucene_core, fam, zlib, dbus, pkgconfig
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   CLUCENE_HOME = clucene_core;
 
   buildInputs =
-    [ zlib bzip2 stdenv.gcc.libc libxml2 qt4 exiv2 clucene_core fam dbus_tools ];
+    [ zlib bzip2 stdenv.gcc.libc libxml2 qt4 exiv2 clucene_core fam dbus ];
 
   buildNativeInputs = [ cmake pkgconfig perl ];
 

--- a/pkgs/development/tools/misc/eggdbus/default.nix
+++ b/pkgs/development/tools/misc/eggdbus/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "118hj63ac65zlg71kydv4607qcg1qpdlql4kvhnwnnhar421jnq4";
   };
   
-  buildInputs = [ pkgconfig glib dbus.libs dbus_glib ];
+  buildInputs = [ pkgconfig glib dbus dbus_glib ];
 
   meta = {
     homepage = http://hal.freedesktop.org/releases/;

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig dbus.libs glib libusb alsaLib python makeWrapper
+    [ pkgconfig dbus glib libusb alsaLib python makeWrapper
       readline libsndfile
       # Disables GStreamer; not clear what it gains us other than a
       # zillion extra dependencies.

--- a/pkgs/os-specific/linux/hal/default.nix
+++ b/pkgs/os-specific/linux/hal/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig python pciutils expat libusb dbus.libs dbus_glib glib
+    pkgconfig python pciutils expat libusb dbus dbus_glib glib
     libuuid perl perlXMLParser gettext zlib gperf
     consolekit policykit
   ];

--- a/pkgs/os-specific/linux/mountall/default.nix
+++ b/pkgs/os-specific/linux/mountall/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   preConfigure = "rm -R aclocal.m4; gettextize -f; autoreconf -vfi";
 
-  buildInputs = [ pkgconfig libnih dbus.libs udev autoconf automake libtool gettext ];
+  buildInputs = [ pkgconfig libnih dbus udev autoconf automake libtool gettext ];
 
   makeFlags = "initramfshookdir=$(out)/share/initramfs-tools/hooks upstart_jobs_initramfs_configdir=$(out)/share/initramfs-tools/event-driven/upstart-jobs";
 

--- a/pkgs/os-specific/linux/pm-utils/default.nix
+++ b/pkgs/os-specific/linux/pm-utils/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, coreutils, gnugrep, utillinux, module_init_tools
-, procps, kbd, dbus_tools }:
+, procps, kbd, dbus }:
 
 let
 
   binPath = stdenv.lib.makeSearchPath "bin"
-    [ coreutils gnugrep utillinux module_init_tools procps kbd dbus_tools ];
+    [ coreutils gnugrep utillinux module_init_tools procps kbd dbus ];
 
   sbinPath = stdenv.lib.makeSearchPath "sbin"
     [ procps ];

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, dbus_libs, pkgconfig, libnl1 }:
+{ stdenv, fetchurl, openssl, dbus, pkgconfig, libnl1 }:
 
 stdenv.mkDerivation rec {
   version = "0.7.3";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace /usr/local $out
   '';
 
-  buildInputs = [ openssl dbus_libs libnl1 ];
+  buildInputs = [ openssl dbus libnl1 ];
 
   buildNativeInputs = [ pkgconfig ];
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -170,7 +170,7 @@ in
   xorgserver = attrs: attrs // {
     patches = [./xorgserver-dri-path.patch ./xorgserver-xkbcomp-path.patch];
     buildInputs = attrs.buildInputs ++
-      [ args.zlib args.udev args.mesa args.dbus.libs
+      [ args.zlib args.udev args.mesa args.dbus
         xorg.xf86bigfontproto xorg.glproto xorg.xf86driproto
         xorg.compositeproto xorg.scrnsaverproto xorg.resourceproto
         xorg.xineramaproto xorg.xf86dgaproto

--- a/pkgs/tools/bluetooth/obexd/default.nix
+++ b/pkgs/tools/bluetooth/obexd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jz0ldg2wvdzzl639xzf76hqwj23svlg3zv1r8nc3hik3pgs6h2l";
   };
 
-  buildInputs = [ glib dbus.libs openobex bluez libical ];
+  buildInputs = [ glib dbus openobex bluez libical ];
 
   buildNativeInputs = [ pkgconfig ];
 

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, udev, pkgconfig, dbus_libs }:
+{ stdenv, fetchurl, udev, pkgconfig, dbus }:
 
 stdenv.mkDerivation rec {
   name = "pcsclite-1.7.4";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     configureFlags="$configureFlags --enable-confdir=$out/etc"
   '';
 
-  buildInputs = [ udev dbus_libs ];
+  buildInputs = [ udev dbus ];
 
   buildNativeInputs = [ pkgconfig ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3376,17 +3376,14 @@ let
 
   db48 = callPackage ../development/libraries/db4/db4-4.8.nix { };
 
-  dbus = pkgs.dbus_all.libs // { inherit (pkgs.dbus_all) libs; };
-
-  dbus_daemon = pkgs.dbus_all.daemon;
-
-  dbus_tools = pkgs.dbus_all.tools;
-
-  dbus_libs = pkgs.dbus_all.libs;
-
-  dbus_all = callPackage ../development/libraries/dbus {
+  dbus = callPackage ../development/libraries/dbus {
     useX11 = true;
   };
+
+  # NixOS needs these. Can be removed when NixOS has been updated.
+  dbus_daemon = dbus;
+  dbus_libs = dbus;
+  dbus_tools = dbus;
 
   dbus_cplusplus = callPackage ../development/libraries/dbus-cplusplus { };
 
@@ -8525,8 +8522,7 @@ let
   gajim = builderDefsPackage (import ../applications/networking/instant-messengers/gajim) {
     inherit perl intltool pyGtkGlade gettext pkgconfig makeWrapper pygobject
       pyopenssl gtkspell libsexy pycrypto aspell pythonDBus pythonSexy
-      docutils gtk;
-    dbus = dbus.libs;
+      docutils gtk dbus;
     inherit (gnome) libglade;
     inherit (xlibs) libXScrnSaver libXt xproto libXext xextproto libX11
       scrnsaverproto;


### PR DESCRIPTION
I ran into a problem where an application (network-manager-applet) tried to execute dbus-launch from /nix/store/...dbus-library.../bin/dbus-launch, which doesn't exist, since the dbus-launch binary is built by the dbus-tools package. It turns out, however, that it is the dbus-library itself that refers to the dbus-launch binary (in its own bin dir). Since dbus-tools depends on dbus-library, this can't be fixed without introducing a circular dependency.

What do you say about merging dbus-library, dbus-tools and dbus-daemon (which already is equal to dbus-library) into one package?

Doing that solves the problem, and doesn't seem to cause any other problems. The only trouble I can imagine, is that some X11 dependencies are introduced in dbus-library:

```
buildInputs = [ expat ] ++ stdenv.lib.optionals useX11 [ libX11 libICE libSM ];
```
