### PR TITLE
Adds a service for haveged, the entropy daemon

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -201,6 +201,7 @@
   ./services/scheduling/fcron.nix
   ./services/search/elasticsearch.nix
   ./services/security/clamav.nix
+  ./services/security/haveged.nix
   ./services/security/fprot.nix
   ./services/security/frandom.nix
   ./services/security/tor.nix

--- a/nixos/modules/services/security/haveged.nix
+++ b/nixos/modules/services/security/haveged.nix
@@ -1,0 +1,63 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+
+  cfg = config.services.haveged;
+
+in
+
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.haveged = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable to haveged entropy daemon, which refills 
+          /dev/random when low.
+        '';
+      };
+      
+      refill_threshold = mkOption {
+        type = types.int;
+        default = 1024;
+        description = ''
+          The number of bits of available entropy beneath which
+          haveged should refill the entropy pool.
+        '';
+      };
+      
+    };
+    
+  };
+  
+  
+  ###### implementation
+  
+  config = mkIf cfg.enable {
+  
+    systemd.services.haveged =
+      { description = "Entropy Harvesting Daemon";
+        unitConfig.documentation = "man:haveged(8)";
+        wantedBy = [ "multi-user.target" ];
+        
+        path = [ pkgs.haveged ];
+        
+        serviceConfig = 
+          { Type = "forking";
+            ExecStart = "${pkgs.haveged}/sbin/haveged -w ${toString cfg.refill_threshold} -v 1";
+            PIDFile = "/run/haveged.pid";
+          };
+      };
+
+  };
+  
+}


### PR DESCRIPTION
Includes configuration option for the threshold beneath which to refill
the entropy pool - defaults to 1024 bits as this is the number used in
other distro's existing service files (that I looked at).
