### PR TITLE
Port over Haskell fixes relating to Darwin to NG

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -43,6 +43,20 @@ self: super: {
     hinotify = if pkgs.stdenv.isLinux then self.hinotify else self.fsnotify;
   };
 
+  fsnotify = overrideCabal (super.fsnotify.override {
+    hinotify = if pkgs.stdenv.isLinux then self.hinotify else self.hfsevents;
+  }) (drv: {
+    doCheck = !pkgs.stdenv.isDarwin;
+  });
+
+  system-fileio = overrideCabal super.system-fileio (drv: {
+    doCheck = !pkgs.stdenv.isDarwin;
+  });
+
+  c2hs = overrideCabal super.c2hs (drv: {
+    doCheck = !pkgs.stdenv.isDarwin;
+  });
+
   # Depends on code distributed under a non-free license.
   bindings-yices = dontDistribute super.bindings-yices;
   yices = dontDistribute super.yices;


### PR DESCRIPTION
@peti These are fixes I've copied over from the old `haskell-packages.nix` framework.  There is nothing here that should be different from what we were doing before, except that I conditionalized the `fsnotify` tests so that they are only disabled on Darwin (before they were always disabled).
