### PR TITLE
vim_configurable: improvements

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -40,7 +40,8 @@ composableDerivation {
       }.src;
     };
 
-    configureFlags = ["--enable-gui=auto" "--with-features=${args.features}"];
+    configureFlags
+      = [ "--enable-gui=${args.gui}" "--with-features=${args.features}" ];
 
     nativeBuildInputs
       = [ ncurses pkgconfig gtk libX11 libXext libSM libXpm libXt libXaw libXau
@@ -76,6 +77,7 @@ composableDerivation {
 
   cfg = {
     pythonSupport    = config.vim.python or true;
+    rubySupport      = config.vim.ruby or true;
     nlsSupport       = config.vim.nls or false;
     tclSupport       = config.vim.tcl or false;
     multibyteSupport = config.vim.multibyte or false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8261,6 +8261,7 @@ let
 
     features = "huge"; # one of  tiny, small, normal, big or huge
     lua = pkgs.lua5;
+    gui = config.vim.gui or "auto";
 
     # optional features by flags
     flags = [ "python" "X11" ]; # only flag "X11" by now


### PR DESCRIPTION
- add ruby interpreter (may have been accidentally removed, or may never
  have existed)
- allow selection of GUI options by setting `config.vim.gui`
