### PR TITLE
libid3tag + mpd fixes/cleanup

### DIFF
--- a/pkgs/development/libraries/libid3tag/debian-patches.patch
+++ b/pkgs/development/libraries/libid3tag/debian-patches.patch
@@ -1,0 +1,89 @@
+diff --git a/compat.gperf b/compat.gperf
+index 4e24613..5635980 100644
+--- a/compat.gperf
++++ b/compat.gperf
+@@ -236,6 +236,10 @@ int id3_compat_fixup(struct id3_tag *tag)
+
+     encoding = id3_parse_uint(&data, 1);
+     string   = id3_parse_string(&data, end - data, encoding, 0);
++    if (!string)
++    {
++	continue;
++    }
+
+     if (id3_ucs4_length(string) < 4) {
+       free(string);
+diff --git a/genre.dat b/genre.dat
+index 17acab5..1f02779 100644
+--- a/genre.dat
++++ b/genre.dat
+@@ -277,8 +277,8 @@ static id3_ucs4_t const genre_PUNK_ROCK[] =
+   { 'P', 'u', 'n', 'k', ' ', 'R', 'o', 'c', 'k', 0 };
+ static id3_ucs4_t const genre_DRUM_SOLO[] =
+   { 'D', 'r', 'u', 'm', ' ', 'S', 'o', 'l', 'o', 0 };
+-static id3_ucs4_t const genre_A_CAPPELLA[] =
+-  { 'A', ' ', 'C', 'a', 'p', 'p', 'e', 'l', 'l', 'a', 0 };
++static id3_ucs4_t const genre_A_CAPELLA[] =
++  { 'A', ' ', 'C', 'a', 'p', 'e', 'l', 'l', 'a', 0 };
+ static id3_ucs4_t const genre_EURO_HOUSE[] =
+   { 'E', 'u', 'r', 'o', '-', 'H', 'o', 'u', 's', 'e', 0 };
+ static id3_ucs4_t const genre_DANCE_HALL[] =
+@@ -452,7 +452,7 @@ static id3_ucs4_t const *const genre_table[] = {
+   genre_DUET,
+   genre_PUNK_ROCK,
+   genre_DRUM_SOLO,
+-  genre_A_CAPPELLA,
++  genre_A_CAPELLA,
+   genre_EURO_HOUSE,
+   genre_DANCE_HALL,
+   genre_GOA,
+diff --git a/genre.dat.in b/genre.dat.in
+index 872de40..e71e34b 100644
+--- a/genre.dat.in
++++ b/genre.dat.in
+@@ -153,7 +153,7 @@ Freestyle
+ Duet
+ Punk Rock
+ Drum Solo
+-A Cappella
++A Capella
+ Euro-House
+ Dance Hall
+ Goa
+diff --git a/parse.c b/parse.c
+index 86a3f21..947c249 100644
+--- a/parse.c
++++ b/parse.c
+@@ -165,6 +165,9 @@ id3_ucs4_t *id3_parse_string(id3_byte_t const **ptr, id3_length_t length,
+   case ID3_FIELD_TEXTENCODING_UTF_8:
+     ucs4 = id3_utf8_deserialize(ptr, length);
+     break;
++  default:
++  	/* FIXME: Unknown encoding! Print warning? */
++	return NULL;
+   }
+
+   if (ucs4 && !full) {
+diff --git a/utf16.c b/utf16.c
+index 70ee9d5..6e60a75 100644
+--- a/utf16.c
++++ b/utf16.c
+@@ -282,5 +282,18 @@ id3_ucs4_t *id3_utf16_deserialize(id3_byte_t const **ptr, id3_length_t length,
+
+   free(utf16);
+
++  if (end == *ptr && length % 2 != 0)
++  {
++     /* We were called with a bogus length.  It should always
++      * be an even number.  We can deal with this in a few ways:
++      * - Always give an error.
++      * - Try and parse as much as we can and
++      *   - return an error if we're called again when we
++      *     already tried to parse everything we can.
++      *   - tell that we parsed it, which is what we do here.
++      */
++     (*ptr)++;
++  }
++
+   return ucs4;
+ }

--- a/pkgs/development/libraries/libid3tag/default.nix
+++ b/pkgs/development/libraries/libid3tag/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, zlib}:
+{stdenv, fetchurl, zlib, gperf}:
 
 stdenv.mkDerivation {
   name = "libid3tag-0.15.1b";
@@ -7,11 +7,14 @@ stdenv.mkDerivation {
     sha256 = "63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151";
   };
 
-  propagatedBuildInputs = [zlib];
+  propagatedBuildInputs = [ zlib gperf ];
 
-  meta = {
+  patches = [ ./debian-patches.patch ];
+
+  meta = with stdenv.lib; {
     description = "ID3 tag manipulation library";
     homepage = http://mad.sourceforge.net/;
-    license = "GPL";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.fuuzetsu ];
   };
 }

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -8,10 +8,8 @@
 , shoutSupport ? true, libshout
 , sqliteSupport ? true, sqlite
 , curlSupport ? true, curl
-, soupSupport ? true, libsoup
 , audiofileSupport ? true, audiofile
 , bzip2Support ? true, bzip2
-, ffadoSupport ? true, ffado
 , ffmpegSupport ? true, ffmpeg
 , fluidsynthSupport ? true, fluidsynth
 , zipSupport ? true, zziplib
@@ -48,10 +46,8 @@ in stdenv.mkDerivation rec {
     ++ opt shoutSupport libshout
     ++ opt sqliteSupport sqlite
     ++ opt curlSupport curl
-    ++ opt soupSupport libsoup
     ++ opt bzip2Support bzip2
     ++ opt audiofileSupport audiofile
-    ++ opt (!stdenv.isDarwin && ffadoSupport) ffado
     ++ opt ffmpegSupport ffmpeg
     ++ opt fluidsynthSupport fluidsynth
     ++ opt samplerateSupport libsamplerate
@@ -72,10 +68,8 @@ in stdenv.mkDerivation rec {
       (mkFlag shoutSupport "shout")
       (mkFlag sqliteSupport "sqlite")
       (mkFlag curlSupport "curl")
-      (mkFlag soupSupport "soup")
       (mkFlag audiofileSupport "audiofile")
       (mkFlag bzip2Support "bzip2")
-      (mkFlag (!stdenv.isDarwin && ffadoSupport) "ffado")
       (mkFlag ffmpegSupport "ffmpeg")
       (mkFlag fluidsynthSupport "fluidsynth")
       (mkFlag zipSupport "zzip")
@@ -85,7 +79,8 @@ in stdenv.mkDerivation rec {
       (mkFlag aacSupport "aac")
       (mkFlag pulseaudioSupport "pulse")
       (mkFlag stdenv.isDarwin "osx")
-      "--enable-debugging" ]
+      "--enable-debug"
+    ]
     ++ opt stdenv.isLinux
       "--with-systemdsystemunitdir=$(out)/etc/systemd/system";
 


### PR DESCRIPTION
libid3tag has some bugs that upstream won't patch (inactive project as far as I can tell). I scoured the net and found some old patches by Debian that fix the problem. mpd now no longer goes OOM at database update.

I removed no longer used MPD flags while I was at it.
