### PR TITLE
Fix & update hugin and enblend-enfuse

### DIFF
--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -1,25 +1,35 @@
-{stdenv, fetchurl, panotools, cmake, wxGTK, libtiff, libpng, openexr, boost
-, pkgconfig, exiv2, gettext, ilmbase, enblendenfuse, autopanosiftc, mesa
-, freeglut, glew, libXmu, libXi, tclap }:
+{ stdenv, cmake, fetchurl, gnumake, pkgconfig
+, boost, gettext, tclap, wxGTK
+, freeglut, glew, libXi, libXmu, mesa
+, autopanosiftc, enblendenfuse, exiv2, ilmbase, lensfun, libpng, libtiff
+, openexr, panotools, perlPackages
+}:
 
 stdenv.mkDerivation rec {
-  name = "hugin-2011.4.0";
+  name = "hugin-2013.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/hugin/${name}.tar.bz2";
-    sha256 = "1bnxljgqxzfdz14l7y29wzi52x1a38mghsjavnr28fr4vfmqwjrf";
+    sha256 = "1mgbvg09xvf0zcm9jfv5lb65nd292l86ffa23yp4pzm6izaiwkj8";
   };
 
   NIX_CFLAGS_COMPILE = "-I${ilmbase}/include/OpenEXR";
 
-#NIX_LDFLAGS = "-lrt";
+  buildInputs = [ boost gettext tclap wxGTK
+                  freeglut glew libXi libXmu mesa
+                  exiv2 ilmbase lensfun libtiff libpng openexr panotools
+                ];
 
-  buildInputs = [ panotools wxGTK libtiff libpng openexr boost tclap
-    exiv2 gettext ilmbase mesa freeglut glew libXmu libXi ];
+  # disable installation of the python scripting interface
+  cmakeFlags = [ "-DBUILD_HSI:BOOl=OFF" ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  propagatedUserEnvPackages = [ enblendenfuse autopanosiftc ];
+  # commandline tools needed by the hugin batch processor
+  # you may have to tell hugin (in the preferences) where these binaries reside
+  propagatedUserEnvPackages = [ autopanosiftc enblendenfuse gnumake
+                                perlPackages.ImageExifTool
+                              ];
 
   postInstall = ''
     mkdir -p "$out/nix-support"

--- a/pkgs/tools/graphics/enblend-enfuse/default.nix
+++ b/pkgs/tools/graphics/enblend-enfuse/default.nix
@@ -1,33 +1,18 @@
-{stdenv, fetchurl, libtiff, libpng, lcms, libxmi, boost, mesa, freeglut
-, pkgconfig, perl, glew }:
+{ stdenv, fetchurl
+, boost, freeglut, glew, gsl, lcms2, libpng, libtiff, libxmi, mesa, vigra
+, pkgconfig, perl }:
 
 stdenv.mkDerivation rec {
-  name = "enblend-enfuse-4.0";
+  name = "enblend-enfuse-4.1.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/enblend/${name}.tar.gz";
-    sha256 = "1i2kq842zrncpadarhcikg447abmh5r7a5js3mzg553ql3148am1";
+    sha256 = "1b7r1nnwaind0344ckwggy0ghl0ipbk9jzylsxcjfl05rnasw00w";
   };
 
-  buildInputs = [ libtiff libpng lcms libxmi boost mesa freeglut glew ];
+  buildInputs = [ boost freeglut glew gsl lcms2 libpng libtiff libxmi mesa vigra ];
 
   nativeBuildInputs = [ perl pkgconfig ];
-
-  patches =
-    let
-      prefix = "http://enblend.hg.sourceforge.net/hgweb/enblend/enblend/raw-diff";
-    in map fetchurl [
-      {
-        url = "${prefix}/9d9b5f3a97cd/src/vigra_impex/png.cxx";
-        name = "ftbfs-libpng15.patch";
-        sha256 = "1nqhbbgphwi087qpazngg04c1whc1p4fwq19fx36jrir96xywgzg";
-      }
-      {
-        url = "${prefix}/101796703d73/src/vigra_impex/png.cxx";
-        name = "ftbfs-libpng15.patch";
-        sha256 = "14frqg4hab9ab6pdypkrmji43fmxjj918j7565rdwmifbm9i3005";
-      }
-    ];
 
   meta = {
     homepage = http://enblend.sourceforge.net/;


### PR DESCRIPTION
This patchset updates hugin (panorama creation tool) and enblend-enfuse (commandline image merging/blending tool) to their latest versions.
Enblends current version on master won't build cause the needed patches don't exist anymore and therefor draws hugin and enblend to be broken. However these patches aren't needed in the latest version.
