### PR TITLE
Cabal builder: enable SSE2 on i686

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -158,6 +158,17 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
             inherit enableSharedExecutables;
 
             extraConfigureFlags = [
+              # SSE2 is not enabled by default on GHC, so we enable it
+              # here.  SSE2 is not supported below Pentium4, so we
+              # theoretically risk losing some systems with this, but
+              # the hashable cabal package (which is very widespread and
+              # has a lot of dependency) enforces sse2, so most of the
+              # haskell libraries in nixpkgs are not usable on old
+              # processors anyways.  On the other hand, by using SSE2 we
+              # fix the "excess precision" issues that caused imprecise
+              # binaries and test failures on i686 (e.g. for the
+              # math-functions).
+              (if stdenv.isi686 then "--ghc-options=-msse2" else [])
               (enableFeature self.enableSplitObjs "split-objs")
               (enableFeature enableLibraryProfiling "library-profiling")
               (enableFeature self.enableSharedLibraries "shared")

--- a/pkgs/development/libraries/haskell/math-functions/default.nix
+++ b/pkgs/development/libraries/haskell/math-functions/default.nix
@@ -12,8 +12,6 @@ cabal.mkDerivation (self: {
     HUnit ieee754 QuickCheck testFramework testFrameworkHunit
     testFrameworkQuickcheck2 vector
   ];
-  # fails on i686 at version 0.1.5.2
-  doCheck = false;
   meta = {
     homepage = "https://github.com/bos/math-functions";
     description = "Special functions and Chebyshev polynomials";


### PR DESCRIPTION
Since the hashable package is already SSE2 only, this doesn't harm us.
But it gives us free performance gains and test success for some
numerical libraries.  This only matters on i686, see
http://www.haskell.org/ghc/docs/7.6.3/html/users_guide/bugs.html.

This commit is extra careful to only trigger a full cabal rebuild for
the i686 platform and not for others.
