### PR TITLE
installation-cd: add wget

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -22,6 +22,7 @@
     pkgs.sshfsFuse
     pkgs.socat
     pkgs.screen
+    pkgs.wget
 
     # Hardware-related tools.
     pkgs.sdparm


### PR DESCRIPTION
wget adds 420K of additional space usage on minimal cd in exchange for comfort: everyone expects it to be there. Fixes #1489
