### PR TITLE
Try to get virtualbox opengl support to work

### DIFF
--- a/nixos/modules/services/x11/mesa.nix
+++ b/nixos/modules/services/x11/mesa.nix
@@ -83,6 +83,8 @@ in {
           ''
         else if elem "ati_unfree" cfg.videoDrivers then
           "ln -sf ${kernelPackages.ati_drivers_x11} /run/opengl-driver"
+        else if elem "virtualbox" cfg.videoDrivers then
+          "ln -sf ${kernelPackages.virtualboxGuestAdditions} /run/opengl-driver"
         else
           ''
             ${optionalString cfg.driSupport "ln -sf ${pkgs.mesa_drivers} /run/opengl-driver"}

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation {
 
     for i in lib/VBoxOGL*.so
     do
-        patchelf --set-rpath $out/lib:${dbus}/lib $i
+        patchelf --set-rpath ${dbus}/lib:${libX11}/lib:${libXcomposite}/lib:${libXdamage}/lib:${libXfixes}/lib:${libXext}/lib:$out/lib $i
     done
 
     # Remove references to /usr from various scripts and files


### PR DESCRIPTION
I've tried to get opengl to work in virtualbox. 

To reproduce deploy a simple nixos machine with nixops and run (make sure you enable 3D acceleration in display settings first):

```
$ LIBGL_DEBUG=verbose glxinfo
Error: couldn't find RGB GLX visual or fbconfig
```
