### PR TITLE
wireshark: change dependency heimdal -> openssl

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, perl, flex, bison, libpcap, libnl, c-ares
-, gnutls, libgcrypt, geoip, heimdal, lua5, makeDesktopItem, python, libcap, glib
+, gnutls, libgcrypt, geoip, openssl, lua5, makeDesktopItem, python, libcap, glib
 , withGtk ? false, gtk ? null
 , withQt ? false, qt4 ? null
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    bison flex perl pkgconfig libpcap lua5 heimdal libgcrypt gnutls
+    bison flex perl pkgconfig libpcap lua5 openssl libgcrypt gnutls
     geoip libnl c-ares python libcap glib
   ] ++ optional withQt qt4
     ++ optional withGtk gtk;


### PR DESCRIPTION
This fixes wirehsark build, which has been broken since commit
942e179974ceae1d8 (heimdal: Correct the openssl dependency).
