### PR TITLE
t1lib: Use metalab mirrors

### DIFF
--- a/pkgs/development/libraries/t1lib/default.nix
+++ b/pkgs/development/libraries/t1lib/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "t1lib-5.1.2";
 
   src = fetchurl {
-    url = "ftp://ftp.nluug.nl/pub/metalab/libs/graphics/t1lib-5.1.2.tar.gz";
+    url = "mirror://metalab/libs/graphics/t1lib-5.1.2.tar.gz";
     sha256 = "0nbvjpnmcznib1nlgg8xckrmsw3haa154byds2h90y2g0nsjh4w2";
   };
 


### PR DESCRIPTION
`ftp.nluug.nl` is currently offline and this is the right way to do it. :)
