### PR TITLE
modules: Add mkSinkUndeclaredOptions.

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -31,6 +31,23 @@ rec {
     type = lib.types.bool;
   };
 
+  # This option accept anything, but it does not produce any result.  This
+  # is useful for sharing a module across different module sets without
+  # having to implement similar features as long as the value of the options
+  # are not expected.
+  mkSinkUndeclaredOptions = attrs: mkOption ({
+    internal = true;
+    visible = false;
+    default = false;
+    description = "Sink for option definitions.";
+    type = mkOptionType {
+      name = "sink";
+      check = x: true;
+      merge = loc: defs: false;
+    };
+    apply = x: throw "Option value is not readable because the option is not declared.";
+  } // attrs);
+
   mergeDefaultOption = loc: defs:
     let list = getValues defs; in
     if length list == 1 then head list


### PR DESCRIPTION
This option is made to create a Sink option which can accept anything and ignores everything.  An error is thrown if one of the module attempt to read anything out of it.  An error is also thrown by the module system if other option declarations are made either at the depth or deeper inside this option:

```
# Add systemd = mkSinkUndeclaredOptions {}; in installer/tools/tools.nix
$ nixos-option systemd
error: The option `systemd' in `/home/nicolas/nixos-dev/nixpkgs/nixos/modules/installer/tools/tools.nix' is a prefix of options in `/home/nicolas/nixos-dev/nixpkgs/nixos/modules/testing/service-runner.nix'.
```

This is convenient for cases where one person might want to add another option with an identical prefix.
This is also convenient for ignoring option which are made for another module-set (sal / NixOS / NixUP / …)

cc: @offlinehacker 
