### PR TITLE
glfw: Update packaging and add v3

### DIFF
--- a/pkgs/development/libraries/glfw/2.x.nix
+++ b/pkgs/development/libraries/glfw/2.x.nix
@@ -1,27 +1,29 @@
-{ stdenv, fetchurl, mesa, libX11, libXext }:
+{ stdenv, fetchurl, mesa, libX11 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "glfw-2.7.9";
 
   src = fetchurl {
-    url = mirror://sourceforge/glfw/glfw-2.7.9.tar.bz2;
+    url = "mirror://sourceforge/glfw/${name}.tar.bz2";
     sha256 = "17c2msdcb7pn3p8f83805h1c216bmdqnbn9hgzr1j8wnwjcpxx6i";
   };
 
-  buildInputs = [ mesa libX11 libXext ];
+  buildInputs = [ mesa libX11 ];
 
   buildPhase = ''
+    make x11
+  '';
+
+  installPhase = ''
     mkdir -p $out
     make x11-install PREFIX=$out
-  '';
+  ''; 
   
-  installPhase = ":";
-
-  meta = { 
+  meta = with stdenv.lib; { 
     description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";
-    homepage = http://glfw.sourceforge.net/;
-    license = "zlib/libpng"; # http://www.opensource.org/licenses/zlib-license.php
+    homepage = "http://glfw.sourceforge.net/";
+    license = licenses.zlib;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, cmake, mesa, libXrandr, libXi, libXxf86vm, libXfixes, x11 }:
+
+stdenv.mkDerivation rec {
+  name = "glfw-3.0.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/glfw/${name}.tar.bz2";
+    sha256 = "1h7g16ncgkl38w19x4dvnn17k9j0kqfvbb9whw9qc71lkq5xf2ag";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ cmake mesa libXrandr libXi libXxf86vm libXfixes x11 ];
+
+  meta = with stdenv.lib; { 
+    description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";
+    homepage = "http://glfw.sourceforge.net/";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ marcweber ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4178,7 +4178,9 @@ let
 
   glew = callPackage ../development/libraries/glew { };
 
-  glfw = callPackage ../development/libraries/glfw { };
+  glfw = glfw3;
+  glfw2 = callPackage ../development/libraries/glfw/2.x.nix { };
+  glfw3 = callPackage ../development/libraries/glfw/3.x.nix { };
 
   glibc = callPackage ../development/libraries/glibc/2.18 {
     kernelHeaders = linuxHeaders;


### PR DESCRIPTION
This patch cleans up the previous glfw2 package. Additionally, it adds
glfw3 and makes that the new default glfw version.
