### PR TITLE
[WIP] finalterm: New package

### DIFF
--- a/pkgs/applications/misc/finalterm/default.nix
+++ b/pkgs/applications/misc/finalterm/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper
+, pkgconfig, cmake, libxml2, vala, intltool, libmx, gnome3, gtk3, gtk_doc
+, keybinder3, clutter_gtk, libnotify
+, libxkbcommon, xlibs, udev
+, bashInteractive
+}:
+
+let rev = "5ccde4e8f2c02a398f9172e07c25262ecf954626";
+in stdenv.mkDerivation {
+  name = "finalterm-git-${builtins.substring 0 8 rev}";
+
+  src = fetchFromGitHub {
+    owner = "p-e-w";
+    repo = "finalterm";
+    inherit rev;
+    sha256 = "1gw6nc19whfjd4xj0lc0fmjypn8d7nasif79671859ymnfizyq4f";
+  };
+
+  buildInputs = [
+    pkgconfig cmake vala intltool gtk3 gnome3.gnome_common gnome3.libgee
+    gtk_doc clutter_gtk libmx keybinder3 libxml2 libnotify makeWrapper
+    xlibs.libpthreadstubs xlibs.libXdmcp xlibs.libxshmfence
+    libxkbcommon
+  ] ++ lib.optionals stdenv.isLinux [
+    udev
+  ];
+
+  preConfigure = ''
+    substituteInPlace data/org.gnome.finalterm.gschema.xml \
+      --replace "/bin/bash" "${bashInteractive}/bin/bash"
+
+    cmakeFlagsArray=(
+      -DMINIMAL_FLAGS=ON
+    )
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/finalterm" \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules" \
+      --prefix XDG_DATA_DIRS : "${gnome3.gnome_icon_theme}/share:${gnome3.gtk}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  meta = with lib; {
+    homepage = "http://finalterm.org";
+    description = "A new breed of terminal emulator";
+    longDescription = ''
+      Final Term is a new breed of terminal emulator.
+
+      It goes beyond mere emulation and understands what is happening inside the shell it is hosting. This allows it to offer features no other terminal can, including:
+
+      - Semantic text menus
+      - Smart command completion
+      - GUI terminal controls
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ cstrahan ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10067,6 +10067,8 @@ let
 
   xterm = callPackage ../applications/misc/xterm { };
 
+  finalterm = callPackage ../applications/misc/finalterm { };
+
   xtrace = callPackage ../tools/X11/xtrace { };
 
   xlaunch = callPackage ../tools/X11/xlaunch { };


### PR DESCRIPTION
This is a work in progress to get [Final Term](http://finalterm.org/) packaged.

I'm running into some trouble thus far; 

```
$ finalterm
/nix/store/v5j7lh2ix3ymjaf6w013qzcwmg64lj04-finalterm-git-5ccde4e8/bin/.finalterm-wrapped: error while loading shared libraries: libclutter-gtk-1.0.so.0: cannot open shared object file: No such file or directory

$ ldd /nix/store/v5j7lh2ix3ymjaf6w013qzcwmg64lj04-finalterm-git-5ccde4e8/bin/.finalterm-wrapped
        linux-vdso.so.1 (0x00007fff749fe000)
        libclutter-gtk-1.0.so.0 => not found
        libmx-1.0.so.2 => not found
        libclutter-1.0.so.0 => not found
        libcogl-pango.so.15 => not found
        libcogl.so.15 => not found
        libgmodule-2.0.so.0 => not found
        libwayland-egl.so.1 => /run/opengl-driver/lib/libwayland-egl.so.1 (0x00007f129b918000)
        libwayland-client.so.0 => not found
        libgbm.so.1 => /run/opengl-driver/lib/libgbm.so.1 (0x00007f129b711000)
        libdrm.so.2 => not found
        libwayland-server.so.0 => not found
        libEGL.so.1 => /run/opengl-driver/lib/libEGL.so.1 (0x00007f129b4ee000)
        libXrandr.so.2 => not found
        libjson-glib-1.0.so.0 => not found
        libX11.so.6 => not found
        libXext.so.6 => not found
        libXdamage.so.1 => not found
        libXfixes.so.3 => not found
        libXcomposite.so.1 => not found
        libXi.so.6 => not found
        libkeybinder-3.0.so.0 => not found
        libgtk-3.so.0 => not found
        libgdk-3.so.0 => not found
        libpangocairo-1.0.so.0 => not found
        libpango-1.0.so.0 => not found
        libatk-1.0.so.0 => not found
        libcairo-gobject.so.2 => not found
        libcairo.so.2 => not found
        libgee-0.8.so.2 => not found
        libnotify.so.4 => not found
        libgdk_pixbuf-2.0.so.0 => not found
        libgio-2.0.so.0 => not found
        libgobject-2.0.so.0 => not found
        libglib-2.0.so.0 => not found
        libm.so.6 => /nix/store/94n64qy99ja0vgbkf675nyk39g9b978n-glibc-2.19/lib/libm.so.6 (0x00007f129b1ed000)
        libutil.so.1 => /nix/store/94n64qy99ja0vgbkf675nyk39g9b978n-glibc-2.19/lib/libutil.so.1 (0x00007f129afea000)
        libc.so.6 => /nix/store/94n64qy99ja0vgbkf675nyk39g9b978n-glibc-2.19/lib/libc.so.6 (0x00007f129ac3d000)
        libudev.so.1 => /nix/store/cqrq1dhkvv6dcdkapymz2hia4d54w3zn-systemd-212/lib/libudev.so.1 (0x00007f129bd18000)
        libdl.so.2 => /nix/store/pdskwizjw8ar31hql2wjnnx6g0s6xc50-glibc-2.19/lib/libdl.so.2 (0x00007f129aa39000)
        libwayland-client.so.0 => /nix/store/r4z7rr71l414zvcwn7yzzbywdkimr2wx-wayland-1.4.0/lib/libwayland-client.so.0 (0x00007f129a82c000)
        libwayland-server.so.0 => /nix/store/r4z7rr71l414zvcwn7yzzbywdkimr2wx-wayland-1.4.0/lib/libwayland-server.so.0 (0x00007f129a61b000)
        libffi.so.6 => /nix/store/fdl79b5fw059dnlbn6gsm7kfs9yzy3q7-libffi-3.0.13/lib64/libffi.so.6 (0x00007f129a412000)
        librt.so.1 => /nix/store/pdskwizjw8ar31hql2wjnnx6g0s6xc50-glibc-2.19/lib/librt.so.1 (0x00007f129a20a000)
        libglapi.so.0 => /run/opengl-driver/lib/libglapi.so.0 (0x00007f1299fe4000)
        libpthread.so.0 => /nix/store/pdskwizjw8ar31hql2wjnnx6g0s6xc50-glibc-2.19/lib/libpthread.so.0 (0x00007f1299dc6000)
        libdrm.so.2 => /nix/store/xs3yz669akhisq21q100clp65rl8pwl5-libdrm-2.4.52/lib/libdrm.so.2 (0x00007f1299bba000)
        libX11-xcb.so.1 => /nix/store/4qfxywb1f82z8a3jl2bnp76iavhhpkc8-libX11-1.6.2/lib/libX11-xcb.so.1 (0x00007f12999b9000)
        libX11.so.6 => /nix/store/4qfxywb1f82z8a3jl2bnp76iavhhpkc8-libX11-1.6.2/lib/libX11.so.6 (0x00007f129967f000)
        libxcb-dri2.so.0 => /nix/store/57gj929843gjip10wwrjiaqjysvbgca1-libxcb-1.10/lib/libxcb-dri2.so.0 (0x00007f129947b000)
        libxcb-xfixes.so.0 => /nix/store/57gj929843gjip10wwrjiaqjysvbgca1-libxcb-1.10/lib/libxcb-xfixes.so.0 (0x00007f1299275000)
        libxcb-render.so.0 => /nix/store/57gj929843gjip10wwrjiaqjysvbgca1-libxcb-1.10/lib/libxcb-render.so.0 (0x00007f129906c000)
        libxcb-shape.so.0 => /nix/store/57gj929843gjip10wwrjiaqjysvbgca1-libxcb-1.10/lib/libxcb-shape.so.0 (0x00007f1298e69000)
        libxcb.so.1 => /nix/store/57gj929843gjip10wwrjiaqjysvbgca1-libxcb-1.10/lib/libxcb.so.1 (0x00007f1298c4b000)
        libXau.so.6 => /nix/store/xfs977fd6x74gwkh3j9yhw1g2pvcii6v-libXau-1.0.8/lib/libXau.so.6 (0x00007f1298a48000)
        libXdmcp.so.6 => /nix/store/20rvszylpx0xdaxan93617m1gprgi2ql-libXdmcp-1.1.1/lib/libXdmcp.so.6 (0x00007f1298843000)
        /nix/store/94n64qy99ja0vgbkf675nyk39g9b978n-glibc-2.19/lib/ld-linux-x86-64.so.2 (0x00007f129bb19000)
```
