### PR TITLE
Bump Android packages to newest versions, add androidsdk_5_1_1 and androidsdk_5_1_1_extras to env

### DIFF
--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -440,6 +440,7 @@ August 15, 2011
         <sdk:description>Android + Google APIs</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>34908058</sdk:size>
@@ -467,6 +468,7 @@ August 15, 2011
         <sdk:description>Android + Google APIs, revision 2</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>42435735</sdk:size>
@@ -550,6 +552,7 @@ August 15, 2011
         <sdk:description>Android + Google APIs, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>53691339</sdk:size>
@@ -659,6 +662,7 @@ August 15, 2011
         <sdk:description>Android + Google APIs, API 11, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>83477179</sdk:size>
@@ -686,6 +690,7 @@ August 15, 2011
         <sdk:description>Android + Google APIs, API 12, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>86099835</sdk:size>
@@ -713,6 +718,7 @@ August 15, 2011
         <sdk:description>Android + Google APIs, API 13, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>88615525</sdk:size>
@@ -738,6 +744,7 @@ August 15, 2011
         <sdk:api-level>14</sdk:api-level>
         <sdk:revision>2</sdk:revision>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:libs>
             <sdk:lib>
                 <sdk:name>com.google.android.maps</sdk:name>
@@ -876,14 +883,14 @@ August 15, 2011
     </sdk:add-on>
 
     <sdk:add-on>
-        <!-- Generated at Wed Jul 30 22:26:20 2014 from git_klp-sdk-release @ 1314097 -->
+        <!-- Generated at Wed Apr 22 12:31:26 2015 from git_klp-sdk-release @ 1873184 -->
         <sdk:vendor-id>google</sdk:vendor-id>
         <sdk:vendor-display>Google Inc.</sdk:vendor-display>
         <sdk:name-id>google_apis</sdk:name-id>
         <sdk:name-display>Google APIs (ARM System Image)</sdk:name-display>
         <sdk:description>Android + Google APIs</sdk:description>
         <sdk:api-level>19</sdk:api-level>
-        <sdk:revision>7</sdk:revision>
+        <sdk:revision>13</sdk:revision>
         <sdk:libs>
             <sdk:lib>
                 <sdk:name>com.google.android.maps</sdk:name>
@@ -897,9 +904,49 @@ August 15, 2011
         </sdk:libs>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>160661775</sdk:size>
-                <sdk:checksum type="sha1">150f5a3fec4f03313ca770b90126605619bd713c</sdk:checksum>
-                <sdk:url>google_apis-19_r07.zip</sdk:url>
+                <sdk:size>181034400</sdk:size>
+                <sdk:checksum type="sha1">75c8af27f1fdf83dc28057537b5bd62b794365cc</sdk:checksum>
+                <sdk:url>google_apis-19_r13.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:add-on>
+
+    <sdk:add-on>
+        <!-- Generated at Tue Oct 14 22:09:52 2014 from git_lmp-release @ 1504858 -->
+        <sdk:vendor-id>google</sdk:vendor-id>
+        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
+        <sdk:name-id>google_apis</sdk:name-id>
+        <sdk:name-display>Google APIs</sdk:name-display>
+        <sdk:description>Android + Google APIs</sdk:description>
+        <sdk:api-level>21</sdk:api-level>
+        <sdk:revision>1</sdk:revision>
+        <sdk:libs/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>179499</sdk:size>
+                <sdk:checksum type="sha1">66a754efb24e9bb07cc51648426443c7586c9d4a</sdk:checksum>
+                <sdk:url>google_apis-21_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:add-on>
+
+    <sdk:add-on>
+        <!-- Generated at Mon Mar  2 16:24:05 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
+        <sdk:vendor-id>google</sdk:vendor-id>
+        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
+        <sdk:name-id>google_apis</sdk:name-id>
+        <sdk:name-display>Google APIs</sdk:name-display>
+        <sdk:description>Android + Google APIs</sdk:description>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:revision>1</sdk:revision>
+        <sdk:libs/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>179259</sdk:size>
+                <sdk:checksum type="sha1">5def0f42160cba8acff51b9c0c7e8be313de84f5</sdk:checksum>
+                <sdk:url>google_apis-22_r01.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
@@ -917,6 +964,7 @@ August 15, 2011
         <sdk:description>Android + Google TV, API 12, preview release</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-googletv-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>78266751</sdk:size>
@@ -938,6 +986,7 @@ August 15, 2011
         <sdk:description>Android + Google TV, API 13</sdk:description>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:uses-license ref="android-googletv-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>87721879</sdk:size>
@@ -951,11 +1000,11 @@ August 15, 2011
     <!-- EXTRAS VENDOR=ANDROID ........................ -->
 
     <sdk:extra>
-        <!-- Generated at Mon Jun 23 19:18:59 2014 from git_klp-modular-release @ 1246132 -->
+        <!-- Generated at Fri Apr 24 09:30:00 2015 from git_lmp-mr1-supportlib-release @ 1877331 -->
         <sdk:revision>
-            <sdk:major>20</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
+            <sdk:major>22</sdk:major>
+            <sdk:minor>1</sdk:minor>
+            <sdk:micro>1</sdk:micro>
         </sdk:revision>
         <sdk:vendor-display>Android</sdk:vendor-display>
         <sdk:vendor-id>android</sdk:vendor-id>
@@ -964,18 +1013,18 @@ August 15, 2011
         <sdk:old-paths>compatibility</sdk:old-paths>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>5508097</sdk:size>
-                <sdk:checksum type="sha1">719c260dc3eb950712988f987daaf91afa9e36af</sdk:checksum>
-                <sdk:url>support_r20.zip</sdk:url>
+                <sdk:size>8475991</sdk:size>
+                <sdk:checksum type='sha1'>88bdc7b4074065ed28681f39e6b32c4f7ab45d94</sdk:checksum>
+                <sdk:url>support_r22.1.1.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:extra>
 
     <sdk:extra>
-        <!-- Generated from git_lmp-preview-release @ 1242878  -->
+        <!-- Generated at Fri Apr 24 09:30:00 2015 from git_lmp-mr1-supportlib-release @ 1877331 -->
         <sdk:revision>
-            <sdk:major>6</sdk:major>
+            <sdk:major>14</sdk:major>
         </sdk:revision>
         <sdk:vendor-display>Android</sdk:vendor-display>
         <sdk:vendor-id>android</sdk:vendor-id>
@@ -984,12 +1033,12 @@ August 15, 2011
         <sdk:path>m2repository</sdk:path>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>22271942</sdk:size>
-                <sdk:checksum type="sha1">d4874fd330f41a7c16de392ce917c2a3562dd620</sdk:checksum>
-                <sdk:url>android_m2repository_r06.zip</sdk:url>
+                <sdk:size>68533453</sdk:size>
+                <sdk:checksum type="sha1">0011dfe1473ccdfb1a533a19cad152c59dcd6b45</sdk:checksum>
+                <sdk:url>android_m2repository_r14.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
+        <sdk:uses-license ref="android-sdk-license"/>
     </sdk:extra>
 
     <!-- EXTRAS VENDOR=GOOGLE ....................... -->
@@ -1000,15 +1049,15 @@ August 15, 2011
         <sdk:name-display>Google Repository</sdk:name-display>
         <sdk:path>m2repository</sdk:path>
         <sdk:revision>
-            <sdk:major>11</sdk:major>
+            <sdk:major>17</sdk:major>
         </sdk:revision>
         <sdk:description>Local Maven repository for Google Libraries</sdk:description>
         <sdk:uses-license ref="android-sdk-license"/>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>18832133</sdk:size>
-                <sdk:checksum type="sha1">08b5114037d187cf3d4b44a25570149ef4f8ab3d</sdk:checksum>
-                <sdk:url>google_m2repository_r11.zip</sdk:url>
+                <sdk:size>43508126</sdk:size>
+                <sdk:checksum type="sha1">a91a809149b69fab1efb4652c21b439e8b9e7150</sdk:checksum>
+                <sdk:url>google_m2repository_r17.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
     </sdk:extra>
@@ -1066,6 +1115,7 @@ August 15, 2011
         <sdk:description>Google Play services client library and sample code</sdk:description>
         <sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>5265389</sdk:size>
@@ -1081,57 +1131,37 @@ August 15, 2011
         <sdk:name-display>Google Play services</sdk:name-display>
         <sdk:path>google_play_services</sdk:path>
         <sdk:revision>
-            <sdk:major>19</sdk:major>
+            <sdk:major>24</sdk:major>
         </sdk:revision>
         <sdk:description>Google Play services client library and sample code</sdk:description>
         <sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license"/>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>13982276</sdk:size>
-                <sdk:checksum type="sha1">847a8806dd3c43effc2afdd7b49fc6ba27f72d5d</sdk:checksum>
-                <sdk:url>google_play_services_5089000_r19.zip</sdk:url>
+                <sdk:size>17636517</sdk:size>
+                <sdk:checksum type="sha1">9dc5092c1043d6d9c162d481e668b95fc2f36782</sdk:checksum>
+                <sdk:url>google_play_services_7327000_r24.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
     </sdk:extra>
 
     <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Play services for Fit Preview</sdk:name-display>
-        <sdk:path>google_play_services_fit_preview</sdk:path>
-        <sdk:revision>
-            <sdk:major>1</sdk:major>
-        </sdk:revision>
-        <sdk:description>Google Play services client library and sample code</sdk:description>
-        <sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>15224769</sdk:size>
-                <sdk:checksum type="sha1">34369ca796268ec7274bc49d659d9e8f042b55ae</sdk:checksum>
-                <sdk:url>google_play_services_fit_preview_5208000_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-    </sdk:extra>
-
-    <sdk:extra>
-        <!-- Generated at Tue Jun 10 11:38:56 2014 from git_master-release @ 1216520 -->
+        <!-- Generated at Wed Sep 17 13:48:28 2014 from lmp-dev @ 1437156 -->
         <sdk:vendor-id>google</sdk:vendor-id>
         <sdk:uses-license ref="android-sdk-license"/>
         <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
         <sdk:path>usb_driver</sdk:path>
-        <sdk:description>USB Driver for Windows, revision 10</sdk:description>
+        <sdk:description>USB Driver for Windows, revision 11</sdk:description>
         <sdk:name-display>Google USB Driver</sdk:name-display>
         <sdk:vendor-display>Google Inc.</sdk:vendor-display>
         <sdk:revision>
-            <sdk:major>10</sdk:major>
+            <sdk:major>11</sdk:major>
         </sdk:revision>
         <sdk:archives>
             <sdk:archive>
