### PR TITLE
v4l-util: refactor & 1.0.0 -> 1.6.2 (libv4l)

### DIFF
--- a/pkgs/os-specific/linux/v4l-utils/default.nix
+++ b/pkgs/os-specific/linux/v4l-utils/default.nix
@@ -1,26 +1,55 @@
-{stdenv, fetchurl, which, libjpeg
-, withQt4 ? false, qt4 ? null}:
+{ stdenv, fetchurl, pkgconfig
+, libjpeg
+, alsaLib ? null
+, libX11 ? null
+, qt4 ? null # The default is set to qt4 in all-packages.nix
+, qt5 ? null
+}:
 
-assert withQt4 -> qt4 != null;
+# See libv4l in all-packages.nix for the libs only (overrides alsa, libX11 & QT)
+
+assert qt4 != null -> qt5 == null;
+assert qt5 != null -> qt4 == null;
+
+let
+  inherit (stdenv.lib) optional;
+in
 
 stdenv.mkDerivation rec {
-  name = "v4l-utils-1.0.0";
+  name = "v4l-utils-1.6.2";
 
   src = fetchurl {
     url = "http://linuxtv.org/downloads/v4l-utils/${name}.tar.bz2";
-    sha256 = "0c2z500ijxr1ldzb4snasfpwi2icp04f8pk7akiqjkp0k4h8iqqx";
+    sha256 = "0zdyjrja2mkqlijpdb4gz1vw0g7pslswmgqqsgri3yq408gypmnk";
   };
 
-  buildInputs = [ which ];
-  propagatedBuildInputs = [ libjpeg ] ++ stdenv.lib.optional withQt4 qt4;
+  configureFlags = [
+    "--enable-libv4l"
+  ] ++ (if (alsaLib != null && libX11 != null && (qt4 != null || qt5 != null)) then [
+    "--with-udevdir=\${out}/lib/udev"
+    "--enable-v4l-utils"
+    "--enable-qv4l2"
+  ] else [
+    "--without-libudev"
+    "--without-udevdir"
+    "--disable-v4l-utils"
+    "--disable-qv4l2"
+  ]);
 
-  preConfigure = ''configureFlags="--with-udevdir=$out/lib/udev"'';
+  postInstall = ''
+    # Create symlink for V4l1 compatibility
+    ln -s $out/include/libv4l1-videodev.h $out/include/videodev.h
+  '';
 
-  meta = {
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ alsaLib libjpeg libX11 qt4 qt5 ];
+
+  meta = with stdenv.lib; {
+    description = "V4L utils and libv4l, provide common image formats regardless of the v4l device";
     homepage = http://linuxtv.org/projects.php;
-    description = "V4L utils and libv4l, that provides common image formats regardless of the v4l device";
-    license = stdenv.lib.licenses.free; # The libs are of LGPLv2.1+, some other pieces are GPL.
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ codyopel viric ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6821,7 +6821,10 @@ let
   });
 
   libv4l = lowPrio (v4l_utils.override {
-    withQt4 = false;
+    alsaLib = null;
+    libX11 = null;
+    qt4 = null;
+    qt5 = null;
   });
 
   libva = callPackage ../development/libraries/libva { };
@@ -9548,7 +9551,7 @@ let
   });
 
   v4l_utils = callPackage ../os-specific/linux/v4l-utils {
-    withQt4 = true;
+    qt5 = null;
   };
 
   windows = rec {


### PR DESCRIPTION
- added missing dependencies (alsa, libX11 & qt5)
- added fixes to make sure unnecessary features are disabled for libv4l
