### PR TITLE
nixos/ca: add symlink for sublimetext

### DIFF
--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -10,6 +10,9 @@ with lib;
       [ { source = "${pkgs.cacert}/etc/ca-bundle.crt";
           target = "ssl/certs/ca-bundle.crt";
         }
+        { source = "${pkgs.cacert}/etc/ca-bundle.crt";
+          target = "ssl/certs/ca-certificates.crt";
+        }
       ];
 
     environment.sessionVariables =


### PR DESCRIPTION
This should fix #4343 . It would be good if Sublime user tests it (a co-worker of mine reported that it's fine; however he had created this symlink manually before and maybe it worked because of that).
