### PR TITLE
haskell-distributed-process-*: disable several checkPhases and haddockPh...

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -530,9 +530,30 @@ self: super: {
   # Upstream notified by e-mail.
   MonadCompose = markBrokenVersion "0.2.0.0" super.MonadCompose;
 
+  # no haddock since this is an umbrella package.
+  cloud-haskell = dontHaddock super.cloud-haskell;
+
+  # Disable tests which couldn't be built.
+  distributed-process-async = dontCheck super.distributed-process-async;
+
+  # Disable tests which couldn't be built.
+  distributed-process-client-server = dontCheck super.distributed-process-client-server;
+
+  # Disable tests which couldn't be built.
+  distributed-process-extras = dontCheck super.distributed-process-extras;
+
   # Make distributed-process-platform compile until next version
   distributed-process-platform = overrideCabal super.distributed-process-platform (drv: {
     patchPhase = "mv Setup.hs Setup.lhs";
+    doCheck = false;
+    doHaddock = false;
+  });
+
+  # Disable tests due to a failure (Sequential Shutdown Ordering test.)
+  distributed-process-supervisor = dontCheck super.distributed-process-supervisor;
+
+  # Disable network test and errorneous haddock.
+  distributed-process-tests = overrideCabal super.distributed-process-tests (drv: { 
     doCheck = false;
     doHaddock = false;
   });


### PR DESCRIPTION
...ases for distributed-process-\* packages and cloud-haskell.

Tested with installing cloud-haskell (an umbrella package for cloud haskell platform) o x86_64-linux machine.
