### PR TITLE
Perl requirement for ddclient

### DIFF
--- a/pkgs/tools/networking/ddclient/default.nix
+++ b/pkgs/tools/networking/ddclient/default.nix
@@ -8,7 +8,7 @@ buildPerlPackage {
     sha256 = "f22ac7b0ec78e310d7b88a1cf636e5c00360b2ed9c087f231b3522ef3e6295f2";
   };
 
-  buildInputs = [ perlPackages.IOSocketSSL ];
+  buildInputs = [ perlPackages.IOSocketSSL perlPackages.DigestSHA1 ];
 
   patches = [ ./ddclient-foreground.patch ];
 


### PR DESCRIPTION
It looks like only the FreeDNS protocol needs it.
Around line 1217 from ddclient script

``` HOST:
1212     foreach my $h (keys %config) {
1213     my $proto;
1214     $proto = $config{$h}{'protocol'};
1215     $proto = opt('protocol')          if !defined($proto);
1216 
1217     load_sha1_support() if ($proto eq "freedns");
1218 
1219     if (!exists($services{$proto})) {
1220         warning("skipping host: %s: unrecognized protocol '%s'", $h, $proto);
1221         delete $config{$h};
```

and the actual requirement:

```
######################################################################
1778 ## load_sha1_support
1779 ######################################################################
1780 sub load_sha1_support {
1781     my $sha1_loaded = eval {require Digest::SHA1};
1782     unless ($sha1_loaded) {
1783         fatal(<<"EOM");
1784 Error loading the Perl module Digest::SHA1 needed for freedns update.
1785 On Debian, the package libdigest-sha1-perl must be installed.
1786 EOM
1787     }
1788     import  Digest::SHA1 (qw/sha1_hex/);
1789 }
```
