### PR TITLE
Fix lambdabot and related packages

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -216,6 +216,7 @@
       rdnssd = 188;
       ihaskell = 189;
       i2p = 190;
+      lambdabot = 191;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -409,6 +410,7 @@
       #rdnssd = 188; # unused
       ihaskell = 189;
       i2p = 190;
+      lambdabot = 191;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -273,6 +273,7 @@
   ./services/networking/iodined.nix
   ./services/networking/ircd-hybrid/default.nix
   ./services/networking/kippo.nix
+  ./services/networking/lambdabot.nix
   ./services/networking/mailpile.nix
   ./services/networking/minidlna.nix
   ./services/networking/mstpd.nix

--- a/nixos/modules/services/networking/lambdabot.nix
+++ b/nixos/modules/services/networking/lambdabot.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.lambdabot;
+
+  rc = builtins.toFile "script.rc" cfg.script;
+
+in
+
+{
+
+  ### configuration
+
+  options = {
+
+    services.lambdabot = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the Lambdabot IRC bot";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.lambdabot;
+        description = "Used lambdabot package";
+      };
+
+      script = mkOption {
+        type = types.str;
+        default = "";
+        description = "Lambdabot script";
+      };
+
+    };
+
+  };
+
+  ### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.services.lambdabot = {
+      description = "Lambdabot daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      # Workaround for https://github.com/lambdabot/lambdabot/issues/117
+      script = ''
+        mkdir -p ~/.lambdabot
+        cd ~/.lambdabot
+        exec ${cfg.package}/bin/lambdabot -e 'rc ${rc}'
+      '';
+      serviceConfig.User = "lambdabot";
+    };
+
+    users.extraUsers.lambdabot = {
+      group = "lambdabot";
+      description = "Lambdabot daemon user";
+      home = "/var/lib/lambdabot";
+      createHome = true;
+      uid = config.ids.uids.lambdabot;
+    };
+
+    users.extraGroups.lambdabot.gid = config.ids.gids.lambdabot;
+
+  };
+
+}

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -754,6 +754,14 @@ self: super: {
   # Patch to consider NIX_GHC just like xmonad does
   dyre = appendPatch super.dyre ./dyre-nix.patch;
 
+  # Fix problems with GHC >=7.8 (in compatible way)
+  mueval = let pkg = appendPatch super.mueval (pkgs.fetchpatch {
+                       url = "https://patch-diff.githubusercontent.com/raw/gwern/mueval/pull/4.patch";
+                       sha256 = "1l0jn2lbzbhx9ifbpb5g617qa0fc8fwa6kyr87pjqfxpqminsgp5";
+                     });
+           # Nix-specific workaround
+           in appendPatch pkg ./mueval-nix.patch;
+
 } // {
 
   # Not on Hackage.

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -298,4 +298,7 @@ self: super: {
             in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
                                           self.webkitgtk3-javascriptcore ];
 
+  # Fix evaluation in GHC >=7.8: https://github.com/lambdabot/lambdabot/issues/116
+  lambdabot = appendPatch super.lambdabot ./lambdabot-fix-ghc78.patch;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -125,4 +125,7 @@ self: super: {
             in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
                                           self.webkitgtk3-javascriptcore ];
 
+  # Fix evaluation in GHC >=7.8: https://github.com/lambdabot/lambdabot/issues/116
+  lambdabot = appendPatch super.lambdabot ./lambdabot-fix-ghc78.patch;
+
 }

--- a/pkgs/development/haskell-modules/lambdabot-fix-ghc78.patch
+++ b/pkgs/development/haskell-modules/lambdabot-fix-ghc78.patch
@@ -1,0 +1,22 @@
+diff -ru3 lambdabot-5.0.1.old/State/L.hs lambdabot-5.0.1/State/L.hs
+--- lambdabot-5.0.1.old/State/L.hs	2015-04-15 03:26:04.818947594 +0300
++++ lambdabot-5.0.1/State/L.hs	2015-04-15 03:26:20.386099365 +0300
+@@ -34,7 +34,6 @@
+ import Control.Monad
+ import Control.Monad.Cont
+ import Control.Monad.Identity
+-import Control.Monad.Instances
+ import Control.Monad.Reader
+ import Control.Monad.ST.Safe
+ import Control.Monad.State
+diff -ru3 lambdabot-5.0.1.old/State/Pristine.hs lambdabot-5.0.1/State/Pristine.hs
+--- lambdabot-5.0.1.old/State/Pristine.hs	2015-04-15 03:26:04.818947594 +0300
++++ lambdabot-5.0.1/State/Pristine.hs	2015-04-15 03:26:20.386099365 +0300
+@@ -34,7 +34,6 @@
+ import Control.Monad
+ import Control.Monad.Cont
+ import Control.Monad.Identity
+-import Control.Monad.Instances
+ import Control.Monad.Reader
+ import Control.Monad.ST.Safe
+ import Control.Monad.State

