### PR TITLE
Add packages for a number of fonts.

### DIFF
--- a/pkgs/data/fonts/caladea/cambria-alias.conf
+++ b/pkgs/data/fonts/caladea/cambria-alias.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Configure Caladea as a metric-compatible alias for the
+       Microsoft Cambria font family. -->
+  <alias binding="same">
+    <family>Cambria</family>
+    <accept>
+      <family>Caladea</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Caladea</family>
+    <default>
+      <family>Cambria</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/pkgs/data/fonts/caladea/default.nix
+++ b/pkgs/data/fonts/caladea/default.nix
@@ -1,0 +1,40 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "caladea-${version}";
+  version = "20130214";
+
+  src = fetchurl {
+    url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-${version}.tar.gz";
+    sha256 = "02addvvkbvf3bn21kfyj10j9w1c8hdxxld4wjmnc1j8ksqpir3f4";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/etc/fonts/conf.d
+    mkdir -p $out/share/fonts/truetype
+    cp -v *.ttf $out/share/fonts/truetype
+    cp -v ${./cambria-alias.conf} $out/etc/fonts/conf.d/30-cambria.conf
+  '';
+
+  meta = with stdenv.lib; {
+    # This font doesn't appear to have any official web site but this
+    # one provides some good information and samples.
+    homepage = http://openfontlibrary.org/en/font/caladea;
+    description = "A serif font metric-compatible with Microsoft Cambria";
+    longDescription = ''
+      Caladea is a free font that is metric-compatible with the
+      Microsoft Cambria font. Developed by Carolina Giovagnoli and
+      Andrés Torresi at Huerta Tipográfica foundry.
+    '';
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+
+    # Reduce the priority of this package. The intent is that if you
+    # also install the `vista-fonts` package, then you probably will
+    # not want to install the font alias of this package.
+    priority = 10;
+  };
+}

--- a/pkgs/data/fonts/carlito/calibri-alias.conf
+++ b/pkgs/data/fonts/carlito/calibri-alias.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Configure Carlito as a metric-compatible alias for the
+       Microsoft Calibri font family. -->
+  <alias binding="same">
+    <family>Calibri</family>
+    <accept>
+      <family>Carlito</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Carlito</family>
+    <default>
+      <family>Calibri</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/pkgs/data/fonts/carlito/default.nix
+++ b/pkgs/data/fonts/carlito/default.nix
@@ -1,0 +1,40 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "carlito-${version}";
+  version = "20130920";
+
+  src = fetchurl {
+    url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-carlito-${version}.tar.gz";
+    sha256 = "0nmgzp6gdvv4dipswrw0l1bfjp4jbic2qvm7dpqiq71jpin2plab";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/etc/fonts/conf.d
+    mkdir -p $out/share/fonts/truetype
+    cp -v *.ttf $out/share/fonts/truetype
+    cp -v ${./calibri-alias.conf} $out/etc/fonts/conf.d/30-calibri.conf
+  '';
+
+  meta = with stdenv.lib; {
+    # This font doesn't appear to have any official web site but this
+    # one provides some good information and samples.
+    homepage = http://openfontlibrary.org/en/font/carlito;
+    description = "A sans-serif font metric-compatible with Microsoft Calibri";
+    longDescription = ''
+      Carlito is a free font that is metric-compatible with the
+      Microsoft Calibri font. The font is designed by Łukasz Dziedzic
+      of the tyPoland foundry and based his Lato font.
+    '';
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+
+    # Reduce the priority of this package. The intent is that if you
+    # also install the `vista-fonts` package, then you probably will
+    # not want to install the font alias of this package.
+    priority = 10;
+  };
+}

