### PR TITLE
linux: Enable NFSv4.1, v4.2 clients and swap on NFS

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -157,6 +157,11 @@ with stdenv.lib;
   BTRFS_FS_POSIX_ACL y
   UBIFS_FS_XATTR? y
   UBIFS_FS_ADVANCED_COMPR? y
+  NFS_SWAP y
+  ${optionalString (versionAtLeast version "3.11") ''
+    NFS_V4_1 y  # NFSv4.1 client support
+    NFS_V4_2 y
+  ''}
   NFSD_V2_ACL y
   NFSD_V3 y
   NFSD_V3_ACL y


### PR DESCRIPTION
I'm only enabling for kernels >= 3.11 to be conservative, because clients and
servers automatically negotiate and use the highest mutually supported version
by default, but only in kernel 3.11 server NFSv4.1 support actually became RFC
compliant.
