### PR TITLE
binutils: add amd64 as additional target when on i686-linux

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -51,7 +51,8 @@ stdenv.mkDerivation rec {
         " --enable-fix-loongson2f-nop"
       + stdenv.lib.optionalString (cross != null) " --target=${cross.config}"
       + stdenv.lib.optionalString gold " --enable-gold"
-      + stdenv.lib.optionalString deterministic " --enable-deterministic-archives";
+      + stdenv.lib.optionalString deterministic " --enable-deterministic-archives"
+      + (if stdenv.system == "i686-linux" then " --enable-targets=x86_64-linux-gnu" else "");
 
   enableParallelBuilding = true;
       


### PR DESCRIPTION
This is _very_ convenient when working on an i686 installation with an amd64 kernel.  I usually do this to make everything small and fast (i686), but occasionally I can still compile stuff to amd64 if the extra registers are needed.  It'd be convenient to use the same binutils tools for those binaries in this case.  This is already like this in Debian, so I don't think we will meet any issues.

Plese note that this may trigger an stdenv rebuild, so you may want to merge it to some other branch than master.
