### PR TITLE
amdadl-sdk: set license to unfree

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -28,12 +28,6 @@
     url = "http://developer.amd.com/amd-license-agreement/";
   };
 
-  amdadl = {
-    shortName = "amd-adl";
-    fullName = "amd-adl license";
-    url = "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/AMD-ADL?revision=1.1";
-  };
-
   # Apple Public Source License 2.0;
   # http://opensource.org/licenses/APSL-2.0
   apsl20 = "APSL 2.0";

--- a/pkgs/development/misc/amdadl-sdk/default.nix
+++ b/pkgs/development/misc/amdadl-sdk/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "API to access display driver functionality for ATI graphics cards";
     homepage = http://developer.amd.com/tools/graphics-development/display-library-adl-sdk/;
-    license = licenses.amdadl;
+    license = "unfree";
     maintainers = [ maintainers.offline ];
     platforms = stdenv.lib.platforms.linux;
     hydraPlatforms = [];


### PR DESCRIPTION
We cannot auto build amdadl-sdk on hydra, so setting license to unfree disable
auto builds. I also remove amdadl license, because it's irrelevant.
