### PR TITLE
ghc is buildable on darwin by hard-fixing darwin platform to 10.9.

### DIFF
--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     url = "http://haskell.org/ghc/dist/${version}/${name}-src.tar.bz2";
     sha256 = "1669m8k9q72rpd2mzs0bh2q6lcwqiwd1ax3vrard1dgn64yq4hxx";
   };
-
+  patches = [ ./fixMACOSXplatform763.patch ];
   buildInputs = [ ghc perl gmp ncurses ];
 
   enableParallelBuilding = true;
@@ -19,10 +19,14 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp}/include"
   '';
 
-  preConfigure = ''
+  preConfigure = if !stdenv.isDarwin then ''
     echo "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+  ''
+  else ''   
+    echo "${buildMK}" > mk/build.mk
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '';
 
   configureFlags = "--with-gcc=${stdenv.gcc}/bin/gcc";

--- a/pkgs/development/compilers/ghc/fixMACOSXplatform763.patch
+++ b/pkgs/development/compilers/ghc/fixMACOSXplatform763.patch
@@ -1,0 +1,16 @@
+diff -Naur a/configure b/configure
+--- a/configure	2013-04-19 00:47:00.000000000 +0200
++++ b/configure	2014-01-10 11:50:13.000000000 +0100
+@@ -4840,9 +4840,9 @@
+   fi
+ fi
+ 
+-
+-
+-
++MACOSX_DEPLOYMENT_VERSION=10.9
++FP_MACOSX_DEPLOYMENT_TARGET=10.9
++MACOSX_DEPLOYMENT_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_VERSION}.sdk
+ 
+ 
+ 

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/gmp/${name}.tar.bz2";
     sha256 = "0x8prpqi9amfcmi7r4zrza609ai9529pjaq0h4aw51i867064qck";
   };
-
+  patches = [ ./darwinPlatform432.patch ];
   nativeBuildInputs = [ m4 ];
 
   # Prevent the build system from using sub-architecture-specific
@@ -16,10 +16,17 @@ stdenv.mkDerivation rec {
   # This is not a problem for Apple machines, which are all alike.  In
   # addition, `configfsf.guess' would return `i386-apple-darwin10.2.0' on
   # `x86_64-darwin', leading to a 32-bit ABI build, which is undesirable.
+  patchPlatformBuild = if !stdenv.isDarwin then "$ac_cv_build" else ''"x86_64-apple-darwin13.0.0"'';
+  patchPlatformHost = if !stdenv.isDarwin then "$ac_cv_host" else ''"x86_64-apple-darwin13.0.0"'';
+
   preConfigure =
     if !stdenv.isDarwin
     then "ln -sf configfsf.guess config.guess"
-    else ''echo "Darwin host is `./config.guess`."'';
+    else ''
+      substituteInPlace configure --replace "/usr/bin/" ""
+      substituteInPlace configure --subst-var patchPlatformBuild --subst-var patchPlatformHost
+      echo "Darwin host is `./config.guess`."'';
+     
 
   configureFlags = if cxx then "--enable-cxx" else "--disable-cxx";
 

--- a/pkgs/development/libraries/gmp/darwinPlatform432.patch
+++ b/pkgs/development/libraries/gmp/darwinPlatform432.patch
@@ -1,0 +1,19 @@
+diff -rupN a/configure b/configure
+--- a/configure	2010-01-07 21:09:40.000000000 +0100
++++ b/configure	2014-01-09 22:19:37.000000000 +0100
+@@ -2140,6 +2140,7 @@ echo "$as_me: error: $SHELL $ac_aux_dir/
+ fi
+ { echo "$as_me:$LINENO: result: $ac_cv_build" >&5
+ echo "${ECHO_T}$ac_cv_build" >&6; }
++ac_cv_build = @patchPlatformBuild@
+ case $ac_cv_build in
+ *-*-*) ;;
+ *) { { echo "$as_me:$LINENO: error: invalid value of canonical build" >&5
+@@ -2177,6 +2178,7 @@ fi
+ fi
+ { echo "$as_me:$LINENO: result: $ac_cv_host" >&5
+ echo "${ECHO_T}$ac_cv_host" >&6; }
++ac_cv_host=@patchPlatformHost@
+ case $ac_cv_host in
+ *-*-*) ;;
+ *) { { echo "$as_me:$LINENO: error: invalid value of canonical host" >&5

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -60,6 +60,9 @@ pythonPackages = modules // import ./python-packages-generated.nix {
   ipython = import ../shells/ipython {
     inherit (pkgs) stdenv fetchurl sip pyqt4;
     inherit buildPythonPackage pythonPackages;
+    qtconsoleSupport = !pkgs.stdenv.isDarwin; # qt is not supported on darwin
+    pylabQtSupport = !pkgs.stdenv.isDarwin;
+    pylabSupport = !pkgs.stdenv.isDarwin; # cups is not supported on darwin
   };
 
   ipythonLight = lowPrio (import ../shells/ipython {


### PR DESCRIPTION
ghc was not buildable on Mac OS  X darwin system (#1157), but with this workaround that fixes darwin platform to 10.9 in configure in a brute force way, ghc can be now buildable and works. 

Squashed commit of the following:

commit d8eb6cb00c8f20af01e9bbdfff5927d0ec85a749
Author: Ian-Woo Kim ianwookim@gmail.com
Date:   Wed Jan 15 01:05:00 2014 +0100

```
remove xcodebuild back. working ghc without xcodebuild modification in stdenv
```

commit a22fa75e0683a150fb22b73137f73468d05de419
Author: Ian-Woo Kim ianwookim@gmail.com
Date:   Fri Jan 10 16:08:34 2014 +0100

```
ghc-7.6.3 buildable on MacOSX darwin system with hard-coded platform information
```

commit f5a72128df12568f9751d87059c578dfedddab7c
Author: Ian-Woo Kim ianwookim@gmail.com
Date:   Thu Jan 9 22:27:20 2014 +0100

```
gmp-4.3.2 is compilable with forced x86_64 architecture
```

commit 58f5dff22b7654a935b600b6b58d8065f938a18a
Author: Ian-Woo Kim ianwookim@gmail.com
Date:   Thu Jan 9 21:36:40 2014 +0100

```
add xcodebuild in native-darwin-cctools-wrapper
```
