### PR TITLE
Add patch for haskell-iconv to support GHC 7.10.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -284,4 +284,7 @@ self: super: {
   # Ugly hack to trigger a rebuild to fix the broken package on Hydra.
   crypto-api = appendConfigureFlag super.crypto-api "-fignore-me-1";
 
+  # Fix compilation under GHC 7.10, patch has been sent upstream.
+  iconv = appendPatch super.iconv ./iconv-fix-ghc710.patch;
+
 }

--- a/pkgs/development/haskell-modules/iconv-fix-ghc710.patch
+++ b/pkgs/development/haskell-modules/iconv-fix-ghc710.patch
@@ -1,0 +1,41 @@
+Running command 'diff -urN old-iconv new-iconv'
+Fri May 29 00:42:30 CEST 2015  Robert Helgesson <robert@rycee.net>
+  * Add Functor and Applicative instances for IConv
+  
+  This makes iconv successfully build under GHC 7.10.
+diff -urN old-iconv/Codec/Text/IConv/Internal.hs new-iconv/Codec/Text/IConv/Internal.hs
+--- old-iconv/Codec/Text/IConv/Internal.hs	2015-05-31 11:26:06.410968449 +0200
++++ new-iconv/Codec/Text/IConv/Internal.hs	2015-05-31 11:26:06.410968449 +0200
+@@ -49,6 +49,7 @@
+ import System.IO.Unsafe (unsafeInterleaveIO, unsafePerformIO)
+ import System.IO (hPutStrLn, stderr)
+ import Control.Exception (assert)
++import Control.Monad (ap, liftM)
+ 
+ import Prelude hiding (length)
+ 
+@@ -192,8 +193,8 @@
+  -}
+ 
+ 
+-----------------------------
+--- IConv monad
++----------------------------------------
++-- IConv functor, applicative, and monad
+ --
+ 
+ newtype IConv a = I {
+@@ -202,6 +203,13 @@
+         -> IO (Buffers, a)
+   }
+ 
++instance Functor IConv where
++  fmap = liftM
++
++instance Applicative IConv where
++  pure = return
++  (<*>) = ap
++
+ instance Monad IConv where
+   (>>=)  = bindI
+ --  m >>= f = (m `bindI` \a -> consistencyCheck `thenI` returnI a) `bindI` f


### PR DESCRIPTION
This adds a minimal patch to make `iconv` compile under GHC 7.10. It adds an `Applicative` instance for a custom data type that has a `Monad` instance. The patch has been sent upstream.
