### PR TITLE
clamav: build mail filter

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl }:
+{ stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl
+, libmilter }:
 stdenv.mkDerivation rec {
   name = "clamav-${version}";
   version = "0.98.6";
@@ -8,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0l99a0shgzpl8rvrrgbm1ki2zxlb7g1n82bhq7f2snj4amfj94b5";
   };
 
-  buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl libiconv ];
+  buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl libiconv libmilter ];
 
   configureFlags = [
     "--with-zlib=${zlib}"
@@ -18,6 +19,7 @@ stdenv.mkDerivation rec {
     "--with-openssl=${openssl}"
     "--with-libncurses-prefix=${ncurses}"
     "--with-libcurl=${curl}"
+    "--enable-milter"
     "--disable-clamav"
   ];
 


### PR DESCRIPTION
Provides clamav-milter, a mail filter for sendmail compatible MTAs.
