### PR TITLE
weston now compiles ! but I could not run it

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -1,26 +1,45 @@
-{ stdenv, fetchurl, pkgconfig, wayland, mesa, libxkbcommon
+{ stdenv, fetchurl, pkgconfig, wayland, mesa_full, libxkbcommon
 , cairo, libxcb, libXcursor, x11, udev, libdrm, mtdev
-, libjpeg, pam, autoconf, automake, libtool }:
+, libjpeg, pam, autoconf, automake, libtool, libunwind }:
 
-let version = "1.0.5"; in
+let version = "1.1.1"; in
 
 stdenv.mkDerivation rec {
   name = "weston-${version}";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "0g2k82pnlxl8b70ykazj7kn8xffjfsmgcgx427qdrm4083z2hgm0";
+    sha256 = "87e1cbbd1a722019ba258d1893c583d96699289196309c93026ae591a2c1f02e";
   };
 
-  buildInputs = [ pkgconfig wayland mesa libxkbcommon
+  buildInputs = [ pkgconfig wayland mesa_full libxkbcommon
     cairo libxcb libXcursor x11 udev libdrm mtdev
-    libjpeg pam autoconf automake libtool ];
+    libjpeg pam autoconf automake libtool libunwind ];
 
-  preConfigure = "autoreconf -vfi";
+  propagatedBuildInputs = [ wayland mesa_full libxkbcommon
+    cairo libxcb libXcursor x11 udev libdrm mtdev
+    libjpeg pam libunwind ];
+
+  #The C_INCLUDE_PATH is there because 
+  preConfigure = ''
+    export LIBUNWIND_CFLAGS='-I${libunwind}/include'
+    export LIBUNWIND_LIBS='-L${libunwind}/lib -lunwind'
+    export COMPOSITOR_CFLAGS='-I${wayland}/include'
+    export COMPOSITOR_LIBS='-L${wayland}/lib -lwayland-server -lwayland-cursor' 
+    export SIMPLE_EGL_CLIENT_CFLAGS='-I${wayland}/include'
+    export SIMPLE_EGL_CLIENT_LIBS='-L${wayland}/lib -lwayland-client -lwayland-cursor'
+    export NIX_LDFLAGS="$NIX_LDFLAGS -lGL -lEGL -lwayland-egl -lGLESv2 -lpixman-1 -lxkbcommon"
+    export C_INCLUDE_PATH='${libdrm}/include/libdrm:${libdrm}/include/libkms'
+    autoreconf -vfi
+  '';
 
   # prevent install target to chown root weston-launch, which fails
   configureFlags = ''
     --disable-setuid-install
