### PR TITLE
added pcalc package

### DIFF
--- a/pkgs/applications/science/math/pcalc/default.nix
+++ b/pkgs/applications/science/math/pcalc/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, bison2, flex }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "pcalc-${version}";
+  version = "20120812";
+
+  src = fetchgit {
+    url = git://git.code.sf.net/p/pcalc/code;
+    rev = "db5c5d587d4d24ff6b23405a92eeaad4c0f99618";
+    sha256 = "1bzmiz9rrss3xk0vzszbisjkph73zwgc0riqn9zdd2h1iv6dgq92";
+  };
+
+  makeFlags = [ "DESTDIR= BINDIR=$(out)/bin" ];
+  buildInputs = [ bison2 flex ];
+
+  meta = {
+    homepage = http://pcalc.sourceforge.net/;
+    description = "Programmer's calculator";
+    license = licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ ftrvxmtrx ];
+    platforms = stdenv.lib.platforms.linux;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11392,6 +11392,8 @@ let
 
   pari = callPackage ../applications/science/math/pari {};
 
+  pcalc = callPackage ../applications/science/math/pcalc { };
+
   pspp = callPackage ../applications/science/math/pssp {
     inherit (gnome) libglade gtksourceview;
   };


### PR DESCRIPTION
From its homepage:

```
Programmer's calculator, command line utility.

There was always a loophole when it came to a need to covert between hexadecimal / decimal / octal / binary.

Especially if it involved an operation like 0x1234 + 0x20 It took a lot of hard work, and mostly a good pocket calculator.

Main features:
Full math parser, paranthases, add, sub, mult, div, exponential
Automatic conversion between HEX DEC OCT BIN numbers
Mixing different bases in one expression
Definable variables
Math constants (E PI ...)
Built in math functions (sin/cos/sqrt ...)
```
