### PR TITLE
bundler-head: fix sha256

### DIFF
--- a/pkgs/development/interpreters/ruby/bundler-head.nix
+++ b/pkgs/development/interpreters/ruby/bundler-head.nix
@@ -5,7 +5,7 @@ buildRubyGem {
   src = fetchgit {
     url = "https://github.com/bundler/bundler.git";
     rev = "a2343c9eabf5403d8ffcbca4dea33d18a60fc157";
-    sha256 = "1l4r55n1wzr817l225l6pm97li1mxg9icd8s51cpfihh91nkdz68";
+    sha256 = "1fywz0m3bb0fmcikhqbw9iaw67k29srwi8dllq6ni1cbm1xfyj46";
     leaveDotGit = true;
   };
   dontPatchShebangs = true;


### PR DESCRIPTION
Hopefully fixes #6326

I worry that fetchgit's current implementation might not be sufficiently deterministic when leaveDotGit is enabled.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/6409)

<!-- Reviewable:end -->
