### PR TITLE
Add Bugwarrior and its dependencies.

### DIFF
--- a/pkgs/development/python-modules/bugzilla/checkPhase-fix-cookie-compare.patch
+++ b/pkgs/development/python-modules/bugzilla/checkPhase-fix-cookie-compare.patch
@@ -1,0 +1,30 @@
+From e7ed770363e8769727a915b2390c0ce1ab2ce964 Mon Sep 17 00:00:00 2001
+From: Michal Hlavinka <mhlavink@redhat.com>
+Date: Wed, 18 Jun 2014 20:07:24 -0400
+Subject: tests: Fix cookie comparison on rawhide
+
+Cookie comments changed, so just strip them out
+
+(crobinso: Add commit message, make change more readable)
+
+diff --git a/tests/misc.py b/tests/misc.py
+index 4b4f99d..12da806 100644
+--- a/tests/misc.py
++++ b/tests/misc.py
+@@ -83,7 +83,12 @@ class MiscAPI(unittest.TestCase):
+ 
+         # Mozilla should be converted inplace to LWP
+         bugzilla.Bugzilla3(url=None, cookiefile=cookiesnew)
+-        self.assertEquals(open(cookiesmoz).read(), open(cookiesnew).read())
++
++        def strip_comments(content):
++            return [l for l in content.split("\n") if not l.startswith("#")]
++        self.assertEquals(
++            strip_comments(open(cookiesmoz).read()),
++            strip_comments(open(cookiesnew).read()))
+ 
+         # Make sure bad cookies raise an error
+         try:
+-- 
+cgit v0.10.2
+

--- a/pkgs/development/python-modules/taskw/use-template-for-taskwarrior-install-path.patch
+++ b/pkgs/development/python-modules/taskw/use-template-for-taskwarrior-install-path.patch
@@ -1,0 +1,48 @@
+commit 4de021d049a9b194da93d7e96ff12cc1cbabac83
+Author: Nicolas B. Pierron <nixos@nbp.name>
+Date:   Sun Nov 16 15:19:38 2014 +0100
+
+    Use a template for taskwarrior install path.
+
+diff --git a/taskw/warrior.py b/taskw/warrior.py
+index 21dde88..e0509f2 100644
+--- a/taskw/warrior.py
++++ b/taskw/warrior.py
+@@ -451,17 +451,17 @@ class TaskWarriorShellout(TaskWarriorBase):
+     def _execute(self, *args):
+         """ Execute a given taskwarrior command with arguments
+ 
+         Returns a 2-tuple of stdout and stderr (respectively).
+ 
+         """
+         command = (
+             [
+-                'task',
++                '@@taskwarrior@@/bin/task',
+                 'rc:%s' % self.config_filename,
+             ]
+             + self.get_configuration_override_args()
+             + [six.text_type(arg) for arg in args]
+         )
+ 
+         # subprocess is expecting bytestrings only, so nuke unicode if present
+         for i in range(len(command)):
+@@ -525,17 +525,17 @@ class TaskWarriorShellout(TaskWarriorBase):
+         except OSError:
+             # OSError is raised if subprocess.Popen fails to find
+             # the executable.
+             return False
+ 
+     @classmethod
+     def get_version(cls):
+         taskwarrior_version = subprocess.Popen(
+-            ['task', '--version'],
++            ['@@taskwarrior@@/bin/task', '--version'],
+             stdout=subprocess.PIPE
+         ).communicate()[0]
+         return LooseVersion(taskwarrior_version.decode())
+ 
+     def sync(self, init=False):
+         if self.get_version() < LooseVersion('2.3'):
+             raise UnsupportedVersionException(
+                 "'sync' requires version 2.3 of taskwarrior or later."

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4753,11 +4753,12 @@ let
   });
 
   jinja2 = buildPythonPackage rec {
-    name = "Jinja2-2.7.1";
+    name = "Jinja2-2.7.3";
 
     src = pkgs.fetchurl {
       url = "http://pypi.python.org/packages/source/J/Jinja2/${name}.tar.gz";
-      sha256 = "12scn3zmmj76rzyc0axjzf6dsazyj9xgp0l46q41rjhxm23s1h2w";
+      # md5 = "b9dffd2f3b43d673802fe857c8445b1a"; # provided by pypi website.
+      sha256 = "2e24ac5d004db5714976a04ac0e80c6df6e47e98c354cb2c0d82f8879d4f8fdb";
     };
 
     propagatedBuildInputs = with self; [ self.markupsafe ];
@@ -4765,12 +4766,14 @@ let
     meta = {
       homepage = http://jinja.pocoo.org/;
       description = "Stand-alone template engine";
-      license = "BSD";
+      license = licenses.bsd3;
       longDescription = ''
         Jinja2 is a template engine written in pure Python. It provides a
         Django inspired non-XML syntax but supports inline expressions and
         an optional sandboxed environment.
       '';
+      platforms = platforms.all;
+      maintainers = [ maintainers.pierron ];
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1134,6 +1134,34 @@ let
   #   };
   # });
 
+  bugzilla = buildPythonPackage rec {
+    name = "bugzilla-${version}";
+    version = "1.1.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/python-bugzilla/python-${name}.tar.gz";
+      # md5 = "c95befd1fecad21f742beaa8180538c0"; # provided by pypi website.
+      sha256 = "11361635a4f1613803a0b9b93ba9126f7fd36180653f953e2590b1536d107d46";
+    };
+
+    patches = [ ../development/python-modules/bugzilla/checkPhase-fix-cookie-compare.patch ];
+
+    buildInputs = with self; [ pep8 coverage logilab_common ];
+    propagatedBuildInputs = [ self.requests2 ];
+
+    preCheck = ''
+      mkdir -p check-phase
+      export HOME=$(pwd)/check-phase
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://fedorahosted.org/python-bugzilla/;
+      description = "Bugzilla XMLRPC access module";
+      license = licenses.gpl2;
+      platforms = platforms.all;
+      maintainers = [ maintainers.pierron ];
+    };
+  };
 
   buildout = self.zc_buildout;
   buildout152 = self.zc_buildout152;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1116,6 +1116,34 @@ let
     };
   };
 
