### PR TITLE
lighttpd: bump to version 1.4.32

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pcre, libxml2, zlib, attr, bzip2 }:
+{ stdenv, fetchurl, pcre, libxml2, zlib, attr, bzip2, which, file }:
 
 stdenv.mkDerivation {
   name = "lighttpd-1.4.32";
@@ -8,7 +8,11 @@ stdenv.mkDerivation {
     sha256 = "1hgd9bi4mrak732h57na89lqg58b1kkchnddij9gawffd40ghs0k";
   };
 
-  buildInputs = [ pcre libxml2 zlib attr bzip2 ];
+  buildInputs = [ pcre libxml2 zlib attr bzip2 which file ];
+
+  preConfigure = ''
+    sed -i "s:/usr/bin/file:${file}/bin/file:g" configure
+  '';
 
   meta = {
     description = "Lightweight high-performance web server";

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pcre, libxml2, zlib, attr, bzip2 }:
 
 stdenv.mkDerivation {
-  name = "lighttpd-1.4.30";
+  name = "lighttpd-1.4.32";
 
   src = fetchurl {
-    url = http://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-1.4.30.tar.xz;
-    sha256 = "c237692366935b19ef8a6a600b2f3c9b259a9c3107271594c081a45902bd9c9b";
+    url = http://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-1.4.32.tar.xz;
+    sha256 = "1hgd9bi4mrak732h57na89lqg58b1kkchnddij9gawffd40ghs0k";
   };
 
   buildInputs = [ pcre libxml2 zlib attr bzip2 ];


### PR DESCRIPTION
One important denial of service (in 1.4.31) fix: CVE-2012-5533[1].

NOTE: There are some errors about missing commands during the build, but
I'm pretty sure they were there before. And the result seems to be
working anyway...
- /usr/bin/file: No such file or directory
- /bin/sh: line 2: which: command not found
- /tmp/nix-build-lighttpd-1.4.32.drv-0/lighttpd-1.4.32/libtool: line 1085: ldconfig: command not found

[1] http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-5533
