### PR TITLE
owncloud: don't store plaintext adminPassword in nix store

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/owncloud.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/owncloud.nix
@@ -384,8 +384,7 @@ rec {
     };
 
     adminPassword = mkOption {
-      description = "The admin password for accessing owncloud.
-        Warning: this is stored in cleartext in the Nix store!";
+      description = "The admin password for accessing owncloud.";
     };
 
     dbType = mkOption {
@@ -571,7 +570,7 @@ rec {
 
     chown wwwrun:wwwrun ${config.dataDir}/owncloud.log || true
 
-    QUERY="INSERT INTO groups (gid) values('admin'); INSERT INTO users (uid,password) values('${config.adminUser}','`echo -n "${config.adminPassword}" | ${pkgs.openssl}/bin/openssl dgst -sha1 | ${pkgs.gawk}/bin/awk '{print $2}'`'); INSERT INTO group_user (gid,uid) values('admin','${config.adminUser}');"
+    QUERY="INSERT INTO groups (gid) values('admin'); INSERT INTO users (uid,password) values('${config.adminUser}','${builtins.hashString "sha1" config.adminPassword}'); INSERT INTO group_user (gid,uid) values('admin','${config.adminUser}');"
     ${pkgs.sudo}/bin/sudo -u postgres ${pkgs.postgresql}/bin/psql -h "/tmp" -U postgres -d ${config.dbName} -Atw -c "$QUERY" || true
   '';
 }


### PR DESCRIPTION
Rather than using openssl to hash the password at build time, and hence
leaving the plaintext password world-readable in the nix store, we can
instead hash the password in the nix expression itself using
builtins.hashString.

I'm new to nix and nixpkgs so I would appreciate feedback on this PR.  In particular, I note that hashString isn't used anywhere else in nixpkgs so I wonder if this somehow is not idiomatic.
