### PR TITLE
Add package for Screencloud 1.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -74,6 +74,7 @@
   falsifian = "James Cook <james.cook@utoronto.ca>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
   fluffynukeit = "Daniel Austin <dan@fluffynukeit.com>";
+  forkk = "Andrew Okin <forkk@forkk.net>";
   fpletz = "Franz Pletz <fpletz@fnordicwalking.de>";
   ftrvxmtrx = "Siarhei Zirukin <ftrvxmtrx@gmail.com>";
   funfunctor = "Edward O'Callaghan <eocallaghan@alterapraxis.com>";

--- a/pkgs/applications/graphics/screencloud/default.nix
+++ b/pkgs/applications/graphics/screencloud/default.nix
@@ -1,0 +1,74 @@
+{ stdenv, fetchurl, fetchFromGitHub, cmake, qt4, quazip, qt-mobility, qxt, python, pycrypto, glib }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "screencloud-${version}";
+  version = "1.2.0";
+
+  # API Keys. According to the author of the AUR package, these are only used
+  # for tracking usage.
+  consumerKey = "23e747012c68601f27ab69c6de129ed70552d55b6";
+  consumerSecret = "4701cb00c1bd357bbcae7c3d713dd216";
+  
+  src = fetchFromGitHub {
+    owner = "olav-st";
+    repo = "screencloud";
+    rev = "v${version}";
+    sha256 = "1s0dxa1sa37nvna5nfqdsp294810favj68qb7ghl78qna7zw0cim";
+  };
+
+  buildInputs = [ cmake qt4 quazip qt-mobility qxt python pycrypto ];
+
+  patchPhase = ''
+    # Required to make the configure script work. Normally, screencloud's
+    # CMakeLists file sets the install prefix to /opt by force. This is stupid
+    # and breaks nix, so we force it to install where we want. Please don't
+    # write CMakeLists files like this, as things like this are why we can't
+    # have nice things.
+    substituteInPlace "CMakeLists.txt" --replace "set(CMAKE_INSTALL_PREFIX \"/opt\")" ""
+  '';
+
+  enableParallelBuilding = true;
+
+  # We need to append /opt to our CMAKE_INSTALL_PREFIX, so we tell the Nix not
+  # to add the argument for us.
+  dontAddPrefix = true;
+
+  cmakeFlags = [
+    "-DQXT_QXTCORE_INCLUDE_DIR=${qxt}/include/QxtCore"
+    "-DQXT_QXTCORE_LIB_RELEASE=${qxt}/lib/libQxtCore.so"
+    "-DQXT_QXTGUI_INCLUDE_DIR=${qxt}/include/QxtGui"
+    "-DQXT_QXTGUI_LIB_RELEASE=${qxt}/lib/libQxtGui.so"
+    "-DCONSUMER_KEY_SCREENCLOUD=${consumerKey}"
+    "-DCONSUMER_SECRET_SCREENCLOUD=${consumerSecret}"
+  ];
+
+  sourceRoot = "screencloud-v${version}-src/screencloud";
+
+  preConfigure = ''
+    # This needs to be set in preConfigure instead of cmakeFlags in order to
+    # access the $prefix environment variable.
+    export cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix/opt $cmakeFlags"
+  '';
+
+  # There are a number of issues with screencloud's installation. We need to add
+  # pycrypto to the PYTHONPATH so that the SFTP plugin will work properly; and
+  # we need to move the libPythonQt library into a folder where it can actually
+  # be found.
+  postInstall = ''
+    patchShebangs $prefix/opt/screencloud/screencloud.sh
+    substituteInPlace "$prefix/opt/screencloud/screencloud.sh" --replace "/opt" "$prefix/opt"
+    sed -i "2 i\export PYTHONPATH=$(toPythonPath ${pycrypto}):\$PYTHONPATH" "$prefix/opt/screencloud/screencloud.sh"
+    mkdir $prefix/bin
+    mkdir $prefix/lib
+    ln -s $prefix/opt/screencloud/screencloud.sh $prefix/bin/screencloud
+    ln -s $prefix/opt/screencloud/libPythonQt.so $prefix/lib/libPythonQt.so
+  '';
+
+  meta = {
+    homepage = https://screencloud.net/;
+    description = "Client for Screencloud, an easy to use screenshot sharing tool";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ forkk ];
+  };
+}

