### PR TITLE
Fix #7279, attribute interpreterName missing

### DIFF
--- a/pkgs/development/web/nodejs/build-node-package.nix
+++ b/pkgs/development/web/nodejs/build-node-package.nix
@@ -4,7 +4,7 @@
   name, version ? "", src,
 
   # by default name of nodejs interpreter e.g. "nodejs-${name}"
-  namePrefix ? nodejs.interpreterName + "-",
+  namePrefix ? (nodejs.interpreterName or "") + "-",
 
   # Node package name
   pkgName ?


### PR DESCRIPTION
error: attribute ‘interpreterName’ missing, at "[..]/pkgs/development/web/nodejs/build-node-package.nix":7:16
when doing nix-env -qa
Fix #7279
