### PR TITLE
OracleJDK: use fetchurl instead of requireFile

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -9,7 +9,7 @@ source $mirrorsFile
 # cryptographic hash of the output anyway).
 curl="curl \
  --location --max-redirs 20 \
- --retry 3
+ --retry 3 \
  --disable-epsv \
  --cookie-jar cookies \
  --insecure \
@@ -32,7 +32,7 @@ tryDownload() {
     # if we get error code 18, resume partial download
     while [ $curlexit -eq 18 ]; do
        # keep this inside an if statement, since on failure it doesn't abort the script
-       if $curl -C - --fail "$url" --output "$downloadedFile"; then
+       if eval $curl -C - --fail "$url" --output "$downloadedFile"; then
           success=1
           break
        else
@@ -58,7 +58,7 @@ tryHashedMirrors() {
 
     for mirror in $hashedMirrors; do
         url="$mirror/$outputHashAlgo/$outputHash"
-        if $curl --retry 0 --connect-timeout "${NIX_CONNECT_TIMEOUT:-15}" \
+        if eval $curl --retry 0 --connect-timeout "${NIX_CONNECT_TIMEOUT:-15}" \
             --fail --silent --show-error --head "$url" \
             --write-out "%{http_code}" --output /dev/null > code 2> log; then
             tryDownload "$url"

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -1,16 +1,16 @@
 { productVersion
 , patchVersion
-, downloadUrl
+, url_i686
+, url_x86_64
 , sha256_i686
 , sha256_x86_64
-, jceName
-, jceDownloadUrl
+, urlJCE
 , sha256JCE
 }:
 
 { swingSupport ? true
 , stdenv
-, requireFile
+, fetchurl
 , unzip
 , file
 , xlibs ? null
@@ -51,10 +51,10 @@ let
 
   jce =
     if installjce then
-      requireFile {
-        name = jceName;
-        url = jceDownloadUrl;
+      fetchurl {
+        url = urlJCE;
         sha256 = sha256JCE;
+        curlOpts = "-H \`echo 'Cookie: oraclelicense=accept-securebackup-cookie'\`";
       }
     else
       "";
@@ -66,16 +66,16 @@ let result = stdenv.mkDerivation rec {
 
   src =
     if stdenv.system == "i686-linux" then
-      requireFile {
-        name = "jdk-${productVersion}u${patchVersion}-linux-i586.tar.gz";
-        url = downloadUrl;
+      fetchurl {
+        url = url_i686;
         sha256 = sha256_i686;
+        curlOpts = "-H 'Cookie: oraclelicense=accept-securebackup-cookie'";
       }
     else if stdenv.system == "x86_64-linux" then
-      requireFile {
-        name = "jdk-${productVersion}u${patchVersion}-linux-x64.tar.gz";
-        url = downloadUrl;
+      fetchurl {
+        url = url_x86_64;
         sha256 = sha256_x86_64;
+        curlOpts = "-H 'Cookie: oraclelicense=accept-securebackup-cookie'";
       }
     else
       abort "jdk requires i686-linux or x86_64 linux";

--- a/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
   patchVersion = "75";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
+  url_i686 = http://download.oracle.com/otn-pub/java/jdk/7u75-b13/jdk-7u75-linux-i586.tar.gz;
+  url_x86_64 = http://download.oracle.com/otn-pub/java/jdk/7u75-b13/jdk-7u75-linux-x64.tar.gz;
   sha256_i686 = "173ppi5d90hllqgys90wlv596bpj2iw8gsbsr6pk7xvd4l1wdhrw";
   sha256_x86_64 = "040n50nglr6rcli2pz5rd503c2qqdqqbqynp6hzc4kakkchmj2a6";
-  jceName = "UnlimitedJCEPolicyJDK7.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
+  urlJCE = http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";
 }

--- a/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
   patchVersion = "76";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
+  url_i686 = http://download.oracle.com/otn-pub/java/jdk/7u76-b13/jdk-7u76-linux-i586.tar.gz;
+  url_x86_64 = http://download.oracle.com/otn-pub/java/jdk/7u76-b13/jdk-7u76-linux-x64.tar.gz;
   sha256_i686 = "0558p5garc4b5g7h11dkzn161kpk84az5ad1q5hhsblbx02aqff3";
   sha256_x86_64 = "130ckrv846amyfzbnnd6skljkznc457yky7d6ajaw5ndsbzg93yf";
-  jceName = "UnlimitedJCEPolicyJDK7.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
+  urlJCE = http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";
 }

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
   patchVersion = "31";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
+  url_i686 = http://download.oracle.com/otn-pub/java/jdk/8u31-b13/jdk-8u31-linux-i586.tar.gz;
+  url_x86_64 = http://download.oracle.com/otn-pub/java/jdk/8u31-b13/jdk-8u31-linux-x64.tar.gz;
   sha256_i686 = "1sr3q9y0cd42cqpf98gsv3hvip0r1vw3d0jh6yml6krzdm96zp8s";
   sha256_x86_64 = "0dz4k3xds1ydqr77hmrjc1w0niqq3jm3h18nk3ibqr1083l1bq7g";
-  jceName = "jce_policy-8.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
+  urlJCE = http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip;
   sha256JCE = "f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59";
 }


### PR DESCRIPTION
So far the change only applies to JDK 7 and 8.
Also, 'fetchurl' is adapted slightly.
