### PR TITLE
MariaDB on OS X

### DIFF
--- a/pkgs/servers/sql/mariadb/my_context_asm.patch
+++ b/pkgs/servers/sql/mariadb/my_context_asm.patch
@@ -1,0 +1,18 @@
+--- a/mysys/my_context.c
++++ b/mysys/my_context.c
+@@ -206,15 +206,6 @@ my_context_spawn(struct my_context *c, void (*f)(void *), void *d)
+     (
+      "movq %%rsp, (%[save])\n\t"
+      "movq %[stack], %%rsp\n\t"
+-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 4 && !defined(__INTEL_COMPILER)
+-     /*
+-       This emits a DWARF DW_CFA_undefined directive to make the return address
+-       undefined. This indicates that this is the top of the stack frame, and
+-       helps tools that use DWARF stack unwinding to obtain stack traces.
+-       (I use numeric constant to avoid a dependency on libdwarf includes).
+-     */
+-     ".cfi_escape 0x07, 16\n\t"
+-#endif
+      "movq %%rbp, 8(%[save])\n\t"
+      "movq %%rbx, 16(%[save])\n\t"
+      "movq %%r12, 24(%[save])\n\t"


### PR DESCRIPTION
With these patches I can build and run MariaDB on OS X.  Most are copied from the mysql5.5 build, but I did have to remove some asm code, otherwise I get the error

```
[ 15%] Building C object mysys/CMakeFiles/mysys.dir/my_context.c.o
.../nix-build-mariadb-10.0.10.drv-1/mariadb-10.0.10/mysys/my_context.c:207:Unknown pseudo-op: .cfi_escape
.../nix-build-mariadb-10.0.10.drv-1/mariadb-10.0.10/mysys/my_context.c:207:Rest of line ignored. 1st junk character valued 48 (0).
make[2]: *** [mysys/CMakeFiles/mysys.dir/my_context.c.o] Error 1
```

I did not investigate fully. Perhaps on OS X a different assembler is used?
