### PR TITLE
libxcb: enable XKB extension

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -49,6 +49,7 @@ in
 
   libxcb = attrs : attrs // {
     nativeBuildInputs = [ args.python ];
+    configureFlags = "--enable-xkb";
   };
 
   xcbproto = attrs : attrs // {


### PR DESCRIPTION
SDDM, a display manager that I'm trying to package, depends on this.
I've rebuilt a minimal KDE system with this and I've not had any issues.

WARNING: This causes lots of rebuilds.
