### PR TITLE
Lighttpd: Enable SSL

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pcre, libxml2, zlib, attr, bzip2, which, file }:
+{ stdenv, fetchurl, pcre, libxml2, zlib, attr, bzip2, which, file, openssl }:
 
 stdenv.mkDerivation {
   name = "lighttpd-1.4.32";
@@ -8,7 +8,9 @@ stdenv.mkDerivation {
     sha256 = "1hgd9bi4mrak732h57na89lqg58b1kkchnddij9gawffd40ghs0k";
   };
 
-  buildInputs = [ pcre libxml2 zlib attr bzip2 which file ];
+  buildInputs = [ pcre libxml2 zlib attr bzip2 which file openssl ];
+
+  configureFlags = "--with-openssl --with-openssl-libs=${openssl}";
 
   preConfigure = ''
     sed -i "s:/usr/bin/file:${file}/bin/file:g" configure


### PR DESCRIPTION
With this patch support for SSL is compiled into lighttpd.

IMO encryption is in most use cases important, therefore SSL support should be build in. This would simplify the setup of a standard web application a lot.

SSL support of lighttpd is documented at  http://redmine.lighttpd.net/projects/1/wiki/Docs_SSL
