### PR TITLE
xca: fix package

### DIFF
--- a/pkgs/applications/misc/xca/default.nix
+++ b/pkgs/applications/misc/xca/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, which, openssl, qt4, libtool }:
+{ stdenv, fetchurl, pkgconfig, which, openssl, qt4, libtool, gcc, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "xca-${version}";
@@ -15,7 +15,12 @@ stdenv.mkDerivation rec {
     prefix=$out ./configure ${openssl} ${libtool}
   '';
 
-  buildInputs = [ openssl qt4 libtool ];
+  postInstall = ''
+    wrapProgram "$out/bin/xca" \
+      --prefix LD_LIBRARY_PATH : "${qt4}/lib:${gcc.gcc}/lib:${gcc.gcc}/lib64:${openssl}/lib:${libtool}/lib"
+  '';
+
+  buildInputs = [ openssl qt4 libtool gcc makeWrapper ];
   nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
For some reason library paths are not set at all for some libraries during the build(they were set, but not anymore). Wrapper with LD_LIBRARY_PATH set for relevant libraries is currently solution.

If you know better fix please let me know :)
