### PR TITLE
libspotify: add darwin library

### DIFF
--- a/pkgs/development/libraries/libspotify/default.nix
+++ b/pkgs/development/libraries/libspotify/default.nix
@@ -1,25 +1,56 @@
-{ stdenv, fetchurl, libspotify, alsaLib, readline, pkgconfig, apiKey }:
+{ stdenv, fetchurl, libspotify, alsaLib, readline, pkgconfig, apiKey, unzip }:
 
 let version = "12.1.51"; in
 
-if stdenv.system != "x86_64-linux" then throw ''
-  Check https://developer.spotify.com/technologies/libspotify/ for a tarball for your system and add it here
-'' else stdenv.mkDerivation {
+if (stdenv.system == "x86_64-linux" && stdenv.system != "x86_64-darwin")
+then throw "Check https://developer.spotify.com/technologies/libspotify/ for a tarball for your system and add it here"
+else stdenv.mkDerivation {
   name = "libspotify-${version}";
 
-  src = fetchurl {
-    url = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Linux-x86_64-release.tar.gz";
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Linux-x86_64-release.tar.gz";
+        sha256 = "0n0h94i4xg46hfba95n3ypah93crwb80bhgsg00f6sms683lx8a3";
+      }
+    else if stdenv.system == "x86_64-darwin" then
+      fetchurl {
+        url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Darwin-universal.zip";
+        sha256 = "1gcgrc8arim3hnszcc886lmcdb4iigc08abkaa02l6gng43ky1c0";
+      }
+    else
+      null;
 
-    sha256 = "0n0h94i4xg46hfba95n3ypah93crwb80bhgsg00f6sms683lx8a3";
-  };
-
+  # common
   buildPhase = "true";
+  # no patch or build phase for darwin
+  phases = [ "unpackPhase" "installPhase" ]
+    ++ stdenv.lib.optionals (stdenv.system == "x86_64-linux")
+      [ "patchPhase" "buildPhase" ];
+  installPhase = if (stdenv.system == "x86_64-linux")
+    then "installPhase"
+    else ''
+      mkdir -p "$out"/include/libspotify
+      mv -v libspotify.framework/Versions/Current/Headers/api.h \
+        "$out"/include/libspotify
+      mkdir -p "$out"/lib
+      mv -v libspotify.framework/Versions/Current/libspotify \
+        "$out"/lib/libspotify.dylib
+      mkdir -p "$out"/share/man
+      mv -v man3 "$out"/share/man
+    '';
+ 
 
-  installFlags = "prefix=$(out)";
+  # darwin-specific
+  buildInputs = stdenv.lib.optional (stdenv.system == "x86_64-darwin") unzip;
 
-  postInstall = "mv -v share $out";
-
-  patchPhase = "sed -i 's/ldconfig//' Makefile";
+  # linux-specific
+  installFlags = stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
+    "prefix=$(out)";
+  patchPhase = stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
+    "sed -i 's/ldconfig//' Makefile";
+  postInstall = stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
+    "mv -v share $out";
 
   passthru = {
     samples = if apiKey == null
@@ -27,35 +58,27 @@ if stdenv.system != "x86_64-linux" then throw ''
         Please visit ${libspotify.meta.homepage} to get an api key then set config.libspotify.apiKey accordingly
       '' else stdenv.mkDerivation {
         name = "libspotify-samples-${version}";
-
         src = libspotify.src;
-
-        buildInputs = [ pkgconfig libspotify alsaLib readline ];
-
+        buildInputs = [ pkgconfig libspotify readline ]
+          ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib;
         postUnpack = "sourceRoot=$sourceRoot/share/doc/libspotify/examples";
-
         patchPhase = "cp ${apiKey} appkey.c";
-
         installPhase = ''
           mkdir -p $out/bin
           install -m 755 jukebox/jukebox $out/bin
           install -m 755 spshell/spshell $out/bin
           install -m 755 localfiles/posix_stu $out/bin
         '';
-
         meta = libspotify.meta // { description = "Spotify API library samples"; };
       };
 
     inherit apiKey;
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Spotify API library";
-
-    homepage = https://developer.spotify.com/technologies/libspotify;
-
-    maintainers = [ stdenv.lib.maintainers.shlevy ];
-
-    license = stdenv.lib.licenses.unfree;
+    homepage    = https://developer.spotify.com/technologies/libspotify;
+    maintainers = with maintainers; [ lovek323 shlevy ];
+    license     = licenses.unfree;
   };
 }

