### PR TITLE
rxvt-unicode: calculate font width correctly

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "terminfo" ];
 
+  patches = [ ./rxvt-unicode-9.06-font-width.patch ];
+
   preConfigure =
     ''
       mkdir -p $terminfo/share/terminfo

--- a/pkgs/applications/misc/rxvt_unicode/rxvt-unicode-9.06-font-width.patch
+++ b/pkgs/applications/misc/rxvt_unicode/rxvt-unicode-9.06-font-width.patch
@@ -1,0 +1,21 @@
+--- a/src/rxvtfont.C	2008-07-09 12:21:45.000000000 +0400
++++ b/src/rxvtfont.C	2009-10-30 14:32:53.000000000 +0300
+@@ -1195,12 +1195,14 @@
+           XGlyphInfo g;
+           XftTextExtents16 (disp, f, &ch, 1, &g);
+ 
+-          g.width -= g.x;
+-
++/*
++ * bukind: don't use g.width as a width of a character!
++ * instead use g.xOff, see e.g.: http://keithp.com/~keithp/render/Xft.tutorial
++ */
+           int wcw = WCWIDTH (ch);
+-          if (wcw > 0) g.width = (g.width + wcw - 1) / wcw;
++          if (wcw > 1) g.xOff = g.xOff / wcw;
++          if (width < g.xOff) width = g.xOff;
+ 
+-          if (width    < g.width       ) width    = g.width;
+           if (height   < g.height      ) height   = g.height;
+           if (glheight < g.height - g.y) glheight = g.height - g.y;
+         }


### PR DESCRIPTION
It is (fairly) well known among rxvt-unicode users that its method of
calculating the width of Xft fonts is not correct. This is the Gentoo
version of the patch which corrects the problem.
