### PR TITLE
add qt decrypt ssl traffic option

### DIFF
--- a/pkgs/development/libraries/qt-5/5.4/0100-ssl.patch
+++ b/pkgs/development/libraries/qt-5/5.4/0100-ssl.patch
@@ -1,0 +1,13 @@
+diff --git a/qtbase/src/network/ssl/qsslsocket_openssl.cpp b/qtbase/src/network/ssl/qsslsocket_openssl.cpp
+index 8833e3f..c56d381 100644
+--- a/qtbase/src/network/ssl/qsslsocket_openssl.cpp
++++ b/qtbase/src/network/ssl/qsslsocket_openssl.cpp
+@@ -47,7 +47,7 @@
+ ****************************************************************************/
+ 
+ //#define QSSLSOCKET_DEBUG
+-//#define QT_DECRYPT_SSL_TRAFFIC
++#define QT_DECRYPT_SSL_TRAFFIC
+ 
+ #include "qssl_p.h"
+ #include "qsslsocket_openssl_p.h"

--- a/pkgs/development/libraries/qt-5/5.4/default.nix
+++ b/pkgs/development/libraries/qt-5/5.4/default.nix
@@ -20,6 +20,7 @@
 
 # options
 , developerBuild ? false
+, decryptSslTraffic ? false
 }:
 
 with autonix;
@@ -61,7 +62,7 @@ let
         # GNOME dependencies are not used unless gtkStyle == true
         inherit (gnome) libgnomeui GConf gnome_vfs;
         bison = bison2; # error: too few arguments to function 'int yylex(...
-        inherit developerBuild srcs version;
+        inherit developerBuild srcs version decryptSslTraffic;
       };
 
       connectivity = callPackage

--- a/pkgs/development/libraries/qt-5/5.4/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/5.4/qtbase.nix
@@ -20,6 +20,7 @@
 , buildTests ? false
 , developerBuild ? false
 , gtkStyle ? false, libgnomeui, GConf, gnome_vfs, gtk
+, decryptSslTraffic ? false
 }:
 
 with stdenv.lib;
@@ -68,7 +69,8 @@ stdenv.mkDerivation {
       (substituteAll { src = ./0011-dlopen-openssl.patch; inherit openssl; })
       (substituteAll { src = ./0012-dlopen-dbus.patch; dbus_libs = dbus; })
       ./0013-xdg_config_dirs.patch
-    ];
+    ]
+    ++ (if decryptSslTraffic then [ ./0100-ssl.patch ] else []);
 
   preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/qtbase/lib:$PWD/qtbase/plugins/platforms:$PWD/qttools/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
this introduces an argument to qt5 that if enabled allows
e.g. wireshark to show decrypted ssl traffic from a qt
application. 
Therefore, a #define has to be uncommented according to https://web.archive.org/web/20131009105758/http://peter.hartmann.tk/blog/2013/04/decrypt-ssl-traffic-of-qt-programs-in-wireshark.html), so qt has to be recompiled.
I used this together with pkgs.replaceDependency to not have to recompile everything which depends on it (i. e. I have something like that in .nixpkgs/config.nix where xyz is the application I want to debug:
packageOverrides = pkgs: rec {
    xzy  = pkgs.replaceDependency { 
        drv = pkgs.xyz;
        oldDependency = pkgs.qt5.base;
        newDependency = pkgs.qt5.base.override { decryptSslTraffic = true; };
    };
})
