### PR TITLE
Allow /niximpure/impure.sh impurity, only for users wanting it

### DIFF
--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -13,6 +13,10 @@ sed -e "s^@initialPath@^$initialPath^g" \
     -e "s^@gcc@^$gcc^g" \
     -e "s^@shell@^$shell^g" \
     < $out/setup > $out/setup.tmp
+if [ -n "$withNixImpure" ]; then
+    sed -i -e 's^@niximpure@^test -f /niximupure/impure.sh && . /niximpure/impure.sh^g' \
+      $out/setup.tmp
+fi
 mv $out/setup.tmp $out/setup
 
 # Allow the user to install stdenv using nix-env and get the packages

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -9,14 +9,16 @@ mkdir $out
 echo "$preHook" > $out/setup
 cat "$setup" >> $out/setup
 
+if [ "$withNixImpure" == 1 ]; then
+    # sed wants \&\& for a &&
+    niximpure='test -f /niximpure/impure.sh \&\& . /niximpure/impure.sh'
+fi
+
 sed -e "s^@initialPath@^$initialPath^g" \
     -e "s^@gcc@^$gcc^g" \
     -e "s^@shell@^$shell^g" \
+    -e "s^@niximpure@^$niximpure^g" \
     < $out/setup > $out/setup.tmp
-if [ -n "$withNixImpure" ]; then
-    sed -i -e 's^@niximpure@^test -f /niximupure/impure.sh && . /niximpure/impure.sh^g' \
-      $out/setup.tmp
-fi
 mv $out/setup.tmp $out/setup
 
 # Allow the user to install stdenv using nix-env and get the packages

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,5 +1,6 @@
 { system, name ? "stdenv", preHook ? "", initialPath, gcc, shell
 , extraAttrs ? {}, overrides ? (pkgs: {})
+, withNixImpure ? false
 
 , # The `fetchurl' to use for downloading curl and its dependencies
   # (see all-packages.nix).
@@ -26,7 +27,7 @@ let
 
         setup = setupScript;
 
-        inherit preHook initialPath gcc shell;
+        inherit preHook initialPath gcc shell withNixImpure;
 
         propagatedUserEnvPkgs = [gcc] ++
           lib.filter lib.isDerivation initialPath;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -270,6 +270,7 @@ elif [ "$NIX_BUILD_CORES" -le 0 ]; then
 fi
 export NIX_BUILD_CORES
 
+@niximpure@
 
 ######################################################################
 # Misc. helper functions.

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -264,7 +264,7 @@ rec {
     inherit system;
     
     preHook = commonPreHook;
-    
+
     initialPath = 
       ((import ../common-path.nix) {pkgs = stdenvLinuxBoot4Pkgs;})
       ++ [stdenvLinuxBoot4Pkgs.patchelf];
@@ -281,6 +281,8 @@ rec {
     shell = stdenvLinuxBoot4Pkgs.bash + "/bin/bash";
     
     fetchurlBoot = fetchurl;
+
+    withNixImpure = if platform ? nixImpure then platform.nixImpure else false;
     
     extraAttrs = {
       inherit (stdenvLinuxBoot3Pkgs) glibc;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -94,6 +94,7 @@ rec {
       initialPath = [bootstrapTools] ++ extraPath;
       fetchurlBoot = fetchurl;
       inherit gcc;
+      withNixImpure = if platform ? nixImpure then platform.nixImpure else false;
       # Having the proper 'platform' in all the stdenvs allows getting proper
       # linuxHeaders for example.
       extraAttrs = extraAttrs // { inherit platform; };


### PR DESCRIPTION
Coming from my previous pull request about this (https://github.com/NixOS/nixpkgs/pull/228), niksnut was against it because it introduces a big source of impurity for everyone.

This new approach makes a 'setup.sh' considering /niximpure/impure.sh only if it has been set in the platform, and the impure derivations coming from that stdenv will all have a different hash compared to the canonical setup.sh.
