### PR TITLE
Provisional: upgrade Mono -> 3.2.8 + LLVM support

### DIFF
--- a/pkgs/development/compilers/mono/build-fix-llvm.patch
+++ b/pkgs/development/compilers/mono/build-fix-llvm.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/CodeGen/AsmPrinter/CMakeLists.txt.old b/lib/CodeGen/AsmPrinter/CMakeLists.txt
+index be484a6..c92ff46 100644
+--- a/lib/CodeGen/AsmPrinter/CMakeLists.txt.old
++++ b/lib/CodeGen/AsmPrinter/CMakeLists.txt
+@@ -10,6 +10,7 @@ add_llvm_library(LLVMAsmPrinter
+   DwarfCompileUnit.cpp
+   DwarfDebug.cpp
+   DwarfException.cpp
++  DwarfMonoException.cpp
+   ErlangGCPrinter.cpp
+   OcamlGCPrinter.cpp
+   Win64Exception.cpp

--- a/pkgs/development/compilers/mono/default.nix
+++ b/pkgs/development/compilers/mono/default.nix
@@ -1,5 +1,9 @@
-{stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11}:
+{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? true }:
 
+let
+  llvm     = callPackage ./llvm.nix { };
+  llvmOpts = stdenv.lib.optionalString withLLVM "--enable-llvm --enable-llvmloaded --with-llvm=${llvm}";
+in
 stdenv.mkDerivation rec {
   name = "mono-${version}";
   version = "3.2.8";
@@ -8,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h0s42pmgrhwqaym0b1401h70dcpr179ngcsp7f8i4hl4snqrd7x";
   };
 
-  buildInputs = [bison pkgconfig glib gettext perl libgdiplus libX11];
+  buildInputs = [bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib];
   propagatedBuildInputs = [glib];
 
   NIX_LDFLAGS = "-lgcc_s" ;
@@ -18,7 +22,7 @@ stdenv.mkDerivation rec {
 
   # In fact I think this line does not help at all to what I
   # wanted to achieve: have mono to find libgdiplus automatically
-  configureFlags = "--x-includes=${libX11}/include --x-libraries=${libX11}/lib --with-libgdiplus=${libgdiplus}/lib/libgdiplus.so";
+  configureFlags = "--x-includes=${libX11}/include --x-libraries=${libX11}/lib --with-libgdiplus=${libgdiplus}/lib/libgdiplus.so ${llvmOpts}";
 
   # Attempt to fix this error when running "mcs --version":
   # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
@@ -27,10 +31,14 @@ stdenv.mkDerivation rec {
   # Parallel building doesn't work, as shows http://hydra.nixos.org/build/2983601
   enableParallelBuilding = false;
 
-  preBuild = "
+  # Patch all the necessary scripts. Also, if we're using LLVM, we fix the default
+  # LLVM path to point into the Mono LLVM build, since it's private anyway.
+  preBuild = ''
     makeFlagsArray=(INSTALL=`type -tp install`)
     patchShebangs ./
-  ";
+  '' + stdenv.lib.optionalString withLLVM ''
+    substituteInPlace mono/mini/aot-compiler.c --replace "llvm_path = g_strdup (\"\")" "llvm_path = g_strdup (\"${llvm}/bin/\")"
+  '';
 
   #Fix mono DLLMap so it can find libX11 and gdiplus to run winforms apps
   #Other items in the DLLMap may need to be pointed to their store locations, I don't think this is exhaustive

--- a/pkgs/development/compilers/mono/default.nix
+++ b/pkgs/development/compilers/mono/default.nix
@@ -1,10 +1,11 @@
 {stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11}:
 
 stdenv.mkDerivation rec {
-  name = "mono-2.11.4";
+  name = "mono-${version}";
+  version = "3.2.8";
   src = fetchurl {
     url = "http://download.mono-project.com/sources/mono/${name}.tar.bz2";
-    sha256 = "0wv8pnj02mq012sihx2scx0avyw51b5wb976wn7x86zda0vfcsnr";
+    sha256 = "0h0s42pmgrhwqaym0b1401h70dcpr179ngcsp7f8i4hl4snqrd7x";
   };
 
   buildInputs = [bison pkgconfig glib gettext perl libgdiplus libX11];

--- a/pkgs/development/compilers/mono/default.nix
+++ b/pkgs/development/compilers/mono/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     homepage = http://mono-project.com/;
     description = "Cross platform, open source .NET development framework";
     platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric thoughtpolice ];
     license = "free"; # Combination of LGPL/X11/GPL ?
   };
 }

--- a/pkgs/development/compilers/mono/llvm.nix
+++ b/pkgs/development/compilers/mono/llvm.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, fetchurl
+, perl
+, groff
+, cmake
+, python
+, libffi
+, binutils
+, libxml2
+, valgrind
+, ncurses
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name    = "llvm-${version}";
+  version = "3.4svn-mono-f9b1a74368";
+  src = fetchurl {
+    # from the HEAD of the 'mono3' branch
+    url = "https://github.com/mono/llvm/archive/f9b1a74368ec299fc04c4cfef4b5aa0992b7b806.tar.gz";
+    name = "${name}.tar.gz";
+    sha256 = "1bbkx4p5zdnk3nbdd5jxvbwqx8cdq8z1n1nhf639i98mggs0zhdg";
+  };
+
+  patches = [ ./build-fix-llvm.patch ];
+  unpackPhase = ''
+    unpackFile ${src}
+    mv llvm-* llvm
+    sourceRoot=$PWD/llvm
+  '';
+
+  buildInputs = [ perl groff cmake libxml2 python libffi ] ++ stdenv.lib.optional stdenv.isLinux valgrind;
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+  postBuild = "rm -fR $out";
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_BINUTILS_INCDIR=${binutils}/include"
+    "-DCMAKE_CXX_FLAGS=-std=c++11"
+  ] ++ stdenv.lib.optional (!isDarwin) "-DBUILD_SHARED_LIBS=ON";
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies - Mono build";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ thoughtpolice ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}


### PR DESCRIPTION
This is a major upgrade of Mono. I have only provisionally tested it because I needed FSharp for some other things (I'll submit a PR for that too).

This also adds LLVM support for Mono - it requires a private LLVM fork. On top of that, Mono needs to correctly point to the right LLVM binary location in the store (why it doesn't do this by default, I have no idea). But otherwise it seems to work nicely with some good speed improvements for some programs.

I'll hopefully get around to double-checking all this more sometime soon.
