### PR TITLE
bastet: new package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -60,6 +60,7 @@
   dbohdan = "Danyil Bohdan <danyil.bohdan@gmail.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";
   devhell = "devhell <\"^\"@regexmail.net>";
+  dezgeg = "Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";

--- a/pkgs/games/bastet/default.nix
+++ b/pkgs/games/bastet/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, ncurses, boost }:
+
+stdenv.mkDerivation rec {
+  name = "bastet-${version}";
+  version = "0.43.1";
+  buildInputs = [ ncurses boost ];
+
+  src = fetchFromGitHub {
+    owner = "fph";
+    repo = "bastet";
+    rev = version;
+    sha256 = "14ymdarx30zqxyixvb17h4hs57y6zfx0lrdvc200crllz8zzdx5z";
+  };
+
+  installPhase = ''
+    mkdir -p "$out"/bin
+    cp bastet "$out"/bin/
+    mkdir -p "$out"/share/man/man6
+    cp bastet.6 "$out"/share/man/man6
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tetris clone with 'bastard' block-choosing AI";
+    homepage = http://fph.altervista.org/prog/bastet.html;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.dezgeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -634,6 +634,8 @@ let
 
   bashmount = callPackage ../tools/filesystems/bashmount {};
 
+  bastet = callPackage ../games/bastet {};
+
   bc = callPackage ../tools/misc/bc { };
 
   bcache-tools = callPackage ../tools/filesystems/bcache-tools { };


### PR DESCRIPTION
This PR adds the (in)famous impossible-to-beat ncurses tetris game.

Tested on x86_64 in nixos' `system-packages.`.
