### PR TITLE
avr-gcc-with-avr-libc: Update to latest versions.

### DIFF
--- a/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix
+++ b/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix
@@ -1,88 +1,75 @@
-{ stdenv, fetchurl, writeTextFile, coreutils, gnumake, gcc, gnutar, bzip2
-  , gnugrep, gnused, gawk, diffutils, patch
-  , gmp, mpfr, libmpc }:
+{ stdenv, fetchurl, texinfo, gmp, mpfr, libmpc, zlib }:
 
 stdenv.mkDerivation {
   name = "avr-gcc-libc";
 
-  srcBinutils = fetchurl {
-    url = "mirror://gnu/binutils/binutils-2.21.1.tar.bz2";
-    sha256 = "0m7nmd7gc9d9md43wbrv65hz6lbi2crqwryzpigv19ray1lzmv6d";
-  };
+  srcs = [
+    (fetchurl {
+        url = "mirror://gnu/binutils/binutils-2.25.tar.bz2";
+        sha256 = "08r9i26b05zcwb9zxb6zllpfdiiicdfsgbpsjlrjmvx3rxjzrpi2";
+    })
 
-  srcGCC = fetchurl {
-    url = "mirror://gcc/releases/gcc-4.6.3/gcc-core-4.6.3.tar.bz2";
-    sha256 = "1hai090f0svf886nyhn4glmfw54v9lz88w2izkx5iqhd3j400gi8";
-  };
+    (fetchurl {
+        url = "mirror://gcc/releases/gcc-4.8.4/gcc-4.8.4.tar.bz2";
+        sha256 = "4a80aa23798b8e9b5793494b8c976b39b8d9aa2e53cd5ed5534aff662a7f8695";
+    })
 
-  srcGCCGPP = fetchurl {
-    url = "mirror://gcc/releases/gcc-4.6.3/gcc-g++-4.6.3.tar.bz2";
-    sha256 = "1s199gb6p65r5k69cdfqqcz5hgifw9bhyj65n2b91s80x4rwgq5k";
-  };
+    (fetchurl {
+        url = http://download.savannah.gnu.org/releases/avr-libc/avr-libc-1.8.1.tar.bz2;
+        sha256 = "0sd9qkvhmk9av4g1f8dsjwc309hf1g0731bhvicnjb3b3d42l1n3";
+    })
+  ];
+  
+  sourceRoot = ".";
 
-  srcAVRLibc = fetchurl {
-    url = http://download.savannah.gnu.org/releases/avr-libc/old-releases/avr-libc-1.7.1.tar.bz2;
-    sha256 = "1b1s4cf787izlm3r094vvkzrzb3w3bg6bwiz2wz71cg7q07kzzn6";
-  };
-
-  phases = "doAll";
-
-  # don't call any wired $buildInputs/nix-support/* scripts or such. This makes the build fail 
-  builder = writeTextFile {
-    name = "avrbinutilsgccavrlibc-builder-script";
-    text =  ''
-    PATH=${coreutils}/bin:${gnumake}/bin:${gcc}/bin:${gnutar}/bin:${bzip2}/bin:${gnugrep}/bin:${gnused}/bin:${gawk}/bin:${diffutils}/bin:${patch}/bin
-    # that's all a bit too hacky...!
-    for i in `cat ${gcc}/nix-support/propagated-user-env-packages`; do
-      echo adding $i
-      PATH=$PATH:$i/bin
-    done
-    mkdir -p "$out"
-    export > env-vars
-
-    for i in "${gmp}" "${mpfr}" "${libmpc}"; do
-      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I$i/include "
-      export NIX_LDFLAGS="$NIX_LDFLAGS -L$i/lib "
-    done
-
+  nativeBuildInputs = [ texinfo ];
+  
+  buildInputs = [ gmp mpfr libmpc zlib ];
+  
+  # Make sure we don't strip the libraries in lib/gcc/avr.
+  stripDebugList= [ "bin" "avr/bin" "libexec" ];
+  
+  installPhase = ''
     # important, without this gcc won't find the binutils executables
-    PATH=$PATH:$out/bin
+    export PATH=$PATH:$out/bin
+    
+    # Binutils.
+    pushd binutils-*/
+    mkdir obj-avr
+    cd obj-avr
+    ../configure --target=avr --prefix="$out" --disable-nls --disable-debug --disable-dependency-tracking
+    make $MAKE_FLAGS
+    make install
+    popd
 
-    prefix=$out
+    # GCC.
+    pushd gcc-*
+    mkdir obj-avr
+    cd obj-avr
+    ../configure --target=avr --prefix="$out" --disable-nls --disable-libssp --with-dwarf2 --disable-install-libiberty --with-system-zlib --enable-languages=c,c++
+    make $MAKE_FLAGS
+    make install
+    popd
 
-    tar jxf $srcBinutils
-      cd binutils-*/
-      mkdir obj-avr
-      cd obj-avr
-      ../configure --target=avr --prefix="$prefix" --disable-nls --prefix=$prefix
-      make $MAKE_FLAGS
-      make install
+    # We don't want avr-libc to use the native compiler.
+    export BUILD_CC=$CC
+    export BUILD_CXX=$CXX
+    unset CC
+    unset CXX
 
-    cd $TMP
-    tar jxf $srcGCC
-    tar jxf $srcGCCGPP
-      cd gcc-*
-      mkdir obj-avr
-      cd obj-avr
-      ../configure --target=avr --prefix="$prefix" --disable-nls --enable-languages=c,c++ --disable-libssp --with-dwarf2
-      make $MAKE_FLAGS
-      make install
-
-    cd $TMP
-      tar jxf $srcAVRLibc
-      cd avr-libc-*
-      patch -Np1 -i ${./avr-libc-fix-gcc-4.6.0.patch}
-      ./configure --prefix="$prefix" --build=`./config.guess` --host=avr
-      make $MAKE_FLAGS
-      make install
-    '';
-  };
-
+    # AVR-libc.
+    pushd avr-libc-*
+    ./configure --prefix="$out" --build=`./config.guess` --host=avr
+    make $MAKE_FLAGS
+    make install
+    popd
+  '';
+  
   meta = with stdenv.lib; {
-      description = "AVR development environment including binutils, avr-gcc and avr-libc";
-      # I've tried compiling the packages separately.. too much hassle. This just works. Fine.
-      license =  ["GPL" "LGPL"]; # see single packages ..
-      homepage = []; # dito
-      platforms = platforms.linux;
+    description = "AVR development environment including binutils, avr-gcc and avr-libc";
+    # I've tried compiling the packages separately.. too much hassle. This just works. Fine.
+    license =  ["GPL" "LGPL"]; # see single packages ..
+    homepage = []; # dito
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4569,10 +4569,7 @@ let
     samples = true;
   };
 
-  avrgcclibc = callPackage ../development/misc/avr-gcc-with-avr-libc {
-    gcc = gcc46;
-    stdenv = overrideCC stdenv gcc46;
-  };
+  avrgcclibc = callPackage ../development/misc/avr-gcc-with-avr-libc {};
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
 


### PR DESCRIPTION
Also modernize the Nix expression.

Test: my APrinter firmware compiles and runs with this.
