### PR TITLE
sup: Push sup to the latest git commit

### DIFF
--- a/pkgs/applications/networking/mailreaders/sup/default.nix
+++ b/pkgs/applications/networking/mailreaders/sup/default.nix
@@ -3,7 +3,7 @@
 , gettext, iconv, locale, text, highline, rmail_sup, unicode, gnupg, which }:
 
 stdenv.mkDerivation rec {
-  version = "20131130";
+  version = "20140312";
   name    = "sup-${version}";
   
   meta = {
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = git://github.com/sup-heliotrope/sup.git;
-    rev = "a5a1e39034204ac4b05c9171a71164712690b010";
-    sha256 = "0w2w7dcif1ri1qq81csz7gj45rqd9z7hjd6x29awibybyyqyvj5s";
+    rev = "0cad7b308237c07b8a46149908b2ad4806ac3d1d";
+    sha256 = "83534b6ad9fb6aa883d630c927e3a71bd09a646e3254b4eb0cc7a09f69a525bc";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/ruby_ncursesw_sup/default.nix
+++ b/pkgs/development/libraries/ruby_ncursesw_sup/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, ncurses, ruby, rubygems }:
 
 stdenv.mkDerivation rec {
-  name = ''ncursesw-sup-afd962b9c06108ff0643e98593c5605314d76917'';
+  name = "ncursesw-sup-${version}";
+  version = "1.4.6";
 
   src = fetchurl {
-    url = "https://github.com/sup-heliotrope/ncursesw-ruby/archive/afd962b9c06108ff0643e98593c5605314d76917.tar.gz";
-    sha256 = "13i286p4bm8zqg9xh96a1dg7wkywj9m6975gbh3w43d3rmfc1h6a";
+    url = "https://github.com/sup-heliotrope/ncursesw-ruby/archive/v${version}.tar.gz";
+    sha256 = "1fzmj5kqh2aql7r7jys8cyf7mb78kz71yc4a6gh74h9s8pybyhh7";
   };
 
   meta = {
@@ -32,12 +33,12 @@ stdenv.mkDerivation rec {
     # For some reason, the installation phase doesn't work with the default
     # make install command run by gem (we'll fix it and do it ourselves later)
     gem install --no-verbose --install-dir "$out/${ruby.gemPath}" \
-        --bindir "$out/bin" --no-rdoc --no-ri ncursesw-sup-1.3.1.2.gem || true
+        --bindir "$out/bin" --no-rdoc --no-ri ncursesw-${version}.gem || true
 
     # Needed for ruby to recognise the gem
     cp ncursesw.gemspec "$out/${ruby.gemPath}/specifications"
 
-    cd "$out/${ruby.gemPath}/gems/ncursesw-sup-1.3.1.2"
+    cd "$out/${ruby.gemPath}/gems/ncursesw-${version}"
     mkdir src
     mv lib src
     sed -i "s/srcdir = ./srcdir = src/" Makefile


### PR DESCRIPTION
ncursesw was also pushed forward from 1.3.1.2 -> 1.4.6 as the packaging
was changed for the latest version of sup
