### PR TITLE
Update tor to 0.2.6.9

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libevent, openssl, zlib, torsocks }:
 
 stdenv.mkDerivation rec {
-  name = "tor-0.2.6.8";
+  name = "tor-0.2.6.9";
 
   src = fetchurl {
     url = "https://archive.torproject.org/tor-package-archive/${name}.tar.gz";
-    sha256 = "0xlsc2pa7i8hm8dyilln6p4rb0pig62b9c31yp1m0hj5jqw3d2xq";
+    sha256 = "171gjhapymfzql3bbx5qndgkamcfdl6lincrqlr7i3d9i6njjv2a";
   };
 
   # Note: torsocks is specified as a dependency, as the distributed


### PR DESCRIPTION
Updates to tor 0.2.6.9. This has the following changelog:

Changes in version 0.2.6.9 - 2015-06-11
  Tor 0.2.6.9 fixes a regression in the circuit isolation code, increases the
  requirements for receiving an HSDir flag, and addresses some other small
  bugs in the systemd and sandbox code. Clients using circuit isolation
  should upgrade; all directory authorities should upgrade.
- Major bugfixes (client-side privacy):
  - Properly separate out each SOCKSPort when applying stream
    isolation. The error occurred because each port's session group was
    being overwritten by a default value when the listener connection
    was initialized. Fixes bug 16247; bugfix on 0.2.6.3-alpha. Patch
    by "jojelino".
- Minor feature (directory authorities, security):
  - The HSDir flag given by authorities now requires the Stable flag.
    For the current network, this results in going from 2887 to 2806
    HSDirs. Also, it makes it harder for an attacker to launch a sybil
    attack by raising the effort for a relay to become Stable which
    takes at the very least 7 days to do so and by keeping the 96
    hours uptime requirement for HSDir. Implements ticket 8243.
- Minor bugfixes (compilation):
  - Build with --enable-systemd correctly when libsystemd is
    installed, but systemd is not. Fixes bug 16164; bugfix on
    0.2.6.3-alpha. Patch from Peter Palfrader.
- Minor bugfixes (Linux seccomp2 sandbox):
  - Fix sandboxing to work when running as a relaymby renaming of
    secret_id_key, and allowing the eventfd2 and futex syscalls. Fixes
    bug 16244; bugfix on 0.2.6.1-alpha. Patch by Peter Palfrader.
  - Allow systemd connections to work with the Linux seccomp2 sandbox
    code. Fixes bug 16212; bugfix on 0.2.6.2-alpha. Patch by
    Peter Palfrader.
- Minor bugfixes (tests):
  - Fix a crash in the unit tests when built with MSVC2013. Fixes bug
    16030; bugfix on 0.2.6.2-alpha. Patch from "NewEraCracker".
