### PR TITLE
Update BLCR to version 0.8.5 Beta 3.

### DIFF
--- a/pkgs/os-specific/linux/blcr/default.nix
+++ b/pkgs/os-specific/linux/blcr/default.nix
@@ -1,15 +1,18 @@
 { stdenv, fetchurl, kernel, perl, makeWrapper }:
 
 # BLCR 0.8.4 works for kernel version up to 2.6.38 (including 2.6.38.x)
+# BLCR 0.8.5_beta3 should works for kernel version up to 3.7.1
+
 assert stdenv.isLinux;
-assert builtins.compareVersions "2.6.39" kernel.version == 1;
+#assert builtins.compareVersions "2.6.39" kernel.version == 1;
+assert builtins.compareVersions "3.7.2" kernel.version == 1;
 
 stdenv.mkDerivation {
-  name = "blcr-0.8.4-${kernel.version}";
+  name = "blcr_${kernel.version}-0.8.5pre3";
 
   src = fetchurl {
-    url = https://ftg.lbl.gov/assets/projects/CheckpointRestart/downloads/blcr-0.8.4.tar.gz;
-    sha256 = "d851da66627d9212ac37bc9ea2aba40008ff2dc51d45dbd395ca2e403c3d78cf";
+    url = https://upc-bugs.lbl.gov/blcr-dist/blcr-0.8.5_b3.tar.gz;
+    sha256 = "1xp2k140w79zqbnfnb2q7z91hv15d5a6p39zdc97f9pfxmyyc8fn";
   };
 
   buildInputs = [ perl makeWrapper ];


### PR DESCRIPTION
This version extends support to kernels up to version 3.7.1.
According to the authors, despite the "beta" in the version name, this
version should be considered "stable" on non exotic architecture
(i686 and x86_64).
