### PR TITLE
grsecurity: add gradm, paxctl, and pax-utils

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
       Also read "The importance of Paying Something" on their homepage, please!
     '';
     homepage = http://ardour.org/;
+    branch  = "2";
     license = "GPLv2";
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/misc/gnome_terminator/default.nix
+++ b/pkgs/applications/misc/gnome_terminator/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, python, pygtk, vte, gettext, intltool, makeWrapper }:
+{ stdenv, fetchurl, python, pygtk, notify, keybinder, vte, gettext, intltool
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   name = "gnome-terminator-${version}";
@@ -9,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "1xykpx10g2zssx0ss6351ca6vmmma7zwxxhjz0fg28ps4dq88cci";
   };
   
-  buildInputs = [ python pygtk vte gettext intltool makeWrapper ];
+  buildInputs = [
+    python pygtk notify keybinder vte gettext intltool makeWrapper
+  ];
 
   installPhase = ''
     python setup.py --without-icon-cache install --prefix="$out"

--- a/pkgs/applications/misc/terminator/default.nix
+++ b/pkgs/applications/misc/terminator/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gnome-terminator-${version}";
+  name = "terminator-${version}";
   version = "0.97";
   
   src = fetchurl {
-    url = "https://launchpad.net/terminator/trunk/${version}/+download/terminator-${version}.tar.gz";
+    url = "https://launchpad.net/terminator/trunk/${version}/+download/${name}.tar.gz";
     sha256 = "1xykpx10g2zssx0ss6351ca6vmmma7zwxxhjz0fg28ps4dq88cci";
   };
   

--- a/pkgs/desktops/kde-4.10/default.nix
+++ b/pkgs/desktops/kde-4.10/default.nix
@@ -1,9 +1,10 @@
 { callPackage, callPackageOrig, stdenv, qt48, release ? "4.10.5" }:
 
 let
+  branch = "4.10";
   # Need callPackageOrig to avoid infinite cycle
   kde = callPackageOrig ./kde-package {
-    inherit release ignoreList extraSubpkgs callPackage;
+    inherit release branch ignoreList extraSubpkgs callPackage;
   };
 
   # The list of igored individual modules
@@ -64,7 +65,7 @@ kde.modules // kde.individual //
   full = stdenv.lib.attrValues kde.modules;
 
   l10n = callPackage ./l10n {
-    inherit release;
+    inherit release branch;
     inherit (kde.manifest) stable;
   };
 }

--- a/pkgs/desktops/kde-4.10/kde-package/default.nix
+++ b/pkgs/desktops/kde-4.10/kde-package/default.nix
@@ -1,5 +1,5 @@
 { callPackage, runCommand, stdenv, fetchurl, qt4, cmake, automoc4
-, release, ignoreList, extraSubpkgs
+, release, branch, ignoreList, extraSubpkgs
 }:
 
 let
@@ -19,6 +19,7 @@ rec {
   # Default meta attribute
   defMeta = {
     homepage = http://www.kde.org;
+    inherit branch;
     platforms = stdenv.lib.platforms.linux;
     inherit (qt4.meta) maintainers;
   };

--- a/pkgs/desktops/kde-4.10/l10n/default.nix
+++ b/pkgs/desktops/kde-4.10/l10n/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kdelibs, gettext, release, stable }:
+{ stdenv, fetchurl, kdelibs, gettext, release, branch, stable }:
 
 let
 
@@ -22,6 +22,7 @@ let
 
       meta = {
         description = "KDE translation for ${lang}";
+        inherit branch;
         license = "GPL";
         platforms = stdenv.lib.platforms.linux;
         inherit (kdelibs.meta) maintainers homepage;

--- a/pkgs/desktops/kde-4.11/default.nix
+++ b/pkgs/desktops/kde-4.11/default.nix
@@ -1,9 +1,11 @@
 { callPackage, callPackageOrig, stdenv, qt48, release ? "4.11.5" }:
 
 let
+  branch = "4.11";
+
   # Need callPackageOrig to avoid infinite cycle
   kde = callPackageOrig ./kde-package {
-    inherit release ignoreList extraSubpkgs callPackage;
+    inherit release branch ignoreList extraSubpkgs callPackage;
   };
 
   # The list of igored individual modules
@@ -36,7 +38,7 @@ kde.modules // kde.individual //
   full = stdenv.lib.attrValues kde.modules;
 
   l10n = callPackage ./l10n {
-    inherit release;
+    inherit release branch;
     inherit (kde.manifest) stable;
   };
 }

