### PR TITLE
add HaskellNet

### DIFF
--- a/pkgs/development/libraries/haskell/HaskellNet/default.nix
+++ b/pkgs/development/libraries/haskell/HaskellNet/default.nix
@@ -1,0 +1,14 @@
+{ cabal, base64String, Crypto, mimeMail, mtl, network, text }:
+
+cabal.mkDerivation (self: {
+  pname = "HaskellNet";
+  version = "0.3.1";
+  sha256 = "168w6y5rizszq1428amxbkhww65sy3b7czxpjyrzzq3dhjn517nr";
+  buildDepends = [ base64String Crypto mimeMail mtl network text ];
+  meta = {
+    homepage = "https://github.com/jtdaugherty/HaskellNet";
+    description = "Client support for POP3, SMTP, and IMAP";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1046,6 +1046,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   haskellNames = callPackage ../development/libraries/haskell/haskell-names {};
 
+  HaskellNet = callPackage ../development/libraries/haskell/HaskellNet {};
+
   haskellPackages = callPackage ../development/libraries/haskell/haskell-packages {};
 
   haskellSrc_1_0_1_3 = callPackage ../development/libraries/haskell/haskell-src/1.0.1.3.nix {};


### PR DESCRIPTION
Hi, first contribution here. I generated `pkgs/development/libraries/haskell/HaskellNet/default.nix` using `cabal2nix cabal://HaskellNet` and added a line to `pkgs/top-level/haskell-packages.nix`.

Testing using the method here also seems fine
https://nixos.org/wiki/Haskell#Maintaining_your_own_set_of_additional_Haskell_packages

 Did I miss anything?
