### PR TITLE
teamviewer: fix broken links

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/8.nix
+++ b/pkgs/applications/networking/remote/teamviewer/8.nix
@@ -10,7 +10,7 @@ in
 stdenv.mkDerivation {
   name = "teamviewer-8.0.17147";
   src = fetchurl {
-    url = "http://download.teamviewer.com/download/teamviewer_linux_x64.deb";
+    url = "http://download.teamviewer.com/download/version_8x/teamviewer_linux_x64.deb";
     sha256 = "0s5m15f99rdmspzwx3gb9mqd6jx1bgfm0d6rfd01k9rf7gi7qk0k";
   };
 

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -11,7 +11,7 @@ in
 stdenv.mkDerivation {
   name = "teamviewer-7.0.9377";
   src = fetchurl {
-    url = "http://www.teamviewer.com/download/version_7x/teamviewer_linux.tar.gz";
+    url = "http://download.teamviewer.com/download/version_7x/teamviewer_linux.tar.gz";
     sha256 = "1f8934jqj093m1z56yl6k2ah6njkk6pz1rjvpqnryi29pp5piaiy";
   };
 


### PR DESCRIPTION
this fixes broken download links.

teamviewer 8 SHA changed because the old link pointed at the new version 9
teamviewer 7 link -> 404: Not Found.
