### PR TITLE
Pure Python Proposal: add --no-deps to builder and set allow-hosts=None

### DIFF
--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -74,6 +74,7 @@ let
     postInstall =
       ''
         rm -rf "$out/lib/python${majorVersion}/test"
+        cp ${./distutils.cfg} "$out/lib/python${majorVersion}/distutils/distutils.cfg"
       '';
 
     passthru = {

--- a/pkgs/development/interpreters/python/2.7/distutils.cfg
+++ b/pkgs/development/interpreters/python/2.7/distutils.cfg
@@ -1,0 +1,2 @@
+[easy_install]
+allow_hosts = None

--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -19,7 +19,7 @@
 
 , installCommand ?
     ''
-      easy_install --prefix="$out" .
+      easy_install --no-deps --prefix="$out" . 
     ''
     
 , buildPhase ? "true"

--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -19,7 +19,7 @@
 
 , installCommand ?
     ''
-      easy_install --no-deps --prefix="$out" . 
+      easy_install --no-deps --always-unzip --prefix="$out" . 
     ''
     
 , buildPhase ? "true"
@@ -47,8 +47,6 @@ python.stdenv.mkDerivation (attrs // {
 
   pythonPath = [ setuptools] ++ pythonPath;
 
-  # XXX: Should we run `easy_install --always-unzip'?  It doesn't seem
-  # to have a noticeable impact on small scripts.
   installPhase = ''
     mkdir -p "$out/lib/${python.libPrefix}/site-packages"
 


### PR DESCRIPTION
Currently the default python builder calls easy_install, which will download the dependencies for the package on the fly. This is impure. Also @garbas mentioned that this makes it impossible to deal with circular dependencies e.g. Zope2 and Products.StandardCacheManagers.

Adding --no-deps to the easy_install command stops it from trying to resolve dependencies. The package will be installed on its own. Dependencies will need to be explicitly specified in the nix expression for it to work correctly (this will break loads of the python packages currently in nixpkgs).

Setting "allow_hosts = None" has a similar effect except that the package will fail to install with an error which shows the missing dependency. This does not help in cases where there are circular dependencies.

Neither of these settings should have any effect on python developers who use virtualenv to install packages outside of nixpkgs for development.
