### PR TITLE
NetworkManager: Fix aliases and dependencies

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -89,7 +89,7 @@ in {
           to change network settings to this group.
         '';
       };
-  
+
       packages = mkOption {
         type = types.listOf types.path;
         default = [ ];
@@ -178,7 +178,7 @@ in {
       description = "NetworkManager initialisation";
       wantedBy = [ "network.target" ];
       partOf = [ "NetworkManager.service" ];
-      wants = [ "ModemManager.service" ];
+      wants = [ "ModemManager.service" "NetworkManager.service" ];
       before = [ "NetworkManager.service" ];
       script = ''
         mkdir -m 700 -p /etc/NetworkManager/system-connections

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -57,12 +57,14 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       mkdir -p $out/lib/NetworkManager
-      
+
       # FIXME: Workaround until NixOS' dbus+systemd supports at_console policy
       substituteInPlace $out/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf --replace 'at_console="true"' 'group="networkmanager"'
 
-      # As NixOS doesn't seem to handle systemd Aliases, we just rename the dispatcher service file
-      mv $out/etc/systemd/system/NetworkManager-dispatcher.service $out/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
+      # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
+      # aliases ourselves.
+      ln -s $out/etc/systemd/system/NetworkManager-dispatcher.service $out/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
+      ln -s $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
     '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
There are two fixes in this commit.

Firstly, I am creating proper symlinks for the Alias= definitions in the
.service files. This achieves the same result as `systemctl enable`, and
I think is preferred over `mv`.

Secondly, `networkmanager-init` now wants `NetworkManager.service`,
along with `ModemManager.service`. ModemManager does not depend on
NetworkManager (according to `systemctl list-dependencies ModemManager`),
thus NetworkManager never got started on boot.
