### PR TITLE
Move jailbreak-cabal to postPatch

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -137,10 +137,12 @@ stdenv.mkDerivation ({
   prePatch = optionalString (editedCabalFile != null) ''
     echo "Replace Cabal file with edited version from ${newCabalFileUrl}."
     cp ${newCabalFile} ${pname}.cabal
-  '' + optionalString jailbreak ''
+  '' + prePatch;
+
+  postPatch = optionalString jailbreak ''
     echo "Run jailbreak-cabal to lift version restrictions on build inputs."
     ${jailbreak-cabal}/bin/jailbreak-cabal ${pname}.cabal
-  '' + prePatch;
+  '' + postPatch;
 
   setupCompilerEnvironmentPhase = ''
     runHook preSetupCompilerEnvironment


### PR DESCRIPTION
This allows us to apply patches which modify stock .cabal file before it's regenerated by jailbreak-cabal. It also appears more logical to me. Warning -- this would cause mass rebuild of Haskell packages! Also needed for #7172.
