### PR TITLE
amazon ec2: Make fetch-ec2-data more robust

### DIFF
--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -22,21 +22,22 @@ with lib;
     systemd.services."fetch-ec2-data" =
       { description = "Fetch EC2 Data";
 
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "multi-user.target" "sshd.service" ];
         before = [ "sshd.service" ];
-        after = [ "network.target" ];
+        wants = [ "ip-up.target" ];
+        after = [ "ip-up.target" ];
 
-        path = [ pkgs.curl pkgs.iproute ];
+        path = [ pkgs.wget pkgs.iproute ];
 
         script =
           ''
             ip route del blackhole 169.254.169.254/32 || true
 
-            curl="curl --retry 3 --retry-delay 0 --fail"
+            wget="wget -q --retry-connrefused -O -"
 
             echo "setting host name..."
             ${optionalString (config.networking.hostName == "") ''
-              ${pkgs.nettools}/bin/hostname $($curl http://169.254.169.254/1.0/meta-data/hostname)
+              ${pkgs.nettools}/bin/hostname $($wget http://169.254.169.254/1.0/meta-data/hostname)
             ''}
 
             # Don't download the SSH key if it has already been injected
@@ -44,7 +45,7 @@ with lib;
             if ! [ -e /root/.ssh/authorized_keys ]; then
                 echo "obtaining SSH key..."
                 mkdir -p /root/.ssh
-                $curl -o /root/key.pub http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
+                $wget http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key > /root/key.pub
                 if [ $? -eq 0 -a -e /root/key.pub ]; then
                     if ! grep -q -f /root/key.pub /root/.ssh/authorized_keys; then
                         cat /root/key.pub >> /root/.ssh/authorized_keys
@@ -58,7 +59,7 @@ with lib;
             # Extract the intended SSH host key for this machine from
             # the supplied user data, if available.  Otherwise sshd will
             # generate one normally.
-            $curl http://169.254.169.254/2011-01-01/user-data > /root/user-data || true
+            $wget http://169.254.169.254/2011-01-01/user-data > /root/user-data || true
             key="$(sed 's/|/\n/g; s/SSH_HOST_DSA_KEY://; t; d' /root/user-data)"
             key_pub="$(sed 's/SSH_HOST_DSA_KEY_PUB://; t; d' /root/user-data)"
             if [ -n "$key" -a -n "$key_pub" -a ! -e /etc/ssh/ssh_host_dsa_key ]; then


### PR DESCRIPTION
curl does not retry if it is unable to connect to the metadata server.
For some reason, when creating a new AMI with a recent nixpkgs, the
metadata server would not be available when fetch-ec2-data ran. Switching
to wget that can retry even on TCP connection errors solved this problem.

I also made the fetch-ec2-data depend on ip-up.target, to get it to start
a bit later.
