### PR TITLE
add the mpc (mpd cli client) package

### DIFF
--- a/pkgs/applications/audio/mpc/default.nix
+++ b/pkgs/applications/audio/mpc/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, mpd_clientlib }:
+
+stdenv.mkDerivation rec {
+  version = "0.23";
+  name = "mpc-${version}";
+
+  src = fetchurl {
+    url = "http://www.musicpd.org/download/mpc/0/${name}.tar.bz2";
+    sha256 = "1ir96wfgq5qfdd2s06zfycv38g3bhn3bpndwx9hwf1w507rvifi9";
+  };
+	
+  buildInputs = [ mpd_clientlib ]; 
+  
+  preConfigure =
+    ''
+      export LIBMPDCLIENT_LIBS=${mpd_clientlib}/lib/libmpdclient.so.2.0.8
+      export LIBMPDCLIENT_CFLAGS=${mpd_clientlib}
+    '';
+
+  meta = {
+    description = "A minimalist command line interface to MPD";
+    homepage = http://www.musicpd.org/clients/mpc/;
+    license = "GPL2";
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/mpc/default.nix
+++ b/pkgs/applications/audio/mpc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   
   preConfigure =
     ''
-      export LIBMPDCLIENT_LIBS=${mpd_clientlib}/lib/libmpdclient.so.2.0.8
+      export LIBMPDCLIENT_LIBS=${mpd_clientlib}/lib/libmpdclient.so.${mpd_clientlib.majorVersion}.0.${mpd_clientlib.minorVersion}
       export LIBMPDCLIENT_CFLAGS=${mpd_clientlib}
     '';
 
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     description = "A minimalist command line interface to MPD";
     homepage = http://www.musicpd.org/clients/mpc/;
     license = "GPL2";
+    maintainers = [ stdenv.lib.maintainers.algorith ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/lib/maintainers.nix
+++ b/pkgs/lib/maintainers.nix
@@ -5,6 +5,7 @@
      alphabetically sorted.  */
 
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
+  algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
   amiddelk = "Arie Middelkoop <amiddelk@gmail.com>";
   amorsillo = "Andrew Morsillo <andrew.morsillo@gmail.com>";

--- a/pkgs/servers/mpd/clientlib.nix
+++ b/pkgs/servers/mpd/clientlib.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchurl, doxygen }:
 
 stdenv.mkDerivation rec {
-
-
   version = "${passthru.majorVersion}.${passthru.minorVersion}";
   name = "libmpdclient-${version}";
 

--- a/pkgs/servers/mpd/clientlib.nix
+++ b/pkgs/servers/mpd/clientlib.nix
@@ -1,14 +1,22 @@
 { stdenv, fetchurl, doxygen }:
 
 stdenv.mkDerivation rec {
-  version = "2.8";
+
+
+  version = "${passthru.majorVersion}.${passthru.minorVersion}";
   name = "libmpdclient-${version}";
+
   src = fetchurl {
     url = "http://www.musicpd.org/download/libmpdclient/2/${name}.tar.bz2";
     sha256 = "1qwjkb56rsbk0hwhg7fl15d6sf580a19gh778zcdg374j4yym3hh";
   };
 
   buildInputs = [ doxygen ];
+
+  passthru = {
+    majorVersion = "2";
+    minorVersion = "8";
+  };
 
   meta = {
     description = "Client library for MPD (music player daemon)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8181,6 +8181,8 @@ let
   mpg123 = callPackage ../applications/audio/mpg123 { };
 
   mpg321 = callPackage ../applications/audio/mpg321 { };
+  
+  mpc_cli = callPackage ../applications/audio/mpc { };
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 


### PR DESCRIPTION
- the package name 'mpc' was already spoken for in all-packages.nix, so I settled on 'mpc_cli'.
- I suspect the preConfigure expression can be written in a better manner, but it's currently beyond my capabilities to do so myself. That expression is necessary in order to successfully compile the package, so it can't simply be omitted.
