### PR TITLE
Add crosstool-ng package

### DIFF
--- a/pkgs/development/compilers/gcc-cross/armv5te/default.nix
+++ b/pkgs/development/compilers/gcc-cross/armv5te/default.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+let
+  ctng = import ../ctng-build.nix { inherit pkgs; };
+in
+ctng.mkCrossToolchain {
+  name = "armv5te-unknown-linux-gnueabi";
+  config = pkgs.fetchurl {
+    url = http://us.mirror.archlinuxarm.org/mirror/development/ct-ng/xtools-dotconfig-v5;
+    sha256 = "05vcgfih5xiy4wv87rg1hhpcw3shqda9kgnia275a9n7h90qkn43";
+  };
+  toolchainPrefix = "armv5te-linux-gnueabi";
+}

--- a/pkgs/development/compilers/gcc-cross/armv6l/default.nix
+++ b/pkgs/development/compilers/gcc-cross/armv6l/default.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+let
+  ctng = import ../ctng-build.nix { inherit pkgs; };
+in
+ctng.mkCrossToolchain {
+  name = "armv6l-unknown-linux-gnueabihf";
+  config = pkgs.fetchurl {
+    url = http://us.mirror.archlinuxarm.org/mirror/development/ct-ng/xtools-dotconfig-v6;
+    sha256 = "0flh16kd9wzpkak0zznj7n6jqnradhi1sik1iw2i3n8i1i684py3";
+  };
+  toolchainPrefix = "armv6l-linux-gnueabihf";
+}

--- a/pkgs/development/compilers/gcc-cross/armv7l/default.nix
+++ b/pkgs/development/compilers/gcc-cross/armv7l/default.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+let
+  ctng = import ../ctng-build.nix { inherit pkgs; };
+in
+ctng.mkCrossToolchain {
+  name = "armv7l-unknown-linux-gnueabihf";
+  config = pkgs.fetchurl {
+    url = http://us.mirror.archlinuxarm.org/mirror/development/ct-ng/xtools-dotconfig-v7;
+    sha256 = "1nsgw1pf0jswwsw6lzf92l6ak6vjzf4jg8fgb5riy5wq30zr033b";
+  };
+  toolchainPrefix = "armv7l-linux-gnueabihf";
+}

