### PR TITLE
added cmake flag to prevent autodetection of SDK directory

### DIFF
--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -3,6 +3,7 @@ let
   atlasMaybeShared = atlas.override { inherit shared; };
   usedLibExtension = if shared then ".so" else ".a";
   version = "3.4.1";
+  inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
   name = "liblapack-${version}";
@@ -21,7 +22,10 @@ stdenv.mkDerivation rec {
     "-DBLAS_ATLAS_atlas_LIBRARY=${atlasMaybeShared}/lib/libatlas${usedLibExtension}"
     "-DCMAKE_Fortran_FLAGS=-fPIC"
   ]
-  ++ (stdenv.lib.optional shared "-DBUILD_SHARED_LIBS=ON")
+  ++ (optional shared "-DBUILD_SHARED_LIBS=ON")
+  # If we're on darwin, CMake will automatically detect impure paths. This switch
+  # prevents that.
+  ++ (optional stdenv.isDarwin "-DCMAKE_OSX_SYSROOT:PATH=''")
   ;
 
   doCheck = ! shared;


### PR DESCRIPTION
Liblapack was failing to build on OS X, complaining about impure paths. Turns out cmake autodetects the Apple SDK path and passes it in as an argument to gfortran under the `-isysroot` argument, which blows things up when `NIX_ENFORCE_PURITY=1`. This overwrites that and things build happily.
