### PR TITLE
bedrock: fix install phase

### DIFF
--- a/pkgs/development/coq-modules/bedrock/default.nix
+++ b/pkgs/development/coq-modules/bedrock/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     COQLIB=$out/lib/coq/${coq.coq-version}/
     mkdir -p $COQLIB/user-contrib/Bedrock
-    cp -pR src/* $COQLIB/user-contrib/Bedrock
+    cp -R src/* $COQLIB/user-contrib/Bedrock
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
When using the current master version, I get the following error message:

``` coq
Coq < Require Import Bedrock.
Error: The file /nix/store/.../lib/coq/8.4/user-contrib/Bedrock/src/Bedrock.vo contains library
Bedrock.Bedrock and not library Bedrock.src.Bedrock
```

This patch removes the extra `src` directory so that the library path matches the file path.

cc @jwiegley  maintainer
