### PR TITLE
Add numdiff-5.6.1

### DIFF
--- a/pkgs/tools/text/numdiff/default.nix
+++ b/pkgs/tools/text/numdiff/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "5.6.1";
+in
+stdenv.mkDerivation {
+  name = "numdiff-${version}";
+  src = fetchurl {
+    url = "http://ftp.igh.cnrs.fr/pub/nongnu/numdiff/numdiff-${version}.tar.gz";
+    sha256 = "062byxp9vajj4flg1rqh0r2nwg9yx608mbsj5y25wkrzmkgcq3fx";
+  };
+  meta = {
+    description = ''
+      A little program that can be used to compare putatively similar files
+      line by line and field by field, ignoring small numeric differences
+      or/and different numeric formats.
+    '';
+    homepage = "http://www.nongnu.org/numdiff/";
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = stdenv.lib.maintainers.bbenoist;
+    platforms = stdenv.lib.platforms.gnu;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1314,6 +1314,8 @@ let
 
   ntp = callPackage ../tools/networking/ntp { };
 
+  numdiff = callPackage ../tools/text/numdiff { };
+
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
   nylon = callPackage ../tools/networking/nylon { };


### PR DESCRIPTION
A little program that can be used to compare putatively similar files line by line and field by field, ignoring small numeric differences or/and different numeric formats.
