### PR TITLE
glibc: add "/run/current-system/sw/bin" to the default search path returned by "getconf CS_PATH"

### DIFF
--- a/pkgs/development/libraries/glibc/2.17/common.nix
+++ b/pkgs/development/libraries/glibc/2.17/common.nix
@@ -55,6 +55,11 @@ stdenv.mkDerivation ({
          rfc3484_sort: Assertion `src->results[i].native == -1 ||
          src->results[i].native == a2_native' failed." crashes. */
       ./glibc-rh739743.patch
+
+      /* The command "getconf CS_PATH" returns the default search path
+         "/bin:/usr/bin", which is inappropriate on NixOS machines. This
+         patch extends the search path by "/run/current-system/sw/bin". */
+      ./fix_path_attribute_in_getconf.patch
     ];
 
   postPatch = ''

--- a/pkgs/development/libraries/glibc/2.17/fix_path_attribute_in_getconf.patch
+++ b/pkgs/development/libraries/glibc/2.17/fix_path_attribute_in_getconf.patch
@@ -1,0 +1,6 @@
+diff -ubr glibc-2.17-orig/sysdeps/unix/confstr.h glibc-2.17/sysdeps/unix/confstr.h
+--- glibc-2.17-orig/sysdeps/unix/confstr.h	2013-06-03 22:01:44.829726968 +0200
++++ glibc-2.17/sysdeps/unix/confstr.h	2013-06-03 22:04:39.469376740 +0200
+@@ -1 +1 @@
+-#define	CS_PATH	"/bin:/usr/bin"
++#define	CS_PATH	"/run/current-system/sw/bin:/bin:/usr/bin"


### PR DESCRIPTION
This patch changes glibc, so it goes into `stdenv-updates`.

See http://thread.gmane.org/gmane.linux.distributions.nixos/10967 for a discussion of the issue that this patch addresses.
