### PR TITLE
Upower local libusb revert

### DIFF
--- a/pkgs/development/libraries/libusb1/1_0_9.nix
+++ b/pkgs/development/libraries/libusb1/1_0_9.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libusb-1.0.9";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/libusb/${name}.tar.bz2";
+    sha256 = "16sz34ix6hw2wwl3kqx6rf26fg210iryr68wc439dc065pffw879";
+  };
+
+  buildInputs = [ pkgconfig ];
+
+  meta = {
+    homepage = http://www.libusb.org;
+    description = "User-space USB library";
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.urkud ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6851,7 +6851,9 @@ let
 
   untie = callPackage ../os-specific/linux/untie { };
 
-  upower = callPackage ../os-specific/linux/upower { };
+  upower = callPackage ../os-specific/linux/upower {
+    libusb1 = callPackage ../development/libraries/libusb1/1_0_9.nix {};
+    };
 
   upstart = callPackage ../os-specific/linux/upstart { };
 


### PR DESCRIPTION
That workarounds the coldplug problem

$ sudo ./libexec/upowerd -v
TI:18:38:27     Starting upowerd version 0.9.19
...
TI:18:38:27     registering subsystem : usb
TI:18:38:27     failed to coldplug /sys/devices/pci0000:00/0000:00:1c.4/0000:03:00.0/usb1
<upowerd EXITS>
