### PR TITLE
Fix calibre PDF handling

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, pyqt5, sip_4_16, poppler, pkgconfig, libpng
+{ stdenv, fetchurl, python, pyqt5, sip_4_16, poppler_utils, pkgconfig, libpng
 , imagemagick, libjpeg, fontconfig, podofo, qt5, icu, sqlite
 , pil, makeWrapper, unrar, chmlib, pythonPackages, xz, libusb1, libmtp
 , xdg_utils
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper pkgconfig ];
 
   buildInputs =
-    [ python pyqt5 sip_4_16 poppler libpng imagemagick libjpeg
+    [ python pyqt5 sip_4_16 poppler_utils libpng imagemagick libjpeg
       fontconfig podofo qt5 pil chmlib icu sqlite libusb1 libmtp xdg_utils
       pythonPackages.mechanize pythonPackages.lxml pythonPackages.dateutil
       pythonPackages.cssutils pythonPackages.beautifulsoup pythonPackages.pillow
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     export HOME=$TMPDIR/fakehome
-    export POPPLER_INC_DIR=${poppler}/include/poppler
-    export POPPLER_LIB_DIR=${poppler}/lib
+    export POPPLER_INC_DIR=${poppler_utils}/include/poppler
+    export POPPLER_LIB_DIR=${poppler_utils}/lib
     export MAGICK_INC=${imagemagick}/include/ImageMagick
     export MAGICK_LIB=${imagemagick}/lib
     export FC_INC_DIR=${fontconfig}/include/fontconfig
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     for a in $out/bin/*; do
       wrapProgram $a --prefix PYTHONPATH : $PYTHONPATH \
                      --prefix LD_LIBRARY_PATH : ${unrar}/lib \
-                     --prefix PATH : ${poppler}/bin
+                     --prefix PATH : ${poppler_utils}/bin
     done
   '';
 


### PR DESCRIPTION
In c0d5cd0ff90cac2e04f6b436991baa4c4471150f, the binaries for poppler
were carved off into a separate package, and calibre has had broken pdf
support since.  This changes all dependencies on poppler to
poppler_utils, which fixes this support, much as was done for
cups_filter in 394562655ff09ef490eca8b14fe02c393e9ac70e.
