### PR TITLE
New package: sqsh. An SQL query tool/shell for Sybase/MSSQL

### DIFF
--- a/pkgs/development/tools/sqsh/default.nix
+++ b/pkgs/development/tools/sqsh/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, freetds, readline }:
+
+stdenv.mkDerivation rec {
+  version = "2.5.16.1";
+  name = "sqsh-${version}";
+
+  src = fetchurl {
+    url = "http://www.mirrorservice.org/sites/downloads.sourceforge.net/s/sq/sqsh/sqsh/sqsh-2.5/${name}.tgz";
+    sha256 = "1wi0hdmhk7l8nrz4j3kaa177mmxyklmzhj7sq1gj4q6fb8v1yr6n";
+  };
+
+  preConfigure =
+    ''
+    export SYBASE=${freetds}
+    '';
+
+  buildInputs = [ 
+    freetds 
+    readline
+  ];
+
+  meta = {
+    description = "SQSH is command line tool for querying Sybase/MSSQL databases";
+    longDescription = 
+      ''
+      Sqsh (pronounced skwish) is short for SQshelL (pronounced s-q-shell),
+      it is intended as a replacement for the venerable 'isql' program supplied
+      by Sybase.
+      '';
+    homepage = "http://www.cs.washington.edu/~rose/sqsh/sqsh.html";
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11061,6 +11061,8 @@ let
 
   streamripper = callPackage ../applications/audio/streamripper { };
 
+  sqsh = callPackage ../development/tools/sqsh { };
+
   tetex = callPackage ../tools/typesetting/tex/tetex { libpng = libpng12; };
 
   tex4ht = callPackage ../tools/typesetting/tex/tex4ht { };


### PR DESCRIPTION
`sqsh` is a useful tool for those dark times when you have to query Microsoft SQL Server from a *nix command line. It uses the `freetds` library and so is compatible with Sybase/MSSQL TSQL flavors of databases.
