### PR TITLE
nixos.libvirtd: Remove `--verbose` argument

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -140,7 +140,7 @@ in
             done
           ''; # */
 
-        serviceConfig.ExecStart = ''@${pkgs.libvirt}/sbin/libvirtd libvirtd --config "${configFile}" --daemon --verbose'';
+        serviceConfig.ExecStart = ''@${pkgs.libvirt}/sbin/libvirtd libvirtd --config "${configFile}" --daemon'';
         serviceConfig.Type = "forking";
         serviceConfig.KillMode = "process"; # when stopping, leave the VMs alone
 


### PR DESCRIPTION
Otherwise libvirtd sends too much output to the systemd journal.
