### PR TITLE
Make numpy and scipy depend on openblas

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7818,6 +7818,13 @@ let
     preConfigure = ''
       sed -i 's/-faltivec//' numpy/distutils/system_info.py
       sed -i '0,/from numpy.distutils.core/s//import setuptools;from numpy.distutils.core/' setup.py
+      # Create a site.cfg with openblas info
+      cat << EOF > site.cfg
+      [openblas]
+      libraries = openblas
+      library_dirs = ${pkgs.openblas}/lib
+      include_dirs = ${pkgs.openblas}/include
+      EOF
     '';
 
     preBuild = ''
@@ -9160,12 +9167,12 @@ let
     version = "1.5.3";
     # FAIL:test_generate_entry and test_time
     # both tests fail due to time issue that doesn't seem to matter in practice
-    doCheck = false; 
+    doCheck = false;
     src = pkgs.fetchurl {
       url = "https://github.com/pyblosxom/pyblosxom/archive/v${version}.tar.gz";
       sha256 = "0de9a7418f4e6d1c45acecf1e77f61c8f96f036ce034493ac67124626fd0d885";
     };
-  
+
     propagatedBuildInputs = with self; [ pygments markdown ];
 
     meta = {
@@ -11193,10 +11200,17 @@ let
     buildInputs = [ pkgs.gfortran ];
     propagatedBuildInputs = with self; [ numpy ];
 
-    # TODO: add ATLAS=${pkgs.atlas}
+    # Note: BLAS and LAPACK environment variables are set from numpy builder.
+    # Also note that pkgs.openblas is a dependency of numpy.
     preConfigure = ''
-      export BLAS=${pkgs.blas} LAPACK=${pkgs.liblapack}
       sed -i '0,/from numpy.distutils.core/s//import setuptools;from numpy.distutils.core/' setup.py
+      # Create a site.cfg with openblas info
+      cat << EOF > site.cfg
+      [openblas]
+      libraries = openblas
+      library_dirs = ${pkgs.openblas}/lib
+      include_dirs = ${pkgs.openblas}/include
+      EOF
     '';
 
     setupPyBuildFlags = [ "--fcompiler='gnu95'" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7824,22 +7824,20 @@ let
       runHook preCheck
 
       _python=${python}/bin/${python.executable}
-      test_dir=$(mktemp -d /tmp/numpy-test-XXX)
-      install_root=$(mktemp -d /tmp/numpy-test-install-XXX)
-      install_dir="$install_root/lib/${python.libPrefix}/site-packages"
+      install_dir="$TMPDIR/test_install/lib/${python.libPrefix}/site-packages"
       mkdir -p $install_dir
       export PYTHONPATH="$install_dir:$PYTHONPATH"
 
       $_python setup.py install \
         --install-lib=$install_dir \
         --old-and-unmanageable \
-        --prefix="$install_root"
+        --prefix="$TMPDIR/test_install"
 
-      pushd $test_dir
+      mkdir $TMPDIR/run_tests
+      pushd $TMPDIR/run_tests
       $_python -c 'import numpy; numpy.test("full", verbose=10)'
       popd
-      rm -r $test_dir
-      rm -r $install_dir
+
       runHook postCheck
   '';
 


### PR DESCRIPTION
This configures numpy and scipy to use the openblas framework for their linear algebra operations, which seems preferable since it reduces the number and complexity of dependencies (a single library for BLAS and LAPACK). In addition openblas seems to be a lighter-weight dependency (in terms of build time, not sure about size) than ATLAS. In addition, on OSX, the numpy setup.py (and presumably scipy) will impurely check for the existence of the `Accelerate` framework, and if found, will pass it as an argument to `clang`, which will fail. It will not do this if there's a `site.cfg` telling it where to find `openblas`. This keeps things pure, and also makes it cross-platform.
