### PR TITLE
libcec: patch dlopen path

### DIFF
--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation {
 
   buildInputs = [ autoreconfHook pkgconfig udev ];
 
+  # Fix dlopen path
+  patchPhase = ''
+    substituteInPlace include/cecloader.h --replace "libcec.so" "$out/lib/libcec.so"
+  '';
+
   meta = with stdenv.lib; {
     description = "USB CEC adapter communication library";
     homepage = "http://libcec.pulse-eight.com";


### PR DESCRIPTION
Otherwise we get:

```
libcec.so.2: cannot open shared object file: No such file or directory
Cannot load libcec.so
```
