### PR TITLE
Remind update to 3.1.14, changes:

### DIFF
--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl} :
 
 stdenv.mkDerivation {
-  name = "remind-3.1.13";
+  name = "remind-3.1.14";
   src = fetchurl {
-    url = http://www.roaringpenguin.com/files/download/remind-03.01.13.tar.gz;
-    sha256 = "0kzw1d53nlj90qfsibbs2gkzp1hamqqxpj57ip4kz1j1xgan69ng";
+    url = http://www.roaringpenguin.com/files/download/remind-03.01.14.tar.gz;
+    sha256 = "1b9ij3r95lf14q6dyh8ilzc3y5yxxc1iss8wj3i49n6zjvklml8a";
   };
 
   meta = {


### PR DESCRIPTION
- Version 3.1 Patch 14 - 2014-04-24
- NEW FEATURE: Putting the line __EOF__ in a .rem file causes Remind to
  treat it as end-of-file.
- IMPROVEMENT: Use better PNG images for moons in the HTML display
- CHANGE: Author name updated from "David" to "Dianne"
- BUG FIX: The "-n" command-line option should really run in
  "ADVANCE_MODE" rather than "CAL_MODE" internally; otherwise, the
  substitution sequences may be misinterpreted.
- BUG FIX: A typo in clearing out MD5 sum context has been fixed.
- BUG FIX: Typo in Spanish translation was fixed.
