### PR TITLE
nixos/gnome: enable MTP support in gvfs

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gvfs.nix
+++ b/nixos/modules/services/desktops/gnome3/gvfs.nix
@@ -1,6 +1,6 @@
 # gvfs backends
 
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -36,6 +36,8 @@ in
     environment.systemPackages = [ gnome3.gvfs ];
 
     services.dbus.packages = [ gnome3.gvfs ];
+
+    services.udev.packages = [ pkgs.libmtp ];
 
   };
 


### PR DESCRIPTION
To support browsing files on Android phones in Nautilus (and other GVFS
based file browsers).

---

Is there any reason not to add this? Seems very useful to me. And user friendly; it works out of the box!
