### PR TITLE
grsecurity: add GRKERNSEC_DENYUSB option (disabled by default)

### DIFF
--- a/pkgs/build-support/grsecurity/default.nix
+++ b/pkgs/build-support/grsecurity/default.nix
@@ -10,6 +10,7 @@ let
       mode = "auto";
       sysctl = false;
       denyChrootChmod = false;
+      denyUSB = false;
       restrictProc = false;
       restrictProcWithGroup = true;
       unrestrictProcGid = 121; # Ugh, an awful hack. See grsecurity NixOS gid
@@ -106,6 +107,7 @@ let
 
         GRKERNSEC_SYSCTL ${boolToKernOpt cfg.config.sysctl}
         GRKERNSEC_CHROOT_CHMOD ${boolToKernOpt cfg.config.denyChrootChmod}
+        GRKERNSEC_DENYUSB ${boolToKernOpt cfg.config.denyUSB}
         GRKERNSEC_NO_RBAC ${boolToKernOpt cfg.config.disableRBAC}
         ${restrictLinks}
 


### PR DESCRIPTION
This option tells the kernel to ignore plug-in events of USB devices. Useful to protect against attacks with malicious hardware. Currently disabled by default, though.
