### PR TITLE
substitute: Preserve newlines at the end of file

### DIFF
--- a/pkgs/stdenv/common-path.nix
+++ b/pkgs/stdenv/common-path.nix
@@ -11,5 +11,6 @@
   pkgs.gnumake
   pkgs.bash
   pkgs.patch
+  pkgs.substitute
   pkgs.xz
 ]

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -304,11 +304,7 @@ substitute() {
 
     local -a params=("$@")
 
-    local n p pattern replacement varName content
-
-    # a slightly hacky way to keep newline at the end
-    content="$(cat $input; echo -n X)"
-    content="${content%X}"
+    local n p pattern replacement varName args
 
     for ((n = 2; n < ${#params[*]}; n += 1)); do
         p=${params[$n]}
@@ -332,13 +328,10 @@ substitute() {
             n=$((n + 2))
         fi
 
-        content="${content//"$pattern"/$replacement}"
+        args="$args -r $pattern $replacement"
     done
 
-    # !!! This doesn't work properly if $content is "-n".
-    echo -n "$content" > "$output".tmp
-    if [ -x "$output" ]; then chmod +x "$output".tmp; fi
-    mv -f "$output".tmp "$output"
+    command substitute $args "$input" "$output"
 }
 
 

--- a/pkgs/tools/text/substitute/default.nix
+++ b/pkgs/tools/text/substitute/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, check }:
+
+stdenv.mkDerivation rec {
+  name = "substitute-0.1.0";
+  
+  src = fetchurl {
+    url = "http://github.com/wkennington/substitute/archive/v0.1.0.tar.gz";
+    sha256 = "0m4hyz39sp1y8fa8v8zmqwyl347ml5qffcivk7c6qchvb9vs1man";
+  };
+
+  buildInputs = [ pkgconfig autoreconfHook check ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A simple utility for replacing strings within a file.";
+    homepage = "https://github.com/wkennington/substitute";
+    license = licenses.mit;
+    platform = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9031,6 +9031,8 @@ let
     conf = config.st.conf or null;
   };
 
+  substitute = callPackage ../tools/text/substitute { };
+
   sxiv = callPackage ../applications/graphics/sxiv { };
 
   bittorrentSync = callPackage ../applications/networking/bittorrentsync { };


### PR DESCRIPTION
Newer version of udev require that files contain newlines at the end.
Many of the udev rules use substitute to replace hardcoded binary paths
with nix compatible binaries. Unfortunately, this breaks on the new
version of udev since substitute always strips the newline from the end
of a file it modifies.

This patch fixes the above behavior of substitute, by determining if the
original file had a newline at the end, and appends it to the modified
file.
