### PR TITLE
nilfs-utils: package hash changed

### DIFF
--- a/pkgs/tools/filesystems/nilfs-utils/default.nix
+++ b/pkgs/tools/filesystems/nilfs-utils/default.nix
@@ -3,7 +3,7 @@ let
   sourceInfo = rec {
     version = "2.2.3";
     url = "http://nilfs.sourceforge.net/download/nilfs-utils-${version}.tar.bz2";
-    sha256 = "17s7d2rdb6fwrfvpif573c8n0i4f21m09pzqdsc0kyy1qqdgnc1v";
+    sha256 = "1sv0p5d9ivik7lhrdynf6brma66llcvn11zhzasws12n4sfk6k6q";
     baseName = "nilfs-utils";
     name = "${baseName}-${version}";
   };


### PR DESCRIPTION
probably related to: https://github.com/nilfs-dev/nilfs-utils/commit/10528d9d21579eb68dc671b408c9a4c7380a329d
