### PR TITLE
hipchat: there is no bin/ directory

### DIFF
--- a/pkgs/applications/networking/instant-messengers/hipchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/hipchat/default.nix
@@ -75,8 +75,6 @@ stdenv.mkDerivation {
     mv opt/HipChat/lib/ $d
     mv usr/share $out
 
-    patchShebangs $out/bin
-
     for file in $(find $d -type f); do
         patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $file || true
         patchelf --set-rpath ${rpath}:\$ORIGIN $file || true


### PR DESCRIPTION
We don't need to care about the shipped wrapper script at all because we are creating our own wrapper for the `hipchat.bin` executable.
