### PR TITLE
Remove `rust=rustc` alias

### DIFF
--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -1,8 +1,4 @@
-{stdenv, fetchgit, rust, makeWrapper }:
-
-let
-  rustSrc = rust.src;
-in
+{stdenv, fetchgit, rustc, makeWrapper }:
 
 stdenv.mkDerivation rec {
   #TODO add emacs support
@@ -13,16 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "1159fsfca2kqvlajp8sawrskip7hc0rppk8vhwxa2vw8zznp56w0";
   };
 
-  buildInputs = [ rust makeWrapper ];
+  buildInputs = [ rustc makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp -p bin/racer $out/bin/
-    wrapProgram $out/bin/racer --set RUST_SRC_PATH "${rustSrc}/src"
+    wrapProgram $out/bin/racer --set RUST_SRC_PATH "${rustc.src}/src"
   '';
 
   meta = with stdenv.lib; {
-    description = "A utility intended to provide rust code completion for editors and IDEs.";
+    description = "A utility intended to provide Rust code completion for editors and IDEs.";
     homepage = https://github.com/phildawes/racer;
     license = stdenv.lib.licenses.mit;
     maintainers = [ maintainers.jagajaga ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3939,8 +3939,6 @@ let
   rustc       = callPackage ../development/compilers/rustc/0.12.nix {};
   rustcMaster = callPackage ../development/compilers/rustc/head.nix {};
 
-  rust = rustc;
-
 
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
   sbcl = callPackage ../development/compilers/sbcl {
@@ -4772,7 +4770,7 @@ let
 
   premake = premake4;
 
-  racerRust = callPackage ../development/tools/rust/racer { rust = rustcMaster; };
+  racerRust = callPackage ../development/tools/rust/racer { rustc = rustcMaster; };
 
   radare = callPackage ../development/tools/analysis/radare {
     inherit (gnome) vte;


### PR DESCRIPTION
I was asked to add this for backwards comparability when I renamed `rust`
to `rustc` and added `rustcMaster`. It has been a few months so I'd hope
deprecating this is acceptable.

Also racer should have Rust's source as an explicit dependency because
compile time dependencies are not propagated by default.
