### PR TITLE
Update create-gce.sh

### DIFF
--- a/nixos/maintainers/scripts/gce/create-gce.sh
+++ b/nixos/maintainers/scripts/gce/create-gce.sh
@@ -12,4 +12,4 @@ img=$(echo gce/*.tar.gz)
 if ! gsutil ls gs://${BUCKET_NAME}/$(basename $img); then
   gsutil cp $img gs://${BUCKET_NAME}/$(basename $img)
 fi
-gcutil addimage $(basename $img .raw.tar.gz | sed 's|\.|-|' | sed 's|_|-|') gs://${BUCKET_NAME}/$(basename $img)
+gcloud compute images create $(basename $img .raw.tar.gz | sed 's|\.|-|' | sed 's|_|-|') --source-uri gs://${BUCKET_NAME}/$(basename $img)

--- a/nixos/maintainers/scripts/gce/create-gce.sh
+++ b/nixos/maintainers/scripts/gce/create-gce.sh
@@ -1,5 +1,6 @@
 #! /bin/sh -e
 
+BUCKET_NAME=${BUCKET_NAME:-nixos}
 export NIX_PATH=nixpkgs=../../../..
 export NIXOS_CONFIG=$(dirname $(readlink -f $0))/../../../modules/virtualisation/google-compute-image.nix
 export TIMESTAMP=$(date +%Y%m%d%H%M)
@@ -8,7 +9,7 @@ nix-build '<nixpkgs/nixos>' \
    -A config.system.build.googleComputeImage --argstr system x86_64-linux -o gce --option extra-binary-caches http://hydra.nixos.org -j 10
 
 img=$(echo gce/*.tar.gz)
-if ! gsutil ls gs://nixos/$(basename $img); then
-  gsutil cp $img gs://nixos/$(basename $img)
+if ! gsutil ls gs://${BUCKET_NAME}/$(basename $img); then
+  gsutil cp $img gs://${BUCKET_NAME}/$(basename $img)
 fi
-gcutil addimage $(basename $img .raw.tar.gz | sed 's|\.|-|' | sed 's|_|-|') gs://nixos/$(basename $img)
+gcutil addimage $(basename $img .raw.tar.gz | sed 's|\.|-|' | sed 's|_|-|') gs://${BUCKET_NAME}/$(basename $img)


### PR DESCRIPTION
Abstracting the BUCKET_NAME allows users of the script to easily build gce images in their through their own personal buckets.

gcutil is deprecated and gcloud compute is the replacement.
