### PR TITLE
libgee: Update to 0.13.90 and enable checks

### DIFF
--- a/pkgs/desktops/gnome-3/core/libgee/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgee/default.nix
@@ -1,12 +1,14 @@
 { stdenv, fetchurl, autoconf, vala, pkgconfig, glib, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  name = "libgee-0.13.4";
+  name = "libgee-0.13.90";
 
   src = fetchurl {
     url = "https://download.gnome.org/sources/libgee/0.13/${name}.tar.xz";
-    sha256 = "1gzyx8gy5m6r8km3xbb1kszz0v3p9vsbzwb78pf3fw122gwbjj4k";
+    sha256 = "9496f8fb249f7850db32b50e8675998db8b5276d4568cbf043faa7e745d7b7d6";
   };
+
+  doCheck = true;
 
   patches = [ ./fix_introspection_paths.patch ];
 


### PR DESCRIPTION
Version 0.13.90 fixes a bug in the tests caused by randomness. For this reason, other than updating, I'm also enabling make check.
