### PR TITLE
xmonad_log_applet: add packages

### DIFF
--- a/pkgs/applications/window-managers/xmonad-log-applet/default.nix
+++ b/pkgs/applications/window-managers/xmonad-log-applet/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, glib, dbus_glib
+, desktopSupport
+, gtk2, gnome2_panel, GConf2
+, libxfce4util, xfce4panel
+}:
+
+assert desktopSupport == "gnome2" || desktopSupport == "gnome3" || desktopSupport == "xfce4";
+
+stdenv.mkDerivation rec {
+  version = "2.1.0";
+  pname = "xmonad-log-applet";
+  name = "${pname}-${version}-${desktopSupport}";
+
+  src = fetchFromGitHub {
+    owner = "alexkay";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "1g1fisyaw83v72b25fxfjln8f4wlw3rm6nyk27mrqlhsc1spnb5p";
+  };
+
+  buildInputs =  with stdenv.lib;
+                 [ glib dbus_glib ]
+              ++ optionals (desktopSupport == "gnome2") [ gtk2 gnome2_panel GConf2 ]
+              # TODO: no idea where to find libpanelapplet-4.0
+              ++ optionals (desktopSupport == "gnome3") [ ]
+              ++ optionals (desktopSupport == "xfce4") [ gtk2 libxfce4util xfce4panel ]
+              ;
+  
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  
+  configureFlags =  [ "--with-panel=${desktopSupport}" ];
+  
+  patches = [ ./fix-paths.patch ];
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/alexkay/xmonad-log-applet;
+    license = licenses.bsd3;
+    description = "An applet that will display XMonad log information (${desktopSupport} version)";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+
+    broken = desktopSupport == "gnome3";
+  };
+}
+

--- a/pkgs/applications/window-managers/xmonad-log-applet/fix-paths.patch
+++ b/pkgs/applications/window-managers/xmonad-log-applet/fix-paths.patch
@@ -1,0 +1,50 @@
+diff --git a/Makefile.am b/Makefile.am
+index 619012d..dcc6d3c 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,4 +1,5 @@
+ plugindir = $(PLUGIN_DIR)
++SESSION_BUS_SERVICES_DIR = $(prefix)/share/dbus-1/services
+ plugin_PROGRAMS = xmonad-log-applet
+ 
+ xmonad_log_applet_SOURCES = main.c
+diff --git a/configure.ac b/configure.ac
+index ad4cffb..110c953 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -27,28 +27,28 @@ AC_ARG_WITH(
+ AS_IF(
+     [test "x$panel" = xgnome2],
+         [PKG_CHECK_MODULES(LIBPANEL, libpanelapplet-3.0 >= 2.32.0)]
+-        LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=prefix libpanelapplet-3.0`/share/gnome-panel/applets
+-        PLUGIN_DIR=`$PKG_CONFIG --variable=prefix libpanelapplet-3.0`/libexec
++        LIBPANEL_APPLET_DIR=${prefix}/share/gnome-panel/applets
++        PLUGIN_DIR=${prefix}/libexec
+         [AC_DEFINE(PANEL_GNOME, 1, [panel type])]
+         [AC_DEFINE(PANEL_GNOME2, 1, [panel type])]
+         ,
+     [test "x$panel" = xgnome3],
+         [PKG_CHECK_MODULES(LIBPANEL, libpanelapplet-4.0 >= 3.0.0)]
+         LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=libpanel_applet_dir libpanelapplet-4.0`
+-        PLUGIN_DIR=`$PKG_CONFIG --variable=prefix libpanelapplet-4.0`/libexec
++        PLUGIN_DIR=${prefix}/libexec
+         [AC_DEFINE(PANEL_GNOME, 1, [panel type])]
+         [AC_DEFINE(PANEL_GNOME3, 1, [panel type])]
+         ,
+     [test "x$panel" = xmate],
+         [PKG_CHECK_MODULES(LIBPANEL, libmatepanelapplet-3.0 >= 1.4.0)]
+-        LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=prefix libmatepanelapplet-3.0`/share/mate-panel/applets
+-        PLUGIN_DIR=`$PKG_CONFIG --variable=prefix libmatepanelapplet-3.0`/libexec
++        LIBPANEL_APPLET_DIR=${prefix}/share/mate-panel/applets
++        PLUGIN_DIR=${prefix}/libexec
+         [AC_DEFINE(PANEL_MATE, 1, [panel type])]
+         ,
+     [test "x$panel" = xxfce4],
+         [PKG_CHECK_MODULES(LIBPANEL, libxfce4panel-1.0 >= 4.6.0)]
+-        LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=prefix libxfce4panel-1.0`/share/xfce4/panel-plugins
+-        PLUGIN_DIR=`$PKG_CONFIG --variable=libdir libxfce4panel-1.0`/xfce4/panel/plugins
++        LIBPANEL_APPLET_DIR=${prefix}/share/xfce4/panel-plugins
++        PLUGIN_DIR=${prefix}/lib/xfce4/panel/plugins
+         [AC_DEFINE(PANEL_XFCE4, 1, [panel type])]
+         ,
+     [AC_MSG_ERROR([Unknown panel type, use gnome2, gnome3, mate or xfce4])]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10871,6 +10871,27 @@ let
 
   xkb_switch = callPackage ../tools/X11/xkb-switch { };
 
+  xmonad_log_applet_gnome2 = callPackage ../applications/window-managers/xmonad-log-applet {
+    desktopSupport = "gnome2";
+    inherit (xfce) libxfce4util xfce4panel;
+    gnome2_panel = gnome2.gnome_panel;
+    GConf2 = gnome2.GConf;
+  };
+
+  xmonad_log_applet_gnome3 = callPackage ../applications/window-managers/xmonad-log-applet {
+    desktopSupport = "gnome3";
+    inherit (xfce) libxfce4util xfce4panel;
+    gnome2_panel = gnome2.gnome_panel;
+    GConf2 = gnome2.GConf;
+  };
+
+  xmonad_log_applet_xfce = callPackage ../applications/window-managers/xmonad-log-applet {
+    desktopSupport = "xfce4";
+    inherit (xfce) libxfce4util xfce4panel;
+    gnome2_panel = gnome2.gnome_panel;
+    GConf2 = gnome2.GConf;
+  };
+
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix { };
 
   xpra = callPackage ../tools/X11/xpra { };


### PR DESCRIPTION
This can be used in tandem with XMonad for nice xmobar-like labels in Xfce and Gnome{2,3}. I haven't tested it in gnome2 and was desperate to find where `libpanelapplet-4.0` from gnome3 resides, but on Xfce this works and is very useful.
