### PR TITLE
nixos-install.sh: added --root parameter

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -30,6 +30,9 @@ while [ "$#" -gt 0 ]; do
             absolute_path=$(readlink -m $given_path)
             extraBuildFlags+=("$i" "/mnt$absolute_path")
             ;;
+        --root)
+            mountPoint="$1"; shift 1
+            ;;
         --show-trace)
             extraBuildFlags+=("$i")
             ;;


### PR DESCRIPTION
Previously:
- setting the mountpoint was only possible through an environment variable
- a discrepancy from nixos-generate-config, which has --root
