### PR TITLE
Build and install the .so for glfw 2.x

### DIFF
--- a/pkgs/development/libraries/glfw/2.x.nix
+++ b/pkgs/development/libraries/glfw/2.x.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    make x11-install PREFIX=$out
+    make x11-dist-install PREFIX=$out
+    mv $out/lib/libglfw.so $out/lib/libglfw.so.2
+    ln -s libglfw.so.2 $out/lib/libglfw.so
   ''; 
   
   meta = with stdenv.lib; { 


### PR DESCRIPTION
This patch installs the dynamic version of glfw 2.x as libglfw.so.2 and libglfw.so.

I needed this for running Finding Teddy from Humble Bundle in chrootenv.
