### PR TITLE
Fix networkmanager resumeCommands

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -194,7 +194,7 @@ in {
     };
 
     powerManagement.resumeCommands = ''
-      Systemctl restart network-manager
+      systemctl restart network-manager
     '';
 
     security.polkit.extraConfig = polkitConf;


### PR DESCRIPTION
Small typo prevented the post resume script to restart network manager
