### PR TITLE
Adds OCaml libraries: uucd, uunf, uutf and xmlm

### DIFF
--- a/pkgs/development/ocaml-modules/uucd/default.nix
+++ b/pkgs/development/ocaml-modules/uucd/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl, ocaml, findlib, opam, xmlm}:
+let
+  pname = "uucd";
+  version = "2.0.0";
+  webpage = "http://erratique.ch/software/${pname}";
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "12lbrrdjwdxfa99pbg344dfkj51lr5d2ispcj7d7lwsqyxy6h57i";
+  };
+
+  buildInputs = [ ocaml findlib opam xmlm ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "ocaml ./pkg/build.ml native=true native-dynlink=true";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install > install.sh
+    sh install.sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+  '';
+
+  propagatedBuildInputs = [ xmlm ];
+
+  meta = {
+    description = "An OCaml module to decode the data of the Unicode character database from its XML representation";
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchurl, ocaml, findlib, opam}:
+let
+  pname = "uunf";
+  version = "0.9.3";
+  webpage = "http://erratique.ch/software/${pname}";
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "16cgjy1m0m61srv1pmlc3gr0y40kd4724clvpagdnz68raz4zmn0";
+  };
+
+  buildInputs = [ ocaml findlib opam ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "./pkg/build true false";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install > install.sh
+    sh install.sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+  '';
+
+  meta = {
+    description = "An OCaml module for normalizing Unicode text";
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchurl, ocaml, findlib, opam}:
+let
+  pname = "uutf";
+  version = "0.9.3";
+  webpage = "http://erratique.ch/software/${pname}";
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "0xvq20knmq25902ijpbk91ax92bkymsqkbfklj1537hpn64lydhz";
+  };
+
+  buildInputs = [ ocaml findlib opam ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "./pkg/build true";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install > install.sh
+    sh install.sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+  '';
+
+  meta = {
+    description = "Non-blocking streaming Unicode codec for OCaml";
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchurl, ocaml, findlib, opam}:
+let
+  pname = "xmlm";
+  version = "1.2.0";
+  webpage = "http://erratique.ch/software/${pname}";
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "1jywcrwn5z3gkgvicr004cxmdaqfmq8wh72f81jqz56iyn5024nh";
+  };
+
+  buildInputs = [ ocaml findlib opam ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "./pkg/build true";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install > install.sh
+    sh install.sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+  '';
+
+  meta = {
+    description = "An OCaml streaming codec to decode and encode the XML data format";
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3293,6 +3293,11 @@ let
     opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix { };
     opam = opam_1_1;
 
+    uucd = callPackage ../development/ocaml-modules/uucd { };
+    uunf = callPackage ../development/ocaml-modules/uunf { };
+    uutf = callPackage ../development/ocaml-modules/uutf { };
+    xmlm = callPackage ../development/ocaml-modules/xmlm { };
+
     yojson = callPackage ../development/ocaml-modules/yojson { };
 
     zarith = callPackage ../development/ocaml-modules/zarith { };


### PR DESCRIPTION
Four OCaml libraries contributed by Daniel Bünzli for unicode and xml
processing.
-  xmlm: Streaming XML codec for OCaml
-  uutf: Non-blocking streaming Unicode codec for OCaml
-  uunf: Unicode text normalization for OCaml
-  uucd: Unicode character database decoder for Ocaml

Homepage: http://erratique.ch/software
