### PR TITLE
Allowing cuda to use its own thrust library

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/5.5.nix
+++ b/pkgs/development/compilers/cudatoolkit/5.5.nix
@@ -51,7 +51,10 @@ stdenv.mkDerivation rec {
     perl ./install-linux.pl --prefix="$out"
     rm $out/tools/CUDA_Occupancy_Calculator.xls
     perl ./install-sdk-linux.pl --prefix="$sdk" --cudaprefix="$out"
+    mv $out/include $out/usr_include
   '';
+
+  setupHook = ./setup-hook.sh;
 
   meta = {
     license = [ "nonfree" ];

--- a/pkgs/development/compilers/cudatoolkit/6.0.nix
+++ b/pkgs/development/compilers/cudatoolkit/6.0.nix
@@ -51,7 +51,10 @@ stdenv.mkDerivation rec {
     perl ./install-linux.pl --prefix="$out"
     rm $out/tools/CUDA_Occupancy_Calculator.xls
     perl ./install-sdk-linux.pl --prefix="$sdk" --cudaprefix="$out"
+    mv $out/include $out/usr_include
   '';
+
+  setupHook = ./setup-hook.sh;
 
   meta = {
     license = [ "nonfree" ];

--- a/pkgs/development/compilers/cudatoolkit/setup-hook.sh
+++ b/pkgs/development/compilers/cudatoolkit/setup-hook.sh
@@ -1,0 +1,8 @@
+addIncludePath () {
+    if test -d "$1/usr_include"
+    then
+        export NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE} -I$1/usr_include"
+    fi
+}
+
+envHooks=(${envHooks[@]} addIncludePath)


### PR DESCRIPTION
If cuda headers are presented to nix in $out/include they are added to future gcc calls via a -isystem flag. However, cuda does not allow kernel calls from template function if these are located in system-headers. We thus move headers from $out/include to $out/usr_include and add a custom hook to add these headers via -I. This allows the cuda thrust libraries to be used.
