### PR TITLE
for eclipse use older cairo.

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,11 +1,22 @@
 { stdenv, fetchurl, patchelf, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
 , glib, gtk, libXtst, jre
+, pkgs, applyGlobalOverrides
 }:
 
 assert stdenv ? glibc;
 
 let
+
+  olderCairoSource = rec {
+    name = "cairo-1.12.2";
+    src = fetchurl {
+      url = "http://cairographics.org/releases/${name}.tar.xz";
+      sha1 = "bc2ee50690575f16dab33af42a2e6cdc6451e3f9";
+    };
+  };
+  p = applyGlobalOverrides (pkgs: { cairo = pkgs.lib.overrideDerivation pkgs.cairo (x: olderCairoSource); } );
+  inherit (p) glib gtk; # only these seem to depend on cairo
 
   buildEclipse =
     { name, src, description }:

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -15,6 +15,7 @@ assert xcbSupport -> libxcb != null && xcbutil != null;
 stdenv.mkDerivation rec {
   name = "cairo-1.12.4";
 
+  # when updating check Eclipse, maybe the older version there can be removed then
   src = fetchurl {
     url = "http://cairographics.org/releases/${name}.tar.xz";
     sha1 = "f4158981ed01e73c94fb8072074b17feee61a68b";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6713,7 +6713,9 @@ let
 
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
-  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { });
+  eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse {
+    inherit applyGlobalOverrides;
+  });
 
   ed = callPackage ../applications/editors/ed { };
 


### PR DESCRIPTION
With newer cairo Eclipse crashes after selecting a workspace
