### PR TITLE
haskell-msgpack: add version 0.7.2.5

### DIFF
--- a/pkgs/development/libraries/haskell/msgpack/default.nix
+++ b/pkgs/development/libraries/haskell/msgpack/default.nix
@@ -1,0 +1,24 @@
+{ cabal, attoparsec, blazeBuilder, deepseq, hashable, mtl
+, QuickCheck, testFramework, testFrameworkQuickcheck2, text
+, unorderedContainers, vector
+}:
+
+cabal.mkDerivation (self: {
+  pname = "msgpack";
+  version = "0.7.2.5";
+  sha256 = "1iwibyv5aqp5h98x4s5pp3hj218l2k3vff87p727mh74f5j6l3s8";
+  buildDepends = [
+    attoparsec blazeBuilder deepseq hashable mtl text
+    unorderedContainers vector
+  ];
+  testDepends = [
+    QuickCheck testFramework testFrameworkQuickcheck2
+  ];
+  jailbreak = true;
+  meta = {
+    homepage = "http://msgpack.org/";
+    description = "A Haskell implementation of MessagePack";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1795,6 +1795,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
   mpppc = callPackage ../development/libraries/haskell/mpppc {};
 
+  msgpack = callPackage ../development/libraries/haskell/msgpack {};
+
   mtl_1_1_0_2 = callPackage ../development/libraries/haskell/mtl/1.1.0.2.nix {};
   mtl_1_1_1_1 = callPackage ../development/libraries/haskell/mtl/1.1.1.1.nix {};
   mtl_2_0_1_0 = callPackage ../development/libraries/haskell/mtl/2.0.1.0.nix {};


### PR DESCRIPTION
As generated by cabal2nix without any further modifications.
