### PR TITLE
keepassx: add version 2.0alpha5

### DIFF
--- a/pkgs/applications/misc/keepassx/2.0alpha5.nix
+++ b/pkgs/applications/misc/keepassx/2.0alpha5.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, cmake, libgcrypt, qt4, xlibs, ... }:
+
+stdenv.mkDerivation {
+  name = "keepassx-2.0alpha5";
+  src = fetchurl {
+    url = "https://github.com/keepassx/keepassx/archive/2.0-alpha5.tar.gz";
+    sha256 = "1vxj306zhrr38mvsy3vpjlg6d0xwlcvsi3l69nhhwzkccsc4smfm";
+  };
+
+  buildInputs = [ cmake libgcrypt qt4 xlibs.libXtst ];
+
+  meta = {
+    description = "Qt password manager compatible with its Win32 and Pocket PC versions";
+    homepage = http://www.keepassx.org/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [qknight];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7708,6 +7708,7 @@ let
   evopedia = callPackage ../applications/misc/evopedia { };
 
   keepassx = callPackage ../applications/misc/keepassx { };
+  keepassx_2 = callPackage ../applications/misc/keepassx/2.0alpha5.nix { };
 
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;


### PR DESCRIPTION
I didn't replace the old keepassx attribute because this is still an alpha release, but it has important features (KeePass 2 database support) that the old version lacks.
