### PR TITLE
Fix remmina the FreeRDP GUI frontend

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -1,8 +1,21 @@
 { stdenv, fetchurl, cmake, pkgconfig, makeWrapper
 , glib, gtk, gettext, libxkbfile, libgnome_keyring, libX11
-, freerdp, libssh, libgcrypt, gnutls }:
+, freerdp, libssh, libgcrypt, gnutls, makeDesktopItem }:
 
-let version = "1.0.0"; in
+let
+  version = "1.0.0";
+  
+  desktopItem = makeDesktopItem {
+    name = "remmina";
+    desktopName = "Remmina";
+    genericName = "Remmina Remote Desktop Client";
+    exec = "remmina";
+    icon = "remmina";
+    comment = "Connect to remote desktops";
+    categories = "GTK;GNOME;X-GNOME-NetworkSettings;Network;";
+  };
+
+in
 
 stdenv.mkDerivation {
   name = "remmina-${version}";
@@ -21,6 +34,10 @@ stdenv.mkDerivation {
   patches = [ ./lgthread.patch ];
 
   postInstall = ''
+    mkdir -pv $out/share/applications
+    mkdir -pv $out/share/icons
+    cp ${desktopItem}/share/applications/* $out/share/applications
+    cp -r $out/share/remmina/icons/* $out/share/icons
     wrapProgram $out/bin/remmina --prefix LD_LIBRARY_PATH : "${libX11}/lib"
   '';
 

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation {
 
   cmakeFlags = "-DWITH_VTE=OFF -DWITH_TELEPATHY=OFF -DWITH_AVAHI=OFF";
 
+  patches = [ ./lgthread.patch ];
+
   postInstall = ''
     wrapProgram $out/bin/remmina --prefix LD_LIBRARY_PATH : "${libX11}/lib"
   '';

--- a/pkgs/applications/networking/remote/remmina/lgthread.patch
+++ b/pkgs/applications/networking/remote/remmina/lgthread.patch
@@ -1,0 +1,16 @@
+Fix [undefined reference to `g_thread_init'] as suggested by
+http://ragnermagalhaes.blogspot.ru/2007/09/undefined-reference-to-gthreadinit.html
+
+diff -ru FreeRDP-Remmina-356c033.orig/remmina/CMakeLists.txt FreeRDP-Remmina-356c033/remmina/CMakeLists.txt
+--- FreeRDP-Remmina-356c033.orig/remmina/CMakeLists.txt	2013-11-05 12:43:27.660276912 +0400
++++ FreeRDP-Remmina-356c033/remmina/CMakeLists.txt	2013-11-05 12:53:39.607018349 +0400
+@@ -132,6 +132,8 @@
+ 	endif()
+ endif()
+ 
++set( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -lgthread-2.0" )
++
+ add_subdirectory(po)
+ add_subdirectory(icons)
+ add_subdirectory(desktop)
+


### PR DESCRIPTION
The patch fixes [undefined reference to `g_thread_init'] as suggested by
http://ragnermagalhaes.blogspot.ru/2007/09/undefined-reference-to-gthreadinit.html
