### PR TITLE
Don't set shells as default whenever enabled

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -53,6 +53,14 @@ in
         type = types.bool;
       };
 
+      default = mkOption {
+        default = true;
+        description = ''
+          Make Bash the default <option>users.defaultUserShell</option>.
+        '';
+        type = types.bool;
+      };
+
       shellAliases = mkOption {
         default = config.environment.shellAliases // { which = "type -P"; };
         description = ''
@@ -196,7 +204,7 @@ in
     # Configuration for readline in bash.
     environment.etc."inputrc".source = ./inputrc;
 
-    users.defaultUserShell = mkDefault "/run/current-system/sw/bin/bash";
+    users.defaultUserShell = mkIf cfg.default (mkDefault "/run/current-system/sw/bin/bash");
 
     environment.pathsToLink = optionals cfg.enableCompletion [
       "/etc/bash_completion.d"

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -35,6 +35,14 @@ in
         type = types.bool;
       };
 
+      default = mkOption {
+        default = false;
+        description = ''
+          Make Zsh the default <option>users.defaultUserShell</option>.
+        '';
+        type = types.bool;
+      };
+
       shellAliases = mkOption {
         default = config.environment.shellAliases;
         description = ''
@@ -167,7 +175,7 @@ in
 
     environment.systemPackages = [ pkgs.zsh ];
 
-    users.defaultUserShell = mkDefault "/run/current-system/sw/bin/zsh";
+    users.defaultUserShell = mkIf cfg.default (mkDefault "/run/current-system/sw/bin/zsh");
 
     environment.shells =
       [ "/run/current-system/sw/bin/zsh"


### PR DESCRIPTION
Because alternative shells like Zsh are almost non-functional unless
"enabled", it doesn't make sense to try setting them as default just
because they are enabled.

In other words, for Bash and Zsh, this decouples "enabled" (i.e., "usable")
from "default." 
