### PR TITLE
Add http mirror for postgresql.

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -275,6 +275,7 @@ rec {
   postgresql = [
     ftp://ftp.postgresql.org/pub/
     ftp://ftp-archives.postgresql.org/pub/
+    http://ftp.postgresql.org/pub/
   ];
 
   metalab = [


### PR DESCRIPTION
I sometimes work on a network that allows only http (don't ask...).
