### PR TITLE
Spyder: add dependencies to make it more full-featured and make desktop item

### DIFF
--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, buildPythonPackage
+{ stdenv, fetchurl, unzip, buildPythonPackage, makeDesktopItem
 # mandatory
 , pyside
 # recommended
@@ -22,6 +22,25 @@ buildPythonPackage rec {
 
   # There is no test for spyder
   doCheck = false;
+
+  desktopItem = makeDesktopItem {
+    name = "Spyder";
+    exec = "spyder";
+    icon = "spyder";
+    comment = "Scientific Python Development Environment";
+    desktopName = "Spyder";
+    genericName = "Python IDE";
+    categories = "Application;Development;Editor;IDE;";
+  };
+
+  # Create desktop item
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp $desktopItem/share/applications/* $out/share/applications/
+
+    mkdir -p $out/share/icons
+    cp spyderlib/images/spyder.svg $out/share/icons/
+  '';
 
   meta = {
     description = "Scientific PYthon Development EnviRonment (SPYDER)";

--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, fetchurl, buildPythonPackage, unzip, sphinx, pyside }:
+{ stdenv, fetchurl, unzip, buildPythonPackage
+# mandatory
+, pyside
+# recommended
+, pyflakes ? null, rope ? null, sphinx ? null, numpy ? null, scipy ? null, matplotlib ? null
+# optional
+, ipython ? null, pylint ? null, pep8 ? null
+}:
 
 buildPythonPackage rec {
   name = "spyder-2.1.13.1";
@@ -9,8 +16,9 @@ buildPythonPackage rec {
     sha256 = "1sg88shvw6k2v5428k13mah4pyqng43856rzr6ypz5qgwn0677ya";
   };
 
-  buildInputs = [ unzip sphinx ];
-  propagatedBuildInputs = [ pyside ];
+  buildInputs = [ unzip ];
+  propagatedBuildInputs =
+    [ pyside pyflakes rope sphinx numpy scipy matplotlib ipython pylint pep8 ];
 
   # There is no test for spyder
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8721,7 +8721,8 @@ let
   gravit = callPackage ../applications/science/astronomy/gravit { };
 
   spyder = callPackage ../applications/science/spyder {
-    inherit (pythonPackages) sphinx;
+    inherit (pythonPackages) pyflakes rope sphinx numpy scipy matplotlib; # recommended
+    inherit (pythonPackages) ipython pylint pep8; # optional
   };
 
   stellarium = callPackage ../applications/science/astronomy/stellarium { };


### PR DESCRIPTION
Spyder says about itself that it has

  ...the support of IPython (enhanced interactive Python interpreter) and
  popular Python libraries such as NumPy (linear algebra), SciPy (signal
  and image processing) or matplotlib (interactive 2D/3D plotting).

So I think having those available as default is a the right thing to to.
(We can easily make a stripped down spyder expression if needed later.)

I've added the list of recommended and optional dependencies as
described here:

  http://pythonhosted.org/spyder/installation.html#dependencies

Also, I've created a desktop menu item for spyder.
