### PR TITLE
removing lingering dependence on atlas with numpy

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7826,7 +7826,7 @@ let
     setupPyBuildFlags = ["--fcompiler='gnu95'"];
 
     buildInputs = [ pkgs.gfortran self.nose ];
-    propagatedBuildInputs = [ pkgs.atlas ];
+    propagatedBuildInputs = [ support.atlas ];
 
     meta = {
       description = "Scientific tools for Python";
@@ -9156,12 +9156,12 @@ let
     version = "1.5.3";
     # FAIL:test_generate_entry and test_time
     # both tests fail due to time issue that doesn't seem to matter in practice
-    doCheck = false; 
+    doCheck = false;
     src = pkgs.fetchurl {
       url = "https://github.com/pyblosxom/pyblosxom/archive/v${version}.tar.gz";
       sha256 = "0de9a7418f4e6d1c45acecf1e77f61c8f96f036ce034493ac67124626fd0d885";
     };
-  
+
     propagatedBuildInputs = with self; [ pygments markdown ];
 
     meta = {

--- a/pkgs/top-level/python-support/numpy-scipy-support.nix
+++ b/pkgs/top-level/python-support/numpy-scipy-support.nix
@@ -8,7 +8,9 @@
 }:
 
 {
-
+  # Re-export atlas here so that it can be sure that the same one will be used
+  # in the propagatedBuildInputs.
+  inherit atlas;
   # First "install" the package, then import what was installed, and call the
   # .test() function, which will run the test suite.
   checkPhase = ''
@@ -40,7 +42,7 @@
     runHook postCheck
   '';
 
-  # Creates a site.cfg telling the setup script where to find depended-on 
+  # Creates a site.cfg telling the setup script where to find depended-on
   # math libraries.
   preBuild = ''
     echo "Creating site.cfg file..."


### PR DESCRIPTION
@peti @domenkozar 

Wah wah. I had changed numpy to depend on `atlasWithLapack`, but still had `atlas` listed as a `propagatedBuildInput`, so it was still being built twice. This fixes that by having the `numpy-scipy-support.nix` expression re-export atlas, so that if in the future atlas gets changed again, there won't be a need to change it in multiple places here.