--- a/pkgs/development/compilers/gcc-cross/ctng-build.nix
+++ b/pkgs/development/compilers/gcc-cross/ctng-build.nix
@@ -1,0 +1,152 @@
+{ pkgs }:
+let
+
+  inherit (builtins) filter head length readFile tail toFile;
+  inherit (pkgs) stdenv writeScript crosstool-ng;
+  inherit (pkgs.lib) any attrNames attrValues concatStringsSep getVersion
+                     hasPrefix hasSuffix last listToAttrs filterAttrs init
+                     mapAttrs mapAttrs' mapAttrsToList nameValuePair
+                     replaceChars splitString toLower;
+
+  # Random helpers
+  stringContains = thing: s: (length (splitString thing s)) != 1;
+
+  stripQuotes = replaceChars ["\"" "'"] ["" ""];
+
+  stripSpace = replaceChars [" " "\t"] ["" ""];
+
+  replaceInString = old: new: s: concatStringsSep new (splitString old s);
+
+  # Returns true if the value v is in the list l
+  contains = v: l: any (x: x == v) l;
+
+  # Function to convert a config file to a set
+  cfgToSet = cfg: let
+    cfgList = splitString "\n" (readFile cfg);
+    cfgFiltered = filter (s: !(hasPrefix "#" s) && (stripSpace s) != "") cfgList;
+    cfgAttrList = map (s:
+      let eqSplit = splitString "=" s;
+      # Accounts for equal signs in the value
+      in nameValuePair (head eqSplit) (concatStringsSep "=" (tail eqSplit))
+    ) cfgFiltered;
+  in listToAttrs cfgAttrList;
+
+  # Convert from a set to a config string
+  setToCfg = set: concatStringsSep "\n" (mapAttrsToList (n: v: n + "=" + v) set);
+
+  # Create a set of dependencies to their versions from the configuration set
+  parseVersions = set:
+    if (any (s: hasSuffix "CUSTOM_LOCATION" s || stringContains "LINARO" s) (attrNames set))
+    || (any (s: stringContains "linaro" s) (attrValues set))
+      then throw "Custom source locations and linaro versions are unsupported."
+      else mapAttrs' (n: v:
+        let k = toLower (head (tail (splitString "_" n)));
+        in nameValuePair
+          (stripQuotes (
+            if k == "kernel" then set.CT_KERNEL
+            else if k == "cc" then set.CT_CC
+            else if k == "libc" then set.CT_LIBC
+            else k))
+          (stripQuotes v)
+        )
+        (filterAttrs (n: v: hasSuffix "_VERSION" n && (length (splitString "_" n) == 3)) set);
+
+  # Returns a map of package names and versions to fetchurl derivations
+  sourcesMap = import ./package-map.nix { inherit pkgs; };
+
+  # Supports finding the same extensions supported by ct-ng's extract function
+  getExt = s: let
+    l = splitString "." s;
+    last1 = last l;
+    last2 = last (init l);
+  in if contains last1 [ "tgz" "tar" "zip" ] then last1
+     else if last2 == "tar" && contains last1 [ "xz" "lzma" "bz2" "gz" ] then "tar." + last1
+     else throw "Unknown file extension.";
+in {
+  mkCrossToolchain = { name, config, toolchainPrefix ? "", additionalInputs ? [] }:
+  let
+    # Set that maps config names to config values
+    cfgSet = cfgToSet config;
+
+    # List of dependencies' calculated parameters
+    depInfo = mapAttrs (n: v: rec {
+      srcTar = sourcesMap."${n}"."${v}".out;
+      base = "${n}-${v}";
+      ext = getExt srcTar;
+      full = base + "." + ext;
+    }) (parseVersions cfgSet);
+
+    altHomeDir = "dummy_home";
+    localTarDir = "tars";
+    buildDir = "build";
+
+  in stdenv.mkDerivation rec {
+    inherit name;
+
+    buildInputs = [ crosstool-ng ] ++ additionalInputs;
+
+    prefix = toolchainPrefix;
+
+    builder = writeScript "builder.sh" ''
+      source $stdenv/setup
+      mkdir -p $out
+
+      # Where ct-ng might put stuff
+      mkdir -p ./${altHomeDir}
+      # Where tarballs go so ct-ng doesn't fetch them from the internet
+      mkdir -p ./${localTarDir}
+      # Where extracted sources go so we can patch what we need to
+      mkdir -p ./${buildDir}/src
+
+      cp ${generatedConfig} .config
+      # Fix out directory
+      substituteAllInPlace .config
+
+      # Copy tarballs from nix store to tarball directory
+      ${concatStringsSep "\n" (
+        map (d: "cp ${d.srcTar} ./${localTarDir}/${d.full}") (attrValues depInfo)
+      )}
+
+      ct-ng build
+    '';
+
+    generatedConfig = toFile (name + ".config") (setToCfg (
+      # In the configuration values, replace all instances of ${HOME} with
+      # ${CT_TOP_DIR}/dummy_home and override parameters for nix builds
+
+      (mapAttrs (n: v: replaceInString "\${HOME}" "\${CT_TOP_DIR}/${altHomeDir}" v) cfgSet) // {
+        # These overrides are required for all configs because of how nix
+        # builds and stores build products.
+
+        CT_WORK_DIR = "\"\${CT_TOP_DIR}/${buildDir}\"";
+
+        CT_TARGET_ALIAS = "\"${toolchainPrefix}\"";
+
+        # Install to the correct output directory.
+        CT_PREFIX_DIR = "\"@out@\"";
+
+        # This option makes the install directory read-only but nix will take
+        # care of that for us. Build fails without this since ct-ng doesn't have
+        # the permissions to perform this.
+        CT_INSTALL_DIR_RO = "n";
+
+        # This is unnecessary because we get a clean environment with nix.
+        CT_RM_RF_PREFIX_DIR = "n";
+
+        # Don't try to download anything
+        CT_FORBID_DOWNLOAD = "y";
+
+        # No need to save tarballs because they are in the nix store.
+        CT_SAVE_TARBALLS = "n";
+
+        # Location where we place tarballs from the nix store.
+        CT_LOCAL_TARBALLS_DIR = "\"\${CT_TOP_DIR}/${localTarDir}\"";
+
+        # Support as many formats as possible since we don't know what format
+        # of source archive we'll be getting from existing nix expressions
+        CT_CONFIGURE_has_lzma = "y";
+        CT_CONFIGURE_has_xz = "y";
+      }
+    ));
+  };
+}

