### PR TITLE
cmake: Update to 2.8.11.2 + Fix CTest custom commands

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/762-13887.patch
+++ b/pkgs/development/tools/build-managers/cmake/762-13887.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/CTest/cmCTestTestHandler.cxx b/Source/CTest/cmCTestTestHandler.cxx
+index e7491bb..57b4348 100644
+--- a/Source/CTest/cmCTestTestHandler.cxx
++++ b/Source/CTest/cmCTestTestHandler.cxx
+@@ -1303,10 +1303,9 @@ int cmCTestTestHandler::ExecuteCommands(std::vector<cmStdString>& vec)
+   for ( it = vec.begin(); it != vec.end(); ++it )
+     {
+     int retVal = 0;
+-    std::string cmd = cmSystemTools::ConvertToOutputPath(it->c_str());
+-    cmCTestLog(this->CTest, HANDLER_VERBOSE_OUTPUT, "Run command: " << cmd
++    cmCTestLog(this->CTest, HANDLER_VERBOSE_OUTPUT, "Run command: " << *it
+       << std::endl);
+-    if ( !cmSystemTools::RunSingleCommand(cmd.c_str(), 0, &retVal, 0,
++    if ( !cmSystemTools::RunSingleCommand((*it).c_str(), 0, &retVal, 0,
+                                           cmSystemTools::OUTPUT_MERGE
+         /*this->Verbose*/) || retVal != 0 )
+       {

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -7,7 +7,7 @@ with stdenv.lib;
 let
   os = stdenv.lib.optionalString;
   majorVersion = "2.8";
-  minorVersion = "11";
+  minorVersion = "11.2";
   version = "${majorVersion}.${minorVersion}";
 in
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}files/v${majorVersion}/cmake-${version}.tar.gz";
-    sha256 = "1rgfgzigmc0b2z5330r3ncf003k4bhqwfxbskv0q5ylp2xkd7l10";
+    sha256 = "0qh5dhd7ff08n2h569j7g9m92gb3bz14wvhwjhwl7lgx794cnamk";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -24,9 +24,13 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patches =
+    # See https://github.com/NixOS/nixpkgs/issues/762
+    # and http://public.kitware.com/Bug/view.php?id=13887
+    # Remove this patch when a CMake release contains the corresponding fix
+    [ ./762-13887.patch ]
     # Don't search in non-Nix locations such as /usr, but do search in
-    # Nixpkgs' Glibc.
-    optional (stdenv ? glibc) ./search-path.patch;
+    # Nixpkgs' Glibc. 
+    ++ optional (stdenv ? glibc) ./search-path.patch;
 
   buildInputs = [ curl expat zlib bzip2 libarchive ]
     ++ optional useNcurses ncurses


### PR DESCRIPTION
For more info about the patch, see:
https://github.com/NixOS/nixpkgs/issues/762
http://public.kitware.com/Bug/view.php?id=13887
http://article.gmane.org/gmane.linux.distributions.nixos/11292/match=
