### PR TITLE
Fix xpwn on Darwin and other case-insensitive file systems

### DIFF
--- a/pkgs/development/mobile/xpwn/default.nix
+++ b/pkgs/development/mobile/xpwn/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
   };
 
   preConfigure = ''
+    rm BUILD # otherwise `mkdir build` fails on case insensitive file systems
     sed -r -i \
       -e 's/(install.*TARGET.*DESTINATION )\.\)/\1bin)/' \
       -e 's!(install.*(FILE|DIR).*DESTINATION )([^)]*)!\1share/xpwn/\3!' \


### PR DESCRIPTION
This fixes `xpwn` on Darwin, which is needed to install `xcode`.
