### PR TITLE
IPv6 containers and NAT

### DIFF
--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -10,52 +10,83 @@ let
 
   cfg = config.networking.nat;
 
-  dest = if cfg.externalIP == null then "-j MASQUERADE" else "-j SNAT --to-source ${cfg.externalIP}";
+  mkDest = externalIP: if externalIP == null
+                       then "-j MASQUERADE"
+                       else "-j SNAT --to-source ${externalIP}";
 
-  flushNat = ''
-    iptables -w -t nat -D PREROUTING -j nixos-nat-pre 2>/dev/null|| true
-    iptables -w -t nat -F nixos-nat-pre 2>/dev/null || true
-    iptables -w -t nat -X nixos-nat-pre 2>/dev/null || true
-    iptables -w -t nat -D POSTROUTING -j nixos-nat-post 2>/dev/null || true
-    iptables -w -t nat -F nixos-nat-post 2>/dev/null || true
-    iptables -w -t nat -X nixos-nat-post 2>/dev/null || true
+  dest = mkDest cfg.externalIP;
+  destIPv6 = mkDest cfg.externalIPv6;
+
+  enableIPv6 = config.networking.enableIPv6 && cfg.enableIPv6;
+
+  # Whether given IP (plus optional port) is an IPv6.
+  isIPv6 = ip: builtins.length (lib.splitString ":" ip) > 2;
+
+  mkFlushNat = iptables: ''
+    ${iptables} -w -t nat -D PREROUTING -j nixos-nat-pre 2>/dev/null|| true
+    ${iptables} -w -t nat -F nixos-nat-pre 2>/dev/null || true
+    ${iptables} -w -t nat -X nixos-nat-pre 2>/dev/null || true
+    ${iptables} -w -t nat -D POSTROUTING -j nixos-nat-post 2>/dev/null || true
+    ${iptables} -w -t nat -F nixos-nat-post 2>/dev/null || true
+    ${iptables} -w -t nat -X nixos-nat-post 2>/dev/null || true
   '';
 
-  setupNat = ''
+  mkSetupNat = { iptables, dest, internalIPs, forwardPorts }: ''
     # Create subchain where we store rules
-    iptables -w -t nat -N nixos-nat-pre
-    iptables -w -t nat -N nixos-nat-post
+    ${iptables} -w -t nat -N nixos-nat-pre
+    ${iptables} -w -t nat -N nixos-nat-post
 
     # We can't match on incoming interface in POSTROUTING, so
     # mark packets coming from the external interfaces.
     ${concatMapStrings (iface: ''
-      iptables -w -t nat -A nixos-nat-pre \
+      ${iptables} -w -t nat -A nixos-nat-pre \
         -i '${iface}' -j MARK --set-mark 1
     '') cfg.internalInterfaces}
 
     # NAT the marked packets.
     ${optionalString (cfg.internalInterfaces != []) ''
-      iptables -w -t nat -A nixos-nat-post -m mark --mark 1 \
+      ${iptables} -w -t nat -A nixos-nat-post -m mark --mark 1 \
         -o ${cfg.externalInterface} ${dest}
     ''}
 
     # NAT packets coming from the internal IPs.
     ${concatMapStrings (range: ''
-      iptables -w -t nat -A nixos-nat-post \
+      ${iptables} -w -t nat -A nixos-nat-post \
         -s '${range}' -o ${cfg.externalInterface} ${dest}
-    '') cfg.internalIPs}
+    '') internalIPs}
 
     # NAT from external ports to internal ports.
     ${concatMapStrings (fwd: ''
-      iptables -w -t nat -A nixos-nat-pre \
+      ${iptables} -w -t nat -A nixos-nat-pre \
         -i ${cfg.externalInterface} -p tcp \
         --dport ${builtins.toString fwd.sourcePort} \
         -j DNAT --to-destination ${fwd.destination}
-    '') cfg.forwardPorts}
+    '') forwardPorts}
 
     # Append our chains to the nat tables
