### PR TITLE
mod_python: Avoid that git is called to generate a version

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_python/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_python/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./install.patch ];
 
+  postPatch = ''
+    substituteInPlace dist/version.sh \
+        --replace 'GIT=`git describe --always`' "" \
+        --replace '-$GIT' ""
+  '';
+
   preInstall = ''
     installFlags="LIBEXECDIR=$out/modules $installFlags"
     mkdir -p $out/modules $out/bin


### PR DESCRIPTION
This failed when building mod_python and resulted in a broken
value being included in the file "version.py".

I faced this problem in my error log of apache when trying to make use of mod_python:

```
Traceback (most recent call last):
  File "/nix/store/nblpw4xyl7zfl1pa7265lgrdwb856njq-mod_python-3.5.0/lib/python2.7/site-packages/mod_python/__init__.py", line 25, in <module>
    from . import version
  File "/nix/store/nblpw4xyl7zfl1pa7265lgrdwb856njq-mod_python-3.5.0/lib/python2.7/site-packages/mod_python/version.py", line 3
    version = "./version.sh: line 8: git: command not found
                                                          ^
SyntaxError: EOL while scanning string literal
```

Found out that a file `dist/version.sh` includes the broken output from a call to `git`.
