### PR TITLE
Update elixir to 1.0.4

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, erlang, rebar, makeWrapper, coreutils, curl, bash, cacert }:
 
 let
-  version = "1.0.3";
+  version = "1.0.4";
 in
 stdenv.mkDerivation {
   name = "elixir-${version}";
 
   src = fetchurl {
     url = "https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz";
-    sha256 = "ec6c4eaffcb771d91bdea9fb274600c624fd16b1891d194b3fcb2b521f52cc75";
+    sha256 = "1babp3ff6hajdm247zl9rc311k973cdnv6dqaai7l8817gg1yd3r";
   };
 
   buildInputs = [ erlang rebar makeWrapper ];


### PR DESCRIPTION
From version 1.0.4 elixir is ready for erlang-17.5 and upcoming erlang-18
