### PR TITLE
Haskell: fix llvm-general

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -717,6 +717,10 @@ self: super: {
   # Uses OpenGL in testing
   caramia = dontCheck super.caramia;
 
+  llvm-general = super.llvm-general.override {
+                   llvm-config = pkgs.llvmPackages_34.llvm;
+                 };
+
 } // {
 
   # Not on Hackage.


### PR DESCRIPTION
This patch fixes `llvm-general` and `llvm-general-pure` packages. Regeneration from Hackage needed for new versions with https://github.com/bscarlet/llvm-general/issues/139 fixed. @peti 
