### PR TITLE
Licenses: prefer spdx.org and improve docs

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -121,10 +121,11 @@ interpretation:</para>
   <varlistentry>
     <term><varname>license</varname></term>
     <listitem><para>The license for the package. One from attribute set defined in
-      <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/lib/licenses.nix">
+      <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix">
       <filename>nixpkgs/lib/licenses.nix</filename></link>.
       Example:
       <literal>stdenv.lib.licenses.gpl3</literal>.</para></listitem>
+      See details in <xref linkend='sec-meta-license'/>,
   </varlistentry>
 
   <varlistentry>
@@ -133,7 +134,7 @@ interpretation:</para>
     maintainers of this Nix expression. If
     you would like to be a maintainer of a package, you may want to add
     yourself to <link
-    xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/lib/maintainers.nix"><filename>nixpkgs/lib/maintainers.nix</filename></link>
+    xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/maintainers.nix"><filename>nixpkgs/lib/maintainers.nix</filename></link>
     and write something like <literal>[ stdenv.lib.maintainers.alice
     stdenv.lib.maintainers.bob ]</literal>.</para></listitem>
   </varlistentry>
@@ -159,8 +160,8 @@ interpretation:</para>
 meta.platforms = stdenv.lib.platforms.linux;
 </programlisting>
 
-    Attribute Set <varname>stdenv.lib.platforms</varname> in 
-    <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/lib/platforms.nix">
+    Attribute Set <varname>stdenv.lib.platforms</varname> in
+    <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/platforms.nix">
     <filename>nixpkgs/lib/platforms.nix</filename></link> defines various common
     lists of platforms types.
     </para></listitem>
@@ -202,9 +203,15 @@ meta.hydraPlatforms = [];
 
 <section xml:id="sec-meta-license"><title>Licenses</title>
 
-<para>The <varname>meta.license</varname> attribute could be one of the
-following:
+<para>The <varname>meta.license</varname> attribute should preferrably contain
+a value from <varname>stdenv.lib.licenses</varname> defined in
+<link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix">
+<filename>nixpkgs/lib/licenses.nix</filename></link>,
+or in-place license description of the same format if the license is
+unlikely to be useful in another expression.
 
