### PR TITLE
pyaudio: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -8,13 +8,40 @@ stdenv.mkDerivation rec {
     sha256 = "168vmcag3c5y3zwf7h5298ydh83g72q5bznskrw9cr2h1lrx29lw";
   };
 
-  buildInputs = [ alsaLib pkgconfig ];
-  
-  meta = {
+  buildInputs = [ pkgconfig ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib;
+
+  configureFlags = stdenv.lib.optionals stdenv.isDarwin
+    [ "--build=x86_64" "--without-oss" "--enable-static" "--enable-shared" ];
+
+  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i '50 i\
+      #include <CoreAudio/AudioHardware.h>\
+      #include <CoreAudio/AudioHardwareBase.h>\
+      #include <CoreAudio/AudioHardwareDeprecated.h>' \
+      include/pa_mac_core.h
+
+    # disable two tests that don't compile
+    sed -i -e 105d Makefile
+    sed -i -e 107d Makefile
+  '';
+
+  # not sure why, but all the headers seem to be installed by the make install
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p "$out"
+    cp -r include "$out"
+    cp -r lib "$out"
+  '' else ''
+    make install
+  '';
+
+  meta = with stdenv.lib; {
     description = "Portable cross-platform Audio API";
-    homepage = http://www.portaudio.com/;
+    homepage    = http://www.portaudio.com/;
     # Not exactly a bsd license, but alike
-    license = "BSD";
+    license     = licenses.bsd;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
   };
 
   passthru = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5149,7 +5149,13 @@ let
 
   popt = callPackage ../development/libraries/popt { };
 
-  portaudio = callPackage ../development/libraries/portaudio { };
+  portaudio = callPackage ../development/libraries/portaudio {
+    # resolves a variety of compile-time errors
+    stdenv = if stdenv.isDarwin
+      then clangStdenv
+      else stdenv;
+  };
+
   portaudioSVN = callPackage ../development/libraries/portaudio/svn-head.nix { };
 
   prison = callPackage ../development/libraries/prison { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3481,9 +3481,13 @@ pythonPackages = python.modules // rec {
 
     buildInputs = [ python pkgs.portaudio ];
 
-    installPhase = ''
-      python setup.py install --prefix=$out
+    buildPhase = if stdenv.isDarwin then ''
+      PORTAUDIO_PATH="${pkgs.portaudio}" python setup.py build --static-link
+    '' else ''
+      python setup.py build
     '';
+
+    installPhase = "python setup.py install --prefix=$out";
 
     meta = {
       description = "Python bindings for PortAudio";


### PR DESCRIPTION
- `portaudio`: remove `alsaLib` from build inputs, add '--build=x86_64'
  '--with-host-os=darwin' to configureFlags, add
  framework header files, copy darwin-specific header on install,
  build with `gccApple` (resolves a variety of syntax errors in the source),
  patch Makefile and libtool to remove specific references to 10.4 SDK
- `pyaudio`: build with '--static-link' flag, set correct PORTAUDIO_PATH
  environment variable
