### PR TITLE
(Does not work yet) Build wxMac 2.8.12 on OS X Snow Leopard (10.6.8).

### DIFF
--- a/pkgs/os-specific/darwin/wxMac/default.nix
+++ b/pkgs/os-specific/darwin/wxMac/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, darwinX11AndOpenGL }:
+
+assert stdenv.isDarwin;
+
+stdenv.mkDerivation rec {
+  name = "wxMac-${version}";
+  version = "2.8.12";
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/wxwindows/${version}/${name}.tar.gz";
+    sha256 = "11qzcbx5kpl22jirfjbjzaax488r1ar2qiw8q7yz7r45b2y1x7gx";
+  };
+
+  buildInputs = [ darwinX11AndOpenGL ];
+  preConfigure = ''
+    export arch_flags="-arch i386"
+  '';
+  configureFlags = ''
+    --enable-unicode --enable-debug --disable-shared
+    --with-expat
+    --enable-display
+    --with-opengl
+    --with-libjpeg
+    --with-libtiff
+    --with-libpng
+    --with-zlib
+    --enable-dnd
+    --enable-clipboard
+    --enable-webkit
+    --enable-svg
+    --enable-std_string
+    --with-osx_carbon
+    --with-macosx-sdk=/Developer/SDKs/MacOSX10.6.sdk
+    --with-macosx-version-min=10.6
+  '';
+
+  meta = {
+    description = "Cross-Platform GUI Library";
+    homepage = "http://www.wxwidgets.org";
+    maintainers = [ stdenv.lib.maintainers.garbas ];
+    license = "wxWindows Licence";
+    platforms = stdenv.lib.platforms.darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4593,6 +4593,10 @@ let
 
   darwinX11AndOpenGL = callPackage ../os-specific/darwin/native-x11-and-opengl { };
 
+  wxMac = callPackage ../os-specific/darwin/wxMac {
+    stdenv = overrideGCC stdenv gccApple;
+  };
+
   mesa = if stdenv.isDarwin then darwinX11AndOpenGL else
     callPackage ../development/libraries/mesa { };
 


### PR DESCRIPTION
I need some assistance.  It would be desirable to have wxPython for Mac OS X (and other platforms) from Nix, since Apple's policies over the last few years have made it nearly impossible to run applications that require it.

With this recipe I am trying to build wxMac (a dependency of wxPython) version 2.8.12 for Snow Leopard (specifically 10.6.8).

The error produced by the current recipe is:

```
checking if std::basic_string<wchar_t> works... no
configure: error: Can't use --enable-std_string without std::wstring or std::basic_string<wchar_t>
note: keeping build directory `/private/var/folders/3k/3kZI+NsbGHywjqA73FwFE++++TI/-Tmp-/nix-build-wxMac-2.8.12.drv-74'
builder for `/nix/store/bjv0lmvxr0aqj1y5p6jwywlg3xz8sm82-wxMac-2.8.12.drv' failed with exit code 1
error: build of `/nix/store/bjv0lmvxr0aqj1y5p6jwywlg3xz8sm82-wxMac-2.8.12.drv' failed
```

This error is triggered by adding the flag `--enable-std_string`, without which the configuration completes, but the compilation of `wxregex_regcomp.o` fails when it can't include `stdarg.h`.

[This page](http://www.wxwidgets.org/docs/faqmac.htm#buildx) suggests following the instructions in docs/osx/install.txt of wxMac, and doing:

```
arch_flags="-arch i386"
../configure CFLAGS="$arch_flags" CXXFLAGS="$arch_flags" CPPFLAGS="$arch_flags" LDFLAGS="$arch_flags" OBJCFLAGS="$arch_flags" OBJCXXFLAGS="$arch_flags" --enable-unicode --enable-debug --disable-shared
```

I found that setting the various `CFLAGS`, `CXXFLAGS`, etc, in `configureFlags` causes all kinds of problems, and does not seem to be necessary, since the resulting config.log shows that the desired architecture is detected automatically, although I'm not sure about that:

```
configure:1725: checking build system type
configure:1743: result: i686-apple-darwin10.8.0
configure:1751: checking host system type
configure:1765: result: i686-apple-darwin10.8.0
configure:1773: checking target system type
configure:1787: result: i686-apple-darwin10.8.0
```

(I am running a MacBook Pro with Intel Core 2 Duo, so it is a 64 bit system).

[This page](http://wiki.wxwidgets.org/Development:_wxMac#Building_under_10.6_Snow_Leopard) has similar advice.
