### PR TITLE
remove stdenv.isBSD

### DIFF
--- a/pkgs/development/compilers/chicken/default.nix
+++ b/pkgs/development/compilers/chicken/default.nix
@@ -5,9 +5,9 @@ let
   platform = with stdenv;
     if isDarwin then "macosx"
     else if isCygwin then "cygwin"
-    else if isBSD then "bsd"
+    else if (isFreeBSD || isOpenBSD) then "bsd"
     else if isSunOS then "solaris"
-    else "linux";               # Should be a sane default
+    else "linux"; # Should be a sane default
   lib = stdenv.lib;
 in
 stdenv.mkDerivation {

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -21,14 +21,13 @@ stdenv.mkDerivation rec {
 
   dontStrip = stdenv ? cross; # Don't run the native `strip' when cross-compiling.
 
-  postInstall =
-    # Install headers in the right place.
-    '' ln -s${if stdenv.isBSD then "" else "r"}v "$out/lib/"libffi*/include "$out/include"
-    '';
+  # Install headers in the right place.
+  postInstall = ''
+    ln -s${if (stdenv.isFreeBSD || stdenv.isOpenBSD || stdenv.isDarwin) then "" else "r"}v "$out/lib/"libffi*/include "$out/include"
+  '';
 
   meta = {
     description = "A foreign function call interface library";
-
     longDescription = ''
       The libffi library provides a portable, high level programming
       interface to various calling conventions.  This allows a
@@ -43,12 +42,9 @@ stdenv.mkDerivation rec {
       interface.  A layer must exist above libffi that handles type
       conversions for values passed between the two languages.
     '';
-
     homepage = http://sourceware.org/libffi/;
-
     # See http://github.com/atgreen/libffi/blob/master/LICENSE .
     license = stdenv.lib.licenses.free;
-
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -200,14 +200,9 @@ let
       isCygwin = system == "i686-cygwin"
               || system == "x86_64-cygwin";
       isFreeBSD = system == "i686-freebsd"
-              || system == "x86_64-freebsd";
+               || system == "x86_64-freebsd";
       isOpenBSD = system == "i686-openbsd"
-              || system == "x86_64-openbsd";
-      isBSD = system == "i686-freebsd"
-           || system == "x86_64-freebsd"
-           || system == "i686-openbsd"
-           || system == "x86_64-openbsd"
-           || system == "x86_64-darwin";
+               || system == "x86_64-openbsd";
       isi686 = system == "i686-linux"
             || system == "i686-gnu"
             || system == "i686-freebsd"

--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     ''
        # Fix for building on Glibc 2.16.  Won't be needed once the
        # gnulib in sharutils is updated.
-       sed -i ${stdenv.lib.optionalString (stdenv.isBSD && stdenv.cc.nativeTools) "''"} '/gets is a security hole/d' lib/stdio.in.h
+       sed -i ${stdenv.lib.optionalString ((stdenv.isFreeBSD || stdenv.isOpenBSD || stdenv.isDarwin) && stdenv.cc.nativeTools) "''"} '/gets is a security hole/d' lib/stdio.in.h
     '';
 
   # GNU Gettext is needed on non-GNU platforms.
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Tools for remote synchronization and `shell archives'";
-
     longDescription =
       '' GNU shar makes so-called shell archives out of many files, preparing
          them for transmission by electronic mail services.  A shell archive
@@ -43,11 +42,8 @@ stdenv.mkDerivation rec {
          by a copy of the shell. unshar may also process files containing
          concatenated shell archives.
       '';
-
     homepage = http://www.gnu.org/software/sharutils/;
-
     license = stdenv.lib.licenses.gpl3Plus;
-
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/tools/archivers/zpaq/default.nix
+++ b/pkgs/tools/archivers/zpaq/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, unzip}:
+{ stdenv, fetchurl, unzip }:
 let
   s = # Generated upstream information
   rec {
@@ -12,7 +12,7 @@ let
   buildInputs = [
     unzip
   ];
-  isUnix = stdenv.isLinux || stdenv.isGNU || stdenv.isDarwin || stdenv.isBSD;
+  isUnix = with stdenv; isLinux || isGNU || isDarwin || isFreeBSD || isOpenBSD;
   isx86 = stdenv.isi686 || stdenv.isx86_64;
   compileFlags = ""
     + (stdenv.lib.optionalString isUnix " -Dunix -pthread ")

--- a/pkgs/tools/archivers/zpaq/zpaqd.nix
+++ b/pkgs/tools/archivers/zpaq/zpaqd.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, unzip}:
+{ stdenv, fetchurl, unzip }:
 let
   s = # Generated upstream information
   rec {
@@ -12,7 +12,7 @@ let
   buildInputs = [
     unzip
   ];
-  isUnix = stdenv.isLinux || stdenv.isGNU || stdenv.isDarwin || stdenv.isBSD;
+  isUnix = with stdenv; isLinux || isGNU || isDarwin || isFreeBSD || isOpenBSD;
   isx86 = stdenv.isi686 || stdenv.isx86_64;
   compileFlags = ""
     + (stdenv.lib.optionalString isUnix " -Dunix -pthread ")

--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl }:
 
 let
   version = "1.7.0";
@@ -6,17 +6,17 @@ let
   # These settings are found in the Makefile, but there seems to be no
   # way to select one ore the other setting other than editing the file
   # manually, so we have to duplicate the know how here.
-  systemFlags =
-    if stdenv.isDarwin then ''
+  systemFlags = with stdenv;
+    if isDarwin then ''
       CFLAGS="-O2 -Wall -fomit-frame-pointer"
       LDFLAGS=
       EXTRA_OBJS=strverscmp.o
-    '' else if stdenv.isCygwin then ''
+    '' else if isCygwin then ''
       CFLAGS="-O2 -Wall -fomit-frame-pointer -DCYGWIN"
       LDFLAGS=-s
       TREE_DEST=tree.exe
       EXTRA_OBJS=strverscmp.o
-    '' else if stdenv.isBSD then ''
+    '' else if (isFreeBSD || isOpenBSD) then ''
       CFLAGS="-O2 -Wall -fomit-frame-pointer"
       LDFLAGS=-s
       EXTRA_OBJS=strverscmp.o


### PR DESCRIPTION
Darwin is a BSD derived OS, however there are vast differences between Darwin and open source BSDs (e.g. the graphics stack), so adding Darwin to `isBSD` diminishes its usefulness.

Darwin was added to `isBSD` by this commit for Darwin fixes: 3e8344d334d42824ac3061a919ac15b19a1bf21d

Adding Darwin to `isBSD` more or less broke the functionality of the following:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/archivers/zpaq/default.nix
https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/archivers/zpaq/zpaqd.nix
https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/system/tree/default.nix
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/chicken/default.nix3
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/libffi/default.nix
