### PR TITLE
version-management/gitolite: Bump version 3.6.1 -> 3.6.2

### DIFF
--- a/pkgs/applications/version-management/gitolite/default.nix
+++ b/pkgs/applications/version-management/gitolite/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "gitolite-${version}";
-  version = "3.6.1";
+  version = "3.6.2";
 
   src = fetchurl {
     url = "https://github.com/sitaramc/gitolite/archive/v${version}.tar.gz";


### PR DESCRIPTION
Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
