### PR TITLE
Build haddock for transformers-compat

### DIFF
--- a/pkgs/development/libraries/haskell/transformers-compat/default.nix
+++ b/pkgs/development/libraries/haskell/transformers-compat/default.nix
@@ -5,7 +5,6 @@ cabal.mkDerivation (self: {
   version = "0.1.1.1";
   sha256 = "0i0bcfmqsnqa8fyp81virr5bh3hk23261xyx28jcfamrc18ly9ij";
   buildDepends = [ transformers ];
-  noHaddock = true;
   meta = {
     homepage = "http://github.com/ekmett/transformers-compat/";
     description = "A small compatibility shim exposing the new types from transformers 0.3 to older Haskell platforms.";


### PR DESCRIPTION
I tested this and it builds, the built docs seems to be minimal, but OK.  Maybe this was needed in old times to cover for some other bugs?  Nowadays, this is the only package in my quite extensive nix based ghc cabal collection that issues warnings when I do a 'ghc-pkg check'.
