### PR TITLE
Haskell-ng: don't use cpphs by default on darwin

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -40,7 +40,7 @@
 , checkPhase ? "", preCheck ? "", postCheck ? ""
 , preFixup ? "", postFixup ? ""
 , coreSetup ? false # Use only core packages to build Setup.hs.
-, useCpphs ? stdenv.isDarwin
+, useCpphs ? false
 }:
 
 assert pkgconfigDepends != [] -> pkgconfig != null;


### PR DESCRIPTION
@peti not sure if I missed this originally, or if it was just changed, but we don't need `cpphs` on darwin (it in fact breaks `regex-tdfa-rc`).
