### PR TITLE
nixos: Add support for changing supported systems

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -1,6 +1,7 @@
 { nixpkgs ? { outPath = ./..; revCount = 5678; shortRev = "gfedcba"; }
 , officialRelease ? false
 , stableBranch ? false
+, supportedSystems ? [ "x86_64-linux" "i686-linux" ]
 }:
 
 let
@@ -23,10 +24,8 @@ in rec {
   });
 
   nixpkgs = builtins.removeAttrs (removeMaintainers (import ../pkgs/top-level/release.nix {
-    inherit officialRelease;
+    inherit officialRelease supportedSystems;
     nixpkgs = nixpkgsSrc;
-    # Only do Linux builds.
-    supportedSystems = [ "x86_64-linux" "i686-linux" ];
   })) [ "unstable" ];
 
   tested = pkgs.releaseTools.aggregate {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -1,6 +1,7 @@
 { nixpkgs ? { outPath = ./..; revCount = 5678; shortRev = "gfedcba"; }
 , officialRelease ? false
 , stableBranch ? false
+, supportedSystems ? [ "x86_64-linux" "i686-linux" ]
 }:
 
 let
@@ -10,9 +11,7 @@ let
     if officialRelease then ""
     else (if stableBranch then "." else "pre") + "${toString nixpkgs.revCount}.${nixpkgs.shortRev}";
 
-  systems = [ "x86_64-linux" "i686-linux" ];
-
-  forAllSystems = pkgs.lib.genAttrs systems;
+  forAllSystems = pkgs.lib.genAttrs supportedSystems;
 
   callTest = fn: args: forAllSystems (system: import fn ({ inherit system; } // args));
 


### PR DESCRIPTION
release.nix and release-combined.nix current hardcode the systems which
they are built for. This change introduces an argument to the
expressions called supportedSystems, which allows the builder to choose
which architectures he wants to build. By default, this uses the same
linux x86_64 and i686 architectures.
