### PR TITLE
radvd: Update to 1.13 and Convert to a Systemd Unit

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -146,6 +146,7 @@
       neo4j = 136;
       riemann = 137;
       riemanndash = 138;
+      radvd = 139;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/pkgs/tools/networking/radvd/default.nix
+++ b/pkgs/tools/networking/radvd/default.nix
@@ -1,16 +1,20 @@
-{ stdenv, fetchurl, bison, flex }:
+{ stdenv, fetchurl, pkgconfig, libdaemon, bison, flex, check }:
 
 stdenv.mkDerivation rec {
-  name = "radvd-1.8.1";
+  name = "radvd-2.5";
   
   src = fetchurl {
-    url = "http://www.litech.org/radvd/dist/${name}.tar.gz";
-    sha256 = "1sg3halppbz3vwr88lbcdv7mndzwl4nkqnrafkyf2a248wwz2cbc";
+    url = "http://www.litech.org/radvd/dist/${name}.tar.xz";
+    sha256 = "0hsa647l236q9rhrwjb44xqmjfz4fxzcixlbf2chk4lzh8lzwjp0";
   };
 
-  buildInputs = [ bison flex ];
+  buildInputs = [ pkgconfig libdaemon bison flex check ];
 
-  meta.homepage = http://www.litech.org/radvd/;
-  meta.description = "IPv6 Router Advertisement Daemon";
-  meta.platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    homepage = http://www.litech.org/radvd/;
+    description = "IPv6 Router Advertisement Daemon";
+    platforms = platforms.linux;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ wkennington ];
+  };
 }


### PR DESCRIPTION
Additionally, allow the end user to configure how they want ipv6 forwarding enabled on their own devices. Don't force the preStart to enable ipv6 forwarding for all interfaces.
