### PR TITLE
Bump version of the_silver_searcher: 0.24.1 -> 0.29.1

### DIFF
--- a/pkgs/tools/text/silver-searcher/default.nix
+++ b/pkgs/tools/text/silver-searcher/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchgit, autoreconfHook, pkgconfig, pcre, zlib, lzma}:
 
-let release = "0.24.1"; in
+let release = "0.29.1"; in
 stdenv.mkDerivation {
   name = "silver-searcher-${release}";
 
   src = fetchgit {
     url = "https://github.com/ggreer/the_silver_searcher.git";
     rev = "refs/tags/${release}";
-    sha256 = "1cwav217mkbwyg8isiak0wynydiil2j9gy4sx79harbcql0f3nl3";
+    sha256 = "05508c2714d356464a0de6f41a6a8408ccd861b967e968302c4b72feade89581";
   };
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";


### PR DESCRIPTION
Yeay :smile: ! First contribution to nix!

For you guys wondering how to get the good `SHA256` of a git repo, use a variant of this:

`$ nix-prefetch-git https://github.com/ggreer/the_silver_searcher.git refs/tags/0.29.1`
