### PR TITLE
add a nix expression for the (haskell) 'managed' package

### DIFF
--- a/pkgs/development/libraries/haskell/managed/default.nix
+++ b/pkgs/development/libraries/haskell/managed/default.nix
@@ -1,0 +1,13 @@
+{ cabal, transformers }:
+
+cabal.mkDerivation (self: {
+  pname = "managed";
+  version = "1.0.0";
+  sha256 = "06nb71pd68m5l6a48sz5kkrdif74phbg3y6bn9ydd00y515b9gn5";
+  buildDepends = [ transformers ];
+  meta = {
+    description = "A monad for managed values";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1548,6 +1548,8 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   machines = callPackage ../development/libraries/haskell/machines {};
 
+  managed = callPackage ../development/libraries/haskell/managed {};
+
   markdown = callPackage ../development/libraries/haskell/markdown {};
 
   markdownUnlit = callPackage ../development/libraries/haskell/markdown-unlit {};


### PR DESCRIPTION
A small PR for the [managed](http://hackage.haskell.org/package/managed) haskell package (by Gabriel Gonzalez). Nix expr generated with cabal2nix.
