### PR TITLE
chromiumWrapper creates two .desktop files (none with working icon)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -39,9 +39,9 @@ let
   };
 
   desktopItem = makeDesktopItem {
-    name = "Chromium";
+    name = "chromium";
     exec = "chromium";
-    icon = "chromium";
+    icon = "${chromium.browser}/share/icons/hicolor/48x48/apps/chromium.png";
     comment = "An open source web browser from Google";
     desktopName = "Chromium";
     genericName = "Web browser";
@@ -74,6 +74,7 @@ in stdenv.mkDerivation {
       --set CHROMIUM_SANDBOX_BINARY_PATH "${sandboxBinary}" \
       --add-flags "${chromium.plugins.flagsEnabled}"
 
+    ln -s "${chromium.browser}/share/icons" "$out/share/icons"
     cp -v "${desktopItem}/share/applications/"* "$out/share/applications"
   '';
 


### PR DESCRIPTION
I have `chromiumWrapper` in `environment.systemPackages` and
after `sudo nix-channel --update` and `sudo nixos-rebuild switch` today (== 33eced411fea68fd033a1fbd6de6b424b3af564b), I got two chromium .desktop files:

```
/run/current-system/sw/share/applications/chromium.desktop
/run/current-system/sw/share/applications/Chromium.desktop
```

The first file:

```
$ cat /run/current-system/sw/share/applications/chromium.desktop                                                                                                                                                                                                              
[Desktop Entry]                                                                                                                                                                                                                                                                
Type=Application                                                                                                                                                                                                                                                               
Exec=chromium %U                                                                                                                                                                                                                                                               
Icon=/nix/store/0ihj3f2prc20wf7rnipkmv1k6na9dbrx-chromium-stable-34.0.1847.116/share/icons/hicolor/48x48/apps/chromium.png                                                                                                                                                     
Comment=                                                                                                                                                                                                                                                                       
Terminal=false                                                                                                                                                                                                                                                                 
Name=Chromium                                                                                                                                                                                                                                                                  
GenericName=Web Browser                                                                                                                                                                                                                                                        
MimeType=                                                                                                                                                                                                                                                                      
Categories=Application;Network;WebBrowser;                                                                                                                                                                                                                                     
Encoding=UTF-8
```

The second file:

```
$ cat /run/current-system/sw/share/applications/Chromium.desktop                                                                                                                                                                                                               
[Desktop Entry]                                                                                                                                                                                                                                                                
Type=Application                                                                                                                                                                                                                                                               
Exec=chromium                                                                                                                                                                                                                                                                  
Icon=chromium                                                                                                                                                                                                                                                                  
Comment=An open source web browser from Google                                                                                                                                                                                                                                 
Terminal=false                                                                                                                                                                                                                                                                 
Name=Chromium                                                                                                                                                                                                                                                                  
GenericName=Web browser                                                                                                                                                                                                                                                        
MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/mailto;x-scheme-handler/webcal                                                                                                            
Categories=Network;WebBrowser                                                                                                                                                                                                                                                  
Encoding=UTF-8
```

Both entries show up in the start menu (KDE Kicker?) but none of them have working icon. Annoying! :-)
