### PR TITLE
lirc: update from 0.9.1a to 0.9.2

### DIFF
--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, alsaLib, bash, help2man }:
 
 stdenv.mkDerivation rec {
-  name = "lirc-0.9.1a";
+  name = "lirc-0.9.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/lirc/${name}.tar.bz2";
-    sha256 = "191vhgsds221rzpzjibj005pfr182hq65hniqfd0qqsl5h1zwq8r";
+    sha256 = "1pd1a7v426hhnj6i6n6xjf2y8yydnw63y53ij40cwvgfrn7r8gsf";
   };
 
   patches = [


### PR DESCRIPTION
Potentially fixes CVE-2013-6404.

Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
