### PR TITLE
btsync: 1.2.91 -> 1.3.77

### DIFF
--- a/pkgs/applications/networking/bittorrentsync/default.nix
+++ b/pkgs/applications/networking/bittorrentsync/default.nix
@@ -1,47 +1,43 @@
 { stdenv, fetchurl, patchelf }:
 
-# this package contains the daemon version of bittorrent sync
-# it's unfortunately closed source.
-
 let
-  # TODO: arm, ppc, osx
-
   arch = if stdenv.system == "x86_64-linux" then "x64"
     else if stdenv.system == "i686-linux" then "i386"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
-    
-  interpreter = if stdenv.system == "x86_64-linux" then "ld-linux-x86-64.so.2"
-    else if stdenv.system == "i686-linux" then "ld-linux.so.2"
+
+  sha256 = if stdenv.system == "x86_64-linux" then "1x95pag8ncjx3svm4424fjk5nmbdg8m87fsxy9sc63ba3qs9645j"
+    else if stdenv.system == "i686-linux" then "0l8d85ib6kbpz5sh9v0qga03i4xph61iiy9xlhazm9h30d5a6l8v"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
 
-  version = "1.2.91";
-  sha256 = if stdenv.system == "x86_64-linux" then "1rx5mmk3ffkh6dbm0m33nyx6spsxqjw9djclcf9x9bs3zfyzgmnd"
-    else if stdenv.system == "i686-linux" then "1566mp01149gsb57dv87420w1vq2f3adp6g1c90xdxjxzd67yqpw"
-    else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.libc ];
+in
+stdenv.mkDerivation rec {
+  name = "btsync-${version}";
+  version = "1.3.77";
 
-in stdenv.mkDerivation {
-  name = "btsync-bin-${version}";
-  src = fetchurl {
-    url = "http://syncapp.bittorrent.com/${version}/btsync_${arch}-${version}.tar.gz";
+  src  = fetchurl {
+    url  = "http://download-lb.utorrent.com/endpoint/btsync/os/linux-${arch}/track/stable";
+    name = "btsync-${arch}-${version}.tar.gz";
     inherit sha256;
   };
 
-  sourceRoot = ".";
+  dontStrip   = true; # Don't strip, otherwise patching the rpaths breaks
+  sourceRoot  = ".";
+  buildInputs = [ patchelf ];
 
   installPhase = ''
     ensureDir "$out/bin/"
     cp -r "btsync" "$out/bin/"
 
-    patchelf --set-interpreter ${stdenv.glibc}/lib/${interpreter} \
-      "$out/bin/btsync"
+    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-rpath ${libPath} "$out/bin/btsync"
   '';
 
-  buildInputs = [ patchelf ];
-
   meta = {
-    homepage = "http://labs.bittorrent.com/experiments/sync.html";
     description = "Automatically sync files via secure, distributed technology";
-    license = stdenv.lib.licenses.unfree;
-    maintainers = [ stdenv.lib.maintainers.iElectric ];
+    homepage    = "http://www.bittorrent.com/sync";
+    license     = stdenv.lib.licenses.unfreeRedistributable;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ iElectric thoughtpolice ];
   };
 }


### PR DESCRIPTION
This also does some various cleanup on the build process. In particular,
patchelf was not properly setting the rpath so e.g. librt and libm did
not point into glibc inside the Nix store on my Ubuntu system. This
properly sets the library paths on installation.

Also, the download URL for BitTorrent Sync changed, which is incredibly
annoying, because the URL doesn't encode version information. So maybe
this will fail later. :(

(A final note: this also changes the package name from 'btsync-bin' to
just 'btsync', and cleans up some meta attributes.)
