### PR TITLE
Adding KVIrc : a IRC Client for Qt and KDE. in kde4.kvirc

### DIFF
--- a/pkgs/applications/networking/irc/kvirc/default.nix
+++ b/pkgs/applications/networking/irc/kvirc/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Graphic IRC client with Qt";
-    license = licences.gpl3;
+    license = licenses.gpl3;
     homepage = http://www.kvirc.net/;
     platforms   = platforms.linux;
   };

--- a/pkgs/applications/networking/irc/kvirc/default.nix
+++ b/pkgs/applications/networking/irc/kvirc/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, qt4, perl, gettext, kdelibs, openssl, zlib}:
+
+let
+  pn = "kvirc";
+  v = "4.2.0";
+in
+
+stdenv.mkDerivation {
+  name = "${pn}-${v}";
+
+  src = fetchurl {
+    url = "ftp://ftp.kvirc.de/pub/${pn}/${v}/source/${pn}-${v}.tar.bz2";
+    sha256 = "9a547d52d804e39c9635c8dc58bccaf4d34341ef16a9a652a5eb5568d4d762cb";
+  };
+
+  buildInputs = [ cmake qt4 perl gettext kdelibs openssl zlib ];
+
+  meta = with stdenv.lib; {
+    description = "Graphic IRC client with Qt";
+    license = "GPL";
+    homepage = http://www.kvirc.net/;
+    platforms   = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/networking/irc/kvirc/default.nix
+++ b/pkgs/applications/networking/irc/kvirc/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Graphic IRC client with Qt";
-    license = "GPL";
+    license = licences.gpl3;
     homepage = http://www.kvirc.net/;
-    platforms   = with stdenv.lib.platforms; linux;
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9557,6 +9557,8 @@ let
 
       konversation = callPackage ../applications/networking/irc/konversation { };
 
+      kvirc = callPackage ../applications/networking/irc/kvirc { };
+
       krename = callPackage ../applications/misc/krename { };
 
       krusader = callPackage ../applications/misc/krusader { };


### PR DESCRIPTION
Hello,
NixPkgs already has some irc clients (though Konversation is the only Qt one) but KVIrc is pretty good, fast, with advanced features, customizable and easy to build with the current NixPkgs. So why not, just one more option.
