### PR TITLE
add xflux

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -129,6 +129,7 @@
   olcai = "Erik Timan <dev@timan.info>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   page = "Carles Pagès <page@cubata.homelinux.net>";
+  paholg = "Paho Lurie-Gregg <paho@paholg.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";

--- a/pkgs/tools/misc/xflux/default.nix
+++ b/pkgs/tools/misc/xflux/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl, libXxf86vm, libXext, libX11, libXrandr}:
+stdenv.mkDerivation {
+  name = "xflux";
+  src = fetchurl {
+    url = https://justgetflux.com/linux/xflux64.tgz;
+    sha256 = "cc50158fabaeee58c331f006cc1c08fd2940a126e99d37b76c8e878ef20c2021";
+  };
+
+  libPath = stdenv.lib.makeLibraryPath [
+    stdenv.cc.gcc
+    libXxf86vm
+    libXext
+    libX11
+    libXrandr
+  ];
+
+  unpackPhase = ''
+    unpackFile $src;
+  '';
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp  xflux "$out/bin"
+  '';
+  postFixup = ''
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath "$libPath" "$out/bin/xflux"
+  '';
+  meta = {
+    description = "Adjusts your screen to emit warmer light at night";
+    longDescription = ''
+      xflux changes the color temperature of your screen to be much warmer
+      when the sun sets, and then changes it back its colder temperature
+      when the sun rises.
+    '';
+    homepage = https://justgetflux.com/;
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.paholg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2966,6 +2966,8 @@ let
 
   xdummy = callPackage ../tools/misc/xdummy { };
 
+  xflux = callPackage ../tools/misc/xflux { };
+
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
 
   xml2 = callPackage ../tools/text/xml/xml2 { };


### PR DESCRIPTION
I created a package for [xflux](https://justgetflux.com/linux.html).

> [xflux] makes the color of your computer's display adapt to the time of day, warm at night and like sunlight during the day. 

I'm new to this, so please let me know if I did anything wrong.

I could change the url point to [this github repository](https://github.com/Kilian/f.lux-indicator-applet), which is distinct from the creator of the program, but is linked to from their website.

I think I did the licensing correct (as unfortunate as it is), but it's available [here](https://justgetflux.com/news/pages/eula/).

(Recreating because I screwed up the last one)
