### PR TITLE
xtrace:  fix build and update to 1.3.1

### DIFF
--- a/pkgs/tools/X11/xtrace/default.nix
+++ b/pkgs/tools/X11/xtrace/default.nix
@@ -1,14 +1,19 @@
-{ stdenv, fetchurl, libX11, xauth, makeWrapper }:
+{ stdenv, autoreconfHook, fetchgit, libX11, xauth, makeWrapper }:
 
-let version = "1.0.2"; in
+let version = "1.3.1"; in
 stdenv.mkDerivation {
   name = "xtrace-${version}";
-  src = fetchurl {
-    url = "https://alioth.debian.org/frs/download.php/3201/xtrace_${version}.orig.tar.gz";
-    sha256 = "0czywk2iwj9vifml0qjlbz8n9jnqjsm4zz22haii82bf4l5w3y04";
+  src = fetchgit {
+    url = "git://git.debian.org/xtrace/xtrace.git";
+    rev = "refs/tags/xtrace-1.3.1";
+    sha256 = "0csjw88ynzzcmx1jlb65c74r2sp9dzxn00airsxxfsipb74049d0";
   };
 
-  buildInputs = [ libX11 makeWrapper ];
+  buildInputs = [ libX11 makeWrapper autoreconfHook ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   postInstall =
     '' wrapProgram "$out/bin/xtrace" \


### PR DESCRIPTION
Alioth now requires a login before you can download tarballs.
