### PR TITLE
Add mps 1.113.0, fix usage of Sleepycat license

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -248,4 +248,10 @@
     fullName = "Zope Public License 2.1";
     url = "http://old.zope.org/Resources/License/ZPL-2.1";
   };
+
+  sleepycat = {
+    shortName = "Sleepycat";
+    fullName  = "Sleepycat Public License";
+    url       = "https://en.wikipedia.org/wiki/Sleepycat_License";
+  };
 }

--- a/pkgs/applications/ike/default.nix
+++ b/pkgs/applications/ike/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     description = "IPsec Client for FreeBSD, NetBSD and many Linux based operating systems";
     platforms = platforms.unix;
     maintainers = [ maintainers.iElectric ];
-    license = "sleepycat";
+    license = licenses.sleepycat;
   };
 }

--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -5,7 +5,7 @@
 # Options from inherited versions
 , version, sha256
 , extraPatches ? [ ]
-, license ? "Berkeley Database License"
+, license ? stdenv.lib.licenses.sleepycat
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     url = "http://download.oracle.com/berkeley-db/${name}.tar.gz";
     sha256 = sha256;
   };
-  
+
   patches = extraPatches;
 
   configureFlags = [

--- a/pkgs/development/libraries/mps/default.nix
+++ b/pkgs/development/libraries/mps/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, autoreconfHook, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "mps-${version}";
+  version = "1.113.0";
+
+  src = fetchurl {
+    url    = "http://www.ravenbrook.com/project/mps/release/${version}/mps-kit-${version}.tar.gz";
+    sha256 = "0v4difh3yl2mvpvnwlavhaags945l1452g07fllhdbpzgbjay79i";
+  };
+
+  buildInputs = [ autoreconfHook sqlite ];
+
+  # Fix a slightly annoying build failure in 'make install'
+  patchPhase = "substituteInPlace ./Makefile.in --replace /hot/Release /hot";
+
+  meta = {
+    description = "A flexible memory management and garbage collection library";
+    homepage    = "http://www.ravenbrook.com/project/mps";
+    license     = stdenv.lib.licenses.sleepycat;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5304,6 +5304,8 @@ let
 
   mlt = callPackage ../development/libraries/mlt { };
 
+  mps = callPackage ../development/libraries/mps { };
+
   libmpeg2 = callPackage ../development/libraries/libmpeg2 { };
 
   mpeg2dec = libmpeg2;


### PR DESCRIPTION
MPS is the "Memory Pool System", a Garbage collection and memory management library from Ravenbrook.

MPS is traditionally used 'inline' without an autoconf-packaged distribution, but this package also installs its telemetry tools and debugging libraries, which are quite useful in practice for client applications.

MPS is under the Sleepycat license (and dually a commercial license). So I took the time to add it to `licenses.nix` and fixed up the uses of it. `ike` and `db` were the only other packages I could find, which I fixed to use sleepycat instead.
