### PR TITLE
Fix gnome3.libgit2-glib build.

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/misc/libgit2-glib/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/misc/libgit2-glib/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "8a0a6f65d86f2c8cb9bcb20c5e0ea6fd02271399292a71fc7e6852f13adbbdb8";
   };
 
-  configureScript = "sh ./autogen.sh";
-
   buildInputs = [ gnome3.gnome_common libtool pkgconfig vala
                   gtk_doc gobjectIntrospection libgit2 glib ];
 


### PR DESCRIPTION
The libgit2-glib build currently fails with:

```
theba :: ~/nixpkgs ‹master› » nix-build . -A gnome3.libgit2-glib                     
these derivations will be built:
  /nix/store/p27j6wkyfi8r02h1k1s5anb928s2cjjx-libgit2-glib-0.0.24.drv
building path(s) ‘/nix/store/g07gdf12qcirpb2m7bs8m8917w7x0rb8-libgit2-glib-0.0.24’
unpacking sources
unpacking source archive /nix/store/nnxrwfddfrln6dnzxp1fh6qfx9wz57id-libgit2-glib-0.0.24.tar.xz
source root is libgit2-glib-0.0.24
patching sources
configuring
fixing libtool script ./ltmain.sh
grep: sh: No such file or directory
grep: ./autogen.sh: No such file or directory
grep: sh: No such file or directory
grep: ./autogen.sh: No such file or directory
configure flags: --prefix=/nix/store/g07gdf12qcirpb2m7bs8m8917w7x0rb8-libgit2-glib-0.0.24  
sh: ./autogen.sh: No such file or directory
builder for ‘/nix/store/p27j6wkyfi8r02h1k1s5anb928s2cjjx-libgit2-glib-0.0.24.drv’ failed with exit code 127
error: build of ‘/nix/store/p27j6wkyfi8r02h1k1s5anb928s2cjjx-libgit2-glib-0.0.24.drv’ failed
```

Apparently, the upstream tarball doesn't contain `autogen.sh`; this PR removes the reference to `autogen.sh` and uses the default `configure` instead.
