### PR TITLE
steam: fix steam on x86_64

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/default.nix
@@ -14,11 +14,36 @@ assert targetPkgs != null -> multiPkgs  != null;
 assert multiPkgs  != null -> targetPkgs != null;
 assert targetPkgs != null -> pkgs       == [];
 
+
+# HOWTO:
+# If pkgs is defined buildFHSChrootEnv will run in legacy mode. This means
+# it will build all pkgs contained in pkgs and basePkgs and then just merge
+# all of their contents together via buildEnv.
+#
+# The new way is to define both targetPkgs and multiPkgs. These two are
+# functions which get a pkgs environment supplied and should then return a list
+# of packages based this environment.
+# For example: targetPkgs = pkgs: [ pkgs.nmap ];
+#
+# All packages (most likeley programs) placed in targetPkgs will only be
+# installed once--matching the hosts architecture (64bit on x86_64 and 32bit on
+# x86). These packages will populate the chroot directory tree.
+#
+# Packages (most likeley libraries) defined in multiPkgs will be installed once
+# on x86 systems and twice on x86_64 systems.
+# On x86 they will just be merge with the packages defined in targetPkgs.
+# On x86_64 they will be added to targetPkgs and in addition their 32bit
+# versions will also be installed. The final directory should look as follows:
+# /lib will include 32bit libraries from multiPkgs
+# /lib32 will link to /lib
+# /lib64 will include 64bit libraries from multiPkgs and targetPkgs
+# /x86 will contain a complete 32bit environment composed by multiPkgs
+
 let
   is64Bit       = system == "x86_64-linux";
   # enable multi builds on x86_64 hosts if pakgs_target/multi are defined
   isMultiBuild  = is64Bit && targetPkgs != null;
-  isNormalBuild = !isMultiBuild;
+  isTargetBuild = !isMultiBuild;
 
   # list of packages (usually programs) which will only be installed for the
   # hosts architecture
@@ -75,7 +100,7 @@ let
   destroySh = ./destroy.sh.in;
 
   linkProfile = profile: ''
-    for i in ${profile}/{etc,bin,lib{,32,64},sbin,share,var}; do
+    for i in ${profile}/{etc,bin,sbin,share,var}; do
         if [ -x "$i" ]
         then
             ln -s "$i"
@@ -86,9 +111,12 @@ let
   # the target profile is the actual profile that will be used for the chroot
   setupTargetProfile = ''
     ${linkProfile staticUsrProfileTarget}
+    ${setupLibDirs}
+
     mkdir -m0755 usr
     cd usr
     ${linkProfile staticUsrProfileTarget}
+    ${setupLibDirs}
     cd ..
   '';
 
@@ -97,21 +125,30 @@ let
   # /lib, /lib32 -> links to 32bit binaries
   # /lib64       -> links to 64bit binaries
   # /usr/lib*    -> same as above
-  setupMultiProfile = if isNormalBuild then "" else ''
+  setupMultiProfile = if isTargetBuild then "" else ''
     mkdir -m0755 x86
     cd x86
     ${linkProfile staticUsrProfileMulti}
     cd ..
-
-    ${setupMultiLibDirs}
-
-    cd usr
-    ${setupMultiLibDirs}
-    cd ..
   '';
 
