### PR TITLE
rubber: Disable etex detection.

### DIFF
--- a/pkgs/tools/typesetting/rubber/default.nix
+++ b/pkgs/tools/typesetting/rubber/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   patchPhase = "substituteInPlace configure --replace which \"type -P\"";
 
+  postInstall = "rm $out/share/rubber/modules/etex.rub";
+
   meta = {
     description = "Wrapper for LaTeX and friends";
 


### PR DESCRIPTION
If etex detection is running it forces LaTeX files using etex package to
be compiled with elatex which is no longer part of current TexLive,
efectivelly making it impossible to simply compile them without hacking
through rubber's commandline option.
I took this fix from fedora .spec for rubber.
