### PR TITLE
Support L2TP in NetworkManager

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -183,6 +183,9 @@ in {
       { source = "${networkmanager_pptp}/etc/NetworkManager/VPN/nm-pptp-service.name";
         target = "NetworkManager/VPN/nm-pptp-service.name";
       }
+      { source = "${networkmanager_l2tp}/etc/NetworkManager/VPN/nm-l2tp-service.name";
+        target = "NetworkManager/VPN/nm-l2tp-service.name";
+      }
     ] ++ optional (cfg.appendNameservers == [] || cfg.insertNameservers == [])
            { source = overrideNameserversScript;
              target = "NetworkManager/dispatcher.d/02overridedns";
@@ -197,6 +200,7 @@ in {
         networkmanager_vpnc
         networkmanager_openconnect
         networkmanager_pptp
+        networkmanager_l2tp
         modemmanager
         ];
 
@@ -240,6 +244,7 @@ in {
         networkmanager_vpnc
         networkmanager_openconnect
         networkmanager_pptp
+        networkmanager_l2tp
         modemmanager
         ];
 

--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -2,7 +2,8 @@
 , libnotify, libsecret, dbus_glib, polkit, isocodes, libgnome_keyring 
 , mobile_broadband_provider_info, glib_networking, gsettings_desktop_schemas
 , makeWrapper, networkmanager_openvpn, networkmanager_vpnc
-, networkmanager_openconnect, networkmanager_pptp, udev, hicolor_icon_theme, dconf }:
+, networkmanager_openconnect, networkmanager_pptp, networkmanager_l2tp
+, udev, hicolor_icon_theme, dconf }:
 
 let
   pn = "network-manager-applet";
