### PR TITLE
virtualbox-guestadditions: fix xorg incompatibility

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -11,8 +11,7 @@ with stdenv.lib;
 
 let
 
-  version = "4.2.12";
-  extpackRevision = "84980";
+  version = "4.2.14"; # changes ./guest-additions as well
 
   forEachModule = action: ''
     for mod in \
@@ -31,12 +30,10 @@ let
     done
   '';
 
-  extensionPack = requireFile {
-    name = "Oracle_VM_VirtualBox_Extension_Pack-${version}-${extpackRevision}"
-         + ".vbox-extpack";
+  extensionPack = fetchurl {
+    url = "http://download.virtualbox.org/virtualbox/${version}/Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack";
     # Has to be base16 because it's used as an input to VBoxExtPackHelperApp!
-    sha256 = "ad15a92e49095c2115bd1793b3b957d3eaf44af0f5d24bb53d6b4fc81c3e2fc4";
-    url = "https://www.virtualbox.org/wiki/Downloads";
+    sha256 = "5813cae72790de4893cadb839ffbd148290a44ec6913d901d84c9b3740ab1b1e";
   };
 
 in stdenv.mkDerivation {
@@ -44,7 +41,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "eb65ecac94f63d6292a967d39cb5e28326404c10d0e8c2c50399eedb59c17ee6";
+    sha256 = "038k65cdvr80da5nfan5r3rjrnxqab2fbf2pr2jq8g1gc4cxrxpq";
   };
 
   buildInputs =
@@ -136,6 +133,8 @@ in stdenv.mkDerivation {
       ln -s $libexec/icons/$size/*.png $out/share/icons/hicolor/$size/apps
     done
   '';
+
+  passthru = { inherit version; /* for guest additions */ };
 
   meta = {
     description = "PC emulator";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -1,8 +1,11 @@
 { stdenv, fetchurl, lib, patchelf, cdrkit, kernelDev, which, makeWrapper
-, libX11, libXt, libXext, libXmu, libXcomposite, libXfixes, libXrandr, libXcursor
-, dbus }:
+, xorg, dbus }:
 
-let version = "4.2.12"; in
+let
+  version = "4.2.12";
+  xserverVListFunc = builtins.elemAt (stdenv.lib.splitString "." xorg.xorgserver.version);
+  xserverABI = xserverVListFunc 0 + xserverVListFunc 1;
+in
 
 stdenv.mkDerivation {
   name = "VirtualBox-GuestAdditions-${version}-${kernelDev.version}";
@@ -22,7 +25,7 @@ stdenv.mkDerivation {
 
   '';
 
-  buildCommand = ''
+  buildCommand = with xorg; ''
     ${if stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" then ''
         isoinfo -J -i $src -x /VBoxLinuxAdditions.run > ./VBoxLinuxAdditions.run
         chmod 755 ./VBoxLinuxAdditions.run
@@ -104,7 +107,7 @@ stdenv.mkDerivation {
 
     # Install Xorg drivers
     mkdir -p $out/lib/xorg/modules/{drivers,input}
-    install -m 644 lib/VBoxGuestAdditions/vboxvideo_drv_113.so $out/lib/xorg/modules/drivers/vboxvideo_drv.so
+    install -m 644 lib/VBoxGuestAdditions/vboxvideo_drv_${xserverABI}.so $out/lib/xorg/modules/drivers/vboxvideo_drv.so
 
     # Install kernel modules
     cd src

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, lib, patchelf, cdrkit, kernelDev, which, makeWrapper
-, xorg, dbus }:
+, xorg, dbus, virtualbox }:
 
 let
-  version = "4.2.12";
+  version = virtualbox.version;
   xserverVListFunc = builtins.elemAt (stdenv.lib.splitString "." xorg.xorgserver.version);
   xserverABI = xserverVListFunc 0 + xserverVListFunc 1;
 in
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "aed4730b643aca8daa0829e1122b7c8d592b9f6cea902a98e390c4d22373dfb8";
+    sha256 = "9f08f13bbd818fb3ef9916658542ad0999c35e11afc1f6e8ff0b944405486e8a";
   };
 
   KERN_DIR = "${kernelDev}/lib/modules/*/build";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation {
 
     # Install Xorg drivers
     mkdir -p $out/lib/xorg/modules/{drivers,input}
-    install -m 644 lib/VBoxGuestAdditions/vboxvideo_drv_112.so $out/lib/xorg/modules/drivers/vboxvideo_drv.so
+    install -m 644 lib/VBoxGuestAdditions/vboxvideo_drv_113.so $out/lib/xorg/modules/drivers/vboxvideo_drv.so
 
     # Install kernel modules
     cd src

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -209,6 +209,7 @@ in
         rm -fr $out/share/X11/xkb/compiled
         ln -s /var/tmp $out/share/X11/xkb/compiled
       '';
+    passthru.version = (builtins.parseDrvName attrs.name).version; # needed by virtualbox guest additions
   };
 
 


### PR DESCRIPTION
A recent X update broke VirtualBox guest additions (vboxvideo driver version
mismatch, desktop won't start). This fixes it.

Here is the error log:

 (II) "glx" will be loaded by default.
 (II) LoadModule: "glx"
 (II) Loading /nix/store/kzvmnjlps51q4piqmwr7zbmxcg2z9vgk-xorg-server-1.13.4/lib/xorg/modules/extensions/libglx.so
 (II) Module glx: vendor="X.Org Foundation"
    compiled for 1.13.4, module version = 1.0.0
    ABI class: X.Org Server Extension, version 7.0
 (==) AIGLX enabled
 Loading extension GLX
 (II) LoadModule: "vboxvideo"
 (II) Loading /nix/store/4kbxi00h8xsmfgbws2qqh674lcfp03h6-VirtualBox-GuestAdditions-4.2.14-3.2.46/lib/xorg/modules/drivers/vboxvideo_drv.so
 (II) Module vboxvideo: vendor="Oracle Corporation"
    compiled for 10.12.0, module version = 1.0.1
    Module class: X.Org Video Driver
    ABI class: X.Org Video Driver, version 12.0
 (EE) module ABI major version (12) doesn't match the server's version (13)
 (II) UnloadModule: "vboxvideo"
 (II) Unloading vboxvideo
 (EE) Failed to load module "vboxvideo" (module requirement mismatch, 0)
 (II) LoadModule: "vboxmouse"
 (WW) Warning, couldn't open module vboxmouse
 (II) UnloadModule: "vboxmouse"
 (II) Unloading vboxmouse
 (EE) Failed to load module "vboxmouse" (module does not exist, 0)
 (EE) No drivers available.

Fatal server error:
 no screens found
