### PR TITLE
Update moderncv SHA

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/moderncv.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderncv.nix
@@ -4,7 +4,7 @@ rec {
   name = "moderncv-${version}";
   src = fetchurl {
     url = "https://launchpad.net/moderncv/trunk/${version}/+download/moderncv-${version}.zip";
-    sha256 = "0k26s0z8hmw3h09vnpndim7gigwh8q6n9nbbihb5qbrw5qg2yqck";
+    sha256 = "0y2m0qd0izrfjcwrmf3nvzkqmrhkdhzbv29s4c0knksdnfgcchc8";
   };
 
   buildInputs = [texLive unzip];


### PR DESCRIPTION
Hi all, apparently the content (and therefore sha) of the  texlive package 'moderncv' has changed.

Since I'm still pretty new to NixOS, so please tell me if I need to do something more than just changing the SHA ;)
