### PR TITLE
pinentry: enable qt4

### DIFF
--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, glib
 , useGtk ? true, gtk
 , useNcurses ? true, ncurses
-, useQt4 ? false, qt4 }:
+, useQt4 ? true, qt4 }:
 
 assert useGtk || useNcurses || useQt4;
 


### PR DESCRIPTION
Enable support for QT4 by default in package pinentry
