### PR TITLE
Packaged nkf (network kanji filter)

### DIFF
--- a/pkgs/tools/text/nkf/default.nix
+++ b/pkgs/tools/text/nkf/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "nkf-${version}";
+  version = "2.1.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforgejp/nkf/59912/${name}.tar.gz";
+    sha256 = "8cb430ae69a1ad58b522eb4927b337b5b420bbaeb69df255919019dc64b72fc2";
+  };
+
+  makeFlags = "prefix=\${out}";
+
+  meta = {
+    description = "tool for converting encoding of Japanese text";
+    homepage = "http://sourceforge.jp/projects/nkf/";
+    license = stdenv.lib.licenses.zlib;
+    maintainers = [ stdenv.lib.maintainers.auntie ];
+  };
+}

--- a/pkgs/tools/text/nkf/default.nix
+++ b/pkgs/tools/text/nkf/default.nix
@@ -12,9 +12,10 @@ stdenv.mkDerivation rec {
   makeFlags = "prefix=\${out}";
 
   meta = {
-    description = "tool for converting encoding of Japanese text";
+    description = "Tool for converting encoding of Japanese text";
     homepage = "http://sourceforge.jp/projects/nkf/";
     license = stdenv.lib.licenses.zlib;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.auntie ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1980,6 +1980,8 @@ let
 
   nitrogen = callPackage ../tools/X11/nitrogen {};
 
+  nkf = callPackage ../tools/text/nkf {};
+
   nlopt = callPackage ../development/libraries/nlopt {};
 
   npapi_sdk = callPackage ../development/libraries/npapi-sdk {};


### PR DESCRIPTION
Added a simple package for nkf tool. Useful for converting ShiftJIS/EUC-JP/utf8 encoding ugliness.
