### PR TITLE
Small changes to the logic how stdenvLinux handles the gcc wrapper

### DIFF
--- a/pkgs/development/interpreters/perl/5.16/default.nix
+++ b/pkgs/development/interpreters/perl/5.16/default.nix
@@ -1,4 +1,16 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, enableThreading ? true }:
+
+# We can only compile perl with threading on platforms where we have a
+# real glibc in the stdenv.
+#
+# Instead of silently building an unthreaded perl if this is not the
+# case, we force callers to disableThreading explicitly, therefore
+# documenting the platforms where the perl is not threaded.
+#
+# In the case of stdenv linux boot stage1 it's not possible to use
+# threading because of the simpleness of the bootstrap glibc, so we
+# use enableThreading = false there.
+assert enableThreading -> (stdenv ? glibc);
 
 let
 
@@ -39,7 +51,7 @@ stdenv.mkDerivation rec {
       "-Dlocincpth=${libc}/include"
       "-Dloclibpth=${libc}/lib"
     ]
-    ++ optional (stdenv ? glibc) "-Dusethreads";
+    ++ optional enableThreading "-Dusethreads";
 
   configureScript = "${stdenv.shell} ./Configure";
 

--- a/pkgs/development/interpreters/perl/5.20/default.nix
+++ b/pkgs/development/interpreters/perl/5.20/default.nix
@@ -1,4 +1,16 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, enableThreading ? true }:
+
+# We can only compile perl with threading on platforms where we have a
+# real glibc in the stdenv.
+#
+# Instead of silently building an unthreaded perl if this is not the
+# case, we force callers to disableThreading explicitly, therefore
+# documenting the platforms where the perl is not threaded.
+#
+# In the case of stdenv linux boot stage1 it's not possible to use
+# threading because of the simpleness of the bootstrap glibc, so we
+# use enableThreading = false there.
+assert enableThreading -> (stdenv ? glibc);
 
 let
 
@@ -39,7 +51,7 @@ stdenv.mkDerivation rec {
       "-Dlocincpth=${libc}/include"
       "-Dloclibpth=${libc}/lib"
     ]
-    ++ optional (stdenv ? glibc) "-Dusethreads";
+    ++ optional enableThreading "-Dusethreads";
 
   configureScript = "${stdenv.shell} ./Configure";
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -66,23 +66,11 @@ rec {
   };
 
 
-  # A helper function to call gcc-wrapper.
-  wrapGCC =
-    { gcc, libc, binutils, coreutils, name }:
-
-    lib.makeOverridable (import ../../build-support/gcc-wrapper) {
-      nativeTools = false;
-      nativeLibc = false;
-      inherit gcc binutils coreutils libc name;
-      stdenv = stage0.stdenv;
-    };
-
-
   # This function builds the various standard environments used during
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun =
-    {gcc, extraAttrs ? {}, overrides ? (pkgs: {}), extraPath ? []}:
+    {gccPlain, glibc, binutils, coreutils, name, overrides ? (pkgs: {}), extraPath ? []}:
 
     let
 
@@ -102,10 +90,28 @@ rec {
           stdenv = stage0.stdenv;
           curl = bootstrapTools;
         };
-        inherit gcc;
-        # Having the proper 'platform' in all the stdenvs allows getting proper
-        # linuxHeaders for example.
-        extraAttrs = extraAttrs // { inherit platform; };
+
+        gcc = if isNull gccPlain
+              then "/no-such-path"
+              else lib.makeOverridable (import ../../build-support/gcc-wrapper) {
+          nativeTools = false;
+          nativeLibc = false;
+          gcc = gccPlain;
+          libc = glibc;
+          inherit binutils coreutils;
+          name = name;
+          stdenv = stage0.stdenv;
+        };
+
+        extraAttrs = {
+          # Having the proper 'platform' in all the stdenvs allows getting proper
+          # linuxHeaders for example.
+          inherit platform;
+
+          # stdenv.glibc is used by GCC build to figure out the system-level
+          # /usr/include directory.
+          inherit glibc;
+        };
         overrides = pkgs: (overrides pkgs) // { fetchurl = thisStdenv.fetchurlBoot; };
       };
 
