### PR TITLE
hsetroot: fix libX11 error

### DIFF
--- a/pkgs/tools/X11/hsetroot/default.nix
+++ b/pkgs/tools/X11/hsetroot/default.nix
@@ -1,19 +1,35 @@
-{stdenv, fetchurl, imlib2, libX11, libXext }:
+{ stdenv, fetchurl, autoconf, automake, imlib2, libtool, libX11, pkgconfig, xproto }:
 
-stdenv.mkDerivation {
-  name = "hsetroot-1.0.2";
+stdenv.mkDerivation rec {
+  name = "hsetroot-${version}";
+  version = "1.0.2";
 
   # The primary download site seems to no longer exist; use Gentoo's mirror for now.
   src = fetchurl {
-    url = "http://mirror.datapipe.net/gentoo/distfiles/hsetroot-1.0.2.tar.gz";
+    url = "http://mirror.datapipe.net/gentoo/distfiles/hsetroot-${version}.tar.gz";
     sha256 = "d6712d330b31122c077bfc712ec4e213abe1fe71ab24b9150ae2774ca3154fd7";
   };
 
-  buildInputs = [ imlib2 libX11 libXext ];
+  # See https://bugs.gentoo.org/show_bug.cgi?id=504056
+  underlinkingPatch = fetchurl {
+    url = http://www.gtlib.gatech.edu/pub/gentoo/gentoo-x86-portage/x11-misc/hsetroot/files/hsetroot-1.0.2-underlinking.patch;
+    name = "hsetroot-1.0.2-underlinking.patch";
+    sha256 = "1px1p3wz7ji725z9nlwb0x0h6lnnvnpz15sblzzq7zrijl3wz65x";
+  };
 
-  meta = {
+  buildInputs = [ autoconf automake imlib2 libtool libX11 pkgconfig xproto ];
+
+  patches = [ underlinkingPatch ];
+
+  patchFlags = "-p0";
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
     description = "Allows you to compose wallpapers ('root pixmaps') for X";
     homepage = http://thegraveyard.org/hsetroot.html;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.henrytill ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
The current expression for `hsetroot` results in a broken binary which fails to set the background and instead returns the following error: 

```
hsetroot: error while loading shared libraries: libX11.so.6: cannot open shared object file: No such file or directory
```

The updated expression applies a [patch](http://www.gtlib.gatech.edu/pub/gentoo/gentoo-x86-portage/x11-misc/hsetroot/files/hsetroot-1.0.2-underlinking.patch) from Gentoo to use `pkg-config` to find `libX11`, which also fixes our problem.
