### PR TITLE
pythonPackages: notmuch: revert 6258728, move sourceRoot setting to top-level

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -7,6 +7,10 @@
 stdenv.mkDerivation rec {
   name = "notmuch-0.19";
 
+  passthru = {
+    pythonSourceRoot = "${name}/bindings/python";
+  };
+
   src = fetchurl {
     url = "http://notmuchmail.org/releases/${name}.tar.gz";
     sha256 = "1szf6c44g209pcjq5nvfhlp3nzcm3lrcwv4spsxmwy13hiaccvrr";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7075,7 +7075,7 @@ let
 
     src = pkgs.notmuch.src;
 
-    sourceRoot = "${pkgs.notmuch.src.name}/bindings/python";
+    sourceRoot = pkgs.notmuch.pythonSourceRoot;
 
     buildInputs = with self; [ python pkgs.notmuch ];
 


### PR DESCRIPTION
Looks like this is the only way to do what 6258728318fe55faef64285e614fe97edc7b9111
was expected to do that doesn't break things and doesn't look like a complete hack.

The problem is that different `fetch`ers generate very different results (from
archive files to plain source trees) and allowing overriding `src` in top-level
derivation when there is a derived python package is no trivial matter.
