### PR TITLE
Add Apple command-line tools

### DIFF
--- a/pkgs/build-support/fetchadc/default.nix
+++ b/pkgs/build-support/fetchadc/default.nix
@@ -10,8 +10,8 @@ let
   ];
 in
 
-{ # URL to fetch.
-  url
+{ # Path to fetch.
+  path
 
   # Hash of the downloaded file
 , sha256
@@ -19,13 +19,14 @@ in
 , # Additional curl options needed for the download to succeed.
   curlOpts ? ""
 
-, # Name of the file.  If empty, use the basename of `url' (or of the
-  # first element of `urls').
+, # Name of the file.  If empty, use the basename of `path'.
   name ? ""
 }:
 
 stdenv.mkDerivation {
-  name    = if name != "" then name else baseNameOf (toString url);
+  url = "https://developer.apple.com/downloads/download.action?path=${path}";
+
+  name    = if name != "" then name else baseNameOf path;
   builder = ./builder.sh;
 
   buildInputs = [ curl ];
@@ -39,7 +40,7 @@ stdenv.mkDerivation {
   outputHash     =  sha256;
   outputHashMode = "flat";
 
-  inherit curlOpts url adc_user adc_pass;
+  inherit curlOpts adc_user adc_pass;
 
   preferLocalBuild = true;
 }

--- a/pkgs/os-specific/darwin/command-line-tools/default.nix
+++ b/pkgs/os-specific/darwin/command-line-tools/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, callPackage, fetchadc, xpwn, xar, gzip, cpio }:
+
+let
+  cmdline_packages = stdenv.mkDerivation {
+    name = "osx-10.9-command-line-tools-packages";
+
+    src = fetchadc {
+      # Isn't this a beautiful path? Note the subtle differences before and after the slash!
+      path   = "Developer_Tools/command_line_tools_os_x_10.9_for_xcode__xcode_6/command_line_tools_for_os_x_10.9_for_xcode_6.dmg";
+      sha256 = "0zrpf73r3kfk9pdh6p6j6w1sbw7s2pp0f8rd83660r5hk1y3j5jc";
+    };
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    outputs = [ "devsdk" "cltools" ];
+
+    unpackPhase = ''
+      ${xpwn}/bin/hdutil $src extract "Command Line Tools (OS X 10.9).pkg" "Command Line Tools (OS X 10.9).pkg"
+      ${xar}/bin/xar -x -f "Command Line Tools (OS X 10.9).pkg"
+    '';
+
+    installPhase = ''
+      cp -r DevSDK_OSX109.pkg/ $devsdk
+      cp -r CLTools_Executables.pkg/ $cltools
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Basis for the Mac OS command-line tools package";
+      maintainers = with maintainers; [ copumpkin ];
+      platforms   = platforms.darwin;
+      license     = licenses.unfree;
+    };
+  };
+in {
+  sdk   = callPackage ./sdk.nix   { inherit cmdline_packages; };
+  tools = callPackage ./tools.nix { inherit cmdline_packages; };
+}

--- a/pkgs/os-specific/darwin/command-line-tools/sdk.nix
+++ b/pkgs/os-specific/darwin/command-line-tools/sdk.nix
@@ -1,0 +1,25 @@
+{ stdenv, cpio, gzip, cmdline_packages }:
+
+stdenv.mkDerivation {
+  name = "osx-command-line-sdk-10.9";
+  src  = cmdline_packages.devsdk;
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  unpackPhase = ''
+    cat $src/Payload | ${gzip}/bin/gzip -d | ${cpio}/bin/cpio -idm
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r System $out
+    cp -r usr/* $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Apple command-line tools SDK (headers and man pages)";
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.darwin;
+    license     = licenses.unfree;
+  };
+}

--- a/pkgs/os-specific/darwin/command-line-tools/tools.nix
+++ b/pkgs/os-specific/darwin/command-line-tools/tools.nix
@@ -1,0 +1,25 @@
+{ stdenv, cpio, gzip, cmdline_packages }:
+
+stdenv.mkDerivation {
+  name = "osx-command-line-sdk-10.9";
+  src  = cmdline_packages.cltools;
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  unpackPhase = ''
+    cat $src/Payload | ${gzip}/bin/gzip -d | ${cpio}/bin/cpio -idm
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r Library/Developer/CommandLineTools/Library $out
+    cp -r Library/Developer/CommandLineTools/usr/* $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Apple command-line developer tools";
+    maintainers = with maintainers; [ copumpkin ];
+    platforms   = platforms.darwin;
+    license     = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -285,7 +285,12 @@ let
 
   fetchadc = import ../build-support/fetchadc {
     inherit curl stdenv;
-    inherit (config) adc_user adc_pass;
+    adc_user = if config ? adc_user
+      then config.adc_user
+      else throw "You need an adc_user attribute in your config to download files from Apple Developer Connection";
+    adc_pass = if config ? adc_pass
+      then config.adc_pass
+      else throw "You need an adc_pass attribute in your config to download files from Apple Developer Connection";
   };
 
   fetchbower = import ../build-support/fetchbower {
@@ -7544,7 +7549,9 @@ let
 
   cramfsswap = callPackage ../os-specific/linux/cramfsswap { };
 
-  darwin = rec {
+  darwin = let
+    cmdline = callPackage ../os-specific/darwin/command-line-tools {};
+  in rec {
     cctools = forceNativeDrv (callPackage ../os-specific/darwin/cctools-port {
       cross = assert crossSystem != null; crossSystem;
       inherit maloader;
@@ -7563,6 +7570,9 @@ let
     osx_private_sdk = callPackage ../os-specific/darwin/osx-private-sdk { inherit osx_sdk; };
 
     security_tool = callPackage ../os-specific/darwin/security-tool { inherit osx_private_sdk; };
+
+    cmdline_sdk   = cmdline.sdk;
+    cmdline_tools = cmdline.tools;
   };
 
   devicemapper = lvm2;


### PR DESCRIPTION
This should add a sensible "SDK" and precompiled command-line tools from ADC, possibly suitable for bootstrapping nix on darwin someday. You'll need to configure an `adc_user` and `adc_pass` to download it. Even if we don't use the binary tools for bootstrapping, having the SDK in the store will be quite valuable when automating calls to `xcodebuild`, which will be necessary for building all sorts of nice packages from opensource.apple.com.

@shlevy, wanna check it out?
