### PR TITLE
haskell-haskore: update to 0.2.0.4

### DIFF
--- a/pkgs/development/libraries/haskell/haskore/default.nix
+++ b/pkgs/development/libraries/haskell/haskore/default.nix
@@ -6,8 +6,8 @@
 
 cabal.mkDerivation (self: {
   pname = "haskore";
-  version = "0.2.0.3";
-  sha256 = "0vg4m2cmy1fabfnck9v22jicflb0if64h0wjvyrgpn2ykb9wwbpa";
+  version = "0.2.0.4";
+  sha256 = "0hhsiazdz44amilcwfxl0r10yxzhql83pgd21k89fmg1gkc4q46j";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [


### PR DESCRIPTION
Fixed a restrictive upper bound on `process`.
