### PR TITLE
vim: enable support for Lua

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -87,7 +87,17 @@ composableDerivation {
 
       // edf { name = "tcl"; enable = { nativeBuildInputs = [tcl]; }; } #Include Tcl interpreter.
       // edf { name = "ruby"; feat = "rubyinterp"; enable = { nativeBuildInputs = [ruby]; };} #Include Ruby interpreter.
-      // edf { name = "lua" ; feat = "luainterp"; enable = { nativeBuildInputs = [lua]; configureFlags = ["--with-lua-prefix=${args.lua}"];};}
+      // edf {
+        name = "lua";
+        feat = "luainterp";
+        enable = {
+          nativeBuildInputs = [lua];
+          configureFlags = [
+            "--with-lua-prefix=${args.lua}"
+            "--enable-luainterp"
+          ];
+        };
+      }
       // edf { name = "cscope"; } #Include cscope interface.
       // edf { name = "workshop"; } #Include Sun Visual Workshop support.
       // edf { name = "netbeans"; } #Disable NetBeans integration support.
@@ -102,6 +112,7 @@ composableDerivation {
       ;
 
   cfg = {
+    luaSupport       = config.vim.lua or true;
     pythonSupport    = config.vim.python or true;
     rubySupport      = config.vim.ruby or true;
     nlsSupport       = config.vim.nls or false;


### PR DESCRIPTION
This patch makes Lua support in vim configurable by the option `config.vim.lua`, similar to the other supported interpreters.
