### PR TITLE
libvirt: update to 1.1.2

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -1,22 +1,25 @@
 { stdenv, fetchurl, pkgconfig, libxml2, gnutls, devicemapper, perl, python
 , iproute, iptables, readline, lvm2, utillinux, udev, libpciaccess, gettext
-, libtasn1, ebtables, libgcrypt, yajl, makeWrapper, pmutils
+, libtasn1, ebtables, libgcrypt, yajl, makeWrapper, pmutils, libcap_ng
 }:
 
-let version = "1.1.1"; in
+let version = "1.1.2"; in
 
 stdenv.mkDerivation {
   name = "libvirt-${version}";
 
   src = fetchurl {
     url = "http://libvirt.org/sources/libvirt-${version}.tar.gz";
-    sha256 = "1hi27d5pld925g1azx8jq0wv557wpkd6xrq6lzm91cdr2lg1wvyw";
+    md5 = "1835bbfa492099bce12e2934870e5611";
   };
 
   buildInputs =
     [ pkgconfig libxml2 gnutls devicemapper perl python readline lvm2
       utillinux udev libpciaccess gettext libtasn1 libgcrypt yajl makeWrapper
+      libcap_ng
     ];
+
+  patches = [ ./securtyfs_userns.patch ];
 
   preConfigure =
     ''

--- a/pkgs/development/libraries/libvirt/securtyfs_userns.patch
+++ b/pkgs/development/libraries/libvirt/securtyfs_userns.patch
@@ -1,0 +1,30 @@
+--- a/src/lxc/lxc_container.c
++++ b/src/lxc/lxc_container.c
+@@ -750,7 +750,7 @@ err:
+ }
+ 
+ 
+-static int lxcContainerMountBasicFS(void)
++static int lxcContainerMountBasicFS(bool userns_enabled)
+ {
+     const struct {
+         const char *src;
+@@ -801,6 +801,9 @@ static int lxcContainerMountBasicFS(void)
+             continue;
+ #endif
+ 
++        if (STREQ(mnts[i].src, "securityfs") && userns_enabled)
++            continue;
++
+         if (virFileMakePath(mnts[i].dst) < 0) {
+             virReportSystemError(errno,
+                                  _("Failed to mkdir %s"),
+@@ -1530,7 +1533,7 @@ static int lxcContainerSetupPivotRoot(virDomainDefPtr vmDef,
+         goto cleanup;
+ 
+     /* Mounts the core /proc, /sys, etc filesystems */
+-    if (lxcContainerMountBasicFS() < 0)
++    if (lxcContainerMountBasicFS(vmDef->idmap.nuidmap) < 0)
+         goto cleanup;
+ 
+     /* Mounts /proc/meminfo etc sysinfo */


### PR DESCRIPTION
This update features the lxc user namespaces, so you can run lxc containers securely if USER_NS(which requires disables FS_XFS currently) is enabled in kernel. Also the patch included is currently neede, so securityfs does not get mounted if in user namespaced container.
