### PR TITLE
nix-prefetch-*: print fetched revision

### DIFF
--- a/pkgs/build-support/fetchbzr/nix-prefetch-bzr
+++ b/pkgs/build-support/fetchbzr/nix-prefetch-bzr
@@ -52,6 +52,8 @@ if test -z "$finalPath"; then
     # Perform the checkout.
     bzr -Ossl.cert_reqs=none export $revarg --format=dir "$tmpFile" "$url"
 
+    echo "bzr revision is $(bzr revno $revarg "$url")"
+
     # Compute the hash.
     hash=$(nix-hash --type $hashType $hashFormat $tmpFile)
     if ! test -n "$QUIET"; then echo "hash is $hash" >&2; fi

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -217,7 +217,7 @@ clone_user_rev() {
             fi;;
     esac
 
-    echo "git revision is $(cd $dir && git rev-parse $rev)"
+    echo "git revision is $(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/fetchgit) | tail -n1)"
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -51,6 +51,7 @@ if test -z "$finalPath"; then
     hg archive -q -y -r "$rev" --cwd $tmpClone $tmpArchive
     rm -f $tmpArchive/.hg_archival.txt
 
+    echo "hg revision is $(cd $tmpClone; hg id -r "$rev" -i)"
 
     # Compute the hash.
     hash=$(nix-hash --type $hashType $hashFormat $tmpArchive)

--- a/pkgs/build-support/fetchsvn/nix-prefetch-svn
+++ b/pkgs/build-support/fetchsvn/nix-prefetch-svn
@@ -56,6 +56,7 @@ if test -z "$finalPath"; then
     fi
 
     echo p | svn "$command" --quiet -r "$rev" "$url" "$tmpFile" >&2
+    echo "svn revision is $(svn info -r "$rev" "$url" | grep "Revision: " | cut -d' ' -f2)"
 
     # Compute the hash.
     hash=$(nix-hash --type $hashType $hashFormat $tmpFile)


### PR DESCRIPTION
nix-prefetch-git already did (though I had to fix a bug to make it work with explicit specified refs) this,
and I think it's useful if you leave out the REV and want to know what HEAD currenlty is. This PR implements the
feature for the rest of the prefetch scripts (bzr, hg, svn).
