### PR TITLE
Adding services.nginx.http.server.<name> option

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -63,6 +63,73 @@ in
         description = "Configuration lines to be appended inside of the http {} block.";
       };
 
+      http.servers = mkOption {
+        description = ''
+          http servers
+        '';
+
+        default = {};
+
+        type = types.loaOf (types.submodule (
+          {
+            options = {
+              server_name = mkOption {
+                description = "name_servers option contents as list of strings.";
+                type = types.listOf types.string;
+              };
+              listen = mkOption {
+                description = ''
+                  Either port or IP:PORT. <code>ssl</code> will be added if
+                  you set sslCert and sslKey.
+                  Use <option>defaultServer</option> to append <code>default_server</code>.
+                '';
+                type = types.string;
+              };
+              defaultServer = mkOption {
+                default = false;
+                type = types.bool;
+                description = ''
+                  Set to true if this server should be the default server.
+                '';
+              };
+              sslCert = mkOption {
+                type = types.string;
+                description = "ssl cert";
+                default = "";
+              };
+              sslKey = mkOption {
+                type = types.string;
+                description = "ssl key";
+                default = "";
+              };
+              errorLog = mkOption {
+                type = types.string;
+                default = "";
+              };
+              accessLog = mkOption {
+                type = types.string;
+                default = "";
+              };
+              preConfig = mkOption {
+                type = types.lines;
+                default = "";
+                description = ''
+                  Configuration which should be put first in server { .. } section.
+                  Use this for logfile declaration
+                '';
+              };
+              config = mkOption {
+                description = ''
+                  contents of this server section
+                '';
+                type = types.lines;
+                default = "";
+              };
+            };
+          }
+        ));
+      };
+
       stateDir = mkOption {
         default = "/var/spool/nginx";
         description = "
@@ -88,6 +155,36 @@ in
 
   config = mkIf cfg.enable {
     # TODO: test user supplied config file pases syntax test
+
+    environment.systemPackages = [ nginx ];
+
+    services.nginx.httpConfig =
+      concatMapStrings (server:
+        let defaultServer = optionalString server.defaultServer "default_server";
+            accessLog = optionalString (server.accessLog != "")  "error_log ${errorLog}";
+            errorLog = optionalString (server.errorLog != "")    "access_log ${accessLog}";
+            listen =
+              if server.sslCert != "" && server.sslKey != ""
+              then ''
+                listen ${server.listen} ssl ${defaultServer};
+                ssl_certificate     ${server.sslCert};
+                ssl_certificate_key ${server.sslKey};
+                ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+                ssl_ciphers         HIGH:!aNULL:!MD5;
+              '' else ''
+                listen ${server.listen} ${defaultServer};
+              '';
+        in ''
+        server {
+          ${listen}
+          server_name = ${concatStringsSep " " server.server_name};
+          ${accessLog}
+          ${errorLog}
+          ${server.preConfig}
+
+          ${server.config}
+        }
+      '') (attrValues cfg.http.servers);
 
     systemd.services.nginx = {
       description = "Nginx Web Server";


### PR DESCRIPTION
which can be used to define servers in the http section
