### PR TITLE
[WIP] qgis: update to 2.8.0

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -2,7 +2,7 @@
   pyqt4, qwt, fcgi, pythonPackages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "qgis-2.6.1";
+  name = "qgis-2.8.1";
 
   buildInputs = [ gdal qt4 flex bison proj geos x11 sqlite gsl pyqt4 qwt qscintilla
     fcgi libspatialindex libspatialite postgresql ] ++
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://qgis.org/downloads/${name}.tar.bz2";
-    sha256 = "1avw9mnhrcxsdalqr2yhyif1cacl4dsgcpfc31axkv7vj401djnl";
+    sha256 = "19acb74e4e2739238b87bf64f2750e10e366e9d61d070a4b8ca341ce01ca9741";
   };
 
   postInstall = ''

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qscintilla";
-  version = "2.8.4";
+  version = "2.9";
 
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/QScintilla2/QScintilla-${version}/QScintilla-gpl-${version}.tar.gz";
-    sha256 = "03z8mc7wpk0hyza9b45pyf523gdk0qsqaywkprmp6ffc81s2sywv";
+    sha256 = "d7c32e32582f93779de861006d87467b38b9ebc06e3d0b32e981cb24369fa417";
   };
 
   buildInputs = [ qt ];


### PR DESCRIPTION
I'm trying to update qgis. I could successfully compile. But when I try to run `qgis`, I get a 
- python error and 
- libpng incompatibility error.

```
libpng warning: Application was compiled with png.h from libpng-1.6.16
libpng warning: Application  is  running with png.c from libpng-1.2.50
libpng error: Incompatible libpng version in application and library
Traceback (most recent call last):
  File "/usr/lib/python2.7/site.py", line 563, in <module>
    main()
  File "/usr/lib/python2.7/site.py", line 545, in main
    known_paths = addusersitepackages(known_paths)
  File "/usr/lib/python2.7/site.py", line 272, in addusersitepackages
    user_site = getusersitepackages()
  File "/usr/lib/python2.7/site.py", line 247, in getusersitepackages
    user_base = getuserbase() # this will also set USER_BASE
  File "/usr/lib/python2.7/site.py", line 237, in getuserbase
    USER_BASE = get_config_var('userbase')
  File "/usr/lib/python2.7/sysconfig.py", line 582, in get_config_var
    return get_config_vars().get(name)
  File "/usr/lib/python2.7/sysconfig.py", line 528, in get_config_vars
    _init_posix(_CONFIG_VARS)
  File "/usr/lib/python2.7/sysconfig.py", line 412, in _init_posix
    from _sysconfigdata import build_time_vars
  File "/usr/lib/python2.7/_sysconfigdata.py", line 6, in <module>
    from _sysconfigdata_nd import *
ImportError: No module named _sysconfigdata_nd
```

@vbgl was the python error solved in #4898?
