### PR TITLE
Add profanity and dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat, ncurses, libnotify, libotr, curl, libstrophe }:
+
+stdenv.mkDerivation rec {
+  name = "profanity-${version}";
+  version = "0.4.5";
+
+  src = fetchurl {
+    url = "http://www.profanity.im/profanity-${version}.tar.gz";
+    sha256 = "0qzwqxcxf695z3gf94psd2x619vlp4hkkjmkrpsla1ns0f6v6dkl";
+  };
+
+  buildInputs = [ automake autoconf pkgconfig glib openssl expat ncurses libnotify libotr curl libstrophe ];
+
+  preConfigure = "sh bootstrap.sh";
+
+  meta = {
+    description = "A console based XMPP client";
+    longDescription = ''
+      Profanity is a console based XMPP client written in C using ncurses and
+      libstrophe, inspired by Irssi.
+    '';
+    homepage = http://profanity.im/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat, ncurses, libnotify, libotr, curl, libstrophe }:
+{ stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat, ncurses, libnotify, libotr, curl, libstrophe, libXScrnSaver, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "profanity-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qzwqxcxf695z3gf94psd2x619vlp4hkkjmkrpsla1ns0f6v6dkl";
   };
 
-  buildInputs = [ automake autoconf pkgconfig glib openssl expat ncurses libnotify libotr curl libstrophe ];
+  buildInputs = [ automake autoconf pkgconfig glib openssl expat ncurses libnotify libotr curl libstrophe libXScrnSaver libX11 ];
 
   preConfigure = "sh bootstrap.sh";
 

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://profanity.im/;
     license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,5 +1,11 @@
-{ stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat, ncurses, libnotify, libotr, curl, libstrophe, libXScrnSaver, libX11 }:
+{ stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat, ncurses, libotr, curl, libstrophe,
+libnotifySupport ? false, libnotify ? null, libXScrnSaver ? null, libX11 ? null, gdk_pixbuf ? null}:
 
+assert libnotifySupport -> (libnotify != null && libXScrnSaver != null && libX11 != null && gdk_pixbuf != null);
+
+let
+  optional = stdenv.lib.optional;
+in
 stdenv.mkDerivation rec {
   name = "profanity-${version}";
   version = "0.4.5";
@@ -9,7 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "0qzwqxcxf695z3gf94psd2x619vlp4hkkjmkrpsla1ns0f6v6dkl";
   };
 
-  buildInputs = [ automake autoconf pkgconfig glib openssl expat ncurses libnotify libotr curl libstrophe libXScrnSaver libX11 ];
+  buildInputs = [ automake autoconf pkgconfig glib openssl expat ncurses libotr curl libstrophe ]
+    ++ optional libnotifySupport [ libnotify libXScrnSaver libX11 gdk_pixbuf ];
 
   preConfigure = "sh bootstrap.sh";
 

--- a/pkgs/development/libraries/libstrophe/default.nix
+++ b/pkgs/development/libraries/libstrophe/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://strophe.im/libstrophe/;
     license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }

--- a/pkgs/development/libraries/libstrophe/default.nix
+++ b/pkgs/development/libraries/libstrophe/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       minimal dependencies and is configurable for various environments. It
       runs well on both Linux, Unix, and Windows based platforms.
     '';
-    hompeage = http://strophe.im/libstrophe/;
+    homepage = http://strophe.im/libstrophe/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.devhell ];
   };

--- a/pkgs/development/libraries/libstrophe/default.nix
+++ b/pkgs/development/libraries/libstrophe/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, automake, autoconf, libtool, openssl, expat, pkgconfig, check }:
+
+stdenv.mkDerivation rec {
+  name = "libstrophe-${version}";
+  version = "0.8.7";
+
+  src = fetchFromGitHub {
+    owner = "strophe";
+    repo = "libstrophe";
+    rev = version;
+    sha256 = "1iic8xbcxh21dzns8m9kkz0cj5f3ppn414gnhyh4y2wcjsz6hp8l";
+  };
+
+  buildInputs = [ automake autoconf openssl expat libtool pkgconfig check ];
+
+  dontDisableStatic = true;
+
+  preConfigure = "mkdir m4 && sh bootstrap.sh";
+
+  doCheck = true;
+
+  meta = {
+    description = "A simple, lightweight C library for writing XMPP clients";
+    longDescription = ''
+      libstrophe is a lightweight XMPP client library written in C. It has
+      minimal dependencies and is configurable for various environments. It
+      runs well on both Linux, Unix, and Windows based platforms.
+    '';
+    hompeage = http://strophe.im/libstrophe/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10579,6 +10579,8 @@ let
   # And I don't want to rewrite all rules
   procmail = callPackage ../applications/misc/procmail { };
 
+  profanity = callPackage ../applications/networking/instant-messengers/profanity { };
+
   pstree = callPackage ../applications/misc/pstree { };
 
   pulseview = callPackage ../applications/science/electronics/pulseview { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10579,7 +10579,9 @@ let
   # And I don't want to rewrite all rules
   procmail = callPackage ../applications/misc/procmail { };
 
-  profanity = callPackage ../applications/networking/instant-messengers/profanity { };
+  profanity = callPackage ../applications/networking/instant-messengers/profanity {
+    libnotifySupport = config.profanity.libnotifySupport or true;
+  };
 
   pstree = callPackage ../applications/misc/pstree { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6164,6 +6164,8 @@ let
 
   libstartup_notification = callPackage ../development/libraries/startup-notification { };
 
+  libstrophe = callPackage ../development/libraries/libstrophe { };
+
   libspatialindex = callPackage ../development/libraries/libspatialindex { };
 
   libspatialite = callPackage ../development/libraries/libspatialite { };


### PR DESCRIPTION
This adds the ncurses irssi-style XMPP client profanity. This commit also includes the dependency libstrophe.
