### PR TITLE
ino: Use picocom rather than minicom

### DIFF
--- a/pkgs/development/arduino/ino/default.nix
+++ b/pkgs/development/arduino/ino/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, minicom
+{ stdenv, fetchurl, buildPythonPackage, pythonPackages, picocom
 , avrdude, arduino_core, avrgcclibc }:
 
 buildPythonPackage rec {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   # TODO: add avrgcclibc, it must be rebuild with C++ support
   propagatedBuildInputs =
-    [ arduino_core avrdude minicom pythonPackages.configobj
+    [ arduino_core avrdude picocom pythonPackages.configobj
       pythonPackages.jinja2 pythonPackages.pyserial pythonPackages.six ];
 
   patchPhase = ''


### PR DESCRIPTION
I have tested this locally, and `ino serial` now works.

In case the PR reviewer wants more evidence, note that the ino source repo
refers to `picocom` but not `minicom`:
- https://github.com/amperka/ino/search?utf8=%E2%9C%93&q=picocom is non-empty
- https://github.com/amperka/ino/search?utf8=%E2%9C%93&q=minicom is empty
