### PR TITLE
arduino: update to 1.6.0

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,28 +1,34 @@
-{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb
-, withGui ? false, gtk2 ? null
+{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb, unzip,
+  readline, zlib, ncurses, withGui ? false, gtk2 ? null
 }:
 
 assert withGui -> gtk2 != null;
 
 stdenv.mkDerivation rec {
 
-  version = "1.0.6";
+  version = "1.6.0";
   name = "arduino${stdenv.lib.optionalString (withGui == false) "-core"}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = "${version}";
-    sha256 = "0nr5b719qi03rcmx6swbhccv6kihxz3b8b6y46bc2j348rja5332";
+    sha256 = "1ycbcr16c53lrvqs9yksn80939ivfai28cxd1b29s61fv3xn7ccm";
   };
 
-  buildInputs = [ jdk ant file ];
+  buildInputs = [ jdk ant file unzip ];
 
   buildPhase = ''
-    cd ./core && ant 
-    cd ../build && ant 
+    cd ./build && ant 
     cd ..
   '';
+
+  rpath = stdenv.lib.makeLibraryPath [
+    zlib
+    ncurses
+    readline
+    stdenv.cc.cc
+  ];
 
   installPhase = ''
     mkdir -p $out/share/arduino
@@ -34,24 +40,42 @@ stdenv.mkDerivation rec {
       sed -i -e "s|^java|${jdk}/bin/java|" "$out/share/arduino/arduino"
       sed -i -e "s|^LD_LIBRARY_PATH=|LD_LIBRARY_PATH=${gtk2}/lib:|" "$out/share/arduino/arduino"
       ln -sr "$out/share/arduino/arduino" "$out/bin/arduino"
+
+      cp -r build/shared/icons $out/share/arduino
+      mkdir $out/share/applications
+      cp build/linux/dist/arduino.desktop $out/share/applications
+      echo "Icon=$out/share/arduino/icons/128x128/apps/arduino.png" >> \
+        $out/share/applications/arduino.desktop
     ''}
 
     # Fixup "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
     echo "running patchelf on prebuilt binaries:"
-    find "$out" | while read filepath; do
-        if file "$filepath" | grep -q "ELF.*executable"; then
-            # skip target firmware files
-            if echo "$filepath" | grep -q "\.elf$"; then
-                continue
+    find "$out" -type f -executable | while read filepath; do
+        # skip target firmware files
+        if [[ "$filepath" == *.elf ]]; then
+            continue;
+        fi  
+
+        if file "$filepath" | grep -q "(ELF.*executable|ELF.*shared object)"; then
+            echo "Patching $filepath"
+            if file "$filepath" | grep -q "ELF.*executable"; then
+                patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath" || \
+                    { echo "patchelf failed to process $filepath"; exit 1; }
             fi
-            echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
-            patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath"
-            test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
+            patchelf --set-rpath ${rpath} "$filepath" || \
+                { echo "patchelf failed to set rpath for $filepath"; exit 1; }
+            patchelf --shrink-rpath ${rpath} "$filepath" || \
+                { echo "patchelf failed to shrink rpath for $filepath"; exit 1; }
         fi
     done
 
-    patchelf --set-rpath ${stdenv.lib.makeSearchPath "lib" [ libusb ]} \
-        "$out/share/arduino/hardware/tools/avrdude"
+    # avrdude_bin explicitly requires libtinfo.so.5, but here these entry points are provided
+    # by libncurses. Upstream provides the avrdude wrapper which adds 
+    # share/arduino/hardware/tools/avr/lib to LD_LIBRARY_PATH. So we provide an appropriately
+    # named link to libnurses there.
+    ln -s ${ncurses}/lib/libncurses.so.5 $out/share/arduino/hardware/tools/avr/lib/libtinfo.so.5
+    ln -s $out/share/arduino/hardware/tools/avr/lib/libtinfo.so.5 $out/share/arduino/hardware/tools/avr/lib/libtinfo.so
+
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
My second attempt at updating Arduino to 1.6.0 incorporating the suggestions given by @bjornfor.

This commit updates arduino to 1.6.0. To this end it does the following:
- It adds unzip as a buildInput which is required during the
  "untar-unzip-download" build steps.
- Added readline, zlib and ncurses as dependencies. These are required
  by some precompiled binaries which are downloaded during the build
  process.  zlib is required by the avr-gcc toolchain. readline and
  ncurses by avrdude.
- installPhase now patches the RPATH of precompiled binaries so that the
  aforementioned additional runtime dependencies can be found. As bossac
  and libastylj.so require libstdc++.so.6, stdenv.cc.cc's library path
  is included.
- installPhase links ncurses.so.5 to libtinfo.so.5 inside a directory
  that's on avrdude_bin's LD_LIBRARY_PATH. libncurses provides the entry
  points that avrdude expects from libtinfo.
- If withGui == true, the .desktop file is copied to
  $out/share/applications.
