### PR TITLE
Add release-notes for unstable revision

### DIFF
--- a/nixos/doc/manual/release-notes/release-notes.xml
+++ b/nixos/doc/manual/release-notes/release-notes.xml
@@ -7,9 +7,11 @@
 <title>Release Notes</title>
 
 <partintro>
-<para>This section lists the release notes for each stable version of NixOS.</para>
+<para>This section lists the release notes for each stable version of NixOS
+and current unstable revision.</para>
 </partintro>
 
+<xi:include href="rl-unstable.xml" />
 <xi:include href="rl-1412.xml" />
 <xi:include href="rl-1404.xml" />
 <xi:include href="rl-1310.xml" />

--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -1,0 +1,41 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xi="http://www.w3.org/2001/XInclude"
+        version="5.0"
+        xml:id="sec-release-unstable">
+
+<title>Unstable revision</title>
+
+<para>In addition to numerous new and upgraded packages, this release has the following highlights:
+
+<!--<itemizedlist>
+
+</itemizedlist>-->
+</para>
+
+<para>Following new services were added since the last release:
+
+<!--<itemizedlist>
+
+</itemizedlist>-->
+</para>
+
+<para>When upgrading from a previous release, please be aware of the
+following incompatible changes:
+
+<itemizedlist>
+
+<listitem><para>Steam now doesn't need root rights to work. Instead of using
+<literal>*-steam-chrootenv</literal>, you should now just run <literal>steam</literal>.
+<literal>steamChrootEnv</literal> package was renamed to <literal>steam</literal>,
+and old <literal>steam</literal> package -- to <literal>steamOriginal</literal>.
+</para></listitem>
+
+<listitem><para>CMPlayer has been renamed to bomi upstream. Package <literal>cmplayer</literal>
+was accordingly renamed to <literal>bomi</literal>
+</para></listitem>
+
+</itemizedlist>
+</para>
+
+</chapter>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9619,7 +9619,6 @@ let
     stdenv = overrideCC stdenv gcc49;
     pulseSupport = config.pulseaudio or false;
   };
-  cmplayer = bomi;
 
   cmus = callPackage ../applications/audio/cmus { };
 
@@ -12165,14 +12164,6 @@ let
   steamOriginal = callPackage ../games/steam { };
 
   steam = callPackage ../games/steam/chrootenv.nix { };
-
-  steamChrootEnv = steam.overrideDerivation (args: {
-    buildCommand = ''
-      ${args.buildCommand}
-      echo >&2 "'steamChrootEnv' is replaced with 'steam' now"
-      echo >&2 "You now need just to run 'steam' without root rights"
-    '';
-  });
 
   stuntrally = callPackage ../games/stuntrally { };
 


### PR DESCRIPTION
This is a followup of a discussion with @wmertens [1] . The idea is to have an "unstable" release notes, which would be copied into new file, cleaned up and started over on each release. Meanwhile one would have where to add notes, so we won't need to write everything from scratch right before a release. I haven't looked into documentation before that; it's possible we've had something like this before somewhere and I've just missed it.

I've also added some first notes to it regarding renames (and new semantics) of some packages. I have a question regarding them -- should I leave old names for compatibility at all, and how should I mark them as "deprecated" if so? For NixOS we have `rename.nix`, but there's no mechanism like this in plain `nixpkgs` AFAIK. For now I've included here a patch to remove old aliases at all -- as one course of action.

A written policy regarding this would be very nice indeed.

1: https://github.com/abbradar/nixpkgs/commit/627f8178b8b779b639a64716dbe13c7a64ad56f0#commitcomment-9611181
