### PR TITLE
Add `--no-same-permission` to `tar` command in node package builder

### DIFF
--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -8,7 +8,7 @@ let
   npmFlags = concatStringsSep " " (map (v: "--${v}") flags);
 
   sources = runCommand "node-sources" {} ''
-    tar --no-same-owner -xf ${nodejs.src}
+    tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
     mv *node* $out
   '';
 


### PR DESCRIPTION
This is because of an error while using `nix` under Archlinux:

```
building path(s) `/nix/store/rwkcbhv9jfhzhandfslg62knl2xw0r7m-node-sources'
building /nix/store/rwkcbhv9jfhzhandfslg62knl2xw0r7m-node-sources
suspicious ownership or permission on `/nix/store/rwkcbhv9jfhzhandfslg62knl2xw0r7m-node-sources'; rejecting this build output
cannot build derivation `/nix/store/01qsszx9y2kyx1x72zr5magy2la98720-uglify-js-2.4.15.drv': 1 dependencies couldn't be built
```

The permissions on all file are like the following:

```
drwxrwxr-x 1 root root    358 Jun  9 17:04 .
drwxr-xr-x 1 root root 421110 Jul 21 15:49 ..
-rw-rw-r-- 1 root root     22 Jun  9 17:04 .gitattributes
```

After the fix, permissions are OK, and no suspicious error any more.

Error is encountered for any node package built. I'm not sure why it
fails on Arch but work on nixos, but I believe the flag is safe to add
anyway.
