### PR TITLE
libvpx: refactor & 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -1,149 +1,148 @@
-{stdenv, fetchurl, bash, perl, yasm
-, vp8Support ? true # VP8
+{stdenv, fetchFromGitHub, perl, yasm
 , vp8DecoderSupport ? true # VP8 decoder
 , vp8EncoderSupport ? true # VP8 encoder
-, vp9Support ? true # VP9
 , vp9DecoderSupport ? true # VP9 decoder
 , vp9EncoderSupport ? true # VP9 encoder
 , extraWarningsSupport ? false # emit non-fatal warnings
 , werrorSupport ? false # treat warnings as errors (not available with all compilers)
-, installBinsSupport ? true # install binaries (vpxdec & vpxenc)
-, installLibsSupport ? true # install libraries
-, installSrcsSupport ? false # install sources
 , debugSupport ? false # debug mode
 , gprofSupport ? false # gprof profiling instrumentation
 , gcovSupport ? false # gcov coverage instrumentation
+, sizeLimitSupport ? true # limit max size to allow in the decoder
 , optimizationsSupport ? true # compiler optimization flags
 , runtimeCpuDetectSupport ? true # detect cpu capabilities at runtime
 , thumbSupport ? false # build arm assembly in thumb mode
-, libsSupport ? true # build librares
 , examplesSupport ? true # build examples (vpxdec & vpxenc are part of examples)
 , fastUnalignedSupport ? true # use unaligned accesses if supported by hardware
-, codecSrcsSupport ? false # codec library source code
 , debugLibsSupport ? false # include debug version of each library
-, md5Support ? true # support for output of checksum data
 , postprocSupport ? true # postprocessing
-, vp9PostprocSupport ? true # VP9 specific postprocessing
 , multithreadSupport ? true # multithreaded decoding & encoding
 , internalStatsSupport ? false # output of encoder internal stats for debug, if supported (encoders)
 , memTrackerSupport ? false # track memory usage
+, spatialResamplingSupport ? true # spatial sampling (scaling)
 , realtimeOnlySupport ? false # build for real-time encoding
 , ontheflyBitpackingSupport ? false # on-the-fly bitpacking in real-time encoding
 , errorConcealmentSupport ? false # decoder conceals losses
 , smallSupport ? false # favor smaller binary over speed
 , postprocVisualizerSupport ? false # macro block/block level visualizers
 , unitTestsSupport ? false, curl ? null, coreutils ? null # unit tests
+, webmIOSupport ? true # input from and output to webm container
+, libyuvSupport ? true # libyuv
+, decodePerfTestsSupport ? false # build decoder perf tests with unit tests
+, encodePerfTestsSupport ? false # build encoder perf tests with unit tests
 , multiResEncodingSupport ? false # multiple-resolution encoding
 , temporalDenoisingSupport ? true # use temporal denoising instead of spatial denoising
-, decryptSupport ? false
+, coefficientRangeCheckingSupport ? false # decoder checks if intermediate transform coefficients are in valid range
+, vp9HighbitdepthSupport ? true # 10/12 bit color support in VP9
 , experimentalSupport ? false # experimental features
 # Experimental features
-, experimentalMultipleArfSupport ? false
-, experimentalNon420Support ? false
-, experimentalAlphaSupport ? false
+, experimentalSpatialSvcSupport ? false # Spatial scalable video coding
+, experimentalFpMbStatsSupport ? false
+, experimentalEmulateHardwareSupport ? false
 }:
 
-assert (vp8Support || vp9Support);
-assert (vp8DecoderSupport || vp8EncoderSupport || vp9DecoderSupport || vp9EncoderSupport);
-assert vp8DecoderSupport -> vp8Support;
-assert vp8EncoderSupport -> vp8Support;
-assert vp9DecoderSupport -> vp9Support;
-assert vp9EncoderSupport -> vp9Support;
-assert installLibsSupport -> libsSupport;
-# libvpx will not build binaries if examplesSupport is not enabled (ie. vpxdec & vpxenc)
-assert installBinsSupport -> examplesSupport;
-assert examplesSupport -> md5Support;
-assert vp9PostprocSupport -> (vp9Support && postprocSupport);
-assert (internalStatsSupport && vp9Support) -> vp9PostprocSupport;
-assert postprocVisualizerSupport -> postprocSupport;
-assert (postprocVisualizerSupport && vp9Support) -> vp9PostprocSupport;
-assert unitTestsSupport -> ((curl != null) && (coreutils != null));
-assert (experimentalMultipleArfSupport || experimentalNon420Support || experimentalAlphaSupport) -> experimentalSupport;
-assert stdenv.isCygwin -> unitTestsSupport;
-
 let
-  mkFlag = optSet: flag: if optSet then "--enable-${flag}" else "--disable-${flag}";
+  inherit (stdenv) isi686 isx86_64 isArm is64bit isMips isDarwin isCygwin;
+  inherit (stdenv.lib) enableFeature optional optionals;
 in
 
-with stdenv.lib;
+assert isi686 || isx86_64 || isArm || isMips; # Requires ARM with floating point support
+
+assert vp8DecoderSupport || vp8EncoderSupport || vp9DecoderSupport || vp9EncoderSupport;
+assert internalStatsSupport && (vp9DecoderSupport || vp9EncoderSupport) -> postprocSupport;
+/* If spatialResamplingSupport not enabled, build will fail with undeclared variable errors.
+   Variables called in vpx_scale/generic/vpx_scale.c are declared by vpx_scale/vpx_scale_rtcd.pl,
+   but is only executed if spatialResamplingSupport is enabled */
+assert spatialResamplingSupport;
+assert postprocVisualizerSupport -> postprocSupport;
+assert unitTestsSupport -> curl != null && coreutils != null;
+assert vp9HighbitdepthSupport -> (vp9DecoderSupport || vp9EncoderSupport);
+assert isCygwin -> unitTestsSupport && webmIOSupport && libyuvSupport;
+
 stdenv.mkDerivation rec {
   name = "libvpx-${version}";
-  version = "1.3.0";
+  version = "1.4.0";
 
-  src = fetchurl {
-    url = "http://webm.googlecode.com/files/libvpx-v${version}.tar.bz2";
-    sha1 = "191b95817aede8c136cc3f3745fb1b8c50e6d5dc";
+  src = fetchFromGitHub {
+    owner = "webmproject";
+    repo = "libvpx";
+    rev = "v${version}";
+    sha256 = "1y8cf2q5ij8z8ab5j36m18rbs62aah6sw6shzbs3jr70ja0z6n8s";
   };
 
-  patchPhase = ''
-    patchShebangs .
-  '';
-
-  nativeBuildInputs = [ bash perl yasm ];
-
-  buildInputs = [ ]
-    ++ optional unitTestsSupport coreutils
-    ++ optional unitTestsSupport curl;
+  patchPhase = ''patchShebangs .'';
 
   configureFlags = [
-    (mkFlag vp8Support "vp8")
-    (mkFlag vp8EncoderSupport "vp8-encoder")
-    (mkFlag vp8DecoderSupport "vp8-decoder")
-    (mkFlag vp9Support "vp9")
-    (mkFlag vp9EncoderSupport "vp9-encoder")
-    (mkFlag vp9DecoderSupport "vp9-decoder")
-    (mkFlag extraWarningsSupport "extra-warnings")
-    (mkFlag werrorSupport "werror")
+    (enableFeature (vp8EncoderSupport || vp8DecoderSupport) "vp8")
+    (enableFeature vp8EncoderSupport "vp8-encoder")
+    (enableFeature vp8DecoderSupport "vp8-decoder")
+    (enableFeature (vp9EncoderSupport || vp9DecoderSupport) "vp9")
+    (enableFeature vp9EncoderSupport "vp9-encoder")
+    (enableFeature vp9DecoderSupport "vp9-decoder")
+    (enableFeature extraWarningsSupport "extra-warnings")
+    (enableFeature werrorSupport "werror")
     "--disable-install-docs"
-    (mkFlag installBinsSupport "install-bins")
-    (mkFlag installLibsSupport "install-libs")
-    (mkFlag installSrcsSupport "install-srcs")
-    (mkFlag debugSupport "debug")
-    (mkFlag gprofSupport "gprof")
-    (mkFlag gcovSupport "gcov")
+    (enableFeature examplesSupport "install-bins")
+    "--enable-install-libs"
+    "--disable-install-srcs"
+    (enableFeature debugSupport "debug")
+    (enableFeature gprofSupport "gprof")
+    (enableFeature gcovSupport "gcov")
     # Required to build shared libraries
-    (mkFlag (!stdenv.isDarwin && !stdenv.isCygwin) "pic")
-    (mkFlag (stdenv.isx86_64 || !stdenv.isDarwin || stdenv.isCygwin) "use-x86inc")
-    (mkFlag optimizationsSupport "optimizations")
-    (mkFlag runtimeCpuDetectSupport "runtime-cpu-detect")
-    (mkFlag thumbSupport "thumb")
-    (mkFlag libsSupport "libs")
-    (mkFlag examplesSupport "examples")
+    (enableFeature (!isCygwin) "pic")
+    (enableFeature (isi686 || isx86_64) "use-x86inc")
+    (enableFeature optimizationsSupport "optimizations")
+    (enableFeature runtimeCpuDetectSupport "runtime-cpu-detect")
+    (enableFeature thumbSupport "thumb")
+    "--enable-libs"
+    (enableFeature examplesSupport "examples")
     "--disable-docs"
     "--as=yasm"
-    (mkFlag fastUnalignedSupport "fast-unaligned")
-    (mkFlag codecSrcsSupport "codec-srcs")
-    (mkFlag debugLibsSupport "debug-libs")
-    (mkFlag md5Support "md5")
-    (mkFlag stdenv.isMips "dequant-tokens")
-    (mkFlag stdenv.isMips "dc-recon")
-    (mkFlag postprocSupport "postproc")
-    (mkFlag vp9PostprocSupport "vp9-postproc")
-    (mkFlag multithreadSupport "multithread")
-    (mkFlag internalStatsSupport "internal-stats")
-    (mkFlag memTrackerSupport "mem-tracker")
-    /* If --enable-spatial-resampling not enabled, build will fail with undeclared variable errors.
-       Variables called in vpx_scale/generic/vpx_scale.c are declared by vpx_scale/vpx_scale_rtcd.pl,
-       but is only executed if --enable-spatial-resampling is enabled */
-    "--enable-spatial-resampling"
-    (mkFlag realtimeOnlySupport "realtime-only")
-    (mkFlag ontheflyBitpackingSupport "onthefly-bitpacking")
-    (mkFlag errorConcealmentSupport "error-concealment")
+    # Limit default decoder max to WHXGA
+    (if sizeLimitSupport then "--size-limit=5120x3200" else null)
+    (enableFeature fastUnalignedSupport "fast-unaligned")
+    "--disable-codec-srcs"
+    (enableFeature debugLibsSupport "debug-libs")
+    (enableFeature isMips "dequant-tokens")
+    (enableFeature isMips "dc-recon")
+    (enableFeature postprocSupport "postproc")
+    (enableFeature (postprocSupport && (vp9DecoderSupport || vp9EncoderSupport)) "vp9-postproc")
+    (enableFeature multithreadSupport "multithread")
+    (enableFeature internalStatsSupport "internal-stats")
+    (enableFeature memTrackerSupport "mem-tracker")
+    (enableFeature spatialResamplingSupport "spatial-resampling")
+    (enableFeature realtimeOnlySupport "realtime-only")
+    (enableFeature ontheflyBitpackingSupport "onthefly-bitpacking")
+    (enableFeature errorConcealmentSupport "error-concealment")
     # Shared libraries are only supported on ELF platforms
-    (mkFlag (stdenv.isDarwin || stdenv.isCygwin) "static")
-    (mkFlag (!stdenv.isDarwin && !stdenv.isCygwin) "shared")
-    (mkFlag smallSupport "small")
-    (mkFlag postprocVisualizerSupport "postproc-visualizer")
-    (mkFlag unitTestsSupport "unit-tests")
-    (mkFlag multiResEncodingSupport "multi-res-encoding")
-    (mkFlag temporalDenoisingSupport "temporal-denoising")
-    (mkFlag decryptSupport "decrypt")
-    (mkFlag experimentalSupport "experimental")
+    (if isDarwin || isCygwin then
+       "--enable-static --disable-shared"
+     else
+       "--disable-static --enable-shared")
+    (enableFeature smallSupport "small")
+    (enableFeature postprocVisualizerSupport "postproc-visualizer")
+    (enableFeature unitTestsSupport "unit-tests")
+    (enableFeature webmIOSupport "webm-io")
+    (enableFeature libyuvSupport "libyuv")
+    (enableFeature decodePerfTestsSupport "decode-perf-tests")
+    (enableFeature encodePerfTestsSupport "encode-perf-tests")
+    (enableFeature multiResEncodingSupport "multi-res-encoding")
+    (enableFeature temporalDenoisingSupport "temporal-denoising")
+    (enableFeature (temporalDenoisingSupport && (vp9DecoderSupport || vp9EncoderSupport)) "vp9-temporal-denoising")
+    (enableFeature coefficientRangeCheckingSupport "coefficient-range-checking")
+    (enableFeature (vp9HighbitdepthSupport && is64bit) "vp9-highbitdepth")
+    (enableFeature (experimentalSpatialSvcSupport ||
+                    experimentalFpMbStatsSupport ||
+                    experimentalEmulateHardwareSupport) "experimental")
     # Experimental features
-    (mkFlag experimentalMultipleArfSupport "multiple-arf")
-    (mkFlag experimentalNon420Support "non420")
-    (mkFlag experimentalAlphaSupport "alpha")
-  ];
+  ] ++ optional experimentalSpatialSvcSupport "--enable-spatial-svc"
+    ++ optional experimentalFpMbStatsSupport "--enable-fp-mb-stats"
+    ++ optional experimentalEmulateHardwareSupport "--enable-emulate-hardware";
+
+  nativeBuildInputs = [ perl yasm ];
+
+  buildInputs = [ ]
+    ++ optionals unitTestsSupport [ coreutils curl ];
 
   enableParallelBuilding = true;
 
@@ -163,7 +162,8 @@ stdenv.mkDerivation rec {
       # Darwin versions: 10.4=8, 10.5=9, 10.6=10, 10.7=11, 10.8=12, 10.9=13, 10.10=14
       "--force-target=${stdenv.cross.config}${(
               if isDarwin then (
-                if stdenv.cross.osxMinVersion == "10.9"  then "13"
+                if      stdenv.cross.osxMinVersion == "10.10" then "14"
+                else if stdenv.cross.osxMinVersion == "10.9"  then "13"
                 else if stdenv.cross.osxMinVersion == "10.8"  then "12"
                 else if stdenv.cross.osxMinVersion == "10.7"  then "11"
                 else if stdenv.cross.osxMinVersion == "10.6"  then "10"
@@ -174,11 +174,11 @@ stdenv.mkDerivation rec {
     ];
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "WebM VP8/VP9 codec SDK";
     homepage    = http://www.webmproject.org/;
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ codyopel lovek323 ];
+    maintainers = with maintainers; [ codyopel ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6826,7 +6826,7 @@ let
 
   libviper = callPackage ../development/libraries/libviper { };
 
-  libvpx = if stdenv.isDarwin then libvpx-git else callPackage ../development/libraries/libvpx { };
+  libvpx = callPackage ../development/libraries/libvpx { };
   libvpx-git = callPackage ../development/libraries/libvpx/git.nix { };
 
   libvterm = callPackage ../development/libraries/libvterm { };


### PR DESCRIPTION
~~Fixed compilation using clang 3.5+
Fixed building on Darwin
Removed unnecessary optionals simplifying the build~~

@spwhitt @gridaphobe 
~~This should resolve compilation using clang 3.5+ for 1.3.0, and hopefully fixes the build on Darwin.  I also refactored the build to simplify everything as much as possible in case more fixes are needed.~~
