### PR TITLE
Fixed settings issue.

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -5,7 +5,7 @@
 , ssl ? true # enable SSL support
 , previews ? false # enable webpage previews on hovering over URLs
 , tag ? "" # tag added to the package name
-, stdenv, fetchurl, cmake, qt4, kdelibs, automoc4, phonon }:
+, stdenv, fetchurl, cmake, makeWrapper, qt4, kdelibs, automoc4, phonon, dconf }:
 
 let
   edf = flag: feature: [("-D" + feature + (if flag then "=ON" else "=OFF"))];
@@ -22,7 +22,7 @@ in with stdenv; mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake qt4 ]
+  buildInputs = [ cmake makeWrapper qt4 ]
     ++ lib.optional withKDE kdelibs
     ++ lib.optional withKDE automoc4
     ++ lib.optional withKDE phonon;
@@ -39,6 +39,11 @@ in with stdenv; mkDerivation rec {
     ++ edf withKDE "WITH_KDE"
     ++ edf ssl "WITH_OPENSSL"
     ++ edf previews "WITH_WEBKIT"  ;
+
+  preFixup = ''
+    wrapProgram "$out/bin/quasselclient" \
+      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules"
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://quassel-irc.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10463,7 +10463,7 @@ let
 
       qtcurve = callPackage ../misc/themes/qtcurve { };
 
-      quassel = callPackage ../applications/networking/irc/quassel { };
+      quassel = callPackage ../applications/networking/irc/quassel { dconf = gnome3.dconf; };
 
       quasselDaemon = (self.quassel.override {
         monolithic = false;


### PR DESCRIPTION
The following warning was shown when I clicked on links:

```
'GLib-GIO-Message: Using the 'memory' GSettings backend. Your settings will not be saved or shared with other applications.'
```

It is fixed in the same way as in 413ebfb and a8f6601.
