### PR TITLE
Adding FriBID browser plugin & abook addressbook

### DIFF
--- a/pkgs/applications/misc/abook/default.nix
+++ b/pkgs/applications/misc/abook/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, ncurses, readline }:
+
+let version = "0.6.0pre2"; in
+stdenv.mkDerivation rec {
+  name = "abook-${version}";
+
+  src = fetchurl {
+    url = "http://abook.sourceforge.net/devel/${name}.tar.gz";
+    sha256 = "59d444504109dd96816e003b3023175981ae179af479349c34fa70bc12f6d385";
+  };
+
+  buildInputs = [ pkgconfig ncurses readline ];
+
+  meta = {
+    homepage = "http://abook.sourceforge.net/";
+    description = "Abook is a text-based addressbook program designed to use with mutt mail client.";
+    license = "GPLv2";
+    maintainers = [ stdenv.lib.maintainers.edwtjo ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/builder.sh
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/builder.sh
@@ -1,0 +1,21 @@
+source $stdenv/setup
+
+preConfigure() {
+  for pot in `awk -F '=' '/POTFILES=/{print $2}' translations/Makefile`; do
+    echo ${pot##../}
+  done > translations/POTFILES.in
+  cat translations/POTFILES.in
+  sed -i -e "/xgettext/d" translations/Makefile
+  sed -i -e "/template.pot:/a\\\tintltool-update --gettext-package=\$(PACKAGENAME) -o \$@ sv" translations/Makefile
+}
+
+postUnpack() {
+  mkdir -p $out/lib/mozilla/plugins
+}
+
+installPhase() {
+  cp -p plugin/libfribidplugin.so $out/lib/mozilla/plugins
+}
+
+genericBuild
+

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, openssl, glib, libX11, gtk3, gettext, intltool }:
+
+let version = "1.0.2"; in
+stdenv.mkDerivation rec {
+  name = "fribid-${version}";
+  builder = ./builder.sh;
+
+  src = fetchurl {
+    url = "https://fribid.se/releases/source/${name}.tar.bz2";
+    sha256 = "d7cd9adf04fedf50b266a5c14ddb427cbb263d3bc160ee0ade03aca9d5356e5c";
+  };
+
+  buildInputs = [ pkgconfig openssl libX11 gtk3 glib gettext intltool ];
+
+  configureFlags = "--plugin-path=/lib/mozilla/plugins";
+
+  passthru.mozillaPlugin = "/lib/mozilla/plugins";
+
+  meta = {
+    description = "A browser plugin to manage Swedish BankID:s";
+    homepage = http://fribid.se;
+    licenses = [ "GPLv2" "MPLv1" ];
+    maintainers = [ stdenv.lib.maintainers.edwtjo ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}
+

--- a/pkgs/lib/maintainers.nix
+++ b/pkgs/lib/maintainers.nix
@@ -19,6 +19,7 @@
   bodil = "Bodil Stokke <nix@bodil.org>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
+  edwtjo = "Edward Tjörnhammar <ed@cflags.cc>";
   eelco = "Eelco Dolstra <eelco.dolstra@logicblox.com>";
   ertes = "Ertugrul Söylemez <es@ertes.de>";
   garbas = "Rok Garbas <rok@garbas.si>";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7133,6 +7133,8 @@ let
     inherit (gnome) libglade libgnomecanvas;
   };
 
+  abook = callPackage ../applications/misc/abook { };
+
   adobeReader = callPackage_i686 ../applications/misc/adobe-reader { };
 
   aewan = callPackage ../applications/editors/aewan { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7556,6 +7556,8 @@ let
 
   fossil = callPackage ../applications/version-management/fossil { };
 
+  fribid = callPackage ../applications/networking/browsers/mozilla-plugins/fribid { };
+
   fvwm = callPackage ../applications/window-managers/fvwm { };
 
   geany = callPackage ../applications/editors/geany { };


### PR DESCRIPTION
FriBID is an open source software for the Swedish e-id system called
BankID. FriBID also supports processor architectures and Linux/BSD
distributions that the official software doesn't support.

Abook is a text-based addressbook program designed to use with mutt mail client.
