### PR TITLE
sysdig: cheat nix into not capturing linux-dev as a runtime dependency

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -10,7 +10,7 @@ let
   };
   buildInputs = [
     cmake zlib luajit
-  ] ++ optional (kernel != null) kernel;
+  ];
 in
 stdenv.mkDerivation {
   inherit (s) name version;
@@ -30,6 +30,10 @@ stdenv.mkDerivation {
   '';
   postInstall = optionalString (kernel != null) ''
     make install_driver
+    kernel_dev=${kernel.dev}
+    kernel_dev=''${kernel_dev#/nix/store/}
+    kernel_dev=''${kernel_dev%%-linux*dev*}
+    sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This shaves off ~40-60 megabytes of your next `nix-copy-closure`.
