### PR TITLE
BOSSA: Try to fix a nondeterministic build failure.

### DIFF
--- a/pkgs/development/tools/misc/bossa/bossa-no-applet-build.patch
+++ b/pkgs/development/tools/misc/bossa/bossa-no-applet-build.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile b/Makefile
+index cc8882e..97b11ee 100644
+--- a/Makefile
++++ b/Makefile
+@@ -184,11 +184,6 @@ $(foreach src,$(COMMON_SRCS),$(eval $(call common_obj,$(src))))
+ # Applet rules
+ #
+ define applet_obj
+-$(SRCDIR)/$(1:%.asm=%.cpp): $(SRCDIR)/$(1)
+-	@echo APPLET $(1:%.asm=%)
+-	$$(Q)$$(ARMAS) -o $$(@:%.o=%.obj) $$<
+-	$$(Q)$$(ARMOBJCOPY) -O binary $$(@:%.o=%.obj) $$(@:%.o=%.bin)
+-	$$(Q)appletgen $(1:%.asm=%) $(SRCDIR) $(OBJDIR)
+ $(OBJDIR)/$(1:%.asm=%.o): $(SRCDIR)/$(1:%.asm=%.cpp)
+ 	@echo CPP APPLET $$<
+ 	$$(Q)$$(CXX) $$(COMMON_CXXFLAGS) -c -o $$(@) $$(<:%.asm=%.cpp)

--- a/pkgs/development/tools/misc/bossa/default.nix
+++ b/pkgs/development/tools/misc/bossa/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "01y8r45fw02rps9q995mv82bxrm6p0mysv4wir5glpagrhnyw7md";
   };
 
+  patches = [ ./bossa-no-applet-build.patch ];
+
   nativeBuildInputs = [ bin2c ];
   buildInputs = [ wxGTK libX11 readline ];
 


### PR DESCRIPTION
There's a Make rule to generate .cpp from .asm but the .cpp is included
in the source. Presumably the timestamps of these two files in the tmp
dir are different when Hydra is building, but not on my system. This
causes Make to try to rebuild .cpp, but the tools needed for that are missing.

EDIT link to build failure: http://hydra.nixos.org/build/14705747/nixlog/1
