### PR TITLE
ati-drivers: fix aticonfig segmentation fault

### DIFF
--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   patchPhase = "patch -p0 < ${./gentoo-patches.patch}";
 
   buildInputs =
-    [ xlibs.libXext xlibs.libX11
+    [ xlibs.libXext xlibs.libX11 xlibs.libXinerama
       xlibs.libXrandr which imake makeWrapper
       patchelf
       unzip
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
       "${xorg.libXrender}/lib"
       "${xorg.libXext}/lib"
       "${xorg.libX11}/lib"
+      "${xorg.libXinerama}/lib"
     ];
 
   # without this some applications like blender don't start, but they start


### PR DESCRIPTION
Fix aticonfig tool by setting libXinerama to LD_LIBRARY_PATH
