### PR TITLE
tlsdate doesn't build on x86_64-darwin

### DIFF
--- a/pkgs/tools/networking/tlsdate/default.nix
+++ b/pkgs/tools/networking/tlsdate/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Secure parasitic rdate replacement";
     homepage = https://github.com/ioerror/tlsdate;
-    platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.tv ];
+    platforms = stdenv.lib.platforms.allBut [ "darwin" ];
   };
 }


### PR DESCRIPTION
tlsdate [fails](http://hydra.nixos.org/build/19975753) to build on x86_64-darwin. As I've no darwin system do make it work, I've to remove it from the supported platforms.
