### PR TITLE
fix idris & llvm-general builds

### DIFF
--- a/pkgs/development/libraries/haskell/llvm-general-pure/3.3.8.2.nix
+++ b/pkgs/development/libraries/haskell/llvm-general-pure/3.3.8.2.nix
@@ -12,6 +12,7 @@ cabal.mkDerivation (self: {
     testFrameworkQuickcheck2
   ];
   doCheck = false;
+  noHaddock = true;
   meta = {
     description = "Pure Haskell LLVM functionality (no FFI)";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/haskell/llvm-general-pure/3.4.2.2.nix
+++ b/pkgs/development/libraries/haskell/llvm-general-pure/3.4.2.2.nix
@@ -12,6 +12,7 @@ cabal.mkDerivation (self: {
     testFrameworkQuickcheck2
   ];
   doCheck = false;
+  noHaddock = true;
   meta = {
     description = "Pure Haskell LLVM functionality (no FFI)";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/haskell/llvm-general/3.3.8.2.nix
+++ b/pkgs/development/libraries/haskell/llvm-general/3.3.8.2.nix
@@ -16,6 +16,7 @@ cabal.mkDerivation (self: {
   ];
   buildTools = [ llvmConfig ];
   doCheck = false;
+  noHaddock = true;
   meta = {
     description = "General purpose LLVM bindings";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/haskell/llvm-general/3.4.2.2.nix
+++ b/pkgs/development/libraries/haskell/llvm-general/3.4.2.2.nix
@@ -16,6 +16,7 @@ cabal.mkDerivation (self: {
   ];
   buildTools = [ llvmConfig ];
   doCheck = false;
+  noHaddock = true;
   meta = {
     description = "General purpose LLVM bindings";
     license = self.stdenv.lib.licenses.bsd3;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2689,6 +2689,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   idris_plain = callPackage ../development/compilers/idris {
     llvmGeneral = self.llvmGeneral_3_3_8_2;
     llvmGeneralPure = self.llvmGeneralPure_3_3_8_2;
+    parsers = self.parsers_0_10_3;
+    trifecta = self.trifecta.override { parsers = self.parsers_0_10_3; };
   };
 
   idris = callPackage ../development/compilers/idris/wrapper.nix {};


### PR DESCRIPTION
llvm-general currently does not build its haddock docs, temporary workaround to disable haddock for it.

idris needs an older parsers, select it.
