### PR TITLE
Add haskellngPackages.cabal2nix missing dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -131,9 +131,10 @@ self: super: {
     isLibrary = false;
     isExecutable = true;
     buildDepends = with self; [
-      aeson base bytestring Cabal containers deepseq directory filepath
-      hackage-db monad-par monad-par-extras mtl pretty process
-      regex-posix SHA split transformers utf8-string
+      aeson base bytestring Cabal containers deepseq deepseq-generics
+      directory filepath hackage-db hspec monad-par monad-par-extras
+      mtl pretty process regex-posix SHA split transformers
+      utf8-string QuickCheck
     ];
     testDepends = with self; [ base doctest ];
     homepage = "http://github.com/NixOS/cabal2nix";


### PR DESCRIPTION
added QuickCheck, deepseq-generics and hspec to buildDepends. I didn't automatically merge this because I'm unsure of the current guidelines for packaging in haskellngPackages. Should I have manually edited this expression to get it to compile? Should I instead check out the git source of cabal2nix and put a fix in there?

cc @peti
