### PR TITLE
Export ghci config files for ghc-vis and ghc-heap-view

### DIFF
--- a/pkgs/development/compilers/ghc/with-packages.nix
+++ b/pkgs/development/compilers/ghc/with-packages.nix
@@ -76,6 +76,11 @@ stdenv.mkDerivation rec {
           ln -s $f $out/share/emacs/site-lisp/
           echo -n .
         done
+        for f in "$currentPath/share/ghci/"*; do
+          mkdir -p $out/share/ghci
+          ln -s $f $out/share/ghci/
+          echo -n .
+        done
         for f in "$currentPkgDir/"*.conf; do
           ln -s $f $linkedPkgDir
           echo -n .

--- a/pkgs/development/libraries/haskell/ghc-heap-view/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-heap-view/default.nix
@@ -5,6 +5,10 @@ cabal.mkDerivation (self: {
   version = "0.5.1";
   sha256 = "1qi7f3phj2j63x1wd2cvk36945cxd84s12zs03hlrn49wzx2pf1n";
   buildDepends = [ binary transformers ];
+  postInstall = ''
+      ensureDir "$out/share/ghci"
+      ln -s "$out/share/$pname-$version/ghci" "$out/share/ghci/$pname"
+    '';
   meta = {
     description = "Extract the heap representation of Haskell values and thunks";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/haskell/ghc-vis/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-vis/default.nix
@@ -10,6 +10,10 @@ cabal.mkDerivation (self: {
     cairo deepseq fgl ghcHeapView graphviz gtk mtl svgcairo text
     transformers xdot
   ];
+  postInstall = ''
+      ensureDir "$out/share/ghci"
+      ln -s "$out/share/$pname-$version/ghci" "$out/share/ghci/$pname"
+    '';
   meta = {
     homepage = "http://felsin9.de/nnis/ghc-vis";
     description = "Live visualization of data structures in GHCi";


### PR DESCRIPTION
So the user has an easy path (through his user profile) to refer to these config files.
