### PR TITLE
Added package tcl2048

### DIFF
--- a/pkgs/games/tcl2048/builder.sh
+++ b/pkgs/games/tcl2048/builder.sh
@@ -1,0 +1,5 @@
+source $stdenv/setup
+
+mkdir -p $out/bin
+cp $src $out/bin/2048
+chmod +x $out/bin/2048

--- a/pkgs/games/tcl2048/default.nix
+++ b/pkgs/games/tcl2048/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, tcl, tcllib }:
+
+stdenv.mkDerivation {
+  name = "tcl2048-0.2.5";
+
+  src = fetchurl {
+    url = https://raw.githubusercontent.com/dbohdan/2048-tcl/v0.2.5/2048.tcl;
+    sha256 = "b0d6e8a31dce8c1ca8dbbb8c513b50fbfb9cd6a313201941fa15531165bf68ce";
+  };
+
+  builder = ./builder.sh;
+
+  meta = {
+    homepage = https://github.com/dbohdan/2048-tcl;
+    description = "The game of 2048 implemented in Tcl.";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/games/tcl2048/default.nix
+++ b/pkgs/games/tcl2048/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, tcl, tcllib }:
 
 stdenv.mkDerivation {
-  name = "tcl2048-0.2.5";
+  name = "tcl2048-0.2.6";
 
   src = fetchurl {
-    url = https://raw.githubusercontent.com/dbohdan/2048-tcl/v0.2.5/2048.tcl;
-    sha256 = "b0d6e8a31dce8c1ca8dbbb8c513b50fbfb9cd6a313201941fa15531165bf68ce";
+    url = https://raw.githubusercontent.com/dbohdan/2048-tcl/v0.2.6/2048.tcl;
+    sha256 = "3a6466a214c538daec8e2d08e0c1467f10f770c74e5897bea642134e22016730";
   };
 
   builder = ./builder.sh;

--- a/pkgs/games/tcl2048/default.nix
+++ b/pkgs/games/tcl2048/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = https://raw.githubusercontent.com/dbohdan/2048-tcl/v0.2.6/2048.tcl;
-    sha256 = "3a6466a214c538daec8e2d08e0c1467f10f770c74e5897bea642134e22016730";
+    sha256 = "481eac7cccc37d1122c3069da6186f584906bd27b86b8d4ae1a2d7e355c1b6b2";
   };
 
   builder = ./builder.sh;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2211,6 +2211,8 @@ let
 
   tboot = callPackage ../tools/security/tboot { };
 
+  tcl2048 = callPackage ../games/tcl2048 { };
+
   tcpdump = callPackage ../tools/networking/tcpdump { };
 
   tcpflow = callPackage ../tools/networking/tcpflow { };
@@ -9215,7 +9217,7 @@ let
   lynx = callPackage ../applications/networking/browsers/lynx { };
 
   lyx = callPackage ../applications/misc/lyx { };
-  
+
   makeself = callPackage ../applications/misc/makeself { };
 
   matchbox = callPackage ../applications/window-managers/matchbox { };


### PR DESCRIPTION
[2048.tcl](https://github.com/dbohdan/2048-tcl) is a text mode implementation of the game of 2048. Package named `tcl2048` to not start with a number.
