### PR TITLE
Enable two modern features of GNU global

### DIFF
--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libtool ncurses ];
-  propagatedBuildInputs = [ libtool ncurses pythonPackages.pygments ];
+  propagatedBuildInputs = [ pythonPackages.pygments ];
 
   configurePhase =
     '' ./configure --prefix="$out" --disable-static ''

--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, libtool, ncurses }:
+{ fetchurl, stdenv, libtool, ncurses, ctags, sqlite, pythonPackages }:
 
 stdenv.mkDerivation rec {
   name = "global-6.3.4";
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
     '' ./configure --prefix="$out" --disable-static ''
     + ''--with-posix-sort=$(type -p sort) ''
     + ''--with-ltdl-include=${libtool}/include --with-ltdl-lib=${libtool}/lib ''
-    + ''--with-ncurses=${ncurses}'';
+    + ''--with-ncurses=${ncurses}''
+    + ''--with-sqlite3=${sqlite}''
+    + ''--with-exuberant-ctags=${ctags}/bin/ctags'';
 
   doCheck = true;
 

--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libtool ncurses ];
+  propagatedBuildInputs = [ libtool ncurses pythonPackages.pygments ];
 
   configurePhase =
     '' ./configure --prefix="$out" --disable-static ''


### PR DESCRIPTION
This enables:
- Use of SQLite as the storage backend (available since 6.3.3)
- Optional use of the ctags backend (which, by way of pygments, allows indexing many more languages than what GNU global normally provides).  Using ctags requires setting up a configuration file, so this should not affect users who only care about GNU global's normally supported languages.
