### PR TITLE
vte: patch for alt key

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/vte/alt.patch
+++ b/pkgs/desktops/gnome-2/desktop/vte/alt.patch
@@ -1,0 +1,50 @@
+From a9d6a34708f846952f423d078397352858f7b1a4 Mon Sep 17 00:00:00 2001
+From: Christian Persch <chpe@gnome.org>
+Date: Sat, 12 May 2012 18:48:05 +0200
+Subject: [PATCH] keymap: Treat ALT as META
+
+https://bugzilla.gnome.org/show_bug.cgi?id=663779
+---
+ src/vte.c |   23 ++++++++++++++---------
+ 1 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/src/vte.c b/src/vte.c
+index dd27e9a..0657921 100644
+--- a/src/vte.c
++++ b/src/vte.c
+@@ -5170,19 +5170,24 @@ static void
+ vte_terminal_read_modifiers (VteTerminal *terminal,
+ 			     GdkEvent *event)
+ {
++        GdkKeymap *keymap;
+ 	GdkModifierType modifiers;
+ 
+ 	/* Read the modifiers. */
+-	if (gdk_event_get_state((GdkEvent*)event, &modifiers)) {
+-		GdkKeymap *keymap;
+-#if GTK_CHECK_VERSION (2, 90, 8)
+-                keymap = gdk_keymap_get_for_display(gdk_window_get_display(((GdkEventAny*)event)->window));
+-#else
+-                keymap = gdk_keymap_get_for_display(gdk_drawable_get_display(((GdkEventAny*)event)->window));
++	if (!gdk_event_get_state((GdkEvent*)event, &modifiers))
++                return;
++
++        keymap = gdk_keymap_get_for_display(gdk_window_get_display(((GdkEventAny*)event)->window));
++
++        gdk_keymap_add_virtual_modifiers (keymap, &modifiers);
++
++#if 1
++        /* HACK! Treat ALT as META; see bug #663779. */
++        if (modifiers & GDK_MOD1_MASK)
++                modifiers |= VTE_META_MASK;
+ #endif
+-                gdk_keymap_add_virtual_modifiers (keymap, &modifiers);
+-		terminal->pvt->modifiers = modifiers;
+-	}
++
++        terminal->pvt->modifiers = modifiers;
+ }
+ 
+ /* Read and handle a keypress event. */
+-- 
+1.7.5.1.217.g4e3aa.dirty

--- a/pkgs/desktops/gnome-2/desktop/vte/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/vte/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0blmblvjr35xajr0a07zcd58lk6x2hzympx17biw2mcym9kcarql";
   };
 
+  patches = [ ./alt.patch ];
+
   buildInputs = [ intltool pkgconfig glib gtk ncurses ] ++
                 stdenv.lib.optionals pythonSupport [python pygtk];
                 


### PR DESCRIPTION
Patch for vte: fixes so that key combinations with ALT key actually work.
Vte package is used in many terminal emulators: xfce4-terminal, gnome-terminal, ...
