### PR TITLE
Some fixes for primus and its support in Steam

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,4 +1,4 @@
-{ buildFHSUserEnv, config }:
+{ lib, buildFHSUserEnv, config }:
 
 buildFHSUserEnv {
   name = "steam";
@@ -14,7 +14,8 @@ buildFHSUserEnv {
       pkgs.gnome2.zenity
       pkgs.xdg_utils
     ]
-    ++ (if config.steam.java or false then [ pkgs.jdk ] else [ ])
+    ++ lib.optional (config.steam.java or false) pkgs.jdk
+    ++ lib.optional (config.steam.primus or false) pkgs.primus
     ;
 
   multiPkgs = pkgs:

--- a/pkgs/tools/X11/primus/default.nix
+++ b/pkgs/tools/X11/primus/default.nix
@@ -14,12 +14,7 @@ let
   ldPath = makeLibraryPath ([primusLib] ++ optional (primusLib_i686 != null) primusLib_i686);
   primusrun = writeScript "primusrun"
 ''
-  export LD_LIBRARY_PATH=${ldPath}:\$LD_LIBRARY_PATH
-  # see: https://github.com/amonakov/primus/issues/138
-  # On my system, as of 3.16.6, the intel driver dies when the pixel buffers try to read from the
-  # source memory directly. Setting PRIMUS_UPLOAD causes an indirection through textures which
-  # avoids this issue.
-  export PRIMUS_UPLOAD=1
+  export LD_LIBRARY_PATH=${ldPath}:$LD_LIBRARY_PATH
   exec "$@"
 '';
 in


### PR DESCRIPTION
This:
1. Fixes LD_LIBRARY_PATH with primus
2. Removes old workaround: the fix (http://cgit.freedesktop.org/xorg/xserver/commit/glx?id=96a28e9c914d7ae9b269f73a27b99cbd3c465ac8) is in our XOrg. Tested and works for me.
3. Adds an option for steam chroot to include primusrun.

Travis check.
