### PR TITLE
Fix haskell-language-ecmasrcript

### DIFF
--- a/pkgs/development/libraries/haskell/language-ecmascript/default.nix
+++ b/pkgs/development/libraries/haskell/language-ecmascript/default.nix
@@ -4,6 +4,7 @@
 }:
 
 cabal.mkDerivation (self: {
+  doCheck = false;
   pname = "language-ecmascript";
   version = "0.15.2";
   sha256 = "1iszs9f2jryddcz36a6anfyfxpwjhzn49xjqvnd5m6rjdq6y403w";

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1371,7 +1371,9 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   languageCQuote = callPackage ../development/libraries/haskell/language-c-quote {};
 
-  languageEcmascript = callPackage ../development/libraries/haskell/language-ecmascript {};
+  languageEcmascript = callPackage ../development/libraries/haskell/language-ecmascript {
+    QuickCheck = with self; QuickCheck_2_5_1_1;
+  };
 
   languageJava = callPackage ../development/libraries/haskell/language-java {};
 


### PR DESCRIPTION
Fix version mismatch in Cabal dependency, disable tests.

language-ecmascript requires Cabal 2.5. Tests fail with Cabal 2.5.1.1 and Cabal 2.6 for me.
