### PR TITLE
experimental/multiple-mysqld-instances

### DIFF
--- a/nixos/modules/misc/resources.nix
+++ b/nixos/modules/misc/resources.nix
@@ -1,0 +1,94 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  resourceOpt = { name, config, ... }: {
+    options = {
+
+      allowCollisions = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          If collissions are fine set to true
+        '';
+      };
+
+      required_by = mkOption {
+        type = mkOptionType {
+          name = "required_by";
+          check = isString;
+          merge = loc: defs: defs;
+        };
+
+        description = ''
+          Talks about what is requiring this resource. This helps the collision faster
+        '';
+      };
+    };
+  };
+
+  assertions_for = rname:
+    let cfg = config.resources.${rname};
+    in
+
+      foldl (assertions: name:
+        let c = cfg."${name}";
+            requires_to_str = xs: lib.concatStringsSep ", " (map (x: "${x.value} defined at ${x.file}" ) xs);
+        in if
+            name != "type"
+           && builtins.length c.required_by > 1
+           && !c.allowCollisions
+        then [{
+          assertion = false;
+          message = "Resource ${rname} ${name} would be used multiple times by ${requires_to_str c.required_by}. Set config.resources.${rname}.${name}.allowCollisions = true to ignore.";
+        }] ++ assertions else assertions
+      ) []
+      (attrNames cfg);
+
+  t = description: {
+    default = {};
+    type = types.attrsOf types.optionSet;
+    options = [ resourceOpt ];
+    inherit description;
+  };
+
+in
+
+{
+
+  options = {
+
+    resources.tcp-ports = mkOption (t "used tcp ports" // {
+      example = {
+        "80".required_by = "apache";
+        "8080".required_by = "tomcat";
+      };
+    });
+
+    resources.udp-ports = mkOption (t "used udp ports");
+
+    resources.paths = mkOption (t "used ptahs" // {
+      example = {
+        "/tmp/mysql.socket".required_by = "mysql";
+      };
+    });
+
+    resources.uids = mkOption (t "used uids");
+    resources.gids = mkOption (t "used gids");
+  };
+
+  config = {
+
+    assertions =
+         assertions_for "tcp-ports"
+      ++ assertions_for "udp-ports"
+      ++ assertions_for "paths"
+      ++ assertions_for "uids"
+      ++ assertions_for "gids"
+    ;
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -139,7 +139,7 @@
   ./services/databases/memcached.nix
   ./services/databases/monetdb.nix
   ./services/databases/mongodb.nix
-  ./services/databases/mysql.nix
+  ./services/databases/mysqls.nix
   ./services/databases/neo4j.nix
   ./services/databases/openldap.nix
   ./services/databases/opentsdb.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -57,6 +57,7 @@
   ./misc/meta.nix
   ./misc/nixpkgs.nix
   ./misc/passthru.nix
+  ./misc/resources.nix
   ./misc/version.nix
   ./programs/atop.nix
   ./programs/bash/bash.nix

--- a/nixos/modules/services/databases/mysqls.nix
+++ b/nixos/modules/services/databases/mysqls.nix
@@ -1,0 +1,352 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  root_config = config;
+
+  cfg = config.services.mysql;
+
+  enabled =
+    # services.mysql:
+    (lib.optional cfg.enable { name = "mysql"; m_config = cfg; })
+    # services.mysql.instances
+    ++ (mapAttrsToList (name: m_config: { inherit name m_config; }) (filterAttrs (n: m: m.enable) cfg.instances));
+
+  configs = map (m_config) enabled;
+
+  m_config = {name, m_config}:
+    let
+
+      mysql = m_config.package;
+
+      is55 = m_config.package.mysqlVersion == "5.6";
+
+      mysqldDir = if mysql ? mysqld_path then "${mysql}/${mysql.mysqld_path}" else "${mysql}/bin";
+
+      pidFile = "${m_config.pidDir}/mysqld.pid";
+
+      mysql_initOptions =
+        "--user=${m_config.user} --datadir=${m_config.dataDir} --basedir=${mysql} ";
+
+      mysqldOptions =
+        mysql_initOptions
+        + "--pid-file=${pidFile} --socket=${m_config.socketFile}";
+
+      myCnf = pkgs.writeText "my.cnf"
+      ''
+        [mysqld]
+        port = ${toString m_config.port}
+        ${optionalString (m_config.replication.role == "master" || m_config.replication.role == "slave") "log-bin=${name}-bin"}
+        ${optionalString (m_config.replication.role == "master" || m_config.replication.role == "slave") "server-id = ${toString m_config.replication.serverId}"}
+        ${optionalString (m_config.replication.role == "slave" && !is55)
+        ''
+          master-host = ${m_config.replication.masterHost}
+          master-user = ${m_config.replication.masterUser}
+          master-password = ${m_config.replication.masterPassword}
+          master-port = ${toString m_config.replication.masterPort}
+        ''}
+        ${m_config.extraOptions}
+      '';
+
+      tmp_init_file = "/tmp/${name}_init";
+
+    in {
+
+      users_extraUsers.${m_config.user} = {
+        description = "MySQL server user";
+        group = m_config.group;
+        uid = m_config.uid;
+      };
+
+      users_extraGroups.${m_config.group}.gid = m_config.gid;
+
+      systemd_services."mysql-${name}" =
+
+        { description = "MySQL Server ${name}";
+
+          wantedBy = [ "multi-user.target" ];
+
+          unitConfig.RequiresMountsFor = "${m_config.dataDir}";
+
+          preStart =
+            ''
+              if ! test -e ${m_config.dataDir}/${name}; then
+                  mkdir -m 0700 -p ${m_config.dataDir}
+                  chown -R ${m_config.user} ${m_config.dataDir}
+                  ${ mysql.mysql_initialize_datadir_cmd (m_config // { inherit mysql; }) }
+                  touch /tmp/mysql_init
+              fi
+              socketDir=$(dirname "${m_config.socketFile}")
+              mkdir -m 0755 -p  $socketDir
+              mkdir -m 0700 -p ${m_config.pidDir}
+              chown -R ${m_config.user} ${m_config.pidDir} $socketDir
+            '';
+
+          serviceConfig.Restart = "always";
+
+          serviceConfig.ExecStart = "${mysqldDir}/mysqld --defaults-extra-file=${myCnf} ${mysqldOptions}";
+
+          postStart =
+            ''
+              # Wait until the MySQL server is available for use
+              count=0
+              while [ ! -e ${m_config.socketFile} ]
+              do
+                  if [ $count -eq 30 ]
+                  then
+                      echo "Tried 30 times, giving up..."
+                      exit 1
+                  fi
+
+                  echo "MySQL daemon not yet started. Waiting for 1 second..."
+                  count=$((count++))
+                  sleep 1
+              done
+
+              if [ -f ${tmp_init_file} ]
+              then
+                  ${concatMapStrings (database:
+                    ''
+                      # Create initial databases
+                      if ! test -e "${m_config.dataDir}/${database.name}"; then
+                          echo "Creating initial database: ${database.name}"
+                          ( echo "create database ${database.name};"
+                            echo "use ${database.name};"
+
+                            if [ -f "${database.schema}" ]
+                            then
+                                cat ${database.schema}
+                            elif [ -d "${database.schema}" ]
+                            then
+                                cat ${database.schema}/mysql-databases/*.sql
+                            fi
+                          ) | ${mysql}/bin/mysql -u root -N -S ${m_config.socketFile}
+                      fi
+                    '') m_config.initialDatabases}
+
+                  ${optionalString (m_config.replication.role == "slave" && is55)
+                    ''
+                      # Set up the replication master
+
+                      ( echo "stop slave;"
+                        echo "change master to master_host='${m_config.replication.masterHost}', master_user='${m_config.replication.masterUser}', master_password='${m_config.replication.masterPassword}';"
+                        echo "start slave;"
+                      ) | ${mysql}/bin/mysql -u root -N -S ${m_config.socketFile}
+                    ''}
+
+                  ${optionalString (m_config.initialScript != null)
+                    ''
+                      # Execute initial script
+                      cat ${m_config.initialScript} | ${mysql}/bin/mysql -u root -N -S ${m_config.socketFile}
+                    ''}
+
+                  ${optionalString (m_config.rootPassword != null)
+                    ''
+                      # Change root password
+
+                      ( echo "use mysql;"
+                        echo "update user set Password=password('$(cat ${m_config.rootPassword})') where User='root';"
+                        echo "flush privileges;"
+                      ) | ${mysql}/bin/mysql -u root -N -S ${m_config.socketFile} || true
+                    ''}
+
+                rm ${tmp_init_file}
+              fi
+            ''; # */
+        };
+
+      };
+
+  mysqlOpts = { name, /*config,*/ ... }: {
+    options = {
+
+      enable = mkOption {
+        default = false;
+        description = "
+          Whether to enable the MySQL server.
+        ";
+      };
+
+      package = mkOption {
+        type = types.package;
+        example = literalExample "pkgs.mysql";
+        description = "
+          Which MySQL derivation to use.
+        ";
+      };
+
+      port = mkOption {
+        default = "3306";
+        description = "Port of MySQL";
+      };
+
+      user = mkOption {
+        default = name;
+        description = "User account under which MySQL runs";
+      };
+
+      uid = mkOption {
+        description = "uid for this mysql instance";
+        default =
+          if (!hasAttr name root_config.ids.uids) then
+            config.ids.uids.mysql
+          else root_config.ids.uids.${name};
+      };
+
+      group = mkOption {
+        description = "group";
+        default = name;
+      };
+
+      gid = mkOption {
+        description = "gid";
+        default =
+          if (!hasAttr name root_config.ids.gids) then
+            config.ids.gids.mysql
+          else root_config.ids.gids.${name};
+      };
+
+      dataDir = mkOption {
+        default = "/var/db/mysqls/${name}";
+        description = "Location where MySQL stores its table files";
+      };
+
+      pidDir = mkOption {
+        default = "/var/run/mysqls/${name}";
+        description = "Location of the file which stores the PID of the MySQL server";
+      };
+
+      socketFile = mkOption {
+        description = "socket file location for this mysql instance";
+        default = "/tmp/${name}.sock";
+      };
+
+      extraOptions = mkOption {
+        default = "";
+        example = ''
+          key_buffer_size = 6G
+          table_cache = 1600
+          log-error = /var/log/mysqls/${name}_err.log
+        '';
+        description = ''
+          Provide extra options to the MySQL configuration file.
+
+          Please note, that these options are added to the
+          <literal>[mysqld]</literal> section so you don't need to explicitly
+          state it again.
+        '';
+      };
+
+      initialDatabases = mkOption {
+        default = [];
+        description = "List of database names and their initial schemas that should be used to create databases on the first startup of MySQL";
+        example = [
+          { name = "foodatabase"; schema = literalExample "./foodatabase.sql"; }
+          { name = "bardatabase"; schema = literalExample "./bardatabase.sql"; }
+        ];
+      };
+
+      initialScript = mkOption {
+        default = null;
+        description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database";
+      };
+
+      # FIXME: remove this option; it's a really bad idea.
+      rootPassword = mkOption {
+        default = null;
+        description = "Path to a file containing the root password, modified on the first startup. Not specifying a root password will leave the root password empty.";
+      };
+
+      replication = {
+        role = mkOption {
+          default = "none";
+          description = "Role of the MySQL server instance. Can be either: master, slave or none";
+        };
+
+        serverId = mkOption {
+          default = 1;
+          description = "Id of the MySQL server instance. This number must be unique for each instance";
+        };
+
+        masterHost = mkOption {
+          description = "Hostname of the MySQL master server";
+        };
+
+        masterUser = mkOption {
+          description = "Username of the MySQL replication user";
+        };
+
+        masterPassword = mkOption {
+          description = "Password of the MySQL replication user";
+        };
+
+        masterPort = mkOption {
+          default = 3306;
+          description = "Port number on which the MySQL master server runs";
+        };
+      };
+    };
+  };
+
+  prepareResources = mysql_attr_name:
+      map ({name, m_config}: {
+          "${builtins.toString m_config.${mysql_attr_name}}".required_by = "mysql instance ${name}"; 
+      }) enabled;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.mysql =
+      # be backward compatible, provide services.mysql
+      (mysqlOpts { name = "mysql"; }).options
+
+      // {
+        systemPackage = mkOption {
+          default =
+            if enabled == [] then null
+            else (builtins.head enabled).m_config.package;
+          type = types.nullOr types.package;
+          description = ''
+            The mysql package to be added to <option>environment.systemPackages</option>
+          '';
+        };
+
+        instances = mkOption {
+          default = {};
+          type = types.attrsOf types.optionSet;
+          example = {
+            mysql.enable = true;
+          };
+          description = ''
+            If you want more than one mysql instance set <option>services.mysql.instances.name.enable = true</option>
+          '';
+          options = [ mysqlOpts ];
+        };
+      };
+  };
+
+
+  ###### implementation
+
+  config = {
+    systemd.services = mkMerge (catAttrs "systemd_services" configs);
+    environment.systemPackages = lib.optional (cfg.systemPackage != null) cfg.systemPackage;
+    users.extraGroups = mkMerge (catAttrs "users_extraGroups" configs);
+    users.extraUsers = mkMerge (catAttrs "users_extraUsers" configs);
+
+    resources."tcp-ports" = mkMerge (prepareResources "port");
+    resources.paths = mkMerge (
+      (prepareResources "socketFile")
+      ++ (prepareResources "dataDir")
+      ++ (prepareResources "pidDir")
+    );
+  };
+
+}

--- a/pkgs/servers/sql/mysql/5.1.x.nix
+++ b/pkgs/servers/sql/mysql/5.1.x.nix
@@ -34,6 +34,10 @@ stdenv.mkDerivation rec {
 
   passthru.mysqlVersion = "5.1";
 
+  mysql_initialize_datadir_cmd = {mysql, user, dataDir, baseDir}: ''
+    ${mysql}/bin/mysql_install_db "--user=${user} --datadir=${dataDir} --basedir=${mysql} ";
+  '';
+
   meta = {
     homepage = http://www.mysql.com/;
     description = "The world's most popular open source database";

--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation rec {
 
   passthru.mysqlVersion = "5.5";
 
+  passthru.mysql_initialize_datadir_cmd = {dir, mysql, user, dataDir, ...}: ''
+    ${mysql}/bin/mysql_install_db "--user=${user} --datadir=${dataDir} --basedir=${mysql} ";
+  '';
+
   meta = {
     homepage = http://www.mysql.com/;
     description = "The world's most popular open source database";

--- a/pkgs/servers/sql/mysql/5.6.x.nix
+++ b/pkgs/servers/sql/mysql/5.6.x.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, cmake, bison, ncurses, openssl, readline, zlib, perl }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+let x = stdenv.mkDerivation rec {
+  name = "mysql-${version}";
+  version = "5.6.23";
+
+  src = fetchurl {
+    url = "http://cdn.mysql.com/Downloads/MySQL-5.6/${name}.tar.gz";
+    md5 = "60344f26eae136a267a0277407926e79";
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  buildInputs = [ cmake bison ncurses openssl readline zlib perl ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = "-DWITH_SSL=yes -DWITH_READLINE=yes -DWITH_EMBEDDED_SERVER=yes -DWITH_ZLIB=yes -DINSTALL_SCRIPTDIR=bin -DHAVE_IPV6=yes";
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+  '';
+  postInstall = ''
+    sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
+    rm -rf $out/mysql-test $out/sql-bench
+  '';
+
+  passthru.mysqlVersion = "5.6";
+  passthru.mysqld_path = "libexec";
+
+  passthru.mysql_initialize_datadir_cmd = {mysql, user, dataDir, ...}: ''
+    ${mysql}/bin/mysql_install_db "--user=${user} --datadir=${dataDir} --basedir=${mysql} ";
+  '';
+
+  meta = {
+    homepage = http://www.mysql.com/;
+    description = "The world's most popular open source database";
+  };
+};
+
+in x // { lib = x; }

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, cmake, bison, ncurses, openssl, readline, zlib, perl, boost159 }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+let x = stdenv.mkDerivation rec {
+  name = "mysql-${version}";
+  version = "5.7.12";
+
+  src = fetchurl {
+    url = http://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.12.tar.gz;
+    md5 = "af17ba16f1b21538c9de092651529f7c";
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  buildInputs = [ cmake bison ncurses openssl readline zlib perl boost159];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = "-DWITH_SSL=yes -DWITH_READLINE=yes -DWITH_EMBEDDED_SERVER=yes -DWITH_ZLIB=yes -DINSTALL_SCRIPTDIR=bin -DHAVE_IPV6=yes";
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+  '';
+  postInstall = ''
+    sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
+    rm -rf $out/mysql-test $out/sql-bench
+  '';
+
+  passthru.mysqlVersion = "5.7";
+
+  passthru.mysql_initialize_datadir_cmd = {mysql, user, dataDir, ...}: ''
+    [ -d ${dataDir}/mysql ] || ${mysql}/bin/mysqld --user=${user} --initialize --initialize-insecure --basedir=${mysql} --datadir=${dataDir}
+  '';
+
+  meta = {
+    homepage = http://www.mysql.com/;
+    description = "The world's most popular open source database";
+  };
+};
+
+in x // { lib = x; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5643,7 +5643,9 @@ in
     php = php70;
   });
 
-  inherit (callPackages ../development/interpreters/php { })
+  inherit (callPackages ../development/interpreters/php {
+      mysql = mysql56;
+   })
     php55
     php56
     php70;
@@ -10092,6 +10094,10 @@ in
     inherit (darwin) cctools;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
+
+  mysql56 = callPackage ../servers/sql/mysql/5.6.x.nix { };
+
+  mysql57 = callPackage ../servers/sql/mysql/5.7.x.nix { };
 
   mysql = mariadb;
   libmysql = mysql.lib;


### PR DESCRIPTION
Allow instantiating multiple mysql instances.

Usage example of most current patch version:

```
  services.mysql.enable = true; // traditional

  // add another instance:
  service.mysql.services.mysql_on_tmp = {
    enable = true;
    port = 3307;
    package = pkgs.mysql55;
    dataDir = "/tmp/mysql";
    socketDir = "/tmp/mysql_tmpfs.socket";
    uid = 20000;
    gid = 20000;
  };
```
