### PR TITLE
Change uses of apparmor to libapparmor (v2.9)

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -256,7 +256,7 @@ let
     qtpaint = [ pkgs.qt4 ];
     R2GUESS = [ pkgs.gsl ];
     R2SWF = [ pkgs.zlib pkgs.libpng pkgs.freetype ];
-    RAppArmor = [ pkgs.apparmor ];
+    RAppArmor = [ pkgs.libapparmor ];
     rbamtools = [ pkgs.zlib ];
     RCA = [ pkgs.gmp ];
     rcdd = [ pkgs.gmp ];
@@ -1003,7 +1003,7 @@ let
 
     RAppArmor = old.RAppArmor.overrideDerivation (attrs: {
       patches = [ ./patches/RAppArmor.patch ];
-      LIBAPPARMOR_HOME = "${pkgs.apparmor}";
+      LIBAPPARMOR_HOME = "${pkgs.libapparmor}";
     });
 
     RMySQL = old.RMySQL.overrideDerivation (attrs: {

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoreconfHook, fetchurl, libcap, apparmor, perl, docbook2x
+{ stdenv, autoreconfHook, fetchurl, libcap, libapparmor, perl, docbook2x
 , docbook_xml_dtd_45, gnutls, pkgconfig
 }:
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wm8n1b8j3x37757h2yyz53k3b6r2r301fmkviqf4xp0jaav1cd0";
   };
 
-  buildInputs = [ libcap apparmor perl docbook2x gnutls autoreconfHook pkgconfig ];
+  buildInputs = [ libcap libapparmor perl docbook2x gnutls autoreconfHook pkgconfig ];
 
   patches = [ ./install-localstatedir-in-store.patch ./support-db2x.patch ];
 


### PR DESCRIPTION
I believe these are the only reverse dependencies of libapparmor (outside of apparmor itself). I have built lxc locally against libapparmor, but not RAppArmor.
