### PR TITLE
dina-font: fix the installPhase

### DIFF
--- a/pkgs/data/fonts/dina/default.nix
+++ b/pkgs/data/fonts/dina/default.nix
@@ -13,14 +13,12 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
   patchPhase = "sed -i 's/microsoft-cp1252/ISO8859-1/' *.bdf";
-  preInstall = ''
-    export _get_font_size() {
+  installPhase = ''
+    _get_font_size() {
       _pt=$\{1%.bdf}
       _pt=$\{_pt#*-}
       echo $_pt
     }
-  '';
-  installPhase = ''
 
     for i in Dina_i400-*.bdf; do
         bdftopcf -t -o DinaItalic$(_get_font_size $i).pcf $i


### PR DESCRIPTION
The existing expression worked fine as a user but seems broken when built by hydra and when in systemEnvironment:
https://hydra.nixos.org/build/17703539/log

I'm not sure why, but hopefully defining the function in the installPhase will fix it?

Is there an easy way to include my ~/.nix-defexpr/ (which has my nixpkgs repo) in the packages searched for systemEnvironment.pkgs?
