### PR TITLE
libjpeg-turbo: Patch to fix CVE-2013-6629 and CVE-2013-6630

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0d0jwdmj3h89bxdxlwrys2mw18mqcj4rzgb5l2ndpah8zj600mr6";
   };
 
+  patches = [ ./libjpeg-turbo-1.3.0-CVE-2013-6629-and-6630.patch ];
+
   buildInputs = [ nasm ];
 
   doCheck = true;

--- a/pkgs/development/libraries/libjpeg-turbo/libjpeg-turbo-1.3.0-CVE-2013-6629-and-6630.patch
+++ b/pkgs/development/libraries/libjpeg-turbo/libjpeg-turbo-1.3.0-CVE-2013-6629-and-6630.patch
@@ -4,8 +4,8 @@ http://bugzilla.redhat.com/show_bug.cgi?id=1031734
 http://bugzilla.redhat.com/show_bug.cgi?id=1031749
 http://sourceforge.net/p/libjpeg-turbo/code/1090/
 
---- jdmarker.c
-+++ jdmarker.c
+--- libjpeg-turbo-1.3.0/jdmarker.c
++++ libjpeg-turbo-1.3.0/jdmarker.c
 @@ -304,7 +304,7 @@
  /* Process a SOS marker */
  {

--- a/pkgs/development/libraries/libjpeg-turbo/libjpeg-turbo-1.3.0-CVE-2013-6629-and-6630.patch
+++ b/pkgs/development/libraries/libjpeg-turbo/libjpeg-turbo-1.3.0-CVE-2013-6629-and-6630.patch
@@ -1,0 +1,40 @@
+Thanks to the sources below; this patch discovered via Gentoo.
+
+http://bugzilla.redhat.com/show_bug.cgi?id=1031734
+http://bugzilla.redhat.com/show_bug.cgi?id=1031749
+http://sourceforge.net/p/libjpeg-turbo/code/1090/
+
+--- jdmarker.c
++++ jdmarker.c
+@@ -304,7 +304,7 @@
+ /* Process a SOS marker */
+ {
+   INT32 length;
+-  int i, ci, n, c, cc;
++  int i, ci, n, c, cc, pi;
+   jpeg_component_info * compptr;
+   INPUT_VARS(cinfo);
+ 
+@@ -348,6 +348,13 @@
+     
+     TRACEMS3(cinfo, 1, JTRC_SOS_COMPONENT, cc,
+ 	     compptr->dc_tbl_no, compptr->ac_tbl_no);
++
++    /* This CSi (cc) should differ from the previous CSi */
++    for (pi = 0; pi < i; pi++) {
++      if (cinfo->cur_comp_info[pi] == compptr) {
++        ERREXIT1(cinfo, JERR_BAD_COMPONENT_ID, cc);
++      }
++    }
+   }
+ 
+   /* Collect the additional scan parameters Ss, Se, Ah/Al. */
+@@ -465,6 +472,8 @@
+     for (i = 0; i < count; i++)
+       INPUT_BYTE(cinfo, huffval[i], return FALSE);
+ 
++    MEMZERO(&huffval[count], (256 - count) * SIZEOF(UINT8));
++
+     length -= count;
+ 
+     if (index & 0x10) {		/* AC table definition */


### PR DESCRIPTION
Testing: I built and used Firefox with this commit, though I'm not sure if Firefox uses libjpeg-turbo directly.
