### PR TITLE
Added snapWebRoutes to haskellPackages.

### DIFF
--- a/pkgs/development/libraries/haskell/snap-web-routes/default.nix
+++ b/pkgs/development/libraries/haskell/snap-web-routes/default.nix
@@ -1,0 +1,14 @@
+{ cabal, heist, mtl, snap, snapCore, text, webRoutes, xmlhtml }:
+
+cabal.mkDerivation (self: {
+  pname = "snap-web-routes";
+  version = "0.5.0.0";
+  sha256 = "1ml0b759k2n9bd2x4akz4dfyk8ywnpgrdlcymng4vhjxbzngnniv";
+  buildDepends = [ heist mtl snap snapCore text webRoutes xmlhtml ];
+  meta = {
+    homepage = "https://github.com/lukerandall/snap-web-routes";
+    description = "Type safe URLs for Snap";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2018,6 +2018,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   snapServer = callPackage ../development/libraries/haskell/snap/server.nix {};
 
+  snapWebRoutes = callPackage ../development/libraries/haskell/snap-web-routes {};
+
   snowball = callPackage ../development/libraries/haskell/snowball {};
 
   socks = callPackage ../development/libraries/haskell/socks {};


### PR DESCRIPTION
Snap-web-routes added to Haskell packages.  Installed with no issues.
