### PR TITLE
haskellPackages: New expressions for ipprint, Extra, bzlib, Unixutils

### DIFF
--- a/pkgs/development/libraries/haskell/Extra/default.nix
+++ b/pkgs/development/libraries/haskell/Extra/default.nix
@@ -1,0 +1,19 @@
+{ cabal, bzlib, filepath, HUnit, mtl, network, pureMD5, QuickCheck
+, random, regexCompat, time, Unixutils, zlib
+}:
+
+cabal.mkDerivation (self: {
+  pname = "Extra";
+  version = "1.46.1";
+  sha256 = "0dgj72s60mhc36x7hpfdcdvxydq5d5aj006gxma9zz3hqzy5nnz9";
+  buildDepends = [
+    bzlib filepath HUnit mtl network pureMD5 QuickCheck random
+    regexCompat time Unixutils zlib
+  ];
+  meta = {
+    homepage = "http://src.seereason.com/haskell-extra";
+    description = "A grab bag of modules";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/Unixutils/default.nix
+++ b/pkgs/development/libraries/haskell/Unixutils/default.nix
@@ -1,0 +1,15 @@
+{ cabal, glibc, filepath, pureMD5, regexTdfa, zlib }:
+
+cabal.mkDerivation (self: {
+  pname = "Unixutils";
+  version = "1.52";
+  sha256 = "1gp04mc6irycwazykl9kpyhkkryn3hbnpn08ih6cjbsm3p8yi8b4";
+  buildDepends = [ filepath pureMD5 regexTdfa zlib ];
+  extraLibraries = [ glibc ];
+  meta = {
+    homepage = "http://src.seereason.com/haskell-unixutils";
+    description = "A crude interface between Haskell and Unix-like operating systems";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/bzlib/default.nix
+++ b/pkgs/development/libraries/haskell/bzlib/default.nix
@@ -1,0 +1,13 @@
+{ cabal, bzip2 }:
+
+cabal.mkDerivation (self: {
+  pname = "bzlib";
+  version = "0.5.0.4";
+  sha256 = "1vf37y7wknrihf7hipd6lihkmn7sszbgfb325my52yzbjs3baccd";
+  extraLibraries = [ bzip2 ];
+  meta = {
+    description = "Compression and decompression in the bzip2 format";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/ipprint/default.nix
+++ b/pkgs/development/libraries/haskell/ipprint/default.nix
@@ -1,0 +1,13 @@
+{ cabal, Extra, haskellSrc }:
+
+cabal.mkDerivation (self: {
+  pname = "ipprint";
+  version = "0.5";
+  sha256 = "0h75k21blbnzvp5l20qsima557dx6zfrww79y7qsqf04pbd81j7s";
+  buildDepends = [ Extra haskellSrc ];
+  meta = {
+    description = "Tiny helper for pretty-printing values in ghci console";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2607,6 +2607,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   unixTime = callPackage ../development/libraries/haskell/unix-time {};
 
+  Unixutils = callPackage ../development/libraries/haskell/Unixutils {};
+
   unlambda = callPackage ../development/libraries/haskell/unlambda {};
 
   unorderedContainers_0_2_3_0 = callPackage ../development/libraries/haskell/unordered-containers/0.2.3.0.nix {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1087,6 +1087,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   executablePath = callPackage ../development/libraries/haskell/executable-path {};
 
+  Extra = callPackage ../development/libraries/haskell/Extra {};
+
   fay = callPackage ../development/libraries/haskell/fay {};
 
   fayBase = callPackage ../development/libraries/haskell/fay-base {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -705,6 +705,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   bytestringProgress = callPackage ../development/libraries/haskell/bytestring-progress {};
 
+  bzlib = callPackage ../development/libraries/haskell/bzlib {};
+
   c2hs = callPackage ../development/libraries/haskell/c2hs {};
 
   c2hsc = callPackage ../development/libraries/haskell/c2hsc {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1566,6 +1566,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   ioStreams = callPackage ../development/libraries/haskell/io-streams {};
 
+  ipprint = callPackage ../development/libraries/haskell/ipprint {};
+
   iproute = callPackage ../development/libraries/haskell/iproute {};
 
   irc = callPackage ../development/libraries/haskell/irc {};


### PR DESCRIPTION
These are just the output of `cabal2nix` except that:
1. I had to change the auto-detected dependency in `haskellPackages.bzlib` from `bz2` (in [`bzlib.cabal`](http://hackage.haskell.org/package/bzlib-0.5.0.4/bzlib.cabal) since the name of the library is `libbz2.so`) to `bzip2` (the name of the Nix expression)
2. Similarly, I had to change the auto-detected dependency in `haskellPackages.Unixutils` from `crypt` (as specified in [`Unixutils.cabal`](http://hackage.haskell.org/package/Unixutils-1.52/Unixutils.cabal)) to `glibc`.  I'm not sure if this is the best way to do this — let me know if it's not.
