### PR TITLE
Zed and nodewebkit

### DIFF
--- a/pkgs/applications/editors/zed/node.nix
+++ b/pkgs/applications/editors/zed/node.nix
@@ -1,6 +1,27 @@
 { self, fetchurl, fetchgit ? null, lib }:
 
 {
+  by-spec."accepts"."~1.1.0" =
+    self.by-version."accepts"."1.1.0";
+  by-version."accepts"."1.1.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-accepts-1.1.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/accepts/-/accepts-1.1.0.tgz";
+        name = "accepts-1.1.0.tgz";
+        sha1 = "43ba6d946374c80f91823eaec6bb43dc4955500b";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."accepts" or []);
+    deps = [
+      self.by-version."mime-types"."2.0.1"
+      self.by-version."negotiator"."0.4.7"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "accepts" ];
+  };
   by-spec."asn1"."0.1.11" =
     self.by-version."asn1"."0.1.11";
   by-version."asn1"."0.1.11" = lib.makeOverridable self.buildNodePackage {
@@ -97,6 +118,34 @@
     ];
     passthru.names = [ "block-stream" ];
   };
+  by-spec."body-parser"."^1.6.3" =
+    self.by-version."body-parser"."1.8.1";
+  by-version."body-parser"."1.8.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-body-parser-1.8.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/body-parser/-/body-parser-1.8.1.tgz";
+        name = "body-parser-1.8.1.tgz";
+        sha1 = "f9f96d221c435c95d18aeaad2bcdea1371902aad";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."body-parser" or []);
+    deps = [
+      self.by-version."bytes"."1.0.0"
+      self.by-version."depd"."0.4.4"
+      self.by-version."iconv-lite"."0.4.4"
+      self.by-version."media-typer"."0.3.0"
+      self.by-version."on-finished"."2.1.0"
+      self.by-version."qs"."2.2.3"
+      self.by-version."raw-body"."1.3.0"
+      self.by-version."type-is"."1.5.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "body-parser" ];
+  };
+  "body-parser" = self.by-version."body-parser"."1.8.1";
   by-spec."boom"."0.4.x" =
     self.by-version."boom"."0.4.2";
   by-version."boom"."0.4.2" = lib.makeOverridable self.buildNodePackage {
@@ -117,6 +166,46 @@
     ];
     passthru.names = [ "boom" ];
   };
+  by-spec."buffer-crc32"."0.2.3" =
+    self.by-version."buffer-crc32"."0.2.3";
+  by-version."buffer-crc32"."0.2.3" = lib.makeOverridable self.buildNodePackage {
+    name = "node-buffer-crc32-0.2.3";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz";
+        name = "buffer-crc32-0.2.3.tgz";
+        sha1 = "bb54519e95d107cbd2400e76d0cab1467336d921";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."buffer-crc32" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "buffer-crc32" ];
+  };
+  by-spec."bytes"."1" =
+    self.by-version."bytes"."1.0.0";
+  by-version."bytes"."1.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-bytes-1.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz";
+        name = "bytes-1.0.0.tgz";
+        sha1 = "3569ede8ba34315fab99c3e92cb04c7220de1fa8";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."bytes" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "bytes" ];
+  };
+  by-spec."bytes"."1.0.0" =
+    self.by-version."bytes"."1.0.0";
   by-spec."combined-stream"."~0.0.4" =
     self.by-version."combined-stream"."0.0.5";
   by-version."combined-stream"."0.0.5" = lib.makeOverridable self.buildNodePackage {
@@ -136,6 +225,63 @@
     peerDependencies = [
     ];
     passthru.names = [ "combined-stream" ];
+  };
+  by-spec."commander"."~2.1.0" =
+    self.by-version."commander"."2.1.0";
+  by-version."commander"."2.1.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-commander-2.1.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz";
+        name = "commander-2.1.0.tgz";
+        sha1 = "d121bbae860d9992a3d517ba96f56588e47c6781";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."commander" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "commander" ];
+  };
+  by-spec."cookie"."0.1.2" =
+    self.by-version."cookie"."0.1.2";
+  by-version."cookie"."0.1.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-cookie-0.1.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz";
+        name = "cookie-0.1.2.tgz";
+        sha1 = "72fec3d24e48a3432073d90c12642005061004b1";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."cookie" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "cookie" ];
+  };
+  by-spec."cookie-signature"."1.0.5" =
+    self.by-version."cookie-signature"."1.0.5";
+  by-version."cookie-signature"."1.0.5" = lib.makeOverridable self.buildNodePackage {
+    name = "node-cookie-signature-1.0.5";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz";
+        name = "cookie-signature-1.0.5.tgz";
+        sha1 = "a122e3f1503eca0f5355795b0711bb2368d450f9";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."cookie-signature" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "cookie-signature" ];
   };
   by-spec."cryptiles"."0.2.x" =
     self.by-version."cryptiles"."0.2.2";
