### PR TITLE
pitz: new package

### DIFF
--- a/pkgs/applications/misc/pitz/default.nix
+++ b/pkgs/applications/misc/pitz/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, buildPythonPackage, tempita, jinja2, pyyaml, clepy, mock
+, nose, decorator, docutils }:
+
+# TODO: pitz has a pitz-shell utility that depends on ipython, but it just
+# errors out and dies (it probably depends on an old ipython version):
+#
+#   from IPython.Shell import IPShellEmbed
+#   ImportError: No module named Shell
+#
+# pitz-shell is not the primary interface, so it is not critical to have it
+# working. Concider fixing pitz upstream.
+
+buildPythonPackage rec {
+  name = "pitz-1.2.4";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "http://pypi.python.org/packages/source/p/pitz/${name}.tar.gz";
+    sha256 = "1k7f3h4acllzqy3mjqnjd4w5jskp03s79b7dx3c85vlmd7824smr";
+  };
+
+  # propagatedBuildInputs is needed for pitz to find its dependencies at
+  # runtime. If we use buildInputs it would just build, not run.
+  propagatedBuildInputs = [ tempita jinja2 pyyaml clepy mock nose decorator docutils ];
+
+  meta = {
+    description = "Distributed bugtracker";
+    license = stdenv.lib.licenses.bsd3;
+    homepage = http://pitz.tplus1.com/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -58,6 +58,11 @@ pythonPackages = python.modules // rec {
     inherit python buildPythonPackage;
   };
 
+  pitz = import ../applications/misc/pitz {
+    inherit (pkgs) stdenv fetchurl;
+    inherit buildPythonPackage tempita jinja2 pyyaml clepy mock nose decorator docutils;
+  };
+
   pycairo = import ../development/python-modules/pycairo {
     inherit (pkgs) stdenv fetchurl pkgconfig cairo x11;
     inherit python;
@@ -533,6 +538,24 @@ pythonPackages = python.modules // rec {
       description = "A pythonic, object-oriented HTTP framework";
     };
   });
+
+
+  clepy = buildPythonPackage rec {
+    name = "clepy-0.3.20";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/c/clepy/${name}.tar.gz";
+      sha256 = "16vibfxms5z4ld8gbkra6dkhqm2cc3jnn0fwp7mw70nlwxnmm51c";
+    };
+
+    buildInputs = [ mock nose decorator ];
+
+    meta = {
+      homepage = http://code.google.com/p/clepy/;
+      description = "Utilities created by the Cleveland Python users group";
+    };
+  };
+
 
   clientform = buildPythonPackage (rec {
     name = "clientform-0.2.10";


### PR DESCRIPTION
pitz is a distributed bug tracker, inspired by ditz.

(The clepy python module is also added, it is a dependency of pitz.)

TODO: pitz has a pitz-shell utility that depends on ipython, but when I
enabled it it raised an exception. I think it depends on an old IPython
version:

  from IPython.Shell import IPShellEmbed
  ImportError: No module named Shell

pitz-shell is not the primary interface, it is not critical to have it
working.

There are not many distributed bug trackers out there, so I hope that
adding pitz to nixpkgs may inspire people to support pitz (or similar
software).