-  setupMultiLibDirs = ''
-    rm -f lib lib32 lib64
+  setupLibDirs = if isTargetBuild then setupLibDirs_target
+                                  else setupLibDirs_multi;
+
+  # setup library paths only for the targeted architecture
+  setupLibDirs_target = ''
+    mkdir -m0755 lib
+
+    # copy content of targetPaths
+    cp -rsf ${staticUsrProfileTarget}/lib/* lib/
+
+    # copy gcc libs
+    cp -rsf ${choosenGcc.gcc}/lib/* lib/
+
+  '';
+
+  # setup /lib, /lib32 and /lib64
+  setupLibDirs_multi = ''
     mkdir -m0755 lib
     mkdir -m0755 lib64
     ln -s lib lib32
@@ -120,12 +157,13 @@ let
     cp -rsf ${staticUsrProfileTarget}/lib/32/* lib/
 
     # copy content of multiPaths (32bit libs)
-    cp -rsf ${staticUsrProfileMulti}/lib/*  lib/
+    cp -rsf ${staticUsrProfileMulti}/lib/* lib/
 
     # copy content of targetPaths (64bit libs)
-    cp -rsf ${staticUsrProfileTarget}/lib/*   lib64/
+    cp -rsf ${staticUsrProfileTarget}/lib/* lib64/
+
     # most 64bit only libs put their stuff into /lib
-    # some pkgs (like gcc_multi) put 32bit libs into /lib 64bit libs into /lib64
+    # some pkgs (like gcc_multi) put 32bit libs into and /lib 64bit libs into /lib64
     # by overwriting these we will hopefully catch all these cases
     # in the end /lib should only contain 32bit and /lib64 only 64bit libs
     cp -rsf ${staticUsrProfileTarget}/lib64/* lib64/

--- a/pkgs/build-support/build-fhs-chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/default.nix
@@ -1,16 +1,50 @@
-{stdenv, glibc, glibcLocales, gcc, coreutils, diffutils, findutils, gnused, gnugrep, gnutar, gzip, bzip2, 
-bashInteractive, xz, shadow, gawk, less, buildEnv}:
-{name, pkgs ? [], profile ? ""}:
+{ buildEnv, nixpkgs, nixpkgs_i686, system
+, stdenv, glibc, glibc_multi, glibcLocales
+, bashInteractive, coreutils, less, shadow su
+, gawk, gcc, diffutils, findutils, gnused, gnugrep
+, gnutar, gzip, bzip2, xz
+} :
+{ name, pkgs ? [], profile ? ""
+, targetPkgs ? null, multiPkgs ? null
+, extraBuildCommands ? "", extraBuildCommandsMulti ? ""
+}:
+
+assert pkgs       != []   -> targetPkgs == null && multiPkgs == null;
+assert targetPkgs != null -> multiPkgs  != null;
+assert multiPkgs  != null -> targetPkgs != null;
+assert targetPkgs != null -> pkgs       == [];
 
 let
-  basePkgs = [
-    glibc glibcLocales gcc coreutils diffutils findutils gnused gnugrep gnutar
-    gzip bzip2 bashInteractive xz shadow gawk less
-  ];
+  is64Bit       = system == "x86_64-linux";
+  # enable multi builds on x86_64 hosts if pakgs_target/multi are defined
+  isMultiBuild  = is64Bit && targetPkgs != null;
+  isNormalBuild = !isMultiBuild;
+
+  # list of packages (usually programs) which will only be installed for the
+  # hosts architecture
+  targetPaths = if targetPkgs == null
+                  then pkgs
+                  else targetPkgs nixpkgs ++ multiPkgs nixpkgs;
+
+  # list of pckages which should be build for both x86 and x86_64 on x86_64
+  # systems
+  multiPaths = if isMultiBuild
+                  then multiPkgs nixpkgs_i686
+                  else [];
+
+  # base packages of the chroot
+  # these match the hosts architecture, glibc_multi will be choosen
+  # on multi builds
+  basePkgs =
+    [ (if isMultiBuild then glibc_multi else glibc)
+      bashInteractive coreutils less shadow su
+      gawk gcc diffutils findutils gnused gnugrep
+      gnutar gzip bzip2 xz
+    ];
 
   # Compose a global profile for the chroot environment
-  profilePkg = stdenv.mkDerivation {
-    name = "${name}-chrootenv-profile";
+  profilePkg = nixpkgs.stdenv.mkDerivation {
+    name         = "${name}-chrootenv-profile";
     buildCommand = ''
       mkdir -p $out/etc
       cat >> $out/etc/profile << "EOF"
@@ -20,67 +54,117 @@ let
     '';
   };
 
-  paths = basePkgs ++ [ profilePkg ] ++ pkgs;
-
   # Composes a /usr like directory structure
-  staticUsrProfile = buildEnv {
-    name = "system-profile";
-    inherit paths;
+  staticUsrProfileTarget = buildEnv {
+    name = "system-profile-target";
+    paths = basePkgs ++ [ profilePkg ] ++ targetPaths;
   };
-  
+
+  staticUsrProfileMulti = buildEnv {
+    name = "system-profile-multi";
+    paths = multiPaths;
+  };
+
   # References to shell scripts that set up or tear down the environment
-  initSh = ./init.sh.in;
-  mountSh = ./mount.sh.in;
-  loadSh = ./load.sh.in;
-  umountSh = ./umount.sh.in;
+  initSh    = ./init.sh.in;
+  mountSh   = ./mount.sh.in;
+  loadSh    = ./load.sh.in;
+  umountSh  = ./umount.sh.in;
   destroySh = ./destroy.sh.in;
-in
-stdenv.mkDerivation {
-  name = "${name}-chrootenv";
-  buildCommand = ''
-    mkdir -p $out/sw
-    cd $out/sw
-    
-    for i in ${staticUsrProfile}/{etc,bin,lib{,32,64},sbin,var}
-    do
+
+  linkProfile = profile: ''
+    for i in ${profile}/{etc,bin,lib{,32,64},sbin,share,var}; do
         if [ -x "$i" ]
         then
             ln -s "$i"
         fi
     done
-    
-    ln -s ${staticUsrProfile} usr
-    
+  '';
+
+  # the target profile is the actual profile that will be used for the chroot
+  setupTargetProfile = ''
+    ${linkProfile staticUsrProfileTarget}
+    mkdir -m0755 usr
+    cd usr
+    ${linkProfile staticUsrProfileTarget}
     cd ..
-    
+  '';
+
+  # this will happen on x86_64 host:
+  # /x86         -> links to the whole profile defined by multiPaths
+  # /lib, /lib32 -> links to 32bit binaries
+  # /lib64       -> links to 64bit binaries
+  # /usr/lib*    -> same as above
+  setupMultiProfile = if isNormalBuild then "" else ''
+    mkdir -m0755 x86
+    cd x86
+    ${linkProfile staticUsrProfileMulti}
+    cd ..
+
+    ${setupLibDirs}
+
+    cd usr
+    ${setupLibDirs}
+    cd ..
+  '';
+
+  setupLibDirs = ''
+    rm -f lib lib32 lib64
+    mkdir -m0755 lib
+    # copy glibc stuff
+    cp -rs  ${staticUsrProfileTarget}/lib/32/* lib/
+    # copy contents of multiPaths
+    cp -rsf ${staticUsrProfileMulti}/lib/*     lib/
+
+    ln -s lib lib32
+    ln -s ${staticUsrProfileTarget}/lib lib64
+  '';
+
+in stdenv.mkDerivation {
+  name         = "${name}-chrootenv";
+  buildCommand = ''
+    mkdir -p "$out/sw"
+    cd "$out/sw"
+    ${setupTargetProfile}
+    ${setupMultiProfile}
+    cd ..
+
     mkdir -p bin
     cd bin
-    
+
     sed -e "s|@chrootEnv@|$out|g" \
         -e "s|@name@|${name}|g" \
         -e "s|@shell@|${stdenv.shell}|g" \
         ${initSh} > init-${name}-chrootenv
     chmod +x init-${name}-chrootenv
-    
+
     sed -e "s|@shell@|${stdenv.shell}|g" \
         -e "s|@name@|${name}|g" \
         ${mountSh} > mount-${name}-chrootenv
     chmod +x mount-${name}-chrootenv
-    
+
     sed -e "s|@shell@|${stdenv.shell}|g" \
         -e "s|@name@|${name}|g" \
         ${loadSh} > load-${name}-chrootenv
     chmod +x load-${name}-chrootenv
-    
+
     sed -e "s|@shell@|${stdenv.shell}|g" \
         -e "s|@name@|${name}|g" \
         ${umountSh} > umount-${name}-chrootenv
     chmod +x umount-${name}-chrootenv
-    
+
     sed -e "s|@chrootEnv@|$out|g" \
         -e "s|@shell@|${stdenv.shell}|g" \
         -e "s|@name@|${name}|g" \
         ${destroySh} > destroy-${name}-chrootenv
     chmod +x destroy-${name}-chrootenv
+
+    cd ..
+
+    cd "$out/sw"
+    ${extraBuildCommands}
+    cd "$out/sw"
+    ${extraBuildCommandsMulti}
+    cd ..
   '';
 }

--- a/pkgs/build-support/build-fhs-chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/default.nix
@@ -213,7 +213,7 @@ in stdenv.mkDerivation {
     cd "$out/sw"
     ${extraBuildCommands}
     cd "$out/sw"
-    ${extraBuildCommandsMulti}
+    ${if isMultiBuild then extraBuildCommandsMulti else ""}
     cd ..
   '';
 }

--- a/pkgs/build-support/build-fhs-chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/default.nix
@@ -1,6 +1,6 @@
 { buildEnv, nixpkgs, nixpkgs_i686, system
 , stdenv, glibc, glibc_multi, glibcLocales
-, bashInteractive, coreutils, less, shadow su
+, bashInteractive, coreutils, less, shadow, su
 , gawk, gcc, diffutils, findutils, gnused, gnugrep
 , gnutar, gzip, bzip2, xz
 } :

--- a/pkgs/build-support/build-fhs-chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/default.nix
@@ -141,10 +141,6 @@ let
 
     # copy content of targetPaths
     cp -rsf ${staticUsrProfileTarget}/lib/* lib/
-
-    # copy gcc libs
-    cp -rsf ${choosenGcc.gcc}/lib/* lib/
-
   '';
 
   # setup /lib, /lib32 and /lib64

--- a/pkgs/build-support/build-fhs-chrootenv/destroy.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/destroy.sh.in
@@ -3,7 +3,8 @@
 chrootenvDest=/run/chrootenv/@name@
 
 # Remove bind mount points
-rmdir $chrootenvDest/{dev,nix/store,nix,proc,sys,host-etc,home,var,run}
+rmdir $chrootenvDest/{dev,nix/store,nix,proc,sys,host-etc,home,var,run,tmp}
+rmdir /tmp/chrootenv-@name@
 
 # Remove symlinks to the software that should be part of the chroot system profile
 for i in @chrootEnv@/sw/*
@@ -15,7 +16,7 @@ do
 done
 
 # Remove the remaining folders
-rm -Rf $chrootenvDest/{etc,root,tmp}
+rm -Rf $chrootenvDest/{etc,root}
 
 # Remove the chroot environment folder
 rmdir $chrootenvDest

--- a/pkgs/build-support/build-fhs-chrootenv/init.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/init.sh.in
@@ -46,3 +46,4 @@ mkdir $chrootenvDest/root
 
 # Create tmp folder
 mkdir -m1777 $chrootenvDest/tmp
+mkdir -m1777 /tmp/chrootenv-@name@

--- a/pkgs/build-support/build-fhs-chrootenv/mount.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/mount.sh.in
@@ -21,3 +21,6 @@ mount --rbind /run $chrootenvDest/run
 
 # Bind mount the host system's /etc
 mount --bind /etc $chrootenvDest/host-etc
+
+# Bind mount /tmp
+mount -o bind /tmp/chrootenv-@name@ /run/chrootenv/steam/tmp

--- a/pkgs/build-support/build-fhs-chrootenv/umount.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/umount.sh.in
@@ -3,4 +3,4 @@
 chrootenvDest=/run/chrootenv/@name@
 
 # Unmount all (r)bind mounts
-umount -l $chrootenvDest/{dev/pts,dev/shm,dev,nix/store,proc,sys,host-etc,home,var,run}
+umount -l $chrootenvDest/{dev/pts,dev/shm,dev,nix/store,proc,sys,host-etc,home,var,run,tmp}

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,4 +1,4 @@
-{ buildFHSChrootEnv }:
+{ buildFHSChrootEnv, config }:
 
 buildFHSChrootEnv {
   name = "steam";
@@ -13,7 +13,9 @@ buildFHSChrootEnv {
       pkgs.python
       pkgs.gnome2.zenity
       pkgs.xdg_utils
-    ];
+    ]
+    ++ (if config.steam.java or false then [ pkgs.jdk ] else [ ])
+    ;
 
   multiPkgs = pkgs:
       [ pkgs.cairo
@@ -23,6 +25,7 @@ buildFHSChrootEnv {
         pkgs.pango
 
         pkgs.freetype
+        pkgs.fontconfig
         pkgs.xlibs.libICE
         pkgs.xlibs.libSM
         pkgs.xlibs.libX11
@@ -41,9 +44,11 @@ buildFHSChrootEnv {
         pkgs.xlibs.libXtst
         pkgs.xlibs.libXxf86vm
 
+        pkgs.ffmpeg
         pkgs.libpng12
         pkgs.mesa
         pkgs.SDL
+        pkgs.SDL2
 
         pkgs.libgcrypt
         pkgs.zlib

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -18,47 +18,47 @@ buildFHSChrootEnv {
     ;
 
   multiPkgs = pkgs:
-      [ pkgs.cairo
-        pkgs.glib
-        pkgs.gtk
-        pkgs.gdk_pixbuf
-        pkgs.pango
+    [ pkgs.cairo
+      pkgs.glib
+      pkgs.gtk
+      pkgs.gdk_pixbuf
+      pkgs.pango
 
-        pkgs.freetype
-        pkgs.xlibs.libICE
-        pkgs.xlibs.libSM
-        pkgs.xlibs.libX11
-        pkgs.xlibs.libXau
-        pkgs.xlibs.libxcb
-        pkgs.xlibs.libXcursor
-        pkgs.xlibs.libXdamage
-        pkgs.xlibs.libXdmcp
-        pkgs.xlibs.libXext
-        pkgs.xlibs.libXfixes
-        pkgs.xlibs.libXi
-        pkgs.xlibs.libXinerama
-        pkgs.xlibs.libXrandr
-        pkgs.xlibs.libXrender
-        pkgs.xlibs.libXScrnSaver
-        pkgs.xlibs.libXtst
-        pkgs.xlibs.libXxf86vm
+      pkgs.freetype
+      pkgs.xlibs.libICE
+      pkgs.xlibs.libSM
+      pkgs.xlibs.libX11
+      pkgs.xlibs.libXau
+      pkgs.xlibs.libxcb
+      pkgs.xlibs.libXcursor
+      pkgs.xlibs.libXdamage
+      pkgs.xlibs.libXdmcp
+      pkgs.xlibs.libXext
+      pkgs.xlibs.libXfixes
+      pkgs.xlibs.libXi
+      pkgs.xlibs.libXinerama
+      pkgs.xlibs.libXrandr
+      pkgs.xlibs.libXrender
+      pkgs.xlibs.libXScrnSaver
+      pkgs.xlibs.libXtst
+      pkgs.xlibs.libXxf86vm
 
-        pkgs.ffmpeg
-        pkgs.libpng12
-        pkgs.mesa
-        pkgs.SDL
-        pkgs.SDL2
+      pkgs.ffmpeg
+      pkgs.libpng12
+      pkgs.mesa
+      pkgs.SDL
+      pkgs.SDL2
 
-        pkgs.libgcrypt
-        pkgs.zlib
+      pkgs.libgcrypt
+      pkgs.zlib
 
-        pkgs.alsaLib
-        pkgs.libvorbis
-        pkgs.openal
-        pkgs.pulseaudio
+      pkgs.alsaLib
+      pkgs.libvorbis
+      pkgs.openal
+      pkgs.pulseaudio
 
-        pkgs.flashplayer
-      ];
+      pkgs.flashplayer
+    ];
 
   extraBuildCommandsMulti = ''
     cd usr/lib

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -25,7 +25,6 @@ buildFHSChrootEnv {
         pkgs.pango
 
         pkgs.freetype
-        pkgs.fontconfig
         pkgs.xlibs.libICE
         pkgs.xlibs.libSM
         pkgs.xlibs.libX11

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,12 +1,69 @@
-{ buildFHSChrootEnv, steam
-, xterm, libX11, zenity, python, mesa, xdg_utils, dbus_tools, alsaLib
-}:
+{ buildFHSChrootEnv }:
 
 buildFHSChrootEnv {
   name = "steam";
-  pkgs = [ steam xterm libX11 zenity python mesa xdg_utils dbus_tools alsaLib ];
+
+  targetPkgs = pkgs:
+    [ pkgs.steam
+      pkgs.corefonts
+      pkgs.curl
+      pkgs.dbus
+      pkgs.dpkg
+      pkgs.mono
+      pkgs.python
+      pkgs.gnome2.zenity
+      pkgs.xdg_utils
+    ];
+
+  multiPkgs = pkgs:
+      [ pkgs.cairo
+        pkgs.glib
+        pkgs.gtk
+        pkgs.gdk_pixbuf
+        pkgs.pango
+
+        pkgs.freetype
+        pkgs.xlibs.libICE
+        pkgs.xlibs.libSM
+        pkgs.xlibs.libX11
+        pkgs.xlibs.libXau
+        pkgs.xlibs.libxcb
+        pkgs.xlibs.libXcursor
+        pkgs.xlibs.libXdamage
+        pkgs.xlibs.libXdmcp
+        pkgs.xlibs.libXext
+        pkgs.xlibs.libXfixes
+        pkgs.xlibs.libXi
+        pkgs.xlibs.libXinerama
+        pkgs.xlibs.libXrandr
+        pkgs.xlibs.libXrender
+        pkgs.xlibs.libXScrnSaver
+        pkgs.xlibs.libXtst
+        pkgs.xlibs.libXxf86vm
+
+        pkgs.libpng12
+        pkgs.mesa
+        pkgs.SDL
+
+        pkgs.libgcrypt
+        pkgs.zlib
+
+        pkgs.alsaLib
+        pkgs.libvorbis
+        pkgs.openal
+        pkgs.pulseaudio
+
+        pkgs.flashplayer
+      ];
+
+  extraBuildCommandsMulti = ''
+    cd usr/lib
+    ln -sf ../lib64/steam steam
+  '';
+
   profile = ''
-    export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib
+    export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib:/lib32:/lib64
+    export PATH=$PATH:/usr/bin:/usr/sbin
     export FONTCONFIG_FILE=/etc/fonts/fonts.conf
   '';
 }

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -1,118 +1,19 @@
-/*{ stdenv, fetchurl, dpkg, makeWrapper, xz, libX11, gcc, glibc
-, libselinux, libXrandr, pango, freetype, fontconfig, glib, gtk
-, gdk_pixbuf, cairo, libXi, alsaLib, libXrender, nss, nspr, zlib
-, dbus, libpng12, libXfixes, cups, libgcrypt, openal, pulseaudio
-, libxcb, libXau, libXdmcp, flashplayer, libSM, libICE, libXext
-, dbus_glib, libusb1, networkmanager
-, SDL # World of Goo
-, libvorbis # Osmos
-, curl, mesa # Superbrothers: S&S EP
-, patchelf }:
-
-assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
-
-let version = "1.0.0.39"; in
-
-stdenv.mkDerivation rec {
-  name = "steam-${version}";
-
-  src = fetchurl {
-    url = "http://repo.steampowered.com/steam/pool/steam/s/steam/steam-launcher_${version}_all.deb";
-    sha256 = "1z1cnlr2qw2ndnqsfwjck9617m2p0f3p9q9409vczj909h2a9wyk";
-  };
-
-  buildInputs = [ dpkg makeWrapper ];
-
-  phases = "installPhase";
-
-  installPhase = ''
-    mkdir -p $out
-    dpkg-deb -x $src $out
-    cp -r $out/usr/* $out/
-    rm -rf $out/usr
-    substituteInPlace "$out/bin/steam" --replace "/usr/bin/env bash" "/bin/sh"
-    substituteInPlace "$out/bin/steam" --replace "/usr/" "$out/"
-    sed -i 's,STEAMPACKAGE=.*,STEAMPACKAGE=steam,' $out/bin/steam
-    sed -i '/STEAMSCRIPT/d' $out/bin/steam
-
-    mv $out/bin/steam $out/bin/.steam-wrapped
-    cat > $out/bin/steam << EOF
-
-    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${libX11}/lib:${gcc.gcc}/lib:${libselinux}/lib:${libXrandr}/lib:${pango}/lib:${freetype}/lib:${fontconfig}/lib:${glib}/lib:${gtk}/lib:${gdk_pixbuf}/lib:${cairo}/lib:${libXi}/lib:${alsaLib}/lib:${libXrender}/lib:${nss}/lib:${nspr}/lib:${zlib}/lib:${dbus}/lib:${libpng12}/lib:${libXfixes}/lib:${cups}/lib:${libgcrypt}/lib:${openal}/lib:${pulseaudio}/lib:${libxcb}/lib:${libXau}/lib:${libXdmcp}/lib:${SDL}/lib:${libvorbis}/lib:${curl}/lib:${libSM}/lib:${libICE}/lib:${dbus_glib}/lib:${networkmanager}/lib:${libXext}/lib:${libusb1}/lib
-    STEAMBOOTSTRAP=~/.steam/steam/steam.sh
-    if [ -f \$STEAMBOOTSTRAP ]; then
-      PLATFORM32=ubuntu12_32
-      STEAMCONFIG=~/.steam
-      STEAMROOT=~/.local/share/Steam
-      STEAMDATA="\$STEAMROOT"
-      PIDFILE="\$STEAMCONFIG/steam.pid"
-      STEAMBIN32LINK="\$STEAMCONFIG/bin32"
-      STEAMBIN64LINK="\$STEAMCONFIG/bin64"
-      STEAMSDK32LINK="\$STEAMCONFIG/sdk32"
-      STEAMSDK64LINK="\$STEAMCONFIG/sdk64"
-      STEAMROOTLINK="\$STEAMCONFIG/root"
-      STEAMDATALINK="\$STEAMCONFIG/steam"
-      STEAMSTARTING="\$STEAMCONFIG/starting"
-      # Create symbolic links for the Steam API
-      if [ ! -e "\$STEAMCONFIG" ]; then
-          mkdir "\$STEAMCONFIG"
-      fi
-      if [ "\$STEAMROOT" != "\$STEAMROOTLINK" -a "\$STEAMROOT" != "\$STEAMDATALINK" ]; then
-          rm -f "\$STEAMBIN32LINK" && ln -s "\$STEAMROOT/\$PLATFORM32" "\$STEAMBIN32LINK"
-          rm -f "\$STEAMBIN64LINK" && ln -s "\$STEAMROOT/\$PLATFORM64" "\$STEAMBIN64LINK"
-          rm -f "\$STEAMSDK32LINK" && ln -s "\$STEAMROOT/linux32" "\$STEAMSDK32LINK"
-          rm -f "\$STEAMSDK64LINK" && ln -s "\$STEAMROOT/linux64" "\$STEAMSDK64LINK"
-          rm -f "\$STEAMROOTLINK" && ln -s "\$STEAMROOT" "\$STEAMROOTLINK"
-          if [ "\$STEAMDATALINK" ]; then
-              rm -f "\$STEAMDATALINK" && ln -s "\$STEAMDATA" "\$STEAMDATALINK"
-          fi
-      fi
-      # Temporary bandaid until everyone has the new libsteam_api.so
-      rm -f ~/.steampath && ln -s "\$STEAMCONFIG/bin32/steam" ~/.steampath
-      rm -f ~/.steampid && ln -s "\$PIDFILE" ~/.steampid
-      rm -f ~/.steam/bin && ln -s "\$STEAMBIN32LINK" ~/.steam/bin
-      export LD_LIBRARY_PATH="\$STEAMBIN32LINK:\$LD_LIBRARY_PATH:${mesa}/lib"
-      export SDL_VIDEO_X11_DGAMOUSE=0
-      cd "\$STEAMROOT"
-      FLASHLINK="\$STEAMCONFIG/bin32/plugins"
-      rm -f "\$FLASHLINK" && ln -s "${flashplayer}/lib/mozilla/plugins" "\$FLASHLINK"
-      LDSO="\$STEAMBIN32LINK/ld.so"
-      cp ${glibc}/lib/ld-linux.so.2 "\$LDSO"
-      chmod u+w "\$LDSO"
-      echo \$\$ > "\$PIDFILE" # pid of the shell will become pid of steam
-      export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${glibc}/lib
-      exec "\$LDSO" "\$STEAMBIN32LINK/steam"
-    else
-      export PATH=${xz}/bin:\$PATH
-      exec $out/bin/.steam-wrapped
-    fi
-    EOF
-
-    chmod +x $out/bin/steam
-  '';
-
-  meta = {
-    description = "A digital distribution platform";
-    homepage = http://store.steampowered.com/;
-    license = stdenv.lib.licenses.unfree;
-  };
-}
-*/
-
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation {
   name = "steam-1.0.0.48";
+
   src = fetchurl {
     url = http://repo.steampowered.com/steam/pool/steam/s/steam/steam_1.0.0.48.tar.gz;
     sha256 = "08y5qf75ssk4fnazyv2yz1c5zs7gjiwigaibv8yz1gbr290r0b52";
   };
+
   installPhase = ''
     make DESTDIR=$out install
     mv $out/usr/* $out #*/
     rmdir $out/usr
   '';
-  
+
   meta = {
     description = "A digital distribution platform";
     homepage = http://store.steampowered.com/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -265,7 +265,7 @@ let
     inherit buildEnv system;
     inherit stdenv glibc glibc_multi glibcLocales;
     inherit bashInteractive coreutils less shadow su;
-    inherit gawk gcc diffutils findutils gnused gnugrep;
+    inherit gawk gcc gcc_multi diffutils findutils gnused gnugrep;
     inherit gnutar gzip bzip2 xz;
 
     nixpkgs      = pkgs;
@@ -2737,7 +2737,8 @@ let
 
   gambit = callPackage ../development/compilers/gambit { };
 
-  gcc = gcc48;
+  gcc       = gcc48;
+  gcc_multi = gcc48_multi;
 
   gcc33 = wrapGCC (import ../development/compilers/gcc/3.3 {
     inherit fetchurl stdenv noSysDirs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -262,9 +262,14 @@ let
   };
 
   buildFHSChrootEnv = import ../build-support/build-fhs-chrootenv {
-    inherit stdenv glibc glibcLocales gcc coreutils diffutils findutils;
-    inherit gnused gnugrep gnutar gzip bzip2 bashInteractive xz shadow gawk;
-    inherit less buildEnv;
+    inherit buildEnv system;
+    inherit stdenv glibc glibc_multi glibcLocales;
+    inherit bashInteractive coreutils less shadow su;
+    inherit gawk gcc diffutils findutils gnused gnugrep;
+    inherit gnutar gzip bzip2 xz;
+
+    nixpkgs      = pkgs;
+    nixpkgs_i686 = pkgsi686Linux;
   };
 
   dotnetenv = import ../build-support/dotnetenv {
@@ -10653,11 +10658,9 @@ let
 
   stardust = callPackage ../games/stardust {};
 
-  steam = callPackage_i686 ../games/steam {};
+  steam = callPackage ../games/steam {};
 
-  steamChrootEnv = callPackage_i686 ../games/steam/chrootenv.nix {
-    zenity = gnome2.zenity;
-  };
+  steamChrootEnv = callPackage ../games/steam/chrootenv.nix { };
 
   stuntrally = callPackage ../games/stuntrally { };
 


### PR DESCRIPTION
Currently steam will do a 32bit only install. On 64bit systems it won't run correctly or at least most games won't. The problem is that games supporting 64bit will run their 64bit binary because the system propagates it. But the current chroot steam env just has 32bit libs installed and the game will therefore crash.

This patch will alter buildFHSChrootEnv to support multi lib installs. For this purpose I have added new config variables to buildFHSChrootEnv--if these keep untouched the env will build as before. This means that the patch should not break any other packages utilizing buildFHSChrootEnv.

On the steam side I have added many missing libraries and made it compatible with the new system.

All games that I have tested yet worked right out of the box what just wasn't possible before.

Since steam uses ldd to find out which libraries are still missing, this patch will only work after PR #2354 has been merged.

Further I haven't tested this on a 32bit only system. So please only merge after someone got this tested.
