### PR TITLE
postgresql: provide a default pager for "psql"

### DIFF
--- a/pkgs/servers/sql/postgresql/8.4.x.nix
+++ b/pkgs/servers/sql/postgresql/8.4.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, ncurses, readline }:
+{ stdenv, fetchurl, zlib, ncurses, readline, less }:
 
 let version = "8.4.19"; in
 
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zlib ncurses readline ];
+
+  prePatch = ''
+    sed -e 's|#define DEFAULT_PAGER.*|#define DEFAULT_PAGER "${less}/bin/less"|' \
+        -i src/bin/psql/print.h
+  '';
 
   LC_ALL = "C";
 

--- a/pkgs/servers/sql/postgresql/9.0.x.nix
+++ b/pkgs/servers/sql/postgresql/9.0.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, less }:
 
 let version = "9.0.15"; in
 
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zlib readline ];
+
+  prePatch = ''
+    sed -e 's|#define DEFAULT_PAGER.*|#define DEFAULT_PAGER "${less}/bin/less"|' \
+        -i src/bin/psql/print.h
+  '';
 
   LC_ALL = "C";
 

--- a/pkgs/servers/sql/postgresql/9.1.x.nix
+++ b/pkgs/servers/sql/postgresql/9.1.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, less }:
 
 let version = "9.1.11"; in
 
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zlib readline ];
+
+  prePatch = ''
+    sed -e 's|#define DEFAULT_PAGER.*|#define DEFAULT_PAGER "${less}/bin/less"|' \
+        -i src/bin/psql/print.h
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/sql/postgresql/9.2.x.nix
+++ b/pkgs/servers/sql/postgresql/9.2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, less }:
 
 let version = "9.2.6"; in
 
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
   makeFlags = [ "world" ];
 
   patches = [ ./disable-resolve_symlinks.patch ];
+
+  prePatch = ''
+    sed -e 's|#define DEFAULT_PAGER.*|#define DEFAULT_PAGER "${less}/bin/less"|' \
+        -i src/bin/psql/print.h
+  '';
 
   installTargets = [ "install-world" ];
 

--- a/pkgs/servers/sql/postgresql/9.3.x.nix
+++ b/pkgs/servers/sql/postgresql/9.3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, less }:
 
 let version = "9.3.2"; in
 
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
   makeFlags = [ "world" ];
 
   patches = [ ./disable-resolve_symlinks.patch ];
+
+  prePatch = ''
+    sed -e 's|#define DEFAULT_PAGER.*|#define DEFAULT_PAGER "${less}/bin/less"|' \
+        -i src/bin/psql/print.h
+  '';
 
   installTargets = [ "install-world" ];
 


### PR DESCRIPTION
When psql is started without the environment variable $PAGER set, it
tries to run "more" from $PATH (or "less", if `__CYGWIN__` was defined
during compilation). On NixOS, $PAGER is generally set to "less -R", but
when psql is run with sudo it is not set:

```
$ sudo psql postgres
psql (9.2.6)
Type "help" for help.

postgres=# \?
sh: more: command not found
postgres=#
```

One could of course run "sudo -E" or install "more" into a profile, but
I think it's better to provide a working default pager by compiling in
the full path to "less" (which is the default pager on NixOS). This is
what this commit does.

The closure size of postgresql (9.2) doesn't really change, it is 225
MiB before and after this change.

WARNING: This causes lots of rebuilding (Qt, KDE, ...). Changes like these makes me wonder whether we should have a "lots-of-rebuilding" branch that is merged periodically (every other week?), so that we can batch up these small changes that cause a lot of rebuilds.
