### PR TITLE
i18n.consoleKeyMap: Accept string or path.

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -53,7 +53,11 @@ in
       };
 
       consoleKeyMap = mkOption {
-        type = types.str;
+        type = mkOptionType {
+          name = "string or path";
+          check = t: (isString t || types.path.check t);
+        };
+
         default = "us";
         example = "fr";
         description = ''


### PR DESCRIPTION
`i18n.consoleKeyMap` maps to `KEYMAP=...` in `vconsole.conf` and `loadkeymap`
in stage1. Both of these accept paths to a keymap file in addition to
a string containing the name of the keymap.

With this commit, it's possible to use your own keymap via:

`i18n.consoleKeyMap = ./path/to/something.kmap`

which will be used in stage1 and all virtual terminals.
