### PR TITLE
kernel: Enable PPP_FILTER by default.

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -239,6 +239,7 @@ with stdenv.lib;
   MTRR_SANITIZER y
   NET_FC y # Fibre Channel driver support
   PPP_MULTILINK y # PPP multilink support
+  PPP_FILTER y
   REGULATOR y # Voltage and Current Regulator Support
   ${optionalString (versionAtLeast version "3.6") ''
     RC_DEVICES? y # Enable IR devices


### PR DESCRIPTION
pppd will try to use it to improve efficiency and complain if it's not available
(but is is not mandatory).
