### PR TITLE
Fix dd-agent buildInputs to include pythonPackages.psutil

### DIFF
--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -12,7 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "05flcbzpnmhf6qskkccbfk957sl9hhydlp4p5vqhs62hkpwmqwan";
   };
 
-  buildInputs = [ python unzip makeWrapper pythonPackages.psycopg2 pythonPackages.ntplib pythonPackages.simplejson pythonPackages.pyyaml pythonPackages.requests ];
+  buildInputs = [
+    python
+    unzip
+    makeWrapper
+    pythonPackages.psycopg2
+    pythonPackages.psutil
+    pythonPackages.ntplib
+    pythonPackages.simplejson
+    pythonPackages.pyyaml
+    pythonPackages.requests
+  ];
   propagatedBuildInputs = [ python tornado ];
 
   buildCommand = ''


### PR DESCRIPTION
When deploying current master version journalctl showed ImportErrors in the logs with message:
'No module named psutil' and systemctl dd-agent service failed to start. To fix I added
pythonPackages.psutil as a buildInputs entry and this fixed the issue.

See this Gist for journalctl errors for reference:
https://gist.github.com/mbbx6spp/59eefabbe708c335a31f
