### PR TITLE
Enable old pythons' wide builds

### DIFF
--- a/pkgs/development/interpreters/python/2.6/default.nix
+++ b/pkgs/development/interpreters/python/2.6/default.nix
@@ -63,7 +63,7 @@ let
     C_INCLUDE_PATH = concatStringsSep ":" (map (p: "${p}/include") buildInputs);
     LIBRARY_PATH = concatStringsSep ":" (map (p: "${p}/lib") buildInputs);
 
-    configureFlags = "--enable-shared --with-threads --enable-unicode";
+    configureFlags = "--enable-shared --with-threads --enable-unicode=ucs4";
 
     NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin "-msse2";
 

--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -79,7 +79,7 @@ let
     C_INCLUDE_PATH = concatStringsSep ":" (map (p: "${p}/include") buildInputs);
     LIBRARY_PATH = concatStringsSep ":" (map (p: "${p}/lib") buildInputs);
 
-    configureFlags = "--enable-shared --with-threads --enable-unicode";
+    configureFlags = "--enable-shared --with-threads --enable-unicode=ucs4";
 
     NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin "-msse2";
     DETERMINISTIC_BUILD = 1;

--- a/pkgs/development/interpreters/python/3.2/default.nix
+++ b/pkgs/development/interpreters/python/3.2/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
     done
     ${optionalString stdenv.isDarwin ''export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"''}
 
-    configureFlagsArray=( --enable-shared --with-threads
+    configureFlagsArray=( --enable-shared --with-threads --with-wide-unicode
                           CPPFLAGS="${concatStringsSep " " (map (p: "-I${p}/include") buildInputs)}"
                           LDFLAGS="${concatStringsSep " " (map (p: "-L${p}/lib") buildInputs)}"
                           LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"


### PR DESCRIPTION
You might want to make this configurable for the user, rather than just merging this straight away. Anyhow I think that this should be the default, rather than the narrow builds.

Wide builds are the "correct" choice and won't fail at runtime. They also expose the same behavior as Python >= 3.3 . The tradeoff is obviously memory consumption.
