### PR TITLE
yandex-disk: fix the url; introduce systemd.service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -118,6 +118,7 @@
       searx = 107;
       kippo = 108;
       jenkins = 109;
+      yandexdisk=110;
 
       # When adding a uid, make sure it doesn't match an existing gid.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -150,6 +150,7 @@
   ./services/network-filesystems/nfsd.nix
   ./services/network-filesystems/openafs-client/default.nix
   ./services/network-filesystems/samba.nix
+  ./services/network-filesystems/yandex-disk.nix
   ./services/networking/amuled.nix
   ./services/networking/avahi-daemon.nix
   ./services/networking/bind.nix

--- a/nixos/modules/services/network-filesystems/yandex-disk.nix
+++ b/nixos/modules/services/network-filesystems/yandex-disk.nix
@@ -1,0 +1,104 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+
+  cfg = config.services.yandex-disk;
+
+  dir = "/var/lib/yandex-disk";
+
+  u = if cfg.user != null then cfg.user else "yandexdisk";
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.yandex-disk = {
+
+      enable = mkOption {
+        default = false;
+        description = "
+          Whether to enable Yandex-disk client.
+        ";
+      };
+
+      username = mkOption {
+        default = "";
+        type = types.string;
+        description = ''
+          Your yandex.com login name.
+        '';
+      };
+
+      password = mkOption {
+        default = "";
+        type = types.string;
+        description = ''
+          Your yandex.com password.
+        '';
+      };
+
+      user = mkOption {
+        default = null;
+        description = ''
+          The user the yandex-disk daemon should run as.
+        '';
+      };
+
+      directory = mkOption {
+        default = "/home/Yandex.Disk";
+        description = "The directory to use for Yandex.Disk storage";
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers = mkIf (cfg.user == null) [ {
+      name = u;
+      uid = config.ids.uids.yandexdisk;
+      group = "nogroup";
+      home = dir;
+    } ];
+
+    systemd.services.yandex-disk = {
+      description = "Yandex-disk server";
+
+      after = [ "network.target" ];
+
+      wantedBy = [ "multi-user.target" ];
+
+      # FIXME: have to specify ${directory} here as well
+      unitConfig.RequiresMountsFor = dir;
+
+      script = ''
+        mkdir -p -m 700 ${dir}
+        chown ${u} ${dir}
+
+        if ! test -d "${cfg.directory}" ; then
+          mkdir -p -m 755 ${cfg.directory} ||
+            exit 1
+        fi
+
+        ${pkgs.su}/bin/su -s ${pkgs.stdenv.shell} ${u} \
+          -c '${pkgs.yandex-disk}/bin/yandex-disk token -p ${cfg.password} ${cfg.username} ${dir}/token'
+
+        ${pkgs.su}/bin/su -s ${pkgs.stdenv.shell} ${u} \
+          -c '${pkgs.yandex-disk}/bin/yandex-disk start --no-daemon -a ${dir}/token -d ${cfg.directory}'
+      '';
+
+    };
+  };
+
+}
+

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -3,17 +3,17 @@ let
   p = if stdenv.is64bit then {
       arch = "x86_64";
       gcclib = "${stdenv.gcc.gcc}/lib64";
-      sha256 = "1fmmlvvh97d60n9k08bn4k6ghwr3yhs8sib82025nwpw1sq08vim";
+      sha256 = "09kw7f0qsvx3vx1c1zb117yf3yk7kkz66agspz5xx9b0zh6i82jw";
     }
     else {
       arch = "i386";
       gcclib = "${stdenv.gcc.gcc}/lib";
-      sha256 = "3940420bd9d1fe1ecec1a117bfd9d21d545bca59f5e0a4364304ab808c976f7f";
+      sha256 = "0f2230c91120f05159281b39c620ab6bad6559ce8a17a0874d0a82350ebba426";
     };
 in 
 stdenv.mkDerivation rec {
 
-  name = "yandex-disk-0.1.2.481";
+  name = "yandex-disk-0.1.4.504";
 
   src = fetchurl {
     url = "http://repo.yandex.ru/yandex-disk/rpm/stable/${p.arch}/${name}-1.fedora.${p.arch}.rpm";


### PR DESCRIPTION
Yandex.com seems to remove the old versions of the application too quickly. This patch does version bump 0.1.2->0.1.4 and also adds a simple systemd service.
