### PR TITLE
stdenv: Add isPc helper to replace (isi686 || isx86_64)

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -33,7 +33,7 @@ in
 
   config = mkIf cfg.enable {
     assertions = [ {
-      assertion = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
+      assertion = pkgs.stdenv.isX86;
       message = "Virtualbox not currently supported on ${pkgs.stdenv.system}";
     } ];
 

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -157,7 +157,7 @@ stdenv.mkDerivation rec {
       ${if jackaudioSupport then "" else "--disable-jack"}
       ${if pulseSupport then "--enable-pulse" else "--disable-pulse"}
       ${optionalString (useUnfreeCodecs && codecs != null) "--codecsdir=${codecs}"}
-      ${optionalString (stdenv.isi686 || stdenv.isx86_64) "--enable-runtime-cpudetection"}
+      ${optionalString stdenv.isX86 "--enable-runtime-cpudetection"}
       ${optionalString fribidiSupport "--enable-fribidi"}
       --disable-xanim
       --disable-ivtv

--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -2,7 +2,7 @@
 
 let
   version = "9.2";
-  bootstrapFromC = ! (stdenv.isi686 || stdenv.isx86_64);
+  bootstrapFromC = !stdenv.isX86;
 
   arch = if      stdenv.isi686   then "-i386"
          else if stdenv.isx86_64 then "-x86-64"

--- a/pkgs/development/compilers/ocaml/3.11.2.nix
+++ b/pkgs/development/compilers/ocaml/3.11.2.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, ncurses, x11 }:
 
 let
-   useX11 = stdenv.isi686 || stdenv.isx86_64;
-   useNativeCompilers = stdenv.isi686 || stdenv.isx86_64 || stdenv.isMips;
+   useX11 = stdenv.isX86;
+   useNativeCompilers = stdenv.isX86 || stdenv.isMips;
    inherit (stdenv.lib) optionals optionalString;
 in
 

--- a/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, ncurses, x11 }:
 
 let
-   useX11 = stdenv.isi686 || stdenv.isx86_64;
-   useNativeCompilers = stdenv.isi686 || stdenv.isx86_64 || stdenv.isMips;
+   useX11 = stdenv.isX86;
+   useNativeCompilers = stdenv.isX86 || stdenv.isMips;
    inherit (stdenv.lib) optionals optionalString;
 in
 

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -42,11 +42,11 @@
 }:
 
 let
-  inherit (stdenv) isi686 isx86_64 isArm is64bit isMips isDarwin isCygwin;
+  inherit (stdenv) isX86 isArm is64bit isMips isDarwin isCygwin;
   inherit (stdenv.lib) enableFeature optional optionals;
 in
 
-assert isi686 || isx86_64 || isArm || isMips; # Requires ARM with floating point support
+assert isX86 || isArm || isMips; # Requires ARM with floating point support
 
 assert vp8DecoderSupport || vp8EncoderSupport || vp9DecoderSupport || vp9EncoderSupport;
 assert internalStatsSupport && (vp9DecoderSupport || vp9EncoderSupport) -> postprocSupport;
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     (enableFeature gcovSupport "gcov")
     # Required to build shared libraries
     (enableFeature (!isCygwin) "pic")
-    (enableFeature (isi686 || isx86_64) "use-x86inc")
+    (enableFeature isX86 "use-x86inc")
     (enableFeature optimizationsSupport "optimizations")
     (enableFeature runtimeCpuDetectSupport "runtime-cpu-detect")
     (enableFeature thumbSupport "thumb")

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -42,11 +42,11 @@
 }:
 
 let
-  inherit (stdenv) isi686 isx86_64 isArm is64bit isMips isDarwin isCygwin;
+  inherit (stdenv) isX86 isArm is64bit isMips isDarwin isCygwin;
   inherit (stdenv.lib) enableFeature optional optionals;
 in
 
-assert isi686 || isx86_64 || isArm || isMips; # Requires ARM with floating point support
+assert isX86 || isArm || isMips; # Requires ARM with floating point support
 
 assert vp8DecoderSupport || vp8EncoderSupport || vp9DecoderSupport || vp9EncoderSupport;
 assert internalStatsSupport && (vp9DecoderSupport || vp9EncoderSupport) -> postprocSupport;
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     (enableFeature gcovSupport "gcov")
     # Required to build shared libraries
     (enableFeature (!isCygwin) "pic")
