### PR TITLE
Emacs: Fix TRAMP and enable nix-mode

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -46,11 +46,6 @@ stdenv.mkDerivation rec {
                           (append (reverse (mapcar (lambda (x) (concat x "/share/emacs/site-lisp/"))
                                                    (split-string (getenv "NIX_PROFILES"))))
                            load-path)))
-
-    ;; enable nix-mode (lazy)
-    (autoload 'nix-mode "nix-mode" "Major mode for editing Nix expressions." t)
-    (push '("\\\\.nix\\\\'" . nix-mode) auto-mode-alist)
-    (push '("\\\\.nix.in\\\\'" . nix-mode) auto-mode-alist)
         
     ;; make tramp work for NixOS machines
     (eval-after-load 'tramp '(add-to-list 'tramp-remote-path "/run/current-system/sw/bin"))

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -46,10 +46,16 @@ stdenv.mkDerivation rec {
                           (append (reverse (mapcar (lambda (x) (concat x "/share/emacs/site-lisp/"))
                                                    (split-string (getenv "NIX_PROFILES"))))
                            load-path)))
+
+    ;; enable nix-mode (lazy)
+    (autoload 'nix-mode "nix-mode" "Major mode for editing Nix expressions." t)
+    (push '("\\\\.nix\\\\'" . nix-mode) auto-mode-alist)
+    (push '("\\\\.nix.in\\\\'" . nix-mode) auto-mode-alist)
+        
+    ;; make tramp work for NixOS machines
+    (eval-after-load 'tramp '(add-to-list 'tramp-remote-path "/run/current-system/sw/bin"))
     EOF
   '';
-
-
 
   doCheck = true;
 


### PR DESCRIPTION
After installing emacs using nix, you currently need to add these lines to get nix-mode and make TRAMP work for NixOS systems:

``` lisp
;; enable nix-mode (lazy)
(autoload 'nix-mode "nix-mode" "Major mode for editing Nix expressions." t)
(push '("\.nix\'" . nix-mode) auto-mode-alist)
(push '("\.nix.in\'" . nix-mode) auto-mode-alist)

;; make tramp work for NixOS machines
(eval-after-load 'tramp '(add-to-list 'tramp-remote-path "/run/current-system/sw/bin"))
```

This patch adds these lines to site-start, so they get executed automatically and do not have to be added by the user.
