### PR TITLE
Revert "Enable dmeventd"

### DIFF
--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   configureFlags =
-    "--disable-readline --enable-udev_rules --enable-udev_sync --enable-pkgconfig --enable-applib --enable-dmeventd --enable-cmdlib";
+    "--disable-readline --enable-udev_rules --enable-udev_sync --enable-pkgconfig --enable-applib";
 
   buildInputs = [ pkgconfig udev ];
 


### PR DESCRIPTION
This reverts commit eecfa6d657380ec52d34017da0fde37332a182a8.
It breaks build of extra utils:
https://github.com/NixOS/nixpkgs/issues/3913
