### PR TITLE
Fixed rewrite rules for Mediawiki

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -34,6 +34,9 @@ rec {
   concatStringsSep = separator: list:
     concatStrings (intersperse separator list);
 
+  concatMapStringsSep = sep: f: list: concatStringsSep sep (map f list);
+  concatImapStringsSep = sep: f: list: concatStringsSep sep (lib.imap f list);
+
 
   # Construct a Unix-style search path consisting of each `subDir"
   # directory of the given list of packages.  For example,

--- a/nixos/modules/services/web-servers/apache-httpd/mediawiki.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/mediawiki.nix
@@ -133,6 +133,7 @@ in
         RewriteEngine On
         RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f
         RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d
+        ${concatMapStringsSep "\n" (u: "RewriteCond %{REQUEST_URI} !^${u.urlPath}") serverInfo.serverConfig.servedDirs}
         RewriteRule ${if config.enableUploads
           then "!^/images"
           else "^.*\$"


### PR DESCRIPTION
If Mediawiki was served from the root directory of the server
it was impossible to serve other directories.

Make sure that URLs defined in servedDirs are not rewritten.
Use case: serving local copy of MathJax:

```
  mathJax= pkgs.fetchgit {
    url = https://github.com/mathjax/MathJax.git;
    rev = "1c54436ae6166a91495aba8a98cc18816b4789df";
    sha256 = "1dgh02y1rkn967pgyhbczqby7lvw9kqi7jmdrb2lfgjbkqrh5arv";
  };

  mathJaxUrl = "/mathjax";

  mathJaxExt = pkgs.fetchgit {
    url = https://github.com/zalora/Mediawiki-MathJax.git;
    rev = "880adf7f9da55dbe257043fe431f825211ee96e1";
    sha256 = "17s3pbxj6jhywsbdss1hqmss8slb89jkwirlsbd0h16m130q72n8";
  };

...

  services.httpd = {
    enable = true;
    servedDirs = [
      { urlPath = mathJaxUrl; dir = "${mathJax}"; }
    ];
    extraSubservices =
    [
      { serviceType = "mediawiki";
        siteName = "My Wiki";
        enableUploads = true;
        uploadDir = "/var/lib/mediawiki";
        urlPrefix = "";
        articleUrlPrefix = "";
        extraConfig = ''
          require_once("${mathJaxExt}/MathJax.php");
            MathJax_Parser::$MathJaxJS = '${mathJaxUrl}/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
        '';
      }
    ];
  };

```

Also reintroduce `concatMapStringsSep` and `concatImapStringsSep`. This the second time I need it :-)

@shlevy ?
