### PR TITLE
grub: Allow setting the boot root explicitly

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -25,7 +25,7 @@ let
       inherit (cfg)
         version extraConfig extraPerEntryConfig extraEntries
         extraEntriesBeforeNixOS extraPrepareConfig configurationLimit copyKernels timeout
-        default devices;
+        default devices explicitBootRoot;
       path = (makeSearchPath "bin" [
         pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.findutils pkgs.diffutils
       ]) + ":" + (makeSearchPath "sbin" [
@@ -206,6 +206,15 @@ in
         type = types.int;
         description = ''
           Index of the default menu item to be booted.
+        '';
+      };
+
+      explicitBootRoot = mkOption {
+        default = "";
+        type = types.str;
+        description = ''
+          The relative path of /boot within the parent volume. Leave empty
+          if /boot is not a btrfs subvolume.
         '';
       };
 

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -39,6 +39,7 @@ my $configurationLimit = int(get("configurationLimit"));
 my $copyKernels = get("copyKernels") eq "true";
 my $timeout = int(get("timeout"));
 my $defaultEntry = int(get("default"));
+my $explicitBootRoot = get("explicitBootRoot");
 $ENV{'PATH'} = get("path");
 
 die "unsupported GRUB version\n" if $grubVersion != 1 && $grubVersion != 2;
@@ -59,6 +60,10 @@ if (stat("/")->dev != stat("/boot")->dev) {
     $copyKernels = 1;
 } elsif (stat("/boot")->dev != stat("/nix/store")->dev) {
     $copyKernels = 1;
+}
+
+if ($explicitBootRoot ne "") {
+    $bootRoot = $explicitBootRoot;
 }
 
 


### PR DESCRIPTION
If /boot is a btrfs subvolume, it will be on a different device than / but not be
at the root from grub's perspective. This should be fixed in a nicer way by #2449,
but that won't make it into 14.04
