### PR TITLE
etcd: upgrade server and ctl

### DIFF
--- a/pkgs/development/tools/etcdctl/default.nix
+++ b/pkgs/development/tools/etcdctl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, go, fetchurl, fetchgit, fetchhg, fetchbzr, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.3";
+  version = "0.4.5";
   name = "etcdctl-${version}";
 
   src = import ./deps.nix {

--- a/pkgs/development/tools/etcdctl/deps.nix
+++ b/pkgs/development/tools/etcdctl/deps.nix
@@ -7,8 +7,8 @@ let
       src = fetchFromGitHub {
         owner = "coreos";
         repo = "etcdctl";
-        rev = "061135b2a02797a6b3c2b6c01183517c1bc76a2c";
-        sha256 = "1hl9cz9ygr2k4d67qj9q1xj0n64b28qjy5sv7zylgg9h9ag2j2p4";
+        rev = "a1b38c93245542e340971189750baef7a55d306e";
+        sha256 = "1kbri59ppil52v7s992q8r6i1zk9lac0s2w00z2lsgc9w1z59qs0";
       };
     }
   ];

--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, go, fetchurl, fetchgit, fetchhg, fetchbzr, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.5.0-alpha.4";
+  version = "2.0.0-rc.1";
   name = "etcd-${version}";
 
   src = import ./deps.nix {

--- a/pkgs/servers/etcd/deps.nix
+++ b/pkgs/servers/etcd/deps.nix
@@ -8,8 +8,8 @@ let
       src = fetchFromGitHub {
         owner = "coreos";
         repo = "etcd";
-        rev = "d01d6119e54f729f54e9776ad5729277fcf38668";
-        sha256 = "0h9d6rc8yx7vyv2ggvzsddyng03pjhyb7avm9wrc805qr7p8nhns";
+        rev = "221abdcb3b755b36d1e7d70149f6de3450351619";
+        sha256 = "1wkd238ap9gp5irrb3f6nnh83rzizwfrfac76j0dvqdka35l247k";
       };
     }
   ];


### PR DESCRIPTION
This fixes timeout errors on postStart on etcd.service.
Both upgrades in one commit because if you only upgrade etcd then service doesnt start because service is using etcdctl.
