### PR TITLE
qt: fix update to 4.8.3

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  v = "4.8.2";
+  v = "4.8.3";
 in
 
 # TODO:
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-${v}.tar.gz";
-    sha256 = "0y93vkkn44md37gyg4y8sc9ylk27xkniaimfcpdcwd090qnjl6wj";
+    md5 = "a663b6c875f8d7caa8ac9c30e4a4ec3b";
   };
 
   patches = [ ( substituteAll {
@@ -142,10 +142,10 @@ stdenv.mkDerivation rec {
   } else {});
 
   meta = with stdenv.lib; {
-    homepage = http://qt.nokia.com/products;
+    homepage = http://qt-project.org/;
     description = "A cross-platform application framework for C++";
     license = "GPL/LGPL";
-    maintainers = with maintainers; [ urkud sander ];
+    maintainers = with maintainers; [ urkud sander bbenoist ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/qt-4.x/4.8/dlopen-absolute-paths.diff
+++ b/pkgs/development/libraries/qt-4.x/4.8/dlopen-absolute-paths.diff
@@ -1,6 +1,30 @@
---- a/src/gui/painting/qcups.cpp	2011-12-08 09:06:02.000000000 +0400
-+++ b/src/gui/painting/qcups.cpp	2011-12-18 12:17:07.000000000 +0400
-@@ -87,7 +87,7 @@
+diff --git a/src/corelib/tools/qlocale_icu.cpp b/src/corelib/tools/qlocale_icu.cpp
+index e8c3fb8..e554e53 100644
+--- a/src/corelib/tools/qlocale_icu.cpp
++++ b/src/corelib/tools/qlocale_icu.cpp
+@@ -81,7 +81,7 @@ bool qt_initIcu(const QString &localeString)
+     if (status == NotLoaded) {
+ 
+         // resolve libicui18n
+-        QLibrary lib(QLatin1String("icui18n"), QLatin1String(U_ICU_VERSION_SHORT));
++        QLibrary lib(QLatin1String("@icu@/lib/libicui18n"), QLatin1String(U_ICU_VERSION_SHORT));
+         lib.setLoadHints(QLibrary::ImprovedSearchHeuristics);
+         if (!lib.load()) {
+             qWarning() << "Unable to load library icui18n" << lib.errorString();
+@@ -111,7 +111,7 @@ bool qt_initIcu(const QString &localeString)
+         }
+ 
+         // resolve libicuuc
+-        QLibrary ucLib(QLatin1String("icuuc"), QLatin1String(U_ICU_VERSION_SHORT));
++        QLibrary ucLib(QLatin1String("@icu@/lib/libicuuc"), QLatin1String(U_ICU_VERSION_SHORT));
+         ucLib.setLoadHints(QLibrary::ImprovedSearchHeuristics);
+         if (!ucLib.load()) {
+             qWarning() << "Unable to load library icuuc" << ucLib.errorString();
+diff --git a/src/gui/painting/qcups.cpp b/src/gui/painting/qcups.cpp
+index 2d45175..31158b3 100644
+--- a/src/gui/painting/qcups.cpp
++++ b/src/gui/painting/qcups.cpp
+@@ -87,7 +87,7 @@ static CupsPrintFile _cupsPrintFile = 0;
  
  static void resolveCups()
  {
@@ -9,9 +33,11 @@
      if(cupsLib.load()) {
          _cupsGetDests = (CupsGetDests) cupsLib.resolve("cupsGetDests");
          _cupsFreeDests = (CupsFreeDests) cupsLib.resolve("cupsFreeDests");
---- a/src/gui/painting/qprinterinfo_unix.cpp	2011-12-08 09:06:02.000000000 +0400
-+++ b/src/gui/painting/qprinterinfo_unix.cpp	2011-12-23 16:22:15.000000000 +0400
-@@ -454,7 +454,7 @@
+diff --git a/src/gui/painting/qprinterinfo_unix.cpp b/src/gui/painting/qprinterinfo_unix.cpp
+index 48a3d8b..8220ee5 100644
+--- a/src/gui/painting/qprinterinfo_unix.cpp
++++ b/src/gui/painting/qprinterinfo_unix.cpp
+@@ -454,7 +454,7 @@ int qt_retrieveNisPrinters(QList<QPrinterDescription> *printers)
      char *domain;
      int err;
  
@@ -20,40 +46,24 @@
      typedef int (*ypGetDefaultDomain)(char **);
      ypGetDefaultDomain _ypGetDefaultDomain = (ypGetDefaultDomain)lib.resolve("yp_get_default_domain");
      typedef int (*ypAll)(const char *, const char *, const struct ypall_callback *);
---- a/src/network/kernel/qhostinfo_unix.cpp	2011-12-23 16:26:07.000000000 +0400
-+++ b/src/network/kernel/qhostinfo_unix.cpp	2011-12-23 16:25:55.000000000 +0400
-@@ -95,7 +95,7 @@
+diff --git a/src/network/kernel/qhostinfo_unix.cpp b/src/network/kernel/qhostinfo_unix.cpp
+index d36d98b..24b41bb 100644
+--- a/src/network/kernel/qhostinfo_unix.cpp
++++ b/src/network/kernel/qhostinfo_unix.cpp
+@@ -95,7 +95,7 @@ static res_state_ptr local_res = 0;
  static void resolveLibrary()
  {
  #ifndef QT_NO_LIBRARY
 -    QLibrary lib(QLatin1String("resolv"));
 +    QLibrary lib(QLatin1String("@glibc@/lib/libresolv"));
+     lib.setLoadHints(QLibrary::ImprovedSearchHeuristics);
      if (!lib.load())
          return;
- 
---- a/src/corelib/tools/qlocale_icu.cpp	2011-12-08 09:06:03.000000000 +0400
-+++ b/src/corelib/tools/qlocale_icu.cpp	2011-12-23 16:29:15.000000000 +0400
-@@ -81,7 +81,7 @@
-     if (status == NotLoaded) {
- 
-         // resolve libicui18n
--        QLibrary lib(QLatin1String("icui18n"), QLatin1String(U_ICU_VERSION_SHORT));
-+        QLibrary lib(QLatin1String("@icu@/lib/libicui18n"), QLatin1String(U_ICU_VERSION_SHORT));
-         if (!lib.load()) {
-             qWarning() << "Unable to load library icui18n" << lib.errorString();
-             status = ErrorLoading;
-@@ -110,7 +110,7 @@
-         }
- 
-         // resolve libicuuc
--        QLibrary ucLib(QLatin1String("icuuc"), QLatin1String(U_ICU_VERSION_SHORT));
-+        QLibrary ucLib(QLatin1String("@icu@/lib/libicuuc"), QLatin1String(U_ICU_VERSION_SHORT));
-         if (!ucLib.load()) {
-             qWarning() << "Unable to load library icuuc" << ucLib.errorString();
-             status = ErrorLoading;
---- a/src/plugins/platforms/xlib/qxlibstatic.cpp	2011-12-08 09:06:02.000000000 +0400
-+++ b/src/plugins/platforms/xlib/qxlibstatic.cpp	2011-12-23 20:38:49.000000000 +0400
-@@ -242,7 +242,7 @@
+diff --git a/src/plugins/platforms/xlib/qxlibstatic.cpp b/src/plugins/platforms/xlib/qxlibstatic.cpp
+index 784f56b..ead9732 100644
+--- a/src/plugins/platforms/xlib/qxlibstatic.cpp
++++ b/src/plugins/platforms/xlib/qxlibstatic.cpp
+@@ -242,7 +242,7 @@ static void* qt_load_library_runtime(const char *library, int vernum,
  }
  
  #  define XFIXES_LOAD_RUNTIME(vernum, symbol, symbol_type) \

--- a/pkgs/development/libraries/qt-4.x/4.8/dlopen-gtkstyle.diff
+++ b/pkgs/development/libraries/qt-4.x/4.8/dlopen-gtkstyle.diff
@@ -1,15 +1,17 @@
---- a/src/gui/styles/qgtkstyle_p.cpp	2011-12-08 09:06:02.000000000 +0400
-+++ b/src/gui/styles/qgtkstyle_p.cpp	2011-12-24 17:56:46.000000000 +0400
-@@ -312,7 +312,7 @@
+diff --git a/src/gui/styles/qgtkstyle_p.cpp b/src/gui/styles/qgtkstyle_p.cpp
+index 3b128e6..39434db 100644
+--- a/src/gui/styles/qgtkstyle_p.cpp
++++ b/src/gui/styles/qgtkstyle_p.cpp
+@@ -312,7 +312,7 @@ GtkStyle* QGtkStylePrivate::gtkStyle(const QHashableLatin1Literal &path)
  void QGtkStylePrivate::resolveGtk() const
  {
      // enforce the "0" suffix, so we'll open libgtk-x11-2.0.so.0
 -    QLibrary libgtk(QLS("gtk-x11-2.0"), 0, 0);
 +    QLibrary libgtk(QLS("@gtk@/lib/libgtk-x11-2.0"), 0, 0);
+     libgtk.setLoadHints(QLibrary::ImprovedSearchHeuristics);
  
      gtk_init = (Ptr_gtk_init)libgtk.resolve("gtk_init");
-     gtk_window_new = (Ptr_gtk_window_new)libgtk.resolve("gtk_window_new");
-@@ -434,8 +434,8 @@
+@@ -435,8 +435,8 @@ void QGtkStylePrivate::resolveGtk() const
      pango_font_description_get_family = (Ptr_pango_font_description_get_family)libgtk.resolve("pango_font_description_get_family");
      pango_font_description_get_style = (Ptr_pango_font_description_get_style)libgtk.resolve("pango_font_description_get_style");
  
@@ -20,7 +22,7 @@
  }
  
  /* \internal
-@@ -607,9 +607,9 @@
+@@ -608,9 +608,9 @@ void QGtkStylePrivate::cleanupGtkWidgets()
  static bool resolveGConf()
  {
      if (!QGtkStylePrivate::gconf_client_get_default) {


### PR DESCRIPTION
It appeared that Eelco DOSTRA already made an update for it.
Unfortunately, his update was not complete as the dlopen-gtkstyle patch didn't worked anymore.
This ommission can be explained by the fact there is (apparently) no usage of the gtkstyle qt option in nixpkgs.
Also, and because Nokia abandonned Qt, I changed the homepage to match the new url of Qt's open side (qt.digia.com is only for the commercial one).

First qt: update to 4.8.3 commit (already merged to master) : https://github.com/NixOS/nixpkgs/commit/bf1b2e9c2ec368b04328c298db546f547de0c582
