### PR TITLE
Merlin (ocaml auto-completion / compilation for vim and emacs)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -41,6 +41,7 @@
   falsifian = "James Cook <james.cook@utoronto.ca>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
   fuuzetsu = "Mateusz Kowalczyk <fuuzetsu@fuuzetsu.co.uk>";
+  gal_bolle = "Florent Becker <florent.becker@ens-lyon.org>";
   garbas = "Rok Garbas <rok@garbas.si>";
   goibhniu = "Cillian de Róiste <cillian.deroiste@gmail.com>";
   guibert = "David Guibert <david.guibert@gmail.com>";

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0ayx17dimnpavdfyq6dk9xv2x1fx69by85vc6vl3nqxjkcv5d2rv";
   };
 
-  buildInputs = [ ocaml findlib cppo easy-format biniou ];
+  buildInputs = [ ocaml findlib ];
+
+  propagatedBuildInputs = [ cppo easy-format biniou ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, ocaml, findlib, menhir, yojson }:
+
+stdenv.mkDerivation {
+  name = "merlin-1.6";
+
+  src = fetchurl {
+    url = https://github.com/the-lambda-church/merlin/archive/v1.6.tar.gz;
+    sha256 = "0wq75hgffaszazrhkl0nfjxgx8bvazi2sjannd8q64hvax8hxzcy";
+  };
+
+  createFindlibDestdir = true;
+
+  prefixKey = "--prefix ";
+
+  buildInputs = [ ocaml findlib menhir yojson ];
+
+  meta = {
+    homepage = https://the-lambda-church.github.io/merlin;
+    description = "An assistant for editing OCaml code";
+    license = stdenv.lib.licenses.mit;
+    platforms = ocaml.meta.platforms;
+    maintainers = with stdenv.lib.maintainers; [ gal_bolle ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3211,6 +3211,8 @@ let
 
     menhir = callPackage ../development/ocaml-modules/menhir { };
 
+    merlin = callPackage ../development/tools/ocaml/merlin { };
+
     mldonkey = callPackage ../applications/networking/p2p/mldonkey { };
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };


### PR DESCRIPTION
Works with emacs (vim not tested), though the .el file does not get byte-compiled. I'm not sure how to add that without adding a dependency on emacs.
