### PR TITLE
hgal: haskell library for computation automorphism group of a graph

### DIFF
--- a/pkgs/development/libraries/haskell/hgal/default.nix
+++ b/pkgs/development/libraries/haskell/hgal/default.nix
@@ -1,0 +1,14 @@
+{ cabal, mtl }:
+
+cabal.mkDerivation (self: {
+  pname = "hgal";
+  version = "2.0.0.2";
+  sha256 = "17qw8izy54042g56mp3hdbmqcyk95cdarg58xggniwd85q2l5dpi";
+  buildDepends = [ mtl ];
+  meta = {
+    description = "library for computation automorphism group and canonical labelling of a graph";
+    license = "GPL";
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -965,6 +965,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   hexpat = callPackage ../development/libraries/haskell/hexpat {};
 
+  hgal = callPackage ../development/libraries/haskell/hgal {};  
+
   hourglass = callPackage ../development/libraries/haskell/hourglass {};
 
   hseCpp = callPackage ../development/libraries/haskell/hse-cpp {};


### PR DESCRIPTION
I have added a haskell library hgal-2.0.0.2 which computes automorphism group and canonical labelling of a graph. 
