### PR TITLE
Add Riak 1.3.1

### DIFF
--- a/pkgs/servers/nosql/riak/1.3.1.nix
+++ b/pkgs/servers/nosql/riak/1.3.1.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, unzip, erlang }:
+
+let
+  srcs = {
+     riak = fetchurl {
+      url = "http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/riak-1.3.1.tar.gz";
+      sha256 = "a69093fc5df1b79f58645048b9571c755e00c3ca14dfd27f9f1cae2c6e628f01";
+    };
+     leveldb = fetchurl {
+      url = "https://github.com/basho/leveldb/zipball/1.3.1";
+      sha256 = "0d60b84e5ea05238ba79b08b4176fc66bf28768c8e6ffcea53092e28eaea091f";
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  name = "riak-1.3.1";
+
+  buildInputs = [unzip erlang];
+
+  src = srcs.riak;
+
+  patches = [ ./riak-1.3.1.patch ./riak-admin-1.3.1.patch ];
+
+  postUnpack = ''
+    ln -sv ${srcs.leveldb} $sourceRoot/deps/eleveldb/c_src/leveldb.zip
+    pushd $sourceRoot/deps/eleveldb/c_src/
+    unzip leveldb.zip
+    mv basho-leveldb-* leveldb
+    cd ../../
+    mkdir riaknostic/deps
+    cp -R lager riaknostic/deps
+    cp -R getopt riaknostic/deps
+    cp -R meck riaknostic/deps
+    popd
+  '';
+
+  buildPhase = ''
+    make rel
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    mkdir $out
+    mv rel/riak/etc rel/riak/riak-etc
+    mkdir -p rel/riak/etc
+    mv rel/riak/riak-etc rel/riak/etc/riak
+    mv rel/riak/* $out
+  '';
+
+  meta = {
+    maintainers = stdenv.lib.maintainers.orbitz;
+    description = "Dynamo inspired NoSQL DB by Basho";
+    longDescription = ''
+      This reworks how the riak and riak-admin scripts work.  Rather
+      than the scripts using their own location to determine where the
+      data, log, and etc directories should live, the scripts expect
+      RIAK_DATA_DIR, RIAK_LOG_DIR, and RIAK_ETC_DIR to be defined
+      and use those.
+    ''
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/servers/nosql/riak/1.3.1.nix
+++ b/pkgs/servers/nosql/riak/1.3.1.nix
@@ -52,9 +52,9 @@ stdenv.mkDerivation rec {
     maintainers = stdenv.lib.maintainers.orbitz;
     description = "Dynamo inspired NoSQL DB by Basho";
     longDescription = ''
-      This reworks how the riak and riak-admin scripts work.  Rather
-      than the scripts using their own location to determine where the
-      data, log, and etc directories should live, the scripts expect
+      This patches the riak and riak-admin scripts to work better in Nix.
+      Rather than the scripts using their own location to determine where
+      the data, log, and etc directories should live, the scripts expect
       RIAK_DATA_DIR, RIAK_LOG_DIR, and RIAK_ETC_DIR to be defined
       and use those.
     ''

--- a/pkgs/servers/nosql/riak/riak-1.3.1.patch
+++ b/pkgs/servers/nosql/riak/riak-1.3.1.patch
@@ -1,0 +1,64 @@
+--- a/rel/files/riak	2013-05-22 20:45:55.613299952 +0200
++++ b/rel/files/riak	2013-06-04 03:20:47.679943612 +0200
+@@ -13,33 +13,34 @@
+ fi
+ unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+ 
++if [ -z "$RIAK_ETC_DIR" ]; then
++    echo "Must set RIAK_ETC_DIR"
++    exit 1
++fi
++
++if [ -z "$RIAK_LOG_DIR" ]; then
++    echo "Must set RIAK_LOG_DIR"
++    exit 1
++fi
++
++if [ -z "$RIAK_DATA_DIR" ]; then
++    echo "Must set RIAK_DATA_DIR"
++    exit 1
++fi
++
+ RUNNER_SCRIPT_DIR={{runner_script_dir}}
+ RUNNER_SCRIPT=${0##*/}
+ 
+ RUNNER_BASE_DIR={{runner_base_dir}}
+-RUNNER_ETC_DIR={{runner_etc_dir}}
++RUNNER_ETC_DIR=$RIAK_ETC_DIR
+ RUNNER_LIB_DIR={{platform_lib_dir}}
+-RUNNER_LOG_DIR={{runner_log_dir}}
++RUNNER_LOG_DIR=$RIAK_LOG_DIR
+ # Note the trailing slash on $PIPE_DIR/
+ PIPE_DIR={{pipe_dir}}
+-RUNNER_USER={{runner_user}}
+-PLATFORM_DATA_DIR={{platform_data_dir}}
++PLATFORM_DATA_DIR=$RIAK_DATA_DIR
+ SSL_DIST_CONFIG=$PLATFORM_DATA_DIR/ssl_distribution.args_file
+ RIAK_VERSION="git"
+ 
+-WHOAMI=$(whoami)
+-
+-# Make sure this script is running as the appropriate user
+-if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
+-    type sudo > /dev/null 2>&1
+-    if [ $? -ne 0 ]; then
+-        echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
+-        exit 1
+-    fi
+-    echo "Attempting to restart script through sudo -H -u $RUNNER_USER" >&2
+-    exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
+-fi
+-
+ # Warn the user if ulimit -n is less than 4096
+ ULIMIT_F=`ulimit -n`
+ if [ "$ULIMIT_F" -lt 4096 ]; then
+@@ -48,9 +49,6 @@
+     echo "!!!!"
+ fi
+ 
+-# Make sure CWD is set to runner base dir
+-cd $RUNNER_BASE_DIR
+-
+ # Make sure log directory exists
+ mkdir -p $RUNNER_LOG_DIR
+ 

--- a/pkgs/servers/nosql/riak/riak-admin-1.3.1.patch
+++ b/pkgs/servers/nosql/riak/riak-admin-1.3.1.patch
@@ -1,0 +1,52 @@
+--- a/rel/files/riak-admin	2013-05-22 20:45:55.613299952 +0200
++++ b/rel/files/riak-admin	2013-06-04 03:30:00.101604175 +0200
+@@ -11,31 +11,31 @@
+ fi
+ unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+ 
++
++if [ -z "$RIAK_ETC_DIR" ]; then
++    echo "Must set RIAK_ETC_DIR"
++    exit 1
++fi
++
++if [ -z "$RIAK_LOG_DIR" ]; then
++    echo "Must set RIAK_LOG_DIR"
++    exit 1
++fi
++
++if [ -z "$RIAK_DATA_DIR" ]; then
++    echo "Must set RIAK_DATA_DIR"
++    exit 1
++fi
++
+ RUNNER_SCRIPT_DIR={{runner_script_dir}}
+ RUNNER_SCRIPT=${0##*/}
+ 
+ RUNNER_BASE_DIR={{runner_base_dir}}
+-RUNNER_ETC_DIR={{runner_etc_dir}}
++RUNNER_ETC_DIR=$RIAK_ETC_DIR
+ RUNNER_LIB_DIR={{platform_lib_dir}}
+-RUNNER_LOG_DIR={{runner_log_dir}}
++RUNNER_LOG_DIR=$RIAK_LOG_DIR
+ RUNNER_USER={{runner_user}}
+ 
+-WHOAMI=$(whoami)
+-
+-# Make sure this script is running as the appropriate user
+-if ([ "$RUNNER_USER" ] && [ "x$WHOAMI" != "x$RUNNER_USER" ]); then
+-    type sudo > /dev/null 2>&1
+-    if [ $? -ne 0 ]; then
+-        echo "sudo doesn't appear to be installed and your EUID isn't $RUNNER_USER" 1>&2
+-        exit 1
+-    fi
+-    echo "Attempting to restart script through sudo -H -u $RUNNER_USER" >&2
+-    exec sudo -H -u $RUNNER_USER -i $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $@
+-fi
+-
+-# Make sure CWD is set to runner base dir
+-cd $RUNNER_BASE_DIR
+-
+ # Extract the target node name from node.args
+ NAME_ARG=`egrep "^ *-s?name" $RUNNER_ETC_DIR/vm.args`
+ if [ -z "$NAME_ARG" ]; then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5657,6 +5657,8 @@ let
 
   mongodb = callPackage ../servers/nosql/mongodb { };
 
+  riak = callPackage ../servers/nosql/riak/1.3.1.nix { };
+
   mysql4 = import ../servers/sql/mysql {
     inherit fetchurl stdenv ncurses zlib perl;
     ps = procps; /* !!! Linux only */


### PR DESCRIPTION
This modifies how the `riak` and `riak-admin` scripts work such that one has to specify environment variables for where the data, log, and etc directories live.

This should be reviewed to make sure these are the kind of changes to how one operates Riak that we want.
