### PR TITLE
Added line SCSI_SAS_ATA y on line 62

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -59,6 +59,7 @@ with stdenv.lib;
   ''}
   SCSI_LOWLEVEL y # enable lots of SCSI devices
   SCSI_LOWLEVEL_PCMCIA y
+  SCSI_SAS_ATA y  # added to enable detection of hard drive
   SPI y # needed for many devices
   SPI_MASTER y
   WAN y


### PR DESCRIPTION
This kernel change makes the nixOS live cd detect the hard drive upon boot.
