### PR TITLE
Fix R expressions when packages are updated

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -305,7 +305,6 @@ rec {
     http://dirichlet.mat.puc.cl/
     http://ftp.ctex.org/mirrors/CRAN/
     http://mirror.bjtu.edu.cn/cran
-    http://cran.dataguru.cn/
     http://mirrors.ustc.edu.cn/CRAN/
     http://mirrors.xmu.edu.cn/CRAN/
     http://www.laqee.unal.edu.co/CRAN/

--- a/pkgs/development/r-modules/cran-packages.nix
+++ b/pkgs/development/r-modules/cran-packages.nix
@@ -44,7 +44,10 @@ let
   derive = { name, version, sha256, depends ? [] }: buildRPackage {
     name = "${name}-${version}";
     src = fetchurl {
-      url = "mirror://cran/src/contrib/${name}_${version}.tar.gz";
+      urls = [
+        "mirror://cran/src/contrib/${name}_${version}.tar.gz"
+        "mirror://cran/src/contrib/Archive/${name}/${name}_${version}.tar.gz"
+      ];
       inherit sha256;
     };
     propagatedBuildInputs = depends;


### PR DESCRIPTION
The CRAN archive has a directory structure that shifts the location of tarballs when a new version is released.  Currently the R package derivation does not check the archive for tarballs and consequently whenever a CRAN package is updated all the dependent build expressions break.  This patch adds the archive to the list of sources so older versions can be found, and removes a problematic mirror.
