### PR TITLE
scala: Bump up version from 2.11.2 to 2.11.4

### DIFF
--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  name = "scala-2.11.2";
+  name = "scala-2.11.4";
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "0mnjhjiixjphr9v101v408815hkl6hlghx9h7lmmylv5z7gk3p8k";
+    sha256 = "0irm601naxdhy53icsspwd73sdnx27gbq65dysfd0d63klqmkvcc";
   };
 
   buildInputs = [ jre makeWrapper ] ;


### PR DESCRIPTION
“Scala 2.11.4 is a bugfix release that is binary compatible with previous releases in the Scala 2.11 series.″
http://www.scala-lang.org/news/2.11.4
