### PR TITLE
package Dirt

### DIFF
--- a/pkgs/applications/audio/dirt/default.nix
+++ b/pkgs/applications/audio/dirt/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, libsndfile, libsamplerate, liblo, jack2 }:
+
+stdenv.mkDerivation rec {
+  name = "dirt-git";
+  src = fetchFromGitHub {
+    repo = "Dirt";
+    owner = "tidalcycles";
+    rev = "cfc5e85318defda7462192b5159103c823ce61f7";
+    sha256 = "1shbyp54q64g6bsl6hhch58k3z1dyyy9ph6cq2xvdf8syy00sisz";
+  };
+  buildInputs = [ libsndfile libsamplerate liblo jack2 ];
+  configurePhase = ''
+    export DESTDIR=$out
+  '';
+
+  meta = {
+    description = "An unimpressive thingie for playing bits of samples with some level of accuracy";
+    homepage = "https://github.com/tidalcycles/Dirt";
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10392,6 +10392,8 @@ let
 
   distrho = callPackage ../applications/audio/distrho {};
 
+  dirt = callPackage ../applications/audio/dirt {};
+
   djvulibre = callPackage ../applications/misc/djvulibre { };
 
   djvu2pdf = callPackage ../tools/typesetting/djvu2pdf { };


### PR DESCRIPTION
Dirt is used with the Tidal audio programming library (already packaged).
I tested by building and running locally.
