### PR TITLE
haskell-poppler: updated to 0.13 to be compatible with gtk2hs-0.13

### DIFF
--- a/pkgs/development/libraries/haskell/poppler/default.nix
+++ b/pkgs/development/libraries/haskell/poppler/default.nix
@@ -6,8 +6,8 @@
 
 cabal.mkDerivation (self: {
   pname = "poppler";
-  version = "0.12.3";
-  sha256 = "1ny2r1cpsshpg00w6bd0f5mw26xsy99l7dgx2xq8f01zcwdy4nrp";
+  version = "0.13";
+  sha256 = "1fv0h2ixanzv5vy4l2ln23f9n8ghmgdxzlyx54hh69bwhrcg049s";
   buildDepends = [ cairo glib gtk mtl ];
   buildTools = [ gtk2hsBuildtools ];
   extraLibraries = [ libc ];
@@ -19,6 +19,5 @@ cabal.mkDerivation (self: {
     platforms = self.ghc.meta.platforms;
     maintainers = with self.stdenv.lib.maintainers; [ ianwookim ];
     hydraPlatforms = self.stdenv.lib.platforms.none;
-    broken = true;
   };
 })


### PR DESCRIPTION
updated to be compatible with the new version of gtk2hs  (0.13). 
