### PR TITLE
Add "emulateWheel" option for trackpoint configuration

### DIFF
--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -36,6 +36,14 @@ with lib;
           configures 97.
         '';
       };
+
+      emulateWheel = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable scrolling while holding the middle mouse button.
+        '';
+      };
       
     };
 
@@ -44,17 +52,33 @@ with lib;
 
   ###### implementation
 
-  config = mkIf config.hardware.trackpoint.enable {
-
-    services.udev.extraRules =
-    ''
-      ACTION=="add|change", SUBSYSTEM=="input", ATTR{name}=="TPPS/2 IBM TrackPoint", ATTR{device/speed}="${toString config.hardware.trackpoint.speed}", ATTR{device/sensitivity}="${toString config.hardware.trackpoint.sensitivity}"
-    '';
-
-    system.activationScripts.trackpoint =
+  config = mkMerge [
+    (mkIf config.hardware.trackpoint.enable {
+      services.udev.extraRules =
       ''
-        ${config.systemd.package}/bin/udevadm trigger --attr-match=name="TPPS/2 IBM TrackPoint"
+        ACTION=="add|change", SUBSYSTEM=="input", ATTR{name}=="TPPS/2 IBM TrackPoint", ATTR{device/speed}="${toString config.hardware.trackpoint.speed}", ATTR{device/sensitivity}="${toString config.hardware.trackpoint.sensitivity}"
       '';
-  };
 
+      system.activationScripts.trackpoint =
+        ''
+          ${config.systemd.package}/bin/udevadm trigger --attr-match=name="TPPS/2 IBM TrackPoint"
+        '';
+    })
+
+    (mkIf config.hardware.trackpoint.emulateWheel {
+      services.xserver.config =
+        ''
+          Section "InputClass"
+            Identifier "Trackpoint Wheel Emulation"
+            MatchProduct "TPPS/2 IBM TrackPoint|DualPoint Stick|Synaptics Inc. Composite TouchPad / TrackPoint|ThinkPad USB Keyboard with TrackPoint|USB Trackpoint pointing device|Composite TouchPad / TrackPoint"
+            MatchDevicePath "/dev/input/event*"
+            Option "EmulateWheel" "true"
+            Option "EmulateWheelButton" "2"
+            Option "Emulate3Buttons" "false"
+            Option "XAxisMapping" "6 7"
+            Option "YAxisMapping" "4 5"
+            EndSection
+        '';
+    })
+  ];
 }


### PR DESCRIPTION
This option enables scrolling while holding the middle mouse button on a Thinkpad. I've already tested the changes on my X201s / X220  and it works fine.

The configuration comes from [ThinkWiki](http://www.thinkwiki.org/wiki/How_to_configure_the_TrackPoint#Scrolling)

Unfortunately, I couldn't find a way to activate the changes on a running system. So the user has to reboot  the machine (or restart xserver) to make the changes available. The only way to configure `emulateWheel` is through xserver configuration and this config is only read when xserver starts.
