### PR TITLE
Make a configuration management tool based on Nix to manage User Profiles.

### DIFF
--- a/nixup/default.nix
+++ b/nixup/default.nix
@@ -1,0 +1,17 @@
+{ configuration ? import ./lib/from-env.nix "NIX_USER_CONFIG" <nixup-config>
+, system ? builtins.currentSystem
+}:
+
+let
+  eval = import ./lib/eval-config.nix {
+    modules = [ configuration { nixpkgs.system = system; } ];
+  };
+
+  inherit (eval) pkgs;
+in
+
+{
+  inherit (eval) config options;
+
+  profile = eval.config.user.build.profile;
+}

--- a/nixup/lib/eval-config.nix
+++ b/nixup/lib/eval-config.nix
@@ -1,0 +1,24 @@
+# From an end-user configuration file (`configuration'), build a NixUP
+# configuration object (`config') from which we can retrieve option
+# values.
+
+{ lib ? import <nixpkgs/lib>
+, baseModules ? import ../modules/module-list.nix
+, modules
+, extraArgs ? {}
+, check ? true
+, prefix ? []
+}:
+
+rec {
+
+  # Merge the option definitions in all modules, forming the full
+  # system configuration.
+  inherit (lib.evalModules {
+    inherit prefix;
+    modules = modules ++ baseModules;
+    args = extraArgs;
+    check = check;
+  }) config options;
+
+}

--- a/nixup/lib/from-env.nix
+++ b/nixup/lib/from-env.nix
@@ -1,0 +1,4 @@
+# TODO: remove this file. There is lib.maybeEnv now
+name: default:
+let value = builtins.getEnv name; in
+if value == "" then default else value

--- a/nixup/modules/module-list.nix
+++ b/nixup/modules/module-list.nix
@@ -1,4 +1,5 @@
 [ ./user/activation.nix
   ./user/build.nix
+  ./user/resourceFiles.nix
   ./nixpkgs.nix
 ]

--- a/nixup/modules/module-list.nix
+++ b/nixup/modules/module-list.nix
@@ -1,5 +1,6 @@
 [ ./user/activation.nix
   ./user/build.nix
+  ./user/packages.nix
   ./user/resourceFiles.nix
   ./nixpkgs.nix
 ]

--- a/nixup/modules/module-list.nix
+++ b/nixup/modules/module-list.nix
@@ -1,0 +1,4 @@
+[ ./user/activation.nix
+  ./user/build.nix
+  ./nixpkgs.nix
+]

--- a/nixup/modules/nixpkgs.nix
+++ b/nixup/modules/nixpkgs.nix
@@ -1,0 +1,96 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+
+  isConfig = x:
+    builtins.isAttrs x || builtins.isFunction x;
+
+  optCall = f: x:
+    if builtins.isFunction f
+    then f x
+    else f;
+
+  mergeConfig = lhs_: rhs_:
+    let
+      lhs = optCall lhs_ { inherit pkgs; };
+      rhs = optCall rhs_ { inherit pkgs; };
+    in
+    lhs // rhs //
+    optionalAttrs (lhs ? packageOverrides) {
+      packageOverrides = pkgs:
+        optCall lhs.packageOverrides pkgs //
+        optCall (attrByPath ["packageOverrides"] ({}) rhs) pkgs;
+    };
+
+  configType = mkOptionType {
+    name = "nixpkgs config";
+    check = traceValIfNot isConfig;
+    merge = args: fold (def: mergeConfig def.value) {};
+  };
+
+in
+
+{
+  options = {
+    nixpkgs.path = mkOption {
+      type = types.path;
+      example = "/home/user/dev/nixpkgs";
+      description = ''
+        Location of the collection of packages which is used for building
+        the current user profile.  This is also useful for building profile
+        against either bleeding-edge recipes or archived version of the
+        recipes.
+      '';
+    };
+
+    nixpkgs.config = mkOption {
+      default = {};
+      example = literalExample
+        ''
+          { firefox.enableGeckoMediaPlayer = true;
+            packageOverrides = pkgs: {
+              firefox60Pkgs = pkgs.firefox60Pkgs.override {
+                enableOfficialBranding = true;
+              };
+            };
+          }
+        '';
+      type = configType;
+      description = ''
+        The configuration of the Nix Packages collection.  (For
+        details, see the Nixpkgs documentation.)  It allows you to set
+        package configuration options, and to override packages
+        globally through the <varname>packageOverrides</varname>
+        option.  The latter is a function that takes as an argument
+        the <emphasis>original</emphasis> Nixpkgs, and must evaluate
+        to a set of new or overridden packages.
+      '';
+    };
+
+    nixpkgs.system = mkOption {
+      type = types.str;
+      description = ''
+        Specifies the Nix platform type for which NixOS should be built.
+        If unset, it defaults to the platform type of your host system.
+        Specifying this option is useful when doing distributed
+        multi-platform deployment, or when building virtual machines.
+      '';
+    };
+
+    nixpkgs.pkgs = mkOption {
+      type = types.attrs;
+      internal = true;
+      description = ''
+        Attribute set containing the collection of packages imported from
+        the <option>nixpkgs.path</option>.
+      '';
+    };
+  };
+
+  config = mkDefault {
+    nixpkgs.path = <nixpkgs>;
+    nixpkgs.pkgs = import config.nixpkgs.path { inherit (config.nixpkgs) system config; };
+  };
+}

