### PR TITLE
libxml2 without python: Add "--with-python=no" to configure flags on all systems

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (rec {
   preInstall = ''substituteInPlace python/libxml2mod.la --replace "${python}" "$out"'';
   installFlags = ''pythondir="$(out)/lib/${python.libPrefix}/site-packages"'';
 
-} // stdenv.lib.optionalAttrs (!pythonSupport && stdenv.isFreeBSD) {
+} // stdenv.lib.optionalAttrs (!pythonSupport) {
   configureFlags = "--with-python=no"; # otherwise build impurity bites us
 })
 


### PR DESCRIPTION
If the flag `--with-python=no` is not specified on the configure command line, libxml2 will be built with python support enabled. This causes configure to search for python by itself, eventually using python distributions found when searching from `/`

When using nix in a rootless configuration, this causes libxml2 to be built against python from its host system. If the host system does not provide a python distribution, building libxml2 fails.

This happened when I did a `nix-env -K -f nixpkgs -iA libxml2` in a clean rootless nix configuration. The error message was:

```
libxml.c:14:20: fatal error: Python.h: No such file or directory
```

Searching `TMPDIR/nix-build*/libxml2*/config.log` revealed the actual command line parameters to configure.

I don't know why the flag was only added on FreeBSD systems before, at least in my rootless configuration running on an Arch Linux amd64 host system I did not experience any error so far.
Maybe vcunat@9220d5b knows more about this?

I did not test this on NixOS, so someone should probably in case this gets merged.
