### PR TITLE
haskellng: Fix amazonka-core on 7.8

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -37,3 +37,46 @@ self: super: {
   # mtl 2.2.x needs the latest transformers.
   mtl_2_2_1 = super.mtl_2_2_1.override { transformers = self.transformers_0_4_2_0; };
 }
+
+// # packages relating to amazonka
+
+(let
+  amazonkaEnv = let self_ = self; in self: super: {
+    mkDerivation = drv: (super.mkDerivation.override {
+      inherit (self_) jailbreak-cabal;
+    }) (drv // {
+      doCheck = false;
+    });
+    mtl = self.mtl_2_2_1;
+    transformers = self.transformers_0_4_2_0;
+    transformers-compat = overrideCabal super.transformers-compat (drv: { configureFlags = []; });
+    aeson = disableCabalFlag super.aeson "old-locale";
+    hscolour = super.hscolour;
+    time = self.time_1_5_0_1;
+    unix = self.unix_2_7_1_0;
+    directory = self.directory_1_2_1_0;
+    process = overrideCabal self.process_1_2_1_0 (drv: {
+      coreSetup = true;
+    });
+  } // (builtins.listToAttrs (map (name: {
+    inherit name;
+    value = overrideCabal super.${name} (drv: {
+      extraLibraries = (drv.extraLibraries or []) ++ [ self.Cabal_1_18_1_6 ];
+    });
+  }) [
+    "conduit-extra"
+    "streaming-commons"
+    "http-client"
+    "cryptohash-conduit"
+    "xml-conduit"
+  ]));
+  Cabal = self.Cabal_1_18_1_6.overrideScope amazonkaEnv;
+in {
+  amazonka-core =
+    overrideCabal (super.amazonka-core.overrideScope amazonkaEnv) (drv: {
+      # https://github.com/brendanhay/amazonka/pull/57
+      prePatch = "sed -i 's|nats >= 0.1.3 && < 1|nats|' amazonka-core.cabal";
+
+      extraLibraries = (drv.extraLibraries or []) ++ [ Cabal ];
+    });
+})

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -39,6 +39,7 @@
 , preInstall ? "", postInstall ? ""
 , checkPhase ? "", preCheck ? "", postCheck ? ""
 , preFixup ? "", postFixup ? ""
+, coreSetup ? false # Use core packages to build Setup.hs
 }:
 
 assert pkgconfigDepends != [] -> pkgconfig != null;
@@ -155,7 +156,7 @@ stdenv.mkDerivation ({
     for i in Setup.hs Setup.lhs ${defaultSetupHs}; do
       test -f $i && break
     done
-    ghc -package-db=$packageConfDir $setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
+    ghc ${optionalString (! coreSetup) "-package-db=$packageConfDir "}$setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
 
     echo configureFlags: $configureFlags
     unset GHC_PACKAGE_PATH      # Cabal complains if this variable is set during configure.


### PR DESCRIPTION
Required adding a flag to the generic builder to build Setup.hs with
core packages even if there is an override in buildInputs, to break
circular dependencies.
