### PR TITLE
Add duff: find duplicate files from the command line

### DIFF
--- a/pkgs/tools/filesystems/duff/default.nix
+++ b/pkgs/tools/filesystems/duff/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, autoconf, automake, gettext }:
+
+stdenv.mkDerivation rec {
+  name = "duff-${version}";
+  version = "0.5.2";
+
+  src = fetchurl {
+    url = "https://github.com/elmindreda/duff/archive/${version}.tar.gz";
+    sha256 = "149dd80f9758085ed199c37aa32ad869409fa5e2c8da8a51294bd64ca886e058";
+  };
+
+  buildInputs = [ autoconf automake gettext ];
+
+  preConfigure = ''
+    # duff is currently badly packaged, requiring us to do extra work here that
+    # should be done upstream. If that is ever fixed, this entire phase can be
+    # removed along with all buildInputs.
+
+    # gettexttize rightly refuses to run non-interactively:
+    cp ${gettext}/bin/gettextize .
+    substituteInPlace gettextize \
+      --replace "read dummy" "echo (Automatically acknowledged)"
+    ./gettextize
+    sed 's@po/Makefile.in\( .*\)po/Makefile.in@po/Makefile.in \1@' \
+      -i configure.ac
+    autoreconf -i
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Quickly find duplicate files.";
+    homepage = http://duff.dreda.org/;
+    license = with licenses; zlib;
+    longDescription = ''
+      Duff is a Unix command-line utility for quickly finding duplicates in
+      a given set of files.
+    '';
+    maintainers = with maintainers; [ nckx ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1037,6 +1037,8 @@ let
 
   dtach = callPackage ../tools/misc/dtach { };
 
+  duff = callPackage ../tools/filesystems/duff { };
+
   duo-unix = callPackage ../tools/security/duo-unix { };
 
   duplicity = callPackage ../tools/backup/duplicity {


### PR DESCRIPTION
Should build on all platforms, according to upstream. I hope they're right.
