### PR TITLE
Logstash 1.4.2

### DIFF
--- a/nixos/modules/services/logging/logstash.nix
+++ b/nixos/modules/services/logging/logstash.nix
@@ -69,9 +69,9 @@ in
     systemd.services.logstash = with pkgs; {
       description = "Logstash Daemon";
       wantedBy = [ "multi-user.target" ];
-
+      environment = { JAVA_HOME = jre; };
       serviceConfig = {
-        ExecStart = "${jre}/bin/java -jar ${logstash} agent -f ${writeText "logstash.conf" ''
+        ExecStart = "${logstash}/bin/logstash agent -f ${writeText "logstash.conf" ''
           input {
             ${cfg.inputConfig}
           }

--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -1,11 +1,24 @@
-{ fetchurl }:
+{ stdenv, fetchurl }:
 
-let version = "1.3.3"; in
+stdenv.mkDerivation rec {
+  version = "1.4.2";
+  name = "logstash-${version}";
 
-fetchurl {
-  url = "https://download.elasticsearch.org/logstash/logstash/logstash-${version}-flatjar.jar";
+  src = fetchurl {
+    url = "https://download.elasticsearch.org/logstash/logstash/logstash-${version}.tar.gz";
+    sha256 = "0sc0bwyf96fzs5h3d7ii65v9vvpfbm7w67vk1im9djnlz0d1ggnm";
+  };
 
-  name = "logstash-${version}-flatjar.jar";
+  dontBuild    = true;
+  dontPatchELF = true;
+  dontStrip    = true;
 
-  sha256 = "a83503bd2aa32e1554b98f812d0b411fbc5f7b6b21cebb48b7d344474f2dfc6d";
+  installPhase = ''
+    cp -a bin $out
+  '';
+
+  meta = {
+    description = "Open Source, Distributed, RESTful Search Engine";
+    homepage    = http://www.elasticsearch.org;
+  };
 }

--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -31,5 +31,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Open Source, Distributed, RESTful Search Engine";
     homepage    = http://www.elasticsearch.org;
+    license     = stdenv.lib.licenses.asl20;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.wjlroe ];
   };
 }

--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -12,9 +12,20 @@ stdenv.mkDerivation rec {
   dontBuild    = true;
   dontPatchELF = true;
   dontStrip    = true;
+  dontPatchShebangs = true;
 
   installPhase = ''
+    ensureDir $out/bin
+    ensureDir $out/vendor
+    ensureDir $out/lib
+    ensureDir $out/locales
+    ensureDir $out/patterns
     cp -a bin $out
+    cp -a vendor $out
+    cp -a lib $out
+    cp -a locales $out
+    cp -a patterns $out
+    patchShebangs $out/bin
   '';
 
   meta = {


### PR DESCRIPTION
This pull request upgrades Logstash from 1.3.3 to 1.4.2. The download is no longer distributed as a flat JAR file, but as a tarball with wrapper shell scripts and so on. 