+  bugwarrior = buildPythonPackage rec {
+    name = "bugwarrior-${version}";
+    version = "1.0.2";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/b/bugwarrior/${name}.tar.gz";
+      # md5 = "09c93f86a27ffc092e69b46889a3bf50"; # provided by pypi website.
+      sha256 = "efe41756c152789f39006f157add9bedfa2b85d2cac15c067e635e37c70cb8f8";
+    };
+
+    buildInputs = with self; [ mock unittest2 nose /* jira megaplan */ ];
+    propagatedBuildInputs = with self; [
+      twiggy requests2 offtrac bugzilla taskw dateutil pytz keyring six
+      jinja2 pycurl dogpile_cache lockfile click
+    ];
+
+    # for the moment jira>=0.22 and megaplan>=1.4 are missing for running the test suite.
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      homepage =  http://github.com/ralphbean/bugwarrior;
+      description = "Sync github, bitbucket, bugzilla, and trac issues with taskwarrior";
+      license = licenses.gpl3Plus;
+      platforms = platforms.all;
+      maintainers = [ maintainers.pierron ];
+    };
+  };
+
   # bugz = buildPythonPackage (rec {
   #   name = "bugz-0.9.3";
   #

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9750,6 +9750,28 @@ let
     };
   });
 
+  twiggy = buildPythonPackage rec {
+    name = "Twiggy-${version}";
+    version = "0.4.5";
+
+    src = pkgs.fetchurl {
+      url    = "https://pypi.python.org/packages/source/T/Twiggy/Twiggy-0.4.5.tar.gz";
+      # md5 = "b0dfbbb7f56342e448af4d22a47a339c"; # provided by pypi website.
+      sha256 = "4e8f1894e5aee522db6cb245ccbfde3c5d1aa08d31330c7e3af783b0e66eec23";
+    };
+
+    doCheck = false;
+
+    meta = {
+      homepage = http://twiggy.wearpants.org;
+      # Taken from http://i.wearpants.org/blog/meet-twiggy/
+      description = "Twiggy is the first totally new design for a logger since log4j";
+      license     = licenses.bsd3;
+      platforms = platforms.all;
+      maintainers = [ maintainers.pierron ];
+    };
+  };
+
   twitter = buildPythonPackage rec {
     name = "twitter-${version}";
     version = "1.15.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9535,6 +9535,34 @@ let
     };
   };
 
+  taskw = buildPythonPackage rec {
+    version = "0.8.6";
+    name = "taskw-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/t/taskw/${name}.tar.gz";
+      # md5 = "9f3ce2eaff9a3986d04632547168894d"; # provided by pypi website.
+      sha256 = "341a165a1c2ef94fb1c2a49a785357377f04a0d55cabe9563179849497e47146";
+    };
+
+    patches = [ ../development/python-modules/taskw/use-template-for-taskwarrior-install-path.patch ];
+    postPatch = ''
+      substituteInPlace taskw/warrior.py \
+        --replace '@@taskwarrior@@' '${pkgs.taskwarrior}'
+    '';
+
+    buildInputs = with self; [ nose pkgs.taskwarrior ];
+    propagatedBuildInputs = with self; [ six dateutil pytz ];
+
+    meta = {
+      homepage =  http://github.com/ralphbean/taskw;
+      description = "Python bindings for your taskwarrior database";
+      license = licenses.gpl3Plus;
+      platforms = platforms.all;
+      maintainers = [ maintainers.pierron ];
+    };
+  };
+
   tempita = buildPythonPackage rec {
     version = "0.5.2";
     name = "tempita-${version}";


### PR DESCRIPTION
This pull requests has one commit for each package.

This include all dependencies which are needed to get bugwarrior working, including a few patch to fix the test suite of python-bugzilla, and a patch to make sure that we bake-in the dependency of taskwarrior in python-taskw (which is useful for running bugwarrior-pull in a service).

The test dependencies of bugwarrior are not all satisfied yet, but so far it is working fine for bugzilla & github on my computer.
