### PR TITLE
teamviewer: fix brokenness after updates / GC

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libX11, libXtst, libXext, libXdamage, libXfixes, wine, makeWrapper
-, bash }:
+, bash, findutils, coreutils }:
 
 assert stdenv.system == "i686-linux";
 let
@@ -31,6 +31,13 @@ stdenv.mkDerivation {
 
     cat > $out/bin/teamviewer << EOF
     #!${bash}/bin/sh
+    # Teamviewer puts symlinks to nix store paths in ~/.teamviewer. When those
+    # paths become garbage collected, teamviewer crashes upon start because of
+    # those broken symlinks. An easy workaround to this behaviour is simply to
+    # delete all symlinks before we start teamviewer. Teamviewer will fixup the
+    # symlinks, just like it did the first time the user ran it.
+    ${findutils}/bin/find "\$HOME"/.teamviewer/*/*/"Program Files/TeamViewer/" -type l -print0 | ${findutils}/bin/xargs -0 ${coreutils}/bin/rm
+
     export LD_LIBRARY_PATH=${toldpath}\''${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
     export PATH=${topath}\''${PATH:+:\$PATH}
     $out/share/teamviewer/wrapper wine "c:\Program Files\TeamViewer\Version7\TeamViewer.exe" "\$@"


### PR DESCRIPTION
Teamviewer puts symlinks to nix store paths in ~/.teamviewer. When those
paths become garbage collected, teamviewer crashes upon start because of
those broken symlinks. An easy workaround to this behaviour is simply to
delete all symlinks before we start teamviewer. Teamviewer will fixup
the symlinks, just like it did the first time the user ran it.
