### PR TITLE
Added version number to fatsort

### DIFF
--- a/pkgs/tools/filesystems/fatsort/default.nix
+++ b/pkgs/tools/filesystems/fatsort/default.nix
@@ -1,9 +1,11 @@
 {stdenv, fetchurl, help2man}:
 
-stdenv.mkDerivation {
-  name = "fatsort";
+stdenv.mkDerivation rec {
+  version = "1.3.365";
+  name = "fatsort-${version}";
+
   src = fetchurl {
-    url = mirror://sourceforge/fatsort/fatsort-1.3.365.tar.gz;
+    url = "mirror://sourceforge/fatsort/${name}.tar.gz";
     sha256 = "0g9zn2ns86g7zmy0y8hw1w1zhnd51hy8yl6kflyhxs49n5sc7b3p";
   };
 
@@ -16,5 +18,6 @@ stdenv.mkDerivation {
     description = "Sorts FAT partition table, for devices that don't do sorting of files.";
     maintainers = [ stdenv.lib.maintainers.kovirobi ];
     license = stdenv.lib.licenses.gpl2;
+    version = "${version}";
   };
 }


### PR DESCRIPTION
Website monitor.nixos.org reported it as out of date when in reality it
just had no version number.
