### PR TITLE
eval-config.nix: Set modulePath to the path to NixOS modules

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -22,8 +22,17 @@
   check ? true
 , prefix ? []
 , lib ? import ../../lib
-}:
+}@args: if !(builtins ? modulePath) then let
+  scope = {
+    scopedImport = newScope: scopedImport (scope // newScope);
 
+    import = scopedImport scope;
+
+    modulePath = ../modules;
+
+    builtins = builtins // (removeAttrs scope [ "builtins" ]);
+  };
+in scopedImport scope ./eval-config.nix args else
 let extraArgs_ = extraArgs; pkgs_ = pkgs; system_ = system;
     extraModules = let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
                    in if e == "" then [] else [(import (builtins.toPath e))];


### PR DESCRIPTION
Alternative (not necessarily superior) to #8188
