### PR TITLE
[WIP] Fix naming conflict between Node and io.js packages

### DIFF
--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, nodejs, neededNatives}:
+{ stdenv, runCommand, nodejs, neededNatives, prefix ? "node-", binPrefix ? "bin-" }:
 
 {
   name, src,
@@ -263,7 +263,7 @@ let
     passthru.pkgName = pkgName;
   } // (filterAttrs (n: v: n != "deps" && n != "resolvedDeps") args) // {
     name = "${
-      if bin == true then "bin-" else if bin == false then "node-" else ""
+      if bin == true then binPrefix else if bin == false then prefix else ""
     }${name}";
 
     # Run the node setup hook when this package is a build input

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1735,7 +1735,7 @@ let
   iojs-nightly = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_0; nightly = true; };
 
   iojsPackages = recurseIntoAttrs (
-    callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; }
+    callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; prefix = "iojs-"; binPrefix = "bin-iojs-"; }
   );
 
   ldapvi = callPackage ../tools/misc/ldapvi { };

--- a/pkgs/top-level/node-packages.nix
+++ b/pkgs/top-level/node-packages.nix
@@ -4,6 +4,12 @@
   # Self-reference
 , self
 
+  # Prefix for package names
+, prefix ? "node-"
+
+  # Prefix for binary package names
+, binPrefix ? "bin-"
+
   # Needed natives for installation
 , neededNatives ? [pkgs.python] ++ stdenv.lib.optionals stdenv.isLinux [ pkgs.utillinux ]
 
@@ -40,7 +46,7 @@ rec {
   let
     pkg = makeOverridable (
       pkgs.callPackage ../development/web/nodejs/build-node-package.nix {
-        inherit nodejs neededNatives;
+        inherit nodejs neededNatives prefix binPrefix;
       }
     ) (args // (optionalAttrs (isList args.src) {
       # Backwards compatibility


### PR DESCRIPTION
Reference "issue": https://github.com/NixOS/nixpkgs/pull/6513#issuecomment-75516885
- Added `prefix` and `binPrefix` parameters to `build-node-package`, defaulting to respectively `node-` and `bin-`. It's backward compatible for `nodePackages`.
- On `top-level`, `iojsPackages` set them to respectively `iojs-` and `iojs-bin-`. This is not consistent with `nodePackages`, since `bin-` would conflict; shouldn't binary Node packages be prefixed with `bin-node-` instead? This wouldn't be BC though.
- `node-packages.nix` will "proxy" the `prefix` and `binPrefix` to `build-node-package`, and defines the same default values. Any idea how to avoid repeating the default values here while stile making these parameters optional?
- About this line:
  
  ``` nix
  if bin == true then binPrefix else if bin == false then prefix else ""
  ```
  
  I just made the prefixes configurable, but I'm curious about the final `else`; I don't know if `bin` is supposed to be ever neither true nor false, but if this can happen, packages will still conflict… maybe this should be enough?
  
  ``` nix
  if bin == true then binPrefix else prefix
  ```

_PR not tested yet, I can try it only tonight but I already wanted to raise some questions about the implementation._
