### PR TITLE
virtualbox: Fix build for manual kernel.

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -23,8 +23,6 @@ let
 in stdenv.mkDerivation {
   name = "virtualbox-${version}-${kernel.version}";
 
-  NIX_CFLAGS_COMPILE="-I${kernel}/lib/modules/${kernel.modDirVersion}/build/include/generated";
-
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
     sha256 = "e650e4fdc23581b9edc0e5d5705cc596c76796851ebf65ccda0edb8e413fa3b7";

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
       name="$(basename "$mod")"
       export INSTALL_MOD_PATH="$out"
       export INSTALL_MOD_DIR=misc
-      make -C "$MODULES_BUILD_DIR" "M=$mod" DEPMOD= modules_install
+      make -C "$MODULES_BUILD_DIR" "M=$mod" DEPMOD=/do_not_use_depmod modules_install
     done
 
     # Create wrapper script

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -11,8 +11,7 @@ with stdenv.lib;
 let
   version = "4.1.18";
   forEachModule = action: ''
-    for makefile in $sourcedir/out/linux.*/release/bin/src/*/Makefile \
-                    $sourcedir/out/linux.*/release/bin/additions/src/*/Makefile
+    for makefile in $sourcedir/out/linux.*/release/bin/src/*/Makefile
     do
       mod="$(dirname "$makefile")"
       export INSTALL_MOD_PATH="$out"

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    srcroot="$(pwd)"
     libexec=$out/libexec/virtualbox
 
     # Install VirtualBox files
@@ -77,9 +78,8 @@ stdenv.mkDerivation {
     cp -av * $libexec
 
     # Install kernel modules
-    curdir="$(pwd)"
-    for makefile in $curdir/out/linux.*/release/bin/src/*/Makefile \
-                    $curdir/out/linux.*/release/bin/additions/src/*/Makefile
+    for makefile in $srcroot/out/linux.*/release/bin/src/*/Makefile \
+                    $srcroot/out/linux.*/release/bin/additions/src/*/Makefile
     do
       mod="$(dirname "$makefile")"
       name="$(basename "$mod")"

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -11,11 +11,18 @@ with stdenv.lib;
 let
   version = "4.1.18";
   forEachModule = action: ''
-    for makefile in $sourcedir/out/linux.*/release/bin/src/*/Makefile
+    for mod in \
+      $sourcedir/out/linux.*/release/bin/src/vboxdrv \
+      $sourcedir/out/linux.*/release/bin/src/vboxpci \
+      $sourcedir/out/linux.*/release/bin/src/vboxnetadp \
+      $sourcedir/out/linux.*/release/bin/src/vboxnetflt
     do
-      mod="$(dirname "$makefile")"
-      export INSTALL_MOD_PATH="$out"
-      export INSTALL_MOD_DIR=misc
+      if [ "x$(basename "$mod")" != xvboxdrv -a ! -e "$mod/Module.symvers" ]
+      then
+        cp -v $sourcedir/out/linux.*/release/bin/src/vboxdrv/Module.symvers \
+              "$mod/Module.symvers"
+      fi
+      INSTALL_MOD_PATH="$out" INSTALL_MOD_DIR=misc \
       make -C "$MODULES_BUILD_DIR" "M=$mod" DEPMOD=/do_not_use_depmod ${action}
     done
   '';

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -85,7 +85,6 @@ in stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    srcroot="$(pwd)"
     libexec=$out/libexec/virtualbox
 
     # Install VirtualBox files


### PR DESCRIPTION
This should fix building VirtualBox against kernels made using the new manual kernel configuration system.
In addition, this adds a small test case to the manual kernel, to ensure that modules can be built properly using kbuild.

And the latter (kbuild) is also used in the VirtualBox derivation, so we shouldn't trap into problems even with generic kernels (which i didn't test, yet so it would make sense to test it before merging...).
