### PR TITLE
Add a list of platforms organized by architecture

### DIFF
--- a/lib/platforms.nix
+++ b/lib/platforms.nix
@@ -13,4 +13,7 @@ rec {
   none = [];
   allBut = platforms: lists.filter (x: !(builtins.elem x platforms)) all;
   mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux"];
+  x64 = ["x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin"];
+  i686 = ["i686-linux" "i686-freebsd" "i686-netbsd" "i686-cygwin"];
+  arm = ["armv5tel-linux" "armv6l-linux" "armv7l-linux" "mips64el-linux"];
 }


### PR DESCRIPTION
I need  this for npm2nix platform support, because node packages are able to speciffy on which os they work and on which architecture.
