### PR TITLE
Fix buildPythonPackage overriding.

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14,7 +14,7 @@ let
 
   callPackage = pkgs.newScope self;
 
-  buildPythonPackage = makeOverridable (callPackage ../development/python-modules/generic { });
+  buildPythonPackage = makeOverridable callPackage ../development/python-modules/generic { };
 
   # Unique python version identifier
   pythonName =


### PR DESCRIPTION
makeOverridable takes a function and an argument, the parenthesis
caused there to be only one argument which works but cannot
be overridden.
