### PR TITLE
fix keepassx under gcc 4.8

### DIFF
--- a/pkgs/applications/misc/keepassx/default.nix
+++ b/pkgs/applications/misc/keepassx/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     qmake PREFIX=$out 
   '';
 
+  patches = [ ./random.patch ];
+
   buildInputs = [ bzip2 qt4 libX11 xextproto libXtst ];
 
   meta = {

--- a/pkgs/applications/misc/keepassx/random.patch
+++ b/pkgs/applications/misc/keepassx/random.patch
@@ -1,0 +1,13 @@
+--- a/src/lib/random.cpp	2014-01-21 21:15:55.829312723 +0000
++++ b/src/lib/random.cpp	2014-01-21 21:16:36.752535839 +0000
+@@ -28,6 +28,10 @@
+ 	#include <wincrypt.h>
+ 	#include <QSysInfo>
+ #endif
++#ifndef Q_WS_WIN
++	#include <sys/types.h>
++	#include <unistd.h>
++#endif
+ 
+ #include <QCryptographicHash>
+ #include <QCursor>


### PR DESCRIPTION
It didn't build because it didn't find getpid, which was probably previously there due to some indirect header include.
