### PR TITLE
fix -G delimiter in call to useradd

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -480,7 +480,7 @@ in {
           if ! id "${u.name}" &>/dev/null; then
             ${pkgs.shadow}/sbin/useradd \
               -g "${u.group}" \
-              -G "${toString u.extraGroups}" \
+              -G "${concatStringsSep "," u.extraGroups}" \
               -s "${u.shell}" \
               -d "${u.home}" \
               ${optionalString u.isSystemUser "--system"} \


### PR DESCRIPTION
The -G flag to `useradd` is currently broken when using `users.mutableUsers=true`; it currently separates groups by space, where it should use use a comma between each group.

You can see the effect by looking at my activation script before applying this fix:
https://gist.github.com/cstrahan/805050545a13a0e1cfcd#file-activate-sh-L52

I've manually tested this with both zero and more than one user. How would one go about writing an automated test for this case?
