### PR TITLE
Update XBMC to 12.0

### DIFF
--- a/pkgs/applications/video/xbmc/default.nix
+++ b/pkgs/applications/video/xbmc/default.nix
@@ -13,7 +13,7 @@
 , ffmpeg, libmpeg2, libsamplerate, libmad
 , libogg, libvorbis, flac
 , lzo, libcdio, libmodplug, libass
-, sqlite, mysql
+, sqlite, mysql, nasm
 , curl, bzip2, zip, unzip, glxinfo, xdpyinfo
 , dbus_libs ? null, dbusSupport ? true
 , udev, udevSupport ? true
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       ffmpeg libmpeg2 libsamplerate libmad
       libogg libvorbis flac
       lzo libcdio libmodplug libass
-      sqlite mysql
+      sqlite mysql nasm
       curl bzip2 zip unzip glxinfo xdpyinfo
     ]
     ++ lib.optional dbusSupport dbus_libs

--- a/pkgs/applications/video/xbmc/default.nix
+++ b/pkgs/applications/video/xbmc/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, cmake, gnumake, yasm, python
 , boost
 , gettext, pcre, yajl, fribidi
-, openssl, gperf
+, openssl, gperf, tinyxml, taglib
 , libX11, xproto, inputproto
 , libXt, libXmu, libXext, xextproto
 , libXinerama, libXrandr, randrproto
@@ -30,11 +30,11 @@ assert sambaSupport -> samba != null;
 assert vdpauSupport -> libvdpau != null && ffmpeg.vdpauSupport;
 
 stdenv.mkDerivation rec {
-    name = "xbmc-11.0";
+    name = "xbmc-12.0";
 
     src = fetchurl {
       url = "http://mirrors.xbmc.org/releases/source/${name}.tar.gz";
-      sha256 = "1fe5d310c16138f26e2b13bc545604e95f48ace6c8636f23e77da402cd7b0b19";
+      sha256 = "0vy1a38gfbp9vhbjvwqm11sd76gl3s9q0h7gwpsks85m2k88q0ak";
     };
 
     buildInputs = [
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
       pkgconfig cmake gnumake yasm python
       boost
       gettext pcre yajl fribidi
-      openssl gperf
+      openssl gperf tinyxml taglib 
       libX11 xproto inputproto
       libXt libXmu libXext xextproto
       libXinerama libXrandr randrproto

--- a/pkgs/development/libraries/taglib/default.nix
+++ b/pkgs/development/libraries/taglib/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, zlib, cmake}:
 
 stdenv.mkDerivation rec {
-  name = "taglib-1.7.1";
+  name = "taglib-1.8";
   
   src = fetchurl {
     url = "https://github.com/downloads/taglib/taglib/${name}.tar.gz";


### PR DESCRIPTION
Doesn't work yet, for some reason pkg-config doesn't find taglib 1.8.

@oxij would be great if you want to take a peek :)
