### PR TITLE
binutils: Move bison to nativeBuildInputs.

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -36,9 +36,8 @@ stdenv.mkDerivation rec {
     ./pt-pax-flags-20121023.patch
   ];
 
-  buildInputs =
-    [ zlib ]
-    ++ optional gold bison;
+  nativeBuildInputs = optional gold bison;
+  buildInputs = [ zlib ];
 
   inherit noSysDirs;
 


### PR DESCRIPTION
Note: mass rebuild.
