### PR TITLE
batman-adv: Update packages & add alfred

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/alfred.nix
+++ b/pkgs/os-specific/linux/batman-adv/alfred.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, gpsd }:
+
+let
+  ver = "2014.4.0";
+in
+stdenv.mkDerivation rec {
+  name = "alfred-${ver}";
+
+  src = fetchurl {
+    url = "http://downloads.open-mesh.org/batman/releases/batman-adv-${ver}/${name}.tar.gz";
+    sha256 = "99e6c64e7069b0b7cb861369d5c198bfc7d74d41509b8edd8a17ba78e7c8d034";
+  };
+
+  buildInputs = [ pkgconfig gpsd ];
+
+  preBuild = ''
+    makeFlags="PREFIX=$out PKG_CONFIG=${pkgconfig}/bin/pkg-config"
+  '';
+
+  meta = {
+    homepage = http://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
+    description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2, information distribution tool";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ fpletz ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/os-specific/linux/batman-adv/batctl.nix
+++ b/pkgs/os-specific/linux/batman-adv/batctl.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchurl}:
 
 let
-  ver = "2013.4.0";
+  ver = "2014.4.0";
 in
 stdenv.mkDerivation rec {
   name = "batctl-${ver}";
 
   src = fetchurl {
     url = "http://downloads.open-mesh.org/batman/releases/batman-adv-${ver}/${name}.tar.gz";
-    sha256 = "0k6b695h38m92a8wn5gvb3z746m3fm0ygv58yyn163adcsvf7sjd";
+    sha256 = "4deae3b6664d0d13acf7a8ece74175a31a72fe58fb15cb9112a9a2014b32cb4c";
   };
 
   preBuild = ''

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -2,14 +2,14 @@
 
 assert stdenv.lib.versionOlder kernel.version "3.17";
 
-let base = "batman-adv-2014.3.0"; in
+let base = "batman-adv-2014.4.0"; in
 
 stdenv.mkDerivation rec {
   name = "${base}-${kernel.version}";
 
   src = fetchurl {
     url = "http://downloads.open-mesh.org/batman/releases/${base}/${base}.tar.gz";
-    sha1 = "wh3if8v4wfwskvzwqsjsyr929krzfmsx";
+    sha256 = "757b9ddd346680f6fd87dc28fde6da0ddc0423a65fbc88fdbaa7b247fed2c1a8";
   };
 
   preBuild = ''
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.open-mesh.org/projects/batman-adv/wiki/Wiki;
     description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric fpletz ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8137,6 +8137,8 @@ let
 
   acpitool = callPackage ../os-specific/linux/acpitool { };
 
+  alfred = callPackage ../os-specific/linux/batman-adv/alfred.nix { };
+
   alienfx = callPackage ../os-specific/linux/alienfx { };
 
   alsaLib = callPackage ../os-specific/linux/alsa-lib { };


### PR DESCRIPTION
This PR updates the packages `batman_adv` and `batctl` from 2014.3.0 to 2014.4.0. Additionally, it adds the `alfred` package, which is distributed alongside batman and distributes local node information in the batman mesh network.

/cc @viric 
