### PR TITLE
Bump Erlang, Rebar, and Elixir versions.

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, erlang, rebar, makeWrapper, coreutils }:
 
 let
-  version = "0.13.3";
+  version = "0.14.2";
 in
 stdenv.mkDerivation {
   name = "elixir-${version}";
 
   src = fetchurl {
     url = "https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz";
-    sha256 = "17nb8qfyjc67g62x10l2gq0z1501xa4wry906br0w2rm8bf4j8rf";
+    sha256 = "0q84lv63zrm828kgs4iwyh2mp18iv3k9qphirlxcfkn40v3yr4cl";
   };
 
   buildInputs = [ erlang rebar makeWrapper ];
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     '';
 
     license = licenses.epl10;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.the-kenny ];
   };
 }

--- a/pkgs/development/interpreters/erlang/R17.nix
+++ b/pkgs/development/interpreters/erlang/R17.nix
@@ -8,11 +8,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "erlang-" + version;
-  version = "17.0";
+  version = "17.1";
 
   src = fetchurl {
     url = "http://www.erlang.org/download/otp_src_${version}.tar.gz";
-    sha256 = "1nyaka6238vh4kdgaynmg8hm5y5zj7hhyl1c971d2pjylsm2nzr9";
+    sha256 = "0mn3p5rwvjfsxjnn1vrm0lxdq40wq9bmd9nibl6hqbfcnnrga1mq";
   };
 
   buildInputs =

--- a/pkgs/development/tools/build-managers/rebar/default.nix
+++ b/pkgs/development/tools/build-managers/rebar/default.nix
@@ -2,14 +2,14 @@
 
 
 let
-  version = "2.3.0";
+  version = "2.5.0";
 in
 stdenv.mkDerivation {
   name = "rebar-${version}";
 
   src = fetchurl {
     url = "https://github.com/rebar/rebar/archive/${version}.tar.gz";
-    sha256 = "0g23ib96lalpmynx39fprlw08ivgyb7i6c6a8jvgqwr9jmd0nj06";
+    sha256 = "1gnc8l997ys13glknl4r7hxfvgis8axn89sms8bn1ijrgx6gm1fm";
   };
 
   buildInputs = [ erlang ];
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
       variety of locations (git, hg, etc).
       '';
 
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.the-kenny ];
   };
 }


### PR DESCRIPTION
Updated the to the latest release for Erlang E17, Rebar and Elixir. Also added darwin as a support platform for each.
- Erlang E17 -> E17.1
- Rebar 2.3.0 -> 2.5.0
- Elixir 13.3 -> 14.2
