### PR TITLE
Add colord-kde.

### DIFF
--- a/pkgs/tools/misc/colord-kde/default.nix
+++ b/pkgs/tools/misc/colord-kde/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, cmake, colord, libX11, libXrandr, lcms2, pkgconfig, kdelibs}:
+
+stdenv.mkDerivation {
+  name = "colord-kde-0.3.0";
+
+  src = fetchurl {
+    url = http://download.kde.org/stable/colord-kde/0.3.0/src/colord-kde-0.3.0.tar.bz2;
+    sha256 = "ab3cdb7c8c98aa2ee8de32a92f87770e1fbd58eade6471f3f24d932b50b4cf09";
+  };
+
+  buildInputs = [ cmake colord libX11 libXrandr lcms2 pkgconfig kdelibs ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A colord front-end for KDE";
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10620,6 +10620,8 @@ let
 
       calligra = callPackage ../applications/office/calligra { };
 
+      colord-kde = callPackage ../tools/misc/colord-kde { };
+
       digikam = if builtins.compareVersions "4.9" kde4.release == 1 then
           callPackage ../applications/graphics/digikam/2.nix { }
         else


### PR DESCRIPTION
A KDE front-end for colord.

Maybe instead of `kde4.colord-kde` it should be called `kde4.colord`.  But this could lead to confusions with `colord`. Alternative names like `kde4.colord-config` could lead to confusion what this actually is.
