### PR TITLE
opensmtpd: fix homepage URL

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];  
 
   meta = {
-    homepage = http://www.postfix.org/;
+    homepage = https://www.opensmtpd.org/;
     description = ''
       A free implementation of the server-side SMTP protocol as defined by
       RFC 5321, with some additional standard extensions


### PR DESCRIPTION
Hey,

Looks like the OpenSMTPD homepage metadata is pointing to the Postfix website. This PR sets it to the actual OpenSMTPD homepage.
