### PR TITLE
haskell-snowball: add version 1.0.0.1

### DIFF
--- a/pkgs/development/libraries/haskell/snowball/default.nix
+++ b/pkgs/development/libraries/haskell/snowball/default.nix
@@ -1,0 +1,21 @@
+{ cabal, HUnit, QuickCheck, quickcheckInstances, testFrameworkHunit
+, testFrameworkQuickcheck2, testFrameworkTh, text, textIcu
+}:
+
+cabal.mkDerivation (self: {
+  pname = "snowball";
+  version = "1.0.0.1";
+  doCheck = false;
+  sha256 = "0fvxzm14ffjqq6n51bi5cmq5yrlggpkbb9rbbw522l6cjgv0apbx";
+  buildDepends = [ text textIcu ];
+  testDepends = [
+    HUnit QuickCheck quickcheckInstances testFrameworkHunit
+    testFrameworkQuickcheck2 testFrameworkTh text
+  ];
+  meta = {
+    homepage = "http://hub.darcs.net/dag/snowball";
+    description = "Bindings to the Snowball library";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2193,6 +2193,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   snapServer = callPackage ../development/libraries/haskell/snap/server.nix {};
 
+  snowball = callPackage ../development/libraries/haskell/snowball {};
+
   socks = callPackage ../development/libraries/haskell/socks {};
 
   sparse = callPackage ../development/libraries/haskell/sparse {};


### PR DESCRIPTION
Created via cabal2nix.

I have disabled tests because they do require a dictionary file to run.
