### PR TITLE
stdenv: Prevent issues like #4266

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -463,7 +463,9 @@ _defaultUnpack() {
     if [ -d "$fn" ]; then
 
         stripHash "$fn"
-        cp -prd --no-preserve=timestamps "$fn" $strippedName
+	# We can't preserve hardlinks because they may have been introduced by
+	# store optimization, which might break things in the build
+        cp -pr --reflink=auto --no-preserve=timestamps "$fn" $strippedName
 
     else
 


### PR DESCRIPTION
This causes a full rebuild due to touching stdenv.

This should fix #4266 and would allow reverting the ugly hack #4273.

It also introduces `--reflink=auto` which greatly speeds up copying on filesystems that support reflinks.
