### PR TITLE
Update nvidia to version 334.21 and Fix

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "331.49";
+  versionNumber = "334.21";
 
 in
 
@@ -25,12 +25,12 @@ stdenv.mkDerivation {
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "00d7bq8cfxk52qd4y226fz8m9m3mjq45fbgr3q7k08jyy9qmswmn";
+        sha256 = "0ffz03vk53ahxjqzzwdpqjg4qwrg25r2zs8avfv57pmhcqfsrrpc";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "0q3lvl1lypi33i847nqz4k3161ackh2n9kgyjn6v2c480f405hfk";
+        sha256 = "0w0l6prfa2fwrkc1b9zrpix688frai7hywi5d72s9cl2v97bxlam";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation {
 
   kernel = if libsOnly then null else kernel.dev;
 
+  # Remove after linux 3.14 compatibility is added
+  patches = optional (versionAtLeast kernel.version "3.14") ./nvidia-3.14.patch;
+
   dontStrip = true;
 
   glPath = stdenv.lib.makeLibraryPath [xlibs.libXext xlibs.libX11 xlibs.libXrandr];

--- a/pkgs/os-specific/linux/nvidia-x11/nvidia-3.14.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/nvidia-3.14.patch
@@ -1,0 +1,12 @@
+--- a/kernel/nv-linux.h         2014-01-09 04:49:25.000000000 +0200
++++ b/kernel/nv-linux.h         2014-02-05 16:46:55.552408568 +0200
+@@ -273,8 +273,7 @@
+ #endif
+ 
+ #if !defined(NV_VMWARE) && defined(CONFIG_ACPI)
+-#include <acpi/acpi.h>
+-#include <acpi/acpi_drivers.h>
++#include <linux/acpi.h>
+ #if defined(NV_ACPI_DEVICE_OPS_HAS_MATCH) || defined(ACPI_VIDEO_HID)
+ #define NV_LINUX_ACPI_EVENTS_SUPPORTED 1
+ #endif


### PR DESCRIPTION
This patch update nvidia from 331.xx to 334.21. Additionally, it applies a patch which fixes builds on kernel 3.14.

Everything was tested to work on kernels 3.13 and 3.14.
