### PR TITLE
writeTextFile: Use passAsFile if available

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -20,13 +20,18 @@ rec {
     }:
     runCommand name
       { inherit text executable;
+        passAsFile = [ "text" ];
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;
       }
       ''
         n=$out${destination}
         mkdir -p "$(dirname "$n")"
-        echo -n "$text" > "$n"
+        if [ -e "$textPath" ]; then
+          mv "$textPath" "$n"
+        else
+          echo -n "$text" > "$n"
+        fi
         (test -n "$executable" && chmod +x "$n") || true
       '';
 


### PR DESCRIPTION
This will work once we get https://github.com/NixOS/nix/commit/bd9106415099b32a51f66be886d18271e65ac9dd in our nixUnstable.

Since we don't have that yet, this code is untested :grin:. Please eyeball @lethalman @edolstra.

I believe this will cause quite a serious rebuild, shame we can't use a fixed-output derivation for files with known content...
