### PR TITLE
racket: enable HTML docs

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, cairo, file, pango, glib, gtk
 , which, libtool, makeWrapper, libjpeg, libpng
-, fontconfig, liberation_ttf } :
+, fontconfig, liberation_ttf, sqlite } :
 
 stdenv.mkDerivation rec {
   pname = "racket";
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
   };
 
   # Various racket executables do run-time searches for these.
-  ffiSharedLibs = "${glib}/lib:${cairo}/lib:${pango}/lib:${gtk}/lib:${libjpeg}/lib:${libpng}/lib";
+  ffiSharedLibs = "${glib}/lib:${cairo}/lib:${pango}/lib:${gtk}/lib:${libjpeg}/lib:${libpng}/lib:${sqlite}/lib";
 
-  buildInputs = [ file libtool which makeWrapper fontconfig liberation_ttf ];
+  buildInputs = [ file libtool which makeWrapper fontconfig liberation_ttf sqlite ];
 
   preConfigure = ''
     export LD_LIBRARY_PATH=${ffiSharedLibs}:$LD_LIBRARY_PATH


### PR DESCRIPTION
racket-3.3.3 has been updated, to build and install the HTML documentation from the Scribble sources, during the install phase.

The patch has been provided by Karn Kallio tierpluspluslists@gmail.com
