### PR TITLE
SDL_mixer : add option to enable FluidSynth for playing MIDIs with SF2s

### DIFF
--- a/pkgs/development/libraries/SDL_mixer/default.nix
+++ b/pkgs/development/libraries/SDL_mixer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL, libogg, libvorbis, enableNativeMidi ? false }:
+{ stdenv, fetchurl, SDL, libogg, libvorbis, enableNativeMidi ? false, fluidsynth ? null }:
 
 stdenv.mkDerivation rec {
   pname   = "SDL_mixer";
@@ -10,9 +10,9 @@ stdenv.mkDerivation rec {
     sha256 = "0alrhqgm40p4c92s26mimg9cm1y7rzr6m0p49687jxd9g6130i0n";
   };
 
-  buildInputs = [SDL libogg libvorbis];
+  buildInputs = [SDL libogg libvorbis fluidsynth];
 
-  configureFlags = "--disable-music-ogg-shared" + stdenv.lib.optionalString enableNativeMidi "--enable-music-native-midi-gpl";
+  configureFlags = "--disable-music-ogg-shared" + stdenv.lib.optionalString enableNativeMidi " --enable-music-native-midi-gpl";
 
   postInstall = "ln -s $out/include/SDL/SDL_mixer.h $out/include/";
 


### PR DESCRIPTION
Fluidsynth is used to enable SDL_mixer to use Soundfonts to play MIDI files, this is invaluable for MIDI programs that use SDL_mixer. Also a small bug with enableNativeMidi was fixed