--- a/pkgs/development/libraries/qt-mobility/default.nix
+++ b/pkgs/development/libraries/qt-mobility/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchurl, qt4, libX11, coreutils, bluez, perl }:
+{ stdenv, fetchFromGitHub, qt4, libX11, coreutils, bluez, perl }:
 # possible additional dependencies: pulseaudio udev networkmanager immerson qmf
 
 stdenv.mkDerivation rec {
   version = "1.2.0";
   name = "qt-mobility-${version}";
-  download = "qt-mobility-opensource-src-${version}";
-  src = fetchurl {
-    url =  "http://get.qt.nokia.com/qt/add-ons/${download}.tar.gz";
-    sha256 = "ee3c88975e04139ac9589f76d4be646d44fcbc4c8c1cf2db621abc154cf0ba44";
+  src = fetchFromGitHub {
+    owner = "qtproject";
+    repo = "qt-mobility";
+    rev = "v${version}";
+    sha256 = "14713pbscysd6d0b9rgm7gg145jzwvgdn22778pf2v13qzvfmy1i";
   };
 
   NIX_CFLAGS_COMPILE="-fpermissive";
@@ -21,6 +22,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     for i in connectivity contacts feedback gallery location multimedia organizer publishsubscribe sensors serviceframework systeminfo; do
       substituteInPlace plugins/declarative/$i/Makefile --replace "${qt4}/lib/qt4/imports/" "$out/lib/qt4/imports/"
+    done
   '';
 
   # Features files (*.prf) are not installed on nixos

--- a/pkgs/development/libraries/qxt/default.nix
+++ b/pkgs/development/libraries/qxt/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, which, coreutils, fetchzip, qt4 }:
+
+stdenv.mkDerivation rec {
+  name = "qxt-${version}";
+  version = "0.6.2";
+  
+  src = fetchzip {
+    url = "http://dev.libqxt.org/libqxt/get/v${version}.tar.gz";
+    sha256 = "0zmqfn0h8cpky7wgaaxlfh0l89r9r0isi87587kaicyap7a6kxwz";
+  };
+
+  buildInputs = [ qt4 which ];
+
+  patchPhase = ''
+    patchShebangs configure
+    substituteInPlace configure --replace "/bin/pwd" "${coreutils}/bin/pwd"
+  '';
+
+  prefixKey = "-prefix ";
+
+  meta = {
+    homepage = http://libqxt.org;
+    description = "An extension library for Qt";
+    longDescription = ''
+      An extension library for Qt providing a suite of cross-platform utility
+      classes to add functionality not readily available in the Qt toolkit by Qt
+      Development Frameworks, Nokia.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ forkk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5920,6 +5920,8 @@ let
     inherit (gnome) gtkdoc;
   };
 
+  qt-mobility = callPackage ../development/libraries/qt-mobility {};
+
   qt_gstreamer = callPackage ../development/libraries/gstreamer/legacy/qt-gstreamer {};
 
   qt_gstreamer1 = callPackage ../development/libraries/gstreamer/qt-gstreamer { boost = boost156;};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7384,6 +7384,8 @@ let
 
   qwt6 = callPackage ../development/libraries/qwt/6.nix { };
 
+  qxt = callPackage ../development/libraries/qxt {};
+
   rabbitmq-c = callPackage ../development/libraries/rabbitmq-c {};
 
   rabbitmq-java-client = callPackage ../development/libraries/rabbitmq-java-client {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2645,6 +2645,10 @@ let
 
   screen-message = callPackage ../tools/X11/screen-message { };
 
+  screencloud = callPackage ../applications/graphics/screencloud {
+    quazip = quazip.override { qt = qt4; };
+  };
+
   scrot = callPackage ../tools/graphics/scrot { };
 
   scrolls = callPackage ../games/scrolls { };


### PR DESCRIPTION
Added a package for Screencloud, a program for taking screenshots and
uploading them to various websites.

This package was a bit finicky due to some nonsense in the CMakeLists
file, but it seems to work properly.

The package also includes API keys for the screencloud.net website.
According to the author of the Arch Linux User Repo package for
screencloud, these keys are only used for usage tracking, so we should
be fine including them in the package here.

I've also added a package for Qxt, and fixed the QtMobility package.
