### PR TITLE
vim: Change python3 ver setting, add nogui version

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12271,16 +12271,41 @@ let
 
   vim_configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
     inherit (pkgs) fetchurl fetchhg stdenv ncurses pkgconfig gettext
-      composableDerivation lib config glib gtk python perl tcl ruby;
+      composableDerivation lib config glib gtk perl tcl ruby;
     inherit (pkgs.xlibs) libX11 libXext libSM libXpm libXt libXaw libXau libXmu
       libICE;
 
     features = "huge"; # one of  tiny, small, normal, big or huge
     lua = pkgs.lua5_1;
+    python = pkgs.python;
     gui = config.vim.gui or "auto";
+    X11 = [ gtk
+            pkgs.xlibs.libX11
+            pkgs.xlibs.libXext
+            pkgs.xlibs.libSM
+            pkgs.xlibs.libXpm
+            pkgs.xlibs.libXt
+            pkgs.xlibs.libXaw
+            pkgs.xlibs.libXau
+            pkgs.xlibs.libXmu
+            pkgs.xlibs.libICE ];
 
     # optional features by flags
     flags = [ "python" "X11" ]; # only flag "X11" by now
+  });
+
+  vim_configurable_nogui = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
+    inherit (pkgs) fetchurl fetchhg stdenv ncurses pkgconfig gettext
+      composableDerivation lib config glib perl tcl ruby;
+
+    features = "huge"; # one of  tiny, small, normal, big or huge
+    lua = pkgs.lua5_1;
+    python = pkgs.python;
+    gui = "no";
+    X11 = [];
+
+    # optional features by flags
+    flags = [ "python" ];
   });
 
   vimNox = lowPrio (vim_configurable.override { source = "vim-nox"; });


### PR DESCRIPTION
Instead of having a specific python3 configuration option, we now just
check the args.python variable passed. This can be trivially set using
stdenv.lib.overrideDerivation.

The nogui part required a bit more changes, completely removing all of
the package requirements in the configurable.nix package, splitting it
all out to the definition in all-packages.nix.

There is a new variable, args.X11, that specifies the build inputs for
building Vim with support for X. On systems where X may not be
available, using the nogui version will set args.X11 to an emply list,
causing none of the X dependencies to be built for Vim. The gui option
is set to "no" in the nogui option, but can be manually overriden with
the overrideDerivation, though then "X11" will have to also be manually
set.
