### PR TITLE
nixos/sshd: drop mode from auth keys file. Closes #2559

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -56,7 +56,6 @@ let
   authKeysFiles = let
     mkAuthKeyFile = u: {
       target = "ssh/authorized_keys.d/${u.name}";
-      mode = "0444";
       source = pkgs.writeText "${u.name}-authorized_keys" ''
         ${concatStringsSep "\n" u.openssh.authorizedKeys.keys}
         ${concatMapStrings (f: readFile f + "\n") u.openssh.authorizedKeys.keyFiles}


### PR DESCRIPTION
Mode was 0444 for ssh keys, and the files in nix store are 444 already. Except the group is nixbld instead of root. Removing the mode, the etc script creates a link to /etc/static.
Haven't tested whether sshd refuses to read symbolic links.
