### PR TITLE
ddclient: Set SSL_CERT_FILE environment variable

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -126,6 +126,8 @@ in
       description = "Dynamic DNS Client";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+
+      environment.SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
       serviceConfig = {
         # Uncomment this if too many problems occur:
         # Type = "forking";


### PR DESCRIPTION
Otherwise connection to SSL hosts fails like this:

```
May 26 06:44:05 kbuilder ddclient[17084]: WARNING:  cannot connect to dynamicdns.park-your-domain.com:443 socket:
    IO::Socket::IP configuration failed SSL connect attempt failed with unknown error
    error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
```
