### PR TITLE
Fix many package descriptions

### DIFF
--- a/pkgs/applications/audio/beast/default.nix
+++ b/pkgs/applications/audio/beast/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     ];
 
   meta = { 
-    description = "BEAST - the Bedevilled Sound Engine";
+    description = "A music composition and modular synthesis application";
     homepage = http://beast.gtk.org;
     license = ["GPL-2" "LGPL-2.1"];
   };

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses pkgconfig alsaLib flac libmad ffmpeg libvorbis mpc mp4v2 ];
 
   meta = {
-    description = "cmus is a small, fast and powerful console music player for Linux and *BSD";
+    description = "Small, fast and powerful console music player for Linux and *BSD";
     homepage = http://cmus.sourceforge.net;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/applications/audio/moc/default.nix
+++ b/pkgs/applications/audio/moc/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "MOC (music on console) is a console audio player for LINUX/UNIX designed to be powerful and easy to use.";
+    description = "An ncurses console audio player designed to be powerful and easy to use";
     homepage = http://moc.daper.net/;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/applications/audio/mp3info/default.nix
+++ b/pkgs/applications/audio/mp3info/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    description = "MP3Info, an MP3 technical info viewer and ID3 1.x tag editor";
+    description = "MP3 technical info viewer and ID3 1.x tag editor";
 
     longDescription =
       '' MP3Info is a little utility used to read and modify the ID3 tags of

--- a/pkgs/applications/audio/mpc123/default.nix
+++ b/pkgs/applications/audio/mpc123/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://mpc123.sourceforge.net/;
 
-    description = "mpc123, a Musepack (.mpc) audio player";
+    description = "A Musepack (.mpc) audio player";
 
     license = stdenv.lib.licenses.gpl2Plus;
 

--- a/pkgs/applications/audio/mpg321/default.nix
+++ b/pkgs/applications/audio/mpg321/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [libao libid3tag libmad zlib];
 
   meta = {
-    description = "mpg321, a command-line MP3 player";
+    description = "Command-line MP3 player";
     homepage = http://mpg321.sourceforge.net/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ ];

--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "pamixer is like amixer but for pulseaudio.";
+    description = "Like amixer but for pulseaudio";
     longDescription = "Features:
       - Get the current volume of the default sink, the default source or a selected one by his id
       - Set the volume for the default sink, the default source or any other device

--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = https://www.spotify.com/;
-    description = "Spotify for Linux allows you to play music from the Spotify music service";
+    description = "Play music from the Spotify music service";
     license = stdenv.lib.licenses.unfree;
     maintainers = [ stdenv.lib.maintainers.eelco ];
   };

--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "GNU ed, an implementation of the standard Unix editor";
+    description = "An implementation of the standard Unix editor";
 
     longDescription = ''
       GNU ed is a line-oriented text editor.  It is used to create,

--- a/pkgs/applications/editors/mg/default.nix
+++ b/pkgs/applications/editors/mg/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://homepage.boetes.org/software/mg/;
-    description = "mg is Micro GNU/emacs, this is a portable version of the mg maintained by the OpenBSD team";
+    description = "Micro GNU/emacs, a portable version of the mg maintained by the OpenBSD team";
     license = "public domain";
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
         "${xmodmap}/bin:${which}/bin";
 
   meta = {
-    description = "GNU TeXmacs, a free WYSIWYW editing platform with special features for scientists";
+    description = "WYSIWYW editing platform with special features for scientists";
     longDescription =
       '' GNU TeXmacs is a free wysiwyw (what you see is what you want)
          editing platform with special features for scientists.  The software

--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    description = "Geeqie, a lightweight GTK+ based image viewer";
+    description = "Lightweight GTK+ based image viewer";
 
     longDescription =
       ''

--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   installPhase = ''make install prefix="$out"'';
 
   meta = {
-    description = "GrafX2 is a bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance.";
+    description = "Bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance";
     homepage = http://code.google.co/p/grafx2/;
     license = stdenv.lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/applications/graphics/jbrout/default.nix
+++ b/pkgs/applications/graphics/jbrout/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage {
   buildInputs = [ python pyGtkGlade makeWrapper pyexiv2 lxml pil fbida which ];
   meta = {
     homepage = "http://code.google.com/p/jbrout";
-    description = "jBrout is a photo manager";
+    description = "Photo manager";
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/ocrad/default.nix
+++ b/pkgs/applications/graphics/ocrad/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Ocrad, optical character recognition (OCR) program & library";
+    description = "Optical character recognition (OCR) program & library";
 
     longDescription =
       '' GNU Ocrad is an OCR (Optical Character Recognition) program based on

--- a/pkgs/applications/graphics/qiv/default.nix
+++ b/pkgs/applications/graphics/qiv/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (rec {
   '';
 
   meta = {
-    description = "qiv (quick image viewer)";
+    description = "Quick image viewer";
     homepage = http://spiegl.de/qiv/;
     inherit version;
   };

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://ufraw.sourceforge.net/;
 
-    description = "UFRaw, a utility to read and manipulate raw images from digital cameras";
+    description = "Utility to read and manipulate raw images from digital cameras";
 
     longDescription =
       '' The Unidentified Flying Raw (UFRaw) is a utility to read and

--- a/pkgs/applications/graphics/viewnior/default.nix
+++ b/pkgs/applications/graphics/viewnior/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Viewnior is a fast and simple image viewer for GNU/Linux";
+    description = "Fast and simple image viewer";
     longDescription =
       '' Viewnior is insipred by big projects like Eye of Gnome, because of it's
          usability and richness,and by GPicView, because of it's lightweight design and

--- a/pkgs/applications/graphics/xaos/default.nix
+++ b/pkgs/applications/graphics/xaos/default.nix
@@ -28,7 +28,7 @@ rec {
   name = "xaos-" + version;
   meta = {
     homepage = http://xaos.sourceforge.net/;
-    description = "XaoS - fractal viewer";
+    description = "Fractal viewer";
     license = a.stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/applications/misc/bitcoin/default.nix
+++ b/pkgs/applications/misc/bitcoin/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-      description = "Bitcoin is a peer-to-peer currency";
+      description = "Peer-to-peer electronic cash system";
       longDescription= ''
         Bitcoin is a free open source peer-to-peer electronic cash system that is
         completely decentralized, without the need for a central server or trusted

--- a/pkgs/applications/misc/camlistore/default.nix
+++ b/pkgs/applications/misc/camlistore/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Camlistore is a way of storing, syncing, sharing, modelling and backing up content";
+    description = "A way of storing, syncing, sharing, modelling and backing up content";
     homepage = https://camlistore.org;
     license = licenses.asl20;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/applications/misc/gpsbabel/default.nix
+++ b/pkgs/applications/misc/gpsbabel/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   meta = {
-    description = "GPSBabel, a tool to convert, upload and download data from GPS and Map programs";
+    description = "Convert, upload and download data from GPS and Map programs";
 
     longDescription = ''
       GPSBabel converts waypoints, tracks, and routes between popular

--- a/pkgs/applications/misc/gv/default.nix
+++ b/pkgs/applications/misc/gv/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://www.gnu.org/software/gv/;
-    description = "GNU gv, a PostScript/PDF document viewer";
+    description = "PostScript/PDF document viewer";
 
     longDescription = ''
       GNU gv allows users to view and navigate through PostScript and

--- a/pkgs/applications/misc/posterazor/default.nix
+++ b/pkgs/applications/misc/posterazor/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://posterazor.sourceforge.net/";
-    description = "The PosteRazor cuts a raster image into pieces which can afterwards be printed out and assembled to a poster";
+    description = "Cuts a raster image into pieces which can afterwards be printed out and assembled to a poster";
     maintainers = [ stdenv.lib.maintainers.madjar ];
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/applications/misc/stardict/stardict.nix
+++ b/pkgs/applications/misc/stardict/stardict.nix
@@ -37,8 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "stardict";
-    homepage = "A international dictionary supporting fuzzy and glob style matching";
+    description = "An international dictionary supporting fuzzy and glob style matching";
     license = stdenv.lib.licenses.lgpl3;
     maintainers = with stdenv.lib.maintainers; [qknight];
   };

--- a/pkgs/applications/misc/tangogps/default.nix
+++ b/pkgs/applications/misc/tangogps/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "tangoGPS, a user friendly map and GPS user interface";
+    description = "User friendly map and GPS user interface";
 
     longDescription = ''
       tangoGPS is an easy to use, fast and lightweight mapping

--- a/pkgs/applications/misc/viking/default.nix
+++ b/pkgs/applications/misc/viking/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   meta = {
-    description = "Viking, a GPS data editor and analyzer";
+    description = "GPS data editor and analyzer";
 
     longDescription = ''
       Viking is a free/open source program to manage GPS data.  You

--- a/pkgs/applications/misc/wordnet/default.nix
+++ b/pkgs/applications/misc/wordnet/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "WordNet, a lexical database for the English language";
+    description = "Lexical database for the English language";
 
     longDescription =
       '' WordNet® is a large lexical database of English.  Nouns, verbs,

--- a/pkgs/applications/misc/xfe/default.nix
+++ b/pkgs/applications/misc/xfe/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "X File Explorer (Xfe) is an MS-Explorer like file manager for X";
+    description = "MS-Explorer like file manager for X";
     longDescription = ''
       X File Explorer (Xfe) is an MS-Explorer like file manager for X.
       It is based on the popular, but discontinued, X Win Commander, which was developed by Maxim Baranov.

--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    description = "Mozilla Firefox - the browser, reloaded";
+    description = "Web browser";
     homepage = http://www.mozilla.com/en-US/firefox/;
     maintainers = with lib.maintainers; [ eelco wizeman ];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.opera.com;
-    description = "The Opera web browser";
+    description = "Web browser";
   };
 }

--- a/pkgs/applications/networking/ids/snort/default.nix
+++ b/pkgs/applications/networking/ids/snort/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpcap pcre libdnet daq zlib flex bison ];
   
   meta = {
-    description = "Snort is an open source network intrusion prevention and detection system (IDS/IPS)";
+    description = "Network intrusion prevention and detection system (IDS/IPS)";
     homepage = http://www.snort.org;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "BitlBee, an IRC to other chat networks gateway";
+    description = "IRC instant messaging gateway";
 
     longDescription = ''
       BitlBee brings IM (instant messaging) to IRC clients.  It's a

--- a/pkgs/applications/networking/instant-messengers/carrier/2.5.0.nix
+++ b/pkgs/applications/networking/instant-messengers/carrier/2.5.0.nix
@@ -41,7 +41,7 @@ rec {
       
   name = "carrier-2.5.0";
   meta = {
-    description = "Carrier - PidginIM GUI fork with user-friendly development model";
+    description = "PidginIM GUI fork with user-friendly development model";
     homepage = http://funpidgin.sf.net; 
   };
 } // (if externalPurple2 then {

--- a/pkgs/applications/networking/instant-messengers/ekiga/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ekiga/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Ekiga SIP client";
+    description = "VOIP/Videoconferencing app with full SIP and H.323 support";
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/networking/instant-messengers/fuze/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fuze/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "Fuze for Linux";
+    description = "Internet and mobile based unified communications solutions (Linux client)";
     homepage = http://www.fuzebox.com;
     license = "unknown";
   };

--- a/pkgs/applications/networking/instant-messengers/hipchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/hipchat/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "HipChat Desktop Client";
+    description = "Desktop client for HipChat services";
     homepage = http://www.hipchat.com;
     license = stdenv.lib.licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   + (lib.optionalString (gnutls != null) " --enable-gnutls=yes --enable-nss=no")
   ;
   meta = with stdenv.lib; {
-    description = "Pidgin IM - XMPP(Jabber), AIM/ICQ, IRC, SIP etc client";
+    description = "Multi-protocol instant messaging client";
     homepage = http://pidgin.im;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Apache JMeter is a 100% pure Java desktop application designed to load test functional behavior and measure performance.";
+    description = "A 100% pure Java desktop application designed to load test functional behavior and measure performance";
     longDescription = ''
       The Apache JMeter desktop application is open source software, a 100%
       pure Java application designed to load test functional behavior and

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -70,8 +70,7 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
 
   meta = {
-    description = "Notmuch -- The mail indexer";
-    longDescription = "";
+    description = "Mail indexer";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ chaoflow garbas ];
     platforms = stdenv.lib.platforms.gnu;

--- a/pkgs/applications/networking/newsreaders/slrn/default.nix
+++ b/pkgs/applications/networking/newsreaders/slrn/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   buildInputs = [ slang ncurses ];
 
   meta = {
-    description = "The slrn (S-Lang read news) newsreader";
+    description = "Text-based newsreader";
     homepage = http://slrn.sourceforge.net/index.html;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   */
 
   meta = {
-    description = "GNUnet, GNU's decentralized anonymous and censorship-resistant P2P framework";
+    description = "GNU's decentralized anonymous and censorship-resistant P2P framework";
 
     longDescription = ''
       GNUnet is a framework for secure peer-to-peer networking that

--- a/pkgs/applications/networking/remote/rdesktop/default.nix
+++ b/pkgs/applications/networking/remote/rdesktop/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation (rec {
   ];
 
   meta = {
-    description = "rdesktop is an open source client for Windows Terminal Services";
+    description = "Open source client for Windows Terminal Services";
   };
 })

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     license = stdenv.lib.licenses.gpl2;
     homepage = "http://remmina.sourceforge.net/";
-    description = "Remmina is a remote desktop client written in GTK+";
+    description = "Remote desktop client written in GTK+";
     maintainers = [];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://syncthing.net/;
-    description = "Syncthing replaces Dropbox and BitTorrent Sync with something open, trustworthy and decentralized";
+    description = "Replaces Dropbox and BitTorrent Sync with something open, trustworthy and decentralized";
     license = with stdenv.lib.licenses; mit;
     maintainers = with stdenv.lib.maintainers; [ matejc ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "GnuCash, a personal and small-business financial-accounting application";
+    description = "Personal and small-business financial-accounting application";
 
     longDescription = ''
       GnuCash is personal and small-business financial-accounting software,

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -252,7 +252,7 @@ stdenv.mkDerivation rec {
     ];
 
   meta = with stdenv.lib; {
-    description = "LibreOffice is a comprehensive, professional-quality productivity suite, a variant of openoffice.org";
+    description = "Comprehensive, professional-quality productivity suite, a variant of openoffice.org";
     homepage = http://libreoffice.org/;
     license = licenses.lgpl3;
     maintainers = [ maintainers.viric maintainers.raskin ];

--- a/pkgs/applications/science/astronomy/gravit/default.nix
+++ b/pkgs/applications/science/astronomy/gravit/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://gravit.slowchop.com";
-    description = "A beautiful OpenGL-based gravity simulator";
+    description = "Beautiful OpenGL-based gravity simulator";
     license = stdenv.lib.licenses.gpl2;
 
     longDescription = ''

--- a/pkgs/applications/science/biology/emboss/default.nix
+++ b/pkgs/applications/science/biology/emboss/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   # '';
 
   meta = {
-    description     = "EMBOSS is 'The European Molecular Biology Open Software Suite'";
+    description     = "The European Molecular Biology Open Software Suite";
     longDescription = ''EMBOSS is a free Open Source software analysis package
     specially developed for the needs of the molecular biology (e.g. EMBnet)
     user community, including libraries. The software automatically copes with

--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     [ ocaml findlib ocamlgraph zarith lablgtk gmp ];
 
   meta = {
-    description = "Alt-Ergo is a high-performance theorem prover and SMT solver";
+    description = "High-performance theorem prover and SMT solver";
     homepage    = "http://alt-ergo.ocamlpro.com/";
     license     = stdenv.lib.licenses.cecill-c; # LGPL-2 compatible
     platforms   = stdenv.lib.platforms.linux;

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
   buildFlags = "revision coq coqide";
 
   meta = {
-    description = "Coq proof assistant";
+    description = "Formal proof management system";
     longDescription = ''
       Coq is a formal proof management system.  It provides a formal language
       to write mathematical definitions, executable algorithms and theorems

--- a/pkgs/applications/science/logic/matita/default.nix
+++ b/pkgs/applications/science/logic/matita/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://matita.cs.unibo.it/;
-    description = "Matita is an experimental, interactive theorem prover";
+    description = "Experimental, interactive theorem prover";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
   };

--- a/pkgs/applications/science/logic/prooftree/default.nix
+++ b/pkgs/applications/science/logic/prooftree/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (rec {
   configureFlags = [ "--prefix" "$(out)" ];
 
   meta = {
-    description = "Prooftree is a program for proof-tree visualization";
+    description = "A program for proof-tree visualization";
     longDescription = ''
       Prooftree is a program for proof-tree visualization during interactive
       proof development in a theorem prover. It is currently being developed

--- a/pkgs/applications/science/logic/twelf/default.nix
+++ b/pkgs/applications/science/logic/twelf/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Twelf logic proof assistant";
+    description = "Logic proof assistant";
     longDescription = ''
       Twelf is a language used to specify, implement, and prove properties of
       deductive systems such as programming languages and logics. Large

--- a/pkgs/applications/science/math/fricas/default.nix
+++ b/pkgs/applications/science/math/fricas/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://fricas.sourceforge.net/;
-    description = "Fricas CAS";
+    description = "An advanced computer algebra system";
     license = stdenv.lib.licenses.bsd3;
 
     hydraPlatforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://www.lama.univ-savoie.fr/~raffalli/glsurf;
-    description = "GlSurf: a program to draw implicit surfaces and curves";
+    description = "A program to draw implicit surfaces and curves";
   };
 }

--- a/pkgs/applications/science/math/jags/default.nix
+++ b/pkgs/applications/science/math/jags/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   buildInputs = [gfortran liblapack blas];
 
   meta = {
-    description = "JAGS: Just Another Gibbs Sampler";
+    description = "Just Another Gibbs Sampler";
     license     = "GPL2";
     homepage    = http://www-ice.iarc.fr/~martyn/software/jags/;
     maintainers = [stdenv.lib.maintainers.andres];

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   meta = {
-    description = "Maxima computer algebra system";
+    description = "Computer algebra system";
     homepage = "http://maxima.sourceforge.net";
     license = stdenv.lib.licenses.gpl2;
 

--- a/pkgs/applications/science/misc/fityk/default.nix
+++ b/pkgs/applications/science/misc/fityk/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   buildInputs = [wxGTK30 boost lua zlib bzip2 xylib readline gnuplot ];
 
   meta = {
-    description = "Fityk -- curve fitting and peak fitting software";
+    description = "Curve fitting and peak fitting software";
     license = "GPL2";
     homepage = http://fityk.nieto.pl/;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    description = "SimGrid, a simulator for distributed applications in heterogeneous environments";
+    description = "Simulator for distributed applications in heterogeneous environments";
 
     longDescription =
       '' SimGrid is a toolkit that provides core functionalities for the

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = {
     homepage    = "http://www.gromacs.org";
     license     = "GPLv2";
-    description = "The GROMACS molecular dynamics software package";
+    description = "Molecular dynamics software package";
     longDescription = ''
       GROMACS is a versatile package to perform molecular dynamics,
       i.e. simulate the Newtonian equations of motion for systems

--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Scientific PYthon Development EnviRonment (SPYDER)";
+    description = "Scientific python development environment";
     longDescription = ''
       Spyder (previously known as Pydee) is a powerful interactive development
       environment for the Python language with advanced editing, interactive

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://git-scm.com/;
-    description = "Git, a popular distributed version control system";
+    description = "Distributed version control system";
     license = stdenv.lib.licenses.gpl2Plus;
 
     longDescription = ''

--- a/pkgs/applications/version-management/rcs/default.nix
+++ b/pkgs/applications/version-management/rcs/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/rcs/;
-    description = "GNU RCS, a revision control system";
+    description = "Revision control system";
     longDescription =
       '' The GNU Revision Control System (RCS) manages multiple revisions of
          files. RCS automates the storing, retrieval, logging,

--- a/pkgs/applications/video/gnash/default.nix
+++ b/pkgs/applications/video/gnash/default.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/gnash/;
-    description = "GNU Gnash, a libre SWF (Flash) movie player";
+    description = "A libre SWF (Flash) movie player";
 
     longDescription = ''
       Gnash is a GNU Flash movie player.  Flash is an animation file format

--- a/pkgs/applications/video/kino/default.nix
+++ b/pkgs/applications/video/kino/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
 
 
   meta = { 
-      description = "Kino is a non-linear DV editor for GNU/Linux";
+      description = "Non-linear DV editor for GNU/Linux";
       homepage = http://www.kinodv.org/;
       license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/applications/video/xbmc/default.nix
+++ b/pkgs/applications/video/xbmc/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
 
     meta = {
       homepage = http://xbmc.org/;
-      description = "XBMC Media Center";
+      description = "Media center";
       license = "GPLv2";
       platforms = stdenv.lib.platforms.linux; 
       maintainers = [ stdenv.lib.maintainers.iElectric ];

--- a/pkgs/applications/window-managers/ratpoison/default.nix
+++ b/pkgs/applications/window-managers/ratpoison/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.nongnu.org/ratpoison/";
-    description = "Ratpoison, a simple mouse-free tiling window manager";
+    description = "Simple mouse-free tiling window manager";
     license = stdenv.lib.licenses.gpl2Plus;
 
     longDescription = ''

--- a/pkgs/desktops/e17/enlightenment/default.nix
+++ b/pkgs/desktops/e17/enlightenment/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     --disable-illume2
   '';
   meta = {
-    description = "Enlightenment, the window manager";
+    description = "A window manager";
     longDescription = ''
       The Enlightenment Desktop shell provides an efficient yet
       breathtaking window manager based on the Enlightenment

--- a/pkgs/development/compilers/bigloo/default.nix
+++ b/pkgs/development/compilers/bigloo/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
 
   meta = {
-    description = "Bigloo, an efficient Scheme compiler";
+    description = "Efficient Scheme compiler";
 
     longDescription = ''
       Bigloo is a Scheme implementation devoted to one goal: enabling

--- a/pkgs/development/compilers/gambit/default.nix
+++ b/pkgs/development/compilers/gambit/default.nix
@@ -18,7 +18,7 @@ rec {
   phaseNames = ["doConfigure" "doMakeInstall"];
       
   meta = {
-    description = "Gambit Scheme to C compiler";
+    description = "Scheme to C compiler";
     maintainers = [
       a.lib.maintainers.raskin
     ];

--- a/pkgs/development/compilers/hugs/default.nix
+++ b/pkgs/development/compilers/hugs/default.nix
@@ -47,7 +47,7 @@ composableDerivation.composableDerivation {} {
 
   meta = {
     license = "as-is"; # gentoo is calling it this way..
-    description = "The HUGS 98 Haskell interpreter";
+    description = "Haskell interpreter";
     homepage = http://www.haskell.org/hugs;
   };
 }

--- a/pkgs/development/compilers/ikarus/default.nix
+++ b/pkgs/development/compilers/ikarus/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gmp ];
 
   meta = {
-    description = "Ikarus - a Scheme compiler, aiming at R6RS";
+    description = "Scheme compiler, aiming at R6RS";
     homepage = http://ikarus-scheme.org/;
     license = stdenv.lib.licenses.gpl3;
   };

--- a/pkgs/development/compilers/mercury/default.nix
+++ b/pkgs/development/compilers/mercury/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Mercury is a pure logic programming language.";
+    description = "A pure logic programming language";
     longDescription = ''
       Mercury is a logic/functional programming language which combines the
       clarity and expressiveness of declarative programming with advanced

--- a/pkgs/development/compilers/ocaml/3.10.0.nix
+++ b/pkgs/development/compilers/ocaml/3.10.0.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (rec {
   meta = {
     homepage = http://caml.inria.fr/ocaml;
     license = "QPL, LGPL2 (library part)";
-    desctiption = "Most popular variant of the Caml language";
+    description = "Most popular variant of the Caml language";
   };
 
 })

--- a/pkgs/development/compilers/ocaml/3.11.2.nix
+++ b/pkgs/development/compilers/ocaml/3.11.2.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://caml.inria.fr/ocaml;
     license = [ "QPL" /* compiler */ "LGPLv2" /* library */ ];
-    description = "Objective Caml, the most popular variant of the Caml language";
+    description = "Most popular variant of the Caml language";
 
     longDescription =
       '' Objective Caml is the most popular variant of the Caml language.

--- a/pkgs/development/compilers/ocaml/3.12.1.nix
+++ b/pkgs/development/compilers/ocaml/3.12.1.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://caml.inria.fr/ocaml;
     license = [ "QPL" /* compiler */ "LGPLv2" /* library */ ];
-    description = "OCaml, the most popular variant of the Caml language";
+    description = "Most popular variant of the Caml language";
 
     longDescription =
       ''

--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://caml.inria.fr/ocaml;
     license = [ "QPL" /* compiler */ "LGPLv2" /* library */ ];
-    description = "OCaml, the most popular variant of the Caml language";
+    description = "Most popular variant of the Caml language";
 
     longDescription =
       ''

--- a/pkgs/development/compilers/ocaml/4.01.0.nix
+++ b/pkgs/development/compilers/ocaml/4.01.0.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://caml.inria.fr/ocaml;
     license = [ "QPL" /* compiler */ "LGPLv2" /* library */ ];
-    description = "OCaml, the most popular variant of the Caml language";
+    description = "Most popular variant of the Caml language";
 
     longDescription =
       ''

--- a/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://okmij.org/ftp/ML/index.html#ber-metaocaml";
     license = [ "QPL" /* compiler */ "LGPLv2" /* library */ ];
-    description = "a conservative extension of OCaml with the primitive type of code values, and three basic multi-stage expression forms: Brackets, Escape, and Run";
+    description = "A conservative extension of OCaml with the primitive type of code values, and three basic multi-stage expression forms: Brackets, Escape, and Run";
   };
 }

--- a/pkgs/development/compilers/qi/default.nix
+++ b/pkgs/development/compilers/qi/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
 	builder = writeScript (name + "-builder")
 		(textClosure localDefs [allBuild doForceShare doPropagate]);
 	meta = {
-		description = "Qi - next generation on top of Common Lisp";
+		description = "Functional programming language, built top of Common Lisp";
 	};
 }

--- a/pkgs/development/compilers/rdmd/default.nix
+++ b/pkgs/development/compilers/rdmd/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "rdmd wrapper for D language compiler";
+    description = "Wrapper for D language compiler";
     homepage = http://dlang.org/rdmd.html;
     license = lib.licenses.boost;
     maintainers = with stdenv.lib.maintainers; [ vlstill ];

--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Scala is a general purpose programming language";
+    description = "General purpose programming language";
     longDescription = ''
       Scala is a general purpose programming language designed to express
       common programming patterns in a concise, elegant, and type-safe way.

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
 
   meta = {
-    description = "TinyCC, a small, fast, and embeddable C compiler and interpreter";
+    description = "Small, fast, and embeddable C compiler and interpreter";
 
     longDescription =
       '' TinyCC (aka TCC) is a small but hyper fast C compiler.  Unlike

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -65,7 +65,7 @@
 
 
   meta = {
-    description = "GNU Guile 2.0, an embeddable Scheme implementation";
+    description = "Embeddable Scheme implementation";
     homepage    = http://www.gnu.org/software/guile/;
     license     = stdenv.lib.licenses.lgpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ ludo lovek323 ];

--- a/pkgs/development/interpreters/maude/default.nix
+++ b/pkgs/development/interpreters/maude/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://maude.cs.uiuc.edu/";
-    description = "Maude -- a high-level specification language";
+    description = "High-level specification language";
     license = stdenv.lib.licenses.gpl2;
 
     longDescription = ''

--- a/pkgs/development/interpreters/php/5.3.nix
+++ b/pkgs/development/interpreters/php/5.3.nix
@@ -233,7 +233,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
   };
 
   meta = {
-    description = "The PHP language runtime engine";
+    description = "An HTML-embedded scripting language";
     homepage    = http://www.php.net/;
     license     = "PHP-3";
     maintainers = with stdenv.lib.maintainers; [ lovek323 ];

--- a/pkgs/development/interpreters/php/5.4.nix
+++ b/pkgs/development/interpreters/php/5.4.nix
@@ -253,7 +253,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
   };
 
   meta = {
-    description = "The PHP language runtime engine";
+    description = "An HTML-embedded scripting language";
     homepage = http://www.php.net/;
     license = "PHP-3";
   };

--- a/pkgs/development/interpreters/pypy/2.3/default.nix
+++ b/pkgs/development/interpreters/pypy/2.3/default.nix
@@ -91,7 +91,7 @@ let
 
     meta = with stdenv.lib; {
       homepage = "http://pypy.org/";
-      description = "PyPy is a fast, compliant alternative implementation of the Python language (2.7.3)";
+      description = "Fast, compliant alternative implementation of the Python language (2.7.3)";
       license = licenses.mit;
       platforms = platforms.linux;
       maintainers = with maintainers; [ iElectric ];

--- a/pkgs/development/libraries/boost/1.44.nix
+++ b/pkgs/development/libraries/boost/1.44.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "http://boost.org/";
-    description = "Boost C++ Library Collection";
+    description = "Collection of C++ libraries";
     license = "boost-license";
 
     maintainers = [ stdenv.lib.maintainers.simons ];

--- a/pkgs/development/libraries/boost/1.49.nix
+++ b/pkgs/development/libraries/boost/1.49.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "http://boost.org/";
-    description = "Boost C++ Library Collection";
+    description = "Collection of C++ libraries";
     license = "boost-license";
 
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/boost/1.55.nix
+++ b/pkgs/development/libraries/boost/1.55.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "http://boost.org/";
-    description = "Boost C++ Library Collection";
+    description = "Collection of C++ libraries";
     license = "boost-license";
 
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/ccrtp/default.nix
+++ b/pkgs/development/libraries/ccrtp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   meta = {
-    description = "GNU ccRTP, an implementation of the IETF real-time transport protocol (RTP)";
+    description = "An implementation of the IETF real-time transport protocol (RTP)";
     homepage = http://www.gnu.org/software/ccrtp/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ marcweber ];

--- a/pkgs/development/libraries/celt/default.nix
+++ b/pkgs/development/libraries/celt/default.nix
@@ -29,7 +29,7 @@ rec {
   phaseNames = ["doConfigure" "doMakeInstall"];
       
   meta = {
-    description = "CELT - low-delay audio codec";
+    description = "Low-delay audio codec";
     maintainers = with a.lib.maintainers;
     [
       raskin

--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://heasarc.gsfc.nasa.gov/fitsio/;
 
-    description = "CFITSIO, a library for reading and writing FITS data files";
+    description = "Library for reading and writing FITS data files";
 
     longDescription =
       '' CFITSIO is a library of C and Fortran subroutines for reading and

--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   doCheck = false;
 
   meta = {
-    description = "Check, a unit testing framework for C";
+    description = "Unit testing framework for C";
 
     longDescription =
       '' Check is a unit testing framework for C.  It features a simple

--- a/pkgs/development/libraries/chipmunk/default.nix
+++ b/pkgs/development/libraries/chipmunk/default.nix
@@ -34,6 +34,6 @@ rec {
       
   name = "chipmunk-" + version;
   meta = {
-    description = "Chipmunk 2D physics engine";
+    description = "2D physics engine";
   };
 }

--- a/pkgs/development/libraries/cloog/default.nix
+++ b/pkgs/development/libraries/cloog/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "CLooG, the Chunky Loop Generator";
+    description = "Library that generates loops for scanning polyhedra";
 
     longDescription = ''
       CLooG is a free software library to generate code for scanning

--- a/pkgs/development/libraries/clutter-gst/default.nix
+++ b/pkgs/development/libraries/clutter-gst/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   postBuild = "rm -rf $out/share/gtk-doc";
 
   meta = {
-    description = "Clutter-GST";
+    description = "GStreamer bindings for clutter";
 
     homepage = http://www.clutter-project.org/;
 

--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   #doCheck = true; # no tests possible without a display
 
   meta = {
-    description = "Clutter, a library for creating fast, dynamic graphical user interfaces";
+    description = "Library for creating fast, dynamic graphical user interfaces";
 
     longDescription =
       '' Clutter is free software library for creating fast, compelling,

--- a/pkgs/development/libraries/fox/default.nix
+++ b/pkgs/development/libraries/fox/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "FOX is a C++ based class library for building Graphical User Interfaces";
+    description = "C++ based class library for building Graphical User Interfaces";
     longDescription = ''
         FOX stands for Free Objects for X.
         It is a C++ based class library for building Graphical User Interfaces.

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (rec {
   };
 
   meta = {
-    description = "GNU gettext, a well integrated set of translation tools and documentation";
+    description = "Well integrated set of translation tools and documentation";
 
     longDescription = ''
       Usually, programs are written and documented in English, and use

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    description = "GLib, a C library of programming buildings blocks";
+    description = "C library of programming buildings blocks";
     homepage    = http://www.gtk.org/;
     license     = licenses.lgpl2Plus;
     maintainers = with maintainers; [ lovek323 raskin urkud ];

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -11,6 +11,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://code.google.com/p/google-glog/;
     license = "BSD";
-    description = "The glog library implements application-level logging.";
+    description = "Library for application-level logging";
   };
 }

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    description = "GMP, the GNU multiple precision arithmetic library";
+    description = "GNU multiple precision arithmetic library";
 
     longDescription =
       '' GMP is a free library for arbitrary precision arithmetic, operating

--- a/pkgs/development/libraries/gmp/5.0.5.nix
+++ b/pkgs/development/libraries/gmp/5.0.5.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "GMP, the GNU multiple precision arithmetic library";
+    description = "GNU multiple precision arithmetic library";
 
     longDescription =
       '' GMP is a free library for arbitrary precision arithmetic, operating

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (rec {
 
   meta = with stdenv.lib; {
     homepage = "http://gmplib.org/";
-    description = "GMP, the GNU multiple precision arithmetic library";
+    description = "GNU multiple precision arithmetic library";
     license = licenses.gpl3Plus;
 
     longDescription =

--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU GSS Generic Security Service";
+    description = "Generic Security Service";
 
     longDescription =
       '' GSS is an implementation of the Generic Security Service Application

--- a/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gnonlin/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://gstreamer.freedesktop.org/modules/gnonlin.html";
-    description = "http://gstreamer.freedesktop.org/modules/gnonlin.html";
+    description = "Gstreamer Non-Linear Multimedia Editing Plugins";
     license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://gstreamer.freedesktop.org;
 
-    description = "GStreamer, a library for constructing graphs of media-handling components";
+    description = "Library for constructing graphs of media-handling components";
 
     longDescription = ''
       GStreamer is a library for constructing graphs of media-handling

--- a/pkgs/development/libraries/gtkimageview/default.nix
+++ b/pkgs/development/libraries/gtkimageview/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://trac.bjourne.webfactional.com/;
 
-    description = "The GtkImageView image viewer widget for GTK+";
+    description = "Image viewer widget for GTK+";
 
     longDescription =
       '' GtkImageView is a simple image viewer widget for GTK+.  Similar to

--- a/pkgs/development/libraries/gtkmathview/default.nix
+++ b/pkgs/development/libraries/gtkmathview/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://helm.cs.unibo.it/mml-widget/;
-    description = "GtkMathView is a C++ rendering engine for MathML documents";
+    description = "C++ rendering engine for MathML documents";
     license = stdenv.lib.licenses.lgpl3Plus;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
   };

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gupnp.org/;
-    description = "GUPnP is an implementation of the UPnP specification.";
+    description = "An implementation of the UPnP specification";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/hwloc/default.nix
+++ b/pkgs/development/libraries/hwloc/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isCygwin;
 
   meta = {
-    description = "hwloc, a portable abstraction of hierarchical architectures for high-performance computing";
+    description = "Portable abstraction of hierarchical architectures for high-performance computing";
 
     longDescription = ''
        hwloc provides a portable abstraction (across OS,

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -15,6 +15,6 @@ stdenv.mkDerivation rec {
   
   meta = {
     homepage = http://www.ece.uvic.ca/~mdadams/jasper/;
-    description = "JasPer JPEG2000 Library";
+    description = "JPEG2000 Library";
   };
 }

--- a/pkgs/development/libraries/java/classpath/default.nix
+++ b/pkgs/development/libraries/java/classpath/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   configureFlags = "--disable-Werror --disable-plugin --with-antlr-jar=${antlr}/lib/antlr.jar";
 
   meta = {
-    description = "GNU Classpath, essential libraries for Java";
+    description = "Essential libraries for Java";
 
     longDescription = ''
       GNU Classpath, Essential Libraries for Java, is a GNU project to create

--- a/pkgs/development/libraries/java/rhino/default.nix
+++ b/pkgs/development/libraries/java/rhino/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     '';
 
   meta = {
-    description = "Mozilla Rhino: JavaScript for Java";
+    description = "An implementation of JavaScript written in Java";
 
     longDescription =
       '' Rhino is an open-source implementation of JavaScript written

--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "Libassuan, the IPC library used by GnuPG and related software";
+    description = "IPC library used by GnuPG and related software";
 
     longDescription = ''
       Libassuan is a small library implementing the so-called Assuan

--- a/pkgs/development/libraries/libcddb/default.nix
+++ b/pkgs/development/libraries/libcddb/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "Libcddb is a C library to access data on a CDDB server (freedb.org)";
+    description = "C library to access data on a CDDB server (freedb.org)";
     license = stdenv.lib.licenses.lgpl2Plus;
     homepage = http://libcddb.sourceforge.net/;
   };

--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = http://projects.gnome.org/libchamplain/;
     license = stdenv.lib.licenses.lgpl2Plus;
 
-    description = "libchamplain, a C library providing a ClutterActor to display maps";
+    description = "C library providing a ClutterActor to display maps";
 
     longDescription =
       '' libchamplain is a C library providing a ClutterActor to display

--- a/pkgs/development/libraries/libchop/default.nix
+++ b/pkgs/development/libraries/libchop/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "libchop, tools & library for data backup and distributed storage";
+    description = "Tools & library for data backup and distributed storage";
 
     longDescription =
       '' Libchop is a set of utilities and library for data backup and

--- a/pkgs/development/libraries/libdaemon/default.nix
+++ b/pkgs/development/libraries/libdaemon/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--disable-lynx" ];
 
   meta = {
-    description = "libdaemon, a lightweight C library that eases the writing of UNIX daemons";
+    description = "Lightweight C library that eases the writing of UNIX daemons";
 
     homepage = http://0pointer.de/lennart/projects/libdaemon/;
 

--- a/pkgs/development/libraries/libdnet/default.nix
+++ b/pkgs/development/libraries/libdnet/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "libdnet provides a simplified, portable interface to several low-level networking routines";
+    description = "Provides a simplified, portable interface to several low-level networking routines";
     homepage = http://code.google.com/p/libdnet/;
     license = "BSD"; # New BSD license
     maintainers = [stdenv.lib.maintainers.marcweber];

--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (rec {
   doCheck = true;
 
   meta = {
-    description = "Libelf, an ELF object file access library";
+    description = "ELF object file access library";
 
     homepage = http://www.mr511.de/software/english.html;
 

--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "libevent, an event notification library";
+    description = "Event notification library";
 
     longDescription =
       '' The libevent API provides a mechanism to execute a callback function

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   #postInstall = "make check";
 
   meta = {
-    description = "GNU libextractor, a simple library for keyword extraction";
+    description = "Simple library for keyword extraction";
 
     longDescription =
       '' GNU libextractor is a library used to extract meta-data from files

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (rec {
   '';
 
   meta = {
-    description = "GNU Libgcrypt, a general-pupose cryptographic library";
+    description = "General-pupose cryptographic library";
 
     longDescription = ''
       GNU Libgcrypt is a general purpose cryptographic library based on

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "GNU libiconv, an iconv(3) implementation";
+    description = "An iconv(3) implementation";
 
     longDescription = ''
       Some programs, like mailers and web browsers, must be able to convert

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/libidn/;
-    description = "GNU Libidn library for internationalized domain names";
+    description = "Library for internationalized domain names";
 
     longDescription = ''
       GNU Libidn is a fully documented implementation of the

--- a/pkgs/development/libraries/libksba/default.nix
+++ b/pkgs/development/libraries/libksba/default.nix
@@ -12,6 +12,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnupg.org;
-    description = "Libksba is a CMS and X.509 access library under development";
+    description = "CMS and X.509 access library under development";
   };
 }

--- a/pkgs/development/libraries/libmicrohttpd/default.nix
+++ b/pkgs/development/libraries/libmicrohttpd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    description = "GNU libmicrohttpd, an embeddable HTTP server library";
+    description = "Embeddable HTTP server library";
 
     longDescription = ''
       GNU libmicrohttpd is a small C library that is supposed to make

--- a/pkgs/development/libraries/libofa/default.nix
+++ b/pkgs/development/libraries/libofa/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://code.google.com/musicip-libofa/;
-    description = "LibOFA - Library Open Fingerprint Architecture";
+    description = "Library Open Fingerprint Architecture";
     longDescription = ''
       LibOFA (Library Open Fingerprint Architecture) is an open-source audio
       fingerprint created and provided by MusicIP'';

--- a/pkgs/development/libraries/libsigsegv/default.nix
+++ b/pkgs/development/libraries/libsigsegv/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/libsigsegv/;
-    description = "GNU libsigsegv, a library to handle page faults in user mode";
+    description = "Library to handle page faults in user mode";
 
     longDescription = ''
       GNU libsigsegv is a library for handling page faults in user mode. A

--- a/pkgs/development/libraries/libspectre/default.nix
+++ b/pkgs/development/libraries/libspectre/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://libspectre.freedesktop.org/;
-    description = "libspectre, a PostScript rendering library";
+    description = "PostScript rendering library";
 
     longDescription = ''
       libspectre is a small library for rendering Postscript

--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/libtasn1/;
-    description = "GNU Libtasn1, an ASN.1 library";
+    description = "An ASN.1 library";
 
     longDescription =
       '' Libtasn1 is the ASN.1 library used by GnuTLS, GNU Shishi and some

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (rec {
   meta = {
     homepage = http://www.gnu.org/software/libunistring/;
 
-    description = "GNU Libunistring, a Unicode string library";
+    description = "Unicode string library";
 
     longDescription = ''
       This library provides functions for manipulating Unicode strings

--- a/pkgs/development/libraries/libxmi/default.nix
+++ b/pkgs/development/libraries/libxmi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   preConfigure = "cp ${libtool}/share/libtool/config/config.sub .";
 
   meta = {
-    description = "GNU libxmi, a library for rasterizing 2-D vector graphics";
+    description = "Library for rasterizing 2-D vector graphics";
     homepage = http://www.gnu.org/software/libxmi/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.gnu;  # arbitrary choice

--- a/pkgs/development/libraries/lightning/default.nix
+++ b/pkgs/development/libraries/lightning/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/lightning/;
-    description = "GNU lightning, a run-time code generation library";
+    description = "Run-time code generation library";
 
     longDescription = ''
       GNU lightning is a library that generates assembly language code

--- a/pkgs/development/libraries/ming/default.nix
+++ b/pkgs/development/libraries/ming/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "Ming, a library for generating Flash `.swf' files";
+    description = "Library for generating Flash `.swf' files";
 
     longDescription = ''
       Ming is a library for generating Macromedia Flash files (.swf),

--- a/pkgs/development/libraries/mpc/default.nix
+++ b/pkgs/development/libraries/mpc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU MPC, a library for multiprecision complex arithmetic with exact rounding";
+    description = "Library for multiprecision complex arithmetic with exact rounding";
 
     longDescription =
       '' GNU MPC is a C library for the arithmetic of complex numbers with

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.mpfr.org/;
-    description = "GNU MPFR, a library for multiple-precision floating-point arithmetic";
+    description = "Library for multiple-precision floating-point arithmetic";
 
     longDescription = ''
       The GNU MPFR library is a C library for multiple-precision

--- a/pkgs/development/libraries/mpich2/default.nix
+++ b/pkgs/development/libraries/mpich2/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     '';
 
   meta = {
-    description = "MPICH2, an implementation of the Message Passing Interface (MPI) standard";
+    description = "Implementation of the Message Passing Interface (MPI) standard";
 
     longDescription = ''
       MPICH2 is a free high-performance and portable implementation of

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   postFixup = lib.optionalString stdenv.isDarwin "rm $out/lib/*.so";
 
   meta = {
-    description = "GNU Ncurses, a free software emulation of curses in SVR4 and more";
+    description = "Free software emulation of curses in SVR4 and more";
 
     longDescription = ''
       The Ncurses (new curses) library is a free software emulation of

--- a/pkgs/development/libraries/nettle/default.nix
+++ b/pkgs/development/libraries/nettle/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (rec {
               ./cygwin.patch;
 
   meta = {
-    description = "GNU Nettle, a cryptographic library";
+    description = "Cryptographic library";
 
     longDescription = ''
         Nettle is a cryptographic library that is designed to fit

--- a/pkgs/development/libraries/oniguruma/default.nix
+++ b/pkgs/development/libraries/oniguruma/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   
   meta = {
     homepage = http://www.geocities.jp/kosako3/oniguruma/;
-    description = "Oniguruma regular expressions library";
+    description = "Regular expressions library";
     license = "BSD";
   };
 }

--- a/pkgs/development/libraries/opal/default.nix
+++ b/pkgs/development/libraries/opal/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   patches = [ ./disable-samples-ftbfs.diff ./libav9.patch ./libav10.patch ];
       
   meta = with stdenv.lib; {
-    description = "OPAL VoIP library";
+    description = "VoIP library";
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/openal/default.nix
+++ b/pkgs/development/libraries/openal/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib;
 
   meta = {
-    description = "OpenAL, a cross-platform 3D audio API";
+    description = "Cross-platform 3D audio API";
 
     longDescription = ''
       OpenAL is a cross-platform 3D audio API appropriate for use with

--- a/pkgs/development/libraries/plib/default.nix
+++ b/pkgs/development/libraries/plib/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "PLIB: A Suite of Portable Game Libraries";
+    description = "A suite of portable game libraries";
 
     longDescription = ''
       PLIB includes sound effects, music, a complete 3D engine, font

--- a/pkgs/development/libraries/ppl/default.nix
+++ b/pkgs/development/libraries/ppl/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "PPL: The Parma Polyhedra Library";
+    description = "The Parma Polyhedra Library";
 
     longDescription = ''
       The Parma Polyhedra Library (PPL) provides numerical abstractions

--- a/pkgs/development/libraries/readline/readline6.3.nix
+++ b/pkgs/development/libraries/readline/readline6.3.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (rec {
     ];
 
   meta = {
-    description = "GNU Readline, a library for interactive line editing";
+    description = "Library for interactive line editing";
 
     longDescription = ''
       The GNU Readline library provides a set of functions for use by

--- a/pkgs/development/libraries/readline/readline6.nix
+++ b/pkgs/development/libraries/readline/readline6.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (rec {
        import ./readline-6.2-patches.nix patch);
 
   meta = {
-    description = "GNU Readline, a library for interactive line editing";
+    description = "Library for interactive line editing";
 
     longDescription = ''
       The GNU Readline library provides a set of functions for use by

--- a/pkgs/development/libraries/science/biology/biolib/default.nix
+++ b/pkgs/development/libraries/science/biology/biolib/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://biolib.open-bio.org/";
-    description = "BioLib";
+    description = "Shared libraries for the major Bio* languages";
     license = stdenv.lib.licenses.gpl2;
     longDescription = ''
       BioLib brings together a set of opensource libraries written

--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -8,9 +8,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    description = "
-      Szip is a compression library that can be used with the hdf5 library.
-    ";
+    description = "Compression library that can be used with the hdf5 library";
     homepage = http://www.hdfgroup.org/doc_resource/SZIP/;
     license = stdenv.lib.licenses.unfree;
   };

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '' else "";
 
   meta = {
-    description = "talloc is a hierarchical pool based memory allocator with destructors";
+    description = "Hierarchical pool based memory allocator with destructors";
     homepage = http://tdb.samba.org/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxslt libxml2 docbook_xsl ];
 
   meta = {
-    description = "TDB, the trivial database";
+    description = "The trivial database";
     longDescription =
       '' TDB is a Trivial Database. In concept, it is very much like GDBM,
          and BSD's DB except that it allows multiple simultaneous writers and

--- a/pkgs/development/libraries/tecla/default.nix
+++ b/pkgs/development/libraries/tecla/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.astro.caltech.edu/~mcs/tecla/";
-    description = "Tecla command-line editing library";
+    description = "Command-line editing library";
     license = "as-is";
 
     hydraPlatforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/ucommon/default.nix
+++ b/pkgs/development/libraries/ucommon/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU uCommon C++, C++ library to facilitate using C++ design patterns";
+    description = "C++ library to facilitate using C++ design patterns";
     homepage = http://www.gnu.org/software/commoncpp/;
     license = stdenv.lib.licenses.lgpl3Plus;
 

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   '' else null;
 
   meta = with stdenv.lib; {
-    description = "V8 is Google's open source JavaScript engine";
+    description = "Google's open source JavaScript engine";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;
   };

--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   buildInputs = [ libuuid zlib ];
 
   meta = { 
-    description = "Xapian Probabilistic Information Retrieval library";
+    description = "Search engine library";
     homepage = "http://xapian.org";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.chaoflow ];

--- a/pkgs/development/libraries/xbase/default.nix
+++ b/pkgs/development/libraries/xbase/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://linux.techass.com/projects/xdb/;
-    description = "XBase compatible C++ class library formerly known as XDB";
+    description = "C++ class library formerly known as XDB";
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.urkud ];
   };

--- a/pkgs/development/libraries/xylib/default.nix
+++ b/pkgs/development/libraries/xylib/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   buildInputs = [boost zlib bzip2 ];
 
   meta = {
-    description = "xylib is a portable library for reading files that contain x-y data from powder diffraction, spectroscopy and other experimental methods.";
+    description = "Portable library for reading files that contain x-y data from powder diffraction, spectroscopy and other experimental methods";
     license = "LGPL";
     homepage = http://xylib.sourceforge.net/;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/python-modules/ecdsa/default.nix
+++ b/pkgs/development/python-modules/ecdsa/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "http://github.com/warner/python-ecdsa";
-    description = "pure-python ECDSA signature/verification";
+    description = "Pure-python ECDSA signature/verification";
     license = stdenv.lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/numeric/default.nix
+++ b/pkgs/development/python-modules/numeric/default.nix
@@ -23,7 +23,7 @@ let version = "24.2"; in
     # FIXME: Run the tests.
 
     meta = {
-      description = "Numeric, a Python module for high-performance, numeric computing";
+      description = "A Python module for high-performance, numeric computing";
 
       longDescription = ''
         Numeric is a Python module for high-performance, numeric

--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "LCOV, a code coverage tool that enhances GNU gcov";
+    description = "Code coverage tool that enhances GNU gcov";
 
     longDescription =
       '' LCOV is an extension of GCOV, a GNU tool which provides information

--- a/pkgs/development/tools/analysis/sparse/default.nix
+++ b/pkgs/development/tools/analysis/sparse/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "Sparse, a semantic parser for C";
+    description = "Semantic parser for C";
     homepage    = "https://git.kernel.org/cgit/devel/sparse/sparse.git/";
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.linux;

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.valgrind.org/;
-    description = "Valgrind, a debugging and profiling tool suite";
+    description = "Debugging and profiling tool suite";
 
     longDescription = ''
       Valgrind is an award-winning instrumentation framework for

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ unzip jdk makeWrapper ];
 
   meta = {
-    description = "Gradle is an enterprise-grade build system";
+    description = "Enterprise-grade build system";
     longDescription = ''
       Gradle is a build system which offers you ease, power and freedom.
       You can choose the balance for yourself. It has powerful multi-project

--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   meta = {
     license = stdenv.lib.licenses.gpl2Plus;
     homepage = "http://doxygen.org/";
-    description = "Doxygen, a source code documentation generator tool";
+    description = "Source code documentation generator tool";
 
     longDescription = ''
       Doxygen is a documentation system for C++, C, Java, Objective-C,

--- a/pkgs/development/tools/java/fastjar/default.nix
+++ b/pkgs/development/tools/java/fastjar/default.nix
@@ -14,7 +14,7 @@ let version = "0.94"; in
     doCheck = true;
 
     meta = {
-      description = "FastJar, a fast Java archiver written in C";
+      description = "Fast Java archiver written in C";
 
       longDescription = ''
         Fastjar is a version of Sun's `jar' utility, written entirely in C, and

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "GNU Binutils, tools for manipulating binaries (linker, assembler, etc.)";
+    description = "Tools for manipulating binaries (linker, assembler, etc.)";
 
     longDescription = ''
       The GNU Binutils are a collection of binary tools.  The main

--- a/pkgs/development/tools/misc/cflow/default.nix
+++ b/pkgs/development/tools/misc/cflow/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU cflow, a tool to analyze the control flow of C programs";
+    description = "Tool to analyze the control flow of C programs";
 
     longDescription = ''
       GNU cflow analyzes a collection of C source files and prints a

--- a/pkgs/development/tools/misc/coccinelle/default.nix
+++ b/pkgs/development/tools/misc/coccinelle/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation {
   configureFlags = "--enable-release";
 
   meta = {
-    description = "Coccinelle, a program to apply C code semantic patches";
+    description = "Program to apply semantic patches to C code";
 
     longDescription =
       '' Coccinelle is a program matching and transformation engine which

--- a/pkgs/development/tools/misc/complexity/default.nix
+++ b/pkgs/development/tools/misc/complexity/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "GNU Complexity, C code complexity measurement tool";
+    description = "C code complexity measurement tool";
 
     longDescription =
       '' GNU Complexity is a tool designed for analyzing the complexity of C

--- a/pkgs/development/tools/misc/cppi/default.nix
+++ b/pkgs/development/tools/misc/cppi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://savannah.gnu.org/projects/cppi/;
 
-    description = "GNU cppi, a cpp directive indenter";
+    description = "A C preprocessor directive indenter";
 
     longDescription =
       '' GNU cppi indents C preprocessor directives to reflect their nesting

--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "Cscope, a developer's tool for browsing source code";
+    description = "A developer's tool for browsing source code";
 
     longDescription = ''
       Cscope is a developer's tool for browsing source code.  It has

--- a/pkgs/development/tools/misc/ctags/default.nix
+++ b/pkgs/development/tools/misc/ctags/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://ctags.sourceforge.net/";
-    description = "Exuberant Ctags, a tool for fast source code browsing";
+    description = "A tool for fast source code browsing (exuberant ctags)";
     license = stdenv.lib.licenses.gpl2Plus;
 
     longDescription = ''

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    description = "GDB, the GNU Project debugger";
+    description = "The GNU Project debugger";
 
     longDescription = ''
       GDB, the GNU Project debugger, allows you to see what is going

--- a/pkgs/development/tools/misc/gengetopt/default.nix
+++ b/pkgs/development/tools/misc/gengetopt/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Gengetopt, a command-line option parser generator";
+    description = "Command-line option parser generator";
 
     longDescription =
       '' GNU Gengetopt program generates a C function that uses getopt_long

--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "GNU GLOBAL source code tag system";
+    description = "Source code tag system";
 
     longDescription = ''
       GNU GLOBAL is a source code tagging system that works the same way

--- a/pkgs/development/tools/misc/gperf/default.nix
+++ b/pkgs/development/tools/misc/gperf/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "GNU gperf, a perfect hash function generator";
+    description = "Perfect hash function generator";
 
     longDescription = ''
       GNU gperf is a perfect hash function generator.  For a given

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
 
   meta = {
-    description = "GNU help2man generates man pages from `--help' output";
+    description = "Generate man pages from `--help' output";
 
     longDescription =
       '' help2man produces simple manual pages from the ‘--help’ and

--- a/pkgs/development/tools/misc/libtool/default.nix
+++ b/pkgs/development/tools/misc/libtool/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   dontPatchShebangs = true;
 
   meta = {
-    description = "GNU Libtool, a generic library support script";
+    description = "Generic library support script";
 
     longDescription = ''
       GNU libtool is a generic library support script.  Libtool hides

--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "SLOCCount, a set of tools for counting physical Source Lines of Code (SLOC)";
+    description = "Set of tools for counting physical Source Lines of Code (SLOC)";
 
     longDescription = ''
       This is the home page of "SLOCCount", a set of tools for

--- a/pkgs/development/tools/misc/swig/default.nix
+++ b/pkgs/development/tools/misc/swig/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   configureFlags = stdenv.lib.optionalString stdenv.isDarwin "--disable-ccache";
 
   meta = {
-    description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
+    description = "Interface compiler that connects C/C++ code to higher-level languages";
 
     longDescription = ''
        SWIG is an interface compiler that connects programs written in C and

--- a/pkgs/development/tools/misc/texinfo/4.13a.nix
+++ b/pkgs/development/tools/misc/texinfo/4.13a.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   #doCheck = true;
 
   meta = {
-    description = "GNU Texinfo, the GNU documentation system";
+    description = "The GNU documentation system";
 
     longDescription = ''
       Texinfo is the official documentation format of the GNU project.

--- a/pkgs/development/tools/misc/texinfo/5.2.nix
+++ b/pkgs/development/tools/misc/texinfo/5.2.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.gnu.org/software/texinfo/";
-    description = "GNU Texinfo, the GNU documentation system";
+    description = "The GNU documentation system";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.all;
 

--- a/pkgs/development/tools/ocaml/omake/default.nix
+++ b/pkgs/development/tools/ocaml/omake/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 #  buildFlags = "world.opt";
 
   meta = {
-    description = "Omake build system";
+    description = "A build system designed for scalability and portability";
     homepage = "${webpage}";
     license = "GPL";
   };

--- a/pkgs/development/tools/parsing/bison/2.x.nix
+++ b/pkgs/development/tools/parsing/bison/2.x.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.gnu.org/software/bison/";
-    description = "GNU Bison, a Yacc-compatible parser generator";
+    description = "Yacc-compatible parser generator";
     license = stdenv.lib.licenses.gpl3Plus;
 
     longDescription = ''

--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.gnu.org/software/bison/";
-    description = "GNU Bison, a Yacc-compatible parser generator";
+    description = "Yacc-compatible parser generator";
     license = stdenv.lib.licenses.gpl3Plus;
 
     longDescription = ''

--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "OProfile, a system-wide profiler for Linux";
+    description = "System-wide profiler for Linux";
     longDescription = ''
       OProfile is a system-wide profiler for Linux systems, capable of
       profiling all running code at low overhead.  It consists of a

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://sysprof.com/;
-    description = "Sysprof, a system-wide profiler for Linux";
+    description = "System-wide profiler for Linux";
     license = stdenv.lib.licenses.gpl2Plus;
 
     longDescription = ''

--- a/pkgs/development/tools/sqsh/default.nix
+++ b/pkgs/development/tools/sqsh/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "SQSH is command line tool for querying Sybase/MSSQL databases";
+    description = "Command line tool for querying Sybase/MSSQL databases";
     longDescription = 
       ''
       Sqsh (pronounced skwish) is short for SQshelL (pronounced s-q-shell),

--- a/pkgs/games/banner/default.nix
+++ b/pkgs/games/banner/default.nix
@@ -36,7 +36,7 @@ mkDerivation "banner-1.3.2" "0dc0ac0667b2e884a7f5ad3e467af68cd0fd5917f8c9aa19188
 
   meta = {
     homepage = "http://shh.thathost.com/pub-unix/";
-    description = "print large banners to ASCII terminals";
+    description = "Print large banners to ASCII terminals";
     license = stdenv.lib.licenses.gpl2;
 
     longDescription = ''

--- a/pkgs/games/chessdb/default.nix
+++ b/pkgs/games/chessdb/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://chessdb.sourceforge.net/;
-    description = "ChessDB is a free chess database";
+    description = "A free chess database";
   };
 }

--- a/pkgs/games/construo/default.nix
+++ b/pkgs/games/construo/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
 	builder = writeScript (name + "-builder")
 		(textClosure localDefs ["preConfigure" "doConfigure" "doMakeInstall" "doForceShare" "doPropagate"]);
 	meta = {
-		description = "Construo masses and springs simulation";
+		description = "Masses and springs simulation game";
 	};
 }

--- a/pkgs/games/crafty/default.nix
+++ b/pkgs/games/crafty/default.nix
@@ -659,7 +659,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.craftychess.com/;
-    description = "Crafty is a free, open-source computer chess program developed by Dr. Robert M. Hyatt";
+    description = "Chess program developed by Dr. Robert M. Hyatt";
     license = stdenv.lib.licenses.unfree;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.jwiegley ];

--- a/pkgs/games/eboard/default.nix
+++ b/pkgs/games/eboard/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://www.bergo.eng.br/eboard/;
-    description = "eboard is a chess interface for Unix-like systems";
+    description = "Chess interface for Unix-like systems";
   };
 }

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     else null;
 
   meta = with stdenv.lib; {
-    description = "OpenSpades is a compatible client of Ace of Spades 0.75";
+    description = "A compatible client of Ace of Spades 0.75";
     homepage    = "https://github.com/yvt/openspades/";
     license     = licenses.gpl3;
     platforms   = platforms.linux;

--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = ''OpenTTD is an open source clone of the Microprose game "Transport Tycoon Deluxe"'';
+    description = ''Open source clone of the Microprose game "Transport Tycoon Deluxe"'';
     longDescription = ''
       OpenTTD is a transportation economics simulator. In single player mode,
       players control a transportation business, and use rail, road, sea, and air

--- a/pkgs/games/opentyrian/default.nix
+++ b/pkgs/games/opentyrian/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ";
 
   meta = {
-    description = ''OpenTyrian is an open source port of the game "Tyrian".'';
+    description = ''Open source port of the game "Tyrian"'';
     homepage = https://opentyrian.googlecode.com/;
     # This does not account of Tyrian data.
     # license = stdenv.lib.licenses.gpl2;

--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -51,7 +51,7 @@ EOF
   '';
 
   meta = {
-    description = "Teeworlds, a retro multiplayer shooter game";
+    description = "Retro multiplayer shooter game";
 
     longDescription = ''
       Teeworlds is a free online multiplayer game, available for all

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -12,7 +12,7 @@ assert cupsSupport -> cups != null;
 let
   meta_common = {
     homepage = "http://www.gnu.org/software/ghostscript/";
-    description = "GNU Ghostscript, a PostScript interpreter";
+    description = "PostScript interpreter (GNU version)";
 
     longDescription = ''
       Ghostscript is the name of a set of tools that provides (i) an
@@ -48,7 +48,7 @@ let
     };
     meta = meta_common // {
       homepage = "http://www.ghostscript.com/";
-      description = "GPL Ghostscript, a PostScript interpreter";
+      description = "PostScript interpreter (mainline version)";
     };
 
     preConfigure = ''

--- a/pkgs/misc/xosd/default.nix
+++ b/pkgs/misc/xosd/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 libXext libXt xextproto xproto ];
 
   meta = {
-    description = "XOSD displays text on your screen";
+    description = "Displays text on your screen";
   };
 }

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://conky.sourceforge.net/;
-    description = "Conky is an advanced, highly configurable system monitor based on torsmo";
+    description = "Advanced, highly configurable system monitor based on torsmo";
     maintainers = [ stdenv.lib.maintainers.guibert ];
     license = stdenv.lib.licenses.gpl3Plus;
   };

--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "GNU Dico, a flexible dictionary server and client implementing RFC 2229";
+    description = "Flexible dictionary server and client implementing RFC 2229";
     homepage    = http://www.gnu.org/software/dico/;
     license     = "GPLv3+";
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.isc.org/software/bind";
-    description = "ISC BIND: a domain name server";
+    description = "Domain name server";
     license = stdenv.lib.licenses.isc;
 
     maintainers = with stdenv.lib.maintainers; [viric simons];

--- a/pkgs/servers/felix/default.nix
+++ b/pkgs/servers/felix/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     cp -av * $out
   '';
   meta = {
-    description = "Apache Felix OSGi gateway";
+    description = "An OSGi gateway";
     homepage = http://felix.apache.org;
     license = "ASF";
     maintainers = [ stdenv.lib.maintainers.sander ];

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   installPhase = ''cp -r gen/firebird $out'';
 
   meta = {
-    description = "firebird database engine";
+    description = "SQL relational database management system";
     homepage = http://www.firebirdnews.org;
     license = ["IDPL" "Interbase-1.0"];
     maintainers = [stdenv.lib.maintainers.marcweber];

--- a/pkgs/servers/http/couchdb/default.nix
+++ b/pkgs/servers/http/couchdb/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Apache CouchDB is a database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API";
+    description = "A database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API";
     homepage = "http://couchdb.apache.org";
     license = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers; [ viric garbas ];

--- a/pkgs/servers/http/jboss/default.nix
+++ b/pkgs/servers/http/jboss/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   
   meta = {
     homepage = "http://www.jboss.org/";
-    description = "JBoss, Open Source J2EE application server";
+    description = "Open Source J2EE application server";
     license = "GPL/LGPL";
     maintainers = [ lib.maintainers.sander ];
   };

--- a/pkgs/servers/pies/default.nix
+++ b/pkgs/servers/pies/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Pies, a program invocation and execution supervisor";
+    description = "A program invocation and execution supervisor";
 
     longDescription =
       '' The name Pies (pronounced "p-yes") stands for Program Invocation and

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   installFlags = "sysconfdir=$(out)/etc pulseconfdir=$(out)/etc/pulse";
 
   meta = with stdenv.lib; {
-    description = "PulseAudio, a sound server for POSIX and Win32 systems";
+    description = "Sound server for POSIX and Win32 systems";
     homepage    = http://www.pulseaudio.org/;
     # Note: Practically, the server is under the GPL due to the
     # dependency on `libsamplerate'.  See `LICENSE' for details.

--- a/pkgs/servers/shishi/default.nix
+++ b/pkgs/servers/shishi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Shishi, free implementation of the Kerberos 5 network security system";
+    description = "An implementation of the Kerberos 5 network security system";
     homepage    = http://www.gnu.org/software/shishi/;
     license     = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ bjg lovek323 ];

--- a/pkgs/shells/rush/default.nix
+++ b/pkgs/shells/rush/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Rush, Restricted User Shell";
+    description = "Restricted User Shell";
 
     longDescription =
       '' GNU Rush is a Restricted User Shell, designed for sites

--- a/pkgs/tools/X11/hsetroot/default.nix
+++ b/pkgs/tools/X11/hsetroot/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   buildInputs = [ imlib2 libX11 libXext ];
 
   meta = {
-    description = "hsetroot allows you to compose wallpapers ('root pixmaps') for X";
+    description = "Allows you to compose wallpapers ('root pixmaps') for X";
     homepage = http://thegraveyard.org/hsetroot.html;
     license = stdenv.lib.licenses.gpl2Plus;
   };

--- a/pkgs/tools/X11/wmctrl/default.nix
+++ b/pkgs/tools/X11/wmctrl/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://tomas.styblo.name/wmctrl/;
-    description = "wmctrl is a UNIX/Linux command line tool to interact with an EWMH/NetWM compatible X Window Manager";
+    description = "Command line tool to interact with an EWMH/NetWM compatible X Window Manager";
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; all;
   };

--- a/pkgs/tools/X11/xnee/default.nix
+++ b/pkgs/tools/X11/xnee/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Xnee, an X11 event recording and replay tool";
+    description = "X11 event recording and replay tool";
 
     longDescription =
       '' Xnee is a suite of programs that can record, replay and distribute

--- a/pkgs/tools/X11/xtrace/default.nix
+++ b/pkgs/tools/X11/xtrace/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://xtrace.alioth.debian.org/;
-    description = "xtrace, a tool to trace X11 protocol connections";
+    description = "Tool to trace X11 protocol connections";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/tools/admin/tightvnc/default.nix
+++ b/pkgs/tools/admin/tightvnc/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   meta = {
     license = stdenv.lib.licenses.gpl2Plus;
     homepage = "http://vnc-tight.sourceforge.net/";
-    description = "TightVNC is an improved version of VNC";
+    description = "Improved version of VNC";
 
     longDescription = ''
       TightVNC is an improved version of VNC, the great free

--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "GNU Sharutils, tools for remote synchronization and `shell archives'";
+    description = "Tools for remote synchronization and `shell archives'";
 
     longDescription =
       '' GNU shar makes so-called shell archives out of many files, preparing

--- a/pkgs/tools/backup/partclone/default.nix
+++ b/pkgs/tools/backup/partclone/default.nix
@@ -17,7 +17,13 @@ stdenv.mkDerivation {
   installPhase = ''make INSTPREFIX=$out install'';
 
   meta = {
-    description = "Partclone provides utilities to save and restore used blocks on a partition and is designed for higher compatibility of the file system by using existing libraries, e.g. e2fslibs is used to read and write the ext2 partition";
+    description = "Utilities to save and restore used blocks on a partition";
+    longDescription = ''
+      Partclone provides utilities to save and restore used blocks on a
+      partition and is designed for higher compatibility of the file system by
+      using existing libraries, e.g. e2fslibs is used to read and write the
+      ext2 partition.
+    '';
     homepage = http://partclone.org;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.marcweber];

--- a/pkgs/tools/cd-dvd/xorriso/default.nix
+++ b/pkgs/tools/cd-dvd/xorriso/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isLinux acl;
 
   meta = {
-    description = "GNU xorriso, an ISO 9660 Rock Ridge file system manipulator";
+    description = "ISO 9660 Rock Ridge file system manipulator";
 
     longDescription =
       '' GNU xorriso copies file objects from POSIX compliant filesystems

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/gzip/;
-    description = "Gzip, the GNU zip compression program";
+    description = "GNU zip compression program";
 
     longDescription =
       ''gzip (GNU zip) is a popular data compression program written by

--- a/pkgs/tools/compression/rzip/default.nix
+++ b/pkgs/tools/compression/rzip/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://rzip.samba.org/;
-    description = "The RZIP compression program";
+    description = "Compression program";
     license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/tools/filesystems/chunkfs/default.nix
+++ b/pkgs/tools/filesystems/chunkfs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "(Un)ChunkFS is a pair of FUSE filesystems for viewing chunksync-style directory trees as a block device and vice versa.";
+    description = "FUSE filesystems for viewing chunksync-style directory trees as a block device and vice versa";
     homepage = "http://chunkfs.florz.de/";
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/tools/filesystems/encfs/default.nix
+++ b/pkgs/tools/filesystems/encfs/default.nix
@@ -14,6 +14,6 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://www.arg0.net/encfs;
-    description = "EncFS provides an encrypted filesystem in user-space via FUSE";
+    description = "Provides an encrypted filesystem in user-space via FUSE";
   };
 }

--- a/pkgs/tools/filesystems/mtools/default.nix
+++ b/pkgs/tools/filesystems/mtools/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/mtools/;
-    description = "GNU mtools, utilities to access MS-DOS disks";
+    description = "Utilities to access MS-DOS disks";
     platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
     maintainers = [ ];
   };

--- a/pkgs/tools/filesystems/svnfs/default.nix
+++ b/pkgs/tools/filesystems/svnfs/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   NIX_LDFLAGS="-lsvn_client-1";
 
   meta = {
-    description = "SvnFs is a filesystem written using FUSE for accessing Subversion repositories";
+    description = "FUSE filesystem for accessing Subversion repositories";
     homepage = http://www.jmadden.eu/index.php/svnfs/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.marcweber];

--- a/pkgs/tools/filesystems/wdfs/default.nix
+++ b/pkgs/tools/filesystems/wdfs/default.nix
@@ -10,6 +10,6 @@ stdenv.mkDerivation rec
   buildInputs = [fuse glib neon pkgconfig];
   meta = {
     homepage = "http://noedler.de/projekte/wdfs/";
-    description = "wdfs a user-space filesystem that allows to mount a webdav share";
+    description = "User-space filesystem that allows to mount a webdav share";
   };
 }

--- a/pkgs/tools/graphics/cuneiform/default.nix
+++ b/pkgs/tools/graphics/cuneiform/default.nix
@@ -37,6 +37,6 @@ rec {
   name = "cuneiform-" + version;
   meta = {
     inherit version;
-    description = "Cuneiform OCR";
+    description = "Multi-language OCR system";
   };
 }

--- a/pkgs/tools/graphics/plotutils/default.nix
+++ b/pkgs/tools/graphics/plotutils/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Plotutils, a powerful C/C++ library for exporting 2D vector graphics";
+    description = "Powerful C/C++ library for exporting 2D vector graphics";
 
     longDescription =
       '' The GNU plotutils package contains software for both programmers and

--- a/pkgs/tools/misc/goaccess/default.nix
+++ b/pkgs/tools/misc/goaccess/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "GoAccess is an open source real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems.";
+    description = "Real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems";
     homepage    = http://goaccess.prosoftcorp.com;
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;

--- a/pkgs/tools/misc/idutils/default.nix
+++ b/pkgs/tools/misc/idutils/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   patches = [ ./nix-mapping.patch ];
 
   meta = {
-    description = "GNU Idutils, a text searching utility";
+    description = "Text searching utility";
 
     longDescription = ''
       An "ID database" is a binary file containing a list of file

--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation {
     homepage = "http://www.spinnaker.de/lbdb/";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.all;
-    description = "The Little Brother's Database (lbdb)";
+    description = "The Little Brother's Database";
   };
 }

--- a/pkgs/tools/misc/ldapvi/default.nix
+++ b/pkgs/tools/misc/ldapvi/default.nix
@@ -21,7 +21,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "ldapvi is an interactive LDAP client for Unix terminals. Using it, you can update LDAP entries with a text editor";
+    description = "Interactive LDAP client for Unix terminals";
+    longDescription = ''
+      ldapvi is an interactive LDAP client for Unix terminals. Using it, you
+      can update LDAP entries with a text editor.
+    '';
     homepage = http://www.lichteblau.com/ldapvi/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ iElectric ];

--- a/pkgs/tools/misc/minicom/default.nix
+++ b/pkgs/tools/misc/minicom/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    description = "Minicom, a modem control and terminal emulation program";
+    description = "Modem control and terminal emulation program";
     homepage = http://alioth.debian.org/projects/minicom/;
 
     longDescription =

--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation {
   buildInputs = [ slang ncurses ];
 
   meta = {
-    description = ''
+    description = "A terminal pager similar to 'more' and 'less'";
+    longDescription = ''
       MOST is a powerful paging program for Unix, VMS, MSDOS, and win32
       systems. Unlike other well-known paging programs most supports multiple
       windows and can scroll left and right. Why settle for less?

--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Parallel, a shell tool for executing jobs in parallel";
+    description = "Shell tool for executing jobs in parallel";
 
     longDescription =
       '' GNU Parallel is a shell tool for executing jobs in parallel.  A job

--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       "export PATH=\"${utillinux}/sbin:$PATH\"";
 
   meta = {
-    description = "GNU Parted, a tool to create, destroy, resize, check, and copy partitions";
+    description = "Create, destroy, resize, check, and copy partitions";
 
     longDescription = ''
       GNU Parted is an industrial-strength package for creating, destroying,

--- a/pkgs/tools/misc/pg_top/default.nix
+++ b/pkgs/tools/misc/pg_top/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   buildInputs = [ncurses postgresql]; 
 
   meta = {
-    description = "pg_top is 'top' for PostgreSQL";
+    description = "A 'top' like tool for PostgreSQL";
     longDescription = '' 
       pg_top allows you to: 
       <itemizedlist>

--- a/pkgs/tools/misc/recutils/default.nix
+++ b/pkgs/tools/misc/recutils/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ curl emacs ] ++ (stdenv.lib.optionals doCheck [ check bc ]);
 
   meta = {
-    description = "GNU Recutils, tools and libraries to access human-editable, text-based databases";
+    description = "Tools and libraries to access human-editable, text-based databases";
 
     longDescription =
       '' GNU Recutils is a set of tools and libraries to access

--- a/pkgs/tools/misc/time/default.nix
+++ b/pkgs/tools/misc/time/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   patches = [ ./max-resident.patch ];
 
   meta = {
-    description = "GNU Time, a tool that runs programs and summarizes the system resources they use";
+    description = "Tool that runs programs and summarizes the system resources they use";
 
     longDescription = ''
       The `time' command runs another program, then displays

--- a/pkgs/tools/misc/tmpwatch/default.nix
+++ b/pkgs/tools/misc/tmpwatch/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://fedorahosted.org/tmpwatch/;
-    description = "The tmpwatch utility recursively searches through specified directories and removes files which have not been accessed in a specified period of time.";
+    description = "Recursively searches through specified directories and removes files which have not been accessed in a specified period of time";
     license = licenses.gpl2;
     maintainers = with maintainers; [ vlstill ];
     platforms = platforms.unix;

--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://tmux.sourceforge.net/;
-    description = "tmux is a terminal multiplexer";
+    description = "Terminal multiplexer";
 
     longDescription =
       '' tmux is intended to be a modern, BSD-licensed alternative to programs such as GNU screen. Major features include:

--- a/pkgs/tools/misc/yad/default.nix
+++ b/pkgs/tools/misc/yad/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://code.google.com/p/yad/";
-    description = "Yad (yet another dialog) is a GUI dialog tool for shell scripts";
+    description = "GUI dialog tool for shell scripts";
     longDescription = ''
       Yad (yet another dialog) is a GUI dialog tool for shell scripts. It is a
       fork of Zenity with many improvements, such as custom buttons, additional

--- a/pkgs/tools/networking/cntlm/default.nix
+++ b/pkgs/tools/networking/cntlm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "Cntlm is an NTLM/NTLMv2 authenticating HTTP proxy";
+    description = "NTLM/NTLMv2 authenticating HTTP proxy";
     homepage = http://cntlm.sourceforge.net/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.qknight ];

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "The ConnMan project provides a daemon for managing internet connections";
+    description = "Provides a daemon for managing internet connections";
     homepage = "https://connman.net/";
     maintainers = [ stdenv.lib.maintainers.matejc ];
     # tested only on linux, might work on others also

--- a/pkgs/tools/networking/flvstreamer/default.nix
+++ b/pkgs/tools/networking/flvstreamer/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "flvstreamer is an command-line RTMP client";
+    description = "Command-line RTMP client";
 
     longDescription =
       '' flvstreamer is an open source command-line RTMP client intended to 

--- a/pkgs/tools/networking/host/default.nix
+++ b/pkgs/tools/networking/host/default.nix
@@ -18,7 +18,7 @@ let version = "20000331"; in
     installTargets = "install man";
 
     meta = {
-      description = "`host', a DNS resolution utility";
+      description = "DNS resolution utility";
       license = "BSD-style";
     };
   }

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "GNU Inetutils, a collection of common network programs";
+    description = "Collection of common network programs";
 
     longDescription =
       '' The GNU network utilities suite provides the

--- a/pkgs/tools/networking/jnettop/default.nix
+++ b/pkgs/tools/networking/jnettop/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   preConfigure = '' autoconf '';
 
   meta = {
-    description = "Jnettop, a network traffic visualizer";
+    description = "Network traffic visualizer";
 
     longDescription = ''
       Jnettop is a traffic visualiser, which captures traffic going

--- a/pkgs/tools/networking/lsh/default.nix
+++ b/pkgs/tools/networking/lsh/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gperf guile gmp zlib liboop readline gnum4 pam ];
 
   meta = {
-    description = "GNU lsh, a GPL'd implementation of the SSH protocol";
+    description = "GPL'd implementation of the SSH protocol";
 
     longDescription = ''
       lsh is a free implementation (in the GNU sense) of the ssh

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    description = "GNU Mailutils is a rich and powerful protocol-independent mail framework";
+    description = "Rich and powerful protocol-independent mail framework";
 
     longDescription = ''
       GNU Mailutils is a rich and powerful protocol-independent mail

--- a/pkgs/tools/networking/minidlna/default.nix
+++ b/pkgs/tools/networking/minidlna/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ffmpeg flac libvorbis libogg libid3tag libexif libjpeg sqlite ];
 
   meta = {
-    description = "MiniDLNA Media Server";
+    description = "Media server software";
     longDescription = ''
       MiniDLNA (aka ReadyDLNA) is server software with the aim of being fully
       compliant with DLNA/UPnP-AV clients.

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "tcpdump, a famous network sniffer";
+    description = "Network sniffer";
     homepage = http://www.tcpdump.org/;
     license = "BSD-style";
     maintainers = stdenv.lib.maintainers.mornfall;

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   doCheck = (perl != null);
 
   meta = {
-    description = "GNU Wget, a tool for retrieving files using HTTP, HTTPS, and FTP";
+    description = "Tool for retrieving files using HTTP, HTTPS, and FTP";
 
     longDescription =
       '' GNU Wget is a free software package for retrieving files using HTTP,

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -66,7 +66,14 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "The Nix Deployment System";
+    description = "Powerful package manager that makes package management reliable and reproducible";
+    longDescription = ''
+      Nix is a powerful package manager for Linux and other Unix systems that
+      makes package management reliable and reproducible. It provides atomic
+      upgrades and rollbacks, side-by-side installation of multiple versions of
+      a package, multi-user package management and easy setup of build
+      environments.
+    '';
     homepage = http://nixos.org/;
     license = stdenv.lib.licenses.lgpl2Plus;
     maintainers = [ stdenv.lib.maintainers.eelco ];

--- a/pkgs/tools/security/scrypt/default.nix
+++ b/pkgs/tools/security/scrypt/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl ];
 
   meta = {
-    description = "The scrypt encryption utility";
+    description = "Encryption utility";
     homepage    = https://www.tarsnap.com/scrypt.html;
     license     = stdenv.lib.licenses.bsd2;
     platforms   = stdenv.lib.platforms.all;

--- a/pkgs/tools/security/steghide/default.nix
+++ b/pkgs/tools/security/steghide/default.nix
@@ -7,7 +7,7 @@
 
     meta = with stdenv.lib; {
         homepage = http://steghide.sourceforge.net/;
-        description = "Steghide is a steganography program that is able to hide data in various kinds of image- and audio-files.";
+        description = "Steganography program that is able to hide data in various kinds of image- and audio-files";
         license = licenses.gpl2;
     };
 

--- a/pkgs/tools/security/tboot/default.nix
+++ b/pkgs/tools/security/tboot/default.nix
@@ -21,9 +21,7 @@ stdenv.mkDerivation rec {
   installFlags = "DESTDIR=$(out)";
 
   meta = with stdenv.lib; {
-    description = ''Trusted Boot (tboot) is an open source, pre-kernel/VMM module that uses
-                    Intel(R) Trusted Execution Technology (Intel(R) TXT) to perform a measured
-                    and verified launch of an OS kernel/VMM.'';
+    description = "A pre-kernel/VMM module that uses Intel(R) TXT to perform a measured and verified launch of an OS kernel/VMM";
     homepage    = http://sourceforge.net/projects/tboot/;
     license     = licenses.bsd3;
     maintainers = [ maintainers.ak ];

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.torproject.org/;
     repositories.git = https://git.torproject.org/git/tor;
-    description = "Tor, an anonymous network router to improve privacy on the Internet";
+    description = "Anonymous network router to improve privacy on the Internet";
 
     longDescription=''
       Tor protects you by bouncing your communications around a distributed

--- a/pkgs/tools/security/tpm-tools/default.nix
+++ b/pkgs/tools/security/tpm-tools/default.nix
@@ -14,9 +14,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ trousers openssl ];
 
   meta = with stdenv.lib; {
-    description = ''tpm-tools is an open-source package designed to enable user and application
-                    enablement of Trusted Computing using a Trusted Platform Module (TPM),
-                    similar to a smart card environment.'';
+    description = "Management tools for TPM hardware";
+    longDescription = ''
+      tpm-tools is an open-source package designed to enable user and
+      application enablement of Trusted Computing using a Trusted Platform
+      Module (TPM), similar to a smart card environment.
+    '';
     homepage    = http://sourceforge.net/projects/trousers/files/tpm-tools/;
     license     = licenses.cpl10;
     maintainers = [ maintainers.ak ];

--- a/pkgs/tools/security/trousers/default.nix
+++ b/pkgs/tools/security/trousers/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lgcc_s";
 
   meta = with stdenv.lib; {
-    description = "TrouSerS is an CPL (Common Public License) licensed Trusted Computing Software Stack.";
+    description = "Trusted computing software stack";
     homepage    = http://trousers.sourceforge.net/;
     license     = licenses.cpl10;
     maintainers = [ maintainers.ak ];

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation {
   preInstall = "mkdir -p $out/bin $out/sbin $out/share/man/man1 $out/share/man/man5 $out/share/man/man8";
   
   meta = {
-    description = "Vixie Cron, a daemon for running commands at specific times";
+    description = "Daemon for running commands at specific times (Vixie Cron)";
   };
 }

--- a/pkgs/tools/system/freeipmi/default.nix
+++ b/pkgs/tools/system/freeipmi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU FreeIPMI, an implementation of the Intelligent Platform Management Interface";
+    description = "Implementation of the Intelligent Platform Management Interface";
 
     longDescription =
       '' GNU FreeIPMI provides in-band and out-of-band IPMI software based on

--- a/pkgs/tools/system/hardlink/default.nix
+++ b/pkgs/tools/system/hardlink/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "http://pkgs.fedoraproject.org/cgit/hardlink.git/";
-    description = "consolidate duplicate files via hardlinks";
+    description = "Consolidate duplicate files via hardlinks";
     license = stdenv.lib.licenses.gpl2Plus;
 
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/system/mcron/default.nix
+++ b/pkgs/tools/system/mcron/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU mcron, a flexible implementation of `cron' in Guile";
+    description = "Flexible implementation of `cron' in Guile";
 
     longDescription = ''
       The GNU package mcron (Mellor's cron) is a 100% compatible

--- a/pkgs/tools/text/enscript/default.nix
+++ b/pkgs/tools/text/enscript/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "GNU Enscript, a converter from ASCII to PostScript, HTML, or RTF";
+    description = "Converter from ASCII to PostScript, HTML, or RTF";
 
     longDescription =
       '' GNU Enscript converts ASCII files to PostScript, HTML, or RTF and

--- a/pkgs/tools/text/mpage/default.nix
+++ b/pkgs/tools/text/mpage/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Mpage, many-to-one page printing utility";
+    description = "Many-to-one page printing utility";
 
     longDescription = ''
       Mpage reads plain text files or PostScript documents and prints

--- a/pkgs/tools/text/namazu/default.nix
+++ b/pkgs/tools/text/namazu/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isLinux;
 
   meta = {
-    description = "Namazu, a full-text search engine";
+    description = "Full-text search engine";
 
     longDescription = ''
       Namazu is a full-text search engine intended for easy use.  Not

--- a/pkgs/tools/text/wdiff/default.nix
+++ b/pkgs/tools/text/wdiff/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://www.gnu.org/software/wdiff/;
-    description = "GNU wdiff, comparing files on a word by word basis";
+    description = "Comparing files on a word by word basis";
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [ stdenv.lib.maintainers.eelco ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/typesetting/lout/default.nix
+++ b/pkgs/tools/typesetting/lout/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   builder = ./builder.sh;
 
   meta = {
-    description = "Lout, a document layout system similar in style to LaTeX";
+    description = "Document layout system similar in style to LaTeX";
 
     longDescription = ''
       The Lout document formatting system is now reads a high-level

--- a/pkgs/tools/typesetting/rubber/default.nix
+++ b/pkgs/tools/typesetting/rubber/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   patchPhase = "substituteInPlace configure --replace which \"type -P\"";
 
   meta = {
-    description = "Rubber, a wrapper for LaTeX and friends";
+    description = "Wrapper for LaTeX and friends";
 
     longDescription = ''
       Rubber is a program whose purpose is to handle all tasks related

--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "xmlto, a front-end to an XSL toolchain";
+    description = "Front-end to an XSL toolchain";
 
     longDescription = ''
       xmlto is a front-end to an XSL toolchain.  It chooses an

--- a/pkgs/tools/video/dvgrab/default.nix
+++ b/pkgs/tools/video/dvgrab/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     ];
 
   meta = {
-    description = "dvgrab, receive and store audio & video over IEEE1394";
+    description = "Receive and store audio & video over IEEE1394";
 
     longDescription =
       '' dvgrab receives audio and video data from a digital camcorder via an


### PR DESCRIPTION
(My OCD kicked in today...)

Remove repeated package names, capitalize first word, remove trailing
periods and move overlong descriptions to longDescription.

I also simplified some descriptions as well, when they were particularly
long or technical, often based on Arch Linux' package descriptions.

I've tried to stay away from generated expressions (and I think I
succeeded).

Some specifics worth mentioning:
- cron, has "Vixie Cron" in its description. The "Vixie" part is not
  mentioned anywhere else. I kept it in a parenthesis at the end of the
  description.
- ctags description started with "Exuberant Ctags ...", and the
  "exuberant" part is not mentioned elsewhere. Kept it in a parenthesis
  at the end of description.
- nix has the description "The Nix Deployment System". Since that
  doesn't really say much what it is/does (especially after removing
  the package name!), I changed that to "Powerful package manager that
  makes package management reliable and reproducible" (borrowed from
  nixos.org).
- Tons of "GNU Foo, Foo is a [the important bits]" descriptions
  is changed to just [the important bits]. If the package name doesn't
  contain GNU I don't think it's needed to say it in the description
  either.
