### PR TITLE
Update inotool and fix `ino upload'.

### DIFF
--- a/pkgs/development/arduino/ino/default.nix
+++ b/pkgs/development/arduino/ino/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, buildPythonPackage, pythonPackages, minicom
 , avrdude, arduino_core, avrgcclibc }:
 
-buildPythonPackage {
-  name = "ino-0.3.4";
+buildPythonPackage rec {
+  name = "ino-0.3.5";
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://pypi.python.org/packages/source/i/ino/ino-0.3.4.tar.gz";
+    url = "http://pypi.python.org/packages/source/i/ino/${name}.tar.gz";
     sha256 = "1v7z3da31cv212k28aci269qkg92p377fm7i76rymjjpjra7payv";
   };
 
@@ -23,12 +23,17 @@ buildPythonPackage {
         requirements.txt
     sed -i -e 's@from ordereddict@from collections@' \
         ino/environment.py ino/utils.py
+
+    # Patch the upload command so it uses the correct avrdude
+    substituteInPlace ino/commands/upload.py \
+      --replace "self.e['avrdude']" "'${avrdude}/bin/avrdude'" \
+      --replace "'-C', self.e['avrdude.conf']," ""
   '';
  
   meta = {
     description = "Command line toolkit for working with Arduino hardware";
     homepage = http://inotool.org/;
-    license = "MIT";
-    maintainers = [ stdenv.lib.maintainers.antono ];
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ antono the-kenny ];
   };
 }


### PR DESCRIPTION
0.3.5 is just a patch-release (no code changes). More important is the
patch to the upload-command. It now uses the nix-supplied avrdude
instead of some random avrdude it finds (in the arduino distribution
or wherever).
