### PR TITLE
gnome-system-log: new package

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-system-log/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-system-log/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, intltool, fetchurl, pkgconfig
+, bash, gtk3, glib, hicolor_icon_theme, makeWrapper
+, itstool, gnome3, librsvg, gdk_pixbuf, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-system-log-3.9.90";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-system-log/3.9/${name}.tar.xz";
+    sha256 = "9eeb51982d347aa7b33703031e2c1d8084201374665425cd62199649b29a5411";
+  };
+
+  doCheck = true;
+
+  NIX_CFLAGS_COMPILE = "-I${gnome3.glib}/include/gio-unix-2.0";
+
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedBuildInputs = [ gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                            hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
+
+  buildInputs = [ bash pkgconfig gtk3 glib intltool itstool
+                  gnome3.gsettings_desktop_schemas makeWrapper libxml2 ];
+
+  installFlags = "gsettingsschemadir=\${out}/share/gnome-system-log/glib-2.0/schemas/";
+
+  postInstall = ''
+    wrapProgram "$out/bin/gnome-system-log" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome3.gsettings_desktop_schemas}/share:$out/share:$out/share/gnome-system-log:$XDG_ICON_DIRS"
+  '';
+
+  preFixup = ''
+    rm $out/share/icons/hicolor/icon-theme.cache
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://help.gnome.org/users/gnome-system-log/3.9/;
+    description = "Graphical, menu-driven viewer that you can use to view and monitor your system logs";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -60,11 +60,13 @@ rec {
 
   gnome_shell = callPackage ./core/gnome-shell { };
 
+  gnome-screenshot = callPackage ./core/gnome-screenshot { };
+
   gnome_settings_daemon = callPackage ./core/gnome-settings-daemon { };
 
-  gnome_terminal = callPackage ./core/gnome-terminal { };
+  gnome-system-log = callPackage ./core/gnome-system-log { };
 
-  gnome-screenshot = callPackage ./core/gnome-screenshot { };
+  gnome_terminal = callPackage ./core/gnome-terminal { };
 
   gnome_themes_standard = callPackage ./core/gnome-themes-standard { };
 


### PR DESCRIPTION
Graphical, menu-driven viewer that you can use to view and monitor your system logs

https://help.gnome.org/users/gnome-system-log/3.9/
