### PR TITLE
Include Python for Vim by default in vim_configureable(pkgs.vimHugX)

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7907,7 +7907,7 @@ let
     inherit (pkgs) python perl tcl ruby /*x11*/;
     lua = pkgs.lua5;
     # optional features by flags
-    flags = [ "X11" ]; # only flag "X11" by now
+    flags = [ "python" "X11" ]; # only flag "X11" by now
   };
 
   virtviewer = callPackage ../applications/virtualization/virt-viewer {};


### PR DESCRIPTION
Python plugin for vim is turned on by default in ubuntu and other flavors of linux and mimicking
this in NixOS will help contribut to the impression that NixOS "just works."
