### PR TITLE
Haskell attoparsec binary

### DIFF
--- a/pkgs/development/libraries/haskell/attoparsec-binary/attoparsec-binary-ghc7.6.1.patch
+++ b/pkgs/development/libraries/haskell/attoparsec-binary/attoparsec-binary-ghc7.6.1.patch
@@ -1,0 +1,20 @@
+diff --git a/Data/Attoparsec/Binary.hs b/Data/Attoparsec/Binary.hs
+index fab76c6..01d6c8b 100644
+--- a/Data/Attoparsec/Binary.hs
++++ b/Data/Attoparsec/Binary.hs
+@@ -23,7 +23,7 @@ import Data.Word
+ byteSize :: (Bits a) => a -> Int
+ byteSize = (`div` 8) . bitSize
+ 
+-pack :: (Bits a) => B.ByteString -> a
++pack :: (Bits a, Num a) => B.ByteString -> a
+ pack = B.foldl' (\n h -> (n `shiftL` 8) .|. fromIntegral h) 0
+ 
+ anyWordN :: (Bits a) => (B.ByteString -> a) -> Parser a
+@@ -84,4 +84,4 @@ word64be = wordN unpack
+ 
+ -- |Match a specific 64-bit little-endian word.
+ word64le :: Word64 -> Parser Word64
+-word64le = wordN $ B.reverse . unpack
+\ No newline at end of file
++word64le = wordN $ B.reverse . unpack

--- a/pkgs/development/libraries/haskell/attoparsec-binary/default.nix
+++ b/pkgs/development/libraries/haskell/attoparsec-binary/default.nix
@@ -5,6 +5,7 @@ cabal.mkDerivation (self: {
   version = "0.1.0.1";
   sha256 = "1d3zjr8bh6d44v1vid0cvrrbyhn7xj4bn96vy36dzk7h7p87bzxa";
   buildDepends = [ attoparsec ];
+  patches = [ ./attoparsec-binary-ghc7.6.1.patch ];
   meta = {
     description = "Binary processing extensions to Attoparsec";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/haskell/attoparsec-binary/default.nix
+++ b/pkgs/development/libraries/haskell/attoparsec-binary/default.nix
@@ -1,0 +1,13 @@
+{ cabal, attoparsec }:
+
+cabal.mkDerivation (self: {
+  pname = "attoparsec-binary";
+  version = "0.1.0.1";
+  sha256 = "1d3zjr8bh6d44v1vid0cvrrbyhn7xj4bn96vy36dzk7h7p87bzxa";
+  buildDepends = [ attoparsec ];
+  meta = {
+    description = "Binary processing extensions to Attoparsec";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -425,6 +425,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   attoparsec = callPackage ../development/libraries/haskell/attoparsec {};
 
+  attoparsecBinary = callPackage ../development/libraries/haskell/attoparsec-binarbinary {};
+
   attoparsecConduit = callPackage ../development/libraries/haskell/attoparsec-conduit {};
 
   attoparsecEnumerator = callPackage ../development/libraries/haskell/attoparsec/enumerator.nix {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -425,7 +425,7 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   attoparsec = callPackage ../development/libraries/haskell/attoparsec {};
 
-  attoparsecBinary = callPackage ../development/libraries/haskell/attoparsec-binarbinary {};
+  attoparsecBinary = callPackage ../development/libraries/haskell/attoparsec-binary {};
 
   attoparsecConduit = callPackage ../development/libraries/haskell/attoparsec-conduit {};
 


### PR DESCRIPTION
This adds the Haskell package attoparsec-binary in the most recent version as of writing. The Nix expression is generated by cabal2nix and a patch is supplied to make the package build with GHC 7.6.1.

Changes are tested locally. The patch should not cause any trouble with less recent versions of GHC, however this has not been tested.

I wrote an e-mail to attoparsec-binary's maintainer to fix this build issue with GHC 7.6.1. In case the patch holds back this pull request, I'll commit again if attoparsec-binary has been patched upstream.

Otherwise I'd be glad if this could be merged into upstream.
