### PR TITLE
vim_configurable: add cscope support by default

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -139,7 +139,7 @@ composableDerivation {
     nlsSupport       = config.vim.nls or false;
     tclSupport       = config.vim.tcl or false;
     multibyteSupport = config.vim.multibyte or false;
-    cscopeSupport    = config.vim.cscope or false;
+    cscopeSupport    = config.vim.cscope or true;
     netbeansSupport  = config.netbeans or true; # eg envim is using it
 
     # by default, compile with darwin support if we're compiling on darwin, but


### PR DESCRIPTION
Without it cscope, hscope packages are almost useless. AFAICS the overhead is neglible, compared to ruby, lua, python support.

Debian, Ubuntu have vim with cscope support enabled by default.
