### PR TITLE
nixos: move environment.{variables => sessionVariables}.MODULE_DIR

### DIFF
--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -101,7 +101,7 @@ with lib;
         echo ${config.system.sbin.modprobe}/sbin/modprobe > /proc/sys/kernel/modprobe
       '';
 
-    environment.variables.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";
+    environment.sessionVariables.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";
 
   };
 


### PR DESCRIPTION
This solves the problem that modprobe does not know about $MODULE_DIR
when run via sudo, and instead wrongly tries to read /lib/modules/:

  $ sudo strace -efile modprobe foo |& grep modules
  open("/lib/modules/3.14.37/modules.softdep", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
  open("/lib/modules/3.14.37/modules.dep.bin", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
  open("/lib/modules/3.14.37/modules.dep.bin", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
  open("/lib/modules/3.14.37/modules.alias.bin", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)

Without this patch, one would have to use sudo -E (preserves environment
vars). But that option is reserved for sudo users with extra rights
(SETENV), so it's not a solution.

environment.sessionVariables are set by PAM, so they are included in the
environment used by sudo.
