### PR TITLE
qgis: update 1.8.0 -> 2.4.0 and adding sip

### DIFF
--- a/pkgs/applications/misc/qgis/default.nix
+++ b/pkgs/applications/misc/qgis/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, gdal, cmake, qt4, flex, bison, proj, geos, x11, sqlite, gsl,
-  pyqt4, qwt, fcgi, python, libspatialindex, libspatialite }:
+  pyqt4, qwt, fcgi, python, libspatialindex, libspatialite, sip }:
 
 stdenv.mkDerivation rec {
-  name = "qgis-1.8.0";
+  name = "qgis-2.4.0";
 
-  buildInputs = [ gdal qt4 flex bison proj geos x11 sqlite gsl pyqt4 qwt
+  buildInputs = [ gdal qt4 flex bison proj geos x11 sqlite gsl pyqt4 sip qwt
     fcgi libspatialindex libspatialite ];
 
   nativeBuildInputs = [ cmake python ];
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://qgis.org/downloads/${name}.tar.bz2";
-    sha256 = "1aq32ch61bqsvh39lmrxah1fmh18cd3nqyi1l0sn6ssa3kwf82vh";
+    sha256 = "711b7d81ddff45b083a21f05c8aa5093a6a38a0ee42dfcc873234fcef1fcdd76";
+    
+
   };
 
   meta = {


### PR DESCRIPTION
Unfortunately adding sip doesn't solve the error-message:

```
Couldn't load SIP module.
Python support will be disabled.
```
