### PR TITLE
nixos: fix shell on containers, preserve session

### DIFF
--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -94,7 +94,8 @@ in
         groupmod = { rootOK = true; };
         groupmems = { rootOK = true; };
         groupdel = { rootOK = true; };
-        login = { startSession = true; allowNullPassword = true; showMotd = true; updateWtmp = true; };
+        # Note: setLoginUid should work again in linux containers in systemd 209, remove when systemd gets updated
+        login = { startSession = true; setLoginUid = !config.boot.isContainer; allowNullPassword = true; showMotd = true; updateWtmp = true; };
         chpasswd = { rootOK = true; };
         chgpasswd = { rootOK = true; };
       };


### PR DESCRIPTION
According to this bug report https://bugzilla.redhat.com/show_bug.cgi?id=966807,
pam_loginuid has to be removed from pam for login shell in containers to work.

This should be fixed in systemd 209
