### PR TITLE
less: Update source package hash

### DIFF
--- a/pkgs/tools/misc/less/default.nix
+++ b/pkgs/tools/misc/less/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.greenwoodsoftware.com/less/${name}.tar.gz";
-    sha256 = "1w7d10h6hzgz5zww8g4aja2fbl7xwx30vd07hcg1fcy7hm8yc1q2";
+    sha256 = "16703m6g5l97af3jwpypgac7gpmh3yjkdpqygf5a2scfip0hxm2g";
   };
 
   # Look for ‘sysless’ in /etc.


### PR DESCRIPTION
Upstream less seems to have changed the distribution package slightly.

This is the diff (got the former package from http://mirror.pistoncloud.com/source/less-475.tar.gz):

```
diff --git old/less-475/README new/less-475/README
index 2d25c85..ed2bfb1 100644
--- old/less-475/README
+++ new/less-475/README
@@ -1,7 +1,7 @@

                             Less, version 475

-    This is the distribution of less, version 475, released 05 Mar 2015.
+    This is the distribution of less, version 475, released 02 May 2015.
     This program is part of the GNU project (http://www.gnu.org).

     This program is free software.  You may redistribute it and/or
diff --git old/less-475/filename.c new/less-475/filename.c
index 290ba23..7e95d83 100644
--- old/less-475/filename.c
+++ new/less-475/filename.c
@@ -979,7 +979,7 @@ close_altfile(altfilename, filename, pipefd)
            return;
    if (num_pct_s(lessclose) > 2) 
    {
-       error("Invalid LESSCLOSE variable");
+       error("Invalid LESSCLOSE variable", NULL_PARG);
        return;
    }
    len = (int) (strlen(lessclose) + strlen(filename) + strlen(altfilename) + 2);
diff --git old/less-475/less.man new/less-475/less.man
index 8c1430a..998c6b1 100644
--- old/less-475/less.man
+++ new/less-475/less.man
@@ -1632,4 +1632,4 @@ LESS(1)                     General Commands Manual                    LESS(1)



-                           Version 475: 05 Mar 2015                    LESS(1)
+                           Version 475: 02 May 2015                    LESS(1)
diff --git old/less-475/less.nro new/less-475/less.nro
index 2a703c8..7b00158 100644
--- old/less-475/less.nro
+++ new/less-475/less.nro
@@ -1,4 +1,4 @@
-.TH LESS 1 "Version 475: 05 Mar 2015"
+.TH LESS 1 "Version 475: 02 May 2015"
 .SH NAME
 less \- opposite of more
 .SH SYNOPSIS
diff --git old/less-475/lessecho.man new/less-475/lessecho.man
index a5bd9cd..b3a002e 100644
--- old/less-475/lessecho.man
+++ new/less-475/lessecho.man
@@ -51,4 +51,4 @@ LESSECHO(1)                 General Commands Manual                LESSECHO(1)



-                           Version 475: 05 Mar 2015                LESSECHO(1)
+                           Version 475: 02 May 2015                LESSECHO(1)
diff --git old/less-475/lessecho.nro new/less-475/lessecho.nro
index 75285df..04b0656 100644
--- old/less-475/lessecho.nro
+++ new/less-475/lessecho.nro
@@ -1,4 +1,4 @@
-.TH LESSECHO 1 "Version 475: 05 Mar 2015"
+.TH LESSECHO 1 "Version 475: 02 May 2015"
 .SH NAME
 lessecho \- expand metacharacters
 .SH SYNOPSIS
diff --git old/less-475/lesskey.man new/less-475/lesskey.man
index 76e1fe9..865367b 100644
--- old/less-475/lesskey.man
+++ new/less-475/lesskey.man
@@ -355,4 +355,4 @@ LESSKEY(1)                  General Commands Manual                 LESSKEY(1)



-                           Version 475: 05 Mar 2015                 LESSKEY(1)
+                           Version 475: 02 May 2015                 LESSKEY(1)
diff --git old/less-475/lesskey.nro new/less-475/lesskey.nro
index fb62e8d..0f28994 100644
--- old/less-475/lesskey.nro
+++ new/less-475/lesskey.nro
@@ -1,4 +1,4 @@
-.TH LESSKEY 1 "Version 475: 05 Mar 2015"
+.TH LESSKEY 1 "Version 475: 02 May 2015"
 .SH NAME
 lesskey \- specify key bindings for less
 .SH SYNOPSIS
```
