### PR TITLE
ZFS improvements

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -223,4 +223,14 @@ rec {
 
   crossLists = f: foldl (fs: args: concatMap (f: map f args) fs) [f];
 
+  # Remove duplicate elements from the list
+  unique = list:
+    if list == [] then
+      []
+    else
+      let
+        x = head list;
+        xs = unique (drop 1 list);
+      in [x] ++ remove x xs;
+
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -45,6 +45,9 @@ with lib;
   # Add support for cow filesystems and their utilities
   boot.supportedFilesystems = [ /* "zfs" */ "btrfs" ];
 
+  # Configure host id for ZFS to work
+  networking.hostId = "8425e349";
+
   # Allow the user to log in as root without a password.
   users.extraUsers.root.initialHashedPassword = "";
 }

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -476,6 +476,14 @@ EOF
 EOF
         }
 
+        # Generate a random 32-bit value to use as the host id
+        open my $rnd, "<", "/dev/urandom" or die $!;
+        read $rnd, $hostIdBin, 4;
+        close $rnd;
+
+        # Convert the 32-bit value to a hex string
+        my $hostIdHex = unpack("H*", $hostIdBin);
+
         write_file($fn, <<EOF);
 # Edit this configuration file to define what should be installed on
 # your system.  Help is available in the configuration.nix(5) man page
@@ -491,6 +499,7 @@ EOF
 
 $bootLoaderConfig
   # networking.hostName = "nixos"; # Define your hostname.
+  networking.hostId = "$hostIdHex";
   # networking.wireless.enable = true;  # Enables wireless.
 
   # Select internationalisation properties.

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -122,6 +122,9 @@ for o in $(cat /proc/cmdline); do
     esac
 done
 
+# Set hostid before modules are loaded.
+# This is needed by the spl/zfs modules.
+@setHostId@
 
 # Load the required kernel modules.
 mkdir -p /lib

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -188,6 +188,15 @@ let
     fsInfo =
       let f = fs: [ fs.mountPoint (if fs.device != null then fs.device else "/dev/disk/by-label/${fs.label}") fs.fsType fs.options ];
       in pkgs.writeText "initrd-fsinfo" (concatStringsSep "\n" (concatMap f fileSystems));
+
+    setHostId = optionalString (config.networking.hostId != null) ''
+      hi="${config.networking.hostId}"
+      ${if pkgs.stdenv.isBigEndian then ''
+        echo -ne "\x''${hi:0:2}\x''${hi:2:2}\x''${hi:4:2}\x''${hi:6:2}" > /etc/hostid
+      '' else ''
+        echo -ne "\x''${hi:6:2}\x''${hi:4:2}\x''${hi:2:2}\x''${hi:0:2}" > /etc/hostid
+      ''}
+    '';
   };
 
 

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -189,6 +189,10 @@ let
 
   };
 
+  hexChars = stringToCharacters "0123456789abcdef";
+
+  isHexString = s: all (c: elem c hexChars) (stringToCharacters (toLower s));
+
 in
 
 {
@@ -202,6 +206,20 @@ in
       description = ''
         The name of the machine.  Leave it empty if you want to obtain
         it from a DHCP server (if using DHCP).
+      '';
+    };
+
+    networking.hostId = mkOption {
+      default = null;
+      example = "4e98920d";
+      type = types.nullOr types.str;
+      description = ''
+        The 32-bit host ID of the machine, formatted as 8 hexadecimal characters.
+
+        You should try to make this ID unique among your machines. You can
+        generate a random 32-bit ID using the following command:
+
+        <literal>head -c4 /dev/urandom | od -A none -t x4</literal>
       '';
     };
 
