### PR TITLE
Add a nix module for AMD Hybrid Graphics

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -91,6 +91,7 @@
   ./services/databases/virtuoso.nix
   ./services/games/ghost-one.nix
   ./services/hardware/acpid.nix
+  ./services/hardware/amd-hybrid-graphics.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/pcscd.nix

--- a/nixos/modules/services/hardware/amd-hybrid-graphics.nix
+++ b/nixos/modules/services/hardware/amd-hybrid-graphics.nix
@@ -1,0 +1,39 @@
+{ config, pkgs, ... }:
+
+{
+
+  ###### interface
+
+  options = {
+
+    hardware.amdHybridGraphics.disable = pkgs.lib.mkOption {
+      default = false;
+      type = pkgs.lib.types.bool;
+      description = ''
+        Completely disable the AMD graphics card and use the
+        integrated graphics processor instead.
+      '';
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = pkgs.lib.mkIf config.hardware.amdHybridGraphics.disable {
+    systemd.services."amd-hybrid-graphics" = {
+      path = [ pkgs.bash ];
+      description = "Disable AMD Card";
+      after = [ "sys-kernel-debug.mount" ];
+      requires = [ "sys-kernel-debug.mount" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.bash}/bin/sh -c 'echo -e \"IGD\\nOFF\" > /sys/kernel/debug/vgaswitcheroo/switch; exit 0'";
+        ExecStop = "${pkgs.bash}/bin/sh -c 'echo ON >/sys/kernel/debug/vgaswitcheroo/switch; exit 0'";
+      };
+    };
+  };
+
+}


### PR DESCRIPTION
We already have a module to handle nvidia optimus and bumblebee. This is a similar service but for amd / intel hybrid graphics.

Adds `services.amdHybridGraphics.disable` to nixos
