### PR TITLE
buildLocalCabal: include cabalInstall to buildDepends to preserve developer experience

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -3096,7 +3096,8 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
       ${self.cabal2nix}/bin/cabal2nix ${src + "/${name}.cabal"} --sha256=FILTERME \
           | grep -v FILTERME | sed \
             -e 's/licenses.proprietary/licenses.unfree/' \
-            -e 's/{ cabal/{ cabal, src/' \
+            -e 's/{ cabal/{ cabal, cabalInstall, src/' \
+            -e 's/buildDepends = \[/buildDepends = \[ cabalInstall/' \
             -e 's/pname = \([^\n]*\)/pname = \1\n  inherit src;\n  jailbreak = true;/'  > $out
       '';
 


### PR DESCRIPTION
This helps developers access current cabal from nix-shell.
