### PR TITLE
Gnome3 session changes, gnome-control-center icons

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -43,7 +43,8 @@ in {
         '';
       };
 
-    environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules" ];
+    environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules"
+                                                "${pkgs.glib_networking}/lib/gio/modules" ];
     environment.systemPackages =
       [ gnome3.evince
         gnome3.eog
@@ -54,6 +55,7 @@ in {
         gnome3.gucharmap
         gnome3.nautilus
         gnome3.yelp
+        pkgs.glib_networking
         pkgs.ibus
         gnome3.gnome_shell
         gnome3.gnome_settings_daemon

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -1,7 +1,8 @@
 { fetchurl, stdenv, pkgconfig, gnome3, ibus, intltool, upower, makeWrapper
 , libcanberra, accountservice, libpwquality, pulseaudio, fontconfig
-, libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk, libxkbfile
-, cracklib, python, krb5, networkmanagerapplet, libwacom, samba, libnotify
+, gdk_pixbuf, hicolor_icon_theme, librsvg, libxkbfile, libnotify
+, libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
+, cracklib, python, krb5, networkmanagerapplet, libwacom, samba
 , shared_mime_info, tzdata, icu, libtool, docbook_xsl, docbook_xsl_ns }:
 
 # http://ftp.gnome.org/pub/GNOME/teams/releng/3.10.2/gnome-suites-core-3.10.2.modules
@@ -14,6 +15,10 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/gnome-control-center/3.10/${name}.tar.xz";
     sha256 = "1ac34kqkf174w0qc12p927dfhcm69xnv7fqzmbhjab56rn49wypn";
   };
+
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedBuildInputs = [ gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                            hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
 
   buildInputs = with gnome3;
     [ pkgconfig intltool ibus gtk glib upower libcanberra gsettings_desktop_schemas
@@ -33,7 +38,8 @@ stdenv.mkDerivation rec {
 
   postInstall = with gnome3; ''
     wrapProgram $out/bin/gnome-control-center \
-      --prefix XDG_DATA_DIRS : "${gsettings_desktop_schemas}/share:${gnome_settings_daemon}/share:${glib}/share:${gtk}/share:${colord}/share:$out/share"
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:${gsettings_desktop_schemas}/share:${gnome_settings_daemon}/share:${glib}/share:${gtk}/share:${colord}/share:$out/share:$out/share/gnome-control-center:$XDG_ICON_DIRS"
     for i in $out/share/applications/*; do
       substituteInPlace $i --replace "gnome-control-center" "$out/bin/gnome-control-center"
     done


### PR DESCRIPTION
Add glib-networking gio modules when starting the gnome3 session, so that applications like epiphany can open https links.
Fix icons in gnome-control-center.
