### PR TITLE
haskell-wai-websockets: add version 2.1.0

### DIFF
--- a/pkgs/development/libraries/haskell/leveldb-haskell/default.nix
+++ b/pkgs/development/libraries/haskell/leveldb-haskell/default.nix
@@ -1,0 +1,21 @@
+{ cabal, async, dataDefault, filepath, leveldb, resourcet
+, transformers
+}:
+
+cabal.mkDerivation (self: {
+  pname = "leveldb-haskell";
+  version = "0.3.0";
+  sha256 = "0hdxn6v7fzc0wlpkymlci60m2584h6fn78bxdnv2q18ra03r3ygs";
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    async dataDefault filepath resourcet transformers
+  ];
+  extraLibraries = [ leveldb ];
+  meta = {
+    homepage = "http://github.com/kim/leveldb-haskell";
+    description = "Haskell bindings to LevelDB";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/wai-websockets/default.nix
+++ b/pkgs/development/libraries/haskell/wai-websockets/default.nix
@@ -1,0 +1,22 @@
+{ cabal, blazeBuilder, caseInsensitive, conduit, fileEmbed
+, httpTypes, ioStreams, network, text, transformers, wai
+, waiAppStatic, warp, websockets
+}:
+
+cabal.mkDerivation (self: {
+  pname = "wai-websockets";
+  version = "2.1.0";
+  sha256 = "094imqhkn4ghifgp2qhs4hnby3zzdd84fhmyvvy7igcpz1rmll7a";
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    blazeBuilder caseInsensitive conduit fileEmbed httpTypes ioStreams
+    network text transformers wai waiAppStatic warp websockets
+  ];
+  meta = {
+    homepage = "http://github.com/yesodweb/wai";
+    description = "Provide a bridge betweeen WAI and the websockets package";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2570,6 +2570,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   waiTest = callPackage ../development/libraries/haskell/wai-test {};
 
+  waiWebsockets = callPackage ../development/libraries/haskell/wai-websockets {};
+
   warp = callPackage ../development/libraries/haskell/warp {};
 
   warpTls = callPackage ../development/libraries/haskell/warp-tls {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1590,6 +1590,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   lenses = callPackage ../development/libraries/haskell/lenses {};
 
+  leveldbHaskell = callPackage ../development/libraries/haskell/leveldb-haskell {};
+
   libffi = callPackage ../development/libraries/haskell/libffi {
     libffi = pkgs.libffi;
   };


### PR DESCRIPTION
Created via cabal2nix without any further modifications.
