### PR TITLE
New packages: Hunspell dictionaries for English, Spanish, Italian and French.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -142,6 +142,7 @@
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";
   refnil = "Martin Lavoie <broemartino@gmail.com>";
   relrod = "Ricky Elrod <ricky@elrod.me>";
+  renzo = "Renzo Carbonara <renzocarbonara@gmail.com>";
   rickynils = "Rickard Nilsson <rickynils@gmail.com>";
   rob = "Rob Vermaas <rob.vermaas@gmail.com>";
   robberer = "Longrin Wischnewski <robberer@freakmail.de>";

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -1,0 +1,368 @@
+/* hunspell dictionaries */
+
+{ stdenv, fetchurl, unzip }:
+
+let
+  mkDictFromRedIRIS =
+    { shortName, shortDescription, dictFileName, src }:
+    stdenv.mkDerivation rec {
+      inherit src;
+      version = "0.7";
+      name = "hunspell-dict-${shortName}-rediris-${version}";
+      meta = {
+        description = "Hunspell dictionary for ${shortDescription} from RedIRIS";
+        platforms = stdenv.lib.platforms.all;
+        homepage = https://forja.rediris.es/projects/rla-es/;
+        license = with stdenv.lib.licenses; [ gpl3 lgpl3 mpl11 ];
+      };
+      buildInputs = [ unzip ];
+      phases = "unpackPhase installPhase";
+      unpackCmd = "unzip $src README.txt ${dictFileName}.dic ${dictFileName}.aff";
+      sourceRoot = ".";
+      installPhase = ''
+        # hunspell dicts
+        install -dm755 "$out/share/hunspell"
+        install -m644 ${dictFileName}.dic "$out/share/hunspell/"
+        install -m644 ${dictFileName}.aff "$out/share/hunspell/"
+        # myspell dicts symlinks
+        install -dm755 "$out/share/myspell/dicts"
+        ln -sv "$out/share/hunspell/${dictFileName}.dic" "$out/share/myspell/dicts/"
+        ln -sv "$out/share/hunspell/${dictFileName}.aff" "$out/share/myspell/dicts/"
+        # docs
+        install -dm755 "$out/share/doc"
+        install -m644 README.txt "$out/share/doc/${name}.txt"
+      '';
+    };
+
+  mkDictFromDicollecte =
+    { shortName, shortDescription, longDescription, dictFileName }:
+    stdenv.mkDerivation rec {
+      version = "5.2";
+      name = "hunspell-dict-${shortName}-dicollecte-${version}";
+      meta = {
+        inherit longDescription;
+        description = "Hunspell dictionary for ${shortDescription} from Dicollecte";
+        platforms = stdenv.lib.platforms.all;
+        homepage = http://www.dicollecte.org/home.php?prj=fr;
+        license = stdenv.lib.licenses.mpl20;
+      };
+      src = fetchurl {
+         url = "http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip";
+         sha256 = "c5863f7592a8c4defe8b4ed2b3b45f6f10ef265d34ae9881c1f3bbb3b80bdd02";
+      };
+      buildInputs = [ unzip ];
+      phases = "unpackPhase installPhase";
+      unpackCmd = "unzip $src README_dict_fr.txt ${dictFileName}.dic ${dictFileName}.aff";
+      sourceRoot = ".";
+      installPhase = ''
+        # hunspell dicts
+        install -dm755 "$out/share/hunspell"
+        install -m644 ${dictFileName}.dic "$out/share/hunspell/"
+        install -m644 ${dictFileName}.aff "$out/share/hunspell/"
+        # myspell dicts symlinks
+        install -dm755 "$out/share/myspell/dicts"
+        ln -sv "$out/share/hunspell/${dictFileName}.dic" "$out/share/myspell/dicts/"
+        ln -sv "$out/share/hunspell/${dictFileName}.aff" "$out/share/myspell/dicts/"
+        # docs
+        install -dm755 "$out/share/doc"
+        install -m644 README_dict_fr.txt "$out/share/doc/${name}.txt"
+      '';
+    };
+
+in {
+
+  /* SPANISH */
+
+  es-any = mkDictFromRedIRIS {
+    shortName = "es-any";
+    shortDescription = "Spanish (any variant)";
+    dictFileName = "es_ANY";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2933/es_ANY.oxt;
+      md5 = "e3d4b38f280e7376178529db2ece982b";
+    };
+  };
+
+  es-ar = mkDictFromRedIRIS {
+    shortName = "es-ar";
+    shortDescription = "Spanish (Argentina)";
+    dictFileName = "es_AR";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2953/es_AR.oxt;
+      md5 = "68ee8f4ebc89a1fa461045d4dbb9b7be";
+    };
+  };
+
+  es-bo = mkDictFromRedIRIS {
+    shortName = "es-bo";
+    shortDescription = "Spanish (Bolivia)";
+    dictFileName = "es_BO";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2952/es_BO.oxt;
+      md5 = "1ebf11b6094e0bfece8e95cc34e7a409";
+    };
+  };
+
+  es-cl = mkDictFromRedIRIS {
+    shortName = "es-cl";
+    shortDescription = "Spanish (Chile)";
+    dictFileName = "es_CL";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2951/es_CL.oxt;
+      md5 = "092a388101350b77af4fd789668582bd";
+    };
+  };
+
+  es-co = mkDictFromRedIRIS {
+    shortName = "es-co";
+    shortDescription = "Spanish (Colombia)";
+    dictFileName = "es_CO";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2950/es_CO.oxt;
+      md5 = "fc440fd9fc55ca2dfb9bfa34a1e63864";
+    };
+  };
+
+  es-cr = mkDictFromRedIRIS {
+    shortName = "es-cr";
+    shortDescription = "Spanish (Costra Rica)";
+    dictFileName = "es_CR";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2949/es_CR.oxt;
+      md5 = "7510fd0f4eb3c6e65523a8d0960f77dd";
+    };
+  };
+
+  es-cu = mkDictFromRedIRIS {
+    shortName = "es-cu";
+    shortDescription = "Spanish (Cuba)";
+    dictFileName = "es_CU";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2948/es_CU.oxt;
+      md5 = "0ab4b9638f58ddd3d95d1265918ff39e";
+    };
+  };
+
+  es-do = mkDictFromRedIRIS {
+    shortName = "es-do";
+    shortDescription = "Spanish (Dominican Republic)";
+    dictFileName = "es_DO";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2947/es_DO.oxt;
+      md5 = "24a20fd4d887693afef539e6f1a3b58e";
+    };
+  };
+
+  es-ec = mkDictFromRedIRIS {
+    shortName = "es-ec";
+    shortDescription = "Spanish (Ecuador)";
+    dictFileName = "es_EC";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2946/es_EC.oxt;
+      md5 = "5d7343a246323ceda58cfbbf1428e279";
+    };
+  };
+
+  es-es = mkDictFromRedIRIS {
+    shortName = "es-es";
+    shortDescription = "Spanish (Spain)";
+    dictFileName = "es_ES";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2945/es_ES.oxt;
+      md5 = "59dd45e6785ed644adbbd73f4f126182";
+    };
+  };
+
+  es-gt = mkDictFromRedIRIS {
+    shortName = "es-gt";
+    shortDescription = "Spanish (Guatemala)";
+    dictFileName = "es_GT";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2944/es_GT.oxt;
+      md5 = "b1a9be80687e3117c67ac46aad6b8d66";
+    };
+  };
+
+  es-hn = mkDictFromRedIRIS {
+    shortName = "es-hn";
+    shortDescription = "Spanish (Honduras)";
+    dictFileName = "es_HN";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2943/es_HN.oxt;
+      md5 = "d0db5bebd6925738b524de9709950f22";
+    };
+  };
+
+  es-mx = mkDictFromRedIRIS {
+    shortName = "es-mx";
+    shortDescription = "Spanish (Mexico)";
+    dictFileName = "es_MX";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2942/es_MX.oxt;
+      md5 = "0de780714f84955112f38f35fb63a894";
+    };
+  };
+
+  es-ni = mkDictFromRedIRIS {
+    shortName = "es-ni";
+    shortDescription = "Spanish (Nicaragua)";
+    dictFileName = "es_NI";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2941/es_NI.oxt;
+      md5 = "d259d7be17c34df76c7de40c80720a39";
+    };
+  };
+
+  es-pa = mkDictFromRedIRIS {
+    shortName = "es-pa";
+    shortDescription = "Spanish (Panama)";
+    dictFileName = "es_PA";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2940/es_PA.oxt;
+      md5 = "085fbdbed6a2e248630c801881563b7a";
+    };
+  };
+
+  es-pe = mkDictFromRedIRIS {
+    shortName = "es-pe";
+    shortDescription = "Spanish (Peru)";
+    dictFileName = "es_PE";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2939/es_PE.oxt;
+      md5 = "f4673063246888995d4eaa2d4a24ee3d";
+    };
+  };
+
+  es-pr = mkDictFromRedIRIS {
+    shortName = "es-pr";
+    shortDescription = "Spanish (Puerto Rico)";
+    dictFileName = "es_PR";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2938/es_PR.oxt;
+      md5 = "e67bcf891ba9eeaeb57a60ec8e57f1ac";
+    };
+  };
+
+  es-py = mkDictFromRedIRIS {
+    shortName = "es-py";
+    shortDescription = "Spanish (Paraguay)";
+    dictFileName = "es_PY";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2937/es_PY.oxt;
+      md5 = "ba98e3197c81db4c572def2c5cca942d";
+    };
+  };
+
+  es-sv = mkDictFromRedIRIS {
+    shortName = "es-sv";
+    shortDescription = "Spanish (El Salvador)";
+    dictFileName = "es_SV";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2936/es_SV.oxt;
+      md5 = "c68ca9d188cb23c88cdd34a069c5a013";
+    };
+  };
+
+  es-uy = mkDictFromRedIRIS {
+    shortName = "es-uy";
+    shortDescription = "Spanish (Uruguay)";
+    dictFileName = "es_UY";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2935/es_UY.oxt;
+      md5 = "aeb9d39e4d17e9c904c1f3567178aad6";
+    };
+  };
+
+  es-ve = mkDictFromRedIRIS {
+    shortName = "es-ve";
+    shortDescription = "Spanish (Venezuela)";
+    dictFileName = "es_VE";
+    src = fetchurl {
+      url = http://forja.rediris.es/frs/download.php/2934/es_VE.oxt;
+      md5 = "8afa9619aede2d9708e799e0f5d0fcab";
+    };
+  };
+
+
+  /* FRENCH */
+  fr-any = mkDictFromDicollecte {
+    shortName = "fr-any";
+    dictFileName = "fr-toutesvariantes";
+    shortDescription = "French (any variant)";
+    longDescription = ''
+      Ce dictionnaire contient les nouvelles et les anciennes graphies des
+      mots concernés par la réforme de 1990.
+    '';
+  };
+
+  fr-classique = mkDictFromDicollecte {
+    shortName = "fr-classique";
+    dictFileName = "fr-classique";
+    shortDescription = "French (classic)";
+    longDescription = ''
+      Ce dictionnaire est une extension du dictionnaire «Moderne» et propose
+      en sus des graphies alternatives, parfois encore très usitées, parfois
+      tombées en désuétude.
+    '';
+  };
+
+  fr-moderne = mkDictFromDicollecte {
+    shortName = "fr-moderne";
+    dictFileName = "fr-moderne";
+    shortDescription = "French (modern)";
+    longDescription = ''
+      Ce dictionnaire propose une sélection des graphies classiques et
+      réformées, suivant la lente évolution de l’orthographe actuelle. Ce
+      dictionnaire contient les graphies les moins polémiques de la réforme.
+    '';
+  };
+
+  fr-reforme1990 = mkDictFromDicollecte {
+    shortName = "fr-reforme1990";
+    dictFileName = "fr-reforme1990";
+    shortDescription = "French (1990 reform)";
+    longDescription = ''
+      Ce dictionnaire ne connaît que les graphies nouvelles des mots concernés
+      par la réforme de 1990.
+    '';
+  };
+
+
+  /* ITALIAN */
+  it-it = stdenv.mkDerivation rec {
+      version = "2.4";
+      name = "hunspell-dict-it-it-linguistico-${version}";
+      src = fetchurl {
+        url = mirror://sourceforge/linguistico/italiano_2_4_2007_09_01.zip;
+        md5 = "e7fbd9e2dfb25ea3288cdb918e1e1260";
+      };
+      meta = {
+        description = "Hunspell dictionary for 'Italian (Italy)' from Linguistico";
+        platforms = stdenv.lib.platforms.all;
+        homepage = http://sourceforge.net/projects/linguistico/;
+        license = stdenv.lib.licenses.gpl3;
+      };
+      buildInputs = [ unzip ];
+      phases = "unpackPhase patchPhase installPhase";
+      unpackCmd = "unzip $src it_IT_README.txt it_IT.dic it_IT.aff";
+      sourceRoot = ".";
+      prePatch = ''
+        # Fix dic file empty lines (FS#22275)
+        sed '/^\/$/d' -i it_IT.dic
+      '';
+      installPhase = ''
+        # hunspell dicts
+        install -dm755 "$out/share/hunspell"
+        install -m644 it_IT.dic "$out/share/hunspell/"
+        install -m644 it_IT.aff "$out/share/hunspell/"
+        # myspell dicts symlinks
+        install -dm755 "$out/share/myspell/dicts"
+        ln -sv "$out/share/hunspell/it_IT.dic" "$out/share/myspell/dicts/"
+        ln -sv "$out/share/hunspell/it_IT.aff" "$out/share/myspell/dicts/"
+        # docs
+        install -dm755 "$out/share/doc"
+        install -m644 it_IT_README.txt "$out/share/doc/${name}.txt"
+      '';
+    };
+
+}

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -9,12 +9,13 @@ let
       inherit src;
       version = "0.7";
       name = "hunspell-dict-${shortName}-rediris-${version}";
