### PR TITLE
Samba: Fixed "syncPasswordsByPam".

### DIFF
--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -27,7 +27,7 @@ let
       [ global ]
       security = ${cfg.securityType}
       passwd program = /var/setuid-wrappers/passwd %u
-      pam password change = ${toString cfg.syncPasswordsByPam}
+      pam password change = ${if cfg.syncPasswordsByPam then "yes" else "no"}
       invalid users = ${toString cfg.invalidUsers}
 
       ${cfg.extraConfig}


### PR DESCRIPTION
Samba uses "yes" and "no" for boolean configuration flags.

On my system, the previous version resulted in `/etc/samba/smb.conf` with `pam password change =` (empty), and this resulted in errors when I attempted to connect to the server with `smbclient`.
