### PR TITLE
ncdu: New package, starting at version 1.8.

### DIFF
--- a/pkgs/tools/misc/ncdu/default.nix
+++ b/pkgs/tools/misc/ncdu/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "ncdu-${version}";
+  version = "1.8";
+
+  src = fetchurl {
+    url = "http://dev.yorhel.nl/download/${name}.tar.gz";
+    sha256 = "42aaf0418c05e725b39b220166a9c604a9c54c0fbf7692c9c119b36d0ed5d099";
+  };
+
+  buildInputs = [ ncurses ];
+
+  meta = {
+    description = "An ncurses disk usage analyzer.";
+    homepage = http://dev.yorhel.nl/ncdu;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7344,6 +7344,8 @@ let
 
   navit = callPackage ../applications/misc/navit { };
 
+  ncdu = callPackage ../tools/misc/ncdu { };
+
   nedit = callPackage ../applications/editors/nedit {
       motif = lesstif;
   };


### PR DESCRIPTION
`ncdu` is a little ncurses tool to browse the filesystem tree sorted by disk
usage.