@@ -513,10 +531,15 @@ in
   config = {
 
     assertions =
-      flip map interfaces (i: {
+      (flip map interfaces (i: {
         assertion = i.subnetMask == null;
         message = "The networking.interfaces.${i.name}.subnetMask option is defunct. Use prefixLength instead.";
-      });
+      })) ++ [
+        {
+          assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
+          message = "Invalid value given to the networking.hostId option.";
+        }
+      ];
 
     boot.kernelModules = [ ]
       ++ optional cfg.enableIPv6 "ipv6"
@@ -872,13 +895,28 @@ in
     # clear it if it's not configured in the NixOS configuration,
     # since it may have been set by dhcpcd in the meantime.
     system.activationScripts.hostname =
-      optionalString (config.networking.hostName != "") ''
-        hostname "${config.networking.hostName}"
+      optionalString (cfg.hostName != "") ''
+        hostname "${cfg.hostName}"
       '';
     system.activationScripts.domain =
-      optionalString (config.networking.domain != "") ''
-        domainname "${config.networking.domain}"
+      optionalString (cfg.domain != "") ''
+        domainname "${cfg.domain}"
       '';
+
+    environment.etc = mkIf (cfg.hostId != null)
+      [
+        {
+          target = "hostid";
+          source = pkgs.runCommand "gen-hostid" {} ''
+            hi="${cfg.hostId}"
+            ${if pkgs.stdenv.isBigEndian then ''
+              echo -ne "\x''${hi:0:2}\x''${hi:2:2}\x''${hi:4:2}\x''${hi:6:2}" > $out
+            '' else ''
+              echo -ne "\x''${hi:6:2}\x''${hi:4:2}\x''${hi:2:2}\x''${hi:0:2}" > $out
+            ''}
+          '';
+        }
+      ];
 
     services.udev.extraRules =
       ''

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -50,12 +50,23 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  # Remove provided services as they are buggy
+  postInstall = ''
+    rm $out/etc/systemd/system/zfs-import-*.service
+
+    sed -i '/zfs-import-scan.service/d' $out/etc/systemd/system/*
+
+    for i in $out/etc/systemd/system/*; do
+      substituteInPlace $i --replace "zfs-import-cache.service" "zfs-import.target"
+    done
+  '';
+
   meta = {
     description = "ZFS Filesystem Linux Kernel module";
     longDescription = ''
       ZFS is a filesystem that combines a logical volume manager with a
       Copy-On-Write filesystem with data integrity detection and repair,
-      snapshotting, cloning, block devices, deduplication, and more. 
+      snapshotting, cloning, block devices, deduplication, and more.
       '';
     homepage = http://zfsonlinux.org/;
     license = stdenv.lib.licenses.cddl;

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -20,24 +20,32 @@ stdenv.mkDerivation {
   NIX_CFLAGS_LINK = "-lgcc_s";
 
   preConfigure = ''
-    ./autogen.sh
+    substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "umount -t zfs"           "${utillinux}/bin/umount -t zfs"
+    substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "mount -t zfs"            "${utillinux}/bin/mount -t zfs"
+    substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/umount"             "${utillinux}/bin/umount"
+    substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/mount"              "${utillinux}/bin/mount"
+    substituteInPlace ./udev/rules.d/*            --replace "/lib/udev/vdev_id"       "$out/lib/udev/vdev_id"
+    substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/ztest"         "$out/sbin/ztest"
+    substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/zdb"           "$out/sbin/zdb"
+    substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
+    substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d"
+    substituteInPlace ./etc/zfs/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
+    substituteInPlace ./cmd/zed/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
 
-    substituteInPlace ./module/zfs/zfs_ctldir.c    --replace "umount -t zfs"     "${utillinux}/bin/umount -t zfs"
-    substituteInPlace ./module/zfs/zfs_ctldir.c    --replace "mount -t zfs"      "${utillinux}/bin/mount -t zfs"
-    substituteInPlace ./lib/libzfs/libzfs_mount.c  --replace "/bin/umount"       "${utillinux}/bin/umount"
-    substituteInPlace ./lib/libzfs/libzfs_mount.c  --replace "/bin/mount"        "${utillinux}/bin/mount"
-    substituteInPlace ./udev/rules.d/*             --replace "/lib/udev/vdev_id" "$out/lib/udev/vdev_id"
-    substituteInPlace ./cmd/ztest/ztest.c          --replace "/usr/sbin/ztest"   "$out/sbin/ztest"
-    substituteInPlace ./cmd/ztest/ztest.c          --replace "/usr/sbin/zdb"     "$out/sbin/zdb"
+    ./autogen.sh
   '';
 
   configureFlags = [
-    "--disable-systemd"
+    "--enable-systemd"
     "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
     "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "--with-spl=${spl}/libexec/spl"
     "--with-dracutdir=$(out)/lib/dracut"
     "--with-udevdir=$(out)/lib/udev"
+    "--with-systemdunitdir=$(out)/etc/systemd/system"
+    "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/zfs/git.nix
+++ b/pkgs/os-specific/linux/zfs/git.nix
@@ -17,24 +17,32 @@ stdenv.mkDerivation {
   NIX_CFLAGS_LINK = "-lgcc_s";
 
   preConfigure = ''
-    ./autogen.sh
+    substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "umount -t zfs"           "${utillinux}/bin/umount -t zfs"
+    substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "mount -t zfs"            "${utillinux}/bin/mount -t zfs"
+    substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/umount"             "${utillinux}/bin/umount"
+    substituteInPlace ./lib/libzfs/libzfs_mount.c --replace "/bin/mount"              "${utillinux}/bin/mount"
+    substituteInPlace ./udev/rules.d/*            --replace "/lib/udev/vdev_id"       "$out/lib/udev/vdev_id"
+    substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/ztest"         "$out/sbin/ztest"
+    substituteInPlace ./cmd/ztest/ztest.c         --replace "/usr/sbin/zdb"           "$out/sbin/zdb"
+    substituteInPlace ./config/user-systemd.m4    --replace "/usr/lib/modules-load.d" "$out/etc/modules-load.d"
+    substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d"
+    substituteInPlace ./etc/zfs/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
+    substituteInPlace ./cmd/zed/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
 
-    substituteInPlace ./module/zfs/zfs_ctldir.c    --replace "umount -t zfs"     "${utillinux}/bin/umount -t zfs"
-    substituteInPlace ./module/zfs/zfs_ctldir.c    --replace "mount -t zfs"      "${utillinux}/bin/mount -t zfs"
-    substituteInPlace ./lib/libzfs/libzfs_mount.c  --replace "/bin/umount"       "${utillinux}/bin/umount"
-    substituteInPlace ./lib/libzfs/libzfs_mount.c  --replace "/bin/mount"        "${utillinux}/bin/mount"
-    substituteInPlace ./udev/rules.d/*             --replace "/lib/udev/vdev_id" "$out/lib/udev/vdev_id"
-    substituteInPlace ./cmd/ztest/ztest.c          --replace "/usr/sbin/ztest"   "$out/sbin/ztest"
-    substituteInPlace ./cmd/ztest/ztest.c          --replace "/usr/sbin/zdb"     "$out/sbin/zdb"
+    ./autogen.sh
   '';
 
   configureFlags = [
-    "--disable-systemd"
+    "--enable-systemd"
     "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
     "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "--with-spl=${spl_git}/libexec/spl"
     "--with-dracutdir=$(out)/lib/dracut"
     "--with-udevdir=$(out)/lib/udev"
+    "--with-systemdunitdir=$(out)/etc/systemd/system"
+    "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/zfs/git.nix
+++ b/pkgs/os-specific/linux/zfs/git.nix
@@ -47,6 +47,17 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  # Remove provided services as they are buggy
+  postInstall = ''
+    rm $out/etc/systemd/system/zfs-import-*.service
+
+    sed -i '/zfs-import-scan.service/d' $out/etc/systemd/system/*
+
+    for i in $out/etc/systemd/system/*; do
+      substituteInPlace $i --replace "zfs-import-cache.service" "zfs-import.target"
+    done
+  '';
+
   meta = {
     description = "ZFS Filesystem Linux Kernel module";
     longDescription = ''

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -187,6 +187,7 @@ let
       isArm = system == "armv5tel-linux"
            || system == "armv6l-linux"
            || system == "armv7l-linux";
+      isBigEndian = system == "powerpc-linux";
 
       # For convenience, bring in the library functions in lib/ so
       # packages don't have to do that themselves.


### PR DESCRIPTION
This PR does the following:
- Uses the upstream systemd services by default (including the one for zed - the ZFS Event Daemon)
- Reimplements the ZFS pool import service so that:
  - We do not fail if there are no ZFS pools to import
  - We not rely on `/etc/zfs/zpool.cache`, which eliminates some issues
  - Instead, the ZFS pools to import have to be specified in `configuration.nix`
  - To avoid issues and make configuration simpler, NixOS will automatically infer the necessary ZFS pools to import for ZFS filesystems which are defined in `fileSystems.*`
  - For ZFS pools which are not mentioned in `fileSystems.*`, the user will have to add them to `boot.zfs.extraPools` if they want them to be automatically imported on every boot
  - Please note that the way in which this PR is now importing ZFS pools is more or less the direction in which upstream ZFS seems to be moving towards
- Added option to disable force import (i.e. `--force / -f`) of ZFS pools. Currently, we still force-import by default to maintain backwards compatibility with NixOS systems that don't have the host ID recorded in their ZFS pool labels, but once most people upgrade to this PR we should disable force-importing by default
- Reimplement SPL's host ID configuration so that:
  - The SPL now correctly picks up the host ID defined in `configuration.nix` (this wasn't happening before due to a bug in the SPL)
  - The host ID is now configured system-wide by writing it to `/etc/hostid`, which makes the ZFS userspace tools agree with the kernel as to what the host ID is. It also makes glibc (and therefore, other unrelated applications) pick up the host ID defined in `configuration.nix`
  - Renamed `boot.spl.hostid` to `networking.hostId`, to make it clear that the host ID is a system-wide config option and not tied to the SPL. I've put it under `networking` because it closely resembles `networking.hostName` in terms of purpose
  - Only allow ZFS to be enabled if `networking.hostId` is set. Otherwise, ZFS pools will not record the host ID in the vdev labels and it will be impossible to open or import a ZFS pool without passing the `--force / -f` parameter
- Make `nixos-generate-config` generate a random 32-bit host ID by default (when installing NixOS). This makes the host ID more reliable than falling back to the default glibc behavior of generating a host ID based on the IP address, which can change quite often and conflict with other machines in the same network in some cases. It also makes using ZFS easier by not requiring the user to worry about manually generating a host ID themselves and adding it to `configuration.nix`

The commit messages contain a bit more details regarding the issues above.
