### PR TITLE
patch Qt 5.4.1 to use XDG_CONFIG_DIRS in QSettings

### DIFF
--- a/pkgs/development/libraries/qt-5/5.4/0013-xdg_config_dirs.patch
+++ b/pkgs/development/libraries/qt-5/5.4/0013-xdg_config_dirs.patch
@@ -1,0 +1,42 @@
+diff --git a/qsettings.cpp b/qsettings.cpp
+index 35b3ed4..210dfeb 100644
+--- a/qsettings.cpp
++++ b/qtbase/src/corelib/io/qsettings.cpp
+@@ -1174,6 +1174,24 @@ QConfFileSettingsPrivate::QConfFileSettingsPrivate(QSettings::Format format,
+     if (!application.isEmpty())
+         confFiles[F_System | F_Application].reset(QConfFile::fromName(systemPath + appFile, false));
+     confFiles[F_System | F_Organization].reset(QConfFile::fromName(systemPath + orgFile, false));
++
++#if !defined(Q_OS_WIN)
++    // Add directories specified in $XDG_CONFIG_DIRS
++    const QString pathEnv = QString::fromLocal8Bit(getenv("XDG_CONFIG_DIRS"));
++    if (!pathEnv.isEmpty()) {
++        const QStringList pathEntries = pathEnv.split(QLatin1Char(':'), QString::SkipEmptyParts);
++        if (!pathEntries.isEmpty()) {
++            int j = 4; // This is the number of confFiles set above -- we need to start adding $XDG_CONFIG_DIRS after those.
++            for (int k = 0; k < pathEntries.size() && j < NumConfFiles - 1; ++k) {
++                const QString& path = pathEntries.at(k);
++                if (!application.isEmpty())
++                    confFiles[j++].reset(QConfFile::fromName(path + QDir::separator() + appFile, false));
++                confFiles[j++].reset(QConfFile::fromName(path + QDir::separator() + orgFile, false));
++            }
++        }
++    }
++#endif
++
+ #else
+     QString confName = getPath(format, QSettings::UserScope) + org;
+     if (!application.isEmpty())
+diff --git a/qsettings_p.h b/qsettings_p.h
+index a28b583..b2a240d 100644
+--- a/qsettings_p.h
++++ b/qtbase/src/corelib/io/qsettings_p.h
+@@ -244,7 +244,7 @@ public:
+         F_Organization = 0x1,
+         F_User = 0x0,
+         F_System = 0x2,
+-        NumConfFiles = 4
++        NumConfFiles = 40 // HACK: increase NumConfFiles from 4 to 40 in order to accommodate more paths in $XDG_CONFIG_DIRS -- ellis
+ #else
+         SandboxConfFile = 0,
+         NumConfFiles = 1

--- a/pkgs/development/libraries/qt-5/5.4/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/5.4/qtbase.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation {
       (substituteAll { src = ./0010-dlopen-libXcursor.patch; inherit libXcursor; })
       (substituteAll { src = ./0011-dlopen-openssl.patch; inherit openssl; })
       (substituteAll { src = ./0012-dlopen-dbus.patch; dbus_libs = dbus; })
+      ./0013-xdg_config_dirs.patch
     ];
 
   preConfigure = ''


### PR DESCRIPTION
This is a little hack to let QSettings use the directories in $XDG_CONFIG_DIRS. Currently, QSettings only checks $XDG_CONFIG_HOME and /nix/store/_-qt-5_/etc/xdg. This is a problem, because it means that Qt software can't find system-wide configuration files. As an example, it blocked me from adding lxqt expressions, because lxqt can't run without the system-wide configuration files.

It's not a pretty hack, but it's minimal, so I'm quite confident that it doesn't introduce any bugs. I'll try to submit a more elegant (but much larger) patch upstream, where I can get feedback from people who can evaluate for possible side-effects.

(This originally came from a different pull request based off of master, but my git-foo was too weak to properly switch that patch to the 'staging' branch, as request by @ttuegel)
