### PR TITLE
Add trusted computing components

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -6,6 +6,7 @@
 
   _1126 = "Christian Lask <mail@elfsechsundzwanzig.de>";
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
+  ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akc = "Anders Claesson <akc@akc.is>";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -236,6 +236,7 @@
       grsecurity = 121;
       hydra = 122;
       spiped = 123;
+      tss = 124;
 
       # When adding a gid, make sure it doesn't match an existing uid.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -115,11 +115,12 @@
   ./services/hardware/pcscd.nix
   ./services/hardware/pommed.nix
   ./services/hardware/sane.nix
+  ./services/hardware/tcsd.nix
+  ./services/hardware/thinkfan.nix
   ./services/hardware/udev.nix
   ./services/hardware/udisks.nix
   ./services/hardware/udisks2.nix
   ./services/hardware/upower.nix
-  ./services/hardware/thinkfan.nix
   ./services/logging/klogd.nix
   ./services/logging/logcheck.nix
   ./services/logging/logrotate.nix

--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -30,7 +30,8 @@ with lib;
 
       description = "Hardware RNG Entropy Gatherer Daemon";
 
-      serviceConfig.ExecStart = "${pkgs.rng_tools}/sbin/rngd -f -v --no-tpm=1";
+      serviceConfig.ExecStart = "${pkgs.rng_tools}/sbin/rngd -f -v" +
+        (if config.services.tcsd.enable then " --no-tpm=1" else "");
 
       restartTriggers = [ pkgs.rng_tools ];
     };

--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -30,7 +30,7 @@ with lib;
 
       description = "Hardware RNG Entropy Gatherer Daemon";
 
-      serviceConfig.ExecStart = "${pkgs.rng_tools}/sbin/rngd -f";
+      serviceConfig.ExecStart = "${pkgs.rng_tools}/sbin/rngd -f -v --no-tpm=1";
 
       restartTriggers = [ pkgs.rng_tools ];
     };

