### PR TITLE
services.redshift: Enable auto-restart

### DIFF
--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -46,6 +46,7 @@ in {
           -t ${toString cfg.temperature.day}:${toString cfg.temperature.night}
       '';
       environment = { DISPLAY = ":0"; };
+      serviceConfig.Restart = "always";
     };
   };
 }

--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -40,6 +40,7 @@ in {
     systemd.services.redshift = {
       description = "Redshift colour temperature adjuster";
       requires = [ "display-manager.service" ];
+      after = [ "display-manager.service" ];
       script = ''
         ${pkgs.redshift}/bin/redshift \
           -l ${cfg.latitude}:${cfg.longitude} \


### PR DESCRIPTION
The redshift service stops working after some time (the program exits
after some hours/days). It looks like these exits are related to calls
to xrandr (for multiple displays) or suspend-to-ram.
