### PR TITLE
Make perl 5.16 binary deterministic.

### DIFF
--- a/pkgs/development/interpreters/perl/5.16/default.nix
+++ b/pkgs/development/interpreters/perl/5.16/default.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation rec {
   patches =
     [ # Do not look in /usr etc. for dependencies.
       ./no-sys-dirs.patch
+      ./no-impure-config-time.patch
+      ./fixed-man-page-date.patch
+      ./no-date-in-perl-binary.patch
     ]
     ++ optional stdenv.isSunOS  ./ld-shared.patch
     ++ stdenv.lib.optional stdenv.isDarwin [ ./cpp-precomp.patch ./no-libutil.patch ] ;
@@ -67,6 +70,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   # some network-related tests don't work, mostly probably due to our sandboxing
+  # man-heading.t is skipped due to output determinism (no dates)
   testsToSkip = ''
     lib/Net/hostent.t \
     dist/IO/t/{io_multihomed.t,io_sock.t} \
@@ -74,6 +78,7 @@ stdenv.mkDerivation rec {
     cpan/autodie/t/truncate.t \
     t/porting/{maintainers.t,regen.t} \
     cpan/Socket/t/get{name,addr}info.t \
+    cpan/podlators/t/man-heading.t \
   '' + optionalString stdenv.isFreeBSD ''
     cpan/CPANPLUS/t/04_CPANPLUS-Module.t \
     cpan/CPANPLUS/t/20_CPANPLUS-Dist-MM.t \

--- a/pkgs/development/interpreters/perl/5.16/fixed-man-page-date.patch
+++ b/pkgs/development/interpreters/perl/5.16/fixed-man-page-date.patch
@@ -1,0 +1,11 @@
+--- a/cpan/podlators/lib/Pod/Man.pm	2014-04-07 06:25:23.730505243 +0200
++++ b/cpan/podlators/lib/Pod/Man.pm	2014-04-07 06:26:40.816552603 +0200
+@@ -768,7 +768,7 @@
+     } else {
+         ($name, $section) = $self->devise_title;
+     }
+-    my $date = $$self{date} || $self->devise_date;
++    my $date = "1970-01-01"; # Fixed date for NixOS, orig: $$self{date} || $self->devise_date;
+     $self->preamble ($name, $section, $date)
+         unless $self->bare_output or DEBUG > 9;
+ 

--- a/pkgs/development/interpreters/perl/5.16/no-date-in-perl-binary.patch
+++ b/pkgs/development/interpreters/perl/5.16/no-date-in-perl-binary.patch
@@ -1,0 +1,11 @@
+--- a/perl.c	2014-04-07 07:58:01.402831615 +0200
++++ b/perl.c	2014-04-07 07:59:38.556945298 +0200
+@@ -1754,7 +1754,7 @@
+     PUSHs(Perl_newSVpvn_flags(aTHX_ non_bincompat_options,
+ 			      sizeof(non_bincompat_options) - 1, SVs_TEMP));
+ 
+-#ifdef __DATE__
++#if 0
+ #  ifdef __TIME__
+     PUSHs(Perl_newSVpvn_flags(aTHX_
+ 			      STR_WITH_LEN("Compiled at " __DATE__ " " __TIME__),

--- a/pkgs/development/interpreters/perl/5.16/no-impure-config-time.patch
+++ b/pkgs/development/interpreters/perl/5.16/no-impure-config-time.patch
@@ -1,0 +1,11 @@
+--- a/Configure	2014-04-05 20:21:33.714635700 +0200
++++ b/Configure	2014-04-05 20:23:23.377441026 +0200
+@@ -3609,6 +3609,8 @@
+ 
+ : who configured the system
+ cf_time=`LC_ALL=C; LANGUAGE=C; export LC_ALL; export LANGUAGE; $date 2>&1`
++cf_time='Thu Jan  1 00:00:00 UTC 1970'
++
+ case "$cf_by" in
+ "")
+ 	cf_by=`(logname) 2>/dev/null`


### PR DESCRIPTION
Perl is part of the bootstrap environment.  For security it is important that it has binary determinism.
