### PR TITLE
Disable simpleparse on python3 and pypy

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9663,6 +9663,8 @@ let
     version = "2.1.1";
     name = "simpleparse-${version}";
 
+    disabled = isPy3k || isPyPy;
+
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/S/SimpleParse/SimpleParse-${version}.tar.gz";
       sha256 = "1n8msk71lpl3kv086xr2sv68ppgz6228575xfnbszc6p1mwr64rg";


### PR DESCRIPTION
This fixes problems in hydra (e.g., http://hydra.nixos.org/build/19822374)
