### PR TITLE
systemd: patch hardcoded "/bin/cat" in systemd-cat

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     ''
       # FIXME: patch this in systemd properly (and send upstream).
       # FIXME: use sulogin from util-linux once updated.
-      for i in src/remount-fs/remount-fs.c src/core/mount.c src/core/swap.c src/fsck/fsck.c units/emergency.service.in units/rescue.service.m4.in; do
+      for i in src/remount-fs/remount-fs.c src/core/mount.c src/core/swap.c src/fsck/fsck.c units/emergency.service.in units/rescue.service.m4.in src/journal/cat.c; do
         test -e $i
         substituteInPlace $i \
           --replace /bin/mount ${utillinux}/bin/mount \
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
           --replace /sbin/swapoff ${utillinux}/sbin/swapoff \
           --replace /sbin/fsck ${utillinux}/sbin/fsck \
           --replace /bin/echo ${coreutils}/bin/echo \
+          --replace /bin/cat ${coreutils}/bin/cat \
           --replace /sbin/sulogin ${sysvtools}/sbin/sulogin
       done
 


### PR DESCRIPTION
Without this patch, systemd-cat doesn't work here:

$ echo "hello world" | systemd-cat
Failed to execute process: No such file or directory
