### PR TITLE
Tox: Update libtoxcore, qtox, utox and toxic

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchurl, libtoxcore, pidgin, autoconf, automake, libtool, libsodium } :
+{ stdenv, fetchFromGitHub, libtoxcore, pidgin, autoconf, automake, libtool
+, libsodium } :
 
 let
-  version = "17a3fd9199";
-  date = "20131012";
+  version = "dd181722ea";
+  date = "20141202";
 in
 stdenv.mkDerivation rec {
   name = "tox-prpl-${date}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/jin-eld/tox-prpl/tarball/${version}";
-    name = "${name}.tar.gz";
-    sha256 = "0sz5wkyfwmhaj652xpsxq4p252cmmfa1vy6mp3jfyn145c758v9n";
+  src = fetchFromGitHub {
+    owner = "jin-eld";
+    repo = "tox-prpl";
+    rev = "${version}";
+    sha256 = "0wzyvg11h4ym28zqd24p35lza3siwm2519ga0yhk98rv458zks0v";
   };
 
   NIX_LDFLAGS = "-lssp -lsodium";

--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -1,29 +1,30 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libtoxcore, qt5, openal, opencv }:
+{ stdenv, fetchFromGitHub, pkgconfig, libtoxcore, qt5, openalSoft, opencv
+, libsodium }:
 
 
 stdenv.mkDerivation rec {
-  name = "qtox-dev-20140918";
+  name = "qtox-dev-20141201";
 
   src = fetchFromGitHub {
     owner = "tux3";
     repo = "qTox";
-    rev = "f06ec65bca";
-    sha256 = "0r7qc444bgsxawyya5nw3xk1c50b90307lcwazs8mn35h4snr97m";
+    rev = "qtox-windows-1417469442.11";
+    sha256 = "02nxj0w5qbgc79n8mgyqldk1yadf4p8pysn79f7fvi8fxq4j0j5n";
   };
 
-  buildInputs = [ pkgconfig libtoxcore qt5 openal opencv ];
+  buildInputs = [ pkgconfig libtoxcore qt5 openalSoft opencv libsodium ];
 
   configurePhase = "qmake";
 
   installPhase = ''
-    ensureDir $out/bin
+    mkdir $out/bin
     cp qtox $out/bin
   '';
 
   meta = with stdenv.lib; {
     description = "QT Tox client";
     license = licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ viric ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ viric jgeerds ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   configurePhase = "qmake";
 
   installPhase = ''
-    mkdir $out/bin
+    mkdir -p $out/bin
     cp qtox $out/bin
   '';
 

--- a/pkgs/applications/networking/instant-messengers/toxic/default.nix
+++ b/pkgs/applications/networking/instant-messengers/toxic/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, autoconf, libtool, automake, libsodium, ncurses
+{ stdenv, fetchFromGitHub, autoconf, libtool, automake, libsodium, ncurses
 , libtoxcore, openal, libvpx, freealut, libconfig, pkgconfig }:
 
-let
-  version = "0.5.1";
-in stdenv.mkDerivation rec {
-  name = "toxic-${version}";
+stdenv.mkDerivation rec {
+  name = "toxic-dev-20141130";
 
-  src = fetchurl {
-    url = "https://github.com/Tox/toxic/archive/v${version}.tar.gz";
-    sha256 = "0zzfgwm17a4xcy9l0ll2pksp45mz6f4s3isdrgjpw1xibv9xnzcm";
+  src = fetchFromGitHub {
+    owner = "Tox";
+    repo = "toxic";
+    rev = "4acfe84171";
+    sha256 = "1yqglh9fm75zph4fzf3z4gwmamngypwpvb7shpqgakdg8ybq0a8s";
   };
 
-  makeFlags = [ "-Cbuild" "VERSION=${version}" "PREFIX=$(out)" ];
+  makeFlags = [ "-Cbuild" "PREFIX=$(out)" ];
   installFlags = [ "PREFIX=$(out)" ];
 
   buildInputs = [
@@ -21,10 +21,10 @@ in stdenv.mkDerivation rec {
     openal libvpx freealut
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Reference CLI for Tox";
-    license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = with stdenv.lib.maintainers; [ viric ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ viric jgeerds ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -3,13 +3,13 @@
 
 
 stdenv.mkDerivation rec {
-  name = "utox-dev-20140921";
+  name = "utox-dev-20141130";
 
   src = fetchFromGitHub {
     owner = "notsecure";
     repo = "uTox";
-    rev = "c0afc95cf3";
-    sha256 = "0a6i0c9crj6b27alm8q0fcfj8q425khg5305sp57r7pj505l4d1f";
+    rev = "38b0a2014f";
+    sha256 = "00g9fsp83yjq6dfim3hfpag0ny9w5kydghycfj3ic8qaljp47y8a";
   };
 
   buildInputs = [ pkgconfig libtoxcore dbus libvpx libX11 openal freetype
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Lightweight Tox client";
     license = licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ iElectric ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ iElectric jgeerds ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -2,8 +2,8 @@
 , libvpx, check, libconfig, pkgconfig }:
 
 let
-  version = "900d72f951";
-  date = "20140921";
+  version = "f6b3e6e8fe98d2457827ac6da944e715f008a08a";
+  date = "20141203";
 in
 stdenv.mkDerivation rec {
   name = "tox-core-${date}-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://github.com/irungentoo/toxcore/tarball/${version}";
     name = "${name}.tar.gz";
-    sha256 = "1fwgflizb21mp4jwkfac7mgmahlly1f3ldbma6h8h6a2qf3pkn2r";
+    sha256 = "1zsx7saqs25vva3pp0bw31yqzrn40fx84w42ig6fiv723k9gpdzy";
   };
 
   NIX_LDFLAGS = "-lgcc_s";
@@ -47,10 +47,10 @@ stdenv.mkDerivation rec {
   # Some tests fail in the Sheevaplug due to timeout
   doCheck = !stdenv.isArm;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "P2P FOSS instant messaging application aimed to replace Skype with crypto";
-    license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = with stdenv.lib.maintainers; [ viric ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ viric jgeerds ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
This PR updates all tox related packages at once. This is necessary due to API changes in libtoxcore. I've tested all clients in a quick way and it worked for me. See commit messages for more information

maintainer: @viric @iElectric 
