### PR TITLE
openvpn: add openvpn_learnaddress script

### DIFF
--- a/pkgs/tools/networking/openvpn/openvpn_learnaddress.nix
+++ b/pkgs/tools/networking/openvpn/openvpn_learnaddress.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, makeWrapper,  coreutils, gawk, utillinux }:
+
+stdenv.mkDerivation rec {
+  name = "openvpn-learnaddress-19b03c3";
+
+  src = fetchgit {
+    url = https://gist.github.com/4058733.git;
+    rev = "19b03c3beb0190df46ea07bf4b68244acb8eae80";
+    sha256 = "16pcyvyhwsx34i0cjkkx906lmrwdd9gvznvqdwlad4ha8l8f8z42";
+  };
+
+  buildInputs = [ makeWrapper coreutils gawk utillinux ];
+
+  installPhase = ''
+    install -Dm555 ovpn-learnaddress $out/libexec/openvpn/openvpn-learnaddress
+
+    wrapProgram $out/libexec/openvpn/openvpn-learnaddress \
+        --prefix PATH : ${coreutils}/bin:${gawk}/bin:${utillinux}/bin
+  '';
+
+  meta = {
+    description = "Openvpn learn-address script to manage a hosts-like file";
+    homepage = https://gist.github.com/offlinehacker/4058733/;
+    maintainers = [ stdenv.lib.maintainers.offline ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1491,6 +1491,8 @@ let
 
   openvpn = callPackage ../tools/networking/openvpn { };
 
+  openvpn_learnaddress = callPackage ../tools/networking/openvpn/openvpn_learnaddress.nix { };
+
   optipng = callPackage ../tools/graphics/optipng { };
 
   oslrd = callPackage ../tools/networking/oslrd { };


### PR DESCRIPTION
I want to share this common used openvpn script, that learns connected openvpn host names(certificate common names) on tun networks and writes them in hosts file and include it in nixpkgs, so managing tun openvpn networks with many hosts becomes easy.

Example usage for server:

```
    services.openvpn.servers = {
      log =
      let
        ca = pkgs.writeText "ca.crt" (builtins.readFile ./keys/ca.crt);
        cert = pkgs.writeText "server.crt" (builtins.readFile ./keys/server.crt);
        key = pkgs.writeText "server.pem" (builtins.readFile ./keys/server.pem);
        dh = pkgs.writeText "dh1024.pem" (builtins.readFile ./keys/dh1024.pem);
      in {
        config = ''
          dev tun
          proto tcp
          server 10.4.0.0 255.255.255.0
          management 127.0.0.1 5094

          ca ${ca}
          cert ${cert}
          key ${key}
          dh ${dh}

          setenv DOMAIN domain.something.xxx
          learn-address ${pkgs.openvpn_learnaddress}/libexec/openvpn/openvpn-learnaddress
          script-security 2
        '';
      };
    };

    services.dnsmasq = {
      enable = true;
      extraConfig = ''
        addn-hosts=/etc/hosts.openvpn-clients
      '';
    };
```

and for client:

```
    services.openvpn.servers = {
      log =
      let
        ca = pkgs.writeText "ca.crt" (builtins.readFile ./keys/ca.crt);
        cert = pkgs.writeText "client.crt" (builtins.readFile ./keys/client.crt);
        key = pkgs.writeText "client.pem" (builtins.readFile ./keys/client.pem);
        dh = pkgs.writeText "dh1024.pem" (builtins.readFile ./keys/dh1024.pem);
      in {
        config = ''
          client
          dev tun
          proto tcp
          remote domain.something.xxx

          ca ${ca}
          cert ${cert}
          key ${key}
          dh ${dh}
        '';
      };
    };
```
