### PR TITLE
Adds camlp4

### DIFF
--- a/pkgs/development/ocaml-modules/camomile/0.8.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.2.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, fetchurl, ocaml, findlib, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     sha256 = "0x43pjxx70kgip86mmdn08s97k4qzdqc8i79xfyyx28smy1bsa00";
   };
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ocaml findlib camlp4];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, fetchurl, ocaml, findlib, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "003ikpvpaliy5hblhckfmln34zqz0mk3y2m1fqvbjngh3h2np045";
   };
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ocaml findlib camlp4];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, minimal ? true}:
+{stdenv, fetchurl, ocaml, findlib, camlp4, minimal ? true}:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.11";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "1jmfj2w0f3ap0swz8k3qqmrl6x2y4gkmg88vv024xnmliiiv7m48";
   };
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ocaml findlib camlp4];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, which, ocaml, findlib, camlzip, extlib}:
+{stdenv, fetchurl, which, ocaml, findlib, camlzip, extlib, camlp4}:
 let
   pname = "javalib";
   version = "2.3";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1i8djcanzm250mwilm3jfy37cz0k0x7jbnrz8a5vvdi91kyzh52j";
   };
 
-  buildInputs = [ which ocaml findlib camlzip extlib ];
+  buildInputs = [ which ocaml findlib camlp4 ];
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk, libgnomecanvas, libglade, gtksourceview}:
+{stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk, libgnomecanvas, libglade, gtksourceview, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -15,7 +15,7 @@ stdenv.mkDerivation (rec {
     sha256 = "a0ea9752eb257dadcfc2914408fff339d4c34357802f02c63329dd41b777de2f";
   };
 
-  buildInputs = [ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview];
+  buildInputs = [ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview camlp4];
 
   configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
   buildFlags = "world";

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     sha256 = "0bxqxzd5sd7siz57vhzb8bmiz1ddhgdv49gcsmwwfmd16mj4cryi";
   };
 
-  buildInputs = [ ocaml findlib ocamlPackages.lablgtk ];
+  buildInputs = [ ocaml findlib ocamlPackages.lablgtk ocamlPackages.camlp4 ];
 
   patches = ./destdir.patch;
 

--- a/pkgs/development/ocaml-modules/ounit/default.nix
+++ b/pkgs/development/ocaml-modules/ounit/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, fetchurl, ocaml, findlib, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "1qw8k2czy0bxhsf25kfpgywhpqmg7bi57rmyhlnmbddmvc61pg76";
   };
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ocaml findlib camlp4];
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, which, perl, ocaml, findlib, javalib }:
+{stdenv, fetchurl, which, perl, ocaml, findlib, javalib, camlp4 }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "0i8qgqkw9vgj6k2g6npss268ivxdkzx5qj2a52jbd8ih59rn68cm";
   };
 
-  buildInputs = [ which perl ocaml findlib javalib ];
+  buildInputs = [ which perl ocaml findlib camlp4 ];
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 

--- a/pkgs/development/ocaml-modules/typeconv/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/typeconv/108.08.00.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, fetchurl, ocaml, findlib, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "08ysikwwp69zvc147lzzg79nwlrzrk738rj0ggcfadi8h5il42sl";
   };
 
-  buildInputs = [ocaml findlib]; 
+  buildInputs = [ocaml findlib camlp4];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/typeconv/default.nix
+++ b/pkgs/development/ocaml-modules/typeconv/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, fetchurl, ocaml, findlib, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "0lpxri68glgq1z2pp02rp45cb909xywbff8d4idljrf6fzzil2zx";
   };
 
