### PR TITLE
nixos: add AppArmor PAM support

### DIFF
--- a/nixos/modules/security/apparmor.nix
+++ b/nixos/modules/security/apparmor.nix
@@ -37,13 +37,5 @@ in
          ) cfg.profiles;
        };
      };
-
-     security.pam.services.apparmor.text = ''
-       ## AppArmor changes hats according to `order`: first try user, then
-       ## group, and finally fall back to a hat called "DEFAULT"
-       ##
-       ## For now, enable debugging as this is an experimental feature.
-       session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug
-     '';
    };
 }

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -192,6 +192,16 @@ let
         description = "Whether to log authentication failures in <filename>/var/log/faillog</filename>.";
       };
 
+      enableAppArmor = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable support for attaching AppArmor profiles at the
+          user/group level, e.g., as part of a role based access
+          control scheme.
+        '';
+      };
+
       text = mkOption {
         type = types.nullOr types.lines;
         description = "Contents of the PAM service file.";
@@ -294,6 +304,8 @@ let
               "session optional ${pkgs.pam}/lib/security/pam_motd.so motd=${motd}"}
           ${optionalString cfg.pamMount
               "session optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
+          ${optionalString (cfg.enableAppArmor && config.security.apparmor.enable)
+              "session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug"}
         '';
     };
 


### PR DESCRIPTION
Enables attaching AppArmor profiles at the user/group level.

By itself, this doesn't do anything without the requisite AppArmor profiles. Also, it is optional
for now and so is mostly of interest to people who want to experiment with the feature.

I have verified that it is indeed safe to enable this, it only adds some minor printk spam. To
build an actual RBAC system you'd change session optional to required, but then it'd be possible
to lock yourself out of the machine ...
