### PR TITLE
Add vdirsyncer (+ request_toolbelt, atomicwrites python packages)

### DIFF
--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  version = "0.4.2";
+  name = "vdirsyncer-${version}";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = https://github.com/untitaker/vdirsyncer/archive/0.4.2.tar.gz;
+    sha256 = "008181mglbrp5jsvpxr59b6w4mw26h4s4gwij152i47mfbrizsl4";
+  };
+
+  pythonPath = with pythonPackages; [
+    icalendar
+    click
+    requests
+    lxml
+    setuptools
+    requests_toolbelt
+    requests2
+    atomicwrites
+  ];
+
+  meta = {
+    homepage = https://github.com/untitaker/vdirsyncer;
+    description = "Synchronize calendars and contacts";
+    maintainers = [ lib.maintainers.matthiasbeyer ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11383,6 +11383,10 @@ let
 
   vcprompt = callPackage ../applications/version-management/vcprompt { };
 
+ vdirsyncer = callPackage ../tools/misc/vdirsyncer {
+   pythonPackages = python3Packages;
+ };
+
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 
   veracity = callPackage ../applications/version-management/veracity {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8955,6 +8955,25 @@ let
     };
   };
 
+  requests_toolbelt = buildPythonPackage rec {
+    version = "0.3.0";
+    name = "requests-toolbelt-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/sigmavirus24/requests-toolbelt/archive/${version}.tar.gz";
+      sha256 = "177lqpm2czx81pjg0zfs1dkbbmcn5yf1y5qxj23x6y5d28518qwl";
+    };
+
+    propagatedBuildInputs = with self; [ requests2 ];
+
+    meta = {
+      description = "A toolbelt of useful classes and functions to be used with python-requests";
+      homepage = http://toolbelt.rtfd.org;
+      maintainers = with maintainers; [ matthiasbeyer ];
+    };
+
+  };
+
   retry_decorator = buildPythonPackage rec {
     name = "retry_decorator-1.0.0";
     src = pkgs.fetchurl {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -492,6 +492,23 @@ let
     };
   };
 
+  atomicwrites = buildPythonPackage rec {
+    version = "0.1.0";
+    name = "atomicwrites-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/a/atomicwrites/atomicwrites-${version}.tar.gz";
+      sha256 = "1lxz0xhnzihqlvl1h6j2nfxjqqgr4s08196z5phnlcz2s7d5z0mg";
+    };
+
+    meta = {
+      description = "Atomic file writes on POSIX";
+      homepage = https://pypi.python.org/pypi/atomicwrites/0.1.0;
+      maintainers = with maintainers; [ matthiasbeyer ];
+    };
+
+  };
+
   argparse = buildPythonPackage (rec {
     name = "argparse-1.2.1";
 


### PR DESCRIPTION
Hi,

this PR adds the following python libraries:
- requests_toolbelt
- atomicwrites

To be able to add
- vdirsyncer

A syncing application for the vdir storage format which can be used to sync ownCloud calendar and contacs (vcf, ical files).

~~It is WIP, though it builds on my machine. I'd like to clean up the history before merging!~~
