### PR TITLE
Fixed idris wrapper to make idris work with different backends.

### DIFF
--- a/pkgs/development/compilers/idris/wrapper.nix
+++ b/pkgs/development/compilers/idris/wrapper.nix
@@ -6,5 +6,6 @@ runCommand "idris-wrapper" {} ''
   ln -s ${idris_plain}/bin/idris $out/bin
       wrapProgram $out/bin/idris \
         --suffix NIX_CFLAGS_COMPILE : '"-I${gmp}/include -L${gmp}/lib -L${boehmgc}/lib"' \
-        --suffix PATH : ${gcc}/bin
+        --suffix PATH : ${gcc}/bin \
+        --suffix PATH : ${idris_plain}/bin
 ''


### PR DESCRIPTION
When compiling with different backends idris needs access to other binaries from idris_plain e.g.:

```
idris --codegen javascript Test.idr -o Test.js
```

Idris would complain about no `idris-javascript` in the environment.
