### PR TITLE
Update default Haskell compiler to GHC 7.8.3 (and other stuff)

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -29,7 +29,7 @@ assert enableSharedExecutables -> versionOlder "7.4" ghc.version;
 # Our GHC 6.10.x builds do not provide sharable versions of their core libraries.
 assert enableSharedLibraries -> versionOlder "6.12" ghc.version;
 
-# Our GHC 6.10.x builds do not provide sharable versions of their core libraries.
+# Pure shared library builds don't work before GHC 7.8.x.
 assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
 
 {

--- a/pkgs/development/compilers/ghc/7.0.2.nix
+++ b/pkgs/development/compilers/ghc/7.0.2.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
       stdenv.lib.maintainers.andres
     ];
     inherit (ghc.meta) license platforms;
+    broken = true;
   };
 
 }

--- a/pkgs/development/compilers/ghc/7.0.3.nix
+++ b/pkgs/development/compilers/ghc/7.0.3.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
       stdenv.lib.maintainers.andres
     ];
     inherit (ghc.meta) license platforms;
+    broken = true;
   };
 
 }

--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ghc, perl, gmp, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "7.8.2";
+  version = "7.8.3";
   name = "ghc-${version}";
 
   src = fetchurl {
-    url = "http://www.haskell.org/ghc/dist/7.8.2/${name}-src.tar.xz";
-    sha256 = "15kyz98zq22sgwkzy2bkx0yz98qkrzgdigz919vafd7fxnkf3la5";
+    url = "http://www.haskell.org/ghc/dist/7.8.3/${name}-src.tar.xz";
+    sha256 = "0n5rhwl83yv8qm0zrbaxnyrf8x1i3b6si927518mwfxs96jrdkdh";
   };
 
   buildInputs = [ ghc perl gmp ncurses ];

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, m4, cxx ? true }:
+{ stdenv, fetchurl, m4, cxx ? true, withStatic ? false }:
 
 with { inherit (stdenv.lib) optional; };
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   name = "gmp-5.1.3";
 
   src = fetchurl { # we need to use bz2, others aren't in bootstrapping stdenv
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://gmplib.org/";
     description = "GMP, the GNU multiple precision arithmetic library";
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
 
     longDescription =
       '' GMP is a free library for arbitrary precision arithmetic, operating
@@ -54,7 +54,10 @@ stdenv.mkDerivation rec {
          asymptotically faster algorithms.
       '';
 
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.simons ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.simons ];
   };
 }
+  // stdenv.lib.optionalAttrs withStatic { dontDisableStatic = true; }
+)
+

--- a/pkgs/development/libraries/haskell/haskell-platform/2010.1.0.0.nix
+++ b/pkgs/development/libraries/haskell/haskell-platform/2010.1.0.0.nix
@@ -22,5 +22,6 @@ cabal.mkDerivation (self : {
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
     maintainers = with self.stdenv.lib.maintainers; [andres simons];
+    broken = true;              # The source code is no longer available from haskell.org.
   };
 })

--- a/pkgs/development/libraries/haskell/haskell-platform/default.nix
+++ b/pkgs/development/libraries/haskell/haskell-platform/default.nix
@@ -257,6 +257,8 @@ let
       stm                       = self.stm_2_1_1_2;
       xhtml                     = self.xhtml_3000_2_0_1;
       happy                     = self.happy_1_18_4;
+      # not actually specified, but important to make the whole thing build
+      mtl                       = self.mtl_1_1_0_2;
     };
   };
 
@@ -285,6 +287,8 @@ let
       cabalInstall              = self.cabalInstall_0_6_2;
       alex                      = self.alex_2_3_1;
       happy                     = self.happy_1_18_4;
+      # not actually specified, but important to make the whole thing build
+      mtl                       = self.mtl_1_1_0_2;
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8270,10 +8270,11 @@ let
 
   d4x = callPackage ../applications/misc/d4x { };
 
