### PR TITLE
nixos: fix infinite recursion in isoImage.isoName

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -105,7 +105,7 @@ in
   options = {
 
     isoImage.isoName = mkOption {
-      default = "${config.isoImage.isoName}.iso";
+      default = "${config.isoImage.isoBaseName}.iso";
       description = ''
         Name of the generated ISO image file.
       '';


### PR DESCRIPTION
`config.isoImage.isoName` was defined in terms of itself, whereas I think it was meant to be:

``` nix
"${config.isoImage.isoBaseName}.iso"
```
