### PR TITLE
gdk-pixbuf: check for writable $out/.., closes #2115

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
+++ b/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
@@ -1,19 +1,25 @@
-make_gtk_applications_find_pixbuf_loaders() {
+findGdkPixbufLoaders() {
 
-    # set pixbuf loaders.cache for this package
-	mkdir -p "$out/lib/$name/gdk-pixbuf"
-	
-	if [ -f "$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" ]; then
-		cat "$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" >> "$out/lib/$name/gdk-pixbuf/loaders.cache"
-	fi
+	if [ -z "$IN_NIX_SHELL" ]; then
 
-	if [ -f "$1/lib/gdk-pixbuf/loaders.cache" ]; then
-		cat "$1/lib/gdk-pixbuf/loaders.cache" >> "$out/lib/$name/gdk-pixbuf/loaders.cache"
-	fi
+		# set pixbuf loaders.cache for this package
+
+		local loadersDir="$out/lib/gdk-pixbuf-loaders-2.0/$name"
+		mkdir -p "$loadersDir"
+		
+		if [ -f "$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" ]; then
+			cat "$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" >> "$loadersDir/loaders.cache"
+		fi
 	
-	# note, this is not a search path
-	export GDK_PIXBUF_MODULE_FILE=$(readlink -e "$out/lib/$name/gdk-pixbuf/loaders.cache")
+		if [ -f "$1/lib/gdk-pixbuf/loaders.cache" ]; then
+			cat "$1/lib/gdk-pixbuf/loaders.cache" >> "$loadersDir/loaders.cache"
+		fi
+		
+		# note, this is not a search path
+		export GDK_PIXBUF_MODULE_FILE=$(readlink -e "$loadersDir/loaders.cache")
+
+	fi
 
 }
 
-envHooks+=(make_gtk_applications_find_pixbuf_loaders)
+envHooks+=(findGdkPixbufLoaders)


### PR DESCRIPTION
Note I've changed the loaders.cache path in order to not clutter /lib. I've only tested this with baobab. It runs with icons, the loaders.cache is created correctly and I've managed to start a nix-shell as user.
