### PR TITLE
Fix pidgin-with-plugins derivation

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -12,7 +12,8 @@
 
 stdenv.mkDerivation rec {
   name = "pidgin-${version}";
-  version = "2.10.10";
+  majorVersion = "2";
+  version = "${majorVersion}.10.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/pidgin/${name}.tar.bz2";

--- a/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
@@ -17,7 +17,7 @@ drv = buildEnv {
       done
     fi
     wrapProgram $out/bin/pidgin \
-      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.version} $out/lib/pidgin" \
+      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion} $out/lib/pidgin" \
       ${toString extraArgs}
   '';
   };


### PR DESCRIPTION
With current version:

``` sh
$ pidgin --version Pidgin 2.10.10 (libpurple 2.10.10)
```

The actual content of `pidgin-with-plugins` wrapper script installed:

``` sh
export
PURPLE_PLUGIN_PATH=$PURPLE_PLUGIN_PATH${PURPLE_PLUGIN_PATH:+:}/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/purple-2.10.10 
export
PURPLE_PLUGIN_PATH=$PURPLE_PLUGIN_PATH${PURPLE_PLUGIN_PATH:+:}/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/pidgin 
exec
/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/bin/.pidgin-wrapped
"${extraFlagsArray[@]}" "$@"
```

We can see that the PURPLE_PLUGIN_PATH looks into something that does not exist...

``` sh
$ file
/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/purple-2.10.10
/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/purple-2.10.10:
cannot open
`/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/purple-2.10.10'
(No such file or directory)

$ file
/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/purple-2
/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/purple-2:
directory
```

Because the folder created is named `purple-2` (2 is what I called `majorVersion`) and
not `purple-2.10.10` (`2.10.10` is the version).

The result is that no plugin are loaded after installation (at least pidgin-sipe):

``` sh
$ ll
/nix/store/ifbf01z4w6pji601jxcsrd034lh60r0g-pidgin-with-plugins-2.10.10/lib/ 
total 76K lrwxrwxrwx 1 root nixbld   68 Jan  1  1970 finch ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/finch 
dr-xr-xr-x 2 root nixbld 4.0K Jan  1  1970 gdk-pixbuf-loaders-2.0 lrwxrwxrwx 1
root nixbld   66 Jan  1  1970 gnt ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/gnt lrwxrwxrwx
1 root nixbld   72 Jan  1  1970 libgnt.la ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libgnt.la 
lrwxrwxrwx 1 root nixbld   72 Jan  1  1970 libgnt.so ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libgnt.so 
lrwxrwxrwx 1 root nixbld   74 Jan  1  1970 libgnt.so.0 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libgnt.so.0 
lrwxrwxrwx 1 root nixbld   79 Jan  1  1970 libgnt.so.0.8.10 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libgnt.so.0.8.10 
lrwxrwxrwx 1 root nixbld   82 Jan  1  1970 libpurple-client.la ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple-client.la 
lrwxrwxrwx 1 root nixbld   82 Jan  1  1970 libpurple-client.so ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple-client.so 
lrwxrwxrwx 1 root nixbld   84 Jan  1  1970 libpurple-client.so.0 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple-client.so.0 
lrwxrwxrwx 1 root nixbld   90 Jan  1  1970 libpurple-client.so.0.10.10 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple-client.so.0.10.10 
lrwxrwxrwx 1 root nixbld   75 Jan  1  1970 libpurple.la ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple.la 
lrwxrwxrwx 1 root nixbld   75 Jan  1  1970 libpurple.so ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple.so 
lrwxrwxrwx 1 root nixbld   77 Jan  1  1970 libpurple.so.0 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple.so.0 
lrwxrwxrwx 1 root nixbld   83 Jan  1  1970 libpurple.so.0.10.10 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/libpurple.so.0.10.10 
lrwxrwxrwx 1 root nixbld   68 Jan  1  1970 perl5 ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/perl5 
dr-xr-xr-x 2 root nixbld 4.0K Jan  1  1970 pidgin lrwxrwxrwx 1 root nixbld  
72 Jan  1  1970 pkgconfig ->
/nix/store/kd55fbz9jvh5vnjbhms7r8460cp4anhg-pidgin-2.10.10/lib/pkgconfig 
dr-xr-xr-x 2 root nixbld 4.0K Jan  1  1970 purple-2
```
