### PR TITLE
logstash service: make log verbosity configurable.

### DIFF
--- a/nixos/modules/services/logging/logstash.nix
+++ b/nixos/modules/services/logging/logstash.nix
@@ -7,6 +7,13 @@ let
   pluginPath = lib.concatStringsSep ":" cfg.plugins;
   havePluginPath = lib.length cfg.plugins > 0;
   ops = lib.optionalString;
+  verbosityFlag = {
+    debug = "--debug";
+    info  = "--verbose";
+    warn  = ""; # intentionally empty
+    error = "--quiet";
+    fatal = "--silent";
+  }."${cfg.logLevel}";
 
 in
 
@@ -35,6 +42,12 @@ in
         default = [ ];
         example = literalExample "[ pkgs.logstash-contrib ]";
         description = "The paths to find other logstash plugins in.";
+      };
+
+      logLevel = mkOption {
+        type = types.enum [ "debug" "info" "warn" "error" "fatal" ];
+        default = "warn";
+        description = "Logging verbosity level.";
       };
 
       watchdogTimeout = mkOption {
@@ -124,6 +137,7 @@ in
           "${cfg.package}/bin/logstash agent " +
           "-w ${toString cfg.filterWorkers} " +
           ops havePluginPath "--pluginpath ${pluginPath} " +
+          "${verbosityFlag} " +
           "--watchdog-timeout ${toString cfg.watchdogTimeout} " +
           "-f ${writeText "logstash.conf" ''
             input {


### PR DESCRIPTION
The log verbosity level is now configurable.

The logstash docs don't mention all of the verbosity flags, but you can view them here: https://github.com/elasticsearch/logstash/commit/9b5a60d561ec014b5ba7d27997ac80f320aeeff5#diff-4fbd59cdf63cce1b9ce69be1aa58c28dR120
