### PR TITLE
prefetch-scripts: improve purity

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation {
         wrapArgs="$wrapArgs --prefix PATH : $dep/bin"
       done
       wrapArgs="$wrapArgs --prefix PATH : ${gnused}/bin"
+      wrapArgs="$wrapArgs --set HOME : /homeless-shelter"
       wrapProgram $out/bin/$name $wrapArgs
     }
 


### PR DESCRIPTION
Set HOME to /homeless-shelter to prevent things like git hooks from
running.
