### PR TITLE
nvidia-x11: add nividia-uvm module.

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -20,6 +20,11 @@ buildPhase() {
         sysOut=$(echo $kernel/lib/modules/$kernelVersion/build)
         unset src # used by the nv makefile
         make SYSSRC=$sysSrc SYSOUT=$sysOut module
+
+        cd uvm
+        make SYSSRC=$sysSrc SYSOUT=$sysOut module
+        cd ..
+
         cd ..
     fi
 }
@@ -55,7 +60,8 @@ installPhase() {
 
         # Install the kernel module.
         mkdir -p $out/lib/modules/$kernelVersion/misc
-        cp kernel/nvidia.ko $out/lib/modules/$kernelVersion/misc
+        cp -v kernel/nvidia.ko $out/lib/modules/$kernelVersion/misc
+        cp -v kernel/uvm/nvidia-uvm.ko $out/lib/modules/$kernelVersion/misc
 
         # Install the X driver.
         mkdir -p $out/lib/xorg/modules


### PR DESCRIPTION
This kernel module provides support for the new Unified Memory feature in
the current CUDA releases.
