### PR TITLE
Add package: scim

### DIFF
--- a/pkgs/applications/misc/scim/default.nix
+++ b/pkgs/applications/misc/scim/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, yacc, ncurses, libxml2 }:
+
+let
+  version = "0.1.8";
+in
+stdenv.mkDerivation rec {
+
+  name = "scim-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/andmarti1424/scim/archive/v${version}.tar.gz";
+    sha256 = "0qjixb1hzbdrypbmzwb2iaw5wp57kn7fmm1zpjp4gzjyanrhazs2";
+  };
+
+  buildInputs = [ yacc ncurses libxml2 ];
+
+  buildPhase = ''
+    cd src
+
+    sed "s,prefix=/usr,prefix=$out," Makefile
+    sed "s,-I/usr/include/libxml2,-I$libxml2," Makefile
+
+    make
+    export DESTDIR=$out
+  '';
+
+  installPhase = ''
+    make install prefix=
+  '';
+
+  meta = {
+    homepage = "https://github.com/andmarti1424/scim";
+    description = "SCIM - Spreadsheet Calculator Improvised - SC fork";
+    license = {
+      fullName = "SCIM License";
+      url = "https://github.com/andmarti1424/scim/raw/master/LICENSE";
+    };
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    platforms = with stdenv.lib.platforms; linux; # Cannot test others
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11363,6 +11363,8 @@ let
     boost = boost155;
   };
 
+  scim = callPackage ../applications/misc/scim { };
+
   scite = callPackage ../applications/editors/scite { };
 
   scribus = callPackage ../applications/office/scribus {


### PR DESCRIPTION
scim is the sc successor, a commandline spreadsheet editor.

I asked upstream to provide git tags in their repository, but there are no tags yet, so I have to do `fetchgit` instead of `fetchurl` here.
