### PR TITLE
pandoc: fix on GHC 7.10

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -33,6 +33,107 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  # should be fixed in versions > 0.6
+  pandoc-citeproc = overrideCabal super.pandoc-citeproc (drv: {
+    patches = [
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/4e4f9c2.patch";
+         sha256 = "18b08k56g5q4zz6jxczkrddblyn52vmd0811n1icfdpzqhgykn4p";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/34cc147.patch";
+         sha256 = "09vrdvg5w14qckn154zlxvk6i2ikmmhpsl9mxycxkql3rl4dqam3";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/8242c70.patch";
+         sha256 = "1lqpwxzz2www81w4mym75z36bsavqfj67hyvzn20ffvxq42yw7ry";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/e59f88d.patch";
+         sha256 = "05699hj3qa2vrfdnikj7rzmc2ajrkd7p8yd4cjlhmqq9asq90xzb";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/ae6ca86.patch";
+         sha256 = "19cag39k5s7iqagpvss9c2ny5g0lwnrawaqcc0labihc1a181k8l";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/f5a9fc7.patch";
+         sha256 = "08lsinh3mkjpz3cqj5i1vcnzkyl07jp38qcjcwcw7m2b7gsjbpvm";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc-citeproc/commit/780a554.patch";
+         sha256 = "1kfn0mcp3vp32c9w8gyz0p0jv0xn90as9mxm8a2lmjng52jlzvy4";
+      })
+   ];
+  });
+
+  # should be fixed in versions > 1.13.2
+  pandoc = overrideCabal super.pandoc (drv: {
+    patches = [
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/693f9ab.patch";
+         sha256 = "1niyrigs47ia1bhk6yrnzf0sq7hz5b7xisc8ph42wkp5sl8x9h1y";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/9c68017.patch";
+         sha256 = "0zccb6l5vmfyq7p8ii88fgggfhrff32hj43f5pp3w88l479f1qlh";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/dbe1b38.patch";
+         sha256 = "0d80692liyjx2y56w07k23adjcxb57w6vzcylmc4cfswzy8agrgy";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/5ea3856.patch";
+         sha256 = "1z15lc0ix9fv278v1xmfw3a6gl85ydahgs8kz61sfvh4jdiacabw";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/c80c9ac.patch";
+         sha256 = "0fk3j53zx0x88jmh0ism0aghs2w5qf87zcp9cwbfcgg5izh3b344";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/8b9bded.patch";
+         sha256 = "0f1dh1jmhq55mlv4dawvx3ck330y82qmys06bfkqcpl0jsyd9x1a";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/e4c7894.patch";
+         sha256 = "1rfdaq6swrl3m9bmbf6yhqq57kv3l3f4927xya3zq29dpvkmmi4z";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/2a6f68f.patch";
+         sha256 = "0sbh2x9jqvis9ln8r2dr6ihkjdn480mjskm4ny91870vg852228c";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/4e3281c.patch";
+         sha256 = "0zafhxxijli2mf1h0j7shp7kd7fxqbvlswm1m8ikax3aknvjxymi";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/cd5b1fe.patch";
+         sha256 = "0nxq7c0gpdiycgdrcj3llbfwxdni6k7hqqniwsbn2ha3h03i8hg1";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/ed7606d.patch";
+         sha256 = "0gchm46ziyj7vw6ibn3kk49cjzsc78z2lm8k7892g79q2livlc1f";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/b748833.patch";
+         sha256 = "03gj4qn9c5zyqrxyrw4xh21xlvbx9rbvw6gh8msgf5xk53ibs68b";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/10d5398.patch";
+         sha256 = "1nhp5b07vywk917bfap6pzahhqnwvvlbbfg5336a2nvb0c8iq6ih";
+      })
+      (pkgs.fetchpatch {
+         url = "https://github.com/jgm/pandoc/commit/f18ceb1.patch";
+         sha256 = "1vxsy5fn4nscvim9wcx1n78q7yh05x0z8p812csi3v3z79lbabhq";
+      })
+    ];
+    # jailbreak-cabal omits part of the file
+    # https://github.com/peti/jailbreak-cabal/issues/9
+    postPatch = ''
+      sed -i '420i\ \ \ \ \ \ \ \ \ \ \ \ buildable: False' pandoc.cabal
+    '';
+  });
+
   # Cabal_1_22_1_1 requires filepath >=1 && <1.4
   cabal-install = dontCheck (super.cabal-install.override { Cabal = null; });
 


### PR DESCRIPTION
This fixes Pandoc on GHC 7.10. These patches should no longer be necessary when these versions are released:
- pandoc-citeproc > 0.6
- pandoc > 1.13.2
