### PR TITLE
plex: add support for managing plugins via Nix

### DIFF
--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -30,6 +30,30 @@ in
         default = "plex";
         description = "Group under which Plex runs.";
       };
+
+
+      managePlugins = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          If set to true, this option will cause all of the symlinks in Plex's
+          plugin directory to be removed and symlinks for paths specified in
+          <option>extraPlugins</option> to be added.
+        '';
+      };
+
+      extraPlugins = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          A list of paths to extra plugin bundles to install in Plex's plugin
+          directory. Every time the systemd unit for Plex starts up, all of the
+          symlinks in Plex's plugin directory will be cleared and this module
+          will symlink all of the paths specified here to that directory. If
+          this behavior is undesired, set <option>managePlugins</option> to
+          false.
+        '';
+      };
     };
   };
 
@@ -45,13 +69,48 @@ in
           mkdir -p "${cfg.dataDir}"
           chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}"
         }
+
         # Copy the database skeleton files to /var/lib/plex/.skeleton
+        # See the the Nix expression for Plex's package for more information on
+        # why this is done.
         test -d "${cfg.dataDir}/.skeleton" || mkdir "${cfg.dataDir}/.skeleton"
         for db in "com.plexapp.plugins.library.db"; do
             cp "${plex}/usr/lib/plexmediaserver/Resources/base_$db" "${cfg.dataDir}/.skeleton/$db"
             chmod u+w "${cfg.dataDir}/.skeleton/$db"
             chown ${cfg.user}:${cfg.group} "${cfg.dataDir}/.skeleton/$db"
         done
+
+        # If managePlugins is enabled, setup symlinks for plugins.
+        ${optionalString cfg.managePlugins ''
+          echo "Preparing plugin directory."
+          PLUGINDIR="${cfg.dataDir}/Plex Media Server/Plug-ins"
+          test -d "$PLUGINDIR" || {
+            mkdir -p "$PLUGINDIR";
+            chown ${cfg.user}:${cfg.group} "$PLUGINDIR";
+          }
+
+          echo "Removing old symlinks."
+          # First, remove all of the symlinks in the directory.
+          for f in `ls "$PLUGINDIR/"`; do
+            if [[ -L "$PLUGINDIR/$f" ]]; then
+              echo "Removing plugin symlink $PLUGINDIR/$f."
+              rm "$PLUGINDIR/$f"
+            fi
+          done
+
+          echo "Symlinking plugins."
+          for path in ${toString cfg.extraPlugins}; do
+            dest="$PLUGINDIR/$(basename $path)"
+            if [[ ! -d "$path" ]]; then
+              echo "Error symlinking plugin from $path: no such directory."
+            elif [[ -d "$dest" || -L "$dest" ]]; then
+              echo "Error symlinking plugin from $path to $dest: file or directory already exists."
+            else
+              echo "Symlinking plugin at $path..."
+              ln -s "$path" "$dest"
+            fi
+          done
+        ''}
      '';
       serviceConfig = {
         Type = "simple";


### PR DESCRIPTION
Added support for managing Plex Media Server plugins via Nix. This is done via an "extraPlugins" configuration option which takes a list of paths to plugin bundles, which are then symlinked into Plex's plugin directory when the service is started.
