### PR TITLE
Add platform definition for BeagleBone and default to it on armv7l-linux.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -73,6 +73,7 @@ let
       platforms = (import ./platforms.nix);
     in
       if system == "armv6l-linux" then platforms.raspberrypi
+      else if system == "armv7l-linux" then platforms.beaglebone
       else if system == "armv5tel-linux" then platforms.sheevaplug
       else if system == "mips64el-linux" then platforms.fuloong2f_n32
       else if system == "x86_64-linux" then platforms.pc64

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -372,4 +372,21 @@ rec {
     uboot = null;
     gcc.arch = "loongson2f";
   };
+  
+  beaglebone = {
+    name = "beaglebone";
+    kernelMajor = "2.6";
+    kernelHeadersBaseConfig = "omap2plus_defconfig";
+    kernelBaseConfig = "omap2plus_defconfig";
+    kernelArch = "arm";
+    kernelAutoModules = false;
+    kernelExtraConfig = ""; # TBD kernel config
+    kernelTarget = "zImage";
+    uboot = null;
+    gcc = {
+      arch = "armv7-a";
+      fpu = "vfpv3-d16";
+      float = "hard";
+    };
+  };
 }


### PR DESCRIPTION
This should be sufficient to use nix on ARMv7 (e.g. BeagleBone), but of course not NixOS.
Note: not completely tested due to other issues, but at least we now pass the right floating-point options to the gcc configure script. Without this, I had an error since gcc doesn't figure it out by itself.
