### PR TITLE
stdenv/setup.sh: Always run postPatch hook.

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -529,9 +529,7 @@ unpackPhase() {
 
 patchPhase() {
     runHook prePatch
-    
-    if [ -z "$patchPhase" -a -z "$patches" ]; then return; fi
-    
+
     for i in $patches; do
         header "applying patch $i" 3
         local uncompress=cat

--- a/pkgs/stdenv/mingw/setup.sh
+++ b/pkgs/stdenv/mingw/setup.sh
@@ -486,9 +486,7 @@ unpackPhase() {
 
 patchPhase() {
     runHook prePatch
-    
-    if test -z "$patchPhase" -a -z "$patches"; then return; fi
-    
+
     for i in $patches; do
         header "applying patch $i" 3
         local uncompress=cat


### PR DESCRIPTION
I'm not sure whether this was by intention (was it, @edolstra? then we might need to fix the documentation), but so far `postPatch` hooks were silently skipped whenever the `patches` list was empty. This change could possibly change the build results of the following packages:
- gcc
- cmake (264)
- systemtap
- quemu-kvm

These packages all have in common that they have a `postPatch` hook and the `patches` list can be empty when certain conditions are met.
