### PR TITLE
networkmanager: load modules required for PPTP

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -130,6 +130,8 @@ in {
       message = "You can not use networking.networkmanager with services.networking.wireless";
     }];
 
+    boot.kernelModules = [ "ppp_mppe" ]; # Needed for most (all?) PPTP VPN connections.
+
     environment.etc = [
       { source = ipUpScript;
         target = "NetworkManager/dispatcher.d/01nixos-ip-up";


### PR DESCRIPTION
Most PPTP VPN connections require the `ppp_mppe` module to be loaded. Without the module, the connection will fail producing no error message. It is much friendlier to users to load the module automatically when NetworkManager is enabled.
