### PR TITLE
curl: add a version of curl which knows where to find ca-bundle.crt

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -5,12 +5,15 @@
 , gssSupport ? false, gss ? null
 , c-aresSupport ? false, c-ares ? null
 , linkStatic ? false
+, cacertSupport ? false, cacert ? null
 }:
 
 assert zlibSupport -> zlib != null;
 assert sslSupport -> openssl != null;
 assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
+assert cacertSupport -> cacert != null;
+
 
 stdenv.mkDerivation rec {
   name = "curl-7.38.0";
@@ -43,6 +46,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional c-aresSupport "--enable-ares=${c-ares}"
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${gss}"
     ++ stdenv.lib.optionals linkStatic [ "--enable-static" "--disable-shared" ]
+    ++ stdenv.lib.optional cacertSupport [ "--with-ca-bundle=${cacert}/etc/ca-bundle.crt" ]
   ;
 
   dontDisableStatic = linkStatic;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -928,6 +928,15 @@ let
     scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
   };
 
+  curl_cacert = callPackage ../tools/networking/curl rec {
+    fetchurl = fetchurlBoot;
+    zlibSupport = true;
+    sslSupport = zlibSupport;
+    scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
+    cacertSupport = sslSupport;
+  };
+
+
   curl3 = callPackage ../tools/networking/curl/7.15.nix rec {
     zlibSupport = true;
     sslSupport = zlibSupport;


### PR DESCRIPTION
AFAIK, we use curl to download the ca-bundle itself. This is why we can't add ca-bundle support to curl by default. This patch adds a different version of curl with new attribute name. I used this version to perform https:// downloads. 
