### PR TITLE
libcxx[abi]: use clang-override stdenv to build

### DIFF
--- a/pkgs/development/compilers/llvm/3.6/default.nix
+++ b/pkgs/development/compilers/llvm/3.6/default.nix
@@ -28,8 +28,12 @@ let
 
     lldb = callPackage ./lldb.nix {};
 
-    libcxx = callPackage ./libc++ {};
+    libcxx = callPackage ./libc++ {
+      inherit stdenv;
+    };
 
-    libcxxabi = callPackage ./libc++abi.nix {};
+    libcxxabi = callPackage ./libc++abi.nix {
+      inherit stdenv;
+    };
   };
 in self


### PR DESCRIPTION
This fixes the error described by #6934.

Pinging @shlevy before committing upstream because I don't see why this would fix anything...
