### PR TITLE
glibc_multi: move glibc_multi script out of all-packages.nix

### DIFF
--- a/pkgs/development/libraries/glibc/2.19/multi.nix
+++ b/pkgs/development/libraries/glibc/2.19/multi.nix
@@ -1,0 +1,31 @@
+{ runCommand, glibc, glibc32
+}:
+
+runCommand "${glibc.name}-multi"
+  { inherit glibc32;
+   glibc64 = glibc;
+  }
+  ''
+    mkdir -p $out
+    ln -s $glibc64/* $out/
+
+    rm $out/lib $out/lib64
+    mkdir -p $out/lib
+    ln -s $glibc64/lib/* $out/lib
+    ln -s $glibc32/lib $out/lib/32
+    ln -s lib $out/lib64
+
+    # fixing ldd RLTDLIST
+    rm $out/bin
+    cp -rs $glibc64/bin $out
+    chmod u+w $out/bin
+    rm $out/bin/ldd
+    sed -e "s|^RTLDLIST=.*$|RTLDLIST=\"$out/lib/ld-2.19.so $out/lib/32/ld-linux.so.2\"|g" \
+        $glibc64/bin/ldd > $out/bin/ldd
+    chmod 555 $out/bin/ldd
+
+    rm $out/include
+    cp -rs $glibc32/include $out
+    chmod -R u+w $out/include
+    cp -rsf $glibc64/include $out
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4634,36 +4634,10 @@ let
 
   glibcInfo = callPackage ../development/libraries/glibc/2.19/info.nix { };
 
-  glibc_multi =
-    runCommand "${glibc.name}-multi"
-      { glibc64 = glibc;
-        glibc32 = (import ./all-packages.nix {system = "i686-linux";}).glibc;
-      }
-      ''
-        mkdir -p $out
-        ln -s $glibc64/* $out/
-
-        rm $out/lib $out/lib64
-        mkdir -p $out/lib
-        ln -s $glibc64/lib/* $out/lib
-        ln -s $glibc32/lib $out/lib/32
-        ln -s lib $out/lib64
-
-        # fixing ldd RLTDLIST
-        rm $out/bin
-        cp -rs $glibc64/bin $out
-        chmod u+w $out/bin
-        rm $out/bin/ldd
-        sed -e "s|^RTLDLIST=.*$|RTLDLIST=\"$out/lib/ld-2.19.so $out/lib/32/ld-linux.so.2\"|g" \
-            $glibc64/bin/ldd > $out/bin/ldd
-        chmod 555 $out/bin/ldd
-
-        rm $out/include
-        cp -rs $glibc32/include $out
-        chmod -R u+w $out/include
-        cp -rsf $glibc64/include $out
-      '' # */
-      ;
+  glibc_multi = callPackage ../development/libraries/glibc/2.19/multi.nix {
+    inherit glibc;
+    glibc32 = (import ./all-packages.nix {system = "i686-linux";}).glibc;
+  };
 
   glm = callPackage ../development/libraries/glm { };
 


### PR DESCRIPTION
This patch moves the glibc_multi build script out of all-packages.nix into a new package. I haven't touched the script itself--so this won't trigger any rebuilds.
