### PR TITLE
haskell: export callPackage to be able to create packages outside haskell-packages.nix

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -74,6 +74,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.final x y);
 
   final = self;
 
+  callPackage = callPackage;
+
   # GHC and its wrapper
   #
   # We use a wrapped version of GHC for nearly everything. The wrapped version


### PR DESCRIPTION
It can be used for example like this: https://github.com/aristidb/aws/blob/master/default.nix
