### PR TITLE
added flags/switches necessary to get openblas to compile on osx

### DIFF
--- a/pkgs/development/compilers/gcc/gfortran-darwin.nix
+++ b/pkgs/development/compilers/gcc/gfortran-darwin.nix
@@ -1,0 +1,22 @@
+# This is a derivation customized to work on OS X (Darwin).
+{gmp, mpfr, libmpc, fetchurl, stdenv}:
+
+# This package is only intended for OSX.
+assert stdenv.isDarwin;
+
+stdenv.mkDerivation rec {
+  name = "gfortran";
+  version = "5.1.0";
+  buildInputs = [gmp mpfr libmpc];
+  src = fetchurl {
+    url = "https://ftp.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
+    sha256 = "1bd5vj4px3s8nlakbgrh38ynxq4s654m6nxz7lrj03mvkkwgvnmp";
+  };
+  configureFlags = ''
+    --enable-languages=fortran --enable-checking=release --disable-bootstrap
+    --with-gmp=${gmp}
+    --with-mpfr=${mpfr}
+    --with-mpc=${libmpc}
+  '';
+  makeFlags = ["CC=/usr/bin/gcc"];
+}

--- a/pkgs/development/compilers/gcc/gfortran-darwin.nix
+++ b/pkgs/development/compilers/gcc/gfortran-darwin.nix
@@ -18,5 +18,5 @@ stdenv.mkDerivation rec {
     --with-mpfr=${mpfr}
     --with-mpc=${libmpc}
   '';
-  makeFlags = ["CC=/usr/bin/gcc"];
+  makeFlags = ["CC=clang"];
 }

--- a/pkgs/development/compilers/gcc/gfortran-darwin.nix
+++ b/pkgs/development/compilers/gcc/gfortran-darwin.nix
@@ -1,15 +1,13 @@
-# This is a derivation customized to work on OS X (Darwin).
+# This is a derivation specific to OS X (Darwin). It may work on other
+# systems as well but has not been tested.
 {gmp, mpfr, libmpc, fetchurl, stdenv}:
 
-# This package is only intended for OSX.
-assert stdenv.isDarwin;
-
 stdenv.mkDerivation rec {
-  name = "gfortran";
+  name = "gfortran-${version}";
   version = "5.1.0";
   buildInputs = [gmp mpfr libmpc];
   src = fetchurl {
-    url = "https://ftp.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
+    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
     sha256 = "1bd5vj4px3s8nlakbgrh38ynxq4s654m6nxz7lrj03mvkkwgvnmp";
   };
   configureFlags = ''
@@ -19,4 +17,10 @@ stdenv.mkDerivation rec {
     --with-mpc=${libmpc}
   '';
   makeFlags = ["CC=clang"];
+  meta = with stdenv.lib; {
+    description = "GNU Fortran compiler, part of the GNU Compiler Collection.";
+    homepage    = "https://gcc.gnu.org/fortran/";
+    license     = licenses.gpl3Plus;
+    platforms   = platforms.darwin;
+  };
 }

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gfortran, perl, liblapack, config, coreutils, clang }:
+{ stdenv, fetchurl, gfortran, perl, liblapack, config, coreutils }:
 
 with stdenv.lib;
 
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     ++
     [
       "FC=gfortran"
+      # Note that clang is available through the stdenv on OSX and
+      # thus is not an explicit dependency.
       "CC=${if stdenv.isDarwin then "clang" else "gcc"}"
       ''PREFIX="''$(out)"''
       "INTERFACE64=1"
@@ -48,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "Basic Linear Algebra Subprograms";
     license = licenses.bsd3;
     homepage = "https://github.com/xianyi/OpenBLAS";
-    platforms = with platforms; all;
+    platforms = with platforms; unix;
     maintainers = with maintainers; [ ttuegel ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3676,7 +3676,8 @@ let
     isl = isl_0_14;
   }));
 
-  gfortran = gfortran48;
+  gfortran = if !stdenv.isDarwin then gfortran48
+             else callPackage ../development/compilers/gcc/gfortran-darwin.nix {};
 
   gfortran48 = wrapCC (gcc48.cc.override {
     name = "gfortran";


### PR DESCRIPTION
Adds a few fixes to get openblas to compile on OSX:
- Dependency on `coreutils`. This contains a version of `readlink` that supports `-f`, which otherwise will throw an error.
- `MACOSX_DEPLOYMENT_TARGET=10.9`. If not set, this will throw an `ld` error.
- Using `clang` instead of `gcc` for the C compiler.
