### PR TITLE
cfr: Update to version 0_101 and remove platform restrictions

### DIFF
--- a/pkgs/development/tools/java/cfr/default.nix
+++ b/pkgs/development/tools/java/cfr/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, jre }:
 
-let version = "0_100"; in
+let version = "0_101"; in
 stdenv.mkDerivation rec {
   name = "cfr-${version}";
 
   src = fetchurl {
-    sha256 = "0q5kh5qdksykz339p55jz0q5cjqvxdzv3a7r4kkijgbfjm1ldr5f";
+    sha256 = "0zwl3whypdm2qrw3hwaqjnifkb4wcdn8fx9scrjkli54bhr6dqch";
     url = "http://www.benf.org/other/cfr/cfr_${version}.jar";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.benf.org/other/cfr/;
     license = with licenses; mit;
-    platforms = with platforms; linux;
+    platforms = with platforms; all;
     maintainers = with maintainers; [ nckx ];
   };
 


### PR DESCRIPTION
cfr is written in Java, so it should work in every platform supported
by jre. This fix makes cfr usable in Darwin.
