### PR TITLE
libtxc_dxtn_s2tc: free s3tc implementation

### DIFF
--- a/pkgs/development/libraries/libtxc_dxtn_s2tc/default.nix
+++ b/pkgs/development/libraries/libtxc_dxtn_s2tc/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, autoreconfHook, mesa }:
+
+let version = "1.0"; in
+
+stdenv.mkDerivation rec {
+  name = "libtxc_dxtn_s2tc-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/divVerent/s2tc/archive/v${version}.tar.gz";
+    sha256 = "0ibfdib277fhbqvxzan0bmglwnsl1y1rw2g8skvz82l1sfmmn752";
+  };
+
+  buildInputs = [ autoreconfHook mesa ];
+
+  meta = {
+    description = "A patent-free S3TC compatible implementation";
+    homepage = https://github.com/divVerent/s2tc;
+    repositories.git = https://github.com/divVerent/s2tc.git;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.page ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5176,6 +5176,8 @@ let
 
   libtxc_dxtn = callPackage ../development/libraries/libtxc_dxtn { };
 
+  libtxc_dxtn_s2tc = callPackage ../development/libraries/libtxc_dxtn_s2tc { };
+
   libgeotiff = callPackage ../development/libraries/libgeotiff { };
 
   libunistring = callPackage ../development/libraries/libunistring { };


### PR DESCRIPTION
This is a patent-free implementation of the s3tc texture compression algorithm. I don't think it has any drawbacks over the patented one, so I think we could drop the other.

Also, I'm not sure if we should add it to the path by default, along with mesa. I think distros like Ubuntu install it by default. Thoughts?
