### PR TITLE
postfix: add extraInit option

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -276,6 +276,13 @@ in
         ";
       };
 
+      extraInit = mkOption {
+        default = "";
+        description = "
+          Extra lines to be added verbatim to the preStart postfix script.
+        ";
+      };
+
       sslCert = mkOption {
         default = "";
         description = "SSL certificate to use.";
@@ -392,6 +399,7 @@ in
             ${pkgs.postfix}/sbin/postmap -c /var/postfix/conf /var/postfix/conf/virtual
 
             ${pkgs.postfix}/sbin/postfix -c /var/postfix/conf start
+            ${cfg.extraInit}
           '';
 
         preStop = ''


### PR DESCRIPTION
Useful to do quick postfix setups using config options obtained as-is from the Internet.
