### PR TITLE
ssh-agent: Limit the amount of time it keeps a key

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -59,6 +59,14 @@ in
         '';
       };
 
+      agentTimeout = mkOption {
+        type = types.string;
+        default = "1h";
+        description = ''
+          How long to keep the private keys in memory.
+        '';
+      };
+
       package = mkOption {
         default = pkgs.openssh;
         description = ''
@@ -99,7 +107,7 @@ in
         wantedBy = [ "default.target" ];
         serviceConfig =
           { ExecStartPre = "${pkgs.coreutils}/bin/rm -f %t/ssh-agent";
-            ExecStart = "${cfg.package}/bin/ssh-agent -a %t/ssh-agent";
+            ExecStart = "${cfg.package}/bin/ssh-agent -t ${cfg.agentTimeout} -a %t/ssh-agent";
             StandardOutput = "null";
             Type = "forking";
             Restart = "on-failure";

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -63,7 +63,7 @@ in
         type = types.string;
         default = "1h";
         description = ''
-          How long to keep the private keys in memory.
+          How long to keep the private keys in memory. Use null to keep them forever.
         '';
       };
 
@@ -107,7 +107,10 @@ in
         wantedBy = [ "default.target" ];
         serviceConfig =
           { ExecStartPre = "${pkgs.coreutils}/bin/rm -f %t/ssh-agent";
-            ExecStart = "${cfg.package}/bin/ssh-agent -t ${cfg.agentTimeout} -a %t/ssh-agent";
+            ExecStart =
+                "${cfg.package}/bin/ssh-agent " +
+                optionalString (cfg.agentTimeout != null) ("-t ${cfg.agentTimeout} ") +
+                "-a %t/ssh-agent";
             StandardOutput = "null";
             Type = "forking";
             Restart = "on-failure";

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -60,7 +60,7 @@ in
       };
 
       agentTimeout = mkOption {
-        type = types.string;
+        type = types.nullOr types.string;
         default = "1h";
         description = ''
           How long to keep the private keys in memory. Use null to keep them forever.


### PR DESCRIPTION
Default: 1 hour

I think keeping keys indefinitely by default is a security risk.
