### PR TITLE
Zotero version bump

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/30.nix
+++ b/pkgs/applications/networking/browsers/firefox/30.nix
@@ -1,0 +1,211 @@
+{ stdenv, fetchurl, pkgconfig, gtk, pango, perl, python, zip, libIDL
+, libjpeg, libpng, zlib, dbus, dbus_glib, bzip2, xlibs
+, freetype, fontconfig, file, alsaLib, nspr, nss, libnotify
+, yasm, mesa, sqlite, unzip, makeWrapper, pysqlite
+, hunspell, libevent, libstartup_notification, libvpx
+, cairo, gstreamer, gst_plugins_base, icu
+, debugBuild ? false
+, # If you want the resulting program to call itself "Firefox" instead
+  # of "Shiretoko" or whatever, enable this option.  However, those
+  # binaries may not be distributed without permission from the
+  # Mozilla Foundation, see
+  # http://www.mozilla.org/foundation/trademarks/.
+  enableOfficialBranding ? false
+}:
+
+assert stdenv.gcc ? libc && stdenv.gcc.libc != null;
+
+rec {
+
+  firefoxVersion = "30.0";
+
+  xulVersion = "30.0"; # this attribute is used by other packages
+
+
+  src = fetchurl {
+    url = "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.bz2";
+    sha1 = "bll9hxf31gvg9db6gxgmq25qsjif3p11";
+  };
+
+  commonConfigureFlags =
+    [ "--with-system-jpeg"
+      "--with-system-zlib"
+      "--with-system-bz2"
+      "--with-system-nspr"
+      "--with-system-nss"
+      "--with-system-libevent"
+      "--with-system-libvpx"
+      "--with-system-png"
+      # "--with-system-icu" # causes ‘ar: invalid option -- 'L'’ in Firefox 28.0
+      "--enable-system-ffi"
+      "--enable-system-hunspell"
+      "--enable-system-pixman"
+      "--enable-system-sqlite"
+      "--enable-system-cairo"
+      "--enable-gstreamer"
+      "--enable-startup-notification"
+      # "--enable-content-sandbox"            # available since 26.0, but not much info available
+      # "--enable-content-sandbox-reporter"   # keeping disabled for now
+      "--disable-crashreporter"
+      "--disable-tests"
+      "--disable-necko-wifi" # maybe we want to enable this at some point
+      "--disable-installer"
+      "--disable-updater"
+      "--disable-pulseaudio"
+    ] ++ (if debugBuild then [ "--enable-debug" "--enable-profiling"]
+                        else [ "--disable-debug" "--enable-release"
+                               "--enable-optimize" "--enable-strip" ]);
+
+
+  xulrunner = stdenv.mkDerivation rec {
+    name = "xulrunner-${xulVersion}";
+
+    inherit src;
+
+    buildInputs =
+      [ pkgconfig libpng gtk perl zip libIDL libjpeg zlib bzip2
+        python dbus dbus_glib pango freetype fontconfig xlibs.libXi
+        xlibs.libX11 xlibs.libXrender xlibs.libXft xlibs.libXt file
+        alsaLib nspr nss libnotify xlibs.pixman yasm mesa
+        xlibs.libXScrnSaver xlibs.scrnsaverproto pysqlite
+        xlibs.libXext xlibs.xextproto sqlite unzip makeWrapper
+        hunspell libevent libstartup_notification libvpx cairo
+        gstreamer gst_plugins_base icu
+      ];
+
+    configureFlags =
+      [ "--enable-application=xulrunner"
+        "--disable-javaxpcom"
+      ] ++ commonConfigureFlags;
+
+    #enableParallelBuilding = true; # cf. https://github.com/NixOS/nixpkgs/pull/1699#issuecomment-35196282
+
+    preConfigure =
+      ''
+        export NIX_LDFLAGS="$NIX_LDFLAGS -L$out/lib/xulrunner-${xulVersion}"
+
+        mkdir ../objdir
+        cd ../objdir
+        configureScript=../mozilla-release/configure
+      ''; # */
+
+    #installFlags = "SKIP_GRE_REGISTRATION=1";
+
+    preInstall = ''
+      # The following is needed for startup cache creation on grsecurity kernels
+      paxmark m ../objdir/dist/bin/xpcshell
+    '';
+
+    postInstall = ''
+      # Fix run-mozilla.sh search
+      libDir=$(cd $out/lib && ls -d xulrunner-[0-9]*)
+      echo libDir: $libDir
+      test -n "$libDir"
+      cd $out/bin
+      rm xulrunner
+
+      for i in $out/lib/$libDir/*; do
+          file $i;
+          if file $i | grep executable &>/dev/null; then
+              echo -e '#! /bin/sh\nexec "'"$i"'" "$@"' > "$out/bin/$(basename "$i")";
+              chmod a+x "$out/bin/$(basename "$i")";
+          fi;
+      done
+      for i in $out/lib/$libDir/*.so; do
+          patchelf --set-rpath "$(patchelf --print-rpath "$i"):$out/lib/$libDir" $i || true
+      done
+
+      # For grsecurity kernels
+      paxmark m $out/lib/$libDir/{plugin-container,xulrunner}
+
+      for i in $out/lib/$libDir/{plugin-container,xulrunner,xulrunner-stub}; do
+          wrapProgram $i --prefix LD_LIBRARY_PATH ':' "$out/lib/$libDir"
+      done
+
+      rm -f $out/bin/run-mozilla.sh
+    ''; # */
+
+    meta = {
+      description = "Mozilla Firefox XUL runner";
+      homepage = http://www.mozilla.com/en-US/firefox/;
+    };
+
+    passthru = { inherit gtk; version = xulVersion; };
+  };
+
+
+  firefox = stdenv.mkDerivation rec {
+    name = "firefox-${firefoxVersion}";
+
+    inherit src;
+
+    enableParallelBuilding = true;
+
+    buildInputs =
+      [ pkgconfig libpng gtk perl zip libIDL libjpeg zlib bzip2 python
+        dbus dbus_glib pango freetype fontconfig alsaLib nspr nss libnotify
+        xlibs.pixman yasm mesa sqlite file unzip pysqlite
+        hunspell libevent libstartup_notification libvpx cairo
+        gstreamer gst_plugins_base icu
+      ];
+
+    patches = [
+      ./disable-reporter.patch # fixes "search box not working when built on xulrunner"
+      ./xpidl.patch
+    ];
+
+    propagatedBuildInputs = [xulrunner];
+
+    configureFlags =
+      [ "--enable-application=browser"
+        "--with-libxul-sdk=${xulrunner}/lib/xulrunner-devel-${xulrunner.version}"
+        "--enable-chrome-format=jar"
+      ]
+      ++ commonConfigureFlags
+      ++ stdenv.lib.optional enableOfficialBranding "--enable-official-branding";
+
+    makeFlags = [
+      "SYSTEM_LIBXUL=1"
+    ];
+
+    # Because preConfigure runs configure from a subdirectory.
+    configureScript = "../configure";
+
+    preConfigure =
+      ''
+        # Hack to work around make's idea of -lbz2 dependency
+        find . -name Makefile.in -execdir sed -i '{}' -e '1ivpath %.so ${
+          stdenv.lib.concatStringsSep ":"
+            (map (s : s + "/lib") (buildInputs ++ [stdenv.gcc.libc]))
+        }' ';'
+
+        # Building directly in the main source directory is not allowed.
+        mkdir obj_dir
+        cd obj_dir
+      '';
+
+    postInstall =
+      ''
+        ln -s ${xulrunner}/lib/xulrunner-${xulrunner.version} $(echo $out/lib/firefox-*)/xulrunner
+        cd "$out/lib/"firefox-*
+        rm firefox
+        echo -e '#!${stdenv.shell}\nexec ${xulrunner}/bin/xulrunner "'"$PWD"'/application.ini" "$@"' > firefox
+        chmod a+x firefox
+
+        # Put chrome.manifest etc. in the right place.
+        mv browser/* .
+        rmdir browser
+      ''; # */
+
+    meta = {
+      description = "Mozilla Firefox - the browser, reloaded";
+      homepage = http://www.mozilla.com/en-US/firefox/;
+      maintainers = with stdenv.lib.maintainers; [ eelco wizeman ];
+    };
+
+    passthru = {
+      inherit gtk xulrunner nspr;
+      isFirefox3Like = true;
+    };
+  };
+}

