### PR TITLE
virt-manager: update to 1.0.1, fix&update dependencies, gtk3 support

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -3,7 +3,7 @@
 , makeWrapper
 , sdlSupport ? true, SDL
 , vncSupport ? true, libjpeg, libpng
-, spiceSupport ? true, spice, spice_protocol
+, spiceSupport ? true, spice, spice_protocol, usbredir
 , x86Only ? false
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ]
     ++ stdenv.lib.optionals sdlSupport [ SDL ]
     ++ stdenv.lib.optionals vncSupport [ libjpeg libpng ]
-    ++ stdenv.lib.optionals spiceSupport [ spice_protocol spice ];
+    ++ stdenv.lib.optionals spiceSupport [ spice_protocol spice usbredir ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,74 +1,67 @@
 { stdenv, fetchurl, pythonPackages, intltool, libxml2Python, curl, python
 , makeWrapper, virtinst, pyGtkGlade, pythonDBus, gnome_python, gtkvnc, vte
-, spiceSupport ? true, spice_gtk
+, gtk3, gobjectIntrospection, libvirt-glib, gsettings_desktop_schemas, glib
+, avahi, gnome3, spiceSupport ? true, spice_gtk
 }:
 
 with stdenv.lib;
+with pythonPackages;
 
-let version = "0.9.5"; in
-
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
   name = "virt-manager-${version}";
+  namePrefix = "";
+  version = "1.0.1";
 
   src = fetchurl {
-    url = "http://virt-manager.et.redhat.com/download/sources/virt-manager/virt-manager-${version}.tar.gz";
-    sha256 = "0gc06cdbq6c2a06l939516lvjii7lr0wng90kqgl1i5q5wlgnajx";
+    url = "http://virt-manager.org/download/sources/virt-manager/${name}.tar.gz";
+    sha256 = "1n248kack1fni8y17ysgq5xhvffcgy4l62hnd0zvr4kjw0579qq8";
   };
 
-  pythonPath = with pythonPackages;
-    [ setuptools eventlet greenlet gflags netaddr sqlalchemy carrot routes
+  propagatedBuildInputs =
+    [ eventlet greenlet gflags netaddr sqlalchemy carrot routes
       paste_deploy m2crypto ipy boto_1_9 twisted sqlalchemy_migrate
       distutils_extra simplejson readline glance cheetah lockfile httplib2
-      # !!! should libvirt be a build-time dependency?  Note that
-      # libxml2Python is a dependency of libvirt.py.
-      libvirt libxml2Python urlgrabber virtinst pyGtkGlade pythonDBus gnome_python
-      gtkvnc vte
+      urlgrabber virtinst pyGtkGlade pythonDBus gnome_python pygobject3
+      libvirt libxml2Python ipaddr vte
     ] ++ optional spiceSupport spice_gtk;
 
   buildInputs =
-    [ pythonPackages.python
-      pythonPackages.wrapPython
-      pythonPackages.mox
-      pythonPackages.urlgrabber
+    [ mox
       intltool
-      pyGtkGlade
-      pythonDBus
-      gnome_python
       gtkvnc
-    ] ++ pythonPath;
+      gtk3
+      libvirt-glib
+      avahi
+      glib
+      gobjectIntrospection
+    ];
 
-  buildPhase = "make";
-
-  nativeBuildInputs = [ makeWrapper pythonPackages.wrapPython ];
-
-  # TODO
-  # virt-manager     -> import gtk.glade -> No module named glade --> fixed by removing 'pygtk' and by only using pyGtkGlade
-  #                  -> import gconf     -> ImportError: No module named gconf
-  #                        -> pfad um gtk-2.0 erweitern in virt-manger runner -> /nix/store/hnyxc9i4yz2mc42n44ms13mn8n486s5h-gnome-python-2.28.1/lib/python2.7/site-packages/gtk-2.0
-  #                  -> Error starting Virtual Machine Manager: Failed to contact configuration server; the most common cause is a missing or misconfigured D-Bus session bus daemon. See http://projects.gnome.org/gconf/ for information. (Details -  1: GetIOR failed: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.gnome.GConf was not provided by any .service files)
-
-#Traceback (most recent call last):
-#  File "/nix/store/y9rcdiv6686sqcv4r39p575s37jzc2cz-virt-manager-0.9.1/share/virt-manager/virt-manager.py", line 383, in <module>
-#    main()
-#  File "/nix/store/y9rcdiv6686sqcv4r39p575s37jzc2cz-virt-manager-0.9.1/share/virt-manager/virt-manager.py", line 315, in main
-#    config = virtManager.config.vmmConfig(appname, appversion, glade_dir)
-#  File "/nix/store/y9rcdiv6686sqcv4r39p575s37jzc2cz-virt-manager-0.9.1/share/virt-manager/virtManager/config.py", line 98, in __init__
-#    self.conf.add_dir(self.conf_dir, gconf.CLIENT_PRELOAD_NONE)
-#GError: Failed to contact configuration server; the most common cause is a missing or misconfigured D-Bus session bus daemon. See http://projects.gnome.org/gconf/ for information. (Details -  1: GetIOR failed: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.gnome.GConf was not provided by any .service files)
-# -> fixed by http://nixos.org/wiki/Solve_GConf_errors_when_running_GNOME_applications & a restart
-  # virt-manager-tui -> ImportError: No module named newt_syrup.dialogscreen
-
-  installPhase = ''
-    make install
-
-    # A hack, but the most reliable method so far
-    echo "#!/usr/bin/env python" | cat - src/virt-manager.py > $out/bin/virt-manager
-    echo "#!/usr/bin/env python" | cat - src/virt-manager-tui.py > $out/bin/virt-manager-tui
-
-    wrapPythonPrograms
+  configurePhase = ''
+    sed -i 's/from distutils.core/from setuptools/g' setup.py
+    sed -i 's/from distutils.command.install/from setuptools.command.install/g' setup.py
+    python setup.py configure --prefix=$out
   '';
 
-  meta = {
+  buildPhase = "true";
+
+  postInstall = ''
+    # GI_TYPELIB_PATH is needed at runtime for GObject stuff to work
+    for file in "$out"/bin/*; do
+      wrapProgram $file \
+        --prefix GI_TYPELIB_PATH : $GI_TYPELIB_PATH \
+        --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules" \
+        --prefix LD_LIBRARY_PATH : ${gtk3}/lib/:${libvirt-glib}/lib/:${vte}/lib:${gtkvnc}/lib${optionalString spiceSupport ":${spice_gtk}/lib"} \
+        --prefix GSETTINGS_SCHEMA_DIR : $out/share/glib-2.0/schemas \
+        --prefix XDG_DATA_DIRS : "$out/share:${gsettings_desktop_schemas}/share:\$XDG_DATA_DIRS"
+    done
+
+    ${glib}/bin/glib-compile-schemas "$out"/share/glib-2.0/schemas
+  '';
+
+  # Failed tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
     homepage = http://virt-manager.org;
     description = "Desktop user interface for managing virtual machines";
     longDescription = ''
@@ -76,7 +69,7 @@ stdenv.mkDerivation rec {
       virtual machines through libvirt. It primarily targets KVM VMs, but also
       manages Xen and LXC (linux containers).
     '';
-    license = "GPLv2";
-    maintainers = with stdenv.lib.maintainers; [qknight];
+    license = licenses.gplv2;
+    maintainers = with maintainers; [qknight offline];
   };
 }

--- a/pkgs/desktops/gnome-3/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/core/vte/default.nix
@@ -1,32 +1,21 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses
-, pythonSupport ? false, python, pygtk}:
+{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
 
-  versionMajor = "0.34";
-  versionMinor = "9";
+  versionMajor = "0.35";
+  versionMinor = "90";
   moduleName   = "vte";
   
   name = "${moduleName}-${versionMajor}.${versionMinor}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
-    sha256 = "1q93dsxg56f57mxblmh8kn4v9kyc643j2pjf1j3mn2kxypnwaf3g";
+    sha256 = "c47182d1724db479095b918898ce62297ec71988f24cd575506151c59f7b98cf";
   };
 
-  buildInputs = [ intltool pkgconfig gnome3.glib gnome3.gtk ncurses ] ++
-                stdenv.lib.optionals pythonSupport [python pygtk];
+  buildInputs = [ gobjectIntrospection intltool pkgconfig gnome3.glib gnome3.gtk3 ncurses ];
 
-  configureFlags = ''
-    ${if pythonSupport then "--enable-python" else "--disable-python"}
-  '';
-
-  postInstall = stdenv.lib.optionalString pythonSupport ''
-    cd $(toPythonPath $out)/gtk-2.0
-    for n in *; do
-      ln -s "gtk-2.0/$n" "../$n"
-    done
-  '';
+  configureFlags = ''--enable-introspection'';
 
   meta = {
     homepage = http://www.gnome.org/;

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, pkgconfig, libvirt, glib, libxml2, intltool, libtool, yajl
+, nettle, libgcrypt, python, pygobject, gobjectIntrospection, libcap_ng
+}:
+
+stdenv.mkDerivation rec {
+  name = "libvirt-glib-0.1.8";
+
+  src = fetchurl {
+    url = "http://libvirt.org/sources/glib/${name}.tar.gz";
+    sha256 = "0ld7g9vlpdzx8rm90i8y1gnpygkn20x5z12gvsgms7dy5nala3ns";
+  };
+
+  buildInputs = [
+    pkgconfig libvirt glib libxml2 intltool libtool yajl nettle libgcrypt
+    python pygobject gobjectIntrospection libcap_ng
+  ];
+
+  # Compiler flag -fstack-protector-all fixes this build error:
+  #
+  #   ./.libs/libvirt-glib-1.0.so: undefined reference to `__stack_chk_guard'
+  #
+  # And the extra include path fixes this build error:
+  #
+  #   In file included from ../libvirt-gobject/libvirt-gobject-domain-device.h:30:0,
+  #                    from /tmp/nix-build-libvirt-glib-0.1.7.drv-2/libvirt-glib-0.1.7/libvirt-gobject/libvirt-gobject.h:33,
+  #                    from <stdin>:4:
+  #   ../libvirt-gobject/libvirt-gobject-domain.h:33:29: fatal error: libvirt/libvirt.h: No such file or directory
+  #   compilation terminated.
+  #   make[3]: *** [LibvirtGObject-1.0.gir] Error 1
+  preConfigure = ''
+    export NIX_CFLAGS_COMPILE="-fstack-protector-all -I${libvirt}/include"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Library for working with virtual machines";
+    longDescription = ''
+      libvirt-glib wraps libvirt to provide a high-level object-oriented API better
+      suited for glib-based applications, via three libraries:
+
+      - libvirt-glib    - GLib main loop integration & misc helper APIs
+      - libvirt-gconfig - GObjects for manipulating libvirt XML documents
+      - libvirt-gobject - GObjects for managing libvirt objects
+    '';
+    homepage = http://libvirt.org/;
+    license = licenses.lgpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, gtk, spice_protocol, intltool, celt_0_5_1
 , openssl, pulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
-, cyrus_sasl, python, pygtk, autoconf, automake, libtool }:
+, cyrus_sasl, python, pygtk, autoconf, automake, libtool, usbredir
+, gtk3, enableGTK3 ? false }:
 
 with stdenv.lib;
 
@@ -13,9 +14,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    gtk spice_protocol celt_0_5_1 openssl pulseaudio pixman gobjectIntrospection
-    libjpeg_turbo zlib cyrus_sasl python pygtk
-  ];
+    spice_protocol celt_0_5_1 openssl pulseaudio pixman gobjectIntrospection
+    libjpeg_turbo zlib cyrus_sasl python pygtk usbredir
+  ] ++ (if enableGTK3 then [ gtk3 ] else [ gtk ]);
 
   nativeBuildInputs = [ pkgconfig intltool libtool autoconf automake ];
 
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-maintainer-mode"
-    "--with-gtk=2.0"
+    (if enableGTK3 then "--with-gtk3" else "--with-gtk=2.0")
   ];
 
   dontDisableStatic = true; # Needed by the coroutine test

--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pkgconfig, libusb }:
+
+stdenv.mkDerivation rec {
+  name = "usbredir-${version}";
+  version = "0.6";
+
+  src = fetchurl {
+    url = "http://spice-space.org/download/usbredir/${name}.tar.bz2";
+    sha256 = "028184960044ea4124030000b3c55a35c3238835116e3a0fbcaff449df2c8edf";
+  };
+
+  buildInputs = [ pkgconfig libusb ];
+  propagatedBuildInputs = [ libusb ];
+
+  meta = with stdenv.lib; {
+    description = "USB traffic redirection protocol";
+    homepage = http://spice-space.org/page/UsbRedir;
+    license = licenses.lgpl21;
+
+    maintainers = [ maintainers.offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchurl
+{ pkgs, stdenv, fetchurl, gobjectIntrospection
 , python, gtk, pygtk, gnutls, cairo, libtool, glib, pkgconfig, libtasn1
 , libffi, cyrus_sasl, intltool, perl, perlPackages, firefoxPkgs, pulseaudio
-, kbproto, libX11, libXext, xextproto, pygobject, libgcrypt }:
+, kbproto, libX11, libXext, xextproto, pygobject, libgcrypt, gtk3, vala
+, pygobject3, enableGTK3 ? false }:
 
+with pkgs.lib;
 
 stdenv.mkDerivation rec {
   name = "gtk-vnc-${version}";
@@ -14,21 +16,24 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    python gtk pygtk gnutls cairo libtool pkgconfig glib libffi libgcrypt
-    intltool cyrus_sasl pulseaudio pygobject perl perlPackages.TextCSV
-  ];
+    python gnutls cairo libtool pkgconfig glib libffi libgcrypt
+    intltool cyrus_sasl pulseaudio perl perlPackages.TextCSV
+    gobjectIntrospection
+  ] ++ (if enableGTK3 then [ gtk3 vala pygobject3 ] else [ gtk pygtk pygobject ]);
 
   NIX_CFLAGS_COMPILE = "-fstack-protector-all";
   configureFlags = [
     "--with-python"
     "--with-examples"
+    (if enableGTK3 then "--with-gtk=3.0" else "--with-gtk=2.0")
   ];
 
-  makeFlags = "CODEGENDIR=${pygobject}/share/pygobject/2.0/codegen/ DEFSDIR=${pygtk}/share/pygtk/2.0/defs/";
+  makeFlags = optionalString (!enableGTK3)
+    "CODEGENDIR=${pygobject}/share/pygobject/2.0/codegen/ DEFSDIR=${pygtk}/share/pygtk/2.0/defs/";
 
   meta = with stdenv.lib; {
     description = "A GTK VNC widget";
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ raskin offline ];
     platforms = platforms.linux;
     license = licenses.lgpl21;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5211,6 +5211,8 @@ let
 
   libvirt = callPackage ../development/libraries/libvirt { };
 
+  libvirt-glib = callPackage ../development/libraries/libvirt-glib { };
+
   libvisio = callPackage ../development/libraries/libvisio { };
 
   libvisual = callPackage ../development/libraries/libvisual { };
@@ -5898,6 +5900,10 @@ let
   urt = callPackage ../development/libraries/urt { };
 
   ustr = callPackage ../development/libraries/ustr { };
+
+  usbredir = callPackage ../development/libraries/usbredir {
+    libusb = libusb1;
+  };
 
   ucommon = callPackage ../development/libraries/ucommon { };
 
@@ -9282,7 +9288,9 @@ let
   virtviewer = callPackage ../applications/virtualization/virt-viewer {};
   virtmanager = callPackage ../applications/virtualization/virt-manager {
     inherit (gnome) gnome_python;
-    vte = gnome.vte.override { pythonSupport = true; };
+    vte = gnome3.vte;
+    gtkvnc = gtkvnc.override { enableGTK3 = true; };
+    spice_gtk = spice_gtk.override { enableGTK3 = true; };
   };
 
   virtinst = callPackage ../applications/virtualization/virtinst {};


### PR DESCRIPTION
This work is based on @bjornfor branch:
https://github.com/bjornfor/nixpkgs/tree/virt-manager-version-bump
- Vte, add gtk3 support, enable introspection, update to 0.35.90
- Spice-gtk, add gtk3 support
- gtk-vnc, add gtk3 support
- Add libvirt-glib (thanks @bjornfor)

TODO (not major): fix virt-manager complaining about avahi
