### PR TITLE
Add keepass password manager and update mono DLLMap.

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, unzip, makeDesktopItem, mono }:
+
+stdenv.mkDerivation rec {
+  name = "keepass-${version}";
+  version = "2.22";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/keepass/KeePass-${version}.zip";
+    sha256 = "0mman7r1jmirfwzix5qww0yn4rrgzcg7546basxjvvfc8flp43j0";
+  };
+
+  sourceRoot = ".";
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  desktopItem = makeDesktopItem {
+    name = "keepass";
+    exec = "keepass";
+    comment = "Password manager";
+    desktopName = "Keepass";
+    genericName = "Password manager";    
+    categories = "Application;Other;";
+  };
+
+
+  installPhase = ''
+    ensureDir "$out/bin"
+    echo "${mono}/bin/mono $out/KeePass.exe" > $out/bin/keepass
+    chmod +x $out/bin/keepass
+    echo $out
+    cp -r ./* $out/
+    ensureDir "$out/share/applications"
+    cp ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  buildInputs = [ unzip ];
+
+  meta = {
+    description = "GUI password manager with strong cryptography";
+    homepage = http://www.keepass.info/;
+    maintainers = with stdenv.lib.maintainers; [amorsillo];
+    platforms = with stdenv.lib.platforms; all;
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/lib/maintainers.nix
+++ b/pkgs/lib/maintainers.nix
@@ -8,6 +8,7 @@
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
   amiddelk = "Arie Middelkoop <amiddelk@gmail.com>";
   andres = "Andres Loeh <ksnixos@andres-loeh.de>";
+  amorsillo = "Andrew Morsillo <andrew.morsillo@gmail.com>";
   antono = "Antono Vasiljev <self@antono.info>";
   astsmtl = "Alexander Tsamutali <astsmtl@yandex.ru>";
   aszlig = "aszlig <aszlig@redmoonstudios.org>";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2645,7 +2645,9 @@ let
 
   mlton = callPackage ../development/compilers/mlton { };
 
-  mono = callPackage ../development/compilers/mono { };
+  mono = callPackage ../development/compilers/mono { 
+    inherit (xlibs) libX11;    
+  };
 
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
@@ -7160,6 +7162,8 @@ let
   evopedia = callPackage ../applications/misc/evopedia { };
 
   keepassx = callPackage ../applications/misc/keepassx { };
+
+  keepass = callPackage ../applications/misc/keepass { };
 
   # FIXME: Evince and other GNOME/GTK+ apps (e.g., Viking) provide
   # `share/icons/hicolor/icon-theme.cache'.  Arbitrarily give this one a


### PR DESCRIPTION
Added the keepass password manager. To make it run I had to modify mono's config "DLLMap" so that mono could find libX11 and libgdiplus at runtime.

http://www.mono-project.com/Config_DllMap

I don't think my changes to mono cover all of the possible "DLL Missing" errors but they do make a basic winforms application like keepass work.
