### PR TITLE
macchanger: new expression

### DIFF
--- a/pkgs/os-specific/linux/macchanger/default.nix
+++ b/pkgs/os-specific/linux/macchanger/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+let
+  pname = "macchanger";
+  version = "1.6.0";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "mirror://gnu/${pname}/${name}.tar.gz";
+    sha256 = "31534f138f1d21fa247be74ba6bef3fbfa47bbcd5033e99bd10c432fe58e51f7";
+  };
+
+  meta = {
+    description = "A utility for viewing/manipulating the MAC address of network interfaces";
+    maintainer = with stdenv.lib.maintainers; [ joachifm ];
+    license = with stdenv.lib.licenses; gpl2Plus;
+    homepage = "https://www.gnu.org/software/macchanger";
+    platform = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1656,6 +1656,8 @@ let
 
   lzop = callPackage ../tools/compression/lzop { };
 
+  macchanger = callPackage ../os-specific/linux/macchanger { };
+
   maildrop = callPackage ../tools/networking/maildrop { };
 
   mailsend = callPackage ../tools/networking/mailsend { };


### PR DESCRIPTION
Having perused the source, I'm pretty sure this is linux only.
Tested randomisation and resetting to factory default.
Obviusly, macchanger must be run before dhcpcd et al.
