### PR TITLE
xfce: add icon cache hack

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
       libstartup_notification
     ];
 
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
A hack to remove local icon cache. In case of installing this lib into local profile
