### PR TITLE
mediainfo, libmediainfo, libzen: fix typo

### DIFF
--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
       MediaInfo is a convenient unified display of the most relevant technical
       and tag data for video and audio files.
     '';
-    homepage = http://mediaarena.net/;
+    homepage = http://mediaarea.net/;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Shared library for mediainfo";
-    homepage = http://mediaarena.net/;
+    homepage = http://mediaarea.net/;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Shared library for libmediainfo and mediainfo";
-    homepage = http://mediaarena.net/;
+    homepage = http://mediaarea.net/;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];


### PR DESCRIPTION
This fixes a typo in the URL name.
