### PR TITLE
remake: bump from version 3.81+dbg-0.2 to 3.82+dbg-0.6

### DIFF
--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -1,15 +1,21 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl, readline }:
 
-stdenv.mkDerivation {
-  name = "remake-3.81-dbg-0.2";
+stdenv.mkDerivation rec {
+  name = "remake-${version}";
+  version = "3.82+dbg-0.6";
+
   src = fetchurl {
-    url = mirror://sourceforge/bashdb/remake-3.81+dbg-0.2.tar.gz;
-    sha256 = "0mhc06zgd39dl8rk16ii0m2x22b9zi67d48km7rn0fzzv519lmwc";
+    url = "mirror://sourceforge/project/bashdb/remake/${version}/${name}.tar.bz2";
+    sha256 = "0i2g6vi9zya78d9zpigfnmzg2qcl93myjfibh3kfmjk7b9lajfyz";
   };
+
+  buildInputs = [ readline ];
 
   meta = {
     homepage = http://bashdb.sourceforge.net/remake/;
-    license = "GPL";
+    license = stdenv.lib.licenses.gpl3;
     description = "GNU Make with comprehensible tracing and a debugger";
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
This version needs readline. And the license is GPLv3. Also, add
meta.platforms and meta.maintainers attributes.
