### PR TITLE
gnome-pomodoro: Fix build for 3.16

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/apps/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/apps/pomodoro/default.nix
@@ -1,34 +1,33 @@
 { stdenv, fetchFromGitHub, which, automake113x, intltool, pkgconfig, libtool, makeWrapper,
-  dbus_glib, libcanberra, gst_all_1, upower, vala, gnome3, gtk3, gst_plugins_base,
-  glib, gobjectIntrospection, hicolor_icon_theme
+  dbus_glib, libcanberra, gst_all_1, vala, gnome3, gtk3, gst_plugins_base,
+  glib, gobjectIntrospection, hicolor_icon_theme, telepathy_glib
 }:
 
 stdenv.mkDerivation rec {
-  rev = "0.10.3";
-  name = "gnome-shell-pomodoro-${rev}-61df3fa";
+  rev = "624945d";
+  name = "gnome-shell-pomodoro-${gnome3.version}-${rev}";
 
   src = fetchFromGitHub {
       owner = "codito";
-      repo = "gnome-shell-pomodoro";
+      repo = "gnome-pomodoro";
       rev = "${rev}";
-      sha256 = "0i0glmijalppb5hdb1xd6xnmv824l2w831rpkqmhxi0iqbvaship";
+      sha256 = "0vjy95zvd309n8g13fa80qhqlv7k6wswhrjw7gddxrnmr662xdqq";
   };
 
   configureScript = ''./autogen.sh'';
 
   buildInputs = [
     which automake113x intltool glib gobjectIntrospection pkgconfig libtool
-    makeWrapper dbus_glib libcanberra upower vala gst_all_1.gstreamer
+    makeWrapper dbus_glib libcanberra vala gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gnome3.gsettings_desktop_schemas gnome3.gnome_desktop
     gnome3.gnome_common gnome3.gnome_shell hicolor_icon_theme gtk3
+    telepathy_glib
   ];
 
   preBuild = ''
-    sed -i \
-        -e 's|/usr\(/share/gir-1.0/UPowerGlib\)|${upower}\1|' \
-        -e 's|/usr\(/share/gir-1.0/GnomeDesktop\)|${gnome3.gnome_desktop}\1|' \
-        vapi/Makefile
+    sed -i 's|\$(INTROSPECTION_GIRDIR)|${gnome3.gnome_desktop}/share/gir-1.0|' \
+      vapi/Makefile
   '';
 
   preFixup = ''
@@ -42,7 +41,7 @@ stdenv.mkDerivation rec {
     description =
       "Personal information management application that provides integrated " + 
       "mail, calendaring and address book functionality";
-    maintainers = with maintainers; [ DamienCassou ];
+    maintainers = with maintainers; [ DamienCassou jgeerds ];
     license = licenses.gpl3;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
Pomodoro seems to be broken with Gnome 3.16. This PR updates pomodoro and fixes the build but there are still some errors:

```
$ result/bin/gnome-pomodoro 

** (.gnome-pomodoro-wrapped:23739): WARNING **: gnome-desktop-module.vala:614: Error loading extension: Error: Schema org.gnome.pomodoro.preferences could not be found for extension pomodoro@arun.codito.in. Please check your installation.
TypeError: settings is null
Error: Schema org.gnome.pomodoro.state could not be found for extension pomodoro@arun.codito.in. Please check your installation.
Gio.IOErrorEnum: Für die Schnittstelle org.gnome.Pomodoro.Extension auf /org/gnome/Pomodoro/Extension wurde bereits ein Objekt exportiert
^C
```

Any ideas?
cc: @DamienCassou @lethalman 
