### PR TITLE
ncmpc: propable fix for x86_64-darwin build error

### DIFF
--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, ncurses, mpd_clientlib }:
+{ stdenv, fetchurl, pkgconfig, glib, ncurses, mpd_clientlib, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   version = "0.21";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "648e846e305c867cb937dcb467393c2f5a30bf460bdf77b63de7af69fba1fd07";
   };
 
-  buildInputs = [ pkgconfig glib ncurses mpd_clientlib ];
+  buildInputs = [ pkgconfig glib ncurses mpd_clientlib libintlOrEmpty ];
 
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";


### PR DESCRIPTION
This patch should fix http://hydra.nixos.org/build/11243446.
