### PR TITLE
Added an option to configure sensitivity and speed of trackpoints.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -317,6 +317,7 @@
   ./tasks/network-interfaces.nix
   ./tasks/scsi-link-power-management.nix
   ./tasks/swraid.nix
+  ./tasks/trackpoint.nix
   ./testing/service-runner.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containers.nix

--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+
+  options = {
+
+    hardware.trackpoint = {
+
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable sensitivity and speed configuration for trackpoints.
+        '';
+      };
+  
+      sensitivity = mkOption {
+        default = 128;
+        example = 255;
+        type = types.int;
+        description = ''
+          Configure the trackpoint sensitivity. By default, the kernel
+          configures 128.
+        '';
+      };
+
+      speed = mkOption {
+        default = 97;
+        example = 255;
+        type = types.int;
+        description = ''
+          Configure the trackpoint sensitivity. By default, the kernel
+          configures 97.
+        '';
+      };
+      
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.hardware.trackpoint.enable {
+
+    jobs.trackpoint =
+      { description = "Initialize trackpoint";
+
+        startOn = "started udev";
+
+        task = true;
+
+        script = ''
+          echo -n ${toString config.hardware.trackpoint.sensitivity} \
+            > /sys/devices/platform/i8042/serio1/sensitivity
+          echo -n ${toString config.hardware.trackpoint.speed} \
+            > /sys/devices/platform/i8042/serio1/speed
+        '';
+      };
+         
+  };
+
+}


### PR DESCRIPTION
This adds trackpoint.nix from NixOS/nixos@f09da4030ae0595672cbe9215d767f403a1af285 and extends it with the possibility to configure speed.
