### PR TITLE
bsdiff: adopt and clean up

### DIFF
--- a/pkgs/tools/compression/bsdiff/builder.sh
+++ b/pkgs/tools/compression/bsdiff/builder.sh
@@ -1,8 +1,0 @@
-source $stdenv/setup
-
-installFlags="PREFIX=$out INSTALL=install"
-
-mkdir -p "$out/bin"
-mkdir -p "$out/man/man1"
-
-genericBuild

--- a/pkgs/tools/compression/bsdiff/default.nix
+++ b/pkgs/tools/compression/bsdiff/default.nix
@@ -1,14 +1,37 @@
-{stdenv, fetchurl, bzip2}:
+{ stdenv, fetchurl, bzip2 }:
 
-stdenv.mkDerivation {
-  name = "bsdiff-4.3";
-  builder = ./builder.sh;
+stdenv.mkDerivation rec {
+  name    = "bsdiff-${version}";
+  version = "4.3";
+
   src = fetchurl {
-    url = http://www.daemonology.net/bsdiff/bsdiff-4.3.tar.gz;
+    url    = "http://www.daemonology.net/bsdiff/${name}.tar.gz";
     sha256 = "0j2zm3z271x5aw63mwhr3vymzn45p2vvrlrpm9cz2nywna41b0hq";
   };
+
   buildInputs = [ bzip2 ];
-  patchPhase = ''
-    sed 's/^\.//g' -i Makefile
+  patches = [ ./include-systypes.patch ];
+
+  buildPhase = ''
+    cc -O3 -lbz2 bspatch.c -o bspatch
+    cc -O3 -lbz2 bsdiff.c  -o bsdiff
   '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+
+    cp bsdiff    $out/bin
+    cp bspatch   $out/bin
+    cp bsdiff.1  $out/share/man/man1
+    cp bspatch.1 $out/share/man/man1
+  '';
+
+  meta = {
+    description = "An efficient binary diff/patch tool";
+    homepage    = "http://www.daemonology.net/bsdiff";
+    license     = stdenv.lib.licenses.bsd2;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
 }

--- a/pkgs/tools/compression/bsdiff/include-systypes.patch
+++ b/pkgs/tools/compression/bsdiff/include-systypes.patch
@@ -1,0 +1,12 @@
+diff --git a/bspatch.c b/bspatch.c
+index 643c60b..543379c 100644
+--- a/bspatch.c
++++ b/bspatch.c
+@@ -28,6 +28,7 @@
+ __FBSDID("$FreeBSD: src/usr.bin/bsdiff/bspatch/bspatch.c,v 1.1 2005/08/06 01:59:06 cperciva Exp $");
+ #endif
+ 
++#include <sys/types.h>
+ #include <bzlib.h>
+ #include <stdlib.h>
+ #include <stdio.h>


### PR DESCRIPTION
Bonus: now goes from broken to working! I'm pretty sure the last expression
didn't actually properly fix the (broken) installation step. Anyway,
it's easier to just build the programs directly than hacking the BSD
makefile with `sed` or whatever.

This should also fix the build of bsdiff for Darwin that I saw fail on
Hydra, due to a missing include (patch taken from Homebrew).
