### PR TITLE
Update ImageMagick to 6.9.1-4

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -10,7 +10,7 @@
 
 let
 
-  version = "6.9.1-0";
+  version = "6.9.1-4";
 
   arch =
     if stdenv.system == "i686-linux" then "i686"
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
   name = "imagemagick-${version}";
 
   src = fetchurl {
-    url = "mirror://imagemagick/releases/ImageMagick-${version}.tar.xz";
-    sha256 = "03lvj6rxv16xk0dpsbzvm2gq5bggkwff9wqbpkq0znihzijpax1j";
+    url = "mirror://imagemagick/ImageMagick-${version}.tar.xz";
+    sha256 = "1gz4y6njqqn0dj1hglnzranp0gbivxhnpxqg0i2cwsc00mw395vl";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -151,9 +151,11 @@ rec {
 
   # ImageMagick mirrors, see http://www.imagemagick.org/script/download.php.
   imagemagick = [
+    http://ftp.surfnet.nl/pub/ImageMagick/
+    http://www.imagemagick.org/download/
     ftp://ftp.nluug.nl/pub/ImageMagick/
-    ftp://ftp.imagemagick.org/pub/ImageMagick/
-    ftp://ftp.imagemagick.net/pub/ImageMagick/
+    ftp://ftp.imagemagick.org/pub/ImageMagick/releases/
+    ftp://ftp.imagemagick.net/pub/ImageMagick/releases/
     ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick/
   ];
 


### PR DESCRIPTION
The archives for 6.9.1-0 seem to be removed from mirrors. Updating
to 6.9.1-4 which does exist on the mirrors. This also fixes the
imagemagick mirror entries where some of them don't have the 'releases'
directory and adds a couple of http mirrors.
