### PR TITLE
Update Tor Browser to 4.0.1

### DIFF
--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -20,18 +20,18 @@ let
 
 in stdenv.mkDerivation rec {
   name = "tor-browser-${version}";
-  version = "3.6.2";
+  version = "4.0.1";
 
   src = fetchurl {
     url = "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux${bits}-${version}_en-US.tar.xz";
     sha256 = if bits == "64" then
-      "1rfv59k9mia6hr1z1k4im20dy59ir7i054cgf78sfj1zsh08q7hf" else
-      "1klkk1k5r51pcx44r1z3sw08fqcl2f2v5iblf4yh83js482c37r8";
+      "1cz36g7jfcz8xs7sa2fl44g1bxlrl0psbsx5hig6j5ydsl87vyak" else
+      "135ya109skzd4x8zhmsiwjg6d533yijbdrscm36lsplgcf7dx8l3";
   };
 
   patchPhase = ''
     patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" Browser/firefox
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" Tor/tor
+    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" Browser/TorBrowser/Tor/tor
   '';
 
   doCheck = true;
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
     echo "Checking firefox..."
     LD_LIBRARY_PATH=${ldLibraryPath} Browser/firefox --help 1> /dev/null
     echo "Checking tor..."
-    LD_LIBRARY_PATH=${torEnv}/lib:Tor Tor/tor --help 1> /dev/null
+    LD_LIBRARY_PATH=${torEnv}/lib:Browser/TorBrowser/Tor Browser/TorBrowser/Tor/tor --help 1> /dev/null
   '';
 
   installPhase = ''
@@ -50,13 +50,13 @@ in stdenv.mkDerivation rec {
     cp -R * $out/share/tor-browser
 
     cat > "$out/bin/tor-browser" << EOF
-      export HOME="\$HOME/.torbrowser"
+      export HOME="\$HOME/.torbrowser4"
       if [ ! -d \$HOME ]; then
-        mkdir -p \$HOME && cp -R $out/share/tor-browser/Data \$HOME/ && chmod -R +w \$HOME
+        mkdir -p \$HOME && cp -R $out/share/tor-browser/Browser/TorBrowser/Data \$HOME/ && chmod -R +w \$HOME
         echo "pref(\"extensions.torlauncher.tordatadir_path\", \"\$HOME/Data/Tor/\");" >> \
           ~/Data/Browser/profile.default/preferences/extension-overrides.js
       fi
-      export LD_LIBRARY_PATH=${ldLibraryPath}:$out/share/tor-browser/Tor
+      export LD_LIBRARY_PATH=${ldLibraryPath}:$out/share/tor-browser/Browser/TorBrowser/Tor
       $out/share/tor-browser/Browser/firefox -no-remote -profile ~/Data/Browser/profile.default "$@"
     EOF
     chmod +x $out/bin/tor-browser
@@ -68,6 +68,6 @@ in stdenv.mkDerivation rec {
     description = "Tor Browser Bundle for GNU/Linux, everything you need to safely browse the Internet";
     homepage = https://www.torproject.org/;
     platforms = ["i686-linux" "x86_64-linux"];
-    maintainers = [ maintainers.offline maintainers.matejc ];
+    maintainers = [ maintainers.offline maintainers.matejc maintainers.doublec ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2497,7 +2497,9 @@ let
 
   torbutton = callPackage ../tools/security/torbutton { };
 
-  torbrowser = callPackage ../tools/security/tor/torbrowser.nix { };
+  torbrowser = callPackage ../tools/security/tor/torbrowser.nix {
+    stdenv = overrideGCC stdenv gcc49;
+  };
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
 


### PR DESCRIPTION
Updates Tor Browser to 4.0.1. This requires the gcc 4.9 runtime, hence the modification in all-packages.nix.

Add myself to the maintainers.

I have tested this on an x86_64 nixos machine.