--- a/pkgs/development/compilers/gcc-cross/package-map.nix
+++ b/pkgs/development/compilers/gcc-cross/package-map.nix
@@ -1,0 +1,30 @@
+{ pkgs }:
+let
+  inherit (builtins) hasAttr singleton;
+  inherit (pkgs) fetchurl;
+  inherit (pkgs.lib) concatStringsSep fold getVersion splitString substring;
+  mkAttr = name: ver: sha256: let
+    origDer = if name == "gcc" then pkgs.gcc.cc
+              else if name == "mpc" then pkgs.libmpc
+              else if name == "isl" && substring 0 4 ver == "0.12" then pkgs.isl_0_12
+              else pkgs."${name}";
+    origUrls = if hasAttr "urls" origDer.src
+                  then origDer.src.urls
+                  else singleton origDer.src.url;
+    origVer = getVersion origDer;
+  in { "${name}"."${ver}" = fetchurl {
+      urls = map (u: concatStringsSep ver (splitString origVer u)) origUrls;
+      inherit sha256;
+  };};
+in
+fold (v: a: a // v) {} [
+  (mkAttr "binutils" "2.25"   "08r9i26b05zcwb9zxb6zllpfdiiicdfsgbpsjlrjmvx3rxjzrpi2")
+  (mkAttr "gcc"      "4.9.2"  "1pbjp4blk2ycaa6r3jmw4ky5f1s9ji3klbqgv8zs2sl5jn1cj810")
+  (mkAttr "cloog"    "0.18.1" "15j19gb078vmbpvwcx143h6cn98456jfvjw4zsa5z1qlvm70ll02")
+  (mkAttr "gmp"      "6.0.0a" "1bwsfmf0vrx3rwl4xmi5jhhy3v1qx1xj0m7p9hb0fvcw9f09m3kz")
+  (mkAttr "isl"      "0.12.2" "1d0zs64yw6fzs6b7kxq6nh9kvas16h8b43agwh30118jjzpdpczl")
+  (mkAttr "linux"    "3.18.1" "13m0s2m0zg304w86yvcmxgbjl41c4kc420044avi8rnr1xwcscsq")
+  (mkAttr "glibc"    "2.20"   "1g6ysvk15arpi7c1f1fpx5slgfr2k3dqd5xr0yvijajp1m0xxq9p")
+  (mkAttr "mpc"      "1.0.2"  "1264h3ivldw5idph63x35dqqdzqqbxrm5vlir0xyx727i96zaqdm")
+  (mkAttr "mpfr"     "3.1.2"  "0sqvpfkzamxdr87anzakf9dhkfh15lfmm5bsqajk02h1mxh3zivr")
+]

