### PR TITLE
Update Smartcard Utils + Fix Daemon Expression

### DIFF
--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pcsclite, pkgconfig, libusb1, perl }:
 stdenv.mkDerivation rec {
-  version = "1.4.14";
+  version = "1.4.15";
   name = "ccid-${version}";
 
   src = fetchurl {
-    url = "http://ftp.de.debian.org/debian/pool/main/c/ccid/ccid_${version}.orig.tar.bz2";
-    sha256 = "0inibkhzk4ghg85jkysscjrzshmxfdzz6b54dqj182l0isn082y5";
+    url = "https://alioth.debian.org/frs/download.php/file/3989/${name}.tar.bz2";
+    sha256 = "5436182246f15b3e78b1ad6707022b02dc400e3f50c4cb5e5d340a4e716d990a";
   };
 
   patchPhase = ''
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pcsclite pkgconfig libusb1 ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "ccid drivers for pcsclite";
     homepage = http://pcsclite.alioth.debian.org/;
-    license = "GPLv2+";
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [viric];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, udev, dbus_libs, perl }:
 
 stdenv.mkDerivation rec {
-  version = "1.8.10";
+  version = "1.8.11";
   name = "pcsclite-${version}";
 
   src = fetchurl {
-    url = "https://alioth.debian.org/frs/download.php/file/3963/pcsc-lite-${version}.tar.bz2";
-    sha256 = "04i63zi9ayg38z3cahp6gf3rgx23w17bmcpdccm2hvaj63blnz30";
+    url = "https://alioth.debian.org/frs/download.php/file/3991/pcsc-lite-${version}.tar.bz2";
+    sha256 = "945041c94c53959ae5a767616a4ec5099fe67f549bfd344e8bd0cfe7a3c71ac6";
   };
 
   # The OS should care on preparing the drivers into this location
@@ -20,11 +20,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Middleware to access a smart card using SCard API (PC/SC)";
     homepage = http://pcsclite.alioth.debian.org/;
-    license = "BSD";
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [viric];
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
This patch updates the ccid driver and pcsclite package as well as fixes the nixos module which implements the daemon service. The pcsc daemon needs to have a blank configuration file or else it throws out errors regarding configuration parsing.
