### PR TITLE
New package: git-remote-gcrypt.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -46,6 +46,7 @@
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   edwtjo = "Edward Tjörnhammar <ed@cflags.cc>";
   eelco = "Eelco Dolstra <eelco.dolstra@logicblox.com>";
+  ellis = "Ellis Whitehead <nixos@ellisw.net>";
   emery = "Emery Hemingway <emery@vfemail.net>";
   ertes = "Ertugrul Söylemez <ertesx@gmx.de>";
   falsifian = "James Cook <james.cook@utoronto.ca>";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -98,4 +98,5 @@ rec {
 
   git-remote-hg = callPackage ./git-remote-hg { };
 
+  gitRemoteGcrypt = callPackage ./git-remote-gcrypt { };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://github.com/joeyh/git-remote-gcrypt";
     description = "GNU Privacy Guard-encrypted git remote";
-    license = self.stdenv.lib.licenses.gpl3;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ ellis ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, docutils }:
+
+stdenv.mkDerivation {
+  name = "git-remote-gcrypt-20140715";
+
+  # Use joeyh's branch that works better with git-annex
+  src = fetchgit {
+    url = "https://github.com/joeyh/git-remote-gcrypt.git";
+    rev = "5dcc77f507d497fe4023e94a47b6a7a1f1146bce";
+    sha256 = "d509efde143cfec4898872b5bb423d52d5d1c940b6a1e21b8444c904bdb250c2";
+  };
+
+  # Required for rst2man.py
+  buildInputs = [ docutils ];
+
+  # The install.sh script expects rst2man, but here it's named rst2man.py
+  patchPhase = ''
+    sed -i 's/rst2man/rst2man.py/g' install.sh
+  '';
+
+  installPhase = ''
+    prefix="$out" ./install.sh
+  '';
+
+  meta = {
+    homepage = "https://github.com/joeyh/git-remote-gcrypt";
+    description = "GNU Privacy Guard-encrypted git remote";
+    license = self.stdenv.lib.licenses.gpl3;
+  };
+}


### PR DESCRIPTION
A git remote for working with encrypted git repositories.
