### PR TITLE
Mariadb darwin

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -49,9 +49,12 @@ stdenv.mkDerivation rec {
     "-DWITH_PARTITION_STORAGE_ENGINE=1"
     "-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1"
     "-DWITHOUT_FEDERATED_STORAGE_ENGINE=1"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "-DWITHOUT_OQGRAPH_STORAGE_ENGINE=1";
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "-DWITHOUT_OQGRAPH_STORAGE_ENGINE=1"
+    "-DWITHOUT_TOKUDB=1"
+  ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
+  NIX_CFLAGS_COMPILE = if stdenv.isDarwin then "" else "-Wno-error=cpp";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
I have successfully compiled mariadb and ncurses on darwin with these patches in place.
I have also tested compilation on linux.

Mariadb - remove TokuDB, change some compiler flags
Ncurses - build shared lib on darwin, support `.dylib` shared lib suffix

The ncurses postInstall script is getting a bit messy. Not sure how to really improve it though.

@wkennington @shlevy @thoughtpolice 
