### PR TITLE
RFC: Add buildExternalNixExpression

### DIFF
--- a/pkgs/build-support/build-external-nix-expression/default.nix
+++ b/pkgs/build-support/build-external-nix-expression/default.nix
@@ -1,0 +1,17 @@
+{ pkgs }: /* nix package collection attrset */
+
+{ src /* result of fetchurl/fetchgit/... */
+, nixExpressionFile ? "./default.nix"
+}:
+
+with pkgs;
+
+let
+  unpack = src: runCommand "unpacked-source" { inherit src; } ''
+    mkdir -p "$out"
+    unpackPhase
+    cp -r "$sourceRoot"/* "$sourceRoot"/.[!.]* "$sourceRoot"/..?* "$out"
+  '';
+  nixExpressionFile_ = (unpack src) + "/" + nixExpressionFile;
+in
+callPackage nixExpressionFile_ { }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -261,6 +261,8 @@ let
     inherit (pkgs) runCommand perl;
   };
 
+  buildExternalNixExpression = callPackage ../build-support/build-external-nix-expression/default.nix { };
+
   buildFHSChrootEnv = import ../build-support/build-fhs-chrootenv {
     inherit buildEnv system;
     inherit stdenv glibc glibc_multi glibcLocales;


### PR DESCRIPTION
My attempt at answering/solving the "upstream nix expressions" question in http://lists.science.uu.nl/pipermail/nix-dev/2014-October/014734.html.

Please have a look and give some feedback :-)

---

This function is for building (external) packages that contain a
default.nix file in their sources.

Example usage:

```
  project-name = buildExternalNixExpression {
    src = fetchurl { ... };
  };
```
