### PR TITLE
glibc: pull a bug work-around from Arch (i686-only ATM)

### DIFF
--- a/pkgs/development/libraries/glibc/2.18/common.nix
+++ b/pkgs/development/libraries/glibc/2.18/common.nix
@@ -61,7 +61,9 @@ stdenv.mkDerivation ({
       ./cve-2013-4332.patch
       ./cve-2013-4458.patch
       ./cve-2013-4788.patch
-    ];
+    ]
+      # the problem only seems to affect i686, so avoid re-hash x86_64 ATM
+      ++ stdenv.lib.optional stdenv.isi686 ./strstr-sse42-hack.patch;
 
   postPatch = ''
     # Needed for glibc to build with the gnumake 3.82

--- a/pkgs/development/libraries/glibc/2.18/strstr-sse42-hack.patch
+++ b/pkgs/development/libraries/glibc/2.18/strstr-sse42-hack.patch
@@ -1,0 +1,14 @@
+https://bugs.archlinux.org/task/36556
+diff --git a/sysdeps/x86_64/multiarch/strstr.c b/sysdeps/x86_64/multiarch/strstr.c
+index cd63b68..03d8b9a 100644
+--- a/sysdeps/x86_64/multiarch/strstr.c
++++ b/sysdeps/x86_64/multiarch/strstr.c
+@@ -86,7 +86,7 @@
+ /* Simple replacement of movdqu to address 4KB boundary cross issue.
+    If EOS occurs within less than 16B before 4KB boundary, we don't
+    cross to next page.  */
+-static __m128i
++static inline __m128i
+ __m128i_strloadu (const unsigned char * p, __m128i zero)
+ {
+   if (__builtin_expect ((int) ((size_t) p & 0xfff) > 0xff0, 0))


### PR DESCRIPTION
This should work around some of our build problems,
e.g. http://hydra.nixos.org/build/7575893/nixlog/1/tail-reload

I tested the builds of jdk and xbmc were broken on my build machine, and now they work. It's a stdenv change for i686, but to me it seems worth it.

If noone protests, I plan to merge in about a day or two? (I don't see any Hydra branch suitable for pre-building this, for nixos:glibc-2.18 is stopped.)
