### PR TITLE
nixos: Add option services.cron.cronFiles

### DIFF
--- a/nixos/modules/services/scheduling/cron.nix
+++ b/nixos/modules/services/scheduling/cron.nix
@@ -25,6 +25,10 @@ let
     sendmailPath = "/var/setuid-wrappers/sendmail";
   };
 
+  allFiles = map (f: "\"${f}\"") (
+    [ "${systemCronJobsFile}" ] ++ config.services.cron.cronFiles
+  );
+
 in
 
 {
@@ -71,6 +75,15 @@ in
         '';
       };
 
+      cronFiles = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          A list of extra crontab files that will be read and appended to the main
+          crontab file when the cron service starts.
+        '';
+      };
+
     };
 
   };
@@ -78,14 +91,7 @@ in
 
   ###### implementation
 
-  config = mkIf config.services.cron.enable {
-
-    environment.etc = singleton
-      # The system-wide crontab.
-      { source = systemCronJobsFile;
-        target = "crontab";
-        mode = "0600"; # Cron requires this.
-      };
+  config = mkIf (config.services.cron.enable && allFiles != []) {
 
     security.setuidPrograms = [ "crontab" ];
 
@@ -100,6 +106,10 @@ in
 
         preStart =
           ''
+            rm -f /etc/crontab
+            cat ${toString allFiles} > /etc/crontab
+            chmod 0600 /etc/crontab
+
             mkdir -m 710 -p /var/cron
 
             # By default, allow all users to create a crontab.  This


### PR DESCRIPTION
This allows you to configure extra files that should be appended to your crontab. Implemented by writing to /etc/crontab when the cron service starts. Would be nicer to use a cron that supports /etc/cron.d but that would require us to patch vixie-cron.
