### PR TITLE
grafx2: new package

### DIFF
--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -12,10 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL SDL_image SDL_ttf libpng zlib lua5 pkgconfig ];
 
-  buildPhase = ''
-    cd src
-    make
-  '';
+  preBuild = "cd src";
 
   installPhase = ''
     mkdir -p "$out"

--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, SDL, SDL_image, SDL_ttf, zlib, libpng, pkgconfig, lua5 }:
+
+stdenv.mkDerivation rec {
+
+  version = "2.4.2035";
+  name = "grafx2-${version}";
+
+  src = fetchurl {
+    url = "https://grafx2.googlecode.com/files/${name}-src.tgz";
+    sha256 = "0svsy6rqmdj11b400c242i2ixihyz0hds0dgicqz6g6dcgmcl62q";
+  };
+
+  buildInputs = [ SDL SDL_image SDL_ttf libpng zlib lua5 pkgconfig ];
+
+  buildPhase = ''
+    cd src
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p "$out"
+    make install prefix="$out"
+  '';
+
+  meta = {
+    description = "GrafX2 is a bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance.";
+    homepage = http://code.google.co/p/grafx2/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ stdenv.lib.maintainers.zoomulator ];
+  };
+}

--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -14,10 +14,7 @@ stdenv.mkDerivation rec {
 
   preBuild = "cd src";
 
-  installPhase = ''
-    mkdir -p "$out"
-    make install prefix="$out"
-  '';
+  preInstall = '' mkdir -p "$out" '';
 
   meta = {
     description = "GrafX2 is a bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1019,6 +1019,8 @@ let
 
   gptfdisk = callPackage ../tools/system/gptfdisk { };
 
+  grafx2 = callPackage ../applications/graphics/grafx2 {};
+
   graphviz = callPackage ../tools/graphics/graphviz { };
 
   /* Readded by Michael Raskin. There are programs in the wild


### PR DESCRIPTION
GrafX2 is a bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance. Specialized in 256-color drawing.
