### PR TITLE
Properly build GHC 7.x and some packages in the Darwin sandbox

### DIFF
--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ghc perl gmp ncurses ];
 
+  enableParallelBuilding = true;
+
   buildMK = ''
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp}/include"
@@ -45,6 +47,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://haskell.org/ghc";
     description = "The Glasgow Haskell Compiler";
+    broken = stdenv.isDarwin;
     maintainers = [
       stdenv.lib.maintainers.marcweber
       stdenv.lib.maintainers.andres

--- a/pkgs/development/compilers/ghc/7.10.1.nix
+++ b/pkgs/development/compilers/ghc/7.10.1.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ghc, perl, gmp, ncurses }:
+{ stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv }:
 
 let
 
@@ -7,7 +7,10 @@ let
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses}/lib"
-    DYNAMIC_BY_DEFAULT = NO
+    ${stdenv.lib.optionalString stdenv.isDarwin ''
+      libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
+      libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
+    ''}
   '';
 
 in
@@ -23,11 +26,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ghc perl ];
 
+  enableParallelBuilding = true;
+
   preConfigure = ''
     echo >mk/build.mk "${buildMK}"
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS+=" -no_dtrace_dof"
   '';
 
   configureFlags = [
@@ -35,11 +42,9 @@ stdenv.mkDerivation rec {
     "--with-gmp-includes=${gmp}/include" "--with-gmp-libraries=${gmp}/lib"
   ];
 
-  enableParallelBuilding = true;
-
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
-  stripDebugFlags = [ "-S" "--keep-file-symbols" ];
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
   meta = {
     homepage = "http://haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   # required, because otherwise all symbols from HSffi.o are stripped, and
   # that in turn causes GHCi to abort
-  stripDebugFlags=["-S" "--keep-file-symbols"];
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
 
   meta = {
     homepage = "http://haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/fix-7.0.4-clang.patch
+++ b/pkgs/development/compilers/ghc/fix-7.0.4-clang.patch
@@ -14,7 +14,7 @@ index f704a69..37753fd 100644
  
  stack_layout :: [(VirtualSpOffset, CgIdInfo)]
 diff --git a/compiler/main/GHC.hs b/compiler/main/GHC.hs
-index 638e1db..a24e564 100644
+index 638e1db..0aee4b7 100644
 --- a/compiler/main/GHC.hs
 +++ b/compiler/main/GHC.hs
 @@ -788,8 +788,7 @@ load2 how_much mod_graph = do
@@ -27,6 +27,16 @@ index 638e1db..a24e564 100644
  		  List.init partial_mg0
  		| otherwise
  		= partial_mg0
+@@ -879,8 +878,7 @@ load2 how_much mod_graph = do
+ 	      liftIO $ cleanTempFilesExcept dflags (ppFilesFromSummaries mods_to_keep)
+ 
+ 	      -- there should be no Nothings where linkables should be, now
+-	      ASSERT(all (isJust.hm_linkable) 
+-			(eltsUFM (hsc_HPT hsc_env))) do
++	      ASSERT(all (isJust.hm_linkable) (eltsUFM (hsc_HPT hsc_env))) do
+ 	
+ 	      -- Link everything together
+               linkresult <- liftIO $ link (ghcLink dflags) dflags False hpt4
 diff --git a/compiler/simplCore/SimplUtils.lhs b/compiler/simplCore/SimplUtils.lhs
 index 99a63e4..3268726 100644
 --- a/compiler/simplCore/SimplUtils.lhs


### PR DESCRIPTION
For GHC 6.x, `cannot bootstrap GHC on this platform` so I left it alone.
