### PR TITLE
rxvt_unicode: Add terminfo output to propagated-user-env-packages

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -45,6 +45,11 @@ stdenv.mkDerivation (rec {
       ln -s $out/{lib/urxvt,lib/perl5/site_perl}
     '';
 
+  postInstall = ''
+    mkdir -p $out/nix-support
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+  '';
+
   meta = {
     description = "A clone of the well-known terminal emulator rxvt";
     homepage = "http://software.schmorp.de/pkg/rxvt-unicode.html";


### PR DESCRIPTION
Fixes #7787. I'm not completely sure why the problem in that issue happens (I can't replicate it) as urxvt explicitly sets the `TERMINFO` environment variable like this: https://github.com/exg/rxvt-unicode/blob/8cfa002d973c2e6397085f42c3d274dccb7dd77d/src/init.C#L932. But regardless, doing this helps with commands like `sudo -E` and should be the right thing to do.
