### PR TITLE
Options json

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -41,7 +41,7 @@ in {
 
       output = mkOption {
         type = types.path;
-        default = /var/cache/locatedb;
+        default = "/var/cache/locatedb";
         description = ''
           The database file to build.
         '';


### PR DESCRIPTION
This add a derivation which would be used by hydra and can be used locally for improving our tools around NixOS.  A tool can get the list of option as follow:

```
$ cd .../nixos
$ nix-build -A config.system.build.manual.options -o options
$ ls options/share/doc/nixos/
options.json  options.xml
```
