### PR TITLE
Fix for hdevtools: update patch to build with ghc 7.8.3

### DIFF
--- a/pkgs/development/tools/haskell/hdevtools/default.nix
+++ b/pkgs/development/tools/haskell/hdevtools/default.nix
@@ -2,11 +2,11 @@
 
 cabal.mkDerivation (self: {
   pname = "hdevtools";
-  version = "0.1.0.5";
+  version = "0.1.0.6-pre-github-schell-9e34f7dd";
   sha256 = "1a218m817q35f52fv6mn28sfv136i6fm2mzgdidpm24pc0585gl7";
   isLibrary = false;
   isExecutable = true;
-  patches = [ (fetchpatch { url = "https://github.com/bitc/hdevtools/pull/28.patch"; sha256 = "1rlv5zskg4ns9ba791x72gycxrr52lhy8x164q38gpq600gh5n40"; }) ];
+  patches = [ (fetchpatch { url = "https://github.com/ts468/hdevtools/pull/2.patch"; sha256 = "0sr62fr1f3cxx86vgd6a56bcjhr02if7n1scj6nbndpfsf9kzadd"; }) ];
   buildDepends = [ cmdargs ghcPaths network syb time ];
   meta = {
     homepage = "https://github.com/bitc/hdevtools/";


### PR DESCRIPTION
I've updated the patch by rebasing the PR https://github.com/bitc/hdevtools/pull/33 onto Hackage's hdevtools tarball.

@tomberek, hope that's fine with you.
