### PR TITLE
HipHopVM update

### DIFF
--- a/pkgs/development/interpreters/hiphopvm/default.nix
+++ b/pkgs/development/interpreters/hiphopvm/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, fetchgit, cmake, boost, libunwind, mysql, libmemcached, pcre
 , libevent, gd, curl, libxml2, icu, flex, bison, openssl, zlib, php, re2c
-, expat, libcap, oniguruma, libdwarf, libmcrypt, inteltbb, gperftools
-, bzip2, openldap, readline, libelf, uwimap, binutils, cyrus_sasl, pam
+, expat, libcap, oniguruma, libdwarf, libmcrypt, inteltbb, gperftools, glog
+, bzip2, openldap, readline, libelf, uwimap, binutils, cyrus_sasl, pam, libpng
 }:
 assert stdenv.system == "x86_64-linux";
 let
   src = fetchgit {
     url = "git://github.com/facebook/hiphop-php.git";
-    rev = "73f1c0ebd9b313f6b3baecd8c8046e0b595b1157";
-    sha256 = "104133c6054bc9ab0288eaa0cea168b6699e537b3ea76ecdc38ee833d93dca09";
+    rev = "1e23dec9f0b1ce8aaa5833d0527a369c8e254ffd";
+    sha256 = "0fblwgq8c3hmamw0m5d1mn8qhyqf14v2zf62cgrkvmbiz6jlrbr6";
   };
 
   libxml2_280 = stdenv.lib.overrideDerivation libxml2 (args: rec { 
@@ -21,37 +21,35 @@ let
 
     patches = [];
   });
- 
-  curlFB = stdenv.lib.overrideDerivation curl (args: { patches = [ "${src}/src/third_party/libcurl-7.22.1.fb-changes.diff" ]; });
 
-  fbPatch = "${src}/src/third_party/libevent-1.4.14.fb-changes.diff";
+  fbPatch = "${src}/hphp/third_party/libevent-1.4.14.fb-changes.diff";
+
   libeventFB = stdenv.lib.overrideDerivation libevent (args: { patches = [fbPatch]; });
 in
 stdenv.mkDerivation {
-  name = "hiphop-php-73f1c0ebd9";
+  name = "hiphop-php-1e23dec9f0";
   inherit src;
   dontUseCmakeBuildDir = true;
   dontUseCmakeConfigure = true;
   USE_HHVM=1;
   preConfigure = ''
-    export HPHP_HOME=$PWD
     export HPHP_LIB=$PWD/bin
     export TBB_INSTALL_DIR=${inteltbb}
     export TBB_ARCH_PLATFORM="intel64/cc4.1.0_libc2.4_kernel2.6.16.21"
-    sed -i 's| DEPRECATED | DEPRECATED_ |' src/runtime/base/runtime_error.h
+    sed 's=/bin/bash=/${stdenv.shell}=g' -i hphp/util/generate-buildinfo.sh
   '';
   NIX_LDFLAGS = "-lpam -L${pam}/lib";
+  MYSQL_INCLUDE_DIR="${mysql}/include/mysql";
   MYSQL_DIR=mysql;
   buildInputs = [ 
-    cmake boost libunwind mysql libmemcached pcre libeventFB gd curlFB
+    cmake boost libunwind mysql libmemcached pcre libeventFB gd curl
     libxml2_280 icu flex bison openssl zlib php expat libcap oniguruma
     libdwarf libmcrypt inteltbb gperftools bzip2 openldap readline
-    libelf uwimap binutils cyrus_sasl pam
+    libelf uwimap binutils cyrus_sasl pam glog libpng
   ];
   installPhase = ''
     mkdir -p $out/bin
-    cp src/hhvm/hhvm $out/bin
-    cp bin/systemlib.php $out/bin
+    cp hphp/hhvm/hhvm $out/bin
   '';
   patches = [./tbb.patch];
 

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "glog-0.3.3";
+  
+  src = fetchurl {
+    url = "http://google-glog.googlecode.com/files/${name}.tar.gz";
+    sha1 = "ed40c26ecffc5ad47c618684415799ebaaa30d65";
+  };
+
+  meta = {
+    homepage = http://code.google.com/p/google-glog/;
+    license = "BSD";
+    description = "The glog library implements application-level logging.";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2670,6 +2670,7 @@ let
   hiphopvm = callPackage ../development/interpreters/hiphopvm {
     libevent = libevent14;
     boost = boost149;
+    stdenv = overrideGCC stdenv gcc48;
   };
 
   falcon = builderDefsPackage (import ../development/interpreters/falcon) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4193,6 +4193,8 @@ let
 
   glm = callPackage ../development/libraries/glm { };
 
+  glog = callPackage ../development/libraries/glog { };
+
   glpk = callPackage ../development/libraries/glpk { };
 
   glsurf = callPackage ../applications/science/math/glsurf {


### PR DESCRIPTION
The current version of hiphop vm is very old (late 2012). This just updates it to a later commit. It might have been nice to use one of the release tags instead but they where more difficult to get to compile.
