### PR TITLE
openal-soft: Add PulseAudio backend, make non-OSS backends work.

### DIFF
--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, fetchurl, cmake, alsaLib }:
+{ stdenv, fetchurl, cmake
+, alsaSupport ? true, alsaLib ? null
+, pulseSupport ? true, pulseaudio ? null
+}:
+
+assert alsaSupport -> alsaLib != null;
+assert pulseSupport -> pulseaudio != null;
 
 stdenv.mkDerivation rec {
-#The current release is still in a testing phase, though it should be stable
-# (neither the ABI or API will break). Please try it out and let me know how it
-#  works. :-)
-
   version = "1.15.1";
   name = "openal-soft-${version}";
 
@@ -13,8 +15,14 @@ stdenv.mkDerivation rec {
     sha256 = "0mmhdqiyb3c9dzvxspm8h2v8jibhi8pfjxnf6m0wn744y1ia2a8f";
   };
 
-  buildInputs = [ cmake alsaLib ];
-  
+  buildInputs = [ cmake ]
+    ++ stdenv.lib.optional alsaSupport alsaLib
+    ++ stdenv.lib.optional pulseSupport pulseaudio;
+
+  NIX_LDFLAGS = []
+    ++ stdenv.lib.optional alsaSupport "-lasound"
+    ++ stdenv.lib.optional pulseSupport "-lpulse";
+
   meta = {
     description = "OpenAL alternative";
     homepage = http://kcat.strangesoft.net/openal.html;


### PR DESCRIPTION
- Added PulseAudio backend support.
- Made ALSA and PulseAudio backends optional.
- Made ALSA and PulseAudio backends actually work by adding to NIX_LDFLAGS (because package uses dlopen).

TEST: Tested all 3 backends (OSS, ALSA, PulseAudio) using openal-info and my upcoming Warzone 2100 update, by selecting the backend in .alsoftrc. It also works without .alsoftrc (I think it first tries pulse then alsa then oss).
