### PR TITLE
tig: enable bash completion

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/tig/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/tig/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     make install
     make install-doc
+    mkdir -p $out/etc/bash_completion.d/
+    cp contrib/tig-completion.bash $out/etc/bash_completion.d/
   '';
   meta = {
     homepage = "http://jonas.nitro.dk/tig/";


### PR DESCRIPTION
Copy the bash completion script that comes with tig to
$out/etc/bash_completion.d/.

Note: to enable bash completion in NixOS, set
environment.enableBashCompletion = true;
