### PR TITLE
gstreamer-1.0.5

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -28,8 +28,8 @@ pythonPackages.buildPythonPackage rec {
   postInstall = ''
     for p in $out/bin/mopidy $out/bin/mopidy-scan; do
       wrapProgram $p \
-        --prefix GST_PLUGIN_PATH : ${gst_plugins_good}/lib/gstreamer-0.10 \
-        --prefix GST_PLUGIN_PATH : ${gst_plugins_base}/lib/gstreamer-0.10
+        --prefix GST_PLUGIN_PATH : ${gst_plugins_good}/lib/gstreamer-1.0 \
+        --prefix GST_PLUGIN_PATH : ${gst_plugins_base}/lib/gstreamer-1.0
     done
   '';
 

--- a/pkgs/applications/audio/mopidy/git.nix
+++ b/pkgs/applications/audio/mopidy/git.nix
@@ -28,8 +28,8 @@ pythonPackages.buildPythonPackage rec {
   postInstall = ''
     for p in $out/bin/mopidy $out/bin/mopidy-scan; do
       wrapProgram $p \
-        --prefix GST_PLUGIN_PATH : ${gst_plugins_good}/lib/gstreamer-0.10 \
-        --prefix GST_PLUGIN_PATH : ${gst_plugins_base}/lib/gstreamer-0.10
+        --prefix GST_PLUGIN_PATH : ${gst_plugins_good}/lib/gstreamer-1.0 \
+        --prefix GST_PLUGIN_PATH : ${gst_plugins_base}/lib/gstreamer-1.0
     done
   '';
 

--- a/pkgs/applications/networking/browsers/uzbl/default.nix
+++ b/pkgs/applications/networking/browsers/uzbl/default.nix
@@ -32,7 +32,7 @@ rec {
       --prefix GST_PLUGIN_PATH : ${a.webkit.gstreamer}/lib/gstreamer-* \
       --prefix GST_PLUGIN_PATH : ${a.webkit.gst_plugins_base}/lib/gstreamer-* \
       --prefix GST_PLUGIN_PATH : ${a.webkit.gst_plugins_good}/lib/gstreamer-* \
-      --prefix GST_PLUGIN_PATH : ${a.webkit.gst_ffmpeg}/lib/gstreamer-* \
+      --prefix GST_PLUGIN_PATH : ${a.webkit.gst_libav}/lib/gstreamer-* \
       --prefix GIO_EXTRA_MODULES : ${a.glib_networking}/lib/gio/modules
     '';
 

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig
-, cairo, mpg123, gstreamer, gst_ffmpeg, gst_plugins_base, gst_plugins_bad
+, cairo, mpg123, gstreamer, gst_libav, gst_plugins_base, gst_plugins_bad
 , gst_plugins_good, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg
 , gsm, speex, portaudio, spandsp, libuuid
 }:
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "3ac15b3d3cf17b2417ba871e7eaaaf41ab10cb30b900adcee357d5e91ea033e7";
   };
   buildInputs = [zlib openssl libre librem pkgconfig
-    cairo mpg123 gstreamer gst_ffmpeg gst_plugins_base gst_plugins_bad gst_plugins_good
+    cairo mpg123 gstreamer gst_libav gst_plugins_base gst_plugins_bad gst_plugins_good
     alsaLib SDL libv4l celt libsndfile srtp ffmpeg gsm speex portaudio spandsp libuuid
     ];
   makeFlags = [

--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -9,7 +9,7 @@ let
     libXt xproto libXext xextproto libX11 gtkspell aspell
     scrnsaverproto pycrypto pythonDBus pythonSexy 
     docutils pyasn1 farstream gst_plugins_bad gstreamer
-    gst_ffmpeg gst_python
+    gst_libav gst_python
   ];
 in
 rec {
@@ -38,7 +38,7 @@ rec {
       sed -e 's^'"$i"'^'"$out/bin-wrapped/$name"'^' -i "$out/bin/$name"
       sed -e "2aexport LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH\''${LD_LIBRARY_PATH:+:}${a.gtkspell}/lib:${a.gtkspell}/lib64\"" -i "$out/bin/gajim"
       sed -e "2aexport NIX_LDFLAGS=\"\$NIX_LDFLAGS -L${a.gtkspell}/lib -L${a.gtkspell}/lib64\"" -i "$out/bin/gajim"
-      sed -e "2aexport GST_PLUGIN_PATH=\"\$GST_PLUGIN_PATH''${GST_PLUGIN_PATH:+:}$(echo ${a.gst_plugins_bad}/lib/gstreamer-*):$(echo ${a.gst_ffmpeg}/lib/gstreamer-*):$(echo ${a.farstream}/lib/gstreamer-*)\"" -i "$out/bin/gajim"
+      sed -e "2aexport GST_PLUGIN_PATH=\"\$GST_PLUGIN_PATH''${GST_PLUGIN_PATH:+:}$(echo ${a.gst_plugins_bad}/lib/gstreamer-*):$(echo ${a.gst_libav}/lib/gstreamer-*):$(echo ${a.farstream}/lib/gstreamer-*)\"" -i "$out/bin/gajim"
     done
   '') ["wrapBinContentsPython"];
 

--- a/pkgs/applications/video/gnash/default.nix
+++ b/pkgs/applications/video/gnash/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , SDL, SDL_mixer, gstreamer, gst_plugins_base, gst_plugins_good
-, gst_ffmpeg, speex
+, gst_libav, speex
 , libogg, libxml2, libjpeg, mesa, libpng, libungif, libtool
 , boost, freetype, agg, dbus, curl, pkgconfig, gettext
 , glib, gtk, gtkglext, x11, ming, dejagnu, python, perl
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   # XXX: KDE is supported as well so we could make it available optionally.
   buildInputs = [
     gettext x11 SDL SDL_mixer gstreamer gst_plugins_base gst_plugins_good
-    gst_ffmpeg speex libtool
+    gst_libav speex libtool
     libogg libxml2 libjpeg mesa libpng libungif boost freetype agg
     dbus curl pkgconfig glib gtk gtkglext
     xulrunner
@@ -65,9 +65,9 @@ stdenv.mkDerivation rec {
          --enable-gui=gtk"
 
        # In `libmedia', Gnash compiles with "-I$gst_plugins_base/include",
-       # whereas it really needs "-I$gst_plugins_base/include/gstreamer-0.10".
+       # whereas it really needs "-I$gst_plugins_base/include/gstreamer-1.0".
        # Work around this using GCC's $CPATH variable.
-       export CPATH="${gst_plugins_base}/include/gstreamer-0.10:${gst_plugins_good}/include/gstreamer-0.10"
+       export CPATH="${gst_plugins_base}/include/gstreamer-1.0:${gst_plugins_good}/include/gstreamer-1.0"
        echo "\$CPATH set to \`$CPATH'"
 
        echo "\$GST_PLUGIN_PATH set to \`$GST_PLUGIN_PATH'"
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     do
       wrapProgram "$prog" --prefix                                            \
         GST_PLUGIN_PATH ":"                                                     \
-        "${gst_plugins_base}/lib/gstreamer-0.10:${gst_plugins_good}/lib/gstreamer-0.10:${gst_ffmpeg}/lib/gstreamer-0.10"
+        "${gst_plugins_base}/lib/gstreamer-1.0:${gst_plugins_good}/lib/gstreamer-1.0:${gst_libav}/lib/gstreamer-1.0"
     done
   '';
 

--- a/pkgs/development/libraries/farstream/default.nix
+++ b/pkgs/development/libraries/farstream/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, libnice, pkgconfig, python, gstreamer, gst_plugins_base
 , pygobject, gst_python, gupnp_igd
-, gst_plugins_good, gst_plugins_bad, gst_ffmpeg
+, gst_plugins_good, gst_plugins_bad, gst_libav
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildNativeInputs = [ pkgconfig ];
 
   propagatedBuildInputs = [ gstreamer gst_plugins_base gst_python 
-    gst_plugins_good gst_plugins_bad gst_ffmpeg
+    gst_plugins_good gst_plugins_bad gst_libav
     ];
 
   meta = {

--- a/pkgs/development/libraries/gstreamer/gst-libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-libav/default.nix
@@ -2,14 +2,14 @@
 , useInternalFfmpeg ? false, ffmpeg ? null }:
 
 stdenv.mkDerivation rec {
-  name = "gst-ffmpeg-0.10.12";
+  name = "gst-libav-1.0.5";
 
   src = fetchurl {
     urls = [
-      "http://gstreamer.freedesktop.org/src/gst-ffmpeg/${name}.tar.bz2"
+      "http://gstreamer.freedesktop.org/src/gst-libav/${name}.tar.xz"
       "mirror://gentoo/distfiles/${name}.tar.bz2"
       ];
-    sha256 = "0fyppl8q18g71jd2r0mbiqk8hhrdxq43dglma06mxyjb5c80fxxi";
+    sha256 = "1m9jzga9ahml3dnfm7syz6mglmysqpbkkyr48kka9cwna1kbxy5f";
   };
 
   # Upstream strongly recommends against using --with-system-ffmpeg,

--- a/pkgs/development/libraries/gstreamer/gst-libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-libav/default.nix
@@ -1,5 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gst_plugins_base, bzip2, yasm
-, useInternalFfmpeg ? false, ffmpeg ? null }:
+{ fetchurl, stdenv, pkgconfig, gst_plugins_base, bzip2, yasm }:
 
 stdenv.mkDerivation rec {
   name = "gst-libav-1.0.5";
@@ -12,17 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "1m9jzga9ahml3dnfm7syz6mglmysqpbkkyr48kka9cwna1kbxy5f";
   };
 
-  # Upstream strongly recommends against using --with-system-ffmpeg,
-  # but we do it anyway because we're so hardcore (and we don't want
-  # multiple copies of ffmpeg).
-  configureFlags = stdenv.lib.optionalString (!useInternalFfmpeg) "--with-system-ffmpeg";
-
   buildInputs =
-    [ pkgconfig bzip2 gst_plugins_base ]
-    ++ (if useInternalFfmpeg then [ yasm ] else [ ffmpeg ]);
+    [ pkgconfig bzip2 gst_plugins_base yasm ];
+
+  enableParallelBuilding = true; 
 
   meta = {
-    homepage = "http://gstreamer.freedesktop.org/releases/gst-ffmpeg";
+    homepage = "http://gstreamer.freedesktop.org/releases/gst-libav";
     description = "GStreamer's plug-in using FFmpeg";
     license = "GPLv2+";
   };

--- a/pkgs/development/libraries/gstreamer/gst-plugins-bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-plugins-bad/default.nix
@@ -2,14 +2,14 @@
 , libdvdnav, libdvdread }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-bad-0.10.22";
+  name = "gst-plugins-bad-1.0.5";
 
   src = fetchurl {
     urls = [
-      "${meta.homepage}/src/gst-plugins-bad/${name}.tar.bz2"
-      "mirror://gentoo/distfiles/${name}.tar.bz2"
+      "${meta.homepage}/src/gst-plugins-bad/${name}.tar.xz"
+      "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "030728gf0zjg62yng4qy9yapaffbvkziawa28rk0gspz8cpi1xyq";
+    sha256 = "0si79dsdx06w6p48v1c5ifbjhq26p4jn8swi18ni8x6j5yd5p3rf";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/gstreamer/gst-plugins-base/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-plugins-base/default.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-base-0.10.36";
+  name = "gst-plugins-base-1.0.5";
 
   src = fetchurl {
     urls = [
       "${meta.homepage}/src/gst-plugins-base/${name}.tar.xz"
       "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "0jp6hjlra98cnkal4n6bdmr577q8mcyp3c08s3a02c4hjhw5rr0z";
+    sha256 = "0wvigpblsarbxfv1ms34qza4yasqj18fwqf8268qgwwyp44nxkip";
   };
 
   patchPhase = ''

--- a/pkgs/development/libraries/gstreamer/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-plugins-good/default.nix
@@ -5,14 +5,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-good-0.10.30";
+  name = "gst-plugins-good-1.0.5";
 
   src = fetchurl {
     urls = [
-      "${meta.homepage}/src/gst-plugins-good/${name}.tar.bz2"
-      "mirror://gentoo/distfiles/${name}.tar.bz2"
+      "${meta.homepage}/src/gst-plugins-good/${name}.tar.xz"
+      "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "1xlmw211fcn60y2m5gxrryb3knqril4kk2c01b6j713xna8blb5i";
+    sha256 = "1i8b2kap50pz5m3iq4hf23jjbx3cwn5lxjj84nrg35kqis20pgak";
   };
 
   configureFlags = "--disable-oss";

--- a/pkgs/development/libraries/gstreamer/gst-plugins-ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-plugins-ugly/default.nix
@@ -2,14 +2,14 @@
 , libmad, libdvdread, libmpeg2, libcdio, a52dec }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-ugly-0.10.18";
+  name = "gst-plugins-ugly-1.0.5";
 
   src = fetchurl {
     urls = [
-      "${meta.homepage}/src/gst-plugins-ugly/${name}.tar.bz2"
-      "mirror://gentoo/distfiles/${name}.tar.bz2"
+      "${meta.homepage}/src/gst-plugins-ugly/${name}.tar.xz"
+      "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "054fdkb2riy5knda39cp6w3xp9lzax52bn12cklglscjrm46ghgr";
+    sha256 = "0c8kg59fg3v6hjf7wlwypcp9vnql359nvd4knj1jg6vdm4p1ham6";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/gstreamer/gst-python/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-python/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-python-0.10.19";
+  name = "gst-python-0.10.22";
 
   src = fetchurl {
     urls = [
       "${meta.homepage}/src/gst-python/${name}.tar.bz2"
       "mirror://gentoo/distfiles/${name}.tar.bz2"
       ];
-    sha256 = "956f81a8c15daa3f17e688a0dc5a5d18a3118141066952d3b201a6ac0c52b415";
+    sha256 = "0y1i4n5m1diljqr9dsq12anwazrhbs70jziich47gkdwllcza9lg";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/gstreamer/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamer/default.nix
@@ -1,14 +1,14 @@
 { fetchurl, stdenv, perl, bison, flex, pkgconfig, glib, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "gstreamer-0.10.36";
+  name = "gstreamer-1.0.5";
 
   src = fetchurl {
     urls =
       [ "${meta.homepage}/src/gstreamer/${name}.tar.xz"
         "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "1nkid1n2l3rrlmq5qrf5yy06grrkwjh3yxl5g0w58w0pih8allci";
+    sha256 = "0xsvgi4axavrh0bkjr9h8yq75bmjjs37y7mwlg84d6phcxsq5hi6";
   };
 
   buildInputs = [ perl bison flex pkgconfig ];

--- a/pkgs/development/libraries/gstreamer/gstreamer/setup-hook.sh
+++ b/pkgs/development/libraries/gstreamer/gstreamer/setup-hook.sh
@@ -1,7 +1,7 @@
 addGstreamerLibPath () {
-    if test -d "$1/lib/gstreamer-0.10"
+    if test -d "$1/lib/gstreamer-1.0"
     then
-        export GST_PLUGIN_PATH="${GST_PLUGIN_PATH}${GST_PLUGIN_PATH:+:}$1/lib/gstreamer-0.10"
+        export GST_PLUGIN_PATH="${GST_PLUGIN_PATH}${GST_PLUGIN_PATH:+:}$1/lib/gstreamer-1.0"
     fi
 }
 

--- a/pkgs/development/libraries/webkit/default.nix
+++ b/pkgs/development/libraries/webkit/default.nix
@@ -18,7 +18,7 @@ rec {
     ];
 
   propagatedBuildInputs = [
-    gstreamer gst_plugins_base gst_ffmpeg gst_plugins_good
+    gstreamer gst_plugins_base gst_libav gst_plugins_good
     ];
 
   configureFlags = [
@@ -91,6 +91,6 @@ rec {
     maintainers = [stdenv.lib.maintainers.raskin];
   };
   passthru = {
-    inherit gstreamer gst_plugins_base gst_plugins_good gst_ffmpeg;
+    inherit gstreamer gst_plugins_base gst_plugins_good gst_libav;
   };
 }

--- a/pkgs/development/libraries/webkit/gtk2.nix
+++ b/pkgs/development/libraries/webkit/gtk2.nix
@@ -18,7 +18,7 @@ rec {
     ];
 
   propagatedBuildInputs = [
-    gstreamer gst_plugins_base gst_ffmpeg gst_plugins_good
+    gstreamer gst_plugins_base gst_libav gst_plugins_good
     ];
 
   configureFlags = [
@@ -87,6 +87,6 @@ rec {
     maintainers = [stdenv.lib.maintainers.raskin];
   };
   passthru = {
-    inherit gstreamer gst_plugins_base gst_plugins_good gst_ffmpeg;
+    inherit gstreamer gst_plugins_base gst_plugins_good gst_libav;
   };
 }

--- a/pkgs/development/libraries/webkit/svn.nix
+++ b/pkgs/development/libraries/webkit/svn.nix
@@ -17,7 +17,7 @@ rec {
     ];
 
   propagatedBuildInputs = [
-    gstreamer gst_plugins_base gst_ffmpeg gst_plugins_good
+    gstreamer gst_plugins_base gst_libav gst_plugins_good
     ];
 
   configureCommand = "./autogen.sh ";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3894,7 +3894,7 @@ let
     gstPluginsBad = pkgs.gst_plugins_bad;
     gstPluginsGood = pkgs.gst_plugins_good;
     gstPluginsUgly = pkgs.gst_plugins_ugly;
-    gstFfmpeg = pkgs.gst_ffmpeg;
+    gstLibAV = pkgs.gst_libav;
   };
 
   gstreamer = callPackage ../development/libraries/gstreamer/gstreamer {};
@@ -3907,7 +3907,7 @@ let
 
   gst_plugins_ugly = callPackage ../development/libraries/gstreamer/gst-plugins-ugly {};
 
-  gst_ffmpeg = callPackage ../development/libraries/gstreamer/gst-ffmpeg {};
+  gst_libav = callPackage ../development/libraries/gstreamer/gst-libav {};
 
   gst_python = callPackage ../development/libraries/gstreamer/gst-python {};
 
@@ -5118,7 +5118,7 @@ let
         icu cairo intltool automake libtool
         pkgconfig autoconf bison libproxy enchant
         python ruby which flex geoclue mesa;
-      inherit gstreamer gst_plugins_base gst_ffmpeg
+      inherit gstreamer gst_plugins_base gst_libav
         gst_plugins_good;
       inherit (xlibs) libXt renderproto libXrender kbproto;
       libpng = libpng12;
@@ -5134,7 +5134,7 @@ let
         icu cairo intltool automake libtool
         pkgconfig autoconf bison libproxy enchant
         python ruby which flex geoclue;
-      inherit gstreamer gst_plugins_base gst_ffmpeg
+      inherit gstreamer gst_plugins_base gst_libav
         gst_plugins_good;
       inherit (xlibs) libXt renderproto libXrender;
       libpng = libpng12;
@@ -5150,7 +5150,7 @@ let
         icu cairo perl intltool automake libtool
         pkgconfig autoconf bison libproxy enchant
         python ruby which flex geoclue;
-      inherit gstreamer gst_plugins_base gst_ffmpeg
+      inherit gstreamer gst_plugins_base gst_libav
         gst_plugins_good;
       inherit (xlibs) libXt renderproto libXrender;
       libpng = libpng12;
@@ -8899,7 +8899,7 @@ let
   gajim = builderDefsPackage (import ../applications/networking/instant-messengers/gajim) {
     inherit perl intltool pyGtkGlade gettext pkgconfig makeWrapper pygobject
       pyopenssl gtkspell libsexy pycrypto aspell pythonDBus pythonSexy
-      docutils gtk farstream gst_plugins_bad gstreamer gst_ffmpeg gst_python;
+      docutils gtk farstream gst_plugins_bad gstreamer gst_libav gst_python;
     dbus = dbus.libs;
     inherit (gnome) libglade;
     inherit (xlibs) libXScrnSaver libXt xproto libXext xextproto libX11

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -549,7 +549,7 @@ in
   gsettings_desktop_schemas = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   gsmartcontrol = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   gssdp = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
-  gst_ffmpeg = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
+  gst_libav = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   gst_plugins_bad = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   gst_plugins_base = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   gst_plugins_good = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };


### PR DESCRIPTION
update gstreamer (and gst_plugin*) to 1.0.5. 
upstream renamed gst-ffmpeg to gst-libav 
fix `GST_PLUGIN_PATH` to point to new gstreamer plugin directory

WARNING: this breaks `modules/services/x11/desktop-managers/kde4.nix` in the nixos repostiory. I'll send another pull request for that. 
