### PR TITLE
Add xf86videodummy and xf86inputvoid to xorg overrides (pixman fix)

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -153,6 +153,11 @@ in
     installFlags = "sdkdir=\${out}/include/xorg configdir=\${out}/include/xorg";
   };
 
+  xf86inputvoid = attrs: attrs // {
+    NIX_CFLAGS_COMPILE = "-I${xorg.pixman}/include/pixman-1";
+    buildInputs = attrs.buildInputs ++ [xorg.pixman];
+  };
+
   xf86videointel = attrs: attrs // {
     buildInputs = attrs.buildInputs ++ [xorg.glproto args.mesa];
   };
@@ -168,6 +173,11 @@ in
   };
 
   xf86videocirrus = attrs: attrs // {
+    NIX_CFLAGS_COMPILE = "-I${xorg.pixman}/include/pixman-1";
+    buildInputs = attrs.buildInputs ++ [xorg.pixman];
+  };
+
+  xf86videodummy = attrs: attrs // {
     NIX_CFLAGS_COMPILE = "-I${xorg.pixman}/include/pixman-1";
     buildInputs = attrs.buildInputs ++ [xorg.pixman];
   };


### PR DESCRIPTION
Now xf86videodummy and xf86inputvoid compiles and we can run dummy xorgserver as non root user (usefull for vnc, xpra, nx,...)
