### PR TITLE
Fix services.udisks.enable = true

### DIFF
--- a/nixos/modules/services/hardware/udisks.nix
+++ b/nixos/modules/services/hardware/udisks.nix
@@ -40,6 +40,8 @@ with pkgs.lib;
       '';
 
     services.udev.packages = [ pkgs.udisks ];
+
+    systemd.packages = [ pkgs.udisks ];
   };
 
 }

--- a/pkgs/os-specific/linux/udisks/1-default.nix
+++ b/pkgs/os-specific/linux/udisks/1-default.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
       substituteInPlace src/main.c --replace \
         "/sbin:/bin:/usr/sbin:/usr/bin" \
         "${utillinux}/bin:${mdadm}/sbin:/var/run/current-system/sw/bin:/var/run/current-system/sw/sbin"
+
+      # For some reason @libexec@ is set to 'lib/' when building.
+      # Passing --libexecdir in configureFlags didn't help.
+      substituteInPlace data/systemd/udisks.service.in \
+        --replace "@libexecdir@" "$out/libexec"
     '';
 
   buildInputs =


### PR DESCRIPTION
Latest update to udisks in 344f2e65 broke it for me. Fix it by doing the
following:
- Add udisks.service to /etc/systemd/system (via systemd.packages)
- Fix path to udisks-daemon in udisks.service (libexec/ instead of lib/)
