### PR TITLE
pstree: version bump from 2.33 to 2.36

### DIFF
--- a/pkgs/applications/misc/pstree/default.nix
+++ b/pkgs/applications/misc/pstree/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pstree-2.33";
+  name = "pstree-2.36";
 
   src = fetchurl {
     url = "http://www.sfr-fresh.com/unix/misc/${name}.tar.gz";
-    sha256 = "1469lrhpy6wghlvbjx6lmvh27rakq00x11cpz4n965fg11i121hg";
+    sha256 = "1vx4fndmkkx3bmcv71rpzjjbn24hlfs10pl99dsfhbx16a2d41cx";
   };
 
   unpackPhase = "unpackFile \$src; sourceRoot=.";


### PR DESCRIPTION
tarball for 2.33 is no longer downloadable.

changelog (excerpt from pstree.c):
- Revision 2.36  2013-04-12 11:47:03+02  fred
- Some processes like apache under a recent Linux were listed with UID
- root instead of the correct UID, as they use setuid(). We now read the
- UID from the owner of /proc/PID instead of /proc/PID/stat, as this
- seems to be updated correctly. Thanks to Tom Schmidt
- <tschmidt AT micron.com> for pointing out this bug.
- Revision 2.35  2013-02-28 08:33:02+01  fred
- Added Stan Sieler's fix to my adaption of snprintf fix by Stan Sieler :-)
- Revision 2.34  2013-02-27 16:57:25+01  fred
- Added snprintf fix by Stan Sieler
