### PR TITLE
cairo-1.12.2: fix pixman include path

### DIFF
--- a/pkgs/development/libraries/cairo/1.12.2.nix
+++ b/pkgs/development/libraries/cairo/1.12.2.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional postscriptSupport zlib ++
     stdenv.lib.optional pngSupport libpng;
 
+  NIX_CFLAGS_COMPILE = ( if stdenv.isDarwin
+                         then "-I${pixman}/include/pixman-1"
+                         else "" );
+
   configureFlags =
     [ "--enable-tee" ]
     ++ stdenv.lib.optional xcbSupport "--enable-xcb"


### PR DESCRIPTION
`cairo-1.12.2` is currently failing on darwin because it can't find `pixman` (http://hydra.nixos.org/build/5089496/nixlog/1/tail-reload)

This should fix the build.
