### PR TITLE
alsa: bump 1.0.26 -> 1.0.27

### DIFF
--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "alsa-lib-1.0.26";
+  name = "alsa-lib-1.0.27.2";
 
   src = fetchurl {
     urls = [
      "ftp://ftp.alsa-project.org/pub/lib/${name}.tar.bz2"
      "http://alsa.cybermirror.org/lib/${name}.tar.bz2"
     ];
-    sha256 = "0zbfkwqn7ixa71lsna9llq6i2gic540h8r8r0rjdphrwc1hq37wc";
+    sha256 = "068d8c92122hwca5jzhrjp4a131995adlb1d79zgrm7gwy9x63k9";
   };
 
   configureFlags = "--disable-xmlto";

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, lib, pkgconfig, alsaLib, pulseaudio ? null, jackaudio ? null }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-plugins-1.0.26";
+  name = "alsa-plugins-1.0.27";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.alsa-project.org/pub/plugins/${name}.tar.bz2"
       "http://alsa.cybermirror.org/plugins/${name}.tar.bz2"
     ];
-    sha256 = "07wz3kl6isabk15ddpzz820pqlgvw6q0m7knnbgv9780s8s52l83";
+    sha256 = "0ddbycq4cn9mc8xin0vh1af0zywz2rc2xyrs6qbayyyxq8vhrg8b";
   };
 
   buildInputs =

--- a/pkgs/os-specific/linux/alsa-utils/default.nix
+++ b/pkgs/os-specific/linux/alsa-utils/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, alsaLib, gettext, ncurses, libsamplerate}:
 
 stdenv.mkDerivation rec {
-  name = "alsa-utils-1.0.26";
+  name = "alsa-utils-1.0.27";
 
   src = fetchurl {
     # url = "ftp://ftp.alsa-project.org/pub/utils/${name}.tar.bz2";
     url = "http://alsa.cybermirror.org/utils/${name}.tar.bz2";
-    sha256 = "1rw1n3w8syqky9i7kwy5xd2rzfdbihxas32vwfxpb177lqx2lpzq";
+    sha256 = "1vssljbdzf0psqhhd7w9m9mzb0sl2kgx9fagkja25sqw6ivwsxkg";
   };
 
   buildInputs = [ alsaLib ncurses libsamplerate ];


### PR DESCRIPTION
Basically, bump all alsa projects to their latest version as per

http://www.alsa-project.org/main/index.php/Main_Page

WARNING: This causes massive rebuilds.
