### PR TITLE
eclipse: update to 4.4.2

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -271,4 +271,19 @@ in {
     };
   };
 
+  eclipse_sdk_442 = buildEclipse {
+    name = "eclipse-sdk-4.4.2";
+    description = "Eclipse Classic";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = http://download.eclipse.org/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk-x86_64.tar.gz;
+          sha256 = "0g00alsixfaakmn4khr0m9fxvkrbhbg6qqfa27xr6a9np6gzg98l";
+
+        };
+      "i686-linux" = fetchurl {
+          url = http://download.eclipse.org/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk.tar.gz;
+          sha256 = "9f4238ce9f887a1a57bbc6c6898e43357d14a6d74f59385327813c5e82aa735d";
+        };
+    };
+  };
 }


### PR DESCRIPTION
I updated eclipse to version 4.4.2. I calculated the hash for the 32bit version with `nix-hash --type sha256 eclipse-SDK-4.4.2-linux-gtk.tar.gz`. Hope that is ok since `sha256sum eclipse-SDK-4.4.2-linux-gtk.tar.gz` returns a different result.

Best,
Sven
