### PR TITLE
Roxterm

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -34,6 +34,7 @@
   bosu = "Boris Sukholitko <boriss@gmail.com>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";
+  cdepillabout = "Dennis Gosnell <cdep.illabout@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -56,6 +56,7 @@ in stdenv.mkDerivation rec {
     longDescription = ''
       Tabbed, VTE-based terminal emulator.  Similar to gnome-terminal without the dependencies on Gnome.
     '';
+    maintainers = with maintainers; [ cdepillabout ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -3,9 +3,10 @@
 , imagemagick, itstool, librsvg, libtool, libxslt, lockfile, makeWrapper
 , pkgconfig, pythonFull, pythonPackages, vte }:
 
-# TODO: Still getting following warning:
-# Gtk-WARNING **: Error loading icon from file '/nix/store/36haql12nc3c91jqf0w8nz29zrwxd2gl-roxterm-2.9.4/share/icons/hicolor/scalable/apps/roxterm.svg':
-# Couldn't recognize the image file format for file '/nix/store/36haql12nc3c91jqf0w8nz29zrwxd2gl-roxterm-2.9.4/share/icons/hicolor/scalable/apps/roxterm.svg'
+# TODO: Still getting following warning.
+# WARNING **: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
+# Seems related to this:
+# https://forums.gentoo.org/viewtopic-t-947210-start-0.html
 
 let version = "2.9.4";
 in stdenv.mkDerivation rec {
@@ -44,7 +45,8 @@ in stdenv.mkDerivation rec {
     python mscript.py install
 
     wrapProgram "$out/bin/roxterm" \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Wrapped the GDK_PIXBUF_MODULE_FILE environment variable so that roxterm is able to
load svg files.

Without it I would get the following warnings when starting roxterm:

```
Gtk-WARNING **: Error loading icon from file '/nix/store/36haql12nc3c91jqf0w8nz29zrwxd2gl-roxterm-2.9.4/share/icons/hicolor/scalable/apps/roxterm.svg':
Couldn't recognize the image file format for file '/nix/store/36haql12nc3c91jqf0w8nz29zrwxd2gl-roxterm-2.9.4/share/icons/hicolor/scalable/apps/roxterm.svg'
```

Also added myself as the maintainer for roxterm.
