### PR TITLE
build-fhs-chrootenv: bind mount chroots /tmp to hosts /tmp

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/destroy.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/destroy.sh.in
@@ -3,7 +3,7 @@
 chrootenvDest=/run/chrootenv/@name@
 
 # Remove bind mount points
-rmdir $chrootenvDest/{dev,nix/store,nix,proc,sys,host-etc,home,var,run}
+rmdir $chrootenvDest/{dev,nix/store,nix,proc,sys,host-etc,home,var,run,tmp}
 
 # Remove symlinks to the software that should be part of the chroot system profile
 for i in @chrootEnv@/sw/*
@@ -15,7 +15,8 @@ do
 done
 
 # Remove the remaining folders
-rm -Rf $chrootenvDest/{etc,root,tmp}
+rm -Rf $chrootenvDest/{etc,root}
+rm -Rf /tmp/chrootenv-@name@
 
 # Remove the chroot environment folder
 rmdir $chrootenvDest

--- a/pkgs/build-support/build-fhs-chrootenv/init.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/init.sh.in
@@ -45,4 +45,5 @@ ln -s ../../../host-etc/static/fonts/conf.d/00-nixos.conf $chrootenvDest/etc/fon
 mkdir $chrootenvDest/root
 
 # Create tmp folder
-mkdir -m1777 $chrootenvDest/tmp
+mkdir -m1777    $chrootenvDest/tmp
+mkdir -m1777 -p /tmp/chrootenv-@name@

--- a/pkgs/build-support/build-fhs-chrootenv/mount.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/mount.sh.in
@@ -21,3 +21,6 @@ mount --rbind /run $chrootenvDest/run
 
 # Bind mount the host system's /etc
 mount --bind /etc $chrootenvDest/host-etc
+
+# Bind mount /tmp
+mount --bind /tmp/chrootenv-@name@ /run/chrootenv/steam/tmp

--- a/pkgs/build-support/build-fhs-chrootenv/umount.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/umount.sh.in
@@ -3,4 +3,4 @@
 chrootenvDest=/run/chrootenv/@name@
 
 # Unmount all (r)bind mounts
-umount -l $chrootenvDest/{dev/pts,dev/shm,dev,nix/store,proc,sys,host-etc,home,var,run}
+umount -l $chrootenvDest/{dev/pts,dev/shm,dev,nix/store,proc,sys,host-etc,home,var,tmp,run}


### PR DESCRIPTION
@svanderburg here is the /tmp related, rebased & checked change to build-fhs-chrootenv as mentioned in #2355

The patch handles how /tmp is handled in build-fhs-chrootenv. Till now it just created a tmp subdirectory within /run. /run lies in memory therefore the chroots /tmp will reside there as well, this triggers two problems 1) the hosts memory is limited and this will also limit the /tmp size of the chroot (this is very bad for example graphical applications) 2) you ram will get polluted leaving you with less bang for your apps.
With the patch applied it will create a directory within the hosts /tmp and will then mount the chroot's /tmp to this newly created directory. So the chroot's /tmp will use the same capabilities and optimizations as the host's does.
