### PR TITLE
firefox-wrapper: add missing gstreamer plugins

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, browser, makeDesktopItem, makeWrapper, plugins, libs, gtk_modules
+{ stdenv, lib, browser, makeDesktopItem, makeWrapper, plugins, gst_plugins, libs, gtk_modules
 , browserName, desktopName, nameSuffix, icon
 }:
 
@@ -32,6 +32,7 @@ stdenv.mkDerivation {
         --suffix-each LD_LIBRARY_PATH ':' "$libs" \
         --suffix-each GTK_PATH ':' "$gtk_modules" \
         --suffix-each LD_PRELOAD ':' "$(cat $(filterExisting $(addSuffix /extra-ld-preload $plugins)))" \
+        --suffix-each GST_PLUGIN_PATH ':' "$gst_plugins" \
         --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))"
 
     mkdir -p $out/share/applications
@@ -48,6 +49,7 @@ stdenv.mkDerivation {
   # where to find the plugin in its tree.
   plugins = map (x: x + x.mozillaPlugin) plugins;
   libs = map (x: x + "/lib") libs ++ map (x: x + "/lib64") libs;
+  gst_plugins = map (x: x + "/lib/gstreamer-0.10") gst_plugins;
   gtk_modules = map (x: x + x.gtkModule) gtk_modules;
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     categories = "Application;Network;WebBrowser;";
   };
 
-  buildInputs = [makeWrapper];
+  buildInputs = [makeWrapper] ++ gst_plugins;
 
   buildCommand = ''
     if [ ! -x "${browser}/bin/${browserName}" ]
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
         --suffix-each LD_LIBRARY_PATH ':' "$libs" \
         --suffix-each GTK_PATH ':' "$gtk_modules" \
         --suffix-each LD_PRELOAD ':' "$(cat $(filterExisting $(addSuffix /extra-ld-preload $plugins)))" \
-        --suffix-each GST_PLUGIN_PATH ':' "$gst_plugins" \
+        --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
         --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))"
 
     mkdir -p $out/share/applications
@@ -49,7 +49,6 @@ stdenv.mkDerivation {
   # where to find the plugin in its tree.
   plugins = map (x: x + x.mozillaPlugin) plugins;
   libs = map (x: x + "/lib") libs ++ map (x: x + "/lib64") libs;
-  gst_plugins = map (x: x + "/lib/gstreamer-0.10") gst_plugins;
   gtk_modules = map (x: x + x.gtkModule) gtk_modules;
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11154,6 +11154,7 @@ let
          );
       libs = [ gstreamer gst_plugins_base ] ++ lib.optionals (cfg.enableQuakeLive or false)
              (with xlibs; [ stdenv.gcc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ]);
+      gst_plugins = [ gst_plugins_base gst_plugins_good gst_ffmpeg ];
       gtk_modules = [ libcanberra ];
     };
 


### PR DESCRIPTION
These GStreamer plugins are required for H264 <video> tag support in Firefox. Is this the right way to add them? 
