### PR TITLE
upgrade google-musicmanager to beta_1.0.129.6633-r0

### DIFF
--- a/pkgs/applications/audio/google-musicmanager/default.nix
+++ b/pkgs/applications/audio/google-musicmanager/default.nix
@@ -4,8 +4,8 @@
 assert stdenv.system == "x86_64-linux" || stdenv.system == "1686-linux";
 
 stdenv.mkDerivation rec {
-  debversion = "beta_1.0.55.7425-r0";
-  version = "beta_1.0.55.7425-r0"; # friendly to nix-env version sorting algo
+  debversion = "beta_1.0.129.6633-r0";
+  version = "beta_1.0.129.6633-r0"; # friendly to nix-env version sorting algo
   product = "google-musicmanager";
   name    = "${product}-${version}";
 
@@ -17,11 +17,11 @@ stdenv.mkDerivation rec {
   src = if stdenv.system == "x86_64-linux"
     then fetchurl {
       url    = "http://dl.google.com/linux/musicmanager/deb/pool/main/g/google-musicmanager-beta/google-musicmanager-${version}_amd64.deb";
-      sha256 = "10nr7qlrn5af4g0l6n4xzximmhc216vhzgpy7cpxs662zpli3v1a";
+      sha256 = "1fq2p721mzv8nd4dq6i9xiqvvqd5ak3v142vsxchg6yn14a9kbvr";
     }
     else fetchurl {
         url    = "http://dl.google.com/linux/musicmanager/deb/pool/main/g/google-musicmanager-beta/google-musicmanager-${version}_i386.deb";
-        sha256 = "4cc8822ab90af97195c2edfa74cc8b4a736e763cc3382f741aa1de0f72ac211e";
+        sha256 = "7914e3e6e2adb2e952ebaf383db5e04727c29cfa83401007f29977f6c5ff6873";
     };
 
   unpackPhase = ''


### PR DESCRIPTION
Pretty simple upgrade to google-musicmanager.  It runs on my amd64, but I haven't tested the i686 version.
