### PR TITLE
Add note that admin-pub-key for gitolite has to be written in one line

### DIFF
--- a/nixos/modules/services/misc/gitolite.nix
+++ b/nixos/modules/services/misc/gitolite.nix
@@ -36,6 +36,7 @@ in
           Initial administrative public key for Gitolite. This should
           be an SSH Public Key. Note that this key will only be used
           once, upon the first initialization of the Gitolite user.
+          The Key has to be written in one line.
         '';
       };
 

--- a/nixos/modules/services/misc/gitolite.nix
+++ b/nixos/modules/services/misc/gitolite.nix
@@ -36,7 +36,7 @@ in
           Initial administrative public key for Gitolite. This should
           be an SSH Public Key. Note that this key will only be used
           once, upon the first initialization of the Gitolite user.
-          The Key has to be written in one line.
+          The key string cannot have any line breaks in it.
         '';
       };
 


### PR DESCRIPTION
Would be nice to have that note in the option description.

I don't know whether the wording is appropriate, though!
