### PR TITLE
update-users-groups.pl: Use UTF-8 instead of latin1.

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -123,7 +123,7 @@ foreach my $g (@{$spec->{groups}}) {
 }
 
 # Update the persistent list of declarative groups.
-write_file($declGroupsFile, join(" ", sort(keys %groupsOut)));
+write_file($declGroupsFile, { binmode => ':utf8' }, join(" ", sort(keys %groupsOut)));
 
 # Merge in the existing /etc/group.
 foreach my $name (keys %groupsCur) {
@@ -140,7 +140,7 @@ foreach my $name (keys %groupsCur) {
 # Rewrite /etc/group. FIXME: acquire lock.
 my @lines = map { join(":", $_->{name}, $_->{password}, $_->{gid}, $_->{members}) . "\n" }
     (sort { $a->{gid} <=> $b->{gid} } values(%groupsOut));
-write_file("/etc/group.tmp", @lines);
+write_file("/etc/group.tmp", { binmode => ':utf8' }, @lines);
 rename("/etc/group.tmp", "/etc/group") or die;
 system("nscd --invalidate group");
 
@@ -198,7 +198,7 @@ foreach my $u (@{$spec->{users}}) {
 }
 
 # Update the persistent list of declarative users.
-write_file($declUsersFile, join(" ", sort(keys %usersOut)));
+write_file($declUsersFile, { binmode => ':utf8' }, join(" ", sort(keys %usersOut)));
 
 # Merge in the existing /etc/passwd.
 foreach my $name (keys %usersCur) {
@@ -214,7 +214,7 @@ foreach my $name (keys %usersCur) {
 # Rewrite /etc/passwd. FIXME: acquire lock.
 @lines = map { join(":", $_->{name}, $_->{fakePassword}, $_->{uid}, $_->{gid}, $_->{description}, $_->{home}, $_->{shell}) . "\n" }
     (sort { $a->{uid} <=> $b->{uid} } (values %usersOut));
-write_file("/etc/passwd.tmp", @lines);
+write_file("/etc/passwd.tmp", { binmode => ':utf8' }, @lines);
 rename("/etc/passwd.tmp", "/etc/passwd") or die;
 system("nscd --invalidate passwd");
 
@@ -242,5 +242,5 @@ foreach my $u (values %usersOut) {
     push @shadowNew, join(":", $u->{name}, $hashedPassword, "1::::::") . "\n";
 }
 
-write_file("/etc/shadow.tmp", { perms => 0600 }, @shadowNew);
+write_file("/etc/shadow.tmp", { binmode => ':utf8', perms => 0600 }, @shadowNew);
 rename("/etc/shadow.tmp", "/etc/shadow") or die;


### PR DESCRIPTION
Perl seems to write the file in latin1 independent of the actual input
encoding.  This can corrupt the `description` field of `/etc/passwd`.  By
setting `binmode` to `:utf8` Perl can be forced to write UTF-8.  Ideally
the program would simply read/write the fields by value without any
changes in encoding.  However, assuming/enforcing UTF-8 is a lot better
than using an obsolete coding like latin1.
