### PR TITLE
Fix zlib handling in stdenvLinux

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -225,7 +225,11 @@ rec {
     };
     extraPath = [ stage3.pkgs.xz ];
     overrides = pkgs: {
-      inherit (stage3.pkgs) gettext gnum4 gmp perl glibc;
+      # Zlib has to be inherited and not rebuilt in this stage,
+      # because gcc (since JAR support) already depends on zlib, and
+      # then if we already have a zlib we want to use that for the
+      # other purposes (binutils and top-level pkgs) too.
+      inherit (stage3.pkgs) gettext gnum4 gmp perl glibc zlib;
     };
   };
 
@@ -274,7 +278,7 @@ rec {
       inherit (stage4.pkgs)
         gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
         glibc gnumake gnused gnutar gnugrep gnupatch patchelf
-        attr acl paxctl;
+        attr acl paxctl zlib;
     };
   };
 


### PR DESCRIPTION
Previously stdenv depended on two different zlibs and there was a third
one in the top-level package set for other purposes.  This commit merges
all this zlibs to one.