@@ -176,6 +322,26 @@
     ];
     passthru.names = [ "ctype" ];
   };
+  by-spec."debug"."~2.0.0" =
+    self.by-version."debug"."2.0.0";
+  by-version."debug"."2.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-debug-2.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/debug/-/debug-2.0.0.tgz";
+        name = "debug-2.0.0.tgz";
+        sha1 = "89bd9df6732b51256bc6705342bba02ed12131ef";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."debug" or []);
+    deps = [
+      self.by-version."ms"."0.6.2"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "debug" ];
+  };
   by-spec."delayed-stream"."0.0.5" =
     self.by-version."delayed-stream"."0.0.5";
   by-version."delayed-stream"."0.0.5" = lib.makeOverridable self.buildNodePackage {
@@ -194,6 +360,167 @@
     peerDependencies = [
     ];
     passthru.names = [ "delayed-stream" ];
+  };
+  by-spec."depd"."0.4.4" =
+    self.by-version."depd"."0.4.4";
+  by-version."depd"."0.4.4" = lib.makeOverridable self.buildNodePackage {
+    name = "node-depd-0.4.4";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/depd/-/depd-0.4.4.tgz";
+        name = "depd-0.4.4.tgz";
+        sha1 = "07091fae75f97828d89b4a02a2d4778f0e7c0662";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."depd" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "depd" ];
+  };
+  by-spec."destroy"."1.0.3" =
+    self.by-version."destroy"."1.0.3";
+  by-version."destroy"."1.0.3" = lib.makeOverridable self.buildNodePackage {
+    name = "node-destroy-1.0.3";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz";
+        name = "destroy-1.0.3.tgz";
+        sha1 = "b433b4724e71fd8551d9885174851c5fc377e2c9";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."destroy" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "destroy" ];
+  };
+  by-spec."ee-first"."1.0.5" =
+    self.by-version."ee-first"."1.0.5";
+  by-version."ee-first"."1.0.5" = lib.makeOverridable self.buildNodePackage {
+    name = "node-ee-first-1.0.5";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz";
+        name = "ee-first-1.0.5.tgz";
+        sha1 = "8c9b212898d8cd9f1a9436650ce7be202c9e9ff0";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."ee-first" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "ee-first" ];
+  };
+  by-spec."escape-html"."1.0.1" =
+    self.by-version."escape-html"."1.0.1";
+  by-version."escape-html"."1.0.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-escape-html-1.0.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz";
+        name = "escape-html-1.0.1.tgz";
+        sha1 = "181a286ead397a39a92857cfb1d43052e356bff0";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."escape-html" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "escape-html" ];
+  };
+  by-spec."etag"."~1.3.0" =
+    self.by-version."etag"."1.3.0";
+  by-version."etag"."1.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-etag-1.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/etag/-/etag-1.3.0.tgz";
+        name = "etag-1.3.0.tgz";
+        sha1 = "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."etag" or []);
+    deps = [
+      self.by-version."buffer-crc32"."0.2.3"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "etag" ];
+  };
+  by-spec."express"."^4.8.3" =
+    self.by-version."express"."4.9.0";
+  by-version."express"."4.9.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-express-4.9.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/express/-/express-4.9.0.tgz";
+        name = "express-4.9.0.tgz";
+        sha1 = "9b2ea4ebce57c7ac710604c74f6c303ab344a7f3";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."express" or []);
+    deps = [
+      self.by-version."accepts"."1.1.0"
+      self.by-version."buffer-crc32"."0.2.3"
+      self.by-version."cookie-signature"."1.0.5"
+      self.by-version."debug"."2.0.0"
+      self.by-version."depd"."0.4.4"
+      self.by-version."escape-html"."1.0.1"
+      self.by-version."etag"."1.3.0"
+      self.by-version."finalhandler"."0.2.0"
+      self.by-version."fresh"."0.2.4"
+      self.by-version."media-typer"."0.3.0"
+      self.by-version."methods"."1.1.0"
+      self.by-version."on-finished"."2.1.0"
+      self.by-version."parseurl"."1.3.0"
+      self.by-version."path-to-regexp"."0.1.3"
+      self.by-version."proxy-addr"."1.0.1"
+      self.by-version."qs"."2.2.3"
+      self.by-version."range-parser"."1.0.2"
+      self.by-version."send"."0.9.1"
+      self.by-version."serve-static"."1.6.1"
+      self.by-version."type-is"."1.5.1"
+      self.by-version."vary"."1.0.0"
+      self.by-version."cookie"."0.1.2"
+      self.by-version."merge-descriptors"."0.0.2"
+      self.by-version."utils-merge"."1.0.0"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "express" ];
+  };
+  "express" = self.by-version."express"."4.9.0";
+  by-spec."finalhandler"."0.2.0" =
+    self.by-version."finalhandler"."0.2.0";
+  by-version."finalhandler"."0.2.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-finalhandler-0.2.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz";
+        name = "finalhandler-0.2.0.tgz";
+        sha1 = "794082424b17f6a4b2a0eda39f9db6948ee4be8d";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."finalhandler" or []);
+    deps = [
+      self.by-version."debug"."2.0.0"
+      self.by-version."escape-html"."1.0.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "finalhandler" ];
   };
   by-spec."forever-agent"."~0.5.0" =
     self.by-version."forever-agent"."0.5.2";
