### PR TITLE
qemu: enable spice protocol support by default

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -2,7 +2,7 @@
 , attr, libcap, vde2, alsaLib, texinfo, libuuid
 , sdlSupport ? true, SDL
 , vncSupport ? true, libjpeg, libpng
-, spiceSupport ? false, spice, spice_protocol
+, spiceSupport ? true, spice, spice_protocol
 , x86Only ? false
 }:
 


### PR DESCRIPTION
We already enable VNC and SDL support by default and adding spice only
increases the closure size from 513 MB to 518 MB.

Closure size:
  du -sch $(nix-store -qR ./result)
