### PR TITLE
asciidoc: add missing dependencies

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -24,7 +24,10 @@ stdenv.mkDerivation rec{
   '';
 
   postInstall = ''
-     for f in $out/bin/*; do wrapProgram $f --set GUILE_AUTO_COMPILE 0; done
+    for f in "$out"/bin/*; do
+        wrapProgram "$f" --set GUILE_AUTO_COMPILE 0 \
+                         --set PATH "${ghostscript}/bin"
+    done
   '';
 
   configureFlags = [ "--disable-documentation" "--with-ncsb-dir=${urwfonts}"];

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -1,4 +1,25 @@
 { fetchurl, stdenv, python
+
+, enableStandardFeatures ? true
+, sourceHighlight ? null
+, highlight ? null
+, pygments ? null
+, graphviz ? null
+, tetex ? null
+, dblatex ? null
+, libxslt ? null
+, w3m ? null
+, lynx ? null
+, imagemagick ? null
+, lilypond ? null
+, libxml2 ? null
+, docbook_xml_dtd_45 ? null
+, docbook5_xsl ? null
+, docbook_xsl ? null
+, fop ? null
+# TODO: Package this:
+#, epubcheck ? null
+
 , unzip ? null
 # filters
 , enableDitaaFilter ? false, jre ? null
@@ -11,6 +32,26 @@
 , enableDeckjsBackend ? false
 , enableOdfBackend ? false
 }:
+
+assert enableStandardFeatures ->
+  sourceHighlight != null &&
+  highlight != null &&
+  pygments != null &&
+  graphviz != null &&
+  tetex != null &&
+  dblatex != null &&
+  libxslt != null &&
+  w3m != null &&
+  lynx != null &&
+  imagemagick != null &&
+  lilypond != null &&
+  libxml2 != null &&
+  docbook_xml_dtd_45 != null &&
+  docbook5_xsl != null &&
+  docbook_xsl != null &&
+  fop != null;
+# TODO: Package this:
+#  epubcheck != null;
 
 # filters
 assert (enableDitaaFilter || enableMscgenFilter || enableDiagFilter || enableQrcodeFilter || enableAafigureFilter) -> unzip != null;
@@ -49,7 +90,7 @@ let
     sha256 = "0h4bql1nb4y4fmg2yvlpfjhvy22ln8jsaxdr10f8bfcg5lr0zkxs";
   };
 
-  # latest commit in master branch as per 2013-09-22
+  # there are no archives or tags, using latest commit in master branch as per 2013-09-22
   matplotlibFilterSrc = let commit = "75f0d009629f93f33fab04b83faca20cc35dd358"; in fetchurl rec {
     name = "mplw-${commit}.tar.gz";
     url = "https://api.github.com/repos/lvv/mplw/tarball/${commit}";
@@ -151,11 +192,48 @@ stdenv.mkDerivation rec {
     # the odp backend already has that fix. Copy it here until fixed upstream.
     sed -i "s|'/etc/asciidoc/backends/odt/asciidoc.ott'|os.path.dirname(__file__),'asciidoc.ott'|" \
         "$out/etc/asciidoc/backends/odt/a2x-backend.py"
+  '' + optionalString enableStandardFeatures ''
+    sed -e "s|dot|${graphviz}/bin/dot|g" \
+        -e "s|neato|${graphviz}/bin/neato|g" \
+        -e "s|twopi|${graphviz}/bin/circo|g" \
+        -e "s|circo|${graphviz}/bin/circo|g" \
+        -e "s|fdp|${graphviz}/bin/fdp|g" \
+        -i "filters/graphviz/graphviz2png.py"
+
+    sed -e "s|run('latex|run('${tetex}/bin/latex|g" \
+        -e "s|cmd = 'dvipng'|cmd = '${tetex}/bin/dvipng'|g" \
+        -i "filters/latex/latex2png.py"
+
+    sed -e "s|run('abc2ly|run('${lilypond}/bin/abc2ly|g" \
+        -e "s|run('lilypond|run('${lilypond}/bin/lilypond|g" \
+        -e "s|run('convert|run('${imagemagick}/bin/convert|g" \
+        -i "filters/music/music2png.py"
+
+    sed -e 's|filter="source-highlight|filter="${sourceHighlight}/bin/source-highlight|' \
+        -e 's|filter="highlight|filter="${highlight}/bin/highlight|' \
+        -e 's|filter="pygmentize|filter="${pygments}/bin/pygmentize|' \
+        -i "filters/source/source-highlight-filter.conf"
+
+    # ENV is custom environment passed to programs that a2x invokes. Here we
+    # use it to work around an impurity in the tetex package; tetex tools
+    # cannot find their neighbours (e.g. pdflatex doesn't find mktextfm).
+    # We can remove PATH= when those impurities are fixed.
+    sed -e "s|^ENV =.*|ENV = dict(XML_CATALOG_FILES='${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook5_xsl}/xml/xsl/docbook/catalog.xml ${docbook_xsl}/xml/xsl/docbook/catalog.xml', PATH='${tetex}/bin')|" \
+        -e "s|^ASCIIDOC =.*|ASCIIDOC = '$out/bin/asciidoc'|" \
+        -e "s|^XSLTPROC =.*|XSLTPROC = '${libxslt}/bin/xsltproc'|" \
+        -e "s|^DBLATEX =.*|DBLATEX = '${dblatex}/bin/dblatex'|" \
+        -e "s|^FOP =.*|FOP = '${fop}/bin/fop'|" \
+        -e "s|^W3M =.*|W3M = '${w3m}/bin/w3m'|" \
+        -e "s|^LYNX =.*|LYNX = '${lynx}/bin/lynx'|" \
+        -e "s|^XMLLINT =.*|XMLLINT = '${libxml2}/bin/xmllint'|" \
+        -e "s|^EPUBCHECK =.*|EPUBCHECK = 'nixpkgs_is_missing_epubcheck'|" \
+        -i a2x.py
   '' + ''
     for n in $(find "$out" . -name \*.py); do
       sed -i -e "s,^#![[:space:]]*.*/bin/env python,#!${python}/bin/python,g" "$n"
       chmod +x "$n"
     done
+
     sed -i -e "s,/etc/vim,,g" Makefile.in
   '';
 

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -161,14 +161,21 @@ stdenv.mkDerivation rec {
 
   preInstall = "mkdir -p $out/etc/vim";
 
-  meta = {
-    homepage = "http://www.methods.co.nz/asciidoc/";
-    description = "ASCII text-based document generation system";
-    license = "GPLv2+";
-
+  meta = with stdenv.lib; {
+    description = "Text-based document generation system";
     longDescription = ''
-      AsciiDoc is a text-based document generation system.  AsciiDoc
-      input files can be translated to HTML and DocBook markups.
+      AsciiDoc is a text document format for writing notes, documentation,
+      articles, books, ebooks, slideshows, web pages, man pages and blogs.
+      AsciiDoc files can be translated to many formats including HTML, PDF,
+      EPUB, man page.
+
+      AsciiDoc is highly configurable: both the AsciiDoc source file syntax and
+      the backend output markups (which can be almost any type of SGML/XML
+      markup) can be customized and extended by the user.
     '';
+    homepage = "http://www.methods.co.nz/asciidoc/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -1,0 +1,56 @@
+{ fetchurl, stdenv, ant, jdk }:
+
+stdenv.mkDerivation rec {
+  name = "fop-1.1";
+
+  src = fetchurl {
+    url = "http://apache.uib.no/xmlgraphics/fop/source/${name}-src.tar.gz";
+    sha256 = "08i56d57w5dl5bqchr34x9165hvi5h4bhiflxhi0a4wd56rlq5jq";
+  };
+
+  buildInputs = [ ant jdk ];
+
+  buildPhase = ''
+    ant
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/lib"
+    mkdir -p "$out/share/doc/fop"
+
+    cp build/*.jar lib/*.jar "$out/lib/"
+    cp -r README examples/ "$out/share/doc/fop/"
+
+    # There is a fop script in the source archive, but it has many impurities.
+    # Instead of patching out 90 % of the script, we write our own.
+    cat > "$out/bin/fop" <<EOF
+    #!${stdenv.shell}
+    java_exec_args="-Djava.awt.headless=true"
+    # Note the wildcard; it will be passed to java and java will expand it
+    LOCALCLASSPATH="$out/lib/*"
+    exec "${jdk}/bin/java" \$java_exec_args -classpath "\$LOCALCLASSPATH" org.apache.fop.cli.Main "\$@"
+    EOF
+    chmod a+x "$out/bin/fop"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "XML formatter driven by XSL Formatting Objects (XSL-FO)";
+    longDescription = ''
+      FOP is a Java application that reads a formatting object tree and then
+      turns it into a wide variety of output presentations (including AFP, PCL,
+      PDF, PNG, PostScript, RTF, TIFF, and plain text), or displays the result
+      on-screen.
+
+      The formatting object tree can be in the form of an XML document (output
+      by an XSLT engine like xalan) or can be passed in memory as a DOM
+      Document or (in the case of xalan) SAX events.
+
+      This package contains the fop command line tool.
+    '';
+    homepage = http://xmlgraphics.apache.org/fop/;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, python, libxslt, tetex }:
+{ stdenv, fetchurl, python, libxslt, tetex, imagemagick, transfig, inkscape
+, fontconfig, ghostscript }:
 
 stdenv.mkDerivation rec {
   name = "dblatex-0.3.4";
@@ -8,14 +9,37 @@ stdenv.mkDerivation rec {
     sha256 = "120w3wm07qx0k1grgdhjwm2vpwil71icshjvqznskp1f6ggch290";
   };
 
+  buildInputs = [ python libxslt tetex imagemagick transfig ];
+
+  # TODO: dblatex tries to execute texindy command, but nixpkgs doesn't have
+  # that yet. In Ubuntu, texindy is a part of the xindy package.
+  preConfigure = ''
+    for file in $(find -name "*.py"); do
+        sed -e 's|cmd = \["xsltproc|cmd = \["${libxslt}/bin/xsltproc|g' \
+            -e 's|Popen(\["xsltproc|Popen(\["${libxslt}/bin/xsltproc|g' \
+            -e 's|cmd = "convert|cmd = "${imagemagick}/bin/convert|g' \
+            -e 's|cmd = "fig2dev|cmd = "${transfig}/bin/fig2dev|g' \
+            -e 's|cmd = \["texindy|cmd = ["nixpkgs_is_missing_texindy|g' \
+            -e 's|cmd = \["ps2pdf|cmd = ["${ghostscript}/bin/ps2pdf|g' \
+            -e 's|cmd = "inkscape|cmd = "${inkscape}/bin/inkscape|g' \
+            -e 's|cmd = "epstopdf|cmd = "${tetex}/bin/epstopdf|g' \
+            -e 's|cmd = \["makeindex|cmd = ["${tetex}/bin/makeindex|g' \
+            -e 's|doc.program = "pdflatex"|doc.program = "${tetex}/bin/pdflatex"|g' \
+            -e 's|self.program = "latex"|self.program = "${tetex}/bin/latex"|g' \
+            -e 's|Popen("pdflatex|Popen("${tetex}/bin/pdflatex|g' \
+            -e 's|"fc-match"|"${fontconfig}/bin/fc-match"|g' \
+            -e 's|"fc-list"|"${fontconfig}/bin/fc-list"|g' \
+            -i "$file"
+    done
+
+    sed -i 's|self.install_layout == "deb"|False|' setup.py
+  '';
+
   buildPhase = "true";
   
   installPhase = ''
-    sed -i 's|self.install_layout == "deb"|False|' setup.py
-    python ./setup.py install --prefix=$out
+    python ./setup.py install --prefix="$out" --use-python-path --verbose
   '';
-
-  buildInputs = [ python libxslt tetex ];
 
   meta = {
     description = "A program to convert DocBook to DVI, PostScript or PDF via LaTeX or ConTeXt";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -553,6 +553,8 @@ let
 
   enca = callPackage ../tools/text/enca { };
 
+  fop = callPackage ../tools/typesetting/fop { };
+
   mcrl = callPackage ../tools/misc/mcrl { };
 
   mcrl2 = callPackage ../tools/misc/mcrl2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -567,7 +567,8 @@ let
   mcelog = callPackage ../os-specific/linux/mcelog { };
 
   asciidoc = callPackage ../tools/typesetting/asciidoc {
-    inherit (pythonPackages) matplotlib numpy aafigure recursivePthLoader;
+    inherit (pythonPackages) matplotlib numpy aafigure recursivePthLoader
+                             pygments;
   };
 
   autossh = callPackage ../tools/networking/autossh { };


### PR DESCRIPTION
Make asciidoc full featured by adding dependencies and fixing up impurities. See commit messages for details.

This increases the closure size from 255 MiB to 1.5 GiB. A few packages use asciidoc for generating documentation:

$ git grep -l asciidoc
pkgs/applications/version-management/git-and-tools/cgit/default.nix
pkgs/applications/version-management/git-and-tools/default.nix
pkgs/applications/version-management/git-and-tools/git-bz/default.nix
pkgs/applications/version-management/git-and-tools/git/default.nix
pkgs/applications/version-management/git-and-tools/tig/default.nix
pkgs/applications/window-managers/awesome/default.nix
pkgs/development/tools/build-managers/ninja/default.nix
pkgs/games/wesnoth/default.nix
pkgs/os-specific/linux/kernel/perf.nix
pkgs/tools/filesystems/httpfs/default.nix
pkgs/tools/text/unoconv/default.nix
pkgs/tools/typesetting/asciidoc/default.nix
pkgs/top-level/all-packages.nix
pkgs/top-level/release-python.nix

The build-time storage footprint will increase for those. But the asciidoc hash shouldn't be retained, so the extra storage can be garbage collected afterwards. And binary channel users shouldn't notice any difference at all (nothing extra to download).

We can of course add asciidocLight/Full attributes, but I remember having to do a workaround in the ninja expression to make it work with the current (incomplete) asciidoc expression, so having a full featured asciidoc tool may be easier for us.

If you want minimal, you can always pass enableStandardFeatures = false to the asciidoc expression.
