### PR TITLE
Rustc 1.0.0 beta2

### DIFF
--- a/pkgs/development/compilers/rustc/1.0.0-beta.nix
+++ b/pkgs/development/compilers/rustc/1.0.0-beta.nix
@@ -1,8 +1,8 @@
 { stdenv, callPackage }:
 callPackage ./makeRustcDerivation.nix {
-  shortVersion = "1.0.0-beta";
+  shortVersion = "1.0.0-beta.2";
   isRelease = true;
-  srcSha = "94248e30487723ac6f6c34a0db5a21085c0b1338e6a32bd12b159e1d2cd80451";
+  srcSha = "0wcpp6fg7cc75bj5b6dcz5dhgps6xw09n75qiapmd12qxjzj17wn";
   snapshotHashLinux686 = "1ef82402ed16f5a6d2f87a9a62eaa83170e249ec";
   snapshotHashLinux64 = "ef2154372e97a3cb687897d027fd51c8f2c5f349";
   snapshotHashDarwin686 = "0310b1a970f2da7e61770fd14dbbbdca3b518234";

--- a/pkgs/development/compilers/rustc/1.0.0-beta.nix
+++ b/pkgs/development/compilers/rustc/1.0.0-beta.nix
@@ -12,4 +12,5 @@ callPackage ./makeRustcDerivation.nix {
   patches = [
     ./patches/beta.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
+  configureFlags = [ "--release-channel=beta" ];
 }

--- a/pkgs/development/compilers/rustc/makeRustcDerivation.nix
+++ b/pkgs/development/compilers/rustc/makeRustcDerivation.nix
@@ -6,6 +6,7 @@
 , snapshotHashLinux686, snapshotHashLinux64
 , snapshotHashDarwin686, snapshotHashDarwin64
 , snapshotDate, snapshotRev
+, configureFlags ? []
 
 , patches
 }:
@@ -113,7 +114,8 @@ stdenv.mkDerivation {
     '' else "");
   };
 
-  configureFlags = [ "--enable-local-rust" "--local-rust-root=$snapshot" ]
+  configureFlags = configureFlags
+                ++ [ "--enable-local-rust" "--local-rust-root=$snapshot" ]
                 ++ stdenv.lib.optional (stdenv.cc ? clang) "--enable-clang";
 
   inherit patches;


### PR DESCRIPTION
This took not one, not two, but three successful builds to make sure it was working.

The first build worked, but because it was missing the proper flag, it was built as a nightly for the source instead of as a beta. This means that `#[feature(...)]` worked without error even though it shouldn't. Technically this affects the old revision too, but since it hasn't gone downstream to 'nixpkgs' or the 'unstable' channel, that shouldn't matter to much.

Then I added the configureFlags change and given my skill level with Nix, it is miraculous this worked the first time without problems. So, why did the build fail? It's because my VM ran out of disk space.

So, the third time, I ran nix-garbage-collect and then built again. It succeeded, and I sent in this PR.

Now, non-fatal, but I did see this a lot:

```
not an ELF executable
/nix/store/ns8vicm74rl50klsjjjy08mslwx2ffzs-rustc-1.0.0-beta.2/share/doc/rust/html/book/lifetimes.html
not an ELF executable
/nix/store/ns8vicm74rl50klsjjjy08mslwx2ffzs-rustc-1.0.0-beta.2/share/doc/rust/html/book/if-let.html
not an ELF executable
/nix/store/ns8vicm74rl50klsjjjy08mslwx2ffzs-rustc-1.0.0-beta.2/share/doc/rust/html/book/ufcs.html
not an ELF executable
/nix/store/ns8vicm74rl50klsjjjy08mslwx2ffzs-rustc-1.0.0-beta.2/share/doc/rust/html/book/crates-and-modules.html
not an ELF executable
/nix/store/ns8vicm74rl50klsjjjy08mslwx2ffzs-rustc-1.0.0-beta.2/share/doc/rust/html/book/ffi.html
not an ELF executable
/nix/store/ns8vicm74rl50klsjjjy08mslwx2ffzs-rustc-1.0.0-beta.2/share/doc/rust/html/FiraSans-Medium.woff
not an ELF executable
```

Can somebody who knows more about building code look into perhaps making this not happen? If I need to, I can open a new issue for it.
