### PR TITLE
vtk: latest version + useQt4 option

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,18 +1,32 @@
-{stdenv, fetchurl, cmake, mesa, libX11, xproto, libXt }:
+{ stdenv, fetchurl, cmake, mesa, libX11, xproto, libXt
+, useQt4 ? false, qt4 }:
+
+with stdenv.lib;
+
+let
+  os = stdenv.lib.optionalString;
+  majorVersion = "5.10";
+  minorVersion = "0";
+  version = "${majorVersion}.${minorVersion}";
+in
 
 stdenv.mkDerivation rec {
-  name = "vtk-5.4.2";
+  name = "vtk-${os useQt4 "qvtk-"}${version}";
   src = fetchurl {
-    url = "http://www.vtk.org/files/release/5.4/${name}.tar.gz";
-    sha256 = "0gd7xlxiqww6xxcs2kicz0g6k147y3200np4jnsf10vlxs10az03";
+    url = "${meta.homepage}files/release/${majorVersion}/vtk-${version}.tar.gz";
+    md5 = "a0363f78910f466ba8f1bd5ab5437cb9";
   };
-  buildInputs = [ cmake mesa libX11 xproto libXt ];
+  buildInputs = [ cmake mesa libX11 xproto libXt ]
+    ++ optional useQt4 qt4;
+
+  cmakeFlags = optional useQt4
+    [ "-DVTK_USE_QT:BOOL=ON" ];
 
   meta = {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
     homepage = http://www.vtk.org/;
     license = "BSD";
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric bbenoist ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4967,6 +4967,8 @@ let
 
   vtk = callPackage ../development/libraries/vtk { };
 
+  vtkWithQt4 = vtk.override { useQt4 = true; };
+
   vxl = callPackage ../development/libraries/vxl {
     libpng = libpng12;
   };


### PR DESCRIPTION
- Updated vtk to v5.10.0 (latest tagged release)
- Introduced a useQt4 option which allows to set the VTK_USE_QT option to true
- Added a package named vtkWithQt4 in the all-packages list
