### PR TITLE
Avoid --no-cpp-precomp for Perl on darwin

### DIFF
--- a/pkgs/development/interpreters/perl/5.16/darwin.patch
+++ b/pkgs/development/interpreters/perl/5.16/darwin.patch
@@ -1,0 +1,11 @@
+--- a/hints/darwin.sh	2013-05-08 11:13:45.000000000 -0600
++++ b/hints/darwin.sh	2013-05-08 11:15:04.000000000 -0600
+@@ -129,7 +129,7 @@
+ 
+ # Avoid Apple's cpp precompiler, better for extensions
+ if [ "X`echo | ${cc} -no-cpp-precomp -E - 2>&1 >/dev/null`" = "X" ]; then
+-    cppflags="${cppflags} -no-cpp-precomp"
++    #cppflags="${cppflags} -no-cpp-precomp"
+ 
+     # This is necessary because perl's build system doesn't
+     # apply cppflags to cc compile lines as it should.

--- a/pkgs/development/interpreters/perl/5.16/default.nix
+++ b/pkgs/development/interpreters/perl/5.16/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     [ # Do not look in /usr etc. for dependencies.
       ./no-sys-dirs.patch
     ]
-    ++ stdenv.lib.optional stdenv.isDarwin ./no-libutil.patch;
+    ++ stdenv.lib.optional stdenv.isDarwin [ ./darwin.patch ./no-libutil.patch ] ;
 
   # Build a thread-safe Perl with a dynamic libperls.o.  We need the
   # "installstyle" option to ensure that modules are put under


### PR DESCRIPTION
Taken from https://trac.macports.org/ticket/38913