--- a/nixup/modules/user/activation.nix
+++ b/nixup/modules/user/activation.nix
@@ -1,0 +1,102 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  pkgs = config.nixpkgs.pkgs;
+
+  addAttributeName = mapAttrs (a: v: v // {
+    text = ''
+      #### Activation script snippet ${a}:
+      ${v.text}
+    '';
+  });
+
+  path = [ pkgs.coreutils ];
+
+  activateScript = pkgs.writeScript "user-profile-activate" config.user.activationScripts;
+in
+
+{
+
+  options = {
+
+    user.activationScripts = mkOption {
+      default = {};
+
+      example = {
+        aliasIfconfig = {
+          text = ''
+            # Some local configuration
+            if ifconfig > /dev/null 2>&1; then
+              :
+            elif test -x /sbin/ifconfig; then
+              ln -s /sbin/ifconfig ~/.usr/bin/ifconfig
+            fi
+          '';
+          deps = [ "setupLocalUsr" ];
+        };
+      };
+
+      description = ''
+        A set of shell script fragments that are executed when a NixOS
+        system configuration is activated.  Examples are updating
+        <filename>~/.</filename>, creating accounts, and so on.  Since these
+        are executed every time you boot the system or run
+        <command>nixos-rebuild</command>, it's important that they are
+        idempotent and fast.
+      '';
+
+      type = types.attrsOf types.unspecified; # FIXME
+
+      apply = set:
+        ''
+          #! ${pkgs.stdenv.shell}
+
+          userConfig=@out@
+          profileLink=$HOME/.nixup/profile
+
+          export PATH=/empty
+          for i in ${toString path}; do
+              PATH=$PATH:$i/bin:$i/sbin
+          done
+
+          _status=0
+          trap "_status=1" ERR
+
+          # Ensure a consistent umask.
+          umask 0022
+
+          ${
+            let
+              set' = mapAttrs (n: v: if isString v then noDepEntry v else v) set;
+              withHeadlines = addAttributeName set';
+            in textClosureMap id (withHeadlines) (attrNames withHeadlines)
+          }
+
+          # Make this configuration the current configuration.
+          # The readlink is there to ensure that when $systemConfig = /system
+          # (which is a symlink to the store), /run/current-system is still
+          # used as a garbage collection root.
+          ln -sfn "$(readlink -f "$userConfig")" $profileLink
+
+          # Prevent the current configuration from being garbage-collected.
+          mkdir -p /nix/var/nix/gcroots/per-user/$USER/$HOME
+          ln -sfn $profileLink /nix/var/nix/gcroots/per-user/$USER/$HOME/profile
+
+          exit $_status
+        '';
+
+    };
+
+  };
+
+  config = {
+    user.buildCommands = ''
+      cp ${toString activateScript} $out/activate
+      substituteInPlace $out/activate --subst-var out
+      chmod u+x $out/activate
+      unset activationScript
+    '';
+  };
+}

--- a/nixup/modules/user/build.nix
+++ b/nixup/modules/user/build.nix
@@ -1,0 +1,50 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  pkgs = config.nixpkgs.pkgs;
+
+  profile = pkgs.stdenv.mkDerivation {
+    name = "nixup-profile";
+    preferLocalBuild = true;
+    buildCommand = ''
+      mkdir $out
+
+      ${config.user.buildCommands}
+    '';
+  };
+
+in
+
+{
+  options = {
+    user.build = mkOption {
+      internal = true;
+      type = types.attrsOf types.package;
+      default = {};
+      description = ''
+        Attribute set of derivations used to setup the system.
+      '';
+    };
+
+    user.buildCommands = mkOption {
+      internal = true;
+      type = types.lines;
+      default = [];
+      example = literalExample ''
+        "ln -s ${pkgs.firefox} $out/firefox-stable"
+     '';
+      description = ''
+        List of commands to build and install the content of the profile
+        directory.
+      '';
+    };
+  };
+
+  config = {
+
+    user.build.profile = profile;
+
+  };
+}

