### PR TITLE
include thermald service in module list

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -143,6 +143,7 @@
   ./services/hardware/udev.nix
   ./services/hardware/udisks2.nix
   ./services/hardware/upower.nix
+  ./services/hardware/thermald.nix
   ./services/logging/klogd.nix
   ./services/logging/logcheck.nix
   ./services/logging/logrotate.nix


### PR DESCRIPTION
`services.thermald.enable = true;`
in configuration.nix gives:
`error: The option services.thermald defined in /etc/nixos/configuration.nix does not exist`

I assume this is because the module is not mentioned in the module list.
