### PR TITLE
tzdata: use symlinks instead of hardlinks

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
   outputs = [ "out" "lib" ];
 
-  makeFlags = "TOPDIR=$(out) TZDIR=$(out)/share/zoneinfo ETCDIR=$(TMPDIR)/etc LIBDIR=$(lib)/lib MANDIR=$(TMPDIR)/man AWK=awk";
+  makeFlags = "TOPDIR=$(out) TZDIR=$(out)/share/zoneinfo ETCDIR=$(TMPDIR)/etc LIBDIR=$(lib)/lib MANDIR=$(TMPDIR)/man AWK=awk CFLAGS=-DHAVE_LINK=0";
 
   postInstall =
     ''


### PR DESCRIPTION
Hard links are not handled by nar, so installing from binary cache
unnecessarily duplicates data. Also, it's more common to use symlinks for the
tzdata package in other distributions.
