### PR TITLE
Add hyperdex.

### DIFF
--- a/pkgs/development/tools/misc/autoconf-archive/default.nix
+++ b/pkgs/development/tools/misc/autoconf-archive/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, xz }:
+stdenv.mkDerivation rec {
+  name = "autoconf-archive-${version}";
+  version = "2014.10.15";
+
+  src = fetchurl {
+    url = "http://ftp.heanet.ie/mirrors/gnu/autoconf-archive/autoconf-archive-${version}.tar.xz";
+    sha256 = "198yrdf8bhrpl7insdyzn65zd60qll0gr9vpz7fl7dpcj78yc7gy";
+  };
+  buildInputs = [ xz ];
+
+  meta = with stdenv.lib; {
+    description = "Archive of autoconf m4 macros.";
+    homepage = http://www.gnu.org/software/autoconf-archive/;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/busybee.nix
+++ b/pkgs/servers/nosql/hyperdex/busybee.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, unzip, autoconf, automake, libtool,
+  libpo6, libe, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "busybee-${version}";
+  version = "0.5.2";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/busybee/archive/releases/${version}.zip";
+    sha256 = "0gr5h2j9rzwarblgcgddnxj39i282rvgn9vqlrcd60dx8c4dkm29";
+  };
+  buildInputs = [
+    autoconf
+    automake
+    libe
+    libpo6
+    libtool
+    pkgconfig
+    unzip
+  ];
+  preConfigure = "autoreconf -i";
+
+  meta = with stdenv.lib; {
+    description = "BusyBee is a high-performance messaging layer.";
+    homepage = https://github.com/rescrv/busybee;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/default.nix
+++ b/pkgs/servers/nosql/hyperdex/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchurl, makeWrapper, unzip, autoconf, automake, libtool,
+  python, sodium, pkgconfig, popt, glog, xz, json_c, gperf, yacc,
+  flex, haskellPackages, help2man, autoconf-archive, callPackage }:
+
+assert stdenv.isLinux;
+
+let
+hyperleveldb = callPackage ./hyperleveldb.nix {};
+libpo6 = callPackage ./libpo6.nix {};
+libe = callPackage ./libe.nix { inherit libpo6; };
+busybee = callPackage ./busybee.nix { inherit libpo6 libe; };
+replicant = callPackage ./replicant.nix {
+  inherit libpo6 libe busybee hyperleveldb;
+};
+libmacaroons = callPackage ./libmacaroons.nix { };
+
+in
+stdenv.mkDerivation rec {
+  name = "hyperdex-${version}";
+  version = "1.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/HyperDex/archive/releases/${version}.zip";
+    sha256 = "0s1capy2hj45f5rmdb4fk0wxy7vz69krplhba57f6wrkpcz1zb57";
+  };
+
+  buildInputs = [
+    autoconf
+    autoconf-archive
+    automake
+    busybee
+    glog
+    hyperleveldb
+    json_c
+    libe
+    libmacaroons
+    libpo6
+    libtool
+    pkgconfig
+    popt
+    python
+    replicant
+    unzip
+    gperf
+    yacc
+    flex
+    help2man
+    haskellPackages.pandoc
+  ];
+  preConfigure = "autoreconf -fi";
+
+  meta = with stdenv.lib; {
+    description = "HyperDex is a scalable, searchable key-value store";
+    homepage = http://hyperdex.org;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/hyperleveldb.nix
+++ b/pkgs/servers/nosql/hyperdex/hyperleveldb.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, unzip, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  name = "hyperleveldb-${version}";
+  version = "1.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/HyperLevelDB/archive/releases/${version}.zip";
+    sha256 = "0xrzhwkrm7f2wz3jn4iqn1dim2pmgjhmpb1fy23fwa06v0q18hw8";
+  };
+  buildInputs = [ unzip autoconf automake libtool ];
+  preConfigure = "autoreconf -i";
+
+  meta = with stdenv.lib; {
+    description = ''A fork of LevelDB intended to meet the needs of
+        HyperDex while remaining compatible with LevelDB.'';
+    homepage = https://github.com/rescrv/HyperLevelDB;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/libe.nix
+++ b/pkgs/servers/nosql/hyperdex/libe.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, unzip, autoconf, automake, libtool, libpo6, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libe-${version}";
+  version = "0.8.1";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/e/archive/releases/0.8.1.zip";
+    sha256 = "1l13axsi52j2qaxbdnszdvfxksi7rwm2j1rrf0nlh990m6a3yg3s";
+  };
+  buildInputs = [ unzip autoconf automake libtool libpo6 pkgconfig ];
+  preConfigure = "autoreconf -i";
+
+  meta = with stdenv.lib; {
+    description = "Library containing high-performance datastructures and utilities for C++";
+    homepage = https://github.com/rescrv/e;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/libmacaroons.nix
+++ b/pkgs/servers/nosql/hyperdex/libmacaroons.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, unzip, autoconf, automake, libtool, 
+  pkgconfig, sodium, python }:
+stdenv.mkDerivation rec {
+  name = "libmacaroons-${version}";
+  version = "HEAD";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/libmacaroons/archive/6febf3ce6c4c77a46d24b40ed29b03ffbfb175a7.zip";
+    sha256 = "0b4qgim87398chvc3qhxfqv2l1cyl65rhyknln8lk0gq9y00p1ik";
+  };
+  buildInputs = [ unzip autoconf automake libtool python sodium pkgconfig ];
+  preConfigure = "autoreconf -i";
+  
+  meta = with stdenv.lib; {
+    description = ''Macaroons are flexible authorization credentials that
+        support decentralized delegation, attenuation, and verification.'';
+    homepage = https://github.com/rescrv/libmacaroons;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/libpo6.nix
+++ b/pkgs/servers/nosql/hyperdex/libpo6.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, unzip, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  name = "libpo6-${version}";
+  version = "0.5.2";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/po6/archive/releases/${version}.zip";
+    sha256 = "14g3ichshnc4wd0iq3q3ymgaq84gjsbqcyn6lri7c7djgkhqijjx";
+  };
+  buildInputs = [ unzip autoconf automake libtool ];
+  preConfigure = "autoreconf -i";
+
+  meta = with stdenv.lib; {
+    description = "POSIX wrappers for C++";
+    homepage = https://github.com/rescrv/po6;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/servers/nosql/hyperdex/replicant.nix
+++ b/pkgs/servers/nosql/hyperdex/replicant.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, unzip, autoconf, automake, libtool, glog,
+  hyperleveldb, libe, pkgconfig, popt, libpo6, busybee }:
+
+stdenv.mkDerivation rec {
+  name = "replicant-${version}";
+  version = "0.5.2";
+
+  src = fetchurl {
+    url = "https://github.com/rescrv/Replicant/archive/releases/0.6.3.zip";
+    sha256 = "1fbagz0nbvinkqr5iw5y187dm4klkswrxnl5ysq8waglg2nj8zzi";
+  };
+  buildInputs = [
+    autoconf
+    automake
+    busybee
+    glog
+    hyperleveldb
+    libe
+    libpo6
+    libtool
+    pkgconfig
+    popt
+    unzip
+  ];
+  preConfigure = "autoreconf -i";
+  
+  meta = with stdenv.lib; {
+    description = "A system for maintaining replicated state machines.";
+    homepage = https://github.com/rescrv/Replicant;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4315,6 +4315,8 @@ let
 
   autoconf = callPackage ../development/tools/misc/autoconf { };
 
+  autoconf-archive = callPackage ../development/tools/misc/autoconf-archive { };
+
   autoconf213 = callPackage ../development/tools/misc/autoconf/2.13.nix { };
 
   autocutsel = callPackage ../tools/X11/autocutsel{ };
@@ -7725,6 +7727,8 @@ let
 
   influxdb = callPackage ../servers/nosql/influxdb { };
 
+  hyperdex = callPackage ../servers/nosql/hyperdex { };
+  
   mysql51 = import ../servers/sql/mysql/5.1.x.nix {
     inherit fetchurl ncurses zlib perl openssl stdenv;
     ps = procps; /* !!! Linux only */


### PR DESCRIPTION
It might make sense to pull out replicant into its own top-level package because it can be used as a stand-alone server but then I have to move libe, ibpo6, etc., too and it's not clear how useful those are in isolation. 
