### PR TITLE
Use libvpx-git on Darwin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6826,7 +6826,7 @@ let
 
   libviper = callPackage ../development/libraries/libviper { };
 
-  libvpx = callPackage ../development/libraries/libvpx { };
+  libvpx = if stdenv.isDarwin then libvpx-git else callPackage ../development/libraries/libvpx { };
   libvpx-git = callPackage ../development/libraries/libvpx/git.nix { };
 
   libvterm = callPackage ../development/libraries/libvterm { };


### PR DESCRIPTION
libvpx 1.3.0 is extremely challenging for us to compile on Darwin. I
think we would need to use clang 3.5 and patch the configure scripts
heavily. But libvpx-git works great, so lets just use that instead.
