### PR TITLE
ansi-wl-pprint: don't patch anymore

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -125,10 +125,4 @@ self: super: {
     sha256 = "1fycvjfr1l9wa03k30bnppl3ns99lffh9kmp9r7sr8b6yiydcajq";
     stripLen = 1;
   });
-
-  # https://github.com/batterseapower/ansi-wl-pprint/issues/13
-  ansi-wl-pprint = appendPatch super.ansi-wl-pprint (pkgs.fetchpatch {
-    url = "https://github.com/hvr/ansi-wl-pprint/commit/7e489ea6b546899074b1cdccf37d2e49ab313098.patch";
-    sha256 = "0j20cwbph1wg82gfad5a6gfc5gy42cf4vz514jrpfg8d9qvyfhlj";
-  });
 }


### PR DESCRIPTION
The package version we have now already has this patch courtesy to @hvr
making a release with it.

cc @peti
