### PR TITLE
kernel: enable CONFIG_RTC_SYSTOHC

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -249,6 +249,7 @@ with stdenv.lib;
   NET_FC y # Fibre Channel driver support
   PPP_MULTILINK y # PPP multilink support
   PPP_FILTER y
+  RTC_SYSTOHC y # copy (NTP synced) system time to hardware clock
   REGULATOR y # Voltage and Current Regulator Support
   ${optionalString (versionAtLeast version "3.6") ''
     RC_DEVICES? y # Enable IR devices


### PR DESCRIPTION
The system time (wall clock) will be stored in the RTC specified by RTC_HCTOSYS_DEVICE approximately every 11 minutes if userspace reports synchronized NTP status.
