### PR TITLE
emacs: allow choosing gtk2 or gtk3

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -2,11 +2,24 @@
 , pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
 , alsaLib, cairo
-, withX ? !stdenv.isDarwin, withGTK ? true
+, withX ? !stdenv.isDarwin
+, withGTK3 ? false, gtk3 ? null
+, withGTK2 ? true, gtk2
 }:
 
 assert (libXft != null) -> libpng != null;	# probably a bug
 assert stdenv.isDarwin -> libXaw != null;	# fails to link otherwise
+assert withGTK2 -> withX;
+assert withGTK3 -> withX;
+assert withGTK2 -> !withGTK3 && gtk2 != null;
+assert withGTK3 -> !withGTK2 && gtk3 != null;
+
+let
+  toolkit =
+    if withGTK3 then "gtk3"
+    else if withGTK2 then "gtk2"
+    else "lucid";
+in
 
 stdenv.mkDerivation rec {
   name = "emacs-24.4";
@@ -28,17 +41,16 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isLinux dbus
     ++ stdenv.lib.optionals withX
       [ x11 libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft
-        imagemagick gtk gconf ]
+        imagemagick gconf ]
+    ++ stdenv.lib.optional (withX && withGTK2) [ gtk2 ]
+    ++ stdenv.lib.optional (withX && withGTK3) [ gtk3 ]
     ++ stdenv.lib.optional (stdenv.isDarwin && withX) cairo;
 
   configureFlags =
-    ( if withX && withGTK then
-        [ "--with-x-toolkit=gtk" "--with-xft"]
-      else (if withX then
-        [ "--with-x-toolkit=lucid" "--with-xft" ]
-      else
-        [ "--with-x=no" "--with-xpm=no" "--with-jpeg=no" "--with-png=no"
-          "--with-gif=no" "--with-tiff=no" ] ) );
+    if withX
+      then [ "--with-x-toolkit=${toolkit}" "--with-xft" ]
+      else [ "--with-x=no" "--with-xpm=no" "--with-jpeg=no" "--with-png=no"
+             "--with-gif=no" "--with-tiff=no" ];
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (stdenv.isDarwin && withX)
     "-I${cairo}/include/cairo";


### PR DESCRIPTION
Sometime recently, the nixpkgs emacs was switched from GTK-2 to GTK-3. I don't think this was intentional: we were setting `--with-x-toolkit=gtk`, which selects the "best" GTK available. The only explicit dependency on GTK was for GTK-2, but I think another dependency started propagating GTK-3. We should allow explicitly choosing the GTK version because of issues in nixpkgs like #5053. I have left the default at GTK-3 for now, in case this change was intentional.

/cc maintainers: @chaoflow @lovek323 @the-kenny @peti
