### PR TITLE
Fix: khal 0.4.0 does not work with python 3

### DIFF
--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -25,11 +25,10 @@ pythonPackages.buildPythonPackage rec {
     python.modules.sqlite3
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://lostpackets.de/khal/;
     description = "CLI calendar application";
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer jgeerds ];
   };
 }
-

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -22,6 +22,7 @@ pythonPackages.buildPythonPackage rec {
     requests_toolbelt
     tzlocal
     urwid
+    python.modules.sqlite3
   ];
 
   meta = {

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, pythonPackages }:
 
 pythonPackages.buildPythonPackage rec {
   version = "0.4.3";
@@ -20,12 +20,11 @@ pythonPackages.buildPythonPackage rec {
     atomicwrites
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/untitaker/vdirsyncer;
     description = "Synchronize calendars and contacts";
-    maintainers = [ lib.maintainers.matthiasbeyer ];
-    platforms = lib.platforms.all;
-    license = lib.licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer jgeerds ];
+    platforms = platforms.all;
+    license = licenses.mit;
   };
 }
-

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -10,10 +10,9 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "0jrxmq8lq0dvqflmh42hhyvc3jjrg1cg3gzfhdcsskj9zz0m6wai";
   };
 
-  pythonPath = with pythonPackages; [
+  propagatedBuildInputs = with pythonPackages; [
     icalendar
     click
-    requests
     lxml
     setuptools
     requests_toolbelt

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12432,9 +12432,7 @@ let
 
   vcprompt = callPackage ../applications/version-management/vcprompt { };
 
- vdirsyncer = callPackage ../tools/misc/vdirsyncer {
-   pythonPackages = python3Packages;
- };
+  vdirsyncer = callPackage ../tools/misc/vdirsyncer { };
 
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11390,9 +11390,7 @@ let
 
   keymon = callPackage ../applications/video/key-mon { };
 
-  khal = callPackage ../applications/misc/khal {
-    pythonPackages = python3Packages;
-  };
+  khal = callPackage ../applications/misc/khal { };
 
   kid3 = callPackage ../applications/audio/kid3 {
     qt = qt4;


### PR DESCRIPTION
khal 0.4.0 does not work with python 3, as the author [just told me](https://github.com/geier/khal/issues/197).

Unfortunately, I cannot build the derivation yet, because of:

```
[...]
building path(s) ‘/nix/store/4vrck309sczs7xx9hki4i5vr3y8hnwry-python2.7-khal-0.4.0’
unpacking sources
unpacking source archive /nix/store/g008v0w328n0chlmpysk34nxcjn4cq3j-v0.4.0.tar.gz
source root is khal-0.4.0
patching sources
configuring
building
wrote khal/version.py with version=0.4.0
running build
running build_py
creating build
creating build/lib
creating build/lib/khal
copying khal/version.py -> build/lib/khal
copying khal/terminal.py -> build/lib/khal
copying khal/log.py -> build/lib/khal
copying khal/exceptions.py -> build/lib/khal
copying khal/controllers.py -> build/lib/khal
copying khal/compat.py -> build/lib/khal
copying khal/cli.py -> build/lib/khal
copying khal/calendar_display.py -> build/lib/khal
copying khal/aux.py -> build/lib/khal
copying khal/__init__.py -> build/lib/khal
creating build/lib/khal/ui
copying khal/ui/widgets.py -> build/lib/khal/ui
copying khal/ui/startendeditor.py -> build/lib/khal/ui
copying khal/ui/base.py -> build/lib/khal/ui
copying khal/ui/__init__.py -> build/lib/khal/ui
creating build/lib/khal/khalendar
copying khal/khalendar/khalendar.py -> build/lib/khal/khalendar
copying khal/khalendar/exceptions.py -> build/lib/khal/khalendar
copying khal/khalendar/event.py -> build/lib/khal/khalendar
copying khal/khalendar/backend.py -> build/lib/khal/khalendar
copying khal/khalendar/aux.py -> build/lib/khal/khalendar
copying khal/khalendar/__init__.py -> build/lib/khal/khalendar
creating build/lib/khal/settings
copying khal/settings/utils.py -> build/lib/khal/settings
copying khal/settings/settings.py -> build/lib/khal/settings
copying khal/settings/exceptions.py -> build/lib/khal/settings
copying khal/settings/__init__.py -> build/lib/khal/settings
copying khal/settings/default.khal -> build/lib/khal/settings
copying khal/settings/khal.spec -> build/lib/khal/settings
running tests
wrote khal/version.py with version=0.4.0
running test
Searching for tzlocal>=1.0
Reading https://pypi.python.org/simple/tzlocal/
Download error on https://pypi.python.org/simple/tzlocal/: [Errno -2] Name or service not known -- Some packages may not be found!
Couldn't find index page for 'tzlocal' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading https://pypi.python.org/simple/
Download error on https://pypi.python.org/simple/: [Errno -2] Name or service not known -- Some packages may not be found!
No local packages or download links found for tzlocal>=1.0
error: Could not find suitable distribution for Requirement.parse('tzlocal>=1.0')
builder for ‘/nix/store/xsbcz1hmgsbiszm48w4ngwsmcxg2z59j-python2.7-khal-0.4.0.drv’ failed with exit code 1
error: build of ‘/nix/store/xsbcz1hmgsbiszm48w4ngwsmcxg2z59j-python2.7-khal-0.4.0.drv’ failed
```

Pointers?
