### PR TITLE
Fix version.h in libmsgpack

### DIFF
--- a/pkgs/development/libraries/libmsgpack/CMakeLists.patch
+++ b/pkgs/development/libraries/libmsgpack/CMakeLists.patch
@@ -1,9 +1,11 @@
 diff -r 791a4edd7e1d CMakeLists.txt
 --- a/CMakeLists.txt	Sun Oct 05 13:14:14 2014 +0100
 +++ b/CMakeLists.txt	Sun Oct 05 13:20:12 2014 +0100
-@@ -158,7 +158,7 @@
+@@ -157,8 +157,9 @@
+ 
  INSTALL (TARGETS msgpack msgpack-static DESTINATION lib)
  INSTALL (DIRECTORY src/msgpack DESTINATION include)
++INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/src/msgpack/version.h DESTINATION include/msgpack)
  INSTALL (FILES src/msgpack.h src/msgpack.hpp DESTINATION include)
 -INSTALL (FILES msgpack.pc DESTINATION lib/pkgconfig)
 +INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/msgpack.pc DESTINATION lib/pkgconfig)


### PR DESCRIPTION
Without this you can't include msgpack.h (because of non-existent msgpack/version.h) Upstream has new build script in master, so they won't accept this now.
