### PR TITLE
Fix bloomfilter package on 32 bits

### DIFF
--- a/pkgs/development/libraries/haskell/bloomfilter/default.nix
+++ b/pkgs/development/libraries/haskell/bloomfilter/default.nix
@@ -9,6 +9,10 @@ cabal.mkDerivation (self: {
   version = "2.0.0.0";
   sha256 = "07fif8i5rinysli1mpi92k405kvw8va7w9v9w4wd5bylb87zy77f";
   buildDepends = [ deepseq ];
+  # https://github.com/bos/bloomfilter/pull/8
+  preConfigure = ''
+    sed -i -e "s/0xffffffff/0x7fffffff/" Data/BloomFilter/Easy.hs
+  '';
   testDepends = [
     QuickCheck random testFramework testFrameworkQuickcheck2
   ];


### PR DESCRIPTION
The git-annex derivation depends on bloomfilter and it's currently broken on
i686 because of this.  Upstream bloomfilter pull request already sent, this
is for the meantime.
