### PR TITLE
Libunique3 (version 3.0.2): New package

### DIFF
--- a/pkgs/development/libraries/libunique/3.x.nix
+++ b/pkgs/development/libraries/libunique/3.x.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig
+, dbus, dbus_glib, gtk3, gobjectIntrospection
+, gtkdoc, docbook_xml_dtd_45, docbook_xsl
+, libxslt, libxml2 }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  majorVer = "3.0";
+  minorVer = "2";
+  version = "${majorVer}.${minorVer}";
+  name = "libunique3-${version}";
+  srcName = "libunique-${version}";  
+
+  src = fetchurl {
+    url = "http://ftp.gnome.org/pub/GNOME/sources/libunique/${majorVer}/${srcName}.tar.xz";
+    sha256 = "0f70lkw66v9cj72q0iw1s2546r6bwwcd8idcm3621fg2fgh2rw58";
+  };
+
+  buildInputs = [ pkgconfig dbus dbus_glib gtk3 gobjectIntrospection gtkdoc docbook_xml_dtd_45 docbook_xsl libxslt libxml2 ];
+
+  meta = {
+    homepage = https://wiki.gnome.org/Attic/LibUnique;
+    description = "A library for writing single instance applications";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6482,6 +6482,7 @@ let
   libunibreak = callPackage ../development/libraries/libunibreak { };
 
   libunique = callPackage ../development/libraries/libunique/default.nix { };
+  libunique3 = callPackage ../development/libraries/libunique/3.x.nix { inherit (gnome) gtkdoc; };
 
   liburcu = callPackage ../development/libraries/liburcu { };
 


### PR DESCRIPTION
Libunique is a library to write single instance applications.

I am creating a new package instead of upgrading the old one because
Mate uses libunique 3.x and other projects not (as far as I know).
