### PR TITLE
llvm+clang: 3.4.1 update

### DIFF
--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetch, cmake, libxml2, libedit, llvm, version }:
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src }:
 
 stdenv.mkDerivation {
   name = "clang-${version}";
 
   unpackPhase = ''
-    unpackFile ${fetch "clang" "06rb4j1ifbznl3gfhl98s7ilj0ns01p7y7zap4p7ynmqnc6pia92"}
-    mv clang-${version} clang
+    unpackFile ${fetch "cfe" "1dvbkld0a1aqj6wcn0ia1wa8lwha30yfgq16j1r7akdka44z70xb"}
+    mv cfe-${version}.src clang
     sourceRoot=$PWD/clang
-    unpackFile ${fetch "clang-tools-extra" "1d1822mwxxl9agmyacqjw800kzz5x8xr0sdmi8fgx5xfa5sii1ds"}
-    mv clang-tools-extra-${version} $sourceRoot/tools/extra
+    unpackFile ${clang-tools-extra_src}
+    mv clang-tools-extra-* $sourceRoot/tools/extra
     # !!! Hopefully won't be needed for 3.5
     unpackFile ${llvm.src}
-    export cmakeFlags="$cmakeFlags -DCLANG_PATH_TO_LLVM_SOURCE=$PWD/llvm-${version}"
-    (cd llvm-${version} && patch -Np1 -i ${./llvm-separate-build.patch})
+    export cmakeFlags="$cmakeFlags -DCLANG_PATH_TO_LLVM_SOURCE="`ls -d $PWD/llvm-*`
+    (cd llvm-* && patch -Np1 -i ${./llvm-separate-build.patch})
   '';
 
   patches = [ ./clang-separate-build.patch ./clang-purity.patch ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   # Clang expects to find sanitizer libraries in its own prefix
   postInstall = ''
     ln -sv ${llvm}/lib/LLVMgold.so $out/lib
-    ln -sv ${llvm}/lib/clang/3.4/lib $out/lib/clang/3.4/
+    ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
   '';
 
   passthru.gcc = stdenv.gcc.gcc;

--- a/pkgs/development/compilers/llvm/3.4/default.nix
+++ b/pkgs/development/compilers/llvm/3.4/default.nix
@@ -4,15 +4,27 @@ let
 
   version = "3.4";
 
-  fetch = name: sha256: fetchurl {
-    url = "http://llvm.org/releases/${version}/${name}-${version}.src.tar.gz";
+  fetch = fetch_v version;
+  fetch_v = ver: name: sha256: fetchurl {
+    url = "http://llvm.org/releases/${ver}/${name}-${ver}.src.tar.gz";
     inherit sha256;
   };
 
-  self = {
-    llvm = callPackage ./llvm.nix {};
+  compiler-rt_src = fetch "compiler-rt" "0p5b6varxdqn7q3n77xym63hhq4qqxd2981pfpa65r1w72qqjz7k";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1d1822mwxxl9agmyacqjw800kzz5x8xr0sdmi8fgx5xfa5sii1ds";
 
-    clang = callPackage ./clang.nix {};
+  self = {
+    llvm = callPackage ./llvm.nix rec {
+      version = "3.4.1";
+      fetch = fetch_v version;
+      inherit compiler-rt_src;
+    };
+
+    clang = callPackage ./clang.nix rec {
+      version = "3.4.1";
+      fetch = fetch_v version;
+      inherit clang-tools-extra_src;
+    };
 
     lld = callPackage ./lld.nix {};
 

--- a/pkgs/development/compilers/llvm/3.4/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.4/llvm.nix
@@ -11,19 +11,20 @@
 , ncurses
 , version
 , zlib
+, compiler-rt_src
 }:
 
 let
-  src = fetch "llvm" "0a169ba045r4apb9cv6ncrwl83l7yiajnzirkcdlhj1cd4nn3995";
+  src = fetch "llvm" "0fprxrilnlwk9qv7f0kplxc7kd8mp4x781asssv2nfi4r9pbna3x";
 in stdenv.mkDerivation rec {
   name = "llvm-${version}";
 
   unpackPhase = ''
     unpackFile ${src}
-    mv llvm-${version} llvm
+    mv llvm-${version}.src llvm
     sourceRoot=$PWD/llvm
-    unpackFile ${fetch "compiler-rt" "0p5b6varxdqn7q3n77xym63hhq4qqxd2981pfpa65r1w72qqjz7k"}
-    mv compiler-rt-${version} $sourceRoot/projects/compiler-rt
+    unpackFile ${compiler-rt_src}
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
   '';
 
   buildInputs = [ perl groff cmake libxml2 python libffi ] ++ stdenv.lib.optional stdenv.isLinux valgrind;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -23,7 +23,7 @@ else
 */
 
 let
-  version = "10.1.2";
+  version = "10.1.3";
   # this is the default search path for DRI drivers
   driverLink = "/run/opengl-driver" + stdenv.lib.optionalString stdenv.isi686 "-32";
 in
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
   src =  fetchurl {
     url = "ftp://ftp.freedesktop.org/pub/mesa/${version}/MesaLib-${version}.tar.bz2";
-    sha256 = "132vn3s5hiwksl7n099fw3g15h3nzj3fp09zzvgnikqcrrv0n8xi";
+    sha256 = "1hzcmpa7ykqm0qrvkm52bkfvf855wb9bs8449fwhypgjdqimwqdj";
   };
 
   prePatch = "patchShebangs .";


### PR DESCRIPTION
- Bundled with mesa update to save rebuilding time.
- The clang part is slightly hacky, but I saw no easy better solution.
- The rest of the llvm suite haven't changed upstream.
- I tested building all three on x86_64-linux.

Any comments, e.g. from llvm/clang users/maintainers?
