### PR TITLE
Fix haddock building for unicode packages

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -142,6 +142,7 @@ assert enableCheckPhase -> stdenv.lib.versionOlder "7" ghc.ghcVersion;
 
               ./Setup build
 
+              export LANG=en_US.UTF-8
               export GHC_PACKAGE_PATH=$(ghc-packages)
               [ -n "$noHaddock" ] || ./Setup haddock
 

--- a/pkgs/development/libraries/haskell/multirec/default.nix
+++ b/pkgs/development/libraries/haskell/multirec/default.nix
@@ -4,7 +4,6 @@ cabal.mkDerivation (self: {
   pname = "multirec";
   version = "0.7.3";
   sha256 = "0k1wbjsvkl08nwjikflc8yyalk654mf8bvi1rhm28i4na52myi5y";
-  noHaddock = true;
   meta = {
     homepage = "http://www.cs.uu.nl/wiki/GenericProgramming/Multirec";
     description = "Generic programming for families of recursive datatypes";


### PR DESCRIPTION
Haskell packages that contain non-ascii characters in their .cabal file
or somewhere else in their haddock documentation fail to compile under
nixpkgs and usually flagged with noHaddock = true.  I wanted to do the
same for modularArithmentic, when I realized that we just have to set
the locale to some UTF-8 compatible locale in build-support/cabal to fix
this issue correctly.
