### PR TITLE
Add emacs24-nox: emacs built without X (or GTK) libraries.

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -2,9 +2,9 @@
 , pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
 , alsaLib
+, buildWithX ? true
 }:
 
-assert (gtk != null) -> (pkgconfig != null);
 assert (libXft != null) -> libpng != null;	# probably a bug
 assert stdenv.isDarwin -> libXaw != null;	# fails to link otherwise
 
@@ -19,14 +19,16 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ ncurses x11 texinfo libXaw Xaw3d libXpm libpng libjpeg libungif
-      libtiff librsvg libXft gconf libxml2 imagemagick gnutls alsaLib
-    ]
-    ++ stdenv.lib.optionals (gtk != null) [ gtk pkgconfig ]
-    ++ stdenv.lib.optional stdenv.isLinux dbus;
+    [ ncurses gconf libxml2 gnutls pkgconfig texinfo ]
+    ++ stdenv.lib.optional stdenv.isLinux dbus
+    ++ stdenv.lib.optionals buildWithX [
+         x11 libXaw Xaw3d libXpm libpng libjpeg libungif
+         libtiff librsvg libXft imagemagick
+       ]
+    ++ stdenv.lib.optional (gtk != null) gtk;
 
   configureFlags =
-    stdenv.lib.optionals (gtk != null) [ "--with-x-toolkit=gtk" "--with-xft"]
+    stdenv.lib.optionals (gtk != null) [ "--with-x-toolkit=gtk" "--with-xft" ]
 
     # On NixOS, help Emacs find `crt*.o'.
     ++ stdenv.lib.optional (stdenv ? glibc)
@@ -67,7 +69,7 @@ EOF
     homepage = "http://www.gnu.org/software/emacs/";
     license = "GPLv3+";
 
-    maintainers = with maintainers; [ chaoflow lovek323 ludo simons ];
+    maintainers = with maintainers; [ chaoflow lovek323 ludo simons the-kenny ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -23,12 +23,11 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isLinux dbus
     ++ stdenv.lib.optionals buildWithX [
          x11 libXaw Xaw3d libXpm libpng libjpeg libungif
-         libtiff librsvg libXft imagemagick
-       ]
-    ++ stdenv.lib.optional (gtk != null) gtk;
+         libtiff librsvg libXft imagemagick gtk
+       ];
 
   configureFlags =
-    stdenv.lib.optionals (gtk != null) [ "--with-x-toolkit=gtk" "--with-xft" ]
+    stdenv.lib.optionals buildWithX [ "--with-x-toolkit=gtk" "--with-xft" ]
 
     # On NixOS, help Emacs find `crt*.o'.
     ++ stdenv.lib.optional (stdenv ? glibc)

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ ncurses gconf libxml2 gnutls pkgconfig texinfo ]
+    [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo ]
     ++ stdenv.lib.optional stdenv.isLinux dbus
     ++ stdenv.lib.optionals buildWithX [
          x11 libXaw Xaw3d libXpm libpng libjpeg libungif

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7347,6 +7347,11 @@ let
       else stdenv;
   };
 
+  emacs24-nox = (appendToName "nox" (emacs24.override {
+    buildWithX = false;
+    gtk = null;
+  }));
+
   emacsPackages = emacs: self: let callPackage = newScope self; in rec {
     inherit emacs;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7349,7 +7349,6 @@ let
 
   emacs24-nox = (appendToName "nox" (emacs24.override {
     buildWithX = false;
-    gtk = null;
   }));
 
   emacsPackages = emacs: self: let callPackage = newScope self; in rec {


### PR DESCRIPTION
This commit also fixes an issue where pkgconfig was only added as a
dependency when gtk support was enabled. This made ./configure unable
to find other libraries (libtiff, libxml2, gnutls, and others).
