### PR TITLE
start dhcpcd after network-interfaces

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -138,6 +138,9 @@ in
       { description = "DHCP Client";
 
         wantedBy = [ "network.target" ];
+        # Work-around to deal with problems where the kernel would remove &
+        # re-create Wifi interfaces early during boot.
+        after = [ "network-interfaces.target" ];
 
         # Stopping dhcpcd during a reconfiguration is undesirable
         # because it brings down the network interfaces configured by


### PR DESCRIPTION
I believe this might fix a race condition with dhcpcd and my Wifi, causing me not to have Internets every once in a while on boot. When that happens, a systemctl restart dhcpcd always fixes it.

@the-kenny was also affected I believe.
