### PR TITLE
swig: support for OS X

### DIFF
--- a/pkgs/development/tools/misc/swig/default.nix
+++ b/pkgs/development/tools/misc/swig/default.nix
@@ -39,8 +39,6 @@ stdenv.mkDerivation rec {
     # Licensing is a mess: http://www.swig.org/Release/LICENSE .
     license = "BSD-style";
 
-    platforms = stdenv.lib.platforms.linux;
-
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
remove unnecessary platform specification in swig nix expression.
