### PR TITLE
quazip: Fix $out variable in installFlags.

### DIFF
--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   configurePhase = "cd quazip && qmake quazip.pro";
 
-  installFlags = "INSTALL_ROOT=$out";
+  installFlags = "INSTALL_ROOT=$(out)";
 
   buildInputs = [ zlib qt5 ];
 


### PR DESCRIPTION
Was producing an empty directory because the nix was not evaluating $out, and qmake evaluates $o.

See the logs/contents from the last hydra evaluation: http://hydra.nixos.org/build/14258828
