### PR TITLE
gnome-themes-standard: Initial expression

### DIFF
--- a/pkgs/misc/themes/gnome-themes-standard/default.nix
+++ b/pkgs/misc/themes/gnome-themes-standard/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchurl, intltool, gtk3, librsvg, pkgconfig, pango, atk, gtk2, gdk_pixbuf }:
+stdenv.mkDerivation {
+  name = "gnome-themes-standard";
+  src = fetchurl {
+    url = "http://ftp.gnome.org/pub/GNOME/sources/gnome-themes-standard/3.7/gnome-themes-standard-3.7.92.tar.xz";
+    sha256 = "0a1ed83c07f57b5b45b8f3817ca0ca14feecb56de505243c086fb306c88da8de";
+  };
+  
+  buildInputs = [ intltool gtk3 librsvg pkgconfig pango atk gtk2 gdk_pixbuf ];
+
+  preConfigure = ''
+    cat ${gdk_pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache ${librsvg}/lib/gdk-pixbuf/loaders.cache > loaders.cache
+    export GDK_PIXBUF_MODULE_FILE=`readlink -e loaders.cache`
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8595,6 +8595,8 @@ let
 
   oxygen_gtk = callPackage ../misc/themes/gtk2/oxygen-gtk { };
 
+  gnome_themes_standard = callPackage ../misc/themes/gnome-themes-standard { };
+
   xfce = xfce4_10;
   xfce4_10 = recurseIntoAttrs (import ../desktops/xfce { inherit pkgs newScope; });
 


### PR DESCRIPTION
This pull request adds the `gnome-themes-standard` expression, which provides the "Adwaita" theme for GTK.

I needed to base this on the `x-updates` branch for GTK+ 3.6.

I was unable to get this to build without manually fudging around with `loaders.cache` for GTK to be able to process both `png` and `svg` files, which feels like a massive hack. Open to suggestions on the correct way to do this!

This is also my first pull request for nixpkgs, so if I've forgotten to do something please let me know and I'll get it fixed. Thanks!
