### PR TITLE
Move namePrefix="" python packages out of python-packges.nix

### DIFF
--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "pylint-0.26.0";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "http://download.logilab.org/pub/pylint/${name}.tar.gz";
+    sha256 = "1mg1ywpj0klklv63s2hwn5xwxi3wfwgnyz9d4pz32hzb53azq835";
+  };
+
+  propagatedBuildInputs = [ pythonPackages.logilab_astng ];
+
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp "elisp/"*.el $out/share/emacs/site-lisp/
+  '';
+
+  meta = {
+    homepage = http://www.logilab.org/project/pylint;
+    description = "A bug and style checker for Python";
+  };
+}

--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -1,0 +1,13 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "rbtools-0.4.1";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "http://downloads.reviewboard.org/releases/RBTools/0.4/RBTools-0.4.1.tar.gz";
+    sha256 = "1v0r7rfzrasj56s53mib51wl056g7ykh2y1c6dwv12r6hzqsycgv";
+  };
+
+  propagatedBuildInputs = [ pythonPackages.setuptools ];
+}

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -34,9 +34,10 @@ stdenv.mkDerivation rec {
     ${python}/bin/${python.executable} setup.py test
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Utilities to facilitate the installation of Python packages";
     homepage = http://pypi.python.org/pypi/setuptools;
     licenses = [ "PSF" "ZPL" ];
+    platforms = platforms.all;
   };    
 }

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "awscli-${version}";
+  version = "0.8.3";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "https://github.com/aws/aws-cli/archive/${version}.tar.gz";
+    sha256 = "0v7igh00zja560v8qz315g3m7x9six1hprrrb10cpp9sy8n58xnn";
+  };
+
+  propagatedBuildInputs = [ 
+    pythonPackages.argparse
+    pythonPackages.botocore
+    pythonPackages.colorama
+  ];
+}

--- a/pkgs/tools/video/vnc2flv/default.nix
+++ b/pkgs/tools/video/vnc2flv/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "vnc2flv-20100207";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "http://pypi.python.org/packages/source/v/vnc2flv/${name}.tar.gz";
+    md5 = "8492e46496e187b49fe5569b5639804e";
+  };
+
+  # error: invalid command 'test'
+  doCheck = false;
+
+  meta = {
+    description = "Tool to record VNC sessions to Flash Video";
+    homepage = http://www.unixuser.org/~euske/python/vnc2flv/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -421,6 +421,8 @@ let
     };
   };
 
+  awscli = callPackage ../tools/admin/awscli { };
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };
@@ -1824,6 +1826,8 @@ let
   viking = callPackage ../applications/misc/viking {
     inherit (gnome) scrollkeeper;
   };
+
+  vnc2flv = callPackage ../tools/video/vnc2flv {};
 
   vncrec = builderDefsPackage ../tools/video/vncrec {
     inherit (xlibs) imake libX11 xproto gccmakedep libXt
@@ -5740,11 +5744,11 @@ let
 
   python3Packages = python33Packages;
 
-  python33Packages = import ./python-packages.nix {
+  python33Packages = recurseIntoAttrs (import ./python-packages.nix {
     inherit pkgs;
     inherit (lib) lowPrio;
     python = python33;
-  };
+  });
 
   python32Packages = import ./python-packages.nix {
     inherit pkgs;
@@ -5758,11 +5762,11 @@ let
     python = python27;
   });
 
-  pypyPackages = import ./python-packages.nix {
+  pypyPackages = recurseIntoAttrs (import ./python-packages.nix {
     inherit pkgs;
     inherit (lib) lowPrio;
     python = pypy;
-  };
+  });
 
   plone41Packages = import ../development/web/plone/4.1.nix {
     inherit pkgs;
@@ -5807,6 +5811,8 @@ let
 
   pyGtkGlade = pythonPackages.pyGtkGlade;
 
+  pylint = callPackage ../development/python-modules/pylint { };
+
   pyopenssl = builderDefsPackage (import ../development/python-modules/pyopenssl) {
     inherit python openssl;
   };
@@ -5830,6 +5836,8 @@ let
   pyx = callPackage ../development/python-modules/pyx { };
 
   pyxml = callPackage ../development/python-modules/pyxml { };
+
+  rbtools = callPackage ../development/python-modules/rbtools { };
 
   setuptools = pythonPackages.setuptools;
 
@@ -9308,7 +9316,8 @@ let
 
   spyder = callPackage ../applications/science/spyder {
     inherit (pythonPackages) pyflakes rope sphinx numpy scipy matplotlib; # recommended
-    inherit (pythonPackages) ipython pylint pep8; # optional
+    inherit (pythonPackages) ipython pep8; # optional
+    inherit pylint;
   };
 
   stellarium = callPackage ../applications/science/astronomy/stellarium { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -341,24 +341,6 @@ pythonPackages = modules // rec {
     };
   });
 
