### PR TITLE
add HaskellNet-SSL

### DIFF
--- a/pkgs/development/libraries/haskell/HaskellNet-SSL/default.nix
+++ b/pkgs/development/libraries/haskell/HaskellNet-SSL/default.nix
@@ -1,0 +1,14 @@
+{ cabal, connection, dataDefault, HaskellNet, network, tls }:
+
+cabal.mkDerivation (self: {
+  pname = "HaskellNet-SSL";
+  version = "0.2.4";
+  sha256 = "0rwj69rz8i84qj6n1zd9fllp4333azfxppd7blzd486bczzkgkbb";
+  buildDepends = [ connection dataDefault HaskellNet network tls ];
+  meta = {
+    homepage = "https://github.com/dpwright/HaskellNet-SSL";
+    description = "Helpers to connect to SSL/TLS mail servers with HaskellNet";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1047,6 +1047,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   haskellNames = callPackage ../development/libraries/haskell/haskell-names {};
 
   HaskellNet = callPackage ../development/libraries/haskell/HaskellNet {};
+  HaskellNetSSL = callPackage ../development/libraries/haskell/HaskellNet-SSL {};
 
   haskellPackages = callPackage ../development/libraries/haskell/haskell-packages {};
 


### PR DESCRIPTION
Another package generated by cabal2nix. I changed the attribute name to `HaskellNetSSL` because that looks right. Let me know if it's not right.
