### PR TITLE
Update chronos default port

### DIFF
--- a/nixos/modules/services/scheduling/chronos.nix
+++ b/nixos/modules/services/scheduling/chronos.nix
@@ -18,7 +18,7 @@ in {
 
     httpPort = mkOption {
       description = "Chronos listening port";
-      default = 8080;
+      default = 4400;
       type = types.int;
     };
 

--- a/pkgs/applications/networking/cluster/chronos/default.nix
+++ b/pkgs/applications/networking/cluster/chronos/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage    = https://github.com/airbnb/chronos;
+    homepage    = http://airbnb.github.io/chronos;
     license     = licenses.asl20;
     description = "Fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules";
     maintainers = with maintainers; [ offline ];


### PR DESCRIPTION
Update chronos default port to match the one documented on
their website (http://airbnb.github.io/chronos). The one in
their repo (the current one) clashes with the marathon documented
one.
