### PR TITLE
gnome3.16: new dconf-editor package

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -132,53 +132,8 @@ in {
     environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules"
                                                 "${gnome3.glib_networking}/lib/gio/modules"
                                                 "${gnome3.gvfs}/lib/gio/modules" ];
-    environment.systemPackages =
-      [ pkgs.desktop_file_utils
-        gnome3.glib_networking
-        gnome3.gtk3 # for gtk-update-icon-cache
-        pkgs.ibus
-        pkgs.shared_mime_info # for update-mime-database
-        gnome3.gvfs
-        gnome3.dconf
-        gnome3.gnome-backgrounds
-        gnome3.gnome_control_center
-        gnome3.gnome-menus
-        gnome3.gnome_settings_daemon
-        gnome3.gnome_shell
-        gnome3.gnome_themes_standard
-        gnome3.defaultIconTheme
-      ] ++ cfg.sessionPath ++ (removePackagesByName [
-        gnome3.baobab
-        gnome3.empathy
-        gnome3.eog
-        gnome3.epiphany
-        gnome3.evince
-        gnome3.gucharmap
-        gnome3.nautilus
-        gnome3.totem
-        gnome3.vino
-        gnome3.yelp
-        gnome3.gnome-bluetooth
-        gnome3.gnome-calculator
-        gnome3.gnome-contacts
-        gnome3.gnome-font-viewer
-        gnome3.gnome-screenshot
-        gnome3.gnome-shell-extensions
-        gnome3.gnome-system-log
-        gnome3.gnome-system-monitor
-        gnome3.gnome_terminal
-        gnome3.gnome-user-docs
-
-        gnome3.bijiben
-        gnome3.evolution
-        gnome3.file-roller
-        gnome3.gedit
-        gnome3.gnome-clocks
-        gnome3.gnome-music
-        gnome3.gnome-tweak-tool
-        gnome3.gnome-photos
-        gnome3.nautilus-sendto
-      ] config.environment.gnome3.excludePackages);
+    environment.systemPackages = gnome3.corePackages ++ cfg.sessionPath
+      ++ (removePackagesByName gnome3.optionalPackages config.environment.gnome3.excludePackages);
 
     # Use the correct gnome3 packageSet
     networking.networkmanager.basePackages =

--- a/pkgs/desktops/gnome-3/3.12/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/default.nix
@@ -1,6 +1,24 @@
 { callPackage, pkgs }:
 
 rec {
+  corePackages = with gnome3; [
+    pkgs.desktop_file_utils pkgs.ibus
+    pkgs.shared_mime_info # for update-mime-database
+    gtk3 # for gtk-update-icon-cache
+    glib_networking gvfs dconf gnome-backgrounds gnome_control_center
+    gnome-menus gnome_settings_daemon gnome_shell
+    gnome_themes_standard defaultIconTheme
+  ];
+
+  optionalPackages = with gnome3; [ baobab empathy eog epiphany evince
+    gucharmap nautilus totem vino yelp gnome-bluetooth
+    gnome-calculator gnome-contacts gnome-font-viewer gnome-screenshot
+    gnome-shell-extensions gnome-system-log gnome-system-monitor
+    gnome_terminal gnome-user-docs bijiben evolution file-roller gedit
+    gnome-clocks gnome-music gnome-tweak-tool gnome-photos
+    nautilus-sendto
+  ];
+
   inherit (pkgs) glib gtk2 gtk3 gnome2;
   gnome3 = pkgs.gnome3_12 // { recurseForDerivations = false; };
 

--- a/pkgs/desktops/gnome-3/3.16/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/dconf-editor/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, vala, libxslt, pkgconfig, glib, dbus_glib, gnome3
+, libxml2, intltool, docbook_xsl_ns, docbook_xsl, makeWrapper }:
+
+let
+  majorVersion = "3.16";
+in
+stdenv.mkDerivation rec {
+  name = "dconf-editor-${version}";
+  version = "${majorVersion}.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/dconf-editor/${majorVersion}/${name}.tar.xz";
+    sha256 = "0vl5ygbh8blbk3710w34lmhxxl4g275vzpyhjsq0016c597isp88";
+  };
+
+  buildInputs = [ vala libxslt pkgconfig glib dbus_glib gnome3.gtk libxml2
+                  intltool docbook_xsl docbook_xsl_ns makeWrapper gnome3.dconf ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/dconf-editor" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    platforms = platforms.linux;
+    maintainers = [ maintainers.lethalman ];
+  };
+}

--- a/pkgs/desktops/gnome-3/3.16/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/dconf/default.nix
@@ -16,13 +16,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ vala libxslt pkgconfig glib dbus_glib gnome3.gtk libxml2
                   intltool docbook_xsl docbook_xsl_ns makeWrapper ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/dconf-editor" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
-    rm $out/lib/gio/modules/giomodule.cache
-  '';
-
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     maintainers = [ maintainers.lethalman ];

--- a/pkgs/desktops/gnome-3/3.16/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/default.nix
@@ -1,6 +1,24 @@
 { callPackage, pkgs, self }:
 
 rec {
+  corePackages = with gnome3; [
+    pkgs.desktop_file_utils pkgs.ibus
+    pkgs.shared_mime_info # for update-mime-database
+    gtk3 # for gtk-update-icon-cache
+    glib_networking gvfs dconf gnome-backgrounds gnome_control_center
+    gnome-menus gnome_settings_daemon gnome_shell
+    gnome_themes_standard defaultIconTheme
+  ];
+
+  optionalPackages = with gnome3; [ baobab empathy eog epiphany evince
+    gucharmap nautilus totem vino yelp gnome-bluetooth
+    gnome-calculator gnome-contacts gnome-font-viewer gnome-screenshot
+    gnome-shell-extensions gnome-system-log gnome-system-monitor
+    gnome_terminal gnome-user-docs bijiben evolution file-roller gedit
+    gnome-clocks gnome-music gnome-tweak-tool gnome-photos
+    nautilus-sendto
+  ];
+
   inherit (pkgs) libsoup glib gtk2;
   inherit (pkgs.gnome2) ORBit2;
   gtk3 = pkgs.gtk3_16;

--- a/pkgs/desktops/gnome-3/3.16/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/default.nix
@@ -16,7 +16,7 @@ rec {
     gnome-shell-extensions gnome-system-log gnome-system-monitor
     gnome_terminal gnome-user-docs bijiben evolution file-roller gedit
     gnome-clocks gnome-music gnome-tweak-tool gnome-photos
-    nautilus-sendto
+    nautilus-sendto dconf-editor
   ];
 
   inherit (pkgs) libsoup glib gtk2;
@@ -66,6 +66,7 @@ rec {
   caribou = callPackage ./core/caribou { };
 
   dconf = callPackage ./core/dconf { };
+  dconf-editor = callPackage ./core/dconf-editor { };
 
   empathy = callPackage ./core/empathy { 
     webkitgtk = webkitgtk24x;


### PR DESCRIPTION
`dconf-editor` used to ship with the `dconf` package, but not any more. This PR pulls the definition of the package sets from the gnome3 module into the package itself, so that definitions of package sets may vary for different gnome versions. Then it adds the new `dconf-editor` package.

This is based on the recent gnome316 work by @lethalman , which got merged to staging and seems not to be in master yet, so I based the PR on current staging.
