### PR TITLE
Ocaml oasis

### DIFF
--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,32 +1,18 @@
 {stdenv, fetchurl, ocaml, findlib, camomile, ounit}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
 stdenv.mkDerivation {
-  name = "ocaml-batteries-1.4.1";
+  name = "ocaml-batteries-2.2.0";
 
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/684/batteries-1.4.1.tar.gz;
-    sha256 = "bdca7deba290d83c66c0a5001da52b2d7f2af58b7b7e7d9303d4363aaafe9c30";
+    url = http://forge.ocamlcore.org/frs/download.php/1363/batteries-2.2.tar.gz;
+    sha256 = "0z4wg357fzz7cnarjsrrdnpmxw8mxcj10fp67dm3bnn0l3zkjwbs";
   };
 
   buildInputs = [ocaml findlib camomile ounit];
 
-  patchPhase = ''
-    substituteInPlace Makefile --replace '/bin/echo -n' echo
-  '';
-
   configurePhase = "true"; 	# Skip configure
 
-  preInstall = ''
-    mkdir -p "$out/lib/ocaml/${ocaml_version}/site-lib"
-  '';
-
-  doCheck = true;
-
-  checkTarget = "test";
+  createFindlibDestdir = true;
 
   meta = {
     homepage = http://batteries.forge.ocamlcore.org/;
@@ -36,7 +22,7 @@ stdenv.mkDerivation {
       and comprehensive development platform for the OCaml programming
       language.
     '';
-    license = "LGPL";
+    license = stdenv.lib.licenses.lgpl21;
     platforms = ocaml.meta.platforms;
     maintainers = [
       stdenv.lib.maintainers.z77z

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -1,0 +1,28 @@
+{stdenv, fetchurl, ocaml, findlib, ocaml_typeconv, ounit}:
+
+stdenv.mkDerivation {
+  name = "ocaml-data-notation-0.0.11";
+
+  src = fetchurl {
+    url = https://forge.ocamlcore.org/frs/download.php/1310/ocaml-data-notation-0.0.11.tar.gz;
+    sha256 = "09a8zdyifpc2nl4hdvg9206142y31cq95ajgij011s1qcg3z93lj";
+  };
+
+  buildInputs = [ocaml findlib ocaml_typeconv ounit];
+
+  createFindlibDestdir = true;
+
+  configurePhase = "ocaml setup.ml -configure";
+  buildPhase     = "ocaml setup.ml -build";
+  installPhase   = "ocaml setup.ml -install";
+
+  meta = {
+    description = "Store data using OCaml notation";
+    homepage = https://forge.ocamlcore.org/projects/odn/;
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = ocaml.meta.platforms;
+    maintainers = with stdenv.lib.maintainers; [
+      z77z
+    ];
+  };
+}

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -1,34 +1,25 @@
-{stdenv, fetchurl, ocaml}:
-
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.9.2";
-in
+{stdenv, fetchurl, ocaml, findlib, ocaml_oasis}:
 
 stdenv.mkDerivation {
-  name = "ocaml-react-${version}";
+  name = "ocaml-react-0.9.4";
 
   src = fetchurl {
-    url = "http://erratique.ch/software/react/releases/react-${version}.tbz";
-    sha256 = "0fiaxzfxv8pc82d31jz85zryz06k84is0l3sn5g0di5mpc5falxr";
+    url = http://github.com/dbuenzli/react/archive/v0.9.4.tar.gz;
+    sha256 = "16k0kx93kd45s7pigkzvirfsbr22xhby0y88y86p473qxzc6ngrm";
   };
 
-  buildInputs = [ocaml];
+  buildInputs = [ocaml findlib ocaml_oasis];
 
-  buildCommand = ''
-    export INSTALLDIR=$out/lib/ocaml/${ocaml_version}/site-lib/react
-    tar xjf $src
-    cd react-*
-    substituteInPlace src/META --replace '+react' $INSTALLDIR
-    chmod +x build
-    ./build 
-    ./build install
-  '';
+  createFindlibDestdir = true;
+
+  configurePhase = "oasis setup && ocaml setup.ml -configure --prefix $out";
+  buildPhase     = "ocaml setup.ml -build";
+  installPhase   = "ocaml setup.ml -install";
 
   meta = {
     homepage = http://erratique.ch/software/react;
     description = "Applicative events and signals for OCaml";
-    license = "BSD";
+    license = stdenv.lib.licenses.bsd3;
     platforms = ocaml.meta.platforms;
     maintainers = [
       stdenv.lib.maintainers.z77z

--- a/pkgs/development/ocaml-modules/typeconv/3.0.5.nix
+++ b/pkgs/development/ocaml-modules/typeconv/3.0.5.nix
@@ -1,11 +1,13 @@
 {stdenv, fetchurl, ocaml, findlib}:
 
+# note: works only with ocaml >3.12
+
 stdenv.mkDerivation {
-  name = "ocaml-typeconv-109.60.01";
+  name = "ocaml-typeconv-3.0.5";
 
   src = fetchurl {
-    url = https://github.com/janestreet/type_conv/archive/109.60.01.tar.gz;
-    sha256 = "0lpxri68glgq1z2pp02rp45cb909xywbff8d4idljrf6fzzil2zx";
+    url = "http://forge.ocamlcore.org/frs/download.php/821/type_conv-3.0.5.tar.gz";
+    sha256 = "90ac6c401a600a23012a3f513def6f67d4979b11bd551f4d0af78f0f0b479198";
   };
 
   buildInputs = [ocaml findlib ]; 
@@ -15,8 +17,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://forge.ocamlcore.org/projects/type-conv/";
     description = "Support library for OCaml preprocessor type conversions";
-    license = stdenv.lib.licenses.lgpl21;
+    license = "LGPL";
     platforms = ocaml.meta.platforms;
-    maintainers = with stdenv.lib.maintainers; [ z77z ];
   };
 }

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -1,0 +1,32 @@
+{stdenv, fetchurl, ocaml, findlib, ocaml_data_notation, ocaml_typeconv,
+ ocamlmod, ocamlify, ounit, expect}:
+
+stdenv.mkDerivation {
+  name = "ocaml-oasis-0.4.1";
+
+  src = fetchurl {
+    url = http://forge.ocamlcore.org/frs/download.php/1355/oasis-0.4.1.tar.gz;
+    sha256 = "1lsnw9f1jh6106kphxg40qp0sia6cbkbb9ahs5y6ifnfkmllkjhj";
+  };
+
+  createFindlibDestdir = true;
+
+  buildInputs =
+    [
+      ocaml findlib ocaml_data_notation ocaml_typeconv ocamlmod ocamlify ounit
+    ];
+
+  configurePhase = "ocaml setup.ml -configure --prefix $out";
+  buildPhase     = "ocaml setup.ml -build";
+  installPhase   = "ocaml setup.ml -install";
+
+  meta = {
+    homepage = http://oasis.forge.ocamlcore.org/;
+    description = "Configure, build and install system for OCaml projects";
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = ocaml.meta.platforms;
+    maintainers = with stdenv.lib.maintainers; [
+      z77z
+    ];
+  };
+}

--- a/pkgs/development/tools/ocaml/ocamlify/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlify/default.nix
@@ -1,0 +1,26 @@
+{stdenv, fetchurl, ocaml, findlib, ounit}:
+
+stdenv.mkDerivation {
+  name = "ocamlify-0.0.2";
+
+  src = fetchurl {
+    url = http://forge.ocamlcore.org/frs/download.php/1209/ocamlify-0.0.2.tar.gz;
+    sha256 = "1f0fghvlbfryf5h3j4as7vcqrgfjb4c8abl5y0y5h069vs4kp5ii";
+  };
+
+  buildInputs = [ocaml findlib ounit];
+
+  configurePhase = "ocaml setup.ml -configure --prefix $out";
+  buildPhase     = "ocaml setup.ml -build";
+  installPhase   = "ocaml setup.ml -install";
+
+  meta = {
+    homepage = http://forge.ocamlcore.org/projects/ocamlmod/ocamlmod;
+    description = "Generate OCaml modules from source files";
+    platforms = ocaml.meta.platforms;
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [
+      z77z
+    ];
+  };
+}

--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -1,0 +1,25 @@
+{stdenv, fetchurl, ocaml, findlib, ounit}:
+
+stdenv.mkDerivation {
+  name = "ocamlmod-0.0.7";
+
+  src = fetchurl {
+    url = http://forge.ocamlcore.org/frs/download.php/1350/ocamlmod-0.0.7.tar.gz;
+    sha256 = "11kg7wh0gy492ma5c6bcjh6frv1a9lh9f26hiys2i0d1ky8s0ad3";
+  };
+
+  buildInputs = [ocaml findlib ounit];
+
+  configurePhase = "ocaml setup.ml -configure --prefix $out";
+  buildPhase     = "ocaml setup.ml -build";
+  installPhase   = "ocaml setup.ml -install";
+
+  meta = {
+    homepage = http://forge.ocamlcore.org/projects/ocamlmod/ocamlmod;
+    description = "Generate OCaml modules from source files";
+    platforms = ocaml.meta.platforms;
+    maintainers = with stdenv.lib.maintainers; [
+      z77z
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2903,17 +2903,25 @@ let
 
     ocaml_cryptgps = callPackage ../development/ocaml-modules/cryptgps { };
 
+    ocaml_data_notation = callPackage ../development/ocaml-modules/odn { };
+
     ocaml_expat = callPackage ../development/ocaml-modules/expat { };
 
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
 
     ocaml_http = callPackage ../development/ocaml-modules/http { };
 
+    ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
+
     ocaml_lwt = callPackage ../development/ocaml-modules/lwt { };
+
+    ocamlmod = callPackage ../development/tools/ocaml/ocamlmod { };
 
     ocaml_mysql = callPackage ../development/ocaml-modules/mysql { };
 
     ocamlnet = callPackage ../development/ocaml-modules/ocamlnet { };
+
+    ocaml_oasis = callPackage ../development/tools/ocaml/oasis { };
 
     ocaml_pcre = callPackage ../development/ocaml-modules/pcre {
       inherit pcre;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2899,9 +2899,7 @@ let
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
-    ocaml_batteries = callPackage ../development/ocaml-modules/batteries {
-      camomile = camomile_0_8_2;
-    };
+    ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
 
     ocaml_cryptgps = callPackage ../development/ocaml-modules/cryptgps { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2939,6 +2939,8 @@ let
 
     ocaml_typeconv = callPackage ../development/ocaml-modules/typeconv { };
 
+    ocaml_typeconv_3_0_5 = callPackage ../development/ocaml-modules/typeconv/3.0.5.nix { };
+
     ocaml_sexplib = callPackage ../development/ocaml-modules/sexplib { };
 
     ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };


### PR DESCRIPTION
Add OCaml Oasis

OCaml Oasis is a configure/build/install system for OCaml proget (like Cabal for Haskell).

Also add and upgrades other related packages:
- Upgrade Type_conv (needed for oasis)
- Add ocamlmod, ocamlify, odn (needed for oasis)
- Upgrade OCaml react (oasis facilitates its build)
- Upgrade OCaml Batteries (actually unrelated to oasis but a good thing anyway, I suppose)
