### PR TITLE
Add XBMC version 11

### DIFF
--- a/pkgs/applications/video/xbmc/default.nix
+++ b/pkgs/applications/video/xbmc/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, lib, fetchurl, makeWrapper
+, pkgconfig, cmake, gnumake, yasm, python
+, boost
+, gettext, pcre, yajl, fribidi
+, openssl, gperf
+, libX11, xproto, inputproto
+, libXt, libXmu, libXext, xextproto
+, libXinerama, libXrandr, randrproto
+, libXtst, libXfixes, fixesproto
+, SDL, SDL_image, SDL_mixer, alsaLib
+, mesa, glew, fontconfig, freetype, ftgl
+, libjpeg, jasper, libpng, libtiff
+, ffmpeg, libmpeg2, libsamplerate, libmad
+, libogg, libvorbis, flac
+, lzo, libcdio, libmodplug, libass
+, sqlite, mysql
+, curl, bzip2, zip, unzip, glxinfo, xdpyinfo
+, dbus_libs ? null, dbusSupport ? true
+, udev, udevSupport ? true
+, libusb ? null, usbSupport ? false
+, samba ? null, sambaSupport ? true
+# TODO: would be nice to have nfsSupport (needs libnfs library)
+, libvdpau ? null, vdpauSupport ? true
+}:
+
+assert dbusSupport  -> dbus_libs != null;
+assert udevSupport  -> udev != null;
+assert usbSupport   -> libusb != null && ! udevSupport; # libusb won't be used if udev is avaliable
+assert sambaSupport -> samba != null;
+assert vdpauSupport -> libvdpau != null && ffmpeg.vdpauSupport;
+
+stdenv.mkDerivation rec {
+    name = "xbmc-11.0";
+
+    src = fetchurl {
+      url = "http://mirrors.xbmc.org/releases/source/${name}.tar.gz";
+      sha256 = "1fe5d310c16138f26e2b13bc545604e95f48ace6c8636f23e77da402cd7b0b19";
+    };
+
+    buildInputs = [
+      makeWrapper
+      pkgconfig cmake gnumake yasm python
+      boost
+      gettext pcre yajl fribidi
+      openssl gperf
+      libX11 xproto inputproto
+      libXt libXmu libXext xextproto
+      libXinerama libXrandr randrproto
+      libXtst libXfixes fixesproto
+      SDL SDL_image SDL_mixer alsaLib
+      mesa glew fontconfig freetype ftgl
+      libjpeg jasper libpng libtiff
+      ffmpeg libmpeg2 libsamplerate libmad
+      libogg libvorbis flac
+      lzo libcdio libmodplug libass
+      sqlite mysql
+      curl bzip2 zip unzip glxinfo xdpyinfo
+    ]
+    ++ lib.optional dbusSupport dbus_libs
+    ++ lib.optional udevSupport udev
+    ++ lib.optional usbSupport libusb
+    ++ lib.optional sambaSupport samba
+    ++ lib.optional vdpauSupport libvdpau;
+
+    dontUseCmakeConfigure = true;
+
+    configureFlags = [
+      "--enable-external-libraries"
+      "--disable-webserver"
+    ]
+    ++ lib.optional (! sambaSupport) "--disable-samba"
+    ++ lib.optional vdpauSupport "--enable-vdpau";
+
+    postInstall = ''
+      for p in $(ls $out/bin/) ; do
+        wrapProgram $out/bin/$p \
+          --prefix PATH ":" "${python}/bin" \
+          --prefix PATH ":" "${glxinfo}/bin" \
+          --prefix PATH ":" "${xdpyinfo}/bin" \
+          --prefix LD_LIBRARY_PATH ":" "${curl}/lib"
+      done
+    '';
+
+    meta = {
+      homepage = http://xbmc.org/;
+      description = "XBMC Media Center";
+      license = "GPLv2";
+    };
+}

--- a/pkgs/build-support/clang-wrapper/utils.sh
+++ b/pkgs/build-support/clang-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/build-support/gcc-cross-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-cross-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/build-support/gcc-upc-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-upc-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/build-support/gcc-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-wrapper/utils.sh
@@ -17,6 +17,7 @@ badPath() {
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \
+        "$p" != "/dev/null" -a \
         "${p:0:${#NIX_STORE}}" != "$NIX_STORE" -a \
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"

--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -74,6 +74,10 @@ stdenv.mkDerivation rec {
       ];
   };
 
+  passthru = {
+    inherit vdpauSupport;
+  };
+
   meta = {
     homepage = http://www.ffmpeg.org/;
     description = "A complete, cross-platform solution to record, convert and stream audio and video";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8064,6 +8064,8 @@ let
 
   xbindkeys = callPackage ../tools/X11/xbindkeys { };
 
+  xbmc = callPackage ../applications/video/xbmc { };
+
   xcalib = callPackage ../tools/X11/xcalib { };
 
   xchat = callPackage ../applications/networking/irc/xchat { };


### PR DESCRIPTION
Commit ecf27c8ce8144e5a2fbeee5489dcf93a24760f5b changes utils.sh in build-support, and so a lot of things get recompiled.
That diff was mentioned in the mailing list several months ago but wasn't merged in.
This time XBMC's configure won't work without it.

Nix-expression for XBMC was tested (by hand that is) on a x86_64 machine with all possible *Support flags combinations. Runs fine on a ASRock ION 330 HTPC.
