### PR TITLE
shotwell: use gsettings dconf backend, use hicolor_icon_theme

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, m4, glibc, gtk3, libexif, libgphoto2, libsoup, libxml2, vala, sqlite, webkitgtk24x
 , pkgconfig, gnome3, gst_all_1, which, udev, libraw, glib, json_glib, gettext, desktop_file_utils
-, lcms2, gdk_pixbuf, librsvg, makeWrapper, gnome_doc_utils }:
+, lcms2, gdk_pixbuf, librsvg, makeWrapper, gnome_doc_utils, hicolor_icon_theme }:
 
 # for dependencies see http://www.yorba.org/projects/shotwell/install/
 
@@ -52,7 +52,8 @@ in stdenv.mkDerivation rec {
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee which udev gnome3.gexiv2
                   libraw rest json_glib gettext desktop_file_utils glib lcms2 gdk_pixbuf librsvg
                   makeWrapper gnome_doc_utils
-                  gnome3.gnome_icon_theme gnome3.gnome_icon_theme_symbolic ];
+                  gnome3.gnome_icon_theme gnome3.gnome_icon_theme_symbolic
+                  hicolor_icon_theme ];
 
   meta = with stdenv.lib; {
     description = "Popular photo organizer for the GNOME desktop";

--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -42,7 +42,8 @@ in stdenv.mkDerivation rec {
   preFixup = ''
     wrapProgram "$out/bin/shotwell" \
      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-     --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
+     --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
+     --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
     rm $out/share/icons/hicolor/icon-theme.cache
   '';
 


### PR DESCRIPTION
This fixes issue #5433. Whilst at it, I found that shotwell also requires hicolor_icon_theme in a few of its dialog windows, so I've added it in as well.
