### PR TITLE
Added config options for systemd-coredump functionality.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -406,6 +406,7 @@
   ./services/x11/xserver.nix
   ./system/activation/activation-script.nix
   ./system/activation/top-level.nix
+  ./system/boot/coredump.nix
   ./system/boot/emergency-mode.nix
   ./system/boot/kernel.nix
   ./system/boot/kexec.nix

--- a/nixos/modules/system/boot/coredump.nix
+++ b/nixos/modules/system/boot/coredump.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+
+  options = {
+
+    systemd.coredump = {
+
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enables storing core dumps in systemd.
+          Note that this alone is not enough to enable core dumps. The maximum
+          file size for core dumps must be specified in limits.conf as well. See
+          <option>security.pam.loginLimits</option> as well as the limits.conf(5)
+          man page.
+        '';
+      };
+
+      extraConfig = mkOption {
+        default = "";
+        type = types.lines;
+        example = "Storage=journal";
+        description = ''
+          Extra config options for systemd-coredump. See coredump.conf(5) man page
+          for available options.
+        '';
+      };
+    };
+
+  };
+
+  config = mkIf config.systemd.coredump.enable {
+
+    environment.etc."systemd/coredump.conf".text =
+      ''
+        [Coredump]
+        ${config.systemd.coredump.extraConfig}
+      '';
+
+    # Have the kernel pass core dumps to systemd's coredump helper binary.
+    # From systemd's 50-coredump.conf file. See:
+    # <https://github.com/systemd/systemd/blob/v218/sysctl.d/50-coredump.conf.in>
+    boot.kernel.sysctl."kernel.core_pattern" = "|${pkgs.systemd}/lib/systemd/systemd-coredump %p %u %g %s %t %e";
+
+  };
+
+}


### PR DESCRIPTION
This adds simple support for configuring the management of core dumps through systemd to the NixOS config. I was debugging a systemd service with a segmentation fault when I noticed that /etc/systemd/coredump.conf isn't configurable through NixOS. This feature is helpful as systemd can place core dumps in a central location and rotate them as needed.

I left the default as systemd core dumps disabled, which is the current behavior. Limits still have to be set separately, which I believe is appropriate considering core dumps can be a security risk on sensitive systems.

I would have added the explicit --enable-coredump flag to the systemd configure flags, but decided against it when Nix started rebuilding Chromium etc. Someone might want to un-comment it at a later time.