-    iptables -w -t nat -A PREROUTING -j nixos-nat-pre
-    iptables -w -t nat -A POSTROUTING -j nixos-nat-post
+    ${iptables} -w -t nat -A PREROUTING -j nixos-nat-pre
+    ${iptables} -w -t nat -A POSTROUTING -j nixos-nat-post
+  '';
+
+  flushNat = ''
+    ${mkFlushNat "iptables"}
+    ${optionalString enableIPv6 (mkFlushNat "ip6tables")}
+  '';
+
+  setupNat = ''
+    ${mkSetupNat {
+      iptables = "iptables";
+      inherit dest;
+      inherit (cfg) internalIPs;
+      forwardPorts = filter (x: !(isIPv6 x.destination)) cfg.forwardPorts;
+    }}
+
+    ${optionalString enableIPv6 (mkSetupNat {
+      iptables = "ip6tables";
+      dest = destIPv6;
+      internalIPs = cfg.internalIPv6s;
+      forwardPorts = filter (x: isIPv6 x.destination) cfg.forwardPorts;
+    })}
   '';
 
 in
@@ -72,6 +103,15 @@ in
       description =
         ''
           Whether to enable Network Address Translation (NAT).
+        '';
+    };
+
+    networking.nat.enableIPv6 = mkOption {
+      type = types.bool;
+      default = false;
+      description =
+        ''
+          Whether to enable IPv6 NAT.
         '';
     };
 
@@ -99,6 +139,18 @@ in
         '';
     };
 
+    networking.nat.internalIPv6s = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "fc00::/64" ];
+      description =
+        ''
+          The IPv6 address ranges for which to perform NAT.  Packets
+          coming from these addresses (on any interface) and destined
+          for the external interface will be rewritten.
+        '';
+    };
+
     networking.nat.externalInterface = mkOption {
       type = types.str;
       example = "eth1";
@@ -121,10 +173,26 @@ in
         '';
     };
 
+    networking.nat.externalIPv6 = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "2001:dc0:2001:11::175";
+      description =
+        ''
+          The public IPv6 address to which packets from the local
+          network are to be rewritten.  If this is left empty, the
+          IP address associated with the external interface will be
+          used.
+        '';
+    };
+
     networking.nat.forwardPorts = mkOption {
       type = types.listOf types.optionSet;
       default = [];
-      example = [ { sourcePort = 8080; destination = "10.0.0.1:80"; } ];
+      example = [
+        { sourcePort = 8080; destination = "10.0.0.1:80"; }
+        { sourcePort = 8080; destination = "[fc00::2]:80"; }
+      ];
       options = {
         sourcePort = mkOption {
           type = types.int;
@@ -135,14 +203,15 @@ in
         destination = mkOption {
           type = types.str;
           example = "10.0.0.1:80";
-          description = "Forward tcp connection to destination ip:port";
+          description = "Forward tcp connection to destination ip:port or [ip]:port for IPv6";
         };
       };
 
       description =
         ''
           List of forwarded ports from the external interface to
-          internal destinations by using DNAT.
+          internal destinations by using DNAT. Destination can be
+          IPv6 if IPv6 NAT is enabled.
         '';
     };
 
@@ -160,7 +229,17 @@ in
       kernel.sysctl = {
         "net.ipv4.conf.all.forwarding" = mkOverride 99 true;
         "net.ipv4.conf.default.forwarding" = mkOverride 99 true;
-      };
+      } // (if enableIPv6 then {
+
+        # Do not prevent IPv6 autoconfiguration.
+        # See <http://strugglers.net/~andy/blog/2011/09/04/linux-ipv6-router-advertisements-and-forwarding/>.
+        "net.ipv6.conf.all.accept_ra" = mkOverride 99 2;
+        "net.ipv6.conf.default.accept_ra" = mkOverride 99 2;
+
+        # Forward IPv6 packets.
+        "net.ipv6.conf.all.forwarding" = mkOverride 99 true;
+        "net.ipv6.conf.default.forwarding" = mkOverride 99 true;
+      } else {});
     };
 
     networking.firewall = mkIf config.networking.firewall.enable {

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -30,6 +30,13 @@ let
         if [ -n "$LOCAL_ADDRESS" ]; then
           ip addr add $LOCAL_ADDRESS dev eth0
         fi
+        if [ -n "$HOST_IPV6_ADDRESS" ]; then
+          ip route add $HOST_IPV6_ADDRESS dev eth0
+          ip route add default via $HOST_IPV6_ADDRESS
+        fi
+        if [ -n "$LOCAL_IPV6_ADDRESS" ]; then
+          ip addr add $LOCAL_IPV6_ADDRESS dev eth0
+        fi
       fi
 
       # Start the regular stage 1 script, passing the bind-mounted
@@ -115,6 +122,25 @@ in
               example = "10.231.136.2";
               description = ''
                 The IPv4 address assigned to <literal>eth0</literal>
+                in the container.
+              '';
+            };
+
+            hostIPv6Address = mkOption {
+              type = types.nullOr types.string;
+              default = null;
+              example = "fc00::1";
+              description = ''
+                The IPv6 address assigned to the host interface.
+              '';
+            };
+
+            localIPv6Address = mkOption {
+              type = types.nullOr types.string;
+              default = null;
+              example = "fc00::2";
+              description = ''
+                The IPv6 address assigned to <literal>eth0</literal>
                 in the container.
               '';
             };
