### PR TITLE
IMM RSS reader and dependencies

### DIFF
--- a/pkgs/development/libraries/haskell/imm/default.nix
+++ b/pkgs/development/libraries/haskell/imm/default.nix
@@ -1,0 +1,27 @@
+{ cabal, async, caseInsensitive, cond, dataDefault, dyre, feed
+, filepath, hslogger, httpConduit, httpTypes, lens, mimeMail
+, monadControl, mtl, network, opml, random, resourcet, text
+, textIcu, time, timerep, tls, transformers, transformersBase
+, utf8String, xdgBasedir, xml
+}:
+
+cabal.mkDerivation (self: {
+  pname = "imm";
+  version = "0.6.0.1";
+  sha256 = "11m6937wafl6nic69mbibrjnxib503907y21n9zmsxc8vnjl3pps";
+  patches = [ ./latest-feed-http-conduit-tls.patch ];
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    async caseInsensitive cond dataDefault dyre feed filepath hslogger
+    httpConduit httpTypes lens mimeMail monadControl mtl network opml
+    random resourcet text textIcu time timerep tls transformers
+    transformersBase utf8String xdgBasedir xml
+  ];
+  meta = {
+    description = "Retrieve RSS/Atom feeds and write one mail per new item in a maildir";
+    license = "unknown";
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ "Daniel Bergey <bergey@teallabs.org>" ];
+  };
+})

