### PR TITLE
gnupg21: Add texinfo as a dependency

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba, npth
 , readline ? null, libusb ? null, gnutls ? null, adns ? null, openldap ? null
-, zlib ? null, bzip2 ? null, pinentry ? null, autoreconfHook, gettext
+, zlib ? null, bzip2 ? null, pinentry ? null, autoreconfHook, gettext, texinfo
 , pcsclite
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     pkgconfig libgcrypt libassuan libksba npth
     readline libusb gnutls adns openldap zlib bzip2
-    autoreconfHook gettext
+    autoreconfHook gettext texinfo
   ];
 
   configureFlags =


### PR DESCRIPTION
This adds texinfo as a dependency, without which the build will fail.
