### PR TITLE
rxvt_unicode: add some plugins and a wrapper

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-perls/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-perls/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "urxvt-perls";
+
+  src = fetchgit {
+    url = "https://github.com/muennich/urxvt-perls";
+    rev = "4dec629b3631297d17855c35be1b723e2d9e7591";
+    sha256 = "c61bc8819b4e6655ed4a3ce3b347cb6dbebcb484d5d3973cbe9aa7f2c98d372f";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib/urxvt/perl
+    cp clipboard \
+       keyboard-select \
+       url-select \
+    $out/lib/urxvt/perl
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Perl extensions for the rxvt-unicode terminal emulator";
+    homepage = "https://github.com/muennich/urxvt-perls";
+    license = licenses.gpl2;
+    maintainers = maintainers.abbradar;
+  };
+}

--- a/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-tabbedex/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-tabbedex/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "urxvt-tabbedex";
+
+  src = fetchgit {
+    url = "https://github.com/mina86/urxvt-tabbedex";
+    rev = "54c8d6beb4d65278ed6db24693ca56e1ee65bb42";
+    sha256 = "f8734ee289e1cfc517d0699627191c98d32ae3549e0f1935af2a5ccb86d4dc1e";
+  };
+
+  installPhase = ''
+    install -D tabbedex $out/lib/urxvt/perl/tabbedex
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tabbed plugin for rxvt-unicode with many enhancements (mina86's fork)";
+    homepage = "https://github.com/mina86/urxvt-tabbedex";
+    maintainers = maintainers.abbradar;
+  };
+}

--- a/pkgs/applications/misc/rxvt_unicode/wrapper.nix
+++ b/pkgs/applications/misc/rxvt_unicode/wrapper.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildEnv, rxvt_unicode, makeWrapper, plugins }:
+
+let
+  rxvt = rxvt_unicode.override {
+    perlSupport = true;
+  };
+
+  drv = buildEnv {
+    name = "${rxvt.name}-with-plugins";
+
+    paths = [ rxvt ] ++ plugins;
+
+    postBuild = ''
+      # TODO: This could be avoided if buildEnv could be forced to create all directories
+      if [ -L $out/bin ]; then
+        rm $out/bin
+        mkdir $out/bin
+        for i in ${rxvt}/bin/*; do
+          ln -s $i $out/bin
+        done
+      fi
+      wrapProgram $out/bin/urxvt \
+        --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
+    '';
+  };
+in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10223,6 +10223,14 @@ let
     unicode3Support = true;
   };
 
+  # urxvt plugins
+  urxvt_perls = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-perls { };
+  urxvt_tabbedex = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-tabbedex { };
+
+  rxvt_unicode_wrapper = callPackage ../applications/misc/rxvt_unicode/wrapper.nix {
+    plugins = [];
+  };
+
   sakura = callPackage ../applications/misc/sakura {
     inherit (gnome) vte;
   };


### PR DESCRIPTION
This adds some rxvt plugins and a wrapper to use them. You can use it with, for example:

```
      rxvt_unicode_wrapper = rxvt_unicode_wrapper.override {
        plugins = [ urxvt_perls urxvt_tabbedex ];
      };
```
