### PR TITLE
Add platforms to coq, so it's built on Hydra

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation {
     homepage = "http://coq.inria.fr";
     license = "LGPL";
     maintainers = [ stdenv.lib.maintainers.roconnor ];
+    platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
This is missing from the binary cache currently and that is very painful, because compilation takes ~40 mins.
