### PR TITLE
Named a fontconfig patch that has a questionmark in url

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
+      name = "fc-cache-bug-77252.patch";
       url = "http://cgit.freedesktop.org/fontconfig/patch/?id=f44157c809d280e2a0ce87fb078fc4b278d24a67";
       sha256 = "19s5irclg4irj2yxd7xw9yikbazs9263px8qbv4r21asw06nfalv";
     })


### PR DESCRIPTION
Named a patch to avoid file in nix store with a ? (was breaking a darwin build)
