### PR TITLE
glibc_multi: fix ldd on x86_64

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4445,6 +4445,15 @@ let
         ln -s $glibc32/lib $out/lib/32
         ln -s lib $out/lib64
 
+        # fixing ldd RLTLIST
+        rm $out/bin
+        cp -rs $glibc64/bin $out
+        chmod u+w $out/bin
+        rm $out/bin/ldd
+        sed -e "s|^RTLDLIST=.*$|RTLDLIST=\"$out/lib/ld-2.19.so $out/lib/32/ld-linux.so.2\"|g" \
+            $glibc64/bin/ldd > $out/bin/ldd
+        chmod 555 $out/bin/ldd
+
         rm $out/include
         cp -rs $glibc32/include $out
         chmod -R u+w $out/include

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4445,7 +4445,7 @@ let
         ln -s $glibc32/lib $out/lib/32
         ln -s lib $out/lib64
 
-        # fixing ldd RLTLIST
+        # fixing ldd RLTDLIST
         rm $out/bin
         cp -rs $glibc64/bin $out
         chmod u+w $out/bin


### PR DESCRIPTION
This patch will fix ldd on x86_64 multi arch systems.

The problem:
ldd will check a given binary against every rtld in a list via $rtld --verify.
Usually this list contains both a path of the 32bit and the 64bit linker.

The problem on NixOS is that these libraries don't correspondent in the same directory since they belong to two different packages--but ldd still thinks so.

That causes that ldd from glibc_multi will only work on 64bit binaries and will exit with "not a dynamic linked library" otherwise.

This fix simply corrects the RTLDLISD variable used in ldd.
