### PR TITLE
Add whois from Debian and generalize mkpasswd build

### DIFF
--- a/pkgs/tools/networking/whois/default.nix
+++ b/pkgs/tools/networking/whois/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, perl, gettext }:
+
+stdenv.mkDerivation rec {
+  version = "5.2.10";
+  name = "whois-${version}";
+
+  src = fetchFromGitHub {
+    owner = "rfc1036";
+    repo = "whois";
+    rev = "v${version}";
+    sha256 = "0fqxbys3ssyplh70wjs83jsljqhmrnjic02ayaznw9m9l6fzhkkr";
+  };
+
+  buildInputs = [ perl gettext ];
+
+  preConfigure = ''
+    for i in Makefile po/Makefile; do
+      substituteInPlace $i --replace "prefix = /usr" "prefix = $out"
+    done
+  '';
+
+  buildPhase = "make whois";
+
+  installPhase = "make install-whois";
+
+  meta = with stdenv.lib; {
+    description = "Intelligent WHOIS client from Debian";
+    longDescription = ''
+      This package provides a commandline client for the WHOIS (RFC 3912)
+      protocol, which queries online servers for information such as contact
+      details for domains and IP address assignments. It can intelligently
+      select the appropriate WHOIS server for most queries.
+    '';
+
+    homepage = http://packages.qa.debian.org/w/whois.html;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fpletz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -1,30 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, whois, perl }:
 
-stdenv.mkDerivation rec {
-  name = "mkpasswd-${version}";
+stdenv.mkDerivation {
+  name = "mkpasswd-${whois.version}";
 
-  version = "5.1.1";
+  src = whois.src;
 
-  src = fetchFromGitHub {
-    owner = "rfc1036";
-    repo = "whois";
-    rev = "v${version}";
-    sha256 = "026x8byx8pcpkdxca64368p0nlspk4phw18jg4p04di6cg6nc1m5";
-  };
+  buildInputs = [ perl ];
 
-  preConfigure = ''
-    substituteInPlace Makefile --replace "prefix = /usr" "prefix = $out"
-  '';
-
+  preConfigure = whois.preConfigure;
   buildPhase = "make mkpasswd";
-
   installPhase = "make install-mkpasswd";
 
   meta = with stdenv.lib; {
     homepage = http://packages.qa.debian.org/w/whois.html;
     description = "Overfeatured front-end to crypt, from the Debian whois package";
     license = licenses.gpl2;
-    maintainers = [ maintainers.cstrahan ];
+    maintainers = with maintainers; [ cstrahan fpletz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3343,6 +3343,8 @@ let
 
   welkin = callPackage ../tools/graphics/welkin {};
 
+  whois = callPackage ../tools/networking/whois { };
+
   wsmancli = callPackage ../tools/system/wsmancli {};
 
   wolfebin = callPackage ../tools/networking/wolfebin {


### PR DESCRIPTION
This commit adds a much more usable whois tool compared to the ones in busybox and inetutils. ~~Additionally, in order to refer the whois source only once, a generalized builder for both whois and mkpasswd is introduced.~~

The sources for whois and mkpasswd from Debian are both located in the whois git repository for historical reasons.

/cc @cstrahan 
