### PR TITLE
haskell: hakyll, github, dns updates (fixes hakyll)

### DIFF
--- a/pkgs/development/libraries/haskell/dns/default.nix
+++ b/pkgs/development/libraries/haskell/dns/default.nix
@@ -6,8 +6,8 @@
 
 cabal.mkDerivation (self: {
   pname = "dns";
-  version = "1.4.3";
-  sha256 = "15v24f338w71dn3cxrzwyg04hk3vxvrvswbv3nnf2ggjgg46yq3i";
+  version = "1.4.4";
+  sha256 = "1g910rlahvrhjlg6jl7gpya1y3mqkkpmihfr2jnmmlzykll10dnd";
   buildDepends = [
     attoparsec binary blazeBuilder conduit conduitExtra iproute mtl
     network random resourcet
@@ -21,5 +21,6 @@ cabal.mkDerivation (self: {
     description = "DNS library in Haskell";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = with self.stdenv.lib.maintainers; [ fuuzetsu ];
   };
 })

--- a/pkgs/development/libraries/haskell/github/default.nix
+++ b/pkgs/development/libraries/haskell/github/default.nix
@@ -7,18 +7,18 @@
 
 cabal.mkDerivation (self: {
   pname = "github";
-  version = "0.10.0";
-  sha256 = "1llwzkhyw5wazczpiv3w8dq4l7j3q49ii64yh7cxwakkp2h5yiwb";
+  version = "0.11.0";
+  sha256 = "13p0iplxr85fvgx5lird76xchmhh7xpddq900qr02kbvn5mqv607";
   buildDepends = [
     aeson attoparsec caseInsensitive conduit dataDefault failure
     hashable HTTP httpConduit httpTypes network text time
     unorderedContainers vector
   ];
-  jailbreak = true;
   meta = {
     homepage = "https://github.com/fpco/github";
     description = "Access to the Github API, v3";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
+    maintainers = with self.stdenv.lib.maintainers; [ fuuzetsu ];
   };
 })

--- a/pkgs/development/libraries/haskell/hakyll/default.nix
+++ b/pkgs/development/libraries/haskell/hakyll/default.nix
@@ -5,13 +5,13 @@
 , HUnit, lrucache, mtl, network, pandoc, pandocCiteproc, parsec
 , QuickCheck, random, regexBase, regexTdfa, snapCore, snapServer
 , systemFilepath, tagsoup, testFramework, testFrameworkHunit
-, testFrameworkQuickcheck2, text, time
+, testFrameworkQuickcheck2, text, time, utillinux
 }:
 
 cabal.mkDerivation (self: {
   pname = "hakyll";
-  version = "4.5.3.0";
-  sha256 = "11ibpjff1zkihpxydlzvvzbgd1vxswi4c7g3lr0hhaaw89bikypy";
+  version = "4.5.4.0";
+  sha256 = "16srkm2fxjw1xg7zaikn49zz4xsz9awddnjm6ibv522k3xf3l24c";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [
@@ -25,15 +25,13 @@ cabal.mkDerivation (self: {
     filepath fsnotify httpConduit httpTypes HUnit lrucache mtl network
     pandoc pandocCiteproc parsec QuickCheck random regexBase regexTdfa
     snapCore snapServer systemFilepath tagsoup testFramework
-    testFrameworkHunit testFrameworkQuickcheck2 text time
+    testFrameworkHunit testFrameworkQuickcheck2 text time utillinux
   ];
-  doCheck = false;
   meta = {
     homepage = "http://jaspervdj.be/hakyll";
     description = "A static website compiler library";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    hydraPlatforms = self.stdenv.lib.platforms.none;
-    broken = true;
+    maintainers = with self.stdenv.lib.maintainers; [ fuuzetsu ];
   };
 })


### PR DESCRIPTION
I'm unsure about Hakyll on Darwin here as we need ‘rev’ from `utillinux` but I didn't see anything `assert`ing that package is Linux-only. Worst case scenario we can `doCheck = false` on Darwin.
