### PR TITLE
plan9port: modify the builder to use the INSTALL script.

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -4,46 +4,14 @@ tar xvfz $src
 
 cd plan9
 
-export PLAN9=`pwd`
-export X11=/tmp
+for p in $patches; do
+  echo "applying patch $p"
+  patch -p1 < $p
+done
 
-# Patch for the installation
-sed -i -e 's@`which echo`@echo@' lib/moveplan9.sh
+./INSTALL -b
+./INSTALL -r $out/plan9
 
-OLDPATH=$PATH
-PATH=`pwd`/bin:$PATH
-
-gcc lib/linux-isnptl.c -lpthread
-set +e 
-if ./a.out > /dev/null
-then
-  echo "SYSVERSION=2.6.x" >config
-else
-  echo "SYSVERSION=2.4.x" >config
-fi
-rm -f ./a.out
-set -e
-
-pushd src
-
-# Build mk
-../dist/buildmk 2>&1 | sed 's/^[+] //'
-
-# Build everything
-
-mk clean
-mk libs-nuke
-mk all || exit 1
-mk install || exit 1
-
-popd
-
-# Installation
-export PLAN9=$out
+export PLAN9=$out/plan9
 mkdir -p $PLAN9
-GLOBIGNORE='src:.*'
 cp -R * $PLAN9
-GLOBIGNORE=
-
-cd $PLAN9
-sh lib/moveplan9.sh `pwd`

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -2,7 +2,9 @@
 
 stdenv.mkDerivation rec {
   name = "plan9port-20140228";
-  
+
+  patches = [ ./fontsrv.patch ];
+
   builder = ./builder.sh;
 
   src = fetchurl {

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -1,4 +1,8 @@
-{stdenv, fetchurl, libX11, xproto, libXt, xextproto, libXext}:
+{stdenv, fetchurl, libX11
+, xproto ? null
+, libXt ? null
+, xextproto ? null
+, libXext ? null }:
 
 stdenv.mkDerivation rec {
   name = "plan9port-20140228";
@@ -12,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l7nsjfrrcq0l43kw0f1437jz3nyl9qw7i2vn0sbmcsv5vmsj0cr";
   };
 
-  buildInputs = [ libX11 xproto libXt xextproto libXext ];
+  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 xproto libXt xextproto libXext ];
 
   meta = {
     homepage = "http://swtch.com/plan9port/";

--- a/pkgs/tools/system/plan9port/fontsrv.patch
+++ b/pkgs/tools/system/plan9port/fontsrv.patch
@@ -1,0 +1,14 @@
+diff -r dc0640f14d07 src/cmd/mkfile
+--- a/src/cmd/mkfile	Tue Mar 25 23:23:10 2014 -0400
++++ b/src/cmd/mkfile	Mon Apr 14 22:36:05 2014 +0530
+@@ -4,8 +4,8 @@
+ 
+ <$PLAN9/src/mkmany
+ 
+-BUGGERED='CVS|faces|factotum|fontsrv|lp|ip|mailfs|upas|vncv|mnihongo|mpm|index|u9fs|secstore|smugfs|snarfer'
+-DIRS=lex `ls -l |sed -n 's/^d.* //p' |egrep -v "^($BUGGERED)$"|egrep -v '^lex$'` $FONTSRV
++BUGGERED='CVS|faces|factotum|lp|ip|mailfs|upas|vncv|mnihongo|mpm|index|u9fs|secstore|smugfs|snarfer'
++DIRS=lex `ls -l |sed -n 's/^d.* //p' |egrep -v "^($BUGGERED)$"|egrep -v '^lex$'`
+ 
+ <$PLAN9/src/mkdirs
+ 


### PR DESCRIPTION
Plan9port ships with an INSTALL script. This commit modifies the
builder to use the script instead of a custom build script. The
commit also adds a patch to build fontsrv, which is otherwise
omitted from the build.

Like the way upstream plan9port installs itself, this package also
installs under ~/.nix-profile/plan9 and one has to add the following
to the shell startup scripts to use it.
PLAN9=~/.nix-profile/plan9 export PLAN9
PATH=$PATH:$PLAN9/bin export PATH
