### PR TITLE
fix "Open..." menu items in "deadbeef"

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -10,7 +10,7 @@
   akc = "Anders Claesson <akc@akc.is>";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
-  abbradar = "Nikolay Amiantov <nikoamia@gmail.com>";
+  abbradar = "Nikolay Amiantov <ab@fmap.me>";
   amiddelk = "Arie Middelkoop <amiddelk@gmail.com>";
   amorsillo = "Andrew Morsillo <andrew.morsillo@gmail.com>";
   AndersonTorres = "Anderson Torres <torres.anderson.85@gmail.com>";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8774,7 +8774,6 @@ let
   dd-agent = callPackage ../tools/networking/dd-agent { inherit (pythonPackages) tornado; };
 
   deadbeef = callPackage ../applications/audio/deadbeef {
-    gtk = gtk3;
     pulseSupport = config.pulseaudio or true;
   };
 


### PR DESCRIPTION
While using GTK3, deadbeef gets SIGTRAP when trying to use "Open" menu items because of "not having any GSettings schemas" on KDE. Workarounded by switching to gtk2; I don't want to introduce another dependency.
Also updated my e-mail.
