### PR TITLE
Unbreak symlinks in initrd.

### DIFF
--- a/pkgs/build-support/kernel/cpio-clean.pl
+++ b/pkgs/build-support/kernel/cpio-clean.pl
@@ -8,12 +8,8 @@ use Archive::Cpio;
 
 my $cpio = Archive::Cpio->new;
 my $IN = \*STDIN;
-my $ino = 1;
 $cpio->read_with_handler($IN, sub {
         my ($e) = @_;
-        $e->{inode} = $ino;
-        $ino++;
-        $e->{nlink} = 1;
         $e->{mtime} = 1;
 	$cpio->write_one(\*STDOUT, $e);
     });


### PR DESCRIPTION
The cpio cleaning was not safe.
