### PR TITLE
Fix cygwin support and add support for x86_64-cygwin

### DIFF
--- a/lib/platforms.nix
+++ b/lib/platforms.nix
@@ -7,7 +7,7 @@ rec {
   freebsd = ["i686-freebsd" "x86_64-freebsd"];
   openbsd = ["i686-openbsd" "x86_64-openbsd"];
   netbsd = ["i686-netbsd" "x86_64-netbsd"];
-  cygwin = ["i686-cygwin"];
+  cygwin = ["i686-cygwin" "x86_64-cygwin"];
   unix = linux ++ darwin ++ freebsd ++ openbsd;
   all = linux ++ darwin ++ cygwin ++ freebsd ++ openbsd;
   none = [];

--- a/pkgs/development/interpreters/perl/5.16/default.nix
+++ b/pkgs/development/interpreters/perl/5.16/default.nix
@@ -54,6 +54,12 @@ stdenv.mkDerivation rec {
       ${optionalString stdenv.isArm ''
         configureFlagsArray=(-Dldflags="-lm -lrt")
       ''}
+      
+      ${optionalString stdenv.isCygwin ''
+        cp cygwin/cygwin{,.bak}
+        echo "#define PERLIO_NOT_STDIO 0" > tmp
+        cat tmp cygwin/cygwin.c.bak > cygwin/cygwin.c
+      ''}
     '';
 
   preBuild = optionalString (!(stdenv ? gcc && stdenv.gcc.nativeTools))
@@ -64,7 +70,7 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = stdenv.isLinux;
 
   # some network-related tests don't work, mostly probably due to our sandboxing
   testsToSkip = ''

--- a/pkgs/development/interpreters/perl/5.16/default.nix
+++ b/pkgs/development/interpreters/perl/5.16/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
       ''}
       
       ${optionalString stdenv.isCygwin ''
-        cp cygwin/cygwin{,.bak}
+        cp cygwin/cygwin.c{,.bak}
         echo "#define PERLIO_NOT_STDIO 0" > tmp
         cat tmp cygwin/cygwin.c.bak > cygwin/cygwin.c
       ''}

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -60,7 +60,12 @@ stdenv.mkDerivation {
     else "./config";
 
   configureFlags = "shared --libdir=lib --openssldir=etc/ssl" +
-    stdenv.lib.optionalString withCryptodev " -DHAVE_CRYPTODEV -DUSE_CRYPTODEV_DIGESTS";
+    stdenv.lib.optionalString withCryptodev " -DHAVE_CRYPTODEV -DUSE_CRYPTODEV_DIGESTS" +
+    stdenv.lib.optionalString (stdenv.system == "x86_64-cygwin") " no-asm";
+
+  preBuild = stdenv.lib.optionalString (stdenv.system == "x86_64-cygwin") ''
+    sed -i -e "s|-march=i486|-march=x86-64|g" Makefile
+  '';
 
   makeFlags = "MANDIR=$(out)/share/man";
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -127,7 +127,8 @@ let
              || system == "x86_64-kfreebsd-gnu";
       isSunOS = system == "i686-solaris"
              || system == "x86_64-solaris";
-      isCygwin = system == "i686-cygwin";
+      isCygwin = system == "i686-cygwin"
+              || system == "x86_64-cygwin";
       isFreeBSD = system == "i686-freebsd"
               || system == "x86_64-freebsd";
       isOpenBSD = system == "i686-openbsd"


### PR DESCRIPTION
The following patches fix cygwin support and also implement x86_64-cygwin support.

However, these patches are meaningless if the following pull request to Nix is not accepted (which fixes Cygwin support): https://github.com/NixOS/nix/pull/274
