### PR TITLE
Fswatch

### DIFF
--- a/pkgs/development/libraries/gettext/0.19.nix
+++ b/pkgs/development/libraries/gettext/0.19.nix
@@ -1,0 +1,10 @@
+{ stdenv, fetchurl, gettext }:
+
+stdenv.lib.overrideDerivation gettext (attrs: rec {
+  name = "gettext-0.19.4";
+
+  src = fetchurl {
+    url = "mirror://gnu/gettext/${name}.tar.gz";
+    sha256 = "0gvz86m4cs8bdf3mwmwsyx6lrq4ydfxgadrgd9jlx32z3bnz3jca";
+  };
+})

--- a/pkgs/development/tools/misc/fswatch/default.nix
+++ b/pkgs/development/tools/misc/fswatch/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchFromGitHub
+, autoconf
+, automake114x
+, findutils                     # for xargs
+, gettext_0_19
+, libtool
+, makeWrapper
+, texinfo
+}:
+
+let
+
+ version = "1.4.5.3";
+
+in stdenv.mkDerivation {
+
+  name = "fswatch-${version}";
+
+  src = fetchFromGitHub {
+    owner = "emcrisostomo";
+    repo = "fswatch";
+    rev = version;
+    sha256 = "05jphslvfgp94vd86myjw5q4wgbayj8avw49h4a4npkwhn93d11j";
+  };
+
+  buildInputs = [ autoconf automake114x gettext_0_19 libtool makeWrapper texinfo ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  postFixup = ''
+    for prog in fswatch-run fswatch-run-bash; do
+      wrapProgram $out/bin/$prog \
+        --prefix PATH "${findutils}/bin"
+    done
+  '';
+
+  meta = {
+    description = "A cross-platform file change monitor with multiple backends";
+    homepage = https://github.com/emcrisostomo/fswatch;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5320,6 +5320,7 @@ let
 
   gettext_0_17 = callPackage ../development/libraries/gettext/0.17.nix { };
   gettext_0_18 = callPackage ../development/libraries/gettext { };
+  gettext_0_19 = callPackage ../development/libraries/gettext/0.19.nix { };
 
   gd = callPackage ../development/libraries/gd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4615,6 +4615,8 @@ let
 
   flow = callPackage ../development/tools/analysis/flow { };
 
+  fswatch = callPackage ../development/tools/misc/fswatch { };
+
   pmd = callPackage ../development/tools/analysis/pmd { };
 
   jdepend = callPackage ../development/tools/analysis/jdepend { };


### PR DESCRIPTION
A cross-platform file change monitor with multiple backends

fswatch requires gettext 0.19, but `nixpkgs.gettext` is 0.18; not sure if appropriate to bump that, so I added a separate derivation for 0.19.
