### PR TITLE
fish: Fixed tab completion with sudo

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
         -e "s|which |${which}/bin/which |" \
         -i "$out/share/fish/functions/_.fish"
     sed -i "s|Popen(\['manpath'|Popen(\['${man_db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"
+    sed -i "s|/sbin /usr/sbin||" \
+           "$out/share/fish/functions/__fish_complete_subcommand_root.fish"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
When hitting tab on a sudo command in fish, I get the following error message:

```
set: Warning: path component /sbin may not be valid in PATH.
set: No such file or directory
set: Warning: path component /usr/sbin may not be valid in PATH.
set: No such file or directory
```

This is because we don't have /sbin and /usr/sbin. I replaced them with more suitable values.
