### PR TITLE
vim_configurable: change source to mercurial and update to 7.3-999

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -4,11 +4,12 @@ args: with args;
 let inherit (args.composableDerivation) composableDerivation edf; in
 composableDerivation {} {
 
-    name = "vim_configurable-7.3";
+    name = "vim_configurable-7.3-999";
 
-    src = args.fetchurl {
-      url = ftp://ftp.vim.org/pub/vim/unix/vim-7.3.tar.bz2;
-      sha256 = "079201qk8g9yisrrb0dn52ch96z3lzw6z473dydw9fzi0xp5spaw";
+    src = args.fetchhg {
+      url = https://code.google.com/p/vim/;
+      tag = "v7-3-999";
+      sha256 = "0ywix37h7cns62qwvndhsswq16ns65namwpgbi7fbqszbn8znzs8";
     };
 
     configureFlags = ["--enable-gui=auto" "--with-features=${args.features}"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8116,7 +8116,7 @@ let
   vimHugeX = vim_configurable;
 
   vim_configurable = import ../applications/editors/vim/configurable.nix {
-    inherit (pkgs) fetchurl stdenv ncurses pkgconfig gettext composableDerivation lib config;
+    inherit (pkgs) fetchhg stdenv ncurses pkgconfig gettext composableDerivation lib config;
     inherit (pkgs.xlibs) libX11 libXext libSM libXpm libXt libXaw libXau libXmu libICE;
     inherit (pkgs) glib gtk;
     features = "huge"; # one of  tiny, small, normal, big or huge


### PR DESCRIPTION
Vim release is rarely updated, but it receives official patches from time to time. Currently it is at patch 999(coincidence?). 

Well some vim plugins don't work with unpatched vim, and there isn't any way to get archive of all patches, you can just download every patch separately and apply them.

But! They also have(official) source on mercurial repo, with tags for every patch, so we why not use that ;)
