### PR TITLE
curl: update to version 7.31.0

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -11,11 +11,11 @@ assert sslSupport -> openssl != null;
 assert scpSupport -> libssh2 != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.30.0";
+  name = "curl-7.31.0";
 
   src = fetchurl {
     url = "http://curl.haxx.se/download/${name}.tar.bz2";
-    sha256 = "04dgm9aqvplsx43n8xin5rkr8mwmc6mdd1gcp80jda5yhw1l273b";
+    sha256 = "021ygqk4gn24iqm0i0xvzldfgqdg18fmvwqia7i5vzzcxj712fx7";
   };
 
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains


### PR DESCRIPTION
Curl recently fixed a security vulnerability (CVE-2013-2174).

The curl website considers the vulnerability relatively mild [0].

I haven't tested this yet; I just started re-building everything.

[0] http://curl.haxx.se/docs/adv_20130622.html

I am providing this patch to you under an open source license.  Because I have done this work with my own personal resources, the license you receive to my code is from me and not from my employer (Facebook).

Since I'm not sure what licence nixpgs uses, I release all patches attached to this pull request under the CC0 licence; feel free to include them anywhere at all and with any modifications.
