### PR TITLE
fix lighttpd modules for gitweb

### DIFF
--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -9,9 +9,9 @@ let
   cfg = config.services.lighttpd;
 
   needModRedirect = cfg.gitweb.enable;
-  needModAlias = cfg.cgit.enable or cfg.gitweb.enable;
-  needModSetenv = cfg.cgit.enable or cfg.gitweb.enable;
-  needModCgi = cfg.cgit.enable or cfg.gitweb.enable;
+  needModAlias = cfg.cgit.enable || cfg.gitweb.enable;
+  needModSetenv = cfg.cgit.enable || cfg.gitweb.enable;
+  needModCgi = cfg.cgit.enable || cfg.gitweb.enable;
   needModStatus = cfg.mod_status;
   needModUserdir = cfg.mod_userdir;
 


### PR DESCRIPTION
Setting `services.lighttpd.gitweb.enable` to `true` doesn't enable the required lighttpd modules to actually make it work. The problem is that `or` and `||` don't mean the same thing: `or` falls back to the second operand if the first is not defined, whereas `||` is the normal logical operator. When `cfg.cgit.enable` is defined, as `false`, the expressions don't have the desired effect.
