### PR TITLE
[WIP][DARWIN] libgsm: 1.0.13 -> 1.0.14 & improve cross platform support

### DIFF
--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -1,45 +1,55 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl
+, staticSupport ? false # Compile statically (support for packages that look for the static object)
+}:
 
-with stdenv.lib;
+let
+  inherit (stdenv) isDarwin;
+  inherit (stdenv.lib) optional optionalString;
+in
+
 stdenv.mkDerivation rec {
   name = "gsm-${version}";
-  version = "1.0.13";
+  version = "1.0.14";
 
   src = fetchurl {
     url = "http://www.quut.com/gsm/${name}.tar.gz";
-    sha256 = "1bcjl2h60gvr1dc5a963h3vnz9zl6n8qrfa3qmb2x3229lj1iiaj";
+    sha256 = "0b1mx69jq88wva3wk0hi6fcl5a52qhnq2f9p3f3jdh5k61ma252q";
   };
 
   patchPhase = ''
     # Fix include directory
     sed -e 's,$(GSM_INSTALL_ROOT)/inc,$(GSM_INSTALL_ROOT)/include/gsm,' -i Makefile
-
-    makeFlags="$makeFlags INSTALL_ROOT=$out"
-
-    # Build shared library instead of static
-    sed -e 's,-c -O2 -DNeedFunctionPrototypes=1,-c -O2 -fPIC -DNeedFunctionPrototypes=1,' -i Makefile
-    sed -e 's,libgsm.a,libgsm.so,' -i Makefile
-    sed -e 's/$(AR) $(ARFLAGS) $(LIBGSM) $(GSM_OBJECTS)/$(LD) -shared -Wl,-soname,libgsm.so -o $(LIBGSM) $(GSM_OBJECTS) -lc/' -i Makefile
-    sed -e 's,$(RANLIB) $(LIBGSM),,' -i Makefile
-  '';
+  '' + optionalString (!staticSupport) (
+    (if isDarwin then  ''
+      # Build dylib on Darwin
+      sed -e 's,libgsm.a,libgsm.dylib,' -i Makefile
+      sed -e 's,$(AR) $(ARFLAGS) $(LIBGSM) $(GSM_OBJECTS),$(LD) -o $(LIBGSM) -dynamiclib -install_name $(GSM_INSTALL_ROOT)/$(LIBGSM) $(GSM_OBJECTS) -lc,' -i Makefile
+    '' else ''
+      # Build ELF shared object by default
+      sed -e 's,libgsm.a,libgsm.so,' -i Makefile
+      sed -e 's/$(AR) $(ARFLAGS) $(LIBGSM) $(GSM_OBJECTS)/$(LD) -shared -Wl,-soname,libgsm.so -o $(LIBGSM) $(GSM_OBJECTS) -lc/' -i Makefile
+    '') + ''
+      # Remove line that is unused when building shared libraries
+      sed -e 's,$(RANLIB) $(LIBGSM),,' -i Makefile
+    ''
+  );
 
   makeFlags = [
-    ''SHELL=${stdenv.shell}''
-  ];
+    "SHELL=${stdenv.shell}"
+    "INSTALL_ROOT=$(out)"
+  ] ++ optional (stdenv.cc.cc.isClang or false) "CC=clang";
 
-  preInstall = ''
-    mkdir -p "$out/"{bin,lib,man/man1,man/man3,include/gsm}
-  '';
+  preInstall = "mkdir -p $out/{bin,lib,man/man1,man/man3,include/gsm}";
 
-  NIX_CFLAGS_COMPILE = "-fPIC";
+  NIX_CFLAGS_COMPILE = optional (!staticSupport) "-fPIC";
 
   parallelBuild = false;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Lossy speech compression codec";
     homepage    = http://www.quut.com/gsm/;
     license     = licenses.bsd2;
     maintainers = with maintainers; [ codyopel raskin ];
-    platforms   = platforms.all;
+    platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
Default Makefile for reference
https://gist.github.com/codyopel/747154cc34874dcb6e4d
dylib patch example (this is a patch for an already patched version)
https://searchcode.com/codesearch/view/37251938/

@spwhitt
Incase you can offer any help.
I originally had to had a few hacks to get this to build a shared library correctly for ELF platforms.  I started adding workarounds for Darwin but I have no clue if they work.  Basically the Makefile needs to be patched to build a dylib instead of building statically preferably.  I left the duplication of arguments between the ELF and Darwin hacks for now in case they need to be modified for Darwin.

If all else fails we can remove the darwin dylib hack and just build is staticly which it will do by default, then we only have to make sure it uses clang.
