### PR TITLE
Alsa: add alsa-tools, add option to load firmware on boot

### DIFF
--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -44,6 +44,14 @@ in
         '';
       };
 
+      enableAlsaFirmware = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Load ALSA firmware on boot.
+        '';
+      };
+
     };
 
   };
@@ -79,6 +87,9 @@ in
           ExecStop = "${alsaUtils}/sbin/alsactl store --ignore";
         };
       };
+
+    hardware.firmware = mkIf config.sound.enableAlsaFirmware
+      [ "${pkgs.alsa-firmware}/lib/firmware" ];
 
   };
 

--- a/pkgs/os-specific/linux/alsa-tools/default.nix
+++ b/pkgs/os-specific/linux/alsa-tools/default.nix
@@ -1,0 +1,76 @@
+{ stdenv,
+  fetchurl,
+  autoconf,
+  automake,
+  alsaLib,
+  pkgconfig,
+  gtk2,
+  gtk3,
+  fltk13,
+  qt3,
+  perl,
+  python,
+  pygobject,
+  pygtk,
+  pyalsa,
+  makeWrapper,
+  libtool,
+  alsa-firmware
+}:
+
+stdenv.mkDerivation rec {
+  name = "alsa-tools-1.0.29";
+
+  src = fetchurl {
+    url = "ftp://ftp.alsa-project.org/pub/tools/alsa-tools-1.0.29.tar.bz2";
+    sha256 = "94abf0ab5a73f0710c70d4fb3dc1003af5bae2d2ed721d59d245b41ad0f2fbd1";
+  };
+
+  buildInputs = [
+    autoconf automake alsaLib pkgconfig gtk2 gtk3 fltk13 qt3 perl python
+    pygobject pygtk pyalsa makeWrapper libtool
+  ];
+
+  GITCOMPILE_ARGS="--prefix= ";
+  GITCOMPILE_NO_MAKE=1;
+
+  automakeVersion = (builtins.parseDrvName automake.name).version;
+  automakeMajorVersion = stdenv.lib.concatStringsSep "."
+    (stdenv.lib.take 2 (stdenv.lib.splitString "." automakeVersion));
+  AUTOMAKE_DIR="${automake}/share/automake-${automakeMajorVersion}";
+
+  phases = [ "unpackPhase" "patchPhase" "buildPhase" "installPhase" "fixupPhase" ];
+
+  patchPhase = ''
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -DDATAPATH=\"${alsa-firmware}/lib/firmware\"";
+    patch -p0 < ${./ld10k1_libtool.patch}
+    patch -p0 < ${./qlo10k1_find_macro.patch}
+    patch -p0 < ${./hdajacksensetest_gitcompile.patch}
+    chmod u+x hdajacksensetest/gitcompile
+    patchShebangs .
+
+    # prevent seq/sbiload/gitcompile from being evaluated more than once
+    pushd seq
+    rm gitcompile; touch gitcompile; chmod u+x gitcompile;
+    popd
+
+    sed -i 's,"$CONFIGURE_ARGS","$(CONFIGURE_ARGS)",' Makefile
+  '';
+
+  installPhase = "make DESTDIR=$out install";
+
+  fixupPhase = ''
+    sed -i "s,/bin/lo10k1,$out/bin/lo10k1,g" $out/bin/init_{audigy,audigy_eq10,live}
+    sed -i "s,bindir=/bin,bindir=$out/bin," $out/bin/init_live
+    wrapProgram $out/bin/hwmixvolume --prefix PYTHONPATH : $PYTHONPATH
+    mv $out/sbin/* $out/bin
+    patchShebangs $out
+  '';
+
+  meta = {
+    homepage = http://www.alsa-project.org/;
+    description = "ALSA Tools contains advanced tools for certain sound cards";
+    platforms = stdenv.lib.platforms.linux;
+    license = with stdenv.lib.licenses; [ gpl2Plus gpl2 free ];
+  };
+}

--- a/pkgs/os-specific/linux/alsa-tools/hdajacksensetest_gitcompile.patch
+++ b/pkgs/os-specific/linux/alsa-tools/hdajacksensetest_gitcompile.patch
@@ -1,0 +1,13 @@
+--- hdajacksensetest/gitcompile.orig	1970-01-01 00:00:00.000000000 +0000
++++ hdajacksensetest/gitcompile	2015-04-09 17:56:37.960007006 +0000
+@@ -0,0 +1,10 @@
++#!/bin/bash
++
++aclocal $ACLOCAL_FLAGS || exit 1
++automake --add-missing || exit 1
++autoconf || exit 1
++echo "./configure $@"
++./configure $@ || exit 1
++if test -z "$GITCOMPILE_NO_MAKE"; then
++  make || exit 1
++fi

--- a/pkgs/os-specific/linux/alsa-tools/ld10k1_libtool.patch
+++ b/pkgs/os-specific/linux/alsa-tools/ld10k1_libtool.patch
@@ -1,0 +1,9 @@
+--- ld10k1/gitcompile.orig	2015-04-09 16:08:26.502714229 +0000
++++ ld10k1/gitcompile	2015-04-09 16:08:40.123096202 +0000
+@@ -1,5 +1,6 @@
+ #!/bin/bash
+ 
++libtoolize --force
+ autoreconf -fi || exit 1
+ export CFLAGS='-O2 -Wall -pipe -g'
+ echo "CFLAGS=$CFLAGS"

--- a/pkgs/os-specific/linux/alsa-tools/qlo10k1_find_macro.patch
+++ b/pkgs/os-specific/linux/alsa-tools/qlo10k1_find_macro.patch
@@ -1,0 +1,11 @@
+--- qlo10k1/configure.ac.orig	2015-04-09 16:38:48.653654110 +0000
++++ qlo10k1/configure.ac	2015-04-09 16:40:28.472401012 +0000
+@@ -1,7 +1,7 @@
+ AC_INIT(qlo10k1, 0.1.2p1)
+ AM_INIT_AUTOMAKE
+ AM_MAINTAINER_MODE([enable])
+-AC_CONFIG_MACRO_DIR([m4])
++AC_CONFIG_MACRO_DIRS([m4 ../ld10k1])
+ AC_CONFIG_HEADERS(config.h)
+ AC_PROG_CXX
+ AC_PROG_LD

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8084,6 +8084,8 @@ let
 
   psyco = callPackage ../development/python-modules/psyco { };
 
+  pyalsa = pythonPackages.pyalsa;
+
   pycairo = pythonPackages.pycairo;
 
   pycapnp = pythonPackages.pycapnp;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8728,6 +8728,8 @@ let
 
   alsa-firmware = callPackage ../os-specific/linux/alsa-firmware { };
 
+  alsa-tools = callPackage ../os-specific/linux/alsa-tools { };
+
   alsaLib = callPackage ../os-specific/linux/alsa-lib { };
 
   alsaPlugins = callPackage ../os-specific/linux/alsa-plugins {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8523,6 +8523,23 @@ let
     };
   });
 
+  pyalsa = buildPythonPackage (rec {
+    name = "pyalsa-1.0.29";
+    disabled = isPy3k;
+    buildInputs = [ pkgs.alsaLib ];
+    src = pkgs.fetchurl {
+      url = "ftp://ftp.alsa-project.org/pub/pyalsa/pyalsa-1.0.29.tar.bz2";
+      sha256 = "87ea6d8a2b7a9d7b015cdd84c898dc5e524f770ae6795e0d32ac2234311c953a";
+    };
+
+    meta = {
+      homepage = http://www.alsa-project.org;
+      description = "Python bindings for ALSA lib";
+      platforms = stdenv.lib.platforms.linux;
+      license = with stdenv.lib.licenses; [ lgpl21Plus gpl2 gpl2Plus free ];
+    };
+  });
+
   pybfd = buildPythonPackage rec {
     name = "pybfd-0.1.1";
 


### PR DESCRIPTION
The firmware in alsa-firmware won't get loaded unless the firmware path is added to hardware.firmware (at least this is what I had to do for my rme hdsp card), so I added an option for it. I also added alsa-tools and pyalsa.
