### PR TITLE
nixos: Create firmware output path without links.

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -182,11 +182,12 @@ in
         Note that you can also add firmware packages to this
         list as these are directories in the nix store.
       '';
-      apply = list: pkgs.buildEnv {
+      apply = list: stdenv.mkDerivation {
         name = "firmware";
-        paths = list;
-        pathsToLink = [ "/" ];
-        ignoreCollisions = true;
+        buildCommand = flip concatMapStrings list (path: ''
+          cd "${path}"
+          find . ! -type d | xargs -i install -D -m 0444 {} "$out/{}"
+        '');
       };
     };
 


### PR DESCRIPTION
Especially when `${kernel}/lib/firmware` is referenced, the store path for firmware could get quite large (>= 150 MB on `x86_64-linux`), and for example in VM tests this closure will end up being included in the initrd.

Instead of building up a link farm, we now just dereference/copy over all files into the firmware closure.

Fixes a regression introduced by PR #3505.
