### PR TITLE
boost-headers: fix hardcoded hash

### DIFF
--- a/pkgs/development/libraries/boost/header-only-wrapper.nix
+++ b/pkgs/development/libraries/boost/header-only-wrapper.nix
@@ -8,10 +8,7 @@ in
 stdenv.mkDerivation {
   name = "boost-headers-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/boost/${pkgid}.tar.bz2";
-    sha256 = "07df925k56pbz3gvhxpx54aij34qd40a7sxw4im11brnwdyr4zh4";
-  };
+  src = boost.src;
 
   phases = [ "installPhase" ];
 


### PR DESCRIPTION
boost-headers has the hash of 1.54 or so hardcoded, which breaks now that we use 1.55.

Just use the src from boost itself instead...
