### PR TITLE
update virtualbox to 4.3.14

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -11,7 +11,7 @@ with stdenv.lib;
 
 let
 
-  version = "4.3.12"; # changes ./guest-additions as well
+  version = "4.3.14"; # changes ./guest-additions as well
 
   forEachModule = action: ''
     for mod in \
@@ -31,13 +31,13 @@ let
   '';
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
-  extpackRevision = "93733";
+  extpackRevision = "95030";
   extensionPack = requireFile rec {
     name = "Oracle_VM_VirtualBox_Extension_Pack-${version}-${extpackRevision}.vbox-extpack";
     # IMPORTANT: Hash must be base16 encoded because it's used as an input to
     # VBoxExtPackHelperApp!
     # Tip: see http://dlc.sun.com.edgesuite.net/virtualbox/4.3.10/SHA256SUMS
-    sha256 = "f931ce41b2cc9500dc43aba004630cf7bb7050ba737eae38827e91062f072d1f";
+    sha256 = "b965c3565e7933bc61019d2992f4da084944cfd9e809fbeaff330f4743d47537";
     message = ''
       In order to use the extension pack, you need to comply with the VirtualBox Personal Use
       and Evaluation License (PUEL) by downloading the related binaries from:
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "db84ddf47d1ecd316ec46417595f0252e3ec2f67e35e1e17320aba87b7c2934f";
+    sha256 = "bc893adde4449a2d35d8b4d0b8b247f0f2ac62a434fd8a8f7c54f613a100855a";
   };
 
   buildInputs =


### PR DESCRIPTION
I mostly did this so I could enable the extension pack (no downloads for the old version anymore), but I figure it should be useful for everybody. I tried building and running it, it seems fine.
