### PR TITLE
pkgs/docbook-xsl: update to 1.78.1

### DIFF
--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation {
-  name = "docbook-xsl-1.72.0";
+  name = "docbook-xsl-1.78.1";
   builder = ./builder.sh;
   src = fetchurl {
-    url = mirror://sourceforge/docbook/docbook-xsl-1.72.0.tar.bz2;
-    sha256 = "1cnrfgqz8pc9wnlgqjch2338ad7jki6d4h6b2fhaxn1a2201df5k";
+    url = mirror://sourceforge/docbook/docbook-xsl-1.78.1.tar.bz2;
+    sha256 = "0rxl013ncmz1n6ymk2idvx3hix9pdabk8xn01cpcv32wmfb753y9";
   };
 }


### PR DESCRIPTION
I need this update, so i can enable optional python support in systemd, because without this update systemd build (with enabled python support) fails with infinite recursion while doing xslt transformations using this lib.

This requires rebuild of a lot of packages!
