### PR TITLE
profile-cleaner: Add package

### DIFF
--- a/pkgs/tools/misc/profile-cleaner/default.nix
+++ b/pkgs/tools/misc/profile-cleaner/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, makeWrapper, parallel, sqlite }:
+
+stdenv.mkDerivation rec {
+  version = "2.34";
+  name = "profile-cleaner-${version}";
+
+  src = fetchFromGitHub {
+    owner = "graysky2";
+    repo = "profile-cleaner";
+    rev = "v${version}";
+    sha256 = "17z73xyn31668f7vmbj7xs659fcrm0m0mnzja7hz6lipfaviqxrs";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    PREFIX=\"\" DESTDIR=$out make install
+    wrapProgram $out/bin/profile-cleaner \
+      --prefix PATH : "${parallel}/bin:${sqlite}/bin"
+  '';
+
+  meta = {
+    description = "Reduces browser profile sizes by cleaning their sqlite databases";
+    longDescription = ''
+      Use profile-cleaner to reduce the size of browser profiles by organizing
+      their sqlite databases using sqlite3's vacuum and reindex functions. The
+      term "browser" is used loosely since profile-cleaner happily works on
+      some email clients and newsreaders too.
+    '';
+    homepage = https://github.com/graysky2/profile-cleaner;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2415,6 +2415,8 @@ let
 
   prey-bash-client = callPackage ../tools/security/prey { };
 
+  profile-cleaner = callPackage ../tools/misc/profile-cleaner { };
+
   profile-sync-daemon = callPackage ../tools/misc/profile-sync-daemon { };
 
   projectm = callPackage ../applications/audio/projectm { };


### PR DESCRIPTION
This commit adds `profile-cleaner`.

Use profile-cleaner to reduce the size of browser profiles by organizing
their sqlite databases using sqlite3's vacuum and reindex functions. The
term "browser" is used loosely since profile-cleaner happily works on
some email clients and newsreaders too.

Supported browsers include:
- Aurora
- Chromium (stable, beta, and dev)
- Conkeror
- Firefox (stable, beta, and aurora)
- Google-chrome (stable, beta, and dev)
- Heftig's version of Aurora
- Icedove
- Midori
- Newsbeuter
- Palemoon
- Qupzilla
- Seamonkey
- Thunderbird
- Tor-browser
