### PR TITLE
Add various libraries for the Haskell "pipes" ecosystem

### DIFF
--- a/pkgs/development/libraries/haskell/pipes-concurrency/default.nix
+++ b/pkgs/development/libraries/haskell/pipes-concurrency/default.nix
@@ -1,0 +1,13 @@
+{ cabal, pipes, stm, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "pipes-concurrency";
+  version = "1.1.0";
+  sha256 = "05xpwxhf08yf88ya89f8gcy4vphi6qxyccf2yiyi5zrf6c2pkr00";
+  buildDepends = [ pipes stm transformers ];
+  meta = {
+    description = "Concurrency for the pipes ecosystem";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/pipes-parse/default.nix
+++ b/pkgs/development/libraries/haskell/pipes-parse/default.nix
@@ -1,0 +1,13 @@
+{ cabal, pipes }:
+
+cabal.mkDerivation (self: {
+  pname = "pipes-parse";
+  version = "1.0.0";
+  sha256 = "0fk39a6d0ik5ghwyj6yyi9d0cj2sp22812fin7amcxcafrplf88w";
+  buildDepends = [ pipes ];
+  meta = {
+    description = "Parsing infrastructure for the pipes ecosystem";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/pipes-safe/default.nix
+++ b/pkgs/development/libraries/haskell/pipes-safe/default.nix
@@ -1,0 +1,13 @@
+{ cabal, pipes, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "pipes-safe";
+  version = "1.2.0";
+  sha256 = "0ki9i9378j8kgw5dd91b38r686pcr9fl2vf9dfgfshia072ppggj";
+  buildDepends = [ pipes transformers ];
+  meta = {
+    description = "Safety for the pipes ecosystem";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/pipes/default.nix
+++ b/pkgs/development/libraries/haskell/pipes/default.nix
@@ -1,0 +1,13 @@
+{ cabal, mmorph, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "pipes";
+  version = "3.3.0";
+  sha256 = "1bgznfv7hxqwj5f7vkm8d41phw63bl2swzr0wrz0pcqxlr42likb";
+  buildDepends = [ mmorph transformers ];
+  meta = {
+    description = "Compositional pipelines";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1551,6 +1551,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   pgm = callPackage ../development/libraries/haskell/pgm {};
 
+  pipes = callPackage ../development/libraries/haskell/pipes {};
+
   polyparse = callPackage ../development/libraries/haskell/polyparse {};
 
   poolConduit = callPackage ../development/libraries/haskell/pool-conduit {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1553,6 +1553,12 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   pipes = callPackage ../development/libraries/haskell/pipes {};
 
+  pipes-concurrency = callPackage ../development/libraries/haskell/pipes-concurrency {};
+
+  pipes-parse = callPackage ../development/libraries/haskell/pipes-parse {};
+
+  pipes-safe = callPackage ../development/libraries/haskell/pipes-safe {};
+
   polyparse = callPackage ../development/libraries/haskell/polyparse {};
 
   poolConduit = callPackage ../development/libraries/haskell/pool-conduit {};


### PR DESCRIPTION
Adds the main `pipes` library, along with `pipes-concurrency`, `pipes-parse` and `pipes-safe`.