@@ -236,15 +563,34 @@
     ];
     passthru.names = [ "form-data" ];
   };
-  by-spec."fstream"."~0.1.28" =
-    self.by-version."fstream"."0.1.29";
-  by-version."fstream"."0.1.29" = lib.makeOverridable self.buildNodePackage {
-    name = "node-fstream-0.1.29";
+  by-spec."fresh"."0.2.4" =
+    self.by-version."fresh"."0.2.4";
+  by-version."fresh"."0.2.4" = lib.makeOverridable self.buildNodePackage {
+    name = "node-fresh-0.2.4";
     src = [
       (fetchurl {
-        url = "http://registry.npmjs.org/fstream/-/fstream-0.1.29.tgz";
-        name = "fstream-0.1.29.tgz";
-        sha1 = "34d04023ebc91a9df47bd31ab97e4704b4db413f";
+        url = "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz";
+        name = "fresh-0.2.4.tgz";
+        sha1 = "3582499206c9723714190edd74b4604feb4a614c";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."fresh" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "fresh" ];
+  };
+  by-spec."fstream"."~0.1.28" =
+    self.by-version."fstream"."0.1.31";
+  by-version."fstream"."0.1.31" = lib.makeOverridable self.buildNodePackage {
+    name = "node-fstream-0.1.31";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz";
+        name = "fstream-0.1.31.tgz";
+        sha1 = "7337f058fbbbbefa8c9f561a28cab0849202c988";
       })
     ];
     buildInputs =
@@ -252,7 +598,7 @@
     deps = [
       self.by-version."graceful-fs"."3.0.2"
       self.by-version."inherits"."2.0.1"
-      self.by-version."mkdirp"."0.3.5"
+      self.by-version."mkdirp"."0.5.0"
       self.by-version."rimraf"."2.2.8"
     ];
     peerDependencies = [
@@ -342,6 +688,25 @@
     ];
     passthru.names = [ "http-signature" ];
   };
