### PR TITLE
Use mktemp to create temporary files to hold ssh host keys and authorized keys

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -143,34 +143,41 @@ in
           umask 077
           # Don't download the SSH key if it has already been downloaded
           if ! [ -e /root/.ssh/authorized_keys ]; then
-                echo "obtaining SSH key..."
-                mkdir -m 0700 -p /root/.ssh
-                ${wget} -O /root/authorized-keys-metadata http://metadata.google.internal/0.1/meta-data/authorized-keys
-                if [ $? -eq 0 -a -e /root/authorized-keys-metadata ]; then
-                    cat /root/authorized-keys-metadata | cut -d: -f2- > /root/key.pub
-                    if ! grep -q -f /root/key.pub /root/.ssh/authorized_keys; then
-                        cat /root/key.pub >> /root/.ssh/authorized_keys
-                        echo "new key added to authorized_keys"
-                    fi
-                    chmod 600 /root/.ssh/authorized_keys
+              echo "obtaining SSH key..."
+              mkdir -m 0700 -p /root/.ssh
+              AUTH_KEYS=$(mktemp) && {
+                ${wget} -O $AUTH_KEYS http://metadata.google.internal/0.1/meta-data/authorized-keys
+                if [ $? -eq 0 -a -e $AUTH_KEYS ]; then
+                    KEY_PUB=$(mktemp) && {
+                      cat $AUTH_KEYS | cut -d: -f2- > $KEY_PUB
+                      if ! grep -q -f $KEY_PUB /root/.ssh/authorized_keys; then
+                          cat $KEY_PUB >> /root/.ssh/authorized_keys
+                          echo "new key added to authorized_keys"
+                      fi
+                      chmod 600 /root/.ssh/authorized_keys
+                      rm -f $KEY_PUB
+                    }
                 fi
-                rm -f /root/key.pub /root/authorized-keys-metadata
+                rm -f $AUTH_KEYS
+              }
           fi
 
           countKeys=0
           ${flip concatMapStrings config.services.openssh.hostKeys (k :
             let kName = baseNameOf k.path; in ''
-              echo "trying to obtain SSH private host key ${kName}"
-              ${wget} -O /root/${kName} http://metadata.google.internal/0.1/meta-data/attributes/${kName} && :
-              if [ $? -eq 0 -a -e /root/${kName} ]; then
-                  countKeys=$((countKeys+1))
-                  mv -f /root/${kName} ${k.path}
-                  echo "downloaded ${k.path}"
-                  chmod 600 ${k.path}
-                  ${config.programs.ssh.package}/bin/ssh-keygen -y -f ${k.path} > ${k.path}.pub
-                  chmod 644 ${k.path}.pub
-              fi
-              rm -f /root/${kName}
+              PRIV_KEY=$(mktemp) && {
+                echo "trying to obtain SSH private host key ${kName}"
+                ${wget} -O $PRIV_KEY http://metadata.google.internal/0.1/meta-data/attributes/${kName} && :
+                if [ $? -eq 0 -a -e $PRIV_KEY ]; then
+                    countKeys=$((countKeys+1))
+                    mv -f $PRIV_KEY ${k.path}
+                    echo "downloaded ${k.path}"
+                    chmod 600 ${k.path}
+                    ${config.programs.ssh.package}/bin/ssh-keygen -y -f ${k.path} > ${k.path}.pub
+                    chmod 644 ${k.path}.pub
+                fi
+                rm -f $PRIV_KEY
+              }
             ''
           )}
 


### PR DESCRIPTION
Currently I'm making the temporary files in $TMP which is /tmp.  I could also put them in /root, but I couldn't think of any reason why I should do that.  Have any preferences?
