### PR TITLE
php: add optional ZTS support and new PECL module pthreads

### DIFF
--- a/pkgs/development/interpreters/php/5.4.nix
+++ b/pkgs/development/interpreters/php/5.4.nix
@@ -185,6 +185,10 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
         buildInputs = [freetds];
       };
 
+      zts = {
+        configureFlags = ["--enable-maintainer-zts"];
+      };
+
       /*
          php is build within this derivation in order to add the xdebug lines to the php.ini.
          So both Apache and command line php both use xdebug without having to configure anything.
@@ -224,6 +228,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     ftpSupport = config.php.ftp or true;
     fpmSupport = config.php.fpm or true;
     mssqlSupport = config.php.mssql or (!stdenv.isDarwin);
+    ztsSupport = config.php.zts or false;
   };
 
   configurePhase = ''

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -78,4 +78,12 @@ let self = with self; {
 
     buildInputs = [ pkgs.m4 ];
   };
+
+  pthreads = assert pkgs.config.php.zts or false; buildPecl {
+    #pthreads requires a build of PHP with ZTS (Zend Thread Safety) enabled
+    #--enable-maintainer-zts or --enable-zts on Windows
+    name = "pthreads-2.0.10";
+    sha256 = "1xlcb1b1g10jd0xhm3c01a06yqpb5qln47pd1k522138324qvpwb";
+  };
+
 }; in self


### PR DESCRIPTION
Zend Thread Safety cannot be enabled post build; it is a build time configuration option.
pthreads requires a build of PHP with ZTS (Zend Thread Safety) enabled
