### PR TITLE
findutils: disable test_canonicalize as it fails when user doesn't have permission to list all TMPDIR's parent directories

### DIFF
--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [coreutils];
 
-  patches = [ ./findutils-path.patch ./change_echo_path.patch ];
+  patches = [ ./findutils-path.patch ./change_echo_path.patch ./disable-test-canonicalize.patch ];
 
   doCheck = true;
 

--- a/pkgs/tools/misc/findutils/disable-test-canonicalize.patch
+++ b/pkgs/tools/misc/findutils/disable-test-canonicalize.patch
@@ -1,0 +1,12 @@
+diff -ruN findutils-4.4.2/tests/test-canonicalize.sh findutils-4.4.2_edited/tests/test-canonicalize.sh
+--- findutils-4.4.2/tests/test-canonicalize.sh	2008-12-23 12:50:15.000000000 +0000
++++ findutils-4.4.2_edited/tests/test-canonicalize.sh	2015-06-14 10:51:19.000000000 +0000
+@@ -1,5 +1,8 @@
+ #!/bin/sh
+ 
++# skipped because user might not have directory listing permission for all parents of TMPDIR
++exit 77
++
+ tmpfiles=""
+ trap 'rm -fr $tmpfiles' 1 2 3 15
+ 


### PR DESCRIPTION
There's probably a better way of doing this (e.g. detecting the situation and selectively skipping the test), and it's probably something that should be fixed upstream.

But... this works for now. Without this patch it precludes users from using a `TMPDIR` in their home directory. Which might be necessary if your `/tmp` is mounted `noexec`.
