### PR TITLE
Fix SHA for pasystray.

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -1,12 +1,14 @@
-{stdenv, fetchzip, autoconf, automake, makeWrapper, pkgconfig
+{stdenv, fetchFromGitHub, autoconf, automake, makeWrapper, pkgconfig
 , gnome3, avahi, gtk3, libnotify, pulseaudio, x11}:
 
 stdenv.mkDerivation rec {
   name = "pasystray-0.5.2";
 
-  src = fetchzip {
-    url = "https://github.com/christophgysin/pasystray/archive/${name}.zip";
-    sha256 = "084jld5zk89h4akll73bwhfav6mpg55zmdd5kvlg396rqi9lqkj4";
+  src = fetchFromGitHub {
+    owner = "christophgysin";
+    repo = "pasystray";
+    rev = "6709fc1e9f792baf4f7b4507a887d5876b2cfa70";
+    sha256 = "1z21wassdiwfnlcrkpdqh8ylblpd1xxjxcmib5mwix9va2lykdfv";
   };
 
   buildInputs = [ autoconf automake makeWrapper pkgconfig 

--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -2,11 +2,11 @@
 , gnome3, avahi, gtk3, libnotify, pulseaudio, x11}:
 
 stdenv.mkDerivation rec {
-  name = "pasystray-0.4.0";
+  name = "pasystray-0.5.2";
 
   src = fetchurl {
     url = "https://github.com/christophgysin/pasystray/archive/${name}.zip";
-    sha256 = "0n41qm04kilhc827yx8y1ijslmajg2dxykaf3s3aq6s6bjzzw8bh";
+    sha256 = "084jld5zk89h4akll73bwhfav6mpg55zmdd5kvlg396rqi9lqkj4";
   };
 
   buildInputs = [ unzip autoconf automake makeWrapper pkgconfig 

--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/christophgysin/pasystray/archive/${name}.zip";
-    sha256 = "1gpb7yqcxqglv50iqbkg2lg3r0z07jm4ir2zqmvns6sgddks590w";
+    sha256 = "0n41qm04kilhc827yx8y1ijslmajg2dxykaf3s3aq6s6bjzzw8bh";
   };
 
   buildInputs = [ unzip autoconf automake makeWrapper pkgconfig 

--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -1,15 +1,15 @@
-{stdenv, fetchurl, unzip, autoconf, automake, makeWrapper, pkgconfig
+{stdenv, fetchzip, autoconf, automake, makeWrapper, pkgconfig
 , gnome3, avahi, gtk3, libnotify, pulseaudio, x11}:
 
 stdenv.mkDerivation rec {
   name = "pasystray-0.5.2";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/christophgysin/pasystray/archive/${name}.zip";
     sha256 = "084jld5zk89h4akll73bwhfav6mpg55zmdd5kvlg396rqi9lqkj4";
   };
 
-  buildInputs = [ unzip autoconf automake makeWrapper pkgconfig 
+  buildInputs = [ autoconf automake makeWrapper pkgconfig 
                   gnome3.defaultIconTheme
                   avahi gtk3 libnotify pulseaudio x11 ];
 


### PR DESCRIPTION
I presume there's something about how github creates the .zip files such
that they can change SHA.

Please note: this is a very outdated version of pasystray---I don't know
if that's intentional, but perhaps a better strategy would be to update
it wholesale.
