### PR TITLE
nginx: add lua module

### DIFF
--- a/pkgs/servers/http/nginx/default.nix
+++ b/pkgs/servers/http/nginx/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, fetchgit, openssl, zlib, pcre, libxml2, libxslt, expat
-, gd, geoip
+, gd, geoip, luajit
 , rtmp ? false
 , fullWebDAV ? false
 , syslog ? false
 , moreheaders ? false
-, echo ? false }:
+, echo ? false
+, ngx_lua ? false }:
 
 with stdenv.lib;
 
@@ -44,6 +45,19 @@ let
     rev = "refs/tags/v0.53";
     sha256 = "90d4e3a49c678019f4f335bc18529aa108fcc9cfe0747ea4e2f6084a70da2868";
   };
+
+  develkit-ext = fetchgit {
+    url = https://github.com/simpl/ngx_devel_kit.git;
+    rev = "refs/tags/v0.2.19";
+    sha256 = "169m6gsa5b6zh1ws8qx2k7dbswld1zmhm4dh57qka0h07gs5dqjg";
+  };
+
+  lua-ext = fetchgit {
+    url = https://github.com/openresty/lua-nginx-module.git;
+    rev = "refs/tags/v0.9.11";
+    sha256 = "0y7238bvb907n7fsz5sivxbhfz2xnf4f0lzwk3k3h9j20fsyvwqq";
+  };
+
 in
 
 stdenv.mkDerivation rec {
@@ -52,7 +66,11 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ openssl zlib pcre libxml2 libxslt gd geoip
-    ] ++ optional fullWebDAV expat;
+    ] ++ optional fullWebDAV expat
+      ++ optional ngx_lua luajit;
+
+  LUAJIT_LIB = if ngx_lua then "${luajit}/lib" else "";
+  LUAJIT_INC = if ngx_lua then "${luajit}/include/luajit-2.0" else "";
 
   patches = if syslog then [ "${syslog-ext}/syslog-1.5.6.patch" ] else [];
 
@@ -83,6 +101,7 @@ stdenv.mkDerivation rec {
     ++ optional syslog "--add-module=${syslog-ext}"
     ++ optional moreheaders "--add-module=${moreheaders-ext}"
     ++ optional echo "--add-module=${echo-ext}"
+    ++ optional ngx_lua "--add-module=${develkit-ext} --add-module=${lua-ext}"
     ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio";
 
 


### PR DESCRIPTION
This adds the `ngx_lua` module as an optional component.

I named the argument key `ngx_lua` since `lua` is already taken, though it now does not match the other modules' argument keys.  ([Upstream](https://github.com/openresty/lua-nginx-module) refers to the package by various names, `ngx_lua` being one of them).

I used `luajit` since that's all I've tested with (on darwin and linux), but it's certainly possible to use with plain lua. Not quite sure on the best way to add support for both, should that be desired.

After building, the output of `nginx -V` looks like this:

```
nginx version: nginx/1.6.1
...
--add-module=/nix/store/aaa-git-export --add-module=/nix/store/bbb-git-export --add-module=/nix/store/ccc-git-export
...
```

It's a minor annoyance that all the modules from git end in `git-export` rather than some identifying string. Is there any way around that?
