### PR TITLE
nixpkgs: added old stable nodejs v0.10.38

### DIFF
--- a/pkgs/development/web/nodejs/v0_10.nix
+++ b/pkgs/development/web/nodejs/v0_10.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, openssl, python, zlib, v8, utillinux, http-parser, c-ares
+, pkgconfig, runCommand, which
+}:
+
+let
+  dtrace = runCommand "dtrace-native" {} ''
+    mkdir -p $out/bin
+    ln -sv /usr/sbin/dtrace $out/bin
+  '';
+
+  version = "0.10.38";
+
+  # !!! Should we also do shared libuv?
+  deps = {
+    inherit openssl zlib;
+
+    # disabled system v8 because v8 3.14 no longer receives security fixes
+    # we fall back to nodejs' internal v8 copy which receives backports for now
+    # inherit v8
+  } // (stdenv.lib.optionalAttrs (!stdenv.isDarwin) {
+    inherit http-parser;
+  })
+  // ({ cares = c-ares; });
+
+  sharedConfigureFlags = name: [
+    "--shared-${name}"
+    "--shared-${name}-includes=${builtins.getAttr name deps}/include"
+    "--shared-${name}-libpath=${builtins.getAttr name deps}/lib"
+  ];
+
+  inherit (stdenv.lib) concatMap optional optionals maintainers licenses platforms;
+in stdenv.mkDerivation {
+  name = "nodejs-${version}";
+
+  src = fetchurl {
+    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
+    sha256 = "12xpa9jzry5g0j41908498qqs8v0q6miqkv6mggyzas8bvnshgai";
+  };
+
+  configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps);
+
+  prePatch = ''
+    sed -e 's|^#!/usr/bin/env python$|#!${python}/bin/python|g' -i configure
+  '';
+
+  patches = if stdenv.isDarwin then [ ./no-xcode.patch ] else null;
+
+  postPatch = if stdenv.isDarwin then ''
+    (cd tools/gyp; patch -Np1 -i ${../../python-modules/gyp/no-darwin-cflags.patch})
+  '' else null;
+
+  buildInputs = [ python which ]
+    ++ (optional stdenv.isLinux utillinux)
+    ++ optionals stdenv.isDarwin [ pkgconfig openssl dtrace ];
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    description = "Event-driven I/O framework for the V8 JavaScript engine";
+    homepage = http://nodejs.org;
+    license = licenses.mit;
+    maintainers = [ maintainers.goibhniu maintainers.shlevy ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1805,6 +1805,7 @@ let
 
   nodejs = callPackage ../development/web/nodejs { libuv = libuvVersions.v1_2_0; };
   nodejs-unstable = callPackage ../development/web/nodejs { libuv = libuvVersions.v1_2_0; unstableVersion = true; };
+  nodejs-0_10 = callPackage ../development/web/nodejs/v0_10.nix { };
 
   nodePackages = callPackage ./node-packages.nix { self = nodePackages; };
 


### PR DESCRIPTION
There are some node packages with native addons that don't compile with node `v0.12.x`. Can we keep an old stable node version?
