### PR TITLE
bar - Remove unnecessary dependencies and centralize version string.

### DIFF
--- a/pkgs/applications/window-managers/bar/default.nix
+++ b/pkgs/applications/window-managers/bar/default.nix
@@ -1,23 +1,25 @@
-{ stdenv, fetchurl, git, perl, libxcb, libXinerama, xcbutil, xcbutilwm, xcbutilkeysyms }:
+{ stdenv, fetchurl, perl, libxcb }:
 
-stdenv.mkDerivation rec {
-  name = "bar-1.0";
-
+let
+  version = "1.0";
+in
+  stdenv.mkDerivation rec {
+    name = "bar-${version}";
   
-  src = fetchurl {
-    url = "https://github.com/LemonBoy/bar/archive/v1.0.tar.gz";
-    sha256 = "1n2vak2acs37sslxl250cnz9c3irif5z4s54wi9qjyxbfzr2h2nc";
-  };
-
-  buildInputs = [ libxcb git perl libXinerama xcbutil xcbutilkeysyms xcbutilwm ];
-
-  prePatch = ''sed -i "s@/usr@$out@" Makefile'';
-
-  meta = {
-    description = "A lightweight xcb based bar";
-    homepage = "https://github.com/LemonBoy/bar";
-    maintainers = stdenv.lib.maintainers.meisternu;
-    license = "Custom";   
-    platforms = stdenv.lib.platforms.linux;
-  };
+    src = fetchurl {
+      url = "https://github.com/LemonBoy/bar/archive/v${version}.tar.gz";
+      sha256 = "1n2vak2acs37sslxl250cnz9c3irif5z4s54wi9qjyxbfzr2h2nc";
+    };
+  
+    buildInputs = [ libxcb perl ];
+  
+    prePatch = ''sed -i "s@/usr@$out@" Makefile'';
+  
+    meta = {
+      description = "A lightweight xcb based bar";
+      homepage = "https://github.com/LemonBoy/bar";
+      maintainers = stdenv.lib.maintainers.meisternu;
+      license = "Custom";   
+      platforms = stdenv.lib.platforms.linux;
+    };
 }


### PR DESCRIPTION
Peti recently accepted a pull request for LemonBoy's Bar Ain't recursive from meisternu. I happened to be working on a derivation for that as well and might have some efficiencies.

@meisternu I see you pushed this derivation along with bspwm - I use herbstluftwm w/o xinerama. The changes build, link, and install cleanly but I wanted to make sure I didn't miss anything you saw.
