### PR TITLE
gnuplot on MacOS X (2nd attempt at #1166)

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
 , alsaLib, cairo
-, withX ? true
+, withX ? !stdenv.isDarwin
 }:
 
 assert (libXft != null) -> libpng != null;	# probably a bug

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -6,6 +6,7 @@
 , libXt ? null
 , libXpm ? null
 , libXaw ? null
+, aquaterm ? false
 , wxGTK ? null
 , pango ? null
 , cairo ? null
@@ -24,15 +25,18 @@ stdenv.mkDerivation rec {
     sha256 = "1xd7gqdhlk7k1p9yyqf9vkk811nadc7m4si0q3nb6cpv4pxglpyz";
   };
 
+  withX = libX11 != null && !aquaterm;
+
   buildInputs =
-    [ zlib gd texinfo readline emacs lua texLive libX11 libXt libXpm libXaw
+    [ zlib gd texinfo readline emacs lua texLive
       pango cairo pkgconfig makeWrapper ]
+    ++ stdenv.lib.optionals withX              [ libX11 libXpm libXt libXaw ]
     # compiling with wxGTK causes a malloc (double free) error on darwin
     ++ stdenv.lib.optional (!stdenv.isDarwin) wxGTK;
 
-  configureFlags = if libX11 != null then ["--with-x"] else ["--without-x"];
+  configureFlags = if withX then ["--with-x"] else ["--without-x"];
 
-  postInstall = stdenv.lib.optionalString (libX11 != null) ''
+  postInstall = stdenv.lib.optionalString withX ''
     wrapProgram $out/bin/gnuplot \
        --prefix PATH : '${gnused}/bin' \
        --prefix PATH : '${coreutils}/bin' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1003,6 +1003,9 @@ let
       else stdenv;
   };
 
+  # must have AquaTerm installed separately
+  gnuplot_aquaterm = gnuplot.override { aquaterm = true; };
+
   gnused = callPackage ../tools/text/gnused { };
 
   gnutar = callPackage ../tools/archivers/gnutar { };


### PR DESCRIPTION
#1166 removed the emacs dependency and built with the aqua driver by default on Mac.  But there are two problems:
1. we need emacs for the Gnuplot Lisp code
2. this aqua driver thing seems to require that AquaTerm be installed on compile time

So this version sticks with the X11 version by default, but offers a top-level gnuplot_aquaterm that you can use to build a more Mac-y gnuplot.

I haven't yet dared contribute an Aquaterm derivation because I don't really know what I'm doing.  It's currently installed as a “framework” (/Library/Frameworks/AquaTerm.framework) which I dimly understand to be self-contained collections of libraries.  I imagine some future nixpkgs will be able to install frameworks too so you get something like ~/.nix-profile/Frameworks.
