### PR TITLE
install-cd: Include nixos-artwork to fix installer tests

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -30,8 +30,8 @@ with lib;
 
   # To speed up installation a little bit, include the complete stdenv
   # in the Nix store on the CD.  Archive::Cpio is needed for the
-  # initrd builder.
-  isoImage.storeContents = [ pkgs.stdenv pkgs.busybox pkgs.perlPackages.ArchiveCpio ];
+  # initrd builder.  nixos-artwork is needed for the GRUB background.
+  isoImage.storeContents = [ pkgs.stdenv pkgs.busybox pkgs.perlPackages.ArchiveCpio pkgs.nixos-artwork ];
 
   # EFI booting
   isoImage.makeEfiBootable = true;


### PR DESCRIPTION
Should fix at least nixos.tests.installer.simple.x86_64-linux (issue #8057)
http://hydra.nixos.org/build/23001712:

```
machine# error: cannot download Encode-Locale-1.03.tar.gz from any mirror
machine# builder for ‘/nix/store/y8gbx2d2fdcvvjy1z53xksfgq66ydlx0-Encode-Locale-1.03.tar.gz.drv’ failed with exit code 1
machine# cannot build derivation ‘/nix/store/y1knci7rix3asnh2b4kfv8jhl2j99xih-perl-Encode-Locale-1.03.drv’: 1 dependencies couldn't be built
machine# cannot build derivation ‘/nix/store/7xspjwh48kg16drv1jjg5cffaqbxbp8p-perl-libwww-perl-6.05.drv’: 1 dependencies couldn't be built
machine# cannot build derivation ‘/nix/store/8qsmz3bbk1jwhh50c3i9700bkmn8ns5c-nss-cacert-3.19.1.drv’: 1 dependencies couldn't be built
machine# cannot build derivation ‘/nix/store/0rgf2l3mdszs4a989ympwc9gk2k8wq6z-nixos-artwork-e71b684.drv’: 1 dependencies couldn't be built
...
```

Maybe in the long run a better solution needs to be figured out for these kinds of deps.
