### PR TITLE
Steam: use native NixOS libraries instead of Steam Runtime

### DIFF
--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl, mesa_glu, x11, libXmu, libXi }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "glew-1.10.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/glew/${name}.tgz";
+    sha256 = "01zki46dr5khzlyywr3cg615bcal32dazfazkf360s1znqh17i4r";
+  };
+
+  nativeBuildInputs = [ x11 libXmu libXi ];
+  propagatedNativeBuildInputs = [ mesa_glu ]; # GL/glew.h includes GL/glu.h
+
+  patchPhase = ''
+    sed -i 's|lib64|lib|' config/Makefile.linux
+    ${optionalString (stdenv ? cross) ''
+    sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
+    ''}
+  '';
+
+  buildFlags = [ "all" ];
+  installFlags = [ "install.all" ];
+
+  preInstall = ''
+    export GLEW_DEST="$out"
+  '';
+
+  postInstall = ''
+    mkdir -pv $out/share/doc/glew
+    mkdir -p $out/lib/pkgconfig
+    cp glew*.pc $out/lib/pkgconfig
+    cp -r README.txt LICENSE.txt doc $out/share/doc/glew
+  '';
+
+  crossAttrs.makeFlags = [
+    "CC=${stdenv.cross.config}-gcc"
+    "LD=${stdenv.cross.config}-gcc"
+    "AR=${stdenv.cross.config}-ar"
+    "STRIP="
+  ] ++ optional (stdenv.cross.libc == "msvcrt") "SYSTEM=mingw"
+    ++ optional (stdenv.cross.libc == "libSystem") "SYSTEM=darwin";
+
+  meta = with stdenv.lib; {
+    description = "An OpenGL extension loading library for C(++)";
+    homepage = http://glew.sourceforge.net/;
+    license = licenses.free; # different files under different licenses
+      #["BSD" "GLX" "SGI-B" "GPL2"]
+    platforms = platforms.mesaPlatforms;
+  };
+}

