### PR TITLE
Allow ansible to install on darwin platforms

### DIFF
--- a/pkgs/tools/system/ansible/default.nix
+++ b/pkgs/tools/system/ansible/default.nix
@@ -32,6 +32,6 @@ pythonPackages.buildPythonPackage rec {
     description = "A simple automation tool";
     license = licenses.gpl3;
     maintainers = [ maintainers.joamaki ];
-    platforms = platforms.linux; # Only tested on Linux
+    platforms = platforms.linux ++ [ "x86_64-darwin" ];
   };
 }

--- a/pkgs/tools/system/ansible/default.nix
+++ b/pkgs/tools/system/ansible/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pythonPackages, python }:
 
 pythonPackages.buildPythonPackage rec {
-  version = "1.6.10";
+  version = "1.7.1";
   name = "ansible-${version}";
   namePrefix = "";
-  
+
   src = fetchurl {
-    url = "https://github.com/ansible/ansible/archive/v${version}.tar.gz";
-    sha256 = "0j133353skzb6ydrqqgfkzbkkj1zaibl1x8sgl0arnfma8qky1g1";
+    url = "http://releases.ansible.com/ansible/ansible-${version}.tar.gz";
+    sha1 = "4f4be4d45f28f52e4ab0c063efb66c7b9f482a51";
   };
 
   prePatch = ''


### PR DESCRIPTION
I am using this package on my Yosemite install of OS X and it works great. It also pretty closely follows the Homebrew recipe that most OS X users use, so I think we can open it up to other OS X users.
