### PR TITLE
gnome-control-center: find gnome-shell search providers

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -68,6 +68,9 @@ in {
           # Don't let epiphany depend upon gnome-shell
           export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${pkgs.gnome3.gnome_shell}/share/gsettings-schemas/${pkgs.gnome3.gnome_shell.name}
 
+          # Let gnome-control-center find gnome-shell search providers
+          export GNOME_SEARCH_PROVIDERS_DIR=${config.system.path}/share/gnome-shell/search-providers/
+
           # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
           ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update
 

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation rec {
     rm $out/share/icons/hicolor/icon-theme.cache
   '';
 
+  patches = [ ./search_providers_dir.patch ];
+
   meta = with stdenv.lib; {
     description = "Single sign-on framework for GNOME";
     maintainers = with maintainers; [ lethalman ];

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/search_providers_dir.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/search_providers_dir.patch
@@ -1,0 +1,17 @@
+diff --git a/panels/search/cc-search-panel.c b/panels/search/cc-search-panel.c
+index d08e230..3bff4ad 100644
+--- a/panels/search/cc-search-panel.c
++++ b/panels/search/cc-search-panel.c
+@@ -574,7 +574,11 @@ populate_search_providers (CcSearchPanel *self)
+ {
+   GFile *providers_location;
+ 
+-  providers_location = g_file_new_for_path (DATADIR "/gnome-shell/search-providers");
++  const gchar* search_providers_dir = g_getenv ("GNOME_SEARCH_PROVIDERS_DIR");
++  if (search_providers_dir == NULL) {
++    search_providers_dir = DATADIR "/gnome-shell/search-providers";
++  }
++  providers_location = g_file_new_for_path (search_providers_dir);
+   g_file_enumerate_children_async (providers_location,
+                                    "standard::type,standard::name,standard::content-type",
+                                    G_FILE_QUERY_INFO_NONE,


### PR DESCRIPTION
This needed a patch to gnome-control-center, because it hardcoded its own datadir. The patch makes it use an env variable, or the datadir as fallback.
