### PR TITLE
Fix user-facing typos (mainly in descriptions)

### DIFF
--- a/nixos/modules/security/duosec.nix
+++ b/nixos/modules/security/duosec.nix
@@ -110,7 +110,7 @@ in
         default = false;
         description = ''
           Print the contents of <literal>/etc/motd</literal> to screen
-          after a succesful login.
+          after a successful login.
         '';
       };
 
@@ -145,7 +145,7 @@ in
 
           When $DUO_PASSCODE is non-empty, it will override
           autopush. The SSH client will need SendEnv DUO_PASSCODE in
-          its configuration, and the SSH server will similarily need
+          its configuration, and the SSH server will similarly need
           AcceptEnv DUO_PASSCODE.
         '';
       };

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -90,7 +90,7 @@ in
       enable = true;
       recipientDelimiter= "+";
       extraMasterConf = ''
-        mlmmj unix - n n - - pipe flags=ORhu user=mlmmj argv=${pkgs.mlmmj}/bin/mlmmj-recieve -F -L ${spoolDir}/$nextHop
+        mlmmj unix - n n - - pipe flags=ORhu user=mlmmj argv=${pkgs.mlmmj}/bin/mlmmj-receive -F -L ${spoolDir}/$nextHop
       '';
 
       extraAliases = concatMapStrings (alias cfg.listDomain) cfg.mailLists;

--- a/nixos/modules/services/monitoring/cadvisor.nix
+++ b/nixos/modules/services/monitoring/cadvisor.nix
@@ -11,7 +11,7 @@ in {
       enable = mkOption {
         default = false;
         type = types.bool;
-        description = "Wherther to enable cadvisor service.";
+        description = "Whether to enable cadvisor service.";
       };
 
       host = mkOption {

--- a/nixos/modules/services/monitoring/statsd.nix
+++ b/nixos/modules/services/monitoring/statsd.nix
@@ -53,7 +53,7 @@ in
     };
 
     mgmt_address = mkOption {
-      description = "Address to run managment TCP interface on";
+      description = "Address to run management TCP interface on";
       default = "127.0.0.1";
       type = types.str;
     };
@@ -65,7 +65,7 @@ in
     };
 
     backends = mkOption {
-      description = "List of backends statsd will use for data persistance";
+      description = "List of backends statsd will use for data persistence";
       default = ["graphite"];
       example = ["graphite" pkgs.nodePackages."statsd-influxdb-backend"];
       type = types.listOf (types.either types.str types.package);

--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -61,7 +61,7 @@ in
           default = null;
           example = 4002;
           description = ''
-            Use fixed port for rpc.mountd, usefull if server is behind firewall.
+            Use fixed port for rpc.mountd, useful if server is behind firewall.
           '';
         };
 

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -142,7 +142,7 @@ in
           type = types.int;
           default = 80;
           description = ''
-            Port to forward incoming trafic to. 80 by default.
+            Port to forward incoming traffic to. 80 by default.
           '';
         };
         keyFile = mkOption {

--- a/nixos/modules/services/networking/tox-bootstrapd.nix
+++ b/nixos/modules/services/networking/tox-bootstrapd.nix
@@ -24,7 +24,7 @@ in
             default = false;
             description =
               ''
-                Whether to enable the Tox DHT boostrap daemon.
+                Whether to enable the Tox DHT bootstrap daemon.
               '';
           };
 
@@ -45,7 +45,7 @@ in
             default = "";
             description =
               ''
-                Configuration for boostrap daemon.
+                Configuration for bootstrap daemon.
                 See <link xlink:href="https://github.com/irungentoo/toxcore/blob/master/other/bootstrap_daemon/tox-bootstrapd.conf"/>
                 and <link xlink:href="http://wiki.tox.im/Nodes"/>.
              '';

