### PR TITLE
memtest86+: fix reboot issues

### DIFF
--- a/pkgs/tools/misc/memtest86+/compile-fix.patch
+++ b/pkgs/tools/misc/memtest86+/compile-fix.patch
@@ -1,0 +1,20 @@
+--- memtest86+-5.01/io.h~	2013-08-10 02:01:58.000000000 +0000
++++ memtest86+-5.01/io.h	2014-01-08 01:29:12.404465515 +0000
+@@ -31,7 +31,7 @@
+  */
+ 
+ #define __OUT1(s,x) \
+-extern inline void __out##s(unsigned x value, unsigned short port) {
++static inline void __out##s(unsigned x value, unsigned short port) {
+ 
+ #define __OUT2(s,s1,s2) \
+ __asm__ __volatile__ ("out" #s " %" s1 "0,%" s2 "1"
+@@ -43,7 +43,7 @@
+ __OUT1(s##c_p,x) __OUT2(s,s1,"") : : "a" (value), "id" (port)); SLOW_DOWN_IO; }
+ 
+ #define __IN1(s) \
+-extern inline RETURN_TYPE __in##s(unsigned short port) { RETURN_TYPE _v;
++static inline RETURN_TYPE __in##s(unsigned short port) { RETURN_TYPE _v;
+ 
+ #define __IN2(s,s1,s2) \
+ __asm__ __volatile__ ("in" #s " %" s2 "1,%" s1 "0"

--- a/pkgs/tools/misc/memtest86+/crash-fix.patch
+++ b/pkgs/tools/misc/memtest86+/crash-fix.patch
@@ -1,0 +1,99 @@
+diff --git a/controller.c b/controller.c
+index f4f7371..183e9c3 100644
+--- a/controller.c
++++ b/controller.c
+@@ -2,6 +2,8 @@
+  * MemTest86+ V5 Specific code (GPL V2.0)
+  * By Samuel DEMEULEMEESTER, sdemeule@memtest.org
+  * http://www.canardpc.com - http://www.memtest.org
++ *
++ * Edited by David McInnis Oct 4, 2014
+  */
+ 
+ //#include "defs.h"
+@@ -292,7 +294,7 @@ static void setup_nhm(void)
+ 
+ 	/* First, locate the PCI bus where the MCH is located */
+ 
+-	for(i = 0; i < sizeof(possible_nhm_bus); i++) {
++	for(i = 0; i < sizeof(possible_nhm_bus) / sizeof(possible_nhm_bus[0]); i++) {
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x00, 2, &vid);
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x02, 2, &did);
+ 		vid &= 0xFFFF;
+@@ -327,7 +329,7 @@ static void setup_nhm32(void)
+ 	ctrl.mode = ECC_NONE;
+ 
+ 	/* First, locate the PCI bus where the MCH is located */
+-	for(i = 0; i < sizeof(possible_nhm_bus); i++) {
++	for(i = 0; i < sizeof(possible_nhm_bus) / sizeof(possible_nhm_bus[0]); i++) {
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x00, 2, &vid);
+ 		pci_conf_read( possible_nhm_bus[i], 3, 4, 0x02, 2, &did);
+ 		vid &= 0xFFFF;
+@@ -1424,7 +1426,7 @@ static void poll_fsb_amd64(void) {
+ 	unsigned long dramchr;
+ 	float clockratio;
+ 	double dramclock;
+-	unsigned int dummy[3];
++	unsigned int dummy[4];
+ 	int ram_type;
+ 
+ 	float coef = 10;
+@@ -2851,13 +2853,13 @@ static void poll_timings_nf4ie(void) {
+ 
+ static void poll_timings_i875(void) {
+ 
+-	ulong dev6, dev62;
++	ulong dev6;
+ 	ulong temp;
+ 	float cas;
+ 	int rcd, rp, ras, chan;
+ 	long *ptr, *ptr2;
+ 
+-	pci_conf_read( 0, 6, 0, 0x40, 4, &dev62);
++	pci_conf_read( 0, 6, 0, 0x40, 4, &dev6);
+ 	ptr2=(long*)(dev6+0x68);
+ 
+ 	/* Read the MMR Base Address & Define the pointer */
+diff --git a/init.c b/init.c
+index 754b8d7..5bd8b4f 100644
+--- a/init.c
++++ b/init.c
+@@ -7,6 +7,8 @@
+  *
+  * Released under version 2 of the Gnu Public License.
+  * By Chris Brady
++ *
++ * Edited by David McInnis October 4, 2014
+  */
+  
+ 
+@@ -914,7 +916,6 @@ void cpu_type(void)
+ 			default:
+ 				cprint(0, COL_MID, "Unknown Intel");
+  				break;
+-			break;
+ 		    }
+ 
+ 		}
+diff --git a/main.c b/main.c
+index 0bc7ca0..613f811 100644
+--- a/main.c
++++ b/main.c
+@@ -422,7 +422,7 @@ void test_start(void)
+ 		//initialise_cpus();
+ 		btrace(my_cpu_num, __LINE__, "BeforeInit", 1, 0, 0);
+ 		/* Draw the screen and get system information */
+-	  init();
++		init();
+ 
+ 		/* Set defaults and initialize variables */
+ 		set_defaults();
+@@ -737,7 +737,7 @@ void test_start(void)
+ 			    /* Do the same test for each CPU */
+ 			    if (++cpu_sel >= act_cpus) 
+ 			    	{
+-	            cpu_sel = 0;
++				cpu_sel = 0;
+ 			        next_test();
+ 			    	} else {
+ 			        continue;

--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -8,6 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "0fch1l55753y6jkk0hj8f6vw4h1kinkn9ysp22dq5g9zjnvjf88l";
   };
 
+  # Patch incompatiblity with GCC. Source: http://koji.fedoraproject.org/koji/buildinfo?buildID=586907
+  patches = [ ./compile-fix.patch ./crash-fix.patch ./no-optimization.patch ];
+
   preBuild = ''
     # Really dirty hack to get Memtest to build without needing a Glibc
     # with 32-bit libraries and headers.

--- a/pkgs/tools/misc/memtest86+/no-optimization.patch
+++ b/pkgs/tools/misc/memtest86+/no-optimization.patch
@@ -1,0 +1,11 @@
+--- memtest86+-5.01/Makefile~	2014-01-08 01:30:11.355900076 +0000
++++ memtest86+-5.01/Makefile	2014-01-08 01:31:19.387555469 +0000
+@@ -12,7 +12,7 @@
+ AS=as -32
+ CC=gcc
+ 
+-CFLAGS= -Wall -march=i486 -m32 -O1 -fomit-frame-pointer -fno-builtin \
++CFLAGS= -Wall -march=i486 -m32 -O0 -fomit-frame-pointer -fno-builtin \
+ 	-ffreestanding -fPIC $(SMP_FL) -fno-stack-protector 
+ 	
+ OBJS= head.o reloc.o main.o test.o init.o lib.o patn.o screen_buffer.o \


### PR DESCRIPTION
As reported in #6145, memtest86+ currently does not work correctly. Booting into the menu works, but after that any user operation results in a reboot. This is due to an incompatiblity with GCC.

~~In this PR it's using the prebuilt binary of memtest86+ instead of trying to compile it.~~

~~Alternatively the source of memtest86+ could be patched. This is what Fedora has done, so we can reuse their patches. However, since we cannot automatically test memtest86+ and it isn't depending on anything at runtime, I thought it would be ok to use the prebuilt binary.~~

This PR reuses the patches from Fedora.

More information:
https://bugzilla.redhat.com/show_bug.cgi?id=1108079
https://bugzilla.redhat.com/show_bug.cgi?id=1013110
http://koji.fedoraproject.org/koji/buildinfo?buildID=586907

I tried to test this using just qemu, but that didn't work somehow. Instead I used the following script:

```
fallocate -l 8M /tmp/memtest.img
mkfs.vfat /tmp/memtest.img
mcopy -i /tmp/memtest.img result/memtest.bin ::memtest.bin
cat > /tmp/syslinux.cfg << EOF
DEFAULT memtest
LABEL memtest
  MENU LABEL Memtest86+
  LINUX memtest.bin
EOF
mcopy -i /tmp/memtest.img /tmp/syslinux.cfg ::syslinux.cfg
syslinux /tmp/memtest.img
qemu-system-x86_64 -hda /tmp/memtest.img
```
