### PR TITLE
add x42-plugins: a collection of LV2 plugins by Robin Gareus

### DIFF
--- a/pkgs/applications/audio/x42-plugins/default.nix
+++ b/pkgs/applications/audio/x42-plugins/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, fetchgit, ftgl, freefont_ttf, jack2, mesa_glu, pkgconfig
+, libltc, libsndfile, libsamplerate
+, lv2, mesa, gtk2, cairo, pango, fftwFloat, zita-convolver }:
+
+stdenv.mkDerivation rec {
+  version = "2014-11-01";
+  name = "x42-plugins-${version}";
+
+  src = fetchurl {
+    url = "http://gareus.org/misc/x42-plugins/x42-plugins-20141101.tar.xz";
+    sha256 = "0pjdhj58hb4n2053v92l7v7097fjm4xzrl8ks4g1hc7miy98ymdk";
+  };
+
+  buildInputs = [ mesa_glu ftgl freefont_ttf jack2 libltc libsndfile libsamplerate lv2 mesa gtk2 cairo pango fftwFloat pkgconfig  zita-convolver];
+
+  makeFlags = [ "PREFIX=$(out)" "FONTFILE=${freefont_ttf}/share/fonts/truetype/FreeSansBold.ttf" ];
+
+  # remove check for zita-convolver in /usr/
+  patchPhase = ''
+    sed -i "38,42d" convoLV2/Makefile
+  '';
+
+  meta = with stdenv.lib;
+    { description = "Collection of LV2 plugins by Robin Gareus";
+      homepage = https://github.com/x42/x42-plugins;
+      maintainers = with maintainers; [ magnetophon ];
+      license = licenses.gpl2;
+      platforms = platforms.linux;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12595,6 +12595,8 @@ let
 
   x2vnc = callPackage ../tools/X11/x2vnc { };
 
+  x42-plugins = callPackage ../applications/audio/x42-plugins { };
+
   xaos = builderDefsPackage (import ../applications/graphics/xaos) {
     inherit (xlibs) libXt libX11 libXext xextproto xproto;
     inherit gsl aalib zlib intltool gettext perl;


### PR DESCRIPTION
These are all Robin Gareus's plugins, including https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/meters_lv2/default.nix
so we might want to get rid of that pkg. idk.

During compilation, a warning pops up, saying some of the plugins are not thread safe.
The makefile suggest:
run   ./static_fft.sh    prior to make
as a workaround. This does:
# !/bin/sh

set -e
curl -L http://www.fftw.org/fftw-3.3.4.tar.gz | tar xz
cd fftw-3.3.4/
CFLAGS="-fvisibility=hidden -fPIC -Wl,--exclude-libs,ALL" \
    ./configure \
    --enable-single --enable-sse --enable-avx --disable-mpi \
    --disable-shared --enable-static
make -j2

But of course that doesn't work in the build env.
I guess we could have a separate static fftw, and use that in all audio plugins, but I'm not sure how best to go about that.
More information: https://github.com/FFTW/fftw3/issues/16

BTW: the current pkg for meters.lv2 also has this issue, afaik.
