### PR TITLE
Remove caches from liferea, evince and network-manager-applet

### DIFF
--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
     libnotify
   ];
 
+  preFixup = ''
+    rm $out/share/icons/hicolor/icon-theme.cache'';
+
   meta = {
     description = "A GTK-based news feed agregator";
     homepage = http://lzone.de/liferea/;

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+
   configureFlags = [
     "--disable-nautilus" # Do not use nautilus
     "--disable-dbus" # strange compilation error

--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
     ''CFLAGS=-DMOBILE_BROADBAND_PROVIDER_INFO=\"${mobile_broadband_provider_info}/share/mobile-broadband-provider-info/serviceproviders.xml\"''
   ];
 
+  preFixup = ''
+    rm $out/share/glib-2.0/schemas/gschemas.compiled'';
+
   postInstall = ''
     mkdir -p $out/etc/NetworkManager/VPN
     ln -s ${networkmanager_openvpn}/etc/NetworkManager/VPN/nm-openvpn-service.name $out/etc/NetworkManager/VPN/nm-openvpn-service.name


### PR DESCRIPTION
This removes caches generated at build time (which collide with each other and are incomplete).
