### PR TITLE
amdappsdk: Fix download urls and some other things, so derivations for older sdk versions now build succesfully

### DIFF
--- a/pkgs/development/misc/amdapp-sdk/default.nix
+++ b/pkgs/development/misc/amdapp-sdk/default.nix
@@ -5,43 +5,44 @@
 
 let
 
-  src_hashes = {
-    "2.6" = {
-      x86 = "99610737f21b2f035e0eac4c9e776446cc4378a614c7667de03a82904ab2d356";
-      x86_64 = "1fj55358s4blxq9bp77k07gqi22n5nfkzwjkbdc62gmy1zxxlhih";
-    };
-
-    "2.7" = {
-      x86 = "99610737f21b2f035e0eac4c9e776446cc4378a614c7667de03a82904ab2d356";
-      x86_64 = "08bi43bgnsxb47vbirh09qy02w7zxymqlqr8iikk9aavfxjlmch1";
-    };
-
-    "2.8" = {
-      x86 = "99610737f21b2f035e0eac4c9e776446cc4378a614c7667de03a82904ab2d356";
-      x86_64 = "d9c120367225bb1cd21abbcf77cb0a69cfb4bb6932d0572990104c566aab9681";
-    };
-  };
-
   bits = if stdenv.system == "x86_64-linux" then "64"
          else "32";
 
   arch = if stdenv.system == "x86_64-linux" then "x86_64"
          else "x86";
 
+  src_info = {
+    "2.6" = {
+      url = "http://download2-developer.amd.com/amd/APPSDK/AMD-APP-SDK-v2.6-lnx${bits}.tgz";
+      x86 = "03vyvqp44f96036zsyy8n21ymbzy2bx09hlbd6ci3ikj8g7ic1dm";
+      x86_64 = "1fj55358s4blxq9bp77k07gqi22n5nfkzwjkbdc62gmy1zxxlhih";
+   };
+
+    "2.7" = {
+      url = "http://download2-developer.amd.com/amd/APPSDK/AMD-APP-SDK-v2.7-lnx${bits}.tgz";
+      x86 = "1v26n7g1xvlg5ralbfk3qiy34gj8fascpnjzm3120b6sgykfp16b";
+      x86_64 = "08bi43bgnsxb47vbirh09qy02w7zxymqlqr8iikk9aavfxjlmch1";
+    };
+
+    "2.8" = {
+      url = "http://developer.amd.com/wordpress/media/2012/11/AMD-APP-SDK-v2.8-lnx${bits}.tgz";
+      x86 = "99610737f21b2f035e0eac4c9e776446cc4378a614c7667de03a82904ab2d356";
+      x86_64 = "d9c120367225bb1cd21abbcf77cb0a69cfb4bb6932d0572990104c566aab9681";
+
+      # TODO: Add support for aparapi, java parallel api
+      patches = [ ./01-remove-aparapi-samples.patch ];
+    };
+  };
+
 in stdenv.mkDerivation rec {
   name = "amdapp-sdk-${version}";
 
-  src = if stdenv.system == "x86_64-linux" then fetchurl {
-    url = "http://developer.amd.com/wordpress/media/2012/11/AMD-APP-SDK-v${version}-lnx64.tgz";
-    sha256 = (builtins.getAttr version src_hashes).x86_64;
-  } else if stdenv.system == "i686-linux" then fetchurl {
-    url = "http://developer.amd.com/wordpress/media/2012/11/AMD-APP-SDK-v${version}-lnx32.tgz";
-    sha256 = (builtins.getAttr version src_hashes).x86;
-  } else
-    throw "System not supported";
+  src = fetchurl {
+    url = stdenv.lib.getAttrFromPath [version "url"] src_info;
+    sha256 = stdenv.lib.getAttrFromPath [version arch] src_info;
+  };
 
-  # TODO: Add support for aparapi, java parallel api
-  patches = [ ./01-remove-aparapi-samples.patch ];
+  patches = stdenv.lib.attrByPath [version "patches"] [] src_info;
 
   patchFlags = "-p0";
   buildInputs = [ makeWrapper perl mesa xorg.libX11 xorg.libXext xorg.libXaw xorg.libXi xorg.libXxf86vm ];
@@ -51,8 +52,8 @@ in stdenv.mkDerivation rec {
 
   unpackPhase = ''
     tar xvzf $src
-    tar xf AMD-APP-SDK-v${version}-RC-lnx${bits}.tgz
-    cd AMD-APP-SDK-v${version}-RC-lnx${bits}
+    tar xf AMD-APP-SDK-v${version}-*-lnx${bits}.tgz
+    cd AMD-APP-SDK-v${version}-*-lnx${bits}
   '';
 
   buildPhase = if !samples then ''echo "nothing to build"'' else null;


### PR DESCRIPTION
This is a fix for #638 merged yesterday, so all derivations now build succesfully. 
