### PR TITLE
sudo: Fix build and nondeterminism with rundir and vardir.

### DIFF
--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -11,6 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "002l6h27pnhb77b65frhazbhknsxvrsnkpi43j7i0qw1lrgi7nkf";
   };
 
+  patches = [ ./sudo-mkdir.patch ];
+
+  configureFlags = [
+    "--with-rundir=/var/run/sudo"
+    "--with-vardir=/var/db/sudo"
+  ];
+
   postConfigure = ''
     cat >> pathnames.h <<EOF
     #undef  _PATH_SUDO_LOGFILE

--- a/pkgs/tools/security/sudo/sudo-mkdir.patch
+++ b/pkgs/tools/security/sudo/sudo-mkdir.patch
@@ -1,0 +1,12 @@
+diff -urN sudo-1.8.10p3.old/plugins/sudoers/Makefile.in sudo-1.8.10p3/plugins/sudoers/Makefile.in
+--- sudo-1.8.10p3.old/plugins/sudoers/Makefile.in	2014-06-22 09:52:22.927066257 +0200
++++ sudo-1.8.10p3/plugins/sudoers/Makefile.in	2014-06-22 09:55:03.951073442 +0200
+@@ -291,8 +291,6 @@
+ 	    $(DESTDIR)$(sudoersdir) $(DESTDIR)$(docdir) \
+ 	    `echo $(DESTDIR)$(rundir)|sed 's,/[^/]*$$,,'` \
+ 	    `echo $(DESTDIR)$(vardir)|sed 's,/[^/]*$$,,'`
+-	$(INSTALL) -d -O $(install_uid) -G $(install_gid) -m 0711 $(DESTDIR)$(rundir)
+-	$(INSTALL) -d -O $(install_uid) -G $(install_gid) -m 0711 $(DESTDIR)$(vardir)
+ 
+ install-binaries: visudo sudoreplay install-dirs
+ 	$(INSTALL) -b~ -O $(install_uid) -G $(install_gid) -m 0755 sudoreplay $(DESTDIR)$(replaydir)/sudoreplay


### PR DESCRIPTION
The sudo configure script will check for the existence of some directories on the system to determine what to use (rundir, vardir). Further, make install will attempt to mkdir those directories that it chose. This causes a build failure when sudo is being built outside chroot.

This commit:
- Tells sudo what to use as rundir and vardir so it doesn't perform nondeterministic checks (same dirs as Gentoo uses).
- Removes the mkdir commands.

I've confirmed it builds and the system boots but not much more. Those directories aren't created automatically on boot, maybe they should be. I also haven't checked if different directories are needed on non-Linux systems.
