### PR TITLE
Enable aalib support in mplayer.

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, pkgconfig, freetype, yasm
+, aalibSupport ? true, aalib ? null
 , fontconfigSupport ? true, fontconfig ? null, freefont_ttf ? null
 , fribidiSupport ? true, fribidi ? null
 , x11Support ? true, libX11 ? null, libXext ? null, mesa ? null
@@ -103,6 +104,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with stdenv.lib;
     [ pkgconfig freetype ]
+    ++ optional aalibSupport aalib
     ++ optional fontconfigSupport fontconfig
     ++ optional fribidiSupport fribidi
     ++ optionals x11Support [ libX11 libXext mesa ]


### PR DESCRIPTION
The performance isn't very good, but I think this is because the aalib expression only has the curses driver, and not the Linux or X11 drivers.

I'll merge this in a couple of days if there aren't any comments.
