### PR TITLE
Issue #7584 Kafka Log Directory Not Writeable

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
     # allow us the specify logging directory using env
     substituteInPlace $out/bin/kafka-run-class.sh \
-      --replace 'LOG_DIR=$base_dir/logs' 'LOG_DIR=$KAFKA_LOG_DIR'
+      --replace 'LOG_DIR="$base_dir/logs"' 'LOG_DIR="$KAFKA_LOG_DIR"'
 
     for p in $out/bin\/*.sh; do
       wrapProgram $p \


### PR DESCRIPTION
Fix quotes in substitution so LOG_DIR is set to a writeable location.

Reproduced error from #7584 with this no error and verified log is written to location:
$ /nix/store/yh8hdd378j1gaaq73gk88ca7gzf590vg-apache-kafka-2.10-0.8.2.1/bin/kafka-server-start.sh /nix/store/yh8hdd378j1gaaq73gk88ca7gzf590vg-apache-kafka-2.10-0.8.2.1/config/server.properties  
[2015-04-26 19:56:25,370] INFO Verifying properties (kafka.utils.VerifiableProperties)
[2015-04-26 19:56:25,413] INFO Property broker.id is overridden to 0 (kafka.utils.VerifiableProperties)

$ ls /tmp/apache-kafka-logs
total 12  
238378449 0 controller.log     238353137 4 kafkaServer-gc.log  238378450 8 server.log
238378448 0 kafka-request.log  238378451 0 log-cleaner.log     238378452 0 state-change.log
