### PR TITLE
guitarix: refactor

### DIFF
--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -1,6 +1,12 @@
-{ stdenv, fetchurl, avahi, boost, eigen, fftw, gettext, glib, glibmm, gtk
-, gtkmm, intltool, jack2, ladspaH, librdf, libsndfile, lilv, lv2
-, pkgconfig, python, serd, sord, sratom }:
+{ stdenv, fetchurl, gettext, intltool, pkgconfig, python
+, avahi, bluez, boost, eigen, fftw, glib, glibmm, gtk, gtkmm, jack2
+, ladspaH, librdf, libsndfile, lilv, lv2, serd, sord, sratom
+, optimizationSupport ? false # Enable support for native CPU extensions
+}:
+
+let
+  inherit (stdenv.lib) optional;
+in
 
 stdenv.mkDerivation rec {
   name = "guitarix-${version}";
@@ -11,16 +17,27 @@ stdenv.mkDerivation rec {
     sha256 = "1ybc5jk7fj6n8qh9ajzl1f6fzdmzab4nwjrh4fsylm94dn1jv0if";
   };
 
+  nativeBuildInputs = [ gettext intltool pkgconfig python ];
+
   buildInputs = [
-    avahi boost eigen fftw gettext glib glibmm gtk gtkmm intltool
-    jack2 ladspaH librdf libsndfile lilv lv2 pkgconfig python serd sord sratom
+    avahi bluez boost eigen fftw glib glibmm gtk gtkmm jack2
+    ladspaH librdf libsndfile lilv lv2 serd sord sratom
   ];
 
-  configurePhase = "python waf configure --prefix=$out";
+  configureFlags = [
+    "--shared-lib"
+    "--no-desktop-update"
+    "--no-faust" # Need to package a release of faust, 0.9.58 or 0.9.65
+    "--enable-nls"
+    "--includeresampler" # Zita-resampler not packaged, use vendored version
+    "--includeconvolver" # Zita-convolver not packaged, use vendored version
+  ] ++ optional optimizationSupport "--optimization";
 
-  buildPhase = "python waf build";
+  configurePhase = ''python waf configure --prefix=$out $configureFlags'';
 
-  installPhase = "python waf install";
+  buildPhase = ''python waf build'';
+
+  installPhase = ''python waf install'';
 
   meta = with stdenv.lib; { 
     description = "A virtual guitar amplifier for Linux running with JACK";


### PR DESCRIPTION
add bluez (bluetooth support)

@astsmtl @cillianderoiste
I also added configure flags so it won't return warnings for faust or zita resampler/convolver and added a flag for native language support.

Faust is a mess and needs to be cleaned up on Nix before support can be added.  It currently for some reason is using a git version instead of a stable release.
