### PR TITLE
Add The Little Brother's Database (lbdb) package

### DIFF
--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
   	buildInputs = [ perl finger_bsd ];
 
 	meta = {
-	    homepage = "http://www.spinnaker.de/lbdb/";
-	    description = "The Little Brother's Database (lbdb)";
+		homepage = "http://www.spinnaker.de/lbdb/";
+		license = stdenv.lib.licenses.gpl2;
+      		platforms = stdenv.lib.platforms.all;
+		description = "The Little Brother's Database (lbdb)";
 	};
 }

--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, perl, finger_bsd }:
+
+let
+	version = "0.38";
+in
+
+stdenv.mkDerivation {
+	name = "lbdb-${version}";
+	src = fetchurl {
+		url = "http://www.spinnaker.de/debian/lbdb_${version}.tar.gz";
+		md5 = "a8e65f1400c90818ff324dc4fd67eba2";
+	};
+
+  	buildInputs = [ perl finger_bsd ];
+
+	meta = {
+	    homepage = "http://www.spinnaker.de/lbdb/";
+	    description = "The Little Brother's Database (lbdb)";
+	};
+}

--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 	meta = {
 		homepage = "http://www.spinnaker.de/lbdb/";
 		license = stdenv.lib.licenses.gpl2;
-      		platforms = stdenv.lib.platforms.all;
+		platforms = stdenv.lib.platforms.all;
 		description = "The Little Brother's Database (lbdb)";
 	};
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7927,6 +7927,8 @@ let
 
   lastwatch = callPackage ../applications/audio/lastwatch { };
 
+  lbdb = callPackage ../tools/misc/lbdb { };
+
   lci = callPackage ../applications/science/logic/lci {};
 
   ldcpp = callPackage ../applications/networking/p2p/ldcpp {
@@ -8114,7 +8116,6 @@ let
   };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
-  lbdb = callPackage ../tools/misc/lbdb { };
 
   ruby_gpgme = callPackage ../development/libraries/ruby_gpgme {
     ruby = ruby19;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8114,6 +8114,7 @@ let
   };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
+  lbdb = callPackage ../tools/misc/lbdb { };
 
   ruby_gpgme = callPackage ../development/libraries/ruby_gpgme {
     ruby = ruby19;


### PR DESCRIPTION
Added lbdb. Utility to manage contacts in mutt. 

I use _finger_bsd_ to compile because if i dont use it, I get an error in execution:

`lbdbq: line 74: m_finger_query: command not found`
