### PR TITLE
cmake: setup-hook.sh bug fix.

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -47,7 +47,7 @@ cmakeConfigurePhase() {
     eval "$postConfigure"
 }
 
-if [ -z "$dontUseCmakeConfigure" -a ! -v configurePhase ]; then
+if [ -z "$dontUseCmakeConfigure" ] && [ ! -v configurePhase ]; then
     configurePhase=cmakeConfigurePhase
 fi
 


### PR DESCRIPTION
syntax for logical statement in condition test was wrong. This bug caused the following annoying error messages for packages that uses cmake build system.  

```
bash: [: -v: unary operator expected
```
