### PR TITLE
Hash url fixes

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "transmission-" + optionalString enableGTK3 "gtk-" + version;
 
   src = fetchurl {
-    url = "http://download.transmissionbt.com/files/transmission-${version}.tar.xz";
+    url = "https://transmission.cachefly.net/transmission-${version}.tar.xz";
     sha256 = "1sxr1magqb5s26yvr5yhs1f7bmir8gl09niafg64lhgfnhv1kz59";
   };
 

--- a/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
+++ b/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
@@ -343,6 +343,7 @@
   name = "libgltf-0.0.2.tar.bz2";
   md5 = "d63a9f47ab048f5009d90693d6aa6424";
   brief = true;
+  subDir = "libgltf/";
 }
 {
   name = "liblangtag-0.5.1.tar.bz2";

--- a/pkgs/os-specific/linux/firmware/iwlegacy/default.nix
+++ b/pkgs/os-specific/linux/firmware/iwlegacy/default.nix
@@ -12,7 +12,7 @@ let
   fetchPackage =
     { name, sha256 }: fetchurl {
       name = "iwlwifi-${name}.tgz";
-      url = "http://wireless.kernel.org/en/users/Drivers/iwlegacy?action=AttachFile&do=get&target=iwlwifi-${name}.tgz";
+      url = "https://wireless.kernel.org/en/users/drivers/iwlwifi-${name}.tgz";
       inherit sha256;
     };
 

--- a/pkgs/os-specific/linux/firmware/iwlwifi/default.nix
+++ b/pkgs/os-specific/linux/firmware/iwlwifi/default.nix
@@ -47,7 +47,7 @@ let
   fetchPackage =
     { name, sha256 }: fetchurl {
       name = "iwlwifi-${name}.tgz";
-      url = "http://wireless.kernel.org/en/users/Drivers/iwlwifi?action=AttachFile&do=get&target=iwlwifi-${name}.tgz";
+      url = "https://wireless.kernel.org/en/users/drivers/iwlwifi-${name}.tgz";
       inherit sha256;
     };
 


### PR DESCRIPTION
1. Fix iwlwifi driver URLs -- the old ones now emit HTML instead of tarballs
2. FIx transmission source package URL
3. Fix libgltf URL
