### PR TITLE
virtualbox: Allow disabling the network interface.

### DIFF
--- a/nixos/modules/programs/virtualbox-host.nix
+++ b/nixos/modules/programs/virtualbox-host.nix
@@ -9,6 +9,11 @@ in
 {
   options = {
     services.virtualboxHost.enable = mkEnableOption "VirtualBox Host support";
+    services.virtualboxHost.addNetworkInterface = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Automatically set up a vboxnet0 host-only network interface.";
+    };
   };
 
   config = mkIf config.services.virtualboxHost.enable {
@@ -46,7 +51,7 @@ in
       '';
 
     # Since we lack the right setuid binaries, set up a host-only network by default.
-
+  } // mkIf config.services.virtualboxHost.addNetworkInterface {
     systemd.services."vboxnet0" =
       { description = "VirtualBox vboxnet0 Interface";
         requires = [ "dev-vboxnetctl.device" ];


### PR DESCRIPTION
The current nixos module for VirtualBox unconditionally configures a vboxnet0
network interface at boot. This may be undesired, especially when the user wants
to manage network interfaces in a centralized manner.
