### PR TITLE
Rolled back xf86-video-ati to 6.14.4.

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1438,11 +1438,11 @@ let
   })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
     
   xf86videoati = (stdenv.mkDerivation ((if overrides ? xf86videoati then overrides.xf86videoati else x: x) {
-    name = "xf86-video-ati-6.14.6";
+    name = "xf86-video-ati-6.14.4";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-video-ati-6.14.6.tar.bz2;
-      sha256 = "0dpcdgw7vmx53l3byp900na5s980v1nw11a7y5yps67hwjrqclma";
+      url = mirror://xorg/individual/driver/xf86-video-ati-6.14.4.tar.bz2;
+      sha256 = "11gg6xn65vym75769hzgzpkjsyhlkrw4zw3ncngriq7vz1g47zjg";
     };
     buildInputs = [pkgconfig fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
   })) // {inherit fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -124,7 +124,7 @@ mirror://xorg/individual/driver/xf86-input-vmmouse-12.9.0.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-input-void-1.4.0.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-video-ark-0.7.4.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-video-ast-0.93.10.tar.bz2
-mirror://xorg/individual/driver/xf86-video-ati-6.14.6.tar.bz2
+mirror://xorg/individual/driver/xf86-video-ati-6.14.4.tar.bz2
 mirror://xorg/individual/driver/xf86-video-cirrus-1.5.1.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-video-dummy-0.3.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-fbdev-0.4.3.tar.bz2


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/163 .

6.14.6 requires a newer version of libdrm, which in turn requires a newer
version of mesa.  I cheated and edited the generated default.nix file instead of
re-generating it, since generate-expr-from-tarballs.pl complained of a collision
between two tarballs providing different versions of xorg-server.
