### PR TITLE
vagrant: upgrade to 1.6.3

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -4,18 +4,18 @@
 assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
 
 stdenv.mkDerivation rec {
-  name = "vagrant-1.4.3";
+  name = "vagrant-1.6.3";
 
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url    = https://dl.bintray.com/mitchellh/vagrant/vagrant_1.4.3_x86_64.deb;
-        sha256 = "dbd06de0f3560e2d046448d627bca0cbb0ee34b036ef605aa87ed20e6ad2684b";
+        url    = https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3_x86_64.deb;
+        sha256 = "1gmdg92dw7afnvpji0wg4nzr7vhk8mrmcqk3hcrkwscby2f2bhqg";
       }
     else
       fetchurl {
-        url    = https://dl.bintray.com/mitchellh/vagrant/vagrant_1.4.3_i686.deb;
-        sha256 = "66e613fc1c9e31ecaf8e5f1d07d2ae4fca3d4fc2e43593543962664258d9af9b";
+        url    = https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3_i686.deb;
+        sha256 = "1z26b6yghqgx8jbi2igf4kk4h6rzy869gli2vj7ayl7vbqdfvb60";
       };
 
   meta = with stdenv.lib; {
@@ -80,5 +80,14 @@ stdenv.mkDerivation rec {
     mkdir -p "$out"
     cp -r opt "$out"
     cp -r usr/bin "$out"
+  '';
+
+  preFixup = ''
+    # 'hide' the template file from shebang-patching
+    chmod -x $out/opt/vagrant/embedded/gems/gems/bundler-1.6.2/lib/bundler/templates/Executable
+  '';
+
+  postFixup = ''
+    chmod +x $out/opt/vagrant/embedded/gems/gems/bundler-1.6.2/lib/bundler/templates/Executable
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4170,7 +4170,9 @@ let
 
   uncrustify = callPackage ../development/tools/misc/uncrustify { };
 
-  vagrant = callPackage ../development/tools/vagrant { };
+  vagrant = callPackage ../development/tools/vagrant {
+    ruby = ruby2;
+  };
 
   gdb = callPackage ../development/tools/misc/gdb {
     hurd = gnu.hurdCross;


### PR DESCRIPTION
ruby dependency upgraded to 2.0
hack to skip embedded bundler's template file while shebang-patching
