### PR TITLE
Patch kbd to add the dvorak programmer (dvp) keymap

### DIFF
--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -8,15 +8,24 @@ stdenv.mkDerivation rec {
     sha256 = "1vcl2791xshjdpi4w88iy87gkb7zv0dbvi83f98v30dvqc9mfl46";
   };
 
-  configureFlags = "--disable-nls";  
+  /* Get the dvorak programmer keymap (present in X but not in kbd) */
+  dvpSrc = fetchurl {
+    url = "http://kaufmann.no/downloads/linux/dvp-1_2_1.map.gz";
+    sha256 = "0e859211cfe16a18a3b9cbf2ca3e280a23a79b4e40b60d8d01d0fde7336b6d50";
+  };
+
+  configureFlags = "--disable-nls";
 
   patchPhase =
     ''
+      # Add the dvp keyboard in the dvorak folder
+      ${gzip}/bin/gzip -c -d ${dvpSrc} > data/keymaps/i386/dvorak/dvp.map
+
       # Fix the path to gzip/bzip2.
       substituteInPlace src/findfile.c \
         --replace gzip ${gzip}/bin/gzip \
         --replace bzip2 ${bzip2}/bin/bzip2 \
-    
+
       # We get a warning in armv5tel-linux and the fuloong2f, so we
       # disable -Werror in it.
       ${stdenv.lib.optionalString (stdenv.isArm || stdenv.system == "mips64el-linux") ''


### PR DESCRIPTION
As discussed in #6060, `kbd` lack the dvorak programmer keymapping by default even when X as accept it by default.

This patch modify the `kbd` package to add this missing mapping.
