### PR TITLE
postgresql module: Use the default superuser username

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -190,7 +190,7 @@ in
                 mkdir -m 0700 -p ${cfg.dataDir}
                 if [ "$(id -u)" = 0 ]; then
                   chown -R postgres ${cfg.dataDir}
-                  su -s ${pkgs.stdenv.shell} postgres -c 'initdb -U root'
+                  su -s ${pkgs.stdenv.shell} postgres -c initdb
                 else
                   # For non-root operation.
                   initdb


### PR DESCRIPTION
PostgreSQL defaults to having 'postgres' as the superuser. NixOS should
use this default name to provide a less surprising result to people who
enable services.postgres.
