### PR TITLE
glibcLocales: cleaner environment handling

### DIFF
--- a/pkgs/applications/version-management/veracity/default.nix
+++ b/pkgs/applications/version-management/veracity/default.nix
@@ -32,7 +32,6 @@ rec {
     export HOME=$PWD/pseudo-home
     export LC_ALL=en_US.UTF-8
     export LANG=en_US.UTF-8
-    ${if a.stdenv.isLinux then "export LOCALE_ARCHIVE=${a.glibcLocales}/lib/locale/locale-archive;" else ""}
     make test || true
   '' else "") ["doMake" "minInit"];
 

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -29,11 +29,10 @@ in
         # There is no Hackage for Agda so we require src.
         inherit (self) src name;
 
-        buildInputs = [ Agda ] ++ self.buildDepends;
+        buildInputs = [ Agda glibcLocales ] ++ self.buildDepends;
         buildDepends = [];
         # Not much choice here ;)
         LANG = "en_US.UTF-8";
-        LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
 
         everythingFile = "Everything.agda";
 

--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -94,7 +94,7 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
             # default buildInputs are just ghc, if more buildInputs are required
             # buildInputs can be extended by the client by using extraBuildInputs,
             # but often propagatedBuildInputs is preferable anyway
-            buildInputs = [ghc Cabal] ++ self.extraBuildInputs;
+            buildInputs = [ghc Cabal glibcLocales] ++ self.extraBuildInputs;
             extraBuildInputs = self.buildTools ++
                                (optionals self.doCheck self.testDepends) ++
                                (optional self.hyperlinkSource hscolour) ++
@@ -176,7 +176,6 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
 
             # GHC needs the locale configured during the Haddock phase.
             LANG = "en_US.UTF-8";
-            LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
 
             # compiles Setup and configures
             configurePhase = ''

--- a/pkgs/development/compilers/pakcs/default.nix
+++ b/pkgs/development/compilers/pakcs/default.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     # Some comments in files are in UTF-8, so include the locale needed by GHC runtime.
-    export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
     export LC_ALL=en_US.UTF-8
 
     # Set up link to cymake, which has been built already.

--- a/pkgs/development/libraries/glibc/2.19/locales.nix
+++ b/pkgs/development/libraries/glibc/2.19/locales.nix
@@ -6,7 +6,7 @@
    http://sourceware.org/cgi-bin/cvsweb.cgi/libc/localedata/SUPPORTED?cvsroot=glibc
 */
 
-{ stdenv, fetchurl, allLocales ? true, locales ? ["en_US.UTF-8/UTF-8"] }:
+{ stdenv, fetchurl, writeText, allLocales ? true, locales ? ["en_US.UTF-8/UTF-8"] }:
 
 let build = import ./common.nix; in
 
@@ -41,6 +41,11 @@ build null {
     ''
       mkdir -p "$out/lib/locale"
       cp -v "$TMPDIR/$NIX_STORE/"*"/lib/locale/locale-archive" "$out/lib/locale"
+    '';
+
+  setupHook = writeText "locales-setup-hook.sh"
+    ''
+      export LOCALE_ARCHIVE=@out@/lib/locale/locale-archive
     '';
 
   meta.description = "Locale information for the GNU C Library";

--- a/pkgs/misc/source-and-tags/default.nix
+++ b/pkgs/misc/source-and-tags/default.nix
@@ -59,7 +59,7 @@ args: with args; {
                     # without this creating tag files for lifted-base fails
                     export LC_ALL=en_US.UTF-8
                     export LANG=en_US.UTF-8
-                    ${if args.stdenv.isLinux then "export LOCALE_ARCHIVE=${args.pkgs.glibcLocales}/lib/locale/locale-archive;" else ""}
+                    ${args.stdenv.lib.optionalString (args.pkgs.glibcLocales != null) "export LOCALE_ARCHIVE=${args.pkgs.glibcLocales}/lib/locale/locale-archive;"}
  
                     ${toString hasktags}/bin/hasktags --ignore-close-implementation --ctags .
                     mv tags \$TAG_FILE

--- a/pkgs/servers/dict/dictd-wiktionary.nix
+++ b/pkgs/servers/dict/dictd-wiktionary.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/dictd/
     cd $out/share/dictd
 
-    export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
     python -O ${convert} ${data}
     dictzip wiktionary-en.dict
     echo en_US.UTF-8 > locale

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5011,7 +5011,8 @@ let
     installLocales = config.glibc.locales or false;
   };
 
-  glibcLocales = callPackage ../development/libraries/glibc/2.19/locales.nix { };
+  # Not supported on Darwin
+  glibcLocales = if (! stdenv.isDarwin) then (callPackage ../development/libraries/glibc/2.19/locales.nix { }) else null;
 
   glibcInfo = callPackage ../development/libraries/glibc/2.19/info.nix { };
 
@@ -6807,7 +6808,6 @@ let
   ### DEVELOPMENT / LIBRARIES / AGDA
 
   agda = callPackage ../build-support/agda {
-    glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
     extension = self : super : {};
     Agda = haskellPackages.Agda;
     inherit writeScriptBin;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -99,7 +99,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
     hscolour = self.hscolourBootstrap;
     inherit enableLibraryProfiling enableCheckPhase
       enableStaticLibraries enableSharedLibraries enableSharedExecutables;
-    glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
     extension = self : super : {};
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2337,8 +2337,9 @@ let
       sha256 = "0qk8fv8cszzqpdi3wl9vvkym1jil502ycn6sic4jrxckw5s9jsfj";
     };
 
+    buildInputs = [ pkgs.glibcLocales ];
+
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
@@ -3510,10 +3511,10 @@ let
     };
 
     preConfigure = ''
