### PR TITLE
Update siege to 3.0.5 and add meta information

### DIFF
--- a/pkgs/tools/networking/siege/default.nix
+++ b/pkgs/tools/networking/siege/default.nix
@@ -1,12 +1,18 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, lib }:
 let
-  version = "3.0.2";
+  version = "3.0.5";
   baseName = "siege";
 in stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
   src = fetchurl {
     url = "http://www.joedog.org/pub/siege/${name}.tar.gz";
-    sha256 = "0b86rvcrjxy6h9w32bhpcm1gwmn223mf9f30dfsnaw51w90kn716";
+    sha256 = "16faa6kappg23bdriyiy3ym94rmddpvw8cl8xgv5nxq2v17n4gi8";
+  };
+  meta = {
+    description = "HTTP load tester";
+    maintainers = with lib.maintainers; [ ocharles raskin ];
+    platforms = with lib.platforms; linux;
+    license = with lib.licenses; gpl2Plus;
   };
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 }


### PR DESCRIPTION
Sorry, I was a little quick on the previous pull request. I removed a bit too much from the file, so this adds the meta section back in. Additionally, 3.0.5 has been released since I wrote that commit - so I've also updated to 3.0.5.
