### PR TITLE
Enable syncthing for Mac OS X.

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -27,6 +27,6 @@ buildGoPackage rec {
     description = "Replaces Dropbox and BitTorrent Sync with something open, trustworthy and decentralized";
     license = with lib.licenses; mit;
     maintainers = with lib.maintainers; [ matejc ];
-    platforms = with lib.platforms; linux;
+    platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/data/misc/iana-etc/default.nix
+++ b/pkgs/data/misc/iana-etc/default.nix
@@ -13,6 +13,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://sethwklein.net/projects/iana-etc/;
     description = "IANA protocol and port number assignments (/etc/protocols and /etc/services)";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Also requires enabling iana-etc. I'm shooting for "unix" platforms which
seems reasonable. Not sure why this was restricted to linux originally --
the history doesn't tell.
