### PR TITLE
pcsclite: $out was misspelled

### DIFF
--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   # The OS should care on preparing the drivers into this location
   configureFlags = [
     "--enable-usbdropdir=/var/lib/pcsc/drivers"
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-    "--enable-confdir=$(out)/etc"
+    "--with-systemdsystemunitdir=$out/etc/systemd/system"
+    "--enable-confdir=$out/etc"
   ];
 
   buildInputs = [ udev dbus_libs perl ];


### PR DESCRIPTION
$(out) was evaluated to an empty string and hence pcscd didn't startup:

  configfile.l:234:tok_error() tok_error: invalid value line ...
