### PR TITLE
Higan - a quick&dirty workaround

### DIFF
--- a/pkgs/misc/emulators/higan/builder.sh
+++ b/pkgs/misc/emulators/higan/builder.sh
@@ -18,3 +18,25 @@ install -m 644 ananke/libananke.so $out/lib/libananke.so.1
 (cd $out/lib && ln -s libananke.so.1 libananke.so)
 oldRPath=$(patchelf --print-rpath $out/bin/higan)
 patchelf --set-rpath $oldRPath:$out/lib $out/bin/higan
+
+# A dirty workaround, suggested by @cpages:
+# we create a wrapper script to set up
+# $HOME local configuration before higan runs
+
+mv $out/bin/higan $out/bin/.higan-wrapped
+cat <<EOF > $out/bin/higan 
+
+#!/bin/bash
+if [ ! -e \$HOME/.config/higan/.was_configured ]
+then
+    cp --update --recursive $out/share/higan \$HOME/.config
+    chmod --recursive u+w \$HOME/.config/higan
+    touch \$HOME/.config/higan/.was_configured
+fi
+# LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$out/lib
+$out/bin/.higan-wrapped "\$@"
+
+EOF
+
+patchShebangs $out/bin/higan
+chmod +x $out/bin/higan

--- a/pkgs/misc/emulators/higan/builder.sh
+++ b/pkgs/misc/emulators/higan/builder.sh
@@ -20,23 +20,16 @@ oldRPath=$(patchelf --print-rpath $out/bin/higan)
 patchelf --set-rpath $oldRPath:$out/lib $out/bin/higan
 
 # A dirty workaround, suggested by @cpages:
-# we create a wrapper script to set up
-# $HOME local configuration before higan runs
+# we create a first-run script to populate
+# the local $HOME with all the auxiliary
+# stuff needed by higan at runtime
 
-mv $out/bin/higan $out/bin/.higan-wrapped
-cat <<EOF > $out/bin/higan 
+cat <<EOF > $out/bin/higan-config.sh
+#!${shell}
 
-#!/bin/bash
-if [ ! -e \$HOME/.config/higan/.was_configured ]
-then
-    cp --update --recursive $out/share/higan \$HOME/.config
-    chmod --recursive u+w \$HOME/.config/higan
-    touch \$HOME/.config/higan/.was_configured
-fi
-# LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$out/lib
-$out/bin/.higan-wrapped "\$@"
+cp --update --recursive $out/share/higan \$HOME/.config
+chmod --recursive u+w \$HOME/.config/higan
 
 EOF
 
-patchShebangs $out/bin/higan
-chmod +x $out/bin/higan
+chmod +x $out/bin/higan-config.sh

--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation rec {
 # TODO:
 #   - options to choose profiles (accuracy, balanced, performance)
 #     and different GUIs (gtk2, qt4)
-#   - fix the BML and BIOS paths - maybe a custom patch to Higan project?
+#   - fix the BML and BIOS paths - maybe submitting
+#     a custom patch to Higan project would not be a bad idea...
 #


### PR DESCRIPTION
Higan uses a lot of hardcoded paths when it looks for runtime files
as shaders, icons and mainly BIOS files. So, we made a q&d wrapper
script: it copies all these files to $HOME/.config/higan in the 1st
invocation.
