### PR TITLE
Application.ini does not refer correctly

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -12,13 +12,14 @@
   enableOfficialBranding ? false
 }:
 
-let version = "17.0.11esr"; in
+let version = "17.0.11"; in
+let verName = "${version}esr"; in
 
 stdenv.mkDerivation {
-  name = "thunderbird-${version}";
+  name = "thunderbird-${verName}";
 
   src = fetchurl {
-    url = "ftp://ftp.mozilla.org/pub/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.bz2";
+    url = "ftp://ftp.mozilla.org/pub/thunderbird/releases/${verName}/source/thunderbird-${verName}.source.tar.bz2";
     sha256 = "1m2lph8x82kgxqzlyaxr1l1x7s4qnqfzfnqck4b777914mrv1mdp";
   };
 


### PR DESCRIPTION
The "Application.ini" provided with Thunderbird does not correctly set the path to the icon location. Visa vi it refers to '$out/lib/thunderbird-17.0.11esr', which doesn't exist, but '$out/lib/thunderbird-17.0.11' does. To remedy this problem I added a new variable called 'verName" which adds 'esr' after the variable '$version'. Then change the variables necessary so that the build process sets working references.

Fuuzetsu suggested putting the verName variable inside of mkDerivation. I cannot surmise.