-  buildInputs = [ocaml findlib ]; 
+  buildInputs = [ocaml findlib camlp4];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/tools/misc/coccinelle/default.nix
+++ b/pkgs/development/tools/misc/coccinelle/default.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
   };
 
   buildInputs = with ocamlPackages; [
-    ocaml findlib menhir
+    ocaml findlib menhir ocamlPackages.camlp4
     ocaml_pcre pycaml
     python ncurses pkgconfig
     makeWrapper

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -1,0 +1,46 @@
+{stdenv, fetchurl, which, ocaml}:
+let
+  ocaml_version = (stdenv.lib.getVersion ocaml);
+in
+
+assert stdenv.lib.versionAtLeast ocaml_version "4.02";
+
+stdenv.mkDerivation {
+  name = "camlp4-4.02.0+1";
+  src = fetchurl {
+    url = https://github.com/ocaml/camlp4/archive/4.02.0+1.tar.gz;
+    sha256 = "0055f4jiz82rgn581xhq3mr4qgq2qgdxqppmp8i2x1xnsim4h9pn";
+  };
+
+  buildInputs = [ which ocaml ];
+
+  dontAddPrefix = true;
+
+  preConfigure = ''
+    configureFlagsArray=(
+      --bindir=$out/bin
+      --libdir=$out/lib/ocaml/${ocaml_version}/site-lib
+      --pkgdir=$out/lib/ocaml/${ocaml_version}/site-lib
+    )
+  '';
+
+  postConfigure = ''
+    substituteInPlace camlp4/META.in \
+    --replace +camlp4 $out/lib/ocaml/${ocaml_version}/site-lib/camlp4
+    substituteInPlace camlp4/config/Camlp4_config.ml \
+    --replace \
+      "Filename.concat ocaml_standard_library" \
+      "Filename.concat \"$out/lib/ocaml/${ocaml_version}/site-lib\""
+  '';
+
+
+  makePhase = "make all";
+
+  installTargets = "install install-META";
+
+  meta = with stdenv.lib; {
+    description = "A software system for writing extensible parsers for programming languages";
+    homepage = https://github.com/ocaml/camlp4;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/development/tools/ocaml/ocamlify/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlify/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, ounit}:
+{stdenv, fetchurl, ocaml, findlib}:
 
 stdenv.mkDerivation {
   name = "ocamlify-0.0.2";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1f0fghvlbfryf5h3j4as7vcqrgfjb4c8abl5y0y5h069vs4kp5ii";
   };
 
-  buildInputs = [ocaml findlib ounit];
+  buildInputs = [ocaml findlib];
 
   configurePhase = "ocaml setup.ml -configure --prefix $out";
   buildPhase     = "ocaml setup.ml -build";

--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, ounit}:
+{stdenv, fetchurl, ocaml, findlib}:
 
 stdenv.mkDerivation {
   name = "ocamlmod-0.0.7";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "11kg7wh0gy492ma5c6bcjh6frv1a9lh9f26hiys2i0d1ky8s0ad3";
   };
 
-  buildInputs = [ocaml findlib ounit];
+  buildInputs = [ocaml findlib];
 
   configurePhase = "ocaml setup.ml -configure --prefix $out";
   buildPhase     = "ocaml setup.ml -build";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11453,8 +11453,8 @@ let
   picosat = callPackage ../applications/science/logic/picosat {};
 
   prooftree = callPackage ../applications/science/logic/prooftree {
-    inherit (ocamlPackages) findlib lablgtk;
-    camlp5 = ocamlPackages.camlp5_transitional;
+    inherit (ocamlPackages_4_01_0) ocaml findlib lablgtk;
+    camlp5 = ocamlPackages_4_01_0.camlp5_transitional;
   };
 
   prover9 = callPackage ../applications/science/logic/prover9 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3351,6 +3351,11 @@ let
 
     camlidl = callPackage ../development/tools/ocaml/camlidl { };
 
+    camlp4 =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/tools/ocaml/camlp4 { }
+      else null;
+
     camlp5_old_strict =
       if lib.versionOlder "4.00" ocaml_version
       then camlp5_6_strict
@@ -3566,7 +3571,9 @@ let
   opa = let callPackage = newScope pkgs.ocamlPackages_4_00_1; in callPackage ../development/compilers/opa { };
 
   opam_1_0_0 = callPackage ../development/tools/ocaml/opam/1.0.0.nix { };
-  opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix { };
+  opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix {
+    inherit (ocamlPackages_4_01_0) ocaml;
+  };
   opam = opam_1_1;
 
   ocamlnat = let callPackage = newScope pkgs.ocamlPackages_3_12_1; in callPackage ../development/ocaml-modules/ocamlnat { };
@@ -11372,8 +11379,8 @@ let
   alt-ergo = callPackage ../applications/science/logic/alt-ergo {};
 
   coq = callPackage ../applications/science/logic/coq {
-    inherit (ocamlPackages) findlib lablgtk;
-    camlp5 = ocamlPackages.camlp5_transitional;
+    inherit (ocamlPackages_4_01_0) ocaml findlib lablgtk;
+    camlp5 = ocamlPackages_4_01_0.camlp5_transitional;
   };
 
   coq_HEAD = callPackage ../applications/science/logic/coq/HEAD.nix {


### PR DESCRIPTION
Camlp4 is a software system for writing extensible parsers for
programming languages.

Camlp4 was part of the official OCaml distribution until its version
4.01.0.

Homepage: https://github.com/ocaml/camlp4
