### PR TITLE
arduino: new package (2nd attempt)

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,9 +1,13 @@
-{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file }:
+{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb
+, withGui ? false, gtk2 ? null
+}:
+
+assert withGui -> gtk2 != null;
 
 stdenv.mkDerivation rec {
 
   version = "1.0.6";
-  name = "arduino-core";
+  name = "arduino${stdenv.lib.optionalString (withGui == false) "-core"}";
 
   src = fetchFromGitHub {
     owner = "arduino";
@@ -22,11 +26,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/arduino
-    cp -r ./build/linux/work/hardware/ $out/share/arduino
-    cp -r ./build/linux/work/libraries/ $out/share/arduino
-    cp -r ./build/linux/work/tools/ $out/share/arduino
-    cp -r ./build/linux/work/lib/ $out/share/arduino
+    cp -r ./build/linux/work/* "$out/share/arduino/"
     echo ${version} > $out/share/arduino/lib/version.txt
+
+    ${stdenv.lib.optionalString withGui ''
+      mkdir -p "$out/bin"
+      sed -i -e "s|^java|${jdk}/bin/java|" "$out/share/arduino/arduino"
+      sed -i -e "s|^LD_LIBRARY_PATH=|LD_LIBRARY_PATH=${gtk2}/lib:|" "$out/share/arduino/arduino"
+      ln -sr "$out/share/arduino/arduino" "$out/bin/arduino"
+    ''}
 
     # Fixup "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
     echo "running patchelf on prebuilt binaries:"
@@ -41,10 +49,13 @@ stdenv.mkDerivation rec {
             test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
         fi
     done
+
+    patchelf --set-rpath ${stdenv.lib.makeSearchPath "lib" [ libusb ]} \
+        "$out/share/arduino/hardware/tools/avrdude"
   '';
 
   meta = {
-    description = "Libraries for the open-source electronics prototyping platform";
+    description = "Open-source electronics prototyping platform";
     homepage = http://arduino.cc/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.antono stdenv.lib.maintainers.robberer ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -499,9 +499,12 @@ let
 
   arcanist = callPackage ../development/tools/misc/arcanist {};
 
+  arduino = arduino-core.override { withGui = true; };
+
   arduino-core = callPackage ../development/arduino/arduino-core {
     jdk = jdk;
     jre = jdk;
+    withGui = false;
   };
 
   apitrace = callPackage ../applications/graphics/apitrace {};


### PR DESCRIPTION
[Now without the "stdenv.glibc" reference (it broke on darwin). It seems
the dynamic linker finds libc/libm without it being explicitly in RPATH,
so we can just drop it.]

This commit adds the graphical Arduino IDE, built from the arduino-core
expression.

Also:
- Add libusb to RPATH for avrdude. Without this, avrdude is broken.
  Possible TODO: replace bundled avrdude with the one from nixpkgs.
- Use "cp -r ./build/linux/work/*", so example sketeches, the HTML
  reference documentation and the 'arduino' shell script that starts the
  IDE gets included.
- Make meta.description slightly more generic, to cover both GUI/core
  variants.
