### PR TITLE
Adds GHC 7.8.3

### DIFF
--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, ghc, perl, gmp, ncurses }:
+
+stdenv.mkDerivation rec {
+  version = "7.8.3";
+  name = "ghc-${version}";
+
+  src = fetchurl {
+    url = "http://www.haskell.org/ghc/dist/7.8.3/${name}-src.tar.xz";
+    sha256 = "0n5rhwl83yv8qm0zrbaxnyrf8x1i3b6si927518mwfxs96jrdkdh";
+  };
+
+  buildInputs = [ ghc perl gmp ncurses ];
+
+  enableParallelBuilding = true;
+
+  buildMK = ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp}/include"
+    DYNAMIC_BY_DEFAULT = NO
+  '';
+
+  preConfigure = ''
+    echo "${buildMK}" > mk/build.mk
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+  '';
+
+  configureFlags = "--with-gcc=${stdenv.gcc}/bin/gcc";
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" "--keep-file-symbols" ];
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    maintainers = [
+      stdenv.lib.maintainers.marcweber
+      stdenv.lib.maintainers.andres
+      stdenv.lib.maintainers.simons
+      stdenv.lib.maintainers.tomberek
+    ];
+    inherit (ghc.meta) license platforms;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2957,6 +2957,7 @@ let
   haskellPackages_ghc763              = recurseIntoAttrs haskell.packages_ghc763.highPrio;
   # Reasonably current HEAD snapshot.
   haskellPackages_ghc782 = haskell.packages_ghc782;
+  haskellPackages_ghc783 = haskell.packages_ghc783;
   haskellPackages_ghcHEAD = haskell.packages_ghcHEAD;
 
   haskellPlatformPackages = recurseIntoAttrs (import ../development/libraries/haskell/haskell-platform { inherit pkgs; });

--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -20,6 +20,12 @@
     transformersCompat = super.transformersCompat_0_3_3;
   };
 
+  ghc783Prefs = self : super : ghcHEADPrefs self super // {
+    cabalInstall_1_20_0_3 = super.cabalInstall_1_20_0_3.override { Cabal = self.Cabal_1_20_0_1; };
+    codex = super.codex.override { hackageDb = super.hackageDb.override { Cabal = self.Cabal_1_20_0_1; }; };
+    mtl = self.mtl_2_1_2;
+  };
+
   ghc782Prefs = self : super : ghcHEADPrefs self super // {
     cabalInstall_1_20_0_3 = super.cabalInstall_1_20_0_3.override { Cabal = self.Cabal_1_20_0_1; };
     codex = super.codex.override { hackageDb = super.hackageDb.override { Cabal = self.Cabal_1_20_0_1; }; };
@@ -212,6 +218,12 @@
                  happy = pkgs.haskellPackages.happy_1_19_2;
                  alex = pkgs.haskellPackages.alex_3_1_3;
                };
+             };
+
+  packages_ghc783 =
+    packages { ghcPath = ../development/compilers/ghc/7.8.3.nix;
+               ghcBinary = ghc742Binary;
+               prefFun = ghc783Prefs;
              };
 
   packages_ghc782 =


### PR DESCRIPTION
This seems to work well for GHC 7.8.3.  @peti has some additional changes in #3232 that seem very interesting (static binaries! will they be fully static?).
#3232 also adds profiling and non-profiling variants as well as what I believe are specifics to ensure binaries are built via Hydra.
