### PR TITLE
Add sha256 hash to winetricks.

### DIFF
--- a/pkgs/misc/emulators/wine/winetricks.nix
+++ b/pkgs/misc/emulators/wine/winetricks.nix
@@ -7,6 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchsvn {
     url = "http://winetricks.googlecode.com/svn/trunk";
     inherit rev;
+    sha256 = "01v13qw4sxmfm09g9amqycnzy743gdrhvv23rjr9255dzlrj1s8f";
   };
 
   buildInputs = [ perl which ];


### PR DESCRIPTION
This patch adds the correct hash to the winetricks nix-pkg.
