### PR TITLE
Fixed wrapper to include a path to sqlite3 python bindings.

### DIFF
--- a/pkgs/applications/video/xbmc/default.nix
+++ b/pkgs/applications/video/xbmc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, makeWrapper
-, pkgconfig, cmake, gnumake, yasm, python
+, pkgconfig, cmake, gnumake, yasm, pythonFull
 , boost, avahi, libdvdcss, lame
 , gettext, pcre, yajl, fribidi
 , openssl, gperf, tinyxml2, taglib, libssh, swig, jre
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
     buildInputs = [
       makeWrapper
-      pkgconfig cmake gnumake yasm python
+      pkgconfig cmake gnumake yasm pythonFull
       boost libmicrohttpd
       gettext pcre yajl fribidi
       openssl gperf tinyxml2 taglib libssh swig jre
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     postInstall = ''
       for p in $(ls $out/bin/) ; do
         wrapProgram $out/bin/$p \
-          --prefix PATH ":" "${python}/bin" \
+          --prefix PATH ":" "${pythonFull}/bin" \
           --prefix PATH ":" "${glxinfo}/bin" \
           --prefix PATH ":" "${xdpyinfo}/bin" \
           --prefix LD_LIBRARY_PATH ":" "${curl}/lib" \


### PR DESCRIPTION
This fixes a problem with runtime errors when calling plugins that make use of the sqlite python bindings. Here is an example of one such error:

```
09:34:15 T:139913009895168   DEBUG: Process - Entering source directory /home/xbmc/.xbmc/addons/plugin.video.canada.on.demand
09:34:15 T:139913009895168   DEBUG: Instantiating addon using automatically obtained id of "plugin.video.canada.on.demand" dependent on version 2.0 of the xbmc.python api
09:34:15 T:139913009895168   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.DeprecationWarning'>
                                            Error Contents: You cannot use pysqlite2 while depending on version 2.0 of the xbmc.python api. Please use sqlite3 instead.
                                            Traceback (most recent call last):
                                              File "/home/xbmc/.xbmc/addons/plugin.video.canada.on.demand/default.py", line 11, in <module>
                                                from channels import *
                                              File "/home/xbmc/.xbmc/addons/plugin.video.canada.on.demand/channels/ctv.py", line 14, in <module>
                                                from pysqlite2 import dbapi2 as sqlite
                                              File "/nix/store/c8vpwbcwg06aa5p0xw6j2plnbrfjhrhw-xbmc-12.2/share/xbmc/addons/script.module.pysqlite/lib/pysqlite2/__init__.py", line 36, in <module>
                                                raise DeprecationWarning("You cannot use pysqlite2 while depending on version " + str(xbmcapiversion) + " of the xbmc.python api. Please use sqlite3 instead.")
                                            DeprecationWarning: You cannot use pysqlite2 while depending on version 2.0 of the xbmc.python api. Please use sqlite3 instead.
                                            -->End of Python script error report<--
09:34:15 T:139913009895168    INFO: Python script stopped
```
