### PR TITLE
chromium: install icudtl.dat when present

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -248,6 +248,8 @@ in stdenv.mkDerivation rec {
     cp -v "${buildPath}/"*.pak "${libExecPath}/"
     cp -vR "${buildPath}/locales" "${buildPath}/resources" "${libExecPath}/"
     cp -v ${buildPath}/libffmpegsumo.so "${libExecPath}/"
+    [ -f "${buildPath}/icudtl.dat" ] && \
+        cp -v "${buildPath}/icudtl.dat" "${libExecPath}/"
 
     cp -v "${buildPath}/chrome" "${libExecPath}/${packageName}"
 


### PR DESCRIPTION
In version >=34, the file icudtl.dat is mmap'd at runtime rather than
compiled into the chromium executable. It should reside in the same
directory as the executable.

(This fixes a crash at runtime with `chromiumBeta` and `chromiumDev`.)
