### PR TITLE
Update wxWidgets to: wxGTK 3.0.1

### DIFF
--- a/pkgs/development/libraries/wxGTK-3.0/default.nix
+++ b/pkgs/development/libraries/wxGTK-3.0/default.nix
@@ -8,14 +8,14 @@ assert withMesa -> mesa != null;
 with stdenv.lib;
 
 let
-  version = "3.0.0";
+  version = "3.0.1";
 in
 stdenv.mkDerivation {
   name = "wxwidgets-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/wxwindows/wxWidgets-${version}.tar.bz2";
-    sha256 = "11dz8pn1nm79i054l05rzyk4vqxw7v0x6j78pj6mvr5nphwhad7z";
+    sha256 = "1xf5s8cnq6xr0r6l0y9cn1pjg961xbycl4afhjrqzbsnxiwinrxx";
   };
 
   buildInputs =


### PR DESCRIPTION
From http://www.wxwidgets.org/:

wxWidgets 3.0.1 bug fix release is now available. Upgrading to it is strongly recommended for all users of 3.0.0 as it contains more than a hundred of important bug fixes to all ports but remains 100% compatible with 3.0.0, both at the API and the ABI level, and so upgrading to it doesn't require absolutely any changes to the existing applications.

So I hope it doesn't break anything.
