### PR TITLE
tracker, licenses.cc-by-30, gnome-user-docs, upgrade sushi, gnome-keyring service, gnome-user-share, gnome-tweak-tool, gnome-shell-extensions, xdg-user-dirs

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -64,6 +64,12 @@
     url = https://fedoraproject.org/wiki/Licensing/BSD;
   };
 
+  cc-by-30 = {
+    shortName = "CC BY 3.0";
+    fullName = "Creative Commons Attribution 3.0";
+    url = http://creativecommons.org/licenses/by/3.0;
+  };
+
   cddl = {
     shortName = "CDDL";
     fullName = "Common Development Distribution License ";

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -227,6 +227,4 @@ in rec {
 
   crossLists = f: foldl (fs: args: concatMap (f: map f args) fs) [f];
 
-  # List difference, xs - ys. Removes elements of ys from xs.
-  difference = xs: ys: filter (y: !(builtins.elem y ys)) xs;
 }

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -135,6 +135,10 @@ in
           if [ -x $out/bin/glib-compile-schemas -a -w $out/share/glib-2.0/schemas ]; then
               $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas
           fi
+
+          if [ -x $out/bin/update-desktop-database -a -w $out/share/applications ]; then
+              $out/bin/update-desktop-database $out/share/applications
+          fi
         '';
     };
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -101,6 +101,7 @@
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix
   ./services/desktops/gnome3/sushi.nix
+  ./services/desktops/gnome3/tracker.nix
   ./services/desktops/telepathy.nix
   ./services/games/ghost-one.nix
   ./services/games/minecraft-server.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -101,6 +101,7 @@
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix
   ./services/desktops/gnome3/gnome-keyring.nix
+  ./services/desktops/gnome3/gnome-online-accounts.nix
   ./services/desktops/gnome3/gnome-user-share.nix
   ./services/desktops/gnome3/sushi.nix
   ./services/desktops/gnome3/tracker.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -101,6 +101,7 @@
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix
   ./services/desktops/gnome3/gnome-keyring.nix
+  ./services/desktops/gnome3/gnome-user-share.nix
   ./services/desktops/gnome3/sushi.nix
   ./services/desktops/gnome3/tracker.nix
   ./services/desktops/telepathy.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -100,6 +100,7 @@
   ./services/desktops/accountservice.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/evolution-data-server.nix
+  ./services/desktops/gnome3/gnome-keyring.nix
   ./services/desktops/gnome3/sushi.nix
   ./services/desktops/gnome3/tracker.nix
   ./services/desktops/telepathy.nix

--- a/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
@@ -1,0 +1,40 @@
+# GNOME Keyring daemon.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.gnome3.gnome-keyring = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable GNOME Keyring daemon, a service designed to
+          take care of the user's security credentials,
+          such as user names and passwordsa search engine.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.gnome3.gnome-keyring.enable {
+
+    environment.systemPackages = [ pkgs.gnome3.gnome_keyring ];
+
+    services.dbus.packages = [ pkgs.gnome3.gnome_keyring ];
+
+  };
+
+}

--- a/nixos/modules/services/desktops/gnome3/gnome-online-accounts.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-online-accounts.nix
@@ -1,0 +1,39 @@
+# GNOME Online Accounts daemon.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.gnome3.gnome-online-accounts = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable GNOME Online Accounts daemon, a service that provides
+          a single sign-on framework for the GNOME desktop.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.gnome3.gnome-online-accounts.enable {
+
+    environment.systemPackages = [ pkgs.gnome3.gnome_online_accounts ];
+
+    services.dbus.packages = [ pkgs.gnome3.gnome_online_accounts ];
+
+  };
+
+}

--- a/nixos/modules/services/desktops/gnome3/gnome-user-share.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-user-share.nix
@@ -1,0 +1,42 @@
+# GNOME User Share daemon.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.gnome3.gnome-user-share = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable GNOME User Share, a service that exports the
+          contents of the Public folder in your home directory on the local network.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.gnome3.gnome-user-share.enable {
+
+    environment.systemPackages = [ pkgs.gnome3.gnome-user-share ];
+
+    services.xserver.displayManager.sessionCommands = with pkgs.gnome3; ''
+      # Don't let gnome-control-center depend upon gnome-user-share
+      export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${gnome-user-share}/share/gsettings-schemas/${gnome-user-share.name}
+    '';
+
+  };
+
+}

