### PR TITLE
e2fsprogs: Update to 1.42.8.

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libuuid }:
 
 stdenv.mkDerivation rec {
-  name = "e2fsprogs-1.42.7";
+  name = "e2fsprogs-1.42.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/e2fsprogs/${name}.tar.gz";
-    sha256 = "0ibkkvp6kan0hn0d1anq4n2md70j5gcm7mwna515w82xwyr02rfw";
+    sha256 = "b984aaf1fe888d6a4cf8c2e8d397207879599b5368f1d33232c1ec9d68d00c97";
   };
 
   buildInputs = [ pkgconfig libuuid ];


### PR DESCRIPTION
This pull request inspired by a resize2fs near-disaster that wouldn't have happened with this version.

EDIT: ignore what's below this line; I couldn't reproduce it

I noticed that this caused many things to rebuild, including e.g. the X.Org server, which I wouldn't have expected to depend on filesystem tools.  Full list at https://gist.github.com/falsifian/7065503 .
