### PR TITLE
fixed a patch which was rejected, i wonder why it was still there...

### DIFF
--- a/pkgs/desktops/kde-4.10/kdebindings/smokegen-nix.patch
+++ b/pkgs/desktops/kde-4.10/kdebindings/smokegen-nix.patch
@@ -1,46 +1,13 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 79945c4..a244d0f 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -32,10 +32,6 @@ set(generator_SRC
-     type.cpp
- )
+diff -urN smokegen-4.10.5.orig/cmake/SmokeConfig.cmake.in smokegen-4.10.5/cmake/SmokeConfig.cmake.in
+--- smokegen-4.10.5.orig/cmake/SmokeConfig.cmake.in	2013-06-28 17:14:50.000000000 +0000
++++ smokegen-4.10.5/cmake/SmokeConfig.cmake.in	2013-07-30 21:26:33.000000000 +0000
+@@ -80,8 +80,7 @@
+ set(SMOKE_API_BIN "@SMOKE_API_BIN@")
  
--# force RPATH so that the binary is usable from within the build tree
--set (CMAKE_SKIP_BUILD_RPATH FALSE)
--set (CMAKE_SKIP_RPATH FALSE)
--
- configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h @ONLY )
+ find_library(SMOKE_BASE_LIBRARY smokebase 
+-              PATHS "@SMOKE_LIBRARY_PREFIX@"
+-              NO_DEFAULT_PATH)
++              PATHS "@SMOKE_LIBRARY_PREFIX@")
  
- add_executable(smokegen ${generator_SRC})
-diff --git a/cmake/SmokeConfig.cmake.in b/cmake/SmokeConfig.cmake.in
-index 947315c..de8d66c 100644
---- a/cmake/SmokeConfig.cmake.in
-+++ b/cmake/SmokeConfig.cmake.in
-@@ -44,21 +44,19 @@ macro (find_smoke_component name)
-         set (SMOKE_${uppercase}_FOUND FALSE CACHE INTERNAL "")
- 
-         find_path(SMOKE_${uppercase}_INCLUDE_DIR 
--            ${lowercase}_smoke.h 
--            PATH ${SMOKE_INCLUDE_DIR}
--            NO_DEFAULT_PATH
-+            ${lowercase}_smoke.h
-+            HINTS ${SMOKE_INCLUDE_DIR}
-+            PATH_SUFFIXES smoke
-             )
-         if(WIN32)
- 		    # DLLs are in the bin directory.
-             find_library(SMOKE_${uppercase}_LIBRARY
-                 smoke${lowercase}
--                PATHS "@CMAKE_INSTALL_PREFIX@/bin"
--                NO_DEFAULT_PATH)
-+                PATHS "@CMAKE_INSTALL_PREFIX@/bin")
-         else(WIN32)
-             find_library(SMOKE_${uppercase}_LIBRARY
-                 smoke${lowercase}
--                PATHS "@SMOKE_LIBRARY_PREFIX@"
--                NO_DEFAULT_PATH)
-+                PATHS "@SMOKE_LIBRARY_PREFIX@")
-         endif(WIN32)
- 
-         if (NOT SMOKE_${uppercase}_INCLUDE_DIR OR NOT SMOKE_${uppercase}_LIBRARY)
+ if (NOT SMOKE_BASE_LIBRARY)
+     if (Smoke_FIND_REQUIRED)


### PR DESCRIPTION
could someone please review this modified patch? the former one was rejected and i don't know why, maybe a version bumb which didn't take the patch into account?

for me it fixed building of kde 4.10
## i had these problems(short version):

/nix/store/w8s1pfqnxfm9krzhxny0k5vsb1ilrypm-smokegen-4.10.5/bin/smokegen: error while loading shared libraries: libQtCore.so.4: cannot open shared object file: No such file or directory

long version:
# 
#   nixos-rebuild -I nixos=$NIXREPOS/nixos -I nixpkgs=$NIXREPOS/nixpkgs build

