### PR TITLE
nixos/haproxy: remove broken default 'config'

### DIFF
--- a/nixos/modules/services/networking/haproxy.nix
+++ b/nixos/modules/services/networking/haproxy.nix
@@ -18,42 +18,8 @@ with lib;
       };
 
       config = mkOption {
-        type = types.lines;
-        default =
-          ''
-          global
-            log 127.0.0.1 local6
-            maxconn  24000
-            daemon
-            nbproc 1
-
-          defaults
-            mode http
-            option httpclose
-
-            # Remove requests from the queue if people press stop button
-            option abortonclose
-
-            # Try to connect this many times on failure
-            retries 3
-
-            # If a client is bound to a particular backend but it goes down,
-            # send them to a different one
-            option redispatch
-
-            monitor-uri /haproxy-ping
-
-            timeout connect 7s
-            timeout queue   300s
-            timeout client  300s
-            timeout server  300s
-
-            # Enable status page at this URL, on the port HAProxy is bound to
-            stats enable
-            stats uri /haproxy-status
-            stats refresh 5s
-            stats realm Haproxy statistics
-          '';
+        type = types.nullOr types.lines;
+        default = null;
         description = ''
           Contents of the HAProxy configuration file,
           <filename>haproxy.conf</filename>.
@@ -65,6 +31,11 @@ with lib;
   };
 
   config = mkIf cfg.enable {
+
+    assertions = [{
+      assertion = cfg.config != null;
+      message = "You must provide services.haproxy.config.";
+    }];
 
     systemd.services.haproxy = {
       description = "HAProxy";


### PR DESCRIPTION
HAProxy fails to start with the default 'config'. Better disable it and
assert that the user provides a suitable 'config'. (AFAICS, there cannot
really be a default config file for HAProxy.)

---

Anyone familiar with HAProxy that can confirm this? I think either we should remove the default config or fix it (if there is such a thing as a default HAProxy config).

CC @garbas 
