### PR TITLE
virt-manager: Fix 'ImportError: No module named libvirt' and add Spice support

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, pythonPackages, intltool, libxml2Python, curl,
-  python, makeWrapper, virtinst, pyGtkGlade, pythonDBus, gnome_python, gtkvnc, vte}:
+{ stdenv, fetchurl, pythonPackages, intltool, libxml2Python, curl, python
+, makeWrapper, virtinst, pyGtkGlade, pythonDBus, gnome_python, gtkvnc, vte
+, spiceSupport ? true, spice_gtk
+}:
 
 with stdenv.lib;
 
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
       # libxml2Python is a dependency of libvirt.py.
       libvirt libxml2Python urlgrabber virtinst pyGtkGlade pythonDBus gnome_python
       gtkvnc vte
-    ];
+    ] ++ optional spiceSupport spice_gtk;
 
   buildInputs =
     [ pythonPackages.python

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, intltool, libvirt, libxml2Python, curl,
+{ stdenv, fetchurl, pythonPackages, intltool, libxml2Python, curl,
   python, makeWrapper, virtinst, pyGtkGlade, pythonDBus, gnome_python, gtkvnc, vte}:
 
 with stdenv.lib;
@@ -18,13 +18,13 @@ stdenv.mkDerivation rec {
       paste_deploy m2crypto ipy boto_1_9 twisted sqlalchemy_migrate
       distutils_extra simplejson readline glance cheetah lockfile httplib2
       # !!! should libvirt be a build-time dependency?  Note that
-      # libxml2Python is a dependency of libvirt.py. 
+      # libxml2Python is a dependency of libvirt.py.
       libvirt libxml2Python urlgrabber virtinst pyGtkGlade pythonDBus gnome_python
       gtkvnc vte
     ];
 
   buildInputs =
-    [ pythonPackages.python 
+    [ pythonPackages.python
       pythonPackages.wrapPython
       pythonPackages.mox
       pythonPackages.urlgrabber
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     ] ++ pythonPath;
 
   buildPhase = "make";
-  
+
   nativeBuildInputs = [ makeWrapper pythonPackages.wrapPython ];
 
   # patch the runner script in order to make wrapPythonPrograms work and run the program using a syscall

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, pkgconfig, gtk, spice_protocol, intltool, celt_0_5_1
+, openssl, pulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
+, cyrus_sasl, python, pygtk, autoconf, automake, libtool }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "spice-gtk-0.22";
+
+  src = fetchurl {
+    url = "http://www.spice-space.org/download/gtk/${name}.tar.bz2";
+    sha256 = "0fpsn6qhy9a701lmd4yym6qz6zhpp8xp6vw42al0b4592pcybs85";
+  };
+
+  buildInputs = [
+    gtk spice_protocol celt_0_5_1 openssl pulseaudio pixman gobjectIntrospection
+    libjpeg_turbo zlib cyrus_sasl python pygtk
+  ];
+
+  nativeBuildInputs = [ pkgconfig intltool libtool autoconf automake ];
+
+  NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+
+  preConfigure = ''
+    substituteInPlace gtk/Makefile.am \
+      --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0'
+
+    autoreconf -v --force --install
+    intltoolize -f
+  '';
+
+  configureFlags = [
+    "--disable-maintainer-mode"
+    "--with-gtk=2.0"
+  ];
+
+  dontDisableStatic = true; # Needed by the coroutine test
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A GTK+2 and GTK+3 SPICE widget";
+    longDescription = ''
+      spice-gtk is a GTK+2 and GTK+3 SPICE widget. It features glib-based
+      objects for SPICE protocol parsing and a gtk widget for embedding
+      the SPICE display into other applications such as virt-manager.
+      Python bindings are available too.
+    '';
+
+    homepage = http://www.spice-space.org/;
+    license = licenses.lgpl21;
+
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5735,6 +5735,8 @@ let
     inherit (pythonPackages) pyparsing;
   };
 
+  spice_gtk = callPackage ../development/libraries/spice-gtk { };
+
   spice_protocol = callPackage ../development/libraries/spice-protocol { };
 
   sratom = callPackage ../development/libraries/audio/sratom { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8195,7 +8195,29 @@ pythonPackages = modules // import ./python-packages-generated.nix {
       description = "A logging replacement for Python";
       license = pkgs.lib.licenses.bsd3;
     };
- };
+  };
+
+  libvirt = pkgs.stdenv.mkDerivation rec {
+    name = "libvirt-python-${version}";
+    version = "1.2.0";
+
+    src = fetchurl {
+      url = "http://libvirt.org/sources/python/${name}.tar.gz";
+      sha256 = "0azml1yv9iqnpj4sdg1wwsa70q7kb06lv85p63qwyd8vrd0y7rrg";
+    };
+
+    buildInputs = [ python pkgs.pkgconfig pkgs.libvirt lxml ];
+
+    buildPhase = "python setup.py build";
+
+    installPhase = "python setup.py install --prefix=$out";
+
+    meta = {
+      homepage = http://www.libvirt.org/;
+      description = "libvirt Python bindings";
+      license = "LGPLv2";
+    };
+  };
 
 # python2.7 specific eggs
 } // pkgs.lib.optionalAttrs (python.majorVersion == "2.7") {


### PR DESCRIPTION
The error was due to libvirt 1.2.0 no longer including the python bindings; it is
a separate package now.

Also added a missing Spice widget for virt-manager, it allows graphical interaction with VMs much faster than VNC.
