### PR TITLE
Revert "VLC wants a newer version of libdvdnav"

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
       "--enable-dc1394"
       "--enable-ncurses"
       "--enable-vdpau"
-      "--enable-dvdnav"
     ]
     ++ optional onlyLibVLC  "--disable-vlc";
 

--- a/pkgs/development/libraries/libdvdnav/A08-dvdnav-dup.patch
+++ b/pkgs/development/libraries/libdvdnav/A08-dvdnav-dup.patch
@@ -1,0 +1,137 @@
+Index: src/dvdnav.c
+===================================================================
+--- libdvdnav.orig/src/dvdnav.c	(revision 1168)
++++ libdvdnav/src/dvdnav.c	(working copy)
+@@ -71,6 +71,67 @@
+   return DVDNAV_STATUS_OK;
+ }
+ 
++dvdnav_status_t dvdnav_dup(dvdnav_t **dest, dvdnav_t *src) {
++  dvdnav_t *this;
++
++  (*dest) = NULL;
++  this = (dvdnav_t*)malloc(sizeof(dvdnav_t));
++  if(!this)
++    return DVDNAV_STATUS_ERR;
++
++  memcpy(this, src, sizeof(dvdnav_t));
++  this->file = NULL;
++
++  pthread_mutex_init(&this->vm_lock, NULL);
++
++  this->vm = vm_new_copy(src->vm);
++  if(!this->vm) {
++    printerr("Error initialising the DVD VM.");
++    pthread_mutex_destroy(&this->vm_lock);
++    free(this);
++    return DVDNAV_STATUS_ERR;
++  }
++
++  /* Start the read-ahead cache. */
++  this->cache = dvdnav_read_cache_new(this);
++
++  (*dest) = this;
++  return DVDNAV_STATUS_OK;
++}
++
++dvdnav_status_t dvdnav_free_dup(dvdnav_t *this) {
++
++#ifdef LOG_DEBUG
++  fprintf(MSG_OUT, "libdvdnav: free_dup:called\n");
++#endif
++
++  if (this->file) {
++    pthread_mutex_lock(&this->vm_lock);
++    DVDCloseFile(this->file);
++#ifdef LOG_DEBUG
++    fprintf(MSG_OUT, "libdvdnav: close:file closing\n");
++#endif
++    this->file = NULL;
++    pthread_mutex_unlock(&this->vm_lock);
++  }
++
++  /* Free the VM */
++  if(this->vm)
++    vm_free_copy(this->vm);
++
++  pthread_mutex_destroy(&this->vm_lock);
++
++  /* We leave the final freeing of the entire structure to the cache,
++   * because we don't know, if there are still buffers out in the wild,
++   * that must return first. */
++  if(this->cache)
++    dvdnav_read_cache_free(this->cache);
++  else
++    free(this);
++
++  return DVDNAV_STATUS_OK;
++}
++
+ dvdnav_status_t dvdnav_open(dvdnav_t** dest, const char *path) {
+   dvdnav_t *this;
+   struct timeval time;
+Index: src/dvdnav/dvdnav.h
+===================================================================
+--- libdvdnav.orig/src/dvdnav/dvdnav.h	(revision 1168)
++++ libdvdnav/src/dvdnav.h	(working copy)
+@@ -89,6 +89,9 @@
+  */
+ dvdnav_status_t dvdnav_open(dvdnav_t **dest, const char *path);
+ 
++dvdnav_status_t dvdnav_dup(dvdnav_t **dest, dvdnav_t *src);
++dvdnav_status_t dvdnav_free_dup(dvdnav_t *this);
++
+ /*
+  * Closes a dvdnav_t previously opened with dvdnav_open(), freeing any
+  * memory associated with it.
+Index: src/vm/vm.c
+===================================================================
+--- libdvdnav.orig/src/vm/vm.c	(revision 1168)
++++ libdvdnav/src/vm/vm.c	(working copy)
+@@ -96,6 +98,7 @@
+ 
+ static pgcit_t* get_MENU_PGCIT(vm_t *vm, ifo_handle_t *h, uint16_t lang);
+ static pgcit_t* get_PGCIT(vm_t *vm);
++static void vm_close(vm_t *vm);
+ 
+ 
+ /* Helper functions */
+@@ -262,7 +265,7 @@
+ }
+ 
+ void vm_free_vm(vm_t *vm) {
+-  vm_stop(vm);
++  vm_close(vm);
+   free(vm);
+ }
+ 
+@@ -289,12 +292,20 @@
+ 
+ int vm_start(vm_t *vm) {
+   /* Set pgc to FP (First Play) pgc */
++  if (vm->stopped) {
++    vm_reset(vm, NULL);
++    vm->stopped = 0;
++  }
+   set_FP_PGC(vm);
+   process_command(vm, play_PGC(vm));
+   return !vm->stopped;
+ }
+ 
+ void vm_stop(vm_t *vm) {
++  vm->stopped = 1;
++}
++
++static void vm_close(vm_t *vm) {
+   if(vm->vmgi) {
+     ifoClose(vm->vmgi);
+     vm->vmgi=NULL;
+@@ -346,7 +357,7 @@
+ 
+   if (vm->dvd && dvdroot) {
+     /* a new dvd device has been requested */
+-    vm_stop(vm);
++    vm_close(vm);
+   }
+   if (!vm->dvd) {
+     vm->dvd = DVDOpen(dvdroot);

--- a/pkgs/development/libraries/libdvdnav/P00-mingw-no-examples.patch
+++ b/pkgs/development/libraries/libdvdnav/P00-mingw-no-examples.patch
@@ -1,0 +1,21 @@
+diff -Naur libdvdnav.orig/Makefile.am libdvdnav/Makefile.am
+--- libdvdnav.orig/Makefile.am	2008-10-03 16:11:46.000000000 -0400
++++ libdvdnav/Makefile.am	2009-04-24 02:53:15.000000000 -0400
+@@ -1,7 +1,7 @@
+ include $(top_srcdir)/misc/Makefile.common
+ 
+ 
+-SUBDIRS = src examples doc misc m4
++SUBDIRS = src doc misc m4
+ 
+ EXTRA_DIST = autogen.sh \
+ 	     AUTHORS \
+diff -Naur libdvdnav.orig/configure.ac libdvdnav/configure.ac
+--- libdvdnav.orig/configure.ac	2009-01-08 17:57:11.000000000 -0500
++++ libdvdnav/configure.ac	2009-04-24 02:52:34.000000000 -0400
+@@ -252,5 +252,4 @@
+ misc/relchk.sh
+ m4/Makefile
+ doc/Makefile
+-examples/Makefile
+ ])

--- a/pkgs/development/libraries/libdvdnav/default.nix
+++ b/pkgs/development/libraries/libdvdnav/default.nix
@@ -1,16 +1,24 @@
 {stdenv, fetchurl, pkgconfig, libdvdread}:
 
-stdenv.mkDerivation rec {
-  name = "libdvdnav";
-  version = "5.0.3";
-
+stdenv.mkDerivation {
+  name = "libdvdnav-4.2.1";
+  
   src = fetchurl {
-    url = "http://download.videolan.org/pub/videolan/${name}/${version}/${name}-${version}.tar.bz2";
-    sha256 = "5097023e3d2b36944c763f1df707ee06b19dc639b2b68fb30113a5f2cbf60b6d";
+    url = http://dvdnav.mplayerhq.hu/releases/libdvdnav-4.2.1.tar.xz;
+    sha256 = "7fca272ecc3241b6de41bbbf7ac9a303ba25cb9e0c82aa23901d3104887f2372";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [libdvdread];
+
+  configureScript = "./configure2"; # wtf?
+
+  preConfigure = ''
+    mkdir -p $out
+  '';
+
+  # From Handbrake
+  patches = [ ./A08-dvdnav-dup.patch ./P00-mingw-no-examples.patch ];
 
   meta = {
     homepage = http://dvdnav.mplayerhq.hu/;

--- a/pkgs/development/libraries/libdvdread/default.nix
+++ b/pkgs/development/libraries/libdvdread/default.nix
@@ -1,12 +1,11 @@
 {stdenv, fetchurl, libdvdcss}:
 
-stdenv.mkDerivation rec {
-  name = "libdvdread";
-  version = "5.0.2";
-
+stdenv.mkDerivation {
+  name = "libdvdread-4.9.9";
+  
   src = fetchurl {
-    url = "http://download.videolan.org/pub/videolan/${name}/${version}/${name}-${version}.tar.bz2";
-    sha256 = "82cbe693f2a3971671e7428790b5498392db32185b8dc8622f7b9cd307d3cfbf";
+    url = http://dvdnav.mplayerhq.hu/releases/libdvdread-4.9.9.tar.xz;
+    sha256 = "d91275471ef69d488b05cf15c60e1cd65e17648bfc692b405787419f47ca424a";
   };
 
   buildInputs = [libdvdcss];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#6886 because these changes break `mplayer`: http://hydra.cryp.to/build/635259/nixlog/1/raw.
