### PR TITLE
premake: bump to version 4.3

### DIFF
--- a/pkgs/development/libraries/aacskeys/default.nix
+++ b/pkgs/development/libraries/aacskeys/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, openssl, jdk, premake}:
+{stdenv, fetchurl, openssl, jdk, premake3}:
 
 # Info on how to use / obtain aacs keys:
 # http://vlc-bluray.whoknowsmy.name/
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     sha256 = "0d3zvwixpkixfkkc16wj37h2xbcq5hsqqhqngzqr6pslmqr67vnr";
   };
 
-  buildInputs = [openssl jdk premake];
+  buildInputs = [openssl jdk premake3];
 
   installPhase = ''
     ensureDir $out/{bin,lib,share/${baseName}}

--- a/pkgs/development/tools/misc/premake/3.nix
+++ b/pkgs/development/tools/misc/premake/3.nix
@@ -1,25 +1,21 @@
 {stdenv, fetchurl, unzip}:
 
 let baseName = "premake";
-  version  = "4.3";
+  version  = "3.7";
 in
 
 stdenv.mkDerivation {
   name = "${baseName}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${baseName}/${baseName}-${version}-src.zip";
-    sha256 = "1017rd0wsjfyq2jvpjjhpszaa7kmig6q1nimw76qx3cjz2868lrn";
+    url = "http://downloads.sourceforge.net/sourceforge/premake/${baseName}-src-${version}.zip";
+    sha256 = "b59841a519e75d5b6566848a2c5be2f91455bf0cc6ae4d688fcbd4c40db934d5";
   };
 
   buildInputs = [unzip];
 
-  buildPhase = ''
-    make -C build/gmake.unix/
-  '';
-
   installPhase = ''
-    install -Dm755 bin/release/premake4 $out/bin/premake4
+    install -Dm755 bin/premake $out/bin/premake
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3304,7 +3304,11 @@ let
   pkgconfig = forceNativeDrv (callPackage ../development/tools/misc/pkgconfig { });
   pkgconfigUpstream = lowPrio (pkgconfig.override { vanilla = true; });
 
-  premake = callPackage ../development/tools/misc/premake { };
+  premake3 = callPackage ../development/tools/misc/premake/3.nix { };
+
+  premake4 = callPackage ../development/tools/misc/premake { };
+
+  premake = premake4;
 
   pstack = callPackage ../development/tools/misc/gdb/pstack.nix { };
 


### PR DESCRIPTION
aacskeys depends on premake3, so keep that version around.

The premake4 source can be built with a few different build systems and platforms. Here is the list (from premake4/build/):

codeblocks.macosx
codeblocks.unix
codeblocks.windows
codelite.macosx
codelite.unix
codelite.windows
gmake.macosx
gmake.unix
gmake.windows
vs2005
vs2008
vs2010
xcode3

Since nixpkgs runs on more than Linux, I'm not sure how to handle this. This is what I've done for the buildPhase as of now:

buildPhase = ''make -C build/gmake.unix/"

Is this ok? At least for now?

premake3 just had a top-level makefile :-)
