### PR TITLE
hostname error check for fetch-ec2 job

### DIFF
--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -36,8 +36,9 @@ with lib;
             wget="wget -q --retry-connrefused -O -"
 
             ${optionalString (config.networking.hostName == "") ''
-              echo "setting host name..."
-              ${pkgs.nettools}/bin/hostname $($wget http://169.254.169.254/1.0/meta-data/hostname)
+              declare hostName="$($wget http://169.254.169.254/1.0/meta-data/hostname)"
+              echo "setting host name to $hostName ..."
+              ${pkgs.nettools}/bin/hostname $hostName || echo "host name set failed with code $?"
             ''}
 
             # Don't download the SSH key if it has already been injected


### PR DESCRIPTION
If a hostname generated from EC2 exceeds 64 characters, the job fails
obscurely and ssh keys aren't installed, leaving the instance unusable.
If setting hostname fails, carry on and log a message that you can
inspect when instance is running.
