### PR TITLE
nixos/rngd: some fixes

### DIFF
--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -20,7 +20,7 @@ with lib;
       KERNEL=="random", TAG+="systemd"
       SUBSYSTEM=="cpu", ENV{MODALIAS}=="x86cpu:*feature:*009E*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rngd.service"
       KERNEL=="hw_random", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rngd.service"
-      KERNEL=="tmp0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rngd.service"
+      ${if config.services.tcsd.enable then "" else ''KERNEL=="tpm0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rngd.service"''}
     '';
 
     systemd.services.rngd = {
@@ -32,8 +32,6 @@ with lib;
 
       serviceConfig.ExecStart = "${pkgs.rng_tools}/sbin/rngd -f -v" +
         (if config.services.tcsd.enable then " --no-tpm=1" else "");
-
-      restartTriggers = [ pkgs.rng_tools ];
     };
   };
 }


### PR DESCRIPTION
A small cleanup (`restartTriggers` is not needed there IIRC, it restarts without it at least), and fix of tpm's handling.
