### PR TITLE
nixos/graphite-service: fix startup

### DIFF
--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -194,7 +194,8 @@ in {
         cfg.carbon.rewriteRules
       ];
       preStart = ''
-        mkdir -m 0700 -p ${cfg.dataDir}/whisper
+        mkdir -p ${cfg.dataDir}/whisper
+        chmod 0700 ${cfg.dataDir}/whisper
         chown -R graphite:graphite ${cfg.dataDir}
       '';
     };
@@ -254,7 +255,8 @@ in {
       };
       preStart = ''
         if ! test -e ${dataDir}/db-created; then
-          mkdir -m 0700 -p ${dataDir}/{whisper/,log/webapp/}
+          mkdir -p ${dataDir}/{whisper/,log/webapp/}
+          chmod 0700 ${dataDir}/{whisper/,log/webapp/}
 
           # populate database
           ${pkgs.python27Packages.graphite_web}/bin/manage-graphite.py syncdb --noinput

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -184,6 +184,7 @@ in {
         ExecStart = "${pkgs.twisted}/bin/twistd ${carbonOpts "carbon-cache"}";
         User = "graphite";
         Group = "graphite";
+        PermissionsStartOnly = true;
       };
       restartTriggers = [
         pkgs.pythonPackages.carbon
@@ -194,7 +195,7 @@ in {
       ];
       preStart = ''
         mkdir -m 0700 -p ${cfg.dataDir}/whisper
-        if [ "$(id -u)" = 0 ]; then chown -R graphite:graphite ${cfg.dataDir}; fi
+        chown -R graphite:graphite ${cfg.dataDir}
       '';
     };
 
@@ -235,6 +236,7 @@ in {
       description = "Graphite Web Interface";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-interfaces.target" ];
+      path = [ pkgs.perl ];
       environment = {
         PYTHONPATH = "${pkgs.python27Packages.graphite_web}/lib/python2.7/site-packages";
         DJANGO_SETTINGS_MODULE = "graphite.settings";
@@ -248,11 +250,11 @@ in {
           --call django.core.handlers.wsgi:WSGIHandler'';
         User = "graphite";
         Group = "graphite";
+        PermissionsStartOnly = true;
       };
       preStart = ''
         if ! test -e ${dataDir}/db-created; then
           mkdir -m 0700 -p ${dataDir}/{whisper/,log/webapp/}
-          if [ "$(id -u)" = 0 ]; then chown -R graphite:graphite ${cfg.dataDir}; fi
 
           # populate database
           ${pkgs.python27Packages.graphite_web}/bin/manage-graphite.py syncdb --noinput
@@ -261,6 +263,8 @@ in {
           ${pkgs.python27Packages.graphite_web}/bin/build-index.sh
 
           touch ${dataDir}/db-created
+
+          chown -R graphite:graphite ${cfg.dataDir}
         fi
       '';
       restartTriggers = [


### PR DESCRIPTION
I couldn't get graphite to start. This fixes it.

CC @offlinehacker.

I have another issue with graphite. It has little to do with this pull requrest, except that graphite may need some more fixes :-)

Disclaimer: I'm a graphite newbie.

When I access http://localhost:8080 I get a white page with a black bar on top with the text "Graphite" on the left and "login, documentation [...]" on the right. I don't know whether that's correct or not (I haven't really configured/customized graphite yet), but the log seems to indicate issues:

```
waitress-serve[25346]: Could not import graphite.local_settings, using defaults!
waitress-serve[25346]: /nix/store/sdfg78hg15qizyh8ws5z55zamxhrsjns-python2.7-graphite-web-0.9.12/lib/python2.7/site-packages/graphite/settings.py:231: UserWarning: SECRET_KEY is set to an unsafe default. This should be se... for better security
waitress-serve[25346]: warn('SECRET_KEY is set to an unsafe default. This should be set in local_settings.py for better security')
waitress-serve[25346]: ERROR:django.request:Internal Server Error: /content/img/carbon-fiber.png
waitress-serve[25346]: Traceback (most recent call last):
waitress-serve[25346]: File "/nix/store/2l86g94bvgd42p0w657gxzz212rj9kqs-python2.7-Django-1.3.7/lib/python2.7/site-packages/django/core/handlers/base.py", line 150, in get_response
waitress-serve[25346]: response = callback(request, **param_dict)
waitress-serve[25346]: File "/nix/store/2l86g94bvgd42p0w657gxzz212rj9kqs-python2.7-Django-1.3.7/lib/python2.7/site-packages/django/utils/decorators.py", line 93, in _wrapped_view
waitress-serve[25346]: response = view_func(request, *args, **kwargs)
waitress-serve[25346]: File "/nix/store/2l86g94bvgd42p0w657gxzz212rj9kqs-python2.7-Django-1.3.7/lib/python2.7/site-packages/django/views/defaults.py", line 18, in page_not_found
waitress-serve[25346]: t = loader.get_template(template_name) # You need to create a 404.html template.
waitress-serve[25346]: File "/nix/store/2l86g94bvgd42p0w657gxzz212rj9kqs-python2.7-Django-1.3.7/lib/python2.7/site-packages/django/template/loader.py", line 157, in get_template
waitress-serve[25346]: template, origin = find_template(template_name)
waitress-serve[25346]: File "/nix/store/2l86g94bvgd42p0w657gxzz212rj9kqs-python2.7-Django-1.3.7/lib/python2.7/site-packages/django/template/loader.py", line 138, in find_template
waitress-serve[25346]: raise TemplateDoesNotExist(name)
waitress-serve[25346]: TemplateDoesNotExist: 404.html
waitress-serve[25346]: ERROR:django.request:Internal Server Error: /content/js/ext/adapter/ext/ext-base.js
waitress-serve[25346]: Traceback (most recent call last):
```

My graphite/statsd config is

```
    statsd = {
      enable = true;
      extraConfig = ''
      '';
    };

    graphite = {
      web.enable = true;
      web.port = 8080;
      carbon.enableCache = true;
      carbon.storageSchemas = ''
        [server_load]
        priority = 100
        pattern = ^servers\.
        retentions = 60:43200,900:350400
      '';
    };
```
