### PR TITLE
Glibc with shell

### DIFF
--- a/pkgs/shells/bash/default.nix
+++ b/pkgs/shells/bash/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, fetchurl, readline ? null, interactive ? false, texinfo ? null, bison }:
+{ stdenv
+, fetchurl
+, readline ? null, interactive ? false
+, texinfo ? null
+, bison
+, combineWithLibc ? false
+, glibc ? null
+}:
 
 assert interactive -> readline != null;
 
@@ -8,7 +15,9 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "${realName}-p${toString (builtins.length patches)}";
+  name = if combineWithLibc
+    then glibc.name
+    else "${realName}-p${toString (builtins.length patches)}";
 
   src = fetchurl {
     url = "mirror://gnu/bash/${realName}.tar.gz";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -191,22 +191,40 @@ rec {
     overrides = pkgs: {
       inherit (stage1.pkgs) perl binutils paxctl;
       glibc = pkgs.glibc.override { combineWithShell = true; };
-      bash = pkgs.bash.override { combineWithLibc = true; };
     };
   };
 
 
-  # Construct a third stdenv identical to the 2nd, except that this
-  # one uses the rebuilt Glibc from stage2.  It still uses the recent
-  # binutils and rest of the bootstrap tools, including GCC.
+  # Construct a third stdenv to combine bash with glibc to avoid a
+  # dependency on /bin/sh
   stage3 = stageFun {
     gccPlain = bootstrapTools;
-    inherit (stage2.pkgs) glibc binutils;
+    inherit (stage2.pkgs) binutils glibc;
     coreutils = bootstrapTools;
     name = "bootstrap-gcc-wrapper";
 
     overrides = pkgs: {
-      inherit (stage2.pkgs) binutils glibc perl patchelf linuxHeaders;
+      inherit (stage2.pkgs) binutils perl paxctl glibc;
+      bash = pkgs.bash.override { combineWithLibc = true; };
+      glibc-bash-final = pkgs.callPackage ./glibc-with-shell.nix {};
+    };
+  };
+
+
+  # Construct a fourth stdenv identical to the 3rd, except that this
+  # one uses the combined Glibc/sh from stage3.  It still uses the recent
+  # binutils and rest of the bootstrap tools, including GCC.
+  stage4 = stageFun {
+    gccPlain = bootstrapTools;
+    inherit (stage3.pkgs) binutils;
+    glibc = stage3.pkgs.glibc-bash-final;
+    coreutils = bootstrapTools;
+    name = "bootstrap-gcc-wrapper";
+
+    overrides = pkgs: {
+      inherit (stage3.pkgs) binutils perl patchelf linuxHeaders;
+      bash = stage3.pkgs.glibc-bash-final;
+      glibc = stage3.pkgs.glibc-bash-final;
       # Link GCC statically against GMP etc.  This makes sense because
       # these builds of the libraries are only used by GCC, so it
       # reduces the size of the stdenv closure.
@@ -217,14 +235,14 @@ rec {
       cloog = pkgs.cloog.override { stdenv = pkgs.makeStaticLibraries pkgs.stdenv; };
       gccPlain = pkgs.gcc.gcc;
     };
-    extraBuildInputs = [ stage2.pkgs.patchelf stage2.pkgs.paxctl ];
+    extraBuildInputs = [ stage3.pkgs.patchelf stage3.pkgs.paxctl ];
   };
 
 
-  # Construct a fourth stdenv that uses the new GCC.  But coreutils is
+  # Construct a fifth stdenv that uses the new GCC.  But coreutils is
   # still from the bootstrap tools.
-  stage4 = stageFun {
-    inherit (stage3.pkgs) gccPlain glibc binutils;
+  stage5 = stageFun {
+    inherit (stage4.pkgs) gccPlain glibc binutils;
     coreutils = bootstrapTools;
     name = "";
 
@@ -233,20 +251,19 @@ rec {
       # because gcc (since JAR support) already depends on zlib, and
       # then if we already have a zlib we want to use that for the
       # other purposes (binutils and top-level pkgs) too.
-      inherit (stage3.pkgs) gettext gnum4 gmp perl glibc zlib linuxHeaders;
-
+      inherit (stage4.pkgs) gettext gnum4 gmp perl glibc zlib linuxHeaders bash;
       gcc = lib.makeOverridable (import ../../build-support/gcc-wrapper) {
         nativeTools = false;
         nativeLibc = false;
-        gcc = stage4.stdenv.gcc.gcc;
-        libc = stage4.pkgs.glibc;
-        inherit (stage4.pkgs) binutils coreutils;
+        gcc = stage5.stdenv.gcc.gcc;
+        libc = stage5.pkgs.glibc;
+        inherit (stage5.pkgs) binutils coreutils;
         name = "";
-        stdenv = stage4.stdenv;
-        shell = stage4.pkgs.bash + "/bin/bash";
+        stdenv = stage5.stdenv;
+        shell = stage5.pkgs.bash + "/bin/bash";
       };
     };
-    extraBuildInputs = [ stage3.pkgs.patchelf stage3.pkgs.xz ];
+    extraBuildInputs = [ stage4.pkgs.patchelf stage4.pkgs.xz ];
   };
 
 
@@ -269,23 +286,23 @@ rec {
       '';
 
     initialPath =
-      ((import ../common-path.nix) {pkgs = stage4.pkgs;});
+      ((import ../common-path.nix) {pkgs = stage5.pkgs;});
 
-    extraBuildInputs = [ stage4.pkgs.patchelf stage4.pkgs.paxctl ];
+    extraBuildInputs = [ stage5.pkgs.patchelf stage5.pkgs.paxctl ];
 
-    gcc = stage4.pkgs.gcc;
+    gcc = stage5.pkgs.gcc;
 
     shell = gcc.shell;
 
-    inherit (stage4.stdenv) fetchurlBoot;
+    inherit (stage5.stdenv) fetchurlBoot;
 
     extraAttrs = {
-      inherit (stage4.pkgs) glibc;
+      inherit (stage5.pkgs) glibc;
       inherit platform bootstrapTools;
-      shellPackage = stage4.pkgs.bash;
+      shellPackage = stage5.pkgs.bash;
     };
 
-    allowedRequisites = with stage4.pkgs;
+    allowedRequisites = with stage5.pkgs;
       [ gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
         glibc gnumake gnused gnutar gnugrep gnupatch patchelf attr acl
         paxctl zlib pcre linuxHeaders ed gcc gcc.gcc libsigsegv
@@ -293,7 +310,7 @@ rec {
 
     overrides = pkgs: {
       inherit gcc;
-      inherit (stage4.pkgs)
+      inherit (stage5.pkgs)
         gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
         glibc gnumake gnused gnutar gnugrep gnupatch patchelf
         attr acl paxctl zlib pcre;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -190,7 +190,8 @@ rec {
 
     overrides = pkgs: {
       inherit (stage1.pkgs) perl binutils paxctl;
-      # This also contains the full, dynamically linked, final Glibc.
+      # This is the full, dynamically linked, final Glibc.
+      glibc = pkgs.glibc.override { combineWithShell = true; };
     };
   };
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -190,8 +190,8 @@ rec {
 
     overrides = pkgs: {
       inherit (stage1.pkgs) perl binutils paxctl;
-      # This is the full, dynamically linked, final Glibc.
       glibc = pkgs.glibc.override { combineWithShell = true; };
+      bash = pkgs.bash.override { combineWithLibc = true; };
     };
   };
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -204,7 +204,7 @@ rec {
     name = "bootstrap-gcc-wrapper";
 
     overrides = pkgs: {
-      inherit (stage2.pkgs) binutils perl paxctl glibc;
+      inherit (stage2.pkgs) binutils perl paxctl glibc linuxHeaders;
       bash = pkgs.bash.override { combineWithLibc = true; };
       glibc-bash-final = pkgs.callPackage ./glibc-with-shell.nix {};
     };

--- a/pkgs/stdenv/linux/glibc-with-shell.nix
+++ b/pkgs/stdenv/linux/glibc-with-shell.nix
@@ -1,0 +1,21 @@
+{ stdenv, bash, glibc, patchelf }:
+
+stdenv.mkDerivation {
+  inherit (glibc) name;
+
+  buildInputs = [ patchelf ];
+
+  buildCommand = ''
+    mkdir -p $out
+    tar -c -C ${glibc} . | \
+      sed "s@${glibc}@$out@g" | \
+      tar -x -C $out
+    chmod +w -R $out
+    unlink $out/bin/sh
+    tar -c -C ${bash} . | \
+      sed -e "s@${glibc}@$out@g" -e "s@${bash}@$out@g" | \
+      tar -x -C $out
+    patchELF $out
+    fixupPhase
+  '';
+}


### PR DESCRIPTION
On linux, combine the final `glibc` with the final `bash`, and use the `sh` from `bash` for `glibc`'s `system(3)`, `popen(3)`, etc.

Fixes #1424