-                <sdk:url>usb_driver_r10-windows.zip</sdk:url>
-                <sdk:checksum type="sha1">a5f8280829f07bb3144a8d657ec7aa0128443a2c</sdk:checksum>
-                <sdk:size>8682752</sdk:size>
+                <sdk:url>usb_driver_r11-windows.zip</sdk:url>
+                <sdk:checksum type="sha1">dc8a2ed2fbd7246d4caf9ab10ffe7749dc35d1cc</sdk:checksum>
+                <sdk:size>8682859</sdk:size>
                 <sdk:host-os>windows</sdk:host-os>
             </sdk:archive>
         </sdk:archives>
@@ -1239,5 +1269,25 @@ August 15, 2011
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
         <sdk:obsolete/>
+    </sdk:extra>
+
+    <sdk:extra>
+        <sdk:vendor-id>google</sdk:vendor-id>
+        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
+        <sdk:name-display>Android Auto API Simulators</sdk:name-display>
+        <sdk:path>simulators</sdk:path>
+        <sdk:revision>
+            <sdk:major>1</sdk:major>
+        </sdk:revision>
+        <sdk:description>Android Auto API testing simulators</sdk:description>
+        <sdk:desc-url>http://developer.android.com/auto</sdk:desc-url>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>2167286</sdk:size>
+                <sdk:checksum type="sha1">4fb5344e34e8faab4db18af07dace44c50db26a7</sdk:checksum>
+                <sdk:url>simulator_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
     </sdk:extra>
 </sdk:sdk-addon>

--- a/pkgs/development/mobile/androidenv/addons.nix
+++ b/pkgs/development/mobile/androidenv/addons.nix
@@ -1,4 +1,6 @@
 
