### PR TITLE
pull module blacklist from Ubuntu and use it by default

### DIFF
--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -68,7 +68,10 @@ with pkgs.lib;
 
   config = mkIf (!config.boot.isContainer) {
 
-    environment.etc = singleton
+    environment.etc = [
+      { source = "${pkgs.kmod-blacklist-ubuntu}/modprobe.conf";
+        target = "modprobe.d/ubuntu.conf";
+      }
       { source = pkgs.writeText "modprobe.conf"
           ''
             ${flip concatMapStrings config.boot.blacklistedKernelModules (name: ''
@@ -77,25 +80,10 @@ with pkgs.lib;
             ${config.boot.extraModprobeConfig}
           '';
         target = "modprobe.d/nixos.conf";
-      };
+      }
+    ];
 
     environment.systemPackages = [ config.system.sbin.modprobe pkgs.kmod ];
-
-    boot.blacklistedKernelModules =
-      [ # This module is for debugging and generates gigantic amounts
-        # of log output, so it should never be loaded automatically.
-        "evbug"
-
-        # This module causes ALSA to occassionally select the wrong
-        # default sound device, and is little more than an annoyance
-        # on modern machines.
-        "snd_pcsp"
-
-        # The cirrusfb module prevents X11 from starting.  FIXME:
-        # Ubuntu blacklists all framebuffer devices because they're
-        # "buggy" and cause suspend problems.  Maybe we should too?
-        "cirrusfb"
-      ];
 
     system.activationScripts.modprobe =
       ''

--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchbzr }:
+{ stdenv, fetchurl }:
+let
+  version = "3ubuntu1"; # Saucy
+in
+stdenv.mkDerivation {
+  name = "kmod-blacklist-${version}";
 
-stdenv.mkDerivation rec {
-  name = "blacklist-ubuntu-${builtins.toString src.revision}"; # Saucy
-
-  src = fetchbzr {
-    url = meta.homepage;
-    sha256 = "0ci4b5dxzirc27zvgpr3s0pa78gjmfjwprmvyplxhwxb765la9v9";
-    revision = 13;
+  src = fetchurl {
+    url = "http://archive.ubuntu.com/ubuntu/pool/main/k/kmod/kmod_9-${version}.debian.tar.gz";
+    sha256 = "0h6h0zw2490iqj9xa2sz4309jyfmcc50jdvkhxa1nw90npxglp67";
   };
-
-  unpackPhase = "true";
 
   installPhase = ''
     mkdir "$out"
-    for f in "$src"/debian/modprobe.d/*.conf; do
+    for f in modprobe.d/*.conf; do
       echo "''\n''\n## file: "`basename "$f"`"''\n''\n" >> "$out"/modprobe.conf
       cat "$f" >> "$out"/modprobe.conf
     done
@@ -22,7 +21,7 @@ stdenv.mkDerivation rec {
   #TODO: iwlwifi.conf has some strange references
 
   meta = {
-    homepage = https://code.launchpad.net/~ubuntu-branches/ubuntu/saucy/kmod/saucy;
+    homepage = http://packages.ubuntu.com/source/saucy/kmod;
     description = "Linux kernel module blacklists from Ubuntu";
   };
 }

--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, gnugrep, findutils }:
 let
   version = "3ubuntu1"; # Saucy
 in
@@ -16,9 +16,14 @@ stdenv.mkDerivation {
       echo "''\n''\n## file: "`basename "$f"`"''\n''\n" >> "$out"/modprobe.conf
       cat "$f" >> "$out"/modprobe.conf
     done
-  '';
 
-  #TODO: iwlwifi.conf has some strange references
+    substituteInPlace "$out"/modprobe.conf \
+      --replace /sbin/lsmod /run/booted-system/sw/bin/lsmod \
+      --replace /sbin/rmmod /run/booted-system/sw/sbin/rmmod \
+      --replace /sbin/modprobe /run/booted-system/sw/sbin/modprobe \
+      --replace " grep " " ${gnugrep}/bin/grep " \
+      --replace " xargs " " ${findutils}/bin/xargs "
+  '';
 
   meta = {
     homepage = http://packages.ubuntu.com/source/saucy/kmod;

--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchbzr }:
+
+stdenv.mkDerivation rec {
+  name = "blacklist-ubuntu-${builtins.toString src.revision}"; # Saucy
+
+  src = fetchbzr {
+    url = meta.homepage;
+    sha256 = "0ci4b5dxzirc27zvgpr3s0pa78gjmfjwprmvyplxhwxb765la9v9";
+    revision = 13;
+  };
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir "$out"
+    for f in "$src"/debian/modprobe.d/*.conf; do
+      echo "''\n''\n## file: "`basename "$f"`"''\n''\n" >> "$out"/modprobe.conf
+      cat "$f" >> "$out"/modprobe.conf
+    done
+  '';
+
+  #TODO: iwlwifi.conf has some strange references
+
+  meta = {
+    homepage = https://code.launchpad.net/~ubuntu-branches/ubuntu/saucy/kmod/saucy;
+    description = "Linux kernel module blacklists from Ubuntu";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6835,6 +6835,8 @@ let
 
   kmod = callPackage ../os-specific/linux/kmod { };
 
+  kmod-blacklist-ubuntu = callPackage ../os-specific/linux/kmod-blacklist-ubuntu { };
+
   kvm = qemu_kvm;
 
   libcap = callPackage ../os-specific/linux/libcap { };


### PR DESCRIPTION
People often have serious problems due to bogus modules like *fb.

Please, review if you're interested. I'm currently using it, and the file seems to be OK and on the right place.
