### PR TITLE
Add Ruby 2.2.0 package

### DIFF
--- a/pkgs/development/interpreters/ruby/ruby-2.2.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.2.0.nix
@@ -1,0 +1,105 @@
+{ stdenv, fetchurl, fetchgit, fetchFromGitHub
+, zlib, zlibSupport ? true
+, openssl, opensslSupport ? true
+, gdbm, gdbmSupport ? true
+, ncurses, readline, cursesSupport ? false
+, groff, docSupport ? false
+, libyaml, yamlSupport ? true
+, libffi, fiddleSupport ? true
+, ruby_2_2_0, autoreconfHook, bison, useRailsExpress ? true
+}:
+
+let
+  op = stdenv.lib.optional;
+  ops = stdenv.lib.optionals;
+  patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
+  config = import ./config.nix fetchgit;
+  baseruby = ruby_2_2_0.override { useRailsExpress = false; };
+in
+
+stdenv.mkDerivation rec {
+  version = with passthru; "${majorVersion}.${minorVersion}.${teenyVersion}-p${patchLevel}";
+
+  name = "ruby-${version}";
+
+  src = if useRailsExpress then fetchFromGitHub {
+    owner  = "ruby";
+    repo   = "ruby";
+    rev    = "v2_2_0";
+    sha256 = "1w7rr2nq1bbw6aiagddzlrr3rl95kk33x4pv6570nm072g55ybpi";
+  } else fetchurl {
+    url = "http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz";
+    sha256 = "1z2092fbpc2qkv1j3yj7jdz7qwvqpxqpmcnkphpjcpgvmfaf6wbn";
+  };
+
+  # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
+  NROFF = "${groff}/bin/nroff";
+
+  buildInputs = ops useRailsExpress [ autoreconfHook bison ]
+    ++ (op fiddleSupport libffi)
+    ++ (ops cursesSupport [ ncurses readline ])
+    ++ (op docSupport groff)
+    ++ (op zlibSupport zlib)
+    ++ (op opensslSupport openssl)
+    ++ (op gdbmSupport gdbm)
+    ++ (op yamlSupport libyaml)
+    # Looks like ruby fails to build on darwin without readline even if curses
+    # support is not enabled, so add readline to the build inputs if curses
+    # support is disabled (if it's enabled, we already have it) and we're
+    # running on darwin
+    ++ (op (!cursesSupport && stdenv.isDarwin) readline);
+
+  enableParallelBuilding = true;
+
+  patches = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.2.0/railsexpress/01-zero-broken-tests.patch"
+    "${patchSet}/patches/ruby/2.2.0/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.2.0/railsexpress/03-display-more-detailed-stack-trace.patch"
+    "${patchSet}/patches/ruby/2.2.0/railsexpress/04-backport-401c8bb.patch"
+    "${patchSet}/patches/ruby/2.2.0/railsexpress/05-fix-packed-bitfield-compat-warning-for-older-gccs.patch"
+  ];
+
+  # Ruby >= 2.1.0 tries to download config.{guess,sub}
+  postPatch = ''
+    rm tool/config_files.rb
+    cp ${config}/config.guess tool/
+    cp ${config}/config.sub tool/
+  '';
+
+  configureFlags = ["--enable-shared" ]
+    ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"
+    # on darwin, we have /usr/include/tk.h -- so the configure script detects
+    # that tk is installed
+    ++ ( if stdenv.isDarwin then [ "--with-out-ext=tk " ] else [ ]);
+
+  installFlags = stdenv.lib.optionalString docSupport "install-doc";
+  # Bundler tries to create this directory
+  postInstall = ''
+    # Bundler tries to create this directory
+    mkdir -pv $out/${passthru.gemPath}
+    mkdir -p $out/nix-support
+    cat > $out/nix-support/setup-hook <<EOF
+    addGemPath() {
+      addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+    }
+
+    envHooks+=(addGemPath)
+    EOF
+  '';
+
+  meta = {
+    license = stdenv.lib.licenses.ruby;
+    homepage = "http://www.ruby-lang.org/en/";
+    description = "The Ruby language";
+    platforms = stdenv.lib.platforms.all;
+  };
+
+  passthru = rec {
+    majorVersion = "2";
+    minorVersion = "2";
+    teenyVersion = "0";
+    patchLevel = "0";
+    libPath = "lib/ruby/${majorVersion}.${minorVersion}";
+    gemPath = "lib/ruby/gems/${majorVersion}.${minorVersion}";
+  };
+}

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "fb6b427f71e756900184d1b6eaeb10245ec8405a";
-  sha256 = "10k7p3nymj7y5a0az8v1aks2w5w190zfqv9kiiafcx0a3qfswnck";
+  rev    = "da2e5b4d81e18154befef1448e037b844cb5a326";
+  sha256 = "0fslnkpirgsm7gjd6g194vd24i3y7kl0ihbq5gr94cgvdzzjgad0";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4263,6 +4263,7 @@ let
   ruby_2_1_1 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.1.nix { });
   ruby_2_1_2 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.2.nix { });
   ruby_2_1_3 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.3.nix { });
+  ruby_2_2_0 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.2.0.nix { });
 
   # Ruby aliases
   ruby = ruby_1_9;
@@ -4270,6 +4271,7 @@ let
   ruby_1_9 = ruby_1_9_3;
   ruby_2_0 = ruby_2_0_0;
   ruby_2_1 = ruby_2_1_3;
+  ruby_2_2 = ruby_2_2_0;
 
   rubyLibs = recurseIntoAttrs (callPackage ../development/interpreters/ruby/libs.nix { });
 


### PR DESCRIPTION
These commits have two effects; respectively:
1. Update RVM patchsets to a revision which includes Ruby 2.2.0 patches
2. Add a Ruby 2.2.0 package
