### PR TITLE
Add support for additional Asciidoc filters

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -1,23 +1,76 @@
-{ fetchurl, stdenv, python }:
+{ fetchurl, stdenv, python
+, unzip ? null
+, enableDitaaFilter ? false, jre ? null
+, enableMscgenFilter ? false, mscgen ? null
+, enableDiagFilter ? false, blockdiag ? null, seqdiag ? null, actdiag ? null, nwdiag ? null
+}:
+
+assert (enableDitaaFilter || enableMscgenFilter || enableDiagFilter) -> unzip != null;
+assert enableDitaaFilter -> jre != null;
+assert enableMscgenFilter -> mscgen != null;
+assert enableDiagFilter -> blockdiag != null && seqdiag != null && actdiag != null && nwdiag != null;
+
+let
+  ditaaFilterSrc = fetchurl {
+    url = "https://asciidoc-ditaa-filter.googlecode.com/files/ditaa-filter-1.1.zip";
+    sha256 = "0p7hm2a1xywx982ia3vg4c0lam5sz0xknsc10i2a5vswy026naf6";
+  };
+
+  mscgenFilterSrc = fetchurl {
+    url = "https://asciidoc-mscgen-filter.googlecode.com/files/mscgen-filter-1.2.zip";
+    sha256 = "1nfwmj375gpv5dn9i770pjv59aihzy2kja0fflsk96xwnlqsqq61";
+  };
+
+  diagFilterSrc = fetchurl {
+    # unfortunately no version number
+    url = "https://asciidoc-diag-filter.googlecode.com/files/diag_filter.zip";
+    sha256 = "1qlqrdbqkdqqgfdhjsgdws1al0sacsyq6jmwxdfy7r8k7bv7n7mm";
+  };
+
+in
 
 stdenv.mkDerivation rec {
   name = "asciidoc-8.6.8";
+
   src = fetchurl {
     url = "mirror://sourceforge/asciidoc/${name}.tar.gz";
     sha256 = "ffb67f59dccaf6f15db72fcd04fdf21a2f9b703d31f94fcd0c49a424a9fcfbc4";
   };
 
-  patchPhase = ''
-    for n in `find . -name \*.py `; do
-      sed -i -e "s,^#!/usr/bin/env python,#!${python}/bin/python,g" "$n"
+  buildInputs = [ python unzip ];
+
+  # install filters early, so their shebangs are patched too
+  patchPhase = with stdenv.lib; ''
+    mkdir -p "$out/etc/asciidoc/filters"
+  '' + optionalString enableDitaaFilter ''
+    echo "Extracting ditaa filter"
+    unzip -d "$out/etc/asciidoc/filters/ditaa" "${ditaaFilterSrc}"
+    sed -i -e "s|java -jar|${jre}/bin/java -jar|" \
+        "$out/etc/asciidoc/filters/ditaa/ditaa2img.py"
+  '' + optionalString enableMscgenFilter ''
+    echo "Extracting mscgen filter"
+    unzip -d "$out/etc/asciidoc/filters/mscgen" "${mscgenFilterSrc}"
+    sed -i -e "s|filter-wrapper.py mscgen|filter-wrapper.py ${mscgen}/bin/mscgen|" \
+        "$out/etc/asciidoc/filters/mscgen/mscgen-filter.conf"
+  '' + optionalString enableDiagFilter ''
+    echo "Extracting diag filter"
+    unzip -d "$out/etc/asciidoc/filters/diag" "${diagFilterSrc}"
+    sed -i \
+        -e "s|filter='blockdiag|filter=\'${blockdiag}/bin/blockdiag|" \
+        -e "s|filter='seqdiag|filter=\'${seqdiag}/bin/seqdiag|" \
+        -e "s|filter='actdiag|filter=\'${actdiag}/bin/actdiag|" \
+        -e "s|filter='nwdiag|filter=\'${nwdiag}/bin/nwdiag|" \
+        -e "s|filter='packetdiag|filter=\'${nwdiag}/bin/packetdiag|" \
+        "$out/etc/asciidoc/filters/diag/diag-filter.conf"
+  '' + ''
+    for n in $(find "$out" . -name \*.py); do
+      sed -i -e "s,^#![[:space:]]*/usr/bin/env python,#!${python}/bin/python,g" "$n"
       chmod +x "$n"
     done
     sed -i -e "s,/etc/vim,,g" Makefile.in
   '';
 
   preInstall = "mkdir -p $out/etc/vim";
-
-  buildInputs = [ python ];
 
   meta = {
     homepage = "http://www.methods.co.nz/asciidoc/";

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -3,9 +3,10 @@
 , enableDitaaFilter ? false, jre ? null
 , enableMscgenFilter ? false, mscgen ? null
 , enableDiagFilter ? false, blockdiag ? null, seqdiag ? null, actdiag ? null, nwdiag ? null
+, enableQrcodeFilter ? false, qrencode ? null
 }:
 
-assert (enableDitaaFilter || enableMscgenFilter || enableDiagFilter) -> unzip != null;
+assert (enableDitaaFilter || enableMscgenFilter || enableDiagFilter || enableQrcodeFilter) -> unzip != null;
 assert enableDitaaFilter -> jre != null;
 assert enableMscgenFilter -> mscgen != null;
 assert enableDiagFilter -> blockdiag != null && seqdiag != null && actdiag != null && nwdiag != null;
@@ -25,6 +26,11 @@ let
     # unfortunately no version number
     url = "https://asciidoc-diag-filter.googlecode.com/files/diag_filter.zip";
     sha256 = "1qlqrdbqkdqqgfdhjsgdws1al0sacsyq6jmwxdfy7r8k7bv7n7mm";
+  };
+
+  qrcodeFilterSrc = fetchurl {
+    url = "https://asciidoc-qrencode-filter.googlecode.com/files/qrcode-filter-1.0.zip";
+    sha256 = "0h4bql1nb4y4fmg2yvlpfjhvy22ln8jsaxdr10f8bfcg5lr0zkxs";
   };
 
 in
