### PR TITLE
django: minimum supported python version for django 1.7 is 2.7

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3952,6 +3952,7 @@ let
   django_1_7 = buildPythonPackage rec {
     name = "Django-${version}";
     version = "1.7.7";
+    disabled = pythonOlder "2.7";
 
     src = pkgs.fetchurl {
       url = "http://www.djangoproject.com/m/releases/1.7/${name}.tar.gz";


### PR DESCRIPTION
Mark appropriately in package.
