### PR TITLE
fix compilation of gccApple

### DIFF
--- a/pkgs/development/compilers/gcc/4.2-apple64/bootstrap.nix
+++ b/pkgs/development/compilers/gcc/4.2-apple64/bootstrap.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+assert stdenv.isDarwin;
+
+let
+  version  = "4.2.1";   # Upstream GCC version, from `gcc/BASE-VER'.
+  revision = "5666.3";  # Apple's fork revision number.
+in
+
+stdenv.mkDerivation {
+  name = "gcc-apple-bootstrap-${version}.${revision}";
+
+  src = fetchurl {
+    url = "http://r.research.att.com/tools/gcc-42-5666.3-darwin11.pkg";
+    sha256 = "0p86vb83cnargqfk2ksfzwdlx88bxb7nwr4rialvyy7m26s96f1g";
+  };
+
+  buildCommand = ''
+    /usr/bin/xar -xf $src
+    /bin/pax --insecure -rz -f usr.pkg/Payload -s ",./usr,$out,"
+    for prog in c++ cpp gcc g++ gfortran gcov; do
+      ln -s $out/bin/$prog{-4.2,}
+    done
+  '';
+
+  langC = true;
+  langCC = true;
+}

--- a/pkgs/development/compilers/gcc/4.2-apple64/builder.sh
+++ b/pkgs/development/compilers/gcc/4.2-apple64/builder.sh
@@ -1,6 +1,5 @@
 source $stdenv/setup
 
-
 export NIX_FIXINC_DUMMY=$NIX_BUILD_TOP/dummy
 mkdir $NIX_FIXINC_DUMMY
 
@@ -52,7 +51,7 @@ fi
 
 
 preConfigure() {
-    
+
     # Determine the frontends to build.
     langs="c"
     if test -n "$langCC"; then
@@ -116,7 +115,7 @@ preConfigure() {
     cd ../build_libstdcxx
 
     ln -s ../build/gcc gcc
-    
+
     configureScript=../$sourceRoot/libstdcxx/configure
     configureFlags="--disable-libstdcxx-pch --disable-libstdcxx-debug --disable-multilib --with-gxx-include-dir=${STDCXX_INCDIR}"
 }

--- a/pkgs/development/compilers/gcc/4.2-apple64/default.nix
+++ b/pkgs/development/compilers/gcc/4.2-apple64/default.nix
@@ -2,6 +2,7 @@
 , langCC ? true, langObjC ? true, langF77 ? false
 , profiledCompiler ? false
 , gmp ? null, mpfr ? null, bison ? null, flex ? null
+, perl
 }:
 
 assert stdenv.isDarwin;
@@ -33,13 +34,15 @@ stdenv.mkDerivation {
 
   sourceRoot = "gcc-${revision}/";
 
-  patches =
-    [ ./pass-cxxcpp.patch ]
-    ++ stdenv.lib.optional noSysDirs ./no-sys-dirs.patch
+  patches = [
+    ./pass-cxxcpp.patch
+    ./gcc-apple-4.2.1-inline.patch
+    ./driverdriver-num_infiles.patch
+  ] ++ stdenv.lib.optional noSysDirs ./no-sys-dirs.patch
     ++ stdenv.lib.optional langCC ./fix-libstdc++-link.patch;
 
   inherit noSysDirs langCC langF77 langObjC;
   langC = true;
 
-  buildInputs = stdenv.lib.optionals langF77 [ gmp mpfr bison flex ];
+  buildInputs = [ perl bison flex ] ++ stdenv.lib.optionals langF77 [ gmp mpfr ];
 }

--- a/pkgs/development/compilers/gcc/4.2-apple64/driverdriver-num_infiles.patch
+++ b/pkgs/development/compilers/gcc/4.2-apple64/driverdriver-num_infiles.patch
@@ -1,0 +1,11 @@
+--- gcc-5666.3/driverdriver.c.orig	2012-03-30 15:23:03.000000000 -0700
++++ gcc-5666.3/driverdriver.c	2012-03-30 15:43:40.000000000 -0700
+@@ -1599,7 +1599,7 @@ main (int argc, const char **argv)
+ 
+       /* If more than one input files are supplied but only one output filename
+ 	 is present then IMA will be used.  */
+-      if (num_infiles > 1 && !compile_only_request)
++      if (num_infiles != 1 && !compile_only_request)
+ 	ima_is_used = 1;
+ 
+       /* Linker wants to know this in case of multiple -arch.  */

