### PR TITLE
nixos/generate-config: Btrfs mounts aren't bind mounts

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -310,7 +310,9 @@ foreach my $fs (read_file("/proc/self/mountinfo")) {
     next if $mountPoint eq "/nix/store" && (grep { $_ eq "rw" } @superOptions) && (grep { $_ eq "ro" } @mountOptions);
 
     # Maybe this is a bind-mount of a filesystem we saw earlier?
-    if (defined $fsByDev{$fields[2]}) {
+    # BTRFS is a special case since regular btrfs mounts can work as bind mounts
+    # If we try to detect bind mounts on BTRFS, we potentially break subvolumes
+    if ($fsType ne "btrfs" && defined $fsByDev{$fields[2]}) {
         my $path = $fields[3]; $path = "" if $path eq "/";
         my $base = $fsByDev{$fields[2]};
         $base = "" if $base eq "/";


### PR DESCRIPTION
Currently, we detect any mount points which use the same device but
exist inside of other mount points as bind mounts. This works for
filesystems which are only ever mounted from a device a single time.
However, btrfs contains subvolumes, which are separate filesystem
entities within the same device. These subvolumes are potentially
mounted inside of other mounts for the same btrfs device. Therefore, the
generate config script detects these as bind mounts and breaks the
mountpoint.

Since btrfs is designed to handle many mountpoints for the same device,
it also internally allows you to mount the same device many times. It
even allows you to mount a subvolume or root volume multiple times
within the same filesystem tree. Therefore, it is okay to treat a bind
mount as a regular btrfs mount as it will achieve the same effect.

This patch changes the behavior to simply generate normal entries for
all btrfs mounts, regardless of whether they are bind mounts or not.
