### PR TITLE
Added tuareg emacs mode and fixed some other emacs mode.

### DIFF
--- a/pkgs/applications/editors/emacs-modes/jdee/default.nix
+++ b/pkgs/applications/editors/emacs-modes/jdee/default.nix
@@ -11,7 +11,7 @@ in
     src = fetchsvn {
       url = "https://jdee.svn.sourceforge.net/svnroot/jdee/trunk/jdee";
       rev = revision;
-      sha256 = "1qj5cv74dp6nf6060jyvnlcbmc4sz8a09806gwa1zfiwz6mm9zrs";
+      sha256 = "1z1y957glbqm7z3dhah9h4jysw3173pq1gpx5agfwcw614n516xz";
     };
 
     patchFlags = "-p1 --ignore-whitespace";

--- a/pkgs/applications/editors/emacs-modes/quack/default.nix
+++ b/pkgs/applications/editors/emacs-modes/quack/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   src = fetchurl {
     # XXX: Upstream URL is not versioned, which might eventually break this.
     url = "http://www.neilvandyke.org/quack/quack.el";
-    sha256 = "1w3p03f1f3l2nldxc7dig1kkgbbvy5j7zid0cfmkcrpp1qrcsqic";
+    sha256 = "1q5bsllxkibiddwp32306flqm8s3caffnpbqz5ka260avllp4jj5";
   };
 
   buildInputs = [ emacs ];

--- a/pkgs/applications/editors/emacs-modes/session-management-for-emacs/default.nix
+++ b/pkgs/applications/editors/emacs-modes/session-management-for-emacs/default.nix
@@ -4,10 +4,11 @@ stdenv.mkDerivation rec {
   name = "session-management-for-emacs-2.2a";
   
   src = fetchurl {
-    url = "mirror://sourceforge.net/sourceforge/emacs-session/session-2.2a.tar.gz";
-    sha256 = "0i01dnkizs349ahyybzy0mjzgj52z65rxynsj2mlw5mm41sbmprp";
+    url = "http://downloads.sourceforge.net/project/emacs-session/session/2.2a/session-2.2a.tar.gz";
+#    url = "mirror://sourceforge.net/sourceforge/emacs-session/session-2.2a.tar.gz";
+    sha256 = "37dfba7420b5164eab90dafa9e8bf9a2c8f76505fe2fefa14a64e81fa76d0144";
   };
-  
+
   buildInputs = [emacs];
   
   installPhase = ''

--- a/pkgs/applications/editors/emacs-modes/tuareg/default.nix
+++ b/pkgs/applications/editors/emacs-modes/tuareg/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, emacs }:
+
+# this package installs the emacs-mode which
+# resides in the ocaml compiler sources.
+
+let version = "2.0.6";
+
+in stdenv.mkDerivation {
+  name = "tuareg-mode-${version}";
+  src = fetchurl {
+    url = https://forge.ocamlcore.org/frs/download.php/882/tuareg-2.0.6.tar.gz;
+    sha256 = "ea79ac24623b82ab8047345f8504abca557a537e639d16ce1ac3e5b27f5b1189";
+  }; 
+
+  buildInputs = [ emacs ];
+
+  installPhase = ''
+    ensureDir "$out/share/emacs/site-lisp"
+    cp *.el *.elc  "$out/share/emacs/site-lisp"
+  '';
+
+  meta = {
+    homepage = http://caml.inria.fr;
+    description = "OCaml mode package for Emacs";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7059,7 +7059,7 @@ let
 
     cua = callPackage ../applications/editors/emacs-modes/cua { };
 
-    ecb = callPackage ../applications/editors/emacs-modes/ecb { };
+    # ecb = callPackage ../applications/editors/emacs-modes/ecb { };
 
     jabber = callPackage ../applications/editors/emacs-modes/jabber { };
 
@@ -7092,6 +7092,8 @@ let
     haskellMode = callPackage ../applications/editors/emacs-modes/haskell { };
 
     ocamlMode = callPackage ../applications/editors/emacs-modes/ocaml { };
+
+    tuaregMode = callPackage ../applications/editors/emacs-modes/tuareg { };
 
     hol_light_mode = callPackage ../applications/editors/emacs-modes/hol_light { };
 


### PR DESCRIPTION
After adding tuareg-mode (an improved emacs mode for ocaml),
I checked that all emacs-mode succesfully compiles and install with emacs 24 (I fixed all the non working ones). The fixed modes are
- fdee
- quack
- session managment

The only one that do not work after this patch is ecb. After some search, it seems that it should use an integrated "decet" inside emacs 23.2 or 24, but it still depends on 
an external decet. I tried various things and failed, therefore I commented this emacs mode.

I also tested with emacs 23 ... and at least gist fails to compile and install. 

I still do a pull request because I fixed some mode at least. 
