### PR TITLE
Put eclipse icon into share/pixmaps

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -50,7 +50,7 @@ let
         mkdir -p $out/share/applications
         cp ${desktopItem}/share/applications/* $out/share/applications
         mkdir -p $out/share/pixmaps
-        cp $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
+        ln -s $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
       ''; # */
 
       meta = {

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -49,6 +49,8 @@ let
         # Create desktop item.
         mkdir -p $out/share/applications
         cp ${desktopItem}/share/applications/* $out/share/applications
+        mkdir -p $out/share/pixmaps
+        cp $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
       ''; # */
 
       meta = {


### PR DESCRIPTION
Put the eclipse icon into $out/share/pixmaps. Now the menu shows eclispse icon correctly.
