### PR TITLE
Liferea 1.10.6 [revised pull request]

### DIFF
--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -1,30 +1,51 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, gtk2, gnome2 /*just GConf*/
-, libsoup, libunique, libxslt, webkit_gtk2, json_glib
-, libnotify /*optional*/ }:
+{ stdenv, fetchurl, pkgconfig, intltool, python, pygobject3
+, glib, gnome3, pango, libxml2, libxslt, sqlite, libsoup
+, webkitgtk, json_glib, gobjectIntrospection, gsettings_desktop_schemas
+, gst_all_1
+, libnotify
+, makeWrapper
+}:
 
-let version = "1.8.15";
+let pname = "liferea";
+    version = "1.10.6";
 in
 stdenv.mkDerivation rec {
-  name = "liferea-${version}";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/liferea/Liferea%20Stable/${version}/${name}.tar.bz2";
-    sha256 = "12hhdl5biwcvr9ds7pdhhvlp4vggjix6xm4z5pnfaz53ai2dnc99";
+    url = "https://github.com/lwindolf/${pname}/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "0vp19z4p3cn3zbg1zjpg2iyzwq893dx5c1kh6aac06s3rf1124gm";
   };
 
-  buildInputs = [
-    pkgconfig intltool gtk2 gnome2.GConf
-    libsoup libunique libxslt webkit_gtk2 json_glib
+  buildInputs = with gst_all_1; [
+    pkgconfig intltool python
+    glib gnome3.gtk pango libxml2 libxslt sqlite libsoup
+    webkitgtk json_glib gobjectIntrospection gsettings_desktop_schemas
+    gnome3.libpeas
+    gst-plugins-base gst-plugins-good gst-plugins-bad
+    gnome3.gnome_keyring
     libnotify
+    makeWrapper
   ];
 
   preFixup = ''
     rm $out/share/icons/hicolor/icon-theme.cache'';
 
+  postInstall  = ''
+    for f in "$out"/bin/*; do
+      wrapProgram "$f" \
+        --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pygobject3})" \
+        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gnome3.gnome_icon_theme}/share:${gsettings_desktop_schemas}/share:${gnome3.gtk}/share:$out/share"
+    done
+  '';
+
   meta = {
     description = "A GTK-based news feed agregator";
     homepage = http://lzone.de/liferea/;
-    maintainers = [ stdenv.lib.maintainers.vcunat ];
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ vcunat romildo ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/core/libpeas/default.nix
+++ b/pkgs/desktops/gnome-3/core/libpeas/default.nix
@@ -1,10 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, gnome3, intltool, gobjectIntrospection }:
+{ stdenv, fetchurl, pkgconfig, intltool
+, glib, gtk3, gobjectIntrospection, python, pygobject3
+}:
 
 stdenv.mkDerivation rec {
   name = "libpeas-${version}";
   version = "1.9.0";
 
-  buildInputs = with gnome3; [ intltool pkgconfig glib gobjectIntrospection gtk3 ];
+  buildInputs =  [
+   intltool pkgconfig
+   glib gtk3 gobjectIntrospection python pygobject3
+  ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/libpeas/1.9/${name}.tar.xz";
@@ -15,8 +20,10 @@ stdenv.mkDerivation rec {
     rm $out/share/icons/hicolor/icon-theme.cache
   '';
 
-  meta = with stdenv.lib; {
-    platforms = platforms.linux;
+  meta = {
+    description = "A GObject-based plugins engine";
+    homepage = "http://ftp.acc.umu.se/pub/GNOME/sources/libpeas/";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux;
   };
-
 }


### PR DESCRIPTION
Updated liferea from 1.8.15 to 1.10.6.
The other pull request includes changes (hexchat) that have already been applied and should be ignored.
