### PR TITLE
emacs24: Let -nox be a whole lot less X than it was

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     (if withX then 
       [ "--with-x-toolkit=gtk" "--with-xft"]
     else
-      [ "--with-x-toolkit=no" ])
+      [ "--with-x=no --with-xpm=no --with-jpeg=no --with-png=no --with-gif=no --with-tiff=no" ])
     # On NixOS, help Emacs find `crt*.o'.
     ++ stdenv.lib.optional (stdenv ? glibc)
          [ "--with-crt-dir=${stdenv.glibc}/lib" ];


### PR DESCRIPTION
--with-x-toolkit=no still wants to -lX11 when checking for ncurses
