### PR TITLE
Add eid-mw: authenticate & sign with Belgian eID identity cards

### DIFF
--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, gtk2, nssTools, pcsclite, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "${package}-${build}";
+  package = "eid-mw-4.0.6-1620";
+  build = "tcm406-258906";
+
+  src = fetchurl {
+    url = "http://eid.belgium.be/en/binaries/${package}.tar_${build}.gz";
+    sha256 = "1ecb30f9f318bdb61a8d774fe76b948eb5841d4de6fee106029ed78daa7efbf2";
+  };
+
+  buildInputs = [ gtk2 pcsclite pkgconfig ];
+
+  unpackPhase = "tar -xzf ${src} --strip-components=1";
+
+  postInstall = ''
+    install -D ${./eid-nssdb.in} $out/bin/eid-nssdb
+    substituteInPlace $out/bin/eid-nssdb \
+      --replace "modutil" "${nssTools}/bin/modutil"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Belgian electronic identity card (eID) middleware";
+    homepage = http://eid.belgium.be/en/using_your_eid/installing_the_eid_software/linux/;
+    license = with licenses; lgpl3;
+    longDescription = ''
+      Allows user authentication and digital signatures with Belgian ID cards.
+      Also requires a running pcscd service and compatible card reader.
+
+      This package only installs the libraries. To use eIDs in NSS-compatible
+      browsers like Chrom{e,ium} or Firefox, each user must first execute:
+
+        ~$ eid-nssdb add
+
+      (Running the script once as root with the --system option enables eID
+      support for all users, but will *not* work when using Chrom{e,ium}!)
+
+      Before uninstalling this package, it is a very good idea to run
+
+        ~$ eid-nssdb [--system] remove
+
+      and remove all ~/.pki and/or /etc/pki directories no longer needed.
+    '';
+    maintainers = with maintainers; [ nckx ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/tools/security/eid-mw/eid-nssdb.in
+++ b/pkgs/tools/security/eid-mw/eid-nssdb.in
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+rootdb="/etc/pki/nssdb"
+userdb="$HOME/.pki/nssdb"
+dbentry="Belgium eID"
+libfile="/run/current-system/sw/libbeidpkcs11.so"
+
+dbdir="$userdb"
+
+case "$1" in
+--help)	cat << EOF
+(Un)register $dbentry with NSS-compatible browsers.
+
+Usage: `basename "$0"` [OPTION] ACTION [LIBRARY]
+
+Options:
+  --db PATH	use custom NSS database directory PATH
+  --user	use user NSS database $userdb (default)
+  --system	use global NSS database $rootdb
+  --help	show this message
+
+Actions:
+  add		add $dbentry to NSS database
+  remove	remove $dbentry from NSS database
+  show		show $dbentry NSS database entry
+
+Default arguments if unspecified:
+  LIBRARY	$libfile
+EOF
+	exit ;;
+--db)	dbdir="$2"
+	shift 2 ;;
+--user)	shift ;;
+--system)
+	dbdir="$rootdb"
+	shift ;;
+esac
+
+if [ "$2" ]; then
+	libfile="$2"
+	if ! [ -f "$libfile" ]; then
+		echo "$0: error: '$libfile' not found" >&2
+		exit 1
+	fi
+fi
+
+mkdir -p "$dbdir"
+if ! [ -d "$dbdir" ]; then
+	echo "$0: error: '$dbdir' must be a writable directory" >&2
+	exit 1
+fi
+
+echo "NSS database: $dbdir"
+echo "BEID library: $libfile"
+
+dbdir="sql:$dbdir"
+
+case "$1" in
+add)	echo "Adding $dbentry to database:"
+	modutil -dbdir "$dbdir" -add "$dbentry" -libfile "$libfile" ||
+		echo "Tip: try removing the module before adding it again." ;;
+remove) echo "Removing $dbentry from database:"
+	modutil -dbdir "$dbdir" -delete "$dbentry" ;;
+show)	echo "Displaying $dbentry database entry, if any:"
+	echo "Note: this may fail if you don't have the correct permissions." ;;
+*)	echo "$0: unknown action: '$1'" >&2
+	echo "Try --help for usage information."
+	exit 1 ;;
+esac
+
+ret=$?
+
+modutil -dbdir "$dbdir" -list "$dbentry" 2>/dev/null
+
+exit $ret

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1069,6 +1069,8 @@ let
 
   edk2 = callPackage ../development/compilers/edk2 { };
 
+  eid-mw = callPackage ../tools/security/eid-mw { };
+
   eid-viewer = callPackage ../tools/security/eid-viewer { };
 
   emscripten = callPackage ../development/compilers/emscripten { };


### PR DESCRIPTION
Adds limited but useful support for Belgian electronic ID cards.

Limited for now, because:
- While a Firefox extension is included and installed, no effort is made to integrate it. I use Chromium.
- The library should work with all NSS-compatible browsers, but must be registered manually by and for each user. Instructions are included.
