### PR TITLE
Disable support for speechd in mumble .

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -17,11 +17,15 @@ stdenv.mkDerivation rec {
     patch -p1 < ${ ./mumble-jack-support.patch }
   '';
 
+  # The speechd is disabled because of the issues in speech dispatcher
+  # https://github.com/NixOS/nixpkgs/issues/1287
+
   configurePhase = ''
     qmake CONFIG+=no-g15 CONFIG+=no-update CONFIG+=no-server \
       CONFIG+=no-embed-qt-translations CONFIG+=packaged \
       CONFIG+=bundled-celt CONFIG+=no-bundled-opus \
-      CONFIG+=no-bundled-speex
+      CONFIG+=no-bundled-speex \
+      CONFIG+=no-speechd
   '' 
   + stdenv.lib.optionalString jackSupport ''
     CONFIG+=no-oss CONFIG+=no-alsa CONFIG+=jackaudio


### PR DESCRIPTION
Hi,

I am experiencing issues with mumble.
The problem is that when I start mumble the speech-dispatcher starts
speaking/playing that it can't load the modules. This makes mumble unusable
because I want to talk to people.

The problem is that mumble automagicaly loads the speech dispatcher. Which is
responsible for the text to speech if a user sends a text message. Disabling
text to speech in mumble does not help because speech dispatcher is
initialized before that.

The issue to the core problem is to fix speech dispatcher and build it with at
least one of the modules. See #1287
