### PR TITLE
Disable tests for haskellngPackages.rematch since it is missing Specs mo...

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -451,6 +451,9 @@ self: super: {
   # Upstream notified by e-mail.
   OpenGLRaw21 = markBrokenVersion "1.2.0.1" super.OpenGLRaw21;
 
+  # module missing: https://github.com/tcrayford/rematch/issues/5
+  rematch = dontCheck super.rematch; 
+
 } // {
 
   # Not on Hackage.


### PR DESCRIPTION
...dule. rematch is needed by distributed-process-platform.
