### PR TITLE
Fix midori; was building but not working.

### DIFF
--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -11,14 +11,18 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Lightweight WebKitGTK+ web browser";
-    homepage = "http://www.midori-browser.org";
+    homepage = "http://midori-browser.org";
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ raskin iyzsong ];
   };
 
   src = fetchurl {
-    url = "${meta.homepage}/downloads/midori_${version}_all_.tar.bz2";
+    urls = [
+      "${meta.homepage}/downloads/midori_${version}_all_.tar.bz2"
+      "http://mirrors-ru.go-parts.com/blfs/conglomeration/midori/midori_${version}_all_.tar.bz2"
+    ];
+    name = "midori_${version}_all_.tar.bz2";
     sha256 = "10ckm98rfqfbwr84b8mc1ssgj84wjgkr4dadvx2l7c64sigi66dg";
   };
 

--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cmake pkgconfig intltool vala makeWrapper
-    webkitgtk librsvg libnotify
+    webkitgtk librsvg libnotify gsettings_desktop_schemas
   ];
 
   cmakeFlags = ''


### PR DESCRIPTION
Two fixes:
1. The URL used was now giving a 404 error. This fix was cherry-picked from `master`.
2. A missing _buildInput_ (as far as I can understand) was making the wrapped executable wrapping with a path to another schema path.

`master` might need the second fix added to it.
