### PR TITLE
Add cassandra 2.0

### DIFF
--- a/pkgs/servers/nosql/cassandra/2.0.nix
+++ b/pkgs/servers/nosql/cassandra/2.0.nix
@@ -8,13 +8,19 @@
 , getopt
 }:
 
-let version = "2.1.3";
-in stdenv.mkDerivation rec {
+let
+
+  version = "2.0.12";
+  sha256 = "125yga0h155fwp5kvgv57y5yyv7x4inib4fp9xsckmc7n7kmjvxg";
+
+in
+
+stdenv.mkDerivation rec {
   name = "cassandra-${version}";
 
   src = fetchurl {
+    inherit sha256;
     url = "http://apache.cs.utah.edu/cassandra/${version}/apache-${name}-bin.tar.gz";
-    sha256 = "1hzb7h73vr28v9axw85c1987l2i5g4i9ivmgq5mqlv3cv1ng0knz";
   };
 
   buildInputs = [ makeWrapper ];
@@ -39,6 +45,6 @@ in stdenv.mkDerivation rec {
     description = "A massively scalable open source NoSQL database";
     platforms = with platforms; all;
     license = with licenses; asl20;
-    maintainers = with maintainers; [ nckx ];
+    maintainers = with maintainers; [ nckx rushmorem ];
   };
 }

--- a/pkgs/servers/nosql/cassandra/2.1.nix
+++ b/pkgs/servers/nosql/cassandra/2.1.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, fetchurl
+, jre
+, python
+, makeWrapper
+, gawk
+, bash
+, getopt
+}:
+
+let
+
+  version = "2.1.3";
+  sha256 = "1hzb7h73vr28v9axw85c1987l2i5g4i9ivmgq5mqlv3cv1ng0knz";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "cassandra-${version}";
+
+  src = fetchurl {
+    inherit sha256;
+    url = "http://apache.cs.utah.edu/cassandra/${version}/apache-${name}-bin.tar.gz";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir $out
+    mv * $out
+
+    for cmd in cassandra nodetool sstablekeys sstableloader sstableupgrade
+      do wrapProgram $out/bin/$cmd \
+        --set JAVA_HOME ${jre} \
+        --prefix PATH : ${bash}/bin \
+        --prefix PATH : ${getopt}/bin \
+        --prefix PATH : ${gawk}/bin
+    done
+
+    wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://cassandra.apache.org/;
+    description = "A massively scalable open source NoSQL database";
+    platforms = with platforms; all;
+    license = with licenses; asl20;
+    maintainers = with maintainers; [ nckx rushmorem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7947,7 +7947,9 @@ let
 
   cadvisor = callPackage ../servers/monitoring/cadvisor { };
 
-  cassandra = callPackage ../servers/nosql/cassandra { };
+  cassandra_2_0 = callPackage ../servers/nosql/cassandra/2.0.nix { };
+  cassandra_2_1 = callPackage ../servers/nosql/cassandra/2.1.nix { };
+  cassandra = cassandra_2_1;
 
   apache-jena = callPackage ../servers/nosql/apache-jena/binary.nix {
     java = jdk;


### PR DESCRIPTION
According to the project website (http://cassandra.apache.org)
version 2.0 is the most stable version. It's the one that's
recommended if you are already in production or going into
production soon.

Cassandra 2.0 is also the version that's officially supported
by Titan (http://thinkaurelius.github.io/titan), a distributed
graph database that uses cassandra as one of it's backends.
