### PR TITLE
uim, gtk-exe-env, qt-plugin-env: Add input method modules for GTK+ and Qt

### DIFF
--- a/nixos/modules/config/gtk-exe-env.nix
+++ b/nixos/modules/config/gtk-exe-env.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [
+  ];
+
+  options = {
+    gtkPlugins = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [];
+      description = ''
+        Plugin packages for GTK+ such as input methods.
+      '';
+    };
+  };
+
+  config = {
+    environment.variables = if builtins.length config.gtkPlugins > 0
+      then
+        let
+          paths = [ pkgs.gtk2 pkgs.gtk3 ] ++ config.gtkPlugins;
+          env = pkgs.buildEnv {
+            name = "gtk-exe-env";
+
+            inherit paths;
+
+            postBuild = lib.concatStringsSep "\n"
+              (map (d: d.gtkExeEnvPostBuild or "") paths);
+
+            ignoreCollisions = true;
+          };
+        in {
+          GTK_EXE_PREFIX = builtins.toString env;
+          GTK_PATH = [
+            "${env}/lib/gtk-2.0"
+            "${env}/lib/gtk-3.0"
+          ];
+        }
+      else {};
+  };
+}

--- a/nixos/modules/config/qt-plugin-env.nix
+++ b/nixos/modules/config/qt-plugin-env.nix
@@ -1,0 +1,37 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [
+  ];
+
+  options = {
+    qtPlugins = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [];
+      description = ''
+        Plugin packages for Qt such as input methods.
+      '';
+    };
+  };
+
+  config = {
+    environment.variables = if builtins.length config.qtPlugins > 0
+      then
+        let
+          paths = [ pkgs.qt48 ] ++ config.qtPlugins;
+          env = pkgs.buildEnv {
+            name = "qt-plugin-env";
+
+            inherit paths;
+
+            postBuild = lib.concatStringsSep "\n"
+              (map (d: d.qtPluginEnvPostBuild or "") paths);
+
+            ignoreCollisions = true;
+          };
+        in {
+          QT_PLUGIN_PATH = [ (builtins.toString env) ];
+        }
+      else {};
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -5,6 +5,7 @@
   ./config/fonts/fonts.nix
   ./config/fonts/ghostscript.nix
   ./config/gnu.nix
+  ./config/gtk-exe-env.nix
   ./config/i18n.nix
   ./config/krb5.nix
   ./config/ldap.nix
@@ -13,6 +14,7 @@
   ./config/nsswitch.nix
   ./config/power-management.nix
   ./config/pulseaudio.nix
+  ./config/qt-plugin-env.nix
   ./config/shells-environment.nix
   ./config/system-environment.nix
   ./config/swap.nix
@@ -56,6 +58,7 @@
   ./programs/shell.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
+  ./programs/uim.nix
   ./programs/venus.nix
   ./programs/wvdial.nix
   ./programs/zsh/zsh.nix

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -52,7 +52,7 @@ in
         STRIGI_PLUGIN_PATH = [ "${i}/lib/strigi/" ];
         QT_PLUGIN_PATH = [ "${i}/lib/qt4/plugins" "${i}/lib/kde4/plugins" ];
         QTWEBKIT_PLUGIN_PATH = [ "${i}/lib/mozilla/plugins/" ];
-        GTK_PATH = [ "${i}/lib/gtk-2.0" ];
+        GTK_PATH = [ "${i}/lib/gtk-2.0" "${i}/lib/gtk-3.0" ];
         XDG_CONFIG_DIRS = [ "${i}/etc/xdg" ];
         XDG_DATA_DIRS = [ "${i}/share" ];
         MOZ_PLUGIN_PATH = [ "${i}/lib/mozilla/plugins" ];

--- a/nixos/modules/programs/uim.nix
+++ b/nixos/modules/programs/uim.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, ... }:
+
+with pkgs.lib;
+
+let
+  cfg = config.uim;
+in
+{
+  options = {
+    uim = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "enable UIM input method";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.uim ];
+    gtkPlugins = [ pkgs.uim ];
+    qtPlugins = [ pkgs.uim ];
+    environment.variables.GTK_IM_MODULE = "uim";
+    environment.variables.QT_IM_MODULE = "uim";
+    environment.variables.XMODIFIERS = "@im=uim";
+    services.xserver.displayManager.sessionCommands = "uim-xim &";
+  };
+}

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -37,6 +37,13 @@ stdenv.mkDerivation rec {
 
   postInstall = "rm -rf $out/share/gtk-doc";
 
+  passthru = {
+    gtkExeEnvPostBuild = ''
+      rm $out/lib/gtk-2.0/2.10.0/immodules.cache
+      $out/bin/gtk-query-immodules-2.0 $out/lib/gtk-2.0/2.10.0/immodules/*.so > $out/lib/gtk-2.0/2.10.0/immodules.cache
+    ''; # workaround for bug of nix-mode for Emacs */ '';
+  };
+
   meta = with stdenv.lib; {
     description = "A multi-platform toolkit for creating graphical user interfaces";
     homepage    = http://www.gtk.org/;

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -38,6 +38,13 @@ stdenv.mkDerivation rec {
 
   postInstall = "rm -rf $out/share/gtk-doc";
 
+  passthru = {
+    gtkExeEnvPostBuild = ''
+      rm $out/lib/gtk-3.0/3.0.0/immodules.cache
+      $out/bin/gtk-query-immodules-3.0 $out/lib/gtk-3.0/3.0.0/immodules/*.so > $out/lib/gtk-3.0/3.0.0/immodules.cache
+    ''; # workaround for bug of nix-mode for Emacs */ '';
+  };
+
   meta = {
     description = "A multi-platform toolkit for creating graphical user interfaces";
 

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -1,0 +1,44 @@
+{stdenv, fetchurl, intltool, pkgconfig, qt4, gtk2, gtk3, kdelibs, cmake, ... }:
+
+stdenv.mkDerivation rec {
+  version = "1.8.6";
+  name = "uim-${version}";
+
+  buildInputs = [
+    intltool
+    pkgconfig
+    qt4
+    gtk2
+    gtk3
+    kdelibs
+    cmake
+  ];
+
+  patches = [ ./immodules_cache.patch ];
+
+  configureFlags = [
+    "--with-gtk2"
+    "--with-gtk3"
+    "--enable-kde4-applet"
+    "--enable-notify=knotify4"
+    "--enable-pref"
+    "--with-qt4"
+    "--with-qt4-immodule"
+    "--with-skk"
+    "--with-x"
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  src = fetchurl {
+    url = "http://uim.googlecode.com/files/uim-${version}.tar.bz2";
+    sha1 = "43b9dbdead6797880e6cfc9c032ecb2d37d42777";
+  };
+
+  meta = {
+    homepage = "http://code.google.com/p/uim/";
+    description = "A multilingual input method framework";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/uim/immodules_cache.patch
+++ b/pkgs/tools/inputmethods/uim/immodules_cache.patch
@@ -1,0 +1,231 @@
+diff -ru -x '*~' uim-1.8.6.orig/gtk2/immodule/Makefile.am uim-1.8.6/gtk2/immodule/Makefile.am
+--- uim-1.8.6.orig/gtk2/immodule/Makefile.am	2013-06-30 13:26:09.000000000 +0900
++++ uim-1.8.6/gtk2/immodule/Makefile.am	2014-07-13 21:51:26.538400004 +0900
+@@ -1,5 +1,5 @@
+ uim_gtk_im_module_path = $(libdir)/gtk-2.0
+-uim_gtk_im_module_file = $(DESTDIR)$(sysconfdir)/gtk-2.0/gtk.immodules
++uim_gtk_im_module_file = $(uim_gtk_im_module_path)/@GTK_BINARY_VERSION@/immodules.cache
+ 
+ moduledir = $(uim_gtk_im_module_path)/@GTK_BINARY_VERSION@/immodules
+ 
+@@ -38,48 +38,12 @@
+ 
+ install-data-hook: gtk-rc-get-immodule-file
+ 	if test -z $(DESTDIR); then \
+-	  if test $(libdir) = $(GTK_LIBDIR); then \
+-	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	      $(QUERY_COMMAND) > `$(GTK_RC_GET_IMMODULE_FILE)`; \
+-	      echo "*** \"`$(GTK_RC_GET_IMMODULE_FILE)`\" is updated. ***";  \
+-	    else \
+-	      echo "********************** Warning ***********************"; \
+-	      echo " $(QUERY_COMMAND) not found"; \
+-	      echo " Please make sure to update"; \
+-	      echo " \"`$(GTK_RC_GET_IMMODULE_FILE)`\""; \
+-	      echo " manually."; \
+-	      echo "******************************************************"; \
+-	    fi \
+-	  else \
+-	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	      $(mkinstalldirs) $(sysconfdir)/gtk-2.0; \
+-	      GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+-	      echo "******************************************************"; \
+-	      echo " You need to set"; \
+-	      echo " GTK_IM_MODULE_FILE=$(uim_gtk_im_module_file)"; \
+-	      echo " environment variable to use this module."; \
+-	      echo "******************************************************"; \
+-	    else \
+-	      echo "********************** Warning ***********************"; \
+-	      echo " $(QUERY_COMMAND) not found"; \
+-	      echo " Please make sure to update"; \
+-	      echo " \"$(uim_gtk_im_module_file)\""; \
+-	      echo " manually, and set"; \
+-	      echo " GTK_IM_MODULE_FILE=$(uim_gtk_im_module_file)"; \
+-	      echo " environment variable to use this module."; \
+-	      echo "******************************************************"; \
+-	    fi \
+-	  fi \
++	  $(mkinstalldirs) $(uim_gtk_im_module_path)/@GTK_BINARY_VERSION@; \
++	  GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+ 	fi
+ uninstall-hook:
+ 	if test -z $(DESTDIR); then \
+-	  if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	    if test $(libdir) = $(GTK_LIBDIR); then \
+-	      $(QUERY_COMMAND) > `$(GTK_RC_GET_IMMODULE_FILE)`; \
+-	    else \
+-	      GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+-	    fi \
+-	  fi \
++	  GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+ 	fi
+ else
+ install-data-hook:
+diff -ru -x '*~' uim-1.8.6.orig/gtk2/immodule/Makefile.in uim-1.8.6/gtk2/immodule/Makefile.in
+--- uim-1.8.6.orig/gtk2/immodule/Makefile.in	2013-06-30 13:27:08.000000000 +0900
++++ uim-1.8.6/gtk2/immodule/Makefile.in	2014-07-13 22:12:27.947595507 +0900
+@@ -434,7 +434,7 @@
+ top_srcdir = @top_srcdir@
+ uim_pixmapsdir = @uim_pixmapsdir@
+ uim_gtk_im_module_path = $(libdir)/gtk-2.0
+-uim_gtk_im_module_file = $(DESTDIR)$(sysconfdir)/gtk-2.0/gtk.immodules
++uim_gtk_im_module_file = $(uim_gtk_im_module_path)/@GTK_BINARY_VERSION@/immodules.cache
+ moduledir = $(uim_gtk_im_module_path)/@GTK_BINARY_VERSION@/immodules
+ @GTK2_TRUE@im_uim_la = im-uim.la
+ @GTK2_TRUE@im_uim_la_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
+@@ -875,48 +875,12 @@
+ 
+ @GTK2_TRUE@install-data-hook: gtk-rc-get-immodule-file
+ @GTK2_TRUE@	if test -z $(DESTDIR); then \
+-@GTK2_TRUE@	  if test $(libdir) = $(GTK_LIBDIR); then \
+-@GTK2_TRUE@	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK2_TRUE@	      $(QUERY_COMMAND) > `$(GTK_RC_GET_IMMODULE_FILE)`; \
+-@GTK2_TRUE@	      echo "*** \"`$(GTK_RC_GET_IMMODULE_FILE)`\" is updated. ***";  \
+-@GTK2_TRUE@	    else \
+-@GTK2_TRUE@	      echo "********************** Warning ***********************"; \
+-@GTK2_TRUE@	      echo " $(QUERY_COMMAND) not found"; \
+-@GTK2_TRUE@	      echo " Please make sure to update"; \
+-@GTK2_TRUE@	      echo " \"`$(GTK_RC_GET_IMMODULE_FILE)`\""; \
+-@GTK2_TRUE@	      echo " manually."; \
+-@GTK2_TRUE@	      echo "******************************************************"; \
+-@GTK2_TRUE@	    fi \
+-@GTK2_TRUE@	  else \
+-@GTK2_TRUE@	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK2_TRUE@	      $(mkinstalldirs) $(sysconfdir)/gtk-2.0; \
+-@GTK2_TRUE@	      GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+-@GTK2_TRUE@	      echo "******************************************************"; \
+-@GTK2_TRUE@	      echo " You need to set"; \
+-@GTK2_TRUE@	      echo " GTK_IM_MODULE_FILE=$(uim_gtk_im_module_file)"; \
+-@GTK2_TRUE@	      echo " environment variable to use this module."; \
+-@GTK2_TRUE@	      echo "******************************************************"; \
+-@GTK2_TRUE@	    else \
+-@GTK2_TRUE@	      echo "********************** Warning ***********************"; \
+-@GTK2_TRUE@	      echo " $(QUERY_COMMAND) not found"; \
+-@GTK2_TRUE@	      echo " Please make sure to update"; \
+-@GTK2_TRUE@	      echo " \"$(uim_gtk_im_module_file)\""; \
+-@GTK2_TRUE@	      echo " manually, and set"; \
+-@GTK2_TRUE@	      echo " GTK_IM_MODULE_FILE=$(uim_gtk_im_module_file)"; \
+-@GTK2_TRUE@	      echo " environment variable to use this module."; \
+-@GTK2_TRUE@	      echo "******************************************************"; \
+-@GTK2_TRUE@	    fi \
+-@GTK2_TRUE@	  fi \
++@GTK2_TRUE@	  $(mkinstalldirs) $(uim_gtk_im_module_path)/@GTK_BINARY_VERSION@; \
++@GTK2_TRUE@	  GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+ @GTK2_TRUE@	fi
+ @GTK2_TRUE@uninstall-hook:
+ @GTK2_TRUE@	if test -z $(DESTDIR); then \
+-@GTK2_TRUE@	  if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK2_TRUE@	    if test $(libdir) = $(GTK_LIBDIR); then \
+-@GTK2_TRUE@	      $(QUERY_COMMAND) > `$(GTK_RC_GET_IMMODULE_FILE)`; \
+-@GTK2_TRUE@	    else \
+-@GTK2_TRUE@	      GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+-@GTK2_TRUE@	    fi \
+-@GTK2_TRUE@	  fi \
++@GTK2_TRUE@	  GTK_PATH=$(uim_gtk_im_module_path) $(QUERY_COMMAND) > $(uim_gtk_im_module_file); \
+ @GTK2_TRUE@	fi
+ @GTK2_FALSE@install-data-hook:
+ 
+diff -ru -x '*~' uim-1.8.6.orig/gtk3/immodule/Makefile.am uim-1.8.6/gtk3/immodule/Makefile.am
+--- uim-1.8.6.orig/gtk3/immodule/Makefile.am	2013-06-30 13:26:20.000000000 +0900
++++ uim-1.8.6/gtk3/immodule/Makefile.am	2014-07-13 21:55:38.114246503 +0900
+@@ -45,42 +45,11 @@
+ 
+ install-data-hook: gtk3-rc-get-immodule-file
+ 	if test -z $(DESTDIR); then \
+-	  if test $(libdir) = $(GTK3_LIBDIR); then \
+-	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	      $(QUERY_COMMAND) --update-cache; \
+-	      echo "*** \"`$(GTK3_RC_GET_IMMODULE_FILE)`\" is updated. ***";  \
+-	    else \
+-	      echo "********************** Warning ***********************"; \
+-	      echo " $(QUERY_COMMAND) not found"; \
+-	      echo " Please make sure to update"; \
+-	      echo " \"`$(GTK3_RC_GET_IMMODULE_FILE)`\""; \
+-	      echo " manually."; \
+-	      echo "******************************************************"; \
+-	    fi \
+-	  else \
+-	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-	    else \
+-	      echo "********************** Warning ***********************"; \
+-	      echo " $(QUERY_COMMAND) not found"; \
+-	      echo " Please make sure to update"; \
+-	      echo " immodules.cache"; \
+-	      echo " manually, and set"; \
+-	      echo " GTK_IM_MODULE_FILE=PATH_TO/immodule.cache"; \
+-	      echo " environment variable to use this module."; \
+-	      echo "******************************************************"; \
+-	    fi \
+-	  fi \
++	  GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ 	fi
+ uninstall-hook:
+ 	if test -z $(DESTDIR); then \
+-	  if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-	    if test $(libdir) = $(GTK3_LIBDIR); then \
+-	      $(QUERY_COMMAND) --update-cache; \
+-	    else \
+-	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-	    fi \
+-	  fi \
++	  GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ 	fi
+ else
+ install-data-hook:
+diff -ru -x '*~' uim-1.8.6.orig/gtk3/immodule/Makefile.in uim-1.8.6/gtk3/immodule/Makefile.in
+--- uim-1.8.6.orig/gtk3/immodule/Makefile.in	2013-06-30 13:27:08.000000000 +0900
++++ uim-1.8.6/gtk3/immodule/Makefile.in	2014-07-13 21:56:11.531225832 +0900
+@@ -893,42 +893,11 @@
+ 
+ @GTK3_TRUE@install-data-hook: gtk3-rc-get-immodule-file
+ @GTK3_TRUE@	if test -z $(DESTDIR); then \
+-@GTK3_TRUE@	  if test $(libdir) = $(GTK3_LIBDIR); then \
+-@GTK3_TRUE@	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK3_TRUE@	      $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	      echo "*** \"`$(GTK3_RC_GET_IMMODULE_FILE)`\" is updated. ***";  \
+-@GTK3_TRUE@	    else \
+-@GTK3_TRUE@	      echo "********************** Warning ***********************"; \
+-@GTK3_TRUE@	      echo " $(QUERY_COMMAND) not found"; \
+-@GTK3_TRUE@	      echo " Please make sure to update"; \
+-@GTK3_TRUE@	      echo " \"`$(GTK3_RC_GET_IMMODULE_FILE)`\""; \
+-@GTK3_TRUE@	      echo " manually."; \
+-@GTK3_TRUE@	      echo "******************************************************"; \
+-@GTK3_TRUE@	    fi \
+-@GTK3_TRUE@	  else \
+-@GTK3_TRUE@	    if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK3_TRUE@	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	    else \
+-@GTK3_TRUE@	      echo "********************** Warning ***********************"; \
+-@GTK3_TRUE@	      echo " $(QUERY_COMMAND) not found"; \
+-@GTK3_TRUE@	      echo " Please make sure to update"; \
+-@GTK3_TRUE@	      echo " immodules.cache"; \
+-@GTK3_TRUE@	      echo " manually, and set"; \
+-@GTK3_TRUE@	      echo " GTK_IM_MODULE_FILE=PATH_TO/immodule.cache"; \
+-@GTK3_TRUE@	      echo " environment variable to use this module."; \
+-@GTK3_TRUE@	      echo "******************************************************"; \
+-@GTK3_TRUE@	    fi \
+-@GTK3_TRUE@	  fi \
++@GTK3_TRUE@	  GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ @GTK3_TRUE@	fi
+ @GTK3_TRUE@uninstall-hook:
+ @GTK3_TRUE@	if test -z $(DESTDIR); then \
+-@GTK3_TRUE@	  if type $(QUERY_COMMAND) > /dev/null 2>&1; then \
+-@GTK3_TRUE@	    if test $(libdir) = $(GTK3_LIBDIR); then \
+-@GTK3_TRUE@	      $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	    else \
+-@GTK3_TRUE@	      GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) --update-cache; \
+-@GTK3_TRUE@	    fi \
+-@GTK3_TRUE@	  fi \
++@GTK3_TRUE@	  GTK_PATH=$(uim_gtk3_im_module_path) $(QUERY_COMMAND) > $(uim_gtk3_im_module_path)/@GTK3_BINARY_VERSION@/immodules.cache ; \
+ @GTK3_TRUE@	fi
+ @GTK3_FALSE@install-data-hook:
+ 
+diff -ru -x '*~' uim-1.8.6.orig/qt4/immodule/quiminputcontextplugin.pro.in uim-1.8.6/qt4/immodule/quiminputcontextplugin.pro.in
+--- uim-1.8.6.orig/qt4/immodule/quiminputcontextplugin.pro.in	2013-06-30 13:26:20.000000000 +0900
++++ uim-1.8.6/qt4/immodule/quiminputcontextplugin.pro.in	2014-03-09 11:31:19.388085048 +0900
+@@ -35,4 +35,4 @@
+ 
+ TARGET = uiminputcontextplugin
+ 
+-target.path += @DESTDIR@$$[QT_INSTALL_PLUGINS]/inputmethods
++target.path += @DESTDIR@@exec_prefix@/lib/qt4/plugins/inputmethods

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2325,6 +2325,10 @@ let
 
   ttmkfdir = callPackage ../tools/misc/ttmkfdir { };
 
+  uim = callPackage ../tools/inputmethods/uim {
+    inherit (pkgs.kde4) kdelibs;
+  };
+
   unclutter = callPackage ../tools/misc/unclutter { };
 
   unbound = callPackage ../tools/networking/unbound { };


### PR DESCRIPTION
This patch adds NixOS modules managing GTK+/Qt plugins such as input methods. The patch also adds uim, a multilingual input method framework.

The module is based on @iyzsong's idea proposed at https://github.com/NixOS/nixpkgs/pull/2450#issuecomment-42130139.
As discussed in #2450, this is not an ideal solution, but it works for most cases.
### How to setup uim

For system wide installation:
1. Add `uim.enable = true;` to the `configuration.nix`.
2. `nixos-rebuild switch`.
3. `uim-pref-gtk`, `uim-pref-gtk3`, or `uim-pref-qt`.

For per-user installation:

```
nix-env -i uim
export GTK_IM_MODULE=uim
export GTK_EXE_PREFIX=~/.nix-profile/
export QT_IM_MODULE=uim
export XMODIFIERS=@im=uim
# ↓ if you does not use NixOS:
export QT_PLUGIN_PATH=~/.nix-profile/lib/qt4/plugins
# ↑ NixOS export QT_PLUGIN_PATH in environment.nix
uim-xim &
uim-pref-gtk
```
### How to add an input method

See `nixos/modules/programs/uim.nix` for example.
1. add the package to `gtkPlugins` and `qtPlugins` to build plugin environments.
2. set `environment.variables.GTK_IM_MODULE`, `environment.variables.QT_IM_MODULE`, and `environment.variables.XMODIFIERS`.
3. set `services.xserver.displayManager.sessionCommands` to start xim bridge.
4. (optional) add the package to `environment.systemPackages` to install helper commands.
### Internals

The module builds environments containing the toolkits (GTK+ and Qt) and plugins. Then it set `GTK_EXE_PREFIX`, `GTK_PATH`, and `QT_PLUGIN_PATH` to point those environments. Toolkits and plugins can execute additional commands (e.g. `gtk-query-immodules-2.0`) while building the environments.
