### PR TITLE
add uim: A multilingual input method framework.

### DIFF
--- a/nixos/modules/config/immodules.nix
+++ b/nixos/modules/config/immodules.nix
@@ -1,0 +1,31 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+{
+  options = {
+    gtk2ImModules = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = [ "${pkgs.uim}/lib/gtk-2.0/2.10.0/immodules/*.so" ];
+      description = "input method modules for GTK+ 2";
+    };
+
+    gtk3ImModules = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = [ "${pkgs.uim}/lib/gtk-3.0/3.0.0/immodules/*.so" ];
+      description = "input method modules for GTK+ 3";
+    };
+
+    qtImModules = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = [ "${pkgs.uim}lib/qt4/plugins/inputmethods/*.so" ];
+      description = "input method modules for Qt 4";
+    };
+  };
+
+  config = {
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -6,6 +6,7 @@
   ./config/fonts/ghostscript.nix
   ./config/gnu.nix
   ./config/i18n.nix
+  ./config/immodules.nix
   ./config/krb5.nix
   ./config/ldap.nix
   ./config/networking.nix
@@ -58,6 +59,7 @@
   ./programs/wvdial.nix
   ./programs/zsh/zsh.nix
   ./programs/screen.nix
+  ./programs/uim.nix
   ./rename.nix
   ./security/apparmor.nix
   ./security/apparmor-suid.nix

--- a/nixos/modules/programs/uim.nix
+++ b/nixos/modules/programs/uim.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+  cfg = config.uim;
+in
+{
+  options = {
+    uim = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "enable UIM input method";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.uim ];
+    gtk2ImModules = [ "${pkgs.uim}/lib/gtk-2.0/2.10.0/immodules/*.so" ];
+    gtk3ImModules = [ "${pkgs.uim}/lib/gtk-3.0/3.0.0/immodules/*.so" ];
+    environment.variables.GTK_IM_MODULES = "uim";
+    environment.variables.QT_IM_MODULES = "uim";
+    environment.variables.XMODIFIERS = "@im=uim";
+    services.xserver.displayManager.sessionCommands = "uim-xim &";
+  };
+}

--- a/nixos/modules/programs/uim.nix
+++ b/nixos/modules/programs/uim.nix
@@ -3,11 +3,11 @@
 with pkgs.lib;
 
 let
