### PR TITLE
Upgrade backup/attic to 0.15

### DIFF
--- a/pkgs/tools/backup/attic/default.nix
+++ b/pkgs/tools/backup/attic/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchzip, python3Packages, openssl, acl }:
 
 python3Packages.buildPythonPackage rec {
-  name = "attic-0.14";
+  name = "attic-0.15";
   namePrefix = "";
 
   src = fetchzip {
     name = "${name}-src";
-    url = "https://github.com/jborg/attic/archive/0.14.tar.gz";
-    sha256 = "1ij99dmd571rvk3kz97vs7wbjj2pbbd54l310lydnwywxhqs8hrv";
+    url = "https://github.com/jborg/attic/archive/0.15.tar.gz";
+    sha256 = "0bing5zg82mwvdi27jl77ardw65zaq4996k4677gz2lq7p7b4gd7";
   };
 
   propagatedBuildInputs = with python3Packages;


### PR DESCRIPTION
A new version of attic was released, so I updated the nix copy.
