### PR TITLE
nixos/apache: Replace port option by listen option

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
@@ -24,13 +24,23 @@ with lib;
     '';
   };
 
-  port = mkOption {
-    type = types.int;
-    default = 0;
-    description = ''
-      Port for the server.  0 means use the default port: 80 for http
-      and 443 for https (i.e. when enableSSL is set).
-    '';
+  listen = mkOption {
+     type = types.listOf (types.submodule (
+          {
+            options = {
+              port = mkOption {
+                type = types.int;
+                description = "port to listen on";
+              };
+              ip = mkOption {
+                type = types.string;
+                default = "*";
+                description = "Ip to listen on. 0.0.0.0 for ipv4 only, * for all.";
+              };
+            };
+          } ));
+
+    default = [];
   };
 
   enableSSL = mkOption {


### PR DESCRIPTION
The port option only allowed a port setting, the listen option supports both:
ip and port setting. Eg listen = { ip: "*"; port = 443; }

Well - yes -this is not backward compatible. However adding a compatibility layer would mean adding a lot of code which needs to be maintained - there is not much which can go wrong because if the user changed the port nixos-rebuild will fail - and if he didn't defaultListen will behave like port did.
