### PR TITLE
mediainfo/-gui: 0.7.71 -> 0.7.72

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,12 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
-let version = "0.7.71"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  version = "0.7.72";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
-    sha256 = "0sf0ym0v5ds5w4bxk66712adybr1prxxqwvrf9clm57ibs602jfq";
+    sha256 = "04sqm2cziqvnghbla89f83vy46bmsfcvlq7f4m4kfcs24bjzfwr1";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,12 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
-let version = "0.7.71"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  version = "0.7.72";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
-    sha256 = "0sf0ym0v5ds5w4bxk66712adybr1prxxqwvrf9clm57ibs602jfq";
+    sha256 = "04sqm2cziqvnghbla89f83vy46bmsfcvlq7f4m4kfcs24bjzfwr1";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,12 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
-let version = "0.7.71"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  version = "0.7.72";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.bz2";
-    sha256 = "088v7qsn7d5pijr88fx4azwb31g6d7bp5ykrzgwhskmj80y3rlp2";
+    sha256 = "1ndfag9a7yl8j1iwxgd2d8slwzc0ifmzg9zf8lg7fsqsa9c3s7m6";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
This updates `mediainfo`, `mediainfo-gui`, and its dependency `libmediainfo` to the latest upstream version.
