### PR TITLE
Update Tor to 0.2.4.21 and tor-browser to 3.6.1

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libevent, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "tor-0.2.3.25";
+  name = "tor-0.2.4.21";
 
   src = fetchurl {
-    url = "http://www.torproject.org/dist/${name}.tar.gz";
-    sha256 = "bb2d6f1136f33e11d37e6e34184143bf191e59501613daf33ae3d6f78f3176a0";
+    url = "https://archive.torproject.org/tor-package-archive/${name}.tar.gz";
+    sha256 = "1kpijqapml7y4sl54qgyrzppxxhmy4xgk2y7wkqwjxn7q24g97d1";
   };
 
   buildInputs = [ libevent openssl zlib ];

--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -20,13 +20,13 @@ let
 
 in stdenv.mkDerivation rec {
   name = "tor-browser-${version}";
-  version = "3.5";
+  version = "3.6.1";
 
   src = fetchurl {
-    url = "https://www.torproject.org/dist/torbrowser/${version}/tor-browser-linux${bits}-${version}_en-US.tar.xz";
+    url = "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux${bits}-${version}_en-US.tar.xz";
     sha256 = if bits == "64" then
-      "e448dc90365a88d73a6ff85347adbe763ef0f800d0cb2e7b7165d7f0646f7c41" else
-      "b0b29b4e75cd4a1aaecf7f4716216edcfc5947516744e2eaeae38bec1d03cea1";
+      "1461l54zc7xgx2zcmi8wra38dknjyy8d2xk84chrwl6ckn2dfzv3" else
+      "183a1wf4a88sijfqr3m6gmvncq8w60i2rkymccg422n7q96j7hqs";
   };
 
   patchPhase = ''


### PR DESCRIPTION
This is an update to pull request #2557 which was merged and then removed with a forced push. This updates tor-browser to 3.6.1 and uses stable URL's for tor and tor-browser. The previous URLs would get deleted by the Tor project when new versions were released. These URL's now point to the Tor project archived files.
