### PR TITLE
ImageMagick: update to 6.8.8-7

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -18,14 +18,14 @@
 }:
 
 let
-  version = "6.8.7-6";
+  version = "6.8.8-7";
 in
 stdenv.mkDerivation rec {
   name = "ImageMagick-${version}";
 
   src = fetchurl {
     url = "mirror://imagemagick/${name}.tar.xz";
-    sha256 = "0cbfhk184kxdxz5czyyqxac29mbfiahygjji6k97z6hp8ngnqlvh";
+    sha256 = "1x5jkbrlc10rx7vm344j7xrs74c80xk3n1akqx8w5c194fj56mza";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fixes CVE-2014-{1947,1958,2030}.
