### PR TITLE
Review PR in travis with nox-review

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+python: "3.4"
+script: ./maintainers/scripts/travis-nox-review-pr.sh

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+set -e
+
+# Install Nix
+bash <(curl https://nixos.org/nix/install)
+source $HOME/.nix-profile/etc/profile.d/nix.sh
+
+# Make sure we can use hydra's binary cache
+sudo mkdir /etc/nix
+echo "binary-caches = http://cache.nixos.org http://hydra.nixos.org" | sudo tee /etc/nix/nix.conf
+echo "trusted-binary-caches = http://hydra.nixos.org" | sudo tee -a /etc/nix/nix.conf
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+    echo "Not a pull request, checking evaluation"
+    nix-env -f. -qaP --drv-path
+    exit 0
+fi
+
+echo "Installing nox"
+git clone https://github.com/madjar/nox
+pip install -e nox
+
+echo "Reviewing PR"
+# The current HEAD is the PR merged into origin/master, so we compare
+# against origin/master
+nox-review wip --against origin/master


### PR DESCRIPTION
This PR enable the use of travis for pull requests.

For each pull requests, each package that is modified by the pull requests (has a different path) is rebuild to check nothing is broken.

One example of the result can be found here: https://github.com/madjar/nixpkgs/pull/1, https://travis-ci.org/madjar/nixpkgs/builds/35873590.

Also, for each commit, the full expression is evaluated, in order to provide fast feedback on broken evaluation (because broken evaluation lead to wrongly failed PR).

This PR should only be merged by a repo admin, who should then activate travis for nixpkgs.
