### PR TITLE
Removed unnecessary mkIf in elasticserach

### DIFF
--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -91,7 +91,7 @@ in {
         target = "elasticsearch/logging.yml"; }
     ];
 
-    systemd.services.elasticsearch = mkIf cfg.enable {
+    systemd.services.elasticsearch = {
       description = "Elasticsearch daemon";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];


### PR DESCRIPTION
The whole block is already wrapped in cfg.enable and this breaks some things.
