### PR TITLE
On Darwin, add /bin/ps to path during MySQL build

### DIFF
--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     md5 = "bf1d80c66d4822ec6036300399a33c03";
   };
 
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
   buildInputs = [ cmake bison ncurses openssl readline zlib ]
      ++ stdenv.lib.optional stdenv.isDarwin perl;
 


### PR DESCRIPTION
MySQL uses a call to `ps` to figure out some flags for `mysqld_safe`. If it can't find `ps` it ends up generating a `mysqld_safe` script with a syntax error (has an empty conditional).
