### PR TITLE
Cleanup fhs-chrootenv's environment and workaround Steam's sound issues

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -62,7 +62,7 @@ let
       chosenGcc
       bashInteractive coreutils less shadow su
       gawk diffutils findutils gnused gnugrep
-      gnutar gzip bzip2 xz
+      gnutar gzip bzip2 xz glibcLocales
     ];
 
   # Compose a global profile for the chroot environment
@@ -72,6 +72,9 @@ let
       mkdir -p $out/etc
       cat >> $out/etc/profile << "EOF"
       export PS1='${name}-chrootenv:\u@\h:\w\$ '
+      export LOCALE_ARCHIVE='/usr/lib${if is64Bit then "64" else ""}/locale/locale-archive'
+      export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib:/lib32:/lib64
+      export PATH='/bin:/sbin'
       ${profile}
       EOF
     '';

--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -89,7 +89,7 @@ let
   };
 
   linkProfile = profile: ''
-    for i in ${profile}/{etc,bin,sbin,share,var}; do
+    for i in ${profile}/{bin,sbin,share,var}; do
         if [ -x "$i" ]
         then
             ln -s "$i"
@@ -158,6 +158,40 @@ let
     cp -rsf ${chosenGcc.cc}/lib64/* lib64/
   '';
 
+  setupEtc = ''
+    mkdir -m0755 etc
+
+    # copy profile content
+    cp -rsf ${staticUsrProfileTarget}/etc/* etc/ && chmod u+w -R etc/
+    [ -d ${staticUsrProfileMulti}/etc ] && cp -rsf ${staticUsrProfileMulti}/etc/* etc/ && chmod u+w -R etc/
+
+    # compatibility with NixOS
+    ln -s /host-etc/static etc/static
+
+    # symlink some NSS stuff
+    ln -s /host-etc/passwd etc/passwd
+    ln -s /host-etc/group etc/group
+    ln -s /host-etc/shadow etc/shadow
+    ln -s /host-etc/hosts etc/hosts
+    ln -s /host-etc/resolv.conf etc/resolv.conf
+    ln -s /host-etc/nsswitch.conf etc/nsswitch.conf
+
+    # symlink other core stuff
+    ln -s /host-etc/localtime etc/localtime
+    ln -s /host-etc/machine-id etc/machine-id
+
+    # symlink PAM stuff
+    rm -rf etc/pam.d
+    ln -s /host-etc/pam.d etc/pam.d
+
+    # symlink fonts stuff
+    rm -rf etc/fonts
+    ln -s /host-etc/fonts etc/fonts
+
+    # symlink ALSA stuff
+    ln -s /host-etc/asound.conf etc/asound.conf
+  '';
+
 in nixpkgs.stdenv.mkDerivation {
   name         = "${name}-fhs";
   buildCommand = ''
@@ -165,6 +199,7 @@ in nixpkgs.stdenv.mkDerivation {
     cd $out
     ${setupTargetProfile}
     ${setupMultiProfile}
+    ${setupEtc}
     cd $out
     ${extraBuildCommands}
     cd $out

--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -81,11 +81,13 @@ let
   staticUsrProfileTarget = nixpkgs.buildEnv {
     name = "system-profile-target";
     paths = basePkgs ++ [ profilePkg ] ++ targetPaths;
+    ignoreCollisions = true;
   };
 
   staticUsrProfileMulti = nixpkgs.buildEnv {
     name = "system-profile-multi";
     paths = multiPaths;
+    ignoreCollisions = true;
   };
 
   linkProfile = profile: ''
@@ -129,7 +131,7 @@ let
     mkdir -m0755 lib
 
     # copy content of targetPaths
-    cp -rsf ${staticUsrProfileTarget}/lib/* lib/
+    cp -rsf ${staticUsrProfileTarget}/lib/* lib/ && chmod u+w -R lib/
   '';
 
   # setup /lib, /lib32 and /lib64
@@ -142,16 +144,16 @@ let
     cp -rsf ${staticUsrProfileTarget}/lib/32/* lib/
 
     # copy content of multiPaths (32bit libs)
-    [ -d ${staticUsrProfileMulti}/lib ] && cp -rsf ${staticUsrProfileMulti}/lib/* lib/
+    [ -d ${staticUsrProfileMulti}/lib ] && cp -rsf ${staticUsrProfileMulti}/lib/* lib/ && chmod u+w -R lib/
 
     # copy content of targetPaths (64bit libs)
-    cp -rsf ${staticUsrProfileTarget}/lib/* lib64/
+    cp -rsf ${staticUsrProfileTarget}/lib/* lib64/ && chmod u+w -R lib64/
 
     # most 64bit only libs put their stuff into /lib
     # some pkgs (like gcc_multi) put 32bit libs into and /lib 64bit libs into /lib64
     # by overwriting these we will hopefully catch all these cases
     # in the end /lib should only contain 32bit and /lib64 only 64bit libs
-    cp -rsf ${staticUsrProfileTarget}/lib64/* lib64/
+    cp -rsf ${staticUsrProfileTarget}/lib64/* lib64/ && chmod u+w -R lib64/
 
     # copy gcc libs (and may overwrite exitsting wrongly placed libs)
     cp -rsf ${chosenGcc.cc}/lib/*   lib/

--- a/pkgs/build-support/build-fhs-chrootenv/init.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/init.sh.in
@@ -8,38 +8,11 @@ mkdir -p $chrootenvDest/{nix/store,dev,proc,sys,host-etc,home,var,run}
 # Symlink the software that should be part of the chroot system profile
 for i in @chrootEnv@/*
 do
-    if [ "$i" != "@chrootEnv@/etc" ] && [ "$i" != "@chrootEnv@/var" ]
+    if [ "$i" != "@chrootEnv@/var" ]
     then
         ln -s "$i" "$chrootenvDest"
     fi
 done
-
-# Symlink the contents of the chroot software's /etc
-
-mkdir $chrootenvDest/etc
-
-for i in @chrootEnv@/etc/*
-do
-    ln -s "$i" $chrootenvDest/etc
-done
-
-# Symlink some NSS stuff
-ln -s ../host-etc/passwd $chrootenvDest/etc/passwd
-ln -s ../host-etc/group $chrootenvDest/etc/group
-ln -s ../host-etc/shadow $chrootenvDest/etc/shadow
-ln -s ../host-etc/hosts $chrootenvDest/etc/hosts
-ln -s ../host-etc/resolv.conf $chrootenvDest/etc/resolv.conf
-ln -s ../host-etc/nsswitch.conf $chrootenvDest/etc/nsswitch.conf
-
-# Symlink PAM stuff
-rm $chrootenvDest/etc/pam.d
-ln -s ../host-etc/static/pam.d $chrootenvDest/etc/pam.d
-
-# Symlink Font stuff
-mkdir -p $chrootenvDest/etc/fonts
-ln -s ../../host-etc/static/fonts/fonts.conf $chrootenvDest/etc/fonts
-mkdir -p $chrootenvDest/etc/fonts/conf.d
-ln -s ../../../host-etc/static/fonts/conf.d/00-nixos.conf $chrootenvDest/etc/fonts/conf.d
 
 # Create root folder
 mkdir $chrootenvDest/root

--- a/pkgs/build-support/build-fhs-chrootenv/load.sh.in
+++ b/pkgs/build-support/build-fhs-chrootenv/load.sh.in
@@ -3,4 +3,10 @@
 chrootenvDest=/run/chrootenv/@name@
 
 # Enter the LFS chroot environment
-sudo chroot --userspec "$USER:${GROUPS[0]}" --groups "${GROUPS[0]}" $chrootenvDest /usr/bin/env -i PS1="$PS1" TERM="$TERM" DISPLAY="$DISPLAY" HOME="$HOME" PATH="/bin:/sbin" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" /bin/bash --login
+sudo chroot --userspec "$USER:${GROUPS[0]}" --groups "${GROUPS[0]}" $chrootenvDest /usr/bin/env -i \
+     TERM="$TERM" \
+     DISPLAY="$DISPLAY" \
+     HOME="$HOME" \
+     XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+     LANG="$LANG" \
+     /bin/bash --login

--- a/pkgs/build-support/build-fhs-userenv/chroot-user.rb
+++ b/pkgs/build-support/build-fhs-userenv/chroot-user.rb
@@ -116,13 +116,11 @@ if $cpid == 0
   link_swdir.call swdir, Pathname.new('')
 
   # New environment
-  oldenv = ENV.to_h
-  ENV.replace({ 'PS1' => oldenv['PS1'],
-                'TERM' => oldenv['TERM'],
-                'DISPLAY' => oldenv['DISPLAY'],
-                'HOME' => oldenv['HOME'],
-                'PATH' => '/bin:/sbin',
-                'XDG_RUNTIME_DIR' => oldenv['XDG_RUNTIME_DIR'],
+  ENV.replace({ 'TERM' => ENV['TERM'],
+                'DISPLAY' => ENV['DISPLAY'],
+                'HOME' => ENV['HOME'],
+                'XDG_RUNTIME_DIR' => ENV['XDG_RUNTIME_DIR'],
+                'LANG' => ENV['LANG'],
               })
 
   # Finally, exec!

--- a/pkgs/build-support/build-fhs-userenv/chroot-user.rb
+++ b/pkgs/build-support/build-fhs-userenv/chroot-user.rb
@@ -17,20 +17,6 @@ mounts = [ ['/nix/store', nil],
 mkdirs = ['tmp',
          ]
 
-# Symlinks: [from, to (dir)]
-symlinks =
-  # /etc symlinks: [file name, prefix in host-etc]
-  [ ['passwd', ''],
-    ['group', ''],
-    ['shadow', ''],
-    ['hosts', ''],
-    ['resolv.conf', ''],
-    ['nsswitch.conf', ''],
-    ['pam.d', 'static'],
-    ['fonts/fonts.conf', 'static'],
-    ['fonts/conf.d/00-nixos.conf', 'static'],
-  ].map! { |x| [ "host-etc/#{x[1]}/#{x[0]}", "etc/#{File.dirname x[0]}" ] }
-
 require 'tmpdir'
 require 'fileutils'
 require 'pathname'
@@ -110,12 +96,6 @@ if $cpid == 0
   # Chroot!
   Dir.chroot root
   Dir.chdir '/'
-
-  # Do symlinks
-  symlinks.each do |x|
-    FileUtils.mkdir_p x[1]
-    FileUtils.ln_s x[0], x[1]
-  end
 
   # Symlink swdir hierarchy
   mount_dirs = Set.new mounts.map { |x| Pathname.new x[1] }

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -66,8 +66,8 @@ buildFHSUserEnv {
   '';
 
   profile = ''
-    export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib:/lib32:/lib64
-    export PATH=$PATH:/usr/bin:/usr/sbin
+    # Ugly workaround for https://github.com/ValveSoftware/steam-for-linux/issues/3504
+    export LD_PRELOAD=/lib32/libpulse.so:/lib64/libpulse.so:/lib32/libasound.so:/lib64/libasound.so
   '';
 
   runScript = "exec steam";

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation rec {
     ''}
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A digital distribution platform";
     homepage = http://store.steampowered.com/;
-    license = stdenv.lib.licenses.unfree;
-    maintainers = [ stdenv.lib.maintainers.jagajaga ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jagajaga ];
   };
 }


### PR DESCRIPTION
This adds locale support in FHS chrootenv, reworks environment, unifies and refactors /etc and finally workarounds Steam and its games' PulseAudio sound issues.

One controversial thing this uses is storing absolute symlinks like "/host-etc/passwd" in Nix store; this allows to greatly unify code between `fhs-chrootenv` and `fhs-userenv`.

Also this makes FHS chroot less NixOS-specific; if someone has used it in just Nix, they should have less issues now.

cc @jagajaga 
