### PR TITLE
Add fetch-bower to node-packages.json

### DIFF
--- a/pkgs/top-level/node-packages.json
+++ b/pkgs/top-level/node-packages.json
@@ -128,6 +128,7 @@
 , "git-run"
 , "bower"
 , "bower2nix"
+, "fetch-bower"
 , "npm-check-updates"
 , "node-stringprep"
 , "ltx"


### PR DESCRIPTION
Otherwise the `fetchbower` builder won't work. I guess nobody has used it before.

I do need someone to run `npm2nix` on this file and commit the results because git can't fetch anything on my machine. May be a Darwin specific problem.
