### PR TITLE
Use jailbreak to deal with over-specified version restrictions in Cabal builds

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -1,6 +1,6 @@
 # generic builder for Cabal packages
 
-{stdenv, fetchurl, lib, pkgconfig, ghc, Cabal, enableLibraryProfiling ? false} :
+{ stdenv, fetchurl, lib, pkgconfig, ghc, Cabal, jailbreakCabal, enableLibraryProfiling ? false }:
 {
   mkDerivation =
     args : # arguments for the individual package, can modify the defaults
@@ -86,7 +86,8 @@
             configurePhase = ''
               eval "$preConfigure"
 
-              for i in Setup.hs Setup.lhs; do
+              ${lib.optionalString (lib.attrByPath ["jailbreak"] false self) "${jailbreakCabal}/bin/jailbreak-cabal ${self.pname}.cabal && "
+              }for i in Setup.hs Setup.lhs; do
                 test -f $i && ghc --make $i
               done
 

--- a/pkgs/development/compilers/ghc/7.6.1.nix
+++ b/pkgs/development/compilers/ghc/7.6.1.nix
@@ -12,7 +12,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ghc perl gmp ncurses ];
 
-  enableParallelBuilding = true;
+  # My attempts to compile GHC with parallel build support enabled, failed
+  # 4 consecutive times with the following error:
+  #
+  #    building rts/dist/build/AutoApply.debug_o
+  #    building rts/dist/build/AutoApply.thr_o
+  #      rts_dist_HC rts/dist/build/AutoApply.debug_o
+  #    /nix/store/1iigiim5855m8j7pmwf5xrnpf705s4dh-binutils-2.21.1a/bin/ld: cannot find libraries/integer-gmp/dist-install/build/cbits/gmp-wrappers_o_split/gmp-wrappers__1.o
+  #    collect2: ld returned 1 exit status
+  #    make[1]: *** [libraries/integer-gmp/dist-install/build/cbits/gmp-wrappers.p_o] Error 1
+  enableParallelBuilding = false;
 
   buildMK = ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp}/lib"

