### PR TITLE
sourcery-codebench: fix installation of manpages

### DIFF
--- a/pkgs/development/compilers/mentor/default.nix
+++ b/pkgs/development/compilers/mentor/default.nix
@@ -37,6 +37,11 @@ let
               *gdb) patchelf --set-rpath "${ncurses}/lib" "$file";;
             esac
         done
+
+        # Manpages
+        mkdir -p "$out/share/man"
+        ln -s "$out"/share/doc/*/man/man1 "$out/share/man/man1"
+        ln -s "$out"/share/doc/*/man/man7 "$out/share/man/man7"
       '';
 
       meta = with stdenv.lib; {


### PR DESCRIPTION
Sourcery CodeBench manpages are installed under
share/doc/<target-triplet>/man/. Add symlinks so that the manpages
become available to "man".

NOTE: I use symlinks instead of moving the manpages, because I think
it is best to do as little as possible to prebuilt packages.
