### PR TITLE
Add security.firejail

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -67,6 +67,7 @@
   ./security/apparmor-suid.nix
   ./security/ca.nix
   ./security/duosec.nix
+  ./security/firejail.nix
   ./security/grsecurity.nix
   ./security/pam.nix
   ./security/pam_usb.nix

--- a/nixos/modules/security/firejail.nix
+++ b/nixos/modules/security/firejail.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.security.firejail;
+in
+{
+  options = {
+    security.firejail = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable firejail support, a lightweight solution for running
+          untrusted applications in a restricted environment.
+
+          This option will install the firejail program along with a
+          setuid wrapper which permits use by non-privileged users.
+        '';
+      };
+    };
+  };
+
+  config = {
+     environment.systemPackages = [ pkgs.firejail ];
+     security.setuidPrograms    = [ "firejail" ];
+  };
+}


### PR DESCRIPTION
firejail requires a setuid wrapper to permit use by non-privileged users.
This patch adds a module whose sole purpose is to install such a wrapper.

This fixes #3691 though I am uncertain whether it is actually the correct thing to do
in these cases.
