### PR TITLE
cc-wrapper: Set default system include flags for non-gcc c++ on Linux

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -80,8 +80,8 @@ if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" ]; then
 fi
 
 if [[ "@prog@" = *++ ]]; then
-    if  echo "$@" | grep -qvw -- -nostdlib; then
-        NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $NIX_CXXSTDLIB_COMPILE"
+    if  echo "$@" | grep -qv -- -nostdlib; then
+        NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
         NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK $NIX_CXXSTDLIB_LINK"
     fi
 fi

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -169,6 +169,12 @@ stdenv.mkDerivation {
 
       export real_cc=cc
       export real_cxx=c++
+      export default_cxx_stdlib_compile="${
+        if stdenv.isLinux && !(cc.isGNU or false)
+          then "-isystem $(echo -n ${cc.gcc}/include/c++/*) -isystem $(echo -n ${cc.gcc}/include/c++/*)/$(${cc.gcc}/bin/gcc -dumpmachine)"
+          else ""
+      }"
+
       if [ -e $ccPath/gcc ]; then
         wrap gcc ${./cc-wrapper.sh} $ccPath/gcc
         ln -s gcc $out/bin/cc


### PR DESCRIPTION
Without this, clang can't find libstdc++. This needs to happen in the wrapper
so that the libc++ setup hook can still override it
