### PR TITLE
Add "rpmextract" script and use it

### DIFF
--- a/pkgs/development/python-modules/rhpl/builder.sh
+++ b/pkgs/development/python-modules/rhpl/builder.sh
@@ -1,6 +1,6 @@
 source $stdenv/setup
 
-rpm2cpio $src | cpio -idv
+rpmextract $src
 tar xfvj rhpl-*.tar.bz2
 rm rhpl-*.tar.bz2
 cd rhpl-*

--- a/pkgs/development/python-modules/rhpl/default.nix
+++ b/pkgs/development/python-modules/rhpl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, rpm, cpio, python, wirelesstools, gettext}:
+{stdenv, fetchurl, rpmextract, python, wirelesstools, gettext}:
 
 stdenv.mkDerivation {
   name = "rhpl-0.218";
@@ -12,5 +12,5 @@ stdenv.mkDerivation {
   
   builder = ./builder.sh;
   
-  buildInputs = [ rpm cpio python wirelesstools gettext ];
+  buildInputs = [ rpmextract python wirelesstools gettext ];
 }

--- a/pkgs/servers/sql/oracle-xe/default.nix
+++ b/pkgs/servers/sql/oracle-xe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, requireFile, patchelf, rpm, cpio, libaio }:
+{ stdenv, makeWrapper, requireFile, patchelf, rpmextract, libaio }:
 
 assert stdenv.system == "x86_64-linux";
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   unpackCmd = ''
     (mkdir -p "${name}" && cd "${name}" &&
-      ${rpm}/bin/rpm2cpio "$curSrc" | ${cpio}/bin/cpio -id)
+      ${rpmextract}/bin/rpmextract "$curSrc")
   '';
 
   buildPhase = let

--- a/pkgs/tools/archivers/rpmextract/default.nix
+++ b/pkgs/tools/archivers/rpmextract/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, rpm, cpio, substituteAll }:
+
+stdenv.mkDerivation rec {
+  name = "rpmextract";
+
+  builder = builtins.toFile "builder.sh" ''
+    source $stdenv/setup
+
+    install -Dm755 $script $out/bin/rpmextract
+  '';
+    
+  script = substituteAll {
+    src = ./rpmextract.sh;
+    inherit rpm cpio;
+  };
+
+  meta = with stdenv.lib; {
+    description = "Script to extract RPM archives";
+    platforms = platforms.all;
+    license = licenses.gpl2;
+    maintainers = maintainers.abbradar;
+  };
+}

--- a/pkgs/tools/archivers/rpmextract/rpmextract.sh
+++ b/pkgs/tools/archivers/rpmextract/rpmextract.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$1" = "" ]; then
+  echo "usage: rpmextract package_name" 1>&2
+  exit 1
+fi
+
+@rpm@/bin/rpm2cpio "$1" | @cpio@/bin/cpio -idv

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, writeText, zlib, rpm, cpio, patchelf, which }:
+{ stdenv, fetchurl, writeText, zlib, rpmextract, patchelf, which }:
 
 assert stdenv.isLinux;
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
     mkdir -pv unpacked
     cd unpacked
-    ${rpm}/bin/rpm2cpio $src | ${cpio}/bin/cpio -imd
+    ${rpmextract}/bin/rpmextract $src
 
     cp -r -t $out/bin usr/bin/*
     cp -r -t $out/share usr/share/*

--- a/pkgs/tools/misc/megacli/default.nix
+++ b/pkgs/tools/misc/megacli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, rpm, cpio, ncurses, patchelf, makeWrapper, requireFile, unzip }:
+{ stdenv, rpmextract, ncurses, patchelf, makeWrapper, requireFile, unzip }:
 
 assert stdenv.system == "x86_64-linux";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
       sha256 = "11jzvh25mlygflazd37gi05xv67im4rgq7sbs5nwgw3gxdh4xfjj";
     };
 
-  buildInputs = [rpm cpio ncurses unzip makeWrapper];
+  buildInputs = [rpmextract ncurses unzip makeWrapper];
   libPath =
     stdenv.lib.makeLibraryPath
        [ stdenv.gcc.gcc stdenv.gcc.libc ncurses ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cd $out
     unzip ${src}
-    rpm2cpio linux/MegaCli-8.07.07-1.noarch.rpm | cpio -idmv
+    rpmextract linux/MegaCli-8.07.07-1.noarch.rpm
     ${patchelf}/bin/patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" --set-rpath ${libPath}:$out/opt/lsi/3rdpartylibs/x86_64:$out/opt/lsi/3rdpartylibs:${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib opt/MegaRAID/MegaCli/MegaCli64
     wrapProgram $out/opt/MegaRAID/MegaCli/MegaCli64 --set LD_LIBRARY_PATH $out/opt/lsi/3rdpartylibs/x86_64
     ln -s $out/opt/MegaRAID/MegaCli/MegaCli64 $out/bin/MegaCli64

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2162,6 +2162,8 @@ let
 
   rpm = callPackage ../tools/package-management/rpm { };
 
+  rpmextract = callPackage ../tools/archivers/rpmextract { };
+
   rrdtool = callPackage ../tools/misc/rrdtool { };
 
   rtorrent = callPackage ../tools/networking/p2p/rtorrent { };


### PR DESCRIPTION
In Arch Linux there is a tiny tool called "rpmextract" which basically just calls rpm2cpio and cpio -d. It, however, saves a lot of time when working with rpm archives (standalone and while packaging smth) and helps a person who doesn't know anything about rpm to just "extract" it (it helped me, at least ^_^).
I've reimplemented this little tool (it lives as a script in Arch Linux packages, and so tiny there's no sense in using it from there) and replaced most uses of rpm+cpio with it. There are also some uses in build-support, but I omitted them for now.
