### PR TITLE
OpenOCD: bump from 0.6.1 to 0.7.0

### DIFF
--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, libusb}:
 
 stdenv.mkDerivation rec {
-  name = "libftdi-0.17";
+  name = "libftdi-0.20";
   
   src = fetchurl {
     url = "http://www.intra2net.com/en/developer/libftdi/download/${name}.tar.gz";
-    sha256 = "1w5bzq4h4v9qah9dx0wbz6w7ircr91ack0sh6wqs8s5b4m8jgh6m";
+    sha256 = "13l39f6k6gff30hsgh0wa2z422g9pyl91rh8a8zz6f34k2sxaxii";
   };
 
   buildInputs = [ libusb ];

--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libftdi libusb1 ];
 
   meta = {
-    homepage = http://openocd.berlios.de;
+    homepage = http://openocd.sourceforge.net/;
     description = "OpenOCD, an on-chip debugger";
 
     longDescription =

--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -1,12 +1,12 @@
-{stdenv, fetchurl, libftdi}:
+{stdenv, fetchurl, libftdi, libusb1 }:
 
 stdenv.mkDerivation rec {
   name = "openocd-${version}";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "http://downloads.sourceforge.net/project/openocd/openocd/${version}/openocd-${version}.tar.bz2";
-    sha256 = "0argjhff9x4ilgycics61kfgkvb6kkkhhhmj3fxcyydd8mscri7l";
+    sha256 = "0qwfyd821sy5p0agz0ybgn5nd7vplipw4mhm485ldj1hcmw7n8sj";
   };
 
   configureFlags = [ "--enable-ft2232_libftdi"
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
                      "--enable-ulink"
                      "--enable-stlink" ];
 
-  buildInputs = [ libftdi ];
+  buildInputs = [ libftdi libusb1 ];
 
   meta = {
     homepage = http://openocd.berlios.de;


### PR DESCRIPTION
libftdi is bumped to newer version because openocd needs it. And openocd meta.homepage is updated.
