### PR TITLE
Fix firefox-bin icon path

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation {
       [Desktop Entry]
       Type=Application
       Exec=$out/bin/firefox
-      Icon=$out/lib/firefox-bin-${version}/chrome/icons/default/default256.png
+      Icon=$out/usr/lib/firefox-bin-${version}/browser/icons/mozicon128.png
       Name=Firefox
       GenericName=Web Browser
       Categories=Application;Network;


### PR DESCRIPTION
It seems the old icon path didn't exist, at least not on my branch.

This commit points the desktop file to the highest-quality icon I could find in the install path.  The highest resolution under the old `chrome/icons/default` path was 48px.
