### PR TITLE
Fix ntrack for latest libnl release

### DIFF
--- a/pkgs/development/libraries/ntrack/default.nix
+++ b/pkgs/development/libraries/ntrack/default.nix
@@ -18,7 +18,12 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--without-gobject CFLAGS=--std=gnu99";
 
-  patchPhase = ''sed -e "s@/usr\(/lib/ntrack/modules/\)@$out&@" -i common/ntrack.c'';
+  # Remove this patch after version 016
+  patches = [ ./libnl-fix.patch ];
+
+  postPatch = ''
+    sed -e "s@/usr\(/lib/ntrack/modules/\)@$out&@" -i common/ntrack.c
+  '';
 
   meta = {
     description = "Network Connectivity Tracking library for Desktop Applications";

--- a/pkgs/development/libraries/ntrack/libnl-fix.patch
+++ b/pkgs/development/libraries/ntrack/libnl-fix.patch
@@ -1,0 +1,11 @@
+--- ./modules/ntrack-libnl.c.orig	2013-12-02 11:31:54.749215448 -0600
++++ ./modules/ntrack-libnl.c	2013-12-02 11:34:46.597684553 -0600
+@@ -530,7 +530,7 @@
+ 		op_default_route_disappeared ((struct _ntrack_monitor_arch*) self, nl_info);
+ 	} else if (nl_info->topmost_route && topmost_route) {
+ 		int diff_bits;
+-		if ((diff_bits = (route_obj_ops.oo_id_attrs | ROUTE_ATTR_OIF
++		if ((diff_bits = (nl_object_get_id_attrs(OBJ_CAST(topmost_route)) | ROUTE_ATTR_OIF
+ 		                  | ROUTE_ATTR_GATEWAY) &
+ 		                  nl_object_diff (OBJ_CAST (nl_info->topmost_route),
+ 		                                  OBJ_CAST (topmost_route)))) {


### PR DESCRIPTION
ntrack compilation was broken with libnl 3.2.21 and later. This patch fixes the build to work with the new versions of libnl.
