### PR TITLE
Qt: build with -pipe for some amount of parallelism

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -130,7 +130,9 @@ stdenv.mkDerivation rec {
   # @vcunat has been unable to find a *reliable* fix
   enableParallelBuilding = false;
 
-  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin
+  NIX_CFLAGS_COMPILE =
+    "-pipe " +
+    optionalString stdenv.isDarwin
     "-I${glib}/include/glib-2.0 -I${glib}/lib/glib-2.0/include";
 
   NIX_LDFLAGS = optionalString stdenv.isDarwin


### PR DESCRIPTION
Building Qt is the most annoying part of rebuilding a system because it has a fuckton of dependencies, a lot of things depend on it, and it builds on a single core only.

-pipe should improve that a tiny bit, I think. (I didn't have the patience to measure build times yet.)
