### PR TITLE
wpa_supplicant: refactor settings, readline support (on by default)

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, openssl, dbus_libs, pkgconfig, libnl }:
+{ stdenv, fetchurl, lib, openssl, dbus_libs, pkgconfig, libnl
+, readlineSupport ? true, readline
+}:
+assert readlineSupport -> readline!=null;
 
 stdenv.mkDerivation rec {
   version = "1.1";
@@ -9,20 +12,26 @@ stdenv.mkDerivation rec {
     url = "http://hostap.epitest.fi/releases/${name}.tar.gz";
     sha256 = "00lyifj8cz7qyal6dy1dxbpk3g3bywvdarik8gbj9ds7zmfbwkd5";
   };
+  extraConfig = lib.concatStringsSep "\n" (
+    [ "CONFIG_DEBUG_SYSLOG=y"
+      "CONFIG_CTRL_IFACE_DBUS=y"
+      "CONFIG_CTRL_IFACE_DBUS_NEW=y"
+      "CONFIG_CTRL_IFACE_DBUS_INTRO=y"
+      "CONFIG_DRIVER_NL80211=y"
+      "CONFIG_LIBNL32=y"
+    ] ++ lib.optional readlineSupport "CONFIG_READLINE=y"
+  );
 
   preBuild = ''
     cd wpa_supplicant
     cp -v defconfig .config
-    echo CONFIG_DEBUG_SYSLOG=y | tee -a .config
-    echo CONFIG_CTRL_IFACE_DBUS=y | tee -a .config
-    echo CONFIG_CTRL_IFACE_DBUS_NEW=y | tee -a .config
-    echo CONFIG_CTRL_IFACE_DBUS_INTRO=y | tee -a .config
-    echo CONFIG_DRIVER_NL80211=y | tee -a .config
+    echo ${extraConfig} | tee -a .config
     echo CONFIG_LIBNL32=y | tee -a .config
     substituteInPlace Makefile --replace /usr/local $out
   '';
 
-  buildInputs = [ openssl dbus_libs libnl ];
+  buildInputs = [ openssl dbus_libs libnl ]
+    ++ lib.optional readlineSupport readline;
 
   buildNativeInputs = [ pkgconfig ];
 


### PR DESCRIPTION
I know there's 2.0 version but doesn't seem ready yet. And these changes probably won't be lost.
