### PR TITLE
Fix haskellng packages using ghc 7.6.3.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.6.x.nix
@@ -32,6 +32,7 @@ self: super: {
   template-haskell = null;
   time = null;
   unix = null;
+  xhtml = null;
 
   # transformers is not a core library for this compiler.
   transformers = self.transformers_0_4_3_0;


### PR DESCRIPTION
Again an issue with xhtml that was missing in
compiler specific configuration.

Actually mirrors what's done with 784.
