### PR TITLE
When auto-formatting ext devices, use the -F flag to make it work with u...

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -187,6 +187,8 @@ in
           let
             mountPoint' = escapeSystemdPath fs.mountPoint;
             device' = escapeSystemdPath fs.device;
+            # -F needed to allow bare block device without partitions
+            mkfsOpts = optional ((builtins.substring 0 3 fs.fsType) == "ext") "-F";
           in nameValuePair "mkfs-${device'}"
           { description = "Initialisation of Filesystem ${fs.device}";
             wantedBy = [ "${mountPoint'}.mount" ];
@@ -201,7 +203,7 @@ in
                 type=$(blkid -p -s TYPE -o value "${fs.device}" || true)
                 if [ -z "$type" ]; then
                   echo "creating ${fs.fsType} filesystem on ${fs.device}..."
-                  mkfs.${fs.fsType} "${fs.device}"
+                  mkfs.${fs.fsType} ${concatStringsSep " " mkfsOpts} "${fs.device}"
                 fi
               '';
             unitConfig.RequiresMountsFor = [ "${dirOf fs.device}" ];


### PR DESCRIPTION
...npartioned disks

Today, autoFormat fails if the device is not a partition. I think it makes sense to support unpartitioned devices too.
