### PR TITLE
grub2: Fix EFI-only installation

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -21,7 +21,7 @@ let
 
   grubEfi =
     # EFI version of Grub v2
-    if (cfg.devices != ["nodev"]) && cfg.efiSupport && (cfg.version == 2)
+    if cfg.efiSupport && (cfg.version == 2)
     then realGrub.override { efiSupport = cfg.efiSupport; }
     else null;
 


### PR DESCRIPTION
Removed invalid check for `boot.loader.grub.devices`; grub-efi installation process only touches `boot.loader.efi.{cantouchEfiVariables,efiSysMountPoint}`. 

Prior to this change it was actually impossible to have an EFI-only grub2 installation -- the code path in install-grub.pl could never be reached. With this, you can (or at least I can on my test hardware).
