### PR TITLE
Recode: Build on OS X

### DIFF
--- a/pkgs/tools/text/recode/default.nix
+++ b/pkgs/tools/text/recode/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Makefile.am --replace "ansi2knr" ""
 
     autoreconf -fi
+  ''
+  + stdenv.lib.optionalString stdenv.isDarwin ''
+    export LDFLAGS=-lintl
   '';
 
   #doCheck = true; # doesn't work yet


### PR DESCRIPTION
On Darwin, this needs a forced LDFLAGS, presumably because of an oversight upstream.
