### PR TITLE
jmeter: fix download URL

### DIFF
--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "jmeter-2.11";
   src = fetchurl {
-    url = "http://ftp.unicamp.br/pub/apache//jmeter/binaries/apache-${name}.tgz";
+    url = "http://archive.apache.org/dist/jmeter/binaries/apache-${name}.tgz";
     sha256 = "1fr3sw06qncb6yygcf2lbnkxma4v1dbigpf39ajrm0isxbpyv944";
   };
 


### PR DESCRIPTION
Previous URL only contains the current release. This PR change the URL to the archives provided by apache.org. The archives contain the current release too.
