### PR TITLE
Default 'jdk' and 'jre' to openjdk and openjre, respectively, on supporting systems

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2363,8 +2363,12 @@ let
     jreOnly = true;
   };
 
-  jdk = if stdenv.isDarwin then openjdk else jdkdistro true false;
-  jre = jdkdistro false false;
+  jdk = if (stdenv.isDarwin || stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
+    then openjdk
+    else jdkdistro true false;
+  jre = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
+    then openjre
+    else jdkdistro false false;
 
   jrePlugin = lowPrio (jdkdistro false true);
 


### PR DESCRIPTION
With this change, java packages will build with openjdk by default. The primary driver for this is legal: The build farm is not allowed to distribute the proprietary Oracle jdk6, and so it is not allowed to distribute any packages that depend on it. In my view, this is a purely beneficial change: from the perspective of the build farm, packages will go from undistributable due to licensing to either distributable or undistributable due to failed build (if the package doesn't build properly with openjdk), and from the perspective of the end user it is very easy to override the jdk on a package-by-package basis or for all of nixpkgs in the nixpkgs configuration.
