### PR TITLE
haskell-alsa-mixer 0.2.0.1 -> 0.2.0.2

### DIFF
--- a/pkgs/development/libraries/haskell/alsa-mixer/default.nix
+++ b/pkgs/development/libraries/haskell/alsa-mixer/default.nix
@@ -2,8 +2,8 @@
 
 cabal.mkDerivation (self: {
   pname = "alsa-mixer";
-  version = "0.2.0.1";
-  sha256 = "1306kw4w85d3pkdqjw8cwx77a2mbhw2hlmxcjczym1nsyp4rhyhr";
+  version = "0.2.0.2";
+  sha256 = "11sc2n879a8rb9yz54cb8vg8rplgapbymzy785p7n7638xx877hk";
   buildDepends = [ alsaCore ];
   buildTools = [ c2hs ];
   extraLibraries = [ alsaLib ];

--- a/pkgs/development/libraries/haskell/alsa-mixer/default.nix
+++ b/pkgs/development/libraries/haskell/alsa-mixer/default.nix
@@ -12,5 +12,6 @@ cabal.mkDerivation (self: {
     description = "Bindings to the ALSA simple mixer API";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.stdenv.lib.platforms.linux;
+    maintainers = with self.stdenv.lib.maintainers; [ ttuegel ];
   };
 })


### PR DESCRIPTION
This bumps the version of alsa-mixer to the latest on Hackage, which is necessary for GHC 7.8 compatibility. I also assigned myself as maintainer because I am the upstream developer, so I'll be very responsive to version bumps and build failures!
