### PR TITLE
nixos: add config.services.openssh.moduliFile option so that users can replace the default file from OpenSSH

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -268,6 +268,16 @@ in
         };
       };
 
+      moduliFile = mkOption {
+        example = "services.openssh.moduliFile = /etc/my-local-ssh-moduli;";
+        type = types.path;
+        description = ''
+          Path to <literal>moduli</literal> file to install in
+          <literal>/etc/ssh/moduli</literal>. If this option is unset, then
+          the <literal>moduli</literal> file shipped with OpenSSH will be used.
+        '';
+      };
+
     };
 
     users.extraUsers = mkOption {
@@ -286,8 +296,10 @@ in
         description = "SSH privilege separation user";
       };
 
+    services.openssh.moduliFile = mkDefault "${cfgc.package}/etc/ssh/moduli";
+
     environment.etc = authKeysFiles ++ [
-      { source = "${cfgc.package}/etc/ssh/moduli";
+      { source = cfg.moduliFile;
         target = "ssh/moduli";
       }
       { text = knownHostsText;


### PR DESCRIPTION
This patch resolves https://github.com/NixOS/nixpkgs/pull/5870.
