### PR TITLE
gnome3 backgrounds, dictionary, grilo, totem

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -57,6 +57,7 @@ in {
         gnome3.yelp
         pkgs.glib_networking
         pkgs.ibus
+        gnome3.gnome-backgrounds
         gnome3.gnome_shell
         gnome3.gnome_settings_daemon
         gnome3.gnome_terminal

--- a/pkgs/desktops/gnome-3/core/gnome-backgrounds/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-backgrounds/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl, pkgconfig, intltool }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-backgrounds-3.12.0";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-backgrounds/3.12/${name}.tar.xz";
+    sha256 = "77a893025a0bed5753631a810154cad53fb2cf34c8ee988016217cd8862eab42";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  meta = with stdenv.lib; {
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/gnome-dictionary/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-dictionary/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, intltool, fetchurl
+, pkgconfig, gtk3, glib, hicolor_icon_theme
+, bash, makeWrapper, itstool, libxml2
+, gnome3, librsvg, gdk_pixbuf, file }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-dictionary-3.10.0";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-dictionary/3.10/${name}.tar.xz";
+    sha256 = "258b60fe50f7d0580a7dc3bb83f7fe2f6f0597d4013d97ac083c3f062c350ed7";
+  };
+
+  doCheck = true;
+
+  NIX_CFLAGS_COMPILE = "-I${gnome3.glib}/include/gio-unix-2.0";
+
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedBuildInputs = [ gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                            hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
+
+  buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2 file
+                  gnome3.gsettings_desktop_schemas makeWrapper ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/gnome-dictionary" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/Dictionary;
+    description = "Dictionary is the GNOME application to look up definitions";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
@@ -29,9 +29,6 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/gnome-disks" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
-
-  preFixup = ''
     rm $out/share/icons/hicolor/icon-theme.cache
   '';
 

--- a/pkgs/desktops/gnome-3/core/grilo/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, file, intltool, glib, libxml2, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name = "grilo-0.2.10";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/grilo/0.2/${name}.tar.xz";
+    sha256 = "559a2470fe541b0090bcfdfac7a33e92dba967727bbab6d0eca70e5636a77b25";
+  };
+
+  configureFlags = [ "--enable-grl-pls" ];
+
+  buildInputs = [ pkgconfig file intltool glib libxml2 gnome3.totem-pl-parser ];
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/action/show/Projects/Grilo;
+    description = "Framework that provides access to various sources of multimedia content, using a pluggable system";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/totem-pl-parser/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem-pl-parser/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, file, intltool, gmime, libxml2, libsoup }:
+
+stdenv.mkDerivation rec {
+  name = "totem-pl-parser-3.10.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/totem-pl-parser/3.10/${name}.tar.xz";
+    sha256 = "38be09bddc46ddecd2b5ed7c82144ef52aafe879a5ec3d8b192b4b64ba995469";
+  };
+
+  buildInputs = [ pkgconfig file intltool gmime libxml2 libsoup ];
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/Videos;
+    description = "Simple GObject-based library to parse and save a host of playlist formats";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, intltool, fetchurl, gst_all_1
+, clutter_gtk, clutter-gst, pygobject3, shared_mime_info
+, pkgconfig, gtk3, glib, hicolor_icon_theme
+, bash, makeWrapper, itstool, libxml2, dbus_glib
+, gnome3, librsvg, gdk_pixbuf, file }:
+
+stdenv.mkDerivation rec {
+  name = "totem-3.10.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/totem/3.10/${name}.tar.xz";
+    sha256 = "b6b6038c9104965671a6d25e98496a487c3a9c590c9c104f668bd9f4fa7be9e2";
+  };
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = "-I${gnome3.glib}/include/gio-unix-2.0";
+
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedBuildInputs = [ gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                            hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
+
+  buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2 gnome3.grilo
+                  clutter_gtk clutter-gst gnome3.totem-pl-parser
+                  gst_all_1.gstreamer gst_all_1.gst-plugins-base
+                  gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
+                  gnome3.libpeas pygobject3 shared_mime_info dbus_glib
+                  gnome3.gsettings_desktop_schemas makeWrapper file ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/totem" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+
+    rm $out/share/icons/hicolor/icon-theme.cache
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/Videos;
+    description = "Movie player for the GNOME desktop based on GStreamer";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -108,6 +108,8 @@ rec {
 
   rest = callPackage ./core/rest { };
 
+  totem-pl-parser = callPackage ./core/totem-pl-parser { };
+
   vte = callPackage ./core/vte { };
 
   vino = callPackage ./core/vino { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,6 +38,8 @@ rec {
 
   gjs = callPackage ./core/gjs { };
 
+  gnome-backgrounds = callPackage ./core/gnome-backgrounds { };
+
   gnome_control_center = callPackage ./core/gnome-control-center { };
 
   gnome-calculator = callPackage ./core/gnome-calculator { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -80,6 +80,8 @@ rec {
 
   gnome_themes_standard = callPackage ./core/gnome-themes-standard { };
 
+  grilo = callPackage ./core/grilo { };
+
   gsettings_desktop_schemas = callPackage ./core/gsettings-desktop-schemas { };
 
   gucharmap = callPackage ./core/gucharmap { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -110,6 +110,8 @@ rec {
 
   rest = callPackage ./core/rest { };
 
+  totem = callPackage ./core/totem { };
+
   totem-pl-parser = callPackage ./core/totem-pl-parser { };
 
   vte = callPackage ./core/vte { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -46,6 +46,8 @@ rec {
 
   gnome_common = callPackage ./core/gnome-common { };
 
+  gnome-dictionary = callPackage ./core/gnome-dictionary { };
+
   gnome-disk-utility = callPackage ./core/gnome-disk-utility { };
 
   gnome-font-viewer = callPackage ./core/gnome-font-viewer { };


### PR DESCRIPTION
Totem 3.10 because 3.12 needs clutter 1.18, which needs cogl 1.18 which breaks BC.
