### PR TITLE
Disable introspection for gcr.

### DIFF
--- a/pkgs/desktops/gnome-3/core/gcr/default.nix
+++ b/pkgs/desktops/gnome-3/core/gcr/default.nix
@@ -14,5 +14,7 @@ stdenv.mkDerivation rec {
     libgcrypt libtasn1 dbus_glib gtk pango gdk_pixbuf atk
   ];
 
+  configureFlags = "--disable-introspection";
+
   #doCheck = true;
 }


### PR DESCRIPTION
gcr stopped building after 7fbcc562 (adding introspection into GTK
libs); this gets it to build again.
