### PR TITLE
Patch gnome-control-center not to override VPN plugin paths.

### DIFF
--- a/pkgs/desktops/gnome-3/3.12/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/core/gnome-control-center/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  patches = [ ./search_providers_dir.patch ];
+  patches = [ ./search_providers_dir.patch ./vpn_plugins_path.patch ];
 
   meta = with stdenv.lib; {
     description = "Single sign-on framework for GNOME";

--- a/pkgs/desktops/gnome-3/3.12/core/gnome-control-center/vpn_plugins_path.patch
+++ b/pkgs/desktops/gnome-3/3.12/core/gnome-control-center/vpn_plugins_path.patch
@@ -1,0 +1,19 @@
+diff --git a/panels/network/connection-editor/vpn-helpers.c b/panels/network/connection-editor/vpn-helpers.c
+index 7dc23c2..fcb1384 100644
+--- a/panels/network/connection-editor/vpn-helpers.c
++++ b/panels/network/connection-editor/vpn-helpers.c
+@@ -95,14 +95,6 @@ vpn_get_plugins (GError **error)
+ 		if (!so_path)
+ 			goto next;
+ 
+-		/* Remove any path and extension components, then reconstruct path
+-		 * to the SO in LIBDIR
+-		 */
+-		so_name = g_path_get_basename (so_path);
+-		g_free (so_path);
+-		so_path = g_build_filename (NM_VPN_MODULE_DIR, so_name, NULL);
+-		g_free (so_name);
+-
+ 		module = g_module_open (so_path, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+ 		if (!module) {
+ 			g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Cannot load the VPN plugin which provides the "


### PR DESCRIPTION
The network-manager vpn plugin configuration files contain the correct absolute paths to the plugin libraries in the store; however upstream (unsuccessfully) tries to find them in a predefined path.

This is how one of the configuration files, `/etc/NetworkManager/VPN/nm-openvpn-service.name`, looks like--the `GNOME/properties` entry is the issue:

```
[VPN Connection]
name=openvpn
service=org.freedesktop.NetworkManager.openvpn
program=/nix/store/ffvgfid1nvj937ps444596avargqwsag-NetworkManager-openvpn-gnome-0.9.8.4/libexec/nm-openvpn-service

[GNOME]
auth-dialog=/nix/store/ffvgfid1nvj937ps444596avargqwsag-NetworkManager-openvpn-gnome-0.9.8.4/libexec/nm-openvpn-auth-dialog
properties=/nix/store/ffvgfid1nvj937ps444596avargqwsag-NetworkManager-openvpn-gnome-0.9.8.4/lib/NetworkManager/libnm-openvpn-properties
supports-external-ui-mode=true
```

Without this patch, when you try to add a VPN connection in gnome-control-center, you get an empty list with "import from file" as the only option since no plugins can be found.  With this patch, I can add an OpenVPN connect and successfully connect.

This seems to be related to #3539.
