### PR TITLE
Add package 'trash-cli'.

### DIFF
--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, substituteAll, coreutils, python2, python2Packages }:
+
+python2Packages.buildPythonPackage rec {
+  name = "trash-cli-${version}";
+  version = "0.12.9.14";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "https://github.com/andreafrancia/trash-cli/archive/${version}.tar.gz";
+    sha256 = "10idvzrlppj632pw6mpk1zy9arn1x4lly4d8nfy9cz4zqv06lhvh";
+  };
+
+
+  patches = [
+    # Fix paths.
+    (substituteAll {
+      src = ./nix-paths.patch;
+      df = "${coreutils}/bin/df";
+      python = "${python2}/bin/${python2.executable}";
+      libc = "${stdenv.gcc.libc}/lib/libc.so.6";
+    })
+
+    # Apply https://github.com/JaviMerino/trash-cli/commit/4f45a37a3
+    # to fix failing test case.
+    ./fix_should_output_info_for_multiple_files.patch
+  ];
+
+  buildInputs = with python2Packages; [ nose mock ];
+
+  checkPhase = "nosetests";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/andreafrancia/trash-cli;
+    description = "Command line tool for the desktop trash can";
+    maintainer = [ maintainers.rycee ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/misc/trash-cli/fix_should_output_info_for_multiple_files.patch
+++ b/pkgs/tools/misc/trash-cli/fix_should_output_info_for_multiple_files.patch
@@ -1,0 +1,60 @@
+From 4f45a37a390d7c844dd9c9b58fff7259a77ffff9 Mon Sep 17 00:00:00 2001
+From: Javi Merino <merino.jav@gmail.com>
+Date: Sun, 31 Aug 2014 05:45:17 -0700
+Subject: [PATCH] Fix should_output_info_for_multiple_files
+
+Test should_output_info_for_multiple_files fails because the output is
+not in the same order as the input.  Add assert_equal_any_order() to
+the OutputCollector, which sorts the expected and actual lines so that
+the output matches even if the order in which they are shown in
+trash-list is different.
+---
+ integration_tests/describe_trash_list.py | 8 +++++---
+ integration_tests/output_collector.py    | 8 ++++++++
+ 2 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/integration_tests/describe_trash_list.py b/integration_tests/describe_trash_list.py
+index 6dd8d30..3489a22 100644
+--- a/integration_tests/describe_trash_list.py
++++ b/integration_tests/describe_trash_list.py
+@@ -73,9 +73,9 @@ def should_output_info_for_multiple_files(self):
+ 
+         self.user.run_trash_list()
+ 
+-        self.user.should_read_output( "2000-01-01 00:00:01 /file1\n"
+-                                      "2000-01-01 00:00:02 /file2\n"
+-                                      "2000-01-01 00:00:03 /file3\n")
++        self.user.should_read_output_any_order( "2000-01-01 00:00:01 /file1\n"
++                                                "2000-01-01 00:00:02 /file2\n"
++                                                "2000-01-01 00:00:03 /file3\n")
+ 
+     @istest
+     def should_output_unknown_dates_with_question_marks(self):
+@@ -294,6 +294,8 @@ def error(self):
+         raise ValueError()
+     def should_read_output(self, expected_value):
+         self.stdout.assert_equal_to(expected_value)
++    def should_read_output_any_order(self, expected_value):
++        self.stdout.assert_equal_any_order(expected_value)
+     def should_read_error(self, expected_value):
+         self.stderr.assert_equal_to(expected_value)
+     def output(self):
+diff --git a/integration_tests/output_collector.py b/integration_tests/output_collector.py
+index 06dc002..7f3704f 100644
+--- a/integration_tests/output_collector.py
++++ b/integration_tests/output_collector.py
+@@ -9,6 +9,14 @@ def write(self,data):
+         self.stream.write(data)
+     def assert_equal_to(self, expected):
+         return self.should_be(expected)
++    def assert_equal_any_order(self, expected):
++        actual_sorted = sorted(self.stream.getvalue().splitlines(1))
++        actual = "".join(actual_sorted)
++
++        expected_sorted = sorted(expected.splitlines(1))
++        expected = "".join(expected_sorted)
++
++        assert_equals_with_unidiff(expected, actual)
+     def should_be(self, expected):
+         assert_equals_with_unidiff(expected, self.stream.getvalue())
+     def should_match(self, regex):

--- a/pkgs/tools/misc/trash-cli/nix-paths.patch
+++ b/pkgs/tools/misc/trash-cli/nix-paths.patch
@@ -1,0 +1,39 @@
+diff -Nurp trash-cli-0.12.9.14-orig/integration_tests/test_trash_rm_script.py trash-cli-0.12.9.14/integration_tests/test_trash_rm_script.py
+--- trash-cli-0.12.9.14-orig/integration_tests/test_trash_rm_script.py	2014-12-23 10:10:43.808470486 +0100
++++ trash-cli-0.12.9.14/integration_tests/test_trash_rm_script.py	2014-12-23 10:11:02.688517975 +0100
+@@ -9,7 +9,7 @@ from pprint import pprint
+ @istest
+ class WhenNoArgs:
+     def setUp(self):
+-        process = Popen(['python', 'trashcli/rm.py'],
++        process = Popen(['@python@', 'trashcli/rm.py'],
+                     env={'PYTHONPATH':'.'},
+                     stdin=None,
+                     stdout=PIPE,
+diff -Nurp trash-cli-0.12.9.14-orig/trashcli/list_mount_points.py trash-cli-0.12.9.14/trashcli/list_mount_points.py
+--- trash-cli-0.12.9.14-orig/trashcli/list_mount_points.py	2014-12-23 10:10:43.808470486 +0100
++++ trash-cli-0.12.9.14/trashcli/list_mount_points.py	2014-12-23 10:19:04.954796457 +0100
+@@ -12,7 +12,7 @@ def mount_points_from_getmnt():
+ 
+ def mount_points_from_df():
+     import subprocess
+-    df_output = subprocess.Popen(["df", "-P"], stdout=subprocess.PIPE).stdout
++    df_output = subprocess.Popen(["@df@", "-P"], stdout=subprocess.PIPE).stdout
+     return list(_mount_points_from_df_output(df_output))
+ 
+ def _mount_points_from_df_output(df_output):
+@@ -46,13 +46,7 @@ def _mounted_filesystems_from_getmnt() :
+                     ("mnt_freq", c_int),       # Dump frequency (in days).
+                     ("mnt_passno", c_int)]     # Pass number for `fsck'.
+ 
+-    if sys.platform == "cygwin":
+-        libc_name = "cygwin1.dll"
+-    else:
+-        libc_name = find_library("c")
+-
+-    if libc_name == None :
+-        libc_name="/lib/libc.so.6" # fix for my Gentoo 4.0
++    libc_name = "@libc@"
+ 
+     libc = cdll.LoadLibrary(libc_name)
+     libc.getmntent.restype = POINTER(mntent_struct)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2579,6 +2579,8 @@ let
 
   traceroute = callPackage ../tools/networking/traceroute { };
 
+  trash-cli = callPackage ../tools/misc/trash-cli { };
+
   trickle = callPackage ../tools/networking/trickle {};
 
   trousers = callPackage ../tools/security/trousers { };


### PR DESCRIPTION
A handy command line tool for managing the freedesktop.org trash can.
