### PR TITLE
haskell-stm-containers: add package version 0.1.2 and its dependencies

### DIFF
--- a/pkgs/development/libraries/haskell/focus/default.nix
+++ b/pkgs/development/libraries/haskell/focus/default.nix
@@ -1,0 +1,14 @@
+{ cabal, lochTh, placeholders }:
+
+cabal.mkDerivation (self: {
+  pname = "focus";
+  version = "0.1.1";
+  sha256 = "0x158zqxgm8ys4mxs94zl811qfdcb06jqy5h99qc63r7snwnixmd";
+  buildDepends = [ lochTh placeholders ];
+  meta = {
+    homepage = "https://github.com/nikita-volkov/focus";
+    description = "A general abstraction for manipulating elements of container data structures";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/loch-th/default.nix
+++ b/pkgs/development/libraries/haskell/loch-th/default.nix
@@ -1,0 +1,13 @@
+{ cabal }:
+
+cabal.mkDerivation (self: {
+  pname = "loch-th";
+  version = "0.2.1";
+  sha256 = "1kfrjsgzq6wl749n2wm1fhwwigjxcd9lww7whiwjrbmhiz5ism3p";
+  meta = {
+    homepage = "https://github.com/liskin/loch-th";
+    description = "Support for precise error locations in source files (Template Haskell version)";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/placeholders/default.nix
+++ b/pkgs/development/libraries/haskell/placeholders/default.nix
@@ -1,0 +1,13 @@
+{ cabal }:
+
+cabal.mkDerivation (self: {
+  pname = "placeholders";
+  version = "0.1";
+  sha256 = "0ih35n2pw5gr9ggj2xz5zfcs4bdk200fdw6q9hdy3xna7maphak5";
+  meta = {
+    homepage = "http://github.com/ahammar/placeholders";
+    description = "Placeholders for use while developing Haskell code";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/development/libraries/haskell/stm-containers/default.nix
+++ b/pkgs/development/libraries/haskell/stm-containers/default.nix
@@ -1,0 +1,21 @@
+{ cabal, focus, free, hashable, HTF, lochTh, mtl, placeholders
+, primitive, QuickCheck, unorderedContainers
+}:
+
+cabal.mkDerivation (self: {
+  pname = "stm-containers";
+  version = "0.1.2";
+  sha256 = "1rzxjspf0lzmviixnxv9f2wjxqhwv65fb1nws915ghs1sj774gab";
+  buildDepends = [ focus hashable lochTh placeholders primitive ];
+  testDepends = [
+    focus free hashable HTF lochTh mtl placeholders primitive
+    QuickCheck unorderedContainers
+  ];
+  doCheck = false;
+  meta = {
+    homepage = "https://github.com/nikita-volkov/stm-containers";
+    description = "Containers for STM";
+    license = self.stdenv.lib.licenses.mit;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -801,6 +801,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   fingertree = callPackage ../development/libraries/haskell/fingertree {};
 
+  focus = callPackage ../development/libraries/haskell/focus {};
+
   foldl = callPackage ../development/libraries/haskell/foldl {};
 
   folds = callPackage ../development/libraries/haskell/folds {};
@@ -1423,6 +1425,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   lrucache = callPackage ../development/libraries/haskell/lrucache {};
 
+  lochTh = callPackage ../development/libraries/haskell/loch-th {};
+
   lockfreeQueue = callPackage ../development/libraries/haskell/lockfree-queue {};
 
   logfloat = callPackage ../development/libraries/haskell/logfloat {};
@@ -1765,6 +1769,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   pipesText = callPackage ../development/libraries/haskell/pipes-text {};
 
   pipesZlib = callPackage ../development/libraries/haskell/pipes-zlib {};
+
+  placeholders = callPackage ../development/libraries/haskell/placeholders {};
 
   polyparse = callPackage ../development/libraries/haskell/polyparse {};
 
@@ -2178,6 +2184,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   stmChans = callPackage ../development/libraries/haskell/stm-chans {};
 
   stmConduit = callPackage ../development/libraries/haskell/stm-conduit {};
+
+  stmContainers = callPackage ../development/libraries/haskell/stm-containers {};
 
   STMonadTrans = callPackage ../development/libraries/haskell/STMonadTrans {};
 


### PR DESCRIPTION
This patch adds the haskell stm-containers package. For easier merging I have added all missing dependencies (all but one are from the same author and seem to be created just for this package).
