### PR TITLE
Minor logic fix

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -52,7 +52,7 @@ in {
       };  
 
       dataDir = mkOption {
-        default = "/var/lib/mpd/";
+        default = "/var/lib/mpd";
         description = ''
           The directory where MPD stores its state, tag cache,
           playlists etc.


### PR DESCRIPTION
music_directory     "${cfg.musicDirectory}"
playlist_directory  "${cfg.dataDir}/playlists"
db_file             "${cfg.dataDir}/tag_cache"
state_file          "${cfg.dataDir}/state"
sticker_file        "${cfg.dataDir}/sticker.sql"

all refer to ${cfg.datadir}, which by default is "/var/lib/mpd/". 

Parsing for instance ${cfg.datadir}/playlists results in:
/var/lib/mpd//playlists - NOT FOUND.
