### PR TITLE
nsd: Fix automatic config options

### DIFF
--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -8,6 +8,7 @@
 , ratelimit        ? false
 , recvmmsg         ? false
 , rootServer       ? false
+, rrtypes          ? false
 , zoneStats        ? false
 }:
 
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
      ++ edf ratelimit        "ratelimit"
      ++ edf recvmmsg         "recvmmsg"
      ++ edf rootServer       "root-server"
+     ++ edf rrtypes          "draft-rrtypes"
      ++ edf zoneStats        "zone-stats"
      ++ [ "--with-ssl=${openssl}" "--with-libevent=${libevent}" ];
 


### PR DESCRIPTION
With this patch the NSD (DNS server) module will automatically enable and disable nsd's compile time options as needed by the given service configuration.
This is how I always wanted it to be—I just did not know how to do this properly when I have created the module.
