### PR TITLE
Configurable FFmpeg expression, fdk-aac library, license fixes

### DIFF
--- a/pkgs/development/libraries/fdk-aac/default.nix
+++ b/pkgs/development/libraries/fdk-aac/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+let version = "0.1.3";
+in
+stdenv.mkDerivation {
+  name = "fdk-aac-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/opencore-amr/fdk-aac/fdk-aac-${version}.tar.gz";
+    sha256 = "138c1l6c571289czihk0vlcfbla7qlac2jd5yyps5dyg08l8gjx9";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A high-quality implementation of the AAC codec from Android";
+    homepage = "http://sourceforge.net/projects/opencore-amr/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/ffmpeg/2.x.nix
+++ b/pkgs/development/libraries/ffmpeg/2.x.nix
@@ -14,6 +14,7 @@
 , x11grabSupport ? false, libXext ? null, libXfixes ? null
 , playSupport ? true, SDL ? null
 , freetypeSupport ? true, freetype ? null, fontconfig ? null
+, fdkAACSupport ? false, fdk_aac ? null
 }:
 
 assert speexSupport -> speex != null;
@@ -29,6 +30,7 @@ assert faacSupport -> faac != null;
 assert x11grabSupport -> libXext != null && libXfixes != null;
 assert playSupport -> SDL != null;
 assert freetypeSupport -> freetype != null;
