### PR TITLE
mkpasswd: Update to 5.0.26

### DIFF
--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   name = "mkpasswd-${version}";
 
-  version = "5.0.25";
+  version = "5.0.26";
 
   src = fetchurl {
     url = "http://ftp.debian.org/debian/pool/main/w/whois/whois_${version}.tar.xz";
-    sha256 = "0qb859vwd6g93cb5zbf19gpw2g2b9s1qlq4nqia1a966pjkvw1qj";
+    sha256 = "729625ef81425f4771e06492bb4f3e9f24bff75b8176044ce8d2f605f7ad6af5";
   };
 
   preConfigure = ''


### PR DESCRIPTION
The previous version (5.0.26) has been removed from the debian ftp.
As the source URL is now down, our own hydra (not hydra.nixos.org) failed to build the package.
This problem will occur again in the future since I only updated the URL without relying on a "more stable" alternative.
