### PR TITLE
xfce4-mixer: add pulseaudio support

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, makeWrapper
 , glib, gstreamer, gst_plugins_base, gtk
 , libxfce4util, libxfce4ui, xfce4panel, xfconf, libunique ? null
+, pulseaudioSupport ? false, gst_plugins_good
 }:
 
 let
@@ -9,7 +10,10 @@ let
   gst_plugins_minimal = gst_plugins_base.override {
     minimalDeps = true;
   };
-  gst_plugins = [ gst_plugins_minimal ];
+  gst_plugins_pulse = gst_plugins_good.override {
+    minimalDeps = true;
+  };
+  gst_plugins = [ gst_plugins_minimal ] ++ stdenv.lib.optional pulseaudioSupport gst_plugins_pulse;
 
 in
 
@@ -25,9 +29,9 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   buildInputs =
-    [ pkgconfig intltool glib gstreamer gst_plugins_minimal gtk
+    [ pkgconfig intltool glib gstreamer gtk
       libxfce4util libxfce4ui xfce4panel xfconf libunique makeWrapper
-    ];
+    ] ++ gst_plugins;
 
   postInstall =
     ''

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, newScope }: let
+{ config, pkgs, newScope }: let
 
 callPackage = newScope (deps // xfce_self);
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -44,7 +44,9 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   parole          = callPackage ./applications/parole.nix { };
   ristretto       = callPackage ./applications/ristretto.nix { };
   terminal        = xfce4terminal; # it has changed its name
-  xfce4mixer      = callPackage ./applications/xfce4-mixer.nix { };
+  xfce4mixer      = callPackage ./applications/xfce4-mixer.nix {
+    pulseaudioSupport = config.pulseaudio or false;
+  };
   xfce4notifyd    = callPackage ./applications/xfce4-notifyd.nix { };
   xfce4taskmanager= callPackage ./applications/xfce4-taskmanager.nix { };
   xfce4terminal   = callPackage ./applications/terminal.nix { };

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
@@ -2,6 +2,9 @@
 , flac, libjpeg, zlib, speex, libpng, libdv, libcaca, libvpx
 , libiec61883, libavc1394, taglib, pulseaudio, gdk_pixbuf, orc
 , glib, gstreamer, bzip2
+, # Whether to build no plugins that have external dependencies
+  # (except the PulseAudio plugin).
+  minimalDeps ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -20,10 +23,10 @@ stdenv.mkDerivation rec {
   configureFlags = "--disable-oss";
 
   buildInputs =
-    [ pkgconfig glib gstreamer gst_plugins_base libavc1394 libiec61883
-      aalib libcaca cairo libdv flac libjpeg libpng pulseaudio speex
-      taglib bzip2 libvpx gdk_pixbuf orc
-    ];
+    [ pkgconfig glib gstreamer gst_plugins_base pulseaudio ]
+    ++ stdenv.lib.optionals (!minimalDeps)
+      [ aalib libcaca cairo libdv flac libjpeg libpng speex
+        taglib bzip2 libvpx gdk_pixbuf orc ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11555,7 +11555,7 @@ let
   mate-themes = callPackage ../misc/themes/mate-themes { };
 
   xfce = xfce4_10;
-  xfce4_10 = recurseIntoAttrs (import ../desktops/xfce { inherit pkgs newScope; });
+  xfce4_10 = recurseIntoAttrs (import ../desktops/xfce { inherit config pkgs newScope; });
 
 
   ### SCIENCE


### PR DESCRIPTION
This adds optional pulseaudio support to xfce4 mixer app, and minimized version of gst-good-plugins for it to work.
