### PR TITLE
curl: ldap and libidn support as `curlFull`

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -1,4 +1,6 @@
 { stdenv, fetchurl
+, idnSupport ? false, libidn ? null
+, ldapSupport ? false, openldap ? null
 , zlibSupport ? false, zlib ? null
 , sslSupport ? false, openssl ? null
 , scpSupport ? false, libssh2 ? null
@@ -6,6 +8,8 @@
 , c-aresSupport ? false, c-ares ? null
 }:
 
+assert idnSupport -> libidn != null;
+assert ldapSupport -> openldap != null;
 assert zlibSupport -> zlib != null;
 assert sslSupport -> openssl != null;
 assert scpSupport -> libssh2 != null;
@@ -23,6 +27,8 @@ stdenv.mkDerivation rec {
   # "-lz -lssl", which aren't necessary direct build inputs of
   # applications that use Curl.
   propagatedBuildInputs = with stdenv.lib;
+    optional idnSupport libidn ++
+    optional ldapSupport openldap ++
     optional zlibSupport zlib ++
     optional gssSupport gss ++
     optional c-aresSupport c-ares ++
@@ -43,6 +49,9 @@ stdenv.mkDerivation rec {
   configureFlags = [
       ( if sslSupport then "--with-ssl=${openssl}" else "--without-ssl" )
       ( if scpSupport then "--with-libssh2=${libssh2}" else "--without-libssh2" )
+      ( if ldapSupport then "--enable-ldap" else "--disable-ldap" )
+      ( if ldapSupport then "--enable-ldaps" else "--disable-ldaps" )
+      ( if idnSupport then "--with-libidn=${libidn}" else "--without-libidn" )
     ]
     ++ stdenv.lib.optional c-aresSupport "--enable-ares=${c-ares}"
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${gss}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1050,6 +1050,12 @@ let
 
   cudatoolkit = cudatoolkit5;
 
+  curlFull = curl.override {
+    idnSupport = true;
+    ldapSupport = true;
+    gssSupport = true;
+  };
+
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
     zlibSupport = true;


### PR DESCRIPTION
This fixes some of #7248.

Before:

```
% nix-env -f $HOME/packages/nixpkgs -iA curl
replacing old ‘curl-7.41.0’
installing ‘curl-7.41.0’
building path(s) ‘/nix/store/3myngzra088pf24wlnjhkh9032lkc50a-user-environment’
created 1943 symlinks in user environment

% curl -u : --negotiate -I https://example.com
curl: option --negotiate: the installed libcurl version doesn't support this
curl: try 'curl --help' for more information
```

After:

```
% nix-env -f $HOME/packages/nixpkgs -iA curlFull
replacing old ‘curl-7.41.0’
installing ‘curl-7.41.0’

% curl -u : --negotiate -I https://example.com
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: max-age=604800
Content-Type: text/html
Date: Sun, 26 Apr 2015 03:59:59 GMT
Etag: "359670651"
Expires: Sun, 03 May 2015 03:59:59 GMT
Last-Modified: Fri, 09 Aug 2013 23:54:35 GMT
Server: ECS (cpm/F845)
X-Cache: HIT
x-ec-custom-error: 1
Content-Length: 1270

```

Comments or suggestions are welcome.
