### PR TITLE
fontconfig: update 2.10.2 -> 2.11.1

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -27,9 +27,11 @@ with lib;
 
   config = mkIf config.fonts.enableFontConfig {
 
-    # Bring in the default (upstream) fontconfig configuration.
+    # Fontconfig 2.10 backward compatibility
+
+    # Bring in the default (upstream) fontconfig configuration, only for fontconfig 2.10
     environment.etc."fonts/fonts.conf".source =
-      pkgs.makeFontsConf { fontDirectories = config.fonts.fonts; };
+      pkgs.makeFontsConf { fontconfig = pkgs.fontconfig_210; fontDirectories = config.fonts.fonts; };
 
     environment.etc."fonts/conf.d/00-nixos.conf".text =
       ''
@@ -43,6 +45,27 @@ with lib;
               <const>hintslight</const>
             </edit>
           </match>
+
+        </fontconfig>
+      '';
+
+    # Versioned fontconfig > 2.10. Only specify font directories.
+
+    environment.etc."fonts/${pkgs.fontconfig.configVersion}/conf.d/00-nixos.conf".text =
+      ''
+        <?xml version='1.0'?>
+        <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+        <fontconfig>
+
+          <!-- Set the default hinting style to "slight". -->
+          <match target="font">
+            <edit mode="assign" name="hintstyle">
+              <const>hintslight</const>
+            </edit>
+          </match>
+
+          <!-- Font directories -->
+          ${concatStringsSep "\n" (map (font: "<dir>${font}</dir>") config.fonts.fonts)}
 
         </fontconfig>
       '';

--- a/nixos/modules/config/fonts/fonts.nix
+++ b/nixos/modules/config/fonts/fonts.nix
@@ -13,14 +13,6 @@ with lib;
         type = types.listOf types.path;
         example = literalExample "[ pkgs.dejavu_fonts ]";
         description = "List of primary font paths.";
-        apply = list: list ++
-          [ # - the user's current profile
-            "~/.nix-profile/lib/X11/fonts"
-            "~/.nix-profile/share/fonts"
-            # - the default profile
-            "/nix/var/nix/profiles/default/lib/X11/fonts"
-            "/nix/var/nix/profiles/default/share/fonts"
-          ];
       };
 
     };

--- a/pkgs/development/libraries/fontconfig/builder.sh
+++ b/pkgs/development/libraries/fontconfig/builder.sh
@@ -1,5 +1,0 @@
-source $stdenv/setup
-
-configureFlags="--with-confdir=$out/etc/fonts --disable-docs"
-
-genericBuild

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -1,13 +1,15 @@
-{ runCommand, libxslt, fontconfig, fontDirectories }:
+{ runCommand, libxslt, fontconfig, fontbhttf, fontDirectories }:
 
 runCommand "fonts.conf"
   {
     buildInputs = [ libxslt fontconfig ];
-    inherit fontDirectories;
+    # Add a default font for non-nixos systems. fontbhttf is only about 1mb.
+    fontDirectories = fontDirectories ++ [ fontbhttf ];
   }
   ''
     xsltproc --stringparam fontDirectories "$fontDirectories" \
       --stringparam fontconfig "${fontconfig}" \
+      --stringparam fontconfigConfigVersion "${fontconfig.configVersion}" \
       --path ${fontconfig}/share/xml/fontconfig \
       ${./make-fonts-conf.xsl} ${fontconfig}/etc/fonts/fonts.conf \
       > $out

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -16,25 +16,37 @@
 
   <xsl:param name="fontDirectories" />
   <xsl:param name="fontconfig" />
+  <xsl:param name="fontconfigConfigVersion" />
 
   <xsl:template match="/fontconfig">
 
     <fontconfig>
       <xsl:apply-templates select="child::node()[name() != 'dir' and name() != 'cachedir' and name() != 'include']" />
 
-      <include ignore_missing="yes">/etc/fonts/conf.d</include>
+      <!-- fontconfig distribution conf.d -->
       <include><xsl:value-of select="$fontconfig" />/etc/fonts/conf.d</include>
+      <!-- versioned system-wide config -->
+      <include ignore_missing="yes">/etc/fonts/<xsl:value-of select="$fontconfigConfigVersion" />/conf.d</include>
+      <!-- look into user config -->
+      <include prefix="xdg" ignore_missing="yes">fontconfig/conf.d</include>
 
+      <!-- the first cachedir will be used to store the cache -->
+      <cachedir prefix="xdg">fontconfig</cachedir>
+      <!-- /var/cache/fontconfig is useful for non-nixos systems -->
       <cachedir>/var/cache/fontconfig</cachedir>
-      <cachedir>~/.fontconfig</cachedir>
 
+      <dir prefix="xdg">fonts</dir>
       <xsl:for-each select="str:tokenize($fontDirectories)">
         <dir><xsl:value-of select="." /></dir>
         <xsl:text>&#0010;</xsl:text>
       </xsl:for-each>
-      <dir prefix="xdg">fonts</dir>
-      <!-- the following element will be removed in the future -->
-      <dir>~/.fonts</dir>
+
+      <!-- nix user profile -->
+      <dir>~/.nix-profile/lib/X11/fonts</dir>
+      <dir>~/.nix-profile/share/fonts</dir>
+      <!-- nix default profile -->
+      <dir>/nix/var/nix/profiles/default/lib/X11/fonts</dir>
+      <dir>/nix/var/nix/profiles/default/share/fonts</dir>
 
     </fontconfig>
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4947,11 +4947,14 @@ let
 
   cfitsio = callPackage ../development/libraries/cfitsio { };
 
+  fontconfig_210 = callPackage ../development/libraries/fontconfig/2.10.nix { };
+
   fontconfig = callPackage ../development/libraries/fontconfig { };
 
   makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
     import ../development/libraries/fontconfig/make-fonts-conf.nix {
       inherit runCommand libxslt fontconfig fontDirectories;
+      inherit (xorg) fontbhttf;
     };
 
   freealut = callPackage ../development/libraries/freealut { };


### PR DESCRIPTION
Reference: #2050 
- Retained fontconfig_210
- Search for configs under `/etc/fonts/2.11`
- Use `$fontconfig/etc/fonts.conf` instead of `/etc/fonts/fonts.conf`
- Move nix profile share/fonts and lib/X11/fonts from nixos to `makeFontsConf`. This allows applications using `makeFontsConf`, nixos and non-nixos to find fonts in the nix profile in all cases.

**Nixos**
- `/etc/fonts/2.11/conf.d/00-nixos.conf` is being created with options plus &lt;dir&gt; for each font.
- For backward-compatibility `/etc/fonts/fonts.conf` is created for fontconfig 2.10.

**Non-nixos**
- Applications with fontconfig 2.10 keeps working as they read the system `/etc/fonts/fonts.conf`.
- Applications with fontconfig 2.11 will have no fonts. Either install some font with nix-env or set `FONTCONFIG_FILE=/etc/fonts/fonts.conf`

**Tested**
- NixOS vm with fontconfig 2.11 by default. Was able to run an app with fontconfig 2.10 without any font problem.
- Non-nixos, just needed to install a random font with nix-env. Also works by setting `FONTCONFIG_FILE=/etc/fonts/fonts.conf`

**Untested**

Whether apps with custom `makeFontsConf` work properly. I see no reason for which they shouldn't.
