### PR TITLE
Adobe Source fonts

### DIFF
--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -22,7 +22,7 @@ rec {
     sha256 = sourceInfo.hash;
   };
 
-  name = "${sourceInfo.name}-${sourceInfo.version}";
+  name = "source-code-pro-${sourceInfo.version}";
   inherit buildInputs;
 
   phaseNames = ["doUnpack" "installFonts"];

--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "source-sans-pro-1.050";
+  src = fetchurl {
+    url = "mirror://sourceforge/sourcesans.adobe/SourceSansPro_FontsOnly-1.050.zip";
+    sha256 = "002z7kx8jxp5pfrilqaxbwbr5yp9fl3zsp0imawmf5wqagpzayf3";
+  };
+
+  buildInputs = [ unzip ];
+
+  phases = "unpackPhase installPhase";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    find . -name "*.otf" -exec cp {} $out/share/fonts/opentype \;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://sourceforge.net/adobe/sourcesans;
+    description = "A set of OpenType fonts designed by Adobe for UIs";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ttuegel ];
+  };
+}

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "source-serif-pro-1.014";
+  src = fetchurl {
+    url = "mirror://sourceforge/sourceserifpro.adobe/SourceSerifPro_FontsOnly-1.014.zip";
+    sha256 = "1agack195jqq4g2hmga6f9nwg44garii1g3jpbrdlrwr97rwvqsh";
+  };
+
+  buildInputs = [ unzip ];
+
+  phases = "unpackPhase installPhase";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    find . -name "*.otf" -exec cp {} $out/share/fonts/opentype \;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://sourceforge.net/adobe/sourceserifpro;
+    description = "A set of OpenType fonts to complement Source Sans Pro";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ttuegel ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7976,7 +7976,7 @@ let
 
   r5rs = callPackage ../data/documentation/rnrs/r5rs.nix { };
 
-  sourceCodePro = callPackage ../data/fonts/source-code-pro {};
+  source-code-pro = callPackage ../data/fonts/source-code-pro {};
 
   source-sans-pro = callPackage ../data/fonts/source-sans-pro { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7978,6 +7978,8 @@ let
 
   sourceCodePro = callPackage ../data/fonts/source-code-pro {};
 
+  source-sans-pro = callPackage ../data/fonts/source-sans-pro { };
+
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme { };
 
   themes = name: import (../data/misc/themes + ("/" + name + ".nix")) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7980,6 +7980,8 @@ let
 
   source-sans-pro = callPackage ../data/fonts/source-sans-pro { };
 
+  source-serif-pro = callPackage ../data/fonts/source-serif-pro { };
+
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme { };
 
   themes = name: import (../data/misc/themes + ("/" + name + ".nix")) {


### PR DESCRIPTION
This adds the Source Sans and Source Serif fonts from Adobe to go with Source Code (already in Nixpkgs).
