### PR TITLE
Turn nixUnstable back on

### DIFF
--- a/pkgs/tools/package-management/nix/unstable.nix
+++ b/pkgs/tools/package-management/nix/unstable.nix
@@ -5,11 +5,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "nix-1.8pre3919_f43a8ed";
+  name = "nix-1.9pre4020_f6716e9";
 
   src = fetchurl {
-    url = http://hydra.nixos.org/build/17676230/download/4/nix-1.8pre3919_f43a8ed.tar.xz;
-    sha256 = "6837adca17a1571fb82f7db0f21230577ff5d3d9b2a5ae1e465862033c6fded4";
+    url = "http://hydra.nixos.org/build/18780017/download/4/${name}.tar.xz";
+    sha256 = "0jki14yxwv1f33fqkd1bi8bpxafkzjv8yixiwnw8nkhx074sipsn";
   };
 
   nativeBuildInputs = [ perl pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12838,13 +12838,10 @@ let
     stateDir = config.nix.stateDir or "/nix/var";
   };
 
-  /*
   nixUnstable = callPackage ../tools/package-management/nix/unstable.nix {
     storeDir = config.nix.storeDir or "/nix/store";
     stateDir = config.nix.stateDir or "/nix/var";
   };
-  */
-  nixUnstable = nixStable;
 
   nixops = callPackage ../tools/package-management/nixops { };
 


### PR DESCRIPTION
`nixUnstable` is currently set to `nix`. This makes it point to an actual recent tarball from nix master, which contains features I desire :smile:
