### PR TITLE
ghc-mod: Wrap to call ghc-get-packages.sh first

### DIFF
--- a/pkgs/development/libraries/haskell/ghc-mod/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-mod/default.nix
@@ -25,6 +25,14 @@ cabal.mkDerivation (self: {
     cd ..
     ensureDir "$out/share/emacs"
     mv $pname-$version emacs/site-lisp
+    mv $out/bin/ghc-mod $out/ghc-mod
+    cat - > $out/bin/ghc-mod <<EOF
+    #!/bin/sh
+    COMMAND=\$1
+    shift
+    eval exec $out/ghc-mod \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.ghcVersion} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
+    EOF
+    chmod +x $out/bin/ghc-mod
   '';
   meta = {
     homepage = "http://www.mew.org/~kazu/proj/ghc-mod/";
@@ -34,6 +42,7 @@ cabal.mkDerivation (self: {
     maintainers = [
       self.stdenv.lib.maintainers.andres
       self.stdenv.lib.maintainers.bluescreen303
+      self.stdenv.lib.maintainers.ocharles
     ];
   };
 })

--- a/pkgs/lib/maintainers.nix
+++ b/pkgs/lib/maintainers.nix
@@ -7,8 +7,8 @@
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
   amiddelk = "Arie Middelkoop <amiddelk@gmail.com>";
-  andres = "Andres Loeh <ksnixos@andres-loeh.de>";
   amorsillo = "Andrew Morsillo <andrew.morsillo@gmail.com>";
+  andres = "Andres Loeh <ksnixos@andres-loeh.de>";
   antono = "Antono Vasiljev <self@antono.info>";
   astsmtl = "Alexander Tsamutali <astsmtl@yandex.ru>";
   aszlig = "aszlig <aszlig@redmoonstudios.org>";
@@ -34,6 +34,7 @@
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
+  ocharles = "Oliver Charles <ollie@ocharles.org.uk>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   page = "Carles Pagès <page@cubata.homelinux.net>";


### PR DESCRIPTION
This allows `ghc-mod` to see all available packages on the `PATH`, just like `ghc`.
