### PR TITLE
Fix Leksah

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -269,4 +269,10 @@ self: super: {
     buildDepends = [ primitive ];
     license = pkgs.stdenv.lib.licenses.bsd3;
   }) {};
+
+  # Workaround for a workaround, see comment for "ghcjs" flag.
+  jsaddle = let jsaddle' = disableCabalFlag super.jsaddle "ghcjs";
+            in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
+                                          self.webkitgtk3-javascriptcore ];
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -112,4 +112,9 @@ self: super: {
   # Newer versions require base > 4.7
   gloss = super.gloss_1_9_2_1;
 
+  # Workaround for a workaround, see comment for "ghcjs" flag.
+  jsaddle = let jsaddle' = disableCabalFlag super.jsaddle "ghcjs";
+            in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
+                                          self.webkitgtk3-javascriptcore ];
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-head.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-head.nix
@@ -85,4 +85,9 @@ self: super: {
   # https://github.com/ndmitchell/extra/issues/4
   extra = dontCheck super.extra;
 
+  # Workaround for a workaround, see comment for "ghcjs" flag.
+  jsaddle = let jsaddle' = disableCabalFlag super.jsaddle "ghcjs";
+            in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
+                                          self.webkitgtk3-javascriptcore ];
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -107,4 +107,5 @@ self: super: {
        license = pkgs.stdenv.lib.licenses.mit;
        hydraPlatforms = pkgs.stdenv.lib.platforms.none;
      }) {};
+
 }

--- a/pkgs/development/tools/leksah/default.nix
+++ b/pkgs/development/tools/leksah/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, ghcWithPackages, gtk3, makeWrapper }:
+
+let
+leksahEnv = ghcWithPackages (self: [ self.leksah-server self.leksah ]);
+in stdenv.mkDerivation {
+  name = "leksah";
+
+  buildInputs = [ gtk3 ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    makeWrapper ${leksahEnv}/bin/leksah $out/bin/leksah \
+      --prefix PATH : "${leksahEnv}/bin" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7399,6 +7399,10 @@ let
 
   readosm = callPackage ../development/libraries/readosm { };
 
+  leksah = callPackage ../development/tools/leksah {
+    inherit (haskellngPackages) ghcWithPackages;
+  };
+
   librdf_raptor = callPackage ../development/libraries/librdf/raptor.nix { };
 
   librdf_raptor2 = callPackage ../development/libraries/librdf/raptor2.nix { };


### PR DESCRIPTION
This adds Leksah wrapper and adds propagation of gtk3 dependency to gtksourceview (to skip adding it to auto-generated Hackage packages where needed). This also shows fixes needed in `cabal2nix` for some packages to build -- cc @peti . `process-leksah` is removed from dependencies because it is actually needed only for GHC <= 7.2 (maybe we want to make it `null` in later GHCs?).

Not for merging until `cabal2nix` fixes are there!
