### PR TITLE
Create a symbolic link to cups/lib

### DIFF
--- a/pkgs/misc/drivers/gutenprint/bin.nix
+++ b/pkgs/misc/drivers/gutenprint/bin.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation {
       patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
           --set-rpath $libPath $p
     done
+    
+    mkdir $out/lib
+    ln -s $out/cups/lib $out/lib/cups
   '';
 
   meta = {


### PR DESCRIPTION
Thias way pkgs.gutenprintBin can be specified as a driver in services.printing.drivers in /etc/nixos/configuration.nix (and this makes printing to a HP Color Laserjet 5500 work).
