### PR TITLE
Use XQuartz on Darwin

### DIFF
--- a/pkgs/applications/misc/xfontsel/default.nix
+++ b/pkgs/applications/misc/xfontsel/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     description = "Allows testing the fonts available in an X server";
     license = "free";
     maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/xlsfonts/default.nix
+++ b/pkgs/applications/misc/xlsfonts/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description = "Lists the fonts available in the X server";
     license = "free";
     maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/xterm/default.nix
+++ b/pkgs/applications/misc/xterm/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     homepage = http://invisible-island.net/xterm;
     license = "BSD";
     maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/mesa-darwin/default.nix
+++ b/pkgs/development/libraries/mesa-darwin/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, stdenvAdapters, gccApple, fetchurl, pkgconfig, intltool, flex, bison
+, python, libxml2Python, file, expat, makedepend, xorg, llvm, libffi, libvdpau
+, enableTextureFloats ? false # Texture floats are patented, see docs/patents.txt
+, enableExtraFeatures ? false # not maintained
+}:
+
+let
+  version = "8.0.5";
+  self = stdenv.mkDerivation rec {
+    name = "mesa-${version}";
+
+    src =  fetchurl {
+      url = "ftp://ftp.freedesktop.org/pub/mesa/older-versions/8.x/${version}/MesaLib-${version}.tar.bz2";
+      sha256 = "0pjs8x51c0i6mawgd4w03lxpyx5fnx7rc8plr8jfsscf9yiqs6si";
+    };
+
+    nativeBuildInputs = [ pkgconfig python makedepend flex bison ];
+
+    buildInputs = with xorg; [
+      glproto dri2proto libXfixes libXi libXmu
+      intltool expat libxml2Python llvm
+      presentproto
+      libX11 libXext libxcb libXt libxshmfence
+      libffi libvdpau
+    ];
+
+    postUnpack = ''
+      ln -s darwin $sourceRoot/configs/current
+    '';
+
+    patches = [
+      ./patches/0003-mesa-fix-per-level-max-texture-size-error-checking.patch
+      ./patches/0008-glsl-initialise-const-force-glsl-extension-warning-i.patch
+      ./patches/0009-mesa-test-for-GL_EXT_framebuffer_sRGB-in-glPopAttrib.patch
+      ./patches/0011-Apple-glFlush-is-not-needed-with-CGLFlushDrawable.patch
+      ./patches/0012-glapi-Avoid-heap-corruption-in-_glapi_table.patch
+      ./patches/0013-darwin-Fix-test-for-kCGLPFAOpenGLProfile-support-at-.patch
+      ./patches/1001-appleglx-Improve-error-reporting-if-CGLChoosePixelFo.patch
+      ./patches/1002-darwin-Write-errors-in-choosing-the-pixel-format-to-.patch
+      ./patches/1003-darwin-Guard-Core-Profile-usage-behind-a-testing-env.patch
+      ./patches/patch-src-mapi-vgapi-Makefile.diff
+    ];
+
+    postPatch = "patchShebangs .";
+
+    configurePhase = ":";
+
+    makeFlags = "INSTALL_DIR=\${out} CC=cc CXX=c++";
+
+    enableParallelBuilding = true;
+
+    passthru = { inherit version; };
+
+    meta = {
+      description = "An open source implementation of OpenGL";
+      homepage = http://www.mesa3d.org/;
+      license = "bsd";
+      platforms = stdenv.lib.platforms.darwin;
+      maintainers = with stdenv.lib.maintainers; [ cstrahan ];
+    };
+  };
+in self // { driverLink = self; }

