### PR TITLE
bittorrentsync: fix storage_path.

### DIFF
--- a/nixos/modules/services/networking/btsync.nix
+++ b/nixos/modules/services/networking/btsync.nix
@@ -208,8 +208,8 @@ in
 
       storagePath = mkOption {
         type = types.path;
-        default = "/var/lib/btsync";
-        example = "/var/lib/btsync";
+        default = "/var/lib/btsync/";
+        example = "/var/lib/btsync/";
         description = ''
           Where to store the bittorrent sync files.
         '';


### PR DESCRIPTION
If this path is a symlink, btsync won't be able to read it if it's not ending with "/".

As seen in https://github.com/NixOS/nixpkgs/commit/f02d4ec9ed39694e04aa52937a9f73e217aff7f8
Broken in https://github.com/NixOS/nixpkgs/commit/0539ed477151a3adfff5012cabff0527a9a8c0bb
