### PR TITLE
haskellPackages.scientific: Enable tests

### DIFF
--- a/pkgs/development/libraries/haskell/scientific/default.nix
+++ b/pkgs/development/libraries/haskell/scientific/default.nix
@@ -8,7 +8,6 @@ cabal.mkDerivation (self: {
   sha256 = "0xwxds884pqywjbc4j6qkx27nbi64sihig8ps9v884sk08021wrp";
   buildDepends = [ deepseq hashable text ];
   testDepends = [ smallcheck tasty tastySmallcheck text ];
-  doCheck = false;
   meta = {
     homepage = "https://github.com/basvandijk/scientific";
     description = "Arbitrary-precision floating-point numbers represented using scientific notation";


### PR DESCRIPTION
The latest version bumps test dependencies so we can run tests.
