### PR TITLE
pygobject: update to 2.28.6

### DIFF
--- a/pkgs/development/python-modules/pygobject/default.nix
+++ b/pkgs/development/python-modules/pygobject/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python, pkgconfig, glib }:
 
 stdenv.mkDerivation rec {
-  name = "pygobject-2.27.0";
+  name = "pygobject-2.28.6";
   
   src = fetchurl {
-    url = "http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.27/${name}.tar.bz2";
-    sha256 = "18mq4mj9s9sw12m6gbbc4iffrq993c7q09v9yahlnamrqn3bv53m";
+    url = "http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/${name}.tar.xz";
+    sha256 = "1f5dfxjnil2glfwxnqr14d2cjfbkghsbsn8n04js2c2icr7iv2pv";
   };
 
   configureFlags = "--disable-introspection";


### PR DESCRIPTION
This fixes an issue with MyPaint: https://gna.org/bugs/?20400

It affects the following packages (which I haven't tested):

blueman
bluez
cinepaint
compiz
farsight2
farstream
gajim
gimp
gimp_2_8
gimpPlugins.fourier
gimpPlugins.gap
gimpPlugins.gimplensfun
gimpPlugins.gmic
gimpPlugins.lqrPlugin
gimpPlugins.resynthesizer
gimpPlugins.texturize
gimpPlugins.ufraw
gimpPlugins.waveletSharpen
gnokii
gnome.gnome_python
gnome.python_rsvg
gnome_terminator
gst_python
gtkpod
gtkvnc
gupnp_igd
gutenprint
hplip
jbrout
kde4.amarok
kde4.kdeadmin
kde4.kdeutils
kde4.kipi_plugins
kde4.printer_applet
kde4.system_config_printer_kde
kde4.telepathy.accounts_kcm
kde4.telepathy.approver
kde4.telepathy.auth_handler
kde4.telepathy.call_ui
kde4.telepathy.common_internals
kde4.telepathy.contact_applet
kde4.telepathy.contact_list
kde4.telepathy.contact_runner
kde4.telepathy.filetransfer_handler
kde4.telepathy.kded_integration_module
kde4.telepathy.presence_applet
kde4.telepathy.send_file
kde4.telepathy.telepathy_logger_qt
kde4.telepathy.text_ui
keepnote
keymon
libgpod
libnice
mcomix
meld
mirage
mopidy
mopidy_git
mypaint
nmap
obexd
obex_data_server
obexfs
obexftp
openobex
pidgin
pidginlatex
pidginlatexSF
pidginmsnpecan
pidginotr
pidginsipe
pygobject
pygtk
pyGtkGlade
python27Packages.notify
python27Packages.skype4py
pythonSexy
salut_a_toi
system_config_printer
telepathy_farstream
telepathy_gabble
telepathy_haze
telepathy_qt
virtmanager
virtviewer
wicd
xpra
zbar
