### PR TITLE
Improve nixos-generate-config filesystem generation

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -305,7 +305,15 @@ EOF
   fileSystems.\"$mountPoint\" =
     { device = \"$device\";
       fsType = \"$fsType\";
-      options = \"${\join ",", uniq(@extraOptions, @superOptions, @mountOptions)}\";
+EOF
+
+    if (scalar @extraOptions > 0) {
+      $fileSystems .= <<EOF;
+      options = \"${\join ",", uniq(@extraOptions)}\";
+EOF
+    }
+
+    $fileSystems .= <<EOF;
     };
 
 EOF

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -256,7 +256,7 @@ foreach my $fs (read_file("/proc/self/mountinfo")) {
     $mountPoint = "/" if $mountPoint eq "";
 
     # Skip special filesystems.
-    next if in($mountPoint, "/proc") || in($mountPoint, "/dev") || in($mountPoint, "/sys") || in($mountPoint, "/run");
+    next if in($mountPoint, "/proc") || in($mountPoint, "/dev") || in($mountPoint, "/sys") || in($mountPoint, "/run") || $mountPoint eq "/var/lib/nfs/rpc_pipefs";
 
     # Skip the optional fields.
     my $n = 6; $n++ while $fields[$n] ne "-"; $n++;


### PR DESCRIPTION
This pull request includes 2 changes for nixos-generate-config:
- Don't generate /var/lib/nfs/rpc_pipefs filesystem. This is automatically mounted if the system has support for NFS, so there's no need to put it into /etc/nixos/hardware-configuration.nix.
- Don't generate filesystem options.

As for the latter, currently, nixos-generate-config generates mount options, which are taken from the current mounted filesystems and written into hardware-configuration.nix.

The problem is, most of these options are usually just defaults chosen by the kernel. So if you upgrade your kernel and the default mount options have changed (such as it happened in the past with "atime -> relatime", or ext4's "barrier=0 -> barrier=1"), you will keep using the old defaults (the ones corresponding to the kernel being used at the time hardware-configuration.nix was generated) instead of the new ones compiled into the current kernel.

Most likely the sysadmin doesn't care about most of these options (e.g. "relatime", "thread_pool=8" in btrfs, ...) and instead he just wants to use the best defaults for the current kernel, so I've changed the code not to generate the options (the only exceptions are "loop" for loop devices and "bind" for bind mounts, as they are required mount options).

After this change, if the sysadmin wants to mount some filesystem with a specific, non-default mount option, he should specify it in /etc/nixos/configuration.nix.
