### PR TITLE
Work around issues that appear when compiling the 'split' and 'dependent-map' packages with ghcjs

### DIFF
--- a/pkgs/top-level/haskell-defaults.nix
+++ b/pkgs/top-level/haskell-defaults.nix
@@ -303,6 +303,24 @@
         unix = null;
         unorderedContainers = null;
         vector = null;
+
+        # GHCJS-specific workarounds
+        split = super.split.override {
+          cabal = self.cabal.override {
+            extension = self: super: {
+              doCheck = false; # Under ghcjs, the tests hang
+            };
+          };
+        };
+        dependentMap = super.dependentMap.override {
+          cabal = self.cabal.override {
+            extension = self: super: {
+              preConfigure = ''
+                sed -i 's/^.*ghc-options:.*$//' *.cabal
+              ''; # Without this, we get "target ‘base’ is not a module name or a source file"
+            };
+          };
+        };
       };
     };
 


### PR DESCRIPTION
These packages work in ghc but not in ghcjs; I've reported the issue to the ghcjs team, and these workarounds can be removed when nixpkgs updates ghcjs to a version that fixes them.
