### PR TITLE
Add documentation for nixpkgs.config settings

### DIFF
--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -12,6 +12,7 @@
   <xi:include href="introduction.xml" />
   <xi:include href="quick-start.xml" />
   <xi:include href="stdenv.xml" />
+  <xi:include href="packageconfig.xml" />
   <xi:include href="meta.xml" />
   <xi:include href="language-support.xml" />
   <xi:include href="package-notes.xml" />

--- a/doc/packageconfig.xml
+++ b/doc/packageconfig.xml
@@ -43,7 +43,7 @@
                 Whenever unfree packages are not allowed, packages can still be
                 whitelisted by their license:
                 <programlisting>
-                    nixpkgs.config.whitelistedLicenses = [ licenseA licenseB ];
+                    nixpkgs.config.whitelistedLicenses = with stdenv.lib.licenses; [ amd wtfpl ];
                 </programlisting>
             </para>
         </listitem>
@@ -54,7 +54,7 @@
                 <literal>allowUnfree</literal> setting, you can also explicitely
                 deny installation of packages which have a certain license:
                 <programlisting>
-                    nixpkgs.config.blacklistedLicenses = [ licenseA licenseB ];
+                    nixpkgs.config.blacklistedLicenses = with stdenv.lib.licenses; [ agpl3 gpl3 ];
                 </programlisting>
             </para>
         </listitem>

--- a/doc/packageconfig.xml
+++ b/doc/packageconfig.xml
@@ -1,0 +1,63 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="chap-packageconfig">
+
+<title>nixpkgs configuration</title>
+
+    <para>
+        The Nix package manager can be configured to allow or deny certain
+        package sets. At this moment, packages can either be allowed to be
+        installed or denied to be installed based on their license.
+    </para>
+
+    <itemizedlist>
+        <listitem>
+            <para>
+                Allow packages that do not have a free license by setting
+                <programlisting>
+                    nixpkgs.config.allowUnfree = true;
+                </programlisting>
+                or deny them by setting it to <literal>false</literal>.
+            </para>
+            <para>
+                This can also be achieved for one call to the Nix package
+                manager by setting the environment variable:
+                <programlisting>
+                    export NIXPKGS_ALLOW_UNFREE=1
+                </programlisting>
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                Whenever unfree packages are not allowed, single packages can
+                still be allowed by a predicate:
+                <programlisting>
+                    nixpkgs.config.allowUnfreePredicate = (x: ...);
+                </programlisting>
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                Whenever unfree packages are not allowed, packages can still be
+                whitelisted by their license:
+                <programlisting>
+                    nixpkgs.config.whitelistedLicenses = [ licenseA licenseB ];
+                </programlisting>
+            </para>
+        </listitem>
+
+        <listitem>
+            <para>
+                In addition to whitelisting licenses which are denied by the
+                <literal>allowUnfree</literal> setting, you can also explicitely
+                deny installation of packages which have a certain license:
+                <programlisting>
+                    nixpkgs.config.blacklistedLicenses = [ licenseA licenseB ];
+                </programlisting>
+            </para>
+        </listitem>
+    </itemizedlist>
+
+</chapter>

--- a/doc/packageconfig.xml
+++ b/doc/packageconfig.xml
@@ -60,4 +60,26 @@
         </listitem>
     </itemizedlist>
 
+    <para>
+        To apply the configuration to the package manager, you have to emit the
+        <programlisting>
+            nixpkgs.config
+        </programlisting>
+        part from the upper listings. So a configuration with
+        <programlisting>
+            {
+                allowUnfree = true;
+            }
+        </programlisting>
+        in
+        <programlisting>
+            ~/.nixpkgs/config.nix
+        </programlisting>
+        will prevent the Nix package manager from installing unfree licensed
+        packages.
+
+        The configuration as listed applies for NixOS.
+    </para>
+
+
 </chapter>

--- a/doc/packageconfig.xml
+++ b/doc/packageconfig.xml
@@ -61,6 +61,14 @@
     </itemizedlist>
 
     <para>
+        A complete list of licenses can be found in the file
+        <programlisting>
+            lib/licenses.nix
+        </programlisting>
+        of the nix package tree.
+    </para>
+
+    <para>
         To apply the configuration to the package manager, you have to emit the
         <programlisting>
             nixpkgs.config


### PR DESCRIPTION
This PR is a follow-up PR for #5892 

It documents the following settings:
- `allowUnfree`
- `allowUnfreePredicate`
- `whitelistedLicenses`
- `blacklistedLicenses`

Feel free to suggest more documentation at the appropriate places.
