### PR TITLE
racket: add libreadline to ffi libs - enables xrepl.

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cairo, file, fontconfig, glib, gtk, freefont_ttf
-, libjpeg, libpng, libtool, makeWrapper, openssl, pango, sqlite, which } :
+, libjpeg, libpng, libtool, makeWrapper, openssl, pango, sqlite, which, readline } :
 
 stdenv.mkDerivation rec {
   pname = "racket";
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
 
   # Various Racket executables do runtime searches for these.
   ffiSharedLibs = "${cairo}/lib:${fontconfig}/lib:${glib}/lib:${gtk}/lib:${libjpeg}/lib:"
-                + "${libpng}/lib:${openssl}/lib:${pango}/lib:${sqlite}/lib";
+                + "${libpng}/lib:${openssl}/lib:${pango}/lib:${sqlite}/lib:"
+                + "${readline}/lib";
 
   buildInputs = [ file fontconfig freefont_ttf libtool makeWrapper sqlite which ];
 


### PR DESCRIPTION
The Racket derivation already includes a bunch of extra libs in the `ffiSharedLibs` field.  However, `libreadline` was missing.  This adds it.  A test of whether this works is the following:

```
$ racket
Welcome to Racket v6.1.1.
-> (require xrepl)
->
```

If that succeeds without warning or error, you have readline loaded.  Alternatively:

```
$ racket
Welcome to Racket v6.1.1.
-> (require ffi/unsafe)
-> (ffi-lib "libreadline.so")
#<ffi-lib>
```

Note that this patch was built not against head, but against the last working copy of Racket.  Because [Racket 6.1.1 recently started failing its builds](http://hydra.nixos.org/build/16967627).  (cc @samth)  However, as a patch against the last working rev (557a3c92e3cb5f81e9), the readline support worked fine for me.
