### PR TITLE
Fix nixos-install when running outside NixOS.

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -254,8 +254,14 @@ NIXOS_INSTALL_GRUB=1 chroot $mountPoint \
 chroot $mountPoint /nix/var/nix/profiles/system/activate
 
 
+# Some systems may not be prepared to use NixOS' paths.
+export PATH=/run/current-system/sw/bin:/run/current-system/sw/sbin:$PATH
+export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixpkgs=/etc/nixos/nixpkgs
+export NIX_PATH=$NIX_PATH:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
+
+
 # Ask the user to set a root password.
-if [ "$(chroot $mountPoint nix-instantiate --eval '<nixos>' -A config.users.mutableUsers)" = true ] && [ -t 0 ] ; then
+if [ "$(chroot $mountPoint nix-instantiate --eval '<nixpkgs/nixos>' -A config.users.mutableUsers)" = true ] && [ -t 1 ] ; then
     echo "setting root password..."
     chroot $mountPoint /var/setuid-wrappers/passwd
 fi

--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -45,7 +45,9 @@ while [ "$#" -gt 0 ]; do
             ;;
         --chroot)
             runChroot=1
-            chrootCommand=("$@")
+            if [[ "$@" != "" ]]; then
+                chrootCommand=("$@")
+            fi
             break
             ;;
         --help)


### PR DESCRIPTION
Due to issues with environmental variables, nixos-install failed to install when
the host operating system wasn't NixOS. This broke bootstrapping from Debian.
