### PR TITLE
Changing setup.sh so it can load impure things from the fs

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -270,6 +270,10 @@ elif [ "$NIX_BUILD_CORES" -le 0 ]; then
 fi
 export NIX_BUILD_CORES
 
+# Allow impure overrides of environment (distcc, ccache)
+if [ -f /niximpure/impure.sh ]; then
+  . /niximpure/impure.sh
+fi
 
 ######################################################################
 # Misc. helper functions.


### PR DESCRIPTION
The goal of this change is to make setup.sh check /niximpure/impure.sh. That script will be sourced if it exists.

The main use I see of it is that, based on PATH, it can override PATH to include 'distcc' callable gcc/cc/c++/g++. This can make builds easier in slow machines like arm, mips, ... And yet get the same hashes as if they were built without any distcc.

The same can be said about ccache; ccache can be of big help, for example, if builds have to be repeated often. It can belp in big kernel builds, for example, where maybe many objects are repeated from previous builds.

I'm currently using the script in the Raspberry Pi, with a distcc server on a Core2Duo, with nixpkgs-built cross-compilers targeted at the Pi (same versions as the Pi native compilers from bootstrap-tools and next). The impure.sh takes care in choosing the proper distcc based on the compiler version found in PATH.
