### PR TITLE
shake: fix binary dependency at binary_0_7_2_1

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2037,7 +2037,9 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   SHA = callPackage ../development/libraries/haskell/SHA {};
 
-  shake = callPackage ../development/libraries/haskell/shake {};
+  shake = callPackage ../development/libraries/haskell/shake {
+    binary = self.binary_0_7_2_1;
+  };
 
   shakespeare = callPackage ../development/libraries/haskell/shakespeare {};
 


### PR DESCRIPTION
@peti I needed this to build hoogle-local with GHC 7.4.2 and 7.6.3, although I never needed it before this week.  Do you know of anything that changed recently to require this?  Is it a correct change?
