### PR TITLE
gnumeric: make use of GIO_EXTRA_MODULES in wrapper

### DIFF
--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, perl, perlXMLParser
-, goffice, makeWrapper, gtk3, gnome_icon_theme
+, goffice, makeWrapper, gtk3, gnome_icon_theme, gnome3
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
   preFixup = ''
     for f in "$out"/bin/gnumeric-*; do
       wrapProgram $f \
-        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+        --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
     done
     rm $out/share/icons/hicolor/icon-theme.cache
   '';


### PR DESCRIPTION
Gnumeric gave warnings when starting:

```
GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
```

Made this patch based on #5433.
