### PR TITLE
youtube-dl: make a python package

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, makeWrapper, python, zip, ffmpeg, pandoc ? null }:
+{ stdenv, fetchurl, makeWrapper, buildPythonPackage, zip, ffmpeg
+, pandoc ? null }:
 
 # Pandoc is required to build the package's man page. Release tarballs
 # contain a formatted man page already, though, so it's fine to pass
@@ -7,7 +8,7 @@
 # case someone wants to use this derivation to build a Git version of
 # the tool that doesn't have the formatted man page included.
 
-stdenv.mkDerivation rec {
+buildPythonPackage rec {
   name = "youtube-dl-${version}";
   version = "2015.05.29";
 
@@ -16,18 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "0lgxir2i5ipplg57wk8gnbbsdrk7szqnyb1bxr97f3h0rbm4dfij";
   };
 
-  buildInputs = [ python makeWrapper zip pandoc ];
-
-  patchPhase = "rm youtube-dl";
-
-  configurePhase = ''
-    makeFlagsArray=( PREFIX=$out SYSCONFDIR=$out/etc PYTHON=${python}/bin/python )
-  '';
+  buildInputs = [ makeWrapper zip pandoc ];
 
   # Ensure ffmpeg is available in $PATH for post-processing & transcoding support.
-  postInstall = ''
-    wrapProgram $out/bin/youtube-dl --prefix PATH : "${ffmpeg}/bin"
-  '';
+  postInstall = stdenv.lib.optionalString (ffmpeg != null) 
+    ''wrapProgram $out/bin/youtube-dl --prefix PATH : "${ffmpeg}/bin"'';
 
   meta = with stdenv.lib; {
     homepage = "http://rg3.github.com/youtube-dl/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3391,12 +3391,6 @@ let
   # To expose more packages for Yi, override the extraPackages arg.
   yi = callPackage ../applications/editors/yi/wrapper.nix { };
 
-  youtube-dl = callPackage ../tools/misc/youtube-dl {
-    # Release versions don't need pandoc because the formatted man page
-    # is included in the tarball.
-    pandoc = null;
-  };
-
   zbar = callPackage ../tools/graphics/zbar {
     pygtk = lib.overrideDerivation pygtk (x: {
       gtk = gtk2;
@@ -14774,6 +14768,7 @@ let
   lttngUst = lttng-ust;  # added 2014-07-31
   jquery_ui = jquery-ui;  # added 2014-09-07
   youtubeDL = youtube-dl;  # added 2014-10-26
+  youtube-dl = pythonPackages.youtube-dl; # added 2015-06-07
   rdiff_backup = rdiff-backup;  # added 2014-11-23
   htmlTidy = html-tidy;  # added 2014-12-06
   libtidy = html-tidy;  # added 2014-12-21

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13466,6 +13466,19 @@ let
     };
   });
 
+  youtube-dl = callPackage ../tools/misc/youtube-dl {
+    # Release versions don't need pandoc because the formatted man page
+    # is included in the tarball.
+    pandoc = null;
+  };
+
+  youtube-dl-light = callPackage ../tools/misc/youtube-dl {
+    # Release versions don't need pandoc because the formatted man page
+    # is included in the tarball.
+    ffmpeg = null;
+    pandoc = null;
+  };
+
   zbase32 = buildPythonPackage (rec {
     name = "zbase32-1.1.2";
 


### PR DESCRIPTION
This allows youtube-dl to support all versions of python, and be built
correctly even when the python version is overridden by the user.

An alias to youtube-dl has been added which points to the default python
version's youtube-dl.

Also, ffmpeg has been made into an optional dependency. If ffmpeg is set
to 'null' then it will not be built and there will be no wrapper for it
either. An extra package, youtube-dl-light, is the same as youtube-dl
but without the ffmpeg dependency.

---

So that's the commit message. There's some reasoning behind this as well. When building the package using the Makefile, `$(PYTHON)` is not always used. Yes, we could patch the Makefile to use `$(PYTHON)` correctly, but I think that is the wrong solution for a python package. Changing this also makes the makeFlagsArray unneeded. On another note, when the package is created using the Makefile I don't think that `youtube-dl` is detected as needing an interpreter change, so it simply uses `#!/usr/bin/env python`, which is not what we want.

Looking at the pandoc dependency, I think that if we're building the python package this way, and not using the Makefile, that pandoc is not needed at all, and can be removed from the package altogether.
