### PR TITLE
Fix python26Packages.sqlite3

### DIFF
--- a/pkgs/development/interpreters/python/2.6/default.nix
+++ b/pkgs/development/interpreters/python/2.6/default.nix
@@ -128,11 +128,6 @@ let
 
       buildPhase =
         ''
-          # Fake the build environment that setup.py expects.
-          ln -s ${python}/include/python*/pyconfig.h .
-          ln -s ${python}/lib/python*/config/Setup Modules/
-          ln -s ${python}/lib/python*/config/Setup.local Modules/
-
           substituteInPlace setup.py --replace 'self.extensions = extensions' \
             'self.extensions = [ext for ext in self.extensions if ext.name in ["${internalName}"]]'
 


### PR DESCRIPTION
The latest `sqlite3` update breaks `python26Packages.sqlite3` (127f5f1):

```
nix-build -vvv -A python26Packages.sqlite3

checking for resize_term... no
checking for resizeterm... no
checking for /dev/ptmx... yes
checking for /dev/ptc... no
checking for %zd printf() format support... yes
checking for socklen_t... yes
checking for build directories... done
configure: creating ./config.status
config.status: creating Makefile.pre
config.status: creating Modules/Setup.config
config.status: creating pyconfig.h
creating Modules/Setup
creating Modules/Setup.local
creating Makefile
building
ln: failed to create symbolic link './pyconfig.h': File exists
|   |   building of `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv': got EOF
|   |   building of `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv': woken up
|   |   building of `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv': build done
|   |   builder process for `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv' finished
|   |   killing all processes running under uid `30001'
|   |   recursively deleting path `/tmp/nix-build-python-sqlite3-2.6.9.drv-1'
|   |   builder for `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv' failed with exit code 1
|   |   lock released on `/nix/store/qlq92h0mihy8hwcj70m0iy99vzljwbsi-python-sqlite3-2.6.9.lock'
|   |   building of `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv': done
|   building of `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv': goal destroyed
error: build of `/nix/store/yv65gb12a6x5lxn2kmj55r0abyf4kwmm-python-sqlite3-2.6.9.drv' failed
```

I think we no longer need this workaround. This fixes the issue for me.
