### PR TITLE
sudo: support insults (but don't enable by default)

### DIFF
--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     "--with-vardir=/var/db/sudo"
     "--with-logpath=/var/log/sudo.log"
     "--with-sendmail=${sendmailPath}"
+    "--with-all-insults"
+    "--with-insults=disabled"
   ];
 
   configureFlagsArray = [


### PR DESCRIPTION
I'm sorry. I've tried.

I've tried for the past half-year to get used to a system that doesn't scold me when I fat-finger my own password. That lets me simply try again - without strongly suggesting I should probably sober up first. Even _apologising_ for my balderdash with a meek:

```
Sorry, try again.
```

I have failed.

This allows insults to be enabled in `sudoers` if desired.