--- a/nixup/modules/user/packages.nix
+++ b/nixup/modules/user/packages.nix
@@ -1,0 +1,56 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  pkgs = config.nixpkgs.pkgs;
+
+  userPath = pkgs.buildEnv {
+    name = "user-path";
+    paths = config.user.packages;
+    pathsToLink = [ "/" ];
+    ignoreCollisions = true;
+    # !!! Hacky, should modularise.
+    postBuild =
+      ''
+        if [ -x $out/bin/update-mime-database -a -w $out/share/mime/packages ]; then
+            XDG_DATA_DIRS=$out/share $out/bin/update-mime-database -V $out/share/mime > /dev/null
+        fi
+
+        if [ -x $out/bin/gtk-update-icon-cache -a -f $out/share/icons/hicolor/index.theme ]; then
+            $out/bin/gtk-update-icon-cache $out/share/icons/hicolor
+        fi
+
+        if [ -x $out/bin/glib-compile-schemas -a -w $out/share/glib-2.0/schemas ]; then
+            $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+        fi
+
+        if [ -x $out/bin/update-desktop-database -a -w $out/share/applications ]; then
+            $out/bin/update-desktop-database $out/share/applications
+        fi
+      '';
+  };
+
+in
+
+{
+  options = {
+    user.packages = mkOption {
+      default = [];
+      type = types.listOf types.path;
+      example = literalExample "with config.nixpkgs.pkgs; [ firefox thunderbird ]";
+      description = ''
+        The set of packages that appear in
+        <filename>$HOME/.nixup/profile/sw</filename>.  These packages are
+        are automatically updated every time you rebuild the user profile.
+      '';
+    };
+  };
+
+  config = {
+    user.build.userPath = userPath;
+    user.buildCommands = ''
+      ln -s ${userPath} $out/sw
+    '';
+  };
+}

--- a/nixup/modules/user/resourceFiles.nix
+++ b/nixup/modules/user/resourceFiles.nix
@@ -1,0 +1,94 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  pkgs = config.nixpkgs.pkgs;
+in
+
+{
+  options = {
+    user.resourceFiles = mkOption rec {
+      default = {};
+      type = types.loaOf (types.submodule options);
+      example = literalExample ''
+        [ { target = ".ssh/config";
+            text = "
+              Host home.my-domain.name
+              User seti
+            ";
+          }
+          { target = ".gitconfig";
+            source = ./gitconfig;
+          }
+        ]
+      '';
+      description = ''
+        Set of files that have to be linked in the home directory.
+      '';
+
+      options = { name, config, ... }: {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Whether this <filename>~/.</filename> file should be generated.  This
+              option allows specific <filename>~/.</filename> files to be disabled.
+            '';
+          };
+
+          target = mkOption {
+            type = types.str;
+            description = ''
+              Name of symlink (relative to <filename>~/.</filename>).
+              Defaults to the attribute name.
+            '';
+          };
+
+          text = mkOption {
+            default = null;
+            type = types.nullOr types.lines;
+            description = "Text of the file.";
+          };
+
+          source = mkOption {
+            type = types.path;
+            description = "Path of the source file.";
+          };
+
+          setupScript = mkOption {
+            type = types.lines;
+            internal = true;
+            description = "Shell script code to produce the resource file.";
+          };
+        };
+
+        config = {
+          target = mkDefault name;
+          source = mkIf (config.text != null)
+            (mkDefault (config.pkgs.writeText "homeDir-${name}" config.text));
+
+          setupScript = mkDefault ''
+            target="$HOME/${config.target}"
+            mkdir -p $(dirname $target)
+            if test -e $target -a \! -L $target; then
+              mv $target $target.backup
+            fi
+            ln -sf "${config.source}" $target
+          '';
+        };
+      };
+
+    };
+  };
+
+  config = {
+
+    user.activationScripts.resourceFiles = ''
+      echo "Setting up resource files ..."
+
+      ${concatMapStringsSep "\n" (rc: rc.setupScript) (attrValues config.user.resourceFiles)}
+    '';
+  };
+}


### PR DESCRIPTION
This pull request is made to bootstrap a variant of NixOS, which is dedicated at managing the home directory of users.  This new project is called NixUP (Nix User Profile), and the goals are the following:
- [✓] Generate an activation script.
- [✓] Abstract the creation of resource files. (similar to environment.etc)
- [✓] Option to list installed packages. (similar to system.packages)
- [✗] Command line tool to manage profiles generations and updates.  (similar to nixos-rebuild)
- [✗] Command line tool to write / read option definition without using an editor.  (no legacy yet)
- [✗] Mock compatibility modules to use some NixOS modules in NixUP.
- [✗] Include NixUP modules as submodules of NixOS option `users.extraUser.<name?>`
