### PR TITLE
saleae-logic: new package

### DIFF
--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -1,0 +1,91 @@
+# Saleae logic analyzer software
+#
+# Suggested udev rules to be able to access the Logic device without being root:
+#   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="0925", ATTR{idProduct}=="3881", MODE="0666"
+#   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="21a9", ATTR{idProduct}=="1001", MODE="0666"
+
+{ stdenv, fetchurl, unzip, glib, libSM, libICE, gtk, libXext, libXft
+, fontconfig, libXrender, libXfixes, libX11, libXi, libXrandr, libXcursor
+, freetype, libXinerama
+, makeDesktopItem
+}:
+
+let
+
+  libPath = stdenv.lib.makeLibraryPath [
+    glib libSM libICE gtk libXext libXft fontconfig libXrender libXfixes libX11
+    libXi libXrandr libXcursor freetype libXinerama
+  ];
+
+in
+
+assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+
+stdenv.mkDerivation rec {
+  pname = "saleae-logic";
+  version = "1.1.15";
+  name = "${pname}-${version}";
+
+  src =
+    if stdenv.system == "i686-linux" then
+      fetchurl {
+	name = "saleae-logic-${version}-32bit.zip";
+	url = "http://downloads.saleae.com/Logic%20${version}%20(32-bit).zip";
+	sha256 = "0h13my4xgv8v8l12shimhhn54nn0dldbxz1gpbx92ysd8q8x1q79";
+      }
+    else if stdenv.system == "x86_64-linux" then
+      fetchurl {
+	name = "saleae-logic-${version}-64bit.zip";
+	url = "http://downloads.saleae.com/Logic%20${version}%20(64-bit).zip";
+	sha256 = "1phnjsmaj1gflx7shh8wfrd8dnhn43s3v7bck41h8yj4nd4ax69z";
+      }
+    else
+      abort "Saleae Logic software requires i686-linux or x86_64-linux";
+
+  desktopItem = makeDesktopItem {
+    name = "saleae-logic";
+    exec = "saleae-logic";
+    icon = ""; # the package contains no icon
+    comment = "Software for Saleae logic analyzers";
+    desktopName = "Saleae Logic";
+    genericName = "Logic analyzer";
+    categories = "Application;Development";
+  };
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    # Copy prebuilt app to $out
+    mkdir "$out"
+    cp -r * "$out"
+
+    # Patch it
+    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" "$out/Logic"
+    patchelf --set-rpath "${stdenv.gcc.gcc}/lib:${stdenv.gcc.gcc}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$out/Logic"
+
+    # Build the LD_PRELOAD library that makes Logic work from a read-only directory
+    mkdir -p "$out/lib"
+    gcc -shared -fPIC -DOUT=\"$out\" "${./preload.c}" -o "$out/lib/preload.so" -ldl
+
+    # Make wrapper script that uses the LD_PRELOAD library
+    mkdir -p "$out/bin"
+    cat > "$out/bin/saleae-logic" << EOF
+    #!${stdenv.shell}
+    export LD_PRELOAD="$out/lib/preload.so"
+    exec "$out/Logic" "\$@"
+    EOF
+    chmod a+x "$out"/bin/saleae-logic
+
+    # Copy the generated .desktop file
+    mkdir -p "$out/share/applications"
+    cp "$desktopItem"/share/applications/* "$out/share/applications/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Software for Saleae logic analyzers";
+    homepage = http://www.saleae.com/;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/development/tools/misc/saleae-logic/preload.c
+++ b/pkgs/development/tools/misc/saleae-logic/preload.c
@@ -1,0 +1,114 @@
+/*
+ * LD_PRELOAD trick to make Saleae Logic work from a read-only installation
+ * directory.
+ *
+ * Saleae Logic tries to write to the ./Settings/settings.xml file, relative to
+ * its installation directory. Because the nix store is read-only, we have to
+ * redirect access to this file somewhere else. Here's the map:
+ *
+ *   $out/Settings/settings.xml => $HOME/.saleae-logic-settings.xml
+ *
+ * This also makes the software multi-user aware :-)
+ *
+ * NOTE: The next Logic version is supposed to have command line parameters for
+ * configuring where the Settings/ directory is located, but until then we have
+ * to use this.
+ *
+ * Usage:
+ *   gcc -shared -fPIC -DOUT="$out" preload.c -o preload.so -ldl
+ *   LD_PRELOAD=$PWD/preload.so ./result/Logic
+ *
+ * To see the paths that are modified at runtime, set the environment variable
+ * PRELOAD_DEBUG to 1 (or anything really; debugging is on as long as the
+ * variable exists).
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dlfcn.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifndef OUT
+#error Missing OUT define - path to the installation directory.
+#endif
+
+typedef FILE *(*fopen_func_t)(const char *path, const char *mode);
+typedef FILE *(*fopen64_func_t)(const char *path, const char *mode);
+
+/*
+ * Redirect $out/Settings/settings.xml => $HOME/.saleae-logic-settings.xml. No
+ * other paths are changed. Path is truncated if bigger than PATH_MAX.
+ *
+ * @param pathname Original file path.
+ * @param buffer Pointer to a buffer of size PATH_MAX bytes that this function
+ * will write the new redirected path to (if needed).
+ *
+ * @return Pointer to the resulting path. It will either be equal to the
+ * pathname or buffer argument.
+ */
+static const char *redirect(const char *pathname, char *buffer)
+{
+	const char *homepath;
+	const char *new_path;
+	static char have_warned;
+
+	homepath = getenv("HOME");
+	if (!homepath) {
+		homepath = "/";
+		if (!have_warned && getenv("PRELOAD_DEBUG")) {
+			fprintf(stderr, "preload_debug: WARNING: HOME is unset, using \"/\" (root) instead.\n");
+			have_warned = 1;
+		}
+	}
+
+	new_path = pathname;
+	if (strcmp(OUT "/Settings/settings.xml", pathname) == 0) {
+		snprintf(buffer, PATH_MAX, "%s/.saleae-logic-settings.xml", homepath);
+		buffer[PATH_MAX-1] = '\0';
+		new_path = buffer;
+	}
+
+	return new_path;
+}
+
+FILE *fopen(const char *pathname, const char *mode)
+{
+	FILE *fp;
+	const char *path;
+	char buffer[PATH_MAX];
+	fopen_func_t orig_fopen;
+
+	orig_fopen = (fopen_func_t)dlsym(RTLD_NEXT, "fopen");
+	path = redirect(pathname, buffer);
+	fp = orig_fopen(path, mode);
+
+	if (path != pathname && getenv("PRELOAD_DEBUG")) {
+		fprintf(stderr, "preload_debug: fopen(\"%s\", \"%s\") => \"%s\": fp=%p\n", pathname, mode, path, fp);
+	}
+
+	return fp;
+}
+
+FILE *fopen64(const char *pathname, const char *mode)
+{
+	FILE *fp;
+	const char *path;
+	char buffer[PATH_MAX];
+	fopen64_func_t orig_fopen64;
+
+	orig_fopen64 = (fopen64_func_t)dlsym(RTLD_NEXT, "fopen64");
+	path = redirect(pathname, buffer);
+	fp = orig_fopen64(path, mode);
+
+	if (path != pathname && getenv("PRELOAD_DEBUG")) {
+		fprintf(stderr, "preload_debug: fopen64(\"%s\", \"%s\") => \"%s\": fp=%p\n", pathname, mode, path, fp);
+	}
+
+	return fp;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3420,6 +3420,8 @@ let
 
   remake = callPackage ../development/tools/build-managers/remake { };
 
+  saleaeLogic = callPackage ../development/tools/misc/saleae-logic { };
+
   # couldn't find the source yet
   seleniumRCBin = callPackage ../development/tools/selenium/remote-control {
     jre = jdk;


### PR DESCRIPTION
Add Saleae Logic - analyzer software for Saleae logic analyzators.

Also, add a small LD_PRELOAD library that is needed to make it work from
a read-only installation directory.
