### PR TITLE
stlink: new package

### DIFF
--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, autoconf, automake, libtool, pkgconfig, libusb1 }:
+
+# IMPORTANT: You need permissions to access the stlink usb devices. Here are
+# example udev rules for stlink v1 and v2 so you don't need to have root
+# permissions (copied from <stlink>/49-stlink*.rules):
+#
+# SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3744", MODE:="0666", SYMLINK+="stlinkv1_%n"
+# SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", MODE:="0666", SYMLINK+="stlinkv2_%n"
+
+stdenv.mkDerivation {
+  name = "stlink-git20130306";
+
+  src = fetchgit {
+    url = git://github.com/texane/stlink.git;
+    rev = "5be889e3feb75fc7f594012c4855b4dc16940050";
+  };
+
+  buildInputs = [ autoconf automake libtool pkgconfig libusb1 ];
+  preConfigure = "./autogen.sh";
+
+  meta = {
+    description = "In-circuit debug and programming for ST-Link devices";
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5014,6 +5014,8 @@ let
     inherit readline ncurses;
   });
 
+  stlink = callPackage ../development/tools/misc/stlink { };
+
   stlport = callPackage ../development/libraries/stlport { };
 
   strigi = callPackage ../development/libraries/strigi {};


### PR DESCRIPTION
stlink is an in-circuit debugging and programming tool for ST-Link v1
and v2 devices. It is similar to OpenOCD but just for ST-Link devices.

  https://github.com/texane/stlink

IMPORTANT: You need permissions to access the stlink usb devices. Here
are example udev rules for stlink v1 and v2 so you don't need to have
root permissions (copied from <stlink>/49-stlink*.rules):

  SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3744", MODE:="0666", SYMLINK+="stlinkv1_%n"
  SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", MODE:="0666", SYMLINK+="stlinkv2_%n"
