### PR TITLE
hplip update and fixes

### DIFF
--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -5,6 +5,8 @@ with lib;
 let
 
   pkg = if config.hardware.sane.snapshot then pkgs.saneBackendsGit else pkgs.saneBackends;
+  backends = [ pkg ] ++ config.hardware.sane.extraBackends;
+  saneConfig = pkgs.mkSaneConfig { paths = backends; };
 
 in
 
@@ -26,6 +28,12 @@ in
       description = "Use a development snapshot of SANE scanner drivers.";
     };
 
+    hardware.sane.extraBackends = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      description = "Packages providing extra SANE backends to enable.";
+    };
+
   };
 
 
@@ -33,8 +41,12 @@ in
 
   config = mkIf config.hardware.sane.enable {
 
-    environment.systemPackages = [ pkg ];
-    services.udev.packages = [ pkg ];
+    environment.systemPackages = backends;
+    environment.variables = {
+      SANE_CONFIG_DIR = "${saneConfig}/etc/sane.d";
+      LD_LIBRARY_PATH = [ "${saneConfig}/lib/sane" ];
+    };
+    services.udev.packages = backends;
 
     users.extraGroups."scanner".gid = config.ids.gids.scanner;
 

--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -1,0 +1,27 @@
+{ stdenv }:
+
+{ paths }:
+
+with stdenv.lib;
+let installSanePath = path: ''
+      find "${path}/lib/sane" -not -type d -maxdepth 1 | while read backend; do
+        ln -s $backend $out/lib/sane/$(basename $backend)
+      done
+
+      find "${path}/etc/sane.d" -not -type d -maxdepth 1 | while read conf; do
+        ln -s $conf $out/etc/sane.d/$(basename $conf)
+      done
+
+      find "${path}/etc/sane.d/dll.d" -not -type d -maxdepth 1 | while read conf; do
+        ln -s $conf $out/etc/sane.d/dll.d/$(basename $conf)
+      done
+    '';
+in
+stdenv.mkDerivation {
+  name = "sane-config";
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/etc/sane.d $out/etc/sane.d/dll.d $out/lib/sane
+  '' + concatMapStrings installSanePath paths;
+}

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,13 +1,13 @@
-{stdenv, fetchurl, cups, zlib, libjpeg, libusb, pythonPackages, saneBackends, dbus
-, pkgconfig, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4, net_snmp
+{stdenv, fetchurl, cups, zlib, libjpeg, libusb1, pythonPackages, saneBackends, dbus
+, pkgconfig, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4, net_snmp, automake
 }:
 
 stdenv.mkDerivation rec {
-  name = "hplip-3.11.1";
+  name = "hplip-3.14.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/hplip/${name}.tar.gz";
-    sha256 = "0y68s4xm5d0kv7p5j41qq0xglp4vdbjwbrjs89b4a21wwn69hp9g";
+    sha256 = "1j8h44f8igl95wqypj4rk9awcw513hlps980jmcnkx60xghc4l6f";
   };
 
   #preBuild=''
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
   prePatch = ''
     sed -i s,/etc/sane.d,$out/etc/sane.d/, Makefile.in
     sed -i s,/etc/hp/,$out/etc/hp/, base/g.py
+    substituteInPlace Makefile.in \
+      --replace "/usr/include/libusb-1.0" "${libusb1}/include/libusb-1.0" \
+      --replace "/usr/lib/systemd/system" "$out/lib/systemd/system"
   '';
 
   # --disable-network-build Until we have snmp
@@ -49,7 +52,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
       libjpeg
       cups
-      libusb
+      libusb1
       pythonPackages.python
       pythonPackages.wrapPython
       saneBackends

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -105,9 +105,11 @@ stdenv.mkDerivation rec {
     ] ++ stdenv.lib.optional qtSupport qt4;
 
   pythonPath = with pythonPackages; [
+      pillow
       pythonDBus
       pygobject
       recursivePthLoader
+      reportlab
     ] ++ stdenv.lib.optional qtSupport pyqt4;
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -115,5 +115,6 @@ stdenv.mkDerivation rec {
     homepage = http://hplipopensource.com/;
     license = if withPlugin then licenses.unfree else "free"; # MIT/BSD/GPL
     platforms = platforms.linux;
+    maintainers = with maintainers; [ ttuegel ];
   };
 }

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -90,6 +90,9 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/var/lib/hp
     cp ${hplip_state} $out/var/lib/hp/hplip.state
+
+    mkdir -p $out/etc/sane.d/dll.d
+    mv $out/etc/sane.d/dll.conf $out/etc/sane.d/dll.d/hpaio.conf
     ''));
 
   buildInputs = [

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,5 +1,7 @@
-{stdenv, fetchurl, cups, zlib, libjpeg, libusb1, pythonPackages, saneBackends, dbus
-, pkgconfig, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4, net_snmp, automake
+{ stdenv, fetchurl, automake, pkgconfig
+, cups, zlib, libjpeg, libusb1, pythonPackages, saneBackends, dbus
+, polkit, qtSupport ? true, qt4, pythonDBus, pyqt4, net_snmp
+, withPlugin ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -10,19 +12,22 @@ stdenv.mkDerivation rec {
     sha256 = "1j8h44f8igl95wqypj4rk9awcw513hlps980jmcnkx60xghc4l6f";
   };
 
-  #preBuild=''
-  #  makeFlags="V=1 DISABLE_JBIG=1 CUPSFILTER=$out/lib/cups/filter CUPSPPD=$out/share/cups/model"
-  #'';
+  plugin = fetchurl {
+    url = "http://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${name}-plugin.run";
+    sha256 = "0k1vpmy7babbm3c5v4dcbhq0jgyr8as722nylfs8zx0dy7kr8874";
+  };
+
+  hplip_state = ./hplip.state;
 
   prePatch = ''
-    sed -i s,/etc/sane.d,$out/etc/sane.d/, Makefile.in
-    sed -i s,/etc/hp/,$out/etc/hp/, base/g.py
-    substituteInPlace Makefile.in \
-      --replace "/usr/include/libusb-1.0" "${libusb1}/include/libusb-1.0" \
-      --replace "/usr/lib/systemd/system" "$out/lib/systemd/system"
+    # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
+    find . -type f -exec sed -i s,/etc/hp,$out/etc/hp, {} \;
+    find . -type f -exec sed -i s,/etc/sane.d,$out/etc/sane.d, {} \;
+    find . -type f -exec sed -i s,/usr/include/libusb-1.0,${libusb1}/include/libusb-1.0, {} \;
+    find . -type f -exec sed -i s,/usr/share/hal/fdi/preprobe/10osvendor,$out/share/hal/fdi/preprobe/10osvendor, {} \;
+    find . -type f -exec sed -i s,/usr/lib/systemd/system,$out/lib/systemd/system, {} \;
+    find . -type f -exec sed -i s,/var/lib/hp,$out/var/lib/hp, {} \;
   '';
-
-  # --disable-network-build Until we have snmp
 
   preConfigure = ''
     export configureFlags="$configureFlags
@@ -36,18 +41,56 @@ stdenv.mkDerivation rec {
 
     export makeFlags="
       halpredir=$out/share/hal/fdi/preprobe/10osvendor
-      hplip_statedir=$out/var
       rulesdir=$out/etc/udev/rules.d
       policykit_dir=$out/share/polkit-1/actions
       policykit_dbus_etcdir=$out/etc/dbus-1/system.d
       policykit_dbus_sharedir=$out/share/dbus-1/system-services
       hplip_confdir=$out/etc/hp
+      hplip_statedir=$out/var/lib/hp
     ";
   '';
 
-  postInstall = ''
+  postInstall =
+    ''
     wrapPythonPrograms
-    '';
+    ''
+    + (stdenv.lib.optionalString withPlugin
+    (let hplip_arch =
+          if builtins.currentSystem == "i686-linux"
+            then "x86_32"
+            else if builtins.currentSystem == "x86_64-linux"
+              then "x86_64"
+              else abort "Platform must be i686-linux or x86_64-linux!";
+    in
+    ''
+    sh ${plugin} --noexec --keep
+    cd plugin_tmp
+
+    cp plugin.spec $out/share/hplip/
+
+    mkdir -p $out/share/hplip/data/firmware
+    cp *.fw.gz $out/share/hplip/data/firmware
+
+    mkdir -p $out/share/hplip/data/plugins
+    cp license.txt $out/share/hplip/data/plugins
+
+    mkdir -p $out/share/hplip/prnt/plugins
+    for plugin in lj hbpl1; do
+      cp $plugin-${hplip_arch}.so $out/share/hplip/prnt/plugins
+      ln -s $out/share/hplip/prnt/plugins/$plugin-${hplip_arch}.so \
+        $out/share/hplip/prnt/plugins/$plugin.so
+    done
+
+    mkdir -p $out/share/hplip/scan/plugins
+    for plugin in bb_soap bb_marvell bb_soapht fax_marvell; do
+      cp $plugin-${hplip_arch}.so $out/share/hplip/scan/plugins
+      ln -s $out/share/hplip/scan/plugins/$plugin-${hplip_arch}.so \
+        $out/share/hplip/scan/plugins/$plugin.so
+    done
+
+    mkdir -p $out/var/lib/hp
+    cp ${hplip_state} $out/var/lib/hp/hplip.state
+    ''));
 
   buildInputs = [
       libjpeg
@@ -70,7 +113,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";
     homepage = http://hplipopensource.com/;
-    license = "free"; # MIT/BSD/GPL
+    license = if withPlugin then licenses.unfree else "free"; # MIT/BSD/GPL
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/drivers/hplip/hplip.state
+++ b/pkgs/misc/drivers/hplip/hplip.state
@@ -1,0 +1,4 @@
+[plugin]
+installed=1
+eula=1
+version=3.14.4

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10735,6 +10735,8 @@ let
     hotplugSupport = config.sane.hotplugSupport or true;
   };
 
+  mkSaneConfig = callPackage ../applications/graphics/sane/config.nix { };
+
   saneFrontends = callPackage ../applications/graphics/sane/frontends.nix { };
 
   seafile-shared = callPackage ../misc/seafile-shared { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10604,6 +10604,8 @@ let
 
   hplip = callPackage ../misc/drivers/hplip { };
 
+  hplipWithPlugin = hplip.override { withPlugin = true; };
+
   # using the new configuration style proposal which is unstable
   jack1d = callPackage ../misc/jackaudio/jack1.nix { };
 


### PR DESCRIPTION
This pull request does several things:
- Bumps hplip version from 3.11.1 to 3.14.4, which brings support for many new devices.
- Adds support for HP's proprietary binary plugin, required to print with many new devices (especially LaserJet models). With the proprietary plugin enabled, the package is unfree, so the plugin is disabled by default. Besides the default `hplip`, a second top-level attribute `hplipWithPlugin` is provided that has the plugin enabled.
- Begins to fix scanning by adding missing dependencies. Scanning still doesn't work because the SANE dynamic loader can't find the driver, but fixing that will require completely restructuring how we do SANE backends.
- Given that the package is so badly out of date and no maintainer is listed, adds myself as maintainer.
