### PR TITLE
vlc: fixing segfaults, by updating ffmpeg to 1.2.3 and vlc to 2.0.8a

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -9,12 +9,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "vlc-${version}";
+  name = "vlc-${version}a";
   version = "2.0.8";
 
   src = fetchurl {
     url = "http://download.videolan.org/pub/videolan/vlc/${version}/${name}.tar.xz";
-    sha256 = "00hpbm0v424yhfzqyxrvrvfjkbvf3f43yqk6h1qhwmnl8n1z4am0";
+    sha256 = "1lilj14il52731h7qvrjcss0zivghcxv8jmmxf23qwl7qhs5y885";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/ffmpeg/1.x.nix
+++ b/pkgs/development/libraries/ffmpeg/1.x.nix
@@ -29,11 +29,11 @@ assert x11grabSupport -> libXext != null && libXfixes != null;
 assert playSupport -> SDL != null;
 
 stdenv.mkDerivation rec {
-  name = "ffmpeg-1.2";
+  name = "ffmpeg-1.2.3";
 
   src = fetchurl {
     url = "http://www.ffmpeg.org/releases/${name}.tar.bz2";
-    sha256 = "1bssxbn4p813xlgb8whg4b60j90yzfy92x70b4q8j35fgp0gnfcs";
+    sha256 = "0nvilgwaivzvikgp9lpvrwi4p1clxl4w8j961599bg0r2v7n4x6r";
   };
 
   # `--enable-gpl' (as well as the `postproc' and `swscale') mean that

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/librsvg/2.36/${name}.tar.xz";
     sha256 = "1hp6325gdkzx8yqn2d2r915ak3k6hfshjjh0sc54z3vr0i99688h";
   };
-  buildInputs = [ libxml2 libgsf bzip2 libcroco pango cairo ]
+  buildInputs = [ libxml2 libgsf bzip2 libcroco pango ]
     ++ stdenv.lib.optional enableIntrospection [ gobjectIntrospection ];
-  propagatedBuildInputs = [ glib gdk_pixbuf gtk2 gtk3 ];
+  propagatedBuildInputs = [ glib gdk_pixbuf gtk2 gtk3 cairo ];
   nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = ["--enable-introspection=auto"];


### PR DESCRIPTION
since the vlc 2.0.8 update i was unable to watch quite a lot of different videos as vlc segfaulted as soon as one launched the video. the update to 2.0.8a together with ffmpeg's version bump brings those videos back.

at the same time, i noticed that vlc kept missing the librsvg library. moving cairo in the librsvg expression into the propagatedBuildInputs fixes this as well. i suppose adding cairo to vlc's buildinputs would achieve the same. i'm unsure whether this is the correct fix.
