### PR TITLE
dvdisaster: Apply debian's patches, fix desktop file and icons

### DIFF
--- a/pkgs/tools/cd-dvd/dvdisaster/default.nix
+++ b/pkgs/tools/cd-dvd/dvdisaster/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, which, gettext, intltool
 , glib, gtk2
+, enableSoftening ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +10,11 @@ stdenv.mkDerivation rec {
     url = "http://dvdisaster.net/downloads/${name}.tar.bz2";
     sha256 = "e9787dea39aeafa38b26604752561bc895083c17b588489d857ac05c58be196b";
   };
+
+  patches = stdenv.lib.optional enableSoftening [
+    ./encryption.patch
+    ./dvdrom.patch
+  ];
 
   postPatch = ''
     patchShebangs ./
@@ -22,11 +28,17 @@ stdenv.mkDerivation rec {
     glib gtk2
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://dvdisaster.net/;
-    description =
-      "Stores data on CD/DVD/BD in a way that it is fully recoverable even " +
-      "after some read errors have developed";
-    license = stdenv.lib.licenses.gpl2;
+    description = "data loss/scratch/aging protection for CD/DVD media";
+    longDescription = ''
+      dvdisaster provides a margin of safety against data loss on CD and
+      DVD media caused by scratches or aging media. It creates error correction
+      data which is used to recover unreadable sectors if the disc becomes
+      damaged at a later time.
+    '';
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jgeerds ];
   };
 }

--- a/pkgs/tools/cd-dvd/dvdisaster/default.nix
+++ b/pkgs/tools/cd-dvd/dvdisaster/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs ./
+    sed -i 's/dvdisaster48.png/dvdisaster/' contrib/dvdisaster.desktop
   '';
 
   # Explicit --docdir= is required for on-line help to work:
@@ -27,6 +28,16 @@ stdenv.mkDerivation rec {
     pkgconfig which gettext intltool
     glib gtk2
   ];
+
+  postInstall = ''
+    mkdir -pv $out/share/applications
+    cp contrib/dvdisaster.desktop $out/share/applications/
+
+    for size in 16 24 32 48 64; do
+      mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps/
+      cp contrib/dvdisaster"$size".png $out/share/icons/hicolor/"$size"x"$size"/apps/dvdisaster.png
+    done
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://dvdisaster.net/;

--- a/pkgs/tools/cd-dvd/dvdisaster/dvdrom.patch
+++ b/pkgs/tools/cd-dvd/dvdisaster/dvdrom.patch
@@ -1,0 +1,19 @@
+Author: Corey Wright <undefined@pobox.com>
+Description: Adds support for DVD-ROM medium-type.
+
+Index: dvdisaster/scsi-layer.c
+===================================================================
+--- dvdisaster.orig/scsi-layer.c	2012-03-06 11:10:17.147044691 +0900
++++ dvdisaster/scsi-layer.c	2012-03-06 11:10:30.927044292 +0900
+@@ -913,6 +913,11 @@
+ 	    break;
+ 	 }
+ 
++	 if(layer_type & 0x01)
++	 {  dh->typeDescr = g_strdup("DVD-ROM");
++	    break;
++	 }
++
+ 	 if(layer_type & 0x06) /* strange thing: (re-)writeable but neither plus nor dash */ 
+ 	 {  dh->typeDescr = g_strdup("DVD-ROM (fake)");
+ 	    dh->subType = DVD;

--- a/pkgs/tools/cd-dvd/dvdisaster/encryption.patch
+++ b/pkgs/tools/cd-dvd/dvdisaster/encryption.patch
@@ -1,0 +1,21 @@
+Author: n/a
+Description: Disables to skip on encrypted disks (e.g. DVD with CSS-Encryption).
+
+Index: dvdisaster/scsi-layer.c
+===================================================================
+--- dvdisaster.orig/scsi-layer.c	2012-04-08 21:51:10.995588783 +0900
++++ dvdisaster/scsi-layer.c	2012-04-08 21:51:29.259678075 +0900
+@@ -2693,11 +2693,12 @@
+        	 return NULL;
+       }
+    }
+-
++/*
+    if(dh->mainType == DVD && query_copyright(dh))
+    {  CloseDevice(dh);
+       Stop(_("This software does not support encrypted media.\n"));
+    }
++*/
+ 
+    /* Create the bitmap of simulated defects */
+ 


### PR DESCRIPTION
This PR makes it possible to build dvdisaster with Debian's patches and enable it by default. I find these patches very useful because they let you backup DVD-ROMs and encrypted DVDs. Apart from that I updated the meta attributes and add a desktop file.

Any suggestions for a better name? I think `enableSoftening` isn't the best name for it
