### PR TITLE
wait for filesystem before starting btsync; bump to new package version

### DIFF
--- a/nixos/modules/services/networking/btsync.nix
+++ b/nixos/modules/services/networking/btsync.nix
@@ -293,7 +293,7 @@ in
     systemd.services.btsync = with pkgs; {
       description = "Bittorrent Sync Service";
       wantedBy    = [ "multi-user.target" ];
-      after       = [ "network.target" ];
+      after       = [ "network.target" "local-fs.target" ];
       serviceConfig = {
         Restart   = "on-abort";
         UMask     = "0002";
@@ -305,7 +305,7 @@ in
 
     systemd.services."btsync@" = with pkgs; {
       description = "Bittorrent Sync Service for %i";
-      after       = [ "network.target" ];
+      after       = [ "network.target" "local-fs.target" ];
       serviceConfig = {
         Restart   = "on-abort";
         User      = "%i";

--- a/pkgs/applications/networking/bittorrentsync/2.0.x.nix
+++ b/pkgs/applications/networking/bittorrentsync/2.0.x.nix
@@ -5,18 +5,18 @@ let
     else if stdenv.system == "i686-linux" then "i386"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
 
-  sha256 = if stdenv.system == "x86_64-linux" then "cbce76f73f47c23d9073644504fa454976629450d008354bd8faef1bddf368fd"
-    else if stdenv.system == "i686-linux" then "d3e8583c8a54cbeb34ea3621daf0498316a959d944b30f24aa4e518a851ecdeb"
+  sha256 = if stdenv.system == "x86_64-linux" then "9e1427b7a6c6e960a378b97ac458ad53c445457ed0e5c8bf693f446597377b78"
+    else if stdenv.system == "i686-linux" then "4d446255ff6332da9a244737d6c20e7dcd32d24a8eaabffbaf73147e5898ed8f"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
 
   libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.libc ];
 in
 stdenv.mkDerivation rec {
   name = "btsync-${version}";
-  version = "2.0.93";
+  version = "2.0.105";
 
   src  = fetchurl {
-    url  = "http://syncapp.bittorrent.com/${version}/btsync_${arch}-${version}.tar.gz";
+    url  = "https://download-cdn.getsyncapp.com/${version}/linux-${arch}/BitTorrent-Sync_${arch}.tar.gz";
     inherit sha256;
   };
 


### PR DESCRIPTION
If btsync starts before it's home dir is mounted, it will generate a new system ID and forget everything.

Also bump the version of btsync2 in use to the latest version (including the new change to canonical urls)
