### PR TITLE
nix-prefetch-git: set deepClone if leaveDotGit is set

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -19,6 +19,7 @@ if test "$leaveDotGit" != 1; then
     leaveDotGit=
 else
     leaveDotGit=true
+    deepClone=true
 fi
 
 
@@ -33,7 +34,7 @@ for arg; do
             --hash) argfun=set_hashType;;
             --deepClone) deepClone=true;;
             --no-deepClone) deepClone=false;;
-            --leave-dotGit) leaveDotGit=true;;
+            --leave-dotGit) leaveDotGit=true; deepClone=true;;
             --fetch-submodules) fetchSubmodules=true;;
             --builder) builder=true;;
             *)

--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = "https://github.com/couchbase/libcouchbase.git";
     rev = "bd3a20f9e18a69dca199134956fd4ad3e1b80ca8";
-    sha256 = "0gimvfxvbmhm6zy4vgs2630ygilhryxl8apfmv3iqs23pafwzm8r";
+    sha256 = "1a1hg9zvnl1icw59xib5wnk3s120isf8c5awm8id6icvhxjv40hd";
     leaveDotGit = true;
   };
 


### PR DESCRIPTION
Without deepClone, things like "git describe" doesn't work. To make
leaveDotGit more useful, this commit enables deepClone if leaveDotGit is
set.

You can still disable deepClone by adding --no-deepClone after the
--leave-dotGit flag. No such option exist for fetchgit though, but I
think there is little reason to skip the deepClone if you have
set leaveDotGit.

Update the hash of libcouchbase, the only package in nixpkgs that uses
leaveDotGit.
