### PR TITLE
haskell-splot: unbreak by using Chart 0.17 instead of 1.0

### DIFF
--- a/pkgs/development/libraries/haskell/Chart/0.17.nix
+++ b/pkgs/development/libraries/haskell/Chart/0.17.nix
@@ -1,0 +1,19 @@
+{ cabal, cairo, colour, dataAccessor, dataAccessorTemplate, mtl
+, time
+}:
+
+cabal.mkDerivation (self: {
+  pname = "Chart";
+  version = "0.17";
+  sha256 = "1ip1a61ryypwfzj6dc6n6pl92rflf7lqf1760ppjyg05q5pn6qxg";
+  buildDepends = [
+    cairo colour dataAccessor dataAccessorTemplate mtl time
+  ];
+  meta = {
+    homepage = "https://github.com/timbod7/haskell-chart/wiki";
+    description = "A library for generating 2D Charts and Plots";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.andres ];
+  };
+})

--- a/pkgs/development/tools/haskell/splot/default.nix
+++ b/pkgs/development/tools/haskell/splot/default.nix
@@ -1,4 +1,4 @@
-{ cabal, bytestringLexing, cairo, Chart, colour, HUnit, mtl
+{ cabal, bytestringLexing, cairo, Chart_0_17, colour, HUnit, mtl
 , strptime, time, vcsRevision
 }:
 
@@ -9,7 +9,7 @@ cabal.mkDerivation (self: {
   isLibrary = false;
   isExecutable = true;
   buildDepends = [
-    bytestringLexing cairo Chart colour HUnit mtl strptime time
+    bytestringLexing cairo Chart_0_17 colour HUnit mtl strptime time
     vcsRevision
   ];
   meta = {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -687,6 +687,7 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
   cgi = self.cgi_3001_1_8_4;
 
   Chart = callPackage ../development/libraries/haskell/Chart {};
+  Chart_0_17 = callPackage ../development/libraries/haskell/Chart/0.17.nix {};
   ChartCairo = callPackage ../development/libraries/haskell/Chart-cairo {};
   ChartGtk = callPackage ../development/libraries/haskell/Chart-gtk {};
 


### PR DESCRIPTION
Bring back the Chart 0.17 expression the way it was before the 1.0 bump
that broke splot.

@peti: Does it look OK? I can commit it myself (for linear history) if you ACK it.
