### PR TITLE
glibcLocales: cleaner environment handling

### DIFF
--- a/pkgs/applications/version-management/veracity/default.nix
+++ b/pkgs/applications/version-management/veracity/default.nix
@@ -32,7 +32,6 @@ rec {
     export HOME=$PWD/pseudo-home
     export LC_ALL=en_US.UTF-8
     export LANG=en_US.UTF-8
-    ${if a.stdenv.isLinux then "export LOCALE_ARCHIVE=${a.glibcLocales}/lib/locale/locale-archive;" else ""}
     make test || true
   '' else "") ["doMake" "minInit"];
 

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -29,11 +29,10 @@ in
         # There is no Hackage for Agda so we require src.
         inherit (self) src name;
 
-        buildInputs = [ Agda ] ++ self.buildDepends;
+        buildInputs = [ Agda glibcLocales ] ++ self.buildDepends;
         buildDepends = [];
         # Not much choice here ;)
         LANG = "en_US.UTF-8";
-        LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
 
         everythingFile = "Everything.agda";
 

--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -94,7 +94,7 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
             # default buildInputs are just ghc, if more buildInputs are required
             # buildInputs can be extended by the client by using extraBuildInputs,
             # but often propagatedBuildInputs is preferable anyway
-            buildInputs = [ghc Cabal] ++ self.extraBuildInputs;
+            buildInputs = [ghc Cabal glibcLocales] ++ self.extraBuildInputs;
             extraBuildInputs = self.buildTools ++
                                (optionals self.doCheck self.testDepends) ++
                                (optional self.hyperlinkSource hscolour) ++
@@ -176,7 +176,6 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
 
             # GHC needs the locale configured during the Haddock phase.
             LANG = "en_US.UTF-8";
-            LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
 
             # compiles Setup and configures
             configurePhase = ''

--- a/pkgs/development/compilers/pakcs/default.nix
+++ b/pkgs/development/compilers/pakcs/default.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     # Some comments in files are in UTF-8, so include the locale needed by GHC runtime.
-    export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
     export LC_ALL=en_US.UTF-8
 
     # Set up link to cymake, which has been built already.

--- a/pkgs/development/libraries/glibc/2.19/locales.nix
+++ b/pkgs/development/libraries/glibc/2.19/locales.nix
@@ -6,7 +6,7 @@
    http://sourceware.org/cgi-bin/cvsweb.cgi/libc/localedata/SUPPORTED?cvsroot=glibc
 */
 
-{ stdenv, fetchurl, allLocales ? true, locales ? ["en_US.UTF-8/UTF-8"] }:
+{ stdenv, fetchurl, writeText, allLocales ? true, locales ? ["en_US.UTF-8/UTF-8"] }:
 
 let build = import ./common.nix; in
 
@@ -41,6 +41,11 @@ build null {
     ''
       mkdir -p "$out/lib/locale"
       cp -v "$TMPDIR/$NIX_STORE/"*"/lib/locale/locale-archive" "$out/lib/locale"
+    '';
+
+  setupHook = writeText "locales-setup-hook.sh"
+    ''
+      export LOCALE_ARCHIVE=@out@/lib/locale/locale-archive
     '';
 
   meta.description = "Locale information for the GNU C Library";

--- a/pkgs/misc/source-and-tags/default.nix
+++ b/pkgs/misc/source-and-tags/default.nix
@@ -59,7 +59,7 @@ args: with args; {
                     # without this creating tag files for lifted-base fails
                     export LC_ALL=en_US.UTF-8
                     export LANG=en_US.UTF-8
-                    ${if args.stdenv.isLinux then "export LOCALE_ARCHIVE=${args.pkgs.glibcLocales}/lib/locale/locale-archive;" else ""}
+                    ${args.stdenv.lib.optionalString (args.pkgs.glibcLocales != null) "export LOCALE_ARCHIVE=${args.pkgs.glibcLocales}/lib/locale/locale-archive;"}
  
                     ${toString hasktags}/bin/hasktags --ignore-close-implementation --ctags .
                     mv tags \$TAG_FILE

--- a/pkgs/servers/dict/dictd-wiktionary.nix
+++ b/pkgs/servers/dict/dictd-wiktionary.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/dictd/
     cd $out/share/dictd
 
-    export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
     python -O ${convert} ${data}
     dictzip wiktionary-en.dict
     echo en_US.UTF-8 > locale

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5001,7 +5001,8 @@ let
     installLocales = config.glibc.locales or false;
   };
 
-  glibcLocales = callPackage ../development/libraries/glibc/2.19/locales.nix { };
+  # Not supported on Darwin
+  glibcLocales = if (! stdenv.isDarwin) then (callPackage ../development/libraries/glibc/2.19/locales.nix { }) else null;
 
   glibcInfo = callPackage ../development/libraries/glibc/2.19/info.nix { };
 
@@ -6795,7 +6796,6 @@ let
   agdaIowaStdlib = callPackage ../development/libraries/agda/agda-iowa-stdlib {};
 
   agda = callPackage ../build-support/agda {
-    glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
     extension = self : super : {};
     Agda = haskellPackages.Agda;
     inherit writeScriptBin;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -99,7 +99,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
     hscolour = self.hscolourBootstrap;
     inherit enableLibraryProfiling enableCheckPhase
       enableStaticLibraries enableSharedLibraries enableSharedExecutables;
-    glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
     extension = self : super : {};
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -40,9 +40,6 @@ let
 
   # helpers
 
-  # glibcLocales doesn't build on Darwin
-  localePath = optionalString (! stdenv.isDarwin) "${pkgs.glibcLocales}/lib/locale/locale-archive";
-
   callPackage = pkgs.newScope pythonPackages;
 
   # global distutils config used by buildPythonPackage
@@ -2321,8 +2318,9 @@ let
       sha256 = "0qk8fv8cszzqpdi3wl9vvkym1jil502ycn6sic4jrxckw5s9jsfj";
     };
 
+    buildInputs = [ pkgs.glibcLocales ];
+
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
@@ -3475,8 +3473,9 @@ let
       md5 = "92978492871342ad64e8ae0ccfcf200c";
     };
 
