### PR TITLE
Import GHC 7.8.3

### DIFF
--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, ghc, perl, gmp, ncurses }:
+
+stdenv.mkDerivation rec {
+  version = "7.8.3";
+  name = "ghc-${version}";
+
+  src = fetchurl {
+    url = "http://www.haskell.org/ghc/dist/${version}/${name}-src.tar.xz";
+    sha256 = "0n5rhwl83yv8qm0zrbaxnyrf8x1i3b6si927518mwfxs96jrdkdh";
+  };
+
+  buildInputs = [ ghc perl gmp ncurses ];
+
+  enableParallelBuilding = true;
+
+  buildMK = ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp}/include"
+    DYNAMIC_BY_DEFAULT = NO
+  '';
+
+  preConfigure = ''
+    echo "${buildMK}" > mk/build.mk
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+  '';
+
+  configureFlags = "--with-gcc=${stdenv.gcc}/bin/gcc";
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" "--keep-file-symbols" ];
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    maintainers = [
+      stdenv.lib.maintainers.marcweber
+      stdenv.lib.maintainers.andres
+      stdenv.lib.maintainers.simons
+    ];
+    inherit (ghc.meta) license platforms;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2967,7 +2967,7 @@ let
   haskellPackages_ghc763_profiling    = recurseIntoAttrs haskell.packages_ghc763.profiling;
   haskellPackages_ghc763              = recurseIntoAttrs haskell.packages_ghc763.highPrio;
   # Reasonably current HEAD snapshot.
-  haskellPackages_ghc782 = haskell.packages_ghc782;
+  haskellPackages_ghc783 = haskell.packages_ghc783;
   haskellPackages_ghcHEAD = haskell.packages_ghcHEAD;
 
   haskellPlatformPackages = recurseIntoAttrs (import ../development/libraries/haskell/haskell-platform { inherit pkgs; });

--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -20,13 +20,13 @@
     transformersCompat = super.transformersCompat_0_3_3;
   };
 
-  ghc782Prefs = self : super : ghcHEADPrefs self super // {
+  ghc783Prefs = self : super : ghcHEADPrefs self super // {
     cabalInstall_1_20_0_3 = super.cabalInstall_1_20_0_3.override { Cabal = self.Cabal_1_20_0_1; };
     codex = super.codex.override { hackageDb = super.hackageDb.override { Cabal = self.Cabal_1_20_0_1; }; };
     mtl = self.mtl_2_1_2;
   };
 
-  ghc763Prefs = self : super : ghc782Prefs self super // {
+  ghc763Prefs = self : super : ghc783Prefs self super // {
     ariadne = super.ariadne.override {
       haskellNames = self.haskellNames.override {
         haskellPackages = self.haskellPackages.override { Cabal = self.Cabal_1_18_1_3; };
@@ -214,10 +214,10 @@
                };
              };
 
-  packages_ghc782 =
-    packages { ghcPath = ../development/compilers/ghc/7.8.2.nix;
+  packages_ghc783 =
+    packages { ghcPath = ../development/compilers/ghc/7.8.3.nix;
                ghcBinary = ghc742Binary;
-               prefFun = ghc782Prefs;
+               prefFun = ghc783Prefs;
              };
 
   packages_ghc763 =


### PR DESCRIPTION
This overwrites GHC 7.8.2 instead of preserving it because GHC 7.8.2 had many major issues fixed and was bugged in general. Onwards to 7.8.3!

Note: I will revise this if wanted.
