### PR TITLE
Added tmuxinator (using bundlerEnv)

### DIFF
--- a/pkgs/tools/misc/tmuxinator/Gemfile
+++ b/pkgs/tools/misc/tmuxinator/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'tmuxinator'

--- a/pkgs/tools/misc/tmuxinator/Gemfile.lock
+++ b/pkgs/tools/misc/tmuxinator/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    erubis (2.7.0)
+    thor (0.19.1)
+    tmuxinator (0.6.9)
+      erubis (~> 2.6)
+      thor (~> 0.19, >= 0.15.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  tmuxinator

--- a/pkgs/tools/misc/tmuxinator/default.nix
+++ b/pkgs/tools/misc/tmuxinator/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  name = "tmuxinator-0.6.9";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = with lib; {
+    description = "Manage complex tmux sessions easily";
+    homepage    = https://github.com/tmuxinator/tmuxinator;
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ auntie ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/tmuxinator/gemset.nix
+++ b/pkgs/tools/misc/tmuxinator/gemset.nix
@@ -1,0 +1,27 @@
+{
+  "erubis" = {
+    version = "2.7.0";
+    source = {
+      type = "gem";
+      sha256 = "1fj827xqjs91yqsydf0zmfyw9p4l2jz5yikg3mppz6d7fi8kyrb3";
+    };
+  };
+  "thor" = {
+    version = "0.19.1";
+    source = {
+      type = "gem";
+      sha256 = "08p5gx18yrbnwc6xc0mxvsfaxzgy2y9i78xq7ds0qmdm67q39y4z";
+    };
+  };
+  "tmuxinator" = {
+    version = "0.6.9";
+    source = {
+      type = "gem";
+      sha256 = "0q0ld82dznjsan7ciblfsxz59brcc16fwmvr9n3c7vdcndj8rd27";
+    };
+    dependencies = [
+      "erubis"
+      "thor"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2725,6 +2725,8 @@ let
 
   tmux = callPackage ../tools/misc/tmux { };
 
+  tmuxinator = callPackage ../tools/misc/tmuxinator { };
+
   tmin = callPackage ../tools/security/tmin { };
 
   tmsu = callPackage ../tools/filesystems/tmsu { };


### PR DESCRIPTION
This is my first package using bundlerEnv. tmuxinator was already part of rubyLibs before rubyLibs was removed.

My only issue with my derivation is that it pulls /bin/thor into the PATH, which is evidenced by this output from nix-env:
https://gist.github.com/auntieNeo/0bf4dd0468d2c3ad3a65

Which also implies that the bundix derivation has the exact same problem. Maybe there's a simple fix I can do in my derivation, but if it's a problem with bundlerEnv then I might file a separate bug report.

@cstrahan
