### PR TITLE
added package for pipelight

### DIFF
--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -1,0 +1,84 @@
+{ stdenv, fetchurl, fetchgit, autoconf, wineUnstable, perl, xlibs,
+  gnupg, gcc48_multi, mesa, curl, bash, cacert, cabextract, utillinux}:
+
+let
+  wine = wineUnstable;
+
+  wine_patches_version = wine.version;
+
+  wine_patches = fetchgit {
+    url = "git://github.com/compholio/wine-compholio.git";
+    rev = "refs/tags/v${wine_patches_version}";
+    sha256 = "16z8nkr3yczam52wrkaygkhgbs9y28jbi6qjxjijwnid7l88lvgn";
+  };
+
+  wine_custom =
+    stdenv.lib.overrideDerivation wine (args: rec {
+      src = null;
+      srcs = [ args.src wine_patches ];
+      sourceRoot = "./${wine.name}";
+      buildInputs = args.buildInputs ++ [ autoconf perl utillinux ];
+      postPatch = ''
+        export wineDir=$(pwd)
+        patchShebangs $wineDir/tools/
+        chmod -R +rwx ../git-export/
+        make -C ../git-export/patches DESTDIR=$wineDir install
+      '';
+    });
+
+  mozillaPluginPath = "/lib/mozilla/plugins";
+
+  fixupPatch = ./pipelight-fixup.patch;
+
+in stdenv.mkDerivation rec {
+
+  version = "0.2.7.2";
+
+  name = "pipelight-${version}";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/mmueller2012/pipelight/get/v${version}.tar.gz";
+    sha256 = "02132151091f1f62d7409a537649efc86deb0eb4a323fd66907fc22947e2cfbd";
+  };
+
+  buildInputs = [ wine_custom xlibs.libX11 gcc48_multi mesa curl ];
+  propagatedbuildInputs = [ curl cabextract ];
+
+  patches = [ ./pipelight.patch ];
+
+  configurePhase = ''
+    ./configure \
+      --prefix=$out \
+      --moz-plugin-path=$out/${mozillaPluginPath} \
+      --wine-path=${wine_custom} \
+      --gpg-exec=${gnupg}/bin/gpg2 \
+      --bash-interp=${bash}/bin/bash \
+      --downloader=${curl}/bin/curl
+      $configureFlags
+  '';
+
+  passthru = {
+    mozillaPlugin = mozillaPluginPath;
+  };
+
+  postInstall = ''
+    $out/bin/pipelight-plugin --update
+    $out/bin/pipelight-plugin --create-mozilla-plugins
+  '';
+
+  preFixup = ''
+    patch -d $out -p1 <${fixupPatch}
+    substituteInPlace $out/share/pipelight/install-dependency \
+      --replace cabextract ${cabextract}/bin/cabextract
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "http://pipelight.net/";
+    licenses = with stdenv.lib.licenses; [ mpl11 gpl2 lgpl21 ];
+    description = "A wrapper for using Windows plugins in Linux browsers";
+    maintainers = with stdenv.lib.maintainers; [skeidel];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/tools/misc/pipelight/pipelight-fixup.patch
+++ b/pkgs/tools/misc/pipelight/pipelight-fixup.patch
@@ -1,0 +1,54 @@
+diff -urN pipelight2.old/share/pipelight/install-dependency pipelight2.new/share/pipelight/install-dependency
+--- pipelight2.old/share/pipelight/install-dependency	2014-07-27 01:38:39.806379602 +0200
++++ pipelight2.new/share/pipelight/install-dependency	2014-07-27 01:40:08.689861556 +0200
+@@ -734,42 +734,14 @@
+	return 0
+ }
+
+-# Use fetch on FreeBSD if wget is not available
+-if command -v wget >/dev/null 2>&1; then
+-	download_file()
+-	{
+-		wget -O "$1" "$2"
+-	}
+-	get_download_size()
+-	{
+-		local filesize="$(wget -O- "$1" --spider --server-response 2>&1 | sed -ne '/Content-Length/{s/.*: //;p}')"
+-		local re='^[0-9]+$'
+-		if [[ "$filesize" -ne "0" ]] && [[ "$filesize" =~ $re ]]; then
+-			echo "$(($filesize/(1024*1024)))"
+-		else
+-			echo "N/A"
+-		fi
+-	}
+-elif command -v fetch >/dev/null 2>&1; then
+-	download_file()
+-	{
+-		fetch -o "$1" "$2"
+-	}
+-	get_download_size()
+-	{
+-		echo "N/A"
+-	}
+-else
+-	download_file()
+-	{
+-		echo "ERROR: Could neither find wget nor fetch. Unable to download file!" >&2
+-		return 1
+-	}
+-	get_download_size()
+-	{
+-		echo "N/A"
+-	}
+-fi
++download_file()
++{
++	curl --cacert /etc/ssl/certs/ca-bundle.crt -o "$1" "$2"
++}
++get_download_size()
++{
++	echo "N/A"
++}
+
+ # Use shasum instead of sha256sum on MacOS / *BSD
+ if ! command -v sha256sum >/dev/null 2>&1 && command -v shasum >/dev/null 2>&1; then

