### PR TITLE
ghc-mod 5.2.1.0 - Fix #387, Pattern match failure in GhcPkg

### DIFF
--- a/pkgs/development/libraries/haskell/ghc-mod/default.nix
+++ b/pkgs/development/libraries/haskell/ghc-mod/default.nix
@@ -9,8 +9,8 @@
 
 cabal.mkDerivation (self: {
   pname = "ghc-mod";
-  version = "5.2.0.0";
-  sha256 = "1zwdr3zlnc8d49d6jrvj2yrfnamp1120gffzd6vfxqgvapk71vfk";
+  version = "5.2.1.0";
+  sha256 = "09858zn4xxgppaqb9ykxisnsd6crrv0671ms7l0hqi37scbf95bj";
   isLibrary = true;
   isExecutable = true;
   buildDepends = [


### PR DESCRIPTION
ghc-mod 5.2.0.0 was broken for NixOS - 5.2.1.0 fixes the issue
