### PR TITLE
Add sloane -- a command line interface to OEIS.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -5,6 +5,7 @@
      alphabetically sorted.  */
 
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
+  akc = "Anders Claesson <akc@akc.is>";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
   amiddelk = "Arie Middelkoop <amiddelk@gmail.com>";

--- a/pkgs/applications/science/math/sloane/default.nix
+++ b/pkgs/applications/science/math/sloane/default.nix
@@ -1,0 +1,21 @@
+{ cabal, ansiTerminal, cmdargs, HTTP, terminalSize, url }:
+
+cabal.mkDerivation (self: {
+  pname = "sloane";
+  version = "1.6";
+  sha256 = "0my3j53bda3s8zxnm6is1align4k082wwsfg2y1i75js5z9kwmzy";
+  isLibrary = false;
+  isExecutable = true;
+  buildDepends = [ ansiTerminal cmdargs HTTP terminalSize url ];
+  postInstall = ''
+    mkdir -p $out/share/man/man1
+    cp sloane.1 $out/share/man/man1/
+  '';
+  meta = {
+    homepage = "http://github.com/akc/sloane";
+    description = "A command line interface to Sloane's On-Line Encyclopedia of Integer Sequences";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+    maintainers = with self.stdenv.lib.maintainers; [ akc ];
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2842,6 +2842,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   nc-indicators = callPackage ../applications/misc/nc-indicators {};
 
+  sloane = callPackage ../applications/science/math/sloane {};
+
   taffybar = callPackage ../applications/misc/taffybar {};
 
   yi = callPackage ../applications/editors/yi/yi.nix {};


### PR DESCRIPTION
A simple tool for looking up integer sequences in [OEIS](http://oeis.org)
without leaving your terminal.
-   Project home: https://github.com/akc/sloane
-   Hackage page: http://hackage.haskell.org/package/sloane-1.6
