### PR TITLE
Fix cabalInstall_1_16_0_2 (wrong Cabal version)

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1965,7 +1965,9 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
   cabalInstall_0_8_2  = callPackage ../tools/package-management/cabal-install/0.8.2.nix  {};
   cabalInstall_0_10_2 = callPackage ../tools/package-management/cabal-install/0.10.2.nix {};
   cabalInstall_0_14_0 = callPackage ../tools/package-management/cabal-install/0.14.0.nix {};
-  cabalInstall_1_16_0_2 = callPackage ../tools/package-management/cabal-install/1.16.0.2.nix {};
+  cabalInstall_1_16_0_2 = callPackage ../tools/package-management/cabal-install/1.16.0.2.nix {
+    Cabal = self.Cabal_1_16_0_3;
+  };
   cabalInstall = self.cabalInstall_1_16_0_2;
 
   jailbreakCabal = callPackage ../development/tools/haskell/jailbreak-cabal {};


### PR DESCRIPTION
This is necessary on my machine to build the most recent version of cabal-install.
