### PR TITLE
build-support: Add writeTextDir (forgotten commit for merged nixos modules)

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -33,6 +33,7 @@ rec {
     
   # Shorthands for `writeTextFile'.
   writeText = name: text: writeTextFile {inherit name text;};
+  writeTextDir = name: text: writeTextFile {inherit name text; destination = "/${name}";};
   writeScript = name: text: writeTextFile {inherit name text; executable = true;};
   writeScriptBin = name: text: writeTextFile {inherit name text; executable = true; destination = "/bin/${name}";};
 


### PR DESCRIPTION
I just noticed that my latest commits to nixos were missing this function.

This `writeTextFile` based helper function is especially usefull for writing a bunch of configuration files to root of the output folder
