### PR TITLE
simplify convoluted path to autojump.zsh

### DIFF
--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -24,7 +24,7 @@ in
 
       # FIXME: What's the right place for `autojump.zsh'?
       # This can be used as a workaround in .zshrc:
-      # . $(dirname $(readlink -f $HOME/.nix-profile/bin/autojump))/../share/autojump/autojump.zsh
+      # . $HOME/.nix-profile/share/autojump/autojump.zsh
     '';
 
     meta = {


### PR DESCRIPTION
After #6915 was merged I realized it was more complicated than needed. Fixed.
