### PR TITLE
libredirect: add access syscall

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -102,3 +102,10 @@ int __xstat(int ver, const char * path, struct stat * st)
     char buf[PATH_MAX];
     return __xstat_real(ver, rewrite(path, buf), st);
 }
+
+int * access(const char * path, int mode)
+{
+    int * (*access_real) (const char *, int mode) = dlsym(RTLD_NEXT, "access");
+    char buf[PATH_MAX];
+    return access_real(rewrite(path, buf), mode);
+}


### PR DESCRIPTION
I have no clue about syscalls and C but reading in FOPEN(3), ACCESS(2) and nixpkgs/pkgs/build-support/libredirect/libredirect.c leads me to this patch. Feel free to refuse, comment or merge this PR.
