### PR TITLE
quassel: add quassel and quassel-client without kde integration

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10651,6 +10651,11 @@ let
 
       quassel = callPackage ../applications/networking/irc/quassel { dconf = gnome3.dconf; };
 
+      quasselWithoutKDE = (self.quassel.override {
+        withKDE = false;
+        tag = "-without-kde";
+      });
+
       quasselDaemon = (self.quassel.override {
         monolithic = false;
         daemon = true;
@@ -10661,6 +10666,11 @@ let
         monolithic = false;
         client = true;
         tag = "-client";
+      });
+
+      quasselClientWithoutKDE = (self.quasselClient.override {
+        withKDE = false;
+        tag = "-client-without-kde";
       });
 
       rekonq = callPackage ../applications/networking/browsers/rekonq { };


### PR DESCRIPTION
Not sure if this is useful for anyone besides me, but quassel with kde integration in a non-kde environment is not very pleasent to use (no notifications, file dialogs broken, …). I am fine with making these changes in my config.nix but I thought that I might not be alone so that it is worth adding this to all-packages.nix.
