### PR TITLE
Update xpra to 0.12.5

### DIFF
--- a/pkgs/development/libraries/ffmpeg/2.x.nix
+++ b/pkgs/development/libraries/ffmpeg/2.x.nix
@@ -5,11 +5,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ffmpeg-2.2.1";
+  name = "ffmpeg-2.2.2";
 
   src = fetchurl {
     url = "http://www.ffmpeg.org/releases/${name}.tar.bz2";
-    sha256 = "153kfk8rzrfxx930rrk417b2m695dvy47v4hci3nd49iggx9jzz1";
+    sha256 = "062jn47sm1ifwswcd3lx47nff62rgcwp84964q0v983issnrfax4";
   };
 
   subtitleSupport = config.ffmpeg.subtitle or true;

--- a/pkgs/development/python-modules/pygtk/default.nix
+++ b/pkgs/development/python-modules/pygtk/default.nix
@@ -2,11 +2,11 @@
 , buildPythonPackage, libglade ? null }:
 
 buildPythonPackage rec {
-  name = "pygtk-2.22.0";
+  name = "pygtk-2.24.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/pygtk/2.22/${name}.tar.bz2";
-    sha256 = "4acf0ef2bde8574913c40ee4a43d9c4f43bb77b577b67147271b534501a54cc8";
+    url = "mirror://gnome/sources/pygtk/2.24/${name}.tar.bz2";
+    sha256 = "04k942gn8vl95kwf0qskkv6npclfm31d78ljkrkgyqxxcni1w76d";
   };
 
   buildInputs = [ pkgconfig ]

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -4,7 +4,7 @@
 , ffmpeg, x264, libvpx, pil, libwebp }:
 
 buildPythonPackage rec {
-  name = "xpra-0.9.5";
+  name = "xpra-0.12.5";
   namePrefix = "";
 
   src = fetchurl {


### PR DESCRIPTION
Updates xpra to latest stable release, 0.12.5. This required upgrading pygtk to 2.24.0 to fix a 100% CPU pegging bug while xpra server is running. The update to ffmpeg 2.2.2 is to fix memory leak warnings from xpra.
