### PR TITLE
Change occurrences of gcc to the more general cc

### DIFF
--- a/doc/old/cross.txt
+++ b/doc/old/cross.txt
@@ -184,10 +184,10 @@ if test "$noSysDirs" = "1"; then
     if test "$noSysDirs" = "1"; then
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        if test -e $NIX_GCC/nix-support/orig-glibc; then
-            glibc=$(cat $NIX_GCC/nix-support/orig-glibc)
+        if test -e $NIX_CC/nix-support/orig-glibc; then
+            glibc=$(cat $NIX_CC/nix-support/orig-glibc)
             # Ugh.  Copied from gcc-wrapper/builder.sh.  We can't just
-            # source in $NIX_GCC/nix-support/add-flags, since that
+            # source in $NIX_CC/nix-support/add-flags, since that
             # would cause *this* GCC to be linked against the
             # *previous* GCC.  Need some more modularity there.
             extraCFlags="-B$glibc/lib -isystem $glibc/include"

--- a/maintainers/scripts/patchelf-hints.sh
+++ b/maintainers/scripts/patchelf-hints.sh
@@ -62,7 +62,7 @@ for bin in $(find $binaryDist -executable -type f) :; do
         )
 
         if test "$names" = "glibc"; then names="stdenv.glibc"; fi
-        if echo $names | grep -c "gcc" &> /dev/null; then names="stdenv.gcc.gcc"; fi
+        if echo $names | grep -c "gcc" &> /dev/null; then names="stdenv.cc.gcc"; fi
 
         if test $lib != $libPath; then
             interpreter="--interpreter \${$names}/lib/$lib"

--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   QT_PLUGIN_PATH="${qtscriptgenerator}/lib/qt4/plugins";
 
-  buildInputs = [ qtscriptgenerator stdenv.gcc.libc gettext curl
+  buildInputs = [ qtscriptgenerator stdenv.cc.libc gettext curl
     libxml2 mysql taglib taglib_extras loudmouth kdelibs automoc4 phonon strigi
     soprano qca2 libmtp liblastfm libgpod pkgconfig qjson ffmpeg libofa nepomuk_core ];
 

--- a/pkgs/applications/audio/cdparanoia/default.nix
+++ b/pkgs/applications/audio/cdparanoia/default.nix
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
     url = "http://downloads.xiph.org/releases/cdparanoia/${name}.src.tgz";
     sha256 = "1pv4zrajm46za0f6lv162iqffih57a8ly4pc69f7y0gfyigb8p80";
   };
