### PR TITLE
nsd: Update from 4.1.0 -> 4.1.1

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -107,6 +107,7 @@ let
     zone:
       name:         "${name}"
       zonefile:     "${stateDir}/zones/${name}"
+      ${maybeString "zonestats: "          zone.zoneStats}
       ${maybeString "outgoing-interface: " zone.outgoingInterface}
     ${forEach     "  rrl-whitelist: "      zone.rrlWhitelist}
 
@@ -268,6 +269,19 @@ let
         description = ''
           The actual zone data. This is the content of your zone file.
           Use imports or pkgs.lib.readFile if you don't want this data in your config file.
+        '';
+      };
+
+      zoneStats = mkOption {
+        type        = types.nullOr types.str;
+        default     = null;
+        example     = "%s";
+        description = ''
+          When config.nsd.zoneStats is set to true NSD is able of collecting
+          statistics per zone. All statistics of this zone(s) will be added
+          to the group specified by this given name. Use "%s" to use the zones
+          name as the group. The groups are output from nsd-control stats
+          and stats_noreset.
         '';
       };
     };

--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -8,14 +8,15 @@
 , ratelimit        ? false
 , recvmmsg         ? false
 , rootServer       ? false
+, zoneStats        ? false
 }:
 
 stdenv.mkDerivation rec {
-  name = "nsd-4.1.0";
+  name = "nsd-4.1.1";
 
   src = fetchurl {
     url = "http://www.nlnetlabs.nl/downloads/nsd/${name}.tar.gz";
-    sha256 = "ec3f6902f6f26a6b9248dcd7e9f42472fa52755740b4ba6b9d3bd08910b39b62";
+    sha256 = "b0c3fab40ac7a8b5ffca642bc9e1b424aa72aebd03adf13a1f24ab4874734640";
   };
 
   buildInputs = [ libevent openssl ];
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
      ++ edf ratelimit        "ratelimit"
      ++ edf recvmmsg         "recvmmsg"
      ++ edf rootServer       "root-server"
+     ++ edf zoneStats        "zone-stats"
      ++ [ "--with-ssl=${openssl}" "--with-libevent=${libevent}" ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Updates NSD name server to the latest version and adds the new zoneStats option to the corresponding service module.