--- a/nixos/modules/services/desktops/gnome3/tracker.nix
+++ b/nixos/modules/services/desktops/gnome3/tracker.nix
@@ -1,0 +1,39 @@
+# Tracker daemon.
+
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.gnome3.tracker = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable Tracker services, a search engine,
+          search tool and metadata storage system.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.gnome3.tracker.enable {
+
+    environment.systemPackages = [ pkgs.gnome3.tracker ];
+
+    services.dbus.packages = [ pkgs.gnome3.tracker ];
+
+  };
+
+}

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -67,6 +67,9 @@ in {
           # Don't let epiphany depend upon gnome-shell
           export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${pkgs.gnome3.gnome_shell}/share/gsettings-schemas/${pkgs.gnome3.gnome_shell.name}
 
+          # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
+          ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update
+
           ${gnome3.gnome_session}/bin/gnome-session&
           waitPID=$!
         '';

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -33,6 +33,7 @@ in {
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
     services.gnome3.sushi.enable = true;
+    services.gnome3.tracker.enable = mkDefault true;
     services.telepathy.enable = true;
     networking.networkmanager.enable = true;
     services.upower.enable = config.powerManagement.enable;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -43,6 +43,7 @@ in {
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
     services.gnome3.gnome-keyring.enable = true;
+    services.gnome3.gnome-online-accounts.enable = mkDefault true;
     services.gnome3.gnome-user-share.enable = mkDefault true;
     services.gnome3.sushi.enable = mkDefault true;
     services.gnome3.tracker.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -43,6 +43,7 @@ in {
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
     services.gnome3.gnome-keyring.enable = true;
+    services.gnome3.gnome-user-share.enable = mkDefault true;
     services.gnome3.sushi.enable = mkDefault true;
     services.gnome3.tracker.enable = mkDefault true;
     services.telepathy.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -32,9 +32,9 @@ in {
     services.accounts-daemon.enable = true;
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
-    services.gnome3.sushi.enable = true;
+    services.gnome3.sushi.enable = mkDefault true;
     services.gnome3.tracker.enable = mkDefault true;
-    services.telepathy.enable = true;
+    services.telepathy.enable = mkDefault true;
     networking.networkmanager.enable = true;
     services.upower.enable = config.powerManagement.enable;
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -105,6 +105,7 @@ in {
         gnome3.gnome-user-docs
 
         gnome3.file-roller
+        gnome3.gnome-tweak-tool
       ] config.environment.gnome3.excludePackages);
   };
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -87,6 +87,7 @@ in {
         gnome3.gnome_themes_standard
       ] ++ (removePackagesByName [
         gnome3.baobab
+        gnome3.empathy
         gnome3.eog
         gnome3.epiphany
         gnome3.evince

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -75,6 +75,7 @@ in {
                                                 "${pkgs.glib_networking}/lib/gio/modules" ];
     environment.systemPackages =
       [ gnome3.dconf
+        pkgs.desktop_file_utils
         pkgs.glib_networking
         pkgs.ibus
         gnome3.gnome-backgrounds

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -62,6 +62,9 @@ in {
 
           export XDG_MENU_PREFIX=gnome
 
+          # Don't let epiphany depend upon gnome-shell
+          export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${pkgs.gnome3.gnome_shell}/share/gsettings-schemas/${pkgs.gnome3.gnome_shell.name}
+
           ${gnome3.gnome_session}/bin/gnome-session&
           waitPID=$!
         '';

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -5,6 +5,16 @@ with pkgs.lib;
 let
   cfg = config.services.xserver.desktopManager.gnome3;
   gnome3 = pkgs.gnome3;
+
+  # Remove packages of ys from xs, based on their names
+  removePackagesByName = xs: ys:
+    let
+      pkgName = drv: (builtins.parseDrvName drv.name).name;
+	  ysNames = map pkgName ys;
+      res = (filter (x: !(builtins.elem (pkgName x) ysNames)) xs);
+    in
+      filter (x: !(builtins.elem (pkgName x) ysNames)) xs;
+
 in {
 
   options = {
@@ -68,7 +78,7 @@ in {
         gnome3.gnome_settings_daemon
         gnome3.gnome_shell
         gnome3.gnome_themes_standard
-      ] ++ (lists.difference [
+      ] ++ (removePackagesByName [
         gnome3.baobab
         gnome3.eog
         gnome3.epiphany

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -79,10 +79,12 @@ in {
         pkgs.glib_networking
         pkgs.gtk3 # for gtk-update-icon-cache
         pkgs.ibus
+        pkgs.shared_mime_info # for update-mime-database
         gnome3.dconf
         gnome3.gnome-backgrounds
         gnome3.gnome_control_center
         gnome3.gnome_icon_theme
+        gnome3.gnome-menus
         gnome3.gnome_settings_daemon
         gnome3.gnome_shell
         gnome3.gnome_themes_standard
@@ -110,6 +112,10 @@ in {
         gnome3.file-roller
         gnome3.gnome-tweak-tool
       ] config.environment.gnome3.excludePackages);
+
+    # Needed for themes and backgrounds
+    environment.pathsToLink = [ "/share" ];
+
   };
 
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -42,6 +42,7 @@ in {
     services.accounts-daemon.enable = true;
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.evolution-data-server.enable = true;
+    services.gnome3.gnome-keyring.enable = true;
     services.gnome3.sushi.enable = mkDefault true;
     services.gnome3.tracker.enable = mkDefault true;
     services.telepathy.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -85,6 +85,7 @@ in {
         gnome3.gnome-system-log
         gnome3.gnome-system-monitor
         gnome3.gnome_terminal
+        gnome3.gnome-user-docs
 
         gnome3.file-roller
       ] config.environment.gnome3.excludePackages);

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -99,6 +99,7 @@ in {
         gnome3.gnome-contacts
         gnome3.gnome-font-viewer
         gnome3.gnome-screenshot
+        gnome3.gnome-shell-extensions
         gnome3.gnome-system-log
         gnome3.gnome-system-monitor
         gnome3.gnome_terminal

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -75,10 +75,11 @@ in {
     environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules"
                                                 "${pkgs.glib_networking}/lib/gio/modules" ];
     environment.systemPackages =
-      [ gnome3.dconf
-        pkgs.desktop_file_utils
+      [ pkgs.desktop_file_utils
         pkgs.glib_networking
+        pkgs.gtk3 # for gtk-update-icon-cache
         pkgs.ibus
+        gnome3.dconf
         gnome3.gnome-backgrounds
         gnome3.gnome_control_center
         gnome3.gnome_icon_theme

--- a/pkgs/desktops/gnome-3/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
 
     rm $out/lib/gio/modules/giomodule.cache
     rm $out/share/icons/hicolor/icon-theme.cache
+    rm $out/share/icons/HighContrast/icon-theme.cache
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/empathy/default.nix
+++ b/pkgs/desktops/gnome-3/core/empathy/default.nix
@@ -37,13 +37,12 @@ stdenv.mkDerivation rec {
                          "-I${dbus_libs}/include/dbus-1.0"
                          "-I${dbus_libs}/lib/dbus-1.0/include" ];
 
-  enableParallelBuilding = true;
-
   preFixup = ''
-    wrapProgram "$out/bin/empathy" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3}/share:${gnome3.gnome_themes_standard}/:${gnome3.gnome_themes_standard}/share:${hicolor_icon_theme}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
-
+    for f in $out/bin/* $out/libexec/*; do
+      wrapProgram $f \
+        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3}/share:${gnome3.gnome_themes_standard}/:${gnome3.gnome_themes_standard}/share:${hicolor_icon_theme}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
+    done
     rm $out/share/icons/hicolor/icon-theme.cache
   '';
 

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gdk_pixbuf gnome3.gnome_icon_theme librsvg
                             hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
 
+  enableParallelBuilding = true;
+
   buildInputs = with gnome3;
     [ pkgconfig intltool ibus gtk glib upower libcanberra gsettings_desktop_schemas
       libxml2 gnome_desktop gnome_settings_daemon polkit libxslt libgtop gnome-menus
@@ -48,6 +50,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    description = "Single sign-on framework for GNOME";
+    maintainers = with maintainers; [ lethalman ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -2,11 +2,12 @@
 , libcanberra, accountservice, libpwquality, pulseaudio, fontconfig
 , gdk_pixbuf, hicolor_icon_theme, librsvg, libxkbfile, libnotify
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
-, cracklib, python, krb5, networkmanagerapplet, libwacom, samba
-, shared_mime_info, tzdata, icu, libtool, docbook_xsl, docbook_xsl_ns }:
+, cracklib, python, krb5, networkmanagerapplet, networkmanager
+, libwacom, samba, shared_mime_info, tzdata, icu, libtool
+, docbook_xsl, docbook_xsl_ns, modemmanager }:
 
 # http://ftp.gnome.org/pub/GNOME/teams/releng/3.10.2/gnome-suites-core-3.10.2.modules
-# TODO: bluetooth, networkmanager, wacom, smbclient, printers
+# TODO: bluetooth, wacom, smbclient, printers
 
 stdenv.mkDerivation rec {
   name = "gnome-control-center-3.10.2";
@@ -27,7 +28,8 @@ stdenv.mkDerivation rec {
       libxml2 gnome_desktop gnome_settings_daemon polkit libxslt libgtop gnome-menus
       gnome_online_accounts libsoup colord pulseaudio fontconfig colord-gtk libpwquality
       accountservice krb5 networkmanagerapplet libwacom samba libnotify libxkbfile
-      shared_mime_info icu libtool docbook_xsl docbook_xsl_ns makeWrapper ];
+      shared_mime_info icu libtool docbook_xsl docbook_xsl_ns 
+      networkmanager modemmanager makeWrapper  ];
 
   preBuild = ''
     substituteInPlace tz.h --replace "/usr/share/zoneinfo/zone.tab" "${tzdata}/share/zoneinfo/zone.tab"

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${dbus_glib}/include/dbus-1.0 -I${dbus_libs}/include/dbus-1.0";
 
+  enableParallelBuilding = true;
+
   buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest libsecret dbus_glib telepathy_glib intltool icu libsoup docbook_xsl_ns docbook_xsl];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, intltool, fetchurl, libgtop
+, pkgconfig, gtk3, glib, hicolor_icon_theme
+, bash, makeWrapper, itstool
+, gnome3, file }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-extensions-3.10.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-shell-extensions/3.10/${name}.tar.xz";
+    sha256 = "9baa9ddaf4e14cab6d4d7944d8dc009378b25f995acfd0fd72843f599cb5ae43";
+  };
+
+  doCheck = true;
+
+  buildInputs = [ pkgconfig gtk3 glib libgtop intltool itstool
+                  makeWrapper file ];
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Projects/GnomeShell/Extensions;
+    description = "Modify and extend GNOME Shell functionality and behavior";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "${evolution_data_server}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
   '';
 
+  patches = [ ./fix_background_corruption.patch ];
+
   meta = with stdenv.lib; {
     platforms = platforms.linux;
   };

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, pkgconfig, gnome3, json_glib, libcroco, intltool, libsecret
 , python, libsoup, polkit, clutter, networkmanager, docbook_xsl, docbook_xsl_ns
-, libstartup_notification, telepathy_glib, telepathy_logger, libXtst, p11_kit
+, libstartup_notification, telepathy_glib, telepathy_logger, libXtst, p11_kit, unzip
 , pulseaudio, libical, libtool, nss, gobjectIntrospection, gstreamer, makeWrapper
 , accountservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet, librsvg }:
 
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
 
   preFixup = with gnome3; ''
     wrapProgram "$out/bin/gnome-shell" \
+      --prefix PATH : "${unzip}/bin" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
       --prefix LD_LIBRARY_PATH : "${accountservice}/lib:${ibus}/lib:${gdm}/lib" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \

--- a/pkgs/desktops/gnome-3/core/gnome-shell/fix_background_corruption.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/fix_background_corruption.patch
@@ -1,0 +1,147 @@
+commit 831bd07b0d6b7055fea8317f2cdf8fd4a408c36d
+Author: Jasper St. Pierre <jstpierre@mecheye.net>
+Date:   Thu Nov 7 17:14:47 2013 -0500
+
+    layout: Fix several issues with the background management code
+    
+    If monitor-changed fires at startup, it will destroy all of the
+    backgrounds, but since this._isStartup is true, won't recreate any
+    of them. Additionally, since _bgManagers is indexed by monitor index,
+    if the primary index is not 0, it could become a sparse array (e.g.
+    [undefined, undefined, primaryBackground]), and our for loop will
+    crash trying to access properties of undefined.
+    
+    Fix both of these issues by always creating background managers for
+    every monitor, hiding them on startup but only showing them after
+    the startup animation is complete.
+    
+    One thing we need to watch out for is that while LayoutManager is
+    constructing, Main.uiGroup / Main.layoutManager will be undefined,
+    so addBackgroundMenu will fail. Fix this by passing down the uiGroup
+    to the background menu code.
+    
+    https://bugzilla.gnome.org/show_bug.cgi?id=709313
+
+diff --git a/js/ui/backgroundMenu.js b/js/ui/backgroundMenu.js
+index 06e698c..dcbbb39 100644
+--- a/js/ui/backgroundMenu.js
++++ b/js/ui/backgroundMenu.js
+@@ -13,7 +13,7 @@ const BackgroundMenu = new Lang.Class({
+     Name: 'BackgroundMenu',
+     Extends: PopupMenu.PopupMenu,
+ 
+-    _init: function(source) {
++    _init: function(source, layoutManager) {
+         this.parent(source, 0, St.Side.TOP);
+ 
+         this.addSettingsAction(_("Settings"), 'gnome-control-center.desktop');
+@@ -22,17 +22,17 @@ const BackgroundMenu = new Lang.Class({
+ 
+         this.actor.add_style_class_name('background-menu');
+ 
+-        Main.uiGroup.add_actor(this.actor);
++        layoutManager.uiGroup.add_actor(this.actor);
+         this.actor.hide();
+     }
+ });
+ 
+-function addBackgroundMenu(actor) {
++function addBackgroundMenu(actor, layoutManager) {
+     let cursor = new St.Bin({ opacity: 0 });
+-    Main.uiGroup.add_actor(cursor);
++    layoutManager.uiGroup.add_actor(cursor);
+ 
+     actor.reactive = true;
+-    actor._backgroundMenu = new BackgroundMenu(cursor);
++    actor._backgroundMenu = new BackgroundMenu(cursor, layoutManager);
+     actor._backgroundManager = new PopupMenu.PopupMenuManager({ actor: actor });
+     actor._backgroundManager.addMenu(actor._backgroundMenu);
+ 
+diff --git a/js/ui/layout.js b/js/ui/layout.js
+index 17073a6..80bae9d 100644
+--- a/js/ui/layout.js
++++ b/js/ui/layout.js
+@@ -352,26 +352,26 @@ const LayoutManager = new Lang.Class({
+         this.emit('hot-corners-changed');
+     },
+ 
+-    _createBackground: function(monitorIndex) {
++    _addBackgroundMenu: function(bgManager) {
++        BackgroundMenu.addBackgroundMenu(bgManager.background.actor, this);
++    },
++
++    _createBackgroundManager: function(monitorIndex) {
+         let bgManager = new Background.BackgroundManager({ container: this._backgroundGroup,
+                                                            layoutManager: this,
+                                                            monitorIndex: monitorIndex });
+-        BackgroundMenu.addBackgroundMenu(bgManager.background.actor);
+-
+-        bgManager.connect('changed', Lang.bind(this, function() {
+-                              BackgroundMenu.addBackgroundMenu(bgManager.background.actor);
+-                          }));
+ 
+-        this._bgManagers[monitorIndex] = bgManager;
++        bgManager.connect('changed', Lang.bind(this, this._addBackgroundMenu));
++        this._addBackgroundMenu(bgManager);
+ 
+-        return bgManager.background;
++        return bgManager;
+     },
+ 
+-    _createSecondaryBackgrounds: function() {
++    _showSecondaryBackgrounds: function() {
+         for (let i = 0; i < this.monitors.length; i++) {
+             if (i != this.primaryIndex) {
+-                let background = this._createBackground(i);
+-
++                let background = this._bgManagers[i].background;
++                background.actor.show();
+                 background.actor.opacity = 0;
+                 Tweener.addTween(background.actor,
+                                  { opacity: 255,
+@@ -381,10 +381,6 @@ const LayoutManager = new Lang.Class({
+         }
+     },
+ 
+-    _createPrimaryBackground: function() {
+-        this._createBackground(this.primaryIndex);
+-    },
+-
+     _updateBackgrounds: function() {
+         let i;
+         for (i = 0; i < this._bgManagers.length; i++)
+@@ -395,11 +391,12 @@ const LayoutManager = new Lang.Class({
+         if (Main.sessionMode.isGreeter)
+             return;
+ 
+-        if (this._startingUp)
+-            return;
+-
+         for (let i = 0; i < this.monitors.length; i++) {
+-            this._createBackground(i);
++            let bgManager = this._createBackgroundManager(i);
++            this._bgManagers.push(bgManager);
++
++            if (i != this.primaryIndex && this._startingUp)
++                bgManager.background.actor.hide();
+         }
+     },
+ 
+@@ -595,7 +592,7 @@ const LayoutManager = new Lang.Class({
+         if (Main.sessionMode.isGreeter) {
+             this.panelBox.translation_y = -this.panelBox.height;
+         } else {
+-            this._createPrimaryBackground();
++            this._updateBackgrounds();
+ 
+             // We need to force an update of the regions now before we scale
+             // the UI group to get the coorect allocation for the struts.
+@@ -673,7 +670,7 @@ const LayoutManager = new Lang.Class({
+         this.keyboardBox.show();
+ 
+         if (!Main.sessionMode.isGreeter) {
+-            this._createSecondaryBackgrounds();
++            this._showSecondaryBackgrounds();
+             global.window_group.remove_clip();
+         }
+ 

--- a/pkgs/desktops/gnome-3/core/gnome-user-docs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-docs/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, file, gnome3, itstool, libxml2, intltool }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-user-docs-3.10.3";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-user-docs/3.10/${name}.tar.xz";
+    sha256 = "960b6373ea52e41e3deb3501930e024005b29d2cc958bfadc87450a291d2a905";
+  };
+
+  buildInputs = [ pkgconfig gnome3.yelp itstool libxml2 intltool ];
+
+  meta = with stdenv.lib; {
+    homepage = https://help.gnome.org/users/gnome-help/3.10;
+    description = "User and system administration help for the Gnome desktop";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.cc-by-30;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, intltool, fetchurl, apacheHttpd_2_2, nautilus
+, pkgconfig, gtk3, glib, hicolor_icon_theme, libxml2, gnused
+, bash, makeWrapper, itstool, libnotify, libtool, mod_dnssd
+, gnome3, librsvg, gdk_pixbuf, file, libcanberra_gtk3 }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-user-share-3.10.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-user-share/3.10/${name}.tar.xz";
+    sha256 = "1d1ea57a49224c36e7cba04f80265e835639377f474a7582c9e8ac946eda0f8f";
+  };
+
+  doCheck = true;
+
+  NIX_CFLAGS_COMPILE = "-I${gnome3.glib}/include/gio-unix-2.0";
+
+  preConfigure = ''
+    sed -e 's,^LoadModule dnssd_module.\+,LoadModule dnssd_module ${mod_dnssd}/modules/mod_dnssd.so,' -i data/dav_user_2.2.conf 
+  '';
+
+  configureFlags = [ "--with-httpd=${apacheHttpd_2_2}/bin/httpd"
+                     "--with-modules-path=${apacheHttpd_2_2}/modules"
+                     "--disable-bluetooth"
+                     "--with-nautilusdir=$(out)/lib/nautilus/extensions-3.0" ];
+
+  buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2 libtool
+                  makeWrapper file gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                  hicolor_icon_theme gnome3.gnome_icon_theme_symbolic
+                  nautilus libnotify libcanberra_gtk3 ];
+
+  postInstall = ''
+    mkdir -p $out/share/gsettings-schemas/$name
+    mv $out/share/glib-2.0 $out/share/gsettings-schemas/$name
+    ${glib}/bin/glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas
+  '';
+
+  preFixup = ''
+    wrapProgram "$out/libexec/gnome-user-share" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    rm $out/share/icons/hicolor/icon-theme.cache
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://help.gnome.org/users/gnome-user-share/3.8;
+    description = "Service that exports the contents of the Public folder in your home directory on the local network";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/core/sushi/default.nix
+++ b/pkgs/desktops/gnome-3/core/sushi/default.nix
@@ -4,11 +4,11 @@
 , gdk_pixbuf, librsvg, hicolor_icon_theme }:
 
 stdenv.mkDerivation rec {
-  name = "sushi-3.8.1";
+  name = "sushi-3.10.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/sushi/3.8/${name}.tar.xz";
-    sha256 = "c4f24d0961ce8fc5ef3a4fe9af178e368c7117459df2c0be12c8f953646c82dd";
+    url = "mirror://gnome/sources/sushi/3.10/${name}.tar.xz";
+    sha256 = "cffcf28b170f5825e84983a979972d4d901a453b61cbe3e560d362e8dd4b4bc8";
   };
 
   propagatedUserEnvPkgs = [ gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good ];

--- a/pkgs/desktops/gnome-3/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, intltool, fetchurl, libxml2, upower
+, pkgconfig, gtk3, glib, hicolor_icon_theme
+, bash, makeWrapper, itstool, vala, sqlite
+, gnome3, librsvg, gdk_pixbuf, file, libnotify
+, evolution_data_server, gst_all_1, poppler
+, icu, taglib, libjpeg, libtiff, giflib, libcue
+, libvorbis, flac, exempi, networkmanager
+, libpng, libexif, libgsf, libuuid, bzip2 }:
+
+stdenv.mkDerivation rec {
+  name = "tracker-1.0.0";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/tracker/1.0/${name}.tar.xz";
+    sha256 = "a1d033faf2c78f0e239f3c2c961b96623c9a7dabd938c08e3f5660bd70f54ba2";
+  };
+
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+
+  NIX_CFLAGS_COMPILE = "-I${gnome3.glib}/include/gio-unix-2.0";
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ vala pkgconfig gtk3 glib intltool itstool libxml2
+                  bzip2 gnome3.totem-pl-parser
+                  gnome3.gsettings_desktop_schemas makeWrapper file
+                  gdk_pixbuf gnome3.gnome_icon_theme librsvg sqlite
+                  upower libnotify evolution_data_server gnome3.libgee
+                  gst_all_1.gstreamer gst_all_1.gst-plugins-base flac
+                  poppler icu taglib libjpeg libtiff giflib libvorbis
+                  exempi networkmanager libpng libexif libgsf libuuid
+                  hicolor_icon_theme gnome3.gnome_icon_theme_symbolic ];
+
+  preFixup = ''
+    for f in $out/bin/* $out/libexec/*; do
+      wrapProgram $f \
+        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Projects/Tracker;
+    description = "Desktop-neutral user information store, search tool and indexer";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -162,4 +162,6 @@ rec {
   libgit2-glib = callPackage ./misc/libgit2-glib { };
   
   gexiv2 = callPackage ./misc/gexiv2 { };
+
+  gnome-tweak-tool = callPackage ./misc/gnome-tweak-tool { };
 }

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -88,6 +88,8 @@ rec {
 
   gnome-user-docs = callPackage ./core/gnome-user-docs { };
 
+  gnome-user-share = callPackage ./core/gnome-user-share { };
+
   grilo = callPackage ./core/grilo { };
 
   gsettings_desktop_schemas = callPackage ./core/gsettings-desktop-schemas { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -86,6 +86,8 @@ rec {
 
   gnome_themes_standard = callPackage ./core/gnome-themes-standard { };
 
+  gnome-user-docs = callPackage ./core/gnome-user-docs { };
+
   grilo = callPackage ./core/grilo { };
 
   gsettings_desktop_schemas = callPackage ./core/gsettings-desktop-schemas { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -74,6 +74,8 @@ rec {
 
   gnome_shell = callPackage ./core/gnome-shell { };
 
+  gnome-shell-extensions = callPackage ./core/gnome-shell-extensions { };
+
   gnome-screenshot = callPackage ./core/gnome-screenshot { };
 
   gnome_settings_daemon = callPackage ./core/gnome-settings-daemon { };

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -122,6 +122,8 @@ rec {
 
   totem-pl-parser = callPackage ./core/totem-pl-parser { };
 
+  tracker = callPackage ./core/tracker { };
+
   vte = callPackage ./core/vte { };
 
   vino = callPackage ./core/vino { };

--- a/pkgs/desktops/gnome-3/misc/gnome-tweak-tool/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweak-tool/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, intltool, fetchurl, python, pygobject3, atk
+, pkgconfig, gtk3, glib, hicolor_icon_theme, libsoup
+, bash, makeWrapper, itstool, libxml2, python3Packages
+, gnome3, librsvg, gdk_pixbuf, file, libnotify }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-tweak-tool-3.10.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-tweak-tool/3.10/${name}.tar.xz";
+    sha256 = "fb5af9022c0521a925ef9f295e4080212b1b45427cd5f5f3a901667590afa7ec";
+  };
+
+  doCheck = true;
+
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+
+  makeFlags = [ "DESTDIR=/" ];
+
+  buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2
+                  gnome3.gsettings_desktop_schemas makeWrapper file
+                  gdk_pixbuf gnome3.gnome_icon_theme librsvg
+                  hicolor_icon_theme gnome3.gnome_icon_theme_symbolic
+                  python pygobject3 libnotify gnome3.gnome_shell
+                  libsoup gnome3.gnome_settings_daemon gnome3.nautilus
+                  gnome3.gnome_desktop ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/gnome-tweak-tool" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+      --prefix LD_LIBRARY_PATH ":" "${libsoup}/lib:${gnome3.gnome_desktop}/lib:${libnotify}/lib:${gtk3}/lib:${atk}/lib" \
+      --prefix PYTHONPATH : "$PYTHONPATH:$(toPythonPath $out)"
+  '';
+
+  patches = [ ./find_gsettings.patch ];
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/action/show/Apps/GnomeTweakTool;
+    description = "A tool to customize advanced GNOME 3 options";
+    maintainers = with maintainers; [ lethalman ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/misc/gnome-tweak-tool/find_gsettings.patch
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweak-tool/find_gsettings.patch
@@ -1,0 +1,22 @@
+diff --git a/gtweak/gsettings.py b/gtweak/gsettings.py
+index a00fe19..dce74b2 100644
+--- a/gtweak/gsettings.py
++++ b/gtweak/gsettings.py
+@@ -33,10 +33,15 @@ class GSettingsMissingError(Exception):
+ 
+ class _GSettingsSchema:
+     def __init__(self, schema_name, schema_dir=None, schema_filename=None, **options):
+-        if not schema_dir:
+-            schema_dir = gtweak.GSETTINGS_SCHEMA_DIR
+         if not schema_filename:
+             schema_filename = schema_name + ".gschema.xml"
++        if not schema_dir:
++            schema_dir = gtweak.GSETTINGS_SCHEMA_DIR
++            for xdg_dir in GLib.get_system_data_dirs():
++                dir = os.path.join(xdg_dir, "glib-2.0", "schemas")
++                if os.path.exists(os.path.join(dir, schema_filename)):
++                    schema_dir = dir
++                    break
+ 
+         schema_path = os.path.join(schema_dir, schema_filename)
+         if not os.path.exists(schema_path):

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, automake, autoconf, libtool, glib, gdk_pixbuf }:
+{ stdenv, fetchurl, pkgconfig, automake, autoconf, libtool
+, glib, gdk_pixbuf, gobjectIntrospection, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   ver_maj = "0.7";
@@ -9,23 +10,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/libnotify/${ver_maj}/${name}.tar.xz";
     sha256 = "0dyq8zgjnnzcah31axnx6afb21kl7bks1gvrg4hjh3nk02j1rxhf";
   };
-  src_m4 = fetchurl {
-    url = "mirror://gentoo/distfiles/introspection-20110205.m4.tar.bz2";
-    sha256 = "1cnqh7aaji648nfd5537v7xaak8hgww3bpifhwam7bl0sc3ad523";
-  };
 
   # see Gentoo ebuild - we don't need to depend on gtk+(2/3)
-  preConfigure = ''
-    cd m4
-    tar xvf ${src_m4}
-    cd ..
-
+  preAutoreconf = ''
     sed -i -e 's:noinst_PROG:check_PROG:' tests/Makefile.am || die
     sed -i -e '/PKG_CHECK_MODULES(TESTS/d' configure.ac || die
-    AT_M4DIR=. autoreconf
   '';
 
-  buildInputs = [ pkgconfig automake autoconf glib gdk_pixbuf ];
+  buildInputs = [ pkgconfig automake autoconf autoreconfHook
+                  libtool glib gdk_pixbuf gobjectIntrospection ];
 
   meta = {
     homepage = http://galago-project.org/; # very obsolete but found no better

--- a/pkgs/development/libraries/telepathy/glib/default.nix
+++ b/pkgs/development/libraries/telepathy/glib/default.nix
@@ -2,11 +2,11 @@
 , gobjectIntrospection, valaSupport ? true, vala }:
 
 stdenv.mkDerivation rec {
-  name = "telepathy-glib-0.22.1";
+  name = "telepathy-glib-0.24.0";
 
   src = fetchurl {
     url = "${meta.homepage}/releases/telepathy-glib/${name}.tar.gz";
-    sha256 = "0vf2drh7g55nxyd0mxyn9sf99m981dagnvv9yc3q9f4k8x092a78";
+    sha256 = "ae0002134991217f42e503c43dea7817853afc18863b913744d51ffa029818cf";
   };
 
   configureFlags = stdenv.lib.optional valaSupport "--enable-vala-bindings";

--- a/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, apacheHttpd_2_2, apr, avahi }:
+
+stdenv.mkDerivation rec {
+  name = "mod_dnssd-0.6";
+
+  src = fetchurl {
+    url = "http://0pointer.de/lennart/projects/mod_dnssd/${name}.tar.gz";
+    sha256 = "2cd171d76eba398f03c1d5bcc468a1756f4801cd8ed5bd065086e4374997c5aa";
+  };
+
+  configureFlags = [ "--disable-lynx" ];
+
+  buildInputs = [ pkgconfig apacheHttpd_2_2 avahi apr ];
+
+  installPhase = ''
+    mkdir -p $out/modules
+    cp src/.libs/mod_dnssd.so $out/modules
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://0pointer.de/lennart/projects/mod_dnssd;
+    description = "Provide Zeroconf support via DNS-SD using Avahi";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lethalman ];
+  };
+}
+

--- a/pkgs/tools/X11/xdg-user-dirs/default.nix
+++ b/pkgs/tools/X11/xdg-user-dirs/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, libxslt, docbook_xsl }:
+
+stdenv.mkDerivation rec {
+  name = "xdg-user-dirs-0.15";
+  
+  src = fetchurl {
+    url = "http://user-dirs.freedesktop.org/releases/${name}.tar.gz";
+    sha256 = "20b4a751f41d0554bce3e0ce5e8d934be98cc62d48f0b90a894c3e1916552786";
+  };
+
+  buildInputs = [ libxslt docbook_xsl ];
+
+  meta = with stdenv.lib; {
+    homepage = http://freedesktop.org/wiki/Software/xdg-user-dirs;
+    description = "A tool to help manage well known user directories like the desktop folder and the music folder";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ lethalman ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6451,6 +6451,8 @@ let
 
   memcached = callPackage ../servers/memcached {};
 
+  mod_dnssd = callPackage ../servers/http/apache-modules/mod_dnssd/default.nix { };
+
   mod_evasive = callPackage ../servers/http/apache-modules/mod_evasive { };
 
   mod_python = callPackage ../servers/http/apache-modules/mod_python { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9455,6 +9455,8 @@ let
 
   xdaliclock = callPackage ../tools/misc/xdaliclock {};
 
+  xdg-user-dirs = callPackage ../tools/X11/xdg-user-dirs { };
+
   xdg_utils = callPackage ../tools/X11/xdg-utils { };
 
   xdotool = callPackage ../tools/X11/xdotool { };


### PR DESCRIPTION
Just packaged with the service, but currently disabled by default on gnome3 because it didn't convince me and didn't really test the search engine.
