### PR TITLE
ARM changes for the Jetson TK1 (and other multiplatform boards)

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -125,7 +125,8 @@ let
         mkdir -p $out/lib/firmware
       '') + (if (platform ? kernelDTB && platform.kernelDTB) then ''
  	make $makeFlags "''${makeFlagsArray[@]}" dtbs
-        cp $buildRoot/arch/$karch/boot/dts/*dtb $out
+        mkdir -p $out/dtbs
+        cp $buildRoot/arch/$karch/boot/dts/*.dtb $out/dtbs
       '' else "") + (if isModular then ''
         make modules_install $makeFlags "''${makeFlagsArray[@]}" \
           $installFlags "''${installFlagsArray[@]}"

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -34,7 +34,7 @@ let
     };
   };
   
-  beagleboneCrossSystem = {
+  armv7l-hf-multiplatform-crossSystem = {
     crossSystem = rec {
       config = "armv7l-unknown-linux-gnueabi";  
       bigEndian = false;
@@ -43,7 +43,7 @@ let
       fpu = "vfpv3-d16";
       withTLS = true;
       libc = "glibc";
-      platform = pkgsNoParams.platforms.beaglebone;
+      platform = pkgsNoParams.platforms.armv7l-hf-multiplatform;
       openssl.system = "linux-generic32";
       inherit (platform) gcc;
     };
@@ -52,7 +52,7 @@ let
   selectedCrossSystem =
     if toolsArch == "armv5tel" then sheevaplugCrossSystem else
     if toolsArch == "armv6l" then raspberrypiCrossSystem else
-    if toolsArch == "armv7l" then beagleboneCrossSystem else null;
+    if toolsArch == "armv7l" then armv7l-hf-multiplatform-crossSystem else null;
 
   pkgs = pkgsFun ({inherit system;} // selectedCrossSystem);
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -72,7 +72,7 @@ let
       platforms = (import ./platforms.nix);
     in
       if system == "armv6l-linux" then platforms.raspberrypi
-      else if system == "armv7l-linux" then platforms.beaglebone
+      else if system == "armv7l-linux" then platforms.armv7l-hf-multiplatform
       else if system == "armv5tel-linux" then platforms.sheevaplug
       else if system == "mips64el-linux" then platforms.fuloong2f_n32
       else if system == "x86_64-linux" then platforms.pc64

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -483,4 +483,22 @@ rec {
       float = "hard";
     };
   };
+
+  armv7l-hf-multiplatform = {
+    name = "armv7l-hf-multiplatform";
+    kernelMajor = "2.6";
+    kernelHeadersBaseConfig = "multi_v7_defconfig";
+    kernelBaseConfig = "multi_v7_defconfig";
+    kernelArch = "arm";
+    kernelAutoModules = false;
+    kernelExtraConfig = "";
+    kernelTarget = "zImage";
+    kernelDTB = true;
+    uboot = null;
+    gcc = {
+      arch = "armv7-a";
+      fpu = "vfpv3-d16";
+      float = "hard";
+    };
+  };
 }

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -217,7 +217,7 @@ rec {
   raspberrypi2 = {
     name = "raspberrypi2";
     kernelMajor = "3.14";
-    kernelHeadersBaseConfig = "kirkwood_defconfig";
+    kernelHeadersBaseConfig = "multi_v7_defconfig";
     kernelBaseConfig = "bcm2709_defconfig";
     kernelArch = "arm";
     kernelDTB = true;
@@ -470,7 +470,7 @@ rec {
   beaglebone = {
     name = "beaglebone";
     kernelMajor = "2.6";
-    kernelHeadersBaseConfig = "omap2plus_defconfig";
+    kernelHeadersBaseConfig = "multi_v7_defconfig";
     kernelBaseConfig = "omap2plus_defconfig";
     kernelArch = "arm";
     kernelAutoModules = false;


### PR DESCRIPTION
These add the platform for hardfloat-capable ARMv7 boards that can boot with the `multi_v7_defconfig` kernel configuration. This can successfully build and boot on the nVIDIA Jetson TK1, apart from the boot script generator which I'm still working on.

Even though this touches the kernel stuff this didn't cause any recompiles on x86.

cc @viric @ambrop72 @Jookia (hopefully I won't break your setups :)
