### PR TITLE
Add noHaddock flag to modular-artihmetic

### DIFF
--- a/pkgs/development/libraries/haskell/modular-arithmetic/default.nix
+++ b/pkgs/development/libraries/haskell/modular-arithmetic/default.nix
@@ -4,6 +4,7 @@ cabal.mkDerivation (self: {
   pname = "modular-arithmetic";
   version = "1.0.1.1";
   sha256 = "14n83kjmz8mqjivjhwxk1zckms5z3gn77yq2hsw2yybzff2vkdkd";
+  noHaddock = true;
   meta = {
     description = "A type for integers modulo some constant";
     license = self.stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
Building of haddock for packages with UTF-8 source is already
fixed in the stdenv-updates branch.  This fixes modular-arithmetic
until that branch is merged.  Will send another pull request to
add back haddock for that branch.
