### PR TITLE
Enable parallel building for cloog and isl

### DIFF
--- a/pkgs/development/libraries/cloog/default.nix
+++ b/pkgs/development/libraries/cloog/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-isl=system" ];
 
+  enableParallelBuilding = true;
+
   doCheck = true;
 
   meta = {

--- a/pkgs/development/libraries/isl/0.12.2.nix
+++ b/pkgs/development/libraries/isl/0.12.2.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gmp ];
 
+  enableParallelBuilding = true;
+
   meta = {
     homepage = http://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;

--- a/pkgs/development/libraries/isl/default.nix
+++ b/pkgs/development/libraries/isl/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ gmp ];
   patches = [ ./fix-gcc-build.diff ];
 
+  enableParallelBuilding = true;
+
   meta = {
     homepage = http://www.kotnet.org/~skimo/isl/;
     license = stdenv.lib.licenses.lgpl21;


### PR DESCRIPTION
Since these are GCC dependencies, this speeds up building the
stdenv closure.
