### PR TITLE
Fix schroedinger on Darwin

### DIFF
--- a/pkgs/development/compilers/orc/default.nix
+++ b/pkgs/development/compilers/orc/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     # The source code implementing the Marsenne Twister algorithm is licensed
     # under the 3-clause BSD license. The rest is 2-clause BSD license.
     license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
   };
 }

--- a/pkgs/development/libraries/schroedinger/default.nix
+++ b/pkgs/development/libraries/schroedinger/default.nix
@@ -1,11 +1,28 @@
-{stdenv, fetchurl, liboil, pkgconfig}:
+{stdenv, fetchurl, orc, pkgconfig}:
 
 stdenv.mkDerivation {
-  name = "schroedinger-1.0.0";
+  name = "schroedinger-1.0.11";
+
   src = fetchurl {
-    url = mirror://sourceforge/schrodinger/schroedinger-1.0.0.tar.gz;
-    sha256 = "0r374wvc73pfzkcpwk0q0sjx6yhp79acyiqbjy3c7sfqdy7sm4x8";
+    url = http://diracvideo.org/download/schroedinger/schroedinger-1.0.11.tar.gz;
+    sha256 = "04prr667l4sn4zx256v1z36a0nnkxfdqyln48rbwlamr6l3jlmqy";
   };
 
-  buildInputs = [liboil pkgconfig];
+  buildInputs = [orc pkgconfig];
+
+  # The test suite is known not to build against Orc >0.4.16 in Schroedinger 1.0.11.
+  # A fix is in upstream, so test when pulling 1.0.12 if this is still needed. See:
+  # http://www.mail-archive.com/schrodinger-devel@lists.sourceforge.net/msg00415.html
+  preBuild = ''
+    substituteInPlace Makefile \
+      --replace "SUBDIRS = schroedinger doc tools testsuite" "SUBDIRS = schroedinger doc tools" \
+      --replace "DIST_SUBDIRS = schroedinger doc tools testsuite" "DIST_SUBDIRS = schroedinger doc tools"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://diracvideo.org/";
+    maintainers = [ maintainers.spwhitt ];
+    license = [ licenses.mpl11 licenses.lgpl2 licenses.mit ];
+    platforms = platforms.unix;
+  };
 }


### PR DESCRIPTION
I updated schrodginer because the latest version builds correctly on
Darwin, but I'm sure many other bugfixes are included as well.
