### PR TITLE
Batti (version 0.3.8): New Package

### DIFF
--- a/pkgs/applications/misc/batti/default.nix
+++ b/pkgs/applications/misc/batti/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl
+, pkgconfig, makeWrapper, gettext, python
+, gtk, pygtk, dbus_python
+, upower }:
+
+stdenv.mkDerivation rec {
+
+  name = "batti-${version}";
+  version = "0.3.8";
+
+  src = fetchurl {
+    url = "https://batti-gtk.googlecode.com/files/${name}.tar.gz";
+    sha256 = "072d92gpsiiin631589nj77i2w1425p6db0qxyml7myscfy9jgx6";
+  };
+
+  buildInputs = with stdenv.lib;
+  [ pkgconfig makeWrapper gettext python gtk pygtk dbus_python upower ];
+
+  configurePhase = "true";
+  
+  buildPhase = ''
+    python setup.py build
+  '';
+
+  installPhase = ''
+    python setup.py install --prefix $out
+    wrapProgram $out/bin/batti --set PYTHONPATH "$PYTHONPATH:$(toPythonPath $out)"
+  '';
+
+  	
+  meta = with stdenv.lib; {
+    description = "An {UPower,GTK}-based battery monitor for the system tray";
+    longDescription = ''
+      Batti is a simple battery monitor for the system tray. Batti
+      uses UPower, and if that is missing DeviceKit.Power, for it's
+      power information.
+    '';
+    homepage = http://batti-gtk.googlecode.com/;
+    license = licenses.lgpl2Plus;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}
+
+# TODO: fix the "icon not found" problems...

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8425,6 +8425,8 @@ let
 
   batik = callPackage ../applications/graphics/batik { };
 
+  batti = callPackage ../applications/misc/batti { };
+
   bazaar = callPackage ../applications/version-management/bazaar { };
 
   bazaarTools = builderDefsPackage (import ../applications/version-management/bazaar/tools.nix) {


### PR DESCRIPTION
Batti is a small, GTK+UPower-based, ideal for lightweight desktop
environments/window managers.
