### PR TITLE
ark: wrap for zipinfo

### DIFF
--- a/pkgs/desktops/kde-4.12/kdeutils/ark.nix
+++ b/pkgs/desktops/kde-4.12/kdeutils/ark.nix
@@ -1,7 +1,15 @@
-{ kde, kdelibs, libarchive, bzip2, kde_baseapps, lzma, qjson }:
+{ makeWrapper, kde, kdelibs, libarchive, bzip2, kde_baseapps, lzma, qjson
+, unzip }:
 
 kde {
-  buildInputs = [ kdelibs kde_baseapps libarchive bzip2 lzma qjson ];
+  buildInputs = [
+    makeWrapper kdelibs kde_baseapps libarchive bzip2 lzma qjson
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ark \
+      --prefix PATH ":" "${unzip}/bin"
+  '';
 
   meta = {
     description = "KDE Archiving Tool";


### PR DESCRIPTION
Ark requires the `zipinfo` program from the `unzip` package to be on its `PATH`, so we should wrap the Ark executable.
