### PR TITLE
New package: Honcho (Python clone of Foreman)

### DIFF
--- a/pkgs/tools/system/honcho/default.nix
+++ b/pkgs/tools/system/honcho/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchzip, pythonPackages, buildPythonPackage }:
+
+let honcho = buildPythonPackage rec {
+  name = "honcho-${version}";
+  version = "0.6.6";
+  namePrefix = "";
+
+  src = fetchzip {
+    url = "https://github.com/nickstenning/honcho/archive/v${version}.tar.gz";
+    md5 = "f5e6a7f6c1d0c167d410d7f601b4407e";
+  };
+
+  buildInputs = with pythonPackages; [ nose mock jinja2 ];
+  checkPhase = ''
+    runHook preCheck
+    nosetests
+    runHook postCheck
+  '';
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A Python clone of Foreman, a tool for managing Procfile-based applications.";
+    license = licenses.mit;
+    homePage = https://github.com/nickstenning/honcho;
+    maintainers = with maintainers; [ benley ];
+    platforms = platforms.unix;
+  };
+};
+
+in
+
+# Some of honcho's tests require that honcho be installed in the environment in
+# order to work. This is a trick to build it without running tests, then pass
+# it to itself as a buildInput so the tests work.
+honcho.overrideDerivation (x: { buildInputs = [ honcho ]; doCheck = true; })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1622,6 +1622,8 @@ let
     lua = lua5;
   };
 
+  honcho = callPackage ../tools/system/honcho { };
+
   host = callPackage ../tools/networking/host { };
 
   hping = callPackage ../tools/networking/hping { };


### PR DESCRIPTION
Please let me know if there's a better way of doing the "build with tests disabled, then feed that into itself as a buildInput and run the tests" trick here.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/6889)

<!-- Reviewable:end -->
