### PR TITLE
Fix ruby path in gitAndTools.hub

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -74,7 +74,7 @@ rec {
 
   hub = import ./hub {
     inherit (rubyLibs) rake;
-    inherit stdenv fetchurl groff makeWrapper;
+    inherit stdenv fetchurl groff ruby makeWrapper;
   };
 
   gitFastExport = import ./fast-export {

--- a/pkgs/applications/version-management/git-and-tools/hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hub/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, groff, rake, makeWrapper }:
+{ stdenv, fetchurl, groff, ruby, rake, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "hub-${version}";
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ rake makeWrapper ];
 
   installPhase = ''
+    sed -i s,/usr/bin/ruby,${ruby}/bin/ruby,g lib/hub/standalone.rb
     rake install "prefix=$out"
   '';
 


### PR DESCRIPTION
`hub` won't work on my NixOS system with the current master branch:

```
$ hub
/run/current-system/sw/bin/hub: /nix/store/j8fazj40azabllknnppbwv7yhpsfwpf6-hub-1.12.2/bin/.hub-wrapped: /usr/bin/ruby: bad interpreter: No such file or directory
/run/current-system/sw/bin/hub: line 3: /nix/store/j8fazj40azabllknnppbwv7yhpsfwpf6-hub-1.12.2/bin/.hub-wrapped: Success
```

The problem is that `hub` searches in `lib/hub/standalone.rb` for `'/usr/bin/ruby'` and fails if that exact path can't be found.

/cc @the-kenny 
