### PR TITLE
Print 'env .. loaded' to stderr instead of stdout

### DIFF
--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -141,7 +141,7 @@ mkDerivation {
       }
 
       export PATH
-      echo $name loaded
+      echo $name loaded >&2
 
       trap nix_cleanup EXIT
     EOF


### PR DESCRIPTION
This is a debugging output and printing it to stdout caused some headaches to me.

For example, I have an haskell programming environment, and want to use:

```
load-env-haskell cabal2nix . > default.nix
```

on my shell. But since load-env prints `env haskell loaded` first, it creates a syntax error in default nix.
