### PR TITLE
Various (hopefully) small changes

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -100,7 +100,7 @@ in
         export HISTSIZE=2000
         export HISTFILE=$HOME/.zsh_history
 
-        setopt HIST_IGNORE_DUPS SHARE_HISTORY
+        setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
       '';
 
     };

--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation {
     ++ optional sslSupport openssl
     ++ optional gpgSupport gpgme;
 
-  configureFlags = optionalString sslSupport "--enable-ssl";
+  configureFlags = optional sslSupport "--enable-ssl"
+                ++ optional gpgSupport "--enable-gpgme";
 
   meta = {
     homepage = http://sylpheed.sraoss.jp/en/;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -326,6 +326,11 @@ with stdenv.lib;
   ''}
   VIRT_DRIVERS y
 
+  # Device virtualisation.
+  ${optionalString (versionAtLeast version "3.9") ''
+    VFIO_PCI_VGA? y
+  ''}
+
   # Media support.
   ${optionalString (versionAtLeast version "3.6") ''
     MEDIA_DIGITAL_TV_SUPPORT y

--- a/pkgs/tools/audio/qastools/default.nix
+++ b/pkgs/tools/audio/qastools/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, alsaLib, udev, qt }:
+
+let
+  version = "0.18.1";
+in
+
+stdenv.mkDerivation {
+  name = "qastools-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/qastools/qastools_${version}.tar.bz2";
+    sha256 = "1sac6a0j1881wgpv4491b2f4jnhqkab6xyldmcg1wfqb5qkdgzvg";
+  };
+
+  buildInputs = [
+    cmake alsaLib udev qt
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSALL_PREFIX=$out"
+    "-DALSA_INCLUDE=${alsaLib}/include/alsa/version.h"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Collection of desktop applications for ALSA configuration";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2251,6 +2251,10 @@ let
 
   openmpi = callPackage ../development/libraries/openmpi { };
 
+  qastools = callPackage ../tools/audio/qastools {
+    qt = qt4;
+  };
+
   qhull = callPackage ../development/libraries/qhull { };
 
   qjoypad = callPackage ../tools/misc/qjoypad { };


### PR DESCRIPTION
Some random well-tested and useful changes.

zsh change is about being more humane to disk drives (especially SSDs).

I debugged this by running

```
echo 1 > /sys/kernel/debug/tracing/events/jbd2/jbd2_run_stats/enable
echo 1 > /sys/kernel/debug/tracing/events/ext4/ext4_journal_start/enable
... (and similarly for other file systems)
cat /sys/kernel/debug/tracing/trace_pipe
```

on a server and then waiting a day without doing anything disk intensive on the machine.

Linux and Sylpheed are about enabling missing features.

Qastools is by request from a colleague.
