### PR TITLE
Add 'host' input parameter to nixos modules and nixpkgs

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29,6 +29,8 @@
 
 , crossSystem ? null
 , platform ? null
+
+, host ? null
 }:
 
 


### PR DESCRIPTION
Add a 'host' input parameter in parallel to the 'system' input parameter.
The 'host' parameter is needed to indicate whether a system is build for
a bare metal machine, or for the Xen hypervisor, for KVM, as a container,
or, e.g., as a Virtual Box image.
The nixos modules and nixpkgs should use 'host' parameter, e.g., to adjust
boot parameters or to automatically integrate host specific packages.
Also, e.g., the option "boot.isContainer" could/should be ported to the
more general 'host' parameter.

The values used so far are:
bare metal: host = null;
Xen:        host = "xen";
KVM:        host = "kvm";

Proposed values are:
Nspawn:     host = "nspawn"
LXC:        host = "lxc";
XenServer:  host = "xenserver";
docker:     host = "docker";
Virtual Box:host = "virtual_box";
