### PR TITLE
Add isGNU and isClang attributes to cc-wrapper

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     patchShebangs share/extensions
   ''
   # Clang gets misdetected, so hardcode the right answer
-  + stdenv.lib.optionalString (stdenv.cc.cc.isClang or false) ''
+  + stdenv.lib.optionalString stdenv.cc.isClang ''
     substituteInPlace src/ui/tool/node.h \
       --replace "#if __cplusplus >= 201103L" "#if true"
   '';

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -6,7 +6,7 @@
 , kdeSupport ? false, qt4, kdelibs
 }:
 
-assert stdenv.isLinux && stdenv.cc.cc.isGNU or false && stdenv.cc.libc != null;
+assert stdenv.isLinux && stdenv.cc.isGNU && stdenv.cc.libc != null;
 
 let
   mirror = http://get.geo.opera.com/pub/opera;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -10,6 +10,7 @@
 , zlib ? null, extraPackages ? []
 , dyld ? null # TODO: should this be a setup-hook on dyld?
 , setupHook ? ./setup-hook.sh
+, isGNU ? false, isClang ? false
 }:
 
 with stdenv.lib;
@@ -41,7 +42,7 @@ stdenv.mkDerivation {
   # The wrapper scripts use 'cat', so we may need coreutils.
   coreutils = if nativeTools then null else coreutils;
 
-  passthru = { inherit nativeTools nativeLibc nativePrefix; };
+  passthru = { inherit nativeTools nativeLibc nativePrefix isGNU isClang; };
 
   buildCommand =
     ''

--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -10,7 +10,7 @@ in
 
 (
 assert a.stdenv ? cc ;
-assert a.stdenv.cc.cc.isGNU or false ;
+assert a.stdenv.cc.isGNU ;
 assert a.stdenv.cc ? libc ;
 assert a.stdenv.cc.libc != null ;
 

--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -1,6 +1,6 @@
 { stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src }:
 let
-  gcc = if stdenv.cc.cc.isGNU or false then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation {
   name = "clang-${version}";
 

--- a/pkgs/development/compilers/llvm/3.6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.6/clang/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src }:
 
 let
-  gcc = if stdenv.cc.cc.isGNU or false then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation {
   name = "clang-${version}";
 

--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, guile, texinfo}:
 
-assert stdenv ? cc && stdenv.cc.cc.isGNU or false;
+assert stdenv ? cc && stdenv.cc.isGNU;
 
 stdenv.mkDerivation rec {
   name = "guile-lib-0.2.2";

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation rec {
       "--disable-stripping"
     # Disable mmx support for 0.6.90
       (verFix null "0.6.90" "--disable-mmx")
-  ] ++ optional (stdenv.cc.cc.isClang or false) "--cc=clang";
+  ] ++ optional stdenv.cc.isClang "--cc=clang";
 
   nativeBuildInputs = [ perl pkgconfig texinfo yasm ];
 

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ++ optional (precision != "double") "--enable-${precision}"
     # all x86_64 have sse2
     ++ optional stdenv.isx86_64 "--enable-sse2"
-    ++ optional (stdenv.cc.cc.isGNU or false) "--enable-openmp";
+    ++ optional stdenv.cc.isGNU "--enable-openmp";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (rec {
 
   patches = [ ./deadlock.patch ]
     ++ map fetchurl (import ./debian-patches.nix)
-    ++ stdenv.lib.optional (stdenv.cc.cc.isClang or false) ./returnval.patch;
+    ++ stdenv.lib.optional stdenv.cc.isClang ./returnval.patch;
 
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -7,7 +7,7 @@
 
 with stdenv.lib;
 
-assert !stdenv.isDarwin -> stdenv.cc.cc.isGNU or false;
+assert !stdenv.isDarwin -> stdenv.cc.isGNU;
 
 # TODO:
 # * Add gio-module-fam

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -8,7 +8,7 @@
 , withGd ? false, gd ? null, libpng ? null
 }:
 
-assert stdenv.cc.cc.isGNU or false;
+assert stdenv.cc.isGNU;
 
 let
   build = import ./common.nix;

--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "SHELL=${stdenv.shell}"
     "INSTALL_ROOT=$(out)"
-  ] ++ optional (stdenv.cc.cc.isClang or false) "CC=clang";
+  ] ++ optional stdenv.cc.isClang "CC=clang";
 
   preInstall = "mkdir -p $out/{bin,lib,man/man1,man/man3,include/gsm}";
 

--- a/pkgs/development/libraries/jbigkit/default.nix
+++ b/pkgs/development/libraries/jbigkit/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -i 's/^\(CFLAGS.*\)$/\1 -fPIC/' Makefile
-  '' + stdenv.lib.optionalString (stdenv.cc.cc.isClang or false) ''
+  '' + stdenv.lib.optionalString stdenv.cc.isClang ''
     substituteInPlace Makefile libjbig/Makefile pbmtools/Makefile \
       --replace "CC = gcc" "CC = clang"
   '';

--- a/pkgs/development/libraries/judy/default.nix
+++ b/pkgs/development/libraries/judy/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   # gcc 4.8 optimisations break judy.
   # http://sourceforge.net/p/judy/mailman/message/31995144/
-  preConfigure = stdenv.lib.optionalString (stdenv.cc.cc.isGNU or false) ''
+  preConfigure = stdenv.lib.optionalString stdenv.cc.isGNU ''
     configureFlagsArray+=("CFLAGS=-fno-strict-aliasing -fno-aggressive-loop-optimizations")
   '';
 

--- a/pkgs/development/libraries/libcdr/default.nix
+++ b/pkgs/development/libraries/libcdr/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  configureFlags = if (stdenv.cc.cc.isClang or false)
+  configureFlags = if stdenv.cc.isClang
     then [ "--disable-werror" ] else null;
 
   CXXFLAGS="--std=gnu++0x"; # For c++11 constants in lcms2.h

--- a/pkgs/development/libraries/libfpx/default.nix
+++ b/pkgs/development/libraries/libfpx/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = if stdenv.isDarwin then "-D__unix" else null;
 
   # This dead code causes a duplicate symbol error in Clang so just remove it
-  postPatch = if (stdenv.cc.cc.isClang or false) then ''
+  postPatch = if stdenv.cc.isClang then ''
     substituteInPlace jpeg/ejpeg.h --replace "int No_JPEG_Header_Flag" ""
   '' else null;
 

--- a/pkgs/development/libraries/libmad/default.nix
+++ b/pkgs/development/libraries/libmad/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   # optimize.diff is taken from https://projects.archlinux.org/svntogit/packages.git/tree/trunk/optimize.diff?h=packages/libmad
   # It is included here in order to fix a build failure in Clang
   # But it may be useful to fix other, currently unknown problems as well
-  ++ stdenv.lib.optional (stdenv.cc.cc.isClang or false) [ ./optimize.diff ];
+  ++ stdenv.lib.optional stdenv.cc.isClang [ ./optimize.diff ];
 
   nativeBuildInputs = [ autoconf ];
 

--- a/pkgs/development/libraries/librevenge/default.nix
+++ b/pkgs/development/libraries/librevenge/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   # Clang generates warnings in Boost's header files
   # -Werror causes these warnings to be interpreted as errors
   # Simplest solution: disable -Werror
-  configureFlags = if (stdenv.cc.cc.isClang or false)
+  configureFlags = if stdenv.cc.isClang
     then [ "--disable-werror" ] else null;
 
   meta = {

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "120jkda2q58p0n68banh64vsfm3hgqnacagj425d218cr4ycdkyb";
   };
 
-  NIX_LDFLAGS = stdenv.lib.optionalString (stdenv.cc.cc.isGNU or false) "-lssp";
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.cc.isGNU "-lssp";
 
   doCheck = true;
 

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   postInstall = glib.flattenInclude;
 
-  patches = stdenv.lib.optional (stdenv.cc.cc.isClang or false) ./fix-clang36.patch;
+  patches = stdenv.lib.optional stdenv.cc.isClang ./fix-clang36.patch;
 
   meta = {
     homepage = http://pixman.org;

--- a/pkgs/development/tools/misc/astyle/default.nix
+++ b/pkgs/development/tools/misc/astyle/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "1b0f4wm1qmgcswmixv9mwbp86hbdqxk754hml8cjv5vajvqwdpzv";
   };
 
-  sourceRoot = if (stdenv.cc.cc.isClang or false)
+  sourceRoot = if stdenv.cc.isClang
     then "astyle/build/clang"
     else "astyle/build/gcc";
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -80,7 +80,7 @@ in
   };
 
   libxkbfile = attrs: attrs // {
