### PR TITLE
Add curlOpts to fetchurl

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -13,6 +13,7 @@ curl="curl \
  --disable-epsv \
  --cookie-jar cookies \
  --insecure \
+ $curlOpts \
  $NIX_CURL_FLAGS"
 
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -47,6 +47,9 @@ in
   # locations.  They are tried in order.
   urls ? []
 
+, # Additional curl options needed for the download to succeed.
+  curlOpts ? ""
+
 , # Name of the file.  If empty, use the basename of `url' (or of the
   # first element of `urls').
   name ? ""
@@ -97,7 +100,7 @@ stdenv.mkDerivation {
   outputHash = if outputHash != "" then outputHash else
       if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
 
-  inherit showURLs mirrorsFile impureEnvVars;
+  inherit curlOpts showURLs mirrorsFile impureEnvVars;
 
   # Doing the download on a remote machine just duplicates network
   # traffic, so don't do that.


### PR DESCRIPTION
So the derivation can change curl options while downloading stuff.  E.g. to provide custom passwords in private nix deployments.
