### PR TITLE
asciidoc: add missing dependency on sourceHighlight/highlight/pygments

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, python
+{ fetchurl, stdenv, python, sourceHighlight, highlight, pygments
 , unzip ? null
 # filters
 , enableDitaaFilter ? false, jre ? null
@@ -139,6 +139,13 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = "mkdir -p $out/etc/vim";
+
+  postInstall = ''
+    sed -e 's|filter="source-highlight|filter="${sourceHighlight}/bin/source-highlight|' \
+        -e 's|filter="highlight|filter="${highlight}/bin/highlight|' \
+        -e 's|filter="pygmentize|filter="${pygments}/bin/pygmentize|' \
+        -i "$out/etc/asciidoc/filters/source/source-highlight-filter.conf"
+  '';
 
   meta = {
     homepage = "http://www.methods.co.nz/asciidoc/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -563,7 +563,8 @@ let
   mcelog = callPackage ../os-specific/linux/mcelog { };
 
   asciidoc = callPackage ../tools/typesetting/asciidoc {
-    inherit (pythonPackages) matplotlib numpy aafigure recursivePthLoader;
+    inherit (pythonPackages) matplotlib numpy aafigure recursivePthLoader
+                             pygments;
   };
 
   autossh = callPackage ../tools/networking/autossh { };


### PR DESCRIPTION
Without this asciidoc will fail when it tries to highlight source code
listings. It increases the closure size from 255 MiB to 438 MiB though
(mostly because of boost).

Discussion:
I'm unsure of what is the best way to handle this dependency. I see a few options:
1. Leave as is (i.e. don't merge this). Currently you get an error message if trying to highlight source code listings, and you have to install one or more of the above dependencies yourself.
2. Add this behind an "enableSourceFilter" parameter. If true, install dependencies, else behave as today.
3. Accept that the source highlight filter is a part of asciidoc (it comes with the source archive), and add the dependencies unconditionally (like this pull does)

Comments?
