### PR TITLE
Added Game_Music_Emu, a decoder plugin for mpd.

### DIFF
--- a/pkgs/applications/audio/game-music-emu/default.nix
+++ b/pkgs/applications/audio/game-music-emu/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, cmake }:
+
+stdenv.mkDerivation rec {
+  version = "0.6.0";
+  name = "game-music-emu-${version}";
+
+  src = fetchurl {
+    url = "https://game-music-emu.googlecode.com/files/${name}.tar.bz2";
+    sha256 = "11s9l938nxbrk7qb2k1ppfgizcz00cakbxgv0gajc6hyqv882vjh";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = https://code.google.com/p/game-music-emu/;
+    description = "Game_Music_Emu is a collection of video game music file emulators.";
+    platforms = platforms.all;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -19,6 +19,7 @@
 , aacSupport ? true, faad2
 , pulseaudioSupport ? true, pulseaudio
 , jackSupport ? true, jack2
+, gmeSupport ? true, game-music-emu
 , icuSupport ? true, icu
 }:
 
@@ -59,6 +60,7 @@ in stdenv.mkDerivation rec {
     ++ opt zipSupport zziplib
     ++ opt pulseaudioSupport pulseaudio
     ++ opt jackSupport jack2
+    ++ opt gmeSupport game-music-emu
     ++ opt icuSupport icu;
 
   configureFlags =
@@ -85,6 +87,7 @@ in stdenv.mkDerivation rec {
       (mkFlag jackSupport "jack")
       (mkFlag stdenv.isDarwin "osx")
       (mkFlag icuSupport "icu")
+      (mkFlag gmeSupport "gme")
       "--enable-debug"
     ]
     ++ opt stdenv.isLinux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9826,6 +9826,8 @@ let
 
   fuze = callPackage ../applications/networking/instant-messengers/fuze {};
 
+  game-music-emu = callPackage ../applications/audio/game-music-emu/default.nix { };
+
   gcolor2 = callPackage ../applications/graphics/gcolor2 { };
 
   get_iplayer = callPackage ../applications/misc/get_iplayer {};


### PR DESCRIPTION
Added is a library for playing video game music and an option to the mpd package to support it. From the Game_Music_Emu website:

Game_Music_Emu is a collection of video game music file emulators that support the following formats and systems:

AY  ZX Spectrum/Amstrad CPC
GBS     Nintendo Game Boy
GYM     Sega Genesis/Mega Drive
HES     NEC TurboGrafx-16/PC Engine
KSS     MSX Home Computer/other Z80 systems (doesn't support FM sound)
NSF/NSFE    Nintendo NES/Famicom (with VRC 6, Namco 106, and FME-7 sound)
SAP     Atari systems using POKEY sound chip
SPC     Super Nintendo/Super Famicom
VGM/VGZ     Sega Master System/Mark III, Sega Genesis/Mega Drive,BBC Micro

Features:

```
Can be used in C and C++ code
High emphasis has been placed on making the library very easy to use
One set of common functions work with all emulators the same way
Several code examples, including music player using SDL
Portable code for use on any system with modern or older C++ compilers
Adjustable output sample rate using quality band-limited resampling
Uniform access to text information fields and track timing information
End-of-track fading and automatic look ahead silence detection
Treble/bass and stereo echo for AY/GBS/HES/KSS/NSF/NSFE/SAP/VGM
Tempo can be adjusted and individual voices can be muted while playing
Can read music data from file, memory, or custom reader function/class
Can access track information without having to load into full emulator
M3U track listing support for multi-track formats
Modular design allows elimination of unneeded emulators/features 
```

This library has been used in game music players for Windows, Linux on several architectures, Mac OS, MorphOS, Xbox, PlayStation Portable, GP2X, and Nintendo DS.
