### PR TITLE
Updates for libvirt and friends

### DIFF
--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "libvirt-glib-0.1.9";
+  name = "libvirt-glib-0.2.0";
 
   src = fetchurl {
     url = "http://libvirt.org/sources/glib/${name}.tar.gz";
-    sha256 = "0n59hp0kwn80z9136g2n7pwkrlhlsxksr6gy4w7783d71qk3cfq5";
+    sha256 = "02saqkk4wzsimsan7s9yc5bx05xn7j00hnxhq4sczkgr4krf1drh";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libxml2, gnutls, devicemapper, perl, python
 , iproute, iptables, readline, lvm2, utillinux, udev, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, makeWrapper, pmutils, libcap_ng
-, dnsmasq, libnl, libpcap
-, pythonPackages
+, dnsmasq, libnl, libpcap, libxslt, xhtml1
+, pythonPackages, perlPackages
 }:
 
-let version = "1.2.9"; in
+let version = "1.2.12"; in
 
 assert version == pythonPackages.libvirt.version;
 
@@ -14,13 +14,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://libvirt.org/sources/${name}.tar.gz";
-    sha256 = "1i4ggs50dipz1hm0qlk6kak1n3klll8sx9fnffmvjlgla9d1m4wm";
+    sha256 = "0sp6xm6iyg5wfjgxiba4rpl527429r22lh241dzxjq25fxzj5xgg";
   };
 
   buildInputs = [
     pkgconfig libxml2 gnutls devicemapper perl python readline lvm2
     utillinux udev libpciaccess gettext libtasn1 libgcrypt yajl makeWrapper
-    libcap_ng libnl
+    libcap_ng libnl libxslt xhtml1 perlPackages.XMLXPath
   ];
 
   preConfigure = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12974,11 +12974,11 @@ let
 
   libvirt = pkgs.stdenv.mkDerivation rec {
     name = "libvirt-python-${version}";
-    version = "1.2.9";
+    version = "1.2.12";
 
     src = pkgs.fetchurl {
       url = "http://libvirt.org/sources/python/${name}.tar.gz";
-      sha256 = "1vbrkwvsvcfgibdw4drcypg2n6zcpi3zv23zw20nkk5fjfp26w4g";
+      sha256 = "17w4mpsp4pxhbzs128ig3gxp12rr0j41mxch8i11dqjrjy7l6bs3";
     };
 
     buildInputs = with self; [ python pkgs.pkgconfig pkgs.libvirt lxml ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12983,9 +12983,9 @@ let
 
     buildInputs = with self; [ python pkgs.pkgconfig pkgs.libvirt lxml ];
 
-    buildPhase = "python setup.py build";
+    buildPhase = "${python.interpreter} setup.py build";
 
-    installPhase = "python setup.py install --prefix=$out";
+    installPhase = "${python.interpreter} setup.py install --prefix=$out";
 
     meta = {
       homepage = http://www.libvirt.org/;


### PR DESCRIPTION
libvirt updates potentially fix security issues: [CVE-2014-7823](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-7823) [CVE-2015-0236](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0236)

I performed limited testing using virtmanager. My windows vm runs fine and I couldn't see any obvious regressions from the previous version. It would be good if others could test their vm setups before this merged.

Also marked pythonPackages.libvirt for python 2 only.
