### PR TITLE
haskellPackages: vector-0.9.1 fix 'primitive' dependency

### DIFF
--- a/pkgs/development/libraries/haskell/primitive/0.4.1.nix
+++ b/pkgs/development/libraries/haskell/primitive/0.4.1.nix
@@ -1,0 +1,13 @@
+{ cabal }:
+
+cabal.mkDerivation (self: {
+  pname = "primitive";
+  version = "0.4.1";
+  sha256 = "06999i59xhvjwfdbnr1n09zkvg7lnim64nqxqlvk0x6slkidb7f6";
+  meta = {
+    homepage = "http://code.haskell.org/primitive";
+    description = "Primitive memory-related operations";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1593,6 +1593,7 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   punycode = callPackage ../development/libraries/haskell/punycode {};
 
+  primitive_0_4_1 = callPackage ../development/libraries/haskell/primitive/0.4.1.nix   {};
   primitive_0_5_0_1 = callPackage ../development/libraries/haskell/primitive/0.5.0.1.nix   {};
   primitive = self.primitive_0_5_0_1;
 
@@ -2005,7 +2006,9 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   vect = callPackage ../development/libraries/haskell/vect {};
 
-  vector_0_9_1 = callPackage ../development/libraries/haskell/vector/0.9.1.nix {};
+  vector_0_9_1 = callPackage ../development/libraries/haskell/vector/0.9.1.nix {
+    primitive = self.primitive_0_4_1;  
+  };
   vector_0_10 = callPackage ../development/libraries/haskell/vector/0.10.nix  {};
   vector_0_10_0_1  = callPackage ../development/libraries/haskell/vector/0.10.0.1.nix  {};
   vector = self.vector_0_10_0_1;


### PR DESCRIPTION
Vector 0.9.1 specifies primitive < 0.5, so I have packaged the maximum compatible version.

This should fix http://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.vector_0_9_1.x86_64-linux
