### PR TITLE
fetchurl: add code to clean changing stuff from patches

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -56,12 +56,14 @@ rec {
   optionalString = cond: string: if cond then string else "";
 
 
-  # Determine whether a filename ends in the given suffix.
-  hasSuffix = ext: fileName:
-    let lenFileName = stringLength fileName;
-        lenExt = stringLength ext;
-    in !(lessThan lenFileName lenExt) &&
-       substring (sub lenFileName lenExt) lenFileName fileName == ext;
+  # Determine whether a string has given prefix/suffix.
+  hasPrefix = pref: str:
+     substring 0 (stringLength pref) str == pref;
+  hasSuffix = suff: str:
+    let lenStr = stringLength str;
+        lenSuff = stringLength suff;
+    in lenStr >= lenSuff &&
+       substring (lenStr - lenSuff) lenStr str == suff;
 
 
   # Convert a string to a list of characters (i.e. singleton strings).

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -157,8 +157,8 @@ rec {
       preLen = stringLength pre;
       sLen = stringLength s;
     in
-      if pre == substring 0 preLen s then
-        substring preLen (sub sLen preLen) s
+      if hasPrefix pre s then
+        substring preLen (sLen - preLen) s
       else
         s;
 

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -1,5 +1,6 @@
 source $stdenv/setup
 
+
 source $mirrorsFile
 
 
@@ -31,6 +32,9 @@ tryDownload() {
 
 finish() {
     stopNest
+
+    eval "$maybeCleanPatch"
+
     exit 0
 }
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -38,6 +38,16 @@ let
     "NIX_CONNECT_TIMEOUT"
   ] ++ (map (site: "NIX_MIRRORS_${site}") sites);
 
+  auto-detected-patch = with stdenv.lib; url:
+    let url2 = removePrefix "http://" (removePrefix "https://" url);
+    in  ( hasPrefix "github.com" url2
+          && (hasSuffix ".diff" url2 || hasSuffix ".patch" url2)
+        ) || (
+          hasPrefix "cgit." url2
+          && ("patch" == (builtins.elemAt (reverseList (splitString "/" url2)) 1))
+                        #^ next-to-last part of the URL is "/patch/"
+        );
+
 in
 
 { # URL to fetch.
@@ -64,6 +74,9 @@ in
 , # If set, don't download the file, but write a list of all possible
   # URLs (resulting from resolving mirror:// URLs) to $out.
   showURLs ? false
+
+  # set for patches to clean useless changing parts, true for github and cgit url
+, cleanPatch ? (auto-detected-patch url)
 }:
 
 assert builtins.isList urls;
@@ -106,4 +119,12 @@ stdenv.mkDerivation {
   # Doing the download on a remote machine just duplicates network
   # traffic, so don't do that.
   preferLocalBuild = true;
+
+  # The following sed commands are a bit crazy, I know
+  maybeCleanPatch = stdenv.lib.optionalString cleanPatch ''
+    echo "Cleaning the patch"
+    sed -e '/^[^-+ @]/d; 0,/^---[ \t]/s/^[^-].*//; /^--[- ]\?$/d; /^$/d' \
+      -e 's/^\(@@[^@]*@@\).*$/\1/; s/^\(\(---\|+++\) [^ \t]*\).*$/\1/' \
+      -i "$out"
+  '';
 }

--- a/pkgs/development/libraries/haskell/HSH/default.nix
+++ b/pkgs/development/libraries/haskell/HSH/default.nix
@@ -11,7 +11,7 @@ cabal.mkDerivation (self: {
   buildDepends = [
     filepath hslogger MissingH mtl regexBase regexCompat regexPosix
   ];
-  patches = [ (fetchurl { url = "https://github.com/jgoerzen/hsh/pull/10.patch"; sha256 = "0fw2ihl4hlncggwf3v4d7aydm3rzgzpcxplfbwq7janysix4q950"; }) ];
+  patches = [ (fetchurl { url = "https://github.com/jgoerzen/hsh/pull/10.patch"; sha256 = "00w2ihl4hlncggwf3v4d7aydm3rzgzpcxplfbwq7janysix4q950"; }) ];
   meta = {
     homepage = "http://software.complete.org/hsh";
     description = "Library to mix shell scripting with Haskell programs";

--- a/pkgs/development/libraries/haskell/gitit/default.nix
+++ b/pkgs/development/libraries/haskell/gitit/default.nix
@@ -20,7 +20,7 @@ cabal.mkDerivation (self: {
   ];
   jailbreak = true;
   patches = [ (fetchurl { url = "https://github.com/jgm/gitit/commit/48155008397bdaed4f97c5678d83c70d4bc3f0ff.patch";
-                          sha256 = "0xdg9frr8lany8ry6vj4vpskmhkpww8jswnb05pzl8a4xfqxh9gd";
+                          sha256 = "16n372wrikwb3g4pb3zljxnp19in0828wp40diqgkplhlnwww6nw";
                         })
             ];
   meta = {

--- a/pkgs/development/tools/haskell/BNFC/default.nix
+++ b/pkgs/development/tools/haskell/BNFC/default.nix
@@ -8,7 +8,7 @@ cabal.mkDerivation (self: {
   isExecutable = true;
   buildDepends = [ mtl ];
   buildTools = [ alex happy ];
-  patches = [ (fetchurl { url = "https://github.com/BNFC/bnfc/pull/3.patch"; sha256 = "103l04ylzswgxrmpv5zy6dd0jyr96z21mdkpgk1z4prvn8wjl624"; }) ];
+  patches = [ (fetchurl { url = "https://github.com/BNFC/bnfc/pull/3.patch"; sha256 = "1i87crwva5m3v095lv3zxs38pr6nmly58krlr6sxpwnakpr0pxsp"; }) ];
   patchFlags = "-p2";
   preConfigure = "runhaskell Setup.lhs clean";
   meta = {

--- a/pkgs/development/tools/parsing/alex/3.0.5.nix
+++ b/pkgs/development/tools/parsing/alex/3.0.5.nix
@@ -8,7 +8,7 @@ cabal.mkDerivation (self: {
   isExecutable = true;
   buildDepends = [ QuickCheck ];
   buildTools = [ perl ];
-  patches = [ (fetchurl { url="https://github.com/simonmar/alex/pull/21.patch"; sha256="0apv3rk00gwkf5rqw3467bg6pnamr07zdksbp9khhzzi73k9aq4f"; }) ];
+  patches = [ (fetchurl { url="http://github.com/simonmar/alex/pull/21.patch"; sha256="050psfwmjlxhyxiy65jsn3v6b9rnfzy8x5q9mmhzwbirqwi0zkfm"; }) ];
   meta = {
     homepage = "http://www.haskell.org/alex/";
     description = "Alex is a tool for generating lexical analysers in Haskell";

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -180,7 +180,7 @@ in
   xf86videonv = attrs: attrs // {
     patches = [( args.fetchurl {
       url = http://cgit.freedesktop.org/xorg/driver/xf86-video-nv/patch/?id=fc78fe98222b0204b8a2872a529763d6fe5048da;
-      sha256 = "0ikbnz6048ygs1qahb6ylnxkyjhfjcqr2gm9bk95ca90v57j7i0f";
+      sha256 = "0i2ddgqwj6cfnk8f4r73kkq3cna7hfnz7k3xj3ifx5v8mfiva6gw";
     })];
   };
 


### PR DESCRIPTION
Applied to github and cgit -looking URLs by default,
as the changes are likely to change the patches within a few months.
For example see #1983 and http://comments.gmane.org/gmane.linux.distributions.nixos/12815

Now I'm getting the same sha256 for github's *.diff and *.patch :-)

I don't think there's anything left now that would be changed by git/cgit updates. Comments welcome!
