### PR TITLE
gcc-wrapper: Correctly handle response files.

### DIFF
--- a/pkgs/build-support/gcc-wrapper/builder.sh
+++ b/pkgs/build-support/gcc-wrapper/builder.sh
@@ -72,6 +72,13 @@ else
     else
       ldPath="$binutils/bin"
     fi;
+
+    if test -n "$expandResponseFiles"; then
+        $gccPath/gcc -Wall $(< "$out/nix-support/libc-cflags") \
+            $expandResponseFiles \
+            -I $gcc/lib/*/*/*/plugin/include -liberty \
+            -o $out/nix-support/expand-response-files
+    fi
 fi
 
 

--- a/pkgs/build-support/gcc-wrapper/builder.sh
+++ b/pkgs/build-support/gcc-wrapper/builder.sh
@@ -210,7 +210,7 @@ doSubstitute "$addFlags" "$out/nix-support/add-flags.sh"
 
 doSubstitute "$setupHook" "$out/nix-support/setup-hook"
 
-cp -p $utils $out/nix-support/utils.sh
+doSubstitute "$utils" "$out/nix-support/utils.sh"
 
 
 # Propagate the wrapped gcc so that if you install the wrapper, you get

--- a/pkgs/build-support/gcc-wrapper/default.nix
+++ b/pkgs/build-support/gcc-wrapper/default.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation {
   utils = ./utils.sh;
   addFlags = ./add-flags;
 
+  expandResponseFiles =
+    if builtins.compareVersions gccVersion "4.0.0" == 1
+    then ./expand-response-files.c
+    else null;
+
   inherit nativeTools nativeLibc nativePrefix gcc;
   libc = if nativeLibc then null else libc;
   binutils = if nativeTools then null else binutils;

--- a/pkgs/build-support/gcc-wrapper/expand-response-files.c
+++ b/pkgs/build-support/gcc-wrapper/expand-response-files.c
@@ -1,0 +1,40 @@
+/* This is a small helper to recursively expand GCC response files and return
+ * them as a BASH array called $params.
+ *
+ * See https://gcc.gnu.org/wiki/Response_Files for more information about it.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <libiberty.h>
+
+int main(int argc, char **argv)
+{
+    int i, j;
+    const char *arg;
+    size_t arglen;
+
+    expandargv(&argc, &argv);
+
+    fputs("params=(", stdout);
+
+    for (i = 1; i < argc; ++i) {
+        arg = argv[i];
+        arglen = strlen(argv[i]);
+
+        fputs(" '", stdout);
+        for (j = 0; j < arglen; ++j) {
+            if (arg[j] == '\'')
+                fputs("'\\''", stdout);
+            else
+                putchar(arg[j]);
+        };
+        putchar('\'');
+    }
+
+    puts(" )\n");
+
+    return 0;
+}

--- a/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
@@ -142,9 +142,9 @@ fi
 # `-B' flags, since they confuse some programs.  Deep bash magic to
 # apply grep to stderr (by swapping stdin/stderr twice).
 if test -z "$NIX_GCC_NEEDS_GREP"; then
-    @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]}
+    runWithExpandedArgs @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]}
 else
-    (@gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]} 3>&2 2>&1 1>&3- \
+    (runWithExpandedArgs @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]} 3>&2 2>&1 1>&3- \
         | (grep -v 'file path prefix' || true); exit ${PIPESTATUS[0]}) 3>&2 2>&1 1>&3-
     exit $?
 fi    

--- a/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
@@ -141,9 +141,9 @@ fi
 # `-B' flags, since they confuse some programs.  Deep bash magic to
 # apply grep to stderr (by swapping stdin/stderr twice).
 if test -z "$NIX_GCC_NEEDS_GREP"; then
-    runWithExpandedArgs @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]}
+    runWithUnexpandedArgs @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]}
 else
-    (runWithExpandedArgs @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]} 3>&2 2>&1 1>&3- \
+    (runWithUnexpandedArgs @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]} 3>&2 2>&1 1>&3- \
         | (grep -v 'file path prefix' || true); exit ${PIPESTATUS[0]}) 3>&2 2>&1 1>&3-
     exit $?
 fi    

--- a/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
@@ -17,7 +17,8 @@ dontLink=0
 getVersion=0
 nonFlagArgs=0
 
-for i in "$@"; do
+params=("$@")
+for i in "${params[@]}"; do
     if test "$i" = "-c"; then
         dontLink=1
     elif test "$i" = "-S"; then
@@ -54,7 +55,6 @@ fi
 
 
 # Optionally filter out paths not refering to the store.
-params=("$@")
 if test "$NIX_ENFORCE_PURITY" = "1" -a -n "$NIX_STORE"; then
     rest=()
     n=0

--- a/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
@@ -17,7 +17,9 @@ dontLink=0
 getVersion=0
 nonFlagArgs=0
 
-params=("$@")
+argsExpanded=1
+expandResponseFileArgs "$@" || argsExpanded=0
+
 for i in "${params[@]}"; do
     if test "$i" = "-c"; then
         dontLink=1

--- a/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
@@ -17,8 +17,7 @@ dontLink=0
 getVersion=0
 nonFlagArgs=0
 
-argsExpanded=1
-expandResponseFileArgs "$@" || argsExpanded=0
+expandResponseFileArgs "$@"
 
 for i in "${params[@]}"; do
     if test "$i" = "-c"; then

--- a/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
@@ -163,5 +163,5 @@ if test -n "$NIX_LD_WRAPPER_EXEC_HOOK"; then
     source "$NIX_LD_WRAPPER_EXEC_HOOK"
 fi
 
-runWithExpandedArgs @ld@ ${extraBefore[@]} "${params[@]}" ${extra[@]}
+runWithUnexpandedArgs @ld@ ${extraBefore[@]} "${params[@]}" ${extra[@]}
 exit $?

--- a/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
@@ -10,9 +10,10 @@ fi
 
 source @out@/nix-support/utils.sh
 
+argsExpanded=1
+expandResponseFileArgs "$@" || argsExpanded=0
 
 # Optionally filter out paths not refering to the store.
-params=("$@")
 if test "$NIX_ENFORCE_PURITY" = "1" -a -n "$NIX_STORE" \
         -a \( -z "$NIX_IGNORE_LD_THROUGH_GCC" -o -z "$NIX_LDFLAGS_SET" \); then
     rest=()

--- a/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
@@ -164,4 +164,5 @@ if test -n "$NIX_LD_WRAPPER_EXEC_HOOK"; then
     source "$NIX_LD_WRAPPER_EXEC_HOOK"
 fi
 
-exec @ld@ ${extraBefore[@]} "${params[@]}" ${extra[@]}
+runWithExpandedArgs @ld@ ${extraBefore[@]} "${params[@]}" ${extra[@]}
+exit $?

--- a/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
@@ -10,8 +10,7 @@ fi
 
 source @out@/nix-support/utils.sh
 
-argsExpanded=1
-expandResponseFileArgs "$@" || argsExpanded=0
+expandResponseFileArgs "$@"
 
 # Optionally filter out paths not refering to the store.
 if test "$NIX_ENFORCE_PURITY" = "1" -a -n "$NIX_STORE" \

--- a/pkgs/build-support/gcc-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-wrapper/utils.sh
@@ -71,7 +71,7 @@ escapeResponseFileArg() {
 # NOTE: This uses the global $responseFileArgsExpanded set by the function
 # expandResponseFileArgs() to determine if it's really necessary to create a
 # temporary response file.
-runWithExpandedArgs() {
+runWithUnexpandedArgs() {
     local program="$1"
     shift
     if test $responseFileArgsExpanded -eq 1 &&

--- a/pkgs/build-support/gcc-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-wrapper/utils.sh
@@ -22,3 +22,22 @@ badPath() {
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"
 }
+
+
+# Iterates through the passed array, looking for @file arguments and return a
+# new array containing the arguments from @file if the file exists.
+#
+# NOTE: This function has a side-effect of writing to the $params array, and
+# returns 0 if expansion was needed and 1 if it wasn't necessary.
+expandResponseFileArgs() {
+    if test -e "@out@/nix-support/expand-response-files"; then
+        for arg in "$@"; do
+            if test "${arg:0:1}" = "@" -a -e "${arg:1}"; then
+                eval "$("@out@/nix-support/expand-response-files" "$@")"
+                return 0
+            fi
+        done
+    fi
+    params=("$@")
+    return 1
+}


### PR DESCRIPTION
This implements handling of so-called [response files](https://gcc.gnu.org/wiki/Response_Files) (available since GCC 4), which allow arguments to be put in a file and the file will be passed back to `gcc` (and other utilities, such as `ld`) via the `@response_file` syntax.

The tricky parts here are that the response files can be nested arbitrarily and have it's own escaping rules (which I'm handling by using [expandargv()](https://gcc.gnu.org/onlinedocs/libiberty/Functions.html#index-expandargv-73) from `libiberty`) and the handling of maximum commandline arguments, so we can't simply expand all args from all response files but have to create a temporary response file.

Cc: @edolstra for review.
Of course, this is meant for the staging branch to see how much I broke with this X-D
