### PR TITLE
nixos-iso: Use a simpler disk label

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -19,7 +19,7 @@ with lib;
   # ISO naming.
   isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixosVersion}-${pkgs.stdenv.system}.iso";
 
-  isoImage.volumeID = substring 0 11 "NIXOS_${config.system.nixosVersion}";
+  isoImage.volumeID = substring 0 11 "NIXOS_ISO";
 
   # Make the installer more likely to succeed in low memory
   # environments.  The kernel's overcommit heustistics bite us


### PR DESCRIPTION
When formatting a nixos usb using my windows machine I noticed that the
disk labeling using periods was not compatible with my linux kernel /
udev recognition. When labeling a volume NIXOS_14.10 on Windows, it would show up as
NIXOS_14_10 under NixOS. This meant that /dev/root would never come up at boot time,
preventing the livecd from starting.

This patch works around this issue by eliminating any special characters
other than underscores. The previous versioning didn't seem all that
useful, especially when consdering there are many different version of
the year.month named iso.
