### PR TITLE
Updated Arduino to 1.6.0

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb, unzip,
-  gccRaw, readline, zlib, ncurses, withGui ? false, gtk2 ? null
+  readline, zlib, ncurses, withGui ? false, gtk2 ? null
 }:
 
 assert withGui -> gtk2 != null;
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     zlib
     ncurses
     readline
-    gccRaw
+    stdenv.cc.cc
   ];
 
   installPhase = ''

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,28 +1,36 @@
-{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb
-, withGui ? false, gtk2 ? null
+{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb, unzip,
+  gccRaw, readline, zlib, ncurses, withGui ? false, gtk2 ? null
 }:
 
 assert withGui -> gtk2 != null;
 
 stdenv.mkDerivation rec {
 
-  version = "1.0.6";
+  version = "1.6.0";
   name = "arduino${stdenv.lib.optionalString (withGui == false) "-core"}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = "${version}";
-    sha256 = "0nr5b719qi03rcmx6swbhccv6kihxz3b8b6y46bc2j348rja5332";
+    sha256 = "1ycbcr16c53lrvqs9yksn80939ivfai28cxd1b29s61fv3xn7ccm";
   };
 
-  buildInputs = [ jdk ant file ];
+  buildInputs = [ jdk ant file unzip ];
 
   buildPhase = ''
-    cd ./core && ant 
-    cd ../build && ant 
+    cd ./build && ant 
     cd ..
   '';
+
+  rpath = stdenv.lib.makeLibraryPath [
+    zlib
+    ncurses
+    readline
+    gccRaw
+  ];
+
+
 
   installPhase = ''
     mkdir -p $out/share/arduino
@@ -34,24 +42,38 @@ stdenv.mkDerivation rec {
       sed -i -e "s|^java|${jdk}/bin/java|" "$out/share/arduino/arduino"
       sed -i -e "s|^LD_LIBRARY_PATH=|LD_LIBRARY_PATH=${gtk2}/lib:|" "$out/share/arduino/arduino"
       ln -sr "$out/share/arduino/arduino" "$out/bin/arduino"
+
+      cp -r build/shared/icons $out/share/arduino
+      mkdir $out/share/applications
+      cp build/linux/dist/arduino.desktop $out/share/applications
+      echo "Icon=$out/share/arduino/icons/128x128/apps/arduino.png" >> \
+        $out/share/applications/arduino.desktop
     ''}
 
     # Fixup "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
     echo "running patchelf on prebuilt binaries:"
-    find "$out" | while read filepath; do
+    echo "Setting rpath to ${rpath}:"
+    echo "ncurses: ${ncurses}:"
+    find "$out" -type f -executable | while read filepath; do
+        echo "Checking `basename $filepath`"
         if file "$filepath" | grep -q "ELF.*executable"; then
             # skip target firmware files
-            if echo "$filepath" | grep -q "\.elf$"; then
+            if [[ "$filepath" == *.elf ]]; then
                 continue
             fi
-            echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
+            echo "Patching $filepath"
+            #echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
             patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath"
             test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
+            patchelf --set-rpath ${rpath} "$filepath"
+            test $? -eq 0 || { echo "patchelf failed to set rpath for $filepath"; exit 1; }
         fi
     done
+    # HACK: link libncurses to libtinfo which avrdude requires. Its wrapper
+    # includes the destination directory in the LD_LIBRARY_PATH
+    ln -s ${ncurses}/lib/libncurses.so.5 $out/share/arduino/hardware/tools/avr/lib/libtinfo.so.5
+    ln -s $out/share/arduino/hardware/tools/avr/lib/libtinfo.so.5 $out/share/arduino/hardware/tools/avr/lib/libtinfo.so
 
-    patchelf --set-rpath ${stdenv.lib.makeSearchPath "lib" [ libusb ]} \
-        "$out/share/arduino/hardware/tools/avrdude"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -520,6 +520,7 @@ let
     jdk = jdk;
     jre = jdk;
     withGui = false;
+    gccRaw = gcc.cc;
   };
 
   apitrace = callPackage ../applications/graphics/apitrace {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -520,7 +520,6 @@ let
     jdk = jdk;
     jre = jdk;
     withGui = false;
-    gccRaw = gcc.cc;
   };
 
   apitrace = callPackage ../applications/graphics/apitrace {};


### PR DESCRIPTION
I updated the arduino expression to build version 1.6.0 rather than 1.0.6. postInstall ensures that the rpaths of the prebuilt binaries (which Arduino's build process pulls in)  are set so that all shared libraries are found. 

The expression also creates a .desktop file if withGui == true.
