### PR TITLE
ffmpeg: Update to 2.3.3 and 1.2.8.

### DIFF
--- a/pkgs/development/libraries/ffmpeg/1.x.nix
+++ b/pkgs/development/libraries/ffmpeg/1.x.nix
@@ -31,11 +31,11 @@ assert playSupport -> SDL != null;
 assert freetypeSupport -> freetype != null;
 
 stdenv.mkDerivation rec {
-  name = "ffmpeg-1.2.7";
+  name = "ffmpeg-1.2.8";
 
   src = fetchurl {
     url = "http://www.ffmpeg.org/releases/${name}.tar.bz2";
-    sha256 = "13nj5q5ad0kcrid8r5x6x8lqfhk8kms14pmncf6vbdbk6x45k6v6";
+    sha256 = "429b5904abca0bc443bcc06358988aab9169683021aac21a306de28f329d2e59";
   };
 
   # `--enable-gpl' (as well as the `postproc' and `swscale') mean that

--- a/pkgs/development/libraries/ffmpeg/2.x.nix
+++ b/pkgs/development/libraries/ffmpeg/2.x.nix
@@ -5,11 +5,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ffmpeg-2.3.2";
+  name = "ffmpeg-2.3.3";
 
   src = fetchurl {
     url = "http://www.ffmpeg.org/releases/${name}.tar.bz2";
-    sha256 = "1lpzqjpklmcjzk327pz070m3qz3s1cwg8v90w6r1sdh8491kbqc4";
+    sha256 = "bb4c0d10a24e08fe67292690a1b4d4ded04f5c4c388f0656c98940ab0c606446";
   };
 
   subtitleSupport = config.ffmpeg.subtitle or true;


### PR DESCRIPTION
This includes security fixes for.

2.3.3:

CVE-2014-5271 60bfa9154d0084bc8b007b984051a6bb82d9652c  /
52b81ff4635c077b2bc8b8d3637d933b6629d803

1.2.8:

CVE-2014-5272, abc1fa7c5a1dca1345b9471b81cfcda00c56220d / 3539d6c63a16e1b2874bb037a86f317449c58770
(CVE-2014-5271, 18342848f7fa0c98f81049495adaf3d528b325f5 / 52b81ff4635c077b2bc8b8d3637d933b6629d803)
