### PR TITLE
dunst: allow user configuration (fixes #5222)

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -12,11 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "0x95f57s0a96c4lifxdpf73v706iggwmdw8742mabbjnxq55l1qs";
   };
 
-  patchPhase = ''
-    substituteInPlace "settings.c" \
-      --replace "xdgConfigOpen(\"dunst/dunstrc\", \"r\", &xdg" "fopen(\"$out/share/dunst/dunstrc\", \"r\""
-  '';
-
   buildInputs =
   [ coreutils unzip which pkgconfig dbus freetype libnotify gdk_pixbuf
     xdg_utils libXext glib pango cairo libX11 libxdg_basedir


### PR DESCRIPTION
This commit eliminates a patch which hard-coded an example configuration file as the program's default settings and prevented the program from reading a user's configuration file.
