### PR TITLE
Test suites and working OSX builds for numpy and scipy

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7802,50 +7802,13 @@ let
     };
   };
 
-  # Special check phase for numpy and scipy, following the same set of steps:
-  # First "install" the package, then import what was installed, and call the
-  # .test() function, which will run the test suite.
-  numpyScipyCheckPhase = python: pkgName: ''
-    runHook preCheck
-
-    _python=${python}/bin/${python.executable}
-
-    # We will "install" into a temp directory, so that we can run the numpy
-    # tests (see below).
-    install_dir="$TMPDIR/test_install"
-    install_lib="$install_dir/lib/${python.libPrefix}/site-packages"
-    mkdir -p $install_dir
-    $_python setup.py install \
-      --install-lib=$install_lib \
-      --old-and-unmanageable \
-      --prefix=$install_dir > /dev/null
-
-    # Create a directory in which to run tests (you get an error if you try to
-    # import the package when you're in the current directory).
-    mkdir $TMPDIR/run_tests
-    pushd $TMPDIR/run_tests > /dev/null
-    # Temporarily add the directory we installed in to the python path
-    # (not permanently, or this pythonpath will wind up getting exported),
-    # and run the test suite.
-    PYTHONPATH="$install_lib:$PYTHONPATH" $_python -c \
-      'import ${pkgName}; ${pkgName}.test("fast", verbose=10)'
-    popd > /dev/null
-
-    runHook postCheck
-  '';
-
-  # Special prebuild step for numpy and scipy. Creates a site.cfg telling
-  # the setup script where to find depended-on math libraries.
-  numpyScipyPrebuild = ''
-    echo "Creating site.cfg file..."
-    cat << EOF > site.cfg
-    [atlas]
-    include_dirs = ${pkgs.atlasWithLapack}/include
-    library_dirs = ${pkgs.atlasWithLapack}/lib
-    EOF
-  '';
-
-  numpy = buildPythonPackage ( rec {
+  numpy = let
+    support = import ./python-support/numpy-scipy-support.nix {
+      inherit python;
+      atlas = atlasWithLapack;
+      pkgName = "numpy";
+    };
+  in buildPythonPackage ( rec {
     name = "numpy-1.9.2";
 
     src = pkgs.fetchurl {
@@ -7860,14 +7823,12 @@ let
       sed -i '0,/from numpy.distutils.core/s//import setuptools;from numpy.distutils.core/' setup.py
     '';
 
-    preBuild = self.numpyScipyPrebuild;
+    inherit (support) preBuild checkPhase;
 
     setupPyBuildFlags = ["--fcompiler='gnu95'"];
 
     buildInputs = [ pkgs.gfortran self.nose ];
     propagatedBuildInputs = [ pkgs.atlas ];
-
-    checkPhase = self.numpyScipyCheckPhase python "numpy";
 
     meta = {
       description = "Scientific tools for Python";
@@ -11219,7 +11180,13 @@ let
   };
 
 
-  scipy = buildPythonPackage rec {
+  scipy = let
+    support = import ./python-support/numpy-scipy-support.nix {
+      inherit python;
+      atlas = atlasWithLapack;
+      pkgName = "numpy";
+    };
+  in buildPythonPackage rec {
     name = "scipy-0.15.1";
 
     src = pkgs.fetchurl {
@@ -11230,16 +11197,13 @@ let
     buildInputs = [ pkgs.gfortran self.nose ];
     propagatedBuildInputs = [ self.numpy ];
 
-    # TODO: add ATLAS=${pkgs.atlas}
     preConfigure = ''
       sed -i '0,/from numpy.distutils.core/s//import setuptools;from numpy.distutils.core/' setup.py
     '';
 
-    preBuild = self.numpyScipyPrebuild;
+    inherit (support) preBuild checkPhase;
 
     setupPyBuildFlags = [ "--fcompiler='gnu95'" ];
-
-    checkPhase = self.numpyScipyCheckPhase python "scipy";
 
     meta = {
       description = "SciPy (pronounced 'Sigh Pie') is open-source software for mathematics, science, and engineering. ";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7805,7 +7805,7 @@ let
   numpy = let
     support = import ./python-support/numpy-scipy-support.nix {
       inherit python;
-      atlas = atlasWithLapack;
+      atlas = pkgs.atlasWithLapack;
       pkgName = "numpy";
     };
   in buildPythonPackage ( rec {
@@ -11183,7 +11183,7 @@ let
   scipy = let
     support = import ./python-support/numpy-scipy-support.nix {
       inherit python;
-      atlas = atlasWithLapack;
+      atlas = pkgs.atlasWithLapack;
       pkgName = "numpy";
     };
   in buildPythonPackage rec {

--- a/pkgs/top-level/python-support/numpy-scipy-support.nix
+++ b/pkgs/top-level/python-support/numpy-scipy-support.nix
@@ -1,0 +1,53 @@
+{
+  # Python package expression
+  python,
+  # Name of package (e.g. numpy or scipy)
+  pkgName,
+  # Atlas math library
+  atlas
+}:
+
+{
+
+  # First "install" the package, then import what was installed, and call the
+  # .test() function, which will run the test suite.
+  checkPhase = ''
+    runHook preCheck
+
+    _python=${python}/bin/${python.executable}
+
+    # We will "install" into a temp directory, so that we can run the numpy
+    # tests (see below).
+    install_dir="$TMPDIR/test_install"
+    install_lib="$install_dir/lib/${python.libPrefix}/site-packages"
+    mkdir -p $install_dir
+    $_python setup.py install \
+      --install-lib=$install_lib \
+      --old-and-unmanageable \
+      --prefix=$install_dir > /dev/null
+
+    # Create a directory in which to run tests (you get an error if you try to
+    # import the package when you're in the current directory).
+    mkdir $TMPDIR/run_tests
+    pushd $TMPDIR/run_tests > /dev/null
+    # Temporarily add the directory we installed in to the python path
+    # (not permanently, or this pythonpath will wind up getting exported),
+    # and run the test suite.
+    PYTHONPATH="$install_lib:$PYTHONPATH" $_python -c \
+      'import ${pkgName}; ${pkgName}.test("fast", verbose=10)'
+    popd > /dev/null
+
+    runHook postCheck
+  '';
+
+  # Creates a site.cfg telling the setup script where to find depended-on 
+  # math libraries.
+  preBuild = ''
+    echo "Creating site.cfg file..."
+    cat << EOF > site.cfg
+    [atlas]
+    include_dirs = ${atlas}/include
+    library_dirs = ${atlas}/lib
+    EOF
+  '';
+}

--- a/pkgs/top-level/python-support/numpy-scipy-support.nix
+++ b/pkgs/top-level/python-support/numpy-scipy-support.nix
@@ -16,7 +16,7 @@
 
     _python=${python}/bin/${python.executable}
 
-    # We will "install" into a temp directory, so that we can run the numpy
+    # We will "install" into a temp directory, so that we can run the
     # tests (see below).
     install_dir="$TMPDIR/test_install"
     install_lib="$install_dir/lib/${python.libPrefix}/site-packages"


### PR DESCRIPTION
Depends on #8042.

This does a few things:
- No longer using `doCheck = false` for numpy and scipy. Wrote a `checkPhase` that will run through the test suites of these apps.
- Creating a `site.cfg` which will instruct numpy/scipy to use atlas.
  - This is essential for OS X, because the way that the dependency checker for numpy works (see [here](https://github.com/numpy/numpy/blob/467d4e16d77a2e7c131aac53c639e82b754578c7/numpy/distutils/system_info.py#L1509)), it will prioritize the impure detection of the `Accelerate` framework over the `BLAS` and `LAPACK` directives that the current derivation uses.
- Using `atlasWithLapack` as input.
  - This is preferable because, in the existing nixpkgs, liblapack depends on atlas anyway, which means that not only was this expensive dependency being built, it wasn't even being used.
  - If no lapack is present in atlas, numpy will not find it on its own (or I haven't figured out how to make it), but if atlas is built with lapack, it will find it OK.
  - Using `openblas` as we have done previously causes segfaults in numpy's test suite.
- Both packages build successfully (including of course their test suites) on OS X.
