### PR TITLE
pinentry: fix on darwin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2363,8 +2363,8 @@ let
   philter = callPackage ../tools/networking/philter { };
 
   pinentry = callPackage ../tools/security/pinentry {
-    gtk2 = if stdenv.isDarwin then null else gtk2;
-    qt4 = if stdenv.isDarwin then qt4 else null;
+    libcap = if stdenv.isDarwin then null else libcap;
+    qt4 = null;
   };
 
   pius = callPackage ../tools/security/pius { };


### PR DESCRIPTION
libcap and qt4 aren't supported on Darwin, but gtk2 is.

Refs 70a8bfb and 8feda47

cc @domenkozar  @wkennington @jwiegley
