### PR TITLE
irssi: fix build on darwin

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, ncurses, glib, openssl, perl}:
+{ stdenv, fetchurl, pkgconfig, ncurses, glib, openssl, perl, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = "irssi-0.8.15";
@@ -8,13 +8,15 @@ stdenv.mkDerivation rec {
     sha256 = "19m0aah9bhc70dnhh7kpydbsz5n35l0l9knxav1df0sic3xicbf1";
   };
   
-  buildInputs = [pkgconfig ncurses glib openssl perl];
+  buildInputs = [ pkgconfig ncurses glib openssl perl libintlOrEmpty ];
   
   NIX_LDFLAGS = "-lncurses";
   
   configureFlags = "--with-proxy --with-ncurses --enable-ssl --with-perl=yes";
 
   meta = {
-    homepage = http://irssi.org;
+    homepage    = http://irssi.org;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7612,7 +7612,12 @@ let
 
   iptraf = callPackage ../applications/networking/iptraf { };
 
-  irssi = callPackage ../applications/networking/irc/irssi { };
+  irssi = callPackage ../applications/networking/irc/irssi {
+    # compile with gccApple on darwin to support the -no-cpp-precompile flag
+    stdenv = if stdenv.isDarwin
+      then stdenvAdapters.overrideGCC stdenv gccApple
+      else stdenv;
+  };
 
   irssi_fish = callPackage ../applications/networking/irc/irssi/fish { };
 


### PR DESCRIPTION
- use `gccApple` (so we can cope with `-no-cpp-precompile`)
- add `libintlOrEmpty`
