### PR TITLE
ddclient: Force line buffering on stdout

### DIFF
--- a/pkgs/tools/networking/ddclient/ddclient-line-buffer-stdout.patch
+++ b/pkgs/tools/networking/ddclient/ddclient-line-buffer-stdout.patch
@@ -1,0 +1,20 @@
+diff -u ddclient-3.8.1/ddclient ddclient-3.8.1.patched/ddclient
+--- ddclient-3.8.1/ddclient	2011-07-11 23:04:21.000000000 +0200
++++ ddclient-3.8.1.patched/ddclient	2012-11-08 11:52:31.930647236 +0100
+@@ -19,6 +19,7 @@ use strict;
+ use Getopt::Long;
+ use Sys::Hostname;
+ use IO::Socket;
++use IO::Handle qw( );
+ 
+ my ($VERSION) = q$Revision: 157 $ =~ /(\d+)/;
+ 
+@@ -675,7 +676,7 @@ $SIG{'TERM'}   = sub { $caught_term = 1; };
+ $SIG{'KILL'}   = sub { $caught_kill = 1; };
+ # don't fork() if foreground or force is on
+ if (opt('foreground') || opt('force')) {
+-    ;
++    STDOUT->autoflush(1);
+ } elsif (opt('daemon')) {
+     $SIG{'CHLD'}   = 'IGNORE';
+     my $pid = fork;

--- a/pkgs/tools/networking/ddclient/default.nix
+++ b/pkgs/tools/networking/ddclient/default.nix
@@ -10,7 +10,7 @@ buildPerlPackage {
 
   buildInputs = [ perlPackages.IOSocketSSL perlPackages.DigestSHA1 ];
 
-  patches = [ ./ddclient-foreground.patch ];
+  patches = [ ./ddclient-foreground.patch ./ddclient-line-buffer-stdout.patch ];
 
   # Use iproute2 instead of ifconfig
   preConfigure = '' 


### PR DESCRIPTION
Status messages of ddclient go to stdout, which is block buffered by
default, so most of its output won't appear in the journal until it is
exiting:

```
-- Reboot --
Apr 19 11:31:04 xen systemd[1]: Starting Dynamic DNS Client...
Apr 19 11:31:04 xen systemd[1]: Started Dynamic DNS Client.
Apr 19 11:31:53 xen systemd[1]: Stopping Dynamic DNS Client...
Apr 19 11:31:53 xen ddclient[530]: === opt ====
Apr 19 11:31:53 xen ddclient[530]: opt{cache}                           : <undefined>
Apr 19 11:31:53 xen ddclient[530]: opt{cmd}                             : <undefined>
...
```

Fix this by adding a patch to set line buffering on stdout.
