### PR TITLE
ghcjs: properly wrap binaries in environment

### DIFF
--- a/pkgs/development/compilers/ghcjs/ghcjs.patch
+++ b/pkgs/development/compilers/ghcjs/ghcjs.patch
@@ -60,15 +60,21 @@ index 3c68dcf..64f3cf7 100644
             , "--haddock-html"
  -- workaround for hoogle support being broken in haddock for GHC 7.10RC1
 diff --git a/src/Compiler/Info.hs b/src/Compiler/Info.hs
-index 33a401f..5d09c86 100644
+index 33a401f..79833c5 100644
 --- a/src/Compiler/Info.hs
 +++ b/src/Compiler/Info.hs
-@@ -49,7 +49,7 @@ compilerInfo nativeToo dflags = do
+@@ -48,13 +48,7 @@ compilerInfo nativeToo dflags = do
+
  -- | the directory to use if started without -B flag
  getDefaultTopDir :: IO FilePath
- getDefaultTopDir = do
+-getDefaultTopDir = do
 -  appdir <- getAppUserDataDirectory "ghcjs"
-+  let appdir = "@PREFIX@/share/ghcjs"
-   return (appdir </> subdir </> "ghcjs")
-       where
-         targetARCH = arch
+-  return (appdir </> subdir </> "ghcjs")
+-      where
+-        targetARCH = arch
+-        targetOS   = os
+-        subdir     = targetARCH ++ '-':targetOS ++ '-':getFullCompilerVersion
++getDefaultTopDir = return "@PREFIX@/lib/ghcjs-@VERSION@"
+
+ getDefaultLibDir :: IO FilePath
+ getDefaultLibDir = getDefaultTopDir

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -99,4 +99,8 @@ self: super: {
     buildDepends = [ self.base self.mtl self.text self.ghcjs-base ];
   });
 
+  ghc-paths = overrideCabal super.ghc-paths (drv: {
+    patches = [ ./ghc-paths-nix-ghcjs.patch ];
+  });
+
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -51,7 +51,7 @@ assert editedCabalFile != null -> revision != null;
 let
 
   inherit (stdenv.lib) optional optionals optionalString versionOlder
-                       concatStringsSep enableFeature optionalAttrs;
+                       concatStringsSep enableFeature optionalAttrs toUpper;
 
   isGhcjs = ghc.isGhcjs or false;
 
@@ -116,6 +116,7 @@ let
 
   setupCommand = if isGhcjs then "${ghc.nodejs}/bin/node ./Setup.jsexe/all.js" else "./Setup";
   ghcCommand = if isGhcjs then "ghcjs" else "ghc";
