### PR TITLE
attic: Refactor and fix SHA

### DIFF
--- a/pkgs/tools/backup/attic/default.nix
+++ b/pkgs/tools/backup/attic/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchzip, python3Packages, openssl, acl }:
+{ stdenv, fetchFromGitHub, python3Packages, openssl, acl }:
 
 python3Packages.buildPythonPackage rec {
-  name = "attic-0.14";
-  namePrefix = "";
+  version = "0.14";
+  name = "attic-${version}";
 
-  src = fetchzip {
-    url = "https://github.com/jborg/attic/archive/0.14.tar.gz";
-    sha256 = "17y7kihykaf84sy9cm00fn4wcc7rnhv2792kcwplylz7dsm7ksiw";
+  src = fetchFromGitHub {
+    owner = "jborg";
+    repo = "attic";
+    rev = version;
+    sha256 = "1ij99dmd571rvk3kz97vs7wbjj2pbbd54l310lydnwywxhqs8hrv";
   };
 
   propagatedBuildInputs = with python3Packages;


### PR DESCRIPTION
Let's move from fetchzip to fetchFromGitHub. This was done as a result
of receiving the wrong SHA.
