### PR TITLE
More helpful message when refusing to evaluate "broken" package

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -29,6 +29,16 @@ let
 
   allowBroken = config.allowBroken or false || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
 
+  forceEvalHelp = unfreeOrBroken:
+    assert (unfreeOrBroken == "Unfree" || unfreeOrBroken == "Broken");
+    ''
+      You can set
+        { nixpkgs.config.allow${unfreeOrBroken} = true; }
+      in configuration.nix to override this. If you use Nix standalone, you can add
+        { allow${unfreeOrBroken} = true; }
+      to ~/.nixpkgs/config.nix.
+    '';
+
   unsafeGetAttrPos = builtins.unsafeGetAttrPos or (n: as: null);
 
   # The stdenv that we are producing.
@@ -78,25 +88,16 @@ let
         in
         if !allowUnfree && (let l = lib.lists.toList attrs.meta.license or []; in lib.lists.elem "unfree" l || lib.lists.elem "unfree-redistributable" l) && !(allowUnfreePredicate attrs) then
           throw ''
-            Package ‘${attrs.name}’ in ${pos'} has an unfree license, refusing to evaluate. You can set
-              { nixpkgs.config.allowUnfree = true; }
-            in configuration.nix to override this. If you use Nix standalone, you can add
-              { allowUnfree = true; }
-            to ~/.nixpkgs/config.nix.''
+            Package ‘${attrs.name}’ in ${pos'} has an unfree license, refusing to evaluate.
+            ${forceEvalHelp "Unfree"}''
         else if !allowBroken && attrs.meta.broken or false then
           throw ''
-            Package ‘${attrs.name}’ in ${pos'} is marked as broken, refusing to evaluate. You can set
-              { nixpkgs.config.allowBroken = true; }
-            in configuration.nix to override this. If you use Nix standalone, you can add
-              { allowBroken = true; }
-            to ~/.nixpkgs/config.nix.''
+            Package ‘${attrs.name}’ in ${pos'} is marked as broken, refusing to evaluate.
+            ${forceEvalHelp "Broken"}''
         else if !allowBroken && attrs.meta.platforms or null != null && !lib.lists.elem result.system attrs.meta.platforms then
           throw ''
-            Package ‘${attrs.name}’ in ${pos'} is not supported on ‘${result.system}’, refusing to evaluate. You can set
-              { nixpkgs.config.allowBroken = true; }
-            in configuration.nix to override this. If you use Nix standalone, you can add
-              { allowBroken = true; }
-            to ~/.nixpkgs/config.nix.''
+            Package ‘${attrs.name}’ in ${pos'} is not supported on ‘${result.system}’, refusing to evaluate.
+            ${forceEvalHelp "Broken"}''
         else
           lib.addPassthru (derivation (
             (removeAttrs attrs ["meta" "passthru" "crossAttrs"])

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -84,9 +84,19 @@ let
               { allowUnfree = true; }
             to ~/.nixpkgs/config.nix.''
         else if !allowBroken && attrs.meta.broken or false then
-          throw "you can't use package ‘${attrs.name}’ in ${pos'} because it has been marked as broken"
+          throw ''
+            Package ‘${attrs.name}’ in ${pos'} is marked as broken, refusing to evaluate. You can set
+              { nixpkgs.config.allowBroken = true; }
+            in configuration.nix to override this. If you use Nix standalone, you can add
+              { allowBroken = true; }
+            to ~/.nixpkgs/config.nix.''
         else if !allowBroken && attrs.meta.platforms or null != null && !lib.lists.elem result.system attrs.meta.platforms then
-          throw "the package ‘${attrs.name}’ in ${pos'} is not supported on ‘${result.system}’"
+          throw ''
+            Package ‘${attrs.name}’ in ${pos'} is not supported on ‘${result.system}’, refusing to evaluate. You can set
+              { nixpkgs.config.allowBroken = true; }
+            in configuration.nix to override this. If you use Nix standalone, you can add
+              { allowBroken = true; }
+            to ~/.nixpkgs/config.nix.''
         else
           lib.addPassthru (derivation (
             (removeAttrs attrs ["meta" "passthru" "crossAttrs"])


### PR DESCRIPTION
A "broken" package is one where either "meta.broken = true" or build
platform != meta.platforms.
