### PR TITLE
python: append paths from PYTHON<VERSION>PATH env var to sys.path

### DIFF
--- a/pkgs/development/python-modules/recursive-pth-loader/sitecustomize.py
+++ b/pkgs/development/python-modules/recursive-pth-loader/sitecustomize.py
@@ -1,5 +1,6 @@
 """Recursively load pth files in site-packages of sys.path
 
+- Append paths from PYTHON<VERSION>PATH environment variable to sys.path
 - iterate over sys.path
 - check for pth in dirs that end in site-packages
 - ignore import statements in pth files
@@ -11,6 +12,19 @@ import os
 import site
 import sys
 
+# Append paths from PYTHON<VERSION>PATH environment variable to sys.path. Use
+# of this (admittedly non-standard) variable enables a safer way to extend
+# Python interpreters with modules that are installed in a nix profile.
+#
+# Instead of the unsafe
+#   export PYTHONPATH=~/.nix-profile/lib/python2.7/site-packages
+# which probably breaks if you start python3, you can now
+#   export PYTHON27PATH=~/.nix-profile/lib/python2.7/site-packages
+#   export PYTHON33PATH=~/.nix-profile/lib/python3.3/site-packages
+# and there will be no interference between python2.7 and python3.3.
+pythonpath = os.getenv("PYTHON%d%dPATH" % (sys.version_info.major, sys.version_info.minor))
+if pythonpath:
+    sys.path.extend(pythonpath.split(os.pathsep))
 
 for path_idx, sitedir in enumerate(sys.path):
     # ignore non-site-packages


### PR DESCRIPTION
Every python interpreter that loads the recursive-pth-loader module will
now append paths to sys.path from PYTHON<VERSION>PATH environment
variable.

This means we can easily mix python2/3 environments and have modules
that are installed in a profile "activated" for the user by default. In
other words, python modules will be as easy to access from the python
shell as programs are to the (bash) shell.

For NixOS, the plan is to export PYTHON{26,27,32,33}PATH with
$PROFILE/lib/pythonVERSION/site-packages (for PROFILE in system_profile,
default_profile and user_profile, similarly as is done with PATH,
PERL5LIB and all other environment variables used to "activate" stuff
from profiles).
