### PR TITLE
Riemann: update to 0.2.8

### DIFF
--- a/pkgs/servers/monitoring/riemann/default.nix
+++ b/pkgs/servers/monitoring/riemann/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "riemann-${version}";
-  version = "0.2.7";
+  version = "0.2.8";
 
   src = fetchurl {
     url = "http://aphyr.com/riemann/${name}.tar.bz2";
-    sha256 = "1hnjikm24jlfi5qav7gam078k5gynca36xbxr3b3lbhw17kyknwg";
+    sha256 = "1p2pdkxy2xc5zlj6kadf4z8l0f0r4bvdgipqf52193l7rdm6dfzm";
   };
 
   phases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
Minor bugfix release: fixes a bug in 0.2.7 which broke TCP servers on non-linux platforms.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/5877)

<!-- Reviewable:end -->
