### PR TITLE
firefox: set mime-type in desktop entry

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -15,6 +15,18 @@ stdenv.mkDerivation {
     desktopName = desktopName;
     genericName = "Web Browser";
     categories = "Application;Network;WebBrowser;";
+    mimeType = stdenv.lib.concatStringsSep ";" [
+      "text/html"
+      "text/xml"
+      "application/xhtml+xml"
+      "x-scheme-handler/http"
+      "x-scheme-handler/https"
+      "x-scheme-handler/ftp"
+      "x-scheme-handler/mailto"
+      "x-scheme-handler/webcal"
+      "x-scheme-handler/about"
+      "x-scheme-handler/unknown"
+    ];
   };
 
   buildInputs = [makeWrapper] ++ gst_plugins;


### PR DESCRIPTION
The desktop entry created by `wrapFirefox` didn't set the MIME type. I copied the list of MIME types from the Chromium wrapper; they looked equally applicable.

@edolstra As the maintainer of Firefox, does this look OK to you?
