### PR TITLE
gnome3: Setup hook for gdk-pixbuf and gnome-icon-theme

### DIFF
--- a/pkgs/desktops/gnome-3/core/baobab/default.nix
+++ b/pkgs/desktops/gnome-3/core/baobab/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, intltool, fetchurl, vala, libgtop, pkgconfig, gtk3, glib
-, bash, makeWrapper, itstool, libxml2, gnome3 }:
-
-# TODO: icons and theme still does not work
-# use packaged gnome3.gnome_icon_theme_symbolic 
+{ stdenv, intltool, fetchurl, vala, libgtop
+, pkgconfig, gtk3, glib, hicolor_icon_theme
+, bash, makeWrapper, itstool, libxml2
+, gnome3, librsvg, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
   name = "baobab-3.10.1";
 
   src = fetchurl {
-    url = "https://download.gnome.org/sources/baobab/3.10/${name}.tar.xz";
+    url = "mirror://gnome/sources/baobab/3.10/${name}.tar.xz";
     sha256 = "23ce8e4847ce5f1c8230e757532d94c84e6e273d6ec8fca20eecaed5f96563f9";
   };
 
@@ -19,15 +18,18 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${gnome3.glib}/include/gio-unix-2.0";
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedBuildInputs = [ gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                            hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
 
   buildInputs = [ vala pkgconfig gtk3 glib libgtop intltool itstool libxml2
                   gnome3.gsettings_desktop_schemas makeWrapper ];
 
-  installFlags = "gsettingsschemadir=\${out}/share/${name}/glib-2.0/schemas/";
+  installFlags = "gsettingsschemadir=\${out}/share/baobab/glib-2.0/schemas/";
 
   postInstall = ''
     wrapProgram "$out/bin/baobab" \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/${name}"
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/baobab:$XDG_ICON_DIRS"
   '';
 
   preFixup = ''

--- a/pkgs/desktops/gnome-3/core/gnome-icon-theme/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-icon-theme/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1xinbgkkvlhazj887ajcl13i7kdc1wcca02jwxzvjrvchjsp4m66";
   };
 
+  setupHook = ./setup-hook.sh;
+
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils gtk ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/gnome-icon-theme/setup-hook.sh
+++ b/pkgs/desktops/gnome-3/core/gnome-icon-theme/setup-hook.sh
@@ -1,0 +1,10 @@
+make_gtk_applications_find_icon_themes() {
+
+    # where to find icon themes
+    if [ -d "$1/share/icons" ]; then
+      addToSearchPath XDG_ICON_DIRS $1/share
+    fi
+	
+}
+
+envHooks+=(make_gtk_applications_find_icon_themes)

--- a/pkgs/desktops/gnome-3/core/yelp/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp/default.nix
@@ -1,18 +1,18 @@
 { stdenv, intltool, fetchurl, webkitgtk, pkgconfig, gtk3, glib
 , file, librsvg, hicolor_icon_theme, gnome3, gdk_pixbuf
-, bash, makeWrapper, itstool, libxml2, libxslt, icu  }:
+, bash, makeWrapper, itstool, libxml2, libxslt, icu }:
 
 stdenv.mkDerivation rec {
   name = "yelp-3.10.1";
 
   src = fetchurl {
-    url = "https://download.gnome.org/sources/yelp/3.10/${name}.tar.xz";
+    url = "mirror://gnome/sources/yelp/3.10/${name}.tar.xz";
     sha256 = "17736479b7d0b1128c7d6cb3073f2b09e4bbc82670731b2a0d3a3219a520f816";
   };
 
-  propagatedUserEnvPkgs = [ librsvg gdk_pixbuf gnome3.gnome_themes_standard
-                            gnome3.gnome_icon_theme hicolor_icon_theme
-                            gnome3.gnome_icon_theme_symbolic ];
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard  ];
+  propagatedBuildInputs = [ librsvg gdk_pixbuf gnome3.gnome_icon_theme
+                            hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
 
   preConfigure = "substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file";
 
@@ -20,14 +20,12 @@ stdenv.mkDerivation rec {
                   libxml2 libxslt icu file makeWrapper gnome3.yelp_xsl
                   gnome3.gsettings_desktop_schemas ];
 
-  installFlags = "gsettingsschemadir=\${out}/share/${name}/glib-2.0/schemas/";
+  installFlags = "gsettingsschemadir=\${out}/share/yelp/glib-2.0/schemas/";
 
   postInstall = ''
-    mkdir -p $out/lib/yelp/gdk-pixbuf-2.0/2.10.0
-    cat ${gdk_pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache ${librsvg}/lib/gdk-pixbuf/loaders.cache > $out/lib/yelp/gdk-pixbuf-2.0/2.10.0/loaders.cache
     wrapProgram "$out/bin/yelp" \
-      --set GDK_PIXBUF_MODULE_FILE `readlink -e $out/lib/yelp/gdk-pixbuf-2.0/2.10.0/loaders.cache` \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/:${gnome3.gnome_themes_standard}/share:${gnome3.gnome_icon_theme_symbolic}/share:${gnome3.yelp_xsl}/share/yelp-xsl:${gnome3.gnome_icon_theme}/share:${hicolor_icon_theme}/share:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/${name}"
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/:${gnome3.gnome_themes_standard}/share:${gnome3.yelp_xsl}/share/yelp-xsl:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/yelp:$XDG_ICON_DIRS"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ldhpdalbyi6q5k1dz498i9hqcsd51yxq0f91ck9p0h4v38blfx1";
   };
 
+  setupHook = ./setup-hook.sh;
+
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
   buildInputs = [ libX11 libintlOrEmpty ];
 

--- a/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
+++ b/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
@@ -1,0 +1,19 @@
+make_gtk_applications_find_pixbuf_loaders() {
+
+    # set pixbuf loaders.cache for this package
+	mkdir -p "$out/lib/$name/gdk-pixbuf"
+	
+	if [ -f "$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" ]; then
+		cat "$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" >> "$out/lib/$name/gdk-pixbuf/loaders.cache"
+	fi
+
+	if [ -f "$1/lib/gdk-pixbuf/loaders.cache" ]; then
+		cat "$1/lib/gdk-pixbuf/loaders.cache" >> "$out/lib/$name/gdk-pixbuf/loaders.cache"
+	fi
+	
+	# note, this is not a search path
+	export GDK_PIXBUF_MODULE_FILE=$(readlink -e "$out/lib/$name/gdk-pixbuf/loaders.cache")
+
+}
+
+envHooks+=(make_gtk_applications_find_pixbuf_loaders)


### PR DESCRIPTION
Add necessary paths to the environment so that
applications can find icons.

Showcase with yelp and baobab. Other applications have to be updated as well if this change is ok.
