### PR TITLE
mu: 0.9.11 -> 0.9.12

### DIFF
--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -3,12 +3,12 @@
 , gtk3, webkit, libsoup, icu, withMug ? false /* doesn't build with current gtk3 */ }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.11";
+  version = "0.9.12";
   name = "mu-${version}";
 
   src = fetchurl {
     url = "https://github.com/djcb/mu/archive/v${version}.tar.gz";
-    sha256 = "01n1lzq4pfsm5pn932p948d1z55yqc7kkm1ifjxjchb3k8lr66fh";
+    sha256 = "1bxryacmas2llj68m2dv8dr1vwx8f5k2i2azh69jajkpqx7i4wdq";
   };
 
   buildInputs =


### PR DESCRIPTION
This release contains quite a few fixes & improvements. Works for me. Note that upstream didn't change the version string, so mu4e etc still report 0.9.11.

@the-kenny @antono 