+  by-spec."iconv-lite"."0.4.4" =
+    self.by-version."iconv-lite"."0.4.4";
+  by-version."iconv-lite"."0.4.4" = lib.makeOverridable self.buildNodePackage {
+    name = "node-iconv-lite-0.4.4";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz";
+        name = "iconv-lite-0.4.4.tgz";
+        sha1 = "e95f2e41db0735fc21652f7827a5ee32e63c83a8";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."iconv-lite" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "iconv-lite" ];
+  };
   by-spec."inherits"."2" =
     self.by-version."inherits"."2.0.1";
   by-version."inherits"."2.0.1" = lib.makeOverridable self.buildNodePackage {
@@ -363,6 +728,25 @@
   };
   by-spec."inherits"."~2.0.0" =
     self.by-version."inherits"."2.0.1";
+  by-spec."ipaddr.js"."0.1.2" =
+    self.by-version."ipaddr.js"."0.1.2";
+  by-version."ipaddr.js"."0.1.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-ipaddr.js-0.1.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz";
+        name = "ipaddr.js-0.1.2.tgz";
+        sha1 = "6a1fd3d854f5002965c34d7bbcd9b4a8d4b0467e";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."ipaddr.js" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "ipaddr.js" ];
+  };
   by-spec."json-stringify-safe"."~5.0.0" =
     self.by-version."json-stringify-safe"."5.0.0";
   by-version."json-stringify-safe"."5.0.0" = lib.makeOverridable self.buildNodePackage {
@@ -382,7 +766,64 @@
     ];
     passthru.names = [ "json-stringify-safe" ];
   };
-  by-spec."mime"."~1.2.11" =
+  by-spec."media-typer"."0.3.0" =
+    self.by-version."media-typer"."0.3.0";
+  by-version."media-typer"."0.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-media-typer-0.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
+        name = "media-typer-0.3.0.tgz";
+        sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."media-typer" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "media-typer" ];
+  };
+  by-spec."merge-descriptors"."0.0.2" =
+    self.by-version."merge-descriptors"."0.0.2";
+  by-version."merge-descriptors"."0.0.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-merge-descriptors-0.0.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz";
+        name = "merge-descriptors-0.0.2.tgz";
+        sha1 = "c36a52a781437513c57275f39dd9d317514ac8c7";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."merge-descriptors" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "merge-descriptors" ];
+  };
+  by-spec."methods"."1.1.0" =
+    self.by-version."methods"."1.1.0";
+  by-version."methods"."1.1.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-methods-1.1.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/methods/-/methods-1.1.0.tgz";
+        name = "methods-1.1.0.tgz";
+        sha1 = "5dca4ee12df52ff3b056145986a8f01cbc86436f";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."methods" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "methods" ];
+  };
+  by-spec."mime"."1.2.11" =
     self.by-version."mime"."1.2.11";
   by-version."mime"."1.2.11" = lib.makeOverridable self.buildNodePackage {
     name = "node-mime-1.2.11";
@@ -401,26 +842,146 @@
     ];
     passthru.names = [ "mime" ];
   };
+  by-spec."mime"."~1.2.11" =
+    self.by-version."mime"."1.2.11";
   by-spec."mime"."~1.2.9" =
     self.by-version."mime"."1.2.11";
