### PR TITLE
lib: Fix matchAttrs by importing builtins.length

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1,7 +1,7 @@
 # Operations on attribute sets.
 
 with {
-  inherit (builtins) head tail;
+  inherit (builtins) head tail length;
   inherit (import ./trivial.nix) or;
   inherit (import ./default.nix) fold;
   inherit (import ./strings.nix) concatStringsSep;


### PR DESCRIPTION
Before:

```
nix-repl> :l <nixpkgs>
nix-repl> lib.matchAttrs { foo = "bar"; } { bar = "bas"; }
error: undefined variable ‘length’ at "/home/benley/nix/nixpkgs/lib/attrsets.nix":317:10
```

After:

```
nix-repl> :l <nixpkgs>
nix-repl> lib.matchAttrs { foo = "bar"; } { bar = "bas"; }
false
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/5516)

<!-- Reviewable:end -->
