### PR TITLE
sqlite: set meta.platforms so that Hydra will build it

### DIFF
--- a/pkgs/development/libraries/sqlite/3.7.14.nix
+++ b/pkgs/development/libraries/sqlite/3.7.14.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://www.sqlite.org/;
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/sqlite/3.7.16.nix
+++ b/pkgs/development/libraries/sqlite/3.7.16.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://www.sqlite.org/;
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
+    platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
I'm sure that sqlite works on more platforms than linux, but I cannot
verify that myself (I only have linux). So I'll leave it up to the users
of other platforms to expand this as needed.
