### PR TITLE
Use feh only as a fallback if the xserver is actually enabled.

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -7,9 +7,9 @@ let
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager;
 
-  # Whether desktop manager `d' is capable of setting a background.
-  # If it isn't, the `feh' program is used as a fallback.
-  needBGCond = d: ! (d ? bgSupport && d.bgSupport);
+  # If desktop manager `d' isn't capable of setting a background and
+  # the xserver is enabled, the `feh' program is used as a fallback.
+  needBGCond = d: ! (d ? bgSupport && d.bgSupport) && xcfg.enable;
 
 in
 


### PR DESCRIPTION
Otherwise feh is installed even though no xserver is available. It would be better to check in addition if the desktop manager is enabled (so that feh isn't installed if no desktop manager is enabled at all), but I don't think there is a reliable way to check this.
