### PR TITLE
Add cleanupCmds option to pkgs.myEnvFun

### DIFF
--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -59,7 +59,7 @@
 { mkDerivation, substituteAll, pkgs }:
     { stdenv ? pkgs.stdenv, name, buildInputs ? []
     , propagatedBuildInputs ? [], gcc ? stdenv.gcc, cTags ? [], extraCmds ? ""
-    , shell ? "${pkgs.bashInteractive}/bin/bash"}:
+    , cleanupCmds ? "", shell ? "${pkgs.bashInteractive}/bin/bash"}:
 
 mkDerivation {
   # The setup.sh script from stdenv will expect the native build inputs in
@@ -133,8 +133,15 @@ mkDerivation {
       fi
       rm -fr "\$tmp"
       ${extraCmds}
+
+      nix_cleanup() {
+        ${cleanupCmds}
+      }
+
       export PATH
       echo $name loaded
+
+      trap nix_cleanup EXIT
     EOF
 
     mkdir -p $out/bin

--- a/pkgs/misc/my-env/loadenv.sh
+++ b/pkgs/misc/my-env/loadenv.sh
@@ -10,4 +10,5 @@ export buildInputs
 export NIX_STRIP_DEBUG=0
 export TZ="$OLDTZ"
 
-exec @shell@ --norc
+@shell@ --norc
+


### PR DESCRIPTION
This option allows the user to specify commands to run when the shell
exits. This can be used to cleanup operations done in `extraCmds'.

Please notice that the 'trap' approach required me to remove the `exec' in front of @shell@ in loadenv.sh. I don't think this is a problem, but it might be for special use cases.
