### PR TITLE
Set CONFIG_SHELL to stdenv.shell in the default builder, just like SHELL

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -102,6 +102,7 @@ fi
 
 # Execute the pre-hook.
 export SHELL=@shell@
+export CONFIG_SHELL="$SHELL"
 if [ -z "$shell" ]; then export shell=@shell@; fi
 runHook preHook
 


### PR DESCRIPTION
It seems to increase purity in builders and can fix some problems in non-NixOS non-chroot builds.
