### PR TITLE
openscad: fix segmentation fault while rendering

### DIFF
--- a/pkgs/development/libraries/CGAL/default.nix
+++ b/pkgs/development/libraries/CGAL/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake, boost, gmp, mpfr }:
 
 stdenv.mkDerivation rec {
-  version = "4.3";
+  version = "4.4";
 
   name = "cgal-${version}";
 
   src = fetchurl {
     url = "https://gforge.inria.fr/frs/download.php/32995/CGAL-${version}.tar.xz";
-    sha256 = "015vw57dmy43bf63mg3916cgcsbv9dahwv24bnmiajyanj2mhiyc";
+    md5 = "c0af5e3a56300b0c92ebd3a1f0df9149";
   };
 
   buildInputs = [ cmake boost gmp mpfr ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8828,7 +8828,9 @@ let
 
   openjump = callPackage ../applications/misc/openjump { };
 
-  openscad = callPackage ../applications/graphics/openscad {};
+  openscad = callPackage ../applications/graphics/openscad {
+    stdenv = overrideGCC stdenv gcc46;
+  };
 
   opera = callPackage ../applications/networking/browsers/opera {
     inherit (pkgs.kde4) kdelibs;


### PR DESCRIPTION
Openscad results in segmentation fault while rendering if built with gcc-4.8.2, build with gcc-4.6 instead.

This pull request also updates cgal to version 4.4
