### PR TITLE
Making machine-id available in build-fhs-userenv environments

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/chroot-user.rb
+++ b/pkgs/build-support/build-fhs-userenv/chroot-user.rb
@@ -29,6 +29,7 @@ symlinks =
     ['pam.d', 'static'],
     ['fonts/fonts.conf', 'static'],
     ['fonts/conf.d/00-nixos.conf', 'static'],
+    ['machine-id', ''],
   ].map! { |x| [ "/host-etc/#{x[1]}/#{x[0]}", "etc/#{File.dirname x[0]}" ] }
 
 require 'tmpdir'

--- a/pkgs/build-support/build-fhs-userenv/chroot-user.rb
+++ b/pkgs/build-support/build-fhs-userenv/chroot-user.rb
@@ -29,7 +29,7 @@ symlinks =
     ['pam.d', 'static'],
     ['fonts/fonts.conf', 'static'],
     ['fonts/conf.d/00-nixos.conf', 'static'],
-  ].map! { |x| [ "host-etc/#{x[1]}/#{x[0]}", "etc/#{File.dirname x[0]}" ] }
+  ].map! { |x| [ "/host-etc/#{x[1]}/#{x[0]}", "etc/#{File.dirname x[0]}" ] }
 
 require 'tmpdir'
 require 'fileutils'


### PR DESCRIPTION
This PR fixes linking from /etc to /host-etc, and adds /etc/machine-id to those links. It fixes a problem with PulseAudio clients not being able to connect to the server running at host, by allowing programs in the userenv to connect to host's DBus (I don't know why, but this fixed sound in steam games for me).