+  ghcCommandCaps = toUpper ghcCommand;
 
 in
 stdenv.mkDerivation ({
@@ -264,10 +265,10 @@ stdenv.mkDerivation ({
       LANG = "en_US.UTF-8";
       LOCALE_ARCHIVE = optionalString stdenv.isLinux "${glibcLocales}/lib/locale/locale-archive";
       shellHook = ''
-        export NIX_GHC="${ghcEnv}/bin/${ghcCommand}"
-        export NIX_GHCPKG="${ghcEnv}/bin/${ghcCommand}-pkg"
-        export NIX_GHC_DOCDIR="${ghcEnv}/share/doc/ghc/html"
-        export NIX_GHC_LIBDIR="${ghcEnv}/lib/${ghcEnv.name}"
+        export NIX_${ghcCommandCaps}="${ghcEnv}/bin/${ghcCommand}"
+        export NIX_${ghcCommandCaps}PKG="${ghcEnv}/bin/${ghcCommand}-pkg"
+        export NIX_${ghcCommandCaps}_DOCDIR="${ghcEnv}/share/doc/ghc/html"
+        export NIX_${ghcCommandCaps}_LIBDIR="${ghcEnv}/lib/${ghcEnv.name}"
       '';
     };
 

--- a/pkgs/development/haskell-modules/ghc-paths-nix-ghcjs.patch
+++ b/pkgs/development/haskell-modules/ghc-paths-nix-ghcjs.patch
@@ -1,0 +1,65 @@
+diff --git a/GHC/Paths.hs b/GHC/Paths.hs
+index c87565d..88b3db4 100644
+--- a/GHC/Paths.hs
++++ b/GHC/Paths.hs
+@@ -1,13 +1,35 @@
+ {-# LANGUAGE CPP #-}
++{-# LANGUAGE ScopedTypeVariables #-}
+ 
+ module GHC.Paths (
+         ghc, ghc_pkg, libdir, docdir
+   ) where
+ 
++import Control.Exception as E
++import Data.Maybe
++import System.Environment
++import System.IO.Unsafe
++
++-- Yes, there's lookupEnv now, but we want to be compatible
++-- with older GHCs.
++checkEnv :: String -> IO (Maybe String)
++checkEnv var = E.catch (fmap Just (getEnv var))
++                       (\ (e :: IOException) -> return Nothing)
++
++nixLibdir, nixDocdir, nixGhc, nixGhcPkg :: Maybe FilePath
++nixLibdir = unsafePerformIO (checkEnv "NIX_GHCJS_LIBDIR")
++nixDocdir = unsafePerformIO (checkEnv "NIX_GHCJS_DOCDIR")
++nixGhc    = unsafePerformIO (checkEnv "NIX_GHCJS")
++nixGhcPkg = unsafePerformIO (checkEnv "NIX_GHCJSPKG")
++{-# NOINLINE nixLibdir #-}
++{-# NOINLINE nixDocdir #-}
++{-# NOINLINE nixGhc    #-}
++{-# NOINLINE nixGhcPkg #-}
++
+ libdir, docdir, ghc, ghc_pkg :: FilePath
+ 
+-libdir  = GHC_PATHS_LIBDIR
+-docdir  = GHC_PATHS_DOCDIR
++libdir  = fromMaybe GHC_PATHS_LIBDIR  nixLibdir
++docdir  = fromMaybe GHC_PATHS_DOCDIR  nixDocdir
+ 
+-ghc     = GHC_PATHS_GHC
+-ghc_pkg = GHC_PATHS_GHC_PKG
++ghc     = fromMaybe GHC_PATHS_GHC     nixGhc
++ghc_pkg = fromMaybe GHC_PATHS_GHC_PKG nixGhcPkg
+diff --git a/Setup.hs b/Setup.hs
+index fad5026..1651650 100644
+--- a/Setup.hs
++++ b/Setup.hs
+@@ -27,13 +27,13 @@ main = defaultMainWithHooks simpleUserHooks {
+     defaultPostConf :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
+     defaultPostConf args flags pkgdescr lbi = do
+       libdir_ <- rawSystemProgramStdoutConf (fromFlag (configVerbosity flags))
+-                     ghcProgram (withPrograms lbi) ["--print-libdir"]
++                     ghcjsProgram (withPrograms lbi) ["--print-libdir"]
+       let libdir = reverse $ dropWhile isSpace $ reverse libdir_
+ 
+-          ghc_pkg = case lookupProgram ghcPkgProgram (withPrograms lbi) of
++          ghc_pkg = case lookupProgram ghcjsPkgProgram (withPrograms lbi) of
+                           Just p  -> programPath p
+                           Nothing -> error "ghc-pkg was not found"
+-          ghc     = case lookupProgram ghcProgram (withPrograms lbi) of
++          ghc     = case lookupProgram ghcjsProgram (withPrograms lbi) of
+                           Just p  -> programPath p
+                           Nothing -> error "ghc was not found"
+ 

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -32,6 +32,7 @@ let
   ghc761OrLater = isGhcjs || lib.versionOlder "7.6.1" ghc.version;
   packageDBFlag = if ghc761OrLater then "--global-package-db" else "--global-conf";
   ghcCommand    = if isGhcjs then "ghcjs" else "ghc";
+  ghcCommandCaps= lib.toUpper ghcCommand;
   libDir        = "$out/lib/${ghcCommand}-${ghc.version}";
   docDir        = "$out/share/doc/ghc/html";
   packageCfgDir = "${libDir}/package.conf.d";
@@ -51,10 +52,6 @@ buildEnv {
   postBuild = ''
     . ${makeWrapper}/nix-support/setup-hook
 
-    ${lib.optionalString isGhcjs ''
-    cp -r "${ghc}/${ghc.libDir}/"* ${libDir}/
-    ''}
-
     if test -L "$out/bin"; then
       binTarget="$(readlink -f "$out/bin")"
       rm "$out/bin"
@@ -62,30 +59,36 @@ buildEnv {
       chmod u+w "$out/bin"
     fi
 
-    for prg in ghc ghci ghc-${ghc.version} ghci-${ghc.version}; do
-      rm -f $out/bin/$prg
-      makeWrapper ${ghc}/bin/$prg $out/bin/$prg             \
-        --add-flags '"-B$NIX_GHC_LIBDIR"'                   \
-        --set "NIX_GHC"        "$out/bin/${ghcCommand}"     \
-        --set "NIX_GHCPKG"     "$out/bin/${ghcCommand}-pkg" \
-        --set "NIX_GHC_DOCDIR" "${docDir}"                  \
-        --set "NIX_GHC_LIBDIR" "${libDir}"                  \
-        ${lib.optionalString withLLVM ''--prefix "PATH" ":" "${llvm}"''}
+    for prg in ${ghcCommand} ${ghcCommand}i ${ghcCommand}-${ghc.version} ${ghcCommand}i-${ghc.version}; do
+      if [[ -x "${ghc}/bin/$prg" ]]; then
+        rm -f $out/bin/$prg
+        makeWrapper ${ghc}/bin/$prg $out/bin/$prg                           \
+          --add-flags '"-B$NIX_${ghcCommandCaps}_LIBDIR"'                   \
+          --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \
+          --set "NIX_${ghcCommandCaps}PKG"     "$out/bin/${ghcCommand}-pkg" \
+          --set "NIX_${ghcCommandCaps}_DOCDIR" "${docDir}"                  \
+          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"                  \
+          ${lib.optionalString withLLVM ''--prefix "PATH" ":" "${llvm}"''}
+      fi
     done
 
     for prg in runghc runhaskell; do
-      rm -f $out/bin/$prg
-      makeWrapper ${ghc}/bin/$prg $out/bin/$prg             \
-        --add-flags "-f $out/bin/ghc"                       \
-        --set "NIX_GHC"        "$out/bin/${ghcCommand}"     \
-        --set "NIX_GHCPKG"     "$out/bin/${ghcCommand}-pkg" \
-        --set "NIX_GHC_DOCDIR" "${docDir}"                  \
-        --set "NIX_GHC_LIBDIR" "${libDir}"
+      if [[ -x "${ghc}/bin/$prg" ]]; then
+        rm -f $out/bin/$prg
+        makeWrapper ${ghc}/bin/$prg $out/bin/$prg                           \
+          --add-flags "-f $out/bin/${ghcCommand}"                           \
+          --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \
+          --set "NIX_${ghcCommandCaps}PKG"     "$out/bin/${ghcCommand}-pkg" \
+          --set "NIX_${ghcCommandCaps}_DOCDIR" "${docDir}"                  \
+          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
+      fi
     done
 
     for prg in ${ghcCommand}-pkg ${ghcCommand}-pkg-${ghc.version}; do
-      rm -f $out/bin/$prg
-      makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "${packageDBFlag}=${packageCfgDir}"
+      if [[ -x "${ghc}/bin/$prg" ]]; then
+        rm -f $out/bin/$prg
+        makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "${packageDBFlag}=${packageCfgDir}"
+      fi
     done
 
     ${lib.optionalString hasLibraries "$out/bin/${ghcCommand}-pkg recache"}


### PR DESCRIPTION
This fixes [the problem](https://github.com/NixOS/nixpkgs/pull/7719#issuecomment-99578013) that @dnhgff brought to my attention. Without this patch, `ghcjs --make` can't find the packages installed by Nix.

**Another consideration:**

I believe we ought to have a separate set of env vars for GHCJS, so programs compiled via GHCJS find the correct libs/compiler. This would entail editing [`pkgs/development/haskell-modules/ghc-paths-nix.patch`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/ghc-paths-nix.patch) so that the the env vars queried are predicated on the compiler. A simple ~~`#ifdef __GHCJS__`~~ `#ifdef ghcjs_HOST_OS` should do.

@peti how does that sound? If you agree, I'll add that to this PR.
