### PR TITLE
gitlab: fix i686-linux build and module

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -193,6 +193,7 @@ in {
         gitAndTools.git
         ruby
         openssh
+        nodejs
       ];
       serviceConfig = {
         Type = "simple";
@@ -227,6 +228,7 @@ in {
         gitAndTools.git
         ruby
         openssh
+        nodejs
       ];
       preStart = ''
         # TODO: use env vars

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -14,6 +14,7 @@ import ./make-test.nix {
   testScript = ''
     $gitlab->start();
     $gitlab->waitForUnit("gitlab.service");
-    $gitlab->waitUntilSucceeds("curl http://localhost:8080");
+    $gitlab->waitForUnit("gitlab-sidekiq.service");
+    $gitlab->waitUntilSucceeds("curl http://localhost:8080/users/sign_in");
   '';
 }

--- a/pkgs/applications/version-management/gitlab/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/Gemfile.lock
@@ -281,7 +281,6 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.1.2)
       launchy (~> 2.2)
-    libv8 (3.16.14.3)
     listen (2.3.1)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -421,7 +420,6 @@ GEM
       redis-store (~> 1.1.0)
     redis-store (1.1.4)
       redis (>= 2.2)
-    ref (1.0.5)
     request_store (1.0.5)
     require_all (1.3.2)
     rest-client (1.6.7)
@@ -520,9 +518,6 @@ GEM
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     test_after_commit (0.2.2)
-    therubyracer (0.12.0)
-      libv8 (~> 3.16.14.0)
-      ref
     thin (1.6.1)
       daemons (>= 1.0.9)
       eventmachine (>= 1.0.0)
@@ -696,7 +691,6 @@ DEPENDENCIES
   stamp
   state_machine
   test_after_commit
-  therubyracer
   thin
   tinder (~> 1.9.2)
   turbolinks

--- a/pkgs/applications/version-management/gitlab/Gemfile.nix
+++ b/pkgs/applications/version-management/gitlab/Gemfile.nix
@@ -702,12 +702,6 @@ url = "http://rubygems.org/downloads/letter_opener-1.1.2.gem";
 version = "1.1.2";
 }
 {
-name = "libv8";
-hash = "64490f61e9aa928e2905e90fafde5403496925d7a9539026628b01854fd69862";
-url = "http://rubygems.org/downloads/libv8-3.16.14.3-x86_64-linux.gem";
-version = "3.16.14.3";
-}
-{
 name = "listen";
 hash = "5549b607337a95bb3248a97660ccaa0c3eeec70e01e61b8a08d4a6c36dd93720";
 url = "http://rubygems.org/downloads/listen-2.3.1.gem";
@@ -1086,12 +1080,6 @@ url = "http://rubygems.org/downloads/redis-store-1.1.4.gem";
 version = "1.1.4";
 }
 {
-name = "ref";
-hash = "8a8ec8f40f1e622c4324055d85300e03d9a78a9faf476ea0d382f1af9dbe0fa7";
-url = "http://rubygems.org/downloads/ref-1.0.5.gem";
-version = "1.0.5";
-}
-{
 name = "request_store";
 hash = "70adb9485eb22113bd165e259b929a449dfe2d2410a880566f06df6a164fc1cf";
 url = "http://rubygems.org/downloads/request_store-1.0.5.gem";
@@ -1372,12 +1360,6 @@ name = "test_after_commit";
 hash = "8be009b5b7dd8f6e712ea92a079625b9a84f9a010ef2d5d5e44bcd45c353fa8f";
 url = "http://rubygems.org/downloads/test_after_commit-0.2.2.gem";
 version = "0.2.2";
-}
-{
-name = "therubyracer";
-hash = "06a711c23c6fcabc60a38413d6e08023b4717b725c0f19b3fd3d6161f714b3a0";
-url = "http://rubygems.org/downloads/therubyracer-0.12.0.gem";
-version = "0.12.0";
 }
 {
 name = "thin";

--- a/pkgs/applications/version-management/gitlab/bootstrap.nix
+++ b/pkgs/applications/version-management/gitlab/bootstrap.nix
@@ -30,6 +30,8 @@ in stdenv.mkDerivation rec {
       adapter: postgresql
     EOF
 
+    substituteInPlace Gemfile --replace 'gem "therubyracer"' ""
+
     bundle config --local build.nokogiri --use-system-libraries \
       --with-iconv-dir=${libiconv} \
       --with-xslt-dir=${libxslt} \

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ruby, rubyLibs, libiconv, libxslt, libxml2, pkgconfig, libffi, postgresql, libyaml, ncurses, curl, openssh, redis, zlib, icu, checkinstall, logrotate, docutils, cmake, git, gdbm, readline, unzip, gnumake, which, tzdata }:
+{ stdenv, fetchurl, ruby, rubyLibs, libiconv, libxslt, libxml2, pkgconfig, libffi, postgresql, libyaml, ncurses, curl, openssh, redis, zlib, icu, checkinstall, logrotate, docutils, cmake, git, gdbm, readline, unzip, gnumake, which, tzdata, nodejs }:
 
 let
   gemspec = map (gem: fetchurl { url=gem.url; sha256=gem.hash; }) (import ./Gemfile.nix);
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     ruby rubyLibs.bundler libyaml gdbm readline ncurses curl openssh redis zlib
-    postgresql libxslt libxml2 pkgconfig libffi icu checkinstall logrotate docutils
+    postgresql libxslt libxml2 pkgconfig libffi icu checkinstall logrotate docutils nodejs
     git unzip gnumake which cmake
   ];
 
@@ -50,6 +50,9 @@ in stdenv.mkDerivation rec {
 
     mkdir -p vendor/cache
     ${stdenv.lib.concatStrings (map (gem: "ln -s ${gem} vendor/cache/${gem.name};") gemspec)}
+
+    cp ${./Gemfile.lock} Gemfile.lock
+    substituteInPlace Gemfile --replace 'gem "therubyracer"' ""
 
     bundle config build.nokogiri \
       --use-system-libraries \


### PR DESCRIPTION
It turns out that installing therubytracer, with dependency on old v8, even
when using source libv8 version is problematic.
(see
http://stackoverflow.com/questions/21666379/problems-installing-gitlab-on-odroid-v8-lib-not-available).

But wait, rails does not even need therubytracer, just any kind of javascript
server side execution framework like nodejs. Well just use that, as also
suggested from different internet sources (look link above), it works just
fine.

Also test improvements.
