### PR TITLE
Add ZFS dependencies to the initrd so that the zpool command works.

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -55,11 +55,13 @@ in
           cp -v ${kernel.zfs}/sbin/zfs $out/bin
           cp -v ${kernel.zfs}/sbin/zdb $out/bin
           cp -v ${kernel.zfs}/sbin/zpool $out/bin
+          cp -v ${kernel.zfs}/sbin/mount.zfs $out/bin
+          cp -pdv ${kernel.zfs}/lib/lib*.so* $out/lib
+          cp -pdv ${pkgs.zlib}/lib/lib*.so* $out/lib
         '';
       postDeviceCommands =
         ''
-          zpool import -f -a -d /dev
-          zfs mount -a
+          zpool import -N -a -f
         '';
     };
 
@@ -70,7 +72,7 @@ in
         Type = "oneshot";
         RemainAfterExit = true;
         restartIfChanged = false;
-        ExecStart = "${kernel.zfs}/sbin/zpool import -f -a -d /dev";
+        ExecStart = "${kernel.zfs}/sbin/zpool import -N -a";
       };
     };
 


### PR DESCRIPTION
During my testing of zfs on root I was unable to mount the zfs pool because of missing shared libraries in the initrd. Looking back on old pull requests it looks as though someone thought they weren't necessary.

Additionally, I'm running a more recent kernel which does not wait for scsi devices to mount with the scsi_wait modules. Therefore, I added a hack to force the zpool import command to wait a reasonable amount of time until device nodes have come up.
