### PR TITLE
stdenv substitute: avoid using a temporary file

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -370,9 +370,8 @@ substitute() {
         content="${content//"$pattern"/$replacement}"
     done
 
-    printf "%s" "$content" > "$output".tmp
-    if [ -x "$output" ]; then chmod +x "$output".tmp; fi
-    mv -f "$output".tmp "$output"
+    chmod -f +w "$output" || true
+    printf "%s" "$content" > "$output"
 }
 
 


### PR DESCRIPTION
- IMO using a temporary is not needed here (anymore),
- temporary at that location can cause a problem (in a specific case):
  for example, when using the substituteAll function from nixpkgs
  on a single file directly under /nix/store/ (or ./foo-file),
  the stdenv's substitute tries to create a temporary directly under
  /nix/store, which causes problems on chrooted darwin
  (according to @copumpkin earlier today on IRC)

Any thoughts? @edolstra or others?
