### PR TITLE
added symlink 'chromium-browser' for xdg-open to work as expected

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -73,7 +73,8 @@ in stdenv.mkDerivation {
     makeWrapper "${browserBinary}" "$out/bin/chromium" \
       --set CHROMIUM_SANDBOX_BINARY_PATH "${sandboxBinary}" \
       --add-flags "${chromium.plugins.flagsEnabled}"
-
+      
+    ln -s  $out/bin/chromium $out/bin/chromium-browser
     ln -s "${chromium.browser}/share/icons" "$out/share/icons"
     cp -v "${desktopItem}/share/applications/"* "$out/share/applications"
   '';


### PR DESCRIPTION
```
$ xdg-open http://google.com
/run/current-system/sw/bin/xdg-open: line 455: firefox: command not found
/run/current-system/sw/bin/xdg-open: line 455: mozilla: command not found
/run/current-system/sw/bin/xdg-open: line 455: epiphany: command not found
/run/current-system/sw/bin/xdg-open: line 455: konqueror: command not found
/run/current-system/sw/bin/xdg-open: line 455: chromium-browser: command not found
/run/current-system/sw/bin/xdg-open: line 455: google-chrome: command not found
/run/current-system/sw/bin/xdg-open: line 455: links2: command not found
/run/current-system/sw/bin/xdg-open: line 455: links: command not found
/run/current-system/sw/bin/xdg-open: line 455: lynx: command not found
/run/current-system/sw/bin/xdg-open: line 455: w3m: command not found
xdg-open: no method available for opening 'http://google.com'
```
