### PR TITLE
nixos: loader: added generic config.boot.loader.timeout option

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -367,6 +367,7 @@
   ./system/boot/kernel.nix
   ./system/boot/kexec.nix
   ./system/boot/loader/efi.nix
+  ./system/boot/loader/loader.nix
   ./system/boot/loader/generations-dir/generations-dir.nix
   ./system/boot/loader/grub/grub.nix
   ./system/boot/loader/grub/ipxe.nix

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -196,7 +196,7 @@ in
       };
 
       timeout = mkOption {
-        default = 5;
+        default = if (config.boot.loader.timeout != null) then config.boot.loader.timeout else -1;
         type = types.int;
         description = ''
           Timeout (in seconds) until GRUB boots the default menu item.

--- a/nixos/modules/system/boot/loader/gummiboot/gummiboot.nix
+++ b/nixos/modules/system/boot/loader/gummiboot/gummiboot.nix
@@ -31,7 +31,9 @@ in {
     };
 
     timeout = mkOption {
-      default = null;
+      default = if (config.boot.loader.timeout != null) then
+        (if (config.boot.loader.timeout == 0) then null else config.boot.loader.timeout)
+        else config.boot.loader.timeout;
 
       example = 4;
 

--- a/nixos/modules/system/boot/loader/gummiboot/gummiboot.nix
+++ b/nixos/modules/system/boot/loader/gummiboot/gummiboot.nix
@@ -31,9 +31,7 @@ in {
     };
 
     timeout = mkOption {
-      default = if (config.boot.loader.timeout != null) then
-        (if (config.boot.loader.timeout == 0) then null else config.boot.loader.timeout)
-        else config.boot.loader.timeout;
+      default = if config.boot.loader.timeout == null then 1000 else config.boot.loader.timeout;
 
       example = 4;
 

--- a/nixos/modules/system/boot/loader/loader.nix
+++ b/nixos/modules/system/boot/loader/loader.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+    options = {
+        boot.loader.timeout =  mkOption {
+            default = 5;
+            type = types.nullOr types.int;
+            description = ''
+              Timeout (in seconds) until loader boots the default menu item. Use null if the loader menu should be displayed indefinitely.
+            '';
+        };
+    };
+}


### PR DESCRIPTION
This adds the option `config.boot.loader.timeout` that can be used to set the timeout of grub as well as gummiboot. You can still override this setting for each specific loader by setting `config.boot.loader.grub.timeout` or `config.boot.loader.gummiboot.timeout`, but they will all use `config.boot.loader.timeout` by default.

Do note that some conversions are happening on Grub and Gummiboots side, since the value of `config.boot.loader.timeout` behaves differently from `config.boot.loader.grub.timeout` or `config.boot.loader.gummiboot.timeout`... though these two bootloaders timeout behave differently from eachother as well.

`null` is no timeout. `0` is instant booting. Any positive integer is the timeout before automatically booting in seconds. Negative integers are undefined behavior.

Lastly, I haven't touched references to `config.boot.loader.grub.timeout`, but I'd imagine most of these will need to be changed to avoid confusing behavior.

I have little experience with the Nix language, so any suggestions improving on the (nested) `if ... then ... else ...` would be appreciated.
