### PR TITLE
prefetch-git: output human-readable rev to stderr

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -219,7 +219,7 @@ clone_user_rev() {
 
     local full_revision=$(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/fetchgit) | tail -n1)
     echo "git revision is $full_revision"
-    echo "git human-readable version is $(cd $dir && (git describe $full_revision 2> /dev/null || git describe --tags $full_revision 2> /dev/null || echo -- none --))"
+    echo "git human-readable version is $(cd $dir && (git describe $full_revision 2> /dev/null || git describe --tags $full_revision 2> /dev/null || echo -- none --))" >&2
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"


### PR DESCRIPTION
That way, the stdout stays compatible with nix-prefetch-{bzr,svn,hg} and it's easier to write scripts that work for all fetchers without special casing. 

If stderr is not the right place for this kind of information, we could also use an environment variable to control output of the human readable rev. 

Another possible implementation could either be to make the human-readable the default (if available, otherwise fallback to rev) or to extend the other scripts to also include human-readable versions. 
