### PR TITLE
gnuplot: fix build on darwin

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -44,7 +44,7 @@ EOF
 
   doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "GNU Emacs 24, the extensible, customizable text editor";
 
     longDescription = ''
@@ -67,7 +67,7 @@ EOF
     homepage = "http://www.gnu.org/software/emacs/";
     license = "GPLv3+";
 
-    maintainers = with stdenv.lib.maintainers; [ ludo simons chaoflow ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ chaoflow lovek323 ludo simons ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -9,10 +9,16 @@ stdenv.mkDerivation {
     sha256 = "09ch709cb9fniwc4221xgkq0jf0x0lxs814sqig8p2dcll0llvzk";
   };
 
-  buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 polkit gtk ];
+  buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 gtk ]
+    # polkit requires pam, which requires shadow.h, which is not available on
+    # darwin
+    ++ stdenv.lib.optional (!stdenv.isDarwin) polkit;
+
   propagatedBuildInputs = [ glib ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  configureFlags = "--with-gtk=2.0";
+  configureFlags = [ "--with-gtk=2.0" ]
+    # fixes the "libgconfbackend-oldxml.so is not portable" error on darwin
+    ++ stdenv.lib.optional stdenv.isDarwin [ "--enable-static" ];
 }

--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl_gnome, pkgconfig, glib, libIDL}:
+{ stdenv, fetchurl_gnome, pkgconfig, glib, libIDL, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = src.pkgname;
@@ -14,5 +14,24 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ glib libIDL ];
+  propagatedBuildInputs = [ glib libIDL ] ++ libintlOrEmpty;
+
+  meta = with stdenv.lib; {
+    homepage    = https://projects.gnome.org/ORBit2/;
+    description = "A a CORBA 2.4-compliant Object Request Broker";
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ lovek323 ];
+
+    longDescription = ''
+      ORBit2 is a CORBA 2.4-compliant Object Request Broker (ORB) featuring
+      mature C, C++ and Python bindings. Bindings (in various degrees of
+      completeness) are also available for Perl, Lisp, Pascal, Ruby, and TCL;
+      others are in-progress. It supports POA, DII, DSI, TypeCode, Any, IR and
+      IIOP. Optional features including INS and threading are available. ORBit2
+      is engineered for the desktop workstation environment, with a focus on
+      performance, low resource usage, and security. The core ORB is written in
+      C, and runs under Linux, UNIX (BSD, Solaris, HP-UX, ...), and Windows.
+      ORBit2 is developed and released as open source software under GPL/LGPL.
+    '';
+  };
 }

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optional (!stdenv.isDarwin) [ "-DBUILD_SHARED_LIBS=ON" ];
 
   enableParallelBuilding = true;
-  doCheck = true; # tests are broken, don't know why
+  # doCheck = true; # tests are broken, don't know why
 
   meta = with stdenv.lib; {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -18,19 +18,23 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ libffi ];
   buildInputs = [ perl groff cmake python ]; # ToDo: polly, libc++; enable cxx11?
 
-  # created binaries need to be run before installation... I coudn't find a better way
-  preBuild = ''export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:"`pwd`/lib'';
+  # created binaries need to be run before installation... I coudn't find a
+  # better way
+  preBuild = ( if stdenv.isDarwin
+               then "export DYLD_LIBRARY_PATH='$DYLD_LIBRARY_PATH:'`pwd`/lib"
+               else "export LD_LIBRARY_PATH='$LD_LIBRARY_PATH:'`pwd`/lib" );
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin) [ "-DBUILD_SHARED_LIBS=ON" ];
 
   enableParallelBuilding = true;
-  #doCheck = true; # tests are broken, don't know why
+  doCheck = true; # tests are broken, don't know why
 
