### PR TITLE
mesa: use buildEnv to join mesa(noglu) and glu

### DIFF
--- a/pkgs/development/libraries/mesa-glu/default.nix
+++ b/pkgs/development/libraries/mesa-glu/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ mesa_noglu ];
 
-  passthru = { inherit (mesa_noglu) libdrm; inherit mesa_noglu; };
-
   meta = {
     description = "OpenGL utility library";
     homepage = http://cgit.freedesktop.org/mesa/glu/;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -12,7 +12,7 @@ let
   version = "9.1.1";
 in
 stdenv.mkDerivation {
-  name = "mesa-${version}";
+  name = "mesa-noglu-${version}";
 
   src = fetchurl {
     url = "ftp://ftp.freedesktop.org/pub/mesa/${version}/MesaLib-${version}.tar.bz2";

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  passthru = { inherit libdrm; };
+  passthru = { inherit libdrm; inherit version; };
 
   meta = {
     description = "An open source implementation of OpenGL";

--- a/pkgs/development/libraries/wxGTK-2.8/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.8/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     "${libXinerama}/include ${libSM}/include ${libXxf86vm}/include";
   SEARCH_LIB =
     "${libXinerama}/lib ${libSM}/lib ${libXxf86vm}/lib "
-    + optionalString withMesa "${mesa.mesa_noglu}/lib ${mesa}/lib ";
+    + optionalString withMesa "${mesa}/lib ";
 
   # Work around a bug in configure.
   NIX_CFLAGS_COMPILE = "-DHAVE_X11_XLIB_H=1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4565,8 +4565,12 @@ let
   mesaSupported = lib.elem system lib.platforms.mesaPlatforms;
 
   mesa_noglu = callPackage ../development/libraries/mesa { };
+  mesa_glu = callPackage ../development/libraries/mesa-glu { };
   mesa = if stdenv.isDarwin then darwinX11AndOpenGL
-    else callPackage ../development/libraries/mesa-glu { }; # mesa *with* GL/glu.h
+    else buildEnv {
+      name = "mesa";
+      paths = [ mesa_glu mesa_noglu ];
+    };
   darwinX11AndOpenGL = callPackage ../os-specific/darwin/native-x11-and-opengl { };
 
   metaEnvironment = recurseIntoAttrs (let callPackage = newScope pkgs.metaEnvironment; in rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4568,7 +4568,7 @@ let
   mesa_glu = callPackage ../development/libraries/mesa-glu { };
   mesa = if stdenv.isDarwin then darwinX11AndOpenGL
     else buildEnv {
-      name = "mesa";
+      name = "mesa-${mesa_noglu.version}";
       paths = [ mesa_glu mesa_noglu ];
     };
   darwinX11AndOpenGL = callPackage ../os-specific/darwin/native-x11-and-opengl { };


### PR DESCRIPTION
We had a brief discussion in https://github.com/NixOS/nixpkgs/commit/aa0fb7306430be2222aa89b88a060f80d7a023c0 and @peti suggested what I think was the best solution to the upstream split of mesa and glu.

From the (little) tests I did, it seems to work (for example, SDL GL apps do work again) and I found no more references of mesa_noglu in nixpkgs besides the wxGTK one that I already fixed.
