### PR TITLE
cb0cat: version 20131216153906

### DIFF
--- a/pkgs/tools/security/cb0cat/default.nix
+++ b/pkgs/tools/security/cb0cat/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name    = "cb0cat-${version}";
+  version = "20131216153906";
+
+  src = fetchurl {
+    url    = "https://www.cblnk.com/cb0cat/dist/${name}.tgz";
+    sha256 = "182767nxfyiis7ac8bn5v8rxb9vlly8n5w42pz1dd0751xwdlp82";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv cb0cat $out/bin
+  '';
+
+  meta = {
+    description = "cryptographic tool based on the CBEAMr0 sponge function";
+    homepage    = "https://www.cblnk.com";
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -424,6 +424,8 @@ let
 
   aescrypt = callPackage ../tools/misc/aescrypt { };
 
+  cb0cat = callPackage ../tools/security/cb0cat { };
+
   ahcpd = callPackage ../tools/networking/ahcpd { };
 
   aircrackng = callPackage ../tools/networking/aircrack-ng { };


### PR DESCRIPTION
`cb0cat` is a handy-dandy little cryptographic tool like `netcat` based on a Sponge function CBEAMr0, and is quite useful IMO.

There will likely be an update to the CBEAM function once the CAESAR deadline approaches, meaning the new version will be `cb1cat` (for CBEAMr1) under this new name.

Despite that, I still offer this as a package.
