### PR TITLE
Python rsvg pull request (was #115)

### DIFF
--- a/pkgs/applications/video/key-mon/default.nix
+++ b/pkgs/applications/video/key-mon/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, buildPythonPackage, gnome, librsvg, makeWrapper, pygtk
+, pythonPackages }:
+
+buildPythonPackage rec {
+  name = "key-mon-${version}";
+  version = "1.13";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "http://key-mon.googlecode.com/files/${name}.tar.gz";
+    sha256 = "02h7lcnyqwyqsycd1vlvl11ms81v0zmr9p0pfyl5gmzry9dj7imj";
+  };
+
+  propagatedBuildInputs =
+    [ gnome.python_rsvg librsvg makeWrapper pygtk pythonPackages.xlib ];
+
+  doCheck = false;
+
+  postInstall = ''
+      wrapProgram $out/bin/key-mon --prefix GDK_PIXBUF_MODULE_FILE : \
+      ${librsvg}/lib/gdk-pixbuf/loaders.cache
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://code.google.com/p/key-mon;
+    description = "Utility to show live keyboard and mouse status for teaching and screencasts";
+    license = licenses.asl20;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/desktops/gnome-2/bindings/gnome-python/default.nix
+++ b/pkgs/desktops/gnome-2/bindings/gnome-python/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
 
   # WAF is probably the biggest crap on this planet, btw i removed the /gtk-2.0 path thingy
   configurePhase = ''
-    sed -e "s@{PYTHONDIR}/gtk-2.0@{PYTHONDIR}/@" -i gconf/wscript 
-    python waf configure --prefix=$out 
+    sed -e "s@{PYTHONDIR}/gtk-2.0@{PYTHONDIR}/@" -i gconf/wscript
+    python waf configure --prefix=$out
   '';
 
   buildPhase = ''
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     python waf install
+    cp bonobo/*.{py,defs} $out/share/pygtk/2.0/defs/
   '';
 
   buildInputs = [ python pkgconfig pygobject pygtk glib gtk GConf libgnome pythonDBus ];

--- a/pkgs/desktops/gnome-2/bindings/python-rsvg/default.nix
+++ b/pkgs/desktops/gnome-2/bindings/python-rsvg/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, gnome, librsvg, pkgconfig, pygtk, python }:
+
+stdenv.mkDerivation rec {
+  version = "2.32";
+  name = "python-rsvg-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-python-desktop/${version}/gnome-python-desktop-${version}.0.tar.gz";
+    sha256 = "1xhh3h1qdnimydvv55pmqwyzjchhjwfvp951sjlq0180kskqrlj5";
+  };
+
+  configurePhase = ''
+    sed -e "s@{PYTHONDIR}/gtk-2.0@{PYTHONDIR}/@" -i rsvg/wscript 
+    python waf configure --enable-modules=rsvg --prefix=$out 
+  '';
+
+  buildPhase = "python waf build";
+
+  installPhase = "python waf install";
+
+  buildInputs = [ gnome.gnome_python librsvg pkgconfig pygtk python ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.pygtk.org";
+    description = "The rsvg python module";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.goibhniu ];
+  };
+}

--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -58,6 +58,8 @@
 
   libbonoboui = callPackage ./platform/libbonoboui { };
 
+  python_rsvg = callPackage ./bindings/python-rsvg { };
+
   at_spi = callPackage ./platform/at-spi { };
 
   gtkhtml = callPackage ./platform/gtkhtml { };

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -11,6 +11,19 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ glib gtk ];
   buildNativeInputs = [ pkgconfig ];
 
-  # It tries to install the loader to $gdk_pixbuf
-  configureFlags = "--disable-pixbuf-loader";
+  # It wants to add loaders and update the loaders.cache in gdk-pixbuf
+  # Patching the Makefiles to it creates rsvg specific loaders and the
+  # relevant loader.cache here.
+  # The loaders.cache can be used by setting GDK_PIXBUF_MODULE_FILE to
+  # point to this file in a wrapper.
+  postConfigure = ''
+    GDK_PIXBUF=$out/lib/gdk-pixbuf
+    mkdir -p $GDK_PIXBUF/loaders
+    sed -e "s#gdk_pixbuf_moduledir = .*#gdk_pixbuf_moduledir = $GDK_PIXBUF/loaders#" \
+        -i gdk-pixbuf-loader/Makefile
+    sed -e "s#gdk_pixbuf_cache_file = .*#gdk_pixbuf_cache_file = $GDK_PIXBUF/loaders.cache#" \
+        -i gdk-pixbuf-loader/Makefile
+    sed -e "s#\$(GDK_PIXBUF_QUERYLOADERS)#GDK_PIXBUF_MODULEDIR=$GDK_PIXBUF/loaders \$(GDK_PIXBUF_QUERYLOADERS)#" \
+         -i gdk-pixbuf-loader/Makefile
+  '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7295,6 +7295,8 @@ let
 
   kermit = callPackage ../tools/misc/kermit { };
 
+  keymon = callPackage ../applications/video/key-mon { };
+
   kino = callPackage ../applications/video/kino {
     inherit (gnome) libglade;
   };


### PR DESCRIPTION
Add python-rsvg and key-mon, which uses python-rsvg.

See the discussion "Python bindings to librsvg or gnome-desktop" on the mailing list and #115 for further details.

This only adds functionality so it shouldn't break anything, it will however cause a lot of rebuilding and I haven't tested that everything will be rebuilt successfully.
