### PR TITLE
Replace resumeDevice with autodetection of hibernation partition

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -168,9 +168,24 @@ if test -e /sys/power/tuxonice/resume; then
     fi
 fi
 
-if test -n "@resumeDevice@" -a -e /sys/power/resume -a -e /sys/power/disk; then
-    echo "@resumeDevice@" > /sys/power/resume 2> /dev/null || echo "failed to resume..."
-    echo shutdown > /sys/power/disk
+if test -e /sys/power/resume -a -e /sys/power/disk; then
+    if test -n "@resumeDevice@"; then
+        resumeDev="@resumeDevice@"
+    else
+        for sd in @resumeDevices@; do
+            # Try to detect resume device. According to Ubuntu bug:
+            # https://bugs.launchpad.net/ubuntu/+source/pm-utils/+bug/923326/comments/1
+            # When there are multiple swap devices, we can't know where will hibernate
+            # image reside. We can check all of them for swsuspend blkid.
+            if [ "$(blkid -o value -s TYPE "$sd")" = "swsuspend" ]; then
+                resumeDev="$sd"
+                break
+            fi
+        done
+    fi
+    if test -n "$resumeDev"; then
+        echo "$resumeDev" > /sys/power/resume 2> /dev/null || echo "failed to resume..."
+    fi
 fi
 
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -177,7 +177,7 @@ if test -e /sys/power/resume -a -e /sys/power/disk; then
             # https://bugs.launchpad.net/ubuntu/+source/pm-utils/+bug/923326/comments/1
             # When there are multiple swap devices, we can't know where will hibernate
             # image reside. We can check all of them for swsuspend blkid.
-            if [ "$(blkid -o value -s TYPE "$sd")" = "swsuspend" ]; then
+            if [ "$(udevadm info -q property "$sd" | sed -n 's/^ID_FS_TYPE=//p')" = "swsuspend" ]; then
                 resumeDev="$sd"
                 break
             fi


### PR DESCRIPTION
This new implementation automagically finds resume partition from all enabled swap partitions. It, therefore, workarounds Linux kernel's problem of having no way to find out which of all enabled swap partitions or devices was used as a resume one. It doesn't cover a case when user has a swap file because we can't specify resume offset not from the kernel command line; user should use boot.kernelParams for that for now.

This covers all old use cases of resumeDevice, because a resumeDevice should be in swapDevices by definition, and extends it by providing out-of-the-box hibernate support and supporting multiple swap devices; so I've removed old configuration option.

Tested on my machine with one swap partition; would be good to have a test with multiple partitions, but I can't see what can go wrong.
