### PR TITLE
Fix platforms attribute for 'cpulimit' expression.

### DIFF
--- a/pkgs/tools/misc/cpulimit/default.nix
+++ b/pkgs/tools/misc/cpulimit/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "http://limitcpu.sourceforge.net/";
     description = "A tool to throttle the CPU usage of programs";
-    platforms = with platforms; [linux freebsd darwin];
+    platforms = with platforms; linux ++ freebsd ++ darwin;
     license = licenses.gpl2;
     maintainer = [maintainers.rycee];
   };


### PR DESCRIPTION
Sorry, I was writing the cpulimit expression too quickly and didn't pay attention. This should fix my messed up platforms attribute.
