### PR TITLE
disable verbose logging for XServer, fixes #4333

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -483,8 +483,6 @@ in
 
     services.xserver.displayManager.xserverArgs =
       [ "-ac"
-        "-logverbose"
-        "-verbose"
         "-terminate"
         "-logfile" "/var/log/X.${toString cfg.display}.log"
         "-config ${configFile}"


### PR DESCRIPTION
The current options for the XServer produce a huge amount of log messages. The server produces around 70-80 messages per minute. The most messages look like this:

```
display-manager-start[1846]: GetModeLine - scrn: 0 clock: 75200
display-manager-start[1846]: GetModeLine - hdsp: 1366 hbeg: 1414 hend: 1478 httl: 1582
display-manager-start[1846]: vdsp: 768 vbeg: 772 vend: 779 vttl: 792 flags: 9
```

Since theses messages aren't very useful, I propose to remove the
`-logverbose` and `-verbose` options from the XServer arguments.
