### PR TITLE
almir: pin the sqlalchemy version used by zope.sqlalchemy to 8

### DIFF
--- a/nixos/modules/services/backup/almir.nix
+++ b/nixos/modules/services/backup/almir.nix
@@ -109,6 +109,7 @@ in {
       };
 
       sqlalchemy_engine_url = mkOption {
+        default = "postgresql:///bacula";
         example = ''
           postgresql://bacula:bacula@localhost:5432/bacula
           mysql+mysqlconnector://<user>:<password>@<hostname>/<database>'

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -309,8 +309,8 @@ let
       self.transaction
       self.waitress
       self.webhelpers
-      self.zope_sqlalchemy
       self.psycopg2
+      (self.zope_sqlalchemy.override rec {propagatedBuildInputs = with self; [ sqlalchemy8 transaction ];})
     ];
 
     postInstall = ''


### PR DESCRIPTION
Otherwise, sqlalchemy 9 is used which triggers iElectric/almir#61
pinning it to 7 caused a build error. This does mean that both versions
are on the PYTHONPATH, but it seems to work.

@iElectric what do you think?

EDIT:
I've also set postgresql:///bacula as the default sqlalchemy_engine_url which should work out of the box.