-      meta = {
+      meta = with stdenv.lib; {
         description = "Hunspell dictionary for ${shortDescription} from RedIRIS";
-        platforms = stdenv.lib.platforms.all;
         homepage = https://forja.rediris.es/projects/rla-es/;
-        license = with stdenv.lib.licenses; [ gpl3 lgpl3 mpl11 ];
+        license = with licenses; [ gpl3 lgpl3 mpl11 ];
+        platforms = platforms.all;
       };
+      maintainers = [ stdenv.lib.maintainers.renzo ];
       buildInputs = [ unzip ];
       phases = "unpackPhase installPhase";
       unpackCmd = "unzip $src README.txt ${dictFileName}.dic ${dictFileName}.aff";
@@ -39,13 +40,14 @@ let
     stdenv.mkDerivation rec {
       version = "5.2";
       name = "hunspell-dict-${shortName}-dicollecte-${version}";
-      meta = {
+      meta = with stdenv.lib; {
         inherit longDescription;
         description = "Hunspell dictionary for ${shortDescription} from Dicollecte";
-        platforms = stdenv.lib.platforms.all;
         homepage = http://www.dicollecte.org/home.php?prj=fr;
-        license = stdenv.lib.licenses.mpl20;
+        license = licenses.mpl20;
+        platforms = platforms.all;
       };
+      maintainers = [ stdenv.lib.maintainers.renzo ];
       src = fetchurl {
          url = "http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip";
          sha256 = "c5863f7592a8c4defe8b4ed2b3b45f6f10ef265d34ae9881c1f3bbb3b80bdd02";
@@ -336,12 +338,13 @@ in {
         url = mirror://sourceforge/linguistico/italiano_2_4_2007_09_01.zip;
         md5 = "e7fbd9e2dfb25ea3288cdb918e1e1260";
       };
-      meta = {
+      meta = with stdenv.lib; {
         description = "Hunspell dictionary for 'Italian (Italy)' from Linguistico";
-        platforms = stdenv.lib.platforms.all;
         homepage = http://sourceforge.net/projects/linguistico/;
-        license = stdenv.lib.licenses.gpl3;
+        license = licenses.gpl3;
+        platforms = platforms.all;
       };
+      maintainers = [ stdenv.lib.maintainers.renzo ];
       buildInputs = [ unzip ];
       phases = "unpackPhase patchPhase installPhase";
       unpackCmd = "unzip $src it_IT_README.txt it_IT.dic it_IT.aff";

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -71,7 +71,79 @@ let
       '';
     };
 
+  mkDictFromWordlist =
+    { shortName, shortDescription, dictFileName, src }:
+    stdenv.mkDerivation rec {
+      inherit src;
+      version = "2014.11.17";
+      name = "hunspell-dict-${shortName}-wordlist-${version}";
+      meta = with stdenv.lib; {
+        description = "Hunspell dictionary for ${shortDescription} from Wordlist";
+        homepage =http://wordlist.aspell.net/;
+        license = licenses.bsd3;
+        platforms = platforms.all;
+      };
+      maintainers = [ stdenv.lib.maintainers.renzo ];
+      buildInputs = [ unzip ];
+      phases = "unpackPhase installPhase";
+      unpackCmd = "unzip $src README_${dictFileName}.txt ${dictFileName}.dic ${dictFileName}.aff";
+      sourceRoot = ".";
+      installPhase = ''
+        # hunspell dicts
+        install -dm755 "$out/share/hunspell"
+        install -m644 ${dictFileName}.dic "$out/share/hunspell/"
+        install -m644 ${dictFileName}.aff "$out/share/hunspell/"
+        # myspell dicts symlinks
+        install -dm755 "$out/share/myspell/dicts"
+        ln -sv "$out/share/hunspell/${dictFileName}.dic" "$out/share/myspell/dicts/"
+        ln -sv "$out/share/hunspell/${dictFileName}.aff" "$out/share/myspell/dicts/"
+        # docs
+        install -dm755 "$out/share/doc"
+        install -m644 README_${dictFileName}.txt "$out/share/doc/${name}.txt"
+      '';
+    };
+
 in {
+  /* ENGLISH */
+  en-us = mkDictFromWordlist {
+    shortName = "en-us";
+    shortDescription = "English (United States)";
+    dictFileName = "en_US";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2014.11.17/hunspell-en_US-2014.11.17.zip;
+      sha256 = "4ce88a1af457ce0e256110277a150e5da798213f611929438db059c1c81e20f2";
+    };
+  };
+
+  en-ca = mkDictFromWordlist {
+    shortName = "en-ca";
+    shortDescription = "English (Canada)";
+    dictFileName = "en_CA";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2014.11.17/hunspell-en_CA-2014.11.17.zip;
+      sha256 = "59950448440657a6fc3ede15720c1b86c0b66c4ec734bf1bd9157f6a1786673b";
+    };
+  };
+
+  en-gb-ise = mkDictFromWordlist {
+    shortName = "en-gb-ise";
+    shortDescription = "English (United Kingdom, 'ise' ending)";
+    dictFileName = "en_GB-ise";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2014.11.17/hunspell-en_GB-ise-2014.11.17.zip;
+      sha256 = "97f3b25102fcadd626ae4af3cdd97f017ce39264494f98b1f36ad7d96b9d5a94";
+    };
+  };
+
+  en-gb-ize = mkDictFromWordlist {
+    shortName = "en-gb-ize";
+    shortDescription = "English (United Kingdom, 'ize' ending)";
+    dictFileName = "en_GB-ize";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2014.11.17/hunspell-en_GB-ize-2014.11.17.zip;
+      sha256 = "84270673ed7c014445f3ba02f9efdb0ac44cea9ee0bfec76e3e10feae55c4e1c";
+    };
+  };
 
   /* SPANISH */
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5697,6 +5697,10 @@ let
 
   hunspell = callPackage ../development/libraries/hunspell { };
 
+  hunspellDicts = recurseIntoAttrs (import ../development/libraries/hunspell/dictionaries.nix {
+    inherit stdenv fetchurl unzip;
+  });
+
   hwloc = callPackage ../development/libraries/hwloc {
     inherit (xlibs) libX11;
   };


### PR DESCRIPTION
These aren't readily picked up by Hunspell-compatible software such as Firefox or LibreOffice just yet, as those programs need to be setup to look for the dictionaries at the proper paths, which involves changing the derivations for those programs. Nevertheless, one can point Hunspell-compatible tools to, say, `$HOME/.nix-profile/share/hunspell` and they will find the dictionaries:

```
% echo "bonjor" | hunspell -d fr-classique
Can't open affix or dictionary files for dictionary named "fr-classique".

% export DICPATH=$HOME/.nix-profile/share/hunspell
% echo "bonjor" | hunspell -d fr-classique
Hunspell 1.3.3
& bonjor 1 0: bonjour
```

The full list of packages added:

```
hunspellDicts.es-any         hunspell-dict-es-any-rediris-0.7
hunspellDicts.es-ar          hunspell-dict-es-ar-rediris-0.7
hunspellDicts.es-bo          hunspell-dict-es-bo-rediris-0.7
hunspellDicts.es-cl          hunspell-dict-es-cl-rediris-0.7
hunspellDicts.es-co          hunspell-dict-es-co-rediris-0.7
hunspellDicts.es-cr          hunspell-dict-es-cr-rediris-0.7
hunspellDicts.es-cu          hunspell-dict-es-cu-rediris-0.7
hunspellDicts.es-do          hunspell-dict-es-do-rediris-0.7
hunspellDicts.es-ec          hunspell-dict-es-ec-rediris-0.7
hunspellDicts.es-es          hunspell-dict-es-es-rediris-0.7
hunspellDicts.es-gt          hunspell-dict-es-gt-rediris-0.7
hunspellDicts.es-hn          hunspell-dict-es-hn-rediris-0.7
hunspellDicts.es-mx          hunspell-dict-es-mx-rediris-0.7
hunspellDicts.es-ni          hunspell-dict-es-ni-rediris-0.7
hunspellDicts.es-pa          hunspell-dict-es-pa-rediris-0.7
hunspellDicts.es-pe          hunspell-dict-es-pe-rediris-0.7
hunspellDicts.es-pr          hunspell-dict-es-pr-rediris-0.7
hunspellDicts.es-py          hunspell-dict-es-py-rediris-0.7
hunspellDicts.es-sv          hunspell-dict-es-sv-rediris-0.7
hunspellDicts.es-uy          hunspell-dict-es-uy-rediris-0.7
hunspellDicts.es-ve          hunspell-dict-es-ve-rediris-0.7
hunspellDicts.fr-any         hunspell-dict-fr-any-dicollecte-5.2
hunspellDicts.fr-classique   hunspell-dict-fr-classique-dicollecte-5.2
hunspellDicts.fr-moderne     hunspell-dict-fr-moderne-dicollecte-5.2
hunspellDicts.fr-reforme1990 hunspell-dict-fr-reforme1990-dicollecte-5.2
hunspellDicts.it-it          hunspell-dict-it-it-linguistico-2.4
```

Hint: in Firefox you can go to `about:config` and create a new string value named `spellchecker.dictionary_path` set to `PATH-TO-YOUR-HOME-FOLDER/.nix-profile/share/hunspell` and the dictionaries will be available after restarting Firefox.
