### PR TITLE
x265-hg: updated to latest commit, fixed package naming issue

### DIFF
--- a/pkgs/development/libraries/x265/hg.nix
+++ b/pkgs/development/libraries/x265/hg.nix
@@ -1,7 +1,7 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "hg-${rev}";
-  rev = "eebb372eec893efc50e66806fcc19b1c1bd89683";
-  sha256 = "03dpbjqcmbmyid45560byabybfzy2bvic0gqa6k6hxci6rvmynpi";
+  version = "hg";
+  rev = "5f9f7194267b76f733e9ffb0f9e8b474dfe89a71";
+  sha256 = "056ng8nsadmjf6s7igbgbxmiapjcxpfy6pbayl764xbhpkv4md88";
 })


### PR DESCRIPTION
fixed issue of hg revision becoming part of the package name
