### PR TITLE
Rename ccgo back to gccgo

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -211,7 +211,7 @@ stdenv.mkDerivation {
     ''
 
     + optionalString cc.langGo or false ''
-      wrap ccgo ${./cc-wrapper.sh} $ccPath/gccgo
+      wrap gccgo ${./cc-wrapper.sh} $ccPath/gccgo
     ''
 
     + optionalString cc.langAda or false ''


### PR DESCRIPTION
I believe this is result of typo, introduced in 48f63c2f.
