### PR TITLE
Linux kernel: enable CONFIG_CHECKPOINT_RESTORE

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -184,6 +184,8 @@ with stdenv.lib;
   ''}
   ${optionalString (versionAtLeast version "3.12") ''
     USER_NS y # Support for user namespaces
+    EXPERT y
+    CHECKPOINT_RESTORE y
   ''}
 
   # AppArmor support


### PR DESCRIPTION
It is needed for criu package to work.
