### PR TITLE
R: install lib/libR.so for use by other programs such as RStudio

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
       --with-system-pcre
       --with-system-xz
       --with-ICU
+      --enable-R-shlib
       AR=$(type -p ar)
       AWK=$(type -p gawk)
       CC=$(type -p gcc)


### PR DESCRIPTION
Adding the --enable-R-shlib flag creates lib/libR.so; this lets RStudio work.
