### PR TITLE
wget darwin: disable Test-iri-disabled.px

### DIFF
--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0yqllj3nv9p3vqbdm6j4nvpjcwf1y19rq8sd966nrbd2qvvxfq8p";
   };
 
+  patches = stdenv.lib.optional stdenv.isDarwin ./iri-test.patch;
+
   preConfigure = stdenv.lib.optionalString doCheck
     '' for i in "doc/texi2pod.pl" "tests/run-px" "util/rmold.pl"
        do

--- a/pkgs/tools/networking/wget/iri-test.patch
+++ b/pkgs/tools/networking/wget/iri-test.patch
@@ -1,0 +1,12 @@
+diff -r --unified a/wget-1.14/tests/run-px b/wget-1.14/tests/run-px
+--- a/tests/run-px	2012-06-16 11:58:11.000000000 +0100
++++ b/tests/run-px	2013-11-02 14:06:14.000000000 +0000
+@@ -48,7 +48,7 @@
+     'Test-idn-robots-utf8.px',
+     'Test-iri.px',
+     'Test-iri-percent.px',
+-    'Test-iri-disabled.px',
++    #'Test-iri-disabled.px',
+     'Test-iri-forced-remote.px',
+     'Test-iri-list.px',
+     'Test-k.px',


### PR DESCRIPTION
This test fails on MacOS X. The failure has something to do with
the tests expecting filesystems to accept/store filenames as
bytes. On the HFS+ filesystem, however, filenames are Unicode
characters (Normalisation Form D).

This wget ticket appears to be relevant
    http://savannah.gnu.org/bugs/index.php?27541

The maintainer does not seem to think that this test
failure represents a problem in practice:
    http://article.gmane.org/gmane.comp.web.wget.general/8988

But this patch should be revisited/removed if this aspect of wget is
ever addressed in the future.

NB: I'm also a bit concerned/confused that none of the tests mentioned
in that message seem to fail, so I'm not 100% sure if this is the
relevant issue.
