### PR TITLE
unrar: Fixed license typo

### DIFF
--- a/pkgs/tools/archivers/unrar/default.nix
+++ b/pkgs/tools/archivers/unrar/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Utility for RAR archives";
     homepage = http://www.rarlab.com/;
-    license = licenses.unfree-redistributable;
+    license = licenses.unfreeRedistributable;
     maintainers = [ maintainers.emery ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
Typo stopping nix-env from doing it's magic.
