### PR TITLE
nixos: Fix sysctl option merging

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -6,8 +6,12 @@ let
 
   sysctlOption = mkOptionType {
     name = "sysctl option value";
-    check = x: isBool x || isString x || isInt x || isNull x;
-    merge = args: defs: (last defs).value; # FIXME: hacky way to allow overriding in configuration.nix.
+    check = val:
+      let
+        checkType = x: isBool x || isString x || isInt x || isNull x;
+      in
+        checkType val || (val._type or "" == "override" && checkType val.content);
+    merge = loc: defs: mergeOneOption loc (filterOverrides defs);
   };
 
 in


### PR DESCRIPTION
Using pkgs.lib.mkOverride in a sysctl option would throw a bogus error.

Also, if you defined a sysctl multiple times in the same configuration, only
one of the values would be picked up, while the others were silently 
discarded.

This patch should fix both issues. If you define a sysctl multiple times at
your highest defined priority level, you will get a proper error with detailed
location information.
