### PR TITLE
darwin: Use xcrun to determine the DEPLOYMENT_TARGET

### DIFF
--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -14,7 +14,7 @@ import ../generic rec {
       dontFixLibtool=1
       stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
       xargsFlags=" "
-      export MACOSX_DEPLOYMENT_TARGET=10.6
+      export MACOSX_DEPLOYMENT_TARGET=$(/usr/bin/xcrun --show-sdk-version 2> /dev/null || true)
       export SDKROOT=$(/usr/bin/xcrun --show-sdk-path 2> /dev/null || true)
       export NIX_CFLAGS_COMPILE+=" --sysroot=/var/empty -idirafter $SDKROOT/usr/include -F$SDKROOT/System/Library/Frameworks -Wno-multichar -Wno-deprecated-declarations"
       export NIX_LDFLAGS_AFTER+=" -L$SDKROOT/usr/lib"


### PR DESCRIPTION
Setting it to 10.6 on 10.9 systems using Xcode 6.0.1 no longer works.  @peti @edolstra Note: This will cause the world to rebuild, so I think this belongs on another branch?
