### PR TITLE
ppp: enable ipv6 support

### DIFF
--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -18,7 +18,12 @@ stdenv.mkDerivation rec {
       ./nonpriv.patch
     ];
 
-  postPatch = "rm -v include/linux/if_pppol2tp.h";
+  postPatch = ''
+    # enable ipv6
+    substituteInPlace pppd/Makefile.linux \
+      --replace "#HAVE_INET6=y" "HAVE_INET6=y"
+    rm -v include/linux/if_pppol2tp.h
+  '';
 
   buildInputs = [ libpcap ];
 


### PR DESCRIPTION
networkmanager requires pppd to have ipv6 support for managing mobile
connections since version 0.9.5.95, ref. to commit 7575f4d [1] or mailinglist [2].

i also thought about setting it up as an option which is only pulled in by nm, but i don't see enough benefit for the added complexity.

footnotes:

[1] http://cgit.freedesktop.org/NetworkManager/NetworkManager/commit/?id=7575f4d1e451a006e4ddd9cc6caa664ce07df83f

[2] https://mail.gnome.org/archives/networkmanager-list/2012-October/msg00053.html
