### PR TITLE
Add despotify

### DIFF
--- a/pkgs/development/libraries/despotify/default.nix
+++ b/pkgs/development/libraries/despotify/default.nix
@@ -1,0 +1,34 @@
+{
+  stdenv, fetchsvn, openssl, zlib, libvorbis, pulseaudio, gstreamer, libao,
+  libtool, ncurses, glibc
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "despotify";
+
+  src = fetchsvn {
+    url = "https://despotify.svn.sourceforge.net/svnroot/despotify";
+    rev = "521";
+  };
+
+  buildInputs = [
+    openssl zlib libvorbis pulseaudio gstreamer libao libtool ncurses glibc
+  ];
+
+  configurePhase = "cd src";
+
+  installPhase = "make LDCONFIG=true INSTALL_PREFIX=$out install";
+
+  meta = {
+    description = "Open source Spotify client and library";
+    longDescription = ''
+      despotify is a open source implementation of the Spotify API.  This
+      package provides both a library and a few already quite useful,
+      proof-of-concept clients.
+    '';
+    homepage = "http://despotify.se";
+    license = stdenv.lib.licenses.bsd2;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -614,6 +614,8 @@ let
 
   desktop_file_utils = callPackage ../tools/misc/desktop-file-utils { };
 
+  despotify = callPackage ../development/libraries/despotify { };
+
   dev86 = callPackage ../development/compilers/dev86 {
     /* Using GNU Make 3.82 leads to this:
          make[4]: *** No rule to make target `__ldivmod.o)'


### PR DESCRIPTION
This adds the despotify library along with some proof-of-concept clients which are already quite useful. A Spotify premium account is necessary for using the clients, but the library and program is open source.
