### PR TITLE
Update glances to 2.3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7481,11 +7481,11 @@ let
 
   psutil = buildPythonPackage rec {
     name = "psutil-${version}";
-    version = "2.1.1";
+    version = "2.2.0";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/p/psutil/${name}.tar.gz";
-      sha256 = "14smqj57yjrm6hjz5n2annkgv0kmxckdhqvfx784f4d4lr52m0dz";
+      sha256 = "088msr52k4zrrrg649hj1xfsk8svm07ajvw0rg8ip6fhrbkwjp5i";
     };
 
     # failed tests: https://code.google.com/p/psutil/issues/detail?id=434

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4743,14 +4743,14 @@ let
 
   glances = buildPythonPackage rec {
     name = "glances-${version}";
-    version = "2.1";
+    version = "2.3";
     disabled = isPyPy;
 
     src = pkgs.fetchFromGitHub {
       owner = "nicolargo";
       repo = "glances";
       rev = "v${version}";
-      sha256 = "1bgr7lif0bpnz39arcdrsfdy7ra4c3ay2pxz1lvh4fqxyxwp3gm6";
+      sha256 = "09x9g4wzfxfhpby3aa1fbhw3iqv1vyd6h526nrm9612ba5d0myh9";
     };
 
     doCheck = false;


### PR DESCRIPTION
Hi!

I tried to update [glances](https://github.com/nicolargo/glances/) from `2.1` to `2.3` which is the last stable.
_I am new to nix and this is my first contribution, so I'll probably need help to do things right._

I also updated `psutil`, because glances `2.3` needs psutil `2.2.0` (see https://github.com/nicolargo/glances/blob/v2.3/requirements.txt).

I tried to build glances with the different python versions, using `nix-build -A python{$version}Packages.glances` from my **nixpkgs** fork.
Then I tried to launch `./result/bin/glances --version` and `./result/bin/glances`.

Here are the results:
- **python26**: doesn't work

```
Traceback (most recent call last):
  File "/nix/store/grs7sj89k5nl92909k1ppl5pqzzpiy3y-python2.6-glances-2.3/bin/.glances-wrapped", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/nix/store/w7nay9cjg82137hkn5pin3cf5xzbbl8z-python2.6-setuptools-7.0/lib/python2.6/site-packages/setuptools-7.0-py2.6.egg/pkg_resources.py", line 2880, in <module>
    working_set = WorkingSet._build_master()
  File "/nix/store/w7nay9cjg82137hkn5pin3cf5xzbbl8z-python2.6-setuptools-7.0/lib/python2.6/site-packages/setuptools-7.0-py2.6.egg/pkg_resources.py", line 432, in _build_master
    ws.require(__requires__)
  File "/nix/store/w7nay9cjg82137hkn5pin3cf5xzbbl8z-python2.6-setuptools-7.0/lib/python2.6/site-packages/setuptools-7.0-py2.6.egg/pkg_resources.py", line 741, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/nix/store/w7nay9cjg82137hkn5pin3cf5xzbbl8z-python2.6-setuptools-7.0/lib/python2.6/site-packages/setuptools-7.0-py2.6.egg/pkg_resources.py", line 626, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: argparse
```
- **python27**: seems to work
- **python32**: `glances --version` works, but not `glances` (according to [its readme](https://github.com/nicolargo/glances/blob/v2.3/README.rst), glances is not tested with Python 3.2)

```
Traceback (most recent call last):
  File "/nix/store/z84h58jlhs7sfj5rlzvq7cf77bjl92gp-python3.2-glances-2.3/bin/.glances-wrapped", line 10, in <module>
    load_entry_point('Glances==2.3', 'console_scripts', 'glances')()
  File "/nix/store/z84h58jlhs7sfj5rlzvq7cf77bjl92gp-python3.2-glances-2.3/lib/python3.2/site-packages/glances/__init__.py", line 119, in main
    args=core.get_args())
  File "/nix/store/z84h58jlhs7sfj5rlzvq7cf77bjl92gp-python3.2-glances-2.3/lib/python3.2/site-packages/glances/core/glances_standalone.py", line 62, in __init__
    self.stats.update()
  File "/nix/store/z84h58jlhs7sfj5rlzvq7cf77bjl92gp-python3.2-glances-2.3/lib/python3.2/site-packages/glances/core/glances_stats.py", line 156, in update
    self._plugins[p].update()
  File "/nix/store/z84h58jlhs7sfj5rlzvq7cf77bjl92gp-python3.2-glances-2.3/lib/python3.2/site-packages/glances/plugins/glances_plugin.py", line 639, in wrapper
    0].__class__.__module__[len('glances_'):], fct.func_name, ret))
AttributeError: 'function' object has no attribute 'func_name'
```
- **python33**: seems to work
- **python34**: seems to work

I investigated a bit more and I'm pretty sure that:
- `python26Packages.glances` was broken _before_ this PR (doesn't work with glances `2.1` and psutil `2.1.1`)
- `python32Packages.glances` is **not** broken because of psutil update (doesn't work either with glances `2.3` and psutil `2.1.1`)

Also, psutil seems to be a dependency of:
- wand
- circus
- powerline (not sure)

Is there a way to update psutil only for glances, or is it better to update it "globally" and check/hope that it doesn't break anything?

To sum up:
1. `python26Packages.glances` seems to be already broken
2. `python32Packages.glances` breaks with glances update
3. other packages depend on psutil and might break

I hope someone will be able to help me with these problems!
