### PR TITLE
criu: version 1.2

### DIFF
--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, protobuf, protobufc, asciidoc, xmlto, utillinux }:
+
+stdenv.mkDerivation rec {
+  name    = "criu-${version}";
+  version = "1.2";
+
+  src = fetchurl {
+    url    = "http://download.openvz.org/criu/${name}.tar.bz2";
+    sha256 = "04xlnqvgbjd5wfmi97m5rr76a3agkz8g96hdyzhc6x8gd52bbg9y";
+  };
+
+  enableParallelBuilding = true;
+  buildInputs = [ protobuf protobufc asciidoc xmlto ];
+
+  patchPhase = ''
+    chmod +w ./scripts/gen-offsets.sh
+    substituteInPlace ./scripts/gen-offsets.sh --replace hexdump ${utillinux}/bin/hexdump
+  '';
+
+  buildPhase = ''
+    make config PREFIX=$out
+    make PREFIX=$out
+  '';
+
+  installPhase = ''
+    mkdir -p $out/etc/logrotate.d
+    make install PREFIX=$out LIBDIR=$out/lib
+  '';
+
+  meta = {
+    description = "userspace checkpoint/restore for Linux";
+    homepage    = "http://criu.org";
+    license     = stdenv.lib.licenses.gpl2;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6521,6 +6521,8 @@ let
 
   cryopid = callPackage ../os-specific/linux/cryopid { };
 
+  criu = callPackage ../os-specific/linux/criu { };
+
   cryptsetup = callPackage ../os-specific/linux/cryptsetup { };
 
   cramfsswap = callPackage ../os-specific/linux/cramfsswap { };


### PR DESCRIPTION
This expression adds the CRIU tools, or "Checkpoint/Restore In Userspace" tools, for Linux users.

CRIU is an attempt to get full checkpoint/restore working mostly in userspace on Linux. As of Kernel 3.11, the mainline kernel has full support for CRIU, and this functionality works very well (including freezing things like LXC containers).

While this technically depends on a specific kernel version in some sense, it doesn't use any of it in the build process, so I didn't add it under `linuxPackages`.
