### PR TITLE
virtualbox: Fix permissions for /dev/vboxdrvu

### DIFF
--- a/nixos/modules/programs/virtualbox.nix
+++ b/nixos/modules/programs/virtualbox.nix
@@ -14,6 +14,7 @@ let virtualbox = config.boot.kernelPackages.virtualbox; in
   services.udev.extraRules =
     ''
       KERNEL=="vboxdrv",    OWNER="root", GROUP="vboxusers", MODE="0660", TAG+="systemd"
+      KERNEL=="vboxdrvu",   OWNER="root", GROUP="root",      MODE="0666", TAG+="systemd"
       KERNEL=="vboxnetctl", OWNER="root", GROUP="root",      MODE="0600", TAG+="systemd"
       SUBSYSTEM=="usb_device", ACTION=="add", RUN+="${virtualbox}/libexec/virtualbox/VBoxCreateUSBNode.sh $major $minor $attr{bDeviceClass}"
       SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", RUN+="${virtualbox}/libexec/virtualbox/VBoxCreateUSBNode.sh $major $minor $attr{bDeviceClass}"


### PR DESCRIPTION
See https://bugs.archlinux.org/task/38314 and https://www.virtualbox.org/browser/vbox/trunk/src/VBox/Installer/linux/installer-common.sh?rev=47894#L28
