### PR TITLE
Add PyChart 1.39 as pychart in the Python packages

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12771,4 +12771,19 @@ let
     };
   };
 
+  pychart = buildPythonPackage rec {
+    name = "pychart-1.39";
+
+    src = pkgs.fetchurl {
+      url = "http://download.gna.org/pychart/PyChart-1.39.tar.gz";
+      sha256 = "882650928776a7ca72e67054a9e0ac98f78645f279c0cfb5910db28f03f07c2e";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Library for creating high quality encapsulated Postscript, PDF, PNG, or SVG charts";
+      homepage = http://home.gna.org/pychart/;
+      license = licenses.gpl2;
+    };
+  };
+
 }); in pythonPackages


### PR DESCRIPTION
I'm rather new to NixOS and nixpkgs but would like to add some python packages such as this one: PyChart (latest version 1.39 from http://home.gna.org/pychart/)
