### PR TITLE
Don't split paths with spaces

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -575,7 +575,7 @@ configurePhase() {
     fi
 
     if [ -z "$dontFixLibtool" ]; then
-        for i in $(find . -name "ltmain.sh"); do
+        find . -iname "ltmain.sh" | while read i; do
             echo "fixing libtool script $i"
             fixLibtool $i
         done
@@ -670,7 +670,7 @@ patchShebangs() {
     local oldInterpreterLine
     local newInterpreterLine
 
-    for f in $(find "$dir" -type f -perm +0100); do
+    find "$dir" -type f -perm +0100 | while read f; do
         if [ "$(head -1 "$f" | head -c +2)" != '#!' ]; then
             # missing shebang => not a script
             continue


### PR DESCRIPTION
setup.sh uses the anti-pattern `for f in $(find ...); do` in several
places. `find` returns one path per line, but `for` splits its arguments
by words, so paths which contain spaces are incorrectly split! The
correct way is `find ... | while read f; do`
