### PR TITLE
Add hackage mirror to mirrors.nix

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -373,4 +373,10 @@ rec {
     http://lib.stat.cmu.edu/
   ];
 
+  # Hackage mirrors
+  hackage = [
+    http://hackage.haskell.org/package/
+    http://hdiff.luite.com/packages/archive/package/
+  ];
+
 }


### PR DESCRIPTION
I'd like to use them for my own cabal derivations, so that luite's mirror can be used if hackage is down. 
