### PR TITLE
my-env/default.nix: fix "sdl-env" vs "env-sdl" topo

### DIFF
--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -12,7 +12,7 @@
   }
 
   # Then you can install it by:  
-  #  $ nix-env -i sdl-env
+  #  $ nix-env -i env-sdl
   # And you can load it simply calling:  
   #  $ load-env-sdl
   # and this will update your env vars to have 'make' and 'gcc' finding the SDL


### PR DESCRIPTION
my-env/default.nix lists an example on how to create an SDL environment
that can be installed with "nix-env -i sdl-env". That is actually wrong
and will not work. The correct command is "nix-env -i env-sdl".
