### PR TITLE
apacheHttpd: fix build on darwin

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-iquote ${apr}/include/apr-1";
 
   # Required for ‘pthread_cancel’.
-  NIX_LDFLAGS = "-lgcc_s";
+  NIX_LDFLAGS = (if stdenv.isDarwin then "" else "-lgcc_s");
 
   configureFlags = ''
     --with-z=${zlib}

--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -55,10 +55,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Apache HTTPD, the world's most popular web server";
-    homepage = http://httpd.apache.org/;
-    license = "ASL2.0";
-
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.simons ];
+    homepage    = http://httpd.apache.org/;
+    license     = stdenv.lib.licenses.asl20;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ simons lovek323 ];
   };
 }


### PR DESCRIPTION
- remove the gcc_s library from NIX_LDFLAGS (not available on darwin)

Fixes issue in this build: http://hydra.nixos.org/build/5158596
