### PR TITLE
rcm: Use Nix store path for RCM_LIB

### DIFF
--- a/pkgs/tools/misc/rcm/default.nix
+++ b/pkgs/tools/misc/rcm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "rcm-1.2.3";
 
   src = fetchurl {
@@ -8,9 +8,18 @@ stdenv.mkDerivation rec {
     sha256 = "0gwpclbc152jkclj3w83s2snx3dcgljwr75q1z8czl3yar7d8bsh";
   };
  
-  meta = {
+  patches = [ ./fix-rcmlib-path.patch ];
+
+  postPatch = ''
+    for f in bin/*.in; do
+      substituteInPlace $f --subst-var-by rcm $out
+    done
+  '';
+
+  meta = with stdenv.lib; {
     description = "Management Suite for Dotfiles";
     homepage = https://github.com/thoughtbot/rcm;
-    license = stdenv.lib.licenses.bsd3;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ malyn ];
   };
 }

--- a/pkgs/tools/misc/rcm/fix-rcmlib-path.patch
+++ b/pkgs/tools/misc/rcm/fix-rcmlib-path.patch
@@ -1,0 +1,68 @@
+*** rcm-1.2.3/bin/lsrc.in.orig	2014-05-09 04:57:39.000000000 -0700
+--- rcm-1.2.3/bin/lsrc.in	2015-01-24 14:27:48.786595479 -0800
+***************
+*** 1,6 ****
+  #!@SHELL@
+  
+! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+  . "$RCM_LIB/rcm.sh"
+  
+  pushdir() {
+--- 1,6 ----
+  #!@SHELL@
+  
+! RCM_LIB=@rcm@/share/rcm
+  . "$RCM_LIB/rcm.sh"
+  
+  pushdir() {
+*** rcm-1.2.3/bin/mkrc.in.orig	2014-05-09 04:57:39.000000000 -0700
+--- rcm-1.2.3/bin/mkrc.in	2015-01-24 14:27:48.786595479 -0800
+***************
+*** 1,6 ****
+  #!@SHELL@
+  
+! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+  . "$RCM_LIB/rcm.sh"
+  
+  destination() {
+--- 1,6 ----
+  #!@SHELL@
+  
+! RCM_LIB=@rcm@/share/rcm
+  . "$RCM_LIB/rcm.sh"
+  
+  destination() {
+*** rcm-1.2.3/bin/rcdn.in.orig	2014-05-09 04:57:39.000000000 -0700
+--- rcm-1.2.3/bin/rcdn.in	2015-01-24 14:27:48.786595479 -0800
+***************
+*** 1,6 ****
+  #!@SHELL@
+  
+! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+  . "$RCM_LIB/rcm.sh"
+  
+  remove_link() {
+--- 1,6 ----
+  #!@SHELL@
+  
+! RCM_LIB=@rcm@/share/rcm
+  . "$RCM_LIB/rcm.sh"
+  
+  remove_link() {
+*** rcm-1.2.3/bin/rcup.in.orig	2014-05-09 04:57:39.000000000 -0700
+--- rcm-1.2.3/bin/rcup.in	2015-01-24 14:27:48.786595479 -0800
+***************
+*** 1,6 ****
+  #!@SHELL@
+  
+! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+  . "$RCM_LIB/rcm.sh"
+  
+  link_or_copy() {
+--- 1,6 ----
+  #!@SHELL@
+  
+! RCM_LIB=@rcm@/share/rcm
+  . "$RCM_LIB/rcm.sh"
+  
+  link_or_copy() {


### PR DESCRIPTION
The shell scripts in the rcm package use a relative path in order to
find the rcm.sh library.  That works fine when rcm is installed with
nix-env -- ~/.nix-profile/share/rcm exists as expected -- but does not
work when installed via /etc/nixos/configuration.nix.  In the
system-wide case, /run/current-system/sw/share does not contain the rcm
directory.
