### PR TITLE
androidEnv.platformTools: add /bin

### DIFF
--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -32,6 +32,12 @@ stdenv.mkDerivation {
             patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib $i
         done
     ''}
+
+    mkdir -p $out/bin
+    for i in adb fastboot
+    do
+        ln -sf $out/platform-tools/$i $out/bin/$i
+    done
   '';
   
   buildInputs = [ unzip ];


### PR DESCRIPTION
This allows one who just needs `adb` and `fastboot` (frequent need for those who flash their phones) to skip pulling the whole SDK. cc @svanderburg @MP2E (git blame)
