### PR TITLE
gvfs: Fix build with lightWeight=false.

### DIFF
--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -2,7 +2,7 @@
 , glib, dbus, udev, udisks2, libgcrypt
 , libgphoto2, avahi, libarchive, fuse, libcdio
 , libxml2, libxslt, docbook_xsl
-, lightWeight ? true, gnome, samba, makeWrapper }:
+, lightWeight ? true, gnome, samba, libgnome_keyring, gconf, makeWrapper }:
 
 let
   ver_maj = "1.18";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4584,7 +4584,7 @@ let
 
   gts = callPackage ../development/libraries/gts { };
 
-  gvfs = callPackage ../development/libraries/gvfs { };
+  gvfs = callPackage ../development/libraries/gvfs { gconf = gnome.GConf; };
 
   gwenhywfar = callPackage ../development/libraries/gwenhywfar { };
 


### PR DESCRIPTION
This fix allows building with lightWeight=false which includes support for SMB backend.
