### PR TITLE
modernize nixos-generate-config

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -429,6 +429,12 @@ $bootLoaderConfig
   #   defaultLocale = "en_US.UTF-8";
   # };
 
+  # List packages installed in system profile. To search by name, run:
+  # $ nix-env -qaP | grep wget
+  # environment.systemPackages = with pkgs; [
+  #   wget
+  # ];
+
   # List services that you want to enable:
 
   # Enable the OpenSSH daemon.
@@ -445,6 +451,17 @@ $bootLoaderConfig
   # Enable the KDE Desktop Environment.
   # services.xserver.displayManager.kdm.enable = true;
   # services.xserver.desktopManager.kde4.enable = true;
+
+  # Define your user and don't forget to set password with passwd
+  # users.extraUsers.guest = {
+  #   name = "guest";
+  #   group = "users";
+  #   uid = 1000;
+  #   createHome = true;
+  #   home = "/home/guest";
+  #   shell = "/run/current-system/sw/bin/bash";
+  # };
+
 }
 EOF
     } else {


### PR DESCRIPTION
I'd mention following things in generated config:
- how to create an user
- how to install packages declaratively
- prefer networkmanager over wpa_supplicant
