### PR TITLE
Bump ghc-head to latest.

### DIFF
--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ghc, perl, gmp, ncurses, happy, alex }:
 
 stdenv.mkDerivation rec {
-  version = "7.9.20140608";
+  version = "7.9.20140814";
   name = "ghc-${version}";
 
   src = fetchurl {
-    url = "http://deb.haskell.org/dailies/2014-06-08/ghc_${version}.orig.tar.bz2";
-    sha256 = "0x3hgh4zfns2m6bbq9xwwlafav0a29azl0xh8549za256clz97w1";
+    url = "http://deb.haskell.org/dailies/2014-08-14/ghc_${version}.orig.tar.bz2";
+    sha256 = "05vmlbzbfv72z570xmlh8n003z9xc4l5hixjqvczyyyisdvmyaa3";
   };
 
   buildInputs = [ ghc perl gmp ncurses happy alex ];


### PR DESCRIPTION
This is just a small bump forward for GHC head.

Motivation: Johan Tibell added several new primps for atomic memory operations.  Having a nix pkg for a build of GHC including these will make it easier to get these changes to people to test/benchmark them.
