### PR TITLE
Add Jekyll

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -153,6 +153,7 @@
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
+  pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
   phausmann = "Philipp Hausmann <nix@314.ch>";
   philandstuff = "Philip Potter <philip.g.potter@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";

--- a/pkgs/applications/misc/jekyll/Gemfile
+++ b/pkgs/applications/misc/jekyll/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'jekyll'
+gem 'rdiscount'

--- a/pkgs/applications/misc/jekyll/Gemfile.lock
+++ b/pkgs/applications/misc/jekyll/Gemfile.lock
@@ -1,0 +1,72 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    blankslate (2.1.2.4)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    classifier-reborn (2.0.3)
+      fast-stemmer (~> 1.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.1.1)
+    colorator (0.1)
+    execjs (2.5.2)
+    fast-stemmer (1.0.2)
+    ffi (1.9.8)
+    hitimes (1.2.2)
+    jekyll (2.5.3)
+      classifier-reborn (~> 2.0)
+      colorator (~> 0.1)
+      jekyll-coffeescript (~> 1.0)
+      jekyll-gist (~> 1.0)
+      jekyll-paginate (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 2.6.1)
+      mercenary (~> 0.3.3)
+      pygments.rb (~> 0.6.0)
+      redcarpet (~> 3.1)
+      safe_yaml (~> 1.0)
+      toml (~> 0.1.0)
+    jekyll-coffeescript (1.0.1)
+      coffee-script (~> 2.2)
+    jekyll-gist (1.2.1)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.2.1)
+      listen (~> 2.7)
+    kramdown (1.7.0)
+    liquid (2.6.2)
+    listen (2.10.0)
+      celluloid (~> 0.16.0)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.11)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rdiscount (2.1.8)
+    redcarpet (3.2.3)
+    safe_yaml (1.0.4)
+    sass (3.4.13)
+    timers (4.0.1)
+      hitimes
+    toml (0.1.2)
+      parslet (~> 1.5.0)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  rdiscount

