### PR TITLE
Upgrade node.js 0.8 -> 0.10, fix Mac build

### DIFF
--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, python, zlib, v8, utillinux }:
+{ stdenv, fetchurl, openssl, python, zlib, utillinux }:
 
 stdenv.mkDerivation rec {
   version = "0.10.7";
@@ -12,14 +12,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--openssl-includes=${openssl}/include"
     "--openssl-libpath=${openssl}/lib"
-  ]
-  ++ (if !stdenv.isDarwin then [ # Shared V8 is broken on Mac OS X. Who can fix V8 on Darwin makes me very happy, but I gave up studying python-gyp.
-    "--shared-v8"
-    "--shared-v8-includes=${v8}/includes"
-    "--shared-v8-libpath=${v8}/lib"
-  ] else []);
-
-  #patches = stdenv.lib.optional stdenv.isDarwin ./no-arch-flag.patch;
+  ];
 
   # Expose the host compiler on darwin, which is the only compiler capable of building it
   preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -31,13 +24,11 @@ stdenv.mkDerivation rec {
     export PATH=$OLDPATH
   '' + ''
     sed -e 's|^#!/usr/bin/env node$|#!'$out'/bin/node|' -i $out/lib/node_modules/npm/bin/npm-cli.js
-  '' /*+ stdenv.lib.optionalString stdenv.isDarwin ''
-    install_name_tool -change libv8.dylib ${v8}/lib/libv8.dylib $out/bin/node
-  ''*/;
+  '';
 
   buildInputs = [ python openssl zlib ]
-    ++ stdenv.lib.optional stdenv.isLinux utillinux
-    ++ stdenv.lib.optional (!stdenv.isDarwin) v8;
+    ++ stdenv.lib.optional stdenv.isLinux utillinux;
+
   setupHook = ./setup-hook.sh;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, openssl, python, zlib, v8, utillinux }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.23";
+  version = "0.10.7";
   name = "nodejs-${version}";
 
   src = fetchurl {
-    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "17gdvv0q95v5dn9mbwrm3pxcchfgmlwa7pamwsam9hpdi9ik491q";
+    url = http://nodejs.org/dist/v0.10.7/node-v0.10.7.tar.gz;
+    sha256 = "1q15siga6b3rxgrmy42310cdya1zcc2dpsrchidzl396yl8x5l92";
   };
 
   configureFlags = [
@@ -24,11 +24,7 @@ stdenv.mkDerivation rec {
   # Expose the host compiler on darwin, which is the only compiler capable of building it
   preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
     export OLDPATH=$PATH
-    export PATH=/usr/bin:$PATH
-  '';
-
-  prePatch = ''
-    sed -e 's|^#!/usr/bin/env python$|#!${python}/bin/python|g' -i tools/{*.py,waf-light,node-waf} configure
+    export PATH=/usr/bin:/usr/sbin:$PATH
   '';
 
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
This patch does three things:
1. Upgrade node.js from 0.8.x to 0.10.x
2. No longer use a shared v8. This is nice in theory, but results in compatibility problems. For instance to upgrade from .8 to .10 I would also have to upgrade the v8 expression, which is not trivial (got gyp errors trying to do that) and may break other packages that rely on the older v8. node.js comes with v8, so let's just use that version.
3. Fix Mac support
