### PR TITLE
linux-3.2 & grsecurity updates

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.2.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.2.54";
+  version = "3.2.55";
   extraMeta.branch = "3.2";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "15mr1mrsldvs3jx9nc25pfmmdbz2ykiaxnqc26chn6k425l4kn67";
+    sha256 = "15fj7kd3ba52in1siqbdq45i7xzb53yy88l9k4bgfgds3j8wxj9m";
   };
 
   features.iwlwifi = true;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -78,11 +78,11 @@ rec {
   };
 
 
-  grsecurity_3_0_3_2_54 =
-    { name = "grsecurity-3.0-3.2.54";
+  grsecurity_3_0_3_2_55 =
+    { name = "grsecurity-3.0-3.2.55";
       patch = fetchurl {
-        url = https://grsecurity.net/stable/grsecurity-3.0-3.2.54-201402062221.patch;
-        sha256 = "14x887xibl7d50a1pxmi0snnwcnh27z8bnidhxg2xfasxxp248m5";
+        url = http://grsecurity.net/stable/grsecurity-3.0-3.2.55-201402152203.patch;
+        sha256 = "1600hydfq2dwyqqzfmsvy50kcicdm2lq44yiiwgnbiykq2135fwx";
       };
       features.grsecurity = true;
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.54
@@ -92,8 +92,8 @@ rec {
   grsecurity_3_0_3_13_3 =
     { name = "grsecurity-3.0-3.13.3";
       patch = fetchurl {
-        url = http://grsecurity.net/test/grsecurity-3.0-3.13.3-201402132113.patch;
-        sha256 = "143givk7xk54c2f9q7h2v5gdc3sy1kcd8j83vn1jfcyipzqkdqnk";
+        url = http://grsecurity.net/test/grsecurity-3.0-3.13.3-201402152204.patch;
+        sha256 = "0c4mswka95zivil3a28ipsbnv2nhrmqwj4l4dig3n8pr6d2vgwc9";
       };
       features.grsecurity = true;
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.13.2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6674,7 +6674,7 @@ let
   # config options you need (e.g. by overriding extraConfig). See list of options here:
   # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
   linux_3_2_grsecurity = lowPrio (lib.overrideDerivation (linux_3_2.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_54 kernelPatches.grsec_path ];
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_55 kernelPatches.grsec_path ];
     argsOverride = {
       modDirVersion = "${linux_3_2.modDirVersion}-grsec";
     };


### PR DESCRIPTION
Updates to grsecurity stable/testing branches.

This also updates `linux-3.2` to 3.2.55, which seems to be required for the latest grsecurity stable patch (it otherwise seems to have a patch error.)
