### PR TITLE
coan: don't double-gzip man page

### DIFF
--- a/pkgs/development/tools/analysis/coan/default.nix
+++ b/pkgs/development/tools/analysis/coan/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  postInstall = ''
+    mv -v $out/share/man/man1/coan.1.{1,gz}
+  '';
+
   meta = with stdenv.lib; {
     description = "The C preprocessor chainsaw";
     longDescription = ''


### PR DESCRIPTION
`make install` gzips `coan.1` with the wrong extension (`.1`).
So Nix re-compresses it.
Result: `coan.1.1.gz`, and a screen full of gobbledygook.

(But not while testing, of course... :unamused: )
