### PR TITLE
Lnxstdenv refactor

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -218,7 +218,7 @@ rec {
     };
     extraPath = [ stage3.pkgs.xz ];
     overrides = pkgs: {
-      inherit (stage3.pkgs) gettext gnum4 gmp perl glibc;
+      inherit (stage3.pkgs) gettext gnum4 gmp perl glibc zlib;
     };
   };
 
@@ -267,7 +267,7 @@ rec {
       inherit gcc;
       inherit (stage4.pkgs)
         gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
-        glibc gnumake gnused gnutar gnugrep gnupatch patchelf
+        glibc zlib gnumake gnused gnutar gnugrep gnupatch patchelf
         attr acl paxctl;
     };
   };


### PR DESCRIPTION
Refactor the pkgs/stdenv/linux/default.nix staging logic to be more easy to read and shorter.

Then I reformulated my former zlib pull request (#3584) on top of this to demonstrate that the new version is easier to change and it's easier to review changes on the new version.

This is essential, because to properly fix #3548, I'll introduce two more stages which would've made the new file even more complex and therefore the code review a hell.

Please note that the first commit doesn't changes the derivation/output hash at all, therefore we know that the refactoring is sound, then I add the zlib change in a separate commit, so the refactoring stays clean.
