### PR TITLE
Fix hash of eclipse_sdk_442_hash 32bit

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -298,7 +298,7 @@ in {
         };
       "i686-linux" = fetchurl {
           url = http://download.eclipse.org/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk.tar.gz;
-          sha256 = "9f4238ce9f887a1a57bbc6c6898e43357d14a6d74f59385327813c5e82aa735d";
+          sha256 = "1hacyjjwhhxi7r3xyhpqgjqpd5r0irw9bfkalz5s5l6shb0lq4i7";
         };
     };
   };


### PR DESCRIPTION
I tried to install https://github.com/NixOS/nixpkgs/pull/6648 on 14.12 32 bit, and got a hash error on the .tar.gz.  Full error: https://github.com/NixOS/nixpkgs/pull/6648#issuecomment-94870477
The odd thing is that neither of the hashes from the error are in the original .nix.

This PR builds and runs here.

I also don't understand how the hash of this PR can be of a different length, without a compiler error.
