### PR TITLE
zsh: profile-relative functions path

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -105,6 +105,10 @@ in
 
     };
 
+    environment.profileRelativeEnvVars =
+      { FPATH = [ "/share/zsh/site-functions" ];
+      };
+
     environment.etc."zshenv".text =
       ''
         # /etc/zshenv: DO NOT EDIT -- this file has been generated automatically.


### PR DESCRIPTION
This is needed mostly for autocompletion.
