### PR TITLE
update texlive-extra to 2014-10-24

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -1,11 +1,11 @@
 args: with args;
 rec {
   name    = "texlive-extra-2014";
-  version = "2014.20140927";
+  version = "2014.20141024";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/t/texlive-extra/texlive-extra_${version}.orig.tar.xz";
-    sha256 = "0chbl20dh61ld7nq9aiay7hi371l6285c2caqz18br29ifh8jicd";
+    sha256 = "190p5v6madcgkxjmfal0pcylfz88zi6yaixky0vrcz1kbvxqlcb9";
   };
 
   buildInputs = [texLive xz];


### PR DESCRIPTION
The 20140927 version disappeared for texlive-extra, too.
