### PR TITLE
Fix some USB keyboards not working in initrd shell

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -196,6 +196,30 @@ sub usbCheck {
             )
         {
             push @initrdAvailableKernelModules, $module;
+        } else {
+            my $vendor = read_file "$path/../idVendor"; chomp $vendor;
+            my $product = read_file "$path/../idProduct"; chomp $product;
+
+            if ($vendor eq "046d" && ($product eq "c52b" || $product eq "c53b")) {
+                # Logitech Unifying receiver
+                push @initrdAvailableKernelModules, "usbhid";
+                push @initrdAvailableKernelModules, "hid_logitech_dj";
+            }
+            if ($vendor eq "17ef" && $product eq "6009") {
+                # Lenovo ThinkPad USB Keyboard with TrackPoint
+                push @initrdAvailableKernelModules, "usbhid";
+                push @initrdAvailableKernelModules, "hid_lenovo_tpkbd";
+            }
+            if ($vendor eq "1e7d" &&
+                ($product == "30d4" || $product == "319c" || $product == "3264" || $product == "2ced" ||
+                 $product == "2d51" || $product == "2dbe" || $product == "2db4" || $product == "2e22" ||
+                 $product == "2d50" || $product == "2c2e" || $product == "2c24" || $product == "2cf6" ||
+                 $product == "3138" || $product == "31ce" || $product == "3232" || $product == "2d5a" ))
+            {
+                # Roccat
+                push @initrdAvailableKernelModules, "usbhid";
+                push @initrdAvailableKernelModules, "hid_roccat";
+            }
         }
     }
 }


### PR DESCRIPTION
So, here is the story. Some USB keyboards have special HID drivers (e. g. my Logitech Wireless Illuminated Keyboard). If this special modules are enabled, generic HID driver will just ignore corresponding devices. See [this kernel patch](https://lkml.org/lkml/2012/2/13/117).
As a result, those keyboards won't work in the initrd debug shell, since now only the generic `usbhid` module is included.

This patch makes `nixos-generate-config` detect this hardware and include necessary modules in `boot.initrd.availableKernelModules`.

_P.S. All the magic constants are directly from the Kernel sources._
