### PR TITLE
nixos/install-grub: Read correct mountpoints

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -277,7 +277,11 @@ in
         '') config.boot.loader.grub.extraFiles);
 
     assertions = [{ assertion = !cfg.zfsSupport || cfg.version == 2;
-                    message = "Only grub version 2 provides zfs support";}];
+                    message = "Only grub version 2 provides zfs support";}]
+      ++ flip map cfg.devices (dev: {
+        assertion = hasPrefix "/" dev;
+        message = "Grub devices must be absolute paths, not ${dev}";
+      });
 
     })
 

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -260,7 +260,7 @@ in
         if cfg.devices == [] then
           throw "You must set the option ‘boot.loader.grub.device’ to make the system bootable."
         else
-          "PERL5LIB=${makePerlPath [ pkgs.perlPackages.XMLLibXML pkgs.perlPackages.XMLSAX ]} " +
+          "PERL5LIB=${makePerlPath (with pkgs.perlPackages; [ FileSlurp XMLLibXML XMLSAX ])} " +
           "${pkgs.perl}/bin/perl ${./install-grub.pl} ${grubConfig}";
 
       system.build.grub = grub;

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -213,8 +213,8 @@ let
 
       # Test nixos-option.
       $machine->succeed("nixos-option boot.initrd.kernelModules | grep virtio_console");
-      $machine->succeed("nixos-option -d boot.initrd.kernelModules | grep 'List of modules'");
-      $machine->succeed("nixos-option -l boot.initrd.kernelModules | grep qemu-guest.nix");
+      $machine->succeed("nixos-option boot.initrd.kernelModules | grep 'List of modules'");
+      $machine->succeed("nixos-option  boot.initrd.kernelModules | grep qemu-guest.nix");
 
       $machine->shutdown;
 


### PR DESCRIPTION
Currently, install-grub uses `df -T` to determine which mount point refers to the given file. The problem is that df reads from /proc/mounts, which includes mount points from outside the nixos-install chroot. Therefore, the install-grub procedure will fail during a nixos-install on the livecd since it will incorrectly determine that /nix/store is mounted on a unionfs.

To remedy this behavior, we check /proc/self/mountinfo which is a sanitized listing for the current environment.
