### PR TITLE
Make cpufrequtils compilation pure.

### DIFF
--- a/pkgs/os-specific/linux/cpufrequtils/default.nix
+++ b/pkgs/os-specific/linux/cpufrequtils/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "127i38d4w1hv2dzdy756gmbhq25q3k34nqb2s0xlhsfhhdqs0lq0";
   };
 
+  patches = [
+    # I am not 100% sure that this is ok, but it breaks repeatable builds.
+    ./remove-pot-creation-date.patch
+  ];
+
   patchPhase = ''
     sed -e "s@= /usr/bin/@= @g" \
       -e "s@/usr/@$out/@" \

--- a/pkgs/os-specific/linux/cpufrequtils/remove-pot-creation-date.patch
+++ b/pkgs/os-specific/linux/cpufrequtils/remove-pot-creation-date.patch
@@ -1,0 +1,24 @@
+diff -u cpufrequtils-008/Makefile cpufrequtils-008.new/Makefile
+--- cpufrequtils-008/Makefile	2012-05-06 01:17:18.000000000 +0200
++++ cpufrequtils-008.new/Makefile	2013-08-16 20:52:29.961086536 +0200
+@@ -205,7 +205,8 @@
+ 	@xgettext --default-domain=$(PACKAGE) --add-comments \
+ 		--keyword=_ --keyword=N_ $(UTIL_SRC) && \
+ 	test -f $(PACKAGE).po && \
+-	mv -f $(PACKAGE).po po/$(PACKAGE).pot
++	mv -f $(PACKAGE).po po/$(PACKAGE).pot && \
++        sed -i -e'/POT-Creation/d' po/*.pot
+ 
+ update-gmo: po/$(PACKAGE).pot
+ 	 @for HLANG in $(LANGUAGES); do \
+@@ -217,6 +218,7 @@
+ 			echo "msgmerge for $$HLANG failed!"; \
+ 			rm -f po/$$HLANG.new.po; \
+ 		fi; \
++		sed -i -e'/POT-Creation/d' po/*.po; \
+ 		msgfmt --statistics -o po/$$HLANG.gmo po/$$HLANG.po; \
+ 	done;
+ 
+Common subdirectories: cpufrequtils-008/man and cpufrequtils-008.new/man
+Common subdirectories: cpufrequtils-008/po and cpufrequtils-008.new/po
+Common subdirectories: cpufrequtils-008/utils and cpufrequtils-008.new/utils


### PR DESCRIPTION
Remove pot-creation date from the output.
