### PR TITLE
Shared libuv in io.js and Node.js

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -105,4 +105,5 @@ in
   //
   mapAttrs (v: h: mkWithAutotools stable (toVersion v) h) {
     v1_2_0 = "1nbp8qpgw64gl9nrjzxw0ndv1m64cfms0cy5a2883vw6877kizmx";
+    v1_4_0 = "17k028gn07vb9in440wbf0ar0rdl8bi5v4shm8nhj22vfb18dhl5";
   }

--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, utillinux, openssl, http-parser, zlib, nightly ? false }:
+{ stdenv, fetchurl, python, utillinux, openssl, http-parser, zlib, libuv, nightly ? false }:
 
 let
   version = if nightly then "1.2.1-nightly20150213f0296933f8" else "1.2.0";
@@ -19,9 +19,9 @@ in stdenv.mkDerivation {
     sed -e 's|^#!/usr/bin/env python$|#!${python}/bin/python|g' -i configure
   '';
 
-  configureFlags = [ "--shared-openssl" "--shared-http-parser" "--shared-zlib" ];
+  configureFlags = [ "--shared-openssl" "--shared-http-parser" "--shared-zlib" "--shared-libuv" ];
 
-  buildInputs = [ python openssl http-parser zlib ] ++ (optional stdenv.isLinux utillinux);
+  buildInputs = [ python openssl http-parser zlib libuv ] ++ (optional stdenv.isLinux utillinux);
   setupHook = ../nodejs/setup-hook.sh;
 
   meta = {

--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, python, zlib, v8, utillinux, http-parser
+{ stdenv, fetchurl, openssl, python, zlib, libuv, v8, utillinux, http-parser
 , pkgconfig, runCommand, which, unstableVersion ? false 
 }:
 
@@ -10,9 +10,8 @@ let
 
   version = if unstableVersion then "0.11.13" else "0.12.0";
 
-  # !!! Should we also do shared libuv?
   deps = {
-    inherit openssl zlib;
+    inherit openssl zlib libuv;
 
     # disabled system v8 because v8 3.14 no longer receives security fixes
     # we fall back to nodejs' internal v8 copy which receives backports for now

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1724,15 +1724,15 @@ let
 
   ninka = callPackage ../development/tools/misc/ninka { };
 
-  nodejs = callPackage ../development/web/nodejs { };
-  nodejs-unstable = callPackage ../development/web/nodejs { unstableVersion = true; };
+  nodejs = callPackage ../development/web/nodejs { libuv = libuvVersions.v1_2_0; };
+  nodejs-unstable = callPackage ../development/web/nodejs { libuv = libuvVersions.v1_2_0; unstableVersion = true; };
 
   nodePackages = recurseIntoAttrs (
     callPackage ./node-packages.nix { self = nodePackages; }
   );
 
-  iojs = callPackage ../development/web/iojs { };
-  iojs-nightly = callPackage ../development/web/iojs { nightly = true; };
+  iojs = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_0; };
+  iojs-nightly = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_0; nightly = true; };
 
   iojsPackages = recurseIntoAttrs (
     callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; }


### PR DESCRIPTION
**Fair warning:** I have currently very little experience with Nix. ![I have ngo idea what I'm doing](http://i.kinja-img.com/gawker-media/image/upload/s--4AFOppDu--/c_fit,fl_progressive,q_80,w_320/18ugghs76a5otjpg.jpg).

---

Following #6234, I'm trying to build Node.js and io.js with a shared libuv instead of the one statically included in the source.

I could build both `iojs` and `nodejs` on NixOS with these updated expressions. I also successfully built `iojsPackages.npm` and `nodePackages.npm` and they seem to work properly.

I currently have a `nox-review wip` build running, however I believe it will fail like #6234 since (at least) the `stream-splitter-transform` package is currently broken.