--- a/pkgs/data/fonts/comfortaa/default.nix
+++ b/pkgs/data/fonts/comfortaa/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "comfortaa-${version}";
+  version = "2.004";
+
+  src = fetchurl {
+    url = "http://openfontlibrary.org/assets/downloads/comfortaa/38318a69b56162733bf82bc0170b7521/comfortaa.zip";
+    sha256 = "0js0kk5g6b7xrq92b68gz5ipbiv1havnbgnfqzvlw3k3nllwnl9z";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  buildInputs = [unzip];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.ttf $out/share/fonts/truetype/
+    cp -v FONTLOG.txt $out/share/doc/${name}/
+    cp -v donate.html $out/share/doc/${name}/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://aajohan.deviantart.com/art/Comfortaa-font-105395949;
+    description = "A clean and modern font suitable for headings and logos";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+  };
+}

--- a/pkgs/data/fonts/comic-relief/comic-sans-ms-alias.conf
+++ b/pkgs/data/fonts/comic-relief/comic-sans-ms-alias.conf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- Configure Comic Relief as a metric-compatible alias for the
+       Microsoft Comic Sans font family. -->
+  <alias binding="same">
+    <family>Comic Sans MS</family>
+    <accept>
+      <family>Comic Relief</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Comic Relief</family>
+    <default>
+      <family>Comic Sans MS</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/pkgs/data/fonts/comic-relief/default.nix
+++ b/pkgs/data/fonts/comic-relief/default.nix
@@ -1,0 +1,49 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "comic-relief-${version}";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "https://dl.dropbox.com/u/56493902/loudifier/comicrelief.zip";
+    sha256 = "0wpf10m9zmcfvcxgc7dxzdm3syam7d7qxlfabgr1nxzq299kh8ch";
+  };
+
+  buildInputs = [unzip];
+
+  phases = ["unpackPhase" "installPhase"];
+
+  unpackCmd = ''
+    mkdir -p ${name}
+    unzip -qq -d ${name} $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/etc/fonts/conf.d
+    mkdir -p $out/share/doc/${name}
+    mkdir -p $out/share/fonts/truetype
+    cp -v *.ttf $out/share/fonts/truetype
+    cp -v ${./comic-sans-ms-alias.conf} $out/etc/fonts/conf.d/30-comic-sans-ms.conf
+    cp -v FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://loudifier.com/comic-relief/;
+    description = "A font metric-compatible with Microsoft Comic Sans";
+    longDescription = ''
+      Comic Relief is a typeface designed to be metrically equivalent
+      to the popular Comic Sans MS. Comic Relief can be used in place
+      of Comic Sans MS without having to move, resize, or reset any
+      part of the copy. It contains all glyphs and characters
+      available in Comic Sans MS.
+    '';
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+
+    # Reduce the priority of this package. The intent is that if you
+    # also install the `corefonts` package, then you probably will not
+    # want to install the font alias of this package.
+    priority = 10;
+  };
+}

--- a/pkgs/data/fonts/corefonts/default.nix
+++ b/pkgs/data/fonts/corefonts/default.nix
@@ -34,18 +34,34 @@ stdenv.mkDerivation {
 
   buildInputs = [cabextract];
 
-  buildCommand = "
+  buildCommand = ''
     for i in $exes; do
         cabextract --lowercase $i
     done
 
     cabextract --lowercase viewer1.cab
-  
+
     fontDir=$out/share/fonts/truetype
     mkdir -p $fontDir
     cp *.ttf $fontDir
 
     # Also put the EULA there to be on the safe side.
     cp ${eula} $fontDir/eula.html
-  ";
+
+    # Set up no-op font configs to override any aliases set up by
+    # other packages.
+    mkdir -p $out/etc/fonts/conf.d
+    for name in Andale-Mono Arial-Black Arial Comic-Sans-MS \
+                Courier-New Georgia Impact Times-New-Roman \
+                Trebuchet Verdana Webdings ; do
+      substitute ${./no-op.conf} $out/etc/fonts/conf.d/30-''${name,,}.conf \
+        --subst-var-by fontname "''${name//-/ }"
+    done
+  '';
+
+  meta = {
+    # Set a non-zero priority to allow easy overriding of the
+    # fontconfig configuration files.
+    priority = 5;
+  };
 }

