### PR TITLE
openssl: upgrade to 1.0.1m

### DIFF
--- a/pkgs/development/libraries/openssl/cert-file-path-max.patch
+++ b/pkgs/development/libraries/openssl/cert-file-path-max.patch
@@ -12,23 +12,29 @@ diff -ubB --show-c-function openssl-1.0.0e/crypto/x509/x509_def.c.orig openssl-1
  #include <limits.h>
  #include <unistd.h>
  #include <sys/types.h>
-@@ -76,14 +77,16 @@ const char *X509_get_default_cert_dir(vo
+@@ -82,7 +83,7 @@ const char *X509_get_default_cert_dir(void)
  
  const char *X509_get_default_cert_file(void)
- 	{
--	static char buf[PATH_MAX] = X509_CERT_FILE;
-+	static char *buf;
- 	static int init = 0;
- 	if (!init) {
- 	    init = 1;
- 	    char * s = getenv("OPENSSL_X509_CERT_FILE");
- 	    if (s && getuid() == geteuid()) {
--		strncpy(buf, s, sizeof(buf));
--		buf[sizeof(buf) - 1] = 0;
-+	         buf = strdup(s);
-+	    }
-+	    if (!s) {
-+	         buf = strdup(X509_CERT_FILE);
- 	    }
- 	}
- 	return buf;
+ {
+-    static char buf[PATH_MAX] = X509_CERT_FILE;
++    static char *buf;
+     static int init = 0;
+     if (!init) {
+         init = 1;
+@@ -91,12 +92,14 @@ const char *X509_get_default_cert_file(void)
+ #ifndef OPENSSL_SYS_WINDOWS
+             if (getuid() == geteuid()) {
+ #endif
+-                strncpy(buf, s, sizeof(buf));
+-                buf[sizeof(buf) - 1] = 0;
++                buf = strdup(s);
+ #ifndef OPENSSL_SYS_WINDOWS
+             }
+ #endif
+         }
++        else {
++          buf = strdup(X509_CERT_FILE);
++        }
+     }
+     return buf;
+ }

--- a/pkgs/development/libraries/openssl/cert-file.patch
+++ b/pkgs/development/libraries/openssl/cert-file.patch
@@ -12,30 +12,29 @@ diff -ru -x '*~' openssl-1.0.0e-orig/crypto/x509/x509_def.c openssl-1.0.0e/crypt
  #include "cryptlib.h"
  #include <openssl/crypto.h>
  #include <openssl/x509.h>
-@@ -71,7 +75,25 @@
- 	{ return(X509_CERT_DIR); }
+@@ -78,7 +78,23 @@ const char *X509_get_default_cert_dir(void)
  
  const char *X509_get_default_cert_file(void)
--	{ return(X509_CERT_FILE); }
-+	{
-+	static char buf[PATH_MAX] = X509_CERT_FILE;
-+	static int init = 0;
-+	if (!init) {
-+	    init = 1;
-+	    char * s = getenv("OPENSSL_X509_CERT_FILE");
-+	    if (s) {
+ {
+-    return (X509_CERT_FILE);
++    static char buf[PATH_MAX] = X509_CERT_FILE;
++    static int init = 0;
++    if (!init) {
++        init = 1;
++        char * s = getenv("OPENSSL_X509_CERT_FILE");
++        if (s) {
 +#ifndef OPENSSL_SYS_WINDOWS
-+	        if (getuid() == geteuid()) {
++            if (getuid() == geteuid()) {
 +#endif
-+		        strncpy(buf, s, sizeof(buf));
-+		        buf[sizeof(buf) - 1] = 0;
++                strncpy(buf, s, sizeof(buf));
++                buf[sizeof(buf) - 1] = 0;
 +#ifndef OPENSSL_SYS_WINDOWS
-+	        }
++            }
 +#endif
-+	    }
-+	}
-+	return buf;
-+	}
++        }
++    }
++    return buf;
+ }
  
  const char *X509_get_default_cert_dir_env(void)
- 	{ return(X509_CERT_DIR_EVP); }
+

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -2,7 +2,7 @@
 , withCryptodev ? false, cryptodevHeaders }:
 
 let
-  name = "openssl-1.0.1l";
+  name = "openssl-1.0.1m";
 
   opensslCrossSystem = stdenv.lib.attrByPath [ "openssl" "system" ]
     (throw "openssl needs its platform name cross building" null)
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha256 = "1m6i80y9c9g7h4303bqbxnsk5wm6jd0n57hwqr0g4jaxzr44vkxj";
+    sha256 = "0x7gvyybmqm4lv62mlhlm80f1rn7il2qh8224rahqv0i15xhnpq9";
   };
 
   patches = patchesCross false;

--- a/pkgs/development/libraries/openssl/gnu.patch
+++ b/pkgs/development/libraries/openssl/gnu.patch
@@ -2,24 +2,12 @@ Patch to fix compilation on GNU/Hurd and GNU/kFreeBSD.
 
 --- openssl-1.0.0e/Configure	2012-01-06 00:39:49.000000000 +0100
 +++ openssl-1.0.0e/Configure	2012-01-06 00:39:51.000000000 +0100
-@@ -563,7 +563,7 @@ my %table=(
+@@ -593,7 +593,7 @@ my %table=(
  "newsos4-gcc","gcc:-O -DB_ENDIAN::(unknown):NEWS4:-lmld -liberty:BN_LLONG RC4_CHAR RC4_CHUNK DES_PTR DES_RISC1 DES_UNROLL BF_PTR::::",
  
  ##### GNU Hurd
--"hurd-x86",  "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -march=i486 -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:dlfcn:linux-shared:-fPIC",
-+"hurd-x86",  "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -march=i486 -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+-"hurd-x86",  "gcc:-DL_ENDIAN -O3 -fomit-frame-pointer -march=i486 -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:dlfcn:linux-shared:-fPIC",
++"hurd-x86",  "gcc:-DL_ENDIAN -O3 -fomit-frame-pointer -march=i486 -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
  
  ##### OS/2 EMX
  "OS2-EMX", "gcc::::::::",
-
---- openssl-1.0.0e/crypto/dso/dso_dlfcn.c	2012-01-06 00:05:47.000000000 +0100
-+++ openssl-1.0.0e/crypto/dso/dso_dlfcn.c	2012-01-06 00:21:05.000000000 +0100
-@@ -60,7 +60,7 @@
-    that handle _GNU_SOURCE and other similar macros.  Defining it later
-    is simply too late, because those headers are protected from re-
-    inclusion.  */
--#ifdef __linux
-+#if defined __linux || defined __GNU__ || defined __GLIBC__
- # ifndef _GNU_SOURCE
- #  define _GNU_SOURCE	/* make sure dladdr is declared */
- # endif


### PR DESCRIPTION
This is a critical security update, see
https://www.openssl.org/news/secadv_20150319.txt

It will fail patching for kfreebsd, I don't know how to test it and the patch
is not trivial
