### PR TITLE
VirtualBox 4.3.22 version bump

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -14,7 +14,7 @@ with stdenv.lib;
 let
   buildType = "release";
 
-  version = "4.3.20"; # changes ./guest-additions as well
+  version = "4.3.22"; # changes ./guest-additions as well
 
   forEachModule = action: ''
     for mod in \
@@ -35,13 +35,13 @@ let
   '';
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
-  extpackRevision = "96996";
+  extpackRevision = "98236";
   extensionPack = requireFile rec {
     name = "Oracle_VM_VirtualBox_Extension_Pack-${version}-${extpackRevision}.vbox-extpack";
     # IMPORTANT: Hash must be base16 encoded because it's used as an input to
     # VBoxExtPackHelperApp!
     # Tip: see http://dlc.sun.com.edgesuite.net/virtualbox/4.3.10/SHA256SUMS
-    sha256 = "7e1253f7013e9cdc84a614a0db38b40de7bbd330cb5b85bd3ef3de213773450d";
+    sha256 = "6ba0d2f46143505f4bf8843538f773a030752c5f2f368bf862f14c9fca234c96";
     message = ''
       In order to use the extension pack, you need to comply with the VirtualBox Personal Use
       and Evaluation License (PUEL) by downloading the related binaries from:
@@ -60,7 +60,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "1484f8e9993ec4fe3892c5165db84d238713d2506e147ed8236541ece642e965";
+    sha256 = "0d41e044589d3371f765a98ddc071d9cf9788289f72b7efbb5db64f5488c8eba";
   };
 
   buildInputs =

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "9ab48f44ac26a6deb374cb5fe6bad103bbf4fdf5186140e2d40ebe48bd01f3ea";
+    sha256 = "d415bdf5c1a37281e77243241acbb9576307379c66d368d7d0aba233fdb1435e";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/*/build";


### PR DESCRIPTION
Pretty please? Works on my netbook. This version supports Windows 10 Tech Preview guests (fixes Windows update).
