### PR TITLE
Add package "fira-mono"

### DIFF
--- a/pkgs/data/fonts/fira-mono/default.nix
+++ b/pkgs/data/fonts/fira-mono/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "fira-mono-3.2";
+
+  src = fetchurl {
+    url = http://www.carrois.com/downloads/fira_mono_3_2/FiraMonoFonts3200.zip;
+    sha256 = "0g3i54q8czf3vylgasj62w2n7l1a2yrbyibjlx1qk3awh7fr1r7p";
+  };
+
+  buildInputs = [ unzip ];
+  phases = [ "unpackPhase" "installPhase" ];
+  sourceRoot = "FiraMonoFonts3200";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    find . -name "*.otf" -exec cp -v {} $out/share/fonts/opentype \;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.carrois.com/fira-4-1/;
+    description = "Monospace font for Firefox OS";
+    longDescription = ''
+      Fira Mono is a monospace font designed by Erik Spiekermann,
+      Ralph du Carrois, Anja Meiners and Botio Nikoltchev of Carrois
+      Type Design for Mozilla Firefox OS. Available in Regular,
+      Medium, and Bold.
+    '';
+    license = licenses.ofl;
+    maintainers = [ maintainers.rycee ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/fira/default.nix
+++ b/pkgs/data/fonts/fira/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://www.carrois.com/fira-4-1/;
-    description = "Sans-serif and monospace font for Firefox OS";
+    description = "Sans-serif font for Firefox OS";
     longDescription = ''
       Fira Sans is a sans-serif font designed by Erik Spiekermann,
       Ralph du Carrois, Anja Meiners and Botio Nikoltchev of Carrois
@@ -27,9 +27,7 @@ stdenv.mkDerivation rec {
       Spiekermann's FF Meta typeface.  Available in Two, Four, Eight,
       Hair, Thin, Ultra Light, Extra Light, Light, Book, Regular,
       Medium, Semi Bold, Bold, Extra Bold, Heavy weights with
-      corresponding italic versions.  Fira Mono is a matching
-      monospace variant of Fira Sans.  It is available in regular, and
-      bold weights.
+      corresponding italic versions.
     '';
     license = licenses.ofl;
     platforms = platforms.all;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9754,6 +9754,8 @@ let
 
   fira = callPackage ../data/fonts/fira { };
 
+  fira-mono = callPackage ../data/fonts/fira-mono { };
+
   freefont_ttf = callPackage ../data/fonts/freefont-ttf { };
 
   freepats = callPackage ../data/misc/freepats { };


### PR DESCRIPTION
Turns out that the monospace fonts in the Fira font family is not actually in the "fira" package. So add a new package for the monospace fonts. I did not add this to the old "fira" package since the versioning is different.
