### PR TITLE
Configure NixOS from EC2 user-data

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-base-config.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-base-config.nix
@@ -1,5 +1,5 @@
 { modulesPath, ...}:
 {
-  imports = [ "${modulesPath}/virtualisation/amazon-image.nix" ];
+  imports = [ "${modulesPath}/virtualisation/amazon-init.nix" ];
   services.journald.rateLimitBurst = 0;
 }

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -1,0 +1,52 @@
+{ config, pkgs, modulesPath, ... }:
+
+# This attempts to pull a nix expression from this EC2 instance's user-data.
+
+let
+  bootScript = pkgs.writeScript "bootscript.sh" ''
+    #!${pkgs.stdenv.shell} -eux
+
+    echo "attempting to fetch configuration from user-data..."
+
+    export PATH=${pkgs.nix}/bin:${pkgs.wget}/bin:${pkgs.systemd}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${config.system.build.nixos-rebuild}/bin:$PATH
+    export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
+
+    userData="$(mktemp)"
+    wget -q --wait=1 --tries=0 --retry-connrefused -O - http://169.254.169.254/2011-01-01/user-data > "$userData"
+
+    if [[ $? -eq 0 ]]; then
+      echo "user-data fetched"
+      # If the user-data looks like it could be a nix expression,
+      # copy it over. Also, look for a magic three-hash comment and set
+      # that as the channel.
+      if sed '/^\(#\|SSH_HOST_.*\)/d' < "$userData" | grep -q '\S'; then
+        channels="$(grep '^###' "$userData" | sed 's|###\s*||')"
+        printf "%s" "$channels" | while read channel; do
+          echo "writing channel: $channel"
+        done
+
+        if [[ -n "$channels" ]]; then
+          printf "%s" "$channels" > /root/.nix-channels
+          nix-channel --update
+        fi
+
+        echo "setting configuration"
+        cp "$userData" /etc/nixos/configuration.nix
+      else
+        echo "user-data does not appear to be a nix expression; ignoring"
+      fi
+    else
+      echo "failed to fetch user-data"
+    fi
+
+    type -f nixos-rebuild
+
+    nixos-rebuild switch
+  '';
+in {
+  imports = [ "${modulesPath}/virtualisation/amazon-image.nix" ];
+  ec2.metadata = true;
+  boot.postBootCommands = ''
+    ${bootScript} &
+  '';
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -247,7 +247,8 @@ in rec {
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
   tests.dockerRegistry = hydraJob (import tests/docker-registry.nix { system = "x86_64-linux"; });
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });
-  tests.ec2 = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).bootEc2NixOps;
+  tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
+  tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;
   tests.firefox = callTest tests/firefox.nix {};
   tests.firewall = callTest tests/firewall.nix {};
   tests.fleet = hydraJob (import tests/fleet.nix { system = "x86_64-linux"; });


### PR DESCRIPTION
[See #6662 for more discussion of how I got here and why I'm doing it this way]

This is my initial attempt at getting a working configure-from-user-data NixOS image working. The basic idea is to create an "unstable" NixOS image: its `/etc/nixos/configuration.nix` doesn't actually specify the way the machine is configured, but rather assumes that an `/etc/nixos/amazon-init.nix` exists, which is not bundled inside the image. Instead of bundling `amazon-init.nix`, the image bundles a `postBootCommands` script that downloads the EC2 user-data and writes it into `/etc/nixos/amazon-init.nix`.

The "unstable" NixOS image thus only configures itself from user-data on first boot, since when it calls `nixos-rebuild switch` on your personalized configuration, the custom `postBootCommands` will go away.

User-data should look something like:

``` nix
### http://nixos.org/channels/nixos-unstable nixos

{
  # Insert your config here, and you'll probably not want me to log into your box so
  # change the user below, or don't put one there at all!

  security.sudo.wheelNeedsPassword = false;

  users.extraUsers.copumpkin = 
    { createHome      = true;
      home            = "/home/copumpkin";
      description     = "Dan P";
      extraGroups     = [ "wheel" ];
      useDefaultShell = true;
      openssh.authorizedKeys.keys = [
        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCkoril5uKjJohHvqz9Ys9R2rBH95MUb4Rxo5kcuRvEIwMranQ7xP5eU7rZqfv7elE1DLfMs19via+btUX3w8o4juYxzXjafnH6Mck5hYdvxNnErW6gsp0vGDQ0ruRCQx3UmOuC5Ld/wXY7iMQqOlxeLZF2dVCKP1+BSs37wLC7scXYu0U+wODprVpAsZIOwLP85w/uCNlC8wbvNDWG+Hx+XD/ml2ezQiNBRnh7Qo3QKgpUvVBO0d9z84g92D2H9IA+pEpJiWFcYKGEowKSVQVFCi5LoWRiz8XLKL+JeBt5mmmqjmJua6o8lXV7+nba//KCIkG+IWS4nwKQlpzZXc4H"
      ];
    };
}
```

One thing to note is the `###` section at the top, which specifies the channels (I just strip off the `###` and direct into `~/.nix-channels`)

If you trust me and want to try it out, I'm hosting a public AMI (until I get sick of paying for storage) of the above with ID `ami-1c477874`.

Questions for anyone still reading:
- Is this the best way to do it? The `postBootCommands` with periodic timed check feels kind of hacky, but I also can't use a systemd service and activation scripts didn't work either.
- Is this the best format for user-data? I like it because it's simple, specifies the full machine (with channels, although I'm not necessarily sold on the `###` convention), and is very clearly just nixos configuration. Unfortunately it's not compatible with the existing format nixops uses for its temporary host keys, but I'd rather make it use a clean nix configuration file than force this into that format and have to deal with escaping and other ugliness. I haven't used NixOps much so perhaps it'll be too painful to transition it, but if possible I'd like the user-data format to be clean.

Note that it's still a WIP, so I'll obviously take out the useless `echo` calls and such before merging :smile: 

cc @edolstra @shlevy @rbvermaa 
