### PR TITLE
postfix: make 2.11 the default, nixos: update postfix config for 2.11

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -96,9 +96,9 @@ let
     #  -o smtpd_sasl_auth_enable=yes
     #  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
     #  -o milter_macro_daemon_name=ORIGINATING
-    pickup    fifo  n       -       n       60      1       pickup
+    pickup    unix  n       -       n       60      1       pickup
     cleanup   unix  n       -       n       -       0       cleanup
-    qmgr      fifo  n       -       n       300     1       qmgr
+    qmgr      unix  n       -       n       300     1       qmgr
     tlsmgr    unix  -       -       n       1000?   1       tlsmgr
     rewrite   unix  -       -       n       -       -       trivial-rewrite
     bounce    unix  -       -       n       -       0       bounce

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7767,9 +7767,11 @@ let
 
   popa3d = callPackage ../servers/mail/popa3d { };
 
-  postfix = callPackage ../servers/mail/postfix { };
+  postfix28 = callPackage ../servers/mail/postfix { };
 
   postfix211 = callPackage ../servers/mail/postfix/2.11.nix { };
+
+  postfix = postfix211;
 
   pulseaudio = callPackage ../servers/pulseaudio {
     gconf = gnome.GConf;


### PR DESCRIPTION
Forked out from https://github.com/NixOS/nixpkgs/pull/5619#discussion-diff-22583008

This change is about being more humane to disk drives (especially SSDs). I have been using this for more than a month both with default and custom postfix configs and there have been no changes/problems whatsoever, except it stopped raping my SSDs.

I'd say this is a rather critical fix since the previous postfix raped one of my disks to death.

I debugged this by running

```
echo 1 > /sys/kernel/debug/tracing/events/jbd2/jbd2_run_stats/enable
echo 1 > /sys/kernel/debug/tracing/events/ext4/ext4_journal_start/enable
... (and similarly for other file systems)
cat /sys/kernel/debug/tracing/trace_pipe
```

on a server and then waiting a day without doing anything disk intensive on the machine.
After applying these and https://github.com/NixOS/nixpkgs/pull/5619 changes only ntpd generates writes in idle. Would be nice if someone could fix that.
