### PR TITLE
Move Loxodo package and add an icon

### DIFF
--- a/pkgs/applications/misc/loxodo/default.nix
+++ b/pkgs/applications/misc/loxodo/default.nix
@@ -16,6 +16,16 @@ py.buildPythonPackage rec {
 
   postInstall = ''
     mv $out/bin/loxodo.py $out/bin/loxodo
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/loxodo.desktop <<EOF
+    [Desktop Entry]
+    Type=Application
+    Exec=$out/bin/loxodo
+    Icon=$out/lib/${python.libPrefix}/site-packages/resources/loxodo-icon.png
+    Name=Loxodo
+    GenericName=Password Vault
+    Categories=Application;Other;
+    EOF
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/loxodo/default.nix
+++ b/pkgs/applications/misc/loxodo/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, python27Packages, fetchgit }:
+let
+  py = python27Packages;
+  python = py.python;
+in
+py.buildPythonPackage rec {
+  name = "loxodo-0.20150124";
+
+  src = fetchgit {
+    url = "https://github.com/sommer/loxodo.git";
+    rev = "6c56efb4511fd6f645ad0f8eb3deafc8071c5795";
+    sha256 = "02whmv4am8cz401rplplqzbipkyf0wd69z43sd3yw05rh7f3xbs2";
+  };
+
+  propagatedBuildInputs = with py; [ wxPython python.modules.readline ];
+
+  postInstall = ''
+    mv $out/bin/loxodo.py $out/bin/loxodo
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Password Safe V3 compatible password vault";
+    homepage = http://www.christoph-sommer.de/loxodo/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11674,6 +11674,8 @@ let
 
   lmms = callPackage ../applications/audio/lmms { };
 
+  loxodo = callPackage ../applications/misc/loxodo { };
+
   lrzsz = callPackage ../tools/misc/lrzsz { };
 
   luakit = callPackage ../applications/networking/browsers/luakit {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6662,27 +6662,6 @@ let
     propagatedBuildInputs = with self; [ unittest2 six ];
   };
 
-  loxodo = buildPythonPackage {
-    name = "loxodo-0.20150124";
-    disabled = isPy3k;
-
-    src = pkgs.fetchgit {
-      url = "https://github.com/sommer/loxodo.git";
-      rev = "6c56efb4511fd6f645ad0f8eb3deafc8071c5795";
-      sha256 = "02whmv4am8cz401rplplqzbipkyf0wd69z43sd3yw05rh7f3xbs2";
-    };
-
-    propagatedBuildInputs = with self; [ wxPython modules.readline ];
-    postInstall = "mv $out/bin/loxodo.py $out/bin/loxodo";
-
-    meta = {
-      description = "A Password Safe V3 compatible password vault";
-      homepage = http://www.christoph-sommer.de/loxodo/;
-      license = licenses.gpl2Plus;
-      platforms = platforms.linux;
-    };
-  };
-
   lxml = buildPythonPackage ( rec {
     name = "lxml-3.3.6";
 


### PR DESCRIPTION
This is a user-facing app, so I figured it made more sense for it to be a top-level package.  It was my mistake to hide it in python-packages.nix in the first place.

I also added a desktop file so the icon and menu entries show up properly.

This was built and tested on top of my nixos-unstable system (f93a8ee) then rebased on to master.  I don't expect any issues, but it's possible that the rebase could have introduced some bugs.