+    buildInputs = [ pkgs.glibcLocales ];
+
     preConfigure = ''
-      export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
       export LC_ALL="en_US.UTF-8"
     '';
 
@@ -4033,11 +4032,10 @@ let
     };
 
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
-    buildInputs = [ six ];
+    buildInputs = [ six pkgs.glibcLocales ];
 
     meta = with stdenv.lib; {
       description = "Library collecting some useful snippets";
@@ -4794,13 +4792,13 @@ let
     doCheck = false;
 
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
     buildInputs = [
       pkgs.libjpeg pkgs.freetype pkgs.zlib
       pillow twitter pyfiglet requests arrow dateutil modules.readline
+      pkgs.glibcLocales
     ];
 
     meta = {
@@ -4966,9 +4964,10 @@ let
 
     # some files in tests dir include unicode names
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     propagatedBuildInputs = [ argparse jinja2 six modules.readline ] ++
                             (optionals isPy26 [ importlib ordereddict ]);
@@ -5009,9 +5008,10 @@ let
     };
 
     preCheck = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     meta = {
       homepage = http://alastair/python-musicbrainz-ngs;
@@ -5815,12 +5815,14 @@ let
     };
 
     preConfigure = ''
-      export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
       export LC_ALL="en_US.UTF-8"
     '';
 
-    # Test data not provided
-    #buildInputs = [nose mock];
+    buildInputs = [
+      pkgs.glibcLocales
+      # Test data not provided
+      #nose mock
+    ];
     doCheck = false;
 
     propagatedBuildInputs = [jinja2 pygments docutils pytz unidecode six dateutil feedgenerator blinker pillow beautifulsoup4];
@@ -6091,8 +6093,9 @@ let
 
     preCheck = ''
       export LANG="en_US.UTF-8"
-      export LOCALE_ARCHIVE=${localePath}
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     meta = {
       description = "Simple Python library for easily displaying tabular data in a visually appealing ASCII table format";
@@ -7945,11 +7948,10 @@ let
       sha256 = "099sc7ajpp6hbgrx3c0bl6hhkz1mhnr0ahvc7s4i3f3b7q1zfn7l";
     };
 
-    buildInputs = [ pkgs.geos ];
+    buildInputs = [ pkgs.geos pkgs.glibcLocales ];
 
     preConfigure = ''
       export LANG="en_US.UTF-8";
-      export LOCALE_ARCHIVE=${localePath}
     '';
 
     patchPhase = ''
@@ -8007,8 +8009,9 @@ let
 
     preCheck = ''
       export LANG="en_US.UTF-8"
-      export LOCALE_ARCHIVE=${localePath}
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     meta = with stdenv.lib; {
       description = "A Python library for symbolic mathematics";
@@ -8070,10 +8073,9 @@ let
 
     preCheck = ''
       export LANG="en_US.UTF-8"
-      export LOCALE_ARCHIVE=${localePath}
     '';
 
-    buildInputs = [ pytest py mock ];
+    buildInputs = [ pytest py mock pkgs.glibcLocales ];
 
     meta = with stdenv.lib; {
       maintainers = [ maintainers.iElectric ];
@@ -8531,7 +8533,6 @@ let
     version = "1.2.7";
 
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
@@ -8540,7 +8541,7 @@ let
       md5 = "6dbecef27dffc41c8cd8aab8a8b3fdfb";
     };
 
-    buildInputs = [ nose ];
+    buildInputs = [ nose pkgs.glibcLocales ];
 
     propagatedBuildInputs = [ six mock ];
 


### PR DESCRIPTION
A continuation/re-imagining of #4318, trying to make it cleaner.
- make pkgs attribute null on unsupported Darwin platform
- add setup hook to provide much-duplicated environment variable

This way, builds should find the locale archive when they add `pkgs.glibcLocales` to `buildInputs`.

My only problem is that I wasn't able to test this on Linux yet. On Darwin it works fine, since it just removes everything :grin:. I mocked the glibcLocales build and it did create the proper setup-hook with the correct path.
