### PR TITLE
haskell-ng: patch dyre to check NIX_GHC

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -731,6 +731,9 @@ self: super: {
   # Tries to run GUI in tests
   leksah = dontCheck super.leksah;
 
+  # Patch to consider NIX_GHC just like xmonad does
+  dyre = appendPatch super.dyre ./dyre-nix.patch;
+
 } // {
 
   # Not on Hackage.

--- a/pkgs/development/haskell-modules/dyre-nix.patch
+++ b/pkgs/development/haskell-modules/dyre-nix.patch
@@ -1,0 +1,25 @@
+--- dyre-0.8.12/Config/Dyre/Compile.hs	2015-04-13 11:00:20.794278350 +0100
++++ dyre-0.8.12-patched/Config/Dyre/Compile.hs	2015-04-13 11:07:26.938893502 +0100
+@@ -10,11 +10,13 @@
+ import System.FilePath   ( (</>) )
+ import System.Directory  ( getCurrentDirectory, doesFileExist
+                          , createDirectoryIfMissing )
++import System.Environment ( lookupEnv )
++import Control.Applicative ((<$>))
+ import Control.Exception ( bracket )
+-import GHC.Paths         ( ghc )
+ 
+ import Config.Dyre.Paths  ( getPaths )
+ import Config.Dyre.Params ( Params(..) )
++import Data.Maybe         ( fromMaybe )
+ 
+ -- | Return the path to the error file.
+ getErrorPath :: Params cfgType -> IO FilePath
+@@ -47,6 +49,7 @@
+     errFile <- getErrorPath params
+     result <- bracket (openFile errFile WriteMode) hClose $ \errHandle -> do
+         ghcOpts <- makeFlags params configFile tempBinary cacheDir libsDir
++        ghc <- fromMaybe "ghc" <$> lookupEnv "NIX_GHC"
+         ghcProc <- runProcess ghc ghcOpts (Just cacheDir) Nothing
+                               Nothing Nothing (Just errHandle)
+         waitForProcess ghcProc


### PR DESCRIPTION
xmonad is patched in similar manner already

cc @peti
