### PR TITLE
Add primus and extend bumblebee to support 32bit/64bit multilib

### DIFF
--- a/nixos/modules/hardware/video/bumblebee.nix
+++ b/nixos/modules/hardware/video/bumblebee.nix
@@ -30,7 +30,7 @@ with lib;
     boot.kernelModules = [ "bbswitch" ];
     boot.extraModulePackages = [ kernel.bbswitch kernel.nvidia_x11 ];
 
-    environment.systemPackages = [ pkgs.bumblebee ];
+    environment.systemPackages = [ pkgs.bumblebee pkgs.primus ];
 
     systemd.services.bumblebeed = {
       description = "Bumblebee Hybrid Graphics Switcher";

--- a/pkgs/tools/X11/primus/builder.sh
+++ b/pkgs/tools/X11/primus/builder.sh
@@ -1,0 +1,12 @@
+source $stdenv/setup
+
+cp -r $src src
+cd src
+
+export LIBDIR=$out/lib
+export PRIMUS_libGLa=$nvidia/lib/libGL.so
+export PRIMUS_libGLd=$mesa/lib/libGL.so
+export PRIMUS_LOAD_GLOBAL=$mesa/lib/libglapi.so
+
+make
+ln -s $LIBDIR/libGL.so.1 $LIBDIR/libGL.so

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -1,0 +1,40 @@
+# For a 64bit + 32bit system the LD_LIBRARY_PATH must contain both the 32bit and 64bit primus
+# libraries. Providing a different primusrun for each architecture will not work as expected. EG:
+# Using steam under wine can involve both 32bit and 64bit process. All of which inherit the
+# same LD_LIBRARY_PATH.
+# Other distributions do the same.
+{ stdenv
+, primusLib
+, writeScript
+, primusLib_i686 ? null
+}:
+with stdenv.lib;
+let
+  version = "1.0.0748176";
+  ldPath = makeLibraryPath ([primusLib] ++ optional (primusLib_i686 != null) primusLib_i686);
+  primusrun = writeScript "primusrun"
+''
+  export LD_LIBRARY_PATH=${ldPath}:\$LD_LIBRARY_PATH
+  # see: https://github.com/amonakov/primus/issues/138
+  # On my system, as of 3.16.6, the intel driver dies when the pixel buffers try to read from the
+  # source memory directly. Setting PRIMUS_UPLOAD causes an indirection through textures which
+  # avoids this issue.
+  export PRIMUS_UPLOAD=1
+  exec "$@"
+'';
+in
+stdenv.mkDerivation {
+  name = "primus-${version}";
+  builder = writeScript "builder"
+  ''
+  source $stdenv/setup
+  mkdir -p $out/bin
+  cp ${primusrun} $out/bin/primusrun
+  '';
+
+  meta = {
+    homepage = https://github.com/amonakov/primus;
+    description = "Faster OpenGL offloading for Bumblebee";
+    maintainer = maintainers.coconnor;
+  };
+}

--- a/pkgs/tools/X11/primus/lib.nix
+++ b/pkgs/tools/X11/primus/lib.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchgit
+, x11, mesa
+, nvidia
+}:
+let
+  version = "1.0.0748176";
+in
+stdenv.mkDerivation {
+  name = "primus-lib-${version}";
+  src = fetchgit {
+    url = git://github.com/amonakov/primus.git;
+    rev = "074817614c014e3a99259388cb18fd54648b659a";
+    sha256 = "0mrh432md6zrm16avxyk57mgszrqpgwdjahspchvlaccqxp3x82v";
+  };
+
+  inherit nvidia mesa;
+
+  buildInputs = [ x11 mesa ];
+  builder = ./builder.sh;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10993,7 +10993,28 @@ let
 
   virtualgl = callPackage ../tools/X11/virtualgl { };
 
-  bumblebee = callPackage ../tools/X11/bumblebee { };
+  primus = callPackage ../tools/X11/primus {
+    primusLib = callPackage ../tools/X11/primus/lib.nix {
+      nvidia = linuxPackages.nvidia_x11;
+    };
+
+    primusLib_i686 = if system == "x86_64-linux"
+      then callPackage_i686 ../tools/X11/primus/lib.nix {
+             nvidia = pkgsi686Linux.linuxPackages.nvidia_x11.override { libsOnly = true; };
+           }
+      else null;
+  };
+
+  bumblebee = callPackage ../tools/X11/bumblebee {
+    nvidia_x11 = linuxPackages.nvidia_x11;
+    nvidia_x11_i686 = if system == "x86_64-linux"
+      then pkgsi686Linux.linuxPackages.nvidia_x11.override { libsOnly = true; }
+      else null;
+    virtualgl = virtualgl;
+    virtualgl_i686 = if system == "x86_64-linux"
+      then pkgsi686Linux.virtualgl
+      else null;
+  };
 
   vkeybd = callPackage ../applications/audio/vkeybd {
     inherit (xlibs) libX11;


### PR DESCRIPTION
Using primusrun will work as expected in a multilib environment. Even if the initial program
executes a another program of the alternate architecture. Assuming the program does not modify
LD_LIBRARY_PATH inappropriately.

This does not update virtualgl for seemless multilib. I was unable to get a mixed 64/32 bit
environment to work with VirtualGL. The mechanism VirtualGL uses to inject the forwarding GL library
fails if both 32bit and 64 bit libraries were in the environment.Though, curiously, that's what is done on other OSs. Instead the bumblebee package
creates a optirun32 executable that can be used to run a 32bit executable with optimus on a 64 bit
host. This is not created if the host is 32bit.

For my usage the primusrun executable works as expected regardless of
32bit/64bit.
