### PR TITLE
Add faust, the functional audio stream programming language

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -98,6 +98,7 @@
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";
+  magnetophon = "Bart Brouns <bart@magnetophon.nl>";
   manveru = "Michael Fellinger <m.fellinger@gmail.com>";
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
   matejc = "Matej Cotman <cotman.matej@gmail.com>";

--- a/pkgs/applications/audio/faust/default.nix
+++ b/pkgs/applications/audio/faust/default.nix
@@ -1,0 +1,44 @@
+{ fetchurl, stdenv, unzip, pkgconfig,  gcc }:
+
+stdenv.mkDerivation rec {
+
+  version = "0.9.67";
+  name = "faust-${version}";
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/faudiostream/${name}.zip";
+    sha256 = "068vl9536zn0j4pknwfcchzi90rx5pk64wbcbd67z32w0csx8xm1";
+  };
+
+  buildInputs = [ unzip pkgconfig gcc ];
+
+  patchPhase=''
+    sed -i 's#?= $(shell uname -s)#:= Linux#g'  architecture/osclib/oscpack/Makefile
+    sed -e "s@\$FAUST_INSTALL /usr/local /usr /opt /opt/local@$out@g" -i tools/faust2appls/faustpath
+    '';
+
+  
+  makeFlags="PREFIX=$(out)";
+
+  meta = with stdenv.lib; {
+    description = "A functional programming language for realtime audio signal processing";
+    longDescription = ''
+      FAUST (Functional Audio Stream) is a functional programming
+      language specifically designed for real-time signal processing
+      and synthesis. FAUST targets high-performance signal processing
+      applications and audio plug-ins for a variety of platforms and
+      standards.
+      The Faust compiler translates DSP specifications into very
+      efficient C++ code. Thanks to the notion of architecture,
+      FAUST programs can be easily deployed on a large variety of
+      audio platforms and plugin formats (jack, alsa, ladspa, maxmsp,
+      puredata, csound, supercollider, pure, vst, coreaudio) without
+      any change to the FAUST code.
+    '';
+    homepage = http://faust.grame.fr/;
+    downloadPage = http://sourceforge.net/projects/faudiostream/files/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.magnetophon ];
+  };
+}
+

--- a/pkgs/applications/audio/faust/default.nix
+++ b/pkgs/applications/audio/faust/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unzip, pkgconfig,  gcc }:
+{ fetchurl, stdenv, unzip }:
 
 stdenv.mkDerivation rec {
 
@@ -9,13 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "068vl9536zn0j4pknwfcchzi90rx5pk64wbcbd67z32w0csx8xm1";
   };
 
-  buildInputs = [ unzip pkgconfig gcc ];
+  buildInputs = [ unzip ];
 
   patchPhase=''
+    sed -i '77,101d' Makefile
     sed -i 's#?= $(shell uname -s)#:= Linux#g'  architecture/osclib/oscpack/Makefile
     sed -e "s@\$FAUST_INSTALL /usr/local /usr /opt /opt/local@$out@g" -i tools/faust2appls/faustpath
     '';
 
+  postInstallPhase=''
+    rm -rf $out/include/
+    '';
   
   makeFlags="PREFIX=$(out)";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12372,6 +12372,8 @@ let
 
   fakenes = callPackage ../misc/emulators/fakenes { };
 
+  faust = callPackage ../applications/audio/faust { };
+
   fceux = callPackage ../misc/emulators/fceux { };
 
   foldingathome = callPackage ../misc/foldingathome { };


### PR DESCRIPTION
This package has just the bare Faust compiler, which will compile a faust.dsp file to a c++ file.
A full Faust development environment includes a group of scripts that compile that c++ file to a binary.
As there are around 30 of these, with lot's of dependencies, which are all optional, it was decided on IRC that these would be made into a separate package. Work has been done on that as well.

PS: this is my first pull-request ever, plus I'm new to NixOS. My apologies for any errors in form or content. 
