### PR TITLE
e19: updates for 1.14.0

### DIFF
--- a/pkgs/desktops/e19/econnman.nix
+++ b/pkgs/desktops/e19/econnman.nix
@@ -8,15 +8,15 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ makeWrapper pkgconfig e19.efl python27 dbus ];
-  propagatedBuildInputs = [ python27Packages.pythonefl_1_13 python27Packages.dbus e19.elementary ];
+  propagatedBuildInputs = [ python27Packages.pythonefl_1_14 python27Packages.dbus e19.elementary ];
   postInstall = ''
-    wrapProgram $out/bin/econnman-bin --prefix PYTHONPATH : ${python27Packages.dbus}/lib/python2.7/site-packages:${python27Packages.pythonefl_1_13}/lib/python2.7/site-packages
+    wrapProgram $out/bin/econnman-bin --prefix PYTHONPATH : ${python27Packages.dbus}/lib/python2.7/site-packages:${python27Packages.pythonefl_1_14}/lib/python2.7/site-packages
   '';
 
   meta = {
     description = "A user interface for the connman network connection manager";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl3;
   };

--- a/pkgs/desktops/e19/efl-elua.patch
+++ b/pkgs/desktops/e19/efl-elua.patch
@@ -1,0 +1,14 @@
+--- ./src/scripts/elua/core/util.lua.old	2015-05-17 11:59:57.307743243 +0200
++++ ./src/scripts/elua/core/util.lua	2015-05-17 12:39:11.906797377 +0200
+@@ -159,7 +159,10 @@
+         local ev = os.getenv("ELUA_" .. libname:upper() .. "_LIBRARY_PATH")
+         local succ, v = load_lib(libname, ev)
+         if not succ then
+-            error(v, 2)
++            succ, v = load_lib(libname, "$out/lib")
++            if not succ then
++                error(v, 2)
++            end
+         end
+         lib = v
+         loaded_libs[libname] = lib

--- a/pkgs/desktops/e19/efl-setup-hook.sh
+++ b/pkgs/desktops/e19/efl-setup-hook.sh
@@ -1,8 +1,0 @@
-addDbusIncludePath () {
-    if test -d "$1/include/dbus-1.0"
-    then
-        export NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE} -I$1/include/dbus-1.0 -I $1/lib/dbus-1.0/include"
-    fi
-}
-
-envHooks=(${envHooks[@]} addDbusIncludePath)

--- a/pkgs/desktops/e19/efl.nix
+++ b/pkgs/desktops/e19/efl.nix
@@ -1,23 +1,23 @@
-{ stdenv, fetchurl, pkgconfig, openssl, libjpeg, zlib, freetype, fontconfig, fribidi, SDL2, SDL, mesa, giflib, libpng, libtiff, glib, gst_all_1, pulseaudio, libsndfile, xlibs, libdrm, libxkbcommon, udev, utillinuxCurses, dbus, bullet, luajit, python27Packages, openjpeg, doxygen, expat, lua5_2, harfbuzz, jbig2dec, librsvg, dbus_libs, alsaLib, poppler, libraw, libspectre, xineLib, vlc, libwebp, curl, libinput }:
+{ stdenv, fetchurl, pkgconfig, openssl, libjpeg, zlib, freetype, fontconfig, fribidi, SDL2, SDL, mesa, giflib, libpng, libtiff, glib, gst_all_1, pulseaudio, libsndfile, xlibs, libdrm, libxkbcommon, udev, utillinuxCurses, dbus, bullet, luajit, python27Packages, openjpeg, doxygen, expat, harfbuzz, jbig2dec, librsvg, dbus_libs, alsaLib, poppler, libraw, libspectre, xineLib, vlc, libwebp, curl, libinput }:
 
 
 stdenv.mkDerivation rec {
   name = "efl-${version}";
-  version = "1.13.2";
+  version = "1.14.0";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/efl/${name}.tar.gz";
-    sha256 = "196293zf4pbyd5acs4nzb818yql9r67709ccfj7k3siyws6lsh4q";
+    sha256 = "0sb2104b2rayr2ag0n3g8zqds9nxd53mlyvq7650c3cy8hws5a1h";
   };
 
   buildInputs = [ pkgconfig openssl zlib freetype fontconfig fribidi SDL2 SDL mesa
     giflib libpng libtiff glib gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-libav pulseaudio libsndfile xlibs.libXcursor xlibs.printproto
-    xlibs.libX11 udev utillinuxCurses luajit ];
+    xlibs.libX11 udev utillinuxCurses ];
 
   propagatedBuildInputs = [ libxkbcommon python27Packages.dbus dbus libjpeg xlibs.libXcomposite
     xlibs.libXdamage xlibs.libXinerama xlibs.libXp xlibs.libXtst xlibs.libXi xlibs.libXext
     bullet xlibs.libXScrnSaver xlibs.libXrender xlibs.libXfixes xlibs.libXrandr
-    xlibs.libxkbfile xlibs.libxcb xlibs.xcbutilkeysyms openjpeg doxygen expat lua5_2
+    xlibs.libxkbfile xlibs.libxcb xlibs.xcbutilkeysyms openjpeg doxygen expat luajit
     harfbuzz jbig2dec librsvg dbus_libs alsaLib poppler libraw libspectre xineLib vlc libwebp curl libdrm
     libinput ];
 
