### PR TITLE
Add shellinabox

### DIFF
--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pam, openssl, openssh }:
+
+stdenv.mkDerivation {
+  name = "shellinabox-2.14";
+
+  src = fetchurl {
+    url = "https://shellinabox.googlecode.com/files/shellinabox-2.14.tar.gz";
+    sha1 = "9e01f58c68cb53211b83d0f02e676e0d50deb781";
+  };
+  buildInputs = [pam openssl openssh];
+
+  # Disable GSSAPIAuthentication errors as well as correct hardcoded path. Take /usr/games's place. 
+  preConfigure = ''
+    substituteInPlace ./shellinabox/service.c --replace "-oGSSAPIAuthentication=no" ""
+    substituteInPlace ./shellinabox/launcher.c --replace "/usr/games" "${openssh}/bin"
+    '';
+  meta = {
+    homepage = https://code.google.com/p/shellinabox;
+    description = "Web based AJAX terminal emulator";
+    license = "GPLv2";
+    maintainers = [stdenv.lib.maintainers.tomberek];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1776,6 +1776,8 @@ let
 
   shebangfix = callPackage ../tools/misc/shebangfix { };
 
+  shellinabox = callPackage ../servers/shellinabox { };
+
   siege = callPackage ../tools/networking/siege {};
 
   silc_client = callPackage ../applications/networking/instant-messengers/silc-client { };


### PR DESCRIPTION
Add shellinabox.

Currently I run this with the following service. Should I add this into nixos/modules/services/web-servers/shellinabox.nix  Add some options for the configuration? If yes, what are some good examples to crib off of?

 systemd.services = {
      shellinaboxd = {
        description = "shellinabox web server.";
        path = [ pkgs.shellinabox pkgs.openssh];
        script = ''shellinaboxd --css ${pkgs.shellinabox}/share/doc/shellinabox/white-on-black.css --no-beep --disable-ssl  --localhost-only -s /:SSH'';
        wantedBy = [ "multi-user.target" ];
        requires = [ "network.target" ];
      };
    };
