### PR TITLE
systemd: implement `systemd.services.dataPrefix`, add a few example modules using this

### DIFF
--- a/nixos/modules/misc/lib.nix
+++ b/nixos/modules/misc/lib.nix
@@ -1,15 +1,27 @@
 { config, pkgs, ... }:
 
+with pkgs.lib;
+
 {
   options = {
-    lib = pkgs.lib.mkOption {
+    lib = mkOption {
       default = {};
 
-      type = pkgs.lib.types.attrsOf pkgs.lib.types.attrs;
+      type = types.attrsOf types.attrs;
 
       description = ''
         This option allows modules to define helper functions, constants, etc.
       '';
     };
+
+    dataPrefix = mkOption {
+      default = "/var";
+      type = types.path;
+      visible = false;
+      description = ''
+        Default prefix for data files, used by some modules.
+      '';
+    };
+
   };
 }

--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -34,7 +34,7 @@ in {
 
       dataDir = mkOption {
         type = types.path;
-        default = "/var/lib/rabbitmq";
+        default = "${config.dataPrefix}/lib/rabbitmq";
         description = ''
           Data directory for rabbitmq.
         '';

--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -64,7 +64,7 @@ in {
 
       databaseDir = mkOption {
         type = types.path;
-        default = "/var/lib/couchdb";
+        default = "${config.dataPrefix}/lib/couchdb";
         description = ''
           Specifies location of CouchDB database files (*.couch named). This
           location should be writable and readable for the user the CouchDB
@@ -74,7 +74,7 @@ in {
 
       uriFile = mkOption {
         type = types.path;
-        default = "/var/run/couchdb/couchdb.uri";
+        default = "${config.dataPrefix}/run/couchdb/couchdb.uri";
         description = ''
           This file contains the full URI that can be used to access this
           instance of CouchDB. It is used to help discover the port CouchDB is
@@ -86,7 +86,7 @@ in {
 
       viewIndexDir = mkOption {
         type = types.path;
-        default = "/var/lib/couchdb";
+        default = "${config.dataPrefix}/lib/couchdb";
         description = ''
           Specifies location of CouchDB view index files. This location should
           be writable and readable for the user that runs the CouchDB service
@@ -112,7 +112,7 @@ in {
 
       logFile = mkOption {
         type = types.path;
-        default = "/var/log/couchdb.log";
+        default = "${config.dataPrefix}/log/couchdb.log";
         description = ''
           Specifies the location of file for logging output.
         '';

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -72,7 +72,7 @@ in
 
       dataDir = mkOption {
         type = types.path;
-        default = "/var/db/postgresql";
+        default = "${config.dataPrefix}/db/postgresql";
         description = ''
           Data directory for PostgreSQL.
         '';

--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -88,7 +88,7 @@ in {
 
     dataDir = mkOption {
       type = types.path;
-      default = "/var/lib/elasticsearch";
+      default = "${config.dataPrefix}/lib/elasticsearch";
       description = ''
         Data directory for elasticsearch.
       '';


### PR DESCRIPTION
It would be nice to have a single one location to change dataPrefix(default /var) of modules. I need this to implement systemd user services.

This commit does not try to fix everything, it's just here to start somewhere and later i will fix other modules as needed.
