### PR TITLE
gobjectIntrospection: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -46,12 +46,7 @@ stdenv.mkDerivation rec {
   preConfigure = "autoreconf -fi";
   configureFlags = "--with-pcre=system --disable-fam";
 
-  postConfigure =
-    optionalString stdenv.isDarwin (''
-      sed '24 i #include <Foundation/Foundation.h>'
-    '' + /* Disable the NeXTstep back-end because stdenv.gcc doesn't support Objective-C. */ ''
-      sed -i configure -e's/glib_have_cocoa=yes/glib_have_cocoa=no/g'
-    '');
+  postConfigure = "sed '/SANE_MALLOC_PROTOS/s,^,//,' -i config.h";
 
   NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin "-lintl";
 


### PR DESCRIPTION
As far as I can tell, d374527509657cfeb8499118b26e7605fab8f4d2 re-introduced some old changes made when building on darwin that are no longer needed.
