### PR TITLE
haskell: network from 2.5.0.0 -> 2.6.0.2

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1741,7 +1741,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   network_2_4_1_2 = callPackage ../development/libraries/haskell/network/2.4.1.2.nix {};
   network_2_5_0_0 = callPackage ../development/libraries/haskell/network/2.5.0.0.nix {};
   network_2_6_0_2 = callPackage ../development/libraries/haskell/network/2.6.0.2.nix {};
-  network = self.network_2_5_0_0;
+  network = self.network_2_6_0_2;
 
   networkCarbon = callPackage ../development/libraries/haskell/network-carbon {};
 


### PR DESCRIPTION
The original comment for choosing to not upgrade to 2.6.0.1 was that the recent version broke HTTP.

Since this comment was removed when updating 2.6.0.1 -> 2.6.0.2, I don't see any reason not to use the latest version.
