### PR TITLE
scala: Bump to 2.11.0, bump 2.10 to 2.10.4

### DIFF
--- a/pkgs/development/compilers/scala/2.10.nix
+++ b/pkgs/development/compilers/scala/2.10.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  name = "scala-2.11.0";
+  name = "scala-2.10.4";
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "00lap31c6rxvg7vipmj0j7f4mv6c58wpfyd3785bxwlhrzmmwgq7";
+    sha256 = "1hqhm1xvd7g78jspvl30zgdzw79xq5zl837h47p6w1n6qlwbcvdl";
   };
 
   buildInputs = [ jre makeWrapper ] ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3211,8 +3211,9 @@ let
   };
 
   scala_2_9 = callPackage ../development/compilers/scala/2.9.nix { };
-  scala_2_10 = callPackage ../development/compilers/scala { };
-  scala = scala_2_10;
+  scala_2_10 = callPackage ../development/compilers/scala/2.10.nix { };
+  scala_2_11 = callPackage ../development/compilers/scala { };
+  scala = scala_2_11;
 
   sdcc = callPackage ../development/compilers/sdcc { };
 


### PR DESCRIPTION
- Make Scala default to 2.11.0 now
- Move the previous 2.10 version into its own file
- Update the 2.10 version to latest (2.10.4).
