### PR TITLE
gcc: update default version to 4.9

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -239,7 +239,7 @@ let
   # just the plain stdenv.
   stdenv_32bit = lowPrio (
     if system == "x86_64-linux" then
-      overrideCC stdenv gcc48_multi
+      overrideCC stdenv gcc49_multi
     else
       stdenv);
 
@@ -3460,8 +3460,8 @@ let
 
   gambit = callPackage ../development/compilers/gambit { };
 
-  gcc       = gcc48;
-  gcc_multi = gcc48_multi;
+  gcc       = gcc49;
+  gcc_multi = gcc49_multi;
 
   gccApple = throw "gccApple is no longer supported";
 
@@ -3599,6 +3599,15 @@ let
   gcc48_multi =
     if system == "x86_64-linux" then lowPrio (
       wrapCCWith (import ../build-support/cc-wrapper) glibc_multi (gcc48.cc.override {
+        stdenv = overrideCC stdenv (wrapCCWith (import ../build-support/cc-wrapper) glibc_multi gcc.cc);
+        profiledCompiler = false;
+        enableMultilib = true;
+      }))
+    else throw "Multilib gcc not supported on ‘${system}’";
+
+  gcc49_multi =
+    if system == "x86_64-linux" then lowPrio (
+      wrapCCWith (import ../build-support/cc-wrapper) glibc_multi (gcc49.cc.override {
         stdenv = overrideCC stdenv (wrapCCWith (import ../build-support/cc-wrapper) glibc_multi gcc.cc);
         profiledCompiler = false;
         enableMultilib = true;


### PR DESCRIPTION
Not sure if the changes are complete or correctly executed; mostly I want to start the conversation regarding making the change, and kick off tests. It might also be desirable to switch straight to 5.1, which has improved support for recent iterations of the standard. In particular, 4.9 has partial C++14 support, which 5.1 brings much closer to completion.
