### PR TITLE
Update QEMU Nixos Virtual Machine

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, edk2, nasm, iasl }:
+{ stdenv, edk2, nasm, iasl, seabios, openssl, secureBoot ? false }:
 
 let
 
@@ -14,14 +14,36 @@ in
 stdenv.mkDerivation (edk2.setup "OvmfPkg/OvmfPkg${targetArch}.dsc" {
   name = "OVMF-2014-12-10";
 
-  buildInputs = [nasm iasl];
+  # TODO: properly include openssl for secureBoot
+  buildInputs = [nasm iasl] ++ stdenv.lib.optionals (secureBoot == true) [ openssl ];
+
   unpackPhase = ''
     for file in \
-      "${edk2.src}"/{OvmfPkg,UefiCpuPkg,MdeModulePkg,IntelFrameworkModulePkg,PcAtChipsetPkg,FatBinPkg,EdkShellBinPkg,MdePkg,ShellPkg,OptionRomPkg,IntelFrameworkPkg};
+      "${edk2.src}"/{UefiCpuPkg,MdeModulePkg,IntelFrameworkModulePkg,PcAtChipsetPkg,FatBinPkg,EdkShellBinPkg,MdePkg,ShellPkg,OptionRomPkg,IntelFrameworkPkg};
     do
       ln -sv "$file" .
     done
-  '';
+
+    ${if (seabios == false) then ''
+        ln -sv ${edk2.src}/OvmfPkg .
+      '' else ''
+        cp -r ${edk2.src}/OvmfPkg .
+        chmod +w OvmfPkg/Csm/Csm16
+        cp ${seabios}/Csm16.bin OvmfPkg/Csm/Csm16/Csm16.bin
+      ''}
+
+    ${if (secureBoot == true) then ''
+        ln -sv ${edk2.src}/SecurityPkg .
+        ln -sv ${edk2.src}/CryptoPkg .
+      '' else ''
+      ''}
+    '';
+
+  buildPhase = if (seabios == false) then ''
+      build ${if secureBoot then "-DSECURE_BOOT_ENABLE=TRUE" else ""}
+    '' else ''
+      build -D CSM_ENABLE -D FD_SIZE_2MB ${if secureBoot then "-DSECURE_BOOT_ENABLE=TRUE" else ""}
+    '';
 
   meta = {
     description = "Sample UEFI firmware for QEMU and KVM";

--- a/pkgs/applications/virtualization/seabios/default.nix
+++ b/pkgs/applications/virtualization/seabios/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, iasl, python }:
+
+stdenv.mkDerivation rec {
+
+  name = "seabios-${version}";
+  version = "1.7.5.2";
+
+  src = fetchurl {
+    url = "http://code.coreboot.org/p/seabios/downloads/get/${name}.tar.gz";
+    sha256 = "1syd3gi5gq0gj2pjvmdis64xc3j1xf0jgy49ngymap0pdpm0cmh0";
+  };
+
+  buildInputs = [ iasl python ];
+
+  configurePhase = ''
+    # build SeaBIOS for CSM
+    cat > .config << EOF
+    CONFIG_CSM=y
+    CONFIG_QEMU_HARDWARE=y
+    CONFIG_PERMIT_UNALIGNED_PCIROM=y
+    EOF
+
+    make olddefconfig
+    '';
+
+  installPhase = ''
+    mkdir $out
+    cp out/Csm16.bin $out/Csm16.bin
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Open source implementation of a 16bit X86 BIOS";
+    longDescription = ''
+      SeaBIOS is an open source implementation of a 16bit X86 BIOS.
+      It can run in an emulator or it can run natively on X86 hardware with the use of coreboot.
+      SeaBIOS is the default BIOS for QEMU and KVM.
+    '';
+    homepage = http://www.seabios.org;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.tstrobel ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8058,7 +8058,11 @@ let
 
   oracleXE = callPackage ../servers/sql/oracle-xe { };
 
-  OVMF = callPackage ../applications/virtualization/OVMF { };
+  OVMF = callPackage ../applications/virtualization/OVMF { seabios=false; openssl=null; };
+  OVMF-CSM = callPackage ../applications/virtualization/OVMF { openssl=null; };
+  #WIP: OVMF-secureBoot = callPackage ../applications/virtualization/OVMF { seabios=false; secureBoot=true; };
+
+  seabios = callPackage ../applications/virtualization/seabios { };
 
   pgpool92 = callPackage ../servers/sql/pgpool/default.nix {
     postgresql = postgresql92;


### PR DESCRIPTION
The Nixos Qemu VM that are used for VM tests can now start without
boot menu even when using a bootloader.
The Nixos Qemu VM with bootloader can emulate a EFI boot now.