--- a/pkgs/development/libraries/mesa-darwin/patches/0003-mesa-fix-per-level-max-texture-size-error-checking.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/0003-mesa-fix-per-level-max-texture-size-error-checking.patch
@@ -1,0 +1,147 @@
+From 9cf1afbf8ae87ddbb29b24a0f9f2724e9e2935c1 Mon Sep 17 00:00:00 2001
+From: Brian Paul <brianp@vmware.com>
+Date: Tue, 4 Sep 2012 20:17:15 -0600
+Subject: [PATCH 03/13] mesa: fix per-level max texture size error checking
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a long-standing omission in Mesa's texture image size checking.
+We need to take the mipmap level into consideration when checking if the
+width, height and depth are too large.
+
+Fixes the new piglit max-texture-size-level test.
+Thanks to Stéphane Marchesin for finding this problem.
+
+Note: This is a candidate for the stable branches.
+
+Reviewed-by: Michel Dänzer <michel.daenzer@amd.com>
+(cherry picked from commit 771e7b6d884bb4294a89f276a904d90b28efb90a)
+---
+ src/mesa/main/teximage.c | 36 +++++++++++++++++++++---------------
+ 1 file changed, 21 insertions(+), 15 deletions(-)
+
+diff --git a/src/mesa/main/teximage.c b/src/mesa/main/teximage.c
+index 3aecc0f..ed22fa9 100644
+--- a/src/mesa/main/teximage.c
++++ b/src/mesa/main/teximage.c
+@@ -1251,11 +1251,12 @@ _mesa_test_proxy_teximage(struct gl_context *ctx, GLenum target, GLint level,
+ 
+    switch (target) {
+    case GL_PROXY_TEXTURE_1D:
+-      maxSize = 1 << (ctx->Const.MaxTextureLevels - 1);
+-      if (width < 2 * border || width > 2 * border + maxSize)
+-         return GL_FALSE;
+       if (level >= ctx->Const.MaxTextureLevels)
+          return GL_FALSE;
++      maxSize = 1 << (ctx->Const.MaxTextureLevels - 1); /* level zero size */
++      maxSize >>= level;  /* level size */
++      if (width < 2 * border || width > 2 * border + maxSize)
++         return GL_FALSE;
+       if (!ctx->Extensions.ARB_texture_non_power_of_two) {
+          if (width > 0 && !_mesa_is_pow_two(width - 2 * border))
+             return GL_FALSE;
+@@ -1263,13 +1264,14 @@ _mesa_test_proxy_teximage(struct gl_context *ctx, GLenum target, GLint level,
+       return GL_TRUE;
+ 
+    case GL_PROXY_TEXTURE_2D:
++      if (level >= ctx->Const.MaxTextureLevels)
++         return GL_FALSE;
+       maxSize = 1 << (ctx->Const.MaxTextureLevels - 1);
++      maxSize >>= level;
+       if (width < 2 * border || width > 2 * border + maxSize)
+          return GL_FALSE;
+       if (height < 2 * border || height > 2 * border + maxSize)
+          return GL_FALSE;
+-      if (level >= ctx->Const.MaxTextureLevels)
+-         return GL_FALSE;
+       if (!ctx->Extensions.ARB_texture_non_power_of_two) {
+          if (width > 0 && !_mesa_is_pow_two(width - 2 * border))
+             return GL_FALSE;
+@@ -1279,15 +1281,16 @@ _mesa_test_proxy_teximage(struct gl_context *ctx, GLenum target, GLint level,
+       return GL_TRUE;
+ 
+    case GL_PROXY_TEXTURE_3D:
++      if (level >= ctx->Const.Max3DTextureLevels)
++         return GL_FALSE;
+       maxSize = 1 << (ctx->Const.Max3DTextureLevels - 1);
++      maxSize >>= level;
+       if (width < 2 * border || width > 2 * border + maxSize)
+          return GL_FALSE;
+       if (height < 2 * border || height > 2 * border + maxSize)
+          return GL_FALSE;
+       if (depth < 2 * border || depth > 2 * border + maxSize)
+          return GL_FALSE;
+-      if (level >= ctx->Const.Max3DTextureLevels)
+-         return GL_FALSE;
+       if (!ctx->Extensions.ARB_texture_non_power_of_two) {
+          if (width > 0 && !_mesa_is_pow_two(width - 2 * border))
+             return GL_FALSE;
+@@ -1299,23 +1302,24 @@ _mesa_test_proxy_teximage(struct gl_context *ctx, GLenum target, GLint level,
+       return GL_TRUE;
+ 
+    case GL_PROXY_TEXTURE_RECTANGLE_NV:
++      if (level != 0)
++         return GL_FALSE;
+       maxSize = ctx->Const.MaxTextureRectSize;
+       if (width < 0 || width > maxSize)
+          return GL_FALSE;
+       if (height < 0 || height > maxSize)
+          return GL_FALSE;
+-      if (level != 0)
+-         return GL_FALSE;
+       return GL_TRUE;
+ 
+    case GL_PROXY_TEXTURE_CUBE_MAP_ARB:
++      if (level >= ctx->Const.MaxCubeTextureLevels)
++         return GL_FALSE;
+       maxSize = 1 << (ctx->Const.MaxCubeTextureLevels - 1);
++      maxSize >>= level;
+       if (width < 2 * border || width > 2 * border + maxSize)
+          return GL_FALSE;
+       if (height < 2 * border || height > 2 * border + maxSize)
+          return GL_FALSE;
+-      if (level >= ctx->Const.MaxCubeTextureLevels)
+-         return GL_FALSE;
+       if (!ctx->Extensions.ARB_texture_non_power_of_two) {
+          if (width > 0 && !_mesa_is_pow_two(width - 2 * border))
+             return GL_FALSE;
+@@ -1325,13 +1329,14 @@ _mesa_test_proxy_teximage(struct gl_context *ctx, GLenum target, GLint level,
+       return GL_TRUE;
+ 
+    case GL_PROXY_TEXTURE_1D_ARRAY_EXT:
++      if (level >= ctx->Const.MaxTextureLevels)
++         return GL_FALSE;
+       maxSize = 1 << (ctx->Const.MaxTextureLevels - 1);
++      maxSize >>= level;
+       if (width < 2 * border || width > 2 * border + maxSize)
+          return GL_FALSE;
+       if (height < 1 || height > ctx->Const.MaxArrayTextureLayers)
+          return GL_FALSE;
+-      if (level >= ctx->Const.MaxTextureLevels)
+-         return GL_FALSE;
+       if (!ctx->Extensions.ARB_texture_non_power_of_two) {
+          if (width > 0 && !_mesa_is_pow_two(width - 2 * border))
+             return GL_FALSE;
+@@ -1339,15 +1344,16 @@ _mesa_test_proxy_teximage(struct gl_context *ctx, GLenum target, GLint level,
+       return GL_TRUE;
+ 
+    case GL_PROXY_TEXTURE_2D_ARRAY_EXT:
++      if (level >= ctx->Const.MaxTextureLevels)
++         return GL_FALSE;
+       maxSize = 1 << (ctx->Const.MaxTextureLevels - 1);
++      maxSize >>= level;
+       if (width < 2 * border || width > 2 * border + maxSize)
+          return GL_FALSE;
+       if (height < 2 * border || height > 2 * border + maxSize)
+          return GL_FALSE;
+       if (depth < 1 || depth > ctx->Const.MaxArrayTextureLayers)
+          return GL_FALSE;
+-      if (level >= ctx->Const.MaxTextureLevels)
+-         return GL_FALSE;
+       if (!ctx->Extensions.ARB_texture_non_power_of_two) {
+          if (width > 0 && !_mesa_is_pow_two(width - 2 * border))
+             return GL_FALSE;
+-- 
+1.9.2
+

--- a/pkgs/development/libraries/mesa-darwin/patches/0008-glsl-initialise-const-force-glsl-extension-warning-i.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/0008-glsl-initialise-const-force-glsl-extension-warning-i.patch
@@ -1,0 +1,33 @@
+From db8cb2250335a93cad6e877e634116e5cd6b42fc Mon Sep 17 00:00:00 2001
+From: Dave Airlie <airlied@redhat.com>
+Date: Tue, 13 Mar 2012 14:53:25 +0000
+Subject: [PATCH 08/13] glsl: initialise const force glsl extension warning in
+ fake ctx
+
+valgrind complained about an uninitialised value being used in
+glsl_parser_extras.cpp, and this was the one it was giving out about.
+
+Just initialise the value in the fakectx.
+
+Signed-off-by: Dave Airlie <airlied@redhat.com>
+Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=48057
+(cherry picked from commit b78a77f979b21a84aecb6fa4f19a2ed51a48c306)
+---
+ src/glsl/builtins/tools/generate_builtins.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/glsl/builtins/tools/generate_builtins.py b/src/glsl/builtins/tools/generate_builtins.py
+index 72d12bb..bd15c4d 100755
+--- a/src/glsl/builtins/tools/generate_builtins.py
++++ b/src/glsl/builtins/tools/generate_builtins.py
+@@ -156,6 +156,7 @@ read_builtins(GLenum target, const char *protos, const char **functions, unsigne
+    fakeCtx.API = API_OPENGL;
+    fakeCtx.Const.GLSLVersion = 130;
+    fakeCtx.Extensions.ARB_ES2_compatibility = true;
++   fakeCtx.Const.ForceGLSLExtensionsWarn = false;
+    gl_shader *sh = _mesa_new_shader(NULL, 0, target);
+    struct _mesa_glsl_parse_state *st =
+       new(sh) _mesa_glsl_parse_state(&fakeCtx, target, sh);
+-- 
+1.9.2
+

--- a/pkgs/development/libraries/mesa-darwin/patches/0009-mesa-test-for-GL_EXT_framebuffer_sRGB-in-glPopAttrib.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/0009-mesa-test-for-GL_EXT_framebuffer_sRGB-in-glPopAttrib.patch
@@ -1,0 +1,28 @@
+From 2286bd68a832a4d4908d50e1a4496853e1f3305a Mon Sep 17 00:00:00 2001
+From: Brian Paul <brianp@vmware.com>
+Date: Mon, 27 Aug 2012 21:52:07 -0600
+Subject: [PATCH 09/13] mesa: test for GL_EXT_framebuffer_sRGB in glPopAttrib()
+
+To avoid spurious GL_INVALID_ENUM errors if the extension isn't supported.
+(cherry picked from commit 1aee8803f83f7ae24d9c2150c70afff2b1ee4c2f)
+---
+ src/mesa/main/attrib.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/mesa/main/attrib.c b/src/mesa/main/attrib.c
+index 225ac89..cc384c7 100644
+--- a/src/mesa/main/attrib.c
++++ b/src/mesa/main/attrib.c
+@@ -993,7 +993,8 @@ _mesa_PopAttrib(void)
+                _mesa_ClampColorARB(GL_CLAMP_READ_COLOR_ARB, color->ClampReadColor);
+ 
+                /* GL_ARB_framebuffer_sRGB / GL_EXT_framebuffer_sRGB */
+-               _mesa_set_enable(ctx, GL_FRAMEBUFFER_SRGB, color->sRGBEnabled);
++               if (ctx->Extensions.EXT_framebuffer_sRGB)
++                  _mesa_set_enable(ctx, GL_FRAMEBUFFER_SRGB, color->sRGBEnabled);
+             }
+             break;
+          case GL_CURRENT_BIT:
+-- 
+1.9.2
+

--- a/pkgs/development/libraries/mesa-darwin/patches/0011-Apple-glFlush-is-not-needed-with-CGLFlushDrawable.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/0011-Apple-glFlush-is-not-needed-with-CGLFlushDrawable.patch
@@ -1,0 +1,29 @@
+From 9c50093adff0c7531ab32a7ec9ce3b91712b4d20 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Sat, 20 Jul 2013 10:25:28 -0700
+Subject: [PATCH 11/13] Apple: glFlush() is not needed with CGLFlushDrawable()
+
+<rdar://problem/14496373>
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+(cherry picked from commit fa5ed99d8e809fb86e486a40273a4a6971055398)
+---
+ src/glx/apple/apple_glx.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/glx/apple/apple_glx.c b/src/glx/apple/apple_glx.c
+index 56cff64..4e2aa33 100644
+--- a/src/glx/apple/apple_glx.c
++++ b/src/glx/apple/apple_glx.c
+@@ -132,8 +132,6 @@ apple_glx_swap_buffers(void *ptr)
+ {
+    struct apple_glx_context *ac = ptr;
+ 
+-   /* This may not be needed with CGLFlushDrawable: */
+-   glFlush();
+    apple_cgl.flush_drawable(ac->context_obj);
+ }
+ 
+-- 
+1.9.2
+

--- a/pkgs/development/libraries/mesa-darwin/patches/0012-glapi-Avoid-heap-corruption-in-_glapi_table.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/0012-glapi-Avoid-heap-corruption-in-_glapi_table.patch
@@ -1,0 +1,28 @@
+From 629600450b3845a768c0edc92ea3f444d03a2738 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Tue, 20 May 2014 01:37:58 -0700
+Subject: [PATCH 12/13] glapi: Avoid heap corruption in _glapi_table
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Reviewed-by: Chia-I Wu <olv@lunarg.com>
+(cherry picked from commit ff5456d1acf6f627a6837be3f3f37c6a268c9e8e)
+---
+ src/mapi/glapi/gen/gl_gentable.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mapi/glapi/gen/gl_gentable.py b/src/mapi/glapi/gen/gl_gentable.py
+index 5657e32..0d0a02d 100644
+--- a/src/mapi/glapi/gen/gl_gentable.py
++++ b/src/mapi/glapi/gen/gl_gentable.py
+@@ -111,7 +111,7 @@ __glapi_gentable_set_remaining_noop(struct _glapi_table *disp) {
+ 
+ struct _glapi_table *
+ _glapi_create_table_from_handle(void *handle, const char *symbol_prefix) {
+-    struct _glapi_table *disp = calloc(1, sizeof(struct _glapi_table));
++    struct _glapi_table *disp = calloc(1, _glapi_get_dispatch_table_size() * sizeof(_glapi_proc));
+     char symboln[512];
+ 
+     if(!disp)
+-- 
+1.9.2
+

--- a/pkgs/development/libraries/mesa-darwin/patches/0013-darwin-Fix-test-for-kCGLPFAOpenGLProfile-support-at-.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/0013-darwin-Fix-test-for-kCGLPFAOpenGLProfile-support-at-.patch
@@ -1,0 +1,40 @@
+From ba59a779ed41e08fa16805c1c60da39885546d0e Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Tue, 20 May 2014 10:53:00 -0700
+Subject: [PATCH 13/13] darwin: Fix test for kCGLPFAOpenGLProfile support at
+ runtime
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+(cherry picked from commit 7a109268ab5b3544e7f7b99e84ef1fdf54023fb4)
+---
+ src/glx/apple/apple_visual.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/src/glx/apple/apple_visual.c b/src/glx/apple/apple_visual.c
+index 282934f..238c248 100644
+--- a/src/glx/apple/apple_visual.c
++++ b/src/glx/apple/apple_visual.c
+@@ -73,11 +73,15 @@ apple_visual_create_pfobj(CGLPixelFormatObj * pfobj, const struct glx_config * m
+    GLint vsref = 0;
+    CGLError error = 0;
+ 
+-   /* Request an OpenGL 3.2 profile if one is available */
+-   if(apple_cgl.version_major > 1 || (apple_cgl.version_major == 1 && apple_cgl.version_minor >= 3)) {
+-      attr[numattr++] = kCGLPFAOpenGLProfile;
+-      attr[numattr++] = kCGLOGLPVersion_3_2_Core;
+-   }
++   /* Request an OpenGL 3.2 profile if one is available and supported */
++   attr[numattr++] = kCGLPFAOpenGLProfile;
++   attr[numattr++] = kCGLOGLPVersion_3_2_Core;
++
++   /* Test for kCGLPFAOpenGLProfile support at runtime and roll it out if not supported */
++   attr[numattr] = 0;
++   error = apple_cgl.choose_pixel_format(attr, pfobj, &vsref);
++   if (error == kCGLBadAttribute)
++      numattr -= 2;
+ 
+    if (offscreen) {
+       apple_glx_diagnostic
+-- 
+1.9.2
+

--- a/pkgs/development/libraries/mesa-darwin/patches/1001-appleglx-Improve-error-reporting-if-CGLChoosePixelFo.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/1001-appleglx-Improve-error-reporting-if-CGLChoosePixelFo.patch
@@ -1,0 +1,30 @@
+From f0702d6e631bb912a230c081463bb51a0dde1bff Mon Sep 17 00:00:00 2001
+From: Jon TURNEY <jon.turney@dronecode.org.uk>
+Date: Mon, 12 May 2014 15:38:26 +0100
+Subject: [PATCH 1001/1003] appleglx: Improve error reporting if
+ CGLChoosePixelFormat() didn't find any matching pixel formats.
+
+Signed-off-by: Jon TURNEY <jon.turney@dronecode.org.uk>
+Reviewed-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+(cherry picked from commit 002a3a74273b81dfb226e1c3f0a8c18525ed0af4)
+---
+ src/glx/apple/apple_visual.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/glx/apple/apple_visual.c b/src/glx/apple/apple_visual.c
+index 238c248..c6ede51 100644
+--- a/src/glx/apple/apple_visual.c
++++ b/src/glx/apple/apple_visual.c
+@@ -167,4 +167,9 @@ apple_visual_create_pfobj(CGLPixelFormatObj * pfobj, const struct glx_config * m
+       fprintf(stderr, "error: %s\n", apple_cgl.error_string(error));
+       abort();
+    }
++
++   if (!*pfobj) {
++      fprintf(stderr, "No matching pixelformats found, perhaps try using LIBGL_ALLOW_SOFTWARE\n");
++      abort();
++   }
+ }
+-- 
+1.9.2 (Apple Git-49)
+

--- a/pkgs/development/libraries/mesa-darwin/patches/1002-darwin-Write-errors-in-choosing-the-pixel-format-to-.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/1002-darwin-Write-errors-in-choosing-the-pixel-format-to-.patch
@@ -1,0 +1,55 @@
+From 1b2f877c8ef052b183c1f20ece6c6e4a7bfd237c Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Sat, 24 May 2014 14:13:33 -0700
+Subject: [PATCH 1002/1003] darwin: Write errors in choosing the pixel format
+ to the crash log
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+(cherry picked from commit 9eb1d36c978a9b15ae2e999c630492dfffd7f165)
+---
+ src/glx/apple/apple_visual.c | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/src/glx/apple/apple_visual.c b/src/glx/apple/apple_visual.c
+index c6ede51..951b213 100644
+--- a/src/glx/apple/apple_visual.c
++++ b/src/glx/apple/apple_visual.c
+@@ -63,6 +63,16 @@ enum
+    MAX_ATTR = 60
+ };
+ 
++static char __crashreporter_info_buff__[4096] = { 0 };
++static const char *__crashreporter_info__ __attribute__((__used__)) =
++    &__crashreporter_info_buff__[0];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
++// This is actually a toolchain requirement, but I'm not sure the correct check,
++// but it should be fine to just only include it for Leopard and later.  This line
++// just tells the linker to never strip this symbol (such as for space optimization)
++__asm__ (".desc ___crashreporter_info__, 0x10");
++#endif
++
+ void
+ apple_visual_create_pfobj(CGLPixelFormatObj * pfobj, const struct glx_config * mode,
+                           bool * double_buffered, bool * uses_stereo,
+@@ -164,12 +174,16 @@ apple_visual_create_pfobj(CGLPixelFormatObj * pfobj, const struct glx_config * m
+    error = apple_cgl.choose_pixel_format(attr, pfobj, &vsref);
+ 
+    if (error) {
+-      fprintf(stderr, "error: %s\n", apple_cgl.error_string(error));
++      snprintf(__crashreporter_info_buff__, sizeof(__crashreporter_info_buff__),
++               "CGLChoosePixelFormat error: %s\n", apple_cgl.error_string(error));
++      fprintf(stderr, "%s", __crashreporter_info_buff__);
+       abort();
+    }
+ 
+    if (!*pfobj) {
+-      fprintf(stderr, "No matching pixelformats found, perhaps try using LIBGL_ALLOW_SOFTWARE\n");
++      snprintf(__crashreporter_info_buff__, sizeof(__crashreporter_info_buff__),
++               "No matching pixelformats found, perhaps try using LIBGL_ALLOW_SOFTWARE\n");
++      fprintf(stderr, "%s", __crashreporter_info_buff__);
+       abort();
+    }
+ }
+-- 
+1.9.2 (Apple Git-49)
+

--- a/pkgs/development/libraries/mesa-darwin/patches/1003-darwin-Guard-Core-Profile-usage-behind-a-testing-env.patch
+++ b/pkgs/development/libraries/mesa-darwin/patches/1003-darwin-Guard-Core-Profile-usage-behind-a-testing-env.patch
@@ -1,0 +1,69 @@
+From 9d6e12eb6b06202519e48a7321f32944d7a34b0f Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Sat, 24 May 2014 14:08:16 -0700
+Subject: [PATCH 1003/1003] darwin: Guard Core Profile usage behind a testing
+ envvar
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+(cherry picked from commit 04ce3be4010305902cc5ae81e8e0c8550d043a1e)
+---
+ src/glx/apple/apple_visual.c | 30 ++++++++++++++++++++----------
+ 1 file changed, 20 insertions(+), 10 deletions(-)
+
+diff --git a/src/glx/apple/apple_visual.c b/src/glx/apple/apple_visual.c
+index 951b213..046581b 100644
+--- a/src/glx/apple/apple_visual.c
++++ b/src/glx/apple/apple_visual.c
+@@ -82,16 +82,7 @@ apple_visual_create_pfobj(CGLPixelFormatObj * pfobj, const struct glx_config * m
+    int numattr = 0;
+    GLint vsref = 0;
+    CGLError error = 0;
+-
+-   /* Request an OpenGL 3.2 profile if one is available and supported */
+-   attr[numattr++] = kCGLPFAOpenGLProfile;
+-   attr[numattr++] = kCGLOGLPVersion_3_2_Core;
+-
+-   /* Test for kCGLPFAOpenGLProfile support at runtime and roll it out if not supported */
+-   attr[numattr] = 0;
+-   error = apple_cgl.choose_pixel_format(attr, pfobj, &vsref);
+-   if (error == kCGLBadAttribute)
+-      numattr -= 2;
++   bool use_core_profile = getenv("LIBGL_PROFILE_CORE");
+ 
+    if (offscreen) {
+       apple_glx_diagnostic
+@@ -167,12 +158,31 @@ apple_visual_create_pfobj(CGLPixelFormatObj * pfobj, const struct glx_config * m
+       attr[numattr++] = mode->samples;
+    }
+ 
++   /* Debugging support for Core profiles to support newer versions of OpenGL */
++   if (use_core_profile) {
++      attr[numattr++] = kCGLPFAOpenGLProfile;
++      attr[numattr++] = kCGLOGLPVersion_3_2_Core;
++   }
++
+    attr[numattr++] = 0;
+ 
+    assert(numattr < MAX_ATTR);
+ 
+    error = apple_cgl.choose_pixel_format(attr, pfobj, &vsref);
+ 
++   if ((error == kCGLBadAttribute || vsref == 0) && use_core_profile) {
++      apple_glx_diagnostic
++         ("Trying again without CoreProfile: error=%s, vsref=%d\n", apple_cgl.error_string(error), vsref);
++
++      if (!error)
++         apple_cgl.destroy_pixel_format(*pfobj);
++
++      numattr -= 3;
++      attr[numattr++] = 0;
++
++      error = apple_cgl.choose_pixel_format(attr, pfobj, &vsref);
++   }
++
+    if (error) {
+       snprintf(__crashreporter_info_buff__, sizeof(__crashreporter_info_buff__),
+                "CGLChoosePixelFormat error: %s\n", apple_cgl.error_string(error));
+-- 
+1.9.2 (Apple Git-49)
+

--- a/pkgs/development/libraries/mesa-darwin/patches/patch-src-mapi-vgapi-Makefile.diff
+++ b/pkgs/development/libraries/mesa-darwin/patches/patch-src-mapi-vgapi-Makefile.diff
@@ -1,0 +1,11 @@
+--- a/src/mapi/vgapi/Makefile	2012-11-30 12:06:24.000000000 -0500
++++ b/src/mapi/vgapi/Makefile	2012-11-30 12:06:52.000000000 -0500
+@@ -75,6 +75,8 @@
+ install-headers:
+ 	$(INSTALL) -d $(DESTDIR)$(INSTALL_INC_DIR)/VG
+ 	$(INSTALL) -m 644 $(TOP)/include/VG/*.h $(DESTDIR)$(INSTALL_INC_DIR)/VG
++	$(INSTALL) -d $(DESTDIR)$(INSTALL_INC_DIR)/KHR
++	$(INSTALL) -m 644 $(TOP)/include/KHR/*.h $(DESTDIR)$(INSTALL_INC_DIR)/KHR
+ 
+ install: default install-headers install-pc
+ 	$(INSTALL) -d $(DESTDIR)$(INSTALL_LIB_DIR)

--- a/pkgs/servers/x11/quartz-wm/default.nix
+++ b/pkgs/servers/x11/quartz-wm/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchurl, xorg, pixman, pkgconfig }:
+
+let version = "1.3.1";
+in stdenv.mkDerivation {
+  name = "quartz-wm-${version}";
+  src = fetchurl {
+    url = "http://xquartz-dl.macosforge.org/src/quartz-wm-${version}.tar.xz";
+    sha256 = "1j8zd3p7rhay1s3sxq6anw78k5s59mx44xpqla2ianl62346a5g9";
+  };
+  patches = [
+    ./no_title_crash.patch
+    ./extern-patch.patch
+  ];
+  buildInputs = [
+    xorg.libXinerama
+    xorg.libAppleWM
+    xorg.applewmproto
+    xorg.libXrandr
+    xorg.libXext
+    pixman
+    pkgconfig
+  ];
+  meta = with lib; {
+    license = licenses.apsl20;
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/servers/x11/quartz-wm/extern-patch.patch
+++ b/pkgs/servers/x11/quartz-wm/extern-patch.patch
@@ -1,0 +1,13 @@
+diff --git a/src/x-list.h b/src/x-list.h
+index bb85c02..059c88b 100644
+--- a/src/x-list.h
++++ b/src/x-list.h
+@@ -39,7 +39,7 @@
+ #endif
+ 
+ #ifndef X_EXTERN
+-# define X_EXTERN __private_extern__
++# define X_EXTERN extern
+ #endif
+ 
+ X_EXTERN void X_PFX (list_free_1) (x_list *node);

--- a/pkgs/servers/x11/quartz-wm/no_title_crash.patch
+++ b/pkgs/servers/x11/quartz-wm/no_title_crash.patch
@@ -1,0 +1,25 @@
+commit c28527b1340c51f2b492a31e49127106cebbfc5d
+Author: Jeremy Huddleston <jeremyhu@apple.com>
+Date:   Fri Jun 1 10:38:37 2012 -0700
+
+    Fix a crash when minimizing windows without titles
+    
+    <rdar://problem/11575791>
+    
+    Regression-from: 21f210c923aa5d79400ce46275084f2636c92bd9
+    
+    Signed-off-by: Jeremy Huddleston <jeremyhu@apple.com>
+
+diff --git a/src/x-window.m b/src/x-window.m
+index a210c6a..e3b9066 100644
+--- a/src/x-window.m
++++ b/src/x-window.m
+@@ -2139,7 +2139,7 @@ - (void) do_collapse
+     if (wid == XP_NULL_NATIVE_WINDOW_ID)
+         return;
+ 
+-    title_c = strdup([_title UTF8String]);
++    title_c = strdup([[self title] UTF8String]);
+     assert(title_c);
+ 
+     err = qwm_dock_minimize_item_with_title_async (wid, title_c);

--- a/pkgs/servers/x11/xorg/darwin/0001-XQuartz-Ensure-we-wait-for-the-server-thread-to-term.patch
+++ b/pkgs/servers/x11/xorg/darwin/0001-XQuartz-Ensure-we-wait-for-the-server-thread-to-term.patch
@@ -1,0 +1,33 @@
+From ec6007e6f7772a90713c9c51c64359229961ce27 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Sun, 6 Apr 2014 05:32:00 -0700
+Subject: [PATCH] XQuartz: Ensure we wait for the server thread to terminate
+
+AKA: XQuartz 2.7.5 doesn't delete its /tmp/.X$d-lock
+
+http://xquartz.macosforge.org/trac/ticket/823
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ hw/xquartz/X11Controller.m | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/hw/xquartz/X11Controller.m b/hw/xquartz/X11Controller.m
+index 5445c6f..022e832 100644
+--- a/hw/xquartz/X11Controller.m
++++ b/hw/xquartz/X11Controller.m
+@@ -942,9 +942,8 @@ extern char *bundle_id_prefix;
+     /* shutdown the X server, it will exit () for us. */
+     DarwinSendDDXEvent(kXquartzQuit, 0);
+ 
+-    /* In case it doesn't, exit anyway after a while. */
+-    remain = 10000000;
+-    while ((remain = usleep(remain)) > 0) ;
++    /* In case it doesn't, exit anyway after 5s. */
++    [NSThread sleepForTimeInterval:5.0];
+ 
+     exit(1);
+ }
+-- 
+1.9.1
+

--- a/pkgs/servers/x11/xorg/darwin/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
+++ b/pkgs/servers/x11/xorg/darwin/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
@@ -1,0 +1,40 @@
+From d36a301fb3d0f2c7a3d81cbda3fd21d8d36038e5 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston <jeremyhu@apple.com>
+Date: Fri, 13 Jan 2012 12:00:57 -0800
+Subject: [PATCH 5000/5004] sdksyms.sh: Use CPPFLAGS, not CFLAGS
+
+CFLAGS can include flags which are not useful to the preprocessor
+or can even cause it to fail.  This fixes a build issue on darwin
+when building for more than one architecture.
+
+Signed-off-by: Jeremy Huddleston <jeremyhu@apple.com>
+Reviewed-by: Keith Packard <keithp@keithp.com>
+---
+ hw/xfree86/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/xfree86/Makefile.am b/hw/xfree86/Makefile.am
+index c3899b5..4f48b85 100644
+--- a/hw/xfree86/Makefile.am
++++ b/hw/xfree86/Makefile.am
+@@ -38,7 +38,7 @@ DIST_SUBDIRS = common ddc i2c x86emu int10 fbdevhw os-support \
+ bin_PROGRAMS = Xorg
+ nodist_Xorg_SOURCES = sdksyms.c
+ 
+-AM_CFLAGS = $(DIX_CFLAGS) @XORG_CFLAGS@
++AM_CPPFLAGS = $(DIX_CFLAGS) @XORG_CFLAGS@
+ INCLUDES = $(XORG_INCS) -I$(srcdir)/parser -I$(top_srcdir)/miext/cw \
+ 	-I$(srcdir)/ddc -I$(srcdir)/i2c -I$(srcdir)/modes -I$(srcdir)/ramdac \
+ 	-I$(srcdir)/dri -I$(srcdir)/dri2
+@@ -115,7 +115,7 @@ CLEANFILES = sdksyms.c sdksyms.dep
+ EXTRA_DIST += sdksyms.sh
+ 
+ sdksyms.dep sdksyms.c: sdksyms.sh
+-	$(AM_V_GEN)CPP='$(CPP)' AWK='$(AWK)' $(SHELL) $(srcdir)/sdksyms.sh $(top_srcdir) $(CFLAGS) $(AM_CFLAGS) $(INCLUDES)
++	$(AM_V_GEN)CPP='$(CPP)' AWK='$(AWK)' $(SHELL) $(srcdir)/sdksyms.sh $(top_srcdir) $(CPPFLAGS) $(AM_CPPFLAGS) $(INCLUDES)
+ 
+ SDKSYMS_DEP = sdksyms.dep
+ include $(SDKSYMS_DEP)
+-- 
+1.8.4.1
+

--- a/pkgs/servers/x11/xorg/darwin/5001-Workaround-the-GC-clipping-problem-in-miPaintWindow-.patch
+++ b/pkgs/servers/x11/xorg/darwin/5001-Workaround-the-GC-clipping-problem-in-miPaintWindow-.patch
@@ -1,0 +1,165 @@
+From 9ca14507a31338fad40d430445a4a4cb8106bc9b Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston <jeremyhu@apple.com>
+Date: Fri, 30 Apr 2010 13:08:25 -0700
+Subject: [PATCH 5001/5004] Workaround the GC clipping problem in miPaintWindow
+ and add some debugging output.
+
+Signed-off-by: Jeremy Huddleston <jeremyhu@apple.com>
+---
+ mi/miexpose.c | 104 ++++++++++++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 94 insertions(+), 10 deletions(-)
+
+diff --git a/mi/miexpose.c b/mi/miexpose.c
+index 8b7c93f..3e972f7 100644
+--- a/mi/miexpose.c
++++ b/mi/miexpose.c
+@@ -489,7 +489,8 @@ void RootlessSetPixmapOfAncestors(WindowPtr pWin);
+ void RootlessStartDrawing(WindowPtr pWin);
+ void RootlessDamageRegion(WindowPtr pWin, RegionPtr prgn);
+ Bool IsFramedWindow(WindowPtr pWin);
+-#endif
++#include "../fb/fb.h"
++#endif 
+ 
+ void
+ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
+@@ -518,23 +519,37 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
+     Bool solid = TRUE;
+     DrawablePtr drawable = &pWin->drawable;
+ 
++#ifdef XQUARTZ_CLIP_DEBUG
++    ErrorF("START %d BS %d (pR = %ld)\n", what, pWin->backgroundState, ParentRelative);
++    ErrorF("      Rgn: %d %d %d %d\n", prgn->extents.x1, prgn->extents.y1,
++	                               prgn->extents.x2 - prgn->extents.x1,
++	                               prgn->extents.y2 - prgn->extents.y1);
++    ErrorF("      Win: %d %d (%d %d) %d %d\n", pWin->origin.x, pWin->origin.y,
++	                                       pWin->winSize.extents.x1, pWin->winSize.extents.y1,
++	                                       pWin->winSize.extents.x2 - pWin->winSize.extents.x1,
++					       pWin->winSize.extents.y2 - pWin->winSize.extents.y1);
++    ErrorF("     Draw: %d %d %d %d\n", pWin->drawable.x, pWin->drawable.y,
++				       pWin->drawable.width, pWin->drawable.height);
++#endif
++
+ #ifdef ROOTLESS
+     if (!drawable || drawable->type == UNDRAWABLE_WINDOW)
+         return;
++#endif
++    
++    if (what == PW_BACKGROUND)
++    {
++#ifdef ROOTLESS
++        if(IsFramedWindow(pWin)) {
++            RootlessStartDrawing(pWin);
++            RootlessDamageRegion(pWin, prgn);
+ 
+-    if (IsFramedWindow(pWin)) {
+-        RootlessStartDrawing(pWin);
+-        RootlessDamageRegion(pWin, prgn);
+-
+-        if (pWin->backgroundState == ParentRelative) {
+-            if ((what == PW_BACKGROUND) ||
+-                (what == PW_BORDER && !pWin->borderIsPixel))
++            if(pWin->backgroundState == ParentRelative) {
+                 RootlessSetPixmapOfAncestors(pWin);
++            }
+         }
+-    }
+ #endif
+ 
+-    if (what == PW_BACKGROUND) {
+         while (pWin->backgroundState == ParentRelative)
+             pWin = pWin->parent;
+ 
+@@ -559,6 +574,18 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
+     else {
+         PixmapPtr pixmap;
+ 
++#ifdef ROOTLESS
++	if(IsFramedWindow(pWin)) {
++	    RootlessStartDrawing(pWin);
++	    RootlessDamageRegion(pWin, prgn);
++	    
++	    if(!pWin->borderIsPixel &&
++		pWin->backgroundState == ParentRelative) {
++		RootlessSetPixmapOfAncestors(pWin);
++	    }
++	}
++#endif
++
+         tile_x_off = drawable->x;
+         tile_y_off = drawable->y;
+ 
+@@ -567,6 +594,12 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
+             return;
+         pixmap = (*pScreen->GetWindowPixmap) ((WindowPtr) drawable);
+         drawable = &pixmap->drawable;
++
++#ifdef XQUARTZ_CLIP_DEBUG
++        ErrorF("     Draw: %d %d %d %d\n",
++               drawable->x, drawable->y, drawable->width, drawable->height);    
++#endif
++	
+ #ifdef COMPOSITE
+         draw_x_off = pixmap->screen_x;
+         draw_y_off = pixmap->screen_y;
+@@ -629,6 +662,57 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
+     ChangeGC(NullClient, pGC, gcmask, gcval);
+     ValidateGC(drawable, pGC);
+ 
++#ifdef XQUARTZ_CLIP_DEBUG
++    ErrorF("       GC: %d %d %d %d\n",
++	   pGC->pCompositeClip->extents.x1, pGC->pCompositeClip->extents.y1,
++	   pGC->pCompositeClip->extents.x2 - pGC->pCompositeClip->extents.x1,
++	   pGC->pCompositeClip->extents.y2 - pGC->pCompositeClip->extents.y1);
++#endif
++    
++#ifdef XQUARTZ
++    /* Looks like our clipping isn't set right for some reason:
++     * http://xquartz.macosforge.org/trac/ticket/290
++     */
++    if(what == PW_BORDER) {
++
++#if 0
++	if(solid) {
++#if 1
++	    fbFillRegionSolid(&pWin->drawable,
++			      prgn,
++			      0,
++			      fbReplicatePixel(fill.pixel,
++					       pWin->drawable.bitsPerPixel));
++#else
++	    fbFillRegionSolid(drawable,
++			      prgn,
++			      0,
++			      fbReplicatePixel(fill.pixel,
++					       drawable->bitsPerPixel));
++#endif
++	    return;
++	}
++#endif
++    
++	pGC->pCompositeClip->extents.x1 += prgn->extents.x1;
++	pGC->pCompositeClip->extents.y1 += prgn->extents.y1;
++	pGC->pCompositeClip->extents.x2 += prgn->extents.x1;
++	pGC->pCompositeClip->extents.y2 += prgn->extents.y1;
++	
++	if(pGC->pCompositeClip->extents.x2 > drawable->pScreen->width)
++	    pGC->pCompositeClip->extents.x2 = drawable->pScreen->width;
++	if(pGC->pCompositeClip->extents.y2 > drawable->pScreen->height)
++	    pGC->pCompositeClip->extents.y2 = drawable->pScreen->height;
++    }
++#endif
++
++#ifdef XQUARTZ_CLIP_DEBUG
++    ErrorF("       GC: %d %d %d %d\n",
++	   pGC->pCompositeClip->extents.x1, pGC->pCompositeClip->extents.y1,
++	   pGC->pCompositeClip->extents.x2 - pGC->pCompositeClip->extents.x1,
++	   pGC->pCompositeClip->extents.y2 - pGC->pCompositeClip->extents.y1);    
++#endif
++
+     numRects = RegionNumRects(prgn);
+     pbox = RegionRects(prgn);
+     for (i = numRects; --i >= 0; pbox++, prect++) {
+-- 
+1.8.4.1
+

--- a/pkgs/servers/x11/xorg/darwin/5002-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/pkgs/servers/x11/xorg/darwin/5002-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -1,0 +1,316 @@
+From 07f9e0beaf66ec9de1455a305c87ab642968f3f1 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston <jeremyhu@apple.com>
+Date: Fri, 12 Feb 2010 19:48:52 -0800
+Subject: [PATCH 5002/5004] fb: Revert fb changes that broke XQuartz
+
+http://bugs.freedesktop.org/show_bug.cgi?id=26124
+
+Revert "Fix source pictures getting random transforms after 2d6a8f668342a5190cdf43b5."
+Revert "fb: Adjust transform or composite coordinates for pixman operations"
+
+http://bugs.freedesktop.org/26124
+
+This reverts commit a72c65e9176c51de95db2fdbf4c5d946a4911695.
+This reverts commit a6bd5d2e482a5aa84acb3d4932e2a166d8670ef1.
+
+Signed-off-by: Jeremy Huddleston <jeremyhu@apple.com>
+---
+ fb/fb.h     |  3 +--
+ fb/fbpict.c | 82 ++++++++++++++++++-------------------------------------------
+ fb/fbtrap.c | 43 ++++++++++++++------------------
+ 3 files changed, 43 insertions(+), 85 deletions(-)
+
+diff --git a/fb/fb.h b/fb/fb.h
+index b869d12..895b148 100644
+--- a/fb/fb.h
++++ b/fb/fb.h
+@@ -1686,8 +1686,7 @@ fbFillRegionSolid(DrawablePtr pDrawable,
+                   RegionPtr pRegion, FbBits and, FbBits xor);
+ 
+ extern _X_EXPORT pixman_image_t *image_from_pict(PicturePtr pict,
+-                                                 Bool has_clip,
+-                                                 int *xoff, int *yoff);
++                                                 Bool has_clip);
+ 
+ extern _X_EXPORT void free_pixman_pict(PicturePtr, pixman_image_t *);
+ 
+diff --git a/fb/fbpict.c b/fb/fbpict.c
+index 2804ff4..80c2a91 100644
+--- a/fb/fbpict.c
++++ b/fb/fbpict.c
+@@ -46,23 +46,18 @@ fbComposite(CARD8 op,
+             INT16 yMask, INT16 xDst, INT16 yDst, CARD16 width, CARD16 height)
+ {
+     pixman_image_t *src, *mask, *dest;
+-    int src_xoff, src_yoff;
+-    int msk_xoff, msk_yoff;
+-    int dst_xoff, dst_yoff;
+-
+     miCompositeSourceValidate(pSrc);
+     if (pMask)
+         miCompositeSourceValidate(pMask);
+ 
+-    src = image_from_pict(pSrc, FALSE, &src_xoff, &src_yoff);
+-    mask = image_from_pict(pMask, FALSE, &msk_xoff, &msk_yoff);
+-    dest = image_from_pict(pDst, TRUE, &dst_xoff, &dst_yoff);
++    src = image_from_pict(pSrc, TRUE);
++    mask = image_from_pict(pMask, TRUE);
++    dest = image_from_pict(pDst, TRUE);
+ 
+     if (src && dest && !(pMask && !mask)) {
+         pixman_image_composite(op, src, mask, dest,
+-                               xSrc + src_xoff, ySrc + src_yoff,
+-                               xMask + msk_xoff, yMask + msk_yoff,
+-                               xDst + dst_xoff, yDst + dst_yoff, width, height);
++                               xSrc, ySrc, xMask, yMask, xDst, yDst,
++                               width, height);
+     }
+ 
+     free_pixman_pict(pSrc, src);
+@@ -293,20 +288,22 @@ create_conical_gradient_image(PictGradient * gradient)
+ }
+ 
+ static pixman_image_t *
+-create_bits_picture(PicturePtr pict, Bool has_clip, int *xoff, int *yoff)
++create_bits_picture(PicturePtr pict, Bool has_clip)
+ {
+-    PixmapPtr pixmap;
+     FbBits *bits;
+     FbStride stride;
+-    int bpp;
++    int bpp, xoff, yoff;
+     pixman_image_t *image;
+ 
+-    fbGetDrawablePixmap(pict->pDrawable, pixmap, *xoff, *yoff);
+-    fbGetPixmapBitsData(pixmap, bits, stride, bpp);
++    fbGetDrawable (pict->pDrawable, bits, stride, bpp, xoff, yoff);
++
++    bits = (FbBits*)((CARD8*)bits +
++                     (pict->pDrawable->y + yoff) * stride * sizeof(FbBits) +
++                     (pict->pDrawable->x + xoff) * (bpp / 8));
+ 
+     image = pixman_image_create_bits((pixman_format_code_t) pict->format,
+-                                     pixmap->drawable.width,
+-                                     pixmap->drawable.height, (uint32_t *) bits,
++                                     pict->pDrawable->width,
++                                     pict->pDrawable->height, (uint32_t *) bits,
+                                      stride * sizeof(FbStride));
+ 
+     if (!image)
+@@ -333,57 +330,31 @@ create_bits_picture(PicturePtr pict, Bool has_clip, int *xoff, int *yoff)
+         if (pict->clientClipType != CT_NONE)
+             pixman_image_set_has_client_clip(image, TRUE);
+ 
+-        if (*xoff || *yoff)
+-            pixman_region_translate(pict->pCompositeClip, *xoff, *yoff);
++        pixman_region_translate (pict->pCompositeClip, - pict->pDrawable->x, - pict->pDrawable->y);
+ 
+         pixman_image_set_clip_region(image, pict->pCompositeClip);
+ 
+-        if (*xoff || *yoff)
+-            pixman_region_translate(pict->pCompositeClip, -*xoff, -*yoff);
++        pixman_region_translate (pict->pCompositeClip, pict->pDrawable->x, pict->pDrawable->y);
+     }
+ 
+     /* Indexed table */
+     if (pict->pFormat->index.devPrivate)
+         pixman_image_set_indexed(image, pict->pFormat->index.devPrivate);
+ 
+-    /* Add in drawable origin to position within the image */
+-    *xoff += pict->pDrawable->x;
+-    *yoff += pict->pDrawable->y;
+-
+     return image;
+ }
+ 
+ static pixman_image_t *image_from_pict_internal(PicturePtr pict, Bool has_clip,
+-                                                int *xoff, int *yoff,
+                                                 Bool is_alpha_map);
+ 
+ static void
+-set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+-                     int *xoff, int *yoff, Bool is_alpha_map)
++set_image_properties(pixman_image_t * image, PicturePtr pict, Bool is_alpha_map)
+ {
+     pixman_repeat_t repeat;
+     pixman_filter_t filter;
+ 
+     if (pict->transform) {
+-        /* For source images, adjust the transform to account
+-         * for the drawable offset within the pixman image,
+-         * then set the offset to 0 as it will be used
+-         * to compute positions within the transformed image.
+-         */
+-        if (!has_clip) {
+-            struct pixman_transform adjusted;
+-
+-            adjusted = *pict->transform;
+-            pixman_transform_translate(&adjusted,
+-                                       NULL,
+-                                       pixman_int_to_fixed(*xoff),
+-                                       pixman_int_to_fixed(*yoff));
+-            pixman_image_set_transform(image, &adjusted);
+-            *xoff = 0;
+-            *yoff = 0;
+-        }
+-        else
+-            pixman_image_set_transform(image, pict->transform);
++        pixman_image_set_transform(image, pict->transform);
+     }
+ 
+     switch (pict->repeatType) {
+@@ -411,10 +382,8 @@ set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+      * as the alpha map for this operation
+      */
+     if (pict->alphaMap && !is_alpha_map) {
+-        int alpha_xoff, alpha_yoff;
+         pixman_image_t *alpha_map =
+-            image_from_pict_internal(pict->alphaMap, FALSE, &alpha_xoff,
+-                                     &alpha_yoff, TRUE);
++            image_from_pict_internal(pict->alphaMap, TRUE, TRUE);
+ 
+         pixman_image_set_alpha_map(image, alpha_map, pict->alphaOrigin.x,
+                                    pict->alphaOrigin.y);
+@@ -448,8 +417,7 @@ set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+ }
+ 
+ static pixman_image_t *
+-image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+-                         Bool is_alpha_map)
++image_from_pict_internal(PicturePtr pict, Bool has_clip, Bool is_alpha_map)
+ {
+     pixman_image_t *image = NULL;
+ 
+@@ -457,7 +425,7 @@ image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+         return NULL;
+ 
+     if (pict->pDrawable) {
+-        image = create_bits_picture(pict, has_clip, xoff, yoff);
++        image = create_bits_picture(pict, has_clip);
+     }
+     else if (pict->pSourcePict) {
+         SourcePict *sp = pict->pSourcePict;
+@@ -475,19 +443,17 @@ image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+             else if (sp->type == SourcePictTypeConical)
+                 image = create_conical_gradient_image(gradient);
+         }
+-        *xoff = *yoff = 0;
+     }
+ 
+     if (image)
+-        set_image_properties(image, pict, has_clip, xoff, yoff, is_alpha_map);
+-
++        set_image_properties (image, pict, is_alpha_map);
+     return image;
+ }
+ 
+ pixman_image_t *
+-image_from_pict(PicturePtr pict, Bool has_clip, int *xoff, int *yoff)
++image_from_pict (PicturePtr pict, Bool has_clip)
+ {
+-    return image_from_pict_internal(pict, has_clip, xoff, yoff, FALSE);
++    return image_from_pict_internal (pict, has_clip, FALSE);
+ }
+ 
+ void
+diff --git a/fb/fbtrap.c b/fb/fbtrap.c
+index bf82f8f..0145ce9 100644
+--- a/fb/fbtrap.c
++++ b/fb/fbtrap.c
+@@ -36,13 +36,12 @@ fbAddTraps(PicturePtr pPicture,
+            INT16 x_off, INT16 y_off, int ntrap, xTrap * traps)
+ {
+     pixman_image_t *image;
+-    int dst_xoff, dst_yoff;
+ 
+-    if (!(image = image_from_pict(pPicture, FALSE, &dst_xoff, &dst_yoff)))
+-        return;
+-
+-    pixman_add_traps(image, x_off + dst_xoff, y_off + dst_yoff,
+-                     ntrap, (pixman_trap_t *) traps);
++    if (!(image = image_from_pict (pPicture, FALSE)))
++	return;
++    
++    pixman_add_traps(image, x_off, y_off,
++                     ntrap, (pixman_trap_t *)traps);
+ 
+     free_pixman_pict(pPicture, image);
+ }
+@@ -52,13 +51,12 @@ fbRasterizeTrapezoid(PicturePtr pPicture,
+                      xTrapezoid * trap, int x_off, int y_off)
+ {
+     pixman_image_t *image;
+-    int dst_xoff, dst_yoff;
+ 
+-    if (!(image = image_from_pict(pPicture, FALSE, &dst_xoff, &dst_yoff)))
++    if (!(image = image_from_pict (pPicture, FALSE)))
+         return;
+ 
+-    pixman_rasterize_trapezoid(image, (pixman_trapezoid_t *) trap,
+-                               x_off + dst_xoff, y_off + dst_yoff);
++    pixman_rasterize_trapezoid(image, (pixman_trapezoid_t *)trap,
++                               x_off, y_off);
+ 
+     free_pixman_pict(pPicture, image);
+ }
+@@ -68,14 +66,12 @@ fbAddTriangles(PicturePtr pPicture,
+                INT16 x_off, INT16 y_off, int ntri, xTriangle * tris)
+ {
+     pixman_image_t *image;
+-    int dst_xoff, dst_yoff;
+ 
+-    if (!(image = image_from_pict(pPicture, FALSE, &dst_xoff, &dst_yoff)))
++    if (!(image = image_from_pict (pPicture, FALSE)))
+         return;
+-
+-    pixman_add_triangles(image,
+-                         dst_xoff + x_off, dst_yoff + y_off,
+-                         ntri, (pixman_triangle_t *) tris);
++    
++    pixman_add_triangles(image, x_off, y_off, ntri,
++                         (pixman_triangle_t *)tris);
+ 
+     free_pixman_pict(pPicture, image);
+ }
+@@ -98,13 +94,11 @@ fbShapes(CompositeShapesFunc composite,
+          int16_t ySrc, int nshapes, int shape_size, const uint8_t * shapes)
+ {
+     pixman_image_t *src, *dst;
+-    int src_xoff, src_yoff;
+-    int dst_xoff, dst_yoff;
+ 
+     miCompositeSourceValidate(pSrc);
+ 
+-    src = image_from_pict(pSrc, FALSE, &src_xoff, &src_yoff);
+-    dst = image_from_pict(pDst, TRUE, &dst_xoff, &dst_yoff);
++    src = image_from_pict(pSrc, FALSE);
++    dst = image_from_pict(pDst, TRUE);
+ 
+     if (src && dst) {
+         pixman_format_code_t format;
+@@ -121,9 +115,8 @@ fbShapes(CompositeShapesFunc composite,
+ 
+             for (i = 0; i < nshapes; ++i) {
+                 composite(op, src, dst, format,
+-                          xSrc + src_xoff,
+-                          ySrc + src_yoff,
+-                          dst_xoff, dst_yoff, 1, shapes + i * shape_size);
++                          xSrc, ySrc, 0, 0, 
++                          1, shapes + i * shape_size);
+             }
+         }
+         else {
+@@ -143,8 +136,8 @@ fbShapes(CompositeShapesFunc composite,
+             }
+ 
+             composite(op, src, dst, format,
+-                      xSrc + src_xoff,
+-                      ySrc + src_yoff, dst_xoff, dst_yoff, nshapes, shapes);
++                      xSrc, ySrc, 0, 0,
++                      nshapes, shapes);
+         }
+ 
+         DamageRegionProcessPending(pDst->pDrawable);
+-- 
+1.8.4.1
+

--- a/pkgs/servers/x11/xorg/darwin/5003-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/pkgs/servers/x11/xorg/darwin/5003-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -1,0 +1,230 @@
+From 4a0444a2773bddc3abbf5305a344001ecfe9378c Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Tue, 18 Dec 2012 01:03:38 -0800
+Subject: [PATCH 5003/5004] fb: Revert fb changes that broke XQuartz
+
+    http://bugs.freedesktop.org/show_bug.cgi?id=26124
+
+Revert "Use new pixman_glyph_cache_t API that will be in pixman 0.28.0"
+
+This reverts commit 9cbcb5bd6a5360a128d15b77a02d8d3351f74366.
+---
+ configure.ac  |   2 +-
+ fb/fb.h       |   3 --
+ fb/fbpict.c   | 153 +---------------------------------------------------------
+ fb/fbscreen.c |   1 -
+ 4 files changed, 2 insertions(+), 157 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8797df5..99a1e62 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -811,7 +811,7 @@ LIBPCIACCESS="pciaccess >= 0.12.901"
+ LIBUDEV="libudev >= 143"
+ LIBSELINUX="libselinux >= 2.0.86"
+ LIBDBUS="dbus-1 >= 1.0"
+-LIBPIXMAN="pixman-1 >= 0.27.2"
++LIBPIXMAN="pixman-1 >= 0.21.8"
+ 
+ dnl Pixman is always required, but we separate it out so we can link
+ dnl specific modules against it
+diff --git a/fb/fb.h b/fb/fb.h
+index 895b148..cc5759c 100644
+--- a/fb/fb.h
++++ b/fb/fb.h
+@@ -1344,9 +1344,6 @@ extern _X_EXPORT void
+ extern _X_EXPORT Bool
+  fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats);
+ 
+-extern _X_EXPORT void
+-fbDestroyGlyphCache(void);
+-
+ /*
+  * fbpixmap.c
+  */
+diff --git a/fb/fbpict.c b/fb/fbpict.c
+index 80c2a91..dc0ca3c 100644
+--- a/fb/fbpict.c
++++ b/fb/fbpict.c
+@@ -65,156 +65,6 @@ fbComposite(CARD8 op,
+     free_pixman_pict(pDst, dest);
+ }
+ 
+-static pixman_glyph_cache_t *glyphCache;
+-
+-void
+-fbDestroyGlyphCache(void)
+-{
+-    if (glyphCache)
+-    {
+-	pixman_glyph_cache_destroy (glyphCache);
+-	glyphCache = NULL;
+-    }
+-}
+-
+-static void
+-fbUnrealizeGlyph(ScreenPtr pScreen,
+-		 GlyphPtr pGlyph)
+-{
+-    if (glyphCache)
+-	pixman_glyph_cache_remove (glyphCache, pGlyph, NULL);
+-}
+-
+-static void
+-fbGlyphs(CARD8 op,
+-	 PicturePtr pSrc,
+-	 PicturePtr pDst,
+-	 PictFormatPtr maskFormat,
+-	 INT16 xSrc,
+-	 INT16 ySrc, int nlist,
+-	 GlyphListPtr list,
+-	 GlyphPtr *glyphs)
+-{
+-#define N_STACK_GLYPHS 512
+-    ScreenPtr pScreen = pDst->pDrawable->pScreen;
+-    pixman_glyph_t stack_glyphs[N_STACK_GLYPHS];
+-    pixman_glyph_t *pglyphs = stack_glyphs;
+-    pixman_image_t *srcImage, *dstImage;
+-    int srcXoff, srcYoff, dstXoff, dstYoff;
+-    GlyphPtr glyph;
+-    int n_glyphs;
+-    int x, y;
+-    int i, n;
+-    int xDst = list->xOff, yDst = list->yOff;
+-
+-    miCompositeSourceValidate(pSrc);
+-    
+-    n_glyphs = 0;
+-    for (i = 0; i < nlist; ++i)
+-	n_glyphs += list[i].len;
+-
+-    if (!glyphCache)
+-	glyphCache = pixman_glyph_cache_create();
+-
+-    pixman_glyph_cache_freeze (glyphCache);
+-    
+-    if (n_glyphs > N_STACK_GLYPHS) {
+-	if (!(pglyphs = malloc (n_glyphs * sizeof (pixman_glyph_t))))
+-	    goto out;
+-    }
+-    
+-    i = 0;
+-    x = y = 0;
+-    while (nlist--) {
+-        x += list->xOff;
+-        y += list->yOff;
+-        n = list->len;
+-        while (n--) {
+-	    const void *g;
+-
+-            glyph = *glyphs++;
+-
+-	    if (!(g = pixman_glyph_cache_lookup (glyphCache, glyph, NULL))) {
+-		pixman_image_t *glyphImage;
+-		PicturePtr pPicture;
+-		int xoff, yoff;
+-
+-		pPicture = GetGlyphPicture(glyph, pScreen);
+-		if (!pPicture) {
+-		    n_glyphs--;
+-		    goto next;
+-		}
+-
+-		if (!(glyphImage = image_from_pict(pPicture, FALSE, &xoff, &yoff)))
+-		    goto out;
+-
+-		g = pixman_glyph_cache_insert(glyphCache, glyph, NULL,
+-					      glyph->info.x,
+-					      glyph->info.y,
+-					      glyphImage);
+-
+-		free_pixman_pict(pPicture, glyphImage);
+-
+-		if (!g)
+-		    goto out;
+-	    }
+-
+-	    pglyphs[i].x = x;
+-	    pglyphs[i].y = y;
+-	    pglyphs[i].glyph = g;
+-	    i++;
+-
+-	next:
+-            x += glyph->info.xOff;
+-            y += glyph->info.yOff;
+-	}
+-	list++;
+-    }
+-
+-    if (!(srcImage = image_from_pict(pSrc, FALSE, &srcXoff, &srcYoff)))
+-	goto out;
+-
+-    if (!(dstImage = image_from_pict(pDst, TRUE, &dstXoff, &dstYoff)))
+-	goto out_free_src;
+-
+-    if (maskFormat) {
+-	pixman_format_code_t format;
+-	pixman_box32_t extents;
+-	int x, y;
+-
+-	format = maskFormat->format | (maskFormat->depth << 24);
+-
+-	pixman_glyph_get_extents(glyphCache, n_glyphs, pglyphs, &extents);
+-
+-	x = extents.x1;
+-	y = extents.y1;
+-
+-	pixman_composite_glyphs(op, srcImage, dstImage, format,
+-				xSrc + srcXoff + xDst, ySrc + srcYoff + yDst,
+-				x, y,
+-				x + dstXoff, y + dstYoff,
+-				extents.x2 - extents.x1,
+-				extents.y2 - extents.y1,
+-				glyphCache, n_glyphs, pglyphs);
+-    }
+-    else {
+-	pixman_composite_glyphs_no_mask(op, srcImage, dstImage,
+-					xSrc + srcXoff - xDst, ySrc + srcYoff - yDst,
+-					dstXoff, dstYoff,
+-					glyphCache, n_glyphs, pglyphs);
+-    }
+-
+-    free_pixman_pict(pDst, dstImage);
+-
+-out_free_src:
+-    free_pixman_pict(pSrc, srcImage);
+-
+-out:
+-    pixman_glyph_cache_thaw(glyphCache);
+-    if (pglyphs != stack_glyphs)
+-	free(pglyphs);
+-}
+-
+ static pixman_image_t *
+ create_solid_fill_image(PicturePtr pict)
+ {
+@@ -473,8 +323,7 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+         return FALSE;
+     ps = GetPictureScreen(pScreen);
+     ps->Composite = fbComposite;
+-    ps->Glyphs = fbGlyphs;
+-    ps->UnrealizeGlyph = fbUnrealizeGlyph;
++    ps->Glyphs = miGlyphs;
+     ps->CompositeRects = miCompositeRects;
+     ps->RasterizeTrapezoid = fbRasterizeTrapezoid;
+     ps->Trapezoids = fbTrapezoids;
+diff --git a/fb/fbscreen.c b/fb/fbscreen.c
+index f9080a4..7c7d656 100644
+--- a/fb/fbscreen.c
++++ b/fb/fbscreen.c
+@@ -32,7 +32,6 @@ fbCloseScreen(ScreenPtr pScreen)
+     int d;
+     DepthPtr depths = pScreen->allowedDepths;
+ 
+-    fbDestroyGlyphCache();
+     for (d = 0; d < pScreen->numDepths; d++)
+         free(depths[d].vids);
+     free(depths);
+-- 
+1.8.4.1
+

--- a/pkgs/servers/x11/xorg/darwin/5004-Use-old-miTrapezoids-and-miTriangles-routines.patch
+++ b/pkgs/servers/x11/xorg/darwin/5004-Use-old-miTrapezoids-and-miTriangles-routines.patch
@@ -1,0 +1,297 @@
+From bd9fce8b74f5358e4d7e5ce9b5cdd8fd195bb3fd Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Sat, 2 Nov 2013 11:00:23 -0700
+Subject: [PATCH 5004/5004] Use old miTrapezoids and miTriangles routines
+
+Reverts commits:
+    788ccb9a8bcf6a4fb4054c507111eec3338fb969
+    566f1931ee2916269e164e114bffaf2da1d039d1
+
+http://xquartz.macosforge.org/trac/ticket/525
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ fb/fbpict.c     |   2 -
+ render/mipict.c |   4 +-
+ render/mipict.h |  27 ++++++++++++++
+ render/mitrap.c | 111 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ render/mitri.c  |  61 +++++++++++++++++++++++++++++++
+ 5 files changed, 201 insertions(+), 4 deletions(-)
+
+diff --git a/fb/fbpict.c b/fb/fbpict.c
+index dc0ca3c..276ff06 100644
+--- a/fb/fbpict.c
++++ b/fb/fbpict.c
+@@ -326,10 +326,8 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+     ps->Glyphs = miGlyphs;
+     ps->CompositeRects = miCompositeRects;
+     ps->RasterizeTrapezoid = fbRasterizeTrapezoid;
+-    ps->Trapezoids = fbTrapezoids;
+     ps->AddTraps = fbAddTraps;
+     ps->AddTriangles = fbAddTriangles;
+-    ps->Triangles = fbTriangles;
+ 
+     return TRUE;
+ }
+diff --git a/render/mipict.c b/render/mipict.c
+index 2e64b20..d21b58a 100644
+--- a/render/mipict.c
++++ b/render/mipict.c
+@@ -595,8 +595,8 @@ miPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+     ps->Composite = 0;          /* requires DDX support */
+     ps->Glyphs = miGlyphs;
+     ps->CompositeRects = miCompositeRects;
+-    ps->Trapezoids = 0;
+-    ps->Triangles = 0;
++    ps->Trapezoids = miTrapezoids;
++    ps->Triangles = miTriangles;
+ 
+     ps->RasterizeTrapezoid = 0; /* requires DDX support */
+     ps->AddTraps = 0;           /* requires DDX support */
+diff --git a/render/mipict.h b/render/mipict.h
+index 9436228..7ee2991 100644
+--- a/render/mipict.h
++++ b/render/mipict.h
+@@ -122,6 +122,16 @@ miCompositeRects(CARD8 op,
+                  xRenderColor * color, int nRect, xRectangle *rects);
+ 
+ extern _X_EXPORT void
++miTriangles (CARD8	    op,
++	     PicturePtr	    pSrc,
++	     PicturePtr	    pDst,
++	     PictFormatPtr  maskFormat,
++	     INT16	    xSrc,
++	     INT16	    ySrc,
++	     int	    ntri,
++	     xTriangle	    *tris);
++
++extern _X_EXPORT void
+ 
+ miTriStrip(CARD8 op,
+            PicturePtr pSrc,
+@@ -137,10 +147,27 @@ miTriFan(CARD8 op,
+          PictFormatPtr maskFormat,
+          INT16 xSrc, INT16 ySrc, int npoints, xPointFixed * points);
+ 
++extern _X_EXPORT PicturePtr
++miCreateAlphaPicture (ScreenPtr	    pScreen, 
++		      PicturePtr    pDst,
++		      PictFormatPtr pPictFormat,
++		      CARD16	    width,
++		      CARD16	    height);
++
+ extern _X_EXPORT void
+  miTrapezoidBounds(int ntrap, xTrapezoid * traps, BoxPtr box);
+ 
+ extern _X_EXPORT void
++miTrapezoids (CARD8        op,
++             PicturePtr    pSrc,
++             PicturePtr    pDst,
++             PictFormatPtr maskFormat,
++             INT16         xSrc,
++             INT16         ySrc,
++             int           ntrap,
++             xTrapezoid    *traps);
++
++extern _X_EXPORT void
+  miPointFixedBounds(int npoint, xPointFixed * points, BoxPtr bounds);
+ 
+ extern _X_EXPORT void
+diff --git a/render/mitrap.c b/render/mitrap.c
+index 17b6dcd..71c1857 100644
+--- a/render/mitrap.c
++++ b/render/mitrap.c
+@@ -34,6 +34,55 @@
+ #include "picturestr.h"
+ #include "mipict.h"
+ 
++PicturePtr
++miCreateAlphaPicture (ScreenPtr	    pScreen, 
++		      PicturePtr    pDst,
++		      PictFormatPtr pPictFormat,
++		      CARD16	    width,
++		      CARD16	    height)
++{
++    PixmapPtr	    pPixmap;
++    PicturePtr	    pPicture;
++    GCPtr	    pGC;
++    int		    error;
++    xRectangle	    rect;
++
++    if (width > 32767 || height > 32767)
++	return 0;
++
++    if (!pPictFormat)
++    {
++	if (pDst->polyEdge == PolyEdgeSharp)
++	    pPictFormat = PictureMatchFormat (pScreen, 1, PICT_a1);
++	else
++	    pPictFormat = PictureMatchFormat (pScreen, 8, PICT_a8);
++	if (!pPictFormat)
++	    return 0;
++    }
++
++    pPixmap = (*pScreen->CreatePixmap) (pScreen, width, height, 
++					pPictFormat->depth, 0);
++    if (!pPixmap)
++	return 0;
++    pGC = GetScratchGC (pPixmap->drawable.depth, pScreen);
++    if (!pGC)
++    {
++	(*pScreen->DestroyPixmap) (pPixmap);
++	return 0;
++    }
++    ValidateGC (&pPixmap->drawable, pGC);
++    rect.x = 0;
++    rect.y = 0;
++    rect.width = width;
++    rect.height = height;
++    (*pGC->ops->PolyFillRect)(&pPixmap->drawable, pGC, 1, &rect);
++    FreeScratchGC (pGC);
++    pPicture = CreatePicture (0, &pPixmap->drawable, pPictFormat,
++			      0, 0, serverClient, &error);
++    (*pScreen->DestroyPixmap) (pPixmap);
++    return pPicture;
++}
++
+ static xFixed
+ miLineFixedX(xLineFixed * l, xFixed y, Bool ceil)
+ {
+@@ -79,3 +128,65 @@ miTrapezoidBounds(int ntrap, xTrapezoid * traps, BoxPtr box)
+             box->x2 = x2;
+     }
+ }
++
++
++void
++miTrapezoids (CARD8        op,
++             PicturePtr    pSrc,
++             PicturePtr    pDst,
++             PictFormatPtr maskFormat,
++             INT16         xSrc,
++             INT16         ySrc,
++             int           ntrap,
++             xTrapezoid    *traps)
++{
++    ScreenPtr          pScreen = pDst->pDrawable->pScreen;
++    PictureScreenPtr    ps = GetPictureScreen(pScreen);
++
++    /*
++     * Check for solid alpha add
++     */
++    if (op == PictOpAdd && miIsSolidAlpha (pSrc))
++    {
++       for (; ntrap; ntrap--, traps++)
++           (*ps->RasterizeTrapezoid) (pDst, traps, 0, 0);
++    } 
++    else if (maskFormat)
++    {
++       PicturePtr      pPicture;
++       BoxRec          bounds;
++       INT16           xDst, yDst;
++       INT16           xRel, yRel;
++       
++       xDst = traps[0].left.p1.x >> 16;
++       yDst = traps[0].left.p1.y >> 16;
++
++       miTrapezoidBounds (ntrap, traps, &bounds);
++       if (bounds.y1 >= bounds.y2 || bounds.x1 >= bounds.x2)
++           return;
++       pPicture = miCreateAlphaPicture (pScreen, pDst, maskFormat,
++                                        bounds.x2 - bounds.x1,
++                                        bounds.y2 - bounds.y1);
++       if (!pPicture)
++           return;
++       for (; ntrap; ntrap--, traps++)
++           (*ps->RasterizeTrapezoid) (pPicture, traps, 
++                                      -bounds.x1, -bounds.y1);
++       xRel = bounds.x1 + xSrc - xDst;
++       yRel = bounds.y1 + ySrc - yDst;
++       CompositePicture (op, pSrc, pPicture, pDst,
++                         xRel, yRel, 0, 0, bounds.x1, bounds.y1,
++                         bounds.x2 - bounds.x1,
++                         bounds.y2 - bounds.y1);
++       FreePicture (pPicture, 0);
++    }
++    else
++    {
++       if (pDst->polyEdge == PolyEdgeSharp)
++           maskFormat = PictureMatchFormat (pScreen, 1, PICT_a1);
++       else
++           maskFormat = PictureMatchFormat (pScreen, 8, PICT_a8);
++       for (; ntrap; ntrap--, traps++)
++           miTrapezoids (op, pSrc, pDst, maskFormat, xSrc, ySrc, 1, traps);
++    }
++}
+diff --git a/render/mitri.c b/render/mitri.c
+index 922f22a..bdca9ca 100644
+--- a/render/mitri.c
++++ b/render/mitri.c
+@@ -65,3 +65,64 @@ miTriangleBounds(int ntri, xTriangle * tris, BoxPtr bounds)
+ {
+     miPointFixedBounds(ntri * 3, (xPointFixed *) tris, bounds);
+ }
++
++
++void
++miTriangles (CARD8	    op,
++	     PicturePtr	    pSrc,
++	     PicturePtr	    pDst,
++	     PictFormatPtr  maskFormat,
++	     INT16	    xSrc,
++	     INT16	    ySrc,
++	     int	    ntri,
++	     xTriangle	    *tris)
++{
++    ScreenPtr		pScreen = pDst->pDrawable->pScreen;
++    PictureScreenPtr    ps = GetPictureScreen(pScreen);
++    
++    /*
++     * Check for solid alpha add
++     */
++    if (op == PictOpAdd && miIsSolidAlpha (pSrc))
++    {
++	(*ps->AddTriangles) (pDst, 0, 0, ntri, tris);
++    }
++    else if (maskFormat)
++    {
++	BoxRec		bounds;
++	PicturePtr	pPicture;
++	INT16		xDst, yDst;
++	INT16		xRel, yRel;
++	
++	xDst = tris[0].p1.x >> 16;
++	yDst = tris[0].p1.y >> 16;
++
++	miTriangleBounds (ntri, tris, &bounds);
++	if (bounds.x2 <= bounds.x1 || bounds.y2 <= bounds.y1)
++	    return;
++	pPicture = miCreateAlphaPicture (pScreen, pDst, maskFormat,
++					 bounds.x2 - bounds.x1,
++					 bounds.y2 - bounds.y1);
++	if (!pPicture)
++	    return;
++	(*ps->AddTriangles) (pPicture, -bounds.x1, -bounds.y1, ntri, tris);
++	
++	xRel = bounds.x1 + xSrc - xDst;
++	yRel = bounds.y1 + ySrc - yDst;
++	CompositePicture (op, pSrc, pPicture, pDst,
++			  xRel, yRel, 0, 0, bounds.x1, bounds.y1,
++			  bounds.x2 - bounds.x1, bounds.y2 - bounds.y1);
++	FreePicture (pPicture, 0);
++    }
++    else
++    {
++	if (pDst->polyEdge == PolyEdgeSharp)
++	    maskFormat = PictureMatchFormat (pScreen, 1, PICT_a1);
++	else
++	    maskFormat = PictureMatchFormat (pScreen, 8, PICT_a8);
++	
++	for (; ntri; ntri--, tris++)
++	    miTriangles (op, pSrc, pDst, maskFormat, xSrc, ySrc, 1, tris);
++    }
++}
++
+-- 
+1.8.4.1
+

--- a/pkgs/servers/x11/xorg/darwin/bundle_main.patch
+++ b/pkgs/servers/x11/xorg/darwin/bundle_main.patch
@@ -1,0 +1,118 @@
+cstrahan:
+
+This patch makes it possible (and necessary) to specify the default
+shell, xterm client, and startx script from environment variables. These
+defaults are used when launching the XQuartz.app, which in turn needs to know
+how to start the X server. I've patched `command_from_prefs' so that it ignores
+the preferences settings and immediately sets them to whatever the environment
+variables are.
+
+When developing an installable package for XQuartz/XQuartz.app, we'll need to
+set an `LSEnvironment' entry in the plist for the XQuartz.app, we'll also need
+to wrap the XQuartz.app/Contents/MacOS/X11 script (the Xquartz server will
+invoke this script during initialization. See stub.patch for more details.).
+
+diff --git a/hw/xquartz/mach-startup/bundle-main.c b/hw/xquartz/mach-startup/bundle-main.c
+index b403662..b1e2070 100644
+--- a/hw/xquartz/mach-startup/bundle-main.c
++++ b/hw/xquartz/mach-startup/bundle-main.c
+@@ -77,13 +77,7 @@ FatalError(const char *f, ...) _X_ATTRIBUTE_PRINTF(1, 2) _X_NORETURN;
+ 
+ extern int noPanoramiXExtension;
+ 
+-#define DEFAULT_CLIENT X11BINDIR "/xterm"
+-#define DEFAULT_STARTX X11BINDIR "/startx -- " X11BINDIR "/Xquartz"
+-#define DEFAULT_SHELL  "/bin/sh"
+-
+-#ifndef BUILD_DATE
+ #define BUILD_DATE ""
+-#endif
+ #ifndef XSERVER_VERSION
+ #define XSERVER_VERSION "?"
+ #endif
+@@ -718,14 +712,14 @@ main(int argc, char **argv, char **envp)
+         pid_t child1, child2;
+         int status;
+ 
+-        pref_app_to_run = command_from_prefs("app_to_run", DEFAULT_CLIENT);
++        pref_app_to_run = command_from_prefs("app_to_run", getenv("XQUARTZ_DEFAULT_CLIENT"));
+         assert(pref_app_to_run);
+ 
+-        pref_login_shell = command_from_prefs("login_shell", DEFAULT_SHELL);
++        pref_login_shell = command_from_prefs("login_shell", getenv("XQUARTZ_DEFAULT_SHELL"));
+         assert(pref_login_shell);
+ 
+         pref_startx_script = command_from_prefs("startx_script",
+-                                                DEFAULT_STARTX);
++                                                getenv("XQUARTZ_DEFAULT_STARTX"));
+         assert(pref_startx_script);
+ 
+         /* Do the fork-twice trick to avoid having to reap zombies */
+@@ -804,10 +798,12 @@ execute(const char *command)
+ static char *
+ command_from_prefs(const char *key, const char *default_value)
+ {
++    if (default_value == NULL)
++        return NULL;
++
+     char *command = NULL;
+ 
+     CFStringRef cfKey;
+-    CFPropertyListRef PlistRef;
+ 
+     if (!key)
+         return NULL;
+@@ -817,40 +813,24 @@ command_from_prefs(const char *key, const char *default_value)
+     if (!cfKey)
+         return NULL;
+ 
+-    PlistRef = CFPreferencesCopyAppValue(cfKey,
+-                                         kCFPreferencesCurrentApplication);
++    CFStringRef cfDefaultValue = CFStringCreateWithCString(
++        NULL, default_value, kCFStringEncodingASCII);
++    int len = strlen(default_value) + 1;
+ 
+-    if ((PlistRef == NULL) ||
+-        (CFGetTypeID(PlistRef) != CFStringGetTypeID())) {
+-        CFStringRef cfDefaultValue = CFStringCreateWithCString(
+-            NULL, default_value, kCFStringEncodingASCII);
+-        int len = strlen(default_value) + 1;
++    if (!cfDefaultValue)
++        goto command_from_prefs_out;
+ 
+-        if (!cfDefaultValue)
+-            goto command_from_prefs_out;
++    CFPreferencesSetAppValue(cfKey, cfDefaultValue,
++                             kCFPreferencesCurrentApplication);
++    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
++    CFRelease(cfDefaultValue);
+ 
+-        CFPreferencesSetAppValue(cfKey, cfDefaultValue,
+-                                 kCFPreferencesCurrentApplication);
+-        CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
+-        CFRelease(cfDefaultValue);
+-
+-        command = (char *)malloc(len * sizeof(char));
+-        if (!command)
+-            goto command_from_prefs_out;
+-        strcpy(command, default_value);
+-    }
+-    else {
+-        int len = CFStringGetLength((CFStringRef)PlistRef) + 1;
+-        command = (char *)malloc(len * sizeof(char));
+-        if (!command)
+-            goto command_from_prefs_out;
+-        CFStringGetCString((CFStringRef)PlistRef, command, len,
+-                           kCFStringEncodingASCII);
+-    }
++    command = (char *)malloc(len * sizeof(char));
++    if (!command)
++        goto command_from_prefs_out;
++    strcpy(command, default_value);
+ 
+ command_from_prefs_out:
+-    if (PlistRef)
+-        CFRelease(PlistRef);
+     if (cfKey)
+         CFRelease(cfKey);
+     return command;

--- a/pkgs/servers/x11/xorg/darwin/dri/GL/internal/dri_interface.h
+++ b/pkgs/servers/x11/xorg/darwin/dri/GL/internal/dri_interface.h
@@ -1,0 +1,1409 @@
+/*
+ * Copyright 1998-1999 Precision Insight, Inc., Cedar Park, Texas.
+ * Copyright 2007-2008 Red Hat, Inc.
+ * (C) Copyright IBM Corporation 2004
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * on the rights to use, copy, modify, merge, publish, distribute, sub
+ * license, and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDERS AND/OR THEIR SUPPLIERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * \file dri_interface.h
+ *
+ * This file contains all the types and functions that define the interface
+ * between a DRI driver and driver loader.  Currently, the most common driver
+ * loader is the XFree86 libGL.so.  However, other loaders do exist, and in
+ * the future the server-side libglx.a will also be a loader.
+ * 
+ * \author Kevin E. Martin <kevin@precisioninsight.com>
+ * \author Ian Romanick <idr@us.ibm.com>
+ * \author Kristian Høgsberg <krh@redhat.com>
+ */
+
+#ifndef DRI_INTERFACE_H
+#define DRI_INTERFACE_H
+
+/* For archs with no drm.h */
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__GNU__)
+#ifndef __NOT_HAVE_DRM_H
+#define __NOT_HAVE_DRM_H
+#endif
+#endif
+
+#ifndef __NOT_HAVE_DRM_H
+#include <drm.h>
+#else
+typedef unsigned int drm_context_t;
+typedef unsigned int drm_drawable_t;
+typedef struct drm_clip_rect drm_clip_rect_t;
+#endif
+
+/**
+ * \name DRI interface structures
+ *
+ * The following structures define the interface between the GLX client
+ * side library and the DRI (direct rendering infrastructure).
+ */
+/*@{*/
+typedef struct __DRIdisplayRec		__DRIdisplay;
+typedef struct __DRIscreenRec		__DRIscreen;
+typedef struct __DRIcontextRec		__DRIcontext;
+typedef struct __DRIdrawableRec		__DRIdrawable;
+typedef struct __DRIconfigRec		__DRIconfig;
+typedef struct __DRIframebufferRec	__DRIframebuffer;
+typedef struct __DRIversionRec		__DRIversion;
+
+typedef struct __DRIcoreExtensionRec		__DRIcoreExtension;
+typedef struct __DRIextensionRec		__DRIextension;
+typedef struct __DRIcopySubBufferExtensionRec	__DRIcopySubBufferExtension;
+typedef struct __DRIswapControlExtensionRec	__DRIswapControlExtension;
+typedef struct __DRIframeTrackingExtensionRec	__DRIframeTrackingExtension;
+typedef struct __DRImediaStreamCounterExtensionRec	__DRImediaStreamCounterExtension;
+typedef struct __DRItexOffsetExtensionRec	__DRItexOffsetExtension;
+typedef struct __DRItexBufferExtensionRec	__DRItexBufferExtension;
+typedef struct __DRIlegacyExtensionRec		__DRIlegacyExtension;
+typedef struct __DRIswrastExtensionRec		__DRIswrastExtension;
+typedef struct __DRIbufferRec			__DRIbuffer;
+typedef struct __DRIdri2ExtensionRec		__DRIdri2Extension;
+typedef struct __DRIdri2LoaderExtensionRec	__DRIdri2LoaderExtension;
+typedef struct __DRI2flushExtensionRec	__DRI2flushExtension;
+typedef struct __DRI2throttleExtensionRec	__DRI2throttleExtension;
+
+
+typedef struct __DRIimageLoaderExtensionRec     __DRIimageLoaderExtension;
+typedef struct __DRIimageDriverExtensionRec     __DRIimageDriverExtension;
+
+/*@}*/
+
+
+/**
+ * Extension struct.  Drivers 'inherit' from this struct by embedding
+ * it as the first element in the extension struct.
+ *
+ * We never break API in for a DRI extension.  If we need to change
+ * the way things work in a non-backwards compatible manner, we
+ * introduce a new extension.  During a transition period, we can
+ * leave both the old and the new extension in the driver, which
+ * allows us to move to the new interface without having to update the
+ * loader(s) in lock step.
+ *
+ * However, we can add entry points to an extension over time as long
+ * as we don't break the old ones.  As we add entry points to an
+ * extension, we increase the version number.  The corresponding
+ * #define can be used to guard code that accesses the new entry
+ * points at compile time and the version field in the extension
+ * struct can be used at run-time to determine how to use the
+ * extension.
+ */
+struct __DRIextensionRec {
+    const char *name;
+    int version;
+};
+
+/**
+ * The first set of extension are the screen extensions, returned by
+ * __DRIcore::getExtensions().  This entry point will return a list of
+ * extensions and the loader can use the ones it knows about by
+ * casting them to more specific extensions and advertising any GLX
+ * extensions the DRI extensions enables.
+ */
+
+/**
+ * Used by drivers to indicate support for setting the read drawable.
+ */
+#define __DRI_READ_DRAWABLE "DRI_ReadDrawable"
+#define __DRI_READ_DRAWABLE_VERSION 1
+
+/**
+ * Used by drivers that implement the GLX_MESA_copy_sub_buffer extension.
+ */
+#define __DRI_COPY_SUB_BUFFER "DRI_CopySubBuffer"
+#define __DRI_COPY_SUB_BUFFER_VERSION 1
+struct __DRIcopySubBufferExtensionRec {
+    __DRIextension base;
+    void (*copySubBuffer)(__DRIdrawable *drawable, int x, int y, int w, int h);
+};
+
+/**
+ * Used by drivers that implement the GLX_SGI_swap_control or
+ * GLX_MESA_swap_control extension.
+ */
+#define __DRI_SWAP_CONTROL "DRI_SwapControl"
+#define __DRI_SWAP_CONTROL_VERSION 1
+struct __DRIswapControlExtensionRec {
+    __DRIextension base;
+    void (*setSwapInterval)(__DRIdrawable *drawable, unsigned int inteval);
+    unsigned int (*getSwapInterval)(__DRIdrawable *drawable);
+};
+
+/**
+ * Used by drivers that implement the GLX_MESA_swap_frame_usage extension.
+ */
+#define __DRI_FRAME_TRACKING "DRI_FrameTracking"
+#define __DRI_FRAME_TRACKING_VERSION 1
+struct __DRIframeTrackingExtensionRec {
+    __DRIextension base;
+
+    /**
+     * Enable or disable frame usage tracking.
+     * 
+     * \since Internal API version 20030317.
+     */
+    int (*frameTracking)(__DRIdrawable *drawable, GLboolean enable);
+
+    /**
+     * Retrieve frame usage information.
+     * 
+     * \since Internal API version 20030317.
+     */
+    int (*queryFrameTracking)(__DRIdrawable *drawable,
+			      int64_t * sbc, int64_t * missedFrames,
+			      float * lastMissedUsage, float * usage);
+};
+
+
+/**
+ * Used by drivers that implement the GLX_SGI_video_sync extension.
+ */
+#define __DRI_MEDIA_STREAM_COUNTER "DRI_MediaStreamCounter"
+#define __DRI_MEDIA_STREAM_COUNTER_VERSION 1
+struct __DRImediaStreamCounterExtensionRec {
+    __DRIextension base;
+
+    /**
+     * Wait for the MSC to equal target_msc, or, if that has already passed,
+     * the next time (MSC % divisor) is equal to remainder.  If divisor is
+     * zero, the function will return as soon as MSC is greater than or equal
+     * to target_msc.
+     */
+    int (*waitForMSC)(__DRIdrawable *drawable,
+		      int64_t target_msc, int64_t divisor, int64_t remainder,
+		      int64_t * msc, int64_t * sbc);
+
+    /**
+     * Get the number of vertical refreshes since some point in time before
+     * this function was first called (i.e., system start up).
+     */
+    int (*getDrawableMSC)(__DRIscreen *screen, __DRIdrawable *drawable,
+			  int64_t *msc);
+};
+
+
+#define __DRI_TEX_OFFSET "DRI_TexOffset"
+#define __DRI_TEX_OFFSET_VERSION 1
+struct __DRItexOffsetExtensionRec {
+    __DRIextension base;
+
+    /**
+     * Method to override base texture image with a driver specific 'offset'.
+     * The depth passed in allows e.g. to ignore the alpha channel of texture
+     * images where the non-alpha components don't occupy a whole texel.
+     *
+     * For GLX_EXT_texture_from_pixmap with AIGLX.
+     */
+    void (*setTexOffset)(__DRIcontext *pDRICtx, GLint texname,
+			 unsigned long long offset, GLint depth, GLuint pitch);
+};
+
+
+/* Valid values for format in the setTexBuffer2 function below.  These
+ * values match the GLX tokens for compatibility reasons, but we
+ * define them here since the DRI interface can't depend on GLX. */
+#define __DRI_TEXTURE_FORMAT_NONE        0x20D8
+#define __DRI_TEXTURE_FORMAT_RGB         0x20D9
+#define __DRI_TEXTURE_FORMAT_RGBA        0x20DA
+
+#define __DRI_TEX_BUFFER "DRI_TexBuffer"
+#define __DRI_TEX_BUFFER_VERSION 2
+struct __DRItexBufferExtensionRec {
+    __DRIextension base;
+
+    /**
+     * Method to override base texture image with the contents of a
+     * __DRIdrawable. 
+     *
+     * For GLX_EXT_texture_from_pixmap with AIGLX.  Deprecated in favor of
+     * setTexBuffer2 in version 2 of this interface
+     */
+    void (*setTexBuffer)(__DRIcontext *pDRICtx,
+			 GLint target,
+			 __DRIdrawable *pDraw);
+
+    /**
+     * Method to override base texture image with the contents of a
+     * __DRIdrawable, including the required texture format attribute.
+     *
+     * For GLX_EXT_texture_from_pixmap with AIGLX.
+     */
+    void (*setTexBuffer2)(__DRIcontext *pDRICtx,
+			  GLint target,
+			  GLint format,
+			  __DRIdrawable *pDraw);
+    /**
+     * Method to release texture buffer in case some special platform
+     * need this.
+     *
+     * For GLX_EXT_texture_from_pixmap with AIGLX.
+     */
+    void (*releaseTexBuffer)(__DRIcontext *pDRICtx,
+			GLint target,
+			__DRIdrawable *pDraw);
+};
+
+/**
+ * Used by drivers that implement DRI2
+ */
+#define __DRI2_FLUSH "DRI2_Flush"
+#define __DRI2_FLUSH_VERSION 4
+
+#define __DRI2_FLUSH_DRAWABLE (1 << 0) /* the drawable should be flushed. */
+#define __DRI2_FLUSH_CONTEXT  (1 << 1) /* glFlush should be called */
+
+enum __DRI2throttleReason {
+   __DRI2_THROTTLE_SWAPBUFFER,
+   __DRI2_THROTTLE_COPYSUBBUFFER,
+   __DRI2_THROTTLE_FLUSHFRONT
+};
+
+struct __DRI2flushExtensionRec {
+    __DRIextension base;
+    void (*flush)(__DRIdrawable *drawable);
+
+    /**
+     * Ask the driver to call getBuffers/getBuffersWithFormat before
+     * it starts rendering again.
+     *
+     * \param drawable the drawable to invalidate
+     *
+     * \since 3
+     */
+    void (*invalidate)(__DRIdrawable *drawable);
+
+    /**
+     * This function reduces the number of flushes in the driver by combining
+     * several operations into one call.
+     *
+     * It can:
+     * - throttle
+     * - flush a drawable
+     * - flush a context
+     *
+     * \param context           the context
+     * \param drawable          the drawable to flush
+     * \param flags             a combination of _DRI2_FLUSH_xxx flags
+     * \param throttle_reason   the reason for throttling, 0 = no throttling
+     *
+     * \since 4
+     */
+    void (*flush_with_flags)(__DRIcontext *ctx,
+                             __DRIdrawable *drawable,
+                             unsigned flags,
+                             enum __DRI2throttleReason throttle_reason);
+};
+
+
+/**
+ * Extension that the driver uses to request
+ * throttle callbacks.
+ */
+
+#define __DRI2_THROTTLE "DRI2_Throttle"
+#define __DRI2_THROTTLE_VERSION 1
+
+struct __DRI2throttleExtensionRec {
+   __DRIextension base;
+   void (*throttle)(__DRIcontext *ctx,
+		    __DRIdrawable *drawable,
+		    enum __DRI2throttleReason reason);
+};
+
+/*@}*/
+
+/**
+ * The following extensions describe loader features that the DRI
+ * driver can make use of.  Some of these are mandatory, such as the
+ * getDrawableInfo extension for DRI and the DRI Loader extensions for
+ * DRI2, while others are optional, and if present allow the driver to
+ * expose certain features.  The loader pass in a NULL terminated
+ * array of these extensions to the driver in the createNewScreen
+ * constructor.
+ */
+
+typedef struct __DRIgetDrawableInfoExtensionRec __DRIgetDrawableInfoExtension;
+typedef struct __DRIsystemTimeExtensionRec __DRIsystemTimeExtension;
+typedef struct __DRIdamageExtensionRec __DRIdamageExtension;
+typedef struct __DRIloaderExtensionRec __DRIloaderExtension;
+typedef struct __DRIswrastLoaderExtensionRec __DRIswrastLoaderExtension;
+
+
+/**
+ * Callback to getDrawableInfo protocol
+ */
+#define __DRI_GET_DRAWABLE_INFO "DRI_GetDrawableInfo"
+#define __DRI_GET_DRAWABLE_INFO_VERSION 1
+struct __DRIgetDrawableInfoExtensionRec {
+    __DRIextension base;
+
+    /**
+     * This function is used to get information about the position, size, and
+     * clip rects of a drawable.
+     */
+    GLboolean (* getDrawableInfo) ( __DRIdrawable *drawable,
+	unsigned int * index, unsigned int * stamp,
+        int * x, int * y, int * width, int * height,
+        int * numClipRects, drm_clip_rect_t ** pClipRects,
+        int * backX, int * backY,
+	int * numBackClipRects, drm_clip_rect_t ** pBackClipRects,
+	void *loaderPrivate);
+};
+
+/**
+ * Callback to get system time for media stream counter extensions.
+ */
+#define __DRI_SYSTEM_TIME "DRI_SystemTime"
+#define __DRI_SYSTEM_TIME_VERSION 1
+struct __DRIsystemTimeExtensionRec {
+    __DRIextension base;
+
+    /**
+     * Get the 64-bit unadjusted system time (UST).
+     */
+    int (*getUST)(int64_t * ust);
+
+    /**
+     * Get the media stream counter (MSC) rate.
+     * 
+     * Matching the definition in GLX_OML_sync_control, this function returns
+     * the rate of the "media stream counter".  In practical terms, this is
+     * the frame refresh rate of the display.
+     */
+    GLboolean (*getMSCRate)(__DRIdrawable *draw,
+			    int32_t * numerator, int32_t * denominator,
+			    void *loaderPrivate);
+};
+
+/**
+ * Damage reporting
+ */
+#define __DRI_DAMAGE "DRI_Damage"
+#define __DRI_DAMAGE_VERSION 1
+struct __DRIdamageExtensionRec {
+    __DRIextension base;
+
+    /**
+     * Reports areas of the given drawable which have been modified by the
+     * driver.
+     *
+     * \param drawable which the drawing was done to.
+     * \param rects rectangles affected, with the drawable origin as the
+     *	      origin.
+     * \param x X offset of the drawable within the screen (used in the
+     *	      front_buffer case)
+     * \param y Y offset of the drawable within the screen.
+     * \param front_buffer boolean flag for whether the drawing to the
+     * 	      drawable was actually done directly to the front buffer (instead
+     *	      of backing storage, for example)
+     * \param loaderPrivate the data passed in at createNewDrawable time
+     */
+    void (*reportDamage)(__DRIdrawable *draw,
+			 int x, int y,
+			 drm_clip_rect_t *rects, int num_rects,
+			 GLboolean front_buffer,
+			 void *loaderPrivate);
+};
+
+#define __DRI_SWRAST_IMAGE_OP_DRAW	1
+#define __DRI_SWRAST_IMAGE_OP_CLEAR	2
+#define __DRI_SWRAST_IMAGE_OP_SWAP	3
+
+/**
+ * SWRast Loader extension.
+ */
+#define __DRI_SWRAST_LOADER "DRI_SWRastLoader"
+#define __DRI_SWRAST_LOADER_VERSION 1
+struct __DRIswrastLoaderExtensionRec {
+    __DRIextension base;
+
+    /*
+     * Drawable position and size
+     */
+    void (*getDrawableInfo)(__DRIdrawable *drawable,
+			    int *x, int *y, int *width, int *height,
+			    void *loaderPrivate);
+
+    /**
+     * Put image to drawable
+     */
+    void (*putImage)(__DRIdrawable *drawable, int op,
+		     int x, int y, int width, int height,
+		     char *data, void *loaderPrivate);
+
+    /**
+     * Get image from readable
+     */
+    void (*getImage)(__DRIdrawable *readable,
+		     int x, int y, int width, int height,
+		     char *data, void *loaderPrivate);
+};
+
+/**
+ * Invalidate loader extension.  The presence of this extension
+ * indicates to the DRI driver that the loader will call invalidate in
+ * the __DRI2_FLUSH extension, whenever the needs to query for new
+ * buffers.  This means that the DRI driver can drop the polling in
+ * glViewport().
+ *
+ * The extension doesn't provide any functionality, it's only use to
+ * indicate to the driver that it can use the new semantics.  A DRI
+ * driver can use this to switch between the different semantics or
+ * just refuse to initialize if this extension isn't present.
+ */
+#define __DRI_USE_INVALIDATE "DRI_UseInvalidate"
+#define __DRI_USE_INVALIDATE_VERSION 1
+
+typedef struct __DRIuseInvalidateExtensionRec __DRIuseInvalidateExtension;
+struct __DRIuseInvalidateExtensionRec {
+   __DRIextension base;
+};
+
+/**
+ * The remaining extensions describe driver extensions, immediately
+ * available interfaces provided by the driver.  To start using the
+ * driver, dlsym() for the __DRI_DRIVER_EXTENSIONS symbol and look for
+ * the extension you need in the array.
+ */
+#define __DRI_DRIVER_EXTENSIONS "__driDriverExtensions"
+
+/**
+ * This symbol replaces the __DRI_DRIVER_EXTENSIONS symbol, and will be
+ * suffixed by "_drivername", allowing multiple drivers to be built into one
+ * library, and also giving the driver the chance to return a variable driver
+ * extensions struct depending on the driver name being loaded or any other
+ * system state.
+ *
+ * The function prototype is:
+ *
+ * const __DRIextension **__driDriverGetExtensions_drivername(void);
+ */
+#define __DRI_DRIVER_GET_EXTENSIONS "__driDriverGetExtensions"
+
+/**
+ * Tokens for __DRIconfig attribs.  A number of attributes defined by
+ * GLX or EGL standards are not in the table, as they must be provided
+ * by the loader.  For example, FBConfig ID or visual ID, drawable type.
+ */
+
+#define __DRI_ATTRIB_BUFFER_SIZE		 1
+#define __DRI_ATTRIB_LEVEL			 2
+#define __DRI_ATTRIB_RED_SIZE			 3
+#define __DRI_ATTRIB_GREEN_SIZE			 4
+#define __DRI_ATTRIB_BLUE_SIZE			 5
+#define __DRI_ATTRIB_LUMINANCE_SIZE		 6
+#define __DRI_ATTRIB_ALPHA_SIZE			 7
+#define __DRI_ATTRIB_ALPHA_MASK_SIZE		 8
+#define __DRI_ATTRIB_DEPTH_SIZE			 9
+#define __DRI_ATTRIB_STENCIL_SIZE		10
+#define __DRI_ATTRIB_ACCUM_RED_SIZE		11
+#define __DRI_ATTRIB_ACCUM_GREEN_SIZE		12
+#define __DRI_ATTRIB_ACCUM_BLUE_SIZE		13
+#define __DRI_ATTRIB_ACCUM_ALPHA_SIZE		14
+#define __DRI_ATTRIB_SAMPLE_BUFFERS		15
+#define __DRI_ATTRIB_SAMPLES			16
+#define __DRI_ATTRIB_RENDER_TYPE		17
+#define __DRI_ATTRIB_CONFIG_CAVEAT		18
+#define __DRI_ATTRIB_CONFORMANT			19
+#define __DRI_ATTRIB_DOUBLE_BUFFER		20
+#define __DRI_ATTRIB_STEREO			21
+#define __DRI_ATTRIB_AUX_BUFFERS		22
+#define __DRI_ATTRIB_TRANSPARENT_TYPE		23
+#define __DRI_ATTRIB_TRANSPARENT_INDEX_VALUE	24
+#define __DRI_ATTRIB_TRANSPARENT_RED_VALUE	25
+#define __DRI_ATTRIB_TRANSPARENT_GREEN_VALUE	26
+#define __DRI_ATTRIB_TRANSPARENT_BLUE_VALUE	27
+#define __DRI_ATTRIB_TRANSPARENT_ALPHA_VALUE	28
+#define __DRI_ATTRIB_FLOAT_MODE			29
+#define __DRI_ATTRIB_RED_MASK			30
+#define __DRI_ATTRIB_GREEN_MASK			31
+#define __DRI_ATTRIB_BLUE_MASK			32
+#define __DRI_ATTRIB_ALPHA_MASK			33
+#define __DRI_ATTRIB_MAX_PBUFFER_WIDTH		34
+#define __DRI_ATTRIB_MAX_PBUFFER_HEIGHT		35
+#define __DRI_ATTRIB_MAX_PBUFFER_PIXELS		36
+#define __DRI_ATTRIB_OPTIMAL_PBUFFER_WIDTH	37
+#define __DRI_ATTRIB_OPTIMAL_PBUFFER_HEIGHT	38
+#define __DRI_ATTRIB_VISUAL_SELECT_GROUP	39
+#define __DRI_ATTRIB_SWAP_METHOD		40
+#define __DRI_ATTRIB_MAX_SWAP_INTERVAL		41
+#define __DRI_ATTRIB_MIN_SWAP_INTERVAL		42
+#define __DRI_ATTRIB_BIND_TO_TEXTURE_RGB	43
+#define __DRI_ATTRIB_BIND_TO_TEXTURE_RGBA	44
+#define __DRI_ATTRIB_BIND_TO_MIPMAP_TEXTURE	45
+#define __DRI_ATTRIB_BIND_TO_TEXTURE_TARGETS	46
+#define __DRI_ATTRIB_YINVERTED			47
+#define __DRI_ATTRIB_FRAMEBUFFER_SRGB_CAPABLE	48
+
+/* __DRI_ATTRIB_RENDER_TYPE */
+#define __DRI_ATTRIB_RGBA_BIT			0x01	
+#define __DRI_ATTRIB_COLOR_INDEX_BIT		0x02
+#define __DRI_ATTRIB_LUMINANCE_BIT		0x04
+#define __DRI_ATTRIB_FLOAT_BIT			0x08
+#define __DRI_ATTRIB_UNSIGNED_FLOAT_BIT		0x10
+
+/* __DRI_ATTRIB_CONFIG_CAVEAT */
+#define __DRI_ATTRIB_SLOW_BIT			0x01
+#define __DRI_ATTRIB_NON_CONFORMANT_CONFIG	0x02
+
+/* __DRI_ATTRIB_TRANSPARENT_TYPE */
+#define __DRI_ATTRIB_TRANSPARENT_RGB		0x00
+#define __DRI_ATTRIB_TRANSPARENT_INDEX		0x01
+
+/* __DRI_ATTRIB_BIND_TO_TEXTURE_TARGETS	 */
+#define __DRI_ATTRIB_TEXTURE_1D_BIT		0x01
+#define __DRI_ATTRIB_TEXTURE_2D_BIT		0x02
+#define __DRI_ATTRIB_TEXTURE_RECTANGLE_BIT	0x04
+
+/**
+ * This extension defines the core DRI functionality.
+ */
+#define __DRI_CORE "DRI_Core"
+#define __DRI_CORE_VERSION 1
+
+struct __DRIcoreExtensionRec {
+    __DRIextension base;
+
+    __DRIscreen *(*createNewScreen)(int screen, int fd,
+				    unsigned int sarea_handle,
+				    const __DRIextension **extensions,
+				    const __DRIconfig ***driverConfigs,
+				    void *loaderPrivate);
+
+    void (*destroyScreen)(__DRIscreen *screen);
+
+    const __DRIextension **(*getExtensions)(__DRIscreen *screen);
+
+    int (*getConfigAttrib)(const __DRIconfig *config,
+			   unsigned int attrib,
+			   unsigned int *value);
+
+    int (*indexConfigAttrib)(const __DRIconfig *config, int index,
+			     unsigned int *attrib, unsigned int *value);
+
+    __DRIdrawable *(*createNewDrawable)(__DRIscreen *screen,
+					const __DRIconfig *config,
+					unsigned int drawable_id,
+					unsigned int head,
+					void *loaderPrivate);
+
+    void (*destroyDrawable)(__DRIdrawable *drawable);
+
+    void (*swapBuffers)(__DRIdrawable *drawable);
+
+    __DRIcontext *(*createNewContext)(__DRIscreen *screen,
+				      const __DRIconfig *config,
+				      __DRIcontext *shared,
+				      void *loaderPrivate);
+
+    int (*copyContext)(__DRIcontext *dest,
+		       __DRIcontext *src,
+		       unsigned long mask);
+
+    void (*destroyContext)(__DRIcontext *context);
+
+    int (*bindContext)(__DRIcontext *ctx,
+		       __DRIdrawable *pdraw,
+		       __DRIdrawable *pread);
+
+    int (*unbindContext)(__DRIcontext *ctx);
+};
+
+/**
+ * Stored version of some component (i.e., server-side DRI module, kernel-side
+ * DRM, etc.).
+ * 
+ * \todo
+ * There are several data structures that explicitly store a major version,
+ * minor version, and patch level.  These structures should be modified to
+ * have a \c __DRIversionRec instead.
+ */
+struct __DRIversionRec {
+    int    major;        /**< Major version number. */
+    int    minor;        /**< Minor version number. */
+    int    patch;        /**< Patch-level. */
+};
+
+/**
+ * Framebuffer information record.  Used by libGL to communicate information
+ * about the framebuffer to the driver's \c __driCreateNewScreen function.
+ * 
+ * In XFree86, most of this information is derrived from data returned by
+ * calling \c XF86DRIGetDeviceInfo.
+ *
+ * \sa XF86DRIGetDeviceInfo __DRIdisplayRec::createNewScreen
+ *     __driUtilCreateNewScreen CallCreateNewScreen
+ *
+ * \bug This structure could be better named.
+ */
+struct __DRIframebufferRec {
+    unsigned char *base;    /**< Framebuffer base address in the CPU's
+			     * address space.  This value is calculated by
+			     * calling \c drmMap on the framebuffer handle
+			     * returned by \c XF86DRIGetDeviceInfo (or a
+			     * similar function).
+			     */
+    int size;               /**< Framebuffer size, in bytes. */
+    int stride;             /**< Number of bytes from one line to the next. */
+    int width;              /**< Pixel width of the framebuffer. */
+    int height;             /**< Pixel height of the framebuffer. */
+    int dev_priv_size;      /**< Size of the driver's dev-priv structure. */
+    void *dev_priv;         /**< Pointer to the driver's dev-priv structure. */
+};
+
+
+/**
+ * This extension provides alternative screen, drawable and context
+ * constructors for legacy DRI functionality.  This is used in
+ * conjunction with the core extension.
+ */
+#define __DRI_LEGACY "DRI_Legacy"
+#define __DRI_LEGACY_VERSION 1
+
+struct __DRIlegacyExtensionRec {
+    __DRIextension base;
+
+    __DRIscreen *(*createNewScreen)(int screen,
+				    const __DRIversion *ddx_version,
+				    const __DRIversion *dri_version,
+				    const __DRIversion *drm_version,
+				    const __DRIframebuffer *frame_buffer,
+				    void *pSAREA, int fd, 
+				    const __DRIextension **extensions,
+				    const __DRIconfig ***driver_configs,
+				    void *loaderPrivate);
+
+    __DRIdrawable *(*createNewDrawable)(__DRIscreen *screen,
+					const __DRIconfig *config,
+					drm_drawable_t hwDrawable,
+					int renderType, const int *attrs,
+					void *loaderPrivate);
+
+    __DRIcontext *(*createNewContext)(__DRIscreen *screen,
+				      const __DRIconfig *config,
+				      int render_type,
+				      __DRIcontext *shared,
+				      drm_context_t hwContext,
+				      void *loaderPrivate);
+};
+
+/**
+ * This extension provides alternative screen, drawable and context
+ * constructors for swrast DRI functionality.  This is used in
+ * conjunction with the core extension.
+ */
+#define __DRI_SWRAST "DRI_SWRast"
+#define __DRI_SWRAST_VERSION 4
+
+struct __DRIswrastExtensionRec {
+    __DRIextension base;
+
+    __DRIscreen *(*createNewScreen)(int screen,
+				    const __DRIextension **extensions,
+				    const __DRIconfig ***driver_configs,
+				    void *loaderPrivate);
+
+    __DRIdrawable *(*createNewDrawable)(__DRIscreen *screen,
+					const __DRIconfig *config,
+					void *loaderPrivate);
+
+   /* Since version 2 */
+   __DRIcontext *(*createNewContextForAPI)(__DRIscreen *screen,
+                                           int api,
+                                           const __DRIconfig *config,
+                                           __DRIcontext *shared,
+                                           void *data);
+
+   /**
+    * Create a context for a particular API with a set of attributes
+    *
+    * \since version 3
+    *
+    * \sa __DRIdri2ExtensionRec::createContextAttribs
+    */
+   __DRIcontext *(*createContextAttribs)(__DRIscreen *screen,
+					 int api,
+					 const __DRIconfig *config,
+					 __DRIcontext *shared,
+					 unsigned num_attribs,
+					 const uint32_t *attribs,
+					 unsigned *error,
+					 void *loaderPrivate);
+
+   /**
+    * createNewScreen() with the driver extensions passed in.
+    *
+    * \since version 4
+    */
+   __DRIscreen *(*createNewScreen2)(int screen,
+                                    const __DRIextension **loader_extensions,
+                                    const __DRIextension **driver_extensions,
+                                    const __DRIconfig ***driver_configs,
+                                    void *loaderPrivate);
+
+};
+
+/** Common DRI function definitions, shared among DRI2 and Image extensions
+ */
+
+typedef __DRIscreen *
+(*__DRIcreateNewScreen2Func)(int screen, int fd,
+                             const __DRIextension **extensions,
+                             const __DRIextension **driver_extensions,
+                             const __DRIconfig ***driver_configs,
+                             void *loaderPrivate);
+
+typedef __DRIdrawable *
+(*__DRIcreateNewDrawableFunc)(__DRIscreen *screen,
+                              const __DRIconfig *config,
+                              void *loaderPrivate);
+
+typedef __DRIcontext *
+(*__DRIcreateContextAttribsFunc)(__DRIscreen *screen,
+                                 int api,
+                                 const __DRIconfig *config,
+                                 __DRIcontext *shared,
+                                 unsigned num_attribs,
+                                 const uint32_t *attribs,
+                                 unsigned *error,
+                                 void *loaderPrivate);
+
+typedef unsigned int
+(*__DRIgetAPIMaskFunc)(__DRIscreen *screen);
+
+/**
+ * DRI2 Loader extension.
+ */
+#define __DRI_BUFFER_FRONT_LEFT		0
+#define __DRI_BUFFER_BACK_LEFT		1
+#define __DRI_BUFFER_FRONT_RIGHT	2
+#define __DRI_BUFFER_BACK_RIGHT		3
+#define __DRI_BUFFER_DEPTH		4
+#define __DRI_BUFFER_STENCIL		5
+#define __DRI_BUFFER_ACCUM		6
+#define __DRI_BUFFER_FAKE_FRONT_LEFT	7
+#define __DRI_BUFFER_FAKE_FRONT_RIGHT	8
+#define __DRI_BUFFER_DEPTH_STENCIL	9  /**< Only available with DRI2 1.1 */
+#define __DRI_BUFFER_HIZ		10
+
+/* Inofficial and for internal use. Increase when adding a new buffer token. */
+#define __DRI_BUFFER_COUNT		11
+
+struct __DRIbufferRec {
+    unsigned int attachment;
+    unsigned int name;
+    unsigned int pitch;
+    unsigned int cpp;
+    unsigned int flags;
+};
+
+#define __DRI_DRI2_LOADER "DRI_DRI2Loader"
+#define __DRI_DRI2_LOADER_VERSION 3
+struct __DRIdri2LoaderExtensionRec {
+    __DRIextension base;
+
+    __DRIbuffer *(*getBuffers)(__DRIdrawable *driDrawable,
+			       int *width, int *height,
+			       unsigned int *attachments, int count,
+			       int *out_count, void *loaderPrivate);
+
+    /**
+     * Flush pending front-buffer rendering
+     *
+     * Any rendering that has been performed to the
+     * \c __DRI_BUFFER_FAKE_FRONT_LEFT will be flushed to the
+     * \c __DRI_BUFFER_FRONT_LEFT.
+     *
+     * \param driDrawable    Drawable whose front-buffer is to be flushed
+     * \param loaderPrivate  Loader's private data that was previously passed
+     *                       into __DRIdri2ExtensionRec::createNewDrawable
+     */
+    void (*flushFrontBuffer)(__DRIdrawable *driDrawable, void *loaderPrivate);
+
+
+    /**
+     * Get list of buffers from the server
+     *
+     * Gets a list of buffer for the specified set of attachments.  Unlike
+     * \c ::getBuffers, this function takes a list of attachments paired with
+     * opaque \c unsigned \c int value describing the format of the buffer.
+     * It is the responsibility of the caller to know what the service that
+     * allocates the buffers will expect to receive for the format.
+     *
+     * \param driDrawable    Drawable whose buffers are being queried.
+     * \param width          Output where the width of the buffers is stored.
+     * \param height         Output where the height of the buffers is stored.
+     * \param attachments    List of pairs of attachment ID and opaque format
+     *                       requested for the drawable.
+     * \param count          Number of attachment / format pairs stored in
+     *                       \c attachments.
+     * \param loaderPrivate  Loader's private data that was previously passed
+     *                       into __DRIdri2ExtensionRec::createNewDrawable.
+     */
+    __DRIbuffer *(*getBuffersWithFormat)(__DRIdrawable *driDrawable,
+					 int *width, int *height,
+					 unsigned int *attachments, int count,
+					 int *out_count, void *loaderPrivate);
+};
+
+/**
+ * This extension provides alternative screen, drawable and context
+ * constructors for DRI2.
+ */
+#define __DRI_DRI2 "DRI_DRI2"
+#define __DRI_DRI2_VERSION 4
+
+#define __DRI_API_OPENGL	0	/**< OpenGL compatibility profile */
+#define __DRI_API_GLES		1	/**< OpenGL ES 1.x */
+#define __DRI_API_GLES2		2	/**< OpenGL ES 2.x */
+#define __DRI_API_OPENGL_CORE	3	/**< OpenGL 3.2+ core profile */
+#define __DRI_API_GLES3		4	/**< OpenGL ES 3.x */
+
+#define __DRI_CTX_ATTRIB_MAJOR_VERSION		0
+#define __DRI_CTX_ATTRIB_MINOR_VERSION		1
+#define __DRI_CTX_ATTRIB_FLAGS			2
+
+/**
+ * \requires __DRI2_ROBUSTNESS.
+ */
+#define __DRI_CTX_ATTRIB_RESET_STRATEGY		3
+
+#define __DRI_CTX_FLAG_DEBUG			0x00000001
+#define __DRI_CTX_FLAG_FORWARD_COMPATIBLE	0x00000002
+
+/**
+ * \requires __DRI2_ROBUSTNESS.
+ */
+#define __DRI_CTX_FLAG_ROBUST_BUFFER_ACCESS	0x00000004
+
+/**
+ * \name Context reset strategies.
+ */
+/*@{*/
+#define __DRI_CTX_RESET_NO_NOTIFICATION		0
+#define __DRI_CTX_RESET_LOSE_CONTEXT		1
+/*@}*/
+
+/**
+ * \name Reasons that __DRIdri2Extension::createContextAttribs might fail
+ */
+/*@{*/
+/** Success! */
+#define __DRI_CTX_ERROR_SUCCESS			0
+
+/** Memory allocation failure */
+#define __DRI_CTX_ERROR_NO_MEMORY		1
+
+/** Client requested an API (e.g., OpenGL ES 2.0) that the driver can't do. */
+#define __DRI_CTX_ERROR_BAD_API			2
+
+/** Client requested an API version that the driver can't do. */
+#define __DRI_CTX_ERROR_BAD_VERSION		3
+
+/** Client requested a flag or combination of flags the driver can't do. */
+#define __DRI_CTX_ERROR_BAD_FLAG		4
+
+/** Client requested an attribute the driver doesn't understand. */
+#define __DRI_CTX_ERROR_UNKNOWN_ATTRIBUTE	5
+
+/** Client requested a flag the driver doesn't understand. */
+#define __DRI_CTX_ERROR_UNKNOWN_FLAG		6
+/*@}*/
+
+struct __DRIdri2ExtensionRec {
+    __DRIextension base;
+
+    __DRIscreen *(*createNewScreen)(int screen, int fd,
+				    const __DRIextension **extensions,
+				    const __DRIconfig ***driver_configs,
+				    void *loaderPrivate);
+
+   __DRIcreateNewDrawableFunc   createNewDrawable;
+   __DRIcontext *(*createNewContext)(__DRIscreen *screen,
+                                     const __DRIconfig *config,
+                                     __DRIcontext *shared,
+                                     void *loaderPrivate);
+
+   /* Since version 2 */
+   __DRIgetAPIMaskFunc          getAPIMask;
+
+   __DRIcontext *(*createNewContextForAPI)(__DRIscreen *screen,
+					   int api,
+					   const __DRIconfig *config,
+					   __DRIcontext *shared,
+					   void *data);
+
+   __DRIbuffer *(*allocateBuffer)(__DRIscreen *screen,
+				  unsigned int attachment,
+				  unsigned int format,
+				  int width,
+				  int height);
+   void (*releaseBuffer)(__DRIscreen *screen,
+			 __DRIbuffer *buffer);
+
+   /**
+    * Create a context for a particular API with a set of attributes
+    *
+    * \since version 3
+    *
+    * \sa __DRIswrastExtensionRec::createContextAttribs
+    */
+   __DRIcreateContextAttribsFunc        createContextAttribs;
+
+   /**
+    * createNewScreen with the driver's extension list passed in.
+    *
+    * \since version 4
+    */
+   __DRIcreateNewScreen2Func            createNewScreen2;
+};
+
+
+/**
+ * This extension provides functionality to enable various EGLImage
+ * extensions.
+ */
+#define __DRI_IMAGE "DRI_IMAGE"
+#define __DRI_IMAGE_VERSION 8
+
+/**
+ * These formats correspond to the similarly named MESA_FORMAT_*
+ * tokens, except in the native endian of the CPU.  For example, on
+ * little endian __DRI_IMAGE_FORMAT_XRGB8888 corresponds to
+ * MESA_FORMAT_XRGB8888, but MESA_FORMAT_XRGB8888_REV on big endian.
+ *
+ * __DRI_IMAGE_FORMAT_NONE is for images that aren't directly usable
+ * by the driver (YUV planar formats) but serve as a base image for
+ * creating sub-images for the different planes within the image.
+ *
+ * R8, GR88 and NONE should not be used with createImageFormName or
+ * createImage, and are returned by query from sub images created with
+ * createImageFromNames (NONE, see above) and fromPlane (R8 & GR88).
+ */
+#define __DRI_IMAGE_FORMAT_RGB565       0x1001
+#define __DRI_IMAGE_FORMAT_XRGB8888     0x1002
+#define __DRI_IMAGE_FORMAT_ARGB8888     0x1003
+#define __DRI_IMAGE_FORMAT_ABGR8888     0x1004
+#define __DRI_IMAGE_FORMAT_XBGR8888     0x1005
+#define __DRI_IMAGE_FORMAT_R8           0x1006 /* Since version 5 */
+#define __DRI_IMAGE_FORMAT_GR88         0x1007
+#define __DRI_IMAGE_FORMAT_NONE         0x1008
+#define __DRI_IMAGE_FORMAT_XRGB2101010  0x1009
+#define __DRI_IMAGE_FORMAT_ARGB2101010  0x100a
+#define __DRI_IMAGE_FORMAT_SARGB8       0x100b
+
+#define __DRI_IMAGE_USE_SHARE		0x0001
+#define __DRI_IMAGE_USE_SCANOUT		0x0002
+#define __DRI_IMAGE_USE_CURSOR		0x0004 /* Depricated */
+#define __DRI_IMAGE_USE_LINEAR		0x0008
+
+
+/**
+ * Four CC formats that matches with WL_DRM_FORMAT_* from wayland_drm.h
+ * and GBM_FORMAT_* from gbm.h, used with createImageFromNames.
+ *
+ * \since 5
+ */
+
+#define __DRI_IMAGE_FOURCC_RGB565	0x36314752
+#define __DRI_IMAGE_FOURCC_ARGB8888	0x34325241
+#define __DRI_IMAGE_FOURCC_XRGB8888	0x34325258
+#define __DRI_IMAGE_FOURCC_ABGR8888	0x34324241
+#define __DRI_IMAGE_FOURCC_XBGR8888	0x34324258
+#define __DRI_IMAGE_FOURCC_YUV410	0x39565559
+#define __DRI_IMAGE_FOURCC_YUV411	0x31315559
+#define __DRI_IMAGE_FOURCC_YUV420	0x32315559
+#define __DRI_IMAGE_FOURCC_YUV422	0x36315559
+#define __DRI_IMAGE_FOURCC_YUV444	0x34325559
+#define __DRI_IMAGE_FOURCC_NV12		0x3231564e
+#define __DRI_IMAGE_FOURCC_NV16		0x3631564e
+#define __DRI_IMAGE_FOURCC_YUYV		0x56595559
+
+
+/**
+ * Queryable on images created by createImageFromNames.
+ *
+ * RGB and RGBA are may be usable directly as images but its still
+ * recommended to call fromPlanar with plane == 0.
+ *
+ * Y_U_V, Y_UV and Y_XUXV all requires call to fromPlanar to create
+ * usable sub-images, sampling from images return raw YUV data and
+ * color conversion needs to be done in the shader.
+ *
+ * \since 5
+ */
+
+#define __DRI_IMAGE_COMPONENTS_RGB	0x3001
+#define __DRI_IMAGE_COMPONENTS_RGBA	0x3002
+#define __DRI_IMAGE_COMPONENTS_Y_U_V	0x3003
+#define __DRI_IMAGE_COMPONENTS_Y_UV	0x3004
+#define __DRI_IMAGE_COMPONENTS_Y_XUXV	0x3005
+
+
+/**
+ * queryImage attributes
+ */
+
+#define __DRI_IMAGE_ATTRIB_STRIDE	0x2000
+#define __DRI_IMAGE_ATTRIB_HANDLE	0x2001
+#define __DRI_IMAGE_ATTRIB_NAME		0x2002
+#define __DRI_IMAGE_ATTRIB_FORMAT	0x2003 /* available in versions 3+ */
+#define __DRI_IMAGE_ATTRIB_WIDTH	0x2004 /* available in versions 4+ */
+#define __DRI_IMAGE_ATTRIB_HEIGHT	0x2005
+#define __DRI_IMAGE_ATTRIB_COMPONENTS	0x2006 /* available in versions 5+ */
+#define __DRI_IMAGE_ATTRIB_FD           0x2007 /* available in versions
+                                                * 7+. Each query will return a
+                                                * new fd. */
+
+enum __DRIYUVColorSpace {
+   __DRI_YUV_COLOR_SPACE_UNDEFINED = 0,
+   __DRI_YUV_COLOR_SPACE_ITU_REC601 = 0x327F,
+   __DRI_YUV_COLOR_SPACE_ITU_REC709 = 0x3280,
+   __DRI_YUV_COLOR_SPACE_ITU_REC2020 = 0x3281
+};
+
+enum __DRISampleRange {
+   __DRI_YUV_RANGE_UNDEFINED = 0,
+   __DRI_YUV_FULL_RANGE = 0x3282,
+   __DRI_YUV_NARROW_RANGE = 0x3283
+};
+
+enum __DRIChromaSiting {
+   __DRI_YUV_CHROMA_SITING_UNDEFINED = 0,
+   __DRI_YUV_CHROMA_SITING_0 = 0x3284,
+   __DRI_YUV_CHROMA_SITING_0_5 = 0x3285
+};
+
+/**
+ * \name Reasons that __DRIimageExtensionRec::createImageFromTexture might fail
+ */
+/*@{*/
+/** Success! */
+#define __DRI_IMAGE_ERROR_SUCCESS       0
+
+/** Memory allocation failure */
+#define __DRI_IMAGE_ERROR_BAD_ALLOC     1
+
+/** Client requested an invalid attribute for a texture object  */
+#define __DRI_IMAGE_ERROR_BAD_MATCH     2
+
+/** Client requested an invalid texture object */
+#define __DRI_IMAGE_ERROR_BAD_PARAMETER 3
+/*@}*/
+
+typedef struct __DRIimageRec          __DRIimage;
+typedef struct __DRIimageExtensionRec __DRIimageExtension;
+struct __DRIimageExtensionRec {
+    __DRIextension base;
+
+    __DRIimage *(*createImageFromName)(__DRIscreen *screen,
+				       int width, int height, int format,
+				       int name, int pitch,
+				       void *loaderPrivate);
+
+    __DRIimage *(*createImageFromRenderbuffer)(__DRIcontext *context,
+					       int renderbuffer,
+					       void *loaderPrivate);
+
+    void (*destroyImage)(__DRIimage *image);
+
+    __DRIimage *(*createImage)(__DRIscreen *screen,
+			       int width, int height, int format,
+			       unsigned int use,
+			       void *loaderPrivate);
+
+   GLboolean (*queryImage)(__DRIimage *image, int attrib, int *value);
+
+   /**
+    * The new __DRIimage will share the content with the old one, see dup(2).
+    */
+   __DRIimage *(*dupImage)(__DRIimage *image, void *loaderPrivate);
+
+   /**
+    * Validate that a __DRIimage can be used a certain way.
+    *
+    * \since 2
+    */
+   GLboolean (*validateUsage)(__DRIimage *image, unsigned int use);
+
+   /**
+    * Unlike createImageFromName __DRI_IMAGE_FORMAT is not but instead
+    * __DRI_IMAGE_FOURCC and strides are in bytes not pixels. Stride is
+    * also per block and not per pixel (for non-RGB, see gallium blocks).
+    *
+    * \since 5
+    */
+   __DRIimage *(*createImageFromNames)(__DRIscreen *screen,
+                                       int width, int height, int fourcc,
+                                       int *names, int num_names,
+                                       int *strides, int *offsets,
+                                       void *loaderPrivate);
+
+   /**
+    * Create an image out of a sub-region of a parent image.  This
+    * entry point lets us create individual __DRIimages for different
+    * planes in a planar buffer (typically yuv), for example.  While a
+    * sub-image shares the underlying buffer object with the parent
+    * image and other sibling sub-images, the life times of parent and
+    * sub-images are not dependent.  Destroying the parent or a
+    * sub-image doesn't affect other images.  The underlying buffer
+    * object is free when no __DRIimage remains that references it.
+    *
+    * Sub-images may overlap, but rendering to overlapping sub-images
+    * is undefined.
+    *
+    * \since 5
+    */
+    __DRIimage *(*fromPlanar)(__DRIimage *image, int plane,
+                              void *loaderPrivate);
+
+    /**
+     * Create image from texture.
+     *
+     * \since 6
+     */
+   __DRIimage *(*createImageFromTexture)(__DRIcontext *context,
+                                         int target,
+                                         unsigned texture,
+                                         int depth,
+                                         int level,
+                                         unsigned *error,
+                                         void *loaderPrivate);
+   /**
+    * Like createImageFromNames, but takes a prime fd instead.
+    *
+    * \since 7
+    */
+   __DRIimage *(*createImageFromFds)(__DRIscreen *screen,
+                                     int width, int height, int fourcc,
+                                     int *fds, int num_fds,
+                                     int *strides, int *offsets,
+                                     void *loaderPrivate);
+
+   /**
+    * Like createImageFromFds, but takes additional attributes.
+    *
+    * For EGL_EXT_image_dma_buf_import.
+    *
+    * \since 8
+    */
+   __DRIimage *(*createImageFromDmaBufs)(__DRIscreen *screen,
+                                         int width, int height, int fourcc,
+                                         int *fds, int num_fds,
+                                         int *strides, int *offsets,
+                                         enum __DRIYUVColorSpace color_space,
+                                         enum __DRISampleRange sample_range,
+                                         enum __DRIChromaSiting horiz_siting,
+                                         enum __DRIChromaSiting vert_siting,
+                                         unsigned *error,
+                                         void *loaderPrivate);
+};
+
+
+/**
+ * This extension must be implemented by the loader and passed to the
+ * driver at screen creation time.  The EGLImage entry points in the
+ * various client APIs take opaque EGLImage handles and use this
+ * extension to map them to a __DRIimage.  At version 1, this
+ * extensions allows mapping EGLImage pointers to __DRIimage pointers,
+ * but future versions could support other EGLImage-like, opaque types
+ * with new lookup functions.
+ */
+#define __DRI_IMAGE_LOOKUP "DRI_IMAGE_LOOKUP"
+#define __DRI_IMAGE_LOOKUP_VERSION 1
+
+typedef struct __DRIimageLookupExtensionRec __DRIimageLookupExtension;
+struct __DRIimageLookupExtensionRec {
+    __DRIextension base;
+
+    __DRIimage *(*lookupEGLImage)(__DRIscreen *screen, void *image,
+				  void *loaderPrivate);
+};
+
+/**
+ * This extension allows for common DRI2 options
+ */
+#define __DRI2_CONFIG_QUERY "DRI_CONFIG_QUERY"
+#define __DRI2_CONFIG_QUERY_VERSION 1
+
+typedef struct __DRI2configQueryExtensionRec __DRI2configQueryExtension;
+struct __DRI2configQueryExtensionRec {
+   __DRIextension base;
+
+   int (*configQueryb)(__DRIscreen *screen, const char *var, GLboolean *val);
+   int (*configQueryi)(__DRIscreen *screen, const char *var, GLint *val);
+   int (*configQueryf)(__DRIscreen *screen, const char *var, GLfloat *val);
+};
+
+/**
+ * Robust context driver extension.
+ *
+ * Existence of this extension means the driver can accept the
+ * \c __DRI_CTX_FLAG_ROBUST_BUFFER_ACCESS flag and the
+ * \c __DRI_CTX_ATTRIB_RESET_STRATEGY attribute in
+ * \c __DRIdri2ExtensionRec::createContextAttribs.
+ */
+#define __DRI2_ROBUSTNESS "DRI_Robustness"
+#define __DRI2_ROBUSTNESS_VERSION 1
+
+typedef struct __DRIrobustnessExtensionRec __DRIrobustnessExtension;
+struct __DRIrobustnessExtensionRec {
+   __DRIextension base;
+};
+
+/**
+ * DRI config options extension.
+ *
+ * This extension provides the XML string containing driver options for use by
+ * the loader in supporting the driconf application.
+ */
+#define __DRI_CONFIG_OPTIONS "DRI_ConfigOptions"
+#define __DRI_CONFIG_OPTIONS_VERSION 1
+
+typedef struct __DRIconfigOptionsExtensionRec {
+   __DRIextension base;
+   const char *xml;
+} __DRIconfigOptionsExtension;
+
+/**
+ * This extension provides a driver vtable to a set of common driver helper
+ * functions (driCoreExtension, driDRI2Extension) within the driver
+ * implementation, as opposed to having to pass them through a global
+ * variable.
+ *
+ * It is not intended to be public API to the actual loader, and the vtable
+ * layout may change at any time.
+ */
+#define __DRI_DRIVER_VTABLE "DRI_DriverVtable"
+#define __DRI_DRIVER_VTABLE_VERSION 1
+
+typedef struct __DRIDriverVtableExtensionRec {
+    __DRIextension base;
+    const struct __DriverAPIRec *vtable;
+} __DRIDriverVtableExtension;
+
+/**
+ * Query renderer driver extension
+ *
+ * This allows the window system layer (either EGL or GLX) to query aspects of
+ * hardware and driver support without creating a context.
+ */
+#define __DRI2_RENDERER_QUERY "DRI_RENDERER_QUERY"
+#define __DRI2_RENDERER_QUERY_VERSION 1
+
+#define __DRI2_RENDERER_VENDOR_ID                             0x0000
+#define __DRI2_RENDERER_DEVICE_ID                             0x0001
+#define __DRI2_RENDERER_VERSION                               0x0002
+#define __DRI2_RENDERER_ACCELERATED                           0x0003
+#define __DRI2_RENDERER_VIDEO_MEMORY                          0x0004
+#define __DRI2_RENDERER_UNIFIED_MEMORY_ARCHITECTURE           0x0005
+#define __DRI2_RENDERER_PREFERRED_PROFILE                     0x0006
+#define __DRI2_RENDERER_OPENGL_CORE_PROFILE_VERSION           0x0007
+#define __DRI2_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION  0x0008
+#define __DRI2_RENDERER_OPENGL_ES_PROFILE_VERSION             0x0009
+#define __DRI2_RENDERER_OPENGL_ES2_PROFILE_VERSION            0x000a
+
+typedef struct __DRI2rendererQueryExtensionRec __DRI2rendererQueryExtension;
+struct __DRI2rendererQueryExtensionRec {
+   __DRIextension base;
+
+   int (*queryInteger)(__DRIscreen *screen, int attribute, unsigned int *val);
+   int (*queryString)(__DRIscreen *screen, int attribute, const char **val);
+};
+
+/**
+ * Image Loader extension. Drivers use this to allocate color buffers
+ */
+
+enum __DRIimageBufferMask {
+   __DRI_IMAGE_BUFFER_BACK = (1 << 0),
+   __DRI_IMAGE_BUFFER_FRONT = (1 << 1)
+};
+
+struct __DRIimageList {
+   uint32_t image_mask;
+   __DRIimage *back;
+   __DRIimage *front;
+};
+
+#define __DRI_IMAGE_LOADER "DRI_IMAGE_LOADER"
+#define __DRI_IMAGE_LOADER_VERSION 1
+
+struct __DRIimageLoaderExtensionRec {
+    __DRIextension base;
+
+   /**
+    * Allocate color buffers.
+    *
+    * \param driDrawable
+    * \param width              Width of allocated buffers
+    * \param height             Height of allocated buffers
+    * \param format             one of __DRI_IMAGE_FORMAT_*
+    * \param stamp              Address of variable to be updated when
+    *                           getBuffers must be called again
+    * \param loaderPrivate      The loaderPrivate for driDrawable
+    * \param buffer_mask        Set of buffers to allocate
+    * \param buffers            Returned buffers
+    */
+   int (*getBuffers)(__DRIdrawable *driDrawable,
+                     unsigned int format,
+                     uint32_t *stamp,
+                     void *loaderPrivate,
+                     uint32_t buffer_mask,
+                     struct __DRIimageList *buffers);
+
+    /**
+     * Flush pending front-buffer rendering
+     *
+     * Any rendering that has been performed to the
+     * fake front will be flushed to the front
+     *
+     * \param driDrawable    Drawable whose front-buffer is to be flushed
+     * \param loaderPrivate  Loader's private data that was previously passed
+     *                       into __DRIdri2ExtensionRec::createNewDrawable
+     */
+    void (*flushFrontBuffer)(__DRIdrawable *driDrawable, void *loaderPrivate);
+};
+
+/**
+ * DRI extension.
+ */
+
+#define __DRI_IMAGE_DRIVER           "DRI_IMAGE_DRIVER"
+#define __DRI_IMAGE_DRIVER_VERSION   1
+
+struct __DRIimageDriverExtensionRec {
+   __DRIextension               base;
+
+   /* Common DRI functions, shared with DRI2 */
+   __DRIcreateNewScreen2Func            createNewScreen2;
+   __DRIcreateNewDrawableFunc           createNewDrawable;
+   __DRIcreateContextAttribsFunc        createContextAttribs;
+   __DRIgetAPIMaskFunc                  getAPIMask;
+};
+
+#endif

--- a/pkgs/servers/x11/xorg/darwin/function-pointer-test.patch
+++ b/pkgs/servers/x11/xorg/darwin/function-pointer-test.patch
@@ -1,0 +1,46 @@
+These are functions, not function pointers, so they always evaluate to true.
+
+diff --git a/hw/xquartz/X11Controller.m b/hw/xquartz/X11Controller.m
+index 5445c6f..8574bf1 100644
+--- a/hw/xquartz/X11Controller.m
++++ b/hw/xquartz/X11Controller.m
+@@ -364,7 +364,6 @@ extern char *bundle_id_prefix;
+     }
+ 
+ #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+-    if (asl_log_descriptor) {
+         char *asl_sender;
+         aslmsg amsg = asl_new(ASL_TYPE_MSG);
+         assert(amsg);
+@@ -394,7 +393,6 @@ extern char *bundle_id_prefix;
+         asl_log_descriptor(aslc, amsg, ASL_LEVEL_NOTICE, stderr_pipe[0], ASL_LOG_DESCRIPTOR_READ);
+ 
+         asl_free(amsg);
+-    }
+ #endif
+ 
+     /* Do the fork-twice trick to avoid having to reap zombies */
+@@ -414,11 +412,9 @@ extern char *bundle_id_prefix;
+ 
+         case 0:                                     /* child2 */
+ #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+-            if (asl_log_descriptor) {
+                 /* Replace our stdout/stderr */
+                 dup2(stdout_pipe[1], STDOUT_FILENO);
+                 dup2(stderr_pipe[1], STDERR_FILENO);
+-            }
+ #endif
+ 
+             /* close all open files except for standard streams */
+@@ -443,11 +439,9 @@ extern char *bundle_id_prefix;
+     }
+ 
+ #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+-    if (asl_log_descriptor) {
+         /* Close the write ends of the pipe */
+         close(stdout_pipe[1]);
+         close(stderr_pipe[1]);
+-    }
+ #endif
+ }
+ 

--- a/pkgs/servers/x11/xorg/darwin/private-extern.patch
+++ b/pkgs/servers/x11/xorg/darwin/private-extern.patch
@@ -1,0 +1,12 @@
+diff --git a/hw/xquartz/xpr/x-list.new.h b/hw/xquartz/xpr/x-list.h
+index 28385fd..71f9d26 100644
+--- a/hw/xquartz/xpr/x-list.new.h
++++ b/hw/xquartz/xpr/x-list.h
+@@ -45,6 +45,7 @@ struct x_list_struct {
+ #endif
+ 
+ #ifndef X_EXTERN
++#define __private_extern__ extern
+ #define X_EXTERN __private_extern__
+ #endif
+ 

--- a/pkgs/servers/x11/xorg/darwin/stub.patch
+++ b/pkgs/servers/x11/xorg/darwin/stub.patch
@@ -1,0 +1,80 @@
+cstrahan:
+
+When the X / Xquartz server initiallizes, it starts the XQuartz.app and
+hands-off the display FD. To start the XQuartz.app, Xquartz normally uses some
+system calls to get the path of the application by app bundle id, and then
+executes the Contents/MacOS/X11 script contained inside, which in turn executes
+Contents/MacOS/X11.bin (the actual app).
+
+This patch replaces that discovery technique with a simple call to
+`getenv'. In order to make Xquartz actually work, we'll need another wrapper
+that sets the `XQUARTZ_X11' environment variable to point to the `X11' script.
+
+diff --git a/hw/xquartz/mach-startup/stub.c b/hw/xquartz/mach-startup/stub.c
+index 756e4ef..3313a55 100644
+--- a/hw/xquartz/mach-startup/stub.c
++++ b/hw/xquartz/mach-startup/stub.c
+@@ -61,54 +61,16 @@ aslclient aslc;
+ static void
+ set_x11_path(void)
+ {
+-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
+-
+-    CFURLRef appURL = NULL;
+-    OSStatus osstatus =
+-        LSFindApplicationForInfo(kLSUnknownCreator, CFSTR(
+-                                     kX11AppBundleId), nil, nil, &appURL);
+-
+-    switch (osstatus) {
+-    case noErr:
+-        if (appURL == NULL) {
+-            asl_log(
+-                aslc, NULL, ASL_LEVEL_ERR,
+-                "Xquartz: Invalid response from LSFindApplicationForInfo(%s)",
+-                kX11AppBundleId);
+-            exit(1);
+-        }
+-
+-        if (!CFURLGetFileSystemRepresentation(appURL, true,
+-                                              (unsigned char *)x11_path,
+-                                              sizeof(x11_path))) {
+-            asl_log(aslc, NULL, ASL_LEVEL_ERR,
+-                    "Xquartz: Error resolving URL for %s",
+-                    kX11AppBundleId);
+-            exit(3);
+-        }
+-
+-        strlcat(x11_path, kX11AppBundlePath, sizeof(x11_path));
+-        asl_log(aslc, NULL, ASL_LEVEL_INFO, "Xquartz: X11.app = %s", x11_path);
+-        break;
+-
+-    case kLSApplicationNotFoundErr:
+-        asl_log(aslc, NULL, ASL_LEVEL_ERR,
+-                "Xquartz: Unable to find application for %s",
+-                kX11AppBundleId);
+-        exit(10);
+-
+-    default:
+-        asl_log(aslc, NULL, ASL_LEVEL_ERR,
+-                "Xquartz: Unable to find application for %s, error code = %d",
+-                kX11AppBundleId,
+-                (int)osstatus);
+-        exit(11);
++    char *xquartzX11 = getenv("XQUARTZ_X11");
++    if (xquartzX11) {
++        strlcpy(x11_path, xquartzX11,
++                sizeof(x11_path));
++    } else {
++        asl_log(
++            aslc, NULL, ASL_LEVEL_ERR,
++            "Xquartz: XQUARTZ_X11 environment variable not set");
++        exit(1);
+     }
+-#else
+-    /* TODO: Make Tiger smarter... but TBH, this should never get called on Tiger... */
+-    strlcpy(x11_path, "/Applications/Utilities/X11.app/Contents/MacOS/X11",
+-            sizeof(x11_path));
+-#endif
+ }
+ 
+ static int

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3,13 +3,18 @@ args: with args;
 
 let
 
+  mkDerivation = name: attrs:
+    let newAttrs = (overrides."${name}" or (x: x)) attrs;
+        stdenv = newAttrs.stdenv or args.stdenv;
+    in stdenv.mkDerivation (removeAttrs newAttrs [ "stdenv" ]);
+
   overrides = import ./overrides.nix {inherit args xorg;};
 
   xorg = rec {
 
   inherit pixman;
 
-  applewmproto = (stdenv.mkDerivation ((if overrides ? applewmproto then overrides.applewmproto else x: x) {
+  applewmproto = (mkDerivation "applewmproto" {
     name = "applewmproto-1.4.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -17,9 +22,9 @@ let
       sha256 = "1zi4p07mp6jmk030p4gmglwxcwp0lzs5mi31y1b4rp8lsqxdxizw";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  bdftopcf = (stdenv.mkDerivation ((if overrides ? bdftopcf then overrides.bdftopcf else x: x) {
+  bdftopcf = (mkDerivation "bdftopcf" {
     name = "bdftopcf-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -27,9 +32,9 @@ let
       sha256 = "1617zmgnx50n7vxlqyj84fl7vnk813jjqmi6jpigyz1xp9br1xga";
     };
     buildInputs = [pkgconfig libXfont ];
-  })) // {inherit libXfont ;};
+  }) // {inherit libXfont ;};
 
-  bigreqsproto = (stdenv.mkDerivation ((if overrides ? bigreqsproto then overrides.bigreqsproto else x: x) {
+  bigreqsproto = (mkDerivation "bigreqsproto" {
     name = "bigreqsproto-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -37,9 +42,9 @@ let
       sha256 = "07hvfm84scz8zjw14riiln2v4w03jlhp756ypwhq27g48jmic8a6";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  compositeproto = (stdenv.mkDerivation ((if overrides ? compositeproto then overrides.compositeproto else x: x) {
+  compositeproto = (mkDerivation "compositeproto" {
     name = "compositeproto-0.4.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -47,9 +52,9 @@ let
       sha256 = "1z0crmf669hirw4s7972mmp8xig80kfndja9h559haqbpvq5k4q4";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  damageproto = (stdenv.mkDerivation ((if overrides ? damageproto then overrides.damageproto else x: x) {
+  damageproto = (mkDerivation "damageproto" {
     name = "damageproto-1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -57,9 +62,9 @@ let
       sha256 = "0nzwr5pv9hg7c21n995pdiv0zqhs91yz3r8rn3aska4ykcp12z2w";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  dmxproto = (stdenv.mkDerivation ((if overrides ? dmxproto then overrides.dmxproto else x: x) {
+  dmxproto = (mkDerivation "dmxproto" {
     name = "dmxproto-2.3.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -67,9 +72,9 @@ let
       sha256 = "02b5x9dkgajizm8dqyx2w6hmqx3v25l67mgf35nj6sz0lgk52877";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  dri2proto = (stdenv.mkDerivation ((if overrides ? dri2proto then overrides.dri2proto else x: x) {
+  dri2proto = (mkDerivation "dri2proto" {
     name = "dri2proto-2.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -77,9 +82,9 @@ let
       sha256 = "015az1vfdqmil1yay5nlsmpf6cf7vcbpslxjb72cfkzlvrv59dgr";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  dri3proto = (stdenv.mkDerivation ((if overrides ? dri3proto then overrides.dri3proto else x: x) {
+  dri3proto = (mkDerivation "dri3proto" {
     name = "dri3proto-1.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -87,9 +92,9 @@ let
       sha256 = "0x609xvnl8jky5m8jdklw4nymx3irkv32w99dfd8nl800bblkgh1";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  encodings = (stdenv.mkDerivation ((if overrides ? encodings then overrides.encodings else x: x) {
+  encodings = (mkDerivation "encodings" {
     name = "encodings-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -97,9 +102,9 @@ let
       sha256 = "0ffmaw80vmfwdgvdkp6495xgsqszb6s0iira5j0j6pd4i0lk3mnf";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  fixesproto = (stdenv.mkDerivation ((if overrides ? fixesproto then overrides.fixesproto else x: x) {
+  fixesproto = (mkDerivation "fixesproto" {
     name = "fixesproto-5.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -107,9 +112,9 @@ let
       sha256 = "1ki4wiq2iivx5g4w5ckzbjbap759kfqd72yg18m3zpbb4hqkybxs";
     };
     buildInputs = [pkgconfig xextproto ];
-  })) // {inherit xextproto ;};
+  }) // {inherit xextproto ;};
 
-  fontadobe100dpi = (stdenv.mkDerivation ((if overrides ? fontadobe100dpi then overrides.fontadobe100dpi else x: x) {
+  fontadobe100dpi = (mkDerivation "fontadobe100dpi" {
     name = "font-adobe-100dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -117,9 +122,9 @@ let
       sha256 = "0m60f5bd0caambrk8ksknb5dks7wzsg7g7xaf0j21jxmx8rq9h5j";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontadobe75dpi = (stdenv.mkDerivation ((if overrides ? fontadobe75dpi then overrides.fontadobe75dpi else x: x) {
+  fontadobe75dpi = (mkDerivation "fontadobe75dpi" {
     name = "font-adobe-75dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -127,9 +132,9 @@ let
       sha256 = "02advcv9lyxpvrjv8bjh1b797lzg6jvhipclz49z8r8y98g4l0n6";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontadobeutopia100dpi = (stdenv.mkDerivation ((if overrides ? fontadobeutopia100dpi then overrides.fontadobeutopia100dpi else x: x) {
+  fontadobeutopia100dpi = (mkDerivation "fontadobeutopia100dpi" {
     name = "font-adobe-utopia-100dpi-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -137,9 +142,9 @@ let
       sha256 = "19dd9znam1ah72jmdh7i6ny2ss2r6m21z9v0l43xvikw48zmwvyi";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontadobeutopia75dpi = (stdenv.mkDerivation ((if overrides ? fontadobeutopia75dpi then overrides.fontadobeutopia75dpi else x: x) {
+  fontadobeutopia75dpi = (mkDerivation "fontadobeutopia75dpi" {
     name = "font-adobe-utopia-75dpi-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -147,9 +152,9 @@ let
       sha256 = "152wigpph5wvl4k9m3l4mchxxisgsnzlx033mn5iqrpkc6f72cl7";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontadobeutopiatype1 = (stdenv.mkDerivation ((if overrides ? fontadobeutopiatype1 then overrides.fontadobeutopiatype1 else x: x) {
+  fontadobeutopiatype1 = (mkDerivation "fontadobeutopiatype1" {
     name = "font-adobe-utopia-type1-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -157,9 +162,9 @@ let
       sha256 = "0xw0pdnzj5jljsbbhakc6q9ha2qnca1jr81zk7w70yl9bw83b54p";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontalias = (stdenv.mkDerivation ((if overrides ? fontalias then overrides.fontalias else x: x) {
+  fontalias = (mkDerivation "fontalias" {
     name = "font-alias-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -167,9 +172,9 @@ let
       sha256 = "16ic8wfwwr3jicaml7b5a0sk6plcgc1kg84w02881yhwmqm3nicb";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  fontarabicmisc = (stdenv.mkDerivation ((if overrides ? fontarabicmisc then overrides.fontarabicmisc else x: x) {
+  fontarabicmisc = (mkDerivation "fontarabicmisc" {
     name = "font-arabic-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -177,9 +182,9 @@ let
       sha256 = "1x246dfnxnmflzf0qzy62k8jdpkb6jkgspcjgbk8jcq9lw99npah";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontbh100dpi = (stdenv.mkDerivation ((if overrides ? fontbh100dpi then overrides.fontbh100dpi else x: x) {
+  fontbh100dpi = (mkDerivation "fontbh100dpi" {
     name = "font-bh-100dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -187,9 +192,9 @@ let
       sha256 = "10cl4gm38dw68jzln99ijix730y7cbx8np096gmpjjwff1i73h13";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontbh75dpi = (stdenv.mkDerivation ((if overrides ? fontbh75dpi then overrides.fontbh75dpi else x: x) {
+  fontbh75dpi = (mkDerivation "fontbh75dpi" {
     name = "font-bh-75dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -197,9 +202,9 @@ let
       sha256 = "073jmhf0sr2j1l8da97pzsqj805f7mf9r2gy92j4diljmi8sm1il";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontbhlucidatypewriter100dpi = (stdenv.mkDerivation ((if overrides ? fontbhlucidatypewriter100dpi then overrides.fontbhlucidatypewriter100dpi else x: x) {
+  fontbhlucidatypewriter100dpi = (mkDerivation "fontbhlucidatypewriter100dpi" {
     name = "font-bh-lucidatypewriter-100dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -207,9 +212,9 @@ let
       sha256 = "1fqzckxdzjv4802iad2fdrkpaxl4w0hhs9lxlkyraq2kq9ik7a32";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontbhlucidatypewriter75dpi = (stdenv.mkDerivation ((if overrides ? fontbhlucidatypewriter75dpi then overrides.fontbhlucidatypewriter75dpi else x: x) {
+  fontbhlucidatypewriter75dpi = (mkDerivation "fontbhlucidatypewriter75dpi" {
     name = "font-bh-lucidatypewriter-75dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -217,9 +222,9 @@ let
       sha256 = "0cfbxdp5m12cm7jsh3my0lym9328cgm7fa9faz2hqj05wbxnmhaa";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontbhttf = (stdenv.mkDerivation ((if overrides ? fontbhttf then overrides.fontbhttf else x: x) {
+  fontbhttf = (mkDerivation "fontbhttf" {
     name = "font-bh-ttf-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -227,9 +232,9 @@ let
       sha256 = "0pyjmc0ha288d4i4j0si4dh3ncf3jiwwjljvddrb0k8v4xiyljqv";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontbhtype1 = (stdenv.mkDerivation ((if overrides ? fontbhtype1 then overrides.fontbhtype1 else x: x) {
+  fontbhtype1 = (mkDerivation "fontbhtype1" {
     name = "font-bh-type1-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -237,9 +242,9 @@ let
       sha256 = "1hb3iav089albp4sdgnlh50k47cdjif9p4axm0kkjvs8jyi5a53n";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontbitstream100dpi = (stdenv.mkDerivation ((if overrides ? fontbitstream100dpi then overrides.fontbitstream100dpi else x: x) {
+  fontbitstream100dpi = (mkDerivation "fontbitstream100dpi" {
     name = "font-bitstream-100dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -247,9 +252,9 @@ let
       sha256 = "1kmn9jbck3vghz6rj3bhc3h0w6gh0qiaqm90cjkqsz1x9r2dgq7b";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontbitstream75dpi = (stdenv.mkDerivation ((if overrides ? fontbitstream75dpi then overrides.fontbitstream75dpi else x: x) {
+  fontbitstream75dpi = (mkDerivation "fontbitstream75dpi" {
     name = "font-bitstream-75dpi-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -257,9 +262,9 @@ let
       sha256 = "13plbifkvfvdfym6gjbgy9wx2xbdxi9hfrl1k22xayy02135wgxs";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontbitstreamtype1 = (stdenv.mkDerivation ((if overrides ? fontbitstreamtype1 then overrides.fontbitstreamtype1 else x: x) {
+  fontbitstreamtype1 = (mkDerivation "fontbitstreamtype1" {
     name = "font-bitstream-type1-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -267,9 +272,9 @@ let
       sha256 = "1256z0jhcf5gbh1d03593qdwnag708rxqa032izmfb5dmmlhbsn6";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontcronyxcyrillic = (stdenv.mkDerivation ((if overrides ? fontcronyxcyrillic then overrides.fontcronyxcyrillic else x: x) {
+  fontcronyxcyrillic = (mkDerivation "fontcronyxcyrillic" {
     name = "font-cronyx-cyrillic-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -277,9 +282,9 @@ let
       sha256 = "0ai1v4n61k8j9x2a1knvfbl2xjxk3xxmqaq3p9vpqrspc69k31kf";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontcursormisc = (stdenv.mkDerivation ((if overrides ? fontcursormisc then overrides.fontcursormisc else x: x) {
+  fontcursormisc = (mkDerivation "fontcursormisc" {
     name = "font-cursor-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -287,9 +292,9 @@ let
       sha256 = "0dd6vfiagjc4zmvlskrbjz85jfqhf060cpys8j0y1qpcbsrkwdhp";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontdaewoomisc = (stdenv.mkDerivation ((if overrides ? fontdaewoomisc then overrides.fontdaewoomisc else x: x) {
+  fontdaewoomisc = (mkDerivation "fontdaewoomisc" {
     name = "font-daewoo-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -297,9 +302,9 @@ let
       sha256 = "1s2bbhizzgbbbn5wqs3vw53n619cclxksljvm759h9p1prqdwrdw";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontdecmisc = (stdenv.mkDerivation ((if overrides ? fontdecmisc then overrides.fontdecmisc else x: x) {
+  fontdecmisc = (mkDerivation "fontdecmisc" {
     name = "font-dec-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -307,9 +312,9 @@ let
       sha256 = "0yzza0l4zwyy7accr1s8ab7fjqkpwggqydbm2vc19scdby5xz7g1";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontibmtype1 = (stdenv.mkDerivation ((if overrides ? fontibmtype1 then overrides.fontibmtype1 else x: x) {
+  fontibmtype1 = (mkDerivation "fontibmtype1" {
     name = "font-ibm-type1-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -317,9 +322,9 @@ let
       sha256 = "1pyjll4adch3z5cg663s6vhi02k8m6488f0mrasg81ssvg9jinzx";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontisasmisc = (stdenv.mkDerivation ((if overrides ? fontisasmisc then overrides.fontisasmisc else x: x) {
+  fontisasmisc = (mkDerivation "fontisasmisc" {
     name = "font-isas-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -327,9 +332,9 @@ let
       sha256 = "0rx8q02rkx673a7skkpnvfkg28i8gmqzgf25s9yi0lar915sn92q";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontjismisc = (stdenv.mkDerivation ((if overrides ? fontjismisc then overrides.fontjismisc else x: x) {
+  fontjismisc = (mkDerivation "fontjismisc" {
     name = "font-jis-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -337,9 +342,9 @@ let
       sha256 = "0rdc3xdz12pnv951538q6wilx8mrdndpkphpbblszsv7nc8cw61b";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontmicromisc = (stdenv.mkDerivation ((if overrides ? fontmicromisc then overrides.fontmicromisc else x: x) {
+  fontmicromisc = (mkDerivation "fontmicromisc" {
     name = "font-micro-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -347,9 +352,9 @@ let
       sha256 = "1dldxlh54zq1yzfnrh83j5vm0k4ijprrs5yl18gm3n9j1z0q2cws";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontmisccyrillic = (stdenv.mkDerivation ((if overrides ? fontmisccyrillic then overrides.fontmisccyrillic else x: x) {
+  fontmisccyrillic = (mkDerivation "fontmisccyrillic" {
     name = "font-misc-cyrillic-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -357,9 +362,9 @@ let
       sha256 = "0q2ybxs8wvylvw95j6x9i800rismsmx4b587alwbfqiw6biy63z4";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontmiscethiopic = (stdenv.mkDerivation ((if overrides ? fontmiscethiopic then overrides.fontmiscethiopic else x: x) {
+  fontmiscethiopic = (mkDerivation "fontmiscethiopic" {
     name = "font-misc-ethiopic-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -367,9 +372,9 @@ let
       sha256 = "19cq7iq0pfad0nc2v28n681fdq3fcw1l1hzaq0wpkgpx7bc1zjsk";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontmiscmeltho = (stdenv.mkDerivation ((if overrides ? fontmiscmeltho then overrides.fontmiscmeltho else x: x) {
+  fontmiscmeltho = (mkDerivation "fontmiscmeltho" {
     name = "font-misc-meltho-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -377,9 +382,9 @@ let
       sha256 = "148793fqwzrc3bmh2vlw5fdiwjc2n7vs25cic35gfp452czk489p";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  fontmiscmisc = (stdenv.mkDerivation ((if overrides ? fontmiscmisc then overrides.fontmiscmisc else x: x) {
+  fontmiscmisc = (mkDerivation "fontmiscmisc" {
     name = "font-misc-misc-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -387,9 +392,9 @@ let
       sha256 = "150pq6n8n984fah34n3k133kggn9v0c5k07igv29sxp1wi07krxq";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontmuttmisc = (stdenv.mkDerivation ((if overrides ? fontmuttmisc then overrides.fontmuttmisc else x: x) {
+  fontmuttmisc = (mkDerivation "fontmuttmisc" {
     name = "font-mutt-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -397,9 +402,9 @@ let
       sha256 = "13qghgr1zzpv64m0p42195k1kc77pksiv059fdvijz1n6kdplpxx";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontschumachermisc = (stdenv.mkDerivation ((if overrides ? fontschumachermisc then overrides.fontschumachermisc else x: x) {
+  fontschumachermisc = (mkDerivation "fontschumachermisc" {
     name = "font-schumacher-misc-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -407,9 +412,9 @@ let
       sha256 = "0nkym3n48b4v36y4s927bbkjnsmicajarnf6vlp7wxp0as304i74";
     };
     buildInputs = [pkgconfig bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
+  }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
-  fontscreencyrillic = (stdenv.mkDerivation ((if overrides ? fontscreencyrillic then overrides.fontscreencyrillic else x: x) {
+  fontscreencyrillic = (mkDerivation "fontscreencyrillic" {
     name = "font-screen-cyrillic-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -417,9 +422,9 @@ let
       sha256 = "0yayf1qlv7irf58nngddz2f1q04qkpr5jwp4aja2j5gyvzl32hl2";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontsonymisc = (stdenv.mkDerivation ((if overrides ? fontsonymisc then overrides.fontsonymisc else x: x) {
+  fontsonymisc = (mkDerivation "fontsonymisc" {
     name = "font-sony-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -427,9 +432,9 @@ let
       sha256 = "1xfgcx4gsgik5mkgkca31fj3w72jw9iw76qyrajrsz1lp8ka6hr0";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontsproto = (stdenv.mkDerivation ((if overrides ? fontsproto then overrides.fontsproto else x: x) {
+  fontsproto = (mkDerivation "fontsproto" {
     name = "fontsproto-2.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -437,9 +442,9 @@ let
       sha256 = "1ab8mbqxdwvdz4k5x4xb9c4n5w7i1xw276cbpk4z7a1nlpjrg746";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  fontsunmisc = (stdenv.mkDerivation ((if overrides ? fontsunmisc then overrides.fontsunmisc else x: x) {
+  fontsunmisc = (mkDerivation "fontsunmisc" {
     name = "font-sun-misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -447,9 +452,9 @@ let
       sha256 = "1q6jcqrffg9q5f5raivzwx9ffvf7r11g6g0b125na1bhpz5ly7s8";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontutil = (stdenv.mkDerivation ((if overrides ? fontutil then overrides.fontutil else x: x) {
+  fontutil = (mkDerivation "fontutil" {
     name = "font-util-1.3.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -457,9 +462,9 @@ let
       sha256 = "15cijajwhjzpy3ydc817zz8x5z4gbkyv3fps687jbq544mbfbafz";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  fontwinitzkicyrillic = (stdenv.mkDerivation ((if overrides ? fontwinitzkicyrillic then overrides.fontwinitzkicyrillic else x: x) {
+  fontwinitzkicyrillic = (mkDerivation "fontwinitzkicyrillic" {
     name = "font-winitzki-cyrillic-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -467,9 +472,9 @@ let
       sha256 = "181n1bgq8vxfxqicmy1jpm1hnr6gwn1kdhl6hr4frjigs1ikpldb";
     };
     buildInputs = [pkgconfig bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit bdftopcf mkfontdir ;};
+  }) // {inherit bdftopcf mkfontdir ;};
 
-  fontxfree86type1 = (stdenv.mkDerivation ((if overrides ? fontxfree86type1 then overrides.fontxfree86type1 else x: x) {
+  fontxfree86type1 = (mkDerivation "fontxfree86type1" {
     name = "font-xfree86-type1-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -477,9 +482,9 @@ let
       sha256 = "0jp3zc0qfdaqfkgzrb44vi9vi0a8ygb35wp082yz7rvvxhmg9sya";
     };
     buildInputs = [pkgconfig mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts"; 
-  })) // {inherit mkfontdir mkfontscale ;};
+  }) // {inherit mkfontdir mkfontscale ;};
 
-  gccmakedep = (stdenv.mkDerivation ((if overrides ? gccmakedep then overrides.gccmakedep else x: x) {
+  gccmakedep = (mkDerivation "gccmakedep" {
     name = "gccmakedep-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -487,9 +492,9 @@ let
       sha256 = "1r1fpy5ni8chbgx7j5sz0008fpb6vbazpy1nifgdhgijyzqxqxdj";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  glamoregl = (stdenv.mkDerivation ((if overrides ? glamoregl then overrides.glamoregl else x: x) {
+  glamoregl = (mkDerivation "glamoregl" {
     name = "glamor-egl-0.6.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -497,9 +502,9 @@ let
       sha256 = "1jg5clihklb9drh1jd7nhhdsszla6nv7xmbvm8yvakh5wrb1nlv6";
     };
     buildInputs = [pkgconfig dri2proto xorgserver ];
-  })) // {inherit dri2proto xorgserver ;};
+  }) // {inherit dri2proto xorgserver ;};
 
-  glproto = (stdenv.mkDerivation ((if overrides ? glproto then overrides.glproto else x: x) {
+  glproto = (mkDerivation "glproto" {
     name = "glproto-1.4.17";
     builder = ./builder.sh;
     src = fetchurl {
@@ -507,9 +512,9 @@ let
       sha256 = "0h5ykmcddwid5qj6sbrszgkcypwn3mslvswxpgy2n2iixnyr9amd";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  iceauth = (stdenv.mkDerivation ((if overrides ? iceauth then overrides.iceauth else x: x) {
+  iceauth = (mkDerivation "iceauth" {
     name = "iceauth-1.0.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -517,9 +522,9 @@ let
       sha256 = "1x72y99dxf2fxnlyf0yrf9yzd8xzimxshy6l8mprwhrv6lvhi6dx";
     };
     buildInputs = [pkgconfig libICE xproto ];
-  })) // {inherit libICE xproto ;};
+  }) // {inherit libICE xproto ;};
 
-  imake = (stdenv.mkDerivation ((if overrides ? imake then overrides.imake else x: x) {
+  imake = (mkDerivation "imake" {
     name = "imake-1.0.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -527,9 +532,9 @@ let
       sha256 = "0zpk8p044jh14bis838shbf4100bjg7mccd7bq54glpsq552q339";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  inputproto = (stdenv.mkDerivation ((if overrides ? inputproto then overrides.inputproto else x: x) {
+  inputproto = (mkDerivation "inputproto" {
     name = "inputproto-2.3.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -537,9 +542,9 @@ let
       sha256 = "1lf1jlxp0fc8h6fjdffhd084dqab94966l1zm3rwwsis0mifwiss";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  kbproto = (stdenv.mkDerivation ((if overrides ? kbproto then overrides.kbproto else x: x) {
+  kbproto = (mkDerivation "kbproto" {
     name = "kbproto-1.0.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -547,9 +552,9 @@ let
       sha256 = "0yal11hhpiisy3w8wmacsdzzzcnc3xwnswxz8k7zri40xc5aqz03";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  libAppleWM = (stdenv.mkDerivation ((if overrides ? libAppleWM then overrides.libAppleWM else x: x) {
+  libAppleWM = (mkDerivation "libAppleWM" {
     name = "libAppleWM-1.4.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -557,9 +562,9 @@ let
       sha256 = "0r8x28n45q89x91mz8mv0zkkcxi8wazkac886fyvflhiv2y8ap2y";
     };
     buildInputs = [pkgconfig applewmproto libX11 libXext xextproto ];
-  })) // {inherit applewmproto libX11 libXext xextproto ;};
+  }) // {inherit applewmproto libX11 libXext xextproto ;};
 
-  libFS = (stdenv.mkDerivation ((if overrides ? libFS then overrides.libFS else x: x) {
+  libFS = (mkDerivation "libFS" {
     name = "libFS-1.0.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -567,9 +572,9 @@ let
       sha256 = "1mxfsvj9m3pn8cdkcn4kg190zp665mf4pv0083g6xykvsgxzq1wh";
     };
     buildInputs = [pkgconfig fontsproto xproto xtrans ];
-  })) // {inherit fontsproto xproto xtrans ;};
+  }) // {inherit fontsproto xproto xtrans ;};
 
-  libICE = (stdenv.mkDerivation ((if overrides ? libICE then overrides.libICE else x: x) {
+  libICE = (mkDerivation "libICE" {
     name = "libICE-1.0.9";
     builder = ./builder.sh;
     src = fetchurl {
@@ -577,9 +582,9 @@ let
       sha256 = "00p2b6bsg6kcdbb39bv46339qcywxfl4hsrz8asm4hy6q7r34w4g";
     };
     buildInputs = [pkgconfig xproto xtrans ];
-  })) // {inherit xproto xtrans ;};
+  }) // {inherit xproto xtrans ;};
 
-  libSM = (stdenv.mkDerivation ((if overrides ? libSM then overrides.libSM else x: x) {
+  libSM = (mkDerivation "libSM" {
     name = "libSM-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -587,9 +592,9 @@ let
       sha256 = "1gc7wavgs435g9qkp9jw4lhmaiq6ip9llv49f054ad6ryp4sib0b";
     };
     buildInputs = [pkgconfig libICE libuuid xproto xtrans ];
-  })) // {inherit libICE libuuid xproto xtrans ;};
+  }) // {inherit libICE libuuid xproto xtrans ;};
 
-  libWindowsWM = (stdenv.mkDerivation ((if overrides ? libWindowsWM then overrides.libWindowsWM else x: x) {
+  libWindowsWM = (mkDerivation "libWindowsWM" {
     name = "libWindowsWM-1.0.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -597,9 +602,9 @@ let
       sha256 = "1p0flwb67xawyv6yhri9w17m1i4lji5qnd0gq8v1vsfb8zw7rw15";
     };
     buildInputs = [pkgconfig windowswmproto libX11 libXext xextproto ];
-  })) // {inherit windowswmproto libX11 libXext xextproto ;};
+  }) // {inherit windowswmproto libX11 libXext xextproto ;};
 
-  libX11 = (stdenv.mkDerivation ((if overrides ? libX11 then overrides.libX11 else x: x) {
+  libX11 = (mkDerivation "libX11" {
     name = "libX11-1.6.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -607,9 +612,9 @@ let
       sha256 = "05mx0s0vqzds3qjc1gmjr2s6x2ll37z4lfhgm7p2w7936zl2g81a";
     };
     buildInputs = [pkgconfig inputproto kbproto libxcb xextproto xf86bigfontproto xproto xtrans ];
-  })) // {inherit inputproto kbproto libxcb xextproto xf86bigfontproto xproto xtrans ;};
+  }) // {inherit inputproto kbproto libxcb xextproto xf86bigfontproto xproto xtrans ;};
 
-  libXScrnSaver = (stdenv.mkDerivation ((if overrides ? libXScrnSaver then overrides.libXScrnSaver else x: x) {
+  libXScrnSaver = (mkDerivation "libXScrnSaver" {
     name = "libXScrnSaver-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -617,9 +622,9 @@ let
       sha256 = "07ff4r20nkkrj7h08f9fwamds9b3imj8jz5iz6y38zqw6jkyzwcg";
     };
     buildInputs = [pkgconfig scrnsaverproto libX11 libXext xextproto ];
-  })) // {inherit scrnsaverproto libX11 libXext xextproto ;};
+  }) // {inherit scrnsaverproto libX11 libXext xextproto ;};
 
-  libXau = (stdenv.mkDerivation ((if overrides ? libXau then overrides.libXau else x: x) {
+  libXau = (mkDerivation "libXau" {
     name = "libXau-1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -627,9 +632,9 @@ let
       sha256 = "1wm4pv12f36cwzhldpp7vy3lhm3xdcnp4f184xkxsp7b18r7gm7x";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  libXaw = (stdenv.mkDerivation ((if overrides ? libXaw then overrides.libXaw else x: x) {
+  libXaw = (mkDerivation "libXaw" {
     name = "libXaw-1.0.12";
     builder = ./builder.sh;
     src = fetchurl {
@@ -637,9 +642,9 @@ let
       sha256 = "1xnv7jy86j9vhmw74frkzcraynqbw1p1s79jasargsgwfi433z4n";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto libXmu libXpm xproto libXt ];
-  })) // {inherit libX11 libXext xextproto libXmu libXpm xproto libXt ;};
+  }) // {inherit libX11 libXext xextproto libXmu libXpm xproto libXt ;};
 
-  libXcomposite = (stdenv.mkDerivation ((if overrides ? libXcomposite then overrides.libXcomposite else x: x) {
+  libXcomposite = (mkDerivation "libXcomposite" {
     name = "libXcomposite-0.4.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -647,9 +652,9 @@ let
       sha256 = "0y21nfpa5s8qmx0srdlilyndas3sgl0c6rc26d5fx2vx436m1qpd";
     };
     buildInputs = [pkgconfig compositeproto libX11 libXfixes xproto ];
-  })) // {inherit compositeproto libX11 libXfixes xproto ;};
+  }) // {inherit compositeproto libX11 libXfixes xproto ;};
 
-  libXcursor = (stdenv.mkDerivation ((if overrides ? libXcursor then overrides.libXcursor else x: x) {
+  libXcursor = (mkDerivation "libXcursor" {
     name = "libXcursor-1.1.14";
     builder = ./builder.sh;
     src = fetchurl {
@@ -657,9 +662,9 @@ let
       sha256 = "1prkdicl5y5yx32h1azh6gjfbijvjp415javv8dsakd13jrarilv";
     };
     buildInputs = [pkgconfig fixesproto libX11 libXfixes xproto libXrender ];
-  })) // {inherit fixesproto libX11 libXfixes xproto libXrender ;};
+  }) // {inherit fixesproto libX11 libXfixes xproto libXrender ;};
 
-  libXdamage = (stdenv.mkDerivation ((if overrides ? libXdamage then overrides.libXdamage else x: x) {
+  libXdamage = (mkDerivation "libXdamage" {
     name = "libXdamage-1.1.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -667,9 +672,9 @@ let
       sha256 = "1bamagq7g6s0d23l8rb3nppj8ifqj05f7z9bhbs4fdg8az3ffgvw";
     };
     buildInputs = [pkgconfig damageproto fixesproto libX11 xextproto libXfixes xproto ];
-  })) // {inherit damageproto fixesproto libX11 xextproto libXfixes xproto ;};
+  }) // {inherit damageproto fixesproto libX11 xextproto libXfixes xproto ;};
 
-  libXdmcp = (stdenv.mkDerivation ((if overrides ? libXdmcp then overrides.libXdmcp else x: x) {
+  libXdmcp = (mkDerivation "libXdmcp" {
     name = "libXdmcp-1.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -677,9 +682,9 @@ let
       sha256 = "13highx4xpgkiwykpcl7z2laslrjc4pzi4h617ny9p7r6116vkls";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  libXext = (stdenv.mkDerivation ((if overrides ? libXext then overrides.libXext else x: x) {
+  libXext = (mkDerivation "libXext" {
     name = "libXext-1.3.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -687,9 +692,9 @@ let
       sha256 = "0dbfn5bznnrhqzvkrcmw4c44yvvpwdcsrvzxf4rk27r36b9x865m";
     };
     buildInputs = [pkgconfig libX11 xextproto xproto ];
-  })) // {inherit libX11 xextproto xproto ;};
+  }) // {inherit libX11 xextproto xproto ;};
 
-  libXfixes = (stdenv.mkDerivation ((if overrides ? libXfixes then overrides.libXfixes else x: x) {
+  libXfixes = (mkDerivation "libXfixes" {
     name = "libXfixes-5.0.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -697,9 +702,9 @@ let
       sha256 = "0rs7qgzr6dpr62db7sd91c1b47hzhzfr010qwnpcm8sg122w1gk3";
     };
     buildInputs = [pkgconfig fixesproto libX11 xextproto xproto ];
-  })) // {inherit fixesproto libX11 xextproto xproto ;};
+  }) // {inherit fixesproto libX11 xextproto xproto ;};
 
-  libXfont = (stdenv.mkDerivation ((if overrides ? libXfont then overrides.libXfont else x: x) {
+  libXfont = (mkDerivation "libXfont" {
     name = "libXfont-1.4.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -707,9 +712,9 @@ let
       sha256 = "01fh2hnnaby8x6mv57x78nsqwhls70gwykldzd8b43vrpzzd8s2m";
     };
     buildInputs = [pkgconfig libfontenc fontsproto freetype xproto xtrans zlib ];
-  })) // {inherit libfontenc fontsproto freetype xproto xtrans zlib ;};
+  }) // {inherit libfontenc fontsproto freetype xproto xtrans zlib ;};
 
-  libXft = (stdenv.mkDerivation ((if overrides ? libXft then overrides.libXft else x: x) {
+  libXft = (mkDerivation "libXft" {
     name = "libXft-2.3.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -717,9 +722,9 @@ let
       sha256 = "0k6wzi5rzs0d0n338ms8n8lfyhq914hw4yl2j7553wqxfqjci8zm";
     };
     buildInputs = [pkgconfig fontconfig freetype libX11 xproto libXrender ];
-  })) // {inherit fontconfig freetype libX11 xproto libXrender ;};
+  }) // {inherit fontconfig freetype libX11 xproto libXrender ;};
 
-  libXi = (stdenv.mkDerivation ((if overrides ? libXi then overrides.libXi else x: x) {
+  libXi = (mkDerivation "libXi" {
     name = "libXi-1.7.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -727,9 +732,9 @@ let
       sha256 = "0i12lj973grlp9fa79v0vh9cahk3nf9csdjnf81iip0qcrlc5zrc";
     };
     buildInputs = [pkgconfig inputproto libX11 libXext xextproto libXfixes xproto ];
-  })) // {inherit inputproto libX11 libXext xextproto libXfixes xproto ;};
+  }) // {inherit inputproto libX11 libXext xextproto libXfixes xproto ;};
 
-  libXinerama = (stdenv.mkDerivation ((if overrides ? libXinerama then overrides.libXinerama else x: x) {
+  libXinerama = (mkDerivation "libXinerama" {
     name = "libXinerama-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -737,9 +742,9 @@ let
       sha256 = "1qlqfvzw45gdzk9xirgwlp2qgj0hbsyiqj8yh8zml2bk2ygnjibs";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto xineramaproto ];
-  })) // {inherit libX11 libXext xextproto xineramaproto ;};
+  }) // {inherit libX11 libXext xextproto xineramaproto ;};
 
-  libXmu = (stdenv.mkDerivation ((if overrides ? libXmu then overrides.libXmu else x: x) {
+  libXmu = (mkDerivation "libXmu" {
     name = "libXmu-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -747,9 +752,9 @@ let
       sha256 = "02wx6jw7i0q5qwx87yf94fsn3h0xpz1k7dz1nkwfwm1j71ydqvkm";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto xproto libXt ];
-  })) // {inherit libX11 libXext xextproto xproto libXt ;};
+  }) // {inherit libX11 libXext xextproto xproto libXt ;};
 
-  libXp = (stdenv.mkDerivation ((if overrides ? libXp then overrides.libXp else x: x) {
+  libXp = (mkDerivation "libXp" {
     name = "libXp-1.0.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -757,9 +762,9 @@ let
       sha256 = "1dfh5w8sjz5b5fl6dl4y63ckq99snslz7bir8zq2rg8ax6syabwm";
     };
     buildInputs = [pkgconfig printproto libX11 libXau libXext xextproto ];
-  })) // {inherit printproto libX11 libXau libXext xextproto ;};
+  }) // {inherit printproto libX11 libXau libXext xextproto ;};
 
-  libXpm = (stdenv.mkDerivation ((if overrides ? libXpm then overrides.libXpm else x: x) {
+  libXpm = (mkDerivation "libXpm" {
     name = "libXpm-3.5.11";
     builder = ./builder.sh;
     src = fetchurl {
@@ -767,9 +772,9 @@ let
       sha256 = "07041q4k8m4nirzl7lrqn8by2zylx0xvh6n0za301qqs3njszgf5";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto xproto libXt ];
-  })) // {inherit libX11 libXext xextproto xproto libXt ;};
+  }) // {inherit libX11 libXext xextproto xproto libXt ;};
 
-  libXrandr = (stdenv.mkDerivation ((if overrides ? libXrandr then overrides.libXrandr else x: x) {
+  libXrandr = (mkDerivation "libXrandr" {
     name = "libXrandr-1.4.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -777,9 +782,9 @@ let
       sha256 = "1b95p3l84ppv6j7dbbmg0zrz6k8xdwvnag1l6ajm3gk9qwdb79ya";
     };
     buildInputs = [pkgconfig randrproto renderproto libX11 libXext xextproto xproto libXrender ];
-  })) // {inherit randrproto renderproto libX11 libXext xextproto xproto libXrender ;};
+  }) // {inherit randrproto renderproto libX11 libXext xextproto xproto libXrender ;};
 
-  libXrender = (stdenv.mkDerivation ((if overrides ? libXrender then overrides.libXrender else x: x) {
+  libXrender = (mkDerivation "libXrender" {
     name = "libXrender-0.9.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -787,9 +792,9 @@ let
       sha256 = "0qpwyjhbpp734vnhca992pjh4w7ijslidkzx1pcwbbk000pv050x";
     };
     buildInputs = [pkgconfig renderproto libX11 xproto ];
-  })) // {inherit renderproto libX11 xproto ;};
+  }) // {inherit renderproto libX11 xproto ;};
 
-  libXres = (stdenv.mkDerivation ((if overrides ? libXres then overrides.libXres else x: x) {
+  libXres = (mkDerivation "libXres" {
     name = "libXres-1.0.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -797,9 +802,9 @@ let
       sha256 = "1rd0bzn67cpb2qkc946gch2183r4bdjfhs6cpqbipy47m9a91296";
     };
     buildInputs = [pkgconfig resourceproto libX11 libXext xextproto xproto ];
-  })) // {inherit resourceproto libX11 libXext xextproto xproto ;};
+  }) // {inherit resourceproto libX11 libXext xextproto xproto ;};
 
-  libXt = (stdenv.mkDerivation ((if overrides ? libXt then overrides.libXt else x: x) {
+  libXt = (mkDerivation "libXt" {
     name = "libXt-1.1.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -807,9 +812,9 @@ let
       sha256 = "0myxwbx9ylam5x3ia5b5f4x8azcqdm420h9ad1r4hrgmi2lrffl4";
     };
     buildInputs = [pkgconfig libICE kbproto libSM libX11 xproto ];
-  })) // {inherit libICE kbproto libSM libX11 xproto ;};
+  }) // {inherit libICE kbproto libSM libX11 xproto ;};
 
-  libXtst = (stdenv.mkDerivation ((if overrides ? libXtst then overrides.libXtst else x: x) {
+  libXtst = (mkDerivation "libXtst" {
     name = "libXtst-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -817,9 +822,9 @@ let
       sha256 = "1ngn161nq679ffmbwl81i2hn75jjg5b3ffv6n4jilpvyazypy2pg";
     };
     buildInputs = [pkgconfig inputproto recordproto libX11 libXext xextproto libXi ];
-  })) // {inherit inputproto recordproto libX11 libXext xextproto libXi ;};
+  }) // {inherit inputproto recordproto libX11 libXext xextproto libXi ;};
 
-  libXv = (stdenv.mkDerivation ((if overrides ? libXv then overrides.libXv else x: x) {
+  libXv = (mkDerivation "libXv" {
     name = "libXv-1.0.10";
     builder = ./builder.sh;
     src = fetchurl {
@@ -827,9 +832,9 @@ let
       sha256 = "09a5j6bisysiipd0nw6s352565bp0n6gbyhv5hp63s3cd3w95zjm";
     };
     buildInputs = [pkgconfig videoproto libX11 libXext xextproto xproto ];
-  })) // {inherit videoproto libX11 libXext xextproto xproto ;};
+  }) // {inherit videoproto libX11 libXext xextproto xproto ;};
 
-  libXvMC = (stdenv.mkDerivation ((if overrides ? libXvMC then overrides.libXvMC else x: x) {
+  libXvMC = (mkDerivation "libXvMC" {
     name = "libXvMC-1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -837,9 +842,9 @@ let
       sha256 = "015jk3bxfmj6zaw99x282f9npi8qqaw34yg186frags3z8g406jy";
     };
     buildInputs = [pkgconfig videoproto libX11 libXext xextproto xproto libXv ];
-  })) // {inherit videoproto libX11 libXext xextproto xproto libXv ;};
+  }) // {inherit videoproto libX11 libXext xextproto xproto libXv ;};
 
-  libXxf86dga = (stdenv.mkDerivation ((if overrides ? libXxf86dga then overrides.libXxf86dga else x: x) {
+  libXxf86dga = (mkDerivation "libXxf86dga" {
     name = "libXxf86dga-1.1.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -847,9 +852,9 @@ let
       sha256 = "0zn7aqj8x0951d8zb2h2andldvwkzbsc4cs7q023g6nzq6vd9v4f";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto xf86dgaproto xproto ];
-  })) // {inherit libX11 libXext xextproto xf86dgaproto xproto ;};
+  }) // {inherit libX11 libXext xextproto xf86dgaproto xproto ;};
 
-  libXxf86misc = (stdenv.mkDerivation ((if overrides ? libXxf86misc then overrides.libXxf86misc else x: x) {
+  libXxf86misc = (mkDerivation "libXxf86misc" {
     name = "libXxf86misc-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -857,9 +862,9 @@ let
       sha256 = "0nvbq9y6k6m9hxdvg3crycqsnnxf1859wrisqcs37z9fhq044gsn";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto xf86miscproto xproto ];
-  })) // {inherit libX11 libXext xextproto xf86miscproto xproto ;};
+  }) // {inherit libX11 libXext xextproto xf86miscproto xproto ;};
 
-  libXxf86vm = (stdenv.mkDerivation ((if overrides ? libXxf86vm then overrides.libXxf86vm else x: x) {
+  libXxf86vm = (mkDerivation "libXxf86vm" {
     name = "libXxf86vm-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -867,9 +872,9 @@ let
       sha256 = "1f1pxj018nk7ybxv58jmn5y8gm2288p4q3l2dng9n1p25v1qcpns";
     };
     buildInputs = [pkgconfig libX11 libXext xextproto xf86vidmodeproto xproto ];
-  })) // {inherit libX11 libXext xextproto xf86vidmodeproto xproto ;};
+  }) // {inherit libX11 libXext xextproto xf86vidmodeproto xproto ;};
 
-  libdmx = (stdenv.mkDerivation ((if overrides ? libdmx then overrides.libdmx else x: x) {
+  libdmx = (mkDerivation "libdmx" {
     name = "libdmx-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -877,9 +882,9 @@ let
       sha256 = "00djlxas38kbsrglcmwmxfbmxjdchlbj95pqwjvdg8jn5rns6zf9";
     };
     buildInputs = [pkgconfig dmxproto libX11 libXext xextproto ];
-  })) // {inherit dmxproto libX11 libXext xextproto ;};
+  }) // {inherit dmxproto libX11 libXext xextproto ;};
 
-  libfontenc = (stdenv.mkDerivation ((if overrides ? libfontenc then overrides.libfontenc else x: x) {
+  libfontenc = (mkDerivation "libfontenc" {
     name = "libfontenc-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -887,9 +892,9 @@ let
       sha256 = "0qign0ivqk166l9yfd51gw9lbhgs718bcrmvc40yicjr6gnyz959";
     };
     buildInputs = [pkgconfig xproto zlib ];
-  })) // {inherit xproto zlib ;};
+  }) // {inherit xproto zlib ;};
 
-  libpciaccess = (stdenv.mkDerivation ((if overrides ? libpciaccess then overrides.libpciaccess else x: x) {
+  libpciaccess = (mkDerivation "libpciaccess" {
     name = "libpciaccess-0.13.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -897,9 +902,9 @@ let
       sha256 = "06fy43n3c450h7xqpn3094bnfn7ca1mrq3i856y8kyqa0lmqraxb";
     };
     buildInputs = [pkgconfig zlib ];
-  })) // {inherit zlib ;};
+  }) // {inherit zlib ;};
 
-  libpthreadstubs = (stdenv.mkDerivation ((if overrides ? libpthreadstubs then overrides.libpthreadstubs else x: x) {
+  libpthreadstubs = (mkDerivation "libpthreadstubs" {
     name = "libpthread-stubs-0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -907,9 +912,9 @@ let
       sha256 = "16bjv3in19l84hbri41iayvvg4ls9gv1ma0x0qlbmwy67i7dbdim";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  libxcb = (stdenv.mkDerivation ((if overrides ? libxcb then overrides.libxcb else x: x) {
+  libxcb = (mkDerivation "libxcb" {
     name = "libxcb-1.10";
     builder = ./builder.sh;
     src = fetchurl {
@@ -917,9 +922,9 @@ let
       sha256 = "1dfmyb1zjx6n0zhr4y40mc1crlmj3bfjjhmn0f30ip9nnq2spncq";
     };
     buildInputs = [pkgconfig libxslt libpthreadstubs python libXau xcbproto libXdmcp ];
-  })) // {inherit libxslt libpthreadstubs python libXau xcbproto libXdmcp ;};
+  }) // {inherit libxslt libpthreadstubs python libXau xcbproto libXdmcp ;};
 
-  libxkbfile = (stdenv.mkDerivation ((if overrides ? libxkbfile then overrides.libxkbfile else x: x) {
+  libxkbfile = (mkDerivation "libxkbfile" {
     name = "libxkbfile-1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -927,9 +932,9 @@ let
       sha256 = "0flg5arw6n3njagmsi4i4l0zl5bfx866a1h9ydc3bi1pqlclxaca";
     };
     buildInputs = [pkgconfig kbproto libX11 ];
-  })) // {inherit kbproto libX11 ;};
+  }) // {inherit kbproto libX11 ;};
 
-  libxshmfence = (stdenv.mkDerivation ((if overrides ? libxshmfence then overrides.libxshmfence else x: x) {
+  libxshmfence = (mkDerivation "libxshmfence" {
     name = "libxshmfence-1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -937,9 +942,9 @@ let
       sha256 = "1gnfb1z8sbbdc3xpz1zmm94lv7yvfh4kvip9s5pj37ya4llxphnv";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  lndir = (stdenv.mkDerivation ((if overrides ? lndir then overrides.lndir else x: x) {
+  lndir = (mkDerivation "lndir" {
     name = "lndir-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -947,9 +952,9 @@ let
       sha256 = "0pdngiy8zdhsiqx2am75yfcl36l7kd7d7nl0rss8shcdvsqgmx29";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  luit = (stdenv.mkDerivation ((if overrides ? luit then overrides.luit else x: x) {
+  luit = (mkDerivation "luit" {
     name = "luit-1.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -957,9 +962,9 @@ let
       sha256 = "0dn694mk56x6hdk6y9ylx4f128h5jcin278gnw2gb807rf3ygc1h";
     };
     buildInputs = [pkgconfig libfontenc ];
-  })) // {inherit libfontenc ;};
+  }) // {inherit libfontenc ;};
 
-  makedepend = (stdenv.mkDerivation ((if overrides ? makedepend then overrides.makedepend else x: x) {
+  makedepend = (mkDerivation "makedepend" {
     name = "makedepend-1.0.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -967,9 +972,9 @@ let
       sha256 = "09alw99r6y2bbd1dc786n3jfgv4j520apblyn7cw6jkjydshba7p";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  mkfontdir = (stdenv.mkDerivation ((if overrides ? mkfontdir then overrides.mkfontdir else x: x) {
+  mkfontdir = (mkDerivation "mkfontdir" {
     name = "mkfontdir-1.0.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -977,9 +982,9 @@ let
       sha256 = "0c3563kw9fg15dpgx4dwvl12qz6sdqdns1pxa574hc7i5m42mman";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  mkfontscale = (stdenv.mkDerivation ((if overrides ? mkfontscale then overrides.mkfontscale else x: x) {
+  mkfontscale = (mkDerivation "mkfontscale" {
     name = "mkfontscale-1.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -987,9 +992,9 @@ let
       sha256 = "0cdpn1ii2iw1vg2ga4w62acrh78gzgf0vza4g8wx5kkp4jcifh14";
     };
     buildInputs = [pkgconfig libfontenc freetype xproto zlib ];
-  })) // {inherit libfontenc freetype xproto zlib ;};
+  }) // {inherit libfontenc freetype xproto zlib ;};
 
-  presentproto = (stdenv.mkDerivation ((if overrides ? presentproto then overrides.presentproto else x: x) {
+  presentproto = (mkDerivation "presentproto" {
     name = "presentproto-1.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -997,9 +1002,9 @@ let
       sha256 = "1kir51aqg9cwazs14ivcldcn3mzadqgykc9cg87rm40zf947sb41";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  printproto = (stdenv.mkDerivation ((if overrides ? printproto then overrides.printproto else x: x) {
+  printproto = (mkDerivation "printproto" {
     name = "printproto-1.0.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1007,9 +1012,9 @@ let
       sha256 = "06liap8n4s25sgp27d371cc7yg9a08dxcr3pmdjp761vyin3360j";
     };
     buildInputs = [pkgconfig libXau ];
-  })) // {inherit libXau ;};
+  }) // {inherit libXau ;};
 
-  randrproto = (stdenv.mkDerivation ((if overrides ? randrproto then overrides.randrproto else x: x) {
+  randrproto = (mkDerivation "randrproto" {
     name = "randrproto-1.4.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1017,9 +1022,9 @@ let
       sha256 = "1kq9h93qdnniiivry8jmhlgwn9fbx9xp5r9cmzfihlx5cs62xi45";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  recordproto = (stdenv.mkDerivation ((if overrides ? recordproto then overrides.recordproto else x: x) {
+  recordproto = (mkDerivation "recordproto" {
     name = "recordproto-1.14.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1027,9 +1032,9 @@ let
       sha256 = "0w3kgr1zabwf79bpc28dcnj0fpni6r53rpi82ngjbalj5s6m8xx7";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  renderproto = (stdenv.mkDerivation ((if overrides ? renderproto then overrides.renderproto else x: x) {
+  renderproto = (mkDerivation "renderproto" {
     name = "renderproto-0.11.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1037,9 +1042,9 @@ let
       sha256 = "0dr5xw6s0qmqg0q5pdkb4jkdhaja0vbfqla79qh5j1xjj9dmlwq6";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  resourceproto = (stdenv.mkDerivation ((if overrides ? resourceproto then overrides.resourceproto else x: x) {
+  resourceproto = (mkDerivation "resourceproto" {
     name = "resourceproto-1.2.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1047,9 +1052,9 @@ let
       sha256 = "0638iyfiiyjw1hg3139pai0j6m65gkskrvd9684zgc6ydcx00riw";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  scrnsaverproto = (stdenv.mkDerivation ((if overrides ? scrnsaverproto then overrides.scrnsaverproto else x: x) {
+  scrnsaverproto = (mkDerivation "scrnsaverproto" {
     name = "scrnsaverproto-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1057,9 +1062,9 @@ let
       sha256 = "0rfdbfwd35d761xkfifcscx56q0n56043ixlmv70r4v4l66hmdwb";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  sessreg = (stdenv.mkDerivation ((if overrides ? sessreg then overrides.sessreg else x: x) {
+  sessreg = (mkDerivation "sessreg" {
     name = "sessreg-1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1067,9 +1072,9 @@ let
       sha256 = "1hy4wvgawajf4qw2k51fkcjzxw0drx60ydzpmqhj7k1g4z3cqahf";
     };
     buildInputs = [pkgconfig xproto ];
-  })) // {inherit xproto ;};
+  }) // {inherit xproto ;};
 
-  setxkbmap = (stdenv.mkDerivation ((if overrides ? setxkbmap then overrides.setxkbmap else x: x) {
+  setxkbmap = (mkDerivation "setxkbmap" {
     name = "setxkbmap-1.3.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1077,9 +1082,9 @@ let
       sha256 = "1inygpvlgc6vr5h9laxw9lnvafnccl3fy0g5n9ll28iq3yfmqc1x";
     };
     buildInputs = [pkgconfig libX11 libxkbfile ];
-  })) // {inherit libX11 libxkbfile ;};
+  }) // {inherit libX11 libxkbfile ;};
 
-  smproxy = (stdenv.mkDerivation ((if overrides ? smproxy then overrides.smproxy else x: x) {
+  smproxy = (mkDerivation "smproxy" {
     name = "smproxy-1.0.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1087,9 +1092,9 @@ let
       sha256 = "02fn5wa1gs2jap6sr9j9yk6zsvz82j8l61pf74iyqwa99q4wnb67";
     };
     buildInputs = [pkgconfig libICE libSM libXmu libXt ];
-  })) // {inherit libICE libSM libXmu libXt ;};
+  }) // {inherit libICE libSM libXmu libXt ;};
 
-  twm = (stdenv.mkDerivation ((if overrides ? twm then overrides.twm else x: x) {
+  twm = (mkDerivation "twm" {
     name = "twm-1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1097,9 +1102,9 @@ let
       sha256 = "0i1ff8h2gh1ab311da5dlhl0nrma0qbrk403ymzi4cnnacikaq3n";
     };
     buildInputs = [pkgconfig libICE libSM libX11 libXext libXmu xproto libXt ];
-  })) // {inherit libICE libSM libX11 libXext libXmu xproto libXt ;};
+  }) // {inherit libICE libSM libX11 libXext libXmu xproto libXt ;};
 
-  utilmacros = (stdenv.mkDerivation ((if overrides ? utilmacros then overrides.utilmacros else x: x) {
+  utilmacros = (mkDerivation "utilmacros" {
     name = "util-macros-1.19.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1107,9 +1112,9 @@ let
       sha256 = "1fnhpryf55l0yqajxn0cxan3kvsjzi67nlanz8clwqzf54cb2d98";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  videoproto = (stdenv.mkDerivation ((if overrides ? videoproto then overrides.videoproto else x: x) {
+  videoproto = (mkDerivation "videoproto" {
     name = "videoproto-2.3.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1117,9 +1122,9 @@ let
       sha256 = "1dnlkd9nb0m135lgd6hd61vc29sdyarsyya8aqpx7z10p261dbld";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  windowswmproto = (stdenv.mkDerivation ((if overrides ? windowswmproto then overrides.windowswmproto else x: x) {
+  windowswmproto = (mkDerivation "windowswmproto" {
     name = "windowswmproto-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1127,9 +1132,9 @@ let
       sha256 = "0syjxgy4m8l94qrm03nvn5k6bkxc8knnlld1gbllym97nvnv0ny0";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  x11perf = (stdenv.mkDerivation ((if overrides ? x11perf then overrides.x11perf else x: x) {
+  x11perf = (mkDerivation "x11perf" {
     name = "x11perf-1.5.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1137,9 +1142,9 @@ let
       sha256 = "111iwpxhnxjiq44w96zf0kszg5zpgv1g3ayx18v4nhdzl9bqivi4";
     };
     buildInputs = [pkgconfig libX11 libXext libXft libXmu libXrender ];
-  })) // {inherit libX11 libXext libXft libXmu libXrender ;};
+  }) // {inherit libX11 libXext libXft libXmu libXrender ;};
 
-  xauth = (stdenv.mkDerivation ((if overrides ? xauth then overrides.xauth else x: x) {
+  xauth = (mkDerivation "xauth" {
     name = "xauth-1.0.9";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1147,9 +1152,9 @@ let
       sha256 = "13y2invb0894b1in03jbglximbz6v31y2kr4yjjgica8xciibkjn";
     };
     buildInputs = [pkgconfig libX11 libXau libXext libXmu xproto ];
-  })) // {inherit libX11 libXau libXext libXmu xproto ;};
+  }) // {inherit libX11 libXau libXext libXmu xproto ;};
 
-  xbacklight = (stdenv.mkDerivation ((if overrides ? xbacklight then overrides.xbacklight else x: x) {
+  xbacklight = (mkDerivation "xbacklight" {
     name = "xbacklight-1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1157,9 +1162,9 @@ let
       sha256 = "0arnd1j8vzhzmw72mqhjjcb2qwcbs9qphsy3ps593ajyld8wzxhp";
     };
     buildInputs = [pkgconfig libxcb xcbutil ];
-  })) // {inherit libxcb xcbutil ;};
+  }) // {inherit libxcb xcbutil ;};
 
-  xbitmaps = (stdenv.mkDerivation ((if overrides ? xbitmaps then overrides.xbitmaps else x: x) {
+  xbitmaps = (mkDerivation "xbitmaps" {
     name = "xbitmaps-1.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1167,9 +1172,9 @@ let
       sha256 = "178ym90kwidia6nas4qr5n5yqh698vv8r02js0r4vg3b6lsb0w9n";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xcbproto = (stdenv.mkDerivation ((if overrides ? xcbproto then overrides.xcbproto else x: x) {
+  xcbproto = (mkDerivation "xcbproto" {
     name = "xcb-proto-1.10";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1177,9 +1182,9 @@ let
       sha256 = "01dgp802i4ic9wkmpa7g1wm50pp547d3b96jjz2hnxavhpfhvx3y";
     };
     buildInputs = [pkgconfig python ];
-  })) // {inherit python ;};
+  }) // {inherit python ;};
 
-  xcbutil = (stdenv.mkDerivation ((if overrides ? xcbutil then overrides.xcbutil else x: x) {
+  xcbutil = (mkDerivation "xcbutil" {
     name = "xcb-util-0.3.9";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1187,9 +1192,9 @@ let
       sha256 = "1i0qbhqkcdlbbsj7ifkyjsffl61whj24d3zlg5pxf3xj1af2a4f6";
     };
     buildInputs = [pkgconfig gperf m4 libxcb xproto ];
-  })) // {inherit gperf m4 libxcb xproto ;};
+  }) // {inherit gperf m4 libxcb xproto ;};
 
-  xcbutilimage = (stdenv.mkDerivation ((if overrides ? xcbutilimage then overrides.xcbutilimage else x: x) {
+  xcbutilimage = (mkDerivation "xcbutilimage" {
     name = "xcb-util-image-0.3.9";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1197,9 +1202,9 @@ let
       sha256 = "1pr1l1nkg197gyl9d0fpwmn72jqpxjfgn9y13q4gawg1m873qnnk";
     };
     buildInputs = [pkgconfig gperf m4 libxcb xcbutil xproto ];
-  })) // {inherit gperf m4 libxcb xcbutil xproto ;};
+  }) // {inherit gperf m4 libxcb xcbutil xproto ;};
 
-  xcbutilkeysyms = (stdenv.mkDerivation ((if overrides ? xcbutilkeysyms then overrides.xcbutilkeysyms else x: x) {
+  xcbutilkeysyms = (mkDerivation "xcbutilkeysyms" {
     name = "xcb-util-keysyms-0.3.9";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1207,9 +1212,9 @@ let
       sha256 = "0vjwk7vrcfnlhiadv445c6skfxmdrg5v4qf81y8s2s5xagqarqbv";
     };
     buildInputs = [pkgconfig gperf m4 libxcb xproto ];
-  })) // {inherit gperf m4 libxcb xproto ;};
+  }) // {inherit gperf m4 libxcb xproto ;};
 
-  xcbutilrenderutil = (stdenv.mkDerivation ((if overrides ? xcbutilrenderutil then overrides.xcbutilrenderutil else x: x) {
+  xcbutilrenderutil = (mkDerivation "xcbutilrenderutil" {
     name = "xcb-util-renderutil-0.3.9";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1217,9 +1222,9 @@ let
       sha256 = "0nza1csdvvxbmk8vgv8vpmq7q8h05xrw3cfx9lwxd1hjzd47xsf6";
     };
     buildInputs = [pkgconfig gperf m4 libxcb xproto ];
-  })) // {inherit gperf m4 libxcb xproto ;};
+  }) // {inherit gperf m4 libxcb xproto ;};
 
-  xcbutilwm = (stdenv.mkDerivation ((if overrides ? xcbutilwm then overrides.xcbutilwm else x: x) {
+  xcbutilwm = (mkDerivation "xcbutilwm" {
     name = "xcb-util-wm-0.4.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1227,9 +1232,9 @@ let
       sha256 = "0gra7hfyxajic4mjd63cpqvd20si53j1q3rbdlkqkahfciwq3gr8";
     };
     buildInputs = [pkgconfig gperf m4 libxcb xproto ];
-  })) // {inherit gperf m4 libxcb xproto ;};
+  }) // {inherit gperf m4 libxcb xproto ;};
 
-  xclock = (stdenv.mkDerivation ((if overrides ? xclock then overrides.xclock else x: x) {
+  xclock = (mkDerivation "xclock" {
     name = "xclock-1.0.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1237,9 +1242,9 @@ let
       sha256 = "1l3xv4bsca6bwxx73jyjz0blav86i7vwffkhdb1ac81y9slyrki3";
     };
     buildInputs = [pkgconfig libX11 libXaw libXft libxkbfile libXmu xproto libXrender libXt ];
-  })) // {inherit libX11 libXaw libXft libxkbfile libXmu xproto libXrender libXt ;};
+  }) // {inherit libX11 libXaw libXft libxkbfile libXmu xproto libXrender libXt ;};
 
-  xcmiscproto = (stdenv.mkDerivation ((if overrides ? xcmiscproto then overrides.xcmiscproto else x: x) {
+  xcmiscproto = (mkDerivation "xcmiscproto" {
     name = "xcmiscproto-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1247,9 +1252,9 @@ let
       sha256 = "1pyjv45wivnwap2wvsbrzdvjc5ql8bakkbkrvcv6q9bjjf33ccmi";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xcmsdb = (stdenv.mkDerivation ((if overrides ? xcmsdb then overrides.xcmsdb else x: x) {
+  xcmsdb = (mkDerivation "xcmsdb" {
     name = "xcmsdb-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1257,9 +1262,9 @@ let
       sha256 = "03ms731l3kvaldq7ycbd30j6134b61i3gbll4b2gl022wyzbjq74";
     };
     buildInputs = [pkgconfig libX11 ];
-  })) // {inherit libX11 ;};
+  }) // {inherit libX11 ;};
 
-  xcursorgen = (stdenv.mkDerivation ((if overrides ? xcursorgen then overrides.xcursorgen else x: x) {
+  xcursorgen = (mkDerivation "xcursorgen" {
     name = "xcursorgen-1.0.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1267,9 +1272,9 @@ let
       sha256 = "0v7nncj3kaa8c0524j7ricdf4rvld5i7c3m6fj55l5zbah7r3j1i";
     };
     buildInputs = [pkgconfig libpng libX11 libXcursor ];
-  })) // {inherit libpng libX11 libXcursor ;};
+  }) // {inherit libpng libX11 libXcursor ;};
 
-  xcursorthemes = (stdenv.mkDerivation ((if overrides ? xcursorthemes then overrides.xcursorthemes else x: x) {
+  xcursorthemes = (mkDerivation "xcursorthemes" {
     name = "xcursor-themes-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1277,9 +1282,9 @@ let
       sha256 = "11mv661nj1p22sqkv87ryj2lcx4m68a04b0rs6iqh3fzp42jrzg3";
     };
     buildInputs = [pkgconfig libXcursor ];
-  })) // {inherit libXcursor ;};
+  }) // {inherit libXcursor ;};
 
-  xdm = (stdenv.mkDerivation ((if overrides ? xdm then overrides.xdm else x: x) {
+  xdm = (mkDerivation "xdm" {
     name = "xdm-1.1.11";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1287,9 +1292,9 @@ let
       sha256 = "0iqw11977lpr9nk1is4fca84d531vck0mq7jldwl44m0vrnl5nnl";
     };
     buildInputs = [pkgconfig libX11 libXau libXaw libXdmcp libXext libXft libXinerama libXmu libXpm libXt ];
-  })) // {inherit libX11 libXau libXaw libXdmcp libXext libXft libXinerama libXmu libXpm libXt ;};
+  }) // {inherit libX11 libXau libXaw libXdmcp libXext libXft libXinerama libXmu libXpm libXt ;};
 
-  xdpyinfo = (stdenv.mkDerivation ((if overrides ? xdpyinfo then overrides.xdpyinfo else x: x) {
+  xdpyinfo = (mkDerivation "xdpyinfo" {
     name = "xdpyinfo-1.3.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1297,9 +1302,9 @@ let
       sha256 = "154b29zlrq33lmni883jgwyrb2kx7z8h52jx1s3ys5x5d582iydf";
     };
     buildInputs = [pkgconfig libdmx libX11 libxcb libXcomposite libXext libXi libXinerama xproto libXrender libXtst libXxf86dga libXxf86misc libXxf86vm ];
-  })) // {inherit libdmx libX11 libxcb libXcomposite libXext libXi libXinerama xproto libXrender libXtst libXxf86dga libXxf86misc libXxf86vm ;};
+  }) // {inherit libdmx libX11 libxcb libXcomposite libXext libXi libXinerama xproto libXrender libXtst libXxf86dga libXxf86misc libXxf86vm ;};
 
-  xdriinfo = (stdenv.mkDerivation ((if overrides ? xdriinfo then overrides.xdriinfo else x: x) {
+  xdriinfo = (mkDerivation "xdriinfo" {
     name = "xdriinfo-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1307,9 +1312,9 @@ let
       sha256 = "076bjix941znyjmh3j5jjsnhp2gv2iq53d0ks29mvvv87cyy9iim";
     };
     buildInputs = [pkgconfig glproto libX11 ];
-  })) // {inherit glproto libX11 ;};
+  }) // {inherit glproto libX11 ;};
 
-  xev = (stdenv.mkDerivation ((if overrides ? xev then overrides.xev else x: x) {
+  xev = (mkDerivation "xev" {
     name = "xev-1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1317,9 +1322,9 @@ let
       sha256 = "0hv296mysglcgkx6lj1wxc23kshb2kix1a8yqppxj5vz16mpzw8i";
     };
     buildInputs = [pkgconfig libX11 xproto libXrandr ];
-  })) // {inherit libX11 xproto libXrandr ;};
+  }) // {inherit libX11 xproto libXrandr ;};
 
-  xextproto = (stdenv.mkDerivation ((if overrides ? xextproto then overrides.xextproto else x: x) {
+  xextproto = (mkDerivation "xextproto" {
     name = "xextproto-7.3.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1327,9 +1332,9 @@ let
       sha256 = "1c2vma9gqgc2v06rfxdiqgwhxmzk2cbmknwf1ng3m76vr0xb5x7k";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xeyes = (stdenv.mkDerivation ((if overrides ? xeyes then overrides.xeyes else x: x) {
+  xeyes = (mkDerivation "xeyes" {
     name = "xeyes-1.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1337,9 +1342,9 @@ let
       sha256 = "08d5x2kar5kg4yammw6hhk10iva6jmh8cqq176a1z7nm1il9hplp";
     };
     buildInputs = [pkgconfig libX11 libXext libXmu libXrender libXt ];
-  })) // {inherit libX11 libXext libXmu libXrender libXt ;};
+  }) // {inherit libX11 libXext libXmu libXrender libXt ;};
 
-  xf86bigfontproto = (stdenv.mkDerivation ((if overrides ? xf86bigfontproto then overrides.xf86bigfontproto else x: x) {
+  xf86bigfontproto = (mkDerivation "xf86bigfontproto" {
     name = "xf86bigfontproto-1.2.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1347,9 +1352,9 @@ let
       sha256 = "0j0n7sj5xfjpmmgx6n5x556rw21hdd18fwmavp95wps7qki214ms";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xf86dgaproto = (stdenv.mkDerivation ((if overrides ? xf86dgaproto then overrides.xf86dgaproto else x: x) {
+  xf86dgaproto = (mkDerivation "xf86dgaproto" {
     name = "xf86dgaproto-2.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1357,9 +1362,9 @@ let
       sha256 = "0l4hx48207mx0hp09026r6gy9nl3asbq0c75hri19wp1118zcpmc";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xf86driproto = (stdenv.mkDerivation ((if overrides ? xf86driproto then overrides.xf86driproto else x: x) {
+  xf86driproto = (mkDerivation "xf86driproto" {
     name = "xf86driproto-2.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1367,9 +1372,9 @@ let
       sha256 = "07v69m0g2dfzb653jni4x656jlr7l84c1k39j8qc8vfb45r8sjww";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xf86inputevdev = (stdenv.mkDerivation ((if overrides ? xf86inputevdev then overrides.xf86inputevdev else x: x) {
+  xf86inputevdev = (mkDerivation "xf86inputevdev" {
     name = "xf86-input-evdev-2.8.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1377,9 +1382,9 @@ let
       sha256 = "030haki1h0m85h91c91812gdnk6znfamw5kpr010zxwwbsgxxyl5";
     };
     buildInputs = [pkgconfig inputproto udev xorgserver xproto ];
-  })) // {inherit inputproto udev xorgserver xproto ;};
+  }) // {inherit inputproto udev xorgserver xproto ;};
 
-  xf86inputjoystick = (stdenv.mkDerivation ((if overrides ? xf86inputjoystick then overrides.xf86inputjoystick else x: x) {
+  xf86inputjoystick = (mkDerivation "xf86inputjoystick" {
     name = "xf86-input-joystick-1.6.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1387,9 +1392,9 @@ let
       sha256 = "038mfqairyyqvz02rk7v3i070sab1wr0k6fkxvyvxdgkfbnqcfzf";
     };
     buildInputs = [pkgconfig inputproto kbproto xorgserver xproto ];
-  })) // {inherit inputproto kbproto xorgserver xproto ;};
+  }) // {inherit inputproto kbproto xorgserver xproto ;};
 
-  xf86inputkeyboard = (stdenv.mkDerivation ((if overrides ? xf86inputkeyboard then overrides.xf86inputkeyboard else x: x) {
+  xf86inputkeyboard = (mkDerivation "xf86inputkeyboard" {
     name = "xf86-input-keyboard-1.8.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1397,9 +1402,9 @@ let
       sha256 = "0nyb61w30z32djrllgr2s1i13di3vsl6hg4pqjhxdal71971ria1";
     };
     buildInputs = [pkgconfig inputproto xorgserver xproto ];
-  })) // {inherit inputproto xorgserver xproto ;};
+  }) // {inherit inputproto xorgserver xproto ;};
 
-  xf86inputmouse = (stdenv.mkDerivation ((if overrides ? xf86inputmouse then overrides.xf86inputmouse else x: x) {
+  xf86inputmouse = (mkDerivation "xf86inputmouse" {
     name = "xf86-input-mouse-1.9.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1407,9 +1412,9 @@ let
       sha256 = "12344w0cxac1ld54qqwynxwazbmmpvqh1mzcskmfkmakmr5iwq2x";
     };
     buildInputs = [pkgconfig inputproto xorgserver xproto ];
-  })) // {inherit inputproto xorgserver xproto ;};
+  }) // {inherit inputproto xorgserver xproto ;};
 
-  xf86inputsynaptics = (stdenv.mkDerivation ((if overrides ? xf86inputsynaptics then overrides.xf86inputsynaptics else x: x) {
+  xf86inputsynaptics = (mkDerivation "xf86inputsynaptics" {
     name = "xf86-input-synaptics-1.7.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1417,9 +1422,9 @@ let
       sha256 = "0ls8f7gy92f54hdqsa19vypg0xm496jrgdhdn4qphycxwn3gwkbm";
     };
     buildInputs = [pkgconfig inputproto randrproto recordproto libX11 libXi xorgserver xproto libXtst ];
-  })) // {inherit inputproto randrproto recordproto libX11 libXi xorgserver xproto libXtst ;};
+  }) // {inherit inputproto randrproto recordproto libX11 libXi xorgserver xproto libXtst ;};
 
-  xf86inputvmmouse = (stdenv.mkDerivation ((if overrides ? xf86inputvmmouse then overrides.xf86inputvmmouse else x: x) {
+  xf86inputvmmouse = (mkDerivation "xf86inputvmmouse" {
     name = "xf86-input-vmmouse-13.0.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1427,9 +1432,9 @@ let
       sha256 = "0b31ap9wp7nwpnihz8m7bz3p0hhaipxxhl652nw4v380cq1vdkq4";
     };
     buildInputs = [pkgconfig inputproto randrproto xorgserver xproto ];
-  })) // {inherit inputproto randrproto xorgserver xproto ;};
+  }) // {inherit inputproto randrproto xorgserver xproto ;};
 
-  xf86inputvoid = (stdenv.mkDerivation ((if overrides ? xf86inputvoid then overrides.xf86inputvoid else x: x) {
+  xf86inputvoid = (mkDerivation "xf86inputvoid" {
     name = "xf86-input-void-1.4.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1437,9 +1442,9 @@ let
       sha256 = "01bmk324fq48wydvy1qrnxbw6qz0fjd0i80g0n4cqr1c4mjmif9a";
     };
     buildInputs = [pkgconfig xorgserver xproto ];
-  })) // {inherit xorgserver xproto ;};
+  }) // {inherit xorgserver xproto ;};
 
-  xf86miscproto = (stdenv.mkDerivation ((if overrides ? xf86miscproto then overrides.xf86miscproto else x: x) {
+  xf86miscproto = (mkDerivation "xf86miscproto" {
     name = "xf86miscproto-0.9.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1447,9 +1452,9 @@ let
       sha256 = "15dhcdpv61fyj6rhzrhnwri9hlw8rjfy05z1vik118lc99mfrf25";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xf86videoark = (stdenv.mkDerivation ((if overrides ? xf86videoark then overrides.xf86videoark else x: x) {
+  xf86videoark = (mkDerivation "xf86videoark" {
     name = "xf86-video-ark-0.7.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1457,9 +1462,9 @@ let
       sha256 = "07p5vdsj2ckxb6wh02s61akcv4qfg6s1d5ld3jn3lfaayd3f1466";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess xextproto xorgserver xproto ;};
 
-  xf86videoast = (stdenv.mkDerivation ((if overrides ? xf86videoast then overrides.xf86videoast else x: x) {
+  xf86videoast = (mkDerivation "xf86videoast" {
     name = "xf86-video-ast-0.98.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1467,9 +1472,9 @@ let
       sha256 = "188nv73w0p5xhfxz2dffli44yzyn1qhhq3qkwc8wva9dhg25n8lh";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
-  xf86videoati = (stdenv.mkDerivation ((if overrides ? xf86videoati then overrides.xf86videoati else x: x) {
+  xf86videoati = (mkDerivation "xf86videoati" {
     name = "xf86-video-ati-7.4.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1477,9 +1482,9 @@ let
       sha256 = "1nbnvxlyn75bcf23m39p7yw80kilgdxmjdvzgcs3walshnlhq8wn";
     };
     buildInputs = [pkgconfig fontsproto glamoregl libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
-  })) // {inherit fontsproto glamoregl libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto glamoregl libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
-  xf86videocirrus = (stdenv.mkDerivation ((if overrides ? xf86videocirrus then overrides.xf86videocirrus else x: x) {
+  xf86videocirrus = (mkDerivation "xf86videocirrus" {
     name = "xf86-video-cirrus-1.5.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1487,9 +1492,9 @@ let
       sha256 = "1mycqgjp18b6adqj2h90vp324xh8ysyi5migfmjc914vbnkf2q9k";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
-  xf86videodummy = (stdenv.mkDerivation ((if overrides ? xf86videodummy then overrides.xf86videodummy else x: x) {
+  xf86videodummy = (mkDerivation "xf86videodummy" {
     name = "xf86-video-dummy-0.3.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1497,9 +1502,9 @@ let
       sha256 = "1046p64xap69vlsmsz5rjv0djc970yhvq44fmllmas0mqp5lzy2n";
     };
     buildInputs = [pkgconfig fontsproto randrproto renderproto videoproto xf86dgaproto xorgserver xproto ];
-  })) // {inherit fontsproto randrproto renderproto videoproto xf86dgaproto xorgserver xproto ;};
+  }) // {inherit fontsproto randrproto renderproto videoproto xf86dgaproto xorgserver xproto ;};
 
-  xf86videofbdev = (stdenv.mkDerivation ((if overrides ? xf86videofbdev then overrides.xf86videofbdev else x: x) {
+  xf86videofbdev = (mkDerivation "xf86videofbdev" {
     name = "xf86-video-fbdev-0.4.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1507,9 +1512,9 @@ let
       sha256 = "06ym7yy017lanj730hfkpfk4znx3dsj8jq3qvyzsn8w294kb7m4x";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xorgserver xproto ;};
 
-  xf86videogeode = (stdenv.mkDerivation ((if overrides ? xf86videogeode then overrides.xf86videogeode else x: x) {
+  xf86videogeode = (mkDerivation "xf86videogeode" {
     name = "xf86-video-geode-2.11.15";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1517,9 +1522,9 @@ let
       sha256 = "1w4ghr2a41kaw4g9na8ws5fjbmy8zkbxpxa21vmqc8mkjzb3pnq0";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
-  xf86videoglide = (stdenv.mkDerivation ((if overrides ? xf86videoglide then overrides.xf86videoglide else x: x) {
+  xf86videoglide = (mkDerivation "xf86videoglide" {
     name = "xf86-video-glide-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1527,9 +1532,9 @@ let
       sha256 = "1vaav6kx4n00q4fawgqnjmbdkppl0dir2dkrj4ad372mxrvl9c4y";
     };
     buildInputs = [pkgconfig xextproto xorgserver xproto ];
-  })) // {inherit xextproto xorgserver xproto ;};
+  }) // {inherit xextproto xorgserver xproto ;};
 
-  xf86videoglint = (stdenv.mkDerivation ((if overrides ? xf86videoglint then overrides.xf86videoglint else x: x) {
+  xf86videoglint = (mkDerivation "xf86videoglint" {
     name = "xf86-video-glint-1.2.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1537,9 +1542,9 @@ let
       sha256 = "08a2aark2yn9irws9c78d9q44dichr03i9zbk61jgr54ncxqhzv5";
     };
     buildInputs = [pkgconfig libpciaccess videoproto xextproto xf86dgaproto xorgserver xproto ];
-  })) // {inherit libpciaccess videoproto xextproto xf86dgaproto xorgserver xproto ;};
+  }) // {inherit libpciaccess videoproto xextproto xf86dgaproto xorgserver xproto ;};
 
-  xf86videoi128 = (stdenv.mkDerivation ((if overrides ? xf86videoi128 then overrides.xf86videoi128 else x: x) {
+  xf86videoi128 = (mkDerivation "xf86videoi128" {
     name = "xf86-video-i128-1.3.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1547,9 +1552,9 @@ let
       sha256 = "171b8lbxr56w3isph947dnw7x87hc46v6m3mcxdcz44gk167x0pq";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
-  xf86videointel = (stdenv.mkDerivation ((if overrides ? xf86videointel then overrides.xf86videointel else x: x) {
+  xf86videointel = (mkDerivation "xf86videointel" {
     name = "xf86-video-intel-2.21.15";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1557,9 +1562,9 @@ let
       sha256 = "1z6ncmpszmwqi9xr590c4kp4gjjf7mndcr56r35x2bx7h87i8nkx";
     };
     buildInputs = [pkgconfig dri2proto fontsproto glamoregl libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto xorgserver xproto libXrender libXvMC ];
-  })) // {inherit dri2proto fontsproto glamoregl libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto xorgserver xproto libXrender libXvMC ;};
+  }) // {inherit dri2proto fontsproto glamoregl libdrm udev libpciaccess randrproto renderproto libX11 xcbutil libxcb libXext xextproto xf86driproto xorgserver xproto libXrender libXvMC ;};
 
-  xf86videomach64 = (stdenv.mkDerivation ((if overrides ? xf86videomach64 then overrides.xf86videomach64 else x: x) {
+  xf86videomach64 = (mkDerivation "xf86videomach64" {
     name = "xf86-video-mach64-6.9.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1567,9 +1572,9 @@ let
       sha256 = "0pl582vnc6hdxqhf5c0qdyanjqxb4crnhqlmxxml5a60syw0iwcp";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
-  xf86videomga = (stdenv.mkDerivation ((if overrides ? xf86videomga then overrides.xf86videomga else x: x) {
+  xf86videomga = (mkDerivation "xf86videomga" {
     name = "xf86-video-mga-1.6.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1577,9 +1582,9 @@ let
       sha256 = "1my7y67sadjjmab1dyxckylrggi7p01yk4wwg9w6k1q96pmb213p";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
-  xf86videomodesetting = (stdenv.mkDerivation ((if overrides ? xf86videomodesetting then overrides.xf86videomodesetting else x: x) {
+  xf86videomodesetting = (mkDerivation "xf86videomodesetting" {
     name = "xf86-video-modesetting-0.9.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1587,9 +1592,9 @@ let
       sha256 = "0p6pjn5bnd2wr3lmas4b12zcq12d9ilvssga93fzlg90fdahikwh";
     };
     buildInputs = [pkgconfig fontsproto libdrm udev libpciaccess randrproto libX11 xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm udev libpciaccess randrproto libX11 xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm udev libpciaccess randrproto libX11 xextproto xorgserver xproto ;};
 
-  xf86videoneomagic = (stdenv.mkDerivation ((if overrides ? xf86videoneomagic then overrides.xf86videoneomagic else x: x) {
+  xf86videoneomagic = (mkDerivation "xf86videoneomagic" {
     name = "xf86-video-neomagic-1.2.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1597,9 +1602,9 @@ let
       sha256 = "0x48sxs1p3kmwk3pq1j7vl93y59gdmgkq1x5xbnh0yal0angdash";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess xorgserver xproto ;};
 
-  xf86videonewport = (stdenv.mkDerivation ((if overrides ? xf86videonewport then overrides.xf86videonewport else x: x) {
+  xf86videonewport = (mkDerivation "xf86videonewport" {
     name = "xf86-video-newport-0.2.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1607,9 +1612,9 @@ let
       sha256 = "1yafmp23jrfdmc094i6a4dsizapsc9v0pl65cpc8w1kvn7343k4i";
     };
     buildInputs = [pkgconfig fontsproto randrproto renderproto videoproto xorgserver xproto ];
-  })) // {inherit fontsproto randrproto renderproto videoproto xorgserver xproto ;};
+  }) // {inherit fontsproto randrproto renderproto videoproto xorgserver xproto ;};
 
-  xf86videonouveau = (stdenv.mkDerivation ((if overrides ? xf86videonouveau then overrides.xf86videonouveau else x: x) {
+  xf86videonouveau = (mkDerivation "xf86videonouveau" {
     name = "xf86-video-nouveau-1.0.10";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1617,9 +1622,9 @@ let
       sha256 = "17fvjplzfx86099sqys0bfl8lfbmjz8li84kzj2x95mf1cbb7fn1";
     };
     buildInputs = [pkgconfig dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
-  })) // {inherit dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
+  }) // {inherit dri2proto fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
-  xf86videonv = (stdenv.mkDerivation ((if overrides ? xf86videonv then overrides.xf86videonv else x: x) {
+  xf86videonv = (mkDerivation "xf86videonv" {
     name = "xf86-video-nv-2.1.20";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1627,9 +1632,9 @@ let
       sha256 = "1gqh1khc4zalip5hh2nksgs7i3piqq18nncgmsx9qvzi05azd5c3";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
-  xf86videoopenchrome = (stdenv.mkDerivation ((if overrides ? xf86videoopenchrome then overrides.xf86videoopenchrome else x: x) {
+  xf86videoopenchrome = (mkDerivation "xf86videoopenchrome" {
     name = "xf86-video-openchrome-0.3.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1637,9 +1642,9 @@ let
       sha256 = "1v8j4i1r268n4fc5gq54zg1x50j0rhw71f3lba7411mcblg2z7p4";
     };
     buildInputs = [pkgconfig fontsproto glproto libdrm udev libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xf86driproto xorgserver xproto libXvMC ];
-  })) // {inherit fontsproto glproto libdrm udev libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xf86driproto xorgserver xproto libXvMC ;};
+  }) // {inherit fontsproto glproto libdrm udev libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xf86driproto xorgserver xproto libXvMC ;};
 
-  xf86videor128 = (stdenv.mkDerivation ((if overrides ? xf86videor128 then overrides.xf86videor128 else x: x) {
+  xf86videor128 = (mkDerivation "xf86videor128" {
     name = "xf86-video-r128-6.9.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1647,9 +1652,9 @@ let
       sha256 = "1q3fsc603k2yinphx5rrcl5356qkpywwz8axlw277l2231gjjbcb";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xf86miscproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xf86miscproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xf86miscproto xorgserver xproto ;};
 
-  xf86videosavage = (stdenv.mkDerivation ((if overrides ? xf86videosavage then overrides.xf86videosavage else x: x) {
+  xf86videosavage = (mkDerivation "xf86videosavage" {
     name = "xf86-video-savage-2.3.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1657,9 +1662,9 @@ let
       sha256 = "0i2aqp68rfkrz9c1p6d7ny9x7bjrlnby7q56zf01fb12r42l4784";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
-  xf86videosiliconmotion = (stdenv.mkDerivation ((if overrides ? xf86videosiliconmotion then overrides.xf86videosiliconmotion else x: x) {
+  xf86videosiliconmotion = (mkDerivation "xf86videosiliconmotion" {
     name = "xf86-video-siliconmotion-1.7.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1667,9 +1672,9 @@ let
       sha256 = "1an321kqvsxq0z35acwl99lc8hpdkayw0q180744ypcl8ffvbf47";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess videoproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess videoproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess videoproto xextproto xorgserver xproto ;};
 
-  xf86videosis = (stdenv.mkDerivation ((if overrides ? xf86videosis then overrides.xf86videosis else x: x) {
+  xf86videosis = (mkDerivation "xf86videosis" {
     name = "xf86-video-sis-0.10.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1677,9 +1682,9 @@ let
       sha256 = "1l0w84x39gq4y9j81dny9r6rma1xkqvxpsavpkd8h7h8panbcbmy";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xf86driproto xineramaproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xf86driproto xineramaproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xf86driproto xineramaproto xorgserver xproto ;};
 
-  xf86videosuncg6 = (stdenv.mkDerivation ((if overrides ? xf86videosuncg6 then overrides.xf86videosuncg6 else x: x) {
+  xf86videosuncg6 = (mkDerivation "xf86videosuncg6" {
     name = "xf86-video-suncg6-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1687,9 +1692,9 @@ let
       sha256 = "04fgwgk02m4nimlv67rrg1wnyahgymrn6rb2cjj1l8bmzkii4glr";
     };
     buildInputs = [pkgconfig fontsproto randrproto renderproto xorgserver xproto ];
-  })) // {inherit fontsproto randrproto renderproto xorgserver xproto ;};
+  }) // {inherit fontsproto randrproto renderproto xorgserver xproto ;};
 
-  xf86videosunffb = (stdenv.mkDerivation ((if overrides ? xf86videosunffb then overrides.xf86videosunffb else x: x) {
+  xf86videosunffb = (mkDerivation "xf86videosunffb" {
     name = "xf86-video-sunffb-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1697,9 +1702,9 @@ let
       sha256 = "07z3ngifwg2d4jgq8pms47n5lr2yn0ai72g86xxjnb3k20n5ym7s";
     };
     buildInputs = [pkgconfig fontsproto randrproto renderproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto randrproto renderproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto randrproto renderproto xextproto xorgserver xproto ;};
 
-  xf86videotdfx = (stdenv.mkDerivation ((if overrides ? xf86videotdfx then overrides.xf86videotdfx else x: x) {
+  xf86videotdfx = (mkDerivation "xf86videotdfx" {
     name = "xf86-video-tdfx-1.4.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1707,9 +1712,9 @@ let
       sha256 = "0nfqf1c8939s21ci1g7gacwzlr4g4nnilahgz7j2bz30zfnzpmbh";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
-  xf86videotga = (stdenv.mkDerivation ((if overrides ? xf86videotga then overrides.xf86videotga else x: x) {
+  xf86videotga = (mkDerivation "xf86videotga" {
     name = "xf86-video-tga-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1717,9 +1722,9 @@ let
       sha256 = "0cb161lvdgi6qnf1sfz722qn38q7kgakcvj7b45ba3i0020828r0";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xorgserver xproto ;};
 
-  xf86videotrident = (stdenv.mkDerivation ((if overrides ? xf86videotrident then overrides.xf86videotrident else x: x) {
+  xf86videotrident = (mkDerivation "xf86videotrident" {
     name = "xf86-video-trident-1.3.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1727,9 +1732,9 @@ let
       sha256 = "0141qbfsm32i0pxjyx5czpa8x8m4lvapsp4amw1qigaa0gry6n3a";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xf86dgaproto xorgserver xproto ;};
 
-  xf86videov4l = (stdenv.mkDerivation ((if overrides ? xf86videov4l then overrides.xf86videov4l else x: x) {
+  xf86videov4l = (mkDerivation "xf86videov4l" {
     name = "xf86-video-v4l-0.2.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1737,9 +1742,9 @@ let
       sha256 = "0pcjc75hgbih3qvhpsx8d4fljysfk025slxcqyyhr45dzch93zyb";
     };
     buildInputs = [pkgconfig randrproto videoproto xorgserver xproto ];
-  })) // {inherit randrproto videoproto xorgserver xproto ;};
+  }) // {inherit randrproto videoproto xorgserver xproto ;};
 
-  xf86videovesa = (stdenv.mkDerivation ((if overrides ? xf86videovesa then overrides.xf86videovesa else x: x) {
+  xf86videovesa = (mkDerivation "xf86videovesa" {
     name = "xf86-video-vesa-2.3.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1747,9 +1752,9 @@ let
       sha256 = "1y5fsg0c4bgmh1cfsbnaaf388fppyy02i7mcy9vax78flkjpb2yf";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto xextproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto xextproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto xextproto xorgserver xproto ;};
 
-  xf86videovmware = (stdenv.mkDerivation ((if overrides ? xf86videovmware then overrides.xf86videovmware else x: x) {
+  xf86videovmware = (mkDerivation "xf86videovmware" {
     name = "xf86-video-vmware-13.0.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1757,9 +1762,9 @@ let
       sha256 = "0m1wfsv34s4pyr5ry87yyjb2p6vmy6vyypdz5jx0sqnkx8n3vfn8";
     };
     buildInputs = [pkgconfig fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto ];
-  })) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto ;};
+  }) // {inherit fontsproto libdrm libpciaccess randrproto renderproto videoproto libX11 libXext xextproto xineramaproto xorgserver xproto ;};
 
-  xf86videovoodoo = (stdenv.mkDerivation ((if overrides ? xf86videovoodoo then overrides.xf86videovoodoo else x: x) {
+  xf86videovoodoo = (mkDerivation "xf86videovoodoo" {
     name = "xf86-video-voodoo-1.2.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1767,9 +1772,9 @@ let
       sha256 = "1s6p7yxmi12q4y05va53rljwyzd6ry492r1pgi7wwq6cznivhgly";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto xextproto xf86dgaproto xorgserver xproto ];
-  })) // {inherit fontsproto libpciaccess randrproto renderproto xextproto xf86dgaproto xorgserver xproto ;};
+  }) // {inherit fontsproto libpciaccess randrproto renderproto xextproto xf86dgaproto xorgserver xproto ;};
 
-  xf86videowsfb = (stdenv.mkDerivation ((if overrides ? xf86videowsfb then overrides.xf86videowsfb else x: x) {
+  xf86videowsfb = (mkDerivation "xf86videowsfb" {
     name = "xf86-video-wsfb-0.4.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1777,9 +1782,9 @@ let
       sha256 = "0hr8397wpd0by1hc47fqqrnaw3qdqd8aqgwgzv38w5k3l3jy6p4p";
     };
     buildInputs = [pkgconfig xorgserver xproto ];
-  })) // {inherit xorgserver xproto ;};
+  }) // {inherit xorgserver xproto ;};
 
-  xf86vidmodeproto = (stdenv.mkDerivation ((if overrides ? xf86vidmodeproto then overrides.xf86vidmodeproto else x: x) {
+  xf86vidmodeproto = (mkDerivation "xf86vidmodeproto" {
     name = "xf86vidmodeproto-2.3.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1787,9 +1792,9 @@ let
       sha256 = "0w47d7gfa8zizh2bshdr2rffvbr4jqjv019mdgyh6cmplyd4kna5";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xfs = (stdenv.mkDerivation ((if overrides ? xfs then overrides.xfs else x: x) {
+  xfs = (mkDerivation "xfs" {
     name = "xfs-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1797,9 +1802,9 @@ let
       sha256 = "1dwnf5gncpnjsbh9bdrc665kfnclhzzcpwpfnprvrnq4mlr4mx3v";
     };
     buildInputs = [pkgconfig libXfont xproto xtrans ];
-  })) // {inherit libXfont xproto xtrans ;};
+  }) // {inherit libXfont xproto xtrans ;};
 
-  xgamma = (stdenv.mkDerivation ((if overrides ? xgamma then overrides.xgamma else x: x) {
+  xgamma = (mkDerivation "xgamma" {
     name = "xgamma-1.0.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1807,9 +1812,9 @@ let
       sha256 = "0463sawps86jnxn121ramsz4sicy3az5wa5wsq4rqm8dm3za48p3";
     };
     buildInputs = [pkgconfig libX11 libXxf86vm ];
-  })) // {inherit libX11 libXxf86vm ;};
+  }) // {inherit libX11 libXxf86vm ;};
 
-  xhost = (stdenv.mkDerivation ((if overrides ? xhost then overrides.xhost else x: x) {
+  xhost = (mkDerivation "xhost" {
     name = "xhost-1.0.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1817,9 +1822,9 @@ let
       sha256 = "1hlxm0is9nks1cx033s1733kkib9ivx2bxa3pb9yayqavwibkxd6";
     };
     buildInputs = [pkgconfig libX11 libXau libXmu xproto ];
-  })) // {inherit libX11 libXau libXmu xproto ;};
+  }) // {inherit libX11 libXau libXmu xproto ;};
 
-  xineramaproto = (stdenv.mkDerivation ((if overrides ? xineramaproto then overrides.xineramaproto else x: x) {
+  xineramaproto = (mkDerivation "xineramaproto" {
     name = "xineramaproto-1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1827,9 +1832,9 @@ let
       sha256 = "0ns8abd27x7gbp4r44z3wc5k9zqxxj8zjnazqpcyr4n17nxp8xcp";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xinit = (stdenv.mkDerivation ((if overrides ? xinit then overrides.xinit else x: x) {
+  xinit = (mkDerivation "xinit" {
     name = "xinit-1.3.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1837,9 +1842,9 @@ let
       sha256 = "1bq0mqy7y305g2rds1g5443f3d2kgxzafqhmiyabbmg3ws6qgckl";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
-  xinput = (stdenv.mkDerivation ((if overrides ? xinput then overrides.xinput else x: x) {
+  xinput = (mkDerivation "xinput" {
     name = "xinput-1.6.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1847,9 +1852,9 @@ let
       sha256 = "07w7zlpdhpwzzshg8q0y152cy3wl2fj7x1897glnp2la487jsqxp";
     };
     buildInputs = [pkgconfig inputproto libX11 libXext libXi libXinerama libXrandr ];
-  })) // {inherit inputproto libX11 libXext libXi libXinerama libXrandr ;};
+  }) // {inherit inputproto libX11 libXext libXi libXinerama libXrandr ;};
 
-  xkbcomp = (stdenv.mkDerivation ((if overrides ? xkbcomp then overrides.xkbcomp else x: x) {
+  xkbcomp = (mkDerivation "xkbcomp" {
     name = "xkbcomp-1.2.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1857,9 +1862,9 @@ let
       sha256 = "0bas1d2wjiy5zy9d0g92d2p9pwv4aapfbfidi7hxy8ax8jmwkl4i";
     };
     buildInputs = [pkgconfig libX11 libxkbfile xproto ];
-  })) // {inherit libX11 libxkbfile xproto ;};
+  }) // {inherit libX11 libxkbfile xproto ;};
 
-  xkbevd = (stdenv.mkDerivation ((if overrides ? xkbevd then overrides.xkbevd else x: x) {
+  xkbevd = (mkDerivation "xkbevd" {
     name = "xkbevd-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1867,9 +1872,9 @@ let
       sha256 = "05h1xcnbalndbrryyqs8wzy9h3wz655vc0ymhlk2q4aik17licjm";
     };
     buildInputs = [pkgconfig libX11 libxkbfile ];
-  })) // {inherit libX11 libxkbfile ;};
+  }) // {inherit libX11 libxkbfile ;};
 
-  xkbprint = (stdenv.mkDerivation ((if overrides ? xkbprint then overrides.xkbprint else x: x) {
+  xkbprint = (mkDerivation "xkbprint" {
     name = "xkbprint-1.0.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1877,9 +1882,9 @@ let
       sha256 = "1h4jb3gjrbjp79h5gcgkjvdxykcy2bmq03smpls820c8wnw6v17s";
     };
     buildInputs = [pkgconfig libX11 libxkbfile ];
-  })) // {inherit libX11 libxkbfile ;};
+  }) // {inherit libX11 libxkbfile ;};
 
-  xkbutils = (stdenv.mkDerivation ((if overrides ? xkbutils then overrides.xkbutils else x: x) {
+  xkbutils = (mkDerivation "xkbutils" {
     name = "xkbutils-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1887,9 +1892,9 @@ let
       sha256 = "0c412isxl65wplhl7nsk12vxlri29lk48g3p52hbrs3m0awqm8fj";
     };
     buildInputs = [pkgconfig inputproto libX11 libXaw xproto libXt ];
-  })) // {inherit inputproto libX11 libXaw xproto libXt ;};
+  }) // {inherit inputproto libX11 libXaw xproto libXt ;};
 
-  xkeyboardconfig = (stdenv.mkDerivation ((if overrides ? xkeyboardconfig then overrides.xkeyboardconfig else x: x) {
+  xkeyboardconfig = (mkDerivation "xkeyboardconfig" {
     name = "xkeyboard-config-2.11";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1897,9 +1902,9 @@ let
       sha256 = "0xkdyyi759hzls42hp4j3q2lc35n4j6b2g44ilx5qarci5h584p7";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
-  xkill = (stdenv.mkDerivation ((if overrides ? xkill then overrides.xkill else x: x) {
+  xkill = (mkDerivation "xkill" {
     name = "xkill-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1907,9 +1912,9 @@ let
       sha256 = "0bl1ky8ps9jg842j4mnmf4zbx8nkvk0h77w7bqjlpwij9wq2mvw8";
     };
     buildInputs = [pkgconfig libX11 libXmu xproto ];
-  })) // {inherit libX11 libXmu xproto ;};
+  }) // {inherit libX11 libXmu xproto ;};
 
-  xlsatoms = (stdenv.mkDerivation ((if overrides ? xlsatoms then overrides.xlsatoms else x: x) {
+  xlsatoms = (mkDerivation "xlsatoms" {
     name = "xlsatoms-1.1.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1917,9 +1922,9 @@ let
       sha256 = "1y9nfl8s7njxbnci8c20j986xixharasgg40vdw92y593j6dk2rv";
     };
     buildInputs = [pkgconfig libxcb ];
-  })) // {inherit libxcb ;};
+  }) // {inherit libxcb ;};
 
-  xlsclients = (stdenv.mkDerivation ((if overrides ? xlsclients then overrides.xlsclients else x: x) {
+  xlsclients = (mkDerivation "xlsclients" {
     name = "xlsclients-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1927,9 +1932,9 @@ let
       sha256 = "0g9x7rrggs741x9xwvv1k9qayma980d88nhdqw7j3pn3qvy6d5jx";
     };
     buildInputs = [pkgconfig libxcb ];
-  })) // {inherit libxcb ;};
+  }) // {inherit libxcb ;};
 
-  xmessage = (stdenv.mkDerivation ((if overrides ? xmessage then overrides.xmessage else x: x) {
+  xmessage = (mkDerivation "xmessage" {
     name = "xmessage-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1937,9 +1942,9 @@ let
       sha256 = "0s5bjlpxnmh8sxx6nfg9m0nr32r1sr3irr71wsnv76s33i34ppxw";
     };
     buildInputs = [pkgconfig libXaw libXt ];
-  })) // {inherit libXaw libXt ;};
+  }) // {inherit libXaw libXt ;};
 
-  xmodmap = (stdenv.mkDerivation ((if overrides ? xmodmap then overrides.xmodmap else x: x) {
+  xmodmap = (mkDerivation "xmodmap" {
     name = "xmodmap-1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1947,9 +1952,9 @@ let
       sha256 = "1hwzm54m4ng09ls9i4bq0x84zbyhamgzasgrvhxxp8jqk34f7qpg";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
-  xorgcffiles = (stdenv.mkDerivation ((if overrides ? xorgcffiles then overrides.xorgcffiles else x: x) {
+  xorgcffiles = (mkDerivation "xorgcffiles" {
     name = "xorg-cf-files-1.0.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1957,9 +1962,9 @@ let
       sha256 = "1m3ypq0xcy46ghxc0svl1rbhpy3zvgmy0aa2mn7w7v7d8d8bh8zd";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xorgdocs = (stdenv.mkDerivation ((if overrides ? xorgdocs then overrides.xorgdocs else x: x) {
+  xorgdocs = (mkDerivation "xorgdocs" {
     name = "xorg-docs-1.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1967,9 +1972,9 @@ let
       sha256 = "0prphdba6kgr1bxk7r07wxxx6x6pqjw6prr5qclypsb5sf5r3cdr";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xorgserver = (stdenv.mkDerivation ((if overrides ? xorgserver then overrides.xorgserver else x: x) {
+  xorgserver = (mkDerivation "xorgserver" {
     name = "xorg-server-1.14.7";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1977,9 +1982,24 @@ let
       sha256 = "07s54g9q1bry1050dsa7x6hy55yjvq9sxs6ks89pc8l6mnk6zxpw";
     };
     buildInputs = [pkgconfig renderproto libdrm openssl libX11 libXau libXaw libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt libXv ];
-  })) // {inherit renderproto libdrm openssl libX11 libXau libXaw libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt libXv ;};
+  }) // {inherit renderproto libdrm openssl libX11 libXau libXaw libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt libXv ;};
 
-  xorgsgmldoctools = (stdenv.mkDerivation ((if overrides ? xorgsgmldoctools then overrides.xorgsgmldoctools else x: x) {
+  # TODO:
+  # With the current state of ./generate-expr-from-tarballs.pl,
+  # this will get overwritten when next invoked.
+  # Could add a special case to ./generate-expr-from-tarballs.pl,
+  # or perhaps there's a cleaner solution.
+  #xquartz = (mkDerivation "xquartz" {
+  #  name = "xorg-server-1.14.6";
+  #  builder = ./builder.sh;
+  #  src = fetchurl {
+  #    url = mirror://xorg/individual/xserver/xorg-server-1.14.6.tar.bz2;
+  #    sha256 = "0c57vp1z0p38dj5gfipkmlw6bvbz1mrr0sb3sbghdxxdyq4kzcz8";
+  #  };
+  #  buildInputs = [pkgconfig renderproto libdrm openssl libX11 libXau libXaw libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt libXv ];
+  #}) // {inherit renderproto libdrm openssl libX11 libXau libXaw libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt libXv ;};
+
+  xorgsgmldoctools = (mkDerivation "xorgsgmldoctools" {
     name = "xorg-sgml-doctools-1.11";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1987,9 +2007,9 @@ let
       sha256 = "0k5pffyi5bx8dmfn033cyhgd3gf6viqj3x769fqixifwhbgy2777";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xpr = (stdenv.mkDerivation ((if overrides ? xpr then overrides.xpr else x: x) {
+  xpr = (mkDerivation "xpr" {
     name = "xpr-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1997,9 +2017,9 @@ let
       sha256 = "1dbcv26w2yand2qy7b3h5rbvw1mdmdd57jw88v53sgdr3vrqvngy";
     };
     buildInputs = [pkgconfig libX11 libXmu xproto ];
-  })) // {inherit libX11 libXmu xproto ;};
+  }) // {inherit libX11 libXmu xproto ;};
 
-  xprop = (stdenv.mkDerivation ((if overrides ? xprop then overrides.xprop else x: x) {
+  xprop = (mkDerivation "xprop" {
     name = "xprop-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2007,9 +2027,9 @@ let
       sha256 = "1ilvhqfjcg6f1hqahjkp8qaay9rhvmv2blvj3w9asraq0aqqivlv";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
-  xproto = (stdenv.mkDerivation ((if overrides ? xproto then overrides.xproto else x: x) {
+  xproto = (mkDerivation "xproto" {
     name = "xproto-7.0.26";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2017,9 +2037,9 @@ let
       sha256 = "0ksi8vhfd916bx2f3xlyhn6azf6cvvzrsdja26haa1cqfp0n4qb3";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xrandr = (stdenv.mkDerivation ((if overrides ? xrandr then overrides.xrandr else x: x) {
+  xrandr = (mkDerivation "xrandr" {
     name = "xrandr-1.4.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2027,9 +2047,9 @@ let
       sha256 = "1g4hnj53wknsjwiqivyy3jl4qw7jwrpncz7d5p2z29zq5zlnxrxj";
     };
     buildInputs = [pkgconfig libX11 xproto libXrandr libXrender ];
-  })) // {inherit libX11 xproto libXrandr libXrender ;};
+  }) // {inherit libX11 xproto libXrandr libXrender ;};
 
-  xrdb = (stdenv.mkDerivation ((if overrides ? xrdb then overrides.xrdb else x: x) {
+  xrdb = (mkDerivation "xrdb" {
     name = "xrdb-1.1.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2037,9 +2057,9 @@ let
       sha256 = "0nsnr90wazcdd50nc5dqswy0bmq6qcj14nnrhyi7rln9pxmpp0kk";
     };
     buildInputs = [pkgconfig libX11 libXmu xproto ];
-  })) // {inherit libX11 libXmu xproto ;};
+  }) // {inherit libX11 libXmu xproto ;};
 
-  xrefresh = (stdenv.mkDerivation ((if overrides ? xrefresh then overrides.xrefresh else x: x) {
+  xrefresh = (mkDerivation "xrefresh" {
     name = "xrefresh-1.0.5";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2047,9 +2067,9 @@ let
       sha256 = "1mlinwgvql6s1rbf46yckbfr9j22d3c3z7jx3n6ix7ca18dnf4rj";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
-  xset = (stdenv.mkDerivation ((if overrides ? xset then overrides.xset else x: x) {
+  xset = (mkDerivation "xset" {
     name = "xset-1.2.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2057,9 +2077,9 @@ let
       sha256 = "0qw0iic27bz3yz2wynf1gxs70hhkcf9c4jrv7zhlg1mq57xz90j3";
     };
     buildInputs = [pkgconfig libX11 libXext libXmu xproto libXxf86misc ];
-  })) // {inherit libX11 libXext libXmu xproto libXxf86misc ;};
+  }) // {inherit libX11 libXext libXmu xproto libXxf86misc ;};
 
-  xsetroot = (stdenv.mkDerivation ((if overrides ? xsetroot then overrides.xsetroot else x: x) {
+  xsetroot = (mkDerivation "xsetroot" {
     name = "xsetroot-1.1.0";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2067,9 +2087,9 @@ let
       sha256 = "1bazzsf9sy0q2bj4lxvh1kvyrhmpggzb7jg575i15sksksa3xwc8";
     };
     buildInputs = [pkgconfig libX11 xbitmaps libXcursor libXmu ];
-  })) // {inherit libX11 xbitmaps libXcursor libXmu ;};
+  }) // {inherit libX11 xbitmaps libXcursor libXmu ;};
 
-  xtrans = (stdenv.mkDerivation ((if overrides ? xtrans then overrides.xtrans else x: x) {
+  xtrans = (mkDerivation "xtrans" {
     name = "xtrans-1.3.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2077,9 +2097,9 @@ let
       sha256 = "0fjq9xa37k1czkidj3c5sads51gibrjvrxz9ag3hh9fmxzilwk85";
     };
     buildInputs = [pkgconfig ];
-  })) // {inherit ;};
+  }) // {inherit ;};
 
-  xvinfo = (stdenv.mkDerivation ((if overrides ? xvinfo then overrides.xvinfo else x: x) {
+  xvinfo = (mkDerivation "xvinfo" {
     name = "xvinfo-1.1.2";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2087,9 +2107,9 @@ let
       sha256 = "1qsh7fszi727l3vwlaf9pb7bpikdv15smrx5qhlgg3kqzl7xklzf";
     };
     buildInputs = [pkgconfig libX11 xproto libXv ];
-  })) // {inherit libX11 xproto libXv ;};
+  }) // {inherit libX11 xproto libXv ;};
 
-  xwd = (stdenv.mkDerivation ((if overrides ? xwd then overrides.xwd else x: x) {
+  xwd = (mkDerivation "xwd" {
     name = "xwd-1.0.6";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2097,9 +2117,9 @@ let
       sha256 = "0ybx48agdvjp9lgwvcw79r1x6jbqbyl3fliy3i5xwy4d4si9dcrv";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
-  xwininfo = (stdenv.mkDerivation ((if overrides ? xwininfo then overrides.xwininfo else x: x) {
+  xwininfo = (mkDerivation "xwininfo" {
     name = "xwininfo-1.1.3";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2107,9 +2127,9 @@ let
       sha256 = "1y1zn8ijqslb5lfpbq4bb78kllhch8in98ps7n8fg3dxjpmb13i1";
     };
     buildInputs = [pkgconfig libX11 libxcb xproto ];
-  })) // {inherit libX11 libxcb xproto ;};
+  }) // {inherit libX11 libxcb xproto ;};
 
-  xwud = (stdenv.mkDerivation ((if overrides ? xwud then overrides.xwud else x: x) {
+  xwud = (mkDerivation "xwud" {
     name = "xwud-1.0.4";
     builder = ./builder.sh;
     src = fetchurl {
@@ -2117,6 +2137,6 @@ let
       sha256 = "1ggql6maivah58kwsh3z9x1hvzxm1a8888xx4s78cl77ryfa1cyn";
     };
     buildInputs = [pkgconfig libX11 xproto ];
-  })) // {inherit libX11 xproto ;};
+  }) // {inherit libX11 xproto ;};
 
 }; in xorg

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -230,6 +230,11 @@ args: with args;
 
 let
 
+  mkDerivation = name: attrs:
+    let newAttrs = (overrides."\${name}" or (x: x)) attrs;
+        stdenv = newAttrs.stdenv or args.stdenv;
+    in stdenv.mkDerivation (removeAttrs newAttrs [ "stdenv" ]);
+
   overrides = import ./overrides.nix {inherit args xorg;};
 
   xorg = rec {
@@ -261,7 +266,7 @@ foreach my $pkg (sort (keys %pkgURLs)) {
     $extraAttrs = "" unless defined $extraAttrs;
 
     print OUT <<EOF
-  $pkg = (stdenv.mkDerivation ((if overrides ? $pkg then overrides.$pkg else x: x) {
+  $pkg = (mkDerivation "$pkg" {
     name = "$pkgNames{$pkg}";
     builder = ./builder.sh;
     src = fetchurl {
@@ -269,7 +274,7 @@ foreach my $pkg (sort (keys %pkgURLs)) {
       sha256 = "$pkgHashes{$pkg}";
     };
     buildInputs = [pkgconfig $inputs];$extraAttrs
-  })) // {inherit $inputs;};
+  }) // {inherit $inputs;};
 
 EOF
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,6 +1,10 @@
 { args, xorg }:
 
 let
+  inherit (args) stdenv;
+  inherit (stdenv) lib isDarwin;
+  inherit (lib) overrideDerivation;
+
   setMalloc0ReturnsNullCrossCompiling = ''
     if test -n "$crossConfig"; then
       configureFlags="$configureFlags --enable-malloc0returnsnull";
@@ -75,7 +79,12 @@ in
 
   libXfont = attrs: attrs // {
     propagatedBuildInputs = [ args.freetype ]; # propagate link reqs. like bzip2
+    # prevents "misaligned_stack_error_entering_dyld_stub_binder"
+    configureFlags = lib.optionals isDarwin [
+      "CFLAGS=-O0"
+    ];
   };
+
 
   libXxf86vm = attrs: attrs // {
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
@@ -219,20 +228,16 @@ in
     # 2: I think pkgconfig/ is supposed to be in /lib/
     postInstall = ''
       ln -s share "$out/etc"
-      mkdir "$out/lib" && ln -s ../share/pkgconfig "$out/lib/"
+      mkdir -p "$out/lib" && ln -s ../share/pkgconfig "$out/lib/"
     '';
   };
 
-  xorgserver = with xorg; attrs: attrs // {
-    configureFlags = [
-      "--enable-xcsecurity" # enable SECURITY extension
-      "--with-default-font-path= "  # there were only paths containing "${prefix}",
-                                    # and there are no fonts in this package anyway
-    ];
-    patches = [ ./xorgserver-xkbcomp-path.patch ];
-    buildInputs = attrs.buildInputs ++ [ xtrans ];
-    propagatedBuildInputs =
-      [ args.zlib args.udev args.mesa args.dbus.libs
+  xorgserver = with xorg; attrs: attrs //
+    (let
+      version = (builtins.parseDrvName attrs.name).version;
+      commonBuildInputs = attrs.buildInputs ++ [ xtrans ];
+      commonPropagatedBuildInputs = [
+        args.zlib args.mesa args.dbus.libs
         xf86bigfontproto glproto xf86driproto
         compositeproto scrnsaverproto resourceproto
         xf86dgaproto
@@ -242,14 +247,86 @@ in
         libpciaccess inputproto xextproto randrproto renderproto
         dri2proto kbproto xineramaproto resourceproto scrnsaverproto videoproto
       ];
-    postInstall =
-      ''
-        rm -fr $out/share/X11/xkb/compiled
-        ln -s /var/tmp $out/share/X11/xkb/compiled
-      '';
-    passthru.version = (builtins.parseDrvName attrs.name).version; # needed by virtualbox guest additions
-  };
+      commonPatches = [ ./xorgserver-xkbcomp-path.patch ];
+      # XQuartz requires two compilations: the first to get X / XQuartz,
+      # and the second to get Xvfb, Xnest, etc.
+      darwinOtherX = overrideDerivation xorgserver (oldAttrs: {
+        stdenv = args.stdenv;
+        configureFlags = oldAttrs.configureFlags ++ [
+          "--disable-xquartz"
+          "--enable-xorg"
+          "--enable-xvfb"
+          "--enable-xnest"
+          "--enable-kdrive"
+        ];
+        postInstall = ":"; # prevent infinite recursion
+      });
+    in
+      if (!isDarwin)
+      then {
+        buildInputs = commonBuildInputs;
+        propagatedBuildInputs = commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [
+          args.udev
+        ];
+        patches = commonPatches;
+        configureFlags = [
+          "--enable-xcsecurity"         # enable SECURITY extension
+          "--with-default-font-path="   # there were only paths containing "${prefix}",
+                                        # and there are no fonts in this package anyway
+        ];
+        postInstall = ''
+          rm -fr $out/share/X11/xkb/compiled
+          ln -s /var/tmp $out/share/X11/xkb/compiled
+        '';
+        passthru.version = version; # needed by virtualbox guest additions
+      } else {
+        stdenv = args.clangStdenv;
+        name = "xorg-server-1.14.6";
+        src = args.fetchurl {
+          url = mirror://xorg/individual/xserver/xorg-server-1.14.6.tar.bz2;
+          sha256 = "0c57vp1z0p38dj5gfipkmlw6bvbz1mrr0sb3sbghdxxdyq4kzcz8";
+        };
+        buildInputs = commonBuildInputs;
+        propagatedBuildInputs = commonPropagatedBuildInputs ++ [
+          libAppleWM applewmproto
+        ];
+        patches = commonPatches ++ [
+          ./darwin/0001-XQuartz-Ensure-we-wait-for-the-server-thread-to-term.patch
+          ./darwin/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
+          ./darwin/5001-Workaround-the-GC-clipping-problem-in-miPaintWindow-.patch
+          ./darwin/5002-fb-Revert-fb-changes-that-broke-XQuartz.patch
+          ./darwin/5003-fb-Revert-fb-changes-that-broke-XQuartz.patch
+          ./darwin/5004-Use-old-miTrapezoids-and-miTriangles-routines.patch
+          ./darwin/private-extern.patch
+          ./darwin/bundle_main.patch
+          ./darwin/stub.patch
+          ./darwin/function-pointer-test.patch
+        ];
+        configureFlags = [
+          # note: --enable-xquartz is auto
+          "CPPFLAGS=-I${./darwin/dri}"
+          "--with-default-font-path="
+          "--with-apple-application-name=XQuartz"
+          "--with-apple-applications-dir=\${out}/Applications"
+          "--with-bundle-id-prefix=org.nixos.xquartz"
+          "--with-sha1=CommonCrypto"
+        ];
+        preConfigure = ''
+          ensureDir $out/Applications
+          export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error"
+        '';
+        postInstall = ''
+          rm -fr $out/share/X11/xkb/compiled
+          ln -s /var/tmp $out/share/X11/xkb/compiled
 
+          cp -rT ${darwinOtherX}/bin $out/bin
+          rm -f $out/bin/X
+          ln -s Xquartz $out/bin/X
+
+          cp ${darwinOtherX}/share/man -rT $out/share/man
+        '' ;
+        passthru.version = version;
+      });
 
   lndir = attrs: attrs // {
     preConfigure = ''
@@ -272,7 +349,14 @@ in
   };
 
   xinit = attrs: attrs // {
-    configureFlags = "--with-xserver=${xorg.xorgserver}/bin/X";
+    stdenv = if isDarwin then args.clangStdenv else stdenv;
+    configureFlags = [
+      "--with-xserver=${xorg.xorgserver}/bin/X"
+    ] ++ lib.optionals isDarwin [
+      "--with-bundle-id-prefix=org.nixos.xquartz"
+      "--with-launchdaemons-dir=\${out}/LaunchDaemons"
+      "--with-launchagents-dir=\${out}/LaunchAgents"
+    ];
     propagatedBuildInputs = [ xorg.xauth ];
     prePatch = ''
       sed -i 's|^defaultserverargs="|&-logfile \"$HOME/.xorg.log\"|p' startx.cpp

--- a/pkgs/servers/x11/xquartz/X11
+++ b/pkgs/servers/x11/xquartz/X11
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set "$(dirname "$0")"/X11.bin "${@}"
+
+export XQUARTZ_DEFAULT_CLIENT="@DEFAULT_CLIENT@"
+export XQUARTZ_DEFAULT_SHELL="@DEFAULT_SHELL@"
+export XQUARTZ_DEFAULT_STARTX="@DEFAULT_STARTX@"
+export FONTCONFIG_FILE="@FONTCONFIG_FILE@"
+
+if [ -x ~/.x11run ]; then
+    exec ~/.x11run "${@}"
+fi
+
+case $(basename "${SHELL}") in
+    bash)          exec -l "${SHELL}" --login -c 'exec "${@}"' - "${@}" ;;
+    ksh|sh|zsh)    exec -l "${SHELL}" -c 'exec "${@}"' - "${@}" ;;
+    csh|tcsh)      exec -l "${SHELL}" -c 'exec $argv:q' "${@}" ;;
+    es|rc)         exec -l "${SHELL}" -l -c 'exec $*' "${@}" ;;
+    *)             exec    "${@}" ;;
+esac

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -1,0 +1,187 @@
+{ stdenv, lib, buildEnv, makeFontsConf, gnused, writeScript, xorg, bashInteractive, substituteAll, xterm, makeWrapper, ruby
+, openssl, quartz-wm, fontconfig, xkeyboard_config, xlsfonts, xfontsel
+, ttf_bitstream_vera, freefont_ttf, liberation_ttf
+, shell ? "${bashInteractive}/bin/bash"
+}:
+
+# ------------
+# Installation
+# ------------
+#
+# First, assuming you've previously installed XQuartz from macosforge.com,
+# unload and remove the existing launch agents:
+#
+#   $ sudo launchctl unload /Library/LaunchAgents/org.macosforge.xquartz.startx.plist
+#   $ sudo launchctl unload /Library/LaunchDaemons/org.macosforge.xquartz.privileged_startx.plist
+#   $ sudo rm /Library/LaunchAgents/org.macosforge.xquartz.startx.plist
+#   $ sudo rm /Library/LaunchDaemons/org.macosforge.xquartz.privileged_startx.plist
+#
+# (You will need to log out for the above changes to take effect.)
+#
+# Then install xquartz from nixpkgs:
+#
+#   $ nix-env -i xquartz
+#   $ xquartz-install
+#
+# You'll also want to add the following to your shell's profile (after you
+# source nix.sh, so $NIX_LINK points to your user profile):
+#
+#   if [ "$(uname)" = "Darwin" -a -n "$NIX_LINK" -a -f $NIX_LINK/etc/X11/fonts.conf ]; then
+#     export FONTCONFIG_FILE=$NIX_LINK/etc/X11/fonts.conf
+#   fi
+
+# A note about dependencies:
+# Xquartz wants to exec XQuartz.app, XQuartz.app wants to exec xstart, and
+# xstart wants to exec Xquartz, so we must bundle all three to prevent a cycle.
+# Coincidentally, this also makes it trivial to install launch agents/daemons
+# that point into the user's profile.
+
+let
+  shellEscape = x: "'${lib.replaceChars ["'"] [("'\\'" + "'")] x}'";
+  installer = writeScript "xquartz-install" ''
+    NIX_LINK=$HOME/.nix-profile
+
+    tmpdir=$(/usr/bin/mktemp -d $TMPDIR/xquartz-installer-XXXXXXXX)
+    agentName=org.nixos.xquartz.startx.plist
+    daemonName=org.nixos.xquartz.privileged_startx.plist
+    sed=${gnused}/bin/sed
+
+    cp ${./org.nixos.xquartz.startx.plist} $tmpdir/$agentName
+    $sed -i "s|@LAUNCHD_STARTX@|$NIX_LINK/etc/X11/xinit/launchd_startx|" $tmpdir/$agentName
+    $sed -i "s|@STARTX@|$NIX_LINK/bin/startx|" $tmpdir/$agentName
+    $sed -i "s|@XQUARTZ@|$NIX_LINK/bin/Xquartz|" $tmpdir/$agentName
+
+    cp ${./org.nixos.xquartz.privileged_startx.plist} $tmpdir/$daemonName
+    $sed -i "s|@PRIVILEGED_STARTX@|$NIX_LINK/lib/X11/xinit/privileged_startx|" $tmpdir/$daemonName
+    $sed -i "s|@PRIVILEGED_STARTX_D@|$NIX_LINK/lib/X11/xinit/privileged_startx.d|" $tmpdir/$daemonName
+
+    sudo cp $tmpdir/$agentName /Library/LaunchAgents/$agentName
+    sudo cp $tmpdir/$daemonName /Library/LaunchDaemons/$daemonName
+    sudo launchctl load -w /Library/LaunchAgents/$agentName
+    sudo launchctl load -w /Library/LaunchDaemons/$daemonName
+  '';
+  fontDirs = [
+    xorg.fontbhttf
+    xorg.fontbhlucidatypewriter100dpi
+    xorg.fontbhlucidatypewriter75dpi
+    ttf_bitstream_vera
+    freefont_ttf
+    liberation_ttf
+    xorg.fontbh100dpi
+    xorg.fontmiscmisc
+    xorg.fontcursormisc
+  ];
+  fontsConf = makeFontsConf {
+    fontDirectories = fontDirs ++ [
+      "/Library/Fonts"
+      "~/Library/Fonts"
+    ];
+  };
+  fonts = import ./system-fonts.nix {
+    inherit stdenv xorg fontDirs;
+  };
+  # any X related programs expected to be available via $PATH
+  env = buildEnv {
+    name = "xquartz-env";
+    pathsToLink = [ "/bin" ];
+    paths = with xorg; [
+      # non-xorg
+      quartz-wm xterm fontconfig
+      # xorg
+      xlsfonts xfontsel
+      bdftopcf fontutil iceauth libXpm lndir luit makedepend mkfontdir
+      mkfontscale sessreg setxkbmap smproxy twm x11perf xauth xbacklight xclock
+      xcmsdb xcursorgen xdm xdpyinfo xdriinfo xev xeyes xfs xgamma xhost
+      xinput xkbcomp xkbevd xkbutils xkill xlsatoms xlsclients xmessage xmodmap
+      xpr xprop xrandr xrdb xrefresh xset xsetroot xvinfo xwd xwininfo xwud
+    ];
+  };
+in stdenv.mkDerivation {
+  name = "xquartz";
+  buildInputs = [ ruby makeWrapper ];
+  unpackPhase = "sourceRoot=.";
+  buildPhase = ":";
+  installPhase = ''
+    cp -rT ${xorg.xinit} $out
+    chmod -R u+w $out
+    cp -rT ${xorg.xorgserver} $out
+    chmod -R u+w $out
+
+    cp ${installer} $out/bin/xquartz-install
+
+    rm -r $out/LaunchAgents
+
+    fontsConfPath=$out/etc/X11/fonts.conf
+    cp ${fontsConf} $fontsConfPath
+
+    cp ${./startx} $out/bin/startx
+    substituteInPlace $out/bin/startx \
+      --replace "@PATH@"              "$out/bin:${env}" \
+      --replace "@XAUTH@"             "${xorg.xauth}/bin/xauth" \
+      --replace "@FONT_CACHE@"        "$out/bin/font_cache" \
+      --replace "@PRIVILEGED_STARTX@" "$out/lib/X11/xinit/privileged_startx" \
+      --replace "@DEFAULT_SERVER@"    "$out/bin/Xquartz" \
+      --replace "@DEFAULT_CLIENT@"    "${xterm}/bin/xterm" \
+      --replace "@XINIT@"             "$out/bin/xinit" \
+      --replace "@XINITRC@"           "$out/etc/X11/xinit/xinitrc" \
+      --replace "@XKEYBOARD_CONFIG@"  "${xkeyboard_config}/etc/X11/xkb" \
+      --replace "@FONTCONFIG_FILE@"   "$fontsConfPath"
+
+    wrapProgram $out/bin/Xquartz \
+      --set XQUARTZ_X11 $out/Applications/XQuartz.app/Contents/MacOS/X11 \
+      --set XKB_BINDIR "${xorg.xkbcomp}/bin"
+
+    defaultStartX="$out/bin/startx -- $out/bin/Xquartz"
+
+    ruby ${./patch_plist.rb} \
+      ${shellEscape (builtins.toXML {
+        XQUARTZ_DEFAULT_CLIENT = "${xterm}/bin/xterm";
+        XQUARTZ_DEFAULT_SHELL  = "${shell}";
+        XQUARTZ_DEFAULT_STARTX = "@STARTX@";
+        FONTCONFIG_FILE        = "@FONTCONFIG_FILE@";
+        XKB_BINDIR             = "${xorg.xkbcomp}/bin";
+      })} \
+      $out/Applications/XQuartz.app/Contents/Info.plist
+    substituteInPlace $out/Applications/XQuartz.app/Contents/Info.plist \
+      --replace "@STARTX@"          "$defaultStartX" \
+      --replace "@FONTCONFIG_FILE@" "$fontsConfPath"
+
+    rm $out/lib/X11/xinit/privileged_startx.d/*
+    cp ${./privileged} $out/lib/X11/xinit/privileged_startx.d/privileged
+    substituteInPlace $out/lib/X11/xinit/privileged_startx.d/privileged \
+      --replace "@PATH@"            "$out/bin:${env}" \
+      --replace "@FONTCONFIG_FILE@" "$fontsConfPath" \
+      --replace "@FONT_CACHE@"      "$out/bin/font_cache"
+
+    cp ${./font_cache} $out/bin/font_cache
+    substituteInPlace $out/bin/font_cache \
+      --replace "@PATH@"            "$out/bin:${env}" \
+      --replace "@ENCODINGSDIR@"    "${xorg.encodings}/share/fonts/X11/encodings" \
+      --replace "@MKFONTDIR@"       "${xorg.mkfontdir}/bin/mkfontdir" \
+      --replace "@MKFONTSCALE@"     "${xorg.mkfontscale}/bin/mkfontscale" \
+      --replace "@FC_CACHE@"        "${fontconfig}/bin/fc-cache" \
+      --replace "@FONTCONFIG_FILE@" "$fontsConfPath"
+
+    cp ${./xinitrc} $out/etc/X11/xinit/xinitrc
+    substituteInPlace $out/etc/X11/xinit/xinitrc \
+      --replace "@PATH@"            "$out/bin:${env}" \
+      --replace "@XSET@"            "${xorg.xset}/bin/xset" \
+      --replace "@XMODMAP@"         "${xorg.xmodmap}/bin/xmodmap" \
+      --replace "@XRDB@"            "${xorg.xrdb}/bin/xrdb" \
+      --replace "@SYSTEM_FONTS@"    "${fonts}/share/X11-fonts/" \
+      --replace "@QUARTZ_WM@"       "${quartz-wm}/bin/quartz-wm" \
+      --replace "@FONTCONFIG_FILE@" "$fontsConfPath"
+
+    cp ${./X11} $out/Applications/XQuartz.app/Contents/MacOS/X11
+    substituteInPlace $out/Applications/XQuartz.app/Contents/MacOS/X11 \
+      --replace "@DEFAULT_SHELL@"   "${shell}" \
+      --replace "@DEFAULT_STARTX@"  "$defaultStartX" \
+      --replace "@DEFAULT_CLIENT@"  "${xterm}/bin/xterm" \
+      --replace "@FONTCONFIG_FILE@" "$fontsConfPath"
+  '';
+  meta = with lib; {
+    platforms   = platforms.darwin;
+    maintainers = with maintainers; [ cstrahan ];
+    license     = licenses.mit;
+  };
+}

--- a/pkgs/servers/x11/xquartz/font_cache
+++ b/pkgs/servers/x11/xquartz/font_cache
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+export PATH=@PATH@:$PATH
+
+export FONTCONFIG_FILE="@FONTCONFIG_FILE@"
+ENCODINGSDIR="@ENCODINGSDIR@"
+FC_LOCKFILE=""
+
+# Are we caching system fonts or user fonts?
+system=0
+
+# Are we including OSX font dirs ({/,~/,/System/}Library/Fonts)
+osxfonts=1
+
+# Do we want to force a recache?
+force=0
+
+# How noisy are we?
+verbose=0
+
+# Check if the data in the given directory is newer than its cache
+check_dirty() {
+    local dir=$1
+    local fontfiles=""
+    local retval=1
+
+    # If the dir does not exist, we just exit
+    if [[ ! -d "${dir}" ]]; then
+        return 1
+    fi
+
+    # Create a list of all files in the dir
+    # Filter out config / cache files.  Ugly... counting down the day until
+    # xfs finally goes away
+    fontfiles="$(find ${dir}/ -maxdepth 1 -type f | awk '$0 !~ /fonts\..*$|^.*\.dir$/ {print}')"
+
+    # Fonts were deleted (or never there).  Kill off the caches
+    if [[ -z "${fontfiles}" ]] ; then
+        local f
+        for f in "${dir}"/fonts.* "${dir}"/encodings.dir; do
+            if [[ -f ${f} ]] ; then
+                rm -f "${f}"
+            fi
+        done
+        return 1
+    fi
+
+    # Force a recache
+    if [[ ${force} == 1 ]] ; then
+        retval=0
+    fi
+
+    # If we don't have our caches, we are dirty
+    if [[ ! -f "${dir}/fonts.list" || ! -f "${dir}/fonts.dir" || ! -f "${dir}/encodings.dir" ]]; then
+        retval=0
+    fi
+
+    # Check that no files were added or removed....
+    if [[ "${retval}" -ne 0 && "$(cat ${dir}/fonts.list)" != "${fontfiles}" ]] ; then
+        retval=0
+    fi
+
+    # Check that no files were updated....
+    if [[ "${retval}" -ne 0 ]] ; then
+        local changed="$(find ${dir}/ -type f -cnewer ${dir}/fonts.dir | awk '$0 !~ /fonts\..*$|^.*\.dir$/ {print}')"
+
+        if [[ -n "${changed}" ]] ; then
+            retval=0
+        fi
+    fi
+
+    # Recreate fonts.list since something changed
+    if [[ "${retval}" == 0 ]] ; then
+        echo "${fontfiles}" > "${dir}"/fonts.list
+    fi
+
+    return ${retval}
+}
+
+get_fontdirs() {
+    local d
+    if [[ $system == 1 ]] ; then
+        if [[ $osxfonts == 1 ]] ; then
+            find {/System/,/}Library/Fonts -type d
+        fi
+    else 
+        if [[ $osxfonts == 1 && -d "${HOME}/Library/Fonts" ]] ; then
+            find "${HOME}/Library/Fonts" -type d
+        fi
+
+        if [[ -d "${HOME}/.fonts" ]] ; then
+            find "${HOME}/.fonts" -type d
+        fi
+    fi
+}
+
+setup_fontdirs() {
+    local x=""
+    local fontdirs=""
+    local changed="no"
+
+    umask 022
+
+    if [[ $system == 1 ]] ; then
+        echo "font_cache: Scanning system font directories to generate X11 font caches"
+    else
+        echo "font_cache: Scanning user font directories to generate X11 font caches"
+    fi
+
+    OIFS=$IFS
+    IFS='
+'
+    for x in $(get_fontdirs) ; do
+        if [[ -d "${x}" ]] && check_dirty "${x}" ; then
+            if [[ -z "${fontdirs}" ]] ; then
+                fontdirs="${x}"
+            else
+                fontdirs="${fontdirs}${IFS}${x}"
+            fi
+        fi
+    done
+
+    if [[ -n "${fontdirs}" ]] ; then
+        echo "font_cache: Making fonts.dir for updated directories."
+        for x in ${fontdirs} ; do
+            if [[ $verbose == 1 ]] ; then
+                echo "font_cache:    ${x}"
+            fi
+
+            # First, generate fonts.scale for scaleable fonts that might be there
+            @MKFONTSCALE@ \
+                -a $ENCODINGSDIR/encodings.dir \
+                -a $ENCODINGSDIR/large/encodings.dir \
+                -- ${x}
+
+            # Next, generate fonts.dir
+            if [[ $verbose == 1 ]] ; then
+                @MKFONTDIR@ \
+                    -e $ENCODINGSDIR \
+                    -e $ENCODINGSDIR/large \
+                    -- ${x}
+            else
+                @MKFONTDIR@ \
+                    -e $ENCODINGSDIR \
+                    -e $ENCODINGSDIR/large \
+                    -- ${x} > /dev/null
+            fi
+        done
+    fi
+    IFS=$OIFS
+
+    # Finally, update fontconfig's cache
+    echo "font_cache: Updating FC cache"
+    if [[ $system == 1 ]] ; then
+        @FC_CACHE@ -s \
+            $([[ $force == 1 ]] && echo "-f -r") \
+            $([[ $verbose == 1 ]] && echo "-v")
+    else
+        @FC_CACHE@ \
+            $([[ $force == 1 ]] && echo "-f -r") \
+            $([[ $verbose == 1 ]] && echo "-v")
+    fi
+    echo "font_cache: Done"
+}
+
+do_usage() {
+    echo "font_cache [options]"
+    echo "    -f, --force        : Force cache recreation"
+    echo "    -n, --no-osxfonts  : Just cache X11 font directories"
+    echo "                         (-n just pertains to XFont cache, not fontconfig)"
+    echo "    -s, --system       : Cache system font dirs instead of user dirs"
+    echo "    -v, --verbose      : Verbose Output"
+}
+
+cleanup() {
+    [[ -r "${FC_LOCKFILE}" ]] && rm -f "${FC_LOCKFILE}"
+    exit 1
+}
+
+while [[ $# -gt 0 ]] ; do
+    case $1 in
+        -s|--system) system=1 ;;
+        -f|--force) force=1 ;;
+        -v|--verbose) verbose=1 ;;
+        -n|--no-osxfonts) osxfonts=0 ;;
+        --help) do_usage ; exit 0 ;;
+        *) do_usage ; exit 1 ;;
+    esac
+    shift
+done
+
+if [[ $system == 1 ]] ; then
+    FC_LOCKFILE="/tmp/font_cache.$UID.lock"
+elif [[ -w "${TMPDIR}" ]] ; then
+    FC_LOCKFILE="${TMPDIR}/font_cache.lock"
+elif [[ -w "/tmp" ]] ; then
+    FC_LOCKFILE="/tmp/font_cache.$UID.lock"
+else
+    FC_LOCKFILE="${HOME}/.font_cache.lock"
+fi
+
+if [[ -x /usr/bin/lockfile ]] ; then
+    if /usr/bin/lockfile -r 0 -l 240 -s 4 -! "${FC_LOCKFILE}" ; then
+            echo "font_cache is already running." >&2
+            echo "If you believe this to be erroneous, please remove ${FC_LOCKFILE}." >&2
+            exit 1
+    fi
+else
+    if [[ -r "${FC_LOCKFILE}" ]] ; then
+        read OLD_PID < "${FC_LOCKFILE}"
+        if kill -0 ${OLD_PID} >& /dev/null ; then
+            echo "font_cache is already running with PID ${OLD_PID}." >&2
+            echo "If you believe this to be erroneous, please remove ${FC_LOCKFILE}." >&2
+            exit 1
+        fi
+
+        echo "Removing stale ${FC_LOCKFILE}" >&2
+        rm -f "${FC_LOCKFILE}"
+    fi
+
+    echo $$ > "${FC_LOCKFILE}"
+
+    if [[ ! -r "${FC_LOCKFILE}" ]] ; then
+        echo "Unable to write to ${FC_LOCKFILE}." >&2
+        exit 1
+    fi
+
+    # Now make sure we didn't collide mid-air
+    read OLD_PID < "${FC_LOCKFILE}"
+    if [[ $$ != ${OLD_PID} ]] ; then
+        echo "font_cache is already running with PID ${OLD_PID}." >&2
+        exit 1
+    fi
+fi
+
+trap cleanup SIGINT SIGQUIT SIGABRT SIGTERM
+
+setup_fontdirs
+
+rm -f "${FC_LOCKFILE}"

--- a/pkgs/servers/x11/xquartz/org.nixos.xquartz.privileged_startx.plist
+++ b/pkgs/servers/x11/xquartz/org.nixos.xquartz.privileged_startx.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>org.nixos.xquartz.privileged_startx</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>@PRIVILEGED_STARTX@</string>
+      <string>-d</string>
+      <string>@PRIVILEGED_STARTX_D@</string>
+    </array>
+    <key>MachServices</key>
+    <dict>
+      <key>org.nixos.xquartz.privileged_startx</key>
+      <true/>
+    </dict>
+    <key>TimeOut</key>
+    <integer>120</integer>
+    <key>EnableTransactions</key>
+    <true/>
+  </dict>
+</plist>

--- a/pkgs/servers/x11/xquartz/org.nixos.xquartz.startx.plist
+++ b/pkgs/servers/x11/xquartz/org.nixos.xquartz.startx.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>org.nixos.xquartz.startx</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>@LAUNCHD_STARTX@</string>
+      <string>@STARTX@</string>
+      <string>--</string>
+      <string>@XQUARTZ@</string>
+    </array>
+    <key>Sockets</key>
+    <dict>
+      <key>org.nixos.xquartz:0</key>
+      <dict>
+        <key>SecureSocketWithKey</key>
+        <string>DISPLAY</string>
+      </dict>
+    </dict>
+    <key>ServiceIPC</key>
+    <true/>
+    <key>EnableTransactions</key>
+    <true/>
+  </dict>
+</plist>

--- a/pkgs/servers/x11/xquartz/patch_plist.rb
+++ b/pkgs/servers/x11/xquartz/patch_plist.rb
@@ -1,0 +1,47 @@
+require 'rexml/document'
+
+# This script is for setting environment variables in OSX applications.
+# 
+# This script takes two arguments:
+# 1) A Nix attrset serialized via `builtins.toXML'
+# 2) The path to an OSX app's Info.plist file.
+
+def main(serialized_attrs, plist_path)
+  env          = attrs_to_hash(serialized_attrs)
+  doc          = REXML::Document.new(File.open(plist_path, &:read))
+  topmost_dict = doc.root.elements.detect { |e| e.name == "dict" }
+  topmost_dict.add_element("key").tap do |key|
+    key.text = "LSEnvironment"
+  end
+  topmost_dict.add_element(env_to_dict(env))
+
+  formatter = REXML::Formatters::Pretty.new(2)
+  formatter.compact = true
+  formatter.write(doc, File.open(plist_path, "w"))
+end
+
+# Convert a `builtins.toXML' serialized attrs to a hash.
+# This assumes the values are strings.
+def attrs_to_hash(serialized_attrs)
+  hash = {}
+  env_vars = REXML::Document.new(serialized_attrs)
+  env_vars.root.elements[1].elements.each do |attr|
+    name = attr.attribute("name")
+    value = attr.elements.first.attribute("value")
+    hash[name] = value
+  end
+  hash
+end
+
+def env_to_dict(env)
+  dict = REXML::Element.new("dict")
+  env.each do |k, v|
+    key = dict.add_element("key")
+    key.text = k
+    string = dict.add_element("string")
+    string.text = v
+  end
+  dict
+end
+
+main(ARGV[0], ARGV[1])

--- a/pkgs/servers/x11/xquartz/privileged
+++ b/pkgs/servers/x11/xquartz/privileged
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+export PATH=@PATH@:$PATH
+export FONTCONFIG_FILE="@FONTCONFIG_FILE@"
+
+# Our usage of mktemp fails with GNU, so prefer /usr/bin to hopefully
+# get BSD mktemp
+if [ -x /usr/bin/mktemp ] ; then
+    MKTEMP=/usr/bin/mktemp
+else
+    MKTEMP=mktemp
+fi
+
+STAT=/usr/bin/stat
+
+for dir in /tmp/.ICE-unix /tmp/.X11-unix /tmp/.font-unix ; do
+    success=0
+    for attempt in 1 2 3 4 5 ; do
+        check=`${STAT} -f '%#p %u %g' ${dir} 2> /dev/null`
+        if [ "${check}" = "041777 0 0" ] ; then
+            success=1
+            break
+        elif [ -n "${check}" ] ; then
+            saved=$(${MKTEMP} -d ${dir}-XXXXXXXX)
+            mv ${dir} ${saved}
+            echo "${dir} exists but is insecure.  It has been moved into ${saved}" >&2
+        fi
+
+        # if $dir exists and is a symlink (ie protect against a race)
+        if ${MKTEMP} -d ${dir} >& /dev/null ; then
+            chmod 1777 $dir
+            chown root:wheel $dir
+            success=1
+            break
+        fi
+    done
+
+    if [ "${success}" -eq 0 ] ; then
+        echo "Could not successfully create ${dir}" >&2
+    fi
+done
+
+@FONT_CACHE@ -s &

--- a/pkgs/servers/x11/xquartz/startx
+++ b/pkgs/servers/x11/xquartz/startx
@@ -1,0 +1,232 @@
+#!/bin/sh
+
+# vim :set ts=4 sw=4 sts=4 et :
+
+#
+# This is just a sample implementation of a slightly less primitive
+# interface than xinit.  It looks for user .xinitrc and .xserverrc
+# files, then system xinitrc and xserverrc files, else lets xinit choose
+# its default.  The system xinitrc should probably do things like check
+# for .Xresources files and merge them in, start up a window manager,
+# and pop a clock and several xterms.
+#
+# Site administrators are STRONGLY urged to write nicer versions.
+#
+
+unset DBUS_SESSION_BUS_ADDRESS
+unset SESSION_MANAGER
+
+
+# Bourne shell does not automatically export modified environment variables
+# so export the new PATH just in case the user changes the shell
+export PATH=@PATH@:$PATH
+
+export FONTCONFIG_FILE="@FONTCONFIG_FILE@"
+
+userclientrc=$HOME/.xinitrc
+sysclientrc=@XINITRC@
+
+userserverrc=$HOME/.xserverrc
+sysserverrc=@XINITRC@
+defaultclient=@DEFAULT_CLIENT@ # xterm
+defaultserver=@DEFAULT_SERVER@
+defaultclientargs=""
+defaultserverargs=""
+defaultdisplay=":0"
+clientargs=""
+serverargs=""
+
+export X11_PREFS_DOMAIN=org.nixos.xquartz".X11"
+
+# Initialize defaults (this will cut down on "safe" error messages)
+if ! /usr/bin/defaults read $X11_PREFS_DOMAIN cache_fonts > /dev/null 2>&1 ; then
+    /usr/bin/defaults write $X11_PREFS_DOMAIN cache_fonts -bool true
+fi
+
+if ! /usr/bin/defaults read $X11_PREFS_DOMAIN no_auth > /dev/null 2>&1 ; then
+    /usr/bin/defaults write $X11_PREFS_DOMAIN no_auth -bool false
+fi
+
+if ! /usr/bin/defaults read $X11_PREFS_DOMAIN nolisten_tcp > /dev/null 2>&1 ; then
+    /usr/bin/defaults write $X11_PREFS_DOMAIN nolisten_tcp -bool true
+fi
+
+# First, start caching fonts
+if [ x`/usr/bin/defaults read $X11_PREFS_DOMAIN cache_fonts` = x1 ] ; then
+    @FONT_CACHE@ &
+fi
+
+# a race to create /tmp/.X11-unix
+@PRIVILEGED_STARTX@
+
+if [ x`/usr/bin/defaults read $X11_PREFS_DOMAIN no_auth` = x0 ] ; then
+    enable_xauth=1
+else
+    enable_xauth=0
+fi
+
+if [ x`defaults read $X11_PREFS_DOMAIN nolisten_tcp` = x1 ] ; then
+    defaultserverargs="$defaultserverargs -nolisten tcp"
+fi
+
+# The second check is the real one.  The first is to hopefully avoid
+# needless syslog spamming.
+if /usr/bin/defaults read $X11_PREFS_DOMAIN 2> /dev/null | grep -q 'dpi' && /usr/bin/defaults read $X11_PREFS_DOMAIN dpi > /dev/null 2>&1 ; then
+    defaultserverargs="$defaultserverargs -dpi `/usr/bin/defaults read $X11_PREFS_DOMAIN dpi`"
+fi
+
+# Automatically determine an unused $DISPLAY
+d=0
+while true ; do
+    [ -e /tmp/.X$d-lock ] || break
+    d=$(($d + 1))
+done
+defaultdisplay=":$d"
+unset d
+
+whoseargs="client"
+while [ x"$1" != x ]; do
+    case "$1" in
+    # '' required to prevent cpp from treating "/*" as a C comment.
+    /''*|\./''*)
+    if [ "$whoseargs" = "client" ]; then
+        if [ x"$client" = x ] && [ x"$clientargs" = x ]; then
+        client="$1"
+        else
+        clientargs="$clientargs $1"
+        fi
+    else
+        if [ x"$server" = x ] && [ x"$serverargs" = x ]; then
+        server="$1"
+        else
+        serverargs="$serverargs $1"
+        fi
+    fi
+    ;;
+    --)
+    whoseargs="server"
+    ;;
+    *)
+    if [ "$whoseargs" = "client" ]; then
+        clientargs="$clientargs $1"
+    else
+        # display must be the FIRST server argument
+        if [ x"$serverargs" = x ] && \
+         expr "$1" : ':[0-9][0-9]*$' > /dev/null 2>&1; then
+        display="$1"
+        else
+        serverargs="$serverargs $1"
+        fi
+    fi
+    ;;
+    esac
+    shift
+done
+
+# process client arguments
+if [ x"$client" = x ]; then
+    client=$defaultclient
+
+    # For compatibility reasons, only use startxrc if there were no client command line arguments
+    if [ x"$clientargs" = x ]; then
+        if [ -f "$userclientrc" ]; then
+            client=$userclientrc
+        elif [ -f "$sysclientrc" ]; then
+            client=$sysclientrc
+        fi
+    fi
+fi
+
+# if no client arguments, use defaults
+if [ x"$clientargs" = x ]; then
+    clientargs=$defaultclientargs
+fi
+
+# process server arguments
+if [ x"$server" = x ]; then
+    server=$defaultserver
+
+    # For compatibility reasons, only use xserverrc if there were no server command line arguments
+    if [ x"$serverargs" = x -a x"$display" = x ]; then
+      if [ -f "$userserverrc" ]; then
+          server=$userserverrc
+      elif [ -f "$sysserverrc" ]; then
+          server=$sysserverrc
+      fi
+    fi
+fi
+
+# if no server arguments, use defaults
+if [ x"$serverargs" = x ]; then
+    serverargs=$defaultserverargs
+fi
+
+# if no display, use default
+if [ x"$display" = x ]; then
+    display=$defaultdisplay
+fi
+
+if [ x"$enable_xauth" = x1 ] ; then
+    if [ x"$XAUTHORITY" = x ]; then
+        XAUTHORITY=$HOME/.Xauthority
+        export XAUTHORITY
+    fi
+
+    removelist=
+
+    # set up default Xauth info for this machine
+    hostname=`/bin/hostname`
+
+    authdisplay=${display:-:0}
+
+    mcookie=`/usr/bin/openssl rand -hex 16`
+
+    if test x"$mcookie" = x; then
+        echo "Couldn't create cookie"
+        exit 1
+    fi
+    dummy=0
+
+    # create a file with auth information for the server. ':0' is a dummy.
+    xserverauthfile=$HOME/.serverauth.$$
+    trap "rm -f '$xserverauthfile'" HUP INT QUIT ILL TRAP KILL BUS TERM
+    @XAUTH@ -q -f "$xserverauthfile" << EOF
+add :$dummy . $mcookie
+EOF
+
+    xserverauthfilequoted=$(echo ${xserverauthfile} | sed "s/'/'\\\\''/g")
+    serverargs=${serverargs}" -auth '"${xserverauthfilequoted}"'"
+
+    # now add the same credentials to the client authority file
+    # if '$displayname' already exists do not overwrite it as another
+    # server man need it. Add them to the '$xserverauthfile' instead.
+    for displayname in $authdisplay $hostname$authdisplay; do
+        authcookie=`@XAUTH@ list "$displayname" \
+        | sed -n "s/.*$displayname[[:space:]*].*[[:space:]*]//p"` 2>/dev/null;
+        if [ "z${authcookie}" = "z" ] ; then
+            @XAUTH@ -q << EOF
+add $displayname . $mcookie
+EOF
+        removelist="$displayname $removelist"
+        else
+            dummy=$(($dummy+1));
+            @XAUTH@ -q -f "$xserverauthfile" << EOF
+add :$dummy . $authcookie
+EOF
+        fi
+    done
+fi
+
+eval @XINIT@ \"$client\" $clientargs -- \"$server\" $display $serverargs "-xkbdir" "@XKEYBOARD_CONFIG@"
+retval=$?
+
+if [ x"$enable_xauth" = x1 ] ; then
+    if [ x"$removelist" != x ]; then
+        @XAUTH@ remove $removelist
+    fi
+    if [ x"$xserverauthfile" != x ]; then
+        rm -f "$xserverauthfile"
+    fi
+fi
+
+exit $retval

--- a/pkgs/servers/x11/xquartz/system-fonts.nix
+++ b/pkgs/servers/x11/xquartz/system-fonts.nix
@@ -1,0 +1,36 @@
+{ stdenv, xorg, fontDirs }:
+
+stdenv.mkDerivation {
+  name = "xquartz-system-fonts";
+  buildInputs = [
+    xorg.mkfontdir xorg.mkfontscale
+  ];
+  buildCommand = ''
+    source $stdenv/setup
+
+    for i in ${toString fontDirs} ; do
+      if [ -d $i/ ]; then
+        list="$list $i";
+      fi;
+    done
+    list=$(find $list -name fonts.dir -o -name '*.ttf' -o -name '*.otf');
+    fontDirs=''';
+    for i in $list ; do
+      fontDirs="$fontDirs $(dirname $i)";
+    done;
+    mkdir -p $out/share/X11-fonts/;
+    find $fontDirs -type f -o -type l | while read i; do
+      j="''${i##*/}"
+      if ! test -e "$out/share/X11-fonts/''${j}"; then
+        ln -s "$i" "$out/share/X11-fonts/''${j}";
+      fi;
+    done;
+    cd $out/share/X11-fonts/
+    rm fonts.dir
+    rm fonts.scale
+    rm fonts.alias
+    mkfontdir
+    mkfontscale
+    cat $( find ${xorg.fontalias}/ -name fonts.alias) >fonts.alias
+  '';
+}

--- a/pkgs/servers/x11/xquartz/xinitrc
+++ b/pkgs/servers/x11/xquartz/xinitrc
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+export PATH=@PATH@:$PATH
+
+userresources=$HOME/.Xresources
+usermodmap=$HOME/.Xmodmap
+
+# Fix ridiculously slow key repeat.
+@XSET@ r rate
+
+# merge in defaults and keymaps
+
+if [ -f "$userresources" ]; then
+    if [ -x /usr/bin/cpp ] ; then
+        @XRDB@ -merge "$userresources"
+    else
+        @XRDB@ -nocpp -merge "$userresources"
+    fi
+fi
+
+if [ -f "$usermodmap" ]; then
+    @XMODMAP@ "$usermodmap"
+fi
+
+fontpath="@SYSTEM_FONTS@"
+[ -e "$HOME"/.fonts/fonts.dir ] && fontpath="$fontpath,$HOME/.fonts"
+[ -e "$HOME"/Library/Fonts/fonts.dir ] && fontpath="$fontpath,$HOME/Library/Fonts"
+[ -e /Library/Fonts/fonts.dir ] && fontpath="$fontpath,/Library/Fonts"
+[ -e /System/Library/Fonts/fonts.dir ] && fontpath="$fontpath,/System/Library/Fonts"
+@XSET@ fp= "$fontpath"
+unset fontpath
+
+if [ -d "${HOME}/.xinitrc.d" ] ; then
+    for f in "${HOME}"/.xinitrc.d/*.sh ; do
+        [ -x "$f" ] && . "$f"
+    done
+    unset f
+fi
+
+exec @QUARTZ_WM@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5674,9 +5674,12 @@ let
     grsecEnabled = true;
   });
   mesa_glu =  mesaDarwinOr (callPackage ../development/libraries/mesa-glu { });
-  mesa_drivers = let
-      mo = mesa_noglu.override { grsecEnabled = config.grsecurity or false; };
-    in mo.drivers;
+  mesa_drivers = mesaDarwinOr (
+    let mo = mesa_noglu.override {
+      grsecEnabled = config.grsecurity or false;
+    };
+    in mo.drivers
+  );
   mesa = mesaDarwinOr (buildEnv {
     name = "mesa-${mesa_noglu.version}";
     paths = [ mesa_noglu mesa_glu ];

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -382,21 +382,21 @@ let
       };
 
       xorg = {
-        fontadobe100dpi = linux;
-        fontadobe75dpi = linux;
-        fontbh100dpi = linux;
-        fontbhlucidatypewriter100dpi = linux;
-        fontbhlucidatypewriter75dpi = linux;
-        fontbhttf = linux;
-        fontcursormisc = linux;
-        fontmiscmisc = linux;
-        iceauth = linux;
-        libX11 = linux;
-        lndir = all;
-        setxkbmap = linux;
-        xauth = linux;
-        xbitmaps = linux;
-        xev = linux;
+        fontadobe100dpi = linux ++ darwin;
+        fontadobe75dpi = linux ++ darwin;
+        fontbh100dpi = linux ++ darwin;
+        fontbhlucidatypewriter100dpi = linux ++ darwin;
+        fontbhlucidatypewriter75dpi = linux ++ darwin;
+        fontbhttf = linux ++ darwin;
+        fontcursormisc = linux ++ darwin;
+        fontmiscmisc = linux ++ darwin;
+        iceauth = linux ++ darwin;
+        libX11 = linux ++ darwin;
+        lndir = all ++ darwin;
+        setxkbmap = linux ++ darwin;
+        xauth = linux ++ darwin;
+        xbitmaps = linux ++ darwin;
+        xev = linux ++ darwin;
         xf86inputevdev = linux;
         xf86inputkeyboard = linux;
         xf86inputmouse = linux;
@@ -408,18 +408,18 @@ let
         xf86videovesa = linux;
         xf86videovmware = linux;
         xf86videomodesetting = linux;
-        xfs = linux;
-        xinput = linux;
-        xkbcomp = linux;
-        xlsclients = linux;
-        xmessage = linux;
-        xorgserver = linux;
-        xprop = linux;
-        xrandr = linux;
-        xrdb = linux;
-        xset = linux;
-        xsetroot = linux;
-        xwininfo = linux;
+        xfs = linux ++ darwin;
+        xinput = linux ++ darwin;
+        xkbcomp = linux ++ darwin;
+        xlsclients = linux ++ darwin;
+        xmessage = linux ++ darwin;
+        xorgserver = linux ++ darwin;
+        xprop = linux ++ darwin;
+        xrandr = linux ++ darwin;
+        xrdb = linux ++ darwin;
+        xset = linux ++ darwin;
+        xsetroot = linux ++ darwin;
+        xwininfo = linux ++ darwin;
       };
 
       xfce = {


### PR DESCRIPTION
I'm opening this ticket to track my work on getting XQuartz into Nixpkgs for X11 on Darwin.

~~As of writing this, this branch is incredibly chopped up and unstable. I'd would suggest waiting for me to give the thumbs up here before diving in and trying to make any sense of it.~~

Some notes:
- [The XQuartz repo](http://cgit.freedesktop.org/~jeremyhu/xserver/)
- [XQuartz build instructions](http://xquartz.macosforge.org/trac/wiki/DeveloperInfo)
- [Some build scripts](https://xquartz.macosforge.org/trac/browser/trunk)
- The MacPorts Portfile: [1.14.6](https://trac.macports.org/browser/trunk/dports/x11/xorg-server/Portfile?rev=119711), [1.15.1](https://trac.macports.org/browser/trunk/dports/x11/xorg-server/Portfile?rev=120521)
- [MacPorts guide](http://guide.macports.org/)
- The XQuartz project bundles both `xorgserver` (`X`, `Xvfb`, `Xnest`, `Xephyr`, `Xfake`, etc) and the `XQuartz.app` in the same source tree. They must be compiled separately (the `--disable-xquartz --enable-xvfb --enable-xnest --enable-kdrive` configure flags mentioned in the build instructions)
- `xorgserver` (sans `XQuartz.app`) builds fine with `stdenv` (haven't tested that it functions properly yet), while the `XQuartz.app` will only build with `clangStdenv`
- With some minor patches (replacing `clock_gettime`) in `libdrm`, all of `xorgserver`'s dependencies build as-is
- `xinit` needs to be built with `clangStdenv`. Currently, the generated `pkgs/servers/x11/xorg/default.nix` file does not support overriding the stdenv per package, so I'll need to come up with some solution to that.
