### PR TITLE
Change stdenv on darwin to not set NIX_ENFORCE_PURITY

### DIFF
--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -9,6 +9,7 @@ import ../generic rec {
       export NIX_IGNORE_LD_THROUGH_GCC=1
 
       if [ "$system" = "i686-darwin" -o "$system" = "powerpc-darwin" -o "$system" = "x86_64-darwin" ]; then
+        export NIX_ENFORCE_PURITY=
         export NIX_DONT_SET_RPATH=1
         export NIX_NO_SELF_RPATH=1
         dontFixLibtool=1


### PR DESCRIPTION
This fixes #2502, but it should only be necessary when clangStdenv is being used.  The regular stdenv on darwin does not need this patch; I'm just not sure of the best way to bring that decision down to this point.  Also, I'm unclear as to which hordes of evil I'm inviting to the party by unsetting this.

See the notes in #2208 for the error being raised in ld-wrapper.sh which prompted me to make this change.  With it, I can now build derivations that require clangStdenv, like emacs24 and SDL.
