### PR TITLE
Add patch to fix btrfs deadlocks to affected kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/btrfs-fix-deadlock.patch
+++ b/pkgs/os-specific/linux/kernel/btrfs-fix-deadlock.patch
@@ -1,0 +1,43 @@
+From 9c4f61f01d269815bb7c37be3ede59c5587747c6 Mon Sep 17 00:00:00 2001
+From: David Sterba <dsterba@suse.cz>
+Date: Fri, 2 Jan 2015 19:12:57 +0100
+Subject: btrfs: simplify insert_orphan_item
+
+We can search and add the orphan item in one go,
+btrfs_insert_orphan_item will find out if the item already exists.
+
+Signed-off-by: David Sterba <dsterba@suse.cz>
+
+diff --git a/fs/btrfs/tree-log.c b/fs/btrfs/tree-log.c
+index 5be45c1..25a1c36 100644
+--- a/fs/btrfs/tree-log.c
++++ b/fs/btrfs/tree-log.c
+@@ -1254,21 +1254,13 @@ out:
+ }
+ 
+ static int insert_orphan_item(struct btrfs_trans_handle *trans,
+-			      struct btrfs_root *root, u64 offset)
++			      struct btrfs_root *root, u64 ino)
+ {
+ 	int ret;
+-	struct btrfs_path *path;
+-
+-	path = btrfs_alloc_path();
+-	if (!path)
+-		return -ENOMEM;
+ 
+-	ret = btrfs_find_item(root, path, BTRFS_ORPHAN_OBJECTID,
+-			offset, BTRFS_ORPHAN_ITEM_KEY, NULL);
+-	if (ret > 0)
+-		ret = btrfs_insert_orphan_item(trans, root, offset);
+-
+-	btrfs_free_path(path);
++	ret = btrfs_insert_orphan_item(trans, root, ino);
++	if (ret == -EEXIST)
++		ret = 0;
+ 
+ 	return ret;
+ }
+-- 
+cgit v0.10.2
+

--- a/pkgs/os-specific/linux/kernel/linux-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14.nix
@@ -10,6 +10,13 @@ import ./generic.nix (args // rec {
     sha256 = "1pq4i97vys38rl8ylx4s08qgh9yz3cl840j1f70yzakmc2017byc";
   };
 
+  # FIXME: remove with the next point release.
+  kernelPatches = args.kernelPatches ++
+    [ { name = "btrfs-fix-deadlock";
+        patch = ./btrfs-fix-deadlock.patch;
+      }
+    ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18.nix
@@ -9,6 +9,13 @@ import ./generic.nix (args // rec {
     sha256 = "19di7k38adnwimxddd1v6flgdsvxhgf8iswjwfyqi2p2bdcb0p5d";
   };
 
+  # FIXME: remove with the next point release.
+  kernelPatches = args.kernelPatches ++
+    [ { name = "btrfs-fix-deadlock";
+        patch = ./btrfs-fix-deadlock.patch;
+      }
+    ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.19.nix
@@ -10,6 +10,13 @@ import ./generic.nix (args // rec {
     sha256 = "0nis1r9fg562ysirzlyvfxvirpcfhxhhpfv3s13ccz20qiqiy46f";
   };
 
+  # FIXME: remove with the next point release.
+  kernelPatches = args.kernelPatches ++
+    [ { name = "btrfs-fix-deadlock";
+        patch = ./btrfs-fix-deadlock.patch;
+      }
+    ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -87,4 +87,5 @@ rec {
     { name = "crc-backport-regression";
       patch = ./crc-regression.patch;
     };
+
 }


### PR DESCRIPTION
This is a temporary patch which should fix a very nasty issue [1] for btrfs users. I personally was bitten by it a few times; it needs `btrfs check` from either a LiveUSB or a debug shell in initrd to boot system again. cc @shlevy @thoughtpolice 

[1]: https://btrfs.wiki.kernel.org/index.php/Gotchas , p. 1
