### PR TITLE
Update lighttable to 0.7.2

### DIFF
--- a/pkgs/applications/editors/lighttable/default.nix
+++ b/pkgs/applications/editors/lighttable/default.nix
@@ -15,20 +15,20 @@ assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
   name = "LightTable-${version}";
-  version = "0.6.7";
+  version = "0.7.2";
 
   src = 
     if stdenv.system == "i686-linux" then
       fetchurl {
         name = "LightTableLinux.tar.gz";
-        url = https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.7/LightTableLinux.tar.gz;
-        sha256 = "3b09f9665ed1b4abb7c1ca16286ac7222caf6dc124059be6db4cb9f5fd041e73";
+        url = "https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/${version}/LightTableLinux.tar.gz";
+        sha256 = "1q5m50r319xn9drfv3cyfja87b7dfhni9d9gmz9733idq3l5fl9i";
       }
     else
       fetchurl {
         name = "LightTableLinux64.tar.gz";
-        url = https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/0.6.7/LightTableLinux64.tar.gz;
-        sha256 = "710d670ccc30aadba521ccb723388679ee6404aac662297a005432c811d59e82";
+        url = "https://d35ac8ww5dfjyg.cloudfront.net/playground/bins/${version}/LightTableLinux64.tar.gz";
+        sha256 = "1jnn103v5qrplkb5ik9p8whfqclcq2r1qv666hp3jaiwb46vhf3c";
       };
 
   buildInputs = [ makeWrapper ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       --set-rpath ${libPath}:${stdenv.cc.cc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
       $out/LightTable/ltbin
 
-    ln -s ${udev}/lib/libudev.so.1 $out/LightTable/libudev.so.0
+    ln -sf ${udev}/lib/libudev.so.1 $out/LightTable/libudev.so.0
 
     makeWrapper $out/LightTable/ltbin $out/bin/lighttable \
       --prefix "LD_LIBRARY_PATH" : $out/LightTable

--- a/pkgs/applications/editors/lighttable/default.nix
+++ b/pkgs/applications/editors/lighttable/default.nix
@@ -14,7 +14,7 @@ in
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
-  name = "LightTable-${version}";
+  name = "lighttable-${version}";
   version = "0.7.2";
 
   src = 


### PR DESCRIPTION
Update lighttable to 0.7.2

Also, I've renamed from LightTable to lighttable. This will cause issues when installing after old 0.6.7. Should I add `priority` parameter to solve this issue? 