@@ -25,23 +25,31 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-tests=none" "--enable-sdl" "--enable-drm" "--with-opengl=full"
     "--enable-image-loader-jp2k" "--enable-xinput22" "--enable-multisense" "--enable-systemd"
     "--enable-image-loader-webp" "--enable-harfbuzz" "--enable-xine" "--enable-fb"
-    "--disable-tslib" "--with-systemdunitdir=$out/systemd/user" "--enable-lua-old"
+    "--disable-tslib" "--with-systemdunitdir=$out/systemd/user"
     "ac_ct_CXX=foo" ];
 
   NIX_CFLAGS_COMPILE = [ "-I${xlibs.libXtst}" "-I${dbus_libs}/include/dbus-1.0" "-I${dbus_libs}/lib/dbus-1.0/include" ];
 
+  patches = [ ./efl-elua.patch ];
+
   preConfigure = ''
     export PKG_CONFIG_PATH="${gst_all_1.gst-plugins-base}/lib/pkgconfig/gstreamer-video-0.10.pc:$PKG_CONFIG_PATH"
+    export LD_LIBRARY_PATH="$(pwd)/src/lib/eina/.libs:$LD_LIBRARY_PATH"
+  '';
+
+  postInstall = ''
+    substituteInPlace "$out/share/elua/core/util.lua" --replace '$out' "$out"
+    modules=$(for i in "$out/include/"*/; do printf ' -I''${includedir}/'`basename $i`; done)
+    substituteInPlace "$out/lib/pkgconfig/efl.pc" --replace 'Cflags: -I''${includedir}/efl-1' \
+      'Cflags: -I''${includedir}/eina-1/eina'"$modules"
   '';
 
   enableParallelBuilding = true;
 
-  setupHook = ./efl-setup-hook.sh;
-
   meta = {
     description = "Enlightenment Core libraries";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl3;
   };

--- a/pkgs/desktops/e19/elementary.nix
+++ b/pkgs/desktops/e19/elementary.nix
@@ -1,20 +1,19 @@
-{ stdenv, fetchurl, pkgconfig, e19, libcap, gdbm }:
+{ stdenv, fetchurl, pkgconfig, e19, libcap, automake114x, autoconf, libdrm, gdbm }:
 stdenv.mkDerivation rec {
   name = "elementary-${version}";
-  version = "1.13.2";
+  version = "1.14.0";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/elementary/${name}.tar.gz";
-    sha256 = "0f8hz60aj4ar8lqnc63nlxkpf3b51scjalgy1iphgjc27hzxcb9i";
+    sha256 = "03h9sv5c3473wxf7hcimdf80d2phxl81yv0kzngx4g1b6cdwl1ma";
   };
