### PR TITLE
kernel: enable intel_pstate

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -7,6 +7,9 @@ with stdenv.lib;
   DEBUG_KERNEL y
   PM_ADVANCED_DEBUG y
   PM_RUNTIME y
+  ${optionalString (versionAtLeast version "3.10") ''
+    X86_INTEL_PSTATE y
+  ''}
   TIMER_STATS y
   ${optionalString (versionOlder version "3.10") ''
     USB_SUSPEND y


### PR DESCRIPTION
This enables `intel_pstate` power governor which takes advantage of modern Intel CPU features if available. It cannot be built as module and switches itself on automatically if processor is supported. Arguably, in some cases users might see worse consumption with it (although in most major distros now it is enabled by default [1](https://askubuntu.com/questions/544266/why-are-missing-the-frequency-options-on-cpufreq-utils-indicator/544273#544273), [2](https://unix.stackexchange.com/questions/117770/how-to-get-ondemand-governor-on-fedora), [3](https://wiki.archlinux.org/index.php/CPU_frequency_scaling#CPU_frequency_driver)) -- we can make it disabled by default if we want, though personally I don't think we need.

P.S. somehow if I write `[1] [2] [3]` in a GitHub comment, [2](https://unix.stackexchange.com/questions/117770/how-to-get-ondemand-governor-on-fedora) is invisible -- is this a bug?
