### PR TITLE
kill libiconvOr*

### DIFF
--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ncurses, curl, taglib, fftw, mpd_clientlib, pkgconfig
-, libiconvOrEmpty, boost, readline }:
+, libiconv, boost, readline }:
 
 stdenv.mkDerivation rec {
   version = "0.6.2";
@@ -12,8 +12,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = "BOOST_LIB_SUFFIX=";
 
-  buildInputs = [ ncurses curl taglib fftw mpd_clientlib boost pkgconfig readline ]
-    ++ libiconvOrEmpty;
+  buildInputs = [ ncurses curl taglib fftw mpd_clientlib boost pkgconfig readline libiconv];
 
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, pkgconfig, cmake, bluez, libusb1, curl
-, libiconvOrEmpty, gettext, sqlite }:
+, libiconv, gettext, sqlite }:
 
 with stdenv.lib;
 
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./bashcomp-dir.patch ];
 
-  buildInputs = [ python pkgconfig cmake bluez libusb1 curl gettext sqlite ]
-    ++ libiconvOrEmpty;
+  buildInputs = [ python pkgconfig cmake bluez libusb1 curl gettext sqlite libiconv ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, sqlite, curl, pkgconfig, libxml2, stfl, json-c-0-11, ncurses
-, gettext, libiconvOrEmpty, makeWrapper, perl }:
+, gettext, libiconv, makeWrapper, perl }:
 
 stdenv.mkDerivation rec {
   name = "newsbeuter-2.8";
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs
     # use gettext instead of libintlOrEmpty so we have access to the msgfmt
     # command
-    = [ pkgconfig sqlite curl libxml2 stfl json-c-0-11 ncurses gettext perl ]
-      ++ libiconvOrEmpty
+    = [ pkgconfig sqlite curl libxml2 stfl json-c-0-11 ncurses gettext perl libiconv ]
       ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
 
   preBuild = ''

--- a/pkgs/applications/networking/feedreaders/newsbeuter/dev.nix
+++ b/pkgs/applications/networking/feedreaders/newsbeuter/dev.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, sqlite, curl, pkgconfig, libxml2, stfl, json-c-0-11, ncurses
-, gettext, libiconvOrEmpty, makeWrapper, perl }:
+, gettext, libiconv, makeWrapper, perl }:
 
 stdenv.mkDerivation rec {
   name = "newsbeuter-dev-20140309";
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs
     # use gettext instead of libintlOrEmpty so we have access to the msgfmt
     # command
-    = [ pkgconfig sqlite curl libxml2 stfl json-c-0-11 ncurses gettext perl ]
-      ++ libiconvOrEmpty
+    = [ pkgconfig sqlite curl libxml2 stfl json-c-0-11 ncurses gettext perl libiconv ]
       ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
 
   preBuild = ''

--- a/pkgs/applications/networking/p2p/twister/default.nix
+++ b/pkgs/applications/networking/p2p/twister/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, python
-, boost, db, openssl, geoip, libiconvOrEmpty, miniupnpc
+, boost, db, openssl, geoip, libiconv, miniupnpc
 , srcOnly, fetchgit
 }:
 
@@ -33,8 +33,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     autoconf automake libtool pkgconfig python
-    boost db openssl geoip miniupnpc
-  ] ++ libiconvOrEmpty;
+    boost db openssl geoip miniupnpc libiconv
+  ];
 
   postPatch = ''
     sed -i -e '/-htmldir/s|(default: [^)]*)|(default: ${twisterHTML})|' \

--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, freetype, libpng, mesa, gettext, openssl, qt5, perl
-, libiconvOrEmpty }:
+, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "stellarium-0.13.2";
@@ -9,8 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1asrq1v6vjzxd2zz92brdfs5f5b1qf8zwd7k2dpg3dl4shl8wwg5";
   };
 
