### PR TITLE
initialized git repo should use the set http_proxy

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -83,6 +83,7 @@ init_remote(){
     local url=$1
     git init
     git remote add origin $url
+    [ -n "$http_proxy" ] && git config http.proxy $http_proxy
 }
 
 # Return the reference of an hash if it exists on the remote repository.


### PR DESCRIPTION
Non destructive change that will make proxy users, already behind a proxy whom are switching to use it, lives more bearable. Since atm fetchgit breaks in such situations.
