### PR TITLE
DisnixWebService: Fix broken build by exposing jdk as buildInputs

### DIFF
--- a/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
+++ b/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
     url = http://hydra.nixos.org/build/910953/download/4/DisnixWebService-0.2.tar.bz2;
     sha256 = "1469l2ykhdjmplkw01x64f7aq9rms05ig9sagyb8l2zksjm6lla8";
   };
-  buildInputs = [ apacheAnt ];
+  buildInputs = [ apacheAnt jdk ];
   PREFIX = ''''${env.out}'';
   AXIS2_LIB = "${axis2}/lib";
   AXIS2_WEBAPP = "${axis2}/webapps/axis2";


### PR DESCRIPTION
DisnixWebService: Fix broken build by exposing jdk as buildInputs
