### PR TITLE
Revert "nixos/libvirtd-service: fix for garbage collected emulator paths"

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -101,19 +101,6 @@ in
                 mkdir -p /etc/$(dirname $i) -m 755
                 cp -fpd ${pkgs.libvirt}/etc/$i /etc/$i
             done
-
-            # libvirtd puts the full path of the emulator binary in the machine
-            # config file. But this path can unfortunately be garbage collected
-            # while still being used by the virtual machine. So update the
-            # emulator path on each startup to something valid (re-scan $PATH).
-            for file in /etc/libvirt/qemu/*.xml; do
-                # get (old) emulator path from config file
-                emulator=$(grep "^[[:space:]]*<emulator>" "$file" | sed 's,^[[:space:]]*<emulator>\(.*\)</emulator>.*,\1,')
-                # get a (definitely) working emulator path by re-scanning $PATH
-                new_emulator=$(command -v $(basename "$emulator"))
-                # write back
-                sed -i "s,^[[:space:]]*<emulator>.*,    <emulator>$new_emulator</emulator> <!-- WARNING: emulator dirname is auto-updated by the nixos libvirtd module -->," "$file"
-            done
           ''; # */
 
         serviceConfig.ExecStart = ''@${pkgs.libvirt}/sbin/libvirtd libvirtd --config "${configFile}" --daemon --verbose'';


### PR DESCRIPTION
This reverts commit f52f9bf7cd922b54c874e5500a2c64277e57d417.

I get following errors with this commit applied:

```
dec 13 19:17:40 laptop libvirtd-pre-start[8951]: grep: /etc/libvirt/qemu/*.xml: No such file or directory
dec 13 19:17:40 laptop libvirtd-pre-start[8951]: sed: /etc/libvirt/qemu/*.xml ni mogoče prebrati: No such file or directory
dec 13 21:04:33 laptop libvirtd-pre-start[10397]: grep: /etc/libvirt/qemu/*.xml: No such file or directory
dec 13 21:04:33 laptop libvirtd-pre-start[10397]: sed: /etc/libvirt/qemu/*.xml ni mogoče prebrati: No such file or directory
```
