### PR TITLE
kde4: added the security patch for CVE-2014-5033 to nixpkgs because it is not available upstream

### DIFF
--- a/pkgs/desktops/kde-4.12/files/kdelibs-cve-2014-5033.patch
+++ b/pkgs/desktops/kde-4.12/files/kdelibs-cve-2014-5033.patch
@@ -1,0 +1,36 @@
+--- a/kdecore/auth/backends/polkit-1/Polkit1Backend.cpp
++++ b/kdecore/auth/backends/polkit-1/Polkit1Backend.cpp
+@@ -144,7 +144,7 @@
+ 
+ Action::AuthStatus Polkit1Backend::actionStatus(const QString &action)
+ {
+-    PolkitQt1::UnixProcessSubject subject(QCoreApplication::applicationPid());
++    PolkitQt1::SystemBusNameSubject subject(QString::fromUtf8(callerID()));
+     PolkitQt1::Authority::Result r = PolkitQt1::Authority::instance()->checkAuthorizationSync(action, subject,
+                                                                                               PolkitQt1::Authority::None);
+     switch (r) {
+@@ -160,21 +160,12 @@
+ 
+ QByteArray Polkit1Backend::callerID() const
+ {
+-    QByteArray a;
+-    QDataStream s(&a, QIODevice::WriteOnly);
+-    s << QCoreApplication::applicationPid();
+-
+-    return a;
++    return QDBusConnection::systemBus().baseService().toUtf8();
+ }
+ 
+ bool Polkit1Backend::isCallerAuthorized(const QString &action, QByteArray callerID)
+ {
+-    QDataStream s(&callerID, QIODevice::ReadOnly);
+-    qint64 pid;
+-
+-    s >> pid;
+-
+-    PolkitQt1::UnixProcessSubject subject(pid);
++    PolkitQt1::SystemBusNameSubject subject(QString::fromUtf8(callerID));
+     PolkitQt1::Authority *authority = PolkitQt1::Authority::instance();
+ 
+     PolkitResultEventLoop e;
+

--- a/pkgs/desktops/kde-4.12/kdelibs/kdelibs.nix
+++ b/pkgs/desktops/kde-4.12/kdelibs/kdelibs.nix
@@ -4,7 +4,7 @@
 , automoc4, soprano, qca2, attica, enchant, libdbusmenu_qt, grantlee
 , docbook_xml_dtd_42, docbook_xsl, polkit_qt_1, acl, attr, libXtst
 , udev, herqq, phonon, libjpeg, xz, ilmbase, libxslt
-, pkgconfig, fetchpatch
+, pkgconfig
 }:
 
 kde {
@@ -30,12 +30,7 @@ kde {
 
   patches = [
     ../files/polkit-install.patch
-    (fetchpatch {
-      name = "CVE-2014-5033.patch";
-      url = "http://quickgit.kde.org/?p=kdelibs.git"
-        + "&a=commit&h=e4e7b53b71e2659adaf52691d4accc3594203b23";
-      sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
-    })
+    ../files/kdelibs-cve-2014-5033.patch  # Security patch, remove when updating to 4.14.0 or more
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
The patch is not available any more at http://quickgit.kde.org/?p=kdelibs.git&a=commit&h=e4e7b53b71e2659adaf52691d4accc3594203b23, so I got it from archlinux and added it to nixpkgs.
