### PR TITLE
android-udev-rules: add package

### DIFF
--- a/pkgs/os-specific/linux/android-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/android-udev-rules/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "android-udev-rules";
+
+  src = fetchgit {
+    url = "git://github.com/M0Rf30/android-udev-rules";
+    rev = "82f78561f388363a925e6663211988d9527de0c6";
+    sha256 = "badd7a152acf92c75335917c07125ffb1b5fda0bed5ec1e474d76e48a8d9f0db";
+  };
+
+  installPhase = ''
+    install -D 51-android.rules $out/lib/udev/rules.d/51-android.rules
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/M0Rf30/android-udev-rules;
+    description = "Android udev rules list aimed to be the most comprehensive on the net";
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9144,9 +9144,11 @@ let
 
   ### DATA
 
-  andagii = callPackage ../data/fonts/andagii {};
+  andagii = callPackage ../data/fonts/andagii { };
 
-  anonymousPro = callPackage ../data/fonts/anonymous-pro {};
+  android-udev-rules = callPackage ../os-specific/linux/android-udev-rules { };
+
+  anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
   arkpandora_ttf = builderDefsPackage (import ../data/fonts/arkpandora) { };
 


### PR DESCRIPTION
This allows one to do

```
  environment.udev.packages = with pkgs; [ android-udev-rules ];
  users.extraGroups.adbusers = {};
  users.extraUsers.myuser.extraGroups = [ "adbusers" ];
```

and access his device (with `fastboot` or `adb`) without root rights.
