### PR TITLE
network-manager: Fix all plugins to use gnome3 and gtk3, like nm-applet does

### DIFF
--- a/pkgs/tools/networking/network-manager/openconnect.nix
+++ b/pkgs/tools/networking/network-manager/openconnect.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openconnect, intltool, pkgconfig, networkmanager
-, withGnome ? true, gtk2, gconf, libgnome_keyring, procps, module_init_tools }:
+, withGnome ? true, gnome3, procps, module_init_tools }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ openconnect networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gtk2 libgnome_keyring gconf ];
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring gnome3.gconf ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 
   configureFlags = [
-    "${if withGnome then "--with-gnome --with-gtkver=2" else "--without-gnome"}"
+    "${if withGnome then "--with-gnome --with-gtkver=3" else "--without-gnome"}"
     "--disable-static"
   ];
 

--- a/pkgs/tools/networking/network-manager/openvpn.nix
+++ b/pkgs/tools/networking/network-manager/openvpn.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openvpn, intltool, pkgconfig, networkmanager
-, withGnome ? true, gtk2, libgnome_keyring, procps, module_init_tools }:
+, withGnome ? true, gnome3, procps, module_init_tools }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ openvpn networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gtk2 libgnome_keyring ];
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 
   configureFlags = [
-    "${if withGnome then "--with-gnome --with-gtkver=2" else "--without-gnome"}"
+    "${if withGnome then "--with-gnome --with-gtkver=3" else "--without-gnome"}"
     "--disable-static"
   ];
 

--- a/pkgs/tools/networking/network-manager/pptp.nix
+++ b/pkgs/tools/networking/network-manager/pptp.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, networkmanager, pptp, ppp, intltool, pkgconfig, substituteAll
-, withGnome ? false, gtk, libgnome_keyring }:
+, withGnome ? true, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ networkmanager pptp ppp ]
-    ++ stdenv.lib.optionals withGnome [ gtk libgnome_keyring ];
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 
   configureFlags =
-    if withGnome then "--with-gnome --with-gtkver=2" else "--without-gnome";
+    if withGnome then "--with-gnome --with-gtkver=3" else "--without-gnome";
 
   postConfigure = "sed 's/-Werror//g' -i Makefile */Makefile";
 

--- a/pkgs/tools/networking/network-manager/vpnc.nix
+++ b/pkgs/tools/networking/network-manager/vpnc.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, vpnc, intltool, pkgconfig, networkmanager
-, withGnome ? true, gtk2, libgnome_keyring, procps, module_init_tools }:
+, withGnome ? true, gnome3, procps, module_init_tools }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -14,12 +14,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ vpnc networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gtk2 libgnome_keyring ];
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 
   configureFlags = [
-    "${if withGnome then "--with-gnome --with-gtkver=2" else "--without-gnome"}"
+    "${if withGnome then "--with-gnome --with-gtkver=3" else "--without-gnome"}"
     "--disable-static"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1565,11 +1565,9 @@ let
 
   networkmanager_pptp = callPackage ../tools/networking/network-manager/pptp.nix { };
 
-  networkmanager_pptp_gnome = networkmanager_pptp.override { withGnome = true; };
-
   networkmanager_vpnc = callPackage ../tools/networking/network-manager/vpnc.nix { };
 
-  networkmanager_openconnect = callPackage ../tools/networking/network-manager/openconnect.nix { gconf = gnome.GConf; };
+  networkmanager_openconnect = callPackage ../tools/networking/network-manager/openconnect.nix { };
 
   networkmanagerapplet = newScope gnome ../tools/networking/network-manager-applet { };
 

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -1190,7 +1190,6 @@ let
   networkmanager = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   networkmanagerapplet = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   networkmanager_pptp = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
-  networkmanager_pptp_gnome = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   neverball = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   nfsUtils = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };
   ngspice = { type = "job"; systems = ["x86_64-linux"]; schedulingPriority = 4; };


### PR DESCRIPTION
I think this makes sense, because now all the plugins will be gnome3 gtk3
based, the same way nm-applet is.

I also removed networkmanager_pptp_gnome variation of networkmanager_pptp
package, because i think no variation is needed and gnome support should
be on by default like in other plugins.
