### PR TITLE
nixos: condition shadow setuid-wrappers on mutableUsers

### DIFF
--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -100,8 +100,10 @@ in
         chgpasswd = { rootOK = true; };
       };
 
-    security.setuidPrograms = [ "passwd" "chfn" "su" "sg" "newgrp"
-      "newuidmap" "newgidmap"  # new in shadow 4.2.x
+    security.setuidPrograms = [ "su" "chfn" ]
+      ++ lib.optionals config.users.mutableUsers
+      [ "passwd" "sg" "newgrp"
+        "newuidmap" "newgidmap" # new in shadow 4.2.x
       ];
 
   };


### PR DESCRIPTION
Having junk setuid wrappers in PATH is annoying.

I don't know if there's actually a reason for installing junk setuid-wrappers here, but I'm
running with this patch and haven't noticed any problems.
