### PR TITLE
libelf: Fix cross-compile by adding glibc as a native build input.

### DIFF
--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gettext }:
+{ fetchurl, stdenv, gettext, glibc }:
 
 stdenv.mkDerivation (rec {
   name = "libelf-0.8.13";
@@ -9,6 +9,9 @@ stdenv.mkDerivation (rec {
   };
 
   doCheck = true;
+  
+  # For cross-compiling, native glibc is needed for the "gencat" program.
+  nativeBuildInputs = [ glibc ];
 
   meta = {
     description = "ELF object file access library";


### PR DESCRIPTION
For cross-compiling, native glibc is needed for the "gencat" program.

Nnote: it is not possible to test this with the current nixpkgs due to general cross-compile regressions.
