### PR TITLE
Copy over libGLESv2 and libEGL too for nVidia blob

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -36,7 +36,7 @@ installPhase() {
     for f in \
       libcuda libGL libnvcuvid libnvidia-cfg libnvidia-compiler \
       libnvidia-encode libnvidia-glcore libnvidia-ml libnvidia-opencl \
-      libnvidia-tls libOpenCL libnvidia-tls libvdpau_nvidia
+      libnvidia-tls libOpenCL libnvidia-tls libvdpau_nvidia libEGL libGLESv2
     do
       cp -prd $f.* $out/lib/
       ln -snf $f.so.$versionNumber $out/lib/$f.so


### PR DESCRIPTION
This copies over libEGL.so and libGLESv2.so which were the source of my trouble over at http://lists.science.uu.nl/pipermail/nix-dev/2014-August/013825.html . 

I think we should simply copy every `.so` file there is in the directory rather than be selective for no reason. I did not do so in this PR because of the way it was done already but I see no downside.
