### PR TITLE
minetest: LuaJIT, in-app mod store, better fonts and enable translations

### DIFF
--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchgit, cmake, irrlicht, libpng, bzip2, curl, libogg, jsoncpp
-, libjpeg, libXxf86vm, mesa, openal, libvorbis, x11, sqlite }:
+, libjpeg, libXxf86vm, mesa, openal, libvorbis, x11, sqlite, luajit, freetype
+, gettext
+}:
 
 let
   version = "0.4.12";
@@ -21,12 +23,15 @@ in stdenv.mkDerivation {
   src = sources.src;
 
   cmakeFlags = [
+    "-DENABLE_FREETYPE=1"
+    "-DENABLE_GETTEXT=1"
+    "-DCURL_INCLUDE_DIR=${curl}/include/curl"
     "-DIRRLICHT_INCLUDE_DIR=${irrlicht}/include/irrlicht"
   ];
 
   buildInputs = [
-    cmake irrlicht libpng bzip2 libjpeg curl libogg jsoncpp
-    libXxf86vm mesa openal libvorbis x11 sqlite
+    cmake irrlicht libpng bzip2 libjpeg curl libogg jsoncpp libXxf86vm mesa
+    openal libvorbis x11 sqlite luajit freetype gettext
   ];
 
   postInstall = ''


### PR DESCRIPTION
cURL was already a dependency, but the build was having some trouble
finding the headers. Just give it a little help and the in-app mod store
store actually works.

The rest of the configuration brings us closer to other distros, like
Fedora (LuaJIT)[1] and Debian (LuaJIT, LevelDB, FreeType, gettext)[2][3]

[1] http://pkgs.fedoraproject.org/cgit/minetest.git/tree/minetest.spec#n28
[2] https://anonscm.debian.org/cgit/pkg-games/minetest-v04x.git/tree/debian/control#n9
[3] https://anonscm.debian.org/cgit/pkg-games/minetest-v04x.git/tree/debian/rules#n56