@@ -37,16 +38,19 @@ stdenv.mkDerivation rec {
     ln -s ${networkmanager_vpnc}/etc/NetworkManager/VPN/nm-vpnc-service.name $out/etc/NetworkManager/VPN/nm-vpnc-service.name
     ln -s ${networkmanager_openconnect}/etc/NetworkManager/VPN/nm-openconnect-service.name $out/etc/NetworkManager/VPN/nm-openconnect-service.name
     ln -s ${networkmanager_pptp}/etc/NetworkManager/VPN/nm-pptp-service.name $out/etc/NetworkManager/VPN/nm-pptp-service.name
+    ln -s ${networkmanager_l2tp}/etc/NetworkManager/VPN/nm-l2tp-service.name $out/etc/NetworkManager/VPN/nm-l2tp-service.name
     mkdir -p $out/lib/NetworkManager
     ln -s ${networkmanager_openvpn}/lib/NetworkManager/* $out/lib/NetworkManager/
     ln -s ${networkmanager_vpnc}/lib/NetworkManager/* $out/lib/NetworkManager/
     ln -s ${networkmanager_openconnect}/lib/NetworkManager/* $out/lib/NetworkManager/
     ln -s ${networkmanager_pptp}/lib/NetworkManager/* $out/lib/NetworkManager/
+    ln -s ${networkmanager_l2tp}/lib/NetworkManager/* $out/lib/NetworkManager/
     mkdir -p $out/libexec
     ln -s ${networkmanager_openvpn}/libexec/* $out/libexec/
     ln -s ${networkmanager_vpnc}/libexec/* $out/libexec/
     ln -s ${networkmanager_openconnect}/libexec/* $out/libexec/
     ln -s ${networkmanager_pptp}/libexec/* $out/libexec/
+    ln -s ${networkmanager_l2tp}/libexec/* $out/libexec/
   '';
 
   preFixup = ''

--- a/pkgs/tools/networking/network-manager/l2tp-purity.patch
+++ b/pkgs/tools/networking/network-manager/l2tp-purity.patch
@@ -1,0 +1,26 @@
+diff --git a/src/nm-l2tp-service.c b/src/nm-l2tp-service.c
+index d2c9dc4..e61d3d2 100644
+--- a/src/nm-l2tp-service.c
++++ b/src/nm-l2tp-service.c
+@@ -655,9 +655,7 @@ nm_find_ipsec (void)
+ {
+ 	static const char *ipsec_binary_paths[] =
+ 		{
+-			"/sbin/ipsec",
+-			"/usr/sbin/ipsec",
+-			"/usr/local/sbin/ipsec",
++                        "@strongswan@/bin/ipsec",
+ 			NULL
+ 		};
+ 
+@@ -677,9 +675,7 @@ nm_find_l2tpd (void)
+ {
+ 	static const char *l2tp_binary_paths[] =
+ 		{
+-			"/sbin/xl2tpd",
+-			"/usr/sbin/xl2tpd",
+-			"/usr/local/sbin/xl2tpd",
++                        "@xl2tpd@/bin/xl2tpd",
+ 			NULL
+ 		};
+ 

--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, substituteAll, automake, autoconf, libtool, intltool, pkgconfig
+, networkmanager, ppp, xl2tpd, strongswan
+, withGnome ? true, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  pname = "NetworkManager-l2tp";
+  version = "0.9.8.7";
+
+  src = fetchFromGitHub {
+    owner = "seriyps";
+    repo = "NetworkManager-l2tp";
+    rev = version;
+    sha256 = "07gl562p3f6l2wn64f3vvz1ygp3hsfhiwh4sn04c3fahfdys69zx";
+  };
+
+  buildInputs = [ networkmanager ppp ]
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring ];
+
+  nativeBuildInputs = [ automake autoconf libtool intltool pkgconfig ];
+
+  configureScript = "./autogen.sh";
+
+  configureFlags =
+    if withGnome then "--with-gnome" else "--without-gnome";
+
+  postConfigure = "sed 's/-Werror//g' -i Makefile */Makefile";
+
+  patches =
+    [ ( substituteAll {
+        src = ./l2tp-purity.patch;
+        inherit xl2tpd strongswan;
+      })
+    ];
+
+  meta = with stdenv.lib; {
+    description = "L2TP plugin for NetworkManager";
+    inherit (networkmanager.meta) platforms;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/tools/networking/xl2tpd/default.nix
+++ b/pkgs/tools/networking/xl2tpd/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, libpcap }:
+
+let version = "1.3.6";
+in stdenv.mkDerivation {
+  name = "xl2tpd-${version}";
+
+  src = fetchFromGitHub {
+    owner = "xelerance";
+    repo = "xl2tpd";
+    rev = "v${version}";
+    sha256 = "17lnsk9fsyfp2g5hha7psim6047wj9qs8x4y4w06gl6bbf36jm9z";
+  };
+
+  buildInputs = [ libpcap ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.xelerance.com/software/xl2tpd/;
+    description = "Layer 2 Tunnelling Protocol Daemon (RFC 2661)";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2077,6 +2077,8 @@ let
 
   networkmanager_pptp = callPackage ../tools/networking/network-manager/pptp.nix { };
 
+  networkmanager_l2tp = callPackage ../tools/networking/network-manager/l2tp.nix { };
+
   networkmanager_vpnc = callPackage ../tools/networking/network-manager/vpnc.nix { };
 
   networkmanager_openconnect = callPackage ../tools/networking/network-manager/openconnect.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2965,6 +2965,8 @@ let
 
   welkin = callPackage ../tools/graphics/welkin {};
 
+  xl2tpd = callPackage ../tools/networking/xl2tpd { };
+
   testdisk = callPackage ../tools/misc/testdisk { };
 
   html2text = callPackage ../tools/text/html2text { };


### PR DESCRIPTION
This adds the support. I have lost an opportunity to use (and test) it before I finished the package, so I can't test the connection itself now. It looks good, though, and at least tries to find a host. The other problem is growth of NM's closure (maybe we want to modularize the whole NM instead of enabling everything?).
