### PR TITLE
Fix rebooting containers where resolv.conf is a symlink

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -212,7 +212,7 @@ in
               "/nix/var/nix/profiles/per-container/$INSTANCE" \
               "/nix/var/nix/gcroots/per-container/$INSTANCE"
 
-            cp -f /etc/resolv.conf "$root/etc/resolv.conf"
+            cp --remove-destination /etc/resolv.conf "$root/etc/resolv.conf"
 
             if [ "$PRIVATE_NETWORK" = 1 ]; then
               extraFlags+=" --network-veth"


### PR DESCRIPTION
If resolv.conf is a symlink within a container (as is the case if the container uses `systemd-resovled`), `cp -f`will fail due to resolv.conf being a dangling symlink. The correct invocation should be `cp --remove-destination`.
