### PR TITLE
Add more configurable options to mumble

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -1,9 +1,18 @@
-{ stdenv, fetchurl, qt4, boost, speechd, protobuf, libsndfile,
- speex, libopus, avahi, pkgconfig,
-jackSupport ? false, 
-jackaudio ? null }:
+{ stdenv, fetchurl, qt4, boost, protobuf, libsndfile
+, speex, libopus, avahi, pkgconfig
+, jackSupport ? false
+, jackaudio ? null
+, speechdSupport ? false
+, speechd ? null
+}:
 
+assert jackSupport -> jackaudio != null;
+assert speechdSupport -> speechd != null;
 
+let
+  optional = stdenv.lib.optional;
+  optionalString = stdenv.lib.optionalString;
+in
 stdenv.mkDerivation rec {
   name = "mumble-" + version;
   version = "1.2.4";
@@ -13,35 +22,33 @@ stdenv.mkDerivation rec {
     sha256 = "16wwj6gwcnyjlnzh7wk0l255ldxmbwx0wi652sdp20lsv61q7kx1";
   };
 
-  patchPhase = ''
-    patch -p1 < ${ ./mumble-jack-support.patch }
-  '';
+  patches = optional jackSupport ./mumble-jack-support.patch;
 
   configurePhase = ''
     qmake CONFIG+=no-g15 CONFIG+=no-update CONFIG+=no-server \
       CONFIG+=no-embed-qt-translations CONFIG+=packaged \
       CONFIG+=bundled-celt CONFIG+=no-bundled-opus \
+      ${optionalString (!speechdSupport) "CONFIG+=no-speechd"} \
+      ${optionalString jackSupport "CONFIG+=no-oss CONFIG+=no-alsa CONFIG+=jackaudio"} \
       CONFIG+=no-bundled-speex
-  '' 
-  + stdenv.lib.optionalString jackSupport ''
-    CONFIG+=no-oss CONFIG+=no-alsa CONFIG+=jackaudio
   '';
 
 
-  buildInputs = [ qt4 boost speechd protobuf libsndfile speex
+  buildInputs = [ qt4 boost protobuf libsndfile speex
     libopus avahi pkgconfig ]
-    ++ (stdenv.lib.optional jackSupport jackaudio);
+    ++ (optional jackSupport jackaudio)
+    ++ (optional speechdSupport speechd);
 
   installPhase = ''
     mkdir -p $out
     cp -r ./release $out/bin
   '';
 
-  meta = { 
-    homepage = http://mumble.sourceforge.net/;
+  meta = with stdenv.lib; { 
+    homepage = "http://mumble.sourceforge.net/";
     description = "Low-latency, high quality voice chat software";
-    license = "BSD";
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ viric ];
   };
 }

--- a/pkgs/applications/networking/mumble/murmur.nix
+++ b/pkgs/applications/networking/mumble/murmur.nix
@@ -1,5 +1,15 @@
-{ stdenv, fetchurl, qt4, boost, protobuf, avahi, libcap, pkgconfig }:
+{ stdenv, fetchurl, qt4, boost, protobuf
+, avahi, libcap, pkgconfig
+, iceSupport ? false
+, zeroc_ice ? null
+}:
 
+assert iceSupport -> zeroc_ice != null;
+
+let
+  optional = stdenv.lib.optional;
+  optionalString = stdenv.lib.optionalString;
+in
 stdenv.mkDerivation rec {
   name = "murmur-" + version;
   version = "1.2.4";
@@ -9,22 +19,28 @@ stdenv.mkDerivation rec {
     sha256 = "16wwj6gwcnyjlnzh7wk0l255ldxmbwx0wi652sdp20lsv61q7kx1";
   };
 
-  configurePhase = ''
-    qmake CONFIG+=no-client CONFIG+=no-ice CONFIG+=no-embed-qt
+  patchPhase = optional iceSupport ''
+    sed -i 's,/usr/share/Ice/,${zeroc_ice}/,g' src/murmur/murmur.pro
   '';
 
-  buildInputs = [ qt4 boost protobuf avahi libcap pkgconfig ];
+  configurePhase = ''
+    qmake CONFIG+=no-client CONFIG+=no-embed-qt \
+    ${optionalString (!iceSupport) "CONFIG+=no-ice"}
+  '';
+
+  buildInputs = [ qt4 boost protobuf avahi libcap pkgconfig ]
+    ++ optional iceSupport [ zeroc_ice ];
 
   installPhase = ''
     mkdir -p $out
     cp -r ./release $out/bin
   '';
 
-  meta = { 
-    homepage = http://mumble.sourceforge.net/;
+  meta = with stdenv.lib; {
+    homepage = "http://mumble.sourceforge.net/";
     description = "Low-latency, high quality voice chat software";
-    license = "BSD";
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ viric ];
   };
 }

--- a/pkgs/development/compilers/mcpp/default.nix
+++ b/pkgs/development/compilers/mcpp/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, mcpp }:
+
+stdenv.mkDerivation rec {
+  name = "mcpp-2.7.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mcpp/${name}.tar.gz";
+    sha256 = "0r48rfghjm90pkdyr4khxg783g9v98rdx2n69xn8f6c5i0hl96rv";
+  };
+
+  configureFlags = [ "--enable-mcpplib" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://mcpp.sourceforge.net/";
+    description = "A portable c preprocessor";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/db/db-5.3.nix
+++ b/pkgs/development/libraries/db/db-5.3.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl
+, cxxSupport ? true
+}:
+
+stdenv.mkDerivation rec {
+  name = "db-5.3.28";
+
+  src = fetchurl {
+    url = "http://download.oracle.com/berkeley-db/${name}.tar.gz";
+    sha256 = "0a1n5hbl7027fbz5lm0vp0zzfp1hmxnz14wx3zl9563h83br5ag0";
+  };
+
+  configureFlags = [
+    (if cxxSupport then "--enable-cxx" else "--disable-cxx")
+  ];
+
+  preConfigure = ''
+    cd build_unix
+    configureScript=../dist/configure
+  '';
+
+  postInstall = ''
+    rm -rf $out/docs
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/index.html";
+    description = "Berkeley DB";
+    license = "Berkeley Database License";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, mcpp, bzip2, expat, openssl, db5 }:
+
+stdenv.mkDerivation rec {
+  name = "zeroc-ice-3.5.1";
+
+  src = fetchurl {
+    url = "http://www.zeroc.com/download/Ice/3.5/Ice-3.5.1.tar.gz";
+    sha256 = "14pk794p0fq3hcp50xmqnf9pp15dggiqhcnsav8xpnka9hcm37lq";
+  };
+
+  buildInputs = [ mcpp bzip2 expat openssl db5 ];
+
+  buildPhase = ''
+    cd cpp
+    make OPTIMIZE=yes
+  '';
+
+  installPhase = ''
+    make prefix=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.zeroc.com/ice.html";
+    description = "The internet communications engine";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3940,6 +3940,10 @@ let
 
   db48 = callPackage ../development/libraries/db4/db4-4.8.nix { };
 
+  db5 = db53;
+
+  db53 = callPackage ../development/libraries/db/db-5.3.nix { };
+
   dbus = callPackage ../development/libraries/dbus { };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
   dbus_glib       = callPackage ../development/libraries/dbus-glib { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8371,6 +8371,7 @@ let
       withLibdnssdCompat = true;
     };
     jackSupport = config.mumble.jackSupport or false;
+    speechdSupport = config.mumble.speechdSupport or false;
   };
 
   murmur = callPackage ../applications/networking/mumble/murmur.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8247,6 +8247,8 @@ let
 
   matchbox = callPackage ../applications/window-managers/matchbox { };
 
+  mcpp = callPackage ../development/compilers/mcpp { };
+
   mda_lv2 = callPackage ../applications/audio/mda-lv2 { };
 
   meld = callPackage ../applications/version-management/meld {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9136,6 +9136,8 @@ let
 
   zathura = zathuraCollection.zathuraWrapper;
 
+  zeroc_ice = callPackage ../development/libraries/zeroc-ice { };
+
   girara = callPackage ../applications/misc/girara {
     gtk = gtk3;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8384,6 +8384,7 @@ let
     avahi = avahi.override {
       withLibdnssdCompat = true;
     };
+    iceSupport = config.murmur.iceSupport or true;
   };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };


### PR DESCRIPTION
This set of patches adds more configurable options to mumble and murmur. Speechd is now optional and disabled by default as per #1606 and #1287. ICE is now available and built by default for murmur. Some other miscellaneous changes are made as well.
