### PR TITLE
traceroute: depends on linux headers.

### DIFF
--- a/pkgs/tools/networking/traceroute/default.nix
+++ b/pkgs/tools/networking/traceroute/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "Tracks the route taken by packets over an IP network";
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ maintainers.koral ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Cf http://hydra.nixos.org/build/15076965/nixlog/1
