### PR TITLE
added libfreefare

### DIFF
--- a/pkgs/development/libraries/libfreefare/default.nix
+++ b/pkgs/development/libraries/libfreefare/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, libnfc, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "libfreefare-${version}";
+  version = "0.4.0";
+
+  src = fetchurl {
+    url = "https://libfreefare.googlecode.com/files/libfreefare-0.4.0.tar.bz2";
+    sha256 = "0r5wfvwgf35lb1v65wavnwz2wlfyfdims6a9xpslf4lsm4a1v8xz";
+  };
+
+  buildInputs = [ pkgconfig libnfc openssl ];
+
+  meta = with stdenv.lib; {
+    description = "The libfreefare project aims to provide a convenient API for MIFARE card manipulations";
+    license = licenses.gpl3;
+    homepage = http://code.google.com/p/libfreefare/;
+    maintainers = with maintainers; [offline];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5339,6 +5339,8 @@ let
 
   libffi = callPackage ../development/libraries/libffi { };
 
+  libfreefare = callPackage ../development/libraries/libfreefare { };
+
   libftdi = callPackage ../development/libraries/libftdi { };
 
   libftdi1 = callPackage ../development/libraries/libftdi/1.x.nix { };


### PR DESCRIPTION
This is a library that adds MIFARE support for libnfc. libnfc was already in nixpkgs and I've based the .nix on that.

This is my first nix package, so if there are problems, please let me know.
