### PR TITLE
Make it easy to add system-wide custom channels.

### DIFF
--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -93,9 +93,17 @@ if [ "$action" = switch -o "$action" = boot -o "$action" = test ]; then
 fi
 
 
-# If ‘--upgrade’ is given, run ‘nix-channel --update’.
+# If ‘--upgrade’ is given, run ‘nix-channel --update nixos’.
 if [ -n "$upgrade" -a -z "$_NIXOS_REBUILD_REEXEC" ]; then
-    nix-channel --update
+    nix-channel --update nixos
+
+    # If there are other channels that contain a file called
+    # ".update-on-nixos-rebuild", update them as well.
+    for channelpath in /nix/var/nix/profiles/per-user/root/channels/*; do
+        if [ -e "$channelpath/.update-on-nixos-rebuild" ]; then
+            nix-channel --update "$(basename "$channelpath")"
+        fi
+    done
 fi
 
 # Make sure that we use the Nix package we depend on, not something

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -93,9 +93,9 @@ if [ "$action" = switch -o "$action" = boot -o "$action" = test ]; then
 fi
 
 
-# If ‘--upgrade’ is given, run ‘nix-channel --update nixos’.
+# If ‘--upgrade’ is given, run ‘nix-channel --update’.
 if [ -n "$upgrade" -a -z "$_NIXOS_REBUILD_REEXEC" ]; then
-    nix-channel --update nixos
+    nix-channel --update
 fi
 
 # Make sure that we use the Nix package we depend on, not something

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -25,10 +25,10 @@ in
 
     environment.sessionVariables =
       { NIX_PATH =
-          [ "/nix/var/nix/profiles/per-user/root/channels"
-            "/nix/var/nix/profiles/per-user/root/channels/nixos"
+          [ "/nix/var/nix/profiles/per-user/root/channels/nixos"
             "nixpkgs=/etc/nixos/nixpkgs"
             "nixos-config=/etc/nixos/configuration.nix"
+            "/nix/var/nix/profiles/per-user/root/channels"
           ];
       };
 

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -25,7 +25,8 @@ in
 
     environment.sessionVariables =
       { NIX_PATH =
-          [ "/nix/var/nix/profiles/per-user/root/channels/nixos"
+          [ "/nix/var/nix/profiles/per-user/root/channels"
+            "/nix/var/nix/profiles/per-user/root/channels/nixos"
             "nixpkgs=/etc/nixos/nixpkgs"
             "nixos-config=/etc/nixos/configuration.nix"
           ];


### PR DESCRIPTION
This is very useful if you want to distribute channels (and thus expressions as well) in a similar fashion to Debians APT sources (or PPAs or whatnot).

So, for example if you have a channel with some additional functions or packages, you simply add that channel with:

``` shell-session
$ sudo nix-channel --add https://example.com/my-nifty-channel foo
```

And you can access that channel using `<foo>`, for example in your configuration.nix:

``` nix
{
  imports = [ <foo/modules/shiny-little-module> ];
  environment.systemPackages = with import <foo/pkgs> {}; [ bar blah ];
  services.udev.extraRules = import <foo/lib/udev/mkrule.nix> {
    kernel = "eth*";
    attr.address = "00:1D:60:B9:6D:4F";
    name = "my_fast_network_card";
  };
}
```

Within nixpkgs, we shouldn't have `<nixos>` used anywhere anymore, so we shouldn't get into conflicts.

Cc: @edolstra
