### PR TITLE
Update QtCreator to 2.8.1, add Qt 5.1.1 and QtSDK

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation {
     ./static-gallium.patch
     ./dricore-gallium.patch
     ./fix-rounding.patch
+    ./werror-wundef.patch
   ];
 
   # Change the search path for EGL drivers from $drivers/* to driverLink

--- a/pkgs/development/libraries/mesa/werror-wundef.patch
+++ b/pkgs/development/libraries/mesa/werror-wundef.patch
@@ -1,0 +1,12 @@
+diff -rupN Mesa-9.2.0-orig/include/GL/gl.h Mesa-9.2.0/include/GL/gl.h
+--- Mesa-9.2.0-orig/include/GL/gl.h	2013-08-14 03:34:42.000000000 +0200
++++ Mesa-9.2.0/include/GL/gl.h	2013-09-24 19:34:58.319140812 +0200
+@@ -2088,7 +2088,7 @@ typedef void (APIENTRYP PFNGLMULTITEXCOO
+ 
+ 
+ 
+-#if GL_ARB_shader_objects
++#if defined(GL_ARB_shaders_objects) && GL_ARB_shader_objects
+ 
+ #ifndef GL_MESA_shader_debug
+ #define GL_MESA_shader_debug 1

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
     sha256 = "0f51dbgn1dcck8pqimls2qyf1pfmsmyknh767cvw87c3d218ywpb";
   };
 
+  # The version property must be kept because it will be included into the QtSDK package name
+  version = vers;
+
   prePatch = ''
     substituteInPlace configure --replace /bin/pwd pwd
     substituteInPlace src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls

