### PR TITLE
qca2: Patch for gcc 4.7+.

### DIFF
--- a/pkgs/development/libraries/qca2/default.nix
+++ b/pkgs/development/libraries/qca2/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
               EMSA3_SHA512      ///< SHA512, with EMSA3 (ie PKCS#1 Version 1.5) encoding'
     '';
 
+  patches = [ ./gcc47.patch ];
+
   configureFlags = "--no-separate-debug-info";
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/qca2/gcc47.patch
+++ b/pkgs/development/libraries/qca2/gcc47.patch
@@ -1,0 +1,12 @@
+# Thanks to http://lists.pld-linux.org/mailman/pipermail/pld-cvs-commit/Week-of-Mon-20120917/347917.html
+--- qca-2.0.3/src/botantools/botan/botan/secmem.h.orig 2007-04-19 23:26:13.000000000 +0200
++++ qca-2.0.3/src/botantools/botan/botan/secmem.h  2012-09-16 23:28:43.767480490 +0200
+@@ -214,7 +214,7 @@
+ 
+       SecureVector(u32bit n = 0) { MemoryRegion<T>::init(true, n); }
+       SecureVector(const T in[], u32bit n)
+-         { MemoryRegion<T>::init(true); set(in, n); }
++         { MemoryRegion<T>::init(true); this->set(in, n); }
+       SecureVector(const MemoryRegion<T>& in)
+          { MemoryRegion<T>::init(true); set(in); }
+       SecureVector(const MemoryRegion<T>& in1, const MemoryRegion<T>& in2)


### PR DESCRIPTION
Thanks to
http://lists.pld-linux.org/mailman/pipermail/pld-cvs-commit/Week-of-Mon-20120917/347917.html

So far I have only tested that it compiles.

qca2 was failing to build with:

```
building big_ops2.o
g++ -c -m64 -pipe -O2 -Wall -W -D_REENTRANT -fPIC -DDATADIR=\"/nix/store/yf4ajdx96c8zfprrghqybl5chbnsc4ar-qca-2.0.3/share/qca\" -DQCA_SYSTEMSTORE_PATH=\"/nix/store/yf4ajdx96c8z
fprrghqybl5chbnsc4ar-qca-2.0.3/share/qca/certs/rootcerts.pem\" -DBOTAN_TYPES_QT -DBOTAN_TOOLS_ONLY -DBOTAN_FIX_GDB -DBOTAN_MINIMAL_BIGINT -DBOTAN_MP_WORD_BITS=32 -DBOTAN_KARAT_
MUL_THRESHOLD=12 -DBOTAN_KARAT_SQR_THRESHOLD=12 -DBOTAN_EXT_MUTEX_QT -DBOTAN_EXT_ALLOC_MMAP -DQT_NO_DEBUG -DQT_CORE_LIB -DQT_SHARED -I/nix/store/q20l3s8h2scx1kw2hg9y9136wrr8vbf
0-qt-4.8.4/share/qt-4.8.4/mkspecs/linux-g++-64 -I. -I/nix/store/q20l3s8h2scx1kw2hg9y9136wrr8vbf0-qt-4.8.4/include/QtCore -I/nix/store/q20l3s8h2scx1kw2hg9y9136wrr8vbf0-qt-4.8.4/
include -I../include/QtCrypto -I. -Ibotantools/botan -I. -o big_ops2.o botantools/botan/big_ops2.cpp
In file included from botantools/botan/botan/bigint.h:38:0,
                 from botantools/botan/big_ops2.cpp:34:
botantools/botan/botan/secmem.h: In instantiation of 'QCA::Botan::SecureVector<T>::SecureVector(const T*, QCA::Botan::u32bit) [with T = unsigned int; QCA::Botan::u32bit = unsig
ned int]':
botantools/botan/big_ops2.cpp:170:40:   required from here
botantools/botan/botan/secmem.h:217:50: error: 'set' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [
-fpermissive]
          { MemoryRegion<T>::init(true); set(in, n); }
                                                  ^
botantools/botan/botan/secmem.h:217:50: note: declarations in dependent base 'QCA::Botan::MemoryRegion<unsigned int>' are not found by unqualified lookup
botantools/botan/botan/secmem.h:217:50: note: use 'this->set' instead
make[1]: *** [big_ops2.o] Error 1
make[1]: Leaving directory `/tmp/nix-build-qca-2.0.3.drv-0/qca-2.0.3/src'
make: *** [sub-src-make_default] Error 2
builder for `/nix/store/snpr8qqn14sz2wsx5plvlflhc73vcm4f-qca-2.0.3.drv' failed with exit code 2
```