-  buildInputs = [ cmake freetype libpng mesa gettext openssl qt5 perl ]
-    ++ libiconvOrEmpty;
+  buildInputs = [ cmake freetype libpng mesa gettext openssl qt5 perl libiconv ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl
 , qt4, xapian, file, python
 , djvulibre, groff, libxslt, unzip, xpdf, antiword, catdoc, lyx
-, ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconvOrLibc }:
+, ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconv }:
 
 assert stdenv.system != "powerpc-linux";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       substituteInPlace  $f --replace grep          ${gnugrep}/bin/grep
       substituteInPlace  $f --replace groff         ${groff}/bin/groff
       substituteInPlace  $f --replace gunzip        ${gzip}/bin/gunzip
-      substituteInPlace  $f --replace iconv         ${libiconvOrLibc}/bin/iconv
+      substituteInPlace  $f --replace iconv         ${libiconv}/bin/iconv
       substituteInPlace  $f --replace lyx           ${lyx}/bin/lyx
       substituteInPlace  $f --replace pdftotext     ${xpdf}/bin/pdftotext
       substituteInPlace  $f --replace pstotext      ${ghostscript}/bin/ps2ascii 

--- a/pkgs/applications/version-management/redmine/default.nix
+++ b/pkgs/applications/version-management/redmine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ruby, bundler, libiconv, libiconvOrNull, libiconvOrLibc, libxslt, libxml2, pkgconfig, libffi, glibc, imagemagickBig, postgresql }:
+{ stdenv, fetchurl, ruby, bundler, libiconv, libxslt, libxml2, pkgconfig, libffi, glibc, imagemagickBig, postgresql }:
 
 let
   gemspec = map (gem: fetchurl { url=gem.url; sha256=gem.hash; }) (import ./Gemfile.nix);
@@ -25,8 +25,7 @@ in stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    ruby bundler
-  ] ++ (if (libiconvOrNull != null) then [libiconv] else []) ++ [
+    ruby bundler libiconv
     libxslt libxml2 pkgconfig libffi
     imagemagickBig postgresql
   ];
@@ -48,7 +47,7 @@ in stdenv.mkDerivation rec {
 
     bundle config build.nokogiri \
       --use-system-libraries \
-      --with-iconv-dir=${libiconvOrLibc} \
+      --with-iconv-dir=${libiconv} \
       --with-xslt-dir=${libxslt} \
       --with-xml2-dir=${libxml2} \
       --with-pkg-config \

--- a/pkgs/applications/video/aegisub/default.nix
+++ b/pkgs/applications/video/aegisub/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , libX11, wxGTK
-, libiconvOrEmpty, fontconfig, freetype
+, libiconv, fontconfig, freetype
 , mesa
 , libass, fftw, ffms
 , ffmpeg, pkgconfig, zlib # Undocumented (?) dependencies
@@ -30,9 +30,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = with stdenv.lib;
   [ pkgconfig intltool libX11 wxGTK fontconfig freetype mesa
-    libass fftw ffms ffmpeg zlib icu boost boost.lib
+    libass fftw ffms ffmpeg zlib icu boost boost.lib libiconv
   ]
-    ++ libiconvOrEmpty
     ++ optional spellChecking hunspell
     ++ optional automationSupport lua
     ++ optional openalSupport openal

--- a/pkgs/development/compilers/vala/0.26.nix
+++ b/pkgs/development/compilers/vala/0.26.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, flex, bison, libxslt
-, glib, libiconvOrEmpty, libintlOrEmpty
+, glib, libiconv, libintlOrEmpty
 }:
 
 let
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig flex bison libxslt ];
 
-  buildInputs = [ glib ]
-    ++ libiconvOrEmpty
+  buildInputs = [ glib libiconv ]
     ++ libintlOrEmpty;
 }

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, flex, bison, libxslt
-, glib, libiconvOrEmpty, libintlOrEmpty
+, glib, libiconv, libintlOrEmpty
 }:
 
 let
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig flex bison libxslt ];
 
-  buildInputs = [ glib ]
-    ++ libiconvOrEmpty
+  buildInputs = [ glib libiconv ]
     ++ libintlOrEmpty;
 }

