### PR TITLE
locate: option includeStore

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -179,6 +179,15 @@ nix-env -f &quot;&lt;nixpkgs&gt;&quot; -iA haskellPackages.cabal-install
   </para>
 </listitem>
 
+<listitem>
+  <para>
+    The <literal>locate</literal> service no longer indexes the nix store
+    by default, preventing packages with potentially numerous versions from
+    cluttering the output. Indexing the store can be activated with
+    <literal>services.locate.includeStore = true;</literal>.
+  </para>
+</listitem>
+
 </itemizedlist>
 </para>
 

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -56,6 +56,14 @@ in {
         '';
       };
 
+      includeStore = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to include /nix/store in the locate database.
+        '';
+      };
+
     };
 
   };
@@ -63,7 +71,6 @@ in {
   ###### implementation
 
   config = {
-
     systemd.services.update-locatedb =
       { description = "Update Locate Database";
         path  = [ pkgs.su ];
@@ -72,6 +79,7 @@ in {
             mkdir -m 0755 -p $(dirname ${toString cfg.output})
             exec updatedb \
             --localuser=${cfg.localuser} \
+	    ${optionalString (!cfg.includeStore) "--prunepaths='/nix/store'"} \
             --output=${toString cfg.output} ${concatStringsSep " " cfg.extraFlags}
           '';
         serviceConfig.Nice = 19;


### PR DESCRIPTION
Reasoning:

/nix/store contains lots of duplicates and clutters the output of locate.

I could have made a prunepaths option with a list, but then it would only made have sense to include every locate option.
This way the very common problem with /nix/store is solved and extraFlags handles every other usecase.

Debatable: default value
