### PR TITLE
Update davmail to 2.6.1.

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, jre, glib, libXtst, gtk, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "davmail-4.5.1";
+  name = "davmail-4.6.1";
   src = fetchurl {
-    url = "mirror://sourceforge/davmail/davmail-linux-x86_64-4.5.1-2303.tgz";
-    sha256 = "0y9dwxlfrfm6yf010fad1p5vsyz2ddci6vhz4sa1js2fq4rvyx7a";
+    url = "mirror://sourceforge/davmail/davmail-linux-x86_64-4.6.1-2343.tgz";
+    sha256 = "15kpbrmw9pcifxj4k4m3q0azbl95kfgwvgb8bc9aj00q0yi3wgiq";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Bugfix release to fix recent regression with Office 365,
also includes a few Linux and IMAP enhancements.
http://sourceforge.net/projects/davmail/files/davmail/4.6.1/releasenotes.txt/download
