### PR TITLE
picolisp: bump to 3.1.9

### DIFF
--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -12,12 +12,12 @@ let
   sourceInfo = rec {
     baseName="picolisp";
     tarballBaseName="picoLisp";
-    version="3.1.8";
+    version="3.1.9";
     name="${baseName}-${version}";
     tarballName="${tarballBaseName}-${version}";
     extension="tgz";
     url="http://www.software-lab.de/${tarballName}.${extension}";
-    sha256="0bkr1ck157871bv4a8dp9dmcvxigjsikm5rr2khylxc3l6il7s1i";
+    sha256="1rhfd743ga9qsgn4h2aw1xcgrc7amsllli2zqg8cgm408vxkr6j1";
   };
 in
 rec {


### PR DESCRIPTION
Tested briefly. By the way, why is this packaged the way it is? I wrote an equivalent version using just stdenv.mkDerivation which works just as well, except quite a bit simpler ...
