### PR TITLE
patch-headers: Add fixup hook

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-headers.sh
+++ b/pkgs/build-support/setup-hooks/patch-headers.sh
@@ -1,0 +1,75 @@
+# This setup hook causes the fixup phase to rewrite all header
+# system includes to be rewritten to absolute paths.  E.g.,
+# #include <stdint.h> will be rewritten to /nix/store/<hash>-some-glibc/include/stdint.h.
+# TODO: Fix absolute paths to headers for cc and libc
+
+fixupOutputHooks+=('if [ -z "$dontPatchHeaders" ]; then patchHeaders "$prefix"; fi')
+
+patchHeaders() {
+    local dir="$1"
+
+    # Check to see if we even have headers
+    [ ! -d $dir/include ] && return 0
+
+    header "patching header files in $dir"
+
+    # Figure out what system header directories are available
+    local extractHeaders='i{print;i=0} /-isystem/{i=1}; /-I/{print substr($0,3)}'
+    local includeDirs=()
+    readarray -t includeDirs <<< "$(echo "$NIX_CFLAGS_COMPILE" | \
+      tr ' ' '\n' | awk "${extractHeaders}")"
+
+    # We must include ourself as a system directory
+    includeDirs+=("$dir/include")
+
+    # Iterate over every file and replace headers
+    rm -f $TMPDIR/patch-headers.awk
+    for file in $(find $dir/include -type f); do
+      # Build the script awk uses to fix headers
+      echo '{' > $TMPDIR/patch-headers.awk
+      local headerTuples
+      readarray -t headerTuples <<< \
+        "$(sed -n 's,.*\(#include \(<\|"\)\([^/>][^>]*\)\(>\|"\)\).*,\3 \1,p' $file)"
+      for headerTuple in "${headerTuples[@]}"; do
+        [ -z "$headerTuple" ] && continue
+        local header="$(echo "$headerTuple" | cut -d' ' -f1)"
+        local includeStmt="$(echo "$headerTuple" | cut -d' ' -f2-)"
+
+        # If we are not doing a system include the include can
+        # reside relative to the current working directory of the
+        # header we are fixing.
+        local canReferToPwd=0
+        if echo "$includeStmt" | grep -q '#include "'; then
+          canReferToPwd=1
+          includeDirs+=("$(dirname "$file")")
+        fi
+
+        # Determine which include path holds the header
+        # we are trying to include
+        local absolute=""
+        for includeDir in "${includeDirs[@]}"; do
+          local tmpName="$(readlink -f "$includeDir/$header")"
+          [ -f "$tmpName" ] && absolute="$tmpName"
+        done
+
+        # Unroll the includeDirs array if we added a cwd
+        if [ "$canReferToPwd" -eq "1" ]; then
+          includeDirs=("${includeDirs[@]:0:${#includeDirs[@]}-1}")
+        fi
+
+        # Generate the expression used for fixing the header file
+        if [ -n "$absolute" ]; then
+          local escapedInclude="$(echo "$includeStmt" | sed 's,/,\\/,g')"
+          echo "\$0=gensub(/$escapedInclude/,\"#include \\\"$absolute\\\"\",\"g\",\$0); " \
+            >> $TMPDIR/patch-headers.awk
+        fi
+      done
+      echo 'print $0}' >> $TMPDIR/patch-headers.awk
+
+      awk -f $TMPDIR/patch-headers.awk $file > $TMPDIR/patch-headers.out
+      mv $TMPDIR/patch-headers.out $file
+      rm $TMPDIR/patch-headers.awk
+    done
+
+    stopNest
+}

--- a/pkgs/build-support/setup-hooks/patch-headers.sh
+++ b/pkgs/build-support/setup-hooks/patch-headers.sh
@@ -1,7 +1,6 @@
 # This setup hook causes the fixup phase to rewrite all header
 # system includes to be rewritten to absolute paths.  E.g.,
 # #include <stdint.h> will be rewritten to /nix/store/<hash>-some-glibc/include/stdint.h.
-# TODO: Fix absolute paths to headers for cc and libc
 
 fixupOutputHooks+=('if [ -z "$dontPatchHeaders" ]; then patchHeaders "$prefix"; fi')
 
