### PR TITLE
nix-prefetch-* and fetch* improvements

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -1,5 +1,7 @@
 #! /bin/sh -e
 
+export GIT_SSL_NO_VERIFY=true
+
 url=
 rev=
 expHash=
@@ -76,6 +78,9 @@ Options:
 
 if test -z "$url"; then
   usage
+fi
+if test -z "$hashFormat"; then
+  hashFormat=--base32
 fi
 
 

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -43,7 +43,7 @@ if test -z "$finalPath"; then
     # Perform the checkout.
     if [[ $url != /* ]]; then
       tmpClone=$tmpPath/hg-clone
-      hg clone -q -y -U "$url" $tmpClone >&2
+      hg clone --insecure -q -y -U "$url" $tmpClone >&2
     else
       tmpClone=$url
     fi


### PR DESCRIPTION
- ~~nix-prefetch-hg:~~
  - ~~disable SSL cert checking via --insecure flag~~
- ~~nix-prefetch-git:~~
  - ~~disable SSL cert checking via GIT_SSL_NO_VERIFY=true~~
  - ~~print hash in base32 by default~~

---

**EDIT:**

Per the comments below, we should really do the opposite of what I propose above.
