### PR TITLE
[nixos] agetty: Add autologinUser config option

### DIFF
--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -30,11 +30,14 @@ with lib;
     # the full glibcLocales package.
     i18n.supportedLocales = ["en_US.UTF-8/UTF-8" "en_US/ISO-8859-1"];
 
+    # Automatically log in at the virtual consoles.
+    services.mingetty.autologinUser = "root";
+
     # Some more help text.
     services.mingetty.helpLine =
       ''
 
-        Log in as "root" with an empty password.  ${
+        The "root" account has an empty password.  ${
           optionalString config.services.xserver.enable
             "Type `start display-manager' to\nstart the graphical user interface."}
       '';


### PR DESCRIPTION
This option causes the specified user to be automatically logged in at
the virtual console. Tested on x86_64 in virtualbox.

It might be useful to set `autologinUser = "root"` for the installation CDs as well.
