### PR TITLE
eigen: upgrading version to 3.2.1

### DIFF
--- a/pkgs/development/libraries/eigen/default.nix
+++ b/pkgs/development/libraries/eigen/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, cmake}:
 
 let
-  v = "3.2.0";
+  v = "3.2.1";
 in
 stdenv.mkDerivation {
   name = "eigen-${v}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "http://bitbucket.org/eigen/eigen/get/${v}.tar.bz2";
     name = "eigen-${v}.tar.bz2";
-    sha256 = "1dpshkcqjz3ckad56mkk1agbnlq0rk2d0wv14zwjg4lk1nb7h7q1";
+    sha256 = "12ljdirih9n3cf8hy00in285c2ccah7mgalmmr8gc3ldwznz5rk6";
   };
   
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Updating to the latest version of Eigen, 3.2.1, which has lots of bugfixes.

This was my excuse to learn a bit about Nix's package maintenance system, so feel free to let me know if I've done anything wrong!
