### PR TITLE
Update cabal-bounds to version 0.7

### DIFF
--- a/pkgs/development/tools/haskell/cabal-bounds/default.nix
+++ b/pkgs/development/tools/haskell/cabal-bounds/default.nix
@@ -6,17 +6,16 @@
 
 cabal.mkDerivation (self: {
   pname = "cabal-bounds";
-  version = "0.6";
-  sha256 = "0dl8rf8y365a20yz5kk1c9y860k5mkg1jp5dipvbf451h7a7h9w5";
+  version = "0.7";
+  sha256 = "1dz3bi33s2s0glsw248dxh76yj6qqlq2v2z7rys5js1mi6dicwa3";
   isLibrary = true;
   isExecutable = true;
+  jailbreak = true;
   buildDepends = [
     Cabal cabalLenses cmdargs either lens strict transformers
     unorderedContainers
   ];
   testDepends = [ filepath tasty tastyGolden ];
-  jailbreak = true;
-  doCheck = false;
   meta = {
     description = "A command line program for managing the bounds/versions of the dependencies in a cabal file";
     license = self.stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
jailbreak is set to true because cabal-bounds set the upper bounds
on lens to 4.2 and 4.3 just came out.
