### PR TITLE
Refactor Agda build support

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -21,7 +21,6 @@ in
         sourceDirectories = filter (y: !(y == null)) x.sourceDirectories;
         propagatedBuildInputs = filter (y : ! (y == null)) x.propagatedBuildInputs;
         propagatedUserEnvPkgs = filter (y : ! (y == null)) x.propagatedUserEnvPkgs;
-        extraBuildFlags = filter (y : ! (y == null)) x.extraBuildFlags;
         everythingFile = if x.everythingFile == "" then "Everything.agda" else x.everythingFile;
       };
 
@@ -50,11 +49,11 @@ in
         # would make a direct copy of the whole thing.
         topSourceDirectories = [ "src" ];
 
-        # Extra stuff to pass to the Agda binary.
-        extraBuildFlags = [ "-i ." ];
-        buildFlags = let r = map (x: "-i " + x + "/share/agda") self.buildDepends;
-                         d = map (x : "-i " + x) (self.sourceDirectories ++ self.topSourceDirectories);
-                     in unwords (r ++ d ++ self.extraBuildFlags);
+        # FIXME: `dirOf self.everythingFile` is what we really want, not hardcoded "./"
+        includeDirs = let r = map (x: x + "/share/agda") self.buildDepends;
+                          d = self.sourceDirectories ++ self.topSourceDirectories;
+                      in r ++ d ++ [ "." ];
+        buildFlags = unwords (map (x: "-i " + x) self.includeDirs);
 
         # We expose this as a mere convenience for any tools.
         AGDA_PACKAGE_PATH = concatMapStrings (x: x + ":") self.buildDepends;

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -69,22 +69,22 @@ in
 
         # configurePhase is idempotent
         configurePhase = ''
-          eval "$preConfigure"
+          runHook preConfigure
           export PATH="${self.agdaWrapper}/bin:$PATH"
-          eval "$postConfigure"
+          runHook postConfigure
         '';
 
         buildPhase = ''
-          eval "$preBuild"
+          runHook preBuild
           ${Agda}/bin/agda ${self.buildFlags} ${self.everythingFile}
-          eval "$postBuild"
+          runHook postBuild
         '';
 
         installPhase = ''
-          eval "$preInstall"
+          runHook preInstall
           mkdir -p $out/share/agda
           cp -pR ${unwords self.sourceDirectories} ${mapInside self.topSourceDirectories} $out/share/agda
-          eval "$postInstall"
+          runHook postInstall
         '';
       };
     in stdenv.mkDerivation

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -70,7 +70,6 @@ in
         # configurePhase is idempotent
         configurePhase = ''
           eval "$preConfigure"
-          export AGDA_PACKAGE_PATH=${self.AGDA_PACKAGE_PATH};
           export PATH="${self.agdaWrapper}/bin:$PATH"
           eval "$postConfigure"
         '';

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -37,7 +37,7 @@ in
 
         everythingFile = "Everything.agda";
 
-        propagatedBuildInputs = self.buildDepends ++ self.buildTools;
+        propagatedBuildInputs = self.buildDepends;
         propagatedUserEnvPkgs = self.buildDepends;
 
         # Immediate source directories under which modules can be found.
@@ -49,8 +49,6 @@ in
         # *contents* copied over as opposed to sourceDirectories which
         # would make a direct copy of the whole thing.
         topSourceDirectories = [ "src" ];
-
-        buildTools = [];
 
         # Extra stuff to pass to the Agda binary.
         extraBuildFlags = [ "-i ." ];

--- a/pkgs/development/libraries/agda/agda-iowa-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/agda-iowa-stdlib/default.nix
@@ -22,5 +22,7 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+
+    broken = true;
   };
 })


### PR DESCRIPTION
The first two commits should be pretty uncontroversial.

The third removes a wrapper shell script intended for "public use". But the generated shell scripts were not used elsewhere in nixpkgs, nor are they terribly useful for Emacs integration (as was the intention IIUC) as that was broken for other reasons.

I replaced the script with a simple environment variable that has the (resolved) agda binary "curried" with the build flags generated by the build support.

With https://github.com/NixOS/nix/issues/534 we can have tools shell out to

``` sh
nix-shell --command \$wrappedAgda -- <args...>
```

As a proof of concept I ran

``` sh
nix-shell --command '$wrappedAgda --interactive'
```

by hand and everything worked correctly.

Finally, making a script accessible to emacs like:

``` sh
#/bin/sh
nix-shell --command '$wrappedAgda '"$@"
```

and having it call that also might work today. agda-mode got as far as checking and accepting the version of the binary, but then the process died for some reason.

---

I'll rebase if this looks good--I've done it locally but just wanted to push what I actually tested. The only "conflict" is `haskell-ng` -> `haskell` on the line below in `all-packages.nix`
