### PR TITLE
i3 window manager: version bump from 4.5.1 to 4.6

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "i3-${version}";
-  version = "4.5.1";
+  version = "4.6";
 
   src = fetchurl {
     url = "http://i3wm.org/downloads/${name}.tar.bz2";
-    sha256 = "bae55f1c7c4a21d71aae182e4fab6038ba65ba4be5d1ceff9e269f4f74b823f2";
+    sha256 = "1qand44hjqz84f2xzd0mmyk9vpsm7iwz6446s4ivdj6f86213lpm";
   };
 
   buildInputs = [ which pkgconfig libxcb xcbutilkeysyms xcbutil xcbutilwm
@@ -20,12 +20,21 @@ stdenv.mkDerivation rec {
 
   configurePhase = "makeFlags=PREFIX=$out";
 
-  meta = {
-    description = "i3 is a tiling window manager";
-    homepage = "http://i3wm.org";
-    maintainers = [ stdenv.lib.maintainers.garbas ];
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.all;
+  meta = with stdenv.lib; {
+    description = "A tiling window manager";
+    homepage    = "http://i3wm.org";
+    maintainers = with maintainers; [ garbas modulistic ];
+    license     = licenses.bsd3;
+    platforms   = platforms.all;
+
+    longDescription = ''
+      A tiling window manager primarily targeted at advanced users and
+      developers. Based on a tree as data structure, supports tiling,
+      stacking, and tabbing layouts, handled dynamically, as well as
+      floating windows. Configured via plain text file. Multi-monitor.
+      UTF-8 clean.
+    '';
   };
 
 }
+

--- a/pkgs/lib/maintainers.nix
+++ b/pkgs/lib/maintainers.nix
@@ -31,6 +31,7 @@
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
+  modulistic = "Pablo Costa <modulistic@gmail.com>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";


### PR DESCRIPTION
I've been using 4.6 since its release ca. Aug 7th.
http://i3wm.org/downloads/RELEASE-NOTES-4.6.txt
