### PR TITLE
Fix getopt path on darwin for password-store

### DIFF
--- a/pkgs/tools/security/pass/darwin-getopt.patch
+++ b/pkgs/tools/security/pass/darwin-getopt.patch
@@ -1,0 +1,11 @@
+diff --git a/src/platform/darwin.sh b/src/platform/darwin.sh
+index 1b76c33..fa40104 100644
+--- a/src/platform/darwin.sh
++++ b/src/platform/darwin.sh
+@@ -31,5 +31,5 @@ tmpdir() {
+ 	mount -t hfs -o noatime -o nobrowse "$ramdisk_dev" "$SECURE_TMPDIR" || exit 1
+ }
+ 
+-GETOPT="$(brew --prefix gnu-getopt 2>/dev/null || echo /usr/local)/bin/getopt"
++GETOPT="getopt"
+ SHRED="srm -f -z"

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1d32y6k625pv704icmhg46zg02kw5zcyxscgljxgy8bb5wv4lv2j";
   };
 
+  patches = [ ./darwin-getopt.patch ];
+
   buildInputs = [ makeWrapper ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Silly brew returns the prefix for any package whether or not it's installed. nix getopt should always be in the path here.
