### PR TITLE
Ocaml findlib add topfind

### DIFF
--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation {
 
   buildInputs = [m4 ncurses ocaml];
 
-  patches = [ ./ldconf.patch ];
+  patches = [ ./ldconf.patch ./install_topfind.patch ];
+  patchFlags = "-p0";
 
   dontAddPrefix=true;
 
@@ -24,7 +25,6 @@ stdenv.mkDerivation {
       -mandir $out/share/man
       -sitelib $out/lib/ocaml/${ocaml_version}/site-lib
       -config $out/etc/findlib.conf
-      -no-topfind
     )
   '';
 

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation {
   buildInputs = [m4 ncurses ocaml];
 
   patches = [ ./ldconf.patch ./install_topfind.patch ];
-  patchFlags = "-p0";
 
   dontAddPrefix=true;
 

--- a/pkgs/development/tools/ocaml/findlib/install_topfind.patch
+++ b/pkgs/development/tools/ocaml/findlib/install_topfind.patch
@@ -1,5 +1,5 @@
---- src/findlib/Makefile
-+++ src/findlib/Makefile
+--- findlib-1.3.3/src/findlib/Makefile
++++ findlib-1.3.3/src/findlib/Makefile
 @@ -82,7 +82,7 @@ clean:
  install: all
  	mkdir -p "$(prefix)$(OCAML_SITELIB)/$(NAME)"

--- a/pkgs/development/tools/ocaml/findlib/install_topfind.patch
+++ b/pkgs/development/tools/ocaml/findlib/install_topfind.patch
@@ -1,0 +1,12 @@
+--- src/findlib/Makefile
++++ src/findlib/Makefile
+@@ -82,7 +82,7 @@ clean:
+ install: all
+ 	mkdir -p "$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	mkdir -p "$(prefix)$(OCAMLFIND_BIN)"
+-	test $(INSTALL_TOPFIND) -eq 0 || cp topfind "$(prefix)$(OCAML_CORE_STDLIB)"
++	test $(INSTALL_TOPFIND) -eq 0 || cp topfind "$(prefix)$(OCAML_SITELIB)"
+ 	files=`$(TOP)/tools/collect_files $(TOP)/Makefile.config findlib.cmi findlib.mli findlib.cma topfind.cmi topfind.mli fl_package_base.mli fl_package_base.cmi fl_metascanner.mli fl_metascanner.cmi fl_metatoken.cmi findlib_top.cma findlib.cmxa findlib.a META` && \
+ 	cp $$files "$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	f="ocamlfind$(EXEC_SUFFIX)"; { test -f ocamlfind_opt$(EXEC_SUFFIX) && f="ocamlfind_opt$(EXEC_SUFFIX)"; }; \
+


### PR DESCRIPTION
This has a patch to install the "topfind" script to the findlib dir, so that findlib can be used from the Ocaml REPL, which makes the user experience much better.  In order to use it one has to use -I </path/to/topfind> when starting ocaml, and add any paths to things they want findlib to locate to OCAMLPATH.
