### PR TITLE
mesa: fix dlopen'ing libGL*

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation {
   '' + /* add libGL* links from /run/opengl-driver */ ''
     (
       cd "$drivers/lib"
-      cp -s "$out"/lib/*.so .
+      cp -s "$out"/lib/*.so* .
     )
   '';
   #ToDo: @vcunat isn't sure if drirc will be found when in $out/etc/, but it doesn't seem important ATM


### PR DESCRIPTION
The libGL\* libraries with full soname were missing from the drivers output,
which is what gets linked in /run/opengl-driver. This broke SDL, for example.
