### PR TITLE
Fix Python 3.{2,3,4} on Darwin.

### DIFF
--- a/pkgs/development/interpreters/python/3.2/default.nix
+++ b/pkgs/development/interpreters/python/3.2/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     configureFlagsArray=( --enable-shared --with-threads
                           CPPFLAGS="${concatStringsSep " " (map (p: "-I${p}/include") buildInputs)}"
                           LDFLAGS="${concatStringsSep " " (map (p: "-L${p}/lib") buildInputs)}"
-                          LIBS="-lcrypt ${optionalString (ncurses != null) "-lncurses"}"
+                          LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';
 
@@ -88,6 +88,6 @@ stdenv.mkDerivation {
     '';
     license = stdenv.lib.licenses.psfl;
     platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ simons chaoflow ];
+    maintainers = with stdenv.lib.maintainers; [ simons chaoflow cstrahan ];
   };
 }

--- a/pkgs/development/interpreters/python/3.3/default.nix
+++ b/pkgs/development/interpreters/python/3.3/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
     configureFlagsArray=( --enable-shared --with-threads
                           CPPFLAGS="${concatStringsSep " " (map (p: "-I${p}/include") buildInputs)}"
                           LDFLAGS="${concatStringsSep " " (map (p: "-L${p}/lib") buildInputs)}"
-                          LIBS="-lcrypt ${optionalString (ncurses != null) "-lncurses"}"
+                          LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
       high level dynamic data types.
     '';
     license = stdenv.lib.licenses.psfl;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ simons chaoflow ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    maintainers = with stdenv.lib.maintainers; [ simons chaoflow cstrahan ];
   };
 }

--- a/pkgs/development/interpreters/python/3.4/default.nix
+++ b/pkgs/development/interpreters/python/3.4/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     configureFlagsArray=( --enable-shared --with-threads
                           CPPFLAGS="${concatStringsSep " " (map (p: "-I${p}/include") buildInputs)}"
                           LDFLAGS="${concatStringsSep " " (map (p: "-L${p}/lib") buildInputs)}"
-                          LIBS="-lcrypt ${optionalString (ncurses != null) "-lncurses"}"
+                          LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';
 
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
       high level dynamic data types.
     '';
     license = stdenv.lib.licenses.psfl;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ simons chaoflow iElectric ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    maintainers = with stdenv.lib.maintainers; [ simons chaoflow iElectric cstrahan ];
   };
 }


### PR DESCRIPTION
This removes the `-lcrypt` linker flag when compiling under Darwin.
