### PR TITLE
Added ocaml-vg-0.8.1 and deps ocaml-otfm-0.2.0 and ocaml-gg-0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, ocaml, findlib, opam }:
+
+let
+  inherit (stdenv.lib) getVersion versionAtLeast;
+
+  pname = "gg";
+  version = "0.9.0";
+  webpage = "http://erratique.ch/software/${pname}";
+in
+
+assert versionAtLeast (getVersion ocaml) "4.01.0";
+
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "055pza6jbjjj7wgzf7pbn0ccxw76i8w5b2bcnaz8b9m4x6jaa6gh";
+  };
+
+  buildInputs = [ ocaml findlib opam ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install | sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Basic types for computer graphics in OCaml";
+    longDescription = ''
+      Gg is an OCaml module providing basic types for computer graphics. It
+      defines types and functions for floats, vectors, points, sizes,
+      matrices, quaternions, axis aligned boxes, colors, color spaces, and
+      raster data.
+    '';
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jirkamarsik ];
+  };
+}

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
     sha256 = "1wgi9plf98gd7x3b7fzjxds089sivsap97bl1bw2lj73nxwnyb9c";
   };
 
-  buildInputs = [ ocaml findlib opam uutf ];
+  buildInputs = [ ocaml findlib opam ];
+
+  propagatedBuildInputs = [ uutf ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, ocaml, findlib, opam, uutf }:
+
+let
+  inherit (stdenv.lib) getVersion versionAtLeast;
+
+  pname = "otfm";
+  version = "0.2.0";
+  webpage = "http://erratique.ch/software/${pname}";
+in
+
+assert versionAtLeast (getVersion ocaml) "4.01.0";
+
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "1wgi9plf98gd7x3b7fzjxds089sivsap97bl1bw2lj73nxwnyb9c";
+  };
+
+  buildInputs = [ ocaml findlib opam uutf ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install | sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenType font decoder for OCaml";
+    longDescription = ''
+      Otfm is an in-memory decoder for the OpenType font data format. It
+      provides low-level access to font tables and functions to decode some
+      of them.
+    '';
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jirkamarsik ];
+  };
+}

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchurl, ocaml, findlib, opam, gg, uutf, otfm, js_of_ocaml,
+  pdfBackend ? true, # depends on uutf and otfm
+  htmlcBackend ? true # depends on js_of_ocaml
+}:
+
+let
+  inherit (stdenv.lib) getVersion optionals versionAtLeast;
+
+  pname = "vg";
+  version = "0.8.1";
+  webpage = "http://erratique.ch/software/${pname}";
+in
+
+assert versionAtLeast (getVersion ocaml) "4.01.0";
+
+stdenv.mkDerivation rec {
+
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "1cdcvsr5z8845ndilnrz7p4n6yn4gv2p91z2mgi4vrailcmn5vzd";
+  };
+
+  buildInputs = [ ocaml findlib opam ];
+
+  propagatedBuildInputs = [ gg ]
+                          ++ optionals pdfBackend [ uutf otfm ]
+                          ++ optionals htmlcBackend [ js_of_ocaml ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true"
+               + (if pdfBackend then " uutf=true otfm=true"
+                                else " uutf=false otfm=false")
+               + (if htmlcBackend then " jsoo=true"
+                                  else " jsoo=false");
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install | sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Declarative 2D vector graphics for OCaml";
+    longDescription = ''
+    Vg is an OCaml module for declarative 2D vector graphics. In Vg, images
+    are values that denote functions mapping points of the cartesian plane
+    to colors. The module provides combinators to define and compose these
+    values.
+
+    Renderers for PDF, SVG and the HTML canvas are distributed with the
+    module. An API allows to implement new renderers.
+    '';
+    homepage = "${webpage}";
+    platforms = ocaml.meta.platforms;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jirkamarsik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3605,6 +3605,8 @@ let
 
     ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
 
+    otfm = callPackage ../development/ocaml-modules/otfm { };
+
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
     tyxml = callPackage ../development/ocaml-modules/tyxml { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3527,6 +3527,8 @@ let
 
     patoline = callPackage ../tools/typesetting/patoline { };
 
+    gg = callPackage ../development/ocaml-modules/gg { };
+
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
 
     js_of_ocaml = callPackage ../development/tools/ocaml/js_of_ocaml { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3657,6 +3657,9 @@ let
     uucd = callPackage ../development/ocaml-modules/uucd { };
     uunf = callPackage ../development/ocaml-modules/uunf { };
     uutf = callPackage ../development/ocaml-modules/uutf { };
+
+    vg = callPackage ../development/ocaml-modules/vg { };
+
     xmlm = callPackage ../development/ocaml-modules/xmlm { };
 
     yojson = callPackage ../development/ocaml-modules/yojson { };


### PR DESCRIPTION
NB: Loading the HTML canvas backend of Vg crashes with `Unimplemented Javascript primitive caml_js_var!`. This seems to be a bug with the Nixpkgs packaging of js_of_ocaml, since it can be reproduced by just trying to load js_of_ocaml into the Ocaml toplevel.
