### PR TITLE
iojs: Fix update script, update iojs

### DIFF
--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, python, utillinux, openssl, http-parser, zlib, libuv, nightly ? false }:
 
 let
-  version = if nightly then "1.2.1-nightly201502201bf91878e7" else "1.3.0";
+  version = if nightly then "1.5.2-nightly201503173c8ae2d934" else "1.5.1";
   inherit (stdenv.lib) optional maintainers licenses platforms;
 in stdenv.mkDerivation {
   name = "iojs-${version}";
@@ -11,8 +11,8 @@ in stdenv.mkDerivation {
           then "https://iojs.org/download/nightly/v${version}/iojs-v${version}.tar.gz"
           else "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
     sha256 = if nightly
-             then "1bk0jiha7n3s9xawj77d4q1navq28pq061w2wa6cs70lik7n6ri4"
-             else "08g0kmz2978jrfx4551fi12ypcsv9p6vic89lfs08ki7ajw2yrgb";
+             then "10blf1hr80fknrzyrbj7qy2xn7wilnyn6y2r7ijrw2gns4ia3d0h"
+             else "0zdxdb9n0yk6dp6j6x3bka7vrnf7kz8jjcpl6fw5fr9f742s9s26";
   };
 
   prePatch = ''

--- a/pkgs/development/web/iojs/update-iojs
+++ b/pkgs/development/web/iojs/update-iojs
@@ -1,10 +1,12 @@
-#!/bin/sh -e
+#!/bin/sh
 #
 # Fetch the latest io.js release (stable/nightly) and update
 # `default.nix` in this directory.
 #
 
-cd "$(dirname "$0")"
+set -e
+
+HERE="$(dirname "$0")"
 
 latest() {
     curl -s "$1" | grep 'href="v' \
@@ -39,11 +41,11 @@ nightly=$(latest_log nightly 'https://iojs.org/download/nightly/')
 
 sed -i \
     "/version = if nightly/s/then.*/then \"$nightly\" else \"$stable\";/" \
-    default.nix
+    "$HERE/default.nix"
 
 stableHash=$(hash_log "$(url iojs.src)")
 nightlyHash=$(hash_log "$(url iojs-nightly.src)")
 
 sed -i \
     "/sha256 = if nightly/{N;s/\"[^\"]*\"/\"$nightlyHash\"/;N;s/\"[^\"]*\";/\"$stableHash\";/}" \
-    default.nix
+    "$HERE/default.nix"


### PR DESCRIPTION
The nix-instantiate invocations only work correctly if this script is
run from the root directory of nixpkgs, or in a directory without a
default.nix file and NIX_PATH set appropriately.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/6866)

<!-- Reviewable:end -->