--- a/nixos/modules/services/web-servers/zope2.nix
+++ b/nixos/modules/services/web-servers/zope2.nix
@@ -24,7 +24,7 @@ let
       http_address = mkOption {
         default = "localhost:8080";
         type = types.string;
-        description = "Give a port and adress for the HTTP server.";
+        description = "Give a port and address for the HTTP server.";
       };
 
       user = mkOption {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -695,21 +695,21 @@ in
       default = {};
       type = types.attrsOf types.optionSet;
       options = [ linkOptions ];
-      description = "Definiton of systemd network links.";
+      description = "Definition of systemd network links.";
     };
 
     systemd.network.netdevs = mkOption {
       default = {};
       type = types.attrsOf types.optionSet;
       options = [ netdevOptions ];
-      description = "Definiton of systemd network devices.";
+      description = "Definition of systemd network devices.";
     };
 
     systemd.network.networks = mkOption {
       default = {};
       type = types.attrsOf types.optionSet;
       options = [ networkOptions networkConfig ];
-      description = "Definiton of systemd networks.";
+      description = "Definition of systemd networks.";
     };
 
     systemd.network.units = mkOption {

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -38,7 +38,7 @@ in
         default = null;
         example = 4000;
         description = ''
-          Use fixed port for rpc.statd, usefull if NFS server is behind firewall.
+          Use fixed port for rpc.statd, useful if NFS server is behind firewall.
         '';
       };
       lockdPort = mkOption {
@@ -46,7 +46,7 @@ in
         example = 4001;
         description = ''
           Use fixed port for NFS lock manager kernel module (lockd/nlockmgr),
-          usefull if NFS server is behind firewall.
+          useful if NFS server is behind firewall.
         '';
       };
     };

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -266,7 +266,7 @@ in
             Networking-related command-line options that should be passed to qemu.
             The default is to use userspace networking (slirp).
 
-            If you override this option, be adviced to keep
+            If you override this option, be advised to keep
             ''${QEMU_NET_OPTS:+,$QEMU_NET_OPTS} (as seen in the default)
             to keep the default runtime behaviour.
           '';

--- a/pkgs/applications/audio/transcode/default.nix
+++ b/pkgs/applications/audio/transcode/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "Suite of command line utilities for transcoding video and audio codecs, and for converting beween different container formats";
+    description = "Suite of command line utilities for transcoding video and audio codecs, and for converting between different container formats";
     homepage = http://www.transcoding.org/;
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/sqliteman/default.nix
+++ b/pkgs/applications/misc/sqliteman/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Sqliteman is simple but powerfull Sqlite3 GUI database manager.";
+    description = "A simple but powerful Sqlite3 GUI database manager";
     homepage = http://sqliteman.yarpen.cz/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
       git-bz is a tool for integrating the Git command line with the
       Bugzilla bug-tracking system. Operations such as attaching patches to
       bugs, applying patches in bugs to your current tree, and closing bugs
-      once you've pushed the fixes publically can be done completely from
+      once you've pushed the fixes publicly can be done completely from
       the command line without having to go to your web browser.
 
       Authentication for git-bz is done by reading the cookies for the

--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A free, open source, cross-platform video editor";
     longDescription = ''
-      An offical binary for Shotcut, which includes all the
+      An official binary for Shotcut, which includes all the
       dependencies pinned to specific versions, is provided on
       http://shotcut.org.
 

--- a/pkgs/development/compilers/rustc/common.nix
+++ b/pkgs/development/compilers/rustc/common.nix
@@ -11,7 +11,7 @@
     then "macos-i386"
     else if stdenv.system == "x86_64-darwin"
     then "macos-x86_64"
-    else abort "no snapshot to boostrap for this platform (missing platform url suffix)";
+    else abort "no snapshot to bootstrap for this platform (missing platform url suffix)";
 
   target = if stdenv.system == "i686-linux"
     then "i686-unknown-linux-gnu"
@@ -21,7 +21,7 @@
     then "i686-apple-darwin"
     else if stdenv.system == "x86_64-darwin"
     then "x86_64-apple-darwin"
