### PR TITLE
git: Provide GIT_SSL_CAINFO if missing

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -83,6 +83,13 @@ stdenv.mkDerivation {
       # gitweb.cgi, need to patch so that it's found
       sed -i -e "s|'compressor' => \['gzip'|'compressor' => ['${gzip}/bin/gzip'|" \
           $out/share/gitweb/gitweb.cgi
+
+      # make sure it finds the CA certificates
+      # SSL_CERT_FILE is set by etc/profile.d/nix.sh
+      for f in $(grep -rl GIT_SSL_CAINFO $out/libexec/git-core/); do
+        wrapProgram "$f" \
+            --run '[ -z "$GIT_SSL_CAINFO" -a -n "$SSL_CERT_FILE" ] && export GIT_SSL_CAINFO="$SSL_CERT_FILE"'
+      done
     ''
 
    + (if svnSupport then


### PR DESCRIPTION
This wraps the git components that depend on cacert, and sets `$GIT_SSL_CAINFO` to `$SSL_CERT_FILE` if it is set.

This way, git installed outside of NixOS also has access to the CA certs, and there's only one environment variable needed in NixOS.
