### PR TITLE
Remove types.functionTo

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -182,16 +182,6 @@ rec {
       substSubModules = m: nullOr (elemType.substSubModules m);
     };
 
-    functionTo = elemType: mkOptionType {
-      name = "function that evaluates to a(n) ${elemType.name}";
-      check = isFunction;
-      merge = loc: defs:
-        fnArgs: elemType.merge loc (map (fn: { inherit (fn) file; value = fn.value fnArgs; }) defs);
-      getSubOptions = elemType.getSubOptions;
-      getSubModules = elemType.getSubModules;
-      substSubModules = m: functionTo (elemType.substSubModules m);
-    };
-
     submodule = opts:
       let
         opts' = toList opts;

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -9,6 +9,23 @@ let
 
   cfg = config.environment;
 
+  exportedEnvVars =
+    let
+      absoluteVariables =
+        mapAttrs (n: toList) cfg.variables;
+
+      suffixedVariables =
+        flip mapAttrs cfg.profileRelativeEnvVars (envVar: listSuffixes:
+          concatMap (profile: map (suffix: "${profile}${suffix}") listSuffixes) cfg.profiles
+        );
+
+      allVariables =
+        zipAttrsWith (n: concatLists) [ absoluteVariables suffixedVariables ];
+
+      exportVariables =
+        mapAttrsToList (n: v: ''export ${n}="${concatStringsSep ":" v}"'') allVariables;
+    in
+      concatStringsSep "\n" exportVariables;
 in
 
 {
@@ -49,22 +66,15 @@ in
       type = types.listOf types.string;
     };
 
-    environment.profileVariables = mkOption {
-      default = (p: {});
+    environment.profileRelativeEnvVars = mkOption {
+      type = types.attrsOf (types.listOf types.str);
+      example = { PATH = [ "/bin" "/sbin" ]; MANPATH = [ "/man" "/share/man" ]; };
       description = ''
-        A function which given a profile path should give back
-        a set of environment variables for that profile.
+	Attribute set of environment variable.  Each attribute maps to a list
+	of relative paths.  Each relative path is appended to the each profile
+        of <option>environment.profiles</option> to form the content of the
+        corresponding environment variable.
       '';
-      # !!! this should be of the following type:
-      #type = types.functionTo (types.attrsOf (types.optionSet envVar));
-      # and envVar should be changed to something more like environOpts.
-      # Having unique `value' _or_ multiple `list' is much more useful
-      # than just sticking everything together with ':' unconditionally.
-      # Anyway, to have this type mentioned above
-      # types.optionSet needs to be transformed into a type constructor
-      # (it has a !!! mark on that in nixpkgs)
-      # for now we hack all this to be
-      type = types.functionTo (types.attrsOf (types.listOf types.string));
     };
 
     # !!! isn't there a better way?
@@ -165,10 +175,7 @@ in
 
     system.build.setEnvironment = pkgs.writeText "set-environment"
        ''
-         ${concatStringsSep "\n" (
-           (mapAttrsToList (n: v: ''export ${n}="${concatStringsSep ":" v}"'')
-             # This line is a kind of a hack because of !!! note above
-             (zipAttrsWith (const concatLists) ([ (mapAttrs (n: v: [ v ]) cfg.variables) ] ++ map cfg.profileVariables cfg.profiles))))}
+         ${exportedEnvVars}
 
          ${cfg.extraInit}
 

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -37,25 +37,24 @@ in
         "/run/current-system/sw"
       ];
 
-    # !!! fix environment.profileVariables definition and then move
-    # most of these elsewhere
-    environment.profileVariables = (i:
-      { PATH = [ "${i}/bin" "${i}/sbin" "${i}/lib/kde4/libexec" ];
-        MANPATH = [ "${i}/man" "${i}/share/man" ];
-        INFOPATH = [ "${i}/info" "${i}/share/info" ];
-        PKG_CONFIG_PATH = [ "${i}/lib/pkgconfig" ];
-        TERMINFO_DIRS = [ "${i}/share/terminfo" ];
-        PERL5LIB = [ "${i}/lib/perl5/site_perl" ];
-        ALSA_PLUGIN_DIRS = [ "${i}/lib/alsa-lib" ];
-        KDEDIRS = [ "${i}" ];
-        STRIGI_PLUGIN_PATH = [ "${i}/lib/strigi/" ];
-        QT_PLUGIN_PATH = [ "${i}/lib/qt4/plugins" "${i}/lib/kde4/plugins" ];
-        QTWEBKIT_PLUGIN_PATH = [ "${i}/lib/mozilla/plugins/" ];
-        GTK_PATH = [ "${i}/lib/gtk-2.0" "${i}/lib/gtk-3.0" ];
-        XDG_CONFIG_DIRS = [ "${i}/etc/xdg" ];
-        XDG_DATA_DIRS = [ "${i}/share" ];
-        MOZ_PLUGIN_PATH = [ "${i}/lib/mozilla/plugins" ];
-      });
+    # TODO: move most of these elsewhere
+    environment.profileRelativeEnvVars =
+      { PATH = [ "/bin" "/sbin" "/lib/kde4/libexec" ];
+        MANPATH = [ "/man" "/share/man" ];
+        INFOPATH = [ "/info" "/share/info" ];
+        PKG_CONFIG_PATH = [ "/lib/pkgconfig" ];
+        TERMINFO_DIRS = [ "/share/terminfo" ];
+        PERL5LIB = [ "/lib/perl5/site_perl" ];
+        ALSA_PLUGIN_DIRS = [ "/lib/alsa-lib" ];
+        KDEDIRS = [ "" ];
+        STRIGI_PLUGIN_PATH = [ "/lib/strigi/" ];
+        QT_PLUGIN_PATH = [ "/lib/qt4/plugins" "/lib/kde4/plugins" ];
+        QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
+        GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" ];
+        XDG_CONFIG_DIRS = [ "/etc/xdg" ];
+        XDG_DATA_DIRS = [ "/share" ];
+        MOZ_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
+      };
 
     environment.extraInit =
       ''


### PR DESCRIPTION
A function is not a trivial concept, and the default value cannot be properly documented.  As such, we should avoid using them as value of options.

The option `environment.profileRelativeEnvVars` represents the most common use case of `environment.profileVariables`, without using `types.functionTo`.