@@ -244,6 +270,8 @@ in
               --setenv PRIVATE_NETWORK="$PRIVATE_NETWORK" \
               --setenv HOST_ADDRESS="$HOST_ADDRESS" \
               --setenv LOCAL_ADDRESS="$LOCAL_ADDRESS" \
+              --setenv HOST_IPV6_ADDRESS="$HOST_IPV6_ADDRESS" \
+              --setenv LOCAL_IPV6_ADDRESS="$LOCAL_IPV6_ADDRESS" \
               --setenv PATH="$PATH" \
               ${containerInit} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
           '';
@@ -258,6 +286,12 @@ in
               fi
               if [ -n "$LOCAL_ADDRESS" ]; then
                 ip route add $LOCAL_ADDRESS dev $ifaceHost
+              fi
+              if [ -n "$HOST_IPV6_ADDRESS" ]; then
+                ip addr add $HOST_IPV6_ADDRESS dev $ifaceHost
+              fi
+              if [ -n "$LOCAL_IPV6_ADDRESS" ]; then
+                ip route add $LOCAL_IPV6_ADDRESS dev $ifaceHost
               fi
             fi
           '';
@@ -318,6 +352,12 @@ in
               ''}
               ${optionalString (cfg.localAddress != null) ''
                 LOCAL_ADDRESS=${cfg.localAddress}
+              ''}
+              ${optionalString (cfg.hostIPv6Address != null) ''
+                HOST_IPV6_ADDRESS=${cfg.hostIPv6Address}
+              ''}
+              ${optionalString (cfg.localIPv6Address != null) ''
+                LOCAL_IPV6_ADDRESS=${cfg.localIPv6Address}
               ''}
             ''}
            ${optionalString cfg.autoStart ''


### PR DESCRIPTION
Following #4917, I updated the containers and NAT modules to support IPv6:
- Allow to define an IPv6 host and local address for a container.
- Support IPv6 port forwarding in NAT configuration.

Here's an example `configuration.nix` I use with these features:

``` nix
{ config, pkgs, ... }:

{
  networking = {
    firewall.allowedTCPPorts = [ 80 ];

    nat = {
      enable = true;
      internalInterfaces = ["ve-+"];
      externalInterface = "enp0s3";

      forwardPorts = [
        { sourcePort = 80; destination = "192.168.100.2:80"; }
      ];

      forwardIPv6Ports = [
        { sourcePort = 80; destination = "[fc00::2]:80"; }
      ];
    };
  };

  containers = {
    web = {
      autoStart = true;

      privateNetwork = true;
      hostAddress = "192.168.100.1";
      localAddress = "192.168.100.2";
      hostIPv6Address = "fc00::1";
      localIPv6Address = "fc00::2";

      config = { config, pkgs, ... }: {
        networking.firewall.allowedTCPPorts = [ 80 443 ];

        services.httpd = {
          enable = true;
          adminAddr = "admin@example.com";
        };
      };
    };
  };
}
```

I'm not sure about the options naming, sometimes it's `IPv6`, sometimes `ipv6` or `ip6`, or just adding `6` to the option name (`defaultGateway6`).

There's also a lot of copy/paste with only `s/iptables/ip6tables/` in `nat.nix`, I'd appreciate input on how to factorize this.
###### Todo
- [x] Make this feature optional, according to `networking.enableIPv6` and a new option `networking.nat.enableIPv6`.
- [x] Unify `forwardIPv6Ports` and `forwardPorts` (determine whether to call iptables or ip6tables depending on the destination address).
