### PR TITLE
Fix the btrfs compile process so that pthread_cancel is linked

### DIFF
--- a/pkgs/tools/filesystems/btrfsprogs/default.nix
+++ b/pkgs/tools/filesystems/btrfsprogs/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib libuuid acl attr e2fsprogs lzo ];
 
+  # for btrfs to get the rpath to libgcc_s, needed for pthread_cancel to work
+  NIX_CFLAGS_LINK = "-lgcc_s";
+
   postPatch = ''
     cp ${./btrfs-set-received-uuid.c} btrfs-set-received-uuid.c
   '';


### PR DESCRIPTION
Currently, the command `btrfs scrub start <filesystem>` attempts to invoke the pthread_cancel routine and ends with an error message about it being missing. This prevents `btrfs scrub status` from maintaining proper statistics about the running scrub. This change forces the btrfs progs to be compiled against libgcc_s, which bring in the pthread_cancel command.
