### PR TITLE
flightgear: 2.10.0 -> 2.12.0 (and make it run again)

### DIFF
--- a/pkgs/development/libraries/simgear/default.nix
+++ b/pkgs/development/libraries/simgear/default.nix
@@ -1,7 +1,7 @@
 x@{builderDefsPackage
   , plib, freeglut, xproto, libX11, libXext, xextproto, libXi , inputproto
   , libICE, libSM, libXt, libXmu, mesa, boost, zlib, libjpeg , freealut
-  , openscenegraph, openal, expat, cmake
+  , openscenegraph, openal, expat, cmake, apr
   , ...}:
 builderDefsPackage
 (a :
@@ -13,11 +13,11 @@ let
     (builtins.attrNames (builtins.removeAttrs x helperArgNames));
   sourceInfo = rec {
     baseName="simgear";
-    version="2.10.0";
+    version="2.12.0";
     name="${baseName}-${version}";
     extension="tar.bz2";
     url="http://mirrors.ibiblio.org/pub/mirrors/simgear/ftp/Source/${name}.${extension}";
-    hash="0pb148hb35p1c5iz0kpiclmswjl9bax9xfm087ldpxsqg9a0sb2q";
+    hash="0spl6afk8rm96ss4lh7zy5561m5m2qgwsnqjyp35jr1gyyrc944f";
   };
 in
 rec {

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -1,58 +1,42 @@
-x@{builderDefsPackage
-  , freeglut, freealut, mesa, libICE, libjpeg, openal, openscenegraph, plib
-  , libSM, libunwind, libX11, xproto, libXext, xextproto, libXi, inputproto
-  , libXmu, libXt, simgear, zlib, boost, cmake, libpng
-  , ...}:
-builderDefsPackage
-(a :
-let
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++
-    [];
+{ stdenv, fetchurl
+, freeglut, freealut, mesa, libICE, libjpeg, openal, openscenegraph, plib
+, libSM, libunwind, libX11, xproto, libXext, xextproto, libXi, inputproto
+, libXmu, libXt, simgear, zlib, boost, cmake, libpng, udev, fltk13, apr
+}:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    baseName="flightgear";
-    version="2.10.0";
-    name="${baseName}-${version}";
-    extension="tar.bz2";
-    url="http://ftp.linux.kiev.ua/pub/fgfs/Source/${name}.${extension}";
-    hash="0pq5nwyxwp8ar5rr0jh8p04bv0i9i841m374jwd748csnsn28zh6";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
+stdenv.mkDerivation rec {
+  version = "2.12.0";
+  name = "flightgear-${version}";
+
+  src = fetchurl {
+    url = "http://ftp.linux.kiev.ua/pub/fgfs/Source/${name}.tar.bz2";
+    sha256 = "0h9ka4pa2njxbvy5jlmnsjy5ynzms504ygqn7hd80g3c58drsjc4";
   };
 
-  datasrc = a.fetchurl {
-    url = "http://ftp.igh.cnrs.fr/pub/flightgear/ftp/Shared/FlightGear-data-2.0.0.tar.bz2";
-    sha256 = "0kvmvh5qycbpdjx12l20cbhljwimmcgww2dg4lkc2sky0kg14ic1";
+  datasrc = fetchurl {
+    url = "http://ftp.igh.cnrs.fr/pub/flightgear/ftp/Shared/FlightGear-data-${version}.tar.bz";
+    sha256 = "0qjvcj2cz7ypa91v95lws44fg8c1p0pazv24ljkai2m2r0jgsv8k";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  buildInputs = [
+    freeglut freealut mesa libICE libjpeg openal openscenegraph plib
+    libSM libunwind libX11 xproto libXext xextproto libXi inputproto
+    libXmu libXt simgear zlib boost cmake libpng udev fltk13 apr
+  ];
 
-  /* doConfigure should be removed if not needed */
-  phaseNames = ["doCmake" "doMakeInstall" "deployData"];
+  preConfigure = ''
+    export cmakeFlagsArray=(-DFG_DATA_DIR="$out/share/FlightGear/")
+  '';
 
-  deployData = a.fullDepEntry ''
+  postInstall = ''
     mkdir -p "$out/share/FlightGear"
-    cd "$out/share/FlightGear"
-    tar xvf ${datasrc}
-  '' ["minInit" "defEnsureDir"];
+    tar xvf "${datasrc}" -C "$out/share/FlightGear/" --strip-components=1
+  '';
 
-  meta = {
-    description = "A flight simulator";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    #platforms = a.lib.platforms.linux;
-    license = a.lib.licenses.gpl2;
+  meta = with stdenv.lib; {
+    description = "Flight simulator";
+    maintainers = with maintainers; [ raskin ];
+    #platforms = platforms.linux; # disabled from hydra because it's so big
+    license = licenses.gpl2;
   };
-  passthru = {
-  };
-}) x
-
+}


### PR DESCRIPTION
The current FlightGear expression doesn't work:

  bash$ nix-build -A flightgear
  /nix/store/3c47sibzb9h1vhnn0gnh692hkpjc5p5v-flightgear-2.10.0

  bash$ ./result/bin/fgfs
  ERROR: The path '/nix/store/3c47sibzb9h1vhnn0gnh692hkpjc5p5v-flightgear-2.10.0/lib/FlightGear' does not exist in the file system.

  Base package check failed:
    Version [none] found at: /nix/store/3c47sibzb9h1vhnn0gnh692hkpjc5p5v-flightgear-2.10.0/lib/FlightGear
    Version 2.10.0 is required.
  Please upgrade/downgrade base package and set the path to your fgdata
  with --fg-root=path_to_your_fgdata

We could probably make the 2.10.0 version run, but I had already
upgraded it to 2.12.0 before I made it work. It seems only the data dir
configuration was wrong/missing: FG_DATA_DIR="$out/share/FlightGear/".

Simgear must be in version sync with flightgear, hence the upgrade.

Most of the diff is because I rewrote the flightgear expression to what
I think is the "new style" (correct me if I'm wrong). I wanted to add a preConfigure phase but
didn't understand why this expression had custom phases. So I just
rewrote the whole thing to something I consider more readable.
