### PR TITLE
initrd.availableKernelModules: add support for keyboards

### DIFF
--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -8,7 +8,7 @@
 {
 
   # The initrd has to contain any module that might be necessary for
-  # mounting the CD/DVD.
+  # supporting the most important parts of HW like drives.
   boot.initrd.availableKernelModules =
     [ # SATA/PATA support.
       "ahci"
@@ -43,7 +43,7 @@
       "virtio_net" "virtio_pci" "virtio_blk" "virtio_balloon" "virtio_console"
 
       # Keyboards
-      "hid_apple"
+      "usbhid" "hid_apple" "hid_logitech_dj" "hid_lenovo_tpkbd" "hid_roccat"
     ];
 
   # Include lots of firmware.

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -195,6 +195,7 @@ in
         "xhci_hcd"
         "usbhid"
         "hid_generic"
+        "hid_apple" "hid_logitech_dj" "hid_lenovo_tpkbd" "hid_roccat"
 
         # Unix domain sockets (needed by udev).
         "unix"


### PR DESCRIPTION
Meant as a replacement for #2169.

BTW, I don't really orient in the files I changed, but it seems we could factor out a common list of essential initrd modules, which would be used both by installer media and regular systems.
