### PR TITLE
Haskell llvm-general 3.4.4.0 requires LLVM==3.4.*

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -1638,7 +1638,7 @@ self : let callPackage = x : y : modifyPrio (newScope self x y); in
 
   ListZipper = callPackage ../development/libraries/haskell/ListZipper {};
 
-  llvmGeneral = callPackage ../development/libraries/haskell/llvm-general { llvmConfig = pkgs.llvm; };
+  llvmGeneral = callPackage ../development/libraries/haskell/llvm-general { llvmConfig = pkgs.llvmPackages_34.llvm; };
 
   llvmGeneralPure = callPackage ../development/libraries/haskell/llvm-general-pure {};
 


### PR DESCRIPTION
This version of Haskell's llvm-general library refuses to build unless llvm-config-3.4 is available. The current default llvm is 3.5.
