### PR TITLE
php53: fix build on darwin

### DIFF
--- a/pkgs/development/interpreters/php-xdebug/default.nix
+++ b/pkgs/development/interpreters/php-xdebug/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     phpize
     ./configure --prefix=$out
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # looks for this file for some reason -- isn't needed
+    touch unix.h
   '';
 
   buildPhase = ''

--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -8,16 +8,22 @@ stdenv.mkDerivation {
     sha256 = "0a2a00hbakh0640r2wdpnwr8789z59wnk7rfsihh3j0vbhmmmqak";
   };
 
-  makeFlags = "lnp" # Linux with PAM modules
+  makeFlags = if stdenv.isDarwin
+    then "osx"
+    else "lnp" # Linux with PAM modules;
     # -fPIC is required to compile php with imap on x86_64 systems
     + stdenv.lib.optionalString stdenv.isx86_64 " EXTRACFLAGS=-fPIC";
 
-  buildInputs = [ pam openssl ];
+  buildInputs = [ openssl ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin) pam;
 
   patchPhase = ''
     sed -i -e s,/usr/local/ssl,${openssl}, \
       src/osdep/unix/Makefile
   '';
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin
+    "-I${openssl}/include/openssl";
 
   installPhase = ''
     mkdir -p $out/bin $out/lib $out/include


### PR DESCRIPTION
- add empty unix.h header
- build with kerberos
- ensure the binary has no extension

There were some strange things happening on another darwin system I have. These fixes mean the build will work on more versions of OS X.
