### PR TITLE
Use `find` instead of cp for installFonts.

### DIFF
--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -545,11 +545,11 @@ let inherit (builtins) head tail trace; in
            mkdir -p $out/share/texmf/fonts/enc/${retrievedName}
            mkdir -p $out/share/texmf/fonts/map/${retrievedName}
 
-        cp *.ttf $out/share/fonts/truetype/public/${retrievedName} || echo No TrueType fonts
-        cp *.otf $out/share/fonts/opentype/public/${retrievedName} || echo No OpenType fonts
-           cp *.{pfm,afm,pfb} $out/share/fonts/type1/public/${retrievedName} || echo No Type1 Fonts
-           cp *.enc $out/share/texmf/fonts/enc/${retrievedName} || echo No fontenc data
-           cp *.map $out/share/texmf/fonts/map/${retrievedName} || echo No fontmap data
+           find -name '*.ttf' -exec cp {} $out/share/fonts/truetype/public/${retrievedName} \;
+           find -name '*.otf' -exec cp {} $out/share/fonts/opentype/public/${retrievedName} \;
+           find -name '*.pfm' -o -name '*.afm' -o -name '*.pfb' -exec cp {} $out/share/fonts/type1/public/${retrievedName} \;
+           find -name '*.enc' -exec cp {} $out/share/texmf/fonts/enc/${retrievedName} \;
+           find -name '*.map' -exec cp {} $out/share/texmf/fonts/map/${retrievedName} \;
    '') ["minInit" "defEnsureDir"];
 
    simplyShare = shareName: fullDepEntry (''


### PR DESCRIPTION
This allows fonts to be installed from anywhere in an unzipped file
rather than having to cd deep into the directory and come back out in
order for e.g. `forceCopy` to work correctly.
