### PR TITLE
kodi: Enable RTMP support

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -21,7 +21,7 @@
 , samba ? null, sambaSupport ? true
 , libmicrohttpd, bash
 # TODO: would be nice to have nfsSupport (needs libnfs library)
-# TODO: librtmp
+, rtmpdump ? null, rtmpSupport ? true
 , libvdpau ? null, vdpauSupport ? true
 , libpulseaudio ? null, pulseSupport ? true
 , libcec ? null, cecSupport ? true
@@ -34,6 +34,7 @@ assert sambaSupport -> samba != null;
 assert vdpauSupport -> libvdpau != null;
 assert pulseSupport -> libpulseaudio != null;
 assert cecSupport   -> libcec != null;
+assert rtmpSupport  -> rtmpdump != null;
 
 let
   rel = "Helix";
@@ -75,7 +76,8 @@ in stdenv.mkDerivation rec {
     ++ lib.optional sambaSupport samba
     ++ lib.optional vdpauSupport libvdpau
     ++ lib.optional pulseSupport libpulseaudio
-    ++ lib.optional cecSupport libcec;
+    ++ lib.optional cecSupport libcec
+    ++ lib.optional rtmpSupport rtmpdump;
 
     dontUseCmakeConfigure = true;
 
@@ -96,7 +98,8 @@ in stdenv.mkDerivation rec {
     ]
     ++ lib.optional (!sambaSupport) "--disable-samba"
     ++ lib.optional vdpauSupport "--enable-vdpau"
-    ++ lib.optional pulseSupport "--enable-pulse";
+    ++ lib.optional pulseSupport "--enable-pulse"
+    ++ lib.optional rtmpSupport "--enable-rtmp";
 
     postInstall = ''
       for p in $(ls $out/bin/) ; do
@@ -108,7 +111,8 @@ in stdenv.mkDerivation rec {
           --prefix LD_LIBRARY_PATH ":" "${systemd}/lib" \
           --prefix LD_LIBRARY_PATH ":" "${libmad}/lib" \
           --prefix LD_LIBRARY_PATH ":" "${libvdpau}/lib" \
-          --prefix LD_LIBRARY_PATH ":" "${libcec}/lib"
+          --prefix LD_LIBRARY_PATH ":" "${libcec}/lib" \
+          --prefix LD_LIBRARY_PATH ":" "${rtmpdump}/lib"
       done
     '';
 


### PR DESCRIPTION
Ports over similar XBMC changes from
d221fd91a3d156bb3cdb4789ee8e068d0641ee8d.

I've tested this against my locally installed nixpkgs (f93a8ee), but not against master.  There was one trivial rebase conflict.  I'm pretty sure this is safe, but I apologize in advance if there are any silly typos or other issues in here.
