### PR TITLE
Use lib instead of pkgs.lib

### DIFF
--- a/nixos/modules/services/backup/crashplan.nix
+++ b/nixos/modules/services/backup/crashplan.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   cfg = config.services.crashplan;
@@ -6,7 +6,7 @@ let
   varDir = "/var/lib/crashplan";
 in
 
-with pkgs.lib;
+with lib;
 
 {
   options = {


### PR DESCRIPTION
Usage of pkgs.lib may cause infinite recursion
