### PR TITLE
notmuch: patch source to use full path of gpg2

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, bash, emacs, gdb, glib, gmime, gnupg1,
+{ fetchurl, stdenv, bash, emacs, gdb, glib, gmime, gnupg,
   pkgconfig, talloc, xapian
 }:
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "03cwylm0y9xld0hn753v0hn62f96nagdmzxv8jlz8vdbh9iszs56";
   };
 
-  buildInputs = [ bash emacs gdb glib gmime gnupg1 pkgconfig talloc xapian ];
+  buildInputs = [ bash emacs gdb glib gmime gnupg pkgconfig talloc xapian ];
 
   patchPhase = ''
     (cd test && for prg in \
@@ -55,6 +55,14 @@ stdenv.mkDerivation rec {
       substituteInPlace "$prg" \
         --replace "#!/usr/bin/env bash" "#!${bash}/bin/bash"
     done)
+
+    for src in \
+      crypto.c \
+      emacs/notmuch-crypto.el
+    do
+      substituteInPlace "$src" \
+        --replace \"gpg\" \"${gnupg}/bin/gpg2\"
+    done
   '';
 
   # XXX: emacs tests broken


### PR DESCRIPTION
gets rid of the dependency on the old gnupg1. and enables decryption
even if the gpg binary is not in the users environment.

warning: i don't know whether the switch from gnupg1 to gnupg
introduces any incompatibilities.

if i interpret https://bugzilla.redhat.com/show_bug.cgi?id=555056#c2 correctly, then fedora effectively is using gpg2 to provide gpg as well as gpg2 by now. and we should be safe to do the same. debian on the other hand still keeps gnupg1 as a dependency of gmime.

any thoughts on this?
