### PR TITLE
Add -p to mkdir in build-fhs-chrootenv to prevent error if directory exists

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/init.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/init.sh.in
@@ -36,9 +36,9 @@ rm $chrootenvDest/etc/pam.d
 ln -s ../host-etc/static/pam.d $chrootenvDest/etc/pam.d
 
 # Symlink Font stuff
-mkdir $chrootenvDest/etc/fonts
+mkdir -p $chrootenvDest/etc/fonts
 ln -s ../../host-etc/static/fonts/fonts.conf $chrootenvDest/etc/fonts
-mkdir $chrootenvDest/etc/fonts/conf.d
+mkdir -p $chrootenvDest/etc/fonts/conf.d
 ln -s ../../../host-etc/static/fonts/conf.d/00-nixos.conf $chrootenvDest/etc/fonts/conf.d
 
 # Create root folder


### PR DESCRIPTION
The 'init' command for an FHS chroot environment tries to create an /etc/fonts directory. This fails if it exists and the rest of the init command doesn't run. This results in the /tmp and /root directories not being created which causes failure in an FHS environment I use.

The fix here uses '-p' on 'mkdir' which prevents the script from bailing out.
