### PR TITLE
build-fhs-userenv passes through command line args

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     mkdir -p $out/bin
     cat > $out/bin/${name} <<EOF
     #! ${stdenv.shell}
-    exec ${chroot-user}/bin/chroot-user ${env} $out/libexec/run
+    exec ${chroot-user}/bin/chroot-user ${env} $out/libexec/run "\$@"
     EOF
     chmod +x $out/bin/${name}
 
@@ -30,7 +30,7 @@ in stdenv.mkDerivation {
     cat > $out/libexec/run <<EOF
     #! ${stdenv.shell}
     source /etc/profile
-    ${runScript}
+    ${runScript} "\$@"
     EOF
     chmod +x $out/libexec/run
   '';


### PR DESCRIPTION
The motivation for this change is to allow things like the
following derivation, which wraps the debian-packaged
hello binary.

let nixpkgs = import <nixpkgs> {};
    stdenv = nixpkgs.stdenv;
in rec {
  dumb-hello = stdenv.mkDerivation {
    name = "dumb-hello";
    builder = ./builder.sh;
    dpkg = nixpkgs.dpkg;
    src = nixpkgs.fetchurl {
      url = "http://ftp.us.debian.org/debian/pool/main/h/hello-traditional/hello-traditional_2.9-2_amd64.deb";
      md5 = "f5f3c28b65221dae44dda6f242c23316";
    };
  };
  full-hello = nixpkgs.buildFHSUserEnv {
    name = "full-hello";
    targetPkgs = pkgs: [ dumb-hello ];
    multiPkgs = pkgs: [ pkgs.dpkg ];
    runScript = "hello";
  };
}
