### PR TITLE
full nixos inside docker

### DIFF
--- a/nixos/lib/make-system-tarball.nix
+++ b/nixos/lib/make-system-tarball.nix
@@ -15,6 +15,9 @@
   # store path whose closure will be copied, and `symlink' is a
   # symlink to `object' that will be added to the tarball.
   storeContents ? []
+
+  # Extra tar arguments
+, extraArgs ? ""
 }:
 
 stdenv.mkDerivation {
@@ -22,7 +25,7 @@ stdenv.mkDerivation {
   builder = ./make-system-tarball.sh;
   buildInputs = [perl xz];
 
-  inherit fileName pathsFromGraph;
+  inherit fileName pathsFromGraph extraArgs;
 
   # !!! should use XML.
   sources = map (x: x.source) contents;

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -50,7 +50,7 @@ done
 
 mkdir -p $out/tarball
 
-tar cvJf $out/tarball/$fileName.tar.xz *
+tar cvJf $out/tarball/$fileName.tar.xz * $extraArgs
 
 mkdir -p $out/nix-support
 echo $system > $out/nix-support/system

--- a/nixos/modules/services/ttys/agetty.nix
+++ b/nixos/modules/services/ttys/agetty.nix
@@ -66,6 +66,12 @@ with lib;
         restartIfChanged = false;
       };
 
+    systemd.services."console-getty" =
+      { serviceConfig.ExecStart = "@${pkgs.utillinux}/sbin/agetty agetty --noclear --login-program ${pkgs.shadow}/bin/login --keep-baud console 115200,38400,9600 $TERM";
+        serviceConfig.Restart = "always";
+        restartIfChanged = false;
+      };
+
     environment.etc = singleton
       { # Friendly greeting on the virtual consoles.
         source = pkgs.writeText "issue" ''

--- a/nixos/modules/virtualisation/docker-image.nix
+++ b/nixos/modules/virtualisation/docker-image.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+ pkgs2storeContents = l : map (x: { object = x; symlink = "none"; }) l;
+
+in {
+  # Create the tarball
+  system.build.dockerImage = import ../../lib/make-system-tarball.nix {
+    inherit (pkgs) stdenv perl xz pathsFromGraph;
+
+    contents = [];
+    extraArgs = "--owner=0";
+    storeContents = [
+      { object = config.system.build.toplevel + "/init";
+        symlink = "/bin/init";
+      }
+    ] ++ (pkgs2storeContents [ pkgs.stdenv ]);
+  };
+
+  boot.postBootCommands =
+    ''
+      # After booting, register the contents of the Nix store in the Nix
+      # database.
+      if [ -f /nix-path-registration ]; then
+        ${config.nix.package}/bin/nix-store --load-db < /nix-path-registration &&
+        rm /nix-path-registration
+      fi
+
+      # nixos-rebuild also requires a "system" profile and an
+      # /etc/NIXOS tag.
+      touch /etc/NIXOS
+      ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+
+      # Set virtualisation to docker
+      echo "docker" > /run/systemd/container 
+    '';
+
+
+  # docker image config
+  require = [
+    ../installer/cd-dvd/channel.nix
+    ../profiles/minimal.nix
+    ../profiles/clone-config.nix
+  ];
+
+  boot.isContainer = true;
+
+  # Iptables do not work in docker
+  networking.firewall.enable = false;
+
+  services.openssh.enable = true;
+
+  # Socket activated ssh presents problem in docker
+  services.openssh.startWhenNeeded = false;
+
+  # Allow the user to login as root without password
+  security.initialRootPassword = "";
+
+  # Some more help text.
+  services.mingetty.helpLine =
+    ''
+
+      Log in as "root" with an empty password.
+    '';
+}


### PR DESCRIPTION
This is first attempt to run full nixos inside docker. You will need docker 1.2.0(already meged into master), because of support of adding capabilities to containers. Currenty it should not be possible to run these images on docker virtualization providers, because docker was, but does not have patch for systemd included anymore, because of (for my opinion) not so relevant non systemd related bugs(see: https://github.com/docker/libcontainer/pull/30 and https://github.com/docker/docker/issues/3629).
- To build docker base image use:

```
export NIXOS_CONFIG=$(pwd)/modules/virtualisation/docker-image.nix
nix-build . -A config.system.build.dockerImage
```
- To import image to docker(docker daemon must be running):

```
cat result/tarball/nixos-system-x86_64-linux.tar.xz| sudo docker import - nixos
```
- To start it:

```
sudo docker/bin/docker run -t -i --cap-add=SYS_ADMIN --cap-add=SYS_RESOURCE -e "container=docker" nixos /bin/init
```

As soon as docker will be patched to have cgroups mounted, i will make it run without these additional flags.

UPDATE: I still have to figure out how to push new base image to docker image repos
