### PR TITLE
go: Include all 3 GOROOT tools

### DIFF
--- a/pkgs/development/compilers/go/1.3.nix
+++ b/pkgs/development/compilers/go/1.3.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, bison, glibc, bash, coreutils, makeWrapper, tzdata, iana_etc }:
+{ stdenv, lib, fetchurl, fetchhg, bison, glibc, bash, coreutils, makeWrapper, tzdata, iana_etc, perl }:
 
 assert stdenv.gcc.gcc != null;
 
@@ -6,23 +6,36 @@ let
   loader386 = "${glibc}/lib/ld-linux.so.2";
   loaderAmd64 = "${glibc}/lib/ld-linux-x86-64.so.2";
   loaderArm = "${glibc}/lib/ld-linux.so.3";
+  srcs = {
+    golang = fetchurl {
+      url = https://storage.googleapis.com/golang/go1.3.1.src.tar.gz;
+      sha256 = "fdfa148cc12f1e4ea45a5565261bf43d8a2e7d1fad4a16aed592d606223b93a8";
+    };
+    tools = fetchhg {
+      url = https://code.google.com/p/go.tools/;
+      rev = "e1c276c4e679";
+      sha256 = "0x62njflwkd99i2ixbksg6mjppl1wfg86f0g3swn350l1h0xzp76";
+    };
+  };
 in
 
 stdenv.mkDerivation {
   name = "go-1.3.1";
 
-  src = fetchurl {
-    url = https://storage.googleapis.com/golang/go1.3.1.src.tar.gz;
-    sha256 = "fdfa148cc12f1e4ea45a5565261bf43d8a2e7d1fad4a16aed592d606223b93a8";
-  };
+  src = srcs.golang;
 
-  buildInputs = [ bison bash makeWrapper ] ++ lib.optionals stdenv.isLinux [ glibc ] ;
+  # perl is used for testing go vet
+  buildInputs = [ bison bash makeWrapper perl ] ++ lib.optionals stdenv.isLinux [ glibc ] ;
 
   # I'm not sure what go wants from its 'src', but the go installation manual
   # describes an installation keeping the src.
   preUnpack = ''
     mkdir -p $out/share
     cd $out/share
+  '';
+  postUnpack = ''
+    mkdir -p $out/share/go/src/pkg/code.google.com/p/
+    cp -rv --no-preserve=mode,ownership ${srcs.tools} $out/share/go/src/pkg/code.google.com/p/go.tools
   '';
 
   prePatch = ''
@@ -80,6 +93,12 @@ stdenv.mkDerivation {
     cd ./src
     ./all.bash
     cd -
+
+    # Build extra tooling
+    # TODO: Fix godoc tests
+    TOOL_ROOT=code.google.com/p/go.tools/cmd
+    go install -v $TOOL_ROOT/cover $TOOL_ROOT/vet $TOOL_ROOT/godoc
+    go test -v    $TOOL_ROOT/cover $TOOL_ROOT/vet # $TOOL_ROOT/godoc
 
     # Copy the emacs configuration for Go files.
     mkdir -p "$out/share/emacs/site-lisp"


### PR DESCRIPTION
Go is supposed to be packaged with 3 tools: cover, vet, and godoc. While most of the things in the go.tools suite can be installed separately, these tools install into $GOROOT instead of $GOPATH. And on NixOS, the $GOROOT directory lives in a read-only subdir in /nix/store.

Include all 3 tools in the standard installation. Right now, godoc tests do not pass, but it seems like that should be tackled as a separate ticket, rather than blocking people's ability to use godoc, vet, and (in particular) cover.

This fixes #3930.
