### PR TITLE
nixos: add 'gvfs' when using GNOME3 desktop

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -108,6 +108,7 @@ in {
         gnome3.gtk3 # for gtk-update-icon-cache
         pkgs.ibus
         pkgs.shared_mime_info # for update-mime-database
+        gnome3.gvfs
         gnome3.dconf
         gnome3.gnome-backgrounds
         gnome3.gnome_control_center


### PR DESCRIPTION
One reason for adding this is to make Chromium able to open files it has
downloaded.

Currently this happens:
  /run/current-system/sw/bin/xdg-open: line 364: gnome-open: command not found

(And nothing happens in the GUI when clicking a downloaded file.)

Looking into xdg-open, one can see that it first tries to run gvfs-open
and then falls back to gnome-open. Adding 'gvfs' makes the first command
succeed.
