### PR TITLE
Fix compiled-in /bin/bash in foomatic filters

### DIFF
--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, cups, poppler, fontconfig
-, libjpeg, libpng, perl, ijs, qpdf, dbus, bash }:
+, libjpeg, libpng, perl, ijs, qpdf, dbus, substituteAll, bash }:
 
 stdenv.mkDerivation rec {
   name = "cups-filters-${version}";
@@ -34,12 +34,12 @@ stdenv.mkDerivation rec {
       substituteInPlace filter/gstoraster.c --replace execve execvpe
     '';
 
-  patches = [ ./longer-shell-path.patch ];
-
-  postPatch =
-    ''
-      substituteInPlace filter/foomatic-rip/foomaticrip.c --replace "/bin/bash" "${bash}/bin/bash"
-    '';
+  patches = [
+    (substituteAll {
+      src = ./longer-shell-path.patch;
+      bash = "${bash}/bin/bash";
+    })
+  ];
 
   postInstall =
     ''

--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, cups, poppler, fontconfig
-, libjpeg, libpng, perl, ijs, qpdf, dbus }:
+, libjpeg, libpng, perl, ijs, qpdf, dbus, bash }:
 
 stdenv.mkDerivation rec {
   name = "cups-filters-${version}";
@@ -32,6 +32,13 @@ stdenv.mkDerivation rec {
 
       # Ensure that gstoraster can find gs in $PATH.
       substituteInPlace filter/gstoraster.c --replace execve execvpe
+    '';
+
+  patches = [ ./longer-shell-path.patch ];
+
+  postPatch =
+    ''
+      substituteInPlace filter/foomatic-rip/foomaticrip.c --replace "/bin/bash" "${bash}/bin/bash"
     '';
 
   postInstall =

--- a/pkgs/misc/cups/longer-shell-path.patch
+++ b/pkgs/misc/cups/longer-shell-path.patch
@@ -7,7 +7,7 @@ index 1c019aa..431d2f9 100644
                                  "/usr/lib/cups/filter";
  
 -char modern_shell[64] = "/bin/bash";
-+char modern_shell[128] = "/bin/bash";
++char modern_shell[128] = "@bash@";
  
  void config_set_option(const char *key, const char *value)
  {

--- a/pkgs/misc/cups/longer-shell-path.patch
+++ b/pkgs/misc/cups/longer-shell-path.patch
@@ -1,0 +1,13 @@
+diff --git a/filter/foomatic-rip/foomaticrip.c b/filter/foomatic-rip/foomaticrip.c
+index 1c019aa..431d2f9 100644
+--- a/filter/foomatic-rip/foomaticrip.c
++++ b/filter/foomatic-rip/foomaticrip.c
+@@ -174,7 +174,7 @@ char cupsfilterpath[PATH_MAX] = "/usr/local/lib/cups/filter:"
+                                 "/opt/cups/filter:"
+                                 "/usr/lib/cups/filter";
+ 
+-char modern_shell[64] = "/bin/bash";
++char modern_shell[128] = "/bin/bash";
+ 
+ void config_set_option(const char *key, const char *value)
+ {


### PR DESCRIPTION
Foomatic filters contained a 64-char c string hardcoded to /bin/bash.  This caused some filters (at least pdftops) to fail.

I also had to increase the size of the string because nix paths are too long to fit in 64 chars.
