### PR TITLE
Fixes go 1.1.2 compilation on OSX Maverick

### DIFF
--- a/pkgs/development/compilers/go/1.1-darwin.nix
+++ b/pkgs/development/compilers/go/1.1-darwin.nix
@@ -45,6 +45,11 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p "$out/bin"
+
+    # CGO is broken on Maverick. See: http://code.google.com/p/go/issues/detail?id=5926
+    # Reevaluate once go 1.1.3 is out
+    export CGO_ENABLED=0
+
     export GOROOT="$(pwd)/"
     export GOBIN="$out/bin"
     export PATH="$GOBIN:$PATH"


### PR DESCRIPTION
Apparently Apple thinks that faking gcc wiht a clang stub but not providing a
compatile libgcc.a is not going to cause any issues. They really do hate GPL.
