### PR TITLE
proot: User-space implementation of chroot, mount --bind and binfmt_misc

### DIFF
--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -16,10 +16,6 @@ stdenv.mkDerivation rec {
     substituteInPlace GNUmakefile --replace "/usr/local" "$out"
   '';
 
-  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
-
-
   sourceRoot = "git-export/src";
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, talloc }:
+
+stdenv.mkDerivation rec {
+  name = "proot-${version}";
+  version = "4.0.3";
+
+  src = fetchgit {
+    url = "git://github.com/cedric-vincent/proot.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "95a52b2fa47b2891eb2c6b6b0e14d42f6d48f6fd5181e359b007831f1a046e84";
+  };
+
+  buildInputs = [ talloc ];
+
+  preBuild = ''
+    substituteInPlace GNUmakefile --replace "/usr/local" "$out"
+  '';
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+
+
+
+  sourceRoot = "git-export/src";
+
+  meta = with stdenv.lib; {
+    homepage = http://proot.me;
+    description = "User-space implementation of chroot, mount --bind and binfmt_misc";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with self.stdenv.lib.maintainers; [ ianwookim ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2024,6 +2024,8 @@ let
 
   projectm = callPackage ../applications/audio/projectm { };
 
+  proot = callPackage ../tools/system/proot { };
+
   proxychains = callPackage ../tools/networking/proxychains { };
 
   proxytunnel = callPackage ../tools/misc/proxytunnel { };


### PR DESCRIPTION
Added a tool `proot`, which is a very useful tool for installing and testing a linux distribution in user space (such as cluster setup). The following is an introduction to PRoot from http://proot.me : 

PRoot is a user-space implementation of chroot, mount --bind, and binfmt_misc. This means that users don't need any privileges or setup to do things like using an arbitrary directory as the new root filesystem, making files accessible somewhere else in the filesystem hierarchy, or executing programs built for another CPU architecture transparently through QEMU user-mode. Also, developers can use PRoot as a generic Linux process instrumentation engine thanks to its extension mechanism, see CARE for an example. Technically PRoot relies on ptrace, an unprivileged system-call available in every Linux kernel.
