### PR TITLE
Fix purity of Elixir and Erlang

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, erlang, rebar }:
+{ stdenv, fetchurl, erlang, rebar, makeWrapper, coreutils }:
 
 stdenv.mkDerivation {
   name = "elixir-0.10.1";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "0gfr2bz3mw7ag9z2wb2g22n2vlyrp8dwy78fj9zi52kzl5w3vc3w";
   };
 
-  buildInputs = [ erlang rebar ];
+  buildInputs = [ erlang rebar makeWrapper ];
 
   preBuild = ''
     substituteInPlace rebar \
@@ -16,6 +16,17 @@ stdenv.mkDerivation {
     substituteInPlace Makefile \
       --replace '$(shell echo `pwd`/rebar)' ${rebar}/bin/rebar \
       --replace "/usr/local" $out
+  '';
+
+  postFixup = ''
+    # Elixirs binaries are shell scripts which run erl. This adds some
+    # stuff to PATH so the scripts run without problems.
+
+    for f in $out/bin/*
+    do
+      wrapProgram $f \
+      --prefix PATH ":" "${erlang}/bin:${coreutils}/bin"
+    done
   '';
 
   meta = {

--- a/pkgs/development/interpreters/erlang/R14B04.nix
+++ b/pkgs/development/interpreters/erlang/R14B04.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, perl, gnum4, ncurses, openssl }:
+{ stdenv, fetchurl, perl, gnum4, ncurses, openssl
+, makeWrapper, gnused, gawk }:
 
 let version = "14B04"; in
 
@@ -10,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0vlvjlg8vzcy6inb4vj00bnj0aarvpchzxwhmi492nv31s8kb6q9";
   };
 
-  buildInputs = [ perl gnum4 ncurses openssl ];
+  buildInputs = [ perl gnum4 ncurses openssl makeWrapper ];
 
   patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
 
@@ -20,6 +21,12 @@ stdenv.mkDerivation {
   '';
 
   configureFlags = "--with-ssl=${openssl}";
+
+  # Some erlang bin/ scripts run sed and awk
+  postFixup = ''
+    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
+    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${gnused}/bin/:${gawk}/bin"
+  '';
 
   meta = {
     homepage = "http://www.erlang.org/";

--- a/pkgs/development/interpreters/erlang/R15B03.nix
+++ b/pkgs/development/interpreters/erlang/R15B03.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, perl, gnum4, ncurses, openssl
+, makeWrapper, gnused, gawk
 , wxSupport ? false, mesa ? null, wxGTK ? null, xlibs ? null }:
 
 assert wxSupport -> mesa != null && wxGTK != null && xlibs != null;
@@ -15,6 +16,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [ perl gnum4 ncurses openssl
+      makeWrapper
     ] ++ stdenv.lib.optional wxSupport [ mesa wxGTK xlibs.libX11 ];
 
   patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
@@ -25,6 +27,12 @@ stdenv.mkDerivation {
   '';
 
   configureFlags = "--with-ssl=${openssl}";
+
+  # Some erlang bin/ scripts run sed and awk
+  postFixup = ''
+    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
+    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${gnused}/bin/:${gawk}/bin"
+  '';
 
   meta = {
     homepage = "http://www.erlang.org/";

--- a/pkgs/development/interpreters/erlang/R16B01.nix
+++ b/pkgs/development/interpreters/erlang/R16B01.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, perl, gnum4, ncurses, openssl
+, gnused, gawk, makeWrapper
 , wxSupport ? false, mesa ? null, wxGTK ? null, xlibs ? null }:
 
 assert wxSupport -> mesa != null && wxGTK != null && xlibs != null;
@@ -14,7 +15,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ perl gnum4 ncurses openssl
+    [ perl gnum4 ncurses openssl makeWrapper
     ] ++ stdenv.lib.optional wxSupport [ mesa wxGTK xlibs.libX11 ];
 
   patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
@@ -25,6 +26,12 @@ stdenv.mkDerivation {
   '';
 
   configureFlags = "--with-ssl=${openssl}";
+
+  # Some erlang bin/ scripts run sed and awk
+  postFixup = ''
+    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
+    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${gnused}/bin/:${gawk}/bin"
+  '';
 
   meta = {
     homepage = "http://www.erlang.org/";


### PR DESCRIPTION
The bash scripts of elixir contain some references to `erl`. This
patch wraps the scripts and extends PATH so `erl` is available. It also wraps some erlang scripts which depend on `sed` and `awk`.
