### PR TITLE
prometheus-mesos-exporter: Fix misplaced dependencies

### DIFF
--- a/pkgs/servers/monitoring/prometheus/mesos_exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/mesos_exporter/default.nix
@@ -12,7 +12,11 @@ goPackages.buildGoPackage rec {
     sha256 = "059az73j717gd960g4jigrxnvqrjh9jw1c324xpwaafa0bf10llm";
   };
 
-  buildInputs = [ goPackages.mesos-stats ];
+  buildInputs = [
+    goPackages.mesos-stats
+    goPackages.prometheus.client_golang
+    goPackages.glog
+  ];
 
   meta = with lib; {
     description = "Export Mesos metrics to Prometheus";

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1674,8 +1674,6 @@ let
       repo = "mesos_stats";
       sha256 = "18ggyjf4nyn77gkn16wg9krp4dsphgzdgcr3mdflv6mvbr482ar4";
     };
-
-    propagatedBuildInputs = [ prometheus.client_golang glog ];
   };
 
   mgo = buildGoPackage rec {


### PR DESCRIPTION
goPackages.mesos-stats doesn't actually have any dependencies of its
own; the mesos_exporter app does.
