### PR TITLE
Definitions for Open Dylan 2013.2 (Dylan Language Implementation)

### DIFF
--- a/pkgs/development/compilers/opendylan/bin.nix
+++ b/pkgs/development/compilers/opendylan/bin.nix
@@ -1,0 +1,41 @@
+# Binaries provided by Open Dylan to be used to bootstrap from source.
+# The binaries can also be used as is.
+{stdenv, fetchurl, patchelf, boehmgc, gnused, gcc, makeWrapper}:
+
+stdenv.mkDerivation {
+  name = "opendylan-2013.2";
+
+  src = if stdenv.system == "x86_64-linux" then fetchurl {
+      url = http://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86_64-linux.tar.bz2;
+      sha256 = "035brbw3hm7zrs593q4zc42yglj1gmmkw3b1r7zzlw3ks4i2lg7h";
+    }
+    else if stdenv.system == "i686-linux" then fetchurl {
+      url = http://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86-linux.tar.bz2;
+      sha256 = "0c61ihvblcsjrw6ncr8x8ylhskcrqs8pajs4mg5di36cvqw12nq5";
+    }
+    else throw "platform ${stdenv.system} not supported.";
+
+  buildInputs = [ patchelf boehmgc gnused makeWrapper ];
+
+  buildCommand = ''
+    mkdir -p "$out"
+    tar --strip-components=1 -xjf "$src" -C "$out"
+
+    interpreter="$(cat "$NIX_GCC"/nix-support/dynamic-linker)"
+    for a in "$out"/bin/*; do 
+      patchelf --set-interpreter "$interpreter" "$a"
+      patchelf --set-rpath "$out/lib:${boehmgc}/lib" "$a"
+    done
+    for a in "$out"/lib/*.so; do 
+      patchelf --set-rpath "$out/lib:${boehmgc}/lib" "$a"
+    done
+    sed -i -e "s|\-lgc|\-L${boehmgc}\/lib -lgc|" $out/lib/config.jam
+    wrapProgram $out/bin/dylan-compiler --suffix PATH : ${gcc}/bin
+  '';
+
+  meta = {
+    homepage = http://opendylan.org;
+    description = "Dylan is a multi-paradigm functional and object-oriented programming language.";
+    license = "MIT";
+  };
+}

--- a/pkgs/development/compilers/opendylan/default.nix
+++ b/pkgs/development/compilers/opendylan/default.nix
@@ -1,0 +1,37 @@
+# Build Open Dylan from source using the binary builds to bootstrap.
+{stdenv, fetchgit, patchelf, boehmgc, mps, gnused, opendylan-bootstrap, autoconf, automake, perl, makeWrapper, gcc }:
+
+stdenv.mkDerivation {
+  name = "opendylan-2013.2";
+
+  src = fetchgit {
+    url = https://github.com/dylan-lang/opendylan;
+    rev = "ce9b14dab6cb9ffedc69fae8c6df524c0c79abd3";
+    sha256 = "cec80980b838ac2581dfb6282e25d208e720d475256b75e24b23dbd30b09d21f";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = (if stdenv.system == "i686-linux" then [ mps ] else [ boehmgc ]) ++ [
+    opendylan-bootstrap boehmgc gnused autoconf automake perl makeWrapper
+  ] ;
+
+  preConfigure = if stdenv.system == "i686-linux" then ''
+    mkdir -p $TMPDIR/mps
+    tar --strip-components=1 -xf ${mps.src} -C $TMPDIR/mps
+    ./autogen.sh
+  ''
+  else ''
+    ./autogen.sh
+  '';
+
+  configureFlags = if stdenv.system == "i686-linux" then "--with-mps=$(TMPDIR)/mps" else "--with-gc=${boehmgc}";
+  buildPhase = "make 3-stage-bootstrap";
+
+  postInstall = "wrapProgram $out/bin/dylan-compiler --suffix PATH : ${gcc}/bin";
+
+  meta = {
+    homepage = http://opendylan.org;
+    description = "Dylan is a multi-paradigm functional and object-oriented programming language.";
+    license = "MIT";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1661,6 +1661,12 @@ let
 
   opendkim = callPackage ../development/libraries/opendkim { };
 
+  opendylan = callPackage ../development/compilers/opendylan {
+    opendylan-bootstrap = opendylan_bin;
+  };
+
+  opendylan_bin = callPackage ../development/compilers/opendylan/bin.nix { };
+
   openjade = callPackage ../tools/text/sgml/openjade {
     perl = perl510;
   };


### PR DESCRIPTION
Open Dylan is an implementation of the Dylan programming language. They provide prebuilt binaries, which the opendylan_bin derivation exposes. They provide source in github which is what the opendylan derivation is used to build native binaries. The opendylan derivation requires an existing dylan compiler to bootstrap from and by default uses the prebuilt binaries in opendylan_bin.
