### PR TITLE
Remove use of builderDefsPackage in font packages.

### DIFF
--- a/pkgs/data/fonts/andagii/default.nix
+++ b/pkgs/data/fonts/andagii/default.nix
@@ -1,59 +1,31 @@
-x@{builderDefsPackage
-  , unzip
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchzip }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    url="http://www.i18nguy.com/unicode/andagii.zip";
-    name="andagii";
-    version="1.0.2";
-    hash="0cknb8vin15akz4ahpyayrpqyaygp9dgrx6qw7zs7d6iv9v59ds1";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
+stdenv.mkDerivation rec {
+  name = "andagii-${version}";
+  version = "1.0.2";
+
+  src = fetchzip {
+    url = http://www.i18nguy.com/unicode/andagii.zip;
+    sha256 = "0a0c43y1fd5ksj50axhng7p00kgga0i15p136g68p35wj7kh5g2k";
+    stripRoot = false;
     curlOpts = "--user-agent 'Mozilla/5.0'";
-    sha256 = sourceInfo.hash;
   };
 
-  name = "${sourceInfo.name}-${sourceInfo.version}";
-  inherit buildInputs;
+  phases = [ "unpackPhase" "installPhase" ];
 
-  /* doConfigure should be removed if not needed */
-  phaseNames = ["doUnpack" "doInstall"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -v ANDAGII_.TTF $out/share/fonts/truetype/andagii.ttf
+  '';
 
-  doUnpack = a.fullDepEntry ''
-    unzip "${src}"
-  '' ["addInputs"];
-
-  doInstall = a.fullDepEntry (''
-    mkdir -p "$out"/share/fonts/ttf/
-    cp ANDAGII_.TTF "$out"/share/fonts/ttf/andagii.ttf
-  '') ["defEnsureDir" "minInit"];
-      
-  meta = {
+  # There are multiple claims that the font is GPL, so I include the
+  # package; but I cannot find the original source, so use it on your
+  # own risk Debian claims it is GPL - good enough for me.
+  meta = with stdenv.lib; {
+    homepage = http://www.i18nguy.com/unicode/unicode-font.HTML;
     description = "Unicode Plane 1 Osmanya script font";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    hydraPlatforms = [];
-    # There are multiple claims that the font is GPL, 
-    # so I include the package; but I cannot find the
-    # original source, so use it on your own risk
-    # Debian claims it is GPL - good enough for me.
+    maintainers = with maintainers; [ raskin rycee ];
+    license = "unknown";
+    platforms = platforms.all;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://www.i18nguy.com/unicode/unicode-font.html";
-    };
-  };
-}) x
-
+}

--- a/pkgs/data/fonts/anonymous-pro/default.nix
+++ b/pkgs/data/fonts/anonymous-pro/default.nix
@@ -1,50 +1,36 @@
-x@{builderDefsPackage
-  , unzip
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchurl, unzip }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    version = "1.002";
-    name="anonymousPro";
-    url="http://www.ms-studio.com/FontSales/AnonymousPro-${version}.zip";
+stdenv.mkDerivation rec {
+  name = "anonymousPro-${version}";
+  version = "1.002";
+
+  src = fetchurl {
+    url = "http://www.marksimonson.com/assets/content/fonts/AnonymousPro-${version}.zip";
     sha256 = "1asj6lykvxh46czbal7ymy2k861zlcdqpz8x3s5bbpqwlm3mhrl6";
   };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.sha256;
-  };
 
-  name = "${sourceInfo.name}-${sourceInfo.version}";
-  inherit buildInputs;
+  nativeBuildInputs = [ unzip ];
+  phases = [ "unpackPhase" "installPhase" ];
 
-  phaseNames = ["doUnpack" "installFonts"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    find . -name "*.ttf" -exec cp -v {} $out/share/fonts/truetype \;
+    find . -name "*.txt" -exec cp -v {} $out/share/doc/${name} \;
+  '';
 
-  doUnpack = a.fullDepEntry (''
-    unzip ${src}
-    cd AnonymousPro*/
-  '') ["addInputs"];
-      
-  meta = {
+  meta = with stdenv.lib; {
+    homepage = http://www.marksimonson.com/fonts/view/anonymous-pro;
     description = "TrueType font set intended for source code";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      all;
-    license = with a.lib.licenses; ofl;
-    hydraPlatforms = [];
-    homepage = "http://www.marksimonson.com/fonts/view/anonymous-pro";
-    downloadPage = "http://www.ms-studio.com/FontSales/anonymouspro.html";
-    inherit (sourceInfo) version;
+    longDescription = ''
+      Anonymous Pro (2009) is a family of four fixed-width fonts
+      designed with coding in mind. Anonymous Pro features an
+      international, Unicode-based character set, with support for
+      most Western and Central European Latin-based languages, plus
+      Greek and Cyrillic. It is designed by Mark Simonson.
+    '';
+    maintainers = with maintainers; [ raskin rycee ];
+    license = licenses.ofl;
+    platforms = platforms.all;
   };
-}) x
-
+}

