### PR TITLE
vlc: Add ffmpeg version 2.3.x for vlc.

### DIFF
--- a/pkgs/development/libraries/ffmpeg/2.3.x.nix
+++ b/pkgs/development/libraries/ffmpeg/2.3.x.nix
@@ -1,0 +1,108 @@
+{ stdenv, fetchurl, config, pkgconfig, yasm, zlib, bzip2, alsaLib, texinfo, perl
+, lame, speex, libass, libtheora, libvorbis, libvpx, x264, xvidcore, libopus
+, libvdpau, libva, faac, libdc1394, libXext, libXfixes, SDL
+, freetype, fontconfig, fdk_aac, gnutls
+}:
+
+stdenv.mkDerivation rec {
+  version = "2.3.3";
+  name = "ffmpeg-${version}";
+
+  src = fetchurl {
+    url = "http://www.ffmpeg.org/releases/${name}.tar.bz2";
+    sha256 = "0ik4c06anh49r5b0d3rq9if4zl6ysjsa341655kzw22fl880sk5v";
+  };
+
+  subtitleSupport = config.ffmpeg.subtitle or true;
+  mp3Support = config.ffmpeg.mp3 or true;
+  speexSupport = config.ffmpeg.speex or true;
+  theoraSupport = config.ffmpeg.theora or true;
+  vorbisSupport = config.ffmpeg.vorbis or true;
+  vpxSupport = config.ffmpeg.vpx or true;
+  x264Support = config.ffmpeg.x264 or true;
+  xvidSupport = config.ffmpeg.xvid or true;
+  opusSupport = config.ffmpeg.opus or true;
+  vdpauSupport = config.ffmpeg.vdpau or true;
+  vaapiSupport = config.ffmpeg.vaapi or true;
+  faacSupport = config.ffmpeg.faac or false;
+  fdkAACSupport = config.ffmpeg.fdk or false;
+  dc1394Support = config.ffmpeg.dc1394 or false;
+  x11grabSupport = config.ffmpeg.x11grab or false;
+  playSupport = config.ffmpeg.play or true;
+  freetypeSupport = config.ffmpeg.freetype or true;
+  gnutlsSupport = config.ffmpeg.gnutls or true;
+
+  # `--enable-gpl' (as well as the `postproc' and `swscale') mean that
+  # the resulting library is GPL'ed, so it can only be used in GPL'ed
+  # applications.
+  configureFlags = [
+    "--enable-gpl"
+    "--enable-postproc"
+    "--enable-swscale"
+    "--enable-shared"
+    "--enable-avresample"
+    "--enable-runtime-cpudetect"
+  ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin && subtitleSupport) "--enable-libass"
+    ++ stdenv.lib.optional mp3Support "--enable-libmp3lame"
+    ++ stdenv.lib.optional speexSupport "--enable-libspeex"
+    ++ stdenv.lib.optional theoraSupport "--enable-libtheora"
+    ++ stdenv.lib.optional vorbisSupport "--enable-libvorbis"
+    ++ stdenv.lib.optional vpxSupport "--enable-libvpx"
+    ++ stdenv.lib.optional x264Support "--enable-libx264"
+    ++ stdenv.lib.optional xvidSupport "--enable-libxvid"
+    ++ stdenv.lib.optional opusSupport "--enable-libopus"
+    ++ stdenv.lib.optional vdpauSupport "--enable-vdpau"
+    ++ stdenv.lib.optional faacSupport "--enable-libfaac --enable-nonfree"
+    ++ stdenv.lib.optional dc1394Support "--enable-libdc1394"
+    ++ stdenv.lib.optional x11grabSupport "--enable-x11grab"
+    ++ stdenv.lib.optional (!stdenv.isDarwin && playSupport) "--enable-ffplay"
+    ++ stdenv.lib.optional freetypeSupport "--enable-libfreetype --enable-fontconfig"
+    ++ stdenv.lib.optional fdkAACSupport "--enable-libfdk_aac --enable-nonfree"
+    ++ stdenv.lib.optional gnutlsSupport "--enable-gnutls";
+
+  buildInputs = [ pkgconfig lame yasm zlib bzip2 texinfo perl ]
+    ++ stdenv.lib.optional mp3Support lame
+    ++ stdenv.lib.optional speexSupport speex
+    ++ stdenv.lib.optional theoraSupport libtheora
+    ++ stdenv.lib.optional vorbisSupport libvorbis
+    ++ stdenv.lib.optional vpxSupport libvpx
+    ++ stdenv.lib.optional x264Support x264
+    ++ stdenv.lib.optional xvidSupport xvidcore
+    ++ stdenv.lib.optional opusSupport libopus
+    ++ stdenv.lib.optional vdpauSupport libvdpau
+    ++ stdenv.lib.optional vaapiSupport libva
+    ++ stdenv.lib.optional faacSupport faac
+    ++ stdenv.lib.optional dc1394Support libdc1394
+    ++ stdenv.lib.optionals x11grabSupport [ libXext libXfixes ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin && playSupport) SDL
+    ++ stdenv.lib.optionals freetypeSupport [ freetype fontconfig ]
+    ++ stdenv.lib.optional fdkAACSupport fdk_aac
+    ++ stdenv.lib.optional gnutlsSupport gnutls
+    ++ stdenv.lib.optional (!stdenv.isDarwin && subtitleSupport) libass
+    ++ stdenv.lib.optional (!stdenv.isDarwin) alsaLib;
+
+  enableParallelBuilding = true;
+
+  crossAttrs = {
+    dontSetConfigureCross = true;
+    configureFlags = configureFlags ++ [
+      "--cross-prefix=${stdenv.cross.config}-"
+      "--enable-cross-compile"
+      "--target_os=linux"
+      "--arch=${stdenv.cross.arch}"
+      ];
+  };
+
+  passthru = {
+    inherit vdpauSupport;
+  };
+
+  meta = {
+    homepage = http://www.ffmpeg.org/;
+    description = "A complete, cross-platform solution to record, convert and stream audio and video";
+    license = if (fdkAACSupport || faacSupport) then stdenv.lib.licenses.unfree else stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4848,6 +4848,8 @@ let
     vpxSupport = !stdenv.isMips;
   };
 
+  ffmpeg_2_3 = callPackage ../development/libraries/ffmpeg/2.3.x.nix { };
+
   ffmpeg_2 = callPackage ../development/libraries/ffmpeg/2.x.nix { };
 
   ffmpeg = ffmpeg_2;
@@ -10401,7 +10403,9 @@ let
     inherit (xlibs) libX11;
   };
 
-  vlc = callPackage ../applications/video/vlc { };
+  vlc = callPackage ../applications/video/vlc {
+    ffmpeg = ffmpeg_2_3;
+  };
 
   vmpk = callPackage ../applications/audio/vmpk { };
 


### PR DESCRIPTION
d6821cc9a83f00834f2003d3c6e15597c24421a7 broke vlc. Vlc doesn't support libavcodec >= 56 yet (fails with a configuration error) so it needs an older version of ffpmeg. This patch adds back the 2.3.3 version of ffmpeg so vlc can build against it.

ffmpeg maintainer: @Fuuzetsu 
