### PR TITLE
fetchurl: resume download of curl exits with status code 18

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -25,8 +25,16 @@ tryDownload() {
     local url="$1"
     echo
     header "trying $url"
+    local curlexit=18;
+
+    # if we get error code 18, resume partial download
+    while [ $curlexit -eq 18 ]; do
+        $curl -C - --fail "$url" --output "$downloadedFile"
+        local curlexit=$?;
+    done
+
     success=
-    if $curl --fail "$url" --output "$downloadedFile"; then
+    if [ $curlexit -eq 0 ]; then
         success=1
     fi
     stopNest


### PR DESCRIPTION
Addresses failures on hydra as: http://hydra.nixos.org/build/14928592/nixlog/1/raw
