### PR TITLE
Fix kerberos related issues

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/gnome-control-center/default.nix
@@ -2,7 +2,7 @@
 , libcanberra, libcanberra_gtk3, accountsservice, libpwquality, pulseaudio, fontconfig
 , gdk_pixbuf, hicolor_icon_theme, librsvg, libxkbfile, libnotify
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
-, cracklib, python, libkrb5, networkmanagerapplet, networkmanager
+, cracklib, python, krb5, networkmanagerapplet, networkmanager
 , libwacom, samba, shared_mime_info, tzdata, icu, libtool, udev
 , docbook_xsl, docbook_xsl_ns, modemmanager, clutter, clutter_gtk }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     [ pkgconfig intltool ibus gtk glib upower libcanberra gsettings_desktop_schemas
       libxml2 gnome_desktop gnome_settings_daemon polkit libxslt libgtop gnome-menus
       gnome_online_accounts libsoup colord pulseaudio fontconfig colord-gtk libpwquality
-      accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify libxkbfile
+      accountsservice krb5 networkmanagerapplet libwacom samba libnotify libxkbfile
       shared_mime_info icu libtool docbook_xsl docbook_xsl_ns gnome3.grilo
       gdk_pixbuf gnome3.defaultIconTheme librsvg clutter clutter_gtk
       gnome3.vino udev libcanberra_gtk3

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -3,7 +3,7 @@
 
 # Optional Dependencies
 , libedit ? null, readline ? null, ncurses ? null, libverto ? null
-, openldap ? null, db ? null
+, openldap ? null
 
 # Crypto Dependencies
 , openssl ? null, nss ? null, nspr ? null
@@ -24,7 +24,6 @@ let
   optNcurses = if libOnly then null else shouldUsePkg ncurses;
   optLibverto = shouldUsePkg libverto;
   optOpenldap = if libOnly then null else shouldUsePkg openldap;
-  optDb = if libOnly then null else shouldUsePkg db;
 
   # Prefer the openssl implementation
   cryptoStr = if optOpenssl != null then "openssl"
@@ -94,7 +93,8 @@ stdenv.mkDerivation rec {
     (mkWith   (optLibverto != null)         "system-verto"        null)
     (mkWith   (optOpenldap != null)         "ldap"                null)
     (mkWith   false                         "tcl"                 null)
-    (mkWith   (optDb != null)               "system-db"           null)
+    # krb5 is only compatible with db 1.85 api
+    (mkWith   false                         "system-db"           null)
   ];
 
   buildPhase = optionalString libOnly ''


### PR DESCRIPTION
kerberos only supports berkley db 1.85, we can't use the system version

gnome-control-center requires a kerberos executable

@lethalman @wkennington 
