### PR TITLE
buildNodePackage: add shell hook for development

### DIFF
--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -1,6 +1,6 @@
 { stdenv, runCommand, nodejs, neededNatives}:
 
-args @ { name, src, deps ? [], peerDependencies ? [], flags ? [], ... }:
+args @ { name, src, deps ? [], peerDependencies ? [], flags ? [], preShellHook ? "",  postShellHook ? "", ... }:
 
 with stdenv.lib;
 
@@ -80,6 +80,16 @@ stdenv.mkDerivation ({
   preFixup = concatStringsSep "\n" (map (src: ''
     find $out -type f -print0 | xargs -0 sed -i 's|${src}|${src.name}|g'
   '') src);
+
+  shellHook = ''
+    ${preShellHook}
+    export PATH=${nodejs}/bin:$(pwd)/node_modules/.bin:$PATH
+    mkdir -p node_modules
+    ${concatStrings (concatMap (dep: map (name: ''
+      ln -sfv ${dep}/lib/node_modules/${name} node_modules/
+    '') dep.names) deps)}
+    ${postShellHook}
+  '';
 } // args // {
   # Run the node setup hook when this package is a build input
   propagatedNativeBuildInputs = (args.propagatedNativeBuildInputs or []) ++ [ nodejs ];


### PR DESCRIPTION
This commit adds a simple shell hook for nodejs packages.

**For nodejs packages in `nixpkgs`**:

You can simply run: `nix-shell '<nixpkgs>' -A nodePackages.<name>` in a path where you've checked out source code of nodejs packag. It's also usefull for development.

**For your own nodejs projects**

This is an example of grunt package:

**default.nix**

```
{
  pkgs ? import <nixpkgs> {}
, stdenv ? pkgs.stdenv
, name ? "todos"
, version ? "0.0.1"
, src ? { outPath = ./.; name = name; }
, gruntArgs ? "build"
}:

with stdenv.lib;

let
  nodeOverrides = nodePackages: {
    by-version."grunt-autoprefixer"."0.7.4"  = nodePackages.by-version."grunt-autoprefixer"."0.7.4".override (p: {
      preBuild = ''
        tar -xvf $src && export src=$(pwd)/package
        substituteInPlace package/package.json --replace "\"autoprefixer\": \"./node_modules/autoprefixer/bin/autoprefixer\"" ""
      '';
    });
  };

  nodePackages = pkgs.callPackage (import <nixpkgs/pkgs/top-level/node-packages.nix>) {
    neededNatives =
      with pkgs; [python optipng libjpeg gifsicle] ++
      optional (stdenv.isLinux) pkgs.utillinux;
    self = recursiveUpdate nodePackages (nodeOverrides nodePackages);
    generated = ./package.nix;
  };

  tarball = pkgs.runCommand "${name}-${version}.tgz" { buildInputs = [ pkgs.nodejs ]; } ''
    mv `HOME=$PWD npm pack ${src}` $out
  '';

in pkgs.nodePackages.buildNodePackage {
  name = "${name}-${version}";
  src = [tarball];
  deps = (filter (v: nixType v == "derivation") (attrValues nodePackages));
  buildInputs = with pkgs; [tarball optipng libjpeg gifsicle];
  outputs = ["out" "www"];

  postInstall = ''
    cd $out/lib/node_modules/${name}
    grunt ${gruntArgs}

    # Tarballs
    ensureDir $out/nix-support
    ensureDir $out/tarballs
    tar -cvzf $out/tarballs/$name.tar.gz dist
    ln -s $src $out/tarballs/$name-src.tgz
    echo "file source-dist tarballs/$name-src.tgz" >> $out/nix-support/hydra-build-products
    echo "file binary-dist tarballs/$name.tgz" >> $out/nix-support/hydra-build-products
    echo "$name" >> $out/nix-support/hydra-release-name

    mv dist $www # Separate output for static html
  '';

  meta.description = "Todos frontend package";
  passthru.names = [ name ];
}
```

Generate `package.nix` using `npm2nix package.json package.nix`. Now you can simply run `nix-shell` and all relevant `node_packages` for development will be symlinked.
