### PR TITLE
ipython: comments about deprecated pylab flag

### DIFF
--- a/pkgs/shells/ipython/default.nix
+++ b/pkgs/shells/ipython/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, buildPythonPackage, pythonPackages, pyqt4 ? null
 , notebookSupport ? true   # ipython notebook
 , qtconsoleSupport ? true  # ipython qtconsole
-, pylabSupport ? true      # ipython --pylab    (backend: agg - no gui, just file)
-, pylabQtSupport ? true    # ipython --pylab=qt (backend: Qt4Agg - plot to window)
+, pylabSupport ? true      # '%pylab' magic (backend: agg - no gui, just file)
+, pylabQtSupport ? true    # '%pylab qt' (backend: Qt4Agg - plot to window)
 }:
 
 # ipython qtconsole works with both pyside and pyqt4. But ipython --pylab=qt


### PR DESCRIPTION
The pylab flag is deprecated: http://mail.scipy.org/pipermail/ipython-dev/2014-March/013411.html
