### PR TITLE
nixos/munin: change activationScript to preStart script

### DIFF
--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -189,18 +189,17 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.munin ];
       environment.MUNIN_PLUGSTATE = "/var/run/munin";
+      preStart = ''
+        echo "updating munin plugins..."
+
+        mkdir -p /etc/munin/plugins
+        rm -rf /etc/munin/plugins/*
+        PATH="/run/current-system/sw/bin:/run/current-system/sw/sbin" ${pkgs.munin}/sbin/munin-node-configure --shell --families contrib,auto,manual --config ${nodeConf} --libdir=${muninPlugins} --servicedir=/etc/munin/plugins 2>/dev/null | ${pkgs.bash}/bin/bash
+      '';
       serviceConfig = {
         ExecStart = "${pkgs.munin}/sbin/munin-node --config ${nodeConf} --servicedir /etc/munin/plugins/";
       };
     };
-
-    system.activationScripts.munin-node = ''
-      echo "updating munin plugins..."
-
-      mkdir -p /etc/munin/plugins
-      rm -rf /etc/munin/plugins/*
-      PATH="/run/current-system/sw/bin:/run/current-system/sw/sbin" ${pkgs.munin}/sbin/munin-node-configure --shell --families contrib,auto,manual --config ${nodeConf} --libdir=${muninPlugins} --servicedir=/etc/munin/plugins 2>/dev/null | ${pkgs.bash}/bin/bash
-    '';
 
   }) (mkIf cronCfg.enable {
 


### PR DESCRIPTION
All activation scripts run in serial upon boot and nixos-rebuild switch
etc., in contrast to preStart which run before a service starts, and can
run in parallel with other services.

The munin(-node) activation script is particularly slow. Change it to a
preStart script so that it can run in parallel with other services and
not slow down boot (or nixos-rebuild switch).

This reduces (repeated) "nixos-rebuild test" time from ~16 seconds to ~8
on my (old) laptop.

CC: @iElectric  -- I assume you approve, but just in case... I don't remember why we ended up using an activationScript in the first place...
