### PR TITLE
Bugfix: Don't preserve hard links in the initrd.

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -31,7 +31,7 @@ storePaths=$(perl $pathsFromGraph closure-*)
 
 # Paths in cpio archives *must* be relative, otherwise the kernel
 # won't unpack 'em.
-(cd root && cp -prd --parents $storePaths .)
+(cd root && cp -pr --parents $storePaths .)
 
 
 # Put the closure in a gzipped cpio archive.


### PR DESCRIPTION
This fixes a bug that stopped my system from booting but the trade-off is that my compressed initrd grows from 6.5M to 6.7M.

The story:

My system stopped booting after a recent nixos-rebuild, with btrfs complaining that a shared library (libz.so.1) had zero length.  When I unpack the initrd with cpio, I indeed see a zero-length file, but libz.so, which I guess it's meant to be hard-linked to, seems fine.  Perhaps if I had passed the right argument to my cpio unpacking command, the hard link would have been recovered, but the point is that the Linux kernel's cpio also seems to see a zero-length file.

A brief web search showed some mention of the initrd format not allowing hard links, but I did not dig too deeply.

James