--- a/nixos/modules/services/hardware/tcsd.nix
+++ b/nixos/modules/services/hardware/tcsd.nix
@@ -38,6 +38,7 @@ in
 
       enable = mkOption {
         default = false;
+        type = types.bool;
         description = ''
           Whether to enable tcsd, a Trusted Computing management service
           that provides TCG Software Stack (TSS).  The tcsd daemon is
@@ -48,16 +49,19 @@ in
 
       user = mkOption {
         default = "tss";
+        type = types.string;
         description = "User account under which tcsd runs.";
       };
 
       group = mkOption {
         default = "tss";
+        type = types.string;
         description = "Group account under which tcsd runs.";
       };
 
       stateDir = mkOption {
 	default = "/var/lib/tpm";
+        type = types.path;
 	description = ''
           The location of the system persistent storage file.
           The system persistent storage file holds keys and data across
@@ -67,6 +71,7 @@ in
 
       platformCred = mkOption {
         default = "${cfg.stateDir}/platform.cert";
+        type = types.path;
         description = ''
 	  Path to the platform credential for your TPM. Your TPM
           manufacturer may have provided you with a set of credentials
@@ -79,6 +84,7 @@ in
 
       conformanceCred = mkOption {
         default = "${cfg.stateDir}/conformance.cert";
+        type = types.path;
         description = ''
           Path to the conformance credential for your TPM.
           See also the platformCred option'';
@@ -86,6 +92,7 @@ in
 
       endorsementCred = mkOption {
         default = "${cfg.stateDir}/endorsement.cert";
+        type = types.path;
         description = ''
           Path to the endorsement credential for your TPM.
           See also the platformCred option'';

--- a/nixos/modules/services/hardware/tcsd.nix
+++ b/nixos/modules/services/hardware/tcsd.nix
@@ -1,0 +1,132 @@
+# tcsd daemon.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+let
+
+  cfg = config.services.tcsd;
+
+  tcsdConf = pkgs.writeText "tcsd.conf" ''
+    port = 30003
+    num_threads = 10
+    system_ps_file = ${cfg.stateDir}/system.data
+    # This is the log of each individual measurement done by the system.
+    # By re-calculating the PCR registers based on this information, even
+    # finer details about the measured environment can be inferred than
+    # what is available directly from the PCR registers.
+    firmware_log_file = /sys/kernel/security/tpm0/binary_bios_measurements
+    kernel_log_file = /sys/kernel/security/ima/binary_runtime_measurements
+    #firmware_pcrs = 0,1,2,3,4,5,6,7
+    #kernel_pcrs = 10,11
+    platform_cred = ${cfg.platformCred}
+    conformance_cred = ${cfg.conformanceCred}
+    endorsement_cred = ${cfg.endorsementCred}
+    #remote_ops = create_key,random
+    #host_platform_class = server_12
+    #all_platform_classes = pc_11,pc_12,mobile_12
+  '';
+
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.tcsd = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable tcsd, a Trusted Computing management service
+          that provides TCG Software Stack (TSS).  The tcsd daemon is
+          the only portal to the Trusted Platform Module (TPM), a hardware
+          chip on the motherboard.
+        '';
+      };
+
+      user = mkOption {
+        default = "tss";
+        description = "User account under which tcsd runs.";
+      };
+
+      group = mkOption {
+        default = "tss";
+        description = "Group account under which tcsd runs.";
+      };
+
+      stateDir = mkOption {
+	default = "/var/lib/tpm";
+	description = ''
+          The location of the system persistent storage file.
+          The system persistent storage file holds keys and data across
+          restarts of the TCSD and system reboots. 
+	'';
+      };
+
+      platformCred = mkOption {
+        default = "${cfg.stateDir}/platform.cert";
+        description = ''
+	  Path to the platform credential for your TPM. Your TPM
+          manufacturer may have provided you with a set of credentials
+          (certificates) that should be used when creating identities
+          using your TPM. When a user of your TPM makes an identity,
+          this credential will be encrypted as part of that process.
+          See the 1.1b TPM Main specification section 9.3 for information
+          on this process. '';
+      };
+
+      conformanceCred = mkOption {
+        default = "${cfg.stateDir}/conformance.cert";
+        description = ''
+          Path to the conformance credential for your TPM.
+          See also the platformCred option'';
+      };
+
+      endorsementCred = mkOption {
+        default = "${cfg.stateDir}/endorsement.cert";
+        description = ''
+          Path to the endorsement credential for your TPM.
+          See also the platformCred option'';
+      };
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.trousers ];
+
+#    system.activationScripts.tcsd =
+#      ''
+#        chown ${cfg.user}:${cfg.group} ${tcsdConf}
+#      '';
+
+    systemd.services.tcsd = {
+      description = "TCSD";
+      after = [ "systemd-udev-settle.service" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.trousers ];
+      preStart =
+        ''
+        mkdir -m 0700 -p ${cfg.stateDir}
+        chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
+        '';
+      serviceConfig.ExecStart = "${pkgs.trousers}/sbin/tcsd -f -c ${tcsdConf}";
+    };
+
+    users.extraUsers = optionalAttrs (cfg.user == "tss") (singleton
+      { name = "tss";
+        group = "tss";
+        uid = config.ids.uids.nginx;
+      });
+
+    users.extraGroups = optionalAttrs (cfg.group == "tss") (singleton
+      { name = "tss";
+        gid = config.ids.gids.nginx;
+      });
+  };
+}

--- a/pkgs/tools/security/tboot/default.nix
+++ b/pkgs/tools/security/tboot/default.nix
@@ -19,4 +19,14 @@ stdenv.mkDerivation {
     substituteInPlace docs/Makefile --replace /usr/share /share
   '';
   installFlags = "DESTDIR=$(out)";
+
+  meta = with stdenv.lib; {
+    description = ''Trusted Boot (tboot) is an open source, pre-kernel/VMM module that uses
+                    Intel(R) Trusted Execution Technology (Intel(R) TXT) to perform a measured
+                    and verified launch of an OS kernel/VMM.'';
+    homepage    = http://sourceforge.net/projects/tboot/;
+    license     = licenses.bsd3;
+    maintainers = [ maintainers.ak ];
+    platforms   = platforms.linux;
+  };
 }

--- a/pkgs/tools/security/tboot/default.nix
+++ b/pkgs/tools/security/tboot/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchurl, autoconf, automake, trousers, openssl, zlib}:
+
+stdenv.mkDerivation {
+  name = "tboot-1.8.0";
+
+  src = fetchurl {
+    url = https://sourceforge.net/projects/tboot/files/tboot/tboot-1.8.0.tar.gz;
+    sha256 = "04z1maryqnr714f3rcynqrpmlx76lxr6bb543xwj5rdl1yvdw2xr";
+  };
+
+  buildInputs = [ trousers openssl zlib ];
+
+  patches = [ ./tboot-add-well-known-secret-option-to-lcp_writepol.patch ];
+
+  configurePhase = ''
+    for a in lcptools utils tb_polgen; do
+      substituteInPlace $a/Makefile --replace /usr/sbin /sbin
+    done
+    substituteInPlace docs/Makefile --replace /usr/share /share
+  '';
+  installFlags = "DESTDIR=$(out)";
+}

