### PR TITLE
Get rid of bootstrap-tools dependency from xz (and therefore stdenv)

### DIFF
--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  # In stdenv-linux, prevent a dependency on bootstrap-tools.
+  preHook = "unset CONFIG_SHELL";
+
   meta = {
     homepage = http://tukaani.org/xz/;
     description = "XZ, general-purpose data compression software, successor of LZMA";


### PR DESCRIPTION
0769fc5b77eb76c6a794187f173c48f912fc837c broke this by setting CONFIG_SHELL.
