### PR TITLE
Major update to vips and nip2 to 8.0.2, changes:

### DIFF
--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -2,11 +2,11 @@
 fftw, gsl, goffice_0_8, libgsf }:
 
 stdenv.mkDerivation rec {
-  name = "nip2-7.42.1";
+  name = "nip2-8.0";
 
   src = fetchurl {
     url = "http://www.vips.ecs.soton.ac.uk/supported/current/${name}.tar.gz";
-    sha256 = "14lfyn0azswrz8r81ign9lbpxzk7ibmnnp03a3l8wgxvm2j9a7jl";
+    sha256 = "10ybac0qrz63x1yk1d0gpv9z1vzpadyii2qhrai6lllplzw6jqx7";
   };
 
   buildInputs =

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "vips-7.42.1";
+  name = "vips-8.0.2";
 
   src = fetchurl {
     url = "http://www.vips.ecs.soton.ac.uk/supported/current/${name}.tar.gz";
-    sha256 = "1gvazsyfa8w9wdwz89rpa1xmfpyk3b0cp4kkila1r9jc3sqp5qjy";
+    sha256 = "0fpshv71sxbkbycxgd2hvwn7fyq9rm0rsgq0b1zld1an88mi0v8y";
   };
 
   buildInputs =


### PR DESCRIPTION
- Much better conversion to greyscale
- More efficient use of file descriptors
- Rewritten TIFF pyramid creator
- Removed old stuff

See http://libvips.blogspot.co.uk/2015/05/whats-new-in-80.html
and https://github.com/jcupitt/libvips/blob/master/ChangeLog
