### PR TITLE
erlang-17.3: crypto/ssl handshake fix for empty SNI

### DIFF
--- a/pkgs/development/interpreters/erlang/R17.nix
+++ b/pkgs/development/interpreters/erlang/R17.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     ] ++ optional wxSupport [ mesa wxGTK xlibs.libX11 ]
       ++ optional odbcSupport [ unixODBC ];
 
-  patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
+  patches = [ ./ssl_handshake_17.3.patch ];
+  postPatch = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
 
   preConfigure = ''
     export HOME=$PWD/../

--- a/pkgs/development/interpreters/erlang/ssl_handshake_17.3.patch
+++ b/pkgs/development/interpreters/erlang/ssl_handshake_17.3.patch
@@ -1,0 +1,40 @@
+diff --git a/lib/ssl/src/ssl_handshake.erl b/lib/ssl/src/ssl_handshake.erl
+index 22673e4..88ccb94 100644
+--- a/lib/ssl/src/ssl_handshake.erl
++++ b/lib/ssl/src/ssl_handshake.erl
+@@ -1732,6 +1732,9 @@ dec_hello_extensions(<<?UINT16(?EC_POINT_FORMATS_EXT), ?UINT16(Len),
+ 							#ec_point_formats{ec_point_format_list =
+ 									      ECPointFormats}});
+ 
++dec_hello_extensions(<<?UINT16(?SNI_EXT), ?UINT16(Len), Rest/binary>>, Acc) when Len == 0 ->
++    dec_hello_extensions(Rest, Acc#hello_extensions{sni = ""}); %% Server may send an empy SNI
++
+ dec_hello_extensions(<<?UINT16(?SNI_EXT), ?UINT16(Len),
+                 ExtData:Len/binary, Rest/binary>>, Acc) ->
+     <<?UINT16(_), NameList/binary>> = ExtData,
+diff --git a/lib/ssl/test/ssl_handshake_SUITE.erl b/lib/ssl/test/ssl_handshake_SUITE.erl
+index e5e942c..8dca733 100644
+--- a/lib/ssl/test/ssl_handshake_SUITE.erl
++++ b/lib/ssl/test/ssl_handshake_SUITE.erl
+@@ -39,6 +39,7 @@ all() -> [decode_hello_handshake,
+ 	  decode_unknown_hello_extension_correctly,
+ 	  encode_single_hello_sni_extension_correctly,
+ 	  decode_single_hello_sni_extension_correctly,
++	  decode_empty_server_sni_correctly,
+ 	  select_proper_tls_1_2_rsa_default_hashsign].
+ 
+ %%--------------------------------------------------------------------
+@@ -106,6 +107,13 @@ decode_single_hello_sni_extension_correctly(_Config) ->
+     Decoded = ssl_handshake:decode_hello_extensions(SNI),
+     Exts = Decoded.
+ 
++decode_empty_server_sni_correctly(_Config) ->
++    Exts = #hello_extensions{sni = ""},
++    SNI = <<?UINT16(?SNI_EXT),?UINT16(0)>>,
++    Decoded = ssl_handshake:decode_hello_extensions(SNI),
++    Exts = Decoded.
++
++
+ select_proper_tls_1_2_rsa_default_hashsign(_Config) ->
+     % RFC 5246 section 7.4.1.4.1 tells to use {sha1,rsa} as default signature_algorithm for RSA key exchanges
+     {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,3}),


### PR DESCRIPTION
Discussion:
https://groups.google.com/forum/#!topic/erlang-programming/7IGtXNzvrD0

The patch itself:
https://github.com/erlang/otp/commit/3b1328d0eaecede8e42b0838f9920e413a19c8d6
