### PR TITLE
Remotes/origin/python2.38.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1298,7 +1298,7 @@ let
 
     src = pkgs.fetchurl {
       url = "https://github.com/boto/boto/archive/${version}.tar.gz";
-      sha256 = "f2659f9b9d4f183a997ad0fc87f99f8cd3998df887fdadd3b776dada2b1df550";
+      sha256 = "0l7m3lmxmnknnz9svzc7z26rklwckzwqgz6hgackl62gkndryrgj";
     };
 
     checkPhase = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1294,11 +1294,11 @@ let
 
   boto = buildPythonPackage rec {
     name = "boto-${version}";
-    version = "2.36.0";
+    version = "2.38.0";
 
     src = pkgs.fetchurl {
       url = "https://github.com/boto/boto/archive/${version}.tar.gz";
-      sha256 = "1zrlmri89q2090yh9ylx798q4yk54y39v7w7xj101fnwc1r6jlqr";
+      sha256 = "f2659f9b9d4f183a997ad0fc87f99f8cd3998df887fdadd3b776dada2b1df550";
     };
 
     checkPhase = ''


### PR DESCRIPTION
Moved to boto 2.38.0
Mainly for the support of the last updates added to manage AWS KMS.
This is needed for the integration of KMS to NixOps.
