### PR TITLE
scala: Bump up version from 2.11.1 to 2.11.2

### DIFF
--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  name = "scala-2.11.1";
+  name = "scala-2.11.2";
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "1vjsmqjwpxavyj29wrbvvx7799fsa65d4iha5mj63cgs8qp605gk";
+    sha256 = "0mnjhjiixjphr9v101v408815hkl6hlghx9h7lmmylv5z7gk3p8k";
   };
 
   buildInputs = [ jre makeWrapper ] ;


### PR DESCRIPTION
As indicated on #4612, Scala 2.11.3 is broken, so upgrading to 2.11.2 instead.