-  by-spec."mkdirp"."0.3" =
-    self.by-version."mkdirp"."0.3.5";
-  by-version."mkdirp"."0.3.5" = lib.makeOverridable self.buildNodePackage {
-    name = "node-mkdirp-0.3.5";
+  by-spec."mime-db"."~1.0.1" =
+    self.by-version."mime-db"."1.0.1";
+  by-version."mime-db"."1.0.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-mime-db-1.0.1";
     src = [
       (fetchurl {
-        url = "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz";
-        name = "mkdirp-0.3.5.tgz";
-        sha1 = "de3e5f8961c88c787ee1368df849ac4413eca8d7";
+        url = "http://registry.npmjs.org/mime-db/-/mime-db-1.0.1.tgz";
+        name = "mime-db-1.0.1.tgz";
+        sha1 = "35d99b0965967253bb30633a7d07a8de9975a952";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."mime-db" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "mime-db" ];
+  };
+  by-spec."mime-types"."~2.0.0" =
+    self.by-version."mime-types"."2.0.1";
+  by-version."mime-types"."2.0.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-mime-types-2.0.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/mime-types/-/mime-types-2.0.1.tgz";
+        name = "mime-types-2.0.1.tgz";
+        sha1 = "7f5b4712592e7dd46ca733fd1c5f5d71356de615";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."mime-types" or []);
+    deps = [
+      self.by-version."mime-db"."1.0.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "mime-types" ];
+  };
+  by-spec."mime-types"."~2.0.1" =
+    self.by-version."mime-types"."2.0.1";
+  by-spec."minimist"."0.0.8" =
+    self.by-version."minimist"."0.0.8";
+  by-version."minimist"."0.0.8" = lib.makeOverridable self.buildNodePackage {
+    name = "node-minimist-0.0.8";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz";
+        name = "minimist-0.0.8.tgz";
+        sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."minimist" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "minimist" ];
+  };
+  by-spec."mkdirp"."0.5" =
+    self.by-version."mkdirp"."0.5.0";
+  by-version."mkdirp"."0.5.0" = lib.makeOverridable self.buildNodePackage {
+    name = "mkdirp-0.5.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz";
+        name = "mkdirp-0.5.0.tgz";
+        sha1 = "1d73076a6df986cd9344e15e71fcc05a4c9abf12";
       })
     ];
     buildInputs =
       (self.nativeDeps."mkdirp" or []);
     deps = [
+      self.by-version."minimist"."0.0.8"
     ];
     peerDependencies = [
     ];
     passthru.names = [ "mkdirp" ];
+  };
+  by-spec."ms"."0.6.2" =
+    self.by-version."ms"."0.6.2";
+  by-version."ms"."0.6.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-ms-0.6.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/ms/-/ms-0.6.2.tgz";
+        name = "ms-0.6.2.tgz";
+        sha1 = "d89c2124c6fdc1353d65a8b77bf1aac4b193708c";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."ms" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "ms" ];
+  };
+  by-spec."nan"."~1.0.0" =
+    self.by-version."nan"."1.0.0";
+  by-version."nan"."1.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-nan-1.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/nan/-/nan-1.0.0.tgz";
+        name = "nan-1.0.0.tgz";
+        sha1 = "ae24f8850818d662fcab5acf7f3b95bfaa2ccf38";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."nan" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "nan" ];
+  };
+  by-spec."negotiator"."0.4.7" =
+    self.by-version."negotiator"."0.4.7";
+  by-version."negotiator"."0.4.7" = lib.makeOverridable self.buildNodePackage {
+    name = "node-negotiator-0.4.7";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz";
+        name = "negotiator-0.4.7.tgz";
+        sha1 = "a4160f7177ec806738631d0d3052325da42abdc8";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."negotiator" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "negotiator" ];
   };
   by-spec."node-uuid"."~1.4.0" =
     self.by-version."node-uuid"."1.4.1";
@@ -460,15 +1021,114 @@
     ];
     passthru.names = [ "oauth-sign" ];
   };
