### PR TITLE
kernel-config: Enable framebuffer console for BIOS systems & /proc/config.gz for ARM

### DIFF
--- a/nixos/doc/manual/installation/installing-uefi.xml
+++ b/nixos/doc/manual/installation/installing-uefi.xml
@@ -41,10 +41,6 @@ changes:
     <option>boot.loader.efi</option> and <option>boot.loader.gummiboot</option>
     as well.</para>
   </listitem>
-  <listitem>
-    <para>To see console messages during early boot, add <literal>"fbcon"</literal>
-    to your <option>boot.initrd.kernelModules</option>.</para>
-  </listitem>
 </itemizedlist>
 </para>
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -42,9 +42,6 @@ with lib;
   # Add Memtest86+ to the CD.
   boot.loader.grub.memtest86.enable = true;
 
-  # Get a console as soon as the initrd loads fbcon on EFI boot.
-  boot.initrd.kernelModules = [ "fbcon" ];
-
   # Allow the user to log in as root without a password.
   users.extraUsers.root.initialHashedPassword = "";
 }

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -131,6 +131,8 @@ with stdenv.lib;
   FB_SIS_300 y
   FB_SIS_315 y
   FB_3DFX_ACCEL y
+  FB_VESA y
+  FRAMEBUFFER_CONSOLE y
   ${optionalString (versionOlder version "3.9" || stdenv.system == "i686-linux") ''
     FB_GEODE y
   ''}

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -54,6 +54,7 @@ with stdenv.lib;
   STANDALONE n
 
   # Make /proc/config.gz available.
+  IKCONFIG y
   IKCONFIG_PROC y
 
   # Optimize with -O2, not -Os.


### PR DESCRIPTION
The first commit is needed to fix #8139 as some EFI fixes to GRUB (commit 159fed47bcfab67d36d4959fb3ac952a7ad9128c) now apparently cause the kernel  to boot in graphical/framebuffer mode instead of text mode. The second one fixes `/proc/config.gz` not existing on ARM even though it should.

I tested the FB_VESA thing on i686 Virtualbox only, no other x86 NixOS systems around.

cc @wkennington for #8139, and kernel maintainers @thoughtpolice @shlevy 
