### PR TITLE
A simple ADC downloader for upcoming darwin goodness

### DIFF
--- a/pkgs/build-support/fetchadc/builder.sh
+++ b/pkgs/build-support/fetchadc/builder.sh
@@ -1,0 +1,7 @@
+source $stdenv/setup
+
+loginpage=`curl --insecure -s -L -b cookies.txt "$url"`
+
+[[ $loginpage =~ form[^\>]+action=\"([^\"]+)\" ]] && loginurl=${BASH_REMATCH[1]}
+
+curl  --insecure -s --output "$out" -L -b cookies.txt --data "appleId=${adc_user}&accountPassword=${adc_pass}" "https://idmsa.apple.com/IDMSWebAuth/${loginurl}"

--- a/pkgs/build-support/fetchadc/default.nix
+++ b/pkgs/build-support/fetchadc/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, curl, adc_user, adc_pass }:
+
+let
+  impureEnvVars = [
+    # We borrow these environment variables from the caller to allow
+    # easy proxy configuration.  This is impure, but a fixed-output
+    # derivation like fetchurl is allowed to do so since its result is
+    # by definition pure.
+    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
+  ];
+in
+
+{ # URL to fetch.
+  url
+
+  # Hash of the downloaded file
+, sha256
+
+, # Additional curl options needed for the download to succeed.
+  curlOpts ? ""
+
+, # Name of the file.  If empty, use the basename of `url' (or of the
+  # first element of `urls').
+  name ? ""
+}:
+
+stdenv.mkDerivation {
+  name    = if name != "" then name else baseNameOf (toString url);
+  builder = ./builder.sh;
+
+  buildInputs = [ curl ];
+
+  meta = {
+    # Password-guarded files from ADC are certainly unfree, as far as we're concerned!
+    license = stdenv.lib.licenses.unfree;
+  };
+
+  outputHashAlgo = "sha256";
+  outputHash     =  sha256;
+  outputHashMode = "flat";
+
+  inherit curlOpts url adc_user adc_pass;
+
+  preferLocalBuild = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -283,6 +283,11 @@ let
     vs = vs90wrapper;
   };
 
+  fetchadc = import ../build-support/fetchadc {
+    inherit curl stdenv;
+    inherit (config) adc_user adc_pass;
+  };
+
   fetchbower = import ../build-support/fetchbower {
     inherit stdenv git;
     inherit (nodePackages) fetch-bower;


### PR DESCRIPTION
ADC = Apple Developer Connection, where they host all their SDKs and other passworded downloads.

It assumes `adc_user` and `adc_pass` in `config`. Not sure of the best way to do this sort of thing, but this seems like a decent starting point. We can now use this to stuff xcode and friends into the nix store and package them nicely.

~~**Reviewers: please make sure that I'm doing the right things to prevent hydra from caching things downloaded from ADC. I'm setting unfree license on the output, but I'm not sure that's sufficient.**~~