--- a/pkgs/development/interpreters/ruby/patches.nix
+++ b/pkgs/development/interpreters/ruby/patches.nix
@@ -1,5 +1,5 @@
 { fetchurl, writeScript, ruby, ncurses, sqlite, libxml2, libxslt, libffi
-, zlib, libuuid, gems, jdk, python, stdenv, libiconvOrEmpty, imagemagick
+, zlib, libuuid, gems, jdk, python, stdenv, libiconv, imagemagick
 , pkgconfig }:
 
 let
@@ -33,7 +33,7 @@ in
     NIX_POST_EXTRACT_FILES_HOOK = patchUsrBinEnv;
   };
 
-  iconv = { buildInputs = [ libiconvOrEmpty ]; };
+  iconv = { buildInputs = [ libiconv ]; };
 
   libv8 = {
     # This fix is needed to fool scons, which clears the environment by default.

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -2,7 +2,7 @@
 , sslSupport ? true, openssl
 , bdbSupport ? false, db
 , ldapSupport ? true, openldap
-, libiconvOrNull
+, libiconv
 }:
 
 assert sslSupport -> openssl != null;
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     ${stdenv.lib.optionalString ldapSupport "--with-ldap"}
   '';
 
-  propagatedBuildInputs = [ makeWrapper apr expat libiconvOrNull ]
+  propagatedBuildInputs = [ makeWrapper apr expat libiconv ]
     ++ optional sslSupport openssl
     ++ optional bdbSupport db
     ++ optional ldapSupport openldap;

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, libdaemon, dbus, perl, perlXMLParser
-, expat, gettext, intltool, glib, libiconvOrEmpty
+, expat, gettext, intltool, glib, libiconv
 , qt4 ? null
 , qt4Support ? false
 , withLibdnssdCompat ? false }:
@@ -16,9 +16,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./no-mkdir-localstatedir.patch ];
 
-  buildInputs = [ libdaemon dbus perl perlXMLParser glib expat ]
-    ++ (stdenv.lib.optional qt4Support qt4)
-    ++ libiconvOrEmpty;
+  buildInputs = [ libdaemon dbus perl perlXMLParser glib expat libiconv ]
+    ++ (stdenv.lib.optional qt4Support qt4);
 
   nativeBuildInputs = [ pkgconfig gettext intltool ];
 

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, libiconvOrEmpty, libintlOrEmpty
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libiconv, libintlOrEmpty
 , expat, zlib, libpng, pixman, fontconfig, freetype, xlibs
 , gobjectSupport ? true, glib
 , xcbSupport ? true # no longer experimental since 1.12
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mk2fd9fwxqzravlmnbbrzwak15wqspn7609y0yn6qh87va5i0x4";
   })];
 
-  nativeBuildInputs = [ pkgconfig ] ++ libintlOrEmpty ++ libiconvOrEmpty;
+  nativeBuildInputs = [ pkgconfig libiconv ] ++ libintlOrEmpty;
 
   propagatedBuildInputs =
     with xlibs; [ xlibs.xlibs fontconfig expat freetype pixman zlib libpng ]

--- a/pkgs/development/libraries/dbus-glib/default.nix
+++ b/pkgs/development/libraries/dbus-glib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, expat, gettext, libiconvOrEmpty, dbus, glib }:
+{ stdenv, fetchurl, pkgconfig, expat, gettext, libiconv, dbus, glib }:
 
 stdenv.mkDerivation rec {
   name = "dbus-glib-0.102";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext ];
 
-  buildInputs = [ expat ] ++ libiconvOrEmpty;
+  buildInputs = [ expat libiconv ];
 
   propagatedBuildInputs = [ dbus.libs glib ];
 

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gettext, perl, python
-, libiconvOrEmpty, libintlOrEmpty, zlib, libffi, pcre, libelf
+, libiconv, libintlOrEmpty, zlib, libffi, pcre, libelf
 
 # this is just for tests (not in closure of any regular package)
 , coreutils, dbus_daemon, libxml2, tzdata, desktop_file_utils, shared_mime_info, doCheck ? false
@@ -60,8 +60,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext perl python ];
 
