### PR TITLE
VMWare guest support and open-vm-tools package

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -460,5 +460,6 @@
   ./virtualisation/openvswitch.nix
   ./virtualisation/parallels-guest.nix
   ./virtualisation/virtualbox-guest.nix
+  ./virtualisation/vmware-guest.nix
   ./virtualisation/xen-dom0.nix
 ]

--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.vmwareGuest;
+  open-vm-tools = pkgs.open-vm-tools;
+in
+{
+  options = {
+    services.vmwareGuest.enable = mkEnableOption "Enable VMWare Guest Support";
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [ {
+      assertion = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
+      message = "VMWare guest is not currently supported on ${pkgs.stdenv.system}";
+    } ];
+
+    environment.systemPackages = [ open-vm-tools ];
+
+    systemd.services.vmware =
+      { description = "VMWare Guest Service";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig.ExecStart = "${open-vm-tools}/bin/vmtoolsd";
+      };
+
+    services.xserver = {
+      videoDrivers = mkOverride 50 [ "vmware" ];
+
+      config = ''
+          Section "InputDevice"
+            Identifier "VMMouse"
+            Driver "vmmouse"
+          EndSection
+        '';
+
+      serverLayoutSection = ''
+          InputDevice "VMMouse"
+        '';
+
+      displayManager.sessionCommands = ''
+          ${open-vm-tools}/bin/vmware-user-suid-wrapper
+        '';
+    };
+  };
+}

--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchurl, makeWrapper, autoconf, automake,
+  libmspack, openssl, pam, xercesc, icu, libdnet, procps, 
+  x11, libXinerama, libXi, libXrender, libXrandr, libXtst,
+  pkgconfig, glib, gtk, gtkmm }:
+
+let
+  majorVersion = "9.10";
+  minorVersion = "0";
+  patchSet = "2476743";
+  version = "${majorVersion}.${minorVersion}-${patchSet}";
+
+in stdenv.mkDerivation {
+  name = "open-vm-tools-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/project/open-vm-tools/open-vm-tools/stable-${majorVersion}.x/open-vm-tools-${version}.tar.gz";
+    sha256 = "15lwayrz9bpx4z12fj616hsn25m997y72licwwz7kms4sx9ssip1";
+  };
+
+  buildInputs = 
+    [ autoconf automake makeWrapper libmspack openssl pam xercesc icu libdnet procps
+      pkgconfig glib gtk gtkmm x11 libXinerama libXi libXrender libXrandr libXtst ];
+
+  patchPhase = ''
+     sed -i s,-Werror,,g configure.ac
+     sed -i 's,^confdir = ,confdir = ''${prefix},' scripts/Makefile.am
+     sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' services/vmtoolsd/Makefile.am
+  '';
+
+  preConfigure = "autoreconf";
+  configureFlags = "--without-kernel-modules --without-xmlsecurity";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/vmware/open-vm-tools";
+    description = "Set of tools for VMWare guests to improve host-guest interaction";
+    longDescription = ''
+      A set of services and modules that enable several features in VMware products for 
+      better management of, and seamless user interactions with, guests. 
+    '';
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ joamaki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9547,6 +9547,11 @@ let
 
   numactl = callPackage ../os-specific/linux/numactl { };
 
+  open-vm-tools = callPackage ../applications/virtualization/open-vm-tools { 
+    inherit (xlibs) libXinerama libXi libXrender libXrandr libXtst;
+    inherit (gnome) gtk gtkmm;
+  };
+
   gocode = callPackage ../development/tools/gocode { };
 
   gotags = callPackage ../development/tools/gotags { };


### PR DESCRIPTION
This adds the open-vm-tools package without the kernel modules and
a service configuration for the vmtoolsd service. 

With this you get copy'n'paste support and monitor resolution automatic
resizing.
