### PR TITLE
graphviz: Patch to fix CVE-2014-9157 (release-14.12)

### DIFF
--- a/pkgs/tools/graphics/graphviz/cve-2014-9157.patch
+++ b/pkgs/tools/graphics/graphviz/cve-2014-9157.patch
@@ -1,0 +1,24 @@
+From https://lists.debian.org/debian-qa-packages/2014/12/msg00048.html , which
+seems to come from Ubuntu.
+
+Subject: Fix format string vulnerability (CVE-2014-9157) in yyerror() routine
+Origin: https://github.com/ellson/graphviz/commit/99eda421f7ddc27b14e4ac1d2126e5fe41719081
+Author: Emden R. Gansner
+
+---
+ lib/cgraph/scan.l |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: b/lib/cgraph/scan.l
+===================================================================
+--- a/lib/cgraph/scan.l
++++ b/lib/cgraph/scan.l
+@@ -225,7 +225,7 @@
+ 	agxbput (&xb, buf);
+ 	agxbput (&xb, yytext);
+ 	agxbput (&xb,"'\n");
+-	agerr(AGERR,agxbuse(&xb));
++	agerr(AGERR, "%s", agxbuse(&xb));
+ 	agxbfree(&xb);
+ }
+ /* must be here to see flex's macro defns */

--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libpng, libjpeg, expat, libXaw
-, yacc, libtool, fontconfig, pango, gd, xlibs, gts, gettext, cairo
+, yacc, libtool, fontconfig, pango, gd, xlibs, gts, gettext, cairo, flex
 }:
 
 stdenv.mkDerivation rec {
@@ -11,11 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "17l5czpvv5ilmg17frg0w4qwf89jzh2aglm9fgx0l0aakn6j7al1";
   };
 
-  patches = [ ./0001-vimdot-lookup-vim-in-PATH.patch ];
+  patches =
+    [ ./0001-vimdot-lookup-vim-in-PATH.patch
+    
+      # NOTE: Once this patch is removed, flex can probably be removed from
+      # buildInputs.
+      ./cve-2014-9157.patch
+    ];
 
   buildInputs =
     [ pkgconfig libpng libjpeg expat libXaw yacc libtool fontconfig
-      pango gd gts
+      pango gd gts flex
     ] ++ stdenv.lib.optionals (xlibs != null) [ xlibs.xlibs xlibs.libXrender ]
     ++ stdenv.lib.optional (stdenv.system == "x86_64-darwin") gettext;
 


### PR DESCRIPTION
Cherry-picked from https://github.com/NixOS/nixpkgs/pull/6625.

I'll merge this in a couple of days after trying out a simple command to make sure it works.
