### PR TITLE
nixos: add uid for logcheck and only create a user for the default user

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -111,6 +111,7 @@
       memcached = 100;
       cgminer = 101;
       munin = 102;
+      logcheck = 103;
 
       # When adding a uid, make sure it doesn't match an existing gid.
 

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -208,12 +208,13 @@ in
         mapAttrsToList writeIgnoreRule cfg.ignore
         ++ mapAttrsToList writeIgnoreCronRule cfg.ignoreCron;
 
-    users.extraUsers = singleton
-      { name = cfg.user;
+    users.extraUsers = optionalAttrs (cfg.user == "logcheck") (singleton
+      { name = "logcheck";
+        uid = config.ids.uids.logcheck;
         shell = "/bin/sh";
         description = "Logcheck user account";
         extraGroups = cfg.extraGroups;
-      };
+      });
 
     system.activationScripts.logcheck = ''
       mkdir -m 700 -p /var/{lib,lock}/logcheck


### PR DESCRIPTION
For compatibility with eb2f44c18cb6d300e965308547d8a4dea110f519.
