### PR TITLE
Python wrappers for mpi and hdf5 (with mpi support for hdf5)

### DIFF
--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -34,9 +34,8 @@ buildPythonPackage rec {
     ;
 
   meta = {
-    description = "
-      The h5py package is a Pythonic interface to the HDF5 binary data format.
-    ";
+    description =
+      "Provides a Pythonic interface to the HDF5 binary data format";
     homepage = "http://www.h5py.org/";
     license = stdenv.lib.licenses.bsd2;
   };

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, python, buildPythonPackage
+, numpy, hdf5, cython
+, mpiSupport ? false, mpi4py ? null, mpi ? null }:
+
+assert mpiSupport == hdf5.mpiSupport;
+assert mpiSupport -> mpi != null
+  && mpi4py != null
+  && mpi == mpi4py.mpi
+  && mpi == hdf5.mpi
+  ;
+
+with stdenv.lib;
+
+buildPythonPackage rec {
+  name = "h5py-2.3.1";
+
+  src = fetchurl {
+    url = "https://pypi.python.org/packages/source/h/h5py/${name}.tar.gz";
+    md5 = "8f32f96d653e904d20f9f910c6d9dd91";
+  };
+
+  setupPyBuildFlags = [ "--hdf5=${hdf5}" ]
+    ++ optional mpiSupport "--mpi"
+    ;
+  setupPyInstallFlags = setupPyBuildFlags;
+
+  preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
+
+  buildInputs = [ hdf5 cython ]
+    ++ optional mpiSupport mpi
+    ;
+  propagatedBuildInputs = [ numpy ]
+    ++ optional mpiSupport mpi4py
+    ;
+
+  meta = {
+    description = "
+      The h5py package is a Pythonic interface to the HDF5 binary data format.
+    ";
+    homepage = "http://www.h5py.org/";
+    license = stdenv.lib.licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = {
     description =
-      "Provides a Pythonic interface to the HDF5 binary data format";
+      "Pythonic interface to the HDF5 binary data format";
     homepage = "http://www.h5py.org/";
     license = stdenv.lib.licenses.bsd2;
   };

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -46,9 +46,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ openssh ];
 
   meta = {
-    description = "
-      Provides Python bindings for the Message Passing Interface standard.
-    ";
+    description =
+      "Provides Python bindings for the Message Passing Interface standard";
     homepage = "http://code.google.com/p/mpi4py/";
     license = stdenv.lib.licenses.bsd3;
   };

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, python, buildPythonPackage, mpi, openssh }:
+
+buildPythonPackage rec {
+  name = "mpi4py-1.3.1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/mpi4py/mpi4py/downloads/${name}.tar.gz";
+    sha256 = "e7bd2044aaac5a6ea87a87b2ecc73b310bb6efe5026031e33067ea3c2efc3507";
+  };
+
+  passthru = {
+    inherit mpi;
+  };
+
+  # The tests in the `test_spawn` module fail in the chroot build environment.
+  # However, they do pass in a pure, or non-pure nix-shell. Hence, we
+  # deactivate these particular tests.
+  # Unfortunately, the command-line arguments to `./setup.py test` are not
+  # correctly passed to the test-runner. Hence, these arguments are patched
+  # directly into `setup.py`.
+  patchPhase = ''
+    sed 's/err = main(cmd.args or \[\])/err = main(cmd.args or ["-v", "-e", "test_spawn"])/' -i setup.py
+  '';
+
+  configurePhase = "";
+
+  installPhase = ''
+    mkdir -p "$out/lib/${python.libPrefix}/site-packages"
+    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+
+    ${python}/bin/${python.executable} setup.py install \
+      --install-lib=$out/lib/${python.libPrefix}/site-packages \
+      --prefix="$out"
+
+    # --install-lib:
+    # sometimes packages specify where files should be installed outside the usual
+    # python lib prefix, we override that back so all infrastructure (setup hooks)
+    # work as expected
+  '';
+
+  setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
+
+  buildInputs = [ mpi ];
+  # Requires openssh for tests. Tests of dependent packages will also fail,
+  # if openssh is not present. E.g. h5py with mpi support.
+  propagatedBuildInputs = [ openssh ];
+
+  meta = {
+    description = "
+      Provides Python bindings for the Message Passing Interface standard.
+    ";
+    homepage = "http://code.google.com/p/mpi4py/";
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   meta = {
     description =
-      "Provides Python bindings for the Message Passing Interface standard";
+      "Python bindings for the Message Passing Interface standard";
     homepage = "http://code.google.com/p/mpi4py/";
     license = stdenv.lib.licenses.bsd3;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -106,6 +106,12 @@ rec {
     pylabQtSupport = false;
   });
 
+  mpi4py = callPackage ../development/python-modules/mpi4py {
+    inherit (pkgs) stdenv fetchurl openssh;
+    inherit python buildPythonPackage;
+    mpi = pkgs.openmpi;
+  };
+
   nixpart = callPackage ../tools/filesystems/nixpart { };
 
   # This is used for NixOps to make sure we won't break it with the next major

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -90,6 +90,19 @@ rec {
     '';
   };
 
+  h5py = callPackage ../development/python-modules/h5py {
+    inherit (pkgs) stdenv fetchurl;
+    inherit python buildPythonPackage cython numpy;
+    hdf5 = pkgs.hdf5.override { mpi = null; };
+  };
+
+  h5py-mpi = h5py.override {
+    mpiSupport = true;
+    mpi = pkgs.openmpi;
+    hdf5 = pkgs.hdf5.override { mpi = pkgs.openmpi; enableShared = true; };
+    inherit mpi4py;
+  };
+
   ipython = import ../shells/ipython {
     inherit (pkgs) stdenv fetchurl sip pyqt4;
     inherit buildPythonPackage pythonPackages;


### PR DESCRIPTION
This is the continuation of pull-request #3316.