-    (enableFeature (isi686 || isx86_64) "use-x86inc")
+    (enableFeature isX86 "use-x86inc")
     (enableFeature optimizationsSupport "optimizations")
     (enableFeature runtimeCpuDetectSupport "runtime-cpu-detect")
     (enableFeature thumbSupport "thumb")

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -216,6 +216,7 @@ let
               || system == "x86_64-freebsd"
               || system == "x86_64-openbsd"
               || system == "x86_64-solaris";
+      isX86 = isi686 || isx86_64;
       is64bit = system == "x86_64-linux"
              || system == "x86_64-darwin"
              || system == "x86_64-freebsd"

--- a/pkgs/tools/archivers/zpaq/default.nix
+++ b/pkgs/tools/archivers/zpaq/default.nix
@@ -13,10 +13,9 @@ let
     unzip
   ];
   isUnix = with stdenv; isLinux || isGNU || isDarwin || isFreeBSD || isOpenBSD;
-  isx86 = stdenv.isi686 || stdenv.isx86_64;
   compileFlags = ""
     + (stdenv.lib.optionalString isUnix " -Dunix -pthread ")
-    + (stdenv.lib.optionalString (!isx86) " -DNOJIT ")
+    + (stdenv.lib.optionalString (!stdenv.isX86) " -DNOJIT ")
     + " -DNDEBUG "
     + " -fPIC "
     ;

--- a/pkgs/tools/archivers/zpaq/zpaqd.nix
+++ b/pkgs/tools/archivers/zpaq/zpaqd.nix
@@ -13,10 +13,9 @@ let
     unzip
   ];
   isUnix = with stdenv; isLinux || isGNU || isDarwin || isFreeBSD || isOpenBSD;
-  isx86 = stdenv.isi686 || stdenv.isx86_64;
   compileFlags = ""
     + (stdenv.lib.optionalString isUnix " -Dunix -pthread ")
-    + (stdenv.lib.optionalString (!isx86) " -DNOJIT ")
+    + (stdenv.lib.optionalString (!stdenv.isX86) " -DNOJIT ")
     + " -DNDEBUG "
     + " -fPIC "
     ;

--- a/pkgs/tools/networking/filegive/default.nix
+++ b/pkgs/tools/networking/filegive/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchgit, go }:
 
-assert stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64 || stdenv.isArm);
+assert stdenv.isLinux && (stdenv.isX86 || stdenv.isArm);
 
 let
 

--- a/pkgs/tools/system/storebrowse/default.nix
+++ b/pkgs/tools/system/storebrowse/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchhg, go, sqlite}:
 
-assert stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64 || stdenv.isArm);
+assert stdenv.isLinux && (stdenv.isX86 || stdenv.isArm);
 
 stdenv.mkDerivation rec {
   name = "storebrowse-20130318212204";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3593,7 +3593,7 @@ let
     inherit noSysDirs;
 
     # PGO seems to speed up compilation by gcc by ~10%, see #445 discussion
-    profiledCompiler = with stdenv; (!isDarwin && (isi686 || isx86_64));
+    profiledCompiler = with stdenv; (!isDarwin && isX86);
 
     # When building `gcc.crossDrv' (a "Canadian cross", with host == target
     # and host != build), `cross' must be null but the cross-libc must still
@@ -3628,7 +3628,7 @@ let
     inherit noSysDirs;
 
     # PGO seems to speed up compilation by gcc by ~10%, see #445 discussion
-    profiledCompiler = with stdenv; (!isDarwin && (isi686 || isx86_64));
+    profiledCompiler = with stdenv; (!isDarwin && isX86);
 
     # When building `gcc.crossDrv' (a "Canadian cross", with host == target
     # and host != build), `cross' must be null but the cross-libc must still
@@ -3649,7 +3649,7 @@ let
     inherit noSysDirs;
 
     # PGO seems to speed up compilation by gcc by ~10%, see #445 discussion
-    profiledCompiler = with stdenv; (!isDarwin && (isi686 || isx86_64));
+    profiledCompiler = with stdenv; (!isDarwin && isX86);
 
     # When building `gcc.crossDrv' (a "Canadian cross", with host == target
     # and host != build), `cross' must be null but the cross-libc must still


### PR DESCRIPTION
It's a relatively common operation to compare the current platform to PC platforms, i.e. x86 compatible platforms.

Bikeshedding: maybe there's a better name than `isPc`?
