### PR TITLE
Add Linux Stopmotion application

### DIFF
--- a/pkgs/applications/video/linuxstopmotion/default.nix
+++ b/pkgs/applications/video/linuxstopmotion/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchgit, pkgconfig, qt4, SDL, SDL_image, libvorbis, libtar, libxml2
+, gamin
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.8";
+  name = "linuxstopmotion-${version}";
+  
+  src = fetchgit {
+    url = "git://git.code.sf.net/p/linuxstopmotion/code";
+    rev = "refs/tags/${version}";
+    sha256 = "1xkkrhllgy2d7k0vrdj794ya7y3g3n7xh8c2qgnb26yrarz79dqj";
+  };
+
+  buildInputs = [ pkgconfig qt4 SDL SDL_image libvorbis libtar libxml2 gamin ];
+
+  patches = [ ./linuxstopmotion-fix-wrong-isProcess-logic.patch ];
+
+  configurePhase = ''
+    qmake PREFIX="$out"
+  '';
+
+  # Installation breaks without this
+  preInstall = ''
+    mkdir -p "$out/share/stopmotion/translations/"
+    cp -v build/*.qm "$out/share/stopmotion/translations/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Create stop-motion animation movies";
+    homepage = http://linuxstopmotion.org/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/applications/video/linuxstopmotion/linuxstopmotion-fix-wrong-isProcess-logic.patch
+++ b/pkgs/applications/video/linuxstopmotion/linuxstopmotion-fix-wrong-isProcess-logic.patch
@@ -1,0 +1,33 @@
+From b23b7dab1d540b0710fcb9ded1c6256a49844906 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B8rn=20Forsman?= <bjorn.forsman@gmail.com>
+Date: Wed, 20 Aug 2014 22:22:00 +0200
+Subject: [PATCH] Fix wrong "isProcess" logic
+
+Stopmotion wrongly thinks that uvccapture should be run as a daemon,
+even though configuration for uvccapture has no "daemon-like" command
+line to be run (according to "preferences"). The result is an error
+popup instead of video/image grabbing.
+
+This brings back the "isProcess" logic that was in stopmotion v0.7.2,
+because it seems to work, while the current logic (v0.8.0) seems to
+fail.
+---
+ src/presentation/frontends/qtfrontend/frameview.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/presentation/frontends/qtfrontend/frameview.cpp b/src/presentation/frontends/qtfrontend/frameview.cpp
+index e44dca7..d2c41fd 100644
+--- a/src/presentation/frontends/qtfrontend/frameview.cpp
++++ b/src/presentation/frontends/qtfrontend/frameview.cpp
+@@ -270,7 +270,7 @@ bool FrameView::on() {
+ 	Preference device(QString("device%1")
+ 			.arg(activeDev).toLatin1().constData(), "");
+ 	QString pre = QString(prepoll.get()).replace("$VIDEODEVICE", device.get());
+-	bool isProcess = startDaemon.get();
++	bool isProcess = (strcmp(startDaemon.get(), "") == 0) ? false : true;
+ 
+ 	bool isCameraReady = true;
+ 	this->grabber = new CommandLineGrabber(capturedFile.path(), isProcess);
+-- 
+2.0.2
+

--- a/pkgs/applications/video/uvccapture/default.nix
+++ b/pkgs/applications/video/uvccapture/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, libjpeg }:
+
+let
+  debianPatches = fetchurl {
+    url = "mirror://debian/pool/main/u/uvccapture/uvccapture_0.5-3.debian.tar.gz";
+    sha256 = "0m29by13nw1r8sch366qzdxg5rsd1k766kqg1nj2pdb8f7pwjh9r";
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "uvccapture-0.5";
+  
+  src = fetchurl {
+    url = "mirror://debian/pool/main/u/uvccapture/uvccapture_0.5.orig.tar.gz";
+    sha256 = "1b3akkcmr3brbf93akr8xi20w8zqf2g0qfq928500wy04qi6jqpi";
+  };
+
+  buildInputs = [ libjpeg ];
+
+  patchPhase = ''
+    tar xvf "${debianPatches}"
+    for fname in debian/patches/fix_videodev_include_FTBFS.patch \
+                 debian/patches/warnings.patch \
+                 debian/patches/numbuffers.patch
+    do
+        echo "Applying patch $fname"
+        patch < "$fname"
+    done
+  '';
+
+  makeFlagsArray = [ "PREFIX=$(out)/bin/" ];
+
+  preInstall = ''
+    mkdir -p "$out/bin"
+  '';
+
+  # Upstream has no man page, install one from Debian
+  postInstall = ''
+    mkdir -p "$out/share/man/man1"
+    cp -v debian/uvccapture.1 "$out/share/man/man1/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Capture image from USB webcam at a specified interval";
+    homepage = http://linux-uvc.berlios.de/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/development/libraries/libtar/default.nix
+++ b/pkgs/development/libraries/libtar/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.20";
+  name = "libtar-${version}";
+  
+  # Maintenance repo for libtar (Arch Linux uses this)
+  src = fetchgit {
+    url = "git://repo.or.cz/libtar.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "1pjsqnqjaqgkzf1j8m6y5h76bwprffsjjj6gk8rh2fjsha14rqn9";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    description = "C library for manipulating POSIX tar files";
+    homepage = http://www.feep.net/libtar/;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9630,6 +9630,8 @@ let
     conf = config.st.conf or null;
   };
 
+  linuxstopmotion = callPackage ../applications/video/linuxstopmotion { };
+
   sweethome3d = recurseIntoAttrs (  (callPackage ../applications/misc/sweethome3d { })
                                  // (callPackage ../applications/misc/sweethome3d/editors.nix {
                                       sweethome3dApp = sweethome3d.application;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9847,6 +9847,8 @@ let
 
   uucp = callPackage ../tools/misc/uucp { };
 
+  uvccapture = callPackage ../applications/video/uvccapture { };
+
   uwimap = callPackage ../tools/networking/uwimap { };
 
   uzbl = callPackage ../applications/networking/browsers/uzbl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5502,6 +5502,8 @@ let
 
   libspatialite = callPackage ../development/libraries/libspatialite { };
 
+  libtar = callPackage ../development/libraries/libtar { };
+
   libtasn1 = callPackage ../development/libraries/libtasn1 { };
 
   libtheora = callPackage ../development/libraries/libtheora { };


### PR DESCRIPTION
Add the Linux Stopmotion application (for creating stop-motion animation movies) and its dependencies.

I had to add a (tiny) patch to make stopmotion work (with uvccapture). Latest Ubuntu (14.04) has stopmotion v0.7.2 which doesn't need the patch, but Arch Linux has v0.8.0 but no patch(!). I'm guessing their version don't work with uvccapture, but I haven't verified it yet.
