### PR TITLE
freetype: disable patent-encumbered code by default

### DIFF
--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -66,11 +66,12 @@ stdenv.mkDerivation rec {
 
   passthru.infinality.useInfinality = useInfinality; # for fontconfig
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A font rendering engine";
     homepage = http://www.freetype.org/;
-    license = if useEncumberedCode then "unfree"
-      else "GPLv2+"; # or the FreeType License (BSD + advertising clause)
-    platforms = stdenv.lib.platforms.all;
+    license = if useEncumberedCode then licenses.unfree
+      else licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
+    platforms = platforms.all;
+    maintainers = [ maintainers.ttuegel ];
   };
 }

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -3,10 +3,14 @@
   # Microsoft, so it is disabled by default.  This option allows it to
   # be enabled.  See http://www.freetype.org/patents.html.
 , useEncumberedCode ? false
-, useInfinality ? true
+, useInfinality ? false
 }:
 
-assert !(useEncumberedCode && useInfinality); # probably wouldn't make sense
+# The Infinality patches enable patent-encumbered code in freetype. This
+# assertion requires the user to acknowledge that they are enabling
+# unredistributable patent-encumbered code. Of course, it is still possible to
+# enable the encumbered code without using Infinality.
+assert (!useInfinality || useEncumberedCode);
 
 let
 


### PR DESCRIPTION
The Infinality patches were enabled by default, but they enabled patent-encumbered code (subpixel rendering).

I have also added myself as maintainer, since noone else was listed.
