### PR TITLE
Enable experimental for gst-plugins-good

### DIFF
--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./v4l.patch ./linux-headers-3.9.patch ];
 
-  configureFlags = "--disable-oss";
+  configureFlags = "--enable-experimental --disable-oss";
 
   buildInputs =
     [ pkgconfig glib gstreamer gst_plugins_base pulseaudio ]


### PR DESCRIPTION
This enables v4l2sink, a way of piping input into v4l2loopback. This is
useful for using a phone camera as a webcam, for example.
