### PR TITLE
grsecurity: add gradm, paxctl, and pax-utils (take #2)

### DIFF
--- a/pkgs/os-specific/linux/gradm/default.nix
+++ b/pkgs/os-specific/linux/gradm/default.nix
@@ -1,0 +1,51 @@
+{ fetchurl, stdenv, bison, flex, pam,
+  gcc, coreutils, findutils, binutils, bash }:
+
+stdenv.mkDerivation rec {
+  name    = "gradm-${version}";
+  version = "3.0-201401291757";
+
+  src  = fetchurl {
+    url    = "http://grsecurity.net/stable/${name}-${version}.tar.gz";
+    sha256 = "19p7kaqbvf41scc63n69b5v5xzpw3mbf5zy691rply8hdm7736cw";
+  };
+
+  buildInputs = [ gcc coreutils findutils binutils pam flex bison bash ];
+  preBuild = ''
+    substituteInPlace ./Makefile --replace "/usr/include/security/pam_" "${pam}/include/security/pam_"
+    substituteInPlace ./gradm_defs.h --replace "/sbin/grlearn"   "$out/sbin/grlearn"
+    substituteInPlace ./gradm_defs.h --replace "/sbin/gradm"     "$out/sbin/gradm"
+    substituteInPlace ./gradm_defs.h --replace "/sbin/gradm_pam" "$out/sbin/gradm_pam"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    cat > $out/lib/udev/rules.d/80-grsec.rules <<EOF
+    ACTION!="add|change", GOTO="permissions_end"
+    KERNEL=="grsec",          MODE="0622"
+    LABEL="permissions_end"
+    EOF
+  '';
+
+  makeFlags =
+    [ "DESTDIR=$(out)"
+      "CC=${gcc}/bin/gcc"
+      "FLEX=${flex}/bin/flex"
+      "BISON=${bison}/bin/bison"
+      "FIND=${findutils}/bin/find"
+      "STRIP=${binutils}/bin/strip"
+      "INSTALL=${coreutils}/bin/install"
+      "MANDIR=/share/man"
+      "MKNOD=true"
+    ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "grsecurity RBAC administration and policy analysis utility";
+    homepage    = "https://grsecurity.net";
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -1,0 +1,24 @@
+{ fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "pax-utils-${version}";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "http://dev.gentoo.org/~vapier/dist/${name}-${version}.tar.xz";
+    sha256 = "111vmwn0ikrmy3s0w3rzpbzwrphawljrmcjya0isg5yam7lwxi0s";
+  };
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    description = "A suite of tools for PaX/grsecurity";
+    homepage    = "http://dev.gentoo.org/~vapier/dist/";
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/os-specific/linux/paxctl/default.nix
+++ b/pkgs/os-specific/linux/paxctl/default.nix
@@ -1,0 +1,28 @@
+{ fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "paxctl-${version}";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://pax.grsecurity.net/${name}-${version}.tar.bz2";
+    sha256 = "1j6dg6wd1v7na5i4xj8zmbff0mdqdnw6cvqy0rsbz5anra27f1zp";
+  };
+
+  preBuild = ''
+    sed "s|--owner 0 --group 0||g" -i Makefile
+  '';
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "MANDIR=share/man/man1"
+  ];
+
+  meta = {
+    description = "A tool for controlling PaX flags on a per binary basis";
+    homepage    = "https://pax.grsecurity.net";
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6986,6 +6986,8 @@ let
 
   pam_usb = callPackage ../os-specific/linux/pam_usb { };
 
+  paxctl = callPackage ../os-specific/linux/paxctl { };
+
   pcmciaUtils = callPackage ../os-specific/linux/pcmciautils {
     firmware = config.pcmciaUtils.firmware or [];
     config = config.pcmciaUtils.config or null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6578,6 +6578,8 @@ let
 
   gpm = callPackage ../servers/gpm { };
 
+  gradm = callPackage ../os-specific/linux/gradm { };
+
   hdparm = callPackage ../os-specific/linux/hdparm { };
 
   hibernate = callPackage ../os-specific/linux/hibernate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6988,6 +6988,8 @@ let
 
   paxctl = callPackage ../os-specific/linux/paxctl { };
 
+  pax-utils = callPackage ../os-specific/linux/pax-utils { };
+
   pcmciaUtils = callPackage ../os-specific/linux/pcmciautils {
     firmware = config.pcmciaUtils.firmware or [];
     config = config.pcmciaUtils.config or null;


### PR DESCRIPTION
Per the #1765 (hopefully without GitHub eating my pull requests again).
- I cleaned up the 'meta' info to always reside at the bottom per recommendation.
- Per point two by @wizeman - the 'gcc' etc `buildInputs` seem to be required. Especially for GCC, because the Makefile for `gradm` is hard-coded to otherwise use `/usr/bin/gcc` it seems, which results in `ld` failing due to an impure link at the end. The makefile is a bit hacky unfortunately so IMO it's safer to properly specify all the tools it needs explicitly.

Otherwise I think this is good to go.

---

This adds 3 packages you might typically want with a grsec deployment.

The pieces here basically overlap some of with #1187 (which I found after I wrote my own `gradm` package). This also installs the udev rules for `gradm`.

Unlike the work by @wizeman it doesn't attempt to properly mark JIT binaries via `paxctl` - it only adds the packages. But I think there's no reason to hold back the packages even without this.

And `pax-utils` is from the Hardened Gentoo project, and includes some useful utilities (like `pspax`).
