### PR TITLE
grsecurity: Update to latest version and add patch for kernel 3.12

### DIFF
--- a/pkgs/os-specific/linux/kernel/grsec-path.patch
+++ b/pkgs/os-specific/linux/kernel/grsec-path.patch
@@ -1,0 +1,15 @@
+diff --git a/kernel/kmod.c b/kernel/kmod.c
+index 3227c2c..f32c944 100644
+--- a/kernel/kmod.c
++++ b/kernel/kmod.c
+@@ -246,8 +246,8 @@ static int ____call_usermodehelper(void *data)
+ 	   out the path to be used prior to this point and are now operating
+ 	   on that copy
+ 	*/
+-	if ((strncmp(sub_info->path, "/sbin/", 6) && strncmp(sub_info->path, "/usr/lib/", 9) &&
+-	     strncmp(sub_info->path, "/lib/", 5) && strncmp(sub_info->path, "/lib64/", 7)) || strstr(sub_info->path, "..")) {
++	if ((strncmp(sub_info->path, "/sbin/", 6) && strncmp(sub_info->path, "/nix/store/", 11) &&
++	     strncmp(sub_info->path, "/run/current-system/systemd/lib/", 32)) || strstr(sub_info->path, "..")) {
+ 		printk(KERN_ALERT "grsec: denied exec of usermode helper binary %.950s located outside of /sbin and system library paths\n", sub_info->path);
+ 		retval = -EPERM;
+ 		goto fail;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -124,14 +124,25 @@ rec {
   };
 
 
-  grsecurity_2_9_1_3_2_52 =
-    { name = "grsecurity-2.9.1-3.2.52";
+  grsecurity_3_0_3_2_52 =
+    { name = "grsecurity-3.0-3.2.52";
       patch = fetchurl {
-        url = http://grsecurity.net/stable/grsecurity-2.9.1-3.2.52-201310271550.patch;
-        sha256 = "08y4y323y2lfvdj67gmg3ca8gaf3snhr3pyrmgvj877avaz0475m";
+        url = https://grsecurity.net/stable/grsecurity-3.0-3.2.52-201311261307.patch;
+        sha256 = "1zmzgjpbq90q2w3yl3dgdc79qan7qkh5w6g3y3nvzr6ww6jl8hqw";
       };
-      # The grsec kernel patch seems to include the apparmor patches as of 2.9.1-3.2.52
+      features.grsecurity = true;
+      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.52
       features.apparmor = true;
     };
 
+  grsecurity_3_0_3_12_1 =
+    { name = "grsecurity-3.0-3.12.1";
+      patch = fetchurl {
+        url = https://grsecurity.net/test/grsecurity-3.0-3.12.1-201311261309.patch;
+        sha256 = "129q740m2iivc4i9a465lvzcph9gxlivxzg2p9dsi7c136p42mdz";
+      };
+      features.grsecurity = true;
+      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.12.1
+      features.apparmor = true;
+    };
 }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -145,4 +145,9 @@ rec {
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.12.1
       features.apparmor = true;
     };
+
+  grsec_path =
+    { name = "grsec-path";
+      patch = ./grsec-path.patch;
+    };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6686,11 +6686,11 @@ let
   # config options you need (e.g. by overriding extraConfig). See list of options here:
   # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
   linux_3_2_grsecurity = lowPrio (lib.overrideDerivation (linux_3_2.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_52 ];
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_52 kernelPatches.grsec_path ];
   })) (args: grsecurityOverrider args));
 
   linux_3_12_grsecurity = lowPrio (lib.overrideDerivation (linux_3_12.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_12_1 ];
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_12_1 kernelPatches.grsec_path ];
   })) (args: grsecurityOverrider args));
 
   linux_3_2_apparmor = lowPrio (linux_3_2.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6665,12 +6665,7 @@ let
       ];
   };
 
-  # Note: grsec is not enabled automatically, you need to specify which kernel
-  # config options you need (e.g. by overriding extraConfig). See list of options here:
-  # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
-  linux_3_2_grsecurity = lowPrio (lib.overrideDerivation (linux_3_2.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_2_9_1_3_2_52 ];
-  })) (args: {
+  grsecurityOverrider = args: {
     # Install gcc plugins. These are needed for compiling dependant packages.
     postInstall = ''
       ${args.postInstall or ""}
@@ -6685,7 +6680,18 @@ let
       sed -i 's|HOST_EXTRACFLAGS +=|HOST_EXTRACFLAGS += -I${gmp}/include|' tools/gcc/Makefile
       sed -i 's|HOST_EXTRACXXFLAGS +=|HOST_EXTRACXXFLAGS += -I${gmp}/include|' tools/gcc/Makefile
     '';
-  }));
+  };
+
+  # Note: grsec is not enabled automatically, you need to specify which kernel
+  # config options you need (e.g. by overriding extraConfig). See list of options here:
+  # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
+  linux_3_2_grsecurity = lowPrio (lib.overrideDerivation (linux_3_2.override (args: {
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_52 ];
+  })) (args: grsecurityOverrider args));
+
+  linux_3_12_grsecurity = lowPrio (lib.overrideDerivation (linux_3_12.override (args: {
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_12_1 ];
+  })) (args: grsecurityOverrider args));
 
   linux_3_2_apparmor = lowPrio (linux_3_2.override {
     kernelPatches = [ kernelPatches.apparmor_3_2 ];
@@ -6890,6 +6896,7 @@ let
   linuxPackages_3_10_tuxonice = linuxPackagesFor pkgs.linux_3_10_tuxonice linuxPackages_3_10_tuxonice;
   linuxPackages_3_11 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_11 linuxPackages_3_11);
   linuxPackages_3_12 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_12 linuxPackages_3_12);
+  linuxPackages_3_12_grsecurity = linuxPackagesFor pkgs.linux_3_12_grsecurity linuxPackages_3_12_grsecurity;
   # Update this when adding a new version!
   linuxPackages_latest = pkgs.linuxPackages_3_12;
 


### PR DESCRIPTION
Also fix path problems in the newest version of the patches
