### PR TITLE
oraclejdk: bump to 8u31, 7u75, and 7u76

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
-  patchVersion = "71";
+  patchVersion = "75";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
-  sha256_i686 = "d3c09a35abc0464d8ad70dfe17e02597eb4c5d489ff4d1bcd14088aeb5016424";
-  sha256_x86_64 = "80d5705fc37fc4eabe3cea480e0530ae0436c2c086eb8fc6f65bb21e8594baf8";
+  sha256_i686 = "173ppi5d90hllqgys90wlv596bpj2iw8gsbsr6pk7xvd4l1wdhrw";
+  sha256_x86_64 = "040n50nglr6rcli2pz5rd503c2qqdqqbqynp6hzc4kakkchmj2a6";
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";

--- a/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
-  patchVersion = "72";
+  patchVersion = "76";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
-  sha256_i686 = "0376c8a0280752b4389b6cb193d463826c55c821587d0278b7fea665a140f407";
-  sha256_x86_64 = "dd1d438e1b7d4b9bb5ea4659f2103b577d1568da51b53f97b736b3232eeade8e";
+  sha256_i686 = "0558p5garc4b5g7h11dkzn161kpk84az5ad1q5hhsblbx02aqff3";
+  sha256_x86_64 = "130ckrv846amyfzbnnd6skljkznc457yky7d6ajaw5ndsbzg93yf";
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "25";
+  patchVersion = "31";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "17f396a541db09c732032185f10f9c6eb42ac7b5776814602342de9655b2e0e2";
-  sha256_x86_64 = "057f660799be2307d2eefa694da9d3fce8e165807948f5bcaa04f72845d2f529";
+  sha256_i686 = "1sr3q9y0cd42cqpf98gsv3hvip0r1vw3d0jh6yml6krzdm96zp8s";
+  sha256_x86_64 = "0dz4k3xds1ydqr77hmrjc1w0niqq3jm3h18nk3ibqr1083l1bq7g";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59";


### PR DESCRIPTION
> Java SE 8u31
> This release includes important security fixes. Oracle strongly recommends that all Java SE 8 users upgrade to this release.
> 
> Java SE 7u75/76
> These releases includes important security fixes. Oracle strongly recommends that all Java SE 7 users upgrade to one of these releases.

http://www.oracle.com/technetwork/java/javase/downloads/index.html

Release notes:
http://www.oracle.com/technetwork/java/javase/8u31-relnotes-2389094.html
http://www.oracle.com/technetwork/java/javase/7u75-relnotes-2389086.html
http://www.oracle.com/technetwork/java/javase/7u76-relnotes-2389087.html
