### PR TITLE
fix the cmake 2.8.x detection of OpenSSL version broken in openssl 1.0.1m.

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/cmake_find_openssl_for_openssl-1.0.1m_and_up.patch
+++ b/pkgs/development/tools/build-managers/cmake/cmake_find_openssl_for_openssl-1.0.1m_and_up.patch
@@ -1,0 +1,11 @@
+--- ./Modules/FindOpenSSL.cmake
++++ ./Modules/FindOpenSSL.cmake
+@@ -264,7 +264,7 @@
+     set(OPENSSL_VERSION "${_OPENSSL_VERSION}")
+   elseif(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+-         REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
++         REGEX "^# *define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+
+     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+     # The status gives if this is a developer or prerelease and is ignored here.

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -30,21 +30,25 @@ stdenv.mkDerivation rec {
       sha256 = "136z63ff83hnwd247cq4m8m8164pklzyl5i2csf5h6wd8p01pdkj";
     })] ++
     # Don't search in non-Nix locations such as /usr, but do search in
-    # Nixpkgs' Glibc. 
+    # Nixpkgs' Glibc.
     optional (stdenv ? glibc) ./search-path.patch ++
     optional (stdenv ? cross) (fetchurl {
       name = "fix-darwin-cross-compile.patch";
       url = "http://public.kitware.com/Bug/file_download.php?"
           + "file_id=4981&type=bug";
       sha256 = "16acmdr27adma7gs9rs0dxdiqppm15vl3vv3agy7y8s94wyh4ybv";
-    });
+    }) ++
+    # fix cmake detection of openssl libs
+    # see: http://public.kitware.com/Bug/bug_relationship_graph.php?bug_id=15386
+    #      and http://www.cmake.org/gitweb?p=cmake.git;a=commitdiff;h=c5d9a8283cfac15b4a5a07f18d5eb10c1f388505#patch1
+    [./cmake_find_openssl_for_openssl-1.0.1m_and_up.patch];
 
   buildInputs = [ curl expat zlib bzip2 libarchive ]
     ++ optional useNcurses ncurses
     ++ optional useQt4 qt4;
 
   CMAKE_PREFIX_PATH = stdenv.lib.concatStringsSep ":" buildInputs;
-  
+
   configureFlags =
     "--docdir=/share/doc/${name} --mandir=/share/man --system-libs"
     + stdenv.lib.optionalString useQt4 " --qt-gui";


### PR DESCRIPTION
this is a follow up to security update for openssl: 1.0.1l -> 1.0.1m,
references:
- http://public.kitware.com/Bug/bug_relationship_graph.php?bug_id=15386
- http://www.cmake.org/gitweb?p=cmake.git;a=commitdiff;h=c5d9a8283cfac15b4a5a07f18d5eb10c1f388505#patch1
