### PR TITLE
nixos: disable ntp on containers by default

### DIFF
--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -36,7 +36,7 @@ in
     services.ntp = {
 
       enable = mkOption {
-        default = true;
+        default = !config.boot.isContainer;
         description = ''
           Whether to synchronise your machine's time using the NTP
           protocol.


### PR DESCRIPTION
I had problems with starting ntp in containers(lxc and libvirt-lxc), so i think it should be disabled by default.
