### PR TITLE
Unable to compile/link on darwin

### DIFF
--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -17,7 +17,7 @@ import ../generic rec {
       export MACOSX_DEPLOYMENT_TARGET=10.6
       export SDKROOT=$(/usr/bin/xcrun --show-sdk-path 2> /dev/null || true)
       export NIX_CFLAGS_COMPILE+=" --sysroot=/var/empty -idirafter $SDKROOT/usr/include -F$SDKROOT/System/Library/Frameworks -Wno-multichar -Wno-deprecated-declarations"
-      export NIX_LDFLAGS_AFTER+=" -L$SDKROOT/usr/lib"
+      export NIX_LDFLAGS_AFTER+=" -L$SDKROOT/usr/lib -L$SDKROOT/usr/lib/system"
     '' else "");
 
   initialPath = (import ../common-path.nix) {pkgs = pkgs;};


### PR DESCRIPTION
Adding this additional path allows me to compile again on my system.

I'm running Mac OSX 10.8.5 (Mountain Lion) with Xcode 5.1.1. I've been using nix successfully for some time, and have some custom packages that `import <nixpkgs>`.  A few days ago, I did a `nix-channel --update`, and was then unable to compile anything. As far as I know, that was the only change (I'd not installed OS updates nor upgraded Xcode). The error I encountered was: 

```
ld: file not found: /usr/lib/system/libsystem_asl.dylib for architecture x86_64
```

And in fact, there is no file in that location on my system.

I set NIX_DEBUG=1, and saw that it is compiling with the SDK for 10.9 (Mavericks)

```
extra flags to /nix/store/kbl68sdzwrp2c9dipm56diaq02cngjs8-native-darwin-cctools-wrapper/bin/ld:
  -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/usr/lib
```

At first I thought that was odd since I'm on 10.8. But, I checked with a co-worker also running 10.8, and that machine can still successfully compile, is also using 10.9 SDK within nix, and **does have `/usr/lib/system/libsystem_asl.dylib`**. So I'm not sure if my system is supposed to have it and it somehow got deleted (I can't imagine how), or what.

But, inside the SDK path, I _do_ have that file, and I was able to successfully compile again by adding `$SDKROOT/usr/lib/system` to the library search path. I'm not sure this is the correct solution. I'm not all that familiar with Mac development.
