### PR TITLE
Re-implement python-wrapper with buildEnv.

### DIFF
--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -1,23 +1,23 @@
-# Create a python that knows about additional python packages via
-# PYTHONPATH
+{ stdenv, python, buildEnv, makeWrapper, recursivePthLoader, extraLibs ? [] }:
 
-{ stdenv, python, makeWrapper, recursivePthLoader, extraLibs ? [] }:
+# Create a python executable that knows about additional packages.
 
-stdenv.mkDerivation {
+(buildEnv {
   name = "python-${python.version}-wrapper";
+  paths = extraLibs ++ [ python makeWrapper recursivePthLoader ];
+  ignoreCollisions = false;
 
-  propagatedBuildInputs = extraLibs ++ [ python makeWrapper recursivePthLoader ];
-
-  unpackPhase = "true";
-  installPhase = ''
+  postBuild = ''
+    . "${makeWrapper}/nix-support/setup-hook"
     mkdir -p "$out/bin"
-    for prg in 2to3 idle pdb pdb${python.majorVersion} pydoc python python-config python${python.majorVersion} python${python.majorVersion}-config smtpd.py; do
-      makeWrapper "$python/bin/$prg" "$out/bin/$prg" --suffix PYTHONPATH : "$PYTHONPATH"
+    cd "${python}/bin"
+    for prg in *; do
+      echo "$prg --> $out/bin/$prg"
+      rm -f "$out/bin/$prg"
+      makeWrapper "${python}/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out"
     done
-    ensureDir "$out/share"
-    ln -s "$python/share/man" "$out/share/man"
   '';
-
+}) // {
   inherit python;
   inherit (python) meta;
 }


### PR DESCRIPTION
The new wrapper creates an environment that contains all files from
Python and the extra libraries that have been specified. All files are
found at run-time by means of the $PYTHONHOME variable; the wrapper no
longer uses $PYTHONPATH.