-    else abort "no snapshot to boostrap for this platform (missing target triple";
+    else abort "no snapshot to bootstrap for this platform (missing target triple";
 
   meta = with stdenv.lib; {
     homepage = http://www.rust-lang.org/;

--- a/pkgs/development/libraries/gdome2/default.nix
+++ b/pkgs/development/libraries/gdome2/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://gdome2.cs.unibo.it/;
-    description = "DOM C library developped for the Gnome project";
+    description = "DOM C library developed for the Gnome project";
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
     broken = true;

--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       Main features:
 
       * Extended support for language peculiarities; Unicode character encoding, compounding and complex morphology.
-      * Improved suggestion using n-gram similarity, rule and dictionary based pronounciation data.
+      * Improved suggestion using n-gram similarity, rule and dictionary based pronunciation data.
       * Morphological analysis, stemming and generation.
       * Hunspell is based on MySpell and works also with MySpell dictionaries.
       * C++ library under GPL/LGPL/MPL tri-license.

--- a/pkgs/development/libraries/libcdio/0.82.nix
+++ b/pkgs/development/libraries/libcdio/0.82.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A library for OS-independent CD-ROM and CD image access";
     longDescription = ''
-      GNU libcdio is a library for OS-idependent CD-ROM and
+      GNU libcdio is a library for OS-independent CD-ROM and
       CD image access.  It includes a library for working with
       ISO-9660 filesystems (libiso9660), as well as utility
       programs such as an audio CD player and an extractor.

--- a/pkgs/development/libraries/libcdio/default.nix
+++ b/pkgs/development/libraries/libcdio/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A library for OS-independent CD-ROM and CD image access";
     longDescription = ''
-      GNU libcdio is a library for OS-idependent CD-ROM and
+      GNU libcdio is a library for OS-independent CD-ROM and
       CD image access.  It includes a library for working with
       ISO-9660 filesystems (libiso9660), as well as utility
       programs such as an audio CD player and an extractor.

--- a/pkgs/development/libraries/readline/6.2.nix
+++ b/pkgs/development/libraries/readline/6.2.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (rec {
       reedit those lines, and perform csh-like history expansion on
       previous commands.
 
-      The history facilites are also placed into a separate library,
+      The history facilities are also placed into a separate library,
       the History library, as part of the build process.  The History
       library may be used without Readline in applications which
       desire its capabilities.

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       reedit those lines, and perform csh-like history expansion on
       previous commands.
 
-      The history facilites are also placed into a separate library,
+      The history facilities are also placed into a separate library,
       the History library, as part of the build process.  The History
       library may be used without Readline in applications which
       desire its capabilities.

--- a/pkgs/development/libraries/slib/default.nix
+++ b/pkgs/development/libraries/slib/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       provides a platform independent framework for using packages of Scheme
       procedures and syntax.  As distributed, SLIB contains useful packages
       for all Scheme implementations.  Its catalog can be transparently
-      extended to accomodate packages specific to a site, implementation,
+      extended to accommodate packages specific to a site, implementation,
       user, or directory.
 
       SLIB supports Bigloo, Chez, ELK 3.0, Gambit 4.0, Guile, JScheme, Kawa,

--- a/pkgs/development/libraries/ti-rpc/default.nix
+++ b/pkgs/development/libraries/ti-rpc/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
        migrated their SunRPC library to a TI-RPC (Transport Independent
        RPC) implementation.  This implementation allows the support of
        other transports than UDP and TCP over IPv4.  FreeBSD provides a
-       TI-RPC library ported from NetBSD with improvments.  This library
+       TI-RPC library ported from NetBSD with improvements.  This library
        already supports IPv6.  So, the FreeBSD release 5.2.1 TI-RPC has
        been ported to replace the SunRPC of the glibc.
     '';

--- a/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix
+++ b/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation {
   };
 
   meta = with stdenv.lib; {
-      description = "AVR developement environment including binutils, avr-gcc and avr-libc";
+      description = "AVR development environment including binutils, avr-gcc and avr-libc";
       # I've tried compiling the packages separately.. too much hassle. This just works. Fine.
       license =  ["GPL" "LGPL"]; # see single packages ..
       homepage = []; # dito

--- a/pkgs/development/ocaml-modules/tyxml/default.nix
+++ b/pkgs/development/ocaml-modules/tyxml/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = http://ocsigen.org/tyxml/;
-    description = "A library that makes it almost impossible for your OCaml programs to generate wrong XML ouput, using static typing";
+    description = "A library that makes it almost impossible for your OCaml programs to generate wrong XML output, using static typing";
     license = licenses.lgpl21;
     platforms = ocaml.meta.platforms;
     maintainers = with maintainers; [

--- a/pkgs/development/tools/build-managers/cargo/common.nix
+++ b/pkgs/development/tools/build-managers/cargo/common.nix
@@ -11,7 +11,7 @@ rec {
     then "i686-apple-darwin"
     else if stdenv.system == "x86_64-darwin"
     then "x86_64-apple-darwin"
-    else throw "no snapshot to boostrap for this platform (missing platform url suffix)";
+    else throw "no snapshot to bootstrap for this platform (missing platform url suffix)";
 
   snapshotHash = if stdenv.system == "i686-linux"
     then "4dea04e278192c5409f43794a98f20a8f59df2d9"

--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
       ocp-build is a build system for OCaml application, based on simple
       descriptions of packages. ocp-build combines the descriptions of
       packages, and optimize the parallel compilation of files depending on
-      the number of cores and the automatically-infered dependencies
+      the number of cores and the automatically-inferred dependencies
       between source files.
     '';
     license = licenses.gpl3;

--- a/pkgs/games/fairymax/default.nix
+++ b/pkgs/games/fairymax/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
        A version of micro-Max that reads the piece description
        from a file fmax.ini, so that arbitrary fairy pieces can be
        implemented. This version (4.8J) supports up to 15 piece types,
-       and board sizes upto 12x8 board. A Linux port exists in the
+       and board sizes up to 12x8. A Linux port exists in the
        format of a debian package.
     '';
     license = stdenv.lib.licenses.free ;

--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Turn-based strategy artillery game similiar to Worms";
+    description = "Turn-based strategy artillery game similar to Worms";
     homepage = http://hedgewars.org/;
     license = licenses.gpl2;
     longDescription = ''

--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
       In multiplayer networked mode, players may:
         - play competitively as different businesses
-        - play cooperatively controling the same business
+        - play cooperatively controlling the same business
         - observe as spectators
     '';
     homepage = http://www.openttd.org/;

--- a/pkgs/misc/emulators/stella/default.nix
+++ b/pkgs/misc/emulators/stella/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     the GNU General Public License (GPL). Stella was originally
     developed for Linux by Bradford W. Mott, and is currently
     maintained by Stephen Anthony.
-    As of its 3.5 release, Stella is officialy donationware. 
+    As of its 3.5 release, Stella is officially donationware. 
     '';
     homepage = http://stella.sourceforge.net/;
     license = licenses.gpl2;

--- a/pkgs/misc/emulators/uae/default.nix
+++ b/pkgs/misc/emulators/uae/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   buildInputs = [ pkgconfig gtk alsaLib SDL ];
   
   meta = {
-    description = "Ultimate/Unix/Unusuable Amiga Emulator";
+    description = "Ultimate/Unix/Unusable Amiga Emulator";
     license = stdenv.lib.licenses.gpl2Plus;
     homepage = http://www.amigaemulator.org;
     maintainers = [ stdenv.lib.maintainers.sander ];

--- a/pkgs/tools/X11/sselp/default.nix
+++ b/pkgs/tools/X11/sselp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://tools.suckless.org/sselp";
-    description = "Prints the X selection to stdout, usefull in scripts";
+    description = "Prints the X selection to stdout, useful in scripts";
     license = stdenv.lib.licenses.mit;
     maintainers = [stdenv.lib.maintainers.magnetophon ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/compression/kzipmix/default.nix
+++ b/pkgs/tools/compression/kzipmix/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A tool that agressively optimizes the sizes of Zip archives";
+    description = "A tool that aggressively optimizes the sizes of Zip archives";
     license = stdenv.lib.licenses.unfree;
     homepage = http://advsys.net/ken/utils.htm;
     maintainers = [ stdenv.lib.maintainers.sander ];

--- a/pkgs/tools/graphics/pngout/default.nix
+++ b/pkgs/tools/graphics/pngout/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A tool that agressively optimizes the sizes of PNG images";
+    description = "A tool that aggressively optimizes the sizes of PNG images";
     license = stdenv.lib.licenses.unfree;
     homepage = http://advsys.net/ken/utils.htm;
     maintainers = [ stdenv.lib.maintainers.sander ];

--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -42,7 +42,7 @@ in
         works by maintaining a database of the directories you use the
         most from the command line.  The jstat command shows you the
         current contents of the database.  You need to work a little
-        bit before the database becomes useable.  Once your database
+        bit before the database becomes usable.  Once your database
         is reasonably complete, you can “jump” to a directory by
         typing "j dirspec", where dirspec is a few characters of the
         directory you want to jump to.  It will jump to the most used

--- a/pkgs/tools/misc/unclutter/default.nix
+++ b/pkgs/tools/misc/unclutter/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     longDescription = ''
       Unclutter hides your X mouse cursor when you do not need it, to prevent
       it from getting in the way. You have only to move the mouse to restore
-      the mouse cursor. Unclutter is very usefull in tiling wm's where you do
+      the mouse cursor. Unclutter is very useful in tiling wm's where you do
       not need the mouse often.
 
       Just run it from your .bash_profile like that:

--- a/pkgs/tools/networking/bwm-ng/default.nix
+++ b/pkgs/tools/networking/bwm-ng/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
         Info
         This was influenced by the old bwm util written by Barney (barney@freewill.tzo.com) which had some issues with faster interfaces and was very simple. Since i had almost all code done anyway for other projects, i decided to create my own version.
 
-        I actually dont know if netstat input is usefull at all. I saw this elsewhere, so i added it. Its target is "netstat 1.42 (2001-04-15)" linux or Free/Open/netBSD. If there are other formats i would be happy to add them.
+        I actually don't know if netstat input is useful at all. I saw this elsewhere, so i added it. Its target is "netstat 1.42 (2001-04-15)" linux or Free/Open/netBSD. If there are other formats i would be happy to add them.
         
         (from homepage)
     '';

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       GnuPG is the GNU project's complete and free implementation of
       the OpenPGP standard as defined by RFC4880.  GnuPG allows to
       encrypt and sign your data and communication, features a
-      versatile key managment system as well as access modules for all
+      versatile key management system as well as access modules for all
       kind of public key directories.  GnuPG, also known as GPG, is a
       command line tool with features for easy integration with other
       applications.  A wealth of frontend applications and libraries

--- a/pkgs/tools/security/haveged/default.nix
+++ b/pkgs/tools/security/haveged/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
       random number generator based upon an adaptation of the HAVEGE algorithm.
       Haveged was created to remedy low-entropy conditions in the Linux random device
       that can occur under some workloads, especially on headless servers. Current development
-      of haveged is directed towards improving overall reliablity and adaptability while minimizing
+      of haveged is directed towards improving overall reliability and adaptability while minimizing
       the barriers to using haveged for other tasks.
     '';
     homepage = http://www.issihosts.com/haveged/;

--- a/pkgs/tools/security/opensc-dnie-wrapper/default.nix
+++ b/pkgs/tools/security/opensc-dnie-wrapper/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     description = "Access to the opensc tools and firefox using the Spanish national ID SmartCard";
     longDescription = ''
       Opensc needs a special configuration and special drivers to use the SmartCard
-      the Spanish governement provides to the citizens as ID card.
+      the Spanish government provides to the citizens as ID card.
       Some wrapper scripts take care for the proper opensc configuration to be used, in order
       to access the certificates in the SmartCard through the opensc tools or firefox.
       Opensc will require a pcscd daemon running, managing the access to the card reader.

--- a/pkgs/tools/text/multitran/mtutils/default.nix
+++ b/pkgs/tools/text/multitran/mtutils/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://multitran.sourceforge.net/;
-    description = "Multitran: simple command line utilities for dictionary maintainance";
+    description = "Multitran: simple command line utilities for dictionary maintenance";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/tools/typesetting/tex/latex2html/default.nix
+++ b/pkgs/tools/typesetting/tex/latex2html/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.latex2html.org/";
-    description = "Convertor written in Perl that converts LaTeX documents to HTML";
+    description = "Converter written in Perl that converts LaTeX documents to HTML";
     license = stdenv.lib.licenses.gpl2Plus;
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5904,7 +5904,7 @@ let self = _self // overrides; _self = with self; {
     buildInputs = [ TestFatal ];
     propagatedBuildInputs = [ ClassMethodModifiers DevelGlobalDestruction ImportInto ModuleRuntime RoleTiny strictures ];
     meta = {
-      description = "Minimalist Object Orientation (with Moose compatiblity)";
+      description = "Minimalist Object Orientation (with Moose compatibility)";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -666,7 +666,7 @@ let
 
     meta = with stdenv.lib; {
       homepage = https://github.com/nicolargo/batinfo;
-      description = "A simple Python lib to retreive battery information";
+      description = "A simple Python lib to retrieve battery information";
       license = licenses.lgpl3;
       platforms = platforms.all;
       maintainers = [ maintainers.koral ];
@@ -12098,7 +12098,7 @@ let
     buildInputs = with self; [ requests gevent ];
 
     meta = {
-      description = "GRequests allows you to use Requests with Gevent to make asyncronous HTTP Requests easily.";
+      description = "GRequests allows you to use Requests with Gevent to make asynchronous HTTP Requests easily.";
       homepage = https://github.com/kennethreitz/grequests;
       license = "bsd";
       maintainers = [ stdenv.lib.maintainers.matejc ];


### PR DESCRIPTION
I'm no fan of wanton clean-ups and don't mind the occasional mistake, but one should probably avoid things like "ouput" and "developement" in package descriptions just for the sake of searchability.

Hence a light New Year's clean-up patch. Bring user-visible strings closer to the same high quality as the code. Increase user confidence. Professionalism. Become more attractive. Exercise.

I didn't mess with the often awkward grammar, or spelling errors in comments, code*, and other "user-invisible" text. Nor did I touch any auto-generated files that were clearly marked as such.

[\* Apart from "mlmmj-recieve", which is just wrong.]
