### PR TITLE
nfs-utils: update from 1.2.5 to 1.3.1

### DIFF
--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -1,18 +1,18 @@
 { fetchurl, stdenv, tcp_wrappers, utillinux, libcap, libtirpc, libevent, libnfsidmap
-, lvm2, e2fsprogs, python
+, lvm2, e2fsprogs, python, sqlite
 }:
 
 stdenv.mkDerivation rec {
-  name = "nfs-utils-1.2.5";
+  name = "nfs-utils-1.3.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/nfs/${name}.tar.bz2";
-    sha256 = "16ssfkj36ljifyaskgwpd3ys8ylhi5gasq88aha3bhg5dr7yv59m";
+    sha256 = "1lxfjl6mzdfn7kw2hcn40q9xn40a539iv7spzqbj1sfkvzxlm33l";
   };
 
   buildInputs =
     [ tcp_wrappers utillinux libcap libtirpc libevent libnfsidmap
-      lvm2 e2fsprogs python
+      lvm2 e2fsprogs python sqlite
     ];
 
   # FIXME: Add the dependencies needed for NFSv4 and TI-RPC.


### PR DESCRIPTION
Potentially fixes CVE-2013-1923.

Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
