### PR TITLE
Fix MacVim by using clang.

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -1,17 +1,16 @@
-{ stdenv, stdenvAdapters, gccApple, fetchFromGitHub, ncurses, gettext,
+{ stdenv, fetchFromGitHub, ncurses, gettext,
   pkgconfig, cscope, python, ruby, tcl, perl, luajit
 }:
 
-let inherit (stdenvAdapters.overrideGCC stdenv gccApple) mkDerivation;
-in mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "macvim-${version}";
 
-  version = "7.4.355";
+  version = "7.4.479";
 
   src = fetchFromGitHub {
     owner = "genoma";
     repo = "macvim";
-    rev = "c18a61f9723565664ffc2eda9179e96c95860e25";
+    rev = "f9c084b97fa9d5cad2448dfd3eff3d9b7f0fac59";
     sha256 = "190bngg8m4bwqcia7w24gn7mmqkhk0mavxy81ziwysam1f652ymf";
   };
 
@@ -46,6 +45,7 @@ in mkDerivation rec {
       "--enable-perlinterp=dynamic"
       "--enable-rubyinterp=dynamic"
       "--enable-tclinterp=yes"
+      "--without-local-dir"
       "--with-luajit"
       "--with-lua-prefix=${luajit}"
       "--with-ruby-command=${ruby}/bin/ruby"
@@ -53,6 +53,8 @@ in mkDerivation rec {
       "--with-tlib=ncurses"
       "--with-compiledby=Nix"
   ];
+
+  makeFlags = ''PREFIX=$(out) CPPFLAGS="-Wno-error"'';
 
   preConfigure = ''
     DEV_DIR=$(/usr/bin/xcode-select -print-path)/Platforms/MacOSX.platform/Developer

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -187,3 +187,36 @@ index bc9f074..9b9125e 100755
    # Use ||, not &&, to avoid exiting from the if with $? = 1, which
    # would make configure fail if this is the last instruction.
    $ac_cs_success || as_fn_exit 1
+
+diff --git a/src/Makefile b/src/Makefile
+index 1c4d104..fff2015 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -1298,7 +1298,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
+ 		  MacVim/MacVim.m
+ MACVIMGUI_OBJ	= objects/gui.o objects/gui_beval.o objects/pty.o \
+ 		  objects/gui_macvim.o objects/MMBackend.o objects/MacVim.o
+-MACVIMGUI_DEFS	= -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe
++MACVIMGUI_DEFS	= -DMACOS_X_UNIX -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe
+ MACVIMGUI_IPATH	=
+ MACVIMGUI_LIBS_DIR =
+ MACVIMGUI_LIBS1	= -framework Cocoa -framework Carbon
+
+diff --git a/src/if_python.c b/src/if_python.c
+index b356bf7..b7bfa78 100644
+--- a/src/if_python.c
++++ b/src/if_python.c
+@@ -55,11 +55,7 @@
+ 
+ #define PY_SSIZE_T_CLEAN
+ 
+-#ifdef FEAT_GUI_MACVIM
+-# include <Python/Python.h>
+-#else
+-# include <Python.h>
+-#endif
++#include <Python.h>
+ 
+ #if !defined(PY_VERSION_HEX) || PY_VERSION_HEX < 0x02050000
+ # undef PY_SSIZE_T_CLEAN
+ MACVIMGUI_LIBS1	= -framework Cocoa -framework Carbon

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10504,7 +10504,7 @@ let
 
   vim = callPackage ../applications/editors/vim { };
 
-  macvim = callPackage ../applications/editors/vim/macvim.nix { };
+  macvim = callPackage ../applications/editors/vim/macvim.nix { stdenv = clangStdenv; };
 
   vimHugeX = vim_configurable;
 


### PR DESCRIPTION
- Use `clangStdenv`
- Remove platform specific Python `#include`
- Fix missing `MACOS_X_UNIX` define
- Bump version up
- Ignore warnings
- Don't attempt to find libs in `/usr/local`
