### PR TITLE
License meta-data for numexpr, tables, and szip

### DIFF
--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl }:
     
 stdenv.mkDerivation {
-    name = "szip-2.1";
-    src = fetchurl {
-        url = ftp://ftp.hdfgroup.org/lib-external/szip/2.1/src/szip-2.1.tar.gz;
-        sha256 = "1vym7r4by02m0yqj10023xyps5b21ryymnxb4nb2gs32arfxj5m8";
-    };
+  name = "szip-2.1";
+  src = fetchurl {
+    url = ftp://ftp.hdfgroup.org/lib-external/szip/2.1/src/szip-2.1.tar.gz;
+    sha256 = "1vym7r4by02m0yqj10023xyps5b21ryymnxb4nb2gs32arfxj5m8";
+  };
 }

--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -6,4 +6,12 @@ stdenv.mkDerivation {
     url = ftp://ftp.hdfgroup.org/lib-external/szip/2.1/src/szip-2.1.tar.gz;
     sha256 = "1vym7r4by02m0yqj10023xyps5b21ryymnxb4nb2gs32arfxj5m8";
   };
+
+  meta = {
+    description = "
+      Szip is a compression library that can be used with the hdf5 library.
+    ";
+    homepage = http://www.hdfgroup.org/doc_resource/SZIP/;
+    license = stdenv.lib.licenses.unfree;
+  };
 }

--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
   meta = {
     description = "Hierarchical datasets for Python";
     homepage = "http://www.pytables.org/";
+    license = stdenv.lib.licenses.bsd2;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4732,6 +4732,7 @@ rec {
     meta = {
       description = "Fast numerical array expression evaluator for NumPy";
       homepage = "https://github.com/pydata/numexpr";
+      license = licenses.mit;
     };
   };
 


### PR DESCRIPTION
With this pull-request I'm adding license meta-data to the packages that I've touched with my last pull-request.
