### PR TITLE
libev: Resolve build problem on OSX 10.9.5

### DIFF
--- a/pkgs/development/libraries/libev/default.nix
+++ b/pkgs/development/libraries/libev/default.nix
@@ -3,6 +3,11 @@
 stdenv.mkDerivation rec {
   name = "libev-${version}";
   version="4.19";
+
+  # Clang defaults to the c11 standard witch breaks libev since
+  # it uses incompatible syntax.
+  CFLAGS = if stdenv.isDarwin then "-std=gnu99" else null;
+
   src = fetchurl {
     url = "http://dist.schmorp.de/libev/${name}.tar.gz";
     sha256 = "1jyw7qbl0spxqa0dccj9x1jsw7cj7szff43cq4acmklnra4mzz48";


### PR DESCRIPTION
At least on OSX 10.9.5 libev relies on some gnu99 specific
keywords. Explicitly setting that flag in the CFLAGS variable solves
the problem.
