### PR TITLE
graphviz: fix vimdot program

### DIFF
--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -32,8 +32,10 @@ stdenv.mkDerivation rec {
     sed -e 's@am__append_5 *=.*@am_append_5 =@' -i lib/gvc/Makefile
   '';
 
+  # "command -v" is POSIX, "which" is not
   postInstall = ''
     sed -i 's|`which lefty`|"'$out'/bin/lefty"|' $out/bin/dotty
+    sed -i 's|which|command -v|' $out/bin/vimdot
   '';
 
   meta = {


### PR DESCRIPTION
vimdot doesn't work at the moment because one of its dependencies,
'which', is missing; vimdot fails to find gvim or vim and aborts.
Instead of adding a dependency on 'which', replace it with the POSIX
command 'command -v'.
