### PR TITLE
Add rakudo & rakudo-star

### DIFF
--- a/pkgs/development/compilers/rakudo/default.nix
+++ b/pkgs/development/compilers/rakudo/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, perl, icu, jdk, git, zlib, gmp, readline
+, useStar ? false }:
+
+with stdenv.lib;
+
+let
+  rakudoNom = rec {
+    name    = "rakudo-${version}";
+    version = "2014.03.01";
+    src = fetchurl {
+      url    = "https://github.com/rakudo/rakudo/archive/${version}.tar.gz";
+      sha256 = "0pxv509431wvn0xiqd69zzx3hz0jwlwrbmzc958jgr1i2h2s2v7b";
+    };
+  };
+
+  rakudoStar = rec {
+    name    = "rakudo-star-${version}";
+    version = "2014.01";
+    src = fetchurl {
+      url    = "http://rakudo.org/downloads/star/${name}.tar.gz";
+      sha256 = "1j432wpcpvv7pk71xv1im8lwnql0rnkp25k2h8nmniw8gi9jhzh1";
+    };
+  };
+
+  rakudoPkg = if useStar then rakudoStar else rakudoNom;
+in
+stdenv.mkDerivation (rakudoPkg // {
+  buildInputs = [ perl icu jdk git zlib gmp readline ];
+  checkTarget = "test";
+  doCheck     = true;
+
+  configureScript = "perl ./Configure.pl";
+  configureFlags =
+    [ "--gen-nqp"
+      "--gen-parrot"
+      ("--backends=jvm,parrot" + (optionalString (!useStar) ",moar --gen-moar"))
+    ];
+
+  meta = {
+    description = "A Perl 6 implementation";
+    homepage    = "http://www.rakudo.org";
+    license     = stdenv.lib.licenses.artistic2;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3434,6 +3434,14 @@ let
 
   rake = rubyLibs.rake;
 
+  rakudo = callPackage ../development/compilers/rakudo {
+    useStar = false;
+  };
+
+  rakudo-star = callPackage ../development/compilers/rakudo {
+    useStar = true;
+  };
+
   rubySqlite3 = callPackage ../development/ruby-modules/sqlite3 { };
 
   rubygemsFun = ruby: builderDefsPackage (import ../development/interpreters/ruby/rubygems.nix) {


### PR DESCRIPTION
(Recreated from #2026 because of an error on my part.)

---

This adds the Rakudo Perl 6 implementations, which come in two forms: Rakudo and Rakudo Star. 'Rakudo' is the mainline version (released monthly), while 'Star' is more of an ongoing RC for users that lags behind a bit.

They are both built from the same expression since there is essentially little difference.

Note that Rakudo comes with multiple backends, and as many as possible are enabled for both versions. Right now, there is Parrot, MoarVM, and the JVM. The JVM backend is the default for the perl6 executable, because while it has a slow startup time, it is the fastest overall backend post warmup (4x-40x faster) and the most compliant with the Perl 6 specification.

Right now, this package uses functionality in the source repositories to download Parrot/MoarVM (via git) and use them in the build system. Ideally, parrot and moarvm would be their own expressions upon which this one can depend, but the current solution works easier for now and ensures good compatibility as the projects move forward.
