### PR TITLE
nixos/sudo: preserve $MODULE_DIR

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -73,6 +73,9 @@ in
         # Keep SSH_AUTH_SOCK so that pam_ssh_agent_auth.so can do its magic.
         Defaults env_keep+=SSH_AUTH_SOCK
 
+        # Keep MODULE_DIR so modprobe doesn't forget where modules are.
+        Defaults env_keep+=MODULE_DIR
+
         # "root" is allowed to do anything.
         root        ALL=(ALL) SETENV: ALL
 


### PR DESCRIPTION
Without this, "sudo modprobe foo" will try to work with modules in
/lib/modules instead of /run/current-system/kernel-modules/lib/modules.

---

I'd like to merge this into master and release-14.12. Any objections?
