### PR TITLE
pulseaudio.nix: user and group are now pulseaudio

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -143,17 +143,17 @@ in {
     })
 
     (mkIf systemWide {
-      users.extraUsers.pulse = {
+      users.extraUsers.pulseaudio = {
         # For some reason, PulseAudio wants UID == GID.
         uid = assert uid == gid; uid;
-        group = "pulse";
+        group = "pulseaudio";
         extraGroups = [ "audio" ];
         description = "PulseAudio system service user";
         home = stateDir;
         createHome = true;
       };
 
-      users.extraGroups.pulse.gid = gid;
+      users.extraGroups.pulseaudio.gid = gid;
 
       systemd.services.pulseaudio = {
         description = "PulseAudio System-Wide Server";


### PR DESCRIPTION
pulseaudio couldn't start in system mode because it was complaining:
"Failed to find user 'pulseaudio'."
"Failed to find group 'pulseaudio'."
