### PR TITLE
hsetroot: fix shared library error

### DIFF
--- a/pkgs/tools/X11/hsetroot/default.nix
+++ b/pkgs/tools/X11/hsetroot/default.nix
@@ -1,19 +1,38 @@
-{stdenv, fetchurl, imlib2, libX11, libXext }:
+{ stdenv, fetchurl, imlib2, libX11, xproto }:
 
-stdenv.mkDerivation {
-  name = "hsetroot-1.0.2";
+let
 
-  # The primary download site seems to no longer exist; use Gentoo's mirror for now.
+  libPath = stdenv.lib.makeLibraryPath [
+    imlib2
+    libX11
+  ];
+
+in
+
+stdenv.mkDerivation rec {
+  name = "hsetroot-${version}";
+  version = "1.0.2";
+
   src = fetchurl {
-    url = "http://mirror.datapipe.net/gentoo/distfiles/hsetroot-1.0.2.tar.gz";
+    url = "http://mirror.datapipe.net/gentoo/distfiles/hsetroot-${version}.tar.gz";
     sha256 = "d6712d330b31122c077bfc712ec4e213abe1fe71ab24b9150ae2774ca3154fd7";
   };
 
-  buildInputs = [ imlib2 libX11 libXext ];
+  buildInputs = [ imlib2 libX11 xproto ];
 
-  meta = {
+  dontPatchELF = true;
+
+  postFixup = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath ${libPath} \
+        $out/bin/hsetroot
+  '';
+
+  meta = with stdenv.lib; {
     description = "Allows you to compose wallpapers ('root pixmaps') for X";
     homepage = http://thegraveyard.org/hsetroot.html;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.henrytill ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
The current expression for `hsetroot` results in a binary which fails to set the background and instead returns the following error: 

```
hsetroot: error while loading shared libraries: libX11.so.6: cannot open shared object file: No such file or directory
```

This PR fixes the problem.
