### PR TITLE
firefox: Add option to build with GTK3

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -1,9 +1,10 @@
-{ lib, stdenv, fetchurl, pkgconfig, gtk, pango, perl, python, zip, libIDL
+{ lib, stdenv, fetchurl, pkgconfig, gtk, gtk3, pango, perl, python, zip, libIDL
 , libjpeg, zlib, dbus, dbus_glib, bzip2, xlibs
 , freetype, fontconfig, file, alsaLib, nspr, nss, libnotify
 , yasm, mesa, sqlite, unzip, makeWrapper, pysqlite
 , hunspell, libevent, libstartup_notification, libvpx
 , cairo, gstreamer, gst_plugins_base, icu
+, enableGTK3 ? false
 , debugBuild ? false
 , # If you want the resulting program to call itself "Firefox" instead
   # of "Shiretoko" or whatever, enable this option.  However, those
@@ -34,7 +35,8 @@ stdenv.mkDerivation rec {
       xlibs.libXext xlibs.xextproto sqlite unzip makeWrapper
       hunspell libevent libstartup_notification libvpx cairo
       gstreamer gst_plugins_base icu
-    ];
+    ]
+    ++ lib.optional enableGTK3 gtk3;
 
   configureFlags =
     [ "--enable-application=browser"
@@ -64,6 +66,7 @@ stdenv.mkDerivation rec {
       "--disable-updater"
       "--disable-pulseaudio"
     ]
+    ++ lib.optional enableGTK3 "--enable-default-toolkit=cairo-gtk3"
     ++ (if debugBuild then [ "--enable-debug" "--enable-profiling"]
                       else [ "--disable-debug" "--enable-release"
                              "--enable-optimize${lib.optionalString (stdenv.system == "i686-linux") "=-O1"}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10836,6 +10836,7 @@ let
   firefox = callPackage ../applications/networking/browsers/firefox {
     inherit (gnome) libIDL;
     inherit (pythonPackages) pysqlite;
+    enableGTK3 = false;
   };
 
   firefoxWrapper = wrapFirefox { browser = pkgs.firefox; };


### PR DESCRIPTION
Does anyone care about GTK3 as much as I do?
Because, you know, pixel-perfect scrolling is awesome, I enjoy it every single time I use zathura and I miss it so much in my web browser!

So, this PR makes Firefox build with GTK3 in a pretty straightforward way. To be honest, I have no idea what is the status of GTK3 support in Firefox right now, there is a [huge tracker](https://bugzilla.mozilla.org/show_bug.cgi?id=627699) but it is hard to tell what is expected to work. I definitely have a problem with themes, Oxygen is not being applied (that’s probably #5053) and there is another strange thing: all the popup menus are black.

Any ideas?
