### PR TITLE
azul-zulu: New package

### DIFF
--- a/pkgs/development/compilers/azul-zulu/default.nix
+++ b/pkgs/development/compilers/azul-zulu/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, unzip, glibc }:
+
+let
+  openjdkVersion = "8";
+  openjdkUpdate = "45";
+  zuluMajorVersion = "8.7";
+  zuluMinorVersion = "0.5";
+in
+
+stdenv.mkDerivation rec {
+  name = "azul-zulu";
+  version = "1.${openjdkVersion}.0_${openjdkUpdate}-${zuluMajorVersion}.${zuluMinorVersion}";
+
+  src = fetchurl {
+    url = "http://cdn.azulsystems.com/zulu/2015-04-${zuluMajorVersion}-bin/zulu${version}-x86lx64.zip";
+    sha256 = "04cngsbflv65js5drmqfwgvi2ld62v6dwvg8mm3azm5z2d71r86w";
+    curlOpts = "--referer http://www.azulsystems.com/products/zulu/downloads";
+  };
+
+  buildInputs = [ unzip ];
+
+  preFixup = ''
+    for p in $out/bin\/*; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        $p
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R bin lib man $out
+    cp -R jre $out
+  '';
+  
+}
+  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3379,6 +3379,8 @@ let
 
   avra = callPackage ../development/compilers/avra { };
 
+  azulZulu = callPackage ../development/compilers/azul-zulu { };
+
   bigloo = callPackage ../development/compilers/bigloo { };
 
   fetchegg = callPackage ../build-support/fetchegg { };


### PR DESCRIPTION
This PR adds support for the Azul Zulu JVM [1](http://www.azulsystems.com/products/zulu). Azul Zulu is a certified build of OpenJDK, providing binaries for Linux, Windows and OSX. It's appealing as it is a solid build of OpenJDK available for download without the hurdles of Oracle JDK.

I've tested this on some of my work JVM code (clojure) and I've also been able to run IntelliJ.

I'd like to get some more eyes on this and would appreciate people testing it with various Java apps. Also, we should be able to support OSX/Windows binaries are provided, but I don't have easy access to those environments.

Ping @shlevy @edolstra as you're maintainers of OpenJDK and can probably provide more insight around JVM/openjdk oddities that I might've missed.
