### PR TITLE
nvidia-x11 updated to 340.32

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "340.24";
+  versionNumber = "340.32";
 
 in
 
@@ -25,12 +25,12 @@ stdenv.mkDerivation {
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "0c5iix6rihbx7mbfhznz0jjbc3kkccwyfxi56p76fvrbyan9dvam";
+        sha256 = "1xcm8czz4bmnlzkl3al58flw6jmbrg1y77cxjjdjqcsvbk1qj10x";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "04yy26722fjf9k7y6r909g68nqnsglfd9xs1dk1nain1021p70iq";
+        sha256 = "1nfrpx73817y1z0wkqqh02xjg65r0f05h9801mqm8ki2gxqv9vq0";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 


### PR DESCRIPTION
implements feature request #3634

X11 works perfectly fine on my x86_64 Linux box after using this driver, however I'd like to hear feedback from Fuuzetsu before merging, because according to https://github.com/NixOS/nixpkgs/issues/3634 he tried to do this and X11 stopped working.
