### PR TITLE
Use pam_env to properly setup system-wide env

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -76,7 +76,7 @@ in
 
     environment.systemPackages = [ glibcLocales ];
 
-    environment.variables =
+    environment.systemVariables =
       { LANG = config.i18n.defaultLocale;
         LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       };

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -19,7 +19,7 @@ in
       default = {};
       description = ''
         A set of environment variables used in the global environment.
-        These variablles will be set on shell initialisation.
+        These variables will be set on shell initialisation.
         The value of each variable can be either a string or a list of
         strings.  The latter is concatenated, interspersed with colon
         characters.

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -19,6 +19,7 @@ in
       default = {};
       description = ''
         A set of environment variables used in the global environment.
+        These variablles will be set on shell initialisation.
         The value of each variable can be either a string or a list of
         strings.  The latter is concatenated, interspersed with colon
         characters.

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -1,0 +1,56 @@
+# This module defines a system-wide environment that will be
+# initialised by pam_env (that is, not only in shells).
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.environment;
+
+in
+
+{
+
+  options = {
+
+    environment.systemVariables = mkOption {
+      default = {};
+      description = ''
+        A set of environment variables used in the global environment.
+        These varibales will be set by PAM.
+        The value of each variable can be either a string or a list of
+        strings.  The latter is concatenated, interspersed with colon
+        characters.
+      '';
+      type = types.attrsOf (mkOptionType {
+        name = "a string or a list of strings";
+        merge = loc: defs:
+          let
+            defs' = filterOverrides defs;
+            res = (head defs').value;
+          in
+          if isList res then concatLists (getValues defs')
+          else if lessThan 1 (length defs') then
+            throw "The option `${showOption loc}' is defined multiple times, in ${showFiles (getFiles defs)}."
+          else if !isString res then
+            throw "The option `${showOption loc}' does not have a string value, in ${showFiles (getFiles defs)}."
+          else res;
+      });
+      apply = mapAttrs (n: v: if isList v then concatStringsSep ":" v else v);
+    };
+
+  };
+
+  config = {
+
+    system.build.pamEnvironment = pkgs.writeText "pam-environment"
+       ''
+         ${concatStringsSep "\n" (
+           (mapAttrsToList (n: v: ''export ${n}="${concatStringsSep ":" v}"'')
+             (zipAttrsWith (const concatLists) ([ (mapAttrs (n: v: [ v ]) cfg.systemVariables) ]))))}
+       '';
+
+  };
+
+}

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -18,7 +18,7 @@ in
       default = {};
       description = ''
         A set of environment variables used in the global environment.
-        These varibales will be set by PAM.
+        These variables will be set by PAM.
         The value of each variable can be either a string or a list of
         strings.  The latter is concatenated, interspersed with colon
         characters.

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -47,7 +47,7 @@ in
     system.build.pamEnvironment = pkgs.writeText "pam-environment"
        ''
          ${concatStringsSep "\n" (
-           (mapAttrsToList (n: v: ''export ${n}="${concatStringsSep ":" v}"'')
+           (mapAttrsToList (n: v: ''${n}="${concatStringsSep ":" v}"'')
              (zipAttrsWith (const concatLists) ([ (mapAttrs (n: v: [ v ]) cfg.systemVariables) ]))))}
        '';
 

--- a/nixos/modules/config/timezone.nix
+++ b/nixos/modules/config/timezone.nix
@@ -24,7 +24,7 @@ with lib;
 
   config = {
 
-    environment.variables.TZDIR = "/etc/zoneinfo";
+    environment.systemVariables.TZDIR = "/etc/zoneinfo";
 
     environment.etc.localtime =
       { source = "${pkgs.tzdata}/share/zoneinfo/${config.time.timeZone}";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -14,6 +14,7 @@
   ./config/power-management.nix
   ./config/pulseaudio.nix
   ./config/shells-environment.nix
+  ./config/system-environment.nix
   ./config/swap.nix
   ./config/sysctl.nix
   ./config/system-path.nix

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -19,13 +19,16 @@ in
     environment.variables =
       { LOCATE_PATH = "/var/cache/locatedb";
         NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-        NIX_PATH =
+        PAGER = "less -R";
+        EDITOR = "nano";
+      };
+
+    environment.systemVariables =
+      { NIX_PATH =
           [ "/nix/var/nix/profiles/per-user/root/channels/nixos"
             "nixpkgs=/etc/nixos/nixpkgs"
             "nixos-config=/etc/nixos/configuration.nix"
           ];
-        PAGER = "less -R";
-        EDITOR = "nano";
       };
 
     environment.profiles =

--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -12,9 +12,11 @@ with lib;
         }
       ];
 
-    environment.variables.OPENSSL_X509_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
-    environment.variables.CURL_CA_BUNDLE = "/etc/ssl/certs/ca-bundle.crt";
-    environment.variables.GIT_SSL_CAINFO = "/etc/ssl/certs/ca-bundle.crt";
+    environment.systemVariables =
+      { OPENSSL_X509_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
+        CURL_CA_BUNDLE         = "/etc/ssl/certs/ca-bundle.crt";
+        GIT_SSL_CAINFO         = "/etc/ssl/certs/ca-bundle.crt";
+      };
 
   };
 

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -186,6 +186,7 @@ let
               "password optional ${pkgs.samba}/lib/security/pam_smbpass.so nullok use_authtok try_first_pass"}
 
           # Session management.
+          session required pam_env.so envfile=${config.system.build.pamEnvironment}
           session required pam_unix.so
           ${optionalString cfg.setLoginUid
               "session required pam_loginuid.so"}

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -58,9 +58,6 @@ in
         # Don't edit this file. Set the NixOS option ‘security.sudo.configFile’ instead.
 
         # Environment variables to keep for root and %wheel.
-        Defaults:root,%wheel env_keep+=LOCALE_ARCHIVE
-        Defaults:root,%wheel env_keep+=NIX_CONF_DIR
-        Defaults:root,%wheel env_keep+=NIX_PATH
         Defaults:root,%wheel env_keep+=TERMINFO_DIRS
         Defaults:root,%wheel env_keep+=TERMINFO
 

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -318,7 +318,7 @@ in
       };
 
     # Set up the environment variables for running Nix.
-    environment.variables = cfg.envVars;
+    environment.systemVariables = cfg.envVars;
 
     environment.extraInit =
       ''


### PR DESCRIPTION
This is the _proper_ fix of  #2688.
