### PR TITLE
Make the kernel build and initrd generation binary repeatable

### DIFF
--- a/pkgs/build-support/kernel/cpio-clean.pl
+++ b/pkgs/build-support/kernel/cpio-clean.pl
@@ -1,0 +1,20 @@
+use strict;
+
+# Make inode number, link info and mtime consistent in order to get a consistent hash.
+#
+# Author: Alexander Kjeldaas <ak@formalprivacy.com>
+
+use Archive::Cpio;
+
+my $cpio = Archive::Cpio->new;
+my $IN = \*STDIN;
+my $ino = 1;
+$cpio->read_with_handler($IN, sub {
+        my ($e) = @_;
+        $e->{inode} = $ino;
+        $ino++;
+        $e->{nlink} = 1;
+        $e->{mtime} = 1;
+	$cpio->write_one(\*STDOUT, $e);
+    });
+$cpio->write_trailer(\*STDOUT);

--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -12,10 +12,10 @@
 # `contents = {object = ...; symlink = /init;}' is a typical
 # argument.
 
-{stdenv, perl, cpio, contents, ubootChooser, compressor}:
+{stdenv, perl, perlArchiveCpio, cpio, contents, ubootChooser, compressor}:
 
 let
-  inputsFun = ubootName : [perl cpio]
+  inputsFun = ubootName : [perl cpio perlArchiveCpio ]
     ++ stdenv.lib.optional (ubootName != null) [ (ubootChooser ubootName) ];
   makeUInitrdFun = ubootName : (ubootName != null);
 in
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
   exportReferencesGraph =
     map (x: [("closure-" + baseNameOf x.symlink) x.object]) contents;
   pathsFromGraph = ./paths-from-graph.pl;
+  cpioClean = ./cpio-clean.pl;
 
   crossAttrs = {
     nativeBuildInputs = inputsFun stdenv.cross.platform.uboot;

--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -36,7 +36,7 @@ storePaths=$(perl $pathsFromGraph closure-*)
 
 # Put the closure in a gzipped cpio archive.
 mkdir -p $out
-(cd root && find * -print0 | cpio -o -H newc --null | $compressor > $out/initrd)
+(cd root && find * -print0 | cpio -o -H newc --null | perl $cpioClean | $compressor > $out/initrd)
 
 if [ -n "$makeUInitrd" ]; then
     mv $out/initrd $out/initrd.gz

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -102,7 +102,11 @@ let
         runHook postConfigure
       '';
 
-      buildFlags = [ "KBUILD_BUILD_VERSION=1-NixOS" platform.kernelTarget ] ++ optional isModular "modules";
+      buildFlags = [
+        "KBUILD_BUILD_VERSION=1-NixOS"
+        "KBUILD_BUILD_TIMESTAMP=Thu_Jan__1_00:00:01_UTC_1970"
+	platform.kernelTarget
+      ] ++ optional isModular "modules";
 
       installFlags = [
         "INSTALLKERNEL=${installkernel}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -354,7 +354,7 @@ let
 
   makeInitrd = {contents, compressor ? "gzip -9"}:
     import ../build-support/kernel/make-initrd.nix {
-      inherit stdenv perl cpio contents ubootChooser compressor;
+      inherit stdenv perl perlArchiveCpio cpio contents ubootChooser compressor;
     };
 
   makeWrapper = makeSetupHook { } ../build-support/setup-hooks/make-wrapper.sh;
@@ -6178,6 +6178,8 @@ let
   perlXMLParser = perlPackages.XMLParser;
 
   ack = perlPackages.ack;
+
+  perlArchiveCpio = perlPackages.ArchiveCpio;
 
   perlcritic = perlPackages.PerlCritic;
   

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -200,6 +200,14 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  ArchiveCpio = buildPerlPackage {
+    name = "Archive-Cpio-0.09";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/P/PI/PIXEL/Archive-Cpio-0.09.tar.gz;
+      sha256 = "1cf8k5zjykdbc1mn8lixlkij6jklwn6divzyq2grycj3rpd36g5c";
+    };
+  };
+
   ArchiveZip = buildPerlPackage {
     name = "Archive-Zip-1.16";
     src = fetchurl {


### PR DESCRIPTION
The kernel includes the build timestamp, and the cpio initrd file contains timestamps for files.

These changes fixes those two issues.
