### PR TITLE
deluge: add curses module for deluge-console

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2395,7 +2395,7 @@ rec {
     };
 
     propagatedBuildInputs = with pkgs; [
-      pyGtkGlade libtorrentRasterbar twisted Mako chardet pyxdg pyopenssl
+      pyGtkGlade libtorrentRasterbar twisted Mako chardet pyxdg pyopenssl modules.curses
     ];
 
     postInstall = ''


### PR DESCRIPTION
deluge-console is a curses application and this package is missing curses module, this pull request fixes it
