### PR TITLE
libuv: version 1.4.2

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -105,5 +105,5 @@ in
   //
   mapAttrs (v: h: mkWithAutotools stable (toVersion v) h) {
     v1_2_0 = "1nbp8qpgw64gl9nrjzxw0ndv1m64cfms0cy5a2883vw6877kizmx";
-    v1_4_0 = "17k028gn07vb9in440wbf0ar0rdl8bi5v4shm8nhj22vfb18dhl5";
+    v1_4_2 = "03ffyjyz92ipi2im05hvlx7jypv9c8fyp90zqyr91w7vszskxnxw";
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1884,7 +1884,7 @@ let
   else
     nodePackages_0_12;
 
-  iojs = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_0; };
+  iojs = callPackage ../development/web/iojs { libuv = libuvVersions.v1_4_2; };
 
   iojsPackages = callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; };
 
@@ -6935,6 +6935,8 @@ let
   libuvVersions = recurseIntoAttrs (callPackage ../development/libraries/libuv {
     automake = automake113x; # fails with 14
   });
+
+  libuv = libuvVersions.v1_4_2;
 
   libv4l = lowPrio (v4l_utils.override {
     alsaLib = null;


### PR DESCRIPTION
Replaces 1.4.0 and adds libuv as a top-level package.
