### PR TITLE
New expression for the davix toolkit

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -6,6 +6,7 @@
 
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
+  adev	   = "Adrien Devresse <adev@adev.name>";
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
   aflatter = "Alexander Flatter <flatter@fastmail.fm>";
   aherrmann = "Andreas Herrmann <andreash87@gmx.ch>";

--- a/pkgs/tools/networking/davix/default.nix
+++ b/pkgs/tools/networking/davix/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, libxml2, boost }:
+
+stdenv.mkDerivation rec {
+  name = "davix-0.4.0";
+  buildInputs = [ stdenv pkgconfig cmake openssl libxml2 boost ];
+
+  src = fetchFromGitHub {
+    owner = "cern-it-sdc-id";
+    repo = "davix";
+    rev = "R_0_4_0-1";
+    sha256 = "0i6ica7rmpc3hbybjql5mr500cd43w4qzc69cj1djkc6bqqb752v";
+  };
+
+
+  meta = with stdenv.lib; {
+    description = "Toolkit for Http-based file management";
+
+    longDescription = "Davix is a toolkit designed for file 
+    operations with Http based protocols (WebDav, Amazon S3, ...).
+    Davix provides an API and a set of command line tools";
+
+    license     = licenses.lgpl2Plus;
+    homepage    = http://dmc.web.cern.ch/projects/davix/home;
+    maintainers = [ maintainers.adev ];
+    platforms   = platforms.all;
+  };  
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -988,6 +988,8 @@ let
 
   cadaver = callPackage ../tools/networking/cadaver { };
 
+  davix = callPackage ../tools/networking/davix { };
+
   cantata = callPackage ../applications/audio/cantata { };
 
   can-utils = callPackage ../os-specific/linux/can-utils { };


### PR DESCRIPTION
Add the davix toolkit to nixpkgs.

Davix is a toolkit (API + tools ) for remote I/O based on HTTP/WebDav/S3 used in the HEP / scientific big data domain
