### PR TITLE
Yakuake: hardcode path to konsole

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kdelibs, gettext }:
+{ stdenv, fetchurl, kdelibs, gettext, konsole }:
 
 let
   pname = "yakuake";
@@ -15,6 +15,10 @@ stdenv.mkDerivation {
   buildInputs = [ kdelibs ];
 
   nativeBuildInputs = [ gettext ];
+
+  patchPhase = ''
+    substituteInPlace app/terminal.cpp --replace \"konsolepart\" "\"${konsole}/lib/kde4/libkonsolepart.so\""
+  '';
 
   meta = {
     homepage = http://yakuake.kde.org;


### PR DESCRIPTION
I have no idea how this worked before.

Yakuake [uses](https://github.com/panzi/Yakuake/blob/master/app/terminal.cpp#L59) `KPluginLoader`, which looks for the library in lots of different weird places but not the correct one. For me it whined that it couldn’t find Konsole and `strace` gave this:

```
access("/home/kirrun/.kde/lib/kde4/konsolepart.so", R_OK) = -1 ENOENT (No such file or directory)
access("/nix/store/2qj7f5r1c3jz1n3zbn2dmj8n6damlfc9-kdelibs-4.14.3/lib/kde4/konsolepart.so", R_OK) = -1 ENOENT (No such file or directory)

access("/home/kirrun/.kde/lib/./libkonsolepart", R_OK) = -1 ENOENT (No such file or directory)
access("/nix/store/2qj7f5r1c3jz1n3zbn2dmj8n6damlfc9-kdelibs-4.14.3/lib/./libkonsolepart", R_OK) = -1 ENOENT (No such file or directory)

access("/home/kirrun/.kde/lib/kde4/konsolepart.so", R_OK) = -1 ENOENT (No such file or directory)
access("/nix/store/2qj7f5r1c3jz1n3zbn2dmj8n6damlfc9-kdelibs-4.14.3/lib/kde4/konsolepart.so", R_OK) = -1 ENOENT (No such file or directory)

access("/home/kirrun/.kde/lib/./libkonsolepart", R_OK) = -1 ENOENT (No such file or directory)
access("/nix/store/2qj7f5r1c3jz1n3zbn2dmj8n6damlfc9-kdelibs-4.14.3/lib/./libkonsolepart", R_OK) = -1 ENOENT (No such file or directory)
```

@urkud
