### PR TITLE
supercollider: add Emacs support (aka SCEL)

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,9 +1,12 @@
 { stdenv, fetchurl, cmake, pkgconfig
 , jackaudio, libsndfile, fftw, curl
-, libXt, qt
+, libXt, qt, readline
+, useSCEL ? false, emacs
 }:
+  
+let optional = stdenv.lib.optional; in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {  
   name = "supercollider-3.6.6";
 
   meta = {
@@ -24,15 +27,14 @@ stdenv.mkDerivation rec {
       --replace Q_WS_X11 Q_GTK_STYLE
   '';
 
-  cmakeFlags = [
-    "-DSC_WII=OFF"
-    "-DSC_EL=OFF"
-  ];
+  cmakeFlags = ''
+    -DSC_WII=OFF
+    -DSC_EL=${if useSCEL then "ON" else "OFF"} 
+  '';
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [
-    jackaudio libsndfile fftw curl
-    libXt qt
-  ];
+  buildInputs = [ 
+    jackaudio libsndfile fftw curl libXt qt readline ] 
+    ++ optional useSCEL emacs;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3544,6 +3544,8 @@ let
     fftw = fftwSinglePrec;
   };
 
+  supercollider_scel = supercollider.override { useSCEL = true; };
+
   sysPerl = callPackage ../development/interpreters/perl/sys-perl { };
 
   tcl = callPackage ../development/interpreters/tcl { };


### PR DESCRIPTION
The current expression for SuperCollider in the repository builds and installs a version of the application which uses a built-in Qt-based IDE, but disables built-in support for using Emacs as an IDE.  This new expression enables that feature and also builds the built-in Qt IDE by default.  I used the current SuperCollider default expression as a staring point, and then modified the proper cmake flag and added the necessary dependencies. 
