### PR TITLE
steamChrootEnv: add conditional pulseaudio support

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,10 +1,12 @@
 { buildFHSChrootEnv, steam
 , xterm, libX11, zenity, python, mesa, xdg_utils, dbus_tools, alsaLib
+, pulseaudio ? null
 }:
 
 buildFHSChrootEnv {
   name = "steam";
-  pkgs = [ steam xterm libX11 zenity python mesa xdg_utils dbus_tools alsaLib ];
+  pkgs = [ steam xterm libX11 zenity python mesa xdg_utils dbus_tools alsaLib
+           pulseaudio ];
   profile = ''
     export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib
     export FONTCONFIG_FILE=/etc/fonts/fonts.conf


### PR DESCRIPTION
Adds conditional pulseaudio support into the chrootenv for steam, so that games/apps in the chroot can play audio via pulseaudio.
