### PR TITLE
boot: Update version from 2.0.0-rc14 to 2.0.0.

### DIFF
--- a/pkgs/development/tools/build-managers/boot/default.nix
+++ b/pkgs/development/tools/build-managers/boot/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, jdk }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.0-rc14";
+  version = "2.0.0";
   name = "boot-${version}";
 
   src = fetchurl {


### PR DESCRIPTION
sha is the same as `boot.sh` script hasn't changed.
