### PR TITLE
Copy all so files over from nVidia blob

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -33,11 +33,9 @@ installPhase() {
     # Install libGL and friends.
     mkdir -p $out/lib/vendors
 
-    for f in \
-      libcuda libGL libnvcuvid libnvidia-cfg libnvidia-compiler \
-      libnvidia-encode libnvidia-glcore libnvidia-ml libnvidia-opencl \
-      libnvidia-tls libOpenCL libnvidia-tls libvdpau_nvidia libEGL libGLESv2
+    for g in *.so.$versionNumber;
     do
+      f=$(basename $g .so.$versionNumber)
       cp -prd $f.* $out/lib/
       ln -snf $f.so.$versionNumber $out/lib/$f.so
       ln -snf $f.so.$versionNumber $out/lib/$f.so.1


### PR DESCRIPTION
This is just like #3498 but over all the .so.$versionNumbers files present. I was already bitten by not copying everything over since my #3498 as libEGL and libGLESv2 needed more libs. I _think_ this doesn't break anything.
