### PR TITLE
cppcheck: Build the cfg files

### DIFF
--- a/pkgs/development/tools/analysis/cppcheck/default.nix
+++ b/pkgs/development/tools/analysis/cppcheck/default.nix
@@ -14,7 +14,11 @@ stdenv.mkDerivation {
     sha256 = "0n2hrg99rsp77b3plpip315pyk0x4gh8gljs9z3iwcbcg14mliff";
   };
 
-  configurePhase = "makeFlags=PREFIX=$out";
+  configurePhase = ''
+    makeFlags="PREFIX=$out CFGDIR=$out/cfg"
+  '';
+
+  postInstall = "cp -r cfg $out/cfg";
 
   meta = {
     description = "Check C/C++ code for memory leaks, mismatching allocation-deallocation, buffer overrun and more";


### PR DESCRIPTION
Before that, cppcheck failed.
Failed to load std.cfg. Your Cppcheck installation is broken, please re-install. The Cppcheck binary was compiled without CFGDIR set.

So, make it with CFGDIR and copy cfg files to output.
