### PR TITLE
Fix sudo installation issue #3027

### DIFF
--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-env-editor"
+    "--with-editor=/run/current-system/sw/bin/nano"
     "--with-rundir=/var/run"
     "--with-vardir=/var/db/sudo"
     "--with-logpath=/var/log/sudo.log"

--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -11,39 +11,42 @@ stdenv.mkDerivation rec {
     sha256 = "002l6h27pnhb77b65frhazbhknsxvrsnkpi43j7i0qw1lrgi7nkf";
   };
 
-  postConfigure = ''
-    cat >> pathnames.h <<EOF
-    #undef  _PATH_SUDO_LOGFILE
-    #define _PATH_SUDO_LOGFILE "/var/log/sudo.log"
-    #undef  _PATH_SUDO_TIMEDIR
-    #define _PATH_SUDO_TIMEDIR "/run/sudo"
-    #undef  _PATH_VI
-    #define _PATH_VI "/run/current-system/sw/bin/nano"
-    #undef  _PATH_MV
-    #define _PATH_MV "${coreutils}/bin/mv"
-    EOF
+  configureFlags = [
+    "--with-env-editor"
+    "--with-rundir=/var/run"
+    "--with-vardir=/var/db/sudo"
+    "--with-logpath=/var/log/sudo.log"
+  ];
 
+  postConfigure =
+    ''
+    cat >> pathnames.h <<'EOF'
+      #undef _PATH_MV
+      #define _PATH_MV "${coreutils}/bin/mv"
+    EOF
     makeFlags="install_uid=$(id -u) install_gid=$(id -g)"
-    installFlags="sudoers_uid=$(id -u) sudoers_gid=$(id -g) sysconfdir=$out/etc timedir=$TMPDIR/dummy"
-  '';
+    installFlags="sudoers_uid=$(id -u) sudoers_gid=$(id -g) sysconfdir=$out/etc rundir=$TMPDIR/dummy vardir=$TMPDIR/dummy"
+    '';
 
   buildInputs = [ coreutils pam groff ];
 
   enableParallelBuilding = true;
 
-  postInstall = ''
-    rm $out/share/doc/sudo/ChangeLog
-  '';
+  postInstall = 
+    ''
+    rm -f $out/share/doc/sudo/ChangeLog
+    '';
 
   meta = {
     description = "A command to run commands as root";
 
-    longDescription = ''
+    longDescription = 
+      ''
       Sudo (su "do") allows a system administrator to delegate
       authority to give certain users (or groups of users) the ability
       to run some (or all) commands as root or another user while
       providing an audit trail of the commands and their arguments.
-    '';
+      '';
 
     homepage = http://www.sudo.ws/;
 


### PR DESCRIPTION
TIMEDIR is no longer used to refer to the timestamp state dir. This patch configures `rundir` / `vardir` instead.

Resolves Issue #3027.

Also use configure flags where possible rather than patching pathnames.h so that we'll get better errors if those items change in the future.
