### PR TITLE
Fixed buildLocalCabal by defining temporary $HOME

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -3037,6 +3037,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
       name = "${name}.nix";
 
       buildCommand = ''
+      export HOME="$TMPDIR"
       ${self.cabal2nix}/bin/cabal2nix ${src + "/${name}.cabal"} --sha256=FILTERME \
           | grep -v FILTERME | sed \
             -e 's/licenses.proprietary/licenses.unfree/' \


### PR DESCRIPTION
This fixes build error:

building path(s) ‘/nix/store/c8i7gm134aij9330h77l4sdna635yj0a-foo.nix’
building /nix/store/c8i7gm134aij9330h77l4sdna635yj0a-foo.nix
cabal2nix: /homeless-shelter/.cache: createDirectory: does not exist (No such file or directory)
error: syntax error, unexpected $end, at /nix/store/c8i7gm134aij9330h77l4sdna635yj0a-foo.nix:1:1
(use ‘--show-trace’ to show detailed location information)…
