### PR TITLE
use mkDefault on root's shell

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -404,7 +404,7 @@ in {
         uid = ids.uids.root;
         description = "System administrator";
         home = "/root";
-        shell = cfg.defaultUserShell;
+        shell = mkDefault cfg.defaultUserShell;
         group = "root";
         extraGroups = [ "grsecurity" ];
         hashedPassword = mkDefault config.security.initialRootPassword;


### PR DESCRIPTION
This fix makes sure that root's shell can be overridden without mkForce.
Would this make sense? By that I mean, what would break?
also this fixes #3688
