### PR TITLE
Update KTorrent to 4.3.1.

### DIFF
--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "KDE integrated BtTorrent client";
-    homepage = http://ktorrent.org;
+    homepage = http://ktorrent.pwsp.net;
     maintainers = with stdenv.lib.maintainers; [ sander urkud ];
     inherit (libktorrent.meta) platforms;
   };

--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -5,11 +5,11 @@ stdenv.mkDerivation rec {
   name = pname + "-" + version;
 
   pname = "ktorrent";
-  version = "4.2.1";
+  version = "4.3.1";
 
   src = fetchurl {
     url = "${meta.homepage}/downloads/${version}/${name}.tar.bz2";
-    sha256 = "1b6w7i1vvq8mlw9yrlxvb51hvaj6rpl8lv9b9zagyl3wcanz73zd";
+    sha256 = "66094f6833347afb0c49e332f0ec15ec48db652cbe66476840846ffd5ca0e4a1";
   };
 
   patches = [ ./find-workspace.diff ];

--- a/pkgs/development/libraries/libktorrent/default.nix
+++ b/pkgs/development/libraries/libktorrent/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   pname = "libktorrent";
 
   src = fetchurl {
-    url = "http://ktorrent.pwsp.net//downloads/${version4}/${name}.tar.bz2";
+    url = "${meta.homepage}/downloads/${version4}/${name}.tar.bz2";
     sha256 = "2fe11ccb4bf2028c3da11e52cde890f1b3a90560e548eac89a4f8e1558b09725";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A BiTtorrent library used by KTorrent";
-    homepage = http://ktorrent.org;
+    homepage = http://ktorrent.pwsp.net;
     inherit (kdelibs.meta) platforms;
   };
 }

--- a/pkgs/development/libraries/libktorrent/default.nix
+++ b/pkgs/development/libraries/libktorrent/default.nix
@@ -2,8 +2,8 @@
 , phonon, libgcrypt }:
 
 let
-  mp_ = "2.1";
-  version = "1.${mp_}-2";
+  mp_ = "3.1";
+  version = "1.${mp_}";
   version4 = "4.${mp_}";
 in
 stdenv.mkDerivation rec {
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
   pname = "libktorrent";
 
   src = fetchurl {
-    url = "http://ktorrent.org/downloads/${version4}/${name}.tar.bz2";
-    sha256 = "1b4ibkba27ivvjsh5s93xwlcgzvvwsgl6mcd8g96d1al05n2ccw9";
+    url = "http://ktorrent.pwsp.net//downloads/${version4}/${name}.tar.bz2";
+    sha256 = "2fe11ccb4bf2028c3da11e52cde890f1b3a90560e548eac89a4f8e1558b09725";
   };
 
   nativeBuildInputs = [ cmake automoc4 gettext ];


### PR DESCRIPTION
Compiles and runs.

Because ktorrent.org is offline, I changed the source URL to another site which pops up on Google. Not sure if this is the new official location of the site; I've taken the sha256 from Gentoo manifest.
