### PR TITLE
Bump taskwarrior to 2.3.0

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "taskwarrior-${version}";
-  version = "2.2.0";
+  version = "2.3.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "http://www.taskwarrior.org/download/task-${version}.tar.gz";
-    sha256 = "057fh50qp9bd5s08rw51iybpamn55v5nhn3s6ds89g76hp95vqir";
+    sha256 = "0wxcfq0n96vmcbwrlk2x377k8cc5k4i64ca6p02y74g6168ji6ib";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake libuuid ];
 
   meta = {
     description = "GTD (getting things done) implementation";


### PR DESCRIPTION
Needs libuuid, otherwise it builds fine locally
