### PR TITLE
new cabal packages

### DIFF
--- a/pkgs/development/libraries/haskell/optparse-applicative/default.nix
+++ b/pkgs/development/libraries/haskell/optparse-applicative/default.nix
@@ -1,0 +1,14 @@
+{ cabal, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "optparse-applicative";
+  version = "0.4.1";
+  sha256 = "00byv248662n6pr8gn5b777l0fjg6f0wcxfkbhw0qyhd1ciq8d38";
+  buildDepends = [ transformers ];
+  meta = {
+    homepage = "https://github.com/pcapriotti/optparse-applicative";
+    description = "Utilities and combinators for parsing command line options";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/test-framework-th-prime/default.nix
+++ b/pkgs/development/libraries/haskell/test-framework-th-prime/default.nix
@@ -1,0 +1,13 @@
+{ cabal, cpphs, haskellSrcExts, testFramework }:
+
+cabal.mkDerivation (self: {
+  pname = "test-framework-th-prime";
+  version = "0.0.5";
+  sha256 = "0lsxnbckh88cq38azml86szdcvx3rhs3is13ib4z0ryfqnv4hhpl";
+  buildDepends = [ cpphs haskellSrcExts testFramework ];
+  meta = {
+    description = "Template Haskell for test framework";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1570,6 +1570,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   testFrameworkTh = callPackage ../development/libraries/haskell/test-framework-th {};
 
+  testFrameworkThPrime = callPackage ../development/libraries/haskell/test-framework-th-prime {};
+
   testpack = callPackage ../development/libraries/haskell/testpack {};
 
   texmath = callPackage ../development/libraries/haskell/texmath {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1243,6 +1243,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   OpenGLRaw = callPackage ../development/libraries/haskell/OpenGLRaw {};
 
+  optparse_applicative = callPackage ../development/libraries/haskell/optparse-applicative {};
+
   pathPieces = callPackage ../development/libraries/haskell/path-pieces {};
 
   pandoc = callPackage ../development/libraries/haskell/pandoc {};


### PR DESCRIPTION
Added optparse-applicative and its test dependency test-framework-th-prime.
