### PR TITLE
[RFC] Stop writing to obsolete /proc/sys/kernel/hotplug

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -236,8 +236,6 @@ in
 
     system.activationScripts.udevd =
       ''
-        echo "" > /proc/sys/kernel/hotplug
-
         # Regenerate the hardware database /var/lib/udev/hwdb.bin
         # whenever systemd changes.
         if [ ! -e /var/lib/udev/prev-systemd -o "$(readlink /var/lib/udev/prev-systemd)" != ${config.systemd.package} ]; then

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -263,6 +263,9 @@ with stdenv.lib;
   SLIP_COMPRESSED y # CSLIP compressed headers
   SLIP_SMART y
   THERMAL_HWMON y # Hardware monitoring support
+  ${optionalString (versionAtLeast version "3.15") ''
+    UEVENT_HELPER n
+  ''}
   USB_DEBUG? n
   USB_EHCI_ROOT_HUB_TT y # Root Hub Transaction Translators
   USB_EHCI_TT_NEWSCHED y # Improved transaction translator scheduling


### PR DESCRIPTION
[It's been deprecated since 2006](http://lwn.net/Articles/166954/) and spews errors on custom kernels. NixOS doesn't use it. Arch doesn't have it.

Any legitimate users left?
