### PR TITLE
i2c-tools, read-edid: New packages

### DIFF
--- a/pkgs/development/libraries/libx86/default.nix
+++ b/pkgs/development/libraries/libx86/default.nix
@@ -12,13 +12,13 @@ rec {
   inherit buildInputs;
 
   phaseNames = ["doPatch" "fixX86Def" "killUsr" "doMakeInstall"];
-  patches = [./constants.patch];
+  patches = [./constants.patch ./non-x86.patch];
 
   # using BACKEND=x86emu on 64bit systems fixes:
   #  http://www.mail-archive.com/suspend-devel@lists.sourceforge.net/msg02355.html
   makeFlags = [
     "DESTDIR=$out"
-  ] ++ a.stdenv.lib.optionals ( a.stdenv.system == "x86_64-linux" ) [ "BACKEND=x86emu" ]; 
+  ] ++ a.stdenv.lib.optionals ( a.stdenv.isx86_64 || a.stdenv.isArm ) [ "BACKEND=x86emu" ];
 
   fixX86Def = a.fullDepEntry (''
     sed -i lrmi.c -e 's@defined(__i386__)@(defined(__i386__) || defined(__x86_64__))@'

--- a/pkgs/development/libraries/libx86/non-x86.patch
+++ b/pkgs/development/libraries/libx86/non-x86.patch
@@ -1,0 +1,38 @@
+diff -Naur libx86-1.1+ds1.orig/Makefile libx86-1.1+ds1/Makefile
+--- libx86-1.1+ds1.orig/Makefile	2008-05-19 12:28:59.000000000 +0300
++++ libx86-1.1+ds1/Makefile	2012-02-20 01:32:03.750068423 +0200
+@@ -5,6 +5,7 @@
+ ifeq ($(BACKEND),x86emu)
+ 	OBJECTS += thunk.o x86emu/decode.o x86emu/debug.o x86emu/fpu.o \
+ 	x86emu/ops.o x86emu/ops2.o x86emu/prim_ops.o x86emu/sys.o
++	CFLAGS += -DX86EMU
+ else
+ 	OBJECTS += lrmi.o
+ endif
+diff -Naur libx86-1.1+ds1.orig/thunk.c libx86-1.1+ds1/thunk.c
+--- libx86-1.1+ds1.orig/thunk.c	2008-04-03 03:48:00.000000000 +0300
++++ libx86-1.1+ds1/thunk.c	2012-02-20 01:12:56.468820192 +0200
+@@ -32,6 +32,7 @@
+ #define TRUE 1
+ #define FALSE 0
+ 
++#ifndef X86EMU
+ #define __BUILDIO(bwl,bw,type) \
+ static inline void out##bwl##_local(unsigned long port, unsigned type value) {        __asm__ __volatile__("out" #bwl " %" #bw "0, %w1" : : "a"(value), "Nd"(port)); \
+ }\
+@@ -44,6 +45,15 @@
+ __BUILDIO(b,b,char)
+ __BUILDIO(w,w,short)
+ __BUILDIO(l,,int)
++#else
++/* use libc functions */
++#define inb_local inb
++#define inw_local inw
++#define inl_local inl
++#define outb_local outb
++#define outw_local outw
++#define outl_local outl
++#endif /* X86EMU */
+ 
+ 
+ char *mmap_addr = SHMERRORPTR;

--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, perl, read-edid }:
+
+stdenv.mkDerivation rec {
+  name = "i2c-tools-${version}";
+  version = "3.1.1";
+
+  src = fetchurl {
+    url = "http://dl.lm-sensors.org/i2c-tools/releases/${name}.tar.bz2";
+    sha256 = "000pvg995qy1b15ks59gd0klri55hb33kqpg5czy84hw1pbdgm0l";
+  };
+
+  buildInputs = [ perl ];
+
+  patchPhase = ''
+    substituteInPlace eeprom/decode-edid --replace "/usr/sbin/parse-edid" "${read-edid}/bin/parse-edid"
+    substituteInPlace stub/i2c-stub-from-dump --replace "/sbin/" ""
+  '';
+
+  installPhase = ''
+    make install prefix=$out
+    rm -rf $out/include # Installs include/linux/i2c-dev.h that conflics with kernel headers
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Set of I2C tools for Linux";
+    homepage = http://www.lm-sensors.org/wiki/I2CTools;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.dezgeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/read-edid/default.nix
+++ b/pkgs/os-specific/linux/read-edid/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake, libx86 }:
+
+stdenv.mkDerivation rec {
+  name = "read-edid-${version}";
+  version = "3.0.2";
+
+  src = fetchurl {
+    url = "http://www.polypux.org/projects/read-edid/${name}.tar.gz";
+    sha256 = "0vqqmwsgh2gchw7qmpqk6idgzcm5rqf2fab84y7gk42v1x2diin7";
+  };
+
+  buildInputs = [ cmake libx86 ];
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt --replace 'COPYING' 'LICENSE'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool for reading and parsing EDID data from monitors";
+    homepage = http://www.polypux.org/projects/read-edid/;
+    license = licenses.bsd2; # Quoted: "This is an unofficial license. Let's call it BSD-like."
+    maintainers = [ maintainers.dezgeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2684,6 +2684,8 @@ let
 
   privateer = callPackage ../games/privateer { };
 
+  read-edid = callPackage ../os-specific/linux/read-edid { };
+
   redmine = callPackage ../applications/version-management/redmine { };
 
   rtmpdump = callPackage ../tools/video/rtmpdump { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1792,6 +1792,8 @@ let
 
   hwinfo = callPackage ../tools/system/hwinfo { };
 
+  i2c-tools = callPackage ../os-specific/linux/i2c-tools { };
+
   i2p = callPackage ../tools/networking/i2p {};
 
   i2pd = callPackage ../tools/networking/i2pd {};


### PR DESCRIPTION
`i2c-tools` is a handy package for hacking on ARM boards. `read-edid` is a dependency of that and useful on it's own as well.

I tested various commands from these on both ARM and x86_64, and also tested that `vbetool` (the only other dependency of `libx86`) still works on my x86_64 laptop.
