### PR TITLE
wicd: fix wicd-curses with new urwid

### DIFF
--- a/pkgs/tools/networking/wicd/default.nix
+++ b/pkgs/tools/networking/wicd/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     ./dhclient.patch 
     ./fix-app-icon.patch
     ./fix-gtk-issues.patch
+    ./urwid-api-update.patch
     ];
 
   # Should I be using pygtk's propogated build inputs?

--- a/pkgs/tools/networking/wicd/urwid-api-update.patch
+++ b/pkgs/tools/networking/wicd/urwid-api-update.patch
@@ -1,0 +1,22 @@
+--- a/curses/curses_misc.py
++++ a/curses/curses_misc.py
+@@ -358,6 +358,19 @@ class ComboBox(urwid.WidgetWrap):
+         self.parent = None
+         self.ui = None
+         self.row = None
++
++    @property
++    def focus(self):
++        return self._focus
++
++    @focus.setter
++    def focus(self, index):
++        self._focus = index
++
++    @focus.deleter
++    def focus(self):
++        del self._focus
++
+     def set_list(self,list):
+         self.list = list
+ 


### PR DESCRIPTION
See e.g. https://bugzilla.redhat.com/show_bug.cgi?id=894646 — without
this patch, wicd-curses throws an AttributeError on startup. The patch
is a cut-down version of the one added there by Pavel Zhukov.
