### PR TITLE
Add alsa-oss program

### DIFF
--- a/pkgs/os-specific/linux/alsa-oss/default.nix
+++ b/pkgs/os-specific/linux/alsa-oss/default.nix
@@ -1,0 +1,33 @@
+{stdenv, fetchurl, alsaLib, gettext, ncurses, libsamplerate}:
+
+stdenv.mkDerivation rec {
+  name = "alsa-oss-1.0.25";
+
+  src = fetchurl {
+    url = "ftp://ftp.alsa-project.org/pub/oss-lib/${name}.tar.bz2";
+    # url = "http://alsa.cybermirror.org/oss-lib/${name}.tar.bz2";
+    sha256 = "ed823b8e42599951d896c1709615d4cf7cb1cb3a7c55c75ccee82e24ccaf28e3";
+  };
+
+  buildInputs = [ alsaLib ncurses libsamplerate ];
+  buildNativeInputs = [ gettext ];
+
+  configureFlags = "--disable-xmlto";
+
+  installFlags = "ASOUND_STATE_DIR=$(TMPDIR)/dummy";
+
+  preConfigure =
+    ''
+    '';
+
+  meta = {
+    description = "ALSA, the Advanced Linux Sound Architecture alsa-oss emulation";
+
+    longDescription = ''
+      The Advanced Linux Sound Architecture (ALSA) provides audio and
+      MIDI functionality to the Linux-based operating system.
+    '';
+
+    homepage = http://www.alsa-project.org/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5666,6 +5666,7 @@ let
   alsaPluginWrapper = callPackage ../os-specific/linux/alsa-plugins/wrapper.nix { };
 
   alsaUtils = callPackage ../os-specific/linux/alsa-utils { };
+  alsaOss = callPackage ../os-specific/linux/alsa-oss { };
 
   microcode2ucode = callPackage ../os-specific/linux/microcode/converter.nix { };
 


### PR DESCRIPTION
alsa-oss is an emulation layer to let OSS programs use proper ALSA sound. This is especially useful to get sound mixing, or run Minecraft in parallel with watching Youtube videos (gotta keep your priorities straight).
