### PR TITLE
nixos/nat: add forwardPorts for external->internal DNAT

### DIFF
--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -75,6 +75,17 @@ in
         '';
     };
 
+    networking.nat.forwardPorts = mkOption {
+      type = types.listOf types.attrs;
+      default = [];
+      example = [ { sourcePort = 8080; destination = "10.0.0.1:80"; } ];
+      description =
+        ''
+          List of forwarded ports from the external interface to
+          internal destinations by using DNAT.
+        '';
+    };
+
   };
 
 
@@ -117,6 +128,14 @@ in
               iptables -w -t nat -A POSTROUTING \
                 -s '${range}' -o ${cfg.externalInterface} ${dest}
             '') cfg.internalIPs}
+
+            # NAT from external ports to internal ports.
+            ${concatMapStrings (fwd: ''
+              iptables -w -t nat -A PREROUTING \
+                -i ${cfg.externalInterface} -p tcp \
+                --dport ${builtins.toString fwd.sourcePort} \
+                -j DNAT --to-destination ${fwd.destination}
+            '') cfg.forwardPorts}
 
             echo 1 > /proc/sys/net/ipv4/ip_forward
           '';


### PR DESCRIPTION
Especially useful when you want to access services in containers from the outside directly without any proxy in the middle.
