### PR TITLE
Disable tests in Elm

### DIFF
--- a/pkgs/development/compilers/elm/elm.nix
+++ b/pkgs/development/compilers/elm/elm.nix
@@ -3,6 +3,7 @@
 }:
 
 cabal.mkDerivation (self: {
+  doCheck = false;
   pname = "Elm";
   version = "0.9.0.1";
   sha256 = "0p6sqfrf11xpgj7y81hsjbvsyyyfvc4nzcg6gmfwyqkg3qc3yg6v";


### PR DESCRIPTION
Elm does not serve any tests besides a test that always fails. Additionally, even calling this fails since no executable is created.

The relevant lines from the build log are:

> Building Elm-0.9.0.1...
> Preprocessing test suite 'test-elm' for Elm-0.9.0.1...
> [1 of 1] Compiling Everything       ( tests/Everything.hs, dist/build/test-elm/test-elm-tmp/Everything.o )
> Warning: output was redirected with -o, but no output will be generated
> because there is no Main module.
> 
> running tests
> Running 1 test suites...
> Setup: Error: Could not find test program "dist/build/test-elm/test-elm". Did
> you build the package first?
> builder for `/nix/store/m01c1jnyi5098fb1v7ag5pjv6y0nmrpy-haskell-Elm-ghc7.6.3-0.9.0.1.drv' failed with exit code 1
> error: build of`/nix/store/m01c1jnyi5098fb1v7ag5pjv6y0nmrpy-haskell-Elm-ghc7.6.3-0.9.0.1.drv' failed
