### PR TITLE
kerberos in openssh

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -17,12 +17,10 @@ let
 in
 
 stdenv.mkDerivation rec {
-  basename = "openssh-6.2p1";
-  # make the option visible
-  name = basename + (if withKerberos then "-krb5" else "");
+  name = "openssh-6.2p1";
 
   src = fetchurl {
-    url = "ftp://ftp.nl.uu.net/pub/OpenBSD/OpenSSH/portable/${basename}.tar.gz";
+    url = "ftp://ftp.nl.uu.net/pub/OpenBSD/OpenSSH/portable/${name}.tar.gz";
     sha1 = "8824708c617cc781b2bb29fa20bd905fd3d2a43d";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1366,19 +1366,13 @@ let
 
   opensc_dnie_wrapper = callPackage ../tools/security/opensc-dnie-wrapper { };
 
-  # an argument is necessary for 
-  # nix-env --arg withKerberos true -iA openssh
-  # to work
-  mkOpenssh = {withKerberos ? false }:
+  openssh =
     callPackage ../tools/networking/openssh {
       hpnSupport = false;
       etcDir = "/etc/ssh";
       pam = if stdenv.isLinux then pam else null;
-      inherit withKerberos;
     };
-
-  openssh = mkOpenssh { };
-  opensshKrb5 = mkOpenssh { withKerberos = true; };
+  opensshKrb5 = openssh.override { withKerberos = true; };
 
   opensp = callPackage ../tools/text/sgml/opensp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1366,11 +1366,19 @@ let
 
   opensc_dnie_wrapper = callPackage ../tools/security/opensc-dnie-wrapper { };
 
-  openssh = callPackage ../tools/networking/openssh {
-    hpnSupport = false;
-    etcDir = "/etc/ssh";
-    pam = if stdenv.isLinux then pam else null;
-  };
+  # an argument is necessary for 
+  # nix-env --arg withKerberos true -iA openssh
+  # to work
+  mkOpenssh = {withKerberos ? false }:
+    callPackage ../tools/networking/openssh {
+      hpnSupport = false;
+      etcDir = "/etc/ssh";
+      pam = if stdenv.isLinux then pam else null;
+      inherit withKerberos;
+    };
+
+  openssh = mkOpenssh { };
+  opensshKrb5 = mkOpenssh { withKerberos = true; };
 
   opensp = callPackage ../tools/text/sgml/opensp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1372,7 +1372,7 @@ let
       etcDir = "/etc/ssh";
       pam = if stdenv.isLinux then pam else null;
     };
-  openssh_with_kerberos = pkgs.appendToName "with-kerberos" (openssh.override { withKerberos = true; });
+  openssh_with_kerberos = lowPrio (pkgs.appendToName "with-kerberos" (openssh.override { withKerberos = true; }));
 
   opensp = callPackage ../tools/text/sgml/opensp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1372,7 +1372,7 @@ let
       etcDir = "/etc/ssh";
       pam = if stdenv.isLinux then pam else null;
     };
-  opensshKrb5 = openssh.override { withKerberos = true; };
+  openssh_with_kerberos = pkgs.appendToName "with-kerberos" (openssh.override { withKerberos = true; });
 
   opensp = callPackage ../tools/text/sgml/opensp { };
 


### PR DESCRIPTION
Added kerberos authentification and ticket forwarding support. 

I make a package names openssh-version-krb5 appear to make this option visible to
nix-env -qa '*'
