### PR TITLE
Install libnvidia-glsi, this fixes firefox and chromium for nvidia-x11

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -34,7 +34,7 @@ installPhase() {
     mkdir -p $out/lib/vendors
 
     for f in \
-      libcuda libGL libnvcuvid libnvidia-cfg libnvidia-compiler \
+      libcuda libGL libnvcuvid libnvidia-cfg libnvidia-compiler libnvidia-glsi \
       libnvidia-encode libnvidia-glcore libnvidia-ml libnvidia-opencl \
       libnvidia-tls libOpenCL libnvidia-tls libvdpau_nvidia libEGL libGLESv2
     do


### PR DESCRIPTION
This was broken because of the interaction between 2015aecd44919666377af1f15a36b402624e7f76
and 477eb18d18843d91c2004f72d5377c7a5edac941, apparently the new nvidia driver needs libnvidia-glsi
