### PR TITLE
fontconfig: don't enable Infinality unconditionally

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     cd "$out/etc/fonts" && tar xvf ${infinality_patch}
-    rm conf.d/{50-user,51-local}.conf
+    rm conf.d/{50-user,51-local,52-infinality}.conf
     "${libxslt}/bin/xsltproc" --stringparam fontDirectories "${fontbhttf}" \
       --stringparam fontconfig "$out" \
       --stringparam fontconfigConfigVersion "${configVersion}" \


### PR DESCRIPTION
The file conf.d/52-infinality.conf loads the upstream-default Infinality
settings unconditionally. We should not do this for two reasons:
1. We don't set the environment variables the FreeType part of
Infinality needs, so it's not actually activated! All the Infinality
fontconfig settings will do without the environment variables is
activate some font substitutions!
2. The settings in infinality/infinality.conf are intended to be
user-customizable. We should have a NixOS module for this, but that's
impossible if fontconfig forcibly loads the upstream default config.

@vcunat Do you have comments or objections before I merge this into staging?
