### PR TITLE
openssh: add version with no private key access rights check

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -2,6 +2,7 @@
 , etcDir ? null
 , hpnSupport ? false
 , withKerberos ? false
+, noKeyRightsCheck ? false
 , kerberos
 }:
 
@@ -41,7 +42,7 @@ stdenv.mkDerivation rec {
         + "hpb=9cbb60f5e4932634db04c330c88abc49cc5567bd";
       sha256 = "160c434igl2r8q4cavhdlwvnbqizx444sjrhg98f997pyhz524h9";
     })
-  ];
+  ] ++ stdenv.lib.optional noKeyRightsCheck ./private-key-rights.patch;
 
   buildInputs = [ zlib openssl libedit pkgconfig pam ]
     ++ stdenv.lib.optional withKerberos [ kerberos ];

--- a/pkgs/tools/networking/openssh/private-key-rights.patch
+++ b/pkgs/tools/networking/openssh/private-key-rights.patch
@@ -1,0 +1,28 @@
+diff -ru3 openssh-6.6p1-old/authfile.c openssh-6.6p1/authfile.c
+--- openssh-6.6p1-old/authfile.c	2014-02-04 04:20:15.000000000 +0400
++++ openssh-6.6p1/authfile.c	2014-11-17 18:23:47.486062501 +0300
+@@ -971,24 +971,6 @@
+ 
+ 	if (fstat(fd, &st) < 0)
+ 		return 0;
+-	/*
+-	 * if a key owned by the user is accessed, then we check the
+-	 * permissions of the file. if the key owned by a different user,
+-	 * then we don't care.
+-	 */
+-#ifdef HAVE_CYGWIN
+-	if (check_ntsec(filename))
+-#endif
+-	if ((st.st_uid == getuid()) && (st.st_mode & 077) != 0) {
+-		error("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+-		error("@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @");
+-		error("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+-		error("Permissions 0%3.3o for '%s' are too open.",
+-		    (u_int)st.st_mode & 0777, filename);
+-		error("It is required that your private key files are NOT accessible by others.");
+-		error("This private key will be ignored.");
+-		return 0;
+-	}
+ 	return 1;
+ }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -313,7 +313,8 @@ let
   };
 
   fetchgitPrivate = import ../build-support/fetchgit/private.nix {
-    inherit fetchgit writeScript openssh stdenv;
+    inherit fetchgit writeScript stdenv;
+    openssh = openssh_no_key_check;
   };
 
   fetchgitrevision = import ../build-support/fetchgitrevision runCommand git;
@@ -1959,6 +1960,8 @@ let
       etcDir = "/etc/ssh";
       pam = if stdenv.isLinux then pam else null;
     };
+
+  openssh_no_key_check = pkgs.appendToName "no-key-check" (openssh.override { noKeyRightsCheck = true; });
 
   openssh_hpn = pkgs.appendToName "with-hpn" (openssh.override { hpnSupport = true; });
 


### PR DESCRIPTION
This improves fetchgitPrivate experience, as one doesn't need anymore to copy private keys for each nixbld\* user and set ssh_config accordingly. A more proper way would be to add a configuration option into ssh_config and submit the patch to the upstream, however this requires much more work -- I think this solution is good enough as this option (if added) shouldn't ever be used by an end user, and we have only one specific usecase.
