### PR TITLE
Replace the current Yubikey PBA implementation with the previous one.

### DIFF
--- a/nixos/modules/system/boot/pbkdf2-sha512.c
+++ b/nixos/modules/system/boot/pbkdf2-sha512.c
@@ -1,0 +1,38 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <openssl/evp.h>
+
+void hextorb(uint8_t* hex, uint8_t* rb)
+{
+	while(sscanf(hex, "%2x", rb) == 1)
+	{
+		hex += 2;
+		rb += 1;
+	}
+	*rb = '\0';
+}
+
+int main(int argc, char** argv)
+{
+	uint8_t k_user[2048];
+	uint8_t salt[2048];
+	uint8_t key[4096];
+
+	uint32_t key_length = atoi(argv[1]);
+	uint32_t iteration_count = atoi(argv[2]);
+
+	hextorb(argv[3], salt);
+	uint32_t salt_length = strlen(argv[3]) / 2;
+
+	fgets(k_user, 2048, stdin);
+	uint32_t k_user_length = strlen(k_user);
+	if(k_user[k_user_length - 1] == '\n') {
+			k_user[k_user_length - 1] = '\0';
+	}
+
+	PKCS5_PBKDF2_HMAC(k_user, k_user_length, salt, salt_length, iteration_count, EVP_sha512(), key_length, key);
+	fwrite(key, 1, key_length, stdout);
+
+	return 0;
+}


### PR DESCRIPTION
Rationale:
- The main reason for choosing to implement the PBA in accordance
  with the Yubico documentation was to prevent a MITM-USB-attack
  successfully recovering the new LUKS key.
- However, a MITM-USB-attacker can read user id and password when
  they were entered for PBA, which allows him to recover the new
  challenge after the PBA is complete, with which he can challenge
  the Yubikey, decrypt the new AES blob and recover the LUKS key.
- Additionally, since the Yubikey shared secret is stored in the
  same AES blob, after such an attack not only is the LUKS device
  compromised, the Yubikey is as well, since the shared secret
  has also been recovered by the attacker.
- Furthermore, with this method an attacker could also bruteforce
  the AES blob, if he has access to the unencrypted device, which
  would again compromise the Yubikey, should he be successful.
- Finally, with this method, once the LUKS key has been recovered
  once, the encryption is permanently broken, while with the previous
  system, the LUKS key itself it changed at every successful boot,
  so recovering it once will not necessarily result in a permanent
  breakage and will also not compromise the Yubikey itself (since
  its secret is never stored anywhere but on the Yubikey itself).

Summary:
The current implementation opens up up vulnerability to brute-forcing
the AES blob, while retaining the current MITM-USB attack, additionally
making the consequences of this attack permanent and extending it to
the Yubikey itself.
