### PR TITLE
named nixos tests

### DIFF
--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -37,7 +37,7 @@ rec {
   # `driver' is the script that runs the network.
   runTests = driver:
     stdenv.mkDerivation {
-      name = "vm-test-run" + "-" + driver.testName;
+      name = "vm-test-run-${driver.testName}";
 
       requiredSystemFeatures = [ "kvm" "nixos-test" ];
 
@@ -72,7 +72,7 @@ rec {
 
     let
       testName = t.name or "unnamed";
-      testDriverName = "nixos-test-driver" + "-" + testName;
+      testDriverName = "nixos-test-driver-${testName}";
 
       nodes = buildVirtualNetwork (
         t.nodes or (if t ? machine then { machine = t.machine; } else { }));

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -37,7 +37,7 @@ rec {
   # `driver' is the script that runs the network.
   runTests = driver:
     stdenv.mkDerivation {
-      name = "vm-test-run";
+      name = "vm-test-run" + "-" + driver.testName;
 
       requiredSystemFeatures = [ "kvm" "nixos-test" ];
 
@@ -71,6 +71,8 @@ rec {
     { testScript, makeCoverageReport ? false, ... } @ t:
 
     let
+      testName = t.name or "unnamed";
+      testDriverName = "nixos-test-driver" + "-" + testName;
 
       nodes = buildVirtualNetwork (
         t.nodes or (if t ? machine then { machine = t.machine; } else { }));
@@ -88,10 +90,11 @@ rec {
       # Generate onvenience wrappers for running the test driver
       # interactively with the specified network, and for starting the
       # VMs from the command line.
-      driver = runCommand "nixos-test-driver"
+      driver = runCommand testDriverName
         { buildInputs = [ makeWrapper];
           testScript = testScript';
           preferLocalBuild = true;
+          inherit testName;
         }
         ''
           mkdir -p $out/bin

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -68,11 +68,10 @@ rec {
 
 
   makeTest =
-    { testScript, makeCoverageReport ? false, ... } @ t:
+    { testScript, makeCoverageReport ? false, name ? "unnamed", ... } @ t:
 
     let
-      testName = t.name or "unnamed";
-      testDriverName = "nixos-test-driver-${testName}";
+      testDriverName = "nixos-test-driver-${name}";
 
       nodes = buildVirtualNetwork (
         t.nodes or (if t ? machine then { machine = t.machine; } else { }));
@@ -94,7 +93,7 @@ rec {
         { buildInputs = [ makeWrapper];
           testScript = testScript';
           preferLocalBuild = true;
-          inherit testName;
+          testName = name;
         }
         ''
           mkdir -p $out/bin


### PR DESCRIPTION
Give nixos tests names:

```
/nix/store/wqvdm02yvvng2mdxvhk1l98149pkynix-vm-test-run-virtualenv-python2.7
```

This shows among others at the top of log files and in the target of the result links created by nix-build. Especially useful when building multiple tests with one nix-build run and examining log files later:

```
nix-build tests/installer.nix
...
firefox result*/log.html
```

Tests that do not define a name will show up as unnamed:

```
/nix/store/aanbj2x1c4giprj5nsrq84r2c5ka3sx0-vm-test-run-unnamed
```

If you like this I would name all existing nixos tests and include with this pull request.
