### PR TITLE
Small fix in handling of "unfree" meta.license attributes

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -49,7 +49,7 @@ let
         # Add a utility function to produce derivations that use this
         # stdenv and its shell.
         mkDerivation = attrs:
-          if !allowUnfree && (let l = attrs.meta.license or ""; in l == "unfree" || l == "unfree-redistributable") then
+          if !allowUnfree && (let l = lib.lists.toList attrs.meta.license or []; in lib.lists.elem "unfree" l || lib.lists.elem "unfree-redistributable" l) then
             throw "package ‘${attrs.name}’ has an unfree license, refusing to evaluate"
           else
             lib.addPassthru (derivation (


### PR DESCRIPTION
meta.license is can be a string or a list of strings. But there is one
unhandled case where "unfree" (or "unfree-redistributable") is a part of
a list. It will currently not be detected as an "unfree" package and
Hydra will attempt to build it. This fixes it.

Example: http://hydra.nixos.org/build/6553461

WARNING: Untested (I don't have hydra)
