### PR TITLE
openssl: fix mingw cross build by disabling patch

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -3,20 +3,22 @@
 let
   name = "openssl-1.0.0i";
 
+  inherit (stdenv.lib) elem optional optionals attrByPath;
+
   opensslCrossSystem = stdenv.lib.attrByPath [ "openssl" "system" ]
-    (throw "openssl needs its platform name cross building" null)
+    (throw "openssl needs its platform name when cross building" null)
     stdenv.cross;
 
   patchesCross = isCross:
-    [ # Allow the location of the X509 certificate file (the CA
+    (optional (!isCross || !elem opensslCrossSystem ["mingw" "mingw64"])
+      # Allow the location of the X509 certificate file (the CA
       # bundle) to be set through the environment variable
       # ‘OPENSSL_X509_CERT_FILE’.  This is necessary because the
       # default location ($out/ssl/cert.pem) doesn't exist, and
       # hardcoding something like /etc/ssl/cert.pem is impure and
       # cannot be overriden per-process.  For security, the
       # environment variable is ignored for setuid binaries.
-      ./cert-file.patch
-    ]
+      ./cert-file.patch)
 
     ++ stdenv.lib.optionals (isCross && opensslCrossSystem == "hurd-x86")
          [ ./cert-file-path-max.patch # merge with `cert-file.patch' eventually
@@ -37,6 +39,9 @@ stdenv.mkDerivation {
     ];
     sha1 = "b7aa11cbd7d264c2b1f44e3d55b334fb33f7b674";
   };
+
+  # doesn't make a difference:
+  # enableParalellBuilding = true;
 
   patches = patchesCross false;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1917,7 +1917,13 @@ let
       cross = assert crossSystem != null; crossSystem;
     });
 
-  gcc_realCross = gcc46_realCross;
+  gcc_realCross =
+    if crossSystem.config == "i686-pc-mingw32"
+    then 
+         # gcc46 targeting 32bit builds executables, but they segfault
+         # gcc45 which seems to work
+         gcc45_realCross
+    else gcc46_realCross;
 
   gccCrossStageStatic = let
       isMingw = (stdenv.cross.libc == "msvcrt");

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -150,6 +150,7 @@ let
       arch = "x86";
       libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
       platform = {};
+      openssl.system = "mingw";
   };
 in {
   crossMingw32 = mapTestOnCross crossSystem {
@@ -173,6 +174,7 @@ let
       arch = "x86_64"; # Irrelevant
       libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
       platform = {};
+      openssl.system = "mingw64";
   };
 in {
   crossMingwW64 = mapTestOnCross crossSystem {


### PR DESCRIPTION
improve exception message, comment that parallel building seems to work
but doesn't yield much faster builds
