### PR TITLE
Fix btrfsprogs so nix detects the version

### DIFF
--- a/pkgs/tools/filesystems/btrfsprogs/default.nix
+++ b/pkgs/tools/filesystems/btrfsprogs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, attr, acl, zlib, libuuid, e2fsprogs, lzo }:
 
 stdenv.mkDerivation rec {
-  name = "btrfs-progs-v3.12";
+  name = "btrfs-progs-3.12";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/people/mason/btrfs-progs/${name}.tar.xz";


### PR DESCRIPTION
Currently, btrfsprogs is misdetected by nix such that it requires
specifying btrfs-progs-v3.12 for install instead of just btrfs-progs.
This patch removes the v so that it now reads btrfs-progs-3.12 and is
properly detected by nix.