-  by-spec."punycode".">=0.2.0" =
-    self.by-version."punycode"."1.3.0";
-  by-version."punycode"."1.3.0" = lib.makeOverridable self.buildNodePackage {
-    name = "node-punycode-1.3.0";
+  by-spec."on-finished"."2.1.0" =
+    self.by-version."on-finished"."2.1.0";
+  by-version."on-finished"."2.1.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-on-finished-2.1.0";
     src = [
       (fetchurl {
-        url = "http://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz";
-        name = "punycode-1.3.0.tgz";
-        sha1 = "7f5009ef539b9444be5c7a19abd2c3ca49e1731c";
+        url = "http://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz";
+        name = "on-finished-2.1.0.tgz";
+        sha1 = "0c539f09291e8ffadde0c8a25850fb2cedc7022d";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."on-finished" or []);
+    deps = [
+      self.by-version."ee-first"."1.0.5"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "on-finished" ];
+  };
+  by-spec."on-finished"."~2.1.0" =
+    self.by-version."on-finished"."2.1.0";
+  by-spec."options".">=0.0.5" =
+    self.by-version."options"."0.0.5";
+  by-version."options"."0.0.5" = lib.makeOverridable self.buildNodePackage {
+    name = "node-options-0.0.5";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/options/-/options-0.0.5.tgz";
+        name = "options-0.0.5.tgz";
+        sha1 = "9a3806378f316536d79038038ba90ccb724816c3";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."options" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "options" ];
+  };
+  by-spec."parseurl"."~1.3.0" =
+    self.by-version."parseurl"."1.3.0";
+  by-version."parseurl"."1.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-parseurl-1.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz";
+        name = "parseurl-1.3.0.tgz";
+        sha1 = "b58046db4223e145afa76009e61bac87cc2281b3";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."parseurl" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "parseurl" ];
+  };
+  by-spec."path-to-regexp"."0.1.3" =
+    self.by-version."path-to-regexp"."0.1.3";
+  by-version."path-to-regexp"."0.1.3" = lib.makeOverridable self.buildNodePackage {
+    name = "node-path-to-regexp-0.1.3";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz";
+        name = "path-to-regexp-0.1.3.tgz";
+        sha1 = "21b9ab82274279de25b156ea08fd12ca51b8aecb";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."path-to-regexp" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "path-to-regexp" ];
+  };
+  by-spec."proxy-addr"."1.0.1" =
+    self.by-version."proxy-addr"."1.0.1";
+  by-version."proxy-addr"."1.0.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-proxy-addr-1.0.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz";
+        name = "proxy-addr-1.0.1.tgz";
+        sha1 = "c7c566d5eb4e3fad67eeb9c77c5558ccc39b88a8";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."proxy-addr" or []);
+    deps = [
+      self.by-version."ipaddr.js"."0.1.2"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "proxy-addr" ];
+  };
+  by-spec."punycode".">=0.2.0" =
+    self.by-version."punycode"."1.3.1";
+  by-version."punycode"."1.3.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-punycode-1.3.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz";
+        name = "punycode-1.3.1.tgz";
+        sha1 = "710afe5123c20a1530b712e3e682b9118fe8058e";
       })
     ];
     buildInputs =
@@ -478,6 +1138,25 @@
     peerDependencies = [
     ];
     passthru.names = [ "punycode" ];
+  };
+  by-spec."qs"."2.2.3" =
+    self.by-version."qs"."2.2.3";
+  by-version."qs"."2.2.3" = lib.makeOverridable self.buildNodePackage {
+    name = "node-qs-2.2.3";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/qs/-/qs-2.2.3.tgz";
+        name = "qs-2.2.3.tgz";
+        sha1 = "6139c1f47960eff5655e56aab0ef9f6dd16d4eeb";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."qs" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "qs" ];
   };
   by-spec."qs"."~0.6.0" =
     self.by-version."qs"."0.6.6";
@@ -497,6 +1176,48 @@
     peerDependencies = [
     ];
     passthru.names = [ "qs" ];
+  };
+  by-spec."range-parser"."~1.0.0" =
+    self.by-version."range-parser"."1.0.2";
+  by-version."range-parser"."1.0.2" = lib.makeOverridable self.buildNodePackage {
+    name = "node-range-parser-1.0.2";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz";
+        name = "range-parser-1.0.2.tgz";
+        sha1 = "06a12a42e5131ba8e457cd892044867f2344e549";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."range-parser" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "range-parser" ];
+  };
+  by-spec."range-parser"."~1.0.2" =
+    self.by-version."range-parser"."1.0.2";
+  by-spec."raw-body"."1.3.0" =
+    self.by-version."raw-body"."1.3.0";
+  by-version."raw-body"."1.3.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-raw-body-1.3.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz";
+        name = "raw-body-1.3.0.tgz";
+        sha1 = "978230a156a5548f42eef14de22d0f4f610083d1";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."raw-body" or []);
+    deps = [
+      self.by-version."bytes"."1.0.0"
+      self.by-version."iconv-lite"."0.4.4"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "raw-body" ];
   };
   by-spec."request"."~2.34.0" =
     self.by-version."request"."2.34.0";
@@ -549,6 +1270,58 @@
     ];
     passthru.names = [ "rimraf" ];
   };
