### PR TITLE
Upgrade kicad to stable 20130325

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,18 +1,18 @@
-{stdenv, fetchurl, fetchbzr, unzip, cmake, mesa, wxGTK, zlib, libX11,
-gettext}:
+{ stdenv, fetchurl, fetchbzr, unzip, cmake, mesa, gtk, wxGTK, zlib, libX11, 
+gettext, cups } : 
 
 stdenv.mkDerivation rec {
-  name = "kicad-20110708";
+  name = "kicad-20130325";
 
   src = fetchurl {
-    url = ftp://iut-tice.ujf-grenoble.fr/cao/sources/kicad_sources-2011-07-08-BZR3044.zip;
-    sha256 = "1gr75zcf55p3xpbg1gdkdpbh5x11bawc9rcff4fskwjyc3vfiv6a";
+    url = "http://iut-tice.ujf-grenoble.fr/cao/kicad-sources-stable_2013-03-25_BZR4005.zip";
+    sha256 = "0hg2aiis14am7mmpimcxnxvhy7c7fr5rgzlk6rjv44d9m0f9957m";
   };
 
   srcLibrary = fetchbzr {
     url = "http://bazaar.launchpad.net/~kicad-lib-committers/kicad/library";
-    revision = 112;
-    sha256 = "49fa9ad90759cfaf522c2a62665f033688b9d84d02f31c6b2505c08a217ad312";
+    revision = 220;
+    sha256 = "0l2lblgnm51n2w1p4ifpwdvq04rxgq73zrfxlhqa9zdlyh4rcddb";
   };
 
   cmakeFlags = "-DKICAD_TESTING_VERSION=ON";

--- a/pkgs/build-support/fetchbzr/builder.sh
+++ b/pkgs/build-support/fetchbzr/builder.sh
@@ -4,6 +4,6 @@ header "exporting \`$url' (revision $revision) into \`$out'"
 
 # Perform a lightweight checkout so that we don't end up importing
 # all the repository's history.
-bzr checkout --lightweight "$url" -r "$revision" "$out"
+bzr -Ossl.cert_reqs=none export -r "$revision" --format=dir "$out" "$url"
 
 stopNest

--- a/pkgs/build-support/fetchbzr/nix-prefetch-bzr
+++ b/pkgs/build-support/fetchbzr/nix-prefetch-bzr
@@ -50,12 +50,7 @@ if test -z "$finalPath"; then
     trap "rm -rf $tmpPath" EXIT
 
     # Perform the checkout.
-    if test "$NIX_PREFETCH_BZR_LEAVE_DOT_BZR" != 1
-    then
-        bzr export $revarg "$tmpFile" "$url" >&2
-    else
-        bzr checkout --lightweight $revarg "$url" "$tmpFile" >&2
-    fi
+    bzr -Ossl.cert_reqs=none export $revarg --format=dir "$tmpFile" "$url"
 
     # Compute the hash.
     hash=$(nix-hash --type $hashType $hashFormat $tmpFile)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8758,7 +8758,9 @@ let
 
   gtkwave = callPackage ../applications/science/electronics/gtkwave { };
 
-  kicad = callPackage ../applications/science/electronics/kicad { };
+  kicad = callPackage ../applications/science/electronics/kicad {
+    wxGTK = wxGTK29;
+  };
 
   ngspice = callPackage ../applications/science/electronics/ngspice { };
 


### PR DESCRIPTION
- upgrade kicad to stable 20130325, and kicad library to r220
- have kicad depend on wxGTK29 and cups -- prevents build errors
- changed fetchbzr to export only (only use is for kicad library)
- removed keep-dot-files option from nix-fetch-bzr (only use is for kicad
  library)
- have fetchbzr and nix-fetch-bzr ignore SSL certificates
