### PR TITLE
cask: fix issue with 'cask init' command

### DIFF
--- a/pkgs/applications/editors/emacs-modes/cask/default.nix
+++ b/pkgs/applications/editors/emacs-modes/cask/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
     install -d "$out/bin"
     install bin/cask "$out/bin"
 
+    # We also need to install cask's templates in order for 'cask
+    # init' to work properly.
+    install -d "$out/templates"
+    install templates/* "$out/templates"
+
     # In order to work with cask's hard coded file paths (during bootstrap),
     # we have to create these links.
     ln -s "$out/share/emacs/site-lisp/"* "$out"


### PR DESCRIPTION
Fix an issue where 'cask init' would fail due to missing template files.