+  '';
+
+  postInstall = ''
+    chmod +s $out/bin/weston-launch
   '';
 
   meta = {

--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -25,10 +25,11 @@ stdenv.mkDerivation rec {
     export LIBUNWIND_CFLAGS='-I${libunwind}/include'
     export LIBUNWIND_LIBS='-L${libunwind}/lib -lunwind'
     export COMPOSITOR_CFLAGS='-I${wayland}/include'
-    export COMPOSITOR_LIBS='-L${wayland}/lib -lwayland-server -lwayland-cursor' 
+    export COMPOSITOR_LIBS='-L${wayland}/lib -lwayland-server -lwayland-cursor'
     export SIMPLE_EGL_CLIENT_CFLAGS='-I${wayland}/include'
     export SIMPLE_EGL_CLIENT_LIBS='-L${wayland}/lib -lwayland-client -lwayland-cursor'
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lGL -lEGL -lwayland-egl -lGLESv2 -lpixman-1 -lxkbcommon"
+#    export PIXMAN_LIBS='-lpixman-1'
+    export LIBS="$LIBS -lGL -lEGL -lwayland-egl -lGLESv2 -lxkbcommon -lpixman-1"
     export C_INCLUDE_PATH='${libdrm}/include/libdrm:${libdrm}/include/libkms'
     autoreconf -vfi
   '';

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchurl, pkgconfig, libpthreadstubs, libpciaccess, udev }:
 
 stdenv.mkDerivation rec {
-  name = "libdrm-2.4.42";
+  name = "libdrm-2.4.45";
 
   src = fetchurl {
     url = "http://dri.freedesktop.org/libdrm/${name}.tar.bz2";
-    sha256 = "1qbnpi64hyqzd650hj6jki1d50pzypdhj3rw9m3whwbqly110rz0";
+    sha256 = "3ef0a70c16080fb90c50e807b660b7353d82509c03647f6ecc00bbfa1caee208";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libpthreadstubs libpciaccess ]
     ++ stdenv.lib.optional stdenv.isLinux udev;
 
+  #This was for 2.4.42, maybe useless with 2.4.45
   patches = stdenv.lib.optional stdenv.isDarwin ./libdrm-apple.patch;
 
   preConfigure = stdenv.lib.optionalString stdenv.isDarwin

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation {
       `#$out/lib/libXvMC*` \
       $out/lib/vdpau \
       $out/lib/libOSMesa* \
-      $out/lib/gbm $out/lib/libgbm* \
       $out/lib/gallium-pipe \
   '' + ''
       $out/lib/libdricore* \

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, libffi, expat, pkgconfig, libxslt, docbook_xsl, doxygen }:
 
-let version = "1.0.5"; in
+let version = "1.1.0"; in
 
 stdenv.mkDerivation rec {
   name = "wayland-${version}";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "130n7v5i7rfsrli2n8vdzfychlgd8v7by7sfgp8vfqdlss5km34w";
+    sha256 = "2ef587cf1a0e52b6dee44eeb9c288110e8180819abf4e419d247dfe234867a5c";
   };
 
   buildInputs = [ pkgconfig libffi expat libxslt docbook_xsl doxygen ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4820,6 +4820,7 @@ let
       name = "mesa-${mesa_noglu.version}";
       paths = [ mesa_glu mesa_noglu ];
     };
+  mesa_full = pkgs.appendToName "full" (mesa_noglu.override { enableExtraFeatures = true; });
   darwinX11AndOpenGL = callPackage ../os-specific/darwin/native-x11-and-opengl { };
 
   metaEnvironment = recurseIntoAttrs (let callPackage = newScope pkgs.metaEnvironment; in rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4811,16 +4811,22 @@ let
   mesaSupported = lib.elem system lib.platforms.mesaPlatforms;
 
   mesa_original = callPackage ../development/libraries/mesa { };
-  mesa_noglu = if stdenv.isDarwin then darwinX11AndOpenGL
-    else mesa_original;
-  mesa_drivers = mesa_original.drivers;
+  mesa_original_full = lowPrio (pkgs.appendToName "full" (mesa_original.override { enableExtraFeatures = true; }));
+  mesa_noglu = if stdenv.isDarwin then darwinX11AndOpenGL else mesa_original;
+  mesa_noglu_full = if stdenv.isDarwin then darwinX11AndOpenGL else mesa_original_full;
+  mesa_drivers = mesa_original;
+  mesa_drivers_full = mesa_original_full;
   mesa_glu = callPackage ../development/libraries/mesa-glu { };
   mesa = if stdenv.isDarwin then darwinX11AndOpenGL
     else buildEnv {
       name = "mesa-${mesa_noglu.version}";
       paths = [ mesa_glu mesa_noglu ];
     };
-  mesa_full = pkgs.appendToName "full" (mesa_noglu.override { enableExtraFeatures = true; });
+  mesa_full = if stdenv.isDarwin then darwinX11AndOpenGL
+    else buildEnv {
+      name = "mesa-${mesa_noglu_full.version}";
+      paths = [ mesa_glu mesa_noglu_full ];
+    };
   darwinX11AndOpenGL = callPackage ../os-specific/darwin/native-x11-and-opengl { };
 
   metaEnvironment = recurseIntoAttrs (let callPackage = newScope pkgs.metaEnvironment; in rec {


### PR DESCRIPTION
Weston did not compile ... after this patch it does.

However, more work need to run it.
Still it is not worst than before so it could probably be merged

Here are what I think should be done:
- the preConfigure phase is ugly and pkg_config should do better
- the chmod +s weston-lauch in postInstall can/should be avoided
- still I could not run it, here is one of my try with sudo:

raffalli@delli7:~$ sudo weston-launch --tty /dev/tty9
Password: 
Date: 2013-06-19 CEST
[04:16:11.724] weston 1.1.1
               http://wayland.freedesktop.org/
               Bug reports to: https://bugs.freedesktop.org/enter_bug.cgi?product=Wayland&component=weston&version=1.1.1
               Build:  
[04:16:11.724] OS: Linux, 3.9.6, #1 SMP Sun Jun 16 21:44:09 UTC 2013, x86_64
[04:16:11.724] warning: XDG_RUNTIME_DIR "/run/user/1000" is not configured
correctly.  Unix access mode must be 0700 but is 700,
and XDG_RUNTIME_DIR must be owned by the user, but is
owned by UID 1000.
Refer to your distribution on how to get it, or
http://www.freedesktop.org/wiki/Specifications/basedir-spec
on how to implement it.
couldn't open /root/.config/weston.ini
[04:16:11.724] Loading module '/nix/store/j52vj6ac60pa43dfc3v8bk80hndglsa9-weston-1.1.1/lib/weston/drm-backend.so'
couldn't open /root/.config/weston.ini
[04:16:11.726] initializing drm backend
couldn't open /root/.config/weston.ini
couldn't open /root/.config/weston.ini
[04:16:13.514] using /dev/dri/card0
failed to open /run/opengl-driver/lib/dri/nouveau_dri.so: /run/opengl-driver/lib/dri/nouveau_dri.so: cannot open shared object file: No such file or directory
gbm: failed to open any driver (search paths /run/opengl-driver/lib/dri)failed to load driver: nouveau
failed to load module: libgallium.so.0: cannot open shared object file: No such file or directory
[04:16:13.515] failed to initialize egl
[04:16:13.523] fatal: failed to create compositor
