### PR TITLE
linux 3.2-3.7: enable NFS_FSCACHE and CIFS_FSCACHE

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.2.nix
@@ -146,8 +146,10 @@ let
       NFSD_V3 y
       NFSD_V3_ACL y
       NFSD_V4 y
+      NFS_FSCACHE y
       CIFS_XATTR y
       CIFS_POSIX y
+      CIFS_FSCACHE y
 
       # Security related features.
       STRICT_DEVMEM y # Filter access to /dev/mem

--- a/pkgs/os-specific/linux/kernel/linux-3.3.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.3.nix
@@ -146,8 +146,10 @@ let
       NFSD_V3 y
       NFSD_V3_ACL y
       NFSD_V4 y
+      NFS_FSCACHE y
       CIFS_XATTR y
       CIFS_POSIX y
+      CIFS_FSCACHE y
 
       # Security related features.
       STRICT_DEVMEM y # Filter access to /dev/mem

--- a/pkgs/os-specific/linux/kernel/linux-3.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.4.nix
@@ -148,8 +148,10 @@ let
       NFSD_V3 y
       NFSD_V3_ACL y
       NFSD_V4 y
+      NFS_FSCACHE y
       CIFS_XATTR y
       CIFS_POSIX y
+      CIFS_FSCACHE y
 
       # Security related features.
       STRICT_DEVMEM y # Filter access to /dev/mem

--- a/pkgs/os-specific/linux/kernel/linux-3.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.5.nix
@@ -148,8 +148,10 @@ let
       NFSD_V3 y
       NFSD_V3_ACL y
       NFSD_V4 y
+      NFS_FSCACHE y
       CIFS_XATTR y
       CIFS_POSIX y
+      CIFS_FSCACHE y
 
       # Security related features.
       STRICT_DEVMEM y # Filter access to /dev/mem

--- a/pkgs/os-specific/linux/kernel/linux-3.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.6.nix
@@ -148,8 +148,10 @@ let
       NFSD_V3 y
       NFSD_V3_ACL y
       NFSD_V4 y
+      NFS_FSCACHE y
       CIFS_XATTR y
       CIFS_POSIX y
+      CIFS_FSCACHE y
 
       # Security related features.
       STRICT_DEVMEM y # Filter access to /dev/mem

--- a/pkgs/os-specific/linux/kernel/linux-3.7.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.7.nix
@@ -148,8 +148,10 @@ let
       NFSD_V3 y
       NFSD_V3_ACL y
       NFSD_V4 y
+      NFS_FSCACHE y
       CIFS_XATTR y
       CIFS_POSIX y
+      CIFS_FSCACHE y
 
       # Security related features.
       STRICT_DEVMEM y # Filter access to /dev/mem


### PR DESCRIPTION
NFS_FSCACHE and CIFS_FSCACHE are required to enable the local cache support for
NFS and CIFS (the 'fsc' mount option). The reasoning for enabling it from 3.2
and forward is that at least Ubuntu 12.04 (linux 3.2) has it turned on. Could
probably be enabled for earlier kernels too.
