### PR TITLE
Fixes to build inkscape on Darwin

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs share/extensions
+  ''
+  # Clang gets misdetected, so hardcode the right answer
+  + stdenv.lib.optionalString (stdenv.cc.cc.isClang or false) ''
+    substituteInPlace src/ui/tool/node.h \
+      --replace "#if __cplusplus >= 201103L" "#if true"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = with stdenv.lib.maintainers; [urkud raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gtkmm/2.x.nix
+++ b/pkgs/development/libraries/gtkmm/2.x.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = with stdenv.lib.maintainers; [ raskin vcunat ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = with stdenv.lib.maintainers; [ raskin urkud vcunat ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libcdr/default.nix
+++ b/pkgs/development/libraries/libcdr/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
+  configureFlags = if (stdenv.cc.cc.isClang or false)
+    then [ "--disable-werror" ] else null;
+
   CXXFLAGS="--std=gnu++0x"; # For c++11 constants in lcms2.h
 
   meta = {

--- a/pkgs/development/libraries/librevenge/default.nix
+++ b/pkgs/development/libraries/librevenge/default.nix
@@ -19,11 +19,18 @@ stdenv.mkDerivation {
   src = fetchurl {
     inherit (s) url sha256;
   };
+
+  # Clang generates warnings in Boost's header files
+  # -Werror causes these warnings to be interpreted as errors
+  # Simplest solution: disable -Werror
+  configureFlags = if (stdenv.cc.cc.isClang or false)
+    then [ "--disable-werror" ] else null;
+
   meta = {
     inherit (s) version;
     description = ''A base library for writing document import filters'';
     license = stdenv.lib.licenses.mpl20 ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libvisio/default.nix
+++ b/pkgs/development/libraries/libvisio/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A library providing ability to interpret and import visio diagrams into various applications";
     homepage = http://www.freedesktop.org/wiki/Software/libvisio;
-    platforms = stdenv.lib.platforms.gnu; # random choice
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
With these changes Inkscape builds on Darwin. However, it still
produces the following error when run:

```
dyld: Library not loaded: libopenjp2.7.dylib ...
```

This error will be resolved when staging is merged.
