### PR TITLE
make-initrd.sh: Fix extracting initrd as non-root user

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -36,7 +36,7 @@ storePaths=$(perl $pathsFromGraph closure-*)
 
 # Put the closure in a gzipped cpio archive.
 mkdir -p $out
-(cd root && find * -print0 | cpio -o -H newc --null | $compressor > $out/initrd)
+(cd root && find * -print0 -depth | cpio -o -H newc --null | $compressor > $out/initrd)
 
 if [ -n "$makeUInitrd" ]; then
     mv $out/initrd $out/initrd.gz


### PR DESCRIPTION
A non-root user cannot extract cpio archives that have read-only directories
with subdirectories or files unless these files appear in the archive
before the read-only directory.

The fix is to pass the -depth option to find, so that the contents of
directories get archived before the directories.
