### PR TITLE
Update feh from 2.11 to 2.12.

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, makeWrapper, fetchurl, x11, imlib2, libjpeg, libpng, giblib
+{ stdenv, makeWrapper, fetchurl, x11, imlib2, libjpeg, libpng
 , libXinerama, curl }:
 
 stdenv.mkDerivation rec {
-  name = "feh-2.11";
+  name = "feh-2.12";
 
   src = fetchurl {
     url = "http://feh.finalrewind.org/${name}.tar.bz2";
-    sha256 = "1y41ixsp5nhvb29hhiyh8g1g28lc0kki619skgxcv5iisc93dk4x";
+    sha256 = "0ckhidmsms2l5jycp0qf71jzmb3bpbhjq3bcgfpvfvszah7pmq30";
   };
 
-  buildInputs = [makeWrapper x11 imlib2 giblib libjpeg libpng libXinerama curl ];
+  buildInputs = [makeWrapper x11 imlib2 libjpeg libpng libXinerama curl];
 
   preBuild = ''
     makeFlags="PREFIX=$out"


### PR DESCRIPTION
The relevant source code of giblib was imported into feh,
therefore giblib is no longer a dependency. Now the only
expression depending on giblib is scrot.
