### PR TITLE
make stdenv build on Debian Squeeze

### DIFF
--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = "MAKE=make MSGFMT=msgfmt MSGMERGE=msgmerge XGETTEXT=xgettext ZIP=gzip ECHO=echo SED=sed AWK=gawk";
 
+  makeFlags = "SHELL=${stdenv.shell}";
+
   installTargets = "install install-lib install-dev";
 
   meta = {

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = "MAKE=make MSGFMT=msgfmt MSGMERGE=msgmerge XGETTEXT=xgettext ECHO=echo SED=sed AWK=gawk";
 
+  makeFlags = "SHELL=${stdenv.shell}";
+
   installTargets = "install install-lib install-dev";
 
   meta = {


### PR DESCRIPTION
Pass SHELL=${stdenv.shell} to make in acl and attr.
This is needed, as both of those packages assume SHELL is bash-like,
and it's dash od Debian.
