### PR TITLE
wavegain: show correct maintainer

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -186,6 +186,7 @@
   rickynils = "Rickard Nilsson <rickynils@gmail.com>";
   rob = "Rob Vermaas <rob.vermaas@gmail.com>";
   robberer = "Longrin Wischnewski <robberer@freakmail.de>";
+  robbinch = "Robbin C. <robbinch33@gmail.com>";
   roconnor = "Russell O'Connor <roconnor@theorem.ca>";
   roelof = "Roelof Wobben <rwobben@hotmail.com>";
   romildo = "José Romildo Malaquias <malaquias@gmail.com>";

--- a/pkgs/applications/audio/wavegain/default.nix
+++ b/pkgs/applications/audio/wavegain/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation {
     homepage = https://github.com/MestreLion/wavegain;
     license = stdenv.lib.licenses.lgpl21;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    maintainers = [ stdenv.lib.maintainers.robbinch ];
   };
 }


### PR DESCRIPTION
@devhell
Sorry for the confusion. I based this on one of your packages and neglected to update the maintainer.
Fixed in this pull request.
