### PR TITLE
power-management: Don't enable acpid.

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -65,9 +65,6 @@ in
 
   config = mkIf cfg.enable {
 
-    # Enable the ACPI daemon.  Not sure whether this is essential.
-    services.acpid.enable = true;
-
     boot.kernelModules =
       [ "acpi_cpufreq" "powernow-k8" "cpufreq_performance" "cpufreq_powersave" "cpufreq_ondemand"
         "cpufreq_conservative"

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -24,6 +24,11 @@ let
 
   driverNames = config.hardware.opengl.videoDrivers;
 
+  needsAcpid =
+     (elem "nvidia" driverNames) ||
+     (elem "nvidiaLegacy173" driverNames) ||
+     (elem "nvidiaLegacy304" driverNames);
+
   drivers = flip map driverNames
     (name: { inherit name; driverName = name; } //
       attrByPath [name] (if (hasAttr ("xf86video" + name) xorg) then { modules = [(getAttr ("xf86video" + name) xorg) ]; } else throw "unknown video driver `${name}'") knownVideoDrivers);
@@ -428,6 +433,8 @@ in
       ++ optional (elem "virtualbox" driverNames) xorg.xrefresh
       ++ optional (elem "ati_unfree" driverNames) kernelPackages.ati_drivers_x11;
 
+    services.acpid.enable = mkIf needsAcpid true;
+
     environment.pathsToLink =
       [ "/etc/xdg" "/share/xdg" "/share/applications" "/share/icons" "/share/pixmaps" ];
 
@@ -436,7 +443,8 @@ in
     systemd.services."display-manager" =
       { description = "X11 Server";
 
-        after = [ "systemd-udev-settle.service" "local-fs.target" ];
+        after = [ "systemd-udev-settle.service" "local-fs.target" ]
+                ++ optional needsAcpid "acpid.service";
 
         restartIfChanged = false;
 


### PR DESCRIPTION
Running acpid along with systemd will cause double handling of acpi events. If user wants acpid to run shell scripts for acpi events, he can still enable it and configure it appropriately.

This change will "break" some installations, in a sense that the power buttons may stop responding while user is logged in. The issue is the default value of

`services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;`

which will inhibit systemd from handling power buttons while a desktop session is running. Before this change acpid would handle the events while user is logged in (so closing lid would still suspend). But while user was logged out, the suspend would indeed happen twice.
