### PR TITLE
added darwin as supported platform for meld

### DIFF
--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation {
     description = "Visual diff and merge tool";
     homepage = http://meld.sourceforge.net;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/desktops/gnome-2/desktop/scrollkeeper/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/scrollkeeper/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, perl, perlXMLParser, libxml2, libxslt, docbook_xml_dtd_42, automake}:
+{stdenv, fetchurl, pkgconfig, perl, perlXMLParser, libxml2, libxslt, docbook_xml_dtd_42, automake, gettext}:
 
 stdenv.mkDerivation {
   name = "scrollkeeper-0.3.14";
@@ -13,6 +13,6 @@ stdenv.mkDerivation {
     cp ${automake}/share/automake*/config.{sub,guess} .
   ";
 
-  buildInputs = [pkgconfig perl perlXMLParser libxml2 libxslt];
+  buildInputs = [pkgconfig perl perlXMLParser libxml2 libxslt gettext];
   configureFlags = "--with-xml-catalog=${docbook_xml_dtd_42}/xml/dtd/docbook/docbook.cat";
 }


### PR DESCRIPTION
in order to build meld on darwin scroolkeeper needs gettext, I tried build on my local machine. 
