### PR TITLE
vim_configurable: change python version detection

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -108,26 +108,14 @@ composableDerivation {
 
       // edf {
         name = "python";
-        feat = "pythoninterp";
+        feat = "python${if python ? isPy3 then "3" else ""}interp";
         enable = {
           nativeBuildInputs = [ python ];
         } // lib.optionalAttrs stdenv.isDarwin {
           configureFlags
-            = [ "--enable-pythoninterp=yes"
-                "--with-python-config-dir=${python}/lib" ];
-        };
-      }
-
-      // edf {
-        name = "python3";
-        feat = "python3interp";
-        enable = {
-          nativeBuildInputs = [ pkgs.python3 ];
-        } // lib.optionalAttrs stdenv.isDarwin {
-          configureFlags
-            = [ "--enable-python3interp=yes"
-                "--with-python3-config-dir=${pkgs.python3}/lib"
-                "--disable-pythoninterp" ];
+            = [ "--enable-python${if python ? isPy3 then "3" else ""}interp=yes"
+                "--with-python${if python ? isPy3 then "3" else ""}-config-dir=${python}/lib"
+                "--disable-python${if python ? isPy3 then "" else "3"}interp" ];
         };
       }
 
@@ -160,7 +148,6 @@ composableDerivation {
   cfg = {
     luaSupport       = config.vim.lua or true;
     pythonSupport    = config.vim.python or true;
-    python3Support   = config.vim.python3 or false;
     rubySupport      = config.vim.ruby or true;
     nlsSupport       = config.vim.nls or false;
     tclSupport       = config.vim.tcl or false;


### PR DESCRIPTION
Instead of explicitly stating "I want version 3" or "I want version 2"
you now simply specify what the `python` argument will be, and
vim_configurable will set up the flags for you. `config.vim.python` must
be set, still.

This is a complete rewrite of the PR I submitted in June 2015.

(Branch name is a bit of a misnomer, but that's the name of the package I use to test.)
