### PR TITLE
global: refactor

### DIFF
--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -1,5 +1,6 @@
-{ fetchurl, stdenv, libtool, ncurses, ctags, sqlite
-, pythonPackages, makeWrapper }:
+{ fetchurl, stdenv, libtool, makeWrapper
+, coreutils, ctags, ncurses, pythonPackages, sqlite, pkgconfig
+}:
 
 stdenv.mkDerivation rec {
   name = "global-6.4";
@@ -9,16 +10,20 @@ stdenv.mkDerivation rec {
     sha256 = "13i4zwx6gaibc4j79wd0hgxysw8ibxz9c018zxhydnxlyadzcnri";
   };
 
-  buildInputs = [ libtool ncurses makeWrapper ];
+  nativeBuildInputs = [ libtool makeWrapper ];
+
+  buildInputs = [ ncurses ];
+
   propagatedBuildInputs = [ pythonPackages.pygments ];
 
-  configurePhase =
-    '' ./configure --prefix="$out" --disable-static ''
-    + ''--with-posix-sort=$(type -p sort) ''
-    + ''--with-ltdl-include=${libtool}/include --with-ltdl-lib=${libtool}/lib ''
-    + ''--with-ncurses=${ncurses} ''
-    + ''--with-sqlite3=${sqlite} ''
-    + ''--with-exuberant-ctags=${ctags}/bin/ctags'';
+  configureFlags = [
+    "--with-ltdl-include=${libtool}/include"
+    "--with-ltdl-lib=${libtool}/lib"
+    "--with-ncurses=${ncurses}"
+    "--with-sqlite3=${sqlite}"
+    "--with-exuberant-ctags=${ctags}/bin/ctags"
+    "--with-posix-sort=${coreutils}/bin/sort"
+  ];
 
   doCheck = true;
 
@@ -34,7 +39,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Source code tag system";
-
     longDescription = ''
       GNU GLOBAL is a source code tagging system that works the same way
       across diverse environments (Emacs, vi, less, Bash, web browser, etc).
@@ -45,11 +49,8 @@ stdenv.mkDerivation rec {
       independence of any editor.  It runs on a UNIX (POSIX) compatible
       operating system like GNU and BSD.
     '';
-
-    license = licenses.gpl3Plus;
-
     homepage = http://www.gnu.org/software/global/;
-
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
This just cleans up `configureFlags` and `nativeBuildInputs`

I am not sure if there was a reason for the `--with-posix-sort=$(type -p sort)` hack, I switched it to use `--with-posix-sort=${coreutils}/bin/sort`

@pSub @jwiegley 
