### PR TITLE
llpp: update to HEAD

### DIFF
--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -4,12 +4,12 @@
 let ocamlVersion = (builtins.parseDrvName (ocaml.name)).version;
 in stdenv.mkDerivation rec {
   name = "llpp-${version}";
-  version = "21";
+  version = "21-git-2015-04-27";
 
   src = fetchgit {
     url = "git://repo.or.cz/llpp.git";
-    rev  = "refs/tags/v${version}";
-    sha256 = "0rxdq6j3bs4drnhlxgm0gcwkhxi98vmxm22lnkpic7h67lgsz51q";
+    rev = "66868744188151eaa433d42c807e1efc5f623aa4";
+    sha256 = "04hjbkzxixw88xmrpbr1smq486wfw3q9hvy7b4bfcb9j32mazk5c";
   };
 
   buildInputs = [ pkgconfig ninja makeWrapper ocaml findlib mupdf lablgl


### PR DESCRIPTION
Current latest tagged version (v21) has been broken
since mupdf has been updated to 1.7.
