### PR TITLE
nixos: capitalize a bunch of service descriptions

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -131,7 +131,7 @@ in {
       users.extraGroups.pulse.gid = gid;
 
       systemd.services.pulseaudio = {
-        description = "PulseAudio system-wide server";
+        description = "PulseAudio System-Wide Server";
         wantedBy = [ "sound.target" ];
         before = [ "sound.target" ];
         path = [ cfg.package ];

--- a/nixos/modules/programs/venus.nix
+++ b/nixos/modules/programs/venus.nix
@@ -161,7 +161,7 @@ in
       '';
 
     systemd.services.venus =
-      { description = "Planet Venus, an awesome ‘river of news’ feed reader";
+      { description = "Planet Venus Feed Reader";
         path  = [ pkgs.venus ];
         script = "exec venus-planet ${configFile}";
         serviceConfig.User = "${cfg.user}";

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -28,7 +28,7 @@ with pkgs.lib;
     services.dbus.packages = [ pkgs.bluez ];
 
     systemd.services."dbus-org.bluez" = {
-      description = "Bluetooth service";
+      description = "Bluetooth Service";
       serviceConfig = {
         Type = "dbus";
         BusName = "org.bluez";

--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -148,7 +148,7 @@ in
     #   wall: cannot get tty name: Inappropriate ioctl for device
     # The message still gets through.
     systemd.services.apcupsd = {
-      description = "APC UPS daemon";
+      description = "APC UPS Daemon";
       wantedBy = [ "multi-user.target" ];
       preStart = "mkdir -p /run/apcupsd/";
       serviceConfig = {
@@ -172,7 +172,7 @@ in
       before = [ "final.target" ];
       wantedBy = [ "shutdown.target" ];
       unitConfig = {
-        Description = "APC UPS killpower";
+        Description = "APC UPS Kill Power";
         ConditionPathExists = "/run/apcupsd/powerfail";
         DefaultDependencies = "no";
       };

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -172,7 +172,7 @@ in {
     ];
 
     systemd.services.carbonCache = mkIf cfg.carbon.enableCache {
-      description = "Graphite data storage backend";
+      description = "Graphite Data Storage Backend";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];
       environment = carbonEnv;
@@ -190,7 +190,7 @@ in {
     };
 
     systemd.services.carbonAggregator = mkIf cfg.carbon.enableAggregator {
-      description = "Carbon data aggregator";
+      description = "Carbon Data Aggregator";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];
       environment = carbonEnv;
@@ -201,7 +201,7 @@ in {
     };
 
     systemd.services.carbonRelay = mkIf cfg.carbon.enableRelay {
-      description = "Carbon data relay";
+      description = "Carbon Data Relay";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];
       environment = carbonEnv;
@@ -212,7 +212,7 @@ in {
     };
 
     systemd.services.graphiteWeb = mkIf cfg.web.enable {
-      description = "Graphite web interface";
+      description = "Graphite Web Interface";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];
       environment = {

--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -182,7 +182,7 @@ in
   }) (mkIf nodeCfg.enable {
 
     systemd.services.munin-node = {
-      description = "Munin node, the agent process";
+      description = "Munin Node";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.munin ];

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -57,7 +57,7 @@ let
   nssModulesPath = config.system.nssModules.path;
 
   daemonService = appName: args:
-    { description = "Samba Service daemon ${appName}";
+    { description = "Samba Service Daemon ${appName}";
 
       wantedBy = [ "samba.target" ];
       partOf = [ "samba.target" ];
@@ -211,7 +211,7 @@ in
 
         systemd = {
           targets.samba = {
-            description = "Samba server";
+            description = "Samba Server";
             requires = [ "samba-setup.service" ];
             after = [ "samba-setup.service" "network.target" ];
             wantedBy = [ "multi-user.target" ];
@@ -222,7 +222,7 @@ in
             "samba-smbd" = daemonService "smbd" "-F";
             "samba-winbindd" = daemonService "winbindd" "-F";
             "samba-setup" = {
-              description = "Samba setup task";
+              description = "Samba Setup Task";
               script = setupScript;
               unitConfig.RequiresMountsFor = "/home/smbd /var/samba /var/log/samba";
             };

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -76,7 +76,7 @@ in
     };
 
     systemd.services."zfs-mount" = {
-      description = "Mount zfs volumes";
+      description = "Mount ZFS Volumes";
       after = [ "zpool-import.service" ];
       wantedBy = [ "local-fs.target" ];
       serviceConfig = {

--- a/nixos/modules/virtualisation/nova.nix
+++ b/nixos/modules/virtualisation/nova.nix
@@ -113,7 +113,7 @@ in
     jobs.nova_objectstore =
       { name = "nova-objectstore";
 
-        description = "Nova simple object store service";
+        description = "Nova Simple Object Store Service";
 
         startOn = "ip-up";
 
@@ -129,7 +129,7 @@ in
     jobs.nova_scheduler =
       { name = "nova-scheduler";
 
-        description = "Nova scheduler service";
+        description = "Nova Scheduler Service";
 
         startOn = "ip-up";
 
@@ -140,7 +140,7 @@ in
     jobs.nova_compute =
       { name = "nova-compute";
 
-        description = "Nova compute service";
+        description = "Nova Compute Service";
 
         startOn = "ip-up";
 
@@ -157,7 +157,7 @@ in
     jobs.nova_network =
       { name = "nova-network";
 
-        description = "Nova network service";
+        description = "Nova Network Service";
 
         startOn = "ip-up";
 

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -107,7 +107,7 @@ in
       '';
 
     jobs.xend =
-      { description = "Xen control daemon";
+      { description = "Xen Control Daemon";
 
         startOn = "stopped udevtrigger";
 


### PR DESCRIPTION
(systemd service descriptions that is, not service descriptions in "man
configuration.nix".)

Capitalizing each word in the description seems to be the accepted
standard.

Also shorten these descriptions:
- "Munin node, the agent process" => "Munin Node"
- "Planet Venus, an awesome ‘river of news’ feed reader" => "Planet Venus Feed Reader"
