### PR TITLE
haskell-wxc: noHaddock

### DIFF
--- a/pkgs/development/libraries/haskell/wxHaskell/wxc.nix
+++ b/pkgs/development/libraries/haskell/wxHaskell/wxc.nix
@@ -10,6 +10,7 @@ cabal.mkDerivation (self: {
     cp -v dist/build/libwxc.so.${self.version} $out/lib/libwxc.so
   '';
   patches = [ ./fix-bogus-pointer-assignment.patch ];
+  noHaddock = true;
   meta = {
     homepage = "http://haskell.org/haskellwiki/WxHaskell";
     description = "wxHaskell C++ wrapper";


### PR DESCRIPTION
wxc provides a C wrapper around the wxWidgets C++ code.  No haddock docs to be found.
