### PR TITLE
gcc build fix attempt

### DIFF
--- a/pkgs/development/compilers/gcc/4.7/build-race.patch
+++ b/pkgs/development/compilers/gcc/4.7/build-race.patch
@@ -1,0 +1,11 @@
+--- gcc-4.7.3/gcc/Makefile.in	2013-04-01 10:11:11.000000000 +0200
++++ gcc-4.7.3/gcc/Makefile.in.new	2014-01-14 00:55:31.056406483 +0100
+@@ -3904,7 +3904,7 @@
+   $(SYSTEM_H) coretypes.h $(GTM_H) errors.h $(READ_MD_H) gensupport.h
+ build/gengenrtl.o : gengenrtl.c $(BCONFIG_H) $(SYSTEM_H) rtl.def
+ gengtype-lex.o build/gengtype-lex.o : gengtype-lex.c gengtype.h $(SYSTEM_H)
+-gengtype-lex.o: $(CONFIG_H)
++gengtype-lex.o: $(CONFIG_H) $(BCONFIG_H)
+ build/gengtype-lex.o: $(BCONFIG_H)
+ gengtype-parse.o build/gengtype-parse.o : gengtype-parse.c gengtype.h \
+   $(SYSTEM_H)

--- a/pkgs/development/compilers/gcc/4.7/default.nix
+++ b/pkgs/development/compilers/gcc/4.7/default.nix
@@ -54,8 +54,9 @@ let version = "4.7.3";
     # Whether building a cross-compiler for GNU/Hurd.
     crossGNU = cross != null && cross.config == "i586-pc-gnu";
 
-    patches = []
-      ++ optional stdenv.isArm [ ./arm-eabi.patch ]
+    patches = [
+      ./build-race.patch
+    ] ++ optional stdenv.isArm [ ./arm-eabi.patch ]
       ++ optional (cross != null) ./libstdc++-target.patch
       # ++ optional noSysDirs ./no-sys-dirs.patch
       # The GNAT Makefiles did not pay attention to CFLAGS_FOR_TARGET for its


### PR DESCRIPTION
Specifically, I am trying to fix the following error seen on Hydra:

../../gcc-4.7.3/gcc/gengtype-lex.c:1:21: fatal error: bconfig.h: No such file or directory

The patch is taken from gcc's SVN revision 193691.
