### PR TITLE
Merge nix-shell and build environments of haskell derivations

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -15,8 +15,13 @@ let
   haskellPackages = self:
     let
 
+      withPackagesBuilder = pkgs.callPackage ./with-packages-builder.nix {
+        inherit (self) ghc;
+        inherit (pkgs) makeWrapper perl;
+      };
+
       mkDerivation = pkgs.callPackage ./generic-builder.nix {
-        inherit stdenv;
+        inherit stdenv withPackagesBuilder;
         inherit (pkgs) fetchurl pkgconfig glibcLocales coreutils gnugrep gnused;
         inherit (self) ghc jailbreak-cabal;
         hscolour = overrideCabal self.hscolour (drv: {
@@ -54,7 +59,11 @@ let
 
         inherit mkDerivation callPackage;
 
-        ghcWithPackages = pkgs: callPackage ./with-packages-wrapper.nix { packages = pkgs self; };
+        ghcWithPackages = pkgs: callPackage ./with-packages-wrapper.nix {
+          packages = pkgs self;
+          inherit withPackagesBuilder;
+          inherit (ghc) version meta;
+        };
 
         ghc = ghc // { withPackages = self.ghcWithPackages; };
 

--- a/pkgs/development/haskell-modules/with-packages-builder.nix
+++ b/pkgs/development/haskell-modules/with-packages-builder.nix
@@ -1,0 +1,57 @@
+{ ghc, lib, makeWrapper, perl }:
+let
+  ghc761OrLater = lib.versionOlder "7.6.1" ghc.version;
+  packageDBFlag = if ghc761OrLater then "--global-package-db" else "--global-conf";
+  libDir        = "$out/lib/ghc-${ghc.version}";
+  docDir        = "$out/share/doc/ghc/html";
+  packageCfgDir = "${libDir}/package.conf.d";
+in { ignoreCollisions, paths }:
+if paths == [] then "ln -s ${ghc} $out" else ''
+export pathsToLink="/"
+export manifest=""
+export paths="${lib.concatStringsSep " " (paths ++ [ghc])}"
+export ignoreCollisions="${builtins.toString ignoreCollisions}"
+. ${makeWrapper}/nix-support/setup-hook
+
+${perl}/bin/perl -w ${../../build-support/buildenv/builder.pl}
+
+if test -L "$out/bin"; then
+  binTarget="$(readlink -f "$out/bin")"
+  rm "$out/bin"
+  cp -r "$binTarget" "$out/bin"
+  chmod u+w "$out/bin"
+fi
+
+for prg in ghc ghci ghc-${ghc.version} ghci-${ghc.version}; do
+  rm -f $out/bin/$prg
+  makeWrapper ${ghc}/bin/$prg $out/bin/$prg         \
+    --add-flags '"-B$NIX_GHC_LIBDIR"'               \
+    --set "NIX_GHC"        "$out/bin/ghc"           \
+    --set "NIX_GHCPKG"     "$out/bin/ghc-pkg"       \
+    --set "NIX_GHC_DOCDIR" "${docDir}"              \
+    --set "NIX_GHC_LIBDIR" "${libDir}"
+done
+
+for prg in runghc runhaskell; do
+  rm -f $out/bin/$prg
+  makeWrapper ${ghc}/bin/$prg $out/bin/$prg         \
+    --add-flags "-f $out/bin/ghc"                   \
+    --set "NIX_GHC"        "$out/bin/ghc"           \
+    --set "NIX_GHCPKG"     "$out/bin/ghc-pkg"       \
+    --set "NIX_GHC_DOCDIR" "${docDir}"              \
+    --set "NIX_GHC_LIBDIR" "${libDir}"
+done
+
+for prg in ghc-pkg ghc-pkg-${ghc.version}; do
+  rm -f $out/bin/$prg
+  makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "${packageDBFlag}=${packageCfgDir}"
+done
+
+export NIX_GHC=$out/bin/ghc
+export NIC_GHCPKG=$out/bin/ghc-pkg
+export NIX_GHC_DOCDIR="${docDir}"
+export NIX_GHC_LIBDIR="${libDir}"
+
+$out/bin/ghc-pkg recache
+$out/bin/ghc-pkg check
+''

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -1,7 +1,4 @@
-{ stdenv, ghc, packages, buildEnv, makeWrapper, ignoreCollisions ? false }:
-
-# This wrapper works only with GHC 6.12 or later.
-assert stdenv.lib.versionOlder "6.12" ghc.version;
+{ runCommand, lib, version, meta, withPackagesBuilder, packages, ignoreCollisions ? false }:
 
 # It's probably a good idea to include the library "ghc-paths" in the
 # compiler environment, because we have a specially patched version of
@@ -24,59 +21,8 @@ assert stdenv.lib.versionOlder "6.12" ghc.version;
 #     eval $(grep export ~/.nix-profile/bin/ghc)
 #   fi
 
-let
-  ghc761OrLater = stdenv.lib.versionOlder "7.6.1" ghc.version;
-  packageDBFlag = if ghc761OrLater then "--global-package-db" else "--global-conf";
-  libDir        = "$out/lib/ghc-${ghc.version}";
-  docDir        = "$out/share/doc/ghc/html";
-  packageCfgDir = "${libDir}/package.conf.d";
-  isHaskellPkg  = x: (x ? pname) && (x ? version) && (x ? env);
-  paths         = stdenv.lib.filter isHaskellPkg (stdenv.lib.closePropagation packages);
-in
-if paths == [] then ghc else
-buildEnv {
-  inherit (ghc) name;
-  paths = paths ++ [ghc];
+runCommand "buildHaskellEnv" { inherit version meta; preferLocalBuild = true; }
+(withPackagesBuilder {
+  paths = lib.filter (x: (x ? pname) && (x ? version)) (lib.closePropagation packages);
   inherit ignoreCollisions;
-  postBuild = ''
-    . ${makeWrapper}/nix-support/setup-hook
-
-    if test -L "$out/bin"; then
-      binTarget="$(readlink -f "$out/bin")"
-      rm "$out/bin"
-      cp -r "$binTarget" "$out/bin"
-      chmod u+w "$out/bin"
-    fi
-
-    for prg in ghc ghci ghc-${ghc.version} ghci-${ghc.version}; do
-      rm -f $out/bin/$prg
-      makeWrapper ${ghc}/bin/$prg $out/bin/$prg         \
-        --add-flags '"-B$NIX_GHC_LIBDIR"'               \
-        --set "NIX_GHC"        "$out/bin/ghc"           \
-        --set "NIX_GHCPKG"     "$out/bin/ghc-pkg"       \
-        --set "NIX_GHC_DOCDIR" "${docDir}"              \
-        --set "NIX_GHC_LIBDIR" "${libDir}"
-    done
-
-    for prg in runghc runhaskell; do
-      rm -f $out/bin/$prg
-      makeWrapper ${ghc}/bin/$prg $out/bin/$prg         \
-        --add-flags "-f $out/bin/ghc"                   \
-        --set "NIX_GHC"        "$out/bin/ghc"           \
-        --set "NIX_GHCPKG"     "$out/bin/ghc-pkg"       \
-        --set "NIX_GHC_DOCDIR" "${docDir}"              \
-        --set "NIX_GHC_LIBDIR" "${libDir}"
-    done
-
-    for prg in ghc-pkg ghc-pkg-${ghc.version}; do
-      rm -f $out/bin/$prg
-      makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "${packageDBFlag}=${packageCfgDir}"
-    done
-
-    $out/bin/ghc-pkg recache
-    $out/bin/ghc-pkg check
-  '';
-} // {
-  preferLocalBuild = true;
-  inherit (ghc) version meta;
-}
+})


### PR DESCRIPTION
This is an experiment to merge the `.env` and the normal build environment of packages by using `ghcWithPackages` for building too. The duplication of store paths is avoided by building the wrapper in a temporary directory directly while building the derivation itself. The advantages of this approach are:
- You can use `nix-shell` on normal derivations and don't need to deal with the `.env` attribute
- There now is only one approach in Nixpkgs' haskell packaging to make GHC find libraries: building a symlinked package db. This ensures that there is no package that builds but doesn't work with the wrapper.
- We don't need GHC_PACKAGE_PATH, which doesn't work well with cabal-install

I've successfully build all packages from https://github.com/peti/ci/blob/master/haskell-nixpkgs.nix with `big = false` with the new builder. Of course this means that any changes to the wrapper also require recompilation of all haskell packages, but the wrapper doesn't change that often anyway. The wrapper for the old haskellPackages set was changed last in November 2013, for example, which is over a year ago.

/cc @peti and anyone else interrested in haskell nixpkgs packaging.
