### PR TITLE
mkOverridable: Use functors to allow overridable functions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
-if ! builtins ? nixVersion || builtins.compareVersions "1.7" builtins.nixVersion == 1 then
+if ! builtins ? nixVersion || builtins.compareVersions "1.8" builtins.nixVersion == 1 then
 
-  abort "This version of Nixpkgs requires Nix >= 1.7, please upgrade!"
+  abort "This version of Nixpkgs requires Nix >= 1.8, please upgrade!"
 
 else
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -65,6 +65,13 @@ rec {
           overrideDerivation = fdrv:
             makeOverridable (args: overrideDerivation (f args) fdrv) origArgs;
         })
+      else if builtins.isFunction ff then
+        { override = newArgs:
+            makeOverridable f (origArgs // (if builtins.isFunction newArgs then newArgs origArgs else newArgs));
+          __functor = self: ff;
+          deepOverride = throw "deepOverride not yet supported for functors";
+          overrideDerivation = throw "overrideDerivation not yet supported for functors";
+        }
       else ff;
 
   deepOverrider = newArgs: name: x: if builtins.isAttrs x then (


### PR DESCRIPTION
As an example use case, take NixOS/nixpkgs@96ae5d58bfa3bb64449bef3703238a1cdc76eff0 . Currently we have to override `jailbreak-cabal` for the whole set, but with this change we could instead override `mkDerivation` only.
