### PR TITLE
Fix mit-scheme

### DIFF
--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gnum4, texinfo, texLive, automake }:
+{ fetchurl, stdenv, makeWrapper, gnum4, texinfo, texLive, automake }:
 
 let
   version = "9.1.1";
@@ -25,6 +25,11 @@ stdenv.mkDerivation {
       sha256 = "0pclakzwxbqgy6wqwvs6ml62wgby8ba8xzmwzdwhx1v8wv05yw1j";
     };
 
+  configurePhase =
+    '' (cd src && ./configure)
+       (cd doc && ./configure)
+    '';
+
   buildPhase =
     '' cd src
        ${if bootstrapFromC
@@ -42,11 +47,19 @@ stdenv.mkDerivation {
     '';
 
   installPhase =
-    '' make install -C src
-       make install -C doc
+    '' make prefix=$out install -C src
+       make prefix=$out install -C doc
     '';
 
-  buildNativeInputs = [ gnum4 texinfo texLive automake ];
+  fixupPhase = ''
+    wrapProgram $out/bin/scheme --set MITSCHEME_LIBRARY_PATH \
+      $out/lib/mit-scheme${
+        if      stdenv.isi686   then "-i386"
+        else if stdenv.isx86_64 then "-x86-64"
+        else                         ""}
+  '';
+
+  buildNativeInputs = [ makeWrapper gnum4 texinfo texLive automake ];
 
   # XXX: The `check' target doesn't exist.
   doCheck = false;


### PR DESCRIPTION
These changes are necessary for me to use mit-scheme on i686 NixOS.
mit-scheme in the current state should be broken on x86_64 either and
these changes should fix, too. I however did not test this.
