### PR TITLE
Freetype 2.5.3; please comment

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -8,14 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "0llraqw86jmw4vzv7inskp3xxm2gc64my08iwq5mzncgfdbfza4f";
   };
 
-  infinality_patch = with freetype.infinality; if useInfinality
-    then let subvers = "1";
-      in fetchurl {
-        url = http://www.infinality.net/fedora/linux/zips/fontconfig-infinality-1-20130104_1.tar.bz2;
-        sha256 = "1fm5xx0mx2243jrq5rxk4v0ajw2nawpj23399h710bx6hd1rviq7";
-      }
-    else null;
-
   propagatedBuildInputs = [ freetype ];
   buildInputs = [ pkgconfig expat ];
 
@@ -34,10 +26,6 @@ stdenv.mkDerivation rec {
 
   # Don't try to write to /etc/fonts or /var/cache/fontconfig at install time.
   installFlags = "sysconfdir=$(out)/etc RUN_FC_CACHE_TEST=false fc_cachedir=$(TMPDIR)/dummy";
-
-  postInstall = stdenv.lib.optionalString freetype.infinality.useInfinality ''
-    cd "$out/etc/fonts" && tar xvf ${infinality_patch}
-  '';
 
   meta = with stdenv.lib; {
     description = "A library for font customization and configuration";

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = with stdenv.lib;
     " -fno-strict-aliasing" # from Gentoo, see https://bugzilla.redhat.com/show_bug.cgi?id=506840
+    + " -DTT_CONFIG_OPTION_SUBPIXEL_HINTING=1"
     + optionalString useEncumberedCode " -DFT_CONFIG_OPTION_SUBPIXEL_RENDERING=1";
 
   patches = [ ./enable-validation.patch ]; # from Gentoo

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -3,14 +3,11 @@
   # Microsoft, so it is disabled by default.  This option allows it to
   # be enabled.  See http://www.freetype.org/patents.html.
 , useEncumberedCode ? false
-, useInfinality ? true
 }:
-
-assert !(useEncumberedCode && useInfinality); # probably wouldn't make sense
 
 let
 
-  version = "2.4.12";
+  version = "2.5.3";
 
 in
 
@@ -19,24 +16,16 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/freetype/${name}.tar.bz2";
-    sha256 = "10akr2c37iv9y7fkgwp2szgwjyl2g6qmk9z1m596iaw9cr41g2m7";
+    sha256 = "0pppcn73b5pwd7zdi9yfx16f5i93y18q7q4jmlkwmwrfsllqp160";
   };
-
-  infinality_patch =
-    if useInfinality then fetchurl {
-      url = http://www.infinality.net/fedora/linux/zips/freetype-infinality-2.4.12-20130514_01-x86_64.tar.bz2;
-      sha256 = "1lg2nzvxmwzwdfhxranw8iyflhr72cw9p11rkpgq1scxbp37668m";
-    } else null;
 
   configureFlags = "--disable-static";
 
   NIX_CFLAGS_COMPILE = with stdenv.lib;
     " -fno-strict-aliasing" # from Gentoo, see https://bugzilla.redhat.com/show_bug.cgi?id=506840
-    + optionalString useEncumberedCode " -DFT_CONFIG_OPTION_SUBPIXEL_RENDERING=1"
-    + optionalString useInfinality " -DTT_CONFIG_OPTION_SUBPIXEL_HINTING=1";
+    + optionalString useEncumberedCode " -DFT_CONFIG_OPTION_SUBPIXEL_RENDERING=1";
 
-  patches = [ ./enable-validation.patch ] # from Gentoo
-    ++ stdenv.lib.optional useInfinality [ infinality_patch ];
+  patches = [ ./enable-validation.patch ]; # from Gentoo
 
   # The asm for armel is written with the 'asm' keyword.
   CFLAGS = stdenv.lib.optionalString stdenv.isArm "-std=gnu99";
@@ -59,8 +48,6 @@ stdenv.mkDerivation rec {
     # know why it's on the PATH.
     configureFlags = "--disable-static CC_BUILD=gcc";
   };
-
-  passthru.infinality.useInfinality = useInfinality; # for fontconfig
 
   meta = {
     description = "A font rendering engine";

--- a/pkgs/servers/x11/xorg/libXft_freetype_2.5.3.patch
+++ b/pkgs/servers/x11/xorg/libXft_freetype_2.5.3.patch
@@ -1,0 +1,19 @@
+From macports.  See http://trac.macports.org/ticket/41578
+
+--- a/src/xftglyphs.c.orig	2012-06-02 11:36:35.000000000 -0500
++++ b/src/xftglyphs.c	2013-11-28 01:39:49.000000000 -0600
+@@ -21,10 +21,10 @@
+  */
+ 
+ #include "xftint.h"
+-#include <freetype/ftoutln.h>
+-#include <freetype/ftlcdfil.h>
+-
+-#include <freetype/ftsynth.h>
++#include <ft2build.h>
++#include FT_OUTLINE_H
++#include FT_LCD_FILTER_H
++#include FT_SYNTHESIS_H
+ 
+ /*
+  * Validate the memory info for a font

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -111,6 +111,7 @@ in
   libXft = attrs: attrs // {
     propagatedBuildInputs = [ xorg.libXrender args.freetype args.fontconfig ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
+    patches = [ ./libXft_freetype_2.5.3.patch ];
   };
 
   libXext = attrs: attrs // {


### PR DESCRIPTION
This fixes CVE-2014-2240.  But I'm not sure I understand the implications completely.  Could @vcunat or maybe someone who commented on #2020 comment?

I removed the Infinality patch, because it looks like it hasn't been updated for 2.5.x, and I read that some of the functionality has been merged into freetype.  But I'm not sure if that means they're included in 2.5.3.

Also worrysome: I enabled `-DTT_CONFIG_OPTION_SUBPIXEL_HINTING=1` unconditionally, since it doesn't depend on Infinality any more.  But why isn't it enabled by default?  Does that use patent-encumbered stuff if the Infinality patch isn't applied?

I submitted the pull request mostly because of the CVE :-)  Tested with Firefox; I'll soon test with everything else.
