### PR TITLE
Remove nightly derivations for iojs

### DIFF
--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,18 +1,14 @@
-{ stdenv, fetchurl, python, utillinux, openssl, http-parser, zlib, libuv, nightly ? false }:
+{ stdenv, fetchurl, python, utillinux, openssl, http-parser, zlib, libuv }:
 
 let
-  version = if nightly then "1.6.5-nightly20150409ff74931107" else "1.6.4";
+  version = "1.6.4";
   inherit (stdenv.lib) optional maintainers licenses platforms;
 in stdenv.mkDerivation {
   name = "iojs-${version}";
 
   src = fetchurl {
-    url = if nightly
-          then "https://iojs.org/download/nightly/v${version}/iojs-v${version}.tar.gz"
-          else "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
-    sha256 = if nightly
-             then "04f7r4iv8p0jfylw4sxg3vsv14rbsi6n9hbqnwvdh6554yrm6d35"
-             else "1qzvf7g457dppzxn23wppjcm09vh1n6bhsvz5szhwgjvl0iv2pc7";
+    url = "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
+    sha256 = "1qzvf7g457dppzxn23wppjcm09vh1n6bhsvz5szhwgjvl0iv2pc7";
   };
 
   prePatch = ''

--- a/pkgs/development/web/iojs/update-iojs
+++ b/pkgs/development/web/iojs/update-iojs
@@ -18,7 +18,7 @@ latest() {
 latest_log() {
     echo "Getting latest $1 version from $2" >&2
     version=$(latest "$2")
-    echo " -> $version" >&2
+    echo "version -> $version" >&2
     echo "$version"
 }
 
@@ -35,20 +35,16 @@ hash() {
 hash_log() {
     echo "Finding hash for $1" >&2
     value=$(hash "$1")
-    echo " -> $value" >&2
+    echo "hash -> $value" >&2
     echo "$value"
 }
 
-stable=$(latest_log stable 'https://iojs.org/dist/')
-nightly=$(latest_log nightly 'https://iojs.org/download/nightly/')
-
-sed -i \
-    "/version = if nightly/s/then.*/then \"$nightly\" else \"$stable\";/" \
-    "$HERE/default.nix"
-
+stableVersion=$(latest_log stable 'https://iojs.org/dist/')
 stableHash=$(hash_log "$(url iojs.src)")
-nightlyHash=$(hash_log "$(url iojs-nightly.src)")
 
 sed -i \
-    "/sha256 = if nightly/{N;s/\"[^\"]*\"/\"$nightlyHash\"/;N;s/\"[^\"]*\";/\"$stableHash\";/}" \
+    "/version = /s/\"[^\"]*\"/\"$stableVersion\"/" \
+    "$HERE/default.nix"
+sed -i \
+    "/sha256 = /s/\"[^\"]*\"/\"$stableHash\"/" \
     "$HERE/default.nix"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1813,7 +1813,6 @@ let
   nodePackages = callPackage ./node-packages.nix { self = nodePackages; };
 
   iojs = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_0; };
-  iojs-nightly = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_0; nightly = true; };
 
   iojsPackages = callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; };
 


### PR DESCRIPTION
Packaging a random nightly version of io.js isn't going to help anybody, but making the derivation easier to understand makes it more maintainable.

See #7293 for rationale.
