### PR TITLE
texlive: Update to latest release 2014.20140927

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -1,20 +1,20 @@
 args : with args;
 rec {
   src = fetchurl {
-    url = mirror://debian/pool/main/t/texlive-bin/texlive-bin_2014.20140528.34243.orig.tar.xz;
-    sha256 = "0nh8hfayyf60nm4z8zyclrbc3792c62azgsvrwxnl28iq223200s";
+    url = mirror://debian/pool/main/t/texlive-bin/texlive-bin_2014.20140926.35254.orig.tar.xz;
+    sha256 = "1c39x059jhn5jsy6i9j3akjbkm1kmmzssy1jyi1aw20rl2vp86w3";
   };
 
-  texmfVersion = "2014.20140821";
+  texmfVersion = "2014.20140927";
   texmfSrc = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-base/texlive-base_${texmfVersion}.orig.tar.xz";
-    sha256 = "02qkzlhb381sybs970fgpc94nhx4jm0l3j5pv8z48l11415lvm9b";
+    sha256 = "1g4nzr9rgmw8i0i82svmkwjy2kvbyrc8jgnk2f3cl2wsx7sfrydy";
   };
 
-  langTexmfVersion = "2014.20140821";
+  langTexmfVersion = "2014.20140927";
   langTexmfSrc = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-lang/texlive-lang_${langTexmfVersion}.orig.tar.xz";
-    sha256 = "075avhhhhzw5pbd19q659rn23rws15b5hv7nv0grd93vn3vfwdcy";
+    sha256 = "1ckm8yra96m44n708dc1kgq4xrzi7ginxpsb73ijbwzbjy1yqzwg";
   };
 
   passthru = { inherit texmfSrc langTexmfSrc; };
@@ -115,7 +115,8 @@ rec {
   buildInputs = [ zlib bzip2 ncurses libpng flex bison libX11 libICE xproto
     freetype t1lib gd libXaw icu ghostscript ed libXt libXpm libXmu libXext
     xextproto perl libSM ruby expat curl libjpeg python fontconfig xz pkgconfig
-    poppler libpaper graphite2 lesstif zziplib harfbuzz texinfo potrace ]
+    poppler libpaper graphite2 lesstif zziplib harfbuzz texinfo potrace gmp mpfr
+    xpdf ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ makeWrapper ]
     ;
 

--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -1,11 +1,11 @@
 args: with args;
 rec {
   name    = "texlive-extra-2014";
-  version = "2014.20140821";
+  version = "2014.20140927";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-extra/texlive-extra_${version}.orig.tar.xz";
-    sha256 = "1y3w8bgp85s90ng2y5dw9chrrvvdf7ibb6ynss8kycvgc0y4m6b3";
+    sha256 = "0chbl20dh61ld7nq9aiay7hi371l6285c2caqz18br29ifh8jicd";
   };
 
   buildInputs = [texLive xz];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12111,7 +12111,7 @@ let
     inherit builderDefs zlib bzip2 ncurses libpng ed lesstif ruby potrace
       gd t1lib freetype icu perl expat curl xz pkgconfig zziplib texinfo
       libjpeg bison python fontconfig flex poppler libpaper graphite2
-      makeWrapper;
+      makeWrapper gmp mpfr xpdf;
     inherit (xlibs) libXaw libX11 xproto libXt libXpm
       libXmu libXext xextproto libSM libICE;
     ghostscript = ghostscriptX;


### PR DESCRIPTION
The old version is no longer available in Debian, so we need to update our packages as well. Build works fine on my machine.
(cc @jwiegley)
