### PR TITLE
haskell-wreq: disable check phase, it requires network

### DIFF
--- a/pkgs/development/libraries/haskell/wreq/default.nix
+++ b/pkgs/development/libraries/haskell/wreq/default.nix
@@ -17,6 +17,7 @@ cabal.mkDerivation (self: {
     aeson doctest filepath httpClient httpTypes HUnit lens temporary
     testFramework testFrameworkHunit text
   ];
+  doCheck = false;
   meta = {
     homepage = "http://www.serpentine.com/wreq";
     description = "An easy-to-use HTTP client library";


### PR DESCRIPTION
Phases generally do not have access to the internet, so the tests for wreq fail.
