### PR TITLE
Fix the new Ruby interpreters (fixes #3509).

### DIFF
--- a/pkgs/development/interpreters/ruby/config.nix
+++ b/pkgs/development/interpreters/ruby/config.nix
@@ -1,0 +1,6 @@
+# Ruby >= 2.1.0 tries to download config.{guess,sub}
+fetchgit: fetchgit {
+  url = "git://git.sv.gnu.org/config.git";
+  rev = "576c839acca0e082e536fd27568b90a446ce5b96";
+  sha256 = "11bjngchjhj0qq0ppp8c37rfw0yhp230nvhs2jvlx15i9qbf56a0";
+}

--- a/pkgs/development/interpreters/ruby/ruby-2.1.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub
+{ stdenv, fetchurl, fetchgit, fetchFromGitHub
 , zlib, zlibSupport ? true
 , openssl, opensslSupport ? true
 , gdbm, gdbmSupport ? true
@@ -12,6 +12,7 @@ let
   op = stdenv.lib.optional;
   ops = stdenv.lib.optionals;
   patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
+  config = import ./config.nix fetchgit;
   baseruby = ruby_2_1_0.override { useRailsExpress = false; };
 in
 
@@ -62,6 +63,13 @@ stdenv.mkDerivation rec {
     "${patchSet}/patches/ruby/2.1.0/railsexpress/11-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/12-backport-r44370.patch"
   ];
+
+  # Ruby >= 2.1.0 tries to download config.{guess,sub}
+  postPatch = ''
+    rm tool/config_files.rb
+    cp ${config}/config.guess tool/
+    cp ${config}/config.sub tool/
+  '';
 
   configureFlags = ["--enable-shared" ]
     ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"

--- a/pkgs/development/interpreters/ruby/ruby-2.1.1.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.1.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub
+{ stdenv, fetchurl, fetchgit, fetchFromGitHub
 , zlib, zlibSupport ? true
 , openssl, opensslSupport ? true
 , gdbm, gdbmSupport ? true
@@ -12,6 +12,7 @@ let
   op = stdenv.lib.optional;
   ops = stdenv.lib.optionals;
   patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
+  config = import ./config.nix fetchgit;
   baseruby = ruby_2_1_1.override { useRailsExpress = false; };
 in
 
@@ -61,6 +62,13 @@ stdenv.mkDerivation rec {
     "${patchSet}/patches/ruby/2.1.0/railsexpress/10-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/11-backport-r44370.patch"
   ];
+
+  # Ruby >= 2.1.0 tries to download config.{guess,sub}
+  postPatch = ''
+    rm tool/config_files.rb
+    cp ${config}/config.guess tool/
+    cp ${config}/config.sub tool/
+  '';
 
   configureFlags = ["--enable-shared" ]
     ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"

--- a/pkgs/development/interpreters/ruby/ruby-2.1.2.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub
+{ stdenv, fetchurl, fetchgit, fetchFromGitHub
 , zlib, zlibSupport ? true
 , openssl, opensslSupport ? true
 , gdbm, gdbmSupport ? true
@@ -12,6 +12,7 @@ let
   op = stdenv.lib.optional;
   ops = stdenv.lib.optionals;
   patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
+  config = import ./config.nix fetchgit;
   baseruby = ruby_2_1_2.override { useRailsExpress = false; };
 in
 
@@ -60,6 +61,13 @@ stdenv.mkDerivation rec {
     "${patchSet}/patches/ruby/2.1.2/railsexpress/09-aman-opt-aset-aref-str.patch"
     "${patchSet}/patches/ruby/2.1.2/railsexpress/10-funny-falcon-method-cache.patch"
   ];
+
+  # Ruby >= 2.1.0 tries to download config.{guess,sub}
+  postPatch = ''
+    rm tool/config_files.rb
+    cp ${config}/config.guess tool/
+    cp ${config}/config.sub tool/
+  '';
 
   configureFlags = ["--enable-shared" ]
     ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"


### PR DESCRIPTION
Ruby >= 2.1.0 will try to download config.{sub,guess} if not already present.
This provides both files in a pure manner, and also deletes the download script
to prevent any future confusion.

(Fixes #3509)
