### PR TITLE
Add recursive directory substitution support to substituteAll

### DIFF
--- a/pkgs/build-support/substitute-files/substitute-all-files.nix
+++ b/pkgs/build-support/substitute-files/substitute-all-files.nix
@@ -1,0 +1,22 @@
+{ stdenv }:
+
+args:
+
+stdenv.mkDerivation ({
+  name = if args ? name then args.name else baseNameOf (toString args.src);
+  builder = with stdenv.lib; builtins.toFile "builder.sh" ''
+    source $stdenv/setup
+    set -o pipefail
+
+    eval "$preInstall"
+
+    args=
+
+    cd "$src"
+    echo -ne "${concatStringsSep "\\0" args.files}" | xargs -0 -n1 -I {} -- find {} -type f -print0 | while read -d "" line; do
+      mkdir -p "$out/$(dirname "$line")"
+      substituteAll "$line" "$out/$line"
+    done
+  '';
+  preferLocalBuild = true;
+} // args)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -391,6 +391,10 @@ let
     inherit stdenv;
   };
 
+  substituteAllFiles = import ../build-support/substitute-files/substitute-all-files.nix {
+    inherit stdenv;
+  };
+
   replaceDependency = import ../build-support/replace-dependency.nix {
     inherit runCommand nix lib;
   };


### PR DESCRIPTION
This allows, for instance, to write complex modular configuration files with substitutions and then use them as such (for nginx):

```
services.nginx.config = let
    configs = pkgs.substituteAll {
      src = ./nginx;

      nginx = pkgs.nginx;
      inherit phpfpm_sock;
    };
  in "include ${configs}/nginx.conf;";
```
