### PR TITLE
Add s3ql package

### DIFF
--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, python3Packages, sqlite  }:
+
+python3Packages.buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "s3ql";
+  version = "2.13";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/nikratio/${pname}/downloads/${name}.tar.bz2";
+    sha256 = "0bxps1iq0rv7bg2b8mys6zyjp912knm6zmafhid1jhsv3xyby4my";
+  };
+
+  propagatedBuildInputs = with python3Packages;
+    [ sqlite apsw pycrypto requests defusedxml dugong llfuse ];
+
+  meta = with stdenv.lib; {
+    description = "A full-featured file system for online data storage";
+    homepage = "https://bitbucket.org/nikratio/s3ql";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ rushmorem ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9629,6 +9629,8 @@ let
 
   rtkit = callPackage ../os-specific/linux/rtkit { };
 
+  s3ql = callPackage ../tools/backup/s3ql { };
+
   sassc = callPackage ../development/tools/sassc { };
 
   schedtool = callPackage ../os-specific/linux/schedtool { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1004,6 +1004,28 @@ let
     };
   };
 
+  defusedxml = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "defusedxml";
+    version = "0.4.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/d/${pname}/${name}.tar.gz";
+      sha256 = "0y147zy3jqmk6ly7fbhqmzn1hf41xcb53f2vcc3m8x4ba5d1smfd";
+    };
+  };
+
+  dugong = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "dugong";
+    version = "3.5";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/d/${pname}/${name}.tar.bz2";
+      sha256 = "0y0rdxbiwm03zv6vpvapqilrird3h8ijz7xmb0j7ds5j4p6q3g24";
+    };
+
+    disabled = pythonOlder "3.3";	# Library does not support versions older than 3.3
+  };
+
   iowait = buildPythonPackage rec {
     name = "iowait-0.2";
 


### PR DESCRIPTION
S3QL is a file system that stores all its data online using storage
services like Google Storage, Amazon S3, or OpenStack. S3QL effectively
provides a hard disk of dynamic, infinite capacity that can be accessed
from any computer with internet access running Linux, FreeBSD or OS-X.