--- a/pkgs/development/compilers/gcc/4.2-apple64/gcc-apple-4.2.1-inline.patch
+++ b/pkgs/development/compilers/gcc/4.2-apple64/gcc-apple-4.2.1-inline.patch
@@ -1,0 +1,65 @@
+https://trac.macports.org/ticket/34639
+https://bugs.gentoo.org/show_bug.cgi?id=491098
+
+--- gcc-5666.3/gcc/toplev.h
++++ gcc-5666.3/gcc/toplev.h
+@@ -151,6 +151,8 @@
+ /* Return true iff flags are set as if -ffast-math.  */
+ extern bool fast_math_flags_set_p	(void);
+ 
++#if GCC_VERSION < 3004
++
+ /* Return log2, or -1 if not exact.  */
+ extern int exact_log2                  (unsigned HOST_WIDE_INT);
+ 
+@@ -158,7 +160,7 @@
+ extern int floor_log2                  (unsigned HOST_WIDE_INT);
+ 
+ /* Inline versions of the above for speed.  */
+-#if GCC_VERSION >= 3004
++#else /* GCC_VERSION < 3004 */
+ # if HOST_BITS_PER_WIDE_INT == HOST_BITS_PER_LONG
+ #  define CLZ_HWI __builtin_clzl
+ #  define CTZ_HWI __builtin_ctzl
+@@ -172,18 +172,18 @@
+ #  define CTZ_HWI __builtin_ctz
+ # endif
+ 
+-extern inline int
++static inline int
+ floor_log2 (unsigned HOST_WIDE_INT x)
+ {
+   return x ? HOST_BITS_PER_WIDE_INT - 1 - (int) CLZ_HWI (x) : -1;
+ }
+ 
+-extern inline int
++static inline int
+ exact_log2 (unsigned HOST_WIDE_INT x)
+ {
+   return x == (x & -x) && x ? (int) CTZ_HWI (x) : -1;
+ }
+-#endif /* GCC_VERSION >= 3004 */
++#endif /* GCC_VERSION < 3004 */
+ 
+ /* Functions used to get and set GCC's notion of in what directory
+    compilation was started.  */
+--- gcc-5666.3/gcc/toplev.c
++++ gcc-5666.3/gcc/toplev.c
+@@ -555,7 +555,7 @@
+    for floor_log2 and exact_log2; see toplev.h.  That construct, however,
+    conflicts with the ISO C++ One Definition Rule.   */
+ 
+-#if GCC_VERSION < 3004 || !defined (__cplusplus)
++#if GCC_VERSION < 3004
+ 
+ /* Given X, an unsigned number, return the largest int Y such that 2**Y <= X.
+    If X is 0, return -1.  */
+@@ -607,7 +607,7 @@
+ #endif
+ }
+ 
+-#endif /*  GCC_VERSION < 3004 || !defined (__cplusplus)  */
++#endif /*  GCC_VERSION < 3004 */
+ 
+ /* Handler for fatal signals, such as SIGSEGV.  These are transformed
+    into ICE messages, which is much more user friendly.  In case the

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2773,14 +2773,18 @@ let
     binutilsCross = null;
   }));
 
+  gccAppleBootstrap =
+    assert stdenv.isDarwin;
+    wrapGCC (makeOverridable (import ../development/compilers/gcc/4.2-apple64/bootstrap.nix) {
+      inherit stdenv fetchurl;
+    });
+
   gccApple =
     assert stdenv.isDarwin;
     wrapGCC (makeOverridable (import ../development/compilers/gcc/4.2-apple64) {
-      inherit fetchurl noSysDirs;
+      inherit fetchurl noSysDirs flex bison perl;
       profiledCompiler = true;
-      # Since it fails to build with GCC 4.6, build it with the "native"
-      # Apple-GCC.
-      stdenv = allStdenvs.stdenvNative;
+      stdenv = stdenvAdapters.overrideGCC stdenv gccAppleBootstrap;
     });
 
   gfortran = gfortran48;


### PR DESCRIPTION
While trying to add cross-building support for `gccApple` (via the `-arch` flags handling in [`driverdriver.c`](http://opensource.apple.com/source/gcc/gcc-5666.3/driverdriver.c)), I discovered that the `gccApple` fails to install under the latest clang/llvm-based native compiler (`/usr/bin/gcc`).

I've added some patches to fix various compilation failures, but I couldn't figure out how to resolve few when compiling libstdcxx ([a bunch of problems regarding `unwind.h`](https://gist.github.com/cstrahan/697e575ec9124f9a4db4)).

As a (potentially stopgap) solution, I've added a `gccAppleBootstrap` package that fetches the same prebuilt binaries as used by the [Homebrew](https://github.com/Homebrew/homebrew) project, which I then use to compile `gccApple`.

If someone can lend a hand with the remaining compilation errors under `/usr/bin/gcc`, we might be able to skip the bootstrap binaries - let me know if you'd like to work on this with me :smile:.
