### PR TITLE
Fixup zfs python scripts

### DIFF
--- a/pkgs/os-specific/linux/zfs/git.nix
+++ b/pkgs/os-specific/linux/zfs/git.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, kernel, spl_git, perl, autoconf, automake, libtool, zlib, libuuid, coreutils, utillinux }:
+{ stdenv, fetchgit, kernel, spl_git, perl, python, autoconf, automake, libtool, zlib, libuuid, coreutils, utillinux }:
 
 stdenv.mkDerivation {
   name = "zfs-0.6.4-${kernel.version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     ./nix-build-git.patch
   ];
 
-  buildInputs = [ spl_git perl autoconf automake libtool zlib libuuid coreutils ];
+  buildInputs = [ spl_git perl python autoconf automake libtool zlib libuuid coreutils ];
 
   # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
   NIX_CFLAGS_LINK = "-lgcc_s";


### PR DESCRIPTION
zfs ships with a couple of python scripts that needed shebang rewriting. Adding
python as a build dependency enables fixup to do the rewrite. This change
complements 390c838c7fd9e21266b33d00da91ffa3d7a3e706 by applying the same to the
git derivation.
