### PR TITLE
kde4: Use plasma-nm instead of knetworkmanager

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -148,7 +148,7 @@ in
         ]
       ++ lib.optional config.hardware.pulseaudio.enable pkgs.kde4.kmix  # Perhaps this should always be enabled
       ++ lib.optional config.hardware.bluetooth.enable pkgs.kde4.bluedevil
-      ++ lib.optional config.networking.networkmanager.enable pkgs.kde4.networkmanagement
+      ++ lib.optional config.networking.networkmanager.enable pkgs.kde4.plasma-nm
       ++ [ nepomukConfig ] ++ phononBackendPackages;
 
     environment.pathsToLink = [ "/share" ];


### PR DESCRIPTION
`plasma-nm` is the successor of `knetworkmanager`, it is written in QML and actively developed. Works fine on my machine for several weeks.
