### PR TITLE
Revert "added myself"

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -100,7 +100,6 @@
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";
   magnetophon = "Bart Brouns <bart@magnetophon.nl>";
   manveru = "Michael Fellinger <m.fellinger@gmail.com>";
-  magnetophon = "Bart Brouns <bart@magnetophon.nl>";
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
   matejc = "Matej Cotman <cotman.matej@gmail.com>";
   meisternu = "Matt Miemiec <meister@krutt.org>";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#5102. @magnetophon added himself in the `faust` pull request already. :-(