--- a/pkgs/data/fonts/cm-unicode/default.nix
+++ b/pkgs/data/fonts/cm-unicode/default.nix
@@ -1,40 +1,28 @@
-x@{builderDefsPackage
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchurl }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    version = "0.7.0";
-    baseName="cm-unicode";
-    name="${baseName}-${version}";
-    url="mirror://sourceforge/${baseName}/${baseName}/${version}/${name}-otf.tar.xz";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
+stdenv.mkDerivation rec {
+  name = "cm-unicode-${version}";
+  version = "0.7.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/cm-unicode/cm-unicode/${version}/${name}-otf.tar.xz";
     sha256 = "0a0w9qm9g8qz2xh3lr61bj1ymqslqsvk4w2ybc3v2qa89nz7x2jl";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  phases = [ "unpackPhase" "installPhase" ];
 
-  phaseNames = ["doUnpack" "installFonts"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.otf $out/share/fonts/opentype/
+    cp -v README FontLog.txt $out/share/doc/${name}
+  '';
 
-  meta = {
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      all;
-    downloadPage = "http://sourceforge.net/projects/cm-unicode/files/cm-unicode/";
-    inherit version;
+  meta = with stdenv.lib; {
+    homepage = http://canopus.iacp.dvo.ru/~panov/cm-unicode/;
+    description = "Computer Modern Unicode fonts";
+    maintainers = with maintainers; [ raskin rycee ];
+    license = licenses.ofl;
+    platforms = platforms.all;
   };
-}) x
-
+}

--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -1,46 +1,29 @@
-x@{builderDefsPackage
-  , unzip
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchzip }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    version="1.504";
-    baseName="GentiumPlus";
-    name="${baseName}-${version}";
-    url="http://scripts.sil.org/cms/scripts/render_download.php?&format=file&media_id=${name}.zip&filename=${name}";
-    hash="04kslaqbscpfrc6igkifcv1nkrclrm35hqpapjhw9102wpq12fpr";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
-    name = "${sourceInfo.name}.zip";
+stdenv.mkDerivation rec {
+  name = "gentium-${version}";
+  version = "1.504";
+
+  src = fetchzip {
+    name = "${name}.zip";
+    url = "http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=GentiumPlus-${version}.zip&filename=${name}.zip";
+    sha256 = "1xdx80dfal0b8rkrp1janybx2hki7algnvkx4hyghgikpjcjkdh7";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  phases = [ "unpackPhase" "installPhase" ];
 
-  phaseNames = ["addInputs" "doUnpack" "installFonts"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.ttf $out/share/fonts/truetype/
+    cp -v FONTLOG.txt GENTIUM-FAQ.txt README.txt $out/share/doc/${name}
+  '';
 
-  meta = {
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      all;
+  meta = with stdenv.lib; {
+    homepage = "http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&item_id=Gentium";
+    description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
+    maintainers = with maintainers; [ raskin rycee ];
+    license = licenses.ofl;
+    platforms = platforms.all;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://scripts.sil.org/cms/scripts/page.php?item_id=Gentium_download";
-    };
-  };
-}) x
-
+}

--- a/pkgs/data/fonts/inconsolata/default.nix
+++ b/pkgs/data/fonts/inconsolata/default.nix
@@ -1,51 +1,26 @@
-x@{builderDefsPackage
-  , fontforge
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchurl }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    name="inconsolata";
-    url="http://www.levien.com/type/myfonts/Inconsolata.sfd";
-    hash="1cd29c8396adb18bfeddb1abf5bdb98b677649bb9b09f126d1335b123a4cfddb";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
+stdenv.mkDerivation rec {
+  name = "inconsolata-${version}";
+  version = "1.010";
+
+  src = fetchurl {
+    url = "http://www.levien.com/type/myfonts/Inconsolata.otf";
+    sha256 = "06js6znbcf7swn8y3b8ki416bz96ay7d3yvddqnvi88lqhbfcq8m";
   };
 
-  inherit (sourceInfo) name;
-  inherit buildInputs;
+  phases = [ "installPhase" ];
 
-  /* doConfigure should be removed if not needed */
-  phaseNames = ["copySrc" "generateFontsFromSFD" "installFonts"];
-  
-  copySrc = a.fullDepEntry (''
-    cp ${src} inconsolata.sfd
-  '') ["minInit"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    cp -v $src $out/share/fonts/opentype/inconsolata.otf
+  '';
 
-  generateFontsFromSFD = a.generateFontsFromSFD // {deps=["addInputs"];};
-
-  meta = {
+  meta = with stdenv.lib; {
+    homepage = http://www.levien.com/type/myfonts/inconsolata.html;
     description = "A monospace font for both screen and print";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      all;
+    maintainers = with maintainers; [ raskin rycee ];
+    license = licenses.ofl;
+    platforms = platforms.all;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://www.levien.com/type/myfonts/inconsolata.html";
-    };
-  };
-}) x
-
+}

