### PR TITLE
ircdHybrid: update from 7.2.3 to 8.2.2

### DIFF
--- a/pkgs/servers/irc/ircd-hybrid/default.nix
+++ b/pkgs/servers/irc/ircd-hybrid/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, openssl, zlib }:
 
 stdenv.mkDerivation {
-  name = "ircd-hybrid-7.2.3";
+  name = "ircd-hybrid-8.2.2";
 
   src = fetchurl {
-    url = mirror://sourceforge/ircd-hybrid/ircd-hybrid-7.2.3.tgz;
-    sha256 = "0w28w10vx3j2s6h2p0qx2p08gafyad7ddxa4f8i94vmx193l7w37";
+    url = mirror://sourceforge/ircd-hybrid/ircd-hybrid-8.2.2.tgz;
+    sha256 = "0k9w2mxgi03cpnmagshcr5v6qjgnmyidf966b50dd6yn1fgqcibm";
   };
 
   buildInputs = [ openssl zlib ];


### PR DESCRIPTION
Potentially fixes CVE-2013-0238.

Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
