### PR TITLE
shellinabox: unhardcode /bin/login, apply vt100 '-' fixup

### DIFF
--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pam, openssl, openssh }:
+{ stdenv, fetchurl, pam, openssl, openssh, shadow }:
 
 stdenv.mkDerivation {
   name = "shellinabox-2.14";
@@ -7,12 +7,17 @@ stdenv.mkDerivation {
     url = "https://shellinabox.googlecode.com/files/shellinabox-2.14.tar.gz";
     sha1 = "9e01f58c68cb53211b83d0f02e676e0d50deb781";
   };
+
   buildInputs = [pam openssl openssh];
+
+  patches = [ ./shellinabox-minus.patch ];
 
   # Disable GSSAPIAuthentication errors as well as correct hardcoded path. Take /usr/games's place. 
   preConfigure = ''
     substituteInPlace ./shellinabox/service.c --replace "-oGSSAPIAuthentication=no" ""
     substituteInPlace ./shellinabox/launcher.c --replace "/usr/games" "${openssh}/bin"
+    substituteInPlace ./shellinabox/service.c --replace "/bin/login" "${shadow}/bin/login"
+    substituteInPlace ./shellinabox/launcher.c --replace "/bin/login" "${shadow}/bin/login"
     '';
   meta = {
     homepage = https://code.google.com/p/shellinabox;

--- a/pkgs/servers/shellinabox/shellinabox-minus.patch
+++ b/pkgs/servers/shellinabox/shellinabox-minus.patch
@@ -1,0 +1,28 @@
+diff -ru shellinabox-2.14/shellinabox/vt100.js shellinabox-2.14.new/shellinabox/vt100.js
+--- shellinabox-2.14/shellinabox/vt100.js	2012-04-21 21:30:44.000000000 +0400
++++ shellinabox-2.14.new/shellinabox/vt100.js	2014-03-27 16:33:31.012344164 +0400
+@@ -2676,6 +2676,7 @@
+       switch (key) {
+       case  33: /* Page Up      */ this.scrollBack();                   return;
+       case  34: /* Page Down    */ this.scrollFore();                   return;
++      case 173: /* _            */ ch = this.applyModifiers(95, event); break;
+       default:                                                          break;
+       }
+     }
+@@ -2738,6 +2739,7 @@
+       case 123: /* F12          */ ch = '\u001B[24~';                   break;
+       case 144: /* Num Lock     */                                      return;
+       case 145: /* Scroll Lock  */                                      return;
++      case 173: /* -            */ ch = this.applyModifiers(45, event); break;
+       case 186: /* ;            */ ch = this.applyModifiers(59, event); break;
+       case 187: /* =            */ ch = this.applyModifiers(61, event); break;
+       case 188: /* ,            */ ch = this.applyModifiers(44, event); break;
+@@ -2882,6 +2884,7 @@
+     case 109: /* - -> _ */ u = 45; s =  95; break;
+     case 111: /* / -> ? */ u = 47; s =  63; break;
+ 
++    case 173: /* - -> _ */ u = 45; s =  95; break;
+     case 186: /* ; -> : */ u = 59; s =  58; break;
+     case 187: /* = -> + */ u = 61; s =  43; break;
+     case 188: /* , -> < */ u = 44; s =  60; break;
+


### PR DESCRIPTION
The VT100 patch re-enables the '-' and '_' keys in Firefox 27.0.1
