### PR TITLE
make wget build on darwin

### DIFF
--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -21,19 +21,22 @@ stdenv.mkDerivation rec {
        do
          sed -i "$i" -e's/localhost/127.0.0.1/g'
        done
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+       export LIBS="-liconv -lintl"
     '';
 
   nativeBuildInputs = [ gettext ];
   buildInputs = [ libidn ]
     ++ stdenv.lib.optionals doCheck [ perl perlPackages.IOSocketSSL LWP python3 ]
-    ++ stdenv.lib.optional (gnutls != null) gnutls;
+    ++ stdenv.lib.optional (gnutls != null) gnutls
+    ++ stdenv.lib.optional stdenv.isDarwin perl;
 
   configureFlags =
     if gnutls != null
     then "--with-ssl=gnutls"
     else "--without-ssl";
 
-  doCheck = (perl != null && python3 != null);
+  doCheck = (perl != null && python3 != null && !stdenv.isDarwin);
 
   meta = with stdenv.lib; {
     description = "Tool for retrieving files using HTTP, HTTPS, and FTP";


### PR DESCRIPTION
This one is a bit weird, perl is required for a regular build on darwin in order to build the manpage, but presumably not on linux?

Also, some of the tests that deal with accented characters in URIs currently fail on darwin.
