### PR TITLE
fixes the build error for 4.7 and 4.8 with both don't work with boost 1....

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8094,9 +8094,9 @@ let
 
   kde4 = recurseIntoAttrs pkgs.kde47;
 
-  kde47 = kdePackagesFor pkgs.kde47 "4.7";
+  kde47 = kdePackagesFor (pkgs.kde47 // {boost = boost149;}) "4.7";
 
-  kde48 = kdePackagesFor pkgs.kde48 "4.8";
+  kde48 = kdePackagesFor (pkgs.kde48 // {boost = boost149;}) "4.8";
 
   kdePackagesFor = self: version:
     let callPackageOrig = callPackage; in


### PR DESCRIPTION
please integrated this into the official nixpkgs as it fixes both kde 4.7 and 4.8
