### PR TITLE
Fixes and updates on qt-4.8, qtcreator, opera, dia and geany

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # This file should normally require a gtk-update-icon-cache -q /usr/share/icons/hicolor command
+  # It have no reasons to exist in a redistribuable package
+  postInstall = "rm $out/share/icons/hicolor/icon-theme.cache";
+
   meta = {
     description = "A GTK2 small and ligthweight IDE.";
     longDescription = ''

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
 
   patches = [ ./glib-top-level-header.patch ];
 
+  # This file should normally require a gtk-update-icon-cache -q /usr/share/icons/hicolor command
+  # It have no reasons to exist in a redistribuable package
+  postInstall = "rm $out/share/icons/hicolor/icon-theme.cache";
+
   meta = {
     description = "Gnome Diagram drawing software";
     homepage = http://live.gnome.org/Dia;

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation rec {
   postFixup = ''
     oldRPATH=`patchelf --print-rpath $out/lib/opera/opera`
     patchelf --set-rpath $oldRPATH:${cups}/lib $out/lib/opera/opera
+
+    # This file should normally require a gtk-update-icon-cache -q /usr/share/icons/hicolor command
+    # It have no reasons to exist in a redistribuable package
+    rm $out/share/icons/hicolor/icon-theme.cache
     '';
 
   meta = {

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -9,6 +9,7 @@
 , buildWebkit ? true
 , flashplayerFix ? false, gdk_pixbuf
 , gtkStyle ? false, libgnomeui, gtk, GConf, gnome_vfs
+, developerBuild ? false
 }:
 
 with stdenv.lib;
@@ -74,6 +75,7 @@ stdenv.mkDerivation rec {
       -nomake demos -nomake examples -nomake docs
 
       -no-phonon ${if buildWebkit then "" else "-no"}-webkit ${if buildMultimedia then "" else "-no"}-multimedia -audio-backend
+      ${if developerBuild then "-developer-build" else ""}
     '';
 
   propagatedBuildInputs =

--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4 }:
+{ stdenv, fetchurl, qt4_for_qtcreator }:
 
 let
   version = "2.6.0";
@@ -12,13 +12,16 @@ stdenv.mkDerivation rec {
     md5 = "9bf01098f84a0fe930b2718d11124204";
   };
 
-  buildInputs = [ qt4 ];
+  buildInputs = [ qt4_for_qtcreator ];
 
   doCheck = false;
 
   enableParallelBuilding = true;
 
-  preConfigure = "qmake";
+  preConfigure = ''
+    qmake -spec linux-g++ "QT_PRIVATE_HEADERS=${qt4_for_qtcreator}/include" qtcreator.pro
+  '';
+
   installFlags = "INSTALL_ROOT=$(out)";
 
   meta = {

--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, qt4 }:
 
 let
-  version = "2.5.2";
+  version = "2.6.0";
 in
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://origin.releases.qt-project.org/qtcreator/${version}/qt-creator-${version}-src.tar.gz";
-    md5 = "4a9c09cdf4609753283c31451c84ceb8";
+    md5 = "9bf01098f84a0fe930b2718d11124204";
   };
 
   buildInputs = [ qt4 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4795,6 +4795,10 @@ let
     gst_plugins_base = null;
   };
 
+  qt4_for_qtcreator = qt48.override {
+    developerBuild = true;
+  };
+
   qtscriptgenerator = callPackage ../development/libraries/qtscriptgenerator { };
 
   quesoglc = callPackage ../development/libraries/quesoglc { };


### PR DESCRIPTION
This pull request contains some fixes for the following packages:
- qt-4.8: I simply added an option allowing to build qt with the -developer-build configure argument.
- qtcreator: I updated it to 2.6.0 and fixed the QmlDesigner plugin build.
- opera, dia and geany: Removed the obsolete $out/share/icons/hicolor/icon-theme.cache file. This file creates collisions between multiple packages when used together.
