### PR TITLE
cmake: Remove bash-ism in setup-hook.sh

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -47,9 +47,10 @@ cmakeConfigurePhase() {
     eval "$postConfigure"
 }
 
-if [ -z "$dontUseCmakeConfigure" -a ! -v configurePhase ]; then
-    configurePhase=cmakeConfigurePhase
-fi
+# Set `configurePhase` to `cmakeConfigurePhase`
+# if `dontUseCmakeConfigure` is empty, and `configurePhase` is unset.
+# Note, that _unset_ is not the same as _empty_!
+[ -z "$dontUseCmakeConfigure" ] && : ${configurePhase=cmakeConfigurePhase}
 
 if [ -n "$crossConfig" ]; then
     crossEnvHooks+=(addCMakeParams)


### PR DESCRIPTION
Note: This will trigger quite a number of rebuilds, as CMake is a fairly central package. I have tested it with `gtest`, and `openimageio`.

This commit fixes the following error message:

```
...cmake.../nix-support/setup-hook: line 50: [: -v: unary operator expected
```

This error appears when using cmake in a `myEnvFun` package that is sourced into an existing shell session.

---

We only want to set `configurePhase` if it hasn't been set before. A user could
wish to specify an empty configure phase by setting `configurePhase=""`.  So, a
test for _empty_ is insufficient.

Bash offers `[[ -v` for that purpose.  However, this only works in the double
brackets `[[`, and it only works in bash.

In the classic bourne shell we can use parameter substitutions for this
purpose. `${parameter=default}` will assign `default` to the variable
`parameter` if and only if `parameter` has not been set before.