-
-  awscli = buildPythonPackage rec {
-    name = "awscli-0.8.3";
-    namePrefix = "";
-
-    src = fetchurl {
-      url = https://github.com/aws/aws-cli/archive/0.8.3.tar.gz;
-      sha256 = "0v7igh00zja560v8qz315g3m7x9six1hprrrb10cpp9sy8n58xnn";
-    };
-
-    propagatedBuildInputs =
-      [ pythonPackages.argparse
-        pythonPackages.botocore
-        pythonPackages.colorama
-      ];
-  };
-
-
   beautifulsoup = buildPythonPackage (rec {
     name = "beautifulsoup-3.2.1";
 
@@ -573,11 +555,12 @@ pythonPackages = modules // rec {
 
 
   botocore = buildPythonPackage rec {
-    name = "botocore-0.8.3";
+    version = "0.13.1";
+    name = "botocore-${version}";
 
     src = fetchurl {
-      url = https://github.com/boto/botocore/archive/0.8.3.tar.gz;
-      sha256 = "0dbm2clrh7zs4brqqj3xssz3nymdg24ff2lww27s3wliirwqdiv1";
+      url = "https://pypi.python.org/packages/source/b/botocore/${name}.tar.gz";
+      sha256 = "192kxgw76b22zmk5mxjkij5rskibb9jfaggvpznzy3ggsgja7yy8";
     };
 
     propagatedBuildInputs =
@@ -2294,11 +2277,11 @@ pythonPackages = modules // rec {
 
 
   jmespath = buildPythonPackage rec {
-    name = "jmespath-0.0.1";
+    name = "jmespath-0.0.2";
 
     src = fetchurl {
-      url = "https://github.com/boto/jmespath/archive/0.0.1.tar.gz";
-      sha256 = "1a5d62qbgfjbaw8wgkfh78gairnpy6bbdsygwm1prqwap1kyq6ch";
+      url = "https://github.com/boto/jmespath/archive/0.0.2.tar.gz";
+      sha256 = "0wr1gq3gdyn3n21pvj62csdm095512zxd10gkg5ai1vvxh0mbn3r";
     };
 
     propagatedBuildInputs = [ ply ];
@@ -4167,8 +4150,7 @@ pythonPackages = modules // rec {
   });
 
   ldap = buildPythonPackage rec {
-    name = "python-ldap-2.4.10";
-    namePrefix = "";
+    name = "ldap-2.4.10";
 
     src = fetchurl {
       url = "http://pypi.python.org/packages/source/p/python-ldap/${name}.tar.gz";
@@ -4199,29 +4181,6 @@ pythonPackages = modules // rec {
       license = stdenv.lib.licenses.lgpl21Plus;
     };
   });
-
-
-  pylint = buildPythonPackage rec {
-    name = "pylint-0.26.0";
-    namePrefix = "";
-
-    src = fetchurl {
-      url = "http://download.logilab.org/pub/pylint/${name}.tar.gz";
-      sha256 = "1mg1ywpj0klklv63s2hwn5xwxi3wfwgnyz9d4pz32hzb53azq835";
-    };
-
-    propagatedBuildInputs = [ logilab_astng ];
-
-    postInstall = ''
-      mkdir -p $out/share/emacs/site-lisp
-      cp "elisp/"*.el $out/share/emacs/site-lisp/
-    '';
-
-    meta = {
-      homepage = http://www.logilab.org/project/pylint;
-      description = "A bug and style checker for Python";
-    };
-  };
 
 
   pymacs = pkgs.stdenv.mkDerivation rec {
@@ -4512,19 +4471,6 @@ pythonPackages = modules // rec {
       license = "free"; # !?
     };
   });
-
-
-  RBTools = buildPythonPackage rec {
-    name = "rbtools-0.4.1";
-    namePrefix = "";
-
-    src = fetchurl {
-      url = "http://downloads.reviewboard.org/releases/RBTools/0.4/RBTools-0.4.1.tar.gz";
-      sha256 = "1v0r7rfzrasj56s53mib51wl056g7ykh2y1c6dwv12r6hzqsycgv";
-    };
-
-    propagatedBuildInputs = [ setuptools ];
-  };
 
 
   recaptcha_client = buildPythonPackage rec {
@@ -5442,24 +5388,6 @@ pythonPackages = modules // rec {
       homepage = http://www.virtualenv.org;
       license = licenses.mit;
       maintainers = [ maintainers.goibhniu ];
-    };
-  };
-
-  vnc2flv = buildPythonPackage rec {
-    name = "vnc2flv-20100207";
-    namePrefix = "";
-
-    src = fetchurl {
-      url = "http://pypi.python.org/packages/source/v/vnc2flv/${name}.tar.gz";
-      md5 = "8492e46496e187b49fe5569b5639804e";
-    };
-
-    # error: invalid command 'test'
-    doCheck = false;
-
-    meta = {
-      description = "Tool to record VNC sessions to Flash Video";
-      homepage = http://www.unixuser.org/~euske/python/vnc2flv/;
     };
   };
 


### PR DESCRIPTION
It doesn't make sense to build tools/applications with three different
python interpreter versions, so move them out of python modules list.

Also reverts 53ffc6e0ef395a2bd7651423d9783ad8184be1d0.
