### PR TITLE
nixos/tests/avahi: Fix race condition on mDNS test

### DIFF
--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -23,12 +23,13 @@ with pkgs;
 
        # mDNS.
        $one->waitForUnit("network.target");
+       $two->waitForUnit("network.target");
+
        $one->succeed("avahi-resolve-host-name one.local | tee out >&2");
        $one->succeed("test \"`cut -f1 < out`\" = one.local");
        $one->succeed("avahi-resolve-host-name two.local | tee out >&2");
        $one->succeed("test \"`cut -f1 < out`\" = two.local");
 
-       $two->waitForUnit("network.target");
        $two->succeed("avahi-resolve-host-name one.local | tee out >&2");
        $two->succeed("test \"`cut -f1 < out`\" = one.local");
        $two->succeed("avahi-resolve-host-name two.local | tee out >&2");


### PR DESCRIPTION
See #2172.

Before this patch, I manually restarted tests.avahi.i686-linux on my local Hydra 3 times and got 3 failures in a row.

After this patch, I manually restarted the same test 3 times and I got 3 successful runs in a row.
