### PR TITLE
libusb1: avoid -lgcc_s on darwin

### DIFF
--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig ];
   propagatedBuildInputs = stdenv.lib.optional (stdenv.isLinux) udev;
 
-  NIX_LDFLAGS = "-lgcc_s";
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
   meta = {
     homepage = http://www.libusb.org;


### PR DESCRIPTION
I confess I don't really understand the implications of this, but other packages seem to use the same fix, stating only that libgcc_s isn't available.  I'm just trying to make gnupg build! (it depends on libusb)
