### PR TITLE
nixos: When generating /etc/fstab, ZFS and NFS filesystems shouldn't be checked

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -142,7 +142,10 @@ in
       ++ config.system.fsPackages;
 
     environment.etc.fstab.text =
-      ''
+      let
+        fsToSkipCheck = [ "none" "btrfs" "zfs" "tmpfs" "nfs" ];
+        skipCheck = fs: fs.noCheck || fs.device == "none" || builtins.elem fs.fsType fsToSkipCheck;
+      in ''
         # This is a generated file.  Do not edit!
 
         # Filesystems.
@@ -154,7 +157,7 @@ in
             + " " + fs.fsType
             + " " + fs.options
             + " 0"
-            + " " + (if fs.fsType == "none" || fs.device == "none" || fs.fsType == "btrfs" || fs.fsType == "tmpfs" || fs.noCheck then "0" else
+            + " " + (if skipCheck fs then "0" else
                      if fs.mountPoint == "/" then "1" else "2")
             + "\n"
         )}


### PR DESCRIPTION
This cleans up `systemd-fstab-generator` warnings such as `Checking was requested for "192.168.1.10:/mntpoint", but it is not a device.`
