### PR TITLE
nixos: add grsecurity module (RFC)

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -392,6 +392,7 @@ in {
         home = "/root";
         shell = cfg.defaultUserShell;
         group = "root";
+        extraGroups = [ "grsecurity" ];
         hashedPassword = mkDefault config.security.initialRootPassword;
       };
       nobody = {
@@ -420,6 +421,7 @@ in {
       nixbld.gid = ids.gids.nixbld;
       utmp.gid = ids.gids.utmp;
       adm.gid = ids.gids.adm;
+      grsecurity.gid = ids.gids.grsecurity;
     };
 
     system.activationScripts.users =

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -231,6 +231,7 @@
       foundationdb = 118;
       newrelic = 119;
       starbound = 120;
+      grsecurity = 121;
 
       # When adding a gid, make sure it doesn't match an existing uid.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -62,6 +62,7 @@
   ./security/apparmor-suid.nix
   ./security/ca.nix
   ./security/duosec.nix
+  ./security/grsecurity.nix
   ./security/pam.nix
   ./security/pam_usb.nix
   ./security/polkit.nix

--- a/nixos/modules/security/grsecurity.nix
+++ b/nixos/modules/security/grsecurity.nix
@@ -1,0 +1,421 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+  cfg = config.security.grsecurity;
+
+  mkKernel = kernel: patch:
+    assert patch.kversion == kernel.version;
+      { inherit kernel patch;
+        inherit (patch) grversion revision;
+      };
+
+  stable-patch = with pkgs.kernelPatches;
+    if cfg.vserver then grsecurity_vserver else grsecurity_stable;
+  stableKernel = mkKernel pkgs.linux_3_2  stable-patch;
+  testKernel   = mkKernel pkgs.linux_3_13 pkgs.kernelPatches.grsecurity_unstable;
+
+  ## -- grsecurity configuration -----------------------------------------------
+
+  grsecPrioCfg =
+    if cfg.config.priority == "security" then
+      "GRKERNSEC_CONFIG_PRIORITY_SECURITY y"
+    else
+      "GRKERNSEC_CONFIG_PRIORITY_PERF y";
+
+  grsecSystemCfg =
+    if cfg.config.system == "desktop" then
+      "GRKERNSEC_CONFIG_DESKTOP y"
+    else
+      "GRKERNSEC_CONFIG_SERVER y";
+
+  grsecVirtCfg =
+    if cfg.config.virtualisationConfig == "none" then
+      "GRKERNSEC_CONFIG_VIRT_NONE y"
+    else if cfg.config.virtualisationConfig == "host" then
+      "GRKERNSEC_CONFIG_VIRT_HOST y"
+    else
+      "GRKERNSEC_CONFIG_VIRT_GUEST y";
+
+  grsecHwvirtCfg = if cfg.config.virtualisationConfig == "none" then "" else
+    if cfg.config.hardwareVirtualisation == true then
+      "GRKERNSEC_CONFIG_VIRT_EPT y"
+    else
+      "GRKERNSEC_CONFIG_VIRT_SOFT y";
+
+  grsecVirtswCfg =
+    let virtCfg = opt: "GRKERNSEC_CONFIG_VIRT_"+opt+" y";
+    in
+      if cfg.config.virtualisationConfig == "none" then ""
+      else if cfg.config.virtualisationSoftware == "xen"    then virtCfg "XEN"
+      else if cfg.config.virtualisationSoftware == "kvm"    then virtCfg "KVM"
+      else if cfg.config.virtualisationSoftware == "vmware" then virtCfg "VMWARE"
+      else                                                       virtCfg "VIRTUALBOX";
+
+  grsecMainConfig = if cfg.config.mode == "custom" then "" else ''
+    GRKERNSEC_CONFIG_AUTO y
+    ${grsecPrioCfg}
+    ${grsecSystemCfg}
+    ${grsecVirtCfg}
+    ${grsecHwvirtCfg}
+    ${grsecVirtswCfg}
+  '';
+
+  grsecConfig =
+    let boolToKernOpt = b: if b then "y" else "n";
+        # Disable RANDSTRUCT under virtualbox, as it has some kind of
+        # breakage with the vbox guest drivers
+        randstruct = optionalString config.services.virtualbox.enable
+          "GRKERNSEC_RANDSTRUCT n";
+        # Disable restricting links under the testing kernel, as something
+        # has changed causing it to fail miserably during boot.
+        restrictLinks = optionalString cfg.testing
+          "GRKERNSEC_LINK n";
+    in ''
+      SECURITY_APPARMOR y
+      DEFAULT_SECURITY_APPARMOR y
+      GRKERNSEC y
+      ${grsecMainConfig}
+
+      GRKERNSEC_PROC_USER ${boolToKernOpt cfg.config.restrictProc}
+      ${if !cfg.config.restrictProc then ""
+        else "GRKERNSEC_PROC_GID "+(toString cfg.config.unrestrictProcGid)}
+
+      GRKERNSEC_SYSCTL ${boolToKernOpt cfg.config.sysctl}
+      GRKERNSEC_CHROOT_CHMOD ${boolToKernOpt cfg.config.denyChrootChmod}
+      GRKERNSEC_NO_RBAC ${boolToKernOpt cfg.config.disableRBAC}
+      ${randstruct}
+      ${restrictLinks}
+
+      ${cfg.config.kernelExtraConfig}
+    '';
+
+  ## -- grsecurity kernel packages ---------------------------------------------
+
+  localver = grkern:
+    "-grsec" + optionalString cfg.config.verboseVersion
+       "-${grkern.grversion}-${grkern.revision}";
+
+  grsecurityOverrider = args: grkern: {
+    # Apparently as of gcc 4.6, gcc-plugin headers (which are needed by PaX plugins)
+    # include libgmp headers, so we need these extra tweaks
+    buildInputs = args.buildInputs ++ [ pkgs.gmp ];
+    preConfigure = ''
+      ${args.preConfigure or ""}
+      sed -i 's|-I|-I${pkgs.gmp}/include -I|' scripts/gcc-plugin.sh
+      sed -i 's|HOST_EXTRACFLAGS +=|HOST_EXTRACFLAGS += -I${pkgs.gmp}/include|' tools/gcc/Makefile
+      sed -i 's|HOST_EXTRACXXFLAGS +=|HOST_EXTRACXXFLAGS += -I${pkgs.gmp}/include|' tools/gcc/Makefile
+      rm localversion-grsec
+      echo ${localver grkern} > localversion-grsec
+    '';
+  };
+
+  mkGrsecPkg = grkern:
+    let kernelPkg = lowPrio (overrideDerivation (grkern.kernel.override (args: {
+          kernelPatches = args.kernelPatches ++ [ grkern.patch pkgs.kernelPatches.grsec_fix_path ];
+          argsOverride = {
+            modDirVersion = "${grkern.kernel.modDirVersion}${localver grkern}";
+          };
+          extraConfig = grsecConfig;
+        })) (args: grsecurityOverrider args grkern));
+    in pkgs.linuxPackagesFor kernelPkg (mkGrsecPkg grkern);
+
+  grsecPackage = mkGrsecPkg (if cfg.stable then stableKernel else testKernel);
+in
+{
+  options = {
+    security.grsecurity = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable grsecurity support. This enables advanced exploit
+          hardening for the Linux kernel, and adds support for
+          administrative Role-Based Acess Control (RBAC) via
+          <literal>gradm</literal>. It also includes traditional
+          utilities for PaX.
+        '';
+      };
+
+      stable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the stable grsecurity patch, based on Linux 3.2.
+        '';
+      };
+
+      vserver = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the stable grsecurity/vserver patches, based on Linux 3.2.
+        '';
+      };
+
+      testing = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the testing grsecurity patch, based on Linux 3.13.
+        '';
+      };
+
+      config = {
+        mode = mkOption {
+          type = types.str;
+          default = "auto";
+          example = "custom";
+          description = ''
+            grsecurity configuration mode. This specifies whether
+            grsecurity is auto-configured or otherwise completely
+            manually configured. Can either by
+            <literal>custom</literal> or <literal>auto</literal>.
+
+            <literal>auto</literal> is recommended.
+          '';
+        };
+
+        priority = mkOption {
+          type = types.str;
+          default = "security";
+          example = "performance";
+          description = ''
+            grsecurity configuration priority. This specifies whether
+            the kernel configuration should emphasize speed or
+            security. Can either by <literal>security</literal> or
+            <literal>performance</literal>.
+          '';
+        };
+
+        system = mkOption {
+          type = types.str;
+          default = "";
+          example = "desktop";
+          description = ''
+            grsecurity system configuration. This specifies whether
+            the kernel configuration should be suitable for a Desktop
+            or a Server. Can either by <literal>server</literal> or
+            <literal>desktop</literal>.
+          '';
+        };
+
+        virtualisationConfig = mkOption {
+          type = types.str;
+          default = "none";
+          example = "host";
+          description = ''
+            grsecurity virtualisation configuration. This specifies
+            the virtualisation role of the machine - that is, whether
+            it will be a virtual machine guest, a virtual machine
+            host, or neither. Can be one of <literal>none</literal>,
+            <literal>host</literal>, or <literal>guest</literal>.
+          '';
+        };
+
+        hardwareVirtualisation = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          example = true;
+          description = ''
+            grsecurity hardware virtualisation configuration. Set to
+            <literal>true</literal> if your machine supports hardware
+            accelerated virtualisation.
+          '';
+        };
+
+        virtualisationSoftware = mkOption {
+          type = types.str;
+          default = "";
+          example = "kvm";
+          description = ''
+            grsecurity virtualisation software. Set this to the
+            specified virtual machine technology if the machine is
+            running as a guest, or a host.
+
+            Can be one of <literal>kvm</literal>,
+            <literal>xen</literal>, <literal>vmware</literal> or
+            <literal>virtualbox</literal>.
+          '';
+        };
+
+        sysctl = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If true, then set <literal>GRKERN_SYSCTL y</literal>. If
+            enabled then grsecurity can be controlled using sysctl
+            (and turned off). You are advised to *never* enable this,
+            but if you do, make sure to always set the sysctl
+            <literal>kernel.grsecurity.grsec_lock</literal> to
+            non-zero as soon as all sysctl options are set. *THIS IS
+            EXTREMELY IMPORTANT*!
+
+            If disabled, this also turns off the
+            <literal>systemd-sysctl</literal> service.
+          '';
+        };
+
+        denyChrootChmod = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If true, then set <literal>GRKERN_CHROOT_CHMOD
+            y</literal>. If enabled, this denies processes inside a
+            chroot from setting the suid or sgid bits using
+            <literal>chmod</literal> or <literal>fchmod</literal>.
+
+            By default this protection is disabled - it makes it
+            impossible to use Nix to build software on your system,
+            which is what most users want.
+
+            If you are using NixOps to deploy your software to a
+            remote machine, you're encouraged to enable this as you
+            won't need to compile code.
+          '';
+        };
+
+        restrictProc = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            If true, then set <literal>GRKERN_PROC_USER
+            y</literal>. This restricts non-root users to only viewing
+            their own processes and restricts network-related
+            information, kernel symbols, and module information.
+          '';
+        };
+
+        unrestrictProcGid = mkOption {
+          type = types.int;
+          default = config.ids.gids.grsecurity;
+          description = ''
+            If set, specifies a GID which is exempt from
+            <literal>/proc</literal> restrictions (set by
+            <literal>GRKERN_PROC_USER</literal>). By default, this is
+            set to the GID for <literal>grsecurity</literal>, a
+            predefined NixOS group, which the <literal>root</literal>
+            account is a member of. You may conveniently add other
+            users to this group if you need access to
+            <literal>/proc</literal>
+          '';
+        };
+
+        disableRBAC = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If true, then set <literal>GRKERN_NO_RBAC
+            y</literal>. This disables the
+            <literal>/dev/grsec</literal> device, which in turn
+            disables the RBAC system (and <literal>gradm</literal>).
+          '';
+        };
+
+        verboseVersion = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Use verbose version in kernel localversion.";
+        };
+
+        kernelExtraConfig = mkOption {
+          type = types.str;
+          default = "";
+          description = "Extra kernel configuration parameters.";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions =
+      [ { assertion = cfg.stable || cfg.testing;
+          message   = ''
+            If grsecurity is enabled, you must select either the
+            stable patch (with kernel 3.2), or the testing patch (with
+            kernel 3.13) to continue.
+          '';
+        }
+        { assertion = (cfg.stable -> !cfg.testing) || (cfg.testing -> !cfg.stable);
+          message   = ''
+            You must select either the stable or testing patch, not
+            both.
+          '';
+        }
+        { assertion = (cfg.testing -> !cfg.vserver);
+          message   = "The vserver patches are only supported in the stable kernel.";
+        }
+        { assertion = config.boot.kernelPackages.kernel.features ? grsecurity
+                   && config.boot.kernelPackages.kernel.features.grsecurity;
+          message = "grsecurity enabled, but kernel doesn't have grsec support";
+        }
+        { assertion = elem cfg.config.mode [ "auto" "custom" ];
+          message = "grsecurity mode must either be 'auto' or 'custom'.";
+        }
+        { assertion = cfg.config.mode == "auto" -> elem cfg.config.system [ "desktop" "server" ];
+          message = "when using auto grsec mode, system must be either 'desktop' or 'server'";
+        }
+        { assertion = cfg.config.mode == "auto" -> elem cfg.config.priority [ "performance" "security" ];
+          message = "when using auto grsec mode, priority must be 'performance' or 'security'.";
+        }
+        { assertion = cfg.config.mode == "auto" -> elem cfg.config.virtualisationConfig [ "host" "guest" "none" ];
+          message = "when using auto grsec mode, 'virt' must be 'host', 'guest' or 'none'.";
+        }
+        { assertion = (cfg.config.mode == "auto" && (elem cfg.config.virtualisationConfig [ "host" "guest" ])) ->
+              cfg.config.hardwareVirtualisation != null;
+          message   = "when using auto grsec mode with virtualisation, you must specify if your hardware has virtualisation extensions";
+        }
+        { assertion = (cfg.config.mode == "auto" && (elem cfg.config.virtualisationConfig [ "host" "guest" ])) ->
+              elem cfg.config.virtualisationSoftware [ "kvm" "xen" "virtualbox" "vmware" ];
+          message   = "virtualisation software must be 'kvm', 'xen', 'vmware' or 'virtualbox'";
+        }
+      ];
+
+    systemd.services.grsec-lock = mkIf cfg.config.sysctl {
+      description     = "grsecurity sysctl-lock Service";
+      requires        = [ "sysctl.service" ];
+      wantedBy        = [ "multi-user.target" ];
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = "yes";
+      script = ''
+        locked=`cat /proc/sys/kernel/grsecurity/grsec_lock`
+        if [ "$locked" == "0" ]; then
+            echo 1 > /proc/sys/kernel/grsecurity/grsec_lock
+            echo grsecurity sysctl lock - enabled
+        else
+            echo grsecurity sysctl lock already enabled - doing nothing
+        fi
+      '';
+    };
+
+#   systemd.services.grsec-learn = {
+#     description     = "grsecurity learning Service";
+#     wantedBy        = [ "local-fs.target" ];
+#     serviceConfig   = {
+#       Type = "oneshot";
+#       RemainAfterExit = "yes";
+#       ExecStart = "${pkgs.gradm}/sbin/gradm -VFL /etc/grsec/learning.logs";
+#       ExecStop  = "${pkgs.gradm}/sbin/gradm -D";
+#     };
+#   };
+
+    system.activationScripts.grsec =
+      ''
+        mkdir -p /etc/grsec
+        if [ ! -f /etc/grsec/learn_config ]; then
+          cp ${pkgs.gradm}/etc/grsec/learn_config /etc/grsec
+        fi
+        if [ ! -f /etc/grsec/policy ]; then
+          cp ${pkgs.gradm}/etc/grsec/policy /etc/grsec
+        fi
+        chmod -R 0600 /etc/grsec
+      '';
+
+    # Enable apparmor support, gradm udev rules, and utilities
+    security.apparmor.enable   = true;
+    boot.kernelPackages        = grsecPackage;
+    services.udev.packages     = [ pkgs.gradm ];
+    environment.systemPackages = [ pkgs.gradm pkgs.paxctl pkgs.pax-utils ];
+  };
+}

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -76,17 +76,17 @@ with stdenv.lib;
   CLS_U32_MARK y
 
   # Wireless networking.
