### PR TITLE
Wrap k3b with PATH to required tools

### DIFF
--- a/pkgs/applications/misc/k3b/default.nix
+++ b/pkgs/applications/misc/k3b/default.nix
@@ -1,8 +1,12 @@
 { stdenv, fetchurl, cmake, qt4, perl, shared_mime_info, libvorbis, taglib
 , flac, libsamplerate, libdvdread, lame, libsndfile, libmad, gettext
 , kdelibs, kdemultimedia, automoc4, phonon, libkcddb ? null
+, makeWrapper, cdrkit, cdrdao, dvdplusrwtools
 }:
 
+let
+  runtimeDeps = [ cdrkit cdrdao dvdplusrwtools ];
+in
 stdenv.mkDerivation rec {
   name = "k3b-2.0.2";
   
@@ -16,10 +20,22 @@ stdenv.mkDerivation rec {
       flac libsamplerate libdvdread lame libsndfile
       libmad gettext stdenv.gcc.libc
       kdelibs kdemultimedia automoc4 phonon
-      libkcddb
-    ];
+      libkcddb makeWrapper
+    ]
+    # Runtime dependencies are *not* propagated so they are easy to override.
+    ++ runtimeDeps;
 
   enableParallelBuilding = true;
+
+  postInstall =
+    # Wrap k3b with PATH to required tools, so they can be found without being
+    # installed in a profile. The PATH is suffixed so that profile-installed
+    # tools take preference.
+    let extraPath = stdenv.lib.makeSearchPath "bin" runtimeDeps;
+    in ''
+      wrapProgram "$out/bin/k3b" --suffix PATH : ${extraPath}
+      wrapProgram "$out/bin/k3bsetup" --suffix PATH : ${extraPath}
+    '';
                   
   meta = with stdenv.lib; {
     description = "CD/DVD Burning Application for KDE";


### PR DESCRIPTION
k3b needs tools from `cdrkit`, `cdrdao` and `dvdplusrwtools` at runtime. This patch wraps the `k3b` and `k3bsetup` executables with the paths to the tools they need so the tools need not be installed in a user's profile.
