### PR TITLE
FONTCONFIG_FILE: remove setters to /etc/fonts/fonts.conf

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -47,11 +47,6 @@ with lib;
         </fontconfig>
       '';
 
-    # FIXME: This variable is no longer needed, but we'll keep it
-    # around for a while for applications linked against old
-    # fontconfig builds.
-    environment.variables.FONTCONFIG_FILE = "/etc/fonts/fonts.conf";
-
     environment.systemPackages = [ pkgs.fontconfig ];
 
   };

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -28,11 +28,10 @@ let
     buildCommand = ''
       mkdir -p $out/gtk-3.0/
 
-      # This wrapper ensures that we actually get fonts
+      # This wrapper ensures that we actually get ?? (fonts should be OK now)
       makeWrapper ${pkgs.lightdm_gtk_greeter}/sbin/lightdm-gtk-greeter \
         $out/greeter \
         --set XDG_DATA_DIRS ${pkgs.gnome2.gnome_icon_theme}/share \
-        --set FONTCONFIG_FILE /etc/fonts/fonts.conf \
         --set XDG_CONFIG_HOME $out/
 
       # We need this to ensure that it actually tries to find icons from gnome-icon-theme

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -458,7 +458,7 @@ in
         restartIfChanged = false;
 
         environment =
-          { FONTCONFIG_FILE = "/etc/fonts/fonts.conf"; # !!! cleanup
+          {
             XKB_BINDIR = "${xorg.xkbcomp}/bin"; # Needed for the Xkb extension.
             XORG_DRI_DRIVER_PATH = "/run/opengl-driver/lib/dri"; # !!! Depends on the driver selected at runtime.
             LD_LIBRARY_PATH = concatStringsSep ":" (

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -68,6 +68,5 @@ buildFHSChrootEnv {
   profile = ''
     export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib:/lib32:/lib64
     export PATH=$PATH:/usr/bin:/usr/sbin
-    export FONTCONFIG_FILE=/etc/fonts/fonts.conf
   '';
 }

--- a/pkgs/tools/X11/bumblebee/default.nix
+++ b/pkgs/tools/X11/bumblebee/default.nix
@@ -88,7 +88,6 @@ in stdenv.mkDerivation {
     wrapProgram "$out/sbin/bumblebeed" \
       --prefix PATH : "${commonEnv}/sbin:${commonEnv}/bin:\$PATH" \
       --prefix LD_LIBRARY_PATH : "${commonEnv}/lib:\$LD_LIBRARY_PATH" \
-      --set FONTCONFIG_FILE "/etc/fonts/fonts.conf" \
       --set XKB_BINDIR "${xorg.xkbcomp}/bin" \
       --set XKB_DIR "${xkeyboard_config}/etc/X11/xkb"
 


### PR DESCRIPTION
Any reasonably new version of fontconfig does search that path by default, and setting this globally causes problems, as 2.10 and 2.11 need incompatible configs.

Tested: slim+xfce desktop, chrootenv-ed steam.
I have no idea why we were setting the global variable; e.g., neither Fedora nor Ubuntu does that.
#### Potential issues
- I couldn't test with **lightdm**, as on my testing machine it fails both before and after the commit, probably due to #2065. @ocharles: you added it for lightdm in 2e088aa2; are you sure it was needed? Can someone test this with lightdm?
- I couldn't test with **bumblebee**, as my motherboard doesn't support optimus. @amiddelk: you added it in 3f1054b1e; are you sure it was needed? Can someone test this with bumblebee?
