### PR TITLE
Support for New Relic system monitor daemon

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -110,6 +110,7 @@
       openldap = 99;
       memcached = 100;
       cgminer = 101;
+      newrelic = 102;
 
       # When adding a uid, make sure it doesn't match an existing gid.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -133,6 +133,7 @@
   ./services/monitoring/monit.nix
   ./services/monitoring/munin.nix
   ./services/monitoring/nagios/default.nix
+  ./services/monitoring/newrelic-sysmond.nix
   ./services/monitoring/smartd.nix
   ./services/monitoring/statsd.nix
   ./services/monitoring/systemhealth.nix

--- a/nixos/modules/services/monitoring/newrelic-sysmond.nix
+++ b/nixos/modules/services/monitoring/newrelic-sysmond.nix
@@ -1,0 +1,157 @@
+{ config, pkgs, ...}:
+
+with pkgs.lib;
+
+let
+  cfg = config.services.nrsysmond;
+
+  configFile = pkgs.writeText "nrsysmond.cfg" ''
+    license_key=${cfg.license}
+    loglevel=${cfg.loglevel}
+    logfile=${toString cfg.logfile}
+    ${if cfg.proxy != "" then ("proxy="+cfg.proxy) else ""}
+    ssl=${if cfg.ssl then "true" else "false"}
+    ssl_ca_bundle=${toString cfg.sslBundle}
+    ssl_ca_path=${toString cfg.sslPath}
+    pidfile=${toString cfg.pidfile}
+    collector_host=${cfg.collectorHost}
+    timeout=${toString cfg.timeout}
+  '';
+
+in
+{
+  options = {
+    services.nrsysmond = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = '';
+          If enabled, start the New Relic system monitor daemon.
+        '';
+      };
+
+      license = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          40-character hexadecimal string provided by New Relic,
+          required for the monitor to start.
+        '';
+      };
+
+      loglevel = mkOption {
+        type    = types.str;
+        default = "info";
+        description = ''
+          Level of detail you want in the logfile. Valid values are:
+            - error
+            - warning
+            - info
+            - verbose
+            - debug
+            - verbosedebug
+        '';
+      };
+
+      logfile = mkOption {
+        type    = types.path;
+        default = "/var/log/newrelic/nrsysmond.log";
+        description = ''
+          Name of the file where the monitor stores log messages.
+        '';
+      };
+
+      proxy = mkOption {
+        type    = types.str;
+        default = "";
+        description = ''
+          Name and (optional) login credentials of the proxy server to
+          use for communication with the New Relic connector.
+        '';
+      };
+
+      ssl = mkOption {
+        type    = types.bool;
+        default = true;
+        description = ''
+          Whether or not to use Secure Sockets Layer (SSL) for
+          communication with the New Relic connector.
+        '';
+      };
+
+      sslBundle = mkOption {
+        type    = types.path;
+        default = "/etc/ssl/certs/ca-bundle.crt";
+        description = ''
+          The path of a PEM-encoded Certificate Authority (CA) bundle
+          to use for SSL connections.
+        '';
+      };
+
+      sslPath = mkOption {
+        type    = types.path;
+        default = "/etc/ssl/certs";
+        description = ''
+          If your SSL installation does not use CA bundles, but rather
+          has a directory with PEM-encoded Certificate Authority
+          files, set this option to the name of the directory that
+          contains all the CA files.
+        '';
+      };
+
+      pidfile = mkOption {
+        type    = types.path;
+        default = "/tmp/nrsysmond.pid";
+        description = ''
+          Name of a file where the monitoring daemon will store its PID.
+        '';
+      };
+
+      collectorHost = mkOption {
+        type        = types.str;
+        default     = "collector.newrelic.com";
+        description = ''
+          The name of the New Relic collector to connect to.
+        '';
+      };
+
+      timeout = mkOption {
+        type        = types.int;
+        default     = 30;
+        description = ''
+          How long the monitor should wait to contact the collector
+          host.
+        '';
+      };
+    };
+  };
+
+  config = mkIf config.services.nrsysmond.enable {
+    assertions = singleton {
+      assertion = stringLength cfg.license == 40;
+      message   = "New Relic license key required to be a 40 character hex string";
+    };
+
+    users.extraUsers = singleton {
+      name        = "newrelic";
+      uid         = config.ids.uids.newrelic;
+      description = "New Relic daemon user";
+      home        = "/var/log/newrelic/";
+      createHome  = true;
+    };
+
+    systemd.services.nrsysmond = {
+      description = "New Relic system monitor";
+      wantedBy    = [ "multi-user.target" ];
+      serviceConfig = {
+        Type      = "forking";
+        PIDFile   = cfg.pidfile;
+        Restart   = "always";
+        User      = "newrelic";
+        ExecStart = "${pkgs.newrelic_sysmond}/bin/nrsysmond -c ${configFile}";
+      };
+    };
+
+    environment.systemPackages = [ pkgs.newrelic_sysmond ];
+  };
+}

