### PR TITLE
lrzsz: Add package and add to picocom's path

### DIFF
--- a/pkgs/tools/misc/lrzsz/default.nix
+++ b/pkgs/tools/misc/lrzsz/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "lrzsz-0.12.20";
+
+  src = fetchurl {
+    url = "https://ohse.de/uwe/releases/${name}.tar.gz";
+    sha256 = "1wcgfa9fsigf1gri74gq0pa7pyajk12m4z69x7ci9c6x9fqkd2y2";
+  };
+
+  configureFlags = [ "--program-transform-name=s/^l//" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://ohse.de/uwe/software/lrzsz.html;
+    description = "a unix communication package providing the XMODEM, YMODEM ZMODEM file transfer protocols";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, lrzsz }:
 
 stdenv.mkDerivation rec {
   name = "picocom-1.7";
@@ -8,10 +8,15 @@ stdenv.mkDerivation rec {
     sha256 = "17hjq713naq02xar711aw24qqd52p591mj1h5n97cni1ga7irwyh";
   };
 
+  buildInputs = [ makeWrapper ];
+
   installPhase = ''
     ensureDir $out/bin $out/share/man/man8
     cp picocom $out/bin
     cp picocom.8 $out/share/man/man8
+
+    wrapProgram $out/bin/picocom \
+      --prefix PATH ":" "${lrzsz}/bin"
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9052,6 +9052,8 @@ let
 
   lmms = callPackage ../applications/audio/lmms { };
 
+  lrzsz = callPackage ../tools/misc/lrzsz { };
+
   lxdvdrip = callPackage ../applications/video/lxdvdrip { };
 
   handbrake = callPackage ../applications/video/handbrake { };


### PR DESCRIPTION
File transfer in picocom depends on the modem transfer binaries provided by lrzsz. This patch adds the lrzsz derivation and adds the binaries to the path of picocom.
