### PR TITLE
nixos-option: Support -I option

### DIFF
--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -76,14 +76,23 @@ evalAttr(){
   local prefix="$1"
   local strict="$2"
   local suffix="$3"
+
+  # If strict is set, then set it to "true".
+  test -n "$strict" && strict=true
+
   evalNix ${strict:+--strict} <<EOF
 let
   reach = attrs: attrs${option:+.$option}${suffix:+.$suffix};
   nixos = import <nixos> {};
   nixpkgs = import <nixpkgs> {};
+  strict = ${strict:-false};
   cleanOutput = x: with nixpkgs.lib;
     if isDerivation x then x.outPath
     else if isFunction x then "<CODE>"
+    else if strict then
+      if isAttrs x then mapAttrs (n: cleanOutput) x
+      else if isList x then map cleanOutput x
+      else x
     else x;
 in
   cleanOutput (reach nixos.$prefix)

--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -94,7 +94,7 @@ in with nixpkgs.lib;
 # the user into accessors for reaching the definition and the declaration
 # corresponding to this option.
 generateAccessors(){
-  evalNix --strict --show-trace <<EOF
+  if result=$(evalNix --strict --show-trace <<EOF
 $header
 
 let
@@ -129,6 +129,17 @@ let
 in
   ''let option = \${walkResult.opt}; config = \${walkResult.cfg}; in''
 EOF
+)
+  then
+      echo $result
+  else
+      # In case of error we want to ignore the error message roduced by the
+      # script above, as it is iterating over each attribute, which does not
+      # produce a nice error message.  The following code is a fallback
+      # solution which is cause a nicer error message in the next
+      # evaluation.
+      echo "\"let option = nixos.options${option:+.$option}; config = nixos.config${option:+.$option}; in\""
+  fi
 }
 
 header="$header

--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -76,7 +76,18 @@ evalAttr(){
   local prefix="$1"
   local strict="$2"
   local suffix="$3"
-  echo "(import <nixos> {}).$prefix${option:+.$option}${suffix:+.$suffix}" | evalNix ${strict:+--strict}
+  evalNix ${strict:+--strict} <<EOF
+let
+  reach = attrs: attrs${option:+.$option}${suffix:+.$suffix};
+  nixos = import <nixos> {};
+  nixpkgs = import <nixpkgs> {};
+  cleanOutput = x: with nixpkgs.lib;
+    if isDerivation x then x.outPath
+    else if isFunction x then "<CODE>"
+    else x;
+in
+  cleanOutput (reach nixos.$prefix)
+EOF
 }
 
 evalOpt(){

--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -69,7 +69,18 @@ fi
 #############################
 
 evalNix(){
-  nix-instantiate - --eval-only "$@"
+  result=$(nix-instantiate - --eval-only "$@" 2>&1)
+  if test $? -eq 0; then
+      cat <<EOF
+$result
+EOF
+      return 0;
+  else
+      sed -n '/error/ { s/, at (string):[0-9]*:[0-9]*//; p; }' <<EOF
+$result
+EOF
+      return 1;
+  fi
 }
 
 evalAttr(){


### PR DESCRIPTION
This gives the ability to set the configuration file or the NIX_PATH from the command line.  This patch is forwarding the `-I` argument with its argument to the nix-instantiate calls made by nixos-option.

This patch is based on top of pull request #5405 and #5415, and fix the issue #2877.
