### PR TITLE
oraclejdk7: add missing dependencies

### DIFF
--- a/pkgs/development/compilers/jdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/jdk/jdk7-linux.nix
@@ -126,6 +126,12 @@ stdenv.mkDerivation rec {
 
     find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
 
+    # HACK: For some reason, appending atk to the global patchelf rpath paths causes:
+    #   java: relocation error: java: symbol , version GLIBC_2.2.5 not defined in file libc.so.6 with link time reference
+    # Because only libglass.so needs atk, we put it only in it's rpath.
+    # This seems to work fine.
+    patchelf --set-rpath "$rpath:${atk}/lib" $out/jre/lib/${architecture}/libglass.so
+
     if test -z "$pluginSupport"; then
       rm -f $out/bin/javaws
       if test -n "$installjdk"; then
@@ -143,7 +149,7 @@ stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg_0_6 libxslt mesa_noglu xlibs.libXxf86vm] ++
+    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg_0_6 libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf] ++
     (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt xlibs.libXrender stdenv.gcc.gcc] else []);
 
   passthru.mozillaPlugin = if installjdk then "/jre/lib/${architecture}/plugins" else "/lib/${architecture}/plugins";

--- a/pkgs/development/compilers/jdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/jdk/jdk7-linux.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg_0_6 libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo atk gdk_pixbuf] ++
+    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg_0_6 libxslt mesa_noglu xlibs.libXxf86vm] ++
     (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt xlibs.libXrender stdenv.gcc.gcc] else []);
 
   passthru.mozillaPlugin = if installjdk then "/jre/lib/${architecture}/plugins" else "/lib/${architecture}/plugins";

--- a/pkgs/development/compilers/jdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/jdk/jdk7-linux.nix
@@ -6,6 +6,19 @@
 , installjdk ? true
 , pluginSupport ? true
 , installjce ? false
+, glib
+, libxml2
+, libav_0_8
+, ffmpeg_0_6
+, libxslt
+, mesa_noglu
+, freetype
+, fontconfig
+, gnome
+, cairo
+, alsaLib
+, atk
+, gdk_pixbuf
 }:
 
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
@@ -87,7 +100,7 @@ stdenv.mkDerivation rec {
     # construct the rpath
     rpath=
     for i in $libraries; do
-        rpath=$rpath''${rpath:+:}$i/lib
+        rpath=$rpath''${rpath:+:}$i/lib''${rpath:+:}$i/lib64
     done
 
     if test -z "$installjdk"; then
@@ -102,6 +115,8 @@ stdenv.mkDerivation rec {
     fi
 
     rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/jli
+    rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/server
+    rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/xawt
     rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}
 
     # set all the dynamic linkers
@@ -128,8 +143,8 @@ stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.gcc.libc] ++
-    (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt] else []);
+    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg_0_6 libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo atk gdk_pixbuf] ++
+    (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt xlibs.libXrender stdenv.gcc.gcc] else []);
 
   passthru.mozillaPlugin = if installjdk then "/jre/lib/${architecture}/plugins" else "/lib/${architecture}/plugins";
 


### PR DESCRIPTION
There were some dependencies missing from oraclejdk7. I'm not sure if these belong to the swingSupport section, they didn't look like they were a part of swing. Maybe just remove the swingSupport flag? 
