### PR TITLE
oraclejdk: bump to 8u45, 7u79, and 7u80

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
-  patchVersion = "75";
+  patchVersion = "79";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
-  sha256_i686 = "173ppi5d90hllqgys90wlv596bpj2iw8gsbsr6pk7xvd4l1wdhrw";
-  sha256_x86_64 = "040n50nglr6rcli2pz5rd503c2qqdqqbqynp6hzc4kakkchmj2a6";
+  sha256_i686 = "1hv9bmj08y8gavhhkip5w5dg96b1dy4sc2cidpjcbwpb2mzh5lhs";
+  sha256_x86_64 = "140xl5kfdrlmh8wh2x3j23x53dbil8qxsvc7gf3138mz4805vmr9";
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";

--- a/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
-  patchVersion = "76";
+  patchVersion = "80";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
-  sha256_i686 = "0558p5garc4b5g7h11dkzn161kpk84az5ad1q5hhsblbx02aqff3";
-  sha256_x86_64 = "130ckrv846amyfzbnnd6skljkznc457yky7d6ajaw5ndsbzg93yf";
+  sha256_i686 = "1fjpm8pa74c4vgv93lnky6pd3igln56yxdn4kbhgcg12lwc17vcx";
+  sha256_x86_64 = "08wn62sammvsvlqac0n8grrikl0ykh9ikqdy823i2mcnccqsgnds";
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "40";
+  patchVersion = "45";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "9300846c8ced85d14b9dd8ec5ec379a0af982c589cf6d149ee09d972fe6729b0";
-  sha256_x86_64 = "da1ad819ce7b7ec528264f831d88afaa5db34b7955e45422a7e380b1ead6b04d";
+  sha256_i686 = "1y1zymydd1azv14r0hh12zjr8k64wa8wfdbz8sn1css84aqwl87d";
+  sha256_x86_64 = "0v9ilahx03isxdzh4ryv1bqmmzppckickz22hvgzs785769cm67j";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
Security fixes and other bug fixes. This will be the last Oracle JDK 7 publicly available update.
http://www.oracle.com/technetwork/java/javase/8u45-relnotes-2494160.html
http://www.oracle.com/technetwork/java/javase/7u79-relnotes-2494161.html
http://www.oracle.com/technetwork/java/javase/7u80-relnotes-2494162.html
