### PR TITLE
cdrtools: Update to 3.00

### DIFF
--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -1,31 +1,19 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "cdrtools-2.01";
+  name = "cdrtools-3.00";
 
-  configurePhase = "prefix=$out";
-
-  #hack, I'm getting "chown: invalid user: `bin" error, so replace chown by a nop dummy script
-  preInstall = ''
-    mkdir "$TMP/bin"
-    for i in chown chgrp; do
-      echo '#!/bin/sh' >> "$TMP/bin/$i"
-      chmod +x "$TMP/bin/$i"
-      PATH="$TMP/bin:$PATH"
-    done
-  '';
+  configurePhase = "true";
 
   src = fetchurl {
     url = "mirror://sourceforge/cdrtools/${name}.tar.bz2";
-    sha256 = "08kc5w4z5k2ka7i05an7gfzzp0fsrc403riav7bw8xws0rsn32vj";
+    sha256 = "0ga2fdwn3898jas5mabb6cc2al9acqb2yyzph2w76m85414bd73z";
   };
 
-  patches = [./cdrtools-2.01-install.patch];
+  patches = [ ./cdrtools-2.01-install.patch ];
 
   meta = {
     homepage = http://sourceforge.net/projects/cdrtools/;
     description = "Highly portable CD/DVD/BluRay command line recording software";
-    broken = true;              # Build errors, probably because the source
-                                # can't deal with recent versions of gcc.
   };
 }

--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -15,5 +15,9 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://sourceforge.net/projects/cdrtools/;
     description = "Highly portable CD/DVD/BluRay command line recording software";
+    # Licensing issues: This package contains code licensed under CDDL, GPL2
+    # and LGPL2. There is debate regarding the legality of this licensing.
+    # Marked as unfree to avoid any possible legal issues.
+    license = stdenv.lib.licenses.unfree;
   };
 }


### PR DESCRIPTION
Update cdrtools and unmark as broken.

Only tested building under linux. Although it should build for darwin, etc. I have no means by which to test this.

Should add a license to the package as well. It contains parts that are licensed under CDDL, GPL2 and LPGL2, what do we do in the case of multiple licenses? Note that this is a package where there has been plenty of disagreement regarding the legality of it's licensing ([package maintainers point of view](http://cdrtools.sourceforge.net/private/linux-dist.html)). Could always just mark as unfree and move on, lol.
