### PR TITLE
async-2.0.1.3: jailbreak (see

### DIFF
--- a/pkgs/development/libraries/haskell/async/2.0.1.3.nix
+++ b/pkgs/development/libraries/haskell/async/2.0.1.3.nix
@@ -6,6 +6,7 @@ cabal.mkDerivation (self: {
   sha256 = "1rbjr6xw5sp8npw17fxg0942kikssv2hyci2sy26r0na98483mkh";
   buildDepends = [ stm ];
   testDepends = [ HUnit testFramework testFrameworkHunit ];
+  jailbreak = true;
   meta = {
     homepage = "https://github.com/simonmar/async";
     description = "Run IO operations asynchronously and wait for their results";


### PR DESCRIPTION
http://hydra.nixos.org/build/10766630/nixlog/1/raw)
