### PR TITLE
Update OUnit to version 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ounit/default.nix
+++ b/pkgs/development/ocaml-modules/ounit/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation {
   name = "ounit-2.0.0";
 
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/886/ounit-2.0.0.tar.gz;
-    sha256 = "1qw8k2czy0bxhsf25kfpgywhpqmg7bi57rmyhlnmbddmvc61pg76";
+    url = https://forge.ocamlcore.org/frs/download.php/1258/ounit-2.0.0.tar.gz;
+    sha256 = "118xsadrx84pif9vaq13hv4yh22w9kmr0ypvhrs0viir1jr0ajjd";
   };
 
   buildInputs = [ocaml findlib camlp4];


### PR DESCRIPTION
The existing URL looks like version 2.0.0, but actually
downloads the contents of ounit-1.2.0.tar.gz into a file named
ounit-2.0.0.tar.gz
