### PR TITLE
Lens cleanup

### DIFF
--- a/pkgs/development/libraries/haskell/hsimport/default.nix
+++ b/pkgs/development/libraries/haskell/hsimport/default.nix
@@ -6,19 +6,17 @@
 
 cabal.mkDerivation (self: {
   pname = "hsimport";
-  version = "0.5";
-  sha256 = "18rhldw6vbkjcpx373m784sppadccm2b3xx3zzr0l45dwmsh6rb4";
+  version = "0.5.1";
+  sha256 = "17yzfikfl8qvm6vp3d472l6p0kzzw694ng19xn3fmrb43qvki4jj";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [
     attoparsec cmdargs dyre haskellSrcExts lens mtl split text
   ];
   testDepends = [ filepath haskellSrcExts tasty tastyGolden ];
-  doCheck = false;
   meta = {
     description = "A command line program for extending the import list of a Haskell source file";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    maintainers = with self.stdenv.lib.maintainers; [ ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/hsimport/default.nix
+++ b/pkgs/development/libraries/haskell/hsimport/default.nix
@@ -18,5 +18,6 @@ cabal.mkDerivation (self: {
     description = "A command line program for extending the import list of a Haskell source file";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = with self.stdenv.lib.maintainers; [ ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/json-assertions/default.nix
+++ b/pkgs/development/libraries/haskell/json-assertions/default.nix
@@ -10,6 +10,8 @@ cabal.mkDerivation (self: {
   meta = {
     homepage = "http://github.com/ocharles/json-assertions.git";
     description = "Test that your (Aeson) JSON encoding matches your expectations";
+    broken = true;
+    hydraPlatforms = self.stdenv.lib.platforms.none;
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
     maintainers = with self.stdenv.lib.maintainers; [ ocharles ];

--- a/pkgs/development/libraries/haskell/twitter-conduit/default.nix
+++ b/pkgs/development/libraries/haskell/twitter-conduit/default.nix
@@ -2,27 +2,27 @@
 
 { cabal, aeson, attoparsec, authenticateOauth, caseInsensitive
 , conduit, conduitExtra, dataDefault, doctest, filepath, hlint
-, hspec, httpClient, httpConduit, httpTypes, lens, monadControl
-, monadLogger, network, resourcet, shakespeare, text, time
+, hspec, httpClient, httpConduit, httpTypes, lens, lensAeson
+, monadControl, monadLogger, networkUri, resourcet, text, time
 , transformers, transformersBase, twitterTypes
 }:
 
 cabal.mkDerivation (self: {
   pname = "twitter-conduit";
-  version = "0.0.5.5";
-  sha256 = "13wk863xjlg8g62yhbq4aar7z77n0awh500l6v41fam99lihzxab";
+  version = "0.0.5.6";
+  sha256 = "1l6gk4538nqknrj082hkdy2jp4gzyq3y473p8gg4mm2n67417r9m";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [
     aeson attoparsec authenticateOauth conduit conduitExtra dataDefault
-    httpClient httpConduit httpTypes lens monadLogger resourcet
-    shakespeare text time transformers twitterTypes
+    httpClient httpConduit httpTypes lens lensAeson monadLogger
+    networkUri resourcet text time transformers twitterTypes
   ];
   testDepends = [
     aeson attoparsec authenticateOauth caseInsensitive conduit
     conduitExtra dataDefault doctest filepath hlint hspec httpClient
-    httpConduit httpTypes lens monadControl monadLogger network
-    resourcet shakespeare text time transformers transformersBase
+    httpConduit httpTypes lens lensAeson monadControl monadLogger
+    networkUri resourcet text time transformers transformersBase
     twitterTypes
   ];
   meta = {
@@ -30,6 +30,5 @@ cabal.mkDerivation (self: {
     description = "Twitter API package with conduit interface and Streaming API support";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    maintainers = with self.stdenv.lib.maintainers; [ ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/twitter-conduit/default.nix
+++ b/pkgs/development/libraries/haskell/twitter-conduit/default.nix
@@ -30,5 +30,6 @@ cabal.mkDerivation (self: {
     description = "Twitter API package with conduit interface and Streaming API support";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = with self.stdenv.lib.maintainers; [ ocharles ];
   };
 })

--- a/pkgs/development/libraries/haskell/wreq/default.nix
+++ b/pkgs/development/libraries/haskell/wreq/default.nix
@@ -24,6 +24,8 @@ cabal.mkDerivation (self: {
     homepage = "http://www.serpentine.com/wreq";
     description = "An easy-to-use HTTP client library";
     license = self.stdenv.lib.licenses.bsd3;
+    broken = true;
+    hydraPlatforms = self.stdenv.lib.platforms.none;
     platforms = self.ghc.meta.platforms;
     maintainers = with self.stdenv.lib.maintainers; [ ocharles ];
   };

--- a/pkgs/development/libraries/haskell/xml-lens/default.nix
+++ b/pkgs/development/libraries/haskell/xml-lens/default.nix
@@ -7,6 +7,7 @@ cabal.mkDerivation (self: {
   version = "0.1.6.1";
   sha256 = "093grvlpm19l3g10ka82xpzl2wr0gli71kfkbvk4gvg3194fkw4h";
   buildDepends = [ lens text xmlConduit ];
+  jailbreak = true;
   meta = {
     homepage = "https://github.com/fumieval/xml-lens";
     description = "Lenses, traversals, prisms for xml-conduit";


### PR DESCRIPTION
This fixes all of the breakages on Hydra introduced by the recent Lens v4.4 update. The only breakage not fixed is hcltest because it fails because of MonadRandom, which is unrelated to lens.
