### PR TITLE
kernelPatches: remove unused parameters

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchgit, apparmor }:
+{ stdenv, fetchurl }:
 
 let
 


### PR DESCRIPTION
Discovered this while looking for apparmor reverse dependencies, seems like a trivial cleanup to me.
