### PR TITLE
GCE updates to ntp server and to fetch all ssh keys

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -132,17 +132,15 @@ in
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
 
-      path  = [ pkgs.wget ];
-      script =
+      script = let wget = "${pkgs.wget}/bin/wget --retry-connrefused -t 6 --waitretry=10"; in
         ''
           # When dealing with cryptographic keys, we want to keep things private.
           umask 077
-          wget="wget --retry-connrefused -t 6 --waitretry=10"
           # Don't download the SSH key if it has already been downloaded
           if ! [ -e /root/.ssh/authorized_keys ]; then
                 echo "obtaining SSH key..."
                 mkdir -p /root/.ssh
-                $wget -O /root/authorized-keys-metadata http://metadata/0.1/meta-data/authorized-keys
+                ${wget} -O /root/authorized-keys-metadata http://metadata/0.1/meta-data/authorized-keys
                 if [ $? -eq 0 -a -e /root/authorized-keys-metadata ]; then
                     cat /root/authorized-keys-metadata | cut -d: -f2- > /root/key.pub
                     if ! grep -q -f /root/key.pub /root/.ssh/authorized_keys; then
@@ -155,7 +153,7 @@ in
           fi
 
           echo "obtaining SSH private host key..."
-          $wget -O /root/ssh_host_ecdsa_key  http://metadata/0.1/meta-data/attributes/ssh_host_ecdsa_key
+          ${wget} -O /root/ssh_host_ecdsa_key  http://metadata/0.1/meta-data/attributes/ssh_host_ecdsa_key
           if [ $? -eq 0 -a -e /root/ssh_host_ecdsa_key ]; then
               mv -f /root/ssh_host_ecdsa_key /etc/ssh/ssh_host_ecdsa_key
               echo "downloaded ssh_host_ecdsa_key"
@@ -163,7 +161,7 @@ in
           fi
 
           echo "obtaining SSH public host key..."
-          $wget -O /root/ssh_host_ecdsa_key.pub http://metadata/0.1/meta-data/attributes/ssh_host_ecdsa_key_pub
+          ${wget} -O /root/ssh_host_ecdsa_key.pub http://metadata/0.1/meta-data/attributes/ssh_host_ecdsa_key_pub
           if [ $? -eq 0 -a -e /root/ssh_host_ecdsa_key.pub ]; then
               mv -f /root/ssh_host_ecdsa_key.pub /etc/ssh/ssh_host_ecdsa_key.pub
               echo "downloaded ssh_host_ecdsa_key.pub"

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -120,6 +120,8 @@ in
     169.254.169.254 metadata.google.internal metadata
   '';
 
+  services.ntp.servers = [ "metadata.google.internal" ];
+
   networking.usePredictableInterfaceNames = false;
 
   systemd.services.fetch-ssh-keys =

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -135,6 +135,8 @@ in
       path  = [ pkgs.wget ];
       script =
         ''
+          # When dealing with cryptographic keys, we want to keep things private.
+          umask 077
           wget="wget --retry-connrefused -t 6 --waitretry=10"
           # Don't download the SSH key if it has already been downloaded
           if ! [ -e /root/.ssh/authorized_keys ]; then

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -150,8 +150,8 @@ in
                         echo "new key added to authorized_keys"
                     fi
                     chmod 600 /root/.ssh/authorized_keys
-                    rm -f /root/key.pub /root/authorized-keys-metadata
                 fi
+                rm -f /root/key.pub /root/authorized-keys-metadata
           fi
 
           echo "obtaining SSH private host key..."

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -158,13 +158,7 @@ in
               mv -f /root/ssh_host_ecdsa_key /etc/ssh/ssh_host_ecdsa_key
               echo "downloaded ssh_host_ecdsa_key"
               chmod 600 /etc/ssh/ssh_host_ecdsa_key
-          fi
-
-          echo "obtaining SSH public host key..."
-          ${wget} -O /root/ssh_host_ecdsa_key.pub http://metadata/0.1/meta-data/attributes/ssh_host_ecdsa_key_pub
-          if [ $? -eq 0 -a -e /root/ssh_host_ecdsa_key.pub ]; then
-              mv -f /root/ssh_host_ecdsa_key.pub /etc/ssh/ssh_host_ecdsa_key.pub
-              echo "downloaded ssh_host_ecdsa_key.pub"
+              ${config.programs.ssh.package}/bin/ssh-keygen -y -f /etc/ssh/ssh_host_ecdsa_key > /etc/ssh/ssh_host_ecdsa_key.pub
               chmod 644 /etc/ssh/ssh_host_ecdsa_key.pub
           fi
         '';


### PR DESCRIPTION
I tested this GCE image on my account and it seems to work and it should be backwards compatible in the sense that if the metadata server only provides ecdsa host private and public keys then the ecdsa private key is downloaded and used.  The public key on the metadata server will be ignored as this patch will regenerated the public key directly from the private key instead.
