### PR TITLE
oraclejdk: bump to 8u25, 7u71, and 7u72

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
-  patchVersion = "71";
+  patchVersion = "72";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
-  sha256_i686 = "d3c09a35abc0464d8ad70dfe17e02597eb4c5d489ff4d1bcd14088aeb5016424";
-  sha256_x86_64 = "80d5705fc37fc4eabe3cea480e0530ae0436c2c086eb8fc6f65bb21e8594baf8";
+  sha256_i686 = "0376c8a0280752b4389b6cb193d463826c55c821587d0278b7fea665a140f407";
+  sha256_x86_64 = "dd1d438e1b7d4b9bb5ea4659f2103b577d1568da51b53f97b736b3232eeade8e";
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "20";
+  patchVersion = "25";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "fa013b3fcbb1308040bf0e75bbd6ef7e8396b547cbc8dd79e3cb8153604bfd06";
-  sha256_x86_64 = "3e717622ae48af5ca7298e7797cb71d4d545238f362741a83e69c097ca055de4";
+  sha256_i686 = "17f396a541db09c732032185f10f9c6eb42ac7b5776814602342de9655b2e0e2";
+  sha256_x86_64 = "057f660799be2307d2eefa694da9d3fce8e165807948f5bcaa04f72845d2f529";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3269,11 +3269,15 @@ let
 
   oraclejdk7 = pkgs.oraclejdk7distro true false;
 
+  oraclejdk7psu = pkgs.oraclejdk7psu_distro true false;
+
   oraclejdk8 = pkgs.oraclejdk8distro true false;
 
   oraclejre = lowPrio (pkgs.jdkdistro false false);
 
   oraclejre7 = lowPrio (pkgs.oraclejdk7distro false false);
+
+  oraclejre7psu = lowPrio (pkgs.oraclejdk7psu_distro false false);
 
   oraclejre8 = lowPrio (pkgs.oraclejdk8distro false false);
 
@@ -3292,6 +3296,11 @@ let
     assert supportsJDK;
     (if pluginSupport then appendToName "with-plugin" else x: x)
       (callPackage ../development/compilers/oraclejdk/jdk7-linux.nix { inherit installjdk; });
+
+  oraclejdk7psu_distro = installjdk: pluginSupport:
+    assert supportsJDK;
+    (if pluginSupport then appendToName "with-plugin" else x: x)
+      (callPackage ../development/compilers/oraclejdk/jdk7psu-linux.nix { inherit installjdk; });
 
   oraclejdk8distro = installjdk: pluginSupport:
     assert supportsJDK;


### PR DESCRIPTION
From this version, Oracle provides two versions of JDK 7.
- JDK 7u71 is a Critical Patch Update (CPU) containing security and critical bug fixes.
- JDK 7u72 is a Patch Set Update (PSU) containing fixes of the CPU as well as non-critical fixes.

They says "Oracle strongly recommends that all Java SE users upgrade to the latest CPU release available for a release family. Most users should choose the CPU release." 
http://www.oracle.com/technetwork/java/javase/downloads/cpu-psu-explained-2331472.html

`oraclejdk7` is the CPU package. I added `oraclejdk7psu` for PSU version.
