### PR TITLE
zsh: don't clobber the environment of non-login shells

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -116,8 +116,9 @@ in
         # This file is read for all shells.
 
         # Only execute this file once per shell.
+        # But don't clobber the environment of interactive non-login children!
         if [ -n "$__ETC_ZSHENV_SOURCED" ]; then return; fi
-        __ETC_ZSHENV_SOURCED=1
+        export __ETC_ZSHENV_SOURCED=1
 
         ${cfg.shellInit}
 


### PR DESCRIPTION
This patch makes a small change to `/etc/zshenv` so that Zsh doesn't clobber the environment of interactive non-login shells.
## Background

On NixOS, `/etc/zshenv` contains the same user environment settings as `/etc/profile` does for Bash. It also sets up `$HOME/.nix-profile`, `$HOME/.nix-defexpr`, etc. Unlike `/etc/profile`, `zshenv` is loaded with every shell. The NixOS `bashrc` file loads `/etc/profile`, but only when it hasn't already been loaded, so as not to clobber the environment if it's already been set. There is no such protection for `/etc/zshenv`, which is loaded every time.
## Problem

The main problem is that child Zsh shells always have the pristine environment settings, as if invoked as `zsh --login`. In particular, this makes it impossible to use Zsh with `myEnvFun`.
## Solution

`/etc/profile` exports a variable that prevents `/etc/bashrc` from resetting the environment. `/etc/zshenv` already exports a variable to prevent it being loaded twice within the same shell. The solution here exports that variable so that child shells also don't reload `/etc/zshenv`.
## Testing

The user environment is set correctly for local and remote logins. `myEnvFun` also works now.
