### PR TITLE
vcprompt: new package

### DIFF
--- a/pkgs/applications/version-management/vcprompt/default.nix
+++ b/pkgs/applications/version-management/vcprompt/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchhg, autoconf, sqlite }:
+
+stdenv.mkDerivation {
+  name = "vcprompt";
+
+  src = fetchhg {
+    url = "http://hg.gerg.ca/vcprompt/";
+    rev = "1.2.1";
+    sha256 = "03xqvp6bfl98bpacrw4n82qv9cw6a4fxci802s3vrygas989v1kj";
+  };
+
+  buildInputs = [ sqlite autoconf ];
+
+  preConfigure = ''
+    autoconf
+    makeFlags="$makeFlags PREFIX=$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      A little C program that prints a short string with barebones information
+      about the current working directory for various version control systems
+    '';
+    homepage    = http://hg.gerg.ca/vcprompt;
+    maintainers = with maintainers; [ cstrahan ];
+    platforms   = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9751,6 +9751,8 @@ let
 
   vbindiff = callPackage ../applications/editors/vbindiff { };
 
+  vcprompt = callPackage ../applications/version-management/vcprompt { };
+
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 
   veracity = callPackage ../applications/version-management/veracity {};


### PR DESCRIPTION
This adds the `vcprompt` utility, a little C program that prints a short string
with barebones information about the current working directory for various
version control systems.
