### PR TITLE
glibc: Disable copying libgcc when cross compiling.

### DIFF
--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -32,7 +32,7 @@ in
     # Building from a proper gcc staying in the path where it was installed,
     # libgcc_s will not be at {gcc}/lib, and gcc's libgcc will be found without
     # any special hack.
-    preInstall = ''
+    preInstall = if cross != null then "" else ''
       if [ -f ${stdenv.cc.gcc}/lib/libgcc_s.so.1 ]; then
           mkdir -p $out/lib
           cp ${stdenv.cc.gcc}/lib/libgcc_s.so.1 $out/lib/libgcc_s.so.1


### PR DESCRIPTION
It seems this is only needed for native bootstrapping.
Without this fix we would end up with the _native_ libgcc in there while cross-compiling.
