### PR TITLE
New packages: claws-mail-3.10.1, libetpan-1.5.

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,0 +1,86 @@
+{ fetchurl, stdenv
+, curl, dbus, dbus_glib, enchant, gtk, gnutls, gnupg, gpgme, libarchive
+, libcanberra, libetpan, libnotify, libsoup, libxml2, networkmanager, openldap
+, perl, pkgconfig, poppler, python, webkitgtk2
+
+# Build options
+# TODO: A flag to build the manual.
+# TODO: Plugins that complain about their missing dependencies, even when
+#       provided:
+#         gdata requires libgdata
+#         geolocation requires libchamplain
+#         python requires python
+, enableLdap ? false
+, enableNetworkManager ? false
+, enablePgp ? false
+, enablePluginArchive ? false
+, enablePluginFancy ? false
+, enablePluginNotificationDialogs ? true
+, enablePluginNotificationSounds ? true
+, enablePluginPdf ? false
+, enablePluginRavatar ? false
+, enablePluginRssyl ? false
+, enablePluginSmime ? false
+, enablePluginSpamassassin ? false
+, enablePluginSpamReport ? false
+, enablePluginVcalendar ? false
+, enableSpellcheck ? false
+}:
+
+with stdenv.lib;
+
+let version = "3.10.1"; in
+
+stdenv.mkDerivation {
+  name = "claws-mail-${version}";
+
+  meta = {
+    description = "The user-friendly, lightweight, and fast email client";
+    homepage = http://www.claws-mail.org/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/claws-mail/Claws%20Mail/${version}/claws-mail-${version}.tar.bz2";
+    sha256 = "634d35dee311a288fb8fcba36d26987afdcd5485730cf67d00554110f414178e";
+  };
+
+  buildInputs =
+    [ dbus dbus_glib gtk gnutls libetpan perl pkgconfig python ]
+    ++ optional enableSpellcheck enchant
+    ++ optionals (enablePgp || enablePluginSmime) [ gnupg gpgme ]
+    ++ optional enablePluginArchive libarchive
+    ++ optional enablePluginNotificationSounds libcanberra
+    ++ optional enablePluginNotificationDialogs libnotify
+    ++ optional enablePluginFancy libsoup
+    ++ optional
+      (enablePluginFancy || enablePluginRavatar || enablePluginRssyl
+        || enablePluginSpamassassin || enablePluginSpamReport
+        || enablePluginVcalendar)
+      curl
+    ++ optional enablePluginRssyl libxml2
+    ++ optional enableNetworkManager networkmanager
+    ++ optional enableLdap openldap
+    ++ optional enablePluginPdf poppler
+    ++ optional enablePluginFancy webkitgtk2;
+
+  configureFlags =
+    optional (!enableLdap) "--disable-ldap"
+    ++ optional (!enableNetworkManager) "--disable-networkmanager"
+    ++ optionals (!enablePgp) [
+      "--disable-pgpcore-plugin"
+      "--disable-pgpinline-plugin"
+      "--disable-pgpmime-plugin"
+    ]
+    ++ optional (!enablePluginArchive) "--disable-archive-plugin"
+    ++ optional (!enablePluginFancy) "--disable-fancy-plugin"
+    ++ optional (!enablePluginPdf) "--disable-pdf_viewer-plugin"
+    ++ optional (!enablePluginRavatar) "--disable-libravatar-plugin"
+    ++ optional (!enablePluginRssyl) "--disable-rssyl-plugin"
+    ++ optional (!enablePluginSmime) "--disable-smime-plugin"
+    ++ optional (!enablePluginSpamassassin) "--disable-spamassassin-plugin"
+    ++ optional (!enablePluginSpamReport) "--disable-spam_report-plugin"
+    ++ optional (!enablePluginVcalendar) "--disable-vcalendar-plugin"
+    ++ optional (!enableSpellcheck) "--disable-enchant";
+}

--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,0 +1,24 @@
+{ autoconf, automake, fetchgit, libtool, stdenv, openssl }:
+
+let version = "1.5"; in
+
+stdenv.mkDerivation {
+  name = "libetpan-${version}";
+
+  meta = with stdenv.lib; {
+    description = "An efficient, portable library for different kinds of mail access: IMAP, SMTP, POP, and NNTP";
+    homepage = http://www.etpan.org/libetpan.html;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+
+  src = fetchgit {
+    url = "git://github.com/dinhviethoa/libetpan";
+    rev = "refs/tags/" + version;
+    sha256 = "bf9465121a0fb09418215ee3474a400ea5bc5ed05a6811a2978afe4905e140c9";
+  };
+
+  buildInputs = [ autoconf automake libtool openssl ];
+
+  configureScript = "./autogen.sh";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5474,6 +5474,8 @@ let
 
   libelf = callPackage ../development/libraries/libelf { };
 
+  libetpan = callPackage ../development/libraries/libetpan { };
+
   libfm = callPackage ../development/libraries/libfm { };
   libfm-extra = callPackage ../development/libraries/libfm {
     extraOnly = true;
@@ -8733,6 +8735,10 @@ let
   chromiumDev = lowPrio (chromium.override { channel = "dev"; });
 
   cinelerra = callPackage ../applications/video/cinelerra { };
+
+  clawsMail = callPackage ../applications/networking/mailreaders/claws-mail {
+    enableNetworkManager = config.networking.networkmanager.enable or false;
+  };
 
   clipit = callPackage ../applications/misc/clipit { };
 


### PR DESCRIPTION
Adds Nix expressions for claws-mail (http://www.claws-mail.org) and a
dependency that is not already in the tree, libetpan
(http://www.etpan.org/libetpan.html).

The Claws expression has flags for toggling the build of various plugins.
