### PR TITLE
openconnect: update to version 7.06 and support openssl or gnutls

### DIFF
--- a/pkgs/tools/networking/openconnect.nix
+++ b/pkgs/tools/networking/openconnect.nix
@@ -1,13 +1,19 @@
-{ stdenv, fetchurl, pkgconfig, vpnc, openssl, libxml2, zlib } :
+{ stdenv, fetchurl, pkgconfig, vpnc, openssl ? null, gnutls ? null, libxml2, zlib } :
+
+let
+  xor = a: b: (a || b) && (!(a && b));
+in
+
+assert xor (openssl != null) (gnutls != null);
 
 stdenv.mkDerivation rec {
-  name = "openconnect-5.02";
+  name = "openconnect-7.06";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.infradead.org/pub/openconnect/${name}.tar.gz"
     ];
-    sha256 = "1y7dn42gd3763sgwv2j72xy9hsikd6y9x142g84kwdbn0y0psgi4";
+    sha256 = "1wkhmgfxkdkhy2p9w9idrgipxmxij2z4f88flfk3fifwd19nkkzs";
   };
 
   preConfigure = ''
@@ -22,5 +28,6 @@ stdenv.mkDerivation rec {
     "--without-openssl-version-check"
   ];
 
-  propagatedBuildInputs = [ vpnc openssl libxml2 zlib ];
+  buildInputs = [ pkgconfig ];
+  propagatedBuildInputs = [ vpnc openssl gnutls libxml2 zlib ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3144,7 +3144,16 @@ let
 
   vpnc = callPackage ../tools/networking/vpnc { };
 
-  openconnect = callPackage ../tools/networking/openconnect.nix { };
+  openconnect = openconnect_openssl;
+
+  openconnect_openssl = callPackage ../tools/networking/openconnect.nix {
+    gnutls = null;
+  };
+
+  openconnect_gnutls = lowPrio (openconnect.override {
+    openssl = null;
+    gnutls = gnutls;
+  });
 
   vtun = callPackage ../tools/networking/vtun { };
 


### PR DESCRIPTION
I'm looking to enable openconnect's juniper support which was introduced in 7.05: http://www.infradead.org/openconnect/changelog.html

```
+ nix-env --file /home/jchee/packages/nixpkgs -iA openconnect
replacing old ‘openconnect-7.06’
installing ‘openconnect-7.06’
+ openconnect --version
OpenConnect version v7.06
Using OpenSSL. Features present: TPM (OpenSSL ENGINE not present), HOTP software token, TOTP software token, DTLS

+ nix-env --file /home/jchee/packages/nixpkgs -iA openconnect_openssl
replacing old ‘openconnect-7.06’
installing ‘openconnect-7.06’
+ openconnect --version
OpenConnect version v7.06
Using OpenSSL. Features present: TPM (OpenSSL ENGINE not present), HOTP software token, TOTP software token, DTLS

+ nix-env --file /home/jchee/packages/nixpkgs -iA openconnect_gnutls
replacing old ‘openconnect-7.06’
installing ‘openconnect-7.06’
+ openconnect --version
OpenConnect version v7.06
Using GnuTLS. Features present: HOTP software token, TOTP software token, System keys, DTLS
```
