### PR TITLE
Add Sourcery CodeBench Lite toolchain(s)

### DIFF
--- a/pkgs/development/compilers/mentor/default.nix
+++ b/pkgs/development/compilers/mentor/default.nix
@@ -1,0 +1,75 @@
+# Sourcery CodeBench Lite toolchain(s) (GCC) from Mentor Graphics
+
+{ stdenv, fetchurl, patchelf, ncurses }:
+
+let
+
+  buildToolchain =
+    { name, src, description }:
+
+    stdenv.mkDerivation rec {
+      inherit name src;
+
+      buildInputs = [ patchelf ];
+
+      buildCommand = ''
+        # Unpack tarball
+        mkdir -p "$out"
+        tar --strip-components=1 -xjf "$src" -C "$out"
+
+        # Patch binaries
+        interpreter="$(cat "$NIX_GCC"/nix-support/dynamic-linker)"
+        for file in "$out"/bin/* "$out"/libexec/gcc/*/*/* "$out"/*/bin/*; do
+            # Skip non-executable files
+            case "$file" in
+              *README.txt) echo "skipping $file"; continue;;
+              *liblto_plugin.so*) echo "skipping $file"; continue;;
+            esac
+
+            # Skip directories
+            test -d "$file" && continue
+
+            echo "patchelf'ing $file"
+            patchelf --set-interpreter "$interpreter" "$file"
+
+            # GDB needs ncurses
+            case "$file" in
+              *gdb) patchelf --set-rpath "${ncurses}/lib" "$file";;
+            esac
+        done
+      '';
+
+      meta = with stdenv.lib; {
+        inherit description;
+        homepage = http://www.mentor.com/embedded-software/sourcery-tools/sourcery-codebench/editions/lite-edition/;
+        license = licenses.gpl3;
+        platforms = platforms.linux;
+        maintainers = [ maintainers.bjornfor ];
+      };
+    };
+
+in
+
+{
+
+  armLinuxGnuEabi = let version = "2013.05-24"; in buildToolchain rec {
+    name = "sourcery-codebench-lite-arm-linux-gnueabi-${version}";
+    description = "Sourcery CodeBench Lite toolchain (GCC) for ARM GNU/Linux, from Mentor Graphics";
+    src = fetchurl {
+      url = "http://sourcery.mentor.com/public/gnu_toolchain/arm-none-linux-gnueabi/arm-${version}-arm-none-linux-gnueabi-i686-pc-linux-gnu.tar.bz2";
+      sha256 = "1xb075ia61c59cya2jl8zp4fvqpfnwkkc5330shvgdlg9981qprr";
+    };
+  };
+
+  armEabi = let version = "2013.05-23"; in buildToolchain rec {
+    name = "sourcery-codebench-lite-arm-eabi-${version}";
+    description = "Sourcery CodeBench Lite toolchain (GCC) for ARM EABI, from Mentor Graphics";
+    src = fetchurl {
+      url = "http://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi/arm-${version}-arm-none-eabi-i686-pc-linux-gnu.tar.bz2";
+      sha256 = "0nbvdwj3kcv9scx808gniqp0ncdiy2i7afmdvribgkz1lsfin923";
+    };
+  };
+
+  # TODO: Sourcery CodeBench is also available for MIPS, Power, SuperH,
+  # ColdFire (and more).
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2612,6 +2612,10 @@ let
       else stdenv;
   };
 
+  mentorToolchains = recurseIntoAttrs (
+    callPackage_i686 ../development/compilers/mentor {}
+  );
+
   mitscheme = callPackage ../development/compilers/mit-scheme { };
 
   mlton = callPackage ../development/compilers/mlton { };


### PR DESCRIPTION
Sourcery CodeBench toolchains are prebuilt GCC toolchains from Mentor
Graphics.

Start out by adding ARM EABI and ARM GNU/Linux toolchains. Sourcery
CodeBench is also available for MIPS, Power, SuperH, ColdFire (and
more), so it should be easy to add later, if needed.

AFAIK, the EABI toolchains use newlib and the GNU/Linux ones use glibc.
