### PR TITLE
Don't try to build BNFC-meta documentation.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -121,6 +121,7 @@ self: super: {
   # The Haddock phase fails for one reason or another.
   attoparsec-conduit = dontHaddock super.attoparsec-conduit;
   blaze-builder-conduit = dontHaddock super.blaze-builder-conduit;
+  BNFC-meta = dontHaddock super.BNFC-meta;
   bytestring-progress = dontHaddock super.bytestring-progress;
   comonads-fd = dontHaddock super.comonads-fd;
   comonad-transformers = dontHaddock super.comonad-transformers;


### PR DESCRIPTION
Don't build BNFC-meta documentation since it fails.

I've reported this to the package maintainer because there does not appear to be a public repository for BNFC-meta.
