### PR TITLE
offlineimap: enable support for the sqlite status backend

### DIFF
--- a/pkgs/tools/networking/offlineimap/default.nix
+++ b/pkgs/tools/networking/offlineimap/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, fetchurl, buildPythonPackage }:
+{ pkgs, fetchurl, buildPythonPackage, sqlite3 }:
 
 buildPythonPackage rec {
   version = "6.5.5-rc2";
@@ -11,6 +11,10 @@ buildPythonPackage rec {
   };
 
   doCheck = false;
+
+  propagatedBuildInputs = [
+    sqlite3
+  ];
 
   meta = {
     description = "OfflineImap synchronizes emails between two repositories, so that you can read the same mailbox from multiple computers.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1296,7 +1296,9 @@ let
 
   odt2txt = callPackage ../tools/text/odt2txt { };
 
-  offlineimap = callPackage ../tools/networking/offlineimap { };
+  offlineimap = callPackage ../tools/networking/offlineimap {
+    inherit (pythonPackages) sqlite3;
+  };
 
   opendbx = callPackage ../development/libraries/opendbx { };
 


### PR DESCRIPTION
... for it speeds things up considerably. if preferred i would also be able to add it as an option.

enabling doesn't change the behaviour of offlineimap at once. instead it has to be activated in the configuration file .offlineimaprc by an entry of "status_backend = sqlite" in the account section.
