### PR TITLE
gpodder: update from 3.8.0 to 3.8.3

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -1,6 +1,5 @@
 { pkgs, stdenv, fetchurl, python, buildPythonPackage, pythonPackages, mygpoclient, intltool,
-  ipodSupport ? true, libgpod, gpodderHome ? "", gpodderDownloadDir ? "",
-  gnome3, hicolor_icon_theme }:
+  ipodSupport ? true, libgpod, gnome3, hicolor_icon_theme }:
 
 with pkgs.lib;
 
@@ -8,20 +7,23 @@ let
   inherit (pythonPackages) coverage feedparser minimock sqlite3 dbus pygtk eyeD3;
 
 in buildPythonPackage rec {
-  name = "gpodder-3.8.0";
+  name = "gpodder-3.8.3";
 
   src = fetchurl {
     url = "http://gpodder.org/src/${name}.tar.gz";
-    sha256 = "0731f08f4270c81872b841b55200ae80feb4502706397d0085079471fb9a8fe4";
+    sha256 = "8ac120a6084bded6bc88ecadbbc9df54a85f44ef4507f73a76de1d7a5574303c";
   };
 
   buildInputs = [
     coverage feedparser minimock sqlite3 mygpoclient intltool
-    gnome3.gnome_icon_theme gnome3.gnome_icon_theme_symbolic
-    hicolor_icon_theme
+    gnome3.gnome_themes_standard gnome3.gnome_icon_theme
+    gnome3.gnome_icon_theme_symbolic hicolor_icon_theme
+    gnome3.gsettings_desktop_schemas
   ];
 
-  propagatedBuildInputs = [ feedparser dbus mygpoclient sqlite3 pygtk eyeD3 ]
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+
+  pythonPath = [ feedparser dbus mygpoclient sqlite3 pygtk eyeD3 ]
     ++ stdenv.lib.optional ipodSupport libgpod;
 
   postPatch = "sed -ie 's/PYTHONPATH=src/PYTHONPATH=\$(PYTHONPATH):src/' makefile";
@@ -30,8 +32,6 @@ in buildPythonPackage rec {
 
   preFixup = ''
     wrapProgram $out/bin/gpodder \
-      ${optionalString (gpodderHome != "") "--set GPODDER_HOME ${gpodderHome}"} \
-      ${optionalString (gpodderDownloadDir != "") "--set GPODDER_DOWNLOAD_DIR ${gpodderDownloadDir}"} \
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
   '';
 


### PR DESCRIPTION
Hi,

I updated the gpodder package. I also moved the entries from `propagatedBuildInputs` to `pythonPath`, which is more appropriate for this package. The `gpodderHome` and `gpodderDownload` variables are removed, because they are useless. The variables should be set as normal environment variables.

Best,
Sven
