### PR TITLE
fix crackxls libgsf dependency and naming problem

### DIFF
--- a/pkgs/tools/security/crackxls/default.nix
+++ b/pkgs/tools/security/crackxls/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchgit, autoconf, automake, openssl, libgsf }:
+{ stdenv, fetchgit, pkgconfig, autoconf, automake, openssl, libgsf, gmp }:
 
 stdenv.mkDerivation rec {
 
   name = "crackxls-${version}";
-  version = "v0.4";
+  version = "0.4";
 
   src = fetchgit {
     url = https://github.com/GavinSmith0123/crackxls2003.git;
-    rev = "refs/tags/${version}";
+    rev = "refs/tags/v${version}";
     sha256 = "0q5jl7hcds3f0rhly3iy4fhhbyh9cdrfaw7zdrazzf1wswwhyssz";
   };
 
-  buildInputs = [ openssl libgsf automake autoconf ];
+  buildInputs = [ pkgconfig autoconf automake openssl libgsf gmp ];
 
   installPhase =
   ''


### PR DESCRIPTION
Without pkgconfig crackxls wouldn't find libgsf which is optional but useful.
Also the v in the name prevents nix from recognizing the version part.
Sorry for the sloppiness.
