### PR TITLE
openldap: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -18,9 +18,10 @@ stdenv.mkDerivation rec {
 
   dontPatchELF = 1; # !!!
 
-  meta = {
-    homepage = "http://www.openldap.org/";
+  meta = with stdenv.lib; {
+    homepage    = http://www.openldap.org/;
     description = "An open source implementation of the Lightweight Directory Access Protocol";
-    maintainers = stdenv.lib.maintainers.mornfall;
+    maintainers = with maintainers; [ lovek323 mornfall ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5899,7 +5899,11 @@ let
 
   openexr = callPackage ../development/libraries/openexr { };
 
-  openldap = callPackage ../development/libraries/openldap { };
+  openldap = callPackage ../development/libraries/openldap {
+    stdenv = if stdenv.isDarwin
+      then clangStdenv
+      else stdenv;
+  };
 
   openlierox = callPackage ../games/openlierox { };
 


### PR DESCRIPTION
I have changed `openldap` so that it uses `clangStdenv` when building on darwin – this fixes issues I'm having on OS X 10.10, but I haven't been able to test it on OS X 10.9.

If merged, this shouldn't break anything, but it would be awesome if someone could test on 10.9. Otherwise, I will try to get a 10.9 machine up and running and test on that. There are plenty of other packages that seem to need the same fix, so I am hesitant to push forward without this.
