### PR TITLE
Update Pure to 0.62 and fix propagatedBuildInputs

### DIFF
--- a/pkgs/development/interpreters/pure/default.nix
+++ b/pkgs/development/interpreters/pure/default.nix
@@ -1,52 +1,33 @@
-x@{builderDefsPackage
-  , llvm, gmp, mpfr, readline, bison, flex, makeWrapper
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ lib, stdenv, fetchurl, makeWrapper,
+  llvm, gmp, mpfr, readline, bison, flex }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    baseName="pure";
-    project="pure-lang";
-    version="0.58";
-    name="${baseName}-${version}";
-    extension="tar.gz";
+stdenv.mkDerivation rec {
+  baseName="pure";
+  project="pure-lang";
+  version="0.62";
+  name="${baseName}-${version}";
+  extension="tar.gz";
+
+  src = fetchurl {
     url="https://bitbucket.org/purelang/${project}/downloads/${name}.${extension}";
-    hash="180ygv8nmfy8v4696km8jdahn5cnr454sc8i1av7s6z4ss7mrxmi";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
+    sha256="77df64e8154ef6f8fac66f8bcc471dc8f994862d1ee77b7c98003607757a013b";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  buildInputs = [ bison flex makeWrapper ];
+  propagatedBuildInputs = [ llvm gmp mpfr readline ];
 
-  /* doConfigure should be removed if not needed */
-  phaseNames = ["doConfigure" "doMakeInstall" "doWrap"];
-
-  doWrap = a.makeManyWrappers ''$out/bin/pure'' ''--prefix LD_LIBRARY_PATH : "${llvm}/lib"'';
+  postInstall = ''
+    wrapProgram $out/bin/pure --prefix LD_LIBRARY_PATH : ${llvm}/lib
+  '';
 
   meta = {
-    description = "A purely functional programming language based on term rewriting";
-    maintainers = with a.lib.maintainers;
+    description = "A modern-style functional programming language based on term rewriting";
+    maintainers = with lib.maintainers;
     [
       raskin
     ];
-    platforms = with a.lib.platforms;
+    platforms = with lib.platforms;
       linux;
-    license = a.lib.licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "https://bitbucket.org/purelang/pure-lang/downloads";
-    };
-  };
-}) x
-
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3924,7 +3924,7 @@ let
   polyml = callPackage ../development/compilers/polyml { };
 
   pure = callPackage ../development/interpreters/pure {
-    llvm = llvm_33 ;
+    llvm = llvm_34 ;
   };
 
   python = python2;


### PR DESCRIPTION
This also changes from `builderDefsPackage` to `mkDerivation`, which I understand from the mailing list is preferred.
