### PR TITLE
nix-prefetch-git: Convert relative submodule URLS to absolute URLS

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -148,6 +148,12 @@ init_submodules(){
             git config -f .gitmodules --get-regexp submodule\.[^.]*\.path |
             sed -n "s,^\(.*\)\.path $dir\$,\\1,p")
         local url=$(git config -f .gitmodules --get ${name}.url);
+
+        # Get Absolute URL if we have a relative URL
+        if ! echo "$url" | grep '^[a-zA-Z]\+://' >/dev/null 2>&1; then
+          url="$(git config --get remote.origin.url)/$url"
+        fi
+
         clone "$dir" "$url" "$hash" "";
     done;
 }


### PR DESCRIPTION
nix-prefetch-git does not convert relative submodule urls into absolute
urls based on the parent's origin. This patch adds support for
repositories which are using the relative url syntax.
