### PR TITLE
Fixed deterministicness of fetchgit with leaveDotGit

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -227,8 +227,9 @@ clone_user_rev() {
 	echo "removing \`.git'..." >&2
         find $dir -name .git\* | xargs rm -rf
     else
-        # The logs and index contain timestamps
-        find $dir -name .git | xargs -I {} rm -rf {}/logs {}/index
+        # The logs and index contain timestamps, and the hooks contain
+        # the nix path of git's bash
+        find $dir -name .git | xargs -I {} rm -rf {}/logs {}/index {}/hooks
     fi
 }
 

--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -7,7 +7,7 @@ pythonPackages.buildPythonPackage rec {
   src = fetchgit {
     url = "git://github.com/madjar/nox.git";
     rev = "49e4bb7de473ac5e446a76c292bdaefa7e20a1c6";
-    sha256 = "0z97anjhvf8qlyq73h3008np7qh1jvv3kafyxhcbjmi1hpimndyy";
+    sha256 = "1w1b2g44lj6nbs7f2j5dz5pijhfah3fyldspfb34zcv17j2nlv0b";
     leaveDotGit = true; # required by pbr
   };
 


### PR DESCRIPTION
The shebang of .git/hooks depended the git's bash, which made the result
depend of that bash's path.
