### PR TITLE
Wrap Haskell tools to find GHC packages

### DIFF
--- a/pkgs/development/libraries/haskell/ghc-mod/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-mod/default.nix
@@ -26,6 +26,7 @@ cabal.mkDerivation (self: {
     cd ..
     ensureDir "$out/share/emacs"
     mv $pname-$version emacs/site-lisp
+
     mv $out/bin/ghc-mod $out/bin/.ghc-mod-wrapped
     cat - > $out/bin/ghc-mod <<EOF
     #! ${self.stdenv.shell}
@@ -34,6 +35,15 @@ cabal.mkDerivation (self: {
     eval exec $out/bin/.ghc-mod-wrapped \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.version} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
     EOF
     chmod +x $out/bin/ghc-mod
+
+    mv $out/bin/ghc-modi $out/bin/.ghc-modi-wrapped
+    cat - > $out/bin/ghc-modi <<EOF
+    #! ${self.stdenv.shell}
+    COMMAND=\$1
+    shift
+    eval exec $out/bin/.ghc-modi-wrapped \$COMMAND \$( ${self.ghc.GHCGetPackages} ${self.ghc.version} | tr " " "\n" | tail -n +2 | paste -d " " - - | sed 's/.*/-g "&"/' | tr "\n" " ") "\$@"
+    EOF
+    chmod +x $out/bin/ghc-modi
   '';
   meta = {
     homepage = "http://www.mew.org/~kazu/proj/ghc-mod/";

--- a/pkgs/development/tools/documentation/haddock/2.10.0.nix
+++ b/pkgs/development/tools/documentation/haddock/2.10.0.nix
@@ -1,4 +1,4 @@
-{ cabal, alex, Cabal, filepath, ghcPaths, happy, xhtml }:
+{ cabal, alex, Cabal, filepath, ghcPaths, happy, xhtml, makeWrapper }:
 
 cabal.mkDerivation (self: {
   pname = "haddock";
@@ -6,10 +6,15 @@ cabal.mkDerivation (self: {
   sha256 = "045lmmna5nwj07si81vxms5xkkmqvjsiif20nny5mvlabshxn1yi";
   isLibrary = true;
   isExecutable = true;
-  buildDepends = [ Cabal filepath ghcPaths xhtml ];
+  buildDepends = [ Cabal filepath ghcPaths xhtml makeWrapper ];
   testDepends = [ Cabal filepath ];
   buildTools = [ alex happy ];
   doCheck = false;
+
+  postInstall = ''
+   wrapProgram $out/bin/haddock --add-flags "\$(${self.ghc.GHCGetPackages} ${self.ghc.version} \"\$(dirname \$0)\" \"--optghc=-package-conf --optghc=\")"
+  '';
+
   meta = {
     homepage = "http://www.haskell.org/haddock/";
     description = "A documentation-generation tool for Haskell libraries";

--- a/pkgs/development/tools/documentation/haddock/2.11.0.nix
+++ b/pkgs/development/tools/documentation/haddock/2.11.0.nix
@@ -1,4 +1,4 @@
-{ cabal, alex, Cabal, filepath, ghcPaths, happy, xhtml }:
+{ cabal, alex, Cabal, filepath, ghcPaths, happy, xhtml, makeWrapper }:
 
 cabal.mkDerivation (self: {
   pname = "haddock";
@@ -6,10 +6,15 @@ cabal.mkDerivation (self: {
   sha256 = "0a29n6y9lmk5w78f6j8s7pg0m0k3wm7bx5r2lhk7bnzkr5f7rkcd";
   isLibrary = true;
   isExecutable = true;
-  buildDepends = [ Cabal filepath ghcPaths xhtml ];
+  buildDepends = [ Cabal filepath ghcPaths xhtml makeWrapper ];
   testDepends = [ Cabal filepath ];
   buildTools = [ alex happy ];
   doCheck = false;
+
+  postInstall = ''
+   wrapProgram $out/bin/haddock --add-flags "\$(${self.ghc.GHCGetPackages} ${self.ghc.version} \"\$(dirname \$0)\" \"--optghc=-package-conf --optghc=\")"
+  '';
+
   meta = {
     homepage = "http://www.haskell.org/haddock/";
     description = "A documentation-generation tool for Haskell libraries";

--- a/pkgs/development/tools/documentation/haddock/2.13.2.1.nix
+++ b/pkgs/development/tools/documentation/haddock/2.13.2.1.nix
@@ -1,4 +1,4 @@
-{ cabal, alex, Cabal, deepseq, filepath, ghcPaths, happy, xhtml }:
+{ cabal, alex, Cabal, deepseq, filepath, ghcPaths, happy, xhtml, makeWrapper }:
 
 cabal.mkDerivation (self: {
   pname = "haddock";
@@ -6,10 +6,15 @@ cabal.mkDerivation (self: {
   sha256 = "0kpk3bmlyd7cb6s39ix8s0ak65xhrln9mg481y3h24lf5syy5ky9";
   isLibrary = true;
   isExecutable = true;
-  buildDepends = [ Cabal deepseq filepath ghcPaths xhtml ];
+  buildDepends = [ Cabal deepseq filepath ghcPaths xhtml makeWrapper ];
   testDepends = [ Cabal deepseq filepath ];
   buildTools = [ alex happy ];
   doCheck = false;
+
+  postInstall = ''
+   wrapProgram $out/bin/haddock --add-flags "\$(${self.ghc.GHCGetPackages} ${self.ghc.version} \"\$(dirname \$0)\" \"--optghc=-package-conf --optghc=\")"
+  '';
+
   meta = {
     homepage = "http://www.haskell.org/haddock/";
     description = "A documentation-generation tool for Haskell libraries";

--- a/pkgs/development/tools/documentation/haddock/2.13.2.nix
+++ b/pkgs/development/tools/documentation/haddock/2.13.2.nix
@@ -1,4 +1,4 @@
-{ cabal, alex, Cabal, deepseq, filepath, ghcPaths, happy, xhtml }:
+{ cabal, alex, Cabal, deepseq, filepath, ghcPaths, happy, xhtml, makeWrapper }:
 
 cabal.mkDerivation (self: {
   pname = "haddock";
@@ -6,10 +6,15 @@ cabal.mkDerivation (self: {
   sha256 = "1qwj13ks3fzar14s587svv1pdiwk80m7x5pzn74v3jrqkn0xbrr5";
   isLibrary = true;
   isExecutable = true;
-  buildDepends = [ Cabal deepseq filepath ghcPaths xhtml ];
+  buildDepends = [ Cabal deepseq filepath ghcPaths xhtml makeWrapper ];
   testDepends = [ Cabal deepseq filepath ];
   buildTools = [ alex happy ];
   doCheck = false;
+
+  postInstall = ''
+   wrapProgram $out/bin/haddock --add-flags "\$(${self.ghc.GHCGetPackages} ${self.ghc.version} \"\$(dirname \$0)\" \"--optghc=-package-conf --optghc=\")"
+  '';
+
   meta = {
     homepage = "http://www.haskell.org/haddock/";
     description = "A documentation-generation tool for Haskell libraries";

--- a/pkgs/development/tools/documentation/haddock/2.14.2.nix
+++ b/pkgs/development/tools/documentation/haddock/2.14.2.nix
@@ -1,5 +1,5 @@
 { cabal, Cabal, deepseq, filepath, ghcPaths, hspec, QuickCheck
-, xhtml
+, xhtml, makeWrapper
 }:
 
 cabal.mkDerivation (self: {
@@ -8,9 +8,14 @@ cabal.mkDerivation (self: {
   sha256 = "0h96jj6y093h4gcqpiq0nyv7h5wjg8ji7z1im9ydivmsv0627prk";
   isLibrary = true;
   isExecutable = true;
-  buildDepends = [ Cabal deepseq filepath ghcPaths xhtml ];
+  buildDepends = [ Cabal deepseq filepath ghcPaths xhtml makeWrapper ];
   testDepends = [ Cabal deepseq filepath hspec QuickCheck ];
   doCheck = false;
+
+  postInstall = ''
+   wrapProgram $out/bin/haddock --add-flags "\$(${self.ghc.GHCGetPackages} ${self.ghc.version} \"\$(dirname \$0)\" \"--optghc=-package-conf --optghc=\")"
+  '';
+
   meta = {
     homepage = "http://www.haskell.org/haddock/";
     description = "A documentation-generation tool for Haskell libraries";


### PR DESCRIPTION
Several Haskell tools that use GHC are missing the environment wrapping required to find Haskell packages:
- `ghc-mod` was correctly wrapped, but not `ghc-modi`
- `haddock` was wrapped prior to 2.10, but not since then.
