### PR TITLE
vimPlugins.YouCompleteMe: update to ee12530df0

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, python, cmake, vim, perl, ruby, unzip }:
+{ fetchurl, fetchgit, stdenv, python, cmake, vim, perl, ruby, unzip }:
 
 /*
 About Vim and plugins
@@ -110,10 +110,13 @@ in
   };
 
   YouCompleteMe = stdenv.mkDerivation {
-    # REGION AUTO UPDATE: { name="youcompleteme"; type="git"; url="git://github.com/Valloric/YouCompleteMe"; }
-    src = (fetchurl { url = "http://mawercer.de/~nix/repos/youcompleteme-git-97306.tar.bz2"; sha256 = "b9b892f5a723370c2034491dc72a4ca722c6cf1e5de4d60501141bba151bc719"; });
-    name = "youcompleteme-git-97306";
-    # END
+    src = fetchgit {
+      url = "https://github.com/Valloric/YouCompleteMe.git";
+      rev = "ee12530df0574e18289d6daf25ff72bd3c6e94f5";
+      sha256 = "1z93l2v0s078h632jrlhxzs9pg8phnx60qlrrhb3l2nbfk047rgx";
+    };
+
+    name = "youcompleteme-git-ee12530df0";
     buildInputs = [ python cmake ];
 
     configurePhase = ":";


### PR DESCRIPTION
This fixes YouCompleteMe to work with latest vim.

I also removed dependency on MarcWeber's nix-repository-manager used for updating, because i don't think it's good to depend on somebody's private repos.
