### PR TITLE
mrtg: add 2.17.4

### DIFF
--- a/pkgs/tools/misc/mrtg/default.nix
+++ b/pkgs/tools/misc/mrtg/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, perl, gd, rrdtool }:
+
+stdenv.mkDerivation rec {
+
+  version = "2.17.4";
+  name = "mrtg-${version}";
+
+  src = fetchurl {
+    url = "http://oss.oetiker.ch/mrtg/pub/${name}.tar.gz";
+    sha256 = "0r93ipscfp7py0b1dcx65s58q7dlwndqhprf8w4945a0h2p7zyjy";
+  };
+
+  buildInputs = [
+    perl gd rrdtool
+  ];
+
+  meta = {
+    description = "The Multi Router Traffic Grapher";
+    homepage = http://oss.oetiker.ch/mrtg/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.robberer ];
+  }; 
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1761,6 +1761,8 @@ let
 
   mr = callPackage ../applications/version-management/mr { };
 
+  mrtg = callPackage ../tools/misc/mrtg { };
+
   mscgen = callPackage ../tools/graphics/mscgen { };
 
   msf = builderDefsPackage (import ../tools/security/metasploit/3.1.nix) {


### PR DESCRIPTION
- The Multi Router Traffic Grapher
- You have a router, you want to know what it does all day long? Then MRTG is for you. It will monitor SNMP network devices and draw pretty pictures showing how much traffic has passed through each interface.
