### PR TITLE
Made fetchgit with leaveDotGit deterministic

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -226,6 +226,9 @@ clone_user_rev() {
     if test -z "$leaveDotGit"; then
 	echo "removing \`.git'..." >&2
         find $dir -name .git\* | xargs rm -rf
+    else
+        # The logs and index contain timestamps
+        find $dir -name .git | xargs -I {} rm -rf {}/logs {}/index
     fi
 }
 


### PR DESCRIPTION
There was a few files containing timestamp, so we now remove them.

It shouldn't be a problem for logs. However, index might be. Anyway,
that's better than nothing.
