### PR TITLE
Fix trackpoint configuration on some systems

### DIFF
--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -46,28 +46,10 @@ with lib;
 
   config = mkIf config.hardware.trackpoint.enable {
 
-    jobs.trackpoint =
-      { description = "Initialize trackpoint";
-
-        startOn = "started udev";
-
-        task = true;
-
-        script = ''
-          for directory in /sys/devices/platform/i8042/serio1 \
-                           /sys/devices/platform/i8042/serio1/serio2 \
-                           /sys/devices/platform/i8042/serio4/serio5; do
-            if [ -e "$directory/speed" ]; then
-              echo -n ${toString config.hardware.trackpoint.speed} \
-                > "$directory/speed"
-              echo -n ${toString config.hardware.trackpoint.sensitivity} \
-                > "$directory/sensitivity"
-              break
-            fi
-          done
-        '';
-      };
-         
+    services.udev.extraRules =
+    ''
+      ACTION=="add|change", SUBSYSTEM=="input", ATTR{name}=="TPPS/2 IBM TrackPoint", ATTR{device/speed}="${toString config.hardware.trackpoint.speed}", ATTR{device/sensitivity}="${toString config.hardware.trackpoint.sensitivity}"
+    '';
   };
 
 }

--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -50,6 +50,11 @@ with lib;
     ''
       ACTION=="add|change", SUBSYSTEM=="input", ATTR{name}=="TPPS/2 IBM TrackPoint", ATTR{device/speed}="${toString config.hardware.trackpoint.speed}", ATTR{device/sensitivity}="${toString config.hardware.trackpoint.sensitivity}"
     '';
+
+    system.activationScripts.trackpoint =
+      ''
+        ${config.systemd.package}/bin/udevadm trigger --attr-match=name="TPPS/2 IBM TrackPoint"
+      '';
   };
 
 }

--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -54,10 +54,17 @@ with lib;
         task = true;
 
         script = ''
-          echo -n ${toString config.hardware.trackpoint.sensitivity} \
-            > /sys/devices/platform/i8042/serio1/sensitivity
-          echo -n ${toString config.hardware.trackpoint.speed} \
-            > /sys/devices/platform/i8042/serio1/speed
+          for directory in /sys/devices/platform/i8042/serio1 \
+                           /sys/devices/platform/i8042/serio1/serio2 \
+                           /sys/devices/platform/i8042/serio4/serio5; do
+            if [ -e "$directory/speed" ]; then
+              echo -n ${toString config.hardware.trackpoint.speed} \
+                > "$directory/speed"
+              echo -n ${toString config.hardware.trackpoint.sensitivity} \
+                > "$directory/sensitivity"
+              break
+            fi
+          done
         '';
       };
          


### PR DESCRIPTION
The path to configure trackpoint devices are not always the same:
- /sys/devices/platform/i8042/serio1/serio2 → with touchpad
- /sys/devices/platform/i8042/serio1 → without (or deactivated) touchpad
- /sys/devices/platform/i8042/serio4/serio5 → ThinkPad X100e, X121e, L520, E145
