### PR TITLE
 flactag-2.0.4, unac-1.7.0, libmusicbrainz-5.0.1, and asciidoc-8.6.7

### DIFF
--- a/pkgs/applications/audio/flactag/default.nix
+++ b/pkgs/applications/audio/flactag/default.nix
@@ -1,10 +1,11 @@
 {stdenv, fetchurl, libmusicbrainz, flac, slang, neon, unac, libjpeg, asciidoc, libdiscid, pkgconfig}:
 
 stdenv.mkDerivation rec {
-  name = "flactag-2.0.4";
+  ver = "2.0.4";
+  name = "flactag-${ver}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/flactag/v2.0.4/flactag-2.0.4.tar.gz";
+    url = "mirror://sourceforge/flactag/v$ver}/${name}.tar.gz";
     sha256 = "c96718ac3ed3a0af494a1970ff64a606bfa54ac78854c5d1c7c19586177335b2";
   };
 

--- a/pkgs/applications/audio/flactag/default.nix
+++ b/pkgs/applications/audio/flactag/default.nix
@@ -1,0 +1,27 @@
+{stdenv, fetchurl, libmusicbrainz, flac, slang, neon, unac, libjpeg, asciidoc, libdiscid, pkgconfig}:
+
+stdenv.mkDerivation rec {
+  name = "flactag-2.0.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/flactag/v2.0.4/flactag-2.0.4.tar.gz";
+    sha256 = "c96718ac3ed3a0af494a1970ff64a606bfa54ac78854c5d1c7c19586177335b2";
+  };
+
+  buildInputs = [ libmusicbrainz flac slang neon unac libjpeg asciidoc libdiscid pkgconfig ];
+
+  meta = {
+    description = "A utility for maintaining single album FLAC file (with embedded CUE sheets) metadata from MusicBrainz. ";
+    longDescription = ''
+      A common mechanism for backing up audio cds is to extract them from the media
+      into a single flac file, and embed the cue sheet into the flac file. This means
+      that the cd can be exactly reproduced at a later date. 
+
+      flactag uses the embedded CUE sheet to create a musicbrainz 'discid', and
+      queries the musicbrainz server for track lists, and other album metadata. 
+    '';
+    homepage = http://flactag.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ jcumming ];
+  };
+}

--- a/pkgs/applications/audio/flactag/default.nix
+++ b/pkgs/applications/audio/flactag/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "flactag-${ver}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/flactag/v$ver}/${name}.tar.gz";
+    url = "mirror://sourceforge/flactag/v${ver}/${name}.tar.gz";
     sha256 = "c96718ac3ed3a0af494a1970ff64a606bfa54ac78854c5d1c7c19586177335b2";
   };
 

--- a/pkgs/development/libraries/libmusicbrainz/default.nix
+++ b/pkgs/development/libraries/libmusicbrainz/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   dontUseCmakeBuildDir=true;
 
   src = fetchurl {
-    url = https://github.com/downloads/metabrainz/libmusicbrainz/libmusicbrainz-5.0.1.tar.gz;
+    url = "https://github.com/downloads/metabrainz/libmusicbrainz/${name}.tar.gz";
     sha256 = "1ca75e1c5059a3620b0d82633b1f468acc2a65fcc4305f844ec44f6fb5db82d5";
   };
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       The libmusicbrainz (also known as mb_client or MusicBrainz Client
       Library) is a development library geared towards developers who wish to
       add MusicBrainz lookup capabilities to their applications.'';
