### PR TITLE
haskell-glfw-b: add package version 1.4.6

### DIFF
--- a/pkgs/development/libraries/haskell/GLFW-b/default.nix
+++ b/pkgs/development/libraries/haskell/GLFW-b/default.nix
@@ -1,0 +1,17 @@
+{ cabal, bindingsGLFW, HUnit, testFramework, testFrameworkHunit }:
+
+cabal.mkDerivation (self: {
+  pname = "GLFW-b";
+  version = "1.4.6";
+  sha256 = "1d9vacb9nsf5cqqwxhn49wsfbhmw1263kgimk5qxpqpg1jiy35hy";
+  buildDepends = [ bindingsGLFW ];
+  testDepends = [
+    bindingsGLFW HUnit testFramework testFrameworkHunit
+  ];
+  doCheck = false;
+  meta = {
+    description = "Bindings to GLFW OpenGL library";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/bindings-GLFW/default.nix
+++ b/pkgs/development/libraries/haskell/bindings-GLFW/default.nix
@@ -1,0 +1,18 @@
+{ cabal, bindingsDSL, HUnit, libX11, libXext, libXfixes, libXi, libXrandr, libXxf86vm
+, mesa, testFramework, testFrameworkHunit
+}:
+
+cabal.mkDerivation (self: {
+  pname = "bindings-GLFW";
+  version = "3.0.3.2";
+  sha256 = "1w4y2ha5x678fiyan79jd59mjrkf4q25v8049sj20fbmabgdqla9";
+  buildDepends = [ bindingsDSL ];
+  testDepends = [ HUnit testFramework testFrameworkHunit ];
+  extraLibraries = [ libX11 libXext libXfixes libXi libXrandr libXxf86vm mesa ];
+  doCheck = false;
+  meta = {
+    description = "Low-level bindings to GLFW OpenGL library";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -236,6 +236,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   bindingsDSL = callPackage ../development/libraries/haskell/bindings-DSL {};
 
+  bindingsGLFW = callPackage ../development/libraries/haskell/bindings-GLFW {};
+
   bindingsLibusb = callPackage ../development/libraries/haskell/bindings-libusb {
     libusb = pkgs.libusb1;
   };
@@ -820,6 +822,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   };
 
   GLFW = callPackage ../development/libraries/haskell/GLFW {};
+
+  GLFWb = callPackage ../development/libraries/haskell/GLFW-b {};
 
   glib = callPackage ../development/libraries/haskell/glib {
     glib = pkgs.glib;


### PR DESCRIPTION
This patch adds the GLFW-b & bindings-GLFW packages for the GLFW OpenGL library. These are bindings to GLFW version 3._, while the existing haskell-GLFW (without the -b) binds to 2._.

Both expressions where generated by cabal2nix. I have added all missing system libraries to the build dependencies and I have disabled all tests since it does not seem to be able to connect to X11 properly.
