### PR TITLE
CUPS system wide client side remote printing.

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -35,7 +35,7 @@ let
   bindir = pkgs.buildEnv {
     name = "cups-progs";
     paths = cfg.drivers;
-    pathsToLink = [ "/lib/cups" "/share/cups" "/bin" ];
+    pathsToLink = [ "/lib/cups" "/share/cups" "/bin" "/etc/cups" ];
     postBuild = cfg.bindirCmds;
   };
 
@@ -89,6 +89,20 @@ in
         '';
       };
 
+      clientConf = mkOption {
+        type = types.lines;
+        default = "";
+        example =
+          ''
+            ServerName server.example.com
+            Encryption Never
+          '';
+        description = ''
+          The contents of the client configuration.
+          (<filename>client.conf</filename>)
+        '';
+      };
+
       drivers = mkOption {
         type = types.listOf types.path;
         example = literalExample "[ pkgs.splix ]";
@@ -123,6 +137,14 @@ in
       };
 
     environment.systemPackages = [ cups ];
+
+    environment.variables.CUPS_SERVERROOT = "/etc/cups";
+
+    environment.etc = [
+      { source = pkgs.writeText "client.conf" cfg.clientConf;
+        target = "cups/client.conf";
+      }
+    ];
 
     services.dbus.packages = [ cups ];
 


### PR DESCRIPTION
Using lpr, lpq and so forth gets redirected to a remote printserver.

For those that might think that you cannot use NixOS as a print server, or use it in conjunction with a print server; you can already(in nixpkgs CUPS) relay print commands by editing your user ~/.cups/client.conf. This PR enables it for all local printing..

This has been tested and confirmed working. This change is also forwards and backwards compatible.
