### PR TITLE
Add support for the ossp-module in postgresql-9.3

### DIFF
--- a/pkgs/servers/sql/postgresql/9.3.x.nix
+++ b/pkgs/servers/sql/postgresql/9.3.x.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, zlib, readline }:
+
+let version = "9.3.2"; in
+
+stdenv.mkDerivation rec {
+  name = "postgresql-${version}";
+
+  src = fetchurl {
+    url = "mirror://postgresql/source/v${version}/${name}.tar.bz2";
+    sha256 = "700da51a71857e092f6af1c85fcd86b46d7d5cd2f2ba343cafb1f206c20232d7";
+  };
+
+  buildInputs = [ zlib readline ];
+
+  enableParallelBuilding = true;
+
+  makeFlags = [ "world" ];
+
+  patches = [ ./disable-resolve_symlinks.patch ];
+
+  installTargets = [ "install-world" ];
+
+  LC_ALL = "C";
+
+  passthru = {
+    inherit readline;
+    psqlSchema = "9.3";
+  };
+
+  meta = {
+    homepage = http://www.postgresql.org/;
+    description = "A powerful, open source object-relational database system";
+    license = "bsd";
+  };
+}

--- a/pkgs/servers/sql/postgresql/9.3.x.nix
+++ b/pkgs/servers/sql/postgresql/9.3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, libossp_uuid }:
 
 let version = "9.3.2"; in
 
@@ -10,11 +10,16 @@ stdenv.mkDerivation rec {
     sha256 = "700da51a71857e092f6af1c85fcd86b46d7d5cd2f2ba343cafb1f206c20232d7";
   };
 
-  buildInputs = [ zlib readline ];
+  buildInputs = [ zlib readline libossp_uuid ];
 
   enableParallelBuilding = true;
 
   makeFlags = [ "world" ];
+
+  configureFlags =
+    ''
+      --with-ossp-uuid
+    '';
 
   patches = [ ./disable-resolve_symlinks.patch ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6393,6 +6393,8 @@ let
 
   postgresql92 = callPackage ../servers/sql/postgresql/9.2.x.nix { };
 
+  postgresql93 = callPackage ../servers/sql/postgresql/9.3.x.nix { };
+
   postgresql_jdbc = callPackage ../servers/sql/postgresql/jdbc { };
 
   psqlodbc = callPackage ../servers/sql/postgresql/psqlodbc { };


### PR DESCRIPTION
Since older version of PostgreSQL also support the ossp-uuid module I can modify them as well if desired.
