### PR TITLE
Change pmount download address and add platforms

### DIFF
--- a/pkgs/os-specific/linux/pmount/default.nix
+++ b/pkgs/os-specific/linux/pmount/default.nix
@@ -8,10 +8,11 @@
 assert stdenv.lib.hasSuffix "/" mediaDir;
 
 stdenv.mkDerivation rec {
-  name = "pmount-0.9.23";
+  name = "pmount-${version}";
+  version = "0.9.23";
 
   src = fetchurl {
-    url = "https://alioth.debian.org/frs/download.php/3310/${name}.tar.gz";
+    url = "mirror://debian/pool/main/p/pmount/pmount_${version}.orig.tar.bz2";
     sha256 = "db38fc290b710e8e9e9d442da2fb627d41e13b3ee80326c15cc2595ba00ea036";
   };
 
@@ -36,5 +37,6 @@ stdenv.mkDerivation rec {
     homepage = http://pmount.alioth.debian.org/;
     description = "Mount removable devices as normal user";
     license = "GPLv2";
+    platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
The URL change is needed as alioth.debian.org is forcing HTTPS with CA we don't recognize.
Or would it be better to package the Debian's certificate?
