### PR TITLE
python-3.3, 3.4: Add support for lzma compression

### DIFF
--- a/pkgs/development/interpreters/python/3.3/default.nix
+++ b/pkgs/development/interpreters/python/3.3/default.nix
@@ -3,6 +3,7 @@
 , db
 , gdbm
 , libX11, xproto
+, lzma
 , ncurses
 , openssl
 , readline
@@ -20,7 +21,7 @@ let
   version = "${majorVersion}.5";
 
   buildInputs = filter (p: p != null) [
-    zlib bzip2 gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
+    zlib bzip2 lzma gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
   ];
 in
 stdenv.mkDerivation {

--- a/pkgs/development/interpreters/python/3.4/default.nix
+++ b/pkgs/development/interpreters/python/3.4/default.nix
@@ -3,6 +3,7 @@
 , db
 , gdbm
 , libX11, xproto
+, lzma
 , ncurses
 , openssl
 , readline
@@ -21,7 +22,7 @@ let
   fullVersion = "${version}";
 
   buildInputs = filter (p: p != null) [
-    zlib bzip2 gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
+    zlib bzip2 lzma gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
   ];
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
This is needed if you want to use the 'tarball' module to open '*.tar.xz' files.
