### PR TITLE
pianobar: update to pianobar-2014.09.28

### DIFF
--- a/pkgs/applications/audio/pianobar/default.nix
+++ b/pkgs/applications/audio/pianobar/default.nix
@@ -1,15 +1,15 @@
-{ fetchurl, stdenv, pkgconfig, libao, faad2, libmad, readline, json_c, libgcrypt, gnutls }:
+{ fetchurl, stdenv, pkgconfig, libao, readline, json_c, libgcrypt, gnutls, libav }:
 
 stdenv.mkDerivation rec {
-  name = "pianobar-2013.05.19";
+  name = "pianobar-2014.09.28";
 
   src = fetchurl {
     url = "http://6xq.net/projects/pianobar/${name}.tar.bz2";
-    sha256 = "cf88e82663d2b0aa4d73e761506eac4f3e7bc789b57d92377acd994d785e1046";
+    sha256 = "6bd10218ad5d68c4c761e02c729627d2581b4a6db559190e7e52dc5df177e68f";
   };
 
   buildInputs = [
-    pkgconfig libao faad2 libmad json_c libgcrypt gnutls
+    pkgconfig libao json_c libgcrypt gnutls libav
   ];
 
   makeFlags="PREFIX=$(out)";
@@ -17,10 +17,13 @@ stdenv.mkDerivation rec {
   CC = "gcc";
   CFLAGS = "-std=c99";
 
+  configurePhase = "export CC=${CC}";
+
   meta = {
     description = "A console front-end for Pandora.com";
     homepage = "http://6xq.net/projects/pianobar/";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.mit; # expat version
+    maintainers = stdenv.lib.maintainers.eduarrrd;
   };
 }


### PR DESCRIPTION
- libmad and faad have been dropped for libav
- CC is exported since pianobar forces CC=c99 else
- add myself to maintainers
