### PR TITLE
mkpasswd: Update to 5.1.2

### DIFF
--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, perl
 }:
-  
+
 stdenv.mkDerivation rec {
   name = "mkpasswd-${version}";
 
-  version = "5.1.1";
+  version = "5.1.2";
 
   src = fetchurl {
     url = "http://ftp.debian.org/debian/pool/main/w/whois/whois_${version}.tar.xz";
-    sha256 = "0i06a9mb9qcq272782mg6dffv3k7bqkw4cdr31yrc0s6jqylryv9";
+    sha256 = "021f76910e772fa569e299210b36e2eeb20b56dc9ca29edb7e83a21b560a5403";
   };
+
+  buildInputs = [ perl ];
 
   preConfigure = ''
     substituteInPlace Makefile --replace "prefix = /usr" "prefix = $out"


### PR DESCRIPTION
The Debian maintainers have removed the download for 5.1.1, making it impossible for me to install NixOS. This updates mkpasswd to the latest/available version.
