### PR TITLE
bacula: fix version mismatch between name and src attribute

### DIFF
--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, sqlite, zlib, acl, ncurses, openssl, readline}:
 
 stdenv.mkDerivation {
-  name = "bacula-5.0.3";
+  name = "bacula-5.2.13";
 
   src = fetchurl {
     url = mirror://sourceforge/bacula/bacula-5.2.13.tar.gz;


### PR DESCRIPTION
Commit 207443b1849e7b1ce65059d2fdad81db04cc75d8 ("upgrade bacula")
updated the backula version in the src attribute but forgot to update
the version number in the name attribute.
