### PR TITLE
Update haskell tar and stringsearch

### DIFF
--- a/pkgs/development/libraries/haskell/stringsearch/default.nix
+++ b/pkgs/development/libraries/haskell/stringsearch/default.nix
@@ -2,8 +2,8 @@
 
 cabal.mkDerivation (self: {
   pname = "stringsearch";
-  version = "0.3.6.3";
-  sha256 = "1f0sl1zjya8glvlscf3g5i0in0ai1knls7kg9dp82grg2k287sgz";
+  version = "0.3.6.4";
+  sha256 = "16g0x0n8x3bg3mij7w3r5m3h2i2dn3bd298n14iccdwhfnlzm91b";
   meta = {
     homepage = "https://bitbucket.org/dafis/stringsearch";
     description = "Fast searching, splitting and replacing of ByteStrings";

--- a/pkgs/development/tools/haskell/tar/0.4.0.1.nix
+++ b/pkgs/development/tools/haskell/tar/0.4.0.1.nix
@@ -1,10 +1,10 @@
-{ cabal, filepath }:
+{ cabal, filepath, time }:
 
 cabal.mkDerivation (self: {
   pname = "tar";
-  version = "0.4.0.0";
-  sha256 = "04qijdfyiqb64q58g0bf46qfgaxqjl3kl68x6z31cv36p3hpplx3";
-  buildDepends = [ filepath ];
+  version = "0.4.0.1";
+  sha256 = "0vbsv7h3zgp30mlgsw156jkv1rqy5zbm98as9haf7x15hd6jf254";
+  buildDepends = [ filepath time ];
   meta = {
     description = "Reading, writing and manipulating \".tar\" archive files.";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1841,8 +1841,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
   };
 
   tar_0_3_2_0 = callPackage ../development/tools/haskell/tar/0.3.2.0.nix {};
-  tar_0_4_0_0 = callPackage ../development/tools/haskell/tar/0.4.0.0.nix {};
-  tar = self.tar_0_4_0_0;
+  tar_0_4_0_1 = callPackage ../development/tools/haskell/tar/0.4.0.1.nix {};
+  tar = self.tar_0_4_0_1;
 
   threadscope = callPackage ../development/tools/haskell/threadscope {};
 


### PR DESCRIPTION
These two packages are required to compile yesod with GHC 7.6.1.
