### PR TITLE
Python module tables

### DIFF
--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -4,6 +4,6 @@ stdenv.mkDerivation {
     name = "szip-2.1";
     src = fetchurl {
         url = ftp://ftp.hdfgroup.org/lib-external/szip/2.1/src/szip-2.1.tar.gz;
-        sha256 = "05707lrdhwp8mv0dgzh2b6m2mwamv1z6k29m2v1v7pz0c1w2gb6z";
+        sha256 = "1vym7r4by02m0yqj10023xyps5b21ryymnxb4nb2gs32arfxj5m8";
     };
 }

--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, python, buildPythonPackage
+, cython, bzip2, lzo, numpy, numexpr, hdf5 }:
+
+buildPythonPackage rec {
+  version = "3.1.1";
+  name = "tables-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pytables/${name}.tar.gz";
+    sha256 = "18rdzv9xwiapb5c8y47rk2fi3fdm2dpjf68wfycma67ifrih7f9r";
+  };
+
+  buildInputs = [ hdf5 cython bzip2 lzo ];
+  propagatedBuildInputs = [ numpy numexpr ];
+
+  # The setup script complains about missing run-paths, but they are
+  # actually set.
+  setupPyBuildFlags =
+    [ "--hdf5=${hdf5}"
+      "--lzo=${lzo}"
+      "--bzip2=${bzip2}"
+    ];
+  setupPyInstallFlags = setupPyBuildFlags;
+
+  # Run the test suite.
+  # It requires the build path to be in the python search path.
+  # These tests take quite some time.
+  # If the hdf5 library is built with zlib then there is only one
+  # test-failure. That is the same failure as described in the following
+  # github issue:
+  #     https://github.com/PyTables/PyTables/issues/269
+  checkPhase = ''
+    ${python}/bin/${python.executable} <<EOF
+    import sysconfig
+    import sys
+    import os
+    f = "lib.{platform}-{version[0]}.{version[1]}"
+    lib = f.format(platform=sysconfig.get_platform(),
+                   version=sys.version_info)
+    build = os.path.join(os.getcwd(), 'build', lib)
+    sys.path.insert(0, build)
+    import tables
+    r = tables.test()
+    if not r.wasSuccessful():
+        sys.exit(1)
+    EOF
+  '';
+
+  # Disable tests until the failure described above is fixed.
+  doCheck = false;
+
+  meta = {
+    description = "Hierarchical datasets for Python";
+    homepage = "http://www.pytables.org/";
+  };
+}

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -2,6 +2,7 @@
 { stdenv
 , fetchurl
 , zlib ? null
+, szip ? null
 }:
 stdenv.mkDerivation {
   name = "hdf5-1.8.10-patch1";
@@ -11,7 +12,10 @@ stdenv.mkDerivation {
   };
 
   buildInputs = []
-    ++ stdenv.lib.optional (zlib != null) zlib;
+    ++ stdenv.lib.optional (zlib != null) zlib
+    ++ stdenv.lib.optional (szip != null) szip;
+
+  configureFlags = if szip != null then "--with-szlib=${szip}" else "";
   
   patches = [./bin-mv.patch];
   

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -4,11 +4,12 @@
 , zlib ? null
 , szip ? null
 }:
-stdenv.mkDerivation {
-  name = "hdf5-1.8.10-patch1";
+stdenv.mkDerivation rec {
+  version = "1.8.13";
+  name = "hdf5-${version}-patch1";
   src = fetchurl {
-    url = http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.10-patch1.tar.gz;
-    sha256 = "08ad32fhnci6rdfn6mn3w9v1wcaxdcd326n3ljwkcq4dzhkh28qz";  			
+    url = "http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-${version}.tar.gz";
+    sha256 = "1h9qdl321gzm3ihdhlijbl9sh9qcdrw94j7izg64yfqhxj7b7xl2";  			
   };
 
   buildInputs = []

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -1,6 +1,7 @@
 
 { stdenv
 , fetchurl
+, zlib ? null
 }:
 stdenv.mkDerivation {
   name = "hdf5-1.8.10-patch1";
@@ -8,7 +9,9 @@ stdenv.mkDerivation {
     url = http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.10-patch1.tar.gz;
     sha256 = "08ad32fhnci6rdfn6mn3w9v1wcaxdcd326n3ljwkcq4dzhkh28qz";  			
   };
-  buildInputs = [] ;
+
+  buildInputs = []
+    ++ stdenv.lib.optional (zlib != null) zlib;
   
   patches = [./bin-mv.patch];
   

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4601,6 +4601,43 @@ rec {
     };
   };
 
+  numexpr = buildPythonPackage rec {
+    version = "2.4";
+    name = "numexpr-${version}";
+
+    src = fetchgit {
+      url = https://github.com/pydata/numexpr.git;
+      rev = "606cc9a110711e947d35ac2770749c00dab184c8";
+      sha256 = "1gxgkg7ncgjhnifn444iha5nrjhyr8sr6w5yp204186a1ysz858g";
+    };
+
+    propagatedBuildInputs = with pkgs; [ numpy ];
+
+    # Run the test suite.
+    # It requires the build path to be in the python search path.
+    checkPhase = ''
+      ${python}/bin/${python.executable} <<EOF
+      import sysconfig
+      import sys
+      import os
+      f = "lib.{platform}-{version[0]}.{version[1]}"
+      lib = f.format(platform=sysconfig.get_platform(),
+                     version=sys.version_info)
+      build = os.path.join(os.getcwd(), 'build', lib)
+      sys.path.insert(0, build)
+      import numexpr
+      r = numexpr.test()
+      if not r.wasSuccessful():
+          sys.exit(1)
+      EOF
+    '';
+
+    meta = {
+      description = "Fast numerical array expression evaluator for NumPy";
+      homepage = "https://github.com/pydata/numexpr";
+    };
+  };
+
   numpy = buildPythonPackage ( rec {
     name = "numpy-1.7.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -146,6 +146,12 @@ rec {
     inherit python;
   };
 
+  tables = import ../development/python-modules/tables {
+    inherit (pkgs) stdenv fetchurl bzip2 lzo;
+    inherit python buildPythonPackage cython numpy numexpr;
+    hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
+  };
+
   # packages defined here
 
   aafigure = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4878,11 +4878,11 @@ rec {
   });
 
   pandas = buildPythonPackage rec {
-    name = "pandas-0.12.0";
+    name = "pandas-0.14.0";
 
     src = fetchurl {
       url = "https://pypi.python.org/packages/source/p/pandas/${name}.tar.gz";
-      sha256 = "0vf865wh1kcq33189ykqgngb25nxhxxch6skfdl3c6w024v4r6xy";
+      sha256 = "f7997debca756c4dd5ccdf5a010dfe3d1c7dac98ee706b715d994cf7c9d35528";
     };
 
     buildInputs = [ nose ];


### PR DESCRIPTION
Added the python module [tables](http://www.pytables.org/moin). It is an optional dependency to [pandas](http://pandas.pydata.org/pandas-docs/stable/install.html#optional-dependencies) for reading/writing hdf5 archives.

I've also added [numexpr](https://github.com/pydata/numexpr), which is a dependency for tables, and updated hdf5, and pandas.

I've added optional dependencies to hdf5. One is zlib, the other is szip. The former is required by tables.

Last, I fixed the source hash for szip.
