### PR TITLE
Rename quassel packages

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -4,6 +4,7 @@
 , withKDE ? stdenv.isLinux # enable KDE integration
 , ssl ? true # enable SSL support
 , previews ? false # enable webpage previews on hovering over URLs
+, tag ? "" # tag added to the package name
 , stdenv, fetchurl, cmake, qt4, kdelibs, automoc4, phonon }:
 
 let
@@ -11,12 +12,15 @@ let
 
 in with stdenv; mkDerivation rec {
 
-  name = "quassel-0.9.2";
+  version = "0.9.2";
+  name = "quassel${tag}-${version}";
 
   src = fetchurl {
-    url = "http://quassel-irc.org/pub/${name}.tar.bz2";
+    url = "http://quassel-irc.org/pub/quassel-${version}.tar.bz2";
     sha256 = "1h2kzi4pgfv3qmvhxix9fffdjixs3bsya0i5c18dkh894mh02kgh";
   };
+
+  enableParallelBuilding = true;
 
   buildInputs = [ cmake qt4 ]
     ++ lib.optional withKDE kdelibs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9709,14 +9709,16 @@ let
 
       quassel = callPackage ../applications/networking/irc/quassel { };
 
-      quasselDaemon = appendToName "daemon" (self.quassel.override {
+      quasselDaemon = (self.quassel.override {
         monolithic = false;
         daemon = true;
+        tag = "-daemon";
       });
 
-      quasselClient = appendToName "client" (self.quassel.override {
+      quasselClient = (self.quassel.override {
         monolithic = false;
         client = true;
+        tag = "-client";
       });
 
       rekonq = callPackage ../applications/networking/browsers/rekonq { };


### PR DESCRIPTION
With -daemon and -client added at the end of the name they were used as part of version, so quassel-X-daemon was considered an upgrade to quassel-X-client.
