### PR TITLE
Fix xf86-video-sis

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -158,6 +158,7 @@ in
   };
 
   xf86videosis = attrs: attrs // {
+    NIX_CFLAGS_COMPILE = "-I${xorg.pixman}/include/pixman-1";
     buildInputs = attrs.buildInputs ++ [xorg.glproto args.mesa];
   };
 


### PR DESCRIPTION
This is a fix of the xf86-video-sis package as suggested by viric in issue #188.
