### PR TITLE
my-env: pull --norc shell flag out into shell parameter

### DIFF
--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -59,7 +59,7 @@
 { mkDerivation, substituteAll, pkgs }:
     { stdenv ? pkgs.stdenv, name, buildInputs ? []
     , propagatedBuildInputs ? [], gcc ? stdenv.gcc, cTags ? [], extraCmds ? ""
-    , cleanupCmds ? "", shell ? "${pkgs.bashInteractive}/bin/bash"}:
+    , cleanupCmds ? "", shell ? "${pkgs.bashInteractive}/bin/bash --norc"}:
 
 mkDerivation {
   # The setup.sh script from stdenv will expect the native build inputs in
@@ -146,8 +146,8 @@ mkDerivation {
     EOF
 
     mkdir -p $out/bin
-    sed -e s,@shell@,${shell}, -e s,@myenvpath@,$out/dev-envs/${name}, \
-      -e s,@name@,${name}, ${./loadenv.sh} > $out/bin/load-env-${name}
+    sed -e 's,@shell@,${shell},' -e s,@myenvpath@,$out/dev-envs/${name}, \
+      -e 's,@name@,${name},' ${./loadenv.sh} > $out/bin/load-env-${name}
     chmod +x $out/bin/load-env-${name}
   '';
 }

--- a/pkgs/misc/my-env/loadenv.sh
+++ b/pkgs/misc/my-env/loadenv.sh
@@ -10,5 +10,5 @@ export buildInputs
 export NIX_STRIP_DEBUG=0
 export TZ="$OLDTZ"
 
-@shell@ --norc
+@shell@
 


### PR DESCRIPTION
as zsh's corresponding flag is called --no-rcs, the build environment
couldn't be configured to use zsh at all.

even then the custom PS1 won't work on zsh, but it's usable enough.
