### PR TITLE
Add Calamares: A distribution independent installer framework.

### DIFF
--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, boost }:
+{ stdenv, fetchurl, cmake, boost, makePIC ? false }:
 
 stdenv.mkDerivation {
   name = "libyaml-cpp-0.5.1";
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ cmake boost ];
+
+  cmakeFlags = stdenv.lib.optionals makePIC [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ];
 
   meta = with stdenv.lib; {
     homepage = http://code.google.com/p/yaml-cpp/;

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchgit, cmake, qt5, polkit_qt5, libyamlcpp, python, boost, parted
+, extra-cmake-modules, kconfig, ki18n, kcoreaddons, solid, utillinux, libatasmart }:
+
+stdenv.mkDerivation rec {
+  name = "calamares-${version}";
+  version = "1.0";
+
+  src = fetchgit {
+    url = "https://github.com/calamares/calamares.git";
+    rev = "dabfb68a68cb012a90cd7b94a22e1ea08f7dd8ad";
+    sha256 = "2851ce487aaac61d2df342a47f91ec87fe52ff036227ef697caa7056fe5f188c";
+  };
+
+  buildInputs = [
+    cmake qt5.base qt5.tools libyamlcpp python boost polkit_qt5 parted
+    extra-cmake-modules kconfig ki18n kcoreaddons solid utillinux libatasmart
+  ];
+
+  cmakeFlags = [
+    "-DPYTHON_LIBRARY=${python}/lib/libpython${python.majorVersion}m.so"
+    "-DPYTHON_INCLUDE_DIR=${python}/include/python${python.majorVersion}m"
+    "-DWITH_PARTITIONMANAGER=1"
+  ];
+
+  preInstall = ''
+    substituteInPlace cmake_install.cmake --replace "${polkit_qt5}" "$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Distribution-independent installer framework";
+    license = licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ tstrobel ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1639,6 +1639,13 @@ let
     ghostscript = null;
   };
 
+  calamares = callPackage ../tools/misc/calamares rec {
+    python = python3;
+    boost = callPackage ../development/libraries/boost/1.57.nix { python=python3; };
+    libyamlcpp = callPackage ../development/libraries/libyaml-cpp { makePIC=true; boost=boost; };
+    inherit (kf5_stable) extra-cmake-modules kconfig ki18n kcoreaddons solid;
+  };
+
   grub = callPackage_i686 ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
     automake = automake112x; # fails with 13 and 14


### PR DESCRIPTION
Replaces #6285.
