### PR TITLE
Despotify

### DIFF
--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -1,38 +1,28 @@
-{
-  fetchurl, stdenv, dpkg, xlibs, qt4, alsaLib, makeWrapper, openssl, glib,
-  freetype, gdk_pixbuf, gtk, cairo, pango, atk, nss
-}:
+{ fetchurl, stdenv, dpkg, xlibs, qt4, alsaLib, makeWrapper, openssl }:
 
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
 
-let version = "0.8.4.103";
-    
-    revision = "g9cb177b.260-1";
+let version = "0.8.3.278"; in
 
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   name = "spotify-${version}";
 
   src =
     if stdenv.system == "i686-linux" then 
       fetchurl {
-        url = "http://repository.spotify.com/pool/non-free/s/spotify/spotify-client_${version}.${revision}_i386.deb";
-        sha256 = "1iri6pgavgb06nx0l3myqryx7zd7cf22my8vh2v6w4kbvaajjl31";
+        url = "http://repository.spotify.com/pool/non-free/s/spotify/spotify-client_${version}.g21c7566.632-1_i386.deb";
+        sha256 = "7f587585365498c5182bd7f3beafaf511d883102f5cece66cf84f4f94077765b";
       }
     else if stdenv.system == "x86_64-linux" then 
       fetchurl {
-        url = "http://repository.spotify.com/pool/non-free/s/spotify/spotify-client_${version}.${revision}_amd64.deb";
-        sha256 = "0y5kyfa1gk16d9z67hgssam8hgzw6g5f7xsxk0lz3ak487xdwl6k";
+        url = "http://repository.spotify.com/pool/non-free/s/spotify/spotify-client_${version}.g21c7566.632-1_amd64.deb";
+        sha256 = "a37a13b1c1a8088a811054c732d85b9d6ccf0bd92ad4da75bfee6d70dc344b5e";
       }
     else throw "Spotify not supported on this platform.";
 
   buildInputs = [ dpkg makeWrapper ];
 
   unpackPhase = "true";
-
-  libraryPath = stdenv.lib.makeLibraryPath [
-    alsaLib freetype glib gdk_pixbuf gtk openssl qt4 stdenv.gcc.gcc
-    xlibs.libX11 xlibs.libXScrnSaver cairo pango atk nss
-  ];
   
   installPhase =
     ''
@@ -46,11 +36,10 @@ in stdenv.mkDerivation {
       mkdir $out/lib
       ln -s ${openssl}/lib/libssl.so $out/lib/libssl.so.0.9.8
       ln -s ${openssl}/lib/libcrypto.so $out/lib/libcrypto.so.0.9.8
-      ln -s ${nss}/lib/libnss3.so $out/lib/libnss3.so.1d
 
       patchelf \
         --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-        --set-rpath $out/lib:$libraryPath:${stdenv.gcc.gcc}/lib64:$out/share/spotify \
+        --set-rpath ${stdenv.lib.makeLibraryPath [ xlibs.libXScrnSaver xlibs.libX11 qt4 alsaLib openssl stdenv.gcc.gcc ]}:${stdenv.gcc.gcc}/lib64:$out/lib \
         $out/bin/spotify
 
       preload=$out/libexec/spotify/libpreload.so

--- a/pkgs/development/libraries/despotify/default.nix
+++ b/pkgs/development/libraries/despotify/default.nix
@@ -1,0 +1,27 @@
+{
+  stdenv, fetchsvn, openssl, zlib, libvorbis, pulseaudio, gstreamer, libao,
+  libtool, ncurses, glibc
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "despotify";
+
+  src = fetchsvn {
+    url = "https://despotify.svn.sourceforge.net/svnroot/despotify";
+    rev = "521";
+  };
+
+  buildInputs = [
+    openssl zlib libvorbis pulseaudio gstreamer libao libtool ncurses glibc
+  ];
+
+  configurePhase = "cd src";
+
+  installPhase = "make LDCONFIG=true INSTALL_PREFIX=$out install";
+
+  meta = {
+    homepage = "despotify.se";
+  };
+
+}

--- a/pkgs/development/libraries/despotify/default.nix
+++ b/pkgs/development/libraries/despotify/default.nix
@@ -21,7 +21,14 @@ stdenv.mkDerivation rec {
   installPhase = "make LDCONFIG=true INSTALL_PREFIX=$out install";
 
   meta = {
-    homepage = "despotify.se";
+    description = "Open source Spotify client and library";
+    longDescription = ''
+      despotify is a open source implementation of the Spotify API.  This
+      package provides both a library and a few already quite useful,
+      proof-of-concept clients.
+    '';
+    homepage = "http://despotify.se";
+    license = stdenv.lib.licenses.bsd2;
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -614,6 +614,8 @@ let
 
   desktop_file_utils = callPackage ../tools/misc/desktop-file-utils { };
 
+  despotify = callPackage ../development/libraries/despotify { };
+
   dev86 = callPackage ../development/compilers/dev86 {
     /* Using GNU Make 3.82 leads to this:
          make[4]: *** No rule to make target `__ldivmod.o)'


### PR DESCRIPTION
This adds the despotify library along with some proof-of-concept clients which are already quite useful. A Spotify premium account is necessary for using the clients, but the library and program is open source.
