### PR TITLE
New package: ncmpcppBeta

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -57,6 +57,7 @@
   ertes = "Ertugrul Söylemez <ertesx@gmx.de>";
   falsifian = "James Cook <james.cook@utoronto.ca>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
+  fpletz = "Franz Pletz <fpletz@fnordicwalking.de>";
   ftrvxmtrx = "Siarhei Zirukin <ftrvxmtrx@gmail.com>";
   funfunctor = "Edward O'Callaghan <eocallaghan@alterapraxis.com>";
   fuuzetsu = "Mateusz Kowalczyk <fuuzetsu@fuuzetsu.co.uk>";

--- a/pkgs/applications/audio/ncmpcpp/beta.nix
+++ b/pkgs/applications/audio/ncmpcpp/beta.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, ncurses, curl, taglib, fftw, mpd_clientlib, pkgconfig
+, boost, readline, libiconvOrEmpty }:
+
+stdenv.mkDerivation rec {
+  version = "0.6_beta5";
+  name = "ncmpcpp-${version}";
+
+  src = fetchurl {
+    url = "http://ncmpcpp.rybczak.net/stable/ncmpcpp-${version}.tar.bz2";
+    sha256 = "05h4mahnh39y9ab333whsgspj5mnbdkqfssgfi4r0zf1fvjwlwj6";
+  };
+
+  buildInputs = [ ncurses curl taglib fftw mpd_clientlib pkgconfig boost readline ]
+    ++ libiconvOrEmpty;
+
+  configureFlags = [
+    "BOOST_LIB_SUFFIX="
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Curses-based interface for MPD (music player daemon)";
+    homepage    = http://unkart.ovh.org/ncmpcpp/;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fpletz ];
+    platforms   = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9840,6 +9840,8 @@ let
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
+  ncmpcppBeta = callPackage ../applications/audio/ncmpcpp/beta.nix { };
+
   normalize = callPackage ../applications/audio/normalize { };
 
   mplayer = callPackage ../applications/video/mplayer {


### PR DESCRIPTION
This adds a recent beta version of ncmpcpp since the last stable release is from 2012.
