### PR TITLE
Use libusb-compat instead of unmaintained libusb

### DIFF
--- a/pkgs/development/libraries/libusb/default.nix
+++ b/pkgs/development/libraries/libusb/default.nix
@@ -1,16 +1,12 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, pkgconfig, libusb1}:
 
 stdenv.mkDerivation {
-  name = "libusb-0.1.12";
+  name = "libusb-compat-0.1.5";
 
-  # On non-linux, we get warnings compiling, and we don't want the
-  # build to break.
-  patchPhase = ''
-    sed -i s/-Werror// Makefile.in
-  '';
+  buildInputs = [ pkgconfig libusb1 ];
 
   src = fetchurl {
-    url = mirror://sourceforge/libusb/libusb-0.1.12.tar.gz;
-    sha256 = "0i4bacxkyr7xyqxbmb00ypkrv4swkgm0mghbzjsnw6blvvczgxip";
+    url = mirror://sourceforge/libusb/libusb-compat-0.1.5.tar.bz2;
+    sha256 = "0nn5icrfm9lkhzw1xjvaks9bq3w6mjg86ggv3fn7kgi4nfvg8kj0";
   };
 }


### PR DESCRIPTION
I had problems building libusb on OS X Yosemite. `libusb-0.1` has not been updated for years, but there's a compatibility layer called `libusb-compat` that wraps around `libusb-1.0`.

```
 libusb-compat-0.1 is a replacement for libusb-0.1. However, instead of being an actual implementation, libusb-0.1 is more of a compatibility layer (or wrapper) which just converts libusb-0.1 calls into their libusb-1.0 equivalents.

It aims to look, feel and behave exactly like libusb-0.1. As it is a replacement, you cannot install it alongside libusb-0.1 on the same system.

As the compatibility layer implements the exact same ABI and API, no modifications to existing libusb-0.1-based applications are needed. You do not even have to recompile them. This compatibility layer is a drop-in replacement. 
```
