### PR TITLE
Update SHA256 for hplip plugin

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -23,7 +23,7 @@ let
 
   plugin = fetchurl {
     url = "http://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${name}-plugin.run";
-    sha256 = "0j8z8m3ygwahka7jv3hpzvfz187lh3kzzjhcy7grgaw2k01v5frm";
+    sha256 = "1pzxv9yway1x1m5grz6042p54ldh7jcgv4qrkjhlcb4vr9plwql9";
   };
 
 in


### PR DESCRIPTION
The hplip plugin SHA256 appears incorrect for version `hplip-3.15.2`.

```
output path ‘/nix/store/671z0sx0giw5jbj14gmfh1q59zq9rc9n-hplip-3.15.2-plugin.run’ should have sha256 hash ‘0j8z8m3ygwahka7jv3hpzvfz187lh3kzzjhcy7grgaw2k01v5frm’, instead has ‘1pzxv9yway1x1m5grz6042p54ldh7jcgv4qrkjhlcb4vr9plwql9’
cannot build derivation ‘/nix/store/d3d745f7inx788wfhjmx0k4868lj2wln-hplip-3.15.2.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/k85x3ddk13mnhrarm8k7fd1vrw8lyqdg-cups-progs.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/7lfx6595pgx8yypnmsmg8wmh1zg2p8zz-etc-file.drv’: 1 dependencies couldn't be built                                                                          
cannot build derivation ‘/nix/store/sr9qgjf5qwc1mkj1jchnyrhx417bvfxy-etc-file.drv’: 1 dependencies couldn't be built                                                                          
cannot build derivation ‘/nix/store/shcbcyxgaxypiy9i1nzr9s20n8npng1n-unit-cups.service.drv’: 2 dependencies couldn't be built                                                                 
cannot build derivation ‘/nix/store/4c7qn2349plmwvy83j1mdqjdny6df57x-system-units.drv’: 1 dependencies couldn't be built                                                                      
cannot build derivation ‘/nix/store/560429ph8slvm5nm53z4xyx1wn0g3l22-etc.drv’: 3 dependencies couldn't be built                                                                               
cannot build derivation ‘/nix/store/6mm8171bgqfxpsj29v9gy1kfcg82fay7-nixos-15.05pre61966.75ebc3c.drv’: 1 dependencies couldn't be built                                                       
error: build of ‘/nix/store/6mm8171bgqfxpsj29v9gy1kfcg82fay7-nixos-15.05pre61966.75ebc3c.drv’ failed                                                                                          
```
