### PR TITLE
Fix compilation of language-glsl.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -55,6 +55,11 @@ self: super: {
     sha256 = "193i1xmq6z0jalwmq0mhqk1khz6zz0i1hs6lgfd7ybd6qyaqnf5f";
   });
 
+  language-glsl = appendPatch super.language-glsl (pkgs.fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/noteed/language-glsl/pull/10.patch";
+    sha256 = "1d8dmfqw9y7v7dlszb7l3wp0vj77j950z2r3r0ar9mcvyrmfm4in";
+  });
+
   # haddock: No input file(s).
   nats = dontHaddock super.nats;
   bytestring-builder = dontHaddock super.bytestring-builder;


### PR DESCRIPTION
The issue / patch https://github.com/noteed/language-glsl/pull/10 fixes
a compilation problem with language-glsl.
The packages pretty and prettyclass conflicted when compiled with GHC 7.10.