+A few generic options are available, although it's typically better
+to indicate the specific license:
 <variablelist>
 
   <varlistentry>

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1,25 +1,29 @@
-{
-  /* License identifiers loosely based on: http://fedoraproject.org/wiki/Licensing
+let
+  spdx = lic: lic // {
+      url = "http://spdx.org/licenses/${lic.shortName}";
+    };
+in
+
+rec {
+  /* License identifiers from spdx.org where possible.
    * If you cannot find your license here, then look for a similar license or
    * add it to this list. The URL mentioned above is a good source for inspiration.
    */
 
-  artistic2 = {
-    shortName = "Artistic 2.0";
-    fullName = "Artistic 2.0";
-    url = "http://opensource.org/licenses/artistic-license-2.0.php";
+  artistic2 = spdx {
+    shortName = "Artistic-2.0";
+    fullName = "Artistic License 2.0";
   };
 
-  agpl3 = {
-    shortName = "AGPLv3";
-    fullName = "GNU Affero General Public License version 3 only";
-    url = https://www.gnu.org/licenses/agpl.html;
+  agpl3 = spdx {
+    shortName = "AGPL-3.0";
+    fullName = "GNU Affero General Public License v3.0";
   };
 
   agpl3Plus = {
-    shortName = "AGPLv3+";
-    fullName = "GNU Affero General Public License version 3 or later";
-    url = https://www.gnu.org/licenses/agpl.html;
+    shortName = "AGPL-3.0+";
+    fullName = "GNU Affero General Public License v3.0 or later";
+    inherit (agpl3) url;
   };
 
   amd = {
@@ -28,126 +32,103 @@
     url = http://developer.amd.com/amd-license-agreement/;
   };#
 
-  apsl20 = {
-    shortName = "APSL 2.0";
+  apsl20 = spdx {
+    shortName = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";
-    url = http://opensource.org/licenses/APSL-2.0;
   };
 
-  asl20 = {
-    shortName = "ASL2.0";
-    fullName = "Apache Software License 2.0";
-    url = http://www.apache.org/licenses/LICENSE-2.0;
+  asl20 = spdx {
+    shortName = "Apache-2.0";
+    fullName = "Apache License 2.0";
   };
 
-  boost = {
-    shortName = "boost";
-    fullName = "Boost Software License";
-    url = http://www.boost.org/LICENSE_1_0.txt;
+  boost = spdx {
+    shortName = "BSL-1.0";
+    fullName = "Boost Software License 1.0";
   };
 
-  bsd2 = {
-    shortName = "BSD-2";
-    fullName = "BSD license (2 clause)";
-    url = http://opensource.org/licenses/BSD-2-Clause;
+  bsd2 = spdx {
+    shortName = "BSD-2-Clause";
+    fullName = ''BSD 2-clause "Simplified" License'';
   };
 
-  bsd3 = {
-    shortName = "BSD-3";
-    fullName = "BSD license (3 clause)";
-    url = http://opensource.org/licenses/BSD-3-Clause;
+  bsd3 = spdx {
+    shortName = "BSD-3-Clause";
+    fullName = ''BSD 3-clause "New" or "Revised" License'';
   };
 
-  bsdOriginal = {
-    shortName = "BSD-original";
-    fullName = "Original BSD license with advertising clause";
-    url = https://fedoraproject.org/wiki/Licensing/BSD;
+  bsdOriginal = spdx {
+    shortName = "BSD-4-Clause";
+    fullName = ''BSD 4-clause "Original" or "Old" License'';
   };
 
-  cc-by-30 = {
-    shortName = "CC BY 3.0";
+  cc-by-30 = spdx {
+    shortName = "CC-BY-3.0";
     fullName = "Creative Commons Attribution 3.0";
-    url = http://creativecommons.org/licenses/by/3.0;
   };
 
-  cddl = {
-    shortName = "CDDL";
-    fullName = "Common Development Distribution License ";
-    url = http://www.opensolaris.org/os/licensing/cddllicense.txt;
+  cddl = spdx {
+    shortName = "CDDL-1.0";
+    fullName = "Common Development and Distribution License 1.0";
   };
 
-  cpl10 = {
-    shortName = "CPL 1.0";
-    fullName = "Common Public License version 1.0";
-    url = http://www.eclipse.org/legal/cpl-v10.html;
+  cpl10 = spdx {
+    shortName = "CPL-1.0";
+    fullName = "Common Public License 1.0";
   };
 
-  epl10 = {
-    shortName = "EPL 1.0";
-    fullName = "Eclipse Public License version 1.0";
-    url = http://www.eclipse.org/legal/epl-v10.html;
+  epl10 = spdx {
+    shortName = "EPL-1.0";
+    fullName = "Eclipse Public License 1.0";
   };
 
   free = "free";
 
-  gpl2 = {
-    shortName = "GPLv2";
-    fullName = "GNU General Public License version 2";
-    url = http://www.gnu.org/licenses/old-licenses/gpl-2.0.html;
+  gpl2 = spdx {
+    shortName = "GPL-2.0";
+    fullName = "GNU General Public License v2.0 only";
   };
 
   gpl2Oss = {
-    shortName = "GPLv2+OSS";
+    shortName = "GPL-2.0-with-OSS";
     fullName = "GNU General Public License version 2 only (with OSI approved licenses linking exception)";
     url = http://www.mysql.com/about/legal/licensing/foss-exception;
   };
 
-  gpl2Plus = {
-    shortName = "GPLv2+";
-    fullName = "GNU General Public License version 2 or later";
-    url = http://www.gnu.org/licenses/old-licenses/gpl-2.0.html;
+  gpl2Plus = spdx {
+    shortName = "GPL-2.0+";
+    fullName = "GNU General Public License v2.0 or later";
   };
 
-  gpl3 = {
-    shortName = "GPLv3";
-    fullName = "GNU General Public License version 3 only";
-    url = http://www.fsf.org/licensing/licenses/gpl.html;
+  gpl3 = spdx {
+    shortName = "GPL-3.0";
+    fullName = "GNU General Public License v3.0 only";
   };
 
-  gpl3Plus = {
-    shortName = "GPLv3+";
-    fullName = "GNU General Public License version 3 or later";
-    url = http://www.fsf.org/licensing/licenses/gpl.html;
+  gpl3Plus = spdx {
+    shortName = "GPL-3.0+";
+    fullName = "GNU General Public License v3.0 or later";
   };
 
   gpl3ClasspathPlus = {
-    shortName = "GPLv3+classpath+";
-    fullName = "GNU General Public License version 3 or later (with Classpath exception)";
+    shortName = "GPL-3.0+-with-classpath-exception";
+    fullName = "GNU General Public License v3.0 or later (with Classpath exception)";
     url = https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception;
   };
 
-  isc = {
+  isc = spdx {
     shortName = "ISC";
-    fullName = "Internet Systems Consortium License";
-    url = http://www.opensource.org/licenses/ISC;
+    fullName = "ISC License";
   };
 
-  ipa = {
-    shortName = "IPA 1.0";
-    fullName = "IPA Font License v1.0";
-    url = http://ipafont.ipa.go.jp/ipafont/;
+  ipa = spdx {
+    shortName = "IPA";
+    fullName = "IPA Font License";
   };
 
-  ipl10 = {
-    shortName = "IPL 1.0";
-    fullName = "IBM Public License Version 1.0";
-    url = http://www.ibm.com/developerworks/opensource/library/os-i18n2/os-ipl.html;
-  };
-
-  ijg = {
-    shortName = "IJG";
-    fullName = "Independent JPEG Group License";
-    url = https://fedoraproject.org/wiki/Licensing/IJG;
+  ipl10 = spdx {
+    shortName = "IPL-1.0";
+    fullName = "IBM Public License v1.0";
   };
 
   libtiff = {
@@ -156,76 +137,65 @@
     url = https://fedoraproject.org/wiki/Licensing/libtiff;
   };
 
-  lgpl2 = {
-    shortName = "LGPLv2";
-    fullName = "GNU Library General Public License version 2";
-    url = http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html;
+  lgpl2 = spdx {
+    shortName = "LGPL-2.0";
+    fullName = "GNU Library General Public License v2 only";
   };
 
-  lgpl2Plus = {
-    shortName = "LGPLv2+";
-    fullName = "GNU Library General Public License version 2 or later";
-    url = http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html;
+  lgpl2Plus = spdx {
+    shortName = "LGPL-2.0+";
+    fullName = "GNU Library General Public License v2 or later";
   };
 
-  lgpl21 = {
-    shortName = "LGPLv2.1";
-    fullName = "GNU Lesser General Public License version 2.1";
-    url = http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html;
+  lgpl21 = spdx {
+    shortName = "LGPL-2.1";
+    fullName = "GNU Library General Public License v2.1 only";
   };
 
-  lgpl21Plus = {
-    shortName = "LGPLv2.1+";
-    fullName = "GNU Lesser General Public License version 2.1 or later";
-    url = http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html;
+  lgpl21Plus = spdx {
+    shortName = "LGPL-2.1+";
+    fullName = "GNU Library General Public License v2.1 or later";
   };
 
   llgpl21 = {
-    shortName = "LLGPLv2.1";
+    shortName = "LLGPL-2.1";
     fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
     url = http://opensource.franz.com/preamble.html;
   };
 
-  lgpl3 = {
-    shortName = "LGPLv3";
-    fullName = "GNU Lesser General Public License version 3 only";
-    url = http://www.fsf.org/licensing/licenses/lgpl.html;
+  lgpl3 = spdx {
+    shortName = "LGPL-3.0";
+    fullName = "GNU Lesser General Public License v3.0 only";
   };
 
-  lgpl3Plus = {
-    shortName = "LGPLv3+";
-    fullName = "GNU Lesser General Public License version 3 or later";
-    url = http://www.fsf.org/licensing/licenses/lgpl.html;
+  lgpl3Plus = spdx {
+    shortName = "LGPL-3.0+";
+    fullName = "GNU Lesser General Public License v3.0 or later";
   };
 
-  mit = {
+  mit = spdx {
     shortName = "MIT";
-    fullName = "MIT/X11 license";
-    url = http://www.opensource.org/licenses/mit-license.php;
+    fullName = "MIT License";
   };
 
-  mpl11 = {
-    shortName = "MPL1.1";
-    fullName = "Mozilla Public License version 1.1";
-    url = http://www.mozilla.org/MPL/MPL-1.1.html;
+  mpl11 = spdx {
+    shortName = "MPL-1.1";
+    fullName = "Mozilla Public License 1.1";
   };
 
-  mpl20 = {
-    shortName = "MPL2.0";
-    fullName = "Mozilla Public License version 2.0";
-    url = https://www.mozilla.org/MPL/2.0;
+  mpl20 = spdx {
+    shortName = "MPL-2.0";
+    fullName = "Mozilla Public License 2.0";
   };
 
-  ofl = {
-    shortName = "OFL";
-    fullName = "SIL Open Font License";
-    url = "http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web";
+  ofl = spdx {
+    shortName = "OFL-1.1";
+    fullName = "SIL Open Font License 1.1";
   };
 
-  openssl = {
-    shortName = "openssl";
-    fullName = "OpenSSL license";
-    url = http://www.openssl.org/source/license.html;
+  openssl = spdx {
+    shortName = "OpenSSL";
+    fullName = "OpenSSL License";
   };
 
   publicDomain = {
@@ -233,10 +203,10 @@
     fullname = "Public Domain";
   };
 
-  psfl = {
-    shortName = "PSFL";
-    fullName = "Python Software Foundation License";
-    url = http://docs.python.org/license.html;
+  psfl = spdx {
+    shortName = "Python-2.0";
+    fullName = "Python Software Foundation License version 2";
+    #url = http://docs.python.org/license.html;
   };
 
   tcltk = {
@@ -257,34 +227,29 @@
     url = https://fedoraproject.org/wiki/Licensing:Wadalab?rd=Licensing/Wadalab;
   };
 
-  zlib = {
-    shortName = "zlib";
-    fullName = "zlib license";
-    url = http://www.gzip.org/zlib/zlib_license.html;
+  zlib = spdx {
+    shortName = "Zlib";
+    fullName = "zlib License";
   };
 
-  zpt20 = {
-    shortName = "ZPT2.0";
+  zpt20 = spdx { # FIXME: why zpt* instead of zpl*
+    shortName = "ZPL-2.0";
     fullName = "Zope Public License 2.0";
-    url = "http://old.zope.org/Resources/License/ZPL-2.0";
   };
 
-  zpt21 = {
-    shortName = "ZPT2.1";
+  zpt21 = spdx {
+    shortName = "ZPL-2.1";
     fullName = "Zope Public License 2.1";
-    url = "http://old.zope.org/Resources/License/ZPL-2.1";
   };
 
-  sleepycat = {
+  sleepycat = spdx {
     shortName = "Sleepycat";
-    fullName  = "Sleepycat Public License";
-    url       = "https://en.wikipedia.org/wiki/Sleepycat_License";
+    fullName  = "Sleepycat License";
   };
 
-  cecill-c = {
-    shortName = "CeCILL-C";
-    fullName  = "CEA CNRS INRIA Logiciel Libre";
-    url       = "http://www.cecill.info/licences.en.html";
+  cecill-c = spdx {
+    shortName = "CECILL-C";
+    fullName  = "CeCILL-C Free Software License Agreement";
   };
 
   msrla = {

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -10,11 +10,6 @@ rec {
    * add it to this list. The URL mentioned above is a good source for inspiration.
    */
 
-  artistic2 = spdx {
-    shortName = "Artistic-2.0";
-    fullName = "Artistic License 2.0";
-  };
-
   agpl3 = spdx {
     shortName = "AGPL-3.0";
     fullName = "GNU Affero General Public License v3.0";
@@ -35,6 +30,11 @@ rec {
   apsl20 = spdx {
     shortName = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";
+  };
+
+  artistic2 = spdx {
+    shortName = "Artistic-2.0";
+    fullName = "Artistic License 2.0";
   };
 
   asl20 = spdx {
@@ -70,6 +70,11 @@ rec {
   cddl = spdx {
     shortName = "CDDL-1.0";
     fullName = "Common Development and Distribution License 1.0";
+  };
+
+  cecill-c = spdx {
+    shortName = "CECILL-C";
+    fullName  = "CeCILL-C Free Software License Agreement";
   };
 
   cpl10 = spdx {
@@ -116,9 +121,10 @@ rec {
     url = https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception;
   };
 
-  isc = spdx {
-    shortName = "ISC";
-    fullName = "ISC License";
+  inria = {
+    shortName = "INRIA-NCLA";
+    fullName  = "INRIA Non-Commercial License Agreement";
+    url       = "http://compcert.inria.fr/doc/LICENSE";
   };
 
   ipa = spdx {
@@ -131,10 +137,9 @@ rec {
     fullName = "IBM Public License v1.0";
   };
 
-  libtiff = {
-    shortName = "libtiff";
-    fullName = "libtiff license";
-    url = https://fedoraproject.org/wiki/Licensing/libtiff;
+  isc = spdx {
+    shortName = "ISC";
+    fullName = "ISC License";
   };
 
   lgpl2 = spdx {
@@ -157,12 +162,6 @@ rec {
     fullName = "GNU Library General Public License v2.1 or later";
   };
 
-  llgpl21 = {
-    shortName = "LLGPL-2.1";
-    fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
-    url = http://opensource.franz.com/preamble.html;
-  };
-
   lgpl3 = spdx {
     shortName = "LGPL-3.0";
     fullName = "GNU Lesser General Public License v3.0 only";
@@ -171,6 +170,18 @@ rec {
   lgpl3Plus = spdx {
     shortName = "LGPL-3.0+";
     fullName = "GNU Lesser General Public License v3.0 or later";
+  };
+
+  libtiff = {
+    shortName = "libtiff";
+    fullName = "libtiff license";
+    url = https://fedoraproject.org/wiki/Licensing/libtiff;
+  };
+
+  llgpl21 = {
+    shortName = "LLGPL-2.1";
+    fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
+    url = http://opensource.franz.com/preamble.html;
   };
 
   mit = spdx {
@@ -188,6 +199,12 @@ rec {
     fullName = "Mozilla Public License 2.0";
   };
 
+  msrla = {
+    shortName = "MSR-LA";
+    fullName  = "Microsoft Research License Agreement";
+    url       = "http://research.microsoft.com/en-us/projects/pex/msr-la.txt";
+  };
+
   ofl = spdx {
     shortName = "OFL-1.1";
     fullName = "SIL Open Font License 1.1";
@@ -198,15 +215,20 @@ rec {
     fullName = "OpenSSL License";
   };
 
+  psfl = spdx {
+    shortName = "Python-2.0";
+    fullName = "Python Software Foundation License version 2";
+    #url = http://docs.python.org/license.html;
+  };
+
   publicDomain = {
     shortName = "Public Domain";
     fullname = "Public Domain";
   };
 
-  psfl = spdx {
-    shortName = "Python-2.0";
-    fullName = "Python Software Foundation License version 2";
-    #url = http://docs.python.org/license.html;
+  sleepycat = spdx {
+    shortName = "Sleepycat";
+    fullName  = "Sleepycat License";
   };
 
   tcltk = {
@@ -242,25 +264,5 @@ rec {
     fullName = "Zope Public License 2.1";
   };
 
-  sleepycat = spdx {
-    shortName = "Sleepycat";
-    fullName  = "Sleepycat License";
-  };
-
-  cecill-c = spdx {
-    shortName = "CECILL-C";
-    fullName  = "CeCILL-C Free Software License Agreement";
-  };
-
-  msrla = {
-    shortName = "MSR-LA";
-    fullName  = "Microsoft Research License Agreement";
-    url       = "http://research.microsoft.com/en-us/projects/pex/msr-la.txt";
-  };
-
-  inria = {
-    shortName = "INRIA-NCLA";
-    fullName  = "INRIA Non-Commercial License Agreement";
-    url       = "http://compcert.inria.fr/doc/LICENSE";
-  };
 }
+

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -4,7 +4,7 @@ let
     };
 in
 
-rec {
+let licenses = rec {
   /* License identifiers from spdx.org where possible.
    * If you cannot find your license here, then look for a similar license or
    * add it to this list. The URL mentioned above is a good source for inspiration.
@@ -87,7 +87,7 @@ rec {
     fullName = "Eclipse Public License 1.0";
   };
 
-  free = "free";
+  free.shortName = "free";
 
   gpl2 = spdx {
     shortName = "GPL-2.0";
@@ -237,11 +237,11 @@ rec {
     url = http://www.tcl.tk/software/tcltk/license.html;
   };
 
-  unfree = "unfree";
+  unfree.shortName = "unfree";
 
-  unfreeRedistributable = "unfree-redistributable";
+  unfreeRedistributable.shortName = "unfree-redistributable";
 
-  unfreeRedistributableFirmware = "unfree-redistributable-firmware";
+  unfreeRedistributableFirmware.shortName = "unfree-redistributable-firmware";
 
   wadalab = {
     shortName = "wadalab";
@@ -264,5 +264,8 @@ rec {
     fullName = "Zope Public License 2.1";
   };
 
-}
+}; in
+  # add the same attrmaps, but named by their shortNames (creating e.g. licenses."GPL-2.0+")
+  with { inherit (import ./attrsets.nix) mapAttrs' nameValuePair; };
+  licenses // (mapAttrs' (_: value: nameValuePair value.shortName value) licenses)
 

--- a/pkgs/applications/misc/xfontsel/default.nix
+++ b/pkgs/applications/misc/xfontsel/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.x.org/;
     description = "Allows testing the fonts available in an X server";
-    licesnse = "free";
+    license = "free";
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;
   };

--- a/pkgs/applications/misc/xlsfonts/default.nix
+++ b/pkgs/applications/misc/xlsfonts/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.x.org/;
     description = "Lists the fonts available in the X server";
-    licesnse = "free";
+    license = "free";
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;
   };

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -40,9 +40,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Library and utilities for working with the TIFF image file format";
     homepage = http://www.remotesensing.org/libtiff/;
-    license = "bsd";
+    license = licenses.libtiff;
   };
 }


### PR DESCRIPTION
http://spdx.org was suggested in related threads. It seems the best shot at standardizing license `shortName`s and providing stable links to the licenses.

I'm not sure about the other style introduced by the third commit: allowing e.g. `license = licenses."GPL-2.0+";` in addition to `license = licenses.gpl2Plus;`.

Any thoughts?
