### PR TITLE
Add xar

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -34,6 +34,7 @@
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
+  copumpkin = "Dan Peebles <pumpkingod@gmail.com>";
   coroa = "Jonas Hörsch <jonas@chaoflow.net>";
   cstrahan = "Charles Strahan <charles.c.strahan@gmail.com>";
   DamienCassou = "Damien Cassou <damien.cassou@gmail.com>";

--- a/pkgs/tools/compression/xar/default.nix
+++ b/pkgs/tools/compression/xar/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, libxml2, openssl, zlib, bzip2 }:
+
+stdenv.mkDerivation rec {
+  version = "1.5.2";
+  name    = "xar-${version}";
+
+  src = fetchurl {
+    url    = "https://xar.googlecode.com/files/${name}.tar.gz";
+    sha256 = "1rp3va6akzlh35yqrapfqnbxaxa0zi8wyr93swbapprwh215cpac";
+  };
+
+  buildInputs = [ libxml2 openssl zlib bzip2 ];
+
+  meta = {
+    homepage    = https://code.google.com/p/xar/;
+    description = "Extensible Archiver";
+
+    longDescription =
+      '' The XAR project aims to provide an easily extensible archive format. 
+         Important design decisions include an easily extensible XML table of
+         contents for random access to archived files, storing the toc at the
+         beginning of the archive to allow for efficient handling of streamed
+         archives, the ability to handle files of arbitrarily large sizes, the
+         ability to choose independent encodings for individual files in the
+         archive, the ability to store checksums for individual files in both
+         compressed and uncompressed form, and the ability to query the table
+         of content's rich meta-data.
+      '';
+
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ copumpkin ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2407,6 +2407,8 @@ let
 
   unrar = callPackage ../tools/archivers/unrar { };
 
+  xar = callPackage ../tools/compression/xar { };
+
   xarchive = callPackage ../tools/archivers/xarchive { };
 
   xarchiver = callPackage ../tools/archivers/xarchiver { };


### PR DESCRIPTION
http://en.wikipedia.org/wiki/Xar_(archiver)

The smlnj package currently implicitly depends on xar being present (https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/smlnj/bootstrap.nix#L16). I'll submit another PR to fix that shortly.
