### PR TITLE
ess: bump version to 14.09

### DIFF
--- a/pkgs/applications/editors/emacs-modes/ess/default.nix
+++ b/pkgs/applications/editors/emacs-modes/ess/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, emacs, texinfo }:
 
 stdenv.mkDerivation rec {
-  name = "ess-13.09";
+  name = "ess-14.09";
 
   src = fetchurl {
     url = "http://ess.r-project.org/downloads/ess/${name}.tgz";
-    sha256 = "1lki3vb6p7cw98zqq0gaia68flpqrjkd6dcl85fs0cc8qf55yqnh";
+    sha256 = "0mk8b5i5pxyqj2i5bn6kspxq4l4i9ql84wmxvvaax9jvfgzcml0y";
   };
 
   buildInputs = [ emacs texinfo ];


### PR DESCRIPTION
Tested basic functionality with GNU R & emacs 24, works for me.
