### PR TITLE
keybase-node: fix imports, reenable build

### DIFF
--- a/pkgs/applications/misc/keybase-node-client/default.nix
+++ b/pkgs/applications/misc/keybase-node-client/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 let 
-  nodePackages = callPackage (import <nixpkgs/pkgs/top-level/node-packages.nix>) {
+  nodePackages = callPackage (import ../../../top-level/node-packages.nix) {
     neededNatives = [] ++ optional (stdenv.isLinux) utillinux;
     self = nodePackages;
     generated = ./package.nix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1752,7 +1752,7 @@ let
 
   kexectools = callPackage ../os-specific/linux/kexectools { };
 
-  #keybase-node-client = callPackage ../applications/misc/keybase-node-client { };
+  keybase-node-client = callPackage ../applications/misc/keybase-node-client { };
 
   keychain = callPackage ../tools/misc/keychain { };
 


### PR DESCRIPTION
Fix keybase imports as requested in 0e2257966f030799334a8df5cdf94977c3513c28
