### PR TITLE
nixos/test-reports: use local copy of jquery

### DIFF
--- a/nixos/lib/test-driver/log2html.xsl
+++ b/nixos/lib/test-driver/log2html.xsl
@@ -9,8 +9,8 @@
   <xsl:template match="logfile">
     <html>
       <head>
-        <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-        <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+        <script type="text/javascript" src="jquery.min.js"></script>
+        <script type="text/javascript" src="jquery-ui.min.js"></script>
         <script type="text/javascript" src="treebits.js" />
         <link rel="stylesheet" href="logfile.css" type="text/css" />
         <title>Log File</title>

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -53,6 +53,8 @@ rec {
           xsltproc --output $out/log.html ${./test-driver/log2html.xsl} $out/log.xml
           ln -s ${./test-driver/logfile.css} $out/logfile.css
           ln -s ${./test-driver/treebits.js} $out/treebits.js
+          ln -s ${jquery}/js/jquery.min.js $out/
+          ln -s ${jquery-ui}/js/jquery-ui.min.js $out/
 
           touch $out/nix-support/hydra-build-products
           echo "report testlog $out log.html" >> $out/nix-support/hydra-build-products


### PR DESCRIPTION
The current way test reports get jquery,

  src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"

only works when getting reports over http:// or https://, not file://.
Change it so that it works for all protocols by using a local copy of
jquery.

This fixes the issue where locally created and browsed test reports
cannot be navigated properly; clicking the '+' symbol to expand
sub-sections doesn't work.

CC: @edolstra 
