### PR TITLE
tinc:  A VPN daemon with full mesh routing.

### DIFF
--- a/pkgs/tools/networking/tinc/default.nix
+++ b/pkgs/tools/networking/tinc/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
       authentication, compression and ethernet bridging.
     '';
     homepage="http://www.tinc-vpn.org/";
-    license = stdenv.lib.licenses.gpl2;
+    license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/tools/networking/tinc/default.nix
+++ b/pkgs/tools/networking/tinc/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
       authentication, compression and ethernet bridging.
     '';
     homepage="http://www.tinc-vpn.org/";
-    license = "gpl2Plus";
+    license = stdenv.lib.licenses.gpl2;
   };
 }

--- a/pkgs/tools/networking/tinc/default.nix
+++ b/pkgs/tools/networking/tinc/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchurl, lzo, openssl, zlib}:
+
+stdenv.mkDerivation rec {
+  version = "1.0.19";
+  name = "tinc-${version}";
+
+  src = fetchurl {
+    url = "http://www.tinc-vpn.org/packages/tinc-${version}.tar.gz";
+    sha256 = "183nxj23d05vc3pxwbb692lr048wr81wnv0avzlkdm4r6c3bp7jh";
+  };
+
+  buildInputs = [ lzo openssl zlib ];
+
+  configureFlags = ''
+    --localstatedir=/var
+    --sysconfdir=/etc
+  '';
+
+  meta = { 
+    description = "VPN daemon with full mesh routing";
+    longDescription = ''
+      tinc is a Virtual Private Network (VPN) daemon that uses tunnelling and
+      encryption to create a secure private network between hosts on the
+      Internet.  It features full mesh routing, as well as encryption,
+      authentication, compression and ethernet bridging.
+    '';
+    homepage="http://www.tinc-vpn.org/";
+    license = "gpl2Plus";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1587,6 +1587,8 @@ let
     guile = guile_1_8;
   };
 
+  tinc = callPackage ../tools/networking/tinc { };
+
   tmux = callPackage ../tools/misc/tmux { };
 
   tor = callPackage ../tools/security/tor { };


### PR DESCRIPTION
I made it read configurations from /etc and store local data in /var; is that good?  The default was under /nix/store.
