### PR TITLE
New package for ALSA volume tray applet, pnmixer

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -30,6 +30,7 @@
   bodil = "Bodil Stokke <nix@bodil.org>";
   bosu = "Boris Sukholitko <boriss@gmail.com>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
+  campadrenalin = "Philip Horger <campadrenalin@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";

--- a/pkgs/tools/audio/pnmixer/default.nix
+++ b/pkgs/tools/audio/pnmixer/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, alsaLib, pkgconfig, gtk3, glibc, autoconf, automake, libnotify, libX11, gettext }:
+
+stdenv.mkDerivation rec {
+  name = "pa-applet";
+
+  src = fetchgit {
+    url = "git://github.com/nicklan/pnmixer.git";
+    rev = "1e09a075c0c63d8b161b13ea92528a798bdb464a";
+    sha256 = "15k689xycpc6pvq9vgg9ak92b9sg09dh4yrh83kjcaws63alrzl5";
+  };
+
+  buildInputs = [
+    alsaLib pkgconfig gtk3 glibc autoconf automake libnotify libX11 gettext
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  # work around a problem related to gtk3 updates
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
+  postInstall = ''
+  '';
+
+  meta = with stdenv.lib; {
+    description = "";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ iElectric ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/audio/pnmixer/default.nix
+++ b/pkgs/tools/audio/pnmixer/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "";
+    description = "ALSA mixer for the system tray.";
     license = licenses.gpl3;
     maintainers = with maintainers; [ campadrenalin ];
     platforms = platforms.linux;

--- a/pkgs/tools/audio/pnmixer/default.nix
+++ b/pkgs/tools/audio/pnmixer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, alsaLib, pkgconfig, gtk3, glibc, autoconf, automake, libnotify, libX11, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "pa-applet";
+  name = "pnmixer";
 
   src = fetchgit {
     url = "git://github.com/nicklan/pnmixer.git";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ iElectric ];
+    maintainers = with maintainers; [ campadrenalin ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1643,6 +1643,8 @@ let
 
   pa_applet = callPackage ../tools/audio/pa-applet { };
 
+  pnmixer = callPackage ../tools/audio/pnmixer { };
+
   nifskope = callPackage ../tools/graphics/nifskope { };
 
   nilfs_utils = callPackage ../tools/filesystems/nilfs-utils {};


### PR DESCRIPTION
First contribution to nixpkgs, which is pretty exciting. Then again, this was a really smooth and easy process, and I'm already using the package locally, so I'm _somewhat_ confident I haven't buggered everything.

https://github.com/nicklan/pnmixer

You'll notice there are some compilation options that are not exposed by my package - using gtk2, for example, or disabling the usage of libnotify. I considered adding support for these, but it probably makes more sense to wait for someone else to scratch their own itch, thus proving there's anyone who cares. Plus, the more complexity in a single PR, the more likely for things to be subtly wrong - right now, it's nice and simple as it is.
