### PR TITLE
Fixes the git installation on Darwin

### DIFF
--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     homepage = https://fedorahosted.org/xmlto/;
 
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    platforms = stdenv.lib.platforms.unix ;
   };
 }


### PR DESCRIPTION
git is missing the xmlto package to install. This patch just changes the allowed platforms of xmlto to "all" since it compiles fine on Darwin.
