### PR TITLE
gawk: Fix cross compiling.

### DIFF
--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     sha256 = "0hin2hswbbd6kd6i4zzvgciwpl5fba8d2s524z8y5qagyz3x010q";
   };
 
+  # Fix cross compile (stolen from Gentoo).
+  # Not needed for 4.1.1.
+  crossAttrs = {
+    preConfigure = ''
+      sed -i \
+        -e '/check-recursive all-recursive: check-for-shared-lib-support/d' \
+        extension/Makefile.in
+    '';
+  };
+
   doCheck = !stdenv.isCygwin; # XXX: `test-dup2' segfaults on Cygwin 6.1
 
   buildInputs = [ libsigsegv ]


### PR DESCRIPTION
Note that this does not trigger rebuild for native builds.