--- a/pkgs/desktops/kde-4.11/kde-package/default.nix
+++ b/pkgs/desktops/kde-4.11/kde-package/default.nix
@@ -1,5 +1,5 @@
 { callPackage, runCommand, stdenv, fetchurl, qt4, cmake, automoc4
-, release, ignoreList, extraSubpkgs
+, release, branch, ignoreList, extraSubpkgs
 }:
 
 let
@@ -19,6 +19,7 @@ rec {
   # Default meta attribute
   defMeta = {
     homepage = http://www.kde.org;
+    inherit branch;
     platforms = stdenv.lib.platforms.linux;
     inherit (qt4.meta) maintainers;
   };

--- a/pkgs/desktops/kde-4.11/l10n/default.nix
+++ b/pkgs/desktops/kde-4.11/l10n/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kdelibs, gettext, release, stable }:
+{ stdenv, fetchurl, kdelibs, gettext, release, branch, stable }:
 
 let
 
@@ -22,6 +22,7 @@ let
 
       meta = {
         description = "KDE translation for ${lang}";
+        inherit branch;
         license = "GPL";
         platforms = stdenv.lib.platforms.linux;
         inherit (kdelibs.meta) maintainers homepage;

--- a/pkgs/desktops/kde-4.12/default.nix
+++ b/pkgs/desktops/kde-4.12/default.nix
@@ -1,9 +1,11 @@
 { callPackage, callPackageOrig, stdenv, qt48, release ? "4.12.2" }:
 
 let
+  branch = "4.12";
+
   # Need callPackageOrig to avoid infinite cycle
   kde = callPackageOrig ./kde-package {
-    inherit release ignoreList extraSubpkgs callPackage;
+    inherit release branch ignoreList extraSubpkgs callPackage;
   };
 
   # The list of igored individual modules
@@ -36,7 +38,7 @@ kde.modules // kde.individual //
   full = stdenv.lib.attrValues kde.modules;
 
   l10n = callPackage ./l10n {
-    inherit release;
+    inherit release branch;
     inherit (kde.manifest) stable;
   };
 }

--- a/pkgs/desktops/kde-4.12/kde-package/default.nix
+++ b/pkgs/desktops/kde-4.12/kde-package/default.nix
@@ -1,5 +1,5 @@
 { callPackage, runCommand, stdenv, fetchurl, qt4, cmake, automoc4
-, release, ignoreList, extraSubpkgs
+, release, branch, ignoreList, extraSubpkgs
 }:
 
 let
@@ -19,6 +19,7 @@ rec {
   # Default meta attribute
   defMeta = {
     homepage = http://www.kde.org;
+    inherit branch;
     platforms = stdenv.lib.platforms.linux;
     inherit (qt4.meta) maintainers;
   };

--- a/pkgs/desktops/kde-4.12/l10n/default.nix
+++ b/pkgs/desktops/kde-4.12/l10n/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kdelibs, gettext, release, stable }:
+{ stdenv, fetchurl, kdelibs, gettext, release, branch, stable }:
 
 let
 
