### PR TITLE
Fix xorg-server on vmware - was: Fix to make xlibs.xf86videovmware build

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1724,8 +1724,9 @@ let
       url = mirror://xorg/X11R7.7/src/everything/xf86-video-vmware-12.0.2.tar.bz2;
       sha256 = "0isiwx516gww8hfk3vy7js83yziyjym9mq2zjadyq1a8v5gqf9y8";
     };
-    buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto ;};
+    CFLAGS = "-I${pixman}/include/pixman-1";
+    buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto pixman ];
+  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto pixman ;};
     
   xf86videovoodoo = (stdenv.mkDerivation ((if overrides ? xf86videovoodoo then overrides.xf86videovoodoo else x: x) {
     name = "xf86-video-voodoo-1.2.4";


### PR DESCRIPTION
This pull request along with adding vmware to the default list of options for services.xserver.videoDrivers, see nixos pull request [1] should fix xserver on vmware.

[1] https://github.com/NixOS/nixos/pull/107

This pull request contains a fix for pkgs.xlibs.xf86videovmware that allow it to build by adding the pixman library header files to CFLAGS.

Additional information:
- nixos - 0.2pre4506_...
- xf86videovmware was not building VMware 4.1.4
- This should also allow for the "vmware" option to be used with services.xserver.videoDrivers in `<nixos-config>`
