### PR TITLE
Let’s compile the Mac OS X SecurityTool ourselves

### DIFF
--- a/pkgs/os-specific/darwin/osx-private-sdk/default.nix
+++ b/pkgs/os-specific/darwin/osx-private-sdk/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, python, osx_sdk }:
+
+let
+  sdkVersion = "10.9";
+in stdenv.mkDerivation {
+  name = "PrivateMacOSX${sdkVersion}.sdk";
+
+  src = fetchFromGitHub {
+    owner  = "copumpkin";
+    repo   = "OSXPrivateSDK";
+    rev    = "bde9cba13e6ae62a8e4e0f405008ea719526e7ad";
+    sha256 = "1vj3fxwp32irxjk987p7a223sm5bl5rrlajcvgy69k0wb0fp0krc";
+  };
+
+  buildInputs = [ python ];
+
+  configurePhase = "true";
+
+  buildPhase = ''
+    python PrivateSDK.py -i ${osx_sdk}/Developer/SDKs/MacOSX${sdkVersion}.sdk -o PrivateMacOSX${sdkVersion}.sdk
+  '';
+
+  installPhase = ''
+    mkdir -p $out/Developer/SDKs/
+    mv PrivateMacOSX${sdkVersion}.sdk $out/Developer/SDKs
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A private Mac OS ${version} SDK, suitable for building many of Apple's open source releases";
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.darwin;
+    license     = licenses.unfree;
+  };
+}

--- a/pkgs/os-specific/darwin/osx-sdk/default.nix
+++ b/pkgs/os-specific/darwin/osx-sdk/default.nix
@@ -1,0 +1,26 @@
+{ stdenv }:
+
+let
+  version = "10.9";
+in stdenv.mkDerivation {
+  name = "MacOSX10.9.sdk";
+
+  src = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk";
+
+  unpackPhase    = "true";
+  configurePhase = "true";
+  buildPhase     = "true";
+
+  installPhase = ''
+    mkdir -p $out/Developer/SDKs/
+    echo "Source is: $src"
+    cp -r $src $out/Developer/SDKs/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Mac OS ${version} SDK";
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.darwin;
+    license     = licenses.unfree;
+  };
+}

--- a/pkgs/os-specific/darwin/security-tool/default.nix
+++ b/pkgs/os-specific/darwin/security-tool/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, osx_private_sdk }:
+
+stdenv.mkDerivation rec {
+	version = "55115";
+  name    = "SecurityTool-${version}";
+
+  src = fetchurl {
+    url = "http://opensource.apple.com/tarballs/SecurityTool/SecurityTool-${version}.tar.gz";
+    sha256 = "0apcz4vy2z5645jhrs60wj3w27mncjjqv42h5lln36g6qs2n9113";
+  };
+
+  configurePhase = "";
+
+  # Someday we shall purge this impurity!
+  buildPhase = ''
+    /usr/bin/xcodebuild SDKROOT=${osx_private_sdk}/Developer/SDKs/PrivateMacOSX10.9.sdk/
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp build/Release/security $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command line interface to Mac OS X keychains and Security framework";
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.darwin;
+    license     = licenses.apsl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7547,6 +7547,11 @@ let
     opencflite = callPackage ../os-specific/darwin/opencflite {};
 
     xcode = callPackage ../os-specific/darwin/xcode {};
+
+    osx_sdk = callPackage ../os-specific/darwin/osx-sdk {};
+    osx_private_sdk = callPackage ../os-specific/darwin/osx-private-sdk { inherit osx_sdk; };
+
+    security_tool = callPackage ../os-specific/darwin/security-tool { inherit osx_private_sdk; };
   };
 
   devicemapper = lvm2;


### PR DESCRIPTION
This allows us to compile SecurityTool ourselves. There are several more Apple opensource projects that can be compiled this way that I'll slowly add.

Remaining sources of impurity:
- Reference to absolute path to Xcode. This should be integrated with the xcode derivation (and the iOS wrapper chain that exists under mobile development) but it's not obvious how to do that yet.
- Absolute reference to `xcodebuild`.

Adding this should make it possible for #3629 to work reasonably cleanly.
