### PR TITLE
Fix virtualenvwrapper shell scripts

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8168,6 +8168,15 @@ rec {
     patchPhase = ''
       substituteInPlace "virtualenvwrapper.sh" --replace "which" "${pkgs.which}/bin/which"
       substituteInPlace "virtualenvwrapper_lazy.sh" --replace "which" "${pkgs.which}/bin/which"
+
+      # This might look like a dirty hack but we can't use the makeWrapper function because
+      # the wrapped file were then called via "exec". The virtualenvwrapper shell scripts
+      # aren't normal executables. Instead, the user has to evaluate them.
+      for file in "virtualenvwrapper.sh" "virtualenvwrapper_lazy.sh"; do
+        # Insert the required PATH & PYTHONPATH variables right on the top
+        sed -i "2iexport PATH=$PATH:\$PATH" "$file"
+        sed -i "3iexport PYTHONPATH=$PYTHONPATH:$(toPythonPath $out):\$PYTHONPATH" "$file"
+      done
     '';
 
     meta = {


### PR DESCRIPTION
This pull request fixes the broken shell scripts. From now on it is possible to call `source virtualenvwrapper.sh` in your shell and virtualenvwrapper is working as expected (e.g. no more `nix-shell -p pythonPackages.python pythonPackages.virtualenvwrapper`)

This might look like a dirty hack but we can't use the makeWrapper function because the wrapped file were then called via "exec". The virtualenvwrapper shell scripts aren't normal executables. Instead, the user has to evaluate them. However, if we really use makeWrapper and call `source virtualenvwrapper.sh`, the current shell quits immediately.
