### PR TITLE
Add github atom, a hackable text editor for the 21st Century

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, fetchurl, buildEnv, makeDesktopItem, makeWrapper, zlib, glib, alsaLib
+, dbus, gtk, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
+, cairo, cups, expat, libgpgerror, nspr, gconf, nss, xlibs
+}:
+
+let
+  atomEnv = buildEnv {
+    name = "env-atom";
+    paths = [
+      stdenv.gcc.gcc zlib glib dbus gtk atk pango freetype libgnome_keyring3
+      fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
+      xlibs.libXrender xlibs.libX11 xlibs.libXext xlibs.libXdamage xlibs.libXtst
+      xlibs.libXcomposite xlibs.libXi xlibs.libXfixes
+    ];
+  };
+in stdenv.mkDerivation rec {
+  name = "atom-${version}";
+  version = "0.99.0";
+
+  src = fetchurl {
+      url = https://github.com/hotice/webupd8/raw/master/atom-linux64-0.99.0~git20140525.tar.xz;
+      sha256 = "55c2415c96e1182ae1517751cbea1db64e9962683b384cfe5e182aec10aebecd";
+      name = "${name}.tar.xz";
+  };
+
+  iconsrc = fetchurl {
+    url = https://raw.githubusercontent.com/atom/atom/master/resources/atom.png;
+    sha256 = "66dc0b432eed7bcd738b7c1b194e539178a83d427c78f103041981f2b840e030";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "atom";
+    exec = "atom";
+    icon = iconsrc;
+    comment = "A hackable text editor for the 21st Century";
+    desktopName = "Atom";
+    genericName = "Text editor";
+    categories = "Development;TextEditor";
+  };
+
+  buildInputs = [ atomEnv makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    ensureDir $out/share/atom
+    ensureDir $out/bin
+    tar -C $out/share/atom -xvf $src
+    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      $out/share/atom/atom
+    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      $out/share/atom/resources/app/apm/node_modules/atom-package-manager/bin/node
+    makeWrapper $out/share/atom/atom $out/bin/atom \
+      --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64"
+
+    # Create a desktop item.
+    mkdir -p "$out/share/applications"
+    cp "${desktopItem}"/share/applications/* "$out/share/applications/"  
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A hackable text editor for the 21st Century";
+    homepage = https://atom.io/;
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.offline ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7940,6 +7940,10 @@ let
 
   arora = callPackage ../applications/networking/browsers/arora { };
 
+  atom = callPackage ../applications/editors/atom {
+    gconf = gnome.GConf;
+  };
+
   aseprite = callPackage ../applications/editors/aseprite {
     giflib = giflib_4_1;
   };


### PR DESCRIPTION
These builds are based on unofficial webupd8 builds, because:

Github does not provide official linux builds and it's really hard to build atom from source deterministically, because of it's custom atom package manager and installation scripts(just don't try to write apm2nix, it's nonsense, different hack can be used). I tried really hard, trying to hack their atom package manager, and i failed.  I don't say it is impossible, i just say, that currently it's not worth it. Before it's even sane to package atom from source, we should build `libchromiumcontent` from source(@aszlig do you think is possible ?), and i might try to build atom deterministically from source then.

PS: One of the main atom developers said that they will provide official linux builds, so i might just fix this expression latter to use them.
