### PR TITLE
version bump gtkpod from 1.0.0 to 2.1.4

### DIFF
--- a/pkgs/applications/audio/gtkpod/default.nix
+++ b/pkgs/applications/audio/gtkpod/default.nix
@@ -33,10 +33,11 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "GTK Manager for an Apple ipod";
     homepage = http://gtkpod.sourceforge.net;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.skeidel ];
   };
 }

--- a/pkgs/applications/audio/gtkpod/default.nix
+++ b/pkgs/applications/audio/gtkpod/default.nix
@@ -1,20 +1,37 @@
-{ stdenv, fetchurl, pkgconfig, libgpod, gtk, glib, gettext, perl, perlXMLParser
-, libglade, flex, libid3tag, libvorbis, intltool }:
+{ stdenv, fetchurl, pkgconfig, makeWrapper, intltool, libgpod, curl, flac,
+  gnome3_12, gtk3, glib, gettext, perl, perlXMLParser , libglade, flex, libid3tag,
+  libvorbis, hicolor_icon_theme, gdk_pixbuf }:
 
-stdenv.mkDerivation {
-  name = "gtkpod-1.0.0";
+let
+  gnome = gnome3_12;
+
+in stdenv.mkDerivation rec {
+  version = "2.1.4";
+  name = "gtkpod-${version}";
 
   src = fetchurl {
-    url = mirror://sourceforge/gtkpod/gtkpod-1.0.0.tar.gz;
-    sha256 = "04jzybs55c27kyp7r9c58prcq0q4ssvj5iggva857f49s1ar826q";
+    url = "mirror://sourceforge/gtkpod/${name}.tar.gz";
+    sha256 = "ba12b35f3f24a155b68f0ffdaf4d3c5c7d1b8df04843a53306e1c83fc811dfaa";
   };
 
-  buildInputs = [ pkgconfig libgpod gettext perl perlXMLParser gtk libglade flex
-    libid3tag libvorbis intltool ];
+  propagatedUserEnvPkgs = [ gnome.gnome_themes_standard ];
+
+  buildInputs = [ pkgconfig makeWrapper intltool curl gettext perl perlXMLParser
+    flex libgpod libid3tag flac libvorbis gtk3 gdk_pixbuf libglade gnome.anjuta
+    gnome.gdl gnome.gnome_icon_theme_symbolic gnome.gnome_icon_theme
+    hicolor_icon_theme ];
 
   patchPhase = ''
     sed -i 's/which/type -P/' scripts/*.sh
   '';
+
+  preFixup = ''
+    wrapProgram "$out/bin/gtkpod" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gnome.gnome_themes_standard}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "GTK Manager for an Apple ipod";

--- a/pkgs/desktops/gnome-3/3.12/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/default.nix
@@ -215,6 +215,11 @@ rec {
 
   seahorse = callPackage ./apps/seahorse { };
 
+#### Dev http://ftp.gnome.org/pub/GNOME/devtools/
+
+  anjuta = callPackage ./devtools/anjuta { };
+
+  gdl = callPackage ./devtools/gdl { };
 
 #### Misc -- other packages on http://ftp.gnome.org/pub/GNOME/sources/
 
@@ -225,6 +230,8 @@ rec {
   goffice = callPackage ./misc/goffice { };
 
   gitg = callPackage ./misc/gitg { };
+
+  libgda = callPackage ./misc/libgda { };
 
   libgit2-glib = callPackage ./misc/libgit2-glib { };
 

--- a/pkgs/desktops/gnome-3/3.12/devtools/anjuta/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/devtools/anjuta/default.nix
@@ -18,4 +18,11 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig flex bison gtk3 libxml2 gnome3.gjs gnome3.gdl
     gnome3.libgda gnome3.gtksourceview intltool itstool python ];
+
+  meta = with stdenv.lib; {
+    description = "Software development studio";
+    homepage = http://anjuta.org/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/desktops/gnome-3/3.12/devtools/anjuta/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/devtools/anjuta/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, flex, bison, libxml2, intltool,
+  itstool, python }:
+
+let
+  major = "3.13";
+  minor = "1";
+
+in stdenv.mkDerivation rec {
+  version = "${major}.${minor}";
+  name = "anjuta-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/anjuta/${major}/${name}.tar.xz";
+    sha256 = "71bdad9a0e427d9481858eec40b9c1facef4b551d732023cc18a50019df4b78b";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ pkgconfig flex bison gtk3 libxml2 gnome3.gjs gnome3.gdl
+    gnome3.libgda gnome3.gtksourceview intltool itstool python ];
+}

--- a/pkgs/desktops/gnome-3/3.12/devtools/gdl/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/devtools/gdl/default.nix
@@ -14,4 +14,11 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ pkgconfig libxml2 gtk3 intltool ];
+
+  meta = with stdenv.lib; {
+    description = "Gnome docking library";
+    homepage = https://developer.gnome.org/gdl/;
+    license = [ licenses.gpl2 ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/desktops/gnome-3/3.12/devtools/gdl/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/devtools/gdl/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, pkgconfig, libxml2, gtk3, intltool }:
+
+let
+  major = "3.12";
+  minor = "0";
+
+in stdenv.mkDerivation rec {
+  version = "${major}.${minor}";
+  name = "gdl-${version}";
+
+  src = fetchurl {
+    url = "https://download.gnome.org/sources/gdl/${major}/${name}.tar.xz";
+    sha256 = "4770f959f31ed5e616fe623c284e8dd6136e49902d19b6e37938d34be4f6b88d";
+  };
+
+  buildInputs = [ pkgconfig libxml2 gtk3 intltool ];
+}

--- a/pkgs/desktops/gnome-3/3.12/misc/libgda/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/misc/libgda/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gtk3 }:
+
+let
+  major = "5.2";
+  minor = "2";
+
+in stdenv.mkDerivation rec {
+  version = "${major}.${minor}";
+  name = "libgda-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/libgda/${major}/${name}.tar.xz";
+    sha256 = "c9b8b1c32f1011e47b73c5dcf36649aaef2f1edaa5f5d75be20d9caadc2bc3e4";
+  };
+
+  configureFlags = [
+    "--enable-gi-system-install=no"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ pkgconfig intltool itstool libxml2 gtk3 ];
+}

--- a/pkgs/desktops/gnome-3/3.12/misc/libgda/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/misc/libgda/default.nix
@@ -20,4 +20,11 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildInputs = [ pkgconfig intltool itstool libxml2 gtk3 ];
+
+  meta = with stdenv.lib; {
+    description = "Database access library";
+    homepage = http://www.gnome-db.org/;
+    license = [ licenses.lgpl2 licenses.gpl2 ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/development/libraries/libid3tag/default.nix
+++ b/pkgs/development/libraries/libid3tag/default.nix
@@ -1,7 +1,10 @@
-{stdenv, fetchurl, zlib, gperf}:
+{stdenv, fetchurl, writeText, zlib, gperf}:
 
-stdenv.mkDerivation {
-  name = "libid3tag-0.15.1b";
+stdenv.mkDerivation rec {
+  version = "0.15.1b";
+
+  name = "libid3tag-${version}";
+
   src = fetchurl {
     url = mirror://sourceforge/mad/libid3tag-0.15.1b.tar.gz;
     sha256 = "63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151";
@@ -10,6 +13,26 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ zlib gperf ];
 
   patches = [ ./debian-patches.patch ];
+
+  postInstall = let pkgconfigFile = writeText "id3tag.pc" ''
+    prefix=@out@
+    exec_prefix=''${prefix}
+    libdir=''${exec_prefix}/lib
+    includedir=''${exec_prefix}/include
+
+    Name: libid3tag
+    Description: ID3 tag manipulation library
+    Version: ${version}
+
+    Libs: -L''${libdir} -lid3tag
+    Cflags: -I''${includedir}
+    '';
+  in ''
+      ensureDir $out/share/pkgconfig
+      cp ${pkgconfigFile} $out/share/pkgconfig/id3tag.pc
+      substituteInPlace $out/share/pkgconfig/id3tag.pc \
+        --subst-var-by out $out
+  '';
 
   meta = with stdenv.lib; {
     description = "ID3 tag manipulation library";


### PR DESCRIPTION
Hi,

I updated gtkpod from a ridiculous old version to the newest one. Unfortunately gtkpod 2.1.4 has a new dependency anjuta, which itself had a few further dependencies that weren't available. So I added them all. Hopefully the change isn't to big.

Best,
Sven
