### PR TITLE
Make QSettings use /run/current-system/sw/etc/xdg instead of /etc/xdg for global settings

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
       -demosdir $out/share/doc/${name}/demos
       -datadir $out/share/${name}
       -translationdir $out/share/${name}/translations
+      -sysconfdir /run/current-system/sw/etc/xdg
     "
   '' + optionalString stdenv.isDarwin ''
     export CXX=clang++


### PR DESCRIPTION
This is necessary due to an acknowledged deficiency in QSettings (https://bugreports.qt-project.org/browse/QTBUG-34919)
