### PR TITLE
Ruby: 2.1.3 and Fiddle support

### DIFF
--- a/pkgs/development/interpreters/ruby/ruby-2.1.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.0.nix
@@ -5,6 +5,7 @@
 , ncurses, readline, cursesSupport ? false
 , groff, docSupport ? false
 , libyaml, yamlSupport ? true
+, libffi, fiddleSupport ? true
 , ruby_2_1_0, autoreconfHook, bison, useRailsExpress ? true
 }:
 
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
   NROFF = "${groff}/bin/nroff";
 
   buildInputs = ops useRailsExpress [ autoreconfHook bison ]
+    ++ (op fiddleSupport libffi)
     ++ (ops cursesSupport [ ncurses readline ] )
     ++ (op docSupport groff )
     ++ (op zlibSupport zlib)

--- a/pkgs/development/interpreters/ruby/ruby-2.1.1.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.1.nix
@@ -5,6 +5,7 @@
 , ncurses, readline, cursesSupport ? false
 , groff, docSupport ? false
 , libyaml, yamlSupport ? true
+, libffi, fiddleSupport ? true
 , ruby_2_1_1, autoreconfHook, bison, useRailsExpress ? true
 }:
 
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
   NROFF = "${groff}/bin/nroff";
 
   buildInputs = ops useRailsExpress [ autoreconfHook bison ]
+    ++ (op fiddleSupport libffi)
     ++ (ops cursesSupport [ ncurses readline ] )
     ++ (op docSupport groff )
     ++ (op zlibSupport zlib)

--- a/pkgs/development/interpreters/ruby/ruby-2.1.2.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.1.2.nix
@@ -5,6 +5,7 @@
 , ncurses, readline, cursesSupport ? false
 , groff, docSupport ? false
 , libyaml, yamlSupport ? true
+, libffi, fiddleSupport ? true
 , ruby_2_1_2, autoreconfHook, bison, useRailsExpress ? true
 }:
 
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
   NROFF = "${groff}/bin/nroff";
 
   buildInputs = ops useRailsExpress [ autoreconfHook bison ]
+    ++ (op fiddleSupport libffi)
     ++ (ops cursesSupport [ ncurses readline ] )
     ++ (op docSupport groff )
     ++ (op zlibSupport zlib)

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "13d535bbc060b1b8166673932fe7098abf4216b8";
-  sha256 = "0hf1m2bsdgdnyi4427gknvpd8cfribw77lf2k980flb1z9g5d7ib";
+  rev    = "fb6b427f71e756900184d1b6eaeb10245ec8405a";
+  sha256 = "10k7p3nymj7y5a0az8v1aks2w5w190zfqv9kiiafcx0a3qfswnck";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4036,13 +4036,14 @@ let
   ruby_2_1_0 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.0.nix { });
   ruby_2_1_1 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.1.nix { });
   ruby_2_1_2 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.2.nix { });
+  ruby_2_1_3 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.3.nix { });
 
   # Ruby aliases
   ruby = ruby_1_9;
   ruby_1_8 = ruby_1_8_7;
   ruby_1_9 = ruby_1_9_3;
   ruby_2_0 = ruby_2_0_0;
-  ruby_2_1 = ruby_2_1_2;
+  ruby_2_1 = ruby_2_1_3;
 
   rubyLibs = recurseIntoAttrs (callPackage ../development/interpreters/ruby/libs.nix { });
 


### PR DESCRIPTION
This packages Ruby 2.1.3, and adds [Fiddle](http://ruby-doc.org/stdlib-2.0/libdoc/fiddle/rdoc/Fiddle.html) support for all 2.x versions.
