### PR TITLE
Small fixups on window-managers module

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -8,12 +8,17 @@ in
 
 {
   imports = [
+    ./afterstep.nix
+    ./awesome.nix
     ./bspwm.nix
     ./compiz.nix
+    ./fluxbox.nix
     ./herbstluftwm.nix
     ./i3.nix
+    ./icewm.nix
     ./metacity.nix
     ./openbox.nix
+    ./ratpoison.nix
     ./sawfish.nix
     ./stumpwm.nix
     ./twm.nix


### PR DESCRIPTION
It adds some window managers to NixOS, declaring them
on "nixos/modules/services/x11/window-managers/default.nix".
