### PR TITLE
twelf: fix by actually including the Twelf SML heap image in the package...

### DIFF
--- a/pkgs/applications/science/logic/twelf/default.nix
+++ b/pkgs/applications/science/logic/twelf/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    rsync -av bin/* $out/bin/
+    rsync -av bin/{*,.heap} $out/bin/
+    bin/.mkexec ${smlnj}/bin/sml $out/ twelf-server twelf-server
 
     mkdir -p $out/share/emacs/site-lisp/twelf/
     rsync -av emacs/ $out/share/emacs/site-lisp/twelf/


### PR DESCRIPTION
... and referencing the SML interpreter so the smlnj package won't be gc'd