--- a/pkgs/tools/security/tboot/tboot-add-well-known-secret-option-to-lcp_writepol.patch
+++ b/pkgs/tools/security/tboot/tboot-add-well-known-secret-option-to-lcp_writepol.patch
@@ -1,0 +1,50 @@
+diff -urp tboot-1.8.0.orig/lcptools/writepol.c tboot-1.8.0/lcptools/writepol.c
+--- tboot-1.8.0.orig/lcptools/writepol.c	2014-01-30 10:34:57.000000000 +0100
++++ tboot-1.8.0/lcptools/writepol.c	2014-02-12 01:48:51.523581057 +0100
+@@ -40,6 +40,7 @@
+ #include <getopt.h>
+ #include <trousers/tss.h>
+ #include <trousers/trousers.h>
++#include <tss/tss_defines.h>
+ 
+ #define PRINT   printf
+ #include "../include/uuid.h"
+@@ -51,14 +52,15 @@ static uint32_t index_value = 0;
+ static char *file_arg=NULL;
+ static uint32_t fLeng;
+ static unsigned char *policy_data = NULL;
+-static char *password = NULL;
++static const char *password = NULL;
+ static uint32_t passwd_length = 0;
++static const char well_known_secret[] = TSS_WELL_KNOWN_SECRET;
+ static int help_input = 0;
+ static unsigned char empty_pol_data[] = {0};
+ 
+-static const char *short_option = "ehi:f:p:";
++static const char *short_option = "ehi:f:p:Z";
+ static const char *usage_string = "lcp_writepol -i index_value "
+-                                  "[-f policy_file] [-e] [-p passwd] [-h]";
++                                  "[-f policy_file] [-e] [-p passwd|-Z] [-h]";
+ 
+ static const char *option_strings[] = {
+     "-i index value: uint32/string.\n"
+@@ -67,6 +69,7 @@ static const char *option_strings[] = {
+     "\tINDEX_AUX:0x50000002 or \"aux\"\n",
+     "-f file_name: string. File name of the policy data is stored. \n",
+     "-p password: string. \n",
++    "-Z use well known secret as password. \n",
+     "-e write 0 length data to the index.\n"
+     "\tIt will be used for some special index.\n"
+     "\tFor example, the index with permission WRITEDEFINE.\n",
+@@ -119,6 +122,11 @@ parse_cmdline(int argc, const char * arg
+                 fLeng = 0;
+                 break;
+ 
++            case 'Z':
++                password = well_known_secret;
++                passwd_length = sizeof(well_known_secret);
++                break;
++
+             case 'h':
+                 help_input = 1;
+                 break;

--- a/pkgs/tools/security/tpm-quote-tools/default.nix
+++ b/pkgs/tools/security/tpm-quote-tools/default.nix
@@ -9,4 +9,14 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ trousers openssl ];
+
+  meta = with stdenv.lib; {
+    description = ''The TPM Quote Tools is a collection of programs that provide support
+                    for TPM based attestation using the TPM quote mechanism.  The manual
+                    page for tpm_quote_tools provides a usage overview.'';
+    homepage    = http://tpmquotetools.sourceforge.net/;
+    license     = licenses.bsd3;
+    maintainers = [ maintainers.ak ];
+    platforms   = platforms.linux;
+  };
 }

--- a/pkgs/tools/security/tpm-quote-tools/default.nix
+++ b/pkgs/tools/security/tpm-quote-tools/default.nix
@@ -1,0 +1,12 @@
+{stdenv, fetchurl, autoconf, automake, trousers, openssl}:
+
+stdenv.mkDerivation {
+  name = "tpm-quote-tools-1.0.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/tpmquotetools/1.0.2/tpm-quote-tools-1.0.2.tar.gz";
+    sha256 = "17bf9d1hiiaybx6rgl0sqcb0prjz6d2mv8fwp4bj1c0rsfw5dbk8";
+  };
+
+  buildInputs = [ trousers openssl ];
+}

