### PR TITLE
Compile postgresql with openssl

### DIFF
--- a/pkgs/servers/sql/postgresql/8.4.x.nix
+++ b/pkgs/servers/sql/postgresql/8.4.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, ncurses, readline }:
+{ stdenv, fetchurl, zlib, ncurses, readline, openssl }:
 
 let version = "8.4.22"; in
 
@@ -10,9 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "09iqr9sldiq7jz1rdnywp2wv36lxy5m8kch3vpchd1s4fz75c7aw";
   };
 
-  buildInputs = [ zlib ncurses readline ];
+  buildInputs = [ zlib ncurses readline openssl ];
 
   LC_ALL = "C";
+
+  configureFlags = [ "--with-openssl" ];
 
   patches = [ ./less-is-more.patch ];
 

--- a/pkgs/servers/sql/postgresql/9.0.x.nix
+++ b/pkgs/servers/sql/postgresql/9.0.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, openssl }:
 
 let version = "9.0.19"; in
 
@@ -10,9 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1h45jdbzdcvprdsi9gija81s3ny46h3faf9f007gza4vm6y15bak";
   };
 
-  buildInputs = [ zlib readline ];
+  buildInputs = [ zlib readline openssl ];
 
   LC_ALL = "C";
+
+  configureFlags = [ "--with-openssl" ];
 
   patches = [ ./less-is-more.patch ];
 

--- a/pkgs/servers/sql/postgresql/9.1.x.nix
+++ b/pkgs/servers/sql/postgresql/9.1.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, openssl }:
 
 let version = "9.1.15"; in
 
@@ -10,11 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "0pyyw0cy91z9wkqf8qzkwsy8cyjps0s94c9czz6mzhyd2npxxmk7";
   };
 
-  buildInputs = [ zlib readline ];
+  buildInputs = [ zlib readline openssl ];
 
   enableParallelBuilding = true;
 
   LC_ALL = "C";
+
+  configureFlags = [ "--with-openssl" ];
 
   patches = [ ./less-is-more.patch ];
 

--- a/pkgs/servers/sql/postgresql/9.2.x.nix
+++ b/pkgs/servers/sql/postgresql/9.2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline }:
+{ stdenv, fetchurl, zlib, readline, openssl }:
 
 let version = "9.2.10"; in
 
@@ -10,11 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "1bbkinqzb3c8i0vfzcy2g7djrq0kxz63jgvzda9p0vylxazmnm1m";
   };
 
-  buildInputs = [ zlib readline ];
+  buildInputs = [ zlib readline openssl ];
 
   enableParallelBuilding = true;
 
   makeFlags = [ "world" ];
+
+  configureFlags = [ "--with-openssl" ];
 
   patches = [ ./disable-resolve_symlinks.patch ./less-is-more.patch ];
 

--- a/pkgs/servers/sql/postgresql/9.3.x.nix
+++ b/pkgs/servers/sql/postgresql/9.3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline, libossp_uuid }:
+{ stdenv, fetchurl, zlib, readline, libossp_uuid, openssl}:
 
 with stdenv.lib;
 
@@ -12,16 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "056ass7nnfyv7blv02anv795kgpz77gipdpxggd835cdwrhwns13";
   };
 
-  buildInputs = [ zlib readline ] ++ optionals (!stdenv.isDarwin) [ libossp_uuid ];
+  buildInputs = [ zlib readline openssl ]
+                ++ optionals (!stdenv.isDarwin) [ libossp_uuid ];
 
   enableParallelBuilding = true;
 
   makeFlags = [ "world" ];
 
-  configureFlags = optional (!stdenv.isDarwin)
-    ''
-      --with-ossp-uuid
-    '';
+  configureFlags = [ "--with-openssl" ]
+                   ++ optional (!stdenv.isDarwin) "--with-ossp-uuid";
 
   patches = [ ./disable-resolve_symlinks.patch ./less-is-more.patch ];
 

--- a/pkgs/servers/sql/postgresql/9.4.x.nix
+++ b/pkgs/servers/sql/postgresql/9.4.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, readline, libossp_uuid }:
+{ stdenv, fetchurl, zlib, readline, libossp_uuid, openssl }:
 
 with stdenv.lib;
 
@@ -12,16 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "19n3i14bhmw8dacd2kl3n1wzj362qv3fjmal5vsvi580h9ybgp99";
   };
 
-  buildInputs = [ zlib readline ] ++ optionals (!stdenv.isDarwin) [ libossp_uuid ];
+  buildInputs = [ zlib readline openssl ]
+                ++ optionals (!stdenv.isDarwin) [ libossp_uuid ];
 
   enableParallelBuilding = true;
 
   makeFlags = [ "world" ];
 
-  configureFlags = optional (!stdenv.isDarwin)
-    ''
-      --with-ossp-uuid
-    '';
+  configureFlags = [ "--with-openssl" ]
+                   ++ optional (!stdenv.isDarwin) "--with-ossp-uuid";
 
   patches = [ ./disable-resolve_symlinks-94.patch ./less-is-more.patch ];
 


### PR DESCRIPTION
This PR enables OpenSSL for all versions of postgresql (#6174). I have only tested 9.3 and 9.4 on darwin.
