### PR TITLE
all-packages: add gitMinimal, use it for nix-exec and fetchgit

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -309,7 +309,8 @@ let
   };
 
   fetchgit = import ../build-support/fetchgit {
-    inherit stdenv git cacert;
+    inherit stdenv cacert;
+    git = gitMinimal;
   };
 
   fetchgitPrivate = import ../build-support/fetchgit/private.nix {
@@ -3983,10 +3984,7 @@ let
 
   nix-exec = callPackage ../development/interpreters/nix-exec {
     nix = nixUnstable;
-    git = git.override {
-      withManual = false;
-      pythonSupport = false;
-    };
+    git = gitMinimal;
   };
 
   octave = callPackage ../development/interpreters/octave {
@@ -9653,6 +9651,10 @@ let
   });
   git = gitAndTools.git;
   gitFull = gitAndTools.gitFull;
+  gitMinimal = git.override {
+    withManual = false;
+    pythonSupport = false;
+  };
   gitSVN = gitAndTools.gitSVN;
 
   gitRepo = callPackage ../applications/version-management/git-repo {


### PR DESCRIPTION
since git is used to bootstrap a lot, this can save lots of waiting time.
