### PR TITLE
grub: make sure grub builds again

### DIFF
--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, autoconf, automake, buggyBiosCDSupport ? true}:
+{stdenv, fetchurl, autoconf, automake, texinfo, buggyBiosCDSupport ? true}:
 
 stdenv.mkDerivation {
   name = "grub-0.97-patch-1.12";
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   ] ++ (stdenv.lib.optional buggyBiosCDSupport ./buggybios.patch);
 
   # Autoconf/automake required for the splashimage patch.
-  buildInputs = [autoconf automake];
+  buildInputs = [autoconf automake texinfo];
 
   prePatch = ''
     unpackFile $gentooPatches
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     autoreconf
+    automake --add-missing
   '';
 
   passthru.grubTarget = "";


### PR DESCRIPTION
When configuring grub, it would fail to execute with the following error:

```
parallel-tests: error: required file './test-driver' not found
parallel-tests:   'automake --add-missing' can install 'test-driver'
```

So that's what I added to the preConfigure phase.

Additionally while generating documentation it needed `makeinfo`, which is part of `texinfo`.

I'm not sure whether we should disable the tests and generating documentation. Let me know if this is preferable.
