### PR TITLE
pysocks: Fix license typo

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6880,7 +6880,7 @@ let
 
     meta = {
       description = "SOCKS module for Python";
-      license     = licenses.bsd;
+      license     = licenses.bsd3;
       maintainers = [ maintainers.thoughtpolice ];
     };
   };


### PR DESCRIPTION
@thoughtpolice 

See cf58933a9b71a5096aa0675f493796e4dc6a51fa
