### PR TITLE
Ocaml/upgrade and new

### DIFF
--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -1,0 +1,43 @@
+{stdenv, fetchurl, omake, ocaml, omake_rc1, libtiff, libjpeg, libpng_apng, giflib, findlib, libXpm, freetype, graphicsmagick, ghostscript }:
+
+let
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+  pname = "camlimages";
+  version = "4.0.1";
+in
+
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl { 
+    url = "https://bitbucket.org/camlspotter/camlimages/get/v4.0.1.tar.gz";
+    sha256 = "b40237c1505487049799a7af296eb3996b3fa08eab94415546f46d61355747c4";
+  };
+
+  buildInputs = [ocaml omake_rc1 findlib graphicsmagick ghostscript ];
+
+  propagatedbuildInputs = [libtiff libjpeg libpng_apng giflib freetype libXpm ];
+
+  createFindlibDestdir = true;
+
+  preConfigure = ''
+    rm ./configure
+  '';
+
+  buildPhase = ''
+    omake
+  '';
+
+  installPhase = ''
+    omake install
+  '';
+
+  #makeFlags = "BINDIR=$(out)/bin  MANDIR=$(out)/usr/share/man/man1 DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib";
+
+  meta = {
+    homepage = http://cristal.inria.fr/camlimages;
+    description = "Image manipulation library";
+    license = "GnuGPLV2";
+#    maintainers = [ stdenv.lib.maintainers.roconnor ];
+  };
+}

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -2,16 +2,16 @@
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "1.04";
+  version = "1.05";
 in
 
 stdenv.mkDerivation {
   name = "camlzip-${version}";
 
   src = fetchurl {
-    url = "http://forge.ocamlcore.org/frs/download.php/328/" +
+    url = "http://forge.ocamlcore.org/frs/download.php/1037/" +
           "camlzip-${version}.tar.gz";
-    sha256 = "1zpchmp199x7f4mzmapvfywgy7f6wy9yynd9nd8yh8l78s5gixbn";
+    sha256 = "930b70c736ab5a7ed1b05220102310a0a2241564786657abe418e834a538d06b";
   };
 
   buildInputs = [zlib ocaml findlib];

--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -2,16 +2,16 @@
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "1.5";
+  version = "1.7";
 in
 
 stdenv.mkDerivation {
   name = "cryptokit-${version}";
 
   src = fetchurl {
-    url = "http://forge.ocamlcore.org/frs/download.php/639/" +
+    url = "http://forge.ocamlcore.org/frs/download.php/1166/" +
           "cryptokit-${version}.tar.gz";
-    sha256 = "1r5kbsbsicrbpdrdim7h8xg2b1a8qg8sxig9q6cywzm57r33lj72";
+    sha256 = "56a8c0339c47ca3cf43c8881d5b519d3bff68bc8a53267e9c5c9cbc9239600ca";
   };
 
   buildInputs = [zlib ocaml findlib ncurses];

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -1,0 +1,33 @@
+{stdenv, fetchurl, ocaml, findlib}:
+
+let
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+  pname = "dypgen";
+  version = "20120619-1";
+in
+
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://dypgen.free.fr/dypgen-20120619-1.tar.bz2";
+    sha256 = "ecb53d6e469e9ec4d57ee6323ff498d45b78883ae13618492488e7c5151fdd97";
+  };
+
+  buildInputs = [ocaml findlib];
+
+  createFindlibDestdir = true;
+
+  buildPhase = ''
+    make
+  '';
+
+  makeFlags = "BINDIR=$(out)/bin  MANDIR=$(out)/usr/share/man/man1 DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib";
+
+  meta = {
+    homepage = http://dypgen.free.fr;
+    description = "Dypgen GLR self extensible parser generator";
+    license = "CeCILL-B_V1";
+#    maintainers = [ stdenv.lib.maintainers.roconnor ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lablgl/Makefile.config.patch
+++ b/pkgs/development/ocaml-modules/lablgl/Makefile.config.patch
@@ -1,0 +1,117 @@
+diff -Naur lablGL.ori/Makefile.config lablGL/Makefile.config
+--- lablGL.ori/Makefile.config	1970-01-01 01:00:00.000000000 +0100
++++ lablGL/Makefile.config	2013-06-02 08:13:10.000000000 +0200
+@@ -0,0 +1,63 @@
++#	LablGL and Togl configuration file
++#
++# Please have a look at the config/Makefile in the Objective Caml distribution,
++# or at the labltklink script to get the information needed here
++#
++
++##### Adjust these always
++
++# Uncomment if you have the fast ".opt" compilers
++#CAMLC = ocamlc.opt
++#CAMLOPT = ocamlopt.opt
++
++# Where to put the lablgl script
++BINDIR = @BINDIR@
++
++# Where to find X headers
++XINCLUDES = @XINCLUDES@
++# X libs (for broken RTLD_GLOBAL: e.g. FreeBSD 4.0)
++#XLIBS = -L/usr/X11R6/lib -lXext -lXmu -lX11 -lXi
++
++# Where to find Tcl/Tk headers
++# This must the same version as for LablTk
++TKINCLUDES = @TKINCLUDES@
++# Tcl/Tk libs (for broken RTLD_GLOBAL: e.g. FreeBSD 4.0)
++#TKLIBS = -L/usr/local/lib -ltk84 -ltcl84
++
++# Where to find OpenGL/Mesa/Glut headers and libraries
++GLINCLUDES =
++GLLIBS = -lGL -lGLU
++GLUTLIBS = -lglut
++# The following libraries may be required (try to add them one at a time)
++#GLLIBS = -lGL -lGLU -lXmu -lXext -lXi -lcipher -lpthread
++
++# How to index a library after installing (ranlib required on MacOSX)
++RANLIB = :
++#RANLIB = ranlib
++
++##### Uncomment these for windows
++#TKLIBS = tk83.lib tcl83.lib gdi32.lib user32.lib
++#GLLIBS = opengl32.lib glu32.lib 
++#TOOLCHAIN = msvc
++#XA = .lib
++#XB = .bat
++#XE = .exe
++#XO = .obj
++#XS = .dll
++
++##### Adjust these if non standard
++
++# The Objective Caml library directory
++#LIBDIR = `ocamlc -where`
++
++# Where to put dlls (if dynamic loading available)
++DLLDIR = @DLLDIR@
++
++# Where to put LablGL (standard)
++INSTALLDIR = @INSTALLDIR@
++
++# Where is Togl (default)
++#TOGLDIR = Togl
++
++# C Compiler options
++#COPTS = -c -O
+diff -Naur lablGL.ori/META lablGL/META
+--- lablGL.ori/META	1970-01-01 01:00:00.000000000 +0100
++++ lablGL/META	2013-06-02 22:00:59.000000000 +0200
+@@ -0,0 +1,21 @@
++description = "Bindings for OpenGL graphics engines"
++version = "1.04-1"
++archive(byte) = "lablgl.cma"
++archive(native) = "lablgl.cmxa"
++
++#package "togl" (
++#	description = "OpenGL widget for labltk"
++#	version = "1.01"
++#	requires = "lablgl, labltk"
++#	archive(byte) = "togl.cma"
++#	archive(native) = "togl.cmxa"
++#)
++
++package "glut" (
++	description = "Platform-independent OpenGL window"
++	version = "1.01"
++	requires = "lablgl"
++	archive(byte) = "lablglut.cma"
++	archive(native) = "lablglut.cmxa"
++)
++
+diff -Naur lablGL.ori/META~ lablGL/META~
+--- lablGL.ori/META~	1970-01-01 01:00:00.000000000 +0100
++++ lablGL/META~	2013-06-02 21:59:17.000000000 +0200
+@@ -0,0 +1,21 @@
++description = "Bindings for OpenGL graphics engines"
++version = "1.04-1"
++archive(byte) = "lablgl.cma"
++archive(native) = "lablgl.cmxa"
++
++#package "togl" (
++#	description = "OpenGL widget for labltk"
++#	version = "1.01"
++#	requires = "lablGL, labltk"
++#	archive(byte) = "togl.cma"
++#	archive(native) = "togl.cmxa"
++#)
++
++package "glut" (
++	description = "Platform-independent OpenGL window"
++	version = "1.01"
++	requires = "lablGL"
++	archive(byte) = "lablglut.cma"
++	archive(native) = "lablglut.cmxa"
++)
++

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -1,0 +1,45 @@
+{stdenv, fetchurl, ocaml, lablgtk, findlib, mesa, freeglut } :
+
+let
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+  pname = "lablgl";
+  version = "1.04-1";
+in
+
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl { 
+    url = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/dist/lablgl-20120306.tar.gz";
+    sha256 = "1w5di2n38h7fkrf668zphnramygwl7ybjhrmww3pi9jcf9apa09r";
+  };
+
+  buildInputs = [ocaml findlib lablgtk mesa freeglut ];
+
+  patches = [ ./Makefile.config.patch ];
+
+  preConfigure = ''
+    substituteInPlace Makefile.config \
+      --subst-var-by BINDIR $out/bin \
+      --subst-var-by INSTALLDIR $out/lib/ocaml/${ocaml_version}/site-lib/lablgl \
+      --subst-var-by DLLDIR $out/lib/ocaml/${ocaml_version}/site-lib/lablgl/stublibs \
+      --subst-var-by TKINCLUDES "" \
+      --subst-var-by XINCLUDES ""
+  '';
+
+  createFindlibDestdir = true;
+
+  #makeFlags = "BINDIR=$(out)/bin  MANDIR=$(out)/usr/share/man/man1 DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib";
+  buildFlags = "lib libopt glut glutopt";
+
+  postInstall = ''
+    cp ./META $out/lib/ocaml/${ocaml_version}/site-lib/lablgl
+  '';
+
+  meta = {
+    homepage = http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgl.html;
+    description = "OpenGL bindings for ocaml";
+    license = "GnuGPLV2";
+#    maintainers = [ stdenv.lib.maintainers.roconnor ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -3,25 +3,26 @@
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "lablgtk";
-  version = "2.14.2";
+  version = "2.16.0";
 in
 
 stdenv.mkDerivation (rec {
   name = "${pname}-${version}";
   src = fetchurl {
-    url = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/olabl/dist/${name}.tar.gz";
-    sha256 = "1fnh0amm7lwgyjdhmlqgsp62gwlar1140425yc1j6inwmgnsp0a9";
+    url = "https://forge.ocamlcore.org/frs/download.php/979/${name}.tar.gz";
+    sha256 = "a0ea9752eb257dadcfc2914408fff339d4c34357802f02c63329dd41b777de2f";
   };
 
   buildInputs = [ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview];
 
-  patches = [ ./META.patch ];
+  # patches = [ ./META.patch ];
 
   configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
   buildFlags = "world";
 
-  postInstall = ''
-    ocamlfind install lablgtk2 META
+  preInstall = ''
+    mkdir -p $out/lib/ocaml/${ocaml_version}/site-lib
+    export OCAMLPATH=$out/lib/ocaml/${ocaml_version}/site-lib/:$OCAMLPATH
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocaml-cairo/META.patch
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/META.patch
@@ -1,0 +1,16 @@
+diff -Naur cairo-ocaml-1.2.0.ori/META cairo-ocaml-1.2.0/META
+--- cairo-ocaml-1.2.0.ori/META	1970-01-01 01:00:00.000000000 +0100
++++ cairo-ocaml-1.2.0/META	2013-06-04 03:31:32.000000000 +0200
+@@ -0,0 +1,12 @@
++name = "cairo-ocaml"
++description = "Bindings to the cairo library."
++version = "@VERSION@"
++archive(byte) = "cairo.cma"
++archive(native) = "cairo.cmxa"
++requires = "bigarray"
++
++package "lablgtk2" (
++        requires = "cairo lablgtk2"
++        archive(byte) = "cairo_lablgtk.cma"
++        archive(native) = "cairo_lablgtk.cmxa"
++)

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -1,0 +1,44 @@
+{stdenv, fetchurl, automake, ocaml, autoconf, gnum4, pkgconfig, freetype, lablgtk, unzip, cairo, findlib, gdk_pixbuf, glib, gtk, pango }: 
+
+let
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+  pname = "ocaml-cairo";
+  version = "1.2.0";
+in
+
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl { 
+    url = "http://cgit.freedesktop.org/cairo-ocaml/snapshot/cairo-ocaml-${version}.zip";
+    sha256 = "2d59678e322c331e3f4bc02a77240fce4a0917acb0d3ae75953a6ac62d70a125";
+  };
+
+  patches = [ ./META.patch ];
+
+  buildInputs = [ocaml automake gnum4 autoconf unzip pkgconfig findlib freetype lablgtk cairo gdk_pixbuf gtk pango ];
+
+  createFindlibDestdir = true;
+
+ preConfigure = ''
+   aclocal -I support
+   autoconf
+   export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE `pkg-config --cflags cairo gdk-pixbuf glib  gtk+ pango`" 
+   export LABLGTKDIR=${lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2
+   cp ${lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2/pango.ml ./src
+   cp ${lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2/gaux.ml ./src
+  '';
+
+  postInstall = ''
+    cp META $out/lib/ocaml/${ocaml_version}/site-lib/cairo/
+  '';
+
+  makeFlags = "INSTALLDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib/cairo";
+
+  meta = {
+    homepage = http://cairographics.org/cairo-ocaml;
+    description = "ocaml bindings for cairo library";
+    license = "GnuGPLV2";
+#    maintainers = [ stdenv.lib.maintainers.roconnor ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocamlnet/configure.patch
+++ b/pkgs/development/ocaml-modules/ocamlnet/configure.patch
@@ -1,0 +1,63 @@
+diff -Naur ocamlnet-3.6.3.ori/configure ocamlnet-3.6.3/configure
+--- ocamlnet-3.6.3.ori/configure	2013-01-14 00:04:59.000000000 +0000
++++ ocamlnet-3.6.3/configure	2013-06-02 21:33:08.000000000 +0000
+@@ -642,59 +642,6 @@
+ 	exit 1
+     fi
+ 
+-    printf "%s" "Checking whether lablgtk2 has GMain.Io.remove... "
+-    mkdir -p tmp
+-    cat <<EOF >tmp/gtk.ml
+-let _ = GMain.Io.remove;;
+-EOF
+-
+-    if ocamlfind ocamlc -package lablgtk2 -c tmp/gtk.ml >/dev/null 2>/dev/null;
+-    then
+-        echo "yes"
+-    else
+-        echo "no"
+-        echo "Your version of lablgtk2 is too old!"
+-	exit 1
+-    fi
+-    
+-    printf "%s" "Checking whether lablgtk2 has GMain.Io.add_watch with list support... "
+-    mkdir -p tmp
+-    cat <<'EOF' >tmp/gtk.ml
+-open GMain.Io
+-let _ = (add_watch : cond:condition list -> callback:(condition list -> bool) -> ?prio:int -> channel -> id);;
+-exit 0
+-EOF
+-    # Note: this newer API is never broken in the sense checked below, i.e.
+-    # such lablgtk2 versions do not exist.
+-    if ocamlfind ocamlc -package unix,lablgtk2 -linkpkg -o tmp/gtk tmp/gtk.ml >/dev/null 2>/dev/null && tmp/gtk; then
+-        echo "yes"
+-        gtk2_io_add_watch_supports_lists="-ppopt -DGTK2_IO_ADD_WATCH_SUPPORTS_LISTS"
+-    else
+-        echo "no"
+-        printf "%s" "Checking whether lablgtk2's GMain.Io.add_watch is broken... "
+-        mkdir -p tmp
+-        cat <<'EOF' >tmp/gtk.ml
+-GMain.Main.init();;
+-let ch = GMain.Io.channel_of_descr (Unix.stdout) in
+-let w = GMain.Io.add_watch
+-          ~cond:`OUT ~callback:(fun () -> true) ch in
+-(* add_watch is broken when it just returns Val_unit, and ok when it
+- * returns a positive int
+- *)
+-if (Obj.magic w : int) > 0 then
+-  exit 0
+-else
+-  exit 1
+-EOF
+-	if ocamlfind ocamlc -package unix,lablgtk2 -linkpkg -o tmp/gtk tmp/gtk.ml >/dev/null 2>/dev/null && tmp/gtk; then
+-            echo "no"
+-        else
+-            echo "yes"
+-            echo "You should apply the patch-ab-ml_glib.c to lablgtk2 to fix this!"
+-	    exit 1
+-        fi
+-    fi
+-
+     for f in Makefile uq_gtk.ml uq_gtk.mli uq_gtk_helper.ml; do
+ 	rm -f src/equeue-gtk2/$f
+ 	ln -s ../equeue-gtk1/$f src/equeue-gtk2

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -1,18 +1,22 @@
-{stdenv, fetchurl, ncurses, ocaml, findlib, ocaml_pcre, camlzip, openssl, ocaml_ssl}:
+{stdenv, fetchurl, ncurses, ocaml, findlib, ocaml_pcre, camlzip, openssl, ocaml_ssl, lablgtk, cryptokit }:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 
 stdenv.mkDerivation {
-  name = "ocamlnet-3.6";
+  name = "ocamlnet-3.6.3";
 
   src = fetchurl {
-    url = http://download.camlcity.org/download/ocamlnet-3.6.tar.gz;
-    sha256 = "306c20aee6512be3564c0f39872b70f929c06e1e893cfcf528ac47ae35cf7a69";
+    url = http://download.camlcity.org/download/ocamlnet-3.6.3.tar.gz;
+    sha256 = "c62fe0a4db6c63c04e24c8d76bcb504054f0b59a7a41c1abcbb8dd504afc9f29";
   };
 
-  buildInputs = [ncurses ocaml findlib ocaml_pcre camlzip openssl ocaml_ssl];
+  buildInputs = [ncurses ocaml findlib ocaml_pcre camlzip openssl ocaml_ssl lablgtk cryptokit];
+
+  propagatedbuildInputs = [ncurses ocaml_pcre camlzip openssl ocaml_ssl lablgtk cryptokit];
+
+  patches = [ ./configure.patch ];
 
   createFindlibDestdir = true;
 
@@ -23,6 +27,10 @@ stdenv.mkDerivation {
       -bindir $out/bin
       -enable-ssl
       -enable-zip
+      -enable-pcre
+      -enable-crypto
+      -disable-gtk2
+      -with-nethttpd
       -datadir $out/lib/ocaml/${ocaml_version}/ocamlnet
     )
   '';

--- a/pkgs/development/ocaml-modules/sqlite3/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3/default.nix
@@ -1,18 +1,19 @@
-{stdenv, fetchurl, sqlite, ocaml, findlib}:
+{stdenv, fetchurl, sqlite, ocaml, findlib, pkgconfig}:
 
 stdenv.mkDerivation {
-  name = "ocaml-sqlite3-1.6.3";
+  name = "ocaml-sqlite3-2.0.4";
 
   src = fetchurl {
-    url = https://bitbucket.org/mmottl/sqlite3-ocaml/downloads/sqlite3-ocaml-1.6.3.tar.gz;
-    sha256 = "004wysf80bmb8r4yaa648v0bqrh2ry3kzy763gdksw4n15blghv5";
+    url = https://bitbucket.org/mmottl/sqlite3-ocaml/downloads/sqlite3-ocaml-2.0.4.tar.gz;
+    sha256 = "51ccb4c7a240eb40652c59e1770cfe1827dfa1eb926c969d19ff414aef4e80a1";
   };
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ocaml findlib pkgconfig ];
 
-  configureFlags = "--with-sqlite3=${sqlite}";
+  #configureFlags = "--with-sqlite3=${sqlite}";
 
   preConfigure = ''
+    export PKG_CONFIG_PATH=${sqlite}/lib/pkgconfig/
     export OCAMLPATH=$OCAMLPATH:$OCAMLFIND_DESTDIR
     mkdir -p $out/bin
   '';

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchurl, makeWrapper, ocaml, ncurses}:
+let
+  pname = "omake";
+  version = "0.9.8.6-0.rc1";
+  webpage = "http://omake.metaprl.org";
+in
+stdenv.mkDerivation {
+
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/downloads/${pname}-${version}.tar.gz";
+    sha256 = "1sas02pbj56m7wi5vf3vqrrpr4ynxymw2a8ybvfj2dkjf7q9ii13";
+  };
+  patchFlags = "-p0";
+  patches = [ ./warn.patch ];
+
+  buildInputs = [ ocaml makeWrapper ncurses ];
+
+  phases = "unpackPhase patchPhase buildPhase";
+  buildPhase = ''
+    make bootstrap
+    make PREFIX=$out all
+    make PREFIX=$out install
+  '';
+#  prefixKey = "-prefix ";
+#
+#  configureFlags = if transitional then "--transitional" else "--strict";
+#
+#  buildFlags = "world.opt";		
+
+  meta = {
+    description = "Omake build system";
+    homepage = "${webpage}";
+    license = "GPL";
+  };
+}

--- a/pkgs/development/tools/ocaml/omake/warn.patch
+++ b/pkgs/development/tools/ocaml/omake/warn.patch
@@ -1,0 +1,10 @@
+diff -p1 -aur ../omake-0.9.8.6.ori/lib/build/OCaml.om ./lib/build/OCaml.om
+--- ../omake-0.9.8.6.ori/lib/build/OCaml.om	2008-03-05 01:07:25.000000000 +0000
++++ ./lib/build/OCaml.om	2013-06-01 15:52:37.000000000 +0000
+@@ -178,3 +178,3 @@ declare OCAMLDEPFLAGS
+ public.OCAMLPPFLAGS  =
+-public.OCAMLFLAGS    = -warn-error A
++public.OCAMLFLAGS    =
+ public.OCAMLCFLAGS   = -g
+Seulement dans ./lib/build: OCaml.om~
+Seulement dans .: warn.patch

--- a/pkgs/tools/typesetting/patoline/default.nix
+++ b/pkgs/tools/typesetting/patoline/default.nix
@@ -1,0 +1,51 @@
+
+{ stdenv, fetchurl, ncurses, mesa, freeglut, libzip, 
+   ocaml, findlib, camomile, 
+   dypgen, ocaml_sqlite3, camlzip, 
+   lablgtk, camlimages, ocaml_cairo,
+   lablgl, ocamlnet, cryptokit,
+   ocaml_pcre }:
+
+let
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+
+stdenv.mkDerivation {
+  name = "patoline-0.1";
+
+  src = fetchurl {
+    url = "http://lama.univ-savoie.fr/patoline/patoline-0.1.tar.bz";
+    sha256 = "c5ac8dcb87ceecaf11876bd0dd425bd0f04d43265adc2cbcb1f1e82a78846d49";
+  };
+
+  createFindlibDestdir = true;
+   
+   buildInputs = [ ocaml findlib dypgen camomile ocaml_sqlite3 camlzip 
+   lablgtk camlimages ocaml_cairo
+   lablgl ocamlnet cryptokit
+   ocaml_pcre ncurses mesa freeglut libzip ];
+
+  propagatedbuildInputs = [ camomile 
+   dypgen ocaml_sqlite3 camlzip 
+   lablgtk camlimages ocaml_cairo
+   lablgl ocamlnet cryptokit
+   ocaml_pcre ncurses mesa freeglut libzip ];
+
+  buildPhase = ''
+    ocaml configure.ml \
+       --prefix $out \
+       --ocaml-libs $out/lib/ocaml/${ocaml_version}/site-lib \
+       --ocamlfind-dir $out/lib/ocaml/${ocaml_version}/site-lib \
+       --fonts-dir $out/share/patoline/fonts \
+       --grammars-dir $out/share/patoline/grammars \
+       --hyphen-dir $out/share/patoline/hyphen
+
+    make
+  '';
+
+  
+  meta = {
+    homepage = http://patoline.com;
+    description = "Patoline ocaml based typesetting system";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2699,11 +2699,21 @@ let
     camomile_0_8_2 = callPackage ../development/ocaml-modules/camomile/0.8.2.nix { };
     camomile = callPackage ../development/ocaml-modules/camomile { };
 
+    camlimages = callPackage ../development/ocaml-modules/camlimages { };
+
+    ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
+
     cryptokit = callPackage ../development/ocaml-modules/cryptokit { };
 
     findlib = callPackage ../development/tools/ocaml/findlib { };
 
+    dypgen = callPackage ../development/ocaml-modules/dypgen { };
+
+    patoline = callPackage ../tools/typesetting/patoline { };
+
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
+
+    lablgl = callPackage ../development/ocaml-modules/lablgl { };
 
     lablgtk = callPackage ../development/ocaml-modules/lablgtk {
       inherit (gnome) libgnomecanvas libglade gtksourceview;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3385,6 +3385,7 @@ let
   noweb = callPackage ../development/tools/literate-programming/noweb { };
 
   omake = callPackage ../development/tools/ocaml/omake { };
+  omake_rc1 = callPackage ../development/tools/ocaml/omake/0.9.8.6-rc1.nix { };
 
   openocd = callPackage ../development/tools/misc/openocd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2786,22 +2786,6 @@ let
 
   ocamlnat = let callPackage = newScope pkgs.ocamlPackages_3_12_1; in callPackage ../development/ocaml-modules/ocamlnat { };
 
-  # patoline requires a rather large ocaml compilation environment.
-  # this is why it is build as an environment and not just a normal package.
-  # remark : the emacs mode is also installed, but you have to adjust your load-path.
-  mkPatolineEnv = pack: pkgs.myEnvFun {
-      name = "patoline";
-      buildInputs = [ stdenv ncurses mesa freeglut libzip
-                                   pack.ocaml pack.findlib pack.camomile 
-	                           pack.dypgen pack.ocaml_sqlite3 pack.camlzip 
-				   pack.lablgtk pack.camlimages pack.ocaml_cairo
-				   pack.lablgl pack.ocamlnet pack.cryptokit
-				   pack.ocaml_pcre pack.patoline
-				   ];
-   };
-
-   patoline = mkPatolineEnv ocamlPackages_4_00_1;
-
   opencxx = callPackage ../development/compilers/opencxx {
     gcc = gcc33;
   };
@@ -9447,6 +9431,28 @@ let
     inherit substituteAll pkgs;
     inherit (stdenv) mkDerivation;
   };
+
+  # patoline requires a rather large ocaml compilation environment.
+  # this is why it is build as an environment and not just a normal package.
+  # remark : the emacs mode is also installed, but you have to adjust your load-path.
+  PatolineEnv = pack: myEnvFun {
+      name = "patoline";
+      buildInputs = [ stdenv ncurses mesa freeglut libzip gcc
+                                   pack.ocaml pack.findlib pack.camomile 
+	                           pack.dypgen pack.ocaml_sqlite3 pack.camlzip 
+				   pack.lablgtk pack.camlimages pack.ocaml_cairo
+				   pack.lablgl pack.ocamlnet pack.cryptokit
+				   pack.ocaml_pcre pack.patoline
+				   ];
+    # this is to circumvent the bug with libgcc_s.so.1 which is
+    # not found when using thread				   
+    extraCmds = ''
+       LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${gcc.gcc}/lib
+       export LD_LIBRARY_PATH
+    '';
+   };
+
+   patoline = PatolineEnv ocamlPackages_4_00_1;
 
   znc = callPackage ../applications/networking/znc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2786,6 +2786,22 @@ let
 
   ocamlnat = let callPackage = newScope pkgs.ocamlPackages_3_12_1; in callPackage ../development/ocaml-modules/ocamlnat { };
 
+  # patoline requires a rather large ocaml compilation environment.
+  # this is why it is build as an environment and not just a normal package.
+  # remark : the emacs mode is also installed, but you have to adjust your load-path.
+  mkPatolineEnv = pack: pkgs.myEnvFun {
+      name = "patoline";
+      buildInputs = [ stdenv ncurses mesa freeglut libzip
+                                   pack.ocaml pack.findlib pack.camomile 
+	                           pack.dypgen pack.ocaml_sqlite3 pack.camlzip 
+				   pack.lablgtk pack.camlimages pack.ocaml_cairo
+				   pack.lablgl pack.ocamlnet pack.cryptokit
+				   pack.ocaml_pcre pack.patoline
+				   ];
+   };
+
+   patoline = mkPatolineEnv ocamlPackages_4_00_1;
+
   opencxx = callPackage ../development/compilers/opencxx {
     gcc = gcc33;
   };


### PR DESCRIPTION
Work on ocaml packages:
  new: dypgen, lablgl, patoline, ocaml-cairo, camlimages
  updated: ocamlnet, lablgtk, sqlite3, camlzip, omake

Notes:
  most of the updated packages did not compile with ocaml-4.00.1
  omake needs an rc1 version to compile camlimages with 4.00.1
  since this is rc, I kept the current version as default.
