### PR TITLE
openal to openalSoft conversion

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libtoxcore, qt5, openalSoft, opencv
+{ stdenv, fetchFromGitHub, pkgconfig, libtoxcore, qt5, openal, opencv
 , libsodium, libXScrnSaver }:
 
 let
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      libtoxcore openalSoft opencv libsodium filteraudio
+      libtoxcore openal opencv libsodium filteraudio
       qt5.base qt5.tools libXScrnSaver
     ];
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/games/0ad/default.nix
+++ b/pkgs/games/0ad/default.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, fetchurl, python27
 , pkgconfig, spidermonkey_24, boost, icu, libxml2, libpng
 , libjpeg, zlib, curl, libogg, libvorbis, enet, miniupnpc
-, openalSoft, mesa, xproto, libX11, libXcursor, nspr, SDL
+, openal, mesa, xproto, libX11, libXcursor, nspr, SDL
 , gloox, nvidia-texture-tools
 , withEditor ? true, wxGTK ? null
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     zeroadData python27 pkgconfig spidermonkey_24 boost icu
     libxml2 libpng libjpeg zlib curl libogg libvorbis enet
-    miniupnpc openalSoft mesa xproto libX11 libXcursor nspr
+    miniupnpc openal mesa xproto libX11 libXcursor nspr
     SDL gloox nvidia-texture-tools
   ] ++ stdenv.lib.optional withEditor wxGTK;
 

--- a/pkgs/games/dhewm3/default.nix
+++ b/pkgs/games/dhewm3/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, unzip, cmake, SDL, mesa, zlib, libjpeg, libogg, libvorbis
-, openalSoft, curl }:
+, openal, curl }:
 
 stdenv.mkDerivation rec {
   hash = "92a41322f4aa8bd45395d8088721c9a2bf43c79b";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cd */neo
   '';
 
-  buildInputs = [ unzip cmake SDL mesa zlib libjpeg libogg libvorbis openalSoft
+  buildInputs = [ unzip cmake SDL mesa zlib libjpeg libogg libvorbis openal
     curl ];
 
   enableParallelBuilding = true;

--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, bison, flex, gettext, pkgconfig, libpng
-, libtheora, openalSoft, physfs, mesa, fribidi, fontconfig
+, libtheora, openal, physfs, mesa, fribidi, fontconfig
 , freetype, qt4, glew, libogg, libvorbis, zlib, libX11
 , libXrandr, zip, unzip, which
 , withVideos ? false
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/${pname}/warzone2100/Videos/high-quality-en/sequences.wz";
     sha256 = "90ff552ca4a70e2537e027e22c5098ea4ed1bc11bb7fc94138c6c941a73d29fa";
   };
-  buildInputs = [ bison flex gettext pkgconfig libpng libtheora openalSoft
+  buildInputs = [ bison flex gettext pkgconfig libpng libtheora openal
                   physfs mesa fribidi fontconfig freetype qt4
                   glew libogg libvorbis zlib libX11 libXrandr zip
                   unzip

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7335,9 +7335,9 @@ let
 
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
-  openal = callPackage ../development/libraries/openal { };
-
-  # added because I hope that it has been easier to compile on x86 (for blender)
+  # openalSoft is 100% ABI compatible to openalLegacy and should be a default
+  openal = openalSoft;
+  openalLegacy = callPackage ../development/libraries/openal { };
   openalSoft = callPackage ../development/libraries/openal-soft { };
 
   openbabel = callPackage ../development/libraries/openbabel { };


### PR DESCRIPTION
openalSoft is a drop in replacement for openal from creative labs.

since openalSoft does support backends as pulseaudio and also because it has the more active user/developer base we should make it the default.

<pre>
# openalSoft is 100% ABI compatible to openalLegacy and should be a default
openal = openalSoft;
openalLegacy = callPackage ../development/libraries/openal { };
openalSoft = callPackage ../development/libraries/openal-soft { };
</pre>


if programs/libraries still require openal from createive labs, just use:
openalLegacy

i've tested spring/fakenes and scorched3d (won't build but not because of openalSoft). also codehero tested with minetest where it works.
