### PR TITLE
kernel-config: Fix 4.0 build on 32-bit

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -396,7 +396,7 @@ with stdenv.lib;
     KVM_CLOCK? y
   ''}
   ${optionalString (versionAtLeast version "4.0") ''
-    KVM_COMPAT y
+    KVM_COMPAT? y
   ''}
   ${optionalString (versionAtLeast version "3.10") ''
     KVM_DEVICE_ASSIGNMENT? y


### PR DESCRIPTION
KVM_COMPAT apparently enables 32-bit compability syscalls for KVM, and
as such can be enabled only on a 64-bit system.

Resolves error http://hydra.nixos.org/build/23014132/nixlog/1/raw:

```
GOT: #
GOT: # configuration written to .config
GOT: #
GOT: make[1]: Leaving directory '/tmp/nix-build-linux-config-4.0.5.drv-0/build'
GOT: make: Leaving directory '/tmp/nix-build-linux-config-4.0.5.drv-0/linux-4.0.5'
unused option: KVM_COMPAT
builder for ‘/nix/store/7kskdvmzs116f1fm55ghm0crjniw9q0a-linux-config-4.0.5.drv’ failed with exit code 255
```
