### PR TITLE
Clojure: boot: Add derivation for boot build tooling

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -141,6 +141,7 @@
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";
   qknight = "Joachim Schiele <js@lastlog.de>";
+  ragge = "Ragnar Dahlen <r.dahlen@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";
   refnil = "Martin Lavoie <broemartino@gmail.com>";

--- a/pkgs/development/tools/build-managers/boot/builder.sh
+++ b/pkgs/development/tools/build-managers/boot/builder.sh
@@ -1,0 +1,13 @@
+source $stdenv/setup
+
+boot_bin=$out/bin/boot
+
+mkdir -pv $(dirname $boot_bin)
+cp -v $src $boot_bin
+chmod -v 755 $boot_bin
+
+patchShebangs $boot_bin
+
+wrapProgram $boot_bin \
+            --set JAVA_HOME "${jdk}" \
+            --prefix PATH ":" "${jdk}/bin"

--- a/pkgs/development/tools/build-managers/boot/default.nix
+++ b/pkgs/development/tools/build-managers/boot/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, makeWrapper, jdk }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.0-rc8";
+  name = "boot-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/boot-clj/boot/releases/download/${version}/boot.sh";
+    sha256 = "1jqj04f33prb6nqsv7mffwdnz47ppi3szsbdzphjx8xzz394nl7j";
+  };
+
+  inherit jdk;
+  
+  builder = ./builder.sh;
+
+  buildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = [ jdk ];
+
+  meta = {
+    description = "Build tooling for Clojure";
+    homepage = http://boot-clj.com/;
+    license = stdenv.lib.licenses.epl10;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    maintainers = [ stdenv.lib.maintainers.ragge ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -659,6 +659,8 @@ let
 
   boost-build = callPackage ../development/tools/boost-build { };
 
+  boot = callPackage ../development/tools/build-managers/boot { };
+
   bootchart = callPackage ../tools/system/bootchart { };
 
   boxfs = callPackage ../tools/filesystems/boxfs { };


### PR DESCRIPTION
This PR adds support for a new clojure build tool, boot (http://boot-clj.com).

This is my first nixpkg contribution so would appreciate any feedback.
