### PR TITLE
postgresql: properly fix permissions issue by in postStart

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -225,14 +225,14 @@ in
         # Wait for PostgreSQL to be ready to accept connections.
         postStart =
           ''
-            while ! psql postgres -c "" 2> /dev/null; do
+            while ! su -s ${pkgs.stdenv.shell} postgres -c 'psql postgres -c ""' 2> /dev/null; do
                 if ! kill -0 "$MAINPID"; then exit 1; fi
                 sleep 0.1
             done
 
             if test -e "${cfg.dataDir}/.first_startup"; then
               ${optionalString (cfg.initialScript != null) ''
-                cat "${cfg.initialScript}" | psql postgres
+                cat "${cfg.initialScript}" | su -s ${pkgs.stdenv.shell} postgres -c 'psql postgres'
               ''}
               rm -f "${cfg.dataDir}/.first_startup"
             fi


### PR DESCRIPTION
as per postgresql manual, interactions with psql should be carried
out with the postgresql system user and postgresql db user by default.

ensure it happens in postStart.

related to #2058
