### PR TITLE
Add asciidocFull (and dblatexFull dependency)

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -1,4 +1,25 @@
 { fetchurl, stdenv, python
+
+, enableStandardFeatures ? false
+, sourceHighlight ? null
+, highlight ? null
+, pygments ? null
+, graphviz ? null
+, tetex ? null
+, dblatexFull ? null
+, libxslt ? null
+, w3m ? null
+, lynx ? null
+, imagemagick ? null
+, lilypond ? null
+, libxml2 ? null
+, docbook_xml_dtd_45 ? null
+, docbook5_xsl ? null
+, docbook_xsl ? null
+, fop ? null
+# TODO: Package this:
+#, epubcheck ? null
+
 , unzip ? null
 # filters
 , enableDitaaFilter ? false, jre ? null
@@ -11,6 +32,26 @@
 , enableDeckjsBackend ? false
 , enableOdfBackend ? false
 }:
+
+assert enableStandardFeatures ->
+  sourceHighlight != null &&
+  highlight != null &&
+  pygments != null &&
+  graphviz != null &&
+  tetex != null &&
+  dblatexFull != null &&
+  libxslt != null &&
+  w3m != null &&
+  lynx != null &&
+  imagemagick != null &&
+  lilypond != null &&
+  libxml2 != null &&
+  docbook_xml_dtd_45 != null &&
+  docbook5_xsl != null &&
+  docbook_xsl != null &&
+  fop != null;
+# TODO: Package this:
+#  epubcheck != null;
 
 # filters
 assert (enableDitaaFilter || enableMscgenFilter || enableDiagFilter || enableQrcodeFilter || enableAafigureFilter) -> unzip != null;
@@ -49,7 +90,7 @@ let
     sha256 = "0h4bql1nb4y4fmg2yvlpfjhvy22ln8jsaxdr10f8bfcg5lr0zkxs";
   };
 
