### PR TITLE
Ledger 3: Update to latest git & fixes

### DIFF
--- a/pkgs/applications/office/ledger/3.0.nix
+++ b/pkgs/applications/office/ledger/3.0.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, cmake, boost, gmp, mpfr, libedit, python, texinfo }:
 
 let
-  rev = "0ec4291013bae966df2f5ca504d2216e488cd7ec";
+  rev = "0ec4291";
 in
 stdenv.mkDerivation {
   name = "ledger3-2013.08.${rev}";

--- a/pkgs/applications/office/ledger/3.0.nix
+++ b/pkgs/applications/office/ledger/3.0.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation {
   doCheck = true;
   enableParallelBuilding = true;
 
+  # Skip byte-compiling of emacs-lisp files because this is currently
+  # broken in ledger...
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp/
+    cp -v $src/lisp/*.el $out/share/emacs/site-lisp/
+  '';
+
   meta = {
     homepage = "http://ledger-cli.org/";
     description = "A double-entry accounting system with a command-line reporting interface";

--- a/pkgs/applications/office/ledger/3.0.nix
+++ b/pkgs/applications/office/ledger/3.0.nix
@@ -1,23 +1,20 @@
 { stdenv, fetchgit, cmake, boost, gmp, mpfr, libedit, python, texinfo }:
 
 let
-  rev = "26d7197";
+  rev = "0ec4291013bae966df2f5ca504d2216e488cd7ec";
 in
 stdenv.mkDerivation {
-  name = "ledger3-2013.06.${rev}";
+  name = "ledger3-2013.08.${rev}";
 
   src = fetchgit {
     url = "https://github.com/ledger/ledger.git";
     inherit rev;
-    sha256 = "02nf4kdrd61q9rf5rrarwmx47y2ya5qix7n82cj9qi9p4v3k3m2g";
+    sha256 = "1y4rcbx8y2fxkdc7i06n1i5jf3cq05bvzpb8498mis2gwfmkw470";
   };
 
   buildInputs = [ cmake boost gmp mpfr libedit python texinfo ];
 
-  # Unit tests fail in the current git snapshot. Try enabling them again
-  # when updating this package!
-  doCheck = false;
-
+  doCheck = true;
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
Latest git works pretty fine for my (small) ledger file. All tests succeed too.

I decided to install the emacs lisp files manually without byte compiling to work around the broken build process.
