### PR TITLE
updated dmtcp major versions

### DIFF
--- a/pkgs/os-specific/linux/dmtcp/1.2.0.nix
+++ b/pkgs/os-specific/linux/dmtcp/1.2.0.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "dmtcp-${version}";
 
-  version = "2.3.1";
+  version = "1.2.0";
 
   buildInputs = [ perl python ];
 
   src = fetchurl {
-    url = "mirror://sourceforge/dmtcp/dmtcp-${version}.tar.gz";
-    sha256 = "1f83ae112e102d4fbf69dded0dfaa6daeb60c4c0c569297553785a876e95ba15";
+    url = "mirror://sourceforge/dmtcp/dmtcp_${version}.tar.gz";
+    sha256 = "1pw3m4l1xf887xagd0yrrnb35s372j0kvjziyy3gmx9fxpga1jzb";
   };
 
   preConfigure = ''
@@ -22,12 +22,10 @@ stdenv.mkDerivation rec {
       --replace /usr/bin/env $(type -p env) \
       --replace /bin/bash $(type -p bash) \
       --replace /usr/bin/perl $(type -p perl) \
-      --replace /usr/bin/python $(type -p python) \
-      --replace "os.environ['USER']" "\"nixbld1\"" \
-      --replace "os.getenv('USER')" "\"nixbld1\""      
+      --replace /usr/bin/python $(type -p python)
   '';
 
-  doCheck = false;
+  doCheck = true;
 
   meta = {
     description = "Distributed MultiThreaded Checkpointing";

--- a/pkgs/os-specific/linux/dmtcp/1.2.0.nix
+++ b/pkgs/os-specific/linux/dmtcp/1.2.0.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace dmtcp/src/dmtcp_coordinator.cpp \
-      --replace /bin/bash /bin/sh
+      --replace /bin/bash ${stdenv.shell}
     substituteInPlace utils/gdb-add-symbol-file \
-      --replace /bin/bash /bin/sh
+      --replace /bin/bash ${stdenv.shell}
     substituteInPlace test/autotest.py \
       --replace /usr/bin/env $(type -p env) \
       --replace /bin/bash $(type -p bash) \

--- a/pkgs/os-specific/linux/dmtcp/default.nix
+++ b/pkgs/os-specific/linux/dmtcp/default.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace dmtcp/src/dmtcp_coordinator.cpp \
-      --replace /bin/bash /bin/sh
+      --replace /bin/bash ${stdenv.shell}
     substituteInPlace utils/gdb-add-symbol-file \
-      --replace /bin/bash /bin/sh
+      --replace /bin/bash ${stdenv.shell}
     substituteInPlace test/autotest.py \
       --replace /usr/bin/env $(type -p env) \
       --replace /bin/bash $(type -p bash) \


### PR DESCRIPTION
The default [dmtcp](http://dmtcp.sourceforge.net) should really be updated to a more recent version, as it is now a major version behind (and more). I'm a nix newbie, but I needed to use this soon so it seemed like a good chance to test out nix-build. So there are a few possible issues:
- My new `--replace` commands may or may not be working correctly. Without these, a python expression trying to access `$USER`  (e.g. `os.environ['USER']`) fails; it seems like `USER` is not being set correctly in the build environment. I attempted to hardcode it to the first build user for now (I guess this would work if it is possible to disable parallel builds). However, I have not checked that this works correctly because specifying `nix-build -A -K dmtcp` does not seem to leave the directory around, even though it now fails much later in the check phase.
- Five out of forty checks will still fail if `doCheck = true`. I haven't investigated these yet, but dmtcp seems to work well enough in general. I will try to investigate these more. Part of the problem could be I'm running in virtualbox for the moment.