-  # latest commit in master branch as per 2013-09-22
+  # there are no archives or tags, using latest commit in master branch as per 2013-09-22
   matplotlibFilterSrc = let commit = "75f0d009629f93f33fab04b83faca20cc35dd358"; in fetchurl rec {
     name = "mplw-${commit}.tar.gz";
     url = "https://api.github.com/repos/lvv/mplw/tarball/${commit}";
@@ -151,11 +192,48 @@ stdenv.mkDerivation rec {
     # the odp backend already has that fix. Copy it here until fixed upstream.
     sed -i "s|'/etc/asciidoc/backends/odt/asciidoc.ott'|os.path.dirname(__file__),'asciidoc.ott'|" \
         "$out/etc/asciidoc/backends/odt/a2x-backend.py"
+  '' + optionalString enableStandardFeatures ''
+    sed -e "s|dot|${graphviz}/bin/dot|g" \
+        -e "s|neato|${graphviz}/bin/neato|g" \
+        -e "s|twopi|${graphviz}/bin/circo|g" \
+        -e "s|circo|${graphviz}/bin/circo|g" \
+        -e "s|fdp|${graphviz}/bin/fdp|g" \
+        -i "filters/graphviz/graphviz2png.py"
+
+    sed -e "s|run('latex|run('${tetex}/bin/latex|g" \
+        -e "s|cmd = 'dvipng'|cmd = '${tetex}/bin/dvipng'|g" \
+        -i "filters/latex/latex2png.py"
+
+    sed -e "s|run('abc2ly|run('${lilypond}/bin/abc2ly|g" \
+        -e "s|run('lilypond|run('${lilypond}/bin/lilypond|g" \
+        -e "s|run('convert|run('${imagemagick}/bin/convert|g" \
+        -i "filters/music/music2png.py"
+
+    sed -e 's|filter="source-highlight|filter="${sourceHighlight}/bin/source-highlight|' \
+        -e 's|filter="highlight|filter="${highlight}/bin/highlight|' \
+        -e 's|filter="pygmentize|filter="${pygments}/bin/pygmentize|' \
+        -i "filters/source/source-highlight-filter.conf"
+
+    # ENV is custom environment passed to programs that a2x invokes. Here we
+    # use it to work around an impurity in the tetex package; tetex tools
+    # cannot find their neighbours (e.g. pdflatex doesn't find mktextfm).
+    # We can remove PATH= when those impurities are fixed.
+    sed -e "s|^ENV =.*|ENV = dict(XML_CATALOG_FILES='${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook5_xsl}/xml/xsl/docbook/catalog.xml ${docbook_xsl}/xml/xsl/docbook/catalog.xml', PATH='${tetex}/bin')|" \
+        -e "s|^ASCIIDOC =.*|ASCIIDOC = '$out/bin/asciidoc'|" \
+        -e "s|^XSLTPROC =.*|XSLTPROC = '${libxslt}/bin/xsltproc'|" \
+        -e "s|^DBLATEX =.*|DBLATEX = '${dblatexFull}/bin/dblatex'|" \
+        -e "s|^FOP =.*|FOP = '${fop}/bin/fop'|" \
+        -e "s|^W3M =.*|W3M = '${w3m}/bin/w3m'|" \
+        -e "s|^LYNX =.*|LYNX = '${lynx}/bin/lynx'|" \
+        -e "s|^XMLLINT =.*|XMLLINT = '${libxml2}/bin/xmllint'|" \
+        -e "s|^EPUBCHECK =.*|EPUBCHECK = 'nixpkgs_is_missing_epubcheck'|" \
+        -i a2x.py
   '' + ''
     for n in $(find "$out" . -name \*.py); do
       sed -i -e "s,^#![[:space:]]*.*/bin/env python,#!${python}/bin/python,g" "$n"
       chmod +x "$n"
     done
+
     sed -i -e "s,/etc/vim,,g" Makefile.in
   '';
 

--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -1,4 +1,15 @@
-{ stdenv, fetchurl, python, libxslt, tetex }:
+{ stdenv, fetchurl, python, libxslt, tetex
+, enableAllFeatures ? false, imagemagick ? null, transfig ? null, inkscape ? null, fontconfig ? null, ghostscript ? null }:
+
+# NOTE: enableAllFeatures just purifies the expression, it doesn't actually
+# enable any extra features.
+
+assert enableAllFeatures ->
+  imagemagick != null &&
+  transfig != null &&
+  inkscape != null &&
+  fontconfig != null &&
+  ghostscript != null;
 
 stdenv.mkDerivation rec {
   name = "dblatex-0.3.4";
@@ -8,14 +19,38 @@ stdenv.mkDerivation rec {
     sha256 = "120w3wm07qx0k1grgdhjwm2vpwil71icshjvqznskp1f6ggch290";
   };
 
+  buildInputs = [ python libxslt tetex ]
+    ++ stdenv.lib.optionals enableAllFeatures [ imagemagick transfig ];
+
+  # TODO: dblatex tries to execute texindy command, but nixpkgs doesn't have
+  # that yet. In Ubuntu, texindy is a part of the xindy package.
+  preConfigure = ''
+    sed -i 's|self.install_layout == "deb"|False|' setup.py
+  '' + stdenv.lib.optionalString enableAllFeatures ''
+    for file in $(find -name "*.py"); do
+        sed -e 's|cmd = \["xsltproc|cmd = \["${libxslt}/bin/xsltproc|g' \
+            -e 's|Popen(\["xsltproc|Popen(\["${libxslt}/bin/xsltproc|g' \
+            -e 's|cmd = \["texindy|cmd = ["nixpkgs_is_missing_texindy|g' \
+            -e 's|cmd = "epstopdf|cmd = "${tetex}/bin/epstopdf|g' \
+            -e 's|cmd = \["makeindex|cmd = ["${tetex}/bin/makeindex|g' \
+            -e 's|doc.program = "pdflatex"|doc.program = "${tetex}/bin/pdflatex"|g' \
+            -e 's|self.program = "latex"|self.program = "${tetex}/bin/latex"|g' \
+            -e 's|Popen("pdflatex|Popen("${tetex}/bin/pdflatex|g' \
+            -e 's|"fc-match"|"${fontconfig}/bin/fc-match"|g' \
+            -e 's|"fc-list"|"${fontconfig}/bin/fc-list"|g' \
+            -e 's|cmd = "inkscape|cmd = "${inkscape}/bin/inkscape|g' \
+            -e 's|cmd = "fig2dev|cmd = "${transfig}/bin/fig2dev|g' \
+            -e 's|cmd = \["ps2pdf|cmd = ["${ghostscript}/bin/ps2pdf|g' \
+            -e 's|cmd = "convert|cmd = "${imagemagick}/bin/convert|g' \
+            -i "$file"
+    done
+  '';
+
   buildPhase = "true";
   
   installPhase = ''
-    sed -i 's|self.install_layout == "deb"|False|' setup.py
-    python ./setup.py install --prefix=$out
+    python ./setup.py install --prefix="$out" --use-python-path --verbose
   '';
-
-  buildInputs = [ python libxslt tetex ];
 
   meta = {
     description = "A program to convert DocBook to DVI, PostScript or PDF via LaTeX or ConTeXt";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9784,7 +9784,13 @@ let
 
   dbacl = callPackage ../tools/misc/dbacl { };
 
-  dblatex = callPackage ../tools/typesetting/tex/dblatex { };
+  dblatex = callPackage ../tools/typesetting/tex/dblatex {
+    enableAllFeatures = false;
+  };
+
+  dblatexFull = appendToName "full" (dblatex.override {
+    enableAllFeatures = true;
+  });
 
   dosbox = callPackage ../misc/emulators/dosbox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -572,7 +572,13 @@ let
 
   asciidoc = callPackage ../tools/typesetting/asciidoc {
     inherit (pythonPackages) matplotlib numpy aafigure recursivePthLoader;
+    enableStandardFeatures = false;
   };
+
+  asciidocFull = appendToName "full" (asciidoc.override {
+    inherit (pythonPackages) pygments;
+    enableStandardFeatures = true;
+  });
 
   autossh = callPackage ../tools/networking/autossh { };
 


### PR DESCRIPTION
Now I've left the existing dblatex and asciidoc attributes alone and added dblatexFull and asciidocFull instead.

With asciidocFull you can use all the various features of asciidoc without experiencing runtime errors (except missing epubcheck, as commented in the commit).
