### PR TITLE
libdevil: patch to build on darwin

### DIFF
--- a/pkgs/development/libraries/libdevil/default.nix
+++ b/pkgs/development/libraries/libdevil/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
         sha256 = "0qkx2qfv02igbrmsn6z5a3lbrbwjfh3rb0c2sj54wy0j1f775hbc";
       } )
       ./ftbfs-libpng15.patch
+      ./il_endian.h.patch
     ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libdevil/il_endian.h.patch
+++ b/pkgs/development/libraries/libdevil/il_endian.h.patch
@@ -1,0 +1,27 @@
+Source: http://sourceforge.net/p/resil/tickets/8/
+--- devil-1.7.8.orig/src-IL/include/il_endian.h.orig	2009-03-08 01:10:08.000000000 -0600
++++ devil-1.7.8/src-IL/include/il_endian.h	2013-11-03 01:52:37.000000000 -0600
+@@ -19,9 +19,13 @@
+ 	#ifndef __BIG_ENDIAN__
+ 	#define __BIG_ENDIAN__ 1
+ 	#endif
++#else
++	#ifndef __LITTLE_ENDIAN__
++	#define __LITTLE_ENDIAN__ 1
++	#endif
+ #endif
+ 
+-#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __BIG_ENDIAN__) \
++#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) \
+   || (defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__))
+  	#undef __LITTLE_ENDIAN__
+ 	#define Short(s) iSwapShort(s)
+@@ -39,8 +43,6 @@
+ 	#define BigDouble(d)  
+ #else
+ 	#undef __BIG_ENDIAN__
+-	#undef __LITTLE_ENDIAN__  // Not sure if it's defined by any compiler...
+-	#define __LITTLE_ENDIAN__
+ 	#define Short(s)  
+ 	#define UShort(s)  
+ 	#define Int(i)  


### PR DESCRIPTION
Note: I've not tested this against master (since I can't get other things to build...), but have tested it against nixpkgs-unstable @ 2015-03-23.

On a OSX 10.10 system:

```
libtool: compile:  clang++ -DHAVE_CONFIG_H -I. -I../include/IL -I ./../src-IL/include -I ./../include -fgnu89-inline -msse -msse2 -msse3 -D_THREAD_SAFE -I/nix/store/7n9c36hz9sl2dqvfry8d554l935hq4ma-openexr-2.2.0/include/OpenEXR -I/nix/store/3jxslxa37wmfdnyfj1hckpxl0skscgj0-ilmbase-2.2.0/include/OpenEXR -O3 -c ./../src-IL/src/il_exr.cpp  -fno-common -DPIC -o .libs/libIL_la-il_exr.o
In file included from ./../src-IL/src/il_exr.cpp:22:
In file included from ./../src-IL/include/il_exr.h:18:
In file included from /nix/store/7n9c36hz9sl2dqvfry8d554l935hq4ma-openexr-2.2.0/include/OpenEXR/ImfIO.h:49:
In file included from /nix/store/3qsrpjbsmn7w4d18i8zc6a44myiaa516-libc++-3.5.0/include/c++/v1/string:434:
/nix/store/3qsrpjbsmn7w4d18i8zc6a44myiaa516-libc++-3.5.0/include/c++/v1/__config:32:22: error: expected value in expression
#if __LITTLE_ENDIAN__
                     ^
/nix/store/3qsrpjbsmn7w4d18i8zc6a44myiaa516-libc++-3.5.0/include/c++/v1/__config:110:11: fatal error: 'endian.h' file not found
# include <endian.h>
          ^
2 errors generated.
make[1]: *** [libIL_la-il_exr.lo] Error 1
make[1]: Leaving directory `/private/var/folders/1g/yfm550_10sb76p0z469bq9mr5zsthm/T/nix-build-libdevil-1.7.8.drv-1/devil-1.7.8/lib'
make: *** [all-recursive] Error 1
```

See http://sourceforge.net/p/resil/tickets/8/
