### PR TITLE
ncmpcpp: fix build on darwin

### DIFF
--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchurl, ncurses, curl, taglib, fftw, mpd_clientlib, pkgconfig}:
+{ stdenv, fetchurl, ncurses, curl, taglib, fftw, mpd_clientlib, pkgconfig
+, libiconvOrEmpty }:
 
 stdenv.mkDerivation rec {
   version = "0.5.10";
@@ -9,14 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "ff6d5376a2d9caba6f5bb78e68af77cefbdb2f04cd256f738e39f8ac9a79a4a8";
   };
 
-  buildInputs = [ ncurses curl taglib fftw mpd_clientlib pkgconfig ];
+  buildInputs = [ ncurses curl taglib fftw mpd_clientlib pkgconfig ]
+    ++ libiconvOrEmpty;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";
-    homepage = http://unkart.ovh.org/ncmpcpp/;
-    license = "GPLv2+";
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
-    platforms = stdenv.lib.platforms.all;
+    homepage    = http://unkart.ovh.org/ncmpcpp/;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lovek323 mornfall ];
+    platforms   = platforms.all;
   };
 }
 


### PR DESCRIPTION
Fixes http://hydra.nixos.org/build/5365577
- add libiconvOrEmpty to build inputs
