### PR TITLE
nvidia-x11: add nvidia-uvm module which is necessary for blender GPU support

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -20,6 +20,9 @@ buildPhase() {
         sysOut=$(echo $kernel/lib/modules/$kernelVersion/build)
         unset src # used by the nv makefile
         make SYSSRC=$sysSrc SYSOUT=$sysOut module
+        cd uvm
+        make SYSSRC=$sysSrc SYSOUT=$sysOut module
+        cd ..
         cd ..
     fi
 }
@@ -56,6 +59,7 @@ installPhase() {
         # Install the kernel module.
         mkdir -p $out/lib/modules/$kernelVersion/misc
         cp kernel/nvidia.ko $out/lib/modules/$kernelVersion/misc
+        cp kernel/uvm/nvidia-uvm.ko $out/lib/modules/$kernelVersion/misc
 
         # Install the X driver.
         mkdir -p $out/lib/xorg/modules


### PR DESCRIPTION
Added nvidia-uvm.ko, the NVIDIA Unified Memory kernel module, to the NVIDIA Linux driver package. This kernel module provides support for the new Unified Memory feature in an upcoming CUDA release.

http://www.nvidia.com/Download/driverResults.aspx/69372/en-us
