### PR TITLE
Add sstp client.

### DIFF
--- a/pkgs/tools/networking/sstp/default.nix
+++ b/pkgs/tools/networking/sstp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, ppp, libevent, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "sstp-client-${version}";
+  version = "1.0.9";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/sstp-client/sstp-client/${version}/sstp-client-${version}.tar.gz";
+    sha256 = "0kpwywbavmlgid07rk8ff0bxp75bnfa1nc28w4j0pkxjhmja5n6k";
+  };
+
+  patchPhase =
+    ''
+      sed 's,/usr/sbin/pppd,${ppp}/sbin/pppd,' -i src/sstp-pppd.c
+      sed "s,sstp-pppd-plugin.so,$out/lib/pppd/sstp-pppd-plugin.so," -i src/sstp-pppd.c
+    '';
+
+  configureFlags = [
+    "--with-openssl=${openssl}"
+    "--with-runtime-dir=/run/sstpc"
+    "--with-pppd-plugin-dir=$(out)/lib/pppd"
+  ];
+
+  buildInputs = [ libevent openssl ppp ];
+
+  meta = {
+    description = "SSTP client for Linux";
+    homepage = http://sstp-client.sourceforge.net/;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.ktosiek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2551,6 +2551,8 @@ let
 
   sshuttle = callPackage ../tools/security/sshuttle { };
 
+  sstp = callPackage ../tools/networking/sstp {};
+
   sudo = callPackage ../tools/security/sudo { };
 
   suidChroot = builderDefsPackage (import ../tools/system/suid-chroot) { };


### PR DESCRIPTION
This adds sstp-client - VPN client for Microsoft's SSTP protocol. I've tested this with my job VPN, and it works without problems.

One thing I'm not sure about in the expression is extending configureFlags in preConfigure, but just adding a flag with "$out" to the configureFlags attribute didn't work (it seems like literal "$out" was passed in the ./configure arguments) - is there some better way to do this?
