### PR TITLE
Rework the knot-tying code for defining Haskell packages.

### DIFF
--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -16,204 +16,204 @@
   # for a particular GHC version.
 
   ghcHEADPrefs =
-    self : self.haskellPlatformArgs_future self // {
+    super : super.haskellPlatformArgs_future super // {
       haskellPlatform = null;
-      extensibleExceptions = self.extensibleExceptions_0_1_1_4;
+      extensibleExceptions = super.extensibleExceptions_0_1_1_4;
       binary_0_7_1_0 = null;
     };
 
   ghc763Prefs =
-    self : self.haskellPlatformArgs_2013_2_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2013_2_0_0;
-      extensibleExceptions = self.extensibleExceptions_0_1_1_4;
+    super : super.haskellPlatformArgs_2013_2_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2013_2_0_0;
+      extensibleExceptions = super.extensibleExceptions_0_1_1_4;
     };
 
   ghc742Prefs =
-    self : self.haskellPlatformArgs_2012_4_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2012_4_0_0;
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+    super : super.haskellPlatformArgs_2012_4_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2012_4_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc741Prefs =
-    self : self.haskellPlatformArgs_2012_2_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2012_2_0_0;
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+    super : super.haskellPlatformArgs_2012_2_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2012_2_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc722Prefs =
-    self : self.haskellPlatformArgs_2012_2_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2012_2_0_0;
-      deepseq = self.deepseq_1_3_0_2;
-      cabalInstall_0_14_0 = self.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; };
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
-      cabalInstall_1_20_0_1 = self.cabalInstall_1_20_0_1.override { HTTP = self.HTTP_4000_2_14; };
-      cabalInstall = self.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      binary = self.binary_0_6_0_0;
-      prettyShow = self.prettyShow_1_2;
-      quickcheckIo = self.quickcheckIo.override {
-        HUnit = self.HUnit_1_2_5_2;
-        QuickCheck = self.QuickCheck2;
+    super : super.haskellPlatformArgs_2012_2_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2012_2_0_0;
+      deepseq = super.deepseq_1_3_0_2;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
+      cabalInstall_1_20_0_1 = super.cabalInstall_1_20_0_1.override { HTTP = super.HTTP_4000_2_14; };
+      cabalInstall = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      binary = super.binary_0_6_0_0;
+      prettyShow = super.prettyShow_1_2;
+      quickcheckIo = super.quickcheckIo.override {
+        HUnit = super.HUnit_1_2_5_2;
+        QuickCheck = super.QuickCheck2;
       };
-      hspecExpectations = self.hspecExpectations.override {
-        HUnit = self.HUnit_1_2_5_2;
+      hspecExpectations = super.hspecExpectations.override {
+        HUnit = super.HUnit_1_2_5_2;
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc721Prefs = ghc722Prefs;
 
   ghc704Prefs =
-    self : self.haskellPlatformArgs_2011_4_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2011_4_0_0;
-      cabalInstall_0_14_0 = self.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; };
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
-      monadPar = self.monadPar_0_1_0_3;
-      jailbreakCabal = self.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      prettyShow = self.prettyShow_1_2;
-      binary = self.binary_0_6_0_0;
-      Cabal_1_18_1_3 = self.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
-      quickcheckIo = self.quickcheckIo.override {
-        HUnit = self.HUnit_1_2_5_2;
-        QuickCheck = self.QuickCheck2;
+    super : super.haskellPlatformArgs_2011_4_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2011_4_0_0;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
+      monadPar = super.monadPar_0_1_0_3;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      prettyShow = super.prettyShow_1_2;
+      binary = super.binary_0_6_0_0;
+      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
+      quickcheckIo = super.quickcheckIo.override {
+        HUnit = super.HUnit_1_2_5_2;
+        QuickCheck = super.QuickCheck2;
       };
-      hspecExpectations = self.hspecExpectations.override {
-        HUnit = self.HUnit_1_2_5_2;
+      hspecExpectations = super.hspecExpectations.override {
+        HUnit = super.HUnit_1_2_5_2;
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc703Prefs =
-    self : self.haskellPlatformArgs_2011_2_0_1 self // {
-      haskellPlatform = self.haskellPlatform_2011_2_0_1;
-      cabalInstall_0_14_0 = self.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; zlib = self.zlib_0_5_3_3; };
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; zlib = self.zlib_0_5_3_3; };
-      monadPar = self.monadPar_0_1_0_3;
-      jailbreakCabal = self.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      prettyShow = self.prettyShow_1_2;
-      binary = self.binary_0_6_0_0;
-      Cabal_1_18_1_3 = self.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
-      quickcheckIo = self.quickcheckIo.override {
-        HUnit = self.HUnit_1_2_5_2;
-        QuickCheck = self.QuickCheck2;
+    super : super.haskellPlatformArgs_2011_2_0_1 super // {
+      haskellPlatform = super.haskellPlatform_2011_2_0_1;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; zlib = super.zlib_0_5_3_3; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; zlib = super.zlib_0_5_3_3; };
+      monadPar = super.monadPar_0_1_0_3;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      prettyShow = super.prettyShow_1_2;
+      binary = super.binary_0_6_0_0;
+      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
+      quickcheckIo = super.quickcheckIo.override {
+        HUnit = super.HUnit_1_2_5_2;
+        QuickCheck = super.QuickCheck2;
       };
-      hspecExpectations = self.hspecExpectations.override {
-        HUnit = self.HUnit_1_2_5_2;
+      hspecExpectations = super.hspecExpectations.override {
+        HUnit = super.HUnit_1_2_5_2;
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc702Prefs = ghc701Prefs;
 
   ghc701Prefs =
-    self : self.haskellPlatformArgs_2011_2_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2011_2_0_0;
-      cabalInstall_0_14_0 = self.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; zlib = self.zlib_0_5_3_3; };
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; zlib = self.zlib_0_5_3_3; };
-      monadPar = self.monadPar_0_1_0_3;
-      jailbreakCabal = self.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      prettyShow = self.prettyShow_1_2;
-      binary = self.binary_0_6_0_0;
-      Cabal_1_18_1_3 = self.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
-      quickcheckIo = self.quickcheckIo.override {
-        HUnit = self.HUnit_1_2_5_2;
-        QuickCheck = self.QuickCheck2;
+    super : super.haskellPlatformArgs_2011_2_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2011_2_0_0;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; zlib = super.zlib_0_5_3_3; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; zlib = super.zlib_0_5_3_3; };
+      monadPar = super.monadPar_0_1_0_3;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      prettyShow = super.prettyShow_1_2;
+      binary = super.binary_0_6_0_0;
+      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
+      quickcheckIo = super.quickcheckIo.override {
+        HUnit = super.HUnit_1_2_5_2;
+        QuickCheck = super.QuickCheck2;
       };
-      hspecExpectations = self.hspecExpectations.override {
-        HUnit = self.HUnit_1_2_5_2;
+      hspecExpectations = super.hspecExpectations.override {
+        HUnit = super.HUnit_1_2_5_2;
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc6123Prefs = ghc6122Prefs;
 
   ghc6122Prefs =
-    self : self.haskellPlatformArgs_2010_2_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2010_2_0_0;
-      mtl1 = self.mtl_1_1_0_2;
-      monadPar = self.monadPar_0_1_0_3;
-      deepseq = self.deepseq_1_1_0_2;
+    super : super.haskellPlatformArgs_2010_2_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2010_2_0_0;
+      mtl1 = super.mtl_1_1_0_2;
+      monadPar = super.monadPar_0_1_0_3;
+      deepseq = super.deepseq_1_1_0_2;
       # deviating from Haskell platform here, to make some packages (notably statistics) compile
-      jailbreakCabal = self.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      binary = self.binary_0_6_0_0;
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override {
-        Cabal = self.Cabal_1_16_0_3; zlib = self.zlib_0_5_3_3;
-        mtl = self.mtl_2_1_2;
-        HTTP = self.HTTP_4000_1_1.override { mtl = self.mtl_2_1_2; };
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      binary = super.binary_0_6_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override {
+        Cabal = super.Cabal_1_16_0_3; zlib = super.zlib_0_5_3_3;
+        mtl = super.mtl_2_1_2;
+        HTTP = super.HTTP_4000_1_1.override { mtl = super.mtl_2_1_2; };
       };
-      quickcheckIo = self.quickcheckIo.override {
-        HUnit = self.HUnit_1_2_5_2;
-        QuickCheck = self.QuickCheck2;
+      quickcheckIo = super.quickcheckIo.override {
+        HUnit = super.HUnit_1_2_5_2;
+        QuickCheck = super.QuickCheck2;
       };
-      hspecExpectations = self.hspecExpectations.override {
-        HUnit = self.HUnit_1_2_5_2;
+      hspecExpectations = super.hspecExpectations.override {
+        HUnit = super.HUnit_1_2_5_2;
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc6121Prefs =
-    self : self.haskellPlatformArgs_2010_1_0_0 self // {
-      haskellPlatform = self.haskellPlatform_2010_1_0_0;
-      mtl1 = self.mtl_1_1_0_2;
-      extensibleExceptions = self.extensibleExceptions_0_1_1_0;
-      deepseq = self.deepseq_1_1_0_2;
-      monadPar = self.monadPar_0_1_0_3;
+    super : super.haskellPlatformArgs_2010_1_0_0 super // {
+      haskellPlatform = super.haskellPlatform_2010_1_0_0;
+      mtl1 = super.mtl_1_1_0_2;
+      extensibleExceptions = super.extensibleExceptions_0_1_1_0;
+      deepseq = super.deepseq_1_1_0_2;
+      monadPar = super.monadPar_0_1_0_3;
       # deviating from Haskell platform here, to make some packages (notably statistics) compile
-      jailbreakCabal = self.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
-      cabal2nix = self.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
-      binary = self.binary_0_6_0_0;
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override {
-        Cabal = self.Cabal_1_16_0_3;
-        zlib = self.zlib_0_5_3_3;
-        mtl = self.mtl_2_1_2;
-        HTTP = self.HTTP_4000_1_1.override { mtl = self.mtl_2_1_2; };
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
+      binary = super.binary_0_6_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override {
+        Cabal = super.Cabal_1_16_0_3;
+        zlib = super.zlib_0_5_3_3;
+        mtl = super.mtl_2_1_2;
+        HTTP = super.HTTP_4000_1_1.override { mtl = super.mtl_2_1_2; };
       };
-      quickcheckIo = self.quickcheckIo.override {
-        HUnit = self.HUnit_1_2_5_2;
-        QuickCheck = self.QuickCheck2;
+      quickcheckIo = super.quickcheckIo.override {
+        HUnit = super.HUnit_1_2_5_2;
+        QuickCheck = super.QuickCheck2;
       };
-      hspecExpectations = self.hspecExpectations.override {
-        HUnit = self.HUnit_1_2_5_2;
+      hspecExpectations = super.hspecExpectations.override {
+        HUnit = super.HUnit_1_2_5_2;
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   ghc6104Prefs =
-    self : self.haskellPlatformArgs_2009_2_0_2 self // {
-      haskellPlatform = self.haskellPlatform_2009_2_0_2;
-      mtl = self.mtl_1_1_0_2;
-      mtl1 = self.mtl_1_1_0_2;
-      extensibleExceptions = self.extensibleExceptions_0_1_1_0;
-      text = self.text_0_11_0_6;
-      deepseq = self.deepseq_1_1_0_2;
-      monadPar = self.monadPar_0_1_0_3;
+    super : super.haskellPlatformArgs_2009_2_0_2 super // {
+      haskellPlatform = super.haskellPlatform_2009_2_0_2;
+      mtl = super.mtl_1_1_0_2;
+      mtl1 = super.mtl_1_1_0_2;
+      extensibleExceptions = super.extensibleExceptions_0_1_1_0;
+      text = super.text_0_11_0_6;
+      deepseq = super.deepseq_1_1_0_2;
+      monadPar = super.monadPar_0_1_0_3;
       # deviating from Haskell platform here, to make some packages (notably statistics) compile
-      jailbreakCabal = self.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
-      binary = self.binary_0_6_0_0;
-      cabalInstall_1_16_0_2 = self.cabalInstall_1_16_0_2.override {
-        Cabal = self.Cabal_1_16_0_3;
-        zlib = self.zlib_0_5_3_3;
-        mtl = self.mtl_2_1_2;
-        HTTP = self.HTTP_4000_1_1.override { mtl = self.mtl_2_1_2; };
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
+      binary = super.binary_0_6_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override {
+        Cabal = super.Cabal_1_16_0_3;
+        zlib = super.zlib_0_5_3_3;
+        mtl = super.mtl_2_1_2;
+        HTTP = super.HTTP_4000_1_1.override { mtl = super.mtl_2_1_2; };
       };
-      haskeline = self.haskeline_0_7_1_1;
-      terminfo = self.terminfo_0_3_2_6;
+      haskeline = super.haskeline_0_7_1_1;
+      terminfo = super.terminfo_0_3_2_6;
     };
 
   # Abstraction for Haskell packages collections
@@ -221,20 +221,22 @@
    ({ ghcPath
     , ghcBinary ? ghc6101Binary
     , prefFun
-    , extraPrefs ? (x : {})
+    , extension ? (self : super : {})
     , profExplicit ? false, profDefault ? false
     , modifyPrio ? lowPrio
     , extraArgs ? {}
     } :
-      import ./haskell-packages.nix {
-        inherit pkgs newScope modifyPrio;
-        prefFun = self : super : self // prefFun super // extraPrefs super;
-        # prefFun = self : super : self;
-        enableLibraryProfiling =
-          if profExplicit then profDefault
-                          else config.cabal.libraryProfiling or profDefault;
-        ghc = callPackage ghcPath ({ ghc = ghcBinary; } // extraArgs);
-      });
+    let haskellPackagesClass = import ./haskell-packages.nix {
+          inherit pkgs newScope modifyPrio;
+          enableLibraryProfiling =
+            if profExplicit then profDefault
+                            else config.cabal.libraryProfiling or profDefault;
+          ghc = callPackage ghcPath ({ ghc = ghcBinary; } // extraArgs);
+        };
+        haskellPackagesPrefsClass = self : let super = haskellPackagesClass self; in super // prefFun super;
+        haskellPackagesExtensionClass = self : let super = haskellPackagesPrefsClass self; in super // extension self super;
+        haskellPackages = haskellPackagesExtensionClass haskellPackages;
+    in haskellPackages);
 
   defaultVersionPrioFun =
     profDefault :

--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -16,204 +16,205 @@
   # for a particular GHC version.
 
   ghcHEADPrefs =
-    super : super.haskellPlatformArgs_future super // {
+    self : super : super.haskellPlatformArgs_future self // {
       haskellPlatform = null;
-      extensibleExceptions = super.extensibleExceptions_0_1_1_4;
+      extensibleExceptions = self.extensibleExceptions_0_1_1_4;
       binary_0_7_1_0 = null;
     };
 
   ghc763Prefs =
-    super : super.haskellPlatformArgs_2013_2_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2013_2_0_0;
-      extensibleExceptions = super.extensibleExceptions_0_1_1_4;
+    self : super : super.haskellPlatformArgs_2013_2_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2013_2_0_0;
+      extensibleExceptions = self.extensibleExceptions_0_1_1_4;
     };
 
   ghc742Prefs =
-    super : super.haskellPlatformArgs_2012_4_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2012_4_0_0;
-      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+    self : super : super.haskellPlatformArgs_2012_4_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2012_4_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc741Prefs =
-    super : super.haskellPlatformArgs_2012_2_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2012_2_0_0;
-      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+    self : super : super.haskellPlatformArgs_2012_2_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2012_2_0_0;
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc722Prefs =
-    super : super.haskellPlatformArgs_2012_2_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2012_2_0_0;
-      deepseq = super.deepseq_1_3_0_2;
-      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; };
-      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
-      cabalInstall_1_20_0_1 = super.cabalInstall_1_20_0_1.override { HTTP = super.HTTP_4000_2_14; };
-      cabalInstall = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      binary = super.binary_0_6_0_0;
-      prettyShow = super.prettyShow_1_2;
+    self : super : super.haskellPlatformArgs_2012_2_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2012_2_0_0;
+      deepseq = self.deepseq_1_3_0_2;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
+      cabalInstall_1_20_0_1 = super.cabalInstall_1_20_0_1.override { HTTP = self.HTTP_4000_2_14; };
+      cabalInstall = super.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      binary = self.binary_0_6_0_0;
+      prettyShow = self.prettyShow_1_2;
       quickcheckIo = super.quickcheckIo.override {
-        HUnit = super.HUnit_1_2_5_2;
-        QuickCheck = super.QuickCheck2;
+        HUnit = self.HUnit_1_2_5_2;
+        QuickCheck = self.QuickCheck2;
       };
       hspecExpectations = super.hspecExpectations.override {
-        HUnit = super.HUnit_1_2_5_2;
+        HUnit = self.HUnit_1_2_5_2;
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc721Prefs = ghc722Prefs;
 
   ghc704Prefs =
-    super : super.haskellPlatformArgs_2011_4_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2011_4_0_0;
-      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; };
-      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; };
-      monadPar = super.monadPar_0_1_0_3;
-      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      prettyShow = super.prettyShow_1_2;
-      binary = super.binary_0_6_0_0;
-      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
+    self : super : super.haskellPlatformArgs_2011_4_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2011_4_0_0;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; };
+      monadPar = self.monadPar_0_1_0_3;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      prettyShow = self.prettyShow_1_2;
+      binary = self.binary_0_6_0_0;
+      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
       quickcheckIo = super.quickcheckIo.override {
-        HUnit = super.HUnit_1_2_5_2;
-        QuickCheck = super.QuickCheck2;
+        HUnit = self.HUnit_1_2_5_2;
+        QuickCheck = self.QuickCheck2;
       };
       hspecExpectations = super.hspecExpectations.override {
-        HUnit = super.HUnit_1_2_5_2;
+        HUnit = self.HUnit_1_2_5_2;
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc703Prefs =
-    super : super.haskellPlatformArgs_2011_2_0_1 super // {
-      haskellPlatform = super.haskellPlatform_2011_2_0_1;
-      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; zlib = super.zlib_0_5_3_3; };
-      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; zlib = super.zlib_0_5_3_3; };
-      monadPar = super.monadPar_0_1_0_3;
-      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      prettyShow = super.prettyShow_1_2;
-      binary = super.binary_0_6_0_0;
-      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
+    self : super : super.haskellPlatformArgs_2011_2_0_1 self // {
+      haskellPlatform = self.haskellPlatform_2011_2_0_1;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; zlib = self.zlib_0_5_3_3; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; zlib = self.zlib_0_5_3_3; };
+      monadPar = self.monadPar_0_1_0_3;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      prettyShow = self.prettyShow_1_2;
+      binary = self.binary_0_6_0_0;
+      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
       quickcheckIo = super.quickcheckIo.override {
-        HUnit = super.HUnit_1_2_5_2;
-        QuickCheck = super.QuickCheck2;
+        HUnit = self.HUnit_1_2_5_2;
+        QuickCheck = self.QuickCheck2;
       };
       hspecExpectations = super.hspecExpectations.override {
-        HUnit = super.HUnit_1_2_5_2;
+        HUnit = self.HUnit_1_2_5_2;
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc702Prefs = ghc701Prefs;
 
   ghc701Prefs =
-    super : super.haskellPlatformArgs_2011_2_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2011_2_0_0;
-      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = super.Cabal_1_14_0; zlib = super.zlib_0_5_3_3; };
-      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = super.Cabal_1_16_0_3; zlib = super.zlib_0_5_3_3; };
-      monadPar = super.monadPar_0_1_0_3;
-      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      prettyShow = super.prettyShow_1_2;
-      binary = super.binary_0_6_0_0;
-      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
+    self : super : super.haskellPlatformArgs_2011_2_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2011_2_0_0;
+      cabalInstall_0_14_0 = super.cabalInstall_0_14_0.override { Cabal = self.Cabal_1_14_0; zlib = self.zlib_0_5_3_3; };
+      cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override { Cabal = self.Cabal_1_16_0_3; zlib = self.zlib_0_5_3_3; };
+      monadPar = self.monadPar_0_1_0_3;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      prettyShow = self.prettyShow_1_2;
+      binary = self.binary_0_6_0_0;
+      Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
       quickcheckIo = super.quickcheckIo.override {
-        HUnit = super.HUnit_1_2_5_2;
-        QuickCheck = super.QuickCheck2;
+        HUnit = self.HUnit_1_2_5_2;
+        QuickCheck = self.QuickCheck2;
       };
       hspecExpectations = super.hspecExpectations.override {
-        HUnit = super.HUnit_1_2_5_2;
+        HUnit = self.HUnit_1_2_5_2;
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc6123Prefs = ghc6122Prefs;
 
   ghc6122Prefs =
-    super : super.haskellPlatformArgs_2010_2_0_0 super // {
+    self : super : super.haskellPlatformArgs_2010_2_0_0 self // {
       haskellPlatform = super.haskellPlatform_2010_2_0_0;
-      mtl1 = super.mtl_1_1_0_2;
-      monadPar = super.monadPar_0_1_0_3;
-      deepseq = super.deepseq_1_1_0_2;
+      mtl1 = self.mtl_1_1_0_2;
+      monadPar = self.monadPar_0_1_0_3;
+      deepseq = self.deepseq_1_1_0_2;
       # deviating from Haskell platform here, to make some packages (notably statistics) compile
-      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      binary = super.binary_0_6_0_0;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      binary = self.binary_0_6_0_0;
       cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override {
-        Cabal = super.Cabal_1_16_0_3; zlib = super.zlib_0_5_3_3;
-        mtl = super.mtl_2_1_2;
-        HTTP = super.HTTP_4000_1_1.override { mtl = super.mtl_2_1_2; };
+        Cabal = self.Cabal_1_16_0_3; 
+        zlib = self.zlib_0_5_3_3;
+        mtl = self.mtl_2_1_2;
+        HTTP = self.HTTP_4000_1_1.override { mtl = self.mtl_2_1_2; };
       };
       quickcheckIo = super.quickcheckIo.override {
-        HUnit = super.HUnit_1_2_5_2;
-        QuickCheck = super.QuickCheck2;
+        HUnit = self.HUnit_1_2_5_2;
+        QuickCheck = self.QuickCheck2;
       };
       hspecExpectations = super.hspecExpectations.override {
-        HUnit = super.HUnit_1_2_5_2;
+        HUnit = self.HUnit_1_2_5_2;
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc6121Prefs =
-    super : super.haskellPlatformArgs_2010_1_0_0 super // {
-      haskellPlatform = super.haskellPlatform_2010_1_0_0;
-      mtl1 = super.mtl_1_1_0_2;
-      extensibleExceptions = super.extensibleExceptions_0_1_1_0;
-      deepseq = super.deepseq_1_1_0_2;
-      monadPar = super.monadPar_0_1_0_3;
+    self : super : super.haskellPlatformArgs_2010_1_0_0 self // {
+      haskellPlatform = self.haskellPlatform_2010_1_0_0;
+      mtl1 = self.mtl_1_1_0_2;
+      extensibleExceptions = self.extensibleExceptions_0_1_1_0;
+      deepseq = self.deepseq_1_1_0_2;
+      monadPar = self.monadPar_0_1_0_3;
       # deviating from Haskell platform here, to make some packages (notably statistics) compile
-      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
-      cabal2nix = super.cabal2nix.override { Cabal = super.Cabal_1_16_0_3; hackageDb = super.hackageDb.override { Cabal = super.Cabal_1_16_0_3; }; };
-      binary = super.binary_0_6_0_0;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
+      cabal2nix = super.cabal2nix.override { Cabal = self.Cabal_1_16_0_3; hackageDb = self.hackageDb.override { Cabal = self.Cabal_1_16_0_3; }; };
+      binary = self.binary_0_6_0_0;
       cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override {
-        Cabal = super.Cabal_1_16_0_3;
-        zlib = super.zlib_0_5_3_3;
-        mtl = super.mtl_2_1_2;
-        HTTP = super.HTTP_4000_1_1.override { mtl = super.mtl_2_1_2; };
+        Cabal = self.Cabal_1_16_0_3;
+        zlib = self.zlib_0_5_3_3;
+        mtl = self.mtl_2_1_2;
+        HTTP = self.HTTP_4000_1_1.override { mtl = self.mtl_2_1_2; };
       };
       quickcheckIo = super.quickcheckIo.override {
-        HUnit = super.HUnit_1_2_5_2;
-        QuickCheck = super.QuickCheck2;
+        HUnit = self.HUnit_1_2_5_2;
+        QuickCheck = self.QuickCheck2;
       };
       hspecExpectations = super.hspecExpectations.override {
-        HUnit = super.HUnit_1_2_5_2;
+        HUnit = self.HUnit_1_2_5_2;
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   ghc6104Prefs =
-    super : super.haskellPlatformArgs_2009_2_0_2 super // {
-      haskellPlatform = super.haskellPlatform_2009_2_0_2;
-      mtl = super.mtl_1_1_0_2;
-      mtl1 = super.mtl_1_1_0_2;
-      extensibleExceptions = super.extensibleExceptions_0_1_1_0;
-      text = super.text_0_11_0_6;
-      deepseq = super.deepseq_1_1_0_2;
-      monadPar = super.monadPar_0_1_0_3;
+    self : super : super.haskellPlatformArgs_2009_2_0_2 self // {
+      haskellPlatform = self.haskellPlatform_2009_2_0_2;
+      mtl = self.mtl1;
+      mtl1 = self.mtl_1_1_0_2;
+      extensibleExceptions = self.extensibleExceptions_0_1_1_0;
+      text = self.text_0_11_0_6;
+      deepseq = self.deepseq_1_1_0_2;
+      monadPar = self.monadPar_0_1_0_3;
       # deviating from Haskell platform here, to make some packages (notably statistics) compile
-      jailbreakCabal = super.jailbreakCabal.override { Cabal = super.disableTest super.Cabal_1_14_0; };
-      binary = super.binary_0_6_0_0;
+      jailbreakCabal = super.jailbreakCabal.override { Cabal = self.disableTest self.Cabal_1_14_0; };
+      binary = self.binary_0_6_0_0;
       cabalInstall_1_16_0_2 = super.cabalInstall_1_16_0_2.override {
-        Cabal = super.Cabal_1_16_0_3;
-        zlib = super.zlib_0_5_3_3;
-        mtl = super.mtl_2_1_2;
-        HTTP = super.HTTP_4000_1_1.override { mtl = super.mtl_2_1_2; };
+        Cabal = self.Cabal_1_16_0_3;
+        zlib = self.zlib_0_5_3_3;
+        mtl = self.mtl_2_1_2;
+        HTTP = self.HTTP_4000_1_1.override { mtl = self.mtl_2_1_2; };
       };
-      haskeline = super.haskeline_0_7_1_1;
-      terminfo = super.terminfo_0_3_2_6;
+      haskeline = self.haskeline_0_7_1_1;
+      terminfo = self.terminfo_0_3_2_6;
     };
 
   # Abstraction for Haskell packages collections
@@ -233,7 +234,7 @@
                             else config.cabal.libraryProfiling or profDefault;
           ghc = callPackage ghcPath ({ ghc = ghcBinary; } // extraArgs);
         };
-        haskellPackagesPrefsClass = self : let super = haskellPackagesClass self; in super // prefFun super;
+        haskellPackagesPrefsClass = self : let super = haskellPackagesClass self; in super // prefFun self super;
         haskellPackagesExtensionClass = self : let super = haskellPackagesPrefsClass self; in super // extension self super;
         haskellPackages = haskellPackagesExtensionClass haskellPackages;
     in haskellPackages);

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -136,7 +136,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   # NOTE: 2013.2.0.0 is the current default.
 
   haskellPlatformArgs_future = self : {
-    inherit (self) cabal ghc;
     async        = self.async_2_0_1_5;
     attoparsec   = self.attoparsec_0_11_3_0;
     caseInsensitive = self.caseInsensitive_1_2_0_0;
@@ -177,7 +176,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   };
 
   haskellPlatformArgs_2013_2_0_0 = self : {
-    inherit (self) cabal ghc;
     async        = self.async_2_0_1_4;
     attoparsec   = self.attoparsec_0_10_4_0;
     caseInsensitive = self.caseInsensitive_1_0_0_1;
@@ -222,7 +220,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2013_2_0_0 self);
 
   haskellPlatformArgs_2012_4_0_0 = self : {
-    inherit (self) cabal ghc;
     async        = self.async_2_0_1_3;
     cgi          = self.cgi_3001_1_7_4;
     fgl          = self.fgl_5_4_2_4;
@@ -261,7 +258,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2012_4_0_0 self);
 
   haskellPlatformArgs_2012_2_0_0 = self : {
-    inherit (self) cabal ghc;
     cgi          = self.cgi_3001_1_7_4;
     fgl          = self.fgl_5_4_2_4;
     GLUT         = self.GLUT_2_1_2_1;
@@ -296,7 +292,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2012_2_0_0 self);
 
   haskellPlatformArgs_2011_4_0_0 = self : {
-    inherit (self) cabal ghc;
     cgi          = self.cgi_3001_1_7_4;
     fgl          = self.fgl_5_4_2_4;
     GLUT         = self.GLUT_2_1_2_1;
@@ -331,7 +326,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2011_4_0_0 self);
 
   haskellPlatformArgs_2011_2_0_1 = self : {
-    inherit (self) cabal ghc;
     cgi          = self.cgi_3001_1_7_4;
     fgl          = self.fgl_5_4_2_3;
     GLUT         = self.GLUT_2_1_2_1;
@@ -366,7 +360,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2011_2_0_1 self);
 
   haskellPlatformArgs_2011_2_0_0 = self : {
-    inherit (self) cabal ghc;
     cgi          = self.cgi_3001_1_7_4;
     fgl          = self.fgl_5_4_2_3;
     GLUT         = self.GLUT_2_1_2_1;
@@ -401,7 +394,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2011_2_0_0 self);
 
   haskellPlatformArgs_2010_2_0_0 = self : {
-    inherit (self) cabal ghc;
     cgi          = self.cgi_3001_1_7_3;
     fgl          = self.fgl_5_4_2_3;
     GLUT         = self.GLUT_2_1_2_1;
@@ -433,7 +425,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2010_2_0_0 self);
 
   haskellPlatformArgs_2010_1_0_0 = self : {
-    inherit (self) cabal ghc;
     haskellSrc   = self.haskellSrc_1_0_1_3;
     html         = self.html_1_0_1_2;
     fgl          = self.fgl_5_4_2_2;
@@ -463,7 +454,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       (self.haskellPlatformArgs_2010_1_0_0 self);
 
   haskellPlatformArgs_2009_2_0_2 = self : {
-    inherit (self) cabal ghc;
     time         = self.time_1_1_2_4;
     haddock      = self.haddock_2_4_2;
     cgi          = self.cgi_3001_1_7_1;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -58,7 +58,7 @@
 #
 # For most packages, however, we keep only one version, and use default.nix.
 
-{ pkgs, newScope, ghc, prefFun, modifyPrio ? (x : x)
+{ pkgs, newScope, ghc, modifyPrio ? (x : x)
 , enableLibraryProfiling ? false
 , enableSharedLibraries ? pkgs.stdenv.lib.versionOlder "7.7" ghc.version
 , enableSharedExecutables ? pkgs.stdenv.lib.versionOlder "7.7" ghc.version
@@ -70,17 +70,13 @@
 # modifyPrio argument can be set to lowPrio to make all Haskell packages have
 # low priority.
 
-let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x y);
-                 self = (prefFun result) result; in
+self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
 # Indentation deliberately broken at this point to keep the bulk
 # of this file at a low indentation level.
 
 {
-
-  finalReturn = self;
-
-  callPackage = callPackage;
+  inherit callPackage;
 
   # GHC and its wrapper
   #
@@ -3171,6 +3167,4 @@ let result = let callPackage = x : y : modifyPrio (newScope result.finalReturn x
 
 # End of the main part of the file.
 
-};
-
-in result.finalReturn
+}


### PR DESCRIPTION
The existing knot-tying code I felt was a bit incoherent with result, finalReturn, self, refering to different various forms of the "haskellPackages" value and often
different forms in the same place.

This commit instills some object-oriented discipline to the construction of hasekllPackages using a small number of fundamental OO concepts:
- An class is a open recursive function of the form (self : fooBody) where fooBody is a set.
- An instance of a class is the fixed point of the class.
  This value is sometimes refered to as an object and the values in the resulting set are sometimes refered to as methods.
- A class, foo = self : fooBody, can be extended by an extension which is a function bar = (self : super : barBody) where barBody a set of overrides for fooBody.
  The result of a class extension is a new class whose value is self : foo self // bar self (foo self).
  The super parameter gives access to the original methods that barBody may be overriding.

This commit turns the haskell-packages value into a "class".

The knot-tying, a.k.a the object instanitation, is moved into haskells-defaults.  The "finalReturn" is no longer needed and is eliminated from the body of
haskell-packages. All the work done by prefFun is moved to haskell-defaults, so that parameter is eliminated form haskell-packages.  Notice that the old prefFun took
two pameters named "self" and "super", but both parameters got passed the same value "result".  There seems to have been some confusion in the old code.

Inside haskell-defaults, the haskell-packages class is extended twice before instantiation.  The first extension is done using prefFun argument.
The second extension is done the extension argument, which is a renamed version of extraPrefs.

This two stage approach means that extension's super gets access to the post "perfFun" object while previously the extraPrefs only had access to the pre "prefFun"
object.  Also the extension function has access to both the super (post "perfFun") object and to self, the final object.  With extraPrefs, one needed to use the
"finalReturn" of the haskell packages to get access to the final object.  Due to significant changes in semantics, I thought it best to replace extraPrefs with
extension so that people using extraPrefs know to update thier cod.

Lastly, all the Prefs functions have renamed the "self" parameter to "super".  This is because "self" was never actually a self-reference in the object oriented sense
of the word.  For example

```
Cabal_1_18_1_3 = self.Cabal_1_18_1_3.override { deepseq = self.deepseq_1_3_0_2; };
```

doesn't actually make sense from an object oriented standpoint because, barring further method overriding, the value of Cabal_1_18_1_3 would be trying to override it's
own value which simply causes a loop exception.  Thankfully all these uses of self were really uses of super:

```
Cabal_1_18_1_3 = super.Cabal_1_18_1_3.override { deepseq = super.deepseq_1_3_0_2; };
```

In this notation the overriden Cabal_1_18_1_3 method calls the Cabal_1_18_1_3 of the super-class, which is a well-founded notion.

Below is an example use of using "extension" parameter

```
{
  packageOverrides = pkgs : {
    testHaskellPackages = pkgs.haskellPackages.override {
      extension = self : super : {
        transformers_0_4_1_0 = self.cabal.mkDerivation (pkgs: {
        pname = "transformers";
        version = "0.4.1.0";
        sha256 = "0jlnz86f87jndv4sifg1zpv5b2g2cxy1x2575x727az6vyaarwwg";
        meta = {
          description = "Concrete functor and monad transformers";
          license = pkgs.stdenv.lib.licenses.bsd3;
          platforms = pkgs.ghc.meta.platforms;
          maintainers = [ pkgs.stdenv.lib.maintainers.andres ];
        };
       });

      transformers = self.transformers_0_4_1_0;

      lensFamilyCore = super.lensFamilyCore.override { transformers = self.transformers_0_3_0_0; };
     };
   };
 };
}
```

Notice the use of self in the body of the override of the transformers method which references the newly defined transformers_0_4_1_0 method.

With the previous code, one would have to instead akwardly write

```
      transformers = super.finalReturn.transformers_0_4_1_0;
```

or use a rec clause, which would prevent futher overriding of transformers_0_4_1_0.
