### PR TITLE
apache-kafka: Treat exit code 143 as success.

### DIFF
--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -143,6 +143,7 @@ in {
         '';
         User = "apache-kafka";
         PermissionsStartOnly = true;
+        SuccessExitStatus = "0 143";
       };
       preStart = ''
         mkdir -m 0700 -p ${concatStringsSep " " cfg.logDirs}


### PR DESCRIPTION
JVMs exit with exit code 128+signal when receiving a (terminating) signal. This means graceful termination of a JVM after receiving a SIGTERM (systemd defaul) will result in 143, so add that to `SuccessExitStatus` in systemd service unit.
