### PR TITLE
Added gmock (Google Mock) package to complement gtest package.

### DIFF
--- a/pkgs/development/libraries/gmock/default.nix
+++ b/pkgs/development/libraries/gmock/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, unzip, cmake}:
+
+stdenv.mkDerivation rec {
+  version = "1.7.0";
+  name = "gmock-${version}";
+
+  src = fetchurl {
+    url = "https://googlemock.googlecode.com/files/${name}.zip";
+    sha256="26fcbb5925b74ad5fc8c26b0495dfc96353f4d553492eb97e85a8a6d2f43095b";
+  };
+
+  buildInputs = [ unzip cmake ];
+
+  configurePhase = ''
+    mkdir build
+    cd build
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$out
+  '';
+
+  buildPhase = ''
+    # avoid building gtest
+    make gmock gmock_main
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -v libgmock.a libgmock_main.a $out/lib
+    cp -v -r ../include $out
+    cp -v -r ../src $out
+  '';
+
+  meta = {
+    description = "Google mock: Google's framework for writing C++ mock classes.";
+    homepage = https://code.google.com/p/googlemock/;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.auntie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1229,6 +1229,7 @@ let
   gt5 = callPackage ../tools/system/gt5 { };
 
   gtest = callPackage ../development/libraries/gtest {};
+  gmock = callPackage ../development/libraries/gmock {};
 
   gtkdatabox = callPackage ../development/libraries/gtkdatabox {};
 


### PR DESCRIPTION
I needed to use gmock and gtest together in a project, so I more or less copied the gtest package into a gmock package.

Another thing to do might be to rewrite the synergy package to use this gmock package, as it downloads gmock itself. But for now here's a standalone gmock package.
