### PR TITLE
Update bash patchset to fix remote execution vulnerability, CVE-2014-6271

### DIFF
--- a/pkgs/shells/bash/bash-4.2-patches.nix
+++ b/pkgs/shells/bash/bash-4.2-patches.nix
@@ -48,4 +48,5 @@ patch: [
 (patch "045" "0vcqn9rb26bahhrarbwhpa0ny0nrf4vyrzh97d44lfcxypqfzdyx")
 (patch "046" "0vc1ngkxkamwr022ww3vjp9ww9c647az4pjn175c1v60d0xk5hcm")
 (patch "047" "0ymgimqz65sx2izg1dvm1h5cc01arl3j9j5137212l1ls00r55y1")
+(patch "048" "091xk1ms7ycnczsl3fx461gjhj69j6ycnfijlymwj6mj60ims6km")
 ]


### PR DESCRIPTION
https://marc.info/?l=oss-security&m=141156757630394&w=2
