### PR TITLE
Update HPLIP and fix for CUPS 1.7

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -5,16 +5,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "hplip-3.14.4";
+  name = "hplip-3.14.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/hplip/${name}.tar.gz";
-    sha256 = "1j8h44f8igl95wqypj4rk9awcw513hlps980jmcnkx60xghc4l6f";
+    sha256 = "164mm30yb61psk5j4ziybxdd310y09fixgl09hmb59ny261wvcqi";
   };
 
   plugin = fetchurl {
     url = "http://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${name}-plugin.run";
-    sha256 = "0k1vpmy7babbm3c5v4dcbhq0jgyr8as722nylfs8zx0dy7kr8874";
+    sha256 = "10cvgy1h84fwh7xpw4x6cbkpisqbn3nbcqrgd9xz5fc6mn0b95dk";
   };
 
   hplip_state = ./hplip.state;

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, automake, pkgconfig
 , cups, zlib, libjpeg, libusb1, pythonPackages, saneBackends, dbus
 , polkit, qtSupport ? true, qt4, pythonDBus, pyqt4, net_snmp
-, withPlugin ? false
+, withPlugin ? false, substituteAll
 }:
 
-stdenv.mkDerivation rec {
+let
+
   name = "hplip-3.14.10";
 
   src = fetchurl {
@@ -12,12 +13,23 @@ stdenv.mkDerivation rec {
     sha256 = "164mm30yb61psk5j4ziybxdd310y09fixgl09hmb59ny261wvcqi";
   };
 
+  hplip_state =
+    substituteAll
+      {
+        src = ./hplip.state;
+        # evaluated this way, version is always up-to-date
+        version = (builtins.parseDrvName name).version;
+      };
+
   plugin = fetchurl {
     url = "http://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${name}-plugin.run";
     sha256 = "10cvgy1h84fwh7xpw4x6cbkpisqbn3nbcqrgd9xz5fc6mn0b95dk";
   };
 
-  hplip_state = ./hplip.state;
+in
+
+stdenv.mkDerivation {
+  inherit name src;
 
   prePatch = ''
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.

--- a/pkgs/misc/drivers/hplip/hplip.state
+++ b/pkgs/misc/drivers/hplip/hplip.state
@@ -1,4 +1,4 @@
 [plugin]
 installed=1
 eula=1
-version=3.14.4
+version=@version@


### PR DESCRIPTION
This updates the HP printer/scanner/fax drivers to the latest version (3.14.10) which is required to support CUPS 1.7. The old drivers had been failing for some time after the CUPS upgrade. This update also fixes the proprietary binary printer driver again; it should be safe to update HPLIP in the future without breaking the plugin.
