### PR TITLE
ssdeep: remove Darwin from Hydra platforms for now

### DIFF
--- a/pkgs/tools/security/ssdeep/default.nix
+++ b/pkgs/tools/security/ssdeep/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A program for calculating fuzzy hashes";
     homepage    = "http://www.ssdeep.sf.net";
     license     = stdenv.lib.licenses.gpl2;
-    platforms   = stdenv.lib.platforms.unix;
+    platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
I really need to get Nix on my Darwin machine, but at the moment this just fixes `ssdeep` to only work on Linux (as there's a bug requiring `patchelf` to fix that I haven't made a patch for yet).
