### PR TITLE
Add auto-start option to containers.

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -111,6 +111,13 @@ in
               '';
             };
 
+            autoStart = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Wether the container is automatically started at boot-time.
+              '';
+            };
           };
 
           config = mkMerge
@@ -305,6 +312,9 @@ in
                 LOCAL_ADDRESS=${cfg.localAddress}
               ''}
             ''}
+           ${optionalString cfg.autoStart ''
+             AUTO_START=1
+           ''}
           '';
       }) config.containers;
 


### PR DESCRIPTION
This is the missing piece in autostarting declarative containers, as the _AUTO_START_ in _/etc/containers/*.nix_ can now be set.

The formatting is a little bit funny though, e.g.:

```
 SYSTEM_PATH=/nix/store/kjcmzgskpcb3p8bpxik5r3aqc9q1hivx-nixos-15.05.git.173f41cM
 PRIVATE_NETWORK=1
HOST_ADDRESS=10.0.1.1

LOCAL_ADDRESS=10.0.2.1


AUTO_START=1
```

Also see #2272 and 2337a85fc3a.
