### PR TITLE
Update logcheck from 1.3.15 to 1.3.16

### DIFF
--- a/pkgs/tools/system/logcheck/default.nix
+++ b/pkgs/tools/system/logcheck/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   _name   = "logcheck";
-  version = "1.3.15";
+  version = "1.3.16";
   name    = "${_name}-${version}";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/l/${_name}/${_name}_${version}.tar.gz";
-    sha256 = "1rdrs12hkm5i5yyz89a6cwhf4fzjkbcd4q4zy6sk148aji9lg6xj";
+    url = "mirror://debian/pool/main/l/${_name}/${_name}_${version}.tar.xz";
+    sha256 = "1rmq4s2fj86226ncw2kdjvjbi29375gd7vdq62fsbjxm4m6nzsiy";
   };
 
   preConfigure = ''


### PR DESCRIPTION
As a side note: Don't be confused if you execute `logcheck -v` and it prints 1.3.14. Somehow the version in the source code wasn't updated in a while. I'll submit a patch to logcheck to fix this.
