### PR TITLE
kmod-blacklist-ubuntu: Fix source package URL returning 404

### DIFF
--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   name = "kmod-blacklist-${version}";
 
   src = fetchurl {
-    url = "http://archive.ubuntu.com/ubuntu/pool/main/k/kmod/kmod_9-${version}.debian.tar.gz";
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/kmod_9-${version}.debian.tar.gz";
     sha256 = "0h6h0zw2490iqj9xa2sz4309jyfmcc50jdvkhxa1nw90npxglp67";
   };
 


### PR DESCRIPTION
The original URL http://archive.ubuntu.com/ubuntu/pool/main/k/kmod/kmod_9-3ubuntu1.debian.tar.gz is dead.

Maybe the package could do some updating as well, but here's a trivial fix for now.
