### PR TITLE
Update mediainfo{-gui} and dependencies

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.73";
+  version = "0.7.74";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
-    sha256 = "14mbiy1xhj4nlp7hnfqvi518xn1f718b2vbl8xkjqr2sqjdf5jm7";
+    sha256 = "06r6inggkb3gmxax182y4y39icxry5hdcvq7syb060l8wxrk14ky";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.73";
+  version = "0.7.74";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
-    sha256 = "14mbiy1xhj4nlp7hnfqvi518xn1f718b2vbl8xkjqr2sqjdf5jm7";
+    sha256 = "06r6inggkb3gmxax182y4y39icxry5hdcvq7syb060l8wxrk14ky";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.73";
+  version = "0.7.74";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.bz2";
-    sha256 = "1c7yc9m4fdrfdlb80g6157sa8s0wlv892pixrfdzfljsqayxnl6k";
+    sha256 = "1dn7zwqkl08vafc979i1mx63r2jlr95gfazg4d2cc9v3pav28zpk";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
- mediainfo{-gui} 0.7.73 -> 0.7.74
- libmediainfo    0.7.73 -> 0.7.74

From the mediainfo ChangeLog:

```
Version 0.7.74, 2015-05-25

+ FIMS: Preliminary version (not for production)
+ D-10 audio: display of real bitrate beside the encoded bitrate
+ VC-3: detection of CDP packets (608/708 captions), created by Nexio, inside the VC-3 private data
+ AES3: generic term AES3 replaced by more precise SMPTE ST numbers (302, 331, 337)
+ NUT: basic detection
+ FFV1: more parsing of the bitstream, support of any version of FFV1 in MOV and Matroska
+ DPX: color space and frame rate
x #B906, Matroska: duration was missing if Info block is at the end of the file
x #B908, AC-3: bit depth removed
x #P86, MPEG-4: moov_trak_edts_elst Atom was ignoring version of the atom
x Dolby E: the MXF channel count value was sometimes reported instead of the real channel count
x VorbisComment: WAVEFORMATEXTENSIBLE_CHANNEL_MASK "0X" ("x" in uppercase) is accepted now
x EBUCore: TotalProgrammeDuration was wrongly filled with IdentClockStart value
x EBUCore: Source/Material moved from timecodeStart to timecodeTrack
x MPEG-4: info is missing for some streams in some specific cases
```
