### PR TITLE
fish-shell builds on unix platforms

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Smart and user-friendly command line shell";
     homepage = "http://fishshell.com/";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ ocharles ];
   };
 }


### PR DESCRIPTION
I can confirm that fish-shell builds fine on darwin without patches, and the docs indicate the same should hold true for BSDs.
