### PR TITLE
nixos default channel: use http instead of https

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -33,7 +33,7 @@ with lib;
     system.defaultChannel = mkOption {
       internal = true;
       type = types.str;
-      default = https://nixos.org/channels/nixos-14.04;
+      default = http://nixos.org/channels/nixos-14.04;
       description = "Default NixOS channel to which the root user is subscribed.";
     };
 


### PR DESCRIPTION
AFAIK https doesn't work in nixos-rebuild --upgrade. I just stumbled into it on a clean install, and I think that I heard before users complaining about errors like this.

Any comments?
