### PR TITLE
Disable NFC on 3.17 or above

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -337,6 +337,8 @@ with stdenv.lib;
     ZSMALLOC y
   ''}
   ZRAM m
+  
+  ${optionalString (versionAtLeast version "3.17") "NFC? n"}
 
   ${kernelPlatform.kernelExtraConfig or ""}
   ${extraConfig}


### PR DESCRIPTION
This should only be temporary, but there's a bug in the 3.17 rc1 and rc2 that leads to cyclic module dependencies and a segfault during the build process.
