### PR TITLE
readline 6.2 patch 5 and gawk readline dependency

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
 
   preConfigure = "autoreconf -fi";
 
-  configureFlags = stdenv.lib.optional stdenv.isSunOS "--disable-modular-tests";
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-compile-warnings" ++
+                   stdenv.lib.optional stdenv.isSunOS "--disable-modular-tests";
 
   CPPFLAGS = stdenv.lib.optionalString stdenv.isSunOS "-DBSD_COMP";
 

--- a/pkgs/development/libraries/readline/readline-6.2-patches.nix
+++ b/pkgs/development/libraries/readline/readline-6.2-patches.nix
@@ -5,4 +5,5 @@ patch: [
 (patch "002" "1m670g2xzib6r81315q9r24nh9brmxkpq07acch1fwxmih94jqqy")
 (patch "003" "0x13c9wir4r44v2vdg96y0ahn8kl3wcmb5y0xn15yvid6pzk28fb")
 (patch "004" "0xjlkxfssfsd6jwbqhfjs4hybcps0b9zgz8v86vbhnzag4j39g89")
+(patch "005" "1x61bjl3wgs1gwla9b3y1hh12m1j5qlbis22258mljjl9mg900pg")
 ]

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libsigsegv }:
+{ stdenv, fetchurl, libsigsegv, readline }:
 
 stdenv.mkDerivation rec {
   name = "gawk-4.1.0";
@@ -12,9 +12,10 @@ stdenv.mkDerivation rec {
 
   doCheck = !stdenv.isCygwin; # XXX: `test-dup2' segfaults on Cygwin 6.1
 
-  buildInputs = [ libsigsegv ];
+  buildInputs = [ libsigsegv readline ];
 
-  configureFlags = [ "--with-libsigsegv-prefix=${libsigsegv}" ];
+  configureFlags = [ "--with-libsigsegv-prefix=${libsigsegv}"
+                     "--with-readline=${readline}" ];
 
   meta = {
     homepage = http://www.gnu.org/software/gawk/;


### PR DESCRIPTION
- Updates readline 6.2 patch set for upstream patch 5.  This is needed for Mac OS X Maverics 10.9.1 (darwin 13).

```
$ uname -a
Darwin fogo.local 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64
$
```
- Adds readline dependency to gawk.  The gawk package configure step looks for readline but since readline was not explicitly found it will pull whatever version it can find from the environment.  On a Mac system (config above) the readline library is new, so the hydra binary version of gawk pulled results in:

```
$ gawk
dyld: Library not loaded: /usr/lib/libreadline.6.0.dylib
  Referenced from: /Users/kquick/.nix-profile/bin/gawk
  Reason: image not found
Trace/BPT trap: 5 (core dumped)
$
```
