### PR TITLE
openjdk: Don't statically link C++ runtime.

### DIFF
--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -108,6 +108,7 @@ stdenv.mkDerivation rec {
     "DEVTOOLS_PATH="
     "UNIXCOMMAND_PATH="
     "BOOTDIR=${jdk}"
+    "STATIC_CXX=false"
   ];
 
   configurePhase = ''


### PR DESCRIPTION
This fixes a build error (https://github.com/NixOS/nixpkgs/issues/707).  openjdk compiles but I haven't tested to see if it works.
Thanks to http://mail.openjdk.java.net/pipermail/build-dev/2012-January/005349.html .

I am providing this patch to you under an open source license. Because I have done this work with my own personal resources, the license you receive to my code is from me and not from my employer (Facebook).
