### PR TITLE
poppler-glib.pc has ${includedir}/poppler in cflags

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -32,7 +32,7 @@ let
 
     cmakeFlags = "-DENABLE_XPDF_HEADERS=ON -DENABLE_LIBCURL=ON -DENABLE_ZLIB=ON";
 
-    patches = [ ./datadir_env.patch ];
+    patches = [ ./datadir_env.patch ./poppler-glib.patch ];
 
     # XXX: The Poppler/Qt4 test suite refers to non-existent PDF files
     # such as `../../../test/unittestcases/UseNone.pdf'.

--- a/pkgs/development/libraries/poppler/poppler-glib.patch
+++ b/pkgs/development/libraries/poppler/poppler-glib.patch
@@ -1,0 +1,19 @@
+diff -rupN a/poppler-glib.pc.cmake b/poppler-glib.pc.cmake
+--- a/poppler-glib.pc.cmake	2013-08-17 01:20:41.000000001 +0200
++++ b/poppler-glib.pc.cmake	2014-01-01 09:30:50.000000001 +0100
+@@ -10,4 +10,4 @@ Requires: glib-2.0 >= @GLIB_REQUIRED@ go
+ @PC_REQUIRES_PRIVATE@
+ 
+ Libs: -L${libdir} -lpoppler-glib
+-Cflags: -I${includedir}/poppler/glib
++Cflags: -I${includedir}/poppler/glib -I${includedir}/poppler
+diff -rupN a/poppler-glib.pc.in b/poppler-glib.pc.in
+--- a/poppler-glib.pc.in	2013-08-17 01:20:41.000000001 +0200
++++ b/poppler-glib.pc.in	2014-01-01 09:27:17.000000001 +0100
+@@ -10,4 +10,5 @@ Requires: glib-2.0 >= @GLIB_REQUIRED@ go
+ @PC_REQUIRES_PRIVATE@
+ 
+ Libs: -L${libdir} -lpoppler-glib
+-Cflags: -I${includedir}/poppler/glib
++Cflags: -I${includedir}/poppler/glib -I${includedir}/poppler
++


### PR DESCRIPTION
Programs/libraries that depends on poppler-glib often assumes the base directory of poppler-glib is under the base directory of poppler, and thus does not work for nixos setup. 
By adding (poppler-glib base)/include/poppler in include path in cflags in pkg-config, this cures missing header problems. This was tested with haskell binding for poppler library.  
