### PR TITLE
nixos-rebuild: changed $SHELL to /bin/sh

### DIFF
--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -100,7 +100,7 @@ fi
 if [ -z "$_NIXOS_REBUILD_REEXEC" -a -n "$canRun" ]; then
     if p=$(nix-instantiate --find-file nixpkgs/nixos/modules/installer/tools/nixos-rebuild.sh "${extraBuildFlags[@]}"); then
         export _NIXOS_REBUILD_REEXEC=1
-        exec $SHELL -e $p "${origArgs[@]}"
+        exec /bin/sh -e $p "${origArgs[@]}"
         exit 1
     fi
 fi
@@ -160,7 +160,7 @@ fi
 # nixos-version shows something useful).
 if [ -n "$canRun" ]; then
     if nixpkgs=$(nix-instantiate --find-file nixpkgs "${extraBuildFlags[@]}"); then
-        suffix=$($SHELL $nixpkgs/nixos/modules/installer/tools/get-version-suffix "${extraBuildFlags[@]}" || true)
+        suffix=$(/bin/sh $nixpkgs/nixos/modules/installer/tools/get-version-suffix "${extraBuildFlags[@]}" || true)
         if [ -n "$suffix" ]; then
             echo -n "$suffix" > "$nixpkgs/.version-suffix" || true
         fi


### PR DESCRIPTION
$SHELL is not always bash, /bin/sh always is. This is a problem when running nixos-rebuild in fish.

$SHELL appears many times in nixpkgs. If I'm not mistaken, each occurence should be replaced by /bin/sh. Should I also do this ?
