### PR TITLE
Update isc-dhcp to the latest version

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -121,6 +121,12 @@ rec {
     url = https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception;
   };
 
+  isc = {
+    shortName = "ISC License";
+    fullName = "Internet Systems Consortium License";
+    url = http://www.isc.org/downloads/software-support-policy/isc-license/;
+  };
+
   inria = {
     shortName = "INRIA-NCLA";
     fullName  = "INRIA Non-Commercial License Agreement";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -140,6 +140,7 @@
       mopidy = 130;
       unifi = 131;
       gdm = 132;
+      dhcpd = 133;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -13,7 +13,7 @@ let
       default-lease-time 600;
       max-lease-time 7200;
       authoritative;
-      ddns-update-style ad-hoc;
+      ddns-update-style interim;
       log-facility local1; # see dhcpd.nix
 
       ${cfg.extraConfig}

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -66,6 +66,24 @@ in
         ";
       };
 
+      user = mkOption {
+        default = "nobody";
+        type = types.nullOr types.str;
+        description = ''
+          The user to drop privileges to after the daemon has started.
+          A value of null disables the user privilege change.
+        '';
+      };
+
+      group = mkOption {
+        default = "nogroup";
+        type = types.nullOr types.str;
+        description = ''
+          The group to drop privileges to after the daemon has started.
+          A value of null disables the group privilege change.
+        '';
+      };
+
       configFile = mkOption {
         default = null;
         description = "
@@ -120,8 +138,10 @@ in
 
             touch ${stateDir}/dhcpd.leases
 
-            exec ${pkgs.dhcp}/sbin/dhcpd -f -cf ${configFile} \
+            exec ${pkgs.dhcp}/sbin/dhcpd -f --no-pid -cf ${configFile} \
                 -lf ${stateDir}/dhcpd.leases \
+                ${optionalString (cfg.user != null) "-user ${cfg.user}"} \
+                ${optionalString (cfg.group != null) "-group ${cfg.group}"} \
                 ${toString cfg.interfaces}
           '';
       };

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -66,24 +66,6 @@ in
         ";
       };
 
-      user = mkOption {
-        default = "nobody";
-        type = types.nullOr types.str;
-        description = ''
-          The user to drop privileges to after the daemon has started.
-          A value of null disables the user privilege change.
-        '';
-      };
-
-      group = mkOption {
-        default = "nogroup";
-        type = types.nullOr types.str;
-        description = ''
-          The group to drop privileges to after the daemon has started.
-          A value of null disables the group privilege change.
-        '';
-      };
-
       configFile = mkOption {
         default = null;
         description = "
@@ -126,6 +108,13 @@ in
 
   config = mkIf config.services.dhcpd.enable {
 
+    users = {
+      extraUsers.dhcpd = {
+        uid = config.ids.uids.dhcpd;
+        description = "DHCP daemon user";
+      };
+    };
+
     jobs.dhcpd =
       { description = "DHCP server";
 
@@ -139,9 +128,7 @@ in
             touch ${stateDir}/dhcpd.leases
 
             exec ${pkgs.dhcp}/sbin/dhcpd -f --no-pid -cf ${configFile} \
-                -lf ${stateDir}/dhcpd.leases \
-                ${optionalString (cfg.user != null) "-user ${cfg.user}"} \
-                ${optionalString (cfg.group != null) "-group ${cfg.group}"} \
+                -lf ${stateDir}/dhcpd.leases -user dhcpd -group nogroup \
                 ${toString cfg.interfaces}
           '';
       };

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -120,6 +120,8 @@ in
 
         wantedBy = [ "multi-user.target" ];
 
+        after = [ "network.target" ];
+
         path = [ pkgs.dhcp ];
 
         preStart =

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 	-"es|^ *#define \+_PATH_DHCLIENT_SCRIPT.*$|#define _PATH_DHCLIENT_SCRIPT \"$out/sbin/dhclient-script\"|g"
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Dynamic Host Configuration Protocol (DHCP) tools";
 
     longDescription = ''
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
    '';
 
     homepage = http://www.isc.org/products/DHCP/;
-    license = "http://www.isc.org/sw/dhcp/dhcp-copyright.php";
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, nettools, iputils, iproute, makeWrapper, coreutils, gnused }:
+{ stdenv, fetchurl, perl, file, nettools, iputils, iproute, makeWrapper, coreutils, gnused }:
 
 stdenv.mkDerivation rec {
-  name = "dhcp-4.1-ESV-R6";
+  name = "dhcp-${version}";
+  version = "4.3.0";
   
   src = fetchurl {
-    url = http://ftp.isc.org/isc/dhcp/4.1-ESV-R6/dhcp-4.1-ESV-R6.tar.gz;
-    sha256 = "17md1vml07szl9dx4875gfg4sgnb3z73glpbq1si7p82mfhnddny";
+    url = "http://ftp.isc.org/isc/dhcp/${version}/${name}.tar.gz";
+    sha256 = "12mydvj6x3zcl3gla06bywfkkrgg03g66fijs94mwb7kbiym3dm7";
   };
 
   patches =
@@ -23,13 +24,15 @@ stdenv.mkDerivation rec {
   # Fixes "socket.c:591: error: invalid application of 'sizeof' to
   # incomplete type 'struct in6_pktinfo'".  See
   # http://www.mail-archive.com/blfs-book@linuxfromscratch.org/msg13013.html
-  NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE";
+  #
+  # Also adds the ability to run dhcpd as a non-root user / group
+  NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE -DPARANOIA";
 
   # It would automatically add -Werror, which disables build in gcc 4.4
   # due to an uninitialized variable.
   CFLAGS = "-g -O2 -Wall";
 
-  buildInputs = [ makeWrapper ];
+  buildInputs = [ perl makeWrapper ];
 
   postInstall =
     ''
@@ -42,6 +45,7 @@ stdenv.mkDerivation rec {
 
   preConfigure =
     ''
+      substituteInPlace configure --replace "/usr/bin/file" "${file}/bin/file"
       sed -i "includes/dhcpd.h" \
 	-"es|^ *#define \+_PATH_DHCLIENT_SCRIPT.*$|#define _PATH_DHCLIENT_SCRIPT \"$out/sbin/dhclient-script\"|g"
     '';


### PR DESCRIPTION
This patchset bumps dhcpd to the latest version as well as builds dhcpd with paranoia enabled. This allows for the additional dhcpd options to drop privileges (-user, -group, -chroot).

Additionally, this updates the nixos dhcp module to drop privileges by default to user nobody and group nogroup.

I tested this with privilege dropping enabled on my local dhcp server and all seems to be in working order.
