### PR TITLE
Downgraded Emacs priority, for exuberant ctags

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -57,6 +57,9 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ chaoflow lovek323 simons the-kenny ];
     platforms   = platforms.all;
 
+    # So that Exuberant ctags is preferred
+    priority = 1;
+
     longDescription = ''
       GNU Emacs is an extensible, customizable text editor—and more.  At its
       core is an interpreter for Emacs Lisp, a dialect of the Lisp


### PR DESCRIPTION
Exuberant ctags works with Emacs among with other editors, and if
installed is probably preferred to Emacs' ctags. Besides, that is still
available as etags.
