### PR TITLE
Fail if patch in "patches" does not exist

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -548,6 +548,10 @@ patchPhase() {
 
     for i in $patches; do
         header "applying patch $i" 3
+        if [ ! -r $i ]; then
+          echo "file $i does not exist or not readable"
+          exit 1
+        fi
         local uncompress=cat
         case $i in
             *.gz)


### PR DESCRIPTION
Without this, build will continue if the patch has not been found, as for example in http://pastebin.com/5pht4SL7.
