### PR TITLE
connman: 1.26 -> 1.28

### DIFF
--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "connman-${version}";
-  version = "1.26";
+  version = "1.28";
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/connman/connman.git";
     rev = "refs/tags/${version}";
-    sha256 = "0pj404iyq6x9x4i2dwqk1dx95yglx7pvkm8cvh13bf50dim92cv9";
+    sha256 = "13c374bfj7dzlx7zvnnigmk0ck5cy601aqi18n77mcrq9yyxw5y9";
   };
 
   buildInputs = [ autoconf automake libtool pkgconfig openconnect polkit


### PR DESCRIPTION
ConnMan 1.28 was released Sunday, February 1st, 2015.

Upgrading ConnMan is strongly encouraged as this release fixes an issue
with DHCPv6 retransmission timer calculation that causes system load to
jump to 100%. In addition, all WiFi P2P issues encountered with Miracast
have been addressed thanks to persistent the reporting and fixing by
Jussi Kukkonen, Tomasz Bursztyka and Jukka Rissanen.

ConnMan no longer hands off foreground autoscanning to wpa_supplicant as
it causes issues when finding hidden WiFi networks. As a result, the
previously recommended build time option has be removed from the
documentation. wpa_supplicant can still be built with autoscan enabled
but as ConnMan no longer enables it run time the issue is mitigated.

Other changes and fixes include:
- Several fixes for handling IPv6 contexts via oFono (Pasi Sjöholm)
- Fix memory deallocation in exit code paths (Hannu Mallat)
- Use OPEN auth_alg for wpa_supplicant open WiFi networks (Slava Monich)
- A WiFi Access Point with unknown strength now has a proper minimum value
  which translates to a service 'Strenght' property of 30 (Patrik Flykt)
- Fix byte order in DHCP server identifier (Jukka Rissanen)
- Properly cancel an ongoing service connect if the Agent exits
  (Patrik Flykt)
