### PR TITLE
haskell-case-insensitive-1.0.0.1: jailbreak

### DIFF
--- a/pkgs/development/libraries/haskell/case-insensitive/1.0.0.1.nix
+++ b/pkgs/development/libraries/haskell/case-insensitive/1.0.0.1.nix
@@ -8,6 +8,7 @@ cabal.mkDerivation (self: {
   sha256 = "1yp8895qvxcmai0hvxdq77qss9cia2f9fyn6rm0hln3rcx8n53xm";
   buildDepends = [ deepseq hashable text ];
   testDepends = [ HUnit testFramework testFrameworkHunit text ];
+  jailbreak = true;
   meta = {
     homepage = "https://github.com/basvandijk/case-insensitive";
     description = "Case insensitive string comparison";


### PR DESCRIPTION
Otherwise, it won't build with the new version text
