### PR TITLE
libc: set the 'zonedir' from tzdata package

### DIFF
--- a/pkgs/development/libraries/glibc/2.19/common.nix
+++ b/pkgs/development/libraries/glibc/2.19/common.nix
@@ -3,7 +3,8 @@
 
 cross:
 
-{ name, fetchurl, fetchgit ? null, stdenv, installLocales ? false
+{ name, fetchurl, fetchgit ? null, stdenv, tzdata
+, installLocales ? false
 , gccCross ? null, kernelHeaders ? null
 , machHeaders ? null, hurdHeaders ? null, libpthreadHeaders ? null
 , mig ? null
@@ -68,6 +69,10 @@ stdenv.mkDerivation ({
     # nscd needs libgcc, and we don't want it dynamically linked
     # because we don't want it to depend on bootstrap-tools libs.
     echo "LDFLAGS-nscd += -static-libgcc" >> nscd/Makefile
+
+    # There is no 'zonedir' configure option, so we have to add
+    # it to 'configparms'.
+    echo "zonedir = ${tzdata}/share/zoneinfo" >> configparms
   '';
 
   configureFlags =

--- a/pkgs/development/libraries/glibc/2.19/default.nix
+++ b/pkgs/development/libraries/glibc/2.19/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchgit ? null, kernelHeaders
+{ stdenv, fetchurl, fetchgit ? null, kernelHeaders, tzdata
 , machHeaders ? null, hurdHeaders ? null, libpthreadHeaders ? null
 , mig ? null
 , installLocales ? true
@@ -21,7 +21,7 @@ in
       + stdenv.lib.optionalString withGd "-gd";
 
     inherit fetchurl fetchgit stdenv kernelHeaders installLocales
-      profilingLibraries gccCross withGd gd libpng;
+      profilingLibraries gccCross withGd gd libpng tzdata;
 
     builder = ./builder.sh;
 


### PR DESCRIPTION
In the future this will allow us not to set $TZDIR globally.
