### PR TITLE
Added Nexuiz-2.5.2.

### DIFF
--- a/pkgs/games/nexuiz/default.nix
+++ b/pkgs/games/nexuiz/default.nix
@@ -1,0 +1,76 @@
+{ stdenv, fetchurl
+, # required for both
+  unzip, zlib, curl, libjpeg, libpng, libvorbis, libtheora
+, libogg, libmodplug
+, # glx
+  libX11, mesa, libXpm, libXext, libXxf86vm, libXxf86dga, alsaLib
+, # sdl
+  SDL
+}:
+
+let
+  version = "2.5.2";
+
+  version_short = stdenv.lib.replaceChars [ "." ] [ "" ] "${version}";
+in stdenv.mkDerivation {
+  name = "nexuiz-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/nexuiz/nexuiz-${version_short}.zip";
+    sha256 = "0010jrxc68qqinkvdh1qn2b8z3sa5v1kcd8d1m4llp3pr6y7xqm5";
+  };
+
+  buildInputs = [
+    # required for both
+    unzip
+    # glx
+    libX11 mesa libXpm libXext libXxf86vm libXxf86dga alsaLib
+    # sdl
+    SDL
+  ];
+
+  postUnpack = ''
+    cd Nexuiz/sources/
+    unzip enginesource*.zip
+    cd ../../
+  '';
+
+  NIX_LDFLAGS = ''
+    -rpath ${zlib}/lib
+    -rpath ${curl}/lib
+    -rpath ${libjpeg}/lib
+    -rpath ${libpng}/lib
+    -rpath ${libvorbis}/lib
+    -rpath ${libtheora}/lib
+    -rpath ${libogg}/lib
+    -rpath ${libmodplug}/lib
+  '';
+
+  buildPhase = ''
+    cd sources/darkplaces/
+    DP_FS_BASEDIR="$out/share/nexuiz"
+    make DP_FS_BASEDIR=$DP_FS_BASEDIR cl-release
+    make DP_FS_BASEDIR=$DP_FS_BASEDIR sdl-release
+    make DP_FS_BASEDIR=$DP_FS_BASEDIR sv-release
+    cd ../../
+  '';
+
+  installPhase = ''
+    mkdir -pv "$out/bin/"
+    cp -v sources/darkplaces/darkplaces-glx "$out/bin/nexuiz-glx"
+    cp -v sources/darkplaces/darkplaces-sdl "$out/bin/nexuiz-sdl"
+    cp -v sources/darkplaces/darkplaces-dedicated "$out/bin/nexuiz-dedicated"
+    mkdir -pv "$out/share/nexuiz/"
+    cp -rv data/ "$out/share/nexuiz/"
+    ln -s "$out/bin/nexuiz-sdl" "$out/bin/nexuiz"
+  '';
+
+  dontPatchELF = true;
+
+  meta = {
+    description = "A free fast-paced first-person shooter";
+    homepage = "http://www.alientrap.org/games/nexuiz";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9436,6 +9436,8 @@ let
 
   naev = callPackage ../games/naev { };
 
+  nexuiz = callPackage ../games/nexuiz { };
+
   njam = callPackage ../games/njam { };
 
   oilrush = callPackage ../games/oilrush { };


### PR DESCRIPTION
I have added Nexuiz-2.5.2.

possible optional TODO's:
- split the DarkPlaces engine so games using it (Nexuiz, Xonotic and others) would not need to compile it seperately. I tried but encountered many problems in both Nexuiz and Xonotic, I might give it a shot some other time again.
- add libOffscreenGecko to nixpkgs and add it to the rpath as Nexuiz searches for it at runtime.
