### PR TITLE
Change download URL for IDEA editor

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -232,8 +232,8 @@ in
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
-      url = "http://download-ln.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "01wcpzdahkh3li2l3k2bgirnlp7hdxk9y1kyrxc3d9d1nazq8wqn";
+      url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
+      sha256 = "167384bfb2a1a53658cf7e069f666ff05c6a737c4bcc4145a4034ea8dabf8c07";
     };
   };
 
@@ -244,8 +244,8 @@ in
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
-      url = "http://download-ln.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "1zkqigdh9l1f3mjjvxsp7b7vc93v5ylvxa1dfpclzmfbzna7h69s";
+      url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
+      sha256 = "3a197894fdcbd54fd9752da8bea92f7b24b6cf3a57f72d651d2ed004db8b78fe";
     };
   };
 

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -232,8 +232,8 @@ in
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
-      url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "167384bfb2a1a53658cf7e069f666ff05c6a737c4bcc4145a4034ea8dabf8c07";
+      url = "http://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
+      sha256 = "01wcpzdahkh3li2l3k2bgirnlp7hdxk9y1kyrxc3d9d1nazq8wqn";
     };
   };
 
@@ -244,8 +244,8 @@ in
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
-      url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "3a197894fdcbd54fd9752da8bea92f7b24b6cf3a57f72d651d2ed004db8b78fe";
+      url = "http://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
+      sha256 = "1zkqigdh9l1f3mjjvxsp7b7vc93v5ylvxa1dfpclzmfbzna7h69s";
     };
   };
 


### PR DESCRIPTION
Old download links were giving me sha mismatches during build. Worse than that, the link seemed to return non-identical files when fetched multiple times. I grabbed the new link from IntelliJ download page. Unlike the old one, this one comes with a corresponding sha file, which is nice:

https://download.jetbrains.com/idea/ideaIC-14.0.3.tar.gz
https://download.jetbrains.com/idea/ideaIC-14.0.3.tar.gz.sha256
