### PR TITLE
added groff as dep for awscli

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -18,6 +18,7 @@ pythonPackages.buildPythonPackage rec {
     pythonPackages.docutils
     pythonPackages.rsa
     pythonPackages.pyasn1
+    groff
   ];
 
   meta = {


### PR DESCRIPTION
added groff as dep

groff is needed for help functionality in awscli
