### PR TITLE
Adds ocaml-cmdliner

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -1,0 +1,36 @@
+{stdenv, fetchurl, ocaml, findlib, opam}:
+
+let
+  pname = "cmdliner";
+  version = "0.9.5";
+  ocaml_version = (builtins.parseDrvName ocaml.name).version;
+in
+stdenv.mkDerivation {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
+    sha256 = "a0e199c4930450e12edf81604eeceddeeb32d55c43438be689e60df282277a7e";
+  };
+
+  unpackCmd = "tar xjf $src";
+  buildInputs = [ ocaml findlib opam ];
+
+  createFindlibDestdir = true;
+
+  configurePhase = "ocaml pkg/git.ml";
+  buildPhase     = "ocaml pkg/build.ml native=true native-dynlink=true";
+  installPhase   = ''
+    opam-installer --script --prefix=$out ${pname}.install > install.sh
+    sh install.sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://erratique.ch/software/cmdliner;
+    description = "An OCaml module for the declarative definition of command line interfaces";
+    license = licenses.bsd3;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3255,6 +3255,8 @@ let
 
     ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
 
+    cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
+
     cppo = callPackage ../development/tools/ocaml/cppo { };
 
     cryptokit = callPackage ../development/ocaml-modules/cryptokit { };


### PR DESCRIPTION
Cmdliner is an OCaml module for the declarative definition of command
line interfaces.

Homepage: http://erratique.ch/software/cmdliner
