### PR TITLE
fetchgit: Use mktemp -d in nix-prefetch-git.

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -256,11 +256,11 @@ else
   # download the file and add it to the store.
   if test -z "$finalPath"; then
 
-      tmpPath=/tmp/git-checkout-tmp-$$
-      tmpFile=$tmpPath/git-export
-      mkdir $tmpPath $tmpFile
+      tmpPath="$(mktemp --tmpdir -d git-checkout-tmp-XXXXXXXX)"
+      trap "rm -rf \"$tmpPath\"" EXIT
 
-      trap "rm -rf $tmpPath" EXIT
+      tmpFile="$tmpPath/git-export"
+      mkdir "$tmpFile"
 
       # Perform the checkout.
       clone_user_rev "$tmpFile" "$url" "$rev"


### PR DESCRIPTION
**I'm doing a PR here for review, because I'm not sure if there is a particular reason why we have used `$$` so far. The main reason for doing this is that I've stumbled on collisions because of this from within the Hydra evaluator.**

Use mktemp instead of relying on `$$` to not collide with an existing path.

Quoting the Bash manual about `$$`:

> Expands to the process ID of the shell. In a () subshell, it expands to the process ID of the current shell, not the subshell.

So, this is different from `$BASHPID`:

> Expands to the process ID of the current bash process. This differs from $$ under certain circumstances, such as subshells that do not require bash to be re-initialized.

But even `$BASHPID` is prone to race conditions if the process IDs wrap around, so to be on the safe side, we're using mktemp here.

Cc: @edolstra, @rbvermaa
