### PR TITLE
fix GNUnet missing dependencies

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -1,7 +1,6 @@
-{ stdenv, fetchurl, libextractor, libmicrohttpd, libgcrypt
-, zlib, gmp, curl, libtool, adns, sqlite, pkgconfig
-, libxml2, ncurses, gettext, libunistring, libidn
-, makeWrapper }:
+{ stdenv, fetchurl, adns, curl, gettext, gmp, gnutls, libextractor
+, libgcrypt, libgnurl, libidn, libmicrohttpd, libtool, libunistring
+, makeWrapper, ncurses, pkgconfig, libxml2, sqlite, zlib }:
 
 stdenv.mkDerivation rec {
   name = "gnunet-0.10.1";
@@ -12,9 +11,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libextractor libmicrohttpd libgcrypt gmp curl libtool
-    zlib adns sqlite libxml2 ncurses libidn
-    pkgconfig gettext libunistring makeWrapper
+    adns curl gettext gmp gnutls libextractor libgcrypt libgnurl libidn
+    libmicrohttpd libtool libunistring libxml2 makeWrapper ncurses
+    pkgconfig sqlite zlib
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/libgnurl/default.nix
+++ b/pkgs/development/libraries/libgnurl/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "7.35.0";
+
+  name = "libgnurl-${version}";
+
+  src = fetchurl {
+    url = "https://gnunet.org/sites/default/files/gnurl-${version}.tar.bz2";
+    sha256 = "0dzj22f5z6ppjj1aq1bml64iwbzzcd8w1qy3bgpk6gnzqslsxknf";
+  };
+
+  preConfigure = ''
+    sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fork of libcurl used by GNUnet";
+    homepage    = https://gnunet.org/gnurl;
+    maintainers = with maintainers; [ falsifian ];
+    hydraPlatforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4945,6 +4945,8 @@ let
   libgnome_keyring = callPackage ../development/libraries/libgnome-keyring { };
   libgnome_keyring3 = gnome3.libgnome_keyring;
 
+  libgnurl = callPackage ../development/libraries/libgnurl { };
+
   libseccomp = callPackage ../development/libraries/libseccomp { };
 
   libsecret = callPackage ../development/libraries/libsecret { };


### PR DESCRIPTION
libgnurl is essential for bootstrapping a new node (to download the hostlist)

gnutls is needed by gnunet-gns-proxy.

I left out bluetooth and gstreamer, which gnunet can also use.

Also, sort the dependencies alphabetically.

I tested this commit cherry-picked to 14.04, but haven't tested it directly.
