### PR TITLE
Smokegen patch fix

### DIFF
--- a/pkgs/desktops/kde-4.10/kdebindings/smokegen-nix.patch
+++ b/pkgs/desktops/kde-4.10/kdebindings/smokegen-nix.patch
@@ -1,46 +1,13 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 79945c4..a244d0f 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -32,10 +32,6 @@ set(generator_SRC
-     type.cpp
- )
+diff -urN smokegen-4.10.5.orig/cmake/SmokeConfig.cmake.in smokegen-4.10.5/cmake/SmokeConfig.cmake.in
+--- smokegen-4.10.5.orig/cmake/SmokeConfig.cmake.in	2013-06-28 17:14:50.000000000 +0000
++++ smokegen-4.10.5/cmake/SmokeConfig.cmake.in	2013-07-30 21:26:33.000000000 +0000
+@@ -80,8 +80,7 @@
+ set(SMOKE_API_BIN "@SMOKE_API_BIN@")
  
--# force RPATH so that the binary is usable from within the build tree
--set (CMAKE_SKIP_BUILD_RPATH FALSE)
--set (CMAKE_SKIP_RPATH FALSE)
--
- configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h @ONLY )
+ find_library(SMOKE_BASE_LIBRARY smokebase 
+-              PATHS "@SMOKE_LIBRARY_PREFIX@"
+-              NO_DEFAULT_PATH)
++              PATHS "@SMOKE_LIBRARY_PREFIX@")
  
- add_executable(smokegen ${generator_SRC})
-diff --git a/cmake/SmokeConfig.cmake.in b/cmake/SmokeConfig.cmake.in
-index 947315c..de8d66c 100644
---- a/cmake/SmokeConfig.cmake.in
-+++ b/cmake/SmokeConfig.cmake.in
-@@ -44,21 +44,19 @@ macro (find_smoke_component name)
-         set (SMOKE_${uppercase}_FOUND FALSE CACHE INTERNAL "")
- 
-         find_path(SMOKE_${uppercase}_INCLUDE_DIR 
--            ${lowercase}_smoke.h 
--            PATH ${SMOKE_INCLUDE_DIR}
--            NO_DEFAULT_PATH
-+            ${lowercase}_smoke.h
-+            HINTS ${SMOKE_INCLUDE_DIR}
-+            PATH_SUFFIXES smoke
-             )
-         if(WIN32)
- 		    # DLLs are in the bin directory.
-             find_library(SMOKE_${uppercase}_LIBRARY
-                 smoke${lowercase}
--                PATHS "@CMAKE_INSTALL_PREFIX@/bin"
--                NO_DEFAULT_PATH)
-+                PATHS "@CMAKE_INSTALL_PREFIX@/bin")
-         else(WIN32)
-             find_library(SMOKE_${uppercase}_LIBRARY
-                 smoke${lowercase}
--                PATHS "@SMOKE_LIBRARY_PREFIX@"
--                NO_DEFAULT_PATH)
-+                PATHS "@SMOKE_LIBRARY_PREFIX@")
-         endif(WIN32)
- 
-         if (NOT SMOKE_${uppercase}_INCLUDE_DIR OR NOT SMOKE_${uppercase}_LIBRARY)
+ if (NOT SMOKE_BASE_LIBRARY)
+     if (Smoke_FIND_REQUIRED)

--- a/pkgs/desktops/kde-4.10/kdebindings/smokegen-nix.patch
+++ b/pkgs/desktops/kde-4.10/kdebindings/smokegen-nix.patch
@@ -1,13 +1,14 @@
-diff -urN smokegen-4.10.5.orig/cmake/SmokeConfig.cmake.in smokegen-4.10.5/cmake/SmokeConfig.cmake.in
---- smokegen-4.10.5.orig/cmake/SmokeConfig.cmake.in	2013-06-28 17:14:50.000000000 +0000
-+++ smokegen-4.10.5/cmake/SmokeConfig.cmake.in	2013-07-30 21:26:33.000000000 +0000
-@@ -80,8 +80,7 @@
- set(SMOKE_API_BIN "@SMOKE_API_BIN@")
- 
- find_library(SMOKE_BASE_LIBRARY smokebase 
--              PATHS "@SMOKE_LIBRARY_PREFIX@"
--              NO_DEFAULT_PATH)
-+              PATHS "@SMOKE_LIBRARY_PREFIX@")
- 
- if (NOT SMOKE_BASE_LIBRARY)
-     if (Smoke_FIND_REQUIRED)
+mokegen-4.10.5.orig/CMakeLists.txt 2013-06-28 17:14:50.000000000 +0000
++++ smokegen-4.10.5/CMakeLists.txt      2013-07-31 19:15:17.000000000 +0000
+@@ -36,6 +36,10 @@
+ set (CMAKE_SKIP_BUILD_RPATH FALSE)
+ set (CMAKE_SKIP_RPATH FALSE)
+
++# add the automatically determined parts of the RPATH
++# which point to directories outside the build tree to the install RPATH
++SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++
+ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h @ONLY )
+
+ add_executable(smokegen ${generator_SRC})
+


### PR DESCRIPTION
using 

+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

makes smokegen work after installation. previously smokegen was working in nix-shell but not after installation. now it does ;-)
