### PR TITLE
Adds javalib and sawja

### DIFF
--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, fetchurl, ocaml, findlib, minimal ? true}:
 
 stdenv.mkDerivation {
   name = "ocaml-extlib-1.6.1";
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
 
   configurePhase = "true";      # Skip configure
   # De facto, option minimal=1 seems to be the default.  See the README.
-  buildPhase     = "make minimal=1 build";
-  installPhase   = "make minimal=1 install";
+  buildPhase     = "make ${if minimal then "minimal=1" else ""} build";
+  installPhase   = "make ${if minimal then "minimal=1" else ""} install";
 
   meta = {
     homepage = http://code.google.com/p/ocaml-extlib/;

--- a/pkgs/development/ocaml-modules/javalib/Makefile.config.example.patch
+++ b/pkgs/development/ocaml-modules/javalib/Makefile.config.example.patch
@@ -1,0 +1,9 @@
+--- javalib-2.3-orig/Makefile.config.example	2013-10-30 08:35:30.000000000 +0100
++++ javalib-2.3/Makefile.config.example	2014-07-06 17:32:29.799398394 +0200
+@@ -1,6 +1,3 @@
+-export OCAMLFIND_DESTDIR=$(LOCALDEST)
+-export OCAMLPATH=$(LOCALDEST)
+-
+ OCAMLC = $(FINDER) ocamlc $(FLAGS)
+ OCAMLOPT = $(FINDER) ocamlopt $(OPT_FLAGS)
+ OCAMLDOC = $(FINDER) ocamldoc

--- a/pkgs/development/ocaml-modules/javalib/configure.sh.patch
+++ b/pkgs/development/ocaml-modules/javalib/configure.sh.patch
@@ -1,0 +1,11 @@
+--- javalib-2.3-orig/configure.sh	2013-10-30 08:35:30.000000000 +0100
++++ javalib-2.3/configure.sh	2014-07-06 17:28:39.025066199 +0200
+@@ -44,7 +44,7 @@
+ DESTDIR=
+ # The ocamlpath variable for the compiler to locate the locally-installed
+ # packages (depends on LOCALDEST)
+-OCAMLPATH=
++#OCAMLPATH=
+ # The packages that need to be made in addition to Savalib / Sawja
+ MAKEDEP=
+ # The packages that need to be made in addition to Savalib / Sawja

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -1,0 +1,40 @@
+{stdenv, fetchurl, which, ocaml, findlib, camlzip, extlib}:
+let
+  pname = "javalib";
+  version = "2.3";
+  webpage = "http://sawja.inria.fr/";
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/33090/${pname}-${version}.tar.bz2";
+    sha256 = "1i8djcanzm250mwilm3jfy37cz0k0x7jbnrz8a5vvdi91kyzh52j";
+  };
+
+  buildInputs = [ which ocaml findlib camlzip extlib ];
+
+  patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
+
+  createFindlibDestdir = true;
+
+  configureScript = "./configure.sh";
+  dontAddPrefix = "true";
+
+  preBuild = ''
+    make ptrees;
+    make installptrees;
+    export OCAMLPATH=$out/lib/ocaml/${ocaml_version}/site-lib/:$OCAMLPATH;
+  '';
+
+  propagatedBuildInputs = [ camlzip extlib ];
+
+  meta = {
+    description = "A library that parses Java .class files into OCaml data structures";
+    homepage = "${webpage}";
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/sawja/Makefile.config.example.patch
+++ b/pkgs/development/ocaml-modules/sawja/Makefile.config.example.patch
@@ -1,0 +1,9 @@
+--- sawja-1.5-orig/Makefile.config.example	2013-10-30 08:35:29.000000000 +0100
++++ sawja-1.5/Makefile.config.example	2014-07-05 18:54:37.902423482 +0200
+@@ -1,6 +1,3 @@
+-export OCAMLFIND_DESTDIR=$(LOCALDEST)
+-export OCAMLPATH=$(LOCALDEST)
+-
+ RECODE=-charset utf-8
+ DOCDIR = doc/api
+ 

--- a/pkgs/development/ocaml-modules/sawja/configure.sh.patch
+++ b/pkgs/development/ocaml-modules/sawja/configure.sh.patch
@@ -1,0 +1,11 @@
+--- sawja-1.5-orig/configure.sh	2013-10-30 08:35:29.000000000 +0100
++++ sawja-1.5/configure.sh	2014-07-05 18:50:26.833798254 +0200
+@@ -39,7 +39,7 @@
+ DESTDIR=
+ # The ocamlpath variable for the compiler to locate the locally-installed
+ # packages (depends on LOCALDEST)
+-OCAMLPATH=
++#OCAMLPATH=
+ # The path to ocamlfind
+ FINDER=`which ocamlfind`
+ # The perl executable

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -1,0 +1,33 @@
+{stdenv, fetchurl, which, perl, ocaml, findlib, javalib }:
+let
+  pname = "sawja";
+  version = "1.5";
+  webpage = "http://sawja.inria.fr/";
+in
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/33091/${pname}-${version}.tar.bz2";
+    sha256 = "0i8qgqkw9vgj6k2g6npss268ivxdkzx5qj2a52jbd8ih59rn68cm";
+  };
+
+  buildInputs = [ which perl ocaml findlib javalib ];
+
+  patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
+
+  createFindlibDestdir = true;
+
+  configureScript = "./configure.sh";
+  dontAddPrefix = "true";
+
+  propagatedBuildInputs = [ javalib ];
+
+  meta = {
+    description = "A library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs";
+    homepage = "${webpage}";
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3201,6 +3201,10 @@ let
 
     findlib = callPackage ../development/tools/ocaml/findlib { };
 
+    javalib = callPackage ../development/ocaml-modules/javalib {
+      extlib = ocaml_extlib_maximal;
+    };
+
     dypgen = callPackage ../development/ocaml-modules/dypgen { };
 
     patoline = callPackage ../tools/typesetting/patoline { };
@@ -3274,12 +3278,17 @@ let
     ocaml_sexplib = callPackage ../development/ocaml-modules/sexplib { };
 
     ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };
+    ocaml_extlib_maximal = callPackage ../development/ocaml-modules/extlib {
+      minimal = false;
+    };
 
     pycaml = callPackage ../development/ocaml-modules/pycaml { };
 
     opam_1_0_0 = callPackage ../development/tools/ocaml/opam/1.0.0.nix { };
     opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix { };
     opam = opam_1_1;
+
+    sawja = callPackage ../development/ocaml-modules/sawja { };
 
     yojson = callPackage ../development/ocaml-modules/yojson { };
 


### PR DESCRIPTION
Javalib is a library that parses Java .class files into OCaml data
structures. Sawja is a library written in OCaml, relying on Javalib to
provide a high level representation of Java bytecode programs.

Homepage: http://sawja.inria.fr/
