### PR TITLE
haskellPackages.HDBCodbc: Do not build Haddocks

### DIFF
--- a/pkgs/development/libraries/haskell/HDBC/HDBC-odbc.nix
+++ b/pkgs/development/libraries/haskell/HDBC/HDBC-odbc.nix
@@ -8,11 +8,15 @@ cabal.mkDerivation (self: {
   isExecutable = true;
   buildDepends = [ HDBC mtl time utf8String ];
   extraLibraries = [ odbc ];
+  noHaddock = true; # Haddocks currently fail to build
   meta = {
     homepage = "https://github.com/hdbc/hdbc-odbc";
     description = "ODBC driver for HDBC";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    maintainers = [ self.stdenv.lib.maintainers.andres ];
+    maintainers = [
+      self.stdenv.lib.maintainers.andres
+      self.stdenv.lib.maintainers.ocharles
+    ];
   };
 })


### PR DESCRIPTION
The Haddocks currently fail to build, which means that HDBC-ODBC
cannot be install.

Planning to submit a patch upstream, but going by the last commit 11 months ago, I'm not very hopefully it will be merged quickly.
