### PR TITLE
nixos: graphite, listen on localhost by default

### DIFF
--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -34,7 +34,14 @@ in {
     carbon = {
       config = mkOption {
         description = "Content of carbon configuration file";
-        default = "";
+        default = ''
+          [cache]
+          # Listen on localhost by default for security reasons
+          UDP_RECEIVER_INTERFACE = 127.0.0.1
+          PICKLE_RECEIVER_INTERFACE = 127.0.0.1
+          LINE_RECEIVER_INTERFACE = 127.0.0.1
+          CACHE_QUERY_INTERFACE = 127.0.0.1
+        '';
         type = types.uniq types.string;
       };
 


### PR DESCRIPTION
This is just a security fix for default settings to listen on localhost by default
