### PR TITLE
libe-book: Add zlib as package requirement

### DIFF
--- a/pkgs/development/libraries/libe-book/default.nix
+++ b/pkgs/development/libraries/libe-book/default.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchurl, gperf, pkgconfig, librevenge, libxml2, boost, icu, cppunit}:
+{ stdenv, fetchurl, gperf, pkgconfig, librevenge, libxml2, boost, icu, cppunit
+, zlib}:
 let
   s = # Generated upstream information
   rec {
@@ -10,7 +11,7 @@ let
     sha256="1v48pd32r2pfysr3a3igc4ivcf6vvb26jq4pdkcnq75p70alp2bz";
   };
   buildInputs = [
-    gperf pkgconfig librevenge libxml2 boost icu cppunit
+    gperf pkgconfig librevenge libxml2 boost icu cppunit zlib
   ];
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
For some reason `zlib` was missing from the package requirements.
This was tested and builds now.
