### PR TITLE
Add fuse-7z-ng package

### DIFF
--- a/pkgs/tools/filesystems/fuse-7z-ng/default.nix
+++ b/pkgs/tools/filesystems/fuse-7z-ng/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, fuse, p7zip, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "fuse-7z-ng";
+
+  src = fetchFromGitHub {
+    owner = "kedazo";
+    repo = "fuse-7z-ng";
+    rev = "eb5efb1f30";
+    sha256 = "17v1gcmg5q661b047zxjar735i4d3508dimw1x3z1pk4d1zjhp3x";
+  };
+
+  buildInputs = [ autoreconfHook pkgconfig fuse makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/fuse-7z-ng  \
+      --prefix LD_LIBRARY_PATH : ${p7zip}/lib/p7zip
+  '';
+
+  meta = {
+    description = "Mount archive formats using fuse and p7zip";
+    longDescription = ''
+    fuse-7z-ng is a FUSE file system that uses the p7zip
+    library to access all archive formats supported by 7-zip.
+
+    This project is a fork of fuse-7z ( https://gitorious.org/fuse-7z/fuse-7z ).
+    '';
+    homepage = https://github.com/kedazo/fuse-7z-ng/;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1526,6 +1526,8 @@ let
   fuseiso = callPackage ../tools/filesystems/fuseiso { };
 
   fuse_zip = callPackage ../tools/filesystems/fuse-zip { };
+  
+  fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
   exfat = callPackage ../tools/filesystems/exfat { };
 


### PR DESCRIPTION
Fuse-7z-ng allows you to mount various archive file types with fuse.
