### PR TITLE
Add an attribute for 32-bit apulse

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -488,6 +488,8 @@ let
 
   apulse = callPackage ../misc/apulse { };
 
+  apulse32 = callPackage_i686 ../misc/apulse { };
+
   archivemount = callPackage ../tools/filesystems/archivemount { };
 
   arandr = callPackage ../tools/X11/arandr { };


### PR DESCRIPTION
This is useful for calling apulse on 32-bit applications, such as Skype.
