### PR TITLE
byobu 5.37 integration

### DIFF
--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "byobu-5.37";
+
+  src = fetchurl {
+    url = "https://launchpad.net/byobu/trunk/5.37/+download/byobu_5.37.orig.tar.gz";
+    sha256 = "e9fec9c03ebdfbeb42d08e8e7a7e45d873e1a5d5f7984a39793e37fe7cc30688";
+  };
+
+  doCheck = true;
+
+  meta = {
+    homepage = https://launchpad.net/byobu/;
+    description = "Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.";
+
+    longDescription =
+      ''Byobu is a GPLv3 open source text-based window manager and terminal multiplexer. 
+        It was originally designed to provide elegant enhancements to the otherwise functional, 
+        plain, practical GNU Screen, for the Ubuntu server distribution. 
+        Byobu now includes an enhanced profiles, convenient keybindings, 
+        configuration utilities, and toggle-able system status notifications for both 
+        the GNU Screen window manager and the more modern Tmux terminal multiplexer, 
+        and works on most Linux, BSD, and Mac distributions.
+      '';
+
+    license = stdenv.lib.licenses.gpl3;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.qknight ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -494,6 +494,8 @@ let
 
   btrfsProgs = callPackage ../tools/filesystems/btrfsprogs { };
 
+  byobu = callPackage ../tools/misc/byobu { };
+
   catdoc = callPackage ../tools/text/catdoc { };
 
   dlx = callPackage ../misc/emulators/dlx { };


### PR DESCRIPTION
added byobu (a screen replacemnt) which i find better than tmux as i can now type:
    byobu
    du -a /
    (hit ctrl+c) after a while
    and then i can use the konsole or shift+pgup to scrollback

in screen i had to use the ctrl+a pgup and to select text spanning more than 25 lines of the screen teriminal was usually a pain.
