### PR TITLE
Create wrapper package for fcitx with plugins.

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/default.nix
+++ b/pkgs/tools/inputmethods/fcitx/default.nix
@@ -5,7 +5,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-4.2.8.5";
+  name = "fcitx-${version}";
+  version = "4.2.8.5";
 
   src = fetchurl {
     url = "http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz";

--- a/pkgs/tools/inputmethods/fcitx/wrapper.nix
+++ b/pkgs/tools/inputmethods/fcitx/wrapper.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildEnv, fcitx, makeWrapper, plugins }:
+
+# This is based on the pidgin-with-plugins package.
+# Users should be able to configure what plugins are used
+# by putting the following in their /etc/nixos/configuration.nix:
+# environment.systemPackages = with pkgs; [
+#     (fcitx-with-plugins.override { plugins = [ fcitx-anthy ]; })
+# ]
+# Or, a normal user could use it by putting the following in his
+# ~/.nixpkgs/config.nix:
+# packageOverrides = pkgs: with pkgs; rec {
+#     (fcitx-with-plugins.override { plugins = [ fcitx-anthy ]; })
+# }
+
+let
+drv = buildEnv {
+  name = "fcitx-with-plugins-" + (builtins.parseDrvName fcitx.name).version;
+
+  paths = [ fcitx ] ++ plugins;
+
+  postBuild = ''
+    # TODO: This could be avoided if buildEnv could be forced to create all directories
+    if [ -L $out/bin ]; then
+      rm $out/bin
+      mkdir $out/bin
+      for i in ${fcitx}/bin/*; do
+        ln -s $i $out/bin
+      done
+    fi
+    wrapProgram $out/bin/fcitx \
+      --set FCITXDIR "$out/"
+  '';
+  };
+in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1117,6 +1117,10 @@ let
 
   fcitx-configtool = callPackage ../tools/inputmethods/fcitx/fcitx-configtool.nix { };
 
+  fcitx-with-plugins = callPackage ../tools/inputmethods/fcitx/wrapper.nix {
+    plugins = [ ];
+  };
+
   fcron = callPackage ../tools/system/fcron { };
 
   fdm = callPackage ../tools/networking/fdm {};


### PR DESCRIPTION
This creates a wrapper package for fcitx so that plugins can be enabled by the user.  This is based on the wrapper package for pidgin-with-plugins.

By using this wrapper instead of the fcitx package itself, it will be possible for the user to enable/disable plugins.

This is an improvement over #4713 that just makes a wrapper package with the plugins instead of creating an entire new package that must be compiled.  This also closes the issue #4550.
