### PR TITLE
LuaJIT: New package

### DIFF
--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchurl} :
+
+stdenv.mkDerivation rec{
+    version = "2.0.2";
+    name = "LuaJIT-${version}";
+
+    src = fetchurl {
+        url="http://luajit.org/download/LuaJIT-2.0.2.tar.gz";
+        sha256="0f3cykihfdn3gi6na9p0xjd4jnv26z18m441n5vyg42q9abh4ln0";
+    };
+
+    installPhase = ''
+        mkdir -p $out
+        make install PREFIX=$out
+    '';
+
+    meta = {
+        description= "Just-in-time compiler and interpreter for lua 5.1.";
+        homepage = http://luajit.org;
+        license = stdenv.lib.licenses.mit;
+    };
+}

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec{
     name = "LuaJIT-${version}";
 
     src = fetchurl {
-        url="http://luajit.org/download/LuaJIT-2.0.2.tar.gz";
+        url="http://luajit.org/download/${name}.tar.gz";
         sha256="0f3cykihfdn3gi6na9p0xjd4jnv26z18m441n5vyg42q9abh4ln0";
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3174,6 +3174,8 @@ let
      lua = lua5;
   };
 
+  luajit = callPackage ../development/interpreters/luajit {};
+
   lush2 = callPackage ../development/interpreters/lush {};
 
   maude = callPackage ../development/interpreters/maude { };


### PR DESCRIPTION
Just-in-time compiler for lua 5.1 with strong focus on performance.
Uses the same API as lua 5.1 which makes it extremely easy to integrate.
