### PR TITLE
Generalize GHC to haskellCompiler in the Haskell infrastrucutre of Nix.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3169,7 +3169,7 @@ let
   ghc = recurseIntoAttrs (lib.mapAttrs' (name: value:
     lib.nameValuePair (builtins.substring (builtins.stringLength "packages_") (builtins.stringLength name) name) value.ghc
   ) (lib.filterAttrs (name: value:
-    builtins.substring 0 (builtins.stringLength "packages_") name == "packages_"
+    builtins.substring 0 (builtins.stringLength "packages_ghc") name == "packages_ghc"
   ) haskell));
 
   haskellPackages = haskellPackages_ghc783;

--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -145,20 +145,26 @@
 
   # Abstraction for Haskell packages collections
   packagesFun = makeOverridable
-   ({ ghcPath
+   ({ ghcPath ? null
+    , haskellCompiler ? callPackage ghcPath ({ ghc = ghcBinary; } // extraArgs)
     , ghcBinary ? ghc6101Binary
     , prefFun
     , extension ? (self : super : {})
     , profExplicit ? false, profDefault ? false
     , modifyPrio ? lowPrio
     , extraArgs ? {}
+    , cabalPackage ? import ../build-support/cabal/default.nix
+    , haskellCompilerWrapperPackage ? import ../development/compilers/ghc/wrapper.nix
+    , haskellCompilerWithPackagesPackage ? import ../development/compilers/ghc/with-packages.nix
+    , haskellCompilerBinaryName ? "ghc"
     } :
     let haskellPackagesClass = import ./haskell-packages.nix {
-          inherit pkgs newScope modifyPrio;
+          inherit pkgs newScope modifyPrio cabalPackage;
           enableLibraryProfiling =
             if profExplicit then profDefault
                             else config.cabal.libraryProfiling or profDefault;
-          ghc = callPackage ghcPath ({ ghc = ghcBinary; } // extraArgs);
+          inherit haskellCompiler;
+          inherit haskellCompilerWrapperPackage haskellCompilerWithPackagesPackage haskellCompilerBinaryName;
         };
         haskellPackagesPrefsClass = self : let super = haskellPackagesClass self; in super // prefFun self super;
         haskellPackagesExtensionClass = self : let super = haskellPackagesPrefsClass self; in super // extension self super;


### PR DESCRIPTION
That PR generalizes the Haskell infrastructure in Nix from GHC to any haskellCompiler. It does not trigger any actual changes to the packages or derivations in Nix. It only provides hooks that different compiler can fill with their specific functions.
