### PR TITLE
microscheme: update to latest release (0.9.1)

### DIFF
--- a/pkgs/development/compilers/microscheme/default.nix
+++ b/pkgs/development/compilers/microscheme/default.nix
@@ -1,27 +1,19 @@
-{ stdenv, fetchgit, vim, avrdude, avrgcclibc, makeWrapper }:
+{ stdenv, fetchzip, vim, avrdude, avrgcclibc, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "microscheme-${version}";
-  version = "2015-02-04";
+  version = "0.9.2";
 
-  # externalize url/rev/sha256 to permit easier override
-  rev = "2f14781034a67adc081a22728fbf47a632f4484e";
-  sha256 = "15bdlmchzbhxj262r2fj78wm4c4hfrap4kyzv8n5b624svszr0zd";
-  url = https://github.com/ryansuchocki/microscheme.git;
-
-  src = fetchgit {
-    inherit rev;
-    inherit sha256;
-    inherit url;
+  src = fetchzip {
+    name = "${name}-src";
+    url = "https://github.com/ryansuchocki/microscheme/archive/v${version}.tar.gz";
+    sha256 = "0ly1cphvnsip70kng9q0blb07pkyp9allav42sr6ybswqfqg60j9";
   };
 
   buildInputs = [ makeWrapper vim ];
 
   installPhase = ''
-    mkdir -p $out/bin && make install PREFIX=$out
-
-    mkdir -p $out/share/microscheme/
-    cp -r examples/ $out/share/microscheme
+    make install PREFIX=$out
 
     wrapProgram $out/bin/microscheme \
       --prefix PATH : "${avrdude}/bin:${avrgcclibc}/bin"


### PR DESCRIPTION
- Don't "externalize url/rev/sha256 to permit easier override".
  Just override 'src' itself. Then you can get the source from anywhere,
  not just git. I needed to touch this anyway, because I want to use
  fetchzip instead of fetchgit for releases (no need to clone repo).
- Latest release has "make install" fixes, simplifies our install.

---

@ardumont: The example you put in the commit message for adding microscheme fails for me, both with this and the previous version. I've stripped the -u and -d flag as I don't have hardware, but I don't think that matters:

```
$ ./result/bin/microscheme -m UNO -ac ./result/share/microscheme/examples/BLINK.ms
Microscheme 0.9.1, (C) Ryan Suchocki
>> Treeshaker: After 4 rounds: 87 globals purged! 22 bytes will be reserved.
>> 18 lines compiled OK
>> Assembling...
/nix/store/df458865akmncpd2qrp4xc3hw8s4gw5z-avr-gcc-libc/lib/gcc/avr/4.8.4/../../../../avr/bin/ld:.s: file format not recognized; treating as linker script
/nix/store/df458865akmncpd2qrp4xc3hw8s4gw5z-avr-gcc-libc/lib/gcc/avr/4.8.4/../../../../avr/bin/ld:.s:1: syntax error
collect2: error: ld returned 1 exit status
>> Warning: Command may have failed. (Exit code 256)
avr-objcopy: '.elf': No such file
>> Warning: Command may have failed. (Exit code 256)
>> Cleaning Up...
>> Finished.
```

```
$ ./result/bin/microscheme -m UNO -ac ./result/share/microscheme/examples/BLINK.ms
Microscheme 0.8, (C) Ryan Suchocki
>> Treeshaker: After 4 rounds: 84 globals purged! 22 bytes will be reserved.
>> 18 lines compiled OK
>> Assembling...
/nix/store/df458865akmncpd2qrp4xc3hw8s4gw5z-avr-gcc-libc/lib/gcc/avr/4.8.4/../../../../avr/bin/ld:.s: file format not recognized; treating as linker script
/nix/store/df458865akmncpd2qrp4xc3hw8s4gw5z-avr-gcc-libc/lib/gcc/avr/4.8.4/../../../../avr/bin/ld:.s:1: syntax error
collect2: error: ld returned 1 exit status
>> Warning: Command may have failed. (Exit code 256)
avr-objcopy: '.elf': No such file
>> Warning: Command may have failed. (Exit code 256)
>> Cleaning Up...
>> Finished.
```
