### PR TITLE
qt5: remove references to /usr/{share,lib}/X11/locale/

### DIFF
--- a/pkgs/development/libraries/qt-5/default.nix
+++ b/pkgs/development/libraries/qt-5/default.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /bin/pwd pwd
     substituteInPlace qtbase/configure --replace /bin/pwd pwd
     substituteInPlace qtbase/src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
+    substituteInPlace qtbase/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp \
+        --replace /usr/share/X11/locale ${libX11}/share/X11/locale \
+        --replace /usr/lib/X11/locale ${libX11}/share/X11/locale
     sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i config.tests/*/*.test -i qtbase/mkspecs/*/*.conf
   '';
 

--- a/pkgs/development/libraries/qt-5/qt-5.3.nix
+++ b/pkgs/development/libraries/qt-5/qt-5.3.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /bin/pwd pwd
     substituteInPlace qtbase/configure --replace /bin/pwd pwd
     substituteInPlace qtbase/src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
+    substituteInPlace qtbase/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp \
+        --replace /usr/share/X11/locale ${libX11}/share/X11/locale \
+        --replace /usr/lib/X11/locale ${libX11}/share/X11/locale
     sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i config.tests/*/*.test -i qtbase/mkspecs/*/*.conf
   '';
 


### PR DESCRIPTION
Qt5 currently hardcodes /usr/{share,lib}/X11/locale/. Fix it to use
paths from the nix store. Qt4 is unaffected.

This fixes a startup warning for applications built with qt5 (e.g. qtcreator, shotcut):

  Qt Warning: Could not find a location of the system's Compose files. Consider setting the QTCOMPOSE environment variable.

---

There are very few packages using qt5 in nixpkgs, so maybe we can merge this directly to master?
