### PR TITLE
Problem: erlang in nixpkgs doesn't support jinterface + no hipe

### DIFF
--- a/pkgs/development/interpreters/erlang/R17.nix
+++ b/pkgs/development/interpreters/erlang/R17.nix
@@ -1,15 +1,19 @@
 { stdenv, fetchurl, perl, gnum4, ncurses, openssl
 , gnused, gawk, makeWrapper
 , odbcSupport ? false, unixODBC ? null
-, wxSupport ? false, mesa ? null, wxGTK ? null, xlibs ? null }:
+, wxSupport ? true, mesa ? null, wxGTK ? null, xlibs ? null
+, javacSupport ? false, openjdk ? null
+, enableHipe ? true}:
 
 assert wxSupport -> mesa != null && wxGTK != null && xlibs != null;
 assert odbcSupport -> unixODBC != null;
+assert javacSupport ->  openjdk != null;
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}";
+  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
+  + "${optionalString javacSupport "-javac"}";
   version = "17.4";
 
   src = fetchurl {
@@ -20,7 +24,8 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ perl gnum4 ncurses openssl makeWrapper
     ] ++ optional wxSupport [ mesa wxGTK xlibs.libX11 ]
-      ++ optional odbcSupport [ unixODBC ];
+      ++ optional odbcSupport [ unixODBC ]
+      ++ optional javacSupport [ openjdk ];
 
   patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
 
@@ -29,7 +34,7 @@ stdenv.mkDerivation rec {
     sed -e s@/bin/pwd@pwd@g -i otp_build
   '';
 
-  configureFlags= "--with-ssl=${openssl} ${optionalString odbcSupport "--with-odbc=${unixODBC}"} ${optionalString stdenv.isDarwin "--enable-darwin-64bit"}";
+  configureFlags= "--with-ssl=${openssl} ${optionalString enableHipe "--enable-hipe"} ${optionalString odbcSupport "--with-odbc=${unixODBC}"} ${optionalString stdenv.isDarwin "--enable-darwin-64bit"} ${optionalString javacSupport "--with-javac"}";
 
   postInstall = let
     manpages = fetchurl {
@@ -68,6 +73,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     # Note: Maintainer of prev. erlang version was simons. If he wants
     # to continue maintaining erlang I'm totally ok with that.
-    maintainers = [ maintainers.the-kenny ];
+    maintainers = [ maintainers.the-kenny maintainers.sjmackenzie ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4161,8 +4161,12 @@ let
   erlangR16_odbc = callPackage ../development/interpreters/erlang/R16.nix { odbcSupport = true; };
   erlangR17 = callPackage ../development/interpreters/erlang/R17.nix { };
   erlangR17_odbc = callPackage ../development/interpreters/erlang/R17.nix { odbcSupport = true; };
+  erlangR17_javac = callPackage ../development/interpreters/erlang/R17.nix { javacSupport = true; };
+  erlangR17_odbc_javac = callPackage ../development/interpreters/erlang/R17.nix { javacSupport = true; odbcSupport = true; };
   erlang = erlangR17;
   erlang_odbc = erlangR17_odbc;
+  erlang_javac = erlangR17_javac;
+  erlang_odbc_javac = erlangR17_odbc_javac;
 
   rebar = callPackage ../development/tools/build-managers/rebar { };
 


### PR DESCRIPTION
Solution:
- Every Erlang programmer expects Hipe to be enabled; So it's now enabled by default
- Java support is very often needed, many expect it by default. So I've added top-level support for erlang-javac and erlang-javac-odbc
