### PR TITLE
mirrors.nix: add http://backpan.perl.org/ for old CPAN modules

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -154,6 +154,7 @@ rec {
     ftp://ftp.nl.uu.net/pub/CPAN/
     http://ftp.funet.fi/pub/CPAN/
     http://cpan.perl.org/
+    http://backpan.perl.org/  # for old releases
   ];
 
   # Debian.


### PR DESCRIPTION
It seems only the latest version of perl modules are in CPAN(?). The
BackPan claims to have a complete history of CPAN.
