### PR TITLE
Add cdemu packages and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -144,6 +144,7 @@
   ./services/games/minecraft-server.nix
   ./services/hardware/acpid.nix
   ./services/hardware/amd-hybrid-graphics.nix
+  ./services/hardware/cdemu.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/freefall.nix
   ./services/hardware/nvidia-optimus.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -55,6 +55,7 @@
   ./programs/atop.nix
   ./programs/bash/bash.nix
   ./programs/blcr.nix
+  ./programs/cdemu.nix
   ./programs/command-not-found/command-not-found.nix
   ./programs/dconf.nix
   ./programs/environment.nix
@@ -144,7 +145,6 @@
   ./services/games/minecraft-server.nix
   ./services/hardware/acpid.nix
   ./services/hardware/amd-hybrid-graphics.nix
-  ./services/hardware/cdemu.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/freefall.nix
   ./services/hardware/nvidia-optimus.nix

--- a/nixos/modules/programs/cdemu.nix
+++ b/nixos/modules/programs/cdemu.nix
@@ -2,11 +2,11 @@
 
 with lib;
 
-let cfg = config.services.cdemu;
+let cfg = config.programs.cdemu;
 in {
 
   options = {
-    services.cdemu = {
+    programs.cdemu = {
       enable = mkOption {
         default = false;
         description = "Whether to enable cdemu for users of appropriate group (default cdrom)";

--- a/nixos/modules/services/hardware/cdemu.nix
+++ b/nixos/modules/services/hardware/cdemu.nix
@@ -9,41 +9,41 @@ in {
     services.cdemu = {
       enable = mkOption {
         default = false;
-	description = "Whether to enable cdemu for users of appropriate group (default cdrom)";
+        description = "Whether to enable cdemu for users of appropriate group (default cdrom)";
       };
       group = mkOption {
         default = "cdrom";
-	description = "Required group for users of cdemu";
+        description = "Required group for users of cdemu";
       };
       gui = mkOption {
         default = true;
-	description = "Whether to install cdemu GUI (gCDEmu)";
+        description = "Whether to install cdemu GUI (gCDEmu)";
       };
       image-analyzer = mkOption {
         default = true;
-	description = "Whether to install image analyzer";
+        description = "Whether to install image analyzer";
       };
     };
   };
 
   config = mkIf cfg.enable {
-  
+
     boot = {
       extraModulePackages = [ pkgs.linuxPackages.vhba ];
       kernelModules = [ "vhba" ];
     };
-    
+
     services = {
       udev.extraRules = ''
         KERNEL=="vhba_ctl", MODE="0660", OWNER="root", GROUP="${cfg.group}"
       '';
       dbus.packages = [ pkgs.cdemu-daemon ];
     };
-    
+
     environment.systemPackages =
       [ pkgs.cdemu-daemon pkgs.cdemu-client ]
       ++ optional cfg.gui pkgs.gcdemu
       ++ optional cfg.image-analyzer pkgs.image-analyzer;
   };
-  
+
 }

--- a/nixos/modules/services/hardware/cdemu.nix
+++ b/nixos/modules/services/hardware/cdemu.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.cdemu;
+in {
+
+  options = {
+    services.cdemu = {
+      enable = mkOption {
+        default = false;
+	description = "Whether to enable cdemu for users of appropriate group (default cdrom)";
+      };
+      group = mkOption {
+        default = "cdrom";
+	description = "Required group for users of cdemu";
+      };
+      gui = mkOption {
+        default = true;
+	description = "Whether to install cdemu GUI (gCDEmu)";
+      };
+      image-analyzer = mkOption {
+        default = true;
+	description = "Whether to install image analyzer";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+  
+    boot = {
+      extraModulePackages = [ pkgs.linuxPackages.vhba ];
+      kernelModules = [ "vhba" ];
+    };
+    
+    services = {
+      udev.extraRules = ''
+        KERNEL=="vhba_ctl", MODE="0660", OWNER="root", GROUP="${cfg.group}"
+      '';
+      dbus.packages = [ pkgs.cdemu-daemon ];
+    };
+    
+    environment.systemPackages =
+      [ pkgs.cdemu-daemon pkgs.cdemu-client ]
+      ++ optional cfg.gui pkgs.gcdemu
+      ++ optional cfg.image-analyzer pkgs.image-analyzer;
+  };
+  
+}

--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,0 +1,15 @@
+{ callPackage, gtk3, libxml2, gnuplot, makeWrapper, stdenv }:
+let pkg = import ./base.nix {
+  version = "3.0.0";
+  pkgName = "image-analyzer";
+  pkgSha256 = "1rb3f7c08dxc02zrwrkfvq7qlzlmm0kd2ah1fhxj6ajiyshi8q4v";
+};
+in callPackage pkg {
+  buildInputs = [ gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper ];
+  drvParams = {
+    postFixup = ''
+      wrapProgram $out/bin/image-analyzer \
+        --set XDG_DATA_DIRS "$out/share:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS"
+    '';
+  };
+}

--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -9,7 +9,7 @@ in callPackage pkg {
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/image-analyzer \
-        --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS"
+        --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
     '';
   };
 }

--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,15 +1,15 @@
-{ callPackage, gtk3, libxml2, gnuplot, makeWrapper, stdenv }:
+{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv }:
 let pkg = import ./base.nix {
   version = "3.0.0";
   pkgName = "image-analyzer";
   pkgSha256 = "1rb3f7c08dxc02zrwrkfvq7qlzlmm0kd2ah1fhxj6ajiyshi8q4v";
 };
 in callPackage pkg {
-  buildInputs = [ gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper ];
+  buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/image-analyzer \
-        --set XDG_DATA_DIRS "$out/share:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS"
+        --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS"
     '';
   };
 }

--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,11 +1,11 @@
-{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv, gnome3 }:
+{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv, gnome3, gdk_pixbuf, librsvg }:
 let pkg = import ./base.nix {
   version = "3.0.0";
   pkgName = "image-analyzer";
   pkgSha256 = "1rb3f7c08dxc02zrwrkfvq7qlzlmm0kd2ah1fhxj6ajiyshi8q4v";
 };
 in callPackage pkg {
-  buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper gnome3.gnome_icon_theme_symbolic ];
+  buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper gnome3.gnome_icon_theme_symbolic gnome3.gnome_icon_theme gdk_pixbuf librsvg ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/image-analyzer \

--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,11 +1,11 @@
-{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv }:
+{ callPackage, gtk3, glib, libxml2, gnuplot, makeWrapper, stdenv, gnome3 }:
 let pkg = import ./base.nix {
   version = "3.0.0";
   pkgName = "image-analyzer";
   pkgSha256 = "1rb3f7c08dxc02zrwrkfvq7qlzlmm0kd2ah1fhxj6ajiyshi8q4v";
 };
 in callPackage pkg {
-  buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper ];
+  buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper gnome3.gnome_icon_theme_symbolic ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/image-analyzer \

--- a/pkgs/misc/emulators/cdemu/base.nix
+++ b/pkgs/misc/emulators/cdemu/base.nix
@@ -1,0 +1,37 @@
+{ pkgName, version, pkgSha256 }:
+{ stdenv, fetchurl, cmake, pkgconfig, buildInputs, drvParams ? {} }:
+let name = "${pkgName}-${version}";
+in stdenv.mkDerivation ({
+  inherit name buildInputs;
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/cdemu/${name}.tar.bz2";
+    sha256 = pkgSha256;
+  };
+  nativeBuildInputs = [ pkgconfig cmake ];
+  setSourceRoot = ''
+    mkdir build
+    cd build
+    sourceRoot="`pwd`"
+  '';
+  configurePhase = ''
+    cmake ../${name} -DCMAKE_INSTALL_PREFIX=$out -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_RPATH=ON
+  '';
+  meta = {
+    description = "CDemu is a software suite designed to emulate an optical drive and disc (including CD-ROMs and DVD-ROMs) on the Linux operating system.";
+    longDescription = ''
+      CDEmu consists of:
+
+      - a kernel module implementing a virtual drive-controller
+      - libmirage which is a software library for interpreting optical disc images
+      - a daemon which emulates the functionality of an optical drive+disc
+      - textmode and GTK clients for controlling the emulator
+      - an image analyzer to view the structure of image files
+
+      Optical media emulated by CDemu can be mounted within Linux. Automounting is also allowed.
+    '';
+    homepage = "http://cdemu.sourceforge.net/";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ "Rok Mandeljc <mrok AT users DOT sourceforge DOT net>" ];
+  };
+} // drvParams)

--- a/pkgs/misc/emulators/cdemu/client.nix
+++ b/pkgs/misc/emulators/cdemu/client.nix
@@ -1,0 +1,15 @@
+{ callPackage, python, dbus_python, intltool, makeWrapper }:
+let pkg = import ./base.nix {
+  version = "3.0.0";
+  pkgName = "cdemu-client";
+  pkgSha256 = "125f6j7c52a0c7smbx323vdpwhx24yl0vglkiyfcbm92fjji14rm";
+};
+in callPackage pkg {
+  buildInputs = [ python dbus_python intltool makeWrapper ];
+  drvParams = {
+    postFixup = ''
+      wrapProgram $out/bin/cdemu \
+        --set PYTHONPATH "$PYTHONPATH"
+    '';
+  };
+}

--- a/pkgs/misc/emulators/cdemu/daemon.nix
+++ b/pkgs/misc/emulators/cdemu/daemon.nix
@@ -1,0 +1,9 @@
+{ callPackage, glib, libao }:
+let pkg = import ./base.nix {
+  version = "3.0.2";
+  pkgName = "cdemu-daemon";
+  pkgSha256 = "01jg9b1nkqrbh6binfcbyraz83s9yjavgwi3y4w1bmqg5qlhv6lc";
+};
+in callPackage pkg {
+  buildInputs = [ glib libao (callPackage ./libmirage.nix {}) ];
+}

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -1,11 +1,11 @@
-{ callPackage, python, pygobject3, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection }:
+{ callPackage, python, pygobject3, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection, gnome3 }:
 let pkg = import ./base.nix {
   version = "3.0.0";
   pkgName = "gcdemu";
   pkgSha256 = "1m5ab325r586v2y2d93a817phn6wck67y5mfkf948mph40ks0mqk";
 };
 in callPackage pkg {
-  buildInputs = [ python pygobject3 gtk3 glib libnotify intltool makeWrapper ];
+  buildInputs = [ python pygobject3 gtk3 glib libnotify intltool makeWrapper gnome3.gnome_icon_theme_symbolic ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/gcdemu \

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -1,0 +1,18 @@
+{ callPackage, python, pygobject3, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection }:
+let pkg = import ./base.nix {
+  version = "3.0.0";
+  pkgName = "gcdemu";
+  pkgSha256 = "1m5ab325r586v2y2d93a817phn6wck67y5mfkf948mph40ks0mqk";
+};
+in callPackage pkg {
+  buildInputs = [ python pygobject3 gtk3 glib libnotify intltool makeWrapper ];
+  drvParams = {
+    postFixup = ''
+      wrapProgram $out/bin/gcdemu \
+        --set PYTHONPATH "$PYTHONPATH" \
+	--set GI_TYPELIB_PATH "$GI_TYPELIB_PATH" \
+	--set XDG_DATA_DIRS "$out/share:$XDG_DATA_DIRS"
+    '';  
+    # TODO AppIndicator
+  };
+}

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -11,7 +11,7 @@ in callPackage pkg {
       wrapProgram $out/bin/gcdemu \
         --set PYTHONPATH "$PYTHONPATH" \
         --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH" \
-        --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS"
+        --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
     '';
     # TODO AppIndicator
   };

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -11,7 +11,7 @@ in callPackage pkg {
       wrapProgram $out/bin/gcdemu \
         --set PYTHONPATH "$PYTHONPATH" \
         --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH" \
-        --set XDG_DATA_DIRS "$out/share:$XDG_DATA_DIRS"
+        --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS"
     '';
     # TODO AppIndicator
   };

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -10,9 +10,9 @@ in callPackage pkg {
     postFixup = ''
       wrapProgram $out/bin/gcdemu \
         --set PYTHONPATH "$PYTHONPATH" \
-	--set GI_TYPELIB_PATH "$GI_TYPELIB_PATH" \
-	--set XDG_DATA_DIRS "$out/share:$XDG_DATA_DIRS"
-    '';  
+        --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH" \
+        --set XDG_DATA_DIRS "$out/share:$XDG_DATA_DIRS"
+    '';
     # TODO AppIndicator
   };
 }

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -1,11 +1,11 @@
-{ callPackage, python, pygobject3, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection, gnome3 }:
+{ callPackage, python, pygobject3, gtk3, glib, libnotify, intltool, makeWrapper, gobjectIntrospection, gnome3, gdk_pixbuf, librsvg }:
 let pkg = import ./base.nix {
   version = "3.0.0";
   pkgName = "gcdemu";
   pkgSha256 = "1m5ab325r586v2y2d93a817phn6wck67y5mfkf948mph40ks0mqk";
 };
 in callPackage pkg {
-  buildInputs = [ python pygobject3 gtk3 glib libnotify intltool makeWrapper gnome3.gnome_icon_theme_symbolic ];
+  buildInputs = [ python pygobject3 gtk3 glib libnotify intltool makeWrapper gnome3.gnome_icon_theme_symbolic gnome3.gnome_icon_theme gdk_pixbuf librsvg ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/gcdemu \

--- a/pkgs/misc/emulators/cdemu/libmirage.nix
+++ b/pkgs/misc/emulators/cdemu/libmirage.nix
@@ -1,0 +1,9 @@
+{ callPackage, glib, libsndfile, zlib, bzip2, lzma, libsamplerate }:
+let pkg = import ./base.nix {
+  version = "3.0.3";
+  pkgName = "libmirage";
+  pkgSha256 = "03idg94h5qhmnnc8g9dw8yqf14yv2paph5n77dfmg925f3z70nyn";
+};
+in callPackage pkg {
+  buildInputs = [ glib libsndfile zlib bzip2 lzma libsamplerate ];
+}

--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchurl, kernel }:
+let version = "20140928";
+in stdenv.mkDerivation {
+  name = "vhba-${version}";
+  src  = fetchurl {
+    url = "http://downloads.sourceforge.net/cdemu/vhba-module-${version}.tar.bz2";
+    sha256 = "18jmpg2kpx87f32b8aprr1pxla9dlhf901rkj1sp3ammf94nxxa5";
+  };
+  preBuild = ''
+    makeFlags="KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build INSTALL_MOD_PATH=$out";
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -686,6 +686,14 @@ let
 
   catdoc = callPackage ../tools/text/catdoc { };
 
+  cdemu-daemon = callPackage ../misc/emulators/cdemu/daemon.nix { };
+
+  cdemu-client = callPackage ../misc/emulators/cdemu/client.nix { };
+
+  gcdemu = callPackage ../misc/emulators/cdemu/gui.nix { };
+
+  image-analyzer = callPackage ../misc/emulators/cdemu/analyzer.nix { };
+
   ccnet = callPackage ../tools/networking/ccnet { };
 
   cloud-init = callPackage ../tools/virtualization/cloud-init { };
@@ -8797,6 +8805,8 @@ let
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };
 
     v86d = callPackage ../os-specific/linux/v86d { };
+
+    vhba = callPackage ../misc/emulators/cdemu/vhba.nix { };
 
     virtualbox = callPackage ../applications/virtualization/virtualbox {
       stdenv = stdenv_32bit;


### PR DESCRIPTION
This adds cdemu to nixos. Everything works for me, but it is my first contribution, so there might be some stylistic issues. Especially the desktop integration is a bit fishy. Maybe somebody with experience in packaging gnome apps will know a better way to set up the gtk3 gsettings schemas for the image analyzer.
