### PR TITLE
Add libkeyfinder and keyfinder{,-cli} interfaces

### DIFF
--- a/pkgs/applications/audio/keyfinder-cli/default.nix
+++ b/pkgs/applications/audio/keyfinder-cli/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, libav, libkeyfinder }:
+
+stdenv.mkDerivation rec {
+  version = "20150125";
+  name = "keyfinder-cli-${version}";
+
+  src = fetchFromGitHub {
+    repo = "keyfinder-cli";
+    owner = "EvanPurkhiser";
+    rev = "3a6f598b3661fdba73ada81cd200a6e56c23ddca";
+    sha256 = "05k4g9zdzi4q81p8lax9b2j4bcg1bpp04sdbza5i5pfz2fng2cf7";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Musical key detection for digital audio (command-line tool)";
+    longDescription = ''
+      This small utility is the automation-oriented DJ's best friend. By making
+      use of Ibrahim Sha'ath's high quality libKeyFinder library, it can be
+      used to estimate the musical key of many different audio formats.
+    '';
+    homepage = https://github.com/EvanPurkhiser/keyfinder-cli;
+    license = with licenses; gpl3Plus;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ nckx ];
+  };
+
+  buildInputs = [ libav libkeyfinder ];
+
+  makeFlagsArray = "PREFIX=$(out)";
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/applications/audio/keyfinder/default.nix
+++ b/pkgs/applications/audio/keyfinder/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, libav_0_8, libkeyfinder, qt5, taglib }:
+
+stdenv.mkDerivation rec {
+  version = "1.25-17-gf670607";
+  name = "keyfinder-${version}";
+
+  src = fetchFromGitHub {
+    repo = "is_KeyFinder";
+    owner = "ibsh";
+    rev = "f6706074435ac14c5238ee3f0dd22ac22d72af9c";
+    sha256 = "1sfnywc6jdpm03344i6i4pz13mqa4i5agagj4k6252m63cqmjkrc";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Musical key detection for digital audio (graphical UI)";
+    longDescription = ''
+      KeyFinder is an open source key detection tool, for DJs interested in
+      harmonic and tonal mixing. Designed primarily for electronic and dance
+      music, it is highly configurable and can be applied to many genres. It
+      supports a huge range of codecs thanks to LibAV, and writes to metadata
+      tags using TagLib. It's intended to be very focused: no library
+      management, no track suggestions, no media player. Just a fast,
+      efficient workflow tool.
+    '';
+    homepage = http://www.ibrahimshaath.co.uk/keyfinder/;
+    license = with licenses; gpl3Plus;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ nckx ];
+  };
+
+  # TODO: upgrade libav when "Audio sample format conversion failed" is fixed
+  buildInputs = [ libav_0_8 libkeyfinder qt5 taglib ];
+
+  configurePhase = ''
+    substituteInPlace is_KeyFinder.pro \
+       --replace "keyfinder.0" "keyfinder" \
+       --replace '$$[QT_INSTALL_PREFIX]' "$out"
+    qmake
+  '';
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/libraries/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/libkeyfinder/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, boost, fftw, qt5 }:
+
+stdenv.mkDerivation rec {
+  version = "0.11.0-20141105";
+  name = "libkeyfinder-${version}";
+
+  src = fetchFromGitHub {
+    repo = "libKeyFinder";
+    owner = "ibsh";
+    rev = "592ef1f3d3ada489f80814d5ccfbc8de6029dc9d";
+    sha256 = "0xcqpizwbn6wik3w7h9k1lvgrp3r3w6yyy55flvnwwwgvkry48as";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Musical key detection for digital audio (C++ library)";
+    homepage = http://www.ibrahimshaath.co.uk/keyfinder/;
+    license = with licenses; gpl3Plus;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ nckx ];
+  };
+
+  buildInputs = [ fftw qt5 ];
+  propagatedBuildInputs = [ boost ];
+
+  patchPhase = ''
+    substituteInPlace LibKeyFinder.pro --replace "/usr/local" "$out"
+  '';
+
+  configurePhase = ''
+    qmake
+  '';
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    mkdir -p $out/include/keyfinder
+    cp *.h $out/include/keyfinder
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10344,6 +10344,8 @@ let
 
   kermit = callPackage ../tools/misc/kermit { };
 
+  keyfinder = callPackage ../applications/audio/keyfinder { };
+
   keymon = callPackage ../applications/video/key-mon { };
 
   kid3 = callPackage ../applications/audio/kid3 {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10346,6 +10346,8 @@ let
 
   keyfinder = callPackage ../applications/audio/keyfinder { };
 
+  keyfinder-cli = callPackage ../applications/audio/keyfinder-cli { };
+
   keymon = callPackage ../applications/video/key-mon { };
 
   kid3 = callPackage ../applications/audio/kid3 {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6172,6 +6172,8 @@ let
 
   libkate = callPackage ../development/libraries/libkate { };
 
+  libkeyfinder = callPackage ../development/libraries/libkeyfinder { };
+
   libksba = callPackage ../development/libraries/libksba { };
 
   libmad = callPackage ../development/libraries/libmad { };


### PR DESCRIPTION
A very useful library, CLI tool, and Qt 5 GUI to automatically detect the key of _most_ audio files.

The `{lib,}keyfinder` packages are both MacOS X projects that also build and run fine on Linux (with a few hiccups left in the GUI). However, `.platforms` is currently limited to Linux because I have never owned a Mac in my life. Help welcome.
