### PR TITLE
GIO_EXTRA_MODULES option as a list of paths

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -43,7 +43,7 @@ in {
         '';
       };
 
-    environment.variables.GIO_EXTRA_MODULES = "${gnome3.dconf}/lib/gio/modules";
+    environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules" ];
     environment.systemPackages =
       [ gnome3.evince
         gnome3.eog

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -81,7 +81,7 @@ in
     environment.pathsToLink =
       [ "/share/xfce4" "/share/themes" "/share/mime" "/share/desktop-directories" "/share/gtksourceview-2.0" ];
 
-    environment.variables.GIO_EXTRA_MODULES = "${pkgs.xfce.gvfs}/lib/gio/modules";
+    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.xfce.gvfs}/lib/gio/modules" ];
 
     # Enable helpful DBus services.
     services.udisks2.enable = true;


### PR DESCRIPTION
The environment variable `GIO_EXTRA_MODULES` can be a list of paths. It does not have to be a single path.

Currently it is defined only in `xfce.nix` and `gnome3.nix` as strings.

This change will make it possible to merge definitions from different modules. Without the change a merge error occurs because options of type string cannot be merged.
