### PR TITLE
Let rsnapshot use /etc/rsnapshot.conf as configuration instead of non-existent ${rsnapshot}/etc/rsnapshot.conf

### DIFF
--- a/pkgs/tools/backup/rsnapshot/default.nix
+++ b/pkgs/tools/backup/rsnapshot/default.nix
@@ -1,5 +1,20 @@
-{fetchurl, stdenv, perl, openssh, rsync, logger}:
+{ fetchurl, stdenv, writeText, perl, openssh, rsync, logger,
+  configFile ? "/etc/rsnapshot.conf" }:
 
+let patch = writeText "rsnapshot-config.patch" ''
+--- rsnapshot-program.pl	2013-10-05 20:31:08.715991442 +0200
++++ rsnapshot-program.pl	2013-10-05 20:31:42.496193633 +0200
+@@ -383,7 +383,7 @@
+ 	}
+ 	
+ 	# set global variable
+-	$config_file = $default_config_file;
++	$config_file = '${configFile}';
+ }
+ 
+ # accepts no args
+'';
+in
 stdenv.mkDerivation rec {
   name = "rsnapshot-1.3.0";
   src = fetchurl {
@@ -12,6 +27,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace "Makefile.in" --replace \
       "/usr/bin/pod2man" "${perl}/bin/pod2man"
+    patch -p0 <${patch}
   '';
 
   meta = {


### PR DESCRIPTION
This allows using it just like:

```
rsnapshot du
```

if you use NixOS's environment.etc to put the configuration in /etc/rsnapshot.conf.
