### PR TITLE
haskell-CouchDB: Disabled tests because a running CouchDB server is needed

### DIFF
--- a/pkgs/development/libraries/haskell/CouchDB/default.nix
+++ b/pkgs/development/libraries/haskell/CouchDB/default.nix
@@ -6,6 +6,10 @@ cabal.mkDerivation (self: {
   sha256 = "0a9g0iblfyqppcy1ni3ac8f3yv5km95bfblhwqlsk6khydi5ka98";
   buildDepends = [ HTTP json mtl network utf8String ];
   testDepends = [ HTTP HUnit json mtl network utf8String ];
+
+  # Disabled tests because a running CouchDB server is needed.
+  doCheck = false;
+
   meta = {
     homepage = "http://github.com/arjunguha/haskell-couchdb/";
     description = "CouchDB interface";


### PR DESCRIPTION
And because they currently don't compile. The latter should be fixed with PR arjunguha/haskell-couchdb#13.
