### PR TITLE
haskell-ng: hoogleLocal support

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -56,6 +56,7 @@ let
 
         ghcWithPackages = pkgs: callPackage ./with-packages-wrapper.nix {
           inherit (self) llvmPackages;
+          haskellPackages = self;
           packages = pkgs self;
         };
 

--- a/pkgs/development/haskell-modules/hoogle-local-wrapper.sh
+++ b/pkgs/development/haskell-modules/hoogle-local-wrapper.sh
@@ -1,0 +1,6 @@
+#! @shell@
+
+COMMAND=$1
+shift
+HOOGLE_DOC_PATH=@out@/share/hoogle/doc exec @hoogle@/bin/hoogle \
+    "$COMMAND" -d @out@/share/hoogle "$@"

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -1,0 +1,107 @@
+# Install not only the Hoogle library and executable, but also a local Hoogle
+# database which provides "Source" links to all specified 'packages' -- or the
+# current Haskell Platform if no custom package set is provided.
+#
+# It is intended to be used in config.nix similarly to:
+#
+# { packageOverrides = pkgs: rec {
+#
+#   haskellPackages =
+#     let callPackage = pkgs.lib.callPackageWith haskellPackages;
+#     in pkgs.recurseIntoAttrs (pkgs.haskellPackages.override {
+#         extension = self: super: {
+#           hoogleLocal = pkgs.haskellPackages.hoogleLocal.override {
+#             packages = with pkgs.haskellPackages; [
+#               mmorph
+#               monadControl
+#             ];
+#           };
+#         };
+#       });
+# }}
+#
+# This will build mmorph and monadControl, and have the hoogle installation
+# refer to their documentation via symlink so they are not garbage collected.
+
+{ stdenv, hoogle, rehoo
+, ghc, packages ? [ ghc.ghc ]
+}:
+
+let
+  inherit (stdenv.lib) optional;
+  wrapper = ./hoogle-local-wrapper.sh;
+in
+stdenv.mkDerivation {
+  name = "hoogle-local-0.1";
+  buildInputs = [hoogle rehoo];
+
+  phases = [ "installPhase" ];
+
+  docPackages = packages;
+  installPhase = ''
+    if [ -z "$docPackages" ]; then
+        echo "ERROR: The packages attribute has not been set"
+        exit 1
+    fi
+
+    mkdir -p $out/share/hoogle/doc
+    export HOOGLE_DOC_PATH=$out/share/hoogle/doc
+
+    cd $out/share/hoogle
+
+    function import_dbs() {
+        find $1 -name '*.txt' | while read f; do
+          newname=$(basename "$f" | tr '[:upper:]' '[:lower:]')
+          if [[ -f $f && ! -f ./$newname ]]; then
+            cp -p $f ./$newname
+            hoogle convert -d "$(dirname $f)" "./$newname"
+          fi
+        done
+    }
+
+    for i in $docPackages; do
+        findInputs $i docPackages propagated-native-build-inputs
+        findInputs $i docPackages propagated-build-inputs
+    done
+
+    for i in $docPackages; do
+      if [[ ! $i == $out ]]; then
+        for docdir in $i/share/doc/*-ghc-*/* $i/share/doc/*; do
+          if [[ -d $docdir ]]; then
+            import_dbs $docdir
+            ln -sf $docdir $out/share/hoogle/doc
+          fi
+        done
+      fi
+    done
+
+    import_dbs ${ghc}/share/doc/ghc*/html/libraries
+    ln -sf ${ghc}/share/doc/ghc*/html/libraries/* $out/share/hoogle/doc
+
+    chmod 644 *.hoo *.txt
+    rehoo -j4 -c64 .
+
+    rm -fr downloads *.dep *.txt
+    mv default.hoo x || exit 0
+    rm -f *.hoo
+    mv x default.hoo || exit 1
+
+    if [ ! -f default.hoo ]; then
+        echo "Unable to build the default Hoogle database"
+        exit 1
+    fi
+
+    mkdir -p $out/bin
+    substitute ${wrapper} $out/bin/hoogle \
+        --subst-var out --subst-var-by shell ${stdenv.shell} \
+        --subst-var-by hoogle ${hoogle}
+    chmod +x $out/bin/hoogle
+  '';
+
+  meta = {
+    description = "A local Hoogle database";
+    platforms = ghc.meta.platforms;
+    hydraPlatforms = with stdenv.lib.platforms; none;
+    maintainers = with stdenv.lib.maintainers; [ ttuegel ];
+  };
+}

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -79,4 +79,10 @@ rec {
 
   triggerRebuild = drv: i: overrideCabal drv (drv: { postUnpack = ": trigger rebuild ${toString i}"; });
 
+  withHoogle = haskellEnv: with haskellEnv.haskellPackages;
+    import ./hoogle.nix {
+      inherit (pkgs) stdenv;
+      inherit hoogle rehoo ghc;
+      packages = haskellEnv.paths;
+    };
 }

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, ghc, llvmPackages, packages, buildEnv, makeWrapper
 , ignoreCollisions ? false, withLLVM ? false
 , postBuild ? ""
+, haskellPackages
 }:
 
 # This wrapper works only with GHC 6.12 or later.
@@ -94,7 +95,9 @@ buildEnv {
     ${lib.optionalString hasLibraries "$out/bin/${ghcCommand}-pkg recache"}
     $out/bin/${ghcCommand}-pkg check
   '' + postBuild;
-} // {
-  preferLocalBuild = true;
-  inherit (ghc) version meta;
+  passthru = {
+    preferLocalBuild = true;
+    inherit (ghc) version meta;
+    inherit haskellPackages;
+  };
 }


### PR DESCRIPTION
This makes it trivial to get local hoogle info for a given Haskell-NG package set:

``` Nix
let
  ghcPackages = (haskellngPackages.ghcWithPackages (p: with p; [
    ipprint
    hspec
    cabal-install
    cabal2nix
    wai
    yesod
    lens
    hdevtools
    ghc-mod
  ]));

in

runCommand "dummy" {
  buildInputs = [
    ghcPackages
    ghcPackages.hoogleLocal
  ];
  shellHook = ''
    export NIX_GHC="${ghcPackages}/bin/ghc"
    export NIX_GHCPKG="${ghcPackages}/bin/ghc-pkg"
    export NIX_GHC_DOCDIR="${ghcPackages}/share/doc/ghc/html"
    export NIX_GHC_LIBDIR=$( $NIX_GHC --print-libdir )
  '';
} ""
```

How do you feel about this, @peti?

Alternatively, I also realized that I could just put this in my `config.nix`:

``` Nix
  withHoogle = haskellEnv: with haskellngPackages;
    import <nixpkgs/pkgs/development/libraries/haskell/hoogle/local.nix> {
      inherit stdenv hoogle rehoo ghc;
      packages = haskellEnv.paths;
    };
```

Regardless of how we do it (new attribute vs combinator), I'd like to see us have a simple/intuitive way to set-up local hoogle support, especially for newcomers.
