### PR TITLE
Fixes for ImageMagick's dependencies on Darwin

### DIFF
--- a/pkgs/development/libraries/jbigkit/default.nix
+++ b/pkgs/development/libraries/jbigkit/default.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -i 's/^\(CFLAGS.*\)$/\1 -fPIC/' Makefile
+  '' + stdenv.lib.optionalString (stdenv.cc.cc.isClang or false) ''
+    substituteInPlace Makefile libjbig/Makefile pbmtools/Makefile \
+      --replace "CC = gcc" "CC = clang"
   '';
 
   installPhase = ''

--- a/pkgs/development/libraries/libfpx/default.nix
+++ b/pkgs/development/libraries/libfpx/default.nix
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     sha256 = "0pbvxbp30zqjpc0q71qbl15cb47py74c4d6a8qv1mqa6j81pb233";
   };
 
+  # Darwin gets misdetected as Windows without this
+  NIX_CFLAGS_COMPILE = if stdenv.isDarwin then "-D__unix" else null;
+
+  # This dead code causes a duplicate symbol error in Clang so just remove it
+  postPatch = if (stdenv.cc.cc.isClang or false) then ''
+    substituteInPlace jpeg/ejpeg.h --replace "int No_JPEG_Header_Flag" ""
+  '' else null;
+
   meta = with stdenv.lib; {
     homepage = http://www.imagemagick.org;
     description = "A library for manipulating FlashPIX images";

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, pango, cairo, libxml2, libgsf
-, bzip2, libcroco
+, bzip2, libcroco, libintlOrEmpty
 , gtk3 ? null
 , gobjectIntrospection ? null, enableIntrospection ? false }:
 
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0fplymmqqr28y24vcnb01szn62pfbqhk8p1ngns54x9m6mflr5hk";
   };
 
-  buildInputs = [ libxml2 libgsf bzip2 libcroco pango ]
+  NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
+
+  buildInputs = [ libxml2 libgsf bzip2 libcroco pango libintlOrEmpty ]
     ++ stdenv.lib.optional enableIntrospection [ gobjectIntrospection ];
 
   propagatedBuildInputs = [ glib gdk_pixbuf cairo gtk3 ];

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, lib
 , autoconf, automake, gnum4, libtool, git, perl, gnulib, uthash, pkgconfig, gettext
-, python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2
+, python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2, pango
 , withGTK ? false, gtk2
 , withPython ? false # python-scripting was breaking inconsolata and libertine builds
 }:
@@ -30,7 +30,9 @@ stdenv.mkDerivation {
     git autoconf automake gnum4 libtool perl pkgconfig gettext uthash
     python freetype zlib glib libungif libpng libjpeg libtiff libxml2
   ]
-    ++ lib.optionals withGTK [ gtk2 ];
+    ++ lib.optionals withGTK [ gtk2 ]
+    # I'm not sure why pango doesn't seem necessary on Linux
+    ++ lib.optionals stdenv.isDarwin [ pango ];
 
   configureFlags =
     lib.optionals (!withPython) [ "--disable-python-scripting" "--disable-python-extension" ]


### PR DESCRIPTION
With these changes, ImageMagick should compile on Darwin.
Requires #7112 and #7101
