### PR TITLE
UID/GID fix for kippo

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -116,6 +116,7 @@
       dictd = 105;
       couchdb = 106;
       searx = 107;
+      kippo = 108;
 
       # When adding a uid, make sure it doesn't match an existing gid.
 
@@ -210,6 +211,7 @@
       dictd = 105;
       couchdb = 106;
       searx = 107;
+      kippo = 108;
 
       # When adding a gid, make sure it doesn't match an existing uid.
 

--- a/nixos/modules/services/networking/kippo.nix
+++ b/nixos/modules/services/networking/kippo.nix
@@ -76,8 +76,9 @@ rec {
     users.extraUsers = singleton {
       name = "kippo";
       description = "kippo web server privilege separation user";
+      uid = 108; # why does config.ids.uids.kippo give an error?
     };
-    users.extraGroups = singleton { name = "kippo"; };
+    users.extraGroups = singleton { name = "kippo";gid=108; };
 
     systemd.services.kippo = with pkgs; {
       description = "Kippo Web Server";


### PR DESCRIPTION
Not sure why trying the same thing as https://github.com/NixOS/nixpkgs/blob/db12d783ffd753145119c22a34ca5945e9a7a4ce/nixos/modules/services/monitoring/munin.nix and https://github.com/NixOS/nixpkgs/blob/f21abed131198355b7623613472dd30330155d28/nixos/modules/services/misc/dictd.nix with config.ids.uids.kippo does not work.
