### PR TITLE
Haskell: explicit reflex-dom dependencies for GHCJS

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -103,4 +103,12 @@ self: super: {
     patches = [ ./ghc-paths-nix-ghcjs.patch ];
   });
 
+  reflex-dom = overrideCabal super.reflex-dom (drv: {
+    buildDepends = [
+      self.aeson self.base self.bytestring self.containers self.data-default
+      self.dependent-map self.dependent-sum self.ghcjs-dom self.lens self.mtl
+      self.ref-tf self.reflex self.safe self.semigroups self.text self.these
+      self.time self.transformers
+    ];
+  });
 }


### PR DESCRIPTION
When building `reflex-dom` for GHCJS, the following dependencies are notneeded and will fail to build: glib, gtk3, webkitgtk3, webkitgtk3-javascriptcore. Now we explicitely need the dependencies needed for building for GHCJS.
