### PR TITLE
Kernel build: copy vmlinux to $out

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -45,6 +45,7 @@ let
     mkdir -p $4
     cp -av $2 $4
     cp -av $3 $4
+    cp -av `dirname $3`/vmlinux $4
   ''; };
 
   commonMakeFlags = [


### PR DESCRIPTION
It is useful for debugging kernel problems.
