### PR TITLE
OCaml-4.02: fix ocamlbuild rules for camlp4

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, dypgen, bolt, ansiterminal,
+{ stdenv, fetchurl, ocaml, findlib, dypgen, bolt, ansiterminal, camlp4,
   buildBytecode ? true,
   buildNative ? true,
   installExamples ? true,
@@ -22,10 +22,15 @@ stdenv.mkDerivation {
     sha256 = "1k1ldqg34bwmgdpmi9gry9czlsk85ycjxnkd25fhlf3mmgg4n9p6";
   };
 
-  buildInputs = [ ocaml findlib dypgen bolt ansiterminal ];
+  buildInputs = [ ocaml findlib dypgen bolt ansiterminal camlp4 ];
 
   patches = [ ./install-emacs-to-site-lisp.patch
               ./use-nix-ocaml-byteflags.patch ];
+
+  postPatch = stdenv.lib.optionalString (camlp4 != null) ''
+    substituteInPlace src/Makefile.master.in \
+      --replace "+camlp4" "${camlp4}/lib/ocaml/${getVersion ocaml}/site-lib/camlp4/"
+  '';
 
   # The bytecode executable is dependent on the dynamic library provided by
   # ANSITerminal. We can use the -dllpath flag of ocamlc (analogous to

--- a/pkgs/applications/science/logic/coq/8.3.nix
+++ b/pkgs/applications/science/logic/coq/8.3.nix
@@ -1,6 +1,6 @@
 # - coqide compilation can be disabled by setting lablgtk to null;
 
-{stdenv, fetchurl, ocaml, findlib, camlp5, ncurses, lablgtk ? null}:
+{ stdenv, make, fetchurl, ocaml, findlib, camlp5, ncurses, lablgtk ? null }:
 
 let 
   version = "8.3pl4";
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     sha256 = "17d3lmchmqir1rawnr52g78srg4wkd7clzpzfsivxc4y1zp6rwkr";
   };
 
-  buildInputs = [ ocaml findlib camlp5 ncurses lablgtk ];
+  buildInputs = [ make ocaml findlib camlp5 ncurses lablgtk ];
 
   prefixKey = "-prefix ";
 

