### PR TITLE
Enable tests for Julia 0.3.X

### DIFF
--- a/pkgs/development/compilers/julia/0.3.5.nix
+++ b/pkgs/development/compilers/julia/0.3.5.nix
@@ -140,6 +140,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = true;
+  checkTarget = "testall";
+
   meta = {
     description = "High-level performance-oriented dynamical language for technical computing";
     homepage = "http://julialang.org/";


### PR DESCRIPTION
It was mentioned in PR #5842 that Julia's testsuite fails under nixpkgs.

This PR enables the testsuite for Julia 0.3.X to demonstrate that it
works.

Since Julia is numerical software, I think it is a great idea to
merge this current PR so that Julia will always be tested in the
future.

I was unable to get the tests to pass on the 0.2.X branch.  However,
this branch is dead (its latest commit was Aug 8) and will receive
no more releases.
