### PR TITLE
gnutls: set certificate location

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   inherit src patches;
 
   configureFlags = [
+    # FIXME: perhaps use $SSL_CERT_FILE instead
+    "--with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt"
     "--disable-dependency-tracking"
     "--enable-fast-install"
   ] ++ stdenv.lib.optional guileBindings


### PR DESCRIPTION
This is a fast fix; it might be best to use $SSL_CERT_FILE. Tested on vlc with youtube https URLs. Discussed also on #8118.

Any better ideas?