--- a/pkgs/data/fonts/corefonts/no-op.conf
+++ b/pkgs/data/fonts/corefonts/no-op.conf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- This configuation is intentionally left empty in order to
+       override any other font package that may wish to set up an
+       alias for the Microsoft @fontname@ font. If you actually do
+       want to have the alias then please change the priority of that
+       package; see the Nix manual page for nix-env for details. -->
+</fontconfig>

--- a/pkgs/data/fonts/crimson/default.nix
+++ b/pkgs/data/fonts/crimson/default.nix
@@ -1,0 +1,28 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "crimson-${version}";
+  version = "2014.10";
+
+  src = fetchurl {
+    url = "https://github.com/skosch/Crimson/archive/fonts-october2014.tar.gz";
+    sha256 = "0qyihrhqb89vwg9cfpaf5xqmcjvs4r4614bxy634vmqv9v1bzn5b";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "Desktop Fonts/OTF/"*.otf $out/share/fonts/opentype
+    cp -v README.md $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://aldusleaf.org/crimson.html;
+    description = "A font family inspired by beautiful oldstyle typefaces";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+  };
+}

--- a/pkgs/data/fonts/fantasque-sans-mono/default.nix
+++ b/pkgs/data/fonts/fantasque-sans-mono/default.nix
@@ -1,0 +1,34 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "fantasque-sans-mono-${version}";
+  version = "1.6.5";
+
+  src = fetchurl {
+    url = "https://github.com/belluzj/fantasque-sans/releases/download/v${version}/FantasqueSansMono.zip";
+    sha256 = "19a82xlbcnd7dxqmpp03b62gjvi33bh635r0bjw2l09lgir6alym";
+  };
+
+  buildInputs = [unzip];
+  phases = ["unpackPhase" "installPhase"];
+
+  unpackCmd = ''
+    mkdir -p ${name}
+    unzip -qq -d ${name} $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "OTF/"*.otf $out/share/fonts/opentype
+    cp -v README.md $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/belluzj/fantasque-sans;
+    description = "A font family with a great monospaced variant for programmers";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+  };
+}

--- a/pkgs/data/fonts/lobster-two/default.nix
+++ b/pkgs/data/fonts/lobster-two/default.nix
@@ -1,0 +1,75 @@
+{stdenv, fetchurl}:
+
+let
+
+  # HG revision in which this version of the font can be fount.
+  rev = "8e98053718f9a15184c93d6530885791be71b756";
+
+  urlBase = "https://googlefontdirectory.googlecode.com/hg-history/${rev}/ofl/lobstertwo";
+
+  # Just a small convenience function.
+  fetch = {name, path ? "/src", sha256}:
+    {
+      inherit name;
+      file = fetchurl {
+        url = "${urlBase}${path}/${name}";
+        inherit sha256;
+      };
+    };
+
+  fontlog =
+    fetch {
+      name = "FONTLOG.txt";
+      path = "";
+      sha256 = "0n405i8m70q95y8w43gzr5yvkj7gx7rd3xa4rx6y8qcqv5g7v9if";
+    };
+
+  bold =
+    fetch {
+      name = "LobsterTwo-Bold.otf";
+      sha256 = "0gkayn96vvgngs9xnmcyyf16q4payk79ghvl354rl93ayb3gf7x0";
+    };
+
+  boldItalic =
+    fetch {
+      name = "LobsterTwo-BoldItalic.otf";
+      sha256 = "0wznqkvwjqi9s4bg10fpp2345by3nxa0m0w6b3al3zaqyx2p1dxp";
+    };
+
+  italic =
+    fetch {
+      name = "LobsterTwo-Italic.otf";
+      sha256 = "0lpnzwgwl5fm6gqy8bylbryz0hy94mf1mp615y5sh0wikdvk570z";
+    };
+
+  regular =
+    fetch {
+      name = "LobsterTwo-Regular.otf";
+      sha256 = "147m3sa3sqqbkbw1hgjdwnw8w0y37x58g5p09s7q2vm74flcpbq1";
+    };
+in
+
+  stdenv.mkDerivation rec {
+    name = "lobstertwo-${version}";
+    version = "1.006";
+
+    phases = ["installPhase"];
+
+    installPhase = ''
+      mkdir -p $out/share/fonts/opentype
+      mkdir -p $out/share/doc/${name}
+      cp -v ${fontlog.file} $out/share/doc/${name}/${fontlog.name}
+      cp -v ${bold.file} $out/share/fonts/opentype/${bold.name}
+      cp -v ${boldItalic.file} $out/share/fonts/opentype/${boldItalic.name}
+      cp -v ${italic.file} $out/share/fonts/opentype/${italic.name}
+      cp -v ${regular.file} $out/share/fonts/opentype/${regular.name}
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = http://www.impallari.com/lobstertwo;
+      description = "Script font with many ligatures";
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [maintainers.rycee];
+    };
+  }