+# This file is generated from generate-addons.sh. DO NOT EDIT.
+# Execute generate-addons.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let
@@ -13,7 +15,7 @@ let
     });
 in
 {
-    
+
   google_apis_3 = buildGoogleApis {
     name = "google_apis-3";
       src = fetchurl {
@@ -25,7 +27,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_4 = buildGoogleApis {
     name = "google_apis-4";
       src = fetchurl {
@@ -37,7 +39,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_5 = buildGoogleApis {
     name = "google_apis-5";
       src = fetchurl {
@@ -49,7 +51,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_6 = buildGoogleApis {
     name = "google_apis-6";
       src = fetchurl {
@@ -61,7 +63,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_7 = buildGoogleApis {
     name = "google_apis-7";
       src = fetchurl {
@@ -73,7 +75,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_8 = buildGoogleApis {
     name = "google_apis-8";
       src = fetchurl {
@@ -85,7 +87,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_9 = buildGoogleApis {
     name = "google_apis-9";
       src = fetchurl {
@@ -97,7 +99,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_10 = buildGoogleApis {
     name = "google_apis-10";
       src = fetchurl {
@@ -109,7 +111,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_11 = buildGoogleApis {
     name = "google_apis-11";
       src = fetchurl {
@@ -121,7 +123,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_12 = buildGoogleApis {
     name = "google_apis-12";
       src = fetchurl {
@@ -133,7 +135,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_13 = buildGoogleApis {
     name = "google_apis-13";
       src = fetchurl {
@@ -145,7 +147,7 @@ in
         url = http://developer.android.com/;
       };
     };
-    
+
   google_apis_14 = buildGoogleApis {
     name = "google_apis-14";
       src = fetchurl {
@@ -154,10 +156,10 @@ in
       };
       meta = {
         description = "Android + Google APIs";
-        
+
       };
     };
-    
+
   google_apis_15 = buildGoogleApis {
     name = "google_apis-15";
       src = fetchurl {
@@ -166,10 +168,10 @@ in
       };
       meta = {
         description = "Android + Google APIs";
-        
+
       };
     };
-    
+
   google_apis_16 = buildGoogleApis {
     name = "google_apis-16";
       src = fetchurl {
@@ -178,10 +180,10 @@ in
       };
       meta = {
         description = "Android + Google APIs";
-        
+
       };
     };
-    
+
   google_apis_17 = buildGoogleApis {
     name = "google_apis-17";
       src = fetchurl {
@@ -190,10 +192,10 @@ in
       };
       meta = {
         description = "Android + Google APIs";
-        
+
       };
     };
-    
+
   google_apis_18 = buildGoogleApis {
     name = "google_apis-18";
       src = fetchurl {
@@ -202,38 +204,63 @@ in
       };
       meta = {
         description = "Android + Google APIs";
-        
+
       };
     };
-    
+
   google_apis_19 = buildGoogleApis {
     name = "google_apis-19";
       src = fetchurl {
-        url = https://dl-ssl.google.com/android/repository/google_apis-19_r07.zip;
-        sha1 = "150f5a3fec4f03313ca770b90126605619bd713c";
+        url = https://dl-ssl.google.com/android/repository/google_apis-19_r13.zip;
+        sha1 = "75c8af27f1fdf83dc28057537b5bd62b794365cc";
       };
       meta = {
         description = "Android + Google APIs";
-        
+
       };
     };
-  
+
+  google_apis_21 = buildGoogleApis {
+    name = "google_apis-21";
+      src = fetchurl {
+        url = https://dl-ssl.google.com/android/repository/google_apis-21_r01.zip;
+        sha1 = "66a754efb24e9bb07cc51648426443c7586c9d4a";
+      };
+      meta = {
+        description = "Android + Google APIs";
+
+      };
+    };
+
+  google_apis_22 = buildGoogleApis {
+    name = "google_apis-22";
+      src = fetchurl {
+        url = https://dl-ssl.google.com/android/repository/google_apis-22_r01.zip;
+        sha1 = "5def0f42160cba8acff51b9c0c7e8be313de84f5";
+      };
+      meta = {
+        description = "Android + Google APIs";
+
+      };
+    };
+
   android_support_extra = buildGoogleApis {
     name = "android_support_extra";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/support_r20.zip;
-      sha1 = "719c260dc3eb950712988f987daaf91afa9e36af";
+      url = https://dl-ssl.google.com/android/repository/support_r22.1.1.zip;
+      sha1 = "88bdc7b4074065ed28681f39e6b32c4f7ab45d94";
     };
     meta = {
       description = "Android Support Library";
       url = http://developer.android.com/;
     };
   };
+
   google_play_services = buildGoogleApis {
     name = "google_play_services";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/google_play_services_3265130_r12.zip;
-      sha1 = "92558dbc380bba3d55d0ec181167fb05ce7c79d9";
+      url = https://dl-ssl.google.com/android/repository/google_play_services_7327000_r24.zip;
+      sha1 = "9dc5092c1043d6d9c162d481e668b95fc2f36782";
     };
     meta = {
       description = "Google Play services client library and sample code";
@@ -241,6 +268,4 @@ in
     };
   };
 
-  
 }
-  

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -3,7 +3,7 @@
 , zlib_32bit
 , libX11_32bit, libxcb_32bit, libXau_32bit, libXdmcp_32bit, libXext_32bit, mesa_32bit, alsaLib_32bit
 , libX11, libXext, libXrender, libxcb, libXau, libXdmcp, libXtst, mesa, alsaLib
-, freetype, fontconfig, glib, gtk, atk, file, jdk
+, freetype, fontconfig, glib, gtk, atk, file, jdk, coreutils
 }:
 {platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs?false, useGooglePlayServices?false}:
 
@@ -27,7 +27,12 @@ stdenv.mkDerivation rec {
     cd $out/libexec
     unpackFile $src
     cd android-sdk-*/tools
-    
+
+    for f in android traceview draw9patch hierarchyviewer monitor ddms screenshot2 uiautomatorviewer monkeyrunner jobb lint
+    do
+        sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
+    done
+
     ${stdenv.lib.optionalString (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     ''
       # There are a number of native binaries. We must patch them to let them find the interpreter and libstdc++
@@ -84,7 +89,7 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath ${libX11}/lib:${libXext}/lib:${libXrender}/lib:${freetype}/lib:${fontconfig}/lib libcairo-swt.so
         
         wrapProgram `pwd`/monitor \
-          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.cc.cc}/lib
+          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.cc.cc}/lib:${libXtst}/lib
 
         cd ../..
       ''
@@ -97,7 +102,7 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath ${libX11}/lib:${libXext}/lib:${libXrender}/lib:${freetype}/lib:${fontconfig}/lib libcairo-swt.so
         
         wrapProgram `pwd`/monitor \
-          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.cc.cc}/lib
+          --prefix LD_LIBRARY_PATH : ${gtk}/lib:${atk}/lib:${stdenv.cc.cc}/lib::${libXtst}/lib
 
         cd ../..
       ''

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -9,16 +9,16 @@
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "24.0.1";
+  version = "24.1.2";
 
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "http://dl.google.com/android/android-sdk_r${version}-linux.tgz";
-      sha1 = "fb46b9afa04e09d3c33fa9bfee5c99e9ec6a9523";
+      sha1 = "a46298bjpgzsnchhpcm1i86c4r50x638";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "http://dl.google.com/android/android-sdk_r${version}-macosx.zip";
-      sha1 = "7097c09c72645d7ad33c81a37b1a1363a9df2a54";
+      sha1 = "as109624lgrn8krylmyvm33yapqkzr00";
     }
     else throw "platform not ${stdenv.system} supported!";
 

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,15 +1,16 @@
 {stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit}:
 
-stdenv.mkDerivation {
-  name = "android-build-tools-r21.1.2";
+stdenv.mkDerivation rec {
+  version="22.0.1";
+  name = "android-build-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
-      url = https://dl-ssl.google.com/android/repository/build-tools_r21.1.2-linux.zip;
-      sha1 = "5e35259843bf2926113a38368b08458735479658";
+      url = "https://dl-ssl.google.com/android/repository/build-tools_r${version}-linux.zip";
+      sha1 = "8sb05s9f1h03qa7hdj72jffy7rf9r2ys";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
-      url = https://dl-ssl.google.com/android/repository/build-tools_r21.1.2-macosx.zip;
-      sha1 = "e7c906b4ba0eea93b32ba36c610dbd6b204bff48";
+      url = "https://dl-ssl.google.com/android/repository/build-tools_r${version}-macosx.zip";
+      sha1 = "pxdwrz6bb8b13fknf6qm67g013vdgnjk";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -40,7 +40,7 @@ rec {
 
   androidsdk = import ./androidsdk.nix {
     inherit (pkgs) stdenv fetchurl unzip makeWrapper;
-    inherit (pkgs) freetype fontconfig glib gtk atk mesa file alsaLib jdk;
+    inherit (pkgs) freetype fontconfig glib gtk atk mesa file alsaLib jdk coreutils;
     inherit (pkgs.xorg) libX11 libXext libXrender libxcb libXau libXdmcp libXtst;
     
     inherit platformTools buildTools support supportRepository platforms sysimages addons;

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -142,6 +142,20 @@ rec {
     useGooglePlayServices = true;
   };
 
+  androidsdk_5_1_1 = androidsdk {
+    platformVersions = [ "22" ];
+    abiVersions = [ "armeabi-v7a" "x86" "x86_64"];
+    useGoogleAPIs = true;
+  };
+
+  androidsdk_5_1_1_extras = androidsdk {
+    platformVersions = [ "22" ];
+    abiVersions = [ "armeabi-v7a" "x86" "x86_64"];
+    useGoogleAPIs = true;
+    useExtraSupportLibs = true;
+    useGooglePlayServices = true;
+  };
+
   androidndk = import ./androidndk.nix {
     inherit (pkgs) stdenv fetchurl zlib ncurses p7zip lib makeWrapper;
     inherit (pkgs) coreutils file findutils gawk gnugrep gnused jdk which;

--- a/pkgs/development/mobile/androidenv/generate-addons.xsl
+++ b/pkgs/development/mobile/androidenv/generate-addons.xsl
@@ -5,6 +5,8 @@
 
   <xsl:output omit-xml-declaration="yes" indent="no" />
   <xsl:template match="/sdk:sdk-addon">
+# This file is generated from generate-addons.sh. DO NOT EDIT.
+# Execute generate-addons.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let
@@ -19,7 +21,7 @@ let
     });
 in
 {
-    <xsl:for-each select="sdk:add-on[sdk:name-id='google_apis']">
+<xsl:for-each select="sdk:add-on[sdk:name-id='google_apis']">
   google_apis_<xsl:value-of select="sdk:api-level" /> = buildGoogleApis {
     name = "<xsl:value-of select="sdk:name-id" />-<xsl:value-of select="sdk:api-level" />";
       src = fetchurl {
@@ -28,11 +30,37 @@ in
       };
       meta = {
         description = "<xsl:value-of select="sdk:description" />";
-        <xsl:for-each select="sdk:desc-url">url = <xsl:value-of select="." />;</xsl:for-each>
+<xsl:for-each select="sdk:desc-url">        url = <xsl:value-of select="." />;</xsl:for-each>
       };
     };
-    </xsl:for-each>
+</xsl:for-each>
+
+<xsl:for-each select="sdk:extra[sdk:path='support']">
+  android_support_extra = buildGoogleApis {
+    name = "android_support_extra";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/<xsl:value-of select="sdk:archives/sdk:archive/sdk:url"/>;
+      sha1 = "<xsl:value-of select="sdk:archives/sdk:archive/sdk:checksum[@type='sha1']" />";
+    };
+    meta = {
+      description = "Android Support Library";
+      url = http://developer.android.com/;
+    };
+  };
+</xsl:for-each><xsl:for-each select="sdk:extra[sdk:path='google_play_services']">
+  google_play_services = buildGoogleApis {
+    name = "google_play_services";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/<xsl:value-of select="sdk:archives/sdk:archive/sdk:url"/>;
+      sha1 = "<xsl:value-of select="sdk:archives/sdk:archive/sdk:checksum[@type='sha1']" />";
+    };
+    meta = {
+      description = "Google Play services client library and sample code";
+      url = http://developer.android.com/;
+    };
+  };
+</xsl:for-each>
 }
-  </xsl:template>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/pkgs/development/mobile/androidenv/generate-platforms.xsl
+++ b/pkgs/development/mobile/androidenv/generate-platforms.xsl
@@ -5,7 +5,23 @@
 
   <xsl:param name="os" />
   <xsl:output omit-xml-declaration="yes" indent="no" />
+
+  <xsl:template name="repository-url">
+    <xsl:variable name="raw-url" select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:url"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($raw-url, 'http')">
+        <xsl:value-of select="$raw-url"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>https://dl-ssl.google.com/android/repository/</xsl:text>
+        <xsl:value-of select="$raw-url"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="/sdk:sdk-repository">
+# This file is generated from generate-platforms.sh. DO NOT EDIT.
+# Execute generate-platforms.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let
@@ -20,19 +36,19 @@ let
   });
 in
 {
-    <xsl:for-each select="sdk:platform[sdk:api-level &lt; 20]">
+    <xsl:for-each select="sdk:platform">
   platform_<xsl:value-of select="sdk:api-level" /> = buildPlatform {
     name = "android-platform-<xsl:value-of select="sdk:version" />";
     src = fetchurl {
-      url = <xsl:value-of select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:url" />;
+      url = <xsl:call-template name="repository-url"/>;
       sha1 = "<xsl:value-of select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:checksum[@type='sha1']" />";
     };
     meta = {
       description = "<xsl:value-of select="sdk:description" />";
-      <xsl:for-each select="sdk:desc-url">url = <xsl:value-of select="." />;</xsl:for-each>
+<xsl:for-each select="sdk:desc-url">      url = <xsl:value-of select="." />;</xsl:for-each>
     };
   };
-    </xsl:for-each>
+</xsl:for-each>
 }
-  </xsl:template>
+</xsl:template>
 </xsl:stylesheet>

--- a/pkgs/development/mobile/androidenv/generate-sysimages.sh
+++ b/pkgs/development/mobile/androidenv/generate-sysimages.sh
@@ -1,6 +1,8 @@
 #!/bin/sh -e
 
 cat > sysimages.nix << "EOF"
+# This file is generated from generate-sysimages.sh. DO NOT EDIT.
+# Execute generate-sysimages.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let

--- a/pkgs/development/mobile/androidenv/generate-sysimages.xsl
+++ b/pkgs/development/mobile/androidenv/generate-sysimages.xsl
@@ -15,6 +15,6 @@
       sha1 = "<xsl:value-of select="sdk:archives/sdk:archive/sdk:checksum[@type='sha1']" />";
     };
   };
-    </xsl:for-each>
+</xsl:for-each>
   </xsl:template>
 </xsl:stylesheet>

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,7 +1,7 @@
 {stdenv, stdenv_32bit, fetchurl, unzip}:
 
 let
-  version = "21";
+  version = "22";
 
 in
 
@@ -10,11 +10,11 @@ stdenv.mkDerivation {
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl-ssl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha256 = "35a1762b355451e000a816d97d9af640ca99ae6c5b5b406a3e680210af8106ad";
+      sha256 = "1kbp5fzfdas6c431n53a9w0z0182ihhadd1h8a64m1alkw0swr41";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl-ssl.google.com/android/repository/platform-tools_r${version}-macosx.zip";
-      sha256 = "30ae8724da3db772a776d616b4746516f24ae81330e84315a7ce0c49e0b0b3cb";
+      sha256 = "0r359xxicn7zw9z0jbrmsppx1372fijg09ck907gg8x1cvzj2ry0";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/platforms-linux.nix
+++ b/pkgs/development/mobile/androidenv/platforms-linux.nix
@@ -1,4 +1,6 @@
 
+# This file is generated from generate-platforms.sh. DO NOT EDIT.
+# Execute generate-platforms.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let
@@ -25,7 +27,7 @@ in
       url = http://developer.android.com/sdk/android-1.1.html;
     };
   };
-    
+
   platform_3 = buildPlatform {
     name = "android-platform-1.5";
     src = fetchurl {
@@ -37,7 +39,7 @@ in
       url = http://developer.android.com/sdk/android-1.5.html;
     };
   };
-    
+
   platform_4 = buildPlatform {
     name = "android-platform-1.6";
     src = fetchurl {
@@ -49,7 +51,7 @@ in
       url = http://developer.android.com/sdk/android-1.6.html;
     };
   };
-    
+
   platform_5 = buildPlatform {
     name = "android-platform-2.0";
     src = fetchurl {
@@ -61,7 +63,7 @@ in
       url = http://developer.android.com/sdk/android-2.0.html;
     };
   };
-    
+
   platform_6 = buildPlatform {
     name = "android-platform-2.0.1";
     src = fetchurl {
@@ -73,7 +75,7 @@ in
       url = http://developer.android.com/sdk/android-2.0.1.html;
     };
   };
-    
+
   platform_7 = buildPlatform {
     name = "android-platform-2.1";
     src = fetchurl {
@@ -85,7 +87,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_8 = buildPlatform {
     name = "android-platform-2.2";
     src = fetchurl {
@@ -97,7 +99,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_9 = buildPlatform {
     name = "android-platform-2.3.1";
     src = fetchurl {
@@ -109,7 +111,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_10 = buildPlatform {
     name = "android-platform-2.3.3";
     src = fetchurl {
@@ -121,7 +123,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_11 = buildPlatform {
     name = "android-platform-3.0";
     src = fetchurl {
@@ -133,7 +135,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_12 = buildPlatform {
     name = "android-platform-3.1";
     src = fetchurl {
@@ -145,7 +147,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_13 = buildPlatform {
     name = "android-platform-3.2";
     src = fetchurl {
@@ -157,76 +159,88 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_14 = buildPlatform {
     name = "android-platform-4.0";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-14_r03.zip;
-      sha1 = "41ba83b51e886461628c41b1b4d47762e0688ed5";
+      url = https://dl-ssl.google.com/android/repository/android-14_r04.zip;
+      sha1 = "d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c";
     };
     meta = {
       description = "Android SDK Platform 4.0";
-      
+
     };
   };
-    
+
   platform_15 = buildPlatform {
     name = "android-platform-4.0.3";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-15_r03.zip;
-      sha1 = "23da24610a8da51054c5391001c51ce43a778b97";
+      url = https://dl-ssl.google.com/android/repository/android-15_r05.zip;
+      sha1 = "69ab4c443b37184b2883af1fd38cc20cbeffd0f3";
     };
     meta = {
       description = "Android SDK Platform 4.0.3";
-      
+
     };
   };
-    
+
   platform_16 = buildPlatform {
     name = "android-platform-4.1.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-16_r04.zip;
-      sha1 = "90b9157b8b45f966be97e11a22fba4591b96c2ee";
+      url = https://dl-ssl.google.com/android/repository/android-16_r05.zip;
+      sha1 = "12a5ce6235a76bc30f62c26bda1b680e336abd07";
     };
     meta = {
       description = "Android SDK Platform 4.1.2";
-      
+
     };
   };
-    
+
   platform_17 = buildPlatform {
     name = "android-platform-4.2.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-17_r02.zip;
-      sha1 = "c442c32c1b702173ab0929a74486e4f86fe528ec";
+      url = https://dl-ssl.google.com/android/repository/android-17_r03.zip;
+      sha1 = "dbe14101c06e6cdb34e300393e64e64f8c92168a";
     };
     meta = {
       description = "Android SDK Platform 4.2.2";
-      
+
     };
   };
-    
+
   platform_18 = buildPlatform {
-    name = "android-platform-4.3";
+    name = "android-platform-4.3.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-18_r02.zip;
-      sha1 = "62a9438d4cf6692f4d6510c27a380be195db9534";
+      url = https://dl-ssl.google.com/android/repository/android-18_r03.zip;
+      sha1 = "e6b09b3505754cbbeb4a5622008b907262ee91cb";
     };
     meta = {
-      description = "Android SDK Platform 4.3";
-      
+      description = "Android SDK Platform 4.3.1";
+
     };
   };
-    
+
   platform_19 = buildPlatform {
     name = "android-platform-4.4.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-19_r03.zip;
-      sha1 = "5f33d8fd36a384fe2b170035e04a29c274a9ef95";
+      url = https://dl-ssl.google.com/android/repository/android-19_r04.zip;
+      sha1 = "2ff20d89e68f2f5390981342e009db5a2d456aaa";
     };
     meta = {
       description = "Android SDK Platform 4.4.2";
-      
+
+    };
+  };
+
+  platform_20 = buildPlatform {
+    name = "android-platform-4.4W.2";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/android-20_r02.zip;
+      sha1 = "a9251f8a3f313ab05834a07a963000927637e01d";
+    };
+    meta = {
+      description = "Android SDK Platform 4.4W.2";
+
     };
   };
 
@@ -238,6 +252,19 @@ in
     };
     meta = {
       description = "Android SDK Platform 5.0.1";
+
+    };
+  };
+
+  platform_22 = buildPlatform {
+    name = "android-platform-5.1.1";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/android-22_r02.zip;
+      sha1 = "5d1bd10fea962b216a0dece1247070164760a9fc";
+    };
+    meta = {
+      description = "Android SDK Platform 5.1.1";
+
     };
   };
 

--- a/pkgs/development/mobile/androidenv/platforms-macosx.nix
+++ b/pkgs/development/mobile/androidenv/platforms-macosx.nix
@@ -1,4 +1,6 @@
 
+# This file is generated from generate-platforms.sh. DO NOT EDIT.
+# Execute generate-platforms.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let
@@ -25,7 +27,7 @@ in
       url = http://developer.android.com/sdk/android-1.1.html;
     };
   };
-    
+
   platform_3 = buildPlatform {
     name = "android-platform-1.5";
     src = fetchurl {
@@ -37,7 +39,7 @@ in
       url = http://developer.android.com/sdk/android-1.5.html;
     };
   };
-    
+
   platform_4 = buildPlatform {
     name = "android-platform-1.6";
     src = fetchurl {
@@ -49,7 +51,7 @@ in
       url = http://developer.android.com/sdk/android-1.6.html;
     };
   };
-    
+
   platform_5 = buildPlatform {
     name = "android-platform-2.0";
     src = fetchurl {
@@ -61,7 +63,7 @@ in
       url = http://developer.android.com/sdk/android-2.0.html;
     };
   };
-    
+
   platform_6 = buildPlatform {
     name = "android-platform-2.0.1";
     src = fetchurl {
@@ -73,7 +75,7 @@ in
       url = http://developer.android.com/sdk/android-2.0.1.html;
     };
   };
-    
+
   platform_7 = buildPlatform {
     name = "android-platform-2.1";
     src = fetchurl {
@@ -85,7 +87,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_8 = buildPlatform {
     name = "android-platform-2.2";
     src = fetchurl {
@@ -97,7 +99,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_9 = buildPlatform {
     name = "android-platform-2.3.1";
     src = fetchurl {
@@ -109,7 +111,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_10 = buildPlatform {
     name = "android-platform-2.3.3";
     src = fetchurl {
@@ -121,7 +123,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_11 = buildPlatform {
     name = "android-platform-3.0";
     src = fetchurl {
@@ -133,7 +135,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_12 = buildPlatform {
     name = "android-platform-3.1";
     src = fetchurl {
@@ -145,7 +147,7 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_13 = buildPlatform {
     name = "android-platform-3.2";
     src = fetchurl {
@@ -157,76 +159,88 @@ in
       url = http://developer.android.com/sdk/;
     };
   };
-    
+
   platform_14 = buildPlatform {
     name = "android-platform-4.0";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-14_r03.zip;
-      sha1 = "41ba83b51e886461628c41b1b4d47762e0688ed5";
+      url = https://dl-ssl.google.com/android/repository/android-14_r04.zip;
+      sha1 = "d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c";
     };
     meta = {
       description = "Android SDK Platform 4.0";
-      
+
     };
   };
-    
+
   platform_15 = buildPlatform {
     name = "android-platform-4.0.3";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-15_r03.zip;
-      sha1 = "23da24610a8da51054c5391001c51ce43a778b97";
+      url = https://dl-ssl.google.com/android/repository/android-15_r05.zip;
+      sha1 = "69ab4c443b37184b2883af1fd38cc20cbeffd0f3";
     };
     meta = {
       description = "Android SDK Platform 4.0.3";
-      
+
     };
   };
-    
+
   platform_16 = buildPlatform {
     name = "android-platform-4.1.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-16_r04.zip;
-      sha1 = "90b9157b8b45f966be97e11a22fba4591b96c2ee";
+      url = https://dl-ssl.google.com/android/repository/android-16_r05.zip;
+      sha1 = "12a5ce6235a76bc30f62c26bda1b680e336abd07";
     };
     meta = {
       description = "Android SDK Platform 4.1.2";
-      
+
     };
   };
-    
+
   platform_17 = buildPlatform {
     name = "android-platform-4.2.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-17_r02.zip;
-      sha1 = "c442c32c1b702173ab0929a74486e4f86fe528ec";
+      url = https://dl-ssl.google.com/android/repository/android-17_r03.zip;
+      sha1 = "dbe14101c06e6cdb34e300393e64e64f8c92168a";
     };
     meta = {
       description = "Android SDK Platform 4.2.2";
-      
+
     };
   };
-    
+
   platform_18 = buildPlatform {
-    name = "android-platform-4.3";
+    name = "android-platform-4.3.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-18_r02.zip;
-      sha1 = "62a9438d4cf6692f4d6510c27a380be195db9534";
+      url = https://dl-ssl.google.com/android/repository/android-18_r03.zip;
+      sha1 = "e6b09b3505754cbbeb4a5622008b907262ee91cb";
     };
     meta = {
-      description = "Android SDK Platform 4.3";
-      
+      description = "Android SDK Platform 4.3.1";
+
     };
   };
-    
+
   platform_19 = buildPlatform {
     name = "android-platform-4.4.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-19_r03.zip;
-      sha1 = "5f33d8fd36a384fe2b170035e04a29c274a9ef95";
+      url = https://dl-ssl.google.com/android/repository/android-19_r04.zip;
+      sha1 = "2ff20d89e68f2f5390981342e009db5a2d456aaa";
     };
     meta = {
       description = "Android SDK Platform 4.4.2";
-      
+
+    };
+  };
+
+  platform_20 = buildPlatform {
+    name = "android-platform-4.4W.2";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/android-20_r02.zip;
+      sha1 = "a9251f8a3f313ab05834a07a963000927637e01d";
+    };
+    meta = {
+      description = "Android SDK Platform 4.4W.2";
+
     };
   };
 
@@ -238,8 +252,20 @@ in
     };
     meta = {
       description = "Android SDK Platform 5.0.1";
+
     };
   };
 
-    
+  platform_22 = buildPlatform {
+    name = "android-platform-5.1.1";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/android-22_r02.zip;
+      sha1 = "5d1bd10fea962b216a0dece1247070164760a9fc";
+    };
+    meta = {
+      description = "Android SDK Platform 5.1.1";
+
+    };
+  };
+
 }

--- a/pkgs/development/mobile/androidenv/repository-10.xml
+++ b/pkgs/development/mobile/androidenv/repository-10.xml
@@ -329,6 +329,7 @@ June 2014.
         </sdk:min-tools-rev>
         <sdk:description>Android SDK Platform 1.5_r3</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/android-1.5.html</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>54624370</sdk:size>
@@ -365,6 +366,7 @@ June 2014.
         </sdk:min-tools-rev>
         <sdk:description>Android SDK Platform 1.6_r2</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/android-1.6.html</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>63454485</sdk:size>
@@ -481,6 +483,7 @@ June 2014.
         </sdk:min-tools-rev>
         <sdk:description>Android SDK Platform 2.1_r3</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>70142829</sdk:size>
@@ -582,6 +585,7 @@ June 2014.
         </sdk:min-tools-rev>
         <sdk:description>Android SDK Platform 3.0, revision 2</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>104513908</sdk:size>
@@ -609,6 +613,7 @@ June 2014.
         </sdk:min-tools-rev>
         <sdk:description>Android SDK Platform 3.1, revision 3</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>106472351</sdk:size>
@@ -634,6 +639,7 @@ June 2014.
         </sdk:min-tools-rev>
         <sdk:description>Android SDK Platform 3.2, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>108426536</sdk:size>
@@ -648,51 +654,52 @@ June 2014.
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Thu Dec 15 16:53:11 2011 from git_ics-mr0 @ 238991 -->
-        <sdk:revision>3</sdk:revision>
+        <!-- Generated at Thu Sep 11 14:16:21 2014 from git_ics-mr0 @ 1406408 -->
+        <sdk:revision>4</sdk:revision>
         <sdk:description>Android SDK Platform 4.0</sdk:description>
         <sdk:version>4.0</sdk:version>
         <sdk:api-level>14</sdk:api-level>
         <sdk:layoutlib>
-            <sdk:api>7</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>45919570</sdk:size>
-                <sdk:checksum type="sha1">41ba83b51e886461628c41b1b4d47762e0688ed5</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-14_r03.zip</sdk:url>
+                <sdk:size>46038082</sdk:size>
+                <sdk:checksum type="sha1">d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c</sdk:checksum>
+                <sdk:url>android-14_r04.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Fri Mar 16 11:22:43 2012 from ics-mr1 @ 291902 -->
-        <sdk:revision>3</sdk:revision>
+        <!-- Generated at Thu Sep 11 14:16:02 2014 from git_ics-mr1 @ 1406430 -->
+        <sdk:revision>5</sdk:revision>
         <sdk:description>Android SDK Platform 4.0.3</sdk:description>
         <sdk:version>4.0.3</sdk:version>
         <sdk:api-level>15</sdk:api-level>
         <sdk:min-tools-rev>
-            <sdk:major>15</sdk:major>
+            <sdk:major>21</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>7</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>44414679</sdk:size>
-                <sdk:checksum type="sha1">23da24610a8da51054c5391001c51ce43a778b97</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-15_r03.zip</sdk:url>
+                <sdk:size>44533475</sdk:size>
+                <sdk:checksum type="sha1">69ab4c443b37184b2883af1fd38cc20cbeffd0f3</sdk:checksum>
+                <sdk:url>android-15_r05.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Thu Dec  6 10:54:05 2012 from git_jb-dev @ 543062 -->
-        <sdk:revision>4</sdk:revision>
+        <!-- Generated at Thu Sep 11 14:15:43 2014 from git_jb-dev @ 1425332 -->
+        <sdk:revision>5</sdk:revision>
         <sdk:description>Android SDK Platform 4.1.2</sdk:description>
         <sdk:version>4.1.2</sdk:version>
         <sdk:api-level>16</sdk:api-level>
@@ -700,22 +707,22 @@ June 2014.
             <sdk:major>21</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>9</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>48005140</sdk:size>
-                <sdk:checksum type="sha1">90b9157b8b45f966be97e11a22fba4591b96c2ee</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-16_r04.zip</sdk:url>
+                <sdk:size>48128695</sdk:size>
+                <sdk:checksum type="sha1">12a5ce6235a76bc30f62c26bda1b680e336abd07</sdk:checksum>
+                <sdk:url>android-16_r05.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Wed Feb 13 11:27:09 2013 from git_jb-mr1.1-dev @ 576024 -->
-        <sdk:revision>2</sdk:revision>
+        <!-- Generated at Thu Sep 11 14:15:23 2014 from git_jb-mr1.1-dev @ 1425461 -->
+        <sdk:revision>3</sdk:revision>
         <sdk:description>Android SDK Platform 4.2.2</sdk:description>
         <sdk:version>4.2.2</sdk:version>
         <sdk:api-level>17</sdk:api-level>
@@ -723,45 +730,45 @@ June 2014.
             <sdk:major>21</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>9</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>48057484</sdk:size>
-                <sdk:checksum type="sha1">c442c32c1b702173ab0929a74486e4f86fe528ec</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-17_r02.zip</sdk:url>
+                <sdk:size>57030216</sdk:size>
+                <sdk:checksum type="sha1">dbe14101c06e6cdb34e300393e64e64f8c92168a</sdk:checksum>
+                <sdk:url>android-17_r03.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Wed Sep 11 18:15:07 2013 from git_jb-mr2-dev @ 819563 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 4.3</sdk:description>
-        <sdk:version>4.3</sdk:version>
+        <!-- Generated at Thu Sep 11 14:14:59 2014 from git_jb-mr2-dev @ 1425645 -->
+        <sdk:revision>3</sdk:revision>
+        <sdk:description>Android SDK Platform 4.3.1</sdk:description>
+        <sdk:version>4.3.1</sdk:version>
         <sdk:api-level>18</sdk:api-level>
         <sdk:min-tools-rev>
             <sdk:major>21</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>10</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>57319855</sdk:size>
-                <sdk:checksum type="sha1">62a9438d4cf6692f4d6510c27a380be195db9534</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-18_r02.zip</sdk:url>
+                <sdk:size>57771739</sdk:size>
+                <sdk:checksum type="sha1">e6b09b3505754cbbeb4a5622008b907262ee91cb</sdk:checksum>
+                <sdk:url>android-18_r03.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Fri Feb 28 18:03:43 2014 from git_klp-sdk-release @ 1035858 -->
-        <sdk:revision>3</sdk:revision>
+        <!-- Generated at Mon Sep 22 15:22:30 2014 from git_klp-sdk-release @ 1456859 -->
+        <sdk:revision>4</sdk:revision>
         <sdk:description>Android SDK Platform 4.4.2</sdk:description>
         <sdk:version>4.4.2</sdk:version>
         <sdk:api-level>19</sdk:api-level>
@@ -769,64 +776,86 @@ June 2014.
             <sdk:major>22</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>10</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>63798840</sdk:size>
-                <sdk:checksum type="sha1">5f33d8fd36a384fe2b170035e04a29c274a9ef95</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-19_r03.zip</sdk:url>
+                <sdk:size>63871092</sdk:size>
+                <sdk:checksum type="sha1">2ff20d89e68f2f5390981342e009db5a2d456aaa</sdk:checksum>
+                <sdk:url>android-19_r04.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Mon Jun 23 19:17:42 2014 from git_klp-modular-release @ 1246132 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform 4.4W</sdk:description>
-        <sdk:version>4.4W</sdk:version>
+        <!-- Generated at Thu Oct 23 11:39:31 2014 from git_klp-modular-dev @ 1537038 -->
+        <sdk:revision>2</sdk:revision>
+        <sdk:description>Android SDK Platform 4.4W.2</sdk:description>
+        <sdk:version>4.4W.2</sdk:version>
         <sdk:api-level>20</sdk:api-level>
         <sdk:min-tools-rev>
             <sdk:major>22</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>10</sdk:api>
+            <sdk:api>12</sdk:api>
             <sdk:revision>1</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>63548914</sdk:size>
-                <sdk:checksum type="sha1">928b1d181101a5bc06f739eb40501e1249dd4895</sdk:checksum>
-                <sdk:url>android-20_r01.zip</sdk:url>
+                <sdk:size>63567784</sdk:size>
+                <sdk:checksum type="sha1">a9251f8a3f313ab05834a07a963000927637e01d</sdk:checksum>
+                <sdk:url>android-20_r02.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <sdk:platform>
-        <!-- Generated at Fri Jul 11 18:20:46 2014 from git_lmp-preview-dev @ 1272903 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform L</sdk:description>
-        <sdk:version>L</sdk:version>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:codename>L</sdk:codename>
+        <!-- Generated at Thu Dec  4 12:23:51 2014 from git_lmp-dev @ 1624448 -->
+        <sdk:revision>2</sdk:revision>
+        <sdk:description>Android SDK Platform 5.0.1</sdk:description>
+        <sdk:version>5.0.1</sdk:version>
+        <sdk:api-level>21</sdk:api-level>
         <sdk:min-tools-rev>
             <sdk:major>22</sdk:major>
         </sdk:min-tools-rev>
         <sdk:layoutlib>
-            <sdk:api>11</sdk:api>
-            <sdk:revision>1</sdk:revision>
+            <sdk:api>12</sdk:api>
+            <sdk:revision>2</sdk:revision>
         </sdk:layoutlib>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>69421660</sdk:size>
-                <sdk:checksum type="sha1">76b6da426db06b2e2901dbc5e02d210ba83753c4</sdk:checksum>
-                <sdk:url>android-L_r03.zip</sdk:url>
+                <sdk:size>65897960</sdk:size>
+                <sdk:checksum type="sha1">53536556059bb29ae82f414fd2e14bc335a4eb4c</sdk:checksum>
+                <sdk:url>android-21_r02.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:platform>
+
+    <sdk:platform>
+        <!-- Generated at Mon Mar 30 10:48:23 2015 from git_lmp-mr1-sdk-release @ 1819727 -->
+        <sdk:revision>2</sdk:revision>
+        <sdk:description>Android SDK Platform 5.1.1</sdk:description>
+        <sdk:version>5.1.1</sdk:version>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:min-tools-rev>
+            <sdk:major>22</sdk:major>
+        </sdk:min-tools-rev>
+        <sdk:layoutlib>
+            <sdk:api>14</sdk:api>
+            <sdk:revision>2</sdk:revision>
+        </sdk:layoutlib>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>66852371</sdk:size>
+                <sdk:checksum type="sha1">5d1bd10fea962b216a0dece1247070164760a9fc</sdk:checksum>
+                <sdk:url>android-22_r02.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
     </sdk:platform>
 
     <!-- SAMPLES ........................ -->
@@ -839,6 +868,7 @@ June 2014.
         <sdk:revision>01</sdk:revision>
         <sdk:description>Android SDK Samples for Android API 7, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>7677831</sdk:size>
@@ -912,6 +942,7 @@ June 2014.
         <sdk:revision>01</sdk:revision>
         <sdk:description>Android SDK Samples for Android API 11, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>11976920</sdk:size>
@@ -930,6 +961,7 @@ June 2014.
         <sdk:revision>01</sdk:revision>
         <sdk:description>Android SDK Samples for Android API 12, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>12150514</sdk:size>
@@ -948,6 +980,7 @@ June 2014.
         <sdk:revision>01</sdk:revision>
         <sdk:description>Android SDK Samples for Android API 13, revision 1</sdk:description>
         <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>12193502</sdk:size>
@@ -962,6 +995,7 @@ June 2014.
         <!-- Generated at Wed Dec  7 13:48:27 2011 from git_ics-mr0 @ 234950 -->
         <sdk:revision>2</sdk:revision>
         <sdk:api-level>14</sdk:api-level>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>16253619</sdk:size>
@@ -1043,60 +1077,73 @@ June 2014.
     </sdk:sample>
 
     <sdk:sample>
-        <!-- Generated at Wed Jul 23 12:59:18 2014 from git_klp-modular-mr0-release @ 1298572 -->
-        <sdk:revision>2</sdk:revision>
+        <!-- Generated at Mon Nov 17 16:23:46 2014 from git_klp-modular-docs @ 1587091 -->
+        <sdk:revision>3</sdk:revision>
         <sdk:api-level>20</sdk:api-level>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>49718791</sdk:size>
-                <sdk:checksum type="sha1">4b906c46057ee8f502b4f27c23670fd87a49d6ff</sdk:checksum>
-                <sdk:url>samples-20_r02.zip</sdk:url>
+                <sdk:size>50796850</sdk:size>
+                <sdk:checksum type="sha1">8b1290b0b707827808392e8178094a68dfb51a14</sdk:checksum>
+                <sdk:url>samples-20_r03.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:sample>
 
     <sdk:sample>
-        <!-- Generated at Wed Aug 27 10:44:44 2014 from git_lmp-preview-dev @ 1378586 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:codename>L</sdk:codename>
+        <!-- Generated at Mon Dec 9 17:22:11 2014 from git_lmp-docs @ 1634277 -->
+        <sdk:revision>4</sdk:revision>
+        <sdk:api-level>21</sdk:api-level>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>41182182</sdk:size>
-                <sdk:checksum type="sha1">4afc36cf3f53051881729f733fe9bb571104c48f</sdk:checksum>
-                <sdk:url>samples-L_r02.zip</sdk:url>
+                <sdk:size>95971939</sdk:size>
+                <sdk:checksum type="sha1">3a08d37e97f567f5f629a06a9012f89b05c5ad8a</sdk:checksum>
+                <sdk:url>samples-21_r04.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:sample>
+
+    <sdk:sample>
+        <!-- Generated at Mon Mar  2 16:26:21 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
+        <sdk:revision>5</sdk:revision>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>107981157</sdk:size>
+                <sdk:checksum type="sha1">dbc5cc27b5d15acc25cd6b94b8c2971806b70bb0</sdk:checksum>
+                <sdk:url>samples-22_r05.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
     </sdk:sample>
 
     <!-- PLATFORM-TOOLS ........................ -->
 
     <sdk:platform-tool>
-        <!-- Generated at Mon Jun 23 19:20:39 2014 from git_lmp-preview-dev @ 1244090 -->
+        <!-- Generated at Mon Mar  2 16:26:07 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
         <sdk:revision>
-            <sdk:major>20</sdk:major>
+            <sdk:major>22</sdk:major>
             <sdk:minor>0</sdk:minor>
             <sdk:micro>0</sdk:micro>
         </sdk:revision>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>1741113</sdk:size>
-                <sdk:checksum type="sha1">72c34cc6a991f53e2588f9d5487559f013bc30f9</sdk:checksum>
-                <sdk:url>platform-tools_r20-windows.zip</sdk:url>
+                <sdk:size>1848028</sdk:size>
+                <sdk:checksum type="sha1">720214bd29d08eb82673cd81a8159b083eef19d7</sdk:checksum>
+                <sdk:url>platform-tools_r22-windows.zip</sdk:url>
                 <sdk:host-os>windows</sdk:host-os>
             </sdk:archive>
             <sdk:archive>
-                <sdk:size>1753061</sdk:size>
-                <sdk:checksum type="sha1">fb120ce85b6698b801cb4788b204693c1d682b87</sdk:checksum>
-                <sdk:url>platform-tools_r20-linux.zip</sdk:url>
+                <sdk:size>1751911</sdk:size>
+                <sdk:checksum type="sha1">b78be9cc31cf9f9fe0609e29a6a133beacf03b52</sdk:checksum>
+                <sdk:url>platform-tools_r22-linux.zip</sdk:url>
                 <sdk:host-os>linux</sdk:host-os>
             </sdk:archive>
             <sdk:archive>
-                <sdk:size>1666257</sdk:size>
-                <sdk:checksum type="sha1">f2c65c58caf76169d9bebf25eef5c69ff99670b5</sdk:checksum>
-                <sdk:url>platform-tools_r20-macosx.zip</sdk:url>
+                <sdk:size>1743025</sdk:size>
+                <sdk:checksum type="sha1">ddc96385bccf8a15d4f8a11eb1cb9d2a08a531c8</sdk:checksum>
+                <sdk:url>platform-tools_r22-macosx.zip</sdk:url>
                 <sdk:host-os>macosx</sdk:host-os>
             </sdk:archive>
         </sdk:archives>
@@ -1112,6 +1159,7 @@ June 2014.
             <sdk:minor>0</sdk:minor>
             <sdk:micro>0</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>11004914</sdk:size>
@@ -1144,6 +1192,7 @@ June 2014.
             <sdk:minor>0</sdk:minor>
             <sdk:micro>1</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>15413527</sdk:size>
@@ -1174,6 +1223,7 @@ June 2014.
             <sdk:minor>1</sdk:minor>
             <sdk:micro>0</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>19659547</sdk:size>
@@ -1204,6 +1254,7 @@ June 2014.
             <sdk:minor>1</sdk:minor>
             <sdk:micro>1</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>19660000</sdk:size>
@@ -1234,6 +1285,7 @@ June 2014.
             <sdk:minor>0</sdk:minor>
             <sdk:micro>0</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>20611447</sdk:size>
@@ -1264,6 +1316,7 @@ June 2014.
             <sdk:minor>0</sdk:minor>
             <sdk:micro>1</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>20500648</sdk:size>
@@ -1294,6 +1347,7 @@ June 2014.
             <sdk:minor>0</sdk:minor>
             <sdk:micro>2</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>20621117</sdk:size>
@@ -1324,6 +1378,7 @@ June 2014.
             <sdk:minor>0</sdk:minor>
             <sdk:micro>3</sdk:micro>
         </sdk:revision>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>20730715</sdk:size>
@@ -1407,13 +1462,259 @@ June 2014.
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:build-tool>
 
+    <sdk:build-tool>
+        <!-- Generated at Thu Oct 16 16:51:40 2014 from git_lmp-release @ 1521886 -->
+        <sdk:revision>
+            <sdk:major>21</sdk:major>
+            <sdk:minor>0</sdk:minor>
+            <sdk:micro>0</sdk:micro>
+        </sdk:revision>
+        <sdk:obsolete/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>22306371</sdk:size>
+                <sdk:checksum type="sha1">5bc8fd399bc0135a9bc91eec78ddc5af4f54bf32</sdk:checksum>
+                <sdk:url>build-tools_r21-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>22153145</sdk:size>
+                <sdk:checksum type="sha1">4933328fdeecbd554a29528f254f4993468e1cf4</sdk:checksum>
+                <sdk:url>build-tools_r21-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>22668456</sdk:size>
+                <sdk:checksum type="sha1">9bef7989b51436bd4e5114d8a0330359f077cbfa</sdk:checksum>
+                <sdk:url>build-tools_r21-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Fri Oct 17 18:37:07 2014 from git_lmp-release @ 1525922 -->
+        <sdk:revision>
+            <sdk:major>21</sdk:major>
+            <sdk:minor>0</sdk:minor>
+            <sdk:micro>1</sdk:micro>
+        </sdk:revision>
+        <sdk:obsolete/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>22306243</sdk:size>
+                <sdk:checksum type="sha1">d68e7e6fd7a48c8759aa41d713c9d4f0e4c1c1df</sdk:checksum>
+                <sdk:url>build-tools_r21.0.1-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>22153013</sdk:size>
+                <sdk:checksum type="sha1">e573069eea3e5255e7a65bedeb767f4fd0a5f49a</sdk:checksum>
+                <sdk:url>build-tools_r21.0.1-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>22668616</sdk:size>
+                <sdk:checksum type="sha1">b60c8f9b810c980abafa04896706f3911be1ade7</sdk:checksum>
+                <sdk:url>build-tools_r21.0.1-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Tue Oct 21 14:50:58 2014 from git_lmp-release @ 1532339 -->
+        <sdk:revision>
+            <sdk:major>21</sdk:major>
+            <sdk:minor>0</sdk:minor>
+            <sdk:micro>2</sdk:micro>
+        </sdk:revision>
+        <sdk:obsolete/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>22306371</sdk:size>
+                <sdk:checksum type="sha1">37496141b23cbe633167927b7abe6e22d9f1a1c1</sdk:checksum>
+                <sdk:url>build-tools_r21.0.2-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>22153122</sdk:size>
+                <sdk:checksum type="sha1">e1236ab8897b62b57414adcf04c132567b2612a5</sdk:checksum>
+                <sdk:url>build-tools_r21.0.2-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>22668597</sdk:size>
+                <sdk:checksum type="sha1">f17471c154058f3734729ef3cc363399b1cd3de1</sdk:checksum>
+                <sdk:url>build-tools_r21.0.2-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Thu Oct 30 13:18:55 2014 from git_lmp-sdk-release @ 1552913 -->
+        <sdk:revision>
+            <sdk:major>21</sdk:major>
+            <sdk:minor>1</sdk:minor>
+            <sdk:micro>0</sdk:micro>
+        </sdk:revision>
+        <sdk:obsolete/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>32797810</sdk:size>
+                <sdk:checksum type="sha1">c79d63ac6b713a1e326ad4dae43f2ee76708a2f4</sdk:checksum>
+                <sdk:url>build-tools_r21.1-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>32642820</sdk:size>
+                <sdk:checksum type="sha1">b7455e543784d52a8925f960bc880493ed1478cb</sdk:checksum>
+                <sdk:url>build-tools_r21.1-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33158159</sdk:size>
+                <sdk:checksum type="sha1">df619356c2359aa5eacdd48699d15b335d9bd246</sdk:checksum>
+                <sdk:url>build-tools_r21.1-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Mon Nov  3 13:43:11 2014 from git_lmp-sdk-release @ 1559046 -->
+        <sdk:revision>
+            <sdk:major>21</sdk:major>
+            <sdk:minor>1</sdk:minor>
+            <sdk:micro>1</sdk:micro>
+        </sdk:revision>
+        <sdk:obsolete/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>32797356</sdk:size>
+                <sdk:checksum type="sha1">53fc4201237f899d5cd92f0b76ad41fb89da188b</sdk:checksum>
+                <sdk:url>build-tools_r21.1.1-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>32642454</sdk:size>
+                <sdk:checksum type="sha1">1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d</sdk:checksum>
+                <sdk:url>build-tools_r21.1.1-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33157676</sdk:size>
+                <sdk:checksum type="sha1">836a146eab0504aa9387a5132e986fe7c7381571</sdk:checksum>
+                <sdk:url>build-tools_r21.1.1-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Tue Dec  9 15:56:55 2014 from git_lmp-sdk-release @ 1635773 -->
+        <sdk:revision>
+            <sdk:major>21</sdk:major>
+            <sdk:minor>1</sdk:minor>
+            <sdk:micro>2</sdk:micro>
+        </sdk:revision>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>32792587</sdk:size>
+                <sdk:checksum type="sha1">1d944759c47f60e634d2b8a1f3a4259be2f8d652</sdk:checksum>
+                <sdk:url>build-tools_r21.1.2-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>32637678</sdk:size>
+                <sdk:checksum type="sha1">5e35259843bf2926113a38368b08458735479658</sdk:checksum>
+                <sdk:url>build-tools_r21.1.2-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33152878</sdk:size>
+                <sdk:checksum type="sha1">e7c906b4ba0eea93b32ba36c610dbd6b204bff48</sdk:checksum>
+                <sdk:url>build-tools_r21.1.2-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Mon Mar  2 21:35:23 2015 from git_lmp-mr1-sdk-release @ 1764203 -->
+        <sdk:revision>
+            <sdk:major>22</sdk:major>
+            <sdk:minor>0</sdk:minor>
+            <sdk:micro>0</sdk:micro>
+        </sdk:revision>
+        <sdk:obsolete/>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>33254114</sdk:size>
+                <sdk:checksum type="sha1">08fcca41e81b172bd9f570963b90d3a84929e043</sdk:checksum>
+                <sdk:url>build-tools_r22-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33104280</sdk:size>
+                <sdk:checksum type="sha1">a8a1619dd090e44fac957bce6842e62abf87965b</sdk:checksum>
+                <sdk:url>build-tools_r22-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33646090</sdk:size>
+                <sdk:checksum type="sha1">af95429b24088d704bc5db9bd606e34ac1b82c0d</sdk:checksum>
+                <sdk:url>build-tools_r22-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
+    <sdk:build-tool>
+        <!-- Generated at Tue Mar 17 10:54:01 2015 from git_lmp-mr1-sdk-release @ 1793126 -->
+        <sdk:revision>
+            <sdk:major>22</sdk:major>
+            <sdk:minor>0</sdk:minor>
+            <sdk:micro>1</sdk:micro>
+        </sdk:revision>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>33254137</sdk:size>
+                <sdk:checksum type="sha1">61d8cbe069d9e0a57872a83e5e5abe164b7d52cf</sdk:checksum>
+                <sdk:url>build-tools_r22.0.1-windows.zip</sdk:url>
+                <sdk:host-os>windows</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33104577</sdk:size>
+                <sdk:checksum type="sha1">da8b9c5c3ede39298e6cf0283c000c2ee9029646</sdk:checksum>
+                <sdk:url>build-tools_r22.0.1-linux.zip</sdk:url>
+                <sdk:host-os>linux</sdk:host-os>
+            </sdk:archive>
+            <sdk:archive>
+                <sdk:size>33646102</sdk:size>
+                <sdk:checksum type="sha1">53dad7f608e01d53b17176ba11165acbfccc5bbf</sdk:checksum>
+                <sdk:url>build-tools_r22.0.1-macosx.zip</sdk:url>
+                <sdk:host-os>macosx</sdk:host-os>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:build-tool>
+
     <!-- TOOLS ........................ -->
 
     <sdk:tool>
-        <!-- Generated at Wed Jul  2 12:10:55 2014 from git_ub-tools-idea133-milestone @ 1259578 -->
+        <!-- Generated at Fri Feb 27 14:06:48 2015 from aosp-studio-1.1-release @ 1758498 -->
         <sdk:revision>
-            <sdk:major>23</sdk:major>
-            <sdk:minor>0</sdk:minor>
+            <sdk:major>24</sdk:major>
+            <sdk:minor>1</sdk:minor>
             <sdk:micro>2</sdk:micro>
         </sdk:revision>
         <sdk:min-platform-tools-rev>
@@ -1421,21 +1722,21 @@ June 2014.
         </sdk:min-platform-tools-rev>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>141154615</sdk:size>
-                <sdk:checksum type="sha1">0a64ec9b7777bb00ff299c94c359163ef5e443ae</sdk:checksum>
-                <sdk:url>tools_r23.0.2-windows.zip</sdk:url>
+                <sdk:size>159505060</sdk:size>
+                <sdk:checksum type="sha1">c20ffa023618c5cb6953131d6dbb0c628a3a1a14</sdk:checksum>
+                <sdk:url>tools_r24.1.2-windows.zip</sdk:url>
                 <sdk:host-os>windows</sdk:host-os>
             </sdk:archive>
             <sdk:archive>
-                <sdk:size>141930870</sdk:size>
-                <sdk:checksum type="sha1">e8a2d55d750adeaded60a3daad48e62b09aa472a</sdk:checksum>
-                <sdk:url>tools_r23.0.2-linux.zip</sdk:url>
+                <sdk:size>169061591</sdk:size>
+                <sdk:checksum type="sha1">c7c30f6da6eff6323260f0353ccaacc984ea6b3e</sdk:checksum>
+                <sdk:url>tools_r24.1.2-linux.zip</sdk:url>
                 <sdk:host-os>linux</sdk:host-os>
             </sdk:archive>
             <sdk:archive>
-                <sdk:size>90920343</sdk:size>
-                <sdk:checksum type="sha1">c46b1e173188ba82a56d6b9e349fdae4e8922bab</sdk:checksum>
-                <sdk:url>tools_r23.0.2-macosx.zip</sdk:url>
+                <sdk:size>89081357</sdk:size>
+                <sdk:checksum type="sha1">e32ba2fb21cc92ec4f1f01b5cb9a06f666eee460</sdk:checksum>
+                <sdk:url>tools_r24.1.2-macosx.zip</sdk:url>
                 <sdk:host-os>macosx</sdk:host-os>
             </sdk:archive>
         </sdk:archives>
@@ -1445,18 +1746,17 @@ June 2014.
     <!-- DOCS ........................ -->
 
     <sdk:doc>
-        <!-- Generated at Mon Jun 23 19:19:47 2014 from git_lmp-preview-release @ 1242878 -->
+        <!-- Generated at Mon Mar  2 16:25:22 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
         <sdk:revision>1</sdk:revision>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:codename>L</sdk:codename>
+        <sdk:api-level>22</sdk:api-level>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>207889084</sdk:size>
-                <sdk:checksum type="sha1">58a94248c7c960829db3d779c84534e5e783210f</sdk:checksum>
-                <sdk:url>docs-L_r01.zip</sdk:url>
+                <sdk:size>296467484</sdk:size>
+                <sdk:checksum type="sha1">419791c49fa0a305a06966fd1734cf5b0498ea1a</sdk:checksum>
+                <sdk:url>docs-22_r01.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
+        <sdk:uses-license ref="android-sdk-license"/>
     </sdk:doc>
 
     <!-- SOURCES ........................ -->
@@ -1465,6 +1765,7 @@ June 2014.
         <!-- Generated at Wed Dec  7 13:48:11 2011 from git_ics-mr0 @ 234950 -->
         <sdk:revision>1</sdk:revision>
         <sdk:api-level>14</sdk:api-level>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>16152383</sdk:size>
@@ -1558,5 +1859,34 @@ June 2014.
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:source>
+
+    <sdk:source>
+        <!-- Generated at Thu Oct 16 16:53:14 2014 from git_lmp-release @ 1521886 -->
+        <sdk:revision>1</sdk:revision>
+        <sdk:api-level>21</sdk:api-level>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>28274751</sdk:size>
+                <sdk:checksum type="sha1">137a5044915d32bea297a8c1552684802bbc2e25</sdk:checksum>
+                <sdk:url>sources-21_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:source>
+
+    <sdk:source>
+        <!-- Generated at Mon Mar  2 16:26:31 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
+        <sdk:revision>1</sdk:revision>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>28861236</sdk:size>
+                <sdk:checksum type="sha1">98320e13976d11597a4a730a8d203ac9a03ed5a6</sdk:checksum>
+                <sdk:url>sources-22_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:source>
+
 </sdk:sdk-repository>
 

--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,10 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
-stdenv.mkDerivation {
-  name = "android-support-repository-r9";
+stdenv.mkDerivation rec {
+  version = "14";
+  name = "android-support-repository-r${version}";
   src = fetchurl {
-    url = http://dl-ssl.google.com/android/repository/android_m2repository_r09.zip;
-    sha256 = "e5295cdbc086251a2904c081038a7f10056359481c66ecff40e59177fd1c753c";
+    url = "http://dl-ssl.google.com/android/repository/android_m2repository_r${version}.zip";
+    sha256 = "027mmfzvs07nbp28vn6c6cgszqdrmmgwdfzda87936lpi5dwg34p";
   };
 
   buildCommand = ''

--- a/pkgs/development/mobile/androidenv/support.nix
+++ b/pkgs/development/mobile/androidenv/support.nix
@@ -1,10 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
-stdenv.mkDerivation {
-  name = "android-support-r21";
+stdenv.mkDerivation rec {
+  version = "22.1.1";
+  name = "android-support-r${version}";
   src = fetchurl {
-    url = https://dl-ssl.google.com/android/repository/support_r21.zip;
-    sha1 = "f9ef8def5c64f17cd8bc41c5efddd37cb155f0be";
+    url = "https://dl-ssl.google.com/android/repository/support_r${version}.zip";
+    sha1 = "jifv8yjg5jrycf8zd0lfsra00yscggc8";
   };
   
   buildCommand = ''

--- a/pkgs/development/mobile/androidenv/sys-img.xml
+++ b/pkgs/development/mobile/androidenv/sys-img.xml
@@ -423,6 +423,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
         <sdk:description>Android SDK Platform 4.0</sdk:description>
         <sdk:api-level>14</sdk:api-level>
         <sdk:abi>armeabi-v7a</sdk:abi>
+        <sdk:obsolete/>
         <sdk:archives>
             <sdk:archive>
                 <sdk:size>99621822</sdk:size>
@@ -520,40 +521,22 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
     </sdk:system-image>
 
     <sdk:system-image>
-        <!-- Generated at Mon Jun 23 19:22:34 2014 from git_lmp-preview-release @ 1242878 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform L</sdk:description>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:codename>L</sdk:codename>
+        <!-- Generated at Fri Mar  6 08:10:49 2015 from git_lmp-sdk-release @ 1772600 -->
+        <sdk:revision>3</sdk:revision>
+        <sdk:description>Android SDK Platform 5.0.2</sdk:description>
+        <sdk:api-level>21</sdk:api-level>
         <sdk:abi>armeabi-v7a</sdk:abi>
         <sdk:tag-id>default</sdk:tag-id>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>227716008</sdk:size>
-                <sdk:checksum type="sha1">1d5d81a7078b5b2a685620d93e1e04a51d2e786a</sdk:checksum>
-                <sdk:url>sysimg_armv7a-L_r01.zip</sdk:url>
+                <sdk:size>186521381</sdk:size>
+                <sdk:checksum type="sha1">0b2e21421d29f48211b5289ca4addfa7f4c7ae5a</sdk:checksum>
+                <sdk:url>sysimg_arm-21_r03.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
+        <sdk:uses-license ref="android-sdk-license"/>
     </sdk:system-image>
 
-    <sdk:system-image>
-        <!-- Generated at Mon Jun 23 19:23:13 2014 from git_lmp-preview-release @ 1242878 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform L</sdk:description>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:codename>L</sdk:codename>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>245850484</sdk:size>
-                <sdk:checksum type="sha1">c2d32d6244821ff59f370469778525f6a5345010</sdk:checksum>
-                <sdk:url>sysimg_x86-L_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
-    </sdk:system-image>
     <!-- X86 SYSTEM IMAGES ........................ -->
 
     <sdk:system-image>
@@ -653,6 +636,90 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
         <sdk:tag-id>default</sdk:tag-id>
     </sdk:system-image>
 
+    <sdk:system-image>
+        <!-- Generated at Fri Mar  6 08:10:07 2015 from git_lmp-sdk-release @ 1772600 -->
+        <sdk:revision>3</sdk:revision>
+        <sdk:description>Android SDK Platform 5.0.2</sdk:description>
+        <sdk:api-level>21</sdk:api-level>
+        <sdk:abi>x86</sdk:abi>
+        <sdk:tag-id>default</sdk:tag-id>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>201601288</sdk:size>
+                <sdk:checksum type="sha1">a0b510c66769e84fa5e40515531be2d266a4247f</sdk:checksum>
+                <sdk:url>sysimg_x86-21_r03.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:system-image>
+
+    <sdk:system-image>
+        <!-- Generated at Fri Mar  6 08:10:31 2015 from git_lmp-sdk-release @ 1772600 -->
+        <sdk:revision>3</sdk:revision>
+        <sdk:description>Android SDK Platform 5.0.2</sdk:description>
+        <sdk:api-level>21</sdk:api-level>
+        <sdk:abi>x86_64</sdk:abi>
+        <sdk:tag-id>default</sdk:tag-id>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>285253158</sdk:size>
+                <sdk:checksum type="sha1">2f205b728695d84488156f4846beb83a353ea64b</sdk:checksum>
+                <sdk:url>sysimg_x86_64-21_r03.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:system-image>
+
+    <sdk:system-image>
+        <!-- Generated at Mon Mar  2 11:00:17 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
+        <sdk:revision>1</sdk:revision>
+        <sdk:description>Android SDK Platform 5.1</sdk:description>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:abi>x86</sdk:abi>
+        <sdk:tag-id>default</sdk:tag-id>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>207436768</sdk:size>
+                <sdk:checksum type="sha1">6c7bb51e41a16099bb1f2a3cc81fdb5aa053fc15</sdk:checksum>
+                <sdk:url>sysimg_x86-22_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:system-image>
+
+    <sdk:system-image>
+        <!-- Generated at Mon Mar  2 11:00:41 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
+        <sdk:revision>1</sdk:revision>
+        <sdk:description>Android SDK Platform 5.1</sdk:description>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:abi>x86_64</sdk:abi>
+        <sdk:tag-id>default</sdk:tag-id>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>292511941</sdk:size>
+                <sdk:checksum type="sha1">05752813603f9fa03a58dcf7f8f5e779be722aae</sdk:checksum>
+                <sdk:url>sysimg_x86_64-22_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:system-image>
+
+    <sdk:system-image>
+        <!-- Generated at Mon Mar  2 11:01:02 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
+        <sdk:revision>1</sdk:revision>
+        <sdk:description>Android SDK Platform 5.1</sdk:description>
+        <sdk:api-level>22</sdk:api-level>
+        <sdk:abi>armeabi-v7a</sdk:abi>
+        <sdk:tag-id>default</sdk:tag-id>
+        <sdk:archives>
+            <sdk:archive>
+                <sdk:size>193687339</sdk:size>
+                <sdk:checksum type="sha1">2aa6a887ee75dcf3ac34627853d561997792fcb8</sdk:checksum>
+                <sdk:url>sysimg_arm-22_r01.zip</sdk:url>
+            </sdk:archive>
+        </sdk:archives>
+        <sdk:uses-license ref="android-sdk-license"/>
+    </sdk:system-image>
     <!-- MIPS SYSTEM IMAGES ........................ -->
 
     <sdk:system-image>

--- a/pkgs/development/mobile/androidenv/sysimages.nix
+++ b/pkgs/development/mobile/androidenv/sysimages.nix
@@ -1,3 +1,5 @@
+# This file is generated from generate-sysimages.sh. DO NOT EDIT.
+# Execute generate-sysimages.sh or fetch.sh to update the file.
 {stdenv, fetchurl, unzip}:
 
 let
@@ -20,7 +22,7 @@ in
       sha1 = "d8991b0c06b18d7d6ed4169d67460ee1add6661b";
     };
   };
-    
+
   sysimg_armeabi-v7a_15 = buildSystemImage {
     name = "sysimg-armeabi-v7a-15";
     src = fetchurl {
@@ -28,7 +30,7 @@ in
       sha1 = "1bf977d6cb4e0ad38dceac0c4863d1caa21f326e";
     };
   };
-    
+
   sysimg_armeabi-v7a_16 = buildSystemImage {
     name = "sysimg-armeabi-v7a-16";
     src = fetchurl {
@@ -36,7 +38,7 @@ in
       sha1 = "d1cddb23f17aad5821a089c403d4cddad2cf9ef7";
     };
   };
-    
+
   sysimg_armeabi-v7a_17 = buildSystemImage {
     name = "sysimg-armeabi-v7a-17";
     src = fetchurl {
@@ -44,7 +46,7 @@ in
       sha1 = "1c321cda1af793b84d47d1a8d15f85444d265e3c";
     };
   };
-    
+
   sysimg_armeabi-v7a_18 = buildSystemImage {
     name = "sysimg-armeabi-v7a-18";
     src = fetchurl {
@@ -52,7 +54,7 @@ in
       sha1 = "4a1a93200210d8c42793324362868846f67401ab";
     };
   };
-    
+
   sysimg_armeabi-v7a_19 = buildSystemImage {
     name = "sysimg-armeabi-v7a-19";
     src = fetchurl {
@@ -60,23 +62,15 @@ in
       sha1 = "e0d375397e28e3d5d9577a00132463a4696248e5";
     };
   };
-    
-  sysimg_armeabi-v7a_20 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-20";
+
+  sysimg_armeabi-v7a_21 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-21";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_armv7a-L_r01.zip;
-      sha1 = "1d5d81a7078b5b2a685620d93e1e04a51d2e786a";
+      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_arm-21_r03.zip;
+      sha1 = "0b2e21421d29f48211b5289ca4addfa7f4c7ae5a";
     };
   };
-    
-  sysimg_x86_20 = buildSystemImage {
-    name = "sysimg-x86-20";
-    src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_x86-L_r01.zip;
-      sha1 = "c2d32d6244821ff59f370469778525f6a5345010";
-    };
-  };
-    
+
   sysimg_x86_10 = buildSystemImage {
     name = "sysimg-x86-10";
     src = fetchurl {
@@ -84,7 +78,7 @@ in
       sha1 = "34e2436f69606cdfe35d3ef9112f0c64e3ff021d";
     };
   };
-    
+
   sysimg_x86_15 = buildSystemImage {
     name = "sysimg-x86-15";
     src = fetchurl {
@@ -92,7 +86,7 @@ in
       sha1 = "d540325952e0f097509622b9e685737584b83e40";
     };
   };
-    
+
   sysimg_x86_16 = buildSystemImage {
     name = "sysimg-x86-16";
     src = fetchurl {
@@ -100,7 +94,7 @@ in
       sha1 = "9d35bcaa4f9b40443941f32b8a50337f413c021a";
     };
   };
-    
+
   sysimg_x86_17 = buildSystemImage {
     name = "sysimg-x86-17";
     src = fetchurl {
@@ -108,7 +102,7 @@ in
       sha1 = "ddb3313e8dcd07926003f7b828eafea1115ea35b";
     };
   };
-    
+
   sysimg_x86_18 = buildSystemImage {
     name = "sysimg-x86-18";
     src = fetchurl {
@@ -116,7 +110,7 @@ in
       sha1 = "f11bc9fccd3e7e46c07d8b26e112a8d0b45966c1";
     };
   };
-    
+
   sysimg_x86_19 = buildSystemImage {
     name = "sysimg-x86-19";
     src = fetchurl {
@@ -124,7 +118,47 @@ in
       sha1 = "8889cb418984a2a7916a359da7c429d2431ed060";
     };
   };
-    
+
+  sysimg_x86_21 = buildSystemImage {
+    name = "sysimg-x86-21";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_x86-21_r03.zip;
+      sha1 = "a0b510c66769e84fa5e40515531be2d266a4247f";
+    };
+  };
+
+  sysimg_x86_64_21 = buildSystemImage {
+    name = "sysimg-x86_64-21";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_x86_64-21_r03.zip;
+      sha1 = "2f205b728695d84488156f4846beb83a353ea64b";
+    };
+  };
+
+  sysimg_x86_22 = buildSystemImage {
+    name = "sysimg-x86-22";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_x86-22_r01.zip;
+      sha1 = "6c7bb51e41a16099bb1f2a3cc81fdb5aa053fc15";
+    };
+  };
+
+  sysimg_x86_64_22 = buildSystemImage {
+    name = "sysimg-x86_64-22";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_x86_64-22_r01.zip;
+      sha1 = "05752813603f9fa03a58dcf7f8f5e779be722aae";
+    };
+  };
+
+  sysimg_armeabi-v7a_22 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-22";
+    src = fetchurl {
+      url = https://dl-ssl.google.com/android/repository/sys-img/android/sysimg_arm-22_r01.zip;
+      sha1 = "2aa6a887ee75dcf3ac34627853d561997792fcb8";
+    };
+  };
+
   sysimg_mips_15 = buildSystemImage {
     name = "sysimg-mips-15";
     src = fetchurl {
@@ -132,7 +166,7 @@ in
       sha1 = "a753bb4a6783124dad726c500ce9aec9d2c1b2d9";
     };
   };
-    
+
   sysimg_mips_16 = buildSystemImage {
     name = "sysimg-mips-16";
     src = fetchurl {
@@ -140,7 +174,7 @@ in
       sha1 = "67943c54fb3943943ffeb05fdd39c0b753681f6e";
     };
   };
-    
+
   sysimg_mips_17 = buildSystemImage {
     name = "sysimg-mips-17";
     src = fetchurl {
@@ -148,4 +182,4 @@ in
       sha1 = "f0c6e153bd584c29e51b5c9723cfbf30f996a05d";
     };
   };
-    }
+}


### PR DESCRIPTION
Detailed changes:
- android-sdk: update 24.0.1 -> 24.1.2
- android-platforms: add 5.1.1
- android-platform-tools: update 21 -> 22
- android-build-tools: update 21.1.2 -> 22.0.1
- android-support: update 21 -> 22.1.1
- android-support-repository: update 9 -> 14

Maybe we should update all-packages.nix as well.