-  CFG80211_WEXT y # Without it, ipw2200 drivers don't build
-  IPW2100_MONITOR y # support promiscuous mode
-  IPW2200_MONITOR y # support promiscuous mode
-  HOSTAP_FIRMWARE y # Support downloading firmware images with Host AP driver
-  HOSTAP_FIRMWARE_NVRAM y
-  ATH9K_PCI y # Detect Atheros AR9xxx cards on PCI(e) bus
-  ATH9K_AHB y # Ditto, AHB bus
+  CFG80211_WEXT? y # Without it, ipw2200 drivers don't build
+  IPW2100_MONITOR? y # support promiscuous mode
+  IPW2200_MONITOR? y # support promiscuous mode
+  HOSTAP_FIRMWARE? y # Support downloading firmware images with Host AP driver
+  HOSTAP_FIRMWARE_NVRAM? y
+  ATH9K_PCI? y # Detect Atheros AR9xxx cards on PCI(e) bus
+  ATH9K_AHB? y # Ditto, AHB bus
   ${optionalString (versionAtLeast version "3.2") ''
-    B43_PHY_HT y
+    B43_PHY_HT? y
   ''}
-  BCMA_HOST_PCI y
+  BCMA_HOST_PCI? y
 
   # Enable various FB devices.
   FB y