-  cfg = config.uim;
+  cfg = config.programs.uim;
 in
 {
   options = {
-    uim = {
+    programs.uim = {
       enable = mkOption {
         type = types.bool;
         default = false;

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xlibs
-, gdk_pixbuf, libintlOrEmpty, x11
+, gdk_pixbuf, libintlOrEmpty, x11, config
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? true, cups ? null
+, extraImModules ? []
 }:
 
 assert xineramaSupport -> xlibs.libXinerama != null;
@@ -32,7 +33,13 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--with-xinput=yes";
 
-  postInstall = "rm -rf $out/share/gtk-doc";
+  immodules = [ "$out/lib/gtk-2.0/2.10.0/immodules/*.so" ] ++ extraImModules;
+  
+  postInstall =
+    ''
+      rm -rf $out/share/gtk-doc
+      $out/bin/gtk-query-immodules-2.0 --update-cache ${stdenv.lib.concatStringsSep " " immodules}
+    '';
 
   meta = with stdenv.lib; {
     description = "A multi-platform toolkit for creating graphical user interfaces";

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchurl, pkgconfig, gettext, perl
 , expat, glib, cairo, pango, gdk_pixbuf, atk, at_spi2_atk, gobjectIntrospection
-, xlibs, x11, wayland, libxkbcommon
+, xlibs, x11, wayland, libxkbcommon, config
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? stdenv.isLinux, cups ? null
+, extraImModules ? []
 }:
 
 assert xineramaSupport -> xlibs.libXinerama != null;
@@ -36,7 +37,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  postInstall = "rm -rf $out/share/gtk-doc";
+  immodules = [ "$out/lib/gtk-3.0/3.0.0/immodules/*.so" ] ++ extraImModules;
+
+  postInstall =
+    ''
+      rm -rf $out/share/gtk-doc
+      $out/bin/gtk-query-immodules-3.0 --update-cache ${stdenv.lib.concatStringsSep " " immodules}
+    '';
 
   meta = {
     description = "A multi-platform toolkit for creating graphical user interfaces";

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll, libXrender, libXinerama, libXcursor, libXmu, libXv, libXext
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
-, libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
+, libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi, config
 , buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst_plugins_base
 , buildWebkit ? stdenv.isLinux
 , flashplayerFix ? false, gdk_pixbuf
@@ -10,6 +10,7 @@
 , docs ? false
 , examples ? false
 , demos ? false
+, extraImModules ? []
 }:
 
 with stdenv.lib;
@@ -160,10 +161,17 @@ stdenv.mkDerivation rec {
         mkspecs/win32-g++/qmake.conf
     '';
 
+    immodules = extraImModules;
+
     # I don't know why it does not install qmake
     postInstall = ''
       cp bin/qmake* $out/bin
-    '';
+    '' + (
+      if immodules != []
+      then "cp $immodules $out/lib/qt4/plugins/inputmethods/\n"
+      else ""
+    );
+
     dontSetConfigureCross = true;
     dontStrip = true;
   } // optionalAttrs isMingw {

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -1,0 +1,44 @@
+{stdenv, fetchurl, intltool, pkgconfig, qt4, gtk2, gtk3, kdelibs, cmake, ... }:
+
+stdenv.mkDerivation rec {
+  version = "1.8.6";
+  name = "uim-${version}";
+
+  buildInputs = [
+    intltool
+    pkgconfig
+    qt4
+    gtk2
+    gtk3
+    kdelibs
+    cmake
+  ];
+
+  patches = [ ./immodules_cache.patch ];
+
+  configureFlags = [
+    "--with-gtk2"
+    "--with-gtk3"
+    "--enable-kde4-applet"
+    "--enable-notify=knotify4"
+    "--enable-pref"
+    "--with-qt4"
+    "--with-qt4-immodule"
+    "--with-skk"
+    "--with-x"
+  ];
+
+  dontUseCmakeConfigure = true;
+  
+  src = fetchurl {
+    url = "http://uim.googlecode.com/files/uim-${version}.tar.bz2";
+    sha1 = "43b9dbdead6797880e6cfc9c032ecb2d37d42777";
+  };
+
+  meta = {
+    homepage = "http://code.google.com/p/uim/";
+    description = "A multilingual input method framework";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/uim/immodules_cache.patch
+++ b/pkgs/tools/inputmethods/uim/immodules_cache.patch
@@ -1,0 +1,105 @@
+diff -ru -x '*~' uim-1.8.6.orig/gtk3/immodule/Makefile.am uim-1.8.6/gtk3/immodule/Makefile.am
+--- uim-1.8.6.orig/gtk3/immodule/Makefile.am	2013-06-30 13:26:20.000000000 +0900
++++ uim-1.8.6/gtk3/immodule/Makefile.am	2014-03-02 12:34:25.744133423 +0900
+@@ -45,42 +45,11 @@
+ 
+ install-data-hook: gtk3-rc-get-immodule-file
+ 	if test -z $(DESTDIR); then \
+-	  if test $(libdir) = $(GTK3_LIBDIR); then \
+-	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	      $(QUERY_COMMAND) --update-cache; \
+-	      echo "*** \"`$(GTK3_RC_GET_IMMODULE_FILE)`\" is updated. ***";  \
+-	    else \
+-	      echo "********************** Warning ***********************"; \
+-	      echo " $(QUERY_COMMAND) not found"; \
+-	      echo " Please make sure to update"; \
+-	      echo " \"`$(GTK3_RC_GET_IMMODULE_FILE)`\""; \
+-	      echo " manually."; \
+-	      echo "******************************************************"; \
+-	    fi \
+-	  else \
+-	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-	    else \
+-	      echo "********************** Warning ***********************"; \
+-	      echo " $(QUERY_COMMAND) not found"; \
+-	      echo " Please make sure to update"; \
+-	      echo " immodules.cache"; \
+-	      echo " manually, and set"; \
+-	      echo " GTK_IM_MODULE_FILE=PATH_TO/immodule.cache"; \
+-	      echo " environment variable to use this module."; \
+-	      echo "******************************************************"; \
+-	    fi \
+-	  fi \
++    GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ 	fi
+ uninstall-hook:
+ 	if test -z $(DESTDIR); then \
+-	  if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	    if test $(libdir) = $(GTK3_LIBDIR); then \
+-	      $(QUERY_COMMAND) --update-cache; \
+-	    else \
+-	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-	    fi \
+-	  fi \
++    GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ 	fi
+ else
+ install-data-hook:
+diff -ru -x '*~' uim-1.8.6.orig/gtk3/immodule/Makefile.in uim-1.8.6/gtk3/immodule/Makefile.in
+--- uim-1.8.6.orig/gtk3/immodule/Makefile.in	2013-06-30 13:27:08.000000000 +0900
++++ uim-1.8.6/gtk3/immodule/Makefile.in	2014-03-02 12:34:46.858108103 +0900
+@@ -893,42 +893,11 @@
+ 
+ @GTK3_TRUE@install-data-hook: gtk3-rc-get-immodule-file
+ @GTK3_TRUE@	if test -z $(DESTDIR); then \
+-@GTK3_TRUE@	  if test $(libdir) = $(GTK3_LIBDIR); then \
+-@GTK3_TRUE@	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK3_TRUE@	      $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	      echo "*** \"`$(GTK3_RC_GET_IMMODULE_FILE)`\" is updated. ***";  \
+-@GTK3_TRUE@	    else \
+-@GTK3_TRUE@	      echo "********************** Warning ***********************"; \
+-@GTK3_TRUE@	      echo " $(QUERY_COMMAND) not found"; \
+-@GTK3_TRUE@	      echo " Please make sure to update"; \
+-@GTK3_TRUE@	      echo " \"`$(GTK3_RC_GET_IMMODULE_FILE)`\""; \
+-@GTK3_TRUE@	      echo " manually."; \
+-@GTK3_TRUE@	      echo "******************************************************"; \
+-@GTK3_TRUE@	    fi \
+-@GTK3_TRUE@	  else \
+-@GTK3_TRUE@	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK3_TRUE@	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	    else \
+-@GTK3_TRUE@	      echo "********************** Warning ***********************"; \
+-@GTK3_TRUE@	      echo " $(QUERY_COMMAND) not found"; \
+-@GTK3_TRUE@	      echo " Please make sure to update"; \
+-@GTK3_TRUE@	      echo " immodules.cache"; \
+-@GTK3_TRUE@	      echo " manually, and set"; \
+-@GTK3_TRUE@	      echo " GTK_IM_MODULE_FILE=PATH_TO/immodule.cache"; \
+-@GTK3_TRUE@	      echo " environment variable to use this module."; \
+-@GTK3_TRUE@	      echo "******************************************************"; \
+-@GTK3_TRUE@	    fi \
+-@GTK3_TRUE@	  fi \
++@GTK3_TRUE@   GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ @GTK3_TRUE@	fi
+ @GTK3_TRUE@uninstall-hook:
+ @GTK3_TRUE@	if test -z $(DESTDIR); then \
+-@GTK3_TRUE@	  if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK3_TRUE@	    if test $(libdir) = $(GTK3_LIBDIR); then \
+-@GTK3_TRUE@	      $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	    else \
+-@GTK3_TRUE@	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	    fi \
+-@GTK3_TRUE@	  fi \
++@GTK3_TRUE@   GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ @GTK3_TRUE@	fi
+ @GTK3_FALSE@install-data-hook:
+ 
+diff -ru -x '*~' uim-1.8.6.orig/qt4/immodule/quiminputcontextplugin.pro.in uim-1.8.6/qt4/immodule/quiminputcontextplugin.pro.in
+--- uim-1.8.6.orig/qt4/immodule/quiminputcontextplugin.pro.in	2013-06-30 13:26:20.000000000 +0900
++++ uim-1.8.6/qt4/immodule/quiminputcontextplugin.pro.in	2014-03-09 11:31:19.388085048 +0900
+@@ -35,4 +35,4 @@
+ 
+ TARGET = uiminputcontextplugin
+ 
+-target.path += @DESTDIR@$$[QT_INSTALL_PLUGINS]/inputmethods
++target.path += @DESTDIR@@exec_prefix@/lib/qt4/plugins/inputmethods

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2210,6 +2210,13 @@ let
 
   ttmkfdir = callPackage ../tools/misc/ttmkfdir { };
 
+  uim = callPackage ../tools/inputmethods/uim {
+    inherit (pkgs.kde4) kdelibs;
+    gtk2 = pkgs.gtk2.override { extraImModules = []; };
+    gtk3 = pkgs.gtk3.override { extraImModules = []; };
+    qt4 = pkgs.qt48.override { extraImModules = []; };
+  };
+
   unclutter = callPackage ../tools/misc/unclutter { };
 
   unbound = callPackage ../tools/networking/unbound { };
@@ -4657,10 +4664,12 @@ let
 
   gtk2 = callPackage ../development/libraries/gtk+/2.x.nix {
     cupsSupport = config.gtk2.cups or stdenv.isLinux;
+    extraImModules = config.gtk2ImModules or [];
   };
 
   gtk3 = callPackage ../development/libraries/gtk+/3.x.nix {
     inherit (gnome3) at_spi2_atk;
+    extraImModules = config.gtk3ImModules or [];
   };
 
   gtk = pkgs.gtk2;
@@ -5721,6 +5730,8 @@ let
     stdenv = if stdenv.isDarwin
       then clangStdenv
       else stdenv;
+
+    extraImModules = config.qtImModules or [];
   };
 
   qt48Full = qt48.override {


### PR DESCRIPTION
UIM is a multilingual input method framework (i.e. programs used to input Japanese, Chinese, Korean, and other complex languages) commonly used in Japan.
This patch adds UIM itself as well as configuration options for input method modules for GTK+ 2, GTK+ 3, and Qt 4. The options tell GTK+ and Qt where shared libraries of input modules are, so that GTK+ and Qt can cooperate with input methods.
Setting `programs.uim.enable = true` in the configuration file installs the UIM and configure GTK+ and Qt. Other input method frameworks such as Fcitx can utilise options `gtk2ImModules`, `gtk3ImModules`, and `qtImModules` to better cooperation with GTK+ and Qt.
