### PR TITLE
Fix runtime dependencies for virtualenvwrapper

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8108,7 +8108,8 @@ rec {
     # pip depend on $HOME setting
     preConfigure = "export HOME=$TMPDIR";
 
-    buildInputs = [ pbr pip stevedore virtualenv virtualenv-clone pkgs.which ];
+    buildInputs = [ pbr pip pkgs.which ];
+    propagatedBuildInputs = [ stevedore virtualenv virtualenv-clone ];
 
     patchPhase = ''
       substituteInPlace "virtualenvwrapper.sh" --replace "which" "${pkgs.which}/bin/which"


### PR DESCRIPTION
My last pull request didn't handle the runtime dependencies of virtualenvwrapper correct. This pull request fixes this issue. Sorry for all the trouble!
