### PR TITLE
bitcoin(d): add git 0.9.4 version

### DIFF
--- a/pkgs/applications/misc/bitcoin/master.nix
+++ b/pkgs/applications/misc/bitcoin/master.nix
@@ -1,0 +1,48 @@
+{ fetchFromGitHub, stdenv, openssl, autoreconfHook, db48, boost, zlib, miniupnpc, qt4
+, utillinux, pkgconfig, protobuf, qrencode, gui ? true }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "0.9.4";
+  name = "bitcoin${toString (optional (!gui) "d")}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "bitcoin";
+    repo = "bitcoin";
+    rev = "v${version}";
+    sha256 = "071y6wz4slhpwm7vnp3ski6x8900f6nssh00zcj3f4vp0968n76m";
+  };
+
+  # hexdump from utillinux is required for tests
+  buildInputs = [
+    openssl db48 boost zlib miniupnpc utillinux pkgconfig protobuf autoreconfHook
+  ] ++ optionals gui [ qt4 qrencode ];
+
+  preCheck = ''
+    # At least one test requires writing in $HOME
+    HOME=$TMPDIR
+  '';
+
+  configureFlags = [ "--with-boost-libdir=${boost.lib}/lib" ];
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  passthru.walletName = "bitcoin";
+
+  meta = {
+      description = "Peer-to-peer electronic cash system";
+      longDescription= ''
+        Bitcoin is a free open source peer-to-peer electronic cash system that is
+        completely decentralized, without the need for a central server or trusted
+        parties.  Users hold the crypto keys to their own money and transact directly
+        with each other, with the help of a P2P network to check for double-spending.
+      '';
+      homepage = "http://www.bitcoin.org/";
+      maintainers = [ maintainers.roconnor ];
+      license = licenses.mit;
+      platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9527,8 +9527,8 @@ let
 
   bibletime = callPackage ../applications/misc/bibletime { };
 
-  bitcoin = callPackage ../applications/misc/bitcoin {};
-  bitcoind = callPackage ../applications/misc/bitcoin { gui = false; };
+  bitcoin = callPackage ../applications/misc/bitcoin/master.nix {};
+  bitcoind = callPackage ../applications/misc/bitcoin/master.nix { gui = false; };
 
   altcoins = recurseIntoAttrs (
     (callPackage ../applications/misc/bitcoin/altcoins.nix {}) //


### PR DESCRIPTION
This is a temporary workaround for #5957 ; it was recommended at https://github.com/bitcoin/bitcoin/pull/5634 to use v0.9.4 from Git. I use this by myself and don't know if we want this in master -- after all, not all people would be happy with potentially unstable version of `bitcoin`.