--- a/pkgs/data/fonts/pecita/default.nix
+++ b/pkgs/data/fonts/pecita/default.nix
@@ -1,0 +1,26 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "pecita-${version}";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "http://pecita.eu/b/Pecita.otf";
+    sha256 = "07krzpbmc5yhfbf3aklv1f150i2g1spaan9girmg3189jsn6qw6p";
+  };
+
+  phases = ["installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    cp -v ${src} $out/share/fonts/opentype/Pecita.otf
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://pecita.eu/police-en.php;
+    description = "Handwritten font with connected glyphs";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+  };
+}

--- a/pkgs/data/fonts/quattrocento-sans/default.nix
+++ b/pkgs/data/fonts/quattrocento-sans/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "quattrocento-sans-${version}";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
+    sha256 = "043jfdn18dgzpx3qb3s0hc541n6xv4gacsm4srd6f0pri45g4wh1";
+  };
+
+  buildInputs = [unzip];
+  phases = ["unpackPhase" "installPhase"];
+
+  sourceRoot = "quattrocento-sans-v${version}";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "src/"*.otf $out/share/fonts/opentype
+    cp -v FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.impallari.com/quattrocentosans/;
+    description = "A classic, elegant and sober sans-serif typeface";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+  };
+}

--- a/pkgs/data/fonts/quattrocento/default.nix
+++ b/pkgs/data/fonts/quattrocento/default.nix
@@ -1,0 +1,29 @@
+{stdenv, fetchurl, unzip}:
+
+stdenv.mkDerivation rec {
+  name = "quattrocento-${version}";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
+    sha256 = "09wmbfwkry1r2cf5z4yy67wd4yzlnsjigg01r5r80z1phl0axn9n";
+  };
+
+  buildInputs = [unzip];
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "src/"*.otf $out/share/fonts/opentype
+    cp -v FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.impallari.com/quattrocento/;
+    description = "A classic, elegant, sober and strong serif typeface";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [maintainers.rycee];
+  };
+}

--- a/pkgs/data/fonts/vista-fonts/default.nix
+++ b/pkgs/data/fonts/vista-fonts/default.nix
@@ -18,13 +18,26 @@ stdenv.mkDerivation {
   
   buildPhase = "true";
   
-  installPhase = "
-    mkdir -p $out/share/fonts/truetype; cp *.ttf $out/share/fonts/truetype
-  ";
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+
+    # Set up no-op font configs to override any aliases set up by
+    # other packages.
+    mkdir -p $out/etc/fonts/conf.d
+    for name in Calibri Cambria Candara Consolas Constantia Corbel ; do
+      substitute ${./no-op.conf} $out/etc/fonts/conf.d/30-''${name,,}.conf \
+        --subst-var-by fontname $name
+    done
+  '';
 
   meta = {
     description = "Some TrueType fonts from Microsoft Windows Vista (Calibri, Cambria, Candara, Consolas, Constantia, Corbel)";
     homepage = http://www.microsoft.com/typography/ClearTypeFonts.mspx;
     binaryDistribution = false; # haven't read the EULA, but we probably can't redistribute these files, so...
+
+    # Set a non-zero priority to allow easy overriding of the
+    # fontconfig configuration files.
+    priority = 5;
   };
 }

