### PR TITLE
fix tigervnc ctrl-* keys, eg ctrl-c ctrl-v ctrl-d by applying patch to fltk

### DIFF
--- a/pkgs/development/libraries/fltk/fltk13.nix
+++ b/pkgs/development/libraries/fltk/fltk13.nix
@@ -1,5 +1,8 @@
 { composableDerivation, fetchurl, pkgconfig, x11, inputproto, libXi
-, freeglut, mesa, libjpeg, zlib, libXinerama, libXft, libpng }:
+, freeglut, mesa, libjpeg, zlib, libXinerama, libXft, libpng
+
+, automake, autoconf, libtool
+}:
 
 let inherit (composableDerivation) edf; in
 
@@ -14,7 +17,13 @@ composableDerivation.composableDerivation {} {
 
   propagatedBuildInputs = [ x11 inputproto libXi freeglut ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  enableParallelBilding = true;
+
+  nativeBuildInputs = [ pkgconfig
+
+  # only required because of patch
+  automake autoconf libtool
+  ];
 
   flags =
     # this could be tidied up (?).. eg why does it require freeglut without glSupport?
@@ -46,4 +55,11 @@ composableDerivation.composableDerivation {} {
     description = "A C++ cross-platform light-weight GUI library binding";
     homepage = http://www.fltk.org;
   };
+
+  patches = [
+    # https://bugs.archlinux.org/task/36186
+    (fetchurl {
+    url = "https://bugs.archlinux.org/task/36186?getfile=10750";
+    sha256 = "1hpb1i87nc3zw6mgpgf3bfv557ci930bsn6rwlhaif51nlqd2wbj";
+  }) ];
 }

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -10,17 +10,24 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  # Release version = "1.3.0";
-  revision = 5129;
-  version = "r${toString revision}";
-  name = "tigervnc-${version}";
 
-  src = fetchsvn {
-    # Release url = "mirror://sourceforge/tigervnc/${version}/${name}.tar.gz";
-    url = "https://tigervnc.svn.sourceforge.net/svnroot/tigervnc/trunk";
-    rev = revision;
-    sha256 = "1qszlqr8z16iqkm05gbs0knj4fxc3bb6gjayky1abmf8pjazi0j8";
-  };
+  # REGION AUTO UPDATE: { name="tigervnc"; type="svn"; url="https://tigervnc.svn.sourceforge.net/svnroot/tigervnc/trunk"; }
+  src = (fetchurl { url = "http://mawercer.de/~nix/repos/tigervnc-svn-5154.tar.bz2"; sha256 = "7fdbeeadbe9e39035dd1a1d9d3d847c1c34d9a33961f3ef5c86e0d8f0a3ebf6b"; });
+  name = "tigervnc-svn-5154";
+  # END
+
+  enableParallelBilding = true;
+
+  # # Release version = "1.3.0";
+  # revision = 5129;
+  # version = "r${toString revision}";
+  # name = "tigervnc-${version}";
+  # src = fetchsvn {
+  #   # Release url = "mirror://sourceforge/tigervnc/${version}/${name}.tar.gz";
+  #   url = "https://tigervnc.svn.sourceforge.net/svnroot/tigervnc/trunk";
+  #   rev = revision;
+  #   sha256 = "1qszlqr8z16iqkm05gbs0knj4fxc3bb6gjayky1abmf8pjazi0j8";
+  # };
 
   inherit fontDirectories;
 


### PR DESCRIPTION
I'm unsure about
- is it ok to apply this patch globally, or should it be overridden for tigervnc only?
- how many rebuilds it triggers
- whether it was neccessary to update to latest dev version (seems to work)
  The bug report indicates that others distros just includes this patch (?)
