### PR TITLE
nixos/pam: make pam_loginuid optional if in container

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -189,7 +189,9 @@ let
           session required pam_env.so envfile=${config.system.build.pamEnvironment}
           session required pam_unix.so
           ${optionalString cfg.setLoginUid
-              "session required pam_loginuid.so"}
+              "session ${
+                if config.boot.isContainer then "optional" else "required"
+              } pam_loginuid.so"}
           ${optionalString cfg.updateWtmp
               "session required ${pkgs.pam}/lib/security/pam_lastlog.so silent"}
           ${optionalString config.users.ldap.enable


### PR DESCRIPTION
This is needed if `audit_control` is not dropped in container, like in `libcontainer` in `docker`.
