### PR TITLE
libarchive: Don't use github for patches

### DIFF
--- a/pkgs/development/libraries/libarchive/CVE-2013-0211.patch
+++ b/pkgs/development/libraries/libarchive/CVE-2013-0211.patch
@@ -1,0 +1,32 @@
+From 22531545514043e04633e1c015c7540b9de9dbe4 Mon Sep 17 00:00:00 2001
+From: Tim Kientzle <kientzle@acm.org>
+Date: Fri, 22 Mar 2013 23:48:41 -0700
+Subject: [PATCH] Limit write requests to at most INT_MAX. This prevents a
+ certain common programming error (passing -1 to write) from leading to other
+ problems deeper in the library.
+
+---
+ libarchive/archive_write.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libarchive/archive_write.c b/libarchive/archive_write.c
+index eede5e0..be85621 100644
+--- a/libarchive/archive_write.c
++++ b/libarchive/archive_write.c
+@@ -673,8 +673,13 @@ struct archive_write_filter *
+ _archive_write_data(struct archive *_a, const void *buff, size_t s)
+ {
+ 	struct archive_write *a = (struct archive_write *)_a;
++	const size_t max_write = INT_MAX;
++
+ 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+ 	    ARCHIVE_STATE_DATA, "archive_write_data");
++	/* In particular, this catches attempts to pass negative values. */
++	if (s > max_write)
++		s = max_write;
+ 	archive_clear_error(&a->archive);
+ 	return ((a->format_write_data)(a, buff, s));
+ }
+-- 
+1.8.5.5
+

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -12,11 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pixqnrcf35dnqgv0lp7qlcw7k13620qkhgxr288v7p4iz6ym1zb";
   };
 
-  patches = [(fetchurl {
-    url = "https://github.com/libarchive/libarchive/commit/22531545514043e04633e1c015c7540b9de9dbe4.patch";
-    sha256 = "0c1a0prlpq5nn7zgs7cqvw9xnmhkkc8l0mpsip86k1lafircqhzh";
-    name = "CVE-2013-0211.patch";
-  })];
+  patches = [ ./CVE-2013-0211.patch ];
 
   buildInputs = [ sharutils libxml2 zlib bzip2 openssl xz ] ++
     stdenv.lib.optionals stdenv.isLinux [ e2fsprogs attr acl ];


### PR DESCRIPTION
Github dynamically generates patches in the git format-patch style each
time they are requested. This is problematic because the version string
at the bottom of the patch will change as github updates their version
of git, causing a sha256 hash mismatch.

This patch adds the CVE-2013-0211 patch to the git repo directly.
