### PR TITLE
livestreamer: version 1.8.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4522,6 +4522,30 @@ rec {
     };
   };
 
+  livestreamer = if isPy34 then null else (buildPythonPackage {
+    #version = "1.8.0";
+    name = "livestreamer-1.8.0";
+
+    src = fetchurl {
+      url = "https://github.com/chrippa/livestreamer/archive/v1.8.0.tar.gz";
+      sha256 = "0fzpznbnhzrqawxdljvyml5251wbr3nifdrvnmh2b8vz356js4l8";
+    };
+
+    buildInputs = [ pkgs.makeWrapper ];
+    propagatedBuildInputs = [ requests ];
+    postInstall = ''
+      wrapProgram $out/bin/livestreamer --prefix PATH : ${pkgs.rtmpdump}/bin
+    '';
+
+    meta = {
+      homepage = http://livestreamer.tanuki.se;
+      description = ''
+        Livestreamer is CLI program that extracts streams from various
+        services and pipes them into a video player of choice.
+      '';
+      license = "bsd";
+    };
+  });
 
   oauth2 = buildPythonPackage (rec {
     name = "oauth2-1.5.211";


### PR DESCRIPTION
A test fails with Python 3.4 so we ignore that one.

The program depends on `rtmpdump` to be in PATH for some sources (but it tells the user at runtime once they try it). Should this be included in the install somehow or is it fine to just have the user install it manually?
