### PR TITLE
Place stumpish from stumpwm's contrib in bin/

### DIFF
--- a/pkgs/development/lisp-modules/stumpwm/default.nix
+++ b/pkgs/development/lisp-modules/stumpwm/default.nix
@@ -19,7 +19,7 @@ buildLispPackage rec {
       ${x.deployConfigScript}
       export CL_SOURCE_REGISTRY="$CL_SOURCE_REGISTRY:$PWD/"
       ./autogen.sh 
-      configureFlags=" --with-lisp=$NIX_LISP --with-$NIX_LISP=$(which common-lisp.sh) "
+      configureFlags=" --with-lisp=$NIX_LISP --with-$NIX_LISP=$(which common-lisp.sh) --with-contrib-dir=$out/lib/common-lisp/stumpwm/contrib/"
     '';
     installPhase=x.installPhase + ''
       make install 

--- a/pkgs/development/lisp-modules/stumpwm/default.nix
+++ b/pkgs/development/lisp-modules/stumpwm/default.nix
@@ -8,7 +8,7 @@ buildLispPackage rec {
     rev = "565ef58f04f59e1667ec1da4087f1a43a32cd67f";
   };
   description = "Tiling window manager for X11";
-  deps = [cl-ppcre clx pkgs.xlibs.xprop];
+  deps = [cl-ppcre clx];
   buildInputs = with pkgs; [texinfo autoconf which makeWrapper];
   meta = {
     maintainers = [nixLib.maintainers.raskin];
@@ -29,7 +29,7 @@ buildLispPackage rec {
       fi;
 
       mv $out/lib/common-lisp/stumpwm/contrib/stumpish $out/bin/stumpish
-      wrapProgram "$out"/bin/stumpish --prefix PATH : "${pkgs.xlibs.xprop}/bin"
+      wrapProgram "$out"/bin/stumpish --prefix PATH : "${pkgs.xlibs.xprop}/bin:${pkgs.coreutils}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${pkgs.rlwrap}/bin"
     '';
     postInstall = ''false'';
   };

--- a/pkgs/development/lisp-modules/stumpwm/default.nix
+++ b/pkgs/development/lisp-modules/stumpwm/default.nix
@@ -21,7 +21,7 @@ buildLispPackage rec {
       ./autogen.sh 
       configureFlags=" --with-lisp=$NIX_LISP --with-$NIX_LISP=$(which common-lisp.sh) --with-contrib-dir=$out/lib/common-lisp/stumpwm/contrib/"
     '';
-    installPhase=x.installPhase + ''
+    installPhase = with pkgs; x.installPhase + ''
       make install 
 
       if [ "$NIX_LISP" = "sbcl" ]; then
@@ -29,7 +29,7 @@ buildLispPackage rec {
       fi;
 
       mv $out/lib/common-lisp/stumpwm/contrib/stumpish $out/bin/stumpish
-      wrapProgram "$out"/bin/stumpish --prefix PATH : "${pkgs.xlibs.xprop}/bin:${pkgs.coreutils}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${pkgs.rlwrap}/bin"
+      wrapProgram "$out"/bin/stumpish --prefix PATH : "${xlibs.xprop}/bin:${coreutils}/bin:${gnugrep}/bin:${gnused}/bin:${rlwrap}/bin:${ncurses}/bin"
     '';
     postInstall = ''false'';
   };

--- a/pkgs/development/lisp-modules/stumpwm/default.nix
+++ b/pkgs/development/lisp-modules/stumpwm/default.nix
@@ -27,6 +27,8 @@ buildLispPackage rec {
       if [ "$NIX_LISP" = "sbcl" ]; then
         wrapProgram "$out"/bin/stumpwm --set SBCL_HOME "${clwrapper.lisp}/lib/sbcl"
       fi;
+
+      mv $out/lib/common-lisp/stumpwm/contrib/stumpish $out/bin/stumpish
     '';
     postInstall = ''false'';
   };

--- a/pkgs/development/lisp-modules/stumpwm/default.nix
+++ b/pkgs/development/lisp-modules/stumpwm/default.nix
@@ -8,7 +8,7 @@ buildLispPackage rec {
     rev = "565ef58f04f59e1667ec1da4087f1a43a32cd67f";
   };
   description = "Tiling window manager for X11";
-  deps = [cl-ppcre clx];
+  deps = [cl-ppcre clx pkgs.xlibs.xprop];
   buildInputs = with pkgs; [texinfo autoconf which makeWrapper];
   meta = {
     maintainers = [nixLib.maintainers.raskin];
@@ -29,6 +29,7 @@ buildLispPackage rec {
       fi;
 
       mv $out/lib/common-lisp/stumpwm/contrib/stumpish $out/bin/stumpish
+      wrapProgram "$out"/bin/stumpish --prefix PATH : "${pkgs.xlibs.xprop}/bin"
     '';
     postInstall = ''false'';
   };


### PR DESCRIPTION
stumpish is a handy CLI RPC client for stumpwm (e.g. it can be used to
send code from Emacs to stumpwm for evaluation).
