### PR TITLE
haskellPackages.acidState: Update to 0.12.1

### DIFF
--- a/pkgs/development/libraries/haskell/acid-state/default.nix
+++ b/pkgs/development/libraries/haskell/acid-state/default.nix
@@ -4,8 +4,8 @@
 
 cabal.mkDerivation (self: {
   pname = "acid-state";
-  version = "0.12.0";
-  sha256 = "0gz66j0091k18yy81kn3vcadjg8lrqdfxibjbzwyhi64m894f13w";
+  version = "0.12.1";
+  sha256 = "0smqhj4layckdsm8xjz1rwgpcqwm5xj2vr8g4i463vgq776fl0q6";
   buildDepends = [
     cereal extensibleExceptions filepath mtl network safecopy stm
   ];


### PR DESCRIPTION
This should fix a few breakages on Hydra
