### PR TITLE
RFC: Agda builder

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -1,0 +1,95 @@
+# Builder for Agda packages. Mostly inspired by the cabal builder.
+#
+# Contact: stdenv.lib.maintainers.fuuzetsu
+
+{ stdenv, Agda, glibcLocales
+, writeScriptBin
+, extension ? (self: super: {})
+}:
+
+let
+  optionalString = stdenv.lib.optionalString;
+  filter = stdenv.lib.filter;
+  concatMapStringsSep = stdenv.lib.strings.concatMapStringsSep;
+  concatMapStrings = stdenv.lib.strings.concatMapStrings;
+  unwords = stdenv.lib.strings.concatStringsSep " ";
+  mapInside = xs: unwords (map (x: x + "/*") xs);
+in
+{ mkDerivation = args:
+    let
+      postprocess = x: x // {
+        sourceDirectories = filter (y: !(y == null)) x.sourceDirectories;
+        propagatedBuildInputs = filter (y : ! (y == null)) x.propagatedBuildInputs;
+        propagatedUserEnvPkgs = filter (y : ! (y == null)) x.propagatedUserEnvPkgs;
+        extraBuildFlags = filter (y : ! (y == null)) x.extraBuildFlags;
+        everythingFile = if x.everythingFile == "" then "Everything.agda" else x.everythingFile;
+      };
+
+      defaults = self : {
+        # There is no Hackage for Agda so we require src.
+        inherit (self) src name;
+
+        buildInputs = [ Agda ] ++ self.buildDepends;
+        buildDepends = [];
+        # Not much choice here ;)
+        LANG = "en_US.UTF-8";
+        LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
+
+        everythingFile = "Everything.agda";
+
+        propagatedBuildInputs = self.buildDepends ++ self.buildTools;
+        propagatedUserEnvPkgs = self.buildDepends;
+
+        # Immediate source directories under which modules can be found.
+        sourceDirectories = [ ];
+
+        # This is used if we have a top-level element that only serves
+        # as the container for the source and we only care about its
+        # contents. The directories put here will have their
+        # *contents* copied over as opposed to sourceDirectories which
+        # would make a direct copy of the whole thing.
+        topSourceDirectories = [ "src" ];
+
+        buildTools = [];
+
+        # Extra stuff to pass to the Agda binary.
+        extraBuildFlags = [ "-i ." ];
+        buildFlags = let r = map (x: "-i " + x + "/share/agda") self.buildDepends;
+                         d = map (x : "-i " + x) (self.sourceDirectories ++ self.topSourceDirectories);
+                     in unwords (r ++ d ++ self.extraBuildFlags);
+
+        # We expose this as a mere convenience for any tools.
+        AGDA_PACKAGE_PATH = concatMapStrings (x: x + ":") self.buildDepends;
+
+        # Makes a wrapper available to the user. Very useful in
+        # nix-shell where all dependencies are -i'd.
+        agdaWrapper = writeScriptBin "agda" ''
+          ${Agda}/bin/agda ${self.buildFlags} "$@"
+        '';
+
+        # configurePhase is idempotent
+        configurePhase = ''
+          eval "$preConfigure"
+          export AGDA_PACKAGE_PATH=${self.AGDA_PACKAGE_PATH};
+          export PATH="${self.agdaWrapper}/bin:$PATH"
+          eval "$postConfigure"
+        '';
+
+        buildPhase = ''
+          eval "$preBuild"
+          ${Agda}/bin/agda ${self.buildFlags} ${self.everythingFile}
+          eval "$postBuild"
+        '';
+
+        installPhase = ''
+          eval "$preInstall"
+          mkdir -p $out/share/agda
+          cp -pR ${unwords self.sourceDirectories} ${mapInside self.topSourceDirectories} $out/share/agda
+          eval "$postInstall"
+        '';
+      };
+    in stdenv.mkDerivation
+         (postprocess (let super = defaults self // args self;
+                           self  = super // extension self super;
+                       in self));
+}

--- a/pkgs/development/compilers/agda/stdlib.nix
+++ b/pkgs/development/compilers/agda/stdlib.nix
@@ -1,7 +1,10 @@
-{ cabal, fetchurl, filemanip, Agda }:
+{ stdenv, agda, fetchurl, ghcWithPackages }:
 
