### PR TITLE
Fix -fsanitize=... options for clang

### DIFF
--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -28,7 +28,11 @@ stdenv.mkDerivation {
   (stdenv.lib.optional (stdenv.gcc.gcc != null) "-DGCC_INSTALL_PREFIX=${stdenv.gcc.gcc}");
 
   # Clang expects to find LLVMgold in its own prefix
-  postInstall = "ln -sv ${llvm}/lib/LLVMgold.so $out/lib";
+  # Clang expects to find sanitizer libraries in its own prefix
+  postInstall = ''
+    ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+    ln -sv ${llvm}/lib/clang/3.4/lib $out/lib/clang/3.4/
+  '';
 
   passthru.gcc = stdenv.gcc.gcc;
 


### PR DESCRIPTION
When using -fsanitize=... options clang implicitly
links binary to static libraries which are part of
llvm, but expects them to be found under clang prefix
