### PR TITLE
haskellPackages: add ghcForStatic

### DIFF
--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, m4, cxx ? true }:
+{ stdenv, fetchurl, m4, cxx ? true, withStatic ? false }:
 
 with { inherit (stdenv.lib) optional; };
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   name = "gmp-5.1.3";
 
   src = fetchurl { # we need to use bz2, others aren't in bootstrapping stdenv
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://gmplib.org/";
     description = "GMP, the GNU multiple precision arithmetic library";
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
 
     longDescription =
       '' GMP is a free library for arbitrary precision arithmetic, operating
@@ -54,7 +54,10 @@ stdenv.mkDerivation rec {
          asymptotically faster algorithms.
       '';
 
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.simons ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.simons ];
   };
 }
+  // stdenv.lib.optionalAttrs withStatic { dontDisableStatic = true; }
+)
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2918,7 +2918,13 @@ let
 
   # Import Haskell infrastructure.
 
-  haskell = callPackage ./haskell-defaults.nix { inherit pkgs; };
+  haskell = callPackage ./haskell-defaults.nix {
+    pkgs = pkgs // {
+      # allow creating static executables by adding -optl-static -optl-pthread
+      # see thread http://permalink.gmane.org/gmane.linux.distributions.nixos/13526
+      gmp = gmp.override { withStatic = true; };
+    };
+  };
 
   # Available GHC versions.
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -78,12 +78,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
     ghc = ghc; # refers to ghcPlain
   };
 
-  # capable of creating static executables by adding -optl-static -optl-pthread
-  # see thread http://permalink.gmane.org/gmane.linux.distributions.nixos/13526
-  ghcForStatic = self.ghc.override {
-    ghc = ghc.override { gmp = pkgs.gmp.override { withStatic = true; }; };
-  };
-
   # An experimental wrapper around ghcPlain that does not automatically
   # pick up packages from the profile, but instead has a fixed set of packages
   # in its global database. The set of packages can be specified as an

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -78,6 +78,12 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
     ghc = ghc; # refers to ghcPlain
   };
 
+  # capable of creating static executables by adding -optl-static -optl-pthread
+  # see thread http://permalink.gmane.org/gmane.linux.distributions.nixos/13526
+  ghcForStatic = self.ghc.override {
+    ghc = ghc.override { gmp = pkgs.gmp.override { withStatic = true; }; };
+  };
+
   # An experimental wrapper around ghcPlain that does not automatically
   # pick up packages from the profile, but instead has a fixed set of packages
   # in its global database. The set of packages can be specified as an


### PR DESCRIPTION
It's built with gmp that contains static libraries as well,
so one is able to build statically linked haskell programs.

Example:

```
$ echo "main = undefined" > test.hs

$ ghc -optl-static -optl-pthread test.hs
[1 of 1] Compiling Main             ( test.hs, test.o )
Linking test ...
/nix/store/1qqhbh9w3mhsl48bsn73ln68ixxv7frz-ghc-7.6.3/lib/ghc-7.6.3/libHSrts.a(Linker.o): In function `addDLL':
Linker.c:(.text+0x1a19): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

$ ldd ./test
        not a dynamic executable
```

**This is just a proof of concept:**
- I don't really use Haskell for anything, so it's likely that a different way of plugging into haskellPackages will be better. CC: @peti, etc.?
- It's probable that when using stuff linked against more non-haskell libs, the static part of those might be missing.
