### PR TITLE
nixpkgs: bump pidginsipe a couple years forward

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/sipe/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pidgin, intltool, libxml2 }:
 
-let version = "1.12.0"; in
+let version = "1.18.1"; in
 
 stdenv.mkDerivation {
   name = "pidgin-sipe-${version}";
   
   src = fetchurl {
     url = "mirror://sourceforge/sipe/pidgin-sipe-${version}.tar.gz";
-    sha256 = "12ki6n360v2ja961fzw4mwpgb8jdp9k21y5mbiab151867c862r6";
+    sha256 = "18ch7jpi7ki7xlpahi88xrnmnhc6dcq4hafm0z6d5nfjfp8ldal5";
   };
 
   meta = {


### PR DESCRIPTION
pidgin-sipe failed to build due to deprecation warnings.
The included version is from 2011, a simple bump and updating the sha256 seems to be enough to make it work again (builds locally whereas it previously didn't. Haven't tested the _functionality_ yet, since my server's currently unavailable).
