### PR TITLE
Support bcache volumes in initrd

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -128,6 +128,7 @@ let
       cp -v ${udev}/lib/udev/rules.d/80-drivers.rules $out/
       cp -v ${pkgs.lvm2}/lib/udev/rules.d/*.rules $out/
       cp -v ${pkgs.mdadm}/lib/udev/rules.d/*.rules $out/
+      cp -v ${pkgs.bcache-tools}/lib/udev/rules.d/*.rules $out/
 
       for i in $out/*.rules; do
           substituteInPlace $i \
@@ -137,7 +138,8 @@ let
             --replace ${pkgs.utillinux}/sbin/blkid ${extraUtils}/bin/blkid \
             --replace /sbin/blkid ${extraUtils}/bin/blkid \
             --replace ${pkgs.lvm2}/sbin ${extraUtils}/bin \
-            --replace /sbin/mdadm ${extraUtils}/bin/mdadm
+            --replace /sbin/mdadm ${extraUtils}/bin/mdadm \
+            --replace /bin/sh ${extraUtils}/bin/sh
       done
 
       # Work around a bug in QEMU, which doesn't implement the "READ

--- a/pkgs/tools/filesystems/bcache-tools/bcache-udev-modern.patch
+++ b/pkgs/tools/filesystems/bcache-tools/bcache-udev-modern.patch
@@ -1,0 +1,52 @@
+This patch does two things:
+1) Drops probe-bcache, so now new util-linux detecting functionality is used.
+2) Drops bcache-register, using kmod (built in udev) and moving registering device
+   into rule using 'sh'.
+This reduces things that need to be present in initrd, replacing them with already
+existing functionality and reducing overall initrd size.
+
+diff --git a/69-bcache.rules b/69-bcache.rules
+index 5d28e70..6a52893 100644
+--- a/69-bcache.rules
++++ b/69-bcache.rules
+@@ -10,15 +10,11 @@ KERNEL=="fd*|sr*", GOTO="bcache_end"
+ # It recognised bcache (util-linux 2.24+)
+ ENV{ID_FS_TYPE}=="bcache", GOTO="bcache_backing_found"
+ # It recognised something else; bail
+-ENV{ID_FS_TYPE}=="?*", GOTO="bcache_backing_end"
+-
+-# Backing devices: scan, symlink, register
+-IMPORT{program}="probe-bcache -o udev $tempnode"
+-ENV{ID_FS_TYPE}!="bcache", GOTO="bcache_backing_end"
+-ENV{ID_FS_UUID_ENC}=="?*", SYMLINK+="disk/by-uuid/$env{ID_FS_UUID_ENC}"
++GOTO="bcache_backing_end"
+ 
+ LABEL="bcache_backing_found"
+-RUN+="bcache-register $tempnode"
++RUN{builtin}+="kmod load bcache"
++RUN+="/bin/sh -c 'echo $tempnode > /sys/fs/bcache/register_quiet'"
+ LABEL="bcache_backing_end"
+ 
+ # Cached devices: symlink
+diff --git a/Makefile b/Makefile
+index 3f8d87b..15638a7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -9,7 +9,7 @@ all: make-bcache probe-bcache bcache-super-show
+ 
+ install: make-bcache probe-bcache bcache-super-show
+ 	$(INSTALL) -m0755 make-bcache bcache-super-show	$(DESTDIR)${PREFIX}/sbin/
+-	$(INSTALL) -m0755 probe-bcache bcache-register		$(DESTDIR)$(UDEVLIBDIR)/
++#	$(INSTALL) -m0755 probe-bcache bcache-register		$(DESTDIR)$(UDEVLIBDIR)/
+ 	$(INSTALL) -m0644 69-bcache.rules	$(DESTDIR)$(UDEVLIBDIR)/rules.d/
+ 	$(INSTALL) -m0644 -- *.8 $(DESTDIR)${PREFIX}/share/man/man8/
+ 	$(INSTALL) -D -m0755 initramfs/hook	$(DESTDIR)/usr/share/initramfs-tools/hooks/bcache
+diff --git a/bcache-register b/bcache-register
+index 9b592bc..75b4faf 100755
+--- a/bcache-register
++++ b/bcache-register
+@@ -1,4 +1,3 @@
+ #!/bin/sh
+-/sbin/modprobe -qba bcache
+ test -f /sys/fs/bcache/register_quiet && echo "$1" > /sys/fs/bcache/register_quiet
+ 

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
         -e "/INSTALL.*initcpio\/install/d" \
         -e "/INSTALL.*dracut\/module-setup.sh/d" \
         -i Makefile
-
-    sed -e "s|/sbin/modprobe|${kmod}/sbin/modprobe|" -i bcache-register
   '';
+
+  patches = [ ./bcache-udev-modern.patch ];
 
   preBuild = ''
     export makeFlags="$makeFlags PREFIX=\"$out\" UDEVLIBDIR=\"$out/lib/udev/\"";


### PR DESCRIPTION
This adds support for registering bcache volumes on demand using udev. To minimize amount of things added to initrd this also changes udev rule provided by bcache-tools to have lesser dependencies.
