### PR TITLE
SDL_mixer : add option to enable FluidSynth for playing MIDIs with SF2s

### DIFF
--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, SDL, libogg, libvorbis, enableNativeMidi ? false }:
+{ stdenv, fetchurl, SDL, libogg, libvorbis, enableNativeMidi ? false, enableFluidSynth ? false, fluidsynth ? null }:
+
+assert enableFluidSynth -> fluidsynth != null;
 
 stdenv.mkDerivation rec {
   pname   = "SDL_mixer";
@@ -10,9 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "0alrhqgm40p4c92s26mimg9cm1y7rzr6m0p49687jxd9g6130i0n";
   };
 
-  buildInputs = [SDL libogg libvorbis];
+  buildInputs = [SDL libogg libvorbis]
+    ++ stdenv.lib.optional enableFluidSynth fluidsynth;
 
-  configureFlags = "--disable-music-ogg-shared" + stdenv.lib.optionalString enableNativeMidi "--enable-music-native-midi-gpl";
+  configureFlags = "--disable-music-ogg-shared" + stdenv.lib.optionalString enableNativeMidi " --enable-music-native-midi-gpl";
 
   postInstall = "ln -s $out/include/SDL/SDL_mixer.h $out/include/";
 


### PR DESCRIPTION
This adds the option to play MIDI files with SF2 soundfonts via FluidSynth using an environment variable(SDL_SOUNDFONTS). This is invaluable to retro gamers with MIDI games in their collection. Also a minor bug was fixed concerning enableNativeMidi
