### PR TITLE
Ddccontrol

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -130,6 +130,7 @@
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   page = "Carles Pagès <page@cubata.homelinux.net>";
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";
+  pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";

--- a/pkgs/data/misc/ddccontrol-db/default.nix
+++ b/pkgs/data/misc/ddccontrol-db/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchurl
+, perl
+, perlPackages
+, libxml2
+, pciutils
+, pkgconfig
+, gtk
+}:
+
+let version = "20061014"; in
+let verName = "${version}"; in
+stdenv.mkDerivation {
+  name = "ddccontrol-db-${verName}";
+  src = fetchurl {
+    url = "mirror://sourceforge/ddccontrol/ddccontrol-db/${verName}/ddccontrol-db-${verName}.tar.bz2";
+    sha1 = "9d06570fdbb4d25e397202a518265cc1173a5de3";
+  };
+  buildInputs =
+    [
+      stdenv
+      perl
+      perlPackages.libxml_perl
+      libxml2
+      pciutils
+      pkgconfig
+      gtk
+    ];
+
+  meta = with stdenv.lib; {
+    description = "Monitor database for DDCcontrol";
+    homepage = "http://http://ddccontrol.sourceforge.net/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.pakhfn ];
+  };
+}

--- a/pkgs/development/tools/misc/automake/automake-1.10.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.10.x.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, perl, autoconf, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "automake-1.10.3";
+
+  # TODO: Remove the `aclocal' wrapper when $ACLOCAL_PATH support is
+  # available upstream; see
+  # <http://debbugs.gnu.org/cgi/bugreport.cgi?bug=9026>.
+  builder = ./builder.sh;
+
+  setupHook = ./setup-hook.sh;
+
+  src = fetchurl {
+    url = "mirror://gnu/automake/${name}.tar.gz";
+    sha256 = "fda9b22ec8705780c8292510b3376bb45977f45a4f7eb3578c5ad126d7758028";
+  };
+
+  buildInputs = [perl autoconf makeWrapper];
+
+  # Disable indented log output from Make, otherwise "make.test" will
+  # fail.
+  preCheck = "unset NIX_INDENT_MAKE";
+
+  # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the
+  # "fixed" path in generated files!
+  dontPatchShebangs = true;
+
+  # Run the test suite in parallel.
+  enableParallelBuilding = true;
+
+  meta = {
+    branch = "1.10";
+    homepage = http://www.gnu.org/software/automake/;
+    description = "GNU standard-compliant makefile generator";
+
+    longDescription = ''
+      GNU Automake is a tool for automatically generating
+      `Makefile.in' files compliant with the GNU Coding
+      Standards.  Automake requires the use of Autoconf.
+    '';
+
+    license = stdenv.lib.licenses.gpl2Plus;
+
+    maintainers = [ ];
+  };
+}

--- a/pkgs/tools/misc/ddccontrol/ddccontrol-db.nix
+++ b/pkgs/tools/misc/ddccontrol/ddccontrol-db.nix
@@ -1,17 +1,35 @@
-{ stdenv, fetchurl, perl, perlPackages, libxml2, pciutils, pkgconfig, gtk  }:
+{ stdenv
+, fetchurl
+, perl
+, perlPackages
+, libxml2
+, pciutils
+, pkgconfig
+, gtk
+}:
+
 let version = "20061014"; in
 let verName = "${version}"; in
 stdenv.mkDerivation {
-         name = "ddccontrol-db-${verName}";
-	 src = fetchurl {
-               url = "mirror://sourceforge/ddccontrol/ddccontrol-db/${verName}/ddccontrol-db-${verName}.tar.bz2";
-               sha1 = "9d06570fdbb4d25e397202a518265cc1173a5de3";
-           };
-	 buildInputs =
-             [ stdenv perl perlPackages.libxml_perl libxml2 pciutils pkgconfig gtk ];
-	 meta=  with stdenv.lib; {
-      	    description = "Monitor database for DDCcontrol";
-            license = licenses.gpl2;
-            platforms = platforms.linux;
-         };
+  name = "ddccontrol-db-${verName}";
+  src = fetchurl {
+    url = "mirror://sourceforge/ddccontrol/ddccontrol-db/${verName}/ddccontrol-db-${verName}.tar.bz2";
+    sha1 = "9d06570fdbb4d25e397202a518265cc1173a5de3";
+  };
+  buildInputs =
+    [
+      stdenv
+      perl
+      perlPackages.libxml_perl
+      libxml2
+      pciutils
+      pkgconfig
+      gtk
+    ];
+
+  meta = with stdenv.lib; {
+    description = "Monitor database for DDCcontrol";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/tools/misc/ddccontrol/ddccontrol-db.nix
+++ b/pkgs/tools/misc/ddccontrol/ddccontrol-db.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Monitor database for DDCcontrol";
+    homepage = "http://http://ddccontrol.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.pakhfn ];
   };
 }

--- a/pkgs/tools/misc/ddccontrol/ddccontrol-db.nix
+++ b/pkgs/tools/misc/ddccontrol/ddccontrol-db.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, perl, perlPackages, libxml2, pciutils, pkgconfig, gtk  }:
+let version = "20061014"; in
+let verName = "${version}"; in
+stdenv.mkDerivation {
+         name = "ddccontrol-db-${verName}";
+	 src = fetchurl {
+               url = "mirror://sourceforge/ddccontrol/ddccontrol-db/${verName}/ddccontrol-db-${verName}.tar.bz2";
+               sha1 = "9d06570fdbb4d25e397202a518265cc1173a5de3";
+           };
+	 buildInputs =
+             [ stdenv perl perlPackages.libxml_perl libxml2 pciutils pkgconfig gtk ];
+	 meta=  with stdenv.lib; {
+      	    description = "Monitor database for DDCcontrol";
+            license = licenses.gpl2;
+            platforms = platforms.linux;
+         };
+}

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -50,8 +50,10 @@ stdenv.mkDerivation {
    
   meta = with stdenv.lib; {
     description = "A program used to control monitor parameters by software";
+    homepage = "http://http://ddccontrol.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.pakhfn ];
   };
 }
 	 

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, intltool, libtool, autoconf, automake110x, perl, perlPackages, libxml2, pciutils, pkgconfig, gtk, ddccontrol-db }:
+let version = "0.4.2"; in
+let verName = "${version}"; in
+stdenv.mkDerivation {
+   name = "ddccontrol-${verName}";
+   src = fetchurl {
+           url = "mirror://sourceforge/ddccontrol/ddccontrol-${version}.tar.bz2";
+           sha1 = "fd5c53286315a61a18697a950e63ed0c8d5acff1";
+         };
+   buildInputs =
+           [ stdenv intltool libtool autoconf automake110x perl perlPackages.libxml_perl libxml2 pciutils pkgconfig gtk ddccontrol-db];
+	   
+   prePatch = ''
+      npath=$(echo "${ddccontrol-db}/share/ddccontrol-db" | sed "s/\\//\\\\\\//g")
+      mv configure.ac configure.ac.old
+      opath="\$"
+      opath+="{datadir}\/ddccontrol-db"
+      sed "s/$opath/$npath/" <configure.ac.old >configure.ac
+      rm configure.ac.old 
+   '';
+   preConfigure = ''
+      autoreconf --install
+   '';
+   
+   meta =  with stdenv.lib; {
+      description = "A program used to control monitor parameters by software";
+      license = licenses.gpl2;
+      platforms = platforms.linux;
+    };
+}
+	 

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -1,31 +1,57 @@
-{ stdenv, fetchurl, intltool, libtool, autoconf, automake110x, perl, perlPackages, libxml2, pciutils, pkgconfig, gtk, ddccontrol-db }:
+{ stdenv
+, fetchurl
+, intltool
+, libtool
+, autoconf
+, automake110x
+, perl
+, perlPackages
+, libxml2
+, pciutils
+, pkgconfig
+, gtk
+, ddccontrol-db
+}:
+
 let version = "0.4.2"; in
 let verName = "${version}"; in
 stdenv.mkDerivation {
-   name = "ddccontrol-${verName}";
-   src = fetchurl {
-           url = "mirror://sourceforge/ddccontrol/ddccontrol-${version}.tar.bz2";
-           sha1 = "fd5c53286315a61a18697a950e63ed0c8d5acff1";
-         };
-   buildInputs =
-           [ stdenv intltool libtool autoconf automake110x perl perlPackages.libxml_perl libxml2 pciutils pkgconfig gtk ddccontrol-db];
+  name = "ddccontrol-${verName}";
+  src = fetchurl {
+    url = "mirror://sourceforge/ddccontrol/ddccontrol-${version}.tar.bz2";
+    sha1 = "fd5c53286315a61a18697a950e63ed0c8d5acff1";
+  };
+  buildInputs =
+    [ stdenv
+      intltool
+      libtool
+      autoconf
+      automake110x
+      perl
+      perlPackages.libxml_perl
+      libxml2
+      pciutils
+      pkgconfig
+      gtk
+      ddccontrol-db
+    ];
 	   
-   prePatch = ''
-      npath=$(echo "${ddccontrol-db}/share/ddccontrol-db" | sed "s/\\//\\\\\\//g")
+  prePatch = ''
+      newPath=$(echo "${ddccontrol-db}/share/ddccontrol-db" | sed "s/\\//\\\\\\//g")
       mv configure.ac configure.ac.old
-      opath="\$"
-      opath+="{datadir}\/ddccontrol-db"
-      sed "s/$opath/$npath/" <configure.ac.old >configure.ac
+      oldPath="\$"
+      oldPath+="{datadir}\/ddccontrol-db"
+      sed "s/$oldPath/$newPath/" <configure.ac.old >configure.ac
       rm configure.ac.old 
-   '';
-   preConfigure = ''
+  '';
+  preConfigure = ''
       autoreconf --install
-   '';
+  '';
    
-   meta =  with stdenv.lib; {
-      description = "A program used to control monitor parameters by software";
-      license = licenses.gpl2;
-      platforms = platforms.linux;
-    };
+  meta = with stdenv.lib; {
+    description = "A program used to control monitor parameters by software";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
 }
 	 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1009,7 +1009,7 @@ let
 
   ddccontrol = callPackage ../tools/misc/ddccontrol { };
 
-  ddccontrol-db = callPackage ../tools/misc/ddccontrol/ddccontrol-db.nix { };
+  ddccontrol-db = callPackage ../data/misc/ddccontrol-db { };
   
   ddclient = callPackage ../tools/networking/ddclient { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1007,6 +1007,10 @@ let
 
   detox = callPackage ../tools/misc/detox { };
 
+  ddccontrol = callPackage ../tools/misc/ddccontrol { };
+
+  ddccontrol-db = callPackage ../tools/misc/ddccontrol/ddccontrol-db.nix { };
+  
   ddclient = callPackage ../tools/networking/ddclient { };
 
   dd_rescue = callPackage ../tools/system/dd_rescue { };
@@ -4527,6 +4531,8 @@ let
   autocutsel = callPackage ../tools/X11/autocutsel{ };
 
   automake = automake112x;
+
+  automake110x = callPackage ../development/tools/misc/automake/automake-1.10.x.nix { };
 
   automake111x = callPackage ../development/tools/misc/automake/automake-1.11.x.nix { };
 


### PR DESCRIPTION
I have added a package for DDCcontrol (a tool for changing monitor brightness, contrast, etc. using ddc protocol). It needs an older version of automake (automake <=1.11.1) to rebuild configure script. I have added a package for automake 1.10.3.
