### PR TITLE
Haskell packages, hlibgit2, gitlib, gitlib-test, gitlib-libgit2

### DIFF
--- a/pkgs/development/libraries/haskell/gitlib-libgit2/default.nix
+++ b/pkgs/development/libraries/haskell/gitlib-libgit2/default.nix
@@ -1,0 +1,29 @@
+{ cabal, conduit, conduitCombinators, exceptions, fastLogger
+, filepath, gitlib, gitlibTest, hlibgit2, hspec, hspecExpectations
+, HUnit, liftedAsync, liftedBase, missingForeign, mmorph
+, monadControl, monadLogger, monadLoops, mtl, resourcet, stm
+, stmConduit, tagged, text, textIcu, time, transformers
+, transformersBase
+}:
+
+cabal.mkDerivation (self: {
+  pname = "gitlib-libgit2";
+  version = "3.1.0";
+  sha256 = "1kjwc36fd14j2ipw53j8hdsy29gxir1qrm54wxgpp5n4q2kcs9pq";
+  buildDepends = [
+    conduit conduitCombinators exceptions fastLogger filepath gitlib
+    hlibgit2 liftedAsync liftedBase missingForeign mmorph monadControl
+    monadLogger monadLoops mtl resourcet stm stmConduit tagged text
+    textIcu time transformers transformersBase
+  ];
+  testDepends = [
+    exceptions gitlib gitlibTest hspec hspecExpectations HUnit
+    monadLogger transformers
+  ];
+  meta = {
+    description = "Libgit2 backend for gitlib";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/gitlib-test/default.nix
+++ b/pkgs/development/libraries/haskell/gitlib-test/default.nix
@@ -1,0 +1,20 @@
+{ cabal, conduit, conduitCombinators, exceptions, gitlib, hspec
+, hspecExpectations, HUnit, monadControl, tagged, text, time
+, transformers
+}:
+
+cabal.mkDerivation (self: {
+  pname = "gitlib-test";
+  version = "3.1.0";
+  sha256 = "0hnwx5r9fdkxvx0zmqffpym921dvf1x2lky8w11y3rfhk9i1g7l4";
+  buildDepends = [
+    conduit conduitCombinators exceptions gitlib hspec
+    hspecExpectations HUnit monadControl tagged text time transformers
+  ];
+  meta = {
+    description = "Test library for confirming gitlib backend compliance";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/gitlib/default.nix
+++ b/pkgs/development/libraries/haskell/gitlib/default.nix
@@ -1,0 +1,23 @@
+{ cabal, base16Bytestring, conduit, conduitCombinators, exceptions
+, filepath, hashable, liftedAsync, liftedBase, monadControl
+, monadLogger, mtl, resourcet, semigroups, systemFilepath, tagged
+, text, time, transformers, unorderedContainers
+}:
+
+cabal.mkDerivation (self: {
+  pname = "gitlib";
+  version = "3.1.0";
+  sha256 = "0zyym7m8bdhc4wi2jrhcmipmlq106qkd61c4y9iisgk73v2pg9f4";
+  buildDepends = [
+    base16Bytestring conduit conduitCombinators exceptions filepath
+    hashable liftedAsync liftedBase monadControl monadLogger mtl
+    resourcet semigroups systemFilepath tagged text time transformers
+    unorderedContainers
+  ];
+  meta = {
+    description = "API library for working with Git repositories";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/development/libraries/haskell/hlibgit2/default.nix
+++ b/pkgs/development/libraries/haskell/hlibgit2/default.nix
@@ -1,0 +1,16 @@
+{ cabal, bindingsDSL, openssl, zlib, git }:
+
+cabal.mkDerivation (self: {
+  pname = "hlibgit2";
+  version = "0.18.0.13";
+  sha256 = "1bslg51kkhnwm48kxaad4izq3xmzv6dpqy10a5kh16vr5zy3w5hz";
+  buildDepends = [ bindingsDSL zlib ];
+  testDepends = [ git ];
+  extraLibraries = [ openssl ];
+  meta = {
+    description = "Low-level bindings to libgit2";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+    maintainers = [ self.stdenv.lib.maintainers.ianwookim ];
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -873,6 +873,12 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   gitit = callPackage ../development/libraries/haskell/gitit {};
 
+  gitlib = callPackage ../development/libraries/haskell/gitlib {};
+
+  gitlibLibgit2 = callPackage ../development/libraries/haskell/gitlib-libgit2 {};
+
+  gitlibTest = callPackage ../development/libraries/haskell/gitlib-test {};
+
   glade = callPackage ../development/libraries/haskell/glade {
     inherit (pkgs.gnome) libglade;
     gtkC = pkgs.gtk;
@@ -1107,6 +1113,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   hledgerInterest = callPackage ../applications/office/hledger-interest {};
   hledgerIrr = callPackage ../applications/office/hledger-irr {};
   hledgerWeb = callPackage ../development/libraries/haskell/hledger-web {};
+
+  hlibgit2 = callPackage ../development/libraries/haskell/hlibgit2 {};
 
   HList = callPackage ../development/libraries/haskell/HList {};
 


### PR DESCRIPTION
Low/high-level libraries for managing git repository. 
hlibgit2 is FFI to the libgit2 library and gitlib is a general high-level library for git repo manipulation. 
gitlib-libgit2 is using libgit2 (and hlibgit2) as a backend for low-level operation. 
