### PR TITLE
dbus: Build on Darwin (Regression fix)

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -76,7 +76,7 @@ let
     # (it just execs dbus-launch in dbus.tools), contrary to what the configure script demands.
     NIX_CFLAGS_COMPILE = "-DDBUS_ENABLE_X11_AUTOLAUNCH=1";
     buildInputs = [ systemdOrEmpty ];
-    meta.platforms = with stdenv.lib.platforms; allBut darwin;
+    meta.platforms = stdenv.lib.platforms.all;
   };
 
 


### PR DESCRIPTION
Re-enables building dbus on darwin, disabled in 232b71c6e8d0722270568567c9a343ad7e15602d.

Dbus does build on Darwin, and is a dependency of several important packages
such as gtk3.

@wkennington
