### PR TITLE
Labels gdome2 as broken.

### DIFF
--- a/pkgs/development/libraries/gdome2/default.nix
+++ b/pkgs/development/libraries/gdome2/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation {
     description = "DOM C library developped for the Gnome project";
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
+    broken = true;
   };
 }


### PR DESCRIPTION
It is broken most probably because it depends on an old version of glib (1.2.0).
