### PR TITLE
Add cryptodisk support for Grub

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -234,6 +234,15 @@ in
         '';
       };
 
+      enableCryptodisk = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable support for encrypted partitions. Grub should automatically
+          unlock the correct encrypted partition and look for filesystems.
+        '';
+      };
+
     };
 
   };
@@ -261,6 +270,7 @@ in
           throw "You must set the option ‘boot.loader.grub.device’ to make the system bootable."
         else
           "PERL5LIB=${makePerlPath (with pkgs.perlPackages; [ FileSlurp XMLLibXML XMLSAX ])} " +
+          (if cfg.enableCryptodisk then "GRUB_ENABLE_CRYPTODISK=y " else "") +
           "${pkgs.perl}/bin/perl ${./install-grub.pl} ${grubConfig}";
 
       system.build.grub = grub;


### PR DESCRIPTION
This PR adds support for having Grub unlock encrypted partitions. This enables `/boot` to reside in i.e. a LUKS container, so that a real full-disk encryption setup is possible.

It is only necessary to call `grub-install` with `GRUB_ENABLE_CRYPTODISK=y` in the environment for this to work. Grub should detect the crypto container and only install successfully if the machine can boot.

I have tested this in an extreme environment: `/boot` on btrfs root partition in LVM in LUKS with an GPT partition table. Boots perfectly with `boot.loader.grub.enableCryptodisk = true` and no custom `boot.loader.grub.extraConfig`.
