### PR TITLE
seafile: update client, ccnet, libsearpc and shared

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec
 {
-  version = "3.0.4";
+  version = "4.0.6";
   name = "seafile-client-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/seafile-client/archive/v${version}.tar.gz";
-    sha256 = "10iz45y8j5f9smi0srxw62frb97vhr0w938v8w3rsjcw9qq366a2";
+    sha256 = "0hx8zjmgj4ki2p5fkdyz32fy8db60p6rvi3my9l59j7fslv71k1z";
   };
 
   buildInputs = [ pkgconfig cmake qt4 seafile-shared makeWrapper ];

--- a/pkgs/development/libraries/libsearpc/default.nix
+++ b/pkgs/development/libraries/libsearpc/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec
 {
   version = "1.2.2";
-  seafileVersion = "3.0.4";
+  seafileVersion = "3.0-latest";
   name = "libsearpc-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/libsearpc/archive/v${seafileVersion}.tar.gz";
-    sha256 = "0s5bqqajxfzyw4km6nhhx39nyq20gv0fxlf2v6ifipvnyk14850k";
+    sha256 = "1kdq6chn3qhvr616sw91gf9kjfgbv9snl2srqisw0zddw1qkfcan";
   };
 
   patches = [ ./libsearpc.pc.patch ];

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -1,18 +1,18 @@
-{stdenv, fetchurl, which, automake, autoconf, pkgconfig, libtool, vala, python, intltool, fuse, ccnet}:
+{stdenv, fetchurl, which, automake, autoconf, pkgconfig, curl, libtool, vala, python, intltool, fuse, ccnet}:
 
 stdenv.mkDerivation rec
 {
-  version = "3.0.4";
+  version = "4.0.6";
   name = "seafile-shared-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/seafile/archive/v${version}.tar.gz";
-    sha256 = "0a0yj9k2rr3q42swwzn1js3r8bld9wcysw6p9415rw5jabcm1af0";
+    sha256 = "1vs1ckxkh0kg1wjklpwdz87d5z60r80q27xv1s6yl7ir65s6zq0i";
   };
 
   buildInputs = [ which automake autoconf pkgconfig libtool vala python intltool fuse ];
-  propagatedBuildInputs = [ ccnet ];
+  propagatedBuildInputs = [ ccnet curl ];
 
   preConfigure = ''
   sed -ie 's|/bin/bash|/bin/sh|g' ./autogen.sh

--- a/pkgs/tools/networking/ccnet/default.nix
+++ b/pkgs/tools/networking/ccnet/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec
 {
   version = "1.4.2";
-  seafileVersion = "3.0.4";
+  seafileVersion = "4.0.6";
   name = "ccnet-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/ccnet/archive/v${seafileVersion}.tar.gz";
-    sha256 = "1y9x6k9ql8bj83016a1mi1m5ixxh8fm7p4qbd5mslnamvjln171q";
+    sha256 = "06srvyphrfx7g18vk899850q0aw8cxx34cj96mjzc3sqm0bkzqsh";
   };
 
   buildInputs = [ which automake autoconf pkgconfig libtool vala  python ];


### PR DESCRIPTION
Update seafile related packages to latest version 4.0.6
