### PR TITLE
Make ant-build (and thus junit) produce deterministic compilation outputs

### DIFF
--- a/pkgs/build-support/release/ant-build.nix
+++ b/pkgs/build-support/release/ant-build.nix
@@ -11,6 +11,8 @@
 , ant ? pkgs.ant
 , jre ? pkgs.openjdk
 , hydraAntLogger ? pkgs.hydraAntLogger
+, zip ? pkgs.zip
+, unzip ? pkgs.unzip
 , ... } @ args:
 
 let
@@ -45,7 +47,10 @@ stdenv.mkDerivation (
          '' else stdenv.lib.concatMapStrings (j: ''
            cp -v ${j} $out/share/java
          '') jars }
+
+      . ${./functions.sh}
       for j in $out/share/java/*.jar ; do
+        canonicalizeJar $j
         echo file jar $j >> $out/nix-support/hydra-build-products
       done
     '';
@@ -95,7 +100,7 @@ stdenv.mkDerivation (
   {
     name = name + (if src ? version then "-" + src.version else "");
   
-    buildInputs = [ant jre] ++ stdenv.lib.optional (args ? buildInputs) args.buildInputs ;
+    buildInputs = [ant jre zip unzip] ++ stdenv.lib.optional (args ? buildInputs) args.buildInputs ;
 
     postHook = ''
       mkdir -p $out/nix-support

--- a/pkgs/build-support/release/functions.sh
+++ b/pkgs/build-support/release/functions.sh
@@ -8,6 +8,29 @@ findTarballs() {
     echo "$1"
 }
 
+canonicalizeJarManifest() {
+	local input=$1
+	# http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Notes_on_Manifest_and_Signature_Files
+	(head -n 1 $input && tail -n +2 $input | sort | grep -v '^\s*$') > $input-tmp
+	mv $input-tmp $input
+}
+
+# Post-process a jar file to contain canonical timestamps and metadata ordering
+canonicalizeJar() {
+	local input=$1
+	local outer=$(pwd)
+	unzip -qq $input -d $input-tmp
+	canonicalizeJarManifest $input-tmp/META-INF/MANIFEST.MF
+	# Set all timestamps to Jan 1 1980, which is the earliest date the zip format supports...
+	find $input-tmp -exec touch -t 198001010000.00 {} +
+	rm $input
+	pushd $input-tmp
+	zip -q -r -o -X $outer/tmp-out.jar . 2> /dev/null
+	popd
+	rm -rf $input-tmp
+	mv $outer/tmp-out.jar $input
+}
+
 propagateImageName() {
     mkdir -p $out/nix-support
     cat "$diskImage"/nix-support/full-name > $out/nix-support/full-name


### PR DESCRIPTION
We now canonicalize the jars it produces so that we produce byte-for-byte identical output.
