### PR TITLE
Update Serf to 0.6.3

### DIFF
--- a/pkgs/servers/serfdom/default.nix
+++ b/pkgs/servers/serfdom/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, go, fetchurl, fetchgit, fetchhg, fetchbzr, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.2";
+  version = "0.6.3";
   name = "serfdom-${version}";
 
   src = import ./deps.nix {

--- a/pkgs/servers/serfdom/deps.nix
+++ b/pkgs/servers/serfdom/deps.nix
@@ -77,8 +77,8 @@ let
       src = fetchFromGitHub {
         owner = "hashicorp";
         repo = "serf";
-        rev = "4232a3f7b52f755084caf6b2cc2789efa2948555";
-        sha256 = "1hxxqrjz08882d205ylakhvvwciahiqdzkwi2a7zwrmx6sxna7sr";
+        rev = "5e0771b8d61bee28986087a246f7611d6bd4a87a";
+        sha256 = "0ck77ji28bvm4ahzxyyi4sm17c3fxc16k0k5mihl1nlkgdd73m8y";
       };
     }
     {


### PR DESCRIPTION
This pull request updates the Serf package (or serfdom as it's called here) to version 0.6.3, the latest
