### PR TITLE
nixos: Add vmtest for sudo.

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -308,6 +308,7 @@ in rec {
   tests.quake3 = callTest tests/quake3.nix {};
   tests.runInMachine = callTest tests/run-in-machine.nix {};
   tests.simple = callTest tests/simple.nix {};
+  tests.sudo = callTest tests/sudo.nix {};
   tests.tomcat = callTest tests/tomcat.nix {};
   tests.udisks2 = callTest tests/udisks2.nix {};
   tests.virtualbox = callTest tests/virtualbox.nix {};

--- a/nixos/tests/sudo.nix
+++ b/nixos/tests/sudo.nix
@@ -1,0 +1,15 @@
+import ./make-test.nix {
+  name = "sudo";
+  nodes = {
+  machine = { pkgs, config, ... }:
+    {
+      security.sudo.enable = true;
+    };
+  };
+  testScript = ''
+    startAll;
+    $machine->waitForUnit("multi-user.target");
+    $machine->succeed("sudo echo foobar");
+    '';
+  }
+


### PR DESCRIPTION
sudo is broken at the moment, complaining about the file
'/libexec/sudo/sudoers.so' not being owned by root (uid=0).