--- a/pkgs/games/steam/build-runtime.sh
+++ b/pkgs/games/steam/build-runtime.sh
@@ -1,0 +1,47 @@
+source $stdenv/setup
+
+outp=$out/lib/steam-runtime
+
+buildDir() {
+  paths="$1"
+  pkgs="$2"
+
+  for pkg in $pkgs; do
+    echo "adding package $pkg"
+    for path in $paths; do
+      if [ -d $pkg/$path ]; then
+        cd $pkg/$path
+        for file in *; do
+          found=""
+          for i in $paths; do
+            if [ -e "$outp/$i/$file" ]; then
+              found=1
+              break
+            fi
+          done
+          if [ -z "$found" ]; then
+            mkdir -p $outp/$path
+            ln -s "$pkg/$path/$file" $outp/$path
+            sovers=$(echo $file | perl -ne 'print if s/.*?\.so\.(.*)/\1/')
+            if [ ! -z "$sovers" ]; then
+              fname=''${file%.''${sovers}}
+              for ver in ''${sovers//./ }; do
+                found=""
+                for i in $paths; do
+                  if [ -e "$outp/$i/$fname" ]; then
+                    found=1
+                    break
+                  fi
+                done
+                [ -n "$found" ] || ln -s "$pkg/$path/$file" "$outp/$path/$fname"
+                fname="$fname.$ver"
+              done
+            fi
+          fi
+        done
+      fi
+    done
+  done
+}
+
+eval "$installPhase"

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -107,12 +107,12 @@ buildFHSUserEnv {
       pkgs.gst_plugins_base
     ];
 
-  extraBuildCommandsMulti = ''
-    cd usr/lib
-    ln -sf ../lib64/steam steam
+  extraBuildCommands = ''
+    [ -d lib64 ] && mv lib64/steam lib
 
     # FIXME: maybe we should replace this with proper libcurl-gnutls
-    ln -s libcurl.so.4 libcurl-gnutls.so.4
+    ( cd lib; ln -s libcurl.so.4 libcurl-gnutls.so.4 )
+    [ -d lib64 ] && ( cd lib64; ln -s libcurl.so.4 libcurl-gnutls.so.4 )
   '';
 
   profile = if withRuntime then ''

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,122 +1,150 @@
-{ lib, buildFHSUserEnv
+{ lib, buildFHSUserEnv, steam-runtime
 , withRuntime ? false
-, withJava ? false
-, withPrimus ? false
+, withJava    ? false
+, withPrimus  ? false
 }:
 
 buildFHSUserEnv {
   name = "steam";
 
-  targetPkgs = pkgs:
-    [ pkgs.steam-original
+  targetPkgs = pkgs: with pkgs; [
+      steam-original
       # Errors in output without those
-      pkgs.pciutils
-      pkgs.python2
+      pciutils
+      python2
       # Games' dependencies
-      pkgs.xlibs.xrandr
-      pkgs.which
+      xlibs.xrandr
+      which
+      # needed by gdialog, including in the steam-runtime
+      perl
     ]
-    ++ lib.optional withJava pkgs.jdk
-    ++ lib.optional withPrimus pkgs.primus
+    ++ lib.optional withJava   jdk
+    ++ lib.optional withPrimus primus
     ;
 
-  multiPkgs = pkgs: [
+  multiPkgs = pkgs: with pkgs; [
       # These are required by steam with proper errors
-      pkgs.xlibs.libXcomposite
-      pkgs.xlibs.libXtst
-      pkgs.xlibs.libXrandr
-      pkgs.xlibs.libXext
-      pkgs.xlibs.libX11
-      pkgs.xlibs.libXfixes
+      xlibs.libXcomposite
+      xlibs.libXtst
+      xlibs.libXrandr
+      xlibs.libXext
+      xlibs.libX11
+      xlibs.libXfixes
 
-      pkgs.glib
-      pkgs.gtk2
-      pkgs.bzip2
-      pkgs.zlib
-      pkgs.libpulseaudio
-      pkgs.gdk_pixbuf
+      glib
+      gtk2
+      bzip2
+      zlib
+      libpulseaudio
+      gdk_pixbuf
 
       # Not formally in runtime but needed by some games
-      pkgs.gst_all_1.gstreamer
-      pkgs.gst_all_1.gst-plugins-ugly
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-ugly
     ] ++ lib.optionals withRuntime [
       # Without these it silently fails
-      pkgs.xlibs.libXinerama
-      pkgs.xlibs.libXdamage
-      pkgs.xlibs.libXcursor
-      pkgs.xlibs.libXrender
-      pkgs.xlibs.libXScrnSaver
-      pkgs.xlibs.libXi
-      pkgs.xlibs.libSM
-      pkgs.xlibs.libICE
-      pkgs.gnome2.GConf
-      pkgs.freetype
-      pkgs.openalSoft
-      pkgs.curl
-      pkgs.nspr
-      pkgs.nss
-      pkgs.fontconfig
-      pkgs.cairo
-      pkgs.pango
-      pkgs.alsaLib
-      pkgs.expat
-      pkgs.dbus
-      pkgs.cups
-      pkgs.libcap
-      pkgs.SDL2
-      pkgs.libusb1
-      pkgs.dbus_glib
-      pkgs.libav
-      pkgs.atk
+      xlibs.libXinerama
+      xlibs.libXdamage
+      xlibs.libXcursor
+      xlibs.libXrender
+      xlibs.libXScrnSaver
+      xlibs.libXi
+      xlibs.libSM
+      xlibs.libICE
+      gnome2.GConf
+      freetype
+      openalSoft
+      curl
+      nspr
+      nss
+      fontconfig
+      cairo
+      pango
+      alsaLib
+      expat
+      dbus
+      cups
+      libcap
+      SDL2
+      libusb1
+      dbus_glib
+      libav
+      atk
       # Only libraries are needed from those two
-      pkgs.udev182
-      pkgs.networkmanager098
+      udev182
+      networkmanager098
 
       # Verified games requirements
-      pkgs.xlibs.libXmu
-      pkgs.xlibs.libxcb
-      pkgs.xlibs.libpciaccess
-      pkgs.mesa_glu
-      pkgs.libuuid
-      pkgs.libogg
-      pkgs.libvorbis
-      pkgs.SDL
-      pkgs.SDL2_image
-      pkgs.glew110
-      pkgs.openssl
-      pkgs.libidn
+      xlibs.libXmu
+      xlibs.libxcb
+      xlibs.libpciaccess
+      mesa_glu
+      libuuid
+      libogg
+      libvorbis
+      SDL
+      SDL2_image
+      glew110
+      openssl
+      libidn
 
       # Other things from runtime
-      pkgs.xlibs.libXinerama
-      pkgs.flac
-      pkgs.freeglut
-      pkgs.libjpeg
-      pkgs.libpng12
-      pkgs.libsamplerate
-      pkgs.libmikmod
-      pkgs.libtheora
-      pkgs.pixman
-      pkgs.speex
-      pkgs.SDL_image
-      pkgs.SDL_ttf
-      pkgs.SDL_mixer
-      pkgs.SDL2_net
-      pkgs.SDL2_ttf
-      pkgs.SDL2_mixer
-      pkgs.gstreamer
-      pkgs.gst_plugins_base
+      xlibs.libXinerama
+      flac
+      freeglut
+      libjpeg
+      libpng12
+      libsamplerate
+      libmikmod
+      libtheora
+      pixman
+      speex
+      SDL_image
+      SDL_ttf
+      SDL_mixer
+      SDL2_net
+      SDL2_ttf
+      SDL2_mixer
+      gstreamer
+      gst_plugins_base
     ];
 
   extraBuildCommands = ''
     [ -d lib64 ] && mv lib64/steam lib
 
     # FIXME: maybe we should replace this with proper libcurl-gnutls
-    ( cd lib; ln -s libcurl.so.4 libcurl-gnutls.so.4 )
-    [ -d lib64 ] && ( cd lib64; ln -s libcurl.so.4 libcurl-gnutls.so.4 )
+    ln -s libcurl.so.4 lib/libcurl-gnutls.so.4
+    [ -d lib64 ] && ln -s libcurl.so.4 lib64/libcurl-gnutls.so.4
+  '' + lib.optionals withRuntime ''
+    mkdir -p    steamrt/usr
+    ln -s lib32 steamrt/lib
+
+    if [ -d lib64 ]; then
+      ln -s                    ${steam-runtime}/i386/usr/bin     steamrt/bin
+    else
+      ln -s                    ${steam-runtime}/amd64/usr/bin    steamrt/bin
+    fi
+
+    ln -s                      ${steam-runtime}/i386/etc         steamrt/etc
+    ln -s                      ${steam-runtime}/i386/usr/include steamrt/usr/include
+
+    cp -rsf --no-preserve mode ${steam-runtime}/i386/usr/lib     steamrt/lib32
+    cp -rsf                    ${steam-runtime}/i386/lib/*       steamrt/lib32
+
+    cp -rsf --no-preserve mode ${steam-runtime}/amd64/usr/lib    steamrt/lib64
+    cp -rsf                    ${steam-runtime}/amd64/lib/*      steamrt/lib64
+
+    libs=$(ls -dm --quoting-style=escape steamrt/lib{32,64}/{,*/})
+
+    echo    'export STEAM_RUNTIME=0'                    >  steamrt/profile
+    echo    'export PATH=$PATH:/steamrt/bin'            >> steamrt/profile
+    echo -n 'export LD_LIBRARY_PATH=/'                  >> steamrt/profile
+    echo -n $libs | sed 's/\/, /:\//g' | sed 's/\/$//g' >> steamrt/profile
+    echo    ':$LD_LIBRARY_PATH'                         >> steamrt/profile
   '';
 
   profile = if withRuntime then ''
-    export STEAM_RUNTIME=0
+    source /steamrt/profile
   '' else ''
     # Ugly workaround for https://github.com/ValveSoftware/steam-for-linux/issues/3504
     export LD_PRELOAD=/lib32/libpulse.so:/lib64/libpulse.so:/lib32/libasound.so:/lib64/libasound.so:$LD_PRELOAD

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -8,6 +8,7 @@ buildFHSUserEnv {
 
   targetPkgs = pkgs: with pkgs; [
       steamPackages.steam
+      steamPackages.steam-fonts
       # Errors in output without those
       pciutils
       python2
@@ -16,8 +17,6 @@ buildFHSUserEnv {
       which
       # Needed by gdialog, including in the steam-runtime
       perl
-      # Problems with text visibility in some games
-      corefonts
     ]
     ++ lib.optional withJava   jdk
     ++ lib.optional withPrimus primus

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -33,6 +33,7 @@ buildFHSUserEnv {
       # Not formally in runtime but needed by some games
       gst_all_1.gstreamer
       gst_all_1.gst-plugins-ugly
+      libdrm
 
       steamPackages.steam-runtime-wrapped
     ];

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -5,15 +5,11 @@ buildFHSUserEnv {
 
   targetPkgs = pkgs:
     [ pkgs.steam-original
-      pkgs.corefonts
-      pkgs.curl
-      pkgs.dbus
-      pkgs.dpkg
-      pkgs.mono
-      pkgs.python
-      pkgs.gnome2.zenity
-      pkgs.xdg_utils
-      pkgs.xorg.xrandr
+      # Errors in output without those
+      pkgs.pciutils
+      pkgs.python2
+      # Games' dependencies
+      pkgs.xlibs.xrandr
       pkgs.which
     ]
     ++ lib.optional (config.steam.java or false) pkgs.jdk
@@ -21,59 +17,102 @@ buildFHSUserEnv {
     ;
 
   multiPkgs = pkgs:
-    [ pkgs.cairo
+    [ # These are required by steam with proper errors
+      pkgs.xlibs.libXcomposite
+      pkgs.xlibs.libXtst
+      pkgs.xlibs.libXrandr
+      pkgs.xlibs.libXext
+      pkgs.xlibs.libX11
+      pkgs.xlibs.libXfixes
+
       pkgs.glib
-      pkgs.gtk
-      pkgs.gdk_pixbuf
-      pkgs.pango
-
-      pkgs.freetype
-      pkgs.xorg.libICE
-      pkgs.xorg.libSM
-      pkgs.xorg.libX11
-      pkgs.xorg.libXau
-      pkgs.xorg.libxcb
-      pkgs.xorg.libXcursor
-      pkgs.xorg.libXdamage
-      pkgs.xorg.libXdmcp
-      pkgs.xorg.libXext
-      pkgs.xorg.libXfixes
-      pkgs.xorg.libXi
-      pkgs.xorg.libXinerama
-      pkgs.xorg.libXrandr
-      pkgs.xorg.libXrender
-      pkgs.xorg.libXScrnSaver
-      pkgs.xorg.libXtst
-      pkgs.xorg.libXxf86vm
-
-      pkgs.ffmpeg
-      pkgs.libpng12
-      pkgs.mesa
-      pkgs.SDL
-      pkgs.SDL2
-      pkgs.libdrm
-
-      pkgs.libgcrypt
+      pkgs.gtk2
+      pkgs.bzip2
       pkgs.zlib
-
-      pkgs.alsaLib
-      pkgs.libvorbis
-      pkgs.openal
       pkgs.libpulseaudio
+      pkgs.gdk_pixbuf
 
-      pkgs.gst_all_1.gst-plugins-ugly # "Audiosurf 2" needs this
+      # Without these it silently fails
+      pkgs.xlibs.libXinerama
+      pkgs.xlibs.libXdamage
+      pkgs.xlibs.libXcursor
+      pkgs.xlibs.libXrender
+      pkgs.xlibs.libXScrnSaver
+      pkgs.xlibs.libXi
+      pkgs.xlibs.libSM
+      pkgs.xlibs.libICE
+      pkgs.gnome2.GConf
+      pkgs.freetype
+      pkgs.openalSoft
+      pkgs.curl
+      pkgs.nspr
+      pkgs.nss
+      pkgs.fontconfig
+      pkgs.cairo
+      pkgs.pango
+      pkgs.alsaLib
+      pkgs.expat
+      pkgs.dbus
+      pkgs.cups
+      pkgs.libcap
+      pkgs.SDL2
+      pkgs.libusb1
+      pkgs.dbus_glib
+      pkgs.libav
+      pkgs.atk
+      # Only libraries are needed from those two
+      pkgs.udev182
+      pkgs.networkmanager098
+
+      # Verified games requirements
+      pkgs.xlibs.libXmu
+      pkgs.xlibs.libxcb
+      pkgs.xlibs.libpciaccess
+      pkgs.mesa_glu
+      pkgs.libuuid
+      pkgs.libogg
+      pkgs.libvorbis
+      pkgs.SDL
+      pkgs.SDL2_image
+      pkgs.glew110
+      pkgs.openssl
+      pkgs.libidn
+
+      # Other things from runtime
+      pkgs.xlibs.libXinerama
+      pkgs.flac
+      pkgs.freeglut
+      pkgs.libjpeg
+      pkgs.libpng12
+      pkgs.libsamplerate
+      pkgs.libmikmod
+      pkgs.libtheora
+      pkgs.pixman
+      pkgs.speex
+      pkgs.SDL_image
+      pkgs.SDL_ttf
+      pkgs.SDL_mixer
+      pkgs.SDL2_net
+      pkgs.SDL2_ttf
+      pkgs.SDL2_mixer
+      pkgs.gstreamer
+      pkgs.gst_plugins_base
+
+      # Not formally in runtime but needed by some games
+      pkgs.gst_all_1.gstreamer
+      pkgs.gst_all_1.gst-plugins-ugly
     ];
 
   extraBuildCommandsMulti = ''
     cd usr/lib
     ln -sf ../lib64/steam steam
+
+    # FIXME: maybe we should replace this with proper libcurl-gnutls
+    ln -s libcurl.so.4 libcurl-gnutls.so.4
   '';
 
   profile = ''
-    # Ugly workaround for https://github.com/ValveSoftware/steam-for-linux/issues/3504
-    export LD_PRELOAD=/lib32/libpulse.so:/lib64/libpulse.so:/lib32/libasound.so:/lib64/libasound.so:$LD_PRELOAD
-    # Another one for https://github.com/ValveSoftware/steam-for-linux/issues/3801
-    export LD_PRELOAD=/lib32/libstdc++.so:/lib64/libstdc++.so:$LD_PRELOAD
+    ${if config.steam.enableRuntime or false then "" else "export STEAM_RUNTIME=0"}
   '';
 
   runScript = "steam";

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,14 +1,13 @@
-{ lib, buildFHSUserEnv, steam-runtime
-, withRuntime ? false
-, withJava    ? false
-, withPrimus  ? false
+{ lib, buildFHSUserEnv
+, withJava   ? false
+, withPrimus ? false
 }:
 
 buildFHSUserEnv {
   name = "steam";
 
   targetPkgs = pkgs: with pkgs; [
-      steam-original
+      steamPackages.steam
       # Errors in output without those
       pciutils
       python2
@@ -31,125 +30,24 @@ buildFHSUserEnv {
       xlibs.libX11
       xlibs.libXfixes
 
-      glib
-      gtk2
-      bzip2
-      zlib
-      libpulseaudio
-      gdk_pixbuf
-
       # Not formally in runtime but needed by some games
       gst_all_1.gstreamer
       gst_all_1.gst-plugins-ugly
-    ] ++ lib.optionals withRuntime [
-      # Without these it silently fails
-      xlibs.libXinerama
-      xlibs.libXdamage
-      xlibs.libXcursor
-      xlibs.libXrender
-      xlibs.libXScrnSaver
-      xlibs.libXi
-      xlibs.libSM
-      xlibs.libICE
-      gnome2.GConf
-      freetype
-      openalSoft
-      curl
-      nspr
-      nss
-      fontconfig
-      cairo
-      pango
-      alsaLib
-      expat
-      dbus
-      cups
-      libcap
-      SDL2
-      libusb1
-      dbus_glib
-      libav
-      atk
-      # Only libraries are needed from those two
-      udev182
-      networkmanager098
 
-      # Verified games requirements
-      xlibs.libXmu
-      xlibs.libxcb
-      xlibs.libpciaccess
-      mesa_glu
-      libuuid
-      libogg
-      libvorbis
-      SDL
-      SDL2_image
-      glew110
-      openssl
-      libidn
-
-      # Other things from runtime
-      xlibs.libXinerama
-      flac
-      freeglut
-      libjpeg
-      libpng12
-      libsamplerate
-      libmikmod
-      libtheora
-      pixman
-      speex
-      SDL_image
-      SDL_ttf
-      SDL_mixer
-      SDL2_net
-      SDL2_ttf
-      SDL2_mixer
-      gstreamer
-      gst_plugins_base
+      steamPackages.steam-runtime-wrapped
     ];
 
   extraBuildCommands = ''
     [ -d lib64 ] && mv lib64/steam lib
 
-    # FIXME: maybe we should replace this with proper libcurl-gnutls
-    ln -s libcurl.so.4 lib/libcurl-gnutls.so.4
-    [ -d lib64 ] && ln -s libcurl.so.4 lib64/libcurl-gnutls.so.4
-  '' + lib.optionals withRuntime ''
-    mkdir -p    steamrt/usr
-    ln -s lib32 steamrt/lib
+    mkdir -p steamrt
 
-    if [ -d lib64 ]; then
-      ln -s                    ${steam-runtime}/i386/usr/bin     steamrt/bin
-    else
-      ln -s                    ${steam-runtime}/amd64/usr/bin    steamrt/bin
-    fi
-
-    ln -s                      ${steam-runtime}/i386/etc         steamrt/etc
-    ln -s                      ${steam-runtime}/i386/usr/include steamrt/usr/include
-
-    cp -rsf --no-preserve mode ${steam-runtime}/i386/usr/lib     steamrt/lib32
-    cp -rsf                    ${steam-runtime}/i386/lib/*       steamrt/lib32
-
-    cp -rsf --no-preserve mode ${steam-runtime}/amd64/usr/lib    steamrt/lib64
-    cp -rsf                    ${steam-runtime}/amd64/lib/*      steamrt/lib64
-
-    libs=$(ls -dm --quoting-style=escape steamrt/lib{32,64}/{,*/})
-
-    echo    'export STEAM_RUNTIME=0'                    >  steamrt/profile
-    echo    'export PATH=$PATH:/steamrt/bin'            >> steamrt/profile
-    echo -n 'export LD_LIBRARY_PATH=/'                  >> steamrt/profile
-    echo -n $libs | sed 's/\/, /:\//g' | sed 's/\/$//g' >> steamrt/profile
-    echo    ':$LD_LIBRARY_PATH'                         >> steamrt/profile
+    ln -s ../lib64/steam-runtime steamrt/amd64
+    ln -s ../lib/steam-runtime steamrt/i386
   '';
 
-  profile = if withRuntime then ''
-    source /steamrt/profile
-  '' else ''
-    # Ugly workaround for https://github.com/ValveSoftware/steam-for-linux/issues/3504
-    export LD_PRELOAD=/lib32/libpulse.so:/lib64/libpulse.so:/lib32/libasound.so:/lib64/libasound.so:$LD_PRELOAD
-    # Another one for https://github.com/ValveSoftware/steam-for-linux/issues/3801
-    export LD_PRELOAD=/lib32/libstdc++.so:/lib64/libstdc++.so:$LD_PRELOAD
+  profile = ''
+    export STEAM_RUNTIME=/steamrt
   '';
 
   runScript = "steam";

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -14,8 +14,10 @@ buildFHSUserEnv {
       # Games' dependencies
       xlibs.xrandr
       which
-      # needed by gdialog, including in the steam-runtime
+      # Needed by gdialog, including in the steam-runtime
       perl
+      # Problems with text visibility in some games
+      corefonts
     ]
     ++ lib.optional withJava   jdk
     ++ lib.optional withPrimus primus

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -1,38 +1,13 @@
-{stdenv, fetchurl, traceDeps ? false}:
+{ pkgs, newScope }:
 
-stdenv.mkDerivation rec {
-  name = "${program}-original-${version}";
-  program = "steam";
-  version = "1.0.0.49";
+let
+  callPackage = newScope self;
 
-  src = fetchurl {
-    url = "http://repo.steampowered.com/steam/pool/steam/s/steam/${program}_${version}.tar.gz";
-    sha256 = "1c1gl5pwvb5gnnnqf5d9hpcjnfjjgmn4lgx8v0fbx1am5xf3p2gx";
+  self = rec {
+    steam-runtime = callPackage ./runtime.nix { };
+    steam-runtime-wrapped = callPackage ./runtime-wrapped.nix { };
+    steam = callPackage ./steam.nix { };
+    steam-chrootenv = callPackage ./chrootenv.nix { };
   };
 
-  traceLog = "/tmp/steam-trace-dependencies.log";
-
-  installPhase = ''
-    make DESTDIR=$out install
-    mv $out/usr/* $out #*/
-    rmdir $out/usr
-
-    rm $out/bin/steamdeps
-    ${stdenv.lib.optionalString traceDeps ''
-      cat > $out/bin/steamdeps <<EOF
-      #! /bin/bash
-      echo \$1 >> ${traceLog}
-      cat \$1 >> ${traceLog}
-      echo >> ${traceLog}
-      EOF
-      chmod +x $out/bin/steamdeps
-    ''}
-  '';
-
-  meta = with stdenv.lib; {
-    description = "A digital distribution platform";
-    homepage = http://store.steampowered.com/;
-    license = licenses.unfree;
-    maintainers = with maintainers; [ jagajaga ];
-  };
-}
+in self

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -8,6 +8,7 @@ let
     steam-runtime-wrapped = callPackage ./runtime-wrapped.nix { };
     steam = callPackage ./steam.nix { };
     steam-chrootenv = callPackage ./chrootenv.nix { };
+    steam-fonts = callPackage ./fonts.nix { };
   };
 
 in self

--- a/pkgs/games/steam/fonts.nix
+++ b/pkgs/games/steam/fonts.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "steam-fonts-1";
+
+  src = fetchurl {
+    url = https://support.steampowered.com/downloads/1974-YFKL-4947/SteamFonts.zip;
+    sha256 = "1cgygmwich5f1jhhbmbkkpnzasjl8gy36xln76n6r2gjh6awqfx0";
+  };
+
+  buildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -r *.TTF *.ttf $out/share/fonts/truetype
+  '';
+}

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -1,0 +1,109 @@
+{ stdenv, perl, pkgs, steam-runtime
+, nativeOnly ? false
+, runtimeOnly ? false
+}:
+
+assert !(nativeOnly && runtimeOnly);
+
+let 
+  runtimePkgs = with pkgs; [
+    # Required
+    glib
+    gtk2
+    bzip2
+    zlib
+    gdk_pixbuf
+
+    # Without these it silently fails
+    xlibs.libXinerama
+    xlibs.libXdamage
+    xlibs.libXcursor
+    xlibs.libXrender
+    xlibs.libXScrnSaver
+    xlibs.libXi
+    xlibs.libSM
+    xlibs.libICE
+    gnome2.GConf
+    freetype
+    curl
+    nspr
+    nss
+    fontconfig
+    cairo
+    pango
+    expat
+    dbus
+    cups
+    libcap
+    SDL2
+    libusb1
+    dbus_glib
+    libav
+    atk
+    # Only libraries are needed from those two
+    udev182
+    networkmanager098
+
+    # Verified games requirements
+    xlibs.libXmu
+    xlibs.libxcb
+    xlibs.libpciaccess
+    mesa_glu
+    libuuid
+    libogg
+    libvorbis
+    SDL
+    SDL2_image
+    glew110
+    openssl
+    libidn
+
+    # Other things from runtime
+    xlibs.libXinerama
+    flac
+    freeglut
+    libjpeg
+    libpng12
+    libsamplerate
+    libmikmod
+    libtheora
+    pixman
+    speex
+    SDL_image
+    SDL_ttf
+    SDL_mixer
+    SDL2_net
+    SDL2_ttf
+    SDL2_mixer
+    gstreamer
+    gst_plugins_base
+  ];
+
+  overridePkgs = with pkgs; [
+    gcc48.cc # libstdc++
+    libpulseaudio
+    alsaLib
+    openalSoft
+  ];
+
+  ourRuntime = if runtimeOnly then []
+               else if nativeOnly then runtimePkgs ++ overridePkgs
+               else overridePkgs;
+  steamRuntime = stdenv.lib.optional (!nativeOnly) steam-runtime;
+
+in stdenv.mkDerivation rec {
+  name = "steam-runtime-wrapped";
+
+  allPkgs = ourRuntime ++ steamRuntime;
+
+  nativeBuildInputs = [ perl ];
+
+  builder = ./build-runtime.sh;
+
+  installPhase = ''
+    buildDir "${toString steam-runtime.libs}" "$allPkgs"
+    buildDir "${toString steam-runtime.bins}" "$allPkgs"
+  '';
+
+  meta.hydraPlatforms = [];
+}

--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "steam-runtime-${version}";
+  version = "2014-04-15";
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  src = fetchurl {
+    url = "http://media.steampowered.com/client/runtime/steam-runtime-release_${version}.tar.xz";
+    sha256 = "0i6xp81rjbfn4664h4mmvw0xjwlwvdp6k7cc53jfjadcblw5cf99";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    mv * $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The official runtime used by Steam";
+    homepage = http://store.steampowered.com/;
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ hrdinka ];
+  };
+}

--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -1,6 +1,10 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
+let arch = if stdenv.system == "x86_64-linux" then "amd64"
+           else if stdenv.system == "i686-linux" then "i386"
+           else abort "Unsupported platform";
+
+in stdenv.mkDerivation rec {
   name = "steam-runtime-${version}";
   version = "2014-04-15";
 
@@ -13,13 +17,25 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    mv * $out/
+    mv ${arch}/* $out/
   '';
+
+  passthru = rec {
+    inherit arch;
+
+    gnuArch = if arch == "amd64" then "x86_64-linux-gnu"
+              else if arch == "i386" then "i386-linux-gnu"
+              else abort "Unsupported architecture";
+
+    libs = [ "lib/${gnuArch}" "lib" "usr/lib/${gnuArch}" "usr/lib" ];
+    bins = [ "bin" "usr/bin" ];
+  };
 
   meta = with stdenv.lib; {
     description = "The official runtime used by Steam";
-    homepage = http://store.steampowered.com/;
-    license = licenses.unfreeRedistributable;
+    homepage = https://github.com/ValveSoftware/steam-runtime;
+    license = licenses.mit;
     maintainers = with maintainers; [ hrdinka ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -1,0 +1,38 @@
+{stdenv, fetchurl, traceDeps ? false}:
+
+stdenv.mkDerivation rec {
+  name = "${program}-original-${version}";
+  program = "steam";
+  version = "1.0.0.49";
+
+  src = fetchurl {
+    url = "http://repo.steampowered.com/steam/pool/steam/s/steam/${program}_${version}.tar.gz";
+    sha256 = "1c1gl5pwvb5gnnnqf5d9hpcjnfjjgmn4lgx8v0fbx1am5xf3p2gx";
+  };
+
+  traceLog = "/tmp/steam-trace-dependencies.log";
+
+  installPhase = ''
+    make DESTDIR=$out install
+    mv $out/usr/* $out #*/
+    rmdir $out/usr
+
+    rm $out/bin/steamdeps
+    ${stdenv.lib.optionalString traceDeps ''
+      cat > $out/bin/steamdeps <<EOF
+      #! /bin/bash
+      echo \$1 >> ${traceLog}
+      cat \$1 >> ${traceLog}
+      echo >> ${traceLog}
+      EOF
+      chmod +x $out/bin/steamdeps
+    ''}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A digital distribution platform";
+    homepage = http://store.steampowered.com/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jagajaga ];
+  };
+}

--- a/pkgs/os-specific/linux/udev/182.nix
+++ b/pkgs/os-specific/linux/udev/182.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pkgconfig
+, pciutils, utillinux, kmod, usbutils, gperf
+}:
+
+assert stdenv ? glibc;
+
+stdenv.mkDerivation rec {
+  name = "udev-182";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/utils/kernel/hotplug/${name}.tar.bz2";
+    sha256 = "143qvm0kij26j2l5icnch4x38fajys6li7j0c5mpwi6kqmc8hqx0";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ utillinux kmod usbutils #glib gobjectIntrospection
+                  gperf
+                ];
+
+  configureFlags = [ "--with-pci-ids-path=${pciutils}/share/pci.ids"
+                     "--disable-gudev"
+                     "--disable-introspection"
+                   ];
+
+  NIX_LDFLAGS = [ "-lrt" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.kernel.org/pub/linux/utils/kernel/hotplug/udev.html;
+    description = "Udev manages the /dev filesystem";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/networking/network-manager/0.9.8.nix
+++ b/pkgs/tools/networking/network-manager/0.9.8.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, intltool, pkgconfig, dbus_glib
+, udev, libnl, libuuid, gnutls, dhcp
+, libgcrypt, perl }:
+
+stdenv.mkDerivation rec {
+  name = "network-manager-${version}";
+  version = "0.9.8.10";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/NetworkManager/0.9/NetworkManager-${version}.tar.xz";
+    sha256 = "0wn9qh8r56r8l19dqr68pdl1rv3zg1dv47rfy6fqa91q7li2fk86";
+  };
+
+  preConfigure = ''
+    substituteInPlace tools/glib-mkenums --replace /usr/bin/perl ${perl}/bin/perl
+  '';
+
+  # Right now we hardcode quite a few paths at build time. Probably we should
+  # patch networkmanager to allow passing these path in config file. This will
+  # remove unneeded build-time dependencies.
+  configureFlags = [
+    "--with-distro=exherbo"
+    "--with-dhclient=${dhcp}/sbin/dhclient"
+    "--with-dhcpcd=no"
+    "--with-iptables=no"
+    "--with-udev-dir=\${out}/lib/udev"
+    "--with-resolvconf=no"
+    "--sysconfdir=/etc" "--localstatedir=/var"
+    "--with-dbus-sys-dir=\${out}/etc/dbus-1/system.d"
+    "--with-crypto=gnutls" "--disable-more-warnings"
+    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+    "--with-kernel-firmware-dir=/run/current-system/firmware"
+    "--disable-ppp"
+  ];
+
+  buildInputs = [ udev libnl libuuid gnutls libgcrypt ];
+
+  propagatedBuildInputs = [ dbus_glib ];
+
+  nativeBuildInputs = [ intltool pkgconfig ];
+
+  patches =
+    [ ./libnl-3.2.25.patch
+      ./nixos-purity.patch
+    ];
+
+  preInstall =
+    ''
+      installFlagsArray=( "sysconfdir=$out/etc" "localstatedir=$out/var" )
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://projects.gnome.org/NetworkManager/;
+    description = "Network configuration and management tool";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/network-manager/libnl-3.2.25.patch
+++ b/pkgs/tools/networking/network-manager/libnl-3.2.25.patch
@@ -1,0 +1,61 @@
+diff --git a/src/nm-netlink-monitor.c b/src/nm-netlink-monitor.c
+index ba8053e..5ac39d3 100644
+--- a/src/nm-netlink-monitor.c
++++ b/src/nm-netlink-monitor.c
+@@ -177,40 +177,15 @@ link_msg_handler (struct nl_object *obj, void *arg)
+ static int
+ event_msg_recv (struct nl_msg *msg, void *arg)
+ {
+-	struct nl_sock *nlh = arg;
+-	struct nlmsghdr *hdr = nlmsg_hdr (msg);
+ 	struct ucred *creds = nlmsg_get_creds (msg);
+-	const struct sockaddr_nl *snl;
+-	guint32 local_port;
+-	gboolean accept_msg = FALSE;
+-
+-	/* Only messages sent from the kernel */
+-	if (!creds || creds->uid != 0) {
+-		nm_log_dbg (LOGD_HW, "ignoring netlink message from UID %d",
+-		            creds ? creds->uid : -1);
+-		return NL_SKIP;
+-	}
+-
+-	snl = nlmsg_get_src (msg);
+-	g_assert (snl);
+-
+-	/* Accept any messages from the kernel */
+-	if (hdr->nlmsg_pid == 0 || snl->nl_pid == 0)
+-		accept_msg = TRUE;
+ 
+-	/* And any multicast message directed to our netlink PID, since multicast
+-	 * currently requires CAP_ADMIN to use.
+-	 */
+-	local_port = nl_socket_get_local_port (nlh);
+-	if ((hdr->nlmsg_pid == local_port) && snl->nl_groups)
+-		accept_msg = TRUE;
+-
+-	if (accept_msg == FALSE) {
+-		nm_log_dbg (LOGD_HW, "ignoring netlink message from PID %d (local PID %d, multicast %d)",
+-		            hdr->nlmsg_pid,
+-		            local_port,
+-		            (hdr->nlmsg_flags & NLM_F_MULTI));
+-		return NL_SKIP;
++	if (!creds || creds->pid || creds->uid || creds->gid) {
++		if (creds)
++			nm_log_dbg (LOGD_HW, "netlink: received non-kernel message (pid %d uid %d gid %d)",
++			            creds->pid, creds->uid, creds->gid);
++		else
++			nm_log_dbg (LOGD_HW, "netlink: received message without credentials");
++		return NL_STOP;
+ 	}
+ 
+ 	return NL_OK;
+@@ -285,7 +260,7 @@ nlh_setup (struct nl_sock *nlh,
+ {
+ 	int err;
+ 
+-	nl_socket_modify_cb (nlh, NL_CB_MSG_IN, NL_CB_CUSTOM, event_msg_recv, cb_data);
++	nl_socket_modify_cb (nlh, NL_CB_MSG_IN, NL_CB_CUSTOM, event_msg_recv, NULL);
+ 
+ 	if (valid_func)
+ 		nl_socket_modify_cb (nlh, NL_CB_VALID, NL_CB_CUSTOM, valid_func, cb_data);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6292,6 +6292,7 @@ let
   libgit2_0_21 = callPackage ../development/libraries/git2/0.21.nix { };
 
   glew = callPackage ../development/libraries/glew { };
+  glew110 = callPackage ../development/libraries/glew/1.10.nix { };
 
   glfw = glfw3;
   glfw2 = callPackage ../development/libraries/glfw/2.x.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13781,7 +13781,12 @@ let
 
   steam-original = lowPrio (callPackage ../games/steam { });
 
-  steam = callPackage ../games/steam/chrootenv.nix { };
+  steam = callPackage ../games/steam/chrootenv.nix {
+    # DEPRECATED
+    withJava = config.steam.java or false;
+    withPrimus = config.steam.primus or false;
+    withRuntime = config.steam.withRuntime or true;
+  };
 
   stuntrally = callPackage ../games/stuntrally { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13788,6 +13788,8 @@ let
     withRuntime = config.steam.withRuntime or true;
   };
 
+  steam-runtime = callPackage ../games/steam/runtime.nix { };
+
   stuntrally = callPackage ../games/stuntrally { };
 
   superTux = callPackage ../games/super-tux { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2333,6 +2333,9 @@ let
 
   netselect = callPackage ../tools/networking/netselect { };
 
+  # stripped down, needed by steam
+  networkmanager098 = callPackage ../tools/networking/network-manager/0.9.8.nix { };
+
   networkmanager = callPackage ../tools/networking/network-manager { };
 
   networkmanager_openvpn = callPackage ../tools/networking/network-manager/openvpn.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10286,6 +10286,9 @@ let
   udev = pkgs.systemd;
   eudev = callPackage ../os-specific/linux/eudev {};
 
+  # libudev.so.0
+  udev182 = callPackage ../os-specific/linux/udev/182.nix { };
+
   udisks1 = callPackage ../os-specific/linux/udisks/1-default.nix { };
   udisks2 = callPackage ../os-specific/linux/udisks/2-default.nix { };
   udisks = udisks1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13779,16 +13779,12 @@ let
 
   stardust = callPackage ../games/stardust {};
 
-  steam-original = lowPrio (callPackage ../games/steam { });
-
-  steam = callPackage ../games/steam/chrootenv.nix {
+  steamPackages = callPackage ../games/steam { };
+  steam = steamPackages.steam-chrootenv.override {
     # DEPRECATED
     withJava = config.steam.java or false;
     withPrimus = config.steam.primus or false;
-    withRuntime = config.steam.withRuntime or true;
   };
-
-  steam-runtime = callPackage ../games/steam/runtime.nix { };
 
   stuntrally = callPackage ../games/stuntrally { };
 


### PR DESCRIPTION
This switches off steam-runtime and instead provides all needed libraries from NixOS. I've redone all dependencies anew, so some are missing now (e.g. dpkg -- why was it needed in the first place?). Steam requires some legacy dependencies which I've added, too (stripped down as much as possible).

I've also dropped `udev-145` (it wasn't even building!) and added `udev-182`, which is, to my knowledge, the last version which provides `libudev.so.0`.

That change allows us to drop ugly PulseAudio workaround and prevent other problems like this in the future, but as a price, breakages would be more often as `nixpkgs` is constantly updated (this wouldn't be a problem for stable releases, I think). Also, this change _will_ break some games, as I've specified only packages which were required to run Steam and a few games that I was able to test.

It would be nice if other Steam users would test this on their games and report any missing libraries and/or other problems. @jagajaga?
