### PR TITLE
Fix #7272 - re-Add modulesPath and add error context on module arguments evaluation.

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -51,7 +51,7 @@ rec {
         };
       };
 
-      closed = closeModules (modules ++ [ internalModule ]) { inherit config options; lib = import ./.; };
+      closed = closeModules (modules ++ [ internalModule ]) (args // { inherit config options; lib = import ./.; });
 
       # Note: the list of modules is reversed to maintain backward
       # compatibility with the old module system.  Not sure if this is
@@ -102,7 +102,7 @@ rec {
      of ‘options’, ‘config’ and ‘imports’ attributes. */
   unifyModuleSyntax = file: key: m:
     if m ? config || m ? options then
-      let badAttrs = removeAttrs m ["imports" "options" "config" "key" "_file"]; in
+      let badAttrs = removeAttrs m ["imports" "importsArgs" "options" "config" "key" "_file"]; in
       if badAttrs != {} then
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by assignments to the top-level attributes `config' or `options'."
       else
@@ -120,7 +120,7 @@ rec {
         config = removeAttrs m ["key" "_file" "require" "imports"];
       };
 
-  applyIfFunction = key: f: args@{config, options, lib}: if isFunction f then
+  applyIfFunction = key: f: args@{config, ...}: if isFunction f then
     let
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the
@@ -136,12 +136,32 @@ rec {
       # evaluation of the option.
       requiredArgs = builtins.attrNames (builtins.functionArgs f);
       context = name: ''while evaluating the module argument `${name}' in "${key}":'';
-      extraArgs = builtins.listToAttrs (map (name: {
-        inherit name;
-        value = addErrorContext (context name) config._module.args.${name};
-      }) requiredArgs);
 
-    in f (extraArgs // args)
+      stage = except: rec {
+        configArgs = subtractLists except requiredArgs;
+        extraArgs = builtins.listToAttrs (map (name: {
+          inherit name;
+          value = addErrorContext (context name) config._module.args.${name};
+        }) configArgs);
+
+        result = f (extraArgs // args);
+      };
+
+      # In order to work-around reflexivity issues, such as default values,
+      # we have to ask the module if some of its arguments are necessary for
+      # importing another module.
+      #
+      # To solve this issue, we evaluate a module a first time to look for
+      # the importsArgs within the module, then we re-evaluate the same
+      # function but with the correct set of arguments.
+      stage1 = (stage []).result;
+      stage2 =
+        if stage1 ? importsArgs then
+          (stage stage1.importsArgs).result
+        else
+          stage1;
+
+    in stage2
   else
     f;
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -107,6 +107,10 @@ set -- config.enable ./declare-enable.nix ./define-enable.nix ./define-loaOfSub-
 checkConfigError 'The option .* defined in .* does not exist.' "$@"
 checkConfigOutput "true" "$@" ./define-module-check.nix
 
+# Check importsArgs with a default value.
+set -- config.enable ./declare-enable.nix
+checkConfigOutput "true" "$@" ./default-imports-define-enable.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/default-imports-define-enable.nix
+++ b/lib/tests/modules/default-imports-define-enable.nix
@@ -1,0 +1,7 @@
+{ otherModule ? ./define-enable.nix, ... }:
+
+{
+  imports = [ otherModule ];
+  importsArgs = [ "otherModule" ];
+  config = {};
+}

--- a/nixos/maintainers/scripts/ec2/amazon-base-config.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-base-config.nix
@@ -1,5 +1,5 @@
-{ modulesPath, ...}:
+{ ... }:
 {
-  imports = [ "${modulesPath}/virtualisation/amazon-config.nix" ];
+  imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-config.nix> ];
   services.journald.rateLimitBurst = 0;
 }

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -1,7 +1,7 @@
 # This module generates nixos-install, nixos-rebuild,
 # nixos-generate-config, etc.
 
-{ config, pkgs, modulesPath, ... }:
+{ config, pkgs, ... }:
 
 let
 

--- a/nixos/modules/misc/extra-arguments.nix
+++ b/nixos/modules/misc/extra-arguments.nix
@@ -2,7 +2,7 @@
 
 {
   _module.args = {
-    modulesPath = ../.;
+    modulesPath = ../..;
 
     pkgs_i686 = import ../../lib/nixpkgs.nix {
       system = "i686-linux";

--- a/nixos/modules/virtualisation/azure-config.nix
+++ b/nixos/modules/virtualisation/azure-config.nix
@@ -1,5 +1,5 @@
-{ config, pkgs, modulesPath, ... }:
+{ config, pkgs, ... }:
 
 {
-  imports = [ "${modulesPath}/virtualisation/azure-image.nix" ];
+  imports = [ <nixpkgs/nixos/modules/virtualisation/azure-image.nix> ];
 }

--- a/nixos/modules/virtualisation/nova-config.nix
+++ b/nixos/modules/virtualisation/nova-config.nix
@@ -1,5 +1,5 @@
-{ config, pkgs, modulesPath, ... }:
+{ config, pkgs, ... }:
 
 {
-  imports = [ "${modulesPath}/virtualisation/nova-image.nix" ];
+  imports = [ <nixpkgs/nixos/modules/virtualisation/nova-image.nix> ];
 }

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -48,7 +48,7 @@ let
                , extraConfig, readOnly ? true, forceGrubReinstallCount ? 0
                }:
     pkgs.writeText "configuration.nix" ''
-      { config, lib, pkgs, modulesPath, ... }:
+      { config, lib, pkgs, ... }:
 
       { imports =
           [ ./hardware-configuration.nix


### PR DESCRIPTION
This modification undo the modifications related to `modulesPath` and use it in the installer to ensure that we do not brake this accidentally.  As there is no module logic for the moment, which can be used to replace the `modulesPath` argument, I prefer to add it back in the mean time.

In addition, this patch add an error context which, display one extra line of information when --show-trace is used.

```
while evaluating the module argument `pkgs' in "/home/nicolas/nixos-dev/nixpkgs/foo.nix":
infinite recursion encountered
```

This error message worked for `modulesPath` before this modification which re-enables it, and it also works for the now deprecated use of `with pkgs.lib;`.

@wizeman, can you confirm if this fix your issues?
