### PR TITLE
Update libuv repository and add latest stable version

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -6,7 +6,7 @@ let
 
   meta = with lib; {
     description = "A multi-platform support library with a focus on asynchronous I/O";
-    homepage    = https://github.com/joyent/libuv;
+    homepage    = https://github.com/libuv/libuv;
     maintainers = with maintainers; [ cstrahan ];
     platforms   = with platforms; linux ++ darwin;
   };
@@ -17,7 +17,7 @@ let
     else "libuv-${stability}-${version}";
 
   mkSrc = version: sha256: fetchFromGitHub {
-    owner = "joyent";
+    owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
     inherit sha256;

--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -102,3 +102,7 @@ in
     v0_11_26 = "1pfjdwrxhqz1vqcdm42g3j45ghrb4yl7wsngvraclhgqicff1sc3";
     v0_11_29 = "1z07phfwryfy2155p3lxcm2a33h20sfl96lds5dghn157x6csz7m";
   }
+  //
+  mapAttrs (v: h: mkWithAutotools stable (toVersion v) h) {
+    v1_2_0 = "1nbp8qpgw64gl9nrjzxw0ndv1m64cfms0cy5a2883vw6877kizmx";
+  }


### PR DESCRIPTION
libuv's repository recently moved (see https://github.com/joyent/libuv ) and multiple new stable releases have occurred. I wasn't sure if I should add all of them or just the latest, since most packages seem to just refer to their latest versions, while libuv has many.
