### PR TITLE
libevent Remove python dependency

### DIFF
--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ python ] ++ stdenv.lib.optional stdenv.isCygwin findutils;
 
-  patchPhase = ''
+  patchPhase = stdenv.lib.optionalString (python != null) ''
     patchShebangs event_rpcgen.py
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6796,7 +6796,8 @@ let
   libev = callPackage ../development/libraries/libev { };
 
   libevent14 = callPackage ../development/libraries/libevent/1.4.nix { };
-  libevent = callPackage ../development/libraries/libevent { };
+  libevent = callPackage ../development/libraries/libevent { python = null; };
+  libevent-rpcgen = callPackage ../development/libraries/libevent { python = pkgs.python; };
 
   libewf = callPackage ../development/libraries/libewf { };
 


### PR DESCRIPTION
Make it optional with libevent-rpcgen, and because rpcgen.py only works
with python2, do a check to see if it's using python2 to be safe.

It's only needed for the event_rpcgen.py script, which I haven't seen used anywhere.
