### PR TITLE
Fix initial-install issues with couchdb.nix.

### DIFF
--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -131,8 +131,8 @@ in {
         type = types.string;
         default = "/var/lib/couchdb/couchdb.ini";
         description = ''
-          Custom configuration file. File needs to be readable and writable
-          from couchdb user/group.
+          Configuration file for persisting runtime changes. File
+          needs to be readable and writable from couchdb user/group.
         '';
       };
 
@@ -157,12 +157,15 @@ in {
         mkdir -p ${cfg.databaseDir};
         mkdir -p ${cfg.viewIndexDir};
         touch ${cfg.configFile}
+        touch -a ${cfg.logFile}
 
         if [ "$(id -u)" = 0 ]; then
-          chown ${cfg.user}:${cfg.group} ${cfg.uriFile}
+          chown ${cfg.user}:${cfg.group} `dirname ${cfg.uriFile}`;
+          (-f ${cfg.uriFile} && chown ${cfg.user}:${cfg.group} ${cfg.uriFile}) || true
           chown ${cfg.user}:${cfg.group} ${cfg.databaseDir}
           chown ${cfg.user}:${cfg.group} ${cfg.viewIndexDir}
           chown ${cfg.user}:${cfg.group} ${cfg.configFile}
+          chown ${cfg.user}:${cfg.group} ${cfg.logFile}
         fi
         '';
 


### PR DESCRIPTION
When starting from a clean slate, the couchdb service fails.

First, the pre-start script fails because it tries to chown the uriFile,
which doesn't exist.  It also doesn't ensure that the directory in which
the uriFIle is placed is writeable by couchdb, which could also cause
failure (though I didn't observe this).

Additionally, the log file's default location isn't a directory owned by
couchdb, nor is the file guaranteed to exist, nor is it guaranteed to be
chowned to the appropriate user.  All of which can cause unexpected
failure.

As a bonus I made a small change in the description of the configFile
attribute, in the hopes of making it a little more obvious why it
existed.