+
+  preConfigure = "unset CC";
   
   meta = {
     homepage = http://xiph.org/paranoia;

--- a/pkgs/applications/audio/google-musicmanager/default.nix
+++ b/pkgs/applications/audio/google-musicmanager/default.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/opt/google/musicmanager:${readline}/lib:${ncurses}/lib:${stdenv.gcc.libc}/lib:${qt48}/lib:${stdenv.gcc.gcc}/lib:${libidn}/lib:${expat}/lib:${flac}/lib:${libvorbis}/lib" opt/google/musicmanager/MusicManager
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "$out/opt/google/musicmanager:${readline}/lib:${ncurses}/lib:${stdenv.cc.libc}/lib:${qt48}/lib:${stdenv.cc.gcc}/lib:${libidn}/lib:${expat}/lib:${flac}/lib:${libvorbis}/lib" opt/google/musicmanager/MusicManager
   '';
 
   dontPatchELF = true;

--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -45,7 +45,7 @@ let
     pango
     qt4
     sqlite
-    stdenv.gcc.gcc
+    stdenv.cc.gcc
     xlibs.libX11
     xlibs.libXcomposite
     xlibs.libXdamage
@@ -113,16 +113,16 @@ stdenv.mkDerivation {
 
       mkdir -p $out/bin
 
-      rpath="$out/spotify-client/Data:$out/lib:$out/spotify-client:${stdenv.gcc.gcc}/lib64"
+      rpath="$out/spotify-client/Data:$out/lib:$out/spotify-client:${stdenv.cc.gcc}/lib64"
 
       ln -s $out/spotify-client/spotify $out/bin/spotify
 
       patchelf \
-        --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath $rpath $out/spotify-client/spotify
 
       patchelf \
-        --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath $rpath $out/spotify-client/Data/SpotifyHelper
 
       dpkg-deb -x ${qt4webkit} ./

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -7,7 +7,7 @@ let
   atomEnv = buildEnv {
     name = "env-atom";
     paths = [
-      stdenv.gcc.gcc zlib glib dbus gtk atk pango freetype libgnome_keyring3
+      stdenv.cc.gcc zlib glib dbus gtk atk pango freetype libgnome_keyring3
       fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
       xlibs.libXrender xlibs.libX11 xlibs.libXext xlibs.libXdamage xlibs.libXtst
       xlibs.libXcomposite xlibs.libXi xlibs.libXfixes xlibs.libXrandr
@@ -33,9 +33,9 @@ in stdenv.mkDerivation rec {
     ar p $src data.tar.gz | tar -C $out -xz ./usr
     mv $out/usr/* $out/
     rm -r $out/usr/
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       $out/share/atom/atom
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       $out/share/atom/resources/app/apm/node_modules/atom-package-manager/bin/node
     wrapProgram $out/bin/atom \
       --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64"

--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   patches = [ ./writable-projects.patch ];
   preConfigure = "substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file";
-  postConfigure = optionalString stdenv.isLinux "substituteInPlace libtool --replace ldconfig ${stdenv.gcc.libc}/sbin/ldconfig";
+  postConfigure = optionalString stdenv.isLinux "substituteInPlace libtool --replace ldconfig ${stdenv.cc.libc}/sbin/ldconfig";
   configureFlags = [ "--enable-pch=no" ]
     ++ optional contribPlugins "--with-contrib-plugins";
 

--- a/pkgs/applications/editors/emacs-24/builder.sh
+++ b/pkgs/applications/editors/emacs-24/builder.sh
@@ -11,7 +11,7 @@ preConfigure() {
         *)              return;
     esac
 
-    libc=$(cat ${NIX_GCC}/nix-support/orig-libc)
+    libc=$(cat ${NIX_CC}/nix-support/orig-libc)
     echo "libc: $libc"
 
     for i in src/s/*.h src/m/*.h; do

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -56,9 +56,9 @@ let
         snappyPath="lib/snappy-java-1.0.5"
         7z x -o"$snappyPath" "$snappyPath.jar"
         if [ "${stdenv.system}" == "x86_64-linux" ]; then
-          patchelf --set-rpath ${stdenv.gcc.gcc}/lib64 "$snappyPath/org/xerial/snappy/native/Linux/amd64/libsnappyjava.so"
+          patchelf --set-rpath ${stdenv.cc.gcc}/lib64 "$snappyPath/org/xerial/snappy/native/Linux/amd64/libsnappyjava.so"
         else
-          patchelf --set-rpath ${stdenv.gcc.gcc}/lib "$snappyPath/org/xerial/snappy/native/Linux/i386/libsnappyjava.so"
+          patchelf --set-rpath ${stdenv.cc.gcc}/lib "$snappyPath/org/xerial/snappy/native/Linux/i386/libsnappyjava.so"
         fi
         7z a -tzip "$snappyPath.jar" ./"$snappyPath"/*
         rm -vr "$snappyPath"
@@ -76,7 +76,7 @@ let
 
       makeWrapper "$out/$name/bin/${loName}.sh" "$out/bin/${loName}" \
         --prefix PATH : "${jdk}/bin:${coreutils}/bin:${gnugrep}/bin:${which}/bin:${git}/bin" \
-        --prefix LD_RUN_PATH : "${stdenv.gcc.gcc}/lib/" \
+        --prefix LD_RUN_PATH : "${stdenv.cc.gcc}/lib/" \
         --prefix JDK_HOME : "$jdk" \
         --prefix ${hiName}_JDK : "$jdk"
 

--- a/pkgs/applications/editors/lighttable/default.nix
+++ b/pkgs/applications/editors/lighttable/default.nix
@@ -5,7 +5,7 @@
 
 let
   libPath = stdenv.lib.makeLibraryPath [
-      stdenv.gcc.gcc zlib glib dbus gtk atk pango freetype libgnome_keyring3 nss
+      stdenv.cc.gcc zlib glib dbus gtk atk pango freetype libgnome_keyring3 nss
       fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gnome3.gconf
       xlibs.libXrender xlibs.libX11 xlibs.libXext xlibs.libXdamage xlibs.libXtst
       xlibs.libXcomposite xlibs.libXi xlibs.libXfixes
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     mv LightTable $out/
 
     patchelf \
-      --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath}:${stdenv.gcc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${libPath}:${stdenv.cc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
       $out/LightTable/ltbin
 
     ln -s ${udev}/lib/libudev.so.1 $out/LightTable/libudev.so.0

--- a/pkgs/applications/editors/sublime/default.nix
+++ b/pkgs/applications/editors/sublime/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
 
     echo ${libPath}
     patchelf \
-      --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath}:${stdenv.gcc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${libPath}:${stdenv.cc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
       $out/sublime/sublime_text
   '';
 

--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -31,8 +31,8 @@ in let
     buildPhase = ''
       for i in sublime_text plugin_host crash_reporter; do
         patchelf \
-          --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-          --set-rpath ${libPath}:${stdenv.gcc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath ${libPath}:${stdenv.cc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
           $i
       done
     '';
@@ -41,7 +41,7 @@ in let
       mkdir -p $out
       cp -prvd * $out/
       # Without this, plugin_host crashes, even though it has the rpath
-      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.gcc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${openssl}/lib/libssl.so:${bzip2}/lib/libbz2.so
+      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${openssl}/lib/libssl.so:${bzip2}/lib/libbz2.so
     '';
   };
 in stdenv.mkDerivation {

--- a/pkgs/applications/misc/adobe-reader/builder.sh
+++ b/pkgs/applications/misc/adobe-reader/builder.sh
@@ -17,7 +17,7 @@ rm $p/Reader/intellinux/plug_ins/PPKLite.api
 # More pointless files.
 rm $p/bin/UNINSTALL
 
-patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
     --set-rpath $libPath \
     $p/Reader/intellinux/bin/acroread
 

--- a/pkgs/applications/misc/adobe-reader/default.nix
+++ b/pkgs/applications/misc/adobe-reader/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   # versions.
 
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.gcc.gcc libX11 zlib libxml2 cups pango atk gtk glib gdk_pixbuf ];
+    [ stdenv.cc.gcc libX11 zlib libxml2 cups pango atk gtk glib gdk_pixbuf ];
 
   meta = {
     description = "Adobe Reader, a viewer for PDF documents";

--- a/pkgs/applications/misc/googleearth/default.nix
+++ b/pkgs/applications/misc/googleearth/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     glibc
     glib
-    stdenv.gcc.gcc
+    stdenv.cc.gcc
     libSM 
     libICE 
     libXi 
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
       fullPath=$fullPath:$i/lib
     done
           
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath $fullPath \
       $out/opt/googleearth/googleearth-bin
 

--- a/pkgs/applications/misc/ikiwiki/default.nix
+++ b/pkgs/applications/misc/ikiwiki/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     sed -i /ENV{PATH}/d ikiwiki.in
     # State the gcc dependency, and make the cgi use our wrapper
     sed -i -e 's@$0@"'$out/bin/ikiwiki'"@' \
-        -e "s@'cc'@'${stdenv.gcc}/bin/gcc'@" IkiWiki/Wrapper.pm
+        -e "s@'cc'@'${stdenv.cc}/bin/gcc'@" IkiWiki/Wrapper.pm
   '';
 
   configurePhase = "perl Makefile.PL PREFIX=$out";

--- a/pkgs/applications/misc/k3b/default.nix
+++ b/pkgs/applications/misc/k3b/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ cmake qt4 perl shared_mime_info libvorbis taglib
       flac libsamplerate libdvdread lame libsndfile
-      libmad gettext stdenv.gcc.libc
+      libmad gettext stdenv.cc.libc
       kdelibs kdemultimedia automoc4 phonon
       libkcddb makeWrapper cdparanoia
     ];

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram "$out/bin/mysql-workbench" \
       --prefix LD_LIBRARY_PATH : "${python}/lib" \
-      --prefix LD_LIBRARY_PATH : "$(cat ${stdenv.gcc}/nix-support/orig-gcc)/lib64" \
+      --prefix LD_LIBRARY_PATH : "$(cat ${stdenv.cc}/nix-support/orig-gcc)/lib64" \
       --prefix PATH : "${gnome_keyring}/bin" \
       --prefix PATH : "${python}/bin" \
       --set PYTHONPATH $PYTHONPATH \

--- a/pkgs/applications/misc/procmail/default.nix
+++ b/pkgs/applications/misc/procmail/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "procmail-3.22";
 
-  buildInputs = [ stdenv.gcc.libc ];
+  buildInputs = [ stdenv.cc.libc ];
 
   # getline is defined differently in glibc now. So rename it.
   installPhase = "

--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     cp usr/bin/rescuetime $out/bin
 
     ${patchelf}/bin/patchelf \
-      --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       $out/bin/rescuetime
 
     wrapProgram $out/bin/rescuetime \

--- a/pkgs/applications/networking/bittorrentsync/default.nix
+++ b/pkgs/applications/networking/bittorrentsync/default.nix
@@ -9,7 +9,7 @@ let
     else if stdenv.system == "i686-linux" then "0jv3zg0jhdzsc56kkpylwihvhsz73gsl2i2pjmqk3r3x4gwjk8xx"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
 
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.libc ];
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.libc ];
 in
 stdenv.mkDerivation rec {
   name = "btsync-${version}";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin/"
     cp -r "btsync" "$out/bin/"
 
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath ${libPath} "$out/bin/btsync"
   '';
 

--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -35,7 +35,7 @@ let
     '';
 
     patchPhase = let
-      rpaths = [ stdenv.gcc.gcc ];
+      rpaths = [ stdenv.cc.gcc ];
       mkrpath = p: "${makeSearchPath "lib64" p}:${makeSearchPath "lib" p}";
     in ''
       for sofile in PepperFlash/libpepflashplayer.so \

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
   phases = "unpackPhase installPhase";
 
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.gcc.gcc
+    [ stdenv.cc.gcc
       alsaLib
       atk
       cairo
@@ -106,7 +106,7 @@ stdenv.mkDerivation {
       pulseaudio
       systemd
     ] + ":" + stdenv.lib.makeSearchPath "lib64" [
-      stdenv.gcc.gcc
+      stdenv.cc.gcc
     ];
 
   # "strip" after "patchelf" may break binaries.
@@ -125,7 +125,7 @@ stdenv.mkDerivation {
         firefox mozilla-xremote-client firefox-bin plugin-container \
         updater crashreporter webapprt-stub
       do
-        patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           "$out/usr/lib/firefox-bin-${version}/$executable"
       done
 

--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -13,7 +13,7 @@
   enableOfficialBranding ? false
 }:
 
-assert stdenv.gcc ? libc && stdenv.gcc.libc != null;
+assert stdenv.cc ? libc && stdenv.cc.libc != null;
 
 let version = "34.0.5"; in
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
@@ -32,7 +32,7 @@ let
       xorg.libXfixes
       xorg.libXrender
       xorg.libXrandr
-      stdenv.gcc.gcc
+      stdenv.cc.gcc
       alsaLib
       pulseaudio
       dbus_glib
@@ -76,19 +76,19 @@ stdenv.mkDerivation rec {
       cp opt/google/talkplugin/*.so $plugins
 
       for i in libnpgoogletalk.so libppgoogletalk.so libppo1d.so; do
-        patchelf --set-rpath "${makeLibraryPath [ stdenv.gcc.gcc xorg.libX11 ]}:${stdenv.gcc.gcc}/lib64" $plugins/$i
+        patchelf --set-rpath "${makeLibraryPath [ stdenv.cc.gcc xorg.libX11 ]}:${stdenv.cc.gcc}/lib64" $plugins/$i
       done
 
       for i in libgoogletalkremoting.so libnpo1d.so; do
-        patchelf --set-rpath "$out/libexec/google/talkplugin/lib:${rpathPlugin}:${stdenv.gcc.gcc}/lib64" $plugins/$i
+        patchelf --set-rpath "$out/libexec/google/talkplugin/lib:${rpathPlugin}:${stdenv.cc.gcc}/lib64" $plugins/$i
       done
 
       mkdir -p $out/libexec/google/talkplugin
       cp -prd opt/google/talkplugin/{data,GoogleTalkPlugin,locale,remoting24x24.png,windowpicker.glade} $out/libexec/google/talkplugin/
 
       patchelf \
-        --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-        --set-rpath "${rpathProgram}:${stdenv.gcc.gcc}/lib64" \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${rpathProgram}:${stdenv.cc.gcc}/lib64" \
         $out/libexec/google/talkplugin/GoogleTalkPlugin
 
       # Generate an LD_PRELOAD wrapper to redirect execvp() calls to

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -6,7 +6,7 @@
 , kdeSupport ? false, qt4, kdelibs
 }:
 
-assert stdenv.isLinux && stdenv.gcc.gcc != null && stdenv.gcc.libc != null;
+assert stdenv.isLinux && stdenv.cc.gcc != null && stdenv.cc.libc != null;
 
 let
   mirror = http://get.geo.opera.com/pub/opera;
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     '';
 
   buildInputs =
-    [ stdenv.gcc.gcc stdenv.gcc.libc zlib libX11 libXt libXext libSM libICE
+    [ stdenv.cc.gcc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE
       libXft freetype fontconfig libXrender libuuid expat
       gstreamer libxml2 gst_plugins_base
     ]
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       elif [ $type == "EXEC" ]; then
         echo "patching $f executable <<"
         patchelf \
-            --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
             --set-rpath "${libPath}" \
             "$f"
       elif [ $type == "DYN" ]; then

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     for n in "bin/"* "sbin/"*; do
       sed -i $n -e "s|#!/usr/bin/env bash|#! ${bash}/bin/bash|"
     done
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" bin/container-executor
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" bin/container-executor
   '';
 
   installPhase = ''

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
     "USE_BV32=" "USE_COREAUDIO=" "USE_G711=" "USE_G722=" "USE_G722_1=" 
     "USE_ILBC=" "USE_OPUS=" "USE_SILK=" 
   ]
-  ++ stdenv.lib.optional (stdenv.gcc.gcc != null) "SYSROOT_ALT=${stdenv.gcc.gcc}"
-  ++ stdenv.lib.optional (stdenv.gcc.libc != null) "SYSROOT=${stdenv.gcc.libc}"
+  ++ stdenv.lib.optional (stdenv.cc.gcc != null) "SYSROOT_ALT=${stdenv.cc.gcc}"
+  ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.cc.libc}"
   ;
   NIX_CFLAGS_COMPILE='' -I${librem}/include/rem -I${gsm}/include/gsm '';
   meta = {

--- a/pkgs/applications/networking/instant-messengers/fuze/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fuze/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   libPath =
     stdenv.lib.makeLibraryPath [
       openssl alsaLib libXext libXfixes libXrandr libjpeg curl_custom
-      libX11 libXmu libXv qt4 libXtst mesa stdenv.gcc.gcc zlib
+      libX11 libXmu libXv qt4 libXtst mesa stdenv.cc.gcc zlib
       gnome.GConf libidn rtmpdump c-ares openldap
     ];
   buildCommand = ''
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     cp -R usr/lib/fuzebox $out/lib
 
     patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath $out/lib/fuzebox:$libPath \
       $out/lib/fuzebox/FuzeLinuxApp
 

--- a/pkgs/applications/networking/instant-messengers/hipchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/hipchat/default.nix
@@ -41,7 +41,7 @@ let
     xz
     libcanberra
     xcbutilkeysyms
-  ] + ":${stdenv.gcc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}";
+  ] + ":${stdenv.cc.gcc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}";
 
   src =
     if stdenv.system == "x86_64-linux" then
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
     mv usr/share $out
 
     for file in $(find $d -type f); do
-        patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $file || true
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $file || true
         patchelf --set-rpath ${rpath}:\$ORIGIN $file || true
     done
 

--- a/pkgs/applications/networking/instant-messengers/skype/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skype/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     stdenv.glibc
-    stdenv.gcc.gcc
+    stdenv.cc.gcc
     libXv
     libXext
     libX11
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       fullPath=$fullPath''${fullPath:+:}$i/lib
     done
 
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "$fullPath" $out/libexec/skype/skype
 
     cat > $out/bin/skype << EOF

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation rec {
       mv ts3client_linux_${arch} ts3client
       echo "patching ts3client..."
       patchelf \
-        --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-        --set-rpath ${stdenv.lib.makeLibraryPath deps}:$(cat $NIX_GCC/nix-support/orig-gcc)/${libDir} \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath ${stdenv.lib.makeLibraryPath deps}:$(cat $NIX_CC/nix-support/orig-gcc)/${libDir} \
         --force-rpath \
         ts3client
     '';

--- a/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
       mv ts3server_linux_${arch} ts3server
       echo "patching ts3server"
       patchelf \
-        --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-        --set-rpath $(cat $NIX_GCC/nix-support/orig-gcc)/${libDir} \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath $(cat $NIX_CC/nix-support/orig-gcc)/${libDir} \
         --force-rpath \
         ts3server
     '';

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation {
         thunderbird mozilla-xremote-client thunderbird-bin plugin-container \
         updater
       do
-        patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           "$out/usr/lib/thunderbird-bin-${version}/$executable"
       done
 

--- a/pkgs/applications/networking/remote/teamviewer/8.nix
+++ b/pkgs/applications/networking/remote/teamviewer/8.nix
@@ -5,7 +5,7 @@ let
   topath = "${wineUnstable}/bin";
 
   toldpath = stdenv.lib.concatStringsSep ":" (map (x: "${x}/lib") 
-    [ stdenv.gcc.gcc libX11 libXtst libXext libXdamage libXfixes wineUnstable ]);
+    [ stdenv.cc.gcc libX11 libXtst libXext libXdamage libXfixes wineUnstable ]);
 in
 stdenv.mkDerivation {
   name = "teamviewer-8.0.17147";
@@ -34,8 +34,8 @@ stdenv.mkDerivation {
     EOF
     chmod +x $out/bin/teamviewer
 
-    patchelf --set-rpath "${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXau}/lib:${libXdamage}/lib:${libXfixes}/lib" $out/share/teamviewer8/tv_bin/teamviewerd
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/share/teamviewer8/tv_bin/teamviewerd
+    patchelf --set-rpath "${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXau}/lib:${libXdamage}/lib:${libXfixes}/lib" $out/share/teamviewer8/tv_bin/teamviewerd
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/teamviewer8/tv_bin/teamviewerd
     ln -s $out/share/teamviewer8/tv_bin/teamviewerd $out/bin/
   '';
 

--- a/pkgs/applications/networking/remote/teamviewer/9.nix
+++ b/pkgs/applications/networking/remote/teamviewer/9.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     chmod +x $out/bin/teamviewer
 
     patchelf --set-rpath "${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXau}/lib:${libXdamage}/lib:${libXfixes}/lib" $out/share/teamviewer9/tv_bin/teamviewerd
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/share/teamviewer9/tv_bin/teamviewerd
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/teamviewer9/tv_bin/teamviewerd
     ln -s $out/share/teamviewer9/tv_bin/teamviewerd $out/bin/
   '';
 

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -6,7 +6,7 @@ let
   topath = "${wine}/bin";
 
   toldpath = stdenv.lib.concatStringsSep ":" (map (x: "${x}/lib") 
-    [ stdenv.gcc.gcc libX11 libXtst libXext libXdamage libXfixes wine ]);
+    [ stdenv.cc.gcc libX11 libXtst libXext libXdamage libXfixes wine ]);
 in
 stdenv.mkDerivation {
   name = "teamviewer-7.0.9377";

--- a/pkgs/applications/office/zotero/firefox-bin/default.nix
+++ b/pkgs/applications/office/zotero/firefox-bin/default.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation {
         firefox mozilla-xremote-client firefox-bin plugin-container \
         updater crashreporter webapprt-stub
       do
-        patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           "$out/usr/lib/firefox-bin-${version}/$executable"
       done
 

--- a/pkgs/applications/science/electronics/eagle/default.nix
+++ b/pkgs/applications/science/electronics/eagle/default.nix
@@ -59,11 +59,11 @@ stdenv.mkDerivation rec {
     gcc -shared -fPIC -DEAGLE_PATH=\"$out/eagle-${version}\" ${./eagle_fixer.c} -o "$out"/lib/eagle_fixer.so -ldl
 
     # Make wrapper script
-    dynlinker="$(cat $NIX_GCC/nix-support/dynamic-linker)"
+    dynlinker="$(cat $NIX_CC/nix-support/dynamic-linker)"
     mkdir -p "$out"/bin
     cat > "$out"/bin/eagle << EOF
     #!${stdenv.shell}
-    export LD_LIBRARY_PATH="${stdenv.gcc.gcc}/lib:${libPath}"
+    export LD_LIBRARY_PATH="${stdenv.cc.gcc}/lib:${libPath}"
     export LD_PRELOAD="$out/lib/eagle_fixer.so"
     exec "$dynlinker" "$out/eagle-${version}/bin/eagle" "\$@"
     EOF

--- a/pkgs/applications/science/logic/verifast/default.nix
+++ b/pkgs/applications/science/logic/verifast/default.nix
@@ -5,12 +5,12 @@ assert stdenv.isLinux;
 
 let
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.gcc.libc stdenv.gcc.gcc gtk gdk_pixbuf atk pango glib cairo
+    [ stdenv.cc.libc stdenv.cc.gcc gtk gdk_pixbuf atk pango glib cairo
       freetype fontconfig libxml2 gnome2.gtksourceview
-    ] + ":${stdenv.gcc.gcc}/lib64";
+    ] + ":${stdenv.cc.gcc}/lib64";
 
   patchExe = x: ''
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath ${libPath} ${x}
   '';
 in

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -3,7 +3,7 @@
 assert stdenv.isLinux;
 
 let
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.libc ];
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.libc ];
 in
 stdenv.mkDerivation rec {
   name    = "yices-${version}";

--- a/pkgs/applications/science/math/mathematica/9.nix
+++ b/pkgs/applications/science/math/mathematica/9.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
       elif [ "$type" == "EXEC" ]; then
         echo "patching $f executable <<"
         patchelf \
-            --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
             --set-rpath "${ldpath}" \
             "$f"
         patchelf --shrink-rpath "$f"

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
         echo "patching $f executable <<"
         patchelf --shrink-rpath "$f"
         patchelf \
-	  --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+	  --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "$(patchelf --print-rpath "$f"):${ldpath}" \
           "$f" \
           && patchelf --shrink-rpath "$f" \

--- a/pkgs/applications/taxes/aangifte-2006/builder.sh
+++ b/pkgs/applications/taxes/aangifte-2006/builder.sh
@@ -3,7 +3,7 @@ source $stdenv/setup
 buildPhase() {
     for i in bin/*; do
         patchelf \
-            --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
             --set-rpath $libX11/lib:$libXext/lib \
             $i
     done

--- a/pkgs/applications/taxes/aangifte-2007/builder.sh
+++ b/pkgs/applications/taxes/aangifte-2007/builder.sh
@@ -1,12 +1,12 @@
 source $stdenv/setup
 
-echo $NIX_GCC
+echo $NIX_CC
 
 buildPhase() {
     for i in bin/*; do
         patchelf \
-            --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-            --set-rpath $libX11/lib:$libXext/lib:$libSM/lib:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+            --set-rpath $libX11/lib:$libXext/lib:$libSM/lib:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
             $i
     done
 }

--- a/pkgs/applications/taxes/aangifte-2008/builder.sh
+++ b/pkgs/applications/taxes/aangifte-2008/builder.sh
@@ -1,12 +1,12 @@
 source $stdenv/setup
 
-echo $NIX_GCC
+echo $NIX_CC
 
 buildPhase() {
     for i in bin/*; do
         patchelf \
-            --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-            --set-rpath $libX11/lib:$libXext/lib:$libSM/lib:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+            --set-rpath $libX11/lib:$libXext/lib:$libSM/lib:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
             $i
     done
 }

--- a/pkgs/applications/taxes/aangifte-2009/default.nix
+++ b/pkgs/applications/taxes/aangifte-2009/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
     ''
       for i in bin/*; do
           patchelf \
-              --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
               $i
       done
     '';

--- a/pkgs/applications/taxes/aangifte-2010/default.nix
+++ b/pkgs/applications/taxes/aangifte-2010/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
     ''
       for i in bin/*; do
           patchelf \
-              --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
               $i
       done
     '';

--- a/pkgs/applications/taxes/aangifte-2011/default.nix
+++ b/pkgs/applications/taxes/aangifte-2011/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
     ''
       for i in bin/*; do
           patchelf \
-              --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
               $i
       done
     '';

--- a/pkgs/applications/taxes/aangifte-2012/default.nix
+++ b/pkgs/applications/taxes/aangifte-2012/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
     ''
       for i in bin/*; do
           patchelf \
-              --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
               $i
       done
     '';
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
       mkdir -p $out
       cp -prvd * $out/
       wrapProgram $out/bin/ib2012ux --prefix PATH : ${xdg_utils}/bin \
-                                    --prefix LD_PRELOAD : $(cat $NIX_GCC/nix-support/orig-gcc)/lib/libgcc_s.so.1
+                                    --prefix LD_PRELOAD : $(cat $NIX_CC/nix-support/orig-gcc)/lib/libgcc_s.so.1
     '';
 
   meta = {

--- a/pkgs/applications/taxes/aangifte-2013/default.nix
+++ b/pkgs/applications/taxes/aangifte-2013/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
     ''
       for i in bin/*; do
           patchelf \
-              --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
               $i
       done
     '';
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
       mkdir -p $out
       cp -prvd * $out/
       wrapProgram $out/bin/ib2013ux --prefix PATH : ${xdg_utils}/bin \
-                                    --prefix LD_PRELOAD : $(cat $NIX_GCC/nix-support/orig-gcc)/lib/libgcc_s.so.1
+                                    --prefix LD_PRELOAD : $(cat $NIX_CC/nix-support/orig-gcc)/lib/libgcc_s.so.1
     '';
 
   meta = {

--- a/pkgs/applications/video/makemkv/builder.sh
+++ b/pkgs/applications/video/makemkv/builder.sh
@@ -27,7 +27,7 @@ libPath="${libPath}:${out}/lib" # XXX: der. This should be in the nix file?
 
 for i in ${bin} ; do
   patchelf \
-    --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
     --set-rpath $libPath \
     ${i}
 done 

--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [openssl qt4 mesa zlib pkgconfig libav];
 
-  libPath = stdenv.lib.makeLibraryPath [stdenv.gcc.gcc openssl mesa qt4 zlib ] 
-          + ":" + stdenv.gcc.gcc + "/lib64";
+  libPath = stdenv.lib.makeLibraryPath [stdenv.cc.gcc openssl mesa qt4 zlib ] 
+          + ":" + stdenv.cc.gcc + "/lib64";
 
   meta = with stdenv.lib; {
     description = "convert blu-ray and dvd to mkv";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
         ''
         else throw ("Architecture: "+stdenv.system+" not supported for VirtualBox guest additions")
         }
-        patchelf --set-rpath ${stdenv.gcc.gcc}/lib:${dbus}/lib:${libX11}/lib:${libXt}/lib:${libXext}/lib:${libXmu}/lib:${libXfixes}/lib:${libXrandr}/lib:${libXcursor}/lib $i
+        patchelf --set-rpath ${stdenv.cc.gcc}/lib:${dbus}/lib:${libX11}/lib:${libXt}/lib:${libXext}/lib:${libXmu}/lib:${libXfixes}/lib:${libXrandr}/lib:${libXcursor}/lib $i
     done
 
     for i in lib/VBoxOGL*.so

--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -100,13 +100,13 @@ let inherit (builtins) head tail trace; in
                 ${stdenv.preHook}
                 
                 set -e
-                NIX_GCC=${stdenv.gcc}
+                NIX_CC=${stdenv.cc}
                 export SHELL=${stdenv.shell}
                 PATH_DELIMITER=':'
                 
                 # Set up the initial path.
                 PATH=
-                for i in \$NIX_GCC ${toString stdenv.initialPath}; do
+                for i in \$NIX_CC ${toString stdenv.initialPath}; do
                     PATH=\$PATH\${PATH:+\"\${PATH_DELIMITER}\"}\$i/bin
                 done
 
@@ -138,7 +138,7 @@ let inherit (builtins) head tail trace; in
                 }
 
                 pkgs=\"\"
-                for i in \$NIX_GCC ${toString realBuildInputs}; do
+                for i in \$NIX_CC ${toString realBuildInputs}; do
                     findInputs \$i
                 done
 

--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -220,6 +220,8 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
                 done
               done
 
+              configureFlags+=" --with-gcc=$CC"
+
               ${optionalString (self.enableSharedExecutables && self.stdenv.isLinux) ''
                 configureFlags+=" --ghc-option=-optl=-Wl,-rpath=$out/lib/${ghc.ghc.name}/${self.pname}-${self.version}"
               ''}

--- a/pkgs/build-support/gcc-cross-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-cross-wrapper/gcc-wrapper.sh
@@ -1,7 +1,7 @@
 #! @shell@ -e
 
-if test -n "$NIX_GCC_WRAPPER_START_HOOK"; then
-    source "$NIX_GCC_WRAPPER_START_HOOK"
+if test -n "$NIX_CC_WRAPPER_START_HOOK"; then
+    source "$NIX_CC_WRAPPER_START_HOOK"
 fi
 
 if test -z "$NIX_CROSS_GLIBC_FLAGS_SET"; then
@@ -107,8 +107,8 @@ if test "$NIX_DEBUG" = "1"; then
   done
 fi
 
-if test -n "$NIX_GCC_WRAPPER_EXEC_HOOK"; then
-    source "$NIX_GCC_WRAPPER_EXEC_HOOK"
+if test -n "$NIX_CC_WRAPPER_EXEC_HOOK"; then
+    source "$NIX_CC_WRAPPER_EXEC_HOOK"
 fi
 
 # We want gcc to call the wrapper linker, not that of binutils.

--- a/pkgs/build-support/gcc-wrapper-old/add-flags
+++ b/pkgs/build-support/gcc-wrapper-old/add-flags
@@ -25,4 +25,4 @@ if test -e @out@/nix-support/libc-ldflags-before; then
     export NIX_LDFLAGS_BEFORE="$(cat @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE"
 fi
 
-export NIX_GCC_WRAPPER_FLAGS_SET=1
+export NIX_CC_WRAPPER_FLAGS_SET=1

--- a/pkgs/build-support/gcc-wrapper-old/gcc-wrapper-old.sh
+++ b/pkgs/build-support/gcc-wrapper-old/gcc-wrapper-old.sh
@@ -1,10 +1,10 @@
 #! @shell@ -e
 
-if [ -n "$NIX_GCC_WRAPPER_START_HOOK" ]; then
-    source "$NIX_GCC_WRAPPER_START_HOOK"
+if [ -n "$NIX_CC_WRAPPER_START_HOOK" ]; then
+    source "$NIX_CC_WRAPPER_START_HOOK"
 fi
 
-if [ -z "$NIX_GCC_WRAPPER_FLAGS_SET" ]; then
+if [ -z "$NIX_CC_WRAPPER_FLAGS_SET" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -139,8 +139,8 @@ if [ -n "$NIX_DEBUG" ]; then
   done
 fi
 
-if [ -n "$NIX_GCC_WRAPPER_EXEC_HOOK" ]; then
-    source "$NIX_GCC_WRAPPER_EXEC_HOOK"
+if [ -n "$NIX_CC_WRAPPER_EXEC_HOOK" ]; then
+    source "$NIX_CC_WRAPPER_EXEC_HOOK"
 fi
 
 exec @prog@ ${extraBefore[@]} "${params[@]}" "${extraAfter[@]}"

--- a/pkgs/build-support/gcc-wrapper-old/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper-old/gcc-wrapper.sh
@@ -1,10 +1,10 @@
 #! @shell@ -e
 
-if test -n "$NIX_GCC_WRAPPER_START_HOOK"; then
-    source "$NIX_GCC_WRAPPER_START_HOOK"
+if test -n "$NIX_CC_WRAPPER_START_HOOK"; then
+    source "$NIX_CC_WRAPPER_START_HOOK"
 fi
 
-if test -z "$NIX_GCC_WRAPPER_FLAGS_SET"; then
+if test -z "$NIX_CC_WRAPPER_FLAGS_SET"; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -130,15 +130,15 @@ if test "$NIX_DEBUG" = "1"; then
   done
 fi
 
-if test -n "$NIX_GCC_WRAPPER_EXEC_HOOK"; then
-    source "$NIX_GCC_WRAPPER_EXEC_HOOK"
+if test -n "$NIX_CC_WRAPPER_EXEC_HOOK"; then
+    source "$NIX_CC_WRAPPER_EXEC_HOOK"
 fi
 
 
 # Call the real `gcc'.  Filter out warnings from stderr about unused
 # `-B' flags, since they confuse some programs.  Deep bash magic to
 # apply grep to stderr (by swapping stdin/stderr twice).
-if test -z "$NIX_GCC_NEEDS_GREP"; then
+if test -z "$NIX_CC_NEEDS_GREP"; then
     @gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]}
 else
     (@gccProg@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]} 3>&2 2>&1 1>&3- \

--- a/pkgs/build-support/gcc-wrapper-old/ld-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper-old/ld-wrapper.sh
@@ -4,7 +4,7 @@ if test -n "$NIX_LD_WRAPPER_START_HOOK"; then
     source "$NIX_LD_WRAPPER_START_HOOK"
 fi
 
-if test -z "$NIX_GCC_WRAPPER_FLAGS_SET"; then
+if test -z "$NIX_CC_WRAPPER_FLAGS_SET"; then
     source @out@/nix-support/add-flags.sh
 fi
 

--- a/pkgs/build-support/gcc-wrapper/add-flags
+++ b/pkgs/build-support/gcc-wrapper/add-flags
@@ -25,4 +25,4 @@ if [ -e @out@/nix-support/libc-ldflags-before ]; then
     export NIX_LDFLAGS_BEFORE="$(cat @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE"
 fi
 
-export NIX_GCC_WRAPPER_FLAGS_SET=1
+export NIX_CC_WRAPPER_FLAGS_SET=1

--- a/pkgs/build-support/gcc-wrapper/default.nix
+++ b/pkgs/build-support/gcc-wrapper/default.nix
@@ -226,7 +226,7 @@ stdenv.mkDerivation {
 
   crossAttrs = {
     shell = shell.crossDrv + shell.crossDrv.shellPath;
-    libc = stdenv.gccCross.libc;
+    libc = stdenv.ccCross.libc;
     coreutils = coreutils.crossDrv;
     binutils = binutils.crossDrv;
     gcc = gcc.crossDrv;

--- a/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/gcc-wrapper.sh
@@ -1,10 +1,10 @@
 #! @shell@ -e
 
-if [ -n "$NIX_GCC_WRAPPER_START_HOOK" ]; then
-    source "$NIX_GCC_WRAPPER_START_HOOK"
+if [ -n "$NIX_CC_WRAPPER_START_HOOK" ]; then
+    source "$NIX_CC_WRAPPER_START_HOOK"
 fi
 
-if [ -z "$NIX_GCC_WRAPPER_FLAGS_SET" ]; then
+if [ -z "$NIX_CC_WRAPPER_FLAGS_SET" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
@@ -139,8 +139,8 @@ if [ -n "$NIX_DEBUG" ]; then
   done
 fi
 
-if [ -n "$NIX_GCC_WRAPPER_EXEC_HOOK" ]; then
-    source "$NIX_GCC_WRAPPER_EXEC_HOOK"
+if [ -n "$NIX_CC_WRAPPER_EXEC_HOOK" ]; then
+    source "$NIX_CC_WRAPPER_EXEC_HOOK"
 fi
 
 exec @prog@ ${extraBefore[@]} "${params[@]}" "${extraAfter[@]}"

--- a/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/gcc-wrapper/ld-wrapper.sh
@@ -4,7 +4,7 @@ if [ -n "$NIX_LD_WRAPPER_START_HOOK" ]; then
     source "$NIX_LD_WRAPPER_START_HOOK"
 fi
 
-if [ -z "$NIX_GCC_WRAPPER_FLAGS_SET" ]; then
+if [ -z "$NIX_CC_WRAPPER_FLAGS_SET" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 

--- a/pkgs/build-support/gcc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/gcc-wrapper/setup-hook.sh
@@ -1,4 +1,4 @@
-export NIX_GCC=@out@
+export NIX_CC=@out@
 
 addCVars () {
     if [ -d $1/include ]; then
@@ -33,3 +33,6 @@ fi
 if [ -n "@coreutils@" ]; then
     addToSearchPath PATH @coreutils@/bin
 fi
+
+export CC=gcc
+export CXX=g++

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation rec {
             if echo "$filepath" | grep -q "\.elf$"; then
                 continue
             fi
-            echo "setting interpreter $(cat "$NIX_GCC"/nix-support/dynamic-linker) in $filepath"
-            patchelf --set-interpreter "$(cat "$NIX_GCC"/nix-support/dynamic-linker)" "$filepath"
+            echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
+            patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath"
             test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
         fi
     done

--- a/pkgs/development/compilers/aldor/default.nix
+++ b/pkgs/development/compilers/aldor/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     do
       wrapProgram $out/bin/$prog --set ALDORROOT $out \
         --prefix PATH : ${openjdk}/bin \
-        --prefix PATH : ${stdenv.gcc}/bin ;
+        --prefix PATH : ${stdenv.cc}/bin ;
     done
   '';
 

--- a/pkgs/development/compilers/bigloo/default.nix
+++ b/pkgs/development/compilers/bigloo/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   preConfigure =
     # Help libgc's configure.
-    '' export CXXCPP="g++ -E"
+    '' export CXXCPP="$CXX -E"
     '';
 
   patchPhase = ''

--- a/pkgs/development/compilers/cmucl/binary.nix
+++ b/pkgs/development/compilers/cmucl/binary.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out
     tar -C $out -xjf ${dist}
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       $out/bin/lisp
   '';
 

--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coq, ocaml, ocamlPackages, gcc }:
+{ stdenv, fetchurl, coq, ocaml, ocamlPackages }:
 
 stdenv.mkDerivation rec {
   name    = "compcert-${version}";
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ coq ocaml ocamlPackages.menhir ];
 
   enableParallelBuilding = true;
-  configurePhase = "./configure -prefix $out -toolprefix ${gcc}/bin/ " +
+
+  configurePhase = ''
+    substituteInPlace ./configure --replace '{toolprefix}gcc' '{toolprefix}cc'
+    ./configure -prefix $out -toolprefix ${stdenv.cc}/bin/ '' +
     (if stdenv.isDarwin then "ia32-macosx" else "ia32-linux");
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/cryptol/1.8.x.nix
+++ b/pkgs/development/compilers/cryptol/1.8.x.nix
@@ -10,12 +10,12 @@ let
   jss-ver = "jss-0.4";
 
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.gcc.libc
-      stdenv.gcc.gcc
+    [ stdenv.cc.libc
+      stdenv.cc.gcc
       gmp4
       ncurses
       zlib
-    ] + ":${stdenv.gcc.gcc}/lib64";
+    ] + ":${stdenv.cc.gcc}/lib64";
 
   cryptol-bin =
     if stdenv.system == "i686-linux"
@@ -94,12 +94,12 @@ stdenv.mkDerivation rec {
 
     # Hack around lack of libtinfo in NixOS
     ln -s ${ncurses}/lib/libncursesw.so.5.9 $out/lib/libtinfo.so.5
-    ln -s ${stdenv.gcc.libc}/lib/libpthread-2.19.so $out/lib/libpthread.so.0
+    ln -s ${stdenv.cc.libc}/lib/libpthread-2.19.so $out/lib/libpthread.so.0
   '';
 
   fixupPhase = ''
     for x in bin/cryptol bin/edif2verilog bin/copy-iverilog bin/symbolic_netlist bin/jaig bin/vvp-galois bin/lss libexec/jss; do
-      patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "$out/lib:${libPath}" $out/$x
       patchelf --shrink-rpath $out/$x
     done

--- a/pkgs/development/compilers/cudatoolkit/5.5.nix
+++ b/pkgs/development/compilers/cudatoolkit/5.5.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     gtk2 glib fontconfig freetype unixODBC alsaLib
   ];
 
-  rpath = "${stdenv.lib.makeLibraryPath runtimeDependencies}:${stdenv.gcc.gcc}/lib64";
+  rpath = "${stdenv.lib.makeLibraryPath runtimeDependencies}:${stdenv.cc.gcc}/lib64";
 
   unpackPhase = ''
     sh $src --keep --noexec
@@ -38,10 +38,10 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     find . -type f -executable -exec patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       '{}' \; || true
     find . -type f -exec patchelf \
-      --set-rpath $rpath:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+      --set-rpath $rpath:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
       --force-rpath \
       '{}' \; || true
   '';

--- a/pkgs/development/compilers/cudatoolkit/6.0.nix
+++ b/pkgs/development/compilers/cudatoolkit/6.0.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     gtk2 glib fontconfig freetype unixODBC alsaLib
   ];
 
-  rpath = "${stdenv.lib.makeLibraryPath runtimeDependencies}:${stdenv.gcc.gcc}/lib64";
+  rpath = "${stdenv.lib.makeLibraryPath runtimeDependencies}:${stdenv.cc.gcc}/lib64";
 
   unpackPhase = ''
     sh $src --keep --noexec
@@ -38,10 +38,10 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     find . -type f -executable -exec patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       '{}' \; || true
     find . -type f -exec patchelf \
-      --set-rpath $rpath:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64:$(cat $NIX_GCC/nix-support/orig-gcc)/lib \
+      --set-rpath $rpath:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64:$(cat $NIX_CC/nix-support/orig-gcc)/lib \
       --force-rpath \
       '{}' \; || true
   '';

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -17,7 +17,7 @@ let
   buildInputs = [
     fpc gtk glib libXi inputproto
     libX11 xproto libXext xextproto pango atk
-    stdenv.gcc makeWrapper gdk_pixbuf
+    stdenv.cc makeWrapper gdk_pixbuf
   ];
 in
 stdenv.mkDerivation {

--- a/pkgs/development/compilers/gcc/3.4/builder.sh
+++ b/pkgs/development/compilers/gcc/3.4/builder.sh
@@ -7,17 +7,17 @@ mkdir $NIX_FIXINC_DUMMY
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraCFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraCFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
         
     else
         # Hack: support impure environments.

--- a/pkgs/development/compilers/gcc/4.2-apple64/builder.sh
+++ b/pkgs/development/compilers/gcc/4.2-apple64/builder.sh
@@ -14,11 +14,11 @@ if test "$noSysDirs" = "1"; then
 
     # Figure out what extra flags to pass to the gcc compilers being
     # generated to make sure that they use our glibc.
-    if test -e $NIX_GCC/nix-support/orig-glibc; then
-        glibc=$(cat $NIX_GCC/nix-support/orig-glibc)
+    if test -e $NIX_CC/nix-support/orig-glibc; then
+        glibc=$(cat $NIX_CC/nix-support/orig-glibc)
 
         # Ugh.  Copied from gcc-wrapper/builder.sh.  We can't just
-        # source in $NIX_GCC/nix-support/add-flags, since that would
+        # source in $NIX_CC/nix-support/add-flags, since that would
         # cause *this* GCC to be linked against the *previous* GCC.
         # Need some more modularity there.
         extraCFlags="-B$glibc/lib -isystem $glibc/include"

--- a/pkgs/development/compilers/gcc/4.3/builder.sh
+++ b/pkgs/development/compilers/gcc/4.3/builder.sh
@@ -12,17 +12,17 @@ export CPP="gcc -E"
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraCFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraCFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
         
     else
         # Hack: support impure environments.

--- a/pkgs/development/compilers/gcc/4.4/builder.sh
+++ b/pkgs/development/compilers/gcc/4.4/builder.sh
@@ -17,20 +17,20 @@ fi
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
 
         # The path to the Glibc binaries such as `crti.o'.
-        glibc_libdir="$(cat $NIX_GCC/nix-support/orig-libc)/lib"
+        glibc_libdir="$(cat $NIX_CC/nix-support/orig-libc)/lib"
         
     else
         # Hack: support impure environments.
@@ -61,27 +61,27 @@ if test "$noSysDirs" = "1"; then
             EXTRA_LDFLAGS_TARGET="-Wl,-L${libcCross}/lib"
         fi
     else
-        if test -z "$NIX_GCC_CROSS"; then
+        if test -z "$NIX_CC_CROSS"; then
             EXTRA_FLAGS_TARGET="$EXTRA_FLAGS"
             EXTRA_LDFLAGS_TARGET="$EXTRA_LDFLAGS"
         else
             # This the case of cross-building the gcc.
             # We need special flags for the target, different than those of the build
             # Assertion:
-            test -e $NIX_GCC_CROSS/nix-support/orig-libc
+            test -e $NIX_CC_CROSS/nix-support/orig-libc
 
             # Figure out what extra flags to pass to the gcc compilers
             # being generated to make sure that they use our glibc.
-            extraFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-cflags)"
-            extraLDFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-ldflags) $(cat $NIX_GCC_CROSS/nix-support/libc-ldflags-before)"
+            extraFlags="$(cat $NIX_CC_CROSS/nix-support/libc-cflags)"
+            extraLDFlags="$(cat $NIX_CC_CROSS/nix-support/libc-ldflags) $(cat $NIX_CC_CROSS/nix-support/libc-ldflags-before)"
 
             # Use *real* header files, otherwise a limits.h is generated
             # that does not include Glibc's limits.h (notably missing
             # SSIZE_MAX, which breaks the build).
-            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/include
+            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_CC_CROSS/nix-support/orig-libc)/include
 
             # The path to the Glibc binaries such as `crti.o'.
-            glibc_libdir="$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/lib"
+            glibc_libdir="$(cat $NIX_CC_CROSS/nix-support/orig-libc)/lib"
 
             extraFlags="-g0 -O2 -I$NIX_FIXINC_DUMMY_CROSS $extraFlags"
             extraLDFlags="--strip-debug -L$glibc_libdir -rpath $glibc_libdir $extraLDFlags"

--- a/pkgs/development/compilers/gcc/4.4/default.nix
+++ b/pkgs/development/compilers/gcc/4.4/default.nix
@@ -188,7 +188,7 @@ stdenv.mkDerivation ({
     NM_FOR_TARGET = "${stdenv.cross.config}-nm";
     CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
     # If we are making a cross compiler, cross != null
-    NIX_GCC_CROSS = if cross == null then "${stdenv.gccCross}" else "";
+    NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     configureFlags = "
       ${if enableMultilib then "" else "--disable-multilib"}
       ${if enableShared then "" else "--disable-shared"}

--- a/pkgs/development/compilers/gcc/4.5/builder.sh
+++ b/pkgs/development/compilers/gcc/4.5/builder.sh
@@ -23,20 +23,20 @@ echo "\$LIBRARY_PATH is \`$LIBRARY_PATH'"
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
 
         # The path to the Glibc binaries such as `crti.o'.
-        glibc_libdir="$(cat $NIX_GCC/nix-support/orig-libc)/lib"
+        glibc_libdir="$(cat $NIX_CC/nix-support/orig-libc)/lib"
         
     else
         # Hack: support impure environments.
@@ -67,27 +67,27 @@ if test "$noSysDirs" = "1"; then
             EXTRA_TARGET_LDFLAGS="-Wl,-L${libcCross}/lib"
         fi
     else
-        if test -z "$NIX_GCC_CROSS"; then
+        if test -z "$NIX_CC_CROSS"; then
             EXTRA_TARGET_CFLAGS="$EXTRA_FLAGS"
             EXTRA_TARGET_LDFLAGS="$EXTRA_LDFLAGS"
         else
             # This the case of cross-building the gcc.
             # We need special flags for the target, different than those of the build
             # Assertion:
-            test -e $NIX_GCC_CROSS/nix-support/orig-libc
+            test -e $NIX_CC_CROSS/nix-support/orig-libc
 
             # Figure out what extra flags to pass to the gcc compilers
             # being generated to make sure that they use our glibc.
-            extraFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-cflags)"
-            extraLDFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-ldflags) $(cat $NIX_GCC_CROSS/nix-support/libc-ldflags-before)"
+            extraFlags="$(cat $NIX_CC_CROSS/nix-support/libc-cflags)"
+            extraLDFlags="$(cat $NIX_CC_CROSS/nix-support/libc-ldflags) $(cat $NIX_CC_CROSS/nix-support/libc-ldflags-before)"
 
             # Use *real* header files, otherwise a limits.h is generated
             # that does not include Glibc's limits.h (notably missing
             # SSIZE_MAX, which breaks the build).
-            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/include
+            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_CC_CROSS/nix-support/orig-libc)/include
 
             # The path to the Glibc binaries such as `crti.o'.
-            glibc_libdir="$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/lib"
+            glibc_libdir="$(cat $NIX_CC_CROSS/nix-support/orig-libc)/lib"
 
             extraFlags="-I$NIX_FIXINC_DUMMY_CROSS $extraFlags"
             extraLDFlags="-L$glibc_libdir -rpath $glibc_libdir $extraLDFlags"
@@ -162,7 +162,7 @@ preConfigure() {
     # Patch the configure script so it finds glibc headers
     # It's important for example in order not to get libssp built, because it's
     # functionality is in glibc already.
-    glibc_headers="$(cat $NIX_GCC/nix-support/orig-libc)/include"
+    glibc_headers="$(cat $NIX_CC/nix-support/orig-libc)/include"
     sed -i \
       -e s,glibc_header_dir=/usr/include,glibc_header_dir=$glibc_headers, \
       gcc/configure

--- a/pkgs/development/compilers/gcc/4.5/default.nix
+++ b/pkgs/development/compilers/gcc/4.5/default.nix
@@ -185,11 +185,11 @@ stdenv.mkDerivation ({
            sed -i gcc/config/t-gnu \
                -es'|NATIVE_SYSTEM_HEADER_DIR.*$|NATIVE_SYSTEM_HEADER_DIR = ${libc}/include|g'
         ''
-    else if cross != null || stdenv.gcc.libc != null then
+    else if cross != null || stdenv.cc.libc != null then
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
       let
-        libc = if libcCross != null then libcCross else stdenv.gcc.libc;
+        libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         '' echo "fixing the \`GLIBC_DYNAMIC_LINKER' and \`UCLIBC_DYNAMIC_LINKER' macros..."
            for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h
@@ -272,7 +272,7 @@ stdenv.mkDerivation ({
     NM_FOR_TARGET = "${stdenv.cross.config}-nm";
     CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
     # If we are making a cross compiler, cross != null
-    NIX_GCC_CROSS = if cross == null then "${stdenv.gccCross}" else "";
+    NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
     configureFlags = ''
       ${if enableMultilib then "" else "--disable-multilib"}

--- a/pkgs/development/compilers/gcc/4.6/builder.sh
+++ b/pkgs/development/compilers/gcc/4.6/builder.sh
@@ -19,20 +19,20 @@ echo "\$LIBRARY_PATH is \`$LIBRARY_PATH'"
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
 
         # The path to the Glibc binaries such as `crti.o'.
-        glibc_libdir="$(cat $NIX_GCC/nix-support/orig-libc)/lib"
+        glibc_libdir="$(cat $NIX_CC/nix-support/orig-libc)/lib"
 
     else
         # Hack: support impure environments.
@@ -74,27 +74,27 @@ if test "$noSysDirs" = "1"; then
             EXTRA_TARGET_LDFLAGS="-Wl,-L${libcCross}/lib"
         fi
     else
-        if test -z "$NIX_GCC_CROSS"; then
+        if test -z "$NIX_CC_CROSS"; then
             EXTRA_TARGET_CFLAGS="$EXTRA_FLAGS"
             EXTRA_TARGET_LDFLAGS="$EXTRA_LDFLAGS"
         else
             # This the case of cross-building the gcc.
             # We need special flags for the target, different than those of the build
             # Assertion:
-            test -e $NIX_GCC_CROSS/nix-support/orig-libc
+            test -e $NIX_CC_CROSS/nix-support/orig-libc
 
             # Figure out what extra flags to pass to the gcc compilers
             # being generated to make sure that they use our glibc.
-            extraFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-cflags)"
-            extraLDFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-ldflags) $(cat $NIX_GCC_CROSS/nix-support/libc-ldflags-before)"
+            extraFlags="$(cat $NIX_CC_CROSS/nix-support/libc-cflags)"
+            extraLDFlags="$(cat $NIX_CC_CROSS/nix-support/libc-ldflags) $(cat $NIX_CC_CROSS/nix-support/libc-ldflags-before)"
 
             # Use *real* header files, otherwise a limits.h is generated
             # that does not include Glibc's limits.h (notably missing
             # SSIZE_MAX, which breaks the build).
-            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/include
+            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_CC_CROSS/nix-support/orig-libc)/include
 
             # The path to the Glibc binaries such as `crti.o'.
-            glibc_libdir="$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/lib"
+            glibc_libdir="$(cat $NIX_CC_CROSS/nix-support/orig-libc)/lib"
 
             extraFlags="-I$NIX_FIXINC_DUMMY_CROSS $extraFlags"
             extraLDFlags="-L$glibc_libdir -rpath $glibc_libdir $extraLDFlags"
@@ -166,11 +166,11 @@ preConfigure() {
         rm -Rf zlib
     fi
 
-    if test -f "$NIX_GCC/nix-support/orig-libc"; then
+    if test -f "$NIX_CC/nix-support/orig-libc"; then
         # Patch the configure script so it finds glibc headers.  It's
         # important for example in order not to get libssp built,
         # because its functionality is in glibc already.
-        glibc_headers="$(cat $NIX_GCC/nix-support/orig-libc)/include"
+        glibc_headers="$(cat $NIX_CC/nix-support/orig-libc)/include"
         sed -i \
             -e "s,glibc_header_dir=/usr/include,glibc_header_dir=$glibc_headers", \
             gcc/configure

--- a/pkgs/development/compilers/gcc/4.6/default.nix
+++ b/pkgs/development/compilers/gcc/4.6/default.nix
@@ -229,11 +229,11 @@ stdenv.mkDerivation ({
            sed -i gcc/config/t-gnu \
                -es'|NATIVE_SYSTEM_HEADER_DIR.*$|NATIVE_SYSTEM_HEADER_DIR = ${libc}/include|g'
         ''
-    else if cross != null || stdenv.gcc.libc != null then
+    else if cross != null || stdenv.cc.libc != null then
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
       let
-        libc = if libcCross != null then libcCross else stdenv.gcc.libc;
+        libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         '' echo "fixing the \`GLIBC_DYNAMIC_LINKER' and \`UCLIBC_DYNAMIC_LINKER' macros..."
            for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h
@@ -339,7 +339,7 @@ stdenv.mkDerivation ({
     NM_FOR_TARGET = "${stdenv.cross.config}-nm";
     CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
     # If we are making a cross compiler, cross != null
-    NIX_GCC_CROSS = if cross == null then "${stdenv.gccCross}" else "";
+    NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
     configureFlags = ''
       ${if enableMultilib then "" else "--disable-multilib"}

--- a/pkgs/development/compilers/gcc/4.8/builder.sh
+++ b/pkgs/development/compilers/gcc/4.8/builder.sh
@@ -19,20 +19,20 @@ echo "\$LIBRARY_PATH is \`$LIBRARY_PATH'"
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
 
         # The path to the Glibc binaries such as `crti.o'.
-        glibc_libdir="$(cat $NIX_GCC/nix-support/orig-libc)/lib"
+        glibc_libdir="$(cat $NIX_CC/nix-support/orig-libc)/lib"
 
     else
         # Hack: support impure environments.
@@ -74,7 +74,7 @@ if test "$noSysDirs" = "1"; then
             EXTRA_TARGET_LDFLAGS="-Wl,-L${libcCross}/lib -Wl,-rpath,${libcCross}/lib -Wl,-rpath-link,${libcCross}/lib"
         fi
     else
-        if test -z "$NIX_GCC_CROSS"; then
+        if test -z "$NIX_CC_CROSS"; then
             EXTRA_TARGET_CFLAGS="$EXTRA_FLAGS"
             EXTRA_TARGET_CXXFLAGS="$EXTRA_FLAGS"
             EXTRA_TARGET_LDFLAGS="$EXTRA_LDFLAGS"
@@ -82,20 +82,20 @@ if test "$noSysDirs" = "1"; then
             # This the case of cross-building the gcc.
             # We need special flags for the target, different than those of the build
             # Assertion:
-            test -e $NIX_GCC_CROSS/nix-support/orig-libc
+            test -e $NIX_CC_CROSS/nix-support/orig-libc
 
             # Figure out what extra flags to pass to the gcc compilers
             # being generated to make sure that they use our glibc.
-            extraFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-cflags)"
-            extraLDFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-ldflags) $(cat $NIX_GCC_CROSS/nix-support/libc-ldflags-before)"
+            extraFlags="$(cat $NIX_CC_CROSS/nix-support/libc-cflags)"
+            extraLDFlags="$(cat $NIX_CC_CROSS/nix-support/libc-ldflags) $(cat $NIX_CC_CROSS/nix-support/libc-ldflags-before)"
 
             # Use *real* header files, otherwise a limits.h is generated
             # that does not include Glibc's limits.h (notably missing
             # SSIZE_MAX, which breaks the build).
-            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/include
+            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_CC_CROSS/nix-support/orig-libc)/include
 
             # The path to the Glibc binaries such as `crti.o'.
-            glibc_dir="$(cat $NIX_GCC_CROSS/nix-support/orig-libc)"
+            glibc_dir="$(cat $NIX_CC_CROSS/nix-support/orig-libc)"
             glibc_libdir="$glibc_dir/lib"
             configureFlags="$configureFlags --with-native-system-header-dir=$glibc_dir/include"
 
@@ -167,11 +167,11 @@ preConfigure() {
         rm -Rf zlib
     fi
 
-    if test -f "$NIX_GCC/nix-support/orig-libc"; then
+    if test -f "$NIX_CC/nix-support/orig-libc"; then
         # Patch the configure script so it finds glibc headers.  It's
         # important for example in order not to get libssp built,
         # because its functionality is in glibc already.
-        glibc_headers="$(cat $NIX_GCC/nix-support/orig-libc)/include"
+        glibc_headers="$(cat $NIX_CC/nix-support/orig-libc)/include"
         sed -i \
             -e "s,glibc_header_dir=/usr/include,glibc_header_dir=$glibc_headers", \
             gcc/configure

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -251,11 +251,11 @@ stdenv.mkDerivation ({
            sed -i "${gnu_h}" \
                -es'|#define STANDARD_INCLUDE_DIR.*$|#define STANDARD_INCLUDE_DIR "${libc}/include"|g'
         ''
-    else if cross != null || stdenv.gcc.libc != null then
+    else if cross != null || stdenv.cc.libc != null then
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
       let
-        libc = if libcCross != null then libcCross else stdenv.gcc.libc;
+        libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         '' echo "fixing the \`GLIBC_DYNAMIC_LINKER' and \`UCLIBC_DYNAMIC_LINKER' macros..."
            for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h
@@ -397,7 +397,7 @@ stdenv.mkDerivation ({
     NM_FOR_TARGET = "${stdenv.cross.config}-nm";
     CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
     # If we are making a cross compiler, cross != null
-    NIX_GCC_CROSS = if cross == null then "${stdenv.gccCross}" else "";
+    NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
     configureFlags = ''
       ${if enableMultilib then "" else "--disable-multilib"}

--- a/pkgs/development/compilers/gcc/4.9/builder.sh
+++ b/pkgs/development/compilers/gcc/4.9/builder.sh
@@ -19,20 +19,20 @@ echo "\$LIBRARY_PATH is \`$LIBRARY_PATH'"
 
 if test "$noSysDirs" = "1"; then
 
-    if test -e $NIX_GCC/nix-support/orig-libc; then
+    if test -e $NIX_CC/nix-support/orig-libc; then
 
         # Figure out what extra flags to pass to the gcc compilers
         # being generated to make sure that they use our glibc.
-        extraFlags="$(cat $NIX_GCC/nix-support/libc-cflags)"
-        extraLDFlags="$(cat $NIX_GCC/nix-support/libc-ldflags) $(cat $NIX_GCC/nix-support/libc-ldflags-before)"
+        extraFlags="$(cat $NIX_CC/nix-support/libc-cflags)"
+        extraLDFlags="$(cat $NIX_CC/nix-support/libc-ldflags) $(cat $NIX_CC/nix-support/libc-ldflags-before)"
 
         # Use *real* header files, otherwise a limits.h is generated
         # that does not include Glibc's limits.h (notably missing
         # SSIZE_MAX, which breaks the build).
-        export NIX_FIXINC_DUMMY=$(cat $NIX_GCC/nix-support/orig-libc)/include
+        export NIX_FIXINC_DUMMY=$(cat $NIX_CC/nix-support/orig-libc)/include
 
         # The path to the Glibc binaries such as `crti.o'.
-        glibc_libdir="$(cat $NIX_GCC/nix-support/orig-libc)/lib"
+        glibc_libdir="$(cat $NIX_CC/nix-support/orig-libc)/lib"
 
     else
         # Hack: support impure environments.
@@ -74,7 +74,7 @@ if test "$noSysDirs" = "1"; then
             EXTRA_TARGET_LDFLAGS="-Wl,-L${libcCross}/lib -Wl,-rpath,${libcCross}/lib -Wl,-rpath-link,${libcCross}/lib"
         fi
     else
-        if test -z "$NIX_GCC_CROSS"; then
+        if test -z "$NIX_CC_CROSS"; then
             EXTRA_TARGET_CFLAGS="$EXTRA_FLAGS"
             EXTRA_TARGET_CXXFLAGS="$EXTRA_FLAGS"
             EXTRA_TARGET_LDFLAGS="$EXTRA_LDFLAGS"
@@ -82,20 +82,20 @@ if test "$noSysDirs" = "1"; then
             # This the case of cross-building the gcc.
             # We need special flags for the target, different than those of the build
             # Assertion:
-            test -e $NIX_GCC_CROSS/nix-support/orig-libc
+            test -e $NIX_CC_CROSS/nix-support/orig-libc
 
             # Figure out what extra flags to pass to the gcc compilers
             # being generated to make sure that they use our glibc.
-            extraFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-cflags)"
-            extraLDFlags="$(cat $NIX_GCC_CROSS/nix-support/libc-ldflags) $(cat $NIX_GCC_CROSS/nix-support/libc-ldflags-before)"
+            extraFlags="$(cat $NIX_CC_CROSS/nix-support/libc-cflags)"
+            extraLDFlags="$(cat $NIX_CC_CROSS/nix-support/libc-ldflags) $(cat $NIX_CC_CROSS/nix-support/libc-ldflags-before)"
 
             # Use *real* header files, otherwise a limits.h is generated
             # that does not include Glibc's limits.h (notably missing
             # SSIZE_MAX, which breaks the build).
-            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_GCC_CROSS/nix-support/orig-libc)/include
+            NIX_FIXINC_DUMMY_CROSS=$(cat $NIX_CC_CROSS/nix-support/orig-libc)/include
 
             # The path to the Glibc binaries such as `crti.o'.
-            glibc_dir="$(cat $NIX_GCC_CROSS/nix-support/orig-libc)"
+            glibc_dir="$(cat $NIX_CC_CROSS/nix-support/orig-libc)"
             glibc_libdir="$glibc_dir/lib"
             configureFlags="$configureFlags --with-native-system-header-dir=$glibc_dir/include"
 
@@ -171,11 +171,11 @@ preConfigure() {
         rm -Rf zlib
     fi
 
-    if test -f "$NIX_GCC/nix-support/orig-libc"; then
+    if test -f "$NIX_CC/nix-support/orig-libc"; then
         # Patch the configure script so it finds glibc headers.  It's
         # important for example in order not to get libssp built,
         # because its functionality is in glibc already.
-        glibc_headers="$(cat $NIX_GCC/nix-support/orig-libc)/include"
+        glibc_headers="$(cat $NIX_CC/nix-support/orig-libc)/include"
         sed -i \
             -e "s,glibc_header_dir=/usr/include,glibc_header_dir=$glibc_headers", \
             gcc/configure

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -247,11 +247,11 @@ stdenv.mkDerivation ({
            sed -i "${gnu_h}" \
                -es'|#define STANDARD_INCLUDE_DIR.*$|#define STANDARD_INCLUDE_DIR "${libc}/include"|g'
         ''
-    else if cross != null || stdenv.gcc.libc != null then
+    else if cross != null || stdenv.cc.libc != null then
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
       let
-        libc = if libcCross != null then libcCross else stdenv.gcc.libc;
+        libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         '' echo "fixing the \`GLIBC_DYNAMIC_LINKER' and \`UCLIBC_DYNAMIC_LINKER' macros..."
            for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h
@@ -385,7 +385,7 @@ stdenv.mkDerivation ({
     NM_FOR_TARGET = "${stdenv.cross.config}-nm";
     CXX_FOR_TARGET = "${stdenv.cross.config}-g++";
     # If we are making a cross compiler, cross != null
-    NIX_GCC_CROSS = if cross == null then "${stdenv.gccCross}" else "";
+    NIX_CC_CROSS = if cross == null then "${stdenv.ccCross}" else "";
     dontStrip = true;
     configureFlags = ''
       ${if enableMultilib then "" else "--disable-multilib"}

--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -9,11 +9,11 @@ let
 in
 
 (
-assert a.stdenv ? gcc ;
-assert a.stdenv.gcc ? gcc ;
-assert a.stdenv.gcc ? libc ;
-assert a.stdenv.gcc.gcc != null ;
-assert a.stdenv.gcc.libc != null ;
+assert a.stdenv ? cc ;
+assert a.stdenv.cc ? gcc ;
+assert a.stdenv.cc ? libc ;
+assert a.stdenv.cc.gcc != null ;
+assert a.stdenv.cc.libc != null ;
 
 rec {
   src = a.fetchurl {
@@ -37,7 +37,7 @@ rec {
   preBuild = a.fullDepEntry (''
     sed -re "s@/bin/cat@$(which cat)@g" -i configure */configure
     sed -re "s@if test -d /proc/self @if false @" -i configure
-    sed -re 's^([ \t])cpp ^\1cpp -I${a.stdenv.gcc.gcc}/include -I${a.stdenv.gcc.libc}/include ^g' -i makefile
+    sed -re 's^([ \t])cpp ^\1cpp -I${a.stdenv.cc.gcc}/include -I${a.stdenv.cc.libc}/include ^g' -i makefile
   '') ["minInit" "doUnpack" "addInputs"];
 
   /* doConfigure should be removed if not needed */

--- a/pkgs/development/compilers/ghc/6.10.1-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.1-binary.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     (if stdenv.isLinux then ''
       find . -type f -perm +100 \
-          -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${libedit}/lib:${ncurses}/lib:${gmp}/lib" {} \;
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;

--- a/pkgs/development/compilers/ghc/6.10.1.nix
+++ b/pkgs/development/compilers/ghc/6.10.1.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   configureFlags=[
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   meta = {

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     (if stdenv.isLinux then ''
       find . -type f -perm +100 \
-          -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${libedit}/lib:${ncurses}/lib:${gmp}/lib" {} \;
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;

--- a/pkgs/development/compilers/ghc/6.10.2.nix
+++ b/pkgs/development/compilers/ghc/6.10.2.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   configureFlags=[
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   meta = {

--- a/pkgs/development/compilers/ghc/6.10.3.nix
+++ b/pkgs/development/compilers/ghc/6.10.3.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   configureFlags=[
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   meta = {

--- a/pkgs/development/compilers/ghc/6.10.4.nix
+++ b/pkgs/development/compilers/ghc/6.10.4.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   configureFlags=[
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";

--- a/pkgs/development/compilers/ghc/6.11.nix
+++ b/pkgs/development/compilers/ghc/6.11.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   configureFlags=[
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   preConfigure=[

--- a/pkgs/development/compilers/ghc/6.12.1-binary.nix
+++ b/pkgs/development/compilers/ghc/6.12.1-binary.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     (if stdenv.isLinux then ''
       find . -type f -perm +100 \
-          -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${ncurses}/lib:${gmp}/lib" {} \;
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2

--- a/pkgs/development/compilers/ghc/6.12.1.nix
+++ b/pkgs/development/compilers/ghc/6.12.1.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/6.12.2.nix
+++ b/pkgs/development/compilers/ghc/6.12.2.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";

--- a/pkgs/development/compilers/ghc/6.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.4.2-binary.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   # find readline/gmp.
   postBuild = if stdenv.isLinux then "
     find . -type f -perm +100 \\
-        -exec patchelf --interpreter \"$(cat $NIX_GCC/nix-support/dynamic-linker)\" \\
+        -exec patchelf --interpreter \"$(cat $NIX_CC/nix-support/dynamic-linker)\" \\
         --set-rpath \"${readline}/lib:${ncurses}/lib:${gmp}/lib\" {} \\;
   " else "";
 

--- a/pkgs/development/compilers/ghc/6.4.2.nix
+++ b/pkgs/development/compilers/ghc/6.4.2.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [readline ncurses gmp];
 
-  configureFlags = "--with-gcc=${stdenv.gcc}/bin/gcc";
+  configureFlags = "--with-gcc=${stdenv.cc}/bin/gcc";
 
   preConfigure =
     ''

--- a/pkgs/development/compilers/ghc/6.8.2.nix
+++ b/pkgs/development/compilers/ghc/6.8.2.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (rec {
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
     "--with-readline-libraries=${readline}/lib"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   preConfigure = "

--- a/pkgs/development/compilers/ghc/6.8.3.nix
+++ b/pkgs/development/compilers/ghc/6.8.3.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     "--with-gmp-libraries=${gmp}/lib"
     "--with-gmp-includes=${gmp}/include"
     "--with-readline-libraries=${readline}/lib"
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   preConfigure = ''

--- a/pkgs/development/compilers/ghc/7.0.1.nix
+++ b/pkgs/development/compilers/ghc/7.0.1.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.0.2.nix
+++ b/pkgs/development/compilers/ghc/7.0.2.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.0.3.nix
+++ b/pkgs/development/compilers/ghc/7.0.3.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     (if stdenv.isLinux then ''
       find . -type f -perm +100 \
-          -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${ncurses}/lib:${gmp}/lib" {} \;
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";

--- a/pkgs/development/compilers/ghc/7.2.1.nix
+++ b/pkgs/development/compilers/ghc/7.2.1.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";

--- a/pkgs/development/compilers/ghc/7.4.1.nix
+++ b/pkgs/development/compilers/ghc/7.4.1.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     (if stdenv.isLinux then ''
       find . -type f -perm +100 \
-          -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${ncurses}/lib:${gmp}/lib" {} \;
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.6.1.nix
+++ b/pkgs/development/compilers/ghc/7.6.1.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags=[
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.6.2.nix
+++ b/pkgs/development/compilers/ghc/7.6.2.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/gcc"
   ];
 
   # required, because otherwise all symbols from HSffi.o are stripped, and

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
   '';
 
-  configureFlags = "--with-gcc=${stdenv.gcc}/bin/gcc";
+  configureFlags = "--with-gcc=${stdenv.cc}/bin/gcc";
 
   postInstall = ''
     # ghci uses mmap with rwx protection at it implements dynamic

--- a/pkgs/development/compilers/ghc/7.8.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.8.3-binary.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     (if stdenv.isLinux then ''
       find . -type f -perm +100 \
-          -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+          -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "${ncurses}/lib:${gmp}/lib" {} \;
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--with-gcc=${stdenv.gcc}/bin/gcc"
+    "--with-gcc=${stdenv.cc}/bin/cc"
     "--with-gmp-includes=${gmp}/include" "--with-gmp-libraries=${gmp}/lib"
   ];
 

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation {
     cp -R * $out
     set +e
     for a in $out/bin/* ; do
-      patchelf --interpreter $(cat $NIX_GCC/nix-support/dynamic-linker) \
-        --set-rpath $(cat $NIX_GCC/nix-support/orig-libc)/lib:$(cat $NIX_GCC/nix-support/orig-gcc)/lib64:$(cat $NIX_GCC/nix-support/orig-gcc)/lib $a
+      patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+        --set-rpath $(cat $NIX_CC/nix-support/orig-libc)/lib:$(cat $NIX_CC/nix-support/orig-gcc)/lib64:$(cat $NIX_CC/nix-support/orig-gcc)/lib $a
     done
     set -e
     mv $out/bin/gnatgcc_2wrap $out/bin/gnatgcc

--- a/pkgs/development/compilers/go/1.3.nix
+++ b/pkgs/development/compilers/go/1.3.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchurl, fetchhg, bison, glibc, bash, coreutils, makeWrapper, tzdata, iana_etc, perl }:
 
-assert stdenv.gcc.gcc != null;
-
 let
   loader386 = "${glibc}/lib/ld-linux.so.2";
   loaderAmd64 = "${glibc}/lib/ld-linux-x86-64.so.2";
@@ -78,16 +76,16 @@ stdenv.mkDerivation {
            else throw "Unsupported system";
   GOARM = stdenv.lib.optionalString (stdenv.system == "armv5tel-linux") "5";
   GO386 = 387; # from Arch: don't assume sse2 on i686
-  CGO_ENABLED = 1;
+  CGO_ENABLED = if stdenv.isDarwin then 0 else 1;
 
   installPhase = ''
     export CC=cc
-
+  '' + stdenv.lib.optionalString (stdenv ? gcc) ''
     # http://lists.science.uu.nl/pipermail/nix-dev/2013-October/011891.html
     # Fix for "libgcc_s.so.1 must be installed for pthread_cancel to work"
     # during tests:
-    export LD_LIBRARY_PATH="$(dirname $(echo ${stdenv.gcc.gcc}/lib/libgcc_s.so))"
-
+    export LD_LIBRARY_PATH="$(dirname $(echo ${stdenv.cc.gcc}/lib/libgcc_s.so))"
+  '' + ''
     mkdir -p "$out/bin"
     export GOROOT="$(pwd)/"
     export GOBIN="$out/bin"

--- a/pkgs/development/compilers/idris/wrapper.nix
+++ b/pkgs/development/compilers/idris/wrapper.nix
@@ -1,4 +1,4 @@
-{ gmp, makeWrapper, gcc, runCommand, idris_plain, boehmgc}:
+{ stdenv, gmp, makeWrapper, runCommand, idris_plain, boehmgc}:
 
 runCommand "idris-wrapper" {} ''
   source ${makeWrapper}/nix-support/setup-hook
@@ -6,6 +6,6 @@ runCommand "idris-wrapper" {} ''
   ln -s ${idris_plain}/bin/idris $out/bin
       wrapProgram $out/bin/idris \
         --suffix NIX_CFLAGS_COMPILE : '"-I${gmp}/include -L${gmp}/lib -L${boehmgc}/lib"' \
-        --suffix PATH : ${gcc}/bin \
+        --suffix PATH : ${stdenv.cc}/bin \
         --suffix PATH : ${idris_plain}/bin
 ''

--- a/pkgs/development/compilers/julia/0.2.1.nix
+++ b/pkgs/development/compilers/julia/0.2.1.nix
@@ -4,7 +4,7 @@
  , tcl, tk, xproto, libX11, git, mpfr
  } :
 let
-  realGcc = stdenv.gcc.gcc;
+  realGcc = stdenv.cc.gcc;
 in
 stdenv.mkDerivation rec {
   pname = "julia";

--- a/pkgs/development/compilers/llvm/3.3/clang.nix
+++ b/pkgs/development/compilers/llvm/3.3/clang.nix
@@ -2,7 +2,7 @@
 
 let
   version = "3.3";
-  gccReal = if (stdenv.gcc.gcc or null) == null then stdenv.gcc else stdenv.gcc.gcc;
+  gccReal = if (stdenv.cc.gcc or null) == null then stdenv.cc else stdenv.cc.gcc;
 in
 
 stdenv.mkDerivation {
@@ -11,15 +11,15 @@ stdenv.mkDerivation {
   buildInputs = [ perl llvm groff cmake libxml2 python ];
 
   patches = [ ./clang-tablegen-dir.patch ] ++
-            stdenv.lib.optional (stdenv.gcc.libc != null) ./clang-purity.patch;
+            stdenv.lib.optional (stdenv.cc.libc != null) ./clang-purity.patch;
 
   cmakeFlags = [
     "-DCLANG_PATH_TO_LLVM_BUILD=${llvm}"
     "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_TARGETS_TO_BUILD=all"
     "-DGCC_INSTALL_PREFIX=${gccReal}"
-  ] ++ stdenv.lib.optionals (stdenv.gcc.libc != null) [
-    "-DC_INCLUDE_DIRS=${stdenv.gcc.libc}/include/"
+  ] ++ stdenv.lib.optionals (stdenv.cc.libc != null) [
+    "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include/"
   ];
 
   enableParallelBuilding = true;
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
       sha256 = "15mrvw43s4frk1j49qr4v5viq68h8qlf10qs6ghd6mrsmgj5vddi";
   };
 
-  passthru = { gcc = stdenv.gcc.gcc; };
+  passthru = { gcc = stdenv.cc.gcc; };
 
   meta = {
     homepage = http://clang.llvm.org/;

--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -1,9 +1,5 @@
 { stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src }:
 
-# be sure not to rebuild clang on darwin; some packages request it specifically
-# we need to fix those
-assert stdenv.isDarwin -> stdenv.gcc.nativeTools;
-
 stdenv.mkDerivation {
   name = "clang-${version}";
 
@@ -28,8 +24,8 @@ stdenv.mkDerivation {
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DCLANG_PATH_TO_LLVM_BUILD=${llvm}"
   ] ++
-  (stdenv.lib.optional (stdenv.gcc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.gcc.libc}/include") ++
-  (stdenv.lib.optional (stdenv.gcc.gcc != null) "-DGCC_INSTALL_PREFIX=${stdenv.gcc.gcc}");
+  (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include") ++
+  (stdenv.lib.optional (stdenv.cc.gcc != null) "-DGCC_INSTALL_PREFIX=${stdenv.cc.gcc}");
 
   # Clang expects to find LLVMgold in its own prefix
   # Clang expects to find sanitizer libraries in its own prefix
@@ -38,7 +34,7 @@ stdenv.mkDerivation {
     ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
   '';
 
-  passthru.gcc = stdenv.gcc.gcc;
+  passthru.gcc = stdenv.cc.gcc;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/mentor/default.nix
+++ b/pkgs/development/compilers/mentor/default.nix
@@ -18,7 +18,7 @@ let
         tar --strip-components=1 -xjf "$src" -C "$out"
 
         # Patch binaries
-        interpreter="$(cat "$NIX_GCC"/nix-support/dynamic-linker)"
+        interpreter="$(cat "$NIX_CC"/nix-support/dynamic-linker)"
         for file in "$out"/bin/* "$out"/libexec/gcc/*/*/* "$out"/*/bin/*; do
             # Skip non-executable files
             case "$file" in

--- a/pkgs/development/compilers/mozart/builder.sh
+++ b/pkgs/development/compilers/mozart/builder.sh
@@ -14,7 +14,7 @@ patchShebangs $out
 for f in $out/bin/*; do
   b=$(basename $f)
   if [ $b == "ozemulator" ] || [ $b == "ozwish" ]; then
-     patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
 	 --set-rpath $libPath \
 	 $f
     continue;

--- a/pkgs/development/compilers/opendylan/bin.nix
+++ b/pkgs/development/compilers/opendylan/bin.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     mkdir -p "$out"
     tar --strip-components=1 -xjf "$src" -C "$out"
 
-    interpreter="$(cat "$NIX_GCC"/nix-support/dynamic-linker)"
+    interpreter="$(cat "$NIX_CC"/nix-support/dynamic-linker)"
     for a in "$out"/bin/*; do 
       patchelf --set-interpreter "$interpreter" "$a"
       patchelf --set-rpath "$out/lib:${boehmgc}/lib" "$a"

--- a/pkgs/development/compilers/oraclejdk/dlj-bundle-builder.sh
+++ b/pkgs/development/compilers/oraclejdk/dlj-bundle-builder.sh
@@ -5,7 +5,7 @@ unzip ${src} || true
 
 # set the dynamic linker of unpack200, necessary for construct script
 echo "patching unpack200"
-patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" --set-rpath "" */bin/unpack200
+patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "" */bin/unpack200
 
 echo "constructing JDK and JRE installations"
 if test -z "$installjdk"; then
@@ -46,7 +46,7 @@ rpath=$rpath${rpath:+:}$jrePath/lib/$architecture/jli
 
 # set all the dynamic linkers
 find $out -type f -perm +100 \
-    -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
     --set-rpath "$rpath" {} \;
 
 find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -143,7 +143,7 @@ let result = stdenv.mkDerivation rec {
 
     # set all the dynamic linkers
     find $out -type f -perm +100 \
-        -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "$rpath" {} \;
 
     find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
@@ -173,8 +173,8 @@ let result = stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.gcc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf atk] ++
-    (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt xlibs.libXrender stdenv.gcc.gcc] else []);
+    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xlibs.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf atk] ++
+    (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt xlibs.libXrender stdenv.cc.gcc] else []);
 
   passthru.mozillaPlugin = if installjdk then "/jre/lib/${architecture}/plugins" else "/lib/${architecture}/plugins";
 

--- a/pkgs/development/compilers/oraclejdk/jdk6-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk6-linux.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.gcc.libc] ++
+    [stdenv.cc.libc] ++
     (if swingSupport then [xlibs.libX11 xlibs.libXext xlibs.libXtst xlibs.libXi xlibs.libXp xlibs.libXt] else []);
 
   inherit swingSupport pluginSupport architecture jce;

--- a/pkgs/development/compilers/path64/default.nix
+++ b/pkgs/development/compilers/path64/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   patchPhase = ''
     sed -i s,/usr/bin/ld,$(type -P ld), src/driver/phases.c
-    sed -i s,/lib64/ld-linux-x86-64.so.2,${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2, src/include/main_defs.h.in
+    sed -i s,/lib64/ld-linux-x86-64.so.2,${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2, src/include/main_defs.h.in
   '';
 
   cmakeFlags = ''
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     -DPATH64_ENABLE_PSCRUNTIME=OFF
     -DPATH64_ENABLE_PROFILING=OFF -DPATH64_ENABLE_TARGETS=x8664 
     -DCMAKE_BUILD_TYPE=Debug -DPATH64_ENABLE_FORTRAN=OFF
-    -DPSC_CRT_PATH=${stdenv.gcc.libc}/lib
+    -DPSC_CRT_PATH=${stdenv.cc.libc}/lib
   '';
 
   makeFlags = "-j4";

--- a/pkgs/development/compilers/rustc/0.12.nix
+++ b/pkgs/development/compilers/rustc/0.12.nix
@@ -1,7 +1,5 @@
 {stdenv, fetchurl, which, file, perl, curl, python27, makeWrapper}:
 
-assert stdenv.gcc.gcc != null;
-
 /* Rust's build process has a few quirks :
 
 - It requires some patched in llvm that haven't landed upstream, so it
@@ -53,21 +51,22 @@ in stdenv.mkDerivation {
       mkdir -p "$out"
       cp -r bin "$out/bin"
     '' + (if stdenv.isLinux then ''
-      patchelf --interpreter "${stdenv.glibc}/lib/${stdenv.gcc.dynamicLinker}" \
-               --set-rpath "${stdenv.gcc.gcc}/lib/:${stdenv.gcc.gcc}/lib64/" \
+      patchelf --interpreter "${stdenv.glibc}/lib/${stdenv.cc.dynamicLinker}" \
+               --set-rpath "${stdenv.cc.gcc}/lib/:${stdenv.cc.gcc}/lib64/" \
                "$out/bin/rustc"
     '' else "");
   };
 
-  configureFlags = [ "--enable-local-rust" "--local-rust-root=$snapshot" ];
+  configureFlags = [ "--enable-local-rust" "--local-rust-root=$snapshot" ]
+                ++ stdenv.lib.optional (stdenv.cc ? clang) "--enable-clang";
 
   # The compiler requires cc, so we patch the source to tell it where to find it
   patches = [ ./hardcode_paths.patch ./local_stage0.patch ];
   postPatch = ''
     substituteInPlace src/librustc/back/link.rs \
-      --subst-var-by "ccPath" "${stdenv.gcc}/bin/cc"
+      --subst-var-by "ccPath" "${stdenv.cc}/bin/cc"
     substituteInPlace src/librustc_back/archive.rs \
-      --subst-var-by "arPath" "${stdenv.gcc.binutils}/bin/ar"
+      --subst-var-by "arPath" "${stdenv.cc.binutils}/bin/ar"
   '';
 
   buildInputs = [ which file perl curl python27 makeWrapper ];

--- a/pkgs/development/compilers/sbcl/1.2.0.nix
+++ b/pkgs/development/compilers/sbcl/1.2.0.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation rec {
 
     sed -e '5,$d' -i contrib/sb-bsd-sockets/tests.lisp
     sed -e '5,$d' -i contrib/sb-simple-streams/*test*.lisp
+
+    # Use whatever `cc` the stdenv provides
+    substituteInPlace src/runtime/Config.x86-64-darwin --replace gcc cc
   '';
 
   preBuild = ''

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
 
     sed -e '5,$d' -i contrib/sb-bsd-sockets/tests.lisp
     sed -e '5,$d' -i contrib/sb-simple-streams/*test*.lisp
+
+    # Use whatever `cc` the stdenv provides
+    substituteInPlace src/runtime/Config.x86-64-darwin --replace gcc cc
   '';
 
   preBuild = ''

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    configureFlagsArray+=("--elfinterp=$(cat $NIX_GCC/nix-support/dynamic-linker)")
+    configureFlagsArray+=("--elfinterp=$(cat $NIX_CC/nix-support/dynamic-linker)")
     configureFlagsArray+=("--crtprefix=${stdenv.glibc}/lib")
     configureFlagsArray+=("--sysincludepaths=${stdenv.glibc}/include:{B}/include")
     configureFlagsArray+=("--libpaths=${stdenv.glibc}/lib")

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "077yakksxvdjlmwgc9wlz9jnkr345sikqjchvmxyv0axga5bw4rj";
   };
 
-  buildInputs = [ stdenv.gcc file openssl mlton mysql postgresql sqlite ];
+  buildInputs = [ stdenv.cc file openssl mlton mysql postgresql sqlite ];
 
   prePatch = ''
     sed -e 's@/usr/bin/file@${file}/bin/file@g' -i configure
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   preConfigure =
     ''
-      export CC="${stdenv.gcc}/bin/gcc";
+      export CC="${stdenv.cc}/bin/gcc";
       export CCARGS="-I$out/include \
                       -L${mysql}/lib/mysql -L${postgresql}/lib -L${sqlite}/lib";
 

--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, guile, texinfo}:
 
-assert stdenv ? gcc && stdenv.gcc ? gcc && stdenv.gcc.gcc != null;
+assert stdenv ? cc && stdenv.cc ? gcc && stdenv.cc.gcc != null;
 
 stdenv.mkDerivation rec {
   name = "guile-lib-0.2.2";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   preCheck =
     # Make `libgcc_s.so' visible for `pthread_cancel'.
-    '' export LD_LIBRARY_PATH="$(dirname $(echo ${stdenv.gcc.gcc}/lib*/libgcc_s.so)):$LD_LIBRARY_PATH"
+    '' export LD_LIBRARY_PATH="$(dirname $(echo ${stdenv.cc.gcc}/lib*/libgcc_s.so)):$LD_LIBRARY_PATH"
     '';
 
   meta = {

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -R * $out/
     echo $libPath
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
              --set-rpath $libPath \
              $out/bin/dart
     
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
         sha256 = "00935c4vxfj2h3x354g75qdazswwissbwc7kj5k05l1m3lizikf6";
       };
  
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc ];
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.gcc ];
  
   dontStrip = true;
 }

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -14,10 +14,12 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace Makefile \
       --replace /usr/local $out
-  '' + stdenv.lib.optionalString (stdenv.gcc.libc != null)
+
+    substituteInPlace src/Makefile --replace gcc cc
+  '' + stdenv.lib.optionalString (stdenv.cc.libc != null)
   ''
     substituteInPlace Makefile \
-      --replace ldconfig ${stdenv.gcc.libc}/sbin/ldconfig
+      --replace ldconfig ${stdenv.cc.libc}/sbin/ldconfig
   '';
 
   configurePhase = false;

--- a/pkgs/development/interpreters/perl/5.16/default.nix
+++ b/pkgs/development/interpreters/perl/5.16/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  libc = if stdenv.gcc.libc or null != null then stdenv.gcc.libc else "/usr";
+  libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
 
 in
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
       ''}
     '';
 
-  preBuild = lib.optionalString (!(stdenv ? gcc && stdenv.gcc.nativeTools))
+  preBuild = lib.optionalString (!(stdenv ? cc && stdenv.cc.nativeTools))
     ''
       # Make Cwd work on NixOS (where we don't have a /bin/pwd).
       substituteInPlace dist/Cwd/Cwd.pm --replace "'/bin/pwd'" "'$(type -tP pwd)'"

--- a/pkgs/development/interpreters/perl/5.20/default.nix
+++ b/pkgs/development/interpreters/perl/5.20/default.nix
@@ -14,7 +14,7 @@ assert enableThreading -> (stdenv ? glibc);
 
 let
 
-  libc = if stdenv.gcc.libc or null != null then stdenv.gcc.libc else "/usr";
+  libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
 
 in
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   # Miniperl needs -lm. perl needs -lrt.
   configureFlags =
     [ "-de"
-      "-Dcc=gcc"
+      "-Dcc=cc"
       "-Uinstallusrbinperl"
       "-Dinstallstyle=lib/perl5"
       "-Duseshrplib"
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
       ''}
     '';
 
-  preBuild = optionalString (!(stdenv ? gcc && stdenv.gcc.nativeTools))
+  preBuild = optionalString (!(stdenv ? cc && stdenv.cc.nativeTools))
     ''
       # Make Cwd work on NixOS (where we don't have a /bin/pwd).
       substituteInPlace dist/PathTools/Cwd.pm --replace "'/bin/pwd'" "'$(type -tP pwd)'"

--- a/pkgs/development/interpreters/pypy/2.4/default.nix
+++ b/pkgs/development/interpreters/pypy/2.4/default.nix
@@ -22,13 +22,13 @@ let
     };
 
     buildInputs = [ bzip2 openssl pkgconfig pythonFull libffi ncurses expat sqlite tk tcl x11 libX11 makeWrapper ]
-      ++ stdenv.lib.optional (stdenv ? gcc && stdenv.gcc.libc != null) stdenv.gcc.libc
+      ++ stdenv.lib.optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc
       ++ stdenv.lib.optional zlibSupport zlib;
 
     C_INCLUDE_PATH = stdenv.lib.concatStringsSep ":" (map (p: "${p}/include") buildInputs);
     LIBRARY_PATH = stdenv.lib.concatStringsSep ":" (map (p: "${p}/lib") buildInputs);
     LD_LIBRARY_PATH = stdenv.lib.concatStringsSep ":" (map (p: "${p}/lib") 
-      (stdenv.lib.filter (x : x.outPath != stdenv.gcc.libc.outPath or "") buildInputs));
+      (stdenv.lib.filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs));
 
     preConfigure = ''
       substituteInPlace Makefile \

--- a/pkgs/development/interpreters/python/2.6/default.nix
+++ b/pkgs/development/interpreters/python/2.6/default.nix
@@ -44,7 +44,7 @@ let
     '';
 
   buildInputs =
-    optional (stdenv ? gcc && stdenv.gcc.libc != null) stdenv.gcc.libc ++
+    optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc ++
     [ bzip2 openssl ]++ optionals includeModules [ db openssl ncurses gdbm readline x11 tcl tk sqlite ]
     ++ optional zlibSupport zlib;
 

--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -47,7 +47,7 @@ let
     '';
 
   buildInputs =
-    optional (stdenv ? gcc && stdenv.gcc.libc != null) stdenv.gcc.libc ++
+    optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc ++
     [ bzip2 openssl ] ++ optionals includeModules [ db openssl ncurses gdbm libX11 readline x11 tcl tk sqlite ]
     ++ optional zlibSupport zlib;
 

--- a/pkgs/development/interpreters/xulrunner/default.nix
+++ b/pkgs/development/interpreters/xulrunner/default.nix
@@ -7,7 +7,7 @@
 , debugBuild ? false
 }:
 
-assert stdenv.gcc ? libc && stdenv.gcc.libc != null;
+assert stdenv.cc ? libc && stdenv.cc.libc != null;
 
 let version = firefox.version; in
 

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -17,8 +17,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ python bzip2 zlib gmp openssl boost ];
 
   configurePhase = ''
-    python configure.py --prefix=$out --with-gnump --with-bzip2 --with-zlib --with-openssl
+    python configure.py --prefix=$out --with-gnump --with-bzip2 --with-zlib --with-openssl --cc=$CC
   '';
+
+  enableParallelBuilding = true;
 
   postInstall = ''
     cd "$out"/lib/pkgconfig

--- a/pkgs/development/libraries/fmod/default.nix
+++ b/pkgs/development/libraries/fmod/default.nix
@@ -5,7 +5,7 @@ let
   bits = stdenv.lib.optionalString (stdenv.system == "x86_64-linux") "64";
 
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.gcc.libc stdenv.gcc.gcc ] + ":${stdenv.gcc.gcc}/lib64";
+    [ stdenv.cc.libc stdenv.cc.gcc ] + ":${stdenv.cc.gcc}/lib64";
   patchLib = x: "patchelf --set-rpath ${libPath} ${x}";
 in
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation (rec {
   enableParallelBuilding = true;
 
   crossAttrs = {
-    buildInputs = stdenv.lib.optional (stdenv.gccCross.libc ? libiconv)
-      stdenv.gccCross.libc.libiconv.crossDrv;
+    buildInputs = stdenv.lib.optional (stdenv.ccCross.libc ? libiconv)
+      stdenv.ccCross.libc.libiconv.crossDrv;
     # Gettext fails to guess the cross compiler
     configureFlags = "CXX=${stdenv.cross.config}-g++";
   };

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -7,7 +7,7 @@
 
 with stdenv.lib;
 
-assert stdenv.gcc.gcc != null;
+assert !stdenv.isDarwin -> stdenv.cc ? gcc;
 
 # TODO:
 # * Add gio-module-fam
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   preCheck = optionalString doCheck
     # libgcc_s.so.1 must be installed for pthread_cancel to work
     # also point to the glib/.libs path
-    '' export LD_LIBRARY_PATH="${stdenv.gcc.gcc}/lib:$NIX_BUILD_TOP/${name}/glib/.libs:$LD_LIBRARY_PATH"
+    '' export LD_LIBRARY_PATH="${stdenv.cc.gcc}/lib:$NIX_BUILD_TOP/${name}/glib/.libs:$LD_LIBRARY_PATH"
        export TZDIR="${tzdata}/share/zoneinfo"
        export XDG_CACHE_HOME="$TMP"
        export XDG_RUNTIME_HOME="$TMP"

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -167,8 +167,8 @@ stdenv.mkDerivation ({
 
     configureScript="`pwd`/../$sourceRoot/configure"
 
-    ${stdenv.lib.optionalString (stdenv.gcc.libc != null)
-      ''makeFlags="$makeFlags BUILD_LDFLAGS=-Wl,-rpath,${stdenv.gcc.libc}/lib"''
+    ${stdenv.lib.optionalString (stdenv.cc.libc != null)
+      ''makeFlags="$makeFlags BUILD_LDFLAGS=-Wl,-rpath,${stdenv.cc.libc}/lib"''
     }
 
     ${preConfigure}

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -8,7 +8,7 @@
 , withGd ? false, gd ? null, libpng ? null
 }:
 
-assert stdenv.gcc.gcc != null;
+assert stdenv.cc ? gcc;
 
 let
   build = import ./common.nix;
@@ -33,9 +33,9 @@ in
     # libgcc_s will not be at {gcc}/lib, and gcc's libgcc will be found without
     # any special hack.
     preInstall = ''
-      if [ -f ${stdenv.gcc.gcc}/lib/libgcc_s.so.1 ]; then
+      if [ -f ${stdenv.cc.gcc}/lib/libgcc_s.so.1 ]; then
           mkdir -p $out/lib
-          cp ${stdenv.gcc.gcc}/lib/libgcc_s.so.1 $out/lib/libgcc_s.so.1
+          cp ${stdenv.cc.gcc}/lib/libgcc_s.so.1 $out/lib/libgcc_s.so.1
       fi
     '';
 

--- a/pkgs/development/libraries/haskell/cuda/default.nix
+++ b/pkgs/development/libraries/haskell/cuda/default.nix
@@ -9,7 +9,7 @@ cabal.mkDerivation (self: {
   isLibrary = true;
   isExecutable = true;
   buildTools = [ c2hs ];
-  extraLibraries = [ cudatoolkit nvidia_x11 self.stdenv.gcc ];
+  extraLibraries = [ cudatoolkit nvidia_x11 self.stdenv.cc ];
   doCheck = false;
   # Perhaps this should be the default in cabal.nix ...
   #

--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   NROFF = "${groff}/bin/nroff";
 
   postInstall = ''
-    sed -i ${stdenv.lib.optionalString (stdenv.isDarwin && stdenv.gcc.nativeTools) "''"} s/-lncurses/-lncursesw/g $out/lib/pkgconfig/libedit.pc
+    sed -i ${stdenv.lib.optionalString (stdenv.isDarwin && stdenv.cc.nativeTools) "''"} s/-lncurses/-lncursesw/g $out/lib/pkgconfig/libedit.pc
   '';
 
   configureFlags = [ "--enable-widec" ];

--- a/pkgs/development/libraries/libopensc-dnie/default.nix
+++ b/pkgs/development/libraries/libopensc-dnie/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     ar x opensc-dnie*
     tar xf data.tar.gz
 
-    RPATH=${glib}/lib:${opensc}/lib:${openssl}/lib:${openct}/lib:${libtool}/lib:${pcsclite}/lib:${stdenv.gcc.libc}/lib:${zlib}/lib
+    RPATH=${glib}/lib:${opensc}/lib:${openssl}/lib:${openct}/lib:${libtool}/lib:${pcsclite}/lib:${stdenv.cc.libc}/lib:${zlib}/lib
 
     for a in "usr/lib/"*.so*; do
         if ! test -L $a; then

--- a/pkgs/development/libraries/libre/default.nix
+++ b/pkgs/development/libraries/libre/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     "USE_ZLIB=1" "USE_OPENSSL=1" 
     ''PREFIX=$(out)''
   ]
-  ++ stdenv.lib.optional (stdenv.gcc.gcc != null) "SYSROOT_ALT=${stdenv.gcc.gcc}"
-  ++ stdenv.lib.optional (stdenv.gcc.libc != null) "SYSROOT=${stdenv.gcc.libc}"
+  ++ stdenv.lib.optional (stdenv.cc.gcc != null) "SYSROOT_ALT=${stdenv.cc.gcc}"
+  ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.cc.libc}"
   ;
   meta = {
     homepage = "http://www.creytiv.com/re.html";

--- a/pkgs/development/libraries/librem/default.nix
+++ b/pkgs/development/libraries/librem/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     "LIBRE_INC=${libre}/include/re"
     ''PREFIX=$(out)''
   ]
-  ++ stdenv.lib.optional (stdenv.gcc.gcc != null) "SYSROOT_ALT=${stdenv.gcc.gcc}"
-  ++ stdenv.lib.optional (stdenv.gcc.libc != null) "SYSROOT=${stdenv.gcc.libc}"
+  ++ stdenv.lib.optional (stdenv.cc.gcc != null) "SYSROOT_ALT=${stdenv.cc.gcc}"
+  ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.cc.libc}"
   ;
   meta = {
     homepage = "http://www.creytiv.com/rem.html";

--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
   };
   preConfigure = ''
-    sed -e 's@/usr/include/linux@${stdenv.gcc.libc}/include/linux@g' -i configure
+    sed -e 's@/usr/include/linux@${stdenv.cc.libc}/include/linux@g' -i configure
   '';
   meta = {
     inherit (s) version;

--- a/pkgs/development/libraries/pdf2xml/default.nix
+++ b/pkgs/development/libraries/pdf2xml/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation {
     sed -i 's|XPDF = xpdf_3.01|XPDF = ${libxpdf}/lib|' Makefile
 
     mkdir exe
+
+    buildFlags+=" CXX=$CXX"
   '';
   
   installPhase = ''

--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -11,12 +11,12 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ zlib freetype libjpeg libtiff fontconfig openssl libpng ];
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ lua5 stdenv.gcc.libc ];
+  buildInputs = [ lua5 stdenv.cc.libc ];
 
   crossAttrs = {
     propagatedBuildInputs = [ zlib.crossDrv freetype.crossDrv libjpeg.crossDrv
       libtiff.crossDrv fontconfig.crossDrv openssl.crossDrv libpng.crossDrv
-      lua5.crossDrv stdenv.gccCross.libc ];
+      lua5.crossDrv stdenv.ccCross.libc ];
   };
 
   # fix finding freetype-2.5

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # remove impure reference to /usr/lib/libstdc++.6.dylib
     # there might be more references, but this is the only one I could find
     substituteInPlace tools/macdeployqt/tests/tst_deployment_mac.cpp \
-      --replace /usr/lib/libstdc++.6.dylib "${stdenv.gcc}/lib/libstdc++.6.dylib"
+      --replace /usr/lib/libstdc++.6.dylib "${stdenv.cc}/lib/libstdc++.6.dylib"
   '';
 
   patches =
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       (substituteAll {
         src = ./dlopen-absolute-paths.diff;
         inherit cups icu libXfixes;
-        glibc = stdenv.gcc.libc;
+        glibc = stdenv.cc.libc;
         openglDriver = if mesaSupported then mesa.driverLink else "/no-such-path";
       })
     ] ++ stdenv.lib.optional gtkStyle (substituteAll {

--- a/pkgs/development/libraries/scmccid/default.nix
+++ b/pkgs/development/libraries/scmccid/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, patchelf, libusb}:
 
-assert stdenv ? gcc && stdenv.gcc.libc != null;
+assert stdenv ? cc && stdenv.cc.libc != null;
 
 stdenv.mkDerivation rec {
   name = "scmccid-5.0.11";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ patchelf ];
 
   installPhase = ''
-    RPATH=${libusb}/lib:${stdenv.gcc.libc}/lib
+    RPATH=${libusb}/lib:${stdenv.cc.libc}/lib
 
     for a in proprietary/*/Contents/Linux/*.so*; do
         if ! test -L $a; then

--- a/pkgs/development/libraries/serf/default.nix
+++ b/pkgs/development/libraries/serf/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     scons PREFIX="$out" OPENSSL="${openssl}" ZLIB="${zlib}" APR="$(echo "${apr}"/bin/*-config)" \
         APU="$(echo "${aprutil}"/bin/*-config)" GSSAPI="${krb5}" CC="${
-          if stdenv.isDarwin then "clang" else "${stdenv.gcc}/bin/gcc"
+          if stdenv.isDarwin then "clang" else "${stdenv.cc}/bin/gcc"
         }"
   '';
 

--- a/pkgs/development/libraries/strigi/default.nix
+++ b/pkgs/development/libraries/strigi/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   CLUCENE_HOME = clucene_core;
 
   buildInputs =
-    [ zlib bzip2 stdenv.gcc.libc libxml2 qt4 exiv2 clucene_core fam dbus_tools ];
+    [ zlib bzip2 stdenv.cc.libc libxml2 qt4 exiv2 clucene_core fam dbus_tools ];
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
 

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -57,8 +57,8 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = if stdenv.isDarwin then ''
-    install_name_tool -change /usr/local/lib/libv8.dylib $out/lib/libv8.dylib -change /usr/lib/libgcc_s.1.dylib ${stdenv.gcc.gcc}/lib/libgcc_s.1.dylib $out/bin/d8
-    install_name_tool -id $out/lib/libv8.dylib -change /usr/lib/libgcc_s.1.dylib ${stdenv.gcc.gcc}/lib/libgcc_s.1.dylib $out/lib/libv8.dylib
+    install_name_tool -change /usr/local/lib/libv8.dylib $out/lib/libv8.dylib -change /usr/lib/libgcc_s.1.dylib ${stdenv.cc.gcc}/lib/libgcc_s.1.dylib $out/bin/d8
+    install_name_tool -id $out/lib/libv8.dylib -change /usr/lib/libgcc_s.1.dylib ${stdenv.cc.gcc}/lib/libgcc_s.1.dylib $out/lib/libv8.dylib
   '' else null;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/wtk/builder.sh
+++ b/pkgs/development/libraries/wtk/builder.sh
@@ -22,6 +22,6 @@ for i in $libraries; do
     rpath=$rpath${rpath:+:}$i/lib
 done
 find $out -type f -perm +100 \
-    -exec patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" {} \;
+    -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" {} \;
 find $out -type f -perm +100 \
     -exec patchelf --set-rpath "$rpath" {} \;

--- a/pkgs/development/libraries/wtk/default.nix
+++ b/pkgs/development/libraries/wtk/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ unzip ];
 
-  libraries = [ xlibs.libXpm xlibs.libXt xlibs.libX11 xlibs.libICE xlibs.libSM stdenv.gcc.gcc ];
+  libraries = [ xlibs.libXpm xlibs.libXt xlibs.libX11 xlibs.libICE xlibs.libSM stdenv.cc.gcc ];
 
   meta = {
     homepage = http://java.sun.com/products/sjwtoolkit/download.html;

--- a/pkgs/development/misc/amdapp-sdk/default.nix
+++ b/pkgs/development/misc/amdapp-sdk/default.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
 
   patchFlags = "-p0";
   buildInputs = [ makeWrapper perl mesa xorg.libX11 xorg.libXext xorg.libXaw xorg.libXi xorg.libXxf86vm ];
-  propagatedBuildInputs = [ stdenv.gcc ];
+  propagatedBuildInputs = [ stdenv.cc ];
   NIX_LDFLAGS = "-lX11 -lXext -lXmu -lXi -lXxf86vm";
   doCheck = false;
 
@@ -81,13 +81,13 @@ in stdenv.mkDerivation rec {
       cp -r "./samples/opencl/bin/${arch}/"* "$out/samples/opencl/bin"
       for f in $(find "$out/samples/opencl/bin/" -type f -not -name "*.*");
       do
-        wrapProgram "$f" --prefix PATH ":" "${stdenv.gcc}/bin"
+        wrapProgram "$f" --prefix PATH ":" "${stdenv.cc}/bin"
       done'' else ""
     }
 
     # Create wrappers
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/bin/clinfo
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib $out/bin/clinfo
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/clinfo
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib $out/bin/clinfo
 
     # Fix modes
     find "$out/" -type f -exec chmod 644 {} \;

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     find $out \( \
         \( -type f -a -name "*.so*" \) -o \
         \( -type f -a -perm /0100 \) \
-        \) -exec patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-*so.? \
+        \) -exec patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-*so.? \
                           --set-rpath ${zlib}/lib:${ncurses}/lib {} \;
     # fix ineffective PROGDIR / MYNDKDIR determination
     for i in ndk-build ndk-gdb ndk-gdb-py

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -43,8 +43,8 @@ stdenv.mkDerivation rec {
         
         for i in emulator64-arm emulator64-mips emulator64-x86
         do
-            patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2 $i
-            patchelf --set-rpath ${stdenv.gcc.gcc}/lib64 $i
+            patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 $i
+            patchelf --set-rpath ${stdenv.cc.gcc}/lib64 $i
         done
       ''}
       
@@ -80,11 +80,11 @@ stdenv.mkDerivation rec {
         # The monitor requires some more patching
         
         cd lib/monitor-x86
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux.so.2 monitor
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 monitor
         patchelf --set-rpath ${libX11}/lib:${libXext}/lib:${libXrender}/lib:${freetype}/lib:${fontconfig}/lib libcairo-swt.so
         
         wrapProgram `pwd`/monitor \
-          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.gcc.gcc}/lib
+          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.cc.gcc}/lib
 
         cd ../..
       ''
@@ -93,11 +93,11 @@ stdenv.mkDerivation rec {
         # The monitor requires some more patching
         
         cd lib/monitor-x86_64
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2 monitor
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 monitor
         patchelf --set-rpath ${libX11}/lib:${libXext}/lib:${libXrender}/lib:${freetype}/lib:${fontconfig}/lib libcairo-swt.so
         
         wrapProgram `pwd`/monitor \
-          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.gcc.gcc}/lib
+          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.cc.gcc}/lib
 
         cd ../..
       ''

--- a/pkgs/development/mobile/flashtool/default.nix
+++ b/pkgs/development/mobile/flashtool/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     ln -s ${libusb1}/lib/libusb-1.0.so.0 ./x10flasher_lib/linux/lib32/libusbx-1.0.so
 
     chmod +x x10flasher_lib/unyaffs.linux.x86 x10flasher_lib/bin2elf x10flasher_lib/bin2sin
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" x10flasher_lib/unyaffs.linux.x86
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" x10flasher_lib/unyaffs.linux.x86
     ln -sf unyaffs.linux.x86 x10flasher_lib/unyaffs.linux
 
     ln -s swt32.jar x10flasher_lib/swtlin/swt.jar

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-3.1.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-3.1.nix
@@ -45,11 +45,11 @@ stdenv.mkDerivation {
     
     ${if stdenv.system == "i686-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
       ''
       else if stdenv.system == "x86_64-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
       ''
       else ""}
     

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-3.2.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-3.2.nix
@@ -44,11 +44,11 @@ stdenv.mkDerivation {
     
     ${if stdenv.system == "i686-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
       ''
       else if stdenv.system == "x86_64-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
       ''
       else ""}
     

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-3.3.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-3.3.nix
@@ -44,11 +44,11 @@ stdenv.mkDerivation {
     
     ${if stdenv.system == "i686-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
       ''
       else if stdenv.system == "x86_64-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
       ''
       else ""}
     

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-3.4.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-3.4.nix
@@ -44,11 +44,11 @@ stdenv.mkDerivation {
     
     ${if stdenv.system == "i686-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 titanium_prep.linux32
       ''
       else if stdenv.system == "x86_64-linux" then
       ''
-        patchelf --set-interpreter ${stdenv.gcc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
+        patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 titanium_prep.linux64
       ''
       else ""}
     

--- a/pkgs/development/tools/atom-shell/default.nix
+++ b/pkgs/development/tools/atom-shell/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     unzip -d $out/bin $src
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
     $out/bin/atom
     mv $out/bin/atom $out/bin/atom-shell
     wrapProgram $out/bin/atom-shell \

--- a/pkgs/development/tools/build-managers/cargo/common.nix
+++ b/pkgs/development/tools/build-managers/cargo/common.nix
@@ -37,8 +37,8 @@ rec {
       mkdir -p "$out"
       cp -r bin "$out/bin"
     '' + (if stdenv.isLinux then ''
-      patchelf --interpreter "${stdenv.glibc}/lib/${stdenv.gcc.dynamicLinker}" \
-               --set-rpath "${stdenv.gcc.gcc}/lib/:${stdenv.gcc.gcc}/lib64/:${zlib}/lib" \
+      patchelf --interpreter "${stdenv.glibc}/lib/${stdenv.cc.dynamicLinker}" \
+               --set-rpath "${stdenv.cc.gcc}/lib/:${stdenv.cc.gcc}/lib64/:${zlib}/lib" \
                "$out/bin/cargo"
     '' else "");
   };

--- a/pkgs/development/tools/cdecl/default.nix
+++ b/pkgs/development/tools/cdecl/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   preBuild = ''
     ${gnused}/bin/sed 's/getline/cdecl_getline/g' -i cdecl.c;
     makeFlagsArray=(CFLAGS="-DBSD -DUSE_READLINE -std=gnu89" LIBS=-lreadline);
-    makeFlags="$makeFlags PREFIX=$out BINDIR=$out/bin MANDIR=$out/man1 CATDIR=$out/cat1";
+    makeFlags="$makeFlags PREFIX=$out BINDIR=$out/bin MANDIR=$out/man1 CATDIR=$out/cat1 CC=$CC";
     mkdir -p $out/bin;
   '';
   buildInputs = [yacc flex readline ncurses];

--- a/pkgs/development/tools/misc/cflow/default.nix
+++ b/pkgs/development/tools/misc/cflow/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace "src/cflow.h"					\
       --replace "/usr/bin/cpp"						\
-                "$(cat ${stdenv.gcc}/nix-support/orig-gcc)/bin/cpp"
+                "$(cat ${stdenv.cc}/nix-support/orig-gcc)/bin/cpp"
   '';
 
   buildInputs = [ gettext ] ++

--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -62,8 +62,8 @@ stdenv.mkDerivation rec {
     cp -r * "$out"
 
     # Patch it
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" "$out/Logic"
-    patchelf --set-rpath "${stdenv.gcc.gcc}/lib:${stdenv.gcc.gcc}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$out/Logic"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/Logic"
+    patchelf --set-rpath "${stdenv.cc.gcc}/lib:${stdenv.cc.gcc}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$out/Logic"
 
     # Build the LD_PRELOAD library that makes Logic work from a read-only directory
     mkdir -p "$out/lib"

--- a/pkgs/development/tools/node-webkit/default.nix
+++ b/pkgs/development/tools/node-webkit/default.nix
@@ -10,7 +10,7 @@ let
     paths = [
       xlibs.libX11 xlibs.libXrender glib gtk atk pango cairo gdk_pixbuf
       freetype fontconfig xlibs.libXcomposite alsaLib xlibs.libXdamage
-      xlibs.libXext xlibs.libXfixes nss nspr gconf expat dbus stdenv.gcc.gcc
+      xlibs.libXext xlibs.libXfixes nss nspr gconf expat dbus stdenv.cc.gcc
       xlibs.libXtst xlibs.libXi
     ];
   };
@@ -30,8 +30,8 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/node-webkit
     cp -R * $out/share/node-webkit
 
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/share/node-webkit/nw
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/share/node-webkit/nwsnapshot
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/node-webkit/nw
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/share/node-webkit/nwsnapshot
 
     ln -s ${udev}/lib/libudev.so $out/share/node-webkit/libudev.so.0
 

--- a/pkgs/development/tools/phantomjs/default.nix
+++ b/pkgs/development/tools/phantomjs/default.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
 
   buildPhase = if stdenv.isDarwin then "" else ''
     patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-      --set-rpath "${freetype}/lib:${fontconfig}/lib:${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${openssl}/lib" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${freetype}/lib:${fontconfig}/lib:${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${openssl}/lib" \
       bin/phantomjs
   '';
 

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     mv chromedriver $out/bin
     patchelf --set-interpreter ${glibc}/lib/ld-linux-x86-64.so.2 $out/bin/chromedriver
     wrapProgram "$out/bin/chromedriver" \
-      --prefix LD_LIBRARY_PATH : "$(cat ${stdenv.gcc}/nix-support/orig-gcc)/lib64:${cairo}/lib:${fontconfig}/lib:${freetype}/lib:${gdk_pixbuf}/lib:${glib}/lib:${gtk}/lib:${libX11}/lib:${nspr}/lib:${nss}/lib:${pango}/lib:${libXrender}/lib:${gconf}/lib:${libXext}/lib:${libXi}/lib:\$LD_LIBRARY_PATH"
+      --prefix LD_LIBRARY_PATH : "$(cat ${stdenv.cc}/nix-support/orig-gcc)/lib64:${cairo}/lib:${fontconfig}/lib:${freetype}/lib:${gdk_pixbuf}/lib:${glib}/lib:${gtk}/lib:${libX11}/lib:${nspr}/lib:${nss}/lib:${pango}/lib:${libXrender}/lib:${gconf}/lib:${libXext}/lib:${libXi}/lib:\$LD_LIBRARY_PATH"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
     ${jdk}/bin/jar xf $src launchers/launcher-linux-amd64
     patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${gcc.gcc}/lib/:${gcc.gcc}/lib64:${xlibs.libX11}/lib" \
       launchers/launcher-linux-${arch}
     ${jdk}/bin/jar uf $src launchers/launcher-linux-${arch}

--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -7,7 +7,7 @@ let
 
   inherit (xlibs) libXext libX11;
 
-  lpath = "${stdenv.gcc.gcc}/lib64:" + stdenv.lib.makeSearchPath "lib" [
+  lpath = "${stdenv.cc.gcc}/lib64:" + stdenv.lib.makeSearchPath "lib" [
       zlib libmad libpng12 libcaca libXext libX11 mesa alsaLib pulseaudio];
 
 in
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     done
 
     ${patchelf}/bin/patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "$out/lib:${lpath}" \
       $out/adom
 

--- a/pkgs/games/andyetitmoves/default.nix
+++ b/pkgs/games/andyetitmoves/default.nix
@@ -41,14 +41,14 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{opt/andyetitmoves,bin}
     cp -r * $out/opt/andyetitmoves/
 
-    fullPath=${stdenv.gcc.gcc}/lib64
+    fullPath=${stdenv.cc.gcc}/lib64
     for i in $nativeBuildInputs; do
       fullPath=$fullPath''${fullPath:+:}$i/lib
     done
 
     binName=${if commercialVersion then "AndYetItMoves" else "AndYetItMovesDemo"}
 
-    patchelf --set-interpreter $(cat $NIX_GCC/nix-support/dynamic-linker) --set-rpath $fullPath $out/opt/andyetitmoves/lib/$binName
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath $fullPath $out/opt/andyetitmoves/lib/$binName
     cat > $out/bin/$binName << EOF
     #!/bin/sh
     cd $out/opt/andyetitmoves

--- a/pkgs/games/banner/default.nix
+++ b/pkgs/games/banner/default.nix
@@ -12,9 +12,9 @@ let
       sha256 = hash;
     };
 
-    configurePhase = "make dep";
+    configurePhase = "make dep CC=$CC";
 
-    buildPhase = "make OPTIM='-DNDEBUG -O3'";
+    buildPhase = "make OPTIM='-DNDEBUG -O3' CC=$CC";
 
     installPhase = ''
       make INSTBASEDIR=$out install

--- a/pkgs/games/castle-combat/default.nix
+++ b/pkgs/games/castle-combat/default.nix
@@ -39,8 +39,8 @@ buildPythonPackage rec {
   fixLoaderPath =
     let dollar = "\$"; in
     '' sed -i "$out/bin/castle-combat" \
-           -e "/^exec/ iexport LD_LIBRARY_PATH=\"$(cat ${stdenv.gcc}/nix-support/orig-gcc)/lib\:"'${dollar}'"LD_LIBRARY_PATH\"\\
-export LD_LIBRARY_PATH=\"$(cat ${stdenv.gcc}/nix-support/orig-gcc)/lib64\:"'${dollar}'"LD_LIBRARY_PATH\""
+           -e "/^exec/ iexport LD_LIBRARY_PATH=\"$(cat ${stdenv.cc}/nix-support/orig-gcc)/lib\:"'${dollar}'"LD_LIBRARY_PATH\"\\
+export LD_LIBRARY_PATH=\"$(cat ${stdenv.cc}/nix-support/orig-gcc)/lib64\:"'${dollar}'"LD_LIBRARY_PATH\""
     '';
       # ^
       # `--- The run-time says: "libgcc_s.so.1 must be installed for

--- a/pkgs/games/gemrb/default.nix
+++ b/pkgs/games/gemrb/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, cmake, SDL, openal, zlib, libpng, python, libvorbis }:
 
-assert stdenv.gcc.libc != null;
+assert stdenv.cc.libc != null;
 
 stdenv.mkDerivation rec {
   name = "gemrb-0.8.1";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   # TODO: make libpng, libvorbis, sdl_mixer, freetype, vlc, glew (and other gl reqs) optional
 
   # Necessary to find libdl.
-  CMAKE_LIBRARY_PATH = "${stdenv.gcc.libc}/lib";
+  CMAKE_LIBRARY_PATH = "${stdenv.cc.libc}/lib";
 
   # Can't have -werror because of the Vorbis header files.
   cmakeFlags = "-DDISABLE_WERROR=ON -DCMAKE_VERBOSE_MAKEFILE=ON";

--- a/pkgs/games/gsb/default.nix
+++ b/pkgs/games/gsb/default.nix
@@ -25,18 +25,18 @@ stdenv.mkDerivation rec {
   phases = "unpackPhase installPhase";
 
   # XXX: stdenv.lib.makeLibraryPath doesn't pick up /lib64
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc stdenv.gcc.libc ] 
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.gcc stdenv.cc.libc ] 
     + ":" + stdenv.lib.makeLibraryPath [ SDL SDL_image libjpeg62 libpng12 mesa ]
     + ":" + stdenv.lib.makeLibraryPath [ curl3 openal libvorbis libogg ]
     + ":" + stdenv.lib.makeLibraryPath [ libX11 libXext libXft fontconfig zlib ]
-    + ":" + stdenv.gcc.gcc + "/lib64";
+    + ":" + stdenv.cc.gcc + "/lib64";
 
   installPhase = ''
     mkdir -p $out/libexec/positech/GSB/
     mkdir -p $out/bin
 
     patchelf \
-      --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath $libPath \
       ./GSB.bin.$arch
 

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -23,27 +23,27 @@ stdenv.mkDerivation {
     cd bin
     for f in launcher_$arch libQtCoreUnigine_$arch.so.4 OilRush_$arch
     do
-      patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $f
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $f
     done
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXrender}/lib:${fontconfig}/lib:${freetype}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXrender}/lib:${fontconfig}/lib:${freetype}/lib\
              launcher_$arch
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib\
              libNetwork_$arch.so
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib\
              libQtCoreUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXrender}/lib:${fontconfig}/lib:${freetype}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXrender}/lib:${fontconfig}/lib:${freetype}/lib\
              libQtGuiUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib\
              libQtNetworkUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXrender}/lib:${fontconfig}/lib:${freetype}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXrender}/lib:${fontconfig}/lib:${freetype}/lib\
              libQtWebKitUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib\
              libQtXmlUnigine_$arch.so.4
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib\
              libRakNet_$arch.so
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXinerama}/lib:${libXrandr}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXinerama}/lib:${libXrandr}/lib\
              libUnigine_$arch.so
-    patchelf --set-rpath ${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXinerama}/lib:${libXrandr}/lib\
+    patchelf --set-rpath ${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib:${libX11}/lib:${libXext}/lib:${libXinerama}/lib:${libXrandr}/lib\
              OilRush_$arch
   '';
   installPhase = ''

--- a/pkgs/games/planetaryannihilation/default.nix
+++ b/pkgs/games/planetaryannihilation/default.nix
@@ -34,13 +34,13 @@ stdenv.mkDerivation {
 
     ln -s ${systemd}/lib/libudev.so.1 $out/lib/libudev.so.0
 
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" "$out/PA"
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc xlibs.libXdamage xorg.libXfixes gtk glib stdenv.glibc "$out" xlibs.libXext pango udev xlibs.libX11 xlibs.libXcomposite alsaLib atk nspr fontconfig cairo pango nss freetype gnome3.gconf gdk_pixbuf xlibs.libXrender ]}:{stdenv.gcc.gcc}/lib64:${stdenv.glibc}/lib64" "$out/host/CoherentUI_Host.bin" 
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/PA"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.gcc xlibs.libXdamage xorg.libXfixes gtk glib stdenv.glibc "$out" xlibs.libXext pango udev xlibs.libX11 xlibs.libXcomposite alsaLib atk nspr fontconfig cairo pango nss freetype gnome3.gconf gdk_pixbuf xlibs.libXrender ]}:{stdenv.cc.gcc}/lib64:${stdenv.glibc}/lib64" "$out/host/CoherentUI_Host.bin" 
 
-    wrapProgram $out/PA --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc stdenv.glibc xlibs.libX11 xlibs.libXcursor gtk glib curl "$out" ]}:${stdenv.gcc.gcc}/lib64:${stdenv.glibc}/lib64"
+    wrapProgram $out/PA --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.gcc stdenv.glibc xlibs.libX11 xlibs.libXcursor gtk glib curl "$out" ]}:${stdenv.cc.gcc}/lib64:${stdenv.glibc}/lib64"
 
     for f in $out/lib/*; do
-      patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc curl xlibs.libX11 stdenv.glibc xlibs.libXcursor "$out" ]}:${stdenv.gcc.gcc}/lib64:${stdenv.glibc}/lib64" $f
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.gcc curl xlibs.libX11 stdenv.glibc xlibs.libXcursor "$out" ]}:${stdenv.cc.gcc}/lib64:${stdenv.glibc}/lib64" $f
     done
   '';
 

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   
   inherit game paks mesa name;
 
-  gcc = stdenv.gcc.gcc;
+  gcc = stdenv.cc.gcc;
   
   meta = {
     inherit description;

--- a/pkgs/games/sdlmame/default.nix
+++ b/pkgs/games/sdlmame/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
-      --set-rpath "${alsaLib}/lib:${qt48}/lib:${SDL}/lib:${fontconfig}/lib:${freetype}/lib:${SDL_ttf}/lib:${xlibs.libX11}/lib:${xlibs.libXinerama}/lib:${stdenv.gcc.gcc}/lib" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${alsaLib}/lib:${qt48}/lib:${SDL}/lib:${fontconfig}/lib:${freetype}/lib:${SDL_ttf}/lib:${xlibs.libX11}/lib:${xlibs.libXinerama}/lib:${stdenv.cc.gcc}/lib" \
       share/sdlmame/sdlmame
 
     mkdir -p "$out/bin"

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram "$out/bin/spring" \
-      --prefix LD_LIBRARY_PATH : "${stdenv.gcc.gcc}/lib::${systemd}/lib"
+      --prefix LD_LIBRARY_PATH : "${stdenv.cc.gcc}/lib::${systemd}/lib"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/tibia/default.nix
+++ b/pkgs/games/tibia/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     cp -r * $out/res
 
     patchelf --set-interpreter ${glibc}/lib/ld-linux.so.2 \
-             --set-rpath ${stdenv.gcc.gcc}/lib:${libX11}/lib:${mesa}/lib \
+             --set-rpath ${stdenv.cc.gcc}/lib:${libX11}/lib:${mesa}/lib \
              "$out/res/Tibia"
 
     # We've patchelf'd the files. The main ‘Tibia’ binary is a bit

--- a/pkgs/games/tremulous/default.nix
+++ b/pkgs/games/tremulous/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   patches = [ ./parse.patch ];
   patchFlags = "-p 0";
   NIX_LD_FLAGS = ''
-    -rpath ${stdenv.gcc}/lib
-    -rpath ${stdenv.gcc}/lib64
+    -rpath ${stdenv.cc}/lib
+    -rpath ${stdenv.cc}/lib64
   '';
   buildPhase = ''
     cd Release_1.011

--- a/pkgs/games/ue4demos/default.nix
+++ b/pkgs/games/ue4demos/default.nix
@@ -12,7 +12,7 @@ let
 
       rtdeps = stdenv.lib.makeLibraryPath
         [ xlibs.libXxf86vm xlibs.libXext openal ]
-        + ":" + stdenv.lib.makeSearchPath "lib64" [ stdenv.gcc.gcc ];
+        + ":" + stdenv.lib.makeSearchPath "lib64" [ stdenv.cc.gcc ];
 
       buildCommand =
       ''

--- a/pkgs/games/ultrastardx/default.nix
+++ b/pkgs/games/ultrastardx/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   # The fpc is not properly wrapped to add -rpath. I add this manually.
   # I even do a trick on lib/lib64 for libgcc, that I expect it will work.
   preBuild = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath ${SDL}/lib -rpath ${SDL_image}/lib -rpath ${libpng}/lib -rpath ${freetype}/lib -rpath ${portaudio}/lib -rpath ${ffmpeg}/lib -rpath ${zlib}/lib -rpath ${sqlite}/lib -rpath ${libX11}/lib -rpath ${pcre}/lib -rpath ${lua}/lib -rpath ${stdenv.gcc.gcc}/lib64 -rpath ${stdenv.gcc.gcc}/lib"
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath ${SDL}/lib -rpath ${SDL_image}/lib -rpath ${libpng}/lib -rpath ${freetype}/lib -rpath ${portaudio}/lib -rpath ${ffmpeg}/lib -rpath ${zlib}/lib -rpath ${sqlite}/lib -rpath ${libX11}/lib -rpath ${pcre}/lib -rpath ${lua}/lib -rpath ${stdenv.cc.gcc}/lib64 -rpath ${stdenv.cc.gcc}/lib"
 
     sed -i 414,424d Makefile
   '';

--- a/pkgs/games/ut2004demo/builder.sh
+++ b/pkgs/games/ut2004demo/builder.sh
@@ -25,5 +25,5 @@ mkdir $out
 
 # Set the ELF interpreter to our own Glibc.
 for i in "$out/System/ucc-bin" "$out/System/ut2004-bin"; do
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" "$i"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$i"
 done

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   phases = "installPhase";
   ld_preload = ./isatty.c;
 
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc stdenv.gcc.libc ] 
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.gcc stdenv.cc.libc ] 
     + ":" + stdenv.lib.makeLibraryPath [ SDL pulseaudio alsaLib ] ;
 
   installPhase = ''
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     echo @@@ 
 
     # if we call ld.so $(bin) we don't need to set the ELF interpreter, and save a patchelf step. 
-    LD_PRELOAD=./isatty.so $(cat $NIX_GCC/nix-support/dynamic-linker) $src << IM_A_BOT
+    LD_PRELOAD=./isatty.so $(cat $NIX_CC/nix-support/dynamic-linker) $src << IM_A_BOT
     n
     $out/libexec/strangeloop/vessel/
     IM_A_BOT
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     # props to Ethan Lee (the Vessel porter) for understanding
     # how $ORIGIN works in rpath. There is hope for humanity. 
     patchelf \
-      --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath $libPath:$out/libexec/strangeloop/vessel/x86/ \
       $out/libexec/strangeloop/vessel/x86/vessel.x86
 

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -45,15 +45,15 @@ stdenv.mkDerivation rec {
   phases = "unpackPhase installPhase";
 
   # XXX: stdenv.lib.makeLibraryPath doesn't pick up /lib64
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc stdenv.gcc.libc ] 
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.gcc stdenv.cc.libc ] 
     + ":" + stdenv.lib.makeLibraryPath [libX11 libXext libXau libxcb libXdmcp SDL SDL_mixer libvorbis mesa ]
-    + ":" + stdenv.gcc.gcc + "/lib64";
+    + ":" + stdenv.cc.gcc + "/lib64";
 
   installPhase = ''
     mkdir -p $out/libexec/2dboy/WorldOfGoo/
     mkdir -p $out/bin
 
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" --set-rpath $libPath ./WorldOfGoo.bin64
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath $libPath ./WorldOfGoo.bin64
 
     cp -r * $out/libexec/2dboy/WorldOfGoo/
 

--- a/pkgs/misc/cups/drivers/samsung/builder.sh
+++ b/pkgs/misc/cups/drivers/samsung/builder.sh
@@ -28,7 +28,7 @@ ln -s ppd model
 cd $out/lib/cups/filter
 for i in $(ls); do
     echo patching $i...
-    patchelf --set-interpreter $(cat $NIX_GCC/nix-support/dynamic-linker) $i || echo "(couldn't set interpreter)"
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $i || echo "(couldn't set interpreter)"
     patchelf --set-rpath $cups/lib:$gcc/lib:$glibc/lib $i  # This might not be necessary.
 done
 

--- a/pkgs/misc/drivers/gutenprint/bin.nix
+++ b/pkgs/misc/drivers/gutenprint/bin.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
 
   phases = "buildPhase";
 
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.gcc zlib ];
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.gcc zlib ];
 
   buildPhase = ''
     ar -x $src data.tar.gz
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
         $out/cups/lib/backend/{canon,epson} \
         $out/sbin/cups-genppd.5.0 \
       ; do
-      patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath $libPath $p
     done
     

--- a/pkgs/misc/emulators/wine/stable.nix
+++ b/pkgs/misc/emulators/wine/stable.nix
@@ -4,7 +4,7 @@
 }:
 
 assert stdenv.isLinux;
-assert stdenv.gcc.gcc != null;
+assert stdenv.cc.gcc != null;
 
 let
     version = "1.6.2";
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
   # them to the RPATH so that the user doesn't have to set them in
   # LD_LIBRARY_PATH.
   NIX_LDFLAGS = map (path: "-rpath ${path}/lib ") [
-    freetype fontconfig stdenv.gcc.gcc mesa mesa_noglu.osmesa libdrm
+    freetype fontconfig stdenv.cc.gcc mesa mesa_noglu.osmesa libdrm
     xlibs.libXinerama xlibs.libXrender xlibs.libXrandr
     xlibs.libXcursor xlibs.libXcomposite libpng libjpeg
     openssl gnutls cups
@@ -65,7 +65,7 @@ in stdenv.mkDerivation rec {
 
     paxmark psmr $out/bin/wine{,-preloader}
 
-    wrapProgram $out/bin/wine --prefix LD_LIBRARY_PATH : ${stdenv.gcc.gcc}/lib
+    wrapProgram $out/bin/wine --prefix LD_LIBRARY_PATH : ${stdenv.cc.gcc}/lib
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/misc/emulators/wine/unstable.nix
+++ b/pkgs/misc/emulators/wine/unstable.nix
@@ -4,7 +4,7 @@
 }:
 
 assert stdenv.isLinux;
-assert stdenv.gcc.gcc != null;
+assert stdenv.cc.gcc != null;
 
 let
     version = "1.7.33";
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
   # them to the RPATH so that the user doesn't have to set them in
   # LD_LIBRARY_PATH.
   NIX_LDFLAGS = map (path: "-rpath ${path}/lib ") [
-    freetype fontconfig stdenv.gcc.gcc mesa mesa_noglu.osmesa libdrm
+    freetype fontconfig stdenv.cc.gcc mesa mesa_noglu.osmesa libdrm
     xlibs.libXinerama xlibs.libXrender xlibs.libXrandr
     xlibs.libXcursor xlibs.libXcomposite libpng libjpeg
     openssl gnutls cups ncurses
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
     install -D ${gecko} $out/share/wine/gecko/${gecko64.name}
   '' + ''
     install -D ${mono} $out/share/wine/mono/${mono.name}
-    wrapProgram $out/bin/wine --prefix LD_LIBRARY_PATH : ${stdenv.gcc.gcc}/lib
+    wrapProgram $out/bin/wine --prefix LD_LIBRARY_PATH : ${stdenv.cc.gcc}/lib
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/misc/foldingathome/default.nix
+++ b/pkgs/misc/foldingathome/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   installPhase = ''
     BINFILES="fah6 mpiexec";
     for a in $BINFILES; do 
-      patchelf --set-interpreter $(cat $NIX_GCC/nix-support/dynamic-linker) $a
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $a
     done
     mkdir -p $out/bin
     cp $BINFILES $out/bin

--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -58,7 +58,7 @@
 
 { mkDerivation, substituteAll, pkgs }:
     { stdenv ? pkgs.stdenv, name, buildInputs ? []
-    , propagatedBuildInputs ? [], gcc ? stdenv.gcc, cTags ? [], extraCmds ? ""
+    , propagatedBuildInputs ? [], gcc ? stdenv.cc, cTags ? [], extraCmds ? ""
     , cleanupCmds ? "", shell ? "${pkgs.bashInteractive}/bin/bash --norc"}:
 
 mkDerivation {

--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
 
   inherit libXxf86vm xf86vidmodeproto;
-  gcc = stdenv.gcc.gcc;
+  gcc = stdenv.cc.gcc;
 
   src = fetchurl {
     url = http://www2.ati.com/drivers/linux/amd-catalyst-omega-14.12-linux-run-installers.zip;

--- a/pkgs/os-specific/linux/cpufrequtils/default.nix
+++ b/pkgs/os-specific/linux/cpufrequtils/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       -i Makefile
   '';
 
-  buildInputs = [ stdenv.gcc.libc.kernelHeaders libtool gettext ];
+  buildInputs = [ stdenv.cc.libc.kernelHeaders libtool gettext ];
 
   meta = {
     description = "Tools to display or change the CPU governor settings";

--- a/pkgs/os-specific/linux/nvidia-x11/builder-legacy173.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder-legacy173.sh
@@ -81,7 +81,7 @@ installPhase() {
 
         for i in nvidia-settings nvidia-xconfig; do
 	    cp usr/bin/$i $out/bin/$i
-	    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+	    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
 	        --set-rpath $out/lib:$programPath:$glPath $out/bin/$i
         done
     

--- a/pkgs/os-specific/linux/nvidia-x11/builder-legacy304.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder-legacy304.sh
@@ -72,7 +72,7 @@ installPhase() {
 
         for i in nvidia-settings nvidia-xconfig; do
 	    cp $i $out/bin/$i
-	    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+	    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
 	        --set-rpath $out/lib:$programPath:$glPath $out/bin/$i
         done
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder-legacy340.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder-legacy340.sh
@@ -51,7 +51,7 @@ installPhase() {
 
         for i in nvidia-settings nvidia-smi; do
             cp $i $out/bin/$i
-            patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+            patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
                 --set-rpath $out/lib:$programPath:$glPath $out/bin/$i
         done
 

--- a/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   glPath = stdenv.lib.makeLibraryPath [xlibs.libXext xlibs.libX11 xlibs.libXrandr];
 
-  cudaPath = stdenv.lib.makeLibraryPath [zlib stdenv.gcc.gcc];
+  cudaPath = stdenv.lib.makeLibraryPath [zlib stdenv.cc.gcc];
 
   programPath = stdenv.lib.makeLibraryPath [ gtk atk pango glib gdk_pixbuf xlibs.libXv ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   glPath = stdenv.lib.makeLibraryPath [xlibs.libXext xlibs.libX11 xlibs.libXrandr];
 
-  cudaPath = stdenv.lib.makeLibraryPath [zlib stdenv.gcc.gcc];
+  cudaPath = stdenv.lib.makeLibraryPath [zlib stdenv.cc.gcc];
 
   programPath = optionalString (!libsOnly) (stdenv.lib.makeLibraryPath
     [ gtk atk pango glib gdk_pixbuf xlibs.libXv ] );

--- a/pkgs/os-specific/linux/nvidia-x11/legacy340.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy340.nix
@@ -45,9 +45,9 @@ stdenv.mkDerivation {
   dontStrip = true;
 
   glPath      = makeLibraryPath [xlibs.libXext xlibs.libX11 xlibs.libXrandr];
-  cudaPath    = makeLibraryPath [zlib stdenv.gcc.gcc];
+  cudaPath    = makeLibraryPath [zlib stdenv.cc.gcc];
   openclPath  = makeLibraryPath [zlib];
-  allLibPath  = makeLibraryPath [xlibs.libXext xlibs.libX11 xlibs.libXrandr zlib stdenv.gcc.gcc];
+  allLibPath  = makeLibraryPath [xlibs.libXext xlibs.libX11 xlibs.libXrandr zlib stdenv.cc.gcc];
 
   programPath = optionalString (!libsOnly) (makeLibraryPath
     [ gtk atk pango glib gdk_pixbuf xlibs.libXv ] );

--- a/pkgs/os-specific/linux/opengl/xorg-sys/default.nix
+++ b/pkgs/os-specific/linux/opengl/xorg-sys/default.nix
@@ -11,6 +11,6 @@
 stdenv.mkDerivation {
   name = "xorg-sys-opengl-3";
   builder = ./builder.sh;
-  neededLibs = [xlibs.libXxf86vm xlibs.libXext expat libdrm stdenv.gcc.gcc];
+  neededLibs = [xlibs.libXxf86vm xlibs.libXext expat libdrm stdenv.cc.gcc];
 }
 

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation rec {
 
         for i in $out/bin/* $out/sbin/*; do
           patchelf \
-            --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+            --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
             --set-rpath "$out/lib:$libPath" \
             $i
         done

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   # This is needed because systemd uses the gold linker, which doesn't
   # yet have the wrapper script to add rpath flags automatically.
-  NIX_LDFLAGS = "-rpath ${pam}/lib -rpath ${libcap}/lib -rpath ${acl}/lib -rpath ${stdenv.gcc.gcc}/lib";
+  NIX_LDFLAGS = "-rpath ${pam}/lib -rpath ${libcap}/lib -rpath ${acl}/lib -rpath ${stdenv.cc.gcc}/lib";
 
   PYTHON_BINARY = "${coreutils}/bin/env python"; # don't want a build time dependency on Python
 

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${libxml2}/include/libxml2 $additionalFlags"
-    export PATH="$PATH:${stdenv.gcc.libc}/sbin"
+    export PATH="$PATH:${stdenv.cc.libc}/sbin"
     patchShebangs .
   '';
 

--- a/pkgs/servers/monitoring/zabbix/2.0.nix
+++ b/pkgs/servers/monitoring/zabbix/2.0.nix
@@ -17,8 +17,8 @@ let
     ''
       substituteInPlace ./configure \
         --replace " -static" "" \
-        ${stdenv.lib.optionalString (stdenv.gcc.libc != null) ''
-          --replace /usr/include/iconv.h ${stdenv.gcc.libc}/include/iconv.h
+        ${stdenv.lib.optionalString (stdenv.cc.libc != null) ''
+          --replace /usr/include/iconv.h ${stdenv.cc.libc}/include/iconv.h
         ''}
     '';
 

--- a/pkgs/servers/monitoring/zabbix/2.2.nix
+++ b/pkgs/servers/monitoring/zabbix/2.2.nix
@@ -22,8 +22,8 @@ let
     ''
       substituteInPlace ./configure \
         --replace " -static" "" \
-        ${stdenv.lib.optionalString (stdenv.gcc.libc != null) ''
-          --replace /usr/include/iconv.h ${stdenv.gcc.libc}/include/iconv.h
+        ${stdenv.lib.optionalString (stdenv.cc.libc != null) ''
+          --replace /usr/include/iconv.h ${stdenv.cc.libc}/include/iconv.h
         ''}
     '';
 

--- a/pkgs/servers/monitoring/zabbix/default.nix
+++ b/pkgs/servers/monitoring/zabbix/default.nix
@@ -13,8 +13,8 @@ let
     ''
       substituteInPlace ./configure \
         --replace " -static" "" \
-        ${stdenv.lib.optionalString (stdenv.gcc.libc != null) ''
-          --replace /usr/include/iconv.h ${stdenv.gcc.libc}/include/iconv.h
+        ${stdenv.lib.optionalString (stdenv.cc.libc != null) ''
+          --replace /usr/include/iconv.h ${stdenv.cc.libc}/include/iconv.h
         ''}
     '';
 

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -D influxdb $out/bin/influxdb
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/bin/influxdb
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/influxdb
     wrapProgram "$out/bin/influxdb" \
-        --prefix LD_LIBRARY_PATH : "${stdenv.gcc.gcc}/lib:${stdenv.gcc.gcc}/lib64:${zlib}/lib:${bzip2}/lib"
+        --prefix LD_LIBRARY_PATH : "${stdenv.cc.gcc}/lib:${stdenv.cc.gcc}/lib64:${zlib}/lib:${bzip2}/lib"
 
     mkdir -p $out/share/influxdb
     cp -R admin scripts config.toml $out/share/influxdb

--- a/pkgs/servers/restund/default.nix
+++ b/pkgs/servers/restund/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
     ''PREFIX=$(out)''
     "USE_MYSQL=1"
   ]
-  ++ stdenv.lib.optional (stdenv.gcc.gcc != null) "SYSROOT_ALT=${stdenv.gcc.gcc}"
-  ++ stdenv.lib.optional (stdenv.gcc.libc != null) "SYSROOT=${stdenv.gcc.libc}"
+  ++ stdenv.lib.optional (stdenv.cc.gcc != null) "SYSROOT_ALT=${stdenv.cc.gcc}"
+  ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.cc.libc}"
   ;
   NIX_LDFLAGS='' -L${mysql}/lib/mysql '';
   meta = {

--- a/pkgs/servers/samba/default.nix
+++ b/pkgs/servers/samba/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
          "--localstatedir=/var"
        ]
     ++ (stdenv.lib.optional winbind "--with-winbind")
-    ++ (stdenv.lib.optional (stdenv.gcc.libc != null) "--with-libiconv=${stdenv.gcc.libc}");
+    ++ (stdenv.lib.optional (stdenv.cc.libc != null) "--with-libiconv=${stdenv.cc.libc}");
 
   # Need to use a DESTDIR because `make install' tries to write in /var and /etc.
   installFlags = "DESTDIR=$(TMPDIR)/inst";

--- a/pkgs/servers/sql/oracle-xe/default.nix
+++ b/pkgs/servers/sql/oracle-xe/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       \( -name '*.sh' \
       -o -path "$basedir/bin/*" \
       \) -print -exec "${patchelf}/bin/patchelf" \
-           --interpreter "$(cat "$NIX_GCC/nix-support/dynamic-linker")" \
+           --interpreter "$(cat "$NIX_CC/nix-support/dynamic-linker")" \
            --set-rpath "${libs}:$out/libexec/oracle/lib" \
            --force-rpath '{}' \;
   '';

--- a/pkgs/servers/sql/virtuoso/6.x.nix
+++ b/pkgs/servers/sql/virtuoso/6.x.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libxml2 openssl readline gawk ];
 
-  CPP = "${stdenv.gcc}/bin/gcc -E";
+  CPP = "${stdenv.cc}/bin/gcc -E";
 
   configureFlags = "
     --enable-shared --disable-all-vads --with-readline=${readline}

--- a/pkgs/servers/sql/virtuoso/7.x.nix
+++ b/pkgs/servers/sql/virtuoso/7.x.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libxml2 openssl readline gawk ];
 
-  CPP = "${stdenv.gcc}/bin/gcc -E";
+  CPP = "${stdenv.cc}/bin/gcc -E";
 
   configureFlags = "
     --enable-shared --disable-all-vads --with-readline=${readline}

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -8,7 +8,7 @@ rec {
 
 
   # Override the compiler in stdenv for specific packages.
-  overrideGCC = stdenv: gcc: stdenv.override { allowedRequisites = null; inherit gcc; };
+  overrideGCC = stdenv: gcc: stdenv.override { allowedRequisites = null; cc = gcc; };
 
 
   # Add some arbitrary packages to buildInputs for specific packages.
@@ -235,9 +235,4 @@ rec {
       });
     };
 
-  dropCxx = drv: drv.override {
-    stdenv = if pkgs.stdenv.isDarwin
-      then pkgs.allStdenvs.stdenvDarwinNaked
-      else pkgs.stdenv;
-  };
 }

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,6 +1,6 @@
 let lib = import ../../../lib; in lib.makeOverridable (
 
-{ system, name ? "stdenv", preHook ? "", initialPath, gcc, shell
+{ system, name ? "stdenv", preHook ? "", initialPath, cc, shell
 , allowedRequisites ? null, extraAttrs ? {}, overrides ? (pkgs: {}), config
 
 , # The `fetchurl' to use for downloading curl and its dependencies
@@ -48,7 +48,7 @@ let
       ../../build-support/setup-hooks/patch-shebangs.sh
       ../../build-support/setup-hooks/move-sbin.sh
       ../../build-support/setup-hooks/move-lib64.sh
-      gcc
+      cc
     ];
 
   # Add a utility function to produce derivations that use this
@@ -198,7 +198,7 @@ let
 
       inherit overrides;
 
-      inherit gcc;
+      inherit cc;
     }
 
     # Propagate any extra attributes.  For instance, we use this to

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -83,9 +83,9 @@ rec {
           curl = bootstrapTools;
         };
 
-        gcc = if isNull gccPlain
-              then "/no-such-path"
-              else lib.makeOverridable (import ../../build-support/gcc-wrapper) {
+        cc = if isNull gccPlain
+             then "/no-such-path"
+             else lib.makeOverridable (import ../../build-support/gcc-wrapper) {
           nativeTools = false;
           nativeLibc = false;
           gcc = gccPlain;
@@ -232,7 +232,7 @@ rec {
       gcc = lib.makeOverridable (import ../../build-support/gcc-wrapper) {
         nativeTools = false;
         nativeLibc = false;
-        gcc = stage4.stdenv.gcc.gcc;
+        gcc = stage4.stdenv.cc.gcc;
         libc = stage4.pkgs.glibc;
         inherit (stage4.pkgs) binutils coreutils;
         name = "";
@@ -267,9 +267,9 @@ rec {
 
     extraBuildInputs = [ stage4.pkgs.patchelf stage4.pkgs.paxctl ];
 
-    gcc = stage4.pkgs.gcc;
+    cc = stage4.pkgs.gcc;
 
-    shell = gcc.shell;
+    shell = cc.shell;
 
     inherit (stage4.stdenv) fetchurlBoot;
 
@@ -286,7 +286,7 @@ rec {
       ];
 
     overrides = pkgs: {
-      inherit gcc;
+      inherit cc;
       inherit (stage4.pkgs)
         gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
         glibc gnumake gnused gnutar gnugrep gnupatch patchelf

--- a/pkgs/tools/admin/tightvnc/default.nix
+++ b/pkgs/tools/admin/tightvnc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   # for the builder script
   inherit xauth fontDirectories perl;
-  gcc = stdenv.gcc.gcc;
+  gcc = stdenv.cc.gcc;
 
   buildInputs = [x11 zlib libjpeg imake gccmakedep libXmu libXaw libXpm libXp xauth];
   builder = ./builder.sh;

--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     ''
        # Fix for building on Glibc 2.16.  Won't be needed once the
        # gnulib in sharutils is updated.
-       sed -i ${stdenv.lib.optionalString (stdenv.isBSD && stdenv.gcc.nativeTools) "''"} '/gets is a security hole/d' lib/stdio.in.h
+       sed -i ${stdenv.lib.optionalString (stdenv.isBSD && stdenv.cc.nativeTools) "''"} '/gets is a security hole/d' lib/stdio.in.h
     '';
 
   # GNU Gettext is needed on non-GNU platforms.

--- a/pkgs/tools/archivers/unrar/default.nix
+++ b/pkgs/tools/archivers/unrar/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation {
     sha256 = "13ida8vcamiagl40d9yfjma9k6givxczhx278f1p7bv9wgb8gfmc";
   };
 
+  preBuild = ''
+    export buildFlags="CXX=$CXX"
+  '';
+
   installPhase = ''
     installBin unrar
 

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -5,12 +5,12 @@ assert stdenv.isLinux;
 let
   p = if stdenv.is64bit then {
       arch = "x86_64";
-      gcclib = "${stdenv.gcc.gcc}/lib64";
+      gcclib = "${stdenv.cc.gcc}/lib64";
       sha256 = "09kw7f0qsvx3vx1c1zb117yf3yk7kkz66agspz5xx9b0zh6i82jw";
     }
     else {
       arch = "i386";
-      gcclib = "${stdenv.gcc.gcc}/lib";
+      gcclib = "${stdenv.cc.gcc}/lib";
       sha256 = "0f2230c91120f05159281b39c620ab6bad6559ce8a17a0874d0a82350ebba426";
     };
 in 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       $out/etc/bash_completion.d/yandex-disk-completion.bash
 
     ${patchelf}/bin/patchelf \
-      --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${zlib}/lib:${p.gcclib}" \
       $out/bin/yandex-disk
   '';

--- a/pkgs/tools/graphics/cuneiform/default.nix
+++ b/pkgs/tools/graphics/cuneiform/default.nix
@@ -31,7 +31,7 @@ rec {
   needLib64 = a.stdenv.system == "x86_64-linux";
 
   postInstall = a.fullDepEntry(''
-    patchelf --set-rpath $out/lib${if needLib64 then "64" else ""}${if a.stdenv.gcc.gcc != null then ":${a.stdenv.gcc.gcc}/lib" else ""}${if a.stdenv.gcc.gcc != null && needLib64 then ":${a.stdenv.gcc.gcc}/lib64" else ""}:${a.imagemagick}/lib $out/bin/cuneiform
+    patchelf --set-rpath $out/lib${if needLib64 then "64" else ""}${if a.stdenv.cc.gcc != null then ":${a.stdenv.cc.gcc}/lib" else ""}${if a.stdenv.cc.gcc != null && needLib64 then ":${a.stdenv.cc.gcc}/lib64" else ""}:${a.imagemagick}/lib $out/bin/cuneiform
   '') ["minInit" "addInputs" "doMakeInstall"];
 
   name = "cuneiform-" + version;

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -27,8 +27,8 @@ let
       buildInputs = [ gmp ]
         ++ optional aclSupport acl.crossDrv
         ++ optionals selinuxSupport [ libselinux.crossDrv libsepol.crossDrv ]
-        ++ optional (stdenv.gccCross.libc ? libiconv)
-          stdenv.gccCross.libc.libiconv.crossDrv;
+        ++ optional (stdenv.ccCross.libc ? libiconv)
+          stdenv.ccCross.libc.libiconv.crossDrv;
 
       buildPhase = ''
         make || (

--- a/pkgs/tools/misc/figlet/default.nix
+++ b/pkgs/tools/misc/figlet/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     mkdir -p $out/{man/man6,bin}
-    makeFlags="DESTDIR=$out/bin MANDIR=$out/man/man6 DEFAULTFONTDIR=$out/share/figlet"
+    makeFlags="DESTDIR=$out/bin MANDIR=$out/man/man6 DEFAULTFONTDIR=$out/share/figlet CC=cc LD=cc"
   '';
 
   meta = {

--- a/pkgs/tools/misc/megacli/default.nix
+++ b/pkgs/tools/misc/megacli/default.nix
@@ -15,14 +15,14 @@ stdenv.mkDerivation rec {
   buildInputs = [rpmextract ncurses unzip makeWrapper];
   libPath =
     stdenv.lib.makeLibraryPath
-       [ stdenv.gcc.gcc stdenv.gcc.libc ncurses ];
+       [ stdenv.cc.gcc stdenv.cc.libc ncurses ];
 
   buildCommand = ''
     mkdir -p $out/bin
     cd $out
     unzip ${src}
     rpmextract linux/MegaCli-8.07.07-1.noarch.rpm
-    ${patchelf}/bin/patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" --set-rpath ${libPath}:$out/opt/lsi/3rdpartylibs/x86_64:$out/opt/lsi/3rdpartylibs:${stdenv.gcc.gcc}/lib64:${stdenv.gcc.gcc}/lib opt/MegaRAID/MegaCli/MegaCli64
+    ${patchelf}/bin/patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath ${libPath}:$out/opt/lsi/3rdpartylibs/x86_64:$out/opt/lsi/3rdpartylibs:${stdenv.cc.gcc}/lib64:${stdenv.cc.gcc}/lib opt/MegaRAID/MegaCli/MegaCli64
     wrapProgram $out/opt/MegaRAID/MegaCli/MegaCli64 --set LD_LIBRARY_PATH $out/opt/lsi/3rdpartylibs/x86_64
     ln -s $out/opt/MegaRAID/MegaCli/MegaCli64 $out/bin/MegaCli64
     eval fixupPhase

--- a/pkgs/tools/networking/atftp/default.nix
+++ b/pkgs/tools/networking/atftp/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, readline, tcp_wrappers, pcre, makeWrapper }:
 assert stdenv.isLinux;
-assert stdenv.gcc.gcc != null;
+assert stdenv.cc.gcc != null;
 let
 version = "0.7";
 debianPatch = fetchurl {
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   buildInputs = [ readline tcp_wrappers pcre makeWrapper ];
   patches = [ debianPatch ];
   postInstall = ''
-    wrapProgram $out/sbin/atftpd --prefix LD_LIBRARY_PATH : ${stdenv.gcc.gcc}/lib${if stdenv.system == "x86_64-linux" then "64" else ""}
+    wrapProgram $out/sbin/atftpd --prefix LD_LIBRARY_PATH : ${stdenv.cc.gcc}/lib${if stdenv.system == "x86_64-linux" then "64" else ""}
   '';
   meta = {
     description = "Advanced tftp tools";

--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -17,13 +17,13 @@ stdenv.mkDerivation rec {
 
   # http://www.gnu.org/software/make/manual/html_node/Libraries_002fSearch.html
   preConfigure = ''
-    makeFlags=VPATH=`cat $NIX_GCC/nix-support/orig-libc`/lib
+    makeFlags=VPATH=`cat $NIX_CC/nix-support/orig-libc`/lib
   '';
 
   crossAttrs = {
     # This works for uclibc, at least.
     preConfigure = ''
-      makeFlags=VPATH=`cat ${stdenv.gccCross}/nix-support/orig-libc`/lib
+      makeFlags=VPATH=`cat ${stdenv.ccCross}/nix-support/orig-libc`/lib
     '';
   };
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     [ ( substituteAll {
         src = ./nixos-purity.patch;
         inherit avahi dnsmasq ppp bind;
-        glibc = stdenv.gcc.libc;
+        glibc = stdenv.cc.libc;
       })
       ./libnl-3.2.25.patch
     ];

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     [ ( substituteAll {
         src = ./nix-purity.patch;
         inherit libpcap;
-        glibc = stdenv.gcc.libc;
+        glibc = stdenv.cc.libc;
       })
       ./nonpriv.patch
     ];

--- a/pkgs/tools/package-management/nix-repl/default.nix
+++ b/pkgs/tools/package-management/nix-repl/default.nix
@@ -20,11 +20,11 @@ stdenv.mkDerivation {
   installPhase =
     ''
       mkdir -p $out/bin
-      g++ -O3 -Wall -std=c++0x \
+      $CXX -O3 -Wall -std=c++0x \
         -o $out/bin/nix-repl nix-repl.cc \
         -I${nix}/include/nix \
         -lnixformat -lnixutil -lnixstore -lnixexpr -lnixmain -lreadline -lgc \
-        -DNIX_VERSION=${(builtins.parseDrvName nix.name).version}
+        -DNIX_VERSION=\"${(builtins.parseDrvName nix.name).version}\"
     '';
 
   meta = {

--- a/pkgs/tools/security/fprot/default.nix
+++ b/pkgs/tools/security/fprot/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     cp f-prot.conf.default $out/opt/f-prot/f-prot.conf
     ln -s $out/opt/f-prot/fpupdate $out/bin/fpupdate
 
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" $out/opt/f-prot/fpupdate
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/f-prot/fpupdate
 
     mkdir -p $out/share/man/
     mkdir -p $out/share/man/man1

--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -4,10 +4,10 @@ assert stdenv.isLinux;
 
 let
   bits    = if stdenv.system == "x86_64-linux" then "64" else "32";
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.gcc.libc ];
+  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.libc ];
 
   fixBin = x: ''
-    patchelf --interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" \
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath ${libPath} ${x}
   '';
 in

--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -9,7 +9,7 @@ let
   torEnv = buildEnv {
     name = "tor-env";
     paths = [
-      stdenv.gcc.gcc zlib glib alsaLib dbus dbus_glib gtk atk pango freetype
+      stdenv.cc.gcc zlib glib alsaLib dbus dbus_glib gtk atk pango freetype
       fontconfig gdk_pixbuf cairo xlibs.libXrender xlibs.libX11 xlibs.libXext
       xlibs.libXt
     ];
@@ -30,8 +30,8 @@ in stdenv.mkDerivation rec {
   };
 
   patchPhase = ''
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" Browser/firefox
-    patchelf --set-interpreter "$(cat $NIX_GCC/nix-support/dynamic-linker)" Browser/TorBrowser/Tor/tor
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" Browser/firefox
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" Browser/TorBrowser/Tor/tor
   '';
 
   doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3930,9 +3930,9 @@ let
   win32hello = callPackage ../development/compilers/visual-c++/test { };
 
   wrapGCCWith = gccWrapper: glibc: baseGCC: gccWrapper {
-    nativeTools = stdenv.gcc.nativeTools or false;
-    nativeLibc = stdenv.gcc.nativeLibc or false;
-    nativePrefix = stdenv.gcc.nativePrefix or "";
+    nativeTools = stdenv.cc.nativeTools or false;
+    nativeLibc = stdenv.cc.nativeLibc or false;
+    nativePrefix = stdenv.cc.nativePrefix or "";
     gcc = baseGCC;
     libc = glibc;
     inherit stdenv binutils coreutils zlib;
@@ -5980,7 +5980,7 @@ let
   libiconvOrEmpty = if libiconvOrNull == null then [] else [libiconv];
 
   libiconvOrNull =
-    if gcc.libc or null != null || stdenv.isGlibc
+    if stdenv.cc.libc or null != null || stdenv.isGlibc
     then null
     else libiconv;
 
@@ -11229,7 +11229,7 @@ let
           ++ lib.optional (cfg.enableTrezor or false) trezor-bridge
          );
       libs = [ gstreamer gst_plugins_base ] ++ lib.optionals (cfg.enableQuakeLive or false)
-             (with xlibs; [ stdenv.gcc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ]);
+             (with xlibs; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ]);
       gst_plugins = [ gst_plugins_base gst_plugins_good gst_plugins_bad gst_plugins_ugly gst_ffmpeg ];
       gtk_modules = [ libcanberra ];
     };

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -368,7 +368,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   cairo = callPackage ../development/libraries/haskell/cairo {
     inherit (pkgs) cairo zlib;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   carray = callPackage ../development/libraries/haskell/carray {};
@@ -975,7 +975,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   glade = callPackage ../development/libraries/haskell/glade {
     inherit (pkgs.gnome) libglade;
     gtkC = pkgs.gtk;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   GLFW = callPackage ../development/libraries/haskell/GLFW {};
@@ -984,7 +984,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   glib = callPackage ../development/libraries/haskell/glib {
     glib = pkgs.glib;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   Glob = callPackage ../development/libraries/haskell/Glob {};
@@ -1023,7 +1023,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   gtk = callPackage ../development/libraries/haskell/gtk {
     inherit (pkgs) gtk;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   gtk3 = callPackage ../development/libraries/haskell/gtk3 {
@@ -1036,7 +1036,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   gtksourceview2 = callPackage ../development/libraries/haskell/gtksourceview2 {
     inherit (pkgs.gnome) gtksourceview;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   gtkTraymanager = callPackage ../development/libraries/haskell/gtk-traymanager {};
@@ -1902,7 +1902,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   pango = callPackage ../development/libraries/haskell/pango {
     inherit (pkgs) pango;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   parallel_3_2_0_3 = callPackage ../development/libraries/haskell/parallel/3.2.0.3.nix {};
@@ -2009,7 +2009,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   poppler = callPackage ../development/libraries/haskell/poppler {
     popplerGlib = pkgs.poppler.poppler_glib;
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   posixPaths = callPackage ../development/libraries/haskell/posix-paths {};
@@ -2475,7 +2475,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
   stripe = callPackage ../development/libraries/haskell/stripe {};
 
   svgcairo = callPackage ../development/libraries/haskell/svgcairo {
-    libc = pkgs.stdenv.gcc.libc;
+    libc = pkgs.stdenv.cc.libc;
   };
 
   SVGFonts = callPackage ../development/libraries/haskell/SVGFonts {};


### PR DESCRIPTION
This is done for the sake of Yosemite, which does not have gcc, and yet
this change is also compatible with Linux.

This is the first in an eventual series of PRs resulting from the `##nix-darwin` work to make darwin in nixpkgs significantly more robust. This is the only change that is expected to require major rebuilds on Linux (though more darwin rebuilds can be expected moving forward).
