### PR TITLE
haskell-leveldb-haskell: add version 0.3.0

### DIFF
--- a/pkgs/development/libraries/haskell/leveldb-haskell/default.nix
+++ b/pkgs/development/libraries/haskell/leveldb-haskell/default.nix
@@ -1,0 +1,21 @@
+{ cabal, async, dataDefault, filepath, leveldb, resourcet
+, transformers
+}:
+
+cabal.mkDerivation (self: {
+  pname = "leveldb-haskell";
+  version = "0.3.0";
+  sha256 = "0hdxn6v7fzc0wlpkymlci60m2584h6fn78bxdnv2q18ra03r3ygs";
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    async dataDefault filepath resourcet transformers
+  ];
+  extraLibraries = [ leveldb ];
+  meta = {
+    homepage = "http://github.com/kim/leveldb-haskell";
+    description = "Haskell bindings to LevelDB";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1590,6 +1590,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   lenses = callPackage ../development/libraries/haskell/lenses {};
 
+  leveldbHaskell = callPackage ../development/libraries/haskell/leveldb-haskell {};
+
   libffi = callPackage ../development/libraries/haskell/libffi {
     libffi = pkgs.libffi;
   };


### PR DESCRIPTION
Created via cabal2nix without any further modifications.
