### PR TITLE
Bumblebee config to enable multiple monitors

### DIFF
--- a/pkgs/tools/X11/bumblebee/nvidia-conf.patch
+++ b/pkgs/tools/X11/bumblebee/nvidia-conf.patch
@@ -1,0 +1,11 @@
+--- bumblebee-3.2.1/conf/xorg.conf.nvidia
++++ bumblebee-3.2.1/conf/xorg.conf.nvidia
+@@ -29,6 +29,5 @@ Section "Device"
+     Option "ProbeAllGpus" "false"
+ 
+     Option "NoLogo" "true"
+-    Option "UseEDID" "false"
+-    Option "UseDisplayDevice" "none"
++@deviceOptions@
+ EndSection
+

--- a/pkgs/tools/X11/bumblebee/xopts.patch
+++ b/pkgs/tools/X11/bumblebee/xopts.patch
@@ -1,5 +1,5 @@
---- bumblebee-3.0/src/bbsecondary.c.orig	2012-02-05 00:03:06.003439638 +0100
-+++ bumblebee-3.0/src/bbsecondary.c	2012-02-05 00:46:38.017382619 +0100
+--- bumblebee-3.2.1/src/bbsecondary.c 2012-02-05 00:03:06.003439638 +0100
++++ bumblebee-3.2.1/src/bbsecondary.c	2012-02-05 00:46:38.017382619 +0100
 @@ -149,6 +149,8 @@
        "-sharevts",
        "-nolisten", "tcp",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11156,6 +11156,11 @@ let
       else null;
   };
 
+  # use if you intend to connect the nvidia card to a monitor
+  bumblebee_display = bumblebee.override {
+    useDisplayDevice = true;
+  };
+
   vkeybd = callPackage ../applications/audio/vkeybd {
     inherit (xlibs) libX11;
   };


### PR DESCRIPTION
Added configurations to `bumblebee` package to easy multiple monitors on Optimus
machines.

The behaviour of the default `bumblebee` package hasn't change, so this change
is backwards compatible. Users who want to connect a monitor to their discrete
card should use the package `bumblebee_display` instead.

Also added new configuration option to nixos bumblebee module:

```
hardware.bumblebee.connectDisplay = true
```

will enable the new configuration, but the default is still false.
