### PR TITLE
krb5: explicitly giving --with-tcl=no option for configure to remove imp...

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (rec {
     cd ${name}/src
   '';
 
+  configureFlags = "--with-tcl=no";
+
   #doCheck = true; # report: No suitable file for testing purposes
 
   enableParallelBuilding = true;


### PR DESCRIPTION
...urity

I got the following build failure. The configure script found tclConfig.sh from impure location

```
checking for tclConfig.sh...  /usr/lib/tcl8.5/tclConfig.sh
```

Whole logs: 

```
building path(s) `/afs/ir.stanford.edu/users/t/i/timcohen/nix/store/y7cz9fbk6ym4rp3q488mpn9fn9wd9phx-krb5-1.11.3'
building /afs/ir.stanford.edu/users/t/i/timcohen/nix/store/y7cz9fbk6ym4rp3q488mpn9fn9wd9phx-krb5-1.11.3
unpacking sources
patching sources
configuring
configure flags: --disable-static --prefix=/afs/ir.stanford.edu/users/t/i/timcohen/nix/store/y7cz9fbk6ym4rp3q488mpn9fn9wd9phx-krb5-1.11.3  
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking how to run the C preprocessor... gcc -E
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for grep that handles long lines and -e... /afs/ir.stanford.edu/users/t/i/timcohen/nix/store/xr28ahc9hgwrn1lmdfr3gd5kd39z35db-gnugrep-2.14/bin/grep
checking for egrep... /afs/ir.stanford.edu/users/t/i/timcohen/nix/store/xr28ahc9hgwrn1lmdfr3gd5kd39z35db-gnugrep-2.14/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for GNU linker... yes
configure: adding extra warning flags for gcc
configure: skipping pedantic warnings on Linux
configure: adding extra warning flags for g++
checking if C compiler supports -Wno-format-zero-length... yes
checking if C compiler supports -Woverflow... yes
checking if C compiler supports -Wstrict-overflow... yes
checking if C compiler supports -Wmissing-format-attribute... yes
checking if C compiler supports -Wmissing-prototypes... yes
checking if C compiler supports -Wreturn-type... yes
checking if C compiler supports -Wmissing-braces... yes
checking if C compiler supports -Wparentheses... yes
checking if C compiler supports -Wswitch... yes
checking if C compiler supports -Wunused-function... yes
checking if C compiler supports -Wunused-label... yes
checking if C compiler supports -Wunused-variable... yes
checking if C compiler supports -Wunused-value... yes
checking if C compiler supports -Wunknown-pragmas... yes
checking if C compiler supports -Wsign-compare... yes
checking if C compiler supports -Wnewline-eof... no
checking if C compiler supports -Werror=uninitialized... yes
checking if C compiler supports -Werror=declaration-after-statement... yes
checking if C compiler supports -Werror=variadic-macros... yes
checking if C compiler supports -Werror-implicit-function-declaration... yes
checking which version of com_err to use... krb5
checking which version of subsystem package to use... krb5
checking for an ANSI C-conforming const... yes
checking for gethostbyname... yes
checking for socket... yes
checking for main in -lresolv... yes
checking for res_ninit... yes
checking for res_nclose... yes
checking for res_ndestroy... no
checking for res_nsearch... yes
checking for ns_initparse... yes
checking for ns_name_uncompress... yes
checking for dn_skipname... yes
checking for res_search... yes
checking whether pragma weak references are supported... yes
checking for constructor/destructor attribute support... yes,yes
configure: enabling thread support
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... no
checking whether pthreads work with -Kthread... no
checking whether pthreads work with -kthread... no
checking for the pthreads library -llthread... no
checking whether pthreads work with -pthread... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
checking for cc_r... gcc
configure: PTHREAD_CC = gcc
configure: PTHREAD_CFLAGS = -pthread
configure: PTHREAD_LIBS = 
checking for pthread_once... no
checking for pthread_rwlock_init... no
configure: rechecking with PTHREAD_... options
checking for pthread_rwlock_init in -lc... yes
checking for library containing dlopen... -ldl
checking keyutils.h usability... no
checking keyutils.h presence... no
checking for keyutils.h... no
checking if va_copy is available... yes
checking if va_list objects can be copied by assignment... no
configure: using shared libraries
checking for tclConfig.sh...  /usr/lib/tcl8.5/tclConfig.sh
checking Tcl info in /usr/lib/tcl8.5/tclConfig.sh... /usr/lib/tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found

.. very many same error

/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/usr/lib//tcl8.5/tclConfig.sh: line 2: dpkg-architecture: command not found
/afs/ir.stanford.edu/users/t/i/timcohen/nix/store/23x1v97syv90qql5xyncrsbi8z1y5n5c-stdenv/setup: line 574: 12734 Segmentation fault      (core dumped) $configureScript $configureFlags "${configureFlagsArray[@]}"
builder for `/afs/ir.stanford.edu/users/t/i/timcohen/nix/store/i6fr9nk4l7vc0q7kw3adipcf3czxj4fk-krb5-1.11.3.drv' failed with exit code 139
```

So I explicitly added `--with-tcl=no` in `configureFlags`.
