### PR TITLE
Make emulator script run without tools in path

### DIFF
--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
     
     # Create a virtual android device for testing if it does not exists
     
-    if [ "$(android list avd | grep 'Name: device')" = "" ]
+    if [ "$(${androidsdkComposition}/libexec/android-sdk-*/tools/android list avd | grep 'Name: device')" = "" ]
     then
         # Create a virtual android device
         yes "" | ${androidsdkComposition}/libexec/android-sdk-*/tools/android create avd -n device -t ${if useGoogleAPIs then "'Google Inc.:Google APIs:"+platformVersion+"'" else "android-"+platformVersion} $NIX_ANDROID_AVD_FLAGS
@@ -106,7 +106,7 @@ stdenv.mkDerivation {
     ${stdenv.lib.optionalString (app != null) ''
       # Install the App through the debugger, if it has not been installed yet
       
-      if [ -z "${package}" ] || [ "$(adb -s emulator-$port shell pm list packages | grep package:${package})" = "" ]
+      if [ -z "${package}" ] || [ "$(${androidsdkComposition}/libexec/android-sdk-*/platform-tools/adb -s emulator-$port shell pm list packages | grep package:${package})" = "" ]
       then
           if [ -d "${app}" ]
           then


### PR DESCRIPTION
Currently the script created by emulateApp references adb and android without a complete path
in two places. Not sure if this is intentional, but it causes the script to fail if you happen to run it
without having those tools in your environment.
