### PR TITLE
st: Add builtInput for pkgconfig

### DIFF
--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, writeText, libX11, ncurses, libXext, libXft, fontconfig
+{ stdenv, fetchurl, pkgconfig, writeText, libX11, ncurses, libXext, libXft, fontconfig
 , conf? null}:
 
 with stdenv.lib;
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
   
-  buildInputs = [ libX11 ncurses libXext libXft fontconfig ];
+  buildInputs = [ pkgconfig libX11 ncurses libXext libXft fontconfig ];
 
   NIX_LDFLAGS = "-lfontconfig";
 


### PR DESCRIPTION
During the build process st fails to find pkg-config. This does not throw a fatal error but it should be included during build time.
