### PR TITLE
Added piglit OpenGL test suite

### DIFF
--- a/pkgs/development/libraries/waffle/default.nix
+++ b/pkgs/development/libraries/waffle/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchurl, cmake, libX11, mesa, pkgconfig, udev }:
+
+stdenv.mkDerivation rec {
+  name = "waffle-${version}";
+  version = "1.5.1";
+
+  src = fetchurl {
+    url = "http://www.waffle-gl.org/files/release/waffle-${version}/waffle-${version}.tar.xz";
+    sha256 = "1ai0zqmrpma0zdcpdl20bxz30cxy0jpsb2ghif0lw1hmcn90xayb";
+  };
+
+  buildInputs = [ cmake libX11 mesa pkgconfig udev ];
+
+  # TODO: More API's can be specified here, but I've only tested GLX for now
+  cmakeFlags = "-Dwaffle_has_glx=1";
+
+  meta = with lib; {
+    description = "Library for selecting an OpenGL API and window system at runtime";
+    homepage    = http://www.waffle-gl.org/;
+    license     = licenses.bsd2;
+    maintainers = with maintainers; [ auntie ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/piglit/default.nix
+++ b/pkgs/development/tools/misc/piglit/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchgit, cmake, glproto, libdrm, libpthreadstubs,
+  libX11, libXau, libXdamage, libXdmcp, libXext, libxshmfence, libXxf86vm,
+  makeWrapper, mesa, pkgconfig, python, pythonPackages, udev, waffle }:
+
+stdenv.mkDerivation rec {
+  name = "piglit-${version}";
+  version = "a04c0af968922b694221899d6da5f5a752a304f8";
+
+  src = fetchgit {
+    url = git://anongit.freedesktop.org/git/piglit;
+    rev = "${version}";
+    sha256 = "6989b07fee2b3e716deaf37d948b62b05cfc74f77281a52fdc788b83666071c5";
+  };
+
+  patches = [
+    # The wrapper provided with piglit expects itself to be named 'piglit.py'.
+    # This patch accounts for the fact that wrapProgram will rename that
+    # wrapper script to '.piglit-wrapped'.
+    ./hack-for-wrapper.patch
+  ];
+
+  buildInputs = [ cmake glproto libdrm libpthreadstubs
+    libX11 libXau libXdamage libXdmcp libXext libxshmfence libXxf86vm
+    makeWrapper mesa pkgconfig python udev waffle ];
+  propagatedBuildInputs = with pythonPackages; [ Mako numpy six ];
+
+  postInstall = ''
+    wrapProgram "$out"/bin/piglit --prefix PYTHONPATH : "$PYTHONPATH"
+  '';
+
+  meta = with lib; {
+    description = "Test suite for OpenGL implementations";
+    homepage    = http://piglit.freedesktop.org/;
+    license     = with licenses; [ mit gpl2 gpl3 bsd3 ];
+    maintainers = with maintainers; [ auntie ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/piglit/hack-for-wrapper.patch
+++ b/pkgs/development/tools/misc/piglit/hack-for-wrapper.patch
@@ -1,0 +1,13 @@
+diff --git a/piglit b/piglit
+index 5ae43e9..7360a99 100755
+--- a/piglit
++++ b/piglit
+@@ -89,7 +89,7 @@ def setup_module_search_path():
+     #       ${prefix}/${libdir}/${script_name}/framework -> Piglit framework module.
+     #
+     abs_bindir = abs_script_dir
+-    script_basename_noext = os.path.splitext(os.path.basename(__file__))[0]
++    script_basename_noext = 'piglit'
+     for libdir in ('lib64', 'lib32', 'lib'):
+         abs_libdir = path.normpath(path.join(abs_bindir, '..', libdir))
+         abs_data_dir = path.join(abs_libdir, script_basename_noext)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5221,6 +5221,8 @@ let
 
   phantomjs = callPackage ../development/tools/phantomjs { };
 
+  piglit = callPackage ../development/tools/misc/piglit { };
+
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
   /* Make pkgconfig always return a nativeDrv, never a proper crossDrv,
@@ -7719,6 +7721,8 @@ let
   vxl = callPackage ../development/libraries/vxl {
     libpng = libpng12;
   };
+
+  waffle = callPackage ../development/libraries/waffle { };
 
   wavpack = callPackage ../development/libraries/wavpack { };
 


### PR DESCRIPTION
I added piglit, which is just a test suite for Mesa's OpenGL/OpenCL functionality. There's no real "release" version of piglit, just a git repository.

piglit uses waffle to do its cross platform OpenGL API initialization and window management.

Ran all of the quick tests on my netbook with the following command:
piglit run /nix/store/7k0xd1bdkwv5m2smf9hikbqg6s47amad-piglit-a04c0af968922b694221899d6da5f5a752a304f8/lib/piglit/tests/quick.py /tmp/piglit_results
