### PR TITLE
attic: fix path to OPENSSL headers.

### DIFF
--- a/pkgs/tools/backup/attic/default.nix
+++ b/pkgs/tools/backup/attic/default.nix
@@ -11,6 +11,10 @@ python3Packages.buildPythonPackage rec {
   buildInputs = with python3Packages;
     [ cython msgpack openssl acl ];
 
+  preConfigure = ''
+    export ATTIC_OPENSSL_PREFIX="${openssl}"
+  '';
+
   meta = with stdenv.lib; {
     description = "A deduplication backup program";
     homepage = "https://attic-backup.org";

--- a/pkgs/tools/backup/attic/default.nix
+++ b/pkgs/tools/backup/attic/default.nix
@@ -4,8 +4,8 @@ python3Packages.buildPythonPackage rec {
   name = "attic-0.13";
 
   src = fetchurl {
-      url = "https://github.com/jborg/attic/archive/0.13.tar.gz";
-      sha256 = "da1c4c0759b541e72f6928341c863b406448351769113165d86d8393a5db98a3";
+      url = "https://github.com/jborg/attic/archive/0.14.tar.gz";
+      sha256 = "929da4b2e900770cd31558e87074ade347b44937c944218549259ea64646f203";
       };
 
   buildInputs = with python3Packages;


### PR DESCRIPTION
Should correct this failure: http://hydra.nixos.org/build/17938626/nixlog/1/tail-reload

I should create a nixos VM so I can do a chroot build....
