### PR TITLE
gstreamer: wrap gst-{launch,inspect,typefind} with GST_PLUGIN_SYSTEM_PATH

### DIFF
--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, perl, bison, flex, python, gobjectIntrospection
-, glib
+, glib, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -19,10 +19,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig perl bison flex python gobjectIntrospection
+    pkgconfig perl bison flex python gobjectIntrospection makeWrapper
   ];
 
   propagatedBuildInputs = [ glib ];
+
+  postInstall = ''
+    for prog in "$out/bin/"*; do
+        wrapProgram "$prog" --prefix GST_PLUGIN_SYSTEM_PATH : "\$(unset _tmp; for profile in \$NIX_PROFILES; do _tmp="\$profile/lib/gstreamer-1.0''$\{_tmp:+:\}\$_tmp"; done; printf "\$_tmp")"
+    done
+  '';
 
   setupHook = ./setup-hook.sh;
 }


### PR DESCRIPTION
So that the tools become useable. The cool thing about wrapping them
like this (looping over $NIX_PROFILES) is that they will work on
non-NixOS systems too, given that $NIX_PROFILES is set correctly.

If you want the old (pure?) behaviour, just run gst-launch etc. with
empty $NIX_PROFILES.
