### PR TITLE
haskellPackages.comonadTransformers: Do not build haddocks

### DIFF
--- a/pkgs/development/libraries/haskell/comonad-transformers/default.nix
+++ b/pkgs/development/libraries/haskell/comonad-transformers/default.nix
@@ -5,10 +5,12 @@ cabal.mkDerivation (self: {
   version = "4.0";
   sha256 = "13zzp6r6s6c80skniphwvzxhpazbyal5854m53139kgcw560rv6z";
   buildDepends = [ comonad ];
+  noHaddock = true;
   meta = {
     homepage = "http://github.com/ekmett/comonad-transformers/";
     description = "This package has been merged into comonad 4.0";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
   };
 })


### PR DESCRIPTION
This package no library provides any modules, so there are no
haddocks to build.
