### PR TITLE
munin: add missing dependencies

### DIFF
--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, perl, perlPackages, makeWrapper, which }:
+{ stdenv, fetchurl, makeWrapper, which, coreutils, rrdtool, perl, perlPackages
+, python, ruby, openjdk }:
 
 # TODO: split into server/node derivations
+
+# FIXME: munin tries to write log files and web graphs to its installation path.
 
 stdenv.mkDerivation rec {
   version = "2.0.14";
@@ -8,26 +11,35 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/munin-monitoring/munin/archive/${version}.tar.gz";
-    md5 = "f43f54cb38a64f6f1388c9cbac0395ee";
+    sha256 = "1d71gvmkrck42z1h1dfk9napbhn7apfmlnp7r62fyylv0m7s2ylx";
   };
 
   buildInputs = [ 
     makeWrapper
     which
-    perlPackages.ModuleBuild
-  ];
-
-  propagatedBuildInputs = [
+    coreutils
+    rrdtool
     perl
+    perlPackages.ModuleBuild
     perlPackages.HTMLTemplate
     perlPackages.NetSSLeay
     perlPackages.NetServer
     perlPackages.Log4Perl
-    #perlPackages.TimeHiRes
-    # TODO: Net::SNMP
+    perlPackages.IOSocketInet6
+    perlPackages.Socket6
+    perlPackages.URI
+    perlPackages.DBFile
+    perlPackages.DateManip
+    perlPackages.FileCopyRecursive
+    perlPackages.FCGI
+    perlPackages.NetSNMP
+    perlPackages.NetServer
+    perlPackages.ListMoreUtils
+    perlPackages.TimeHiRes
+    python
+    ruby
+    openjdk
   ];
-
-  makeFlags="PERL=${perl}/bin/perl DESTDIR=$(out) PREFIX=$(out)";
 
   preBuild = ''
     sed -i '/CHECKUSER/d' Makefile
@@ -37,14 +49,47 @@ stdenv.mkDerivation rec {
       --replace "/usr/pwd" "pwd"
   '';
 
+  # DESTDIR shouldn't be needed (and shouldn't have worked), but munin
+  # developers have forgotten to use PREFIX everywhere, so we use DESTDIR to
+  # ensure that everything is installed in $out.
+  makeFlags = ''
+    PREFIX=$(out)
+    DESTDIR=$(out)
+    PERLLIB=$(out)/lib/perl5/site_perl
+    PERL=${perl}/bin/perl
+    PYTHON=${python}/bin/python
+    RUBY=${ruby}/bin/ruby
+    JAVARUN=${openjdk}/bin/java
+    HOSTNAME=default
+  '';
+
   postFixup = ''
     if test -e $out/nix-support/propagated-native-build-inputs; then
         ln -s $out/nix-support/propagated-native-build-inputs $out/nix-support/propagated-user-env-packages
     fi
+
+    # TODO: toPerlLibPath can be added to
+    # pkgs/development/interpreters/perl5.16/setup-hook.sh (and the other perl
+    # versions) just like for python. NOTE: it causes massive rebuilds.
+    # $(toPerlLibPath $out perlPackages.Log4Perl ...)
+
+    for file in "$out"/bin/munindoc "$out"/sbin/munin-* "$out"/lib/munin-* "$out"/www/cgi/*; do
+        # don't wrap .jar files
+        case "$file" in
+            *.jar) continue;;
+        esac
+        wrapProgram "$file" --set PERL5LIB $out/lib/perl5/site_perl:${perlPackages.Log4Perl}/lib/perl5/site_perl:${perlPackages.IOSocketInet6}/lib/perl5/site_perl:${perlPackages.Socket6}/lib/perl5/site_perl:${perlPackages.URI}/lib/perl5/site_perl:${perlPackages.DBFile}/lib/perl5/site_perl:${perlPackages.DateManip}/lib/perl5/site_perl:${perlPackages.HTMLTemplate}/lib/perl5/site_perl:${perlPackages.FileCopyRecursive}/lib/perl5/site_perl:${perlPackages.FCGI}/lib/perl5/site_perl:${perlPackages.NetSNMP}/lib/perl5/site_perl:${perlPackages.NetServer}/lib/perl5/site_perl:${perlPackages.ListMoreUtils}/lib/perl5/site_perl:${perlPackages.TimeHiRes}/lib/perl5/site_perl:${rrdtool}/lib/perl
+    done
   '';
 
   meta = with stdenv.lib; {
-    description = "Munin is a networked resource monitoring tool that can help analyze resource trends and 'what just happened to kill our performance?' problems";
+    description = "Networked resource monitoring tool";
+    longDescription = ''
+      Munin is a monitoring tool that surveys all your computers and remembers
+      what it saw. It presents all the information in graphs through a web
+      interface. Munin can help analyze resource trends and 'what just happened
+      to kill our performance?' problems.
+    '';
     homepage = http://munin-monitoring.org/;
     license = licenses.gpl2;
     maintainers = [ maintainers.iElectric ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1995,6 +1995,15 @@ rec {
     buildInputs = [ Spiffy TestBase TestDifferences ];
   };
 
+  FCGI = buildPerlPackage rec {
+    name = "FCGI-0.74";
+    src = fetchurl {
+      url = "mirror://cpan/modules/by-module/FCGI/${name}.tar.gz";
+      sha256 = "0m089q07kpsk8y8g2wmi3d8i1jzn5m5m00shs7vnf2lnvvv4d7pm";
+    };
+    buildInputs = [ ];
+  };
+
   FileChangeNotify = buildPerlModule rec {
     name = "File-ChangeNotify-0.20";
     src = fetchurl {
@@ -3802,6 +3811,14 @@ rec {
     propagatedBuildInputs = [IOSocketSSL DigestHMAC];
   };
 
+  NetSNMP = buildPerlPackage rec {
+    name = "Net-SNMP-v6.0.1";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DT/DTOWN/${name}.tar.gz";
+      sha256 = "0hdpn1cw52x8cw24m9ayzpf4rwarm0khygn1sv3wvwxkrg0pphql";
+    };
+  };
+
   NetSSLeay = buildPerlPackage rec {
     name = "Net-SSLeay-1.52";
     src = fetchurl {
@@ -5347,10 +5364,10 @@ rec {
   };
 
   TimeHiRes = buildPerlPackage rec {
-    name = "Time-HiRes-1.9724";
+    name = "Time-HiRes-1.9725";
     src = fetchurl {
       url = "mirror://cpan/modules/by-module/Time/${name}.tar.gz";
-      sha256 = "0lrwfixr3qg8j4vkfax1z4gqiccq0v0jyvc7db40qpvi88655gjs";
+      sha256 = "0fr7zkc55kazcjxdkrcjgimic8xpk6imxkckdpjlggjpkggv76f0";
     };
   };
 


### PR DESCRIPTION
- Add needed dependencies:
  coreutils, python, ruby, java and several Perl modules (Time::HiRes
  1.9.724 is no longer available, bump to 1.9725)
- Use sha256 instead of md5 (more secure)
- Wrap munin perl scripts so they find their dependencies at runtime
- Rework meta description attributes.

FIXME/TODO: munin is still not usable; it tries to write log files and
web graphs to its installation path.
