### PR TITLE
Add a function "fetchdir"

### DIFF
--- a/pkgs/build-support/fetchdir/builder.sh
+++ b/pkgs/build-support/fetchdir/builder.sh
@@ -1,0 +1,11 @@
+source $stdenv/setup
+
+echo "copying $pathname into $out..."
+
+cp -r "$pathname" "$out" || exit 1
+
+actual=$(nix-hash --type md5 $out | cut -c1-32)
+if test "$actual" != "$md5"; then
+    echo "hash is $actual, expected $md5"
+    exit 1
+fi

--- a/pkgs/build-support/fetchdir/default.nix
+++ b/pkgs/build-support/fetchdir/default.nix
@@ -1,0 +1,8 @@
+{stdenv, nix}: {pathname, md5}: stdenv.mkDerivation {
+  name = baseNameOf (toString pathname);
+  buildInputs = [ nix ];
+  builder = ./builder.sh;
+  pathname = pathname;
+  md5 = md5;
+  id = md5;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -299,6 +299,10 @@ let
     inherit stdenv darcs nix;
   };
 
+  fetchdir = import ../build-support/fetchdir {
+    inherit stdenv nix;
+  };
+
   fetchgit = import ../build-support/fetchgit {
     inherit stdenv git cacert;
   };


### PR DESCRIPTION
This function copies the source directory for building.
This is useful if the source is stored in plain directory, not stored in
archive form.

This is implemented similar to fetchfile.
