### PR TITLE
pulseaudio: system user and group changed to pulse.

### DIFF
--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -148,8 +148,8 @@ stdenv.mkDerivation rec {
     (mkEnable true                    "manpages"                   null)
     (mkEnable hasWebrtc               "webrtc-aec"                 null)
     (mkEnable true                    "adrian-aec"                 null)
-    (mkWith   true                    "system-user"                "pulseaudio")
-    (mkWith   true                    "system-group"               "pulseaudio")
+    (mkWith   true                    "system-user"                "pulse")
+    (mkWith   true                    "system-group"               "pulse")
     (mkWith   true                    "access-group"               "audio")
     "--with-systemduserunitdir=\${out}/lib/systemd/user"
   ] ++ stdenv.lib.optional stdenv.isDarwin "--with-mac-sysroot=/";


### PR DESCRIPTION
pulseaudio couldnt be started in system-wide mode because the user and group pulseaudio couldn't be found.
