### PR TITLE
Add linode python binding

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -91,6 +91,7 @@
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
+  nslqqq = "Nikita Mikhailov <nslqqq@gmail.com>";
   ocharles = "Oliver Charles <ollie@ocharles.org.uk>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4453,6 +4453,25 @@ let
   });
 
 
+  linode = buildPythonPackage rec {
+    name = "linode-${version}";
+    version = "0.4";
+
+    src = fetchurl {
+      url = "https://pypi.python.org/packages/source/l/linode/linode-${version}.tar.gz";
+      md5 = "03a306575cf274719b3206ecee0bda9e";
+    };
+
+    propagatedBuildInputs = [ requests2 ];
+
+    meta = {
+      homepage = "https://github.com/ghickman/linode";
+      description = "A thin python wrapper around Linode's API.";
+      license = licenses.mit;
+    };
+  };
+
+
   lockfile = buildPythonPackage rec {
     name = "lockfile-0.9.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4464,10 +4464,11 @@ let
 
     propagatedBuildInputs = [ requests2 ];
 
-    meta = {
+    meta = with stdenv.lib; {
       homepage = "https://github.com/ghickman/linode";
-      description = "A thin python wrapper around Linode's API.";
+      description = "A thin python wrapper around Linode's API";
       license = licenses.mit;
+      maintainers = [ maintainers.nslqqq ];
     };
   };
 


### PR DESCRIPTION
Linode API python binding
I was unable to build it for pypy because dependency 'python-tkinter' failed

UPD1: fixed @cillianderoiste's comments
