### PR TITLE
pythonPackages: shellHook, globally override prefix, so development of other packages is possible

### DIFF
--- a/pkgs/development/python-modules/distutils-cfg/default.nix
+++ b/pkgs/development/python-modules/distutils-cfg/default.nix
@@ -1,10 +1,11 @@
 # global distutils configuration, see http://docs.python.org/2/install/index.html#distutils-configuration-files
 
-{ stdenv, python, writeText, extraCfg ? "" }:
+{ stdenv, python, writeText, extraCfg ? "", overrideCfg ? "" }:
 
 
 let
-  distutilsCfg = writeText "distutils.cfg" ''
+  distutilsCfg = writeText "distutils.cfg" (
+  if overrideCfg != "" then overrideCfg else ''
     [easy_install]
 
     # don't allow network connections during build to ensure purity
@@ -14,7 +15,7 @@ let
     zip_ok = 0
 
     ${extraCfg}
-  '';
+  '');
 in stdenv.mkDerivation {
   name = "${python.libPrefix}-distutils.cfg";
 

--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -156,11 +156,19 @@ python.stdenv.mkDerivation (attrs // {
       done
     '';
 
-  shellHook = attrs.shellHook or ''
+  shellHook = let
+    # Globablly override prefix, so development of other packages is possible
+    _distutils-cfg = distutils-cfg.override {
+      overrideCfg = ''
+        [easy_install]
+        prefix = /tmp/${namePrefix + name}
+      '' + distutilsExtraCfg;
+    };
+  in attrs.shellHook or ''
     mkdir -p /tmp/$name/lib/${python.libPrefix}/site-packages
     ${preShellHook}
     export PATH="/tmp/$name/bin:$PATH"
-    export PYTHONPATH="/tmp/$name/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+    export PYTHONPATH="${_distutils-cfg}/lib/${python.libPrefix}/site-packages:/tmp/$name/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
     python setup.py develop --prefix /tmp/$name
     ${postShellHook}
     return


### PR DESCRIPTION
This is usefull, because you can do `python setup.py develop` in other packages and it will just work :)
