### PR TITLE
init list helper

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -209,6 +209,10 @@ in rec {
     assert list != []; elemAt list (dec (length list));
 
 
+  # Return all elements but the last
+  init = list: assert list != []; take (length list - 1) list;
+
+
   # Zip two lists together.
   zipTwoLists = xs: ys:
     let


### PR DESCRIPTION
Suggestion for list helper

```
nix-repl> lib.init [ 1 2 3 4 ]
[ 1 2 3 ]

nix-repl> lib.elem 4 (lib.init [ 1 2 3 4 ])
false
```
