### PR TITLE
clamav: update to version 0.98.4 and run freshclam in daemon mode

### DIFF
--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -71,7 +71,7 @@ in
             mkdir -m 0755 -p ${stateDir}
             chown ${clamavUser}:${clamavGroup} ${stateDir}
           '';
-          exec = "${pkgs.clamav}/bin/freshclam --config-file=${pkgs.writeText "freshclam.conf" cfg.updater.config}";
+          exec = "${pkgs.clamav}/bin/freshclam --daemon --config-file=${pkgs.writeText "freshclam.conf" cfg.updater.config}";
       }; 
     };
 

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,19 +1,23 @@
-{ stdenv, fetchurl, zlib, bzip2, libiconv }:
+{ stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl }:
 stdenv.mkDerivation rec {
   name = "clamav-${version}";
-  version = "0.98.1";
+  version = "0.98.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/clamav/clamav-${version}.tar.gz";
-    sha256 = "1p13n8g3b88cxwxj07if9z1d2cav1ib94v6cq4r4bpacfd6yix9m";
+    sha256 = "071yzamalj3rf7kl2jvc35ipnk1imdkq5ylbb8whyxfgmd3nf06k";
   };
 
-  buildInputs = [ zlib bzip2 libiconv ];
+  buildInputs = [ zlib bzip2 libiconv libxml2 openssl ncurses curl ];
 
   configureFlags = [
     "--with-zlib=${zlib}"
     "--with-libbz2-prefix=${bzip2}"
     "--with-iconv-dir=${libiconv}"
+    "--with-xml=${libxml2}"
+    "--with-openssl=${openssl}"
+    "--with-libncurses-prefix=${ncurses}"
+    "--with-libcurl=${curl}"
     "--disable-clamav" ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
- update from very outdated version 0.98.1 to version 0.98.4
- enable clamdtop binary
- run freshclam in daemon mode because running in foreground leads to a freshclam which is restarted over and over because freshclam quits after updating the signatures
