### PR TITLE
mcomix: add sqlite3 dependency

### DIFF
--- a/pkgs/applications/graphics/mcomix/default.nix
+++ b/pkgs/applications/graphics/mcomix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, pygtk, pil }:
+{ stdenv, fetchurl, buildPythonPackage, pygtk, pil, python27Packages }:
 
 buildPythonPackage rec {
     namePrefix = "";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
     doCheck = false;
 
-    pythonPath = [ pygtk pil ];
+    pythonPath = [ pygtk pil python27Packages.sqlite3 ];
 
     meta = {
       description = "Image viewer designed to handle comic books";


### PR DESCRIPTION
This patch adds sqlite3 dep to the mcomix comic viewer. SQLite isn't needed to build and run mcomix but without it the library feature won't work.
