### PR TITLE
cabal.mkDerivation: Use defaultMain if no Setup.{l,}hs exists.

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -182,6 +182,12 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
               for i in Setup.hs Setup.lhs; do
                 test -f $i && ghc --make $i
               done
+              if [ ! -f Setup ]; then
+                  ghc --make ${builtins.toFile "Setup.hs" ''
+                    import Distribution.Simple
+                    main = defaultMain
+                  ''} -o Setup -odir $TMPDIR
+              fi
 
               for p in $extraBuildInputs $propagatedNativeBuildInputs; do
                 if [ -d "$p/lib/ghc-${ghc.ghc.version}/package.conf.d" ]; then


### PR DESCRIPTION
This mirrors the default behaviour of cabal-install for the Simple build type