--- a/pkgs/data/fonts/vista-fonts/no-op.conf
+++ b/pkgs/data/fonts/vista-fonts/no-op.conf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- This configuation is intentionally left empty in order to
+       override any other font package that may wish to set up an
+       alias for the Microsoft @fontname@ font. If you actually do
+       want to have the alias then please change the priority of that
+       package; see the Nix manual page for nix-env for details. -->
+</fontconfig>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9539,9 +9539,17 @@ let
 
   cacert = callPackage ../data/misc/cacert { };
 
+  caladea = callPackage ../data/fonts/caladea {};
+
   cantarell_fonts = callPackage ../data/fonts/cantarell-fonts { };
 
+  carlito = callPackage ../data/fonts/carlito {};
+
+  comfortaa = callPackage ../data/fonts/comfortaa {};
+
   comic-neue = callPackage ../data/fonts/comic-neue { };
+
+  comic-relief = callPackage ../data/fonts/comic-relief {};
 
   corefonts = callPackage ../data/fonts/corefonts { };
 
@@ -9553,6 +9561,8 @@ let
   clearlyU = callPackage ../data/fonts/clearlyU { };
 
   cm_unicode = callPackage ../data/fonts/cm-unicode {};
+
+  crimson = callPackage ../data/fonts/crimson {};
 
   dejavu_fonts = callPackage ../data/fonts/dejavu-fonts {
     inherit (perlPackages) FontTTF;
@@ -9587,6 +9597,8 @@ let
   dosemu_fonts = callPackage ../data/fonts/dosemu-fonts { };
 
   eb-garamond = callPackage ../data/fonts/eb-garamond { };
+
+  fantasque-sans-mono = callPackage ../data/fonts/fantasque-sans-mono {};
 
   fira = callPackage ../data/fonts/fira { };
 
@@ -9628,6 +9640,8 @@ let
 
   lmodern = callPackage ../data/fonts/lmodern { };
 
+  lobster-two = callPackage ../data/fonts/lobster-two {};
+
   lohit-fonts = callPackage ../data/fonts/lohit-fonts { };
 
   manpages = callPackage ../data/documentation/man-pages { };
@@ -9654,6 +9668,8 @@ let
 
   opensans-ttf = callPackage ../data/fonts/opensans-ttf { };
 
+  pecita = callPackage ../data/fonts/pecita {};
+
   poly = callPackage ../data/fonts/poly { };
 
   posix_man_pages = callPackage ../data/documentation/man-pages-posix { };
@@ -9677,6 +9693,10 @@ let
   iana_etc = callPackage ../data/misc/iana-etc { };
 
   poppler_data = callPackage ../data/misc/poppler-data { };
+
+  quattrocento = callPackage ../data/fonts/quattrocento {};
+
+  quattrocento-sans = callPackage ../data/fonts/quattrocento-sans {};
 
   r3rs = callPackage ../data/documentation/rnrs/r3rs.nix { };
 


### PR DESCRIPTION
These are some packages for some nice fonts I like. Some of these also add fontconfig configs to establish aliases with popular Microsoft fonts but I am uncertain what is the best way to install those. I've manually added

``` xml
<include ignore_missing="yes">~/.nix-profile/etc/fonts/conf.d</include>
```

to my `fonts.conf` file but some more smooth solution should hopefully be possible.

The added fonts are
- Caladea,
- Carlito,
- Comfortaa,
- Comic Relief,
- Fantasque Sans Mono,
- Lobster Two,
- Pecita,
- Quattrocento, and
- Quattrocento Sans.

Also added is a set "fonts" giving, for example, Pecita the attribute path "fonts.pecita". Again, I am not certain if this would be considered best practice or I instead should put them in the "global path".
