### PR TITLE
updated wkhtmltopdf and use patched qt

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -1,22 +1,88 @@
-{ stdenv, fetchurl, qt4 }:
+{ stdenv, fetchgit, qt4, fontconfig, freetype, libpng, zlib, libjpeg
+, openssl, libX11, libXext, libXrender, overrideDerivation }:
 
 stdenv.mkDerivation rec {
-  name = "wkhtmltopdf-0.11.0_rc1";
+  version = "0.12.1";
+  name = "wkhtmltopdf-${version}";
 
-  src = fetchurl {
-    url = "http://wkhtmltopdf.googlecode.com/files/${name}.tar.bz2";
-    sha1 = "db03922d281856e503b3d562614e3936285728c7";
+  src = fetchgit {
+    url = "https://github.com/wkhtmltopdf/wkhtmltopdf.git";
+    rev = "refs/tags/${version}";
+    sha256 = "0wjzaaviy1k3z8r2kzb2rmyx6xdj23a338b86sxcb15ws3kzwgwh";
   };
 
-  buildInputs = [ qt4 ];
+  wkQt = overrideDerivation qt4 (deriv: {
+    name = "qt-mod-4.8.6";
+    src = fetchgit {
+      url = "https://github.com/wkhtmltopdf/qt.git";
+      rev = "82b568b"; # From git submodule spec in wkhtml repo.
+      sha256 = "0whppwxnymh5bdayqsqx54n074m99yk6v78z7f0k5prja55yvwyx";
+    };
+    configureFlags =
+      ''
+        -v -no-separate-debug-info -release -confirm-license -opensource
+        -qdbus -glib -dbus-linked -openssl-linked
+      ''
+      + # This is taken from the wkhtml build script that we don't run
+      ''
+        -fast
+        -static
+        -exceptions
+        -xmlpatterns
+        -webkit
+        -system-zlib
+        -system-libpng
+        -system-libjpeg
+        -no-libmng
+        -no-libtiff
+        -no-accessibility
+        -no-stl
+        -no-qt3support
+        -no-phonon
+        -no-phonon-backend
+        -no-opengl
+        -no-declarative
+        -no-sql-ibase
+        -no-sql-mysql
+        -no-sql-odbc
+        -no-sql-psql
+        -no-sql-sqlite
+        -no-sql-sqlite2
+        -no-mmx
+        -no-3dnow
+        -no-sse
+        -no-sse2
+        -no-multimedia
+        -nomake demos
+        -nomake docs
+        -nomake examples
+        -nomake tools
+        -nomake tests
+        -nomake translations
+      '';
+  });
+
+  buildInputs = [ wkQt fontconfig freetype libpng zlib libjpeg openssl
+    libX11 libXext libXrender
+    ];
 
   configurePhase = "qmake wkhtmltopdf.pro INSTALLBASE=$out";
   
+  patches = [ ./makefix.patch ];
+
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://code.google.com/p/wkhtmltopdf/;
+    homepage = http://wkhtmltopdf.org/;
     description = "Tools for rendering web pages to PDF or images";
+    longDescription = ''
+      wkhtmltopdf and wkhtmltoimage are open source (LGPL) command line tools
+      to render HTML into PDF and various image formats using the QT Webkit
+      rendering engine. These run entirely "headless" and do not require a
+      display or display service.
+
+      There is also a C library, if you're into that kind of thing.
+    '';
     license = stdenv.lib.licenses.gpl3Plus;
   };
 }

--- a/pkgs/tools/graphics/wkhtmltopdf/makefix.patch
+++ b/pkgs/tools/graphics/wkhtmltopdf/makefix.patch
@@ -1,0 +1,24 @@
+diff -Naur a/src/image/image.pro b/src/image/image.pro
+--- a/src/image/image.pro	2014-08-28 14:07:51.024561967 +0200
++++ b/src/image/image.pro	2014-08-28 14:08:22.383623390 +0200
+@@ -25,7 +25,7 @@
+ 
+ unix {
+     man.path=$$INSTALLBASE/share/man/man1
+-    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltoimage --manpage | gzip > $(INSTALL_ROOT)/share/man/man1/wkhtmltoimage.1.gz
++    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltoimage --manpage | gzip > $$INSTALLBASE/share/man/man1/wkhtmltoimage.1.gz
+ 
+     QMAKE_EXTRA_TARGETS += man
+     INSTALLS += man
+diff -Naur a/src/pdf/pdf.pro b/src/pdf/pdf.pro
+--- a/src/pdf/pdf.pro	2014-08-28 14:10:02.305818775 +0200
++++ b/src/pdf/pdf.pro	2014-08-28 14:09:47.360789555 +0200
+@@ -25,7 +25,7 @@
+ 
+ unix {
+     man.path=$$INSTALLBASE/share/man/man1
+-    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltopdf --manpage | gzip > $(INSTALL_ROOT)/share/man/man1/wkhtmltopdf.1.gz
++    man.extra=LD_LIBRARY_PATH=../../bin/ ../../bin/wkhtmltopdf --manpage | gzip > $$INSTALLBASE/share/man/man1/wkhtmltopdf.1.gz
+ 
+     QMAKE_EXTRA_TARGETS += man
+     INSTALLS += man

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2462,7 +2462,10 @@ let
 
   wicd = callPackage ../tools/networking/wicd { };
 
-  wkhtmltopdf = callPackage ../tools/graphics/wkhtmltopdf { };
+  wkhtmltopdf = callPackage ../tools/graphics/wkhtmltopdf {
+    overrideDerivation = lib.overrideDerivation;
+    inherit (xlibs) libX11 libXext libXrender;
+  };
 
   wv = callPackage ../tools/misc/wv { };
 


### PR DESCRIPTION
wkhtmltopdf was very old. Also, compiling against stock version of qt4
disables a lot of features:
- Running without an X11 server
- Printing more then one HTML document into a PDF file
- Adding a document outline to the PDF file
- Adding headers and footers to the PDF file
- Generating a table of contents
- Adding links in the generated PDF file
- Printing using the screen media-type
- Disabling the smart shrink feature of webkit

I haven't set the meta.platform right now. What is nixpkgs policy there? It would
be convenient to have binaries since the build takes a long time because of qt
but it might not be a very popular package.
