### PR TITLE
mailutils-minimal: A minimal mailutils, able to send email.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -68,6 +68,7 @@
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
+  nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
   ocharles = "Oliver Charles <ollie@ocharles.org.uk>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";

--- a/pkgs/tools/networking/mailutils-minimal/default.nix
+++ b/pkgs/tools/networking/mailutils-minimal/default.nix
@@ -1,0 +1,89 @@
+{ fetchurl, stdenv, gettext, gdbm, libtool, pam, readline
+, ncurses, gnutls, texinfo, gnum4, dejagnu, postfix }:
+
+/* TODO: Add GNU SASL, GNU GSSAPI, and FreeBidi.  */
+
+stdenv.mkDerivation rec {
+  name = "mailutils-minimal-2.2";
+
+  src = fetchurl {
+    url = "mirror://gnu/mailutils/mailutils-2.2.tar.bz2";
+    sha256 = "0szbqa12zqzldqyw97lxqax3ja2adis83i7brdfsxmrfw68iaf65";
+  };
+
+  configureFlags = ''
+     --without-mysql
+     --without-guile
+     --without-berkeley-db 
+     --without-tokyocabinet 
+     --without-fribidi 
+     --without-postgres 
+     --without-obdc 
+     --without-ldap 
+     --disable-virtual-domains 
+     --disable-imap 
+     --disable-pop 
+     --disable-nntp  
+     --disable-mh 
+     --disable-maildir 
+     --disable-radius
+     --disable-build-pop3d 
+     --disable-build-imap4d 
+     --disable-build-frm 
+     --disable-build-maidag 
+     --disable-build-sieve 
+     --disable-build-guimb 
+     --disable-build-messages 
+     --disable-build-movemail 
+     --disable-build-mimeview 
+     --disable-build-mh
+     --disable-virtual-domains
+     --with-path-sendmail=${postfix}/bin/sendmail
+  '';
+  
+  
+  patches = [ ./path-to-cat.patch ./no-gets.patch ];
+
+  buildInputs =
+   [ gettext gdbm libtool pam readline ncurses
+     gnutls texinfo gnum4 ]
+   ++ stdenv.lib.optional doCheck dejagnu;
+
+  # Tests fail since gcc 4.8
+  doCheck = false;
+
+  meta = {
+    description = "GNU Mailutils, with most options disabled.";
+
+    longDescription = ''
+      GNU Mailutils is a rich and powerful protocol-independent mail
+      framework.  It contains a series of useful mail libraries, clients, and
+      servers.  These are the primary mail utilities for the GNU system.  The
+      central library is capable of handling electronic mail in various
+      mailbox formats and protocols, both local and remote.  Specifically,
+      this project contains a POP3 server, an IMAP4 server, and a Sieve mail
+      filter.  It also provides a POSIX `mailx' client, and a collection of
+      other handy tools.
+
+      The GNU Mailutils libraries supply an ample set of primitives for
+      handling electronic mail in programs written in C, C++, Python or
+      Scheme.
+
+      The utilities provided by Mailutils include imap4d and pop3d mail
+      servers, mail reporting utility comsatd, general-purpose mail delivery
+      agent maidag, mail filtering program sieve, and an implementation of MH
+      message handling system.
+
+      This package is based on mailutils, but with most options disabled.
+    '';
+
+    license = [ "LGPLv3+" /* libraries */  "GPLv3+" /* tools */ ];
+
+    maintainers = [ stdenv.lib.maintainers.nathan-gs stdenv.lib.maintainers.ludo ];
+
+    homepage = http://www.gnu.org/software/mailutils/;
+
+    # Some of the dependencies fail to build on {cyg,dar}win.
+    platforms = stdenv.lib.platforms.gnu;
+  };
+}

--- a/pkgs/tools/networking/mailutils-minimal/default.nix
+++ b/pkgs/tools/networking/mailutils-minimal/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, gettext, gdbm, libtool, pam, readline
-, ncurses, gnutls, texinfo, gnum4, dejagnu }:
+, ncurses, gnutls, texinfo, gnum4, dejagnu, sendmailPath ? "/var/setuid-wrappers/sendmail" }:
 
 /* TODO: Add GNU SASL, GNU GSSAPI, and FreeBidi.  */
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
      --disable-build-mimeview 
      --disable-build-mh
      --disable-virtual-domains
-     --with-path-sendmail=/var/setuid-wrappers/sendmail
+     --with-path-sendmail=${sendmailPath}
   '';
   
   

--- a/pkgs/tools/networking/mailutils-minimal/default.nix
+++ b/pkgs/tools/networking/mailutils-minimal/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, gettext, gdbm, libtool, pam, readline
-, ncurses, gnutls, texinfo, gnum4, dejagnu, postfix }:
+, ncurses, gnutls, texinfo, gnum4, dejagnu }:
 
 /* TODO: Add GNU SASL, GNU GSSAPI, and FreeBidi.  */
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
      --disable-build-mimeview 
      --disable-build-mh
      --disable-virtual-domains
-     --with-path-sendmail=${postfix}/bin/sendmail
+     --with-path-sendmail=/var/setuid-wrappers/sendmail
   '';
   
   

--- a/pkgs/tools/networking/mailutils-minimal/no-gets.patch
+++ b/pkgs/tools/networking/mailutils-minimal/no-gets.patch
@@ -1,0 +1,14 @@
+--- a/lib/stdio.in.h
++++ b/lib/stdio.in.h
+@@ -138,8 +138,10 @@
+ /* It is very rare that the developer ever has full control of stdin,
+    so any use of gets warrants an unconditional warning.  Assume it is
+    always declared, since it is required by C89.  */
+-#undef gets
++#ifdef gets
++# undef gets
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
++#endif
+ 
+ #if @GNULIB_FOPEN@
+ # if @REPLACE_FOPEN@

--- a/pkgs/tools/networking/mailutils-minimal/path-to-cat.patch
+++ b/pkgs/tools/networking/mailutils-minimal/path-to-cat.patch
@@ -1,0 +1,13 @@
+Fix absolute path to `cat'.
+
+--- mailutils-2.2/testsuite/lib/mailutils.exp	2010-09-10 13:39:58.000000000 +0200
++++ mailutils-2.2/testsuite/lib/mailutils.exp	2010-09-10 13:40:00.000000000 +0200
+@@ -719,7 +719,7 @@ proc mu_test_file {args} {
+         set pattern [lrange $args 1 end]
+     }
+     
+-    set res [remote_spawn host "/bin/cat $filename"]
++    set res [remote_spawn host "cat $filename"]
+     if { $res < 0 || $res == "" } {
+ 	perror "Reading $filename failed."
+ 	return 1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1459,6 +1459,8 @@ let
     guile = guile_1_8;
   };
 
+  mailutils-minimal = callPackage ../tools/networking/mailutils-minimal { };
+
   mairix = callPackage ../tools/text/mairix { };
 
   makemkv = callPackage ../applications/video/makemkv { };


### PR DESCRIPTION
Note, there is a hardcoded dependency on postfix, which is probable unnecessary. It should be made configurable.
