### PR TITLE
Reduce hydra errors

### DIFF
--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -3,9 +3,17 @@
    (http://pypi.python.org/pypi/setuptools/), which represents a large
    number of Python packages nowadays.  */
 
-{ python, setuptools, unzip, wrapPython, lib, recursivePthLoader, distutils-cfg }:
-
-{ name
+{ python
+, setuptools
+, unzip
+, wrapPython
+, lib
+, recursivePthLoader
+, distutils-cfg
+, config
+}: let
+  noThrowOnDisabled = config.noThrowOnBrokenOrUnfree or false || builtins.getEnv "NIXPKGS_NO_THROW_ON_BROKEN_OR_UNFREE" == "1";
+in { name
 
 # by default prefix `name` e.g. "python3.3-${name}"
 , namePrefix ? python.libPrefix + "-"
@@ -51,7 +59,7 @@
 
 
 # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-if disabled then throw "${name} not supported for interpreter ${python.executable}" else python.stdenv.mkDerivation (attrs // {
+if disabled && !noThrowOnDisabled then throw "${name} not supported for interpreter ${python.executable}" else assert !disabled; python.stdenv.mkDerivation (attrs // {
   inherit doCheck;
 
   name = namePrefix + name;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -15,6 +15,7 @@ let lib = import ../../../lib; in lib.makeOverridable (
 let
 
   allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  noThrowOnBrokenOrUnfree = config.noThrowOnBrokenOrUnfree or false || builtins.getEnv "NIXPKGS_NO_THROW_ON_BROKEN_OR_UNFREE" == "1";
 
   whitelist = config.whitelistedLicenses or [];
   blacklist = config.blacklistedLicenses or [];
@@ -103,6 +104,8 @@ let
 
       throwEvalHelp = unfreeOrBroken: whatIsWrong:
         assert builtins.elem unfreeOrBroken ["Unfree" "Broken" "blacklisted"];
+
+        if noThrowOnBrokenOrUnfree then false else
 
         throw ("Package ‘${attrs.name or "«name-missing»"}’ in ${pos''} ${whatIsWrong}, refusing to evaluate."
         + (lib.strings.optionalString (unfreeOrBroken != "blacklisted") ''


### PR DESCRIPTION
With this patchset, hydra can set the `NIXPKGS_NO_THROW_ON_BROKEN_OR_UNFREE` env var to `1` to remove the evaluation errors resulting from nixpkgs unfree/broken/disabled logic.

cc @edolstra for stdenv stuff, @domenkozar for python stuff.
