### PR TITLE
expect: fix build on freebsd

### DIFF
--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
     substituteInPlace configure --replace /bin/stty "$(type -tP stty)"
     sed -e '1i\#include <tclInt.h>' -i exp_inter.c
     export NIX_LDFLAGS="-rpath $out/lib $NIX_LDFLAGS"
+  '' + stdenv.lib.optionalString stdenv.isFreeBSD ''
+    ln -s libexpect.so.1 libexpect545.so
   '';
 
   configureFlags = [


### PR DESCRIPTION
I am not sure if this will resolve any of the builds that are failing on hydra, but I couldn't get `expect` to build on FreeBSD 9.1 (x86_64). It was a simple library naming problem.

If anyone wants me to try building something that depends on `expect`, let me know.
