### PR TITLE
Add package 'xml2'.

### DIFF
--- a/pkgs/tools/text/xml/xml2/default.nix
+++ b/pkgs/tools/text/xml/xml2/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, pkgconfig, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "xml2-0.5";
+
+  src = fetchurl {
+    url = "http://download.ofb.net/gale/${name}.tar.gz";
+    sha256 = "01cps980m99y99cnmvydihga9zh3pvdsqag2fi1n6k2x7rfkl873";
+  };
+
+  buildInputs = [ pkgconfig libxml2 ];
+
+  meta = with stdenv.lib; {
+    homepage = http://ofb.net/~egnor/xml2/;
+    description = "Tools for command line processing of XML, HTML, and CSV";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.rycee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2791,6 +2791,8 @@ let
 
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
 
+  xml2 = callPackage ../tools/text/xml/xml2 { };
+
   xmlroff = callPackage ../tools/typesetting/xmlroff {
     inherit (gnome) libgnomeprint;
   };


### PR DESCRIPTION
Provides some tools for manipulating XML, HTML, and CSV in shell pipes. For example using the `xml2` tool we have

```
$ nix-env -f . -qa xml2 --xml --meta | xml2 | grep -A2 /items/item/meta/@name=homepage
/items/item/meta/@name=homepage
/items/item/meta/@type=string
/items/item/meta/@value=http://ofb.net/~egnor/xml2/
```