@@ -62,6 +68,11 @@ stdenv.mkDerivation rec {
         -e "s|filter='nwdiag|filter=\'${nwdiag}/bin/nwdiag|" \
         -e "s|filter='packetdiag|filter=\'${nwdiag}/bin/packetdiag|" \
         "$out/etc/asciidoc/filters/diag/diag-filter.conf"
+  '' + optionalString enableQrcodeFilter ''
+    echo "Extracting qrcode filter"
+    unzip -d "$out/etc/asciidoc/filters/qrcode" "${qrcodeFilterSrc}"
+    sed -i -e "s|systemcmd('qrencode|systemcmd('${qrencode}/bin/qrencode|" \
+        "$out/etc/asciidoc/filters/qrcode/qrcode2img.py"
   '' + ''
     for n in $(find "$out" . -name \*.py); do
       sed -i -e "s,^#![[:space:]]*/usr/bin/env python,#!${python}/bin/python,g" "$n"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -519,6 +519,8 @@ let
 
   bfr = callPackage ../tools/misc/bfr { };
 
+  blockdiag = pythonPackages.blockdiag;
+
   bmon = callPackage ../tools/misc/bmon { };
 
   boomerang = callPackage ../development/tools/boomerang {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1403,6 +1403,8 @@ let
 
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
+  nwdiag = pythonPackages.nwdiag;
+
   nylon = callPackage ../tools/networking/nylon { };
 
   nzbget = callPackage ../tools/networking/nzbget { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -395,6 +395,8 @@ let
   acoustidFingerprinter = callPackage
     ../tools/audio/acoustid-fingerprinter { };
 
+  actdiag = pythonPackages.actdiag;
+
   aefs = callPackage ../tools/filesystems/aefs { };
 
   aespipe = callPackage ../tools/security/aespipe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1709,6 +1709,8 @@ let
     inherit groff;
   };
 
+  seqdiag = pythonPackages.seqdiag;
+
   sg3_utils = callPackage ../tools/system/sg3_utils { };
 
   sharutils = callPackage ../tools/archivers/sharutils { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -563,7 +563,7 @@ let
   mcelog = callPackage ../os-specific/linux/mcelog { };
 
   asciidoc = callPackage ../tools/typesetting/asciidoc {
-    inherit (pythonPackages) matplotlib numpy;
+    inherit (pythonPackages) matplotlib numpy aafigure recursivePthLoader;
   };
 
   autossh = callPackage ../tools/networking/autossh { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -562,7 +562,9 @@ let
 
   mcelog = callPackage ../os-specific/linux/mcelog { };
 
-  asciidoc = callPackage ../tools/typesetting/asciidoc { };
+  asciidoc = callPackage ../tools/typesetting/asciidoc {
+    inherit (pythonPackages) matplotlib numpy;
+  };
 
   autossh = callPackage ../tools/networking/autossh { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -131,6 +131,31 @@ pythonPackages = modules // import ./python-packages-generated.nix {
 
   # packages defined here
 
+  actdiag = buildPythonPackage rec {
+    name = "actdiag-0.4.3";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/a/actdiag/${name}.tar.gz";
+      md5 = "428aaab849f04668fa12388b964a56ea";
+    };
+
+    buildInputs = [ pep8 nose unittest2 docutils ];
+
+    propagatedBuildInputs = [ blockdiag ];
+
+    # One test fails, because of missing simple.diag input file
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      description = "Generate activity-diagram image from spec-text file (similar to Graphviz)";
+      homepage = http://blockdiag.com/;
+      license = licenses.asl20;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   afew = buildPythonPackage rec {
     rev = "6bb3915636aaf86f046a017ffffd9a4ef395e199";
     name = "afew-1.0_${rev}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3618,6 +3618,32 @@ pythonPackages = modules // import ./python-packages-generated.nix {
     };
   });
 
+
+  nwdiag = buildPythonPackage rec {
+    name = "nwdiag-0.9.4";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/n/nwdiag/${name}.tar.gz";
+      md5 = "199b22f66ec3012c3999177d376a3842";
+    };
+
+    buildInputs = [ pep8 nose unittest2 docutils ];
+
+    propagatedBuildInputs = [ blockdiag ];
+
+    # tests fail
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      description = "Generate network-diagram image from spec-text file (similar to Graphviz)";
+      homepage = http://blockdiag.com/;
+      license = licenses.asl20;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   oauth2 = buildPythonPackage (rec {
     name = "oauth2-1.5.211";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -131,6 +131,36 @@ pythonPackages = modules // import ./python-packages-generated.nix {
 
   # packages defined here
 
+  aafigure = buildPythonPackage rec {
+    name = "aafigure-0.5";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/a/aafigure/${name}.tar.gz";
+      md5 = "5322888a21eb0bb2e749fbf98eddf574";
+    };
+
+    propagatedBuildInputs = [ pillow ];
+
+    # error: invalid command 'test'
+    doCheck = false;
+
+    # Fix impurity. TODO: Do the font lookup using fontconfig instead of this
+    # manual method. Until that is fixed, we get this whenever we run aafigure:
+    #   WARNING: font not found, using PIL default font
+    patchPhase = ''
+      sed -i "s|/usr/share/fonts|/nonexisting-fonts-path|" aafigure/PILhelper.py
+    '';
+
+    meta = with stdenv.lib; {
+      description = "ASCII art to image converter";
+      homepage = https://launchpad.net/aafigure/;
+      license = licenses.bsd2;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   actdiag = buildPythonPackage rec {
     name = "actdiag-0.4.3";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5165,6 +5165,33 @@ pythonPackages = modules // import ./python-packages-generated.nix {
   };
 
 
+  seqdiag = buildPythonPackage rec {
+    name = "seqdiag-0.8.2";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/s/seqdiag/${name}.tar.gz";
+      md5 = "61b3da29b5efaa89701b4db6d2d4d5fa";
+    };
+
+    buildInputs = [ pep8 nose unittest2 docutils ];
+
+    propagatedBuildInputs = [ blockdiag ];
+
+    # Some tests fail (because of missing input files?):
+    #   ...
+    #   IOError: [Errno 2] No such file or directory: '/tmp/nix-build-python2.7-seqdiag-0.8.2.drv-0/seqdiag-0.8.2/src/seqdiag/tests/diagrams/separators.diag'
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      description = "Generate sequence-diagram image from spec-text file (similar to Graphviz)";
+      homepage = http://blockdiag.com/;
+      license = licenses.asl20;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   scipy = buildPythonPackage rec {
     name = "scipy-0.9.0";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -491,6 +491,34 @@ pythonPackages = modules // import ./python-packages-generated.nix {
     };
   };
 
+
+  blockdiag = buildPythonPackage rec {
+    name = "blockdiag-1.2.4";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/b/blockdiag/${name}.tar.gz";
+      md5 = "244334f60cc10b0cb73b5df5279bcdd1";
+    };
+
+    buildInputs = [ pep8 nose unittest2 docutils ];
+
+    propagatedBuildInputs = [ pil webcolors funcparserlib ];
+
+    # One test fails:
+    #   ...
+    #   FAIL: test_auto_font_detection (blockdiag.tests.test_boot_params.TestBootParams)
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      description = "Generate block-diagram image from spec-text file (similar to Graphviz)";
+      homepage = http://blockdiag.com/;
+      license = licenses.asl20;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   bpython = buildPythonPackage rec {
      name = "bpython-0.12";
      src = fetchurl {
@@ -1258,6 +1286,24 @@ pythonPackages = modules // import ./python-packages-generated.nix {
     buildInputs = [ nose nosejs ];
     propagatedBuildInputs = [ sphinx ];
   };
+
+
+  funcparserlib = buildPythonPackage rec {
+    name = "funcparserlib-0.3.6";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/f/funcparserlib/${name}.tar.gz";
+      md5 = "3aba546bdad5d0826596910551ce37c0";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Recursive descent parsing library based on functional combinators";
+      homepage = https://code.google.com/p/funcparserlib/;
+      license = licenses.mit;
+      platforms = platforms.linux;
+    };
+  };
+
 
   googlecl = buildPythonPackage rec {
     version = "0.9.14";
@@ -5974,6 +6020,27 @@ pythonPackages = modules // import ./python-packages-generated.nix {
        platforms = stdenv.lib.platforms.all;
     };
   };
+
+
+  webcolors = buildPythonPackage rec {
+    name = "webcolors-1.4";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/w/webcolors/${name}.tar.gz";
+      md5 = "35de9d785b5c04a9cc66a2eae0519254";
+    };
+
+    # error: invalid command 'test'
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      description = "Library for working with color names/values defined by the HTML and CSS specifications";
+      homepage = https://bitbucket.org/ubernostrum/webcolors/overview/;
+      license = licenses.bsd3;
+      platforms = platforms.linux;
+    };
+  };
+
 
   webob = buildPythonPackage rec {
     version = "1.2.3";


### PR DESCRIPTION
This adds support for some extra filters for Asciidoc:
- ditaa
- mscgen
- diag (includes blockdiag, seqdiag, actdiag, nwdiag)
- qrcode
- matplotlib
- aafigure

For more info, see commit messages.
