### PR TITLE
file: bump from 5.04 to 5.12

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -1,18 +1,15 @@
 {stdenv, fetchurl}:
  
-stdenv.mkDerivation {
-  name = "file-5.04";
+stdenv.mkDerivation rec {
+  name = "file-5.12";
 
   src = fetchurl {
-    urls = [
-      ftp://ftp.astron.com/pub/file/file-5.04.tar.gz
-      http://pkgs.fedoraproject.org/repo/pkgs/file/file-5.04.tar.gz/accade81ff1cc774904b47c72c8aeea0/file-5.04.tar.gz
-    ];
-    sha256 = "0316lj3jxmp2g8azv0iykmmwjsnjanq93bklccwb6k77jiwnx7jc";
+    url = "ftp://ftp.astron.com/pub/file/${name}.tar.gz";
+    sha256 = "08ix4xrvan0k80n0l5lqfmc4azjv5lyhvhwdxny4r09j5smhv78r";
   };
 
   meta = {
     description = "A program that shows the type of files";
-    homepage = ftp://ftp.astron.com/pub/file;
+    homepage = http://www.darwinsys.com/file/;
   };
 }


### PR DESCRIPTION
Also correct the homepage URL and use 'rec' so that we can refer to the
'name' attribute inside the expression (less duplication).
