### PR TITLE
Enable kernel configuration option FANOTIFY

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -147,6 +147,7 @@ with stdenv.lib;
 
   # Filesystem options - in particular, enable extended attributes and
   # ACLs for all filesystems that support them.
+  FANOTIFY y
   EXT2_FS_XATTR y
   EXT2_FS_POSIX_ACL y
   EXT2_FS_SECURITY y

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -49,7 +49,6 @@ with stdenv.lib;
   NUMA? y
 
   # Disable some expensive (?) features.
-  FTRACE n
   KPROBES n
   PM_TRACE_RTC n
 


### PR DESCRIPTION
Makes fatrace work out of the box without having to compile a whole custom kernel.
