### PR TITLE
Document likely breakage when people update the kernel.

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
+  # Remember to update grsecurity!
   version = "3.14.23";
   extraMeta.branch = "3.14";
 

--- a/pkgs/os-specific/linux/kernel/linux-3.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.17.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, ... } @ args:
 
 import ./generic.nix (args // rec {
+  # Remember to update grsecurity!
   version = "3.17.2";
   extraMeta.branch = "3.17";
 


### PR DESCRIPTION
grsecurity is being broken every other day.  Don't update the kernel without updating grsecurity.
