### PR TITLE
chromium: Install libffmpegsumo.so.

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -172,6 +172,7 @@ in stdenv.mkDerivation rec {
     mkdir -vp "$out/libexec/${packageName}"
     cp -v "out/${buildType}/"*.pak "$out/libexec/${packageName}/"
     cp -vR "out/${buildType}/locales" "out/${buildType}/resources" "$out/libexec/${packageName}/"
+    cp -v out/${buildType}/libffmpegsumo.so "$out/libexec/${packageName}/"
 
     cp -v "out/${buildType}/chrome" "$out/libexec/${packageName}/${packageName}"
 


### PR DESCRIPTION
This caused HTML5 video to not work because this shared library is loaded at runtime.

Unfortunately we can't use system ffmpeg yet, because upgrading would break builds of other packages, and it would result in a copy of ffmpeg laying around aswell, so we can defer this until we have fixed ffmpeg.
