### PR TITLE
 haskell-pipes: use camelCase to name pipes packages, rather than separating words with hyphens

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1560,11 +1560,11 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   pipes = callPackage ../development/libraries/haskell/pipes {};
 
-  pipes-concurrency = callPackage ../development/libraries/haskell/pipes-concurrency {};
+  pipesConcurrency = callPackage ../development/libraries/haskell/pipes-concurrency {};
 
-  pipes-parse = callPackage ../development/libraries/haskell/pipes-parse {};
+  pipesParse = callPackage ../development/libraries/haskell/pipes-parse {};
 
-  pipes-safe = callPackage ../development/libraries/haskell/pipes-safe {};
+  pipesSafe = callPackage ../development/libraries/haskell/pipes-safe {};
 
   polyparse = callPackage ../development/libraries/haskell/polyparse {};
 


### PR DESCRIPTION
Sorry for multiple commits here - I wasn't aware of the naming conventions.
