### PR TITLE
Tor module: append redundant specifications of 'extraConfig', via 'types.lines'.

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -58,7 +58,7 @@ in
       };
 
       extraConfig = mkOption {
-        type = types.str;
+        type = types.lines;
         default = "";
         description = ''
           Extra configuration. Contents will be added verbatim to the


### PR DESCRIPTION
My existing specification (pre-overhaul) is fairly modular, this simplifies porting it.

Cc: @thoughtpolice 
