### PR TITLE
nixos/generate-config: Don't generate swap devices

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -160,9 +160,9 @@ in
         )}
 
         # Swap devices.
-        ${flip concatMapStrings config.swapDevices (sw:
-            "${sw.device} none swap${prioOption sw.priority}\n"
-        )}
+        #${flip concatMapStrings config.swapDevices (sw:
+        #    "${sw.device} none swap${prioOption sw.priority}\n"
+        #)}
       '';
 
     # Provide a target that pulls in all filesystems.


### PR DESCRIPTION
This is intended to be a temporary change to prevent transient failures
in the installer tests. The change should be fine for most users since
systemd will automount swap devices as they appear to the system whether
they are defined or not.

Revert this change when upstream has fixed the swap bug causing the
transient failures starting in v217.
