### PR TITLE
Add missing runtime dependency for python-stevedore

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7184,6 +7184,8 @@ rec {
 
     buildInputs = [ pbr pip ];
 
+    propagatedBuildInputs = [ setuptools ];
+
     meta = {
       description = "Manage dynamic plugins for Python applications";
       homepage = "https://pypi.python.org/pypi/stevedore";


### PR DESCRIPTION
_pythonPackages.stevedore_ has a run time dependency on _pythonPackages.setuptools_. This pull request fixes this issue.

current state:

```
[jascha@loshi:~/git/nixpkgs]$ nix-shell -p pythonPackages.python pythonPackages.stevedore

[nix-shell:~/git/nixpkgs]$ python -c "import stevedore"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/nix/store/f2mm3m01j39f9scai9fhgk8hjxd5ga4k-python2.7-stevedore-0.15/lib/python2.7/site-packages/stevedore/__init__.py", line 11, in <module>
    from .extension import ExtensionManager
  File "/nix/store/f2mm3m01j39f9scai9fhgk8hjxd5ga4k-python2.7-stevedore-0.15/lib/python2.7/site-packages/stevedore/extension.py", line 4, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
```

after this fix:

```
[jascha@loshi:~/git/nixpkgs]$ nix-shell -I nixpkgs=$HOME/git/nixpkgs -p pythonPackages.python pythonPackages.stevedore

[nix-shell:~/git/nixpkgs]$ python -c "import stevedore"
```
