### PR TITLE
nixos/git-daemon: fix a bug and add 'user' and 'group' options

### DIFF
--- a/nixos/modules/services/networking/git-daemon.nix
+++ b/nixos/modules/services/networking/git-daemon.nix
@@ -122,7 +122,7 @@ in
         + (optionalString (cfg.basePath != "") "--base-path=${cfg.basePath} ")
         + (optionalString (cfg.listenAddress != "") "--listen=${cfg.listenAddress} ")
         + "--port=${toString cfg.port} --user=${cfg.user} --group=${cfg.group} ${cfg.options} "
-        + "--verbose " + (optionalString cfg.exportAll "--export-all")  + concatStringsSep " " cfg.repositories;
+        + "--verbose " + (optionalString cfg.exportAll "--export-all ")  + concatStringsSep " " cfg.repositories;
     };
 
   };

--- a/nixos/modules/services/networking/git-daemon.nix
+++ b/nixos/modules/services/networking/git-daemon.nix
@@ -14,6 +14,7 @@ in
     services.gitDaemon = {
 
       enable = mkOption {
+        type = types.bool;
         default = false;
         description = ''
           Enable Git daemon, which allows public hosting  of git repositories
@@ -28,6 +29,7 @@ in
       };
 
       basePath = mkOption {
+        type = types.str;
         default = "";
         example = "/srv/git/";
         description = ''
@@ -38,6 +40,7 @@ in
       };
 
       exportAll = mkOption {
+        type = types.bool;
         default = false;
         description = ''
           Publish all directories that look like Git repositories (have the objects
@@ -52,6 +55,7 @@ in
       };
 
       repositories = mkOption {
+        type = types.listOf types.str;
         default = [];
         example = [ "/srv/git" "/home/user/git/repo2" ];
         description = ''
@@ -64,17 +68,20 @@ in
       };
 
       listenAddress = mkOption {
+        type = types.str;
         default = "";
         example = "example.com";
         description = "Listen on a specific IP address or hostname.";
       };
 
       port = mkOption {
+        type = types.int;
         default = 9418;
         description = "Port to listen on.";
       };
 
       options = mkOption {
+        type = types.str;
         default = "";
         description = "Extra configuration options to be passed to Git daemon.";
       };


### PR DESCRIPTION
This fixes a bug when using together `exportAll` and `repositories` and adds `user` and `group` options. Latter allow one, e.g., to run gitolite with access rights and git-daemon for pulls in the same gitolite home.
