### PR TITLE
teamspeak_client: Updated to 3.0.13.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -1,23 +1,34 @@
-{ stdenv, fetchurl, zlib, glib, libpng, freetype, xorg, fontconfig, alsaLib }:
+{ stdenv, fetchurl, zlib, glib, libpng, freetype, xorg, fontconfig, alsaLib,
+  qt4, pulseaudio ? null }:
 
 let
 
+  version = "3.0.13.1";
+
+  arch = if stdenv.is64bit then "amd64" else "x86";
+ 
   libDir = if stdenv.is64bit then "lib64" else "lib";
 
   deps =
     [ zlib glib libpng freetype xorg.libSM xorg.libICE xorg.libXrender
       xorg.libXrandr xorg.libXfixes xorg.libXcursor xorg.libXinerama
-      fontconfig xorg.libXext xorg.libX11 alsaLib
+      fontconfig xorg.libXext xorg.libX11 alsaLib qt4 pulseaudio
     ];
 
 in
 
 stdenv.mkDerivation {
-  name = "teamspeak-client-3.0.0-beta35";
+  name = "teamspeak-client-${version}";
 
   src = fetchurl {
-    url = http://ftp.4players.de/pub/hosted/ts3/releases/beta-35/TeamSpeak3-Client-linux_amd64-3.0.0-beta35.run;
-    sha256 = "0vygsvjs11lr5lv4x7awv7hvkycvmm9qs2vklfjs91w3f434cmrx";
+    urls = [
+       "http://dl.4players.de/ts/releases/${version}/TeamSpeak3-Client-linux_${arch}-${version}.run"
+      "http://teamspeak.gameserver.gamed.de/ts3/releases/${version}/TeamSpeak3-Client-linux_${arch}-${version}.run"
+      "http://files.teamspeak-services.com/releases/${version}/TeamSpeak3-Client-linux_${arch}-${version}.run"
+    ];
+    sha256 = if stdenv.is64bit 
+		then "0mj8vpsnv906n3wgjwhiby5gk26jr5jbd94swmsf0s9kqwhsj6i1"
+                else "1hlw7lc0nl1mrsyd052s6ws64q5aabnw6qpv8mrdxb3hyp7g2qh1";
   };
 
   unpackPhase =
@@ -28,22 +39,27 @@ stdenv.mkDerivation {
 
   buildPhase =
     ''
-      ls -l
-      for i in ts3client_linux_*; do
-        echo "patching $i..."
-        patchelf \
-          --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-          --set-rpath ${stdenv.lib.makeLibraryPath deps}:$(cat $NIX_GCC/nix-support/orig-gcc)/${libDir} \
-          --force-rpath \
-          $i
-      done
+      mv ts3client_linux_${arch} ts3client
+      echo "patching ts3client..."
+      patchelf \
+        --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        --set-rpath ${stdenv.lib.makeLibraryPath deps}:$(cat $NIX_GCC/nix-support/orig-gcc)/${libDir} \
+        --force-rpath \
+        ts3client
     '';
-    
 
   installPhase =
     ''
+      # Delete unecessary libraries - these are provided by nixos.
+      rm *.so.*
+
+      # Install files.
       mkdir -p $out/lib/teamspeak
       mv * $out/lib/teamspeak/
+
+      # Make a symlink to the binary from bin.
+      mkdir -p $out/bin/
+      ln -s $out/lib/teamspeak/ts3client $out/bin/ts3client
     '';
 
   dontStrip = true;
@@ -53,6 +69,7 @@ stdenv.mkDerivation {
     description = "The TeamSpeak voice communication tool";
     homepage = http://teamspeak.com/;
     license = "http://www.teamspeak.com/?page=downloads&type=ts3_linux_client_latest";
+    platforms = stdenv.lib.platforms.linux;
   };
 }
 


### PR DESCRIPTION
Updated ancient teamspeak client. From 3.0.0-beta35 to 3.0.13.1.
Added support for i686-linux.
Added support for pulseaudio.
Teamspeak now uses nixos qt4 libraries.
