### PR TITLE
emacs: fix doc-view-mode; add support for acl, gpm and aspell (flyspell-mode)

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ncurses, x11, libXaw, libXpm, Xaw3d
 , pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
-, alsaLib, cairo
+, alsaLib, cairo, acl, gpm
 , withX ? !stdenv.isDarwin
 , withGTK3 ? false, gtk3 ? null
 , withGTK2 ? true, gtk2
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs =
-    [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo ]
+    [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo acl gpm ]
     ++ stdenv.lib.optional stdenv.isLinux dbus
     ++ stdenv.lib.optionals withX
       [ x11 libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -26,17 +26,7 @@ let
      ]) ++ [
        aspell
      ]);
-  addSiteLisp = lib.optionalString
-    (0 < (lib.length addExecPath))
-    ''
-      ;; Where to find additional programs on NixOS
-      (setq exec-path (append exec-path '(
-        ${lib.strings.concatMapStringsSep "\n"
-          (p: ''"${p}/bin"'') addExecPath})))
-    '';
-in
-
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "emacs-24.5";
 
   builder = ./builder.sh;
@@ -69,10 +59,10 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && withX)
     "-I${cairo}/include/cairo";
 
-  inherit addSiteLisp;
+  nixExecPath = map (p: ''"${p}/bin"'') addExecPath;
   postInstall = ''
     mkdir -p $out/share/emacs/site-lisp/
-    echo "$addSiteLisp" | cat ${./site-start.el} - > $out/share/emacs/site-lisp/site-start.el
+    substituteAll ${./site-start.el} $out/share/emacs/site-lisp/site-start.el
   '';
 
   doCheck = true;

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, ncurses, x11, libXaw, libXpm, Xaw3d
 , pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
-, alsaLib, cairo, acl, gpm, ghostscript
+, alsaLib, cairo, acl, gpm, ghostscript, aspell
 , withX ? !stdenv.isDarwin
 , withGTK3 ? false, gtk3 ? null
 , withGTK2 ? true, gtk2
@@ -21,9 +21,11 @@ let
     else "lucid";
   addExecPath = lib.filter
     (p: p != null)
-    (lib.optionals withX [
-      ghostscript
-    ]);
+    ((lib.optionals withX [
+       ghostscript
+     ]) ++ [
+       aspell
+     ]);
   addSiteLisp = lib.optionalString
     (0 < (lib.length addExecPath))
     ''

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, x11, libXaw, libXpm, Xaw3d
+{ stdenv, lib, fetchurl, ncurses, x11, libXaw, libXpm, Xaw3d
 , pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
 , alsaLib, cairo, acl, gpm, ghostscript
@@ -19,20 +19,18 @@ let
     if withGTK3 then "gtk3"
     else if withGTK2 then "gtk2"
     else "lucid";
-  addExecPath = stdenv.lib.filter
+  addExecPath = lib.filter
     (p: p != null)
-    (stdenv.lib.optionals withX [
+    (lib.optionals withX [
       ghostscript
     ]);
-  addSiteLisp = stdenv.lib.optionalString
-    (0 < (stdenv.lib.length addExecPath))
+  addSiteLisp = lib.optionalString
+    (0 < (lib.length addExecPath))
     ''
       ;; Where to find additional programs on NixOS
       (setq exec-path (append exec-path '(
-        ${stdenv.lib.strings.concatMapStringsSep
-          "\n"
-          (p: ''"${p}/bin"'')
-          addExecPath})))
+        ${lib.strings.concatMapStringsSep "\n"
+          (p: ''"${p}/bin"'') addExecPath})))
     '';
 in
 
@@ -46,19 +44,19 @@ stdenv.mkDerivation rec {
     sha256 = "0kn3rzm91qiswi0cql89kbv6mqn27rwsyjfb8xmwy9m5s8fxfiyx";
   };
 
-  patches = stdenv.lib.optionals stdenv.isDarwin [
+  patches = lib.optionals stdenv.isDarwin [
     ./at-fdcwd.patch
   ];
 
   buildInputs =
     [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo acl gpm ]
-    ++ stdenv.lib.optional stdenv.isLinux dbus
-    ++ stdenv.lib.optionals withX
+    ++ lib.optional stdenv.isLinux dbus
+    ++ lib.optionals withX
       [ x11 libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft
         imagemagick gconf ]
-    ++ stdenv.lib.optional (withX && withGTK2) [ gtk2 ]
-    ++ stdenv.lib.optional (withX && withGTK3) [ gtk3 ]
-    ++ stdenv.lib.optional (stdenv.isDarwin && withX) cairo;
+    ++ lib.optional (withX && withGTK2) gtk2
+    ++ lib.optional (withX && withGTK3) gtk3
+    ++ lib.optional (stdenv.isDarwin && withX) cairo;
 
   configureFlags =
     if withX
@@ -66,7 +64,7 @@ stdenv.mkDerivation rec {
       else [ "--with-x=no" "--with-xpm=no" "--with-jpeg=no" "--with-png=no"
              "--with-gif=no" "--with-tiff=no" ];
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (stdenv.isDarwin && withX)
+  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && withX)
     "-I${cairo}/include/cairo";
 
   inherit addSiteLisp;
@@ -77,7 +75,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "GNU Emacs 24, the extensible, customizable text editor";
     homepage    = http://www.gnu.org/software/emacs/;
     license     = licenses.gpl3Plus;

--- a/pkgs/applications/editors/emacs-24/site-start.el
+++ b/pkgs/applications/editors/emacs-24/site-start.el
@@ -15,3 +15,6 @@
 ;;; NOTE: You might want to add 
 (eval-after-load 'tramp
   '(add-to-list 'tramp-remote-path "/run/current-system/sw/bin"))
+
+;; Path for executables, that emacs shells out to
+(setq exec-path (append exec-path '(@nixExecPath@)))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10633,6 +10633,8 @@ let
     gconf = null;
     alsaLib = null;
     imagemagick = null;
+    acl = null;
+    gpm = null;
   };
 
   emacs24-nox = lowPrio (appendToName "nox" (emacs24.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10635,6 +10635,7 @@ let
     imagemagick = null;
     acl = null;
     gpm = null;
+    aspell = null;
   };
 
   emacs24-nox = lowPrio (appendToName "nox" (emacs24.override {


### PR DESCRIPTION
To make `doc-view-mode` work, emacs needs ghostscript on its path. Since it is already a runtime dependency (at least when built with x support), I updated site-lisp to adjust `exec-path`.

`acl` and `gpm` support were added, disabled by default, ready to be enabled by a package override.

cc @chaoflow @lovek323 @the-kenny 
