### PR TITLE
Update Haskell 'tasty' family of libraries; Update haskellPackages.smallcheck

### DIFF
--- a/pkgs/development/libraries/haskell/smallcheck/default.nix
+++ b/pkgs/development/libraries/haskell/smallcheck/default.nix
@@ -2,14 +2,17 @@
 
 cabal.mkDerivation (self: {
   pname = "smallcheck";
-  version = "1.0.4";
-  sha256 = "0zqssw7r56k7gi1lxdss3f4piqa692y728rli9p81q9rbcvi3x7z";
+  version = "1.1";
+  sha256 = "167dhi0j4mfmf9idjcfx0x1y1jajx4qmgcpiia93vjpmv8ha56j8";
   buildDepends = [ logict mtl ];
   meta = {
     homepage = "https://github.com/feuerbach/smallcheck";
     description = "A property-based testing library";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    maintainers = [ self.stdenv.lib.maintainers.andres ];
+    maintainers = [
+      self.stdenv.lib.maintainers.andres
+      self.stdenv.lib.maintainers.ocharles
+    ];
   };
 })

--- a/pkgs/development/libraries/haskell/tasty-ant-xml/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-ant-xml/default.nix
@@ -14,5 +14,6 @@ cabal.mkDerivation (self: {
     description = "A tasty ingredient to output test results in XML, using the Ant schema. This XML can be consumed by the Jenkins continuous integration framework.";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/tasty-ant-xml/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-ant-xml/default.nix
@@ -1,0 +1,18 @@
+{ cabal, genericDeriving, mtl, reducers, stm, tagged, tasty
+, transformers, xml
+}:
+
+cabal.mkDerivation (self: {
+  pname = "tasty-ant-xml";
+  version = "1.0.0.1";
+  sha256 = "1yn337dr9clzrkr8kpvm7x07lyb3v8pcijrddqah08k0ds8zpzcj";
+  buildDepends = [
+    genericDeriving mtl reducers stm tagged tasty transformers xml
+  ];
+  meta = {
+    homepage = "http://github.com/ocharles/tasty-ant-xml";
+    description = "A tasty ingredient to output test results in XML, using the Ant schema. This XML can be consumed by the Jenkins continuous integration framework.";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/tasty-golden/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-golden/default.nix
@@ -1,0 +1,19 @@
+{ cabal, filepath, mtl, optparseApplicative, tagged, tasty
+, temporary
+}:
+
+cabal.mkDerivation (self: {
+  pname = "tasty-golden";
+  version = "2.2";
+  sha256 = "0z49w4ksbbih3x0j170pfy93r2d68jw34hdni4s2p43kds52cakb";
+  buildDepends = [
+    filepath mtl optparseApplicative tagged tasty temporary
+  ];
+  meta = {
+    homepage = "https://github.com/feuerbach/tasty-golden";
+    description = "Golden tests support for tasty";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
+  };
+})

--- a/pkgs/development/libraries/haskell/tasty-hspec/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-hspec/default.nix
@@ -1,0 +1,15 @@
+{ cabal, hspec, tasty }:
+
+cabal.mkDerivation (self: {
+  pname = "tasty-hspec";
+  version = "0.1";
+  sha256 = "1pf4ffaqy0f25a2sjirg5g4gdcfslapwq4mm0pkdsysmh9bv1f64";
+  buildDepends = [ hspec tasty ];
+  meta = {
+    homepage = "http://github.com/mitchellwrosen/tasty-hspec";
+    description = "Hspec support for the Tasty test framework";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
+  };
+})

--- a/pkgs/development/libraries/haskell/tasty-hunit/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-hunit/default.nix
@@ -9,5 +9,6 @@ cabal.mkDerivation (self: {
     description = "HUnit support for the Tasty test framework";
     license = self.stdenv.lib.licenses.mit;
     platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/tasty-quickcheck/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-quickcheck/default.nix
@@ -1,0 +1,14 @@
+{ cabal, QuickCheck, random, tagged, tasty }:
+
+cabal.mkDerivation (self: {
+  pname = "tasty-quickcheck";
+  version = "0.3.1";
+  sha256 = "1rajvcq2a1yxdbb4kykvab1p9rnmsd2lgmlk61nd4fxvsvfj5gzn";
+  buildDepends = [ QuickCheck random tagged tasty ];
+  meta = {
+    description = "QuickCheck support for the Tasty test framework";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
+  };
+})

--- a/pkgs/development/libraries/haskell/tasty-smallcheck/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-smallcheck/default.nix
@@ -10,5 +10,6 @@ cabal.mkDerivation (self: {
     description = "SmallCheck support for the Tasty test framework";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/tasty-th/default.nix
+++ b/pkgs/development/libraries/haskell/tasty-th/default.nix
@@ -1,0 +1,15 @@
+{ cabal, languageHaskellExtract, tasty }:
+
+cabal.mkDerivation (self: {
+  pname = "tasty-th";
+  version = "0.1.1";
+  sha256 = "0ndwfz2gq0did6dfjilhdaxzya2qw9gckjkj090cp2rbkahywsga";
+  buildDepends = [ languageHaskellExtract tasty ];
+  meta = {
+    homepage = "http://github.com/bennofs/tasty-th";
+    description = "Automagically generate the HUnit- and Quickcheck-bulk-code using Template Haskell";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
+  };
+})

--- a/pkgs/development/libraries/haskell/tasty/default.nix
+++ b/pkgs/development/libraries/haskell/tasty/default.nix
@@ -13,5 +13,6 @@ cabal.mkDerivation (self: {
     description = "Modern and extensible testing framework";
     license = self.stdenv.lib.licenses.mit;
     platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
   };
 })

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2052,6 +2052,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   tastyHunit = callPackage ../development/libraries/haskell/tasty-hunit {};
 
+  tastyQuickcheck = callPackage ../development/libraries/haskell/tasty-quickcheck {};
+
   tastySmallcheck = callPackage ../development/libraries/haskell/tasty-smallcheck {};
 
   templateDefault = callPackage ../development/libraries/haskell/template-default {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2048,6 +2048,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   tastyAntXml = callPackage ../development/libraries/haskell/tasty-ant-xml {};
 
+  tastyGolden = callPackage ../development/libraries/haskell/tasty-golden {};
+
   tastyHspec = callPackage ../development/libraries/haskell/tasty-hspec {};
 
   tastyHunit = callPackage ../development/libraries/haskell/tasty-hunit {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2046,6 +2046,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   tasty = callPackage ../development/libraries/haskell/tasty {};
 
+  tastyAntXml = callPackage ../development/libraries/haskell/tasty-ant-xml {};
+
   tastyHunit = callPackage ../development/libraries/haskell/tasty-hunit {};
 
   tastySmallcheck = callPackage ../development/libraries/haskell/tasty-smallcheck {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2058,6 +2058,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   tastySmallcheck = callPackage ../development/libraries/haskell/tasty-smallcheck {};
 
+  tastyTh = callPackage ../development/libraries/haskell/tasty-th {};
+
   templateDefault = callPackage ../development/libraries/haskell/template-default {};
 
   temporary = callPackage ../development/libraries/haskell/temporary {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2048,6 +2048,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   tastyAntXml = callPackage ../development/libraries/haskell/tasty-ant-xml {};
 
+  tastyHspec = callPackage ../development/libraries/haskell/tasty-hspec {};
+
   tastyHunit = callPackage ../development/libraries/haskell/tasty-hunit {};
 
   tastySmallcheck = callPackage ../development/libraries/haskell/tasty-smallcheck {};


### PR DESCRIPTION
See commits for specific packages updated. Mostly bringing the 'tasty' ecosystem up to date, and also bringing in the latest version of smallcheck.
