### PR TITLE
linuxPackages: point to latests longterm kernel 3.18

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9056,7 +9056,7 @@ let
   };
 
   # The current default kernel / kernel modules.
-  linuxPackages = linuxPackages_3_14;
+  linuxPackages = linuxPackages_3_18;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!


### PR DESCRIPTION
http://www.linux.com/news/software/linux-kernel/815939-linux-kernel-3189-is-now-an-lts-long-term-support-release
