### PR TITLE
fix missing glx with nvidia_x11 (proprietary non-legacy driver)

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -45,6 +45,10 @@ installPhase() {
         mkdir -p $out/lib/xorg/modules/extensions
         cp -p libglx.so.* $out/lib/xorg/modules/extensions
 
+        ln -snf $out/lib/xorg/modules/extensions/libglx.so.$versionNumber $out/lib/xorg/modules/extensions/libglx.so
+
+        patchelf --set-rpath $out/lib $out/lib/xorg/modules/extensions/libglx.so.$versionNumber
+
         # Install the kernel module.
         mkdir -p $out/lib/modules/$kernelVersion/misc
         cp kernel/nvidia.ko $out/lib/modules/$kernelVersion/misc


### PR DESCRIPTION
On unstable channel this fixes this problem with missing GLX (taken from /var/log/X.0.log):

```
[     2.822] (EE) NVIDIA(0): Failed to initialize the GLX module; please check in your X
[     2.822] (EE) NVIDIA(0):     log file that the GLX module has been loaded in your X
[     2.822] (EE) NVIDIA(0):     server, and that the module is the NVIDIA GLX module.  If
[     2.822] (EE) NVIDIA(0):     you continue to encounter problems, Please try
[     2.822] (EE) NVIDIA(0):     reinstalling the NVIDIA driver.
```

I do not have disk space nor time to rebuild master (this missingglx branch) so I am asking politely that someone with nvidia device with this error tests it... to reproduce the error, set `services.xserver.videoDrivers = [ "nvidia" ];`, rebuild, reboot and just run the glxgears and if you have the this problem then it will complain about the missing GLX, also compositing will not work (I could not even successfully log into kde5) and E19 was complaining about this.
