### PR TITLE
HTTPD: Check for SSL Cert value before building with SSL support.

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -260,7 +260,7 @@ let
 
     '' else ""}
 
-    ${if cfg.globalRedirect != null then ''
+    ${if cfg.globalRedirect != null && cfg.globalRedirect != "" then ''
       RedirectPermanent / ${cfg.globalRedirect}
     '' else ""}
 

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -584,8 +584,8 @@ in
   config = mkIf config.services.httpd.enable {
   
     assertions = [ { assertion = mainCfg.enableSSL == true
-                               -> mainCfg.sslServerCert != null && mainCfg.sslServerCert != ""
-                                    && mainCfg.sslServerKey != null && mainCfg.sslServerKey != "";
+                               -> mainCfg.sslServerCert != null
+                                    && mainCfg.sslServerKey != null;
                      message = "SSL is enabled for HTTPD, but sslServerCert and/or sslServerKey haven't been specified."; }
                  ];
 

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -582,6 +582,12 @@ in
   ###### implementation
 
   config = mkIf config.services.httpd.enable {
+  
+    assertions = [ { assertion = mainCfg.enableSSL == true
+                               -> mainCfg.sslServerCert != null && mainCfg.sslServerCert != ""
+                                    && mainCfg.sslServerKey != null && mainCfg.sslServerKey != "";
+                     message = "SSL is enabled for HTTPD, but sslServerCert and/or sslServerKey haven't been specified."; }
+                 ];
 
     users.extraUsers = optionalAttrs (mainCfg.user == "wwwrun") singleton
       { name = "wwwrun";


### PR DESCRIPTION
HTTPD: Ensure user specifies SSL Cert and SSL Key paths when enabling SSL.

I want to fix this error. My NixOS instance had no SSL certs when I enabled SSL and rebuilt.
The build succeeded, but the HTTPD didn't start. The error? Pasted below.

"[error] Server should be SSL-aware but has no certificate configured [Hint: SSLCertificateFile]"

An assertion won't completely prevent this error, but it is helpful.