--- a/pkgs/development/haskell-modules/mueval-nix.patch
+++ b/pkgs/development/haskell-modules/mueval-nix.patch
@@ -1,0 +1,23 @@
+diff --git a/Mueval/Interpreter.hs b/Mueval/Interpreter.hs
+index 29b771f..6360ee3 100644
+--- a/Mueval/Interpreter.hs
++++ b/Mueval/Interpreter.hs
+@@ -8,6 +8,7 @@ import Control.Monad.Writer (Any(..),runWriterT,tell)
+ import Data.Char (isDigit)
+ import Data.List (stripPrefix)
+ import System.Directory (copyFile, makeRelativeToCurrentDirectory, removeFile, setCurrentDirectory)
++import System.Environment (lookupEnv)
+ import System.Exit (exitFailure)
+ import System.FilePath.Posix (takeFileName)
+ import qualified Control.Exception.Extensible as E (evaluate,catch,SomeException(..))
+@@ -47,6 +48,10 @@ interpreter Options { extensions = exts, namedExtensions = nexts,
+                                   -- Explicitly adding ImplicitPrelude because of
+                                   -- http://darcsden.com/jcpetruzza/hint/issue/1
+                                   unless (null lexts) $ set [languageExtensions := (UnknownExtension "ImplicitPrelude" : lexts)]
++                                  pkgs' <- liftIO $ lookupEnv "NIX_GHC_LIBDIR"
++                                  case pkgs' of
++                                    Just pkgs -> unsafeSetGhcOption ("-package-db " ++ pkgs ++ "/package.conf.d")
++                                    Nothing -> return ()
+                                   when trust $ do
+                                     unsafeSetGhcOption "-fpackage-trust"
+                                     forM_ (trustPkgs >>= words) $ \pkg ->

--- a/pkgs/development/tools/lambdabot/default.nix
+++ b/pkgs/development/tools/lambdabot/default.nix
@@ -1,0 +1,47 @@
+{ lib, makeWrapper, haskellngPackages
+, mueval
+, withDjinn ? true
+, aspell ? null
+, packages ? (pkgs: [])
+, modules ? ''
+    haskellPlugins
+    ++ ["irc", "localtime", "topic"]
+    ++ ["dummy", "fresh", "todo"]
+    ++ ["bf", "dice", "elite", "filter", "quote", "slap", "unlambda", "vixen"]
+    ++ referencePlugins
+    ++ socialPlugins
+''
+}:
+
+# FIXME: fix hoogle search
+
+let allPkgs = pkgs: mueval.defaultPkgs pkgs ++ [ pkgs.lambdabot-trusted ] ++ packages pkgs;
+    mueval' = mueval.override {
+      inherit haskellngPackages;
+      packages = allPkgs;
+    };
+    bins = lib.makeSearchPath "bin" ([ mueval'
+                                       (haskellngPackages.ghcWithPackages allPkgs)
+                                       haskellngPackages.unlambda
+                                       haskellngPackages.brainfuck
+                                     ]
+                                     ++ lib.optional withDjinn haskellngPackages.djinn
+                                     ++ lib.optional (aspell != null) aspell
+                                    );
+    modulesStr = lib.replaceChars ["\n"] [" "] ("corePlugins ++ " + modules);
+
+in lib.overrideDerivation haskellngPackages.lambdabot (self: {
+  postPatch = (self.postPatch or "") + ''
+    sed -i 's/\(\$(modules \$ \).*/\1@modules@)/; /@modules@/q' src/Modules.hs
+    # not via sed to avoid escaping issues
+    substituteInPlace src/Modules.hs \
+      --replace '@modules@' '${modulesStr}'
+  '';
+
+  buildInputs = self.buildInputs ++ [ makeWrapper ];
+
+  postInstall = (self.postInstall or "") + lib.optionalString (bins != "") ''
+    wrapProgram $out/bin/lambdabot \
+      --prefix PATH ":" '${bins}'
+  '';
+})

--- a/pkgs/development/tools/mueval/default.nix
+++ b/pkgs/development/tools/mueval/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, makeWrapper, haskellngPackages, packages ? (pkgs: [])
+}:
+
+let defaultPkgs = pkgs: [ pkgs.show
+                          pkgs.simple-reflect
+                          pkgs.QuickCheck
+                          pkgs.mtl
+                        ];
+    env = haskellngPackages.ghcWithPackages
+           (pkgs: defaultPkgs pkgs ++ packages pkgs);
+    libDir = "${env}/lib/ghc-${env.version}";
+
+in stdenv.mkDerivation {
+  name = "mueval-env";
+
+  inherit (haskellngPackages) mueval;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    
+    makeWrapper $mueval/bin/mueval $out/bin/mueval \
+      --prefix PATH ":" "$out/bin"
+
+    makeWrapper $mueval/bin/mueval-core $out/bin/mueval \
+      --set "NIX_GHC_LIBDIR" "${libDir}"
+
+  '';
+
+  passthru = { inherit defaultPkgs; };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7078,6 +7078,8 @@ let
     texinfo = texinfo4;
   };
 
+  mueval = callPackage ../development/tools/mueval { };
+
   muparser = callPackage ../development/libraries/muparser { };
 
   mygpoclient = callPackage ../development/python-modules/mygpoclient { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7415,6 +7415,8 @@ let
 
   readosm = callPackage ../development/libraries/readosm { };
 
+  lambdabot = callPackage ../development/tools/lambdabot { };
+
   leksah = callPackage ../development/tools/leksah {
     inherit (haskellngPackages) ghcWithPackages;
   };


### PR DESCRIPTION
This adds NixOS lambdabot service, `mueval` and `lambdabot` derivations which allow specifying options and fixes `mueval` and `lambdabot`'s Nix-specific issues.

Travis test.
