### PR TITLE
TBD: fetchgit: use non-default option values in name

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -41,7 +41,6 @@ in
 assert md5 != "" || sha256 != "";
 
 stdenv.mkDerivation {
-  inherit name;
   builder = ./builder.sh;
   fetcher = ./nix-prefetch-git;
   buildInputs = [git];
@@ -51,6 +50,12 @@ stdenv.mkDerivation {
   outputHash = if sha256 == "" then md5 else sha256;
 
   inherit url rev leaveDotGit fetchSubmodules;
+
+  # Append non-default options to name, to make the derivation depend on it.
+  name = if leaveDotGit && !fetchSubmodules then name + "-opt-+dotgit-sm"
+    else if leaveDotGit then name + "-opt-+dotgit"
+    else if !fetchSubmodules then name + "-opt--sm"
+    else name;
 
   GIT_SSL_CAINFO = "${cacert}/etc/ca-bundle.crt";
 


### PR DESCRIPTION
This appends "+dotgit" for leaveDotGit and "-sm" for !fetchSubmodules.

Fixes https://github.com/NixOS/nixpkgs/issues/6700.
