### PR TITLE
added mtpfs to mount MTP devices via usb using FUSE

### DIFF
--- a/pkgs/tools/filesystems/mtpfs/default.nix
+++ b/pkgs/tools/filesystems/mtpfs/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pkgconfig, fuse, libmtp, glib, libmad, libid3tag }:
+
+stdenv.mkDerivation rec {
+  name = "mtpfs-1.1";
+
+  buildInputs = [ pkgconfig fuse libmtp glib libid3tag libmad ];
+
+  # adding LIBS is a hack, duno why it does not find libid3tag.so by adding buildInputs
+  preConfigure = ''
+    export MAD_CFLAGS=${libmad}/include
+    export MAD_LIBS=${libmad}/lib/libmad.so
+    export LIBS=${libid3tag}/lib/libid3tag.so
+  '';
+
+  src = fetchurl {
+    url = "http://www.adebenham.com/files/mtp/${name}.tar.gz";
+    sha256 = "07acrqb17kpif2xcsqfqh5j4axvsa4rnh6xwnpqab5b9w5ykbbqv";
+  };
+
+  meta = {
+    homepage = https://code.google.com/p/mtpfs/;
+    description = "FUSE Filesystem providing access to MTP devices";
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.qknight ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4929,6 +4929,7 @@ let
 
   libmtp = callPackage ../development/libraries/libmtp { };
 
+
   libmsgpack = callPackage ../development/libraries/libmsgpack { };
 
   libnatspec = callPackage ../development/libraries/libnatspec { };
@@ -5374,6 +5375,8 @@ let
   mpich2 = callPackage ../development/libraries/mpich2 { };
 
   mtdev = callPackage ../development/libraries/mtdev { };
+
+  mtpfs = callPackage ../tools/filesystems/mtpfs { };
 
   mu = callPackage ../tools/networking/mu {
     texinfo = texinfo4;


### PR DESCRIPTION
two comments:
- mtpfs does not work for my samsung S2 but other reported this issue as well. might be related to the libmtp version and not to the way i package it
- **i don't understand why libmad and libid3tag wasn't found by configure automatically**
