### PR TITLE
nixos/network-interfaces: Only flush global ipv6 addresses

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -522,7 +522,7 @@ in
                   # interface (e.g. in a QEMU VM test).
                   if ! ip -6 -o a show dev "${i.name}" | grep "${i.ipv6Address}/${toString i.ipv6prefixLength}"; then
                     echo "configuring interface..."
-                    ip -6 addr flush dev "${i.name}"
+                    ip -6 addr flush scope global dev "${i.name}"
                     ip -6 addr add "${i.ipv6Address}/${toString i.ipv6prefixLength}" dev "${i.name}"
                     restart_network_setup=true
                   else


### PR DESCRIPTION
Currently, when initializing static ipv6 addresses, we flush all of the
old addresses on the network interface. The problem with this approach
is that it flushes the autogenerated link local addresses, which are mandatory for
properly supporting ipv6.

This patch changes the flush behavior so that it only flushes global
addresses when bringing up static ip's on the interface.
