### PR TITLE
haskell: fix taffybar on GHC 7.10

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -137,6 +137,8 @@ self: super: {
   # Cabal_1_22_1_1 requires filepath >=1 && <1.4
   cabal-install = dontCheck (super.cabal-install.override { Cabal = null; });
 
+  HStringTemplate = self.HStringTemplate_0_8_3;
+
   # We have Cabal 1.22.x.
   jailbreak-cabal = super.jailbreak-cabal.override { Cabal = null; };
 


### PR DESCRIPTION
This:
- Updates the versions for the gtk2hs subprojects
- Use HStringTemplate-0.8.3 on GHC 7.10
- ~~Fixes taffybar~~ (the fix landed in 0.4.5, so I'll just wait for hackage-packages.nix to be updated)
