### PR TITLE
Add namecoin cryptocurrency

### DIFF
--- a/pkgs/applications/misc/namecoin/default.nix
+++ b/pkgs/applications/misc/namecoin/default.nix
@@ -1,0 +1,37 @@
+{ fetchgit, stdenv, db4, boost, openssl, unzip }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.75";
+  name = "namecoin-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/namecoin/namecoin";
+    rev = "31ea638d4ba7f0a3011cb25483f4c7d293134c7a";
+    sha256 = "c14a5663cba675b3508937a26a812316559938fd7b64659dd00749a9f5d7e9e0";
+  };
+
+  # Don't build with miniupnpc due to namecoin using a different verison that
+  # ships with NixOS and it is API incompatible.
+  buildInputs = [ db4 boost openssl unzip ];
+
+  patchPhase = ''
+    sed -e 's/-Wl,-Bstatic//g' -e 's/-l gthread-2.0//g' -e 's/-l z//g' -i src/Makefile
+  '';
+
+  buildPhase = ''
+    make -C src INCLUDEPATHS= LIBPATHS=
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp src/namecoind $out/bin
+  '';
+
+  meta = {
+    description = "Decentralized open source information registration and transfer system based on the Bitcoin cryptocurrency";
+    homepage = "http://namecoin.info";
+    license = "MIT";
+    maintainers = [ "Chris Double <chris.double@double.co.nz>" ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/misc/namecoin/qt.nix
+++ b/pkgs/applications/misc/namecoin/qt.nix
@@ -1,0 +1,33 @@
+{ fetchgit, stdenv, db4, boost, openssl, qt4, unzip, namecoin }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.75";
+  name = "namecoin-qt-${version}";
+
+  src = namecoin.src;
+
+  # Don't build with miniupnpc due to namecoin using a different verison that
+  # ships with NixOS and it is API incompatible.
+  buildInputs = [ db4 boost openssl unzip qt4 ];
+
+  configurePhase = ''
+    qmake USE_UPNP=-
+  '';
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp namecoin-qt $out/bin
+  '';
+
+  meta = {
+    description = "Decentralized open source information registration and transfer system based on the Bitcoin cryptocurrency";
+    homepage = "http://namecoin.info";
+    license = "MIT";
+    maintainers = [ "Chris Double <chris.double@double.co.nz>" ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9169,6 +9169,9 @@ let
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
 
+  namecoin = callPackage ../applications/misc/namecoin { };
+  namecoinqt = callPackage ../applications/misc/namecoin/qt.nix { };
+
   pcmanfm = callPackage ../applications/misc/pcmanfm { };
 
   ruby_gpgme = callPackage ../development/libraries/ruby_gpgme {


### PR DESCRIPTION
Adds support for namecoin, a bitcoin variant for key/value storage. Has 'namecoind', the cli version, and 'namecoin-qt', the GUI version.
