### PR TITLE
fix to: ~/.nix-defexpr wasn't created

### DIFF
--- a/nixos/doc/manual/configuration/user-mgmt.xml
+++ b/nixos/doc/manual/configuration/user-mgmt.xml
@@ -65,6 +65,15 @@ account named <literal>alice</literal>:
 <screen>
 $ useradd -m alice</screen>
 
+<para>To make all nix tools available to this new user use `su - USER` which 
+opens a login shell (==shell that loads the profile) for given user. 
+This will create the ~/.nix-defexpr symlink. So run: </para>
+
+<screen>
+$ su - alice -c "true"
+</screen>
+
+
 The flag <option>-m</option> causes the creation of a home directory
 for the new user, which is generally what you want.  The user does not
 have an initial password and therefore cannot log in.  A password can


### PR DESCRIPTION
warning: i did not build the documentation so i don't know how it looks.
# nix-build

i tried though

```
% nix-build nixos/release.nix -A manual.x86_64-linux 
these derivations will be built:
  /nix/store/4lmdg7gidgaj29mggfyv2p99k5qdxsxp-nixos-manual.drv
building path(s) ‘/nix/store/ywby4c0kpvjaq1r53b18swylydzy2234-nixos-manual’
manual.xml:16: element tgroup: Relax-NG validity error : Did not expect element tgroup there
manual.xml:9: element para: Relax-NG validity error : Did not expect element para there
manual.xml:35: element para: Relax-NG validity error : Element chapter has extra content: para
manual.xml:5: element chapter: Relax-NG validity error : Element part has extra content: chapter
manual.xml:7: element info: Relax-NG validity error : Element book has extra content: info
manual.xml fails to validate
builder for ‘/nix/store/4lmdg7gidgaj29mggfyv2p99k5qdxsxp-nixos-manual.drv’ failed with exit code 3

```
