### PR TITLE
talloc: Fix linker flags on darwin.

### DIFF
--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   
   # https://bugzilla.samba.org/show_bug.cgi?id=7000
   postConfigure = if stdenv.isDarwin then ''
-    substituteInPlace "Makefile" --replace "SONAMEFLAG = #" "SONAMEFLAG = -install_name"
+    substituteInPlace "Makefile" --replace "SONAMEFLAG = #" "SONAMEFLAG = -Wl,-install_name,"
   '' else "";
 
   meta = {


### PR DESCRIPTION
Before this patch, building talloc on darwin (OS X 10.8.5) results in:

```
gcc -dynamiclib -Wl,-search_paths_first -undefined error -o libtalloc.dylib.2.0.1 ./talloc.o  ./libreplace/replace.o ./libreplace/snprintf.o ./libreplace/getpass.o ./libreplace/strptime.o   -install_namelibtalloc.dylib.2
gcc: error: unrecognized command line option '-install_namelibtalloc.dylib.2'
make: *** [libtalloc.dylib.2.0.1] Error 1
```

Setting SONAMEFLAG to either "-install_name " (note trailing space), or
"-Wl,-install_name," results in a successful build. The latter seems
more clear.

I haven't yet tested this lib since the package that depends on it is also giving me fits on darwin for unrelated reasons.
