### PR TITLE
PPSSPP: 0.9.8

### DIFF
--- a/pkgs/misc/emulators/ppsspp/bump-version-to-0.9.8.patch
+++ b/pkgs/misc/emulators/ppsspp/bump-version-to-0.9.8.patch
@@ -1,0 +1,22 @@
+From 48f6bf352154511d5acddfe44dd241c6a9ed92d7 Mon Sep 17 00:00:00 2001
+From: Bhavin <bhavin192@users.noreply.github.com>
+Date: Tue, 6 May 2014 22:44:58 +0530
+Subject: [PATCH] Update vaersion to 0.9.8
+
+It was 0.9.6 :(
+---
+ Qt/Settings.pri | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Qt/Settings.pri b/Qt/Settings.pri
+index 8b4c1d7..67949f2 100644
+--- a/Qt/Settings.pri
++++ b/Qt/Settings.pri
+@@ -1,4 +1,4 @@
+-VERSION = 0.9.6
++VERSION = 0.9.8
+ DEFINES += USING_QT_UI USE_FFMPEG
+ unix:!qnx:!symbian:!mac: CONFIG += linux
+ maemo5|contains(MEEGO_EDITION,harmattan): CONFIG += maemo
+--
+1.9.3

--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, zlib, libpng, qt4, pkgconfig
+, withGamepads ? true, SDL # SDL is used for gamepad functionality
+}:
+
+let
+  version = "0.9.8";
+  fstat = x: fn: "-D" + fn + "=" + (if x then "ON" else "OFF");
+in stdenv.mkDerivation {
+  name = "PPSSPP-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/hrydgard/ppsspp.git";
+    sha256 = "11sqhb2m3502dzbizahh1w2dl7jv3fipwxyrmryj8fyaqqw0i36q";
+    rev = "cbc46be3f91cb8558fbb4b175b14e8e16cbf0243";
+    fetchSubmodules = true;
+  };
+
+  # Upstream forgot to bump a version in one file.
+  patches = [ ./bump-version-to-0.9.8.patch ];
+
+  buildInputs = [ zlib libpng pkgconfig qt4 ]
+                ++ (if withGamepads then [ SDL ] else [ ]);
+
+  configurePhase = "cd Qt && qmake PPSSPPQt.pro";
+  installPhase = "mkdir -p $out/bin && cp PPSSPPQt $out/bin";
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.ppsspp.org/";
+    description = "A PSP emulator, the Qt4 version.";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.fuuzetsu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1155,7 +1155,7 @@ let
   gnuvd = callPackage ../tools/misc/gnuvd { };
 
   goaccess = callPackage ../tools/misc/goaccess { };
-  
+
   googleAuthenticator = callPackage ../os-specific/linux/google-authenticator { };
 
   gource = callPackage ../applications/version-management/gource {};
@@ -3462,7 +3462,7 @@ let
 
   # mercurial (hg) bleeding edge version
   octaveHG = callPackage ../development/interpreters/octave/hg.nix { };
-  
+
   ocropus = callPackage ../applications/misc/ocropus { };
 
   perl58 = callPackage ../development/interpreters/perl/5.8 {
@@ -10866,6 +10866,8 @@ let
   pjsip = callPackage ../applications/networking/pjsip { };
 
   polytable = callPackage ../tools/typesetting/tex/polytable { };
+
+  PPSSPP = callPackage ../misc/emulators/ppsspp { };
 
   uae = callPackage ../misc/emulators/uae { };
 


### PR DESCRIPTION
The Qt way is recommended although there are more options if someone
wants to put those in.

The patch is something upstream forgot to do at release time and someone fixed up few weeks after. It is necessary as the version is user-visible.
