### PR TITLE
new package: xwayland

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, wayland, mesa, libxkbcommon, cairo, libxcb
 , libXcursor, x11, udev, libdrm, mtdev, libjpeg, pam, dbus, libinput
 , pango ? null, libunwind ? null, freerdp ? null, vaapi ? null, libva ? null
-, libwebp ? null
+, libwebp ? null, xwayland ? null
 }:
 
 let version = "1.6.0"; in
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--enable-xwayland"
     "--enable-x11-compositor"
     "--enable-drm-compositor"
     "--enable-wayland-compositor"
@@ -32,7 +31,10 @@ stdenv.mkDerivation rec {
     "--enable-weston-launch"
     "--disable-setuid-install" # prevent install target to chown root weston-launch, which fails
   ] ++ stdenv.lib.optional (freerdp != null) "--enable-rdp-compositor"
-    ++ stdenv.lib.optional (vaapi != null) "--enabe-vaapi-recorder";
+    ++ stdenv.lib.optional (vaapi != null) "--enabe-vaapi-recorder"
+    ++ stdenv.lib.optional (xwayland != null) (
+        "--enable-xwayland " +
+        "--with-xserver-path=${xwayland}/bin/Xwayland");
 
   meta = with stdenv.lib; {
     description = "Reference implementation of a Wayland compositor";

--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -1,0 +1,41 @@
+
+{ stdenv, wayland, xorgserver, xkbcomp, xkeyboard_config, epoxy, libxslt, libunwind, makeWrapper } :
+
+with stdenv.lib;
+
+overrideDerivation xorgserver (oldAttrs: {
+
+  name = "xwayland-${xorgserver.version}";
+  propagatedNativeBuildInputs = oldAttrs.propagatedNativeBuildInputs
+    ++ [wayland epoxy libxslt makeWrapper libunwind];
+  configureFlags = [
+    "--disable-docs"
+    "--disable-devel-docs"
+    "--enable-xwayland"
+    "--disable-xorg"
+    "--disable-xvfb"
+    "--disable-xnest"
+    "--disable-xquartz"
+    "--disable-xwin"
+    "--with-default-font-path="
+    "--with-xkb-bin-directory=${xkbcomp}/bin"
+    "--with-xkb-path=${xkeyboard_config}/etc/X11/xkb"
+    "--with-xkb-output=$out/share/X11/xkb/compiled"
+  ];
+
+  postInstall = ''
+    rm -fr $out/share/X11/xkb/compiled
+    ln -s /var/tmp $out/share/X11/xkb/compiled
+  '';
+
+}) // {
+  meta = {
+    description = "An X server for interfacing X11 apps with the Wayland protocol";
+    homepage = http://wayland.freedesktop.org/xserver.html;
+    license = licenses.mit;
+    platforms = platforms.linux;
+};
+}
+
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10965,6 +10965,7 @@ let
     vaapi = null;
     libva = null;
     libwebp = null;
+    xwayland = null;
   };
 
   weston = callPackage ../applications/window-managers/weston {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7828,6 +7828,8 @@ let
 
   xorgVideoUnichrome = callPackage ../servers/x11/xorg/unichrome/default.nix { };
 
+  xwayland = with xorg; callPackage ../servers/x11/xorg/xwayland.nix { };
+
   yaws = callPackage ../servers/http/yaws { };
 
   zabbix = recurseIntoAttrs (import ../servers/monitoring/zabbix {


### PR DESCRIPTION
Xwayland is an X server which interfaces X11 apps with a wayland server. To test it in weston, put the following in `~/.config/weston.ini` with the correct path.

```
[xwayland]
path=/path/to/Xwayland
```
