### PR TITLE
Add systemd system sleep hook dir

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -63,15 +63,8 @@ in
         mkdir -m 0755 -p /var/lib/upower
       '';
 
-    # The upower daemon seems to get stuck after doing a suspend
-    # (i.e. subsequent suspend requests will say "Sleep has already
-    # been requested and is pending").  So as a workaround, restart
-    # the daemon.
-    powerManagement.resumeCommands =
-      ''
-        ${config.systemd.package}/bin/systemctl try-restart upower
-      '';
-
+    systemd.sleepHooks = [
+      "${pkgs.upower}/lib/systemd/system-sleep/system-sleep/notify-upower.sh"
+    ];
   };
-
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -473,6 +473,19 @@ let
       ''}
     ''; # */
 
+  linkSleepHooks = sleepHooks:
+    pkgs.runCommand "systemd-suspend-sleep-hooks" { preferLocalBuild = true; } ''
+      mkdir -p $out
+      ${concatMapStrings (p: ''
+        if [ -d ${p} ]; then
+          for f in ${p}/bin/* ; do
+            ln -sfn $f $out/
+          done
+        else
+          ln -sfn ${p} $out/
+        fi
+      '') sleepHooks}
+    '';
 in
 
 {
@@ -584,6 +597,16 @@ in
       description = ''
         Extra config options for systemd. See man systemd-system.conf for
         available options.
+      '';
+    };
+
+    systemd.sleepHooks = mkOption {
+      default = [];
+      type = types.listOf types.path;
+      description = ''
+        Executables to place under /etc/systemd/system-sleep. Can be a path
+        to an executable or a path to a directory containing executables under
+        bin. See man systemd-suspend.service.
       '';
     };
 
@@ -710,6 +733,8 @@ in
     system.build.units = cfg.units;
 
     environment.systemPackages = [ systemd ];
+
+    environment.etc."systemd/system-sleep".source = linkSleepHooks cfg.sleepHooks;
 
     environment.etc."systemd/system".source =
       generateUnits "system" cfg.units upstreamSystemUnits upstreamSystemWants;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -2,6 +2,8 @@
 , xz, pam, acl, cryptsetup, libuuid, m4, utillinux
 , glib, kbd, libxslt, coreutils, libgcrypt, sysvtools
 , kexectools, libmicrohttpd, linuxHeaders
+, automake113x
+, autoconf
 , pythonPackages ? null, pythonSupport ? false
 }:
 
@@ -33,7 +35,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig intltool gperf libcap kmod xz pam acl
       /* cryptsetup */ libuuid m4 glib libxslt libgcrypt
-      libmicrohttpd linuxHeaders
+      libmicrohttpd linuxHeaders automake113x autoconf
     ] ++ stdenv.lib.optionals pythonSupport [pythonPackages.python pythonPackages.lxml];
 
   configureFlags =

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
       # Fixes systemd-journald so that it does not get killed
       # by systemd-journal-flush starting too quickly
       ./systemd-journald-type-notify.patch
+      # removes the system sleep directory from install directories. NixOS handles creating the
+      # directory.
+      ./no-install-system-sleep-dir.patch
     ];
 
   buildInputs =
@@ -112,13 +115,17 @@ stdenv.mkDerivation rec {
   # 1e1954f53386cb773e2a152748dd31c4d36aa2d8) because using /var is
   # forbidden in early boot, but in NixOS the initrd guarantees that
   # /var is mounted.
-  makeFlags = "hwdb_bin=/var/lib/udev/hwdb.bin";
+  makeFlags =
+    [ "hwdb_bin=/var/lib/udev/hwdb.bin"
+      "systemsleepdir=/etc/systemd/system-sleep"
+    ];
 
   installFlags =
     [ "localstatedir=$(TMPDIR)/var"
       "sysconfdir=$(out)/etc"
       "sysvinitdir=$(TMPDIR)/etc/init.d"
       "pamconfdir=$(out)/etc/pam.d"
+      "systemsleepdir=/etc/systemd/system-sleep"
     ];
 
   postInstall =

--- a/pkgs/os-specific/linux/systemd/no-install-system-sleep-dir.patch
+++ b/pkgs/os-specific/linux/systemd/no-install-system-sleep-dir.patch
@@ -1,0 +1,11 @@
+diff -ru systemd-212-orig/Makefile.am systemd-212/Makefile.am
+--- systemd-212-orig/Makefile.am	2014-05-18 22:54:57.743555394 -0700
++++ systemd-212/Makefile.am	2014-05-18 22:59:25.302463456 -0700
+@@ -4980,7 +4980,6 @@
+ 	$(prefix)/lib/kernel/install.d \
+ 	$(sysconfdir)/kernel/install.d \
+ 	$(systemshutdowndir) \
+-	$(systemsleepdir) \
+ 	$(systemgeneratordir) \
+ 	$(usergeneratordir) \
+ 	\


### PR DESCRIPTION
Enables the use and configuration of hooks in /etc/systemd/system-sleep. Which is used, for instance, by upower to notify the upower daemon of resume.
In order for NixOS to manage the system-sleep directory the systemd Makefile.am must be patched. Otherwise systemd will attempt to create and write to the directory directly during build. Which will fail. Since Makefile.am is patched the systemd build is extended to depend on automake and autoconf.
