### PR TITLE
Fix quassel sha256

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -20,7 +20,7 @@ in with stdenv; mkDerivation rec {
 
   src = fetchurl {
     url = "http://quassel-irc.org/pub/quassel-${version}.tar.bz2";
-    sha256 = "106zjn705vyh0msqwg3v4dhaahffhkn1bmfsljdz57jd539bf5qd";
+    sha256 = "01251y5i1fvm6s2g9acxaczk2jdyw1byr45q41q0yh9apjw938cr";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
This didn't get updated in 9c064a72dee0ddaa108dfc5e8776b5e5ee681e1e. See this failure: http://hydra.nixos.org/build/16546419