@@ -13,25 +12,41 @@ patchHeaders() {
 
     header "patching header files in $dir"
 
+    # HACK: Fix gcc header linking by using the new cpp binary
+    # This prevents us from linking to bootstrap tools in new stdenvs
+    local cpp=cpp
+    local output
+    for output in $outputs; do
+      if ${!output}/bin/cpp --help >/dev/null 2>&1; then
+        cpp=${!output}/bin/cpp
+        break
+      fi
+    done
+
     # Iterate over every file and replace headers
     rm -f $TMPDIR/patch-headers.awk
+    local file
     for file in $(find $dir/include -type f); do
       # Determine what paths to search for includes
       # CPP is the most reliable way to parse the environment as
       # it gives us system and libc includes as well.
-      local rawCpp="$(cpp -v -M $NIX_CFLAGS_COMPILE $file 2>&1)"
+      local rawCpp="$($cpp -v -M $NIX_CFLAGS_COMPILE $file 2>&1)"
       if [ "$?" -ne "0" ]; then
-        echo "Failed to process: $file"
+        echo "Failed to process: $file" >&2
         continue
       fi
 
       # Parse the cpp output into useful header location lists
-      local systemIncludes="$(echo "$rawCpp" | awk '/End/{f=0};f{print $1};/#include </{f=1};')"
-      local localIncludes="$(echo "$rawCpp" | awk '/#include </{f=0};f{print $1};/#include "/{f=1};')"
-      local tmpComb="$(dirname "$file")"$'\n'"$localIncludes"$'\n'"$systemIncludes"
-      local localAndSystemIncludes="$(echo "$tmpComb" | grep -v '^[ \r]*$')"
+      local cppSystemIncludes="$(echo "$rawCpp" | awk '/End/{f=0};f{print $1};/#include </{f=1};')"
+      local tmpComb="$dir/include"$'\n'"$cppSystemIncludes"
+      local systemIncludes="$(echo "$tmpComb" | grep -v '^[ \r]*$')"
+
+      local cppLocalIncludes="$(echo "$rawCpp" | awk '/#include </{f=0};f{print $1};/#include "/{f=1};')"
+      local tmpComb="$(dirname "$file")"$'\n'"$cppLocalIncludes"$'\n'"$systemIncludes"
+      local localIncludes="$(echo "$tmpComb" | grep -v '^[ \r]*$')"
+
       local headerPath="$(readlink -f "$(dirname "$file")")"
-      local nextIncludes="$(for includeDir in $localAndSystemIncludes; do
+      local nextIncludes="$(for includeDir in $localIncludes; do
         [ "$(readlink -f "$includeDir")" != "$headerPath" ] && echo "$includeDir"; done)"
 
       # Build the script awk uses to fix headers
@@ -44,19 +59,25 @@ patchHeaders() {
       # include_next in this context would effectively exclude any cwd
       local headerTuples
       readarray -t headerTuples <<< \
-        "$(sed -n 's,.*\(#[ ]*include\?\(_next\)[ ]*\(<\|"\)\([^/>][^>]*\)\(>\|"\)\).*,\4 \1,p' $file)"
+        "$(sed -n 's;.*\(#[ ]*include\(_next\)\{0,1\}[ ]*\(<\|"\)\([^/>][^>]*\)\(>\|"\)\).*;\4 \1;p' $file)"
 
       # Determine where each of the includes resides and build an expression to patch it
+      local headerTuple
       for headerTuple in "${headerTuples[@]}"; do
         [ -z "$headerTuple" ] && continue
         local header="$(echo "$headerTuple" | cut -d' ' -f1)"
         local includeStmt="$(echo "$headerTuple" | cut -d' ' -f2-)"
 
+        # HACK: Prevent cyclic references to compiler defined headers
+        # which bring in dependencies like bootstrap-tools.
+        # These headers are guaranteed to exist.
+        grep -q '^\(stddef.h\|stdarg.h\|limits.h\|float.h\)$' <<< "$header" && continue
+
         # Determine directory list based on the type of include
         if echo "$includeStmt" | grep -q '_next'; then
           local includeDirs="$nextIncludes"
         elif echo "$includeStmt" | grep -q '"'; then
-          local includeDirs="$localAndSystemIncludes"
+          local includeDirs="$localIncludes"
         else
           local includeDirs="$systemIncludes"
         fi
@@ -64,9 +85,13 @@ patchHeaders() {
         # Determine which include path holds the header
         # we are trying to include
         local absolute=""
+        local includeDir
         for includeDir in $includeDirs; do
           local tmpName="$(readlink -f "$includeDir/$header")"
-          [ -f "$tmpName" ] && absolute="$tmpName"
+          if [ -f "$tmpName" ]; then
+            absolute="$tmpName"
+            break
+          fi
         done
 
         # Generate the expression used for fixing the header file

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -73,6 +73,7 @@ let
     [ ../../build-support/setup-hooks/move-docs.sh
       ../../build-support/setup-hooks/compress-man-pages.sh
       ../../build-support/setup-hooks/strip.sh
+      ../../build-support/setup-hooks/patch-headers.sh
       ../../build-support/setup-hooks/patch-shebangs.sh
       ../../build-support/setup-hooks/move-sbin.sh
       ../../build-support/setup-hooks/move-lib64.sh


### PR DESCRIPTION
This patch is the first step in removing some of the propagatedBuildInputs hacks needed for some applications which depend on headers but don't list them in their package config, or are not detected through the package config interface.

This patch adds a hook which resolves all includes within c / c++ header files to their absolute paths and substitutes them into the original headers. This should mimic the behavior of cpp -I / -isystem in the behavior of resolution. It also respects the distinction between system includes and system + cwd includes (#include <> vs #include "").

Eg. If we are building libvorbis and we have $out/include/codec.h which contains "#include <ogg/ogg.h>" this would resolve that to ${libogg}/include/ogg/ogg.h and replace the include with "#include \"/nix/store/xxxxxxxxxxxxxxxxxx-libogg-1.3.2/include/ogg/ogg.h\"".
