### PR TITLE
Add Meslo LG & Meslo LG DZ fonts

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -23,6 +23,7 @@
   aszlig = "aszlig <aszlig@redmoonstudios.org>";
   auntie = "Jonathan Glines <auntieNeo@gmail.com>";
   aycanirican = "Aycan iRiCAN <iricanaycan@gmail.com>";
+  balajisivaraman = "Balaji Sivaraman<sivaraman.balaji@gmail.com>";
   bbenoist = "Baptist BENOIST <return_0@live.com>";
   bennofs = "Benno Fünfstück <benno.fuenfstueck@gmail.com>";
   berdario = "Dario Bertini <berdario@gmail.com>";

--- a/pkgs/data/fonts/meslo-lg/default.nix
+++ b/pkgs/data/fonts/meslo-lg/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.1";
+
+  name = "meslo-lg";
+
+  meslo-lg = fetchurl {
+    url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20v${version}.zip?raw=true";
+    name="${name}";
+    sha256="1l08mxlzaz3i5bamnfr49s2k4k23vdm64b8nz2ha33ysimkbgg6h";
+  };
+
+  meslo-lg-dz = fetchurl {
+    url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20DZ%20v${version}.zip?raw=true";
+    name="${name}-dz";
+    sha256="0lnbkrvcpgz9chnvix79j6fiz36wj6n46brb7b1746182rl1l875";
+  };
+
+  buildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  phases = [ "unpackPhase" "installPhase" ];
+  unpackPhase = ''
+    unzip -j ${meslo-lg}
+    unzip -j ${meslo-lg-dz}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  meta = {
+    description = "A customized version of Apple’s Menlo-Regular font";
+    homepage = https://github.com/andreberg/Meslo-Font/;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ balajisivaraman ];
+    platforms = with stdenv.lib.platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8594,6 +8594,8 @@ let
 
   manpages = callPackage ../data/documentation/man-pages { };
 
+  meslo-lg = callPackage ../data/fonts/meslo-lg {};
+
   miscfiles = callPackage ../data/misc/miscfiles { };
 
   mobile_broadband_provider_info = callPackage ../data/misc/mobile-broadband-provider-info { };


### PR DESCRIPTION
This is a neat little font set which is missing from the package repository. It is absolutely great for coding.

As per the [discussion](https://github.com/balajisivaraman/nixpkgs/commit/425e6965df82f381686f7c445b96b2a71fec207a#commitcomment-8315049) with @Fuuzetsu, I've updated the package to use `stdenv.mkDerivation` instead of the old `builderDefsPackage`. It seems a lot cleaner now and builds without any errors as well.
