### PR TITLE
erlang: Add manpages to all release packages.

### DIFF
--- a/pkgs/development/interpreters/erlang/R14.nix
+++ b/pkgs/development/interpreters/erlang/R14.nix
@@ -22,6 +22,20 @@ stdenv.mkDerivation {
 
   configureFlags = "--with-ssl=${openssl}";
 
+  postInstall = let
+    manpages = fetchurl {
+      url = "http://www.erlang.org/download/otp_doc_man_R${version}.tar.gz";
+      sha256 = "1nh7l7wilyyaxvlwkjxgm3cq7wpd90sk6vxhgpvg7hwai8g52545";
+    };
+  in ''
+    tar xf "${manpages}" -C "$out/lib/erlang"
+    for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
+      prefix="''${i%/*}"
+      ensureDir "$out/share/man/''${prefix##*/}"
+      ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
+    done
+  '';
+
   # Some erlang bin/ scripts run sed and awk
   postFixup = ''
     wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"

--- a/pkgs/development/interpreters/erlang/R15.nix
+++ b/pkgs/development/interpreters/erlang/R15.nix
@@ -28,6 +28,20 @@ stdenv.mkDerivation {
 
   configureFlags = "--with-ssl=${openssl}";
 
+  postInstall = let
+    manpages = fetchurl {
+      url = "http://www.erlang.org/download/otp_doc_man_R${version}.tar.gz";
+      sha256 = "0sqamzbd7qyz3klgl9vm1qvl0rhsfd1dx485pb0m2185qvw02nha";
+    };
+  in ''
+    tar xf "${manpages}" -C "$out/lib/erlang"
+    for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
+      prefix="''${i%/*}"
+      ensureDir "$out/share/man/''${prefix##*/}"
+      ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
+    done
+  '';
+
   # Some erlang bin/ scripts run sed and awk
   postFixup = ''
     wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"

--- a/pkgs/development/interpreters/erlang/R16.nix
+++ b/pkgs/development/interpreters/erlang/R16.nix
@@ -28,8 +28,19 @@ stdenv.mkDerivation rec {
 
   configureFlags= "--with-ssl=${openssl} ${optionalString stdenv.isDarwin "--enable-darwin-64bit"}";
 
-  postInstall = ''
+  postInstall = let
+    manpages = fetchurl {
+      url = "http://www.erlang.org/download/otp_doc_man_${version}.tar.gz";
+      sha256 = "17f3k5j17rdsah18gywjngip6cbfgp6nb9di6il4pahmf9yvqc8g";
+    };
+  in ''
     ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
+    tar xf "${manpages}" -C "$out/lib/erlang"
+    for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
+      prefix="''${i%/*}"
+      ensureDir "$out/share/man/''${prefix##*/}"
+      ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
+    done
   '';
 
   # Some erlang bin/ scripts run sed and awk

--- a/pkgs/development/interpreters/erlang/R17.nix
+++ b/pkgs/development/interpreters/erlang/R17.nix
@@ -28,8 +28,19 @@ stdenv.mkDerivation rec {
 
   configureFlags= "--with-ssl=${openssl} ${optionalString stdenv.isDarwin "--enable-darwin-64bit"}";
 
-  postInstall = ''
+  postInstall = let
+    manpages = fetchurl {
+      url = "http://www.erlang.org/download/otp_doc_man_${version}.tar.gz";
+      sha256 = "16dkz3w1q4ahy37c8a8r2h8zjcr7cxz7pd9z38chbxf6frc2pxxc";
+    };
+  in ''
     ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
+    tar xf "${manpages}" -C "$out/lib/erlang"
+    for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
+      prefix="''${i%/*}"
+      ensureDir "$out/share/man/''${prefix##*/}"
+      ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
+    done
   '';
 
   # Some erlang bin/ scripts run sed and awk


### PR DESCRIPTION
For review by @the-kenny, as he's the maintainer of Erlang in `<nixpkgs>`.

This puts manpages into `$out/lib/erlang/man` and also symlinks them into `$out/share/man` with an `erl` suffix (similar to how Debian is handling this) so those manpages are unlikely to collide with any other manpages, like for example `inet(3)`.
