### PR TITLE
sane: Fix evaluation on ARM.

### DIFF
--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -36,8 +36,8 @@ in
 
     hardware.sane.configDir = mkOption {
       type = types.string;
-      default = "${saneConfig}/etc/sane.d";
-      description = "The value of SANE_CONFIG_DIR.";
+      default = "";
+      description = "Override the value of SANE_CONFIG_DIR.";
     };
 
   };
@@ -45,17 +45,21 @@ in
 
   ###### implementation
 
-  config = mkIf config.hardware.sane.enable {
+  config = mkIf config.hardware.sane.enable (let
+    effectiveConfigDir = if config.hardware.sane.configDir != "" then
+      config.hardware.sane.configDir else
+      "${saneConfig}/etc/sane.d";
+  in {
 
     environment.systemPackages = backends;
     environment.sessionVariables = {
-      SANE_CONFIG_DIR = config.hardware.sane.configDir;
+      SANE_CONFIG_DIR = effectiveConfigDir;
       LD_LIBRARY_PATH = [ "${saneConfig}/lib/sane" ];
     };
     services.udev.packages = backends;
 
     users.extraGroups."scanner".gid = config.ids.gids.scanner;
 
-  };
+  });
 
 }


### PR DESCRIPTION
The sane package will be evaluated even if the sane service is disabled, because it is used in the default value of the configDir option.
This breaks NixOS evaluation on ARM in the default configuration, due to an assertion error in the sane package.
Fix it by setting the default configDir to an empty string and later turning an empty string to what used to be the default.
