### PR TITLE
graphite-web: Fix webapp content path

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8915,7 +8915,7 @@ rec {
 
     preConfigure = ''
       substituteInPlace webapp/graphite/thirdparty/pytz/__init__.py --replace '/usr/share/zoneinfo' '/etc/zoneinfo'
-      substituteInPlace webapp/graphite/settings.py --replace "join(WEBAPP_DIR, 'content')" "join(WEBAPP_DIR, 'webapp', 'content')"
+      substituteInPlace webapp/graphite/settings.py --replace "join(WEBAPP_DIR, 'content')" "join('$out', 'webapp', 'content')"
       cp webapp/graphite/manage.py bin/manage-graphite.py
       substituteInPlace bin/manage-graphite.py --replace 'settings' 'graphite.settings'
     '';


### PR DESCRIPTION
WEBAPP_DIR pointed to the python lib directory so webapp assets were not found.
