### PR TITLE
gdal: fix the build

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -10,14 +10,15 @@ composableDerivation.composableDerivation {} (fixed: rec {
     sha256 = "0h1kib2pzv4nbppdnxv6vhngvk9ic531y8rzcwb8bg6am125jszl";
   };
 
-  buildInputs = [ unzip libjpeg libtiff python pythonPackages.numpy proj];
+  buildInputs = [ unzip libjpeg libtiff python pythonPackages.numpy proj ];
 
-  # don't use optimization for gcc >= 4.3. That's said to be causeing segfaults
-  preConfigure = "export CFLAGS=-O0; export CXXFLAGS=-O0";
+  # Don't use optimization for gcc >= 4.3. That's said to be causing segfaults.
+  # Unset CC and CXX as they confuse libtool.
+  preConfigure = "export CFLAGS=-O0 CXXFLAGS=-O0; unset CC CXX";
 
   configureFlags = [
     "--with-jpeg=${libjpeg}"
-    "--with-libtiff=${libtiff}" # optional (without largetiff support
+    "--with-libtiff=${libtiff}" # optional (without largetiff support)
     "--with-libz=${zlib}"       # optional
 
     "--with-pg=${postgresql}/bin/pg_config"
@@ -33,6 +34,5 @@ composableDerivation.composableDerivation {} (fixed: rec {
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = stdenv.lib.platforms.linux;
-    broken = true;
   };
 })


### PR DESCRIPTION
Commit 28b6fb61e651a3e2cca57d087781e7ba6ab45e7c added explicit CC and
CXX assignments in pkgs/build-support/gcc-wrapper/setup-hook.sh.
That breaks the gdal python extension build somehow, presumably by
confusing libtool.

This appears to revert gdal to building with g++ and gcc (on linux at
least), but at least it builds this way.
