### PR TITLE
capnproto: Add package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -26,6 +26,7 @@
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
   coroa = "Jonas Hörsch <jonas@chaoflow.net>";
+  cstrahan = "Charles Strahan <charles.c.strahan@gmail.com>";
   edwtjo = "Edward Tjörnhammar <ed@cflags.cc>";
   eelco = "Eelco Dolstra <eelco.dolstra@logicblox.com>";
   emery = "Emery Hemingawy <emery@vfemail.net>";

--- a/pkgs/development/libraries/capnproto/default.nix
+++ b/pkgs/development/libraries/capnproto/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "capnproto-0.4.1";
+
+  meta = with stdenv.lib; {
+    homepage    = "http://kentonv.github.io/capnproto";
+    description = "Cap'n Proto cerealization protocol";
+    longDescription = ''
+      Cap’n Proto is an insanely fast data interchange format and
+      capability-based RPC system. Think JSON, except binary. Or think Protocol
+      Buffers, except faster.
+    '';
+    license     = licenses.bsd2;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+
+  src = fetchurl {
+    url = "https://capnproto.org/capnproto-c++-0.4.1.tar.gz";
+    sha256 = "8453e8d508906062f113dbdfff552f41e08083ccf7c9407778a8d107675cd468";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4132,6 +4132,8 @@ let
 
   caelum = callPackage ../development/libraries/caelum { };
 
+  capnproto = callPackage ../development/libraries/capnproto { };
+
   scmccid = callPackage ../development/libraries/scmccid { };
 
   ccrtp = callPackage ../development/libraries/ccrtp { };


### PR DESCRIPTION
This PR adds a nix expr for the [capnproto](http://kentonv.github.io/capnproto) serialization library.
