### PR TITLE
Hplip: python programs can now be used

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,5 +1,5 @@
-{stdenv, fetchurl, cups, zlib, libjpeg, libusb, python, saneBackends, dbus
-, pkgconfig, polkit, qtSupport ? true, qt4
+{stdenv, fetchurl, cups, zlib, libjpeg, libusb, pythonPackages, saneBackends, dbus
+, pkgconfig, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     sed -i s,/etc/sane.d,$out/etc/sane.d/, Makefile.in
+    sed -i s,/etc/hp/,$out/etc/hp/, base/g.py
   '';
 
   # --disable-network-build Until we have snmp
@@ -41,8 +42,27 @@ stdenv.mkDerivation rec {
     ";
   '';
 
-  buildInputs = [libjpeg cups libusb python saneBackends dbus pkgconfig] ++
+  postInstall = ''
+    wrapPythonPrograms
+    '';
+
+  buildInputs = [
+      libjpeg
+      cups
+      libusb
+      pythonPackages.python
+      pythonPackages.wrapPython
+      pythonPackages.recursivePthLoader # does not seem to work?
+      saneBackends
+      dbus
+      pkgconfig] ++
     stdenv.lib.optional qtSupport qt4;
+
+  pythonPath = with pythonPackages; [
+      pythonDBus
+      pyqt4
+      pygobject
+    ];
 
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, cups, zlib, libjpeg, libusb, pythonPackages, saneBackends, dbus
-, pkgconfig, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4
+, pkgconfig, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4, net_snmp
 }:
 
 stdenv.mkDerivation rec {
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
       --with-systraydir=$out/xdg/autostart
       --with-mimedir=$out/etc/cups
       --enable-policykit
-      --disable-network-build"
+    "
 
     export makeFlags="
       halpredir=$out/share/hal/fdi/preprobe/10osvendor
@@ -54,8 +54,9 @@ stdenv.mkDerivation rec {
       pythonPackages.wrapPython
       saneBackends
       dbus
-      pkgconfig] ++
-    stdenv.lib.optional qtSupport qt4;
+      pkgconfig
+      net_snmp
+    ] ++ stdenv.lib.optional qtSupport qt4;
 
   pythonPath = with pythonPackages; [
       pythonDBus

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
       libusb
       pythonPackages.python
       pythonPackages.wrapPython
-      pythonPackages.recursivePthLoader # does not seem to work?
       saneBackends
       dbus
       pkgconfig] ++
@@ -62,6 +61,7 @@ stdenv.mkDerivation rec {
       pythonDBus
       pyqt4
       pygobject
+      recursivePthLoader
     ];
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -60,10 +60,9 @@ stdenv.mkDerivation rec {
 
   pythonPath = with pythonPackages; [
       pythonDBus
-      pyqt4
       pygobject
       recursivePthLoader
-    ];
+    ] ++ stdenv.lib.optional qtSupport pyqt4;
 
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";


### PR DESCRIPTION
The hplip package wasn't really "python-aware" before. It should be now: I tried running hp-setup, and it works.
