### PR TITLE
Fix compilation of ocaml-facile with OCaml 4.xx

### DIFF
--- a/pkgs/development/libraries/facile/default.nix
+++ b/pkgs/development/libraries/facile/default.nix
@@ -9,9 +9,11 @@ stdenv.mkDerivation rec {
   };
   
   dontAddPrefix = 1;
-        
-  patchPhase = "sed -e 's@mkdir@mkdir -p@' -i Makefile";
-  
+
+  patches = [ ./ocaml_4.xx.patch ];
+
+  postPatch = "sed -e 's@mkdir@mkdir -p@' -i Makefile";
+
   postConfigure = "make -C src .depend";
   
   makeFlags = "FACILEDIR=\${out}/lib/ocaml/facile";

--- a/pkgs/development/libraries/facile/ocaml_4.xx.patch
+++ b/pkgs/development/libraries/facile/ocaml_4.xx.patch
@@ -1,0 +1,12 @@
+diff -rupN facile-1.1/src/fcl_data.ml facile-1.1-patched//src/fcl_data.ml
+--- facile-1.1/src/fcl_data.ml	2004-09-08 11:51:02.000000000 +0200
++++ facile-1.1-patched//src/fcl_data.ml	2012-12-16 13:49:36.286722670 +0100
+@@ -16,7 +16,7 @@ end
+ 
+ module Hashtbl = struct
+   type ('a, 'b) t = ('a, 'b) Hashtbl.t
+-  let create = Hashtbl.create
++  let create x = Hashtbl.create x
+   let get h = h
+ 
+   let add h k d =


### PR DESCRIPTION
Make ocaml-facile compatible with OCaml 3.12 and OCaml 4.XX
Fix http://hydra.nixos.org/build/9604433#tabs-summary
