### PR TITLE
Use newer kernel headers for cross compilation.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8524,7 +8524,7 @@ let
     cross = assert crossSystem != null; crossSystem;
   });
 
-  linuxHeaders26Cross = forceNativeDrv (import ../os-specific/linux/kernel-headers/2.6.32.nix {
+  linuxHeaders26Cross = forceNativeDrv (import ../os-specific/linux/kernel-headers/3.12.nix {
     inherit stdenv fetchurl perl;
     cross = assert crossSystem != null; crossSystem;
   });


### PR DESCRIPTION
This is needed for ARMv7/BeagleBone since the old version does not have the `omap2plus_defconfig`.
I don't know if this breaks anything (I wouldn't worry about it considering cross compilation has been generally broken lately).
