### PR TITLE
Add basic nixos module for fish shell

### DIFF
--- a/nixos/modules/programs/fish/fish.nix
+++ b/nixos/modules/programs/fish/fish.nix
@@ -10,6 +10,10 @@ cfge = config.environment;
 
 cfg = config.programs.fish;
 
+fishAliases = concatStringsSep "\n" (
+  mapAttrsFlatten (k: v: "alias ${k}='${v}'") cfg.shellAliases
+);
+
 in
 
 {
@@ -87,6 +91,8 @@ in
         ${cfge.interactiveShellInit}
 
         ${cfg.promptInit}
+
+        ${fishAliases}
       '';
 
     };

--- a/nixos/modules/programs/fish/fish.nix
+++ b/nixos/modules/programs/fish/fish.nix
@@ -1,0 +1,109 @@
+# This module defines global configuration for the fish.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+cfge = config.environment;
+
+cfg = config.programs.fish;
+
+in
+
+{
+
+  options = {
+
+    programs.fish = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whenever to configure fish as an interactive shell.
+          '';
+        type = types.bool;
+      };
+
+      shellAliases = mkOption {
+        default = config.environment.shellAliases;
+        description = ''
+          Set of aliases for zsh shell. See <option>environment.shellAliases</option>
+          for an option format description.
+            '';
+        type = types.attrs; # types.attrsOf types.stringOrPath;
+      };
+
+      shellInit = mkOption {
+        default = "";
+        description = ''
+          Shell script code called during fish shell initialisation.
+        '';
+        type = types.lines;
+      };
+
+      loginShellInit = mkOption {
+        default = "";
+        description = ''
+          Shell script code called during fish login shell initialisation.
+        '';
+        type = types.lines;
+      };
+
+      interactiveShellInit = mkOption {
+        default = "";
+        description = ''
+          Shell script code called during interactive fish initialisation.
+        '';
+        type = types.lines;
+      };
+
+      promptInit = mkOption {
+        default = "";
+        description = ''
+          Shell script code used to initialise the fish prompt.
+        '';
+        type = types.lines;
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    programs.fish = {
+
+      shellInit = ''
+        . ${config.system.build.setEnvironment}
+
+        ${cfge.shellInit}
+      '';
+
+      loginShellInit = cfge.loginShellInit;
+
+      interactiveShellInit = ''
+        ${cfge.interactiveShellInit}
+
+        ${cfg.promptInit}
+      '';
+
+    };
+
+    environment.profileRelativeEnvVars = { };
+
+    environment.systemPackages = [ pkgs.fish ];
+
+    #users.defaultUserShell = mkDefault "/run/current-system/sw/bin/fish";
+
+    environment.shells =
+      [ "/run/current-system/sw/bin/fish"
+        "/var/run/current-system/sw/bin/fish"
+        "${pkgs.fish}/bin/fish"
+      ];
+
+  };
+
+}
+


### PR DESCRIPTION
My approach on #5331 .

Please note that I'm a complete nixos newbie and I don't even know how to test this! I'm also not a fish shell user, actually, but I guess this is a rather trivial patch, so I tried it.

I copied all stuff I thought would be required for this from the zsh module in `nixos/modules/programs/zsh/`.
