### PR TITLE
Add PAM support for U2F devices

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -153,6 +153,7 @@
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   phausmann = "Philipp Hausmann <nix@314.ch>";
+  philandstuff = "Philip Potter <philip.g.potter@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";
   piotr = "Piotr Pietraszkiewicz <ppietrasa@gmail.com>";

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -36,6 +36,16 @@ let
         '';
       };
 
+      u2fAuth = mkOption {
+        default = config.security.pam.enableU2F;
+        type = types.bool;
+        description = ''
+          If set, users listed in
+          <filename>~/.yubico/u2f_keys</filename> are able to log in
+          with the associated U2F key.
+        '';
+      };
+
       usbAuth = mkOption {
         default = config.security.pam.usb.enable;
         type = types.bool;
@@ -209,6 +219,8 @@ let
               "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u"}
           ${optionalString cfg.fprintAuth
               "auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so"}
+          ${optionalString cfg.u2fAuth
+              "auth sufficient ${pkgs.pam_u2f}/lib/security/pam_u2f.so"}
           ${optionalString cfg.usbAuth
               "auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so"}
           ${optionalString cfg.unixAuth
@@ -364,6 +376,13 @@ in
       '';
     };
 
+    security.pam.enableU2F = mkOption {
+      default = false;
+      description = ''
+        Enable the U2F PAM module.
+      '';
+    };
+
     security.pam.enableEcryptfs = mkOption {
       default = false;
       description = ''
@@ -392,6 +411,7 @@ in
       ++ optionals config.krb5.enable [pam_krb5 pam_ccreds]
       ++ optionals config.security.pam.enableOTPW [ pkgs.otpw ]
       ++ optionals config.security.pam.enableOATH [ pkgs.oathToolkit ]
+      ++ optionals config.security.pam.enableU2F [ pkgs.pam_u2f ]
       ++ optionals config.security.pam.enableEcryptfs [ pkgs.ecryptfs ];
 
     security.setuidPrograms =

--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://developers.yubico.com/libu2f-host;
-    description = "a C library and command-line tool thati mplements the host-side of the U2F protocol";
+    description = "A C library and command-line tool thati mplements the host-side of the U2F protocol";
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ wkennington ];

--- a/pkgs/development/libraries/libu2f-server/default.nix
+++ b/pkgs/development/libraries/libu2f-server/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, json_c, hidapi, openssl, check }:
+
+stdenv.mkDerivation rec {
+  name = "libu2f-server-0.0.0";
+
+  src = fetchurl {
+    url = "https://developers.yubico.com/libu2f-server/Releases/libu2f-server-0.0.0.tar.xz";
+    sha256 = "1vdl3qavzfpi6p6h48zw17md9wykfzpay5c4l1c08id46m560wp0";
+  };
+
+  buildInputs = [ pkgconfig json_c hidapi openssl check ];
+
+  meta = with stdenv.lib; {
+    homepage = https://developers.yubico.com/libu2f-server/;
+    description = "A C library that implements the server-side of the U2F protocol";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ philandstuff ];
+  };
+}

--- a/pkgs/os-specific/linux/pam_u2f/default.nix
+++ b/pkgs/os-specific/linux/pam_u2f/default.nix
@@ -1,0 +1,22 @@
+{ pkgs, fetchurl, stdenv }:
+stdenv.mkDerivation rec {
+  name    = "pam_u2f-${version}";
+  version = "0.0.1";
+  src     = fetchurl {
+    url = "https://developers.yubico.com/pam-u2f/Releases/${name}.tar.gz";
+    sha256 = "0p1wia4nfw5h0pmy1lcgwsbrlm7z39v1n37692lgqfzyg1kmpv7l";
+  };
+  buildInputs = with pkgs; [ asciidoc autoconf automake docbook_xml_dtd_45 libtool libu2f-host libu2f-server libxml2 libxslt pkgconfig pam ];
+
+  installFlags = [
+    "PAMDIR=$(out)/lib/security"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://developers.yubico.com/pam-u2f/;
+    description = "A PAM module for allowing authentication with a U2F device";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ philandstuff ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6920,6 +6920,8 @@ let
 
   libu2f-host = callPackage ../development/libraries/libu2f-host { };
 
+  libu2f-server = callPackage ../development/libraries/libu2f-server { };
+
   libunistring = callPackage ../development/libraries/libunistring { };
 
   libupnp = callPackage ../development/libraries/pupnp { };
@@ -9572,6 +9574,8 @@ let
   pam_mount = callPackage ../os-specific/linux/pam_mount { };
 
   pam_ssh_agent_auth = callPackage ../os-specific/linux/pam_ssh_agent_auth { };
+
+  pam_u2f = callPackage ../os-specific/linux/pam_u2f { };
 
   pam_usb = callPackage ../os-specific/linux/pam_usb { };
 


### PR DESCRIPTION
This adds support for Yubikey's pam_u2f module, which allows using a U2F device such as a Yubikey NEO to authenticate to the system.