@@ -120,7 +126,11 @@ rec {
   # Build a dummy stdenv with no GCC or working fetchurl.  This is
   # because we need a stdenv to build the GCC wrapper and fetchurl.
   stage0 = stageFun {
-    gcc = "/no-such-path";
+    gccPlain = null;
+    glibc = null;
+    binutils = null;
+    coreutils = null;
+    name = null;
 
     overrides = pkgs: {
       # The Glibc include directory cannot have the same prefix as the
@@ -151,17 +161,19 @@ rec {
   # simply re-export those packages in the middle stage(s) using the
   # overrides attribute and the inherit syntax.
   stage1 = stageFun {
-    gcc = wrapGCC {
-      gcc = bootstrapTools;
-      libc = stage0.pkgs.glibc;
-      binutils = bootstrapTools;
-      coreutils = bootstrapTools;
-      name = "bootstrap-gcc-wrapper";
-    };
+    gccPlain = bootstrapTools;
+    inherit (stage0.pkgs) glibc;
+    binutils = bootstrapTools;
+    coreutils = bootstrapTools;
+    name = "bootstrap-gcc-wrapper";
+
     # Rebuild binutils to use from stage2 onwards.
     overrides = pkgs: {
       binutils = pkgs.binutils.override { gold = false; };
       inherit (stage0.pkgs) glibc;
+
+      # TODO(errge) This was accidentally like this historically, most probably not needed
+      perl = pkgs.perl.override { stdenv = stage1.stdenv.override { extraAttrs = { inherit platform; }; }; };
     };
   };
 
@@ -169,13 +181,12 @@ rec {
   # 2nd stdenv that contains our own rebuilt binutils and is used for
   # compiling our own Glibc.
   stage2 = stageFun {
-    gcc = wrapGCC {
-      gcc = bootstrapTools;
-      libc = stage1.pkgs.glibc;
-      binutils = stage1.pkgs.binutils;
-      coreutils = bootstrapTools;
-      name = "bootstrap-gcc-wrapper";
-    };
+    gccPlain = bootstrapTools;
+    inherit (stage1.pkgs) glibc;
+    binutils = stage1.pkgs.binutils;
+    coreutils = bootstrapTools;
+    name = "bootstrap-gcc-wrapper";
+
     overrides = pkgs: {
       inherit (stage1.pkgs) perl binutils paxctl;
       # This also contains the full, dynamically linked, final Glibc.
@@ -187,13 +198,11 @@ rec {
   # one uses the rebuilt Glibc from stage2.  It still uses the recent
   # binutils and rest of the bootstrap tools, including GCC.
   stage3 = stageFun {
-    gcc = wrapGCC {
-      gcc = bootstrapTools;
-      libc = stage2.pkgs.glibc;
-      binutils = stage2.pkgs.binutils;
-      coreutils = bootstrapTools;
-      name = "bootstrap-gcc-wrapper";
-    };
+    gccPlain = bootstrapTools;
+    inherit (stage2.pkgs) glibc binutils;
+    coreutils = bootstrapTools;
+    name = "bootstrap-gcc-wrapper";
+
     overrides = pkgs: {
       inherit (stage2.pkgs) binutils glibc perl;
       # Link GCC statically against GMP etc.  This makes sense because
@@ -205,9 +214,7 @@ rec {
       isl = pkgs.isl.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
       cloog = pkgs.cloog.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
       ppl = pkgs.ppl.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
-    };
-    extraAttrs = {
-      glibc = stage2.pkgs.glibc;  # Required by gcc47 build
+      gccPlain = pkgs.gcc.gcc;
     };
     extraPath = [ stage2.pkgs.paxctl ];
   };
@@ -216,13 +223,10 @@ rec {
   # Construct a fourth stdenv that uses the new GCC.  But coreutils is
   # still from the bootstrap tools.
   stage4 = stageFun {
-    gcc = wrapGCC {
-      gcc = stage3.pkgs.gcc.gcc;
-      libc = stage3.pkgs.glibc;
-      binutils = stage3.pkgs.binutils;
-      coreutils = bootstrapTools;
-      name = "";
-    };
+    inherit (stage3.pkgs) gccPlain glibc binutils;
+    coreutils = bootstrapTools;
+    name = "";
+
     extraPath = [ stage3.pkgs.xz ];
     overrides = pkgs: {
       # Zlib has to be inherited and not rebuilt in this stage,
@@ -230,6 +234,14 @@ rec {
       # then if we already have a zlib we want to use that for the
       # other purposes (binutils and top-level pkgs) too.
       inherit (stage3.pkgs) gettext gnum4 gmp perl glibc zlib;
+
+      # Accidental historical garbage
+      #
+      # TODO(errge): this historical mistake accidentally disables
+      # tests for the production coreutils, we definitely don't want
+      # that, so fix this in another commit!  (But will change drv and
+      # out hashes.)
+      coreutils = pkgs.coreutils.override { stdenv = stage4.stdenv.override { extraAttrs = { inherit platform; }; }; };
     };
   };
 
@@ -258,12 +270,16 @@ rec {
 
     shell = stage4.pkgs.bash + "/bin/bash";
 
-    gcc = (wrapGCC rec {
+    gcc = lib.makeOverridable (import ../../build-support/gcc-wrapper) {
+      inherit shell;
+      nativeTools = false;
+      nativeLibc = false;
       gcc = stage4.stdenv.gcc.gcc;
       libc = stage4.pkgs.glibc;
       inherit (stage4.pkgs) binutils coreutils;
       name = "";
-    }).override { inherit shell; };
+      stdenv = stage0.stdenv; # TODO(errge): legacy
+    };
 
     inherit (stage4.stdenv) fetchurlBoot;
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -172,8 +172,12 @@ rec {
       binutils = pkgs.binutils.override { gold = false; };
       inherit (stage0.pkgs) glibc;
 
-      # TODO(errge) This was accidentally like this historically, most probably not needed
-      perl = pkgs.perl.override { stdenv = stage1.stdenv.override { extraAttrs = { inherit platform; }; }; };
+      # A threaded perl build needs glibc/libpthread_nonshared.a,
+      # which is not included in bootstrapTools, so disable threading.
+      # This is not an issue for the final stdenv, because this perl
+      # won't be included in the final stdenv and won't be exported to
+      # top-level pkgs as an override either.
+      perl = pkgs.perl.override { enableThreading = false; };
     };
   };
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -217,7 +217,6 @@ rec {
       mpc = pkgs.mpc.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
       isl = pkgs.isl.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
       cloog = pkgs.cloog.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
-      ppl = pkgs.ppl.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
       gccPlain = pkgs.gcc.gcc;
     };
     extraPath = [ stage2.pkgs.paxctl ];
@@ -238,14 +237,6 @@ rec {
       # then if we already have a zlib we want to use that for the
       # other purposes (binutils and top-level pkgs) too.
       inherit (stage3.pkgs) gettext gnum4 gmp perl glibc zlib;
-
-      # Accidental historical garbage
-      #
-      # TODO(errge): this historical mistake accidentally disables
-      # tests for the production coreutils, we definitely don't want
-      # that, so fix this in another commit!  (But will change drv and
-      # out hashes.)
-      coreutils = pkgs.coreutils.override { stdenv = stage4.stdenv.override { extraAttrs = { inherit platform; }; }; };
     };
   };
 
@@ -282,7 +273,7 @@ rec {
       libc = stage4.pkgs.glibc;
       inherit (stage4.pkgs) binutils coreutils;
       name = "";
-      stdenv = stage0.stdenv; # TODO(errge): legacy
+      stdenv = stage4.stdenv;
     };
 
     inherit (stage4.stdenv) fetchurlBoot;


### PR DESCRIPTION
Similarly to before, please review not the whole change at once, but first the first commit as a commit that doesn't changes any derivation or output hash; then the second commit is the change over that that actually changes hashes.
