### PR TITLE
cups-browsed: build with Avahi

### DIFF
--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, cups, poppler, poppler_utils, fontconfig
-, libjpeg, libpng, perl, ijs, qpdf, dbus, substituteAll, bash }:
+, libjpeg, libpng, perl, ijs, qpdf, dbus, substituteAll, bash, avahi }:
 
 stdenv.mkDerivation rec {
   name = "cups-filters-${version}";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig cups poppler poppler_utils fontconfig libjpeg libpng perl
-    ijs qpdf dbus
+    ijs qpdf dbus avahi
   ];
 
   configureFlags = "--with-pdftops=pdftops --enable-imagefilters --with-rcdir=no";

--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -29,11 +29,7 @@ stdenv.mkDerivation rec {
     ijs qpdf dbus
   ];
 
-  preBuild = ''
-    substituteInPlace Makefile --replace "/etc/rc.d" "$out/etc/rc.d"
-  '';
-
-  configureFlags = "--with-pdftops=pdftops --enable-imagefilters";
+  configureFlags = "--with-pdftops=pdftops --enable-imagefilters --with-rcdir=no";
 
   makeFlags = "CUPS_SERVERBIN=$(out)/lib/cups CUPS_DATADIR=$(out)/share/cups CUPS_SERVERROOT=$(out)/etc/cups";
 


### PR DESCRIPTION
The first commit fixes cups-filters expression on non-NixOS.
The second one adds DNS-SD to cups-browsed (that is, makes it not useless).
