### PR TITLE
add Source Han Sans font

### DIFF
--- a/pkgs/data/fonts/source-han-sans/base.nix
+++ b/pkgs/data/fonts/source-han-sans/base.nix
@@ -1,0 +1,26 @@
+{version ? "1.000", prefix, url, sha256, description}:
+
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  inherit version;
+  name = "${prefix}-${version}";
+
+  src = fetchurl {
+    inherit url sha256;
+  };
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp $( find . -name '*.otf' ) $out/share/fonts/truetype
+  '';
+
+  meta = {
+    inherit description;
+
+    homepage = http://sourceforge.net/adobe/source-han-sans/;
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/data/fonts/source-han-sans/japanese.nix
+++ b/pkgs/data/fonts/source-han-sans/japanese.nix
@@ -1,0 +1,6 @@
+import ./base.nix {
+  prefix = "SourceHanSansJP";
+  url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansJP-1.000.zip";
+  sha256 = "c5930036660bea22ffceaa9e2df765776494800d330a59be7936ab3c763c4c82";
+  description = "Japanese subset of an open source Pan-CJK typeface";
+}

--- a/pkgs/data/fonts/source-han-sans/japanese.nix
+++ b/pkgs/data/fonts/source-han-sans/japanese.nix
@@ -1,5 +1,5 @@
 import ./base.nix {
-  prefix = "SourceHanSansJP";
+  prefix = "source-han-sans-japanese";
   url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansJP-1.000.zip";
   sha256 = "c5930036660bea22ffceaa9e2df765776494800d330a59be7936ab3c763c4c82";
   description = "Japanese subset of an open source Pan-CJK typeface";

--- a/pkgs/data/fonts/source-han-sans/korean.nix
+++ b/pkgs/data/fonts/source-han-sans/korean.nix
@@ -1,0 +1,6 @@
+import ./base.nix {
+  prefix = "SourceHanSansKR";
+  url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansKR-1.000.zip";
+  sha256 = "8eed4ad092fcf640e44f73ba510e0ed1c1cabf79776f68d02820734bbba21cf8";
+  description = "Korean subset of an open source Pan-CJK typeface";
+}

--- a/pkgs/data/fonts/source-han-sans/korean.nix
+++ b/pkgs/data/fonts/source-han-sans/korean.nix
@@ -1,5 +1,5 @@
 import ./base.nix {
-  prefix = "SourceHanSansKR";
+  prefix = "source-han-sans-korean";
   url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansKR-1.000.zip";
   sha256 = "8eed4ad092fcf640e44f73ba510e0ed1c1cabf79776f68d02820734bbba21cf8";
   description = "Korean subset of an open source Pan-CJK typeface";

--- a/pkgs/data/fonts/source-han-sans/simplified-chinese.nix
+++ b/pkgs/data/fonts/source-han-sans/simplified-chinese.nix
@@ -1,0 +1,6 @@
+import ./base.nix {
+  prefix = "SourceHanSansCN";
+  url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansCN-1.000.zip";
+  sha256 = "88117aa8f8b4ab65d6f7a919a5e1b06d6c00f75b1abecccf120246536123754d";
+  description = "Simplified Chinese subset of an open source Pan-CJK typeface";
+}

--- a/pkgs/data/fonts/source-han-sans/simplified-chinese.nix
+++ b/pkgs/data/fonts/source-han-sans/simplified-chinese.nix
@@ -1,5 +1,5 @@
 import ./base.nix {
-  prefix = "SourceHanSansCN";
+  prefix = "source-han-sans-simplified-chinese";
   url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansCN-1.000.zip";
   sha256 = "88117aa8f8b4ab65d6f7a919a5e1b06d6c00f75b1abecccf120246536123754d";
   description = "Simplified Chinese subset of an open source Pan-CJK typeface";

--- a/pkgs/data/fonts/source-han-sans/traditional-chinese.nix
+++ b/pkgs/data/fonts/source-han-sans/traditional-chinese.nix
@@ -1,5 +1,5 @@
 import ./base.nix {
-  prefix = "SourceHanSansTWHK";
+  prefix = "source-han-sans-traditional-chinese";
   url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansTWHK-1.000.zip";
   sha256 = "2371a726757a51322243b1ed7a9fde562621b0813b5e6d6443e06847ad7bbd20";
   description = "Traditional Chinese subset of an open source Pan-CJK typeface";

--- a/pkgs/data/fonts/source-han-sans/traditional-chinese.nix
+++ b/pkgs/data/fonts/source-han-sans/traditional-chinese.nix
@@ -1,0 +1,6 @@
+import ./base.nix {
+  prefix = "SourceHanSansTWHK";
+  url = "mirror://sourceforge/source-han-sans.adobe/SourceHanSansTWHK-1.000.zip";
+  sha256 = "2371a726757a51322243b1ed7a9fde562621b0813b5e6d6443e06847ad7bbd20";
+  description = "Traditional Chinese subset of an open source Pan-CJK typeface";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8013,6 +8013,11 @@ let
 
   sourceCodePro = callPackage ../data/fonts/source-code-pro {};
 
+  source-han-sans-japanese = callPackage ../data/fonts/source-han-sans/japanese.nix {};
+  source-han-sans-korean = callPackage ../data/fonts/source-han-sans/korean.nix {};
+  source-han-sans-simplified-chinese = callPackage ../data/fonts/source-han-sans/simplified-chinese.nix {};
+  source-han-sans-traditional-chinese = callPackage ../data/fonts/source-han-sans/traditional-chinese.nix {};
+
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme { };
 
   themes = name: import (../data/misc/themes + ("/" + name + ".nix")) {


### PR DESCRIPTION
Source Han Sans font is an OpenType pan-CJK font family by Adobe. It contains Japanese, Korean, Traditional Chinese, and Simplified Chinese glyphs. The font is licensed under Apache License 2.0.
