### PR TITLE
haskell-clay: add package version 0.9.0.1

### DIFF
--- a/pkgs/development/libraries/haskell/clay/default.nix
+++ b/pkgs/development/libraries/haskell/clay/default.nix
@@ -1,0 +1,15 @@
+{ cabal, HUnit, mtl, testFramework, testFrameworkHunit, text }:
+
+cabal.mkDerivation (self: {
+  pname = "clay";
+  version = "0.9.0.1";
+  sha256 = "1w2617kpj6rblmycqb97gyshwbvzp5w2h4xh494mvdzi3bkahqpn";
+  buildDepends = [ mtl text ];
+  testDepends = [ HUnit mtl testFramework testFrameworkHunit text ];
+  meta = {
+    homepage = "http://fvisser.nl/clay";
+    description = "CSS preprocessor as embedded Haskell";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -411,6 +411,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   classyPreludeConduit = callPackage ../development/libraries/haskell/classy-prelude-conduit {};
 
+  clay = callPackage ../development/libraries/haskell/clay {};
+
   clientsession = callPackage ../development/libraries/haskell/clientsession {};
 
   clock = callPackage ../development/libraries/haskell/clock {};


### PR DESCRIPTION
Adds the clay haskell package. Generated via cabal2nix without any modifications.
