### PR TITLE
dbus_python: Add missing isPyPy argument.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4627,7 +4627,9 @@ let
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
   dbus_glib       = callPackage ../development/libraries/dbus-glib { };
   dbus_java       = callPackage ../development/libraries/java/dbus-java { };
-  dbus_python     = callPackage ../development/python-modules/dbus { };
+  dbus_python     = callPackage ../development/python-modules/dbus {
+    isPyPy = python.executable == "pypy";
+  };
 
   # Should we deprecate these? Currently there are many references.
   dbus_tools = pkgs.dbus.tools;


### PR DESCRIPTION
Fixes a bug introduced in 2632afa13121bdce1f6d8e9dcfdf754b0fe0b669.

When running nix-env -qaP

```
error: anonymous function at /root/nixpkgs/pkgs/development/python-modules/dbus/default.nix:1:1 called without required argument `isPyPy', at /root/nixpkgs/lib/customisation.nix:58:12
```
