### PR TITLE
support -Q in nixos-rebuild

### DIFF
--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -40,7 +40,7 @@ while [ "$#" -gt 0 ]; do
         repair=1
         extraBuildFlags+=("$i")
         ;;
-      --show-trace|--no-build-hook|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair)
+      --show-trace|--no-build-hook|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair|--no-build-output|-Q)
         extraBuildFlags+=("$i")
         ;;
       --max-jobs|-j|--cores|-I)


### PR DESCRIPTION
Both nix-env and nix-build support it, so just pass it on. It is nice to be able to see _what_ is currently building.
