### PR TITLE
mailcore2: new package

### DIFF
--- a/pkgs/development/libraries/libctemplate/default.nix
+++ b/pkgs/development/libraries/libctemplate/default.nix
@@ -1,22 +1,29 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchsvn, python }:
 
 stdenv.mkDerivation rec {
+  name = "ctemplate-${version}";
+
+  version = "2.3";
+
+  src = fetchsvn {
+    url = "http://ctemplate.googlecode.com/svn/tags/${name}";
+    sha256 = "1kvh82mhazf4qz7blnv0rcax7vi524dmz6v6rp89z2h3qjilbvc7";
+  };
+
+  buildInputs = [ python ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
   meta = {
     description = "A simple but powerful template language for C++";
     longDescription = ''
       CTemplate is a simple but powerful template language for C++. It
       emphasizes separating logic from presentation: it is impossible to
-      embed application logic in this template language.  '';
+      embed application logic in this template language.
+    '';
     homepage = http://code.google.com/p/google-ctemplate/;
     license = "bsd";
-  };
-
-  pname = "ctemplate";
-  version = "2.2";
-  name = "${pname}-${version}";
-
-  src = fetchurl {
-    url = "http://ctemplate.googlecode.com/files/${name}.tar.gz";
-    sha256 = "0vv8gvyndppm9m5s1i5k0jvwcz41l1vfgg04r7nssdpzyz0cpwq4";
   };
 }

--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,9 +1,19 @@
 { autoconf, automake, fetchgit, libtool, stdenv, openssl }:
 
-let version = "1.5"; in
+let version = "1.6"; in
 
 stdenv.mkDerivation {
   name = "libetpan-${version}";
+
+  src = fetchgit {
+    url = "git://github.com/dinhviethoa/libetpan";
+    rev = "refs/tags/" + version;
+    sha256 = "12n0vd0bwdyjcmwmpv1hdq5l04mqy6qfyy8mhsblddqaa1ah9qy8";
+  };
+
+  buildInputs = [ autoconf automake libtool openssl ];
+
+  configureScript = "./autogen.sh";
 
   meta = with stdenv.lib; {
     description = "An efficient, portable library for different kinds of mail access: IMAP, SMTP, POP, and NNTP";
@@ -11,14 +21,4 @@ stdenv.mkDerivation {
     license = licenses.bsd3;
     platforms = platforms.linux;
   };
-
-  src = fetchgit {
-    url = "git://github.com/dinhviethoa/libetpan";
-    rev = "refs/tags/" + version;
-    sha256 = "bf9465121a0fb09418215ee3474a400ea5bc5ed05a6811a2978afe4905e140c9";
-  };
-
-  buildInputs = [ autoconf automake libtool openssl ];
-
-  configureScript = "./autogen.sh";
 }

--- a/pkgs/development/libraries/libtidy/default.nix
+++ b/pkgs/development/libraries/libtidy/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchcvs, cmake, libtool, automake, autoconf }:
+
+stdenv.mkDerivation rec {
+  name = "libtidy-${version}";
+
+  version = "1.46";
+
+  src = fetchcvs {
+    cvsRoot = ":pserver:anonymous@tidy.cvs.sourceforge.net:/cvsroot/tidy";
+    module  = "tidy";
+    date    = "2009-03-25";
+    sha256  = "0bnxn1qgjx1pfyn2q4y24yj1gwqq5bxwf5ksjljqzqzrmjv3q46x";
+  };
+
+  preConfigure = ''
+    source build/gnuauto/setup.sh
+  '';
+
+  buildInputs = [ libtool automake autoconf ];
+
+  meta = with lib; {
+    description = "Validate, correct, and pretty-print HTML files";
+    homepage    = http://tidy.sourceforge.net;
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/development/libraries/libuchardet/default.nix
+++ b/pkgs/development/libraries/libuchardet/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "libuchardet-${version}";
+
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner  = "BYVoid";
+    repo   = "uchardet";
+    rev    = "69b7133995e4ee260b093323c57a7f8c6c6803b8";
+    sha256 = "0yqrc9a7wxsh2fvigjppjp55v4r1q8p40yh048xsvl3kly2rkqy9";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Mozilla's Universal Charset Detector C/C++ API";
+    homepage    = https://www.byvoid.com/zht/project/uchardet;
+    license     = licenses.mpl11;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, lib, fetchFromGitHub, cmake, libetpan, icu, cyrus_sasl, libctemplate
+, libuchardet, pkgconfig, glib, libtidy, libxml2, libuuid, openssl
+}:
+
+stdenv.mkDerivation rec {
+  name = "mailcore2-${version}";
+
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner  = "MailCore";
+    repo   = "mailcore2";
+    rev    = version;
+    sha256 = "1f2kpw8ha4j43jlimw0my9b7x1gbik7yyg1m87q6nhbbsci78qly";
+  };
+
+  buildInputs = [
+    libetpan cmake icu cyrus_sasl libctemplate libuchardet pkgconfig glib
+    libtidy libxml2 libuuid openssl
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+       --replace "tidy/tidy.h" "tidy.h" \
+       --replace "/usr/include/tidy" "${libtidy}/include" \
+       --replace "/usr/include/libxml2" "${libxml2}/include/libxml2" \
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  installPhase = ''
+    mkdir $out
+    cp -r src/include $out
+
+    mkdir $out/lib
+    cp src/libMailCore.so $out/lib
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    (
+      cd unittest
+      LD_LIBRARY_PATH="$(cd ../src; pwd)" TZ=PST8PDT ./unittestcpp ../../unittest/data
+    )
+  '';
+
+  meta = with lib; {
+    description = "A simple and asynchronous API to work with e-mail protocols IMAP, POP and SMTP";
+    homepage    = http://libmailcore.com;
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1644,6 +1644,8 @@ let
 
   liboauth = callPackage ../development/libraries/liboauth { };
 
+  libtidy = callPackage ../development/libraries/libtidy { };
+
   libtirpc = callPackage ../development/libraries/ti-rpc { };
 
   libshout = callPackage ../development/libraries/libshout { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12589,6 +12589,8 @@ let
 
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };
 
+  mailcore2 = callPackage ../development/libraries/mailcore2 { };
+
   martyr = callPackage ../development/libraries/martyr { };
 
   mess = callPackage ../misc/emulators/mess {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5713,6 +5713,8 @@ let
 
   libchardet = callPackage ../development/libraries/libchardet { };
 
+  libuchardet = callPackage ../development/libraries/libuchardet { };
+
   libchop = callPackage ../development/libraries/libchop { };
 
   libcm = callPackage ../development/libraries/libcm { };


### PR DESCRIPTION
This PR is primarily intended to introduce `mailcore2` as a new package. New libraries were needed, and some existing libraries required newer versions.
