### PR TITLE
zd1211fw: update from 1.4 to 1.5

### DIFF
--- a/pkgs/os-specific/linux/firmware/zd1211/default.nix
+++ b/pkgs/os-specific/linux/firmware/zd1211/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zd1211-firmware";
-  version = "1.4";
+  version = "1.5";
 
   name = "${pname}-${version}";
   
   src = fetchurl {
     url = "mirror://sourceforge/zd1211/${name}.tar.bz2";
-    sha256 = "866308f6f59f7075f075d4959dff2ede47735c751251fecd1496df1ba4d338e1";
+    sha256 = "04ibs0qw8bh6h6zmm5iz6lddgknwhsjq8ib3gyck6a7psw83h7gi";
   };
   
   buildPhase = "true";


### PR DESCRIPTION
Potentially fixes CVE-2012-2187.

Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
