### PR TITLE
Fix several Haskell expressions to work with GHC 7.8.2

### DIFF
--- a/pkgs/development/libraries/haskell/download-curl/default.nix
+++ b/pkgs/development/libraries/haskell/download-curl/default.nix
@@ -5,6 +5,9 @@ cabal.mkDerivation (self: {
   version = "0.1.4";
   sha256 = "1wf3pf2k4i6jvpfsjlxdj6v53qd33jj1z1ipaf3p47glgx4xw3lm";
   buildDepends = [ curl feed tagsoup xml ];
+  preConfigure = ''
+    sed -i -e 's/0\.13/0.14/' download-curl.cabal
+  '';
   meta = {
     homepage = "http://code.haskell.org/~dons/code/download-curl";
     description = "High-level file download based on URLs";

--- a/pkgs/development/libraries/haskell/ghc-mod/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-mod/default.nix
@@ -31,6 +31,7 @@ cabal.mkDerivation (self: {
     #! ${self.stdenv.shell}
     COMMAND=\$1
     shift
+    export LD_LIBRARY_PATH=$out/lib/ghc-${self.ghc.version}/${self.pname}-${self.version}
     eval exec $out/bin/.ghc-mod-wrapped \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.version} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
     EOF
     chmod +x $out/bin/ghc-mod

--- a/pkgs/development/libraries/haskell/ghc-mod/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-mod/default.nix
@@ -21,11 +21,13 @@ cabal.mkDerivation (self: {
   configureFlags = "--datasubdir=${self.pname}-${self.version}";
   postInstall = ''
     cd $out/share/$pname-$version
+    sed -i -e 's/"-b" "\\n" "-l"/"-l" "-b" "\\"\\\\n\\""/' ghc-process.el
     make
     rm Makefile
     cd ..
     ensureDir "$out/share/emacs"
     mv $pname-$version emacs/site-lisp
+
     mv $out/bin/ghc-mod $out/bin/.ghc-mod-wrapped
     cat - > $out/bin/ghc-mod <<EOF
     #! ${self.stdenv.shell}
@@ -35,6 +37,16 @@ cabal.mkDerivation (self: {
     eval exec $out/bin/.ghc-mod-wrapped \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.version} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
     EOF
     chmod +x $out/bin/ghc-mod
+
+    mv $out/bin/ghc-modi $out/bin/.ghc-modi-wrapped
+    cat - > $out/bin/ghc-modi <<EOF
+    #! ${self.stdenv.shell}
+    COMMAND=\$1
+    shift
+    export LD_LIBRARY_PATH=$out/lib/ghc-${self.ghc.version}/${self.pname}-${self.version}
+    eval exec $out/bin/.ghc-modi-wrapped \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.version} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
+    EOF
+    chmod +x $out/bin/ghc-modi
   '';
   meta = {
     homepage = "http://www.mew.org/~kazu/proj/ghc-mod/";

--- a/pkgs/development/tools/haskell/cabal-bounds/default.nix
+++ b/pkgs/development/tools/haskell/cabal-bounds/default.nix
@@ -14,6 +14,17 @@ cabal.mkDerivation (self: {
   testDepends = [ filepath tasty tastyGolden ];
   jailbreak = true;
   doCheck = false;
+  postInstall = ''
+    mv $out/bin/cabal-bounds $out/bin/.cabal-bounds-wrapped
+    cat - > $out/bin/cabal-bounds <<EOF
+    #! ${self.stdenv.shell}
+    COMMAND=\$1
+    shift
+    export LD_LIBRARY_PATH=$out/lib/ghc-${self.ghc.version}/${self.pname}-${self.version}
+    eval exec $out/bin/.cabal-bounds-wrapped "\$@"
+    EOF
+    chmod +x $out/bin/cabal-bounds
+  '';
   meta = {
     description = "A command line program for managing the bounds/versions of the dependencies in a cabal file";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/development/tools/haskell/hdevtools/default.nix
+++ b/pkgs/development/tools/haskell/hdevtools/default.nix
@@ -7,6 +7,17 @@ cabal.mkDerivation (self: {
   isLibrary = false;
   isExecutable = true;
   buildDepends = [ cmdargs ghcPaths network syb time ];
+  postInstall = ''
+    mv $out/bin/hdevtools $out/bin/.hdevtools-wrapped
+    cat - > $out/bin/hdevtools <<EOF
+    #! ${self.stdenv.shell}
+    COMMAND=\$1
+    shift
+    export LD_LIBRARY_PATH=$out/lib/ghc-${self.ghc.version}/${self.pname}-${self.version}
+    eval exec $out/bin/.hdevtools-wrapped \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.version} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
+    EOF
+    chmod +x $out/bin/hdevtools
+  '';
   meta = {
     homepage = "https://github.com/bitc/hdevtools/";
     description = "Persistent GHC powered background server for FAST haskell development tools";


### PR DESCRIPTION
This is especially important with regard to the new default of dynamically linked libraries and executables.
