### PR TITLE
Folly: add package

### DIFF
--- a/pkgs/development/libraries/double-conversion/default.nix
+++ b/pkgs/development/libraries/double-conversion/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "double-conversion-1.1.5";
+
+  src = fetchurl {
+    url = "https://double-conversion.googlecode.com/files/${name}.tar.gz";
+    sha256 = "0hnlyn9r8vd9b3dafnk01ykz4k7bk6xvmvslv93as1cswf7vdvqv";
+  };
+
+  unpackPhase = ''
+    mkdir $name
+    cd $name
+    tar xzf $src
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Binary-decimal and decimal-binary routines for IEEE doubles";
+    homepage = https://code.google.com/p/double-conversion/;
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = maintainers.abbradar;
+  };
+}

--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, autoreconfHook, boost, libevent, double_conversion, glog
+, google-gflags, python, libiberty }:
+
+stdenv.mkDerivation rec {
+  name = "folly-12";
+
+  src = fetchgit {
+    url = "https://github.com/facebook/folly";
+    rev = "8d3b079a75fe1a8cf5811f290642b4f494f13822";
+    sha256 = "005fa202aca29c3a6757ae3bb050a6e4e5e773a1439f5803257a5f9e3cc9bdb6";
+  };
+
+  buildInputs = [ libiberty boost.lib libevent double_conversion glog google-gflags ];
+
+  nativeBuildInputs = [ autoreconfHook python boost ];
+
+  postUnpack = "sourceRoot=\${sourceRoot}/folly";
+  preBuild = ''
+    patchShebangs build
+  '';
+
+  configureFlags = [ "--with-boost-libdir=${boost.lib}/lib" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A YAML parser and emitter for C++";
+    homepage = https://code.google.com/p/yaml-cpp/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = maintainers.abbradar;
+  };
+}

--- a/pkgs/development/libraries/libiberty/default.nix
+++ b/pkgs/development/libraries/libiberty/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "4.8.3";
+  name = "libiberty-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
+    sha256 = "07hg10zs7gnqz58my10ch0zygizqh0z0bz6pv4pgxx45n48lz3ka";
+  };
+
+  postUnpack = "sourceRoot=\${sourceRoot}/libiberty";
+
+  enable_shared = 1;
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp pic/libiberty.a $out/lib/libiberty_pic.a
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://gcc.gnu.org/;
+    license = licenses.lgpl2;
+    description = "Collection of subroutines used by various GNU programs";
+    maintainers = maintainers.abbradar;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5119,6 +5119,8 @@ let
 
   fontconfig = callPackage ../development/libraries/fontconfig { };
 
+  folly = callPackage ../development/libraries/folly { };
+
   makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
     import ../development/libraries/fontconfig/make-fonts-conf.nix {
       inherit runCommand libxslt fontconfig fontDirectories;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5005,6 +5005,8 @@ let
 
   dhex = callPackage ../applications/editors/dhex { };
 
+  double_conversion = callPackage ../development/libraries/double-conversion { };
+
   dclib = callPackage ../development/libraries/dclib { };
 
   dillo = callPackage ../applications/networking/browsers/dillo {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1604,6 +1604,8 @@ let
 
   libtorrent-git = callPackage ../tools/networking/p2p/libtorrent/git.nix { };
 
+  libiberty = callPackage ../development/libraries/libiberty { };
+
   libibverbs = callPackage ../development/libraries/libibverbs { };
 
   librdmacm = callPackage ../development/libraries/librdmacm { };


### PR DESCRIPTION
This needs, among others, libiberty which has no official releases and is typically provided with whatever package uses it. I've added a package which builds gcc 4.8 version -- this works fine.
