### PR TITLE
sox: Patches for CVE-2014-8145

### DIFF
--- a/pkgs/applications/misc/audio/sox/0001-Check-for-minimum-size-sphere-headers.patch
+++ b/pkgs/applications/misc/audio/sox/0001-Check-for-minimum-size-sphere-headers.patch
@@ -1,0 +1,28 @@
+From 55e33019afcb3256cccedf606548b86816f6da59 Mon Sep 17 00:00:00 2001
+From: Chris Bagwell <chris@cnpbagwell.com>
+Date: Sat, 13 Dec 2014 12:48:37 -0600
+Subject: [PATCH 1/2] Check for minimum size sphere headers
+
+---
+ src/sphere.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/sphere.c b/src/sphere.c
+index 479a552..a3fd1c6 100644
+--- a/src/sphere.c
++++ b/src/sphere.c
+@@ -47,6 +47,11 @@ static int start_read(sox_format_t * ft)
+ 
+   /* Determine header size, and allocate a buffer large enough to hold it. */
+   sscanf(fldsval, "%lu", &header_size_ul);
++  if (header_size_ul < 16) {
++    lsx_fail_errno(ft, SOX_EHDR, "Error reading Sphere header");
++    return (SOX_EOF);
++  }
++
+   buf = lsx_malloc(header_size = header_size_ul);
+ 
+   /* Skip what we have read so far */
+-- 
+2.1.0
+

--- a/pkgs/applications/misc/audio/sox/0002-More-checks-for-invalid-MS-ADPCM-blocks.patch
+++ b/pkgs/applications/misc/audio/sox/0002-More-checks-for-invalid-MS-ADPCM-blocks.patch
@@ -1,0 +1,28 @@
+From ebb64cddde59ecc9cedf3741ce2337c72148cc0c Mon Sep 17 00:00:00 2001
+From: Chris Bagwell <chris@cnpbagwell.com>
+Date: Sat, 13 Dec 2014 12:49:55 -0600
+Subject: [PATCH 2/2] More checks for invalid MS ADPCM blocks.
+
+If block doesn't exacty match blockAlign then do not allow
+number of samples in invalid size block to ever be more than
+what WAV header defined as samplesPerBlock.
+---
+ src/wav.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/wav.c b/src/wav.c
+index 61d5908..5202556 100644
+--- a/src/wav.c
++++ b/src/wav.c
+@@ -168,7 +168,7 @@ static unsigned short  AdpcmReadBlock(sox_format_t * ft)
+         /* work with partial blocks.  Specs say it should be null */
+         /* padded but I guess this is better than trailing quiet. */
+         samplesThisBlock = lsx_ms_adpcm_samples_in((size_t)0, (size_t)ft->signal.channels, bytesRead, (size_t)0);
+-        if (samplesThisBlock == 0)
++        if (samplesThisBlock == 0 || samplesThisBlock > wav->samplesPerBlock)
+         {
+             lsx_warn("Premature EOF on .wav input file");
+             return 0;
+-- 
+2.1.0
+

--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -18,6 +18,13 @@ stdenv.mkDerivation rec {
     sha256 = "16x8gykfjdhxg0kdxwzcwgwpm5caa08y2mx18siqsq0ywmpjr34s";
   };
 
+  patches = [
+    # Patches for CVE-2014-8145, found via RedHat bug 1174792.  It was not
+    # clear whether these address a NULL deref and a division by zero.
+    ./0001-Check-for-minimum-size-sphere-headers.patch
+    ./0002-More-checks-for-invalid-MS-ADPCM-blocks.patch
+  ];
+
   buildInputs =
     optional (enableAlsa && stdenv.isLinux) alsaLib ++
     optional enableLibao libao ++


### PR DESCRIPTION
Found via RedHat bug 1174792.  It was not clear whether these address a
NULL dereference and a division by zero.

(Untested; I'll merge if it seems to work.)
