### PR TITLE
WIP: Request to remove ruby 1.8 from the tree

### DIFF
--- a/pkgs/desktops/kde-4.11/kdewebdev/klinkstatus.nix
+++ b/pkgs/desktops/kde-4.11/kdewebdev/klinkstatus.nix
@@ -1,8 +1,8 @@
-{ kde, kdelibs, libxml2, libxslt, kdepimlibs, htmlTidy, boost, ruby18 }:
+{ kde, kdelibs, libxml2, libxslt, kdepimlibs, htmlTidy, boost }:
 
 kde {
 
-  buildInputs = [ kdelibs kdepimlibs ruby18 htmlTidy boost ];
+  buildInputs = [ kdelibs kdepimlibs htmlTidy boost ];
 
   meta = {
     description = "A KDE link checker";


### PR DESCRIPTION
To continue the discussion on #1272 , ruby 1.8 is unsupported by the ruby dev team and has known vulnerability issues. I propose to we remove it from the tree.

There's two blockers: klinkstatus and s3sync.

klinkstatus seem to compile fine without ruby18 but I'm not sure exactly how the kde {} derivation work.

s3sync seems to be an old ruby1.8 script that interacts with S3. It doesn't seem to be maintained anymore: http://s3sync.net/wiki ( the new maintainer has just pushed 1 commit and didn't release anything). Either find a replacement, upgrade the script or just remove it all-together.

TODO:
- [x] klinkstatus
- [ ] Find a solution for s3sync
- [ ] actually remove ruby18
