### PR TITLE
libyaml: Patch to fix CVE-2013-6393.

### DIFF
--- a/pkgs/development/libraries/libyaml/cve-2013-6393_a.patch
+++ b/pkgs/development/libraries/libyaml/cve-2013-6393_a.patch
@@ -1,0 +1,11 @@
+--- a/src/scanner.c	
++++ a/src/scanner.c	
+@@ -2574,7 +2574,7 @@ 
+ 
+     /* Resize the string to include the head. */
+ 
+-    while (string.end - string.start <= (int)length) {
++    while ((size_t)(string.end - string.start) <= length) {
+         if (!yaml_string_extend(&string.start, &string.pointer, &string.end)) {
+             parser->error = YAML_MEMORY_ERROR;
+             goto error;

--- a/pkgs/development/libraries/libyaml/cve-2013-6393_b.patch
+++ b/pkgs/development/libraries/libyaml/cve-2013-6393_b.patch
@@ -1,0 +1,16 @@
+--- a/src/api.c	
++++ a/src/api.c	
+@@ -117,7 +117,12 @@ 
+ YAML_DECLARE(int)
+ yaml_stack_extend(void **start, void **top, void **end)
+ {
+-    void *new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
++    void *new_start;
++
++    if ((char *)*end - (char *)*start >= INT_MAX / 2)
++	return 0;
++
++    new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
+ 
+     if (!new_start) return 0;
+ 

--- a/pkgs/development/libraries/libyaml/cve-2013-6393_c.patch
+++ b/pkgs/development/libraries/libyaml/cve-2013-6393_c.patch
@@ -1,0 +1,131 @@
+--- a/src/scanner.c	Mon Dec 24 03:51:32 2012 +0000
++++ a/src/scanner.c	Mon Jan 27 19:48:28 2014 -0500
+@@ -615,11 +615,14 @@ 
+  */
+ 
+ static int
+-yaml_parser_roll_indent(yaml_parser_t *parser, int column,
++yaml_parser_roll_indent(yaml_parser_t *parser, size_t column,
+         int number, yaml_token_type_t type, yaml_mark_t mark);
+ 
+ static int
+-yaml_parser_unroll_indent(yaml_parser_t *parser, int column);
++yaml_parser_unroll_indent(yaml_parser_t *parser, size_t column);
++
++static int
++yaml_parser_reset_indent(yaml_parser_t *parser);
+ 
+ /*
+  * Token fetchers.
+@@ -1206,7 +1209,7 @@ 
+  */
+ 
+ static int
+-yaml_parser_roll_indent(yaml_parser_t *parser, int column,
++yaml_parser_roll_indent(yaml_parser_t *parser, size_t column,
+         int number, yaml_token_type_t type, yaml_mark_t mark)
+ {
+     yaml_token_t token;
+@@ -1216,7 +1219,7 @@ 
+     if (parser->flow_level)
+         return 1;
+ 
+-    if (parser->indent < column)
++    if (parser->indent == -1 || parser->indent < column)
+     {
+         /*
+          * Push the current indentation level to the stack and set the new
+@@ -1254,7 +1257,7 @@ 
+ 
+ 
+ static int
+-yaml_parser_unroll_indent(yaml_parser_t *parser, int column)
++yaml_parser_unroll_indent(yaml_parser_t *parser, size_t column)
+ {
+     yaml_token_t token;
+ 
+@@ -1263,6 +1266,15 @@ 
+     if (parser->flow_level)
+         return 1;
+ 
++    /*
++     * column is unsigned and parser->indent is signed, so if
++     * parser->indent is less than zero the conditional in the while
++     * loop below is incorrect.  Guard against that.
++     */
++    
++    if (parser->indent < 0)
++        return 1;
++
+     /* Loop through the intendation levels in the stack. */
+ 
+     while (parser->indent > column)
+@@ -1283,6 +1295,41 @@ 
+ }
+ 
+ /*
++ * Pop indentation levels from the indents stack until the current
++ * level resets to -1.  For each intendation level, append the
++ * BLOCK-END token.
++ */
++
++static int
++yaml_parser_reset_indent(yaml_parser_t *parser)
++{
++    yaml_token_t token;
++
++    /* In the flow context, do nothing. */
++
++    if (parser->flow_level)
++        return 1;
++
++    /* Loop through the intendation levels in the stack. */
++
++    while (parser->indent > -1)
++    {
++        /* Create a token and append it to the queue. */
++
++        TOKEN_INIT(token, YAML_BLOCK_END_TOKEN, parser->mark, parser->mark);
++
++        if (!ENQUEUE(parser, parser->tokens, token))
++            return 0;
++
++        /* Pop the indentation level. */
++
++        parser->indent = POP(parser, parser->indents);
++    }
++
++    return 1;
++}
++
++/*
+  * Initialize the scanner and produce the STREAM-START token.
+  */
+ 
+@@ -1338,7 +1385,7 @@ 
+ 
+     /* Reset the indentation level. */
+ 
+-    if (!yaml_parser_unroll_indent(parser, -1))
++    if (!yaml_parser_reset_indent(parser))
+         return 0;
+ 
+     /* Reset simple keys. */
+@@ -1369,7 +1416,7 @@ 
+ 
+     /* Reset the indentation level. */
+ 
+-    if (!yaml_parser_unroll_indent(parser, -1))
++    if (!yaml_parser_reset_indent(parser))
+         return 0;
+ 
+     /* Reset simple keys. */
+@@ -1407,7 +1454,7 @@ 
+ 
+     /* Reset the indentation level. */
+ 
+-    if (!yaml_parser_unroll_indent(parser, -1))
++    if (!yaml_parser_reset_indent(parser))
+         return 0;
+ 
+     /* Reset simple keys. */

--- a/pkgs/development/libraries/libyaml/default.nix
+++ b/pkgs/development/libraries/libyaml/default.nix
@@ -8,6 +8,9 @@ stdenv.mkDerivation {
     sha256 = "0dvavrhxjrjfxgdgysxqfpdy08lpg3m9i8vxjyvdkcjsmra1by3v";
   };
 
+  # Downloaded on 2014-02-01 from https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+  patches = [ ./cve-2013-6393_a.patch ./cve-2013-6393_b.patch ./cve-2013-6393_c.patch ];
+
   meta = {
     homepage = http://pyyaml.org/;
     description = "A YAML 1.1 parser and emitter written in C";


### PR DESCRIPTION
I used all the patches from the RedHat bugzilla thread at https://bugzilla.redhat.com/show_bug.cgi?id=1033990 .  Hopefully they fix the problem.

I haven't really tested this.  On my system this only causes LaTeX to be rebuilt, and I am guessing it is only some obscure LaTeX package that uses yaml.
