### PR TITLE
bittorrentsync: fix storage_path

### DIFF
--- a/nixos/modules/services/networking/btsync.nix
+++ b/nixos/modules/services/networking/btsync.nix
@@ -57,7 +57,7 @@ let
     ''
       {
         "device_name":     "${cfg.deviceName}",
-        "storage_path":    "/var/lib/btsync",
+        "storage_path":    "/var/lib/btsync/",
         "listening_port":  ${toString cfg.listeningPort},
         "use_gui":         false,
 


### PR DESCRIPTION
If this path is a symlink, btsync won't be able to read it if it's not ending with "/".
