### PR TITLE
nix-prefetch-git: Don't use --tmpdir for mktemp

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -256,7 +256,8 @@ else
   # download the file and add it to the store.
   if test -z "$finalPath"; then
 
-      tmpPath="$(mktemp --tmpdir -d git-checkout-tmp-XXXXXXXX)"
+      TMPDIR=${TMPDIR:-/tmp}
+      tmpPath="$(mktemp -d ${TMPDIR}/git-checkout-tmp-XXXXXXXX)"
       trap "rm -rf \"$tmpPath\"" EXIT
 
       tmpFile="$tmpPath/git-export"


### PR DESCRIPTION
No --tmpdir for Darwin

Related to f83af95f8a54d0375ac6e159b663de887ba5b6a6:

```
build-support: Use mktemp -d in nix-prefetch-*.
```
