### PR TITLE
removed clang-unwrapped in vimPlugins.youcompleteme

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -685,7 +685,8 @@ rec {
     dependencies = [];
     buildInputs = [
       python cmake
-      llvmPackages.clang-unwrapped llvmPackages.llvm
+      (if stdenv.isDarwin then llvmPackages.clang else llvmPackages.clang-unwrapped)
+      llvmPackages.llvm
     ];
 
     configurePhase = ":";


### PR DESCRIPTION
this failed with clang-unwrapped on darwin

```
impure path
`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk'
used in link
```
