### PR TITLE
move libid3tag's pkgconfig file into its nix-expression directory

### DIFF
--- a/pkgs/development/libraries/libid3tag/default.nix
+++ b/pkgs/development/libraries/libid3tag/default.nix
@@ -14,24 +14,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./debian-patches.patch ];
 
-  postInstall = let pkgconfigFile = writeText "id3tag.pc" ''
-    prefix=@out@
-    exec_prefix=''${prefix}
-    libdir=''${exec_prefix}/lib
-    includedir=''${exec_prefix}/include
-
-    Name: libid3tag
-    Description: ID3 tag manipulation library
-    Version: ${version}
-
-    Libs: -L''${libdir} -lid3tag
-    Cflags: -I''${includedir}
-    '';
-  in ''
-      ensureDir $out/share/pkgconfig
-      cp ${pkgconfigFile} $out/share/pkgconfig/id3tag.pc
-      substituteInPlace $out/share/pkgconfig/id3tag.pc \
-        --subst-var-by out $out
+  postInstall = ''
+    ensureDir $out/share/pkgconfig
+    cp ${./id3tag.pc} $out/share/pkgconfig/id3tag.pc
+    substituteInPlace $out/share/pkgconfig/id3tag.pc \
+      --subst-var-by out $out \
+      --subst-var-by version "${version}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libid3tag/id3tag.pc
+++ b/pkgs/development/libraries/libid3tag/id3tag.pc
@@ -1,0 +1,11 @@
+prefix=@out@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: libid3tag
+Description: ID3 tag manipulation library
+Version: @version@
+
+Libs: -L${libdir} -lid3tag
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi,

I recently made a change to libid3tag https://github.com/NixOS/nixpkgs/blob/2d31046a40e2ae5546971728477a0a1a17c49e08/pkgs/development/libraries/libid3tag/default.nix#L17-L35. I didn't know that you could reference files in the directory of the current nix-expression. I think that makes a little bit prettier.

Best,
Sven
