### PR TITLE
gtk2: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${cairo}/include/cairo"
     + stdenv.lib.optionalString (libintlOrEmpty != []) " -lintl";
 
+  buildInputs = stdenv.lib.optional stdenv.isDarwin xlibs.libXi;
+
   nativeBuildInputs = [ perl pkgconfig gettext ];
 
   propagatedBuildInputs = with xlibs; with stdenv.lib;


### PR DESCRIPTION
- add xlibs.libXi to build inputs
