### PR TITLE
gst-plugins-bad: disable faac by default because it's unfree

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -1,10 +1,13 @@
 { stdenv, fetchurl, pkgconfig, python, gst-plugins-base, orc
-, faac, faad2, libass, libkate, libmms
+, faacSupport ? false, faac ? null
+, faad2, libass, libkate, libmms
 , libmodplug, mpeg2dec, mpg123 
 , openjpeg, libopus, librsvg
 , timidity, libvdpau, wayland
 , libwebp, xvidcore, gnutls
 }:
+
+assert faacSupport -> faac != null;
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-bad-1.2.3";
@@ -32,10 +35,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gst-plugins-base orc
-    faac faad2 libass libkate libmms
+    faad2 libass libkate libmms
     libmodplug mpeg2dec mpg123 
     openjpeg libopus librsvg
     timidity libvdpau wayland
     libwebp xvidcore gnutls
-  ];
+  ] ++ stdenv.lib.optional faacSupport faac;
 }


### PR DESCRIPTION
A lot of packages are not built in hydra due to gst-plugins-bad
being unfree. Make faac dependency optional.
