### PR TITLE
Update `macvim` package to v7.4.355

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -6,13 +6,13 @@ let inherit (stdenvAdapters.overrideGCC stdenv gccApple) mkDerivation;
 in mkDerivation rec {
   name = "macvim-${version}";
 
-  version = "7.4-73";
+  version = "7.4.355";
 
   src = fetchFromGitHub {
-    owner = "b4winckler";
+    owner = "genoma";
     repo = "macvim";
-    rev = "snapshot-73";
-    sha256 = "0zv82y2wz8b482khkgbl08cnxq3pv5bm37c71wgfa0fzy3h12gcj";
+    rev = "c18a61f9723565664ffc2eda9179e96c95860e25";
+    sha256 = "190bngg8m4bwqcia7w24gn7mmqkhk0mavxy81ziwysam1f652ymf";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -1,3 +1,33 @@
+diff --git a/src/MacVim/MacVim.xcodeproj/project.pbxproj b/src/MacVim/MacVim.xcodeproj/project.pbxproj
+index 1c5ff47..677a2cc 100644
+--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
++++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
+@@ -437,6 +437,8 @@
+ /* Begin PBXProject section */
+ 		29B97313FDCFA39411CA2CEA /* Project object */ = {
+ 			isa = PBXProject;
++			attributes = {
++			};
+ 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MacVim" */;
+ 			compatibilityVersion = "Xcode 2.4";
+ 			developmentRegion = English;
+@@ -632,6 +634,7 @@
+ 				INSTALL_PATH = "$(HOME)/Applications";
+ 				MACOSX_DEPLOYMENT_TARGET = "";
+ 				ONLY_ACTIVE_ARCH = YES;
++				OTHER_LDFLAGS = "-headerpad_max_install_names";
+ 				PRODUCT_NAME = MacVim;
+ 				VERSIONING_SYSTEM = "apple-generic";
+ 				WARNING_CFLAGS = "-Wall";
+@@ -662,6 +665,7 @@
+ 				INSTALL_PATH = "$(HOME)/Applications";
+ 				MACOSX_DEPLOYMENT_TARGET = "";
+ 				ONLY_ACTIVE_ARCH = YES;
++				OTHER_LDFLAGS = "-headerpad_max_install_names";
+ 				PRODUCT_NAME = MacVim;
+ 				VERSIONING_SYSTEM = "apple-generic";
+ 				WRAPPER_EXTENSION = app;
+
 diff --git a/src/vimtutor b/src/vimtutor
 index 70d9ec7..b565a1a 100755
 --- a/src/vimtutor


### PR DESCRIPTION
MacVim's maintenance has stagnated, so this moves `macvim` to a new maintainer.
Additionally, the `-headerpad_max_install_names` linker flag is passed to
prevent problems when setting the rpaths.
