### PR TITLE
Add nvidia-smi tool and fix an embarrassing bug in a previous pull request of mine

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   preConfigure = ''
     cd tools/perf
     sed -i s,/usr/include/elfutils,$elfutils/include/elfutils, Makefile
-    -f bash_completion && sed -i 's,^have perf,_have perf,' bash_completion
+    [ -f bash_completion ] && sed -i 's,^have perf,_have perf,' bash_completion
     export makeFlags="DESTDIR=$out $makeFlags"
   '';
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -74,7 +74,7 @@ installPhase() {
         # Install the programs.
         mkdir -p $out/bin
 
-        for i in nvidia-settings nvidia-xconfig; do
+        for i in nvidia-settings nvidia-smi nvidia-xconfig; do
 	    cp $i $out/bin/$i
 	    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
 	        --set-rpath $out/lib:$programPath:$glPath $out/bin/$i


### PR DESCRIPTION
nvidia-smi is nice because it's command line. It's already in the tarball for ages, no idea why we never installed it. :)

Also, yes indeed in my previous perf fix I forgot that -f must be in [ ] and didn't test properly that it still works (it did still build, but that's just because bash ignores such errors).
