### PR TITLE
Add an expression for the "Mac-Port" variant of Emacs on darwin

### DIFF
--- a/pkgs/applications/editors/emacs-24/macport.nix
+++ b/pkgs/applications/editors/emacs-24/macport.nix
@@ -1,0 +1,96 @@
+{ stdenv, fetchurl, ncurses, pkgconfig, texinfo, libxml2, gnutls
+}:
+
+stdenv.mkDerivation rec {
+  emacsName = "emacs-24.3";
+  name = "${emacsName}-mac-4.8";
+
+  src = fetchurl {
+    url = "mirror://gnu/emacs/${emacsName}.tar.xz";
+    sha256 = "1385qzs3bsa52s5rcncbrkxlydkw0ajzrvfxgv8rws5fx512kakh";
+  };
+
+  macportSrc = fetchurl {
+    url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/${name}.tar.gz";
+    sha256 = "194y341zrpjp75mc3099kjc0inr1d379wwsnav257bwsc967h8yx";
+  };
+
+  buildInputs = [ ncurses pkgconfig texinfo libxml2 gnutls ];
+
+  postUnpack = ''
+    mv $emacsName $name
+    tar xzf $macportSrc
+    mv $name $emacsName
+  '';
+
+  preConfigure = ''
+    patch -p0 < patch-mac
+
+    # The search for 'tputs' will fail because it's in ncursesw within the
+    # ncurses package, yet Emacs' configure script only looks in ncurses.
+    # Further, we need to make sure that the -L option occurs before mention
+    # of the library, so that it finds it within the Nix store.
+    sed -i 's/tinfo ncurses/tinfo ncursesw/' configure
+    ncurseslib=$(echo ${ncurses}/lib | sed 's#/#\\/#g')
+    sed -i "s/OLIBS=\$LIBS/OLIBS=\"-L$ncurseslib \$LIBS\"/" configure
+    sed -i 's/LIBS="\$LIBS_TERMCAP \$LIBS"/LIBS="\$LIBS \$LIBS_TERMCAP"/' configure
+
+    configureFlagsArray=(
+      CC=/usr/bin/clang         # jww (2014-04-18): Bad bad bad!
+      LDFLAGS=-L${ncurses}/lib
+      --with-xml2=yes
+      --with-gnutls=yes
+      --with-mac
+      --enable-mac-app=$out/Applications
+    )
+    makeFlagsArray=(
+      CFLAGS=-O3
+      LDFLAGS="-O3 -L${ncurses}/lib"
+    );
+  '';
+
+  #builder = ./builder.sh;
+
+  postInstall = ''
+    cat >$out/share/emacs/site-lisp/site-start.el <<EOF
+    ;; nixos specific load-path
+    (when (getenv "NIX_PROFILES")
+      (setq load-path
+            (append (reverse
+                     (mapcar (lambda (x) (concat x "/share/emacs/site-lisp/"))
+                             (split-string (getenv "NIX_PROFILES"))))
+                    load-path)))
+
+    ;; make tramp work for NixOS machines
+    (eval-after-load 'tramp
+      '(add-to-list 'tramp-remote-path "/run/current-system/sw/bin"))
+    EOF
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "GNU Emacs 24, the extensible, customizable text editor";
+    homepage    = http://www.gnu.org/software/emacs/;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jwiegley ];
+    platforms   = platforms.all;
+
+    longDescription = ''
+      GNU Emacs is an extensible, customizable text editor—and more.  At its
+      core is an interpreter for Emacs Lisp, a dialect of the Lisp
+      programming language with extensions to support text editing.
+
+      The features of GNU Emacs include: content-sensitive editing modes,
+      including syntax coloring, for a wide variety of file types including
+      plain text, source code, and HTML; complete built-in documentation,
+      including a tutorial for new users; full Unicode support for nearly all
+      human languages and their scripts; highly customizable, using Emacs
+      Lisp code or a graphical interface; a large number of extensions that
+      add other functionality, including a project planner, mail and news
+      reader, debugger interface, calendar, and more.  Many of these
+      extensions are distributed with GNU Emacs; others are available
+      separately.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8036,6 +8036,14 @@ let
     withX = false;
   }));
 
+  emacs24Macport = callPackage ../applications/editors/emacs-24/macport.nix {
+    # use clangStdenv on darwin to deal with: unexec: 'my_edata is not in
+    # section __data'
+    stdenv = if stdenv.isDarwin
+      then clangStdenv
+      else stdenv;
+  };
+
   emacsPackages = emacs: self: let callPackage = newScope self; in rec {
     inherit emacs;
 


### PR DESCRIPTION
This is a Carbon Emacs backport, which has several advantages over the stock Cocoa Emacs, mostly in terms of font rendering and subprocess communication speed.
