### PR TITLE
types.nix: better error message for non-paths

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -103,7 +103,8 @@ rec {
     path = mkOptionType {
       name = "path";
       # Hacky: there is no ‘isPath’ primop.
-      check = x: builtins.substring 0 1 (toString x) == "/";
+      # need to check isString first because otherwise toString throws an error.
+      check = x: builtins.isString x && builtins.substring 0 1 (toString x) == "/";
       merge = mergeOneOption;
     };
 

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -57,7 +57,7 @@ in
     environment = {
 
       systemPackages = mkOption {
-        type = types.listOf types.path;
+        type = types.listOf types.package;
         default = [];
         example = literalExample "[ pkgs.firefox pkgs.thunderbird ]";
         description = ''


### PR DESCRIPTION
This improves error messages when a set or a list is used where a path
was expected. For an example, if you used a package set (as opposed to a
single package) in systemPackages before this commit, the error was:

```
cannot coerce a list to a string, at "/home/nixpkgs/lib/types.nix":103:37
```

Now, the error message reads:

```
The option value `environment.systemPackages' in `/etc/nixos/configuration.nix' is not a list of paths.
```
