### PR TITLE
steam: replace steamdeps

### DIFF
--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, traceDeps ? false}:
 
 stdenv.mkDerivation rec {
   name = "${program}-${version}";
@@ -10,10 +10,23 @@ stdenv.mkDerivation rec {
     sha256 = "1c1gl5pwvb5gnnnqf5d9hpcjnfjjgmn4lgx8v0fbx1am5xf3p2gx";
   };
 
+  traceLog = "/tmp/steam-trace-dependencies.log";
+
   installPhase = ''
     make DESTDIR=$out install
     mv $out/usr/* $out #*/
     rmdir $out/usr
+
+    rm $out/bin/steamdeps
+    ${stdenv.lib.optionalString traceDeps ''
+      cat > $out/bin/steamdeps <<EOF
+      #! /bin/bash
+      echo \$1 >> ${traceLog}
+      cat \$1 >> ${traceLog}
+      echo >> ${traceLog}
+      EOF
+      chmod +x $out/bin/steamdeps
+    ''}
   '';
 
   meta = {


### PR DESCRIPTION
This removes original `steamdeps` from Valve which tries to install its dependencies using `apt-get`. It also adds an option to use debug version of `steamdeps` which would dump all dependencies it was asked for into a file.

@jagajaga 
