### PR TITLE
Wrap 'tig' command to add with git to PATH.

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -68,9 +68,7 @@ rec {
     inherit stdenv fetchurl;
   };
 
-  tig = import ./tig {
-    inherit stdenv fetchurl ncurses asciidoc xmlto docbook_xsl docbook_xml_dtd_45 readline;
-  };
+  tig = callPackage ./tig { };
 
   hub = import ./hub {
     inherit go;

--- a/pkgs/applications/version-management/git-and-tools/tig/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/tig/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ncurses, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45
-, readline
+, readline, makeWrapper, git
 }:
 
 stdenv.mkDerivation rec {
@@ -11,17 +11,22 @@ stdenv.mkDerivation rec {
 
   };
 
-  buildInputs = [ ncurses asciidoc xmlto docbook_xsl readline ];
+  buildInputs = [ ncurses asciidoc xmlto docbook_xsl readline git makeWrapper ];
 
   preConfigure = ''
     export XML_CATALOG_FILES='${docbook_xsl}/xml/xsl/docbook/catalog.xml ${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml'
   '';
+
+  enableParallelBuilding = true;
 
   installPhase = ''
     make install
     make install-doc
     mkdir -p $out/etc/bash_completion.d/
     cp contrib/tig-completion.bash $out/etc/bash_completion.d/
+
+    wrapProgram $out/bin/tig \
+      --prefix PATH ':' "${git}/bin"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This ensures that git is added as a run-time dependency of tig and allows tig to find the git command even if git is not installed in the user environment. Fixes #5741.
