### PR TITLE
xmobar: update to 0.21

### DIFF
--- a/pkgs/applications/misc/xmobar/default.nix
+++ b/pkgs/applications/misc/xmobar/default.nix
@@ -6,8 +6,8 @@
 
 cabal.mkDerivation (self: {
   pname = "xmobar";
-  version = "0.20.1";
-  sha256 = "16jfgn6ciqxrwj6qjhbcpms7mzlbxfaxyxfxp64xvnw626xlpjvk";
+  version = "0.21";
+  sha256 = "1h0gsb808zm4j4kmw7fl4339wllc16ldy1ki96l8w3fvj30bcxpm";
   isLibrary = false;
   isExecutable = true;
   buildDepends = [


### PR DESCRIPTION
Among others, this update fixes `CoreTemp` for Linux kernels > 3.14.