--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchdarcs, ocaml, findlib,  lablgl, camlimages, mesa, freeglut, ocaml_mysql, mlgmp, mpfr, gmp, libtiff, libjpeg, libpng, giflib }:
+{ stdenv, fetchdarcs, ocaml, findlib,  lablgl, camlimages, mesa, freeglut, ocaml_mysql, mysql, mlgmp, mpfr, gmp, libtiff, libjpeg, libpng, giflib }:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -10,11 +10,11 @@ stdenv.mkDerivation {
   src = fetchdarcs {
     url = "http://lama.univ-savoie.fr/~raffalli/GlSurf";
     rev = "3.3";
-    sha256 = ""; md5="";
+    sha256 = "0ljvvzz31j7l8rvsv63x1kj70nhw3al3k294m79hpmwjvym1mzfa";
   };
 
   buildInputs = [ ocaml findlib freeglut mesa
-  	          lablgl camlimages ocaml_mysql mlgmp mpfr gmp
+  	          lablgl camlimages ocaml_mysql mysql.lib mlgmp mpfr gmp
 		  libtiff libjpeg libpng giflib ];
 
   installPhase = ''

--- a/pkgs/development/compilers/ocaml/4.02.1.nix
+++ b/pkgs/development/compilers/ocaml/4.02.1.nix
@@ -9,6 +9,10 @@ assert useX11 -> !stdenv.isArm && !stdenv.isMips;
 let
    useNativeCompilers = !stdenv.isMips;
    inherit (stdenv.lib) optionals optionalString;
+   patchOcamlBuild = fetchurl {
+     url = https://github.com/ocaml/ocaml/pull/117.patch;
+     sha256 = "0x2cdn2sgzq29qzqg5y2ial0jqy8gjg5a7jf8qqch55dc4vkyjw0";
+   };
 in
 
 stdenv.mkDerivation rec {
@@ -23,6 +27,8 @@ stdenv.mkDerivation rec {
     url = "http://caml.inria.fr/pub/distrib/ocaml-4.02/${name}.tar.xz";
     sha256 = "1p7lqvh64xpykh99014mz21q8fs3qyjym2qazhhbq8scwldv1i38";
   };
+
+  patches = [ patchOcamlBuild ];
 
   prefixKey = "-prefix ";
   configureFlags = optionals useX11 [ "-x11lib" x11lib

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, which }:
+{ stdenv, fetchurl, ocaml, findlib, which, camlp4 }:
 
 let inherit (stdenv.lib) getVersion versionAtLeast; in
 
@@ -14,7 +14,20 @@ stdenv.mkDerivation rec {
     sha256 = "1c807wrpxra9sbb34lajhimwra28ldxv04m570567lh2b04n38zy";
   };
 
-  buildInputs = [ ocaml findlib which ];
+  buildInputs = [ ocaml findlib which camlp4 ];
+
+  patchPhase = ''
+    patch myocamlbuild.ml <<EOF
+70,74c70
+<         let camlp4of =
+<           try
+<             let path_bin = Filename.concat (Sys.getenv "PATH_OCAML_PREFIX") "bin" in
+<             Filename.concat path_bin "camlp4of"
+<           with _ -> "camlp4of" in
+---
+>         let camlp4of = "camlp4of" in
+EOF
+  '';
 
   # The custom `configure` script does not expect the --prefix
   # option. Installation is handled by ocamlfind.

--- a/pkgs/development/ocaml-modules/eliom/camlp4.patch
+++ b/pkgs/development/ocaml-modules/eliom/camlp4.patch
@@ -1,0 +1,24 @@
+--- a/src/_tags	2014-10-01 16:19:35.000000000 +0100
++++ b/src/_tags	2014-11-09 16:55:34.470663377 +0000
+@@ -39,7 +39,7 @@
+ <lib/server/monitor/*.ml{,i}>:I(src/lib/server)
+ 
+ <syntax/pa_*.ml{,i}>: syntax(camlp4o),package(camlp4.quotations.o,camlp4.extend)
+-<syntax/pa_*.ml{,i}>: I(+camlp4/Camlp4Parsers)
++<syntax/pa_*.ml{,i}>: use_camlp4_full
+ 
+ 
+ <ocamlbuild/ocamlbuild_eliom.ml{,i}>: package(ocamlbuild,js_of_ocaml.ocamlbuild)
+
+--- a/src/lib/eliom_registration.server.ml	2014-10-01 16:19:35.000000000 +0100
++++ b/src/lib/eliom_registration.server.ml	2014-11-09 17:26:16.093198699 +0000
+@@ -2440,7 +2440,7 @@
+       (Ocaml.register_post_coservice'
+          ?scope ?options ?charset ?code ?content_type ?headers ?secure_session ?name
+          ?csrf_safe ?csrf_scope ?csrf_secure ?max_use ?timeout ?https ?error_handler
+-         ~post_params:Eliom_parameter.(ocaml "argument" argument_type)
++         ~post_params:(Eliom_parameter.ocaml "argument" argument_type)
+          (fun () argument -> f argument))
+       (Eliom_wrap.create_unwrapper
+          (Eliom_wrap.id_of_int Eliom_common_base.server_function_unwrap_id_int))
+

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec
     sha256 = "10v7mrq3zsbxdlg8k8xif777mbvcdpabvnd1g7p2yqivr7f1qm24";
   };
 
+  patches = [ ./camlp4.patch ];
+
   buildInputs = [ocaml which ocsigen_server findlib ocsigen_deriving
                  js_of_ocaml ocaml_optcomp opam];
 

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk, libgnomecanvas, libglade, gtksourceview}:
+{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk, libgnomecanvas, libglade, gtksourceview, camlp4 }:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -14,7 +14,7 @@ stdenv.mkDerivation (rec {
     sha256 = "1fnh0amm7lwgyjdhmlqgsp62gwlar1140425yc1j6inwmgnsp0a9";
   };
 
-  buildInputs = [ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview];
+  buildInputs = [ ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview camlp4 ];
 
   configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
   buildFlags = "world";

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, mysql}:
+{ stdenv, fetchurl, ocaml, findlib, mysql, camlp4 }:
 
 # TODO: la versione stabile da' un errore di compilazione dovuto a
 # qualche cambiamento negli header .h
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
      "--libdir=$out/lib/ocaml/${ocaml_version}/site-lib/mysql"
   ];
 
-  buildInputs = [ocaml findlib mysql.lib ];
+  buildInputs = [ocaml findlib mysql.lib camlp4 ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib }:
+{ stdenv, fetchurl, ocaml, findlib, camlp4 }:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
-  buildInputs = [ocaml findlib];
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ camlp4 ];
 
   buildFlags = "all all.opt";
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation {
     };
   
   buildInputs = [ocaml findlib menhir ocsigen_deriving
-                 cmdliner tyxml camlp4 reactivedata];
-  propagatedBuildInputs = [ ocaml_lwt ];
+                 cmdliner tyxml reactivedata];
+  propagatedBuildInputs = [ ocaml_lwt camlp4 ];
 
   patches = [ ./Makefile.conf.diff ];  
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14095,6 +14095,7 @@ let
   };
 
   coq_8_3 = callPackage ../applications/science/logic/coq/8.3.nix {
+    make = gnumake3;
     inherit (ocamlPackages_3_12_1) ocaml findlib;
     camlp5 = ocamlPackages_3_12_1.camlp5_transitional;
     lablgtk = ocamlPackages_3_12_1.lablgtk_2_14;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4380,8 +4380,6 @@ let
 
     mezzo = callPackage ../development/compilers/mezzo { };
 
-    mldonkey = callPackage ../applications/networking/p2p/mldonkey { };
-
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
@@ -11875,6 +11873,8 @@ let
   };
 
   mjpg-streamer = callPackage ../applications/video/mjpg-streamer { };
+
+  mldonkey = callPackage ../applications/networking/p2p/mldonkey { };
 
   mmex = callPackage ../applications/office/mmex { };
 


### PR DESCRIPTION
Some OCaml packages do not build with OCaml-4.02 because they expect the `camlp4` library to be installed in the same directory as the compiler, which is not the case in `nixpkgs`.

This issue has been known for some time. See #4398.

A patch has been proposed upstream but did not receive much attention. This PR brings this patch into `nixpkgs`.
