### PR TITLE
default applications for xserver specified by mime types

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -381,6 +381,27 @@ in
           if possible.
         '';
       };
+
+      defaultApps = mkOption {
+        default = [];
+        example = literalExample ''[
+          {mimetypes = ["text/plain" "text/css"]; exec = "/run/current-system/sw/bin/sublime";}
+          {mimetypes = ["image/png" "image/jpeg" "image/gif"]; exec = "/run/current-system/sw/bin/gpicview";}
+          {
+            mimetypes = ["video/x-msvideo" "video/mp4" "application/mp4" "video/x-m4v" "video/x-ms-wmv"
+              "video/x-matroska" "video/quicktime"];
+            exec = "/run/current-system/sw/bin/mpv --hwdec=vdpau --vo=vdpau --no-terminal --force-window";
+          }
+        ]'';
+        description = ''
+          Default application list by mimetypes. This is used by file managers
+          and web browsers. To apply this option in some cases you need to
+          re-login beside to rebuild the configuration. Keep in mind that there
+          are many mimetypes per file, to get right mimetype use commands like
+          `file --mime-type ./file.ext` and file preferences of your file manager.
+        '';
+      };
+
     };
 
   };
@@ -443,7 +464,10 @@ in
         pkgs.xterm
         pkgs.xdg_utils
       ]
-      ++ optional (elem "virtualbox" cfg.videoDrivers) xorg.xrefresh;
+      ++ optional (elem "virtualbox" cfg.videoDrivers) xorg.xrefresh
+      ++ optionals (cfg.defaultApps != []) [(pkgs.makeDefaultApps {
+        applist = cfg.defaultApps;
+      }) pkgs.perlPackages.FileMimeInfo ];
 
     environment.pathsToLink =
       [ "/etc/xdg" "/share/xdg" "/share/applications" "/share/icons" "/share/pixmaps" ];
@@ -593,4 +617,3 @@ in
   };
 
 }
-

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -10,6 +10,7 @@
 , mimeType ? ""
 , categories ? "Application;Other;"
 , encoding ? "UTF-8"
+, noDisplay ? "false"
 }:
 
 stdenv.mkDerivation {
@@ -28,6 +29,7 @@ stdenv.mkDerivation {
     MimeType=${mimeType}
     Categories=${categories}
     Encoding=${encoding}
+    NoDisplay=${noDisplay}
     EOF
   '';
 }

--- a/pkgs/misc/defaultapps.nix
+++ b/pkgs/misc/defaultapps.nix
@@ -1,0 +1,71 @@
+{ pkgs, lib }:
+{ applist }:
+let
+  # Example:
+  # applist = [
+  #   {mimetypes = ["text/plain" "text/css"]; exec = "${pkgs.sublime3}/bin/sublime";}
+  #   {mimetypes = ["text/html"]; exec = "${pkgs.firefox}/bin/firefox";}
+  # ];
+
+  zeroArgv = cmd: builtins.head (lib.splitString " " cmd);
+  lastInPath = path: lib.last (lib.splitString "/" path);
+
+  mimetypeList = lib.flatten (map (item: (map (m: rec {
+    mimetype = m;
+    exec = item.exec;
+    name = (zeroArgv (lastInPath exec));
+    hash = builtins.hashString "md5" (exec+mimetypes);
+    desktop = "${name}-${hash}.desktop";
+    mimetypes = lib.concatStringsSep ";" item.mimetypes;
+    outPath = desktopItem name exec hash mimetypes;
+  }) item.mimetypes)) applist);
+
+  desktopItem = name: exec: hash: mimetypes:
+    pkgs.makeDesktopItem {
+      name = builtins.unsafeDiscardStringContext "${name}-${hash}";
+      inherit exec;
+      mimeType = mimetypes;
+      desktopName = "${name}";
+      genericName = "NixOS default";
+      noDisplay = "true";
+    };
+
+  defaultsListString = lib.concatStringsSep "\n" (
+    map (item: item.mimetype+"="+item.desktop+";") mimetypeList
+  );
+
+  mimeappsListFile = pkgs.writeTextFile {
+    name = "mimeapps.list";
+    destination = "/share/applications/mimeapps.list";
+    text = ''
+      [Default Applications]
+      ${defaultsListString}
+
+      [Added Associations]
+      ${defaultsListString}
+    '';
+  };
+
+  defaultsListFile = pkgs.writeTextFile {
+    name = "defaults.list";
+    destination = "/share/applications/defaults.list";
+    text = ''
+      [Default Applications]
+      ${defaultsListString}
+    '';
+  };
+
+  mimeinfoCacheFile = pkgs.writeTextFile {
+    name = "mimeinfo.cache";
+    destination = "/share/applications/mimeinfo.cache";
+    text = ''
+      [MIME Cache]
+      ${defaultsListString}
+    '';
+  };
+
+in pkgs.buildEnv {
+  name = "defaultapps";
+  paths = mimetypeList ++ [ mimeappsListFile defaultsListFile mimeinfoCacheFile ];
+  pathsToLink = [ "/share/applications" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -380,6 +380,10 @@ let
 
   libredirect = callPackage ../build-support/libredirect { };
 
+  makeDefaultApps = import ../misc/defaultapps.nix {
+    inherit pkgs lib;
+  };
+
   makeDesktopItem = import ../build-support/make-desktopitem {
     inherit stdenv;
   };


### PR DESCRIPTION
A much needed feature!

This works in enlightenment and should work in other window/desktop managers, I haven't touched any specific window/desktop manager settings.

When you set

```
services.xserver.defaultApps = [
    {mimetypes = ["text/plain" "text/css"]; exec = "${pkgs.sublime3}/bin/sublime";}
    {mimetypes = ["image/png" "image/jpeg" "image/gif" "image/x-apple-ios-png"]; exec = "${pkgs.e19.ephoto}/bin/ephoto";}
    {
        mimetypes = ["video/x-msvideo" "video/mp4" "application/mp4" "video/x-m4v" "video/x-ms-wmv"
            "video/x-matroska" "video/quicktime"];
        exec = "${pkgs.mpv}/bin/mpv --hwdec=vdpau --vo=vdpau --no-terminal --force-window";
    }
];
```

then for example: plain text files beside css files should be opened by sublime text editor.

Right mime types are tricky to find and different applications see for the same file differently, for example:
Mimetype `image/png` is supposed to match `png` files, but enlightenment_filemanager sees this as `image/x-apple-ios-png`.

And yes, I know that I am creating two the same files named differently: `defaults.list` and `mimeapps.list`, the first one should be deprecated but for example enlightenment file manager uses it (I strace'd it).

Suggestions and questions are more than welcome before merging.
