### PR TITLE
Security update: update to warp 2.0.3.3

### DIFF
--- a/pkgs/development/libraries/haskell/warp/default.nix
+++ b/pkgs/development/libraries/haskell/warp/default.nix
@@ -6,8 +6,8 @@
 
 cabal.mkDerivation (self: {
   pname = "warp";
-  version = "2.0.3.2";
-  sha256 = "1aapwhgqn693cvdhj4zafyww2xrpjn8wzdgrwxz8k6mq0f2lh599";
+  version = "2.0.3.3";
+  sha256 = "02wh8jf8pcjb03xxdim9q92vr4jk9jibqqzl8kvccqlqfi5giq0f";
   buildDepends = [
     blazeBuilder blazeBuilderConduit caseInsensitive conduit hashable
     httpDate httpTypes liftedBase network networkConduit simpleSendfile


### PR DESCRIPTION
From the web-devel mailing list: "We received a security report yesterday of a regression in the Warp 2.0
series related to Slowloris protection."
See https://github.com/yesodweb/wai/issues/231 for details.

CC @peti