--- a/pkgs/tools/security/tpm-tools/default.nix
+++ b/pkgs/tools/security/tpm-tools/default.nix
@@ -9,4 +9,14 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ trousers openssl ];
+
+  meta = with stdenv.lib; {
+    description = ''tpm-tools is an open-source package designed to enable user and application
+                    enablement of Trusted Computing using a Trusted Platform Module (TPM),
+                    similar to a smart card environment.'';
+    homepage    = http://sourceforge.net/projects/trousers/files/tpm-tools/;
+    license     = licenses.cpl10;
+    maintainers = [ maintainers.ak ];
+    platforms   = platforms.unix;
+  };
 }

--- a/pkgs/tools/security/tpm-tools/default.nix
+++ b/pkgs/tools/security/tpm-tools/default.nix
@@ -1,0 +1,12 @@
+{stdenv, fetchurl, autoconf, automake, trousers, openssl}:
+
+stdenv.mkDerivation {
+  name = "tpm-tools-1.3.8";
+
+  src = fetchurl {
+    url = https://sourceforge.net/projects/trousers/files/tpm-tools/1.3.8/tpm-tools-1.3.8.tar.gz;
+    sha256 = "10za1gi89vi9m2lmm7jfzs281h55x1sbbm2bdgdh692ljpq4zsv6";
+  };
+
+  buildInputs = [ trousers openssl ];
+}

