### PR TITLE
Fcron: Disable checks for root{name,group} and others.

### DIFF
--- a/pkgs/tools/system/fcron/default.nix
+++ b/pkgs/tools/system/fcron/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
       # fcron would have been default user/grp
       "--with-username=root"
       "--with-groupname=root"
+      "--with-rootname=root"
+      "--with-rootgroup=root"
+      "--disable-checks"
     ];
     
   installTargets = "install-staged"; # install does also try to change permissions of /etc/* files


### PR DESCRIPTION
This fixes building fcron. It was complaining it couldn't check root's
user name and the suggested flag (--with-rootname) didn't do anything.