-cabal.mkDerivation (self: rec {
-  pname = "Agda-stdlib";
+let
+  ghc = ghcWithPackages (s: [ s.filemanip ]);
+in
+agda.mkDerivation (self: rec {
+  name = "Agda-stdlib";
   version = "0.8.1";
 
   src = fetchurl {
@@ -9,23 +12,16 @@ cabal.mkDerivation (self: rec {
     sha256 = "0ij4rg4lk0pq01ing285gbmnn23dcf2rhihdcs8bbdpjg52vl4gf";
   };
 
-  buildDepends = [ filemanip Agda ];
-
-  preConfigure = "cd ffi";
-
-  postInstall = ''
-      mkdir -p $out/share
-      cd ..
-      ${self.ghc.ghc}/bin/runhaskell GenerateEverything
-      ${Agda}/bin/agda -i . -i src Everything.agda
-      cp -pR src $out/share/agda
+  preConfigure = ''
+    ${ghc}/bin/runhaskell GenerateEverything.hs
   '';
+
+  topSourceDirectories = [ "src" ];
 
   meta = {
     homepage = "http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Libraries.StandardLibrary";
     description = "A standard library for use with the Agda compiler.";
     license = "unknown";
-    platforms = self.ghc.meta.platforms;
-    maintainers = [ self.stdenv.lib.maintainers.jwiegley ];
+    maintainers = with stdenv.lib.maintaianers; [ jwiegley ];
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6535,6 +6535,10 @@ let
     inherit writeScriptBin;
   };
 
+  AgdaStdlib = callPackage ../development/compilers/agda/stdlib.nix {
+    ghcWithPackages = haskellPackages.ghcWithPackages;
+  };
+
   ### DEVELOPMENT / LIBRARIES / JAVA
 
   atermjava = callPackage ../development/libraries/java/aterm {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6526,6 +6526,14 @@ let
 
   zziplib = callPackage ../development/libraries/zziplib { };
 
+  ### DEVELOPMENT / LIBRARIES / AGDA
+
+  agda = callPackage ../build-support/agda {
+    glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
+    extension = self : super : {};
+    Agda = haskellPackages.Agda;
+    inherit writeScriptBin;
+  };
 
   ### DEVELOPMENT / LIBRARIES / JAVA
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -2888,7 +2888,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   # Compilers.
 
   Agda = callPackage ../development/compilers/agda {};
-  AgdaStdlib = callPackage ../development/compilers/agda/stdlib.nix {};
 
   uhc = callPackage ../development/compilers/uhc {};
 


### PR DESCRIPTION
Below is a builder for Agda libraries. Unlike Haskell, there is no cabal or anything of the sort to tell us about the package. The common practice is for authors to expose a file to compile, commonly `Everything.agda`.

Simply, it does the following
- Prepare `-i` flags to call agda with
- Create a wrapped binary in front of PATH and make AGDA_PACKAGE_PATH. This is mostly for benefit of tooling: in `nix-shell` we now have to only call `agda` and all our dependencies are accounted for. `buildTools` don't get accounted for here.
- Compile the files under specified directories and copy them under `$out/share/agda`. There is no canonical place to put it but if all packages put it there then we can always find the files that way. An alternative way would be to put a script at the top level at build time which can tell us where in the tree to find the files but benefit of this is dubious and I feel user-experience would suffer.

As proof of concept I converted the existing stdlib expression to use the new builder. I also packaged the `categories` library using it. It's not included because it the library happens to not compile with the recent update to Agda 2.4.2 but otherwise there is nothing wrong with it, I tested with previous version. You can see the expression [here](https://github.com/Fuuzetsu/nixpkgs/commit/0ab9900d6fa1a6590edb4e5325d106d13f75eb2d). As you can see it's nice and short.

This is a step up from how `stdlib` was packaged: abuse the cabal file inside of it and do everything manually in `postInstall`.

I think this could be made more resillent but I think most of all it just needs a bit of testing by others. cc @johnw who's listed under Agda things.
