### PR TITLE
kdevelop: Update to 4.6.

### DIFF
--- a/pkgs/applications/editors/kdevelop/default.nix
+++ b/pkgs/applications/editors/kdevelop/default.nix
@@ -1,27 +1,19 @@
 { stdenv, fetchurl, kdevplatform, cmake, pkgconfig, automoc4, shared_mime_info,
-  kdebase_workspace, gettext, perl, okteta }:
+  kdebase_workspace, gettext, perl, okteta, qjson }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "4.3.1";
+  version = "4.6.0";
   pname = "kdevelop";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.bz2";
-    sha256 = "0015hv39rqhyq1w6jw65lx7ls4l5pc3a2asvd5zsd65831vrfxxs";
+    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
+    sha256 = "1ee9e7b8c46f575dd29d920cfd6284130f2e738a2e1f52dfd97b075fab2e4c73";
   };
 
-  buildInputs = [ kdevplatform kdebase_workspace okteta ];
+  buildInputs = [ kdevplatform kdebase_workspace okteta qjson ];
 
   nativeBuildInputs = [ cmake pkgconfig automoc4 shared_mime_info gettext perl ];
-
-  patches =
-    [ ( fetchurl {
-        url = https://git.reviewboard.kde.org/r/105211/diff/raw/;
-        name = "okteta-0.9.patch"; # fixes build with KDE-4.9.x
-        sha256 = "1mvqhw7jr1vi66l3jgam3slyfafcvwy4g3iapfi69dpfnzhmcxl0";
-      } )
-    ];
 
   NIX_CFLAGS_COMPILE = "-I${okteta}/include/KDE";
 

--- a/pkgs/development/libraries/kdevplatform/default.nix
+++ b/pkgs/development/libraries/kdevplatform/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, cmake, kdelibs, subversion, qt4, automoc4, perl, phonon,
-  gettext, pkgconfig, apr, aprutil, boost, qjson }:
+  gettext, pkgconfig, apr, aprutil, boost, qjson, grantlee }:
 
 stdenv.mkDerivation rec {
-  name = "kdevplatform-1.3.1";
+  name = "kdevplatform-1.6.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/kdevelop/4.3.1/src/${name}.tar.bz2";
-    sha256 = "1fiqwabw5ilhw1jwvvr743dym12y3kxrs3zlqahz57yncdsglcl6";
+    url = "mirror://kde/stable/kdevelop/4.6.0/src/${name}.tar.xz";
+    sha256 = "cdf7c88ca8860258f46e41d2107c826a307212fd041345bee54fbd70c9794f80";
   };
 
   propagatedBuildInputs = [ kdelibs qt4 phonon ];
-  buildInputs = [ apr aprutil subversion boost qjson ];
+  buildInputs = [ apr aprutil subversion boost qjson grantlee ];
 
   nativeBuildInputs = [ cmake automoc4 gettext pkgconfig ];
 


### PR DESCRIPTION
This updates KDevelop and KDevPlatform to the latest versions.

To get it to run, the following is (and has been) required:
- Either install this and all KDE dependencies to user environment, or add this to configuration:

```
environment.pathsToLink = ["/share/apps" "/share/kde4"];
```
- Make sure `pkgs.kde4.kdelibs` is installed either in user or system environment (e.g. add it to `environment.systemPackages`). This is needed to get `kbuildsycoca4` in PATH.
- Run `kbuildsycoca4` once in user session (or re-login).
