### PR TITLE
Add option to build old androidndk r8e.

### DIFF
--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -1,27 +1,35 @@
 { stdenv, fetchurl, zlib, ncurses, p7zip, lib, makeWrapper
 , coreutils, file, findutils, gawk, gnugrep, gnused, jdk, which
-, platformTools
+, platformTools , pinToVersion8 ? false
 }:
 
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "android-ndk-r10c";
+  name = if pinToVersion8 then
+      "android-ndk-r8e"
+    else
+      "android-ndk-r10c";
 
   src = if stdenv.system == "i686-linux"
     then fetchurl {
-      url = "http://dl.google.com/android/ndk/${name}-linux-x86.bin";
-      sha256 = "0gyq68zrpzj3gkh81czs6r0jmikg5rwzh1bqg4rk16g2nxm4lll3";
+      url = if pinToVersion8 then "http://dl.google.com/android/ndk/${name}-linux-x86.tar.bz2"
+            else "http://dl.google.com/android/ndk/${name}-linux-x86.bin";
+      sha256 = if pinToVersion8 then "c2c4e0c8b3037149a0f5dbb08d72f814a52af4da9fff9d80328c675457e95a98"
+               else "0gyq68zrpzj3gkh81czs6r0jmikg5rwzh1bqg4rk16g2nxm4lll3";
     }
     else if stdenv.system == "x86_64-linux" then fetchurl {
-      url = "http://dl.google.com/android/ndk/${name}-linux-x86_64.bin";
-      sha256 = "126rqzkmf8xz1hqdziwx81yln17hpivs2j45rxhzdr45iw9b758c";
+      url = if pinToVersion8 then "http://dl.google.com/android/ndk/${name}-linux-x86_64.tar.bz2"
+            else "http://dl.google.com/android/ndk/${name}-linux-x86_64.bin";
+      sha256 = if pinToVersion8 then "093gf55zbh38p2gk5bdykj1vg9p5l774wjdzw5mhk4144jm1wdq7"
+               else "126rqzkmf8xz1hqdziwx81yln17hpivs2j45rxhzdr45iw9b758c";
     }
     else throw "platform ${stdenv.system} not supported!";
 
   phases = "buildPhase";
 
-  buildInputs = [ p7zip makeWrapper ];
+  buildInputs = if pinToVersion8 then [ makeWrapper ]
+                else [ p7zip makeWrapper ];
 
   buildCommand = let
     bin_path = "$out/bin";
