### PR TITLE
nix-prefetch-git: print commit date

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -254,6 +254,7 @@ clone_user_rev() {
     local full_revision=$(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/fetchgit) | tail -n1)
     echo "git revision is $full_revision"
     echo "git human-readable version is $(cd $dir && (git describe $full_revision 2> /dev/null || git describe --tags $full_revision 2> /dev/null || echo -- none --))" >&2
+    echo "Commit date is $(cd $dir && git show --no-patch --pretty=%ci $full_revision)"
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"


### PR DESCRIPTION
The commit date can be used as a version number in packages that don't
have proper releases.

---

nix-prefetch-git prints some messages to stdout and some to stderr. I don't see the pattern (not only error messages are printed to stderr), so I've added this new printout to stdout.

Should fix half of https://github.com/NixOS/nixpkgs/issues/6479.
