### PR TITLE
Patch npm packages to ignore npm requirements

### DIFF
--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -83,6 +83,9 @@ let
       # Some version specifiers (latest, unstable, URLs, file paths) force NPM
       # to make remote connections or consult paths outside the Nix store.
       # The following JavaScript replaces these by * to prevent that:
+      # Also some packages require a specific npm version because npm may
+      # resovle dependencies differently, but npm is not used by Nix for dependency
+      # reslution, so these requirements are dropped.
 
       (
       cat <<EOF
@@ -129,6 +132,11 @@ let
                 var versionSpec = packageObj.optionalDependencies[dependency];
                 packageObj.optionalDependencies[dependency] = replaceImpureVersionSpec(versionSpec);
             }
+        }
+
+        /* Ignore npm version requirement */
+        if(packageObj.engines) {
+            delete packageObj.engines.npm;
         }
 
         /* Write the fixed JSON file */


### PR DESCRIPTION
Some npm packages strictly require a specific npm version because npm don't handle some version requirements the same way in 1.0 and 2.0.

However, Nix don't use npm for dependency resolution (this is always achieved with npm 1.0 criteria by npm2nix), so these requirements turns out to be pointless and just crashes some package installations.

This patch removes npm requirements so the packages can still be built.

This solves #5787.
