### PR TITLE
haskell: Add uhc compiler

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -138,6 +138,7 @@
   page = "Carles Pagès <page@cubata.homelinux.net>";
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
+  phausmann = "Philipp Hausmann <nix@314.ch>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";
   piotr = "Piotr Pietraszkiewicz <ppietrasa@gmail.com>";

--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, coreutils, fetchgit, m4, libtool, clang, ghcWithPackages,
+  shuffle,
+  binary, hashable, mtl, network, uhc-util, uulib
+}:
+
+let wrappedGhc = ghcWithPackages ( self: [binary hashable mtl network uhc-util uulib] );
+in stdenv.mkDerivation rec {
+  version = "1.1.8.7";
+  name = "uhc-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/UU-ComputerScience/uhc.git";
+    rev = "0dec07e9cb60e78bbca63fc101f8fec6e249269f";
+    sha256 = "0isz3qz23ihbn0rg54x8ddzwpsqlmmpkvaa66b7srfly7nciv8gl";
+  };
+
+  postUnpack = "sourceRoot=\${sourceRoot}/EHC";
+
+  buildInputs = [ m4 wrappedGhc clang libtool shuffle ];
+
+  configureFlags = [ "--with-gcc=${clang}/bin/clang" ];
+
+  # UHC builds packages during compilation; these are by default
+  # installed in the user-specific package config file. We do not
+  # want that, and hack the build process to use a temporary package
+  # configuration file instead.
+  preConfigure = ''
+    p=`pwd`/uhc-local-packages
+    echo '[]' > $p
+    sed -i "s|--user|--package-db=$p|g" mk/shared.mk.in
+    sed -i "s|-fglasgow-exts|-fglasgow-exts -package-conf=$p|g" mk/shared.mk.in
+    sed -i "s|/bin/date|${coreutils}/bin/date|g" mk/dist.mk
+    sed -i "s|/bin/date|${coreutils}/bin/date|g" mk/config.mk.in
+    sed -i "s|--make|--make -package-db=$p|g" src/ehc/files2.mk
+    sed -i "s|--make|--make -package-db=$p|g" src/gen/files.mk
+  '';
+
+  inherit clang;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.cs.uu.nl/wiki/UHC";
+    description = "Utrecht Haskell Compiler";
+    maintainers = [ maintainers.phausmann ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -1,9 +1,9 @@
 { stdenv, coreutils, fetchgit, m4, libtool, clang, ghcWithPackages,
   shuffle,
-  binary, hashable, mtl, network, uhc-util, uulib
+  hashable, mtl, network, uhc-util, uulib
 }:
 
-let wrappedGhc = ghcWithPackages ( self: [binary hashable mtl network uhc-util uulib] );
+let wrappedGhc = ghcWithPackages ( self: [hashable mtl network uhc-util uulib] );
 in stdenv.mkDerivation rec {
   version = "1.1.8.7";
   name = "uhc-${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3511,6 +3511,12 @@ let
       regexCompat HsSyck random;
   };
 
+  uhc = callPackage ../development/compilers/uhc/default.nix ({
+    stdenv = clangStdenv;
+    ghcWithPackages = haskellngPackages.ghcWithPackages;
+    inherit (haskellngPackages) shuffle binary hashable mtl network uhc-util uulib;
+  });
+
   gcc-arm-embedded-4_7 = callPackage_i686 ../development/compilers/gcc-arm-embedded {
     version = "4.7-2013q3-20130916";
     releaseType = "update";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3514,7 +3514,7 @@ let
   uhc = callPackage ../development/compilers/uhc/default.nix ({
     stdenv = clangStdenv;
     ghcWithPackages = haskellngPackages.ghcWithPackages;
-    inherit (haskellngPackages) shuffle binary hashable mtl network uhc-util uulib;
+    inherit (haskellngPackages) shuffle hashable mtl network uhc-util uulib;
   });
 
   gcc-arm-embedded-4_7 = callPackage_i686 ../development/compilers/gcc-arm-embedded {


### PR DESCRIPTION
Adds the UHC haskell compiler.

Based upon the previously removed uhc package (see issue #3565 ), tested on Fedora 21 amd64.
