### PR TITLE
doxygen: update to 1.8.3.1

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, perl, flex, bison, qt4 }:
 
 let
-  name = "doxygen-1.8.1";
+  name = "doxygen-1.8.3.1";
 in
 stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "ftp://ftp.stack.nl/pub/users/dimitri/${name}.src.tar.gz";
-    sha256 = "0qmprax8d5fwx6sc7x9l06ilh2ffgvm6xs0rh54k3v5q5879r7mg";
+    sha256 = "0m9bwxg9g2h5fp9as0l0rmibm9ing39nssfrn3608v0v21l9yx0c";
   };
 
   patches = [ ./tmake.patch ];


### PR DESCRIPTION
There are many bugfixes and some new features over 1.8.1. I don't think there's any breakage over existing functionality.
