### PR TITLE
Fixing the bubmblebee support and logs.

### DIFF
--- a/pkgs/tools/X11/bumblebee/xopts.patch
+++ b/pkgs/tools/X11/bumblebee/xopts.patch
@@ -5,7 +5,7 @@
        "-nolisten", "tcp",
        "-noreset",
 +      "-xkbdir", getenv("XKB_DIR"),
-+      "-logfile", "/dev/null",
++      "-logfile", "/var/log/X.8.log",
        "-verbose", "3",
        "-isolateDevice", pci_id,
        "-modulepath",

--- a/pkgs/tools/X11/bumblebee/xorg.conf.nvidia
+++ b/pkgs/tools/X11/bumblebee/xorg.conf.nvidia
@@ -26,7 +26,7 @@ Section "Device"
     VendorName "NVIDIA Corporation"
     Option "NoLogo" "true"
     Option "UseEDID" "false"
-    Option "ConnectedMonitor" "CRT-0"
+    Option "UseDisplayDevice" "none"
 EndSection
 
 Section "Screen"


### PR DESCRIPTION
Optirun logs are now created at /var/log/X.8.log.
