### PR TITLE
Add new package charybdis ircd

### DIFF
--- a/pkgs/servers/irc/charybdis/default.nix
+++ b/pkgs/servers/irc/charybdis/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, zlib, openssl, bison, flex }:
+
+stdenv.mkDerivation rec {
+  name = "charybdis-3.4.2-git22e4a9b";
+
+  src = fetchFromGitHub {
+    owner = "atheme";
+    repo = "charybdis";
+    rev = "22e4a9bc2b34915bf6e907e90d60bf7d002c7dc5";
+    sha256 = "0i22hc9al1g6ffa6vqw0lxdy1zj2y0ixgmmhi0kbc3j6xqp78kwj";
+  };
+
+  configureFlags = [
+    "--sysconfdir=/etc/charybdis"
+    "--localstatedir=/var"
+    "--disable-assert"
+    "--enable-openssl=${openssl}"
+    "--enable-ipv6"
+    "--with-program-prefix=charybdis-"
+  ];
+
+  buildInputs = [ zlib openssl bison flex ];
+
+  meta = {
+    description = "Charybdis IRC Daemon";
+    homepage    = http://www.atheme.org/projects/charybdis.html;
+    license     = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.fpletz ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -717,6 +717,8 @@ let
 
   corosync = callPackage ../servers/corosync { };
 
+  charybdis = callPackage ../servers/irc/charybdis { };
+
   cherrytree = callPackage ../applications/misc/cherrytree { };
 
   chntpw = callPackage ../tools/security/chntpw { };


### PR DESCRIPTION
From their website http://atheme.org/projects/charybdis.html:

> charybdis is an ircd used on various networks either as itself, or as the basis of a customized IRC server implementation. A derivative of charybdis, ircd-seven powers freenode, which is the largest IRC network in the world.

I've picked a git version because there were some security-related fixes. I use this with in production with NixOS for a small IRC network. I also have a NixOS module but that needs some cleanup. PR will follow.