-  buildInputs = [ pkgconfig e19.efl gdbm ] ++ stdenv.lib.optionals stdenv.isLinux [ libcap ];
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/ethumb-1 -I${e19.efl}/include/efl-1 $NIX_CFLAGS_COMPILE"
-  '';
+  buildInputs = [ pkgconfig e19.efl libdrm gdbm automake114x autoconf ] ++ stdenv.lib.optionals stdenv.isLinux [ libcap ];
+  NIX_CFLAGS_COMPILE = [ "-I${libdrm}/include/libdrm" ];
+  patches = [ ./elementary.patch ];
   enableParallelBuilding = true;
   meta = {
     description = "Widget set/toolkit";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl2;
   };

--- a/pkgs/desktops/e19/elementary.patch
+++ b/pkgs/desktops/e19/elementary.patch
@@ -1,0 +1,18 @@
+--- a/elementary.pc.in	2015-05-16 21:08:14.321148417 +0200
++++ b/elementary.pc.in	2015-05-16 21:08:30.643412725 +0200
+@@ -14,4 +14,4 @@
+ Requires.private: @requirement_elm_pc@
+ Version: @VERSION@
+ Libs: -L${libdir} -lelementary @ELEMENTARY_PC_LIBS@
+-Cflags: -I${includedir}/elementary-@VMAJ@
++Cflags: -I${includedir}/elementary-@VMAJ@ @ELEMENTARY_PC_CFLAGS@
+--- a/Makefile.am	2015-05-16 21:08:14.322148433 +0200
++++ b/Makefile.am	2015-05-16 21:08:30.643412725 +0200
+@@ -84,6 +84,7 @@
+ -e 's,@requirement_elm_pc\@,$(requirement_elm_pc),g' \
+ -e 's,@ELEMENTARY_LIBS\@,$(ELEMENTARY_LIBS),g' \
+ -e 's,@ELEMENTARY_PC_LIBS\@,$(ELEMENTARY_PC_LIBS),g' \
++-e 's,@ELEMENTARY_PC_CFLAGS\@,$(ELEMENTARY_PC_CFLAGS),g' \
+ < $< > $@ || rm $@
+ 
+ pc_verbose = $(pc_verbose_@AM_V@)

--- a/pkgs/desktops/e19/emotion.nix
+++ b/pkgs/desktops/e19/emotion.nix
@@ -1,19 +1,17 @@
 { stdenv, fetchurl, pkgconfig, e19, vlc }:
 stdenv.mkDerivation rec {
   name = "emotion_generic_players-${version}";
-  version = "1.13.0";
+  version = "1.14.0";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/emotion_generic_players/${name}.tar.gz";
-    sha256 = "0gin3cjhfj75v0gjsvv7harbj4fs4r7r1sfi74ncxzna71nrd8r3";
+    sha256 = "1n1a5n2wi68n8gjw4yk6cyf11djpqpac0025vysn5w6dqgccfic3";
   };
   buildInputs = [ pkgconfig e19.efl vlc ];
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/eo-1 $NIX_CFLAGS_COMPILE"
-  '';
+  NIX_CFLAGS_COMPILE = [ "-I${e19.efl}/include/eo-1" ];
   meta = {
     description = "Extra video decoders";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
   };

