### PR TITLE
haskellPackages: Add AES and pbkdf haskell packages

### DIFF
--- a/pkgs/development/libraries/haskell/aes/default.nix
+++ b/pkgs/development/libraries/haskell/aes/default.nix
@@ -1,0 +1,13 @@
+{ cabal, cereal, monadsTf, random, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "AES";
+  version = "0.2.8";
+  sha256 = "1yf0mhmj294gf1b1m11gixa1xxlbvv0yl60b59fnv5lf0s170jn3";
+  buildDepends = [ cereal monadsTf random transformers ];
+  meta = {
+    description = "Fast AES encryption/decryption for bytestrings";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/pbkdf/default.nix
+++ b/pkgs/development/libraries/haskell/pbkdf/default.nix
@@ -1,0 +1,15 @@
+{ cabal, binary, byteable, bytedump, cryptohash, utf8String }:
+
+cabal.mkDerivation (self: {
+  pname = "pbkdf";
+  version = "1.1.1.1";
+  sha256 = "1nbn8kan43i00g23g8aljxjpaxm9q1qhzxxdgks0mc4mr1f7bifx";
+  buildDepends = [ binary byteable bytedump cryptohash utf8String ];
+  testDepends = [ binary byteable bytedump cryptohash utf8String ];
+  meta = {
+    homepage = "https://github.com/cdornan/pbkdf";
+    description = "Haskell implementation of the PBKDF functions from RFC-2898";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -526,6 +526,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   adjunctions = callPackage ../development/libraries/haskell/adjunctions {};
 
+  aes = callPackage ../development/libraries/haskell/aes {};
+
   aeson = callPackage ../development/libraries/haskell/aeson {
     blazeBuilder = if (pkgs.stdenv.lib.versionOlder ghc.version "7.6") then self.blazeBuilder else null;
   };

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1895,6 +1895,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   pathtype = callPackage ../development/libraries/haskell/pathtype {};
 
+  pbkdf = callPackage ../development/libraries/haskell/pbkdf {};
+
   pcap = callPackage ../development/libraries/haskell/pcap {};
 
   pcapEnumerator = callPackage ../development/libraries/haskell/pcap-enumerator {};


### PR DESCRIPTION
I noticed these two packages were missing from nixpkgs.  This is my first contribution to nixpkgs.  I just used cabal2nix, and verified that the packages are found by cabal just fine in another haskell project.
