### PR TITLE
lightdm: Add lightdm and lightdm-gtk-greeter

### DIFF
--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, lightdm, pkgconfig, gtk3, intltool }:
+
+stdenv.mkDerivation {
+  name = "lightdm-gtk-greeter";
+
+  src = fetchurl {
+    url = "https://launchpad.net/lightdm-gtk-greeter/1.6/1.5.1/+download/lightdm-gtk-greeter-1.5.1.tar.gz";
+    sha256 = "ecce7e917a79fa8f2126c3fafb6337f81f2198892159a4ef695016afecd2d621";
+  };
+
+  buildInputs = [ pkgconfig gtk3 lightdm intltool ];
+
+  patches =
+    [ ./lightdm-gtk-greeter.patch
+    ];
+
+  patchFlags = "-p0";
+
+  postInstall = ''
+      substituteInPlace "$out/share/xgreeters/lightdm-gtk-greeter.desktop" \
+        --replace "Exec=lightdm-gtk-greeter" "Exec=$out/sbin/lightdm-gtk-greeter"
+    '';
+}

--- a/pkgs/applications/display-managers/lightdm-gtk-greeter/lightdm-gtk-greeter.patch
+++ b/pkgs/applications/display-managers/lightdm-gtk-greeter/lightdm-gtk-greeter.patch
@@ -1,0 +1,13 @@
+=== modified file 'src/lightdm-gtk-greeter.c'
+--- src/lightdm-gtk-greeter.c	2013-02-09 23:20:39 +0000
++++ src/lightdm-gtk-greeter.c	2013-03-29 12:21:34 +0000
+@@ -1273,7 +1273,7 @@
+     gtk_cell_layout_pack_start (GTK_CELL_LAYOUT (session_combo), renderer, TRUE);
+     gtk_cell_layout_add_attribute (GTK_CELL_LAYOUT (session_combo), renderer, "text", 0);
+     model = gtk_combo_box_get_model (session_combo);
+-    items = lightdm_get_sessions ();
++    items = lightdm_get_sessions (greeter);
+     for (item = items; item; item = item->next)
+     {
+         LightDMSession *session = item->data;
+

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pam, pkgconfig, libxcb, glib, libXdmcp, itstool, libxml2, intltool, x11, libxklavier, libgcrypt, makeWrapper }:
+
+stdenv.mkDerivation {
+  name = "lightdm-1.5.1";
+
+  src = fetchurl {
+    url = https://launchpad.net/lightdm/1.6/1.5.1/+download/lightdm-1.5.1.tar.xz;
+    sha256 = "645db2d763cc514d6aecb1838f4a9c33c3dcf0c94567a7ef36c6b23d8aa56c86";
+  };
+
+  buildInputs = [ pkgconfig pam libxcb glib libXdmcp itstool libxml2 intltool libxklavier libgcrypt makeWrapper ];
+
+  configureFlags = [ "--enable-liblightdm-gobject" ];
+
+  patches =
+    [ ./lightdm.patch
+    ];
+
+  patchFlags = "-p0";
+
+  meta = {
+    homepage = http://launchpad.net/lightdm;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/display-managers/lightdm/lightdm.patch
+++ b/pkgs/applications/display-managers/lightdm/lightdm.patch
@@ -1,0 +1,193 @@
+=== modified file 'liblightdm-gobject/greeter.c'
+--- liblightdm-gobject/greeter.c	2013-01-31 20:56:09 +0000
++++ liblightdm-gobject/greeter.c	2013-03-29 14:15:58 +0000
+@@ -567,6 +567,21 @@
+ }
+ 
+ /**
++ * lightdm_greeter_get_config_path
++ * @greeter: A #LightDMGreeter
++ *
++ * Get the config path to LightDM.
++ *
++ * Return value: The path to the current LightDM configuration file.
++ **/
++const gchar *
++lightdm_greeter_get_config_path (LightDMGreeter *greeter)
++{
++    g_return_val_if_fail (LIGHTDM_IS_GREETER (greeter), NULL);
++    return lightdm_greeter_get_hint (greeter, "config-path");
++}
++
++/**
+  * lightdm_greeter_get_hide_users_hint:
+  * @greeter: A #LightDMGreeter
+  *
+
+=== modified file 'liblightdm-gobject/lightdm/greeter.h'
+--- liblightdm-gobject/lightdm/greeter.h	2013-01-31 20:56:09 +0000
++++ liblightdm-gobject/lightdm/greeter.h	2013-03-29 11:56:11 +0000
+@@ -93,6 +93,8 @@
+ 
+ const gchar *lightdm_greeter_get_autologin_user_hint (LightDMGreeter *greeter);
+ 
++const gchar *lightdm_greeter_get_config_path (LightDMGreeter *greeter);
++
+ gboolean lightdm_greeter_get_autologin_guest_hint (LightDMGreeter *greeter);
+ 
+ gint lightdm_greeter_get_autologin_timeout_hint (LightDMGreeter *greeter);
+
+=== modified file 'liblightdm-gobject/lightdm/session.h'
+--- liblightdm-gobject/lightdm/session.h	2013-01-31 20:56:09 +0000
++++ liblightdm-gobject/lightdm/session.h	2013-03-29 11:59:16 +0000
+@@ -12,6 +12,7 @@
+ #define _LIGHTDM_SESSION_H_
+ 
+ #include <glib-object.h>
++#include "greeter.h"
+ 
+ G_BEGIN_DECLS
+ 
+@@ -42,9 +43,9 @@
+ 
+ GType lightdm_session_get_type (void);
+ 
+-GList *lightdm_get_sessions (void);
++GList *lightdm_get_sessions (LightDMGreeter *greeter);
+ 
+-GList *lightdm_get_remote_sessions (void);
++GList *lightdm_get_remote_sessions (LightDMGreeter *greeter);
+ 
+ const gchar *lightdm_session_get_key (LightDMSession *session);
+ 
+
+=== modified file 'liblightdm-gobject/session.c'
+--- liblightdm-gobject/session.c	2013-01-31 20:56:09 +0000
++++ liblightdm-gobject/session.c	2013-03-29 14:16:48 +0000
+@@ -11,6 +11,7 @@
+ #include <string.h>
+ #include <gio/gdesktopappinfo.h>
+ 
++#include "lightdm/greeter.h"
+ #include "lightdm/session.h"
+ 
+ enum {
+@@ -167,7 +168,7 @@
+ }
+ 
+ static void
+-update_sessions (void)
++update_sessions (LightDMGreeter *greeter)
+ {
+     GKeyFile *config_key_file = NULL;
+     gchar *config_path = NULL;
+@@ -183,8 +184,8 @@
+     remote_sessions_dir = g_strdup (REMOTE_SESSIONS_DIR);
+ 
+     /* Use session directory from configuration */
+-    /* FIXME: This should be sent in the greeter connection */
+-    config_path = g_build_filename (CONFIG_DIR, "lightdm.conf", NULL);
++    config_path = g_strdup (lightdm_greeter_get_config_path (greeter));
++
+     config_key_file = g_key_file_new ();
+     result = g_key_file_load_from_file (config_key_file, config_path, G_KEY_FILE_NONE, &error);
+     if (error)
+@@ -228,9 +229,9 @@
+  * Return value: (element-type LightDMSession) (transfer none): A list of #LightDMSession
+  **/
+ GList *
+-lightdm_get_sessions (void)
++lightdm_get_sessions (LightDMGreeter *greeter)
+ {
+-    update_sessions ();
++    update_sessions (greeter);
+     return local_sessions;
+ }
+ 
+@@ -242,9 +243,9 @@
+  * Return value: (element-type LightDMSession) (transfer none): A list of #LightDMSession
+  **/
+ GList *
+-lightdm_get_remote_sessions (void)
++lightdm_get_remote_sessions (LightDMGreeter *greeter)
+ {
+-    update_sessions ();
++    update_sessions (greeter);
+     return remote_sessions;
+ }
+ 
+
+=== modified file 'src/display.c'
+--- src/display.c	2013-03-26 22:22:49 +0000
++++ src/display.c	2013-03-29 12:12:43 +0000
+@@ -62,6 +62,9 @@
+     /* Program to run sessions through */
+     gchar *session_wrapper;
+ 
++    /* Path to the configuration file that lightdm is running under */
++    gchar *config_path;
++
+     /* TRUE if in a user session */
+     gboolean in_user_session;
+ 
+@@ -213,6 +216,14 @@
+ }
+ 
+ void
++display_set_config_path (Display *display, const gchar *config_path)
++{
++    g_return_if_fail (display != NULL);
++    g_free (display->priv->config_path);
++    display->priv->config_path = g_strdup (config_path);
++}
++
++void
+ display_set_show_remote_login_hint (Display *display, gboolean show_remote_login)
+ {
+     g_return_if_fail (display != NULL);
+@@ -436,6 +447,7 @@
+     greeter_set_hint (display->priv->greeter, "show-remote-login", display->priv->greeter_show_remote_login ? "true" : "false");
+     if (display->priv->greeter_is_lock)
+         greeter_set_hint (display->priv->greeter, "lock-screen", "true");
++    greeter_set_hint (display->priv->greeter, "config-path", display->priv->config_path);
+ 
+     /* Run greeter as unprivileged user */
+     if (getuid () != 0)
+
+=== modified file 'src/display.h'
+--- src/display.h	2013-03-26 22:22:49 +0000
++++ src/display.h	2013-03-29 12:12:37 +0000
+@@ -80,6 +80,8 @@
+ 
+ void display_set_user_session (Display *display, SessionType type, const gchar *session_name);
+ 
++void display_set_config_path (Display *display, const gchar *config_path);
++
+ gboolean display_start (Display *display);
+ 
+ gboolean display_get_is_ready (Display *display);
+
+=== modified file 'src/lightdm.c'
+--- src/lightdm.c	2013-03-07 21:40:31 +0000
++++ src/lightdm.c	2013-03-29 11:48:45 +0000
+@@ -1050,6 +1050,7 @@
+     g_debug ("Starting Light Display Manager %s, UID=%i PID=%i", VERSION, getuid (), getpid ());
+ 
+     g_debug ("Loaded configuration from %s", config_path);
++    config_set_string (config_get_instance (), "LightDM", "config-path", config_path);
+     g_free (config_path);
+ 
+     g_debug ("Using D-Bus name %s", LIGHTDM_BUS_NAME);
+
+=== modified file 'src/seat.c'
+--- src/seat.c	2013-03-26 22:22:49 +0000
++++ src/seat.c	2013-03-29 12:13:00 +0000
+@@ -536,6 +536,7 @@
+     if (!session_name)
+         session_name = seat_get_string_property (seat, "user-session");
+     display_set_user_session (display, SESSION_TYPE_LOCAL, session_name);
++    display_set_config_path (display, config_get_string (config_get_instance (), "LightDM", "config-path"));
+ 
+     seat->priv->displays = g_list_append (seat->priv->displays, display);
+     g_signal_emit (seat, signals[DISPLAY_ADDED], 0, display);
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7739,6 +7739,10 @@ let
 
   dropbox = callPackage ../applications/networking/dropbox { };
 
+  lightdm = callPackage ../applications/display-managers/lightdm { };
+
+  lightdm_gtk_greeter = callPackage ../applications/display-managers/lightdm-gtk-greeter { };
+
   slim = callPackage ../applications/display-managers/slim { };
 
   sndBase = builderDefsPackage (import ../applications/audio/snd) {


### PR DESCRIPTION
Adds the [LightDM](http://launchpad.net/lightdm) display and login manager, along with the [LightDM GTK Greeter](http://launchpad.net/lightdm-gtk-greeter). A few patches are needed to get things running without any manual intervention - which is just the normal fuss about hard-coded directories. I haven't yet submitted these patches upstream, but plan to.