--- a/pkgs/development/libraries/haskell/imm/latest-feed-http-conduit-tls.patch
+++ b/pkgs/development/libraries/haskell/imm/latest-feed-http-conduit-tls.patch
@@ -1,0 +1,73 @@
+# HG changeset patch
+# User Daniel Bergey <bergey@alum.mit.edu>
+# Date 1398284724 0
+#      Wed Apr 23 20:25:24 2014 +0000
+# Node ID 4cc692e7acc4f21ffab9e5572d286495791d22d1
+# Parent  31e3ba1aaaf9efdce66e8ef5c192d0f4214150f4
+Update for feed-0.3.9.2, http-conduit-2.0, tls-1.2
+
+diff -r 31e3ba1aaaf9 -r 4cc692e7acc4 Imm/Error.hs
+--- a/Imm/Error.hs	Sun Jun 16 12:23:40 2013 +0200
++++ b/Imm/Error.hs	Wed Apr 23 20:25:24 2014 +0000
+@@ -41,7 +41,7 @@
+ data ImmError =
+     OtherError         String
+   | HTTPError          HttpException
+-  | TLSError           HandshakeFailed
++  | TLSError           TLSException
+   | UnicodeError       UnicodeException
+   | ParseUriError      String
+   | ParseTimeError     String
+@@ -63,7 +63,7 @@
+         "/!\\ Cannot parse date from item: ",
+         "    title: "       ++ (show $ getItemTitle item),
+         "    link:"         ++ (show $ getItemLink item),
+-        "    publish date:" ++ (show $ getItemPublishDate item),
++        "    publish date:" ++ (show (getItemPublishDate item :: Maybe (Maybe UTCTime))),
+         "    date:"         ++ (show $ getItemDate item)]
+     show (ParseTimeError raw)      = "/!\\ Cannot parse time: " ++ raw
+     show (ParseFeedError raw)      = "/!\\ Cannot parse feed: " ++ raw
+diff -r 31e3ba1aaaf9 -r 4cc692e7acc4 Imm/HTTP.hs
+--- a/Imm/HTTP.hs	Sun Jun 16 12:23:40 2013 +0200
++++ b/Imm/HTTP.hs	Wed Apr 23 20:25:24 2014 +0000
+@@ -50,13 +50,13 @@
+     either throwError return res
+ 
+ -- | Monad-agnostic version of 'parseUrl'
+-parseURL :: (MonadBase IO m, MonadError ImmError m) => String -> m (Request m')
++parseURL :: (MonadBase IO m, MonadError ImmError m) => String -> m Request
+ parseURL uri = do
+     result <- io $ (Right <$> parseUrl uri) `catch` (return . Left . HTTPError)
+     either throwError return result
+ 
+ -- | Build an HTTP request for given URI
+-request :: (MonadBase IO m, MonadError ImmError m) => String -> m (Request a)
++request :: (MonadBase IO m, MonadError ImmError m) => String -> m Request
+ request uri = do
+     req <- parseURL uri
+     return $ req { requestHeaders = [
+diff -r 31e3ba1aaaf9 -r 4cc692e7acc4 imm.cabal
+--- a/imm.cabal	Sun Jun 16 12:23:40 2013 +0200
++++ b/imm.cabal	Wed Apr 23 20:25:24 2014 +0000
+@@ -46,10 +46,10 @@
+         data-default,
+         directory,
+         dyre,
+-        feed,
++        feed == 0.3.9.2,
+         filepath,
+         hslogger,
+-        http-conduit >= 1.9.0,
++        http-conduit >= 2.0 && < 2.2,
+         http-types,
+         lens,
+         mime-mail,
+@@ -66,7 +66,7 @@
+         transformers,
+         time,
+         timerep >= 1.0.3,
+-        tls,
++        tls >= 1.2 && < 1.3,
+         utf8-string,
+         xdg-basedir,
+         xml

--- a/pkgs/development/libraries/haskell/opml/default.nix
+++ b/pkgs/development/libraries/haskell/opml/default.nix
@@ -1,0 +1,13 @@
+{ cabal, xml }:
+
+cabal.mkDerivation (self: {
+  pname = "opml";
+  version = "0.4";
+  sha256 = "1bnr6lkcf2qs7pvrmd8a5xmklcg67l64b776hzclfvxqy1qil29x";
+  buildDepends = [ xml ];
+  meta = {
+    description = "Representing and handling OPML subscription information";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/timerep/default.nix
+++ b/pkgs/development/libraries/haskell/timerep/default.nix
@@ -1,0 +1,12 @@
+{ cabal }:
+
+cabal.mkDerivation (self: {
+  pname = "timerep";
+  version = "1.0.3";
+  sha256 = "14lz8nzfy1j7snvifbwjkk1fjc8wy4jk67xk9n87r25v3cva3x0p";
+  meta = {
+    description = "Parse and display time according to some RFCs (RFC3339, RFC2822)";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1172,6 +1172,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   ieee754 = callPackage ../development/libraries/haskell/ieee754 {};
 
+  imm = callPackage ../development/libraries/haskell/imm {};
+
   indents = callPackage ../development/libraries/haskell/indents {};
 
   indexed = callPackage ../development/libraries/haskell/indexed {};
@@ -1551,6 +1553,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   opensslStreams = callPackage ../development/libraries/haskell/openssl-streams {};
 
   operational = callPackage ../development/libraries/haskell/operational {};
+
+  opml = callPackage ../development/libraries/haskell/opml {};
 
   options = callPackage ../development/libraries/haskell/options {};
 
@@ -2172,6 +2176,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   time_1_1_2_4 = callPackage ../development/libraries/haskell/time/1.1.2.4.nix {};
   time_1_4_2 = callPackage ../development/libraries/haskell/time/1.4.2.nix {};
   time = null;                  # core package since ghc >= 6.12.x
+
+  timerep = callPackage ../development/libraries/haskell/timerep {};
 
   timeparsers = callPackage ../development/libraries/haskell/timeparsers {
     convertible = self.convertible_1_0_11_1;


### PR DESCRIPTION
The patch I've applied below has been accepted upstream (https://bitbucket.org/k0ral/imm/pull-request/1/update-for-feed-0392-http-conduit-20-tls/diff) but not yet released to Hackage.  It is needed to build against the latest versions of these dependencies.

I've tested this by using `imm` for my RSS reading for the last few weeks.
