### PR TITLE
Enable parallel building for GCC.

### DIFF
--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -59,10 +59,7 @@ let version = "4.8.3";
     # Whether building a cross-compiler for GNU/Hurd.
     crossGNU = cross != null && cross.config == "i586-pc-gnu";
 
-  /* gccinstall.info says that "parallel make is currently not supported since
-     collisions in profile collecting may occur".
-  */
-    enableParallelBuilding = !profiledCompiler;
+    enableParallelBuilding = true;
 
     patches = []
       ++ optional enableParallelBuilding ./parallel-bconfig.patch

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -57,10 +57,7 @@ let version = "4.9.1";
     # Whether building a cross-compiler for GNU/Hurd.
     crossGNU = cross != null && cross.config == "i586-pc-gnu";
 
-  /* gccinstall.info says that "parallel make is currently not supported since
-     collisions in profile collecting may occur".
-  */
-    enableParallelBuilding = !profiledCompiler;
+    enableParallelBuilding = true;
 
     patches = [ ]
       ++ optional enableParallelBuilding ./parallel-bconfig.patch


### PR DESCRIPTION
Even if using profiledbootstrap.  This was unsafe before 4.8, and
then the documentation was not fixed on time.

The documentation got fixed here:
  https://github.com/gcc-mirror/gcc/commit/c763997f340ec1fab37ad538b57afdad4f4bf747

But the actual code was already fixed here:
  https://github.com/gcc-mirror/gcc/commit/5d2fca09d543d4b42b99fe20f412efb78cc50ec3

So this is safe both for GCC 4.8 and GCC 4.9.
