### PR TITLE
tzdata: fix `posix` symlink

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
 
   postInstall =
     ''
-      mv $out/share/zoneinfo-posix $out/share/zoneinfo/posix
+      rm $out/share/zoneinfo-posix
+      ln -s . $out/share/zoneinfo/posix
       mv $out/share/zoneinfo-leaps $out/share/zoneinfo/right
 
       ensureDir "$lib/include"


### PR DESCRIPTION
`zoneinfo-posix` is a symlink, so just moving it in breaks it.