--- a/pkgs/development/libraries/qt-5/default.nix
+++ b/pkgs/development/libraries/qt-5/default.nix
@@ -1,0 +1,157 @@
+{ stdenv, fetchurl, substituteAll, libXrender, libXext
+, libXfixes, freetype, fontconfig, zlib, libjpeg, libpng
+, mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
+, libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
+, gdk_pixbuf, python, gdb, xlibs, libX11, libxcb, xcbutil, xcbutilimage
+, xcbutilkeysyms, xcbutilwm,udev, libxml2, libxslt, pcre, libxkbcommon
+, alsaLib, gstreamer, gst_plugins_base
+, pulseaudio, bison, flex, gperf, ruby, libwebp
+, flashplayerFix ? false
+, gtkStyle ? false, libgnomeui, gtk, GConf, gnome_vfs
+, buildDocs ? false
+, buildExamples ? false
+, buildTests ? true
+, developerBuild ? false
+}:
+
+with stdenv.lib;
+
+let
+  v_maj = "5.1";
+  v_min = "1";
+  ver = "${v_maj}.${v_min}";
+in
+
+stdenv.mkDerivation rec {
+  name = "qt-${ver}";
+
+  src = fetchurl {
+    url = "http://download.qt-project.org/official_releases/qt/"
+      + "${v_maj}/${ver}/single/qt-everywhere-opensource-src-${ver}.tar.gz";
+    sha256 = "4c05742db52325e96b1d610a2388140dcc1e3d03d93faea2b2d3791015b186f6";
+  };
+
+  # The version property must be kept because it will be included into the QtSDK package name
+  version = ver;
+
+  prePatch = ''
+    substituteInPlace configure --replace /bin/pwd pwd
+    substituteInPlace qtbase/configure --replace /bin/pwd pwd
+    substituteInPlace qtbase/src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
+    sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i config.tests/*/*.test -i qtbase/mkspecs/*/*.conf
+  '';
+
+  patches =
+    [ ./glib-2.32.patch
+      (substituteAll {
+        src = ./dlopen-absolute-paths.patch;
+        inherit cups icu libXfixes;
+        glibc = stdenv.gcc.libc;
+        openglDriver = if mesaSupported then mesa.driverLink else "/no-such-path";
+      })
+    ] ++ optional gtkStyle (substituteAll {
+        src = ./dlopen-gtkstyle.patch;
+        # substituteAll ignores env vars starting with capital letter
+        gconf = GConf;
+        inherit gnome_vfs libgnomeui gtk;
+      })
+    ++ optional flashplayerFix (substituteAll {
+        src = ./dlopen-webkit-nsplugin.patch;
+        inherit gtk gdk_pixbuf;
+      });
+
+  preConfigure = ''
+    export LD_LIBRARY_PATH="$PWD/qtbase/lib:$PWD/qtbase/plugins/platforms:$PWD/qttools/lib:$LD_LIBRARY_PATH"
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+  '';
+
+  prefixKey = "-prefix ";
+
+  # -no-eglfs, -no-directfb, -no-linuxfb and -no-kms because of the current minimalist mesa
+  # TODO Remove obsolete and useless flags once the build will be totally mastered
+  configureFlags = ''
+    -verbose
+    -confirm-license
+    -opensource
+
+    -release
+    -shared
+    -c++11
+    ${optionalString developerBuild "-developer-build"}
+    -largefile
+    -accessibility
+    -rpath
+    -optimized-qmake
+    -strip
+    -reduce-relocations
+    -force-debug-info
+    -no-separate-debug-info
+    -system-proxies
+
+    -gui
+    -widgets
+    -opengl desktop
+    -javascript-jit
+    -qml-debug
+    -nis
+    -iconv
+    -icu
+    -pch
+    -glib
+    -xcb
+    -qpa xcb
+    -${optionalString (cups == null) "no-"}cups
+
+    -no-eglfs
+    -no-directfb
+    -no-linuxfb
+    -no-kms
+
+    -system-zlib
+    -system-libpng
+    -system-libjpeg
+    -system-xcb
+    -system-xkbcommon
+    -openssl-linked
+    -dbus-linked
+
+    -system-sqlite
+    -${if mysql != null then "plugin" else "no"}-sql-mysql
+    -${if postgresql != null then "plugin" else "no"}-sql-psql
+
+    -make libs
+    -make tools
+    -${optionalString (buildExamples == false) "no"}make examples
+    -${optionalString (buildTests == false) "no"}make tests
+  '';
+
+  propagatedBuildInputs = [
+    xlibs.libXcomposite libX11 libxcb libXext libXrender libXi
+    fontconfig freetype openssl dbus.libs glib udev libxml2 libxslt pcre
+    zlib libjpeg libpng libtiff sqlite icu
+    libwebp alsaLib gstreamer gst_plugins_base pulseaudio
+    xcbutil xcbutilimage xcbutilkeysyms xcbutilwm libxkbcommon
+  ]
+  # Qt doesn't directly need GLU (just GL), but many apps use, it's small and
+  # doesn't remain a runtime-dep if not used
+  ++ optionals mesaSupported [ mesa mesa_glu ]
+  ++ optional (cups != null) cups
+  ++ optional (mysql != null) mysql
+  ++ optional (postgresql != null) postgresql;
+
+  buildInputs = [ gdb bison flex gperf ruby ];
+
+  nativeBuildInputs = [ python perl pkgconfig ];
+
+  postInstall = if buildDocs then "make docs&&make install_docs" else "";
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://qt-project.org;
+    description = "A cross-platform application framework for C++";
+    license = "GPL/LGPL";
+    maintainers = [ maintainers.bbenoist ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/qt-5/dlopen-absolute-paths.patch
+++ b/pkgs/development/libraries/qt-5/dlopen-absolute-paths.patch
@@ -1,0 +1,36 @@
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/network/kernel/qhostinfo_unix.cpp qt-everywhere-opensource-src-5.1.1/qtbase/src/network/kernel/qhostinfo_unix.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/network/kernel/qhostinfo_unix.cpp	2013-08-25 20:03:35.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtbase/src/network/kernel/qhostinfo_unix.cpp	2013-09-25 17:43:14.047015411 +0200
+@@ -93,7 +93,7 @@
+ static void resolveLibrary()
+ {
+ #if !defined(QT_NO_LIBRARY) && !defined(Q_OS_QNX)
+-    QLibrary lib(QLatin1String("resolv"));
++    QLibrary lib(QLatin1String("@glibc@/lib/libresolv"));
+     if (!lib.load())
+         return;
+ 
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/plugins/platforms/xcb/qglxintegration.cpp qt-everywhere-opensource-src-5.1.1/qtbase/src/plugins/platforms/xcb/qglxintegration.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/plugins/platforms/xcb/qglxintegration.cpp	2013-08-25 20:03:35.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtbase/src/plugins/platforms/xcb/qglxintegration.cpp	2013-09-25 17:51:29.834674976 +0200
+@@ -379,7 +379,7 @@
+             {
+                 extern const QString qt_gl_library_name();
+ //                QLibrary lib(qt_gl_library_name());
+-                QLibrary lib(QLatin1String("GL"));
++                QLibrary lib(QLatin1String("@openglDriver@/lib/libGL"));
+                 glXGetProcAddressARB = (qt_glXGetProcAddressARB) lib.resolve("glXGetProcAddressARB");
+             }
+         }
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/printsupport/kernel/qcups.cpp qt-everywhere-opensource-src-5.1.1/qtbase/src/printsupport/kernel/qcups.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/printsupport/kernel/qcups.cpp	2013-08-25 20:03:36.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtbase/src/printsupport/kernel/qcups.cpp	2013-09-25 17:40:35.895942599 +0200
+@@ -91,7 +91,7 @@
+ 
+ static void resolveCups()
+ {
+-    QLibrary cupsLib(QLatin1String("cups"), 2);
++    QLibrary cupsLib(QLatin1String("@cups@/lib/libcups"), 2);
+     if(cupsLib.load()) {
+         _cupsGetDests = (CupsGetDests) cupsLib.resolve("cupsGetDests");
+         _cupsFreeDests = (CupsFreeDests) cupsLib.resolve("cupsFreeDests");

--- a/pkgs/development/libraries/qt-5/dlopen-gtkstyle.patch
+++ b/pkgs/development/libraries/qt-5/dlopen-gtkstyle.patch
@@ -1,0 +1,36 @@
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/widgets/styles/qgtkstyle_p.cpp qt-everywhere-opensource-src-5.1.1/qtbase/src/widgets/styles/qgtkstyle_p.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtbase/src/widgets/styles/qgtkstyle_p.cpp	2013-08-25 20:03:30.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtbase/src/widgets/styles/qgtkstyle_p.cpp	2013-09-25 17:58:04.229373681 +0200
+@@ -348,7 +348,7 @@
+ void QGtkStylePrivate::resolveGtk() const
+ {
+     // enforce the "0" suffix, so we'll open libgtk-x11-2.0.so.0
+-    QLibrary libgtk(QLS("gtk-x11-2.0"), 0, 0);
++    QLibrary libgtk(QLS("@gtk@/lib/libgtk-x11-2.0"), 0, 0);
+ 
+     gtk_init = (Ptr_gtk_init)libgtk.resolve("gtk_init");
+     gtk_window_new = (Ptr_gtk_window_new)libgtk.resolve("gtk_window_new");
+@@ -461,8 +461,8 @@
+     pango_font_description_get_family = (Ptr_pango_font_description_get_family)libgtk.resolve("pango_font_description_get_family");
+     pango_font_description_get_style = (Ptr_pango_font_description_get_style)libgtk.resolve("pango_font_description_get_style");
+ 
+-    gnome_icon_lookup_sync = (Ptr_gnome_icon_lookup_sync)QLibrary::resolve(QLS("gnomeui-2"), 0, "gnome_icon_lookup_sync");
+-    gnome_vfs_init= (Ptr_gnome_vfs_init)QLibrary::resolve(QLS("gnomevfs-2"), 0, "gnome_vfs_init");
++    gnome_icon_lookup_sync = (Ptr_gnome_icon_lookup_sync)QLibrary::resolve(QLS("@libgnomeui@/lib/libgnomeui-2"), 0, "gnome_icon_lookup_sync");
++    gnome_vfs_init= (Ptr_gnome_vfs_init)QLibrary::resolve(QLS("@gnome_vfs@/lib/libgnomevfs-2"), 0, "gnome_vfs_init");
+ }
+ 
+ /* \internal
+@@ -630,9 +630,9 @@
+ static bool resolveGConf()
+ {
+     if (!QGtkStylePrivate::gconf_client_get_default) {
+-        QGtkStylePrivate::gconf_client_get_default = (Ptr_gconf_client_get_default)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_default");
+-        QGtkStylePrivate::gconf_client_get_string =  (Ptr_gconf_client_get_string)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_string");
+-        QGtkStylePrivate::gconf_client_get_bool =  (Ptr_gconf_client_get_bool)QLibrary::resolve(QLS("gconf-2"), 4, "gconf_client_get_bool");
++        QGtkStylePrivate::gconf_client_get_default = (Ptr_gconf_client_get_default)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_default");
++        QGtkStylePrivate::gconf_client_get_string =  (Ptr_gconf_client_get_string)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_string");
++        QGtkStylePrivate::gconf_client_get_bool =  (Ptr_gconf_client_get_bool)QLibrary::resolve(QLS("@gconf@/lib/libgconf-2"), 4, "gconf_client_get_bool");
+     }
+     return (QGtkStylePrivate::gconf_client_get_default !=0);
+ }

--- a/pkgs/development/libraries/qt-5/dlopen-webkit-nsplugin.patch
+++ b/pkgs/development/libraries/qt-5/dlopen-webkit-nsplugin.patch
@@ -1,0 +1,36 @@
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtwebkit/Source/WebCore/plugins/qt/PluginPackageQt.cpp qt-everywhere-opensource-src-5.1.1/qtwebkit/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtwebkit/Source/WebCore/plugins/qt/PluginPackageQt.cpp	2013-08-25 20:04:47.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtwebkit/Source/WebCore/plugins/qt/PluginPackageQt.cpp	2013-09-25 17:59:45.925363807 +0200
+@@ -132,7 +132,7 @@
+         }
+     }
+ 
+-    QLibrary library(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (library.load()) {
+         typedef void *(*gtk_init_check_ptr)(int*, char***);
+         gtk_init_check_ptr gtkInitCheck = (gtk_init_check_ptr)library.resolve("gtk_init_check");
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtwebkit/Source/WebCore/plugins/qt/PluginViewQt.cpp qt-everywhere-opensource-src-5.1.1/qtwebkit/Source/WebCore/plugins/qt/PluginViewQt.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtwebkit/Source/WebCore/plugins/qt/PluginViewQt.cpp	2013-08-25 20:04:47.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtwebkit/Source/WebCore/plugins/qt/PluginViewQt.cpp	2013-09-25 18:00:29.551215155 +0200
+@@ -702,7 +702,7 @@
+     // support gdk based plugins (like flash) that use a different X connection.
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/lib/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+ 
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtwebkit/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp qt-everywhere-opensource-src-5.1.1/qtwebkit/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+--- qt-everywhere-opensource-src-5.1.1-orig/qtwebkit/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp	2013-08-25 20:04:42.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtwebkit/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp	2013-09-25 18:04:54.955408293 +0200
+@@ -64,7 +64,7 @@
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+ 
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+ 

--- a/pkgs/development/libraries/qt-5/glib-2.32.patch
+++ b/pkgs/development/libraries/qt-5/glib-2.32.patch
@@ -1,0 +1,12 @@
+diff -ruN qt-everywhere-opensource-src-5.1.1-orig/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h qt-everywhere-opensource-src-5.1.1/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h
+--- qt-everywhere-opensource-src-5.1.1-orig/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h	2013-08-25 20:04:35.000000000 +0200
++++ qt-everywhere-opensource-src-5.1.1/qtscript/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Threading.h	2013-09-25 18:09:22.154639482 +0200
+@@ -81,7 +81,7 @@
+ #include <pthread.h>
+ #elif PLATFORM(GTK)
+ #include <wtf/gtk/GOwnPtr.h>
+-typedef struct _GMutex GMutex;
++typedef union _GMutex GMutex;
+ typedef struct _GCond GCond;
+ #endif
+ 

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, mesa, libX11, xproto, libXt
-, useQt4 ? false, qt4 }:
+, qtLib ? null }:
 
 with stdenv.lib;
 
@@ -11,22 +11,22 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "vtk-${os useQt4 "qvtk-"}${version}";
+  name = "vtk-${os (qtLib != null) "qvtk-"}${version}";
   src = fetchurl {
     url = "${meta.homepage}files/release/${majorVersion}/vtk-${version}.tar.gz";
     md5 = "a0363f78910f466ba8f1bd5ab5437cb9";
   };
 
   buildInputs = [ cmake mesa libX11 xproto libXt ]
-    ++ optional useQt4 qt4;
+    ++ optional (qtLib != null) qtLib;
 
   # Shared libraries don't work, because of rpath troubles with the current
   # nixpkgs camke approach. It wants to call a binary at build time, just
   # built and requiring one of the shared objects.
   # At least, we use -fPIC for other packages to be able to use this in shared
   # objects.
-  cmakeFlags = [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ] ++ optional useQt4
-    [ "-DVTK_USE_QT:BOOL=ON" ];
+  cmakeFlags = [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ]
+    ++ optional (qtLib != null) [ "-DVTK_USE_QT:BOOL=ON" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/qtcreator/default.nix
+++ b/pkgs/development/qtcreator/default.nix
@@ -2,7 +2,7 @@
 
 let
   baseVersion = "2.8";
-  revision = "0";
+  revision = "1";
   version = "${baseVersion}.${revision}";
   qt4_for_qtcreator = qt48.override {
     developerBuild = true;
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.qt-project.org/official_releases/qtcreator/${baseVersion}/${version}/qt-creator-${version}-src.tar.gz";
-    sha256 = "7ac5d9a36c2f561f74d77378d4eae95a78c7752b323e1df924d6e895e99f45d2";
+    sha256 = "d5ae007a297a4288d0e95fd605edbfb8aee80f6788c7a6cfb9cb297f50c364b9";
   };
 
   buildInputs = [ qt4_for_qtcreator ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5446,6 +5446,25 @@ let
     qtLib = qt48Full;
   };
 
+  qt5 = callPackage ../development/libraries/qt-5 {
+    mesa = mesa_noglu;
+    cups = if stdenv.isLinux then cups else null;
+    # GNOME dependencies are not used unless gtkStyle == true
+    inherit (gnome) libgnomeui GConf gnome_vfs;
+  };
+
+  qt5Full = qt5.override {
+    buildDocs = true;
+    buildExamples = true;
+    buildTests = true;
+    developerBuild = true;
+  };
+
+  qt5SDK = qtcreator.override {
+    sdkBuild = true;
+    qtLib = qt5Full;
+  };
+
   qtcreator = callPackage ../development/qtcreator {
     qtLib = qt48.override { developerBuild = true; };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5731,7 +5731,7 @@ let
 
   vtk = callPackage ../development/libraries/vtk { };
 
-  vtkWithQt4 = vtk.override { useQt4 = true; };
+  vtkWithQt4 = vtk.override { qtLib = qt4; };
 
   vxl = callPackage ../development/libraries/vxl {
     libpng = libpng12;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5438,6 +5438,16 @@ let
     docs = true;
     demos = true;
     examples = true;
+    developerBuild = true;
+  };
+
+  qt4SDK = qtcreator.override {
+    sdkBuild = true;
+    qtLib = qt48Full;
+  };
+
+  qtcreator = callPackage ../development/qtcreator {
+    qtLib = qt48.override { developerBuild = true; };
   };
 
   qtscriptgenerator = callPackage ../development/libraries/qtscriptgenerator { };
@@ -8510,8 +8520,6 @@ let
   qsampler = callPackage ../applications/audio/qsampler { };
 
   qsynth = callPackage ../applications/audio/qsynth { };
-
-  qtcreator = callPackage ../development/qtcreator { };
 
   qtpfsgui = callPackage ../applications/graphics/qtpfsgui { };
 


### PR DESCRIPTION
Because other people seems to be interested in a Qt 5 package, you can find here my work on the packaging of Qt 5.1.1 for nixpkgs. Technical descriptions are present in each related commit.

As my mesa change will not affect the functional behavior of its current dependencies, I am asking you to directly integrate it into the master branch. You can still push it into x-updates if the necessary mesa and dependencies rebuild on hydra remains an issue for you.

Because I did not had the time yet to write a dedicated wiki page, feel free to ask me anything about programming using Qt 5 and QtCreator and QtSDK (a pre-packaged Qt+QtCreator) on NixOS :wink:
