### PR TITLE
kernel security: set nx bit on module ro segments.

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -176,6 +176,9 @@ with stdenv.lib;
   CIFS_POSIX y
   CIFS_FSCACHE y
 
+  # Runtime testing
+  DEBUG_SET_MODULE_RONX? y # Detect writes to read-only module pages
+
   # Security related features.
   STRICT_DEVMEM y # Filter access to /dev/mem
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default


### PR DESCRIPTION
This is a config setting I saw that Ubuntu uses 

https://wiki.ubuntu.com/Security/Features#module-ronx
