### PR TITLE
Add pyuv.

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -100,4 +100,5 @@ in
     v0_11_24 = "1hygn81iwbdshzrq603qm6k1r7pjflx9qqazmlb72c3vy1hq21c6";
     v0_11_25 = "1abszivlxf0sddwvcj3jywfsip5q9vz6axvn40qqyl8sjs80zcvj";
     v0_11_26 = "1pfjdwrxhqz1vqcdm42g3j45ghrb4yl7wsngvraclhgqicff1sc3";
+    v0_11_29 = "1z07phfwryfy2155p3lxcm2a33h20sfl96lds5dghn157x6csz7m";
   }

--- a/pkgs/development/python-modules/pyuv-external-libuv.patch
+++ b/pkgs/development/python-modules/pyuv-external-libuv.patch
@@ -1,0 +1,27 @@
+diff --git a/setup.py b/setup.py
+index ec0caac..2c1fdb6 100644
+--- a/setup.py
++++ b/setup.py
+@@ -6,7 +6,6 @@ try:
+     from setuptools import setup, Extension
+ except ImportError:
+     from distutils.core import setup, Extension
+-from setup_libuv import libuv_build_ext, libuv_sdist
+ 
+ 
+ __version__ = "0.11.5"
+@@ -32,12 +31,11 @@ setup(name             = "pyuv",
+           "Programming Language :: Python :: 3.3",
+           "Programming Language :: Python :: 3.4"
+       ],
+-      cmdclass     = {'build_ext': libuv_build_ext,
+-                      'sdist'    : libuv_sdist},
+       ext_modules  = [Extension('pyuv',
+                                 sources = ['src/pyuv.c'],
++                                libraries = ['uv'],
+                                 define_macros=[('MODULE_VERSION', __version__),
+-                                               ('LIBUV_REVISION', libuv_build_ext.libuv_revision)]
++                                               ('LIBUV_REVISION', 'unknown')]
+                      )]
+      )
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8248,6 +8248,26 @@ rec {
     };
   });
 
+  pyuv = buildPythonPackage rec {
+    name = "pyuv-0.11.5";
+
+    src = fetchurl {
+      url = "https://github.com/saghul/pyuv/archive/${name}.tar.gz";
+      sha256 = "c251952cb4e54c92ab0e871decd13cf73d11ca5dba9f92962de51d12e3a310a9";
+    };
+
+    patches = [ ../development/python-modules/pyuv-external-libuv.patch ];
+
+    buildInputs = [ pkgs.libuvVersions.v0_11_29 ];
+
+    meta = {
+      description = "Python interface for libuv";
+      homepage = https://github.com/saghul/pyuv;
+      repositories.git = git://github.com/saghul/pyuv.git;
+      license = licenses.mit;
+    };
+  };
+
   virtualenv = buildPythonPackage rec {
     name = "virtualenv-1.11.6";
     src = fetchurl {


### PR DESCRIPTION
Pyuv is a Python interface to libuv, a cross-platform asychronous I/O library.

This also adds the latest version of libuv, because pyuv requires the recently added uv_udp_try_send() function.

The setup.py is tweaked to that the system version of libuv is used, instead of tying to fetch one with git.
