### PR TITLE
nixos: add bird module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -217,6 +217,7 @@
       lambdabot = 191;
       asterisk = 192;
       plex = 193;
+      bird = 195;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -412,6 +413,7 @@
       #asterisk = 192; # unused
       plex = 193;
       sabnzbd = 194;
+      bird = 195;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -252,6 +252,7 @@
   ./services/networking/atftpd.nix
   ./services/networking/avahi-daemon.nix
   ./services/networking/bind.nix
+  ./services/networking/bird.nix
   ./services/networking/bitlbee.nix
   ./services/networking/btsync.nix
   ./services/networking/charybdis.nix

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf mkOption singleton types;
+  inherit (pkgs) bird;
+  cfg = config.services.bird;
+
+  configFile = pkgs.writeText "bird.conf" ''
+    ${cfg.config}
+  '';
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.bird = {
+
+      enable = mkEnableOption "BIRD Internet Routing Daemon";
+
+      config = mkOption {
+        type = types.string;
+        description = ''
+          BIRD Internet Routing Daemon configuration file.
+          http://bird.network.cz/?get_doc&f=bird-3.html
+        '';
+      };
+
+      user = mkOption {
+        type = types.string;
+        default = "ircd";
+        description = ''
+          BIRD Internet Routing Daemon user.
+        '';
+      };
+
+      group = mkOption {
+        type = types.string;
+        default = "ircd";
+        description = ''
+          BIRD Internet Routing Daemon group.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers = singleton {
+      name = cfg.user;
+      description = "BIRD Internet Routing Daemon user";
+      uid = config.ids.uids.bird;
+      group = cfg.group;
+    };
+
+    users.extraGroups = singleton {
+      name = cfg.group;
+      gid = config.ids.gids.bird;
+    };
+
+    systemd.services.bird = {
+      description = "BIRD Internet Routing Daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart   = "${bird}/bin/bird -d -c ${configFile} -s /var/run/bird.ctl -u ${cfg.user} -g ${cfg.group}";
+      };
+    };
+  };
+}

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flex bison readline ];
 
+  patches = [
+    ./dont-create-sysconfdir.patch
+  ];
+
+  configureFlags = [
+    "--localstatedir /var"
+  ];
+
   meta = {
     description = "BIRD Internet Routing Daemon";
     homepage = http://bird.network.cz;

--- a/pkgs/servers/bird/dont-create-sysconfdir.patch
+++ b/pkgs/servers/bird/dont-create-sysconfdir.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/Makefile.in b/tools/Makefile.in
+index 062ba91..4fd7453 100644
+--- a/tools/Makefile.in
++++ b/tools/Makefile.in
+@@ -68,7 +68,7 @@ tags:
+ 	cd $(srcdir) ; etags -lc `find $(static-dirs) $(addprefix $(objdir)/,$(dynamic-dirs)) $(client-dirs) -name *.[chY]`
+ 
+ install: all
+-	$(INSTALL) -d $(DESTDIR)/$(sbindir) $(DESTDIR)/$(sysconfdir) $(DESTDIR)/@runtimedir@
++	$(INSTALL) -d $(DESTDIR)/$(sbindir) $(DESTDIR)/$(sysconfdir)
+ 	$(INSTALL_PROGRAM) $(exedir)/bird $(DESTDIR)/$(sbindir)/bird@SUFFIX@
+ 	$(INSTALL_PROGRAM) $(exedir)/birdcl $(DESTDIR)/$(sbindir)/birdcl@SUFFIX@
+ 	if test -n "@CLIENT@" ; then								\


### PR DESCRIPTION
birdc and birdcl from the bird package need to be fixed to look in /var/run/ instead of prefix/var/run for bird.ctl.
I will look into this today.
Feedback for the current state is appreciated.
