### PR TITLE
a2jmidid: wrap python path for a2j_control, fixes #6916

### DIFF
--- a/pkgs/applications/audio/a2jmidid/default.nix
+++ b/pkgs/applications/audio/a2jmidid/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, alsaLib, dbus, jack2, pkgconfig, python }:
+{ stdenv, fetchurl, makeWrapper, pkgconfig, alsaLib, dbus, jack2
+, python, pythonDBus }:
 
 stdenv.mkDerivation rec {
   name = "a2jmidid-${version}";
@@ -9,13 +10,16 @@ stdenv.mkDerivation rec {
     sha256 = "0pzm0qk5ilqhwz74pydg1jwrds27vm47185dakdrxidb5bv3b5ia";
   };
 
-  buildInputs = [ alsaLib dbus jack2 pkgconfig python ];
+  buildInputs = [ makeWrapper pkgconfig alsaLib dbus jack2 python pythonDBus ];
 
   configurePhase = "python waf configure --prefix=$out";
 
   buildPhase = "python waf";
 
-  installPhase = "python waf install";
+  installPhase = ''
+    python waf install
+    wrapProgram $out/bin/a2j_control --set PYTHONPATH $PYTHONPATH
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://home.gna.org/a2jmidid;


### PR DESCRIPTION
`a2j_control` fails because dbus is not in the python path. The exact error
message is:

```
Traceback (most recent call last):
  File ".nix-profile/bin/a2j_control", line 11, in <module>
    import dbus
  ImportError: No module named dbus
```

The fix is to add the python dbus module to the build inputs and wrap the
python path for `a2j_control`.
