### PR TITLE
udisks: update from 1.0.4 to 1.0.5

### DIFF
--- a/pkgs/os-specific/linux/udisks/1-default.nix
+++ b/pkgs/os-specific/linux/udisks/1-default.nix
@@ -3,14 +3,19 @@
 , libxslt, docbook_xsl, utillinux }:
 
 stdenv.mkDerivation rec {
-  name = "udisks-1.0.4";
+  name = "udisks-1.0.5";
 
   src = fetchurl {
     url = "http://hal.freedesktop.org/releases/${name}.tar.gz";
-    sha256 = "1xgqifddwaavmjc8c30i0mdffyirsld7c6qhfyjw7f9khwv8jjw5";
+    sha256 = "0wbg3jrv8limdgvcygf4dqin3y6d30y9pcmmk711vq571vmq5v7j";
   };
 
-  patches = [ ./purity.patch ./no-pci-db.patch ./cve-2014-0004.patch ];
+  patches = [ ./purity.patch ./no-pci-db.patch ];
+
+  preConfigure =
+    ''
+      configureFlagsArray+=(--with-systemdsystemunitdir=$out/lib/systemd/system)
+    '';
 
   postPatch =
     ''


### PR DESCRIPTION
It builds I can't test it easily, and they seem to have changed some things, so it would be best if somebody who uses udisks1 could test it.
