### PR TITLE
keepassx: update to 2.0-alpha6

### DIFF
--- a/pkgs/applications/misc/keepassx/2.0.nix
+++ b/pkgs/applications/misc/keepassx/2.0.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, cmake, libgcrypt, qt4, xlibs, ... }:
 
 stdenv.mkDerivation {
-  name = "keepassx2-2.0alpha5";
+  name = "keepassx2-2.0alpha6";
   src = fetchurl {
-    url = "https://github.com/keepassx/keepassx/archive/2.0-alpha5.tar.gz";
-    sha256 = "1vxj306zhrr38mvsy3vpjlg6d0xwlcvsi3l69nhhwzkccsc4smfm";
+    url = "https://github.com/keepassx/keepassx/archive/2.0-alpha6.tar.gz";
+    sha256 = "592f9995b13c4f84724fb24a0078162246397eedccd467daaf0fd3608151f2b0";
   };
 
   buildInputs = [ cmake libgcrypt qt4 xlibs.libXtst ];


### PR DESCRIPTION
https://github.com/keepassx/keepassx/archive/2.0-alpha6.tar.gz
