### PR TITLE
Update Firefox 16.0 to 16.0.1, and switch to the high-bandwidth releases.mozilla.org for the source.

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/16.0.nix
+++ b/pkgs/applications/networking/browsers/firefox/16.0.nix
@@ -15,14 +15,17 @@ assert stdenv.gcc ? libc && stdenv.gcc.libc != null;
 
 rec {
 
-  firefoxVersion = "16.0";
+  firefoxVersion = "16.0.1";
 
-  xulVersion = "16.0"; # this attribute is used by other packages
+  xulVersion = "16.0.1"; # this attribute is used by other packages
 
 
   src = fetchurl {
-    url = "ftp://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2";
-    sha1 = "8f79e4ccf28c57afd341b9fc258931b5f9e62064";
+    # Use this url for official releases.
+    url = "http://releases.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2";
+    # Use this url only for versions not available at releases.mozilla.org, to take load off Mozilla's ftp server.
+    #url = "ftp://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2";
+    sha256 = "1rrg2rmhczcwx5p5gilavqp4cvlig40ipw9avbgczahqjw89ivap";
   };
 
   commonConfigureFlags =

--- a/pkgs/applications/networking/browsers/firefox/16.0.nix
+++ b/pkgs/applications/networking/browsers/firefox/16.0.nix
@@ -21,11 +21,13 @@ rec {
 
 
   src = fetchurl {
-    # Use this url for official releases.
-    url = "http://releases.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2";
-    # Use this url only for versions not available at releases.mozilla.org, to take load off Mozilla's ftp server.
-    #url = "ftp://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2";
-    sha256 = "1rrg2rmhczcwx5p5gilavqp4cvlig40ipw9avbgczahqjw89ivap";
+    urls = [
+        # It is better to use this url for official releases, to take load off Mozilla's ftp server.
+        "http://releases.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2"
+        # Fall back to this url for versions not available at releases.mozilla.org.
+        "ftp://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2"
+    ];
+    sha1 = "ad5723fcf4ec6c6734e2022cecad174290fa425e";
   };
 
   commonConfigureFlags =


### PR DESCRIPTION
(Maybe all-packages.nix should use firefox16 by defaut now.)
