### PR TITLE
aria2: Bump version to 1.18.8

### DIFF
--- a/pkgs/tools/networking/aria2/default.nix
+++ b/pkgs/tools/networking/aria2/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, openssl, libxml2, sqlite, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "aria2-1.18.5";
+  name = "aria2-1.18.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/aria2/stable/${name}/${name}.tar.bz2";
-    sha256 = "0gyfp4zw7rlaxcxhb402azazf1fi83kk3qg4w0j8d2i7pfa1zqi5";
+    sha256 = "1lpcdpkc22prkzhqrhrd6ccra6vpf2w8mla0z3jv26dqafaxif6b";
   };
 
   buildInputs = [ pkgconfig openssl libxml2 sqlite zlib ];


### PR DESCRIPTION
Builds: http://monitor.nixos.org/pd?p=aria
