### PR TITLE
xf86-video-ati: Update to 7.3.0.

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -20,6 +20,7 @@ let
     nvidiaLegacy304 = { modules = [ kernelPackages.nvidia_x11_legacy304 ]; driverName = "nvidia"; };
     unichrome    = { modules = [ pkgs.xorgVideoUnichrome ]; };
     virtualbox   = { modules = [ kernelPackages.virtualboxGuestAdditions ]; driverName = "vboxvideo"; };
+    ati = { modules = [ pkgs.xorg.xf86videoati pkgs.xorg.glamor ]; };
   };
 
   driverNames = config.hardware.opengl.videoDrivers;
@@ -372,6 +373,14 @@ in
         '';
       };
 
+      useGlamor = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to use the Glamor module for 2D acceleration,
+          if possible.
+        '';
+      };
     };
 
   };
@@ -523,6 +532,13 @@ in
           '')}
         EndSection
 
+        ${if cfg.useGlamor then ''
+          Section "Module"
+            Load "dri2"
+            Load "glamoregl"
+          EndSection
+        '' else ""}
+
         # For each supported driver, add a "Device" and "Screen"
         # section.
         ${flip concatMapStrings drivers (driver: ''
@@ -530,6 +546,7 @@ in
           Section "Device"
             Identifier "Device-${driver.name}[0]"
             Driver "${driver.driverName}"
+            ${if cfg.useGlamor then ''Option "AccelMethod" "glamor"'' else ""}
             ${cfg.deviceSection}
             ${xrandrDeviceSection}
           EndSection

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1460,14 +1460,14 @@ let
   })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
   xf86videoati = (stdenv.mkDerivation ((if overrides ? xf86videoati then overrides.xf86videoati else x: x) {
-    name = "xf86-video-ati-7.2.0";
+    name = "xf86-video-ati-7.3.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-video-ati-7.2.0.tar.bz2;
-      sha256 = "1i5fknbbhynl5hv2dzznzcf0yadpm28jzvx7xl38vlfpr3ymw3zk";
+      url = mirror://xorg/individual/driver/xf86-video-ati-7.3.0.tar.bz2;
+      sha256 = "107c072c4919a996e04f47afdb53d5946a3ad574f270b8c560ef8b3a032046fe";
     };
-    buildInputs = [pkgconfig fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+    buildInputs = [pkgconfig fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto glamor ];
+  })) // {inherit fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto glamor ;};
 
   xf86videocirrus = (stdenv.mkDerivation ((if overrides ? xf86videocirrus then overrides.xf86videocirrus else x: x) {
     name = "xf86-video-cirrus-1.5.2";
@@ -2088,5 +2088,19 @@ let
     };
     buildInputs = [pkgconfig libX11 xproto ];
   })) // {inherit libX11 xproto ;};
+
+  glamor = (stdenv.mkDerivation ((if overrides ? glamor then overrides.glamor else x: x) {
+    name = "glamor-0.6.0";
+    builder = ./builder.sh;
+    src = fetchurl {
+      url = http://xorg.freedesktop.org/archive/individual/driver/glamor-egl-0.6.0.tar.bz2;
+      sha256 = "66531b56e6054eb53daa7bd57eb6358a7ead1b84f63419606e69d1092365e5c9";
+    };
+    buildInputs = [pkgconfig xorgserver mesa pixman ];
+    configureFlags = "--with-xorg-conf-dir=$(out)/etc/X11";
+    patchPhase = ''
+      sed -i 's,sdkdir=`$PKG_CONFIG --variable=sdkdir xorg-server`,sdkdir=$out/include/xorg,' configure
+    '';
+  })) // {inherit xorgserver mesa pixman ;};
 
 }; in xorg


### PR DESCRIPTION
Includes addition of Glamor library for 2D acceleration (but using it is not enabled by default).
