### PR TITLE
Emacs d mode

### DIFF
--- a/pkgs/applications/editors/emacs-modes/d/default.nix
+++ b/pkgs/applications/editors/emacs-modes/d/default.nix
@@ -1,5 +1,6 @@
 {stdenv, fetchurl, emacs}:
 
+# Note: Don't have a version, using date as fallback.
 let version = "20150111";
 
 in stdenv.mkDerivation {
@@ -20,4 +21,12 @@ in stdenv.mkDerivation {
     install -d $out/share/emacs/site-lisp
     install *.el *.elc $out/share/emacs/site-lisp
   '';
+
+  meta = {
+    description = "Major mode for editing D code";
+    homepage = https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.all;
+  };
+
 }

--- a/pkgs/applications/editors/emacs-modes/d/default.nix
+++ b/pkgs/applications/editors/emacs-modes/d/default.nix
@@ -1,0 +1,23 @@
+{stdenv, fetchurl, emacs}:
+
+let version = "20150111";
+
+in stdenv.mkDerivation {
+  name = "emacs-d-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode/archive/53efec4d83c7cee8227597f010fe7fc400ff05f1.tar.gz";
+    sha256 = "0vb0za51lc6qf1qgqisap4vzk36caa5k17zajjn034rhjsqfw0w7";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    emacs -L . --batch -f batch-byte-compile *.el
+  '';
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9592,6 +9592,8 @@ let
 
     cua = callPackage ../applications/editors/emacs-modes/cua { };
 
+    d = callPackage ../applications/editors/emacs-modes/d { };
+
     darcsum = callPackage ../applications/editors/emacs-modes/darcsum { };
 
     dash = callPackage ../applications/editors/emacs-modes/dash { };


### PR DESCRIPTION
Just tried to do some D programming on NixOS and found that this Emacs mode was missing.

Was not sure what to do with the version attribute since they seem not to maintain versions for this mode anymore.