@@ -108,7 +108,7 @@ with stdenv.lib;
   # Enable KMS for devices whose X.org driver supports it.
   DRM_I915_KMS y
   ${optionalString (versionOlder version "3.9") ''
-    DRM_RADEON_KMS y
+    DRM_RADEON_KMS? y
   ''}
   # Hybrid graphics support
   VGA_SWITCHEROO y
@@ -142,18 +142,18 @@ with stdenv.lib;
   EXT2_FS_XIP y # Ext2 execute in place support
   EXT4_FS_POSIX_ACL y
   EXT4_FS_SECURITY y
-  REISERFS_FS_XATTR y
-  REISERFS_FS_POSIX_ACL y
-  REISERFS_FS_SECURITY y
-  JFS_POSIX_ACL y
-  JFS_SECURITY y
-  XFS_QUOTA y
-  XFS_POSIX_ACL y
-  XFS_RT y # XFS Realtime subvolume support
-  OCFS2_DEBUG_MASKLOG n
+  REISERFS_FS_XATTR? y
+  REISERFS_FS_POSIX_ACL? y
+  REISERFS_FS_SECURITY? y
+  JFS_POSIX_ACL? y
+  JFS_SECURITY? y
+  XFS_QUOTA? y
+  XFS_POSIX_ACL? y
+  XFS_RT? y # XFS Realtime subvolume support
+  OCFS2_DEBUG_MASKLOG? n
   BTRFS_FS_POSIX_ACL y
   UBIFS_FS_XATTR? y
