### PR TITLE
Add libchewing, ibus-chewing and ibus module.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -47,6 +47,7 @@
   ./programs/bash/command-not-found.nix
   ./programs/blcr.nix
   ./programs/environment.nix
+  ./programs/ibus.nix
   ./programs/info.nix
   ./programs/shadow.nix
   ./programs/shell.nix

--- a/nixos/modules/programs/ibus.nix
+++ b/nixos/modules/programs/ibus.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+  cfg = config.programs.ibus;
+
+in {
+  options = {
+    programs.ibus.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Enable Intelligent Input Bus (ibus)";
+    };
+
+    programs.ibus.engines = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = [ pkgs.ibus_chewing ];
+      description = "A list of ibus engines to enable";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Need to add dconf, or otherwise dbus will complain that it cannot find ca.desrt.dconf.service.
+    environment.systemPackages = [ pkgs.ibus pkgs.gnome3.dconf ] ++ cfg.engines;
+    environment.pathsToLink = [ "/share/ibus/component" ];
+  };
+}

--- a/pkgs/development/libraries/ibus-chewing/default.nix
+++ b/pkgs/development/libraries/ibus-chewing/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, cmake, pkgconfig
+, ibus, libchewing, x11, gtk, gob2, gconf, gettext
+, libxcb, libpthreadstubs, libXdmcp
+, libXtst, libXi, libXfixes }:
+
+let
+  pkgname = "ibus-chewing";
+  version = "1.4.7";
+
+in stdenv.mkDerivation {
+  name = "${pkgname}-${version}";
+
+  src = fetchurl {
+    url = "http://ibus.googlecode.com/files/${pkgname}-${version}-Source.tar.gz";
+    sha1 = "9e2a9792db374be2575f5dd6998755a699d9011d";
+  };
+
+  buildInputs = [
+    cmake
+    pkgconfig
+    x11
+    gtk
+    gob2
+    gconf
+    gettext
+    libxcb
+    libpthreadstubs
+    libXdmcp
+    libXtst
+    libXi
+    libXfixes
+    ibus
+    libchewing
+  ];
+
+  postBuild = ''make translations'';
+  preInstall = ''sed -i -e "s!/etc!$out/etc!g" cmake_install.cmake'';
+}

--- a/pkgs/development/libraries/ibus/default.nix
+++ b/pkgs/development/libraries/ibus/default.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
                        --prefix PYTHONPATH : "$(toPythonPath ${pygobject3})" \
                        --prefix LD_LIBRARY_PATH : "${gnome3.gtk3}/lib:${atk}/lib:$out/lib" \
                        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
-                       --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+                       --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules" \
+                       --prefix IBUS_COMPONENT_PATH : "/run/current-system/sw/share/ibus/component"
     done
   '';
 

--- a/pkgs/development/libraries/libchewing/default.nix
+++ b/pkgs/development/libraries/libchewing/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 
 let
   pkgname = "libchewing";

--- a/pkgs/development/libraries/libchewing/default.nix
+++ b/pkgs/development/libraries/libchewing/default.nix
@@ -1,0 +1,14 @@
+{stdenv, fetchurl}:
+
+let
+  pkgname = "libchewing";
+  version = "0.3.5";
+
+in stdenv.mkDerivation {
+  name = "${pkgname}-${version}";
+
+  src = fetchurl {
+    url = "https://chewing.googlecode.com/files/${pkgname}-${version}.tar.bz2";
+    sha1 = "5ee3941f0f62fa14fbda53e1032970b04a7a88b7";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1169,7 +1169,7 @@ let
 
   ibus_chewing = callPackage ../development/libraries/ibus-chewing {
     inherit (xlibs);
-    gconf = gnome.GConf;
+    gconf = gnome3.gconf;
   };
 
   icecast = callPackage ../servers/icecast { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1167,6 +1167,11 @@ let
 
   iasl = callPackage ../development/compilers/iasl { };
 
+  ibus_chewing = callPackage ../development/libraries/ibus-chewing {
+    inherit (xlibs);
+    gconf = gnome.GConf;
+  };
+
   icecast = callPackage ../servers/icecast { };
 
   icoutils = callPackage ../tools/graphics/icoutils { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4625,6 +4625,8 @@ let
 
   libchamplain_0_6 = callPackage ../development/libraries/libchamplain/0.6.nix {};
 
+  libchewing = callPackage ../development/libraries/libchewing {};
+
   libchop = callPackage ../development/libraries/libchop {
     gnutls = gnutls31;
   };


### PR DESCRIPTION
The ibus module is needed so that other engines can be plugged in at run-time. Other ibus-\* engines should work as well if they install their component XML's to `$out/share/ibus/component`.
