### PR TITLE
ruby: Fix build on systems with store optimisation

### DIFF
--- a/pkgs/development/interpreters/ruby/ruby-1.9.3.nix
+++ b/pkgs/development/interpreters/ruby/ruby-1.9.3.nix
@@ -48,6 +48,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # Fix a build failure on systems with nix store optimisation.
+  # (The build process attempted to copy file a overwriting file b, where a and
+  # b are hard-linked, which results in cp returning a non-zero exit code.)
+  # https://github.com/NixOS/nixpkgs/issues/4266
+  postUnpack = ''rm "$sourceRoot/enc/unicode/name2ctype.h"'';
+
   patches = [
     ./ruby19-parallel-install.patch
     ./bitperfect-rdoc.patch

--- a/pkgs/development/interpreters/ruby/ruby-2.0.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.0.0.nix
@@ -48,6 +48,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # Fix a build failure on systems with nix store optimisation.
+  # (The build process attempted to copy file a overwriting file b, where a and
+  # b are hard-linked, which results in cp returning a non-zero exit code.)
+  # https://github.com/NixOS/nixpkgs/issues/4266
+  postUnpack = ''rm "$sourceRoot/enc/unicode/name2ctype.h"'';
+
   patches = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.0.0/p481/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.0.0/p481/02-railsexpress-gc.patch"

--- a/pkgs/development/interpreters/ruby/ruby-2.1.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.0.nix
@@ -49,6 +49,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # Fix a build failure on systems with nix store optimisation.
+  # (The build process attempted to copy file a overwriting file b, where a and
+  # b are hard-linked, which results in cp returning a non-zero exit code.)
+  # https://github.com/NixOS/nixpkgs/issues/4266
+  postUnpack = ''rm "$sourceRoot/enc/unicode/name2ctype.h"'';
+
   patches = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.0/railsexpress/01-current-2.1.1-fixes.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/02-zero-broken-tests.patch"

--- a/pkgs/development/interpreters/ruby/ruby-2.1.1.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.1.nix
@@ -49,6 +49,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # Fix a build failure on systems with nix store optimisation.
+  # (The build process attempted to copy file a overwriting file b, where a and
+  # b are hard-linked, which results in cp returning a non-zero exit code.)
+  # https://github.com/NixOS/nixpkgs/issues/4266
+  postUnpack = ''rm "$sourceRoot/enc/unicode/name2ctype.h"'';
+
   patches = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.0/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/02-improve-gc-stats.patch"

--- a/pkgs/development/interpreters/ruby/ruby-2.1.2.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.2.nix
@@ -49,6 +49,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # Fix a build failure on systems with nix store optimisation.
+  # (The build process attempted to copy file a overwriting file b, where a and
+  # b are hard-linked, which results in cp returning a non-zero exit code.)
+  # https://github.com/NixOS/nixpkgs/issues/4266
+  postUnpack = ''rm "$sourceRoot/enc/unicode/name2ctype.h"'';
+
   patches = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.2/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.2/railsexpress/02-improve-gc-stats.patch"


### PR DESCRIPTION
Fixes #4266.  Though I haven't tested this beyond verifying that the ruby expressions build now.

This seems like an awful hack to me.  I think a better solution would be to remove the -d option in https://github.com/NixOS/nixpkgs/blob/52d9c93abef582cfa32d94397aa86f0aa169917c/pkgs/stdenv/generic/setup.sh#L464 as suggested by @wmertens.
