### PR TITLE
dnsmasq: upgrade to 2.71, fixed dnsmasq module

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -7,6 +7,9 @@ with lib;
 let
 
   cfg = config.networking;
+  dnsmasqResolve = config.services.dnsmasq.enable &&
+                   config.services.dnsmasq.resolveLocalQueries;
+  hasLocalResolver = config.services.bind.enable || dnsmasqResolve;
 
 in
 
@@ -74,9 +77,12 @@ in
             '' + optionalString cfg.dnsSingleRequest ''
               # only send one DNS request at a time
               resolv_conf_options='single-request'
-            '' + optionalString config.services.bind.enable ''
+            '' + optionalString hasLocalResolver ''
               # This hosts runs a full-blown DNS resolver.
               name_servers='127.0.0.1'
+            '' + optionalString dnsmasqResolve ''
+              dnsmasq_conf=/etc/dnsmasq-conf.conf
+              dnsmasq_resolv=/etc/dnsmasq-resolv.conf
             '';
       };
 

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -135,6 +135,7 @@
       influxdb = 125;
       nsd = 126;
       gitolite = 127;
+      dnsmasq = 128;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -1,14 +1,36 @@
-{ stdenv, fetchurl }:
+{ pkgconfig, dbus_libs, nettle, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "dnsmasq-2.69";
+  name = "dnsmasq-2.71";
 
   src = fetchurl {
-    url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.gz";
-    sha256 = "1zf4d6kjbsn6gwfwvmch1y84q67na1qhh0gyd50ip1vjsmw2l4i7";
+    url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.xz";
+    sha256 = "1fpzpzja7qr8b4kfdhh4i4sijp62c634yf0xvq2n4p7d5xbzn6a9";
   };
 
+  # Can't rely on make flags because of space in one of the parameters
+  buildPhase = ''
+    make COPTS="-DHAVE_DNSSEC -DHAVE_DBUS"
+  '';
+
+  # make flags used for installation only
   makeFlags = "DESTDIR= BINDIR=$(out)/bin MANDIR=$(out)/man LOCALEDIR=$(out)/share/locale";
+
+  postInstall = ''
+    install -Dm644 dbus/dnsmasq.conf $out/etc/dbus-1/system.d/dnsmasq.conf
+    install -Dm644 trust-anchors.conf $out/share/dnsmasq/trust-anchors.conf
+
+    ensureDir $out/share/dbus-1/system-services
+    cat <<END > $out/share/dbus-1/system-services/uk.org.thekelleys.dnsmasq.service
+    [D-BUS Service]
+    Name=uk.org.thekelleys.dnsmasq
+    Exec=$out/sbin/dnsmasq -k -1
+    User=root
+    SystemdService=dnsmasq.service
+    END
+  '';
+
+  buildInputs = [ pkgconfig dbus_libs nettle ];
 
   meta = {
     description = "An integrated DNS, DHCP and TFTP server for small networks";


### PR DESCRIPTION
- The module now has systemd config
- Add resolveLocalQueries option which sets up it as a dns server for
  local host (including reasonable setup of resolvconf)
- Add "dnsmasq" user for running daemon
- Enabled dbus and dnssec support for the package
