### PR TITLE
Fixing mit-scheme build on linux

### DIFF
--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -29,6 +29,9 @@ stdenv.mkDerivation {
       sha256 = "0pclakzwxbqgy6wqwvs6ml62wgby8ba8xzmwzdwhx1v8wv05yw1j";
     };
 
+  # http://savannah.gnu.org/bugs/?38845
+  patches = [ ./make-doc-make.patch ];
+
   configurePhase =
     '' (cd src && ./configure)
        (cd doc && ./configure)
@@ -84,8 +87,7 @@ stdenv.mkDerivation {
 
     # Build fails on Cygwin and Darwin:
     # <http://article.gmane.org/gmane.lisp.scheme.mit-scheme.devel/489>.
-    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.freebsd;
-
-    broken = true;
+    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.freebsd
+      ++ stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/compilers/mit-scheme/make-doc-make.patch
+++ b/pkgs/development/compilers/mit-scheme/make-doc-make.patch
@@ -1,0 +1,61 @@
+diff --git a/doc/ffi/ffi.texinfo b/doc/ffi/ffi.texinfo
+index da6c87e..066501a 100644
+--- a/doc/ffi/ffi.texinfo
++++ b/doc/ffi/ffi.texinfo
+@@ -6,13 +6,13 @@
+ @settitle FFI @value{VERSION}
+ @comment %**end of header
+ 
+-@macro myresult{}
+ @ifhtml
++@macro myresult{}
+  =>
++@end macro
+ @end ifhtml
+ @ifnothtml
+- @result{}
++@alias myresult = result
+ @end ifnothtml
+-@end macro
+ 
+ @copying
+ This manual documents @acronym{FFI} @value{VERSION}.
+diff --git a/doc/imail/imail.texinfo b/doc/imail/imail.texinfo
+index 11088b1..1059401 100644
+--- a/doc/imail/imail.texinfo
++++ b/doc/imail/imail.texinfo
+@@ -36,7 +36,7 @@ Documentation License.''
+ @end direntry
+ 
+ @titlepage
+-@title{IMAIL User's Manual}
++@title IMAIL User's Manual
+ @subtitle Edition @value{EDITION} for IMAIL @value{VERSION}
+ @subtitle @value{UPDATED}
+ @author by Chris Hanson
+diff --git a/doc/ref-manual/scheme.texinfo b/doc/ref-manual/scheme.texinfo
+index 864d708..ccfb7cb 100644
+--- a/doc/ref-manual/scheme.texinfo
++++ b/doc/ref-manual/scheme.texinfo
+@@ -44,7 +44,7 @@ Documentation License.''
+ @end direntry
+ 
+ @titlepage
+-@title{MIT/GNU Scheme Reference Manual}
++@title MIT/GNU Scheme Reference Manual
+ @subtitle Edition @value{EDITION} for release @value{VERSION}
+ @subtitle @value{UPDATED}
+ @author by Chris Hanson
+diff --git a/doc/user-manual/user.texinfo b/doc/user-manual/user.texinfo
+index e6942de..4366525 100644
+--- a/doc/user-manual/user.texinfo
++++ b/doc/user-manual/user.texinfo
+@@ -44,7 +44,7 @@ Documentation License.''
+ @end direntry
+ 
+ @titlepage
+-@title{MIT/GNU Scheme User's Manual}
++@title MIT/GNU Scheme User's Manual
+ @subtitle Edition @value{EDITION} for MIT/GNU Scheme @value{VERSION}
+ @subtitle @value{UPDATED}
+ @author by Stephen Adams


### PR DESCRIPTION
Modified the build for mit-scheme, fixing doc generation, unmakring package as broken, and marking linux as a supported platform.
