### PR TITLE
autojump: fix build on darwin

### DIFF
--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -16,6 +16,9 @@ in
     dontBuild = true;
 
     installPhase = ''
+      # don't check shell support (we're running with bash anyway)
+      sed -i -e 150,153d install.sh
+
       bash ./install.sh -d $out
 
       mkdir -p "$out/etc/bash_completion.d"


### PR DESCRIPTION
- remove install.sh shell check

Fixes http://hydra.nixos.org/eval/943035
