### PR TITLE
virtualboxGuest: replace requires/after with bindsTo

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -49,8 +49,7 @@ in
       { description = "VirtualBox Guest Services";
 
         wantedBy = [ "multi-user.target" ];
-        requires = [ "dev-vboxguest.device" ];
-        after = [ "dev-vboxguest.device" ];
+        bindsTo = [ "dev-vboxguest.device" ];
 
         unitConfig.ConditionVirtualization = "oracle";
 


### PR DESCRIPTION
Otherwise multi-user.target is not met until 90 seconds of waiting for the device have passed. Looks like `ConditionVirtualization` is considered too late down the dep graph.
