### PR TITLE
Fix impurity in HFuse

### DIFF
--- a/pkgs/development/libraries/haskell/HFuse/default.nix
+++ b/pkgs/development/libraries/haskell/HFuse/default.nix
@@ -7,6 +7,7 @@ cabal.mkDerivation (self: {
   extraLibraries = [ fuse ];
   preConfigure = ''
     sed -i -e "s@  Extra-Lib-Dirs:         /usr/local/lib@  Extra-Lib-Dirs:         ${fuse}/lib@" HFuse.cabal
+    sed -i -e "s@  Include-Dirs:           /usr/include, /usr/local/include, .@  Include-Dirs:           ${fuse}/include@" HFuse.cabal
     sed -i -e "s/LANGUAGE FlexibleContexts/LANGUAGE FlexibleContexts, RankNTypes/" System/Fuse.hsc
     sed -i -e "s/E(Exception/E(catch, Exception, IOException/" System/Fuse.hsc
     sed -i -e "s/IO(catch,/IO(/" System/Fuse.hsc


### PR DESCRIPTION
This impurity caused hsc2hs to start look into /usr/include in any Cabal
project that depends on HFuse on systems where /usr/include is present.
