### PR TITLE
wip: Allow booting nixos from a subdirectory of the root device

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -26,6 +26,7 @@ let
         version extraConfig extraPerEntryConfig extraEntries
         extraEntriesBeforeNixOS extraPrepareConfig configurationLimit copyKernels timeout
         default devices explicitBootRoot;
+      inherit (config.lib.fileSystems) rootDirectory;
       path = (makeSearchPath "bin" [
         pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.findutils pkgs.diffutils
       ]) + ":" + (makeSearchPath "sbin" [

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -5,6 +5,7 @@ use File::Basename;
 use File::Path;
 use File::stat;
 use File::Copy;
+use File::Spec;
 use POSIX;
 use Cwd;
 
@@ -40,6 +41,7 @@ my $copyKernels = get("copyKernels") eq "true";
 my $timeout = int(get("timeout"));
 my $defaultEntry = int(get("default"));
 my $explicitBootRoot = get("explicitBootRoot");
+my $rootDirectory = get("rootDirectory");
 $ENV{'PATH'} = get("path");
 
 die "unsupported GRUB version\n" if $grubVersion != 1 && $grubVersion != 2;
@@ -139,7 +141,7 @@ mkpath("/boot/kernels", 0, 0755) if $copyKernels;
 
 sub copyToKernelsDir {
     my ($path) = @_;
-    return $path unless $copyKernels;
+    return File::Spec->canonpath("$rootDirectory/$path") unless $copyKernels;
     $path =~ /\/nix\/store\/(.*)/ or die;
     my $name = $1; $name =~ s/\//-/g;
     my $dst = "/boot/kernels/$name";
@@ -152,7 +154,7 @@ sub copyToKernelsDir {
         rename $tmp, $dst or die "cannot rename $tmp to $dst\n";
     }
     $copied{$dst} = 1;
-    return "$bootRoot/kernels/$name";
+    return File::Spec->canonpath("$rootDirectory/$bootRoot/kernels/$name");
 }
 
 sub addEntry {

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -22,11 +22,10 @@ let
     allowMissing = true;
   };
 
-
   needsCifsUtils = kernelPackages.kernel ? features
                 && kernelPackages.kernel.features ? needsCifsUtils
                 && kernelPackages.kernel.features.needsCifsUtils
-                && any (fs: fs.fsType == "cifs") fileSystems;
+                && any (fs: fs.fsType == "cifs") config.lib.fileSystems.orderedForBoot;
 
   busybox =
     if needsCifsUtils
@@ -128,15 +127,6 @@ let
       ${config.boot.initrd.extraUtilsCommandsTest}
     ''; # */
 
-
-  # The initrd only has to mount / or any FS marked as necessary for
-  # booting (such as the FS containing /nix/store, or an FS needed for
-  # mounting /, like / on a loopback).
-  fileSystems = filter
-    (fs: fs.neededForBoot || elem fs.mountPoint [ "/" "/nix" "/nix/store" "/var" "/var/log" "/var/lib" "/etc" ])
-    (attrValues config.fileSystems);
-
-
   udevRules = pkgs.stdenv.mkDerivation {
     name = "udev-rules";
     buildCommand = ''
@@ -204,7 +194,7 @@ let
 
     fsInfo =
       let f = fs: [ fs.mountPoint (if fs.device != null then fs.device else "/dev/disk/by-label/${fs.label}") fs.fsType fs.options ];
-      in pkgs.writeText "initrd-fsinfo" (concatStringsSep "\n" (concatMap f fileSystems));
+      in pkgs.writeText "initrd-fsinfo" (concatStringsSep "\n" (concatMap f config.lib.fileSystems.orderedForBoot));
   };
 
 

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -213,6 +213,48 @@ in
 
       in listToAttrs (map formatDevice (filter (fs: fs.autoFormat) fileSystems));
 
+    lib.fileSystems = let
+      # The initrd only has to mount / or any FS marked as necessary for
+      # booting (such as the FS containing /nix/store, or an FS needed for
+      # mounting /, like / on a loopback).
+      fsList = filter (fs: fs.neededForBoot || elem fs.mountPoint [ "/" "/nix" "/nix/store" "/var" "/var/log" "/var/lib" "/etc" ]) (attrValues config.fileSystems);
+
+      # Returns the file system to be mounted in order to access the given path.
+      # Heuristic: we find the file system with the mount point having the longest prefix for the given path.
+      # If the given path has prefix /dev/* then it returns null.
+      # Example: for mount points /, /a, /a/b, it returns /a/b in order to access the path /a/b/c.
+      requiredForPath = fileSystems: path:
+        if path == null || hasPrefix "/dev/" path
+          then null
+          else fold (fs: best: if (hasPrefix fs.mountPoint path &&
+                                   (best == null || stringLength fs.mountPoint > stringLength best.mountPoint)) then fs else best)
+                    null fileSystems;
+
+      in {
+        # Detect bind mount in case of NixOS installation in a subdirectory of the device.
+        # If /dev/x is mounted to /mnt/root, and /mnt/root/nixos is bind mounted to /, then rootDirectory is /nixos.
+        rootDirectory =
+          let 
+            optList = splitString "," config.fileSystems."/".options;
+            path = config.fileSystems."/".device;
+            dep = requiredForPath fsList path;
+          in if elem "bind" optList && dep != null
+            then substring (stringLength dep.mountPoint) (stringLength path) path
+            else "/";
+
+        # Returns a the list of file systems in the right order for mount at boot time, to be used in the initrd.
+        orderedForBoot = 
+          let
+            # Returns the closure of dependencies of the given file system.
+            # If the file system / has device /mnt/a/b, and there's a mount point /mnt/a, then it returns [ /mnt/a / ]
+            # 'visited' is the list of file systems already taken into account, to avoid cycles and duplicates.
+            fsClosure = fs: visited:
+              let dep = requiredForPath fsList fs.device;
+                  depClosure = optionals (dep != null) (fsClosure dep (visited ++ [ fs ]));
+              in if elem fs visited then [ ] else depClosure ++ [ fs ];
+          in fold (fs: list: list ++ (fsClosure fs list)) [ ] fsList;
+      };
+
   };
 
 }


### PR DESCRIPTION
Assuming we are installing nixos under /nixos, we mount --rbind /nixos /mnt and do the usual installation.
Then in the configuration.nix:

```
  boot.loader.grub.doInstall = false;

  fileSystems."/mnt/root" =
    { device = "/dev/foo";
      fsType = "bar";
      neededForBoot = true;
    };

  fileSystems."/" =
    { device = "/mnt/root/nixos";
      fsType = "none";
      options = "bind";
    };
```

Finally add a menu entry to the existing grub loader of your device with something like: `configfile (hd0,...)/nixos/boot/grub/grub.cfg`.

This PR must not be merged, I need some help on what's the best practice for factorizing bootFileSystems and closestMountPoint which are used in both grub.nix and stage-1.nix.
They are used to automatically detect the correct order of the mounts and to detect the subdirectory of the nixos installation to be used in the grub configuration. This was a choice from a discussion with @edolstra on irc.
