### PR TITLE
Link against lua correctly

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.2.nix
+++ b/pkgs/development/interpreters/lua-5/5.2.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     Description: An Extensible Extension Language
     Version: ${version}
     Requires:
-    Libs: -L$out/lib -llua -lm
+    Libs: -L$out/lib -llua.${version} -lm
     Cflags: -I$out/include
     EOF
   '';


### PR DESCRIPTION
Only `liblua.5.2.3.dylib` is produced on Darwin and as far as I can tell this solution should work for Linux too
