### PR TITLE
fcgiwrap: new package, useful for e.g. running nagios with nginx

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -252,6 +252,7 @@
   ./services/ttys/agetty.nix
   ./services/ttys/kmscon.nix
   ./services/web-servers/apache-httpd/default.nix
+  ./services/web-servers/fcgiwrap.nix
   ./services/web-servers/jboss/default.nix
   ./services/web-servers/lighttpd/default.nix
   ./services/web-servers/lighttpd/cgit.nix

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.fcgiwrap;
+
+in {
+
+  options = {
+    services.fcgiwrap = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable fcgiwrap, a server for running CGI applications over FastCGI.";
+      };
+
+      preforkProcesses = mkOption {
+        type = types.int;
+        default = 1;
+        description = "Number of processes to prefork.";
+      };
+
+      bindSocket = mkOption {
+        type = types.string;
+        default = "unix:/run/fcgiwrap.sock";
+        description = ''
+          Socket to bind to. Valid socket URLs are:
+            unix:/path/to/socket for Unix sockets
+            tcp:dot.ted.qu.ad:port for IPv4 sockets
+            tcp6:[ipv6_addr]:port for IPv6 sockets
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.fcgiwrap = {
+      after = [ "nss-user-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.fcgiwrap}/sbin/fcgiwrap -c ${builtins.toString cfg.preforkProcesses} -s ${cfg.bindSocket}";
+      };
+    };
+
+  };
+}

--- a/pkgs/servers/fcgiwrap/default.nix
+++ b/pkgs/servers/fcgiwrap/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, systemd, fcgi, autoreconfHook, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "fcgiwrap-${version}";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "http://github.com/gnosek/fcgiwrap/archive/${version}.tar.gz";
+    sha256 = "07y6s4mm86cv7p1ljz94sxnqa89y9amn3vzwsnbq5hrl4vdy0zac";
+  };
+
+  configureFlags = [ "--with-systemd" "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];
+
+  buildInputs = [ autoreconfHook systemd fcgi pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = https://nginx.localdomain.pl/wiki/FcgiWrap;
+    description = "Simple server for running CGI applications over FastCGI";
+    maintainers = with maintainers; [ lethalman ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6494,6 +6494,8 @@ let
 
   elasticmq = callPackage ../servers/elasticmq { };
 
+  fcgiwrap = callPackage ../servers/fcgiwrap { };
+
   felix = callPackage ../servers/felix { };
 
   felix_remoteshell = callPackage ../servers/felix/remoteshell.nix { };


### PR DESCRIPTION
Simple server for running CGI applications over FastCGI.
If is particularly useful for services that run cgi scripts, like nagios. In fact, this package makes it possible to run nagios with nginx.
