### PR TITLE
Fix boost 1.55 on clang (1.56 onwards already have the fix)

### DIFF
--- a/pkgs/development/libraries/boost/1.55.nix
+++ b/pkgs/development/libraries/boost/1.55.nix
@@ -3,6 +3,8 @@
 callPackage ./generic.nix (args // rec {
   version = "1.55.0";
 
+  patches = [ ./clang-math.patch ./clang-math-2.patch ];
+
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_55_0.tar.bz2";
     sha256 = "0lkv5dzssbl5fmh2nkaszi8x9qbj80pr4acf9i26sj3rvlih1w7z";

--- a/pkgs/development/libraries/boost/clang-math-2.patch
+++ b/pkgs/development/libraries/boost/clang-math-2.patch
@@ -1,0 +1,45 @@
+From 6bb71fdd8f7cc346d90fb14beb38b7297fc1ffd9 Mon Sep 17 00:00:00 2001
+From: Andrey Semashev <andrey.semashev@gmail.com>
+Date: Sun, 26 Jan 2014 13:58:48 +0400
+Subject: [PATCH] Fixed incorrect initialization of 128-bit values, when no
+ native support for 128-bit integers is available.
+
+---
+ boost/atomic/detail/cas128strong.hpp | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/boost/atomic/detail/cas128strong.hpp b/boost/atomic/detail/cas128strong.hpp
+index 906c13e..dcb4d7d 100644
+--- a/boost/atomic/detail/cas128strong.hpp
++++ b/boost/atomic/detail/cas128strong.hpp
+@@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void
+     store(value_type const& value, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type value_s = 0;
++        storage_type value_s;
++        memset(&value_s, 0, sizeof(value_s));
+         memcpy(&value_s, &value, sizeof(value_type));
+         platform_fence_before_store(order);
+         platform_store128(value_s, &v_);
+@@ -247,7 +249,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+ 

--- a/pkgs/development/libraries/boost/clang-math.patch
+++ b/pkgs/development/libraries/boost/clang-math.patch
@@ -1,0 +1,65 @@
+From e4bde20f2eec0a51be14533871d2123bd2ab9cf3 Mon Sep 17 00:00:00 2001
+From: Andrey Semashev <andrey.semashev@gmail.com>
+Date: Fri, 28 Feb 2014 12:43:11 +0400
+Subject: [PATCH] More compilation fixes for the case when 128-bit integers are
+ not supported.
+
+---
+ boost/atomic/detail/gcc-atomic.hpp | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/boost/atomic/detail/gcc-atomic.hpp b/boost/atomic/detail/gcc-atomic.hpp
+index a130590..4af99a1 100644
+--- a/boost/atomic/detail/gcc-atomic.hpp
++++ b/boost/atomic/detail/gcc-atomic.hpp
+@@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void store(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         __atomic_store_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+     }
+@@ -980,7 +982,8 @@ class base_atomic<T, void, 16, Sign>
+ 
+     value_type exchange(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         tmp = __atomic_exchange_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+         value_type res;
+@@ -994,7 +997,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, false,
+@@ -1010,7 +1015,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, true,

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -9,6 +9,7 @@
 , enablePIC ? false
 , enableExceptions ? false
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
+, patches ? null
 , mpi ? null
 
 # Attributes inherit from specific versions
@@ -114,7 +115,7 @@ in
 stdenv.mkDerivation {
   name = "boost-${version}";
 
-  inherit src;
+  inherit src patches;
 
   meta = {
     homepage = "http://boost.org/";


### PR DESCRIPTION
More of the pure-darwin changes. I'm not sure if this rebuilds the world. I _think_ the patches are innocuous for gcc, but if necessary I can guard them.

See https://trac.macports.org/ticket/42282 for more.

cc @shlevy (who might be able to make me a hydra jobset for this) @joelteon (who originally wrote this)
