### PR TITLE
syslog-ng 3.6

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -131,5 +131,6 @@ in zipModules ([]
 ++ obsolete' [ "programs" "bash" "enable" ]
 ++ obsolete' [ "services" "samba" "defaultShare" ]
 ++ obsolete' [ "services" "syslog-ng" "serviceName" ]
+++ obsolete' [ "services" "syslog-ng" "listenToJournal" ]
 
 )

--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -43,15 +43,6 @@ in {
           The package providing syslog-ng binaries.
         '';
       };
-      listenToJournal = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether syslog-ng should listen to the syslog socket used
-          by journald, and therefore receive all logs that journald
-          produces.
-        '';
-      };
       extraModulePaths = mkOption {
         type = types.listOf types.str;
         default = [];
@@ -74,7 +65,7 @@ in {
       configHeader = mkOption {
         type = types.lines;
         default = ''
-          @version: 3.5
+          @version: 3.6
           @include "scl.conf"
         '';
         description = ''
@@ -86,18 +77,13 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.sockets.syslog = mkIf cfg.listenToJournal {
-      wantedBy = [ "sockets.target" ];
-      socketConfig.Service = "syslog-ng.service";
-    };
     systemd.services.syslog-ng = {
       description = "syslog-ng daemon";
       preStart = "mkdir -p /{var,run}/syslog-ng";
-      wantedBy = optional (!cfg.listenToJournal) "multi-user.target";
+      wantedBy = [ "multi-user.target" ];
       after = [ "multi-user.target" ]; # makes sure hostname etc is set
       serviceConfig = {
         Type = "notify";
-        Sockets = if cfg.listenToJournal then "syslog.socket" else null;
         StandardOutput = "null";
         Restart = "on-failure";
         ExecStart = "${cfg.package}/sbin/syslog-ng ${concatStringsSep " " syslogngOptions}";

--- a/pkgs/tools/system/syslog-ng-incubator/default.nix
+++ b/pkgs/tools/system/syslog-ng-incubator/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "syslog-ng-incubator-${version}";
-  version = "0.3.3";
+  version = "141106-54179c5";
 
   src = fetchFromGitHub {
     owner = "balabit";
     repo = "syslog-ng-incubator";
-    rev = name;
-    sha256 = "0pswajcw9f651c1jmprbf1mlr6qadiaplyygz5j16vj0d23x4mal";
+    rev = "54179c5f733487fe97ee856bc27130d0b09f3d5a";
+    sha256 = "1y099f7pdan1441ycycd67igcwbla2m2cgnxjfvdw76llvi35sam";
   };
 
   buildInputs = [
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--without-ivykis"
-    "--with-riemann"
     "--with-module-dir=$(out)/lib/syslog-ng"
   ];
 

--- a/pkgs/tools/system/syslog-ng/default.nix
+++ b/pkgs/tools/system/syslog-ng/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchurl, eventlog, pkgconfig, glib, python, systemd, perl }:
+{ stdenv, fetchurl, eventlog, pkgconfig, glib, python, systemd, perl
+, riemann_c_client, protobufc, yacc }:
 
 stdenv.mkDerivation rec {
   name = "syslog-ng-${version}";
 
-  version = "3.5.6";
+  version = "3.6.1";
 
   src = fetchurl {
     url = "http://www.balabit.com/downloads/files?path=/syslog-ng/sources/${version}/source/syslog-ng_${version}.tar.gz";
-    sha256 = "19i1idklpgn6mz0mg7194by5fjgvvh5n4v2a0rr1z0778l2038kc";
+    sha256 = "1s3lsxk2pky3jkfamkw5ivpxq2kazikcvdgpmxiyn5w10dwkd0m7";
   };
 
-  buildInputs = [ eventlog pkgconfig glib python systemd perl ];
+  buildInputs = [ eventlog pkgconfig glib python systemd perl riemann_c_client protobufc yacc ];
 
   configureFlags = [
     "--enable-dynamic-linking"


### PR DESCRIPTION
Revert the revert in 8e1072fd60f9dcf5eac0bb2d604258f121b658d8 and fix the `syslog-ng-incubator` build to work with syslog-ng 3.6
