### PR TITLE
Set vs list

### DIFF
--- a/pkgs/development/interpreters/php/5.4.nix
+++ b/pkgs/development/interpreters/php/5.4.nix
@@ -171,7 +171,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
         configureFlags = ["--enable-fpm"];
       };
 
-      mssql = stdenv.lib.optional (!stdenv.isDarwin) {
+      mssql = stdenv.lib.optionals (!stdenv.isDarwin) {
         configureFlags = ["--with-mssql=${freetds}"];
         buildInputs = [freetds];
       };


### PR DESCRIPTION
Fixes 1228caae9e5f525abed6061001121fbb670716a6

I just came across the solution by chance and fixed it. In general, where can I find the definitions and documentation for functions like stdenv.lib.optional?
