### PR TITLE
Add new package screen-message

### DIFF
--- a/pkgs/tools/X11/screen-message/default.nix
+++ b/pkgs/tools/X11/screen-message/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchdarcs, autoreconfHook, pkgconfig, gtk3 }:
+
+stdenv.mkDerivation {
+  name = "screen-message-0.23";
+
+  src = fetchdarcs {
+    url = "http://darcs.nomeata.de/screen-message.debian";
+    rev = "0.23-1";
+  };
+
+  buildInputs = [ autoreconfHook pkgconfig gtk3 ];
+
+  # screen-message installs its binary in $(prefix)/games per default
+  makeFlags = [ "execgamesdir=$(out)/bin" ];
+
+  meta = {
+    homepage = "http://darcs.nomeata.de/cgi-bin/darcsweb.cgi?r=screen-message.debian";
+    description = "Displays a short text fullscreen in an X11 window";
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.fpletz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2519,6 +2519,8 @@ let
 
   screen = callPackage ../tools/misc/screen { };
 
+  screen-message = callPackage ../tools/X11/screen-message { };
+
   scrot = callPackage ../tools/graphics/scrot { };
 
   scrypt = callPackage ../tools/security/scrypt { };


### PR DESCRIPTION
This is a simple tool that displays the entered or piped text on the screen as big as possible. Good for showing people sitting near you some text on your display really fast.
