### PR TITLE
bittorrent: Remove reference to deleted package.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -690,10 +690,6 @@ let
     inherit (strategoPackages016) strategoxt sdf;
   };
 
-  bittorrent = callPackage ../tools/networking/p2p/bittorrent {
-    gui = true;
-  };
-
   bittornado = callPackage ../tools/networking/p2p/bit-tornado { };
 
   blueman = callPackage ../tools/bluetooth/blueman {


### PR DESCRIPTION
nixpkgs/pkgs/tools/networking/p2p/bittorrent no longer exists, so there shouldn't be a reference to it from all-packages.nix, makes nix-env (etc.) sad.

See b420eeba44c8428bf90f4655d94cc336c49ffec4
