### PR TITLE
haskell-data-hash: disable broken test suite

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -349,6 +349,7 @@ self: super: {
   conduit-connection = dontCheck super.conduit-connection;
   craftwerk = dontCheck super.craftwerk;
   damnpacket = dontCheck super.damnpacket;              # http://hydra.cryp.to/build/496923/log
+  data-hash = dontCheck super.data-hash;
   Deadpan-DDP = dontCheck super.Deadpan-DDP;            # http://hydra.cryp.to/build/496418/log/raw
   DigitalOcean = dontCheck super.DigitalOcean;
   directory-layout = dontCheck super.directory-layout;


### PR DESCRIPTION
Test suite is broken on GHC 7.10.

@peti 
