### PR TITLE
Use "pipefail" in setup.sh

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,4 +1,5 @@
 set -e
+set -o pipefail
 
 : ${outputs:=out}
 
@@ -568,10 +569,6 @@ patchPhase() {
 
     for i in $patches; do
         header "applying patch $i" 3
-        if [ ! -r "$i" ]; then
-            echo "file $i does not exist or not readable"
-            exit 1
-        fi
         local uncompress=cat
         case "$i" in
             *.gz)


### PR DESCRIPTION
Instead of checking if patches exist (and to possibly prevent such bugs in future) we can just enable pipefail for the whole script. I've looked through it and I think that nothing should break (we don't have possibly failing pipes besides patch uncompressing one). cc @edolstra , #4445
