### PR TITLE
Fixed dwb startup issue

### DIFF
--- a/pkgs/applications/networking/browsers/dwb/default.nix
+++ b/pkgs/applications/networking/browsers/dwb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, pkgconfig, makeWrapper, libsoup, webkit, gtk3, gnutls, json_c,
-  m4, glib_networking, gsettings_desktop_schemas }:
+  m4, glib_networking, gsettings_desktop_schemas, dconf }:
 
 stdenv.mkDerivation {
   name = "dwb-2014-06-03";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   preFixup=''
     wrapProgram "$out/bin/dwb" \
-     --prefix GIO_EXTRA_MODULES : "${glib_networking}/lib/gio/modules" \
+     --prefix GIO_EXTRA_MODULES : "${glib_networking}/lib/gio/modules:${dconf}/lib/gio/modules" \
      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share"
     wrapProgram "$out/bin/dwbem" \
      --prefix GIO_EXTRA_MODULES : "${glib_networking}/lib/gio/modules"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8169,7 +8169,7 @@ let
 
   dvdauthor = callPackage ../applications/video/dvdauthor { };
 
-  dwb = callPackage ../applications/networking/browsers/dwb { };
+  dwb = callPackage ../applications/networking/browsers/dwb { dconf = gnome3.dconf; };
 
   dwm = callPackage ../applications/window-managers/dwm {
     patches = config.dwm.patches or [];


### PR DESCRIPTION
This solves the following issue:

```
'GLib-GIO-Message: Using the 'memory' GSettings backend. Your settings will not be saved or shared with other applications.'
```

in the same way as in 413ebfb2469b394a4f4d48ba3567be3c68344722 and a8f6601fc63336eec82189b1568e4a47c6b67205.
