### PR TITLE
Update leiningen to 2.3.1.

### DIFF
--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "leiningen";
-  version = "2.3.0";
+  version = "2.3.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://raw.github.com/technomancy/leiningen/${version}/bin/lein-pkg";
-    sha256 = "18rk1rr9il5jc3103cnmii6hyc1j3k12d975sqrcqyg97h7f0jkb";
+    sha256 = "07z4sr4ssi9lqr1kydxn4gp992n44jsr6llarlvpx0ns8yi4gx0l";
   };
 
   jarsrc = fetchurl {
     url = "https://leiningen.s3.amazonaws.com/downloads/${pname}-${version}-standalone.jar";
-    sha256 = "04xmnw80f39qs2vfm5ic8bmhks1fvasiwg4snckg2zhfjkhzms05";
+    sha256 = "00hmxyvrzxjwa2qz3flnrvg2k2llzvprk9b5szyrh3rv5z5jd4hw";
   };
 
   patches = ./lein_2.3.0.patch;
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ jdk clojure ];
 
   meta = {
-    homepage = https://github.com/technomancy/leiningen;
+    homepage = http://leiningen.org/;
     description = "Project automation for Clojure";
     license = "EPL";
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
2.3.0 included an annoying bug affecting uberjars (jars with all dependencies packaged).
