### PR TITLE
Add options for enabling libvirtd TLS and certificates in nixos

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -7,11 +7,21 @@ with pkgs.lib;
 let
 
   cfg = config.virtualisation.libvirtd;
+
+  listenArgs = if cfg.listen then "--listen" else "";
+  
+  caFile = if cfg.authorityCert != "" then pkgs.writeText "cacert.pem" cfg.authorityCert else "";
+  certFile = if cfg.serverCert != "" then pkgs.writeText "servercert.pem" cfg.serverCert else "";
+  keyFile = if cfg.serverKey != "" then pkgs.writeText "serverkey.pem" cfg.serverKey else "";
+
   configFile = pkgs.writeText "libvirtd.conf" ''
     unix_sock_group = "libvirtd"
     unix_sock_rw_perms = "0770"
     auth_unix_ro = "none"
     auth_unix_rw = "none"
+    ca_file = "${caFile}"
+    key_file = "${keyFile}"
+    cert_file = "${certFile}"
     ${cfg.extraConfig}
   '';
 
@@ -53,6 +63,61 @@ in
           '';
       };
 
+    virtualisation.libvirtd.listen =
+      mkOption {
+        default = false;
+        description =
+          ''
+            Start libvirtd with the listen_tls option.
+            Note: requires that you also set caPem, keyPem, certPem 
+          '';
+      };
+
+    virtualisation.libvirtd.authorityCert =
+      mkOption {
+        default = "";
+        description =
+          ''
+            Set the trusted CA certificate in pem format. 
+          '';
+      };
+
+    virtualisation.libvirtd.serverCert =
+      mkOption {
+        default = "";
+        description =
+          ''
+            Set the server's certificate signed by the CA.
+          '';
+      };
+
+    virtualisation.libvirtd.serverKey =
+      mkOption {
+        default = "";
+        description =
+          ''
+            Set the server's private key.
+          '';
+      };
+
+    virtualisation.libvirtd.clientCert =
+      mkOption {
+        default = "";
+        description =
+          ''
+            Set the client's certificate signed by the CA.
+          '';
+      };
+
+    virtualisation.libvirtd.clientKey =
+      mkOption {
+        default = "";
+        description =
+          ''
+            Set the client's private key.
+          '';
+      };
+
   };
 
 
@@ -70,7 +135,7 @@ in
       { description = "Libvirt Virtual Machine Management Daemon";
 
         wantedBy = [ "multi-user.target" ];
-        after = [ "systemd-udev-settle.service" ];
+        after = [ "systemd-udev-settle.service" "syslog.target" "network.target"];
 
         path =
           [ pkgs.bridge_utils pkgs.dmidecode pkgs.dnsmasq
@@ -117,8 +182,7 @@ in
             done
           ''; # */
 
-        serviceConfig.ExecStart = ''@${pkgs.libvirt}/sbin/libvirtd libvirtd --config "${configFile}" --daemon --verbose'';
-        serviceConfig.Type = "forking";
+        serviceConfig.ExecStart = ''@${pkgs.libvirt}/sbin/libvirtd libvirtd --config "${configFile}" --verbose ${listenArgs}'';
         serviceConfig.KillMode = "process"; # when stopping, leave the VMs alone
 
         # Wait until libvirtd is ready to accept requests.
@@ -156,6 +220,20 @@ in
       };
 
     users.extraGroups.libvirtd.gid = config.ids.gids.libvirtd;
+
+    environment.etc = []
+      ++ optional (caFile != "") {
+        target = "pki/CA/cacert.pem";
+        source = caFile;
+      }
+      ++ optional (cfg.clientCert != "") {
+        target = "pki/libvirt/clientcert.pem";
+        text = cfg.clientCert;
+      }
+      ++ optional (cfg.clientKey != "") {
+        target = "pki/libvirt/private/clientkey.pem";
+        text = cfg.clientKey;
+      };
 
   };
 


### PR DESCRIPTION
## Libvirtd remote connections

libvirtd requires that you setup TLS server (and potentially client) certificates and keys to enable remote connections.

To allow this to be configured in nixos this patch makes the following options available: 
- **virtualisation.libvirtd.listen** Starts libvirtd with the listen_tls option. (Default: false)
- **virtualisation.libvirtd.authorityCert** Sets the trusted CA certificate in pem format. (Default: "")
- **virtualisation.libvirtd.serverCert** Sets the server´s certificate signed by the CA. (Default: "")
- **virtualisation.libvirtd.serverKey** Sets the server´s private key. (Default: "")
- **virtualisation.libvirtd.clientCert** Sets the default client certificate signed by the CA in pem format. (Default: "")
- **virtualisation.libvirtd.clientKey** Sets the default client key. (Default: "")
## Systemd tweak.

I was also seeing issues where libvirtd would not shutdown or restart correctly when running with `listen` enabled. By removing the "--daemon" option and letting systemd manage the process without forking seemed to resolve this.

**I believe removing the `--daemon` option has made the "post-start" script redundant (as systemd correctly waits anyway). Was there any reason why libvirtd was set to fork? What was the purpose of the post-start script?**
