### PR TITLE
Correct web-skip value to match behavior of checkip.dyndns.com

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -86,7 +86,7 @@ in
       };
 
       web = mkOption {
-        default = "web, web=checkip.dyndns.com/, web-skip='IP Address'" ;
+        default = "web, web=checkip.dyndns.com/, web-skip='Current IP Address: '" ;
         description = "";
       };
 


### PR DESCRIPTION
checkip.dyndns.com has different behavior now. This removes many warnings from the journal of ddclient.
