### PR TITLE
Set ES_HOME for Elasticsearch

### DIFF
--- a/pkgs/servers/search/elasticsearch/default.nix
+++ b/pkgs/servers/search/elasticsearch/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/elasticsearch \
       --prefix ES_CLASSPATH : "$out/lib/${name}.jar":"$out/lib/*":"$out/lib/sigar/*" \
       ${optionalString (!stdenv.isDarwin) ''--prefix PATH : "${utillinux}/bin/"''} \
-      --set JAVA_HOME "${jre}"
+      --set JAVA_HOME "${jre}" \
+      --set ES_HOME "$out"
     wrapProgram $out/bin/elasticsearch-plugin \
       --prefix ES_CLASSPATH : "$out/lib/${name}.jar":"$out/lib/*":"$out/lib/sigar/*" --set JAVA_HOME "${jre}"
   '';


### PR DESCRIPTION
Elasticsearch requires ES_HOME to be set so that it can find config and so on
