### PR TITLE
gcc-wrapper: add 'cpp' wrapper

### DIFF
--- a/pkgs/build-support/gcc-cross-wrapper/builder.sh
+++ b/pkgs/build-support/gcc-cross-wrapper/builder.sh
@@ -87,6 +87,8 @@ mkGccWrapper $out/bin/$crossConfig-gcc $gccPath/$crossConfig-gcc
 mkGccWrapper $out/bin/$crossConfig-g++ $gccPath/$crossConfig-g++
 ln -s $crossConfig-g++ $out/bin/$crossConfig-c++
 
+mkGccWrapper $out/bin/$crossConfig-cpp $gccPath/$crossConfig-cpp
+
 mkGccWrapper $out/bin/$crossConfig-g77 $gccPath/$crossConfig-g77
 ln -s $crossConfig-g77 $out/bin/$crossConfig-f77
 

--- a/pkgs/build-support/gcc-wrapper/builder.sh
+++ b/pkgs/build-support/gcc-wrapper/builder.sh
@@ -154,6 +154,8 @@ then
     ln -sv g++ $out/bin/c++
 fi
 
+mkGccWrapper $out/bin/cpp $gccPath/cpp
+
 if mkGccWrapper $out/bin/gfortran $gccPath/gfortran
 then
     ln -sv gfortran $out/bin/g77


### PR DESCRIPTION
The gcc-wrapper doesn't wrap 'cpp'. This breaks some software (such as Buildroot) because the 'cpp' they get come from the non-wrapped gcc package which doesn't know about any standard include paths.

I also added wrapping for cross-'cpp', but I didn't test it. It's "identical" to the native 'cpp' wrapping, so I expect it to work.

WARNING: massive rebuilds.
