### PR TITLE
glibc: don't assume /bin/sh is bash

### DIFF
--- a/pkgs/development/libraries/glibc/2.18/common.nix
+++ b/pkgs/development/libraries/glibc/2.18/common.nix
@@ -119,10 +119,10 @@ stdenv.mkDerivation ({
     ++ stdenv.lib.optional (mig != null) mig
     ++ stdenv.lib.optionals withGd [ gd libpng ];
 
-  # Needed to install share/zoneinfo/zone.tab.  Set to impure /bin/sh to
-  # prevent a retained dependency on the bootstrap tools in the stdenv-linux
+  # Needed to install share/zoneinfo/zone.tab.  Set to impure "/usr/bin/env bash"
+  # to prevent a retained dependency on the bootstrap tools in the stdenv-linux
   # bootstrap.
-  BASH_SHELL = "/bin/sh";
+  BASH_SHELL = "/usr/bin/env bash";
 
   # Workaround for this bug:
   #   http://sourceware.org/bugzilla/show_bug.cgi?id=411


### PR DESCRIPTION
The expression for glibc incorrectly assumes that `/bin/sh` is bash. That's fine on NixOS, but when running Nix on other distributions, the scripts shipped with glibc may be broken. This is particularly bad on Debian-based systems, where `/bin/sh` is dash!

The solution I propose is to use `/usr/bin/env bash` instead. This works on NixOS, and the location of `env` is standardized by the LSB specification, so it should work on ~all distributions. This fixes several builds that were failing on Ubuntu because `ldd` was broken.

Thanks to @ktosiek for pointing out that `ldd` is a script and that `/bin/sh` is not bash on Ubuntu!
