### PR TITLE
fetchhg: add option to fetch hg subrepos

### DIFF
--- a/pkgs/build-support/fetchhg/builder.sh
+++ b/pkgs/build-support/fetchhg/builder.sh
@@ -3,7 +3,7 @@ header "getting $url${rev:+ ($rev)} into $out"
 
 hg clone --insecure "$url" hg-clone
 
-hg archive -q -y ${rev:+-r "$rev"} --cwd hg-clone $out
+hg archive -q$subrepoClause -y ${rev:+-r "$rev"} --cwd hg-clone $out
 rm -f $out/.hg_archival.txt
 
 stopNest

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -1,4 +1,4 @@
-{stdenv, mercurial, nix}: {name ? null, url, rev ? null, md5 ? null, sha256 ? null}:
+{stdenv, mercurial, nix}: {name ? null, url, rev ? null, md5 ? null, sha256 ? null, fetchSubrepos ? false}:
 
 # TODO: statically check if mercurial as the https support if the url starts woth https.
 stdenv.mkDerivation {
@@ -9,10 +9,12 @@ stdenv.mkDerivation {
   # Nix <= 0.7 compatibility.
   id = md5;
 
+  subrepoClause = if fetchSubrepos then "S" else "";
+
   outputHashAlgo = if md5 != null then "md5" else "sha256";
   outputHashMode = "recursive";
   outputHash = if md5 != null then md5 else sha256;
-  
+
   inherit url rev;
   preferLocalBuild = true;
 }

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -17,6 +17,12 @@ if test -z "$url"; then
     exit 1
 fi
 
+if test "$fetchSubrepos" == 1; then
+    subrepoClause=S
+else
+    subrepoClause=
+fi
+
 test -n "$rev" || rev="tip"
 
 
@@ -47,7 +53,7 @@ if test -z "$finalPath"; then
     else
       tmpClone=$url
     fi
-    hg archive -q -y -r "$rev" --cwd $tmpClone $tmpArchive
+    hg archive -q$subrepoClause -y -r "$rev" --cwd $tmpClone $tmpArchive
     rm -f $tmpArchive/.hg_archival.txt
 
     echo "hg revision is $(cd $tmpClone; hg id -r "$rev" -i)"


### PR DESCRIPTION
The changes made here to the actual fetchhg derivation are straightforward enough.

The nix-prefetch-hg script however uses positional arguments, so I didn't quite know how is best to expose this option. Another positional argument would be another step towards madness. Rewriting the argument parsing to be more like nix-prefetch-git is outside the scope of that I need to do an the moment. So I've just exposed it as an environment variable here.

I'm also wondering if I'm doing this the right way so as to minimize everyone's need for rebuilding. Perhaps someone can advise me there.
