### PR TITLE
youtube-dl: remove unnecessary pandoc dependency

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, makeWrapper, python, zip, pandoc, ffmpeg }:
+{ manuals ? true
+, stdenv, fetchurl, makeWrapper, python, zip, 
+pandoc ? null 
+, ffmpeg }:
+
+assert manuals -> pandoc != null;
 
 stdenv.mkDerivation rec {
   name = "youtube-dl-${version}";
@@ -9,7 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lgxir2i5ipplg57wk8gnbbsdrk7szqnyb1bxr97f3h0rbm4dfij";
   };
 
-  nativeBuildInputs = [ pandoc ];
+  nativeBuildInputs = [ ]
+    ++ stdenv.lib.optional manuals pandoc;
 
   buildInputs = [ python makeWrapper zip ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3384,7 +3384,9 @@ let
   # To expose more packages for Yi, override the extraPackages arg.
   yi = callPackage ../applications/editors/yi/wrapper.nix { };
 
-  youtube-dl = callPackage ../tools/misc/youtube-dl { };
+  youtube-dl = callPackage ../tools/misc/youtube-dl {
+  	manuals = false;
+   };
 
   zbar = callPackage ../tools/graphics/zbar {
     pygtk = lib.overrideDerivation pygtk (x: {


### PR DESCRIPTION
Per upstream developer [1], pandoc is not needed for users or developers; only for generating the manpage/README. The manpage/README is pre-generated, so this dependency is just adding a lot of bloat for no reason.

[1] https://github.com/rg3/youtube-dl/issues/581
