### PR TITLE
Update virtualbox/guest additions to 4.3.6

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -38,6 +38,8 @@ optionalAttrs (pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) # ugly...
 
     boot.extraModulePackages = [ kernel.virtualboxGuestAdditions ];
 
+    boot.kernelModules = [ "vboxsf" ];
+
     users.extraGroups.vboxsf.gid = config.ids.gids.vboxsf;
 
     systemd.services.virtualbox =

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -11,7 +11,7 @@ with stdenv.lib;
 
 let
 
-  version = "4.2.18"; # changes ./guest-additions as well
+  version = "4.3.6"; # changes ./guest-additions as well
 
   forEachModule = action: ''
     for mod in \
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "9dbddf393b029c549249f627d12040c1d257972bc09292969b8819a31ab78d74";
+    sha256 = "09xvrk5g14q71lmprcdaci6fks6yilpq99scxslzn1hb5viy2iy5";
   };
 
   buildInputs =

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "f11a7f13dfe7bf9f246fb877144bb467fe6deadcd876568ec79b6ccd3b59d767";
+    sha256 = "1w3rrabd5zk1b8lqjqrnv8cx4in950pjzzm28m0yca6hnp6qyr4m";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/*/build";


### PR DESCRIPTION
Previous guest additions are no longer compatible with current version of virtualbox which makes it a pain to play with NixOs in a vm.... so bump to 4.3.6?

The vboxsf module was not getting loaded when the virtualbox service is enabled, so fixed that.
