### PR TITLE
Update python libraries so ipython3 works

### DIFF
--- a/pkgs/development/interpreters/python/3.3/default.nix
+++ b/pkgs/development/interpreters/python/3.3/default.nix
@@ -17,7 +17,7 @@ with stdenv.lib;
 
 let
   majorVersion = "3.3";
-  version = "${majorVersion}.2";
+  version = "${majorVersion}.3";
 
   buildInputs = filter (p: p != null) [
     zlib bzip2 gdbm sqlite db4 readline ncurses openssl tcl tk libX11 xproto
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.python.org/ftp/python/${version}/Python-${version}.tar.bz2";
-    sha256 = "16myvina7nakyyg7r5gnjyydk8bzar988vmxsw2k485w5gz04wpp";
+    sha256 = "1jwd9pw7vx6xpjyi7iv5j3rwwkf3vzrwj36kcj1qh8zn2avfj9p5";
   };
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5023,11 +5023,11 @@ pythonPackages = modules // import ./python-packages-generated.nix {
 
 
   pyparsing = buildPythonPackage rec {
-    name = "pyparsing-1.5.6";
+    name = "pyparsing-2.0.1";
 
     src = fetchurl {
       url = "http://pypi.python.org/packages/source/p/pyparsing/${name}.tar.gz";
-      md5 = "1e41cb219dae9fc353bd4cd47636b283";
+      sha256 = "1r742rjbagf2i166k2w0r192adfw7l9lnsqz7wh4mflf00zws1q0";
     };
 
     # error: invalid command 'test'

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1273,11 +1273,11 @@ pythonPackages = modules // import ./python-packages-generated.nix {
 
 
   dateutil = buildPythonPackage (rec {
-    name = "dateutil-2.1";
+    name = "dateutil-2.2";
 
     src = fetchurl {
       url = "http://pypi.python.org/packages/source/p/python-dateutil/python-${name}.tar.gz";
-      sha256 = "1vlx0lpsxjxz64pz87csx800cwfqznjyr2y7nk3vhmzhkwzyqi2c";
+      sha256 = "0s74ad6r789810s10dxgvaf48ni6adac2icrdad34zxygqq6bj7f";
     };
 
     propagatedBuildInputs = [ pythonPackages.six ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3452,25 +3452,30 @@ pythonPackages = modules // import ./python-packages-generated.nix {
     else pkgs.stdenv;
 
   matplotlib = matplotlibStdenv.mkDerivation (rec {
-    name = "matplotlib-1.2.1";
+    name = "matplotlib-1.3.1";
 
     src = fetchurl {
-      url = "http://downloads.sourceforge.net/matplotlib/${name}.tar.gz";
-      sha256 = "16x2ksdxx5p92v98qngh29hdz1bnqy77fhggbjq30pyqmrr8kqaj";
+      url = "mirror://sourceforge/matplotlib/${name}.tar.gz";
+      sha256 = "0smgpn7lwbn02nbyhawyn0n6r3pb65zk501f21bjgavnjjfnf5pa";
     };
 
     # error: invalid command 'test'
     doCheck = false;
 
-    buildInputs = [ python pkgs.which pkgs.ghostscript ];
+    buildInputs = [ python pkgs.which pkgs.ghostscript distribute ];
 
     propagatedBuildInputs =
-      [ dateutil numpy pkgs.freetype pkgs.libpng pkgs.pkgconfig pkgs.tcl
+      [ dateutil nose numpy pyparsing tornado pkgs.freetype pkgs.libpng pkgs.pkgconfig pkgs.tcl
         pkgs.tk pkgs.xlibs.libX11 ];
+    
+    buildPhase = "${python}/bin/${python.executable} setup.py build";
 
-    buildPhase = "python setup.py build";
-
-    installPhase = "python setup.py install --prefix=$out";
+    # The sed expression parses out the python version from an executable with appended characters
+    installPhase = ''
+      SITE="$out/lib/${python.libPrefix}/site-packages"
+      mkdir -p "$SITE"
+      PYTHONPATH="$PYTHONPATH:$SITE" ${python}/bin/${python.executable} setup.py install --prefix=$out
+    '';
 
     meta = with stdenv.lib; {
       description = "python plotting library, making publication quality plots";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7700,11 +7700,13 @@ pythonPackages = modules // import ./python-packages-generated.nix {
 
 
   tornado = buildPythonPackage rec {
-    name = "tornado-2.4";
+    name = "tornado-3.1.1";
+
     src = fetchurl {
-      url = "http://pypi.python.org/packages/source/t/tornado/tornado-2.4.tar.gz";
-      md5 = "c738af97c31dd70f41f6726cf0968941";
+      url = "http://pypi.python.org/packages/source/t/tornado/${name}.tar.gz";
+      sha256 = "1ipx23ix8hyd88rywmwr7bfdgkvkdac87xq3f9l5vkm0wjzh8n9l";
     };
+
     doCheck = false;
   };
 


### PR DESCRIPTION
ipython3 was currently unable to be built due to dateutil and matplotlib not building correctly under python3.
This set of patches updates dependencies for ipython3 as well as updates python from 3.3.2 -> 3.3.3
