### PR TITLE
Removed leaveDotGit from fetchgit, since it's broken by design.

### DIFF
--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -7,7 +7,6 @@ source $stdenv/setup
 header "exporting $url (rev $rev) into $out"
 
 $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
-  ${leaveDotGit:+--leave-dotGit} \
   ${fetchSubmodules:+--fetch-submodules}
 
 stopNest

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,5 +1,5 @@
 {stdenv, git, cacert}:
-{url, rev ? "HEAD", md5 ? "", sha256 ? "", leaveDotGit ? false, fetchSubmodules ? true
+{url, rev ? "HEAD", md5 ? "", sha256 ? "", fetchSubmodules ? true
 , name ? "git-export"
 }:
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   outputHashMode = "recursive";
   outputHash = if sha256 == "" then md5 else sha256;
 
-  inherit url rev leaveDotGit fetchSubmodules;
+  inherit url rev fetchSubmodules;
 
   GIT_SSL_CAINFO = "${cacert}/etc/ca-bundle.crt";
 

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -5,7 +5,6 @@ rev=
 expHash=
 hashType=$NIX_HASH_ALGO
 deepClone=$NIX_PREFETCH_GIT_DEEP_CLONE
-leaveDotGit=$NIX_PREFETCH_GIT_LEAVE_DOT_GIT
 fetchSubmodules=
 builder=
 
@@ -13,12 +12,6 @@ if test -n "$deepClone"; then
   deepClone=true
 else
   deepClone=false
-fi
-
-if test "$leaveDotGit" != 1; then
-  leaveDotGit=
-else
-  leaveDotGit=true
 fi
 
 
@@ -33,7 +26,6 @@ for arg; do
       --hash) argfun=set_hashType;;
       --deepClone) deepClone=true;;
       --no-deepClone) deepClone=false;;
-      --leave-dotGit) leaveDotGit=true;;
       --fetch-submodules) fetchSubmodules=true;;
       --builder) builder=true;;
       *)
@@ -67,7 +59,6 @@ Options:
       --hash h        Expected hash.
       --deepClone     Clone submodules recursively.
       --no-deepClone  Do not clone submodules.
-      --leave-dotGit  Keep the .git directories.
       --fetch-submodules Fetch submodules.
       --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
 "
@@ -223,14 +214,8 @@ clone_user_rev() {
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
-    if test -z "$leaveDotGit"; then
-	echo "removing \`.git'..." >&2
-        find $dir -name .git\* | xargs rm -rf
-    else
-        # The logs and index contain timestamps, and the hooks contain
-        # the nix path of git's bash
-        find $dir -name .git | xargs -I {} rm -rf {}/logs {}/index {}/hooks
-    fi
+    echo "removing \`.git'..." >&2
+    find $dir -name .git\* | xargs rm -rf
 }
 
 if test -n "$builder"; then


### PR DESCRIPTION
fetchgit with leaveDotGit can never be deterministic, since the
resulting .git can change whenever the upstream repository
changes.

Since it is impossible for git to download a single commit, fetchgit
downloads the whole repository and searches for the specific
commit. This means that the resulting .git contains the whole
repository, including any commit that was made after the one we
want. This also mean that adding any commit to the repository will add
it to prefetch's .git, thus changing its hash, and making it impossible
to make it deterministic.
