### PR TITLE
unison: update from 2.40.102 to 2.48.3

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -3,10 +3,10 @@
 
 stdenv.mkDerivation (rec {
 
-  name = "unison-2.40.102";
+  name = "unison-2.48.3";
   src = fetchurl {
     url = "http://www.seas.upenn.edu/~bcpierce/unison/download/releases/stable/${name}.tar.gz";
-    sha256 = "0m78q5vnsric1virvkmxxx32ipaq0cnj0kbirdbg36395gq94jix";
+    sha256 = "1vmpf11f282sg0dzh28plmd0xcjy3y4z3jszyb1xklwmbvagk5d6";
   };
 
   buildInputs = [ ocaml makeWrapper ncurses ];


### PR DESCRIPTION
Not sure if this breaks backwards compatibility somehow.

cc @viric 
