### PR TITLE
make a wrapper so that dunst can find dbus-launch

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchurl, coreutils , unzip, which, pkgconfig , dbus
-, freetype, xdg_utils , libXext, glib, pango , cairo, libX11, libnotify
-, libxdg_basedir , libXScrnSaver, xproto, libXinerama , perl, gdk_pixbuf
+{ stdenv, fetchurl, coreutils, unzip, which, pkgconfig, dbus
+, freetype, xdg_utils, libXext, glib, pango, cairo, libX11, libnotify
+, libxdg_basedir, libXScrnSaver, xproto, libXinerama, perl, gdk_pixbuf
+, dbus_daemon, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -15,12 +16,17 @@ stdenv.mkDerivation rec {
   buildInputs =
   [ coreutils unzip which pkgconfig dbus freetype libnotify gdk_pixbuf
     xdg_utils libXext glib pango cairo libX11 libxdg_basedir
-    libXScrnSaver xproto libXinerama perl];
+    libXScrnSaver xproto libXinerama perl dbus_daemon makeWrapper ];
 
   buildPhase = ''
     export VERSION=${version};
     export PREFIX=$out;
     make dunst;
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/dunst" \
+      --prefix PATH : '${dbus_daemon}/bin'
   '';
 
   meta = {


### PR DESCRIPTION
Prior to this change, the following would fail
  nix-shell --pure -p dunst --command dunst
while this would succeed
  nix-shell --pure -p dunst -p dbus_daemon --command dunst

because dunst tries to execve 'dbus-launch'. The same issue hit if dunst
was used inside a (user) systemd service (which is what I actually care
about).
