### PR TITLE
xdg-utils update (fixes problems with xdg-open)

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, file }:
 
 stdenv.mkDerivation rec {
-  name = "xdg-utils-1.0.2";
+  name = "xdg-utils-1.1.0-rc1";
   
   src = fetchurl {
-    url = "http://portland.freedesktop.org/download/${name}.tgz";
-    sha256 = "1b019d3r1379b60p33d6z44kx589xjgga62ijz9vha95dg8vgbi1";
+    url = "http://portland.freedesktop.org/download/${name}.tar.gz";
+    sha256 = "00lisw4x43sp189lb7dz46j2l09y5v2fijk3d0sxx3mvwj55a1bv";
   };
 
   postInstall = ''


### PR DESCRIPTION
The specific problem was that xdg-open opened everything in $BROWSER. Now it actually uses the xdg-mime database.

I believe @the-kenny wants this too.
