### PR TITLE
update mpv and add support for vaapi

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchgit, freetype, pkgconfig, freefont_ttf, ffmpeg, libass
 , lua, perl, libpthreadstubs
 , lua5_sockets
-, python3, docutils, which
+, python3, docutils, which, lib
 , x11Support ? true, libX11 ? null, libXext ? null, mesa ? null, libXxf86vm ? null
 , xineramaSupport ? true, libXinerama ? null
 , xvSupport ? true, libXv ? null
@@ -22,6 +22,7 @@
 # for Youtube support
 , quviSupport? false, libquvi ? null
 , cacaSupport? false, libcaca ? null
+, vaapiSupport? false, libva ? null
 }:
 
 assert x11Support -> (libX11 != null && libXext != null && mesa != null && libXxf86vm != null);
@@ -57,11 +58,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "mpv-${version}";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchurl {
     url = "https://github.com/mpv-player/mpv/archive/v${version}.tar.gz";
-    sha256 = "0wqjyzw3kk854zj263k7jyykzfaz1g27z50aqrd26hylg8k135cn";
+    sha256 = "17mmc6xm8yir2p379h00q3wy7rplz2s31h6sxswmzbh72xf10g96";
   };
 
   buildInputs = with stdenv.lib;
@@ -84,6 +85,7 @@ stdenv.mkDerivation rec {
     ++ optional quviSupport libquvi
     ++ optional sdl2Support SDL2
     ++ optional cacaSupport libcaca
+    ++ optional vaapiSupport libva
     ;
 
   nativeBuildInputs = [ python3 lua perl ];
@@ -97,7 +99,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configurePhase = ''
-    python3 ${waf} configure --prefix=$out
+    python3 ${waf} configure --prefix=$out ${lib.optionalString vaapiSupport "--enable-vaapi"}
     patchShebangs TOOLS
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9276,6 +9276,7 @@ let
     bs2bSupport = true;
     quviSupport = true;
     cacaSupport = true;
+    vaapiSupport = config.mpv.vaapiSupport or false;
   };
 
   mrxvt = callPackage ../applications/misc/mrxvt { };


### PR DESCRIPTION
`python3 ${waf} configure --help` should auto-detect as stated in readme of mpv, but it just thinks that most of dependencies are detected, build then just silently ignores the so called false-autodetected dependencies, therefore I added a `optionalString` with `--enable-vaapi`.

Vaapi support can be enabled by `nixpkgs.config.mpv.vaapiSupport = true;`
Tested with Intel HD Graphics 4000 on i5, the cpu usage was halved, from 10% to 5%,
I think this is first vaapi supported video player in NixOS, I tried to make it work with mplayer (vaapi support not found), mplayer-vaapi (too much work, and last commit is half a year back) and vlc and was a no-go, I compiled it .. but watching videos made me want to take a dump - lagging and color deformation.

oh yea and do not forget to use: `$ mpv --hwdec=vaapi --vo=vaapi ./some/video.mp4`
and you have to have intel graphics (or possibly amd, not tested)
