### PR TITLE
Thunderbird's Icon is not showing in menus

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -13,6 +13,7 @@
 }:
 
 let version = "17.0.11esr"; in
+let friendlyVersion = "17.0.11"; in
 
 stdenv.mkDerivation {
   name = "thunderbird-${version}";
@@ -75,7 +76,7 @@ stdenv.mkDerivation {
       [Desktop Entry]
       Type=Application
       Exec=$out/bin/thunderbird
-      Icon=$out/lib/thunderbird-${version}/chrome/icons/default/default256.png
+      Icon=$out/lib/thunderbird-${friendlyVersion}/chrome/icons/default/default256.png
       Name=Thunderbird
       GenericName=Mail Reader
       Categories=Application;Network;


### PR DESCRIPTION
This is caused by the fact that the thunderbird library folder is not called 'thunderbird-17.0.11esr', but 'thunderbird-17.0.11'. I've implemented a "hackish" solution (without using sed, awk or cut - because I'm a complete newb) where there is a "friendlyVersion" variable that is simply a carbon copy of the version variable, minus the three last characters.
