### PR TITLE
strigi (needed for KDE): patch to compile on stdenv-updates

### DIFF
--- a/pkgs/development/libraries/strigi/default.nix
+++ b/pkgs/development/libraries/strigi/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
 
+  patches = [ ./export_bufferedstream.patch ];
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/development/libraries/strigi/export_bufferedstream.patch
+++ b/pkgs/development/libraries/strigi/export_bufferedstream.patch
@@ -1,0 +1,12 @@
+diff -u -r strigi-0.7.8/libstreams/include/strigi/bufferedstream.h strigi-0.7.8_new/libstreams/include/strigi/bufferedstream.h
+--- strigi-0.7.8/libstreams/include/strigi/bufferedstream.h	2013-02-05 13:34:57.000000000 -0800
++++ strigi-0.7.8_new/libstreams/include/strigi/bufferedstream.h	2013-07-14 17:01:54.000000000 -0700
+@@ -34,7 +34,7 @@
+  * BufferedStream will do the rest.
+  */
+ template <class T>
+-class BufferedStream : public StreamBase<T> {
++class STRIGI_EXPORT BufferedStream : public StreamBase<T> {
+ private:
+     StreamBuffer<T> buffer;
+     bool finishedWritingToBuffer;


### PR DESCRIPTION
This patch exports a class with STRIGI_EXPORT that wasn't exported
before.

This fixes the following build error.  I haven't tested the library, but at least it compiles now.

```
[ 66%] Building CXX object libstreamanalyzer/plugins/indexers/clucenengindexer/CMakeFiles/lucene2indexer.dir/luceneindexer.cpp.o
building libstreamanalyzer/plugins/indexers/clucenengindexer/lucene2indexer
Linking CXX executable lucene2indexer
../../../lib/libstreamanalyzer.so.0.7.8: undefined reference to `Strigi::BufferedStream<char>::reset(long)'
../../../lib/libstreamanalyzer.so.0.7.8: undefined reference to `Strigi::BufferedStream<char>::read(char const*&, int, int)'
collect2: error: ld returned 1 exit status
make[2]: *** [libstreamanalyzer/plugins/indexers/clucenengindexer/lucene2indexer] Error 1
make[1]: *** [libstreamanalyzer/plugins/indexers/clucenengindexer/CMakeFiles/lucene2indexer.dir/all] Error 2
make: *** [all] Error 2
builder for `/nix/store/d4lq1kfzjl68kzzk0867vydy9ds1acid-strigi-0.7.8.drv' failed with exit code 2
```

I am providing this patch to you under an open source license. Because I have done this work with my own personal resources, the license you receive to my code is from me and not from my employer (Facebook).
