### PR TITLE
mpv: refactor & fix youtube-dl support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,7 +1,5 @@
-{ stdenv, fetchurl, fetchgit, freetype, pkgconfig, freefont_ttf, ffmpeg, libass
-, lua, perl, libpthreadstubs
-, lua5_sockets
-, python3, docutils, which, lib
+{ stdenv, fetchurl, docutils, makeWrapper, perl, pkgconfig, python, which
+, ffmpeg, freefont_ttf, freetype, libass, libpthreadstubs, lua, lua5_sockets
 , x11Support ? true, libX11 ? null, libXext ? null, mesa ? null, libXxf86vm ? null
 , xineramaSupport ? true, libXinerama ? null
 , xvSupport ? true, libXv ? null
@@ -16,14 +14,18 @@
 , theoraSupport ? true, libtheora ? null
 , jackaudioSupport ? true, jack2 ? null
 , pulseSupport ? true, pulseaudio ? null
-, bs2bSupport ? false, libbs2b ? null
+, bs2bSupport ? true, libbs2b ? null
 # For screenshots
 , libpngSupport ? true, libpng ? null
 # for Youtube support
-, youtubeSupport ? false, youtubeDL ? null
-, cacaSupport ? false, libcaca ? null
+, youtubeSupport ? true, youtube-dl ? null
+, cacaSupport ? true, libcaca ? null
 , vaapiSupport ? false, libva ? null
 }:
+
+# TODO: Wayland support
+# TODO: investigate caca support
+# TODO: investigate lua5_sockets bug
 
 assert x11Support -> (libX11 != null && libXext != null && mesa != null && libXxf86vm != null);
 assert xineramaSupport -> (libXinerama != null && x11Support);
@@ -41,22 +43,20 @@ assert jackaudioSupport -> jack2 != null;
 assert pulseSupport -> pulseaudio != null;
 assert bs2bSupport -> libbs2b != null;
 assert libpngSupport -> libpng != null;
-assert youtubeSupport -> youtubeDL != null;
+assert youtubeSupport -> youtube-dl != null;
 assert cacaSupport -> libcaca != null;
 
-# Purity problem: Waf needed to be is downloaded by bootstrap.py
-# but by purity reasons it should be avoided; thanks the-kenny to point it out!
-# Now, it will just download and package Waf, mimetizing bootstrap.py behaviour
-
 let
+  inherit (stdenv.lib) optional optionals optionalString;
+
+  # Purity: Waf is normally downloaded by bootstrap.py, but
+  # for purity reasons this behavior should be avoided.
   waf = fetchurl {
     url = http://ftp.waf.io/pub/release/waf-1.8.5;
     sha256 = "0gh266076pd9fzwkycskyd3kkv2kds9613blpxmn9w4glkiwmmh5";
   };
-
 in
 
-with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "mpv-${version}";
   version = "0.9.2";
@@ -66,9 +66,30 @@ stdenv.mkDerivation rec {
     sha256 = "0la7pmy75mq92kcrawdiw5idw6a46z7d15mlkgs0axyivdaqy560";
   };
 
-  buildInputs =
-    [ python3 lua perl freetype pkgconfig ffmpeg libass docutils which libpthreadstubs lua5_sockets ]
-    ++ optionals x11Support [ libX11 libXext mesa libXxf86vm ]
+  patchPhase = ''
+    patchShebangs ./TOOLS/
+  '';
+
+  NIX_LDFLAGS = optionalString x11Support "-lX11 -lXext";
+
+  configureFlags = [
+    "--enable-libmpv-shared"
+    "--disable-libmpv-static"
+    "--disable-static-build"
+    "--enable-manpage-build"
+    "--disable-build-date" # Purity
+    "--enable-zsh-comp"
+  ] ++ optional vaapiSupport "--enable-vaapi";
+
+  configurePhase = ''
+    python ${waf} configure --prefix=$out $configureFlags
+  '';
+
+  nativeBuildInputs = [ docutils makeWrapper perl pkgconfig python which ];
+
+  buildInputs = [
+    ffmpeg freetype libass libpthreadstubs lua lua5_sockets
+  ] ++ optionals x11Support [ libX11 libXext mesa libXxf86vm ]
     ++ optional alsaSupport alsaLib
     ++ optional xvSupport libXv
     ++ optional theoraSupport libtheora
@@ -83,49 +104,39 @@ stdenv.mkDerivation rec {
     ++ optional speexSupport speex
     ++ optional bs2bSupport libbs2b
     ++ optional libpngSupport libpng
-    ++ optional youtubeSupport youtubeDL
+    ++ optional youtubeSupport youtube-dl
     ++ optional sdl2Support SDL2
     ++ optional cacaSupport libcaca
-    ++ optional vaapiSupport libva
-    ;
-
-# There are almost no need of "configure flags", but some libraries
-# weren't detected; see the TODO comments below
-
-  NIX_LDFLAGS = stdenv.lib.optionalString x11Support "-lX11 -lXext";
+    ++ optional vaapiSupport libva;
 
   enableParallelBuilding = true;
 
-  configurePhase = ''
-    python3 ${waf} configure --prefix=$out ${lib.optionalString vaapiSupport "--enable-vaapi"}
-    patchShebangs TOOLS
-  '';
-
   buildPhase = ''
-    python3 ${waf} build
+    python ${waf} build
   '';
 
   installPhase = ''
-    python3 ${waf} install
-    # Maybe not needed, but it doesn't hurt anyway: a standard font
+    python ${waf} install
+
+    # Use a standard font
     mkdir -p $out/share/mpv
     ln -s ${freefont_ttf}/share/fonts/truetype/FreeSans.ttf $out/share/mpv/subfont.ttf
-    '';
+  '' + optionalString youtubeSupport ''
+    # Ensure youtube-dl is available in $PATH for MPV
+    wrapProgram $out/bin/mpv --prefix PATH : "${youtube-dl}/bin"
+  '';
 
-  meta = with stdenv.lib;{
-    description = "A movie player that supports many video formats (MPlayer and mplayer2 fork)";
+  meta = with stdenv.lib; {
+    description = "A media player that supports many video formats (MPlayer and mplayer2 fork)";
+    homepage = http://mpv.io;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres fuuzetsu ];
+    platforms = platforms.linux;
+
     longDescription = ''
       mpv is a free and open-source general-purpose video player,
       based on the MPlayer and mplayer2 projects, with great
       improvements above both.
     '';
-    homepage = http://mpv.io;
-    license = licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ AndersonTorres fuuzetsu ];
-    platforms = platforms.linux;
   };
 }
-
-# TODO: Wayland support
-# TODO: investigate caca support
-# TODO: investigate lua5_sockets bug

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11806,8 +11806,6 @@ let
     youtubeSupport = config.mpv.youtubeSupport or true;
     cacaSupport = config.mpv.cacaSupport or true;
     vaapiSupport = config.mpv.vaapiSupport or false;
-    # YouTube needs network support and potentially openssl/tls
-    ffmpeg = if youtubeSupport then ffmpeg-full else ffmpeg;
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
@Fuuzetsu 
I got the youtube-dl support for mpv cleaned up, along with some other cleanup to youtube-dl and mpv in this PR, #8038 & #8039.  I will still have to add a fix for ffmpeg-full to use samba's version of gnutls at some point soon to completely resolve this.
