### PR TITLE
Minecraft sound with Pulseaudio

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -34,6 +34,7 @@ tryDownload() {
        # keep this inside an if statement, since on failure it doesn't abort the script
        if $curl -C - --fail "$url" --output "$downloadedFile"; then
           success=1
+          break
        else
           curlexit=$?;
        fi

--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, jre, libX11, libXext, libXcursor, libXrandr, libXxf86vm
-, mesa, openal, alsaOss }:
+, mesa, openal, alsaOss, pulseaudioSupport ? false, pulseaudio }:
 
 assert jre ? architecture;
 
@@ -23,7 +23,8 @@ stdenv.mkDerivation {
 
     # wrapper for minecraft
     export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${jre}/lib/${jre.architecture}/:${libX11}/lib/:${libXext}/lib/:${libXcursor}/lib/:${libXrandr}/lib/:${libXxf86vm}/lib/:${mesa}/lib/:${openal}/lib/
-    ${alsaOss}/bin/aoss ${jre}/bin/java -jar $out/minecraft.jar
+    ${if pulseaudioSupport then "${pulseaudio}/bin/padsp" else "${alsaOss}/bin/aoss" } \
+      ${jre}/bin/java -jar $out/minecraft.jar
     EOF
 
     chmod +x $out/bin/minecraft

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -3,7 +3,8 @@
 , bluez, sbc, udev, libcap, json_c
 , jackaudioSupport ? false, jack2 ? null
 , x11Support ? false, xlibs
-, useSystemd ? false, systemd ? null }:
+, useSystemd ? false, systemd ? null
+, ossWrapper ? false }:
 
 assert jackaudioSupport -> jack2 != null;
 
@@ -49,11 +50,13 @@ stdenv.mkDerivation rec {
     "--disable-solaris"
     "--disable-jack"
     "--disable-oss-output"
-    "--disable-oss-wrapper"
+  ] ++ stdenv.lib.optional (!ossWrapper) "--disable-oss-wrapper" ++
+  [
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--with-access-group=audio"
-  ] ++ stdenv.lib.optional jackaudioSupport "--enable-jack"
+  ]
+    ++ stdenv.lib.optional jackaudioSupport "--enable-jack"
     ++ stdenv.lib.optional stdenv.isDarwin "--with-mac-sysroot=/";
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1628,7 +1628,10 @@ let
 
   mfoc = callPackage ../tools/security/mfoc { };
 
-  minecraft = callPackage ../games/minecraft { };
+  minecraft = callPackage ../games/minecraft {
+    pulseaudioSupport = config.pulseaudio or true;
+    pulseaudio = pulseaudio.override { ossWrapper = true; };
+  };
 
   minecraft-server = callPackage ../games/minecraft-server { };
 


### PR DESCRIPTION
When using PA, I would get no or choppy sound. Switching to padsp rather than aoss fixes it.

I was careful not to change the default pulseaudio derivation as not to trigger Chromium rebuilds.

It would be better if we could get the Minecraft OpenAL to work with PA, but Minecraft supplies its own OpenAL, which we might have to somehow prevent it from doing. Running in padsp is just much easier. :)
