### PR TITLE
Add ncursesw compatibility link also for includes

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation (rec {
         ln -svf lib''${lib}w.so.5 $out/lib/lib$lib.so.5
       fi
     done;
+    ln -svf . $out/include/ncursesw
   '' else "";
 
   meta = {


### PR DESCRIPTION
This is needed for the ncurses cabal package to compile.  It uses
include/ncursesw/curses.h, without trying include/curses.h first.  The
files are provided through include/ncursesw on a clean Debian too, in
the unicode case (when the libncursesw5-dev is installed).
