### PR TITLE
jq: make sure libjq is in library search path

### DIFF
--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation {
   src = fetchurl {
     inherit (s) url sha256;
   };
+
+  # jq is linked to libjq:
+  configureFlags = [
+    "LDFLAGS=-Wl,-rpath,\\\${libdir}"
+  ];
   meta = {
     inherit (s) version;
     description = ''A lightweight and flexible command-line JSON processor'';


### PR DESCRIPTION
Fixes runtime error:

jq: error while loading shared libraries: libjq.so.1:
cannot open shared object file: No such file or directory
