### PR TITLE
Ipopt: Added an environment variable that enables building using the new GCC

### DIFF
--- a/pkgs/development/libraries/science/math/ipopt/default.nix
+++ b/pkgs/development/libraries/science/math/ipopt/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0sji4spl5dhw1s3f9y0ym09gi7d1c8wldn6wbiap4q8dq7cvklq5";
   };
 
+  preConfigure = ''
+     export CXXDEFS="-DHAVE_RAND -DHAVE_CSTRING -DHAVE_CSTDIO"
+  '';
+
   nativeBuildInputs = [ unzip ];
 
   buildInputs = [ gfortran blas liblapack ];


### PR DESCRIPTION
The configure script only checks for a specific version to enable a fix in
finding cstdlib and cstring.
