### PR TITLE
Update ffmpeg dependency to 0.10 in oraclejdk7

### DIFF
--- a/pkgs/development/compilers/jdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/jdk/jdk7-linux.nix
@@ -9,7 +9,7 @@
 , glib
 , libxml2
 , libav_0_8
-, ffmpeg_0_6
+, ffmpeg
 , libxslt
 , mesa_noglu
 , freetype
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg_0_6 libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf] ++
+    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf] ++
     (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt xlibs.libXrender stdenv.gcc.gcc] else []);
 
   passthru.mozillaPlugin = if installjdk then "/jre/lib/${architecture}/plugins" else "/lib/${architecture}/plugins";


### PR DESCRIPTION
Since ffmpeg_0_6 is totally outdated and not even in the binary cache, this makes oraclejdk installation unnecessarily harder
