### PR TITLE
nixos/cadvisor: fixes

### DIFF
--- a/nixos/modules/services/monitoring/cadvisor.nix
+++ b/nixos/modules/services/monitoring/cadvisor.nix
@@ -90,17 +90,9 @@ in {
             ${optionalString cfg.storageDriverSecure "-storage_driver_secure"}
           ''}
         '';
-        User = "cadvisor";
       };
     };
 
-    virtualisation.docker.enable = true;
-
-    users.extraUsers = singleton {
-      name = "cadvisor";
-      uid = config.ids.uids.cadvisor;
-      description = "Cadvisor user";
-      extraGroups = [ "docker" ];
-    };
+    virtualisation.docker.enable = mkDefault true;
   };
 }


### PR DESCRIPTION
- run as non root user, because of docker
- run docker by default

So basically just run it is as root, until docker fixes permissions, i left user id in ids.nix, because i'm sure docker will fix it some day.
