### PR TITLE
Vim huge nogui

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -11,7 +11,7 @@ composableDerivation {
                    else stdenv ).mkDerivation;
 } (fix: {
 
-    name = "vim_configurable-7.4.23";
+    name = "vim_configurable-7.4.316";
 
     enableParallelBuilding = true; # test this
 
@@ -21,8 +21,8 @@ composableDerivation {
         # latest release
       args.fetchhg {
             url = "https://vim.googlecode.com/hg/";
-            tag = "v7-4-131";
-            sha256 = "1akr0i4pykbrkqwrglm0dfn5nwpncb9pgg4h7fl6a8likbr5f3wb";
+            tag = "v7-4-316";
+            sha256 = "0scxx33p1ky0wihk04xqpd6rygp1crm0hx446zbjwbsjj6xxn7sx";
       };
 
       "vim-nox" =
@@ -35,16 +35,13 @@ composableDerivation {
           }.src;
       };
 
+    prePatch = "cd src";
+
     # if darwin support is enabled, we want to make sure we're not building with
     # OS-installed python framework
-    preConfigure
-      = stdenv.lib.optionalString
-        (stdenv.isDarwin && (config.vim.darwin or true)) ''
-          # TODO: we should find a better way of doing this as, if the configure
-          # file changes, we need to change these line numbers
-          sed -i "5641,5644d" src/auto/configure
-          sed -i "5648d" src/auto/configure
-        '';
+    patches = stdenv.lib.optionals 
+      (stdenv.isDarwin && (config.vim.darwin or true))
+      [ ./python_framework.patch ];
 
     configureFlags
       = [ "--enable-gui=${args.gui}" "--with-features=${args.features}" ];
@@ -53,8 +50,6 @@ composableDerivation {
       = [ ncurses pkgconfig gtk libX11 libXext libSM libXpm libXt libXaw libXau
           libXmu glib libICE ];
 
-    prePatch = "cd src";
-    
     # most interpreters aren't tested yet.. (see python for example how to do it)
     flags = {
         ftNix = {

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,10 +1,13 @@
 # TODO tidy up eg The patchelf code is patching gvim even if you don't build it..
 # but I have gvim with python support now :) - Marc
-args@{source ? "default", ...}: with args;
+args@{source ? "default", withGui ? true, ...}: with args;
 
-
-let inherit (args.composableDerivation) composableDerivation edf; in
-composableDerivation {
+let
+  inherit (args.composableDerivation) composableDerivation edf;
+  guiPkgs = [
+    gtk libX11 libXext libSM libXpm libXt libXaw libXau libXmu glib libICE
+  ];
+in composableDerivation {
   # use gccApple to compile on darwin
   mkDerivation = ( if stdenv.isDarwin
                    then stdenvAdapters.overrideGCC stdenv gccApple
@@ -44,11 +47,10 @@ composableDerivation {
       [ ./python_framework.patch ];
 
     configureFlags
-      = [ "--enable-gui=${args.gui}" "--with-features=${args.features}" ];
+      = [ "--with-features=${args.features}" ] ++ lib.optionals withGui [ "--enable-gui=${args.gui}" ];
 
     nativeBuildInputs
-      = [ ncurses pkgconfig gtk libX11 libXext libSM libXpm libXt libXaw libXau
-          libXmu glib libICE ];
+      = [ ncurses pkgconfig ] ++ lib.optionals withGui guiPkgs;
 
     # most interpreters aren't tested yet.. (see python for example how to do it)
     flags = {

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "vim-${version}";
 
-  version = "7.4.131";
+  version = "7.4.316";
 
   src = fetchhg {
     url = "https://vim.googlecode.com/hg/";
-    tag = "v7-4-131";
-    sha256 = "1akr0i4pykbrkqwrglm0dfn5nwpncb9pgg4h7fl6a8likbr5f3wb";
+    tag = "v7-4-316";
+    sha256 = "0scxx33p1ky0wihk04xqpd6rygp1crm0hx446zbjwbsjj6xxn7sx";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/editors/vim/python_framework.patch
+++ b/pkgs/applications/editors/vim/python_framework.patch
@@ -1,0 +1,23 @@
+diff --git a/src/auto/configure b/src/auto/configure
+index a9755a0..4a0e2a4 100755
+--- a/auto/configure
++++ b/auto/configure
+@@ -5638,10 +5638,6 @@ __:
+ eof
+ 	    	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
+ 	    rm -f -- "${tmp_mkf}"
+-	    if test "x$MACOSX" = "xyes" && ${vi_cv_path_python} -c \
+-		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
+-	      vi_cv_path_python_plibs="-framework Python"
+-	    else
+ 	      if test "${vi_cv_var_python_version}" = "1.4"; then
+ 		  vi_cv_path_python_plibs="${PYTHON_CONFDIR}/libModules.a ${PYTHON_CONFDIR}/libPython.a ${PYTHON_CONFDIR}/libObjects.a ${PYTHON_CONFDIR}/libParser.a"
+ 	      else
+@@ -5649,7 +5645,6 @@ eof
+ 	      fi
+ 	      vi_cv_path_python_plibs="${vi_cv_path_python_plibs} ${python_BASEMODLIBS} ${python_LIBS} ${python_SYSLIBS} ${python_LINKFORSHARED}"
+ 	      	      vi_cv_path_python_plibs=`echo $vi_cv_path_python_plibs | sed s/-ltermcap//`
+-	    fi
+ 
+ fi
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9586,6 +9586,10 @@ let
 
   vimWrapper = wrapVim vim;
 
+  vimHuge = vim_configurable.override { withGui = false; };
+
+  vimHugeWrapper = wrapVim vimHuge;
+
   vimHugeX = vim_configurable;
 
   vimHugeXWrapper = wrapVim vimHugeX;
@@ -9597,6 +9601,7 @@ let
       libICE;
 
     features = "huge"; # one of  tiny, small, normal, big or huge
+    withGui = true;
     lua = pkgs.lua5;
     gui = config.vim.gui or "auto";
 


### PR DESCRIPTION
This builds on my other PR #2807.

This adds `vimHuge` and `vimHugeWrapper` packages by extending `vim_configurable`.

`vim_configurable` now accepts a `withGui` argument; when `false`, `--enable-gui` is elided along with the otherwise requisite nativeBuildInputs.
