### PR TITLE
Logstash-forwarder requires Go-1.1/1.2

### DIFF
--- a/pkgs/tools/misc/logstash-forwarder/default.nix
+++ b/pkgs/tools/misc/logstash-forwarder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, go }:
+{ stdenv, fetchgit, go_1_1 }:
 stdenv.mkDerivation {
   name = "logstash-forwarder-20140410";
   src = fetchgit {
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
     rev = "ec504792108ab6536b45bcf6dff6d26a6b56fef3";
     sha256 = "309545ceaec171bee997cad260bef1433e041b9f3bfe617d475bcf79924f943d";
   };
-  buildInputs = [ go ];
+  buildInputs = [ go_1_1 ];
   installPhase = ''
     mkdir -p $out/bin
     cp build/bin/logstash-forwarder $out/bin


### PR DESCRIPTION
The SSL stuff in it doesn't work right with Go 1.3 yet.
1.2 doesn't have a derivation for darwin, so go 1.1 should work for
everyone
