### PR TITLE
Attempt at upgrading to redshift 1.10.

### DIFF
--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -1,31 +1,33 @@
-{ fetchurl, stdenv, libX11, libXrandr, libXxf86vm, libxcb, pkgconfig, python
-, randrproto, xcbutil, xf86vidmodeproto, autoconf, automake, gettext, glib
-, GConf, dbus, dbus_glib, makeWrapper, gtk, pygtk, pyxdg, geoclue }:
+{ fetchurl, stdenv, libX11, libXrandr, libXxf86vm, libxcb, pkgconfig, python3
+, randrproto, xcbutil, xf86vidmodeproto, autoconf, automake, libtool, intltool, gettext
+, glib, GConf, dbus, dbus_glib, makeWrapper, geoclue, pygobject3, pyxdg, gtk3 }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.1";
+  version = "1.10";
   name = "redshift-${version}";
   src = fetchurl {
     url = "https://github.com/jonls/redshift/archive/v${version}.tar.gz";
-    sha256 = "0rj7lyg4ikwpk1hr1k2bgk9gjqvvv51z8hydsgpx2k2lqdv6lqri";
+    sha256 = "f7a1ca1eccf662995737e14f894c2b15193923fbbe378d151e346a8013644f16";
   };
 
   buildInputs = [
-    libX11 libXrandr libXxf86vm libxcb pkgconfig python randrproto xcbutil
-    xf86vidmodeproto autoconf automake gettext glib GConf dbus dbus_glib
-    makeWrapper gtk pygtk pyxdg geoclue
+    libX11 libXrandr libXxf86vm libxcb pkgconfig python3 randrproto xcbutil
+    xf86vidmodeproto autoconf automake libtool intltool gettext glib GConf dbus dbus_glib
+    makeWrapper geoclue pygobject3 gtk3
   ];
 
   preConfigure = ''
     ./bootstrap
   '';
 
+  configureFlags = ''--enable-gui=yes'';
+
   preInstall = ''
-    substituteInPlace src/redshift-gtk/redshift-gtk python --replace "/usr/bin/env python" "${python}/bin/${python.executable}"
+    substituteInPlace src/redshift-gtk/redshift-gtk python --replace "/usr/bin/env python3" "${python3}/bin/${python3.executable}"
   '';
 
   postInstall = ''
-    wrapProgram "$out/bin/redshift-gtk" --prefix PYTHONPATH : $PYTHONPATH:${pygtk}/lib/${python.libPrefix}/site-packages/gtk-2.0:${pyxdg}/lib/${python.libPrefix}/site-packages/pyxdg:$out/lib/${python.libPrefix}/site-packages
+    wrapProgram "$out/bin/redshift-gtk" --prefix PYTHONPATH : $PYTHONPATH:${pygobject3}/lib/${python3.libPrefix}/site-packages/gi:${pyxdg}/lib/${python3.libPrefix}/site-packages/pyxdg:$out/lib/${python3.libPrefix}/site-packages
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12801,7 +12801,8 @@ let
     inherit (xorg) libX11 libXrandr libxcb randrproto libXxf86vm
       xf86vidmodeproto;
     inherit (gnome) GConf;
-    inherit (pythonPackages) pyxdg;
+    inherit (python3Packages) pyxdg;
+    inherit (python3Packages) pygobject3;
     geoclue = geoclue2;
   };
 


### PR DESCRIPTION
This build works but running redshift-gtk fails with this message:

Traceback (most recent call last):
  File "/nix/store/dxjacmxvyv3nnnkzmc5yjflww0xddhsw-redshift-1.10/bin/.redshift-gtk-wrapped", line 26, in <module>
    from redshift_gtk.statusicon import run
  File "/nix/store/dxjacmxvyv3nnnkzmc5yjflww0xddhsw-redshift-1.10/lib/python3.4/site-packages/redshift_gtk/statusicon.py", line 30, in <module>
    import gettext
  File "/nix/store/mrnx02fglz1cqsnqqf916i58pbvh1x2d-python3-3.4.2/lib/python3.4/gettext.py", line 49, in <module>
    import locale, copy, io, os, re, struct, sys
  File "/nix/store/mrnx02fglz1cqsnqqf916i58pbvh1x2d-python3-3.4.2/lib/python3.4/locale.py", line 20, in <module>
    import functools
  File "/nix/store/mrnx02fglz1cqsnqqf916i58pbvh1x2d-python3-3.4.2/lib/python3.4/functools.py", line 22, in <module>
    from types import MappingProxyType
  File "/nix/store/dbmvgicplkk3grs8dc0s89ykyic1gi1b-pygobject-3.12.1/lib/python3.4/site-packages/gi/types.py", line 28, in <module>
    from ._constants import TYPE_INVALID
SystemError: Parent module '' not loaded, cannot perform relative import

If this problem can be fixed, this pull request would be useful.