-  propagatedBuildInputs = [ pcre zlib libffi ]
-    ++ optional (!stdenv.isDarwin) libiconvOrEmpty
+  propagatedBuildInputs = [ pcre zlib libffi libiconv ]
     ++ libintlOrEmpty;
 
   configureFlags =

--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, intltool, gettext, glib, libxml2, zlib, bzip2
-, python, gdk_pixbuf, libiconvOrEmpty, libintlOrEmpty }:
+, python, gdk_pixbuf, libiconv, libintlOrEmpty }:
 
 with { inherit (stdenv.lib) optionals; };
 
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gettext bzip2 zlib python ];
 
-  propagatedBuildInputs = [ libxml2 glib gdk_pixbuf ]
-    ++ libiconvOrEmpty
+  propagatedBuildInputs = [ libxml2 glib gdk_pixbuf libiconv ]
     ++ libintlOrEmpty;
 
   doCheck = true;

--- a/pkgs/development/libraries/libtorrent-rasterbar/generic.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, openssl, pkgconfig, zlib, python, libiconvOrNull, geoip
+{ stdenv, fetchurl, boost, openssl, pkgconfig, zlib, python, libiconv, geoip
 # Version specific options
 , version, sha256
 , ... }:
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  buildInputs = [ boost pkgconfig openssl zlib python libiconvOrNull geoip ];
+  buildInputs = [ boost pkgconfig openssl zlib python libiconv geoip ];
 
   configureFlags = [ 
     "--enable-python-binding"
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
     "--with-libiconv=yes"
     "--with-boost=${boost.dev}"
     "--with-boost-libdir=${boost.lib}/lib"
-  ] ++ stdenv.lib.optional (libiconvOrNull != null) "--with-libiconv=yes";
+    "--with-libiconv=yes"
+  ];
   
   meta = with stdenv.lib; {
     homepage = http://www.rasterbar.com/products/libtorrent/;

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libiconvOrEmpty, pkgconfig, libffi, libtasn1 }:
+{ stdenv, fetchurl, libiconv, pkgconfig, libffi, libtasn1 }:
 
 stdenv.mkDerivation rec {
   name = "p11-kit-0.20.2";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--without-libtasn1";
 
-  buildInputs = [ pkgconfig libffi libtasn1 ] ++ libiconvOrEmpty;
+  buildInputs = [ pkgconfig libffi libtasn1 libiconv ];
 
   meta = {
     homepage = http://p11-glue.freedesktop.org/;

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, cmake, libiconvOrEmpty, libintlOrEmpty
+{ stdenv, fetchurl, fetchpatch, pkgconfig, cmake, libiconv, libintlOrEmpty
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg
 , qt4Support ? false, qt4 ? null, qt5
 }:
@@ -26,7 +26,7 @@ let
 
     propagatedBuildInputs = [ zlib cairo freetype fontconfig libjpeg lcms curl openjpeg ];
 
-    nativeBuildInputs = [ pkgconfig cmake ] ++ libiconvOrEmpty ++ libintlOrEmpty;
+    nativeBuildInputs = [ pkgconfig cmake libiconv ] ++ libintlOrEmpty;
 
     cmakeFlags = "-DENABLE_XPDF_HEADERS=ON -DENABLE_LIBCURL=ON -DENABLE_ZLIB=ON";
 

--- a/pkgs/development/libraries/stfl/default.nix
+++ b/pkgs/development/libraries/stfl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, libiconvOrEmpty }:
+{ stdenv, fetchurl, ncurses, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "stfl-0.22";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "062lqlf3qhp8bcapbpc0k3wym7x6ngncql8jmx5x06p6679szp9d";
   };
 
-  buildInputs = [ ncurses ] ++ libiconvOrEmpty;
+  buildInputs = [ ncurses libiconv ];
 
   buildPhase = ''
     sed -i s%ncursesw/ncurses.h%ncurses.h% stfl_internals.h

--- a/pkgs/development/ocaml-modules/ocaml-text/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-text/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, libiconvOrNull, ocaml, findlib, ncurses}:
+{stdenv, fetchurl, libiconv, ocaml, findlib, ncurses}:
 
 stdenv.mkDerivation {
   name = "ocaml-text-0.6";
@@ -8,12 +8,9 @@ stdenv.mkDerivation {
     sha256 = "0j8gaak0ajnlmn8knvfygqwwzs7awjv5rfn5cbj6qxqbxhjd5m6g";
   };
 
-  buildInputs = [ocaml findlib ncurses]
-    ++ stdenv.lib.optional (libiconvOrNull != null) libiconvOrNull;
+  buildInputs = [ocaml findlib ncurses libiconv];
 
-  configurePhase =
-    (stdenv.lib.optionalString (libiconvOrNull != null) "iconv_prefix=${libiconvOrNull} ")
-    + "ocaml setup.ml -configure";
+  configurePhase = "iconv_prefix=${libiconv} ocaml setup.ml -configure";
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dpkg, curl, libarchive, openssl, ruby, buildRubyGem, libiconvOrLibc
+{ stdenv, fetchurl, dpkg, curl, libarchive, openssl, ruby, buildRubyGem, libiconv
 , libxml2, libxslt }:
 
 assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
     # libiconv: iconv
     rm opt/vagrant/embedded/bin/iconv
-    ln -s ${libiconvOrLibc}/bin/iconv opt/vagrant/embedded/bin
+    ln -s ${libiconv}/bin/iconv opt/vagrant/embedded/bin
 
     # libxml: xml2-config, xmlcatalog, xmllint
     rm opt/vagrant/embedded/bin/{xml2-config,xmlcatalog,xmllint}

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, zlib, expat, openssl
 , libjpeg, libpng, libtiff, freetype, fontconfig, lcms2, libpaper, jbig2dec
-, libiconvOrEmpty
+, libiconv
 , x11Support ? false, x11 ? null
 , cupsSupport ? false, cups ? null
 }:
@@ -33,10 +33,10 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig zlib expat openssl
       libjpeg libpng libtiff freetype fontconfig lcms2 libpaper jbig2dec
+      libiconv
     ]
     ++ stdenv.lib.optional x11Support x11
     ++ stdenv.lib.optional cupsSupport cups
-    ++ libiconvOrEmpty
     # [] # maybe sometimes jpeg2000 support
     ;
 

--- a/pkgs/servers/irc/ngircd/default.nix
+++ b/pkgs/servers/irc/ngircd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, openssl, pam, libiconvOrNull }:
+{ stdenv, fetchurl, zlib, openssl, pam, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "ngircd-21";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     "--with-iconv"
   ];
 
-  buildInputs = [ zlib pam openssl libiconvOrNull ];
+  buildInputs = [ zlib pam openssl libiconv ];
 
   meta = {
     description = "Next Generation IRC Daemon";

--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, db, libgcrypt, avahi, libiconvOrEmpty, pam, openssl }:
+{ fetchurl, stdenv, pkgconfig, db, libgcrypt, avahi, libiconv, pam, openssl }:
 
 stdenv.mkDerivation rec {
   name = "netatalk-3.1.0";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1d8dc8ysslkis4yl1xab1w9p0pz7a1kg0i6fds4wxsp4fhb6wqhq";
   };
 
-  buildInputs = [ pkgconfig db libgcrypt avahi pam openssl ] ++ libiconvOrEmpty;
+  buildInputs = [ pkgconfig db libgcrypt avahi pam openssl libiconv ];
 
   configureFlags = [
     "--with-bdb=${db}"

--- a/pkgs/tools/misc/aescrypt/default.nix
+++ b/pkgs/tools/misc/aescrypt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libiconvOrEmpty }:
+{ stdenv, fetchurl, libiconv }:
 
 stdenv.mkDerivation rec {
   version = "3.0.9";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cp aescrypt_keygen $out/bin
   '';
 
-  buildInputs = [ libiconvOrEmpty ];
+  buildInputs = [ libiconv ];
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-liconv";
 

--- a/pkgs/tools/misc/mdbtools/git.nix
+++ b/pkgs/tools/misc/mdbtools/git.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit, glib, readline, bison, flex, pkgconfig,
-  libiconvOrEmpty, autoconf, automake, libtool, which, txt2man, gnome_doc_utils,
+  libiconv, autoconf, automake, libtool, which, txt2man, gnome_doc_utils,
   scrollkeeper}:
 
 stdenv.mkDerivation {
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
 
   buildInputs = [
     glib readline bison flex pkgconfig autoconf automake
-    libtool which txt2man gnome_doc_utils scrollkeeper
-  ] ++ libiconvOrEmpty;
+    libtool which txt2man gnome_doc_utils scrollkeeper libiconv
+  ];
 
   preConfigure = ''
     sed -e 's@static \(GHashTable [*]mdb_backends;\)@\1@' -i src/libmdb/backend.c

