### PR TITLE
Update fossil to 1.27, and enable the JSON API.

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -1,11 +1,11 @@
-{stdenv, fetchurl, zlib, openssl, tcl, readline, sqlite}:
+{stdenv, fetchurl, zlib, openssl, tcl, readline, sqlite, withJson ? true}:
 
 stdenv.mkDerivation {
-  name = "fossil-1.24";
+  name = "fossil-1.27";
 
   src = fetchurl {
-    url = http://www.fossil-scm.org/download/fossil-src-20121022124804.tar.gz;
-    sha256 = "0gcvcrd368acxd79gh7p7caicgqd0f076n0i2if63mg3b8ivz9im";
+    url = http://www.fossil-scm.org/download/fossil-src-20130911114349.tar.gz;
+    sha256 = "0n40z8bx2311i11zjx2x15lw3q8vzjwvfqzikrjlqnpal4vzd72f";
   };
 
   buildInputs = [ zlib openssl readline sqlite ];
@@ -14,6 +14,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   checkTarget = "test";
+  configureFlags = if withJson then  "--json" else  "";
 
   preBuild=''
     export USER=nonexistent-but-specified-user


### PR DESCRIPTION
Fossil 1.24 is pretty ancient, this updates to 1.27, and enables a new feature by default.
The new feature adds one new command, and no new dependencies. I'm not sure what the policy here is, exactly, in nixpkgs, so I can make it off-by-default if that's the way of things.
