### PR TITLE
Cleanups of legacy gst-python package

### DIFF
--- a/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, python, gstreamer
-  , gst_plugins_base, pygtk
+, gst_plugins_base, pygobject
 }:
 
 stdenv.mkDerivation rec {
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig gst_plugins_base pygtk ]
+    [ pkgconfig gst_plugins_base pygobject ]
     ;
 
   propagatedBuildInputs = [ gstreamer python ];
- 
+
   meta = {
     homepage = http://gstreamer.freedesktop.org;
 

--- a/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "0y1i4n5m1diljqr9dsq12anwazrhbs70jziich47gkdwllcza9lg";
   };
 
+  # Need to disable the testFake test case due to bug in pygobject.
+  # See https://bugzilla.gnome.org/show_bug.cgi?id=692479
+  patches = [ ./disable-testFake.patch ];
+
   buildInputs =
     [ pkgconfig gst_plugins_base pygobject ]
     ;

--- a/pkgs/development/libraries/gstreamer/legacy/gst-python/disable-testFake.patch
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-python/disable-testFake.patch
@@ -1,0 +1,56 @@
+diff -Nurp gst-python-0.10.22.orig/testsuite/test_bin.py gst-python-0.10.22/testsuite/test_bin.py
+--- gst-python-0.10.22.orig/testsuite/test_bin.py	2014-10-29 18:58:00.921827721 +0100
++++ gst-python-0.10.22/testsuite/test_bin.py	2014-10-29 19:00:32.019353092 +0100
+@@ -131,52 +131,6 @@ class BinAddRemove(TestCase):
+         self.assertRaises(gst.AddError, self.bin.add, src, sink)
+         self.bin.remove(src, sink)
+         self.assertRaises(gst.RemoveError, self.bin.remove, src, sink)
+-
+-class Preroll(TestCase):
+-    def setUp(self):
+-        TestCase.setUp(self)
+-        self.bin = gst.Bin('bin')
+-
+-    def tearDown(self):
+-        # FIXME: wait for state change thread to settle down
+-        while self.bin.__gstrefcount__ > 1:
+-            time.sleep(0.1)
+-        self.assertEquals(self.bin.__gstrefcount__, 1)
+-        del self.bin
+-        TestCase.tearDown(self)
+-
+-    def testFake(self):
+-        src = gst.element_factory_make('fakesrc')
+-        sink = gst.element_factory_make('fakesink')
+-        self.bin.add(src)
+-
+-        # bin will go to paused, src pad task will start and error out
+-        self.bin.set_state(gst.STATE_PAUSED)
+-        ret = self.bin.get_state()
+-        self.assertEquals(ret[0], gst.STATE_CHANGE_SUCCESS)
+-        self.assertEquals(ret[1], gst.STATE_PAUSED)
+-        self.assertEquals(ret[2], gst.STATE_VOID_PENDING)
+-
+-        # adding the sink will cause the bin to go in preroll mode
+-        gst.debug('adding sink and setting to PAUSED, should cause preroll')
+-        self.bin.add(sink)
+-        sink.set_state(gst.STATE_PAUSED)
+-        ret = self.bin.get_state(timeout=0)
+-        self.assertEquals(ret[0], gst.STATE_CHANGE_ASYNC)
+-        self.assertEquals(ret[1], gst.STATE_PAUSED)
+-        self.assertEquals(ret[2], gst.STATE_PAUSED)
+-
+-        # to actually complete preroll, we need to link and re-enable fakesrc
+-        src.set_state(gst.STATE_READY)
+-        src.link(sink)
+-        src.set_state(gst.STATE_PAUSED)
+-        ret = self.bin.get_state()
+-        self.assertEquals(ret[0], gst.STATE_CHANGE_SUCCESS)
+-        self.assertEquals(ret[1], gst.STATE_PAUSED)
+-        self.assertEquals(ret[2], gst.STATE_VOID_PENDING)
+-
+-        self.bin.set_state(gst.STATE_NULL)
+-        self.bin.get_state()
+  
+ class ConstructorTest(TestCase):
+     def testGood(self):


### PR DESCRIPTION
These two commits
1. Replace the `pygtk` dependency by `pygobject`, this reduces the total amount of dependencies necessary.
2. Adds a patch that disables the Preroll.testFake test case since it fails due to a [bug in pygobject](https://bugzilla.gnome.org/show_bug.cgi?id=692479).
