### PR TITLE
Update tzdata's hashes

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
   srcs =
     [ (fetchurl {
         url = "http://www.iana.org/time-zones/repository/releases/tzdata${version}.tar.gz";
-        sha256 = "1k165i8g23rr0z26k02x1l4immp69g6yqjrd3lwmbvj5li4mmsdg";
+        sha256 = "0k2qyxkifhy3a0kxfkz737sh21j5wia3wa9s0v4lf8fn8fk7vw03";
       })
       (fetchurl {
         url = "http://www.iana.org/time-zones/repository/releases/tzcode${version}.tar.gz";
-        sha256 = "1m6rg9003mkjyvpv5gg5lcia9fzhy7ndwgs68qlpbipnw5p0k2pk";
+        sha256 = "1skl69vydrf0vl6qifwz0yvh5fhspyd31kg6sslxdhfdlslnljkl";
       })
     ];
 


### PR DESCRIPTION
tzdata did not build locally because of a hash mismatch. I updated the hashes without investigating the cause any further.
