### PR TITLE
Firefox 26

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -17,9 +17,9 @@ assert stdenv.gcc ? libc && stdenv.gcc.libc != null;
 
 rec {
 
-  firefoxVersion = "25.0.1";
+  firefoxVersion = "26.0";
 
-  xulVersion = "25.0.1"; # this attribute is used by other packages
+  xulVersion = "26.0"; # this attribute is used by other packages
 
 
   src = fetchurl {
@@ -29,7 +29,7 @@ rec {
         # Fall back to this url for versions not available at releases.mozilla.org.
         "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2"
     ];
-    sha1 = "592ebd242c4839ef0e18707a7e959d8bed2a98f3";
+    sha1 = "f7c6642d6f62aea8d4eced48dd27aba0634edcd5";
   };
 
   commonConfigureFlags =

--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -143,6 +143,7 @@ rec {
 
     patches = [
       ./disable-reporter.patch # fixes "search box not working when built on xulrunner"
+      ./xpidl.patch
     ];
 
     propagatedBuildInputs = [xulrunner];

--- a/pkgs/applications/networking/browsers/firefox/xpidl.patch
+++ b/pkgs/applications/networking/browsers/firefox/xpidl.patch
@@ -1,0 +1,11 @@
+--- mozilla-release/python/mozbuild/mozbuild/backend/recursivemake.py	2013-12-05 08:07:53.000000000 -0800
++++ mozilla-release_1/python/mozbuild/mozbuild/backend/recursivemake.py	2013-12-12 23:38:39.697318563 -0800
+@@ -421,7 +421,7 @@
+     def _handle_idl_manager(self, manager):
+         build_files = self._purge_manifests['xpidl']
+ 
+-        for p in ('Makefile', 'backend.mk', '.deps/.mkdir.done',
++        for p in ('Makefile.in', 'Makefile', 'backend.mk', '.deps/.mkdir.done',
+             'xpt/.mkdir.done'):
+             build_files.add(p)
+ 


### PR DESCRIPTION
Tested on my computer.

I needed to patch the build system to make Firefox compile.  I don't exactly understand what I did, but I'm pretty sure my patch just changes how files are purged at some step, so it should be harmless.

Should I mention this upstream, or is this NixOS's fault?

Here is the error that the patch fixes.  This happens after the build phase, so probably during the install phase.

```
building tools
make[2]: Leaving directory `/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/browser'
make[1]: Leaving directory `/tmp/nix-build-firefox-26.0.drv-0/mozilla-release'
building dist/bin/browser/.purgecaches
if test -d dist/bin/browser ; then touch dist/bin/browser/.purgecaches ; fi
building dist/bin/webapprt/.purgecaches
if test -d dist/bin/webapprt ; then touch dist/bin/webapprt/.purgecaches ; fi
installing
install flags: install SYSTEM_LIBXUL=1   
building backend.RecursiveMakeBackend.built
Build configuration changed. Regenerating backend.
Reticulating splines...
building libgnashbase_la-RTMP.lo
  CXX    libgnashbase_la-RTMP.lo
/bin/sh ../libtool --silent --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I. -I..  -DPLUGINSDIR=\"/nix/store/rfwywvbjgcf2jhsmj1p8bh0g2vdh7xc1-gnash-0.8.10/lib/gnash/plugins\" -DSYSCONFDIR=\"/nix/store/rfwywvbjgcf2jhsmj1p8bh0g2vdh7xc1-gnash-0.8.10/etc\" -pthread -I/nix/store/jn120w693hhx1fx3yn45pmji66szsd6s-libpng-1.6.4/include/libpng16    -I/nix/store/vrgbgiv7wls0asdhgsh1z9l0mrvg4b2q-curl-7.33.0/include -DCURL_STATICLIB      -I../librender      -g -O2          -W     -Wall     -Wcast-align     -Wcast-qual     -Wpointer-arith     -Wreturn-type     -Wnon-virtual-dtor     -Wunused      -fvisibility-inlines-hidden -c -o libgnashbase_la-RTMP.lo `test -f 'RTMP.cpp' || echo './'`RTMP.cpp
Traceback (most recent call last):
  File "./config.status", line 945, in <module>
    config_status(**args)
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/build/ConfigStatus.py", line 126, in config_status
    summary = backend.consume(definitions)
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/python/mozbuild/mozbuild/backend/base.py", line 210, in consume
    self.consume_finished()
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/python/mozbuild/mozbuild/backend/recursivemake.py", line 246, in consume_finished
    CommonBackend.consume_finished(self)
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/python/mozbuild/mozbuild/backend/common.py", line 58, in consume_finished
    self._handle_idl_manager(self._idl_manager)
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/python/mozbuild/mozbuild/backend/recursivemake.py", line 471, in _handle_idl_manager
    xpidl_modules=' '.join(xpt_modules),
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/python/mozbuild/mozbuild/backend/configenvironment.py", line 209, in create_config_file
    return self.create_makefile(path, extra=extra)
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/python/mozbuild/mozbuild/backend/configenvironment.py", line 231, in create_makefile
    pp.do_include(self.get_input(path))
  File "/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/config/Preprocessor.py", line 445, in do_include
    raise Preprocessor.Error(self, 'FILE_NOT_FOUND', str(args))
Preprocessor.Error: ('', 0, 'FILE_NOT_FOUND', '/tmp/nix-build-firefox-26.0.drv-0/mozilla-release/config/makefiles/xpidl/Makefile.in')
make: *** [backend.RecursiveMakeBackend.built] Error 1
builder for `/nix/store/h7pwlhs2m0w4nl7zdbf4qnj9j5fnwsn3-firefox-26.0.drv' failed with exit code 2
cannot build derivation `/nix/store/887yrqwkaa3xm0yp809cbqzp8bvvx8id-firefox-26.0-with-plugins.drv': 1 dependencies couldn't be built
error: build of `/nix/store/887yrqwkaa3xm0yp809cbqzp8bvvx8id-firefox-26.0-with-plugins.drv' failed
```
