### PR TITLE
darwin x11/opengl: only copy subset of pkgconfigs

### DIFF
--- a/pkgs/os-specific/darwin/native-x11-and-opengl/default.nix
+++ b/pkgs/os-specific/darwin/native-x11-and-opengl/default.nix
@@ -7,6 +7,10 @@ stdenv.mkDerivation rec {
 
   builder = writeScript "${name}-builder.sh" ''
     /bin/mkdir -p $out
-    /bin/ln -sv /usr/X11/{bin,lib,include,share} $out/
+    /bin/mkdir $out/lib
+    /bin/ln -sv /usr/X11/lib/{*.dylib,X11,xorg} $out/lib
+    /bin/mkdir $out/lib/pkgconfig
+    /bin/ln -sv /usr/X11/lib/pkgconfig/{x*.pc,gl*.pc} $out/lib/pkgconfig
+    /bin/ln -sv /usr/X11/{bin,include,share} $out/
   '';
 }


### PR DESCRIPTION
Copy only the pc files related to X11 and OpenGL.

This should allow us to build our own version of libraries like
cairo without having the native ones be accidentally dynamically
linked in to things that depend on them.

Before this patch if we `dyldinfo -dylibs libpangocairo` we can
see that it was dynamically linked against the OS X (but seemingly
built against include files from the nix one, as we would get a
runtime complaint about missing symbols)

---

This fixes an issues I was experiencing where if I ran graphviz from a GUI app (but not when I ran it from the terminal), I would get a complaint like this:

```
dyld: lazy symbol binding failed: Symbol not found: _cairo_quartz_font_face_create_for_cgfont
Referenced from: /nix/store/xbbaz0qyjcqp0pgnhw6akdwnws74b2yr-pango-1.32.5/lib/libpangocairo-1.0.0.dylib
Expected in: flat namespace

dyld: Symbol not found: _cairo_quartz_font_face_create_for_cgfont
Referenced from: /nix/store/xbbaz0qyjcqp0pgnhw6akdwnws74b2yr-pango-1.32.5/lib/libpangocairo-1.0.0.dylib
Expected in: flat namespace
```

And further inspection of that dylib would reveal /usr/X11/lib/libcairo…
