### PR TITLE
ncurses: install *.pc files (pkg-config)

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation (rec {
       fi
     done;
     ln -svf . $out/include/ncursesw
+    ln -svf ncursesw5-config $out/bin/ncurses5-config
   '' else "";
 
   meta = {


### PR DESCRIPTION
To make e.g. "pkg-config --cflags ncursesw" work.

We also have ncurses v5.4 (old) in nixpkgs, but that version doesn't
know how to generate *.pc files. So I'm not touching it.

There is one thing I'd like to discuss before this is merged. In the ncurses expression there is this comment[1]:

  # When building a wide-character (Unicode) build, create backward
  # compatibility links from the the "normal" libraries to the
  # wide-character libraries (e.g. libncurses.so to libncursesw.so).

Should that also apply to the pkg-config files? With this patch pkg-config will know about "ncursesw", but should we also make it know about "ncurses" (minus the 'w')? (Of course, if ncurses is built _without_ unicode/wide chars then it'll probably generate "ncurses" *.pc files and not "ncursesw".)

My initial thought is "no". I don't know why we want to make "backward compatibility links" in the first place. Is it completely safe?

[1] https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/ncurses/default.nix#L36-38
