### PR TITLE
nixos: allow adding extra modules through environment

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -11,15 +11,16 @@
 , prefix ? []
 }:
 
-let extraArgs_ = extraArgs; pkgs_ = pkgs; system_ = system; in
-
-rec {
+let extraArgs_ = extraArgs; pkgs_ = pkgs; system_ = system;
+    extraModules = let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
+                   in if e == "" then [] else [(import (builtins.toPath e))];
+in rec {
 
   # Merge the option definitions in all modules, forming the full
   # system configuration.
   inherit (pkgs.lib.evalModules {
     inherit prefix;
-    modules = modules ++ baseModules;
+    modules = modules ++ extraModules ++ baseModules;
     args = extraArgs;
     check = check && options.environment.checkConfigurationOptions.value;
   }) config options;


### PR DESCRIPTION
This is useful for adding extra functionality or defaults to _every_
nixos evaluation.

My use case is overriding behaviour for all nixos tests, for example
setting packageOverrides to newer versions and changing some default
dependencies/settings.

By making this accessible through an environment variable, this can now
be fully accomplished externally. No more need to fork
nixos/nixpkgs (which becomes a maintenance burden), just use the channel
instead and plug in via this envvar.
