### PR TITLE
Let systemd units define their documentation

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -78,6 +78,21 @@ in rec {
       description = "Description of this unit used in systemd messages and progress indicators.";
     };
 
+    documentation = mkOption {
+      default = [];
+      type = types.listOf types.str;
+      description = ''
+        A list of URIs referencing documentation for this unit or its
+        configuration. Accepted are only URIs of the types "http://",
+        "https://", "file:", "info:", "man:". For more information
+        about the syntax of these URIs, see uri(7). The URIs should be
+        listed in order of relevance, starting with the most relevant.
+        It is a good idea to first reference documentation that
+        explains what the unit's purpose is, followed by how it is
+        configured, followed by any other related documentation.
+      '';
+    };
+
     requires = mkOption {
       default = [];
       type = types.listOf types.str;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -209,6 +209,8 @@ let
           { Conflicts = toString config.conflicts; }
         // optionalAttrs (config.restartTriggers != [])
           { X-Restart-Triggers = toString config.restartTriggers; }
+        // optionalAttrs (config.documentation != [])
+          { Documentation = toString config.documentation; }
         // optionalAttrs (config.description != "") {
           Description = config.description;
         };


### PR DESCRIPTION
Systemd units can define their documentation through the `Documentation`
option. From `man:systemd.unit(5)`:

```
  Documentation=
   A space-separated list of URIs referencing documentation for this unit
   or its configuration. Accepted are only URIs of the types "http://",
   "https://", "file:", "info:", "man:". For more information about the
   syntax of these URIs, see uri(7). The URIs should be listed in order
   of relevance, starting with the most relevant. It is a good idea to
   first reference documentation that explains what the unit's purpose
   is, followed by how it is configured, followed by any other related
   documentation. This option may be specified more than once, in which
   case the specified list of URIs is merged. If the empty string is
   assigned to this option, the list is reset and all prior assignments
   will have no effect.
```
