### PR TITLE
rtmpdump_gnutls: add missing lib nettle & use git date format

### DIFF
--- a/pkgs/tools/video/rtmpdump/default.nix
+++ b/pkgs/tools/video/rtmpdump/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchgit, zlib
-, gnutlsSupport ? false, gnutls ? null
+, gnutlsSupport ? false, gnutls ? null, nettle ? null
 , opensslSupport ? true, openssl ? null
 }:
 
 # Must have an ssl library enabled
 assert (gnutlsSupport || opensslSupport);
-assert gnutlsSupport -> ((gnutlsSupport != null) && (!opensslSupport));
-assert opensslSupport -> ((openssl != null) && (!gnutlsSupport));
+assert gnutlsSupport -> gnutlsSupport != null && nettle != null && !opensslSupport;
+assert opensslSupport -> openssl != null && !gnutlsSupport;
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "rtmpdump-${version}";
-  version = "2.4";
+  version = "2015-01-15";
 
   src = fetchgit {
     url = git://git.ffmpeg.org/rtmpdump;
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.cc.isClang "CC=clang";
 
   propagatedBuildInputs = [ zlib ]
-    ++ optional gnutlsSupport gnutls
+    ++ optionals gnutlsSupport [ gnutls nettle ]
     ++ optional opensslSupport openssl;
 
   meta = {


### PR DESCRIPTION
@vcunat @pSub 
This was just changed recently to try an get rid of more instances of `propagatedBuildInputs`
https://github.com/NixOS/nixpkgs/commit/775c412e573fa405da130b93363c8f8bc1d9e0b3#diff-cff75ddd8906caa1da857c27ce0a660aR26
