### PR TITLE
openssh: Upgrade from 6.4p1 -> 6.5p1

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -13,15 +13,16 @@ let
     url = mirror://sourceforge/hpnssh/openssh-6.3p1-hpnssh14v2.diff.gz;
     sha256 = "1jldqjwry9qpxxzb3mikfmmmv90mfb7xkmcfdbvwqac6nl3r7bi3";
   };
+  optionalString = stdenv.lib.optionalString;
 
 in
 
 stdenv.mkDerivation rec {
-  name = "openssh-6.4p1";
+  name = "openssh-6.5p1";
 
   src = fetchurl {
     url = "ftp://ftp.nl.uu.net/pub/OpenBSD/OpenSSH/portable/${name}.tar.gz";
-    sha256 = "1lkmi7v83qvpcc04qrrqk4k7mafnmwxkfk1ccsisw51va4bgcc2m";
+    sha256 = "09wh7mi65aahyxd2xvq1makckhd5laid8c0pb8njaidrbpamw6d1";
   };
 
   prePatch = stdenv.lib.optionalString hpnSupport
@@ -32,9 +33,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./locale_archive.patch ];
 
-  buildInputs = [ zlib openssl libedit pkgconfig pam ] ++
-    (if withKerberos then [ kerberos ] else [])
-  ;
+  buildInputs = [ zlib openssl libedit pkgconfig pam ]
+    ++ stdenv.lib.optional withKerberos [ kerberos ];
 
   # I set --disable-strip because later we strip anyway. And it fails to strip
   # properly when cross building.
@@ -44,8 +44,8 @@ stdenv.mkDerivation rec {
       --with-libedit=yes
       --disable-strip
       ${if pam != null then "--with-pam" else "--without-pam"}
-      ${if etcDir != null then "--sysconfdir=${etcDir}" else ""}
-      ${if withKerberos  then "--with-kerberos5=${kerberos}" else ""}
+      ${optionalString (etcDir != null) "--sysconfdir=${etcDir}"}
+      ${optionalString withKerberos "--with-kerberos5=${kerberos}"}
     '';
 
   preConfigure =
@@ -67,11 +67,11 @@ stdenv.mkDerivation rec {
 
   installTargets = "install-nosysconf";
 
-  meta = {
-    homepage = http://www.openssh.org/;
+  meta = with stdenv.lib; {
+    homepage = "http://www.openssh.org/";
     description = "An implementation of the SSH protocol";
     license = "bsd";
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = stdenv.lib.maintainers.eelco;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ eelco ];
   };
 }


### PR DESCRIPTION
We are still waiting on the hpn patch so openssh_hpn fails to build at this time.
