### PR TITLE
systemd-journal-gatewayd: add systemd-journal group

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1032,6 +1032,11 @@ in
       ''
         # This file is created automatically and should not be modified.
         # Please change the option ‘systemd.tmpfiles.rules’ instead.
+
+        z /var/log/journal 2755 root systemd-journal - -
+        z /var/log/journal/%m 2755 root systemd-journal - -
+        z /var/log/journal/%m/* 0640 root systemd-journal - -
+
         ${concatStringsSep "\n" cfg.tmpfiles.rules}
       '';
 


### PR DESCRIPTION
when option `services.journald.enableHttpGateway` is set, the web interface doesn't show any entries and outputs an error:
![shot-2014-12-28_06-41-09](https://cloud.githubusercontent.com/assets/854770/5563245/ad5f4d36-8e64-11e4-939d-5e1d8cfdce13.jpg)

with this fix it now shows everything, like it should and like the comment says, this should be default, but its not, maybe there was some day... because for some users, like for @offlinehacker , web interface works without this modification - the `setfacl -m ...` command does not remove the ACL rules, but it just adds or modifies them as the -m means, therefore something could added in the past ACL rule and now it does not or something.

PS: if it does not work for you, maybe `setfacl --recursive ...` is missing for you so that rules are applied to all of the sub-folders and files, I just removed the `/var/log/journal` and ran rebuild, because the activation script creates it, if does not exist.
