### PR TITLE
mark ghc-heap-view/ghc-vis as broken on 7.8.3

### DIFF
--- a/pkgs/development/libraries/haskell/ghc-heap-view/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-heap-view/default.nix
@@ -8,13 +8,16 @@ cabal.mkDerivation (self: {
   sha256 = "1qi7f3phj2j63x1wd2cvk36945cxd84s12zs03hlrn49wzx2pf1n";
   buildDepends = [ binary transformers ];
   postInstall = ''
-    mkdir -p "$out/share/ghci"
+    ensureDir "$out/share/ghci"
     ln -s "$out/share/$pname-$version/ghci" "$out/share/ghci/$pname"
   '';
   meta = {
     description = "Extract the heap representation of Haskell values and thunks";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    maintainers = [ self.stdenv.lib.maintainers.andres ];
+    maintainers = with self.stdenv.lib.maintainers; [ andres ];
+    hydraPlatforms = self.stdenv.lib.platforms.none;
+    broken = self.stdenv.lib.versionOlder "7.7" self.ghc.version;
+
   };
 })

--- a/pkgs/development/libraries/haskell/ghc-vis/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-vis/default.nix
@@ -12,9 +12,8 @@ cabal.mkDerivation (self: {
     cairo deepseq fgl ghcHeapView graphviz gtk mtl svgcairo text
     transformers xdot
   ];
-  jailbreak = true;
   postInstall = ''
-    mkdir -p "$out/share/ghci"
+    ensureDir "$out/share/ghci"
     ln -s "$out/share/$pname-$version/ghci" "$out/share/ghci/$pname"
   '';
   meta = {
@@ -22,6 +21,7 @@ cabal.mkDerivation (self: {
     description = "Live visualization of data structures in GHCi";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    maintainers = [ self.stdenv.lib.maintainers.andres ];
+    maintainers = with self.stdenv.lib.maintainers; [ andres ];
+    hydraPlatforms = self.stdenv.lib.platforms.none;
   };
 })


### PR DESCRIPTION
I mark -vis broken because it depends on now-broken heap-view but I'm unsure if that's the way to proceed. If we don't do that however then we get evaluation errors about dependending on broken package.
