### PR TITLE
nixos: condition sysctl.kptr_restrict on features.grsecurity

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -64,6 +64,6 @@ in
     #
     # Removed under grsecurity.
     boot.kernel.sysctl."kernel.kptr_restrict" =
-      if config.security.grsecurity.enable then null else 1;
+      if (config.boot.kernelPackages.kernel.features.grsecurity or false) then null else 1;
   };
 }


### PR DESCRIPTION
The motivation for this is that the grsecurity module doesn't quite fit my needs and I wanted to use a grsec enabled kernel without it. I could use mkForce in my configuration.nix to achieve the same result, but this seems to me like a generally sensible change.
