### PR TITLE
[WIP] grsecurity: configure via sysctl

### DIFF
--- a/nixos/modules/security/grsecurity.nix
+++ b/nixos/modules/security/grsecurity.nix
@@ -223,6 +223,12 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions =
+      [ { assertion = config.boot.kernelPackages.kernel.features.grsecurity or false;
+          message = "the selected kernel does not support grsecurity";
+        }
+      ];
+
     /*
     assertions =
       [ { assertion = cfg.stable || cfg.testing;

--- a/nixos/modules/security/grsecurity.nix
+++ b/nixos/modules/security/grsecurity.nix
@@ -20,15 +20,6 @@ in
         '';
       };
 
-      kernelPackages = mkOption {
-        type = types.package;
-        description = ''
-          The kernel package set to use. In order to
-          understand how to set this option appropriately, please see
-          the NixOS wiki: TODO FIXME.
-        '';
-      };
-
       /*
       stable = mkOption {
         type = types.bool;


### PR DESCRIPTION
@thoughtpolice, this is what I think the grsecurity module should be doing. This is based on my own setup, which suits my own needs very well and lines up with what Arch Linux does. See the commit message for details. The existing, commented out options belong in a builder expression or something, I think ...
