### PR TITLE
dmd: update to 2.066.1

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,20 +1,15 @@
 { stdenv, fetchurl, gcc, unzip, curl }:
 
 stdenv.mkDerivation {
-  name = "dmd-2.064.2";
+  name = "dmd-2.066.1";
 
   src = fetchurl {
-    url = http://downloads.dlang.org/releases/2013/dmd.2.064.2.zip;
-    sha256 = "1i0jdybigffwyb7c43j0c4aayxx3b93zzqrjxyw6zgp06yhi06pm";
+    url = http://downloads.dlang.org/releases/2014/dmd.2.066.1.zip;
+    sha256 = "1qifwgrl6h232zsnvcx3kmb5d0fsy7j9zv17r3b4vln7x5rvzc66";
   };
 
   buildInputs = [ gcc unzip curl ];
 
-  configurePhase = "";
-  patchPhase = ''
-      cp src/VERSION src/dmd/
-      cp license.txt src/phobos/LICENSE_1_0.txt
-  '';
   buildPhase = ''
       cd src/dmd
       make -f posix.mak INSTALL_DIR=$out
@@ -28,25 +23,33 @@ stdenv.mkDerivation {
 
   installPhase = ''
       cd src/dmd
-      tee dmd.conf.default << EOF
-          [Environment]
-          DFLAGS=-I$out/import -L-L$out/lib
-      EOF
-
-      make -f posix.mak INSTALL_DIR=$out install
-      export DMD=$PWD/dmd
-      cd ../druntime 
-      make -f posix.mak INSTALL_DIR=$out install
+      mkdir $out
+      mkdir $out/bin
+      cp dmd $out/bin
+       
+      cd ../druntime
+      mkdir $out/include
+      mkdir $out/include/d2
+      cp -r import/* $out/include/d2
+       
       cd ../phobos
-      make -f posix.mak INSTALL_DIR=$out install
-      cd ../..
+      mkdir $out/lib
+      cp generated/linux/release/64/libphobos2.a $out/lib    # for 64-bit version
+
+      cp -r std $out/include/d2
+      cp -r etc $out/include/d2
+
+      cd $out/bin
+      tee dmd.conf << EOF
+[Environment]
+DFLAGS=-I$out/include/d2 -L-L$out/lib -L--no-warn-search-mismatch -L--export-dynamic
+EOF
   '';
 
   meta = {
     description = "D language compiler";
     homepage = http://dlang.org/;
     license = "open source, see included files";
-    maintainers = with stdenv.lib.maintainers; [ vlstill ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/compilers/rdmd/default.nix
+++ b/pkgs/development/compilers/rdmd/default.nix
@@ -1,29 +1,29 @@
-{ stdenv, fetchurl, writeText, lib, dmd }:
+{stdenv, lib, fetchgit, dmd}:
 
 stdenv.mkDerivation {
-  name = "rdmd-2.064";
-
-  src = fetchurl {
-    url = https://raw2.github.com/D-Programming-Language/tools/2.064/rdmd.d;
-    sha256 = "0b1g3ng6bkanvg00r6xb4ycpbh9x8b9dw589av665azxbcraqrs1";
-    name = "rdmd-src";
-  };
+  name = "rdmd-20141113";
 
   buildInputs = [ dmd ];
 
-  builder = writeText "drmd-builder.sh" ''
-      source $stdenv/setup
-      cp $src rdmd.d
-      dmd rdmd.d
-      mkdir -p $out/bin
-      cp rdmd $out/bin/
+  src = fetchgit {
+    url = git://github.com/D-Programming-Language/tools.git;
+    rev = "f496c68ee4e776597bd7382aa47f05da698a69e";
+    sha256 = "0vbhmz8nbh8ayml4vad0239kfg982vqfyqqrjv6wrlnjah97n5ms";
+  };
+
+  buildPhase = ''
+    dmd rdmd.d
   '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp rdmd $out/bin/
+	'';
 
   meta = {
     description = "Wrapper for D language compiler";
     homepage = http://dlang.org/rdmd.html;
     license = lib.licenses.boost;
-    maintainers = with stdenv.lib.maintainers; [ vlstill ];
     platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Update the D compiler to version 2.066.1. The installation method follows the notes here:
http://wiki.dlang.org/Building_DMD
