### PR TITLE
Python-gobject update to 3.0.4, for bluez-simple-agent to work

### DIFF
--- a/pkgs/development/python-modules/pygobject/default.nix
+++ b/pkgs/development/python-modules/pygobject/default.nix
@@ -1,24 +1,16 @@
-{ stdenv, fetchurl, python, pkgconfig, glib }:
+{ stdenv, fetchurl, python, pkgconfig, glib, gobjectIntrospection, pycairo, cairo }:
 
 stdenv.mkDerivation rec {
-  name = "pygobject-2.28.6";
+  name = "pygobject-3.0.4";
   
   src = fetchurl {
-    url = "http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/${name}.tar.xz";
-    sha256 = "1f5dfxjnil2glfwxnqr14d2cjfbkghsbsn8n04js2c2icr7iv2pv";
+    url = "http://ftp.gnome.org/pub/GNOME/sources/pygobject/3.0/${name}.tar.xz";
+    sha256 = "f457b1d7f6b8bfa727593c3696d2b405da66b4a8d34cd7d3362ebda1221f0661";
   };
 
   configureFlags = "--disable-introspection";
 
-  buildInputs = [ python pkgconfig glib ];
-
-  # in a "normal" setup, pygobject and pygtk are installed into the
-  # same site-packages: we need a pth file for both. pygtk.py would be
-  # used to select a specific version, in our setup it should have no
-  # effect, but we leave it in case somebody expects and calls it.
-  postInstall = ''
-    mv $out/lib/${python.libPrefix}/site-packages/{pygtk.pth,${name}.pth}
-  '';
+  buildInputs = [ python pkgconfig glib gobjectIntrospection pycairo cairo ];
 
   meta = {
     homepage = http://live.gnome.org/PyGObject;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -87,8 +87,8 @@ pythonPackages = python.modules // rec {
   };
 
   pygobject = import ../development/python-modules/pygobject {
-    inherit (pkgs) stdenv fetchurl pkgconfig glib;
-    inherit python;
+    inherit (pkgs) stdenv fetchurl pkgconfig glib gobjectIntrospection cairo;
+    inherit python pycairo;
   };
 
   pygtk = import ../development/python-modules/pygtk {


### PR DESCRIPTION
This makes 'bluez' python programs work (they import gi.repository, iirc), like bluez-simple-agent. But I don't know if it breaks things.

bluez-simple-agent is what I use to authenticate bluetooth devices, so for me it is important to have it working.

It'd be nice if some python maintainer could take a look; if it breaks things, we can have two pygobject.