+  by-spec."send"."0.9.1" =
+    self.by-version."send"."0.9.1";
+  by-version."send"."0.9.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-send-0.9.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/send/-/send-0.9.1.tgz";
+        name = "send-0.9.1.tgz";
+        sha1 = "d93689f7c9ce36bd32f8ee572bb60bda032edc23";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."send" or []);
+    deps = [
+      self.by-version."debug"."2.0.0"
+      self.by-version."depd"."0.4.4"
+      self.by-version."destroy"."1.0.3"
+      self.by-version."escape-html"."1.0.1"
+      self.by-version."etag"."1.3.0"
+      self.by-version."fresh"."0.2.4"
+      self.by-version."mime"."1.2.11"
+      self.by-version."ms"."0.6.2"
+      self.by-version."on-finished"."2.1.0"
+      self.by-version."range-parser"."1.0.2"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "send" ];
+  };
+  by-spec."serve-static"."~1.6.1" =
+    self.by-version."serve-static"."1.6.1";
+  by-version."serve-static"."1.6.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-serve-static-1.6.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/serve-static/-/serve-static-1.6.1.tgz";
+        name = "serve-static-1.6.1.tgz";
+        sha1 = "2f257563afbe931d28cee4aa3dfeddc975a87193";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."serve-static" or []);
+    deps = [
+      self.by-version."escape-html"."1.0.1"
+      self.by-version."parseurl"."1.3.0"
+      self.by-version."send"."0.9.1"
+      self.by-version."utils-merge"."1.0.0"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "serve-static" ];
+  };
   by-spec."sntp"."0.2.x" =
     self.by-version."sntp"."0.2.4";
   by-version."sntp"."0.2.4" = lib.makeOverridable self.buildNodePackage {
@@ -584,7 +1357,7 @@
       (self.nativeDeps."tar" or []);
     deps = [
       self.by-version."block-stream"."0.0.7"
-      self.by-version."fstream"."0.1.29"
+      self.by-version."fstream"."0.1.31"
       self.by-version."inherits"."2.0.1"
     ];
     peerDependencies = [
@@ -592,6 +1365,25 @@
     passthru.names = [ "tar" ];
   };
   "tar" = self.by-version."tar"."0.1.20";
+  by-spec."tinycolor"."0.x" =
+    self.by-version."tinycolor"."0.0.1";
+  by-version."tinycolor"."0.0.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-tinycolor-0.0.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz";
+        name = "tinycolor-0.0.1.tgz";
+        sha1 = "320b5a52d83abb5978d81a3e887d4aefb15a6164";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."tinycolor" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "tinycolor" ];
+  };
   by-spec."tough-cookie".">=0.12.0" =
     self.by-version."tough-cookie"."0.12.1";
   by-version."tough-cookie"."0.12.1" = lib.makeOverridable self.buildNodePackage {
@@ -606,7 +1398,7 @@
     buildInputs =
       (self.nativeDeps."tough-cookie" or []);
     deps = [
-      self.by-version."punycode"."1.3.0"
+      self.by-version."punycode"."1.3.1"
     ];
     peerDependencies = [
     ];
@@ -631,4 +1423,87 @@
     ];
     passthru.names = [ "tunnel-agent" ];
   };
