### PR TITLE
curl: ldap and libidn support as `curlFull`

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -1,4 +1,6 @@
 { stdenv, fetchurl
+, idnSupport ? false, libidn ? null
+, ldapSupport ? false, openldap ? null
 , zlibSupport ? false, zlib ? null
 , sslSupport ? false, openssl ? null
 , scpSupport ? false, libssh2 ? null
@@ -6,6 +8,8 @@
 , c-aresSupport ? false, c-ares ? null
 }:
 
+assert idnSupport -> libidn != null;
+assert ldapSupport -> openldap != null;
 assert zlibSupport -> zlib != null;
 assert sslSupport -> openssl != null;
 assert scpSupport -> libssh2 != null;
@@ -23,11 +27,14 @@ stdenv.mkDerivation rec {
   # "-lz -lssl", which aren't necessary direct build inputs of
   # applications that use Curl.
   propagatedBuildInputs = with stdenv.lib;
+    optional idnSupport libidn ++
+    optional ldapSupport openldap ++
     optional zlibSupport zlib ++
     optional gssSupport gss ++
     optional c-aresSupport c-ares ++
     optional sslSupport openssl ++
     optional scpSupport libssh2;
+
 
   # for the second line see http://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''
@@ -43,6 +50,9 @@ stdenv.mkDerivation rec {
   configureFlags = [
       ( if sslSupport then "--with-ssl=${openssl}" else "--without-ssl" )
       ( if scpSupport then "--with-libssh2=${libssh2}" else "--without-libssh2" )
+      ( if ldapSupport then "--enable-ldap" else "--disable-ldap" )
+      ( if ldapSupport then "--enable-ldaps" else "--disable-ldaps" )
+      ( if idnSupport then "--with-libidn=${libidn}" else "--without-libidn" )
     ]
     ++ stdenv.lib.optional c-aresSupport "--enable-ares=${c-ares}"
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${gss}";

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     optional sslSupport openssl ++
     optional scpSupport libssh2;
 
-
   # for the second line see http://curl.haxx.se/mail/tracker-2014-03/0087.html
   preConfigure = ''
     sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1050,6 +1050,12 @@ let
 
   cudatoolkit = cudatoolkit5;
 
+  curlFull = curl.override {
+    idnSupport = true;
+    ldapSupport = true;
+    gssSupport = true;
+  };
+
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
     zlibSupport = true;
@@ -10227,7 +10233,7 @@ let
   };
 
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
-  
+
   dd-agent = callPackage ../tools/networking/dd-agent { inherit (pythonPackages) tornado; };
 
   deadbeef = callPackage ../applications/audio/deadbeef {


### PR DESCRIPTION
This fixes some of #7248.

Before:

```
% nix-env -f $HOME/packages/nixpkgs -iA curl
replacing old ‘curl-7.41.0’
installing ‘curl-7.41.0’

% curl -u : --negotiate -I https://example.com
curl: option --negotiate: the installed libcurl version doesn't support this
curl: try 'curl --help' for more information

```

After:

```
% nix-env -f $HOME/packages/nixpkgs -iA curlFull
replacing old ‘curl-7.41.0’
installing ‘curl-7.41.0’

% curl -u : --negotiate -I https://example.com
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=604800
Content-Type: text/html
Date: Sat, 25 Apr 2015 19:09:20 GMT
Etag: "359670651"
Expires: Sat, 02 May 2015 19:09:20 GMT
Last-Modified: Fri, 09 Aug 2013 23:54:35 GMT
Server: ECS (rhv/8199)
X-Cache: HIT
x-ec-custom-error: 1
Content-Length: 1270

```

Comments or suggestions are welcome.
