### PR TITLE
Break mumble into client and server components

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, qt4, libvorbis, boost, speechd, protobuf, libsndfile,
- avahi, dbus, libcap, pkgconfig,
+{ stdenv, fetchurl, qt4, boost, speechd, protobuf, libsndfile,
+ speex, libopus, avahi, pkgconfig
 jackSupport ? false, 
 jackaudio ? null }:
 
@@ -18,16 +18,18 @@ stdenv.mkDerivation rec {
   '';
 
   configurePhase = ''
-    qmake CONFIG+=no-g15 CONFIG+=no-update \
-      CONFIG+=no-embed-qt-translations CONFIG+=no-ice \
+    qmake CONFIG+=no-g15 CONFIG+=no-update CONFIG+=no-server \
+      CONFIG+=no-embed-qt-translations CONFIG+=packaged \
+      CONFIG+=bundled-celt CONFIG+=no-bundled-opus \
+      CONFIG+=no-bundled-speex
   '' 
   + stdenv.lib.optionalString jackSupport ''
     CONFIG+=no-oss CONFIG+=no-alsa CONFIG+=jackaudio
   '';
 
 
-  buildInputs = [ qt4 libvorbis boost speechd protobuf libsndfile avahi dbus
-    libcap pkgconfig ]
+  buildInputs = [ qt4 boost speechd protobuf libsndfile speex
+    libopus avahi pkgconfig ]
     ++ (stdenv.lib.optional jackSupport jackaudio);
 
   installPhase = ''

--- a/pkgs/applications/networking/mumble/murmur.nix
+++ b/pkgs/applications/networking/mumble/murmur.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, qt4, boost, protobuf, avahi, libcap, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "murmur-" + version;
+  version = "1.2.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mumble/mumble-${version}.tar.gz";
+    sha256 = "16wwj6gwcnyjlnzh7wk0l255ldxmbwx0wi652sdp20lsv61q7kx1";
+  };
+
+  configurePhase = ''
+    qmake CONFIG+=no-client CONFIG+=no-ice CONFIG+=no-embed-qt
+  '';
+
+  buildInputs = [ qt4 boost protobuf avahi libcap pkgconfig ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./release $out/bin
+  '';
+
+  meta = { 
+    homepage = http://mumble.sourceforge.net/;
+    description = "Low-latency, high quality voice chat software";
+    license = "BSD";
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [viric];
+  };
+}

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -7,11 +7,11 @@
 assert qt4Support -> qt4 != null;
 
 stdenv.mkDerivation rec {
-  name = "avahi-0.6.30";
+  name = "avahi-0.6.31";
 
   src = fetchurl {
     url = "${meta.homepage}/download/${name}.tar.gz";
-    sha256 = "07zzaxs81rbrfhj0rnq616c3j37f3g84dn7d4q3h5l1r4dn33r7r";
+    sha256 = "0j5b5ld6bjyh3qhd2nw0jb84znq0wqai7fsrdzg7bpg24jdp2wl3";
   };
 
   patches = [ ./no-mkdir-localstatedir.patch ];
@@ -35,6 +35,13 @@ stdenv.mkDerivation rec {
     sed -i '20 i\
     #define __APPLE_USE_RFC_2292' \
     avahi-core/socket.c
+  '';
+
+  postInstall = ''
+    # Maintain compat for mdnsresponder and howl
+    ${if withLibdnssdCompat then "ln -s avahi-compat-libdns_sd/dns_sd.h $out/include/dns_sd.h" else ""}
+    ln -s avahi-compat-howl $out/include/howl
+    ln -s avahi-compat-howl.pc $out/lib/pkgconfig/howl.pc
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fixedPoint ? false }:
 
 stdenv.mkDerivation rec {
-  name = "libopus-1.0.2";
+  name = "libopus-1.0.3";
   
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/opus/opus-1.0.2.tar.gz";
-    sha256 = "12npbkrcwvh3fl9l18cwrxwg269cg2j6j7876cc9q0axxvdmwqfs";
+    url = "http://downloads.xiph.org/releases/opus/opus-1.0.3.tar.gz";
+    sha256 = "175l7hv7d03c4iz60g185nqvwrabc39ksil0d7g07i6vjaf0h6hr";
   };
 
   configureFlags = stdenv.lib.optionalString fixedPoint "--enable-fixed-point";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8454,6 +8454,12 @@ let
     jackSupport = config.mumble.jackSupport or false;
   };
 
+  murmur = callPackage ../applications/networking/mumble/murmur.nix { 
+    avahi = avahi.override {
+      withLibdnssdCompat = true;
+    };
+  };
+
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
 
   ruby_gpgme = callPackage ../development/libraries/ruby_gpgme {


### PR DESCRIPTION
Currently, the mumble derivation builds both the client and the server at the same time. This patch breaks apart the two components into separate derivations as well as updates dependent packages.
