### PR TITLE
django: Adds pypyPackages.django_1_7

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3901,6 +3901,24 @@ let
 
   django = self.django_1_6;
 
+  django_1_7 = buildPythonPackage rec {
+    name = "Django-${version}";
+    version = "1.7.5";
+
+    src = pkgs.fetchurl {
+      url = "http://www.djangoproject.com/m/releases/1.7/${name}.tar.gz";
+      sha256 = "1g302ird4kg7c1h8wjck8g8f8da2yaciain3v81zazf9969iyf8w";
+    };
+
+    # error: invalid command 'test'
+    doCheck = false;
+
+    meta = {
+      description = "A high-level Python Web framework";
+      homepage = https://www.djangoproject.com/;
+    };
+  };
+
   django_1_6 = buildPythonPackage rec {
     name = "Django-${version}";
     version = "1.6.6";


### PR DESCRIPTION
Adds the latest stable release of Django (1.7.5) to `pypyPackages` as `django_1_7`.

Does not change the `pypyPackages.django` from `django_1_6` to `django_1_7` as I don't know whether that would break something (this is my first PR to nixpkgs).

Tested by running in nixpkgs root dir:

```
$ nix-build -A pypyPackages.django_1_7
/nix/store/rx1w6kzh4b1p1m4dkdcal01sxklcvpvf-pypy2.5-Django-1.7.5
```
