### PR TITLE
rtmpdump: fix clang support

### DIFF
--- a/pkgs/tools/video/rtmpdump/default.nix
+++ b/pkgs/tools/video/rtmpdump/default.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
   makeFlags = [ ''prefix=$(out)'' ]
     ++ optional gnutlsSupport "CRYPTO=GNUTLS"
     ++ optional opensslSupport "CRYPTO=OPENSSL"
-    ++ optional stdenv.isDarwin "CC=clang SYS=darwin";
+    ++ optional stdenv.isDarwin "SYS=darwin"
+    ++ optional (stdenv.cc.cc.isClang or false) "CC=clang";
 
   buildInputs = [ zlib ]
     ++ optional gnutlsSupport gnutls


### PR DESCRIPTION
@spwhitt I add this correction so that it should work for the BSD's
