### PR TITLE
Check if /proc/sys/kernel/hotplug exists before writing

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -237,7 +237,10 @@ in
 
     system.activationScripts.udevd =
       ''
-        echo "" > /proc/sys/kernel/hotplug
+        # The deprecated hotplug uevent helper is not used anymore
+        if [ -e /proc/sys/kernel/hotplug ]; then
+          echo "" > /proc/sys/kernel/hotplug
+        fi
 
         # Regenerate the hardware database /var/lib/udev/hwdb.bin
         # whenever systemd changes.


### PR DESCRIPTION
If a kernel without `CONFIG_UEVENT_HELPER` set is used with NixOS, the file `/proc/sys/kernel/hotplug` does not exist. Before writing to it to disable this deprecated mechanism, we have to ensure it actually exists because otherwise the activation script will fail.
