### PR TITLE
Update GHC 7.4.2 prefs to select network 2.3.0.13

### DIFF
--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -62,6 +62,7 @@
     hackageDb = super.hackageDb.override { Cabal = self.Cabal_1_16_0_3; };
     haddock = self.haddock_2_11_0;
     haskeline = super.haskeline.override { cabal = self.cabal.override { Cabal = self.Cabal_1_16_0_3; }; };
+    network = self.network_2_3_0_13;
     shelly = self.shelly_0_15_4_1;
   };
 


### PR DESCRIPTION
network < 2.4 is needed for other libraries that are selected for GHC 7.4.2
