### PR TITLE
feh: Set the default theme explicitly to 'feh'

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    wrapProgram "$out/bin/feh" --prefix PATH : "${libjpeg}/bin"
+    wrapProgram "$out/bin/feh" --prefix PATH : "${libjpeg}/bin" \
+                               --add-flags '--theme=feh'
   '';
 
   meta = {


### PR DESCRIPTION
feh uses argv[0] to set the default theme, because
feh is wrapped this will be .feh-wrapper. This makes
it hard to use the configuration on multiple systems
and can be confusion. Therefore the theme is explicity
set to 'feh'.
