### PR TITLE
free-game: jailbreak due to new OpenGLRaw version

### DIFF
--- a/pkgs/development/libraries/haskell/free-game/1.0.5.nix
+++ b/pkgs/development/libraries/haskell/free-game/1.0.5.nix
@@ -13,6 +13,9 @@ cabal.mkDerivation (self: {
     hashable JuicyPixels JuicyPixelsUtil lens linear mtl OpenGL
     OpenGLRaw random reflection transformers vector void
   ];
+
+  jailbreak = true;
+
   meta = {
     homepage = "https://github.com/fumieval/free-game";
     description = "Create games for free";

--- a/pkgs/development/libraries/haskell/free-game/1.1.nix
+++ b/pkgs/development/libraries/haskell/free-game/1.1.nix
@@ -13,6 +13,9 @@ cabal.mkDerivation (self: {
     hashable JuicyPixels JuicyPixelsUtil lens linear mtl OpenGL
     OpenGLRaw random reflection transformers vector void
   ];
+
+  jailbreak = true;
+
   meta = {
     homepage = "https://github.com/fumieval/free-game";
     description = "Create games for free";


### PR DESCRIPTION
This allows it to keep building after
ba5473676f867e32e9be5c2225ab4e8c8ded2be2 was pushed. Perhaps we should
add the extra OpenGL versions (2.9.1.0) and specify strict versions so
that it doesn't fail to build in 2 weeks.
