### PR TITLE
my-env: Preserve http_proxy and ftp_proxy variables

### DIFF
--- a/pkgs/misc/my-env/loadenv.sh
+++ b/pkgs/misc/my-env/loadenv.sh
@@ -2,6 +2,8 @@
 
 OLDPATH="$PATH"
 OLDTZ="$TZ"
+OLD_http_proxy="$http_proxy"
+OLD_ftp_proxy="$http_proxy"
 source @myenvpath@
 
 PATH="$PATH:$OLDPATH"
@@ -10,6 +12,8 @@ export NIX_MYENV_NAME="@name@"
 export buildInputs
 export NIX_STRIP_DEBUG=0
 export TZ="$OLDTZ"
+export http_proxy="$OLD_http_proxy"
+export ftp_proxy="$OLD_ftp_proxy"
 
 if test $# -gt 0; then
     exec "$@"


### PR DESCRIPTION
That variables are there to make build environment more pure. But they are not
needed for `myEnvFun`.
