### PR TITLE
Fixes to the travis script

### DIFF
--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -7,8 +7,11 @@ source $HOME/.nix-profile/etc/profile.d/nix.sh
 
 # Make sure we can use hydra's binary cache
 sudo mkdir /etc/nix
-echo "binary-caches = http://cache.nixos.org http://hydra.nixos.org" | sudo tee /etc/nix/nix.conf
-echo "trusted-binary-caches = http://hydra.nixos.org" | sudo tee -a /etc/nix/nix.conf
+sudo tee /etc/nix/nix.conf <<EOF
+binary-caches = http://cache.nixos.org http://hydra.nixos.org
+trusted-binary-caches = http://hydra.nixos.org
+build-max-jobs = 4
+EOF
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     echo "Not a pull request, checking evaluation"
@@ -18,7 +21,7 @@ fi
 
 echo "Installing nox"
 git clone https://github.com/madjar/nox
-pip install -e nox
+pip --quiet install -e nox
 
 echo "Reviewing PR"
 # The current HEAD is the PR merged into origin/master, so we compare


### PR DESCRIPTION
- Build 4 jobs at a time (might help with the timeout)
- Be quiet with pip (should make the output more readable)
