### PR TITLE
Adding Danish dictionary to Aspell

### DIFF
--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -37,6 +37,15 @@ in {
     };
   };
 
+  da = buildDict {
+    shortName = "da-1.4.42-1";
+    fullName = "Danish";
+    src = fetchurl {
+      url = mirror://gnu/aspell/dict/da/aspell5-da-1.4.42-1.tar.bz2;
+      sha256 = "1hfkmiyhgrx5lgrb2mffjbdn1hivrm73wcg7x0iid74p2yb0fjpp";
+    };
+  };
+
   de = buildDict {
     shortName = "de-20030222-1";
     fullName = "German";


### PR DESCRIPTION
I have added the Danish dictionary to Aspell. It is my first pull request for NixOS and GitHub, and hope I am doing everything by the book. Please correct me, if I am not doing things by the book.

I have tested the Danish dictionary using Aspell command line tool and Emacs.
