### PR TITLE
add mplus-outline-fonts

### DIFF
--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "mplus-${version}";
+  version = "TESTFLIGHT-059";
+
+  src = fetchurl {
+    url = "mirror://sourceforgejp/mplus-fonts/62344/mplus-TESTFLIGHT-059.tar.xz";
+    sha256 = "09dzdgqqflpijd3c30m38cyidshawfp4nz162xhn91j9w09y2qkq";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    description = "M+ Outline Fonts";
+    homepage = http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/index-en.html;
+    license = licenses.mit;
+    maintainers = with maintainers; [ henrytill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9682,6 +9682,8 @@ let
 
   mph_2b_damase = callPackage ../data/fonts/mph-2b-damase { };
 
+  mplus-outline-fonts = callPackage ../data/fonts/mplus-outline-fonts { };
+
   nafees = callPackage ../data/fonts/nafees { };
 
   numix-icon-theme = callPackage ../data/icons/numix-icon-theme { };


### PR DESCRIPTION
Naming is consistent with upstream and Gentoo.
