### PR TITLE
Set default kernel to 3.8

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6072,7 +6072,7 @@ let
 
   # The current default kernel / kernel modules.
   linux = linuxPackages.kernel;
-  linuxPackages = linuxPackages_3_2;
+  linuxPackages = linuxPackages_3_8;
 
   # A function to build a manually-configured kernel
   linuxManualConfig = import ../os-specific/linux/kernel/manual-config.nix {


### PR DESCRIPTION
Following discussion from https://github.com/NixOS/nixos/issues/157, is anything stopping us from upgrading default kernel to 3.8?
