### PR TITLE
Add fetchurl mirrors for OpenBSD

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -431,4 +431,13 @@ rec {
     http://mysql.mirrors.pair.com/Downloads/
     http://cdn.mysql.com/Downloads/
   ];
+
+  # OpenBSD mirrors
+  openbsd = [
+    http://ftp.openbsd.org/pub/OpenBSD/
+    ftp://ftp.nluug.nl/pub/OpenBSD/
+    ftp://ftp-stud.fht-esslingen.de/pub/OpenBSD/
+    ftp://ftp.halifax.rwth-aachen.de/pub/OpenBSD/
+    ftp://mirror.switch.ch/pub/OpenBSD/
+  ];
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.0.5";
 
   src = fetchurl {
-    url    = "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${name}.tar.gz";
+    url    = "mirror://openbsd/LibreSSL/${name}.tar.gz";
     sha256 = "16pwgmj90k10pf03il39lnck5kqw59hj0fp2qhmgsgmrvssn6m1z";
   };
 

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   name = "openssh-6.7p1";
 
   src = fetchurl {
-    url = "http://ftp.nluug.nl/pub/OpenBSD/OpenSSH/portable/${name}.tar.gz";
+    url = "mirror://openbsd/OpenSSH/portable/${name}.tar.gz";
     sha256 = "01smf9pvn2sk5qs80gkmc9acj07ckawi1b3xxyysp3c5mr73ky5j";
   };
 


### PR DESCRIPTION
This changes source URLs for openssh and libressl accordingly.

This was done because `ftp.nluug.nl` is currently offline and the source tarball of `openssh` couldn't be fetched.
