### PR TITLE
[Dont Merge] nixos-iso: Add zfs / btrfs to supportedFilesystems

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -42,6 +42,9 @@ with lib;
   # Get a console as soon as the initrd loads fbcon on EFI boot.
   boot.initrd.kernelModules = [ "fbcon" ];
 
+  # Add support for cow filesystems and their utilities
+  boot.supportedFilesystems = [ "zfs" "btrfs" ];
+
   # Allow the user to log in as root without a password.
   security.initialRootPassword = "";
 }


### PR DESCRIPTION
Does this seem reasonable to everyone? My only worry is that zfs sometimes falls behind in supporting newer kernels which would cause the iso build to fail. It would be nice to be able to create zfs root installs and access zfs pools from the iso though.
