### PR TITLE
transmission: Update from 2.82 -> 2.83 + fixes

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -125,13 +125,17 @@ in
           #include <abstractions/base>
           #include <abstractions/nameservice>
 
-          ${pkgs.glibc}/lib/*.so             mr,
-          ${pkgs.libevent}/lib/libevent*.so* mr,
-          ${pkgs.curl}/lib/libcurl*.so*      mr,
-          ${pkgs.openssl}/lib/libssl*.so*    mr,
-          ${pkgs.openssl}/lib/libcrypto*.so* mr,
-          ${pkgs.zlib}/lib/libz*.so*         mr,
-          ${pkgs.libssh2}/lib/libssh2*.so*   mr,
+          ${pkgs.glibc}/lib/*.so               mr,
+          ${pkgs.libevent}/lib/libevent*.so*   mr,
+          ${pkgs.curl}/lib/libcurl*.so*        mr,
+          ${pkgs.openssl}/lib/libssl*.so*      mr,
+          ${pkgs.openssl}/lib/libcrypto*.so*   mr,
+          ${pkgs.zlib}/lib/libz*.so*           mr,
+          ${pkgs.libssh2}/lib/libssh2*.so*     mr,
+          ${pkgs.systemd}/lib/libsystemd*.so*  mr,
+          ${pkgs.xz}/lib/liblzma*.so*          mr,
+          ${pkgs.libgcrypt}/lib/libgcrypt*.so* mr,
+          ${pkgs.libgpgerror}/lib/libgpg-error*.so* mr,
 
           @{PROC}/sys/kernel/random/uuid   r,
           @{PROC}/sys/vm/overcommit_memory r,

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, file, makeWrapper
-, openssl, curl, libevent, inotifyTools
+, openssl, curl, libevent, inotifyTools, systemd
 , enableGTK3 ? false, gtk3
 }:
 
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ pkgconfig intltool file openssl curl libevent inotifyTools ]
-    ++ optionals enableGTK3 [ gtk3 makeWrapper ];
+    ++ optionals enableGTK3 [ gtk3 makeWrapper ]
+    ++ optional stdenv.isLinux systemd;
 
   preConfigure = ''
     sed -i -e 's|/usr/bin/file|${file}/bin/file|g' configure

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "2.82";
+  version = "2.83";
 in
 
 with { inherit (stdenv.lib) optional optionals optionalString; };
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.transmissionbt.com/files/transmission-${version}.tar.xz";
-    sha256 = "08imy28hpjxwdzgvhm66hkfyzp8qnnqr4jhv3rgshryzhw86b5ir";
+    sha256 = "0cqlgl6jmjw1caybz6nzh3l8z0jak1dxba01isv72zvy2r8b1qdh";
   };
 
   buildInputs = [ pkgconfig intltool file openssl curl libevent inotifyTools ]


### PR DESCRIPTION
Note that for some reason the settings file got corrupted during the upgrade and the transmission service wouldn't start anymore.

To workaround the problem I had to do `rm /var/lib/transmission/.config/transmission-daemon/settings.json` and then restart the service.

I'm not sure what went wrong there or how to fix it...
