### PR TITLE
Eliminate "libtool" buildInput for Crypto++

### DIFF
--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unzip, libtool }:
+{ fetchurl, stdenv, unzip }:
 
 stdenv.mkDerivation rec {
   name = "crypto++-5.6.2";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.optional (stdenv.system != "i686-cygwin") ./dll.patch;
 
-  buildInputs = [ unzip libtool ];
+  buildInputs = [ unzip ];
 
   # Unpack the thing in a subdirectory.
   unpackPhase = ''


### PR DESCRIPTION
It appears that the libtool derivation pulled in previously is invalid. It lacks the `-static` flag that Crypto++ uses.

See #6150.
