### PR TITLE
bind: Expand to all unix platforms.

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.isc;
 
     maintainers = with stdenv.lib.maintainers; [viric simons];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; unix;
   };
 }


### PR DESCRIPTION
I just built this successfully on OS X 10.8.4.

I have not done extensive testing as I only need the `named-checkzone` command and do not intend to run the daemon.

Is there other testing I should do, or can this be enabled on `unix`, or perhaps `darwin ++ linux`?
