### PR TITLE
gtk3: fix Darwin build

### DIFF
--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
                   intltool dbus_glib at_spi2_core libSM ];
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = with stdenv; lib.optionalString isDarwin "-lintl";
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }
 

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -21,12 +21,14 @@ stdenv.mkDerivation rec {
     sha256 = "1l45nd7ln2pnrf99vdki3l7an5wrzkbak11hnnj1w6r3fkm4xmv1";
   };
 
+  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
+
   nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection perl ];
 
   buildInputs = [ libxkbcommon ];
   propagatedBuildInputs = with xlibs; with stdenv.lib;
-    [ expat glib cairo pango gdk_pixbuf atk at_spi2_atk ]
-    ++ optionals stdenv.isLinux [ libXrandr libXrender libXcomposite libXi libXcursor wayland ]
+    [ expat glib cairo pango gdk_pixbuf atk at_spi2_atk libXrandr libXrender libXcomposite libXi libXcursor ]
+    ++ optionals stdenv.isLinux [ wayland ]
     ++ optional stdenv.isDarwin x11
     ++ optional xineramaSupport libXinerama
     ++ optional cupsSupport cups;

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "01rdzjh68w8l5zn0648yibyarj8p6g7yfn59nw5awaz1i8dvbnqq";
   };
 
-  buildInputs = with stdenv.lib;
-    optional (!stdenv.isDarwin) gobjectIntrospection # build problems of itself and flex
+  buildInputs = with stdenv.lib; [ gobjectIntrospection ]
     ++ optionals stdenv.isDarwin [ fontconfig ];
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
**Update:** this works now, no longer WIP

This is a work in progress effort to fix the gtk3 build on Darwin.
I'm currently encountering the following build error:

```
Undefined symbols for architecture x86_64:
  "_libintl_bind_textdomain_codeset", referenced from:
      _main in updateiconcache.o
  "_libintl_bindtextdomain", referenced from:
      _main in updateiconcache.o
  "_libintl_gettext", referenced from:
      _main in updateiconcache.o
  "_libintl_setlocale", referenced from:
      _main in updateiconcache.o
ld: symbol(s) not found for architecture x86_64
```