--- a/pkgs/tools/system/newrelic-sysmond/default.nix
+++ b/pkgs/tools/system/newrelic-sysmond/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "newrelic-sysmond-1.3.1.437";
+  meta = {
+    description = "New Relic system monitor daemon";
+    homepage    = "https://newrelic.com";
+    license     = "unfree-redistributable";
+  };
+  src = fetchurl {
+    url    = "http://download.newrelic.com/server_monitor/release/${name}-linux.tar.gz";
+    sha256 = "efe04ef6f1b23d327fe7bb56f4d181d6c42fec9d9cb8238d220defc5ef08b20f";
+  };
+
+  arch = if stdenv.system == "x86_64-linux" then "x64"
+    else if stdenv.system == "i686-linux" then "x86"
+    else throw "nrsysmond: ${stdenv.system} not supported!";
+  daemonexe = "${name}-linux/daemon/nrsysmond." + arch;
+
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.libc ];
+
+  unpackPhase = ''tar zxf $src'';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${daemonexe} $out/bin/nrsysmond
+  '';
+
+  fixupPhase = ''
+    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-rpath $libPath $out/bin/nrsysmond
+  '';
+
+  phases = "unpackPhase installPhase fixupPhase";
+}

--- a/pkgs/tools/system/newrelic-sysmond/default.nix
+++ b/pkgs/tools/system/newrelic-sysmond/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, patchelf }:
 
 stdenv.mkDerivation rec {
   name = "newrelic-sysmond-1.3.1.437";
   meta = {
     description = "New Relic system monitor daemon";
     homepage    = "https://newrelic.com";
-    license     = "unfree-redistributable";
+    license     = stdenv.lib.licenses.unfree;
   };
   src = fetchurl {
     url    = "http://download.newrelic.com/server_monitor/release/${name}-linux.tar.gz";
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   daemonexe = "${name}-linux/daemon/nrsysmond." + arch;
 
   libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.libc ];
+  buildInputs = [ patchelf ];
 
   unpackPhase = ''tar zxf $src'';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -588,6 +588,8 @@ let
 
   rsyslog = callPackage ../tools/system/rsyslog { };
 
+  newrelic_sysmond = callPackage ../tools/system/newrelic-sysmond { };
+
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
   mcelog = callPackage ../os-specific/linux/mcelog { };


### PR DESCRIPTION
These patches add support for the New Relic `nrsysmond` binary as a package named `newrelic_sysmond`, along with a NixOS `systemd` module. The package only installs the binary while all the configuration is left in the module (I imagine most people won't care about this unless they're running NixOS anyway.)

The binary itself is proprietary but otherwise has very runtime minimal dependencies (glibc 2.5+ only), so patching it to work is quite trivial.

The daemon runs as user `newrelic` with uid `102`. Using it is as simple as setting `services.nrsysmond.enable` to `true` and `services.nrsysmond.license` to your New Relic license key. Everything else sets a sensible default (including `ssl=true` which, in a bizarre twist, is not enabled by default in their example configuration...)
