### PR TITLE
libcurl: Honor $SSL_CERT_FILE

### DIFF
--- a/pkgs/tools/networking/curl/7.15.nix
+++ b/pkgs/tools/networking/curl/7.15.nix
@@ -32,6 +32,12 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
   '';
+
+  # make curl honor CURL_CA_BUNDLE & SSL_CERT_FILE
+  postConfigure = ''
+    echo  '#define CURL_CA_BUNDLE (getenv("CURL_CA_BUNDLE") || getenv("SSL_CERT_FILE"))' >> lib/curl_config.h
+  '';
+
   configureFlags = [
       ( if sslSupport then "--with-ssl=${openssl}" else "--without-ssl" )
       ( if scpSupport then "--with-libssh2=${libssh2}" else "--without-libssh2" )

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
     rm src/tool_hugehelp.c
   '';
 
+  # make curl honor CURL_CA_BUNDLE & SSL_CERT_FILE
+  postConfigure = ''
+    echo  '#define CURL_CA_BUNDLE (getenv("CURL_CA_BUNDLE") || getenv("SSL_CERT_FILE"))' >> lib/curl_config.h
+  '';
+
   configureFlags = [
       ( if sslSupport then "--with-ssl=${openssl}" else "--without-ssl" )
       ( if scpSupport then "--with-libssh2=${libssh2}" else "--without-libssh2" )


### PR DESCRIPTION
This makes libcurl search `getenv("SSL_CERT_FILE")` for https urls. 

I'm submitting this as a pull request as I'm not 100% sure there aren't any security implications from this. 
