### PR TITLE
boost: use ${python.interpreter} rather than ${python}/bin/python

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation {
   configureScript = "./bootstrap.sh";
   configureFlags = commonConfigureFlags ++ [
     "--with-icu=${icu}"
-    "--with-python=${python}/bin/python"
+    "--with-python=${python.interpreter}"
   ] ++ optional (toolset != null) "--with-toolset=${toolset}";
 
   buildPhase = builder nativeB2Args;


### PR DESCRIPTION
Without this patch, the `boost_python` library fails to build against python 3.
