### PR TITLE
Fix networkmanager-pptp

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -146,6 +146,9 @@ in {
       { source = "${networkmanager_openconnect}/etc/NetworkManager/VPN/nm-openconnect-service.name";
         target = "NetworkManager/VPN/nm-openconnect-service.name";
       }
+      { source = "${networkmanager_pptp}/etc/NetworkManager/VPN/nm-pptp-service.name";
+        target = "NetworkManager/VPN/nm-pptp-service.name";
+      }
     ] ++ pkgs.lib.optional (cfg.appendNameservers == [] || cfg.insertNameservers == [])
            { source = overrideNameserversScript;
              target = "NetworkManager/dispatcher.d/02overridedns";
@@ -155,6 +158,7 @@ in {
         networkmanager_openvpn
         networkmanager_vpnc
         networkmanager_openconnect
+        networkmanager_pptp
         ];
 
     users.extraGroups = singleton {
@@ -199,6 +203,7 @@ in {
         networkmanager_openvpn
         networkmanager_vpnc
         networkmanager_openconnect
+        networkmanager_pptp
         ];
 
     services.udev.packages = cfg.packages;

--- a/pkgs/tools/networking/network-manager/pptp.nix
+++ b/pkgs/tools/networking/network-manager/pptp.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/0.9/${pname}-${version}.tar.xz";
-    sha256 = "7f46ea61376d13d03685eca3f26a26e0022f6e92e6f1fc356034ca9717eb6daa";
+    sha256 = "1s6wmznd6azvg028x8y3syniqy9j7nmx5j71w2wc6mk0f9pqzflp";
   };
 
   buildInputs = [ networkmanager pptp ppp ]


### PR DESCRIPTION
The expression for networkmanager-pptp has the wrong sha256 sum. The module for NixOS also needs to register the service with D-Bus and NetworkManager.
