### PR TITLE
Notmuch: fix build on darwin

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -13,48 +13,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ bash emacs gdb glib gmime gnupg pkgconfig talloc xapian ];
 
   patchPhase = ''
-    (cd test && for prg in \
-        aggregate-results.sh \
-        argument-parsing \
-        atomicity \
-        author-order \
-        basic \
-        crypto \
-        count \
-        dump-restore \
-        emacs \
-        emacs-large-search-buffer \
-        encoding \
-        from-guessing \
-        help-test \
-        hooks \
-        json \
-        long-id \
-        maildir-sync \
-        multipart \
-        new \
-        notmuch-test \
-        python \
-        raw \
-        reply \
-        search \
-        search-by-folder \
-        search-insufficient-from-quoting \
-        search-folder-coherence \
-        search-limiting \
-        search-output \
-        search-position-overlap-bug \
-        symbol-hiding \
-        tagging \
-        test-lib.sh \
-        test-verbose \
-        thread-naming \
-        thread-order \
-        uuencode \
-    ;do
-      substituteInPlace "$prg" \
-        --replace "#!/usr/bin/env bash" "#!${bash}/bin/bash"
-    done)
+    find test -type f -exec \
+      sed -i \
+        "1s_#!/usr/bin/env bash_#!${bash}/bin/bash_" \
+        "{}" ";"
 
     for src in \
       crypto.c \


### PR DESCRIPTION
This patch requires this fix to [talloc](https://github.com/NixOS/nixpkgs/pull/4557)

But with talloc and notmuch patched, I am able to build and run notmuch on darwin.

The first patch changes a bunch of hardcoded paths to test scripts whose shebangs are patched; some of these paths did not exist in my build; not sure why.

The second changes `bin/notmuch` from linking to relative `libnotmuch.3.dylib` to linking to an absolute path, otherwise the dylib is not found at runtime.  The command `otool -L .../bin/notmuch` shows the dylib links on darwin.
