### PR TITLE
nvidiabl: fix builds for other kernel versions than current

### DIFF
--- a/pkgs/os-specific/linux/nvidiabl/default.nix
+++ b/pkgs/os-specific/linux/nvidiabl/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation {
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "DESTDIR=$(out)"
+    "KVER=${kernel.modDirVersion}"
   ];
 
   meta = {


### PR DESCRIPTION
The makefile for this package uses `uname -r` internally, so it won't compile for any other kernel than the currently running one. This PR should fix that using another makeflag.
