### PR TITLE
Add Slic3r, a 3D printer tool

### DIFF
--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchgit, perl, makeWrapper, makeDesktopItem
+# Perl modules:
+, EncodeLocale, MathClipper, ExtUtilsXSpp, BoostGeometryUtils
+, MathConvexHullMonotoneChain, MathGeometryVoronoi, MathPlanePath, Moo
+, IOStringy, ClassXSAccessor, Wx, GrowlGNTP, NetDBus }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.10b";
+  name = "slic3r-${version}";
+
+  # Slic3r doesn't put out tarballs, only a git repository is available
+  src = fetchgit {
+    url = "git://github.com/alexrj/Slic3r";
+    rev = "refs/tags/${version}";
+    sha256 = "0j06h0z65qn4kyb2b7pnq6bcn4al60q227iz9jlrin0ffx3l0ra7";
+  };
+
+  buildInputs = [ perl makeWrapper
+    EncodeLocale MathClipper ExtUtilsXSpp BoostGeometryUtils
+    MathConvexHullMonotoneChain MathGeometryVoronoi MathPlanePath Moo
+    IOStringy ClassXSAccessor Wx GrowlGNTP NetDBus
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "slic3r";
+    exec = "slic3r";
+    icon = "slic3r";
+    comment = "G-code generator for 3D printers";
+    desktopName = "Slic3r";
+    genericName = "3D printer tool";
+    categories = "Application;Development;";
+  };
+
+  # Nothing to do here
+  buildPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out/share/slic3r/"
+    cp -r * "$out/share/slic3r/"
+    wrapProgram "$out/share/slic3r/slic3r.pl" --prefix PERL5LIB : $PERL5LIB
+    mkdir -p "$out/bin"
+    ln -s "$out/share/slic3r/slic3r.pl" "$out/bin/slic3r"
+    mkdir -p "$out/share/pixmaps/"
+    ln -s "$out/share/slic3r/var/Slic3r.png" "$out/share/pixmaps/slic3r.png"
+    mkdir -p "$out/share/applications"
+    cp "$desktopItem"/share/applications/* "$out/share/applications/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "G-code generator for 3D printers";
+    longDescription = ''
+      Slic3r is the tool you need to convert a digital 3D model into printing
+      instructions for your 3D printer. It cuts the model into horizontal
+      slices (layers), generates toolpaths to fill them and calculates the
+      amount of material to be extruded.'';
+    homepage = http://slic3r.org/;
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5679,6 +5679,14 @@ let
     __overrides = (config.perl510PackageOverrides or (p: {})) pkgs;
   };
 
+  perl514Packages = import ./perl-packages.nix {
+    pkgs = pkgs // {
+      perl = perl514;
+      buildPerlPackage = import ../development/perl-modules/generic perl514;
+    };
+    __overrides = (config.perl514PackageOverrides or (p: {})) pkgs;
+  };
+
   perlXMLParser = perlPackages.XMLParser;
 
   ack = perlPackages.ack;
@@ -8300,6 +8308,14 @@ let
   lightdm = callPackage ../applications/display-managers/lightdm { };
 
   lightdm_gtk_greeter = callPackage ../applications/display-managers/lightdm-gtk-greeter { };
+
+  # slic3r 0.9.10b says: "Running Slic3r under Perl >= 5.16 is not supported nor recommended"
+  slic3r = callPackage ../applications/misc/slic3r {
+    inherit (perl514Packages) EncodeLocale MathClipper ExtUtilsXSpp
+            BoostGeometryUtils MathConvexHullMonotoneChain MathGeometryVoronoi
+            MathPlanePath Moo IOStringy ClassXSAccessor Wx GrowlGNTP NetDBus;
+    perl = perl514;
+  };
 
   slim = callPackage ../applications/display-managers/slim {
     libpng = libpng12;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2472,11 +2472,12 @@ rec {
   };
 
   ExtUtilsCBuilder = buildPerlPackage rec {
-    name = "ExtUtils-CBuilder-0.280202";
+    name = "ExtUtils-CBuilder-0.280205";
     src = fetchurl {
       url = "mirror://cpan/modules/by-module/ExtUtils/${name}.tar.gz";
-      sha256 = "13qjdz1kmrp5mp404by94cdsyydjadg974ykinqga450djjaqpbq";
+      sha256 = "0nfrr3zd71gnsbp5xacdb70n17slrzj421s4nyr11zg5cqsj3ngs";
     };
+    buildInputs = [ PerlOSType ];
   };
 
   ExtUtilsConfig = buildPerlPackage {
@@ -4064,6 +4065,7 @@ rec {
       url = mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4005.tar.gz;
       sha256 = "eb2522507251550f459c11223ea6d86b34f1dee9b3e3928d0d6a0497505cb7ef";
     };
+    buildInputs = [ CPANMeta ExtUtilsCBuilder ];
     meta = {
       description = "Build and install Perl modules";
       license = "perl";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -296,10 +296,10 @@ rec {
   };
 
   BoostGeometryUtils = buildPerlModule rec {
-    name = "Boost-Geometry-Utils-0.09";
+    name = "Boost-Geometry-Utils-0.12";
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AA/AAR/${name}.tar.gz";
-      sha256 = "0wgd36rxd5lj0vlkp7l9zgx8bgbv0nj4kia83ipb7p64xpyysghg";
+      sha256 = "1pywbxjf05qpcixshblhd2cham601zwa9w7c3k5waz4cdild6g1m";
     };
     propagatedBuildInputs = [ ModuleBuildWithXSpp ExtUtilsTypemapsDefault ];
   };
@@ -3934,10 +3934,10 @@ rec {
   };
 
   MathClipper = buildPerlModule rec {
-    name = "Math-Clipper-1.19";
+    name = "Math-Clipper-1.22";
     src = fetchurl {
       url = "mirror://cpan/modules/by-module/Math/${name}.tar.gz";
-      sha256 = "1hrdand4i937bgsr3f3yma5ckkdwkprdwmkyyl37v1vqcjdrjr7j";
+      sha256 = "0p5iblg979v3pb6a8kyhjdv33yadr5997nhz9asjksgvww328nfa";
     };
     propagatedBuildInputs = [ ModuleBuildWithXSpp ExtUtilsXSpp ExtUtilsTypemapsDefault TestDeep ];
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2569,11 +2569,31 @@ rec {
   };
 
   ExtUtilsParseXS = buildPerlPackage rec {
-    name = "ExtUtils-ParseXS-3.15";
+    name = "ExtUtils-ParseXS-3.18";
     src = fetchurl {
       url = "mirror://cpan/modules/by-module/ExtUtils/${name}.tar.gz";
-      sha256 = "06baf0nsmdkfk50p4x9kss4ncm8h49gkzy8hl5cxbxdsab65gmrb";
+      sha256 = "0kvbx66vncgk2c72994z31bgh2w3rsrlnx0z7cmxqa7w3hlc4741";
     };
+  };
+
+  # From CPAN[1]:
+  #   This module exists merely as a compatibility wrapper around
+  #   ExtUtils::Typemaps. In a nutshell, ExtUtils::Typemap was renamed to
+  #   ExtUtils::Typemaps because the Typemap directory in lib/ could collide with
+  #   the typemap file on case-insensitive file systems.
+  #
+  #   The ExtUtils::Typemaps module is part of the ExtUtils::ParseXS distribution
+  #   and ships with the standard library of perl starting with perl version
+  #   5.16.
+  #
+  # [1] http://search.cpan.org/~smueller/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap.pm:
+  ExtUtilsTypemap = buildPerlPackage rec {
+    name = "ExtUtils-Typemap-1.00";
+    src = fetchurl {
+      url = "mirror://cpan/modules/by-module/ExtUtils/${name}.tar.gz";
+      sha256 = "1iqz0xlscg655gnwb2h1wrjj70llblps1zznl29qn1mv5mvibc5i";
+    };
+    buildInputs = [ ExtUtilsParseXS ];
   };
 
   ExtUtilsTypemapsDefault = buildPerlModule rec {
@@ -2582,6 +2602,7 @@ rec {
       url = "mirror://cpan/modules/by-module/ExtUtils/${name}.tar.gz";
       sha256 = "0k03rr7bmhnn6j0505w9id5apss85yvqnx76hxf3javn3klj1m5z";
     };
+    propagatedBuildInputs = [ ExtUtilsTypemap ExtUtilsParseXS ];
   };
 
   ExtUtilsXSpp = buildPerlModule rec {


### PR DESCRIPTION
@the-kenny: I hope you don't mind that I post this pull request now that you have posted yours :-) I am just eager to get the slic3r branch merged. It feels like I've had it in my tree forever... well, according to git, since 28th of april.

I have
- bumped Slic3r to the latest 0.9.10b release (which according to the author works fine, even if the tests don't work[1])
- added desktop item
- cleaned up my branch so it's easy to review

Slic3r has issues with perl 5.16 (nixpkgs default), so I use perl 5.14. I have also made a commit that enables building of some modules against perl 5.10 (I tried to use perl 5.10 with slic3r for a while).

[1] https://github.com/alexrj/Slic3r/issues/1303
