### PR TITLE
linux/make-bootstrap-tools: Add support for a real XZ and HTTPS in curl

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -85,16 +85,12 @@ let
   curl-light = pkgs.curl-light.crossDrv;
   xz = pkgs.xz.crossDrv;
   cacert = pkgs.cacert.crossDrv;
+  coreutils = pkgs.coreutils.crossDrv;
   busyboxBootstrap = pkgs.busyboxBootstrap.crossDrv;
 
 in
 
 rec {
-
-  # We want coreutils without ACL support.
-  coreutilsMinimal = (pkgs.coreutils.override (args: {
-    aclSupport = false;
-  })).crossDrv;
   
   inherit pkgs;
 
@@ -135,7 +131,7 @@ rec {
         mv $out/include $out/include-glibc
 
         # Copy coreutils, bash, etc.
-        cp ${coreutilsMinimal}/bin/* $out/bin
+        cp ${coreutils}/bin/* $out/bin
         (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
 
         cp ${bash}/bin/bash $out/bin

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -219,7 +219,7 @@ rec {
             done
           done
         }
-        for BIN in $(find $out/bin -type f); do
+        for BIN in $out/bin/* $out/libexec/gcc/*/*/*; do
           echo "Copying libs for bin $BIN"
           copy_libs_in_elf $BIN
         done

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -85,6 +85,7 @@ let
   curl-light = pkgs.curl-light.crossDrv;
   xz = pkgs.xz.crossDrv;
   cacert = pkgs.cacert.crossDrv;
+  busyboxBootstrap = pkgs.busyboxBootstrap.crossDrv;
 
 in
 
@@ -94,22 +95,6 @@ rec {
   coreutilsMinimal = (pkgs.coreutils.override (args: {
     aclSupport = false;
   })).crossDrv;
-  
-  busyboxMinimal = (pkgs.busybox.override {
-    # TBD: uClibc is broken.
-    # useUclibc = true;
-    enableStatic = true;
-    enableMinimal = true;
-    extraConfig = ''
-      CONFIG_ASH y
-      CONFIG_ASH_BUILTIN_ECHO y
-      CONFIG_ASH_BUILTIN_TEST y
-      CONFIG_ASH_OPTIMIZE_FOR_SIZE y
-      CONFIG_MKDIR y
-      CONFIG_TAR y
-      CONFIG_UNXZ y
-    '';
-  }).crossDrv;
   
   inherit pkgs;
 
@@ -240,7 +225,7 @@ rec {
 
         mkdir $out/on-server
         tar cvfJ $out/on-server/bootstrap-tools.tar.xz -C $out/pack .
-        cp ${busyboxMinimal}/bin/busybox $out/on-server
+        cp ${busyboxBootstrap}/bin/busybox $out/on-server
         chmod u+w $out/on-server/busybox
         nuke-refs $out/on-server/busybox
       ''; # */

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -82,6 +82,9 @@ let
   libmpc = pkgs.libmpc.crossDrv;
   binutils = pkgs.binutils.crossDrv;
   libelf = pkgs.libelf.crossDrv;
+  curl-light = pkgs.curl-light.crossDrv;
+  xz = pkgs.xz.crossDrv;
+  cacert = pkgs.cacert.crossDrv;
 
 in
 
@@ -91,8 +94,6 @@ rec {
   coreutilsMinimal = (pkgs.coreutils.override (args: {
     aclSupport = false;
   })).crossDrv;
-  
-  curl-light = pkgs.curl-light.crossDrv;
   
   busyboxMinimal = (pkgs.busybox.override {
     # TBD: uClibc is broken.
@@ -122,11 +123,11 @@ rec {
       crossConfig = stdenv.cross.config;
 
       buildCommand = ''
-	set -x
+        set -x
         mkdir -p $out/bin $out/lib $out/libexec
 
         # Copy what we need of Glibc.
-        cp -d ${glibc}/lib/ld-*.so* $out/lib
+        cp -d ${glibc}/lib/ld*.so* $out/lib
         cp -d ${glibc}/lib/libc*.so* $out/lib
         cp -d ${glibc}/lib/libc_nonshared.a $out/lib
         cp -d ${glibc}/lib/libm*.so* $out/lib
@@ -138,20 +139,20 @@ rec {
         cp -d ${glibc}/lib/libnss*.so* $out/lib
         cp -d ${glibc}/lib/libresolv*.so* $out/lib
         cp -d ${glibc}/lib/crt?.o $out/lib
-        
+
         cp -rL ${glibc}/include $out
         chmod -R u+w $out/include
-        
+
         # Hopefully we won't need these.
         rm -rf $out/include/mtd $out/include/rdma $out/include/sound $out/include/video
         find $out/include -name .install -exec rm {} \;
         find $out/include -name ..install.cmd -exec rm {} \;
         mv $out/include $out/include-glibc
-        
+
         # Copy coreutils, bash, etc.
         cp ${coreutilsMinimal}/bin/* $out/bin
         (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
-        
+
         cp ${bash}/bin/bash $out/bin
         cp ${findutils}/bin/find $out/bin
         cp ${findutils}/bin/xargs $out/bin
@@ -163,14 +164,16 @@ rec {
         cp ${gnutar}/bin/tar $out/bin
         cp ${gzip}/bin/gzip $out/bin
         cp ${bzip2}/bin/bzip2 $out/bin
+        cp ${xz}/bin/xz $out/bin
         cp -d ${gnumake}/bin/* $out/bin
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin
         cp ${curl-light}/bin/curl $out/bin
-        cp -d ${curl-light}/lib/libcurl* $out/lib
 
-        cp -d ${gnugrep.pcre.crossDrv}/lib/libpcre*.so* $out/lib # needed by grep
-        
+        # Add ca certificates for curl
+        mkdir -p $out/etc/ssl/certs
+        cp -d ${cacert}/ca-bundle.crt $out/etc/ssl/certs
+
         # Copy what we need of GCC.
         cp -d ${gcc}/bin/gcc $out/bin
         cp -d ${gcc}/bin/cpp $out/bin
@@ -194,25 +197,31 @@ rec {
         rm -rf $out/include/c++/*/ext/pb_ds
         rm -rf $out/include/c++/*/ext/parallel
 
-        cp -d ${gmpxx}/lib/libgmp*.so* $out/lib
-        cp -d ${mpfr}/lib/libmpfr*.so* $out/lib
-        cp -d ${libmpc}/lib/libmpc*.so* $out/lib
-        cp -d ${zlib}/lib/libz.so* $out/lib
-        cp -d ${libelf}/lib/libelf.so* $out/lib
-        
-        # TBD: Why are these needed for cross but not native tools?
-        cp -d ${cloogppl}/lib/libcloog*.so* $out/lib
-        cp -d ${cloog}/lib/libcloog*.so* $out/lib
-        cp -d ${isl}/lib/libisl*.so* $out/lib
-        
         # Copy binutils.
         for i in as ld ar ranlib nm strip readelf objdump; do
           cp ${binutils}/bin/$i $out/bin
         done
-        cp -d ${binutils}/lib/lib*.so* $out/lib
+
+        # Copy all of the needed libraries for the binaries
+        for BIN in $(find $out/bin -type f); do
+          echo "Copying libs for bin $BIN"
+          LDD="$(ldd $BIN)" || continue
+          LIBS="$(echo "$LDD" | awk '{print $3}' | sed '/^$/d')"
+          for LIB in $LIBS; do
+            [ ! -f "$out/lib/$(basename $LIB)" ] && cp -pdv $LIB $out/lib
+            while [ "$(readlink $LIB)" != "" ]; do
+              LINK="$(readlink $LIB)"
+              if [ "${LINK:0:1}" != "/" ]; then
+                LINK="$(dirname $LIB)/$LINK"
+              fi
+              LIB="$LINK"
+              [ ! -f "$out/lib/$(basename $LIB)" ] && cp -pdv $LIB $out/lib
+            done
+          done
+        done
 
         chmod -R u+w $out
-        
+
         # Strip executables even further.
         for i in $out/bin/* $out/libexec/gcc/*/*/*; do
             if test -x $i -a ! -L $i; then

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -195,7 +195,7 @@ rec {
           LIBS="$(echo "$RELF" | grep 'Shared library' | sed 's,.*\[\([^]]*\)\].*,\1,')"
           for LIB in $LIBS; do
             # Find the libraries on the system
-            for LIBPATH in $(echo "$RPATH" | tr ':' ' '); do
+            for LIBPATH in $(echo "$RPATH:${libmpc}/lib" | tr ':' ' '); do
               if [ -f "$LIBPATH/$LIB" ]; then
                 LIB="$LIBPATH/$LIB"
                 break

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -74,6 +74,7 @@ rec {
         cp ${gnutar}/bin/tar $out/bin
         cp ${gzip}/bin/gzip $out/bin
         cp ${bzip2}/bin/bzip2 $out/bin
+        cp ${xz}/bin/xz $out/bin
         cp -d ${gnumake}/bin/* $out/bin
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -39,7 +39,7 @@ rec {
         mv $out/include $out/include-glibc
 
         # Copy coreutils, bash, etc.
-        cp ${coreutilsMinimal}/bin/* $out/bin
+        cp ${coreutils}/bin/* $out/bin
         (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
 
         cp ${bash}/bin/bash $out/bin

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -4,27 +4,6 @@ with import ../../top-level/all-packages.nix {inherit system;};
 
 rec {
 
-
-  # We want coreutils without ACL support.
-  coreutilsMinimal = coreutils.override (args: {
-    aclSupport = false;
-  });
-
-  busyboxMinimal = busybox.override {
-    useMusl = true;
-    enableStatic = true;
-    enableMinimal = true;
-    extraConfig = ''
-      CONFIG_ASH y
-      CONFIG_ASH_BUILTIN_ECHO y
-      CONFIG_ASH_BUILTIN_TEST y
-      CONFIG_ASH_OPTIMIZE_FOR_SIZE y
-      CONFIG_MKDIR y
-      CONFIG_TAR y
-      CONFIG_UNXZ y
-    '';
-  };
-
   build =
 
     stdenv.mkDerivation {
@@ -150,7 +129,7 @@ rec {
 
         mkdir $out/on-server
         tar cvfJ $out/on-server/bootstrap-tools.tar.xz -C $out/pack .
-        cp ${busyboxMinimal}/bin/busybox $out/on-server
+        cp ${busyboxBootstrap}/bin/busybox $out/on-server
         chmod u+w $out/on-server/busybox
         nuke-refs $out/on-server/busybox
       ''; # */

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -80,6 +80,9 @@ rec {
         cp ${patchelf}/bin/* $out/bin
         cp ${curl-light}/bin/curl $out/bin
 
+        # Add ca certificates for curl
+        mkdir -p $out/etc/ssl/certs
+        cp -d ${cacert}/ca-bundle.crt $out/etc/ssl/certs
 
         # Copy what we need of GCC.
         cp -d ${gcc.cc}/bin/gcc $out/bin

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -17,7 +17,7 @@ let
 
   # Normal Depedencies
   optZlib = if isLight then null else shouldUsePkg zlib;
-  optOpenssl = if isLight then null else shouldUsePkg openssl;
+  optOpenssl = shouldUsePkg openssl;
   optLibssh2 = if isLight then null else shouldUsePkg libssh2;
   optLibnghttp2 = if isLight then null else shouldUsePkg libnghttp2;
   optC-ares = if isLight then null else shouldUsePkg c-ares;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9220,6 +9220,21 @@ let
 
   busybox = callPackage ../os-specific/linux/busybox { };
 
+  busyboxBootstrap = busybox.override {
+    useMusl = true;
+    enableStatic = true;
+    enableMinimal = true;
+    extraConfig = ''
+      CONFIG_ASH y
+      CONFIG_ASH_BUILTIN_ECHO y
+      CONFIG_ASH_BUILTIN_TEST y
+      CONFIG_ASH_OPTIMIZE_FOR_SIZE y
+      CONFIG_MKDIR y
+      CONFIG_TAR y
+      CONFIG_UNXZ y
+    '';
+  };
+
   cgmanager = callPackage ../os-specific/linux/cgmanager { };
 
   checkpolicy = callPackage ../os-specific/linux/checkpolicy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9221,7 +9221,7 @@ let
   busybox = callPackage ../os-specific/linux/busybox { };
 
   busyboxBootstrap = busybox.override {
-    useMusl = true;
+    useMusl = false; # Broken for all systems except x86_64-linux
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''


### PR DESCRIPTION
This change makes bootstrap-tools.tar.xz 500k larger which should be inconsequential given that bootstrap-tools is already 26MB. It also reduces the overall size of the bootstrap-tools tarball by dynamically determining what libraries it needs to include at build time. Note this is the first of 2 PR's
