### PR TITLE
new package: cmst - qt gui for connman

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -77,7 +77,7 @@ in {
     services.gnome3.tracker.enable = mkDefault true;
     hardware.pulseaudio.enable = mkDefault true;
     services.telepathy.enable = mkDefault true;
-    networking.networkmanager.enable = true;
+    networking.networkmanager.enable = mkDefault true;
     services.upower.enable = config.powerManagement.enable;
     services.upower.package = gnome3.upower;
 

--- a/pkgs/tools/networking/cmst/default.nix
+++ b/pkgs/tools/networking/cmst/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchgit, qt5, makeWrapper, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "cmst-2014.08.23";
+  rev = "refs/tags/${name}";
+  src = fetchgit {
+    url = "git://github.com/andrew-bibb/cmst.git";
+    inherit rev;
+    sha256 = "07g5i929jxlh6vm0ad8x33qmf2sryiichlv37x7fpn20h3xcsia0";
+  };
+
+  buildInputs = [ qt5 makeWrapper ];
+
+  configurePhase = ''
+    substituteInPlace ./cmst.pro \
+      --replace "/usr/bin" "$out/bin" \
+      --replace "/usr/share" "$out/usr/share"
+  '';
+
+  buildPhase = ''
+    qmake PREFIX=$out
+    make
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/cmst \
+      --prefix "QTCOMPOSE" ":" "${libX11}/share/X11/locale"
+  '';
+
+  meta = {
+    description = "QT GUI for Connman with system tray icon";
+    homepage = "https://github.com/andrew-bibb/cmst";
+    maintainers = [ stdenv.lib.maintainers.matejc ];
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -776,6 +776,8 @@ let
 
   ciopfs = callPackage ../tools/filesystems/ciopfs { };
 
+  cmst = callPackage ../tools/networking/cmst { };
+
   colord = callPackage ../tools/misc/colord { };
 
   colord-gtk = callPackage ../tools/misc/colord-gtk { };


### PR DESCRIPTION
- make network manager in gnome3 as default option, so it can be disabled normally when using `networking.connman.enable = true;`
- new package: graphical (qt) user interface - cmst for managing connman, the most configurable UI I could find at this time
