### PR TITLE
fix openjdk url for Darwin

### DIFF
--- a/pkgs/development/compilers/openjdk-darwin/default.nix
+++ b/pkgs/development/compilers/openjdk-darwin/default.nix
@@ -4,7 +4,7 @@ let
     name = "openjdk6-b16-24_apr_2009-r1";
 
     src = fetchurl {
-      url = http://hg.bikemonkey.org/archive/openjdk6_darwin/openjdk6-b16-24_apr_2009-r1.tar.bz2;
+      url = http://landonf.bikemonkey.org/static/soylatte/bsd-dist/openjdk6_darwin/openjdk6-b16-24_apr_2009-r1.tar.bz2;
       sha256 = "14pbv6jjk95k7hbgiwyvjdjv8pccm7m8a130k0q7mjssf4qmpx1v";
     };
 


### PR DESCRIPTION
This fixes the url for openjdk on darwin.
