### PR TITLE
SDL*: Fix on Darwin

### DIFF
--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = let
     notMingw = !(stdenv ? cross) || stdenv.cross.libc != "msvcrt";
-  in [ libcap ]
+  in stdenv.lib.optional stdenv.isLinux libcap
     ++ (stdenv.lib.optional notMingw audiofile);
 
   nativeBuildInputs = [ pkgconfig ] ++

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -19,6 +19,7 @@ let
         --disable-oss --disable-x11-shared
         --disable-pulseaudio-shared --disable-alsa-shared
         ${if alsaSupport then "--with-alsa-prefix=${attrs.alsaLib}/lib" else ""}
+        ${if (!x11Support) then "--without-x" else ""}
       '';
 in
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/SDL2_gfx/default.nix
+++ b/pkgs/development/libraries/SDL2_gfx/default.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = [ stdenv.lib.maintainers.bjg ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/SDL2_image/default.nix
+++ b/pkgs/development/libraries/SDL2_image/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "SDL image library";
     homepage = "http://www.libsdl.org/projects/SDL_image/";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/SDL_gfx/default.nix
+++ b/pkgs/development/libraries/SDL_gfx/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.lgpl2Plus;
 
     maintainers = [ stdenv.lib.maintainers.bjg ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7546,11 +7546,6 @@ let
     alsaSupport = (!stdenv.isDarwin);
     x11Support = true;
     pulseaudioSupport = (!stdenv.isDarwin);
-
-    # resolve the unrecognized -fpascal-strings option error
-    stdenv = if stdenv.isDarwin
-      then clangStdenv
-      else stdenv;
   };
 
   SDL_gfx = callPackage ../development/libraries/SDL_gfx { };


### PR DESCRIPTION
This fixes all SDL and SDL2 libs on Darwin except SDL_mixer and SDL_stretch
(I ran out of energy before fixing those two).