--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -3,7 +3,7 @@
 assert (stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux");
 
 let
-  version = "4.0.21.1";
+  version = "4.0.21.2";
   arch = if stdenv.system == "x86_64-linux"
            then "linux-x86_64"
            else "linux-i686";
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "https://download.zotero.org/standalone/${version}/Zotero-${version}_${arch}.tar.bz2";
     sha256 = if stdenv.system == "x86_64-linux"
-               then "1d6ih9q0daxxqqbr134la5y39648hpd53srf43lljjs8wr71wbn8"
-               else "121myzwxw3frps77lpzza82glyz9qgwbl5bh3zngfx9vwx3n8q0v";
+               then "1df101j2qwdp001m8x3ihbzz2j23x43804k8ww749y09d1ydb4dx"
+               else "1bcrpl6gdxlygd5ppyrhw42q24kjcakma3qv6mpzgp91phkf6g30";
   };
 
   # Strip the bundled xulrunner

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3665,6 +3665,8 @@ let
     inherit (pythonPackages) pysqlite;
   };
 
+  xulrunner_30 = firefox30Pkgs.xulrunner;
+
 
   ### DEVELOPMENT / MISC
 
@@ -8663,6 +8665,12 @@ let
 
   firefox13Wrapper = wrapFirefox { browser = firefox13Pkgs.firefox; };
 
+  firefox30Pkgs = callPackage ../applications/networking/browsers/firefox/30.nix {
+    inherit (gnome) libIDL;
+    inherit (pythonPackages) pysqlite;
+    libpng = libpng_apng;
+  };
+
   firefox = callPackage ../applications/networking/browsers/firefox {
     inherit (gnome) libIDL;
     inherit (pythonPackages) pysqlite;
@@ -10134,7 +10142,9 @@ let
 
   zgrviewer = callPackage ../applications/graphics/zgrviewer {};
 
-  zotero = callPackage ../applications/office/zotero { };
+  zotero = callPackage ../applications/office/zotero {
+    xulrunner = xulrunner_30;
+  };
 
   zynaddsubfx = callPackage ../applications/audio/zynaddsubfx { };
 


### PR DESCRIPTION
This pull request has a minor version bump for Zotero. Also, because upstream doesn't update frequently enough, the Firefox version bump has left us without a suitable version of xulrunner. Again. This has been happening like clockwork recently, so I'm pulling Firefox 30 back in. We can drop it after Zotero upstream updates.