--- a/pkgs/desktops/e19/enlightenment.nix
+++ b/pkgs/desktops/e19/enlightenment.nix
@@ -3,16 +3,16 @@
 
 stdenv.mkDerivation rec {
   name = "enlightenment-${version}";
-  version = "0.19.4";
+  version = "0.19.5";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/enlightenment/${name}.tar.xz";
-    sha256 = "0r3bad700cfx5sq8y61dbz3hxdx9n3nf5hzx40ryqld75yxzwxz7";
+    sha256 = "0j66x7x76fbgqfw6fi77v8qy50slw3jnsq3vvs82rrfvniabm8wc";
   };
   buildInputs = [ pkgconfig e19.efl e19.elementary xlibs.libXdmcp xlibs.libxcb
     xlibs.xcbutilkeysyms xlibs.libXrandr libffi pam alsaLib luajit bzip2
     libpthreadstubs gdbm ] ++ stdenv.lib.optionals stdenv.isLinux [ libcap ];
+  NIX_CFLAGS_COMPILE = [ "-I${e19.efl}/include/eo-1" "-I${e19.efl}/include/emile-1" ];
   preConfigure = ''
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/eo-1 -I${e19.efl}/include/ecore-imf-1 -I${e19.efl}/include/ethumb-client-1 -I${e19.efl}/include/elocation-1 -I${e19.efl}/include/ethumb-1 $NIX_CFLAGS_COMPILE"
     export USER_SESSION_DIR=$prefix/lib/systemd/user
 
     substituteInPlace src/modules/xkbswitch/e_mod_parse.c \
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "The Compositing Window Manager and Desktop Shell";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
   };

--- a/pkgs/desktops/e19/evas.nix
+++ b/pkgs/desktops/e19/evas.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, pkgconfig, e19, zlib, libspectre, gstreamer, gst_plugins_base, gst_ffmpeg, gst_plugins_good, poppler, librsvg, libraw }:
 stdenv.mkDerivation rec {
   name = "evas_generic_loaders-${version}";
-  version = "1.13.2";
+  version = "1.14.0";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/evas_generic_loaders/${name}.tar.gz";
-    sha256 = "06m8p8k8dpyvzdm690zhdzcr7n0ld12bcgjdssjfl66lil5z2mc4";
+    sha256 = "04m8vsrigbsg9hm94lxac56frdxil1bib0bjmspa6xsfgi12afwl";
   };
   buildInputs = [ pkgconfig e19.efl zlib libspectre gstreamer gst_plugins_base gst_ffmpeg gst_plugins_good poppler librsvg libraw ];
   meta = {
     description = "Extra image decoders";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/desktops/e19/rage.nix
+++ b/pkgs/desktops/e19/rage.nix
@@ -2,28 +2,13 @@
 , makeWrapper, lib }:
 stdenv.mkDerivation rec {
   name = "rage-${version}";
-  version = "0.1.1";
+  version = "0.1.4";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/rage/${name}.tar.gz";
-    sha256 = "0jdhbzmnvl0i2zzmjs1wgvxmnv0lm76k7h5llbb8ai34xh4yp3fi";
+    sha256 = "10j3n8crk16jzqz2hn5djx6vms5f6x83qyiaphhqx94h9dgv2mgg";
   };
   buildInputs = [ e19.elementary e19.efl automake autoconf libtool pkgconfig
     makeWrapper ];
