### PR TITLE
/run/mysqld now 0755 (instead 0700)

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -176,11 +176,11 @@ in
                 touch /tmp/mysql_init
             fi
 
-            mkdir -m 0700 -p ${cfg.pidDir}
+            mkdir -m 0755 -p ${cfg.pidDir}
             chown -R ${cfg.user} ${cfg.pidDir}
 
             # Make the socket directory
-            mkdir -m 0700 -p /run/mysqld
+            mkdir -m 0755 -p /run/mysqld
             chown -R ${cfg.user} /run/mysqld
           '';
 


### PR DESCRIPTION
# prolog

marc weber added a 0700 default permission on the mysql socket and i don't know his motivations. maybe using 0755 as a default is not a good idea security wise? maybe i should put the wwwrun user also into the mysql group?

please think/discuss before hitting 'merge'.
# issue

not 100% sure why it worked previosly and why the more recent system fails but it might have something to do with my recent IPv6 adaption.

if i use 'localhost' as for mysql server host, instead of '127.0.0.1' inside the php scripts, for instance in mediawiki, the mysql database won't be usable:

```
(Can't contact the database server: Can't connect to local MySQL server through socket '/run/mysqld/mysqld.sock' (13 "Permission denied") (localhost))
```

mysql is available via ipv4 localhost and not via ipv6 at all:

```
netstat -tulpen | grep mysql
tcp        0      0 0.0.0.0:3306            0.0.0.0:*               LISTEN      84         21759      1935/mysqld 
```

ls -la /run/ | grep mysqld
drwx------  2 mysql root     80 Apr 20 14:26 mysqld
## ubuntu 14.04 default

```
$ ls -la /run/ | grep mysql
drwxr-xr-x  2 mysql      root         80 Mar 27 23:53 mysqld

$ ls -la /run/mysqld/
total 4
drwxr-xr-x  2 mysql root   80 Mar 27 23:53 .
drwxr-xr-x 29 root  root  900 Apr 20 14:40 ..
-rw-rw----  1 mysql mysql   5 Mar 27 23:53 mysqld.pid
srwxrwxrwx  1 mysql mysql   0 Mar 27 23:53 mysqld.sock
```
# fix

when i issue:

```
chmod 0755 /run/mysqld/
```

then the webapp in question starts to work immediately afterwards.
