### PR TITLE
NetworkManager: openresolv support

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     "--with-dhcpcd=no"
     "--with-iptables=${iptables}/sbin/iptables"
     "--with-udev-dir=\${out}/lib/udev"
-    "--with-resolvconf=${openresolv}/sbin/openresolv"
+    "--with-resolvconf=${openresolv}/sbin/resolvconf"
     "--sysconfdir=/etc" "--localstatedir=/var"
     "--with-dbus-sys-dir=\${out}/etc/dbus-1/system.d"
     "--with-crypto=gnutls" "--disable-more-warnings"

--- a/pkgs/tools/networking/openresolv/default.nix
+++ b/pkgs/tools/networking/openresolv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "openresolv-3.5.6";
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
     url = "http://roy.marples.name/downloads/openresolv/${name}.tar.bz2";
     sha256 = "1n3cw1vbm7mh5d95ykhzdn2mrrf3pm65sp61p8iwydz1gqkp2inv";
   };
+
+  buildInputs = [ makeWrapper ];
 
   configurePhase =
     ''
@@ -22,6 +24,10 @@ stdenv.mkDerivation rec {
     '';
 
   installFlags = "SYSCONFDIR=$(out)/etc";
+
+  postInstall = ''
+    wrapProgram "$out/sbin/resolvconf" --set PATH "${coreutils}/bin"
+  '';
 
   meta = {
     description = "A program to manage /etc/resolv.conf";


### PR DESCRIPTION
@iElectric This fixes up openresolv support in NetworkManager. IIUC, it will update your pull request #1828 if you pull it into the PR branch. I have tested, and this gives me correct DNS settings through openresolv; NetworkManager never touches `/etc/resolv.conf`.
