### PR TITLE
mathematica: fix x86 build of mathematica

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -18,10 +18,8 @@
 
 let
   platform =
-    if stdenv.system == "i686-linux" then
+    if stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux" then
       "Linux"
-    else if stdenv.system == "x86_64-linux" then
-      "Linux-x86-64"
     else
       throw "Mathematica requires i686-linux or x86_64 linux";
 in


### PR DESCRIPTION
the MathInstaller doesn't distinguish between 64bit and 32bit linux
platforms.
