### PR TITLE
zopfli: removed roconnor as a maintainer

### DIFF
--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
       '';
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.asl20;
-    maintainers = with maintainers; [ roconnor bobvanderlinden ];
+    maintainers = with maintainers; [ bobvanderlinden ];
   };
 }


### PR DESCRIPTION
roconnor was initially added as a maintainer by accident.
