### PR TITLE
Yubikey PBA

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -18,6 +18,7 @@
   bjornfor = "Bjørn Forsman <bjorn.forsman@gmail.com>";
   bluescreen303 = "Mathijs Kwik <mathijs@bluescreen303.nl>";
   bodil = "Bodil Stokke <nix@bodil.org>";
+  calrama = "Moritz Maxeiner <moritz@ucworks.org>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
   coroa = "Jonas Hörsch <jonas@chaoflow.net>";

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -148,21 +148,25 @@ let
         umount ${yubikey.storage.mountPoint}
     }
 
-    ykinfo -v
-    yubikey_missing="$(ykinfo -v 1>/dev/null 2>&1)$?"
-    if [ "$yubikey_missing" != "0" ]; then
+    yubikey_missing=true
+    ykinfo -v 1>/dev/null 2>&1
+    if [ $? != "0" ]; then
         echo -n "waiting 10 seconds for yubikey to appear..."
         for try in $(seq 10); do
             sleep 1
-            ykinfo -v
-            yubikey_missing="$(ykinfo -v 1>/dev/null 2>&1)$?"
-            if [ "$yubikey_missing" == "0" ]; then break; fi
+            ykinfo -v 1>/dev/null 2>&1
+            if [ $? == "0" ]; then
+                yubikey_missing=false
+                break
+            fi
             echo -n .
         done
         echo "ok"
+    else
+        yubikey_missing=false
     fi
 
