### PR TITLE
dnscrypt-proxy: minor superficial improvements

### DIFF
--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -6,13 +6,14 @@ let
   dnscrypt-proxy = pkgs.dnscrypt-proxy;
   cfg = config.services.dnscrypt-proxy;
   uid = config.ids.uids.dnscrypt-proxy;
-  daemonArgs = [ "--daemonize"
-                 "--user=dnscrypt-proxy"
-                 "--local-address=${cfg.localAddress}:${toString cfg.port}"
-                 (optionalString cfg.tcpOnly "--tcp-only")
-                 "--resolvers-list=${dnscrypt-proxy}/share/dnscrypt-proxy/dnscrypt-resolvers.csv"
-                 "--resolver-name=${cfg.resolverName}"
-               ];
+  daemonArgs =
+    [ "--daemonize"
+      "--user=dnscrypt-proxy"
+      "--local-address=${cfg.localAddress}:${toString cfg.port}"
+      (optionalString cfg.tcpOnly "--tcp-only")
+      "--resolvers-list=${dnscrypt-proxy}/share/dnscrypt-proxy/dnscrypt-resolvers.csv"
+      "--resolver-name=${cfg.resolverName}"
+    ];
 in
 
 {

--- a/pkgs/tools/networking/dnscrypt-proxy/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/default.nix
@@ -11,9 +11,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ libsodium ];
 
   meta = {
-    description = "A DNS proxy which encrypts and authenticates requests using the DNSCrypt protocol.";
+    description = "A tool for securing communications between a client and a DNS resolver";
     homepage = http://dnscrypt.org/;
     license = with stdenv.lib.licenses; [ isc ];
     maintainers = with stdenv.lib.maintainers; [ joachifm ];
+    platform = stdenv.lib.platforms.all;
   };
 }


### PR DESCRIPTION
- Use upstream description and explicitly set platforms = all
- Coding conventions fix