--- a/pkgs/applications/misc/jekyll/default.nix
+++ b/pkgs/applications/misc/jekyll/default.nix
@@ -14,7 +14,7 @@ bundlerEnv {
     description = "Simple, blog aware, static site generator";
     homepage    =  http://jekyllrb.com/;
     license     = with licenses; mit;
-    # maintainers = with maintainers; [ offline ];
+    maintainers = with maintainers; [ pesterhazy ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/jekyll/default.nix
+++ b/pkgs/applications/misc/jekyll/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, lib, bundlerEnv, ruby_2_1, curl }:
+
+bundlerEnv {
+  name = "jekyll-2.5.3";
+
+  ruby = ruby_2_1;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  buildInputs = [ curl ];
+
+  meta = with lib; {
+    description = "Simple, blog aware, static site generator";
+    homepage    =  http://jekyllrb.com/;
+    license     = with licenses; mit;
+    # maintainers = with maintainers; [ offline ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/jekyll/gemset.nix
+++ b/pkgs/applications/misc/jekyll/gemset.nix
@@ -1,0 +1,282 @@
+{
+  "blankslate" = {
+    version = "2.1.2.4";
+    source = {
+      type = "gem";
+      sha256 = "0jnnq5q5dwy2rbfcl769vd9bk1yn0242f6yjlb9mnqdm9627cdcx";
+    };
+  };
+  "celluloid" = {
+    version = "0.16.0";
+    source = {
+      type = "gem";
+      sha256 = "044xk0y7i1xjafzv7blzj5r56s7zr8nzb619arkrl390mf19jxv3";
+    };
+    dependencies = [
+      "timers"
+    ];
+  };
+  "classifier-reborn" = {
+    version = "2.0.3";
+    source = {
+      type = "gem";
+      sha256 = "0vca8jl7nbgzyb7zlvnq9cqgabwjdl59jqlpfkwzv6znkri7cpby";
+    };
+    dependencies = [
+      "fast-stemmer"
+    ];
+  };
+  "coffee-script" = {
+    version = "2.4.1";
+    source = {
+      type = "gem";
+      sha256 = "0rc7scyk7mnpfxqv5yy4y5q1hx3i7q3ahplcp4bq2g5r24g2izl2";
+    };
+    dependencies = [
+      "coffee-script-source"
+      "execjs"
+    ];
+  };
+  "coffee-script-source" = {
+    version = "1.9.1.1";
+    source = {
+      type = "gem";
+      sha256 = "1arfrwyzw4sn7nnaq8jji5sv855rp4c5pvmzkabbdgca0w1cxfq5";
+    };
+  };
+  "colorator" = {
+    version = "0.1";
+    source = {
+      type = "gem";
+      sha256 = "09zp15hyd9wlbgf1kmrf4rnry8cpvh1h9fj7afarlqcy4hrfdpvs";
+    };
+  };
+  "execjs" = {
+    version = "2.5.2";
+    source = {
+      type = "gem";
+      sha256 = "0y2193yhcyz9f97m7g3wanvwzdjb08sllrj1g84sgn848j12vyl0";
+    };
+  };
+  "fast-stemmer" = {
+    version = "1.0.2";
+    source = {
+      type = "gem";
+      sha256 = "0688clyk4xxh3kdb18vi089k90mca8ji5fwaknh3da5wrzcrzanh";
+    };
+  };
+  "ffi" = {
+    version = "1.9.8";
+    source = {
+      type = "gem";
+      sha256 = "0ph098bv92rn5wl6rn2hwb4ng24v4187sz8pa0bpi9jfh50im879";
+    };
+  };
+  "hitimes" = {
+    version = "1.2.2";
+    source = {
+      type = "gem";
+      sha256 = "17y3ggqxl3m6x9gqpgdn39z0pxpmw666d40r39bs7ngdmy680jn4";
+    };
+  };
+  "jekyll" = {
+    version = "2.5.3";
+    source = {
+      type = "gem";
+      sha256 = "1ad3d62yd5rxkvn3xls3xmr2wnk8fiickjy27g098hs842wmw22n";
+    };
+    dependencies = [
+      "classifier-reborn"
+      "colorator"
+      "jekyll-coffeescript"
+      "jekyll-gist"
+      "jekyll-paginate"
+      "jekyll-sass-converter"
+      "jekyll-watch"
+      "kramdown"
+      "liquid"
+      "mercenary"
+      "pygments.rb"
+      "redcarpet"
+      "safe_yaml"
+      "toml"
+    ];
+  };
+  "jekyll-coffeescript" = {
+    version = "1.0.1";
+    source = {
+      type = "gem";
+      sha256 = "19nkqbaxqbzqbfbi7sgshshj2krp9ap88m9fc5pa6mglb2ypk3hg";
+    };
+    dependencies = [
+      "coffee-script"
+    ];
+  };
+  "jekyll-gist" = {
+    version = "1.2.1";
+    source = {
+      type = "gem";
+      sha256 = "10hywgdwqafa21nwa5br54wvp4wsr3wnx64v8d81glj5cs17f9bv";
+    };
+  };
+  "jekyll-paginate" = {
+    version = "1.1.0";
+    source = {
+      type = "gem";
+      sha256 = "0r7bcs8fq98zldih4787zk5i9w24nz5wa26m84ssja95n3sas2l8";
+    };
+  };
+  "jekyll-sass-converter" = {
+    version = "1.3.0";
+    source = {
+      type = "gem";
+      sha256 = "1xqmlr87xmzpalf846gybkbfqkj48y3fva81r7c7175my9p4ykl1";
+    };
+    dependencies = [
+      "sass"
+    ];
+  };
+  "jekyll-watch" = {
+    version = "1.2.1";
+    source = {
+      type = "gem";
+      sha256 = "0p9mc8m4bggsqlq567g1g67z5fvzlm7yyv4l8717l46nq0d52gja";
+    };
+    dependencies = [
+      "listen"
+    ];
+  };
+  "kramdown" = {
+    version = "1.7.0";
+    source = {
+      type = "gem";
+      sha256 = "070r81kz88zw28c8bs5p0p92ymn1nldci2fm1arkas0bnqrd3rna";
+    };
+  };
+  "liquid" = {
+    version = "2.6.2";
+    source = {
+      type = "gem";
+      sha256 = "1k7lx7szwnz7vv3hqpdb6bgw8p73sa1ss9m1m5h0jaqb9xkqnfzb";
+    };
+  };
+  "listen" = {
+    version = "2.10.0";
+    source = {
+      type = "gem";
+      sha256 = "131pgi5bsqln2kfkp72wpi0dfz5i124758xcl1h3c5gz75j0vg2i";
+    };
+    dependencies = [
+      "celluloid"
+      "rb-fsevent"
+      "rb-inotify"
+    ];
+  };
+  "mercenary" = {
+    version = "0.3.5";
+    source = {
+      type = "gem";
+      sha256 = "0ls7z086v4xl02g4ia5jhl9s76d22crgmplpmj0c383liwbqi9pb";
+    };
+  };
+  "parslet" = {
+    version = "1.5.0";
+    source = {
+      type = "gem";
+      sha256 = "0qp1m8n3m6k6g22nn1ivcfkvccq5jmbkw53vvcjw5xssq179l9z3";
+    };
+    dependencies = [
+      "blankslate"
+    ];
+  };
+  "posix-spawn" = {
+    version = "0.3.11";
+    source = {
+      type = "gem";
+      sha256 = "052lnxbkvlnwfjw4qd7vn2xrlaaqiav6f5x5bcjin97bsrfq6cmr";
+    };
+  };
+  "pygments.rb" = {
+    version = "0.6.3";
+    source = {
+      type = "gem";
+      sha256 = "160i761q2z8kandcikf2r5318glgi3pf6b45wa407wacjvz2966i";
+    };
+    dependencies = [
+      "posix-spawn"
+      "yajl-ruby"
+    ];
+  };
+  "rb-fsevent" = {
+    version = "0.9.4";
+    source = {
+      type = "gem";
+      sha256 = "12if5xsik64kihxf5awsyavlp595y47g9qz77vfp2zvkxgglaka7";
+    };
+  };
+  "rb-inotify" = {
+    version = "0.9.5";
+    source = {
+      type = "gem";
+      sha256 = "0kddx2ia0qylw3r52nhg83irkaclvrncgy2m1ywpbhlhsz1rymb9";
+    };
+    dependencies = [
+      "ffi"
+    ];
+  };
+  "rdiscount" = {
+    version = "2.1.8";
+    source = {
+      type = "gem";
+      sha256 = "0vcyy90r6wfg0b0y5wqp3d25bdyqjbwjhkm1xy9jkz9a7j72n70v";
+    };
+  };
+  "redcarpet" = {
+    version = "3.2.3";
+    source = {
+      type = "gem";
+      sha256 = "0l6zr8wlqb648z202kzi7l9p89b6v4ivdhif5w803l1rrwyzvj0m";
+    };
+  };
+  "safe_yaml" = {
+    version = "1.0.4";
+    source = {
+      type = "gem";
+      sha256 = "1hly915584hyi9q9vgd968x2nsi5yag9jyf5kq60lwzi5scr7094";
+    };
+  };
+  "sass" = {
+    version = "3.4.13";
+    source = {
+      type = "gem";
+      sha256 = "0wxkjm41xr77pnfi06cbwv6vq0ypbni03jpbpskd7rj5b0zr27ig";
+    };
+  };
+  "timers" = {
+    version = "4.0.1";
+    source = {
+      type = "gem";
+      sha256 = "03ahv07wn1f2g3c5843q7sf03a81518lq5624s9f49kbrswa2p7l";
+    };
+    dependencies = [
+      "hitimes"
+    ];
+  };
+  "toml" = {
+    version = "0.1.2";
+    source = {
+      type = "gem";
+      sha256 = "1wnvi1g8id1sg6776fvzf98lhfbscchgiy1fp5pvd58a8ds2fq9v";
+    };
+    dependencies = [
+      "parslet"
+    ];
+  };
+  "yajl-ruby" = {
+    version = "1.2.1";
+    source = {
+      type = "gem";
+      sha256 = "0zvvb7i1bl98k3zkdrnx9vasq0rp2cyy5n7p9804dqs4fz9xh9vf";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1795,6 +1795,8 @@ let
 
   jdiskreport = callPackage ../tools/misc/jdiskreport { };
 
+  jekyll = callPackage ../applications/misc/jekyll { };
+
   jfsutils = callPackage ../tools/filesystems/jfsutils { };
 
   jhead = callPackage ../tools/graphics/jhead { };


### PR DESCRIPTION
This adds the `jekyll` static site generator. My understanding is that it used to be included in 14.10 but got dropped in relations to `rubyLibs`. I used the `bundix` tool to generate `gemset.nix` as per documentation.

As `jekyll listen --watch` fails with MRI ruby 1.9, I chose a 2.1 version of ruby instead.
