### PR TITLE
Fix default icon location in 'wrapFirefox'

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9994,7 +9994,7 @@ let
 
   wrapFirefox =
     { browser, browserName ? "firefox", desktopName ? "Firefox", nameSuffix ? ""
-    , icon ? "${browser}/lib/${browser.name}/icons/mozicon128.png" }:
+    , icon ? "${browser}/lib/${browser.name}/browser/icons/mozicon128.png" }:
     let
       cfg = stdenv.lib.attrByPath [ browserName ] {} config;
       enableAdobeFlash = cfg.enableAdobeFlash or false;


### PR DESCRIPTION
This pull request probably fixes #2897

_/nix/store/3r83139gsh0qqifv9x7x1fq7h2maxyhg-firefox-with-plugins-31.0/share/applications/firefox.desktop:_

```
[Desktop Entry]
Type=Application
Exec=firefox %U
Icon=/nix/store/7yrxr3yd4c3vgx48c89xi20hybcmdy6n-firefox-31.0/lib/firefox-31.0/icons/mozicon128.png
[...]
```

The icon path doesn't exist. Instead, this is the correct path:

```
/nix/store/7yrxr3yd4c3vgx48c89xi20hybcmdy6n-firefox-31.0/lib/firefox-31.0/browser/icons/mozicon128.png
```

However, I could not test the new firefoxWrapper package because I can't build the new one. The hash of the build inputs are the same, so calling `nix-build $NIXREPO -A firefoxWrapper` use the build cache. Is there a way to force a rebuild? or is this a "bug" ?
