### PR TITLE
libav: major update and refactoring

### DIFF
--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -1,72 +1,112 @@
-{ stdenv, fetchurl, pkgconfig, yasm, xz
-, mp3Support ? true, lame ? null
-, speexSupport ? true, speex ? null
-, theoraSupport ? true, libtheora ? null
-, vorbisSupport ? true, libvorbis ? null
-, vpxSupport ? false, libvpx ? null
-, x264Support ? false, x264 ? null
-, xvidSupport ? true, xvidcore ? null
-, faacSupport ? false, faac ? null
+{ stdenv, fetchurl, pkgconfig, yasm, bzip2, zlib
+, mp3Support    ? true,   lame      ? null
+, speexSupport  ? true,   speex     ? null
+, theoraSupport ? true,   libtheora ? null
+, vorbisSupport ? true,   libvorbis ? null
+, vpxSupport    ? true,   libvpx    ? null
+, x264Support   ? false,  x264      ? null
+, xvidSupport   ? true,   xvidcore  ? null
+, faacSupport   ? false,  faac      ? null
+, vaapiSupport  ? false,  libva     ? null # ToDo: it has huge closure
+, vdpauSupport  ? true,   libvdpau  ? null
+, freetypeSupport ? true, freetype  ? null # it's small and almost everywhere
+, SDL # only for avplay in $tools, adds nontrivial closure to it
+, enableGPL ? true # ToDo: some additional default stuff may need GPL
+, enableUnfree ? faacSupport
 }:
 
-assert speexSupport -> speex != null;
-assert theoraSupport -> libtheora != null;
-assert vorbisSupport -> libvorbis != null;
-assert vpxSupport -> libvpx != null;
-assert x264Support -> x264 != null;
-assert xvidSupport -> xvidcore != null;
+assert faacSupport -> enableUnfree;
 
-stdenv.mkDerivation rec {
-  name = "libav-0.7";
-  
-  src = fetchurl {
-    url = "http://libav.org/releases/${name}.tar.xz";
-    sha256 = "04pl6y53xh6xmwzz0f12mg5vh62ylp5zwwinj6dxzd8pnbjg4lsz";
+with { inherit (stdenv.lib) optional optionals; };
+
+/* ToDo:
+    - more deps, inspiration: http://packages.ubuntu.com/raring/libav-tools
+    - maybe do some more splitting into outputs
+*/
+
+let
+  result = {
+    libav_9   = libavFun   "9.8" "0r7hg9wg3cxjsmwzpa6f2p1a092g2iazyjjy23604ccskzbnirg3";
+    libav_0_8 = libavFun "0.8.8" "1wnbmbs0z4f55y8r9bwb63l04zn383l1avy4c9x1ffb2xccgcp79";
   };
 
-  # `--enable-gpl' (as well as the `postproc' and `swscale') mean that
-  # the resulting library is GPL'ed, so it can only be used in GPL'ed
-  # applications.
-  configureFlags = [
-    "--enable-gpl"
-    "--enable-postproc"
-    "--enable-swscale"
-    "--disable-ffserver"
-    "--disable-ffplay"
-    "--enable-shared"
-    "--enable-runtime-cpudetect"
-  ]
-    ++ stdenv.lib.optional mp3Support "--enable-libmp3lame"
-    ++ stdenv.lib.optional speexSupport "--enable-libspeex"
-    ++ stdenv.lib.optional theoraSupport "--enable-libtheora"
-    ++ stdenv.lib.optional vorbisSupport "--enable-libvorbis"
-    ++ stdenv.lib.optional vpxSupport "--enable-libvpx"
-    ++ stdenv.lib.optional x264Support "--enable-libx264"
-    ++ stdenv.lib.optional xvidSupport "--enable-libxvid"
-    ++ stdenv.lib.optional faacSupport "--enable-libfaac --enable-nonfree";
+  libavFun = version : sha256 : stdenv.mkDerivation rec {
+    name = "libav-${version}";
 
-  buildInputs = [ pkgconfig lame yasm ]
-    ++ stdenv.lib.optional mp3Support lame
-    ++ stdenv.lib.optional speexSupport speex
-    ++ stdenv.lib.optional theoraSupport libtheora
-    ++ stdenv.lib.optional vorbisSupport libvorbis
-    ++ stdenv.lib.optional vpxSupport libvpx
-    ++ stdenv.lib.optional x264Support x264
-    ++ stdenv.lib.optional xvidSupport xvidcore
-    ++ stdenv.lib.optional faacSupport faac;
+    src = fetchurl {
+      url = "http://libav.org/releases/${name}.tar.xz";
+      inherit sha256;
+    };
+    configureFlags =
+      assert stdenv.lib.all (x: x!=null) buildInputs;
+    [
+      #"--enable-postproc" # it's now a separate package in upstream
+      "--disable-avserver" # upstream says it's in a bad state
+      "--enable-avplay"
+      "--enable-shared"
+      "--enable-runtime-cpudetect"
+    ]
+      ++ optionals enableGPL [ "--enable-gpl" "--enable-swscale" ]
+      ++ optional mp3Support "--enable-libmp3lame"
+      ++ optional speexSupport "--enable-libspeex"
+      ++ optional theoraSupport "--enable-libtheora"
+      ++ optional vorbisSupport "--enable-libvorbis"
+      ++ optional vpxSupport "--enable-libvpx"
+      ++ optional x264Support "--enable-libx264"
+      ++ optional xvidSupport "--enable-libxvid"
+      ++ optional faacSupport "--enable-libfaac --enable-nonfree"
+      ++ optional vaapiSupport "--enable-vaapi"
+      ++ optional vdpauSupport "--enable-vdpau"
+      ++ optional freetypeSupport "--enable-libfreetype"
+      ;
 
-  crossAttrs = {
-    dontSetConfigureCross = true;
-    configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cross.config}-"
-      "--enable-cross-compile"
-      "--target_os=linux"
-      "--arch=${stdenv.cross.arch}"
-      ];
-  };
+    buildInputs = [ pkgconfig lame yasm zlib bzip2 SDL ]
+      ++ optional mp3Support lame
+      ++ optional speexSupport speex
+      ++ optional theoraSupport libtheora
+      ++ optional vorbisSupport libvorbis
+      ++ optional vpxSupport libvpx
+      ++ optional x264Support x264
+      ++ optional xvidSupport xvidcore
+      ++ optional faacSupport faac
+      ++ optional vaapiSupport libva
+      ++ optional vdpauSupport libvdpau
+      ++ optional freetypeSupport freetype
+      ;
 
-  meta = {
-    homepage = http://libav.org/;
-    description = "A complete, cross-platform solution to record, convert and stream audio and video (fork of ffmpeg)";
-  };
-}
+    enableParallelBuilding = true;
+
+    outputs = [ "out" "tools" ];
+
+    postInstall = ''
+      mkdir -p "$tools/bin"
+      mv "$out/bin/avplay" "$tools/bin"
+      cp -s "$out"/bin/* "$tools/bin/"
+    '';
+
+    doInstallCheck = true;
+    installCheckTarget = "check"; # tests need to be run *after* installation
+
+    crossAttrs = {
+      dontSetConfigureCross = true;
+      configureFlags = configureFlags ++ [
+        "--cross-prefix=${stdenv.cross.config}-"
+        "--enable-cross-compile"
+        "--target_os=linux"
+        "--arch=${stdenv.cross.arch}"
+        ];
+    };
+
+    passthru = { inherit vdpauSupport; };
+
+    meta = with stdenv.lib; {
+      homepage = http://libav.org/;
+      description = "A complete, cross-platform solution to record, convert and stream audio and video (fork of ffmpeg)";
+      license = with licenses; if enableUnfree then unfree #ToDo: redistributable or not?
+        else if enableGPL then gpl2Plus else lgpl21Plus;
+      platforms = platforms.all;
+    };
+  }; # libavFun
+
+in result
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4473,7 +4473,9 @@ let
 
   libassuan2_1 = callPackage ../development/libraries/libassuan/git.nix { };
 
-  libav = callPackage ../development/libraries/libav { };
+  libav = libav_9;
+  libav_all = callPackage ../development/libraries/libav { };
+  inherit (libav_all) libav_9 libav_0_8;
 
   libavc1394 = callPackage ../development/libraries/libavc1394 { };
 


### PR DESCRIPTION
Also leaving 0_8 branch, as it's compatible with older ffmpeg versions.
I'm planning that all expressions will be able to switch easily
between ffmpeg and libav (whatever default we choose, but I prefer libav).

Edited according to notes on the reverted b00313.
