### PR TITLE
django: add a django_gis variant which patches django to properly point ...

### DIFF
--- a/pkgs/development/python-modules/django/1.7.7-gis-libs.template.patch
+++ b/pkgs/development/python-modules/django/1.7.7-gis-libs.template.patch
@@ -1,0 +1,24 @@
+diff --git a/django/contrib/gis/gdal/libgdal.py b/django/contrib/gis/gdal/libgdal.py
+--- a/django/contrib/gis/gdal/libgdal.py
++++ b/django/contrib/gis/gdal/libgdal.py
+@@ -17,7 +17,7 @@ try:
+     lib_path = settings.GDAL_LIBRARY_PATH
+ except (AttributeError, EnvironmentError,
+         ImportError, ImproperlyConfigured):
+-    lib_path = None
++    lib_path = "@gdal@/lib/libgdal.so"
+ 
+ if lib_path:
+     lib_names = None
+diff --git a/django/contrib/gis/geos/libgeos.py b/django/contrib/gis/geos/libgeos.py
+--- a/django/contrib/gis/geos/libgeos.py
++++ b/django/contrib/gis/geos/libgeos.py
+@@ -23,7 +23,7 @@ try:
+     lib_path = settings.GEOS_LIBRARY_PATH
+ except (AttributeError, EnvironmentError,
+         ImportError, ImproperlyConfigured):
+-    lib_path = None
++    lib_path = "@geos@/lib/libgeos_c.so"
+ 
+ # Setting the appropriate names for the GEOS-C library.
+ if lib_path:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6226,6 +6226,16 @@ in modules // {
 
   django = self.django_1_7;
 
+  django_gis = self.django.override rec {
+    patches = [
+      (pkgs.substituteAll {
+        src = ../development/python-modules/django/1.7.7-gis-libs.template.patch;
+        geos = pkgs.geos;
+        gdal = pkgs.gdal;
+      })
+    ];
+  };
+
   django_1_8 = buildPythonPackage rec {
     name = "Django-${version}";
     version = "1.8.4";


### PR DESCRIPTION
...at its gis libs but therefore also has them as dependencies (gdal for one can be quite big)

I'm unsure as to whether this is the best way to expose this as a package, so I'm open to ideas, but this works for me.
