### PR TITLE
obconf: Added obconf - A gui configuration tool for openbox

### DIFF
--- a/pkgs/tools/X11/obconf/default.nix
+++ b/pkgs/tools/X11/obconf/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pkgconfig, gtk, libglade, openbox,
+  imlib2, libstartup_notification, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "obconf-${version}";
+  version = "2.0.4";
+
+  src = fetchurl {
+    url = "http://openbox.org/dist/obconf/obconf-${version}.tar.gz";
+    sha256 = "1fanjdmd8727kk74x5404vi8v7s4kpq48l583d12fsi4xvsfb8vi";
+  };
+
+  buildInputs = [
+    pkgconfig gtk libglade openbox imlib2 libstartup_notification makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/obconf --prefix XDG_DATA_DIRS : ${openbox}/share/
+  '';
+
+  meta = {
+    description = "GUI configuration tool for openbox";
+    homepage = "http://openbox.org/wiki/ObConf";
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9391,6 +9391,10 @@ let
 
   nvpy = callPackage ../applications/editors/nvpy { };
 
+  obconf = callPackage ../tools/X11/obconf {
+    inherit (gnome) libglade;
+  };
+
   ocrad = callPackage ../applications/graphics/ocrad { };
 
   offrss = callPackage ../applications/networking/offrss { };


### PR DESCRIPTION
Obconf is a simple and stable gui configuration tool for openbox, provided by the openbox team.
