### PR TITLE
git: fix gitweb.cgi runtime dependency on gzip

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -10,7 +10,7 @@ rec {
   git = lib.makeOverridable (import ./git) {
     inherit fetchurl stdenv curl openssl zlib expat perl python gettext gnugrep
       asciidoc texinfo xmlto docbook2x docbook_xsl docbook_xml_dtd_45 libxslt
-      cpio tcl tk makeWrapper subversionClient hardlink;
+      cpio tcl tk makeWrapper subversionClient hardlink gzip;
     svnSupport = false;		# for git-svn support
     guiSupport = false;		# requires tcl/tk
     sendEmailSupport = false;	# requires plenty of perl libraries

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, curl, openssl, zlib, expat, perl, python, gettext, cpio, gnugrep
+{ fetchurl, stdenv, curl, openssl, zlib, expat, perl, python, gettext, cpio, gnugrep, gzip
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
 , libxslt, tcl, tk, makeWrapper, hardlink
 , svnSupport, subversionClient, perlLibs, smtpPerlLibs
@@ -66,6 +66,11 @@ stdenv.mkDerivation {
       sed -i -e 's|	perl -ne|	${perl}/bin/perl -ne|g' \
              -e 's|	perl -e|	${perl}/bin/perl -e|g' \
              $out/libexec/git-core/{git-am,git-submodule}
+
+      # gzip (and optionally bzip2, xz, zip) are a runtime dependencies for
+      # gitweb.cgi, need to patch so that it's found
+      sed -i -e "s|'compressor' => \['gzip'|'compressor' => ['${gzip}/bin/gzip'|" \
+          $out/share/gitweb/gitweb.cgi
     ''
 
    + (if svnSupport then


### PR DESCRIPTION
gitweb.cgi uses gzip for creating "snapshots". Without this patch it
doesn't work.
