### PR TITLE
Enable RTTI for LLVM-3.4

### DIFF
--- a/pkgs/development/compilers/llvm/3.4/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.4/llvm.nix
@@ -44,6 +44,7 @@ in stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_REQUIRES_RTTI=1"
     "-DLLVM_BINUTILS_INCDIR=${binutils}/include"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
   ] ++ stdenv.lib.optional (!isDarwin) "-DBUILD_SHARED_LIBS=ON";


### PR DESCRIPTION
RTTI is on for llvm-3.5 and llvm-3.6 already, this makes llvm-3.4 follow suit.
I needed llvm-3.4 RTTI for another package (which I will submit after this and my ocaml PRs make it in).
