### PR TITLE
Add patch for GCC bug 58800.

### DIFF
--- a/pkgs/development/compilers/gcc/4.8/bug58800.patch
+++ b/pkgs/development/compilers/gcc/4.8/bug58800.patch
@@ -1,0 +1,95 @@
+Index: gcc-4_8-branch/libstdc++-v3/include/bits/stl_algo.h
+===================================================================
+--- gcc-4_8-branch/libstdc++-v3/include/bits/stl_algo.h	(revision 203872)
++++ gcc-4_8-branch/libstdc++-v3/include/bits/stl_algo.h	(revision 203873)
+@@ -2279,7 +2279,7 @@
+ 				_RandomAccessIterator __last)
+     {
+       _RandomAccessIterator __mid = __first + (__last - __first) / 2;
+-      std::__move_median_to_first(__first, __first + 1, __mid, (__last - 2));
++      std::__move_median_to_first(__first, __first + 1, __mid, __last - 1);
+       return std::__unguarded_partition(__first + 1, __last, *__first);
+     }
+ 
+@@ -2291,7 +2291,7 @@
+ 				_RandomAccessIterator __last, _Compare __comp)
+     {
+       _RandomAccessIterator __mid = __first + (__last - __first) / 2;
+-      std::__move_median_to_first(__first, __first + 1, __mid, (__last - 2),
++      std::__move_median_to_first(__first, __first + 1, __mid, __last - 1,
+ 				  __comp);
+       return std::__unguarded_partition(__first + 1, __last, *__first, __comp);
+     }
+Index: gcc-4_8-branch/libstdc++-v3/ChangeLog
+===================================================================
+--- gcc-4_8-branch/libstdc++-v3/ChangeLog	(revision 203872)
++++ gcc-4_8-branch/libstdc++-v3/ChangeLog	(revision 203873)
+@@ -1,3 +1,11 @@
++2013-10-20  Chris Jefferson  <chris@bubblescope.net>
++	    Paolo Carlini  <paolo.carlini@oracle.com>
++
++	PR libstdc++/58800
++	* include/bits/stl_algo.h (__unguarded_partition_pivot): Change
++	__last - 2 to __last - 1.
++	* testsuite/25_algorithms/nth_element/58800.cc: New
++
+ 2013-10-16  François Dumont  <fdumont@gcc.gnu.org>
+ 
+ 	PR libstdc++/58191
+Index: gcc-4_8-branch/libstdc++-v3/testsuite/25_algorithms/nth_element/58800.cc
+===================================================================
+--- gcc-4_8-branch/libstdc++-v3/testsuite/25_algorithms/nth_element/58800.cc	(revision 0)
++++ gcc-4_8-branch/libstdc++-v3/testsuite/25_algorithms/nth_element/58800.cc	(revision 203873)
+@@ -0,0 +1,52 @@
++// Copyright (C) 2013 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// You should have received a copy of the GNU General Public License along
++// with this library; see the file COPYING3.  If not see
++// <http://www.gnu.org/licenses/>.
++
++// 25.3.2 [lib.alg.nth.element]
++
++// { dg-options "-std=gnu++11" }
++
++#include <algorithm>
++#include <testsuite_hooks.h>
++#include <testsuite_iterators.h>
++
++using __gnu_test::test_container;
++using __gnu_test::random_access_iterator_wrapper;
++
++typedef test_container<int, random_access_iterator_wrapper> Container;
++
++void test01()
++{
++  std::vector<int> v = {
++    207089,
++    202585,
++    180067,
++    157549,
++    211592,
++    216096,
++    207089
++  };
++
++  Container con(v.data(), v.data() + 7);
++
++  std::nth_element(con.begin(), con.begin() + 3, con.end());
++}
++
++int main()
++{
++  test01();
++  return 0;
++}

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -62,7 +62,7 @@ let version = "4.8.2";
   */
     enableParallelBuilding = !profiledCompiler;
 
-    patches = []
+    patches = [ ./bug58800.patch ]
       ++ optional enableParallelBuilding ./parallel-bconfig.patch
       ++ optional (cross != null) ./libstdc++-target.patch
       # ++ optional noSysDirs ./no-sys-dirs.patch


### PR DESCRIPTION
http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58800

I have not been able to test this due to nix wanting to rebuild lots of things before building gcc.
Patch was created with: `svn diff -r 203872:203873 http://gcc.gnu.org/svn/gcc/branches`

This should fix a crash in OpenSCAD: https://github.com/openscad/openscad/issues/514
