### PR TITLE
Stop binutils from trying to build on Darwin

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -2,6 +2,8 @@
 , cross ? null, gold ? true, bison ? null
 }:
 
+assert !stdenv.isDarwin;
+
 let basename = "binutils-2.23.1"; in
 
 with { inherit (stdenv.lib) optional optionals optionalString; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3769,9 +3769,11 @@ let
 
   bam = callPackage ../development/tools/build-managers/bam {};
 
-  binutils = callPackage ../development/tools/misc/binutils {
-    inherit noSysDirs;
-  };
+  binutils = if stdenv.isDarwin
+    then stdenv.gcc.binutils
+    else callPackage ../development/tools/misc/binutils {
+      inherit noSysDirs;
+    };
 
   binutils_nogold = lowPrio (callPackage ../development/tools/misc/binutils {
     inherit noSysDirs;


### PR DESCRIPTION
Sometimes, for no reason whatsoever, my machine tries to build binutils. This happens whenever a package overrides `stdenv` to use `gccApple` (examples: redis, phantomjs). I've spoken to some other Darwin users in #nixos and some have the same problem, but some (@jwiegley as far as I know) don't.

Until someone, possibly me, can figure out the problem, this is a patch that'll unconditionally stop binutils from building on Darwin and also hopefully restricts any references to binutils to use native-darwin-cctools-wrapper.
