### PR TITLE
Add hostname to /etc/hosts

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -123,9 +123,9 @@ in
         # /etc/hosts: Hostname-to-IP mappings.
         "hosts".text =
           ''
-            127.0.0.1 localhost
+            127.0.0.1 localhost ${cfg.hostName}
             ${optionalString cfg.enableIPv6 ''
-              ::1 localhost
+              ::1 localhost ${cfg.hostName}
             ''}
             ${cfg.extraHosts}
           '';


### PR DESCRIPTION
Emacs was slow because the hostname wasn't in /etc/hosts, and I suppose some other tools expect it too.

From what I remember, it's standard practice in arch. Can someone confirm this is right?
