### PR TITLE
xbmc: add libmad to LD_LIBRARY_PATH to enable mp3 file playback

### DIFF
--- a/pkgs/applications/video/xbmc/default.nix
+++ b/pkgs/applications/video/xbmc/default.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation rec {
           --prefix PATH ":" "${xdpyinfo}/bin" \
           --prefix LD_LIBRARY_PATH ":" "${curl}/lib" \
           --prefix LD_LIBRARY_PATH ":" "${systemd}/lib" \
+          --prefix LD_LIBRARY_PATH ":" "${libmad}/lib" \
           --prefix LD_LIBRARY_PATH ":" "${libvdpau}/lib"
       done
     '';


### PR DESCRIPTION
xbmc tries to dynamically open libmad.so.0, fails -> no mp3 playback. Complains in xbmc.log. Fixing this.
