### PR TITLE
Update: neovim

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://github.com/neovim/neovim";
-    rev = "8c27b0dd45731b1eb70edeafd9729b4d25b07f87";
-    sha256 = "5df4ed304451cab35619c5b8c55fe165997f2a3f4aacb68706f77222daa8cd18";
+    rev = "8ef5a61dd6bcaa24d26e450041bcba821fa3dbc7";
+    sha256 = "3bc707febe8bedc430b79a9c3d3717abc93d85ded33bcc32268e4f49f75635ff";
   };
 
   libmsgpack = stdenv.mkDerivation rec {

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -82,6 +82,30 @@ stdenv.mkDerivation rec {
     };
   };
 
+  unibilium = stdenv.mkDerivation rec {
+    version = "1.1.0";
+    name = "unibilium-${version}";
+
+    src = fetchurl {
+      url = "https://github.com/neovim/unibilium/archive/v1.1.0.tar.gz";
+      sha256 = "1qdviq887977nw4iay9a0fdqqpd799zrjxb7v1s1dx3ygi1njy2y";
+    };
+
+    buildInputs = [ libtool ];
+
+    installPhase = ''
+      make install PREFIX=$out
+    '';
+
+    meta = with stdenv.lib; {
+      description = "neovim fork of unibilium";
+      homepage = https://github.com/neovim/unibilium;
+      maintainers = [ maintainers.matthiasbeyer ];
+      license = licenses.lgpl-3;
+      platforms = platforms.all;
+    };
+  };
+
   enableParallelBuilding = true;
 
   buildInputs = [

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -14,13 +14,12 @@ stdenv.mkDerivation rec {
   };
 
   libmsgpack = stdenv.mkDerivation rec {
-    version = "0.5.9";
+    version = "1.1.0";
     name = "libmsgpack-${version}";
 
-    src = fetchgit {
-      rev = "ecf4b09acd29746829b6a02939db91dfdec635b4";
-      url = "https://github.com/msgpack/msgpack-c";
-      sha256 = "076ygqgxrc3vk2l20l8x2cgcv05py3am6mjjkknr418pf8yav2ww";
+    src = fetchurl {
+      url = "https://github.com/msgpack/msgpack-c/archive/cpp-${version}.tar.gz";
+      sha256 = "0a73dmhk0jhwcip1wkvz50cyxsi3alzm6ak187xdai0zdxcck6cd";
     };
 
     buildInputs = [ cmake ];

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchgit, fetchurl, unzip, callPackage, ncurses, gettext, pkgconfig,
-cmake, pkgs, lpeg, lua, luajit, luaMessagePack, luabitop, libtermkey,
-libvterm, unibilium }:
+cmake, pkgs, lpeg, lua, luajit, luaMessagePack, luabitop, libtool, perl }:
 
 stdenv.mkDerivation rec {
   name = "neovim-nightly";
@@ -29,6 +28,31 @@ stdenv.mkDerivation rec {
       homepage = http://msgpack.org;
       maintainers = [ maintainers.manveru ];
       license = licenses.asl20;
+      platforms = platforms.all;
+    };
+  };
+
+  libvterm = stdenv.mkDerivation rec {
+    version = "latest";
+    name = "libvterm-${version}";
+
+    src = fetchgit {
+      url = "https://github.com/neovim/libvterm";
+      rev = "20ad1396c178c72873aeeb2870bd726f847acb70";
+      sha256 = "85314aafc3d599537e363b0b9ca1254fca45c943b29fb23548de919e25395044";
+    };
+
+    buildInputs = [ libtool perl ];
+
+    installPhase = ''
+      make install PREFIX=$out
+    '';
+
+    meta = with stdenv.lib; {
+      description = "neovim fork of libvterm";
+      homepage = https://github.com/neovim/libvterm;
+      maintainers = [ maintainers.matthiasbeyer ];
+      license = licenses.mit;
       platforms = platforms.all;
     };
   };

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -57,6 +57,31 @@ stdenv.mkDerivation rec {
     };
   };
 
+  libtermkey = stdenv.mkDerivation rec {
+    version = "latest";
+    name = "libtermkey-${version}";
+
+    src = fetchgit {
+      url = "https://github.com/neovim/libtermkey";
+      rev = "8c0cb7108cc63218ea19aa898968eede19e19603";
+      sha256 = "216cf8ed79f8528d747349de2de080a6e3bb69a96b0bcd54b53badd36779401a";
+    };
+
+    buildInputs = [ libtool ncurses ];
+
+    installPhase = ''
+      make install PREFIX=$out
+    '';
+
+    meta = with stdenv.lib; {
+      description = "neovim fork of libtermkey";
+      homepage = https://github.com/neovim/libtermkey;
+      maintainers = [ maintainers.matthiasbeyer ];
+      license = licenses.mit;
+      platforms = platforms.all;
+    };
+  };
+
   enableParallelBuilding = true;
 
   buildInputs = [

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchgit, fetchurl, unzip, callPackage, ncurses, gettext, pkgconfig,
-cmake, pkgs, lpeg, lua, luajit, luaMessagePack, luabitop }:
+cmake, pkgs, lpeg, lua, luajit, luaMessagePack, luabitop, libtermkey,
+libvterm, unibilium }:
 
 stdenv.mkDerivation rec {
   name = "neovim-nightly";
@@ -8,8 +9,8 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://github.com/neovim/neovim";
-    rev = "68fcd8b696dae33897303c9f8265629a31afbf17";
-    sha256 = "0hxkcy641jpn4qka44gfvhmb6q3dkjx6lvn9748lcl2gx2d36w4i";
+    rev = "8c27b0dd45731b1eb70edeafd9729b4d25b07f87";
+    sha256 = "5df4ed304451cab35619c5b8c55fe165997f2a3f4aacb68706f77222daa8cd18";
   };
 
   libmsgpack = stdenv.mkDerivation rec {
@@ -46,6 +47,9 @@ stdenv.mkDerivation rec {
     luaMessagePack
     luabitop
     libmsgpack
+    libtermkey
+    libvterm
+    unibilium
   ];
   nativeBuildInputs = [ gettext ];
 


### PR DESCRIPTION
This updates neovim to the nightly build from 2 days ago.

I created this patch based on 2d8cfe7 (which is my current channel-unstable commit) and tried to build it, but it failed because of:

```
In file included from /tmp/nix-build-neovim-nightly.drv-6/neovim-8c27b0d/src/nvim/terminal.c:43:0:
/nix/store/7i0azzx7mg2g3lygc433c7js89axbn8c-libvterm-0.99.7/include/vterm.h:29:18: fatal error: glib.h: No such file or directory
 #include <glib.h>
                  ^
compilation terminated.
src/nvim/CMakeFiles/nvim.dir/build.make:90: recipe for target 'src/nvim/auto/terminal.c.generated.h' failed
make[2]: *** [src/nvim/auto/terminal.c.generated.h] Error 1
CMakeFiles/Makefile2:110: recipe for target 'src/nvim/CMakeFiles/nvim.dir/all' failed
make[1]: *** [src/nvim/CMakeFiles/nvim.dir/all] Error 2
Makefile:113: recipe for target 'all' failed
make: *** [all] Error 2
note: keeping build directory ‘/tmp/nix-build-neovim-nightly.drv-6’
builder for ‘/nix/store/pfzg8m9pm1crwcbrw272d3cw9m935yk5-neovim-nightly.drv’ failed with exit code 2
```

libvterm fails to build, because it cannot find glib. Any ideas how to solve this issue?
