### PR TITLE
php-5.4: Reintroduce the ftpSupport build option

### DIFF
--- a/pkgs/development/interpreters/php/5.4.nix
+++ b/pkgs/development/interpreters/php/5.4.nix
@@ -144,6 +144,10 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
         configureFlags = ["--enable-zip"];
       };
 
+      ftp = {
+        configureFlags = ["--enable-ftp"];
+      };
+
       /*
          php is build within this derivation in order to add the xdebug lines to the php.ini.
          So both Apache and command line php both use xdebug without having to configure anything.
@@ -181,6 +185,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     mcryptSupport = config.php.mcrypt or false;
     bz2Support = config.php.bz2 or false;
     zipSupport = config.php.zip or true;
+    ftpSupport = config.php.ftp or true;
   };
 
   configurePhase = ''


### PR DESCRIPTION
The ftpSupport build option I added on the 5.3 version of PHP was not
present in the version 5.4 because it was not yet merged when I wrote my
commit.
