### PR TITLE
openimageio: using tagged version as src url instead of (moving) branch

### DIFF
--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "oiio-${version}";
-  version = "1.4";
+  version = "1.4.13";
 
   src = fetchurl {
-    url = "https://github.com/OpenImageIO/oiio/archive/RB-${version}.zip";
-    sha256 = "0ldj3hwpz363l1zyzf6c62wc5d2cpbiszlpjvv5w6rrsx2ddbbn1";
+    url = "https://github.com/OpenImageIO/oiio/archive/Release-${version}.zip";
+    sha256 = "1idscm2qqdjgv362l7xk9v162axji7hqh7xdnd3i0wcxwjpgygca";
   };
 
   buildInputs = [


### PR DESCRIPTION
A recent change referred to the url of the 1.4 release branch head, which is changing in time, instead of the most recent tag of that branch
