### PR TITLE
Restart nscd (if running) when interface comes up

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -70,6 +70,13 @@ let
     ${coreutils}/bin/rm -f $tmp $tmp.ns
   '';
 
+  nscdScript = writeScript "03nscd" ''
+    #!/bin/sh
+    if test "$2" = "up"; then
+      ${config.systemd.package}/bin/systemctl --quiet try-restart nscd.service
+    fi
+  '';
+
 in {
 
   ###### interface
@@ -135,6 +142,9 @@ in {
     environment.etc = [
       { source = ipUpScript;
         target = "NetworkManager/dispatcher.d/01nixos-ip-up";
+      }
+      { source = nscdScript;
+        target = "NetworkManager/dispatcher.d/03nscd";
       }
       { source = configFile;
         target = "NetworkManager/NetworkManager.conf";

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -70,6 +70,13 @@ let
     ${coreutils}/bin/rm -f $tmp $tmp.ns
   '';
 
+  nscdScript = writeScript "03nscd" ''
+    #!/bin/sh
+    if test "$2" = "up"; then
+      ${config.systemd.package}/bin/systemctl --quiet reload nscd.service
+    fi
+  '';
+
 in {
 
   ###### interface
@@ -135,6 +142,9 @@ in {
     environment.etc = [
       { source = ipUpScript;
         target = "NetworkManager/dispatcher.d/01nixos-ip-up";
+      }
+      { source = nscdScript;
+        target = "NetworkManager/dispatcher.d/03nscd";
       }
       { source = configFile;
         target = "NetworkManager/NetworkManager.conf";


### PR DESCRIPTION
DNS entries can become stale when switching networks. We need to invalidate nscd's hosts cache when a new network (interface) comes up. The simplest way to do this on NixOS is to simply restart the nscd service. This is what other distros running NetworkManager do; see e.g. http://lists.freedesktop.org/archives/systemd-devel/2012-April/004877.html
