### PR TITLE
nixos/postfix: make symlink /var/mail -> /var/spool/mail

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -380,6 +380,7 @@ in
             ${pkgs.coreutils}/bin/chmod -R ug+rwX /var/postfix/queue
             ${pkgs.coreutils}/bin/chown root:root /var/spool/mail
             ${pkgs.coreutils}/bin/chmod a+rwxt /var/spool/mail
+            ${pkgs.coreutils}/bin/ln -sf /var/spool/mail /var/mail
 
             ln -sf "${pkgs.postfix}/share/postfix/conf/"* /var/postfix/conf
 


### PR DESCRIPTION
This solves the problem of e.g. mutt not finding mail unless the user
sets MAIL=/var/spool/mail/$USER.

The default MAIL variable seems come from bash. Reasons for adding
symlink instead of changing MAIL default in bash:
- No need to rebuild world
- FHS recommends /var/mail over /var/spool/mail anyway[1]. Better fix
  NixOS mail location than change MAIL in bash to something that doesn't
  work on non-NixOS (however unlikely that users run nixpkgs bash on a
  non-NixOS distro...).

[1] http://www.pathname.com/fhs/pub/fhs-2.3.html#VARMAILUSERMAILBOXFILES
