### PR TITLE
hakyll: fix on GHC 7.10

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -134,6 +134,17 @@ self: super: {
     '';
   });
 
+  # see: https://github.com/jaspervdj/hakyll/issues/343
+  hakyll = overrideCabal super.hakyll (drv: {
+    buildDepends = drv.buildDepends ++ [ self.time-locale-compat ];
+    patches = [
+      (pkgs.fetchpatch {
+         url = "https://github.com/jaspervdj/hakyll/pull/344.patch";
+         sha256 = "130c0icw3cj209p219siaq0n8avmm0fpmph0iyjgx67w62sffrli";
+      })
+    ];
+  });
+
   # Cabal_1_22_1_1 requires filepath >=1 && <1.4
   cabal-install = dontCheck (super.cabal-install.override { Cabal = null; });
 


### PR DESCRIPTION
This fixes Hakyll on GHC 7.10. I've sent a PR upstream. For detauls, see:
- https://github.com/jaspervdj/hakyll/pull/344
- https://github.com/jaspervdj/hakyll/issues/343

This depends on the fixes to Pandoc in https://github.com/NixOS/nixpkgs/pull/7168
