### PR TITLE
texlive: Updated to latest release 2014.20140821

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -5,16 +5,16 @@ rec {
     sha256 = "0nh8hfayyf60nm4z8zyclrbc3792c62azgsvrwxnl28iq223200s";
   };
 
-  texmfVersion = "2014.20140717";
+  texmfVersion = "2014.20140821";
   texmfSrc = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-base/texlive-base_${texmfVersion}.orig.tar.xz";
-    sha256 = "08vhl6x742r8fl0gags2r6yspz8ynvz26vdjrqb4vyz5h7h3rzc9";
+    sha256 = "02qkzlhb381sybs970fgpc94nhx4jm0l3j5pv8z48l11415lvm9b";
   };
 
-  langTexmfVersion = "2014.20140717";
+  langTexmfVersion = "2014.20140821";
   langTexmfSrc = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-lang/texlive-lang_${langTexmfVersion}.orig.tar.xz";
-    sha256 = "1x9aa3v2cg4lcb58lwksnfdsgrhi0sg968pjqsbndmbxhr1msbp7";
+    sha256 = "075avhhhhzw5pbd19q659rn23rws15b5hv7nv0grd93vn3vfwdcy";
   };
 
   passthru = { inherit texmfSrc langTexmfSrc; };

--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -1,11 +1,11 @@
 args: with args;
 rec {
   name    = "texlive-extra-2014";
-  version = "2014.20140717";
+  version = "2014.20140821";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-extra/texlive-extra_${version}.orig.tar.xz";
-    sha256 = "1khxqdq9gagm6z8kbpjbraysfzibfjs2cgbrhjpncbd24sxpw13q";
+    sha256 = "1y3w8bgp85s90ng2y5dw9chrrvvdf7ibb6ynss8kycvgc0y4m6b3";
   };
 
   buildInputs = [texLive xz];


### PR DESCRIPTION
Old release does not appear to be on the mirrors, breaking the build.

This just fixes broken download URL's . I don't know anything about TEX.
