### PR TITLE
Add Calamares: A distribution independent installer framework.

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation {
   configureScript = "./bootstrap.sh";
   configureFlags = commonConfigureFlags ++ [
     "--with-icu=${icu}"
-    "--with-python=${python}/bin/python"
+    "--with-python=${python.interpreter}"
   ] ++ optional (toolset != null) "--with-toolset=${toolset}";
 
   buildPhase = builder nativeB2Args;

--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, cmake, boost }:
+{ stdenv, fetchurl, cmake, boost, makePIC ? false }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   name = "libyaml-cpp-0.5.1";
 
   src = fetchurl {
@@ -17,4 +17,6 @@ stdenv.mkDerivation {
     platforms = platforms.unix;
     maintainers = with maintainers; [ wkennington ];
   };
-}
+} // (if makePIC then {
+  cmakeFlags = [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ];
+} else {}))

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, cmake, qt5, polkit_qt5, libyamlcpp, python, boost, parted }:
+
+stdenv.mkDerivation rec {
+  name = "calamares-${version}";
+  version = "1.0";
+
+  src = fetchgit {
+    url = "https://github.com/calamares/calamares.git";
+    rev = "dabfb68a68cb012a90cd7b94a22e1ea08f7dd8ad";
+    sha256 = "2851ce487aaac61d2df342a47f91ec87fe52ff036227ef697caa7056fe5f188c";
+  };
+
+  buildInputs = [
+    cmake qt5 libyamlcpp python boost polkit_qt5 parted
+  ];
+
+  cmakeFlags = [
+    "-DPYTHON_LIBRARY=${python}/lib/libpython${python.majorVersion}m.so"
+    "-DPYTHON_INCLUDE_DIR=${python}/include/python${python.majorVersion}m"
+  ];
+
+  preInstall = ''
+    substituteInPlace cmake_install.cmake --replace "${polkit_qt5}" "$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Distribution-independent installer framework";
+    license = licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ tstrobel ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1449,6 +1449,12 @@ let
     ghostscript = null;
   };
 
+  calamares = callPackage ../tools/misc/calamares rec {
+    python = python3;
+    boost = callPackage ../development/libraries/boost/1.57.nix { python=python3; };
+    libyamlcpp = callPackage ../development/libraries/libyaml-cpp { makePIC=true; boost=boost; };
+  };
+
   grub = callPackage_i686 ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
   };


### PR DESCRIPTION
The PR adapts boost lib as well, so it probably expensive to merge.
