### PR TITLE
mysql-5.1.x: add net-tools dependency

### DIFF
--- a/pkgs/servers/sql/mysql/5.1.x.nix
+++ b/pkgs/servers/sql/mysql/5.1.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ps, ncurses, zlib, perl, openssl }:
+{ stdenv, fetchurl, ps, ncurses, zlib, perl, openssl, net-tools }:
 
 # Note: zlib is not required; MySQL can use an internal zlib.
 

--- a/pkgs/servers/sql/mysql/5.1.x.nix
+++ b/pkgs/servers/sql/mysql/5.1.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ps, ncurses, zlib, perl, openssl, net-tools }:
+{ stdenv, fetchurl, ps, ncurses, zlib, perl, openssl, nettools }:
 
 # Note: zlib is not required; MySQL can use an internal zlib.
 


### PR DESCRIPTION
# problem

i see this error:

```
hostname: command not found
```

a lot.

here is a log from mysql:

```
Apr 15 16:12:28 nixcloud.io mysql-post-start[435]: MySQL daemon not yet started. Waiting for 1 second...
Apr 15 16:12:28 nixcloud.io mysqld[434]: /nix/store/7f9y837g7hckiiv7b280l1kd0j53ymr1-mysql-5.1.73/bin/mysqld: line 381: hostname: command not found
Apr 15 16:12:28 nixcloud.io mysqld[434]: 150415 16:12:28 mysqld_safe Logging to '/var/mysql/.err'.
Apr 15 16:12:28 nixcloud.io mysqld[434]: 150415 16:12:28 mysqld_safe Starting mysqld daemon with databases from /var/mysql
Apr 15 16:12:29 nixcloud.io systemd[1]: Started MySQL Server.
Apr 15 16:13:49 nixcloud.io systemd[1]: Stopping MySQL Server...
Apr 15 16:13:49 nixcloud.io mysqld[434]: 150415 16:13:49 mysqld_safe mysqld from pid file /run/mysqld/mysqld.pid ended
Apr 15 16:13:49 nixcloud.io systemd[1]: Starting MySQL Server...
Apr 15 16:13:49 nixcloud.io mysql-post-start[971]: MySQL daemon not yet started. Waiting for 1 second...
Apr 15 16:13:49 nixcloud.io mysqld[970]: /nix/store/7f9y837g7hckiiv7b280l1kd0j53ymr1-mysql-5.1.73/bin/mysqld: line 381: hostname: command not found
Apr 15 16:13:49 nixcloud.io mysqld[970]: 150415 16:13:49 mysqld_safe Logging to '/var/mysql/.err'.
Apr 15 16:13:49 nixcloud.io mysqld[970]: 150415 16:13:49 mysqld_safe Starting mysqld daemon with databases from /var/mysql
Apr 15 16:13:50 nixcloud.io systemd[1]: Started MySQL Server.
Apr 15 16:17:04 nixcloud.io systemd[1]: Stopping MySQL Server...
Apr 15 16:17:05 nixcloud.io systemd[1]: Stopped MySQL Server.
```

furthermore it would save errors for `hostname` into **/var/mysql/.err'** instead of **/var/mysql/myhostname.err'**.
# fix

le'ts add net-tools to the dependencies to fix this.
