### PR TITLE
tcptrack: new package

### DIFF
--- a/pkgs/development/tools/misc/tcptrack/default.nix
+++ b/pkgs/development/tools/misc/tcptrack/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, ncurses, libpcap }:
+
+stdenv.mkDerivation rec {
+  name = "tcptrack-${version}";
+  version = "1.4.2";
+
+  src = fetchurl {
+    # TODO: find better URL
+    url = http://pkgs.fedoraproject.org/repo/pkgs/tcptrack/tcptrack-1.4.2.tar.gz/dacf71a6b5310caf1203a2171b598610/tcptrack-1.4.2.tar.gz;
+    sha256 = "0jbh20kjaqdiasy5s9dk53dv4vpnbh31kqcmhwz9vi3qqzhv21v6";
+  };
+
+  buildInputs = [ ncurses libpcap ];
+
+  meta = { 
+    description = "libpcap based program for live TCP connection monitoring";
+    homepage = http://www.rhythm.cx/~steve/devel/tcptrack/; # dead link
+    license = stdenv.lib.licenses.lgpl21;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3414,6 +3414,8 @@ let
 
   swftools = callPackage ../tools/video/swftools { };
 
+  tcptrack = callPackage ../development/tools/misc/tcptrack { };
+
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };
   texinfo49 = callPackage ../development/tools/misc/texinfo/4.9.nix { };
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.1.nix { };


### PR DESCRIPTION
tcptrack is a small libpcap based program (with ncurses UI) for live TCP
connection monitoring.

It seems upstream homepage is down, so download the source code from a
fedora server instead.
