### PR TITLE
skype: add workaround for pulseaudio glitches

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skype/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skype/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
 
     cat > $out/bin/skype << EOF
     #!${stdenv.shell}
+    export PULSE_LATENCY_MSEC=60  # workaround for pulseaudio glitches
     export LD_LIBRARY_PATH=$fullPath:$LD_LIBRARY_PATH
     $dynlinker $out/libexec/skype/skype --resources=$out/libexec/skype "\$@"
     EOF


### PR DESCRIPTION
See http://arunraghavan.net/2013/08/pulseaudio-4-0-and-skype/

Relevant bug reports:
  https://github.com/NixOS/nixpkgs/issues/788
  https://bugs.archlinux.org/task/35690
  https://bugs.freedesktop.org/show_bug.cgi?id=50510

We don't want to disable pulseaudio timer-based scheduling (tsched=0)
because that affects everyone. It seems this is the proper distro "fix"
for skype + pulseaudio at the moment.
