### PR TITLE
haskell-uhc: New version with GHC 7.10 support.

### DIFF
--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -2,13 +2,13 @@
 
 let wrappedGhc = ghcWithPackages (hpkgs: with hpkgs; [shuffle hashable mtl network uhc-util uulib] );
 in stdenv.mkDerivation rec {
-  version = "1.1.8.10";
+  version = "1.1.9.0";
   name = "uhc-${version}";
 
   src = fetchgit {
     url = "https://github.com/UU-ComputerScience/uhc.git";
-    rev = "449d9578e06af1362d7f746798f0aed57ab6ca88";
-    sha256 = "0f8abhl9idbc2qlnb7ynrb11yvm3y07vksyzs1yg6snjvlhfj5az";
+    rev = "0363bbcf4cf8c47d30c3a188e3e53b3f8454bbe4";
+    sha256 = "0sa9b341mm5ggmbydc33ja3h7k9w65qnki9gsaagb06gkvvqc7c2";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/EHC";
@@ -22,8 +22,8 @@ in stdenv.mkDerivation rec {
   # want that, and hack the build process to use a temporary package
   # configuration file instead.
   preConfigure = ''
-    p=`pwd`/uhc-local-packages
-    echo '[]' > $p
+    p=`pwd`/uhc-local-packages/
+    ghc-pkg init $p
     sed -i "s|--user|--package-db=$p|g" mk/shared.mk.in
     sed -i "s|-fglasgow-exts|-fglasgow-exts -package-conf=$p|g" mk/shared.mk.in
     sed -i "s|/bin/date|${coreutils}/bin/date|g" mk/dist.mk


### PR DESCRIPTION
New version which fixes compile errors on GHC 7.10.

Requires a newer version of the hackage-packages than in current master. Version 83879a6daafac9b813284dff208597320f6b1717 from peti/nixpkgs or any hackage snapshot with uhc-util 0.1.5.5 and shuffle 0.1.3.3 is fine.
