### PR TITLE
Fixed download of andagii.zip

### DIFF
--- a/pkgs/data/fonts/andagii/default.nix
+++ b/pkgs/data/fonts/andagii/default.nix
@@ -19,6 +19,7 @@ in
 rec {
   src = a.fetchurl {
     url = sourceInfo.url;
+    curlOpts = "--user-agent 'Mozilla/5.0'";
     sha256 = sourceInfo.hash;
   };
 


### PR DESCRIPTION
Download of andagii.zip failed with 403 because curls user-agent is
filtered out. Fixed by providing a different user-agent.
