### PR TITLE
Adding FriBID browser plugin

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/builder.sh
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/builder.sh
@@ -1,0 +1,4 @@
+source $stdenv/setup
+export PREFIX=$out
+configureFlags="--plugin-path=$out/lib/mozilla/plugins"
+genericBuild

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgconfig, openssl, glib, libX11, gtk3, gettext, intltool }:
+
+let version = "1.0.2"; in
+stdenv.mkDerivation rec {
+  name = "fribid-${version}";
+  builder = ./builder.sh;
+
+  src = fetchurl {
+    url = "https://fribid.se/releases/source/${name}.tar.bz2";
+    sha256 = "d7cd9adf04fedf50b266a5c14ddb427cbb263d3bc160ee0ade03aca9d5356e5c";
+  };
+
+  buildInputs = [ pkgconfig openssl libX11 gtk3 glib gettext intltool ];
+  patches = [
+    ./translation-xgettext-to-intltool.patch
+    ./plugin-linkfix.patch
+    ./emulated-version.patch
+    ./ipc-lazytrace.patch
+    ];
+
+  passthru.mozillaPlugin = "/lib/mozilla/plugins";
+
+  meta = {
+    description = "A browser plugin to manage Swedish BankID:s";
+    homepage = http://fribid.se;
+    licenses = [ "GPLv2" "MPLv1" ];
+    maintainers = [ stdenv.lib.maintainers.edwtjo ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}
+

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/emulated-version.patch
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/emulated-version.patch
@@ -1,0 +1,12 @@
+--- a/common/defines.h  2012-11-14 18:02:43.000000000 +0100
++++ b/common/defines.h  2013-09-20 19:17:45.669290630 +0200
+@@ -39,7 +39,7 @@
+ #define RELEASE_TIME        1352912534
+ #define IPCVERSION          "10"
+ 
+-#define EMULATED_VERSION    "4.15.0.14"
++#define EMULATED_VERSION    "4.17.0.11" // Was 4.15.0.14
+ #define DNSVERSION          "2"
+ #define STATUSDOMAIN        ".status.fribid.se"
+ 
+

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/ipc-lazytrace.patch
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/ipc-lazytrace.patch
@@ -1,0 +1,10 @@
+--- a/plugin/ipc.c	2012-11-14 18:02:43.000000000 +0100
++++ b/plugin/ipc.c	2013-09-21 08:55:39.960265058 +0200
+@@ -74,6 +74,7 @@
+         //close(pipeOut[PIPE_READ_END]);
+
+         execvp(mainBinary, (char *const *)argv);
++        fprintf(stderr, "Wanted signing executable\t<%s>\n", mainBinary);
+         perror(BINNAME ": Failed to execute main binary");
+         exit(1);
+     } else {

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/plugin-linkfix.patch
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/plugin-linkfix.patch
@@ -1,0 +1,11 @@
+--- a/plugin/Makefile	2013-09-18 13:55:11.091652553 +0200
++++ b/plugin/Makefile	2013-09-18 13:58:27.513618750 +0200
+@@ -60,7 +60,7 @@
+ 	for path in $(NPAPI_PLUGIN_PATHS); do \
+ 	    (../configure --internal--remove-link $(DESTDIR)$$path/libfribidplugin.so $(NPAPI_PLUGIN_LIB) || exit 1) && \
+ 	    install -d $(DESTDIR)$$path && \
+-	    ln -sf $(NPAPI_PLUGIN_LIB) $(DESTDIR)$$path/libfribidplugin.so; \
++	    ln -sf $(DESTDIR)$(NPAPI_PLUGIN_LIB) $(DESTDIR)$$path/libfribidplugin.so; \
+ 	done
+
+ uninstall:

--- a/pkgs/applications/networking/browsers/mozilla-plugins/fribid/translation-xgettext-to-intltool.patch
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/fribid/translation-xgettext-to-intltool.patch
@@ -1,0 +1,16 @@
+--- a/translations/Makefile	2013-09-18 07:25:16.503800613 +0200
++++ b/translations/Makefile	2013-09-18 07:25:29.495869405 +0200
+@@ -38,7 +38,7 @@
+ all: template.pot $(MOFILES)
+
+ template.pot: $(POTFILES) $(DEFINES)
+-	xgettext -k_ -ktranslatable -d $(DOMAIN) --package-name=$(PACKAGENAME) --package-version=$(PACKAGEVERSION) --copyright-holder='YOUR NAME' -o $@ $(POTFILES)
++	intltool-update --gettext-package=$(PACKAGENAME) -o $@ sv
+
+ .po.mo:
+ 	msgfmt $< -o $@
+--- a/translations/POTFILES.in	2013-09-16 20:28:56.766106014 +0200
++++ b/translations/POTFILES.in	2013-09-18 13:15:05.252689648 +0200
+@@ -0,0 +1,2 @@
++client/gtk.c
++client/gtk/sign.glade

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7727,6 +7727,8 @@ let
 
   fossil = callPackage ../applications/version-management/fossil { };
 
+  fribid = callPackage ../applications/networking/browsers/mozilla-plugins/fribid { };
+
   fvwm = callPackage ../applications/window-managers/fvwm { };
 
   geany = callPackage ../applications/editors/geany { };
@@ -8939,6 +8941,7 @@ let
           ++ lib.optional (cfg.enableGeckoMediaPlayer or false) gecko_mediaplayer
           ++ lib.optional (supportsJDK && cfg.jre or false && jrePlugin ? mozillaPlugin) jrePlugin
           ++ lib.optional (cfg.enableGoogleTalkPlugin or false) google_talk_plugin
+          ++ lib.optional (cfg.enableFriBIDPlugin or false) fribid
          );
       libs =
         if cfg.enableQuakeLive or false


### PR DESCRIPTION
FriBID is an open source software for the Swedish e-id system called
BankID. FriBID also supports processor architectures and Linux/BSD
distributions that the official software doesn't support.

https://fribid.se/index.en.html
