### PR TITLE
openjdk: Read SSL truststore from JAVAX_NET_SSL_TRUSTSTORE

### DIFF
--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -61,7 +61,12 @@ stdenv.mkDerivation rec {
     makeFlagsArray+=(CUPS_HEADERS_PATH=$cupsDir)
   '';
 
-  patches = [ ./cppflags-include-fix.patch ./fix-java-home.patch ./paxctl.patch ];
+  patches = [
+    ./cppflags-include-fix.patch
+    ./fix-java-home.patch
+    ./paxctl.patch
+    ./read-truststore-from-env.patch
+  ];
 
   NIX_NO_SELF_RPATH = true;
 

--- a/pkgs/development/compilers/openjdk/read-truststore-from-env.patch
+++ b/pkgs/development/compilers/openjdk/read-truststore-from-env.patch
@@ -1,0 +1,21 @@
+diff -ur openjdk-7u65-b32/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java openjdk-7u65-b32.new/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java
+--- openjdk-7u65-b32/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java	2014-07-17 12:12:14.000000000 +0200
++++ openjdk-7u65-b32.new/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java	2014-12-09 13:31:27.821960372 +0100
+@@ -158,6 +158,7 @@
+         /*
+          * Try:
+          *      javax.net.ssl.trustStore  (if this variable exists, stop)
++         *      system environment variable JAVAX_NET_SSL_TRUSTSTORE
+          *      jssecacerts
+          *      cacerts
+          *
+@@ -165,6 +166,9 @@
+          */
+ 
+         storeFileName = props.get("trustStore");
++        if (storeFileName == null) {
++            storeFileName = System.getenv("JAVAX_NET_SSL_TRUSTSTORE");
++        }
+         if (!"NONE".equals(storeFileName)) {
+             if (storeFileName != null) {
+                 storeFile = new File(storeFileName);


### PR DESCRIPTION
This small patch makes it possible to control java's truststore path through the environment. This makes it possible to add custom CAs that should be allowed by Java. Java users can still use `-Djavax.net.ssl.truststore` to point Java at another truststore, in that case `JAVAX_NET_SSL_TRUSTSTORE` will be overridden.

Something like this can be used to build the truststore (in this example just using the standard `pkgs.cacert` CA-bundle):

``` nix
{
  environment.variables.JAVAX_NET_SSL_TRUSTSTORE = "${
    pkgs.runCommand "cacerts" {} ''
      ${pkgs.perl}/bin/perl \
        ${pkgs.path}/pkgs/development/compilers/openjdk/generate-cacerts.pl \
        ${pkgs.jre}/bin/keytool \
        ${pkgs.cacert}/etc/ca-bundle.crt
      mv cacerts $out
    ''
  }";
} 
```

Ideally, the dependency on `pkgs.cacert` should also be removed from `pkgs.openjdk` to avoid rebuilding java each time the standard CA-bundle changes. Something along the example above should then be added to NixOS (however, it would be nice to not depend on `${pkgs.jre}/bin/keytool` to generate that environment variable.
