### PR TITLE
rmlint: Install to /bin, not /usr/bin

### DIFF
--- a/pkgs/tools/misc/rmlint/default.nix
+++ b/pkgs/tools/misc/rmlint/default.nix
@@ -8,6 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "bea39a5872b39d3596e756f242967bc5bde6febeb996fdcd63fbcf5bfdc75f01";
   };
 
+  preConfigure = ''
+    substituteInPlace Makefile.in \
+      --replace "/usr/" "/"
+  '';
+
   makeFlags="DESTDIR=$(out)";
 
   meta = {


### PR DESCRIPTION
I discovered that after installing rmlint, I couldn't run it. This was because it was installed to /usr/bin (inside its Nix store path), and that was not in my path. After a quick search through /nix/store, I discovered that no other packages (at least of the ones I have installed) have a /usr/bin either, so this must not be good.

This commit fixes the problem by changing rmlint to install in /bin. I had to use preConfigure because rmlint's Makefile doesn't support PREFIX.
