### PR TITLE
nixos-install: fix -I flag

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -30,8 +30,7 @@ while [ "$#" -gt 0 ]; do
     case "$i" in
         -I)
             given_path="$1"; shift 1
-            absolute_path=$(readlink -m $given_path)
-            extraBuildFlags+=("$i" "/mnt$absolute_path")
+            extraBuildFlags+=("$i" "$given_path")
             ;;
         --root)
             mountPoint="$1"; shift 1


### PR DESCRIPTION
Current processing of -I flag in `nixos-install` breaks `name=value`-style parameters -- from reading the code, it's actually completely broken (as it appends /mnt for path that would be already used in chroot). This removes that additional processing, though if someone uses relative paths, I can try to improve this further.
