### PR TITLE
zotero: version bump 4.0.19 -> 4.0.20

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -3,7 +3,7 @@
 assert (stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux");
 
 let
-  version = "4.0.19";
+  version = "4.0.20";
   arch = if stdenv.system == "x86_64-linux"
            then "linux-x86_64"
            else "linux-i686";
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "https://download.zotero.org/standalone/${version}/Zotero-${version}_${arch}.tar.bz2";
     sha256 = if stdenv.system == "x86_64-linux"
-               then "0xihvk7ms1vvzmxvpw8hs15pl1vvmf3zd72nwyaqhg469kwcz9s1"
-               else "1z4q8nzl90snb03ywk0cp64nv3cgasj9fvbcw2d4bgl2zlgwzpy9";
+               then "0d7813k3h60fpxabdwiw83g5zfy9knxc9irgxxz60z31vd14zi0x"
+               else "0nj4mj22bkn2nwbkfs40kg4br6h6gcf718v9lfnvs13cyhx0wapc";
   };
 
   # Strip the bundled xulrunner


### PR DESCRIPTION
This is semi-urgent because 4.0.19 doesn't work with the recently-updated xulrunner 29!
