### PR TITLE
cabal: Allow optional use of cpphs as a preprocessor

### DIFF
--- a/pkgs/build-support/cabal/default.nix
+++ b/pkgs/build-support/cabal/default.nix
@@ -1,13 +1,14 @@
 # generic builder for Cabal packages
 
 { stdenv, fetchurl, lib, pkgconfig, ghc, Cabal, jailbreakCabal, glibcLocales
-, gnugrep, coreutils, hscolour
+, gnugrep, coreutils, hscolour, cpphs
 , enableLibraryProfiling ? false
 , enableSharedLibraries ? false
 , enableSharedExecutables ? false
 , enableStaticLibraries ? true
 , enableCheckPhase ? stdenv.lib.versionOlder "7.4" ghc.version
 , enableHyperlinkSource ? true
+, enableCpphs ? false
 , extension ? (self : super : {})
 }:
 
@@ -56,6 +57,7 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
                 propagatedBuildInputs = filter (y : ! (y == null)) x.propagatedBuildInputs;
                 propagatedUserEnvPkgs = filter (y : ! (y == null)) x.propagatedUserEnvPkgs;
                 doCheck               = enableCheckPhase && x.doCheck;
+                useCpphs              = enableCpphs && x.useCpphs;
                 hyperlinkSource       = enableHyperlinkSource && x.hyperlinkSource;
                 # Disable Darwin builds: <https://github.com/NixOS/nixpkgs/issues/2689>.
                 meta                  = let meta = x.meta or {};
@@ -105,6 +107,7 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
             extraBuildInputs = self.buildTools ++
                                (optionals self.doCheck self.testDepends) ++
                                (optional self.hyperlinkSource hscolour) ++
+                               (optional self.useCpphs cpphs) ++
                                (if self.pkgconfigDepends == [] then [] else [pkgconfig]) ++
                                (if self.isLibrary then [] else self.buildDepends ++ self.extraLibraries ++ self.pkgconfigDepends);
 
@@ -152,6 +155,10 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
             # pass the '--enable-tests' flag to cabal in the configure stage
             # and run any regression test suites the package might have
             doCheck = enableCheckPhase;
+
+            # force cpphs instead of the C compiler's preprocessor; sometimes
+            # needed due to clang's wacky behavior
+            useCpphs = false;
 
             # pass the '--hyperlink-source' flag to ./Setup haddock
             hyperlinkSource = enableHyperlinkSource;
@@ -231,6 +238,9 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
               ${optionalString (versionOlder "7.8" ghc.version && !self.isLibrary) ''
                 configureFlags+=" --ghc-option=-j$NIX_BUILD_CORES"
               ''}
+              ${optionalString self.useCpphs ''
+                configureFlags+=" --ghc-option=-pgmPcpphs --ghc-option=-optP--cpp"
+              ''}
 
               ${optionalString self.stdenv.isDarwin ''
                 configureFlags+=" --with-gcc=clang"
@@ -259,7 +269,10 @@ assert !enableStaticLibraries -> versionOlder "7.7" ghc.version;
               export GHC_PACKAGE_PATH=$(${ghc.GHCPackages})
               test -n "$noHaddock" || ./Setup haddock --html --hoogle \
                   ${optionalString (stdenv.lib.versionOlder "6.12" ghc.version) "--ghc-options=-optP-P"} \
-                  ${optionalString self.hyperlinkSource "--hyperlink-source"}
+                  ${optionalString self.hyperlinkSource "--hyperlink-source"} \
+                  ${optionalString self.useCpphs ''
+                    --haddock-options="--optghc=-pgmPcpphs --optghc=-optP--cpp"
+                  ''}
 
               eval "$postBuild"
             '';


### PR DESCRIPTION
Pinging @peti @shlevy @joelteon.  This is needed on Darwin/Yosemite because clang's preprocessor is broken there.
