### PR TITLE
stage-1-init: fix PID 1 shell

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -36,7 +36,7 @@ EOF
     read reply
 
     if [ -n "$allowShell" -a "$reply" = f ]; then
-        exec setsid @shell@ -c "@shell@ < /dev/$console >/dev/$console 2>/dev/$console"
+        exec setsid @shell@ -c "exec @shell@ < /dev/$console >/dev/$console 2>/dev/$console"
     elif [ -n "$allowShell" -a "$reply" = i ]; then
         echo "Starting interactive shell..."
         setsid @shell@ -c "@shell@ < /dev/$console >/dev/$console 2>/dev/$console" || fail


### PR DESCRIPTION
The PID 1 shell is executed as the last command in a sh invocation. Some
shells implicitly use exec for that, but the current busybox ash does not,
so the shell gets a wrong PID. Spell out the exec.
