### PR TITLE
libatomic_ops: Allow on all unix platforms

### DIFF
--- a/pkgs/development/libraries/libatomic_ops/default.nix
+++ b/pkgs/development/libraries/libatomic_ops/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation {
     description = ''A library for semi-portable access to hardware-provided atomic memory update operations'';
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Suggestion to extend the supported platforms for libatopic_ops so that it can be installed also on darwin.
