### PR TITLE
add hoodle (pen notetaking program written in haskell) to nixpkgs

### DIFF
--- a/pkgs/applications/graphics/hoodle/default.nix
+++ b/pkgs/applications/graphics/hoodle/default.nix
@@ -1,0 +1,18 @@
+{ cabal, cmdargs, configurator, dyre, hoodleCore, mtl }:
+
+cabal.mkDerivation (self: {
+  pname = "hoodle";
+  version = "0.2.2.1";
+  sha256 = "1qkyyzfmprhniwarnq6cdmv1r6605b3h2lsc1rlalxhq6jh5gamd";
+  isLibrary = false;
+  isExecutable = true; 
+  buildDepends = [ cmdargs configurator dyre hoodleCore mtl ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Pen notetaking program written in haskell";
+    license = self.stdenv.lib.licenses.gpl3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim];
+  };
+})

--- a/pkgs/development/libraries/haskell/TypeCompose/default.nix
+++ b/pkgs/development/libraries/haskell/TypeCompose/default.nix
@@ -1,0 +1,15 @@
+{ cabal }:
+
+cabal.mkDerivation (self: {
+  pname = "TypeCompose";
+  version = "0.9.9";
+  sha256 = "0i89r1yaglkcc1fdhn0m4hws5rqcpmkg32ddznch7a3rz1l9gqwg";
+  buildDepends = [ ];
+  meta = {
+    homepage = "https://github.com/conal/TypeCompose";
+    description = "Type composition classes & instances";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/coroutine-object/default.nix
+++ b/pkgs/development/libraries/haskell/coroutine-object/default.nix
@@ -1,0 +1,16 @@
+{ cabal, cereal, either, lens, mtl, safecopy, transformers, transformersFree, uuid }:
+
+cabal.mkDerivation (self: {
+  pname = "coroutine-object";
+  version = "0.2.0.0";
+  sha256 = "1jl5glnk4ildjrxyxscxd0v7xfqbd9vpv5gaxygsfsbfr1zizp3s";
+  buildDepends = [ cereal either either lens mtl safecopy transformers transformersFree uuid ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Object-oriented programming realization using coroutine";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/hoodle-builder/default.nix
+++ b/pkgs/development/libraries/haskell/hoodle-builder/default.nix
@@ -1,0 +1,16 @@
+{ cabal, blazeBuilder, doubleConversion, hoodleTypes, lens, strict}:
+
+cabal.mkDerivation (self: {
+  pname = "hoodle-builder";
+  version = "0.2.2";
+  sha256 = "0gagfpjihf6lafi90r883n9agaj1pw4gygaaxv4xxfsc270855bq";
+  buildDepends = [ blazeBuilder doubleConversion hoodleTypes lens strict ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "text builder for hoodle file format";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/hoodle-core/default.nix
+++ b/pkgs/development/libraries/haskell/hoodle-core/default.nix
@@ -1,0 +1,22 @@
+{ cabal, Diff, attoparsec, base64Bytestring, cairo, cereal, configurator, 
+  coroutineObject, dbus, dyre, errors, fsnotify, gd, gtk, hoodleBuilder, 
+  hoodleParser, hoodleRender, hoodleTypes, monadLoops, networkSimple,
+  pureMD5, stm, xournalParser }:
+
+cabal.mkDerivation (self: {
+  pname = "hoodle-core";
+  version = "0.13.0.0";
+  sha256 = "1krq7i7kvymjhj9kar2rpy4qkbak8p4n1ifswdnk9r1dw7fr8vdx";
+  buildDepends = [ Diff attoparsec base64Bytestring cairo cereal configurator 
+                   coroutineObject dbus dyre errors fsnotify gd gtk hoodleBuilder
+                   hoodleParser hoodleRender hoodleTypes monadLoops networkSimple
+                   pureMD5 stm xournalParser ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Core library for hoodle";
+    license = self.stdenv.lib.licenses.gpl3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim];
+  };
+})

--- a/pkgs/development/libraries/haskell/hoodle-parser/default.nix
+++ b/pkgs/development/libraries/haskell/hoodle-parser/default.nix
@@ -1,0 +1,16 @@
+{ cabal, attoparsec, either, hoodleTypes, lens, mtl, strict, text, transformers, xournalTypes }:
+
+cabal.mkDerivation (self: {
+  pname = "hoodle-parser";
+  version = "0.2.2";
+  sha256 = "1m0jf7820hkdq69866hwqd1cc6rv331jrar8ayr28692h09j02rm";
+  buildDepends = [ attoparsec either hoodleTypes lens mtl strict text transformers xournalTypes ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Hoodle file parser";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/hoodle-render/default.nix
+++ b/pkgs/development/libraries/haskell/hoodle-render/default.nix
@@ -1,0 +1,16 @@
+{ cabal, base64Bytestring, cairo, gd, hoodleTypes, lens, monadLoops, poppler, strict, svgcairo, uuid }:
+
+cabal.mkDerivation (self: {
+  pname = "hoodle-render";
+  version = "0.3.2";
+  sha256 = "1mmx27g1vqpndk26nz2hy7rckcgg68clvr5x31cqz9f8sifd8rsg";
+  buildDepends = [ base64Bytestring cairo gd hoodleTypes lens monadLoops poppler strict svgcairo uuid];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Hoodle file renderer";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/hoodle-types/default.nix
+++ b/pkgs/development/libraries/haskell/hoodle-types/default.nix
@@ -1,0 +1,17 @@
+{ cabal, cereal, lens, mtl, strict, uuid }:
+
+cabal.mkDerivation (self: {
+  pname = "hoodle-types";
+  version = "0.2.2";
+  sha256 = "0dw2ji676nq3idb7izzzfnxzhyngf84wkapc0la43g4w4hzv1zxz";
+  buildDepends = [ cereal lens mtl strict uuid ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Data types for programs for hoodle file format";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})
+

--- a/pkgs/development/libraries/haskell/transformers-free/default.nix
+++ b/pkgs/development/libraries/haskell/transformers-free/default.nix
@@ -1,0 +1,15 @@
+{ cabal, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "transformers-free";
+  version = "1.0.1";
+  sha256 = "0fbzkr7ifvqng8wqi3332vwvmx36f8z167angyskfdd0a5rik2z0";
+  buildDepends = [ transformers ];
+  meta = {
+    homepage = "https://github.com/Gabriel439/Haskell-Transformers-Free-Library";
+    description = "Free monad transformers";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/xournal-parser/default.nix
+++ b/pkgs/development/libraries/haskell/xournal-parser/default.nix
@@ -1,0 +1,16 @@
+{ cabal, attoparsec, attoparsecConduit, conduit, lens, mtl, strict, text, transformers, xmlConduit, xmlTypes, xournalTypes, zlibConduit }:
+
+cabal.mkDerivation (self: {
+  pname = "xournal-parser";
+  version = "0.5.0.2";
+  sha256 = "1s9z7s6mcsn4s2krrcb1x63ca1d0rpyzdhb147w9524qw7gvbjin";
+  buildDepends = [ attoparsec attoparsecConduit conduit lens mtl strict text transformers xmlConduit xmlTypes xournalTypes zlibConduit ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Xournal file parser";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/xournal-types/default.nix
+++ b/pkgs/development/libraries/haskell/xournal-types/default.nix
@@ -1,0 +1,16 @@
+{ cabal, TypeCompose, cereal, lens, strict }:
+
+cabal.mkDerivation (self: {
+  pname = "xournal-types";
+  version = "0.5.0.2";
+  sha256 = "1z1zxgwnd2bpgmiimil2jnz4xdcvvi59y2qdvqgy42b10db8rvkm";
+  buildDepends = [ TypeCompose cereal lens strict ];
+  #jailbreak = true;
+  meta = {
+    homepage = "http://ianwookim.org/hoodle";
+    description = "Data types for programs for xournal file format";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -800,6 +800,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   cookie = callPackage ../development/libraries/haskell/cookie {};
 
+  coroutineObject = callPackage ../development/libraries/haskell/coroutine-object {};
+
   cprngAes = callPackage ../development/libraries/haskell/cprng-aes {};
 
   criterion = callPackage ../development/libraries/haskell/criterion {};
@@ -1324,6 +1326,18 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
   hmatrix = callPackage ../development/libraries/haskell/hmatrix {};
 
   hoauth = callPackage ../development/libraries/haskell/hoauth {};
+
+  hoodle = callPackage ../applications/graphics/hoodle {};
+
+  hoodleBuilder = callPackage ../development/libraries/haskell/hoodle-builder {};
+
+  hoodleCore = callPackage ../development/libraries/haskell/hoodle-core {}; 
+
+  hoodleParser = callPackage ../development/libraries/haskell/hoodle-parser {}; 
+
+  hoodleRender = callPackage ../development/libraries/haskell/hoodle-render {}; 
+
+  hoodleTypes = callPackage ../development/libraries/haskell/hoodle-types {}; 
 
   hoogle = callPackage ../development/libraries/haskell/hoogle {};
 
@@ -2292,6 +2306,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   transformersCompat = callPackage ../development/libraries/haskell/transformers-compat {};
 
+  transformersFree = callPackage ../development/libraries/haskell/transformers-free {};
+
   traverseWithClass = callPackage ../development/libraries/haskell/traverse-with-class {};
 
   trifecta_1_1 = callPackage ../development/libraries/haskell/trifecta/1.1.nix {
@@ -2301,6 +2317,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
   trifecta = self.trifecta_1_2;
 
   tuple = callPackage ../development/libraries/haskell/tuple {};
+
+  TypeCompose = callPackage ../development/libraries/haskell/TypeCompose {};
 
   typeEq = callPackage ../development/libraries/haskell/type-eq {};
 
@@ -2480,6 +2498,10 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
   xmlhtml = callPackage ../development/libraries/haskell/xmlhtml {};
 
   xmlTypes = callPackage ../development/libraries/haskell/xml-types {};
+
+  xournalParser = callPackage ../development/libraries/haskell/xournal-parser {};
+
+  xournalTypes = callPackage ../development/libraries/haskell/xournal-types {};
 
   xtest = callPackage ../development/libraries/haskell/xtest {};
 


### PR DESCRIPTION
I made  a nix-expression of hoodle: pen notetaking program which is written in haskell.
The home page of hoodle is http://ianwookim.org/hoodle
It depends on several component libraries such as coroutine-object, hoodle-types, xournal-types, xournal-parser, hoodle-builder, hoodle-parser, hoodle-render and hoodle-core. I added all the necessary dependencies.  Current version is 0.2.2.1.
