### PR TITLE
FreeCAD: Fix build.

### DIFF
--- a/pkgs/applications/graphics/freecad/cmake.patch
+++ b/pkgs/applications/graphics/freecad/cmake.patch
@@ -1,7 +1,27 @@
-diff -ru freecad-0.13.1830.orig/CMakeLists.txt freecad-0.13.1830/CMakeLists.txt
---- freecad-0.13.1830.orig/CMakeLists.txt       2013-02-02 18:09:17.000000000 +0100
-+++ freecad-0.13.1830/CMakeLists.txt    2014-02-15 10:16:00.939725500 +0100
-@@ -321,7 +321,7 @@
+diff -urN freecad-0.13.1830.old/cMake/FreeCadMacros.cmake freecad-0.13.1830/cMake/FreeCadMacros.cmake
+--- freecad-0.13.1830.old/cMake/FreeCadMacros.cmake	2013-02-02 18:09:17.000000000 +0100
++++ freecad-0.13.1830/cMake/FreeCadMacros.cmake	2014-04-20 10:52:17.293599913 +0200
+@@ -201,7 +201,7 @@
+ #endmacro(fc_add_resources)
+ 
+ MACRO (fc_add_resources outfiles )
+-  QT4_EXTRACT_OPTIONS(rcc_files rcc_options ${ARGN})
++  QT4_EXTRACT_OPTIONS(rcc_files rcc_options rcc_target ${ARGN})
+ 
+   FOREACH (it ${rcc_files})
+     GET_FILENAME_COMPONENT(outfilename ${it} NAME_WE)
+diff -urN freecad-0.13.1830.old/CMakeLists.txt freecad-0.13.1830/CMakeLists.txt
+--- freecad-0.13.1830.old/CMakeLists.txt	2013-02-02 18:09:17.000000000 +0100
++++ freecad-0.13.1830/CMakeLists.txt	2014-04-20 10:28:41.782536753 +0200
+@@ -314,14 +314,14 @@
+     macro(fc_wrap_cpp outfiles )
+         # get include dirs
+         QT4_GET_MOC_FLAGS(moc_flags)
+-        QT4_EXTRACT_OPTIONS(moc_files moc_options ${ARGN})
++        QT4_EXTRACT_OPTIONS(moc_files moc_options moc_target ${ARGN})
+         # fixes bug 0000585: bug with boost 1.48
+         SET(moc_options ${moc_options} -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
+ 
          foreach(it ${moc_files})
              get_filename_component(it ${it} ABSOLUTE)
              QT4_MAKE_OUTPUT_FILE(${it} moc_ cpp outfile)


### PR DESCRIPTION
Some other Qt macros have also gained an additional argument...
FreeCAD now builds and runs.