--- a/pkgs/tools/security/trousers/allow-non-tss-config-file-owner.patch
+++ b/pkgs/tools/security/trousers/allow-non-tss-config-file-owner.patch
@@ -1,0 +1,19 @@
+diff -ur trousers-0.3.11.2.orig/src/tcsd/tcsd_conf.c trousers-0.3.11.2/src/tcsd/tcsd_conf.c
+--- trousers-0.3.11.2.orig/src/tcsd/tcsd_conf.c	2013-07-12 18:27:37.000000000 +0200
++++ trousers-0.3.11.2/src/tcsd/tcsd_conf.c	2013-08-21 14:29:42.917231648 +0200
+@@ -763,6 +763,7 @@
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
+ 
++#ifndef ALLOW_NON_TSS_CONFIG_FILE
+ 	/* make sure user/group TSS owns the conf file */
+ 	if (pw->pw_uid != stat_buf.st_uid || grp->gr_gid != stat_buf.st_gid) {
+ 		LogError("TCSD config file (%s) must be user/group %s/%s", tcsd_config_file,
+@@ -775,6 +776,7 @@
+ 		LogError("TCSD config file (%s) must be mode 0600", tcsd_config_file);
+ 		return TCSERR(TSS_E_INTERNAL_ERROR);
+ 	}
++#endif
+ #endif /* SOLARIS */
+ 
+ 	if ((f = fopen(tcsd_config_file, "r")) == NULL) {

--- a/pkgs/tools/security/trousers/default.nix
+++ b/pkgs/tools/security/trousers/default.nix
@@ -1,0 +1,27 @@
+{stdenv, fetchurl, autoconf, automake, openssl}:
+
+stdenv.mkDerivation {
+  name = "trousers-0.3.11.2";
+
+  src = fetchurl {
+    url = https://sourceforge.net/projects/trousers/files/trousers/0.3.11/trousers-0.3.11.2.tar.gz;
+    sha256 = "03c71szmij1nx3jicacmazh0yan3qm00k0ahmh4mq88fw00k1p4v";
+  };
+
+  buildInputs = [ openssl ];
+
+  patches = [ # ./double-installed-man-page.patch
+              ./disable-install-rule.patch
+              ./allow-non-tss-config-file-owner.patch
+            ];
+
+  NIX_CFLAGS_COMPILE = "-DALLOW_NON_TSS_CONFIG_FILE";
+  NIX_LDFLAGS = "-lgcc_s";
+
+  meta = with stdenv.lib; {
+    description = "TrouSerS is an CPL (Common Public License) licensed Trusted Computing Software Stack.";
+    homepage    = http://trousers.sourceforge.net/;
+    license     = licenses.cpl;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/trousers/default.nix
+++ b/pkgs/tools/security/trousers/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
     description = "TrouSerS is an CPL (Common Public License) licensed Trusted Computing Software Stack.";
     homepage    = http://trousers.sourceforge.net/;
     license     = licenses.cpl;
+    maintainers = [ maintainers.ak ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/tools/security/trousers/default.nix
+++ b/pkgs/tools/security/trousers/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "TrouSerS is an CPL (Common Public License) licensed Trusted Computing Software Stack.";
     homepage    = http://trousers.sourceforge.net/;
-    license     = licenses.cpl;
+    license     = licenses.cpl10;
     maintainers = [ maintainers.ak ];
     platforms   = platforms.unix;
   };

--- a/pkgs/tools/security/trousers/disable-install-rule.patch
+++ b/pkgs/tools/security/trousers/disable-install-rule.patch
@@ -1,0 +1,27 @@
+--- trousers-0.3.11/dist/Makefile.in	2013-08-14 06:49:37.597558787 +0200
++++ trousers-0.3.11/dist/Makefile.in	2013-08-14 06:50:07.134510774 +0200
+@@ -363,16 +363,16 @@
+ 	uninstall uninstall-am uninstall-hook
+ 
+ install: install-exec-hook
+-	if test ! -e ${DESTDIR}/@sysconfdir@/tcsd.conf; then mkdir -p ${DESTDIR}/@sysconfdir@ && cp tcsd.conf ${DESTDIR}/@sysconfdir@; fi
+-	/bin/chown tss:tss ${DESTDIR}/@sysconfdir@/tcsd.conf || true
+-	/bin/chmod 0600 ${DESTDIR}/@sysconfdir@/tcsd.conf
++#	echo if test ! -e ${DESTDIR}/@sysconfdir@/tcsd.conf; then mkdir -p ${DESTDIR}/@sysconfdir@ && cp tcsd.conf ${DESTDIR}/@sysconfdir@; fi
++	echo /bin/chown tss:tss ${DESTDIR}/@sysconfdir@/tcsd.conf || true
++	echo /bin/chmod 0600 ${DESTDIR}/@sysconfdir@/tcsd.conf
+ 
+ install-exec-hook:
+-	/usr/sbin/groupadd tss || true
+-	/usr/sbin/useradd -r tss -g tss || true
+-	/bin/sh -c 'if [ ! -e ${DESTDIR}/@localstatedir@/lib/tpm ];then mkdir -p ${DESTDIR}/@localstatedir@/lib/tpm; fi'
+-	/bin/chown tss:tss ${DESTDIR}/@localstatedir@/lib/tpm || true
+-	/bin/chmod 0700 ${DESTDIR}/@localstatedir@/lib/tpm
++	echo /usr/sbin/groupadd tss || true
++	echo /usr/sbin/useradd -r tss -g tss || true
++	echo /bin/sh -c 'if [ ! -e ${DESTDIR}/@localstatedir@/lib/tpm ];then mkdir -p ${DESTDIR}/@localstatedir@/lib/tpm; fi'
++	echo /bin/chown tss:tss ${DESTDIR}/@localstatedir@/lib/tpm || true
++	echo /bin/chmod 0700 ${DESTDIR}/@localstatedir@/lib/tpm
+ 
+ uninstall-hook:
+ 	/usr/sbin/userdel tss || true

--- a/pkgs/tools/security/trousers/double-installed-man-page.patch
+++ b/pkgs/tools/security/trousers/double-installed-man-page.patch
@@ -1,0 +1,32 @@
+--- trousers-0.3.11/man/man3/Makefile.am	2013-08-14 04:57:47.018494495 +0200
++++ trousers-0.3.11/man/man3/Makefile.am	2013-08-14 04:58:10.353453471 +0200
+@@ -75,7 +75,6 @@
+ 	    Tspi_TPM_TakeOwnership.3 \
+ 	    Tspi_TPM_GetAuditDigest.3 \
+ 	    Tspi_TPM_OwnerGetSRKPubKey.3 \
+-	    Tspi_TPM_Quote.3 \
+ 	    Tspi_TPM_CMKSetRestrictions.3
+ if TSS_BUILD_DAA
+ man3_MANS += Tspi_DAA_IssueCredential.3 \
+--- trousers-0.3.11/man/man3/Makefile.in	2013-08-14 05:06:25.029490899 +0200
++++ trousers-0.3.11/man/man3/Makefile.in	2013-08-14 05:06:43.153457942 +0200
+@@ -243,7 +243,7 @@
+ 	Tspi_TPM_PcrExtend.3 Tspi_TPM_Quote.3 Tspi_TPM_SelfTestFull.3 \
+ 	Tspi_TPM_SetStatus.3 Tspi_TPM_StirRandom.3 \
+ 	Tspi_TPM_TakeOwnership.3 Tspi_TPM_GetAuditDigest.3 \
+-	Tspi_TPM_OwnerGetSRKPubKey.3 Tspi_TPM_Quote.3 \
++	Tspi_TPM_OwnerGetSRKPubKey.3 \
+ 	Tspi_TPM_CMKSetRestrictions.3 $(am__append_1)
+ EXTRA_DIST = $(man3_MANS)
+ all: all-am
+--- trousers-0.3.11/man/man3/Makefile	2013-08-14 05:07:05.686414845 +0200
++++ trousers-0.3.11/man/man3/Makefile	2013-08-14 05:07:23.233381327 +0200
+@@ -243,7 +243,7 @@
+ 	Tspi_TPM_PcrExtend.3 Tspi_TPM_Quote.3 Tspi_TPM_SelfTestFull.3 \
+ 	Tspi_TPM_SetStatus.3 Tspi_TPM_StirRandom.3 \
+ 	Tspi_TPM_TakeOwnership.3 Tspi_TPM_GetAuditDigest.3 \
+-	Tspi_TPM_OwnerGetSRKPubKey.3 Tspi_TPM_Quote.3 \
++	Tspi_TPM_OwnerGetSRKPubKey.3 \
+ 	Tspi_TPM_CMKSetRestrictions.3 $(am__append_1)
+ EXTRA_DIST = $(man3_MANS)
+ all: all-am

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2040,6 +2040,8 @@ let
 
   tcpcrypt = callPackage ../tools/security/tcpcrypt { };
 
+  tboot = callPackage ../tools/security/tboot { };
+
   tcpdump = callPackage ../tools/networking/tcpdump { };
 
   tcpflow = callPackage ../tools/networking/tcpflow { };
@@ -2075,7 +2077,11 @@ let
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
 
+  tpm-tools = callPackage ../tools/security/tpm-tools { };
+
   trickle = callPackage ../tools/networking/trickle {};
+
+  trousers = callPackage ../tools/security/trousers { };
 
   ttf2pt1 = callPackage ../tools/misc/ttf2pt1 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2077,6 +2077,8 @@ let
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
 
+  tpm-quote-tools = callPackage ../tools/security/tpm-quote-tools { };
+
   tpm-tools = callPackage ../tools/security/tpm-tools { };
 
   trickle = callPackage ../tools/networking/trickle {};


### PR DESCRIPTION
This adds software components needed to work with the Trusted Platform Module (TPM) as well as trusted boot, and remote attestation.

tboot - trusted boot
sinit - Intel TXT modules for motherboard bioses where this is not integrated with the BIOS
tpm-quote-tools - Remote attestation tools
rngd - rngd should not touch the TPM
tcsd - The Trusted Computing Group Software Stack (TSS) daemon which interfaces with the TPM
