### PR TITLE
Add primus

### DIFF
--- a/pkgs/tools/X11/primus/builder.sh
+++ b/pkgs/tools/X11/primus/builder.sh
@@ -1,0 +1,12 @@
+source $stdenv/setup
+
+cp -r $src src
+cd src
+
+export LIBDIR=$out/x86_64
+export PRIMUS_libGLa=$nvidia/lib/libGL.so
+export PRIMUS_libGLd=/var/run/opengl-driver/lib/libGL.so
+export PRIMUS_LOAD_GLOBAL=/var/run/opengl-driver/lib/libglapi.so
+
+make
+ln -s $out/x86_64/libGL.so.1 $out/x86_64/libGL.so

--- a/pkgs/tools/X11/primus/builder.sh
+++ b/pkgs/tools/X11/primus/builder.sh
@@ -3,10 +3,10 @@ source $stdenv/setup
 cp -r $src src
 cd src
 
-export LIBDIR=$out/x86_64
+export LIBDIR=$out/lib
 export PRIMUS_libGLa=$nvidia/lib/libGL.so
-export PRIMUS_libGLd=/var/run/opengl-driver/lib/libGL.so
-export PRIMUS_LOAD_GLOBAL=/var/run/opengl-driver/lib/libglapi.so
+export PRIMUS_libGLd=$mesa/lib/libGL.so
+export PRIMUS_LOAD_GLOBAL=$mesa/lib/libglapi.so
 
 make
-ln -s $out/x86_64/libGL.so.1 $out/x86_64/libGL.so
+ln -s $out/libGL.so.1 $out/libGL.so

--- a/pkgs/tools/X11/primus/builder.sh
+++ b/pkgs/tools/X11/primus/builder.sh
@@ -9,4 +9,4 @@ export PRIMUS_libGLd=$mesa/lib/libGL.so
 export PRIMUS_LOAD_GLOBAL=$mesa/lib/libglapi.so
 
 make
-ln -s $out/libGL.so.1 $out/libGL.so
+ln -s $LIBDIR/libGL.so.1 $LIBDIR/libGL.so

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -1,13 +1,15 @@
 { stdenv
-, primusLib_x64
-, primusLib_i686
+, primusLib
 , writeScript
+, primusLib_i686 ? null
 }:
+with stdenv.lib;
 let
-  version = "1.0.0";
+  version = "1.074817614c";
+  ld_path = makeLibraryPath ([primusLib] ++ optional (primusLib_i686 != null) primusLib_i686);
   primusrun = writeScript "primusrun"
 ''
-  export LD_LIBRARY_PATH=${primusLib_x64}/lib:${primusLib_i686}/lib
+  export LD_LIBRARY_PATH=${ld_path}
   exec "$@"
 '';
 in
@@ -19,4 +21,10 @@ stdenv.mkDerivation {
   mkdir -p $out/bin
   cp ${primusrun} $out/bin/primusrun
   '';
+
+  meta = {
+    homepage = https://github.com/amonakov/primus;
+    description = "Faster OpenGL offloading for Bumblebee";
+    maintainer = maintainers.coconnor;
+  };
 }

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchgit
+, x11, mesa
+, linuxPackages
+}:
+let
+  version = "1.0.0";
+in
+stdenv.mkDerivation {
+  name = "primus-${version}";
+  src = fetchgit {
+    url = git://github.com/amonakov/primus.git;
+    rev = "074817614c014e3a99259388cb18fd54648b659a";
+    sha256 = "0mrh432md6zrm16avxyk57mgszrqpgwdjahspchvlaccqxp3x82v";
+  };
+
+  nvidia = linuxPackages.nvidia_x11;
+
+  buildInputs = [ x11 mesa ];
+  builder = ./builder.sh;
+}

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, fetchgit
-, x11, mesa
-, linuxPackages
+{ stdenv
+, primusLib_x64
+, primusLib_i686
+, writeScript
 }:
 let
   version = "1.0.0";
+  primusrun = writeScript "primusrun"
+''
+  export LD_LIBRARY_PATH=${primusLib_x64}/lib:${primusLib_i686}/lib
+  exec "$@"
+'';
 in
 stdenv.mkDerivation {
   name = "primus-${version}";
-  src = fetchgit {
-    url = git://github.com/amonakov/primus.git;
-    rev = "074817614c014e3a99259388cb18fd54648b659a";
-    sha256 = "0mrh432md6zrm16avxyk57mgszrqpgwdjahspchvlaccqxp3x82v";
-  };
-
-  nvidia = linuxPackages.nvidia_x11;
-
-  buildInputs = [ x11 mesa ];
-  builder = ./builder.sh;
+  builder = writeScript "builder"
+  ''
+  source $stdenv/setup
+  mkdir -p $out/bin
+  cp ${primusrun} $out/bin/primusrun
+  '';
 }

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -10,6 +10,10 @@ let
   primusrun = writeScript "primusrun"
 ''
   export LD_LIBRARY_PATH=${ld_path}
