### PR TITLE
Bluez 5.8 and other packages that required upgrading

### DIFF
--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -63,6 +63,10 @@ stdenv.mkDerivation rec {
     done
     popd
     wrapPythonProgramsIn $out/test "$out/test $pythonPath"
+
+    # for bluez4 compatibility for NixOS
+    mkdir $out/sbin
+    ln -s ../libexec/bluetooth/bluetoothd $out/sbin/bluetoothd
   '';
 
   meta = {

--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -9,11 +9,11 @@ let
 in
    
 stdenv.mkDerivation rec {
-  name = "bluez-5.3";
+  name = "bluez-5.8";
    
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/${name}.tar.xz";
-    sha256 = "41b0559e3a8436a739eb7cc79156ca91daf8c115f57971b6bcb422ee0213db42";
+    sha256 = "1l33lq1lpg7hy26138ir5dj4gl3mql2qxpj20rjnnwyckc3jk700";
   };
 
   buildInputs =

--- a/pkgs/tools/bluetooth/obexftp/default.nix
+++ b/pkgs/tools/bluetooth/obexftp/default.nix
@@ -1,14 +1,14 @@
-{stdenv, fetchurl, pkgconfig, openobex, bluez}:
+{stdenv, fetchurl, pkgconfig, openobex, bluez, cmake}:
    
 stdenv.mkDerivation rec {
-  name = "obexftp-0.23";
+  name = "obexftp-0.24";
    
   src = fetchurl {
-    url = "mirror://sourceforge/openobex/${name}.tar.bz2";
-    sha256 = "0djv239b14p221xjxzza280w3pnnwzpw4ssd6mshz36ki3r4z9s4";
+    url = "mirror://sourceforge/openobex/${name}-Source.tar.gz";
+    sha256 = "0szy7p3y75bd5h4af0j5kf0fpzx2w560fpy4kg3603mz11b9c1xr";
   };
 
-  buildInputs = [pkgconfig bluez];
+  buildInputs = [pkgconfig bluez cmake];
 
   propagatedBuildInputs = [openobex];
 

--- a/pkgs/tools/bluetooth/openobex/default.nix
+++ b/pkgs/tools/bluetooth/openobex/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, bluez, libusb, udev, cmake}:
+{stdenv, fetchurl, pkgconfig, bluez, libusb, cmake}:
    
 stdenv.mkDerivation rec {
   name = "openobex-1.7.1";

--- a/pkgs/tools/bluetooth/openobex/default.nix
+++ b/pkgs/tools/bluetooth/openobex/default.nix
@@ -1,16 +1,20 @@
-{stdenv, fetchurl, pkgconfig, bluez, libusb}:
+{stdenv, fetchurl, pkgconfig, bluez, libusb, udev, cmake}:
    
 stdenv.mkDerivation rec {
-  name = "openobex-1.5";
+  name = "openobex-1.7.1";
    
   src = fetchurl {
-    url = "mirror://kernel/linux/bluetooth/${name}.tar.gz";
-    sha256 = "0rayjci99ahhvs2d16as1qql3vrcizd0nhi8n3n4g6krf1sh80p6";
+    url = "mirror://sourceforge/openobex/${name}-Source.tar.gz";
+    sha256 = "0mza0mrdrbcw4yix6qvl31kqy7bdkgxjycr0yx7yl089v5jlc9iv";
   };
 
-  buildInputs = [pkgconfig bluez libusb];
+  buildInputs = [pkgconfig bluez libusb cmake];
 
   configureFlags = "--enable-apps";
+
+  patchPhase = ''
+    sed -i "s!/lib/udev!$out/lib/udev!" udev/CMakeLists.txt
+    '';
 
   meta = {
     homepage = http://dev.zuckschwerdt.org/openobex/;


### PR DESCRIPTION
The goal was just a system using Bluez5, which did not work out of the box. I fixed all the dependencies, and upgraded bluez5 to 5.8.

It is also compatible with the NixOS bluetooth service, to use set a packageOverride for bluez = pkgs.bluez5;
