### PR TITLE
Add haskell-Chart-diagrams-1.2 and dependencies

### DIFF
--- a/pkgs/development/libraries/haskell/Chart-diagrams/default.nix
+++ b/pkgs/development/libraries/haskell/Chart-diagrams/default.nix
@@ -1,0 +1,21 @@
+{ cabal, blazeSvg, Chart, colour, dataDefaultClass, diagramsCore
+, diagramsLib, diagramsPostscript, diagramsSvg, lens, mtl
+, operational, SVGFonts, text, time
+}:
+
+cabal.mkDerivation (self: {
+  pname = "Chart-diagrams";
+  version = "1.2";
+  sha256 = "11pvyasra4mxid6826z6rkjhr71lg37fihzr8mgvjw3arascgqxz";
+  buildDepends = [
+    blazeSvg Chart colour dataDefaultClass diagramsCore diagramsLib
+    diagramsPostscript diagramsSvg lens mtl operational SVGFonts text
+    time
+  ];
+  meta = {
+    homepage = "https://github.com/timbod7/haskell-chart/wiki";
+    description = "Diagrams backend for Charts";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/SVGFonts/default.nix
+++ b/pkgs/development/libraries/haskell/SVGFonts/default.nix
@@ -1,0 +1,18 @@
+{ cabal, attoparsec, blazeMarkup, blazeSvg, dataDefaultClass
+, diagramsLib, parsec, split, text, tuple, vector, vectorSpace, xml
+}:
+
+cabal.mkDerivation (self: {
+  pname = "SVGFonts";
+  version = "1.4.0.1";
+  sha256 = "0f878xg6qngl8ahk8zz03f1kyn2jq1dz05zw8av7s91x2ms8q3rg";
+  buildDepends = [
+    attoparsec blazeMarkup blazeSvg dataDefaultClass diagramsLib parsec
+    split text tuple vector vectorSpace xml
+  ];
+  meta = {
+    description = "Fonts from the SVG-Font format";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/diagrams/postscript.nix
+++ b/pkgs/development/libraries/haskell/diagrams/postscript.nix
@@ -1,0 +1,19 @@
+{ cabal, diagramsCore, diagramsLib, dlist, filepath, hashable, lens
+, monoidExtras, mtl, semigroups, split, vectorSpace
+}:
+
+cabal.mkDerivation (self: {
+  pname = "diagrams-postscript";
+  version = "1.0.1.2";
+  sha256 = "0im1w70qi8qs2z8x41v7pwvk1alfaw1h8k0683njzd5sfz2m1gny";
+  buildDepends = [
+    diagramsCore diagramsLib dlist filepath hashable lens monoidExtras
+    mtl semigroups split vectorSpace
+  ];
+  meta = {
+    homepage = "http://projects.haskell.org/diagrams/";
+    description = "Postscript backend for diagrams drawing EDSL";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2280,6 +2280,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
     libc = pkgs.stdenv.gcc.libc;
   };
 
+  SVGFonts = callPackage ../development/libraries/haskell/SVGFonts {};
+
   symbol = callPackage ../development/libraries/haskell/symbol {};
 
   systemFilepath = callPackage ../development/libraries/haskell/system-filepath {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -940,6 +940,7 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
   diagramsCore = callPackage ../development/libraries/haskell/diagrams/core.nix {};
   diagramsContrib = callPackage ../development/libraries/haskell/diagrams/contrib.nix {};
   diagramsLib = callPackage ../development/libraries/haskell/diagrams/lib.nix {};
+  diagramsPostscript = callPackage ../development/libraries/haskell/diagrams/postscript.nix {};
   diagramsSvg = callPackage ../development/libraries/haskell/diagrams/svg.nix {};
 
   Diff = callPackage ../development/libraries/haskell/Diff {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -749,6 +749,7 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   Chart = callPackage ../development/libraries/haskell/Chart {};
   ChartCairo = callPackage ../development/libraries/haskell/Chart-cairo {};
+  ChartDiagrams = callPackage ../development/libraries/haskell/Chart-diagrams {};
   ChartGtk = callPackage ../development/libraries/haskell/Chart-gtk {};
 
   ChasingBottoms = callPackage ../development/libraries/haskell/ChasingBottoms {};


### PR DESCRIPTION
This would add the `diagrams` backend for the `Chart` package. The main advantage of this backend is requiring fewer dependencies than the Cairo or GTK backends.
