### PR TITLE
keepassx: Renamed KeePassX 2.0 to keepassx2.

### DIFF
--- a/pkgs/applications/misc/keepassx/2.0.nix
+++ b/pkgs/applications/misc/keepassx/2.0.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, cmake, libgcrypt, qt4, xlibs, ... }:
 
 stdenv.mkDerivation {
-  name = "keepassx-2.0alpha5";
+  name = "keepassx2-2.0alpha5";
   src = fetchurl {
     url = "https://github.com/keepassx/keepassx/archive/2.0-alpha5.tar.gz";
     sha256 = "1vxj306zhrr38mvsy3vpjlg6d0xwlcvsi3l69nhhwzkccsc4smfm";


### PR DESCRIPTION
Since the 2.0 version lacks a lot of important functionality a lot of
users want to go with the 0.4.3 version.  The two versions are
sufficiently different that having to tell nix not to update KeePassX to
version 2.0 on every machine quickly becomes awkward.
