### PR TITLE
Ruby security updates

### DIFF
--- a/pkgs/development/interpreters/ruby/ruby-18.nix
+++ b/pkgs/development/interpreters/ruby/ruby-18.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   name = "ruby-${version}";
   
   src = fetchurl {
-    url = "http://cache.ruby-lang.org/pub/ruby/1.8/${name}.tar.gz";
-    sha256 = "0g2dsn8lmiqwqsp13ryzi97qxr7742v5l7v506x6wq9aiwpk42p6";
+    url = "http://cache.ruby-lang.org/pub/ruby/1.8/${name}.tar.bz2";
+    sha256 = "b4e34703137f7bfb8761c4ea474f7438d6ccf440b3d35f39cc5e4d4e239c07e3";
   };
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   passthru = rec {
     majorVersion = "1.8";
     minorVersion = "7";
-    patchLevel = "371";
+    patchLevel = "374";
     libPath = "lib/ruby/${majorVersion}";
     gemPath = "lib/ruby/gems/${majorVersion}";
   };

--- a/pkgs/development/interpreters/ruby/ruby-18.nix
+++ b/pkgs/development/interpreters/ruby/ruby-18.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   name = "ruby-${version}";
   
   src = fetchurl {
-    url = "ftp://ftp.ruby-lang.org/pub/ruby/1.8/${name}.tar.gz";
+    url = "http://cache.ruby-lang.org/pub/ruby/1.8/${name}.tar.gz";
     sha256 = "0g2dsn8lmiqwqsp13ryzi97qxr7742v5l7v506x6wq9aiwpk42p6";
   };
 

--- a/pkgs/development/interpreters/ruby/ruby-19.nix
+++ b/pkgs/development/interpreters/ruby/ruby-19.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   
   src = fetchurl {
     url = "http://cache.ruby-lang.org/pub/ruby/1.9/${name}.tar.bz2";
-    sha256 = "0w1avj8qfskvkgvrjxxc1cxjm14bf1v60ipvcl5q3zpn9k14k2cx";
+    sha256 = "0fdc6e860d0023ba7b94c7a0cf1f7d32908b65b526246de9dfd5bb39d0d7922b";
   };
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   passthru = rec {
     majorVersion = "1.9";
     minorVersion = "3";
-    patchLevel = "429";
+    patchLevel = "484";
     libPath = "lib/ruby/${majorVersion}";
     gemPath = "lib/ruby/gems/${majorVersion}";
   };

--- a/pkgs/development/interpreters/ruby/ruby-19.nix
+++ b/pkgs/development/interpreters/ruby/ruby-19.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   name = "ruby-${version}";
   
   src = fetchurl {
-    url = "ftp://ftp.ruby-lang.org/pub/ruby/1.9/${name}.tar.bz2";
+    url = "http://cache.ruby-lang.org/pub/ruby/1.9/${name}.tar.bz2";
     sha256 = "0w1avj8qfskvkgvrjxxc1cxjm14bf1v60ipvcl5q3zpn9k14k2cx";
   };
 

--- a/pkgs/development/interpreters/ruby/ruby-2.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.0.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   
   src = fetchurl {
     url = "http://cache.ruby-lang.org/pub/ruby/2.0/${name}.tar.bz2";
-    sha256 = "0pr9jf01cfap93xcngyd5zpns67ffjsgaxkm0qr1r464rj9d7066";
+    sha256 = "3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9";
   };
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   passthru = rec {
     majorVersion = "2.0";
     minorVersion = "0";
-    patchLevel = "0";
+    patchLevel = "353";
     libPath = "lib/ruby/${majorVersion}";
     gemPath = "lib/ruby/gems/${majorVersion}";
   };

--- a/pkgs/development/interpreters/ruby/ruby-2.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.0.nix
@@ -30,11 +30,19 @@ stdenv.mkDerivation rec {
     ++ (op zlibSupport zlib)
     ++ (op opensslSupport openssl)
     ++ (op gdbmSupport gdbm)
-    ++ (op yamlSupport libyaml);
+    ++ (op yamlSupport libyaml)
+    # Looks like ruby fails to build on darwin without readline even if curses
+    # support is not enabled, so add readline to the build inputs if curses
+    # support is disabled (if it's enabled, we already have it) and we're
+    # running on darwin
+    ++ (op (!cursesSupport && stdenv.isDarwin) readline);
 
   enableParallelBuilding = true;
     
-  configureFlags = ["--enable-shared" ];
+  configureFlags = ["--enable-shared" ]
+    # on darwin, we have /usr/include/tk.h -- so the configure script detects
+    # that tk is installed
+    ++ ( if stdenv.isDarwin then [ "--with-out-ext=tk " ] else [ ]);
 
   installFlags = stdenv.lib.optionalString docSupport "install-doc";
   # Bundler tries to create this directory

--- a/pkgs/development/interpreters/ruby/ruby-2.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.0.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   name = "ruby-${version}";
   
   src = fetchurl {
-    url = "ftp://ftp.ruby-lang.org/pub/ruby/2.0/${name}.tar.bz2";
+    url = "http://cache.ruby-lang.org/pub/ruby/2.0/${name}.tar.bz2";
     sha256 = "0pr9jf01cfap93xcngyd5zpns67ffjsgaxkm0qr1r464rj9d7066";
   };
 


### PR DESCRIPTION
These commits fix the security issue described in [CVE-2013-4164](https://www.ruby-lang.org/en/news/2013/11/22/heap-overflow-in-floating-point-parsing-cve-2013-4164/). Ruby 1.8.7 has also been updates but it still vulnerable to that CVE. Ruby 1.8.7 is not supported by the ruby core team and should probably be removed from the repo entirely.

The Darwin patch has also been imported from #1229
