### PR TITLE
st: Update to 0.4.1 and add support for custom config

### DIFF
--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -1,14 +1,22 @@
-{ stdenv, fetchurl, libX11, ncurses, libXext, libXft }:
+{ stdenv, fetchurl, writeText, libX11, ncurses, libXext, libXft, fontconfig
+, conf? null}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "st-0.3";
+  name = "st-0.4.1";
   
   src = fetchurl {
     url = "http://dl.suckless.org/st/${name}.tar.gz";
-    sha256 = "0d0fjixiis4ixbz4l18rqhnssa7cy2bap3jkjyphqlqhl7lahv3d";
+    sha256 = "0cdzwbm5fxrwz8ryxkh90d3vwx54wjyywgj28ymsb5fdv3396bzf";
   };
+
+  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
   
-  buildInputs = [ libX11 ncurses libXext libXft ];
+  buildInputs = [ libX11 ncurses libXext libXft fontconfig ];
+
+  NIX_LDFLAGS = "-lfontconfig";
 
   installPhase = ''
     TERMINFO=$out/share/terminfo make install PREFIX=$out
@@ -17,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://st.suckless.org/;
     license = "MIT";
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with maintainers; [viric];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7853,7 +7853,9 @@ let
 
   skype_call_recorder = callPackage ../applications/networking/instant-messengers/skype-call-recorder { };
 
-  st = callPackage ../applications/misc/st { };
+  st = callPackage ../applications/misc/st {
+    conf = config.st.conf or null;
+  };
 
   bittorrentSync = callPackage ../applications/networking/bittorrentsync { };
 


### PR DESCRIPTION
Simple terminal, doesn't have support for runtime configs(which is good, because it makes it super fast), but config is set in compile time, with header file. This commit adds support for setting custom config(for example to change theme).

I also updated it, because it now supports fontconfig, so you don't have to patch your fonts anymore like you do in uxrvt and similar ;)