-  UBIFS_FS_ADVANCED_COMPR y
+  UBIFS_FS_ADVANCED_COMPR? y
   NFSD_V2_ACL y
   NFSD_V3 y
   NFSD_V3_ACL y
@@ -166,7 +166,7 @@ with stdenv.lib;
   # Security related features.
   STRICT_DEVMEM y # Filter access to /dev/mem
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default
-  DEVKMEM n # Disable /dev/kmem
+  DEVKMEM? n # Disable /dev/kmem
   ${if versionOlder version "3.14" then ''
     CC_STACKPROTECTOR y # Detect buffer overflows on the stack
   '' else ''
@@ -185,14 +185,14 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "3.3" && versionOlder version "3.13") ''
     AUDIT_LOGINUID_IMMUTABLE y
   ''}
-  B43_PCMCIA y
+  B43_PCMCIA? y
   BLK_DEV_CMD640_ENHANCED y # CMD640 enhanced support
   BLK_DEV_IDEACPI y # IDE ACPI support
   BLK_DEV_INTEGRITY y
   BSD_PROCESS_ACCT_V3 y
-  BT_HCIUART_BCSP y
-  BT_HCIUART_H4 y # UART (H4) protocol support
-  BT_HCIUART_LL y
+  BT_HCIUART_BCSP? y
+  BT_HCIUART_H4? y # UART (H4) protocol support
+  BT_HCIUART_LL? y
   BT_RFCOMM_TTY? y # RFCOMM TTY support
   CRASH_DUMP? n
   ${optionalString (versionOlder version "3.1") ''
@@ -206,10 +206,10 @@ with stdenv.lib;
   FUSION y # Fusion MPT device support
   IDE_GD_ATAPI y # ATAPI floppy support
   IRDA_ULTRA y # Ultra (connectionless) protocol
-  JOYSTICK_IFORCE_232 y # I-Force Serial joysticks and wheels
-  JOYSTICK_IFORCE_USB y # I-Force USB joysticks and wheels
-  JOYSTICK_XPAD_FF y # X-Box gamepad rumble support
-  JOYSTICK_XPAD_LEDS y # LED Support for Xbox360 controller 'BigX' LED
+  JOYSTICK_IFORCE_232? y # I-Force Serial joysticks and wheels
+  JOYSTICK_IFORCE_USB? y # I-Force USB joysticks and wheels
+  JOYSTICK_XPAD_FF? y # X-Box gamepad rumble support
+  JOYSTICK_XPAD_LEDS? y # LED Support for Xbox360 controller 'BigX' LED
   LDM_PARTITION y # Windows Logical Disk Manager (Dynamic Disk) support
   LEDS_TRIGGER_IDE_DISK y # LED IDE Disk Trigger
   LOGIRUMBLEPAD2_FF y # Logitech Rumblepad 2 force feedback
@@ -275,17 +275,17 @@ with stdenv.lib;
   ''}
 
   # Virtualisation.
