### PR TITLE
syncthing: Update to 0.10.17

### DIFF
--- a/pkgs/applications/networking/syncthing/fix-go-1.4-range.patch
+++ b/pkgs/applications/networking/syncthing/fix-go-1.4-range.patch
@@ -1,0 +1,14 @@
+diff --git a/internal/model/queue_test.go b/internal/model/queue_test.go
+index 3745664..96aaf38 100644
+--- a/internal/model/queue_test.go
++++ b/internal/model/queue_test.go
+@@ -191,7 +191,7 @@ func BenchmarkJobQueuePushPopDone10k(b *testing.B) {
+ 		for _, f := range files {
+ 			q.Push(f.Name)
+ 		}
+-		for range files {
++		for _ = range files {
+ 			n, _ := q.Pop()
+ 			q.Done(n)
+ 		}
+--


### PR DESCRIPTION
Changes:
- Syncthing's repo moved
- One of the tests won't build on Go 1.3. I submitted [a pull request to fix that](https://github.com/syncthing/syncthing/pull/1183), and also just included the patch so we don't have to wait for the next release.
- Dependencies are easier to deal with now, since there's only one "internal" folder.
- The TestPredictableRandom test relies on global state, so we can't run it with -cpu.
- stcli doesn't exist anymore. I have no idea what this is so maybe someone else should sanity check this.
