### PR TITLE
Add network manager firewalld, enable gobject introspection

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, glib, libintlOrEmpty }:
+{ stdenv, fetchurl, pkgconfig, perl, glib, libintlOrEmpty, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   name = "atk-2.8.0";
@@ -8,13 +8,20 @@ stdenv.mkDerivation rec {
     sha256 = "1x3dd3hg9l1j9dq70xwph13vxdp6a9wbfcnryryf1wr6c8bij9dj";
   };
 
-  buildInputs = libintlOrEmpty;
+  buildInputs = libintlOrEmpty ++ [ gobjectIntrospection ];
 
   nativeBuildInputs = [ pkgconfig perl ];
 
   propagatedBuildInputs = [ glib ];
 
+  configureFlags = "--enable-introspection";
+
   postInstall = "rm -rf $out/share/gtk-doc";
+
+  passthru = {
+    gir_path = "/share/gir-1.0";
+    gi_typelib_path = "/lib/girepository-1.0";
+  };
 
   meta = {
     description = "ATK, the accessibility toolkit";

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, libtiff, libjpeg, libpng, libX11, xz
-, jasper, libintlOrEmpty }:
+, jasper, libintlOrEmpty, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   name = "gdk-pixbuf-2.28.1";
@@ -10,15 +10,20 @@ stdenv.mkDerivation rec {
   };
 
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 libintlOrEmpty ];
+  buildInputs = [ gobjectIntrospection libX11 libintlOrEmpty];
 
   nativeBuildInputs = [ pkgconfig ];
 
   propagatedBuildInputs = [ glib libtiff libjpeg libpng jasper ];
 
-  configureFlags = "--with-libjasper --with-x11";
+  configureFlags = "--with-libjasper --with-x11 --enable-introspection";
 
   postInstall = "rm -rf $out/share/gtk-doc";
+
+  passthru = {
+    gir_path = "/share/gir-1.0";
+    gi_typelib_path = "/lib/girepository-1.0";
+  };
 
   meta = {
     description = "A library for image loading and manipulation";

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "gobject-introspection-1.34.2";
 
-  buildInputs = [ flex bison glib pkgconfig python gdk_pixbuf ];
+  buildInputs = [ flex bison glib pkgconfig python ];
   propagatedBuildInputs = [ libffi ];
 
   # Tests depend on cairo, which is undesirable (it pulls in lots of

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, automake, autoconf, libtool, glib, gdk_pixbuf }:
+{ stdenv, fetchurl, pkgconfig, automake, autoconf, libtool, glib, gdk_pixbuf,
+  gtk3, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   ver_maj = "0.7";
@@ -9,23 +10,20 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/libnotify/${ver_maj}/${name}.tar.xz";
     sha256 = "0lmnzy16vdjs9vlgdm0b7wfyi1nh526hv2dpb7vxb92bhx3wny23";
   };
-  src_m4 = fetchurl {
-    url = "mirror://gentoo/distfiles/introspection-20110205.m4.tar.bz2";
-    sha256 = "1cnqh7aaji648nfd5537v7xaak8hgww3bpifhwam7bl0sc3ad523";
-  };
 
-  # see Gentoo ebuild - we don't need to depend on gtk+(2/3)
-  preConfigure = ''
-    cd m4
-    tar xvf ${src_m4}
-    cd ..
+  configureFlags = "--enable-introspection";
 
