### PR TITLE
eduke32.nix: disable libpng

### DIFF
--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    make OPTLEVEL=0
+    make OPTLEVEL=0 USE_LIBPNG=0
   '';
 
   installPhase = ''


### PR DESCRIPTION
This patch makes it possible to build (and run) eduke32 on my machine. PNG is not strictly necessary, the game still runs, the difference I know so far is the disabled screenshots. 
