### PR TITLE
hdevtools compiles

### DIFF
--- a/pkgs/development/tools/haskell/hdevtools/default.nix
+++ b/pkgs/development/tools/haskell/hdevtools/default.nix
@@ -1,4 +1,4 @@
-{ cabal, cmdargs, ghcPaths, network, syb, time }:
+{ cabal, cmdargs, ghcPaths, network, syb, time, fetchpatch }:
 
 cabal.mkDerivation (self: {
   pname = "hdevtools";
@@ -6,6 +6,7 @@ cabal.mkDerivation (self: {
   sha256 = "1a218m817q35f52fv6mn28sfv136i6fm2mzgdidpm24pc0585gl7";
   isLibrary = false;
   isExecutable = true;
+  patches = [ (fetchpatch { url = "https://github.com/bitc/hdevtools/pull/28.patch"; sha256 = "1rlv5zskg4ns9ba791x72gycxrr52lhy8x164q38gpq600gh5n40"; }) ];
   buildDepends = [ cmdargs ghcPaths network syb time ];
   meta = {
     homepage = "https://github.com/bitc/hdevtools/";


### PR DESCRIPTION
Hackage version of hdevtools has been languishing due to this patch. When Hackage is updated, I will remove the patching.
