### PR TITLE
update s6, execline, other skarnet.org

### DIFF
--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.2.0.0";
+  version = "2.3.2.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/skalibs";
     rev = "refs/tags/v${version}";
-    sha256 = "1ww45ygrws7h3p3p7y3blc5kzvvy5fmzb158ngfbdamf0pgc5vkn";
+    sha256 = "1l7f2zmas0w28j19g46bvm13j3cx7jimxifivd04zz5r7g79ik5a";
   };
 
   dontDisableStatic = true;

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.0.0";
+  version = "2.0.2.0";
 
 in stdenv.mkDerivation rec {
 
@@ -10,7 +10,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.skarnet.org/software/s6-linux-utils/${name}.tar.gz";
-    sha256 = "0lfgfwnk81vjlkvmr1gzknz9swgcrp5s7x19dfkw6shvi95fyirh";
+    sha256 = "0y6dq4wb5v1c6ps6a7jyq08r2pjksrvz6n3dnfa9c91gzm4m1dxb";
   };
 
   dontDisableStatic = true;

--- a/pkgs/servers/s6/default.nix
+++ b/pkgs/servers/s6/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.1.0";
+  version = "2.1.3.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6";
     rev = "refs/tags/v${version}";
-    sha256 = "1x7za0b1a2i6xn06grpb5j361s9bl4524bp5mz3zcdg8s9nil50d";
+    sha256 = "0dnwkdxqjv5awdgwxci1spcx1s13y5s9wd8ccskwv1rymvpgn8b3";
   };
 
   dontDisableStatic = true;
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     "--with-lib=${execline}/lib"
     "--with-dynlib=${skalibs}/lib"
     "--with-dynlib=${execline}/lib"
-  ] ++ stdenv.lib.optional stdenv.isDarwin [ "--disable-shared" ];
+  ] ++ [ (if stdenv.isDarwin then "--disable-shared" else "--enable-shared") ];
 
   preBuild = ''
     substituteInPlace "src/daemontools-extras/s6-log.c" \

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.1.1";
+  version = "2.1.1.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/execline";
     rev = "refs/tags/v${version}";
-    sha256 = "06fn4fb8hp68pffgfc55l5raph3bk9v0gngbgxfyzkmwbb1gxhll";
+    sha256 = "0yhxyih8p6p9135nifi655qk4gnhdarjzfp1lb4pxx9ar9ay5q7w";
   };
 
   dontDisableStatic = true;

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.0.0";
+  version = "2.0.4.0";
 
 in stdenv.mkDerivation rec {
 
@@ -10,7 +10,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.skarnet.org/software/s6-portable-utils/${name}.tar.gz";
-    sha256 = "1vszqaqkyhz1v69pxls3c7y1qs8wjkdylpg0yz183xlirywimwwk";
+    sha256 = "0gl4v6hslqkxdfxj3qzi1xpiiw52ic8y8l9nkl2z5gp893qb6yvx";
   };
 
   dontDisableStatic = true;

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-dns";
     rev = "refs/tags/v${version}";
-    sha256 = "0y76gvgvg2y3hhr3pk2nkki1idjj6sxxcnvd29yd79v0419p2dl3";
+    sha256 = "0rsw19r9hwxb0xj9xs1rwb7fa21wwbsnfq3p2nfg4lf6cc64b39r";
   };
 
   dontDisableStatic = true;

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.0.1.0";
+  version = "2.1.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-networking";
     rev = "refs/tags/v${version}";
-    sha256 = "1q094x8x99cy0kkq74kfw1rd9kmp6ynpz9ahx0lviz05n9paq7ya";
+    sha256 = "057xwh1dpwg2dz47s0badqhi66nhxgs5ps0xwn7s6hvba0lwyy4c";
   };
 
   dontDisableStatic = true;
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     "--with-include=${s6Dns}/include"
     "--with-lib=${skalibs}/lib"
     "--with-lib=${execline}/lib"
-    "--with-lib=${s6}/lib"
+    "--with-lib=${s6}/lib/s6"
     "--with-lib=${s6Dns}/lib"
     "--with-dynlib=${skalibs}/lib"
     "--with-dynlib=${execline}/lib"


### PR DESCRIPTION
Version bumps, minor changes. Note the version tag `v2.0.0.2` on s6-dns was changed upstream; that's why the sha256 was updated without any other change.
