### PR TITLE
Rewrite RPATH of Vagrant-bundled nokogiri.so to reference $out/opt/vagrant/embedded/lib

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     # rewrite RPATH of embedded libraries to reference the embedded lib
     # directory
     patchelf --set-rpath "\$ORIGIN/../lib:\$ORIGIN/../../../../../lib" \
-        "$out/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri/nokogiri.so"
+        "opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri/nokogiri.so"
 
     mkdir -p "$out"
     cp -r opt "$out"

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -86,6 +86,11 @@ stdenv.mkDerivation rec {
     ln -s ${libxslt}/bin/xslt-config opt/vagrant/embedded/bin
     ln -s ${libxslt}/bin/xsltproc opt/vagrant/embedded/bin
 
+    # rewrite RPATH of embedded libraries to reference the embedded lib
+    # directory
+    patchelf --set-rpath "\$ORIGIN/../lib:\$ORIGIN/../../../../../lib" \
+        "$out/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri/nokogiri.so"
+
     mkdir -p "$out"
     cp -r opt "$out"
     cp -r usr/bin "$out"


### PR DESCRIPTION
After installing vagrant and the vagrant-vsphere plugin (using the non-nix `vagrant plugin install vagrant-vsphere`), vagrant fails to load binaries that are bundled in the nix store. In this case, vagrant-vsphere adds some pure-ruby code that causes loading of nokogiri, which then fails to locate some required dependencies. The full traceback and ldd details are available at https://gist.github.com/sjagoe/f64880239c085c5c621c, with some extracts below.

This pull request patches the RPATH of nokogiri.so to add the location where the vagrant-bundled binaries are located. 

```
/nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri.rb:29:in `require': libiconv.so.2: cannot open shared object file: No such file or directory - /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri/nokogiri.so (LoadError)
        from /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri.rb:29:in `rescue in <top (required)>'
        from /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri.rb:25:in `<top (required)>'
        from /home/sjagoe/.vagrant.d/gems/gems/rbvmomi-1.6.0/lib/rbvmomi/trivial_soap.rb:4:in `require'
... skipped ...
        from /home/sjagoe/.vagrant.d/gems/gems/vagrant-vsphere-1.0.1/lib/vSphere/provider.rb:12:in `action'
        from /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:163:in `block in action'
... skipped ...
        from /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/bin/../embedded/gems/gems/vagrant-1.6.5/bin/vagrant:174:in `<main>'
... truncated
```

```
$ ldd /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri/nokogiri.so
        libruby.so.2.0 => not found
        libiconv.so.2 => not found
        libz.so.1 => not found
$ readelf -d /nix/store/svbyi8vv3fhzfkqmhmyv4z8yqb1qfjn6-vagrant-1.6.5/opt/vagrant/embedded/gems/gems/nokogiri-1.6.3.1/lib/nokogiri/nokogiri.so

Dynamic section at offset 0x226518 contains 30 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libruby.so.2.0]
 0x0000000000000001 (NEEDED)             Shared library: [libiconv.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x000000000000001d (RUNPATH)            Library runpath: [${ORIGIN}/../lib]
```
