### PR TITLE
add package MJPG-streamer

### DIFF
--- a/pkgs/applications/video/mjpg-streamer/default.nix
+++ b/pkgs/applications/video/mjpg-streamer/default.nix
@@ -1,0 +1,34 @@
+{stdenv, fetchsvn, pkgconfig, libjpeg, imagemagick, libv4l}:
+
+stdenv.mkDerivation rec {
+  rev = "182";
+  name = "mjpg-streamer-${rev}";
+
+  src = fetchsvn {
+    url = https://mjpg-streamer.svn.sourceforge.net/svnroot/mjpg-streamer/mjpg-streamer;
+    inherit rev;
+    sha256 = "008k2wk6xagprbiwk8fvzbz4dd6i8kzrr9n62gj5i1zdv7zcb16q";
+  };
+
+  patchPhase = ''
+    substituteInPlace Makefile "make -C plugins\/input_gspcav1" "# make -C plugins\/input_gspcav1"
+    substituteInPlace Makefile "cp plugins\/input_gspcav1\/input_gspcav1.so" "# cp plugins\/input_gspcav1\/input_gspcav1.so"
+  '';
+
+  # Make sure mjpeg-streamer will look in "$out/lib/plugins" for its plugins.
+  NIX_LDFLAGS = "-rpath $out/lib:$out/lib/plugins";
+  dontPatchELF = true;
+
+  makeFlags = "DESTDIR=$(out)";
+
+  preInstall = ''
+    mkdir -p $out/{bin,lib}
+  '';
+
+  buildInputs = [ pkgconfig libjpeg imagemagick libv4l ];
+  
+  meta = {
+    homepage = http://sourceforge.net/projects/mjpg-streamer/;
+    description = "MJPG-streamer takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software";
+  };
+}

--- a/pkgs/applications/video/mjpg-streamer/default.nix
+++ b/pkgs/applications/video/mjpg-streamer/default.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile "cp plugins\/input_gspcav1\/input_gspcav1.so" "# cp plugins\/input_gspcav1\/input_gspcav1.so"
   '';
 
-  # Make sure mjpeg-streamer will look in "$out/lib/plugins" for its plugins.
-  NIX_LDFLAGS = "-rpath $out/lib:$out/lib/plugins";
-  dontPatchELF = true;
+  postFixup = ''
+    patchelf --set-rpath "$(patchelf --print-rpath $out/bin/mjpg_streamer):$out/lib:$out/lib/plugins" $out/bin/mjpg_streamer
+  '';
 
   makeFlags = "DESTDIR=$(out)";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9406,7 +9406,7 @@ let
     inherit (vamp) vampSDK;
   };
 
-  mjpg_streamer = callPackage ../applications/video/mjpg-streamer { };
+  mjpg-streamer = callPackage ../applications/video/mjpg-streamer { };
 
   mmex = callPackage ../applications/office/mmex { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9406,6 +9406,8 @@ let
     inherit (vamp) vampSDK;
   };
 
+  mjpg_streamer = callPackage ../applications/video/mjpg-streamer { };
+
   mmex = callPackage ../applications/office/mmex { };
 
   moc = callPackage ../applications/audio/moc { };


### PR DESCRIPTION
MJPG-streamer takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software. It is the successor of uvc-streamer, a Linux-UVC streaming application with Pan/Tilt.

MJPG-streamer does not have a configuration step (just a bare makefile), so `gspcav` support needed to be disabled by altering the `Makefile`.
Also MJPG-streamer is build using dynamically linked plugins. On ArchLinux these are placed in `/usr/lib/`, so the linker can always find these, here I've used the `-rpath` option and enabled `dontPatchELF`. Let me know if there is a better way to do this.
