### PR TITLE
nixos: don't generate sshd keys with DSA or ECDSA algorithms by default

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -184,16 +184,8 @@ in
       hostKeys = mkOption {
         type = types.listOf types.attrs;
         default =
-          [ { path = "/etc/ssh/ssh_host_dsa_key";
-              type = "dsa";
-            }
-            { path = "/etc/ssh/ssh_host_ecdsa_key";
-              type = "ecdsa";
-              bits = 521;
-            }
-            { path = "/etc/ssh/ssh_host_ed25519_key";
-              type = "ed25519";
-            }
+          [ { type = "rsa"; bits = 4096; path = "/etc/ssh/ssh_host_rsa_key"; }
+            { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; }
           ];
         description = ''
           NixOS can automatically generate SSH host keys.  This option


### PR DESCRIPTION
Some people doubt that DSA and ECDSA keys offer good security and thus
recommend using ED25519 or RSA keys instead, so we make those algorithms our
default choices. Note that NixOS users can still choose whatever algorithms and
key sizes they please; these are just the defaults.

Further details can be found at:

  https://stribika.github.io/2015/01/04/secure-secure-shell.html

This patch resolves https://github.com/NixOS/nixpkgs/issues/5809.
