### PR TITLE
Added package 'fatsort'.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -90,6 +90,7 @@
   jzellner = "Jeff Zellner <jeffz@eml.cc>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   koral = "Koral <koral@mailoo.org>";
+  kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
   kragniz = "Louis Taylor <kragniz@gmail.com>";
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";
   lethalman = "Luca Bruno <lucabru@src.gnome.org>";

--- a/pkgs/tools/filesystems/fatsort/default.nix
+++ b/pkgs/tools/filesystems/fatsort/default.nix
@@ -1,0 +1,20 @@
+{stdenv, fetchurl, help2man}:
+
+stdenv.mkDerivation {
+  name = "fatsort";
+  src = fetchurl {
+    url = mirror://sourceforge/fatsort/fatsort-1.3.365.tar.gz;
+    sha256 = "0g9zn2ns86g7zmy0y8hw1w1zhnd51hy8yl6kflyhxs49n5sc7b3p";
+  };
+
+  patches = [ ./fatsort-Makefiles.patch ];
+
+  buildInputs = [ help2man ];
+
+  meta = {
+    homepage = http://fatsort.sourceforge.net/;
+    description = "Sorts FAT partition table, for devices that don't do sorting of files.";
+    maintainers = [ stdenv.lib.maintainers.kovirobi ];
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/tools/filesystems/fatsort/fatsort-Makefiles.patch
+++ b/pkgs/tools/filesystems/fatsort/fatsort-Makefiles.patch
@@ -1,0 +1,31 @@
+diff -uNr fatsort-1.3.365-a/Makefile fatsort-1.3.365-b/Makefile
+--- fatsort-1.3.365-a/Makefile	2014-04-08 19:19:36.000000000 +0100
++++ fatsort-1.3.365-b/Makefile	2014-12-14 18:31:55.982857720 +0000
+@@ -1,4 +1,5 @@
+-MANDIR=/usr/local/share/man/man1
++PREFIX=$(out)
++MANDIR=$(PREFIX)/share/man/man1
+ 
+ INSTALL_FLAGS=-m 0755 -p -D
+ 
+diff -uNr fatsort-1.3.365-a/src/Makefile fatsort-1.3.365-b/src/Makefile
+--- fatsort-1.3.365-a/src/Makefile	2014-04-08 19:19:36.000000000 +0100
++++ fatsort-1.3.365-b/src/Makefile	2014-12-14 18:32:08.282870461 +0000
+@@ -1,3 +1,5 @@
++PREFIX=$(out)
++
+ CC=gcc
+ LD=gcc
+ 
+@@ -33,9 +35,9 @@
+ 
+ # Mac OS X does not have a "/usr/local/sbin"
+ ifeq ($(UNAME),Darwin)
+-SBINDIR=/usr/local/bin
++SBINDIR=$(PREFIX)/bin
+ else
+-SBINDIR=/usr/local/sbin
++SBINDIR=$(PREFIX)/sbin
+ endif
+ 
+ OBJ=fatsort.o FAT_fs.o fileio.o endianness.o signal.o entrylist.o errors.o options.o clusterchain.o sort.o misc.o natstrcmp.o stringlist.o

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1145,6 +1145,8 @@ let
 
   fakechroot = callPackage ../tools/system/fakechroot { };
 
+  fatsort = callPackage ../tools/filesystems/fatsort { };
+
   fatrace = callPackage ../os-specific/linux/fatrace { };
 
   fcitx = callPackage ../tools/inputmethods/fcitx { };


### PR DESCRIPTION
Fatsort sorts partition table on FAT12/16/32 partitions for devices that
don't sort the files for themselves (e.g. some media players).
