### PR TITLE
Update cups to 2.0.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -57,7 +57,7 @@ was accordingly renamed to <literal>bomi</literal>
   <para>
 	Local printers are no longer shared or advertised by default. This behavior
 	can be changed by enabling <literal>services.printing.defaultShared</literal>
-	or <literal>services.printing.browsing</literal> respectively.
+	or <literal>services.printing.advertise</literal> respectively.
   </para>
 </listitem>
 

--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -49,6 +49,19 @@ was accordingly renamed to <literal>bomi</literal>
     </para>
 </listitem>
 
+<listitem>
+  <para>
+	The CUPS printing service has been updated to version <literal>2.0.2</literal>.
+	Furthermore its systemd service has been renamed to <literal>cups.service</literal>.
+  </para>
+  <para>
+	Local printers are no longer shared or advertised by default. This behavior
+	can be changed by enabling <literal>services.printing.defaultShared</literal>
+	or <literal>services.printing.browsing</literal> respectively.
+  </para>
+</listitem>
+
+
 </itemizedlist>
 </para>
 

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -72,6 +72,30 @@ in
         '';
       };
 
+      defaultShared = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Specifies whether local printers are shared by default.
+        '';
+      };
+
+      browsing = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Specifies whether shared printers are advertised.
+        '';
+      };
+
+      webInterface = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Specifies whether the web interface is enabled.
+        '';
+      };
+
       cupsdConf = mkOption {
         type = types.lines;
         default = "";
@@ -259,7 +283,11 @@ in
 
         SetEnv PATH ${bindir}/lib/cups/filter:${bindir}/bin:${bindir}/sbin
 
-        Browsing On
+        DefaultShared ${if cfg.defaultShared then "Yes" else "No"}
+
+        Browsing ${if cfg.browsing then "Yes" else "No"}
+
+        WebInterface ${if cfg.webInterface then "Yes" else "No"}
 
         DefaultAuthType Basic
 

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -183,10 +183,10 @@ in
     # gets loaded, and then cups cannot access the printers.
     boot.blacklistedKernelModules = [ "usblp" ];
 
-    systemd.services.cups =
-      { description = "CUPS Printing Daemon";
+    systemd.packages = [ cups ];
 
-        wantedBy = [ "multi-user.target" ];
+    systemd.services.cups =
+      { wantedBy = [ "multi-user.target" ];
         wants = [ "network.target" ];
         after = [ "network.target" ];
 
@@ -199,9 +199,6 @@ in
             mkdir -m 0700 -p /var/spool/cups
             mkdir -m 0755 -p ${cfg.tempDir}
           '';
-
-        serviceConfig.Type = "forking";
-        serviceConfig.ExecStart = "@${cups}/sbin/cupsd cupsd";
 
         restartTriggers =
           [ config.environment.etc."cups/cups-files.conf".source

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -260,8 +260,6 @@ in
         SetEnv PATH ${bindir}/lib/cups/filter:${bindir}/bin:${bindir}/sbin
 
         Browsing On
-        BrowseOrder allow,deny
-        BrowseAllow @LOCAL
 
         DefaultAuthType Basic
 

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -80,7 +80,7 @@ in
         '';
       };
 
-      browsing = mkOption {
+      advertise = mkOption {
         type = types.bool;
         default = false;
         description = ''
@@ -285,7 +285,7 @@ in
 
         DefaultShared ${if cfg.defaultShared then "Yes" else "No"}
 
-        Browsing ${if cfg.browsing then "Yes" else "No"}
+        Browsing ${if cfg.advertise then "Yes" else "No"}
 
         WebInterface ${if cfg.webInterface then "Yes" else "No"}
 

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -48,7 +48,7 @@ import ./make-test.nix ({pkgs, ... }: {
 
       # Do some status checks.
       $client->succeed("lpstat -a") =~ /DeskjetRemote accepting requests/ or die;
-      $client->succeed("lpstat -h server -a") =~ /DeskjetLocal accepting requests/ or die;
+      $client->succeed("lpstat -h server:631 -a") =~ /DeskjetLocal accepting requests/ or die;
       $client->succeed("cupsdisable DeskjetRemote");
       $client->succeed("lpq") =~ /DeskjetRemote is not ready.*no entries/s or die;
       $client->succeed("cupsenable DeskjetRemote");

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -9,6 +9,7 @@ import ./make-test.nix ({pkgs, ... }: {
       { config, pkgs, ... }:
       { services.printing.enable = true;
         services.printing.listenAddresses = [ "*:631" ];
+        services.printing.defaultShared = true;
         services.printing.extraConf =
           ''
             <Location />

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, zlib, libjpeg, libpng, libtiff, pam, openssl
-, dbus, acl, gmp
+, dbus, acl, gmp, xdg_utils
 , libusb ? null, gnutls ? null, avahi ? null, libpaper ? null
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ pkgconfig zlib libjpeg libpng libtiff libusb gnutls avahi libpaper ]
-    ++ optionals stdenv.isLinux [ pam dbus.libs acl ] ;
+    ++ optionals stdenv.isLinux [ pam dbus.libs acl xdg_utils ] ;
 
   propagatedBuildInputs = [ openssl gmp ];
 

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -1,8 +1,11 @@
 { stdenv, fetchurl, pkgconfig, zlib, libjpeg, libpng, libtiff, pam, openssl
-, dbus, libusb, acl, gmp }:
+, dbus, acl, gmp
+, libusb ? null, gnutls ? null, avahi ? null, libpaper ? null
+}:
 
-let version = "1.7.5"; in
+let version = "2.0.2"; in
 
+with stdenv.lib;
 stdenv.mkDerivation {
   name = "cups-${version}";
 
@@ -10,15 +13,27 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.cups.org/software/${version}/cups-${version}-source.tar.bz2";
-    sha256 = "00mx4rpiqw9cwx46bd3hd5lcgmcxy63zfnmkr02smanv8xl4rjqq";
+    sha256 = "12xild9nrhqnrzx8zqh78v3chm4mpp5gf5iamr0h9zb6dgvj11w5";
   };
 
-  buildInputs = [ pkgconfig zlib libjpeg libpng libtiff libusb ]
+  buildInputs = [ pkgconfig zlib libjpeg libpng libtiff libusb gnutls avahi libpaper ]
     ++ stdenv.lib.optionals stdenv.isLinux [ pam dbus.libs acl ] ;
 
   propagatedBuildInputs = [ openssl gmp ];
 
-  configureFlags = "--localstatedir=/var --sysconfdir=/etc --enable-dbus"; # --with-dbusdir
+  configureFlags = [
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--with-systemd=\${out}/lib/systemd/system"
+    "--enable-raw-printing"
+    "--enable-threads"
+  ] ++ optionals stdenv.isLinux [
+    "--enable-dbus"
+    "--enable-pam"
+  ] ++ optional (libusb != null) "--enable-libusb"
+    ++ optional (gnutls != null) "--enable-ssl"
+    ++ optional (avahi != null) "--enable-avahi"
+    ++ optional (libpaper != null) "--enable-libpaper";
 
   installFlags =
     [ # Don't try to write in /var at build time.

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -58,6 +58,19 @@ stdenv.mkDerivation {
     ''
       # Delete obsolete stuff that conflicts with cups-filters.
       rm -rf $out/share/cups/banners $out/share/cups/data/testprint
+
+      # Rename systemd files provided by CUPS
+      for f in $out/lib/systemd/system/*; do
+        substituteInPlace "$f" \
+          --replace "org.cups.cupsd" "cups" \
+          --replace "org.cups." ""
+
+        if [[ "$f" =~ .*cupsd\..* ]]; then
+          mv "$f" "''${f/org\.cups\.cupsd/cups}"
+        else
+          mv "$f" "''${f/org\.cups\./}"
+        fi
+      done
     '';
 
   meta = {

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ pkgconfig zlib libjpeg libpng libtiff libusb gnutls avahi libpaper ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ pam dbus.libs acl ] ;
+    ++ optionals stdenv.isLinux [ pam dbus.libs acl ] ;
 
   propagatedBuildInputs = [ openssl gmp ];
 
@@ -61,10 +61,10 @@ stdenv.mkDerivation {
     '';
 
   meta = {
-    homepage = "http://www.cups.org/";
+    homepage = https://cups.org/;
     description = "A standards-based printing system for UNIX";
-    license = stdenv.lib.licenses.gpl2; # actually LGPL for the library and GPL for the rest
-    maintainers = [ stdenv.lib.maintainers.urkud stdenv.lib.maintainers.simons ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2; # actually LGPL for the library and GPL for the rest
+    maintainers = with maintainers; [ urkud simons jgeerds ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13914,7 +13914,9 @@ let
 
   beep = callPackage ../misc/beep { };
 
-  cups = callPackage ../misc/cups { libusb = libusb1; };
+  cups = callPackage ../misc/cups {
+    libusb = libusb1;
+  };
 
   cups_filters = callPackage ../misc/cups/filters.nix { };
 


### PR DESCRIPTION
This is the second attempt to update cups to the latest version. I've tested these changes on my machine and it works fine.

This also solves my issue in detecting remote printers via DNSSD. It doesn't suffice to build `cups-filters` (`cups-browsed`) with DNSSD support. We need to build cups with DNSSD support as well. Otherwise the detected printers won't show up in the web interface.
- update to 2.0.2
- rename `cups.service` to `cupsd.service` because it's the official name and it makes it simpler to reuse official systemd service files thanks to 179acfb664ed06519ac515eada7bbef677cbee87
- refactor meta attributes, remove deprecated config options from cupsd.conf, ...

However, there is still a strange problem with our printing test (already mentioned in #7083 by @vcunat):

```
nix-build nixos/tests/printing.nix
[...]
client: exit status 0
client: must succeed: lpstat -a
client: exit status 0
client: must succeed: lpstat -h server -a
client: exit status 0
error: Died at (eval 13) line 21, <__ANONIO__> line 256.
Died at (eval 13) line 21, <__ANONIO__> line 256.
cleaning up
killing client (pid 4437)
killing server (pid 4447)
vde_switch: EOF on stdin, cleaning up and exiting
vde_switch: Could not remove ctl dir '/tmp/nix-build-vm-test-run-printing.drv-0/vde1.ctl': Directory not empty
builder for ‘/nix/store/q1kvd0km864cr5cd790x3yki4z5j39qj-vm-test-run-printing.drv’ failed with exit code 255
error: build of ‘/nix/store/q1kvd0km864cr5cd790x3yki4z5j39qj-vm-test-run-printing.drv’ failed
```

```
      $client->succeed("lpstat -a") =~ /DeskjetRemote accepting requests/ or die;
      $client->succeed("lpstat -h server -a") =~ /DeskjetLocal accepting requests/ or die;
```

The second line let our test fail. If I replace `/DeskjetLocal accepting requests/` with `/DeskjetRemote accepting requests/` (like one line above) then the test doesn't fail. I don't understand the problem here because if I run this test manually then the output looks good to me. It should work.

I think this is a Perl related issue or something like that? Any idea?

CC: @wkennington @edolstra
