### PR TITLE
Pin 1.3.1 to R15B03, riak does not work with R16

### DIFF
--- a/pkgs/servers/nosql/riak/1.3.1.nix
+++ b/pkgs/servers/nosql/riak/1.3.1.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, erlang }:
+{ stdenv, fetchurl, unzip, erlangR15B03 }:
 
 let
   srcs = {
@@ -15,7 +15,7 @@ in
 stdenv.mkDerivation rec {
   name = "riak-1.3.1";
 
-  buildInputs = [unzip erlang];
+  buildInputs = [unzip erlangR15B03];
 
   src = srcs.riak;
 


### PR DESCRIPTION
I didn't specify the dependency hard enough originally.