--- a/pkgs/development/tools/crosstool-ng/ct-ng.patch
+++ b/pkgs/development/tools/crosstool-ng/ct-ng.patch
@@ -1,0 +1,12 @@
+diff --git a/scripts/crosstool-NG.sh.in b/scripts/crosstool-NG.sh.in
+index 53ac552..d5904f7 100644
+--- a/scripts/crosstool-NG.sh.in
++++ b/scripts/crosstool-NG.sh.in
+@@ -609,6 +609,7 @@ if [ -z "${CT_RESTART}" ]; then
+         do_libc_extract
+         do_debug_extract
+         do_test_suite_extract
++        do_nix_patching
+         CT_EndStep
+     fi
+ fi

--- a/pkgs/development/tools/crosstool-ng/default.nix
+++ b/pkgs/development/tools/crosstool-ng/default.nix
@@ -1,0 +1,90 @@
+{ stdenv, lib, makeWrapper, fetchurl, writeScript
+, gcc, m4, perl, which, gperf, bison, flex, texinfo, wget, libtool, automake
+, ncurses, file, unzip, python, expat
+}:
+let
+  inherit (lib) concatMapStringsSep;
+  inherit (stdenv) mkDerivation ;
+  inherit (stdenv.lib) overrideDerivation;
+
+  version = "1.20.0";
+
+  gcc-wrapper-with-triple = mkDerivation rec {
+    name = "gcc-with-triple-fakey";
+    srcs = [];
+    builder = writeScript "${name}-builder.sh" ''
+      source $stdenv/setup
+      mkdir -p $out/bin
+      ln -s $NIX_CC/bin/gcc $out/bin/$(basename $(find ${gcc.cc.outPath}/bin -name \*-gcc))
+      ln -s $NIX_CC/bin/g++ $out/bin/$(basename $(find ${gcc.cc.outPath}/bin -name \*-g++))
+    '';
+  };
+
+  # We override expat to provide static libs as well since the ct-ng config
+  # might want static libs
+  expat-static = overrideDerivation expat (origAttrs: {
+    dontDisableStatic = true;
+  });
+
+in mkDerivation rec {
+  name = "crosstool-ng-${version}";
+
+  src = fetchurl {
+    url = "http://crosstool-ng.org/download/crosstool-ng/${name}.tar.bz2";
+    sha256 = "0r1lqwqgw90q3a3gpr1a29zvn84r5d9id17byrid5nxmld8x5cdz";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  # This patch adds a call to the script patchToolchainSourcesScript
+  # after ct-ng does its own patching.
+  patches = [ ./ct-ng.patch ];
+
+  # This script is executed by ct-ng after it does its own patching.
+  # It fixes some absolute pathes (/bin/pwd) in toolchain sources
+  patchToolchainSourcesScript = ./patch-toolchain-sources.sh;
+
+  # Clearing CC was required otherwise the target compiler was misidentified
+  # when building the ncurses (dependency of native gdb)
+  # CXX cleared simply because CC was also cleared, although clearing it may
+  # not be required
+  postInstall = ''
+    # We use substituteInPlace in patchToolchainSourcesScript so add it to ct-ng
+    declare -f substitute >> $out/lib/ct-ng.${version}/scripts/functions
+    declare -f substituteInPlace >> $out/lib/ct-ng.${version}/scripts/functions
+
+    # ct-ng.patch adds a call to the function defined in patchToolchainSourcesScript
+    cat $patchToolchainSourcesScript >> $out/lib/ct-ng.${version}/scripts/functions
+
+    # ct-ng requires all its inputs be discoverable for building (just adding to
+    # PATH is insufficient) so we make use of stdenv's setup, but only if run
+    # standalone. We use whether NIX_BUILD_TOP is set or not to determine this.
+    wrapProgram $out/bin/ct-ng \
+      --set LD_LIBRARY_PATH "" \
+      --run "if [ -z \"\$NIX_BUILD_TOP\" ]; then \
+                NIX_BUILD_TOP=\$(pwd); \
+                propagatedNativeBuildInputs=\"\$(cat $out/nix-support/propagated-native-build-inputs)\"; \
+                source $stdenv/setup; \
+             fi" \
+      --prefix PATH : ${gcc-wrapper-with-triple}/bin \
+      --set CC "" \
+      --set CXX ""
+  '';
+
+  # These are inputs that are both required to install ct-ng and required to
+  # build common components of toolchains (e.g. gcc and m4 are required to build
+  # gmp when ct-ng is run standalone but are not required for installing ct-ng).
+  # None (few?) of these dependencies are discovered by nix since ct-ng is, for
+  # the most part, just a collection of shell scripts. The assumption is that
+  # anything invoking, or depending on, ct-ng will require all of these
+  # dependencies. All propagated build inputs also wrap the ct-ng script so it
+  # can be run standalone, meaning any additional build dependencies for
+  # toolchain components should also be added.
+  propagatedBuildInputs = [
+    # To build/run ct-ng
+    which gperf bison flex texinfo wget libtool automake ncurses file unzip
+    gcc m4   # For building gmp
+    perl     # For installing linux headers
+    python expat-static # For gdb
+  ];
+}

--- a/pkgs/development/tools/crosstool-ng/patch-toolchain-sources.sh
+++ b/pkgs/development/tools/crosstool-ng/patch-toolchain-sources.sh
@@ -1,0 +1,29 @@
+# The following is a check that patches don't get applied multiple times in the
+# same manner that ct-ng does.
+
+do_nix_patching() {
+    # Check if already patched
+    if [ -e "${CT_SRC_DIR}/.nix-patches.patched" ]; then
+        CT_DoLog DEBUG "Already applied nix patching."
+        return 0
+    fi
+
+    # Check if previously partially patched
+    if [ -e "${CT_SRC_DIR}/.nix-patches.patching" ]; then
+        CT_DoLog ERROR "Nix patches were partially applied."
+        CT_DoLog ERROR "Please remove first:"
+        CT_DoLog ERROR " - All source directories and .extracted files."
+        CT_DoLog ERROR " - the .nix-patches.patching file'"
+        CT_Abort "I'll stop now to avoid any carnage..."
+    fi
+    CT_DoExecLog DEBUG touch "${CT_SRC_DIR}/.nix-patches.patching"
+
+    #Now we do the patching
+    CT_DoLog EXTRA "Extra Nix patching"
+    for f in $(find ${CT_WORK_DIR}/src -type f -name configure -o -name Makefile); do
+        substituteInPlace $f --replace /bin/pwd pwd
+    done
+
+    CT_DoExecLog DEBUG touch "${CT_SRC_DIR}/.nix-patches.patched"
+    CT_DoExecLog DEBUG rm -f "${CT_SRC_DIR}/.nix-patches.patching"
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1029,6 +1029,8 @@ let
 
   cron = callPackage ../tools/system/cron { };
 
+  crosstool-ng = callPackage ../development/tools/crosstool-ng/default.nix { };
+
   cudatoolkit5 = callPackage ../development/compilers/cudatoolkit/5.5.nix {
     python = python26;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3606,6 +3606,10 @@ let
   };
   gcc-arm-embedded = gcc-arm-embedded-4_9;
 
+  gcc-armv5te-unknown-linux-gnueabi = callPackage ../development/compilers/gcc-cross/armv5te { };
+  gcc-armv6l-unknown-linux-gnueabihf = callPackage ../development/compilers/gcc-cross/armv6l { };
+  gcc-armv7l-unknown-linux-gnueabihf = callPackage ../development/compilers/gcc-cross/armv7l { };
+
   gforth = callPackage ../development/compilers/gforth {};
 
   # Haskell and GHC


### PR DESCRIPTION
This pull request adds a package for crosstool-ng that can be run standalone. The previous pull request also included several toolchain packages that depended on crosstool-ng but they will be submitted as a separate pull request if there is interest in the toolchains (they were the arm v5, v6, and v7 toolchains from Arch Linux Arm).
