### PR TITLE
openbox: Update to 3.5.2

### DIFF
--- a/pkgs/applications/window-managers/openbox/default.nix
+++ b/pkgs/applications/window-managers/openbox/default.nix
@@ -3,7 +3,7 @@
 , imlib2, pango, libstartup_notification }:
 
 stdenv.mkDerivation rec {
-  name = "openbox-3.5.0";
+  name = "openbox-3.5.2";
 
   buildInputs = [
     pkgconfig libxml2
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://openbox.org/dist/openbox/${name}.tar.gz";
-    sha256 = "02pa1wa2rzvnq1z3xchzafc96hvp3537jh155q8acfhbacb01abg";
+    sha256 = "0cxgb334zj6aszwiki9g10i56sm18i7w1kw52vdnwgzq27pv93qj";
   };
 
   meta = {


### PR DESCRIPTION
Bump openbox version to latest upstream stable - 3.5.2.
