### PR TITLE
cupsd: rename `cupsd.service` to `cups.service`

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -183,7 +183,7 @@ in
     # gets loaded, and then cups cannot access the printers.
     boot.blacklistedKernelModules = [ "usblp" ];
 
-    systemd.services.cupsd =
+    systemd.services.cups =
       { description = "CUPS Printing Daemon";
 
         wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -82,7 +82,7 @@ in
     systemd.services.prlshprint = {
       description = "Parallels Shared Printer Tool";
       wantedBy = [ "multi-user.target" ];
-      bindsTo = [ "cupsd.service" ];
+      bindsTo = [ "cups.service" ];
       serviceConfig = {
         Type = "forking";
         ExecStart = "${prl-tools}/bin/prlshprint";


### PR DESCRIPTION
This is how the service is called in other distros. Plus, fixes wrong dependency of `cups-browsed.service`.