--- a/pkgs/tools/package-management/disnix/default.nix
+++ b/pkgs/tools/package-management/disnix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, dbus_glib, libxml2, libxslt, getopt, nixUnstable, dysnomia, libintlOrEmpty, libiconvOrEmpty }:
+{ stdenv, fetchurl, pkgconfig, dbus_glib, libxml2, libxslt, getopt, nixUnstable, dysnomia, libintlOrEmpty, libiconv }:
 
 stdenv.mkDerivation {
   name = "disnix-0.3prea0484a2c19d1947c21f11b4fc7c3f6049bd11efa";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "06qjaxysnkm31rgjlqy9n7p59q5v3jl57jm9jya7zf2g90syhdn7";
   };
   
-  buildInputs = [ pkgconfig dbus_glib libxml2 libxslt getopt nixUnstable libintlOrEmpty libiconvOrEmpty dysnomia ];
+  buildInputs = [ pkgconfig dbus_glib libxml2 libxslt getopt nixUnstable libintlOrEmpty libiconv dysnomia ];
 
   dontStrip = true;
   

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, bzip2, libiconvOrNull, libxml2, openssl, ncurses, curl }:
+{ stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl }:
 stdenv.mkDerivation rec {
   name = "clamav-${version}";
   version = "0.98.6";
@@ -8,20 +8,18 @@ stdenv.mkDerivation rec {
     sha256 = "0l99a0shgzpl8rvrrgbm1ki2zxlb7g1n82bhq7f2snj4amfj94b5";
   };
 
-  buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl ]
-    ++ stdenv.lib.optional (libiconvOrNull != null) libiconvOrNull;
+  buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl libiconv ];
 
   configureFlags = [
     "--with-zlib=${zlib}"
     "--with-libbz2-prefix=${bzip2}"
-  ] ++ (stdenv.lib.optional (libiconvOrNull != null)
-       "--with-iconv-dir=${libiconvOrNull}")
-  ++ [
+    "--with-iconv-dir=${libiconv}"
     "--with-xml=${libxml2}"
     "--with-openssl=${openssl}"
     "--with-libncurses-prefix=${ncurses}"
     "--with-libcurl=${curl}"
-    "--disable-clamav" ];
+    "--disable-clamav"
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://www.clamav.net;

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, readline, zlib, libgpgerror, pth, libgcrypt, libassuan
-, libksba, coreutils, libiconvOrEmpty
+, libksba, coreutils, libiconv
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
 , pinentry ? null, openldap ? null, bzip2 ? null, libusb ? null, curl ? null
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs
     = [ readline zlib libgpgerror libgcrypt libassuan libksba pth
-        openldap bzip2 libusb curl ]
-    ++ libiconvOrEmpty;
+        openldap bzip2 libusb curl libiconv ];
 
   patchPhase = ''
     find tests -type f | xargs sed -e 's@/bin/pwd@${coreutils}&@g' -i

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libtool, readline, zlib, openssl, libiconvOrNull, pcsclite
+{ stdenv, fetchurl, libtool, readline, zlib, openssl, libiconv, pcsclite
 , libassuan1, pkgconfig, libXt, docbook_xsl, libxslt, docbook_xml_dtd_412
 }:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libtool readline zlib openssl pcsclite libassuan1 pkgconfig
