### PR TITLE
Revert "cabal: enable multi-threaded builds with GHC 7.8.x or later"

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -210,9 +210,6 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
               ${optionalString (self.enableSharedExecutables && self.stdenv.isDarwin) ''
                 configureFlags+=" --ghc-option=-optl=-Wl,-headerpad_max_install_names"
               ''}
-              ${optionalString (versionOlder "7.8" ghc.version) ''
-                configureFlags+=" --ghc-option=-j$NIX_BUILD_CORES"
-              ''}
 
               echo "configure flags: $extraConfigureFlags $configureFlags"
               ./Setup configure --verbose --prefix="$out" --libdir='$prefix/lib/$compiler' \


### PR DESCRIPTION
This likely exacerbates the non-determinism in ghc package ids, so until
that is fixed let's live with the slow builds.

This reverts commit 817c0e41443a5176baf6dd9b422878fdccecd266.
