### PR TITLE
security update for openssl: 1.0.1l -> 1.0.1m

### DIFF
--- a/pkgs/development/libraries/openssl/cert-file.patch
+++ b/pkgs/development/libraries/openssl/cert-file.patch
@@ -1,6 +1,6 @@
-diff -ru -x '*~' openssl-1.0.0e-orig/crypto/x509/x509_def.c openssl-1.0.0e/crypto/x509/x509_def.c
---- openssl-1.0.0e-orig/crypto/x509/x509_def.c	1999-09-11 19:54:11.000000000 +0200
-+++ openssl-1.0.0e/crypto/x509/x509_def.c	2011-09-12 18:30:59.386501609 +0200
+diff -ru openssl-1.0.1m-orig/crypto/x509/x509_def.c openssl-1.0.1m/crypto/x509/x509_def.c
+--- openssl-1.0.1m-orig/crypto/x509/x509_def.c	2015-03-19 14:19:00.000000000 +0100
++++ openssl-1.0.1m/crypto/x509/x509_def.c	2015-03-19 15:50:44.676683616 +0100
 @@ -57,6 +57,10 @@
   */
  
@@ -12,30 +12,28 @@ diff -ru -x '*~' openssl-1.0.0e-orig/crypto/x509/x509_def.c openssl-1.0.0e/crypt
  #include "cryptlib.h"
  #include <openssl/crypto.h>
  #include <openssl/x509.h>
-@@ -71,7 +75,25 @@
- 	{ return(X509_CERT_DIR); }
+@@ -78,7 +82,23 @@
  
  const char *X509_get_default_cert_file(void)
--	{ return(X509_CERT_FILE); }
-+	{
-+	static char buf[PATH_MAX] = X509_CERT_FILE;
-+	static int init = 0;
-+	if (!init) {
-+	    init = 1;
-+	    char * s = getenv("OPENSSL_X509_CERT_FILE");
-+	    if (s) {
+ {
+-    return (X509_CERT_FILE);
++    static char buf[PATH_MAX] = X509_CERT_FILE;
++    static int init = 0;
++    if (!init) {
++        init = 1;
++        char * s = getenv("OPENSSL_X509_CERT_FILE");
++        if (s) {
 +#ifndef OPENSSL_SYS_WINDOWS
-+	        if (getuid() == geteuid()) {
++            if (getuid() == geteuid()) {
 +#endif
-+		        strncpy(buf, s, sizeof(buf));
-+		        buf[sizeof(buf) - 1] = 0;
++                strncpy(buf, s, sizeof(buf));
++                buf[sizeof(buf) - 1] = 0;
 +#ifndef OPENSSL_SYS_WINDOWS
-+	        }
++            }
 +#endif
-+	    }
-+	}
-+	return buf;
-+	}
++        }
++    }
++    return buf;
+ }
  
  const char *X509_get_default_cert_dir_env(void)
- 	{ return(X509_CERT_DIR_EVP); }

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -2,7 +2,7 @@
 , withCryptodev ? false, cryptodevHeaders }:
 
 let
-  name = "openssl-1.0.1l";
+  name = "openssl-1.0.1m";
 
   opensslCrossSystem = stdenv.lib.attrByPath [ "openssl" "system" ]
     (throw "openssl needs its platform name cross building" null)
@@ -18,6 +18,8 @@ let
       # hardcoding something like /etc/ssl/cert.pem is impure and
       # cannot be overriden per-process.  For security, the
       # environment variable is ignored for setuid binaries.
+      # FIXME: drop this patch; it really isn't necessary, because
+      # OpenSSL already supports a ‘SSL_CERT_FILE’ variable.
       ./cert-file.patch
     ]
 
@@ -43,7 +45,7 @@ stdenv.mkDerivation {
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha256 = "1m6i80y9c9g7h4303bqbxnsk5wm6jd0n57hwqr0g4jaxzr44vkxj";
+    sha256 = "0x7gvyybmqm4lv62mlhlm80f1rn7il2qh8224rahqv0i15xhnpq9";
   };
 
   patches = patchesCross false;


### PR DESCRIPTION
Errata: https://github.com/openssl/openssl/blob/OpenSSL_1_0_1-stable/NEWS

Major changes between OpenSSL 1.0.1l and OpenSSL 1.0.1m [19 Mar 2015]
o Segmentation fault in ASN1_TYPE_cmp fix (CVE-2015-0286)
o ASN.1 structure reuse memory corruption fix (CVE-2015-0287)
o PKCS7 NULL pointer dereferences fix (CVE-2015-0289)
o DoS via reachable assert in SSLv2 servers fix (CVE-2015-0293)
o Use After Free following d2i_ECPrivatekey error fix (CVE-2015-0209)
o X509_to_X509_REQ NULL pointer deref fix (CVE-2015-0288)
o Removed the export ciphers from the DEFAULT ciphers
