### PR TITLE
Make `shellInit` option and friends follow documentation

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -78,16 +78,6 @@ in
       type = types.lines;
     };
 
-    environment.shellInit = mkOption {
-      default = "";
-      description = ''
-        Shell script code called during shell initialisation.
-        This code is asumed to be shell-independent, which means you should
-        stick to pure sh without sh word split.
-      '';
-      type = types.lines;
-    };
-
     environment.loginShellInit = mkOption {
       default = "";
       description = ''

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -62,14 +62,6 @@ in
         type = types.attrs; # types.attrsOf types.stringOrPath;
       };
 
-      shellInit = mkOption {
-        default = "";
-        description = ''
-          Shell script code called during bash shell initialisation.
-        '';
-        type = types.lines;
-      };
-
       loginShellInit = mkOption {
         default = "";
         description = ''
@@ -118,13 +110,11 @@ in
 
     programs.bash = {
 
-      shellInit = ''
+      loginShellInit = ''
         . ${config.system.build.setEnvironment}
 
-        ${cfge.shellInit}
+        ${cfge.loginShellInit}
       '';
-
-      loginShellInit = cfge.loginShellInit;
 
       interactiveShellInit = ''
         # Check the window size after every command.
@@ -154,7 +144,6 @@ in
         # Prevent this file from being sourced by interactive non-login child shells.
         export __ETC_PROFILE_DONE=1
 
-        ${cfg.shellInit}
         ${cfg.loginShellInit}
 
         # Read system-wide modifications.

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -20,7 +20,7 @@ in
         l  = "ls -alh";
       };
 
-    environment.shellInit =
+    environment.loginShellInit =
       ''
         # Set up the per-user profile.
         mkdir -m 0755 -p $NIX_USER_PROFILE_DIR

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -86,13 +86,11 @@ in
 
     programs.zsh = {
 
-      shellInit = ''
+      loginShellInit = ''
         . ${config.system.build.setEnvironment}
 
-        ${cfge.shellInit}
+        ${cfge.loginShellInit};
       '';
-
-      loginShellInit = cfge.loginShellInit;
 
       interactiveShellInit = ''
         ${cfge.interactiveShellInit}


### PR DESCRIPTION
# Synopsis

First, let me apologize for dropping this non-trivial, unsolicited pull request. This pull request tries to address the following problems:
1. `programs.bash.shellInit` is actually only read for login bash shells.
2. There are settings in `environment.shellInit` that should only be read for login shells. On bash, this is okay (see above), but on shells that actually support the `shellInit` option, you get a pristine login shell with every invocation, whether you want it or not.
3. The `environment.shellInit` option is not actually shell-agnostic for the above reasons.
# Proposed solution

As a solution, I propose the following four patches:

(935c181) Remove `programs.bash.shellInit` option:

> The `shellInit` is supposed to contain settings used to initialize all
> bash shells, but is actually only used for login shells. This is because
> bash does not have a global initialization file for all shells: for
> login shells `/etc/profile` is read and for interactive shells
> `/etc/bashrc` is read, but there is no global initialization file for
> non-interactive, non-login shells. The `shellInit` option should be
> removed for bash because it cannot do what it says.

(12d4fc8) Move login shell settings to `environment.loginShellInit`

> The `shellInit` option was being used for settings that are only
> appropriate for login shells.

(a96ee92) Set zsh environment for login shells only

> Environment variables should be set in `/etc/zprofile` where they will
> only be loaded for login shells. They were being set in `/etc/zshenv`;
> as a result, _every_ new zsh invocation was like a new login shell.
> After this change, environment variables are set in zsh as they are in
> bash (as they should be).

(8d07669) Remove `environment.shellInit` option

> The `environment.shellInit` option is supposed to contain initialization
> settings for all invocations of all shells. However, not all shells
> support global initialization settings for all types of invocation.
> Notably, bash does not support this option. Shell-agnostic settings
> should go in `environment.loginShellInit` or
> `environment.interactiveShellInit` instead.
## Pros
- All options now match their documentation.
- Options that cannot actually be implemented are removed.
- bash users (which I think are most NixOS users) without custom settings for `programs.bash.shellInit` or `environment.shellInit` see no change.
## Cons
- Anyone who uses `programs.bash.shellInit` or `environment.shellInit` will have to move their settings to `loginShellInit`. I'm not entirely sure this is a "con", because these users might not be aware of what their settings actually do!

Thanks for reading!