-    if [ "$yubikey_missing" != "0" ]; then
+    if [ "$yubikey_missing" == true ]; then
         echo "no yubikey found, falling back to non-yubikey open procedure"
         open_normally
     else

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -53,7 +53,7 @@ let
     }
 
     drop() {
-        local c=$1
+        local c="$1"
         shift
         if [ -e "$1" ]; then
             cat "$1" | ( dd of=/dev/null bs="$c" count=1 2>/dev/null ; dd 2>/dev/null )
@@ -286,48 +286,57 @@ in
         yubikey = mkOption {
           default = null;
           type = types.nullOr types.optionSet;
-          description = "TODO";
+          description = ''
+            The options to use for this LUKS device in Yubikey-PBA.
+            If null (the default), Yubikey-PBA will be disabled for this device.
+          '';
 
           options = {
             twoFactor = mkOption {
-              default = false;
+              default = true;
               type = types.bool;
-              description = "TODO";
+              description = "Whether to use a passphrase and a Yubikey (true), or only a Yubikey (false)";
             };
 
             slot = mkOption {
               default = 2;
               type = types.int;
-              description = "TODO";
+              description = "Which slot on the Yubikey to challenge";
             };
 
             storage = mkOption {
               type = types.optionSet;
-              description = "TODO";
+              description = "Options related to the authentication record";
 
               options = {
                 device = mkOption {
                   default = /dev/sda1;
                   type = types.path;
-                  description = "TODO";
+                  description = ''
+                    An unencrypted device that will temporarily be mounted in stage-1.
+                    Must contain the authentication record for this LUKS device.
+                  '';
                 };
 
                 fsType = mkOption {
                   default = "vfat";
                   type = types.string;
-                  description = "TODO";
+                  description = "The filesystem of the unencrypted device";
                 };
 
                 mountPoint = mkOption {
                   default = "/crypt-storage";
                   type = types.string;
-                  description = "TODO";
+                  description = "Path where the unencrypted device will be mounted in stage-1";
                 };
 
                 path = mkOption {
                   default = "/crypt-storage/default";
                   type = types.string;
-                  description = "TODO";
+                  description = ''
+                    Absolute path of the authentication record on the unencrypted device with
+                    that device's root directory as "/".
+                  '';
                 };
               };
             };
@@ -340,7 +349,11 @@ in
     boot.initrd.luks.yubikeySupport = mkOption {
       default = false;
       type = types.bool;
-      description = "TODO";
+      description = ''
+            Enables support for authenticating with a Yubikey on LUKS devices.
+            See the NixOS wiki for information on how to properly setup a LUKS device
+            and a Yubikey to work with this feature.
+          '';
     };
   };
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -413,36 +413,23 @@ in
     # copy the cryptsetup binary and it's dependencies
     boot.initrd.extraUtilsCommands = ''
       cp -pdv ${pkgs.cryptsetup}/sbin/cryptsetup $out/bin
-      # XXX: do we have a function that does this?
-      for lib in $(ldd $out/bin/cryptsetup |grep '=>' |grep /nix/store/ |cut -d' ' -f3); do
-        cp -pdvn $lib $out/lib
-        cp -pvn $(readlink -f $lib) $out/lib
-      done
+
+      cp -pdv ${pkgs.libgcrypt}/lib/libgcrypt*.so.* $out/lib
+      cp -pdv ${pkgs.libgpgerror}/lib/libgpg-error*.so.* $out/lib
+      cp -pdv ${pkgs.cryptsetup}/lib/libcryptsetup*.so.* $out/lib
+      cp -pdv ${pkgs.popt}/lib/libpopt*.so.* $out/lib
 
       ${optionalString luks.yubikeySupport ''
       cp -pdv ${pkgs.utillinux}/bin/uuidgen $out/bin
-      for lib in $(ldd $out/bin/uuidgen |grep '=>' |grep /nix/store/ |cut -d' ' -f3); do
-        cp -pdvn $lib $out/lib
-        cp -pvn $(readlink -f $lib) $out/lib
-      done
-
       cp -pdv ${pkgs.ykpers}/bin/ykchalresp $out/bin
-      for lib in $(ldd $out/bin/ykchalresp |grep '=>' |grep /nix/store/ |cut -d' ' -f3); do
-        cp -pdvn $lib $out/lib
-        cp -pvn $(readlink -f $lib) $out/lib
-      done
-
       cp -pdv ${pkgs.ykpers}/bin/ykinfo $out/bin
-      for lib in $(ldd $out/bin/ykinfo |grep '=>' |grep /nix/store/ |cut -d' ' -f3); do
-        cp -pdvn $lib $out/lib
-        cp -pvn $(readlink -f $lib) $out/lib
-      done
-
       cp -pdv ${pkgs.openssl}/bin/openssl $out/bin
-      for lib in $(ldd $out/bin/openssl |grep '=>' |grep /nix/store/ |cut -d' ' -f3); do
-        cp -pdvn $lib $out/lib
-        cp -pvn $(readlink -f $lib) $out/lib
-      done
+
+      cp -pdv ${pkgs.libusb1}/lib/libusb*.so.* $out/lib
+      cp -pdv ${pkgs.ykpers}/lib/libykpers*.so.* $out/lib
+      cp -pdv ${pkgs.libyubikey}/lib/libyubikey*.so.* $out/lib
+      cp -pdv ${pkgs.openssl}/lib/libssl*.so.* $out/lib
+      cp -pdv ${pkgs.openssl}/lib/libcrypto*.so.* $out/lib
 
       mkdir -p $out/etc/ssl
       cp -pdv ${pkgs.openssl}/etc/ssl/openssl.cnf $out/etc/ssl

--- a/pkgs/applications/misc/ykpers/default.nix
+++ b/pkgs/applications/misc/ykpers/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec
   src = fetchurl
   {
     url = "http://opensource.yubico.com/yubikey-personalization/releases/${name}.tar.gz";
-	sha256 = "1n4s8kk31q5zh2rm7sj9qmv86yl8ibimdnpvk9ny391a88qlypyd";
+    sha256 = "1n4s8kk31q5zh2rm7sj9qmv86yl8ibimdnpvk9ny391a88qlypyd";
   };
 
   buildInputs = [pkgconfig libusb1 libyubikey];
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec
   meta =
   {
     homepage = "http://opensource.yubico.com/yubikey-personalization/";
-	description = "YubiKey Personalization cross-platform library and tool";
-	license = "bsd";
+    description = "YubiKey Personalization cross-platform library and tool";
+    license = "bsd";
+    maintainers = [ stdenv.lib.maintainers.calrama ];
   };
 }

--- a/pkgs/applications/misc/ykpers/default.nix
+++ b/pkgs/applications/misc/ykpers/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchurl, pkgconfig, libusb1, libyubikey}:
+
+stdenv.mkDerivation rec
+{
+  version = "1.15.0";
+  name = "ykpers-${version}";
+
+  src = fetchurl
+  {
+    url = "http://opensource.yubico.com/yubikey-personalization/releases/${name}.tar.gz";
+	sha256 = "1n4s8kk31q5zh2rm7sj9qmv86yl8ibimdnpvk9ny391a88qlypyd";
+  };
+
+  buildInputs = [pkgconfig libusb1 libyubikey];
+
+  meta =
+  {
+    homepage = "http://opensource.yubico.com/yubikey-personalization/";
+	description = "YubiKey Personalization cross-platform library and tool";
+	license = "bsd";
+  };
+}

--- a/pkgs/development/libraries/libyubikey/default.nix
+++ b/pkgs/development/libraries/libyubikey/default.nix
@@ -1,0 +1,20 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec
+{
+  version = "1.11";
+  name = "libyubikey-${version}";
+
+  src = fetchurl
+  {
+    url = "http://opensource.yubico.com/yubico-c/releases/${name}.tar.gz";
+	sha256 = "19pm4rqsnm9r0n5j26bqkxa1jpimdavzcvg5g7p416vkjhxc6lw9";
+  };
+
+  meta =
+  {
+    homepage = "http://opensource.yubico.com/yubico-c/";
+	description = "C library for manipulating Yubico YubiKey One-Time Passwords (OTPs)";
+	license = "bsd";
+  };
+}

--- a/pkgs/development/libraries/libyubikey/default.nix
+++ b/pkgs/development/libraries/libyubikey/default.nix
@@ -8,13 +8,14 @@ stdenv.mkDerivation rec
   src = fetchurl
   {
     url = "http://opensource.yubico.com/yubico-c/releases/${name}.tar.gz";
-	sha256 = "19pm4rqsnm9r0n5j26bqkxa1jpimdavzcvg5g7p416vkjhxc6lw9";
+    sha256 = "19pm4rqsnm9r0n5j26bqkxa1jpimdavzcvg5g7p416vkjhxc6lw9";
   };
 
   meta =
   {
     homepage = "http://opensource.yubico.com/yubico-c/";
-	description = "C library for manipulating Yubico YubiKey One-Time Passwords (OTPs)";
-	license = "bsd";
+    description = "C library for manipulating Yubico YubiKey One-Time Passwords (OTPs)";
+    license = "bsd";
+    maintainers = [ stdenv.lib.maintainers.calrama ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5036,6 +5036,8 @@ let
   libyamlcpp = callPackage ../development/libraries/libyaml-cpp { };
   libyamlcpp03 = callPackage ../development/libraries/libyaml-cpp/0.3.x.nix { };
 
+  libyubikey = callPackage ../development/libraries/libyubikey {};
+
   libzip = callPackage ../development/libraries/libzip { };
 
   libzrtpcpp = callPackage ../development/libraries/libzrtpcpp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9119,6 +9119,8 @@ let
 
   qgis = callPackage ../applications/misc/qgis {};
 
+  ykpers = callPackage ../applications/misc/ykpers {};
+
   yoshimi = callPackage ../applications/audio/yoshimi {
     fltk = fltk13;
   };


### PR DESCRIPTION
Implement pre-boot authentication with a Yubikey for NixOS.
Features both two-factor authentication and using the Yubikey by itself (the former is recommended and the default)
The necessary setup to use this feature is shown here: https://gist.github.com/Calrama/9ed4d59f295f2431b651#file-setup_luks_device_for_pba-sh (Simply change the DEVICE, STORAGE, SLOT, YUBIKEYS, and MULTIUSER variables to your requirements; to not use two-factor authentication, simply press enter when asked for your user passphrase).
