### PR TITLE
passwordFile: update description

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -184,7 +184,7 @@ let
         type = with types; uniq (nullOr string);
         default = null;
         description = ''
-          The path to a file that contains the user's password. The password
+          The full path to a file that contains the user's password. The password
           file is read on each system activation. The file should contain
           exactly one line, which should be the password in an encrypted form
           that is suitable for the <literal>chpasswd -e</literal> command.


### PR DESCRIPTION
I updated the description of passwordFile because if you do not define a full path to the passwordFile you can easily lock out yourself from the system.

e.g.:

configuration.nix is in /etc/nixos/configuration.nix
password file is in /etc/nixos/pwd.root

mutableUsers=false;
passwordFile="./pwd.root";

nixos-rebuild does it's job because it can find the path defined in passwordFile but on next reboot the file isn't accessible. This took me a while to figure out because my SSD is booting so fast that i couldn't read the error message thast the file couldn't be found.
