### PR TITLE
Add io.js

### DIFF
--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, python, utillinux, nightly ? false }:
+
+let
+  version = if nightly then "1.1.1-nightly201502072c3121c606" else "1.1.0";
+  inherit (stdenv.lib) optional maintainers licenses platforms;
+in stdenv.mkDerivation {
+  name = "iojs-${version}";
+
+  src = fetchurl {
+    url = if nightly
+          then "https://iojs.org/download/nightly/v${version}/iojs-v${version}.tar.gz"
+          else "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
+    sha256 = if nightly
+             then "1jjh5f8kpcgdjjib9q1f2hqvrs6p4m4fyfbfy6dsdbzl2hglajvw"
+             else "0yvz3rw7d73snc1g447l4amqbbyydbyzr9ynykmyld7l3gdsif7h";
+  };
+
+  prePatch = ''
+    sed -e 's|^#!/usr/bin/env python$|#!${python}/bin/python|g' -i configure
+  '';
+
+  buildInputs = [ python ] ++ (optional stdenv.isLinux utillinux);
+  setupHook = ../nodejs/setup-hook.sh;
+
+  meta = {
+    description = "A friendly fork of Node.js with an open governance model";
+    homepage = https://iojs.org/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, python, utillinux, nightly ? false }:
 
 let
-  version = if nightly then "1.1.1-nightly201502072c3121c606" else "1.1.0";
+  version = if nightly then "1.2.1-nightly20150213f0296933f8" else "1.2.0";
   inherit (stdenv.lib) optional maintainers licenses platforms;
 in stdenv.mkDerivation {
   name = "iojs-${version}";
@@ -11,8 +11,8 @@ in stdenv.mkDerivation {
           then "https://iojs.org/download/nightly/v${version}/iojs-v${version}.tar.gz"
           else "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
     sha256 = if nightly
-             then "1jjh5f8kpcgdjjib9q1f2hqvrs6p4m4fyfbfy6dsdbzl2hglajvw"
-             else "0yvz3rw7d73snc1g447l4amqbbyydbyzr9ynykmyld7l3gdsif7h";
+             then "0v9njaggddi128v58rd34qknph8pn9c653gqd4y29l1mwjvqg62s"
+             else "17axqswpl252gliak1wjc2l9jk6n5jqdfa9f1vv7x9acj776yrik";
   };
 
   prePatch = ''

--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, utillinux, nightly ? false }:
+{ stdenv, fetchurl, python, utillinux, openssl, http-parser, zlib, nightly ? false }:
 
 let
   version = if nightly then "1.2.1-nightly20150213f0296933f8" else "1.2.0";
@@ -19,7 +19,9 @@ in stdenv.mkDerivation {
     sed -e 's|^#!/usr/bin/env python$|#!${python}/bin/python|g' -i configure
   '';
 
-  buildInputs = [ python ] ++ (optional stdenv.isLinux utillinux);
+  configureFlags = [ "--shared-openssl" "--shared-http-parser" "--shared-zlib" ];
+
+  buildInputs = [ python openssl http-parser zlib ] ++ (optional stdenv.isLinux utillinux);
   setupHook = ../nodejs/setup-hook.sh;
 
   meta = {

--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -38,7 +38,7 @@ let
 
   sources = runCommand "node-sources" {} ''
     tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
-    mv *node* $out
+    mv $(find . -type d -mindepth 1 -maxdepth 1) $out
   '';
 
   # Convert deps to attribute set

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1729,6 +1729,13 @@ let
     callPackage ./node-packages.nix { self = nodePackages; }
   );
 
+  iojs = callPackage ../development/web/iojs { };
+  iojs-nightly = callPackage ../development/web/iojs { nightly = true; };
+
+  iojsPackages = recurseIntoAttrs (
+    callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; }
+  );
+
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
   ldns = callPackage ../development/libraries/ldns { };


### PR DESCRIPTION
https://iojs.org/

I copied a bit `nodejs/default.nix` to make the io.js derivation, though It's my first "real" package and I don't know how to handle eventual shared dependencies, and I removed Darwin specific stuff since I have no Mac to try it.

I successfully built io.js both stable and nightly with this derivation on NixOS.

Also since io.js is Node.js compatible, there's maybe more to do, for example allow to build npm packages with io.js instead of Node.js (not sure this is possible actually, maybe something like `nodePackages.override { nodejs = iojs }` could work?).
