### PR TITLE
krb5: Update to 12.2.2.  (Please test before merging.)

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "krb5";
-  version = "1.11.3";
+  version = "1.12.2";
   name = "${pname}-${version}";
   webpage = http://web.mit.edu/kerberos/;
 in
@@ -11,8 +11,8 @@ stdenv.mkDerivation (rec {
   inherit name;
 
   src = fetchurl {
-    url = "${webpage}/dist/krb5/1.11/${name}-signed.tar";
-    sha256 = "1daiaxgkxcryqs37w28v4x1vajqmay4l144d1zd9c2d7jjxr9gcs";
+    url = "${webpage}dist/krb5/1.12/${name}-signed.tar";
+    sha256 = "0i1p9xx5s9q0sqnnz7f3rba07882zciw0mwc6yvv7hmm0w0iig89";
   };
 
   buildInputs = [ perl ncurses yacc ];


### PR DESCRIPTION
I don't know the first think about kerberos, but it compiles and doesn't seem to break things that don't involve kerberos.  Someone who uses kerberos should probably test this before it gets merged.  (I'm just putting it here because I like fixing security vulnerabilities on my own system.)

Fixes security vulnerabilities CVE-2014-4341, CVE-2014-4342,
CVE-2014-4343, CVE-2014-4344 and CVE-2014-4345.
