### PR TITLE
Libvirtd fixes

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -82,8 +82,11 @@ in
             mkdir -p /var/log/libvirt/qemu -m 755
             rm -f /var/run/libvirtd.pid
 
-            mkdir -p /var/lib/libvirt -m 700
-            mkdir -p /var/lib/libvirt/dnsmasq -m 700
+            mkdir -p /var/lib/libvirt
+            mkdir -p /var/lib/libvirt/dnsmasq
+
+            chmod 755 /var/lib/libvirt
+            chmod 755 /var/lib/libvirt/dnsmasq
 
             # Libvirt unfortunately writes mutable state (such as
             # runtime changes to VM, network or filter configurations)

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, libxml2, gnutls, devicemapper, perl, python
 , iproute, iptables, readline, lvm2, utillinux, udev, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, makeWrapper, pmutils, libcap_ng
+, dnsmasq
 }:
 
 let version = "1.1.4"; in
@@ -21,7 +22,7 @@ stdenv.mkDerivation {
 
   preConfigure =
     ''
-      PATH=${iproute}/sbin:${iptables}/sbin:${ebtables}/sbin:${lvm2}/sbin:${udev}/sbin:$PATH
+      PATH=${iproute}/sbin:${iptables}/sbin:${ebtables}/sbin:${lvm2}/sbin:${udev}/sbin:${dnsmasq}/bin:$PATH
       patchShebangs . # fixes /usr/bin/python references
     '';
 


### PR DESCRIPTION
Two small fixes for libvirtd + libvirtd-service that makes virt-manager work again.