@@ -22,6 +22,7 @@ let
 
       meta = {
         description = "KDE translation for ${lang}";
+        inherit branch;
         license = "GPL";
         platforms = stdenv.lib.platforms.linux;
         inherit (kdelibs.meta) maintainers homepage;

--- a/pkgs/development/libraries/keybinder/default.nix
+++ b/pkgs/development/libraries/keybinder/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, gnome_common
+, gtk_doc, gtk2, python, pygtk, pygobject, lua
+}:
+
+stdenv.mkDerivation rec {
+  name = "keybinder-${version}";
+  version = "0.3.0";
+
+  src = fetchurl {
+    name = "${name}.tar.gz";
+    url = "https://github.com/engla/keybinder/archive/v${version}.tar.gz";
+    sha256 = "0kkplz5snycik5xknwq1s8rnmls3qsp32z09mdpmaacydcw7g3cf";
+  };
+
+  buildInputs = [
+    autoconf automake libtool pkgconfig gnome_common gtk_doc gtk2
+    python pygtk pygobject lua
+  ];
+
+  preConfigure = ''
+    ./autogen.sh --prefix="$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Library for registering global key bindings";
+    longDescription = ''
+      keybinder is a library for registering global keyboard shortcuts.
+      Keybinder works with GTK-based applications using the X Window System.
+
+      The library contains:
+
+      * A C library, ``libkeybinder``
+      * Gobject-Introspection (gir)  generated bindings
+      * Lua bindings, ``lua-keybinder``
+      * Python bindings, ``python-keybinder``
+      * An ``examples`` directory with programs in C, Lua, Python and Vala.
+    '';
+    homepage = https://github.com/engla/keybinder/;
+    license = licenses.gpl2Plus;
+    platform = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/development/tools/misc/autoconf/2.13.nix
+++ b/pkgs/development/tools/misc/autoconf/2.13.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.gnu.org/software/autoconf/;
     description = "Part of the GNU Build System";
+    branch = "2.13";
 
     longDescription = ''
       GNU Autoconf is an extensible package of M4 macros that produce

--- a/pkgs/development/tools/misc/teensy/default.nix
+++ b/pkgs/development/tools/misc/teensy/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, unzip, libusb }:
+let
+  version = "2.1";
+in
+stdenv.mkDerivation {
+  name = "teensy-loader-${version}";
+  src = fetchurl {
+    url = "http://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip";
+    sha256 = "0iidj3q0l2hds1gaadnwgni4qdgk6r0nv101986jxda8cw6h9zfs";
+  };
+
+  buildInputs = [ unzip libusb ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v teensy_loader_cli $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    description = "Firmware uploader for the Teensy microcontroller board";
+    homepage = http://www.pjrc.com/teensy/;
+    maintainers = with maintainers; [ the-kenny ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/gradm/default.nix
+++ b/pkgs/os-specific/linux/gradm/default.nix
@@ -1,0 +1,53 @@
+{ fetchurl, stdenv, bison, flex, pam }:
+
+stdenv.mkDerivation rec {
+  name    = "gradm";
+  version = "3.0-201401291757";
+
+  src  = fetchurl {
+    url    = "http://grsecurity.net/stable/${name}-${version}.tar.gz";
+    sha256 = "19p7kaqbvf41scc63n69b5v5xzpw3mbf5zy691rply8hdm7736cw";
+  };
+
+  buildInputs =
+    [ gcc coreutils pam flex bison
+      findutils binutils bash
+    ];
+
+  preBuild = ''
+    substituteInPlace ./Makefile --replace "/usr/include/security/pam_" "${pam}/include/security/pam_"
+    substituteInPlace ./gradm_defs.h --replace "/sbin/grlearn"   "$out/sbin/grlearn"
+    substituteInPlace ./gradm_defs.h --replace "/sbin/gradm"     "$out/sbin/gradm"
+    substituteInPlace ./gradm_defs.h --replace "/sbin/gradm_pam" "$out/sbin/gradm_pam"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    cat > $out/lib/udev/rules.d/80-grsec.rules <<EOF
+    ACTION!="add|change", GOTO="permissions_end"
+    KERNEL=="grsec",          MODE="0622"
+    LABEL="permissions_end"
+    EOF
+  '';
+
+  makeFlags =
+    [ "DESTDIR=$(out)"
+      "CC=${gcc}/bin/gcc"
+      "FLEX=${flex}/bin/flex"
+      "BISON=${bison}/bin/bison"
+      "FIND=${findutils}/bin/find"
+      "STRIP=${binutils}/bin/strip"
+      "INSTALL=${coreutils}/bin/install"
+      "MANDIR=/share/man"
+      "MKNOD=true"
+    ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "grsecurity RBAC administration and policy analysis utility";
+    homepage    = "https://grsecurity.net";
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -1,0 +1,22 @@
+{ fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "pax-utils";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "http://dev.gentoo.org/~vapier/dist/${name}-${version}.tar.xz";
+    sha256 = "111vmwn0ikrmy3s0w3rzpbzwrphawljrmcjya0isg5yam7lwxi0s";
+  };
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    description = "A suite of tools for PaX/grsecurity.";
+    homepage = "http://dev.gentoo.org/~vapier/dist/";
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/paxctl/default.nix
+++ b/pkgs/os-specific/linux/paxctl/default.nix
@@ -1,0 +1,26 @@
+{ fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "paxctl";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://pax.grsecurity.net/${name}-${version}.tar.bz2";
+    sha256 = "1j6dg6wd1v7na5i4xj8zmbff0mdqdnw6cvqy0rsbz5anra27f1zp";
+  };
+
+  preBuild = ''
+    sed "s|--owner 0 --group 0||g" -i Makefile
+  '';
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "MANDIR=share/man/man1"
+  ];
+
+  meta = {
+    description = "A tool for controlling PaX flags on a per binary basis";
+    homepage = "https://pax.grsecurity.net";
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Apache HTTPD, the world's most popular web server";
+    branch      = "2.2";
     homepage    = http://httpd.apache.org/;
     license     = stdenv.lib.licenses.asl20;
     platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, python, zip }:
 
 let
-  version = "2014.02.13";
+  version = "2014.02.17";
 in
 stdenv.mkDerivation rec {
   name = "youtube-dl-${version}";
 
   src = fetchurl {
     url = "http://youtube-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "0l88n1qrhjj2dvxlpd4hpqrdpxihqv3y9mrf1jgra3jyvb9pbnxq";
+    sha256 = "0yv13k8cqrv3i8zv5ad286niwxk5a4ggngcx6b0d6kg7c03rkgkq";
   };
 
   buildInputs = [ python ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8107,11 +8107,6 @@ let
     inherit (gnome) GConf;
   };
 
-  gnome_terminator = callPackage ../applications/misc/gnome_terminator {
-    vte = gnome.vte.override { pythonSupport = true; };
-    inherit (pythonPackages) notify;
-  };
-
   googleearth = callPackage_i686 ../applications/misc/googleearth { };
 
   google_talk_plugin = callPackage ../applications/networking/browsers/mozilla-plugins/google-talk-plugin {
@@ -8911,6 +8906,11 @@ let
   telepathy_rakia = callPackage ../applications/networking/instant-messengers/telepathy/rakia { };
 
   telepathy_salut = callPackage ../applications/networking/instant-messengers/telepathy/salut {};
+
+  terminator = callPackage ../applications/misc/terminator {
+    vte = gnome.vte.override { pythonSupport = true; };
+    inherit (pythonPackages) notify;
+  };
 
   tesseract = callPackage ../applications/graphics/tesseract { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6986,6 +6986,8 @@ let
 
   pam_usb = callPackage ../os-specific/linux/pam_usb { };
 
+  paxctl = callPackage ../os-specific/linux/paxctl { };
+
   pcmciaUtils = callPackage ../os-specific/linux/pcmciautils {
     firmware = config.pcmciaUtils.firmware or [];
     config = config.pcmciaUtils.config or null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6578,6 +6578,8 @@ let
 
   gpm = callPackage ../servers/gpm { };
 
+  gradm = callPackage ../os-specific/linux/gradm { };
+
   hdparm = callPackage ../os-specific/linux/hdparm { };
 
   hibernate = callPackage ../os-specific/linux/hibernate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3771,6 +3771,8 @@ let
 
   tcptrack = callPackage ../development/tools/misc/tcptrack { };
 
+  teensy-loader = callPackage ../development/tools/misc/teensy { };
+
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.2.nix { };
   texinfo4 = texinfo413;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8109,6 +8109,7 @@ let
 
   gnome_terminator = callPackage ../applications/misc/gnome_terminator {
     vte = gnome.vte.override { pythonSupport = true; };
+    inherit (pythonPackages) notify;
   };
 
   googleearth = callPackage_i686 ../applications/misc/googleearth { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4547,6 +4547,12 @@ let
 
   judy = callPackage ../development/libraries/judy { };
 
+  keybinder = callPackage ../development/libraries/keybinder {
+    inherit (gnome2) gnome_common;
+    automake = automake111x;
+    lua = lua5_1;
+  };
+
   krb5 = callPackage ../development/libraries/kerberos/krb5.nix { };
 
   lcms = lcms1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6988,6 +6988,8 @@ let
 
   paxctl = callPackage ../os-specific/linux/paxctl { };
 
+  pax_utils = callPackage ../os-specific/linux/pax-utils { };
+
   pcmciaUtils = callPackage ../os-specific/linux/pcmciautils {
     firmware = config.pcmciaUtils.firmware or [];
     config = config.pcmciaUtils.config or null;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3053,10 +3053,10 @@ let self = _self // overrides; _self = with self; {
   };
 
   ExceptionClass = buildPerlPackage rec {
-    name = "Exception-Class-1.30";
+    name = "Exception-Class-1.37";
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
-      sha256 = "54e256fdb317c1736c2c257fa63d5b87cfb382870711b24937c36eb5171b3154";
+      sha256 = "1p6f20fi82mr5bz7d2c7nqh0322r8n2kszfw37c77g8b1b4r72w3";
     };
     propagatedBuildInputs = [ ClassDataInheritable DevelStackTrace ];
   };


### PR DESCRIPTION
This adds 3 packages you might typically want with a grsec deployment.

The pieces here basically overlap some of with #1187 (which I found after I wrote my own `gradm` package). This also installs the udev rules for `gradm`.

Unlike the work by @wizeman it doesn't attempt to properly mark JIT binaries via `paxctl` - it only adds the packages. But I think there's no reason to hold back the packages even without this.

And `pax-utils` is from the Hardened Gentoo project, and includes some useful utilities (like `pspax`).
