### PR TITLE
proot: allow static compilation

### DIFF
--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     "--builtin-libraries=replace"
   ];
 
+  postInstall = ''
+    ar qf $out/lib/libtalloc.a bin/default/talloc_5.o
+  '';
+
   meta = with stdenv.lib; {
     description = "Hierarchical pool based memory allocator with destructors";
     homepage = http://tdb.samba.org/;

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, talloc }:
+{ stdenv, fetchgit, talloc, enableStatic ? false }:
 
 stdenv.mkDerivation rec {
   name = "proot-${version}";
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ talloc ];
 
-  preBuild = ''
+  preBuild = stdenv.lib.optionalString enableStatic ''
+    export LDFLAGS="-static -L${talloc}/lib"
+  '' + ''
     substituteInPlace GNUmakefile --replace "/usr/local" "$out"
   '';
 


### PR DESCRIPTION
Thus nix compiled proot becomes useful on other Linuxes.
