### PR TITLE
checksec: version 1.5

### DIFF
--- a/pkgs/os-specific/linux/checksec/0001-attempt-to-modprobe-config-before-checking-kernel.patch
+++ b/pkgs/os-specific/linux/checksec/0001-attempt-to-modprobe-config-before-checking-kernel.patch
@@ -1,0 +1,27 @@
+From 6503848d9e0eb009e5f462116a963beacb208930 Mon Sep 17 00:00:00 2001
+From: Austin Seipp <aseipp@pobox.com>
+Date: Thu, 20 Feb 2014 00:11:44 -0600
+Subject: [PATCH] attempt to 'modprobe config' before checking kernel
+
+Signed-off-by: Austin Seipp <aseipp@pobox.com>
+---
+ checksec.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/checksec.sh b/checksec.sh
+index dd1f72e..63acc29 100644
+--- a/checksec.sh
++++ b/checksec.sh
+@@ -337,7 +337,8 @@ kernelcheck() {
+   printf "  userspace processes, this option lists the status of kernel configuration\n"
+   printf "  options that harden the kernel itself against attack.\n\n"
+   printf "  Kernel config: "
+- 
++
++  modprobe configs 2> /dev/null
+   if [ -f /proc/config.gz ] ; then
+     kconfig="zcat /proc/config.gz"
+     printf "\033[32m/proc/config.gz\033[m\n\n"
+-- 
+1.8.3.2
+

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, file, findutils, elfutils, glibc }:
+
+stdenv.mkDerivation rec {
+  name = "checksec-${version}";
+  version = "1.5";
+  src = fetchurl {
+    url    = "http://www.trapkit.de/tools/checksec.sh";
+    sha256 = "0iq9v568mk7g7ksa1939g5f5sx7ffq8s8n2ncvphvlckjgysgf3p";
+  };
+
+  patches = [ ./0001-attempt-to-modprobe-config-before-checking-kernel.patch ];
+
+  unpackPhase = ''
+    mkdir ${name}-${version}
+    cp $src ${name}-${version}/checksec.sh
+    cd ${name}-${version}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp checksec.sh $out/bin/checksec
+    chmod +x $out/bin/checksec
+    substituteInPlace $out/bin/checksec --replace /bin/bash ${stdenv.shell}
+    substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc}/lib/libc.so.6
+    substituteInPlace $out/bin/checksec --replace find ${findutils}/bin/find
+    substituteInPlace $out/bin/checksec --replace "file $" "${file}/bin/file $"
+    substituteInPlace $out/bin/checksec --replace "xargs file" "xargs ${file}/bin/file"
+    substituteInPlace $out/bin/checksec --replace " readelf -" " ${elfutils}/bin/readelf -"
+    substituteInPlace $out/bin/checksec --replace "(readelf -" "(${elfutils}/bin/readelf -"
+    substituteInPlace $out/bin/checksec --replace "command_exists readelf" "command_exists ${elfutils}/bin/readelf"
+  '';
+
+  phases = "unpackPhase patchPhase installPhase";
+
+  meta = {
+    description = "A tool for checking security bits on executables";
+    platforms   = stdenv.lib.platforms.linux;
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6504,6 +6504,8 @@ let
 
   checkpolicy = callPackage ../os-specific/linux/checkpolicy { };
 
+  checksec = callPackage ../os-specific/linux/checksec { };
+
   cifs_utils = callPackage ../os-specific/linux/cifs-utils { };
 
   conky = callPackage ../os-specific/linux/conky { };


### PR DESCRIPTION
This adds support for the `checksec` utility, which makes it convenient and easy to see how hardened the applications on your system are. Unfortunately there's no versioned URL.
