### PR TITLE
Updated monad-journal and scotty

### DIFF
--- a/pkgs/development/libraries/haskell/monad-journal/default.nix
+++ b/pkgs/development/libraries/haskell/monad-journal/default.nix
@@ -5,8 +5,8 @@
 
 cabal.mkDerivation (self: {
   pname = "monad-journal";
-  version = "0.5.0.1";
-  sha256 = "1rxmz6hx8kh8sw497h4kpxkvhgaa7jbzif7qssjqijyfmghsxh80";
+  version = "0.7";
+  sha256 = "1bfm5p027vf8dz92m6s47z06h05j2jv4pbwkl31svrz5pi5a9lz2";
   buildDepends = [
     either monadControl mtl transformers transformersBase
   ];

--- a/pkgs/development/libraries/haskell/scotty/default.nix
+++ b/pkgs/development/libraries/haskell/scotty/default.nix
@@ -7,8 +7,8 @@
 
 cabal.mkDerivation (self: {
   pname = "scotty";
-  version = "0.9.0";
-  sha256 = "0gx00k5w4cs68bh3ciplkwhzh2412y6wqg0qdsslnnsb41l5kb1d";
+  version = "0.9.1";
+  sha256 = "0w07ghnd7l8ibfbl8p74lwn8gxy3z28mp0rlv5crma3yh42irsqm";
   buildDepends = [
     aeson blazeBuilder caseInsensitive dataDefault httpTypes
     monadControl mtl regexCompat text transformers transformersBase wai


### PR DESCRIPTION
Had a dependencies on monad-control 0.3, latest versions of both packages compile fine.

As far as I can tell only ghc-mod uses monad-journal which I tested.

I tried building a few packages that depend on scotty and they all seem fine as well.