--- a/pkgs/tools/misc/pipelight/pipelight.patch
+++ b/pkgs/tools/misc/pipelight/pipelight.patch
@@ -1,0 +1,149 @@
+diff -urN pipelight.old/bin/pipelight-plugin.in pipelight.new/bin/pipelight-plugin.in
+--- pipelight.old/bin/pipelight-plugin.in	2014-07-19 22:53:02.000000000 +0200
++++ pipelight.new/bin/pipelight-plugin.in	2014-07-27 00:02:39.275834030 +0200
+@@ -92,7 +92,7 @@
+	PLUGIN_PATH=$(realpath "$PLUGIN_PATH")
+
+	# Global installation
+-	if [ $(/usr/bin/id -u) -eq 0 ]; then
++	if [ $(id -u) -eq 0 ]; then
+		INSTALLDIR="$PLUGIN_PATH"
+
+	# Use environment variable (only if it doesn't point to the global directory)
+@@ -594,7 +594,7 @@
+	fi
+
+	# Ensure the signature is valid, extract the content
+-	if ! @@GPG@@ --batch --no-default-keyring --keyring "$PIPELIGHT_SHARE_PATH/sig-install-dependency.gpg" --decrypt "$tmpfile" > "$decfile"; then
++	if ! @@GPG@@ --homedir /tmp --batch --no-default-keyring --keyring "$PIPELIGHT_SHARE_PATH/sig-install-dependency.gpg" --decrypt "$tmpfile" > "$decfile"; then
+		rm "$tmpfile"
+		rm "$decfile"
+		echo ""
+@@ -630,24 +630,10 @@
+	return 0
+ }
+
+-# Use fetch on FreeBSD if wget is not available
+-if command -v wget >/dev/null 2>&1; then
+-	download_file()
+-	{
+-		wget -O "$1" "$2"
+-	}
+-elif command -v fetch >/dev/null 2>&1; then
+-	download_file()
+-	{
+-		fetch -o "$1" "$2"
+-	}
+-else
+-	download_file()
+-	{
+-		echo "ERROR: Could neither find wget nor fetch. Unable to download file!" >&2
+-		return 1
+-	}
+-fi
++download_file()
++{
++	curl --cacert /etc/ssl/certs/ca-bundle.crt -o "$1" "$2"
++}
+
+ # Use shasum instead of sha256sum on MacOS / *BSD
+ if ! command -v sha256sum >/dev/null 2>&1 && command -v shasum >/dev/null 2>&1; then
+diff -urN pipelight.old/configure pipelight.new/configure
+--- pipelight.old/configure	2014-07-19 22:53:02.000000000 +0200
++++ pipelight.new/configure	2014-07-26 23:52:13.690881447 +0200
+@@ -66,12 +66,8 @@
+ datadir=""
+ libdir=""
+ mandir=""
+-bash_interp="$(which bash)"
+-if which gpg &> /dev/null; then
+-	gpg_exec="$(which gpg)"
+-else
+-	gpg_exec="/usr/bin/gpg"
+-fi
++bash_interp=bash
++gpg_exec=gpg2
+ moz_plugin_path=""
+ gcc_runtime_dlls=""
+ so_mode="0644"
+diff -urN pipelight.old/Makefile pipelight.new/Makefile
+--- pipelight.old/Makefile	2014-07-19 22:53:02.000000000 +0200
++++ pipelight.new/Makefile	2014-07-26 23:25:22.020707765 +0200
+@@ -29,7 +29,7 @@
+			-e 's|@@BINDIR@@|$(bindir)|g' \
+			-e 's|@@DATADIR@@|$(datadir)|g' \
+			-e 's|@@GCC_RUNTIME_DLLS@@|$(gcc_runtime_dlls)|g' \
+-			-e 's|@@GPG@@|$(gpgexec)|g' \
++			-e 's|@@GPG@@|$(gpg_exec)|g' \
+			-e 's|@@LIBDIR@@|$(libdir)|g' \
+			-e 's|@@MANDIR@@|$(mandir)|g' \
+			-e 's|@@MOZ_PLUGIN_PATH@@|$(moz_plugin_path)|g' \
+@@ -69,12 +69,12 @@
+
+ .PHONY: prebuilt32
+ prebuilt32: config.make pluginloader-$(git_commit).tar.gz pluginloader-$(git_commit).tar.gz.sig
+-	$(gpgexec) --batch --no-default-keyring --keyring "share/sig-pluginloader.gpg" --verify "pluginloader-$(git_commit).tar.gz.sig"
++	$(gpg_exec) --batch --no-default-keyring --keyring "share/sig-pluginloader.gpg" --verify "pluginloader-$(git_commit).tar.gz.sig"
+	tar -xvf "pluginloader-$(git_commit).tar.gz" src/windows/pluginloader.exe src/winecheck/winecheck.exe
+
+ .PHONY: prebuilt64
+ prebuilt64: config.make pluginloader-$(git_commit).tar.gz pluginloader-$(git_commit).tar.gz.sig
+-	$(gpgexec) --batch --no-default-keyring --keyring "share/sig-pluginloader.gpg" --verify "pluginloader-$(git_commit).tar.gz.sig"
++	$(gpg_exec) --batch --no-default-keyring --keyring "share/sig-pluginloader.gpg" --verify "pluginloader-$(git_commit).tar.gz.sig"
+	tar -xvf "pluginloader-$(git_commit).tar.gz" src/windows/pluginloader64.exe src/winecheck/winecheck64.exe
+
+ .PHONY: pluginloader32
+diff -urN pipelight.old/share/install-dependency pipelight.new/share/install-dependency
+--- pipelight.old/share/install-dependency	2014-07-19 22:53:02.000000000 +0200
++++ pipelight.new/share/install-dependency	2014-07-26 23:26:18.431938546 +0200
+@@ -734,42 +734,14 @@
+	return 0
+ }
+
+-# Use fetch on FreeBSD if wget is not available
+-if command -v wget >/dev/null 2>&1; then
+-	download_file()
+-	{
+-		wget -O "$1" "$2"
+-	}
+-	get_download_size()
+-	{
+-		local filesize="$(wget -O- "$1" --spider --server-response 2>&1 | sed -ne '/Content-Length/{s/.*: //;p}')"
+-		local re='^[0-9]+$'
+-		if [[ "$filesize" -ne "0" ]] && [[ "$filesize" =~ $re ]]; then
+-			echo "$(($filesize/(1024*1024)))"
+-		else
+-			echo "N/A"
+-		fi
+-	}
+-elif command -v fetch >/dev/null 2>&1; then
+-	download_file()
+-	{
+-		fetch -o "$1" "$2"
+-	}
+-	get_download_size()
+-	{
+-		echo "N/A"
+-	}
+-else
+-	download_file()
+-	{
+-		echo "ERROR: Could neither find wget nor fetch. Unable to download file!" >&2
+-		return 1
+-	}
+-	get_download_size()
+-	{
+-		echo "N/A"
+-	}
+-fi
++download_file()
++{
++	curl --cacert /etc/ssl/certs/ca-bundle.crt -o "$1" "$2"
++}
++get_download_size()
++{
++	echo "N/A"
++}
+
+ # Use shasum instead of sha256sum on MacOS / *BSD
+ if ! command -v sha256sum >/dev/null 2>&1 && command -v shasum >/dev/null 2>&1; then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5964,6 +5964,8 @@ let
 
   physfs = callPackage ../development/libraries/physfs { };
 
