### PR TITLE
RFC: collectd: enable a bunch of plugins (by adding more deps)

### DIFF
--- a/pkgs/development/libraries/libcredis/default.nix
+++ b/pkgs/development/libraries/libcredis/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libcredis-0.2.3";
+
+  src = fetchurl {
+    url = "https://credis.googlecode.com/files/credis-0.2.3.tar.gz";
+    sha256 = "1l3hlw9rrc11qggbg9a2303p3bhxxx2vqkmlk8avsrbqw15r1ayr";
+  };
+
+  # credis build system has no install actions, provide our own.
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/lib"
+    mkdir -p "$out/include"
+
+    cp -v credis-test "$out/bin/"
+    cp -v *.a *.so "$out/lib/"
+    cp -v *.h "$out/include/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C client library for Redis (key-value database)";
+    homepage = https://code.google.com/p/credis/;
+    license = licenses.bsd3; # from homepage
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/development/libraries/libmemcached/default.nix
+++ b/pkgs/development/libraries/libmemcached/default.nix
@@ -15,9 +15,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cyrus_sasl libevent ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://libmemcached.org;
     description = "Open source C/C++ client library and tools for the memcached server";
-    license = "BSD";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libmemcached/default.nix
+++ b/pkgs/development/libraries/libmemcached/default.nix
@@ -8,6 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "10jzi14j32lpq0if0p9vygcl2c1352hwbywzvr9qzq7x6aq0nb72";
   };
   
+  # Fix linking against libpthread (patch from Fedora)
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1037707
+  # https://bugs.launchpad.net/libmemcached/+bug/1281907
+  patches = [ ./libmemcached-fix-linking-with-libpthread.patch ];
+
   buildInputs = [ cyrus_sasl libevent ];
 
   meta = {

--- a/pkgs/development/libraries/libmemcached/libmemcached-fix-linking-with-libpthread.patch
+++ b/pkgs/development/libraries/libmemcached/libmemcached-fix-linking-with-libpthread.patch
@@ -1,0 +1,19 @@
+diff -up libmemcached-1.0.16/build-aux/ltmain.sh.orig libmemcached-1.0.16/build-aux/ltmain.sh
+--- libmemcached-1.0.16/build-aux/ltmain.sh.orig	2013-12-03 16:36:53.222107642 +0100
++++ libmemcached-1.0.16/build-aux/ltmain.sh	2013-12-03 16:37:35.770132249 +0100
+@@ -5664,6 +5664,15 @@ func_mode_link ()
+ 	    *" $arg "*) ;;
+ 	    * ) func_append new_inherited_linker_flags " $arg" ;;
+ 	esac
++	# As we are forced to pass -nostdlib to g++ during linking, the option
++	# -pthread{,s} is not in effect;  add the -lpthread to $deplist
++	# explicitly to link correctly.
++	if test "$tagname" = CXX -a x"$with_gcc" = xyes; then
++	  case "$arg" in
++	    -pthread*) func_append deplibs " -lpthread" ;;
++	  esac
++	fi
++
+ 	continue
+ 	;;
+ 

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -45,10 +45,11 @@ stdenv.mkDerivation rec {
   # for some reason libsigrok isn't auto-detected
   configureFlags = stdenv.lib.optional (libsigrok != null) "--with-libsigrok";
 
-  meta = {
+  meta = with stdenv.lib; {
+    description = "Daemon which collects system performance statistics periodically";
     homepage = http://collectd.org;
-    description = "collectd is a daemon which collects system performance statistics periodically";
-    platforms = stdenv.lib.platforms.linux;
-    license = "GPLv2";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -1,4 +1,29 @@
-{stdenv, fetchurl }:
+{ stdenv, fetchurl
+# optional:
+, pkgconfig ? null  # most of the extra deps need pkgconfig to be found
+, curl ? null
+, iptables ? null
+, libcredis ? null
+, libdbi ? null
+, libgcrypt ? null
+, libmemcached ? null, cyrus_sasl ? null
+, libmodbus ? null
+, libnotify ? null, gdk_pixbuf ? null
+, liboping ? null
+, libpcap ? null
+, libsigrok ? null
+, libvirt ? null
+, libxml2 ? null
+, lm_sensors ? null
+, lvm2 ? null
+, mysql ? null
+, postgresql ? null
+, protobufc ? null
+, rabbitmq-c ? null
+, rrdtool ? null
+, varnish ? null
+, yajl ? null
+}:
 
 stdenv.mkDerivation rec {
   name = "collectd-5.4.1";
@@ -9,6 +34,16 @@ stdenv.mkDerivation rec {
   };
 
   NIX_LDFLAGS = "-lgcc_s"; # for pthread_cancel
+
+  buildInputs = [
+    pkgconfig curl iptables libcredis libdbi libgcrypt libmemcached cyrus_sasl
+    libmodbus libnotify gdk_pixbuf liboping libpcap libsigrok libvirt
+    lm_sensors libxml2 lvm2 mysql postgresql protobufc rabbitmq-c rrdtool
+    varnish yajl
+  ];
+
+  # for some reason libsigrok isn't auto-detected
+  configureFlags = stdenv.lib.optional (libsigrok != null) "--with-libsigrok";
 
   meta = {
     homepage = http://collectd.org;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5041,6 +5041,8 @@ let
 
   libcangjie = callPackage ../development/libraries/libcangjie { };
 
+  libcredis = callPackage ../development/libraries/libcredis { };
+
   libctemplate = callPackage ../development/libraries/libctemplate { };
 
   libcue = callPackage ../development/libraries/libcue { };


### PR DESCRIPTION
Increases the closure size from 129 MiB to 546 MiB.

---

Actually, I'm unsure of whether this should be committed or not, so I'm making this PR as a RFC. There are so many plugins (more than I've now enabled) that I'm wondering if the better/more sustainable solution is to tell users to just use lib.overrideDerivation in configuration.nix... Thoughts?
