### PR TITLE
libusb1: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ udev ];
+  propagatedBuildInputs = stdenv.lib.optional (!stdenv.isDarwin) udev;
 
   meta = {
     homepage = http://www.libusb.org;


### PR DESCRIPTION
`udev` introduced as build input in 8500581a
