### PR TITLE
lirc: upgraded to 0.9.2a

### DIFF
--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -8,6 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "011nwpxm5d12rsapljg3pjf9pgb0j8ngmc3zg69q4kv61hkx2zim";
   };
 
+  patchPhase = ''
+    sed -e 's|^#!/usr/bin/env python3$|#!${python3}/bin/python3|g' -i tools/*.py
+  '';
+
   preBuild = "patchShebangs .";
 
   buildInputs = [ alsaLib help2man pkgconfig x11 python3 ];

--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -1,23 +1,16 @@
-{ stdenv, fetchurl, alsaLib, bash, help2man }:
+{ stdenv, fetchurl, alsaLib, bash, help2man, pkgconfig, x11, python3 }:
 
 stdenv.mkDerivation rec {
-  name = "lirc-0.9.1a";
+  name = "lirc-0.9.2a";
 
   src = fetchurl {
     url = "mirror://sourceforge/lirc/${name}.tar.bz2";
-    sha256 = "191vhgsds221rzpzjibj005pfr182hq65hniqfd0qqsl5h1zwq8r";
+    sha256 = "011nwpxm5d12rsapljg3pjf9pgb0j8ngmc3zg69q4kv61hkx2zim";
   };
-
-  patches = [
-    (fetchurl {
-       url = "https://projects.archlinux.org/svntogit/packages.git/plain/trunk/lirc-0.9.1a-fix-segfaults.patch?h=packages/lirc";
-       sha256 = "00ainq7y8yh2r447968jid06cqfb1xirv24xxrkl0gvakrrv9gnh";
-    })
-  ];
 
   preBuild = "patchShebangs .";
 
-  buildInputs = [ alsaLib help2man ];
+  buildInputs = [ alsaLib help2man pkgconfig x11 python3 ];
 
   configureFlags = [
     "--with-driver=devinput"


### PR DESCRIPTION
An attempt to solve the problems mentioned in #6050. From ArchLinux repo I gathered that the patch wasn't needed anymore. In addition lirc now needs pkgconfig and x11. Python3 is used during the build phase.

I got everything compiled. Testing lirc gave a bit of trouble. I had the same trouble with lirc on the stable channel. I probably don't know how lirc works on a laptop (I only have it running on a non-nix raspberry pi).
