### PR TITLE
plan9port: make it actually work

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -1,12 +1,12 @@
+set -e
 source $stdenv/setup
 
 tar xvfz $src
 
 cd plan9port
 
-cflags="echo \"CFLAGS='-I${libXt}/include'\" >> \$PLAN9/config"
-
-sed -i "43i\\${cflags}" INSTALL
+echo CFLAGS=\"-I${fontconfig}/include -I${libXt}/include\" > LOCAL.config
+echo X11=\"${libXt}/include\" >> LOCAL.config
 
 for p in $patches; do
   echo "applying patch $p"

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, libX11, libXt
+{stdenv, fetchurl, which, libX11, libXt, fontconfig
 , xproto ? null
 , xextproto ? null
 , libXext ? null }:
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sza12j3db7i54r3pzli8wmby6aiyzmyfj8w0nidmawkwv6jdf6b";
   };
 
-  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 xproto libXt xextproto libXext ];
+  NIX_LDFLAGS="-lgcc_s";
+  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [ which libX11 fontconfig xproto libXt xextproto libXext ];
 
   enableParallelBuilding = true;
 
@@ -29,4 +30,5 @@ stdenv.mkDerivation rec {
   };
 
   inherit libXt;
+  inherit fontconfig;
 }


### PR DESCRIPTION
- Add "which" dependency, otherwise it builds with lots of "command not found" errors.
- -lgcc_s, otherwise many commands basically fail without pthread_cancel.
- Fix X11 dependencies, otherwise it would be plan9port with none of UI programs working.
