### PR TITLE
Give fail2ban systemd support

### DIFF
--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -25,6 +25,11 @@ in
   options = {
 
     services.fail2ban = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to enable the fail2ban service.";
+      };
 
       daemonConfig = mkOption {
         default =
@@ -80,7 +85,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = mkIf cfg.enable {
 
     environment.systemPackages = [ pkgs.fail2ban ];
 

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -30,7 +30,7 @@ in
         default =
           ''
             [Definition]
-            loglevel  = 3
+            loglevel  = INFO
             logtarget = SYSLOG
             socket    = /run/fail2ban/fail2ban.sock
             pidfile   = /run/fail2ban/fail2ban.pid
@@ -101,12 +101,13 @@ in
         preStart =
           ''
             mkdir -p /run/fail2ban -m 0755
+            mkdir -p /var/lib/fail2ban
           '';
 
         serviceConfig =
           { ExecStart = "${pkgs.fail2ban}/bin/fail2ban-server -f";
             ReadOnlyDirectories = "/";
-            ReadWriteDirectories = "/run /var/tmp";
+            ReadWriteDirectories = "/run /var/tmp /var/lib";
             CapabilityBoundingSet = "CAP_DAC_READ_SEARCH CAP_NET_ADMIN CAP_NET_RAW";
           };
 
@@ -131,15 +132,14 @@ in
         bantime  = 600
         findtime = 600
         maxretry = 3
-        backend  = auto
-      '';
+        backend  = systemd
+       '';
 
     # Block SSH if there are too many failing connection attempts.
     services.fail2ban.jails.ssh-iptables =
       ''
         filter   = sshd
         action   = iptables[name=SSH, port=ssh, protocol=tcp]
-        logpath  = /var/log/warn
         maxretry = 5
       '';
 

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, unzip, python27Full, systemd }:
+{ stdenv, fetchurl, python, pythonPackages, unzip, systemd }:
 
 let version = "0.9"; in
 
@@ -14,7 +14,7 @@ pythonPackages.buildPythonPackage {
 
   buildInputs = [ unzip ];
 
-  pythonPath = [ systemd python27Full ];
+  pythonPath = [ systemd python.modules.sqlite3 ];
 
   preConfigure = ''
     substituteInPlace setup.cfg \

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, unzip, gamin }:
+{ stdenv, fetchurl, pythonPackages, unzip, python27Full, systemd }:
 
-let version = "0.8.13"; in
+let version = "0.9"; in
 
 pythonPackages.buildPythonPackage {
   name = "fail2ban-${version}";
@@ -9,12 +9,12 @@ pythonPackages.buildPythonPackage {
   src = fetchurl {
     url    = "https://github.com/fail2ban/fail2ban/zipball/${version}";
     name   = "fail2ban-${version}.zip";
-    sha256 = "0c63i5jsn2n6hv6fb6q922ksxfpppah9415vpydiv0vpf23pq0cb";
+    sha256 = "0dawl0vvdvpnkg1hc4l0c8sj8ikcr2l48d6khfx0174nq8yfcg93";
   };
 
   buildInputs = [ unzip ];
 
-  pythonPath = [ gamin ];
+  pythonPath = [ systemd python27Full ];
 
   preConfigure = ''
     substituteInPlace setup.cfg \

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, pythonPackages, unzip, systemd }:
+{ stdenv, fetchurl, python, pythonPackages, unzip, systemd, gamin }:
 
 let version = "0.9"; in
 
@@ -14,7 +14,7 @@ pythonPackages.buildPythonPackage {
 
   buildInputs = [ unzip ];
 
-  pythonPath = [ systemd python.modules.sqlite3 ];
+  pythonPath = [ systemd python.modules.sqlite3 gamin ];
 
   preConfigure = ''
     substituteInPlace setup.cfg \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1006,7 +1006,11 @@ let
 
   fabric = pythonPackages.fabric;
 
-  fail2ban = callPackage ../tools/security/fail2ban { };
+  fail2ban = callPackage ../tools/security/fail2ban {
+    systemd = systemd.override {
+      pythonSupport = true;
+    };
+  };
 
   fakeroot = callPackage ../tools/system/fakeroot { };
 


### PR DESCRIPTION
I assume nobody's really been using fail2ban since it has been 0.8 up to now and 0.9 added support for reading the system journal. These commits update it to 0.9.

Also, python27Full is in the pythonPath for fail2ban because otherwise it can't find the _sqlite3 module. If anyone knows a better way to address that problem, I'd like to hear it.
