### PR TITLE
fix wavpack .pc file

### DIFF
--- a/pkgs/development/libraries/wavpack/default.nix
+++ b/pkgs/development/libraries/wavpack/default.nix
@@ -4,6 +4,12 @@ stdenv.mkDerivation rec {
   name = "wavpack-${version}";
   version = "4.70.0";
 
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    sed -i '2iexec_prefix=@exec_prefix@' wavpack.pc.in
+  '';
+
   src = fetchurl {
     url = "http://www.wavpack.com/${name}.tar.bz2";
     sha256 = "191h8hv8qk72hfh1crg429i9yq3cminwqb249sy9zadbn1wy7b9c";


### PR DESCRIPTION
The .pc file is missing declaration of exec_prefix causing other packages to
fail such as gst-plugins-good beacuse pkg-config stops processing
remaining .pc files

I notified david at wavpack com

enableParallelBuilding = true; also happens to work
