### PR TITLE
transmission: bump from 2.52 to 2.60

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchurl, pkgconfig, openssl, curl, intltool, libevent, gtkClient ? true, gtk }:
+{ stdenv, fetchurl, pkgconfig, openssl, curl, intltool, libevent,
+  file, inotifyTools, gtk ? null }:
 
 stdenv.mkDerivation rec {
-  name = "transmission-2.52";
+  name = "transmission-2.60"; # transmission >= 2.61 requires gtk3
 
   src = fetchurl {
     url = "http://download.transmissionbt.com/files/${name}.tar.xz";
-    sha256 = "05sfq5h3731xc9a1k5r1q4gbs9yk0dr229asfxjjgg0lw1xzppdw";
+    sha256 = "1ramdliyy8j7qqpkxg643lda11ynxwfhq6qcs31fr3h9x72l0rg4";
   };
 
-  buildInputs = [ pkgconfig openssl curl intltool libevent ] ++
-                stdenv.lib.optional gtkClient gtk;
+  buildInputs = [ pkgconfig openssl curl intltool libevent
+                  file inotifyTools gtk ];
 
-  configureFlags = if gtkClient then "--enable-gtk" else "--disable-gtk";
+  preConfigure = ''
+    sed -i -e 's|/usr/bin/file|${file}/bin/file|g' configure
+  '';
 
   postInstall = ''
-    rm $out/share/icons/hicolor/icon-theme.cache
+    rm -f $out/share/icons/hicolor/icon-theme.cache
   '';
 
   meta = {


### PR DESCRIPTION
2.60 is the newest of the gtk2-compatible versions. (Transmission >=
2.61 requires gtk3.)
- Add inotify as input to not have transmission-daemon poll the torrent
  auto-load directory.
- Add file as input to fix a small build time issue (non-fatal).
- Remove unneeded gtk configure flags (support is auto-detected).
- icon-theme.cache is only generated when building with gtk, so use
  rm -f to not error out when building without gtk.
- Use gtk ? null instead of gtkClient flag because it is simpler.

Build and runtime tested with and without gtk support.
