### PR TITLE
Bumped blink version to 1.2.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -2,14 +2,17 @@
 
 pythonPackages.buildPythonPackage rec {
   name = "blink-${version}";
-  version = "0.9.1";
+  version = "1.2.2";
   
   src = fetchurl {
     url = "http://download.ag-projects.com/BlinkQt/${name}.tar.gz";
-    sha256 = "f578e5186893c3488e7773fbb775028ae54540433a0c51aefa5af983ca2bfdae";
+    sha256 = "0z7bhfz2775cm7c7s794s5ighp5q7fb6jn8dw025m49vlgqzr78c";
   };
 
   patches = [ ./pythonpath.patch ];
+  postPatch = ''
+    sed -i 's|@out@|'"''${out}"'|g' blink/resources.py
+  '';
 
   propagatedBuildInputs = [ pyqt4 pythonPackages.cjson pythonPackages.sipsimple twisted ];
 

--- a/pkgs/applications/networking/instant-messengers/blink/pythonpath.patch
+++ b/pkgs/applications/networking/instant-messengers/blink/pythonpath.patch
@@ -1,12 +1,20 @@
-diff --git a/blink/resources.py b/blink/resources.py
-index 524d9e5..c271887 100644
---- a/blink/resources.py
-+++ b/blink/resources.py
-@@ -64,6 +64,7 @@ class Resources(object):
-             if script == '':
-                 application_directory = os.path.realpath(script) # executed in interactive interpreter
+diff -rupN a/blink/resources.py b/blink/resources.py
+--- a/blink/resources.py	2015-03-17 03:24:06.000000000 -0600
++++ b/blink/resources.py	2015-04-07 22:52:06.101096413 -0600
+@@ -60,14 +60,7 @@ class Resources(object):
+     @classproperty
+     def directory(cls):
+         if cls._cached_directory is None:
+-            if sys.path[0] == '':
+-                application_directory = os.path.realpath('') # executed in interactive interpreter
+-            else:
+-                binary_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+-                if os.path.basename(binary_directory) == 'bin':
+-                    application_directory = os.path.dirname(binary_directory)
+-                else:
+-                    application_directory = binary_directory
++            application_directory = '@out@'
+             if os.path.exists(os.path.join(application_directory, 'resources', 'blink.ui')):
+                 cls._cached_directory = os.path.join(application_directory, 'resources').decode(sys.getfilesystemencoding())
              else:
-+                script = os.path.join(sys.path[0], script)
-                 binary_directory = os.path.dirname(os.path.realpath(script))
-                 if os.path.basename(binary_directory) == 'bin':
-                     application_directory = os.path.dirname(binary_directory)
+Binary files a/blink/.resources.py.swp and b/blink/.resources.py.swp differ

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10094,19 +10094,19 @@ let
 
   sipsimple = buildPythonPackage rec {
     name = "sipsimple-${version}";
-    version = "1.4.2";
+    version = "2.3.1";
     disabled = isPy3k;
 
     configurePhase = "find -name 'configure' -exec chmod a+x {} \\; ; find -name 'aconfigure' -exec chmod a+x {} \\; ; ${python}/bin/${python.executable} setup.py build_ext --pjsip-clean-compile";
 
     src = pkgs.fetchurl {
       url = "http://download.ag-projects.com/SipClient/python-${name}.tar.gz";
-      sha256 = "f6e6de7ab5f20e8ae08966b8811462e4271833db4f7fbab58ffba4e5c07ab114";
+      sha256 = "1n3g1zg3zgdybikdla0qdqvpa06vn1ka2asr61lb8kk6xbvqkljv";
     };
 
-    propagatedBuildInputs = with self; [ cython pkgs.openssl dns dateutil xcaplib msrplib];
+    propagatedBuildInputs = with self; [ cython pkgs.openssl dns dateutil xcaplib msrplib lxml ];
 
-    buildInputs = with self; [ pkgs.alsaLib ];
+    buildInputs = with pkgs; [ alsaLib ffmpeg libv4l pkgconfig sqlite ];
 
     installPhase = "${python}/bin/${python.executable} setup.py install --prefix=$out";
 


### PR DESCRIPTION
Blink wasn't working for me (sipsimple was missing lxml python dependency), so in the process of fixing it I bumped the version to 1.2.2. It looks like this version adds video chat.

Some of the code around the old patch changed, so I made a new patch.

Upstream doesn't seem to keep old versions of blink source archives around, which is a bit of a problem. In the future I might change this to use a tagged reference to their source repo.
