### PR TITLE
cmake: Update to 2.8.11.2

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -7,7 +7,7 @@ with stdenv.lib;
 let
   os = stdenv.lib.optionalString;
   majorVersion = "2.8";
-  minorVersion = "9";
+  minorVersion = "11.2";
   version = "${majorVersion}.${minorVersion}";
 in
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}files/v${majorVersion}/cmake-${version}.tar.gz";
-    sha256 = "1yg68ng732cfm5c0h91chqwhg06zdh45bybm353kd1myk5rwqgfw";
+    sha256 = "0qh5dhd7ff08n2h569j7g9m92gb3bz14wvhwjhwl7lgx794cnamk";
   };
 
   patches =

--- a/pkgs/development/tools/build-managers/cmake/search-path.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path.patch
@@ -1,53 +1,54 @@
-diff -ru -x '*~' cmake-2.8.5-orig/Modules/Platform/Linux.cmake cmake-2.8.5/Modules/Platform/Linux.cmake
---- cmake-2.8.5-orig/Modules/Platform/Linux.cmake	2011-07-08 14:21:44.000000000 +0200
-+++ cmake-2.8.5/Modules/Platform/Linux.cmake	2011-07-21 19:45:00.000000000 +0200
-@@ -36,13 +36,13 @@
+diff -ru -x '*~' cmake-2.8.11.2-orig/Modules/Platform/Linux.cmake cmake-2.8.11.2/Modules/Platform/Linux.cmake
+--- cmake-2.8.11.2-orig/Modules/Platform/Linux.cmake	2013-07-02 15:41:40.000000000 +0200
++++ cmake-2.8.11.2/Modules/Platform/Linux.cmake	2013-07-15 11:43:30.557888066 +0200
+@@ -36,13 +36,8 @@
    # checking the platform every time.  This option is advanced enough
    # that only package maintainers should need to adjust it.  They are
    # capable of providing a setting on the command line.
--  IF(EXISTS "/etc/debian_version")
--    SET(CMAKE_INSTALL_SO_NO_EXE 1 CACHE INTERNAL
+-  if(EXISTS "/etc/debian_version")
+-    set(CMAKE_INSTALL_SO_NO_EXE 1 CACHE INTERNAL
 -      "Install .so files without execute permission.")
--  ELSE(EXISTS "/etc/debian_version")
-+  #IF(EXISTS "/etc/debian_version")
-+  #  SET(CMAKE_INSTALL_SO_NO_EXE 1 CACHE INTERNAL
-+  #    "Install .so files without execute permission.")
-+  #ELSE(EXISTS "/etc/debian_version")
-     SET(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL
-       "Install .so files without execute permission.")
--  ENDIF(EXISTS "/etc/debian_version")
-+  #ENDIF(EXISTS "/etc/debian_version")
- ENDIF(DEFINED CMAKE_INSTALL_SO_NO_EXE)
+-  else()
+-    set(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL
+-      "Install .so files without execute permission.")
+-  endif()
++  set(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL
++    "Install .so files without execute permission.")
+ endif()
  
  # Match multiarch library directory names.
-@@ -52,6 +52,6 @@
+@@ -50,8 +45,3 @@
  
- # Debian has lib64 paths only for compatibility so they should not be
- # searched.
--IF(EXISTS "/etc/debian_version")
--  SET_PROPERTY(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
--ENDIF(EXISTS "/etc/debian_version")
-+#IF(EXISTS "/etc/debian_version")
-+#  SET_PROPERTY(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
-+#ENDIF(EXISTS "/etc/debian_version")
-diff -ru -x '*~' cmake-2.8.5-orig/Modules/Platform/UnixPaths.cmake cmake-2.8.5/Modules/Platform/UnixPaths.cmake
---- cmake-2.8.5-orig/Modules/Platform/UnixPaths.cmake	2011-07-08 14:21:44.000000000 +0200
-+++ cmake-2.8.5/Modules/Platform/UnixPaths.cmake	2011-07-21 19:50:52.000000000 +0200
-@@ -33,55 +33,18 @@
+ include(Platform/UnixPaths)
+ 
+-# Debian has lib64 paths only for compatibility so they should not be
+-# searched.
+-if(EXISTS "/etc/debian_version")
+-  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
+-endif()
+diff -ru -x '*~' cmake-2.8.11.2-orig/Modules/Platform/UnixPaths.cmake cmake-2.8.11.2/Modules/Platform/UnixPaths.cmake
+--- cmake-2.8.11.2-orig/Modules/Platform/UnixPaths.cmake	2013-07-02 15:41:40.000000000 +0200
++++ cmake-2.8.11.2/Modules/Platform/UnixPaths.cmake	2013-07-15 11:42:02.949204549 +0200
+@@ -31,58 +31,13 @@
+ 
+ # List common installation prefixes.  These will be used for all
  # search types.
- LIST(APPEND CMAKE_SYSTEM_PREFIX_PATH
-   # Standard
+-list(APPEND CMAKE_SYSTEM_PREFIX_PATH
+-  # Standard
 -  /usr/local /usr /
--
++list(APPEND CMAKE_SYSTEM_PREFIX_PATH "@glibc@")
+ 
 -  # CMake install location
 -  "${_CMAKE_INSTALL_DIR}"
--
++list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "@glibc@/lib")
+ 
 -  # Project install destination.
 -  "${CMAKE_INSTALL_PREFIX}"
 -  )
--
++list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES "@glibc@/include")
+ 
 -# List common include file locations not under the common prefixes.
--LIST(APPEND CMAKE_SYSTEM_INCLUDE_PATH
+-list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
 -  # Windows API on Cygwin
 -  /usr/include/w32api
 -
@@ -56,11 +57,11 @@ diff -ru -x '*~' cmake-2.8.5-orig/Modules/Platform/UnixPaths.cmake cmake-2.8.5/M
 -
 -  # Other
 -  /usr/pkg/include
--  /opt/csw/include /opt/include  
+-  /opt/csw/include /opt/include
 -  /usr/openwin/include
 -  )
 -
--LIST(APPEND CMAKE_SYSTEM_LIBRARY_PATH
+-list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
 -  # Windows API on Cygwin
 -  /usr/lib/w32api
 -
@@ -69,27 +70,25 @@ diff -ru -x '*~' cmake-2.8.5-orig/Modules/Platform/UnixPaths.cmake cmake-2.8.5/M
 -
 -  # Other
 -  /usr/pkg/lib
--  /opt/csw/lib /opt/lib 
+-  /opt/csw/lib /opt/lib
 -  /usr/openwin/lib
 -  )
 -
--LIST(APPEND CMAKE_SYSTEM_PROGRAM_PATH
+-list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
 -  /usr/pkg/bin
-+  "@glibc@"
-   )
- 
- LIST(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+-  )
+-
+-list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 -  /lib /usr/lib /usr/lib32 /usr/lib64
-+  "@glibc@/lib"
-   )
- 
- LIST(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
+-  )
+-
+-list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  "@glibc@/include"
-   )
- LIST(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
+-  )
+-list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  "@glibc@/include"
-   )
+-  )
++list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES "@glibc@/include")
  
  # Enable use of lib64 search path variants by default.
+ set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)


### PR DESCRIPTION
The changelog is available at http://www.cmake.org/files/v2.8/CMakeChangeLog-2.8.11
