### PR TITLE
This resolves crypto++ build problems on OSX

### DIFF
--- a/pkgs/development/libraries/crypto++/GNUmakefile.patch
+++ b/pkgs/development/libraries/crypto++/GNUmakefile.patch
@@ -1,0 +1,13 @@
+--- crypto++/GNUmakefile 2013-02-20 10:30:52.000000000 -0500
++++ crypto++/GNUmakefile 2015-05-07 18:34:25.000000000 -0500
+@@ -87,8 +87,8 @@
+ endif
+
+ ifeq ($(UNAME),Darwin)
+-AR = libtool
+-ARFLAGS = -static -o
++AR = ar
++ARFLAGS = cru
+ CXX = c++
+ IS_GCC2 = $(shell $(CXX) -v 2>&1 | $(EGREP) -c gcc-932)
+ ifeq ($(IS_GCC2),1)

--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0x1mqpz1v071cfrw4grbw7z734cxnpry1qh2b6rsmcx6nkyd5gsw";
   };
 
-  patches = stdenv.lib.optional (stdenv.system != "i686-cygwin") ./dll.patch;
+  patches = (stdenv.lib.optional (stdenv.system != "i686-cygwin") ./dll.patch)
+            ++ (stdenv.lib.optional stdenv.isDarwin ./GNUmakefile.patch);
 
   buildInputs = [ unzip libtool ];
 


### PR DESCRIPTION
This should also resolve NixOS/nixpkgs#6150 and NixOS/nixpkgs#6157 in a way that doesn't break other platforms. It essentially changes the makefile from using libtool to ar directly. As a note: I have only tested this in OSX 10.9.5 with some of the ocaml packages that depend on crypto++. 
