### PR TITLE
Stdenv stages refactor

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -66,6 +66,18 @@ rec {
   };
 
 
+  # A helper function to call gcc-wrapper.
+  wrapGCC =
+    { gcc, libc, binutils, coreutils, name }:
+
+    lib.makeOverridable (import ../../build-support/gcc-wrapper) {
+      nativeTools = false;
+      nativeLibc = false;
+      inherit gcc binutils coreutils libc name;
+      stdenv = stage0.stdenv;
+    };
+
+
   # This function builds the various standard environments used during
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
@@ -101,6 +113,7 @@ rec {
     };
     in { stdenv = thisStdenv; pkgs = thisPkgs; };
 
+
   # Build a dummy stdenv with no GCC or working fetchurl.  This is
   # because we need a stdenv to build the GCC wrapper and fetchurl.
   stage0 = stageFun {
@@ -122,18 +135,6 @@ rec {
       };
     };
   };
-
-
-  # A helper function to call gcc-wrapper.
-  wrapGCC =
-    { gcc, libc, binutils, coreutils, name }:
-
-    lib.makeOverridable (import ../../build-support/gcc-wrapper) {
-      nativeTools = false;
-      nativeLibc = false;
-      inherit gcc binutils coreutils libc name;
-      stdenv = stage0.stdenv;
-    };
 
 
   # Create the first "real" standard environment.  This one consists


### PR DESCRIPTION
This is a second try for the linux stdenv refactoring.

Previously I didn't manage to get any reviews. probably because the commit was too large to review.  It also changed the output and derivation hashes, therefore generating a mass rebuild.

This time, I ask for review with the following info kept in mind:
- none of these commits change the output path or the derivation path of 32 or 64-bit stdenvLinux,
- to be safe, I'm still requesting this merge to the staging branch,
- don't review the whole merge request as a whole, but go through the six commits one-by-one, then the commits are quite small and it's easy to follow what's happening,
- the final file is 30 lines shorter and more logical, easier to read than the original while doing the same task.

After we're done with this review, I'll post other improvements (like getting rid of triple zlib's, or having a glibc that is compiled with recent gcc, not an ancient one, or having the gcc_s issue fixed correctly) in another, separate pull requests.

I'd really appreciate to get some kind of a review this time, thanks! :)
