### PR TITLE
ipython: modularize and enable more features

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -49,7 +49,7 @@ pythonPackages = python.modules // rec {
   # packages defined elsewhere
 
   ipython = import ../shells/ipython {
-    inherit (pkgs) stdenv fetchurl;
+    inherit (pkgs) stdenv fetchurl sip pyqt4;
     inherit buildPythonPackage pythonPackages;
   };
 


### PR DESCRIPTION
Add these new attributes (all default to true):

  notebookSupport
  qtconsoleSupport
  pylabSupport
  pylabQtSupport

This adds jinja2, matplotlib, pyqt4 and sip as new dependencies of
ipython.

This commit fixes "ipython --pylab" so that it no more errors out with
"ImportError: No module named matplotlib" (which was my initial goal).
