### PR TITLE
my-env: Support for running command directly by load-env-xxx script

### DIFF
--- a/pkgs/misc/my-env/loadenv.sh
+++ b/pkgs/misc/my-env/loadenv.sh
@@ -11,5 +11,9 @@ export buildInputs
 export NIX_STRIP_DEBUG=0
 export TZ="$OLDTZ"
 
-@shell@
+if test $# -gt 0; then
+    exec "$@"
+else
+    exec @shell@
+fi
 


### PR DESCRIPTION
First I don't think there is a reason to run shell as a child of `load-env-xxx` script and not to just `exec` into it.

Also it's often useful to just run a command inside the environment `load-env-xxx command --args`
