### PR TITLE
ncurses: add --enable-symlinks in configure flag

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (rec {
   patches = [ ./patch-ac ];
 
   configureFlags = ''
-    --with-shared --without-debug --enable-pc-files
+    --with-shared --without-debug --enable-pc-files --enable-symlinks
     ${if unicode then "--enable-widec" else ""}${if cxx then "" else "--without-cxx-binding"}
   '';
 

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   # libuuid, libblkid, uuidd and fsck are in util-linux-ng (the "libuuid" dependency).
-  configureFlags = "--enable-elf-shlibs --disable-libuuid --disable-libblkid --disable-uuidd --disable-fsck";
+  configureFlags = "--enable-elf-shlibs --disable-libuuid --disable-libblkid --disable-uuidd --disable-fsck --enable-symlink-install";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
If nix store is on AFS file system, ncurses build fails since terminfo generation tries to hardlink beyond file system boundary. By adding --enable-symlinks in configure flag, the build is successful.  

Reference discussion: 
http://lists.bestpractical.com/pipermail/shipwright/2010-June/000029.html
