### PR TITLE
nixos/install-grub.pl: handle being given a partition device file

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -408,8 +408,10 @@ if (($ENV{'NIXOS_INSTALL_GRUB'} // "") eq "1" || get("fullVersion") ne $prevVers
     foreach my $dev ($dom->findnodes('/expr/attrs/attr[@name = "devices"]/list/string/@value')) {
         $dev = $dev->findvalue(".") or die;
         next if $dev eq "nodev";
-        print STDERR "installing the GRUB $grubVersion boot loader on $dev...\n";
-        system("$grub/sbin/grub-install", "--recheck", Cwd::abs_path($dev)) == 0
+        my $realdev = Cwd::abs_path($dev);
+        $realdev =~ s/\d+//;
+        print STDERR "installing the GRUB $grubVersion boot loader on $dev => $realdev...\n";
+        system("$grub/sbin/grub-install", "--recheck", $realdev) == 0
             or die "$0: installation of GRUB on $dev failed\n";
     }
     writeFile("/boot/grub/version", get("fullVersion"));


### PR DESCRIPTION
If the "boot.loader.grub.device" config option points to a hard disk
partition device file (e.g. /dev/disk/by-label/nixos, which is a symlink
to /dev/sda1), installing grub fails like this:

$ sudo nixos-rebuild switch
[...]
installing the GRUB 2 boot loader on /dev/disk/by-label/nixos...
Installing for i386-pc platform.
.../sbin/grub-install: warning: File system `ext2' doesn't support embedding.
.../sbin/grub-install: warning: Embedding is not possible.  GRUB can only be installed in this setup by using blocklists.  However, blocklists are UNRELIABLE and their use is discouraged..
.../sbin/grub-install: error: will not proceed with blocklists.
/nix/store/HASH-install-grub.pl: installation of GRUB on /dev/disk/by-label/nixos failed

(Grub doesn't differentiate between the various ext2/3/4 variants here
and prints ext2 even for ext4 filesystem.)

This patch makes install-grub.pl strip off numbers in the device file,
so that even if a /dev/sda1 path is given, it is converted to /dev/sda
before passing it on to grub-install.

This enables using human friendly "by-label" device files, and allows
using the same setting for boot.loader.grub.device and
fileSystems."/".device.

Alternatives to using "by-label" device files are:

1) Names like /dev/sda. Downside: unstable, name may change after a reboot.

2) Specify /disk/by-id/\* names. This namespace has both partitions and
   raw disk nodes, unlike the "by-label" namespace. Downside: ugly names
   like "ata-KINGSTON_SH103S3120G_50026B722600AA5F".
