### PR TITLE
slic3r: update 1.2.1 -> 1.2.6

### DIFF
--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -3,17 +3,17 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.1";
+  version = "1.2.6";
   name = "slic3r-${version}";
 
   src = fetchgit {
     url = "git://github.com/alexrj/Slic3r";
     rev = "refs/tags/${version}";
-    sha256 = "03xj2kv2d4j6nwmdd5cyghnvjyj4g7g9z0ynynbviyfiplmka2ph";
+    sha256 = "1ymk2n9dw1mpizwg6bxbzq60mg1cwljxlncaasdyakqrkkr22r8k";
   };
 
   buildInputs = with perlPackages; [ perl makeWrapper which
-    EncodeLocale MathClipper ExtUtilsXSpp
+    EncodeLocale MathClipper ExtUtilsXSpp threads
     MathConvexHullMonotoneChain MathGeometryVoronoi MathPlanePath Moo
     IOStringy ClassXSAccessor Wx GrowlGNTP NetDBus ImportInto XMLSAX
     ExtUtilsMakeMaker OpenGL WxGLCanvas

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10042,6 +10042,18 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  threads = buildPerlPackage {
+    name = "threads-2.01";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/J/JD/JDHEDDEN/threads-2.01.tar.gz;
+      sha256 = "429fea88757e0a347dac2cf9e414dfe8f06c8ca3c5445f6da4a95c2f883b6399";
+    };
+    meta = {
+      description = "Perl interpreter-based threads";
+      license = "perl";
+    };
+  };
+
   Throwable = buildPerlPackage rec {
     name = "Throwable-0.200010";
     src = fetchurl {


### PR DESCRIPTION
Release notes: http://slic3r.org/releases/1.2.6

Slic3r needs additional dependency, 'threads'. Add it.

In addition to bug fixes and some new features, this update stops Slic3r
from printing this on startup:

  `Running Slic3r under Perl >= 5.16 is not supported nor recommended`

We don't have perl < 5.16 anymore, so we better update slic3r.

I guess this should be cherry-picked to release-14.12 too?

CC @the-kenny
