### PR TITLE
nixos: limit size of systemd journal to 256M by default

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -606,7 +606,7 @@ in
     };
 
     services.journald.extraConfig = mkOption {
-      default = "";
+      default = "SystemMaxUse=256M";
       type = types.lines;
       example = "Storage=volatile";
       description = ''


### PR DESCRIPTION
The systemd default is 10% of FS, which is IMHO way too much.
Perhaps that was the reason why a simple look at tail of the logs
took reading hundreds of megabytes (for the single last log message to appear).

I only have negligible server experience -- any comments?
