### PR TITLE
LLVM plugin for ld.gold support

### DIFF
--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, perl, groff, cmake, python, libffi }:
+{ stdenv, fetchurl, perl, groff, cmake, python, libffi, binutils_gold }:
 
 let version = "3.2"; in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "llvm-${version}";
 
   src = fetchurl {
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
                then "export DYLD_LIBRARY_PATH='$DYLD_LIBRARY_PATH:'`pwd`/lib"
                else "export LD_LIBRARY_PATH='$LD_LIBRARY_PATH:'`pwd`/lib" );
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DLLVM_BINUTILS_INCDIR=${binutils_gold}/include" ]
     ++ stdenv.lib.optional (!stdenv.isDarwin) [ "-DBUILD_SHARED_LIBS=ON" ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       + stdenv.lib.optionalString (stdenv.system == "mips64el-linux")
         " --enable-fix-loongson2f-nop"
       + stdenv.lib.optionalString (cross != null) " --target=${cross.config}"
-      + stdenv.lib.optionalString gold " --enable-gold"
+      + stdenv.lib.optionalString gold " --enable-gold --enable-plugins"
       + stdenv.lib.optionalString deterministic " --enable-deterministic-archives";
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Enable plug-in support in binutils_gold and enable building of gold plug-in in LLVM. This allows ld.gold to link LLVM IL. (Not my patches but still I believe this is important feature)
