### PR TITLE
Generate hoogle databases beside HTML haddock documentation for Haskell packages

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -220,7 +220,7 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
               ./Setup build ${self.buildTarget}
 
               export GHC_PACKAGE_PATH=$(${ghc.GHCPackages})
-              test -n "$noHaddock" || ./Setup haddock
+              test -n "$noHaddock" || ./Setup haddock --html --hoogle
 
               eval "$postBuild"
             '';


### PR DESCRIPTION
Today I wanted to generate a local hoogle database which exactly reflects my haskell-env generated by nix.  This is unfortunately not possible, because the hackage server only hosts the newest version of hoogle database files, and nix doesn't build hoogle files.

Even if the hackage server was correct, I don't think we should make the users depend on online resources, it's way more practical to have the hoogle database generated right beside the package.

I tested this with the Text package as an example and it only increased the final documentation size by 10% and the whole package size by 1%.

I know that this change will trigger an all haskell package rebuild.  If it's not possible to merge it now, can we at please merge it to a branch where it won't be forgotten?  Thanks!  I'm looking forward to have my nice hoogle documentation in nix store! :)
