### PR TITLE
libgcrypt: Update 1.5.3 and 1.6.2.

### DIFF
--- a/pkgs/development/libraries/libgcrypt/1.6.nix
+++ b/pkgs/development/libraries/libgcrypt/1.6.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, libgpgerror, transfig, ghostscript, texinfo }:
 
 stdenv.mkDerivation rec {
-  name = "libgcrypt-1.6.1";
+  name = "libgcrypt-1.6.2";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${name}.tar.bz2";
-    sha256 = "0w10vhpj1r5nq7qm6jp21p1v1vhf37701cw8yilygzzqd7mfzhx1";
+    sha256 = "de084492a6b38cdb27b67eaf749ceba76bf7029f63a9c0c3c1b05c88c9885c4c";
   };
 
   nativeBuildInputs = [ transfig ghostscript texinfo ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "GNU Libgcrypt, a general-pupose cryptographic library";
+    description = "General-pupose cryptographic library";
 
     longDescription = ''
       GNU Libgcrypt is a general purpose cryptographic library based on

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, libgpgerror }:
 
 stdenv.mkDerivation (rec {
-  name = "libgcrypt-1.5.3";
+  name = "libgcrypt-1.5.4";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${name}.tar.bz2";
-    sha256 = "1lar8y3lh61zl5flljpz540d78g99h4d5idfwrfw8lm3gm737xdw";
+    sha256 = "d5f88d9f41a46953dc250cdb8575129b37ee2208401b7fa338c897f667c7fb33";
   };
 
   propagatedBuildInputs = [ libgpgerror ];


### PR DESCRIPTION
Also changed the description of 1.6.nix to match that of
default.nix (1.5).
- https://lists.gnu.org/archive/html/info-gnu/2014-08/msg00001.html
- https://lists.gnu.org/archive/html/info-gnu/2014-08/msg00011.html
