### PR TITLE
Fix obex-data-server so it builds

### DIFF
--- a/pkgs/tools/bluetooth/obex-data-server/default.nix
+++ b/pkgs/tools/bluetooth/obex-data-server/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libusb, glib, dbus_glib, bluez, openobex }:
+{ stdenv, fetchurl, pkgconfig, libusb, glib, dbus_glib, bluez, openobex, dbus_libs }:
    
 stdenv.mkDerivation rec {
   name = "obex-data-server-0.4.6";
@@ -8,7 +8,14 @@ stdenv.mkDerivation rec {
     sha256 = "0kq940wqs9j8qjnl58d6l3zhx0jaszci356xprx23l6nvdfld6dk";
   };
 
-  buildInputs = [ pkgconfig libusb glib dbus_glib bluez openobex ];
+  buildInputs = [ pkgconfig libusb glib dbus_glib bluez openobex dbus_libs ];
+
+  patches = [ ./obex-data-server-0.4.6-build-fixes-1.patch ];
+
+  preConfigure = ''
+  addToSearchPath PKG_CONFIG_PATH ${openobex}/lib64/pkgconfig
+  export PKG_CONFIG_PATH="${dbus_libs}/lib/pkgconfig:$PKG_CONFIG_PATH"
+  '';
 
   meta = {
     homepage = http://wiki.muiline.com/obex-data-server;

--- a/pkgs/tools/bluetooth/obex-data-server/obex-data-server-0.4.6-build-fixes-1.patch
+++ b/pkgs/tools/bluetooth/obex-data-server/obex-data-server-0.4.6-build-fixes-1.patch
@@ -1,0 +1,56 @@
+Submitted By:            Armin K. <krejzi at email dot com>
+Date:                    2012-07-06
+Initial Package Version: 0.4.6
+Upstream Status:         Unknown
+Origin:                  Self
+Description:             Some build fixes.
+
+--- obex-data-server.orig/src/ods-obex.c	2011-02-10 10:14:42.000000000 +0100
++++ obex-data-server/src/ods-obex.c	2012-07-06 20:10:09.208712553 +0200
+@@ -412,7 +412,7 @@
+ 		goto err;
+ 	}
+ 
+-	interfaces_num = OBEX_FindInterfaces(obex_context->obex_handle, &obex_intf);
++	interfaces_num = OBEX_EnumerateInterfaces(obex_context->obex_handle);
+ 	if (intf_num >= interfaces_num) {
+ 		g_set_error (error, ODS_ERROR, ODS_ERROR_FAILED, "Invalid interface number");
+ 		goto err;
+@@ -1928,7 +1928,7 @@
+ 	gchar	*uname;
+ 	gsize	uname_len;
+ 
+-	if (action != OBEX_ACTION_SETPERM)
++	if (action != 0x03)
+ 		g_assert (src && dst);
+ 
+ 	object = OBEX_ObjectNew (obex_context->obex_handle, OBEX_CMD_ACTION);
+@@ -1974,7 +1974,7 @@
+ 	                      OBEX_HDR_ACTION_ID, hv, 1, 0);
+ 
+ 	/* permissions header */
+-	if (action == OBEX_ACTION_SETPERM) {
++	if (action == 0x03) {
+ 		hv.bq4 = perms;
+ 		ret = OBEX_ObjectAddHeader (obex_context->obex_handle, object,
+ 		                            OBEX_HDR_PERMISSIONS, hv, 4, 0);
+--- obex-data-server.orig/src/ods-session.c	2011-02-10 09:57:31.000000000 +0100
++++ obex-data-server/src/ods-session.c	2012-07-06 20:10:09.208712553 +0200
+@@ -1761,7 +1761,7 @@
+                          DBusGMethodInvocation *context)
+ {
+ 	return ods_session_remote_action (session, remote_source,
+-	                                  remote_destination, OBEX_ACTION_COPY,
++	                                  remote_destination, 0x00,
+ 	                                  context);
+ }
+ 
+@@ -1772,7 +1772,7 @@
+                          DBusGMethodInvocation *context)
+ {
+ 	return ods_session_remote_action (session, remote_source,
+-	                                  remote_destination, OBEX_ACTION_MOVE,
++	                                  remote_destination, 0x01,
+ 	                                  context);
+ }
+ 


### PR DESCRIPTION
This is a slightly hacky fix to obex-data-server, which deals with the following issues:
1. openobex has its pkg-config file in lib64/pkgconfig; nix's pkgconfig setup only searches lib/pkgconfig. This could also be fixed in pkgs/development/tools/misc/pkgconfig/setup-hook.sh, so it would apply for all packages.
2. dbus_glib's pkg-config file has a Requirement onto dbus-1, which should be satisfied by the pkg-config in dbus-libs; the dbus-daemon package also has a pkg-config called dbus1, which will often end up in /run/current-system which is at the front of $PKG_CONFIG_PATH. This breaks the compile because the includes provided by dbus-daemon are not sufficient. This is fixed by wangling the dbus_libs pkgconfig onto the front of $PKG_CONFIG_PATH
3. the downloaded version of obex-data-server doesn't build against the suggested openobex anyway; the included patch fixes it so that it does. I yanked the patch from [here](http://www.linuxfromscratch.org/blfs/view/svn/general/obex-data-server.html)
