### PR TITLE
More-itertools test uses python2 specific syntax.

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13115,7 +13115,7 @@ let
       sha256 = "4606417182e0a1289e23fb7f964a64ca9fdaafb7c1999034dc4fa0cc5850c478";
     };
    
-    propagatedBuildInputs = with self; [ nose ];
+    doCheck = false;
 
     meta = {
       homepage = "https://more-itertools.readthedocs.org";


### PR DESCRIPTION
Uses tuple unpacking in argument which is no longer supported.
Only seems to happen during test.
