### PR TITLE
Fixes for X server to run in tty1 with various display managers

### DIFF
--- a/nixos/modules/services/x11/display-managers/kdm.nix
+++ b/nixos/modules/services/x11/display-managers/kdm.nix
@@ -4,13 +4,16 @@ with lib;
 
 let
 
-  dmcfg = config.services.xserver.displayManager;
+  xcfg = config.services.xserver;
+  dmcfg = xcfg.displayManager;
   cfg = dmcfg.kdm;
 
   inherit (pkgs.kde4) kdebase_workspace;
 
   defaultConfig =
     ''
+      [General]
+      ServerVTs=${toString xcfg.tty}
       [Shutdown]
       HaltCmd=${config.systemd.package}/sbin/shutdown -h now
       RebootCmd=${config.systemd.package}/sbin/shutdown -r now

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -4,7 +4,8 @@ with lib;
 
 let
 
-  dmcfg = config.services.xserver.displayManager;
+  xcfg = config.services.xserver;
+  dmcfg = xcfg.displayManager;
   xEnv = config.systemd.services."display-manager".environment;
   cfg = dmcfg.lightdm;
 
@@ -15,7 +16,7 @@ let
     ''
       #! /bin/sh
       ${concatMapStrings (n: "export ${n}=\"${getAttr n xEnv}\"\n") (attrNames xEnv)}
-      exec ${dmcfg.xserverBin} ${dmcfg.xserverArgs}
+      exec ${dmcfg.xserverBin} ${dmcfg.xserverArgs} "$@"
     '';
 
   # The default greeter provided with this expression is the GTK greeter.
@@ -56,11 +57,13 @@ let
       greeter-user = ${config.users.extraUsers.lightdm.name}
       greeters-directory = ${cfg.greeter.package}
       sessions-directory = ${dmcfg.session.desktops}
+      minimum-vt = ${toString xcfg.tty}
 
       [SeatDefaults]
       xserver-command = ${xserverWrapper}
       session-wrapper = ${dmcfg.session.script}
       greeter-session = ${cfg.greeter.name}
+      xserver-allow-tcp = ${if xcfg.enableTCP then "true" else "false"}
     '';
 
 in


### PR DESCRIPTION
This fix `services.xserver.tty` for lightdm. Tried to fix KDM but though it now can run in tty1, for some reason it fails to login on it (it's good with tty7). GDM doesn't run for me at all, so I haven't tried to fix it.

Also this removes `-ac` and `-terminate` options for X server by default -- I don't have any idea why they were added, but it would be nice to hear maintainer's comments. @edolstra ?
