### PR TITLE
systemd: Use upstream tmpfiles.d rules

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -114,10 +114,6 @@ in
       ''
         # Various log/runtime directories.
 
-        touch /run/utmp # must exist
-        chgrp ${toString config.ids.gids.utmp} /run/utmp
-        chmod 664 /run/utmp
-
         mkdir -m 0755 -p /run/nix/current-load # for distributed builds
         mkdir -m 0700 -p /run/nix/remote-stores
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -638,13 +638,6 @@ in
     system.activationScripts.systemd = stringAfter [ "groups" ]
       ''
         mkdir -m 0755 -p /var/lib/udev
-        mkdir -p /var/log/journal
-        chmod 0755 /var/log/journal
-
-        # Make all journals readable to users in the wheel and adm
-        # groups, in addition to those in the systemd-journal group.
-        # Users can always read their own journals.
-        ${pkgs.acl}/bin/setfacl -nm g:wheel:rx,d:g:wheel:rx,g:adm:rx,d:g:adm:rx /var/log/journal || true
 
         if ! [ -e /etc/machine-id ]; then
           ${systemd}/bin/systemd-machine-id-setup
@@ -730,16 +723,13 @@ in
         startSession = true;
       };
 
+    environment.etc."tmpfiles.d/systemd.conf".source = "${systemd}/example/tmpfiles.d/systemd.conf";
     environment.etc."tmpfiles.d/x11.conf".source = "${systemd}/example/tmpfiles.d/x11.conf";
 
     environment.etc."tmpfiles.d/nixos.conf".text =
       ''
         # This file is created automatically and should not be modified.
         # Please change the option ‘systemd.tmpfiles.rules’ instead.
-
-        z /var/log/journal 2755 root systemd-journal - -
-        z /var/log/journal/%m 2755 root systemd-journal - -
-        z /var/log/journal/%m/* 0640 root systemd-journal - -
 
         ${concatStringsSep "\n" cfg.tmpfiles.rules}
       '';


### PR DESCRIPTION
This fixes a failing assert in systemd-timesyncd (issue #5913) as it
expects the directory `/run/systemd/netif/links/` to exist, and nothing in
NixOS currently creates it.

Also we get a net reduction in our code as rules for /run/utmp and
/var/log/journal are also provided by the same upstream file.

For reference, these are the installed rules:

```
d /run/user 0755 root root -
F! /run/utmp 0664 root utmp -

d /run/systemd/ask-password 0755 root root -
d /run/systemd/seats 0755 root root -
d /run/systemd/sessions 0755 root root -
d /run/systemd/users 0755 root root -
d /run/systemd/machines 0755 root root -
d /run/systemd/shutdown 0755 root root -
d /run/systemd/netif 0755 systemd-network systemd-network -
d /run/systemd/netif/links 0755 systemd-network systemd-network -
d /run/systemd/netif/leases 0755 systemd-network systemd-network -

d /run/log 0755 root root -

z /run/log/journal 2755 root systemd-journal - -
Z /run/log/journal/%m ~2750 root systemd-journal - -

a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x
A+ /run/log/journal/%m - - - - group:adm:r-x,group:wheel:r-x

z /var/log/journal 2755 root systemd-journal - -
z /var/log/journal/%m 2755 root systemd-journal - -

a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x
A+ /var/log/journal/%m - - - - group:adm:r-x,group:wheel:r-x

d /var/lib/systemd 0755 root root -
d /var/lib/systemd/coredump 0755 root root 3d
```

This is based on the `systemd-219` branch since https://github.com/NixOS/nixpkgs/commit/f19b58fb6a5cc55af6d8d8ca7979f8e64255d2d0 is a prerequisite, and avoids a merge conflict as well.

cc @edolstra 
