### PR TITLE
hoogle-local-wrapper should quote the command argument

### DIFF
--- a/pkgs/development/libraries/haskell/hoogle/hoogle-local-wrapper.sh
+++ b/pkgs/development/libraries/haskell/hoogle/hoogle-local-wrapper.sh
@@ -3,4 +3,4 @@
 COMMAND=$1
 shift
 HOOGLE_DOC_PATH=@out@/share/hoogle/doc exec @hoogle@/bin/hoogle \
-    $COMMAND -d @out@/share/hoogle "$@"
+    "$COMMAND" -d @out@/share/hoogle "$@"


### PR DESCRIPTION
`hoogle "[a] -> a"`

used to fail ("unknown flag: ->"), while

`hoogle "[a]->a"`

succeeded.
