### PR TITLE
libvpx: refactor and add git version

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6555,6 +6555,7 @@ let
   libviper = callPackage ../development/libraries/libviper { };
 
   libvpx = callPackage ../development/libraries/libvpx { };
+  libvpx-git = callPackage ../development/libraries/libvpx/git.nix { };
 
   libvterm = callPackage ../development/libraries/libvterm { };
 


### PR DESCRIPTION
refactored and add git version

Currently a couple of the optionals are not actually optional, but are implemented as such in case upstream makes changes.
- See `spatialResamplingSupport` & `examplesSupport`

As it stands it was a challenge to get libvpx to build on Linux, so I have no clue if this will build on Cygwin or Darwin, I am not familiar with either platform so changes to `crossAttrs` might be need.
- Darwin targets also include darwin version in the target string
