### PR TITLE
php-xdebug: update to latest version

### DIFF
--- a/pkgs/development/interpreters/php-xdebug/default.nix
+++ b/pkgs/development/interpreters/php-xdebug/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, php, autoconf, automake }:
 
-stdenv.mkDerivation {
-  name = "php-xdebug-2.0.5";
+stdenv.mkDerivation rec {
+  version = "2.2.3";
+  name = "php-xdebug-${version}";
 
   src = fetchurl {
-    url = "http://xdebug.org/files/xdebug-2.0.5.tgz";
-    sha256 = "1cmq7c36gj8n41mfq1wba5rij8j77yqhydpcsbcysk1zchg68f26";
+    url = "http://xdebug.org/files/xdebug-2.2.3.tgz";
+    sha256 = "076px4ax3qcqr3mmhi9jjkfhn7pcymrpda4hzy6kgn3flhnqfldk";
   };
 
   buildInputs = [ php autoconf automake ];


### PR DESCRIPTION
Fixes http://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.phpXdebug.x86_64-linux and maybe http://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.phpXdebug_5_4.i686-linux

https://github.com/NixOS/nixpkgs/pull/661
