### PR TITLE
ddclient: Fix capitalization of systemd unit keys

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -127,8 +127,8 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        # This may change back to forking if too many problems occur:
-        type = "simple";
+        # Uncomment this if too many problems occur:
+        # Type = "forking";
         User = ddclientUser;
         Group = "nogroup"; #TODO get this to work
         PermissionsStartOnly = "true";


### PR DESCRIPTION
This avoids the following warning:

```
Apr 19 10:53:48 xen systemd[1]: [/nix/store/...-unit-ddclient.service/ddclient.service:19] Unknown lvalue 'type' in section 'Service'
```

As `Type=simple` is the default in systemd, this shouldn't have any
functional changes.
