### PR TITLE
procmail: Patch to fix CVE-2014-3618.

### DIFF
--- a/pkgs/applications/misc/procmail/CVE-2014-3618.patch
+++ b/pkgs/applications/misc/procmail/CVE-2014-3618.patch
@@ -1,0 +1,18 @@
+From http://seclists.org/oss-sec/2014/q3/495 (with whitespace corrected).
+
+--- a/src/formisc.c 2013-08-04 00:13:33.000000000 -0700
++++ b/src/formisc.c 2014-09-03 11:42:25.986002396 -0700
+@@ -84,12 +84,11 @@
+ 	case '"':*target++=delim='"';start++;
+       }
+      ;{ int i;
+-	do
++	while(*start)
+ 	   if((i= *target++= *start++)==delim)	 /* corresponding delimiter? */
+ 	      break;
+ 	   else if(i=='\\'&&*start)		    /* skip quoted character */
+ 	      *target++= *start++;
+-	while(*start);						/* anything? */
+       }
+      hitspc=2;
+    }

--- a/pkgs/applications/misc/procmail/default.nix
+++ b/pkgs/applications/misc/procmail/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation {
     make DESTDIR=\$out install
    ";
 
-  phases = "unpackPhase installPhase";
+  phases = "unpackPhase patchPhase installPhase";
+
+  patches = [ ./CVE-2014-3618.patch ];
 
   src = fetchurl {
     url = ftp://ftp.fu-berlin.de/pub/unix/mail/procmail/procmail-3.22.tar.gz;


### PR DESCRIPTION
Tested with the example at http://seclists.org/oss-sec/2014/q3/495.