-    patches = lib.optional (stdenv.cc.cc.isClang or false) ./libxkbfile-clang36.patch;
+    patches = lib.optional stdenv.cc.isClang ./libxkbfile-clang36.patch;
   };
 
   libpciaccess = attrs : attrs // {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -90,6 +90,7 @@ rec {
           cc      = "/usr";
           outPath = nativePrefix;
         };
+        isClang      = true;
       };
     };
     pkgs = allPackages {
@@ -129,13 +130,14 @@ rec {
 
     cc = import ../../build-support/cc-wrapper {
       inherit stdenv;
-      nativeTools  = false;
-      nativeLibc   = true;
-      binutils  = pkgs.darwin.cctools;
-      cc        = pkgs.llvmPackages.clang-unwrapped;
-      coreutils = pkgs.coreutils;
-      shell     = "${pkgs.bash}/bin/bash";
+      nativeTools   = false;
+      nativeLibc    = true;
+      binutils      = pkgs.darwin.cctools;
+      cc            = pkgs.llvmPackages.clang-unwrapped;
+      coreutils     = pkgs.coreutils;
+      shell         = "${pkgs.bash}/bin/bash";
       extraPackages = [ pkgs.libcxx ];
+      isClang       = true;
     };
 
     shell = "${pkgs.bash}/bin/bash";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -91,6 +91,7 @@ rec {
           nativeTools = false;
           nativeLibc = false;
           cc = gccPlain;
+          isGNU = true;
           libc = glibc;
           inherit binutils coreutils;
           name = name;
@@ -234,6 +235,7 @@ rec {
       gcc = lib.makeOverridable (import ../../build-support/cc-wrapper) {
         nativeTools = false;
         nativeLibc = false;
+        isGNU = true;
         cc = stage4.stdenv.cc.cc;
         libc = stage4.pkgs.glibc;
         inherit (stage4.pkgs) binutils coreutils;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -20,6 +20,7 @@ import ../generic rec {
     inherit stdenv;
     binutils = pkgs.binutils;
     cc = pkgs.gcc.cc;
+    isGNU = true;
     coreutils = pkgs.coreutils;
     shell = pkgs.bash + "/bin/sh";
   };

--- a/pkgs/tools/networking/atftp/default.nix
+++ b/pkgs/tools/networking/atftp/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, readline, tcp_wrappers, pcre, makeWrapper }:
 assert stdenv.isLinux;
-assert stdenv.cc.cc.isGNU or false;
+assert stdenv.cc.isGNU;
 let
 version = "0.7";
 debianPatch = fetchurl {

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   # ./configure time check for any of this.
   buildInputs = [ libevent openssl zlib torsocks ];
 
-  CFLAGS = stdenv.lib.optionalString (stdenv.cc.cc.isGNU or false) "-lgcc_s";
+  CFLAGS = stdenv.lib.optionalString stdenv.cc.isGNU "-lgcc_s";
 
   # Patch 'torify' to point directly to torsocks.
   patchPhase = ''

--- a/pkgs/tools/video/rtmpdump/default.nix
+++ b/pkgs/tools/video/rtmpdump/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     ++ optional gnutlsSupport "CRYPTO=GNUTLS"
     ++ optional opensslSupport "CRYPTO=OPENSSL"
     ++ optional stdenv.isDarwin "SYS=darwin"
-    ++ optional (stdenv.cc.cc.isClang or false) "CC=clang";
+    ++ optional stdenv.cc.isClang "CC=clang";
 
   buildInputs = [ zlib ]
     ++ optional gnutlsSupport gnutls

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3433,6 +3433,7 @@ let
 
   clangWrapSelf = build: (import ../build-support/cc-wrapper) {
     cc = build;
+    isClang = true;
     stdenv = clangStdenv;
     libc = glibc;
     binutils = binutils;
@@ -4479,6 +4480,8 @@ let
     nativePrefix = stdenv.cc.nativePrefix or "";
     cc = baseCC;
     libc = libc;
+    isGNU = baseCC.isGNU or false;
+    isClang = baseCC.isClang or false;
     inherit stdenv binutils coreutils zlib;
   };
 
@@ -4518,6 +4521,7 @@ let
     nativePrefix = stdenv.cc.nativePrefix or "";
     cc = baseGCC;
     libc = glibc;
+    isGNU = true;
     inherit stdenv binutils coreutils zlib;
     setupHook = ../build-support/cc-wrapper/setup-hook-stdinc.sh;
   };


### PR DESCRIPTION
These are meant to replace the current idiom of using `stdenv.cc.cc.isGNU or false` to check which compiler we're currently building with.
