### PR TITLE
Be more obvious about using bash features

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -47,7 +47,7 @@ cmakeConfigurePhase() {
     eval "$postConfigure"
 }
 
-if [ -z "$dontUseCmakeConfigure" -a ! -v configurePhase ]; then
+if [[ -z "$dontUseCmakeConfigure" && ! -v configurePhase ]]; then
     configurePhase=cmakeConfigurePhase
 fi
 

--- a/pkgs/misc/my-env/loadenv.sh
+++ b/pkgs/misc/my-env/loadenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 OLDPATH="$PATH"
 OLDTZ="$TZ"


### PR DESCRIPTION
This pull-request is intended as an alternative option to #3204.

`-v` in `[` type conditionals seems to be undocumented. It can certainly not be found in the man-page of `test`. By using bash-style conditionals (`[[`) instead it is more obvious that we are using a bash feature, and it can also be found in the man-page of bash.

Similarly, `loadenv.sh` expects to be executed in bash. This becomes much more obvious when the she-bang explicitely mentions bash. Note, that `/bin/bash` is still going to be replaced by the actual install-path of bash under `/nix/store`.

Also note, that this pull-request does not fix the issue with older bash versions, or Bourne shell that is mentioned in #3204, and #3053. At least in my case (#3204) `cmake/setup-hook.sh` fails to execute if sourced into an existing system-shell. The reason is that the bash version on that system (`GNU bash, version 4.1.2(1)-release (x86_64-redhat-linux-gnu)`) does not yet support `-v` inside conditionals (neither `[`, nor `[[`). In that case the fix would be to use the bash version that comes with Nix instead.
