### PR TITLE
Handbrake 0.9.9

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -91,6 +91,7 @@
   vlstill = "Vladimír Štill <xstill@fi.muni.cz>";
   winden = "Antonio Vargas Gonzalez <windenntw@gmail.com>";
   wizeman = "Ricardo M. Correia <rcorreia@wizy.org>";
+  wmertens = "Wout Mertens <Wout.Mertens@gmail.com>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zef = "Zef Hemel <zef@zef.me>";
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -1,0 +1,99 @@
+# Handbrake normally uses its own copies of the libraries it uses, for better
+# control over library patches.
+#
+# This derivation patches HB so it doesn't do that. The relevant patches
+# are added to the Nix packages and proposed upstream instead. In several cases
+# upstream already incorporated these patches.
+# This has the benefits of providing improvements to other packages,
+# making licenses more clear and reducing compile time/install size.
+#
+# For compliance, the unfree codec faac is optionally spliced out.
+#
+# Only tested on Linux
+#
+# TODO: package and use libappindicator
+
+{ stdenv, config, fetchurl,
+  python, pkgconfig, yasm,
+  autoconf, automake, libtool, m4,
+  libass, libsamplerate, fribidi, libxml2, bzip2,
+  libogg, libtheora, libvorbis, libdvdcss, a52dec, fdk_aac,
+  lame, faac, ffmpeg, libdvdread, libdvdnav, libbluray,
+  mp4v2, mpeg2dec, x264, libmkv,
+  fontconfig, freetype,
+  glib, gtk, webkitgtk, intltool, libnotify,
+  gst_all_1, dbus_glib, udev,
+  useGtk ? true,
+  useWebKitGtk ? false # This prevents ghb from starting in my tests
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.9.9";
+  name = "handbrake-${version}";
+
+  allowUnfree = config.allowUnfree or false;
+
+  buildInputsX = stdenv.lib.optionals useGtk [
+    glib gtk intltool libnotify
+    gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus_glib udev
+  ] ++ stdenv.lib.optionals useWebKitGtk [ webkitgtk ];
+
+  # Did not test compiling with it
+  unfreeInputs = stdenv.lib.optionals allowUnfree [ faac ];
+
+  nativeBuildInputs = [ python pkgconfig yasm autoconf automake libtool m4 ];
+  buildInputs = [
+    fribidi fontconfig freetype
+    libass libsamplerate libxml2 bzip2
+    libogg libtheora libvorbis libdvdcss a52dec libmkv fdk_aac
+    lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264
+  ] ++ buildInputsX ++ unfreeInputs;
+
+  
+  src = fetchurl {
+    name = "HandBrake-${version}.tar.bz2";
+    url = "http://handbrake.fr/rotation.php?file=HandBrake-${version}.tar.bz2";
+    sha256 = "1crmm1c32vx60jfl2bqzg59q4qqx6m83b08snp7h1njc21sdf7d7";
+  };
+
+  patches = stdenv.lib.optionals (! allowUnfree) [ ./disable-unfree.patch ];
+
+  preConfigure = ''
+    # Fake wget to prevent downloads
+    mkdir wget
+    echo "#!/bin/sh" > wget/wget
+    echo "echo ===== Not fetching \$*" >> wget/wget
+    echo "exit 1" >> wget/wget
+    chmod +x wget/wget
+    export PATH=$PATH:$PWD/wget
+
+    # Force using nixpkgs dependencies
+    sed -i '/MODULES += contrib/d' make/include/main.defs
+    sed -i '/PKG_CONFIG_PATH=/d' gtk/module.rules
+
+    # disable faac if non-free
+    if [ -z "$allowUnfree" ]; then
+      rm libhb/encfaac.c
+    fi
+  '';
+
+  configureFlags = "--enable-fdk-aac ${if useGtk then "--disable-gtk-update-checks" else "--disable-gtk"}";
+
+  preBuild = ''
+    cd build
+  '';
+
+  meta = {
+    homepage = http://handbrake.fr/;
+    description = "A tool for ripping DVDs into video files";
+    longDescription = ''
+      Handbrake is a versatile transcoding DVD ripper. This package
+      provides the cli HandbrakeCLI and the GTK+ version ghb.
+      The faac library is disabled if you're compiling free-only.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.wmertens ];
+    # Not tested on anything else
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/video/handbrake/disable-unfree.patch
+++ b/pkgs/applications/video/handbrake/disable-unfree.patch
@@ -1,0 +1,101 @@
+diff -ru HandBrake-0.9.9-orig/gtk/configure.ac HandBrake-0.9.9/gtk/configure.ac
+--- HandBrake-0.9.9-orig/gtk/configure.ac	2014-05-02 22:50:00.047305795 +0200
++++ HandBrake-0.9.9/gtk/configure.ac	2014-05-02 22:48:57.119304020 +0200
+@@ -203,7 +203,7 @@
+     ;;
+ esac
+ 
+-HB_LIBS="-lhb -la52 -lmkv -lavresample -lavformat -lavcodec -lavutil -ldvdnav -ldvdread -lfaac -lmp3lame -lmpeg2 -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lmp4v2 -lswscale -ltheoraenc -ltheoradec -lz -lbz2 -lpthread -lbluray -lass -lfontconfig -lfreetype -lxml2"
++HB_LIBS="-lhb -la52 -lmkv -lavresample -lavformat -lavcodec -lavutil -ldvdnav -ldvdread -lmp3lame -lmpeg2 -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lmp4v2 -lswscale -ltheoraenc -ltheoradec -lz -lbz2 -lpthread -lbluray -lass -lfontconfig -lfreetype -lxml2"
+ 
+ if test "x$use_fdk_aac" = "xyes" ; then
+     HB_LIBS+=" -lfdk-aac"
+diff -ru HandBrake-0.9.9-orig/gtk/src/preset_xlat.c HandBrake-0.9.9/gtk/src/preset_xlat.c
+--- HandBrake-0.9.9-orig/gtk/src/preset_xlat.c	2014-05-02 22:50:00.043305794 +0200
++++ HandBrake-0.9.9/gtk/src/preset_xlat.c	2014-05-02 22:42:20.987292846 +0200
+@@ -260,7 +260,6 @@
+ 
+ static value_map_t acodec_xlat[] =
+ {
+-    {"AAC (faac)", "faac"},
+     {"AC3 Passthru", "ac3"},
+     {"MP3 (lame)", "lame"},
+     {"Vorbis (vorbis)", "vorbis"},
+diff -ru HandBrake-0.9.9-orig/gtk/src/presets.c HandBrake-0.9.9/gtk/src/presets.c
+--- HandBrake-0.9.9-orig/gtk/src/presets.c	2014-05-02 22:50:00.043305794 +0200
++++ HandBrake-0.9.9/gtk/src/presets.c	2014-05-02 22:42:41.283293419 +0200
+@@ -2029,8 +2029,6 @@
+ 
+ static value_map_t acodec_xlat_compat[] =
+ {
+-    {"AAC (CoreAudio)", "faac"},
+-    {"HE-AAC (CoreAudio)", "faac"},
+     {"AC3 (ffmpeg)", "ac3"},
+     {"AC3", "ac3"},
+     {"MP3 Passthru", "mp3pass"},
+diff -ru HandBrake-0.9.9-orig/libhb/common.c HandBrake-0.9.9/libhb/common.c
+--- HandBrake-0.9.9-orig/libhb/common.c	2014-05-02 22:50:00.047305795 +0200
++++ HandBrake-0.9.9/libhb/common.c	2014-05-02 22:37:24.679284489 +0200
+@@ -126,7 +126,6 @@
+     { "AAC (CoreAudio)",    "ca_aac",     HB_ACODEC_CA_AAC,       HB_MUX_MP4|HB_MUX_MKV },
+     { "HE-AAC (CoreAudio)", "ca_haac",    HB_ACODEC_CA_HAAC,      HB_MUX_MP4|HB_MUX_MKV },
+ #endif
+-    { "AAC (faac)",         "faac",       HB_ACODEC_FAAC,         HB_MUX_MP4|HB_MUX_MKV },
+ #ifdef USE_FDK_AAC
+     { "AAC (FDK)",          "fdk_aac",    HB_ACODEC_FDK_AAC,      HB_MUX_MP4|HB_MUX_MKV },
+     { "HE-AAC (FDK)",       "fdk_haac",   HB_ACODEC_FDK_HAAC,     HB_MUX_MP4|HB_MUX_MKV },
+diff -ru HandBrake-0.9.9-orig/libhb/common.h HandBrake-0.9.9/libhb/common.h
+--- HandBrake-0.9.9-orig/libhb/common.h	2014-05-02 22:50:00.047305795 +0200
++++ HandBrake-0.9.9/libhb/common.h	2014-05-02 22:39:37.839288245 +0200
+@@ -945,7 +945,6 @@
+ extern hb_work_object_t hb_decavcodeca;
+ extern hb_work_object_t hb_decavcodecv;
+ extern hb_work_object_t hb_declpcm;
+-extern hb_work_object_t hb_encfaac;
+ extern hb_work_object_t hb_enclame;
+ extern hb_work_object_t hb_encvorbis;
+ extern hb_work_object_t hb_muxer;
+diff -ru HandBrake-0.9.9-orig/libhb/hb.c HandBrake-0.9.9/libhb/hb.c
+--- HandBrake-0.9.9-orig/libhb/hb.c	2014-05-02 22:50:00.047305795 +0200
++++ HandBrake-0.9.9/libhb/hb.c	2014-05-02 22:39:02.287287242 +0200
+@@ -487,7 +487,6 @@
+ 	hb_register( &hb_decavcodeca );
+ 	hb_register( &hb_decavcodecv );
+ 	hb_register( &hb_declpcm );
+-	hb_register( &hb_encfaac );
+ 	hb_register( &hb_enclame );
+ 	hb_register( &hb_encvorbis );
+ 	hb_register( &hb_muxer );
+@@ -588,7 +587,6 @@
+ 	hb_register( &hb_decavcodeca );
+ 	hb_register( &hb_decavcodecv );
+ 	hb_register( &hb_declpcm );
+-	hb_register( &hb_encfaac );
+ 	hb_register( &hb_enclame );
+ 	hb_register( &hb_encvorbis );
+ 	hb_register( &hb_muxer );
+diff -ru HandBrake-0.9.9-orig/libhb/module.defs HandBrake-0.9.9/libhb/module.defs
+--- HandBrake-0.9.9-orig/libhb/module.defs	2014-05-02 22:50:00.047305795 +0200
++++ HandBrake-0.9.9/libhb/module.defs	2014-05-02 22:39:25.727287903 +0200
+@@ -95,7 +95,7 @@
+ LIBHB.lib = $(LIBHB.build/)hb.lib
+ 
+ LIBHB.dll.libs = $(foreach n, \
+-        a52 ass avcodec avformat avutil avresample dvdnav dvdread faac \
++        a52 ass avcodec avformat avutil avresample dvdnav dvdread \
+         fontconfig freetype mkv mpeg2 mp3lame mp4v2 \
+         ogg samplerate swscale theora vorbis vorbisenc x264 xml2 bluray, \
+         $(CONTRIB.build/)lib/lib$(n).a )
+Only in HandBrake-0.9.9: libhb-orig
+diff -ru HandBrake-0.9.9orig/test/module.defs HandBrake-0.9.9/test/module.defs
+--- HandBrake-0.9.9-orig/test/module.defs	2014-05-02 23:15:10.575348401 +0200
++++ HandBrake-0.9.9/test/module.defs	2014-05-02 23:17:00.523351502 +0200
+@@ -14,7 +14,7 @@
+ TEST.libs = $(LIBHB.a)
+ 
+ TEST.GCC.l = \
+-        a52 ass avcodec avformat avutil avresample dvdnav dvdread faac \
++        a52 ass avcodec avformat avutil avresample dvdnav dvdread \
+         fontconfig freetype fribidi mkv mpeg2 mp3lame mp4v2 ogg \
+         samplerate swscale theoraenc theoradec vorbis vorbisenc x264 \
+         bluray xml2 bz2 z

--- a/pkgs/development/libraries/a52dec/A00-a52-state-t-public.patch
+++ b/pkgs/development/libraries/a52dec/A00-a52-state-t-public.patch
@@ -1,0 +1,152 @@
+diff -Naur a52dec.old/include/a52.h a52dec.new/include/a52.h
+--- a52dec.old/include/a52.h	2002-01-28 06:37:54.000000000 +0100
++++ a52dec.new/include/a52.h	2012-07-16 14:13:35.000000000 +0200
+@@ -30,7 +30,71 @@
+ typedef double sample_t;
+ #endif
+ 
+-typedef struct a52_state_s a52_state_t;
++typedef struct {
++    uint8_t bai;              /* fine SNR offset, fast gain */
++    uint8_t deltbae;          /* delta bit allocation exists */
++    int8_t deltba[50];        /* per-band delta bit allocation */
++} ba_t;
++
++typedef struct {
++    uint8_t exp[256];         /* decoded channel exponents */
++    int8_t bap[256];          /* derived channel bit allocation */
++} expbap_t;
++
++typedef struct {
++    uint8_t fscod;            /* sample rate */
++    uint8_t halfrate;         /* halfrate factor */
++    uint8_t acmod;            /* coded channels */
++    uint8_t lfeon;            /* coded lfe channel */
++    sample_t clev;            /* centre channel mix level */
++    sample_t slev;            /* surround channels mix level */
++
++    int output;               /* type of output */
++    sample_t level;           /* output level */
++    sample_t bias;            /* output bias */
++
++    int dynrnge;              /* apply dynamic range */
++    sample_t dynrng;          /* dynamic range */
++    void * dynrngdata;        /* dynamic range callback funtion and data */
++    sample_t (* dynrngcall) (sample_t range, void * dynrngdata);
++
++    uint8_t chincpl;          /* channel coupled */
++    uint8_t phsflginu;        /* phase flags in use (stereo only) */
++    uint8_t cplstrtmant;      /* coupling channel start mantissa */
++    uint8_t cplendmant;       /* coupling channel end mantissa */
++    uint32_t cplbndstrc;      /* coupling band structure */
++    sample_t cplco[5][18];    /* coupling coordinates */
++
++    /* derived information */
++    uint8_t cplstrtbnd;       /* coupling start band (for bit allocation) */
++    uint8_t ncplbnd;          /* number of coupling bands */
++
++    uint8_t rematflg;         /* stereo rematrixing */
++
++    uint8_t endmant[5];       /* channel end mantissa */
++
++    uint16_t bai;             /* bit allocation information */
++
++    uint32_t * buffer_start;
++    uint16_t lfsr_state;      /* dither state */
++    uint32_t bits_left;
++    uint32_t current_word;
++
++    uint8_t csnroffst;        /* coarse SNR offset */
++    ba_t cplba;               /* coupling bit allocation parameters */
++    ba_t ba[5];               /* channel bit allocation parameters */
++    ba_t lfeba;               /* lfe bit allocation parameters */
++
++    uint8_t cplfleak;         /* coupling fast leak init */
++    uint8_t cplsleak;         /* coupling slow leak init */
++
++    expbap_t cpl_expbap;
++    expbap_t fbw_expbap[5];
++    expbap_t lfe_expbap;
++
++    sample_t * samples;
++    int downmixed;
++} a52_state_t;
+ 
+ #define A52_CHANNEL 0
+ #define A52_MONO 1
+diff -Naur a52dec.old/liba52/a52_internal.h a52dec.new/liba52/a52_internal.h
+--- a52dec.old/liba52/a52_internal.h	2002-07-28 03:52:06.000000000 +0200
++++ a52dec.new/liba52/a52_internal.h	2012-07-16 14:11:47.000000000 +0200
+@@ -21,72 +21,6 @@
+  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  */
+ 
+-typedef struct {
+-    uint8_t bai;		/* fine SNR offset, fast gain */
+-    uint8_t deltbae;		/* delta bit allocation exists */
+-    int8_t deltba[50];		/* per-band delta bit allocation */
+-} ba_t;
+-
+-typedef struct {
+-    uint8_t exp[256];		/* decoded channel exponents */
+-    int8_t bap[256];		/* derived channel bit allocation */
+-} expbap_t;
+-
+-struct a52_state_s {
+-    uint8_t fscod;		/* sample rate */
+-    uint8_t halfrate;		/* halfrate factor */
+-    uint8_t acmod;		/* coded channels */
+-    uint8_t lfeon;		/* coded lfe channel */
+-    sample_t clev;		/* centre channel mix level */
+-    sample_t slev;		/* surround channels mix level */
+-
+-    int output;			/* type of output */
+-    sample_t level;		/* output level */
+-    sample_t bias;		/* output bias */
+-
+-    int dynrnge;		/* apply dynamic range */
+-    sample_t dynrng;		/* dynamic range */
+-    void * dynrngdata;		/* dynamic range callback funtion and data */
+-    sample_t (* dynrngcall) (sample_t range, void * dynrngdata);
+-
+-    uint8_t chincpl;		/* channel coupled */
+-    uint8_t phsflginu;		/* phase flags in use (stereo only) */
+-    uint8_t cplstrtmant;	/* coupling channel start mantissa */
+-    uint8_t cplendmant;		/* coupling channel end mantissa */
+-    uint32_t cplbndstrc;	/* coupling band structure */
+-    sample_t cplco[5][18];	/* coupling coordinates */
+-
+-    /* derived information */
+-    uint8_t cplstrtbnd;		/* coupling start band (for bit allocation) */
+-    uint8_t ncplbnd;		/* number of coupling bands */
+-
+-    uint8_t rematflg;		/* stereo rematrixing */
+-
+-    uint8_t endmant[5];		/* channel end mantissa */
+-
+-    uint16_t bai;		/* bit allocation information */
+-
+-    uint32_t * buffer_start;
+-    uint16_t lfsr_state;	/* dither state */
+-    uint32_t bits_left;
+-    uint32_t current_word;
+-
+-    uint8_t csnroffst;		/* coarse SNR offset */
+-    ba_t cplba;			/* coupling bit allocation parameters */
+-    ba_t ba[5];			/* channel bit allocation parameters */
+-    ba_t lfeba;			/* lfe bit allocation parameters */
+-
+-    uint8_t cplfleak;		/* coupling fast leak init */
+-    uint8_t cplsleak;		/* coupling slow leak init */
+-
+-    expbap_t cpl_expbap;
+-    expbap_t fbw_expbap[5];
+-    expbap_t lfe_expbap;
+-
+-    sample_t * samples;
+-    int downmixed;
+-};
+-
+ #define LEVEL_PLUS6DB 2.0
+ #define LEVEL_PLUS3DB 1.4142135623730951
+ #define LEVEL_3DB 0.7071067811865476

--- a/pkgs/development/libraries/a52dec/A01-thread-safe.patch
+++ b/pkgs/development/libraries/a52dec/A01-thread-safe.patch
@@ -1,0 +1,462 @@
+diff -Naur a52dec.old/include/a52.h a52dec.new/include/a52.h
+--- a52dec.old/include/a52.h	2012-07-16 14:24:14.000000000 +0200
++++ a52dec.new/include/a52.h	2012-07-16 14:31:37.000000000 +0200
+@@ -42,6 +42,11 @@
+ } expbap_t;
+ 
+ typedef struct {
++    sample_t real;
++    sample_t imag;
++} complex_t;
++
++typedef struct {
+     uint8_t fscod;            /* sample rate */
+     uint8_t halfrate;         /* halfrate factor */
+     uint8_t acmod;            /* coded channels */
+@@ -94,6 +99,20 @@
+ 
+     sample_t * samples;
+     int downmixed;
++
++    /* Root values for IFFT */
++    sample_t * roots16;           // size 3
++    sample_t * roots32;           // size 7
++    sample_t * roots64;           // size 15
++    sample_t * roots128;          // size 31
++
++    /* Twiddle factors for IMDCT */
++    complex_t * pre1;             // size 128
++    complex_t * post1;            // size 64
++    complex_t * pre2;             // size 64
++    complex_t * post2;            // size 32
++
++    sample_t * a52_imdct_window;  // size 256
+ } a52_state_t;
+ 
+ #define A52_CHANNEL 0
+diff -Naur a52dec.old/liba52/a52_internal.h a52dec.new/liba52/a52_internal.h
+--- a52dec.old/liba52/a52_internal.h	2012-07-16 14:24:14.000000000 +0200
++++ a52dec.new/liba52/a52_internal.h	2012-07-16 14:28:33.000000000 +0200
+@@ -49,6 +49,6 @@
+ 		  sample_t clev, sample_t slev);
+ void a52_upmix (sample_t * samples, int acmod, int output);
+ 
+-void a52_imdct_init (uint32_t mm_accel);
+-void a52_imdct_256 (sample_t * data, sample_t * delay, sample_t bias);
+-void a52_imdct_512 (sample_t * data, sample_t * delay, sample_t bias);
++void a52_imdct_init (a52_state_t * state, uint32_t mm_accel);
++void a52_imdct_256 (a52_state_t * state, sample_t * data, sample_t * delay, sample_t bias);
++void a52_imdct_512 (a52_state_t * state, sample_t * data, sample_t * delay, sample_t bias);
+diff -Naur a52dec.old/liba52/imdct.c a52dec.new/liba52/imdct.c
+--- a52dec.old/liba52/imdct.c	2012-07-16 14:24:14.000000000 +0200
++++ a52dec.new/liba52/imdct.c	2012-07-16 14:33:00.000000000 +0200
+@@ -40,11 +40,6 @@
+ #include "a52_internal.h"
+ #include "mm_accel.h"
+ 
+-typedef struct complex_s {
+-    sample_t real;
+-    sample_t imag;
+-} complex_t;
+-
+ static uint8_t fftorder[] = {
+       0,128, 64,192, 32,160,224, 96, 16,144, 80,208,240,112, 48,176,
+       8,136, 72,200, 40,168,232,104,248,120, 56,184, 24,152,216, 88,
+@@ -56,22 +51,8 @@
+       6,134, 70,198, 38,166,230,102,246,118, 54,182, 22,150,214, 86
+ };
+ 
+-/* Root values for IFFT */
+-static sample_t roots16[3];
+-static sample_t roots32[7];
+-static sample_t roots64[15];
+-static sample_t roots128[31];
+-
+-/* Twiddle factors for IMDCT */
+-static complex_t pre1[128];
+-static complex_t post1[64];
+-static complex_t pre2[64];
+-static complex_t post2[32];
+-
+-static sample_t a52_imdct_window[256];
+-
+-static void (* ifft128) (complex_t * buf);
+-static void (* ifft64) (complex_t * buf);
++static void (* ifft128) (a52_state_t * state, complex_t * buf);
++static void (* ifft64) (a52_state_t * state, complex_t * buf);
+ 
+ static inline void ifft2 (complex_t * buf)
+ {
+@@ -167,7 +148,7 @@
+     a1.imag += tmp4;				\
+ } while (0)
+ 
+-static inline void ifft8 (complex_t * buf)
++static inline void ifft8 (a52_state_t * state, complex_t * buf)
+ {
+     double tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8;
+ 
+@@ -175,7 +156,7 @@
+     ifft2 (buf + 4);
+     ifft2 (buf + 6);
+     BUTTERFLY_ZERO (buf[0], buf[2], buf[4], buf[6]);
+-    BUTTERFLY_HALF (buf[1], buf[3], buf[5], buf[7], roots16[1]);
++    BUTTERFLY_HALF (buf[1], buf[3], buf[5], buf[7], state->roots16[1]);
+ }
+ 
+ static void ifft_pass (complex_t * buf, sample_t * weight, int n)
+@@ -205,66 +186,66 @@
+     } while (--i);
+ }
+ 
+-static void ifft16 (complex_t * buf)
++static void ifft16 (a52_state_t * state, complex_t * buf)
+ {
+-    ifft8 (buf);
++    ifft8 (state, buf);
+     ifft4 (buf + 8);
+     ifft4 (buf + 12);
+-    ifft_pass (buf, roots16 - 4, 4);
++    ifft_pass (buf, state->roots16 - 4, 4);
+ }
+ 
+-static void ifft32 (complex_t * buf)
++static void ifft32 (a52_state_t * state, complex_t * buf)
+ {
+-    ifft16 (buf);
+-    ifft8 (buf + 16);
+-    ifft8 (buf + 24);
+-    ifft_pass (buf, roots32 - 8, 8);
++    ifft16 (state, buf);
++    ifft8 (state, buf + 16);
++    ifft8 (state, buf + 24);
++    ifft_pass (buf, state->roots32 - 8, 8);
+ }
+ 
+-static void ifft64_c (complex_t * buf)
++static void ifft64_c (a52_state_t * state, complex_t * buf)
+ {
+-    ifft32 (buf);
+-    ifft16 (buf + 32);
+-    ifft16 (buf + 48);
+-    ifft_pass (buf, roots64 - 16, 16);
++    ifft32 (state, buf);
++    ifft16 (state, buf + 32);
++    ifft16 (state, buf + 48);
++    ifft_pass (buf, state->roots64 - 16, 16);
+ }
+ 
+-static void ifft128_c (complex_t * buf)
++static void ifft128_c (a52_state_t * state, complex_t * buf)
+ {
+-    ifft32 (buf);
+-    ifft16 (buf + 32);
+-    ifft16 (buf + 48);
+-    ifft_pass (buf, roots64 - 16, 16);
++    ifft32 (state, buf);
++    ifft16 (state, buf + 32);
++    ifft16 (state, buf + 48);
++    ifft_pass (buf, state->roots64 - 16, 16);
+ 
+-    ifft32 (buf + 64);
+-    ifft32 (buf + 96);
+-    ifft_pass (buf, roots128 - 32, 32);
++    ifft32 (state, buf + 64);
++    ifft32 (state, buf + 96);
++    ifft_pass (buf, state->roots128 - 32, 32);
+ }
+ 
+-void a52_imdct_512 (sample_t * data, sample_t * delay, sample_t bias)
++void a52_imdct_512 (a52_state_t * state, sample_t * data, sample_t * delay, sample_t bias)
+ {
+     int i, k;
+     sample_t t_r, t_i, a_r, a_i, b_r, b_i, w_1, w_2;
+-    const sample_t * window = a52_imdct_window;
++    const sample_t * window = state->a52_imdct_window;
+     complex_t buf[128];
+ 	
+     for (i = 0; i < 128; i++) {
+ 	k = fftorder[i];
+-	t_r = pre1[i].real;
+-	t_i = pre1[i].imag;
++	t_r = state->pre1[i].real;
++	t_i = state->pre1[i].imag;
+ 
+ 	buf[i].real = t_i * data[255-k] + t_r * data[k];
+ 	buf[i].imag = t_r * data[255-k] - t_i * data[k];
+     }
+ 
+-    ifft128 (buf);
++    ifft128 (state, buf);
+ 
+     /* Post IFFT complex multiply plus IFFT complex conjugate*/
+     /* Window and convert to real valued signal */
+     for (i = 0; i < 64; i++) {
+ 	/* y[n] = z[n] * (xcos1[n] + j * xsin1[n]) ; */
+-	t_r = post1[i].real;
+-	t_i = post1[i].imag;
++	t_r = state->post1[i].real;
++	t_i = state->post1[i].imag;
+ 
+ 	a_r = t_r * buf[i].real     + t_i * buf[i].imag;
+ 	a_i = t_i * buf[i].real     - t_r * buf[i].imag;
+@@ -285,18 +266,18 @@
+     }
+ }
+ 
+-void a52_imdct_256(sample_t * data, sample_t * delay, sample_t bias)
++void a52_imdct_256(a52_state_t * state, sample_t * data, sample_t * delay, sample_t bias)
+ {
+     int i, k;
+     sample_t t_r, t_i, a_r, a_i, b_r, b_i, c_r, c_i, d_r, d_i, w_1, w_2;
+-    const sample_t * window = a52_imdct_window;
++    const sample_t * window = state->a52_imdct_window;
+     complex_t buf1[64], buf2[64];
+ 
+     /* Pre IFFT complex multiply plus IFFT cmplx conjugate */
+     for (i = 0; i < 64; i++) {
+ 	k = fftorder[i];
+-	t_r = pre2[i].real;
+-	t_i = pre2[i].imag;
++	t_r = state->pre2[i].real;
++	t_i = state->pre2[i].imag;
+ 
+ 	buf1[i].real = t_i * data[254-k] + t_r * data[k];
+ 	buf1[i].imag = t_r * data[254-k] - t_i * data[k];
+@@ -305,15 +286,15 @@
+ 	buf2[i].imag = t_r * data[255-k] - t_i * data[k+1];
+     }
+ 
+-    ifft64 (buf1);
+-    ifft64 (buf2);
++    ifft64 (state, buf1);
++    ifft64 (state, buf2);
+ 
+     /* Post IFFT complex multiply */
+     /* Window and convert to real valued signal */
+     for (i = 0; i < 32; i++) {
+ 	/* y1[n] = z1[n] * (xcos2[n] + j * xs in2[n]) ; */ 
+-	t_r = post2[i].real;
+-	t_i = post2[i].imag;
++	t_r = state->post2[i].real;
++	t_i = state->post2[i].imag;
+ 
+ 	a_r = t_r * buf1[i].real    + t_i * buf1[i].imag;
+ 	a_i = t_i * buf1[i].real    - t_r * buf1[i].imag;
+@@ -362,7 +343,7 @@
+     return bessel;
+ }
+ 
+-void a52_imdct_init (uint32_t mm_accel)
++void a52_imdct_init (a52_state_t * state, uint32_t mm_accel)
+ {
+     int i, k;
+     double sum;
+@@ -371,50 +352,50 @@
+     sum = 0;
+     for (i = 0; i < 256; i++) {
+ 	sum += besselI0 (i * (256 - i) * (5 * M_PI / 256) * (5 * M_PI / 256));
+-	a52_imdct_window[i] = sum;
++	state->a52_imdct_window[i] = sum;
+     }
+     sum++;
+     for (i = 0; i < 256; i++)
+-	a52_imdct_window[i] = sqrt (a52_imdct_window[i] / sum);
++	state->a52_imdct_window[i] = sqrt (state->a52_imdct_window[i] / sum);
+ 
+     for (i = 0; i < 3; i++)
+-	roots16[i] = cos ((M_PI / 8) * (i + 1));
++	state->roots16[i] = cos ((M_PI / 8) * (i + 1));
+ 
+     for (i = 0; i < 7; i++)
+-	roots32[i] = cos ((M_PI / 16) * (i + 1));
++	state->roots32[i] = cos ((M_PI / 16) * (i + 1));
+ 
+     for (i = 0; i < 15; i++)
+-	roots64[i] = cos ((M_PI / 32) * (i + 1));
++	state->roots64[i] = cos ((M_PI / 32) * (i + 1));
+ 
+     for (i = 0; i < 31; i++)
+-	roots128[i] = cos ((M_PI / 64) * (i + 1));
++	state->roots128[i] = cos ((M_PI / 64) * (i + 1));
+ 
+     for (i = 0; i < 64; i++) {
+ 	k = fftorder[i] / 2 + 64;
+-	pre1[i].real = cos ((M_PI / 256) * (k - 0.25));
+-	pre1[i].imag = sin ((M_PI / 256) * (k - 0.25));
++	state->pre1[i].real = cos ((M_PI / 256) * (k - 0.25));
++	state->pre1[i].imag = sin ((M_PI / 256) * (k - 0.25));
+     }
+ 
+     for (i = 64; i < 128; i++) {
+ 	k = fftorder[i] / 2 + 64;
+-	pre1[i].real = -cos ((M_PI / 256) * (k - 0.25));
+-	pre1[i].imag = -sin ((M_PI / 256) * (k - 0.25));
++	state->pre1[i].real = -cos ((M_PI / 256) * (k - 0.25));
++	state->pre1[i].imag = -sin ((M_PI / 256) * (k - 0.25));
+     }
+ 
+     for (i = 0; i < 64; i++) {
+-	post1[i].real = cos ((M_PI / 256) * (i + 0.5));
+-	post1[i].imag = sin ((M_PI / 256) * (i + 0.5));
++	state->post1[i].real = cos ((M_PI / 256) * (i + 0.5));
++	state->post1[i].imag = sin ((M_PI / 256) * (i + 0.5));
+     }
+ 
+     for (i = 0; i < 64; i++) {
+ 	k = fftorder[i] / 4;
+-	pre2[i].real = cos ((M_PI / 128) * (k - 0.25));
+-	pre2[i].imag = sin ((M_PI / 128) * (k - 0.25));
++	state->pre2[i].real = cos ((M_PI / 128) * (k - 0.25));
++	state->pre2[i].imag = sin ((M_PI / 128) * (k - 0.25));
+     }
+ 
+     for (i = 0; i < 32; i++) {
+-	post2[i].real = cos ((M_PI / 128) * (i + 0.5));
+-	post2[i].imag = sin ((M_PI / 128) * (i + 0.5));
++	state->post2[i].real = cos ((M_PI / 128) * (i + 0.5));
++	state->post2[i].imag = sin ((M_PI / 128) * (i + 0.5));
+     }
+ 
+ #ifdef LIBA52_DJBFFT
+diff -Naur a52dec.old/liba52/parse.c a52dec.new/liba52/parse.c
+--- a52dec.old/liba52/parse.c	2012-07-16 14:24:14.000000000 +0200
++++ a52dec.new/liba52/parse.c	2012-07-16 14:33:00.000000000 +0200
+@@ -56,16 +56,53 @@
+     a52_state_t * state;
+     int i;
+ 
+-    state = malloc (sizeof (a52_state_t));
++    state = calloc (1, sizeof (a52_state_t));
+     if (state == NULL)
+ 	return NULL;
+ 
+     state->samples = memalign (16, 256 * 12 * sizeof (sample_t));
+     if (state->samples == NULL) {
+-	free (state);
+-	return NULL;
++        goto fail;
+     }
+ 
++    /* Root values for IFFT */
++    state->roots16 = memalign (16, 3 * sizeof (sample_t));
++    if (state->roots16 == NULL)
++        goto fail;
++
++    state->roots32 = memalign (16, 7 * sizeof (sample_t));
++    if (state->roots32 == NULL)
++        goto fail;
++
++    state->roots64 = memalign (16, 15 * sizeof (sample_t));
++    if (state->roots64 == NULL)
++        goto fail;
++
++    state->roots128 = memalign (16, 31 * sizeof (sample_t));
++    if (state->roots128 == NULL)
++        goto fail;
++
++    /* Twiddle factors for IMDCT */
++    state->pre1 = memalign (16, 128 * sizeof (complex_t));
++    if (state->pre1 == NULL)
++        goto fail;
++
++    state->post1 = memalign (16, 64 * sizeof (complex_t));
++    if (state->post1 == NULL)
++        goto fail;
++
++    state->pre2 = memalign (16, 64 * sizeof (complex_t));
++    if (state->pre2 == NULL)
++        goto fail;
++
++    state->post2 = memalign (16, 32 * sizeof (complex_t));
++    if (state->post2 == NULL)
++        goto fail;
++
++    state->a52_imdct_window = memalign (16, 256 * sizeof (sample_t));
++    if (state->a52_imdct_window == NULL)
++        goto fail;
++
+     for (i = 0; i < 256 * 12; i++)
+ 	state->samples[i] = 0;
+ 
+@@ -73,9 +110,27 @@
+ 
+     state->lfsr_state = 1;
+ 
+-    a52_imdct_init (mm_accel);
++    a52_imdct_init (state, mm_accel);
+ 
+     return state;
++
++fail:
++    if ( state )
++    {
++        free (state->a52_imdct_window);
++        free (state->post2);
++        free (state->pre2);
++        free (state->post1);
++        free (state->pre1);
++        free (state->roots128);
++        free (state->roots64);
++        free (state->roots32);
++        free (state->roots16);
++        free (state->samples);
++        free (state);
++    }
++    return NULL;
++
+ }
+ 
+ sample_t * a52_samples (a52_state_t * state)
+@@ -825,7 +880,7 @@
+ 		       state->dynrng, 0, 7);
+ 	    for (i = 7; i < 256; i++)
+ 		(samples-256)[i] = 0;
+-	    a52_imdct_512 (samples - 256, samples + 1536 - 256, state->bias);
++	    a52_imdct_512 (state, samples - 256, samples + 1536 - 256, state->bias);
+ 	} else {
+ 	    /* just skip the LFE coefficients */
+ 	    coeff_get (state, samples + 1280, &state->lfe_expbap, &quantizer,
+@@ -854,10 +909,10 @@
+ 
+ 	    if (coeff[i]) {
+ 		if (blksw[i])
+-		    a52_imdct_256 (samples + 256 * i, samples + 1536 + 256 * i,
++		    a52_imdct_256 (state, samples + 256 * i, samples + 1536 + 256 * i,
+ 				   bias);
+ 		else 
+-		    a52_imdct_512 (samples + 256 * i, samples + 1536 + 256 * i,
++		    a52_imdct_512 (state, samples + 256 * i, samples + 1536 + 256 * i,
+ 				   bias);
+ 	    } else {
+ 		int j;
+@@ -883,11 +938,11 @@
+ 
+ 	if (blksw[0])
+ 	    for (i = 0; i < nfchans; i++)
+-		a52_imdct_256 (samples + 256 * i, samples + 1536 + 256 * i,
++		a52_imdct_256 (state, samples + 256 * i, samples + 1536 + 256 * i,
+ 			       state->bias);
+ 	else 
+ 	    for (i = 0; i < nfchans; i++)
+-		a52_imdct_512 (samples + 256 * i, samples + 1536 + 256 * i,
++		a52_imdct_512 (state, samples + 256 * i, samples + 1536 + 256 * i,
+ 			       state->bias);
+     }
+ 
+@@ -896,6 +951,15 @@
+ 
+ void a52_free (a52_state_t * state)
+ {
++    free (state->a52_imdct_window);
++    free (state->post2);
++    free (state->pre2);
++    free (state->post1);
++    free (state->pre1);
++    free (state->roots128);
++    free (state->roots64);
++    free (state->roots32);
++    free (state->roots16);
+     free (state->samples);
+     free (state);
+ }

--- a/pkgs/development/libraries/a52dec/A02-imdct-shutup.patch
+++ b/pkgs/development/libraries/a52dec/A02-imdct-shutup.patch
@@ -1,0 +1,11 @@
+diff -Naur a52dec_original/liba52/imdct.c a52dec_patched/liba52/imdct.c
+--- a52dec.old/liba52/imdct.c	2002-07-28 03:52:07.000000000 +0200
++++ a52dec.new/liba52/imdct.c	2011-07-15 20:29:09.000000000 +0200
+@@ -425,7 +425,6 @@
+     } else
+ #endif
+     {
+-	fprintf (stderr, "No accelerated IMDCT transform found\n");
+ 	ifft128 = ifft128_c;
+ 	ifft64 = ifft64_c;
+     }

--- a/pkgs/development/libraries/a52dec/A03-automake.patch
+++ b/pkgs/development/libraries/a52dec/A03-automake.patch
@@ -1,0 +1,12 @@
+diff -Naur a52dec.orig/configure.in a52dec/configure.in
+--- a52dec.orig/configure.in	2002-07-27 23:50:20.000000000 -0400
++++ a52dec/configure.in	2013-01-28 21:06:27.000000000 -0500
+@@ -6,7 +6,7 @@
+ AC_CONFIG_FILES([Makefile autotools/Makefile include/Makefile test/Makefile
+     doc/Makefile src/Makefile liba52/Makefile libao/Makefile vc++/Makefile])
+ AM_INIT_AUTOMAKE([a52dec],[0.7.4])
+-AM_CONFIG_HEADER(include/config.h)
++AC_CONFIG_HEADER(include/config.h)
+ AM_MAINTAINER_MODE
+ AC_CANONICAL_HOST
+ 

--- a/pkgs/development/libraries/a52dec/default.nix
+++ b/pkgs/development/libraries/a52dec/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "a52dec-0.7.4";
+  name = "a52dec-0.7.4p4";
   
   src = fetchurl {
     url = "${meta.homepage}/files/a52dec-0.7.4.tar.gz";
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
   };
 
   NIX_CFLAGS_COMPILE = "-fpic";
+
+  # From Handbrake
+  patches = [
+    ./A00-a52-state-t-public.patch
+    ./A01-thread-safe.patch
+    ./A02-imdct-shutup.patch
+    ./A03-automake.patch
+  ];
 
   meta = {
     description = "ATSC A/52 stream decoder";

--- a/pkgs/development/libraries/libbluray/A01-filter-dup.patch
+++ b/pkgs/development/libraries/libbluray/A01-filter-dup.patch
@@ -1,0 +1,80 @@
+diff --git a/src/libbluray/bdnav/navigation.c b/src/libbluray/bdnav/navigation.c
+index c8dc307..26d0000 100644
+--- a/src/libbluray/bdnav/navigation.c
++++ b/src/libbluray/bdnav/navigation.c
+@@ -32,9 +32,25 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++static int _stream_cmp(MPLS_STREAM *a, MPLS_STREAM *b)
++{
++    if (a->stream_type == b->stream_type &&
++        a->coding_type == b->coding_type &&
++        a->pid         == b->pid         &&
++        a->subpath_id  == b->subpath_id  &&
++        a->subclip_id  == b->subclip_id  &&
++        a->format      == b->format      &&
++        a->rate        == b->rate        &&
++        a->char_code   == b->char_code   &&
++        memcmp(a->lang, b->lang, 4) == 0) {
++        return 1;
++    }
++    return 0;
++}
++
+ static int _filter_dup(MPLS_PL *pl_list[], unsigned count, MPLS_PL *pl)
+ {
+-    unsigned ii, jj;
++    unsigned ii, jj, kk;
+ 
+     for (ii = 0; ii < count; ii++) {
+         if (pl->list_count != pl_list[ii]->list_count) {
+@@ -54,7 +70,48 @@ static int _filter_dup(MPLS_PL *pl_list[], unsigned count, MPLS_PL *pl)
+                 pi1->out_time != pi2->out_time) {
+                 break;
+             }
++            if (pi1->stn.num_video           != pi2->stn.num_video           ||
++                pi1->stn.num_audio           != pi2->stn.num_audio           ||
++                pi1->stn.num_pg              != pi2->stn.num_pg              || 
++                pi1->stn.num_ig              != pi2->stn.num_ig              ||
++                pi1->stn.num_secondary_audio != pi2->stn.num_secondary_audio ||
++                pi1->stn.num_secondary_video != pi2->stn.num_secondary_video) {
++                break;
++            }
++            for (kk = 0; kk < pi1->stn.num_video; kk++) {
++                if (!_stream_cmp(&pi1->stn.video[kk], &pi2->stn.video[kk])) {
++                    goto next;
++                }
++            }
++            for (kk = 0; kk < pi1->stn.num_audio; kk++) {
++                if (!_stream_cmp(&pi1->stn.audio[kk], &pi2->stn.audio[kk])) {
++                    goto next;
++                }
++            }
++            for (kk = 0; kk < pi1->stn.num_pg; kk++) {
++                if (!_stream_cmp(&pi1->stn.pg[kk], &pi2->stn.pg[kk])) {
++                    goto next;
++                }
++            }
++            for (kk = 0; kk < pi1->stn.num_ig; kk++) {
++                if (!_stream_cmp(&pi1->stn.ig[kk], &pi2->stn.ig[kk])) {
++                    goto next;
++                }
++            }
++            for (kk = 0; kk < pi1->stn.num_secondary_audio; kk++) {
++                if (!_stream_cmp(&pi1->stn.secondary_audio[kk],
++                                 &pi2->stn.secondary_audio[kk])) {
++                    goto next;
++                }
++            }
++            for (kk = 0; kk < pi1->stn.num_secondary_video; kk++) {
++                if (!_stream_cmp(&pi1->stn.secondary_video[kk],
++                                 &pi2->stn.secondary_video[kk])) {
++                    goto next;
++                }
++            }
+         }
++next:
+         if (jj != pl->list_count) {
+             continue;
+         }

--- a/pkgs/development/libraries/libbluray/default.nix
+++ b/pkgs/development/libraries/libbluray/default.nix
@@ -11,7 +11,7 @@ let baseName = "libbluray";
 in
 
 stdenv.mkDerivation {
-  name = "${baseName}-${version}";
+  name = "${baseName}-${version}p1";
 
   src = fetchgit {
     url = git://git.videolan.org/libbluray.git;
@@ -25,6 +25,9 @@ stdenv.mkDerivation {
 
   preConfigure = "./bootstrap";
   configureFlags = ["--disable-static"] ++ stdenv.lib.optionals withAACS ["--enable-bdjava" "--with-jdk=${jdk}"];
+
+  # From Handbrake
+  patches = [ ./A01-filter-dup.patch ];
 
   meta = {
     homepage = http://www.videolan.org/developers/libbluray.html;

--- a/pkgs/development/libraries/libdvdnav/A08-dvdnav-dup.patch
+++ b/pkgs/development/libraries/libdvdnav/A08-dvdnav-dup.patch
@@ -1,0 +1,137 @@
+Index: src/dvdnav.c
+===================================================================
+--- libdvdnav.orig/src/dvdnav.c	(revision 1168)
++++ libdvdnav/src/dvdnav.c	(working copy)
+@@ -71,6 +71,67 @@
+   return DVDNAV_STATUS_OK;
+ }
+ 
++dvdnav_status_t dvdnav_dup(dvdnav_t **dest, dvdnav_t *src) {
++  dvdnav_t *this;
++
++  (*dest) = NULL;
++  this = (dvdnav_t*)malloc(sizeof(dvdnav_t));
++  if(!this)
++    return DVDNAV_STATUS_ERR;
++
++  memcpy(this, src, sizeof(dvdnav_t));
++  this->file = NULL;
++
++  pthread_mutex_init(&this->vm_lock, NULL);
++
++  this->vm = vm_new_copy(src->vm);
++  if(!this->vm) {
++    printerr("Error initialising the DVD VM.");
++    pthread_mutex_destroy(&this->vm_lock);
++    free(this);
++    return DVDNAV_STATUS_ERR;
++  }
++
++  /* Start the read-ahead cache. */
++  this->cache = dvdnav_read_cache_new(this);
++
++  (*dest) = this;
++  return DVDNAV_STATUS_OK;
++}
++
++dvdnav_status_t dvdnav_free_dup(dvdnav_t *this) {
++
++#ifdef LOG_DEBUG
++  fprintf(MSG_OUT, "libdvdnav: free_dup:called\n");
++#endif
++
++  if (this->file) {
++    pthread_mutex_lock(&this->vm_lock);
++    DVDCloseFile(this->file);
++#ifdef LOG_DEBUG
++    fprintf(MSG_OUT, "libdvdnav: close:file closing\n");
++#endif
++    this->file = NULL;
++    pthread_mutex_unlock(&this->vm_lock);
++  }
++
++  /* Free the VM */
++  if(this->vm)
++    vm_free_copy(this->vm);
++
++  pthread_mutex_destroy(&this->vm_lock);
++
++  /* We leave the final freeing of the entire structure to the cache,
++   * because we don't know, if there are still buffers out in the wild,
++   * that must return first. */
++  if(this->cache)
++    dvdnav_read_cache_free(this->cache);
++  else
++    free(this);
++
++  return DVDNAV_STATUS_OK;
++}
++
+ dvdnav_status_t dvdnav_open(dvdnav_t** dest, const char *path) {
+   dvdnav_t *this;
+   struct timeval time;
+Index: src/dvdnav/dvdnav.h
+===================================================================
+--- libdvdnav.orig/src/dvdnav/dvdnav.h	(revision 1168)
++++ libdvdnav/src/dvdnav.h	(working copy)
+@@ -89,6 +89,9 @@
+  */
+ dvdnav_status_t dvdnav_open(dvdnav_t **dest, const char *path);
+ 
++dvdnav_status_t dvdnav_dup(dvdnav_t **dest, dvdnav_t *src);
++dvdnav_status_t dvdnav_free_dup(dvdnav_t *this);
++
+ /*
+  * Closes a dvdnav_t previously opened with dvdnav_open(), freeing any
+  * memory associated with it.
+Index: src/vm/vm.c
+===================================================================
+--- libdvdnav.orig/src/vm/vm.c	(revision 1168)
++++ libdvdnav/src/vm/vm.c	(working copy)
+@@ -96,6 +98,7 @@
+ 
+ static pgcit_t* get_MENU_PGCIT(vm_t *vm, ifo_handle_t *h, uint16_t lang);
+ static pgcit_t* get_PGCIT(vm_t *vm);
++static void vm_close(vm_t *vm);
+ 
+ 
+ /* Helper functions */
+@@ -262,7 +265,7 @@
+ }
+ 
+ void vm_free_vm(vm_t *vm) {
+-  vm_stop(vm);
++  vm_close(vm);
+   free(vm);
+ }
+ 
+@@ -289,12 +292,20 @@
+ 
+ int vm_start(vm_t *vm) {
+   /* Set pgc to FP (First Play) pgc */
++  if (vm->stopped) {
++    vm_reset(vm, NULL);
++    vm->stopped = 0;
++  }
+   set_FP_PGC(vm);
+   process_command(vm, play_PGC(vm));
+   return !vm->stopped;
+ }
+ 
+ void vm_stop(vm_t *vm) {
++  vm->stopped = 1;
++}
++
++static void vm_close(vm_t *vm) {
+   if(vm->vmgi) {
+     ifoClose(vm->vmgi);
+     vm->vmgi=NULL;
+@@ -346,7 +357,7 @@
+ 
+   if (vm->dvd && dvdroot) {
+     /* a new dvd device has been requested */
+-    vm_stop(vm);
++    vm_close(vm);
+   }
+   if (!vm->dvd) {
+     vm->dvd = DVDOpen(dvdroot);

--- a/pkgs/development/libraries/libdvdnav/P00-mingw-no-examples.patch
+++ b/pkgs/development/libraries/libdvdnav/P00-mingw-no-examples.patch
@@ -1,0 +1,21 @@
+diff -Naur libdvdnav.orig/Makefile.am libdvdnav/Makefile.am
+--- libdvdnav.orig/Makefile.am	2008-10-03 16:11:46.000000000 -0400
++++ libdvdnav/Makefile.am	2009-04-24 02:53:15.000000000 -0400
+@@ -1,7 +1,7 @@
+ include $(top_srcdir)/misc/Makefile.common
+ 
+ 
+-SUBDIRS = src examples doc misc m4
++SUBDIRS = src doc misc m4
+ 
+ EXTRA_DIST = autogen.sh \
+ 	     AUTHORS \
+diff -Naur libdvdnav.orig/configure.ac libdvdnav/configure.ac
+--- libdvdnav.orig/configure.ac	2009-01-08 17:57:11.000000000 -0500
++++ libdvdnav/configure.ac	2009-04-24 02:52:34.000000000 -0400
+@@ -252,5 +252,4 @@
+ misc/relchk.sh
+ m4/Makefile
+ doc/Makefile
+-examples/Makefile
+ ])

--- a/pkgs/development/libraries/libdvdnav/default.nix
+++ b/pkgs/development/libraries/libdvdnav/default.nix
@@ -1,13 +1,14 @@
-{stdenv, fetchurl, libdvdread}:
+{stdenv, fetchurl, pkgconfig, libdvdread}:
 
 stdenv.mkDerivation {
-  name = "libdvdnav-4.1.3";
+  name = "libdvdnav-4.2.1";
   
   src = fetchurl {
-    url = http://www2.mplayerhq.hu/MPlayer/releases/dvdnav/libdvdnav-4.1.3.tar.bz2;
-    sha1 = "d1b95eb8a7caee1fa7580a1abad84d6cb3cad046";
+    url = http://dvdnav.mplayerhq.hu/releases/libdvdnav-4.2.1.tar.xz;
+    sha256 = "7fca272ecc3241b6de41bbbf7ac9a303ba25cb9e0c82aa23901d3104887f2372";
   };
 
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [libdvdread];
 
   configureScript = "./configure2"; # wtf?
@@ -16,9 +17,14 @@ stdenv.mkDerivation {
     mkdir -p $out
   '';
 
+  # From Handbrake
+  patches = [ ./A08-dvdnav-dup.patch ./P00-mingw-no-examples.patch ];
+
   meta = {
-    homepage = http://www.mplayerhq.hu/;
+    homepage = http://dvdnav.mplayerhq.hu/;
     description = "A library that implements DVD navigation features such as DVD menus";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.wmertens ];
   };
 
   passthru = { inherit libdvdread; };

--- a/pkgs/development/libraries/libdvdread/default.nix
+++ b/pkgs/development/libraries/libdvdread/default.nix
@@ -1,29 +1,25 @@
 {stdenv, fetchurl, libdvdcss}:
 
 stdenv.mkDerivation {
-  name = "libdvdread-4.2.1";
+  name = "libdvdread-4.9.9";
   
   src = fetchurl {
-    url = http://dvdnav.mplayerhq.hu/releases/libdvdread-4.2.1.tar.xz;
-    sha256 = "af9b98f049580a6521d56c978b736d3d609562dd12955e11d50e26d97542dcd4";
+    url = http://dvdnav.mplayerhq.hu/releases/libdvdread-4.9.9.tar.xz;
+    sha256 = "d91275471ef69d488b05cf15c60e1cd65e17648bfc692b405787419f47ca424a";
   };
 
   buildInputs = [libdvdcss];
 
   NIX_LDFLAGS = "-ldvdcss";
 
-  configureScript = "./configure2"; # wtf?
-
-  preConfigure = ''
-    mkdir -p $out
-  '';
-
   postInstall = ''
     ln -s dvdread $out/include/libdvdread
   '';
 
   meta = {
-    homepage = http://www.mplayerhq.hu/;
+    homepage = http://dvdnav.mplayerhq.hu/;
     description = "A library for reading DVDs";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.wmertens ];
   };
 }

--- a/pkgs/development/libraries/libmkv/A01-hbmv-pgs.patch
+++ b/pkgs/development/libraries/libmkv/A01-hbmv-pgs.patch
@@ -1,0 +1,12 @@
+diff --git a/include/libmkv.h b/include/libmkv.h
+index 146a91f..f03d608 100644
+--- a/include/libmkv.h
++++ b/include/libmkv.h
+@@ -94,6 +94,7 @@ extern "C" {
+ #define MK_SUBTITLE_USF    "S_TEXT/USF"
+ #define MK_SUBTITLE_VOBSUB "S_VOBSUB"
+ #define MK_SUBTITLE_BMP    "S_IMAGE/BMP"
++#define MK_SUBTITLE_PGS    "S_HDMV/PGS"
+ 
+ /* Official Tags */
+ #define MK_TAG_TITLE		"TITLE"

--- a/pkgs/development/libraries/libmkv/A02-audio-out-sampling-freq.patch
+++ b/pkgs/development/libraries/libmkv/A02-audio-out-sampling-freq.patch
@@ -1,0 +1,28 @@
+diff --git a/include/libmkv.h b/include/libmkv.h
+index 146a91f..f03d608 100644
+--- a/include/libmkv.h
++++ b/include/libmkv.h
+@@ -203,6 +204,7 @@ struct mk_TrackConfig_s {
+ 		} video;
+ 		struct {
+ 			float samplingFreq;	/* Sampling Frequency in Hz */
++			float outputSamplingFreq;	/* Playback Sampling Frequency in Hz (e.g. for AAC w/SBR) */
+ 			unsigned channels;	/* Number of channels for this track */
+ 			unsigned bitDepth;	/* Bits per sample (PCM) */
+ 		} audio;
+diff --git a/src/tracks.c b/src/tracks.c
+index f9c7e48..a2a60ca 100644
+--- a/src/tracks.c
++++ b/src/tracks.c
+@@ -174,6 +174,11 @@ mk_Track *mk_createTrack(mk_Writer *w, mk_TrackConfig *tc)
+ 			/* SamplingFrequency */
+ 			if (mk_writeFloat(v, MATROSKA_ID_AUDIOSAMPLINGFREQ, tc->extra.audio.samplingFreq) < 0)
+ 				return NULL;
++			if (tc->extra.audio.outputSamplingFreq) {
++				/* Output SamplingFrequency */
++				if (mk_writeFloat(v, MATROSKA_ID_AUDIOOUTSAMPLINGFREQ, tc->extra.audio.outputSamplingFreq) < 0)
++					return NULL;
++			}
+ 			/* Channels */
+ 			if (mk_writeUInt(v, MATROSKA_ID_AUDIOCHANNELS, tc->extra.audio.channels) < 0)
+ 				return NULL;

--- a/pkgs/development/libraries/libmkv/P00-mingw-large-file.patch
+++ b/pkgs/development/libraries/libmkv/P00-mingw-large-file.patch
@@ -1,0 +1,24 @@
+--- libmkv.orig/src/matroska.c	2009-01-12 23:14:26.000000000 -0800
++++ libmkv/src/matroska.c	2009-03-25 15:22:30.000000000 -0700
+@@ -27,6 +27,11 @@
+ 
+ #include <sys/time.h>
+ 
++#if defined( __MINGW32__ )
++#undef fseeko
++#define fseeko fseeko64
++#endif
++
+ #define RESERVED_SEEKHEAD 0x100
+ /* 256 bytes should be enough room for our Seek entries. */
+ #define RESERVED_CHAPTERS 0x800
+@@ -34,7 +39,7 @@
+ 
+ int mk_seekFile(mk_Writer *w, uint64_t pos)
+ {
+-	if (fseek(w->fp, pos, SEEK_SET))
++	if (fseeko(w->fp, pos, SEEK_SET))
+ 		return -1;
+ 
+ 	w->f_pos = pos;
+

--- a/pkgs/development/libraries/libmkv/default.nix
+++ b/pkgs/development/libraries/libmkv/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, libtool, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  name = "libmkv-0.6.5.1p2";
+  
+  src = fetchgit {
+    url = https://github.com/saintdev/libmkv.git;
+    rev = "refs/tags/0.6.5.1";
+    sha256 = "1b0441x5rl5dbwrc0hq9jih111iil7ckqws3hcdj63jx2ma3s4hi";
+  };
+
+  nativeBuildInputs = [ libtool autoconf automake ];
+
+  # TODO fix library version
+  preConfigure = "sh bootstrap.sh";
+
+  # From Handbrake
+  patches = [
+    ./A01-hbmv-pgs.patch
+    ./A02-audio-out-sampling-freq.patch
+    ./P00-mingw-large-file.patch
+  ];
+
+  meta = {
+    homepage = https://github.com/saintdev/libmkv;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.wmertens ];
+  };
+}

--- a/pkgs/development/libraries/libmpeg2/A00-tags.patch
+++ b/pkgs/development/libraries/libmpeg2/A00-tags.patch
@@ -1,0 +1,27 @@
+diff -ru mpeg2dec.orig/libmpeg2/decode.c mpeg2dec/libmpeg2/decode.c
+--- mpeg2dec.orig/libmpeg2/decode.c	2008-07-09 12:16:05.000000000 -0700
++++ mpeg2dec/libmpeg2/decode.c	2009-07-03 16:29:48.000000000 -0700
+@@ -212,7 +212,7 @@
+ 
+ mpeg2_state_t mpeg2_parse_header (mpeg2dec_t * mpeg2dec)
+ {
+-    static int (* process_header[]) (mpeg2dec_t * mpeg2dec) = {
++    static int (* process_header[]) (mpeg2dec_t *) = {
+ 	mpeg2_header_picture, mpeg2_header_extension, mpeg2_header_user_data,
+ 	mpeg2_header_sequence, NULL, NULL, NULL, NULL, mpeg2_header_gop
+     };
+@@ -368,6 +368,14 @@
+ 
+ void mpeg2_tag_picture (mpeg2dec_t * mpeg2dec, uint32_t tag, uint32_t tag2)
+ {
++    if (mpeg2dec->num_tags == 0 && mpeg2dec->state == STATE_PICTURE && mpeg2dec->picture) {
++        // since tags got processed when we entered this state we
++        // have to set them directly or they'll end up on the next frame.
++        mpeg2dec->picture->tag = tag;
++        mpeg2dec->picture->tag2 = tag2;
++        mpeg2dec->picture->flags |= PIC_FLAG_TAGS;
++        return;
++    }
+     mpeg2dec->tag_previous = mpeg2dec->tag_current;
+     mpeg2dec->tag2_previous = mpeg2dec->tag2_current;
+     mpeg2dec->tag_current = tag;

--- a/pkgs/development/libraries/libmpeg2/default.nix
+++ b/pkgs/development/libraries/libmpeg2/default.nix
@@ -1,12 +1,17 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libmpeg2-0.5.1";
+  name = "libmpeg2-0.5.1p4";
   
   src = fetchurl {
     url = "http://libmpeg2.sourceforge.net/files/${name}.tar.gz";
     sha256 = "1m3i322n2fwgrvbs1yck7g5md1dbg22bhq5xdqmjpz5m7j4jxqny";
   };
+
+  # From Handbrake - Project seems unmaintained
+  patches = [
+    ./A00-tags.patch
+  ];
 
   meta = {
     homepage = http://libmpeg2.sourceforge.net/;

--- a/pkgs/development/libraries/mp4v2/A00-nero-vobsub.patch
+++ b/pkgs/development/libraries/mp4v2/A00-nero-vobsub.patch
@@ -1,0 +1,142 @@
+diff -Naur mp4v2-trunk-r355/include/mp4v2/general.h mp4v2-trunk-r355/include/mp4v2/general.h
+--- mp4v2-trunk-r355/include/mp4v2/general.h	2009-05-23 06:09:58.000000000 -0700
++++ mp4v2-trunk-r355/include/mp4v2/general.h	2010-05-23 14:22:21.949288657 -0700
+@@ -75,6 +75,7 @@
+ #define MP4_CNTL_TRACK_TYPE     "cntl"  /**< Constant: control track. */
+ #define MP4_TEXT_TRACK_TYPE     "text"  /**< Constant: text track. */
+ #define MP4_SUBTITLE_TRACK_TYPE "sbtl"  /**< Constant: subtitle track. */
++#define MP4_SUBPIC_TRACK_TYPE   "subp"  /**< Constant: subtitle track. */
+ /*
+  * This second set of track types should be created
+  * via MP4AddSystemsTrack(type)
+diff -Naur mp4v2-trunk-r355/include/mp4v2/track.h mp4v2-trunk-r355/include/mp4v2/track.h
+--- mp4v2-trunk-r355/include/mp4v2/track.h	2009-05-23 06:21:49.000000000 -0700
++++ mp4v2-trunk-r355/include/mp4v2/track.h	2010-05-23 15:43:47.249286008 -0700
+@@ -310,6 +310,13 @@
+     uint16_t      height );
+ 
+ MP4V2_EXPORT
++MP4TrackId MP4AddSubpicTrack(
++    MP4FileHandle hFile,
++    uint32_t      timescale,
++    uint16_t      width,
++    uint16_t      height );
++
++MP4V2_EXPORT
+ MP4TrackId MP4AddPixelAspectRatio(
+     MP4FileHandle hFile,
+     MP4TrackId    refTrackId,
+diff -Naur mp4v2-trunk-r355/src/descriptors.h mp4v2-trunk-r355/src/descriptors.h
+--- mp4v2-trunk-r355/src/descriptors.h	2009-05-20 19:52:32.000000000 -0700
++++ mp4v2-trunk-r355/src/descriptors.h	2010-05-23 16:29:34.800935677 -0700
+@@ -119,6 +119,7 @@
+ // ES objectTypeId
+ const uint8_t MP4SystemsV1ObjectType            = 0x01;
+ const uint8_t MP4SystemsV2ObjectType            = 0x02;
++const uint8_t MP4SubpicObjectType               = 0xe0;
+ 
+ // ES streamType
+ const uint8_t MP4ObjectDescriptionStreamType    = 0x01;
+@@ -131,6 +132,7 @@
+ const uint8_t MP4OCIStreamType                  = 0x08;
+ const uint8_t MP4MPEGJStreamType                = 0x09;
+ const uint8_t MP4UserPrivateStreamType          = 0x20;
++const uint8_t MP4NeroSubpicStreamType           = 0x38;
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+ 
+diff -Naur mp4v2-trunk-r355/src/mp4.cpp mp4v2-trunk-r355/src/mp4.cpp
+--- mp4v2-trunk-r355/src/mp4.cpp	2009-05-23 06:29:37.000000000 -0700
++++ mp4v2-trunk-r355/src/mp4.cpp	2010-05-23 15:45:28.852222074 -0700
+@@ -1174,6 +1174,23 @@
+         return MP4_INVALID_TRACK_ID;
+     }
+ 
++    MP4TrackId MP4AddSubpicTrack(MP4FileHandle hFile,
++                                   uint32_t timescale,
++                                   uint16_t width,
++                                   uint16_t height)
++    {
++        if (MP4_IS_VALID_FILE_HANDLE(hFile)) {
++            try {
++                return ((MP4File*)hFile)->AddSubpicTrack(timescale, width, height);
++            }
++            catch (MP4Error* e) {
++                PRINT_ERROR(e);
++                delete e;
++            }
++        }
++        return MP4_INVALID_TRACK_ID;
++    }
++
+     MP4TrackId MP4AddChapterTextTrack(
+         MP4FileHandle hFile, MP4TrackId refTrackId, uint32_t timescale)
+     {
+diff -Naur mp4v2-trunk-r355/src/mp4file.cpp mp4v2-trunk-r355/src/mp4file.cpp
+--- mp4v2-trunk-r355/src/mp4file.cpp	2009-05-26 19:34:56.000000000 -0700
++++ mp4v2-trunk-r355/src/mp4file.cpp	2010-05-23 16:32:52.654220633 -0700
+@@ -2095,6 +2095,50 @@
+     return trackId;
+ }
+ 
++MP4TrackId MP4File::AddSubpicTrack(uint32_t timescale,
++                                     uint16_t width,
++                                     uint16_t height)
++{
++    MP4TrackId trackId =
++        AddTrack(MP4_SUBPIC_TRACK_TYPE, timescale);
++
++    InsertChildAtom(MakeTrackName(trackId, "mdia.minf"), "nmhd", 0);
++
++    (void)AddChildAtom(MakeTrackName(trackId, "mdia.minf.stbl.stsd"), "mp4s");
++
++    SetTrackFloatProperty(trackId, "tkhd.width", width);
++    SetTrackFloatProperty(trackId, "tkhd.height", height);
++    SetTrackIntegerProperty(trackId, "tkhd.layer", 0);
++
++    // stsd is a unique beast in that it has a count of the number
++    // of child atoms that needs to be incremented after we add the mp4s atom
++    MP4Integer32Property* pStsdCountProperty;
++    FindIntegerProperty(
++        MakeTrackName(trackId, "mdia.minf.stbl.stsd.entryCount"),
++        (MP4Property**)&pStsdCountProperty);
++    pStsdCountProperty->IncrementValue();
++
++    SetTrackIntegerProperty(trackId,
++                            "mdia.minf.stbl.stsd.mp4s.esds.ESID",
++#if 0
++                            // note - for a file, these values need to
++                            // be 0 - wmay - 04/16/2003
++                            trackId
++#else
++                            0
++#endif
++                           );
++
++    SetTrackIntegerProperty(trackId,
++                            "mdia.minf.stbl.stsd.mp4s.esds.decConfigDescr.objectTypeId",
++                            MP4SubpicObjectType);
++
++    SetTrackIntegerProperty(trackId,
++                            "mdia.minf.stbl.stsd.mp4s.esds.decConfigDescr.streamType",
++                            MP4NeroSubpicStreamType);
++    return trackId;
++}
++
+ MP4TrackId MP4File::AddChapterTextTrack(MP4TrackId refTrackId, uint32_t timescale)
+ {
+     // validate reference track id
+diff -Naur mp4v2-trunk-r355/src/mp4file.h mp4v2-trunk-r355/src/mp4file.h
+--- mp4v2-trunk-r355/src/mp4file.h	2009-05-23 06:29:37.000000000 -0700
++++ mp4v2-trunk-r355/src/mp4file.h	2010-05-23 15:44:57.568026299 -0700
+@@ -388,6 +388,10 @@
+                                 uint16_t width,
+                                 uint16_t height);
+ 
++    MP4TrackId AddSubpicTrack(uint32_t timescale,
++                                uint16_t width,
++                                uint16_t height);
++
+     MP4TrackId AddPixelAspectRatio(MP4TrackId trackId, uint32_t hSpacing, uint32_t vSpacing);
+     MP4TrackId AddColr(MP4TrackId trackId, uint16_t pri, uint16_t tran, uint16_t mat);
+ 

--- a/pkgs/development/libraries/mp4v2/A01-divide-zero.patch
+++ b/pkgs/development/libraries/mp4v2/A01-divide-zero.patch
@@ -1,0 +1,22 @@
+--- mp4v2-r355/src/mp4track.cpp	2012-01-05 15:44:29.000000000 +0100
++++ mp4v2-r355/src/mp4track.cpp	2012-01-05 15:47:34.000000000 +0100
+@@ -819,13 +819,14 @@
+                 (thisSecStart + timeScale) - lastSampleTime;
+             // calculate the duration of the last sample
+             MP4Duration lastSampleDur = sampleTime - lastSampleTime;
+-            uint32_t overflow_bytes;
+             // now, calculate the number of bytes we overflowed.  Round up.
+-            overflow_bytes =
+-                ((lastSampleSize * overflow_dur) + (lastSampleDur - 1)) / lastSampleDur;
++            if( lastSampleDur > 0 ) {
++                uint32_t overflow_bytes = 0;
++                overflow_bytes = ((lastSampleSize * overflow_dur) + (lastSampleDur - 1)) / lastSampleDur;
+ 
+-            if (bytesThisSec - overflow_bytes > maxBytesPerSec) {
+-                maxBytesPerSec = bytesThisSec - overflow_bytes;
++                if (bytesThisSec - overflow_bytes > maxBytesPerSec) {
++                    maxBytesPerSec = bytesThisSec - overflow_bytes;
++                }
+             }
+ 
+             // now adjust the values for this sample.  Remove the bytes

--- a/pkgs/development/libraries/mp4v2/A02-meaningful-4gb-warning.patch
+++ b/pkgs/development/libraries/mp4v2/A02-meaningful-4gb-warning.patch
@@ -1,0 +1,14 @@
+diff -Naur mp4v2-trunk-r355/src/mp4atom.cpp mp4v2-trunk-r355/src/mp4atom.cpp
+--- mp4v2-trunk-r355/src/mp4atom.cpp	2012-02-21 19:40:03.000000000 +0100
++++ mp4v2-trunk-r355/src/mp4atom.cpp	2012-02-21 19:36:38.000000000 +0100
+@@ -543,6 +543,10 @@
+         m_pFile->SetPosition(m_start + 8);
+         m_pFile->WriteUInt64(m_size);
+     } else {
++        if (!(m_size <= (uint64_t)0xFFFFFFFF)) {
++            // Let the user know what the following assert is all about
++            fprintf(stderr, "MP4ERROR: File size exceeded 4 GB; output unplayable. Enable \"Large file size\" to fix it.\n");
++        }
+         ASSERT(m_size <= (uint64_t)0xFFFFFFFF);
+         m_pFile->SetPosition(m_start);
+         m_pFile->WriteUInt32(m_size);

--- a/pkgs/development/libraries/mp4v2/P00-mingw-dllimport.patch
+++ b/pkgs/development/libraries/mp4v2/P00-mingw-dllimport.patch
@@ -1,0 +1,11 @@
+--- mp4v2-trunk-r355/include/mp4v2/platform.h	2009-05-20 19:52:26.000000000 -0700
++++ xxx/include/mp4v2/platform.h	2010-09-11 09:36:20.881523832 -0700
+@@ -24,7 +24,7 @@
+ #if defined( _WIN32 ) || defined( __MINGW32__ )
+ #   if defined( _WINDLL ) || defined( DLL_EXPORT )
+ #       define MP4V2_EXPORT __declspec(dllexport)
+-#   elif defined( _DLL ) || defined( DLL_IMPORT ) 
++#   elif defined( DLL_IMPORT ) 
+ #       define MP4V2_EXPORT __declspec(dllimport)
+ #   else
+ #       define MP4V2_EXPORT

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -1,13 +1,19 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "mp4v2-1.9.1";
+  name = "mp4v2-1.9.1p4";
 
   src = fetchurl {
     url = "http://mp4v2.googlecode.com/files/${name}.tar.bz2";
     sha256 = "1d73qbi0faqad3bpmjfr4kk0mfmqpl1f43ysrx4gq9i3mfp1qf2w";
   };
 
+  # From Handbrake
+  # mp4v2 doesn't seem to be actively maintained any more :-/
+  patches = [
+    ./A00-nero-vobsub.patch ./A01-divide-zero.patch ./A02-meaningful-4gb-warning.patch
+    ./P00-mingw-dllimport.patch
+  ];
   # `faac' expects `mp4.h'.
   postInstall = "ln -s mp4v2/mp4v2.h $out/include/mp4.h";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5142,6 +5142,8 @@ let
 
   libmilter = callPackage ../development/libraries/libmilter { };
 
+  libmkv = callPackage ../development/libraries/libmkv { };
+
   libmms = callPackage ../development/libraries/libmms { };
 
   libmowgli = callPackage ../development/libraries/libmowgli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8704,6 +8704,8 @@ let
 
   lxdvdrip = callPackage ../applications/video/lxdvdrip { };
 
+  handbrake = callPackage ../applications/video/handbrake { };
+
   lynx = callPackage ../applications/networking/browsers/lynx { };
 
   lyx = callPackage ../applications/misc/lyx { };


### PR DESCRIPTION
This adds handbrake 0.9.9.

Handbrake has the habit of downloading all it dependencies and compiling them itself, with patches. That has been patched out, and the relevant patches were applied to existing packages (and sent upstream where possible). Several packages didn't need the patches any more in newer upstream versions.
Furthermore, the non-free library faac has been spliced off so it is only added when you allowUnfree.
