### PR TITLE
ncmpcpp: add support for optional screens

### DIFF
--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -1,23 +1,44 @@
-{ stdenv, fetchurl, ncurses, curl, taglib, fftw, mpd_clientlib, pkgconfig
-, libiconvOrEmpty, boost, readline }:
+{ stdenv, fetchurl, boost, mpd_clientlib, ncurses, pkgconfig, readline
+, libiconvOrEmpty
+, outputsSupport ? false # outputs screen
+, visualizerSupport ? false, fftw ? null # visualizer screen
+, clockSupport ? false # clock screen
+, unicodeSupport ? true # utf8 support
+, curlSupport ? true, curl ? null # allow fetching lyrics from the internet
+, taglibSupport ? true, taglib ? null # tag editor
+}:
 
+assert visualizerSupport -> (fftw != null);
+assert curlSupport -> (curl != null);
+assert taglibSupport -> (taglib != null);
+
+with stdenv.lib;
 stdenv.mkDerivation rec {
-  version = "0.6.2";
   name = "ncmpcpp-${version}";
+  version = "0.6.2";
 
   src = fetchurl {
-    url = "http://ncmpcpp.rybczak.net/stable/ncmpcpp-${version}.tar.bz2";
+    url = "http://ncmpcpp.rybczak.net/stable/${name}.tar.bz2";
     sha256 = "1mrd6m6ph0fscxp9x96ipxh6ai7w0n1miapcfqrqfy058qx5zbck";
   };
 
-  configureFlags = "BOOST_LIB_SUFFIX=";
+  configureFlags = [ "BOOST_LIB_SUFFIX=" ]
+    ++ optional outputsSupport "--enable-outputs"
+    ++ optional visualizerSupport "--enable-visualizer --with-fftw"
+    ++ optional clockSupport "--enable-clock"
+    ++ optional unicodeSupport "--enable-unicode"
+    ++ optional curlSupport "--with-curl"
+    ++ optional taglibSupport "--with-taglib";
 
-  buildInputs = [ ncurses curl taglib fftw mpd_clientlib boost pkgconfig readline ]
+  buildInputs = [ boost mpd_clientlib ncurses pkgconfig readline ]
+    ++ optional curlSupport curl
+    ++ optional visualizerSupport fftw
+    ++ optional taglibSupport taglib
     ++ libiconvOrEmpty;
 
-  meta = with stdenv.lib; {
-    description = "Curses-based interface for MPD (music player daemon)";
-    homepage    = http://unkart.ovh.org/ncmpcpp/;
+  meta = {
+    description = "A featureful ncurses based MPD client inspired by ncmpc";
+    homepage    = http://ncmpcpp.rybczak.net/;
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ lovek323 mornfall koral ];
     platforms   = platforms.all;


### PR DESCRIPTION
The only change to the defaults is that fftw is not passed as a build input by default, it is only needed if the visualizer screen is enabled.
