### PR TITLE
Some minor fixes for my packages - ktap, cb0cat, etc

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation rec {
 
   phases = "unpackPhase installPhase";
 
-  meta    = {
+  meta = {
     description = "Spark cluster computing";
     homepage    = "http://spark.incubator.apache.org";
     platforms   = stdenv.lib.platforms.all;

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A tool for checking security bits on executables";
+    homepage    = "http://www.trapkit.de/tools/checksec.html";
     platforms   = stdenv.lib.platforms.linux;
     license     = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];

--- a/pkgs/os-specific/linux/ktap/default.nix
+++ b/pkgs/os-specific/linux/ktap/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ktap-${version}";
-  version = "0.5-7ee59b19";
+  version = "0.5-e7a38ef0";
   src = fetchgit {
     url    = "https://github.com/ktap/ktap.git";
-    rev    = "7ee59b19d536fd3d3164ff0a0623faff827e5d97";
-    sha256 = "0a46836469d0afb088e72fd6310406a86c487d17bac40e390cec8bc869e7379c";
+    rev    = "e7a38ef06bec9a651c9e8bdb3ad66a104210d475";
+    sha256 = "07acf20e1926d3afd89b13855154b8cc792c57261e7d3cae2da70cb08844f9c8";
   };
 
   buildPhase = ''

--- a/pkgs/os-specific/linux/ktap/default.nix
+++ b/pkgs/os-specific/linux/ktap/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, fetchgit, kernel }:
+{ stdenv, fetchgit, kernel, useFFI ? false }:
 
+let
+  ffiArgs = stdenv.lib.optionalString useFFI "FFI=1";
+in
 stdenv.mkDerivation rec {
   name = "ktap-${version}";
   version = "0.5-e7a38ef0";
@@ -10,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildPhase = ''
-    make FFI=1 KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build
+    make ${ffiArgs} KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build
   '';
 
   installPhase = ''

--- a/pkgs/tools/security/cb0cat/default.nix
+++ b/pkgs/tools/security/cb0cat/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "cryptographic tool based on the CBEAMr0 sponge function";
     homepage    = "https://www.cblnk.com";
+    platforms   = stdenv.lib.platforms.unix;
     license     = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };


### PR DESCRIPTION
This contains some amendments to my packages:
- Updates `ktap` (which adds a useful new library), and fixes the i686 build - since the FFI is not available yet. This is now controlled by a `useFFI` attribute.
- Specifies the `cb0cat` platform to be `unix` so binaries will be built by Hydra
- Adds a homepage to `checksec`, and removes some whitespace.
