### PR TITLE
Fix empty cleanupCmds in myEnvFun.

### DIFF
--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -136,6 +136,7 @@ mkDerivation {
 
       nix_cleanup() {
         ${cleanupCmds}
+        true
       }
 
       export PATH


### PR DESCRIPTION
foo() { } error's in bash. This patch adds a single 'true' to the
function to make sure it's always valid & succeeds.
