### PR TITLE
Add Workrave, an RSI prevention app

### DIFF
--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, autoconf, automake, gettext, intltool, libtool, pkgconfig,
+  libXtst, cheetah, libXScrnSaver,
+  glib, glibmm,
+  gtk, gtkmm,
+  atk,
+  pango, pangomm,
+  cairo, cairomm,
+  dbus, dbus_glib,
+  GConf, gconfmm,
+  gdome2, gstreamer, libsigcxx }:
+
+stdenv.mkDerivation rec {
+  version = "v1_10_6";
+  name = "workrave-${version}";
+
+  src = fetchurl {
+    url = "http://github.com/rcaelers/workrave/archive/${version}.tar.gz";
+    sha256 = "0q2p83n33chbqzdcdm7ykfsy73frfi6drxzm4qidxwzpzsxrysgq";
+  };
+
+  buildInputs = [
+    autoconf automake gettext intltool libtool pkgconfig libXtst cheetah
+    libXScrnSaver
+
+    glib glibmm gtk gtkmm atk pango pangomm cairo cairomm
+    dbus dbus_glib GConf gconfmm gdome2 gstreamer libsigcxx
+  ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "A program to help prevent Repetitive Strain Injury";
+    longDescription = ''
+      Workrave is a program that assists in the recovery and prevention of
+      Repetitive Strain Injury (RSI). The program frequently alerts you to
+      take micro-pauses, rest breaks and restricts you to your daily limit.
+    '';
+    homepage = http://www.workrave.org/;
+    downloadPage = https://github.com/rcaelers/workrave/releases;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ prikhi ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/logic/matita/130312.nix
+++ b/pkgs/applications/science/logic/matita/130312.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://matita.cs.unibo.it/sources/${pname}_130312.tar.gz"; 
+    url = "http://matita.cs.unibo.it/sources/${pname}_130312.tar.gz";
     sha256 = "13mjvvldv53dcdid6wmc6g8yn98xca26xq2rgq2jg700lqsni59s";
   };
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '';
 
   prePatch = ''
-   autoreconf -fvi 
+   autoreconf -fvi
   '';
 
   buildInputs = [ocaml findlib gdome2 ocaml_expat gmetadom ocaml_http lablgtk ocaml_mysql ocamlnet ulex08 camlzip ocaml_pcre automake autoconf];
@@ -62,5 +62,6 @@ stdenv.mkDerivation {
     description = "Matita is an experimental, interactive theorem prover";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/gdome2/default.nix
+++ b/pkgs/development/libraries/gdome2/default.nix
@@ -15,12 +15,13 @@ stdenv.mkDerivation {
 
   buildInputs = [pkgconfig glib libxml2 gtkdoc];
   propagatedBuildInputs = [glib libxml2];
+  patches = [ ./xml-document.patch ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://gdome2.cs.unibo.it/;
     description = "DOM C library developed for the Gnome project";
-    license = stdenv.lib.licenses.lgpl21Plus;
-    maintainers = [ stdenv.lib.maintainers.roconnor ];
-    broken = true;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ prikhi roconnor ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/gdome2/xml-document.patch
+++ b/pkgs/development/libraries/gdome2/xml-document.patch
@@ -1,0 +1,11 @@
+--- a/libgdome/gdomecore/gdome-xml-documentt.c	2003-07-13 14:47:54.000000000 +0400
++++ b/libgdome/gdomecore/gdome-xml-documentt.c	2013-07-02 14:09:18.304613703 +0400
+@@ -342,7 +342,7 @@
+ 	}
+ 	xmlNodeDumpOutput (out_buff, NULL, (xmlNode *)is, 0, 0, NULL);
+ 	xmlOutputBufferFlush(out_buff);
+-	ret = g_strndup (out_buff->buffer->content, out_buff->buffer->use);
++	ret = g_strndup (xmlBufContent(out_buff), xmlBufUse(out_buff));
+ 	(void)xmlOutputBufferClose(out_buff);
+
+ 	return gdome_xml_str_mkref_own (ret);

--- a/pkgs/development/ocaml-modules/lablgtkmathview/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtkmathview/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation {
     description = "OCaml bindings for gtkmathview";
     license = stdenv.lib.licenses.lgpl2Plus;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11316,6 +11316,11 @@ let
 
   wordnet = callPackage ../applications/misc/wordnet { };
 
+  workrave = callPackage ../applications/misc/workrave {
+    inherit (gnome) GConf gconfmm;
+    inherit (python27Packages) cheetah;
+  };
+
   wrapFirefox =
     { browser, browserName ? "firefox", desktopName ? "Firefox", nameSuffix ? ""
     , icon ? "${browser}/lib/${browser.name}/browser/icons/mozicon128.png" }:


### PR DESCRIPTION
`lablgtkmathview` and `matita_130312` came up as broken when I ran `nox-review`.
