### PR TITLE
xfce: enable tumbler the thumbnail manager

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -72,6 +72,7 @@ in
         pkgs.xfce.thunar_volman
         pkgs.xfce.gvfs
         pkgs.xfce.xfce4_appfinder
+        pkgs.xfce.tumbler
       ]
       ++ optional config.powerManagement.enable pkgs.xfce.xfce4_power_manager;
 

--- a/pkgs/desktops/xfce/core/tumbler.nix
+++ b/pkgs/desktops/xfce/core/tumbler.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, intltool, dbus_glib, gdk_pixbuf }:
+{ stdenv, fetchurl, pkgconfig, intltool, dbus_glib, gdk_pixbuf, curl, freetype,
+libgsf, poppler, bzip2 }:
 
 stdenv.mkDerivation rec {
   p_name  = "tumbler";
@@ -11,11 +12,24 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  buildInputs = [ pkgconfig intltool dbus_glib gdk_pixbuf ];
+  buildInputs = [ pkgconfig intltool dbus_glib gdk_pixbuf curl freetype
+    poppler libgsf bzip2];
+
+  configureFlags = [
+    # Needs gst-tag
+    # "--enable-gstreamer-thumbnailer"
+
+    # Needs libffmpegthumbnailer
+    # "--enable-ffmpeg-thumbnailer"
+    
+    "--enable-odf-thumbnailer"
+    "--enable-poppler-thumbnailer"
+  ];
 
   meta = {
     homepage = http://git.xfce.org/xfce/tumbler/;
     description = "A D-Bus thumbnailer service";
+    platforms = stdenv.lib.platforms.linux;
     license = "GPLv2";
   };
 }


### PR DESCRIPTION
Enable the tumbler and turn on more thumbnail plugins. This affects Thunar and Ristretto.  
