### PR TITLE
update to 2013Q1 Intel Graphics Stack Release

### DIFF
--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libX11, pkgconfig, libXext, mesa, libdrm, libXfixes }:
 
 stdenv.mkDerivation rec {
-  name = "libva-1.1.0";
+  name = "libva-1.1.1";
   
   src = fetchurl {
     url = "http://www.freedesktop.org/software/vaapi/releases/libva/${name}.tar.bz2";
-    sha256 = "1a7g7i96ww8hmim2pq2a3xc89073lzacxn1xh9526bzhlqjdqsnv";
+    sha256 = "0kfdcrzcr82g15l0vvmm6rqr0f0604d4dgrza78gn6bfx7rppby0";
   };
 
   buildInputs = [ libX11 libXext pkgconfig mesa libdrm libXfixes ];

--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -2,11 +2,11 @@
 , intelgen4asm }:
 
 stdenv.mkDerivation rec {
-  name = "libva-intel-driver-1.0.19";
+  name = "libva-intel-driver-1.0.20";
   
   src = fetchurl {
     url = "http://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/${name}.tar.bz2";
-    sha256 = "14m7krah3ajkwj190q431lqqa84hdljcdmrcrqkbgaffyjlqvdid";
+    sha256 = "1jfl8909j3a3in6m8b5bx3dn7pzr8a1sw3sk4vzm7h3j2dkgpzhj";
   };
 
   buildInputs = [ autoconf automake libtool mesa libva pkgconfig libdrm libX11 intelgen4asm ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1513,8 +1513,8 @@ let
     name = "xf86-video-intel-2.21.7";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-video-intel-2.21.3.tar.bz2;
-      sha256 = "1nb3hc1h6scja89rwf2fvadj5z8ckcnm94lryf895i3r02jbpsps";
+      url = mirror://xorg/individual/driver/xf86-video-intel-2.21.7.tar.bz2;
+      sha256 = "0mpdd7am813gv7nxxvbllcph1xg7czy0bd1kn3q6bc489h53wzbp";
     };
     buildInputs = [pkgconfig dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto libXfixes xorgserver xproto libXrender libXvMC ];
   })) // {inherit dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto libXfixes xorgserver xproto libXrender libXvMC ;};

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1510,11 +1510,11 @@ let
   })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
     
   xf86videointel = (stdenv.mkDerivation ((if overrides ? xf86videointel then overrides.xf86videointel else x: x) {
-    name = "xf86-video-intel-2.21.3";
+    name = "xf86-video-intel-2.21.7";
     builder = ./builder.sh;
     src = fetchurl {
       url = mirror://xorg/individual/driver/xf86-video-intel-2.21.3.tar.bz2;
-      sha256 = "1fwxjc6vnr926yd92y1w70kvnky24xw0dsa9crvvlv928ah75rhw";
+      sha256 = "1nb3hc1h6scja89rwf2fvadj5z8ckcnm94lryf895i3r02jbpsps";
     };
     buildInputs = [pkgconfig dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto libXfixes xorgserver xproto libXrender libXvMC ];
   })) // {inherit dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto libXfixes xorgserver xproto libXrender libXvMC ;};

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1510,11 +1510,11 @@ let
   })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
     
   xf86videointel = (stdenv.mkDerivation ((if overrides ? xf86videointel then overrides.xf86videointel else x: x) {
-    name = "xf86-video-intel-2.20.19";
+    name = "xf86-video-intel-2.21.3";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-video-intel-2.20.19.tar.bz2;
-      sha256 = "0k67vcf0aqhv9zmy1arxyjdl7fsrg90cjm0ryyhamghq67z0xcmr";
+      url = mirror://xorg/individual/driver/xf86-video-intel-2.21.3.tar.bz2;
+      sha256 = "1fwxjc6vnr926yd92y1w70kvnky24xw0dsa9crvvlv928ah75rhw";
     };
     buildInputs = [pkgconfig dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto libXfixes xorgserver xproto libXrender libXvMC ];
   })) // {inherit dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto libXfixes xorgserver xproto libXrender libXvMC ;};

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -129,7 +129,7 @@ mirror://xorg/individual/driver/xf86-video-geode-2.11.14.tar.bz2
 mirror://xorg/individual/driver/xf86-video-glide-1.2.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-glint-1.2.8.tar.bz2
 mirror://xorg/individual/driver/xf86-video-i128-1.3.6.tar.bz2
-mirror://xorg/individual/driver/xf86-video-intel-2.20.19.tar.bz2
+mirror://xorg/individual/driver/xf86-video-intel-2.21.3.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mach64-6.9.4.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mga-1.6.2.tar.bz2
 mirror://xorg/individual/driver/xf86-video-neomagic-1.2.7.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -129,7 +129,7 @@ mirror://xorg/individual/driver/xf86-video-geode-2.11.14.tar.bz2
 mirror://xorg/individual/driver/xf86-video-glide-1.2.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-glint-1.2.8.tar.bz2
 mirror://xorg/individual/driver/xf86-video-i128-1.3.6.tar.bz2
-mirror://xorg/individual/driver/xf86-video-intel-2.21.3.tar.bz2
+mirror://xorg/individual/driver/xf86-video-intel-2.21.7.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mach64-6.9.4.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mga-1.6.2.tar.bz2
 mirror://xorg/individual/driver/xf86-video-neomagic-1.2.7.tar.bz2


### PR DESCRIPTION
This changeset updates to all of the versions in
https://01.org/linuxgraphics/downloads/2013/2013q1-intel-graphics-stack-release
(but does not regression from newer version).

I tried generating 'servers/x11/xorg/default.nix' with the perl script,
but unrelated packges changed, so I just manually updated the file.