-    sed -i -e 's:noinst_PROG:check_PROG:' tests/Makefile.am || die
-    sed -i -e '/PKG_CHECK_MODULES(TESTS/d' configure.ac || die
-    AT_M4DIR=. autoreconf
+  preBuild = ''
+    ln -s ${gdk_pixbuf + gdk_pixbuf.gir_path}/* .
   '';
 
-  buildInputs = [ pkgconfig automake autoconf glib gdk_pixbuf ];
+  passthru = {
+    gir_path = "/share/gir-1.0";
+    gi_typelib_path = "/lib/girepository-1.0";
+    gi_typelib_exports = [ gdk_pixbuf ];
+  };
+
+  buildInputs = [ pkgconfig automake autoconf glib gdk_pixbuf gtk3 gobjectIntrospection ];
 
   meta = {
     homepage = http://galago-project.org/; # very obsolete but found no better

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gettext, x11, glib, cairo, libpng, harfbuzz, fontconfig
-, libintlOrEmpty }:
+, libintlOrEmpty, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   name = "pango-1.32.5"; #.6 needs a not-yet-stable fontconfig
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${cairo}/include/cairo";
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ gettext fontconfig ];
+  configureFlags = "--enable-introspection";
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ gettext fontconfig ] ++ [ gobjectIntrospection ];
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -20,6 +22,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = "rm -rf $out/share/gtk-doc";
+
+  passthru = {
+    gir_path = "/share/gir-1.0";
+    gi_typelib_path = "/lib/girepository-1.0";
+  };
 
   meta = {
     description = "A library for laying out and rendering of text, with an emphasis on internationalization";

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "f457b1d7f6b8bfa727593c3696d2b405da66b4a8d34cd7d3362ebda1221f0661";
   };
 
-  configureFlags = "--disable-introspection";
+  configureFlags = "--enable-introspection";
 
   buildInputs = [ python pkgconfig glib gobjectIntrospection pycairo cairo ];
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, intltool, wirelesstools, pkgconfig, dbus_glib, xz
 , udev, libnl, libuuid, polkit, gnutls, ppp, dhcp, dhcpcd, iptables
-, libgcrypt, dnsmasq, avahi, bind, perl, substituteAll }:
+, libgcrypt, dnsmasq, avahi, bind, perl, substituteAll, gobjectIntrospection}:
 
 stdenv.mkDerivation rec {
   name = "network-manager-${version}";
@@ -32,9 +32,10 @@ stdenv.mkDerivation rec {
     "--with-crypto=gnutls" "--disable-more-warnings"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-kernel-firmware-dir=/run/current-system/firmware"
-    "--with-session-tracking=systemd" ];
+    "--with-session-tracking=systemd"
+    "--enable-introspection" ];
 
-  buildInputs = [ wirelesstools udev libnl libuuid polkit ppp xz ];
+  buildInputs = [ wirelesstools udev libnl libuuid polkit ppp xz gobjectIntrospection ];
 
   propagatedBuildInputs = [ dbus_glib gnutls libgcrypt ];
 
@@ -60,6 +61,11 @@ stdenv.mkDerivation rec {
       # FIXME: Workaround until NixOS' dbus+systemd supports at_console policy
       substituteInPlace $out/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf --replace 'at_console="true"' 'group="networkmanager"'
     '';
+
+  passthru = {
+    gir_path = "/share/gir-1.0";
+    gi_typelib_path = "/lib/girepository-1.0";
+  };
 
   meta = with stdenv.lib; {
     homepage = http://projects.gnome.org/NetworkManager/;

--- a/pkgs/tools/networking/network-manager/firewalld.nix
+++ b/pkgs/tools/networking/network-manager/firewalld.nix
@@ -1,0 +1,66 @@
+{stdenv, buildPythonPackage, fetchurl, pkgconfig, intltool,
+ networkmanager, networkmanagerapplet, ebtables, iptables, gtk3,
+ pygobject3, pythonDBus, libnotify, slip}:
+
+buildPythonPackage (rec {
+  name = "NetworkManager-${pname}-${version}";
+  namePrefix = "";  # We don't want to prefix it with python
+  pname = "firewalld";
+  version = "0.3.3";
+
+  src = fetchurl {
+    url = "http://fedorahosted.org/released/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "3fc9aa4fe177f07167048e50308cfda3875df03a454bab2110f81219fe98362d";
+  };
+
+  buildInputs = [ pkgconfig intltool networkmanager networkmanagerapplet ebtables iptables gtk3 ];
+  propagatedBuildInputs = [ pygobject3 pythonDBus libnotify slip ];
+
+  preConfigure = ''
+    substituteInPlace "src/firewall-applet" \
+        --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
+    substituteInPlace "src/firewall-config" \
+        --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
+    substituteInPlace "src/firewall/config/__init__.py.in" \
+        --replace "/usr/share/" "$out/share/"
+    substituteInPlace "src/firewall/core/ebtables.py" \
+        --replace "/sbin/ebtables" "${ebtables}/sbin/ebtables"
+    substituteInPlace "src/firewall/core/ipXtables.py" \
+        --replace "/sbin/iptables" "${iptables}/sbin/iptables"
+    substituteInPlace "src/firewall/core/ipXtables.py" \
+        --replace "/sbin/ip6tables" "${iptables}/sbin/ip6tables"
+  '';
+
+  configureFlags = [
+    "--with-systemd-unitdir=$(out)/etc/systemd/system/"
+    "--sysconfdir=/etc" "--localstatedir=/var"
+  ];
+
+  buildPhase = '''';  # reset to default build phase
+  installCommand = ''make install prefix=$out sysconfdir=$out/etc localstatedir=$out/var'';
+
+  # Prefix it with library paths to gtk and libnotify and with gi_typelibs
+  postInstall = ''
+    for file in "$out"/bin/*; do
+      wrapProgram $file \
+        --prefix LD_LIBRARY_PATH : ${gtk3}/lib:${libnotify}/lib \
+        --suffix-each GI_TYPELIB_PATH ':' "$typelibs"
+    done
+
+    mv $out/share/firewalld/gtk3_chooserbutton.py $out/lib/python2.7/site-packages
+  '';
+
+  # include inherited and exported typelibs, and make gobject introspection work
+  typelibs = map (x: x + x.gi_typelib_path) ([gtk3 libnotify networkmanager] ++
+             gtk3.gi_typelib_exports ++ libnotify.gi_typelib_exports);
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://fedoraproject.org/wiki/FirewallD;
+    description = "A firewall daemon with D-BUS interface providing a dynamic firewall";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ offline];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1298,6 +1298,10 @@ let
 
   networkmanagerapplet = newScope gnome ../tools/networking/network-manager-applet { };
 
+  networkmanager_firewalld = callPackage ../tools/networking/network-manager/firewalld.nix {
+    slip = pythonPackages.slip;
+  };
+
   pa_applet = callPackage ../tools/audio/pa-applet { };
 
   nilfs_utils = callPackage ../tools/filesystems/nilfs-utils {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4612,6 +4612,34 @@ pythonPackages = python.modules // rec {
   };
 
 
+  slip = buildPythonPackage rec {
+    version = "0.4.0";
+    name = "python-slip-${version}";
+
+    src = fetchurl {
+      url = "https://fedorahosted.org/released/python-slip/python-slip-${version}.tar.bz2";
+      sha256 = "04lj0xg78qawvl8q21d31q93iqbs8hrcrqf5b6aza5qyd1czlnnv";
+    };
+
+    propagatedBuildInputs = [ decorator pygobject pygtk pkgs.polkit pkgs.pythonDBus ];
+
+    buildPhase = ''make'';
+
+    installPhase = ''
+      mkdir $out
+      make DESTDIR="$out" PREFIX="." install
+    '';
+
+    doCheck = false;
+
+    meta = {
+      description = "Simple Library for Python from fedora";
+      homepage = https://fedorahosted.org/python-slip/
+      license = pkgs.lib.licenses.gpl2;
+    };
+  };
+
+
   supervisor = buildPythonPackage rec {
     name = "supervisor-3.0b2";
 


### PR DESCRIPTION
This pull request brings some quite big changes to make firewalld work:
- Python packages using gtk3 require **gobject introspection** to work. It was not enabled before, so i had to enable it in **gdk_pixbuf, gtk3, atk, pango, pygobject3, libnotify and network-manager** to make firewalld work.
  It should not cause any problems, because apps(mostly native) not using introspection just don't care.
- The way i export gobject introspection typelib path is by using passthru.
- One exeception which could cause problems is libnotify. Now it depend on gtk3, because i was not able to make it work otherwise. I don't know if this is bad or not.

I would also need some help implementing nixos firewalld module. I think this package can help many. Thanks!
