### PR TITLE
Add wpa_supplicant p2p patch.

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, openssl, pkgconfig, libnl
+{ stdenv, fetchpatch, fetchurl, lib, openssl, pkgconfig, libnl
 , dbus_libs ? null, readline ? null, pcsclite ? null
 }:
 
@@ -79,6 +79,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001-P2P-Validate-SSID-element-length-before-copying-it-C.patch
     ./build-fix.patch
+    (fetchpatch {
+      name = "p2p-fix.patch";
+      url = "http://w1.fi/cgit/hostap/patch/?id=8a78e227df1ead19be8e12a4108e448887e64d6f";
+      sha256 = "1k2mcq1jv8xzi8061ixcz6j56n4i8wbq0vxcvml204q1syy2ika0";
+    })
   ];
 
   postInstall = ''


### PR DESCRIPTION
wpa_supplicant 2.4 appears to have a serious bug that makes impossible
to use wifi for some number of people.

(See https://bbs.archlinux.org/viewtopic.php?id=196584 for an example)

It was resolved in a patch for the to-be-released 2.5 which it seemed
worth it to cherry-pick here.
