### PR TITLE
zeal: update to 0.1.1

### DIFF
--- a/pkgs/data/documentation/zeal/default.nix
+++ b/pkgs/data/documentation/zeal/default.nix
@@ -1,36 +1,24 @@
 { stdenv, fetchFromGitHub, pkgconfig, qt5, libarchive }:
 
 stdenv.mkDerivation rec {
-  version = "20141123";
+  version = "0.1.1";
   name = "zeal-${version}";
 
   src = fetchFromGitHub {
     owner = "zealdocs";
     repo = "zeal";
-    rev = "76405f8387d6a82697faab9630c78f31417d8450";
-    sha256 = "1057py3j2flzxyiks031s0mwm9h82v033iqn5cq8sycmrb3ihj2s";
+    rev = "v${version}";
+    sha256 = "172wf50fq1l5p8hq1irvpwr7ljxkjaby71afrm82jz3ixl6dg2ii";
   };
 
-  buildInputs = [ pkgconfig qt5.base qt5.webkit libarchive ];
+  buildInputs = [ pkgconfig qt5.base qt5.webkit qt5.imageformats libarchive ];
 
-  patchPhase = ''
-    substituteInPlace src/main.cpp \
-      --replace /usr/share/pixmaps/zeal $out/share/pixmaps/zeal
-  '';
-
-  buildPhase = ''
-    qmake PREFIX=$out
-    make
+  configurePhase = ''
+    qmake PREFIX=/
   '';
 
   installPhase = ''
     make INSTALL_ROOT=$out install
-  '';
-
-  preFixup = ''
-    mv $out/usr/bin $out/bin
-    mv $out/usr/share $out/share
-    rmdir $out/usr
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Update and cleanup of the package. The patching and fixup phase are not necessary anymore.