-    libXt libxslt libiconvOrNull docbook_xml_dtd_412
+    libXt libxslt libiconv docbook_xml_dtd_412
   ];
 
   configureFlags = [

--- a/pkgs/tools/text/enca/default.nix
+++ b/pkgs/tools/text/enca/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libiconvOrNull, recode }:
+{ stdenv, fetchurl, libiconv, recode }:
 
 stdenv.mkDerivation rec {
   name = "enca-1.16";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hg7ggldam66l9j53nlrvi2lv1k99r2qfk6dh23vg6mi05cph7bw";
   };
 
-  buildInputs = [ recode libiconvOrNull ];
+  buildInputs = [ recode libiconv ];
 
   meta = {
     homepage = http://freecode.com/projects/enca;

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pcre, libiconvOrNull }:
+{ stdenv, fetchurl, pcre, libiconv }:
 
 let version = "2.20"; in
 
@@ -10,9 +10,9 @@ stdenv.mkDerivation {
     sha256 = "0rcs0spsxdmh6yz8y4frkqp6f5iw19mdbdl9s2v6956hq0mlbbzh";
   };
 
-  buildInputs = [ pcre libiconvOrNull ];
+  buildInputs = [ pcre libiconv ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString (libiconvOrNull != null) "-L${libiconvOrNull}/lib -liconv";
+  NIX_LDFLAGS = "-L${libiconv}/lib -liconv";
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ pcre libiconv ];
 
-  NIX_LDFLAGS = "-L${libiconv}/lib -liconv";
-
   doCheck = !stdenv.isDarwin;
 
   # On Mac OS X, force use of mkdir -p, since Grep's fallback

--- a/pkgs/tools/typesetting/docbook2x/default.nix
+++ b/pkgs/tools/typesetting/docbook2x/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, texinfo, perl
 , XMLSAX, XMLParser, XMLNamespaceSupport
-, groff, libxml2, libxslt, gnused, libiconvOrEmpty, opensp
+, groff, libxml2, libxslt, gnused, libiconv, opensp
 , docbook_xml_dtd_43
 , makeWrapper }:
 
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   patches = [ ./db2x_texixml-to-stdout.patch ];
 
   buildInputs = [ perl texinfo groff libxml2 libxslt makeWrapper
-                  XMLSAX XMLParser XMLNamespaceSupport opensp
-                ] ++ libiconvOrEmpty;
+                  XMLSAX XMLParser XMLNamespaceSupport opensp libiconv
+                ];
 
   postConfigure = ''
     # Broken substitution is used for `perl/config.pl', which leaves literal

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6244,19 +6244,10 @@ let
 
   libgsf = callPackage ../development/libraries/libgsf { };
 
-  libiconv = callPackage ../development/libraries/libiconv { };
-
-  libiconvOrEmpty = if libiconvOrNull == null then [] else [libiconv];
-
-  libiconvOrNull =
-    if stdenv.cc.libc or null != null || stdenv.isGlibc
-    then null
-    else libiconv;
-
-  # The logic behind this attribute is broken: libiconvOrNull==null does
-  # NOT imply libiconv=glibc! On Darwin, for example, we have a native
-  # libiconv library which is not glibc.
-  libiconvOrLibc = if libiconvOrNull == null then stdenv.cc.libc else libiconv;
+  libiconv =
+    if stdenv.isGlibc
+    then stdenv.cc.libc
+    else callPackage ../development/libraries/libiconv { };
 
   # On non-GNU systems we need GNU Gettext for libintl.
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux) gettext;


### PR DESCRIPTION
The pure-darwin branch doesn't include libiconv in its libc the way glibc does, nor does it let nixpkgs link against apple's libiconv (for obvious reasons). So we've had to make a lot of packages more explicit about their dependence on libiconv, and have merged all the libiconvOr variants into a single libiconv that points to glibc on linux and libiconv on darwin.

An alternative approach would be to just bundle libiconv with the darwin stdenv, but @copumpkin has strong feelings against this :smile:.

The downside to this PR is that it will cause major rebuilding on linux.

/cc @shlevy @edolstra 
