### PR TITLE
zfs: Fix systemd warning

### DIFF
--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, utillinux, nukeReferences
+{ stdenv, fetchFromGitHub, autoreconfHook, utillinux, nukeReferences, coreutils
 , configFile ? "all"
 
 # Userspace dependencies
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
     substituteInPlace ./etc/zfs/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
     substituteInPlace ./cmd/zed/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
     substituteInPlace ./module/Makefile.in        --replace "/bin/cp"                 "cp"
-
+    substituteInPlace ./etc/systemd/system/zfs-share.service.in \
+        --replace "@bindir@/rm " "${coreutils}/bin/rm "
     ./autogen.sh
   '';
 


### PR DESCRIPTION
The `zfs-share` service was trying to execute the `rm` binary, but it
was providing an invalid `/bin` path.

This should fix #8171.
