### PR TITLE
su: Make the su package a provider of only the su binary

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -46,6 +46,7 @@ let
       pkgs.rsync
       pkgs.strace
       pkgs.sysvtools
+      pkgs.su
       pkgs.time
       pkgs.usbutils
       pkgs.utillinux

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./keep-path.patch dots_in_usernames ];
 
+  outputs = [ "out" "su" ];
+
   # Assume System V `setpgrp (void)', which is the default on GNU variants
   # (`AC_FUNC_SETPGRP' is not cross-compilation capable.)
   preConfigure = "export ac_cv_func_setpgrp_void=yes";
@@ -35,10 +37,14 @@ stdenv.mkDerivation rec {
       substituteInPlace lib/nscd.c --replace /usr/sbin/nscd ${glibc}/sbin/nscd
     '';
 
-  # Don't install ‘groups’, since coreutils already provides it.
   postInstall =
     ''
+      # Don't install ‘groups’, since coreutils already provides it.
       rm $out/bin/groups $out/share/man/man1/groups.*
+
+      # Move the su binary into the su package
+      mkdir -p $su/bin
+      mv $out/bin/su $su/bin
     '';
 
   meta = {

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -36,6 +36,10 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (ncurses != null) ncurses
     ++ stdenv.lib.optional (perl != null) perl;
 
+  postInstall = ''
+    rm $out/bin/su # su should be supplied by the su package (shadow)
+  '';
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1995,7 +1995,7 @@ let
 
   stunnel = callPackage ../tools/networking/stunnel { };
 
-  su = shadow;
+  su = shadow.su;
 
   surfraw = callPackage ../tools/networking/surfraw { };
 


### PR DESCRIPTION
Additionally, provide su with the base system and remove su from the
util-linux package as it is now provided by shadow.
