### PR TITLE
haskell-bitarray: update to 0.0.1.1

### DIFF
--- a/pkgs/development/libraries/haskell/bitarray/default.nix
+++ b/pkgs/development/libraries/haskell/bitarray/default.nix
@@ -4,14 +4,12 @@
 
 cabal.mkDerivation (self: {
   pname = "bitarray";
-  version = "0.0.1";
-  sha256 = "01ijysisw70zaw70hx851axw48agfamdqj21rzzhdqd2ww6bwchb";
+  version = "0.0.1.1";
+  sha256 = "00nqd62cbh42qqqvcl6iv1i9kbv0f0mkiygv4j70wfh5cl86yzxj";
   meta = {
     homepage = "http://code.haskell.org/~bkomuves/";
     description = "Mutable and immutable bit arrays";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    hydraPlatforms = self.stdenv.lib.platforms.none;
-    broken = true;
   };
 })


### PR DESCRIPTION
Upstream informed me that the ‘array’ problem should be fixed and it does indeed build now.
