### PR TITLE
gdb: Update to 7.8 and include Guile support.

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, ncurses, readline, gmp, mpfr, expat, texinfo
-, dejagnu, python, target ? null
+, dejagnu, python, pkgconfig, guile, target ? null
 
 # Additional dependencies for GNU/Hurd.
 , mig ? null, hurd ? null
@@ -8,7 +8,7 @@
 
 let
 
-  basename = "gdb-7.7";
+  basename = "gdb-7.8";
 
   # Whether (cross-)building for GNU/Hurd.  This is an approximation since
   # having `stdenv ? cross' doesn't tell us if we're building `crossDrv' and
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
       ("-" + target.config);
 
   src = fetchurl {
-    url = "mirror://gnu/gdb/${basename}.tar.bz2";
-    sha256 = "08vcb97j1b7vxwq6088wb6s3g3bm8iwikd922y0xsgbbxv3d2104";
+    url = "mirror://gnu/gdb/${basename}.tar.xz";
+    sha256 = "49c4abe174f79f54e1f9e75210ffb590d9b497d5b5200b5398c0e073a4ecb875";
   };
 
   patches = [ ./edit-signals.patch ];
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ texinfo python ]
     ++ stdenv.lib.optional isGNU mig;
 
-  buildInputs = [ ncurses readline gmp mpfr expat ]
+  buildInputs = [ ncurses readline gmp mpfr expat pkgconfig guile ]
     ++ stdenv.lib.optional isGNU hurd
     ++ stdenv.lib.optional doCheck dejagnu;
 


### PR DESCRIPTION
GDB 7.8 adds Guile scripting support.  This is now enabled by default as
well.  Checking for guile also adds a pkg-config dependency.

It seems Python is explicitly excluded from cross building.  I'm not
sure if Guile should also be excluded.
