### PR TITLE
qt: make package names of "full" variants appear as such

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6024,24 +6024,24 @@ let
       else stdenv;
   };
 
-  qt48Full = qt48.override {
+  qt48Full = appendToName "full" (qt48.override {
     docs = true;
     demos = true;
     examples = true;
     developerBuild = true;
-  };
+  });
 
   qt4SDK = qtcreator.override {
     sdkBuild = true;
     qtLib = qt48Full;
   };
 
-  qt53Full = qt53.override {
+  qt53Full = appendToName "full" (qt53.override {
     buildDocs = true;
     buildExamples = true;
     buildTests = true;
     developerBuild = true;
-  };
+  });
 
   qt53 = callPackage ../development/libraries/qt-5/qt-5.3.nix {
     mesa = mesa_noglu;
@@ -6059,12 +6059,12 @@ let
     bison = bison2; # error: too few arguments to function 'int yylex(...
   };
 
-  qt5Full = qt5.override {
+  qt5Full = appendToName "full" (qt5.override {
     buildDocs = true;
     buildExamples = true;
     buildTests = true;
     developerBuild = true;
-  };
+  });
 
   qt5SDK = qtcreator.override {
     sdkBuild = true;


### PR DESCRIPTION
Currently there is no distinction in the package names of Qt packages
whether they are "full" or not (i.e. coming from a qt5Full or qt5
attribute).

Currently:
  $ nix-env -f. -qaP | grep "^qt[45]"
  qt48Full   qt-4.8.6
  qt5Full    qt-5.2.1
  qt5        qt-5.2.1
  qt53       qt-5.3.1
  qt53Full   qt-5.3.1
  [...]

With this change:
  $ nix-env -f. -qaP | grep "^qt[45]"
  qt5        qt-5.2.1
  qt53       qt-5.3.1
  qt48Full   qt-full-4.8.6
  qt5Full    qt-full-5.2.1
  qt53Full   qt-full-5.3.1
  [...]

NOTE: This only touches the "full" variants (which are basically unreferenced in nixpkgs), so it will not cause a massive rebuild.
