### PR TITLE
Properly escape passwords sent to chpasswd

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -411,13 +411,13 @@ in
           if [ "$setpw" == "yes" ]; then
             ${if !(isNull u.hashedPassword)
               then ''
-                echo "${u.name}:${u.hashedPassword}" | \
+                echo '${u.name}:${u.hashedPassword}' | \
                   ${pkgs.shadow}/sbin/chpasswd -e''
               else if u.password == ""
               then "passwd -d '${u.name}' &>/dev/null"
               else if !(isNull u.password)
               then ''
-                echo "${u.name}:${u.password}" | ${pkgs.shadow}/sbin/chpasswd''
+                echo '${u.name}:${u.password}' | ${pkgs.shadow}/sbin/chpasswd''
               else if !(isNull u.passwordFile)
               then ''
                 echo -n "${u.name}:" | cat - "${u.passwordFile}" | \


### PR DESCRIPTION
The mutableUsers feature uses `chpasswd` to set users passwords.
Passwords and their hashes were being piped into the program using
double quotes ("") to escape. This causes any `$` characters to be
expanded as shell variables. This is a serious problem because all the
password hash methods besides DES use multiple `$` in the hashes. Single
quotes ('') should be used instead to prevent shell variable expansion.
