### PR TITLE
fix `bind` broken build

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, libtool, perl, libxml2 }:
+{ stdenv, fetchurl, openssl, libtool, perl, libxml2, json_c }:
 
 let version = "9.10.2"; in
 
@@ -14,12 +14,13 @@ stdenv.mkDerivation rec {
     sed -i 's/^\t.*run/\t/' Makefile.in
   '';
 
-  buildInputs = [ openssl libtool perl libxml2 ];
+  buildInputs = [ openssl libtool perl libxml2 json_c ];
 
   configureFlags = [
     "--localstatedir=/var"
     "--with-libtool"
     "--with-libxml2=${libxml2}"
+    "--with-libjson=${json_c}"
     "--with-openssl=${openssl}"
     "--without-atf"
     "--without-dlopen"


### PR DESCRIPTION
When building bind with

```
nix-shell --pure -I nixpkgs=/path-to/nixpkgs -p bind
```

I get configure output error:

```
configure: error: found libjson include but not library.
```

This PR allows it to build again. I do not know if this is the correct way to resolve the issue, but it builds it on my machine.

cc/ @viric @peti 