-  PARAVIRT y
+  PARAVIRT? y
   ${if versionAtLeast version "3.10" then ''
-    HYPERVISOR_GUEST y
+    HYPERVISOR_GUEST? y
   '' else ''
-    PARAVIRT_GUEST y
+    PARAVIRT_GUEST? y
   ''}
-  KVM_GUEST y
+  KVM_GUEST? y
   ${optionalString (versionOlder version "3.7") ''
-    KVM_CLOCK y
+    KVM_CLOCK? y
   ''}
-  XEN y
+  XEN? y
   XEN_DOM0? y
   KSM y
   ${optionalString (!stdenv.is64bit) ''
@@ -308,8 +308,8 @@ with stdenv.lib;
   ''}
 
   # Enable the 9P cache to speed up NixOS VM tests.
-  9P_FSCACHE y
-  9P_FS_POSIX_ACL y
+  9P_FSCACHE? y
+  9P_FS_POSIX_ACL? y
 
   ${kernelPlatform.kernelExtraConfig or ""}
   ${extraConfig}

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -18,6 +18,18 @@ let
       };
     };
 
+  grsecPatch = { grversion ? "3.0", kversion, revision, branch, sha256 }:
+    { name = "grsecurity-${grversion}-${kversion}";
+      inherit grversion kversion revision;
+      patch = fetchurl {
+        url = "http://grsecurity.net/${branch}/grsecurity-${grversion}-${kversion}-${revision}.patch";
+        inherit sha256;
+      };
+      features.grsecurity = true;
+      # The grsec kernel patchset includes AppArmor patches
+      features.apparmor = true;
+    };
+
   makeAppArmorPatch = {apparmor, version}:
     stdenv.mkDerivation {
       name = "apparmor-${version}.patch";
@@ -26,6 +38,7 @@ let
         cat ${apparmor}/kernel-patches/${version}/* > $out
       '';
     };
+
 in
 
 rec {
@@ -71,31 +84,29 @@ rec {
     sha256 = "00b1rqgd4yr206dxp4mcymr56ymbjcjfa4m82pxw73khj032qw3j";
   };
 
-
-  grsecurity_3_0_3_2_56 =
-    { name = "grsecurity-3.0-3.2.56";
-      patch = fetchurl {
-        url = http://grsecurity.net/stable/grsecurity-3.0-3.2.56-201404062126.patch;
-        sha256 = "0pm8a6h5dky1frg7bi6ldq849w8xz8isnlw5jpbzix46m3myy3x0";
-      };
-      features.grsecurity = true;
-      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.2.56
-      features.apparmor = true;
+  grsecurity_stable = grsecPatch
+    { kversion  = "3.2.56";
+      revision  = "201404062126";
+      branch    = "stable";
+      sha256    = "0pm8a6h5dky1frg7bi6ldq849w8xz8isnlw5jpbzix46m3myy3x0";
     };
 
-  grsecurity_3_0_3_13_9 =
-    { name = "grsecurity-3.0-3.13.9";
-      patch = fetchurl {
-        url = http://grsecurity.net/test/grsecurity-3.0-3.13.9-201404062127.patch;
-        sha256 = "0kwqgw2a44wqhwjwws63ww15apb8jki372iccq7h1w5vi551sl0m";
-      };
-      features.grsecurity = true;
-      # The grsec kernel patch seems to include the apparmor patches as of 3.0-3.13.9
-      features.apparmor = true;
+  grsecurity_vserver = grsecPatch
+    { kversion  = "3.2.56";
+      revision  = "vs2.3.2.16-201404062127";
+      branch    = "vserver";
+      sha256    = "1124qi894bf76kwij9s13yx3zd6kr9yh26y365cr9iis0aysrpfq";
     };
 
-  grsec_path =
-    { name = "grsec-path";
+  grsecurity_unstable = grsecPatch
+    { kversion  = "3.13.9";
+      revision  = "201404062127";
+      branch    = "test";
+      sha256    = "0kwqgw2a44wqhwjwws63ww15apb8jki372iccq7h1w5vi551sl0m";
+    };
+
+  grsec_fix_path =
+    { name = "grsec-fix-path";
       patch = ./grsec-path.patch;
     };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6890,39 +6890,6 @@ let
     kernelPatches = [];
   };
 
-  grsecurityOverrider = args: {
-    # Apparently as of gcc 4.6, gcc-plugin headers (which are needed by PaX plugins)
-    # include libgmp headers, so we need these extra tweaks
-    buildInputs = args.buildInputs ++ [ gmp ];
-    preConfigure = ''
-      ${args.preConfigure or ""}
-      sed -i 's|-I|-I${gmp}/include -I|' scripts/gcc-plugin.sh
-      sed -i 's|HOST_EXTRACFLAGS +=|HOST_EXTRACFLAGS += -I${gmp}/include|' tools/gcc/Makefile
-      sed -i 's|HOST_EXTRACXXFLAGS +=|HOST_EXTRACXXFLAGS += -I${gmp}/include|' tools/gcc/Makefile
-    '';
-  };
-
-  # Note: grsec is not enabled automatically, you need to specify which kernel
-  # config options you need (e.g. by overriding extraConfig). See list of options here:
-  # https://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options
-  linux_3_2_grsecurity = lowPrio (lib.addMetaAttrs {
-    maintainers = with lib.maintainers; [ wizeman thoughtpolice ];
-  } (lib.overrideDerivation (linux_3_2.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_2_56 kernelPatches.grsec_path ];
-    argsOverride = {
-      modDirVersion = "${linux_3_2.modDirVersion}-grsec";
-    };
-  })) (args: grsecurityOverrider args)));
-
-  linux_3_13_grsecurity = lowPrio (lib.addMetaAttrs {
-    maintainers = with lib.maintainers; [ wizeman thoughtpolice ];
-  } (lib.overrideDerivation (linux_3_13.override (args: {
-    kernelPatches = args.kernelPatches ++ [ kernelPatches.grsecurity_3_0_3_13_9 kernelPatches.grsec_path ];
-    argsOverride = {
-      modDirVersion = "${linux_3_13.modDirVersion}-grsec";
-    };
-  })) (args: grsecurityOverrider args)));
-
   linux_3_2_apparmor = lowPrio (linux_3_2.override {
     kernelPatches = [ kernelPatches.apparmor_3_2 ];
     extraConfig = ''
@@ -7089,7 +7056,6 @@ let
   # Build the kernel modules for the some of the kernels.
   linuxPackages_3_2 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_2 linuxPackages_3_2);
   linuxPackages_3_2_apparmor = linuxPackagesFor pkgs.linux_3_2_apparmor linuxPackages_3_2_apparmor;
-  linuxPackages_3_2_grsecurity = linuxPackagesFor pkgs.linux_3_2_grsecurity linuxPackages_3_2_grsecurity;
   linuxPackages_3_2_xen = linuxPackagesFor pkgs.linux_3_2_xen linuxPackages_3_2_xen;
   linuxPackages_3_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_4 linuxPackages_3_4);
   linuxPackages_3_4_apparmor = linuxPackagesFor pkgs.linux_3_4_apparmor linuxPackages_3_4_apparmor;
@@ -7097,7 +7063,6 @@ let
   linuxPackages_3_10 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_10 linuxPackages_3_10);
   linuxPackages_3_10_tuxonice = linuxPackagesFor pkgs.linux_3_10_tuxonice linuxPackages_3_10_tuxonice;
   linuxPackages_3_12 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_12 linuxPackages_3_12);
-  linuxPackages_3_13_grsecurity = linuxPackagesFor pkgs.linux_3_13_grsecurity linuxPackages_3_13_grsecurity;
   linuxPackages_3_13 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_13 linuxPackages_3_13);
   linuxPackages_3_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_14 linuxPackages_3_14);
   # Update this when adding a new version!


### PR DESCRIPTION
This module is a work-in-progress which refactors grsecurity support into a module, which can be easily enabled from a users `configuration.nix`.

There are a few reasons for doing this: the current way of enabling grsec support is incredibly un-nix like, as it requires choosing a kernel package and then appropriate options. This is error prone, and requires a lot of work for users when they really want an easy way to do it.

Second, grsec naturally encompasses some other things that can only be handled by a module, that are beyond the kernel package: in particular, mutable files must be installed appropriately into `/etc/grsec` (as `gradm` will use/update the policy files). There are also needed udev rules for `/dev/grsec`. Furthermore, some options like `GRKERNSEC_CHROOT_CHMOD` are extremely incompatible with Nix, and make it impossible to install software. So by default, the module disables this (although it works great if you deploy with NixOps).

Also, some options are incompatible in other ways: for example, `GRKERNSEC_RANDSTRUCT` breaks the virtualbox guest networking drivers (a bug I need to send to grsec upstream), and `GRKERNSEC_LINK` breaks on the 3.13.5 testing kernel (but not the 3.2 stable kernel). Also, if you disable `sysctl` support, things like `systemd-sysctl` must be disabled as they won't work.

Overall, having a module take care of this means there's a lot less pain. This module naturally takes control of `boot.kernelPackages` - I'm not sure how much precedent there is for that, but I think it's reasonable given the purpose.

This also moves the grsecurity overrides out of the kernel package and into the module itself, leaving only the patches in `pkgs`, which I think is probably where it belongs anyway.

Finally, as the grsecurity patches imply `config.apparmor=true`, the module also turns apparmor on as the patches are included (which is easily overlooked).

This is my first 'big' NixOS module that's not simply a service, so I'd appreciate input. If we can land this in some form, more exciting work can happen soon, including enforcement/management of RBAC policies and userspace hardening.

Here's an example of enabling the configuration:

```
  security.grsecurity.enable  = true;
  #security.grsecurity.stable = true; # enable stable 3.2.55 kernel
  security.grsecurity.testing = true; # enable testing 3.13.5 kernel
  security.grsecurity.config = {
    mode     = "auto";
    priority = "security";
    system   = "server";
    virtualisationConfig     = "host";
    hardwareVirtualisation   = true;
    virtualisationSoftware   = "kvm";

    # Extra protection options
    denyChrootChmod   = true;

    # Extra kernel options
    kernelExtraConfig = ''
      DEVKMEM? n
      HIBERNATION? n
      XEN? n
      HYPERVISOR_GUEST? n
      KVM_GUEST? n
      PARAVIRT? n
    '';
  };
```

I'm using this configuration with NixOps, and am successfully deploying Linux 3.13.5-grsec onto Hetzner with this module.

There are some things left **TODO**:
- [x] Enable AppArmor patches by default
- [x] Enable AppArmor module by default
- [ ] Automatically enable AppArmor configurations in modules by default.
  - So far, I think transmission is about the only one that does this.
  - We should review upstream apparmor configurations
- [x] When first deployed with NixOps, `systemd.services.systemd-sysctl.enable` gets shadowed rather than cleanly disabled it appears, meaning I probably got this wrong somehow.
- [x] Make sysctl options 'optional' (they will not appear in the `systemd-sysctl` config) if specified with `null`.
- [x] Ensure `kptr_restrict` is `null` if grsecurity is enabled.
- [x] Fix all option names
- [x] Enable revision in module version.
  - Should probably be optional
  - Needs to override `./locaversion-grsec` after patching
- [x] Properly detect virtualbox guest drivers to disable RANDSTRUCT.
- [x] Abstract out the building of grsecurity patches
- [x] Enable vserver patches
- [ ] Fix kernel package configuration overrides
- [x] Enable `grsec-lock` service for configurations that enable sysctl support
- [ ] Enable a `gradm` module for RBAC control. Ideally most of this could be declarative.
- [x] Fix configuration of `RANDSTRUCT` and `GRKERNSEC_LINKS`
- [x] Make `common-config` kernel options optional
  - When using grsec, you often want to cut down the amount of stuff built (and it makes testing easier), so several of these things should be optional (e.g. I have no need for bluetooth, NFC, or many of the extra filesystems).

/cc @wizeman
