### PR TITLE
Add d-feet, a DBus debugger

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -31,6 +31,7 @@
   iyzsong = "Song Wenwu <iyzsong@gmail.com>";
   jcumming = "Jack Cummings <jack@mudshark.org>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
+  ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   marcweber = "Marc Weber <marco-oweber@gmx.de>";

--- a/pkgs/development/libraries/libwnck/3.x.nix
+++ b/pkgs/development/libraries/libwnck/3.x.nix
@@ -1,15 +1,15 @@
 {stdenv, fetchurl, pkgconfig, libX11, gtk3, intltool}:
 
 stdenv.mkDerivation {
-  name = "libwnck-3.2.1";
+  name = "libwnck-3.4.7";
 
   src = fetchurl {
-    url = mirror://gnome/sources/libwnck/3.2/libwnck-3.2.1.tar.xz;
-    sha256 = "1nm34rpr0n559x1ba4kmxbhqclvvnlz0g8xqbbj709q9irnmifpa";
+    url = mirror://gnome/sources/libwnck/3.4/libwnck-3.4.7.tar.xz;
+    sha256 = "d48ac9c7f50c0d563097f63d07bcc83744c7d92a1b4ef65e5faeab32b5ccb723";
   };
+
+  patches = [ ./install_introspection_to_prefix.patch ];
 
   buildInputs = [ pkgconfig intltool ];
   propagatedBuildInputs = [ libX11 gtk3 ];
-
-  configureFlags = [ "--disable-introspection" ];
 }

--- a/pkgs/development/libraries/libwnck/install_introspection_to_prefix.patch
+++ b/pkgs/development/libraries/libwnck/install_introspection_to_prefix.patch
@@ -1,0 +1,12 @@
+--- libwnck-3.4.7/configure	2013-08-20 14:46:14.000000000 +0000
++++ libwnck-3.4.7-fix/configure	2014-01-05 17:18:56.665427787 +0000
+@@ -16150,7 +16150,7 @@ $as_echo "$found_introspection" >&6; }
+        INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+        INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+-       INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
++       INTROSPECTION_GIRDIR="${datadir}/gir-1.0"
+-       INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
++       INTROSPECTION_TYPELIBDIR="${libdir}/girepository-1.0"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+        INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -1,14 +1,12 @@
 { stdenv, fetchurl, python, pkgconfig, glib, gobjectIntrospection, pycairo, cairo }:
  
 stdenv.mkDerivation rec {
-  name = "pygobject-3.0.4";
-   
-  src = fetchurl {
-    url = "mirror://gnome/sources/pygobject/3.0/${name}.tar.xz";
-    sha256 = "f457b1d7f6b8bfa727593c3696d2b405da66b4a8d34cd7d3362ebda1221f0661";
-  };
+  name = "pygobject-3.10.2";
 
-  configureFlags = "--disable-introspection";
+  src = fetchurl {
+    url = "mirror://gnome/sources/pygobject/3.10/${name}.tar.xz";
+    sha256 = "75608f2c4052f0277508fc79debef026d9e84cb9261de2b922387c093d32c326";
+  };
 
   buildInputs = [ python pkgconfig glib gobjectIntrospection pycairo cairo ];
 

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, pkgconfig, fetchurl, itstool, intltool, libxml2, glib, gtk3
+, pango, gdk_pixbuf, atk, pep8, python, makeWrapper
+, pygobject3, gobjectIntrospection, libwnck3
+, gnome_icon_theme }:
+
+let
+  version = "${major}.8";
+  major = "0.3";
+in
+
+stdenv.mkDerivation rec {
+  name = "d-feet-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/d-feet/${major}/d-feet-${version}.tar.xz";
+    sha256 = "e8423feb18fdff9b1465bf8442b78994ba13c12f8fa3b08e6a2f05768b4feee5";
+  };
+
+  buildInputs = [
+    pkgconfig libxml2 itstool intltool glib gtk3 pep8 python
+    makeWrapper pygobject3 libwnck3
+  ];
+
+  postInstall =
+    ''
+      wrapProgram $out/bin/d-feet \
+        --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pygobject3})" \
+        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+        --prefix LD_LIBRARY_PATH : "${gtk3}/lib:${atk}/lib:${libwnck3}/lib" \
+        --prefix XDG_DATA_DIRS : "${gnome_icon_theme}/share:$out/share"
+    '';
+
+  meta = {
+    description = "D-Feet is an easy to use D-Bus debugger";
+
+    longDescription = ''
+      D-Feet can be used to inspect D-Bus interfaces of running programs
+      and invoke methods on those interfaces.
+    '';
+
+    homepage = https://wiki.gnome.org/action/show/Apps/DFeet;
+  };
+}

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -39,5 +39,7 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = https://wiki.gnome.org/action/show/Apps/DFeet;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ ktosiek ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3613,6 +3613,11 @@ let
 
   dejagnu = callPackage ../development/tools/misc/dejagnu { };
 
+  dfeet = callPackage ../development/tools/misc/d-feet {
+    inherit (pythonPackages) pep8;
+    inherit (gnome3) gnome_icon_theme;
+  };
+
   ddd = callPackage ../development/tools/misc/ddd { };
 
   distcc = callPackage ../development/tools/misc/distcc { };


### PR DESCRIPTION
This PR adds d-feet. It required bumping of pygobject3, and enabling of introspection in both pygobject3 and libwnck3.

Patch for libwnck3 is needed to make it install gobject introspection data into $out, and not into ${gobjectIntrospection}.