-  NIX_CFLAGS_COMPILE = [ "-I${e19.efl}/include/evas-1"
-    "-I${e19.efl}/include/ecore-1"
-    "-I${e19.efl}/include/eina-1"
-    "-I${e19.efl}/include/eina-1/eina"
-    "-I${e19.efl}/include/eet-1"
-    "-I${e19.efl}/include/eo-1"
-    "-I${e19.efl}/include/ecore-evas-1"
-    "-I${e19.efl}/include/ecore-imf-1"
-    "-I${e19.efl}/include/ecore-con-1"
-    "-I${e19.efl}/include/ecore-file-1"
-    "-I${e19.efl}/include/ecore-input-1"
-    "-I${e19.efl}/include/eldbus-1"
-    "-I${e19.efl}/include/efreet-1"
-    "-I${e19.efl}/include/ethumb-client-1"
-    "-I${e19.efl}/include/ethumb-1" ];
   GST_PLUGIN_PATH = lib.makeSearchPath "lib/gstreamer-1.0" [
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
@@ -39,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Video + Audio player along the lines of mplayer";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc ];
+    maintainers = with stdenv.lib.maintainers; [ matejc ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
   };

--- a/pkgs/desktops/e19/terminology.nix
+++ b/pkgs/desktops/e19/terminology.nix
@@ -7,17 +7,10 @@ stdenv.mkDerivation rec {
     sha256 = "7a10d44b023cf6134c2483304e4ad33bea6df0f11266aec482f54fa67a3ce628";
   };
   buildInputs = [ pkgconfig e19.efl e19.elementary ];
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/eo-1 $NIX_CFLAGS_COMPILE"
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/ecore-con-1 $NIX_CFLAGS_COMPILE"
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/eldbus-1 $NIX_CFLAGS_COMPILE"
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/ethumb-1 $NIX_CFLAGS_COMPILE"
-    export NIX_CFLAGS_COMPILE="-I${e19.efl}/include/elocation-1 $NIX_CFLAGS_COMPILE"
-  '';
   meta = {
     description = "The best terminal emulator written with the EFL";
     homepage = http://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ];
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14964,21 +14964,21 @@ let
     };
   };
 
-  pythonefl_1_13 = buildPythonPackage rec {
+  pythonefl_1_14 = buildPythonPackage rec {
     name = "python-efl-${version}";
-    version = "1.13.0";
+    version = "1.14.0";
     src = pkgs.fetchurl {
-      url = "http://download.enlightenment.org/rel/bindings/python/${name}.tar.bz2";
-      sha256 = "0yy4v0f04dgdz21wd2c09x9w6lzsbq6g12s8895laln44l5aqd82";
+      url = "http://download.enlightenment.org/rel/bindings/python/${name}.tar.gz";
+      sha256 = "1pns5mdyc069z6j1pywjasdd6v9xka5kjdl2yxpd6ds948dia0q0";
     };
     preConfigure = ''
-      export NIX_CFLAGS_COMPILE="-I${pkgs.e19.efl}/include/eo-1 -I${pkgs.e19.efl}/include/eina-1 -I${pkgs.e19.efl}/include/eina-1/eina -I${pkgs.e19.efl}/include/evas-1 -I${self.dbus}/include/dbus-1.0 -I${pkgs.e19.efl}/include/efl-1 -I${pkgs.e19.efl}/include/eet-1 -I${pkgs.e19.efl}/include/ecore-1 -I${pkgs.e19.efl}/include/ecore-evas-1 -I${pkgs.e19.efl}/include/ecore-file-1 -I${pkgs.e19.efl}/include/ecore-input-1 -I${pkgs.e19.efl}/include/ecore-imf-1 -I${pkgs.e19.efl}/include/ecore-con-1 -I${pkgs.e19.efl}/include/edje-1 -I${pkgs.e19.efl}/include/eldbus-1 -I${pkgs.e19.efl}/include/efreet-1 -I${pkgs.e19.efl}/include/ethumb-client-1 -I${pkgs.e19.efl}/include/ethumb-1 -I${pkgs.e19.efl}/include/ecore-x-1 $NIX_CFLAGS_COMPILE"
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${self.dbus}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"
     '';
     buildInputs = with self; [ pkgs.pkgconfig pkgs.e19.efl pkgs.e19.elementary ];
     meta = {
       description = "Python bindings for EFL and Elementary";
       homepage = http://enlightenment.org/;
-      maintainers = with maintainers; [ matejc tstrobel ];
+      maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx ];
       platforms = platforms.linux;
       license = licenses.gpl3;
     };


### PR DESCRIPTION
- libraries and applications updated to the latest
- the "elementary getting started" (https://docs.enlightenment.org/auto/elementary/group__Start.html)
  works with just `pkg-config --cflags --libs elementary`
- switched from lua-old to elua
