### PR TITLE
fixed some typos

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.xml
+++ b/nixos/doc/manual/configuration/linux-kernel.xml
@@ -56,7 +56,7 @@ root file system), you can use
 boot.initrd.extraKernelModules = [ "cifs" ];
 </programlisting>
 This causes the specified modules and their dependencies to be added
-to the initial ramdark.</para>
+to the initial ramdisk.</para>
 
 <para>Kernel runtime parameters can be set through
 <option>boot.kernel.sysctl</option>, e.g.

--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -63,7 +63,7 @@ end.)  For instance, to use the NixOS 14.04 stable channel:
 $ nix-channel --add http://nixos.org/channels/nixos-14.04 nixos
 </screen>
 
-But it you want to live on the bleeding edge:
+But if you want to live on the bleeding edge:
 
 <screen>
 $ nix-channel --add http://nixos.org/channels/nixos-unstable nixos

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -147,7 +147,7 @@ in
       default = [];
       description = ''
         Additional configurations to build based on the current
-        configuration which is has a lower priority.
+        configuration which then has a lower priority.
       '';
     };
 


### PR DESCRIPTION
Please check whether the change in `activation/top-level.nix` does say the correct thing now.
