### PR TITLE
Fix build of 'pyacoustid' under Python 3.

### DIFF
--- a/pkgs/development/python-modules/pyacoustid-py3.patch
+++ b/pkgs/development/python-modules/pyacoustid-py3.patch
@@ -1,0 +1,32 @@
+From 19209469a709ec0914f82c9de23137e360e5e804 Mon Sep 17 00:00:00 2001
+From: Simon Chopin <chopin.simon@gmail.com>
+Date: Mon, 29 Sep 2014 10:38:20 +0200
+Subject: [PATCH] Explicit the UTF-8 encoding also when installing using Python
+ 3
+
+If the locale isn't UTF-8, or for some reason Python doesn't pick up on
+it, it will try to decode using ASCII, which will of course cause
+mayhem, crash and despair.
+
+This patch will be shipped with the Debian package 1.1.0-1
+---
+ setup.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index eafe5ea..0732fe3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -18,9 +18,10 @@
+ 
+ def _read(fn):
+     path = os.path.join(os.path.dirname(__file__), fn)
+-    data = open(path).read()
+     if sys.version_info[0] < 3:
+-        data = data.decode('utf8')
++        data = open(path).read().decode('utf8')
++    else:
++        data = open(path, encoding='utf8').read()
+     # Special case some Unicode characters; PyPI seems to only like ASCII.
+     data = data.replace(u'\xe1', u'a')
+     data = data.replace(u'\u0161', u's')

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7235,6 +7235,8 @@ let
 
     propagatedBuildInputs = with self; [ requests audioread ];
 
+    patches = [ ../development/python-modules/pyacoustid-py3.patch ];
+
     postPatch = ''
       sed -i \
           -e '/^FPCALC_COMMAND *=/s|=.*|= "${pkgs.chromaprint}/bin/fpcalc"|' \


### PR DESCRIPTION
The added patch ([source](https://github.com/sampsyo/pyacoustid/commit/19209469a709ec0914f82c9de23137e360e5e804)) ought to fix the Hydra failure for this module under Python 3.
