### PR TITLE
sage fixes

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -23,9 +23,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.scilab.org/;
-    description = "Scientific software package for numerical computations (Matlab lookalike)";
-    # see http://www.scilab.org/legal
-    license = "SciLab";
+    homepage = "http://www.sagemath.org";
+    description = "A free open source mathematics software system";
+    license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "sage-6.1.1";
 
   src = fetchurl {
-    url = "http://mirrors.xmission.com/sage/src/sage-6.1.1.tar.gz";
+    url = "http://www.sagemath.org/src-old/sage-6.1.1.tar.gz";
     sha256 = "0kbzs0l9q7y34jv3f8rd1c2mrjsjkdgaw6mfdwjlpg9g4gghmq5y";
   };
 


### PR DESCRIPTION
These patches fix metadata and updates the download URL for the sage package (see #4784).
Note that version 6.1.1 is obsolete, but version 6.3 will not build for me.
I assume 6.1.1 once did build for someone and have opted to fix the url rather
than do a version bump.
