### PR TITLE
badvpn: Add debug flag to enable assertions.

### DIFF
--- a/pkgs/tools/networking/badvpn/default.nix
+++ b/pkgs/tools/networking/badvpn/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cmake, openssl, nss, pkgconfig, nspr, bash}:
+{stdenv, fetchurl, cmake, openssl, nss, pkgconfig, nspr, bash, debug ? false}:
 let
   s = # Generated upstream information
   rec {
@@ -12,6 +12,7 @@ let
   buildInputs = [
     cmake openssl nss pkgconfig nspr
   ];
+  compileFlags = "-O3 ${stdenv.lib.optionalString (!debug) "-DNDEBUG"}";
 in
 stdenv.mkDerivation {
   inherit (s) name version;
@@ -23,6 +24,7 @@ stdenv.mkDerivation {
   preConfigure = ''
     find . -name '*.sh' -exec sed -e 's@#!/bin/sh@${stdenv.shell}@' -i '{}' ';'
     find . -name '*.sh' -exec sed -e 's@#!/bin/bash@${bash}/bin/bash@' -i '{}' ';'
+    cmakeFlagsArray=("-DCMAKE_BUILD_TYPE=" "-DCMAKE_C_FLAGS=${compileFlags}");
   '';
 
   meta = {


### PR DESCRIPTION
This adds a "debug" flag to prevent NDEBUG from being passed, enabling assertions.

This works by setting the CMAKE_C_FLAGS to whatever we need them to be, while setting the CMAKE_BUILD_TYPE back to empty (set to Release by the default builder). Because otherwise -DNDEBUG would be added by cmake on top of our flags, nullifying the effect.

It would be nice to do this in a way that all cmake packages would have this functionality automatically, but right now I really need this.
