### PR TITLE
Disable network-transport-tcp tests, since it should depend on network-t...

### DIFF
--- a/pkgs/development/libraries/haskell/network-transport-tcp/default.nix
+++ b/pkgs/development/libraries/haskell/network-transport-tcp/default.nix
@@ -1,4 +1,4 @@
-{ cabal, dataAccessor, network, networkTransport
+{ cabal, dataAccessor, network_2_4_1_2, networkTransport
 , networkTransportTests
 }:
 
@@ -6,8 +6,11 @@ cabal.mkDerivation (self: {
   pname = "network-transport-tcp";
   version = "0.4.0";
   sha256 = "1jjf1dj67a7l3jg3qgbg0hrjfnx1kr9n7hfvqssq7kr8sq1sc49v";
-  buildDepends = [ dataAccessor network networkTransport ];
-  testDepends = [ network networkTransport networkTransportTests ];
+  buildDepends = [ dataAccessor network_2_4_1_2 networkTransport ];
+  testDepends = [ network_2_4_1_2 networkTransport networkTransportTests ];
+  # tests should be enabled when network-transport-tests 0.2.0.0 released.
+  doCheck = false;
+
   meta = {
     homepage = "http://haskell-distributed.github.com";
     description = "TCP instantiation of Network.Transport";


### PR DESCRIPTION
...ransport-tests-0.2.0.0 which is not released yet.

Also networkTransportTcp depends on network < 2.5.
