### PR TITLE
Update dnsmasq to new version and enable for OS X

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   name = "dnsmasq-2.71";
 
   src = fetchurl {
-    url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.gz";
-    sha256 = "1i1l2s2bcs6yx05wh1p2rf4bl0jfdgmg77b33gh44r1rdbv6933x";
+    url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.xz";
+    sha256 = "1fpzpzja7qr8b4kfdhh4i4sijp62c634yf0xvq2n4p7d5xbzn6a9";
   };
 
   makeFlags = "DESTDIR= BINDIR=$(out)/bin MANDIR=$(out)/man LOCALEDIR=$(out)/share/locale";

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     description = "An integrated DNS, DHCP and TFTP server for small networks";
     homepage = http://www.thekelleys.org.uk/dnsmasq/doc.html;
     license = "GPL";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.eelco ];
   };
 }

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "dnsmasq-2.69";
+  name = "dnsmasq-2.71";
 
   src = fetchurl {
     url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.gz";
-    sha256 = "1zf4d6kjbsn6gwfwvmch1y84q67na1qhh0gyd50ip1vjsmw2l4i7";
+    sha256 = "1i1l2s2bcs6yx05wh1p2rf4bl0jfdgmg77b33gh44r1rdbv6933x";
   };
 
   makeFlags = "DESTDIR= BINDIR=$(out)/bin MANDIR=$(out)/man LOCALEDIR=$(out)/share/locale";


### PR DESCRIPTION
I've been using dnsmasq on OS X for quite some time and it works alright, so one of the commits enables the package for OS X. I updated the package to the current dnsmasq version (2.71) while I was at it and also made it use the .xz file instead of the .gz archive since the former is about 30% smaller.