-    maintainers = [ stdenv.lib.maintainers.urkud ];
+    maintainers = [ stdenv.lib.maintainers.urkud stdenv.lib.maintainers.jcumming ];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/libmusicbrainz/default.nix
+++ b/pkgs/development/libraries/libmusicbrainz/default.nix
@@ -1,13 +1,16 @@
 { stdenv, fetchurl, cmake, neon, libdiscid }:
 
 stdenv.mkDerivation rec {
-  name = "libmusicbrainz-3.0.3";
+  name = "libmusicbrainz-5.0.1";
 
   buildInputs = [ cmake neon libdiscid ];
 
+  # this probably can be removed after 5.0.1: https://github.com/metabrainz/libmusicbrainz/issues/1
+  dontUseCmakeBuildDir=true;
+
   src = fetchurl {
-    url = "ftp://ftp.musicbrainz.org/pub/musicbrainz/${name}.tar.gz";
-    md5 = "f4824d0a75bdeeef1e45cc88de7bb58a";
+    url = https://github.com/downloads/metabrainz/libmusicbrainz/libmusicbrainz-5.0.1.tar.gz;
+    sha256 = "1ca75e1c5059a3620b0d82633b1f468acc2a65fcc4305f844ec44f6fb5db82d5";
   };
 
   meta = {

--- a/pkgs/development/libraries/unac/default.nix
+++ b/pkgs/development/libraries/unac/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "unac-1.7.0";
 
   src = fetchurl {
-    url = http://download.savannah.gnu.org/releases/unac/unac-1.7.0.tar.gz;
+    url = "http://download.savannah.gnu.org/releases/unac/${name}.tar.gz";
     sha256 = "1r54dzgcgrmllps1wzivzwx1dzjxcs7v2swwf7jrlp125154k0jy";
   };
 

--- a/pkgs/development/libraries/unac/default.nix
+++ b/pkgs/development/libraries/unac/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  name = "unac-1.7.0";
+
+  src = fetchurl {
+    url = http://download.savannah.gnu.org/releases/unac/unac-1.7.0.tar.gz;
+    sha256 = "1r54dzgcgrmllps1wzivzwx1dzjxcs7v2swwf7jrlp125154k0jy";
+  };
+
+  patches = [ ./multiline-string.patch ];
+
+  buildInputs = [ perl ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "unac is a C library and command that removes accents from a string.";
+    longDescription = ''
+      unac is a C library and command that removes accents from a string. For
+      instance the string été will become ete. It provides a command line interface
+      that removes accents from a input flow or a string given in argument (unaccent
+      command).
+    '';
+    homepage = http://savannah.nongnu.org/projects/unac;
+    maintainers = with stdenv.lib.maintainers; [ jcumming ];
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/development/libraries/unac/multiline-string.patch
+++ b/pkgs/development/libraries/unac/multiline-string.patch
@@ -1,0 +1,833 @@
+*** unac-1.7.0.orig/unactest1.c	Wed Jul  3 00:41:54 2002
+--- unac-1.7.0/unactest1.c	Sun Jul 15 11:27:19 2012
+***************
+*** 26,439 ****
+  
+  #include "unac.h"
+  
+! static char* longstr_expected = " 
+! 
+! Senga - Catalog software
+! 
+! 
+! 
+! 
+! 
+! 
+!    
+!     
+!  
+! 
+!     
+!   
+!    
+!      
+!        
+! 
+!   
+!   
+!    senga.org
+!    
+! 
+!   
+! 
+! 
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+! 
+! 
+! 
+! 
+! 
+! December 28, 2000 
+!      
+!       January 27, 2000
+!       Catalog-1.02 
+!         is available. 
+!       
+!        The dmoz loading process has been dramatically simplified. It is
+!           now only available as a command. No more fancy web interface that
+! 	  confuses everyone. In addition the convert_dmoz script now generates
+! 	  text files that can be directly loaded into Catalog instead of the
+! 	  intermediate XML file. The whole loading process now takes from 
+! 	  one to two hours depending on your machine. It took around 10 hours
+! 	  with the previous version. 
+!        The -exclude option was added to convert_dmoz to get rid of 
+!           a whole branch of the catalog at load time. Typical usage would
+! 	  be convert_dmoz -exclude '^/Adult' -what content content.rdf.gz.
+!        A lot more sanity checks and repair have been added to deal with
+!           duplicates, category id conflicts and the like.
+!        Hopefully this new method will also be more understandable and 
+!           generate less traffic on the mailing list. There is room for 
+! 	  improvements and contributors are welcome. 
+!       
+!       A new set of software is available in the 
+!       download directory under the RedHat-6.1 section. These
+!       are the most up to date versions on which Catalog depends. Although the
+!       binaries depend on RedHat-6.1 the perl modules are source and can be
+!       used on any platform.
+!       
+!       September 7, 1999
+!       Catalog-1.01 
+!         is available. 
+!       This is a maintainance release.
+!       
+!         Various bug fixes. All easy
+! 	  to fix bugs have been fixed. Take a look at Bug Track to see what hasn't been fixed.
+!         The _PATHTEXT_ and _PATHFILE_ 
+! 	  tags syntax has been extended to specify a range of path component.
+!           
+!         Graham Barr added a recursive
+! 	  template feature for a catalog root page. This allows to show sub-categories
+! 	  of the root categories in the root page of a catalog.
+!           
+!       
+!       Don't hesitate to submit bugs
+!         or ideas to bug track. Hopefully the next version of Catalog will have
+! 	a fast full text indexing mechanism and I'll be able to implement new
+! 	functionalities.
+!         
+!       Have fun !
+!       July 3, 1999
+!       Catalog-1.00 
+!         is available. 
+!       This release includes PHP3 
+!         code to display a catalog. The author is Weston Bustraan (weston@infinityteldata.net). 
+!         The main motivation to jump directly to version 1.00 is to avoid version 
+!         number problems on CPAN. 
+!       July 2, 1999
+!       Catalog-0.19 
+!         is available. 
+!       This is a minor release. The 
+!         most noticeable addition is the new search mechanism.
+!       
+!         Searching : two search modes 
+!           are now available. AltaVista simple syntax and AltaVista advanced syntax. 
+!           Both use the Text-Query and Text-Query-SQL perl modules. 
+!         Dmoz loading is much more 
+!           fault tolerant. In addition it can handle compressed versions of content.rdf 
+!           and structure.rdf. The comments are now stored in text fields instead 
+!           of char(255).
+!         The template system was 
+!           extended with the pre_fill and post_fill parameters.
+!         Searching associated to 
+!           a catalog dumped to static pages is now possible using the 'static' 
+!           mode.
+!         Fixed two security weakness 
+!           in confedit and recursive cgi handling.
+!         Many sql queries have been 
+!           optimized.
+!         The configuration was changed 
+!           a bit to fix bugs and to isolate database dependencies.
+!         The tests were updated to 
+!           isolate database dependencies. 
+!         Fixed numerous minor bugs, 
+!           check ChangeLog if you're interested in details.
+!       
+!       Many thanks to Tim Bunce for 
+!         his numerous contributions and ideas. He is the architect of the Text-Query 
+!         and Text-Query-SQL modules, Eric Bohlman and Loic Dachary did the programming. 
+!         
+!       Thanks to Eric Bohlman for 
+!         his help on the Text-Query module. He was very busy but managed to spend 
+!         the time needed to release it. 
+!       There is not yet anything usable 
+!         for full text indexing but we keep working on it. The storage management 
+!         is now handled by the reiserfs file system thanks to Hans Reiser who is 
+!         working full time on this. Loic Dachary does his best to get something 
+!         working, if you're interested go to http://www.senga.org/mifluz/. 
+!       For some mysterious reason 
+!         CPAN lost track of Catalog name. In order to install catalog you should 
+!         use perl -MCPAN -e 'install Catalog::db'. Weird but temporary.
+!       Have fun !
+!        The Senga Team
+!         Ecila
+!         100 Av. du General Leclerc
+!         93 500 Pantin
+!         Tel: 33 1 56 96 09 80
+!         Fax: 33 1 56 96 09 81
+!         WEB: http://www.senga.org/
+!         Mail: senga@senga.org
+!       
+!     
+!   
+!   
+!      
+!     
+!       
+! 
+! [
+! Catalog |
+! webbase |
+! mifluz |
+! unac |
+! Search-Mifluz |
+! Text-Query |
+! uri |
+! Statistics |
+! News
+! ]
+! 
+! 
+!     
+!   
+! 
+! 
+! 
+  ";
+  
+! static char* longstr = " 
+! 
+! Senga - Catalog software
+! 
+! 
+! 
+! 
+! 
+! 
+!    
+!     
+!  
+! 
+!     
+!   
+!    
+!      
+!        
+! 
+!   
+!   
+!    senga.org
+!    
+! 
+!   
+! 
+! 
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+!    
+!     
+!   
+! 
+! 
+! 
+! 
+! 
+! December 28, 2000 
+!      
+!       January 27, 2000
+!       Catalog-1.02 
+!         is available. 
+!       
+!        The dmoz loading process has been dramatically simplified. It is
+!           now only available as a command. No more fancy web interface that
+! 	  confuses everyone. In addition the convert_dmoz script now generates
+! 	  text files that can be directly loaded into Catalog instead of the
+! 	  intermediate XML file. The whole loading process now takes from 
+! 	  one to two hours depending on your machine. It took around 10 hours
+! 	  with the previous version. 
+!        The -exclude option was added to convert_dmoz to get rid of 
+!           a whole branch of the catalog at load time. Typical usage would
+! 	  be convert_dmoz -exclude '^/Adult' -what content content.rdf.gz.
+!        A lot more sanity checks and repair have been added to deal with
+!           duplicates, category id conflicts and the like.
+!        Hopefully this new method will also be more understandable and 
+!           generate less traffic on the mailing list. There is room for 
+! 	  improvements and contributors are welcome. 
+!       
+!       A new set of software is available in the 
+!       download directory under the RedHat-6.1 section. These
+!       are the most up to date versions on which Catalog depends. Although the
+!       binaries depend on RedHat-6.1 the perl modules are source and can be
+!       used on any platform.
+!       
+!       September 7, 1999
+!       Catalog-1.01 
+!         is available. 
+!       This is a maintainance release.
+!       
+!         Various bug fixes. All easy
+! 	  to fix bugs have been fixed. Take a look at Bug Track to see what hasn't been fixed.
+!         The _PATHTEXT_ and _PATHFILE_ 
+! 	  tags syntax has been extended to specify a range of path component.
+!           
+!         Graham Barr added a recursive
+! 	  template feature for a catalog root page. This allows to show sub-categories
+! 	  of the root categories in the root page of a catalog.
+!           
+!       
+!       Don't hesitate to submit bugs
+!         or ideas to bug track. Hopefully the next version of Catalog will have
+! 	a fast full text indexing mechanism and I'll be able to implement new
+! 	functionalities.
+!         
+!       Have fun !
+!       July 3, 1999
+!       Catalog-1.00 
+!         is available. 
+!       This release includes PHP3 
+!         code to display a catalog. The author is Weston Bustraan (weston@infinityteldata.net). 
+!         The main motivation to jump directly to version 1.00 is to avoid version 
+!         number problems on CPAN. 
+!       July 2, 1999
+!       Catalog-0.19 
+!         is available. 
+!       This is a minor release. The 
+!         most noticeable addition is the new search mechanism.
+!       
+!         Searching : two search modes 
+!           are now available. AltaVista simple syntax and AltaVista advanced syntax. 
+!           Both use the Text-Query and Text-Query-SQL perl modules. 
+!         Dmoz loading is much more 
+!           fault tolerant. In addition it can handle compressed versions of content.rdf 
+!           and structure.rdf. The comments are now stored in text fields instead 
+!           of char(255).
+!         The template system was 
+!           extended with the pre_fill and post_fill parameters.
+!         Searching associated to 
+!           a catalog dumped to static pages is now possible using the 'static' 
+!           mode.
+!         Fixed two security weakness 
+!           in confedit and recursive cgi handling.
+!         Many sql queries have been 
+!           optimized.
+!         The configuration was changed 
+!           a bit to fix bugs and to isolate database dependencies.
+!         The tests were updated to 
+!           isolate database dependencies. 
+!         Fixed numerous minor bugs, 
+!           check ChangeLog if you're interested in details.
+!       
+!       Many thanks to Tim Bunce for 
+!         his numerous contributions and ideas. He is the architect of the Text-Query 
+!         and Text-Query-SQL modules, Eric Bohlman and Loic Dachary did the programming. 
+!         
+!       Thanks to Eric Bohlman for 
+!         his help on the Text-Query module. He was very busy but managed to spend 
+!         the time needed to release it. 
+!       There is not yet anything usable 
+!         for full text indexing but we keep working on it. The storage management 
+!         is now handled by the reiserfs file system thanks to Hans Reiser who is 
+!         working full time on this. Loic Dachary does his best to get something 
+!         working, if you're interested go to http://www.senga.org/mifluz/. 
+!       For some mysterious reason 
+!         CPAN lost track of Catalog name. In order to install catalog you should 
+!         use perl -MCPAN -e 'install Catalog::db'. Weird but temporary.
+!       Have fun !
+!        The Senga Team
+!         Ecila
+!         100 Av. du Général Leclerc
+!         93 500 Pantin
+!         Tel: 33 1 56 96 09 80
+!         Fax: 33 1 56 96 09 81
+!         WEB: http://www.senga.org/
+!         Mail: senga@senga.org
+!       
+!     
+!   
+!   
+!      
+!     
+!       
+! 
+! [
+! Catalog |
+! webbase |
+! mifluz |
+! unac |
+! Search-Mifluz |
+! Text-Query |
+! uri |
+! Statistics |
+! News
+! ]
+! 
+! 
+!     
+!   
+! 
+! 
+! 
+  ";
+  
+  int main() {
+--- 26,439 ----
+  
+  #include "unac.h"
+  
+! static char* longstr_expected = " \n\
+! \n\
+! Senga - Catalog software\n\
+! \n\
+! \n\
+! \n\
+! \n\
+! \n\
+! \n\
+!    \n\
+!     \n\
+!  \n\
+! \n\
+!     \n\
+!   \n\
+!    \n\
+!      \n\
+!        \n\
+! \n\
+!   \n\
+!   \n\
+!    senga.org\n\
+!    \n\
+! \n\
+!   \n\
+! \n\
+! \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+! \n\
+! \n\
+! \n\
+! \n\
+! \n\
+! December 28, 2000 \n\
+!      \n\
+!       January 27, 2000\n\
+!       Catalog-1.02 \n\
+!         is available. \n\
+!       \n\
+!        The dmoz loading process has been dramatically simplified. It is\n\
+!           now only available as a command. No more fancy web interface that\n\
+! 	  confuses everyone. In addition the convert_dmoz script now generates\n\
+! 	  text files that can be directly loaded into Catalog instead of the\n\
+! 	  intermediate XML file. The whole loading process now takes from \n\
+! 	  one to two hours depending on your machine. It took around 10 hours\n\
+! 	  with the previous version. \n\
+!        The -exclude option was added to convert_dmoz to get rid of \n\
+!           a whole branch of the catalog at load time. Typical usage would\n\
+! 	  be convert_dmoz -exclude '^/Adult' -what content content.rdf.gz.\n\
+!        A lot more sanity checks and repair have been added to deal with\n\
+!           duplicates, category id conflicts and the like.\n\
+!        Hopefully this new method will also be more understandable and \n\
+!           generate less traffic on the mailing list. There is room for \n\
+! 	  improvements and contributors are welcome. \n\
+!       \n\
+!       A new set of software is available in the \n\
+!       download directory under the RedHat-6.1 section. These\n\
+!       are the most up to date versions on which Catalog depends. Although the\n\
+!       binaries depend on RedHat-6.1 the perl modules are source and can be\n\
+!       used on any platform.\n\
+!       \n\
+!       September 7, 1999\n\
+!       Catalog-1.01 \n\
+!         is available. \n\
+!       This is a maintainance release.\n\
+!       \n\
+!         Various bug fixes. All easy\n\
+! 	  to fix bugs have been fixed. Take a look at Bug Track to see what hasn't been fixed.\n\
+!         The _PATHTEXT_ and _PATHFILE_ \n\
+! 	  tags syntax has been extended to specify a range of path component.\n\
+!           \n\
+!         Graham Barr added a recursive\n\
+! 	  template feature for a catalog root page. This allows to show sub-categories\n\
+! 	  of the root categories in the root page of a catalog.\n\
+!           \n\
+!       \n\
+!       Don't hesitate to submit bugs\n\
+!         or ideas to bug track. Hopefully the next version of Catalog will have\n\
+! 	a fast full text indexing mechanism and I'll be able to implement new\n\
+! 	functionalities.\n\
+!         \n\
+!       Have fun !\n\
+!       July 3, 1999\n\
+!       Catalog-1.00 \n\
+!         is available. \n\
+!       This release includes PHP3 \n\
+!         code to display a catalog. The author is Weston Bustraan (weston@infinityteldata.net). \n\
+!         The main motivation to jump directly to version 1.00 is to avoid version \n\
+!         number problems on CPAN. \n\
+!       July 2, 1999\n\
+!       Catalog-0.19 \n\
+!         is available. \n\
+!       This is a minor release. The \n\
+!         most noticeable addition is the new search mechanism.\n\
+!       \n\
+!         Searching : two search modes \n\
+!           are now available. AltaVista simple syntax and AltaVista advanced syntax. \n\
+!           Both use the Text-Query and Text-Query-SQL perl modules. \n\
+!         Dmoz loading is much more \n\
+!           fault tolerant. In addition it can handle compressed versions of content.rdf \n\
+!           and structure.rdf. The comments are now stored in text fields instead \n\
+!           of char(255).\n\
+!         The template system was \n\
+!           extended with the pre_fill and post_fill parameters.\n\
+!         Searching associated to \n\
+!           a catalog dumped to static pages is now possible using the 'static' \n\
+!           mode.\n\
+!         Fixed two security weakness \n\
+!           in confedit and recursive cgi handling.\n\
+!         Many sql queries have been \n\
+!           optimized.\n\
+!         The configuration was changed \n\
+!           a bit to fix bugs and to isolate database dependencies.\n\
+!         The tests were updated to \n\
+!           isolate database dependencies. \n\
+!         Fixed numerous minor bugs, \n\
+!           check ChangeLog if you're interested in details.\n\
+!       \n\
+!       Many thanks to Tim Bunce for \n\
+!         his numerous contributions and ideas. He is the architect of the Text-Query \n\
+!         and Text-Query-SQL modules, Eric Bohlman and Loic Dachary did the programming. \n\
+!         \n\
+!       Thanks to Eric Bohlman for \n\
+!         his help on the Text-Query module. He was very busy but managed to spend \n\
+!         the time needed to release it. \n\
+!       There is not yet anything usable \n\
+!         for full text indexing but we keep working on it. The storage management \n\
+!         is now handled by the reiserfs file system thanks to Hans Reiser who is \n\
+!         working full time on this. Loic Dachary does his best to get something \n\
+!         working, if you're interested go to http://www.senga.org/mifluz/. \n\
+!       For some mysterious reason \n\
+!         CPAN lost track of Catalog name. In order to install catalog you should \n\
+!         use perl -MCPAN -e 'install Catalog::db'. Weird but temporary.\n\
+!       Have fun !\n\
+!        The Senga Team\n\
+!         Ecila\n\
+!         100 Av. du General Leclerc\n\
+!         93 500 Pantin\n\
+!         Tel: 33 1 56 96 09 80\n\
+!         Fax: 33 1 56 96 09 81\n\
+!         WEB: http://www.senga.org/\n\
+!         Mail: senga@senga.org\n\
+!       \n\
+!     \n\
+!   \n\
+!   \n\
+!      \n\
+!     \n\
+!       \n\
+! \n\
+! [\n\
+! Catalog |\n\
+! webbase |\n\
+! mifluz |\n\
+! unac |\n\
+! Search-Mifluz |\n\
+! Text-Query |\n\
+! uri |\n\
+! Statistics |\n\
+! News\n\
+! ]\n\
+! \n\
+! \n\
+!     \n\
+!   \n\
+! \n\
+! \n\
+! \n\
+  ";
+  
+! static char* longstr = " \n\
+! \n\
+! Senga - Catalog software\n\
+! \n\
+! \n\
+! \n\
+! \n\
+! \n\
+! \n\
+!    \n\
+!     \n\
+!  \n\
+! \n\
+!     \n\
+!   \n\
+!    \n\
+!      \n\
+!        \n\
+! \n\
+!   \n\
+!   \n\
+!    senga.org\n\
+!    \n\
+! \n\
+!   \n\
+! \n\
+! \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+!    \n\
+!     \n\
+!   \n\
+! \n\
+! \n\
+! \n\
+! \n\
+! \n\
+! December 28, 2000 \n\
+!      \n\
+!       January 27, 2000\n\
+!       Catalog-1.02 \n\
+!         is available. \n\
+!       \n\
+!        The dmoz loading process has been dramatically simplified. It is\n\
+!           now only available as a command. No more fancy web interface that\n\
+! 	  confuses everyone. In addition the convert_dmoz script now generates\n\
+! 	  text files that can be directly loaded into Catalog instead of the\n\
+! 	  intermediate XML file. The whole loading process now takes from \n\
+! 	  one to two hours depending on your machine. It took around 10 hours\n\
+! 	  with the previous version. \n\
+!        The -exclude option was added to convert_dmoz to get rid of \n\
+!           a whole branch of the catalog at load time. Typical usage would\n\
+! 	  be convert_dmoz -exclude '^/Adult' -what content content.rdf.gz.\n\
+!        A lot more sanity checks and repair have been added to deal with\n\
+!           duplicates, category id conflicts and the like.\n\
+!        Hopefully this new method will also be more understandable and \n\
+!           generate less traffic on the mailing list. There is room for \n\
+! 	  improvements and contributors are welcome. \n\
+!       \n\
+!       A new set of software is available in the \n\
+!       download directory under the RedHat-6.1 section. These\n\
+!       are the most up to date versions on which Catalog depends. Although the\n\
+!       binaries depend on RedHat-6.1 the perl modules are source and can be\n\
+!       used on any platform.\n\
+!       \n\
+!       September 7, 1999\n\
+!       Catalog-1.01 \n\
+!         is available. \n\
+!       This is a maintainance release.\n\
+!       \n\
+!         Various bug fixes. All easy\n\
+! 	  to fix bugs have been fixed. Take a look at Bug Track to see what hasn't been fixed.\n\
+!         The _PATHTEXT_ and _PATHFILE_ \n\
+! 	  tags syntax has been extended to specify a range of path component.\n\
+!           \n\
+!         Graham Barr added a recursive\n\
+! 	  template feature for a catalog root page. This allows to show sub-categories\n\
+! 	  of the root categories in the root page of a catalog.\n\
+!           \n\
+!       \n\
+!       Don't hesitate to submit bugs\n\
+!         or ideas to bug track. Hopefully the next version of Catalog will have\n\
+! 	a fast full text indexing mechanism and I'll be able to implement new\n\
+! 	functionalities.\n\
+!         \n\
+!       Have fun !\n\
+!       July 3, 1999\n\
+!       Catalog-1.00 \n\
+!         is available. \n\
+!       This release includes PHP3 \n\
+!         code to display a catalog. The author is Weston Bustraan (weston@infinityteldata.net). \n\
+!         The main motivation to jump directly to version 1.00 is to avoid version \n\
+!         number problems on CPAN. \n\
+!       July 2, 1999\n\
+!       Catalog-0.19 \n\
+!         is available. \n\
+!       This is a minor release. The \n\
+!         most noticeable addition is the new search mechanism.\n\
+!       \n\
+!         Searching : two search modes \n\
+!           are now available. AltaVista simple syntax and AltaVista advanced syntax. \n\
+!           Both use the Text-Query and Text-Query-SQL perl modules. \n\
+!         Dmoz loading is much more \n\
+!           fault tolerant. In addition it can handle compressed versions of content.rdf \n\
+!           and structure.rdf. The comments are now stored in text fields instead \n\
+!           of char(255).\n\
+!         The template system was \n\
+!           extended with the pre_fill and post_fill parameters.\n\
+!         Searching associated to \n\
+!           a catalog dumped to static pages is now possible using the 'static' \n\
+!           mode.\n\
+!         Fixed two security weakness \n\
+!           in confedit and recursive cgi handling.\n\
+!         Many sql queries have been \n\
+!           optimized.\n\
+!         The configuration was changed \n\
+!           a bit to fix bugs and to isolate database dependencies.\n\
+!         The tests were updated to \n\
+!           isolate database dependencies. \n\
+!         Fixed numerous minor bugs, \n\
+!           check ChangeLog if you're interested in details.\n\
+!       \n\
+!       Many thanks to Tim Bunce for \n\
+!         his numerous contributions and ideas. He is the architect of the Text-Query \n\
+!         and Text-Query-SQL modules, Eric Bohlman and Loic Dachary did the programming. \n\
+!         \n\
+!       Thanks to Eric Bohlman for \n\
+!         his help on the Text-Query module. He was very busy but managed to spend \n\
+!         the time needed to release it. \n\
+!       There is not yet anything usable \n\
+!         for full text indexing but we keep working on it. The storage management \n\
+!         is now handled by the reiserfs file system thanks to Hans Reiser who is \n\
+!         working full time on this. Loic Dachary does his best to get something \n\
+!         working, if you're interested go to http://www.senga.org/mifluz/. \n\
+!       For some mysterious reason \n\
+!         CPAN lost track of Catalog name. In order to install catalog you should \n\
+!         use perl -MCPAN -e 'install Catalog::db'. Weird but temporary.\n\
+!       Have fun !\n\
+!        The Senga Team\n\
+!         Ecila\n\
+!         100 Av. du Général Leclerc\n\
+!         93 500 Pantin\n\
+!         Tel: 33 1 56 96 09 80\n\
+!         Fax: 33 1 56 96 09 81\n\
+!         WEB: http://www.senga.org/\n\
+!         Mail: senga@senga.org\n\
+!       \n\
+!     \n\
+!   \n\
+!   \n\
+!      \n\
+!     \n\
+!       \n\
+! \n\
+! [\n\
+! Catalog |\n\
+! webbase |\n\
+! mifluz |\n\
+! unac |\n\
+! Search-Mifluz |\n\
+! Text-Query |\n\
+! uri |\n\
+! Statistics |\n\
+! News\n\
+! ]\n\
+! \n\
+! \n\
+!     \n\
+!   \n\
+! \n\
+! \n\
+! \n\
+  ";
+  
+  int main() {

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -1,10 +1,14 @@
-{ fetchurl, stdenv, python }:
+{ fetchhg, stdenv, python, autoconf, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45 }:
 
 stdenv.mkDerivation rec {
-  name = "asciidoc-8.6.6";
-  src = fetchurl {
-    url = "mirror://sourceforge/asciidoc/${name}.tar.gz";
-    sha256 = "9d54c11716e4309ff4d942cf6a6d9745d6a28754ff1de01efed0dc659457ac71";
+  ver = "8.6.7";
+  name = "asciidoc-${ver}";
+
+  src = fetchhg {
+    name = "hg";
+    url = https://asciidoc.googlecode.com/;
+    tag = "${ver}";
+    sha256 = "1m0zd9b4qjnhpnhfcn4p3n2ffi1bl39lzh52li0fzxl3xqxqvfq2";
   };
 
   patchPhase = ''
@@ -15,9 +19,12 @@ stdenv.mkDerivation rec {
     sed -i -e "s,/etc/vim,,g" Makefile.in
   '';
 
+  preConfigure = ''autoconf'';
+
   preInstall = "mkdir -p $out/etc/vim";
 
-  buildInputs = [ python ];
+  buildInputs = [ python autoconf ];
+  propagatedBuildInputs = [ libxml2 libxslt docbook_xsl docbook_xml_dtd_45]; 
 
   meta = {
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1642,6 +1642,8 @@ let
 
   ttmkfdir = callPackage ../tools/misc/ttmkfdir { };
 
+  unac = callPackage ../development/libraries/unac { };
+
   unclutter = callPackage ../tools/misc/unclutter { };
 
   unbound = callPackage ../tools/networking/unbound { };
@@ -6990,6 +6992,8 @@ let
   firefox16Wrapper = lowPrio (wrapFirefox { browser = firefox16Pkgs.firefox; });
 
   flac = callPackage ../applications/audio/flac { };
+
+  flactag = callPackage ../applications/audio/flactag { };
 
   flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer-11 {
     debug = config.flashplayer.debug or false;


### PR DESCRIPTION
Flactag is a utility for keeping audio cd image metadata upto date. 

Add new dependent library 'unac'

Update libmusicbrainz to 5.0.1. 

Update asciidoc to 8.6.7, and add dependencies on the docbook xml catalog and the docbook xsl package, so that asciidoc can generate docbook (and derivatives). 