+  pipelight = callPackage ../tools/misc/pipelight { };
+
   pkcs11helper = callPackage ../development/libraries/pkcs11helper { };
 
   plib = callPackage ../development/libraries/plib { };


### PR DESCRIPTION
Hi,

I created a package for Piplight (http://pipelight.net/cms/about.html). This one wasn't easy to package. Here are some thoughts and questions I had during the creation of the package.
- Pipelight needs a number of patches to the current wine version. Thankfully Nix makes this easy because of the great `overrideDerivation` function.
- Pipelight uses a lot of shell scripts which refer to programs by the full path. I patched these paths to contain just the filename of the executable (I don't know if this is the best approach).
- I had problems when I tried to use the `$out` variable in `configureFlags`, so I overwrote the `configurePhase`. Is there a corresponding Nix variable for `$out` or another trick to get this to work?
- Pipelight needs to download some files during usage. I replaced the downloader choices wget and fetch by curl since curl comes preinstalled on every NixOS installation. Is there a more flexible solution for downloading files?
-  Pipelight lets you install proprietary browser plugins like MS Silverlight. During the enabling of those plugins you have to accept the corresponding licenses. Pipelight itself is free and open source. Do I have to set the `unfree` flag in the meta information?

I'm open for suggestions.

Best,
Sven
