### PR TITLE
Mednafen: add version 0.9.34.1 + server 0.5.1

### DIFF
--- a/pkgs/misc/emulators/mednafen/default.nix
+++ b/pkgs/misc/emulators/mednafen/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig
+, libX11, mesa, freeglut
+, jackaudio, libcdio, libsndfile, libsamplerate
+, SDL, SDL_net, zlib
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "mednafen-${version}";
+  version = "0.9.34.1";
+
+  src = fetchurl {
+    url = "http://sourceforge.net/projects/mednafen/files/Mednafen/${version}/${name}.tar.bz2";
+    sha256 = "1d783ws5rpx6r8qk1l9nksx3kahbalis606psk4067bvfzy7kjb9";
+  };
+
+  buildInputs = with stdenv.lib;
+  [ libX11 mesa freeglut jackaudio libcdio libsndfile libsamplerate SDL SDL_net zlib ];
+  
+  nativeBuildInputs = [ pkgconfig ];
+
+  # Install docs
+  postInstall = ''
+    mkdir -p $out/share/doc/$name
+    cd Documentation
+    install -m 644 -t $out/share/doc/$name *.css *.def *.html *.php *.png *.txt
+  '';
+
+  meta = {
+    description = "A portable, CLI-driven, SDL+OpenGL-based, multi-system emulator";
+    homepage = http://mednafen.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.AndersonTorres ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/misc/emulators/mednafen/server.nix
+++ b/pkgs/misc/emulators/mednafen/server.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+
+  name = "mednafen-server-${version}";
+  version = "0.5.1";
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/mednafen/Mednafen-Server/${version}/${name}-${version}.tar.gz";
+    sha256="0c5wvg938y3h4n5lb0dl8pvmjzphhkbba34r6ikpvdahq166ps4j";
+  };
+
+  postInstall = ''
+    mkdir -p $out/share/$name 
+    install -m 644 -t $out/share/$name standard.conf
+  '';
+
+  meta = {
+    description = "Netplay server for Mednafen";
+    homepage = http://mednafen.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.AndersonTorres ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1438,6 +1438,10 @@ let
     inherit (gnome) scrollkeeper;
   };
 
+  mednafen = callPackage ../misc/emulators/mednafen { };
+
+  mednafen-server = callPackage ../misc/emulators/mednafen/server.nix { };
+
   megacli = callPackage ../tools/misc/megacli { };
 
   megatools = callPackage ../tools/networking/megatools { };


### PR DESCRIPTION
Mednafen is a portable, CLI-driven, multi-system emulator
