### PR TITLE
Add mailnag package

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, buildPythonPackage, fetchurl, gettext, gtk3, pythonPackages
+, gdk_pixbuf, libnotify, gst_all_1
+, libgnome_keyring3 ? null, networkmanager ? null
+}:
+
+buildPythonPackage rec {
+  name = "mailnag-${version}";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/pulb/mailnag/archive/v${version}.tar.gz";
+    sha256 = "0li4kvxjmbz3nqg6bysgn2wdazqrd7gm9fym3rd7148aiqqwa91r";
+  };
+
+  # Sometimes the generated output isn't identical. It seems like there's a
+  # race condtion while patching the Mailnag/commons/dist_cfg.py file. This is
+  # a small workaround to produce deterministic builds.
+  # For more information see https://github.com/NixOS/nixpkgs/pull/8279
+  setupPyBuildFlags = [ "--build-base=$PWD" ];
+
+  buildInputs = [
+    gettext gtk3 pythonPackages.pygobject3 pythonPackages.dbus
+    pythonPackages.pyxdg gdk_pixbuf libnotify gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad libgnome_keyring3 networkmanager
+  ];
+
+  preFixup = ''
+    for script in mailnag mailnag-config; do
+      wrapProgram $out/bin/$script \
+        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share" \
+        --prefix PYTHONPATH : "$PYTHONPATH"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An extensible mail notification daemon";
+    homepage = https://github.com/pulb/mailnag;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jgeerds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2061,6 +2061,8 @@ let
 
   maildrop = callPackage ../tools/networking/maildrop { };
 
+  mailnag = callPackage ../applications/networking/mailreaders/mailnag { };
+
   mailsend = callPackage ../tools/networking/mailsend { };
 
   mailpile = callPackage ../applications/networking/mailreaders/mailpile { };


### PR DESCRIPTION
Mailnag is a mail notification daemon. I've tested this package for about one week and it works well. Anyway, it seems like there is an interesting race condition bug. I've discovered that mailnag sometimes doesn't find its own plugins. The build output differentiates from time to time:

`nix-build -A mailnag && result/bin/mailnag-config`, click on `Plugins` to check which plugins were found. Finally a `nix-store --delete --ignore-liveness $output` and build the package again. Repeat it ~10 times.

I've already diffed the outputs:

```
$ diff -r mailnag-broken/ mailnag-working/
diff -r mailnag-broken/lib/python2.7/site-packages/Mailnag/common/dist_cfg.py mailnag-working/lib/python2.7/site-packages/Mailnag/common/dist_cfg.py
44c44
< LOCALE_DIR = '/usr/share/locale'

---
> LOCALE_DIR = '/nix/store/dz0zsmm4plj2h9d3jp7mf3a9xrvi5z4x-python2.7-mailnag-1.1.0/share/locale'
48c48
< LIB_DIR = '/usr/lib/python2.7/site-packages/Mailnag'

---
> LIB_DIR = '/nix/store/dz0zsmm4plj2h9d3jp7mf3a9xrvi5z4x-python2.7-mailnag-1.1.0/lib/python2.7/site-packages/Mailnag'
52c52
< BIN_DIR = '/usr/bin'

---
> BIN_DIR = '/nix/store/dz0zsmm4plj2h9d3jp7mf3a9xrvi5z4x-python2.7-mailnag-1.1.0/bin'
Binary files mailnag-broken/lib/python2.7/site-packages/Mailnag/common/dist_cfg.pyc and mailnag-working/lib/python2.7/site-packages/Mailnag/common/dist_cfg.pyc differ
```

(the hashes of the derivatons are identical - /nix/store/dz0zsmm4plj2h9d3jp7mf3a9xrvi5z4x-python2.7-mailnag-1.1.0 in my case)

CC: @domenkozar @lethalman 