-      export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
       export LC_ALL="en_US.UTF-8"
     '';
 
+    buildInputs = [ pkgs.glibcLocales ];
     propagatedBuildInputs = [ six pytz ];
 
     meta = {
@@ -4085,11 +4086,10 @@ let
     };
 
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
-    buildInputs = [ six ];
+    buildInputs = [ six pkgs.glibcLocales ];
 
     meta = with stdenv.lib; {
       description = "Library collecting some useful snippets";
@@ -4866,13 +4866,13 @@ let
     doCheck = false;
 
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
     buildInputs = [
       pkgs.libjpeg pkgs.freetype pkgs.zlib
       pillow twitter pyfiglet requests arrow dateutil modules.readline
+      pkgs.glibcLocales
     ];
 
     meta = {
@@ -5038,9 +5038,10 @@ let
 
     # some files in tests dir include unicode names
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     propagatedBuildInputs = [ argparse jinja2 six modules.readline ] ++
                             (optionals isPy26 [ importlib ordereddict ]);
@@ -5081,9 +5082,10 @@ let
     };
 
     preCheck = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     meta = {
       homepage = http://alastair/python-musicbrainz-ngs;
@@ -6163,8 +6165,9 @@ let
 
     preCheck = ''
       export LANG="en_US.UTF-8"
-      export LOCALE_ARCHIVE=${localePath}
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     meta = {
       description = "Simple Python library for easily displaying tabular data in a visually appealing ASCII table format";
@@ -8038,11 +8041,10 @@ let
       sha256 = "099sc7ajpp6hbgrx3c0bl6hhkz1mhnr0ahvc7s4i3f3b7q1zfn7l";
     };
 
-    buildInputs = [ pkgs.geos ];
+    buildInputs = [ pkgs.geos pkgs.glibcLocales ];
 
     preConfigure = ''
       export LANG="en_US.UTF-8";
-      export LOCALE_ARCHIVE=${localePath}
     '';
 
     patchPhase = ''
@@ -8100,8 +8102,9 @@ let
 
     preCheck = ''
       export LANG="en_US.UTF-8"
-      export LOCALE_ARCHIVE=${localePath}
     '';
+
+    buildInputs = [ pkgs.glibcLocales ];
 
     meta = with stdenv.lib; {
       description = "A Python library for symbolic mathematics";
@@ -8163,10 +8166,9 @@ let
 
     preCheck = ''
       export LANG="en_US.UTF-8"
-      export LOCALE_ARCHIVE=${localePath}
     '';
 
-    buildInputs = [ pytest py mock ];
+    buildInputs = [ pytest py mock pkgs.glibcLocales ];
 
     meta = with stdenv.lib; {
       maintainers = [ maintainers.iElectric ];
@@ -8624,7 +8626,6 @@ let
     version = "1.2.7";
 
     preBuild = ''
-      export LOCALE_ARCHIVE=${localePath}
       export LC_ALL="en_US.UTF-8"
     '';
 
@@ -8633,7 +8634,7 @@ let
       md5 = "6dbecef27dffc41c8cd8aab8a8b3fdfb";
     };
 
-    buildInputs = [ nose ];
+    buildInputs = [ nose pkgs.glibcLocales ];
 
     propagatedBuildInputs = [ six mock ];
 


### PR DESCRIPTION
- make pkgs attribute null on unsupported Darwin platform
- add setup hook to provide much-duplicated environment variable

There are still some locations where LOCALE_ARCHIVE is set manually, these are special cases not using the default builder.

This is needed to be able to install nixops on Darwin.

@edolstra @joelteon @copumpkin ? Note that this is a PR for the darwin-clang-stdenv branch.
