### PR TITLE
Added package for Japanese IPAFonts.

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -130,6 +130,12 @@
     url = http://www.opensource.org/licenses/ISC;
   };
 
+  ipa = {
+    shortName = "IPA 1.0";
+    fullName = "IPA Font License v1.0";
+    url = http://ipafont.ipa.go.jp/ipafont/;
+  };
+
   ipl10 = {
     shortName = "IPL 1.0";
     fullName = "IBM Public License Version 1.0";

--- a/pkgs/data/fonts/ipafont/default.nix
+++ b/pkgs/data/fonts/ipafont/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "ipafont-003.03";
+
+  src = fetchurl {
+    url = "http://ipafont.ipa.go.jp/ipafont/IPAfont00303.php";
+    sha256 = "f755ed79a4b8e715bed2f05a189172138aedf93db0f465b4e20c344a02766fe5";
+  };
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    cp ./IPAfont00303/*.ttf $out/share/fonts/opentype/
+  '';
+
+  meta = {
+    description = "Japanese font package with Mincho and Gothic fonts";
+    longDescription = ''
+      IPAFont is a Japanese font developed by the Information-technology
+      Promotion Agency of Japan. It provides both Mincho and Gothic fonts,
+      suitable for both display and printing.
+    '';
+    homepage = http://ipafont.ipa.go.jp/ipafont/;
+    license = stdenv.lib.licenses.ipa;
+    maintainers = [ stdenv.lib.maintainers.auntie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7826,6 +7826,8 @@ let
 
   inconsolata = callPackage ../data/fonts/inconsolata {};
 
+  ipafont = callPackage ../data/fonts/ipafont {};
+
   junicode = callPackage ../data/fonts/junicode { };
 
   liberation_ttf = callPackage ../data/fonts/redhat-liberation-fonts { };


### PR DESCRIPTION
It took me a while to figure out how to test these fonts on all of my computers. I had to nix-rebuild from my own patched nixpkgs in order to add the font path to /etc/fonts/fonts.conf properly.

Anyway, here's some more Japanese fonts. I still like the kochi-substitute fonts, but these IPA fonts are definitely more free.
