### PR TITLE
nmap: fix GUI paths

### DIFF
--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -2,7 +2,7 @@
 , openssl, python, pygtk, makeWrapper, pygobject
 , pycairo, pysqlite
 }:
-  
+
 stdenv.mkDerivation rec {
   name = "nmap-5.50";
 
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     url = "http://nmap.org/dist/${name}.tar.bz2";
     sha256 = "aa044113caa47e172c154daed73afc70ffa18d359eb47c22a9ea85ffcb14ffb8";
   };
+
+  patches = [ ./zenmap.patch ];
 
   postInstall =
     ''

--- a/pkgs/tools/security/nmap/zenmap.patch
+++ b/pkgs/tools/security/nmap/zenmap.patch
@@ -1,0 +1,15 @@
+diff -ruN nmap-5.50.orig/zenmap/zenmapCore/Paths.py nmap-5.50/zenmap/zenmapCore/Paths.py
+--- nmap-5.50.orig/zenmap/zenmapCore/Paths.py	2013-06-06 05:52:10.723087428 +0000
++++ nmap-5.50/zenmap/zenmapCore/Paths.py	2013-06-06 07:07:25.481261761 +0000
+@@ -115,7 +115,10 @@
+     else:
+         # Normal script execution. Look in the current directory to allow
+         # running from the distribution.
+-        return os.path.abspath(os.path.dirname(fs_dec(sys.argv[0])))
++        #
++        # Grrwlf: No,no,dear. That's not a script, thats Nixos wrapper. Go add
++        # those '..' to substract /bin part.
++        return os.path.abspath(os.path.join(os.path.dirname(fs_dec(sys.argv[0])), ".."))
+
+ prefix = get_prefix()
+


### PR DESCRIPTION
Zenamp wrapper confuses python so it thinks that zenmap is launched as a script
and not as an executable. This leads to incorrect /share path and missing
templates. ./zenmap.patch cures that (a bit hacky as usual).
