### PR TITLE
dolphinEmu doesn't need the git package

### DIFF
--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, mesa, gtk2, glib
-, gettext, git, libpthreadstubs, libXrandr, libXext, readline
+, gettext, libpthreadstubs, libXrandr, libXext, readline
 , openal, libXdmcp, portaudio, SDL, wxGTK30, fetchurl
 , pulseaudio ? null }:
 


### PR DESCRIPTION
Just noticed this, sorry
