### PR TITLE
Add Darwin case for java.swt

### DIFF
--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -7,21 +7,19 @@
 }:
 
 let
-  metadata =
-    if stdenv.isLinux then
-      if stdenv.isx86_64 then
-        { platform = "gtk-linux-x86_64";
-          sha256 = "0hq48zfqx2p0fqr0rlabnz2pdj0874k19918a4dbj0fhzkhrh959"; }
-      else if stdenv.isi686 then
-             { platform = "gtk-linux-x86";
-               sha256 = "10si8kmc7c9qmbpzs76609wkfb784pln3qpmra73gb3fbk7z8caf"; }
-           else { }
-    else if stdenv.isDarwin then
-           if stdenv.isx86_64 then
-             { platform = "cocoa-macosx-x86_64";
-               sha256 = "1565gg63ssrl04fh355vf9mnmq8qwwki3zpc3ybm7bylgkfwc9h4"; }
-           else { }
-         else { };
+  platformMap = {
+    "x86_64-linux" =
+      { platform = "gtk-linux-x86_64";
+        sha256 = "0hq48zfqx2p0fqr0rlabnz2pdj0874k19918a4dbj0fhzkhrh959"; };
+    "i686-linux" =
+      { platform = "gtk-linux-x86";
+        sha256 = "10si8kmc7c9qmbpzs76609wkfb784pln3qpmra73gb3fbk7z8caf"; };
+    "x86_64-darwin" =
+      { platform = "cocoa-macosx-x86_64";
+        sha256 = "1565gg63ssrl04fh355vf9mnmq8qwwki3zpc3ybm7bylgkfwc9h4"; };
+  };
+
+  metadata = assert platformMap ? ${stdenv.system}; platformMap.${stdenv.system};
 
 in stdenv.mkDerivation rec {
   version = "3.7.2";

--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -6,11 +6,23 @@
 , libsoup
 }:
 
-let metadata = if stdenv.system == "i686-linux"
-               then { arch = "x86"; sha256 = "10si8kmc7c9qmbpzs76609wkfb784pln3qpmra73gb3fbk7z8caf"; }
-               else if stdenv.system == "x86_64-linux"
-                    then { arch = "x86_64"; sha256 = "0hq48zfqx2p0fqr0rlabnz2pdj0874k19918a4dbj0fhzkhrh959"; }
-                    else { };
+let
+  metadata =
+    if stdenv.isLinux then
+      if stdenv.isx86_64 then
+        { platform = "gtk-linux-x86_64";
+          sha256 = "0hq48zfqx2p0fqr0rlabnz2pdj0874k19918a4dbj0fhzkhrh959"; }
+      else if stdenv.isi686 then
+             { platform = "gtk-linux-x86";
+               sha256 = "10si8kmc7c9qmbpzs76609wkfb784pln3qpmra73gb3fbk7z8caf"; }
+           else { }
+    else if stdenv.isDarwin then
+           if stdenv.isx86_64 then
+             { platform = "cocoa-macosx-x86_64";
+               sha256 = "1565gg63ssrl04fh355vf9mnmq8qwwki3zpc3ybm7bylgkfwc9h4"; }
+           else { }
+         else { };
+
 in stdenv.mkDerivation rec {
   version = "3.7.2";
   fullVersion = "${version}-201202080800";
@@ -22,7 +34,7 @@ in stdenv.mkDerivation rec {
   # releases of SWT.  So we just grab a binary release and extract
   # "src.zip" from that.
   src = fetchurl {
-    url = "http://archive.eclipse.org/eclipse/downloads/drops/R-${fullVersion}/${name}-gtk-linux-${metadata.arch}.zip";
+    url = "http://archive.eclipse.org/eclipse/downloads/drops/R-${fullVersion}/${name}-${metadata.platform}.zip";
     sha256 = metadata.sha256;
   };
 


### PR DESCRIPTION
Fixes crash on Darwin when running `nix-env -qas`.
