### PR TITLE
Allow funcy package to be built under python3 and python2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13510,6 +13510,7 @@ let
     };
   };
 
+
   moreItertools = buildPythonPackage rec {
     name = "more-itertools-2.2";
 
@@ -13529,6 +13530,7 @@ let
     };
   };
 
+
   uncertainties = buildPythonPackage rec {
     name = "uncertainties-2.4.6.1";
 
@@ -13543,6 +13545,23 @@ let
       homepage = "http://pythonhosted.org/uncertainties/";
       description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation)";
       license = licenses.bsd3;
+    };
+  };
+
+
+  funcy = buildPythonPackage rec {
+    name = "funcy-1.4";
+
+    src = pkgs.fetchurl {
+        url = "https://github.com/Suor/funcy/archive/1.4.tar.gz";
+        sha256 = "694e29aa67d03a6ab006f1854740b65f4f87e581afb33853f80e647ddb5f24e7";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Collection of fancy functional tools focused on practicality.";
+      homepage = "http://funcy.readthedocs.org/";
+      license = stdenv.lib.licenses.bsd3;
+
     };
   };
 
@@ -13845,21 +13864,6 @@ let
       homepage = "https://github.com/erikrose/parsimonious";
       description = "Fast arbitrary-lookahead packrat parser written in pure Python.";
       license = licenses.mit;
-    };
-  };
-
-  funcy = buildPythonPackage rec {
-    name = "funcy-1.4";
-
-    src = pkgs.fetchurl {
-        url = "https://github.com/Suor/funcy/archive/1.4.tar.gz";
-        sha256 = "694e29aa67d03a6ab006f1854740b65f4f87e581afb33853f80e647ddb5f24e7";
-    };
-
-    meta = with stdenv.lib; {
-      description = "Collection of fancy functional tools focused on practicality.";
-      homepage = "http://funcy.readthedocs.org/";
-      license = stdenv.lib.licenses.bsd3;
     };
   };
 


### PR DESCRIPTION
Funcy was under python2.7 specific packages
