### PR TITLE
if users.mutableUsers is false, require root password to be set

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -504,6 +504,12 @@ in {
       { assertion = !cfg.enforceIdUniqueness || (uidsAreUnique && gidsAreUnique);
         message = "UIDs and GIDs must be unique!";
       }
+      { assertion = cfg.mutableUsers ||
+                   (cfg.extraUsers.root.hashedPassword != "!") ||
+                   (cfg.extraUsers.root.password != null) ||
+                   (cfg.extraUsers.root.passwordFile != null);
+        message = "if users.mutableUsers is false, users.extraUsers.root requires hashedPassword/password/passwordFile to be set";
+      }
     ];
 
   };

--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -249,8 +249,8 @@ NIXOS_INSTALL_GRUB=1 chroot $mountPoint \
 chroot $mountPoint /nix/var/nix/profiles/system/activate
 
 
-# Ask the user to set a root password.
-if [ -t 0 ] ; then
+# Ask the user to set a root password if it's not set already
+if grep -q '^root:!' $mountPoint/etc/shadow && [ -t 0 ] ; then
     echo "setting root password..."
     chroot $mountPoint /var/setuid-wrappers/passwd
 fi


### PR DESCRIPTION
Running `nixos-install` with `users.mutableUsers = false;` currently doesn't work. Following PR requires root password to be set once immutable users are used.

Also fixes #3788
