### PR TITLE
Added snapWebRoutes to haskellPackages

### DIFF
--- a/pkgs/development/libraries/haskell/resource-pool-catchio/default.nix
+++ b/pkgs/development/libraries/haskell/resource-pool-catchio/default.nix
@@ -1,0 +1,20 @@
+{ cabal, hashable, MonadCatchIOTransformers, stm, time
+, transformers, transformersBase, vector
+}:
+
+cabal.mkDerivation (self: {
+  pname = "resource-pool-catchio";
+  version = "0.2.1.0";
+  sha256 = "0g9r6hnn01n3p2ikcfkfc4afh83pzam29zal3k2ivajpl3kramsw";
+  buildDepends = [
+  hashable MonadCatchIOTransformers stm time transformers
+  transformersBase vector
+  ];
+  meta = {
+    homepage = "http://github.com/norm2782/pool";
+    description = "Fork of resource-pool, with a MonadCatchIO constraint";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})
+

--- a/pkgs/development/libraries/haskell/snap-web-routes/default.nix
+++ b/pkgs/development/libraries/haskell/snap-web-routes/default.nix
@@ -1,0 +1,15 @@
+{ cabal, heist, mtl, snap, snapCore, text, webRoutes, xmlhtml }:
+
+cabal.mkDerivation (self: {
+  pname = "snap-web-routes";
+  version = "0.5.0.0";
+  sha256 = "1ml0b759k2n9bd2x4akz4dfyk8ywnpgrdlcymng4vhjxbzngnniv";
+  buildDepends = [ heist mtl snap snapCore text webRoutes xmlhtml ];
+  meta = {
+    homepage = "https://github.com/lukerandall/snap-web-routes";
+    description = "Type safe URLs for Snap";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})
+

--- a/pkgs/development/libraries/haskell/snaplet-postgresql-simple/default.nix
+++ b/pkgs/development/libraries/haskell/snaplet-postgresql-simple/default.nix
@@ -1,0 +1,23 @@
+{cabal, clientsession, configurator, errors
+, MonadCatchIOTransformers, mtl, postgresqlSimple
+, resourcePoolCatchio, snap, text, transformers
+, unorderedContainers
+}:
+
+cabal.mkDerivation (self: {
+  pname = "snaplet-postgresql-simple";
+  version = "0.5";
+  sha256 = "0pzn0lg1slrllrrx1n9s1kp1pmq2ahrkjypcwnnld8zxzvz4g5jm";
+  buildDepends = [
+    clientsession configurator errors MonadCatchIOTransformers mtl
+    postgresqlSimple resourcePoolCatchio snap text transformers
+    unorderedContainers
+  ];
+  meta = {
+    homepage = "https://github.com/mightybyte/snaplet-postgresql-simple";
+    description = "postgresql-simple snaplet for the Snap Framework";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})
+                                          

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1990,8 +1990,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   snapBlaze = callPackage ../development/libraries/haskell/snap-blaze/default.nix {};
 
-  snapWebRoutes = callPackage ../development/libraries/haskell/snap-web-routes/default.nix {};
-
   snapCore = callPackage ../development/libraries/haskell/snap/core.nix {};
 
   snapCORS = callPackage ../development/libraries/haskell/snap-cors {};
@@ -2001,7 +1999,9 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   snapLoaderStatic = callPackage ../development/libraries/haskell/snap/loader-static.nix {};
 
   snapServer = callPackage ../development/libraries/haskell/snap/server.nix {};
-
+ 
+  snapWebRoutes = callPackage ../development/libraries/haskell/snap-web-routes/default.nix {};
+  
   snowball = callPackage ../development/libraries/haskell/snowball {};
 
   socks = callPackage ../development/libraries/haskell/socks {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1990,6 +1990,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   snapBlaze = callPackage ../development/libraries/haskell/snap-blaze/default.nix {};
 
+  snapWebRoutes = callPackage ../development/libraries/haskell/snap-web-routes/default.nix {};
+
   snapCore = callPackage ../development/libraries/haskell/snap/core.nix {};
 
   snapCORS = callPackage ../development/libraries/haskell/snap-cors {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1908,6 +1908,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   resourcePool = callPackage ../development/libraries/haskell/resource-pool {};
 
+  resourcePoolCatchio = callPackage ../development/libraries/haskell/resource-pool-catchio {};
+
   resourcet = callPackage ../development/libraries/haskell/resourcet {};
 
   retry = callPackage ../development/libraries/haskell/retry {};
@@ -1985,6 +1987,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   snapletAcidState = callPackage ../development/libraries/haskell/snaplet-acid-state {};
 
   snapletRedis = callPackage ../development/libraries/haskell/snaplet-redis {};
+
+  snapletPostgreSqlSimple = callPackage ../development/libraries/haskell/snaplet-postgresql-simple {}; 
 
   snapletStripe = callPackage ../development/libraries/haskell/snaplet-stripe {};
 


### PR DESCRIPTION
Cabal2nix used to add snap-web-routes hackage package to haskell-packages.nix.

This was my first go at nix expressions so hopefully everything is in order.  Seemed simple to do.
