### PR TITLE
dnsmasq: Update and enable dbus support

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -7,6 +7,9 @@ with lib;
 let
 
   cfg = config.networking;
+  dnsmasqResolve = config.services.dnsmasq.enable &&
+                   config.services.dnsmasq.resolveLocalQueries;
+  hasLocalResolver = config.services.bind.enable || dnsmasqResolve;
 
 in
 
@@ -74,9 +77,12 @@ in
             '' + optionalString cfg.dnsSingleRequest ''
               # only send one DNS request at a time
               resolv_conf_options='single-request'
-            '' + optionalString config.services.bind.enable ''
+            '' + optionalString hasLocalResolver ''
               # This hosts runs a full-blown DNS resolver.
               name_servers='127.0.0.1'
+            '' + optionalString dnsmasqResolve ''
+              dnsmasq_conf=/etc/dnsmasq-conf.conf
+              dnsmasq_resolv=/etc/dnsmasq-resolv.conf
             '';
       };
 

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -148,6 +148,7 @@
       riemanndash = 138;
       radvd = 139;
       zookeeper = 140;
+      dnsmasq = 141;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ pkgconfig, dbus_libs, nettle, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "dnsmasq-2.71";
@@ -8,7 +8,29 @@ stdenv.mkDerivation rec {
     sha256 = "1fpzpzja7qr8b4kfdhh4i4sijp62c634yf0xvq2n4p7d5xbzn6a9";
   };
 
+  # Can't rely on make flags because of space in one of the parameters
+  buildPhase = ''
+    make COPTS="-DHAVE_DNSSEC -DHAVE_DBUS"
+  '';
+
+  # make flags used for installation only
   makeFlags = "DESTDIR= BINDIR=$(out)/bin MANDIR=$(out)/man LOCALEDIR=$(out)/share/locale";
+
+  postInstall = ''
+    install -Dm644 dbus/dnsmasq.conf $out/etc/dbus-1/system.d/dnsmasq.conf
+    install -Dm644 trust-anchors.conf $out/share/dnsmasq/trust-anchors.conf
+
+    ensureDir $out/share/dbus-1/system-services
+    cat <<END > $out/share/dbus-1/system-services/uk.org.thekelleys.dnsmasq.service
+    [D-BUS Service]
+    Name=uk.org.thekelleys.dnsmasq
+    Exec=$out/sbin/dnsmasq -k -1
+    User=root
+    SystemdService=dnsmasq.service
+    END
+  '';
+
+  buildInputs = [ pkgconfig dbus_libs nettle ];
 
   meta = {
     description = "An integrated DNS, DHCP and TFTP server for small networks";

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -32,11 +32,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig dbus_libs nettle ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "An integrated DNS, DHCP and TFTP server for small networks";
     homepage = http://www.thekelleys.org.uk/dnsmasq/doc.html;
-    license = "GPL";
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ eelco ];
   };
 }


### PR DESCRIPTION
This is the same as #3167 but rebased against the current tree with a meta cleanup.
