### PR TITLE
nixos-manual: Fix reference to obsolete configuration option

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -67,7 +67,7 @@ with other kernel modules.</para>
 <para>On 64-bit systems, if you want full acceleration for 32-bit
 programs such as Wine, you should also set the following:
 <programlisting>
-services.xserver.driSupport32Bit = true;
+hardware.opengl.driSupport32Bit = true;
 </programlisting>
 </para>
 


### PR DESCRIPTION
"services.xserver.driSupport32Bit" was made obsolete and replaced with "hardware.opengl.driSupport32Bit" a while back, updating the nvidia section of the manual as such.
