### PR TITLE
gdal: update to 1.11.1 and compiling with proj

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,28 +1,30 @@
 { stdenv, fetchurl, composableDerivation, unzip, libjpeg, libtiff, zlib
-, postgresql, mysql, libgeotiff, python, pythonPackages}:
+, postgresql, mysql, libgeotiff, python, pythonPackages, proj}:
 
 composableDerivation.composableDerivation {} (fixed: rec {
-  name = "gdal-1.11.0";
+  version = "1.11.1";
+  name = "gdal-${version}";
 
   src = fetchurl {
-    url = "http://download.osgeo.org/gdal/1.11.0/${name}.tar.gz";
-    md5 = "9fdf0f2371a3e9863d83e69951c71ec4";
+    url = "http://download.osgeo.org/gdal/${version}/${name}.tar.gz";
+    sha256 = "0h1kib2pzv4nbppdnxv6vhngvk9ic531y8rzcwb8bg6am125jszl";
   };
 
-  buildInputs = [ unzip libjpeg libtiff python pythonPackages.numpy];
+  buildInputs = [ unzip libjpeg libtiff python pythonPackages.numpy proj];
 
   # don't use optimization for gcc >= 4.3. That's said to be causeing segfaults
   preConfigure = "export CFLAGS=-O0; export CXXFLAGS=-O0";
 
   configureFlags = [
     "--with-jpeg=${libjpeg}"
-    "--with-libtiff=${libtiff}"  # optional (without largetiff support
-    "--with-libz=${zlib}"        # optional
+    "--with-libtiff=${libtiff}" # optional (without largetiff support
+    "--with-libz=${zlib}"       # optional
 
     "--with-pg=${postgresql}/bin/pg_config"
     "--with-mysql=${mysql}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
-    "--with-python"    # optional
+    "--with-python"               # optional
+    "--with-static-proj4=${proj}" # optional
   ];
 
   meta = {


### PR DESCRIPTION
proj is needed by ogr2ogr to convert in between coordinate systems
