### PR TITLE
systemd: python support & journal http gateway

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -110,6 +110,7 @@
       openldap = 99;
       memcached = 100;
       cgminer = 101;
+      systemd-journal-gateway = 102;
 
       # When adding a uid, make sure it doesn't match an existing gid.
 
@@ -199,6 +200,7 @@
       haproxy = 92;
       openldap = 93;
       connman = 94;
+      systemd-journal-gateway = 95;
 
       # When adding a gid, make sure it doesn't match an existing uid.
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, pkgconfig, intltool, gperf, libcap, dbus, kmod
 , xz, pam, acl, cryptsetup, libuuid, m4, utillinux
 , glib, kbd, libxslt, coreutils, libgcrypt, sysvtools, docbook_xsl
-, kexectools, python ? null, pythonSupport ? false
+, kexectools, libmicrohttpd
+, python ? null, pythonSupport ? false
 }:
 
 assert stdenv.isLinux;
@@ -27,6 +28,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig intltool gperf libcap dbus.libs kmod xz pam acl
       /* cryptsetup */ libuuid m4 glib libxslt libgcrypt docbook_xsl
+      libmicrohttpd
     ] ++ stdenv.lib.optional pythonSupport python;
 
   configureFlags =

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, pkgconfig, intltool, gperf, libcap, dbus, kmod
 , xz, pam, acl, cryptsetup, libuuid, m4, utillinux
 , glib, kbd, libxslt, coreutils, libgcrypt, sysvtools, docbook_xsl
-, kexectools
+, kexectools, python ? null, pythonSupport ? false
 }:
 
 assert stdenv.isLinux;
+
+assert pythonSupport -> python != null;
 
 stdenv.mkDerivation rec {
   version = "203";
@@ -25,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig intltool gperf libcap dbus.libs kmod xz pam acl
       /* cryptsetup */ libuuid m4 glib libxslt libgcrypt docbook_xsl
-    ];
+    ] ++ stdenv.lib.optional pythonSupport python;
 
   configureFlags =
     [ "--localstatedir=/var"


### PR DESCRIPTION
- add optional python support
- enable journal http gateway by adding libmicrohttp
