### PR TITLE
Upgrade docker to 1.1.2 and add docker module

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -92,6 +92,7 @@
   skeidel = "Sven Keidel <svenkeidel@gmail.com>";
   smironov = "Sergey Mironov <ierton@gmail.com>";
   sprock = "Roger Mason <rmason@mun.ca>";
+  tailhook = "Paul Colomiets <paul@colomiets.name>";
   thammers = "Tobias Hammerschmidt <jawr@gmx.de>";
   the-kenny = "Moritz Ulrich <moritz@tarn-vedra.de>";
   thoughtpolice = "Austin Seipp <aseipp@pobox.com>";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -248,6 +248,7 @@
       firebird = 127;
       znc = 128;
       polipo = 129;
+      docker = 130;
 
       # When adding a gid, make sure it doesn't match an existing uid. And don't use gids above 399!
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -334,6 +334,7 @@
   ./testing/service-runner.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containers.nix
+  ./virtualisation/docker.nix
   ./virtualisation/libvirtd.nix
   #./virtualisation/nova.nix
   ./virtualisation/virtualbox-guest.nix

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -1,0 +1,109 @@
+# Systemd services for docker.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.virtualisation.docker;
+
+in
+
+{
+  ###### interface
+
+  options.virtualisation.docker = {
+    enable =
+      mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          ''
+            This option enables docker, a daemon that manages
+            linux containers. Users in the "docker" group can interact with
+            the daemon (e.g. to start or stop containers) using the
+            <command>docker</command> command line tool.
+          '';
+      };
+    socketActivation =
+      mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          ''
+            This option enables docker with socket activation. I.e. docker will
+            start when first called by client.
+
+            Note: This is false by default because systemd lower than 214 that
+            nixos uses so far, doesn't support SocketGroup option, so socket
+            created by docker has root group now. This will likely be changed
+            in future.  So set this option explicitly to false if you wish.
+          '';
+      };
+    extraOptions =
+      mkOption {
+        type = types.str;
+        default = "";
+        description =
+          ''
+            The extra command-line options to pass to
+            <command>docker</command> daemon.
+          '';
+      };
+
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable (mkMerge [
+    { environment.systemPackages = [ pkgs.docker ];
+    }
+    (mkIf cfg.socketActivation {
+
+      systemd.services.docker = {
+        description = "Docker Application Container Engine";
+        after = [ "network.target" "docker.socket" ];
+        requires = [ "docker.socket" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.docker}/bin/docker --daemon=true --host=fd:// --group=docker ${cfg.extraOptions}";
+          #  I'm not sure if that limits aren't too high, but it's what
+          #  goes in config bundled with docker itself
+          LimitNOFILE = 1048576;
+          LimitNPROC = 1048576;
+        };
+      };
+
+      systemd.sockets.docker = {
+        description = "Docker Socket for the API";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = "/var/run/docker.sock";
+          SocketMode = "0660";
+          SocketUser = "root";
+          SocketGroup = "docker";
+        };
+      };
+    })
+    (mkIf (!cfg.socketActivation) {
+
+      systemd.services.docker = {
+        description = "Docker Application Container Engine";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.docker}/bin/docker --daemon=true --group=docker ${cfg.extraOptions}";
+          #  I'm not sure if that limits aren't too high, but it's what
+          #  goes in config bundled with docker itself
+          LimitNOFILE = 1048576;
+          LimitNPROC = 1048576;
+        };
+
+        # Presumably some containers are running we don't want to interrupt
+        restartIfChanged = false;
+      };
+    })
+  ]);
+
+}

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -3,24 +3,21 @@ btrfsProgs, iptables, bash}:
 
 stdenv.mkDerivation rec {
   name = "docker-${version}";
-  version = "0.10.0";
+  version = "1.1.2";
 
   src = fetchurl {
     url = "https://github.com/dotcloud/docker/archive/v${version}.tar.gz";
-    sha256 = "14gmx119hd3j0c6rbks2mm83hk46s5wnnyvj8rhn25h0yp39pm5q";
+    sha256 = "1pa6k3gx940ap3r96xdry6apzkm0ymqra92b2mrp25b25264cqcy";
   };
-
-  phases = ["unpackPhase" "preBuild" "buildPhase" "installPhase"];
 
   buildInputs = [ makeWrapper go sqlite lxc iproute bridge_utils devicemapper btrfsProgs iptables ];
 
-  preBuild = ''
-    patchShebangs ./hack
-  '';
+  dontStrip = true;
 
   buildPhase = ''
+    patchShebangs ./hack
     export AUTO_GOPATH=1
-    export DOCKER_GITCOMMIT="867b2a90c228f62cdcd44907ceef279a2d8f1ac5"
+    export DOCKER_GITCOMMIT="d84a070"
     ./hack/make.sh dynbinary
   '';
 
@@ -41,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.docker.io/;
     description = "An open source project to pack, ship and run any application as a lightweight container";
     license = licenses.asl20;
-    maintainers = with maintainers; [ offline ];
+    maintainers = with maintainers; [ offline tailhook ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This version of module has disabled socketActivation, because until
nixos upgrade systemd to at least 214, systemd does not support
SocketGroup. So socket is created with "root" group when
socketActivation enabled. Should be fixed as soon as systemd upgraded.

Includes changes from #3015 and supersedes #3028

(It's my first nixos module, so feel free to critique me)
