### PR TITLE
libunique: Get it to compile with gcc 4.8.

### DIFF
--- a/pkgs/development/libraries/libunique/default.nix
+++ b/pkgs/development/libraries/libunique/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   preBuildPhases = "preBuild";
   preBuild = ''substituteInPlace unique/dbus/Makefile --replace -Werror ""'';
 
+  # gcc 4.8 introduces a new warning, -Wunused-local-typedefs, which seems to
+  # be triggered by libunique's static assertion mechanism.
+  configureFlags = "CFLAGS=-Wno-unused-local-typedefs";
+
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
Fixes #704, probably.

Warning: I have not yet tested this exact commit.  I have only verified that the same change off an earlier commit gets libunique to compile, but I have since rebased.  That said, it didn't compile before, so there can't be any harm in this.

I am providing this patch to you under an open source license. Because I have done this work with my own personal resources, the license you receive to my code is from me and not from my employer (Facebook).

Since I'm not sure what licence nixpgs uses, I release all patches attached to this pull request under the CC0 licence; feel free to include them anywhere at all and with any modifications.
