### PR TITLE
Application.ini does not refer correctly

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -12,13 +12,13 @@
   enableOfficialBranding ? false
 }:
 
-let version = "17.0.11esr"; in
+let version = "17.0.11"; in
 
 stdenv.mkDerivation {
-  name = "thunderbird-${version}";
+  name = "thunderbird-${version}esr";
 
   src = fetchurl {
-    url = "ftp://ftp.mozilla.org/pub/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.bz2";
+    url = "ftp://ftp.mozilla.org/pub/thunderbird/releases/${version}/source/thunderbird-${version}esr.source.tar.bz2";
     sha256 = "1m2lph8x82kgxqzlyaxr1l1x7s4qnqfzfnqck4b777914mrv1mdp";
   };
 


### PR DESCRIPTION
Changed "version" to "17.0.11", added "esr" to the tarball download URL. This way Application.ini points to the correct path ("$out/lib/thunderbird-17.0.11/").
