### PR TITLE
bitcoin: Update from 0.8.6 -> 0.9.1

### DIFF
--- a/pkgs/tools/graphics/qrencode/00_configure_fix
+++ b/pkgs/tools/graphics/qrencode/00_configure_fix
@@ -1,0 +1,16 @@
+Description: Fix configure.ac to enable HAVE_LIBPTHREAD (shell) variable.
+Author: NIIBE Yutaka <gniibe@fsij.org>
+
+Index: qrencode-3.2.0/configure.ac
+===================================================================
+--- qrencode-3.2.0.orig/configure.ac	2011-10-23 20:21:17.000000000 +0000
++++ qrencode-3.2.0/configure.ac	2012-03-30 02:39:37.000000000 +0000
+@@ -41,7 +41,7 @@
+ if test x$enable_thread_safety = xyes; then
+ 	AC_CHECK_LIB([pthread], [pthread_mutex_init])
+ fi
+-AM_CONDITIONAL([HAVE_LIBPTHREAD], [test "x$HAVE_LIBPTHREAD" = "xyes" ])
++AM_CONDITIONAL([HAVE_LIBPTHREAD], [test "x$ac_cv_lib_pthread_pthread_mutex_init" = "xyes" ])
+ 
+ 
+ dnl --with-tools

--- a/pkgs/tools/graphics/qrencode/01_pkg_config_fix
+++ b/pkgs/tools/graphics/qrencode/01_pkg_config_fix
@@ -1,0 +1,14 @@
+Description: Fix generated libqrencode.pc include correct LIBS (-lpthread).
+Author: NIIBE Yutaka <gniibe@fsij.org>
+
+Index: qrencode-3.2.0/libqrencode.pc.in
+===================================================================
+--- qrencode-3.2.0.orig/libqrencode.pc.in	2011-10-23 20:21:17.000000000 +0000
++++ qrencode-3.2.0/libqrencode.pc.in	2012-03-30 02:54:06.130468748 +0000
+@@ -6,5 +6,5 @@
+ Name: libqrencode
+ Description: A QR Code encoding library
+ Version: @VERSION@
+-Libs: -L${libdir} -lqrencode @LIBPTHREAD@
++Libs: -L${libdir} -lqrencode @LIBS@
+ Cflags: -I${includedir}

--- a/pkgs/tools/graphics/qrencode/03_libpthread_handling_fix
+++ b/pkgs/tools/graphics/qrencode/03_libpthread_handling_fix
@@ -1,0 +1,41 @@
+Description: Fix handling of libpthread
+Author: NIIBE Yutaka <gniibe@fsij.org>
+
+Index: qrencode-3.3.0/configure.ac
+===================================================================
+--- qrencode-3.3.0.orig/configure.ac	2012-04-02 02:36:10.318718543 +0000
++++ qrencode-3.3.0/configure.ac	2012-04-02 02:37:07.822718976 +0000
+@@ -42,7 +42,7 @@
+  [], [enable_thread_safety=yes])
+ 
+ if test x$enable_thread_safety = xyes; then
+-	AC_CHECK_LIB([pthread], [pthread_mutex_init])
++	AC_CHECK_LIB([pthread], [pthread_mutex_init], [AC_SUBST([LIBPTHREAD], [-lpthread])])
+ fi
+ AM_CONDITIONAL([HAVE_LIBPTHREAD], [test "x$ac_cv_lib_pthread_pthread_mutex_init" = "xyes" ])
+ 
+Index: qrencode-3.3.0/libqrencode.pc.in
+===================================================================
+--- qrencode-3.3.0.orig/libqrencode.pc.in	2012-04-02 02:36:10.318718543 +0000
++++ qrencode-3.3.0/libqrencode.pc.in	2012-04-02 02:37:07.822718976 +0000
+@@ -6,5 +6,6 @@
+ Name: libqrencode
+ Description: A QR Code encoding library
+ Version: @VERSION@
+-Libs: -L${libdir} -lqrencode @LIBS@
++Libs: -L${libdir} -lqrencode
++Libs.private: @LIBPTHREAD@
+ Cflags: -I${includedir}
+Index: qrencode-3.3.0/tests/Makefile.am
+===================================================================
+--- qrencode-3.3.0.orig/tests/Makefile.am	2012-01-23 06:18:00.000000000 +0000
++++ qrencode-3.3.0/tests/Makefile.am	2012-04-02 02:37:07.822718976 +0000
+@@ -55,7 +55,7 @@
+ prof_qrencode_LDADD = ../libqrencode.la
+ 
+ pthread_qrencode_SOURCES = pthread_qrencode.c
+-pthread_qrencode_LDADD = ../libqrencode.la
++pthread_qrencode_LDADD = ../libqrencode.la -lpthread
+ 
+ create_frame_pattern_SOURCES = create_frame_pattern.c
+ create_frame_pattern_CFLAGS = $(png_CFLAGS)

--- a/pkgs/tools/graphics/qrencode/default.nix
+++ b/pkgs/tools/graphics/qrencode/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpng ];
   nativeBuildInputs = [ pkgconfig ];
 
+  patches = [ ./00_configure_fix ./01_pkg_config_fix ./03_libpthread_handling_fix ];
+
   meta = {
     homepage = http://fukuchi.org/works/qrencode/;
     description = "QR code encoder";


### PR DESCRIPTION
Changes:
- The download URL seems to have changed
- The source tarball is now actually inside the downloaded tarball
- The build system changed from qmake to autotools
- Added new dependencies
- Bitcoin now requires db48 during ./configure in order to keep wallet compatibility between systems. nixpkgs was using db53 before, so **I'm not sure what effect this will have on bitcoin wallets of existing Nix systems... they may even become unreadable**
- Fixed boost detection in ./configure by providing direct path to derivation
- I also had to fix a bug in qrencode which caused a build failure in bitcoin, see bitcoin/bitcoin#3307 for details
- Enabled tests
- Worked around one of the tests needing to write to $HOME (which fails in chroot builds)
- Enabled parallel building
