### PR TITLE
nixos: Don't fail if the default value of an option for the manual cannot be evaluated.

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -99,7 +99,10 @@ rec {
           type = opt.type.name or null;
         }
         // (if opt ? example then { example = scrubOptionValue opt.example; } else {})
-        // (if opt ? default then { default = scrubOptionValue opt.default; } else {})
+        // (if opt ? default then (
+          let canEval = (builtins.tryEval (builtins.deepSeq opt.default null)).success; in
+          { default = if canEval then scrubOptionValue opt.default else
+              "Default value could not be evaluated."; }) else {})
         // (if opt ? defaultText then { default = opt.defaultText; } else {});
 
         subOptions =


### PR DESCRIPTION
There are errors evaluating the NixOS manual on ARM because certain services provide default option values which depend on expressions that fail to evaluate with assertion errors, due to not being supported on ARM.

Some examples: `services.jenkins.packages`, `services.tomcat.jdk` (contain `pkgs.jdk`), and `hardware.sane.configDir`.

Note: here I used the undocumented `builtins.tryEval`. Additionally, I used `builtins.deepSeq` to deeply evaluate an expression, else `tryEval` would not catch the assertion errors.
