### PR TITLE
vim-plugins: update youcompleteme to build with latest llvmPackages

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -544,15 +544,18 @@ rec {
     };
   };
 
-  YouCompleteMe = buildVimPlugin { 
+  YouCompleteMe = buildVimPlugin {
     src = fetchgit {
-      rev = "56dc60ddc88d075902a5f13f10446923b009ad2f";
-      url = "https://github.com/Valloric/YouCompleteMe.git";
-      sha256 = "1i4qv2g9vhd8999iv7ly0pxyp9l99dzq3rjf4snkb8rpcrimgbkj";
+      rev = "2f8109020644ad28e5cd795c29bc1150f87b3cb4";
+      url = "https://github.com/Valloric/YouCompleteMe";
+      sha256 = "15d3dhxan602qxz2wixjf4pjrf210qwa51ckzyjyh5kqak9lx8pi";
      };
-    name = "youcompleteme-2015-03-25";
+    name = "youcompleteme-2015-03-27";
 
-    buildInputs = [ python cmake llvmPackages.clang ];
+    buildInputs = [
+      python cmake
+      llvmPackages.clang-unwrapped llvmPackages.llvm
+    ];
 
     configurePhase = ":";
 


### PR DESCRIPTION
let me know if there's a better way to migrate for the changes to llvmPackages.clang. it seemed like pulling in llvmPackages.clang-unwrapped would pull in the least dependencies so i used that
