### PR TITLE
ninja: include package name in source archive path

### DIFF
--- a/pkgs/development/tools/build-managers/ninja/default.nix
+++ b/pkgs/development/tools/build-managers/ninja/default.nix
@@ -5,6 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.2.0";
 
   src = fetchurl {
+    name = "${name}.zip";
     url = "https://github.com/martine/ninja/archive/v${version}.zip";
     sha256 = "15ynh806ah37bqb57hcs3mj2g82900sncp6n3bssfggb4azgjlh3";
   };


### PR DESCRIPTION
So that the nix store path becomes this:

  /nix/store/HASH-ninja-1.2.0.zip.drv

instead of this anonymous path:

  /nix/store/HASH-v1.2.0.zip.drv
