### PR TITLE
geoip: Install geolite database by default

### DIFF
--- a/pkgs/development/libraries/geoip/default.nix
+++ b/pkgs/development/libraries/geoip/default.nix
@@ -1,14 +1,23 @@
-{ stdenv, fetchurl }:
+# in geoipDatabase, you can insert a package defining ${geoipDatabase}/share/GeoIP
+# e.g. geolite-legacy
+{ stdenv, fetchurl, pkgs, drvName ? "geoip", geoipDatabase ? null }:
 
 let version = "1.6.2"; in
 
 stdenv.mkDerivation {
-  name = "geoip-${version}";
+  name = "${drvName}-${version}";
 
   src = fetchurl {
     url = "http://geolite.maxmind.com/download/geoip/api/c/GeoIP-${version}.tar.gz";
     sha256 = "0dd6si4cvip73kxdn43apg6yygvaf7dnk5awqfg9w2fd2ll0qnh7";
   };
+
+  postInstall = ''
+    DB=${toString geoipDatabase}
+    if [ -n "$DB" ]; then
+      ln -s $DB/share/GeoIP $out/share/GeoIP
+    fi
+  '';
 
   meta = {
     description = "Geolocation API";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5767,6 +5767,11 @@ let
 
   geoclue2 = callPackage ../development/libraries/geoclue/2.0.nix {};
 
+  geoipWithDatabase = makeOverridable (callPackage ../development/libraries/geoip) {
+    drvName = "geoip-tools";
+    geoipDatabase = geolite-legacy;
+  };
+
   geoip = callPackage ../development/libraries/geoip { };
 
   geoipjava = callPackage ../development/libraries/java/geoipjava { };


### PR DESCRIPTION
This makes the geoiplookup command work without special parameters and
it establishes a directory that is mentioned in the man page.
(/nix/store/_geoip_/share/GeoIP/)

@7c6f434c
