### PR TITLE
simutrans: update, refactor, improve, add paksets

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12612,6 +12612,8 @@ let
   };
 
   simutrans = callPackage ../games/simutrans { };
+  # get binaries without data built by Hydra
+  simutrans_binaries = lowPrio simutrans.binaries;
 
   soi = callPackage ../games/soi {};
 


### PR DESCRIPTION
- update all, and add more paksets
- add config.simutrans.paksets, multiple are possible now
- fix #6719: missing sounds
- move user settings from ~/simutrans to ~/.simutrans
- darwin support is untested (but claimed upstream)
