### PR TITLE
Add oxygen-gtk3.

### DIFF
--- a/pkgs/misc/themes/gtk3/oxygen-gtk3/default.nix
+++ b/pkgs/misc/themes/gtk3/oxygen-gtk3/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl
+, cmake, dbus_glib, glib, gtk3, gdk_pixbuf, pkgconfig, xorg }:
+
+stdenv.mkDerivation rec {
+  version = "1.4.0";
+  name = "oxygen-gtk3-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/oxygen-gtk3/${version}/src/${name}.tar.bz2";
+    sha256 = "d119bcc94ffc04b67e7d238fc922b37f2904447085a06758451b8c0b0302ab80";
+  };
+
+  buildInputs = [ cmake dbus_glib glib gtk3 gdk_pixbuf
+   pkgconfig xorg.libXau xorg.libXdmcp xorg.libpthreadstubs
+   xorg.libxcb xorg.pixman ];
+
+  meta = with stdenv.lib; {
+    description = "Port of the default KDE widget theme (Oxygen), to gtk 3";
+    homepage = https://projects.kde.org/projects/playground/artwork/oxygen-gtk;
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10825,7 +10825,11 @@ let
     geoclue = geoclue2;
   };
 
-  oxygen_gtk = callPackage ../misc/themes/gtk2/oxygen-gtk { };
+  oxygen-gtk2 = callPackage ../misc/themes/gtk2/oxygen-gtk { };
+
+  oxygen-gtk3 = callPackage ../misc/themes/gtk3/oxygen-gtk3 { };
+
+  oxygen_gtk = oxygen-gtk2; # backwards compatibility
 
   gtk_engines = callPackage ../misc/themes/gtk2/gtk-engines { };
 


### PR DESCRIPTION
GTK 3 version of the Oxygen theme.

Because the GTK2 version is called `oxygen_gtk` I've added a `oxygen_gtk3` as well as a `oxygen-gtk3`.  I think the latter is preferred now but the former should be there as well to make it more consistent.  But I don't know what the official position on `_` vs `-` is and right now it's a bit of a mess to be honest.

/cc @cillianderoiste 