--- a/pkgs/data/fonts/oldstandard/default.nix
+++ b/pkgs/data/fonts/oldstandard/default.nix
@@ -1,50 +1,29 @@
-x@{builderDefsPackage
-  , unzip
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchzip }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    version="2.2";
-    baseName="oldstandard";
-    name="${baseName}-${version}";
-    url="http://www.thessalonica.org.ru/downloads/${name}.otf.zip";
-    hash="0xhbksrh9mv1cs6dl2mc8l6sypialy9wirkjr54nf7s9bcynv1h6";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
+stdenv.mkDerivation rec {
+  name = "oldstandard-${version}";
+  version = "2.2";
+
+  src = fetchzip {
+    stripRoot = false;
+    url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${name}.otf.zip";
+    sha256 = "1hl78jw5szdjq9dhbcv2ln75wpp2lzcxrnfc36z35v5wk4l7jc3h";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  phases = [ "unpackPhase" "installPhase" ];
 
-  phaseNames = ["doUnpack" "installFonts"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.otf $out/share/fonts/opentype/
+    cp -v FONTLOG.txt $out/share/doc/${name}
+  '';
 
-  doUnpack = a.fullDepEntry ''
-    unzip ${src}
-  '' ["addInputs"];
-      
-  meta = {
-    description = "An old-style font";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      all;
+  meta = with stdenv.lib; {
+    homepage = https://github.com/akryukov/oldstand;
+    description = "An attempt to revive a specific type of Modern style of serif typefaces";
+    maintainers = with maintainers; [ raskin rycee ];
+    license = licenses.ofl;
+    platforms = platforms.all;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://www.thessalonica.org.ru/ru/fonts-download.html";
-    };
-  };
-}) x
-
+}

--- a/pkgs/data/fonts/theano/default.nix
+++ b/pkgs/data/fonts/theano/default.nix
@@ -1,50 +1,29 @@
-x@{builderDefsPackage
-  , unzip
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchzip }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    version="2.0";
-    baseName="theano";
-    name="${baseName}-${version}";
-    url="http://www.thessalonica.org.ru/downloads/${name}.otf.zip";
-    hash="1xiykqbbiawvfk33639awmgdn25b8s2k7vpwncl17bzlk887b4z6";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
+stdenv.mkDerivation rec {
+  name = "theano-${version}";
+  version = "2.0";
+
+  src = fetchzip {
+    stripRoot = false;
+    url = "https://github.com/akryukov/theano/releases/download/v${version}/theano-${version}.otf.zip";
+    sha256 = "1z3c63rcp4vfjyfv8xwc3br10ydwjyac3ipbl09y01s7qhfz02gp";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  phases = [ "unpackPhase" "installPhase" ];
 
-  phaseNames = ["doUnpack" "installFonts"];
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    find . -name "*.otf" -exec cp -v {} $out/share/fonts/opentype \;
+    find . -name "*.txt" -exec cp -v {} $out/share/doc/${name} \;
+  '';
 
-  doUnpack = a.fullDepEntry ''
-    unzip ${src}
-  '' ["addInputs"];
-      
-  meta = {
-    description = "An old-style font";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      all;
+  meta = with stdenv.lib; {
+    homepage = https://github.com/akryukov/theano;
+    description = "An old-style font designed from historic samples";
+    maintainers = with maintainers; [ raskin rycee ];
+    license = licenses.ofl;
+    platforms = platforms.all;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://www.thessalonica.org.ru/ru/fonts-download.html";
-    };
-  };
-}) x
-
+}


### PR DESCRIPTION
With this change they now use `stdenv.mkDerivation` instead. Also some minor cleanups such as URL fixes, adding version numbers, adding descriptions, etc.
