### PR TITLE
Bump SFML to version 2.2, and update MARS game

### DIFF
--- a/pkgs/development/libraries/sfml/default.nix
+++ b/pkgs/development/libraries/sfml/default.nix
@@ -1,26 +1,22 @@
-{ stdenv, fetchgit, cmake, mesa, libX11, freetype, libjpeg, openal, libsndfile
-, glew, libXrandr, libXrender
+{ stdenv, fetchurl, cmake, libX11, freetype, libjpeg, openal, libsndfile
+, glew, libXrandr, libXrender, udev
 }:
 stdenv.mkDerivation rec {
-  name = "sfml-git-20110428";
-  src = fetchgit {
-    url = "http://github.com/LaurentGomila/SFML.git";
-    rev = "6eac4256f3be353f51ee";
-    sha256 = "1b4f1901e0e482dbc0ad60e2821af766fb8ce093de51d678918ac2a0fb6e8587";
+  name = "sfml-2.2";
+  src = fetchurl {
+    url = "https://github.com/LaurentGomila/SFML/archive/2.2.tar.gz";
+    sha256 = "1xbpzkqwgbsjdda7n3c2z5m16bhppz1z9rbhmhb8r1im7s95hd2l";
   };
-  buildInputs = [ cmake mesa libX11 freetype libjpeg openal libsndfile glew
-                  libXrandr libXrender
+  buildInputs = [ cmake libX11 freetype libjpeg openal libsndfile glew
+                  libXrandr libXrender udev
                 ];
-  patchPhase = "
-    substituteInPlace CMakeLists.txt --replace '\${CMAKE_ROOT}/Modules' 'share/cmake-2.8/Modules'
-  ";
   meta = with stdenv.lib; {
     homepage = http://www.sfml-dev.org/;
     description = "Simple and fast multimedia library";
     longDescription = ''
-      SFML provides a simple interface to the various components of your PC, to
-      ease the development of games and multimedia applications. It is composed
-      of five modules: system, window, graphics, audio and network.
+      SFML is a simple, fast, cross-platform and object-oriented multimedia API.
+      It provides access to windowing, graphics, audio and network.
+      It is written in C++, and has bindings for various languages such as C, .Net, Ruby, Python.
     '';
     license = licenses.zlib;
     maintainers = [ maintainers.astsmtl ];

--- a/pkgs/games/mars/default.nix
+++ b/pkgs/games/mars/default.nix
@@ -1,12 +1,15 @@
-{ stdenv, fetchurl, cmake, mesa, sfml_git, fribidi, taglib }:
+{ stdenv, fetchgit, cmake, mesa, sfml, fribidi, taglib }:
 stdenv.mkDerivation rec {
-  name = "mars-${version}";
-  version = "0.7.2";
-  src = fetchurl {
-    url = "mirror://sourceforge/mars-game/mars_source_${version}.tar.gz";
-    sha256 = "092y0y1dghkvs0syjg9cv8iq0w29hkin8bznqc8sqm21v0swk451";
+  name = "mars-${version}-${rev}";
+  version = "0.7.5";
+  rev = "c855d04409";
+  src = fetchgit {
+    url = "https://github.com/thelaui/M.A.R.S..git";
+    inherit rev;
+    sha256 = "70fc4b5823f2efb03e0bcd3fe82dee88ee93ddfd81d53de0d7eb3fe02793d65e";
   };
-  buildInputs = [ cmake mesa sfml_git fribidi taglib ];
+  buildInputs = [ cmake mesa sfml fribidi taglib ];
+  patches = [ ./unbind_fix.patch ];
   installPhase = ''
     cd ..
     find -name '*.svn' -exec rm -rf {} \;

--- a/pkgs/games/mars/unbind_fix.patch
+++ b/pkgs/games/mars/unbind_fix.patch
@@ -1,0 +1,19 @@
+diff --git a/src/System/window.cpp b/src/System/window.cpp
+index e9a099a..e3f6de9 100644
+--- a/src/System/window.cpp
++++ b/src/System/window.cpp
+@@ -308,12 +308,12 @@ namespace window {
+         glEnable(GL_TEXTURE_2D);
+ 
+         if (shader)
+-            shader->bind();
++            sf::Shader::bind(shader);
+ 
+         window_.draw(toBeDrawn, states);
+ 
+         if (shader)
+-            shader->unbind();
++            sf::Shader::bind(NULL);
+ 
+         window_.popGLStates();
+         glPopMatrix();

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7527,7 +7527,7 @@ let
 
   simgear = callPackage ../development/libraries/simgear { };
 
-  sfml_git = callPackage ../development/libraries/sfml { };
+  sfml = callPackage ../development/libraries/sfml { };
 
   skalibs = callPackage ../development/libraries/skalibs { };
 


### PR DESCRIPTION
The version of SFML was really old, so I bumped it up to 2.2.

I kept the old "sfml_git" target for compatibility because it's used by some other derivations aswell. I changed the default.nix to 2.2, however.

(This is a retry after a fail on my part in #7451)
