### PR TITLE
fixes two issues via patches to get knetwork compiling

### DIFF
--- a/pkgs/desktops/kde-4.10/kdenetwork/kopete-4.10.4-kopete-linphonemediaengine.patch
+++ b/pkgs/desktops/kde-4.10/kdenetwork/kopete-4.10.4-kopete-linphonemediaengine.patch
@@ -1,0 +1,22 @@
+diff --git a/kopete/protocols/jabber/googletalk/libjingle/talk/session/phone/linphonemediaengine.cc b/kopete/protocols/jabber/googletalk/libjingle/talk/session/phone/linphonemediaengine.cc
+index 88fdbd1..57c6c05 100644
+--- a/kopete/protocols/jabber/googletalk/libjingle/talk/session/phone/linphonemediaengine.cc
++++ b/kopete/protocols/jabber/googletalk/libjingle/talk/session/phone/linphonemediaengine.cc
+@@ -200,7 +200,7 @@ bool LinphoneVoiceChannel::SetSendCodecs(const std::vector<AudioCodec>& codecs)
+       LOG(LS_INFO) << "Using " << i->name << "/" << i->clockrate;
+       pt_ = i->id;
+       audio_stream_ = audio_stream_start(&av_profile, -1, "localhost", port1, i->id, 250, 0); /* -1 means that function will choose some free port */
+-      port2 = rtp_session_get_local_port(audio_stream_->session);
++      port2 = rtp_session_get_local_port(audio_stream_->ms.session);
+       first = false;
+     }
+   }
+@@ -211,7 +211,7 @@ bool LinphoneVoiceChannel::SetSendCodecs(const std::vector<AudioCodec>& codecs)
+     // working with a buggy client; let's try PCMU.
+     LOG(LS_WARNING) << "Received empty list of codces; using PCMU/8000";
+     audio_stream_ = audio_stream_start(&av_profile, -1, "localhost", port1, 0, 250, 0); /* -1 means that function will choose some free port */
+-    port2 = rtp_session_get_local_port(audio_stream_->session);
++    port2 = rtp_session_get_local_port(audio_stream_->ms.session);
+   }
+ 
+   return true;

--- a/pkgs/desktops/kde-4.10/kdenetwork/kopete-4.10.4-kopete-stun.patch
+++ b/pkgs/desktops/kde-4.10/kdenetwork/kopete-4.10.4-kopete-stun.patch
@@ -1,0 +1,47 @@
+diff --git a/kopete/protocols/jabber/googletalk/libjingle/talk/p2p/base/stun.h b/kopete/protocols/jabber/googletalk/libjingle/talk/p2p/base/stun.h
+--- a/kopete/protocols/jabber/googletalk/libjingle/talk/p2p/base/stun.h
++++ b/kopete/protocols/jabber/googletalk/libjingle/talk/p2p/base/stun.h
+@@ -25,16 +25,8 @@
+  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#ifndef __STUN_H__
+-#define __STUN_H__
+-
+-// This file contains classes for dealing with the STUN and TURN protocols.
+-// Both protocols use the same wire format.
+-
+-#include "talk/base/basictypes.h"
+-#include "talk/base/bytebuffer.h"
+-#include <string>
+-#include <vector>
++#ifndef STUN__HH__IN__STUNREQUEST_CYCLIC_PROBLEM_FIX
++#define STUN__HH__IN__STUNREQUEST_CYCLIC_PROBLEM_FIX
+ 
+ namespace cricket {
+ 
+@@ -55,6 +47,23 @@
+   STUN_DATA_INDICATION              = 0x0115
+ };
+ 
++}
++
++#endif // STUN__HH__IN__STUNREQUEST_CYCLIC_PROBLEM_FIX
++
++#ifndef __STUN_H__
++#define __STUN_H__
++
++// This file contains classes for dealing with the STUN and TURN protocols.
++// Both protocols use the same wire format.
++
++#include "talk/base/basictypes.h"
++#include "talk/base/bytebuffer.h"
++#include <string>
++#include <vector>
++
++namespace cricket {
++
+ // These are the types of attributes defined in STUN & TURN.  Next to each is
+ // the name of the class (T is StunTAttribute) that implements that type.
+ enum StunAttributeType {
+

--- a/pkgs/desktops/kde-4.10/kdenetwork/kopete.nix
+++ b/pkgs/desktops/kde-4.10/kdenetwork/kopete.nix
@@ -18,6 +18,8 @@ kde {
   patchPhase =
     ''
       cp -v ${./FindmsiLBC.cmake} kopete/cmake/modules/FindmsiLBC.cmake
+      patch -p1 < ${./kopete-4.10.4-kopete-linphonemediaengine.patch}
+      patch -p1 < ${./kopete-4.10.4-kopete-stun.patch}
     '';
 
   cmakeFlags = [ "-DBUILD_skypebuttons=TRUE" ];


### PR DESCRIPTION
## kopete-4.10.4-kopete-linphonemediaengine.patch

patch copied from here:
  https://bugs.kde.org/show_bug.cgi?id=318825
## kopete-4.10.4-kopete-stun.patch

  when compiling kopete/protocols/jabber/googletalk/libjingle/talk/session/phone/channelmanager.cc
  it would produce this error:

  kopete/protocols/jabber/googletalk/libjingle/talk/p2p/base/stunrequest.h:91:9: error: ‘StunMessageType’ does not name a type

  problem:
    this is cased by a cyclic use of stun.h, stunrequest.h and channelmanager.cc with the outcome,
    that kdenetwork couldn't be compiled since kopete fails to build.

  solution:
    move the StunMessageType enum into its own #ifndef
