### PR TITLE
Fix NSS library not finding root CA certificates.

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -32,7 +32,7 @@ let
     channel = "stable";
     selinux = false;
     nacl = false;
-    openssl = true;
+    openssl = false;
     gnome = false;
     gnomeKeyring = false;
     proprietaryCodecs = true;
@@ -59,7 +59,7 @@ let
     use_system_libpng = true;
     use_system_libxml = true;
     use_system_speex = true;
-    use_system_ssl = true;
+    use_system_ssl = config.openssl;
     use_system_stlport = true;
     use_system_xdg_utils = true;
     use_system_yasm = true;

--- a/pkgs/applications/networking/browsers/firefox/12.0.nix
+++ b/pkgs/applications/networking/browsers/firefox/12.0.nix
@@ -33,7 +33,7 @@ rec {
       "--with-system-zlib"
       "--with-system-bz2"
       "--with-system-nspr"
-      # "--with-system-nss"
+      "--with-system-nss"
       # "--with-system-png" # <-- "--with-system-png won't work because the system's libpng doesn't have APNG support"
       # "--enable-system-cairo" # disabled for the moment because our Cairo is too old
       "--enable-system-sqlite"
@@ -54,7 +54,7 @@ rec {
       [ pkgconfig gtk perl zip libIDL libjpeg libpng zlib cairo bzip2
         python dbus dbus_glib pango freetype fontconfig xlibs.libXi
         xlibs.libX11 xlibs.libXrender xlibs.libXft xlibs.libXt file
-        alsaLib nspr /* nss */ libnotify xlibs.pixman yasm mesa
+        alsaLib nspr nss libnotify xlibs.pixman yasm mesa
         xlibs.libXScrnSaver xlibs.scrnsaverproto
         xlibs.libXext xlibs.xextproto sqlite unzip
       ];
@@ -129,7 +129,7 @@ rec {
       
     buildInputs =
       [ pkgconfig gtk perl zip libIDL libjpeg zlib cairo bzip2 python
-        dbus dbus_glib pango freetype fontconfig alsaLib nspr libnotify
+        dbus dbus_glib pango freetype fontconfig alsaLib nspr nss libnotify
         xlibs.pixman yasm mesa sqlite file unzip
       ];
 

--- a/pkgs/applications/networking/browsers/firefox/13.0.nix
+++ b/pkgs/applications/networking/browsers/firefox/13.0.nix
@@ -33,7 +33,7 @@ rec {
       "--with-system-zlib"
       "--with-system-bz2"
       "--with-system-nspr"
-      # "--with-system-nss"
+      "--with-system-nss"
       # "--with-system-png" # <-- "--with-system-png won't work because the system's libpng doesn't have APNG support"
       # "--enable-system-cairo" # disabled for the moment because our Cairo is too old
       "--enable-system-sqlite"
@@ -54,7 +54,7 @@ rec {
       [ pkgconfig gtk perl zip libIDL libjpeg libpng zlib cairo bzip2
         python dbus dbus_glib pango freetype fontconfig xlibs.libXi
         xlibs.libX11 xlibs.libXrender xlibs.libXft xlibs.libXt file
-        alsaLib nspr /* nss */ libnotify xlibs.pixman yasm mesa
+        alsaLib nspr nss libnotify xlibs.pixman yasm mesa
         xlibs.libXScrnSaver xlibs.scrnsaverproto
         xlibs.libXext xlibs.xextproto sqlite unzip makeWrapper
       ];
@@ -136,7 +136,7 @@ rec {
       
     buildInputs =
       [ pkgconfig gtk perl zip libIDL libjpeg zlib cairo bzip2 python
-        dbus dbus_glib pango freetype fontconfig alsaLib nspr libnotify
+        dbus dbus_glib pango freetype fontconfig alsaLib nspr nss libnotify
         xlibs.pixman yasm mesa sqlite file unzip
       ];
 

--- a/pkgs/applications/networking/browsers/firefox/3.6.nix
+++ b/pkgs/applications/networking/browsers/firefox/3.6.nix
@@ -31,7 +31,7 @@ rec {
       "--with-system-zlib"
       "--with-system-bz2"
       "--with-system-nspr"
-      #"--with-system-nss"
+      "--with-system-nss"
       # "--with-system-png" # <-- "--with-system-png won't work because the system's libpng doesn't have APNG support"
       "--enable-system-cairo"
       #"--enable-system-sqlite" # <-- this seems to be discouraged
@@ -59,7 +59,7 @@ rec {
       [ pkgconfig gtk perl zip libIDL libjpeg libpng zlib cairo bzip2
         python dbus dbus_glib pango freetype fontconfig xlibs.libXi
         xlibs.libX11 xlibs.libXrender xlibs.libXft xlibs.libXt file
-        alsaLib nspr /* nss */ libnotify xlibs.pixman
+        alsaLib nspr nss libnotify xlibs.pixman
       ];
 
     preConfigure = if stdenv.isMips then ''
@@ -118,7 +118,7 @@ rec {
 
     buildInputs =
       [ pkgconfig gtk perl zip libIDL libjpeg zlib cairo bzip2 python
-        dbus dbus_glib pango freetype fontconfig alsaLib nspr libnotify
+        dbus dbus_glib pango freetype fontconfig alsaLib nspr nss libnotify
         xlibs.pixman
       ];
 

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, nspr, perl, zlib, includeTools ? false}:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite
+, includeTools ? false
+}:
 
 let
 
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = "f7e90727e0ecc1c29de10da39a79bc9c53b814ccfbf40720e053b29c683d43a0";
   };
 
-  buildInputs = [nspr perl zlib];
+  buildInputs = [ nspr perl zlib sqlite ];
 
   patches = [ ./nss-3.12.5-gentoo-fixups.diff ];
 
@@ -38,7 +40,7 @@ stdenv.mkDerivation rec {
 
   makeFlags =
     [ "NSPR_CONFIG_STATUS=" "NSDISTMODE=copy" "BUILD_OPT=1" "SOURCE_PREFIX=\$(out)"
-      "NSS_ENABLE_ECC=1"
+      "NSS_ENABLE_ECC=1" "NSS_USE_SYSTEM_SQLITE=1"
     ]
     ++ stdenv.lib.optional stdenv.is64bit "USE_64=1";
 

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -86,4 +86,12 @@ stdenv.mkDerivation rec {
         --subst-var-by includedir $out/include/nss \
         --subst-var-by libdir $out/lib
     ''; # */
+
+  postFixup = ''
+    for libname in freebl3 nssdbm3 softokn3
+    do
+      libfile="$out/lib/lib$libname.so"
+      LD_LIBRARY_PATH=$out/lib $out/bin/shlibsign -v -i "$libfile"
+    done
+  '';
 }

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -4,11 +4,6 @@
 
 let
 
-  nssConfig = fetchurl {
-    url = "http://sources.gentoo.org/viewcvs.py/*checkout*/gentoo-x86/dev-libs/nss/files/3.12-nss-config.in?rev=1.2";
-    sha256 = "1ck9q68fxkjq16nflixbqi4xc6bmylmj994h3f1j42g8mp0xf0vd";
-  };
-
   nssPEM = fetchgit {
     url = "git://git.fedorahosted.org/git/nss-pem.git";
     rev = "07a683505d4a0a1113c4085c1ce117425d0afd80";
@@ -65,34 +60,15 @@ in stdenv.mkDerivation rec {
 
   buildFlags = [ "build_coreconf" "build_dbm" "all" ];
 
-  postInstall =
-    ''
-      #find $out -name "*.a" | xargs rm
-      rm -rf $out/private
-      mv $out/public $out/include
-      mv $out/*.OBJ/* $out/
-      rmdir $out/*.OBJ
-      ${if includeTools then "" else "rm -rf $out/bin"}
+  postInstall = ''
+    rm -rf $out/private
+    mv $out/public $out/include
+    mv $out/*.OBJ/* $out/
+    rmdir $out/*.OBJ
+    ${if includeTools then "" else "rm -rf $out/bin; mkdir $out/bin"}
 
-      # Borrowed from Gentoo.  Firefox expects an nss-config script,
-      # but NSS doesn't provide it.
-
-      NSS_VMAJOR=`cat lib/nss/nss.h | grep "#define.*NSS_VMAJOR" | awk '{print $3}'`
-      NSS_VMINOR=`cat lib/nss/nss.h | grep "#define.*NSS_VMINOR" | awk '{print $3}'`
-      NSS_VPATCH=`cat lib/nss/nss.h | grep "#define.*NSS_VPATCH" | awk '{print $3}'`
-
-      ${if includeTools then "" else "mkdir $out/bin"}
-      cp ${nssConfig} $out/bin/nss-config
-      chmod u+x $out/bin/nss-config
-      substituteInPlace $out/bin/nss-config \
-        --subst-var-by MOD_MAJOR_VERSION $NSS_VMAJOR \
-        --subst-var-by MOD_MINOR_VERSION $NSS_VMINOR \
-        --subst-var-by MOD_PATCH_VERSION $NSS_VPATCH \
-        --subst-var-by prefix $out \
-        --subst-var-by exec_prefix $out \
-        --subst-var-by includedir $out/include/nss \
-        --subst-var-by libdir $out/lib
-    ''; # */
+    cp -av config/nss-config $out/bin/nss-config
+  '';
 
   postFixup = ''
     for libname in freebl3 nssdbm3 softokn3

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,12 +9,16 @@ let
 
 in
 
-stdenv.mkDerivation {
-  name = "nss-3.13.3";
+stdenv.mkDerivation rec {
+  name = "nss-${version}";
+  version = "3.13.6";
 
-  src = fetchurl {
-    url = http://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_13_3_RTM/src/nss-3.13.3.tar.gz;
-    sha256 = "efa10f2c70da4bddabf1a6081964969bb23359b93d6eadbf4739274a77bc3587";
+  src = let
+    uscoreVersion = stdenv.lib.replaceChars ["."] ["_"] version;
+    releasePath = "releases/NSS_${uscoreVersion}_RTM/src/nss-${version}.tar.gz";
+  in fetchurl {
+    url = "http://ftp.mozilla.org/pub/mozilla.org/security/nss/${releasePath}";
+    sha256 = "f7e90727e0ecc1c29de10da39a79bc9c53b814ccfbf40720e053b29c683d43a0";
   };
 
   buildInputs = [nspr perl zlib];

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -15,9 +15,12 @@ let
     sha256 = "e4a9396d90e50e8b3cceff45f312eda9aaf356423f4eddd354a0e1afbbfd4cf8";
   };
 
-in
+  secLoadPatch = fetchurl {
+    url = "http://patch-tracker.debian.org/patch/series/dl/nss/2:3.13.5-1/85_security_load.patch";
+    sha256 = "8a8d0ae4ebbd7c389973fa5d26d8bc5f473046c6cb1d8283cb9a3c1f4c565c47";
+  };
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "nss-${version}";
   version = "3.13.6";
 
@@ -37,7 +40,11 @@ stdenv.mkDerivation rec {
     chmod -R u+w "$sourceRoot/mozilla/security/nss/lib/ckfw/pem"
   '';
 
-  patches = [ ./nss-3.12.5-gentoo-fixups.diff ];
+  patches = [
+    ./nss-3.12.5-gentoo-fixups.diff
+    secLoadPatch
+    ./nix_secload_fixup.patch
+  ];
 
   postPatch = ''
     sed -i -e 's/^DIRS.*$/& pem/' mozilla/security/nss/lib/ckfw/manifest.mn

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -65,7 +65,6 @@ in stdenv.mkDerivation rec {
     mv $out/public $out/include
     mv $out/*.OBJ/* $out/
     rmdir $out/*.OBJ
-    ${if includeTools then "" else "rm -rf $out/bin; mkdir $out/bin"}
 
     cp -av config/nss-config $out/bin/nss-config
   '';
@@ -76,5 +75,7 @@ in stdenv.mkDerivation rec {
       libfile="$out/lib/lib$libname.so"
       LD_LIBRARY_PATH=$out/lib $out/bin/shlibsign -v -i "$libfile"
     done
+  '' + stdenv.lib.optionalString (!includeTools) ''
+    find $out/bin -type f \( -name nss-config -o -delete \)
   '';
 }

--- a/pkgs/development/libraries/nss/nix_secload_fixup.patch
+++ b/pkgs/development/libraries/nss/nix_secload_fixup.patch
@@ -1,0 +1,50 @@
+diff --git a/mozilla/security/coreconf/config.mk b/mozilla/security/coreconf/config.mk
+index 72557c6..bdcbf88 100644
+--- a/mozilla/security/coreconf/config.mk
++++ b/mozilla/security/coreconf/config.mk
+@@ -207,3 +207,5 @@ endif
+ DEFINES += -DUSE_UTIL_DIRECTLY
+ USE_UTIL_DIRECTLY = 1
+ 
++# nix specific stuff:
++DEFINES += -DNIX_NSS_LIBDIR=\"$(out)/lib/\"
+diff --git a/mozilla/security/nss/cmd/shlibsign/shlibsign.c b/mozilla/security/nss/cmd/shlibsign/shlibsign.c
+index 5ce626e..e1e8039 100644
+--- a/mozilla/security/nss/cmd/shlibsign/shlibsign.c
++++ b/mozilla/security/nss/cmd/shlibsign/shlibsign.c
+@@ -770,7 +770,7 @@ int main(int argc, char **argv)
+     assert(libname != NULL);
+     lib = PR_LoadLibrary(libname);
+     if (!lib)
+-        lib = PR_LoadLibrary("/usr/lib/nss/libsoftokn3.so");
++        lib = PR_LoadLibrary(NIX_NSS_LIBDIR"libsoftokn3.so");
+     assert(lib != NULL);
+     PR_FreeLibraryName(libname);
+ 
+diff --git a/mozilla/security/nss/lib/util/secload.c b/mozilla/security/nss/lib/util/secload.c
+index 7d6fc22..0b7759b 100644
+--- a/mozilla/security/nss/lib/util/secload.c
++++ b/mozilla/security/nss/lib/util/secload.c
+@@ -105,9 +105,9 @@ loader_LoadLibInReferenceDir(const char *referencePath, const char *name)
+     /* Remove the trailing filename from referencePath and add the new one */
+     c = strrchr(referencePath, PR_GetDirectorySeparator());
+     if (!c) { /* referencePath doesn't contain a / means that dladdr gave us argv[0]
+-               * and program was called from $PATH. Hack to get libs from /usr/lib */
+-        referencePath = "/usr/lib/";
+-        c = &referencePath[8]; /* last / */
++               * and program was called from $PATH. Hack to get libs from NIX_NSS_LIBDIR */
++        referencePath = NIX_NSS_LIBDIR;
++        c = &referencePath[sizeof(NIX_NSS_LIBDIR) - 1]; /* last / */
+     }
+     if (c) {
+         size_t referencePathSize = 1 + c - referencePath;
+@@ -125,8 +125,7 @@ loader_LoadLibInReferenceDir(const char *referencePath, const char *name)
+                 (strncmp(fullName + referencePathSize - 4, "bin", 3) == 0)) {
+                 memcpy(fullName + referencePathSize -4, "lib", 3);
+             }
+-            strcpy(fullName + referencePathSize, "nss/");
+-            strcpy(fullName + referencePathSize + 4, name);
++            strcpy(fullName + referencePathSize, name);
+             dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL
+ #ifdef PR_LD_ALT_SEARCH_PATH
+             /* allow library's dependencies to be found in the same directory


### PR DESCRIPTION
This now uses more or less hardcoded CA certificates from Mozilla, which is the case on Debian and Gentoo aswell. And it fixes the root CA loading issue, as i discovered that firefox builds with the bundled version of NSS. With this branch this is no longer the case.

My long-term plans are to integrate an automatic chainloader for OPENSSL_X509_CERT_FILE, but I'm not sure if this is really a good idea (hence not included in this branch), as the nss-pem module is still somewhat experimental. Regardless of it's experimental nature i'm still including it in order to make it possible for users to load custom PEM encoded certificates into the NSS database.

This fixups also makes it possible to enable FIPS mode, in case someone might be interested in that.

And finally, we have a Chromium without quirky bugs from the experimental OpenSSL integration, which was my original motivation to do this.
