### PR TITLE
ghc: update HEAD version

### DIFF
--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ghc, perl, gmp, ncurses, happy, alex }:
 
 stdenv.mkDerivation rec {
-  version = "7.9.20140313";
+  version = "7.9.20140430";
   name = "ghc-${version}";
 
   src = fetchurl {
-    url = "http://cryp.to/${name}.tar.xz";
-    sha256 = "03i9ajgzlp2y0qq7qnmyji6vdcgx2xnsyrc2zbqbziinf86igwhi";
+    url = http://deb.haskell.org/dailies/2014-05-01/ghc_7.9.20140430.orig.tar.bz2;
+    sha256 = "072c1d71idi7jw711icn1wz4q64laasvb0ii8xvg5mbhi9szbwk4";
   };
 
   buildInputs = [ ghc perl gmp ncurses happy alex ];

--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -413,7 +413,8 @@
   # Reasonably current HEAD snapshot. Should *always* be lowPrio.
   packages_ghcHEAD =
     packages { ghcPath = ../development/compilers/ghc/head.nix;
-               ghcBinary = ghc742Binary;
+               # Use the 7.8.2 package to bootstrap.
+               ghcBinary = pkgs.haskellPackages_ghc782.ghc;
                prefFun = ghcHEADPrefs;
                extraArgs = {
                  happy = pkgs.haskellPackages.happy_1_19_2;


### PR DESCRIPTION
Closes #2428.

Note this does not use the most recent snapshot as that current doesn't build on 32-bit platforms due to upstream commit few hours ago.

Using 7.8.2 to bootstrap allows us to compile HEAD fine, without the compile-time error manifested in #2428. I use the already-packaged 7.8.2 here as I had difficulties trying to install the 7.8.2 binary to follow the pattern of older compilers.
