### PR TITLE
Change aspell configure to use $out/lib/aspell

### DIFF
--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -12,6 +12,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  preConfigure = ''
+    configureFlagsArray=(
+      --enable-pkglibdir=$out/lib/aspell
+      --enable-pkgdatadir=$out/lib/aspell
+    );
+  '';
+
   # Note: Users should define the `ASPELL_CONF' environment variable to
   # `dict-dir $HOME/.nix-profile/lib/aspell/' so that they can access
   # dictionaries installed in their profile.


### PR DESCRIPTION
This change is need so that the following comment will work:

```
  # Note: Users should define the `ASPELL_CONF' environment variable to
  # `dict-dir $HOME/.nix-profile/lib/aspell/' so that they can access
  # dictionaries installed in their profile.
```

And now I have Nix's `aspell` driving spelling in my Emacs!
