### PR TITLE
Remove non-cpufreq_* modules since they are loaded by udev

### DIFF
--- a/nixos/modules/tasks/cpu-freq.nix
+++ b/nixos/modules/tasks/cpu-freq.nix
@@ -30,9 +30,7 @@ in
 
   config = mkIf (!config.boot.isContainer && config.powerManagement.cpuFreqGovernor != null) {
 
-    boot.kernelModules = [ "acpi-cpufreq" "speedstep-lib" "pcc-cpufreq"
-      "cpufreq_${cfg.cpuFreqGovernor}"
-    ];
+    boot.kernelModules = [ "cpufreq_${cfg.cpuFreqGovernor}" ];
 
     environment.systemPackages = [ cpupower ];
 


### PR DESCRIPTION
In my system log:

```
Jul 01 01:07:51 nixos systemd-modules-load[1376]: Failed to insert 'pcc_cpufreq': No such device
Jul 01 02:41:31 nixos systemd-modules-load[1280]: Failed to insert 'pcc_cpufreq': No such device
Jul 01 13:58:41 nixos systemd-modules-load[1280]: Failed to insert 'pcc_cpufreq': No such device
Jul 05 21:55:34 nixos systemd-modules-load[29460]: Failed to insert 'pcc_cpufreq': No such device
<etc.>
Jul 14 01:48:45 nixos systemd-modules-load[1333]: Failed to insert 'pcc_cpufreq': No such device
```

According to [this page](https://wiki.archlinux.org/index.php/CPU_frequency_scaling#CPU_frequency_driver), the device-specific module is loaded on-demand as of kernel 3.4, through some udev-kernel interaction. This is indeed the case on my system. Supposing that other systems are similarly successful in auto-probing, there is no reason to specifically load the modules. According to [the source](http://lxr.free-electrons.com/source/drivers/cpufreq/cpufreq.c#L463) modules such as cpufreq_ondemand should also be loaded, but that doesn't seem to work so I'm leaving it in.
