### PR TITLE
Add jython

### DIFF
--- a/pkgs/development/interpreters/jython/default.nix
+++ b/pkgs/development/interpreters/jython/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  name = "jython-${version}";
+
+  version = "2.7-rc3";
+
+  src = fetchurl {
+    url = "http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/${version}/jython-standalone-${version}.jar";
+    sha256 = "89fcaf53f1bda6124f836065c1e318e2e853d5a9a1fbf0e96a387c6d38828c78";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+     mkdir -pv $out/bin
+     cp $src $out/jython.jar
+     makeWrapper ${jre}/bin/java $out/bin/jython --add-flags "-jar $out/jython.jar"
+  '';
+
+  meta = {
+    description = "Python interpreter written in Java";
+    homepage = http://jython.org/;
+    license = stdenv.lib.licenses.psfl;
+    platforms = jre.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4793,6 +4793,8 @@ let
   jdtsdk = callPackage ../development/eclipse/jdt-sdk { };
 
   jruby165 = callPackage ../development/interpreters/jruby { };
+  
+  jython = callPackage ../development/interpreters/jython {};
 
   guileCairo = callPackage ../development/guile-modules/guile-cairo { };
 


### PR DESCRIPTION
jython 2.7-rc3 has been released a couple days ago

This works, but I haven't been able to get virtualenv running with it, but it should be compatible.
Maybe the builtin support for pip/setuptools requires the normal installation and not the standalone jar, in that case this package would need to be improved.
