### PR TITLE
skarnet.org UNIX utilities

### DIFF
--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, skalibs }:
+
+let
+
+  version = "1.0.3.1";
+
+in stdenv.mkDerivation rec {
+
+  name = "s6-linux-utils-${version}";
+
+  src = fetchurl {
+    url = "http://www.skarnet.org/software/s6-linux-utils/${name}.tar.gz";
+    sha256 = "1s17g03z5hfpiz32g001g5wyamyvn9l36fr2csk3k7r0jkqfnl0d";
+  };
+
+  buildInputs = [ skalibs ];
+
+  sourceRoot = "admin/${name}";
+
+  configurePhase = ''
+    pushd conf-compile
+
+    printf "$out/bin"           > conf-install-command
+    printf "$out/include"       > conf-install-include
+    printf "$out/lib"           > conf-install-library
+    printf "$out/lib"           > conf-install-library.so
+
+    # let nix builder strip things, cross-platform
+    truncate --size 0 conf-stripbins
+    truncate --size 0 conf-striplibs
+
+    printf "${skalibs}/sysdeps"      > import
+    printf "%s" "${skalibs}/include" > path-include
+    printf "%s" "${skalibs}/lib"     > path-library
+
+    rm -f flag-slashpackage
+    touch flag-allstatic
+
+    popd
+  '';
+
+  preBuild = ''
+    patchShebangs src/sys
+  '';
+
+  meta = {
+    homepage = http://www.skarnet.org/software/s6-linux-utils/;
+    description = "A set of minimalistic Linux-specific system utilities.";
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.isc;
+  };
+
+}

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, skalibs }:
+
+let
+
+  version = "1.0.3.2";
+
+in stdenv.mkDerivation rec {
+
+  name = "s6-portable-utils-${version}";
+
+  src = fetchurl {
+    url = "http://www.skarnet.org/software/s6-portable-utils/${name}.tar.gz";
+    sha256 = "040nmls7qbgw8yn502lym4kgqh5zxr2ks734bqajpi2ricnasvhl";
+  };
+
+  buildInputs = [ skalibs ];
+
+  sourceRoot = "admin/${name}";
+
+  configurePhase = ''
+    pushd conf-compile
+
+    printf "$out/bin"           > conf-install-command
+    printf "$out/libexec"       > conf-install-libexec
+
+    # let nix builder strip things, cross-platform
+    truncate --size 0 conf-stripbins
+    truncate --size 0 conf-striplibs
+
+    printf "${skalibs}/sysdeps"      > import
+    printf "%s" "${skalibs}/include" > path-include
+    printf "%s" "${skalibs}/lib"     > path-library
+
+    rm -f flag-slashpackage
+    touch flag-allstatic
+
+    popd
+  '';
+
+  preBuild = ''
+    patchShebangs src/sys
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/libexec"
+  '';
+
+  meta = {
+    homepage = http://www.skarnet.org/software/s6-portable-utils/;
+    description = "A set of tiny general Unix utilities optimized for simplicity and small size.";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.isc;
+  };
+
+}

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, skalibs }:
+
+let
+
+  version = "0.1.0.0";
+
+in stdenv.mkDerivation rec {
+
+  name = "s6-dns-${version}";
+
+  src = fetchurl {
+    url = "http://www.skarnet.org/software/s6-dns/${name}.tar.gz";
+    sha256 = "1r82l5fnz2rrwm5wq2sldqp74lk9fifr0d8hyq98xdyh24hish68";
+  };
+
+  buildInputs = [ skalibs ];
+
+  sourceRoot = "web/${name}";
+
+  configurePhase = ''
+    pushd conf-compile
+
+    printf "$out/bin"           > conf-install-command
+    printf "$out/include"       > conf-install-include
+    printf "$out/lib"           > conf-install-library
+    printf "$out/lib"           > conf-install-library.so
+
+    # let nix builder strip things, cross-platform
+    truncate --size 0 conf-stripbins
+    truncate --size 0 conf-striplibs
+
+    printf "${skalibs}/sysdeps"      > import
+    printf "%s" "${skalibs}/include" > path-include
+    printf "%s" "${skalibs}/lib"     > path-library
+
+    rm -f flag-slashpackage
+    touch flag-allstatic
+
+    popd
+  '';
+
+  preBuild = ''
+    patchShebangs src/sys
+  '';
+
+  meta = {
+    homepage = http://www.skarnet.org/software/s6-dns/;
+    description = "A suite of DNS client programs and libraries for Unix systems.";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.isc;
+  };
+
+}

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, execline
+, fetchurl
+, s6Dns
+, skalibs
+}:
+
+let
+
+  version = "0.1.0.0";
+
+in stdenv.mkDerivation rec {
+
+  name = "s6-networking-${version}";
+
+  src = fetchurl {
+    url = "http://www.skarnet.org/software/s6-networking/${name}.tar.gz";
+    sha256 = "1np9m2j1i2450mbcjvpbb56kv3wc2fbyvmv2a039q61j2lk6vjz7";
+  };
+
+  buildInputs = [ skalibs s6Dns execline ];
+
+  sourceRoot = "net/${name}";
+
+  configurePhase = ''
+    pushd conf-compile
+
+    printf "$out/bin"           > conf-install-command
+    printf "$out/include"       > conf-install-include
+    printf "$out/lib"           > conf-install-library
+    printf "$out/lib"           > conf-install-library.so
+
+    # let nix builder strip things, cross-platform
+    truncate --size 0 conf-stripbins
+    truncate --size 0 conf-striplibs
+
+    printf "${skalibs}/sysdeps"      > import
+
+    rm -f path-include
+    rm -f path-library
+    for dep in "${execline}" "${s6Dns}" "${skalibs}"; do
+      printf "%s\n" "$dep/include" >> path-include
+      printf "%s\n" "$dep/lib"     >> path-library
+    done
+
+    rm -f flag-slashpackage
+    touch flag-allstatic
+
+    popd
+  '';
+
+  preBuild = ''
+    patchShebangs src/sys
+  '';
+
+  meta = {
+    homepage = http://www.skarnet.org/software/s6-networking/;
+    description = "A suite of small networking utilities for Unix systems.";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.isc;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2051,6 +2051,8 @@ let
     ruby = ruby18;
   };
 
+  s6Dns = callPackage ../tools/networking/s6-dns { };
+
   s6PortableUtils = callPackage ../tools/misc/s6-portable-utils { };
 
   sablotron = callPackage ../tools/text/xml/sablotron { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2051,6 +2051,8 @@ let
     ruby = ruby18;
   };
 
+  s6PortableUtils = callPackage ../tools/misc/s6-portable-utils { };
+
   sablotron = callPackage ../tools/text/xml/sablotron { };
 
   safecopy = callPackage ../tools/system/safecopy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2053,6 +2053,8 @@ let
 
   s6Dns = callPackage ../tools/networking/s6-dns { };
 
+  s6LinuxUtils = callPackage ../os-specific/linux/s6-linux-utils { };
+
   s6Networking = callPackage ../tools/networking/s6-networking { };
 
   s6PortableUtils = callPackage ../tools/misc/s6-portable-utils { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2053,6 +2053,8 @@ let
 
   s6Dns = callPackage ../tools/networking/s6-dns { };
 
+  s6Networking = callPackage ../tools/networking/s6-networking { };
+
   s6PortableUtils = callPackage ../tools/misc/s6-portable-utils { };
 
   sablotron = callPackage ../tools/text/xml/sablotron { };


### PR DESCRIPTION
Rounding out the collection from [http://www.skarnet.org/software/](http://www.skarnet.org/software/).

These are configured to link statically (to skalibs, not libc).

I use a couple of these here and there, mostly [s6-update-symlinks](http://www.skarnet.org/software/s6-portable-utils/s6-update-symlinks.html).
