### PR TITLE
systemd: extend checkUnitConfig with on-abnormal

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -58,7 +58,7 @@ let
       "simple" "forking" "oneshot" "dbus" "notify" "idle"
     ])
     (assertValueOneOf "Restart" [
-      "no" "on-success" "on-failure" "on-abort" "always"
+      "no" "on-success" "on-failure" "on-abnormal" "on-abort" "always"
     ])
   ];
 


### PR DESCRIPTION
"on-abnormal" should be available since v214.
