### PR TITLE
Use shared atlas in liblapack for hmatrix

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1164,7 +1164,9 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   HList = callPackage ../development/libraries/haskell/HList {};
 
-  hmatrix = callPackage ../development/libraries/haskell/hmatrix {};
+  hmatrix = callPackage ../development/libraries/haskell/hmatrix {
+    liblapack = pkgs.liblapack.override { shared = true; };
+  };
 
   hmatrixSpecial = callPackage ../development/libraries/haskell/hmatrix-special {};
 


### PR DESCRIPTION
With the following test program:

``` haskell
{-# LANGUAGE TemplateHaskell #-}

import Language.Haskell.TH
import Numeric.GSL

$(do
  runIO $ setErrorHandlerOff
  return []
  )

main = return ()
```

I get the following compilation error only with NixOS GHC:

```
...
Loading package hmatrix-0.15.2.1 ... 

GHCi runtime linker: fatal error: I found a duplicate definition for symbol
   __x86.get_pc_thunk.bx
whilst processing object file
   /nix/store/y6fxny6iwhb8apxf5sfgqx4f4mzk692b-liblapack-3.4.1/lib/liblapack.a
This could be caused by:
   * Loading two different object files which export the same symbol
   * Specifying the same object file twice on the GHCi command line
   * An incorrect `package.conf' entry, causing some object to be
     loaded twice.
GHCi cannot safely continue in this situation.  Exiting now.  Sorry.
```

This is because of the GHC 7.8 dynamic by default change interacting with template haskell and the fact that it tries to use liblapack.a instead of liblapack.so.  Forcing liblapack.so fixes the issue for me.

Please note that Debian/Ubuntu also uses liblapack.so for hmatrix, not liblapack.a.
