### PR TITLE
Reapply the multi-ip code

### DIFF
--- a/nixos/doc/manual/configuration/ipv4-config.xml
+++ b/nixos/doc/manual/configuration/ipv4-config.xml
@@ -12,12 +12,9 @@ interfaces.  However, you can configure an interface manually as
 follows:
 
 <programlisting>
-networking.interfaces.eth0 = { ipAddress = "192.168.1.2"; prefixLength = 24; };
+networking.interfaces.eth0.ip4 = [ { address = "192.168.1.2"; prefixLength = 24; } ];
 </programlisting>
 
-(The network prefix can also be specified using the option
-<literal>subnetMask</literal>,
-e.g. <literal>"255.255.255.0"</literal>, but this is deprecated.)
 Typically you’ll also want to set a default gateway and set of name
 servers:
 

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -52,7 +52,7 @@ rec {
                   [ { address = "192.168.${toString first}.${toString m.second}";
                       prefixLength = 24;
                   } ];
-                }
+                });
             in
             { key = "ip-address";
               config =

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -48,10 +48,11 @@ rec {
             let
               interfacesNumbered = zipTwoLists config.virtualisation.vlans (range 1 255);
               interfaces = flip map interfacesNumbered ({ first, second }:
-                nameValuePair "eth${toString second}"
-                  { ipAddress = "192.168.${toString first}.${toString m.second}";
-                    subnetMask = "255.255.255.0";
-                  });
+                nameValuePair "eth${toString second}" { ip4 =
+                  [ { address = "192.168.${toString first}.${toString m.second}";
+                      prefixLength = 24;
+                  } ];
+                }
             in
             { key = "ip-address";
               config =
@@ -60,7 +61,7 @@ rec {
                   networking.interfaces = listToAttrs interfaces;
 
                   networking.primaryIPAddress =
-                    optionalString (interfaces != []) (head interfaces).value.ipAddress;
+                    optionalString (interfaces != []) (head (head interfaces).value.ip4).address;
 
                   # Put the IP addresses of all VMs in this machine's
                   # /etc/hosts file.  If a machine has multiple

--- a/nixos/modules/programs/virtualbox.nix
+++ b/nixos/modules/programs/virtualbox.nix
@@ -44,5 +44,5 @@ let virtualbox = config.boot.kernelPackages.virtualbox; in
         '';
     };
 
-  networking.interfaces.vboxnet0 = { ipAddress = "192.168.56.1"; prefixLength = 24; };
+  networking.interfaces.vboxnet0.ip4 = [ { address = "192.168.56.1"; prefixLength = 24; } ];
 }

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -11,7 +11,7 @@ let
   # Don't start dhcpcd on explicitly configured interfaces or on
   # interfaces that are part of a bridge, bond or sit device.
   ignoredInterfaces =
-    map (i: i.name) (filter (i: i.ipAddress != null) (attrValues config.networking.interfaces))
+    map (i: i.name) (filter (i: i.ip4 != [ ] || i.ipAddress != null) (attrValues config.networking.interfaces))
     ++ mapAttrsToList (i: _: i) config.networking.sits
     ++ concatLists (attrValues (mapAttrs (n: v: v.interfaces) config.networking.bridges))
     ++ concatLists (attrValues (mapAttrs (n: v: v.interfaces) config.networking.bonds))

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -586,10 +586,10 @@ in
           let
             ips = i.ip4 ++ optionals cfg.enableIPv6 i.ip6
               ++ optional (i.ipAddress != null) {
-                ipAddress = i.ipAddress;
+                address = i.ipAddress;
                 prefixLength = i.prefixLength;
               } ++ optional (cfg.enableIPv6 && i.ipv6Address != null) {
-                ipAddress = i.ipv6Address;
+                address = i.ipv6Address;
                 prefixLength = i.ipv6PrefixLength;
               };
           in

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -10,6 +10,26 @@ let
   hasSits = cfg.sits != { };
   hasBonds = cfg.bonds != { };
 
+  addrOpts = v:
+    assert v == 4 || v == 6;
+    {
+      address = mkOption {
+        type = types.str;
+        description = ''
+          IPv${toString v} address of the interface.  Leave empty to configure the
+          interface using DHCP.
+        '';
+      };
+
+      prefixLength = mkOption {
+        type = types.addCheck types.int (n: n >= 0 && n <= (if v == 4 then 32 else 128));
+        description = ''
+          Subnet mask of the interface, specified as the number of
+          bits in the prefix (<literal>${if v == 4 then "24" else "64"}</literal>).
+        '';
+      };
+    };
+
   interfaceOpts = { name, ... }: {
 
     options = {
@@ -20,10 +40,36 @@ let
         description = "Name of the interface.";
       };
 
+      ip4 = mkOption {
+        default = [ ];
+        example = [
+          { address = "10.0.0.1"; prefixLength = 16; }
+          { address = "192.168.1.1"; prefixLength = 24; }
+        ];
+        type = types.listOf types.optionSet;
+        options = addrOpts 4;
+        description = ''
+          List of IPv4 addresses that will be statically assigned to the interface.
+        '';
+      };
+
+      ip6 = mkOption {
+        default = [ ];
+        example = [
+          { address = "fdfd:b3f0:482::1"; prefixLength = 48; }
+          { address = "2001:1470:fffd:2098::e006"; prefixLength = 64; }
+        ];
+        type = types.listOf types.optionSet;
+        options = addrOpts 6;
+        description = ''
+          List of IPv6 addresses that will be statically assigned to the interface.
+        '';
+      };
+
       ipAddress = mkOption {
         default = null;
         example = "10.0.0.1";
-        type = types.nullOr (types.str);
+        type = types.nullOr types.str;
         description = ''
           IP address of the interface.  Leave empty to configure the
           interface using DHCP.
@@ -41,20 +87,16 @@ let
       };
 
       subnetMask = mkOption {
-        default = "";
-        example = "255.255.255.0";
-        type = types.str;
+        default = null;
         description = ''
-          Subnet mask of the interface, specified as a bitmask.
-          This is deprecated; use <option>prefixLength</option>
-          instead.
+          Defunct, supply the prefix length instead.
         '';
       };
 
       ipv6Address = mkOption {
         default = null;
         example = "2001:1470:fffd:2098::e006";
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         description = ''
           IPv6 address of the interface.  Leave empty to configure the
           interface using NDP.
@@ -224,10 +266,10 @@ in
     networking.interfaces = mkOption {
       default = {};
       example =
-        { eth0 = {
-            ipAddress = "131.211.84.78";
-            subnetMask = "255.255.255.128";
-          };
+        { eth0.ip4 = [ {
+            address = "131.211.84.78";
+            prefixLength = 25;
+          } ];
         };
       description = ''
         The configuration for each network interface.  If
@@ -438,6 +480,12 @@ in
 
   config = {
 
+    assertions =
+      flip map interfaces (i: {
+        assertion = i.subnetMask == null;
+        message = "The networking.interfaces.${i.name}.subnetMask option is defunct. Use prefixLength instead.";
+      });
+
     boot.kernelModules = [ ]
       ++ optional cfg.enableIPv6 "ipv6"
       ++ optional hasVirtuals "tun"
@@ -534,12 +582,18 @@ in
         # network device, so it only gets started after the interface
         # has appeared, and it's stopped when the interface
         # disappears.
-        configureInterface = i: nameValuePair "${i.name}-cfg"
-          (let mask =
-                if i.prefixLength != null then toString i.prefixLength else
-                if i.subnetMask != "" then i.subnetMask else "32";
-               staticIPv6 = cfg.enableIPv6 && i.ipv6Address != null;
+        configureInterface = i:
+          let
+            ips = i.ip4 ++ optionals cfg.enableIPv6 i.ip6
+              ++ optional (i.ipAddress != null) {
+                ipAddress = i.ipAddress;
+                prefixLength = i.prefixLength;
+              } ++ optional (cfg.enableIPv6 && i.ipv6Address != null) {
+                ipAddress = i.ipv6Address;
+                prefixLength = i.ipv6PrefixLength;
+              };
           in
+          nameValuePair "${i.name}-cfg"
           { description = "Configuration of ${i.name}";
             wantedBy = [ "network-interfaces.target" ];
             bindsTo = [ "sys-subsystem-net-devices-${i.name}.device" ];
@@ -562,36 +616,32 @@ in
                   echo "setting MTU to ${toString i.mtu}..."
                   ip link set "${i.name}" mtu "${toString i.mtu}"
                 ''
-              + optionalString (i.ipAddress != null)
+
+              # Ip Setup
+              +
                 ''
-                  cur=$(ip -4 -o a show dev "${i.name}" | awk '{print $4}')
-                  # Only do a flush/add if it's necessary.  This is
+                  curIps=$(ip -o a show dev "${i.name}" | awk '{print $4}')
+                  # Only do an add if it's necessary.  This is
                   # useful when the Nix store is accessed via this
                   # interface (e.g. in a QEMU VM test).
-                  if [ "$cur" != "${i.ipAddress}/${mask}" ]; then
-                    echo "configuring interface..."
-                    ip -4 addr flush dev "${i.name}"
-                    ip -4 addr add "${i.ipAddress}/${mask}" dev "${i.name}"
-                    restart_network_setup=true
-                  else
-                    echo "skipping configuring interface"
+                ''
+              + flip concatMapStrings (ips) (ip:
+                let
+                  address = "${ip.address}/${toString ip.prefixLength}";
+                in
+                ''
+                  echo "checking ip ${address}..."
+                  if ! echo "$curIps" | grep "${address}" >/dev/null 2>&1; then
+                    if out=$(ip addr add "${address}" dev "${i.name}" 2>&1); then
+                      echo "added ip ${address}..."
+                      restart_network_setup=true
+                    elif ! echo "$out" | grep "File exists" >/dev/null 2>&1; then
+                      echo "failed to add ${address}"
+                      exit 1
+                    fi
                   fi
-                ''
-              + optionalString (staticIPv6)
-                ''
-                  # Only do a flush/add if it's necessary.  This is
-                  # useful when the Nix store is accessed via this
-                  # interface (e.g. in a QEMU VM test).
-                  if ! ip -6 -o a show dev "${i.name}" | grep "${i.ipv6Address}/${toString i.ipv6prefixLength}"; then
-                    echo "configuring interface..."
-                    ip -6 addr flush dev "${i.name}"
-                    ip -6 addr add "${i.ipv6Address}/${toString i.ipv6prefixLength}" dev "${i.name}"
-                    restart_network_setup=true
-                  else
-                    echo "skipping configuring interface"
-                  fi
-                ''
-              + optionalString (i.ipAddress != null || staticIPv6)
+                '')
+              + optionalString (ips != [ ])
                 ''
                   if [ restart_network_setup = true ]; then
                     # Ensure that the default gateway remains set.
@@ -608,7 +658,20 @@ in
                 ''
                   echo 1 > /proc/sys/net/ipv6/conf/${i.name}/proxy_ndp
                 '';
-          });
+            preStop =
+              ''
+                echo "releasing configured ip's..."
+              ''
+              + flip concatMapStrings (ips) (ip:
+                let
+                  address = "${ip.address}/${toString ip.prefixLength}";
+                in
+                ''
+                  echo -n "Deleting ${address}..."
+                  ip addr del "${address}" dev "${i.name}" >/dev/null 2>&1 || echo -n " Failed"
+                  echo ""
+                '');
+          };
 
         createTunDevice = i: nameValuePair "${i.name}"
           { description = "Virtual Network Interface ${i.name}";

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -16,7 +16,7 @@ let
   miniupnpdConf = nodes: pkgs.writeText "miniupnpd.conf"
     ''
       ext_ifname=eth1
-      listening_ip=${nodes.router.config.networking.interfaces.eth2.ipAddress}/24
+      listening_ip=${(head nodes.router.config.networking.interfaces.eth2.ip4).address}/24
       allow 1024-65535 192.168.2.0/24 1024-65535
     '';
 
@@ -53,7 +53,7 @@ in
         { environment.systemPackages = [ pkgs.transmission ];
           virtualisation.vlans = [ 2 ];
           networking.defaultGateway =
-            nodes.router.config.networking.interfaces.eth2.ipAddress;
+            (head nodes.router.config.networking.interfaces.eth2.ip4).address;
           networking.firewall.enable = false;
         };
 
@@ -81,7 +81,7 @@ in
       # Create the torrent.
       $tracker->succeed("mkdir /tmp/data");
       $tracker->succeed("cp ${file} /tmp/data/test.tar.bz2");
-      $tracker->succeed("transmission-create /tmp/data/test.tar.bz2 -t http://${nodes.tracker.config.networking.interfaces.eth1.ipAddress}:6969/announce -o /tmp/test.torrent");
+      $tracker->succeed("transmission-create /tmp/data/test.tar.bz2 -t http://${(head nodes.tracker.config.networking.interfaces.eth1.ip4).address}:6969/announce -o /tmp/test.torrent");
       $tracker->succeed("chmod 644 /tmp/test.torrent");
 
       # Start the tracker.  !!! use a less crappy tracker

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -13,7 +13,7 @@ import ./make-test.nix {
         { virtualisation.vlans = [ 1 ];
           networking.firewall.allowPing = true;
           networking.defaultGateway =
-            nodes.router.config.networking.interfaces.eth2.ipAddress;
+            (head nodes.router.config.networking.interfaces.eth2.ip4).address;
         };
 
       router =


### PR DESCRIPTION
This patchset reapplies the multi-ip changes with a fix that corrects a bug in translating old syntax to new syntax.
