### PR TITLE
Disable exec symlink resolution for PostgreSQL 9.2

### DIFF
--- a/pkgs/servers/sql/postgresql/9.2.x.nix
+++ b/pkgs/servers/sql/postgresql/9.2.x.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "world" ];
 
+  patches = [ ./disable-resolve_symlinks.patch ];
+
   installTargets = [ "install-world" ];
 
   LC_ALL = "C";

--- a/pkgs/servers/sql/postgresql/disable-resolve_symlinks.patch
+++ b/pkgs/servers/sql/postgresql/disable-resolve_symlinks.patch
@@ -1,0 +1,14 @@
+diff --git a/src/port/exec.c b/src/port/exec.c
+index c79e8ba..42c4091 100644
+--- a/src/port/exec.c
++++ b/src/port/exec.c
+@@ -216,6 +216,9 @@ find_my_exec(const char *argv0, char *retpath)
+ static int
+ resolve_symlinks(char *path)
+ {
++    // On NixOS we *want* stuff relative to symlinks.
++    return 0;
++
+ #ifdef HAVE_READLINK
+ 	struct stat buf;
+ 	char		orig_wd[MAXPGPATH],


### PR DESCRIPTION
When building PostgreSQL with plugins under NixOS, NixOS will create a
postgresql-and-plugins directory which symlinks PostgreSQL and all the plugins
into a single directory. Unfortunately, the plugins will not actually be usable
by PostgreSQL because it will still try and locate them in the original
PostgreSQL share directory, not postgresql-and-plugins.

In this commit, I have patched resolve_symlinks to always return success, which
matches the behavior if HAVE_READLINK is false (so presumably invalid paths are
never passed to this function).

---

I haven't added this patch to all the other versions, as I wanted to discuss it first.
