### PR TITLE
canto-{curses,daemon}: Add packages

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -172,6 +172,7 @@
   ./services/mail/spamassassin.nix
   ./services/misc/apache-kafka.nix
   #./services/misc/autofs.nix
+  ./services/misc/canto-daemon.nix
   ./services/misc/cpuminer-cryptonight.nix
   ./services/misc/cgminer.nix
   ./services/misc/dictd.nix

--- a/nixos/modules/services/misc/canto-daemon.nix
+++ b/nixos/modules/services/misc/canto-daemon.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+cfg = config.services.canto-daemon;
+
+in {
+
+##### interface
+
+  options = {
+
+    services.canto-daemon {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the canto RSS daemon.";
+      };
+    };
+
+  };
+
+##### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.user.services.canto-next = {
+      description = "Canto RSS Daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "default.target" ];
+      serviceConfig.ExecStart = "${pkgs.canto-daemon}/bin/canto-daemon";
+      TimeoutStopSec = 10;
+    };
+  };
+}

--- a/nixos/modules/services/misc/canto-daemon.nix
+++ b/nixos/modules/services/misc/canto-daemon.nix
@@ -12,7 +12,7 @@ in {
 
   options = {
 
-    services.canto-daemon {
+    services.canto-daemon = {
       enable = mkOption {
         type = types.bool;
         default = false;
@@ -26,12 +26,12 @@ in {
 
   config = mkIf cfg.enable {
 
-    systemd.user.services.canto-next = {
+    systemd.user.services.canto-daemon = {
       description = "Canto RSS Daemon";
       after = [ "network.target" ];
       wantedBy = [ "default.target" ];
       serviceConfig.ExecStart = "${pkgs.canto-daemon}/bin/canto-daemon";
-      TimeoutStopSec = 10;
     };
   };
+
 }

--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, python34Packages, readline, ncurses, canto-daemon }:
+
+python34Packages.buildPythonPackage rec {
+  version = "0.9.1";
+  name = "canto-curses-${version}";
+
+  src = fetchFromGitHub {
+    owner = "themoken";
+    repo = "canto-curses";
+    rev = "v${version}";
+    sha256 = "1vb5g0vdkp233r09qv0g4rgz7nprr2a625lf6nf6a51wpimdwgdy";
+  };
+
+  buildInputs = [ readline ncurses canto-daemon ];
+  propagatedBuildInputs = [ canto-daemon ];
+
+  meta = {
+    description = "An ncurses-based console Atom/RSS feed reader";
+    longDescription = ''
+      Canto is an Atom/RSS feed reader for the console that is meant to be
+      quick, concise, and colorful. It's meant to allow you to crank through
+      feeds like you've never cranked before by providing a minimal, yet
+      information packed interface. No navigating menus. No dense blocks of
+      unreadable white text. An interface with almost infinite customization
+      and extensibility using the excellent Python programming language.
+    '';
+    homepage = http://codezen.org/canto-ng/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, python34Packages, }:
+
+python34Packages.buildPythonPackage rec {
+  version = "0.9.1";
+  name = "canto-daemon-${version}";
+  namePrefix = "";
+
+  src = fetchFromGitHub {
+    owner = "themoken";
+    repo = "canto-next";
+    rev = "v${version}";
+    sha256 = "14lh6x0yz2asspwdi1ims01589r79q0dv77vq61gfjk5wiwfbdwa";
+  };
+
+  propagatedBuildInputs = with python34Packages; [ feedparser ];
+
+  meta = {
+    description = "Daemon for the canto Atom/RSS feed reader";
+    longDescription = ''
+      Canto is an Atom/RSS feed reader for the console that is meant to be
+      quick, concise, and colorful. It's meant to allow you to crank through
+      feeds like you've never cranked before by providing a minimal, yet
+      information packed interface. No navigating menus. No dense blocks of
+      unreadable white text. An interface with almost infinite customization
+      and extensibility using the excellent Python programming language.
+    '';
+    homepage = http://codezen.org/canto-ng/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9553,6 +9553,10 @@ let
 
   camlistore = callPackage ../applications/misc/camlistore { };
 
+  canto-curses = callPackage ../applications/networking/feedreaders/canto-curses { };
+
+  canto-daemon = callPackage ../applications/networking/feedreaders/canto-daemon { };
+
   carrier = builderDefsPackage (import ../applications/networking/instant-messengers/carrier/2.5.0.nix) {
     inherit fetchurl stdenv pkgconfig perl perlXMLParser libxml2 openssl nss
       gtkspell aspell gettext ncurses avahi dbus dbus_glib python


### PR DESCRIPTION
This adds the RSS/Atom feedparser `canto-curses` and its daemon `canto-daemon`.

The daemon is realized with a systemd user service and can be activated via `services.canto-daemon.enable = true`.
