### PR TITLE
openssl: security update

### DIFF
--- a/pkgs/development/libraries/openssl/1.0.1j.nix
+++ b/pkgs/development/libraries/openssl/1.0.1j.nix
@@ -18,7 +18,7 @@ let
       # hardcoding something like /etc/ssl/cert.pem is impure and
       # cannot be overriden per-process.  For security, the
       # environment variable is ignored for setuid binaries.
-      ./cert-file.patch
+      ./cert-file-1.0.1j.patch
       # Remove the compilation time from the library
       ./no-date-in-library.patch
     ]

--- a/pkgs/development/libraries/openssl/cert-file-1.0.1j.patch
+++ b/pkgs/development/libraries/openssl/cert-file-1.0.1j.patch
@@ -12,11 +12,12 @@ diff -ru -x '*~' openssl-1.0.0e-orig/crypto/x509/x509_def.c openssl-1.0.0e/crypt
  #include "cryptlib.h"
  #include <openssl/crypto.h>
  #include <openssl/x509.h>
-@@ -78,7 +78,23 @@
+@@ -71,7 +75,25 @@
+ 	{ return(X509_CERT_DIR); }
  
  const char *X509_get_default_cert_file(void)
- {
--    return (X509_CERT_FILE);
+-	{ return(X509_CERT_FILE); }
++	{
 +	static char buf[PATH_MAX] = X509_CERT_FILE;
 +	static int init = 0;
 +	if (!init) {
@@ -34,4 +35,7 @@ diff -ru -x '*~' openssl-1.0.0e-orig/crypto/x509/x509_def.c openssl-1.0.0e/crypt
 +	    }
 +	}
 +	return buf;
- }
++	}
+ 
+ const char *X509_get_default_cert_dir_env(void)
+ 	{ return(X509_CERT_DIR_EVP); }

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -2,7 +2,7 @@
 , withCryptodev ? false, cryptodevHeaders }:
 
 let
-  name = "openssl-1.0.1l";
+  name = "openssl-1.0.1m";
 
   opensslCrossSystem = stdenv.lib.attrByPath [ "openssl" "system" ]
     (throw "openssl needs its platform name cross building" null)
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha256 = "1m6i80y9c9g7h4303bqbxnsk5wm6jd0n57hwqr0g4jaxzr44vkxj";
+    sha256 = "0x7gvyybmqm4lv62mlhlm80f1rn7il2qh8224rahqv0i15xhnpq9";
   };
 
   patches = patchesCross false;


### PR DESCRIPTION
http://openssl.org/news/secadv_20150319.txt

./cert-file.patch needed to be changed due to formatting-only stuff,
and original version was retained to support 1.0.1j.

It's a mass-rebuild, but I guess many may want this directly in master and 14.12.
BTW, Hydra doesn't evaluate, and all except darwin are idling.
