### PR TITLE
Agda: upgrade to 2.4.0

### DIFF
--- a/pkgs/development/compilers/agda/agda.nix
+++ b/pkgs/development/compilers/agda/agda.nix
@@ -1,22 +1,24 @@
-{ cabal, alex, binary, deepseq, emacs, filepath, geniplate, happy
-, hashable, hashtables, haskeline, haskellSrcExts, mtl, parallel
-, QuickCheck, text, time, unorderedContainers, xhtml, zlib
+{ cabal, alex, binary, boxes, dataHash, deepseq, emacs, equivalence
+, filepath, geniplate, happy, hashable, hashtables, haskeline
+, haskellSrcExts, mtl, parallel, QuickCheck, STMonadTrans, strict
+, text, time, transformers, unorderedContainers, xhtml, zlib
 }:
 
 cabal.mkDerivation (self: {
   pname = "Agda";
-  version = "2.3.2.2";
-  sha256 = "0zr2rg2yvq6pqg69c6h7hqqpc5nj8prfhcvj5p2alkby0vs110qc";
+  version = "2.4.0";
+  sha256 = "0w8fxfg4b2w7d2k7zanimcg90h240rm5smm5m4i0ydr8zw8zv3yn";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [
-    binary deepseq filepath geniplate hashable hashtables haskeline
-    haskellSrcExts mtl parallel QuickCheck text time
+    binary boxes dataHash deepseq equivalence filepath geniplate
+    hashable hashtables haskeline haskellSrcExts mtl parallel
+    QuickCheck STMonadTrans strict text time transformers
     unorderedContainers xhtml zlib
   ];
   buildTools = [ alex emacs happy ];
-  jailbreak = true;
   postInstall = ''
+    $out/bin/agda $out/share/Agda-*/lib/prim/Agda/Primitive.agda
     $out/bin/agda-mode compile
   '';
   meta = {

--- a/pkgs/development/compilers/agda/stdlib.nix
+++ b/pkgs/development/compilers/agda/stdlib.nix
@@ -1,12 +1,12 @@
 { cabal, fetchurl, filemanip, Agda }:
 
-cabal.mkDerivation (self: {
+cabal.mkDerivation (self: rec {
   pname = "Agda-stdlib";
-  version = "0.7";
+  version = "2.4.0";
 
   src = fetchurl {
-    url = "http://www.cse.chalmers.se/~nad/software/lib-0.7.tar.gz";
-    sha256 = "1ynjgqk8hhnm6rbngy8fjsrd6i4phj2hlan9bk435bbywbl366k3";
+    url = "https://github.com/agda/agda-stdlib/archive/v${version}.tar.gz";
+    sha256 = "1rz0jrkm1b8d8aj9hbj3yl2k219c57r0cizfx98qqf1b9mwixzbf";
   };
 
   buildDepends = [ filemanip Agda ];

--- a/pkgs/development/libraries/haskell/STMonadTrans/default.nix
+++ b/pkgs/development/libraries/haskell/STMonadTrans/default.nix
@@ -1,0 +1,13 @@
+{ cabal, mtl }:
+
+cabal.mkDerivation (self: {
+  pname = "STMonadTrans";
+  version = "0.3.2";
+  sha256 = "1cl5bsc5mr3silcmbjylgw5qa04pf2np9mippxnsa4p3dk089gkh";
+  buildDepends = [ mtl ];
+  meta = {
+    description = "A monad transformer version of the ST monad";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/boxes/default.nix
+++ b/pkgs/development/libraries/haskell/boxes/default.nix
@@ -1,0 +1,13 @@
+{ cabal, split }:
+
+cabal.mkDerivation (self: {
+  pname = "boxes";
+  version = "0.1.3";
+  sha256 = "1sia3j0x7m68j6j9n7bi1l1yg56ivpkxd95l19xl5vpkg03qizkq";
+  buildDepends = [ split ];
+  meta = {
+    description = "2D text pretty-printing library";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/equivalence/default.nix
+++ b/pkgs/development/libraries/haskell/equivalence/default.nix
@@ -1,0 +1,20 @@
+{ cabal, mtl, QuickCheck, STMonadTrans, testFramework
+, testFrameworkQuickcheck2
+}:
+
+cabal.mkDerivation (self: {
+  pname = "equivalence";
+  version = "0.2.3";
+  sha256 = "0dd986y0sn89fparyz6kz9yhzysbqjcp8s99r81ihghg7s9yc743";
+  buildDepends = [ mtl STMonadTrans ];
+  testDepends = [
+    mtl QuickCheck STMonadTrans testFramework testFrameworkQuickcheck2
+  ];
+  doCheck = false;
+  meta = {
+    homepage = "https://bitbucket.org/paba/equivalence/";
+    description = "Maintaining an equivalence relation implemented as union-find using STT";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -288,6 +288,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   BoundedChan = callPackage ../development/libraries/haskell/BoundedChan {};
 
+  boxes = callPackage ../development/libraries/haskell/boxes {};
+
   brainfuck = callPackage ../development/libraries/haskell/brainfuck {};
 
   bson = callPackage ../development/libraries/haskell/bson {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -702,6 +702,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   entropy = callPackage ../development/libraries/haskell/entropy {};
 
+  equivalence = callPackage ../development/libraries/haskell/equivalence {};
+
   erf = callPackage ../development/libraries/haskell/erf {};
 
   errorcallEqInstance = callPackage ../development/libraries/haskell/errorcall-eq-instance {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2022,6 +2022,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   statvfs = callPackage ../development/libraries/haskell/statvfs {};
 
+  STMonadTrans = callPackage ../development/libraries/haskell/STMonadTrans {};
+
   StrafunskiStrategyLib = callPackage ../development/libraries/haskell/Strafunski-StrategyLib {};
 
   streamingCommons = callPackage ../development/libraries/haskell/streaming-commons {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2598,7 +2598,9 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   # Compilers.
 
-  Agda = callPackage ../development/compilers/agda/agda.nix { QuickCheck = self.QuickCheck_2_6; };
+  Agda = callPackage ../development/compilers/agda/agda.nix {
+    binary = self.binary_0_7_2_1;
+  };
   AgdaStdlib = callPackage ../development/compilers/agda/stdlib.nix {};
 
   uhc = callPackage ../development/compilers/uhc {};


### PR DESCRIPTION
I did not test this on master as I keep al my boxes on 14.04. I did eyeball the haskell changes on master and adjusted my commits accordingly, so I think it should be fine.

Cabal2nix's postInstall hook will receive its own pull request.
