### PR TITLE
sane: fix multifunctional devices rights conflict with cups

### DIFF
--- a/pkgs/applications/graphics/sane/backends.nix
+++ b/pkgs/applications/graphics/sane/backends.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     if test "$udevSupport" = "1"; then
       mkdir -p $out/etc/udev/rules.d/
-      ./tools/sane-desc -m udev > $out/etc/udev/rules.d/60-libsane.rules || \
-      cp tools/udev/libsane.rules $out/etc/udev/rules.d/60-libsane.rules
+      ./tools/sane-desc -m udev > $out/etc/udev/rules.d/49-libsane.rules || \
+      cp tools/udev/libsane.rules $out/etc/udev/rules.d/49-libsane.rules
     fi
   '';
 


### PR DESCRIPTION
Another part of https://github.com/NixOS/nixpkgs/pull/4857 -- this makes MFDs work both with cups and sane. Without this they were being assigned to 'scanner' group, which prevented CUPS from working with them at all. This is how it's fixed on Arch Linux IIRC. Tested.
