### PR TITLE
gconf: removed heavy dependency on gtk by default.

### DIFF
--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, pkgconfig, dbus_glib, glib, ORBit2, libxml2
-, polkit, intltool, dbus_libs, gtk }:
+, polkit, intltool, dbus_libs, gtk ? null, withGtk ? false }:
+
+assert withGtk -> (gtk != null);
 
 stdenv.mkDerivation {
   name = "GConf-2.32.4";
@@ -9,16 +11,17 @@ stdenv.mkDerivation {
     sha256 = "09ch709cb9fniwc4221xgkq0jf0x0lxs814sqig8p2dcll0llvzk";
   };
 
-  buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 gtk ]
+  buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 ]
     # polkit requires pam, which requires shadow.h, which is not available on
     # darwin
-    ++ stdenv.lib.optional (!stdenv.isDarwin) polkit;
+    ++ stdenv.lib.optional (!stdenv.isDarwin) polkit
+    ++ stdenv.lib.optional withGtk gtk;
 
   propagatedBuildInputs = [ glib ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  configureFlags = [ "--with-gtk=2.0" ]
+  configureFlags = stdenv.lib.optional withGtk "--with-gtk=2.0"
     # fixes the "libgconfbackend-oldxml.so is not portable" error on darwin
     ++ stdenv.lib.optional stdenv.isDarwin [ "--enable-static" ];
 }

--- a/pkgs/desktops/gnome-3/3.12/core/gconf/default.nix
+++ b/pkgs/desktops/gnome-3/3.12/core/gconf/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, dbus_glib, gnome3, glib, libxml2
-, intltool, polkit, orbit }:
+{ stdenv, fetchurl, pkgconfig, dbus_glib, gnome3 ? null, glib, libxml2
+, intltool, polkit, orbit, withGtk ? false }:
+
+assert withGtk -> (gnome3 != null);
 
 stdenv.mkDerivation rec {
 
@@ -16,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "0k3q9nh53yhc9qxf1zaicz4sk8p3kzq4ndjdsgpaa2db0ccbj4hr";
   };
 
-  buildInputs = [ libxml2 polkit gnome3.gtk orbit ];
+  buildInputs = [ libxml2 polkit orbit ] ++ stdenv.lib.optional withGtk gnome3.gtk;
   propagatedBuildInputs = [ glib dbus_glib  ];
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/desktops/gnome-3/3.16/core/gconf/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/gconf/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, dbus_glib, gnome3, glib, libxml2
-, intltool, polkit, orbit }:
+{ stdenv, fetchurl, pkgconfig, dbus_glib, gnome3 ? null, glib, libxml2
+, intltool, polkit, orbit, withGtk ? false }:
+
+assert withGtk -> (gnome3 != null);
 
 stdenv.mkDerivation rec {
 
@@ -16,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "0k3q9nh53yhc9qxf1zaicz4sk8p3kzq4ndjdsgpaa2db0ccbj4hr";
   };
 
-  buildInputs = [ libxml2 polkit gnome3.gtk orbit ];
+  buildInputs = [ libxml2 polkit orbit ] ++ stdenv.lib.optional withGtk gnome3.gtk;
   propagatedBuildInputs = [ glib dbus_glib  ];
   nativeBuildInputs = [ pkgconfig intltool ];
 


### PR DESCRIPTION
Moved from #7652 .
Updated gnome-3.16 as well.
