### PR TITLE
add lohit-fonts-20140220

### DIFF
--- a/pkgs/data/fonts/lohit-fonts/default.nix
+++ b/pkgs/data/fonts/lohit-fonts/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "lohit-fonts-20140220";
+  src = fetchurl {
+    url = https://fedorahosted.org/releases/l/o/lohit/lohit-ttf-20140220.tar.gz;
+    sha256 = "1rmgr445hw1n851ywy28csfvswz1i6hnc8mzp88qw2xk9j4dn32d";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://fedorahosted.org/lohit/;
+    description = "Fonts for 21 Indian languages";
+    license = licenses.ofl;
+    maintainers = [ maintainers.ttuegel ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7752,6 +7752,8 @@ let
 
   lmodern = callPackage ../data/fonts/lmodern { };
 
+  lohit-fonts = callPackage ../data/fonts/lohit-fonts { };
+
   manpages = callPackage ../data/documentation/man-pages { };
 
   miscfiles = callPackage ../data/misc/miscfiles { };


### PR DESCRIPTION
Lohit is a set of fonts covering 21 Indian languages developed by Red Hat. With this minor addition, I think Nixpkgs will have fonts covering all the major world languages!
