### PR TITLE
Fix Hydra build of EventStore

### DIFF
--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     ln -s ${icu}/lib/libicui18n.so src/libs/libicui18n.so
     ln -s ${icu}/lib/libicuuc.so src/libs/libicuuc.so
 
+    patchShebangs build.sh
     ./build.sh js1
     ./build.sh quick ${version}
   '';


### PR DESCRIPTION
Need to patch the build.sh shebang to make it pure.

---

You can see the Hydra job failure here:

https://hydra.nixos.org/build/21992356

```
/nix/store/jg990hzan73yksf8gghmri5iszdrr8mg-stdenv/setup: ./build.sh: /usr/bin/env: bad interpreter: No such file or directory
```