@@ -42,13 +50,17 @@ stdenv.mkDerivation rec {
     set -x
     mkdir -pv $out/libexec
     cd $out/libexec
-    7z x $src
+
+    ${if pinToVersion8 then "tar -xjf $src"
+      else "7z x $src"}
 
     # so that it doesn't fail because of read-only permissions set
     cd -
     patch -p1 \
         --no-backup-if-mismatch \
-        -d $out/libexec/${name} < ${ ./make-standalone-toolchain.patch }
+        ${if pinToVersion8 then 
+             "-d $out/libexec/${name} < ${ ./make-standalone-toolchain_r8e.patch }"
+        else "-d $out/libexec/${name} < ${ ./make-standalone-toolchain.patch }"}
     cd ${pkg_path}
 
     find $out \( \

--- a/pkgs/development/mobile/androidenv/androidndk_r8e.nix
+++ b/pkgs/development/mobile/androidenv/androidndk_r8e.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, ncurses, p7zip, lib, makeWrapper
+{ stdenv, fetchurl, zlib, ncurses, lib, makeWrapper
 , coreutils, file, findutils, gawk, gnugrep, gnused, jdk, which
 , platformTools
 }:
@@ -6,22 +6,22 @@
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "android-ndk-r10c";
+  name = "android-ndk-r8e";
 
   src = if stdenv.system == "i686-linux"
     then fetchurl {
-      url = "http://dl.google.com/android/ndk/${name}-linux-x86.bin";
-      sha256 = "0gyq68zrpzj3gkh81czs6r0jmikg5rwzh1bqg4rk16g2nxm4lll3";
+      url = "http://dl.google.com/android/ndk/${name}-linux-x86.tar.bz2";
+      sha256 = "c2c4e0c8b3037149a0f5dbb08d72f814a52af4da9fff9d80328c675457e95a98";
     }
     else if stdenv.system == "x86_64-linux" then fetchurl {
-      url = "http://dl.google.com/android/ndk/${name}-linux-x86_64.bin";
-      sha256 = "126rqzkmf8xz1hqdziwx81yln17hpivs2j45rxhzdr45iw9b758c";
+      url = "http://dl.google.com/android/ndk/${name}-linux-x86_64.tar.bz2";
+      sha256 = "093gf55zbh38p2gk5bdykj1vg9p5l774wjdzw5mhk4144jm1wdq7";
     }
     else throw "platform ${stdenv.system} not supported!";
 
   phases = "buildPhase";
 
-  buildInputs = [ p7zip makeWrapper ];
+  buildInputs = [ makeWrapper ];
 
   buildCommand = let
     bin_path = "$out/bin";
@@ -42,13 +42,13 @@ stdenv.mkDerivation rec {
     set -x
     mkdir -pv $out/libexec
     cd $out/libexec
-    7z x $src
+    tar -xjf $src
 
     # so that it doesn't fail because of read-only permissions set
     cd -
     patch -p1 \
         --no-backup-if-mismatch \
-        -d $out/libexec/${name} < ${ ./make-standalone-toolchain.patch }
+        -d $out/libexec/${name} < ${ ./make-standalone-toolchain_r8e.patch }
     cd ${pkg_path}
 
     find $out \( \

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -147,6 +147,14 @@ rec {
     inherit (pkgs) coreutils file findutils gawk gnugrep gnused jdk which;
     inherit platformTools;
   };
+
+  androidndk_r8e = import ./androidndk.nix {
+    inherit (pkgs) stdenv fetchurl zlib ncurses p7zip lib makeWrapper;
+    inherit (pkgs) coreutils file findutils gawk gnugrep gnused jdk which;
+    inherit platformTools;
+    pinToVersion8 = true;
+  };
+
   
   buildApp = import ./build-app.nix {
     inherit (pkgs) stdenv jdk ant gnumake gawk file which;

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -148,11 +148,10 @@ rec {
     inherit platformTools;
   };
 
-  androidndk_r8e = import ./androidndk.nix {
-    inherit (pkgs) stdenv fetchurl zlib ncurses p7zip lib makeWrapper;
+  androidndk_r8e = import ./androidndk_r8e.nix {
+    inherit (pkgs) stdenv fetchurl zlib ncurses lib makeWrapper;
     inherit (pkgs) coreutils file findutils gawk gnugrep gnused jdk which;
     inherit platformTools;
-    pinToVersion8 = true;
   };
 
   

--- a/pkgs/development/mobile/androidenv/make-standalone-toolchain_r8e.patch
+++ b/pkgs/development/mobile/androidenv/make-standalone-toolchain_r8e.patch
@@ -1,0 +1,13 @@
+diff -ru android-ndk-r8e.old/build/tools/make-standalone-toolchain.sh android-ndk-r8e/build/tools/make-standalone-toolchain.sh
+--- android-ndk-r8e.old/build/tools/make-standalone-toolchain.sh	2014-10-16 03:46:32.000000000 +0200
++++ android-ndk-r8e/build/tools/make-standalone-toolchain.sh	2014-10-24 23:46:22.544928306 +0200
+@@ -194,6 +194,9 @@
+ # Now copy the GCC toolchain prebuilt binaries
+ run copy_directory "$TOOLCHAIN_PATH" "$TMPDIR"
+ 
++# Making it writable again
++chmod -R +w "$TMPDIR"
++
+ if [ -n "$LLVM_VERSION" ]; then
+   # Copy the clang/llvm toolchain prebuilt binaries
+   run copy_directory "$LLVM_TOOLCHAIN_PATH" "$TMPDIR"


### PR DESCRIPTION
This version is the one required to build mobile Firefox. See build
documentation here:

https://wiki.mozilla.org/Mobile/Fennec/Android/Detailed_build_instructions#Install_Android_NDK

@svanderburg 
