### PR TITLE
Update gnupg21 package to gpg-2.1.2

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -5,11 +5,11 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "gnupg-2.1.1";
+  name = "gnupg-2.1.2";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";
-    sha256 = "0jffj23a02gw7gmrh9j9ynp50bvl2pc2y74i9ii65nvm50fx1v3h";
+    sha256 = "14k7c5spai3yppz6izf1ggbnffskl54ln87v1wgy9pwism1mlks0";
   };
 
   patches = [ ./socket-activate-2.1.1.patch ];


### PR DESCRIPTION
This updates the gnupg21 package to gpg-2.1.2.

Unfortunately when building it, gcc gets rebuild on my machine (why the hell?), so I'd prefer someone telling me either how to build it without building the world or someone else testing it (_nice smile_).

I did this because the actually used version (2.1.1) is a development version which shouldn't be used...
