### PR TITLE
added zopfli package

### DIFF
--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "zopfli-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "zopfli";
+    rev = name;
+    name = "${name}-src";
+    sha256 = "0r2k3md24y5laslzsph7kh4synm5az4ppv64idrvjk5yh2qwwb62";
+  };
+
+  installPhase = ''
+    install -D zopfli $out/bin/zopfli
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/google/zopfli;
+    description = "A compression tool to perform very good, but slow, deflate or zlib compression";
+    longDescription =
+      ''Zopfli Compression Algorithm is a compression library programmed
+        in C to perform very good, but slow, deflate or zlib compression.
+
+        This library can only compress, not decompress. Existing zlib or
+        deflate libraries can decompress the data.
+      '';
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with maintainers; [ roconnor bobvanderlinden ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14185,6 +14185,8 @@ let
 
   zdfmediathk = callPackage ../applications/video/zdfmediathk { };
 
+  zopfli = callPackage ../tools/compression/zopfli { };
+
   myEnvFun = import ../misc/my-env {
     inherit substituteAll pkgs;
     inherit (stdenv) mkDerivation;


### PR DESCRIPTION
Zopfli is a compression library and command-line tool to perform very good, but slow, deflate or zlib compression. Since 1.0.0 does not yet have make rules to create a shared library, this patch only includes the command-line tool.
