### PR TITLE
snort: Fix version (download error)

### DIFF
--- a/pkgs/applications/networking/ids/snort/default.nix
+++ b/pkgs/applications/networking/ids/snort/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchurl, libpcap, pcre, libdnet, daq, zlib, flex, bison}:
 
 stdenv.mkDerivation rec {
-  version = "2.9.7.2";
+  version = "2.9.7.3";
   name = "snort-${version}";
   
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "http://www.snort.org/downloads/snort/${name}.tar.gz";
-    sha256 = "1gmlrh9ygpd5h6nnrr4090wk5n2yq2yrvwi7q6xbm6lxj4rcamyv";
+    sha256 = "0af2dkk122wzbba336v5y9l078nrfqy7gv5yl93lkicgi0xn3hwc";
   };
   
   buildInputs = [ libpcap pcre libdnet daq zlib flex bison ];


### PR DESCRIPTION
Fixes #8065 for me. (currently building locally... hopefully I can rebuild my system _now_, after beeing unable to build it for ... I guess 4 weeks now).
