### PR TITLE
pipes-bytestring: updated to 2.1.0

### DIFF
--- a/pkgs/development/libraries/haskell/pipes-bytestring/default.nix
+++ b/pkgs/development/libraries/haskell/pipes-bytestring/default.nix
@@ -1,13 +1,11 @@
-{ cabal, pipes, pipesGroup, pipesParse, profunctors, transformers
+{ cabal, pipes, pipesGroup, pipesParse, transformers
 }:
 
 cabal.mkDerivation (self: {
   pname = "pipes-bytestring";
-  version = "2.0.1";
-  sha256 = "1vsfqqkr5danb0n30av4vk8d4by9f50y5l8ywm1xjrmwrx999gvf";
-  buildDepends = [
-    pipes pipesGroup pipesParse profunctors transformers
-  ];
+  version = "2.1.0";
+  sha256 = "1q98444kpcdc817zbg121g2n1mhblrdfsmd0bs5rqq6ijxb213z0";
+  buildDepends = [ pipes pipesGroup pipesParse transformers ];
   meta = {
     description = "ByteString support for pipes";
     license = self.stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
2.1.0 doesn't depend on profunctors.
