### PR TITLE
Fix disnix related sources that were referencing dead hydra tarball

### DIFF
--- a/pkgs/tools/package-management/disnix/default.nix
+++ b/pkgs/tools/package-management/disnix/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation {
   name = "disnix-0.3pre8aa12b65ced9029f7c17a494cee25e6ffc69fdea";
   
   src = fetchurl {
-    url = http://hydra.nixos.org/build/6763179/download/4/disnix-0.3pre8aa12b65ced9029f7c17a494cee25e6ffc69fdea.tar.gz;
-    sha256 = "0zmsaz1kvc7dl1igh6z74jxy3w5p2zbfm9jsczdjdh3947fkni4p";
+    url = http://hydra.nixos.org/build/9876935/download/4/disnix-0.3pre15e93a364ad9439d8336e659921600d48252045d.tar.gz;
+    sha256 = "1kgc6cacpp3ly7c62ah6pdprdl1bab08b4ir4dcrrm44x6fa1k63";
   };
   
   buildInputs = [ pkgconfig dbus_glib libxml2 libxslt getopt nixUnstable libintlOrEmpty libiconvOrEmpty dysnomia ];

--- a/pkgs/tools/package-management/disnix/disnixos/default.nix
+++ b/pkgs/tools/package-management/disnix/disnixos/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, disnix, socat, pkgconfig }:
+{ stdenv, fetchurl, disnix, socat, pkgconfig, getopt }:
 
 stdenv.mkDerivation {
   name = "disnixos-0.2prebb320d396f93d7062c28d6a54105d8e8196b9d99";
   
   src = fetchurl {
-    url = http://hydra.nixos.org/build/6769017/download/3/disnixos-0.2prebb320d396f93d7062c28d6a54105d8e8196b9d99.tar.gz;
-    sha256 = "0jw05qjn0fbf4xb2g8a8i0padmsw17ayr4acw7z784bljrm1z055";
+    url = http://hydra.nixos.org/build/9877039/download/3/disnixos-0.2preb10c56eeb1be3046645eea90c779e2d64045581f.tar.gz;
+    sha256 = "1pkpf6vp9q3jjp212lghbs1km8iqh4rm9xa5jm0dqb5ya25f0jf2";
   };
   
-  buildInputs = [ socat pkgconfig disnix ];
+  buildInputs = [ socat pkgconfig disnix getopt ];
   
   dontStrip = true;
   

--- a/pkgs/tools/package-management/disnix/dysnomia/default.nix
+++ b/pkgs/tools/package-management/disnix/dysnomia/default.nix
@@ -9,6 +9,7 @@
 , enableTomcatWebApplication ? false
 , enableMongoDatabase ? false
 , catalinaBaseDir ? "/var/tomcat"
+, getopt
 }:
 
 assert enableMySQLDatabase -> mysql != null;
@@ -20,8 +21,8 @@ assert enableMongoDatabase -> mongodb != null;
 stdenv.mkDerivation {
   name = "dysnomia-0.3pred677260f77bb202c7490f7db08dbd8442c9db484";
   src = fetchurl {
-    url = http://hydra.nixos.org/build/6763096/download/1/dysnomia-0.3pred677260f77bb202c7490f7db08dbd8442c9db484.tar.gz;
-    sha256 = "0k7qpqa9inzxjdryd7zfzxid8k1icsxxw995chzw4wrlgxns16xy";
+    url = http://hydra.nixos.org/build/9146265/download/1/dysnomia-0.3pre313a5f99a166fee2e0245dfd25f41ec9ed958075.tar.gz;
+    sha256 = "0fgbqybr9rfr95fkmv1hpq7al0p1kxa385k6sjc7iwwcxs4cmxf5";
   };
   
   preConfigure = if enableEjabberdDump then "export PATH=$PATH:${ejabberd}/sbin" else "";
@@ -37,7 +38,7 @@ stdenv.mkDerivation {
      ${if enableMongoDatabase then "--with-mongodb" else "--without-mongodb"}
    '';
   
-  buildInputs = []
+  buildInputs = [ getopt ]
     ++ stdenv.lib.optional enableEjabberdDump ejabberd
     ++ stdenv.lib.optional enableMySQLDatabase mysql
     ++ stdenv.lib.optional enablePostgreSQLDatabase postgresql


### PR DESCRIPTION
Disnix & Dysnomia reference sources from a hydra build that do not exist any more. This patch updates to more recent tarball builds. 

Also adds `getopt` dependency which appears to now be required.