+assert fdkAACSupport -> fdk_aac != null;
 
 stdenv.mkDerivation rec {
   name = "ffmpeg-2.1.1";
@@ -62,7 +64,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional dc1394Support "--enable-libdc1394"
     ++ stdenv.lib.optional x11grabSupport "--enable-x11grab"
     ++ stdenv.lib.optional playSupport "--enable-ffplay"
-    ++ stdenv.lib.optional freetypeSupport "--enable-libfreetype --enable-fontconfig";
+    ++ stdenv.lib.optional freetypeSupport "--enable-libfreetype --enable-fontconfig"
+    ++ stdenv.lib.optional fdkAACSupport "--enable-libfdk_aac --enable-nonfree";
 
   buildInputs = [ pkgconfig lame yasm zlib bzip2 alsaLib texinfo perl ]
     ++ stdenv.lib.optional mp3Support lame
@@ -79,7 +82,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional dc1394Support libdc1394
     ++ stdenv.lib.optionals x11grabSupport [ libXext libXfixes ]
     ++ stdenv.lib.optional playSupport SDL
-    ++ stdenv.lib.optionals freetypeSupport [ freetype fontconfig ];
+    ++ stdenv.lib.optionals freetypeSupport [ freetype fontconfig ]
+    ++ stdenv.lib.optional fdkAACSupport fdk_aac;
 
   enableParallelBuilding = true;
 
@@ -100,5 +104,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.ffmpeg.org/;
     description = "A complete, cross-platform solution to record, convert and stream audio and video";
+    license = if (fdkAACSupport || faacSupport) then stdenv.lib.licenses.unfree else stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/libraries/ffmpeg/configurable.nix
+++ b/pkgs/development/libraries/ffmpeg/configurable.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, config, pkgconfig, yasm, zlib, bzip2, alsaLib, texinfo, perl
 , lame, speex, libtheora, libvorbis, libvpx, x264, xvidcore, libopus
 , libvdpau, libva, faac, libdc1394, libXext, libXfixes, SDL
-, freetype, fontconfig
+, freetype, fontconfig, fdk_aac
 }:
 
 stdenv.mkDerivation rec {
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   vdpauSupport = config.ffmpeg.vdpau or true;
   vaapiSupport = config.ffmpeg.vaapi or true;
   faacSupport = config.ffmpeg.faac or false;
+  fdkAACSupport = config.ffmpeg.fdk or false;
   dc1394Support = config.ffmpeg.dc1394 or false;
   x11grabSupport = config.ffmpeg.x11grab or false;
   playSupport = config.ffmpeg.play or true;
@@ -52,7 +53,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional dc1394Support "--enable-libdc1394"
     ++ stdenv.lib.optional x11grabSupport "--enable-x11grab"
     ++ stdenv.lib.optional playSupport "--enable-ffplay"
-    ++ stdenv.lib.optional freetypeSupport "--enable-libfreetype --enable-fontconfig";
+    ++ stdenv.lib.optional freetypeSupport "--enable-libfreetype --enable-fontconfig"
+    ++ stdenv.lib.optional fdkAACSupport "--enable-libfdk_aac --enable-nonfree";
 
   buildInputs = [ pkgconfig lame yasm zlib bzip2 alsaLib texinfo perl ]
     ++ stdenv.lib.optional mp3Support lame
@@ -69,7 +71,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional dc1394Support libdc1394
     ++ stdenv.lib.optionals x11grabSupport [ libXext libXfixes ]
     ++ stdenv.lib.optional playSupport SDL
-    ++ stdenv.lib.optionals freetypeSupport [ freetype fontconfig ];
+    ++ stdenv.lib.optionals freetypeSupport [ freetype fontconfig ]
+    ++ stdenv.lib.optional fdkAACSupport fdk_aac;
 
   enableParallelBuilding = true;
 
@@ -90,5 +93,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.ffmpeg.org/;
     description = "A complete, cross-platform solution to record, convert and stream audio and video";
+    license = if (fdkAACSupport || faacSupport) then stdenv.lib.licenses.unfree else stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/libraries/ffmpeg/configurable.nix
+++ b/pkgs/development/libraries/ffmpeg/configurable.nix
@@ -1,0 +1,94 @@
+{ stdenv, fetchurl, config, pkgconfig, yasm, zlib, bzip2, alsaLib, texinfo, perl
+, lame, speex, libtheora, libvorbis, libvpx, x264, xvidcore, libopus
+, libvdpau, libva, faac, libdc1394, libXext, libXfixes, SDL
+, freetype, fontconfig
+}:
+
+stdenv.mkDerivation rec {
+  name = "ffmpeg-2.1.1";
+
+  src = fetchurl {
+    url = "http://www.ffmpeg.org/releases/${name}.tar.bz2";
+    sha256 = "1qnspbpwa6cflsb6mkm84ay4nfx60ism6d7lgvnasidck9dmxydy";
+  };
+
+  mp3Support = config.ffmpeg.mp3 or true;
+  speexSupport = config.ffmpeg.speex or true;
+  theoraSupport = config.ffmpeg.theora or true;
+  vorbisSupport = config.ffmpeg.vorbis or true;
+  vpxSupport = config.ffmpeg.vpx or false;
+  x264Support = config.ffmpeg.x264 or true;
+  xvidSupport = config.ffmpeg.xvid or true;
+  opusSupport = config.ffmpeg.opus or true;
+  vdpauSupport = config.ffmpeg.vdpau or true;
+  vaapiSupport = config.ffmpeg.vaapi or true;
+  faacSupport = config.ffmpeg.faac or false;
+  dc1394Support = config.ffmpeg.dc1394 or false;
+  x11grabSupport = config.ffmpeg.x11grab or false;
+  playSupport = config.ffmpeg.play or true;
+  freetypeSupport = config.ffmpeg.freetype or true;
+
+  # `--enable-gpl' (as well as the `postproc' and `swscale') mean that
+  # the resulting library is GPL'ed, so it can only be used in GPL'ed
+  # applications.
+  configureFlags = [
+    "--enable-gpl"
+    "--enable-postproc"
+    "--enable-swscale"
+    "--enable-shared"
+    "--enable-avresample"
+    "--enable-runtime-cpudetect"
+  ]
+    ++ stdenv.lib.optional mp3Support "--enable-libmp3lame"
+    ++ stdenv.lib.optional speexSupport "--enable-libspeex"
+    ++ stdenv.lib.optional theoraSupport "--enable-libtheora"
+    ++ stdenv.lib.optional vorbisSupport "--enable-libvorbis"
+    ++ stdenv.lib.optional vpxSupport "--enable-libvpx"
+    ++ stdenv.lib.optional x264Support "--enable-libx264"
+    ++ stdenv.lib.optional xvidSupport "--enable-libxvid"
+    ++ stdenv.lib.optional opusSupport "--enable-libopus"
+    ++ stdenv.lib.optional vdpauSupport "--enable-vdpau"
+    ++ stdenv.lib.optional faacSupport "--enable-libfaac --enable-nonfree"
+    ++ stdenv.lib.optional dc1394Support "--enable-libdc1394"
+    ++ stdenv.lib.optional x11grabSupport "--enable-x11grab"
+    ++ stdenv.lib.optional playSupport "--enable-ffplay"
+    ++ stdenv.lib.optional freetypeSupport "--enable-libfreetype --enable-fontconfig";
+
+  buildInputs = [ pkgconfig lame yasm zlib bzip2 alsaLib texinfo perl ]
+    ++ stdenv.lib.optional mp3Support lame
+    ++ stdenv.lib.optional speexSupport speex
+    ++ stdenv.lib.optional theoraSupport libtheora
+    ++ stdenv.lib.optional vorbisSupport libvorbis
+    ++ stdenv.lib.optional vpxSupport libvpx
+    ++ stdenv.lib.optional x264Support x264
+    ++ stdenv.lib.optional xvidSupport xvidcore
+    ++ stdenv.lib.optional opusSupport libopus
+    ++ stdenv.lib.optional vdpauSupport libvdpau
+    ++ stdenv.lib.optional vaapiSupport libva
+    ++ stdenv.lib.optional faacSupport faac
+    ++ stdenv.lib.optional dc1394Support libdc1394
+    ++ stdenv.lib.optionals x11grabSupport [ libXext libXfixes ]
+    ++ stdenv.lib.optional playSupport SDL
+    ++ stdenv.lib.optionals freetypeSupport [ freetype fontconfig ];
+
+  enableParallelBuilding = true;
+
+  crossAttrs = {
+    dontSetConfigureCross = true;
+    configureFlags = configureFlags ++ [
+      "--cross-prefix=${stdenv.cross.config}-"
+      "--enable-cross-compile"
+      "--target_os=linux"
+      "--arch=${stdenv.cross.arch}"
+      ];
+  };
+
+  passthru = {
+    inherit vdpauSupport;
+  };
+
+  meta = {
+    homepage = http://www.ffmpeg.org/;
+    description = "A complete, cross-platform solution to record, convert and stream audio and video";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -913,6 +913,8 @@ let
 
   lprof = callPackage ../tools/graphics/lprof { };
 
+  fdk_aac = callPackage ../development/libraries/fdk-aac { };
+
   flvtool2 = callPackage ../tools/video/flvtool2 { };
 
   fontforge = lowPrio (callPackage ../tools/misc/fontforge { });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4184,6 +4184,8 @@ let
 
   ffmpeg = ffmpeg_2;
 
+  ffmpeg_configurable = callPackage ../development/libraries/ffmpeg/configurable.nix { };
+
   ffms = callPackage ../development/libraries/ffms { };
 
   fftw = callPackage ../development/libraries/fftw { };


### PR DESCRIPTION
These commits do several things:
- Add `ffmpeg_configurable`, a configurable expression for FFmpeg styled after `vim_configurable`. Otherwise, it's difficult to configure an FFmpeg expression for users who want the command line tool in their environment.
- Add the `fdk-aac` library, a high-quality AAC codec implementation from Android.
- Allow `ffmpeg_2` and `ffmpeg_configurable` to use the `fdk-aac` library. This is disabled by default because:
- FFmpeg is GPLv2+ unless `fdk-aac` or `faac` are enabled, in which case it is non-free and unredistributable.
