### PR TITLE
Fixed grsecurity path patch for testing (3.19)

### DIFF
--- a/pkgs/os-specific/linux/kernel/grsec-path.patch
+++ b/pkgs/os-specific/linux/kernel/grsec-path.patch
@@ -1,17 +1,18 @@
-diff --git a/kernel/kmod.c b/kernel/kmod.c
-index 67f7981..03f127d 100644
---- a/kernel/kmod.c
-+++ b/kernel/kmod.c
-@@ -246,9 +246,9 @@ static int ____call_usermodehelper(void *data)
+diff --git a/a/kernel/kmod.c b/b/kernel/kmod.c
+index a26e825..29baec1 100644
+--- a/a/kernel/kmod.c
++++ b/b/kernel/kmod.c
+@@ -294,10 +294,9 @@ static int ____call_usermodehelper(void *data)
  	   out the path to be used prior to this point and are now operating
  	   on that copy
  	*/
 -	if ((strncmp(sub_info->path, "/sbin/", 6) && strncmp(sub_info->path, "/usr/lib/", 9) &&
 -	     strncmp(sub_info->path, "/lib/", 5) && strncmp(sub_info->path, "/lib64/", 7) &&
+-	     strncmp(sub_info->path, "/usr/libexec/", 13) &&
 -	     strcmp(sub_info->path, "/usr/share/apport/apport")) || strstr(sub_info->path, "..")) {
-+	if ((strncmp(sub_info->path, "/sbin/", 6) && strncmp(sub_info->path, "/nix/store/", 11) &&
-+	     strncmp(sub_info->path, "/run/current-system/systemd/lib/", 32)) ||
-+	     strstr(sub_info->path, "..")) {
++        if ((strncmp(sub_info->path, "/sbin/", 6) && strncmp(sub_info->path, "/nix/store/", 11) &&
++             strncmp(sub_info->path, "/run/current-system/systemd/lib/", 32)) ||
++             strstr(sub_info->path, "..")) {
  		printk(KERN_ALERT "grsec: denied exec of usermode helper binary %.950s located outside of /sbin and system library paths\n", sub_info->path);
  		retval = -EPERM;
- 		goto fail;
+ 		goto out;

--- a/pkgs/os-specific/linux/kernel/grsec-path.patch
+++ b/pkgs/os-specific/linux/kernel/grsec-path.patch
@@ -1,7 +1,7 @@
-diff --git a/a/kernel/kmod.c b/b/kernel/kmod.c
+diff --git a/kernel/kmod.c b/kernel/kmod.c
 index a26e825..29baec1 100644
---- a/a/kernel/kmod.c
-+++ b/b/kernel/kmod.c
+--- a/kernel/kmod.c
++++ b/kernel/kmod.c
 @@ -294,10 +294,9 @@ static int ____call_usermodehelper(void *data)
  	   out the path to be used prior to this point and are now operating
  	   on that copy


### PR DESCRIPTION
The grsec-path patch fails when using grsecurity. This should fix it (though I don't know if it will work for earlier (i.e.: non-testing) versions of grsecurity/earlier kernels).