--- a/pkgs/os-specific/darwin/install_name_tool/default.nix
+++ b/pkgs/os-specific/darwin/install_name_tool/default.nix
@@ -1,0 +1,29 @@
+{ stdenv }:
+
+assert stdenv.isDarwin;
+
+stdenv.mkDerivation {
+  name = "install_name_tool";
+  src = "/usr/bin/install_name_tool";
+  unpackPhase = "true";
+  configurePhase = "true";
+  buildPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out"/bin
+    ln -s "$src" "$out"/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Change dynamic shared library install names";
+    homepage    = https://developer.apple.com/library/mac/documentation/Darwin/Reference/Manpages/man1/install_name_tool.1.html;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.darwin;
+
+    longDescription = ''
+      Install_name_tool changes the dynamic shared library install names and or
+      adds, changes or deletes the rpaths recorded in a Mach-O binary.
+    '';
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -444,6 +444,8 @@ let
 
   apg = callPackage ../tools/security/apg { };
 
+  install_name_tool = callPackage ../os-specific/darwin/install_name_tool { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   titaniumenv_2_1 = import ../development/mobile/titaniumenv {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6197,14 +6197,24 @@ pythonPackages = python.modules // rec {
     preConfigure = ''
       find -print0 | xargs -0 touch
     '';
+
+    postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+      find "$out" -name _spotify.so -exec \
+          install_name_tool -change \
+          @loader_path/../Frameworks/libspotify.framework/libspotify \
+          ${pkgs.libspotify}/lib/libspotify.dylib \
+          {} \;
+    '';
   
     # There are no tests
     doCheck = false;
   
-    meta = {
-      homepage = http://pyspotify.mopidy.com;
+    meta = with stdenv.lib; {
+      homepage    = http://pyspotify.mopidy.com;
       description = "A Python interface to Spotify’s online music streaming service";
-      maintainers = [ stdenv.lib.maintainers.rickynils ];
+      license     = licenses.unfree;
+      maintainers = with maintainers; [ lovek323 rickynils ];
+      platforms   = platforms.unix;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6190,7 +6190,8 @@ pythonPackages = python.modules // rec {
       sha256 = "1rvgrviwn6f037m8vq395chz6a1119dbsdhfwdbv5ambi0bak6ll";
     };
   
-    buildInputs = [ pkgs.libspotify ];
+    buildInputs = [ pkgs.libspotify ]
+      ++ stdenv.lib.optional stdenv.isDarwin pkgs.install_name_tool;
   
     # python zip complains about old timestamps
     preConfigure = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6182,12 +6182,11 @@ pythonPackages = python.modules // rec {
   pyspotify = buildPythonPackage rec {
     name = "pyspotify-${version}";
   
-    version = "1.10";
+    version = "1.11";
   
-    src = fetchgit {
-      url = "https://github.com/mopidy/pyspotify.git";
-      rev = "refs/tags/v${version}";
-      sha256 = "1rvgrviwn6f037m8vq395chz6a1119dbsdhfwdbv5ambi0bak6ll";
+    src = fetchurl {
+      url = "https://github.com/mopidy/pyspotify/archive/v1.11.tar.gz";
+      sha256 = "089ml6pqr3f2d15n70jpzbaqjp5pjgqlyv4algkxw92xscjw2izg";
     };
   
     buildInputs = [ pkgs.libspotify ]


### PR DESCRIPTION
I've also fixed `pyspotify` for darwin in this PR

This won't build successfully until https://github.com/NixOS/nixpkgs/pull/720 is merged.
- `install_name_tool`: add expression
- `libspotify`: add darwin library, add install_name_tool expression
- `pyspotify`: use install_name_tool to have _spotify.so point to the correct
  libspotify.dylib, update to latest version
