### PR TITLE
Remove stumpwmContrib from top-level and fix runtime dependency on it

### DIFF
--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -23,12 +23,16 @@ stdenv.mkDerivation rec {
  '';
 
  configurePhase = ''
-   ./configure --prefix=$out --with-contrib-dir=${pkgs.stumpwmContrib}/contrib
+   ./configure --prefix=$out --with-contrib-dir=${stumpwmContrib}/contrib
  '';
 
  installPhase = ''
    make
    make install
+   # STUMPWM_CONTRIB_DIR is not actually used. We just set it so that
+   # stumpwmContrib gets retained as a runtime dependency because for
+   # some reason $out/bin/stumpwm does not contain a reference to it.
+   wrapProgram $out/bin/stumpwm --set STUMPWM_CONTRIB_DIR "${stumpwmContrib}/contrib"
  '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -29,10 +29,11 @@ stdenv.mkDerivation rec {
  installPhase = ''
    make
    make install
-   # STUMPWM_CONTRIB_DIR is not actually used. We just set it so that
-   # stumpwmContrib gets retained as a runtime dependency because for
-   # some reason $out/bin/stumpwm does not contain a reference to it.
-   wrapProgram $out/bin/stumpwm --set STUMPWM_CONTRIB_DIR "${stumpwmContrib}/contrib"
+   # For some reason, stumpwmContrib is not retained as a runtime
+   # dependency (probably because $out/bin/stumpwm is compressed or
+   # obfuscated in some way). Thus we add an explicit reference here.
+   mkdir $out/nix-support
+   echo ${stumpwmContrib} > $out/nix-support/stumpwm-contrib
  '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10446,8 +10446,9 @@ let
 
   stp = callPackage ../applications/science/logic/stp {};
 
-  stumpwm = callPackage ../applications/window-managers/stumpwm {};
-  stumpwmContrib = callPackage ../applications/window-managers/stumpwm/contrib.nix {};
+  stumpwm = callPackage ../applications/window-managers/stumpwm {
+    stumpwmContrib = callPackage ../applications/window-managers/stumpwm/contrib.nix { };
+  };
 
   sublime = callPackage ../applications/editors/sublime { };
 


### PR DESCRIPTION
This patch removes the stumpwmContrib package from the top-level since
it can't sensibly be used on its own. Also, it wraps the stumpwm
executable with a dummy reference to the contrib dir to work around the
issue that the stumpwm executable doesn't reference the contrib dir
that's passed in the configure phase for some reason.
