### PR TITLE
eid-viewer: associate with XML & text/plain (MIME type of .eid files)

### DIFF
--- a/pkgs/tools/security/eid-viewer/default.nix
+++ b/pkgs/tools/security/eid-viewer/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/eid-viewer --suffix LD_LIBRARY_PATH : ${pcsclite}/lib
+    cat >> $out/share/applications/eid-viewer.desktop << EOF
+    # eid-viewer creates XML without a header, making it "plain text":
+    MimeType=application/xml;text/xml;text/plain
+    EOF
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
The .eid files are in fact XML, but lack an <?xml...?> declaration which
file(1) seems to expect. At least the viewer now appears as an option in
most GUIs.
