### PR TITLE
nixos: make several kernel common-config options optional

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -76,17 +76,17 @@ with stdenv.lib;
   CLS_U32_MARK y
 
   # Wireless networking.
-  CFG80211_WEXT y # Without it, ipw2200 drivers don't build
-  IPW2100_MONITOR y # support promiscuous mode
-  IPW2200_MONITOR y # support promiscuous mode
-  HOSTAP_FIRMWARE y # Support downloading firmware images with Host AP driver
-  HOSTAP_FIRMWARE_NVRAM y
-  ATH9K_PCI y # Detect Atheros AR9xxx cards on PCI(e) bus
-  ATH9K_AHB y # Ditto, AHB bus
+  CFG80211_WEXT? y # Without it, ipw2200 drivers don't build
+  IPW2100_MONITOR? y # support promiscuous mode
+  IPW2200_MONITOR? y # support promiscuous mode
+  HOSTAP_FIRMWARE? y # Support downloading firmware images with Host AP driver
+  HOSTAP_FIRMWARE_NVRAM? y
+  ATH9K_PCI? y # Detect Atheros AR9xxx cards on PCI(e) bus
+  ATH9K_AHB? y # Ditto, AHB bus
   ${optionalString (versionAtLeast version "3.2") ''
-    B43_PHY_HT y
+    B43_PHY_HT? y
   ''}
-  BCMA_HOST_PCI y
+  BCMA_HOST_PCI? y
 
   # Enable various FB devices.
   FB y
@@ -108,7 +108,7 @@ with stdenv.lib;
   # Enable KMS for devices whose X.org driver supports it.
   DRM_I915_KMS y
   ${optionalString (versionOlder version "3.9") ''
-    DRM_RADEON_KMS y
+    DRM_RADEON_KMS? y
   ''}
   # Hybrid graphics support
   VGA_SWITCHEROO y
@@ -142,18 +142,18 @@ with stdenv.lib;
   EXT2_FS_XIP y # Ext2 execute in place support
   EXT4_FS_POSIX_ACL y
   EXT4_FS_SECURITY y
-  REISERFS_FS_XATTR y
-  REISERFS_FS_POSIX_ACL y
-  REISERFS_FS_SECURITY y
-  JFS_POSIX_ACL y
-  JFS_SECURITY y
-  XFS_QUOTA y
-  XFS_POSIX_ACL y
-  XFS_RT y # XFS Realtime subvolume support
-  OCFS2_DEBUG_MASKLOG n
+  REISERFS_FS_XATTR? y
+  REISERFS_FS_POSIX_ACL? y
+  REISERFS_FS_SECURITY? y
+  JFS_POSIX_ACL? y
+  JFS_SECURITY? y
+  XFS_QUOTA? y
+  XFS_POSIX_ACL? y
+  XFS_RT? y # XFS Realtime subvolume support
+  OCFS2_DEBUG_MASKLOG? n
   BTRFS_FS_POSIX_ACL y
   UBIFS_FS_XATTR? y
-  UBIFS_FS_ADVANCED_COMPR y
+  UBIFS_FS_ADVANCED_COMPR? y
   NFSD_V2_ACL y
   NFSD_V3 y
   NFSD_V3_ACL y
@@ -166,7 +166,7 @@ with stdenv.lib;
   # Security related features.
   STRICT_DEVMEM y # Filter access to /dev/mem
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default
-  DEVKMEM n # Disable /dev/kmem
+  DEVKMEM? n # Disable /dev/kmem
   ${if versionOlder version "3.14" then ''
     CC_STACKPROTECTOR y # Detect buffer overflows on the stack
   '' else ''
@@ -185,14 +185,14 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "3.3" && versionOlder version "3.13") ''
     AUDIT_LOGINUID_IMMUTABLE y
   ''}
-  B43_PCMCIA y
+  B43_PCMCIA? y
   BLK_DEV_CMD640_ENHANCED y # CMD640 enhanced support
   BLK_DEV_IDEACPI y # IDE ACPI support
   BLK_DEV_INTEGRITY y
   BSD_PROCESS_ACCT_V3 y
-  BT_HCIUART_BCSP y
-  BT_HCIUART_H4 y # UART (H4) protocol support
-  BT_HCIUART_LL y
+  BT_HCIUART_BCSP? y
+  BT_HCIUART_H4? y # UART (H4) protocol support
+  BT_HCIUART_LL? y
   BT_RFCOMM_TTY? y # RFCOMM TTY support
   CRASH_DUMP? n
   ${optionalString (versionOlder version "3.1") ''
@@ -206,10 +206,10 @@ with stdenv.lib;
   FUSION y # Fusion MPT device support
   IDE_GD_ATAPI y # ATAPI floppy support
   IRDA_ULTRA y # Ultra (connectionless) protocol
-  JOYSTICK_IFORCE_232 y # I-Force Serial joysticks and wheels
-  JOYSTICK_IFORCE_USB y # I-Force USB joysticks and wheels
-  JOYSTICK_XPAD_FF y # X-Box gamepad rumble support
-  JOYSTICK_XPAD_LEDS y # LED Support for Xbox360 controller 'BigX' LED
+  JOYSTICK_IFORCE_232? y # I-Force Serial joysticks and wheels
+  JOYSTICK_IFORCE_USB? y # I-Force USB joysticks and wheels
+  JOYSTICK_XPAD_FF? y # X-Box gamepad rumble support
+  JOYSTICK_XPAD_LEDS? y # LED Support for Xbox360 controller 'BigX' LED
   LDM_PARTITION y # Windows Logical Disk Manager (Dynamic Disk) support
   LEDS_TRIGGER_IDE_DISK y # LED IDE Disk Trigger
   LOGIRUMBLEPAD2_FF y # Logitech Rumblepad 2 force feedback
@@ -275,17 +275,17 @@ with stdenv.lib;
   ''}
 
   # Virtualisation.
-  PARAVIRT y
+  PARAVIRT? y
   ${if versionAtLeast version "3.10" then ''
-    HYPERVISOR_GUEST y
+    HYPERVISOR_GUEST? y
   '' else ''
-    PARAVIRT_GUEST y
+    PARAVIRT_GUEST? y
   ''}
-  KVM_GUEST y
+  KVM_GUEST? y
   ${optionalString (versionOlder version "3.7") ''
-    KVM_CLOCK y
+    KVM_CLOCK? y
   ''}
-  XEN y
+  XEN? y
   XEN_DOM0? y
   KSM y
   ${optionalString (!stdenv.is64bit) ''
@@ -308,8 +308,8 @@ with stdenv.lib;
   ''}
 
   # Enable the 9P cache to speed up NixOS VM tests.
-  9P_FSCACHE y
-  9P_FS_POSIX_ACL y
+  9P_FSCACHE? y
+  9P_FS_POSIX_ACL? y
 
   ${kernelPlatform.kernelExtraConfig or ""}
   ${extraConfig}


### PR DESCRIPTION
This is a follow up from #1875 - I still want this commit, but @edolstra probably wants to double check it first.

---

Realistically, common-config is useful, but there are a lot of things in
there that are non-optionally specified that aren't always useful. For
example, when deploying grsecurity, I don't want the bluetooth,
wireless, or input joystick/extra filesystem stack (XFS, etc), nor the
staging drivers tree.

The problem is that if you specify this in your own kernel config in the
grsecurity module, by saying 'BT n' to turn off bluetooth,
common-config turns on 'BT_HCIUART_BCSP y', which then becomes unused
and errors out.

This is really just an arbitrary picking at the moment, but it should be
OK.
