### PR TITLE
setup-etc.pl: Fail when symlink/rename fails

### DIFF
--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -12,8 +12,8 @@ sub atomicSymlink {
     my ($source, $target) = @_;
     my $tmp = "$target.tmp";
     unlink $tmp;
-    symlink $source, $tmp or return 1;
-    rename $tmp, $target or return 1;
+    symlink $source, $tmp or return 0;
+    rename $tmp, $target or return 0;
     return 1;
 }
 


### PR DESCRIPTION
When `atomicSymlink` can't symlink or rename, it should return failure. This is then handled with `... or die` and `... or warn` which currently never get triggered.
