### PR TITLE
add residualvm (v0.1.1)

### DIFF
--- a/pkgs/games/residualvm/default.nix
+++ b/pkgs/games/residualvm/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib
+, openglSupport ? false, mesa ? null
+}:
+
+assert openglSupport -> mesa != null;
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec { 
+  version = "0.1.1";
+  name = "residualvm-${version}";
+
+  src = fetchurl { 
+    url = "http://prdownloads.sourceforge.net/residualvm/residualvm-${version}-sources.tar.bz2";
+    sha256 = "99c419b13885a49bdfc10a50a3a6000fd1ba9504f6aae04c74b840ec6f57a963";
+  };
+
+  buildInputs = [ stdenv SDL zlib libmpeg2 libmad libogg libvorbis flac alsaLib ] ++ 
+     optional openglSupport [ mesa ]; 
+
+  configureFlags="--enable-all-engines";
+
+  meta = {
+    description = "ResidualVM is a interpreter for LucasArts' Lua-based 3D adventure games.";
+    homepage = http://residualvm.org/;
+    licencse = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9303,6 +9303,10 @@ let
 
   scummvm = callPackage ../games/scummvm { };
 
+  residualvm = callPackage ../games/residualvm { 
+    openglSupport = mesaSupported; 
+  };
+
   scorched3d = callPackage ../games/scorched3d { };
 
   sdlmame = callPackage ../games/sdlmame { };


### PR DESCRIPTION
ResidualVM is a interpreter for LucasArts' Lua-based 3D adventure
games like Grim Fandango.
