### PR TITLE
enlightenment: import dialog fix

### DIFF
--- a/pkgs/desktops/e19/enlightenment.nix
+++ b/pkgs/desktops/e19/enlightenment.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
 
     substituteInPlace src/modules/xkbswitch/e_mod_parse.c \
       --replace "/usr/share/X11/xkb/rules/xorg.lst" "${xkeyboard_config}/share/X11/xkb/rules/base.lst"
+
+    substituteInPlace "src/bin/e_import_config_dialog.c" \
+      --replace "e_prefix_bin_get()" "\"${e19.efl}/bin\""
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fix import issue.

Ex.: you can import/use *.edj wallpapers and you can use system wallpapers in the wallpaper chooser window because they are already compiled, but with this fix you can now select _any_ wallpaper without error - the Enlightenment in Nixos can now compile pictures on its own... baby steps :D

Please do report more bugs for this desktop... my "E bug fixing warfare" TODO-list is kind of empty now.

Slowly I will catch them all!
