### PR TITLE
nixos: fix linux containers (systemd-nspawn, lxc, lxc-libvirt)

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -4,7 +4,7 @@ with pkgs.lib;
 
 let
 
-  inherit (pkgs) dhcpcd;
+  dhcpcd =  if !config.boot.isContainer then pkgs.dhcpcd else pkgs.dhcpcd_without_udev;
 
   # Don't start dhcpcd on explicitly configured interfaces or on
   # interfaces that are part of a bridge.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -285,7 +285,7 @@ in
     networking.firewall.allowedTCPPorts = cfg.ports;
 
     security.pam.services.sshd =
-      { startSession = true;
+      { startSession = !config.boot.isContainer;
         showMotd = true;
         unixAuth = cfg.passwordAuthentication;
       };

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     [ # These are all changes between upstream and
       # https://github.com/edolstra/systemd/tree/nixos-v203.
       ./fixes.patch
+      ./fix_console_in_containers.patch
     ]
     ++ stdenv.lib.optional stdenv.isArm ./libc-bug-accept4-arm.patch;
 

--- a/pkgs/os-specific/linux/systemd/fix_console_in_containers.patch
+++ b/pkgs/os-specific/linux/systemd/fix_console_in_containers.patch
@@ -1,0 +1,14 @@
+diff -ruN systemd-203/units/getty@.service.m4 systemd-203-patched/units/getty@.service.m4
+--- systemd-203/units/getty@.service.m4	2013-01-07 22:50:49.083315575 +0100
++++ systemd-203-patched/units/getty@.service.m4	2014-03-18 09:54:40.002476232 +0100
+@@ -23,7 +23,9 @@
+ # On systems without virtual consoles, don't start any getty. (Note
+ # that serial gettys are covered by serial-getty@.service, not this
+ # unit
+-ConditionPathExists=/dev/tty0
++ConditionPathExists=|/dev/tty0
++ConditionVirtualization=|lxc
++ConditionVirtualization=|lxc-libvirt
+ 
+ [Service]
+ # the VT is cleared by TTYVTDisallocate

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   installFlags = "DBDIR=\${TMPDIR}/db SYSCONFDIR=$(out)/etc";
 
   # Check that the udev plugin got built.
-  postInstall = "[ -e $out/lib/dhcpcd/dev/udev.so ]";
+  postInstall = stdenv.lib.optional (udev != null) "[ -e $out/lib/dhcpcd/dev/udev.so ]";
 
   meta = {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -823,6 +823,8 @@ let
 
   dhcpcd = callPackage ../tools/networking/dhcpcd { };
 
+  dhcpcd_without_udev = callPackage ../tools/networking/dhcpcd { udev = null; };
+
   diffstat = callPackage ../tools/text/diffstat { };
 
   diffutils = callPackage ../tools/text/diffutils { };


### PR DESCRIPTION
- Make dhcp work, use dhcpcd without udev in container
- Make login shell work, patch getty to not wait for /dev/tty0
- Make ssh work, sshd/pam do not start session
