### PR TITLE
gimp: revert broken gimp-2.6 dependencies

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, gtk, freetype
-, fontconfig, libart_lgpl, libtiff, libjpeg, libpng, libexif, zlib, perl
-, perlXMLParser, python, pygtk, gettext, xlibs, intltool, babl, gegl
+, fontconfig, libart_lgpl, libtiff, libjpeg, libpng12, libexif, zlib, perl
+, perlXMLParser, python, pygtk, gettext, xlibs, intltool, babl_0_0_22, gegl_0_0_22
 }:
 
 stdenv.mkDerivation rec {
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   
   buildInputs = [
     pkgconfig gtk freetype fontconfig
-    libart_lgpl libtiff libjpeg libpng libexif zlib perl
-    perlXMLParser python pygtk gettext intltool babl gegl
+    libart_lgpl libtiff libjpeg libpng12 libexif zlib perl
+    perlXMLParser python pygtk gettext intltool babl_0_0_22 gegl_0_0_22
   ];
 
   passthru = { inherit gtk; }; # probably its a good idea to use the same gtk in plugins ?

--- a/pkgs/development/libraries/babl/0_0_22.nix
+++ b/pkgs/development/libraries/babl/0_0_22.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "babl-0.0.22";
+
+  src = fetchurl {
+    url = ftp://ftp.gtk.org/pub/babl/0.0/babl-0.0.22.tar.bz2;
+    sha256 = "0v8gbf9si4sd06199f8lfmrsbvi6i0hxphd34kyvsj6g2kkkg10s";
+  };
+
+  meta = { 
+    description = "Image pixel format conversion library";
+    homepage = http://gegl.org/babl/;
+    license = "GPL3";
+  };
+}

--- a/pkgs/development/libraries/gegl/0_0_22.nix
+++ b/pkgs/development/libraries/gegl/0_0_22.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, glib, babl_0_0_22, libpng12, cairo, libjpeg
+, librsvg, pango, gtk }:
+        
+stdenv.mkDerivation {
+  name = "gegl-0.0.22";
+
+  src = fetchurl {
+    url = ftp://ftp.gimp.org/pub/gegl/0.0/gegl-0.0.22.tar.bz2;
+    sha256 = "0nx6r9amzhw5d2ghlw3z8qnry18rwz1ymvl2cm31b8p49z436wl5";
+  };
+
+  configureFlags = "--disable-docs"; # needs fonts otherwise  don't know how to pass them
+
+  buildInputs = [ pkgconfig glib babl_0_0_22 libpng12 cairo libjpeg librsvg pango gtk ];
+
+  meta = { 
+    description = "Graph-based image processing framework";
+    homepage = http://www.gegl.org;
+    license = "GPL3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3273,6 +3273,8 @@ let
 
   axis = callPackage ../development/libraries/axis { };
 
+  babl_0_0_22 = callPackage ../development/libraries/babl/0_0_22.nix { };
+
   babl = callPackage ../development/libraries/babl { };
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
@@ -3526,6 +3528,9 @@ let
     #  avocodec avformat librsvg
   };
 
+  gegl_0_0_22 = callPackage ../development/libraries/gegl/0_0_22.nix {
+    #  avocodec avformat librsvg
+  };
   geoclue = callPackage ../development/libraries/geoclue {};
 
   geoip = builderDefsPackage ../development/libraries/geoip {
@@ -6891,13 +6896,15 @@ let
 
   get_iplayer = callPackage ../applications/misc/get_iplayer {};
 
-  gimp = callPackage ../applications/graphics/gimp {
+  gimp_2_6 = callPackage ../applications/graphics/gimp {
     inherit (gnome) libart_lgpl;
   };
 
   gimp_2_8 = callPackage ../applications/graphics/gimp/2.8.nix {
     inherit (gnome) libart_lgpl;
   };
+
+  gimp = gimp_2_6;
 
   gimpPlugins = recurseIntoAttrs (import ../applications/graphics/gimp/plugins {
     inherit pkgs gimp;


### PR DESCRIPTION
This patch brings gimp-2.6 back to work. Looks like new gegl / babl are not compatible with it anymore. gimp-2.8 needs further investigations.
