### PR TITLE
[WIP] gmp6: Fix build on ARM

### DIFF
--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, m4, cxx ? true, withStatic ? true }:
 
-with { inherit (stdenv.lib) optional; };
+with { inherit (stdenv.lib) optional optionalString; };
 
 stdenv.mkDerivation rec {
   name = "gmp-5.1.3";
@@ -27,6 +27,13 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin "ABI=64"
     ++ optional stdenv.is64bit "--with-pic"
     ;
+
+  # The config.guess in GMP tries to runtime-detect various
+  # ARM optimization flags via /proc/cpuinfo (and is also
+  # broken on multicore CPUs). Avoid this impurity.
+  preConfigure = optionalString stdenv.isArm ''
+      configureFlagsArray+=("--build=$(./configfsf.guess)")
+    '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, m4, cxx ? true, withStatic ? true }:
 
-with { inherit (stdenv.lib) optional; };
+with { inherit (stdenv.lib) optional optionalString; };
 
 stdenv.mkDerivation rec {
   name = "gmp-6.0.0a";
@@ -25,6 +25,13 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin "ABI=64"
     ++ optional stdenv.is64bit "--with-pic"
     ;
+
+  # The config.guess in GMP tries to runtime-detect various
+  # ARM optimization flags via /proc/cpuinfo (and is also
+  # broken on multicore CPUs). Avoid this impurity.
+  preConfigure = optionalString stdenv.isArm ''
+      configureFlagsArray+=("--build=$(./configfsf.guess)")
+    '';
 
   doCheck = true;
 


### PR DESCRIPTION
The config.guess script is borked; it seems to determine a machine type
of `neon neon neon neon-unknown-linux-gnueabihf` on a quad-core machine:

```
checking build system type... Invalid configuration `neon': machine `neon' not recognized
configure: error: /nix/store/bafimhdj1yaxj6m1hvq7wvhwwizc939x-bootstrap-tools/bin/sh ./config.sub neon
neon
neon
neon-unknown-linux-gnueabihf failed
builder for ‘/nix/store/1npm2358bpvclj5w7fqjjwg72vbb0d79-gmp-6.0.0a.drv’ failed with exit code 1
```

Set the machine type explicitly to fix the build an avoid the impurity
of peeking at the build machine's CPU as well.

cc @wkennington: this is now needed to build stdenv on ARM after 370fc79b948438694dc4767570afe43c5b1fb7c4
