### PR TITLE
keychain: fixup shebang, use upstream builder, install manpage

### DIFF
--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, coreutils, openssh, gnupg
-, procps, gnugrep, gawk, findutils, gnused }:
+, perl, procps, gnugrep, gawk, findutils, gnused }:
 
 stdenv.mkDerivation rec {
   name = "keychain-${version}";
@@ -12,15 +12,12 @@ stdenv.mkDerivation rec {
     sha256 = "0ajas58cv8mp5wb6hn1zhsqiwfxvx69p4f91a5j2as299rxgrxlp";
   };
 
-  phases = [ "unpackPhase" "patchPhase" "buildPhase" ];
+  buildInputs = [ makeWrapper perl ];
 
-  buildInputs = [ makeWrapper ];
-
-  patchPhase = "sed -i -e 's,version=.*,version=\"${version}\",g' keychain.sh";
-
-  buildPhase = ''
-    mkdir -p $out/bin
-    cp keychain.sh $out/bin/keychain
+  installPhase = ''
+    mkdir -p $out/{bin,share/man/man1}
+    cp keychain $out/bin/keychain
+    cp keychain.1 $out/share/man/man1
     wrapProgram $out/bin/keychain \
       --prefix PATH ":" "${coreutils}/bin" \
       --prefix PATH ":" "${openssh}/bin" \


### PR DESCRIPTION
fixup shebang - build was not running fixupPhase, and shebang was pointing to
/bin/sh. On a system where /bin/sh links to dash, this results in errors:

```
/nix/store/v40yk16fl1rhvr6zz91ij753ziyphwwp-keychain-2.8.0/bin/.keychain-wrapped: 59: /nix/store/v40yk16fl1rhvr6zz91ij753ziyphwwp-keychain-2.8.0/bin/.keychain-wrapped: shopt: not found
/nix/store/v40yk16fl1rhvr6zz91ij753ziyphwwp-keychain-2.8.0/bin/.keychain-wrapped: 686: /nix/store/v40yk16fl1rhvr6zz91ij753ziyphwwp-keychain-2.8.0/bin/.keychain-wrapped: Syntax error: "(" unexpected (expecting ")")
```

use upstream builder - the included Makefile uses perl to generate a manpage and
insert the same text into the keychain script for '--help' output, which was
otherwise missing:

```
$ keychain --help

 * keychain 2.8.0 ~ http://www.funtoo.org

[snip]

INSERT_POD_OUTPUT_HERE
```

install manpage - self explanatory
