### PR TITLE
Galculator: add version 2.3.1

### DIFF
--- a/pkgs/applications/misc/galculator/default.nix
+++ b/pkgs/applications/misc/galculator/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl
+, intltool, pkgconfig, gtk
+ }:
+
+stdenv.mkDerivation rec {
+  
+  name = "galculator-${version}";
+  version = "2.1.3";
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/galculator/${name}.tar.gz";
+    sha256 = "12m7dldjk10lpkdxk7zpk98n32ci65zmxidghihb7n1m3rhp3q17";
+  };
+
+  buildInputs = [ intltool pkgconfig gtk ];
+
+  meta = {
+    description = "A GTK 2/3 algebraic and RPN calculator";
+    longDescription = ''
+      galculator is a GTK 2 / GTK 3 based calculator. Its main features include:
+
+      - Algebraic, RPN (Reverse Polish Notation), Formula Entry and Paper modes;
+      - Basic and Scientific Modes
+      - Decimal, hexadecimal, octal and binary number base
+      - Radiant, degree and grad support
+      - User defined constants and functions
+      - A bunch of common functions
+      - Binary arithmetic of configurable bit length and signedness
+      - Quad-precision floating point arithmetic, and 112-bit binary arithmetic
+    '';
+    homepage = http://galculator.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1070,6 +1070,10 @@ let
 
   g500-control = callPackage ../tools/misc/g500-control { };
 
+  galculator = callPackage ../applications/misc/galculator {
+    gtk = gtk3;
+  };
+
   gawk = callPackage ../tools/text/gawk { };
 
   gawkInteractive = appendToName "interactive"


### PR DESCRIPTION
Galculator is a GTK full-fledged calculator.
It will substitute mate-calc, the Mate Desktop's calculator.

P.S.: Mate wasn't released yet for NixOS - but I am working on it!
