### PR TITLE
sqlite: cherry-pick stable updates to release-14.12 branch

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -114,6 +114,7 @@
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
+  np = "Nicolas Pouillard <np.nix@nicolaspouillard.fr>";
   nslqqq = "Nikita Mikhailov <nslqqq@gmail.com>";
   ocharles = "Oliver Charles <ollie@ocharles.org.uk>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -3,11 +3,11 @@
 assert interactive -> readline != null && ncurses != null;
 
 stdenv.mkDerivation {
-  name = "sqlite-3.8.8.3";
+  name = "sqlite-3.8.9";
 
   src = fetchurl {
-    url = "http://sqlite.org/2015/sqlite-autoconf-3080803.tar.gz";
-    sha1 = "2fe3f6226a2a08a2e814b97cd53e36bb3c597112";
+    url = "http://sqlite.org/2015/sqlite-autoconf-3080900.tar.gz";
+    sha1 = "p6vwiqalhk7ybcx5p8n322vhd3idww6v";
   };
 
   buildInputs = lib.optionals interactive [ readline ncurses ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -3,11 +3,11 @@
 assert interactive -> readline != null && ncurses != null;
 
 stdenv.mkDerivation {
-  name = "sqlite-3.8.10.1";
+  name = "sqlite-3.8.10.2";
 
   src = fetchurl {
-    url = "http://sqlite.org/2015/sqlite-autoconf-3081001.tar.gz";
-    sha1 = "86bfed5752783fb24c051f3efac5972ce11023f0";
+    url = "http://sqlite.org/2015/sqlite-autoconf-3081002.tar.gz";
+    sha1 = "c2f2c17d3dc4c4e179d35cc04e4420636d48a152";
   };
 
   buildInputs = lib.optionals interactive [ readline ncurses ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -3,11 +3,11 @@
 assert interactive -> readline != null && ncurses != null;
 
 stdenv.mkDerivation {
-  name = "sqlite-3.8.7.4";
+  name = "sqlite-3.8.8.3";
 
   src = fetchurl {
-    url = "http://www.sqlite.org/2014/sqlite-autoconf-3080704.tar.gz";
-    sha1 = "70ca0b8884a6b145b7f777724670566e2b4f3cde";
+    url = "http://sqlite.org/2015/sqlite-autoconf-3080803.tar.gz";
+    sha1 = "2fe3f6226a2a08a2e814b97cd53e36bb3c597112";
   };
 
   buildInputs = lib.optionals interactive [ readline ncurses ];
@@ -20,6 +20,6 @@ stdenv.mkDerivation {
     homepage = http://www.sqlite.org/;
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
     platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    maintainers = with stdenv.lib.maintainers; [ eelco np ];
   };
 }

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -3,11 +3,11 @@
 assert interactive -> readline != null && ncurses != null;
 
 stdenv.mkDerivation {
-  name = "sqlite-3.8.9";
+  name = "sqlite-3.8.10.1";
 
   src = fetchurl {
-    url = "http://sqlite.org/2015/sqlite-autoconf-3080900.tar.gz";
-    sha1 = "p6vwiqalhk7ybcx5p8n322vhd3idww6v";
+    url = "http://sqlite.org/2015/sqlite-autoconf-3081001.tar.gz";
+    sha1 = "86bfed5752783fb24c051f3efac5972ce11023f0";
   };
 
   buildInputs = lib.optionals interactive [ readline ncurses ];


### PR DESCRIPTION
Making PR to see if anything breaks.

This unbreaks xulrunner, which requires at least sqlite 3.8.9.
