### PR TITLE
Add the Clearlooks-Phenix GTK3 Theme

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -124,6 +124,7 @@
   piotr = "Piotr Pietraszkiewicz <ppietrasa@gmail.com>";
   pkmx = "Chih-Mao Chen <pkmx.tw@gmail.com>";
   plcplc = "Philip Lykke Carlsen <plcplc@gmail.com>";
+  prikhi = "Pavan Rikhi <pavan.rikhi@gmail.com>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";
   qknight = "Joachim Schiele <js@lastlog.de>";

--- a/pkgs/misc/themes/gtk3/clearlooks-phenix/default.nix
+++ b/pkgs/misc/themes/gtk3/clearlooks-phenix/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, gtk }:
+
+stdenv.mkDerivation rec {
+  version = "5.0.7";
+  name = "clearlooks-phenix-${version}";
+
+  src = fetchurl {
+    url = "http://github.com/jpfleury/clearlooks-phenix/archive/${version}.tar.gz";
+    sha256 = "107jx3p3zwzy8xy0m8hwzs1kp8j60xgc3dja27r3vwhb3x3y1i8k";
+  };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/share/themes/Clearlooks-Phenix
+    cp -r . $out/share/themes/Clearlooks-Phenix/
+  '';
+
+  preferLocalBuild = true;
+
+  meta = with stdenv.lib; {
+    descriptioon = "GTK3 port of the Clearlooks theme";
+    longDescription = ''
+      The Clearlooks-Phénix project aims at creating a GTK3 port of Clearlooks,
+      the default theme for Gnome 2. Style is also included for GTK2, Unity and
+      for Metacity, Openbox and Xfwm4 window managers.
+
+      You should install this theme into your user profile and then set
+      GTK_DATA_PREFIX to `~/.nix-profile`.
+    '';
+    homepage = https://github.com/jpfleury/clearlooks-phenix;
+    downloadPage = https://github.com/jpfleury/clearlooks-phenix/releases;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.prikhi ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11800,6 +11800,8 @@ let
     cjs = callPackage ../desktops/cinnamon/cjs.nix { };
   };
 
+  clearlooks-phenix = callPackage ../misc/themes/gtk3/clearlooks-phenix { };
+
   enlightenment = callPackage ../desktops/enlightenment { };
 
   e19 = recurseIntoAttrs (


### PR DESCRIPTION
Due to #5053, users need to install this into their user profile and set the `GTK_DATA_PREFIX` environmental variable to `~/.nix-profile`
