### PR TITLE
zed: build from source and ditch the installer

### DIFF
--- a/pkgs/applications/editors/zed/default.nix
+++ b/pkgs/applications/editors/zed/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, buildEnv, fetchurl, xlibs, glib, gtk2, atk, pango, gdk_pixbuf,
+{ stdenv, buildEnv, fetchgit, xlibs, glib, gtk2, atk, pango, gdk_pixbuf,
   cairo, freetype, fontconfig, nss, nspr, gnome, alsaLib, expat, dbus, udev,
-  makeWrapper, writeScript, gnused }:
+  makeWrapper, writeScript, fetchurl, zip, pkgs, node_webkit }:
 
 let
+  name = "zed-${version}";
+  version = "0.12";
 
   rpath_env = buildEnv {
     name = "rpath_env";
@@ -13,25 +15,50 @@ let
     pathsToLink = [ "/lib" "/lib64" ];
   };
 
-  name = "zed-${version}";
-  version = "0.12.0";
+  # When upgrading node.nix / node packages:
+  #   fetch package.json from Zed's repository
+  #   run `npm2nix package.json node.nix`
+  #   and replace node.nix with new one
+  nodePackages = import ../../../../pkgs/top-level/node-packages.nix {
+    inherit pkgs;
+    inherit (pkgs) stdenv nodejs fetchurl fetchgit;
+    neededNatives = [ pkgs.python ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.utillinux;
+    self = nodePackages;
+    generated = ./node.nix;
+  };
+
+  node_env = buildEnv {
+    name = "node_env";
+    paths = [ nodePackages.tar nodePackages.request ];
+    pathsToLink = [ "/lib" ];
+  };
 
   zed = stdenv.mkDerivation rec {
     inherit name version;
 
-    src = if stdenv.system == "i686-linux" then fetchurl {
-      url = "http://download.zedapp.org/zed-linux32-v${version}.tar.gz";
-      sha256 = "04cygfhaynlpl8jrf2r55qk5zz1ipad8l9m8q81lfly2q0h9fbxi";
-    } else fetchurl {
-      url = "http://download.zedapp.org/zed-linux64-v${version}.tar.gz";
-      sha256 = "0ng2v07fyglpbyl4pwm2bn5rbldw51kliw8rakbpcdia891hi6z1";
-    };
+    src = fetchgit {
+        url = "git://github.com/zedapp/zed";
+        rev = "refs/tags/v${version}";
+        sha256 = "1l1adj4p916km626vxg1lv0bapzay4z5nq005pxsbjbcycrhds59";
+      };
 
-    buildInputs = [ makeWrapper ];
+    buildInputs = [ makeWrapper zip ];
+
+    dontBuild = true;
 
     installPhase = ''
+      export NWPATH="${node_webkit}/share/node-webkit";
+
       mkdir -p $out/zed
-      cp ./* $out/zed
+
+      cd ${src}/app; zip -r $out/zed/app.nw *; cd ..
+
+      cat $NWPATH/nw $out/zed/app.nw > $out/zed/zed-bin
+      cp $NWPATH/nw.pak $out/zed/
+      cp nw/zed-linux $out/zed/zed
+      chmod +x $out/zed/zed*
+      cp Zed.desktop.tmpl Zed.svg Zed.png $out/zed
+      rm $out/zed/app.nw
     '';
 
     postFixup = ''
@@ -42,17 +69,18 @@ let
       ln -s ${udev}/lib/libudev.so.1 $out/lib/libudev.so.0
 
       wrapProgram $out/zed/zed-bin \
-        --prefix LD_LIBRARY_PATH : $out/lib
+        --prefix LD_LIBRARY_PATH : $out/lib \
+        --prefix NODE_PATH : ${node_env}/lib/node_modules
     '';
   };
-  zed_installer = writeScript "zed-installer.sh" ''
-    mkdir -p ~/.zed
-    cp -rv ${zed}/zed/* ~/.zed
 
-    ${gnused}/bin/sed -ri 's/DIR\=\$\(dirname\ \$0\)/DIR\=\~\/\.zed/' ~/.zed/zed
-
-    mkdir -p ~/bin
-    ln -sv ~/.zed/zed ~/bin/zed
+  zed_script = writeScript "zed.sh" ''
+    if [[ $1 == http://* ]] || [[ $1 == https://* ]]; then
+        PROJECT=$1
+    elif [ "" != "$1" ]; then
+       PROJECT=$(readlink -f $1)
+    fi
+    ${zed}/zed/zed-bin $PROJECT
   '';
 
 in stdenv.mkDerivation rec {
@@ -62,7 +90,7 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s ${zed_installer} $out/bin/zed-installer
+    ln -s ${zed_script} $out/bin/zed
   '';
 
   meta = {

--- a/pkgs/applications/editors/zed/node.nix
+++ b/pkgs/applications/editors/zed/node.nix
@@ -1,0 +1,634 @@
+{ self, fetchurl, fetchgit ? null, lib }:
+
+{
+  by-spec."asn1"."0.1.11" =
+    self.by-version."asn1"."0.1.11";
+  by-version."asn1"."0.1.11" = lib.makeOverridable self.buildNodePackage {
+    name = "node-asn1-0.1.11";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz";
+        name = "asn1-0.1.11.tgz";
+        sha1 = "559be18376d08a4ec4dbe80877d27818639b2df7";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."asn1" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "asn1" ];
+  };
+  by-spec."assert-plus"."0.1.2" =
+    self.by-version."assert-plus"."0.1.2";
+  by-version."assert-plus"."0.1.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-assert-plus-0.1.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz";
+        name = "assert-plus-0.1.2.tgz";
+        sha1 = "d93ffdbb67ac5507779be316a7d65146417beef8";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."assert-plus" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "assert-plus" ];
+  };
+  by-spec."async"."~0.9.0" =
+    self.by-version."async"."0.9.0";
+  by-version."async"."0.9.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-async-0.9.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/async/-/async-0.9.0.tgz";
+        name = "async-0.9.0.tgz";
+        sha1 = "ac3613b1da9bed1b47510bb4651b8931e47146c7";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."async" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "async" ];
+  };
+  by-spec."aws-sign2"."~0.5.0" =
+    self.by-version."aws-sign2"."0.5.0";
+  by-version."aws-sign2"."0.5.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-aws-sign2-0.5.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz";
+        name = "aws-sign2-0.5.0.tgz";
+        sha1 = "c57103f7a17fc037f02d7c2e64b602ea223f7d63";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."aws-sign2" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "aws-sign2" ];
+  };
+  by-spec."block-stream"."*" =
+    self.by-version."block-stream"."0.0.7";
+  by-version."block-stream"."0.0.7" = lib.makeOverridable self.buildNodePackage {
+    name = "node-block-stream-0.0.7";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz";
+        name = "block-stream-0.0.7.tgz";
+        sha1 = "9088ab5ae1e861f4d81b176b4a8046080703deed";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."block-stream" or []);
+    deps = [
+      self.by-version."inherits"."2.0.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "block-stream" ];
+  };
+  by-spec."boom"."0.4.x" =
+    self.by-version."boom"."0.4.2";
+  by-version."boom"."0.4.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-boom-0.4.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz";
+        name = "boom-0.4.2.tgz";
+        sha1 = "7a636e9ded4efcefb19cef4947a3c67dfaee911b";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."boom" or []);
+    deps = [
+      self.by-version."hoek"."0.9.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "boom" ];
+  };
+  by-spec."combined-stream"."~0.0.4" =
+    self.by-version."combined-stream"."0.0.5";
+  by-version."combined-stream"."0.0.5" = lib.makeOverridable self.buildNodePackage {
+    name = "node-combined-stream-0.0.5";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz";
+        name = "combined-stream-0.0.5.tgz";
+        sha1 = "29ed76e5c9aad07c4acf9ca3d32601cce28697a2";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."combined-stream" or []);
+    deps = [
+      self.by-version."delayed-stream"."0.0.5"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "combined-stream" ];
+  };
+  by-spec."cryptiles"."0.2.x" =
+    self.by-version."cryptiles"."0.2.2";
+  by-version."cryptiles"."0.2.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-cryptiles-0.2.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz";
+        name = "cryptiles-0.2.2.tgz";
+        sha1 = "ed91ff1f17ad13d3748288594f8a48a0d26f325c";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."cryptiles" or []);
+    deps = [
+      self.by-version."boom"."0.4.2"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "cryptiles" ];
+  };
+  by-spec."ctype"."0.5.2" =
+    self.by-version."ctype"."0.5.2";
+  by-version."ctype"."0.5.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-ctype-0.5.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz";
+        name = "ctype-0.5.2.tgz";
+        sha1 = "fe8091d468a373a0b0c9ff8bbfb3425c00973a1d";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."ctype" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "ctype" ];
+  };
+  by-spec."delayed-stream"."0.0.5" =
+    self.by-version."delayed-stream"."0.0.5";
+  by-version."delayed-stream"."0.0.5" = lib.makeOverridable self.buildNodePackage {
+    name = "node-delayed-stream-0.0.5";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz";
+        name = "delayed-stream-0.0.5.tgz";
+        sha1 = "d4b1f43a93e8296dfe02694f4680bc37a313c73f";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."delayed-stream" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "delayed-stream" ];
+  };
+  by-spec."forever-agent"."~0.5.0" =
+    self.by-version."forever-agent"."0.5.2";
+  by-version."forever-agent"."0.5.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-forever-agent-0.5.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz";
+        name = "forever-agent-0.5.2.tgz";
+        sha1 = "6d0e09c4921f94a27f63d3b49c5feff1ea4c5130";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."forever-agent" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "forever-agent" ];
+  };
+  by-spec."form-data"."~0.1.0" =
+    self.by-version."form-data"."0.1.4";
+  by-version."form-data"."0.1.4" = lib.makeOverridable self.buildNodePackage {
+    name = "node-form-data-0.1.4";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz";
+        name = "form-data-0.1.4.tgz";
+        sha1 = "91abd788aba9702b1aabfa8bc01031a2ac9e3b12";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."form-data" or []);
+    deps = [
+      self.by-version."combined-stream"."0.0.5"
+      self.by-version."mime"."1.2.11"
+      self.by-version."async"."0.9.0"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "form-data" ];
+  };
+  by-spec."fstream"."~0.1.28" =
+    self.by-version."fstream"."0.1.29";
+  by-version."fstream"."0.1.29" = lib.makeOverridable self.buildNodePackage {
+    name = "node-fstream-0.1.29";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/fstream/-/fstream-0.1.29.tgz";
+        name = "fstream-0.1.29.tgz";
+        sha1 = "34d04023ebc91a9df47bd31ab97e4704b4db413f";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."fstream" or []);
+    deps = [
+      self.by-version."graceful-fs"."3.0.2"
+      self.by-version."inherits"."2.0.1"
+      self.by-version."mkdirp"."0.3.5"
+      self.by-version."rimraf"."2.2.8"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "fstream" ];
+  };
+  by-spec."graceful-fs"."~3.0.2" =
+    self.by-version."graceful-fs"."3.0.2";
+  by-version."graceful-fs"."3.0.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-graceful-fs-3.0.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz";
+        name = "graceful-fs-3.0.2.tgz";
+        sha1 = "2cb5bf7f742bea8ad47c754caeee032b7e71a577";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."graceful-fs" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "graceful-fs" ];
+  };
+  by-spec."hawk"."~1.0.0" =
+    self.by-version."hawk"."1.0.0";
+  by-version."hawk"."1.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-hawk-1.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz";
+        name = "hawk-1.0.0.tgz";
+        sha1 = "b90bb169807285411da7ffcb8dd2598502d3b52d";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."hawk" or []);
+    deps = [
+      self.by-version."hoek"."0.9.1"
+      self.by-version."boom"."0.4.2"
+      self.by-version."cryptiles"."0.2.2"
+      self.by-version."sntp"."0.2.4"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "hawk" ];
+  };
+  by-spec."hoek"."0.9.x" =
+    self.by-version."hoek"."0.9.1";
+  by-version."hoek"."0.9.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-hoek-0.9.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz";
+        name = "hoek-0.9.1.tgz";
+        sha1 = "3d322462badf07716ea7eb85baf88079cddce505";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."hoek" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "hoek" ];
+  };
+  by-spec."http-signature"."~0.10.0" =
+    self.by-version."http-signature"."0.10.0";
+  by-version."http-signature"."0.10.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-http-signature-0.10.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz";
+        name = "http-signature-0.10.0.tgz";
+        sha1 = "1494e4f5000a83c0f11bcc12d6007c530cb99582";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."http-signature" or []);
+    deps = [
+      self.by-version."assert-plus"."0.1.2"
+      self.by-version."asn1"."0.1.11"
+      self.by-version."ctype"."0.5.2"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "http-signature" ];
+  };
+  by-spec."inherits"."2" =
+    self.by-version."inherits"."2.0.1";
+  by-version."inherits"."2.0.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-inherits-2.0.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz";
+        name = "inherits-2.0.1.tgz";
+        sha1 = "b17d08d326b4423e568eff719f91b0b1cbdf69f1";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."inherits" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "inherits" ];
+  };
+  by-spec."inherits"."~2.0.0" =
+    self.by-version."inherits"."2.0.1";
+  by-spec."json-stringify-safe"."~5.0.0" =
+    self.by-version."json-stringify-safe"."5.0.0";
+  by-version."json-stringify-safe"."5.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-json-stringify-safe-5.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz";
+        name = "json-stringify-safe-5.0.0.tgz";
+        sha1 = "4c1f228b5050837eba9d21f50c2e6e320624566e";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."json-stringify-safe" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "json-stringify-safe" ];
+  };
+  by-spec."mime"."~1.2.11" =
+    self.by-version."mime"."1.2.11";
+  by-version."mime"."1.2.11" = lib.makeOverridable self.buildNodePackage {
+    name = "node-mime-1.2.11";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz";
+        name = "mime-1.2.11.tgz";
+        sha1 = "58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."mime" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "mime" ];
+  };
+  by-spec."mime"."~1.2.9" =
+    self.by-version."mime"."1.2.11";
+  by-spec."mkdirp"."0.3" =
+    self.by-version."mkdirp"."0.3.5";
+  by-version."mkdirp"."0.3.5" = lib.makeOverridable self.buildNodePackage {
+    name = "node-mkdirp-0.3.5";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz";
+        name = "mkdirp-0.3.5.tgz";
+        sha1 = "de3e5f8961c88c787ee1368df849ac4413eca8d7";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."mkdirp" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "mkdirp" ];
+  };
+  by-spec."node-uuid"."~1.4.0" =
+    self.by-version."node-uuid"."1.4.1";
+  by-version."node-uuid"."1.4.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-node-uuid-1.4.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz";
+        name = "node-uuid-1.4.1.tgz";
+        sha1 = "39aef510e5889a3dca9c895b506c73aae1bac048";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."node-uuid" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "node-uuid" ];
+  };
+  by-spec."oauth-sign"."~0.3.0" =
+    self.by-version."oauth-sign"."0.3.0";
+  by-version."oauth-sign"."0.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-oauth-sign-0.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz";
+        name = "oauth-sign-0.3.0.tgz";
+        sha1 = "cb540f93bb2b22a7d5941691a288d60e8ea9386e";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."oauth-sign" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "oauth-sign" ];
+  };
+  by-spec."punycode".">=0.2.0" =
+    self.by-version."punycode"."1.3.0";
+  by-version."punycode"."1.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-punycode-1.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz";
+        name = "punycode-1.3.0.tgz";
+        sha1 = "7f5009ef539b9444be5c7a19abd2c3ca49e1731c";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."punycode" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "punycode" ];
+  };
+  by-spec."qs"."~0.6.0" =
+    self.by-version."qs"."0.6.6";
+  by-version."qs"."0.6.6" = lib.makeOverridable self.buildNodePackage {
+    name = "node-qs-0.6.6";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/qs/-/qs-0.6.6.tgz";
+        name = "qs-0.6.6.tgz";
+        sha1 = "6e015098ff51968b8a3c819001d5f2c89bc4b107";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."qs" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "qs" ];
+  };
+  by-spec."request"."~2.34.0" =
+    self.by-version."request"."2.34.0";
+  by-version."request"."2.34.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-request-2.34.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/request/-/request-2.34.0.tgz";
+        name = "request-2.34.0.tgz";
+        sha1 = "b5d8b9526add4a2d4629f4d417124573996445ae";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."request" or []);
+    deps = [
+      self.by-version."qs"."0.6.6"
+      self.by-version."json-stringify-safe"."5.0.0"
+      self.by-version."forever-agent"."0.5.2"
+      self.by-version."node-uuid"."1.4.1"
+      self.by-version."mime"."1.2.11"
+      self.by-version."tough-cookie"."0.12.1"
+      self.by-version."form-data"."0.1.4"
+      self.by-version."tunnel-agent"."0.3.0"
+      self.by-version."http-signature"."0.10.0"
+      self.by-version."oauth-sign"."0.3.0"
+      self.by-version."hawk"."1.0.0"
+      self.by-version."aws-sign2"."0.5.0"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "request" ];
+  };
+  "request" = self.by-version."request"."2.34.0";
+  by-spec."rimraf"."2" =
+    self.by-version."rimraf"."2.2.8";
+  by-version."rimraf"."2.2.8" = lib.makeOverridable self.buildNodePackage {
+    name = "rimraf-2.2.8";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz";
+        name = "rimraf-2.2.8.tgz";
+        sha1 = "e439be2aaee327321952730f99a8929e4fc50582";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."rimraf" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "rimraf" ];
+  };
+  by-spec."sntp"."0.2.x" =
+    self.by-version."sntp"."0.2.4";
+  by-version."sntp"."0.2.4" = lib.makeOverridable self.buildNodePackage {
+    name = "node-sntp-0.2.4";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz";
+        name = "sntp-0.2.4.tgz";
+        sha1 = "fb885f18b0f3aad189f824862536bceeec750900";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."sntp" or []);
+    deps = [
+      self.by-version."hoek"."0.9.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "sntp" ];
+  };
+  by-spec."tar"."~0.1.19" =
+    self.by-version."tar"."0.1.20";
+  by-version."tar"."0.1.20" = lib.makeOverridable self.buildNodePackage {
+    name = "node-tar-0.1.20";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/tar/-/tar-0.1.20.tgz";
+        name = "tar-0.1.20.tgz";
+        sha1 = "42940bae5b5f22c74483699126f9f3f27449cb13";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."tar" or []);
+    deps = [
+      self.by-version."block-stream"."0.0.7"
+      self.by-version."fstream"."0.1.29"
+      self.by-version."inherits"."2.0.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "tar" ];
+  };
+  "tar" = self.by-version."tar"."0.1.20";
+  by-spec."tough-cookie".">=0.12.0" =
+    self.by-version."tough-cookie"."0.12.1";
+  by-version."tough-cookie"."0.12.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-tough-cookie-0.12.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz";
+        name = "tough-cookie-0.12.1.tgz";
+        sha1 = "8220c7e21abd5b13d96804254bd5a81ebf2c7d62";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."tough-cookie" or []);
+    deps = [
+      self.by-version."punycode"."1.3.0"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "tough-cookie" ];
+  };
+  by-spec."tunnel-agent"."~0.3.0" =
+    self.by-version."tunnel-agent"."0.3.0";
+  by-version."tunnel-agent"."0.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-tunnel-agent-0.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz";
+        name = "tunnel-agent-0.3.0.tgz";
+        sha1 = "ad681b68f5321ad2827c4cfb1b7d5df2cfe942ee";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."tunnel-agent" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "tunnel-agent" ];
+  };
+}

--- a/pkgs/development/tools/node-webkit/default.nix
+++ b/pkgs/development/tools/node-webkit/default.nix
@@ -16,13 +16,13 @@ let
 
 in stdenv.mkDerivation rec {
   name = "node-webkit-${version}";
-  version = "0.8.4";
+  version = "0.9.2";
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/node-webkit/v${version}/node-webkit-v${version}-linux-${bits}.tar.gz";
     sha256 = if bits == "x64" then
-      "91229edfb03349306c5ce101fdab2de55f7473cc7c36367e9611a0527d2ef591" else
-      "12axppynangh0q72swzqcmz2blncgm2dw9n489313ybnp2p42hnp";
+      "04b9hgrxxnvrzyc7kmlabvrfbzj9d6lif7z69zgsbn3x25nxxd2n" else
+      "0icwdl564sbx27124js1l4whfld0n6nbysdd522frzk1759dzgri";
   };
 
   patchPhase = ''


### PR DESCRIPTION
I did not like the previous commit I made - the zed installer.

Changes:
- build from scratch
- have executables in nix store (auto updater will not work, but probably it would not anyway because of needed patchelf)

If you installed zed from previous commit (zed-installer) then just remove `~/.zed` folder and `~/bin/zed`.