--- a/pkgs/development/libraries/haskell/Agda/default.nix
+++ b/pkgs/development/libraries/haskell/Agda/default.nix
@@ -13,9 +13,7 @@ cabal.mkDerivation (self: {
     QuickCheck syb xhtml zlib
   ];
   buildTools = [ alex happy ];
-  patchPhase = ''
-    sed -i -e 's|mtl == 2.0.\*|mtl|' Agda.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://wiki.portal.chalmers.se/agda/";
     description = "A dependently typed functional programming language and proof assistant";

--- a/pkgs/development/libraries/haskell/accelerate-cuda/default.nix
+++ b/pkgs/development/libraries/haskell/accelerate-cuda/default.nix
@@ -12,9 +12,6 @@ cabal.mkDerivation (self: {
     hashable hashtables languageCQuote mainlandPretty mtl srcloc
     transformers unorderedContainers
   ];
-  patchPhase = ''
-    sed -i -e 's|\<defaultMain\>|defaultMainWithHooks autoconfUserHooks|' Setup.hs
-  '';
   meta = {
     homepage = "http://www.cse.unsw.edu.au/~chak/project/accelerate/";
     description = "Accelerate backend for NVIDIA GPUs";

--- a/pkgs/development/libraries/haskell/clientsession/default.nix
+++ b/pkgs/development/libraries/haskell/clientsession/default.nix
@@ -10,9 +10,7 @@ cabal.mkDerivation (self: {
     base64Bytestring cereal cprngAes cryptoApi cryptocipher entropy
     skein tagged
   ];
-  patchPhase = ''
-    sed -i -e 's|, base64-bytestring.*|, base64-bytestring|' clientsession.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://github.com/yesodweb/clientsession/tree/master";
     description = "Securely store session data in a client-side cookie";

--- a/pkgs/development/libraries/haskell/filestore/default.nix
+++ b/pkgs/development/libraries/haskell/filestore/default.nix
@@ -11,9 +11,7 @@ cabal.mkDerivation (self: {
   buildDepends = [
     Diff filepath HUnit mtl parsec split time utf8String xml
   ];
-  patchPhase = ''
-    sed -i -e 's|split.*,|split,|' filestore.cabal
-  '';
+  jailbreak = true;
   noHaddock = true;
   meta = {
     description = "Interface for versioning file stores";

--- a/pkgs/development/libraries/haskell/ghc-events/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-events/default.nix
@@ -7,9 +7,7 @@ cabal.mkDerivation (self: {
   isLibrary = true;
   isExecutable = true;
   buildDepends = [ binary mtl ];
-  patchPhase = ''
-    sed -i -e 's|mtl *>=.*$|mtl,|' ghc-events.cabal
-  '';
+  jailbreak = true;
   noHaddock = true;
   meta = {
     description = "Library and tool for parsing .eventlog files from GHC";

--- a/pkgs/development/libraries/haskell/gitit/default.nix
+++ b/pkgs/development/libraries/haskell/gitit/default.nix
@@ -18,9 +18,7 @@ cabal.mkDerivation (self: {
     safe SHA syb tagsoup text time url utf8String xhtml xml xssSanitize
     zlib
   ];
-  patchPhase = ''
-    sed -i -e 's|hslogger.*,|hslogger,|' -e 's|base64-bytestring.*,|base64-bytestring,|' gitit.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://gitit.net";
     description = "Wiki using happstack, git or darcs, and pandoc";

--- a/pkgs/development/libraries/haskell/happstack/happstack-hamlet.nix
+++ b/pkgs/development/libraries/haskell/happstack/happstack-hamlet.nix
@@ -5,9 +5,7 @@ cabal.mkDerivation (self: {
   version = "7.0.1";
   sha256 = "13ayypl2x402h6a7yq7fvgd2mn21gl5gcw2hk7f5vr2bdlvwv53n";
   buildDepends = [ hamlet happstackServer text ];
-  patchPhase = ''
-    sed -i -e 's|hamlet .*,|hamlet,|' happstack-hamlet.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://www.happstack.com/";
     description = "Support for Hamlet HTML templates in Happstack";

--- a/pkgs/development/libraries/haskell/happstack/happstack-server.nix
+++ b/pkgs/development/libraries/haskell/happstack/happstack-server.nix
@@ -13,9 +13,7 @@ cabal.mkDerivation (self: {
     html monadControl mtl network parsec sendfile syb systemFilepath
     text time transformers transformersBase utf8String xhtml zlib
   ];
-  patchPhase = ''
-    sed -i -e 's|base64-bytestring.*,|base64-bytestring,|' happstack-server.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://happstack.com";
     description = "Web related tools and services";

--- a/pkgs/development/libraries/haskell/happstack/happstack-util.nix
+++ b/pkgs/development/libraries/haskell/happstack/happstack-util.nix
@@ -12,9 +12,7 @@ cabal.mkDerivation (self: {
     extensibleExceptions filepath hslogger mtl network parsec random
     time unixCompat
   ];
-  patchPhase = ''
-    sed -i -e 's|mtl >= 1.1 && < 2.1|mtl|' happstack-util.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://happstack.com";
     description = "Web framework";

--- a/pkgs/development/libraries/haskell/hledger-lib/default.nix
+++ b/pkgs/development/libraries/haskell/hledger-lib/default.nix
@@ -10,9 +10,7 @@ cabal.mkDerivation (self: {
     cmdargs csv filepath HUnit mtl parsec regexpr safe shakespeareText
     split time transformers utf8String
   ];
-  patchPhase = ''
-    sed -i -e 's|,split.*|,split|' -e 's|,cmdargs.*|,cmdargs|' hledger-lib.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://hledger.org";
     description = "Core data types, parsers and utilities for the hledger accounting tool";

--- a/pkgs/development/libraries/haskell/hledger/default.nix
+++ b/pkgs/development/libraries/haskell/hledger/default.nix
@@ -13,9 +13,7 @@ cabal.mkDerivation (self: {
     cabalFileTh cmdargs filepath haskeline hledgerLib HUnit mtl parsec
     regexpr safe shakespeareText split text time utf8String
   ];
-  patchPhase = ''
-    sed -i -e 's|,split.*|,split|' -e 's|,cmdargs.*|,cmdargs|' hledger.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://hledger.org";
     description = "The main command-line interface for the hledger accounting tool";

--- a/pkgs/development/libraries/haskell/mime-mail/default.nix
+++ b/pkgs/development/libraries/haskell/mime-mail/default.nix
@@ -7,9 +7,7 @@ cabal.mkDerivation (self: {
   buildDepends = [
     base64Bytestring blazeBuilder filepath random text
   ];
-  patchPhase = ''
-    sed -i -e 's|, base64-bytestring.*|, base64-bytestring|' mime-mail.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://github.com/snoyberg/mime-mail";
     description = "Compose MIME email messages";

--- a/pkgs/development/libraries/haskell/pandoc/default.nix
+++ b/pkgs/development/libraries/haskell/pandoc/default.nix
@@ -15,9 +15,7 @@ cabal.mkDerivation (self: {
     highlightingKate HTTP json mtl network pandocTypes parsec random
     syb tagsoup temporary texmath time utf8String xml zipArchive zlib
   ];
-  patchPhase = ''
-    sed -i -e 's|base64-bytestring.*,|base64-bytestring,|' pandoc.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://johnmacfarlane.net/pandoc";
     description = "Conversion between markup formats";

--- a/pkgs/development/libraries/haskell/snap/snap.nix
+++ b/pkgs/development/libraries/haskell/snap/snap.nix
@@ -19,9 +19,7 @@ cabal.mkDerivation (self: {
     snapServer stm syb text time transformers unorderedContainers
     utf8String vector vectorAlgorithms xmlhtml
   ];
-  patchPhase = ''
-    sed -i snap.cabal -e 's|clientsession.*,|clientsession,|'
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://snapframework.com/";
     description = "Snap: A Haskell Web Framework: project starter executable and glue code library";

--- a/pkgs/development/libraries/haskell/urlencoded/default.nix
+++ b/pkgs/development/libraries/haskell/urlencoded/default.nix
@@ -7,9 +7,7 @@ cabal.mkDerivation (self: {
   isLibrary = true;
   isExecutable = true;
   buildDepends = [ mtl network split ];
-  patchPhase = ''
-    sed -i -e 's|split.*|split|' urlencoded.cabal
-  '';
+  jailbreak = true;
   meta = {
     homepage = "https://github.com/pheaver/urlencoded";
     description = "Generate or process x-www-urlencoded data";

--- a/pkgs/development/libraries/haskell/wai-app-static/default.nix
+++ b/pkgs/development/libraries/haskell/wai-app-static/default.nix
@@ -13,10 +13,8 @@ cabal.mkDerivation (self: {
     cryptoConduit cryptohash fileEmbed httpDate httpTypes mimeTypes
     systemFileio systemFilepath text time transformers unixCompat wai
   ];
-  patchPhase = ''
-    sed -i -e 's|, base64-bytestring.*|, base64-bytestring|' wai-app-static.cabal
-  '';
-    meta = {
+  jailbreak = true;
+  meta = {
     homepage = "http://www.yesodweb.com/book/wai";
     description = "WAI application for static serving";
     license = self.stdenv.lib.licenses.mit;

--- a/pkgs/development/libraries/haskell/yesod-static/default.nix
+++ b/pkgs/development/libraries/haskell/yesod-static/default.nix
@@ -12,9 +12,7 @@ cabal.mkDerivation (self: {
     httpTypes systemFilepath text transformers unixCompat wai
     waiAppStatic yesodCore
   ];
-  patchPhase = ''
-    sed -i yesod-static.cabal -e 's|, base64-bytestring.*|, base64-bytestring|'
-  '';
+  jailbreak = true;
   meta = {
     homepage = "http://www.yesodweb.com/";
     description = "Static file serving subsite for Yesod Web Framework";

--- a/pkgs/development/tools/haskell/cabal2nix/default.nix
+++ b/pkgs/development/tools/haskell/cabal2nix/default.nix
@@ -2,8 +2,8 @@
 
 cabal.mkDerivation (self: {
   pname = "cabal2nix";
-  version = "1.38";
-  sha256 = "1kybxrkddbzr1cqpqplbflhakf9njb9hvamhdwvlanlk8985h8jg";
+  version = "1.39";
+  sha256 = "0q2kgzjbcrqxml12hncsrkjdwjiq52dp00v6i3qdgiyj460iy60d";
   isLibrary = false;
   isExecutable = true;
   buildDepends = [ Cabal filepath hackageDb HTTP mtl regexPosix ];

--- a/pkgs/development/tools/haskell/jailbreak-cabal/default.nix
+++ b/pkgs/development/tools/haskell/jailbreak-cabal/default.nix
@@ -1,0 +1,17 @@
+{ cabal, Cabal }:
+
+cabal.mkDerivation (self: {
+  pname = "jailbreak-cabal";
+  version = "1.0";
+  sha256 = "10vq592fx1i3fdqiij7daf3dmqq5c8c29ihr2y1rn2pjhkyiy4kk";
+  isLibrary = false;
+  isExecutable = true;
+  buildDepends = [ Cabal ];
+  meta = {
+    homepage = "http://github.com/peti/jailbreak-cabal";
+    description = "Strip version restrictions from build dependencies in Cabal files";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.simons ];
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1788,6 +1788,10 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
   cabalInstall_0_14_0 = callPackage ../tools/package-management/cabal-install/0.14.0.nix {};
   cabalInstall = self.cabalInstall_0_14_0;
 
+  jailbreakCabal = callPackage ../development/tools/haskell/jailbreak-cabal {
+    Cabal = self.Cabal_1_14_0;
+  };
+
   lhs2tex = callPackage ../tools/typesetting/lhs2tex {};
 
   myhasktags = callPackage ../tools/misc/myhasktags {};


### PR DESCRIPTION
`jailbreak` is a tool to drop all versions restrictions on build dependencies from Cabal files. Use of that tool makes it a lot easier to perform updates. Until now, I've manually patched Cabal files with `sed` to achieve the same effect. Please provide feedback whether you like this solution or not.
