### PR TITLE
Allow the user to execute commands at the beginning of the X session.

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -103,6 +103,11 @@ let
 
       ${cfg.displayManager.sessionCommands}
 
+      # Allow the user to execute commands at the beginning of the X session.
+      if test -f ~/.xprofile; then
+          source ~/.xprofile
+      fi
+
       # Allow the user to setup a custom session type.
       if test -x ~/.xsession; then
           exec ~/.xsession


### PR DESCRIPTION
The difference between xsession and xprofile is that xsession is exec'd and xprofile is sourced.
So with xprofile all commands after sourcing will still be exectued. This allows for instance
autostarting of applications while configuring the start of a window manager via configuration.nix.
