### PR TITLE
mediainfo(-gui): Add packages and dependencies

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -50,6 +50,7 @@
   davidrusu = "David Rusu <davidrusu.me@gmail.com>";
   dbohdan = "Danyil Bohdan <danyil.bohdan@gmail.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";
+  devhell = "devhell <\"^\"@regexmail.net>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";

--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
+
+let version = "0.7.71"; in
+
+stdenv.mkDerivation {
+  name = "mediainfo-gui-${version}";
+  src = fetchurl {
+    url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
+    sha256 = "0sf0ym0v5ds5w4bxk66712adybr1prxxqwvrf9clm57ibs602jfq";
+  };
+
+  buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];
+
+  sourceRoot = "./MediaInfo/Project/GNU/GUI/";
+
+  preConfigure = "sh autogen";
+
+  meta = {
+    description = "Supplies technical and tag information about a video or audio file (GUI version)";
+    longDescription = ''
+      MediaInfo is a convenient unified display of the most relevant technical
+      and tag data for video and audio files.
+    '';
+    homepage = http://mediaarea.net/;
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation {
     homepage = http://mediaarena.net/;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
+
+let version = "0.7.71"; in
+
+stdenv.mkDerivation {
+  name = "mediainfo-${version}";
+  src = fetchurl {
+    url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
+    sha256 = "0sf0ym0v5ds5w4bxk66712adybr1prxxqwvrf9clm57ibs602jfq";
+  };
+
+  buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];
+
+  sourceRoot = "./MediaInfo/Project/GNU/CLI/";
+
+  configureFlags = [ "--with-libmediainfo=${libmediainfo}" ];
+  preConfigure = "sh autogen";
+
+  meta = {
+    description = "Supplies technical and tag information about a video or audio file";
+    longDescription = ''
+      MediaInfo is a convenient unified display of the most relevant technical
+      and tag data for video and audio files.
+    '';
+    homepage = http://mediaarena.net/;
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
+
+let version = "0.7.71"; in
+
+stdenv.mkDerivation {
+  name = "libmediainfo-${version}";
+  src = fetchurl {
+    url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.bz2";
+    sha256 = "088v7qsn7d5pijr88fx4azwb31g6d7bp5ykrzgwhskmj80y3rlp2";
+  };
+
+  buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];
+
+  sourceRoot = "./MediaInfoLib/Project/GNU/Library/";
+
+  configureFlags = [ "--enable-shared" ];
+  preConfigure = "sh autogen";
+
+  postInstall = ''
+    install -vD -m 644 libmediainfo.pc "$out/lib/pkgconfig/libmediainfo.pc"
+  '';
+
+  meta = {
+    description = "Shared library for mediainfo";
+    homepage = http://mediaarena.net/;
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation {
     homepage = http://mediaarena.net/;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
     homepage = http://mediaarena.net/;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig }:
+
+let version = "0.4.30"; in
+
+stdenv.mkDerivation {
+  name = "libzen-${version}";
+  src = fetchurl {
+    url = "http://mediaarea.net/download/source/libzen/${version}/libzen_${version}.tar.bz2";
+    sha256 = "1ripvyzz2lw9nx2j8mkjgjfpabrz6knwxri52asqf1abnszbry64";
+  };
+
+  buildInputs = [ automake autoconf libtool pkgconfig ];
+
+  sourceRoot = "./ZenLib/Project/GNU/Library/";
+
+  preConfigure = "sh autogen";
+
+  meta = {
+    description = "Shared library for libmediainfo and mediainfo";
+    homepage = http://mediaarena.net/;
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5911,6 +5911,8 @@ let
 
   libmcrypt = callPackage ../development/libraries/libmcrypt {};
 
+  libmediainfo = callPackage ../development/libraries/libmediainfo { };
+
   libmhash = callPackage ../development/libraries/libmhash {};
 
   libmodbus = callPackage ../development/libraries/libmodbus {};
@@ -6318,6 +6320,8 @@ let
   libykneomgr = callPackage ../development/libraries/libykneomgr { };
 
   libyubikey = callPackage ../development/libraries/libyubikey { };
+
+  libzen = callPackage ../development/libraries/libzen { };
 
   libzip = callPackage ../development/libraries/libzip { };
 
@@ -10178,6 +10182,8 @@ let
   mcpp = callPackage ../development/compilers/mcpp { };
 
   mda_lv2 = callPackage ../applications/audio/mda-lv2 { };
+
+  mediainfo = callPackage ../applications/misc/mediainfo { };
 
   meld = callPackage ../applications/version-management/meld {
     inherit (gnome) scrollkeeper;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10185,6 +10185,8 @@ let
 
   mediainfo = callPackage ../applications/misc/mediainfo { };
 
+  mediainfo-gui = callPackage ../applications/misc/mediainfo-gui { };
+
   meld = callPackage ../applications/version-management/meld {
     inherit (gnome) scrollkeeper;
     pygtk = pyGtkGlade;


### PR DESCRIPTION
Includes the CLI and GUI version, as well as the following dependencies:
- libzen
- libmediainfo
