### PR TITLE
rpm: Upgrade from 4.7.2 -> 4.11.2

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, cpio, zlib, bzip2, file, elfutils, nspr, nss, popt, db4, xz, python }:
+{ stdenv, fetchurl, cpio, zlib, bzip2, file, elfutils, nspr, nss, popt, db, xz, python }:
 
 stdenv.mkDerivation rec {
-  name = "rpm-4.7.2";
+  name = "rpm-4.11.2";
 
   src = fetchurl {
-    url = "http://rpm.org/releases/rpm-4.7.x/${name}.tar.bz2";
-    sha1 = "07b90f653775329ea726ce0005c4c82f56167ca0";
+    url = "http://rpm.org/releases/rpm-4.11.x/${name}.tar.bz2";
+    sha256 = "1m2859js0dwg26sg2mnbkpzhvx303b12kx26az74cf5k6bk8sgs0";
   };
 
-  buildInputs = [ cpio zlib bzip2 file nspr nss popt db4 xz python ];
+  buildInputs = [ cpio zlib bzip2 file nspr nss popt db xz python ];
 
   # Note: we don't add elfutils to buildInputs, since it provides a
   # bad `ld' and other stuff.
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
   
   configureFlags = "--with-external-db --without-lua --enable-python";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.rpm.org/;
-    license = "GPLv2";
+    license = licenses.gpl2;
     description = "The RPM Package Manager";
-    maintainers = stdenv.lib.maintainers.mornfall;
+    maintainers = with maintainers; [ mornfall ];
   };
 }


### PR DESCRIPTION
This builds fine and I would assume that it is still interoperable. It would be nice if someone who uses rpm could test this.
