### PR TITLE
kernel: add linux 3.12-rc2

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -169,6 +169,9 @@ with stdenv.lib;
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default
   DEVKMEM n # Disable /dev/kmem
   CC_STACKPROTECTOR y # Detect buffer overflows on the stack
+  ${optionalString (versionAtLeast version "3.12") ''
+    USER_NS y # Support for user namespaces
+  ''}
 
   # Misc. options.
   8139TOO_8129 y

--- a/pkgs/os-specific/linux/kernel/linux-3.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.12.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "3.12-rc2";
+
+  src = fetchurl {
+    url = "https://www.kernel.org/pub/linux/kernel/v3.0/testing/linux-${version}.tar.gz";
+    sha256 = "1m24fh3cwmkb1scn3sl7gbc50jl53v357kjpgda9avi3ljxmyq5z";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6554,6 +6554,19 @@ let
       ];
   };
 
+  linux_3_12 = makeOverridable (import ../os-specific/linux/kernel/linux-3.12.nix) {
+    inherit fetchurl stdenv perl mktemp bc kmod ubootChooser;
+    kernelPatches =
+      [
+        kernelPatches.sec_perm_2_6_24
+      ] ++ lib.optionals (platform.kernelArch == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
+
   /* Linux kernel modules are inherently tied to a specific kernel.  So
      rather than provide specific instances of those packages for a
      specific kernel, we have a function that builds those packages
@@ -6676,6 +6689,7 @@ let
   linuxPackages_3_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_9 linuxPackages_3_9);
   linuxPackages_3_10 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_10 linuxPackages_3_10);
   linuxPackages_3_11 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_11 linuxPackages_3_11);
+  linuxPackages_3_12 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_12 linuxPackages_3_12);
   # Update this when adding a new version!
   linuxPackages_latest = pkgs.linuxPackages_3_11;
 


### PR DESCRIPTION
I know this kernel is not released yet, but i need user namespaces support. I didn't update linuxPackages_latest, because we probably want to wait for release.
USER_NS is pretty basic option (especially chromium users will be happy with sandbox), that's why i put it in common-config.
