### PR TITLE
Get vim_configurable compiling on darwin

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -4,7 +4,12 @@ args@{source ? "latest", ...}: with args;
 
 
 let inherit (args.composableDerivation) composableDerivation edf; in
-composableDerivation {} (fix: {
+composableDerivation {
+  # use gccApple to compile on darwin
+  mkDerivation = ( if stdenv.isDarwin
+                   then stdenvAdapters.overrideGCC stdenv gccApple
+                   else stdenv ).mkDerivation;
+} (fix: {
 
     name = "vim_configurable-7.3";
 
@@ -37,9 +42,9 @@ composableDerivation {} (fix: {
 
     configureFlags = ["--enable-gui=auto" "--with-features=${args.features}"];
 
-    nativeBuildInputs = [ncurses pkgconfig]
-      ++ [ gtk libX11 libXext libSM libXpm libXt libXaw libXau libXmu glib 
-           libICE ];
+    nativeBuildInputs
+      = [ ncurses pkgconfig gtk libX11 libXext libSM libXpm libXt libXaw libXau
+          libXmu glib libICE ];
 
     # most interpreters aren't tested yet.. (see python for example how to do it)
     flags = {
@@ -71,14 +76,18 @@ composableDerivation {} (fix: {
 
   cfg = {
     pythonSupport    = config.vim.python or true;
-    darwinSupport    = config.vim.darwin or false;
     nlsSupport       = config.vim.nls or false;
     tclSupport       = config.vim.tcl or false;
     multibyteSupport = config.vim.multibyte or false;
     cscopeSupport    = config.vim.cscope or false;
+    netbeansSupport  = config.netbeans or true; # eg envim is using it
+
+    # by default, compile with darwin support if we're compiling on darwin, but
+    # allow this to be disabled by setting config.vim.darwin to false
+    darwinSupport    = stdenv.isDarwin && (config.vim.darwin or true);
+
     # add .nix filetype detection and minimal syntax highlighting support
     ftNixSupport     = config.vim.ftNix or true;
-    netbeansSupport = config.netbeans or true; # eg envim is using it
   };
 
   #--enable-gui=OPTS     X11 GUI default=auto OPTS=auto/no/gtk/gtk2/gnome/gnome2/motif/athena/neXtaw/photon/carbon
@@ -93,22 +102,23 @@ composableDerivation {} (fix: {
       // edf "gtktest" "gtktest" { } #Do not try to compile and run a test GTK program
     */
 
-  postInstall = "
-    rpath=`patchelf --print-rpath \$out/bin/vim`;
-    for i in \$nativeBuildInputs; do
-      echo adding \$i/lib
-      rpath=\$rpath:\$i/lib
+  postInstall = if stdenv.isLinux then ''
+    rpath=`patchelf --print-rpath $out/bin/vim`;
+    for i in $nativeBuildInputs; do
+      echo adding $i/lib
+      rpath=$rpath:$i/lib
     done
-    echo \$nativeBuildInputs
-    echo \$rpath
-    patchelf --set-rpath \$rpath \$out/bin/{vim,gvim}
-  ";
-  dontStrip =1;
+    echo $nativeBuildInputs
+    echo $rpath
+    patchelf --set-rpath $rpath $out/bin/{vim,gvim}
+  '' else "";
+
+  dontStrip = 1;
 
   meta = {
     description = "The most popular clone of the VI editor";
-    homepage = "www.vim.org";
+    homepage    = "www.vim.org";
+    platforms   = lib.platforms.unix;
   };
-
 })
 

--- a/pkgs/development/libraries/atk/2.6.x.nix
+++ b/pkgs/development/libraries/atk/2.6.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, glib }:
+{ stdenv, fetchurl, pkgconfig, perl, glib, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = "atk-2.6.0";
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/atk/2.6/${name}.tar.xz";
     sha256 = "eff663f90847620bb68c9c2cbaaf7f45e2ff44163b9ab3f10d15be763680491f";
   };
+
+  buildInputs = libintlOrEmpty;
 
   nativeBuildInputs = [ pkgconfig perl ];
 

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional postscriptSupport zlib ++
     stdenv.lib.optional pngSupport libpng;
 
+  NIX_CFLAGS_COMPILE = "-I${pixman}/include/pixman-1";
+
   configureFlags =
     [ "--enable-tee" ]
     ++ stdenv.lib.optional xcbSupport "--enable-xcb"

--- a/pkgs/development/libraries/gdk-pixbuf/2.26.x.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/2.26.x.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, glib, libtiff, libjpeg, libpng, libX11, xz, jasper }:
+{ stdenv, fetchurl, pkgconfig, glib, libtiff, libjpeg, libpng, libX11, xz
+, jasper, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = "gdk-pixbuf-2.26.1";
@@ -9,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 ];
+  buildInputs = [ libX11 libintlOrEmpty ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/gtk+/2.24.x.nix
+++ b/pkgs/development/libraries/gtk+/2.24.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, atk, pango, cairo, perl, xlibs
-, gdk_pixbuf, xz
+, gdk_pixbuf, xz, libintlOrEmpty
 , xineramaSupport ? true
 , cupsSupport ? true, cups ? null
 }:
@@ -17,12 +17,14 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  NIX_CFLAGS_COMPILE = "-I${cairo}/include/cairo";
+
   nativeBuildInputs = [ perl pkgconfig ];
 
   propagatedBuildInputs =
     [ xlibs.xlibs glib atk pango gdk_pixbuf cairo
-      xlibs.libXrandr xlibs.libXrender xlibs.libXcomposite xlibs.libXi
-    ]
+      xlibs.libXrandr xlibs.libXrender xlibs.libXcomposite xlibs.libXi ]
+    ++ libintlOrEmpty
     ++ stdenv.lib.optional xineramaSupport xlibs.libXinerama
     ++ stdenv.lib.optionals cupsSupport [ cups ];
 

--- a/pkgs/development/libraries/pango/1.30.x.nix
+++ b/pkgs/development/libraries/pango/1.30.x.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "3a8c061e143c272ddcd5467b3567e970cfbb64d1d1600a8f8e62435556220cbe";
   };
 
+  NIX_CFLAGS_COMPILE = "-I${cairo}/include/cairo";
+
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ gettext fontconfig ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8217,18 +8217,20 @@ let
 
   vimHugeX = vim_configurable;
 
-  vim_configurable = callPackage (import ../applications/editors/vim/configurable.nix) {
-    inherit (pkgs) fetchurl stdenv ncurses pkgconfig gettext composableDerivation lib config;
-    inherit (pkgs.xlibs) libX11 libXext libSM libXpm libXt libXaw libXau libXmu libICE;
-    inherit (pkgs) glib gtk;
+  vim_configurable = callPackage ../applications/editors/vim/configurable.nix {
+    inherit (pkgs) fetchurl stdenv ncurses pkgconfig gettext
+      composableDerivation lib config glib gtk python perl tcl ruby;
+    inherit (pkgs.xlibs) libX11 libXext libSM libXpm libXt libXaw libXau libXmu
+      libICE;
+
     features = "huge"; # one of  tiny, small, normal, big or huge
-    # optional features by passing
-    # python
-    # TODO mzschemeinterp perlinterp
-    inherit (pkgs) python perl tcl ruby /*x11*/;
     lua = pkgs.lua5;
+
     # optional features by flags
     flags = [ "python" "X11" ]; # only flag "X11" by now
+
+    # so that we can use gccApple if we're building on darwin
+    inherit stdenvAdapters gccApple;
   };
   vimLatest = vim_configurable.override { source = "latest"; };
   vimNox = vim_configurable.override { source = "vim-nox"; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4089,7 +4089,9 @@ let
 
   gdk_pixbuf = callPackage ../development/libraries/gdk-pixbuf/2.26.x.nix { };
 
-  gtk2 = callPackage ../development/libraries/gtk+/2.24.x.nix { };
+  gtk2 = callPackage ../development/libraries/gtk+/2.24.x.nix {
+    cupsSupport = config.gtk2.cups or true;
+  };
   gtk3 = lowPrio (callPackage ../development/libraries/gtk+/3.2.x.nix { });
   gtk = pkgs.gtk2;
 


### PR DESCRIPTION
I had to do several things to get this working:
- add `libintlOrEmpty` to `buildInputs` for `atk`, `gdk-pixbuf` and `gtk2`
- fix include path for `pixman` in `cairo`
- fix include path for `cairo` in `pango`
- allow cups to be disabled in `gtk2` by setting a flag in `config`
- use `gccApple` to build `vim` (the configure script incorrectly determined the architecture on which it was building and defined some X11 function incorrectly)
- enabled `darwinSupport` when building on darwin
- disabled `patchelf` when building on darwin

As usual, I have tested this on my own OS X box and a CentOS box sitting on EC2.
