### PR TITLE
replace use of `which` with `command -v` in i3 scripts

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/i3-save-tree" --prefix PERL5LIB ":" "$PERL5LIB"
     mkdir -p $out/man/man1
     cp man/*.1 $out/man/man1
+    for program in $out/bin/i3-sensible-*; do
+      sed -i 's/which/command -v/' $program
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
I haven't tested it, but it is modeled off of https://github.com/bjornfor/nixpkgs/commit/74d631502439ec4e17182e0e812eb030e729dc6c
