### PR TITLE
Load ehci_hcd before ohci_hcd and uhci_hcd

### DIFF
--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -81,6 +81,13 @@ with lib;
           '';
         target = "modprobe.d/nixos.conf";
       }
+      { source = pkgs.writeText "modprobe-ehci.conf"
+	  ''
+	    softdep uhci_hcd pre: ehci_hcd
+	    softdep ohci_hcd pre: ehci_hcd
+	  '';
+        target = "modprobe.d/usb-load-ehci-first.conf";
+      }
     ];
 
     environment.systemPackages = [ config.system.sbin.modprobe pkgs.kmod ];


### PR DESCRIPTION
In my dmesg:

```
Jul 01 01:07:50 nixos kernel: Warning! ehci_hcd should always be loaded before uhci_hcd and ohci_hcd, not after
```

In Gentoo: https://bugs.gentoo.org/show_bug.cgi?id=260139
In LFS: http://www.linuxfromscratch.org/lfs/view/development/chapter08/kernel.html#conf-modprobe

I'm not really certain how to test it without switching to unstable nixpkgs, which means downloading 440 MB, but maybe Hydra will do that?
