### PR TITLE
nixos/systemd: Also escape ':' characters

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -13,7 +13,7 @@ let
 
   makeUnit = name: unit:
     let
-      pathSafeName = lib.replaceChars ["@" "\\"] ["-" "-"] name;
+      pathSafeName = lib.replaceChars ["@" ":" "\\"] ["-" "-" "-"] name;
     in
     if unit.enable then
       pkgs.runCommand "unit-${pathSafeName}" { preferLocalBuild = true; inherit (unit) text; }


### PR DESCRIPTION
This is needed for services with names like "systemd-backlight@backlight:intel_backlight.service".
