### PR TITLE
nixos: iso-image: use syslinux bootloader for USB booting support

### DIFF
--- a/nixos/lib/make-iso9660-image.nix
+++ b/nixos/lib/make-iso9660-image.nix
@@ -1,4 +1,4 @@
-{ stdenv, perl, cdrkit, pathsFromGraph
+{ stdenv, perl, pathsFromGraph, xorriso, syslinux
 
 , # The file name of the resulting ISO image.
   isoName ? "cd.iso"
@@ -22,11 +22,17 @@
 , # Whether this should be an efi-bootable El-Torito CD.
   efiBootable ? false
 
+, # Wheter this should be an hybrid CD (bootable from USB as well as CD).
+  usbBootable ? false
+
 , # The path (in the ISO file system) of the boot image.
   bootImage ? ""
 
 , # The path (in the ISO file system) of the efi boot image.
   efiBootImage ? ""
+
+, # The path (outside the ISO file system) of the isohybrid-mbr image.
+  isohybridMbrImage ? ""
 
 , # Whether to compress the resulting ISO image with bzip2.
   compressImage ? false
@@ -38,13 +44,14 @@
 
 assert bootable -> bootImage != "";
 assert efiBootable -> efiBootImage != "";
+assert usbBootable -> isohybridMbrImage != "";
 
 stdenv.mkDerivation {
   name = "iso9660-image";
   builder = ./make-iso9660-image.sh;
-  buildInputs = [perl cdrkit];
+  buildInputs = [perl xorriso syslinux];
 
-  inherit isoName bootable bootImage compressImage volumeID pathsFromGraph efiBootImage efiBootable;
+  inherit isoName bootable bootImage compressImage volumeID pathsFromGraph efiBootImage efiBootable isohybridMbrImage usbBootable;
 
   # !!! should use XML.
   sources = map (x: x.source) contents;

--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -31,11 +31,20 @@ if test -n "$bootable"; then
         fi
     done
 
-    bootFlags="-b $bootImage -c .boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table"
+    isoBootFlags="-eltorito-boot ${bootImage}
+                  -eltorito-catalog .boot.cat
+                  -no-emul-boot -boot-load-size 4 -boot-info-table"
+fi
+
+if test -n "$usbBootable"; then
+    usbBootFlags="-isohybrid-mbr ${isohybridMbrImage}"
 fi
 
 if test -n "$efiBootable"; then
-    bootFlags="$bootFlags -eltorito-alt-boot -e $efiBootImage -no-emul-boot"
+    efiBootFlags="-eltorito-alt-boot
+                  -e $efiBootImage
+                  -no-emul-boot
+                  -isohybrid-gpt-basdat"
 fi
 
 touch pathlist
@@ -74,18 +83,41 @@ for ((n = 0; n < ${#objects[*]}; n++)); do
     fi
 done
 
-# !!! what does this do?
+# Escape filenames that contain '='.
+# TODO: Handle this properly. This fails for filenames
+#       that contain multiple '=' symbols.
 cat pathlist | sed -e 's/=\(.*\)=\(.*\)=/\\=\1=\2\\=/' | tee pathlist.safer
 
 
 mkdir -p $out/iso
-genCommand="genisoimage -iso-level 4 -r -J $bootFlags -hide-rr-moved -graft-points -path-list pathlist.safer ${volumeID:+-V $volumeID}"
-if test -z "$compressImage"; then
-    $genCommand -o $out/iso/$isoName
-else
-    $genCommand | bzip2 > $out/iso/$isoName.bz2
+
+xorriso="xorriso
+ -as mkisofs
+ -iso-level 3
+ -volid ${volumeID}
+ -appid nixos
+ -publisher nixos
+ -graft-points
+ -full-iso9660-filenames
+ ${isoBootFlags}
+ ${usbBootFlags}
+ ${efiBootFlags}
+ -r
+ -path-list pathlist.safer
+ --sort-weight 0 /
+ --sort-weight 1 /isolinux" # Make sure isolinux is near the beginning of the ISO
+
+$xorriso -output $out/iso/$isoName
+
+if test -n "$usbBootable"; then
+    echo "Making image hybrid..."
+    isohybrid --uefi $out/iso/$isoName
 fi
 
+if test -n "$compressImage"; then
+    echo "Compressing image..."
+    bzip2 $out/iso/$isoName
+fi
 
 mkdir -p $out/nix-support
 echo $system > $out/nix-support/system

--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -83,12 +83,6 @@ for ((n = 0; n < ${#objects[*]}; n++)); do
     fi
 done
 
-# Escape filenames that contain '='.
-# TODO: Handle this properly. This fails for filenames
-#       that contain multiple '=' symbols.
-cat pathlist | sed -e 's/=\(.*\)=\(.*\)=/\\=\1=\2\\=/g' | tee pathlist.safer
-
-
 mkdir -p $out/iso
 
 xorriso="xorriso
@@ -103,7 +97,7 @@ xorriso="xorriso
  ${usbBootFlags}
  ${efiBootFlags}
  -r
- -path-list pathlist.safer
+ -path-list pathlist
  --sort-weight 0 /
  --sort-weight 1 /isolinux" # Make sure isolinux is near the beginning of the ISO
 

--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -86,7 +86,7 @@ done
 # Escape filenames that contain '='.
 # TODO: Handle this properly. This fails for filenames
 #       that contain multiple '=' symbols.
-cat pathlist | sed -e 's/=\(.*\)=\(.*\)=/\\=\1=\2\\=/' | tee pathlist.safer
+cat pathlist | sed -e 's/=\(.*\)=\(.*\)=/\\=\1=\2\\=/g' | tee pathlist.safer
 
 
 mkdir -p $out/iso

--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -37,6 +37,10 @@ sub new {
             if defined $args->{hda};
         $startCommand .= "-cdrom $args->{cdrom} "
             if defined $args->{cdrom};
+        $startCommand .= "-device piix3-usb-uhci -drive id=usbdisk,file=$args->{usb},if=none,readonly -device usb-storage,drive=usbdisk "
+            if defined $args->{usb};
+        $startCommand .= "-bios $args->{bios} "
+            if defined $args->{bios};
         $startCommand .= $args->{qemuFlags} || "";
     } else {
         $startCommand = Cwd::abs_path $startCommand;

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -36,6 +36,9 @@ with lib;
   # EFI booting
   isoImage.makeEfiBootable = true;
 
+  # USB booting
+  isoImage.makeUsbBootable = true;
+
   # Add Memtest86+ to the CD.
   boot.loader.grub.memtest86.enable = true;
 

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -48,7 +48,7 @@ let
 
   isolinuxMemtest86Entry = ''
     LABEL memtest
-    MENU LABEL Memtest86+
+    MENU LABEL Memtest86
     LINUX /boot/memtest.bin
   '';
 
@@ -297,7 +297,7 @@ in
           target = "/loader";
         }
       ] ++ optionals config.boot.loader.grub.memtest86.enable [
-        { source = "${pkgs.memtest86plus}/memtest.bin";
+        { source = "${pkgs.memtest86}/memtest.bin";
           target = "/boot/memtest.bin";
         }
       ];

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -8,45 +8,37 @@ with lib;
 
 let
 
-  # The Grub image.
-  grubImage = pkgs.runCommand "grub_eltorito" {}
+  # The configuration file for syslinux.
+  isolinuxCfg =
     ''
-      ${pkgs.grub2}/bin/grub-mkimage -p /boot/grub -O i386-pc -o tmp biosdisk iso9660 help linux linux16 chain png jpeg echo gfxmenu reboot
-      cat ${pkgs.grub2}/lib/grub/*/cdboot.img tmp > $out
-    ''; # */
+    SERIAL 0 38400
+    UI vesamenu.c32
+    MENU TITLE NixOS
+    MENU BACKGROUND /isolinux/background.png
 
+    LABEL boot
+    MENU LABEL Boot NixOS
+    LINUX /boot/bzImage init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+    INITRD /boot/initrd
 
-  # The configuration file for Grub.
-  grubCfg =
-    ''
-      set default=${builtins.toString config.boot.loader.grub.default}
-      set timeout=${builtins.toString config.boot.loader.grub.timeout}
+    LABEL chain
+    MENU LABEL Boot existing OS
+    COM32 chain.c32
+    APPEND hd0 0
 
-      if loadfont /boot/grub/unicode.pf2; then
-        set gfxmode=640x480
-        insmod gfxterm
-        insmod vbe
-        terminal_output gfxterm
+    LABEL reboot
+    MENU LABEL Reboot
+    COM32 reboot.c32
 
-        insmod png
-        if background_image /boot/grub/splash.png; then
-          set color_normal=white/black
-          set color_highlight=black/white
-        else
-          set menu_color_normal=cyan/blue
-          set menu_color_highlight=white/blue
-        fi
-
-      fi
-
-      ${config.boot.loader.grub.extraEntries}
+    LABEL poweroff
+    MENU LABEL Power Off
+    COM32 poweroff.c32
     '';
-
 
   # The efi boot image
   efiDir = pkgs.runCommand "efi-directory" {} ''
-    mkdir -p $out/efi/boot
-    cp -v ${pkgs.gummiboot}/lib/gummiboot/gummiboot${targetArch}.efi $out/efi/boot/boot${targetArch}.efi
+    mkdir -p $out/EFI/boot
+    cp -v ${pkgs.gummiboot}/lib/gummiboot/gummiboot${targetArch}.efi $out/EFI/boot/boot${targetArch}.efi
     mkdir -p $out/loader/entries
     echo "title NixOS LiveCD" > $out/loader/entries/nixos-livecd.conf
     echo "linux /boot/bzImage" >> $out/loader/entries/nixos-livecd.conf
@@ -152,6 +144,22 @@ in
       '';
     };
 
+    isoImage.makeUsbBootable = mkOption {
+      default = false;
+      description = ''
+        Whether the ISO image should be bootable from CD as well as USB.
+      '';
+    };
+
+    isoImage.splashImage = mkOption {
+      default = pkgs.fetchurl {
+          url = https://raw.githubusercontent.com/NixOS/nixos-artwork/5729ab16c6a5793c10a2913b5a1b3f59b91c36ee/ideas/grub-splash/grub-nixos-1.png;
+          sha256 = "43fd8ad5decf6c23c87e9026170a13588c2eba249d9013cb9f888da5e2002217";
+        };
+      description = ''
+        The splash image to use in the bootloader.
+      '';
+    };
 
   };
 
@@ -166,7 +174,7 @@ in
 
     # !!! Hack - attributes expected by other modules.
     system.boot.loader.kernelFile = "bzImage";
-    environment.systemPackages = [ pkgs.grub2 ];
+    environment.systemPackages = [ pkgs.grub2 pkgs.syslinux ];
 
     # In stage 1 of the boot, mount the CD as the root FS by label so
     # that we don't need to know its device.  We pass the label of the
@@ -216,7 +224,7 @@ in
         options = "allow_other,cow,nonempty,chroot=/mnt-root,max_files=32768,hide_meta_files,dirs=/nix/.rw-store=rw:/nix/.ro-store=ro";
       };
 
-    boot.initrd.availableKernelModules = [ "squashfs" "iso9660" ];
+    boot.initrd.availableKernelModules = [ "squashfs" "iso9660" "usb-storage" ];
 
     boot.initrd.kernelModules = [ "loop" ];
 
@@ -236,15 +244,12 @@ in
     # Individual files to be included on the CD, outside of the Nix
     # store on the CD.
     isoImage.contents =
-      [ { source = grubImage;
-          target = "/boot/grub/grub_eltorito";
-        }
-        { source = pkgs.substituteAll  {
-            name = "grub.cfg";
-            src = pkgs.writeText "grub.cfg-in" grubCfg;
+      [ { source = pkgs.substituteAll  {
+            name = "isolinux.cfg";
+            src = pkgs.writeText "isolinux.cfg-in" isolinuxCfg;
             bootRoot = "/boot";
           };
-          target = "/boot/grub/grub.cfg";
+          target = "/isolinux/isolinux.cfg";
         }
         { source = config.boot.kernelPackages.kernel + "/bzImage";
           target = "/boot/bzImage";
@@ -252,51 +257,38 @@ in
         { source = config.system.build.initialRamdisk + "/initrd";
           target = "/boot/initrd";
         }
-        { source = "${pkgs.grub2}/share/grub/unicode.pf2";
-          target = "/boot/grub/unicode.pf2";
-        }
-        { source = config.boot.loader.grub.splashImage;
-          target = "/boot/grub/splash.png";
-        }
         { source = config.system.build.squashfsStore;
           target = "/nix-store.squashfs";
+        }
+        { source = "${pkgs.syslinux}/share/syslinux";
+          target = "/isolinux";
+        }
+        { source = config.isoImage.splashImage;
+          target = "/isolinux/background.png";
         }
       ] ++ optionals config.isoImage.makeEfiBootable [
         { source = efiImg;
           target = "/boot/efi.img";
         }
-        { source = "${efiDir}/efi";
-          target = "/efi";
+        { source = "${efiDir}/EFI";
+          target = "/EFI";
         }
         { source = "${efiDir}/loader";
           target = "/loader";
         }
-      ] ++ mapAttrsToList (n: v: { source = v; target = "/boot/${n}"; }) config.boot.loader.grub.extraFiles;
-
-    # The Grub menu.
-    boot.loader.grub.extraEntries =
-      ''
-        menuentry "NixOS ${config.system.nixosVersion} Installer" {
-          linux /boot/bzImage init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
-          initrd /boot/initrd
-        }
-
-        menuentry "Boot from hard disk" {
-          set root=(hd0)
-          chainloader +1
-        }
-      '';
-
-    boot.loader.grub.timeout = 10;
+      ];
 
     # Create the ISO image.
     system.build.isoImage = import ../../../lib/make-iso9660-image.nix ({
-      inherit (pkgs) stdenv perl cdrkit pathsFromGraph;
+      inherit (pkgs) stdenv perl pathsFromGraph xorriso syslinux;
 
       inherit (config.isoImage) isoName compressImage volumeID contents;
 
       bootable = true;
-      bootImage = "/boot/grub/grub_eltorito";
+      bootImage = "/isolinux/isolinux.bin";
+    } // optionalAttrs config.isoImage.makeUsbBootable {
+      usbBootable = true;
+      isohybridMbrImage = "${pkgs.syslinux}/share/syslinux/isohdpfx.bin";
     } // optionalAttrs config.isoImage.makeEfiBootable {
       efiBootable = true;
       efiBootImage = "boot/efi.img";

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -7,6 +7,11 @@
 with lib;
 
 let
+  # Timeout in syslinux is in units of 1/10 of a second.
+  # 0 is used to disable timeouts.
+  syslinuxTimeout = max (config.boot.loader.grub.timeout * 10) 1;
+
+  max = x: y: if x > y then x else y;
 
   # The configuration file for syslinux.
 
@@ -23,11 +28,12 @@ let
 
   isolinuxCfg =
     ''
-    TIMEOUT ${builtins.toString config.boot.loader.grub.timeout}
     SERIAL 0 38400
+    TIMEOUT ${builtins.toString syslinuxTimeout}
     UI vesamenu.c32
     MENU TITLE NixOS
     MENU BACKGROUND /isolinux/background.png
+    DEFAULT boot
 
     LABEL boot
     MENU LABEL NixOS ${config.system.nixosVersion} Installer

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -52,7 +52,7 @@ let
     echo "initrd /boot/initrd" >> $out/loader/entries/nixos-livecd.conf
     echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}" >> $out/loader/entries/nixos-livecd.conf
     echo "default nixos-livecd" > $out/loader/loader.conf
-    echo "timeout ${builtins.toString config.boot.loader.grub.timeout}" >> $out/loader/loader.conf
+    echo "timeout ${builtins.toString config.boot.loader.gummiboot.timeout}" >> $out/loader/loader.conf
   '';
 
   efiImg = pkgs.runCommand "efi-image_eltorito" { buildInputs = [ pkgs.mtools ]; }

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -18,8 +18,9 @@ let
     MENU BACKGROUND /isolinux/background.png
 
     LABEL boot
-    MENU LABEL Boot NixOS
-    LINUX /boot/bzImage init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+    MENU LABEL NixOS ${config.system.nixosVersion} Installer
+    LINUX /boot/bzImage
+    APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
     INITRD /boot/initrd
 
     LABEL chain

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -22,19 +22,6 @@ let
     LINUX /boot/bzImage
     APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
     INITRD /boot/initrd
-
-    LABEL chain
-    MENU LABEL Boot existing OS
-    COM32 chain.c32
-    APPEND hd0 0
-
-    LABEL reboot
-    MENU LABEL Reboot
-    COM32 reboot.c32
-
-    LABEL poweroff
-    MENU LABEL Power Off
-    COM32 poweroff.c32
     '';
 
   # The efi boot image

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -9,6 +9,18 @@ with lib;
 let
 
   # The configuration file for syslinux.
+
+  # Notes on syslinux configuration and UNetbootin compatiblity:
+  #   * Do not use '/syslinux/syslinux.cfg' as the path for this
+  #     configuration. UNetbootin will not parse the file and use it as-is.
+  #     This results in a broken configuration if the partition label does
+  #     not match the specified config.isoImage.volumeID. For this reason
+  #     we're using '/isolinux/isolinux.cfg'.
+  #   * Use APPEND instead of adding command-line arguments directly after
+  #     the LINUX entries.
+  #   * COM32 entries (chainload, reboot, poweroff) are not recognized. They
+  #     result in incorrect boot entries.
+
   isolinuxCfg =
     ''
     TIMEOUT ${builtins.toString config.boot.loader.grub.timeout}

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -48,7 +48,7 @@ let
     LINUX /boot/memtest.bin
   '';
 
-  isolinuxCfg = baseIsolinuxCfg + (if config.boot.loader.grub.memtest86.enable then isolinuxMemtest86Entry else "");
+  isolinuxCfg = baseIsolinuxCfg + (optionalString config.boot.loader.grub.memtest86.enable isolinuxMemtest86Entry);
 
   # The efi boot image
   efiDir = pkgs.runCommand "efi-directory" {} ''

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -11,6 +11,7 @@ let
   # The configuration file for syslinux.
   isolinuxCfg =
     ''
+    TIMEOUT ${builtins.toString config.boot.loader.grub.timeout}
     SERIAL 0 38400
     UI vesamenu.c32
     MENU TITLE NixOS
@@ -45,7 +46,7 @@ let
     echo "initrd /boot/initrd" >> $out/loader/entries/nixos-livecd.conf
     echo "options init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}" >> $out/loader/entries/nixos-livecd.conf
     echo "default nixos-livecd" > $out/loader/loader.conf
-    echo "timeout 5" >> $out/loader/loader.conf
+    echo "timeout ${builtins.toString config.boot.loader.grub.timeout}" >> $out/loader/loader.conf
   '';
 
   efiImg = pkgs.runCommand "efi-image_eltorito" { buildInputs = [ pkgs.mtools ]; }
@@ -277,6 +278,8 @@ in
           target = "/loader";
         }
       ];
+
+    boot.loader.grub.timeout = 10;
 
     # Create the ISO image.
     system.build.isoImage = import ../../../lib/make-iso9660-image.nix ({

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -9,7 +9,11 @@ with lib;
 let
   # Timeout in syslinux is in units of 1/10 of a second.
   # 0 is used to disable timeouts.
-  syslinuxTimeout = max (config.boot.loader.grub.timeout * 10) 1;
+  syslinuxTimeout = if config.boot.loader.timeout == null then
+      0
+    else
+      max (config.boot.loader.timeout * 10) 1;
+
 
   max = x: y: if x > y then x else y;
 
@@ -297,7 +301,7 @@ in
         }
       ];
 
-    boot.loader.grub.timeout = 10;
+    boot.loader.timeout = 10;
 
     # Create the ISO image.
     system.build.isoImage = import ../../../lib/make-iso9660-image.nix ({

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -26,7 +26,7 @@ let
   #   * COM32 entries (chainload, reboot, poweroff) are not recognized. They
   #     result in incorrect boot entries.
 
-  isolinuxCfg =
+  baseIsolinuxCfg =
     ''
     SERIAL 0 38400
     TIMEOUT ${builtins.toString syslinuxTimeout}
@@ -41,6 +41,14 @@ let
     APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
     INITRD /boot/initrd
     '';
+
+  isolinuxMemtest86Entry = ''
+    LABEL memtest
+    MENU LABEL Memtest86+
+    LINUX /boot/memtest.bin
+  '';
+
+  isolinuxCfg = baseIsolinuxCfg + (if config.boot.loader.grub.memtest86.enable then isolinuxMemtest86Entry else "");
 
   # The efi boot image
   efiDir = pkgs.runCommand "efi-directory" {} ''
@@ -282,6 +290,10 @@ in
         }
         { source = "${efiDir}/loader";
           target = "/loader";
+        }
+      ] ++ optionals config.boot.loader.grub.memtest86.enable [
+        { source = "${pkgs.memtest86plus}/memtest.bin";
+          target = "/boot/memtest.bin";
         }
       ];
 

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -50,6 +50,7 @@ let
     LABEL memtest
     MENU LABEL Memtest86+
     LINUX /boot/memtest.bin
+    APPEND ${toString config.boot.loader.grub.memtest86.params}
   '';
 
   isolinuxCfg = baseIsolinuxCfg + (optionalString config.boot.loader.grub.memtest86.enable isolinuxMemtest86Entry);

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -72,6 +72,7 @@ let
       #Let's hope 15M is enough
       dd bs=2048 count=7680 if=/dev/zero of="$out"
       ${pkgs.dosfstools}/sbin/mkfs.vfat "$out"
+      mlabel -i "$out" ::EFIBOOT
       mcopy -svi "$out" ${efiDir}/* ::
       mmd -i "$out" boot
       mcopy -v -i "$out" \

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -48,7 +48,7 @@ let
 
   isolinuxMemtest86Entry = ''
     LABEL memtest
-    MENU LABEL Memtest86
+    MENU LABEL Memtest86+
     LINUX /boot/memtest.bin
   '';
 
@@ -297,7 +297,7 @@ in
           target = "/loader";
         }
       ] ++ optionals config.boot.loader.grub.memtest86.enable [
-        { source = "${pkgs.memtest86}/memtest.bin";
+        { source = "${pkgs.memtest86plus}/memtest.bin";
           target = "/boot/memtest.bin";
         }
       ];

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -311,6 +311,10 @@ in rec {
   tests.udisks2 = callTest tests/udisks2.nix {};
   tests.virtualbox = callTest tests/virtualbox.nix {};
   tests.xfce = callTest tests/xfce.nix {};
+  tests.bootBiosCdrom = forAllSystems (system: scrubDrv (import tests/boot.nix { inherit system; }).bootBiosCdrom);
+  tests.bootBiosUsb = forAllSystems (system: scrubDrv (import tests/boot.nix { inherit system; }).bootBiosUsb);
+  tests.bootUefiCdrom = forAllSystems (system: scrubDrv (import tests/boot.nix { inherit system; }).bootUefiCdrom);
+  tests.bootUefiUsb = forAllSystems (system: scrubDrv (import tests/boot.nix { inherit system; }).bootUefiUsb);
 
 
   /* Build a bunch of typical closures so that Hydra can keep track of

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -1,0 +1,63 @@
+{ system ? builtins.currentSystem }:
+
+with import ../lib/testing.nix { inherit system; };
+with import ../lib/qemu-flags.nix;
+with pkgs.lib;
+
+let
+
+  iso =
+    (import ../lib/eval-config.nix {
+      inherit system;
+      modules =
+        [ ../modules/installer/cd-dvd/installation-cd-minimal.nix
+          ../modules/testing/test-instrumentation.nix
+          { key = "serial";
+            boot.loader.grub.timeout = mkOverride 0 0;
+
+            # The test cannot access the network, so any sources we
+            # need must be included in the ISO.
+            isoImage.storeContents =
+              [ pkgs.glibcLocales
+                pkgs.sudo
+                pkgs.docbook5
+                pkgs.docbook5_xsl
+                pkgs.grub
+                pkgs.perlPackages.XMLLibXML
+                pkgs.unionfs-fuse
+                pkgs.gummiboot
+              ];
+          }
+        ];
+    }).config.system.build.isoImage;
+
+  makeBootTest = name: machineConfig:
+    makeTest {
+      inherit iso;
+      name = "boot-" + name;
+      nodes = { };
+      testScript =
+        ''
+          my $machine = createMachine({ ${machineConfig}, qemuFlags => '-m 768' });
+          $machine->start;
+          $machine->waitForUnit("multi-user.target");
+          $machine->shutdown;
+        '';
+    };
+in {
+    bootBiosCdrom = makeBootTest "bios-cdrom" ''
+        cdrom => glob("${iso}/iso/*.iso")
+      '';
+    bootBiosUsb = makeBootTest "bios-usb" ''
+        usb => glob("${iso}/iso/*.iso")
+      '';
+    bootUefiCdrom = makeBootTest "uefi-cdrom" ''
+        cdrom => glob("${iso}/iso/*.iso"),
+        bios => '${pkgs.OVMF}/FV/OVMF.fd'
+      '';
+    bootUefiUsb = makeBootTest "uefi-usb" ''
+        usb => glob("${iso}/iso/*.iso"),
+        bios => '${pkgs.OVMF}/FV/OVMF.fd'
+      '';
+  }
+


### PR DESCRIPTION
This changes the bootloader for iso generation from Grub to syslinux. In addition this adds USB booting support, so that "dd" can be used to burn the generated ISO to USB thumbdrives
instead of needing applications like UnetBootin.

Most of this is based on the ISO generation methods that is used for ArchLinux.

---

Prebuilt iso by @lethalman, updated 26 Feb 2015, based on unstable release of 25 Feb 2015 (commit a869c83):
- Graphical ISO x86_64-linux: http://lethal.noip.me/dl/nixos-graphical-15.05pre56789.gfedcba-x86_64-linux.iso (sha256: 646cc4e699613cae436cab7c22207603ef0c0995a985b6d76507e79137c4ad0a)
- Minimal ISO x86_64-linux: http://lethal.noip.me/dl/nixos-minimal-15.05pre56789.gfedcba-x86_64-linux.iso (sha256: 97b15d201c37a8c7a19a6b60e5d24bc82dcd83edb42dabfc7a78ed23bdd3517b)

---

Shared doc for tests: https://docs.google.com/spreadsheets/d/103doEIjC_Sk_nkmSq9stkVD3tbh4st_4JKYLlXAel84/edit#gid=1631478778
