### PR TITLE
firefoxWrapper: Add libcanberra gtk module to firefox

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, browser, makeDesktopItem, makeWrapper, plugins, libs
+{ stdenv, browser, makeDesktopItem, makeWrapper, plugins, libs, gtk_modules
 , browserName, desktopName, nameSuffix, icon
 }:
 
@@ -28,6 +28,7 @@ stdenv.mkDerivation {
         "$out/bin/${browserName}${nameSuffix}" \
         --suffix-each MOZ_PLUGIN_PATH ':' "$plugins" \
         --suffix-each LD_LIBRARY_PATH ':' "$libs" \
+        --suffix-each GTK_PATH ':' "$gtk_modules" \
         --suffix-each LD_PRELOAD ':' "$(cat $(filterExisting $(addSuffix /extra-ld-preload $plugins)))" \
         --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))"
 
@@ -43,6 +44,7 @@ stdenv.mkDerivation {
   # where to find the plugin in its tree.
   plugins = map (x: x + x.mozillaPlugin) plugins;
   libs = map (x: x + "/lib") libs ++ map (x: x + "/lib64") libs;
+  gtk_modules = map (x: x + x.gtkModule) gtk_modules;
 
   meta = {
     description =

--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--disable-oss --disable-schemas-install";
 
+  passthru = {
+    gtkModule = "/lib/gtk-2.0/";
+  };
+
   meta = {
     description = "libcanberra, an implementation of the XDG Sound Theme and Name Specifications";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8155,6 +8155,7 @@ let
         if cfg.enableQuakeLive or false
         then with xlibs; [ stdenv.gcc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ]
         else [ ];
+      gtk_modules = [ libcanberra ];
     };
 
   x11vnc = callPackage ../tools/X11/x11vnc { };


### PR DESCRIPTION
Libcanberra is a simple abstract interface for playing event sounds. 

I don't know if this implementation is correct, but i got warnings without libcamberra while starting firefox(on debian running nix), so including libcamberra as gtk module fixes that.
