### PR TITLE
androidndk: fix make-standalone-toolchain.sh helper script

### DIFF
--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
     mkdir -pv $out
     tar xf $src
     mv */* $out
+
+    # so that it doesn't fail because of read-only permissions set
+    patch -p1 -d $out < ${ ./make-standalone-toolchain.patch }
+
     find $out \( \
         \( -type f -a -name "*.so*" \) -o \
         \( -type f -a -perm +0100 \) \

--- a/pkgs/development/mobile/androidenv/make-standalone-toolchain.patch
+++ b/pkgs/development/mobile/androidenv/make-standalone-toolchain.patch
@@ -1,0 +1,13 @@
+diff -ru android-ndk-r9d.old/build/tools/make-standalone-toolchain.sh android-ndk-r9d/build/tools/make-standalone-toolchain.sh
+--- android-ndk-r9d.old/build/tools/make-standalone-toolchain.sh	2014-09-25 11:42:09.990500975 +0200
++++ android-ndk-r9d/build/tools/make-standalone-toolchain.sh	2014-09-25 11:43:06.097501636 +0200
+@@ -252,6 +252,9 @@
+ # Now copy the GCC toolchain prebuilt binaries
+ run copy_directory "$TOOLCHAIN_PATH" "$TMPDIR"
+ 
++# Making it writable again
++chmod -R +w "$TMPDIR"
++
+ # Replace soft-link mcld by real file
+ ALL_LDS=`find $TMPDIR -name "*mcld"`
+ for LD in $ALL_LDS; do


### PR DESCRIPTION
The script does a copy of a toolchain and then rearranges files a bit.
The problem is that these files have the same permissions (read-only)
as installed ones. The patch fixes the problem by changing permissions
of the copy before doing anything else.
