### PR TITLE
Fixed link to the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Nixpkgs is a collection of packages for [Nix](http://nixos.org/nix/) package
 manager. Nixpkgs also includes [NixOS](http://nixos.org/nixos/) linux distribution source code.
 
-* [NixOS installation instructions](http://nixos.org/nixos/manual/#idm139984689550080)
+* [NixOS installation instructions](http://nixos.org/nixos/manual/#installing-nixos)
 * [Manual (How to write packages for Nix)](http://nixos.org/nixpkgs/manual/)
 * [Manual (NixOS)](http://nixos.org/nixos/manual/)
 * [Continuous build](http://hydra.nixos.org/jobset/nixos/trunk-combined)

--- a/nixos/doc/manual/installation.xml
+++ b/nixos/doc/manual/installation.xml
@@ -1,5 +1,6 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
-         xmlns:xlink="http://www.w3.org/1999/xlink">
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="installing-nixos">
 
 <title>Installing NixOS</title>
 


### PR DESCRIPTION
The fragment identifier was wrong/outdated.
