### PR TITLE
pkgs charybdis: change platforms to linux only

### DIFF
--- a/pkgs/servers/irc/charybdis/default.nix
+++ b/pkgs/servers/irc/charybdis/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     homepage    = https://github.com/atheme/charybdis;
     license     = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.lassulus ];
-    platforms   = stdenv.lib.platforms.all;
+    platforms   = stdenv.lib.platforms.linux;
   };
 
 


### PR DESCRIPTION
hydra complained it cant build on darwin.
http://hydra.nixos.org/build/22190142
