### PR TITLE
new: rtorrentGit

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -38,6 +38,7 @@
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
+  codyopel = "Cody Opel <codyopel@gmail.com>";
   copumpkin = "Dan Peebles <pumpkingod@gmail.com>";
   coroa = "Jonas Hörsch <jonas@chaoflow.net>";
   cstrahan = "Charles Strahan <charles.c.strahan@gmail.com>";

--- a/pkgs/tools/networking/p2p/libtorrent/git.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/git.nix
@@ -1,0 +1,28 @@
+{ stdenv, autoconf, automake, cppunit, fetchFromGitHub, pkgconfig, openssl, libsigcxx, libtool, zlib }:
+
+stdenv.mkDerivation {
+  name = "libtorrent-git";
+
+  src = fetchFromGitHub rec {
+    owner = "rakshasa";
+    repo = "libtorrent";
+    rev = "c60d2b9475804e41649356fa0301e9f770798f8d";
+    sha256 = "1x78g5yd4q0ksdsw91awz2a1ax8zyfy5b53gbbil4fpjy96vb577";
+  };
+  
+  buildInputs = [ autoconf automake cppunit pkgconfig openssl libsigcxx libtool zlib ];
+
+  configureFlags = "--disable-dependency-tracking --enable-aligned";
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://libtorrent.rakshasa.no/";
+    description = "A BitTorrent library written in C++ for *nix, with a focus on high performance and good code";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ codyopel ];
+  };
+}

--- a/pkgs/tools/networking/p2p/rtorrent/git.nix
+++ b/pkgs/tools/networking/p2p/rtorrent/git.nix
@@ -1,0 +1,63 @@
+{ stdenv, autoconf, automake, cppunit, curl, fetchFromGitHub
+, fetchurl, libsigcxx, libtool, libtorrent-git, ncurses, openssl
+, pkgconfig, zlib, xmlrpc_c
+, colorSupport ? false
+}:
+
+# NOTICE: changes since 0.9.4 break the current configuration syntax, an
+# example configuration file using the latest changes can be found at
+# https://github.com/codyopel/dotfiles/blob/master/dotfiles/rtorrent.rc
+
+stdenv.mkDerivation {
+  name = "rtorrent-git";
+
+  src = fetchFromGitHub {
+    owner = "rakshasa";
+    repo = "rtorrent";
+    rev = "7537a3c2a91d0915f1c4c89b01cd583629dc5fd4";
+    sha256 = "1xnyjjff575jfq9c542yq3rr9q03z5x6xbg84d000wkjphbq7h7q";
+  };
+
+  buildInputs = [
+    autoconf
+    automake
+    cppunit
+    libtorrent-git
+    ncurses
+    pkgconfig
+    libsigcxx
+    libtool
+    curl
+    zlib
+    openssl
+    xmlrpc_c
+  ];
+
+  configureFlags = "--with-xmlrpc-c";
+
+  # Optional patch adds support for custom configurable colors
+  # https://github.com/Chlorm/chlorm_overlay/blob/master/net-p2p/rtorrent/README.md
+
+  patches = stdenv.lib.optional colorSupport (fetchurl {
+    url = "https://gist.githubusercontent.com/codyopel/a816c2993f8013b5f4d6/raw/b952b32da1dcf14c61820dfcf7df00bc8918fec4/rtorrent-color.patch";
+    sha256 = "00gcl7yq6261rrfzpz2k8bd7mffwya0ifji1xqcvhfw50syk8965";
+  });
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  # postInstall = ''
+  #   mkdir -p $out/share/man/man1 $out/share/rtorrent
+  #   mv doc/rtorrent.1 $out/share/man/man1/rtorrent.1
+  #   mv doc/rtorrent.rc $out/share/rtorrent/rtorrent.rc
+  # '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://libtorrent.rakshasa.no/";
+    description = "An ncurses client for libtorrent, ideal for use with screen or dtach";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ codyopel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1538,6 +1538,8 @@ let
 
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };
 
+  libtorrent-git = callPackage ../tools/networking/p2p/libtorrent/git.nix { };
+
   logcheck = callPackage ../tools/system/logcheck {
     inherit (perlPackages) mimeConstruct;
   };
@@ -2129,6 +2131,8 @@ let
   rrdtool = callPackage ../tools/misc/rrdtool { };
 
   rtorrent = callPackage ../tools/networking/p2p/rtorrent { };
+
+  rtorrent-git = callPackage ../tools/networking/p2p/rtorrent/git.nix { };
 
   rubber = callPackage ../tools/typesetting/rubber { };
 


### PR DESCRIPTION
Add latest git of libtorrent and rtorrent which contains numerous C++11 changes and configuration syntax changes.  Also adds patch to rtorrent enabling support for colors.

Updated rTorrent Config File Example:
https://github.com/codyopel/dotfiles/blob/master/dotfiles/rtorrent.rc

Color Patch Details:
https://github.com/Chlorm/chlorm_overlay/blob/master/net-p2p/rtorrent/README.md
