### PR TITLE
git-cola: add package

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -100,4 +100,6 @@ rec {
   gitRemoteGcrypt = callPackage ./git-remote-gcrypt { };
 
   git-extras = callPackage ./git-extras { };
+
+  git-cola = callPackage ./git-cola { };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, python, pythonPackages, makeWrapper, gettext }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "git-cola-${version}";
+  version = "2.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/git-cola/git-cola/archive/v${version}.tar.gz";
+    sha256 = "0fpi5nvhyqkx67ak5pfcpgxbc3m19dqlvdh2c9igv2j0vp5rzkj1";
+  };
+
+  buildInputs = [ makeWrapper gettext ];
+  propagatedBuildInputs = with pythonPackages; [ pyqt4 sip pyinotify ];
+
+  # HACK: wrapPythonPrograms adds 'import sys; sys.argv[0] = "git-cola"', but
+  # "import __future__" must be placed above that. This removes the argv[0] line.
+  postFixup = ''
+    wrapPythonPrograms
+
+    sed -i "$out/bin/.git-dag-wrapped" -e '{
+      /import sys; sys.argv/d
+    }'
+    
+    sed -i "$out/bin/.git-cola-wrapped" -e '{
+      /import sys; sys.argv/d
+    }'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/git-cola/git-cola;
+    description = "A sleek and powerful Git GUI";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.bobvanderlinden ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10376,6 +10376,7 @@ let
     pythonSupport = false;
   };
   gitSVN = gitAndTools.gitSVN;
+  git-cola = gitAndTools.git-cola;
 
   gitRepo = callPackage ../applications/version-management/git-repo {
     python = python27;


### PR DESCRIPTION
Works here, though it doesn't theme right (I think this is an configuration issue with qt on my system/dotfiles).

This one needed a bit of a workaround for the wrapper. The problem (and workaround) is similar to the one in gpodder.

The head of git-cola looks like:

```
#!/nix/store/8s3nglkv227477q6cpzfr6f2bmaxxm4p-python-2.7.9/bin/python2.7
# -*- python-mode -*-
"""git-cola: The highly caffeinated Git GUI
"""

from __future__ import division, absolute_import, unicode_literals
```

`buildPythonPackage` adds `import sys; sys.argv[0] = "git-cola"`, but it does so in the wrong place. It'll look like:

```
#!/nix/store/8s3nglkv227477q6cpzfr6f2bmaxxm4p-python-2.7.9/bin/python2.7
# -*- python-mode -*-
import sys; sys.argv[0] = "git-cola"
"""git-cola: The highly caffeinated Git GUI
"""

from __future__ import division, absolute_import, unicode_literals
```

It'll place `import sys; sys.argv[0] = "git-cola"` above `from __future__ ...`. This will cause a parse error, since `import __future__` must be the first non-comment python finds.

From what I can tell the problem lays here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/generic/wrap.sh#L32
There it indeed looks for `from __future__` and it also does look for comments in-between, but it doesn't look for comments in string-form, like git-cola does. I wasn't sure how to fix this in wrap.sh, so I reused the workaround that gpodder uses.
