### PR TITLE
gnome-icon-theme-symbolic and yelp update

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-icon-theme-symbolic/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-icon-theme-symbolic/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, gnome3, iconnamingutils, gtk }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-icon-theme-symbolic-3.10.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-icon-theme-symbolic/3.10/${name}.tar.xz";
+    sha256 = "344e88e5f9dac3184bf012d9bac972110df2133b93d76f2ad128d4c9cbf41412";
+  };
+
+  configureFlags = "--enable-icon-mapping";
+
+  # Avoid postinstall make hooks
+  installPhase = ''
+    make install-exec-am install-data-local install-pkgconfigDATA
+    make -C src install
+  '';
+
+  buildInputs = [ pkgconfig iconnamingutils gtk];
+
+  meta = with stdenv.lib; {
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/yelp/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, intltool, fetchurl, webkitgtk, pkgconfig, gtk3, glib, file
-, bash, makeWrapper, itstool, libxml2, libxslt, gnome3, icu }:
-
-# TODO: icons and theme still does not work
-# use packaged gnome3.gnome_icon_theme_symbolic 
+{ stdenv, intltool, fetchurl, webkitgtk, pkgconfig, gtk3, glib
+, file, librsvg, hicolor_icon_theme, gnome3, gdk_pixbuf
+, bash, makeWrapper, itstool, libxml2, libxslt, icu  }:
 
 stdenv.mkDerivation rec {
   name = "yelp-3.10.1";
@@ -12,25 +10,23 @@ stdenv.mkDerivation rec {
     sha256 = "17736479b7d0b1128c7d6cb3073f2b09e4bbc82670731b2a0d3a3219a520f816";
   };
 
-  configureFlags = [ "--disable-static" ];
-
-  doCheck = true;
-
-  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedUserEnvPkgs = [ librsvg gdk_pixbuf gnome3.gnome_themes_standard
+                            gnome3.gnome_icon_theme hicolor_icon_theme
+                            gnome3.gnome_icon_theme_symbolic ];
 
   preConfigure = "substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file";
 
-  buildInputs = [ pkgconfig gtk3 glib webkitgtk intltool itstool libxml2 libxslt icu file
-                  gnome3.gsettings_desktop_schemas makeWrapper gnome3.yelp_xsl ];
+  buildInputs = [ pkgconfig gtk3 glib webkitgtk intltool itstool
+                  libxml2 libxslt icu file makeWrapper gnome3.yelp_xsl
+                  gnome3.gsettings_desktop_schemas ];
 
   installFlags = "gsettingsschemadir=\${out}/share/${name}/glib-2.0/schemas/";
 
   postInstall = ''
+    cat ${gdk_pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache ${librsvg}/lib/gdk-pixbuf/loaders.cache > $out/loaders.cache
     wrapProgram "$out/bin/yelp" \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/${name}"
-  '';
-
-  preFixup = ''
+      --set GDK_PIXBUF_MODULE_FILE `readlink -e $out/loaders.cache` \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/:${gnome3.gnome_themes_standard}/share:${gnome3.gnome_icon_theme_symbolic}/share:${gnome3.yelp_xsl}/share/yelp-xsl:${gnome3.gnome_icon_theme}/share:${hicolor_icon_theme}/share:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/${name}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -42,6 +42,8 @@ rec {
 
   gnome_icon_theme = callPackage ./core/gnome-icon-theme { };
 
+  gnome_icon_theme_symbolic = callPackage ./core/gnome-icon-theme-symbolic { };
+
   gnome-menus = callPackage ./core/gnome-menus { };
 
   gnome_keyring = callPackage ./core/gnome-keyring { };


### PR DESCRIPTION
Add new gnome-icon-theme-symbolic package. Update yelp to show icons in the application as a starting point for further gnome apps refactoring.
