### PR TITLE
id3v2 now also requires zlib (presumably because id3lib no longer ships it)

### DIFF
--- a/pkgs/applications/audio/id3v2/default.nix
+++ b/pkgs/applications/audio/id3v2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, id3lib, groff}:
+{stdenv, fetchurl, id3lib, groff, zlib}:
 
 stdenv.mkDerivation rec {
   name = "id3v2-0.1.11";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   patches = [ ./id3v2-0.1.11-track-bad-free.patch ];
 
   nativeBuildInputs = [ groff ];
-  buildInputs = [ id3lib ];
+  buildInputs = [ id3lib zlib ];
 
   configurePhase = ''
     export makeFlags=PREFIX=$out


### PR DESCRIPTION
Required to be able to build it.
