### PR TITLE
util-linux: subsitute /run/current-system/sw/bin for hard-coded /{,s}bin

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -27,6 +27,13 @@ stdenv.mkDerivation rec {
     ${if ncurses == null then "--without-ncurses" else ""}
   '';
 
+  postConfigure = ''
+    # Substituting store paths would create a circular dependency on systemd
+    substituteInPlace include/pathnames.h \
+      --replace "/bin/login" "/run/current-system/sw/bin/login" \
+      --replace "/sbin/shutdown" "/run/current-system/sw/bin/shutdown"
+  '';
+
   buildInputs =
     [ zlib pam ]
     ++ stdenv.lib.optional (ncurses != null) ncurses


### PR DESCRIPTION
Currently, rtcwake -m off doesn't work at all, since /sbin/shutdown is missing. Creating a circular dependency on its provider (systemd) for this just isn't worth the trouble, so take the straightforward way out.

One could easily make the argument that rtcwake wants to shut down the _currently running system_, and that the correct API for that _is_ in fact /run/current-system. And it makes a very tempting sort of sense.
