### PR TITLE
Update to latest org-trello stable (0.6.9.3)

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -746,12 +746,12 @@ let self = _self // overrides;
 
   org-trello = melpaBuild rec {
     pname = "org-trello";
-    version = "0.6.9.2";
+    version = "0.6.9.3";
     src = fetchFromGitHub {
       owner = "org-trello";
       repo = pname;
-      rev = "5656f32d3624b3c82014658aef88ffa47c0fca7b";
-      sha256 = "0781prmxbx3lmylma63vw80rix7dmhy8861jz4cbqmkfid6d3x73";
+      rev = "f1e1401a373dd492eee49fb131b1cd66b3a9ac37";
+      sha256 = "003gdh8rgdl3k8h20wgbciqyacyqr64w1wfdqvwm9qdz414q5yj3";
     };
     packageRequires = [ request-deferred deferred dash s ];
     files = [ "org-trello-*.el" ];


### PR DESCRIPTION
Hello.

Built locally without problems.

``` sh
# tony at myrkr in ~/repo/perso/nixpkgs on git:update-org-trello-derivation o [11:02:48]
$ git log | head -5                                                                                                                                                                                                                                                                                      ~/repo/perso/nixpkgs
commit 412379223947b4c18203085cff583be9495eb233
Author: Antoine R. Dumont <antoine.romain.dumont@gmail.com>
Date:   Sat Mar 21 19:06:35 2015 +0100

    Update to latest org-trello stable (0.6.9.3)

# tony at myrkr in ~/repo/perso/nixpkgs on git:update-org-trello-derivation o [11:02:54]
$ nix-build -A emacs24PackagesNg.org-trello                                                                                                                                                                                                                                                              ~/repo/perso/nixpkgs
/nix/store/zd0xy78fi8ms3f4fmh57wbnc94wvnbqp-emacs-org-trello-0.6.9.3

# tony at myrkr in ~/repo/perso/nixpkgs on git:update-org-trello-derivation o [11:03:06]
$ 
```
