### PR TITLE
A Makefile to build nixos manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ result-*
 /doc/manual.html
 /doc/manual.pdf
 .version-suffix
+/nixos/doc/manual/manual.html
+/nixos/doc/manual/manual.pdf
+/nixos/doc/manual/options-db.xml
+/nixos/doc/manual/version

--- a/nixos/doc/manual/Makefile
+++ b/nixos/doc/manual/Makefile
@@ -1,0 +1,32 @@
+# You may need to override this.
+
+docbookxsl = $(HOME)/.nix-profile/xml/xsl/docbook
+dblatex = dblatex
+
+XMLLINT = xmllint --catalogs
+XSLTPROC = xsltproc --catalogs \
+ --param section.autolabel 1 \
+ --param section.label.includes.component.label 1 \
+ --param html.stylesheet \'style.css\' \
+ --param xref.with.number.and.title 1 \
+ --param toc.section.depth 3 \
+ --param admon.style \'\' \
+ --param callout.graphics.extension \'.gif\'
+
+all: manual.html manual.pdf
+
+manual.html: *.xml options-db.xml version
+	$(XSLTPROC) --nonet --xinclude --output manual.html \
+	  $(docbookxsl)/xhtml/docbook.xsl manual.xml
+
+manual.pdf: *.xml options-db.xml version
+	$(dblatex) \
+	  -P doc.collab.show=0 \
+	  -P latex.output.revhistory=0 \
+	  manual.xml
+
+options-db.xml:
+	echo '<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"></refentry>' > options-db.xml
+
+version:
+	echo 'Local Snapshot' > version


### PR DESCRIPTION
This is copy/pasted from /doc/Makefile with these additions:
- `options-db.xml` is generated with empty content if it does not exist
  yet ;
- `version` is generated with empty content if it does not exist yet

This Makefile is only useful for users not having nix installed.
