### PR TITLE
sdcv: fix build on darwin

### DIFF
--- a/pkgs/applications/misc/sdcv/default.nix
+++ b/pkgs/applications/misc/sdcv/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     sed -i 's/guint32 page_size/size_t page_size/' src/lib/lib.cpp
   '';
 
-  NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__";
+  NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__"
+    + stdenv.lib.optionalString stdenv.isDarwin " -lintl";
 }
 


### PR DESCRIPTION
- add -lintl flag to NIX_CFLAGS_COMPILE

Fixes http://hydra.nixos.org/build/5516212
