### PR TITLE
add CERN's 'root' Application Framework

### DIFF
--- a/pkgs/applications/science/math/fricas/default.nix
+++ b/pkgs/applications/science/math/fricas/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, sbcl, libX11, libXpm, libICE, libSM, libXt, libXau, libXdmcp }:
+
+stdenv.mkDerivation rec {
+  name = "fricas-1.2.2";
+
+  src = fetchurl {
+    url    = "http://sourceforge.net/projects/fricas/files/fricas/1.2.2/${name}-full.tar.bz2";
+    sha256 = "87db64a1fd4211f3b776793acea931b4271d2e7a28396414c7d7397d833defe1";
+  };
+
+  buildInputs = [ sbcl libX11 libXpm libICE libSM libXt libXau libXdmcp ];
+
+  dontStrip = true;
+
+  meta = {
+    description = "Fricas CAS";
+    homepage    = http://fricas.sourceforge.net/;
+    maintainers = stdenv.lib.maintainers.sprock;
+    platforms   = stdenv.lib.platforms.linux;
+    license     = stdenv.lib.license.bsd3;
+  };
+}

--- a/pkgs/applications/science/physics/root/cmake.patch
+++ b/pkgs/applications/science/physics/root/cmake.patch
@@ -1,0 +1,11 @@
+--- cmake/modules/RootBuildOptions.cmake	1969-12-31 20:30:01.000000000 -0330
++++ cmake/modules/RootBuildOptions.cmake	2014-01-10 14:09:29.424937408 -0330
+@@ -149,7 +149,7 @@
+ 
+ #---General Build options----------------------------------------------------------------------
+ # use, i.e. don't skip the full RPATH for the build tree
+-set(CMAKE_SKIP_BUILD_RPATH  FALSE)
++set(CMAKE_SKIP_BUILD_RPATH  TRUE)
+ # when building, don't use the install RPATH already (but later on when installing)
+ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
+ # add the automatically determined parts of the RPATH

--- a/pkgs/applications/science/physics/root/default.nix
+++ b/pkgs/applications/science/physics/root/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, mesa, libX11, gfortran, libXpm, libXft, libXext, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "root_v5.34.14";
+
+  src = fetchurl {
+    url = "ftp://root.cern.ch/root/${name}.source.tar.gz";
+    sha256 = "d5347ba1b614eb083cf08050b784d66a93c125ed89938708da1adb33323dee2b";
+  };
+
+  buildInputs = [ cmake gfortran mesa libX11 libXpm libXft libXext zlib ];
+
+  # CMAKE_INSTALL_RPATH_USE_LINK_PATH is set to FALSE in
+  # <rootsrc>/cmake/modules/RootBuildOptions.cmake.
+  # This patch sets it to TRUE.
+  patches = [ ./cmake.patch ];
+  patchFlags = "-p0";
+
+  meta = {
+    description = "A data analysis framework";
+    #maintainers = [ stdenv.lib.maintainers.urkud ];
+    platforms = stdenv.lib.platforms.mesaPlatforms;
+  };
+}


### PR DESCRIPTION
default.nix: build CERN's 'root' Application Framework from source.
