### PR TITLE
apache-httpd: adding support for sslServerChain

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -231,6 +231,9 @@ let
     ${if cfg.sslServerCert != null then ''
       SSLCertificateFile ${cfg.sslServerCert}
       SSLCertificateKeyFile ${cfg.sslServerKey}
+      ${if cfg.sslServerChain != null then ''
+        SSLCertificateChainFile ${cfg.sslServerChain}
+      '' else ""}
     '' else ""}
 
     ${if cfg.enableSSL then ''

--- a/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
@@ -56,6 +56,12 @@ with lib;
     description = "Path to server SSL certificate key.";
   };
 
+  sslServerChain = mkOption {
+    type = types.path;
+    example = "/var/ca.pem";
+    description = "Path to server SSL extra chain file.";
+  };
+
   adminAddr = mkOption ({
     type = types.nullOr types.str;
     example = "admin@example.org";

--- a/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
@@ -59,7 +59,7 @@ with lib;
   sslServerChain = mkOption {
     type = types.path;
     example = "/var/ca.pem";
-    description = "Path to server SSL extra chain file.";
+    description = "Path to server SSL chain file.";
   };
 
   adminAddr = mkOption ({


### PR DESCRIPTION
This small patch adds support for the SSLCertificateChainFile apache option.
