### PR TITLE
utf8proc: add the library

### DIFF
--- a/pkgs/development/libraries/utf8proc/default.nix
+++ b/pkgs/development/libraries/utf8proc/default.nix
@@ -1,0 +1,25 @@
+{ fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  version = "v1.1.6";
+
+  name = "utf8proc-${version}";
+
+  src = fetchurl {
+    url = "http://www.public-software-group.org/pub/projects/utf8proc/${version}/utf8proc-${version}.tar.gz";
+    sha256 = "1rwr84pw92ajjlbcxq0da7yxgg3ijngmrj7vhh2qzsr2h2kqzp7y";
+  };
+
+  installPhase = ''
+    mkdir -pv $out/lib $out/include
+    cp libutf8proc.so libutf8proc.a $out/lib
+    cp utf8proc.h $out/include
+  '';
+
+  meta = {
+    description = "utf8proc is a library for processing UTF-8 encoded Unicode strings";
+    homepage = http://www.public-software-group.org/utf8proc;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12632,6 +12632,8 @@ let
 
   thinkfan = callPackage ../tools/system/thinkfan { };
 
+  utf8proc = callPackage ../development/libraries/utf8proc { };
+
   vice = callPackage ../misc/emulators/vice {
     libX11 = xlibs.libX11;
     giflib = giflib_4_1;


### PR DESCRIPTION
utf8proc is a library for processing utf8 strings. It offers clean and simple API and requires only minimal dependencies.
