### PR TITLE
nixos/stage-1: Change the way we check btrfs filesystems

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -193,6 +193,9 @@ checkFS() {
     # Don't check ROM filesystems.
     if [ "$fsType" = iso9660 -o "$fsType" = udf ]; then return 0; fi
 
+    # Don't check resilient COWs as they validate the fs structures at mount time
+    if [ "$fsType" = btrfs -o "$fsType" = zfs ]; then return 0; fi
+
     # If we couldn't figure out the FS type, then skip fsck.
     if [ "$fsType" = auto ]; then
         echo 'cannot check filesystem with type "auto"!'


### PR DESCRIPTION
Currently, we attempt to fsck btrfs whether the checkJournalingFS option is specified or not. This patch respects that option as btrfs is a journaling filesystem. Additionally, if we are checking btrfs, we should use `btrfs check` instead of the fsck command.
