### PR TITLE
dub: Add dub to interact with the D package registry

### DIFF
--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -1,0 +1,35 @@
+{stdenv, fetchurl, curl, dmd, gcc, unzip}:
+
+stdenv.mkDerivation {
+  name = "dub-0.9.22";
+
+  src = fetchurl {
+    url = "https://github.com/rejectedsoftware/dub/archive/v0.9.22.tar.gz";
+    sha256 = "0vhn96ybbsfflldlbyc17rmwb7bz21slbm189k5glyfr9nnp4cir";
+  };
+
+  buildInputs = [ unzip curl ];
+
+  propagatedBuildInputs = [ gcc dmd ];
+
+  buildPhase = ''
+      # Avoid that the version file is overwritten
+      substituteInPlace build.sh \
+          --replace source/dub/version_.d /dev/null
+      ./build.sh
+  '';
+
+  installPhase = ''
+      mkdir $out
+      mkdir $out/bin
+      cp bin/dub $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Build tool for D projects";
+    homepage = http://code.dlang.org/;
+    license = stdenv.lib.licenses.mit;
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1056,6 +1056,8 @@ let
 
   dtach = callPackage ../tools/misc/dtach { };
 
+  dub = callPackage ../development/tools/build-managers/dub { };
+
   duff = callPackage ../tools/filesystems/duff { };
 
   duo-unix = callPackage ../tools/security/duo-unix { };


### PR DESCRIPTION
Suggesting to add "dub" which is a build tool and package manager used in D development, somehow similar in concept to what pip is in python or ant in java.
