### PR TITLE
xorg-server: add Xephyr

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -298,6 +298,7 @@ in
         ];
         patches = commonPatches;
         configureFlags = [
+          "--enable-kdrive"             # not built by default
           "--enable-xcsecurity"         # enable SECURITY extension
           "--with-default-font-path="   # there were only paths containing "${prefix}",
                                         # and there are no fonts in this package anyway


### PR DESCRIPTION
It's needed e.g. for sddm "preview" feature to work. I don't know if it's the right place to add this flag (and maybe it shouldn't be enabled on Darwin?).

cc @vcunat @cstrahan (via `git blame`, sorry if I bothered a wrong person)
