### PR TITLE
lftp: use a download location that keeps old versions around

### DIFF
--- a/pkgs/tools/networking/lftp/default.nix
+++ b/pkgs/tools/networking/lftp/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "lftp-4.4.5";
 
   src = fetchurl {
-    url = "ftp://ftp.cs.tu-berlin.de/pub/net/ftp/lftp/${name}.tar.xz";
+    url = "ftp://ftp.tuwien.ac.at/infosys/browsers/ftp/lftp/${name}.tar.xz";
     sha256 = "1p3nxsd2an9pdwc3vgwxy8p5nnjrc7mhilikjaddy62cyvxdbpxq";
   };
 


### PR DESCRIPTION
This changes the mirror for LFTP from ftp://ftp.cs.tu-berlin.de/pub/net/ftp/lftp/ to ftp://ftp.tuwien.ac.at/infosys/browsers/ftp/lftp/. The old mirror only had the latest version of lftp and would break every time a new version was released.
