### PR TITLE
pytest: fix `py` not found error, add selenium

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1074,7 +1074,7 @@ pythonPackages = modules // import ./python-packages-generated.nix {
       md5 = "18f150e7be96b5fe3c388b0e817b8087";
     };
 
-    buildInputs = [ py ];
+    propagatedBuildInputs = [ pythonPackages.py ];
 
     meta = {
       maintainers = [ stdenv.lib.maintainers.iElectric ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1074,10 +1074,14 @@ pythonPackages = modules // import ./python-packages-generated.nix {
       md5 = "18f150e7be96b5fe3c388b0e817b8087";
     };
 
-    propagatedBuildInputs = [ pythonPackages.py ];
+    propagatedBuildInputs = [ pythonPackages.py ]
+      ++ stdenv.lib.optional
+        pkgs.config.pythonPackages.pytest.selenium
+        pythonPackages.selenium;
 
-    meta = {
-      maintainers = [ stdenv.lib.maintainers.iElectric ];
+    meta = with stdenv.lib; {
+      maintainers = with maintainers; [ iElectric lovek323 ];
+      platforms   = platforms.unix;
     };
   };
 
@@ -5341,7 +5345,11 @@ pythonPackages = modules // import ./python-packages-generated.nix {
         cp "${x_ignore_nofocus}/"* .
         sed -i 's|dlopen(library,|dlopen("libX11.so.6",|' x_ignore_nofocus.c
         gcc -c -fPIC x_ignore_nofocus.c -o x_ignore_nofocus.o
-        gcc -shared -Wl,-soname,x_ignore_nofocus.so -o x_ignore_nofocus.so  x_ignore_nofocus.o
+        gcc -shared \
+          -Wl,${if stdenv.isDarwin then "-install_name" else "-soname"},x_ignore_nofocus.so \
+          -o x_ignore_nofocus.so \
+          x_ignore_nofocus.o \
+          ${if stdenv.isDarwin then "-lx11" else ""}
         cp -v x_ignore_nofocus.so py/selenium/webdriver/firefox/${if pkgs.stdenv.is64bit then "amd64" else "x86"}/
       '';
     };


### PR DESCRIPTION
I've fixed a `pkg_resources.DistributionNotFound: py>=1.4.13dev6` error and added selenium as an optional propagated input so people can use the selenium web driver with this.

I've also fixed the `selenium` builder on darwin.

If there's a better way to get this happening, I'm happy to hear it.
