### PR TITLE
kernel: stable updates, grsecurity patch updates

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.10.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.10.30";
+  version = "3.10.31";
   extraMeta.branch = "3.10";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "0a9x27g026gvy64w2xkpkdf3kzjfzzgy0kgikdyk604zdz4ha2hm";
+    sha256 = "1nz8203avjjin3sivx6h6ddsramk37vp02g9lw2ix3hxji0lsz1m";
   };
 
   features.iwlwifi = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.12.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.12.11";
+  version = "3.12.12";
   extraMeta.branch = "3.12";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "1zqwfzb0hmx69caw54np6if2nybmin4mhxj9milfflc6z40fn06r";
+    sha256 = "0wndjj5bdjfl4i9s5mj9wylhspygsvnl3pnwps6d65q2jm813lrv";
   };
 
   features.iwlwifi = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.13.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.13.3";
+  version = "3.13.4";
   extraMeta.branch = "3.13";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "0x277h0ccdjivi16w20aj59ncazr7zs07zprazm0ph4qyffv0r4g";
+    sha256 = "0hzxr8gsafnyc96x5p2clgi827ahidk1hma0yd48gdx9dhynrq2r";
   };
 
   features.iwlwifi = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.4.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.4.80";
+  version = "3.4.81";
   extraMeta.branch = "3.4";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "1vma3bxydryhcg7iimndq4rbpzbpjvnq7qa5md6wm6iill011pil";
+    sha256 = "17m8b9wcsz8ryakhk8v85iknylkjlbsx69wkj1rbvqi2f1sjihx5";
   };
 
   features.iwlwifi = true;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -81,19 +81,19 @@ rec {
   grsecurity_3_0_3_2_55 =
     { name = "grsecurity-3.0-3.2.55";
       patch = fetchurl {
-        url = http://grsecurity.net/stable/grsecurity-3.0-3.2.55-201402192249.patch;
-        sha256 = "16q531j9gphqgqw6v0g45l9hzpz6gnsmh72b9435xs3pjwz1wp44";
+        url = http://grsecurity.net/stable/grsecurity-3.0-3.2.55-201402201903.patch;
+        sha256 = "01kvs5z4ia5d5s4z8kfqyvh06qlw4v14hfll9n9qav6z8s5wyx10";
       };
       features.grsecurity = true;
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.54
       features.apparmor = true;
     };
 
-  grsecurity_3_0_3_13_3 =
-    { name = "grsecurity-3.0-3.13.3";
+  grsecurity_3_0_3_13_4 =
+    { name = "grsecurity-3.0-3.13.4";
       patch = fetchurl {
-        url = http://grsecurity.net/test/grsecurity-3.0-3.13.3-201402192252.patch;
-        sha256 = "09f2ym9hyfff83yvaflj7zzk78c2xw4xvn70bj1x3ybawv3sw83k";
+        url = http://grsecurity.net/test/grsecurity-3.0-3.13.4-201402201908.patch;
+        sha256 = "140rp57hzbjljhcgvdcczfhw0ghyw1x1ga2xv5ma2pk3dml158lh";
       };
       features.grsecurity = true;
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.13.2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6695,7 +6695,7 @@ let
   })) (args: grsecurityOverrider args));
 
   linux_3_13_grsecurity = lowPrio (lib.overrideDerivation (linux_3_13.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_13_3 kernelPatches.grsec_path ];
+    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_13_4 kernelPatches.grsec_path ];
     argsOverride = {
       modDirVersion = "${linux_3_13.modDirVersion}-grsec";
     };


### PR DESCRIPTION
This updates all of the stable kernels, as well as the grsecurity testing/stable patches bumping the testing kernel to 3.13.4 (Brad releases often, obviously).
