### PR TITLE
fix mkpasswd: use the git repository

### DIFF
--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchurl
-}:
+{ stdenv, fetchFromGitHub }:
   
 stdenv.mkDerivation rec {
   name = "mkpasswd-${version}";
 
   version = "5.1.1";
 
-  src = fetchurl {
-    url = "http://ftp.debian.org/debian/pool/main/w/whois/whois_${version}.tar.xz";
-    sha256 = "0i06a9mb9qcq272782mg6dffv3k7bqkw4cdr31yrc0s6jqylryv9";
+  src = fetchFromGitHub {
+    owner = "rfc1036";
+    repo = "whois";
+    rev = "v${version}";
+    sha256 = "026x8byx8pcpkdxca64368p0nlspk4phw18jg4p04di6cg6nc1m5";
   };
 
   preConfigure = ''
@@ -19,10 +20,12 @@ stdenv.mkDerivation rec {
 
   installPhase = "make install-mkpasswd";
 
-  meta = {
-    homepage = http://ftp.debian.org/debian/pool/main/w/whois/;
+  meta = with stdenv.lib; {
+    homepage = http://packages.qa.debian.org/w/whois.html;
     description = ''
-      Overfeatured front end to crypt, from the Debian whois package.
+      Overfeatured front end to crypt, from the Debian whois package
     '';
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ cstrahan ];
   };
 }


### PR DESCRIPTION
This fixes the mkpasswd package. Debian removed v5.1.1 from their FTP server, so this uses the official git repo instead.
