### PR TITLE
Change default timezone to UTC.

### DIFF
--- a/nixos/modules/config/timezone.nix
+++ b/nixos/modules/config/timezone.nix
@@ -14,7 +14,7 @@ in
     time = {
 
       timeZone = mkOption {
-        default = "CET";
+        default = "UTC";
         type = types.str;
         example = "America/New_York";
         description = "The time zone used when displaying times and dates.";


### PR DESCRIPTION
Change default timezone to Coordinated Universal Time UTC [0] to reflect latest time standard [1] [2]. 
Not to confuse with its predecessor GMT [3].

Let the user define the timezone, and not default to a timezone limited to parts of Europe (CET) [4].

The timezone can also be specified per user rule:
export TZ="/usr/share/zoneinfo/Europe/Amsterdam"

Best Regards,
Hakisho Nukama

[0] https://en.wikipedia.org/wiki/Universal_Time
[1] https://en.wikipedia.org/wiki/Time_standard
[2] https://en.wikipedia.org/wiki/ISO_8601
[3] https://en.wikipedia.org/wiki/Greenwich_Mean_Time
[4] https://en.wikipedia.org/wiki/Central_European_Time
