### PR TITLE
nixos: refactor tarsnap backup service module

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -112,6 +112,9 @@ in zipModules ([]
 # VirtualBox
 ++ obsolete [ "services" "virtualbox" "enable" ] [ "services" "virtualboxGuest" "enable" ]
 
+# Tarsnap
+++ obsolete [ "services" "tarsnap" "config" ] [ "services" "tarsnap" "archives" ]
+
 # proxy
 ++ obsolete [ "nix" "proxy" ] [ "networking" "proxy" "default" ]
 


### PR DESCRIPTION
I am using this myself, appears to work as advertised thus far.

Major changes
- Port to systemd timers: for each archive configuration is created a
  `tarsnap@archive-name.timer` which triggers the instanced service unit
- Rename the `config` option to `archives`
- Rename the `directories` option to `paths`

Minor/superficial improvements
- Restrict tarsnap service capabilities
- Use `dirOf` builtin
- Set executable bit for owner of tarsnap cache directory
- Set `IOSchedulingClass` to `idle`
- Humanize numbers when printing stats
- Rewrite most option descriptions
- Simplify assertion
