### PR TITLE
haskellPackages: add list-tries

### DIFF
--- a/pkgs/development/libraries/haskell/list-tries/default.nix
+++ b/pkgs/development/libraries/haskell/list-tries/default.nix
@@ -1,0 +1,16 @@
+{ cabal, binary, dlist }:
+
+cabal.mkDerivation (self: {
+  pname = "list-tries";
+  version = "0.5.1";
+  sha256 = "15lbq41rikj5vm9gfgjxz98pamnib4dcs48fr2vm9r3s3fikd2kz";
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [ binary dlist ];
+  meta = {
+    homepage = "http://iki.fi/matti.niemenmaa/list-tries/";
+    description = "Tries and Patricia tries: finite sets and maps for list keys";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1384,6 +1384,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   List = callPackage ../development/libraries/haskell/List {};
 
+  list-tries = callPackage ../development/libraries/haskell/list-tries {};
+
   ListLike = callPackage ../development/libraries/haskell/ListLike {};
 
   ListZipper = callPackage ../development/libraries/haskell/ListZipper {};


### PR DESCRIPTION
via cabal2nix

I'm not sure if there's some naming convention for the haskell attributes.
