### PR TITLE
updated Atom Editor to v0.150.0 and fixed apm LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -16,11 +16,11 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "atom-${version}";
-  version = "0.139.0";
+  version = "0.150.0";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "0732s4r9qx0sgsnz415z5r9685scly2084q80kz2xw0d2gfx04xr";
+    sha256 = "1vvsxj1pwpcz0hn58k1hsrv994vm61lxkih58ix1rkj32wpvdjxn";
     name = "${name}.deb";
   };
 
@@ -38,6 +38,8 @@ in stdenv.mkDerivation rec {
     patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
       $out/share/atom/resources/app/apm/node_modules/atom-package-manager/bin/node
     wrapProgram $out/bin/atom \
+      --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64"
+    wrapProgram $out/bin/apm \
       --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64"
   '';
 


### PR DESCRIPTION
installing/uninstalling atom editor modules without apm wrapped was causing `error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory` for some modules
