### PR TITLE
Add Dockerfile, which builds docker with nix package manager

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+*~
+,*
+.*.swp
+.*.swo
+result
+result-*
+/doc/NEWS.html
+/doc/NEWS.txt
+/doc/manual.html
+/doc/manual.pdf
+.version-suffix
+
+.DS_Store
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM busybox
+
+RUN dir=`mktemp -d` && trap 'rm -rf "$dir"' EXIT && \
+    wget -O- http://nixos.org/releases/nix/nix-1.7/nix-1.7-x86_64-linux.tar.bz2  | bzcat | tar x -C $dir && \
+    mkdir -m 0755 /nix && USER=root sh $dir/*/install && \
+    echo ". /root/.nix-profile/etc/profile.d/nix.sh" >> /etc/profile
+
+ADD . /root/nix/nixpkgs
+ONBUILD ENV NIX_PATH nixpkgs=/root/nix/nixpkgs:nixos=/root/nix/nixpkgs/nixos
+ONBUILD ENV PATH /root/.nix-profile/bin:/root/.nix-profile/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+ONBUILD ENV ENV /etc/profile
+ENV ENV /etc/profile


### PR DESCRIPTION
With this Dockerfile, https://registry.hub.docker.com/u/offlinehacker/nixpkgs will automaticlly build docker image with nix package manager and nixpkgs(repo itself) on every push. To use this docker image: docker -t -i offlinehacker/nixpkgs. I advise nixos organization to create it's own account on docker registry and setup automated builds.

Example Dockefile that uses this image:

```
FROM offlinehacker/nixpkgs
RUN nix-env -iA nixpkgs.mongodb
RUN mkdir -p /var/db/mongodb
CMD mongod --dbpath /var/db/mongodb
```

PS: Docker is not a replacement for nixos, docker is process manager(which can also run whole nixos container), nixos is os, just to make this clear.
