### PR TITLE
libxslt: Add lzma to build inputs.

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libxml2 }:
+{ stdenv, fetchurl, libxml2, lzma }:
 
 stdenv.mkDerivation rec {
   name = "libxslt-1.1.28";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "13029baw9kkyjgr7q3jccw2mz38amq7mmpr5p3bh775qawd1bisz";
   };
 
-  buildInputs = [ libxml2 ];
+  buildInputs = [ libxml2 lzma ];
 
   patches = stdenv.lib.optionals stdenv.isSunOS [ ./patch-ah.patch ];
 


### PR DESCRIPTION
I was unable to build this on Linux until I added this patch (though it is available in the binary cache, so it got built somehow...).

See [log](https://gist.github.com/pmahoney/a40cec4f56d3801b09dc) for the build output from failing build and successful build after this patch.
