### PR TITLE
nixos: Fixes eval and build error of nova image builder

### DIFF
--- a/nixos/modules/virtualisation/nova-image.nix
+++ b/nixos/modules/virtualisation/nova-image.nix
@@ -46,15 +46,19 @@ with lib;
 
           # Register the paths in the Nix database.
           printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-              chroot /mnt ${config.nix.package}/bin/nix-store --load-db
+              chroot /mnt ${config.nix.package}/bin/nix-store --load-db --option build-users-group ""
 
           # Create the system profile to allow nixos-rebuild to work.
-          chroot /mnt ${config.nix.package}/bin/nix-env \
+          chroot /mnt ${config.nix.package}/bin/nix-env --option build-users-group "" \
               -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel}
 
           # `nixos-rebuild' requires an /etc/NIXOS.
           mkdir -p /mnt/etc
           touch /mnt/etc/NIXOS
+
+          # `switch-to-configuration' requires a /bin/sh
+          mkdir -p /mnt/bin
+          ln -s ${config.system.build.binsh}/bin/sh /mnt/bin/sh
 
           # Install a configuration.nix.
           mkdir -p /mnt/etc/nixos
@@ -106,7 +110,6 @@ with lib;
 
   # Since Nova allows VNC access to instances, it's nice to start to
   # start a few virtual consoles.
-  services.mingetty.ttys = [ "tty1" "tty2" ];
 
   # Allow root logins only using the SSH key that the user specified
   # at instance creation time.


### PR DESCRIPTION
Fixes eval and build error of nova image builder by removing deprecated attributes and adding parts from `amazon-image.nix`. 

I have tested this by running `nix-build -A config.system.build.novaImage` in the repo with `NIXOS_CONFIG` set with the path to `nova-config.nix`. 

~~I have not tested whether the image actually works on nova, but I am planning to do this today on my OpenStack host~~. It works! See comment below!

See relevant discussion in issue #7869 

Great news everyone! I imported the image into my OpenStack install and started a new instance and everything worked!

Importing the actual image:

```
$ glance image-create --name "nixos-unstable-amd64" --is-public true --disk-format raw --container-format bare --file ./nixos-unstable-nova.img 
+------------------+--------------------------------------+
| Property         | Value                                |
+------------------+--------------------------------------+
| checksum         | ●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●     |
| container_format | bare                                 |
| created_at       | 2015-05-17T19:49:38.000000           |
| deleted          | False                                |
| deleted_at       | None                                 |
| disk_format      | raw                                  |
| id               | ●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●● |
| is_public        | True                                 |
| min_disk         | 0                                    |
| min_ram          | 0                                    |
| name             | nixos-unstable-amd64                 |
| owner            | ●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●     |
| protected        | False                                |
| size             | 4294967296                           |
| status           | active                               |
| updated_at       | 2015-05-17T19:50:15.000000           |
| virtual_size     | None                                 |
+------------------+--------------------------------------+
```

After starting a new instance and assigning a floating IP to it, I could SSH into it:

```
$ ssh -i mysupersecretkeyname.pem root@x.x.x.107
The authenticity of host 'x.x.x.107 (x.x.x.107)' can't be established.
ECDSA key fingerprint is SHA256:●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'x.x.x.107' (ECDSA) to the list of known hosts.

[root@nixos:~]# ls -la
total 20
drwx------  4 root root 4096 May 17 19:57 .
drwxr-xr-x 16 root root 4096 May 17 19:53 ..
-rw-r--r--  1 root root   48 May 17 19:57 .nix-channels
drwxr-xr-x  2 root root 4096 May 17 19:57 .nix-defexpr
lrwxrwxrwx  1 root root   29 May 17 19:57 .nix-profile -> /nix/var/nix/profiles/default
drwx------  2 root root 4096 May 17 19:53 .ssh
-rw-r--r--  1 root root    0 May 17 19:53 user-data
```

I tested this on a fresh OpenStack install on CentOS 7 that used the packstack installer.
