### PR TITLE
haskell-xml-html-conduit-lens 0.3.2.0 -> 0.3.2.1

### DIFF
--- a/pkgs/development/libraries/haskell/xml-html-conduit-lens/default.nix
+++ b/pkgs/development/libraries/haskell/xml-html-conduit-lens/default.nix
@@ -6,8 +6,8 @@
 
 cabal.mkDerivation (self: {
   pname = "xml-html-conduit-lens";
-  version = "0.3.2.0";
-  sha256 = "150b772wkl2k8xcrcbqj3qhndjkl35qzwqdjbgs9mxp867aihiv0";
+  version = "0.3.2.1";
+  sha256 = "0iy58nq5b6ixdky2xr4r8xxk3c8wqp1y3jbpsk3dr1qawzjbzp12";
   buildDepends = [ htmlConduit lens text xmlConduit ];
   testDepends = [
     doctest hspec hspecExpectationsLens lens xmlConduit
@@ -17,7 +17,5 @@ cabal.mkDerivation (self: {
     description = "Optics for xml-conduit and html-conduit";
     license = self.stdenv.lib.licenses.bsd3;
     platforms = self.ghc.meta.platforms;
-    hydraPlatforms = self.stdenv.lib.platforms.none;
-    broken = true;
   };
 })


### PR DESCRIPTION
There was a problem with this package https://hydra.nixos.org/build/13042028
It was fixed https://github.com/supki/xml-html-conduit-lens/pull/2
