### PR TITLE
Add parallel functional compiler, Manticore

### DIFF
--- a/pkgs/development/compilers/manticore/builder.sh
+++ b/pkgs/development/compilers/manticore/builder.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+source $stdenv/setup
+echo "Building Manticore research compiler."
+set -xe
+
+PATH=$smlnj/bin:$PATH
+
+mkdir -p $out/bin
+
+# Manticore seems to use the MLB files from the build tree,
+# so for now we copy the whole build tree into the store:
+cd $out/
+tar xf $src
+mv manticore* repo_checkout
+cd repo_checkout/
+# TODO: At the very least, this could probably be cut down to a subset
+# of the repo.
+
+${autoconf}/bin/autoheader -Iconfig
+${autoconf}/bin/autoconf -Iconfig
+./configure --prefix=$out
+make build -j
+make install

--- a/pkgs/development/compilers/manticore/default.nix
+++ b/pkgs/development/compilers/manticore/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   inherit stdenv coreutils autoconf automake smlnj;
 
   meta = {
-    description = "Manticore: a parallel, pure variant of Standard ML";
+    description = "a parallel, pure variant of Standard ML";
 
     longDescription = '' 
       Manticore is a high-level parallel programming language aimed at

--- a/pkgs/development/compilers/manticore/default.nix
+++ b/pkgs/development/compilers/manticore/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, coreutils, autoconf, automake, smlnj }:
+
+stdenv.mkDerivation rec {
+  name = "manticore-${version}";
+  version = "2014.08.18";
+  builder = ./builder.sh;
+  src = fetchurl {
+    url = https://github.com/rrnewton/manticore_temp_mirror/archive/snapshot-20140818.tar.gz; 
+    sha256 = "1x52xpj5gbcpqjqm6aw6ssn901f353zypj3d5scm8i3ad777y29d";
+  };
+  inherit stdenv coreutils autoconf automake smlnj;
+
+  meta = {
+    description = "Manticore: a parallel, pure variant of Standard ML";
+
+    longDescription = '' 
+      Manticore is a high-level parallel programming language aimed at
+      general-purpose applications running on multi-core
+      processors. Manticore supports parallelism at multiple levels:
+      explicit concurrency and coarse-grain parallelism via CML-style
+      constructs and fine-grain parallelism via various light-weight
+      notations, such as parallel tuple expressions and NESL/Nepal-style
+      parallel array comprehensions.  
+    '';
+
+    homepage = http://manticore.cs.uchicago.edu/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3122,6 +3122,8 @@ let
   });
   llvmPackagesSelf = import ../development/compilers/llvm/3.4 { inherit newScope fetchurl; isl = isl_0_12; stdenv = libcxxStdenv; };
 
+  manticore = callPackage ../development/compilers/manticore { };
+
   mentorToolchains = recurseIntoAttrs (
     callPackage_i686 ../development/compilers/mentor {}
   );


### PR DESCRIPTION
The Manticore project is described [here](http://manticore.cs.uchicago.edu/).  The compiler packaged here implements a strict, pure, parallel functional programming language.

This is my first NixPkg patch, so if there are extra testing criteria, please let me know.
