### PR TITLE
linux: switch to 3.12 by default (latest longterm)

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7097,7 +7097,7 @@ let
 
   # The current default kernel / kernel modules.
   linux = linuxPackages.kernel;
-  linuxPackages = linuxPackages_3_10;
+  linuxPackages = linuxPackages_3_12;
 
   # A function to build a manually-configured kernel
   linuxManualConfig = pkgs.buildLinux;


### PR DESCRIPTION
I think we should have the latest longterm kernel branch as the default in 14.04. If you know about any disadvantages, write them.