+  # see: https://github.com/amonakov/primus/issues/138
+  # I think the intel driver barfs when the pixel buffers try to read from the source memory
+  # directly. This causes an indirection through textures which appears to avoid issues.
+  export PRIMUS_UPLOAD=1
   exec "$@"
 '';
 in

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -11,8 +11,9 @@ let
 ''
   export LD_LIBRARY_PATH=${ld_path}
   # see: https://github.com/amonakov/primus/issues/138
-  # I think the intel driver barfs when the pixel buffers try to read from the source memory
-  # directly. This causes an indirection through textures which appears to avoid issues.
+  # I think the intel driver dies when the pixel buffers try to read from the source memory
+  # directly. Setting PRIMUS_UPLOAD causes an indirection through textures which appears to avoid
+  # this issue.
   export PRIMUS_UPLOAD=1
   exec "$@"
 '';

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -1,3 +1,8 @@
+# For a 64bit + 32bit system the LD_LIBRARY_PATH must contain both the 32bit and 64bit primus
+# libraries. Providing a different primusrun for each architecture does not work as expected. Using
+# steam under wine, for instance, can involve both 32bit and 64bit process. All of which inherit the
+# same LD_LIBRARY_PATH.
+# Other distributions do much the same.
 { stdenv
 , primusLib
 , writeScript

--- a/pkgs/tools/X11/primus/lib.nix
+++ b/pkgs/tools/X11/primus/lib.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchgit
+, x11, mesa
+, nvidia
+}:
+let
+  version = "1.0.0";
+in
+stdenv.mkDerivation {
+  name = "primus-lib-${version}";
+  src = fetchgit {
+    url = git://github.com/amonakov/primus.git;
+    rev = "074817614c014e3a99259388cb18fd54648b659a";
+    sha256 = "0mrh432md6zrm16avxyk57mgszrqpgwdjahspchvlaccqxp3x82v";
+  };
+
+  inherit nvidia mesa;
+
+  buildInputs = [ x11 mesa ];
+  builder = ./builder.sh;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9523,6 +9523,13 @@ let
   virtualgl = callPackage ../tools/X11/virtualgl { };
 
   primus = callPackage ../tools/X11/primus {
+    inherit writeScript;
+    primusLib_x64 = callPackage ../tools/X11/primus/lib.nix {
+      nvidia = linuxPackages.nvidia_x11;
+    };
+    primusLib_i686 = callPackage_i686 ../tools/X11/primus/lib.nix {
+      nvidia = callPackage_i686 ../os-specific/linux/nvidia-x11 { libsOnly = true; };
+    };
   };
 
   bumblebee = callPackage ../tools/X11/bumblebee {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9522,7 +9522,15 @@ let
 
   virtualgl = callPackage ../tools/X11/virtualgl { };
 
-  bumblebee = callPackage ../tools/X11/bumblebee { };
+  primus = callPackage ../tools/X11/primus {
+  };
+
+  bumblebee = callPackage ../tools/X11/bumblebee {
+    nvidia_x11_x64 = linuxPackages.nvidia_x11;
+    nvidia_x11_i686 = callPackage_i686 ../os-specific/linux/nvidia-x11 { libsOnly = true; };
+    virtualgl_x64 = virtualgl;
+    virtualgl_i686 = pkgsi686Linux.virtualgl;
+  };
 
   vkeybd = callPackage ../applications/audio/vkeybd {
     inherit (xlibs) libX11;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9523,13 +9523,15 @@ let
   virtualgl = callPackage ../tools/X11/virtualgl { };
 
   primus = callPackage ../tools/X11/primus {
-    inherit writeScript;
-    primusLib_x64 = callPackage ../tools/X11/primus/lib.nix {
+    primusLib = callPackage ../tools/X11/primus/lib.nix {
       nvidia = linuxPackages.nvidia_x11;
     };
-    primusLib_i686 = callPackage_i686 ../tools/X11/primus/lib.nix {
-      nvidia = callPackage_i686 ../os-specific/linux/nvidia-x11 { libsOnly = true; };
-    };
+
+    primusLib_i686 = if system == "x86_64-linux"
+      then callPackage_i686 ../tools/X11/primus/lib.nix {
+             nvidia = callPackage_i686 ../os-specific/linux/nvidia-x11 { libsOnly = true; };
+           }
+      else null;
   };
 
   bumblebee = callPackage ../tools/X11/bumblebee {


### PR DESCRIPTION
Adds primus: https://github.com/amonakov/primus

For a 64bit + 32bit system the LD_LIBRARY_PATH must contain both the 32bit and 64bit primus libraries. Providing a different primusrun for each architecture does not work as expected. Using steam under wine, for instance, can involve both 32bit and 64bit process. All of which inherit the same LD_LIBRARY_PATH.

Perhaps this should only be done if a config is set?

Both bumblebee and virtualgl will need similar setups. Full support requires at least bumblebee to be changed. Even so, I'd like to get this pull request accepted before completing bumbleebee and virtualgl. That way I can incorporate any changes into those developments.
