### PR TITLE
haskellPackages.singletons: New expression

### DIFF
--- a/pkgs/development/libraries/haskell/singletons/default.nix
+++ b/pkgs/development/libraries/haskell/singletons/default.nix
@@ -1,0 +1,16 @@
+{ cabal, mtl, syb, thDesugar }:
+
+cabal.mkDerivation (self: {
+  pname = "singletons";
+  version = "0.9.3";
+  sha256 = "0m90k3ygm04c0gjfiaw5rmajyn2yz0ldcqm2xmm39d10270skpb4";
+  buildDepends = [ mtl syb thDesugar ];
+  meta = {
+    homepage = "http://www.cis.upenn.edu/~eir/packages/singletons";
+    description = "A framework for generating singleton types";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
+  };
+  noHaddock = true;
+})

--- a/pkgs/development/libraries/haskell/th-desugar/default.nix
+++ b/pkgs/development/libraries/haskell/th-desugar/default.nix
@@ -1,0 +1,15 @@
+{ cabal, mtl, syb }:
+
+cabal.mkDerivation (self: {
+  pname = "th-desugar";
+  version = "1.2.1";
+  sha256 = "12a8m1vzfbn728psaiqxwngmksrbybci3g7a47z04rjbsjf3cy4v";
+  buildDepends = [ mtl syb ];
+  meta = {
+    homepage = "http://www.cis.upenn.edu/~eir/packages/th-desugar";
+    description = "Functions to desugar Template Haskell";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ocharles ];
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2267,6 +2267,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   show = callPackage ../development/libraries/haskell/show {};
 
+  singletons = callPackage ../development/libraries/haskell/singletons {};
+
   SMTPClient = callPackage ../development/libraries/haskell/SMTPClient {};
 
   socketActivation = callPackage ../development/libraries/haskell/socket-activation {};
@@ -2390,6 +2392,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
   textStreamDecode = callPackage ../development/libraries/haskell/text-stream-decode {};
 
   thespian = callPackage ../development/libraries/haskell/thespian {};
+
+  thDesugar = callPackage ../development/libraries/haskell/th-desugar {};
 
   thExtras = callPackage ../development/libraries/haskell/th-extras {};
 


### PR DESCRIPTION
Haddock's are disabled for the singletons library as it can't yet
understand some of the extensions that this library uses.
