### PR TITLE
Skarnet refactor

### DIFF
--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -1,10 +1,14 @@
-{stdenv, fetchurl}:
+{ stdenv
+, skarnetConfCompile
+, fetchurl
+}:
 
 let
 
   version = "1.6.0.0";
 
 in stdenv.mkDerivation rec {
+
   name = "skalibs-${version}";
 
   src = fetchurl {
@@ -17,32 +21,7 @@ in stdenv.mkDerivation rec {
   # See http://skarnet.org/cgi-bin/archive.cgi?1:mss:75:201405:pkmodhckjklemogbplje
   patches = [ ./getpeereid.patch ];
 
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"     > conf-defaultpath
-    printf "$out/etc"     > conf-etc
-    printf "$out/bin"     > conf-install-command
-    printf "$out/include" > conf-install-include
-    printf "$out/libexec" > conf-install-libexec
-    printf "$out/lib"     > conf-install-library
-    printf "$out/lib"     > conf-install-library.so
-    printf "$out/sysdeps" > conf-install-sysdeps
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-    touch flag-forcedevr
-
-    popd
-  '';
-
-  preBuild = ''
-    patchShebangs src/sys
-  '';
+  buildInputs = [ skarnetConfCompile ];
 
   preInstall = ''
     mkdir -p "$out/etc"

--- a/pkgs/development/tools/build-managers/skarnet/default.nix
+++ b/pkgs/development/tools/build-managers/skarnet/default.nix
@@ -1,0 +1,21 @@
+{ stdenv }:
+
+let
+
+  version = "2014-11-28";
+
+in stdenv.mkDerivation {
+
+  name = "skarnet-conf-compile-${version}";
+
+  phases = [ "fixupPhase" ];
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://www.skarnet.org/software/conf-compile.html;
+    description = "Support for configuring skarnet.org packages for nix builds";
+    platforms = stdenv.lib.platforms.all;
+  };
+
+}

--- a/pkgs/development/tools/build-managers/skarnet/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/skarnet/setup-hook.sh
@@ -16,6 +16,11 @@ skarnetConfigure() {
   > conf-install-library.so  printf "$out/lib"
   > conf-install-sysdeps     printf "$out/sysdeps"
 
+  # use generic 'cc' to support both gcc and clang (darwin) stdenvs
+  for file in conf-cc conf-dynld conf-ld; do
+    substituteInPlace $file --replace gcc cc
+  done
+
   # let nix builder strip things, cross-platform
   truncate --size 0 conf-stripbins conf-striplibs
 

--- a/pkgs/development/tools/build-managers/skarnet/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/skarnet/setup-hook.sh
@@ -1,0 +1,42 @@
+# Packages from skarnet.org use a unique build system. These functions
+# assist with some common configuration and shebang patching.
+
+skarnetConfigure() {
+  runHook preConfigure
+
+  pushd conf-compile >/dev/null
+
+  # paths
+  > conf-defaultpath         printf "$out/bin"
+  > conf-etc                 printf "$out/etc"
+  > conf-install-command     printf "$out/bin"
+  > conf-install-include     printf "$out/include"
+  > conf-install-libexec     printf "$out/libexec"
+  > conf-install-library     printf "$out/lib"
+  > conf-install-library.so  printf "$out/lib"
+  > conf-install-sysdeps     printf "$out/sysdeps"
+
+  # let nix builder strip things, cross-platform
+  truncate --size 0 conf-stripbins conf-striplibs
+
+  rm -f flag-slashpackage
+  touch flag-allstatic
+  touch flag-forcedevr          # only used for skalibs
+
+  # build inputs
+  truncate --size 0 import path-include path-library
+  for input in $nativeBuildInputs; do
+    [[ -a "$input/sysdeps" ]] && >> import       printf "$input/sysdeps"
+    [[ -a "$input/include" ]] && >> path-include printf "$input/include"
+    [[ -a "$input/lib" ]]     && >> path-library printf "$input/lib"
+  done
+
+  popd >/dev/null
+
+  # patch various scripts to use stdenv shell
+  patchShebangs src/sys
+
+  runHook postConfigure
+}
+
+export configurePhase=skarnetConfigure

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, skalibs }:
+{ stdenv
+, fetchurl
+, skalibs
+, skarnetConfCompile
+}:
 
 let
 
@@ -13,35 +17,9 @@ in stdenv.mkDerivation rec {
     sha256 = "1s17g03z5hfpiz32g001g5wyamyvn9l36fr2csk3k7r0jkqfnl0d";
   };
 
-  buildInputs = [ skalibs ];
+  buildInputs = [ skalibs skarnetConfCompile ];
 
   sourceRoot = "admin/${name}";
-
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"           > conf-install-command
-    printf "$out/include"       > conf-install-include
-    printf "$out/lib"           > conf-install-library
-    printf "$out/lib"           > conf-install-library.so
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    printf "${skalibs}/sysdeps"      > import
-    printf "%s" "${skalibs}/include" > path-include
-    printf "%s" "${skalibs}/lib"     > path-library
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-
-    popd
-  '';
-
-  preBuild = ''
-    patchShebangs src/sys
-  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-linux-utils/;

--- a/pkgs/servers/s6/default.nix
+++ b/pkgs/servers/s6/default.nix
@@ -1,4 +1,9 @@
-{stdenv, fetchurl, skalibs, execline}:
+{ stdenv
+, execline
+, fetchurl
+, skalibs
+, skarnetConfCompile
+}:
 
 let
 
@@ -13,38 +18,13 @@ in stdenv.mkDerivation rec {
     sha256 = "0djxdd3d3mlp63sjqqs0ilf8p68m86c1s98d82fl0kgaaibpsikp";
   };
 
-  buildInputs = [ skalibs execline ];
+  buildInputs = [ skalibs execline skarnetConfCompile ];
 
   sourceRoot = "admin/${name}";
-
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"           > conf-install-command
-    printf "$out/include"       > conf-install-include
-    printf "$out/lib"           > conf-install-library
-    printf "$out/lib"           > conf-install-library.so
-    printf "$out/sysdeps"       > conf-install-sysdeps
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    printf "${skalibs}/sysdeps" > import
-    printf "%s\n%s" "${skalibs}/include" "${execline}/include" > path-include
-    printf "%s\n%s" "${skalibs}/lib"     "${execline}/lib"     > path-library
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-
-    popd
-  '';
 
   preBuild = ''
     substituteInPlace "src/daemontools-extras/s6-log.c" \
       --replace '"execlineb"' '"${execline}/bin/execlineb"'
-
-    patchShebangs src/sys
   '';
 
   meta = {

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -1,4 +1,8 @@
-{stdenv, fetchurl, skalibs}:
+{ stdenv
+, fetchurl
+, skalibs
+, skarnetConfCompile
+}:
 
 let
 
@@ -13,36 +17,9 @@ in stdenv.mkDerivation rec {
     sha256 = "1br3qzif166kbp4k813ljbyq058p7mfsp2lj88n8vi4dmj935nzg";
   };
 
-  buildInputs = [ skalibs ];
+  buildInputs = [ skalibs skarnetConfCompile ];
 
   sourceRoot = "admin/${name}";
-
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"     > conf-install-command
-    printf "$out/include" > conf-install-include
-    printf "$out/lib"     > conf-install-library
-    printf "$out/lib"     > conf-install-library.so
-    printf "$out/sysdeps" > conf-install-sysdeps
-
-    printf "${skalibs}/sysdeps" > import
-    printf "${skalibs}/include" > path-include
-    printf "${skalibs}/lib"     > path-library
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-
-    popd
-  '';
-
-  preBuild = ''
-    patchShebangs src/sys
-  '';
 
   meta = {
     homepage = http://skarnet.org/software/execline/;

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, skalibs }:
+{ stdenv
+, fetchurl
+, skalibs
+, skarnetConfCompile
+}:
 
 let
 
@@ -13,33 +17,9 @@ in stdenv.mkDerivation rec {
     sha256 = "040nmls7qbgw8yn502lym4kgqh5zxr2ks734bqajpi2ricnasvhl";
   };
 
-  buildInputs = [ skalibs ];
+  buildInputs = [ skalibs skarnetConfCompile ];
 
   sourceRoot = "admin/${name}";
-
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"           > conf-install-command
-    printf "$out/libexec"       > conf-install-libexec
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    printf "${skalibs}/sysdeps"      > import
-    printf "%s" "${skalibs}/include" > path-include
-    printf "%s" "${skalibs}/lib"     > path-library
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-
-    popd
-  '';
-
-  preBuild = ''
-    patchShebangs src/sys
-  '';
 
   preInstall = ''
     mkdir -p "$out/libexec"

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, skalibs }:
+{ stdenv
+, fetchurl
+, skalibs
+, skarnetConfCompile
+}:
 
 let
 
@@ -13,35 +17,9 @@ in stdenv.mkDerivation rec {
     sha256 = "1r82l5fnz2rrwm5wq2sldqp74lk9fifr0d8hyq98xdyh24hish68";
   };
 
-  buildInputs = [ skalibs ];
+  buildInputs = [ skalibs skarnetConfCompile ];
 
   sourceRoot = "web/${name}";
-
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"           > conf-install-command
-    printf "$out/include"       > conf-install-include
-    printf "$out/lib"           > conf-install-library
-    printf "$out/lib"           > conf-install-library.so
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    printf "${skalibs}/sysdeps"      > import
-    printf "%s" "${skalibs}/include" > path-include
-    printf "%s" "${skalibs}/lib"     > path-library
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-
-    popd
-  '';
-
-  preBuild = ''
-    patchShebangs src/sys
-  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-dns/;

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , s6Dns
 , skalibs
+, skarnetConfCompile
 }:
 
 let
@@ -18,40 +19,9 @@ in stdenv.mkDerivation rec {
     sha256 = "1np9m2j1i2450mbcjvpbb56kv3wc2fbyvmv2a039q61j2lk6vjz7";
   };
 
-  buildInputs = [ skalibs s6Dns execline ];
+  buildInputs = [ skalibs s6Dns execline skarnetConfCompile ];
 
   sourceRoot = "net/${name}";
-
-  configurePhase = ''
-    pushd conf-compile
-
-    printf "$out/bin"           > conf-install-command
-    printf "$out/include"       > conf-install-include
-    printf "$out/lib"           > conf-install-library
-    printf "$out/lib"           > conf-install-library.so
-
-    # let nix builder strip things, cross-platform
-    truncate --size 0 conf-stripbins
-    truncate --size 0 conf-striplibs
-
-    printf "${skalibs}/sysdeps"      > import
-
-    rm -f path-include
-    rm -f path-library
-    for dep in "${execline}" "${s6Dns}" "${skalibs}"; do
-      printf "%s\n" "$dep/include" >> path-include
-      printf "%s\n" "$dep/lib"     >> path-library
-    done
-
-    rm -f flag-slashpackage
-    touch flag-allstatic
-
-    popd
-  '';
-
-  preBuild = ''
-    patchShebangs src/sys
-  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-networking/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6831,6 +6831,8 @@ let
 
   skalibs = callPackage ../development/libraries/skalibs { };
 
+  skarnetConfCompile = callPackage ../development/tools/build-managers/skarnet { };
+
   slang = callPackage ../development/libraries/slang { };
 
   slibGuile = callPackage ../development/libraries/slib {


### PR DESCRIPTION
1. refactor common configuration of the skarnet.org build system (configured by editing files in `conf-compile` directory)
2. use `cc` rather than `gcc` to build on darwin with clang
