### PR TITLE
Screen configuration in /etc/screenrc

### DIFF
--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    configureFlags="--enable-telnet --enable-pam --infodir=$out/share/info --mandir=$out/share/man"
+    configureFlags="--enable-telnet --enable-pam --infodir=$out/share/info --mandir=$out/share/man --with-sys-screenrc=/etc/screenrc"
     sed -i -e "s|/usr/local|/non-existent|g" -e "s|/usr|/non-existent|g" configure Makefile.in */Makefile.in
   '';
 


### PR DESCRIPTION
It is in general possible to add a global screen configuration, but the nixpkgs screen package does not generate one. Most people only use a per-user configuration, of course.

I saw two options:
1. Parametrise the screen package with the configuration file. While pure, this would require rebuilding screen for every change and would make it impossible to use binary packages.
2. Set screen to use the global /etc/screenrc. Use this in conjunction with the nixos "etc" configuration option, and it should be possible to deal with.

While not entirely happy, as it is slightly impure, I chose option (2): I think it is a strict improvement over the status quo and should be workable.

(Oh and yes, I am absolutely militant about Ctrl-a being a stupid escape sequence for screen.)