-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/nix-build-smokeqt-4.10.5.drv-1/smokeqt-4.10.5/build
building
make flags:  
building cmake_check_build_system
building all
building qtcore/CMakeFiles/smokeqtcore.dir/all
building qtcore/smokedata.cpp
[  0%] Generating smokedata.cpp, x_1.cpp, x_2.cpp, x_3.cpp, x_4.cpp, x_5.cpp, x_6.cpp, x_7.cpp, x_8.cpp, x_9.cpp, x_10.cpp, x_11.cpp, x_12.cpp, x_13.cpp, x_14.cpp, x_15.cpp, x_16.cpp, x_17.cpp, x_18.cpp, x_19.cpp, x_20.cpp
/nix/store/w8s1pfqnxfm9krzhxny0k5vsb1ilrypm-smokegen-4.10.5/bin/smokegen: error while loading shared libraries: libQtCore.so.4: cannot open shared object file: No such file or directory
make[2]: **\* [qtcore/smokedata.cpp] Error 127
make[1]: **\* [qtcore/CMakeFiles/smokeqtcore.dir/all] Error 2
make: **\* [all] Error 2
note: keeping build directory `/tmp/nix-build-smokeqt-4.10.5.drv-1'
builder for`/nix/store/4pr544gsy0g7hx682ka5anabrknrdqpz-smokeqt-4.10.5.drv' failed with exit code 2
cannot build derivation `/nix/store/64xq0x27awwcl4xhf97k7iy94bclqvmw-qtruby-4.10.5.drv': 1 dependencies couldn't be built
cannot build derivation`/nix/store/pk36c97cmrgiy5mpryv53n34l3v70gva-perlqt-4.10.5.drv': 1 dependencies couldn't be built
cannot build derivation `/nix/store/yv6sfrz6mdi2blcn7fhszx8yfih9bqih-smokekde-4.10.5.drv': 1 dependencies couldn't be built
# 
#  ldd smokegen

joachim@lenovo-t530 ~/Desktop/projects/nixos/nixpkgs (git)-[master] % ldd =smokegen
        linux-vdso.so.1 (0x00007fffe6bff000)
        libQtCore.so.4 => not found
        libQtXml.so.4 => not found
        libcppparser.so => not found
        libstdc++.so.6 => not found
        libm.so.6 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/libm.so.6 (0x00007f5d89cac000)
        libgcc_s.so.1 => not found
        libc.so.6 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/libc.so.6 (0x00007f5d898fc000)
        /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/ld-linux-x86-64.so.2 (0x00007f5d89faa000)
joachim@lenovo-t530 ~/Desktop/projects/nixos/nixpkgs (git)-[master] % which =smokegen
/home/joachim/.nix-profile/bin/smokegen
# 
#  ./nix-shell $NIXREPOS/nixpkgs  -A kde4.smokegen 

so when i build smokegen-4.10.5 i have this result:

┌─nix-shell - smokegen-4.10.5 - unpack patch configure build check install fixup installCheck dist
└──> /tmp/smokegen/smokegen-4.10.5/build % ldd bin/smokegen 
        linux-vdso.so.1 (0x00007fff943ff000)
        libQtCore.so.4 => /nix/store/dkahi0snc7818ik67y9gdsw1c7dszl3l-qt-4.8.4/lib/libQtCore.so.4 (0x00007fb8ca281000)
        libQtXml.so.4 => /nix/store/dkahi0snc7818ik67y9gdsw1c7dszl3l-qt-4.8.4/lib/libQtXml.so.4 (0x00007fb8ca03d000)
        libcppparser.so => /tmp/smokegen/smokegen-4.10.5/build/bin/libcppparser.so (0x00007fb8c9da1000)
        libstdc++.so.6 => /nix/store/r7jz82h8d9fpqvyphcxr1hrqfnsp7q8v-gcc-4.6.3/lib64/libstdc++.so.6 (0x00007fb8c9aa3000)
        libm.so.6 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/libm.so.6 (0x00007fb8c97a5000)
        libgcc_s.so.1 => /nix/store/r7jz82h8d9fpqvyphcxr1hrqfnsp7q8v-gcc-4.6.3/lib64/libgcc_s.so.1 (0x00007fb8c9590000)
        libc.so.6 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/libc.so.6 (0x00007fb8c91e0000)
        libpthread.so.0 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/libpthread.so.0 (0x00007fb8c8fc4000)
        libz.so.1 => /nix/store/xpv2mhi187yc02icqkiqx404ca418kfm-zlib-1.2.7/lib/libz.so.1 (0x00007fb8c8dae000)
        libdl.so.2 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/libdl.so.2 (0x00007fb8c8baa000)
        libgthread-2.0.so.0 => /nix/store/67d3nrvv939mrjmf3y5pb4x097hcxcp6-glib-2.36.1/lib/libgthread-2.0.so.0 (0x00007fb8c89a9000)
        libglib-2.0.so.0 => /nix/store/67d3nrvv939mrjmf3y5pb4x097hcxcp6-glib-2.36.1/lib/libglib-2.0.so.0 (0x00007fb8c86b0000)
        librt.so.1 => /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/librt.so.1 (0x00007fb8c84a8000)
        /nix/store/zm4bhsm8lprkzvrjgqr0klfkvr21als4-glibc-2.17/lib/ld-linux-x86-64.so.2 (0x00007fb8ca770000)
        libpcre.so.1 => /nix/store/3yjfyak4930rj08kbiwij6xnzwxlpix2-pcre-8.31/lib/libpcre.so.1 (0x00007fb8c826a000)
