### PR TITLE
TuxOnIce: Add a 3.10 linux kernel with the TuxOnIce hibernation patch

### DIFF
--- a/pkgs/os-specific/linux/hibernate/default.nix
+++ b/pkgs/os-specific/linux/hibernate/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, gawk }:
 
-let version = "1.98.1";
+let version = "2.0";
 in
   stdenv.mkDerivation rec {
     name = "hibernate-${version}";
     src = fetchurl {
-      url = "http://www.tuxonice.net/downloads/all/hibernate-script-${version}.tar.gz";
-      sha256 = "1xpc2i16jczc3nhvxlkn6fb044srqrh528gnp92cwy4hxf2nzi1z";
+      url = "http://tuxonice.nigelcunningham.com.au/files/hibernate-script-${version}.tar.gz";
+      sha256 = "0ib5bac3spbcwmhf8f9apjbll8x7fgqj4k1s5q3srijh793rfifh";
     };
 
     patches = [ ./install.patch ./gen-manpages.patch ./hibernate.patch ];

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -3,7 +3,7 @@
 let
 
   makeTuxonicePatch = { version, kernelVersion, sha256,
-    url ? "http://tuxonice.net/files/tuxonice-${version}-for-${kernelVersion}.patch.bz2" }:
+    url ? "http://tuxonice.nigelcunningham.com.au/downloads/all/tuxonice-for-linux-${kernelVersion}-${version}.patch.bz2" }:
     { name = "tuxonice-${kernelVersion}";
       patch = stdenv.mkDerivation {
         name = "tuxonice-${version}-for-${kernelVersion}.patch";
@@ -116,6 +116,13 @@ rec {
     { name = "mips-ext3-n32";
       patch = ./mips-ext3-n32.patch;
     };
+
+  tuxonice_3_10 = makeTuxonicePatch {
+    version = "2013-11-07";
+    kernelVersion = "3.10.18";
+    sha256 = "00b1rqgd4yr206dxp4mcymr56ymbjcjfa4m82pxw73khj032qw3j";
+  };
+
 
   grsecurity_2_9_1_3_2_52 =
     { name = "grsecurity-2.9.1-3.2.52";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6690,6 +6690,15 @@ let
       ];
   };
 
+  linux_3_10_tuxonice = linux_3_10.override (attrs: {
+    kernelPatches = attrs.kernelPatches ++ [
+      kernelPatches.tuxonice_3_10
+    ];
+    extraConfig = ''
+      TOI_CORE y
+    '';
+  });
+
   linux_3_11 = makeOverridable (import ../os-specific/linux/kernel/linux-3.11.nix) {
     inherit fetchurl stdenv perl mktemp bc kmod ubootChooser;
     kernelPatches =
@@ -6832,6 +6841,7 @@ let
   linuxPackages_3_4_apparmor = linuxPackagesFor pkgs.linux_3_4_apparmor linuxPackages_3_4_apparmor;
   linuxPackages_3_6_rpi = linuxPackagesFor pkgs.linux_3_6_rpi linuxPackages_3_6_rpi;
   linuxPackages_3_10 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_10 linuxPackages_3_10);
+  linuxPackages_3_10_tuxonice = linuxPackagesFor pkgs.linux_3_10_tuxonice linuxPackages_3_10_tuxonice;
   linuxPackages_3_11 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_11 linuxPackages_3_11);
   linuxPackages_3_12 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_12 linuxPackages_3_12);
   # Update this when adding a new version!


### PR DESCRIPTION
This also updates the hibernate script from 1.98.1 to 2.0

I failed to get suspend or hibernation to work on a default kernel on a particular machine, but with the TuxOnIce patch it seems to work quite well.
