### PR TITLE
Enable encrypted backing devices in fileystem configurations

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -311,6 +311,7 @@
   ./tasks/filesystems/vfat.nix
   ./tasks/filesystems/xfs.nix
   ./tasks/filesystems/zfs.nix
+  ./tasks/encrypted-devices.nix
   ./tasks/kbd.nix
   ./tasks/lvm.nix
   ./tasks/network-interfaces.nix

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -1,0 +1,69 @@
+{ config, pkgs, modulesPath, ... }:
+
+with pkgs.lib;
+
+let
+  fileSystems = attrValues config.fileSystems ++ config.swapDevices;
+  encDevs = filter (dev: dev.encrypted.enable) fileSystems;
+  keyedEncDevs = filter (dev: dev.encrypted.keyFile != null) encDevs;
+  isIn = needle: haystack: filter (p: p == needle) haystack != [];
+  anyEncrypted =
+    fold (j: v: v || j.encrypted.enable) false encDevs;
+
+  encryptedFSOptions = {
+
+    encrypted = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "The block device is backed by an encrypted one, adds this device as a initrd luks entry";
+      };
+
+      blkDev = mkOption {
+        default = null;
+        example = "/dev/sda1";
+        type = types.uniq (types.nullOr types.string);
+        description = "Location of the backing encrypted device";
+      };
+
+      label = mkOption {
+        default = null;
+        example = "rootfs";
+        type = types.uniq (types.nullOr types.string);
+        description = "Label of the backing encrypted device";
+      };
+
+      keyFile = mkOption {
+        default = null;
+        example = "/root/.swapkey";
+        type = types.uniq (types.nullOr types.string);
+        description = "File system location of keyfile";
+      };
+    };
+  };
+in
+
+{
+
+  options = {
+    fileSystems = mkOption {
+      options = [encryptedFSOptions];
+    };
+    swapDevices = mkOption {
+      options = [encryptedFSOptions];
+    };
+  };
+
+  config = mkIf anyEncrypted {
+    boot.initrd = {
+      luks = {
+        devices =
+          map (dev: { name = dev.encrypted.label; device = dev.encrypted.blkDev; } ) encDevs;
+        cryptoModules = [ "aes" "sha256" "sha1" "xts" ];
+      };
+      postMountCommands =
+        concatMapStrings (dev: "cryptsetup luksOpen --key-file ${dev.encrypted.keyFile} ${dev.encrypted.label};\n") keyedEncDevs;
+    };
+  };
+}
+


### PR DESCRIPTION
Example configuration can be viewed at: https://github.com/edwtjo/nixcfgs/blob/master/tempest.nix

This could possibly need some more work, like deciding on what encryption modules to use and autofill the filesystem device since we know the label..
