### PR TITLE
Bump TeXLive versions

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/beamer.nix
+++ b/pkgs/tools/typesetting/tex/texlive/beamer.nix
@@ -1,9 +1,9 @@
 args: with args;
 rec {
-  name = "texlive-beamer-2012";
+  name = "texlive-beamer-2013";
   src = fetchurl {
-    url = mirror://debian/pool/main/l/latex-beamer/latex-beamer_3.10.orig.tar.gz;
-    sha256 = "1vk7nr1lxinyj941nz5xzcpzircd60s8sgmq7jd2gqmf5ynd27nx";
+    url = mirror://debian/pool/main/l/latex-beamer/latex-beamer_3.24.orig.tar.gz;
+    sha256 = "0rzjlbs67kzmvlh7lwga4yxgddvrvfkkhhx1ajdn4lqy2w9zxiv8";
   };
 
   buildInputs = [texLive];

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -6,13 +6,13 @@ rec {
   };
 
   texmfSrc = fetchurl {
-    url = mirror://debian/pool/main/t/texlive-base/texlive-base_2013.20131112.orig.tar.xz;
-    sha256 = "1zak95xh35bnzr3hjrjaxg0yisyw8g3xcym0ywsspc4dxpn1qgk1";
+    url = mirror://debian/pool/main/t/texlive-base/texlive-base_2013.20131219.orig.tar.xz;
+    sha256 = "1kcfw6n9rv3wznyqkvkad60p1zljbn1cw2jhajzcrn8m39y0ad3x";
   };
 
   langTexmfSrc = fetchurl {
-    url = mirror://debian/pool/main/t/texlive-lang/texlive-lang_2013.20131112.orig.tar.xz;
-    sha256 = "003rj7pv38lgmggya2nbzcyfdx5d4wa7h1h4xh7iivsxja7z4m1d";
+    url = mirror://debian/pool/main/t/texlive-lang/texlive-lang_2013.20131219.orig.tar.xz;
+    sha256 = "139hb91ks62q56dnnrzhcxmm2wpz0b40ka7smaqgw86r002albb0";
   };
 
   passthru = { inherit texmfSrc langTexmfSrc; };

--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -2,8 +2,8 @@ args: with args;
 rec {
   name = "texlive-extra-2013";
   src = fetchurl {
-    url = mirror://debian/pool/main/t/texlive-extra/texlive-extra_2013.20131112.orig.tar.xz;
-    sha256 = "0qpiig9sz8wx3dhy1jha7rkxrhvpf2cmfx424h68s3ql05nnw65i";
+    url = mirror://debian/pool/main/t/texlive-extra/texlive-extra_2013.20131219.orig.tar.xz;
+    sha256 = "09iijzq0y5kq16f3lv2jrln190ldbbzywpwr33hrmnw5yp3izmrh";
   };
 
   buildInputs = [texLive xz];


### PR DESCRIPTION
Building these expressions was failing because Debian has updated their TeXLive packages and the old sources are no longer available.
