### PR TITLE
kernel: move XFS_FS to extra kernel config, add additional platform with USER_NS support

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -148,9 +148,6 @@ with stdenv.lib;
   REISERFS_FS_SECURITY y
   JFS_POSIX_ACL y
   JFS_SECURITY y
-  XFS_QUOTA y
-  XFS_POSIX_ACL y
-  XFS_RT y # XFS Realtime subvolume support
   OCFS2_DEBUG_MASKLOG n
   BTRFS_FS_POSIX_ACL y
   UBIFS_FS_XATTR? y

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -10,10 +10,25 @@ rec {
     # Currently ignored - it should be set according to 'system' once it is
     # not ignored. This is for stdenv-updates.
     kernelArch = "i386";
+    kernelExtraConfig =
+      ''
+        # Move to common-config when XFS will support USER_NS
+        XFS_QUOTA y
+        XFS_POSIX_ACL y
+        XFS_RT y # XFS Realtime subvolume support
+      '';
   };
 
   pc_simplekernel = pc // {
     kernelAutoModules = false;
+  };
+
+  pc_userns = pc // {
+    kernelExtraConfig =
+      ''
+        XFS_FS n
+        USER_NS y
+      '';
   };
 
   sheevaplug = {


### PR DESCRIPTION
With XFS_FS enabled USER_NS can't be enabled. We need user namespaces for example for chromium sandbox to work and for fully isolated linux containers.

I put XFS_FS to kernelExtraConfig until XFS_FS will not support user namespaces. I also added additional platform with enabled user namespaces.

If there is any nicer better way please let me know.
