### PR TITLE
apulse: add pkg

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -67,6 +67,7 @@
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";
   iElectric = "Domen Kozar <domen@dev.si>";
   iyzsong = "Song Wenwu <iyzsong@gmail.com>";
+  jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
   jcumming = "Jack Cummings <jack@mudshark.org>";
   jgeerds = "Jascha Geerds <jg@ekby.de>";
   joamaki = "Jussi Maki <joamaki@gmail.com>";

--- a/pkgs/applications/audio/moc/default.nix
+++ b/pkgs/applications/audio/moc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "An ncurses console audio player designed to be powerful and easy to use";
     homepage = http://moc.daper.net/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [ pSub jagajaga ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, alsaLib, cmake, pkgconfig, glib }:
+
+stdenv.mkDerivation rec {
+  name = "apulse-${version}";
+  version = "0.1.2";
+
+  src = fetchurl {
+    url = "https://github.com/i-rinat/apulse/archive/v${version}.tar.gz";
+    sha256 = "02906a8iwwjzzkjvhqqai2yd1636cgz9vl69vwq0vkv2v6cn21ky";
+  };
+
+  buildInputs =
+    [ alsaLib cmake pkgconfig glib ];
+
+  meta = with stdenv.lib; {
+    description = "PulseAudio emulation for ALSA.";
+    homepage = "https://github.com/i-rinat/apulse";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.jagajaga ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -476,6 +476,8 @@ let
 
   apt-offline = callPackage ../tools/misc/apt-offline { };
 
+  apulse = callPackage ../misc/apulse { };
+
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };


### PR DESCRIPTION
PulseAudio emulation for ALSA.

This program can help to stark skype without pulseaudio.
