### PR TITLE
Improvements to the clementine package.

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -1,60 +1,88 @@
 { stdenv, fetchurl, boost, cmake, gettext, gstreamer, gst_plugins_base
-, gst_plugins_good, gst_plugins_bad, gst_plugins_ugly, gst_ffmpeg
 , liblastfm, qt4, taglib, fftw, glew, qjson, sqlite, libgpod, libplist
 , usbmuxd, libmtp, gvfs, libcdio, protobuf, libspotify, qca2, pkgconfig
-, sparsehash, config, makeWrapper }:
+, sparsehash, config, makeWrapper, gst_plugins }:
 
-let withSpotify = config.clementine.spotify or false;
-in
-stdenv.mkDerivation {
-  name = "clementine-1.2.3";
+let 
+  version = "1.2.3";
 
-  src = fetchurl {
-    url = https://github.com/clementine-player/Clementine/archive/1.2.3.tar.gz;
-    sha256 = "1gx1109i4pylz6x7gvp4rdzc6dvh0w6in6hfbygw01d08l26bxbx";
+  withSpotify = config.clementine.spotify or false;
+
+  wrappedExeName = "clementine";
+
+  wrapped = stdenv.mkDerivation {
+    name = "clementine-wrapped-${version}";
+
+    src = fetchurl {
+      url = https://github.com/clementine-player/Clementine/archive/1.2.3.tar.gz;
+      sha256 = "1gx1109i4pylz6x7gvp4rdzc6dvh0w6in6hfbygw01d08l26bxbx";
+    };
+
+    patches = [ ./clementine-1.2.1-include-paths.patch ];
+
+    buildInputs = [
+      boost
+      cmake
+      fftw
+      gettext
+      glew
+      gst_plugins_base
+      gstreamer
+      gvfs
+      libcdio
+      libgpod
+      liblastfm
+      libmtp
+      libplist
+      pkgconfig
+      protobuf
+      qca2
+      qjson
+      qt4
+      sparsehash
+      sqlite
+      taglib
+      usbmuxd
+    ];
+
+    enableParallelBuilding = true;
   };
 
-  patches = [ ./clementine-1.2.1-include-paths.patch ];
+in
+
+stdenv.mkDerivation {
+  name = "clementine-${version}";
+
+  src = ./.;
+
 
   buildInputs = [
-    boost
-    cmake
-    fftw
-    gettext
-    glew
-    gst_plugins_base
-    gst_plugins_good
-    gst_plugins_ugly
-    gst_ffmpeg
-    gstreamer
-    gvfs
-    libcdio
-    libgpod
-    liblastfm
-    libmtp
-    libplist
+    wrapped
     makeWrapper
-    pkgconfig
-    protobuf
-    qca2
-    qjson
-    qt4
-    sparsehash
-    sqlite
-    taglib
-    usbmuxd
-  ] ++ stdenv.lib.optional withSpotify libspotify;
+  ] ++ gst_plugins
+    ++ stdenv.lib.optional withSpotify libspotify;
 
-  enableParallelBuilding = true;
+  installPhase = ''
+    mkdir -p $out
+    cp -a ${wrapped}/* $out
+    chmod -R u+w-t $out
 
-  postInstall = ''
-    wrapProgram $out/bin/clementine \
-      --set GST_PLUGIN_SYSTEM_PATH "$GST_PLUGIN_SYSTEM_PATH"
+    wrapProgram "$out/bin/${wrappedExeName}" \
+        --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
   '';
+
+  preferLocalBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
 
   meta = with stdenv.lib; {
     homepage = "http://www.clementine-player.org";
-    description = "A multiplatform music player";
+    description = "A multiplatform music player"
+      + " ("
+      + concatStrings (optionals (withSpotify) ["with spotify, "])
+      + "with gstreamer plugins: "
+      + concatStrings (intersperse ", " (map (x: x.name) gst_plugins))
+      + ")";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.ttuegel ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -976,6 +976,7 @@ let
 
   clementine = callPackage ../applications/audio/clementine {
     boost = boost156;
+    gst_plugins = [ gst_plugins_base gst_plugins_good gst_plugins_ugly gst_ffmpeg ];
   };
 
   ciopfs = callPackage ../tools/filesystems/ciopfs { };


### PR DESCRIPTION
-  Pass the gstreamer plugins as a list attribute instead of
  individual attributes.
  -  This should allow for greater customization (e.g.: a
      user can add / remove plugins by overriding
      the plugin list attribute).
  
  This is the same technique as used for wrapping chrome
  with gstreamer plugins.
-  Moved integration of gstreamer plugins, spotify
  library and clementine into a wrapper derivation.
  -  This should allow a user to change the gstreamer
      plugin set and activate / deactivate the spotify
      plugin without triggering a whole rebuild of the
      clementine sources (which is pretty long).
## Tests

Tested complex meta data with `nix-env -qa --xml --meta 'clementine-1.2.3'`.

Tested proper execution of the application and integration with gstreamer plugins.

Validated that changing gstreamer plugin set or spotify option effectively does
not trigger a recompile.

The spotify option no longer seem to be necessary as the clementine application
will automatically fetch the proper `libspotify` library with its plugin (`blob`) when
user install it from the setting page.
