### PR TITLE
release-lib: add option to use another package set

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,9 +1,9 @@
-{ supportedSystems }:
+{ supportedSystems, packageSet ? (import ./all-packages.nix) }:
 
 rec {
 
   # Ensure that we don't build packages marked as unfree.
-  allPackages = args: import ./all-packages.nix (args // {
+  allPackages = args: packageSet (args // {
     config.allowUnfree = false;
   });
 


### PR DESCRIPTION
This allows one to use release-lib for his own package trees, like this (release.nix for Hydra):

```
{ supportedSystems ? [ "x86_64-linux" ] }:
let
  lib = import <nixpkgs/pkgs/top-level/release-lib.nix> {
    inherit supportedSystems;
    packageSet = import <mytree>;
  };
in
lib.mapTestOn (lib.packagesWithMetaPlatform lib.pkgs)
```
