### PR TITLE
make ORBit2 build again by disabling deprecation warnings for linc2, the...

### DIFF
--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0l3mhpyym9m5iz09fz0rgiqxl2ym6kpkwpsp1xrr4aa80nlh1jam";
   };
 
+  preBuild = ''
+    sed 's/-DG_DISABLE_DEPRECATED//' -i linc2/src/Makefile
+  '';
+
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib libIDL ];
 }


### PR DESCRIPTION
... commit introducing it didn't show any strong reason
