### PR TITLE
django: Adds pypyPackages.django_1_7 (1.7.6)

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3901,6 +3901,24 @@ let
 
   django = self.django_1_6;
 
+  django_1_7 = buildPythonPackage rec {
+    name = "Django-${version}";
+    version = "1.7.6";
+
+    src = pkgs.fetchurl {
+      url = "http://www.djangoproject.com/m/releases/1.7/${name}.tar.gz";
+      sha256 = "142cim55wnv5q0zg039rankwah1gbpq46dgmp9yg78jrzq7mxwdh";
+    };
+
+    # error: invalid command 'test'
+    doCheck = false;
+
+    meta = {
+      description = "A high-level Python Web framework";
+      homepage = https://www.djangoproject.com/;
+    };
+  };
+
   django_1_6 = buildPythonPackage rec {
     name = "Django-${version}";
     version = "1.6.6";


### PR DESCRIPTION
Adds the latest stable release of Django (1.7.6) to pypyPackages as django_1_7.

Does not change the pypyPackages.django from django_1_6 to django_1_7.

Tested by running in nixpkgs root dir:

```
$ nix-build -A pypyPackages.django_1_7
/nix/store/pdbbx083kicp0zz7mlcbk5mvgmdzqgsp-pypy2.5-Django-1.7.6
```
