### PR TITLE
Fix build-fhs-chrootenv mount script

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/mount.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/mount.sh.in
@@ -23,4 +23,4 @@ mount --rbind /run $chrootenvDest/run
 mount --bind /etc $chrootenvDest/host-etc
 
 # Bind mount /tmp
-mount --bind /tmp/chrootenv-@name@ /run/chrootenv/steam/tmp
+mount --bind /tmp/chrootenv-@name@ $chrootenvDest/tmp


### PR DESCRIPTION
The mount script in build-fhs-chrootenv has 'steam' hardcoded in one place instead of the chrootenvDest.