-  darcs = haskellPackages.darcs.override {
+  darcs = haskellPackages_ghc763.darcs.override {
     # A variant of the Darcs derivation that containts only the executable and
-    # thus has no dependencies on other Haskell packages.
-    cabal = haskellPackages.cabal.override {
+    # thus has no dependencies on other Haskell packages. We have to use the older
+    # GHC 7.6.3 package set because darcs won't compile with 7.8.x.
+    cabal = haskellPackages_ghc763.cabal.override {
       extension = self : super : {
         isLibrary = false;
         configureFlags = "-f-library " + super.configureFlags or "";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2954,7 +2954,7 @@ let
     builtins.substring 0 (builtins.stringLength "packages_") name == "packages_"
   ) haskell));
 
-  haskellPackages = haskellPackages_ghc763;
+  haskellPackages = haskellPackages_ghc783;
   haskellPlatform = haskellPlatformPackages."2013_2_0_0";
 
   haskellPackages_ghc6104 = haskell.packages_ghc6104;
@@ -2962,15 +2962,10 @@ let
   haskellPackages_ghc704  = haskell.packages_ghc704;
   haskellPackages_ghc722  = haskell.packages_ghc722;
   haskellPackages_ghc742  = haskell.packages_ghc742;
-  # For the default version, we build profiling versions of the libraries, too.
-  # The following three lines achieve that: the first two make Hydra build explicit
-  # profiling and non-profiling versions; the final respects the user-configured
-  # default setting.
-  haskellPackages_ghc763_no_profiling = recurseIntoAttrs haskell.packages_ghc763.noProfiling;
-  haskellPackages_ghc763_profiling    = recurseIntoAttrs haskell.packages_ghc763.profiling;
-  haskellPackages_ghc763              = recurseIntoAttrs haskell.packages_ghc763.highPrio;
-  # Reasonably current HEAD snapshot.
-  haskellPackages_ghc782 = haskell.packages_ghc782;
+  haskellPackages_ghc763  = haskell.packages_ghc763;
+  haskellPackages_ghc783_no_profiling = recurseIntoAttrs haskell.packages_ghc783.noProfiling;
+  haskellPackages_ghc783_profiling    = recurseIntoAttrs haskell.packages_ghc783.profiling;
+  haskellPackages_ghc783              = recurseIntoAttrs haskell.packages_ghc783.highPrio;
   haskellPackages_ghcHEAD = haskell.packages_ghcHEAD;
 
   haskellPlatformPackages = recurseIntoAttrs (import ../development/libraries/haskell/haskell-platform { inherit pkgs; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2933,7 +2933,10 @@ let
 
   # Import Haskell infrastructure.
 
-  haskell = callPackage ./haskell-defaults.nix { inherit pkgs; };
+  haskell = let pkgs_       = pkgs // { gmp = gmp.override { withStatic = true; }; };
+                callPackage = newScope pkgs_;
+                newScope    = extra: lib.callPackageWith (pkgs_ // pkgs_.xorg // extra);
+            in callPackage ./haskell-defaults.nix { pkgs = pkgs_; inherit callPackage newScope; };
 
   # Available GHC versions.
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2582,7 +2582,7 @@ let
   compcert = callPackage ../development/compilers/compcert {};
 
   cryptol1 = lowPrio (callPackage ../development/compilers/cryptol/1.8.x.nix {});
-  cryptol2 = haskellPackages.cryptol;
+  cryptol2 = haskellPackages_ghc763.cryptol; # doesn't compile with the lastest 7.8.3 release
 
   cython = pythonPackages.cython;
   cython3 = python3Packages.cython;

--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -20,13 +20,13 @@
     transformersCompat = super.transformersCompat_0_3_3;
   };
 
-  ghc782Prefs = self : super : ghcHEADPrefs self super // {
+  ghc783Prefs = self : super : ghcHEADPrefs self super // {
     cabalInstall_1_20_0_3 = super.cabalInstall_1_20_0_3.override { Cabal = self.Cabal_1_20_0_1; };
     codex = super.codex.override { hackageDb = super.hackageDb.override { Cabal = self.Cabal_1_20_0_1; }; };
     mtl = self.mtl_2_1_2;
   };
 
-  ghc763Prefs = self : super : ghc782Prefs self super // {
+  ghc763Prefs = self : super : ghc783Prefs self super // {
     ariadne = super.ariadne.override {
       haskellNames = self.haskellNames.override {
         haskellPackages = self.haskellPackages.override { Cabal = self.Cabal_1_18_1_3; };
@@ -214,10 +214,10 @@
                };
              };
 
-  packages_ghc782 =
-    packages { ghcPath = ../development/compilers/ghc/7.8.2.nix;
+  packages_ghc783 =
+    packages { ghcPath = ../development/compilers/ghc/7.8.3.nix;
                ghcBinary = ghc742Binary;
-               prefFun = ghc782Prefs;
+               prefFun = ghc783Prefs;
              };
 
   packages_ghc763 =

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1358,7 +1358,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       additionalPackages = [ self.lambdabot ];
     };
   };
-  
+
   lambdabotUtils = callPackage ../development/libraries/haskell/lambdabot-utils {};
 
   lambdacubeEngine = callPackage ../development/libraries/haskell/lambdacube-engine {};
@@ -2364,7 +2364,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   transformers_0_2_2_0 = callPackage ../development/libraries/haskell/transformers/0.2.2.0.nix {};
   transformers_0_3_0_0 = callPackage ../development/libraries/haskell/transformers/0.3.0.0.nix {};
   transformers_0_4_1_0 = callPackage ../development/libraries/haskell/transformers/0.4.1.0.nix {};
-  transformers = null;          # core package since ghc >= 7.8.2
+  transformers = null;          # core package since ghc >= 7.8.x
 
   transformersBase = callPackage ../development/libraries/haskell/transformers-base {};
 


### PR DESCRIPTION
This patch updates the default Haskell compiler and package set to GHC 7.8.3. Another side effect is that our compilers can now build static binaries, because the missing gmp libraries are now included in the closure.
