### PR TITLE
recursive-pth-loader: build sitecustomize.pyc

### DIFF
--- a/pkgs/development/python-modules/recursive-pth-loader/default.nix
+++ b/pkgs/development/python-modules/recursive-pth-loader/default.nix
@@ -7,11 +7,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ python ];
 
+  patchPhase = "cat ${./sitecustomize.py} > sitecustomize.py";
+
+  buildPhase = "python -m compileall .";
+
   installPhase =
     ''
       dst=$out/lib/${python.libPrefix}/site-packages
       mkdir -p $dst
-      cat ${./sitecustomize.py} >> $dst/sitecustomize.py
+      cp sitecustomize.* $dst/
     '';
 
   meta = {


### PR DESCRIPTION
If this file is not created at build time, then python (when run as root) will
create it at run time and mess up the consistency of the nix store.
