### PR TITLE
Xmobar 0.22

### DIFF
--- a/pkgs/applications/misc/xmobar/default.nix
+++ b/pkgs/applications/misc/xmobar/default.nix
@@ -3,13 +3,13 @@
 { cabal, alsaCore, alsaMixer, dbus, filepath, hinotify, HTTP
 , libmpd, libXrandr, mtl, parsec, regexCompat, stm, time
 , timezoneOlson, timezoneSeries, utf8String, wirelesstools, X11
-, X11Xft
+, X11Xft, libXpm
 }:
 
 cabal.mkDerivation (self: {
   pname = "xmobar";
-  version = "0.21";
-  sha256 = "1h0gsb808zm4j4kmw7fl4339wllc16ldy1ki96l8w3fvj30bcxpm";
+  version = "0.22";
+  sha256 = "158q2mcdn58jjli3wh3zlcjchrzz9krdgvx39n8qdl6a9pgmf8bd";
   isLibrary = false;
   isExecutable = true;
   buildDepends = [
@@ -17,7 +17,7 @@ cabal.mkDerivation (self: {
     regexCompat stm time timezoneOlson timezoneSeries utf8String X11
     X11Xft
   ];
-  extraLibraries = [ libXrandr wirelesstools ];
+  extraLibraries = [ libXrandr wirelesstools libXpm ];
   configureFlags = "-fall_extensions";
   meta = {
     homepage = "http://xmobar.org";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2694,6 +2694,19 @@ let
 
   xmltv = callPackage ../tools/misc/xmltv { };
 
+  xmobar = let haskellPackagesExt = haskellPackages.override {
+      extension = self : super : {
+        # We need to disable tests unfortunately because doctest
+        # does not work with transformers-overrides, because it
+        # uses the GHC API.
+        cabal = super.cabal.override { enableCheckPhase = false; };
+
+        transformers = self.transformers_0_4_1_0;
+        mtl = self.mtl_2_2_1;
+      };
+    };
+    in haskellPackagesExt.callPackage ../applications/misc/xmobar {};
+
   xmpppy = builderDefsPackage (import ../development/python-modules/xmpppy) {
     inherit python setuptools;
   };

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -3071,10 +3071,6 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   xlsx = callPackage ../development/libraries/haskell/xlsx {};
 
-  xmobar = callPackage ../applications/misc/xmobar {
-    libmpd = self.libmpd_0_8_0_5;
-  };
-
   xmonad = callPackage ../applications/window-managers/xmonad {};
 
   xmonadContrib = callPackage ../applications/window-managers/xmonad/xmonad-contrib.nix {};


### PR DESCRIPTION
Requires mtl 2.2, so I moved it to all-packages and gave it that... Also disabled testing because doctest (used by distributive) uses the GHC API.

Is there a better way?

CC @peti @rejuvyesh
