### PR TITLE
grsecurity: Fix build and update patches

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -78,25 +78,25 @@ rec {
   };
 
 
-  grsecurity_3_0_3_2_53 =
-    { name = "grsecurity-3.0-3.2.53";
+  grsecurity_3_0_3_2_54 =
+    { name = "grsecurity-3.0-3.2.54";
       patch = fetchurl {
-        url = https://grsecurity.net/stable/grsecurity-3.0-3.2.53-201312021727.patch;
-        sha256 = "1ifndcbpz552d0n2dgb38di8lhqd4x2msshdbdx33jlfdl7mk6x4";
+        url = https://grsecurity.net/stable/grsecurity-3.0-3.2.54-201401191012.patch;
+        sha256 = "10kfdk46fgd1awys8f8520w7kanc4m0ckn28xg36473fi76i6snx";
       };
       features.grsecurity = true;
-      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.53
+      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.54
       features.apparmor = true;
     };
 
-  grsecurity_3_0_3_12_2 =
-    { name = "grsecurity-3.0-3.12.2";
+  grsecurity_3_0_3_12_8 =
+    { name = "grsecurity-3.0-3.12.8";
       patch = fetchurl {
-        url = https://grsecurity.net/test/grsecurity-3.0-3.12.2-201312021733.patch;
-        sha256 = "0xcsq6778rk9afg3078d772iflz7p4ahvr6wdq5c4s3jyssam783";
+        url = https://grsecurity.net/test/grsecurity-3.0-3.12.8-201401191015.patch;
+        sha256 = "0dy7daar873jp0afkf48l8ij1ii8cgcc9z5pn50h1fvhc9ap1j4f";
       };
       features.grsecurity = true;
-      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.12.2
+      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.12.8
       features.apparmor = true;
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6557,11 +6557,6 @@ let
   };
 
   grsecurityOverrider = args: {
-    # Install gcc plugins. These are needed for compiling dependant packages.
-    postInstall = ''
-      ${args.postInstall or ""}
-      cp "tools/gcc/"*.so $out/lib/modules/$version/build/tools/gcc/
-    '';
     # Apparently as of gcc 4.6, gcc-plugin headers (which are needed by PaX plugins)
     # include libgmp headers, so we need these extra tweaks
     buildInputs = args.buildInputs ++ [ gmp ];
@@ -6577,10 +6572,12 @@ let
   # config options you need (e.g. by overriding extraConfig). See list of options here:
   # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
   linux_3_2_grsecurity = lowPrio (lib.overrideDerivation (linux_3_2.override (args: {
+    modDirVersion = "${linux_3_2.version}-grsec";
     kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_53 kernelPatches.grsec_path ];
   })) (args: grsecurityOverrider args));
 
   linux_3_12_grsecurity = lowPrio (lib.overrideDerivation (linux_3_12.override (args: {
+    modDirVersion = "${linux_3_12.version}-grsec";
     kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_12_2 kernelPatches.grsec_path ];
   })) (args: grsecurityOverrider args));
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6573,12 +6573,12 @@ let
   # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
   linux_3_2_grsecurity = lowPrio (lib.overrideDerivation (linux_3_2.override (args: {
     modDirVersion = "${linux_3_2.version}-grsec";
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_53 kernelPatches.grsec_path ];
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_54 kernelPatches.grsec_path ];
   })) (args: grsecurityOverrider args));
 
   linux_3_12_grsecurity = lowPrio (lib.overrideDerivation (linux_3_12.override (args: {
     modDirVersion = "${linux_3_12.version}-grsec";
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_12_2 kernelPatches.grsec_path ];
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_12_8 kernelPatches.grsec_path ];
   })) (args: grsecurityOverrider args));
 
   linux_3_2_apparmor = lowPrio (linux_3_2.override {


### PR DESCRIPTION
```
stable: 3.0-3.2.53-201312021727 -> 3.0-3.2.54-201401191012
test:   3.0-3.12.2-201312021733 -> 3.0-3.12.8-201401191015
```
