### PR TITLE
Print output of `git describe` in `nix-prefetch-git`

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -217,7 +217,9 @@ clone_user_rev() {
             fi;;
     esac
 
-    echo "git revision is $(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/fetchgit) | tail -n1)"
+    local full_revision=$(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/fetchgit) | tail -n1)
+    echo "git revision is $full_revision"
+    echo "git human-readable version is $(cd $dir && (git describe $full_revision 2> /dev/null || git describe --tags $full_revision 2> /dev/null || echo -- none --))"
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"


### PR DESCRIPTION
The output is like this:

```
Switched to a new branch 'fetchgit'
git revision is 942100b2fe5ebf57a908171c071f7bd343106c5c
git human-readable version is v0.6.2-10-g942100b
```

I hope it will help make git-packages' version much nicer
