### PR TITLE
freemind: 0.9.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/misc/freemind/default.nix
+++ b/pkgs/applications/misc/freemind/default.nix
@@ -1,51 +1,42 @@
-{ stdenv, fetchurl, jdk, jre, ant, coreutils, gnugrep }:
+{ stdenv, fetchurl, jdk, jre, ant }:
 
-stdenv.mkDerivation {
-  name = "freemind-0.9.0";
+stdenv.mkDerivation rec {
+  name = "freemind-${version}";
+  version = "1.0.1";
 
   src = fetchurl {
-    url = mirror://sourceforge/freemind/freemind-src-0.9.0.tar.gz;
-    sha256 = "1qd535gwx00d8z56mplxli5529yds2gsmbgla5b0bhhmsdwmrxmf";
+    url = "mirror://sourceforge/freemind/freemind-src-${version}.tar.gz";
+    sha256 = "06c6pm7hpwh9hbmyah3lj2wp1g957x8znfwc5cwygsi7dc98b0h1";
   };
 
   buildInputs = [ jdk ant ];
 
-  phases = "unpackPhase patchPhase buildPhase installPhase";
+  preConfigure = ''
+    chmod +x check_for_duplicate_resources.sh
+    sed 's,/bin/bash,${stdenv.shell},' -i check_for_duplicate_resources.sh
 
-  patchPhase = ''
-    # There is a complain about this. I don't understand it.
-    mkdir plugins/plugins
+    ## work around javac encoding errors
+    export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
   '';
 
-  buildPhase="ant dist";
-  
-  # LIBXCB_ALLOW_SLOPPY_LOCK=true :
-  # don't know yet what this option really means but I'm no longer getting
-  #   Checking Java Version...
-  #   Locking assertion failure.  Backtrace:
-  #   java: xcb_xlib.c:82: xcb_xlib_unlock: Assertion `c->xlib.lock' failed
-  # this way
-  # reference and more info https://bugs.launchpad.net/ubuntu/+source/sun-java5/+bug/86103
-  # JDK 7 beta seems to have fixed this (bug ?)
+  buildPhase = "ant dist";
 
   installPhase = ''
     mkdir -p $out/{bin,nix-support}
     cp -r ../bin/dist $out/nix-support
     sed -i 's/which/type -p/' $out/nix-support/dist/freemind.sh
-    cat > $out/bin/freemind << EOF
-    #!/bin/sh
-    export PATH=${coreutils}/bin:${gnugrep}/bin:"$PATH"
-    export JAVA_HOME="${jre}"
-    export LIBXCB_ALLOW_SLOPPY_LOCK=true
-    $out/nix-support/dist/freemind.sh
-    EOF
 
+    cat >$out/bin/freemind <<EOF
+    #! /bin/sh
+    JAVA_HOME=${jre} $out/nix-support/dist/freemind.sh
+    EOF
     chmod +x $out/{bin/freemind,nix-support/dist/freemind.sh}
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Mind-mapping software";
     homepage = http://freemind.sourceforge.net/wiki/index.php/Main_Page;
-    license = "GPL";
-  }; 
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10871,10 +10871,7 @@ let
     inherit (pythonPackages) matplotlib pycollada;
   };
 
-  freemind = callPackage ../applications/misc/freemind {
-    jdk = jdk;
-    jre = jdk;
-  };
+  freemind = callPackage ../applications/misc/freemind { };
 
   freenet = callPackage ../applications/networking/p2p/freenet { };
 


### PR DESCRIPTION
See http://freemind.sourceforge.net/wiki/index.php/FreeMind_1.0.0:_The_New_Features
for an overview of changes in version 1.

Tested briefly by creating, saving & loading a simple mind map. The
problems referred to in the previous version of the build recipe
do not occur for me.

This patch simplifies the build somewhat, but it could still be improved
by not copying the freemind dist wholesale into nix-support and replacing
freemind.sh with a more specialized wrapper.
