### PR TITLE
cloog: patch to use ppl version 1.0

### DIFF
--- a/pkgs/development/libraries/cloog-ppl/default.nix
+++ b/pkgs/development/libraries/cloog-ppl/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, ppl }:
+{ fetchurl, stdenv, ppl, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
   name = "cloog-ppl-0.15.11";
@@ -10,7 +10,20 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ ppl ];
 
+  buildInputs = [ automake autoconf libtool ];
+
+  patches = [ ./fix-ppl-version.patch ];
+
   configureFlags = "--with-ppl=${ppl}";
+
+  preConfigure = ''
+    touch NEWS ChangeLog AUTHORS
+    ${libtool}/bin/libtoolize -c --force
+    ${automake}/bin/aclocal
+    ${automake}/bin/automake --add-missing
+    ${automake}/bin/automake -a -c --foreign
+    ${autoconf}/bin/autoreconf
+  '';
 
   crossAttrs = {
     configureFlags = "--with-ppl=${ppl.crossDrv}";

--- a/pkgs/development/libraries/cloog-ppl/fix-ppl-version.patch
+++ b/pkgs/development/libraries/cloog-ppl/fix-ppl-version.patch
@@ -1,0 +1,16 @@
+diff -rupN src/configure.in cloog-ppl-0.15.11/configure.in
+--- src/configure.in	2014-04-13 13:33:43.349392305 +0200
++++ cloog-ppl-0.15.11/configure.in	2014-04-13 13:34:12.695379888 +0200
+@@ -337,11 +337,7 @@ if test "x$with_ppl" != "x" -a "x$with_p
+ 		        [AC_MSG_ERROR(Can't find PPL headers.)])
+ 
+ 	AC_MSG_CHECKING([for version 0.10 (or later revision) of PPL])
+-	AC_TRY_COMPILE([#include "ppl_c.h"],[
+-	#if PPL_VERSION_MAJOR != 0 || PPL_VERSION_MINOR < 10
+-	choke me
+-	#endif
+-	], [AC_MSG_RESULT([yes])], [AC_MSG_ERROR(Can't find correct version of PPL.) ])
++	AC_MSG_RESULT([yes])
+ 
+ 	LIBS="$LIBS -lppl_c -lppl -lgmpxx"
+ 	AC_DEFINE([CLOOG_PPL_BACKEND], 1, [Use the PPL backend])


### PR DESCRIPTION
I've run the test suite, all tests pass. I haven't tested the program manually, but looking at the
changelog of ppl, there should be no changes in semantics.
