### PR TITLE
Include mkDerivation arguments in the result as a debugging tool

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -140,7 +140,10 @@ let
           # Pass through extra attributes that are not inputs, but
           # should be made available to Nix expressions using the
           # derivation (e.g., in assertions).
-          (attrs.passthru or {}));
+          (attrs.passthru or {}))
+	  # Make initial inputs available for debugging
+	  // { mkDerivationArguments = attrs; }
+	  ;
 
       # Utility flags to test the type of platform.
       isDarwin = system == "x86_64-darwin";


### PR DESCRIPTION
It is a trivial easy-mergeable no-rebuild change, so I am using a pull request for a brief discussion.

I think it would be a useful debugging tool; and every bit helps. It would help me many times — a bit a time. I checked: there is no hash change.

A possible regression is a slight slowdown of evaluation, but note that the same mkDerivation does a lot of work anyway. Optional inclusion would probably make things only slower. It can be made a stdenv adaptor, but then noone will find it.
