### PR TITLE
trace-cmd: Fix build by adding docbook_xsl dependency

### DIFF
--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, asciidoc, libxslt }:
+{ stdenv, fetchgit, asciidoc, docbook_xsl, libxslt }:
 
 stdenv.mkDerivation rec {
   name    = "trace-cmd-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ asciidoc libxslt ];
 
   configurePhase = "true";
-  buildPhase     = "make prefix=$out all doc";
+  buildPhase     = "make prefix=$out MANPAGE_DOCBOOK_XSL=${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl all doc";
   installPhase   = "make prefix=$out install install_doc";
 
   meta = {


### PR DESCRIPTION
Gets rid of this build error:

```
make -C /tmp/nix-build-trace-cmd-2.5.3.drv-0/trace-cmd/Documentation all
      ASCIIDOC            trace-cmd-hist.1.xsl
*********************************
** No docbook.xsl is installed **
** Can't make man pages        **
*********************************
Makefile:59: recipe for target '/tmp/nix-build-trace-cmd-2.5.3.drv-0/trace-cmd/Documentation/trace-cmd-hist.1' failed
```
