### PR TITLE
dropbox[-cli]: update to latest versions

### DIFF
--- a/pkgs/applications/networking/dropbox-cli/default.nix
+++ b/pkgs/applications/networking/dropbox-cli/default.nix
@@ -1,6 +1,6 @@
 { stdenv, pkgconfig, fetchurl, python, dropbox }:
 let
-  version = "2.10.0";
+  version = "2015.02.12";
   dropboxd = "${dropbox}/bin/dropbox";
 in
 stdenv.mkDerivation {
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://linux.dropbox.com/packages/nautilus-dropbox-${version}.tar.bz2";
-    sha256 = "0f765rpp357vy7zvn1jq6q48d10fi4v13yb7vv3qx3az3f3472lg";
+    sha256 = "12md01ymxsly1rdhdi2sw3aiwykd4y8z8isipc8mjfk8bbp55q86";
   };
 
   buildInputs = [ pkgconfig python ];

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -26,9 +26,9 @@ let
     else if stdenv.system == "i686-linux" then "ld-linux.so.2"
     else throw "Dropbox client for: ${stdenv.system} not supported!";
 
-  version = "3.2.9";
-  sha256 = if stdenv.system == "x86_64-linux" then "1w1xqizd4xhf9d3gwg9wwys2rdbacs390zf4a7z76m9h5r2lz049"
-    else if stdenv.system == "i686-linux" then "0lzrb0b7hi22ij7fmn7i3wkzbzv99858ah7w8ysg65za0c8qwksc"
+  version = "3.4.4";
+  sha256 = if stdenv.system == "x86_64-linux" then "05ncbxwkimq7cl3bad759qvda7zjdh07f5wh6aw12g472l4yqq98"
+    else if stdenv.system == "i686-linux" then "18089bh6i64yw75pswgn2vkcl1kf7ipxxncmssw3qhb6791qfhbk"
     else throw "Dropbox client for: ${stdenv.system} not supported!";
 
   # relative location where the dropbox libraries are stored

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -26,6 +26,7 @@ let
     else if stdenv.system == "i686-linux" then "ld-linux.so.2"
     else throw "Dropbox client for: ${stdenv.system} not supported!";
 
+  # NOTE: When updating, please also update in current stable, as older versions stop working  
   version = "3.4.4";
   sha256 = if stdenv.system == "x86_64-linux" then "05ncbxwkimq7cl3bad759qvda7zjdh07f5wh6aw12g472l4yqq98"
     else if stdenv.system == "i686-linux" then "18089bh6i64yw75pswgn2vkcl1kf7ipxxncmssw3qhb6791qfhbk"


### PR DESCRIPTION
dropbox: 3.2.9 - > 3.4.4
dropbox-cli: 2.10.0 -> 2015.02.12

These updates should also hit stable, since older versions of dropbox stop working.
Shall I file a pull request against release-14.12?

cc @the-kenny @ttuegel 
