### PR TITLE
mpi4py: Disable for Python3 and PyPy

### DIFF
--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, buildPythonPackage, mpi, openssh }:
+{ stdenv, fetchurl, python, buildPythonPackage, mpi, openssh, isPy3k, isPyPy }:
 
 buildPythonPackage rec {
   name = "mpi4py-1.3.1";
@@ -44,6 +44,8 @@ buildPythonPackage rec {
   # Requires openssh for tests. Tests of dependent packages will also fail,
   # if openssh is not present. E.g. h5py with mpi support.
   propagatedBuildInputs = [ openssh ];
+
+  disabled = isPy3k || isPyPy;
 
   meta = {
     description =


### PR DESCRIPTION
Builds for Python3 and PyPy are failing at the moment [1](https://github.com/NixOS/nixpkgs/pull/3938#issuecomment-54750065),[2](http://hydra.nixos.org/build/13993137/nixlog/1/raw),[3](http://hydra.nixos.org/build/13873028/log/raw). Therefore, they
are disabled.
