### PR TITLE
haskell-glutil: add version 0.7.4

### DIFF
--- a/pkgs/development/libraries/haskell/GLUtil/default.nix
+++ b/pkgs/development/libraries/haskell/GLUtil/default.nix
@@ -1,0 +1,16 @@
+{ cabal, cpphs, JuicyPixels, linear, OpenGL, OpenGLRaw, vector }:
+
+cabal.mkDerivation (self: {
+  pname = "GLUtil";
+  version = "0.7.4";
+  sha256 = "0l1w0k3q5g22y90w5frljqh1v4jb7gjzb3scg79zp42pc9v3h4l5";
+  buildDepends = [
+    cpphs JuicyPixels linear OpenGL OpenGLRaw vector
+  ];
+  buildTools = [ cpphs ];
+  meta = {
+    description = "Miscellaneous OpenGL utilities";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -895,6 +895,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   };
   GLUT = self.GLUT_2_5_1_1;
 
+  GLUtil = callPackage ../development/libraries/haskell/GLUtil {};
+
   gnuidn = callPackage ../development/libraries/haskell/gnuidn {};
 
   gnuplot = callPackage ../development/libraries/haskell/gnuplot {};


### PR DESCRIPTION
Adds the OpenGL helper library GLUtil. Generated by cabal2nix without any further modifications.
