### PR TITLE
grsecurity: stable/testing updates

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -81,8 +81,8 @@ rec {
   grsecurity_3_0_3_2_55 =
     { name = "grsecurity-3.0-3.2.55";
       patch = fetchurl {
-        url = http://grsecurity.net/stable/grsecurity-3.0-3.2.55-201402201903.patch;
-        sha256 = "01kvs5z4ia5d5s4z8kfqyvh06qlw4v14hfll9n9qav6z8s5wyx10";
+        url = http://grsecurity.net/stable/grsecurity-3.0-3.2.55-201402221305.patch;
+        sha256 = "0g6mqbmjmqz4xh18cq5mn3d0zlzjlk76x0lmpwbrcapdcg5apcp5";
       };
       features.grsecurity = true;
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.54
@@ -92,8 +92,8 @@ rec {
   grsecurity_3_0_3_13_4 =
     { name = "grsecurity-3.0-3.13.4";
       patch = fetchurl {
-        url = http://grsecurity.net/test/grsecurity-3.0-3.13.4-201402201908.patch;
-        sha256 = "140rp57hzbjljhcgvdcczfhw0ghyw1x1ga2xv5ma2pk3dml158lh";
+        url = http://grsecurity.net/test/grsecurity-3.0-3.13.4-201402221308.patch;
+        sha256 = "0783an79485wwbsvcf8ggsmc2bwsbj1i7q6r8g22b19i9hzqmr64";
       };
       features.grsecurity = true;
       # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.13.2


### PR DESCRIPTION
- stable:  3.0-3.2.55-201402201903 -> 3.0-3.2.55-201402221305
- testing: 3.0-3.13.4-201402201908 -> 3.0-3.13.4-201402221308
