### PR TITLE
haskell-scrypt: add version 0.5.0

### DIFF
--- a/pkgs/development/libraries/haskell/scrypt/default.nix
+++ b/pkgs/development/libraries/haskell/scrypt/default.nix
@@ -1,0 +1,20 @@
+{ cabal, base64Bytestring, entropy, HUnit, QuickCheck
+, testFramework, testFrameworkHunit, testFrameworkQuickcheck2
+}:
+
+cabal.mkDerivation (self: {
+  pname = "scrypt";
+  version = "0.5.0";
+  sha256 = "1cnrjdq1ncv224dlk236a7w29na8r019d2acrsxlsaiy74iadh1y";
+  buildDepends = [ base64Bytestring entropy ];
+  testDepends = [
+    HUnit QuickCheck testFramework testFrameworkHunit
+    testFrameworkQuickcheck2
+  ];
+  meta = {
+    homepage = "http://github.com/informatikr/scrypt";
+    description = "Stronger password hashing via sequential memory-hard functions";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2149,6 +2149,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   scottyHastache = callPackage ../development/libraries/haskell/scotty-hastache {};
 
+  scrypt = callPackage ../development/libraries/haskell/scrypt {};
+
   securemem = callPackage ../development/libraries/haskell/securemem {};
 
   sendfile = callPackage ../development/libraries/haskell/sendfile {};


### PR DESCRIPTION
Created via cabal2nix without any further modifications.
