### PR TITLE
Add package: trustedGrub

### DIFF
--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -1,0 +1,26 @@
+{stdenv, fetchgit, autoconf, automake, buggyBiosCDSupport ? true}:
+
+stdenv.mkDerivation {
+  name = "trustedGRUB-1.1.5";
+
+  src = fetchgit {
+     url = "https://github.com/ts468/TrustedGRUB";
+     rev = "954941c17e14c8f7b18e6cd3043ef5f946866f1c";
+     sha256 = "30c21765dc44f02275e66220d6724ec9cd45496226ca28c6db59a9147aa22685";
+  };
+
+  # Autoconf/automake required for the splashimage patch.
+  buildInputs = [autoconf automake];
+
+  preConfigure = ''
+    autoreconf
+  '';
+
+  meta = {
+    homepage = "http://sourceforge.net/projects/trustedgrub/";
+    repositories.git = https://github.com/ts468/TrustedGRUB;
+    description = "Legacy GRUB bootloader extended with TCG support";
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ tstrobel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1308,6 +1308,10 @@ let
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
   };
 
+  trustedGrub = callPackage_i686 ../tools/misc/grub/trusted.nix {
+    buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
+  };
+
   grub2 = callPackage ../tools/misc/grub/2.0x.nix { };
 
   grub2_efi = grub2.override { efiSupport = true; };


### PR DESCRIPTION
Legacy GRUB bootloader with "Trusted Computing Group" extension.
It is a version of TrustedGRUB that I updated with patches from OpenSUSE and from Legacy GRUB.
