### PR TITLE
resolve issue #2308

### DIFF
--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -36,6 +36,6 @@ import ./make-test.nix {
     print $slave->execute("sudo -u jenkins groups");
     $slave->mustSucceed("sudo -u jenkins groups | grep jenkins | grep users");
 
-    $slave->mustFail("systemctl status jenkins.service");
+    $slave->mustFail("systemctl is-enabled jenkins.service");
   '';
 }


### PR DESCRIPTION
Resolves issue #2308: use is-enabled to check for service existence. This version of systemd exits with 0 when using status on non-existent units. Previous version would exit with non-zero.
