### PR TITLE
Updated remind package name (otherwise unchanged).

### DIFF
--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl} :
 
 stdenv.mkDerivation {
-  name = "remind-3.1.8";
+  name = "remind-3.1.13";
   src = fetchurl {
     url = http://www.roaringpenguin.com/files/download/remind-03.01.13.tar.gz;
     sha256 = "0kzw1d53nlj90qfsibbs2gkzp1hamqqxpj57ip4kz1j1xgan69ng";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     homepage = http://www.roaringpenguin.com/products/remind;
     description = "Sophisticated calendar and alarm program for the console";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [viric raskin];
+    maintainers = with stdenv.lib.maintainers; [viric raskin kovirobi];
     platforms = with stdenv.lib.platforms; linux;
   };
 }


### PR DESCRIPTION
The source URL pointed to 03.01.13, but the name was "remind-3.1.8".
Also added myself to the maintainers list.