-  meta = {
-    homepage = http://llvm.org/;
+  meta = with stdenv.lib; {
     description = "Collection of modular and reusable compiler and toolchain technologies";
-    license = "BSD";
-    maintainers = with stdenv.lib.maintainers; [viric shlevy raskin];
-    platforms = with stdenv.lib.platforms; all;
+    homepage    = http://llvm.org/;
+    license     = licenses.bsd;
+    maintainers = with maintainers; [ lovek323 raskin shlevy viric ];
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = "cracklib-2.8.16";
@@ -8,8 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "1g3mchdvra9nihxlkl3rdz96as3xnfw5m59hmr5k17l7qa9a8fpw";
   };
 
-  meta = {
-    homepage = http://sourceforge.net/projects/cracklib;
+  buildInputs = libintlOrEmpty;
+
+  meta = with stdenv.lib; {
+    homepage    = http://sourceforge.net/projects/cracklib;
     description = "A library for checking the strength of passwords";
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -24,7 +24,7 @@ let
   '';
 in
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "glib-2.36.1";
 
   src = fetchurl {
@@ -41,10 +41,7 @@ stdenv.mkDerivation (rec {
 
   configureFlags = "--with-pcre=system --disable-fam";
 
-  postConfigure = "sed '/SANE_MALLOC_PROTOS/s,^,//,' -i config.h" # https://bugzilla.gnome.org/show_bug.cgi?id=698716 :-)
-    + stdenv.lib.optionalString stdenv.isDarwin ''
-      sed '24 i #include <Foundation/Foundation.h>'
-    '';
+  postConfigure = "sed '/SANE_MALLOC_PROTOS/s,^,//,' -i config.h";
 
   enableParallelBuilding = true;
 
@@ -55,12 +52,12 @@ stdenv.mkDerivation (rec {
      inherit flattenInclude;
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "GLib, a C library of programming buildings blocks";
     homepage    = http://www.gtk.org/;
-    license     = "LGPLv2+";
-    maintainers = with stdenv.lib.maintainers; [ raskin urkud lovek323 ];
-    platforms   = stdenv.lib.platforms.unix;
+    license     = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ lovek323 raskin urkud ];
+    platforms   = platforms.unix;
 
     longDescription = ''
       GLib provides the core application building blocks for libraries
@@ -71,12 +68,3 @@ stdenv.mkDerivation (rec {
   };
 }
 
-//
-
-(stdenv.lib.optionalAttrs stdenv.isDarwin {
-  # XXX: Disable the NeXTstep back-end because stdenv.gcc doesn't support
-  # Objective-C.
-  postConfigure =
-    '' sed -i configure -e's/glib_have_cocoa=yes/glib_have_cocoa=no/g'
-    '';
-}))

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchurl, glib, flex, bison, pkgconfig, libffi, python, gdk_pixbuf }:
+{ stdenv, fetchurl, glib, flex, bison, pkgconfig, libffi, python, gdk_pixbuf
+, libintlOrEmpty, autoconf, automake, otool }:
 
 stdenv.mkDerivation rec {
   name = "gobject-introspection-1.34.2";
 
-  buildInputs = [ flex bison glib pkgconfig python gdk_pixbuf ];
+  buildInputs = [ flex bison glib pkgconfig python gdk_pixbuf ]
+    ++ libintlOrEmpty
+    ++ stdenv.lib.optional stdenv.isDarwin otool;
   propagatedBuildInputs = [ libffi ];
 
   # Tests depend on cairo, which is undesirable (it pulls in lots of
   # other dependencies).
-  configureFlags = "--disable-tests";
+  configureFlags = [ "--disable-tests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gobject-introspection/1.34/${name}.tar.xz";
@@ -18,8 +21,17 @@ stdenv.mkDerivation rec {
   postInstall = "rm -rf $out/share/gtk-doc";
 
   meta = with stdenv.lib; {
-    maintainers = [ maintainers.urkud ];
-    platforms = platforms.linux;
-    homepage = http://live.gnome.org/GObjectIntrospection;
+    description = "A middleware layer between C libraries and language bindings";
+    homepage    = http://live.gnome.org/GObjectIntrospection;
+    maintainers = with maintainers; [ lovek323 urkud ];
+    platforms   = platforms.unix;
+
+    longDescription = ''
+      GObject introspection is a middleware layer between C libraries (using
+      GObject) and language bindings. The C library can be scanned at compile
+      time and generate a metadata file, in addition to the actual native C
+      library. Then at runtime, language bindings can read this metadata and
+      automatically provide bindings to call into the C library.
+    '';
   };
 }

--- a/pkgs/development/libraries/gstreamer/gst-plugins-base/default.nix
+++ b/pkgs/development/libraries/gstreamer/gst-plugins-base/default.nix
@@ -1,7 +1,5 @@
-{ fetchurl, stdenv, pkgconfig, python, gstreamer
-, xlibs, alsaLib, cdparanoia, libogg
-, libtheora, libvorbis, freetype, pango
-, liboil, glib
+{ fetchurl, stdenv, pkgconfig, python, gstreamer, xlibs, alsaLib, cdparanoia
+, libogg, libtheora, libvorbis, freetype, pango, liboil, glib, cairo
 , # Whether to build no plugins that have external dependencies
   # (except the ALSA plugin).
   minimalDeps ? false
@@ -25,22 +23,25 @@ stdenv.mkDerivation rec {
 
   # TODO : v4l, libvisual
   buildInputs =
-    [ pkgconfig glib alsaLib ]
+    [ pkgconfig glib cairo ]
+    # can't build alsaLib on darwin
+    ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib
     ++ stdenv.lib.optionals (!minimalDeps)
-      [ xlibs.xlibs xlibs.libXv cdparanoia libogg libtheora libvorbis
-        freetype pango liboil
-      ];
+      [ xlibs.xlibs xlibs.libXv libogg libtheora libvorbis freetype pango
+        liboil ]
+    # can't build cdparanoia on darwin
+    ++ stdenv.lib.optional (!minimalDeps && !stdenv.isDarwin) cdparanoia;
 
   propagatedBuildInputs = [ gstreamer ];
  
   postInstall = "rm -rf $out/share/gtk-doc";
   
-  meta = {
-    homepage = http://gstreamer.freedesktop.org;
-
+  meta = with stdenv.lib; {
+    homepage    = http://gstreamer.freedesktop.org;
     description = "Base plug-ins for GStreamer";
-
-    license = "LGPLv2+";
+    license     = licences.lgpl2Plus;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
   };
 }
 

--- a/pkgs/development/libraries/liboil/default.nix
+++ b/pkgs/development/libraries/liboil/default.nix
@@ -12,9 +12,15 @@ stdenv.mkDerivation rec {
 
   patches = [ ./x86_64-cpuid.patch ];
 
-  meta = {
-    homepage = http://liboil.freedesktop.org;
+  # fix "argb_paint_i386.c:53:Incorrect register `%rax' used with `l' suffix"
+  # errors
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--build=x86_64";
+
+  meta = with stdenv.lib; {
     description = "A library of simple functions that are optimized for various CPUs";
-    license = "BSD-2";
+    homepage    = http://liboil.freedesktop.org;
+    license     = libraries.bsd2;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/development/tools/misc/otool/default.nix
+++ b/pkgs/development/tools/misc/otool/default.nix
@@ -1,5 +1,8 @@
 { stdenv }:
 
+# this tool only exists on darwin
+assert stdenv.isDarwin;
+
 stdenv.mkDerivation {
   name = "otool";
 

--- a/pkgs/development/tools/misc/otool/default.nix
+++ b/pkgs/development/tools/misc/otool/default.nix
@@ -1,0 +1,31 @@
+{ stdenv }:
+
+stdenv.mkDerivation {
+  name = "otool";
+
+  src = "/usr/bin/otool";
+
+  unpackPhase = "true";
+  configurePhase = "true";
+  buildPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp /usr/bin/otool "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Object file displaying tool";
+    homepage    = https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/otool.1.html;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.darwin;
+
+    longDescription = ''
+      The otool command displays specified parts of object files or libraries.
+      If the, -m option is not used, the file arguments may be of the form
+      libx.a(foo.o), to request information about only that object file and not
+      the entire library.
+    '';
+  };
+}
+

--- a/pkgs/development/tools/misc/setFile/default.nix
+++ b/pkgs/development/tools/misc/setFile/default.nix
@@ -1,5 +1,8 @@
 { stdenv }:
 
+# this tool only exists on darwin
+assert stdenv.isDarwin;
+
 stdenv.mkDerivation {
   name = "setFile";
 

--- a/pkgs/development/tools/misc/setFile/default.nix
+++ b/pkgs/development/tools/misc/setFile/default.nix
@@ -1,0 +1,31 @@
+{ stdenv }:
+
+stdenv.mkDerivation {
+  name = "setFile";
+
+  src = "/usr/bin/SetFile";
+
+  unpackPhase = "true";
+  configurePhase = "true";
+  buildPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp $src "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Set attributes of files and directories";
+    homepage    = "http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/setfile.1.html";
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.darwin;
+
+    longDescription = ''
+      SetFile is a tool to set the file attributes on files in an HFS+
+      directory. It attempts to be similar to the setfile command in MPW. It can
+      apply rules to more than one file with the options apply- ing to all files
+      listed.
+    '';
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -446,6 +446,8 @@ let
 
   otool = callPackage ../development/tools/misc/otool { };
 
+  setFile = callPackage ../development/tools/misc/setFile { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   titaniumenv_2_1 = import ../development/mobile/titaniumenv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7232,6 +7232,12 @@ let
     alsaLib = null;
     imagemagick = null;
     texinfo = texinfo5;
+
+    # use gccApple on darwin to deal with: unexec: 'my_edata is not in section
+    # __data'
+    stdenv = if stdenv.isDarwin
+      then stdenvAdapters.overrideGCC stdenv gccApple
+      else stdenv;
   };
 
   emacsPackages = emacs: self: let callPackage = newScope self; in rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -444,6 +444,8 @@ let
 
   apg = callPackage ../tools/security/apg { };
 
+  otool = callPackage ../development/tools/misc/otool { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   titaniumenv_2_1 = import ../development/mobile/titaniumenv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5475,6 +5475,11 @@ let
   wxGTK29 = callPackage ../development/libraries/wxGTK-2.9/default.nix {
     inherit (gnome) GConf;
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
+
+    # use for Objective-C++ compiler
+    stdenv = if stdenv.isDarwin
+      then clangStdenv
+      else stdenv;
   };
 
   wtk = callPackage ../development/libraries/wtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -917,6 +917,11 @@ let
   gnuplot = callPackage ../tools/graphics/gnuplot {
     texLive = null;
     lua = null;
+
+    # use gccApple to compile on darwin, seems to resolve a malloc error
+    stdenv = if stdenv.isDarwin
+      then stdenvAdapters.overrideGCC stdenv gccApple
+      else stdenv;
   };
 
   gnused = callPackage ../tools/text/gnused { };


### PR DESCRIPTION
gnuplot: fix build on darwin

This was a crazy tangle of dependencies.

I didn't end up using `wxGTK29`, but I left the fixes in here for others who
wish to use it.

In order to get `gnuplot` building on darwin, I had to do the following:
- `cracklib`: add `libintlOrEmpty` to build inputs
- `emacs24`: build with gccApple (fixes http://hydra.nixos.org/build/5440806)
- `glib`: remove unnecessary restrictions
- `gnome.GConf`: disable `polkit` (requires `pam` which requires `shadow.h`
  which is not available on darwin), add --enable-static to configureFlags
- `gnome.ORBit2`: add `libintlOrEmpty` to build inputs
- `gnuplot`: add `readline` to build inputs, don't use wxGTK (gives a malloc
  double free error)
- `gobject-introspection`: add `libintlOrEmpty` to build inputs, add `otool` as
  build input
- `gst-plugins-base`: remove `alsaLib` and `cdparanoia` from build inputs when
  building on darwin, add `cairo` to build inputs
- `liboil`: force architecture to x86_64
- `llvm`: add `DYLD_LIBRARY_PATH` (recent modifications broke the build on
  darwin -- fixes http://hydra.nixos.org/build/5407837), don't build with shared
  libs
- `otool`: add expression (this is just copied straight from /usr/bin -- I'm
  open to suggestions on how to improve)
- `setFile`: add expression (same as for `otool` -- straight from /usr/bin)
- `wxGTK29`: use `clang` for Objective-C++ compiler, add configure flags to
  enable building on 64-bit, add `setFile` to build inputs
