### PR TITLE
Fix bip build

### DIFF
--- a/pkgs/applications/networking/irc/bip/bip-0.8.8-yyparse.patch
+++ b/pkgs/applications/networking/irc/bip/bip-0.8.8-yyparse.patch
@@ -1,0 +1,11 @@
+--- bip-0.8.8/src/lex.l.orig
++++ bip-0.8.8/src/lex.l
+@@ -16,7 +16,7 @@
+ int linec;
+ #include "util.h"
+ extern list_t *root_list;
+-void yyparse(void);
++int yyparse(void);
+ void free_conf(list_t*);
+ int conf_error;
+ typedef struct bip bip_t;

--- a/pkgs/applications/networking/irc/bip/default.nix
+++ b/pkgs/applications/networking/irc/bip/default.nix
@@ -36,6 +36,10 @@ in stdenv.mkDerivation {
     }
   ];
 
+  postPatch = ''
+    patch -p1 < ${./bip-0.8.8-yyparse.patch}
+  '';
+
   configureFlags = [ "--disable-pie" ];
 
   buildInputs = [ bison flex autoconf automake openssl ];


### PR DESCRIPTION
The build for bip is failing with the following error:

```
lex.l:19:6: error: conflicting types for 'yyparse'
src/conf.h:201:5: note: previous declaration of 'yyparse' was here
```

This commit adds a patch that fixes it.
