### PR TITLE
Adds antimony 0.8.0b CAD program

### DIFF
--- a/pkgs/applications/graphics/antimony/default.nix
+++ b/pkgs/applications/graphics/antimony/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchgit, libpng, python3, boost, mesa, qt5, ncurses }:
+
+let
+  gitRev    = "745eca3a2d2657c495d5509e9083c884e021d09c";
+  gitBranch = "master";
+  gitTag    = "0.8.0b";
+in 
+  stdenv.mkDerivation rec {
+    name    = "antimony-${version}";
+    version = gitTag;
+
+    src  = fetchgit {
+      url         = "git://github.com/mkeeter/antimony.git";
+      rev         = gitRev;
+      sha256      = "19ir3y5ipmfyygcn8mbxika4j3af6dfrv54dvhn6maz7dy8h30f4";
+    };
+
+    patches = [ ./paths-fix.patch ];
+
+    buildInputs = [
+      libpng python3 (boost.override { python = python3; })
+      mesa qt5.base ncurses
+    ];
+
+    configurePhase = ''
+      export GITREV=${gitRev}
+      export GITBRANCH=${gitBranch}
+      export GITTAG=${gitTag}
+
+      cd qt
+      export sourceRoot=$sourceRoot/qt
+      qmake antimony.pro PREFIX=$out
+    '';
+
+    meta = with stdenv.lib; {
+      description = "A computer-aided design (CAD) tool from a parallel universe";
+      homepage    = "https://github.com/mkeeter/antimony";
+      license     = licenses.mit;
+      platforms   = platforms.linux;
+    };
+  }

--- a/pkgs/applications/graphics/antimony/paths-fix.patch
+++ b/pkgs/applications/graphics/antimony/paths-fix.patch
@@ -1,0 +1,99 @@
+diff --git a/qt/antimony.pro b/qt/antimony.pro
+index 9d586f4..b055a6d 100644
+--- a/qt/antimony.pro
++++ b/qt/antimony.pro
+@@ -12,14 +12,9 @@ QMAKE_CXXFLAGS_RELEASE += -O3
+ 
+ QMAKE_CXXFLAGS += -Werror=switch
+ 
+-GITREV = $$system(git log --pretty=format:'%h' -n 1)
+-GITDIFF = $$system(git diff --quiet --exit-code || echo "+")
+-GITTAG = $$system(git describe --exact-match --tags 2> /dev/null)
+-GITBRANCH = $$system(git rev-parse --abbrev-ref HEAD)
+-
+-QMAKE_CXXFLAGS += "-D'GITREV=\"$${GITREV}$${GITDIFF}\"'"
+-QMAKE_CXXFLAGS += "-D'GITTAG=\"$${GITTAG}\"'"
+-QMAKE_CXXFLAGS += "-D'GITBRANCH=\"$${GITBRANCH}\"'"
++QMAKE_CXXFLAGS += "-D'GITREV=\"$$(GITREV)\"'"
++QMAKE_CXXFLAGS += "-D'GITTAG=\"$$(GITTAG)\"'"
++QMAKE_CXXFLAGS += "-D'GITBRANCH=\"$$(GITBRANCH)\"'"
+ 
+ OLD_GL_SET = $$(OLD_GL)
+ equals(OLD_GL_SET, "true") {
+@@ -125,11 +120,11 @@ macx {
+ }
+ 
+ linux {
+-    executable.path = /usr/local/bin
++    executable.path = $$(out)/bin
+     executable.files = antimony
+-    nodes_folder.path = /usr/local/bin/sb/nodes
++    nodes_folder.path = $$(out)/bin/sb/nodes
+     nodes_folder.files = ../py/nodes/*
+-    fab_folder.path = /usr/local/bin/sb/fab
++    fab_folder.path = $$(out)/bin/sb/fab
+     fab_folder.files = ../py/fab/*
+     INSTALLS += executable nodes_folder fab_folder
+ }
+diff --git a/qt/fab.pri b/qt/fab.pri
+index a54813b..b500536 100644
+--- a/qt/fab.pri
++++ b/qt/fab.pri
+@@ -54,7 +54,7 @@ DEFINES += '_STATIC_= '
+ 
+ linux {
+     QMAKE_CFLAGS += -std=gnu99
+-    QMAKE_CXXFLAGS += $$system(/usr/bin/python3-config --includes)
++    QMAKE_CXXFLAGS += $$system(python3-config --includes)
+     LIBS += -lpng
+ }
+ 
+diff --git a/qt/shared.pri b/qt/shared.pri
+index e7d0e3a..026eae3 100644
+--- a/qt/shared.pri
++++ b/qt/shared.pri
+@@ -39,41 +39,11 @@ macx {
+ }
+ 
+ linux {
+-    QMAKE_CXXFLAGS += $$system(/usr/bin/python3-config --includes)
+-    QMAKE_LFLAGS   += $$system(/usr/bin/python3-config --ldflags)
++    QMAKE_CXXFLAGS += $$system(python3-config --includes)
++    QMAKE_LFLAGS   += $$system(python3-config --ldflags)
+ 
+     # Even though this is in QMAKE_LFLAGS, the linker is picky about
+     # library ordering (so it needs to be here too).
+     LIBS += -lpython3.4m
+-
+-    # ldconfig is being used to find libboost_python, but it's in a different
+-    # place in different distros (and is not in the default $PATH on Debian).
+-    # First, check to see if it's on the default $PATH.
+-    system(which ldconfig > /dev/null) {
+-        LDCONFIG_BIN = "ldconfig"
+-    }
+-    # If that failed, then search for it in its usual places.
+-    isEmpty(LDCONFIG_BIN) {
+-        for(p, $$list(/sbin/ldconfig /usr/bin/ldconfig)) {
+-            exists($$p): LDCONFIG_BIN = $$p
+-        }
+-    }
+-    # If that search failed too, then exit with an error.
+-    isEmpty(LDCONFIG_BIN) {
+-        error("Could not find ldconfig!")
+-    }
+-
+-    # Check for different boost::python naming schemes
+-    LDCONFIG_OUT = $$system($$LDCONFIG_BIN -p|grep python)
+-    for (b, $$list(boost_python-py34 boost_python3)) {
+-        contains(LDCONFIG_OUT, "lib$${b}.so") {
+-            LIBS += "-l$$b"
+-            GOT_BOOST_PYTHON = True
+-        }
+-    }
+-
+-    # If we couldn't find boost::python, exit with an error.
+-    isEmpty(GOT_BOOST_PYTHON) {
+-        error("Could not find boost::python3")
+-    }
++    LIBS += -lboost_python3
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10451,6 +10451,8 @@ let
 
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
+  antimony = callPackage ../applications/graphics/antimony {};
+
   antiword = callPackage ../applications/office/antiword {};
 
   ardour = ardour4;


### PR DESCRIPTION
Adds the [antimony CAD program](https://vimeo.com/125111378) for Linux. (The application itself can be built on Linux and OS X. So this addition could be used to also add support for OS X.)

Builds the latest stable version ~~(0.7.9)~~ (0.8.0b), more information can be found on [antimony's github repo.](https://github.com/mkeeter/antimony).

I have provided [a standalone repo](https://github.com/rzetterberg/antimony-nixpkgs) that can be used with `nixos-unstable` to easily try out the project.
