### PR TITLE
elasticsearch: update to 0.90.3

### DIFF
--- a/pkgs/servers/search/elasticsearch/default.nix
+++ b/pkgs/servers/search/elasticsearch/default.nix
@@ -1,17 +1,30 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, jre, utillinux }:
 stdenv.mkDerivation rec {
-  name = "elasticsearch-0.20.5";
+  name = "elasticsearch-0.90.3";
 
   src = fetchurl {
     url = "https://download.elasticsearch.org/elasticsearch/elasticsearch/${name}.tar.gz";
-    sha256 = "0r0h9znyflajps1k8hl9naixhg1gqmhz7glc009pzzv94ncdzrq1";
+    sha256 = "1l6rnp4yvlz4z6z4v3af08yd4sl91c4zz20a8yyif2p234lh3n2s";
   };
 
   patches = [ ./es-home.patch ];
 
+  buildInputs = [ makeWrapper jre utillinux ];
+
   installPhase = ''
     mkdir -p $out
     cp -R bin config lib $out
+
+    # don't want to have binary with name plugin
+    mv $out/bin/plugin $out/bin/elasticsearch-plugin
+
+    # set ES_CLASSPATH and JAVA_HOME
+    wrapProgram $out/bin/elasticsearch \
+      --prefix ES_CLASSPATH : "$out/lib/${name}.jar":"$out/lib/*":"$out/lib/sigar/*" \
+      --prefix PATH : "${utillinux}/bin/" \
+      --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/elasticsearch-plugin \
+      --prefix ES_CLASSPATH : "$out/lib/${name}.jar":"$out/lib/*":"$out/lib/sigar/*" --set JAVA_HOME "${jre}"
   '';
 
   meta = {

--- a/pkgs/servers/search/elasticsearch/es-home.patch
+++ b/pkgs/servers/search/elasticsearch/es-home.patch
@@ -1,6 +1,6 @@
-diff -rc elasticsearch-0.20.5/bin/elasticsearch elasticsearch-0.20.5-new/bin/elasticsearch
-*** elasticsearch-0.20.5/bin/elasticsearch	2013-03-07 12:16:31.152494626 +0100
---- elasticsearch-0.20.5-new/bin/elasticsearch	2013-03-07 12:24:41.076081272 +0100
+diff -rc elasticsearch-0.90.3/bin/elasticsearch elasticsearch-0.90.3-new/bin/elasticsearch
+*** elasticsearch-0.90.3/bin/elasticsearch	2013-08-06 15:19:22.000000000 +0200
+--- elasticsearch-0.90.3-new/bin/elasticsearch	2013-08-27 16:42:00.935880011 +0200
 ***************
 *** 62,68 ****
   done
@@ -10,11 +10,50 @@ diff -rc elasticsearch-0.20.5/bin/elasticsearch elasticsearch-0.20.5-new/bin/ela
   
   # make ELASTICSEARCH_HOME absolute
   ES_HOME=`cd "$ES_HOME"; pwd`
---- 62,68 ----
+--- 62,71 ----
   done
   
   # determine elasticsearch home
-! ES_HOME=${ES_HOME:=`dirname "$SCRIPT"`/..}
+! if [ -z "$ES_HOME" ]; then
+!     echo "You must set the ES_HOME var" >&2
+!     exit 1
+! fi
   
   # make ELASTICSEARCH_HOME absolute
   ES_HOME=`cd "$ES_HOME"; pwd`
+diff -rc elasticsearch-0.90.3/bin/plugin elasticsearch-0.90.3-new/bin/plugin
+*** elasticsearch-0.90.3/bin/plugin	2013-08-06 15:19:22.000000000 +0200
+--- elasticsearch-0.90.3-new/bin/plugin	2013-08-27 16:49:01.024160295 +0200
+***************
+*** 16,22 ****
+  done
+  
+  # determine elasticsearch home
+! ES_HOME=`dirname "$SCRIPT"`/..
+  
+  # make ELASTICSEARCH_HOME absolute
+  ES_HOME=`cd "$ES_HOME"; pwd`
+--- 16,25 ----
+  done
+  
+  # determine elasticsearch home
+! if [ -z "$ES_HOME" ]; then
+!     echo "You must set the ES_HOME var" >&2
+!     exit 1
+! fi
+  
+  # make ELASTICSEARCH_HOME absolute
+  ES_HOME=`cd "$ES_HOME"; pwd`
+***************
+*** 46,50 ****
+    shift
+  done
+  
+! exec $JAVA $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $args
+  
+--- 49,53 ----
+    shift
+  done
+  
+! exec $JAVA $JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_CLASSPATH/lib/*" org.elasticsearch.plugins.PluginManager $args
+  


### PR DESCRIPTION
This commit updates elasticsearch and makes it more nix friendly. Now you can simply run `ES_PATH=<elasticseach_home> elasticsearch` and it will start.
