### PR TITLE
nixos/docker: set extraOptions to separatedString type

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -45,7 +45,7 @@ in
       };
     extraOptions =
       mkOption {
-        type = types.str;
+        type = types.separatedString " ";
         default = "";
         description =
           ''


### PR DESCRIPTION
This change is needed if you want to pass extraOptions to docker in multiple
nixos modules.
