### PR TITLE
Add transmisson_gtk to all-packages.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7882,6 +7882,12 @@ let
 
   # This builds the gtk client
   transmission_260 = callPackage ../applications/networking/p2p/transmission/2.60.nix { };
+  # It needs gtk3+ version  >= 3.4.0
+  # transmission_gtk = callPackage ../applications/networking/p2p/transmission { 
+  #  enableGtk = true;
+  # };
+
+  transmission_gtk = callPackage ../applications/networking/p2p/transmission/2.60.nix { };
 
   transmission = callPackage ../applications/networking/p2p/transmission { };
 


### PR DESCRIPTION
Hi,

currently we can not compile transmission with gtk support due dependency
issues. I think there should be a name for the last working gtk version so
I created a new transmission_gtk which should link to the last working transmission
with gtk support.
