### PR TITLE
Wine: add several dependencies

### DIFF
--- a/pkgs/misc/emulators/wine/stable.nix
+++ b/pkgs/misc/emulators/wine/stable.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, xlibs, flex, bison, mesa, mesa_noglu, alsaLib
 , ncurses, libpng, libjpeg, lcms2, freetype, fontconfig, gettext, fontforge
-, libxml2, libxslt, openssl, gnutls, cups, libdrm, makeWrapper
+, libxml2, libxslt, openssl, gnutls, cups, libdrm, mpg123, makeWrapper
 }:
 
 assert stdenv.isLinux;
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
     xlibs.libXcursor xlibs.libXinerama xlibs.libXrandr
     xlibs.libXrender xlibs.libXxf86vm xlibs.libXcomposite
     alsaLib ncurses libpng libjpeg lcms2 gettext fontforge
-    libxml2 libxslt openssl gnutls cups makeWrapper
+    libxml2 libxslt openssl gnutls cups mpg123 makeWrapper
   ];
 
   # Wine locates a lot of libraries dynamically through dlopen().  Add

--- a/pkgs/misc/emulators/wine/stable.nix
+++ b/pkgs/misc/emulators/wine/stable.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, xlibs, flex, bison, mesa, mesa_noglu, alsaLib
-, ncurses, libpng, libjpeg, lcms2, freetype, fontconfig, fontforge
+, ncurses, libpng, libjpeg, lcms2, freetype, fontconfig, gettext, fontforge
 , libxml2, libxslt, openssl, gnutls, cups, libdrm, makeWrapper
 }:
 
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     xlibs.xlibs flex bison xlibs.libXi mesa mesa_noglu.osmesa
     xlibs.libXcursor xlibs.libXinerama xlibs.libXrandr
     xlibs.libXrender xlibs.libXxf86vm xlibs.libXcomposite
-    alsaLib ncurses libpng libjpeg lcms2 fontforge
+    alsaLib ncurses libpng libjpeg lcms2 gettext fontforge
     libxml2 libxslt openssl gnutls cups makeWrapper
   ];
 

--- a/pkgs/misc/emulators/wine/unstable.nix
+++ b/pkgs/misc/emulators/wine/unstable.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, xlibs, flex, bison, mesa, mesa_noglu, alsaLib
 , ncurses, libpng, libjpeg, lcms, freetype, fontconfig, gettext, fontforge
-, libxml2, libxslt, openssl, gnutls, cups, libdrm, makeWrapper
+, libxml2, libxslt, openssl, gnutls, cups, libdrm, mpg123, makeWrapper
 }:
 
 assert stdenv.isLinux;
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
     xlibs.libXcursor xlibs.libXinerama xlibs.libXrandr
     xlibs.libXrender xlibs.libXxf86vm xlibs.libXcomposite
     alsaLib ncurses libpng libjpeg lcms gettext fontforge
-    libxml2 libxslt openssl gnutls cups makeWrapper
+    libxml2 libxslt openssl gnutls cups mpg123 makeWrapper
   ];
 
   # Wine locates a lot of libraries dynamically through dlopen().  Add

--- a/pkgs/misc/emulators/wine/unstable.nix
+++ b/pkgs/misc/emulators/wine/unstable.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, xlibs, flex, bison, mesa, mesa_noglu, alsaLib
-, ncurses, libpng, libjpeg, lcms, freetype, fontconfig, fontforge
+, ncurses, libpng, libjpeg, lcms, freetype, fontconfig, gettext, fontforge
 , libxml2, libxslt, openssl, gnutls, cups, libdrm, makeWrapper
 }:
 
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     xlibs.xlibs flex bison xlibs.libXi mesa mesa_noglu.osmesa
     xlibs.libXcursor xlibs.libXinerama xlibs.libXrandr
     xlibs.libXrender xlibs.libXxf86vm xlibs.libXcomposite
-    alsaLib ncurses libpng libjpeg lcms fontforge
+    alsaLib ncurses libpng libjpeg lcms gettext fontforge
     libxml2 libxslt openssl gnutls cups makeWrapper
   ];
 


### PR DESCRIPTION
This adds Wine Staging patchset as new derivation. Also, `gettext` is added for Wine translations and `mpg123` for MP3 playing without replacing Wine's `quartz.dll`. I have a feeling the latter was omitted because of licensing issues, so we can't just add it by default. cc @7c6f434c 
