### PR TITLE
ocaml 4.02: makes dependency to campl4 explicit

### DIFF
--- a/pkgs/development/ocaml-modules/http/default.nix
+++ b/pkgs/development/ocaml-modules/http/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml_pcre, ocamlnet, ocaml, findlib}:
+{stdenv, fetchurl, ocaml_pcre, ocamlnet, ocaml, findlib, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "070xw033r4pk6f4l0wcknm75y9qm4mp622a4cgzmcfhm58v6kssn";
   };
 
-  buildInputs = [ocaml_pcre ocamlnet ocaml findlib];
+  buildInputs = [ocaml_pcre ocamlnet ocaml findlib camlp4];
 
   createFindlibDestdir = true;
 
@@ -30,10 +30,10 @@ stdenv.mkDerivation {
     make all opt
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://upsilon.cc/~zack/hacking/software/ocaml-http/";
     description = "do it yourself (OCaml) HTTP daemon";
-    license = stdenv.lib.licenses.lgpl2;
-    maintainers = [ stdenv.lib.maintainers.roconnor ];
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ roconnor vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, lablgtk, findlib, mesa, freeglut } :
+{stdenv, fetchurl, ocaml, lablgtk, findlib, mesa, freeglut, camlp4 } :
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "0qabydd219i4ak7hxgc67496qnnscpnydya2m4ijn3cpbgih7zyq";
   };
 
-  buildInputs = [ocaml findlib lablgtk freeglut ];
+  buildInputs = [ocaml findlib lablgtk freeglut camlp4];
   propagatedBuildInputs = [ mesa ];
 
   patches = [ ./Makefile.config.patch ./META.patch ];

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, ocaml_typeconv, ounit}:
+{stdenv, fetchurl, ocaml, findlib, ocaml_typeconv, ounit, camlp4}:
 
 stdenv.mkDerivation {
   name = "ocaml-data-notation-0.0.11";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "09a8zdyifpc2nl4hdvg9206142y31cq95ajgij011s1qcg3z93lj";
   };
 
-  buildInputs = [ocaml findlib ocaml_typeconv ounit];
+  buildInputs = [ocaml findlib ocaml_typeconv ounit camlp4];
 
   createFindlibDestdir = true;
 
@@ -16,13 +16,13 @@ stdenv.mkDerivation {
   buildPhase     = "ocaml setup.ml -build";
   installPhase   = "ocaml setup.ml -install";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Store data using OCaml notation";
     homepage = https://forge.ocamlcore.org/projects/odn/;
-    license = stdenv.lib.licenses.lgpl21;
+    license = licenses.lgpl21;
     platforms = ocaml.meta.platforms;
-    maintainers = with stdenv.lib.maintainers; [
-      z77z
+    maintainers = with maintainers; [
+      vbgl z77z
     ];
   };
 }

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, ocaml_data_notation, ocaml_typeconv,
+{stdenv, fetchurl, ocaml, findlib, ocaml_data_notation, ocaml_typeconv, camlp4,
  ocamlmod, ocamlify, ounit, expect}:
 
 stdenv.mkDerivation {
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [
-      ocaml findlib ocaml_typeconv ocamlmod ocamlify ounit
+      ocaml findlib ocaml_typeconv ocamlmod ocamlify ounit camlp4
     ];
 
   propagatedBuildInputs = [ ocaml_data_notation ];
@@ -22,13 +22,13 @@ stdenv.mkDerivation {
   buildPhase     = "ocaml setup.ml -build";
   installPhase   = "ocaml setup.ml -install";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://oasis.forge.ocamlcore.org/;
     description = "Configure, build and install system for OCaml projects";
-    license = stdenv.lib.licenses.lgpl21;
+    license = licenses.lgpl21;
     platforms = ocaml.meta.platforms;
-    maintainers = with stdenv.lib.maintainers; [
-      z77z
+    maintainers = with maintainers; [
+      vbgl z77z
     ];
   };
 }


### PR DESCRIPTION
From version 4.02 of OCaml, camlp4 is now packaged separately. Some packages have then an extra dependency.