+  by-spec."type-is"."~1.5.1" =
+    self.by-version."type-is"."1.5.1";
+  by-version."type-is"."1.5.1" = lib.makeOverridable self.buildNodePackage {
+    name = "node-type-is-1.5.1";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/type-is/-/type-is-1.5.1.tgz";
+        name = "type-is-1.5.1.tgz";
+        sha1 = "5c1e62d874f79199fb16b34d16972dba376ccbed";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."type-is" or []);
+    deps = [
+      self.by-version."media-typer"."0.3.0"
+      self.by-version."mime-types"."2.0.1"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "type-is" ];
+  };
+  by-spec."utils-merge"."1.0.0" =
+    self.by-version."utils-merge"."1.0.0";
+  by-version."utils-merge"."1.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-utils-merge-1.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
+        name = "utils-merge-1.0.0.tgz";
+        sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."utils-merge" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "utils-merge" ];
+  };
+  by-spec."vary"."~1.0.0" =
+    self.by-version."vary"."1.0.0";
+  by-version."vary"."1.0.0" = lib.makeOverridable self.buildNodePackage {
+    name = "node-vary-1.0.0";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/vary/-/vary-1.0.0.tgz";
+        name = "vary-1.0.0.tgz";
+        sha1 = "c5e76cec20d3820d8f2a96e7bee38731c34da1e7";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."vary" or []);
+    deps = [
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "vary" ];
+  };
+  by-spec."ws"."~0.4.32" =
+    self.by-version."ws"."0.4.32";
+  by-version."ws"."0.4.32" = lib.makeOverridable self.buildNodePackage {
+    name = "ws-0.4.32";
+    src = [
+      (fetchurl {
+        url = "http://registry.npmjs.org/ws/-/ws-0.4.32.tgz";
+        name = "ws-0.4.32.tgz";
+        sha1 = "787a6154414f3c99ed83c5772153b20feb0cec32";
+      })
+    ];
+    buildInputs =
+      (self.nativeDeps."ws" or []);
+    deps = [
+      self.by-version."commander"."2.1.0"
+      self.by-version."nan"."1.0.0"
+      self.by-version."tinycolor"."0.0.1"
+      self.by-version."options"."0.0.5"
+    ];
+    peerDependencies = [
+    ];
+    passthru.names = [ "ws" ];
+  };
+  "ws" = self.by-version."ws"."0.4.32";
 }

--- a/pkgs/development/tools/node-webkit/default.nix
+++ b/pkgs/development/tools/node-webkit/default.nix
@@ -9,8 +9,9 @@ let
     name = "node-webkit-env";
     paths = [
       xlibs.libX11 xlibs.libXrender glib gtk atk pango cairo gdk_pixbuf
-      freetype fontconfig xlibs.libXcomposite alsaLib xlibs.libXdamage xlibs.libXext
-      xlibs.libXfixes nss nspr gconf expat dbus udev stdenv.gcc.gcc
+      freetype fontconfig xlibs.libXcomposite alsaLib xlibs.libXdamage
+      xlibs.libXext xlibs.libXfixes nss nspr gconf expat dbus stdenv.gcc.gcc
+      xlibs.libXtst xlibs.libXi
     ];
   };
 
@@ -19,28 +20,27 @@ in stdenv.mkDerivation rec {
   version = "0.9.2";
 
   src = fetchurl {
-    url = "https://s3.amazonaws.com/node-webkit/v${version}/node-webkit-v${version}-linux-${bits}.tar.gz";
+    url = "http://dl.node-webkit.org/v${version}/node-webkit-v${version}-linux-${bits}.tar.gz";
     sha256 = if bits == "x64" then
       "04b9hgrxxnvrzyc7kmlabvrfbzj9d6lif7z69zgsbn3x25nxxd2n" else
       "0icwdl564sbx27124js1l4whfld0n6nbysdd522frzk1759dzgri";
   };
 
-  patchPhase = ''
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" nw
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" nwsnapshot
-  '';
-
-  installPhase = let
-    LD_LIBRARY_PATH = "${nwEnv}/lib:${nwEnv}/lib64:$out/share/node-webkit";
-  in ''
-    mkdir -p $out/bin
+  installPhase = ''
     mkdir -p $out/share/node-webkit
     cp -R * $out/share/node-webkit
 
+    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/share/node-webkit/nw
+    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/share/node-webkit/nwsnapshot
+
     ln -s ${udev}/lib/libudev.so $out/share/node-webkit/libudev.so.0
 
-    makeWrapper $out/share/node-webkit/nw $out/bin/nw --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}"
-    makeWrapper $out/share/node-webkit/nwsnapshot $out/bin/nwsnapshot --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}"
+    patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:$out/share/node-webkit" $out/share/node-webkit/nw
+    patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:$out/share/node-webkit" $out/share/node-webkit/nwsnapshot
+
+    mkdir -p $out/bin
+    ln -s $out/share/node-webkit/nw $out/bin
+    ln -s $out/share/node-webkit/nwsnapshot $out/bin
   '';
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
- upgrade Zed to 0.13
- move nodewebkit patchelf code from Zed to node-webkit (so that nodewebkit can be used as standalone)
- node-webkit change download url because currently can not be downloaded or built for that matter
