### PR TITLE
goPackages: grpc: fix dependencies so that grpc builds

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -652,6 +652,12 @@ let
     buildInputs = [ net oauth2 protobuf google-api-go-client grpc ];
   };
 
+  gcloud-golang-compute-metadata = buildGoPackage rec {
+    inherit (gcloud-golang) rev name goPackagePath src;
+    subPackages = [ "compute/metadata" ];
+    buildInputs = [ net ];
+  };
+
   ginkgo = buildGoPackage rec {
     rev = "5ed93e443a4b7dfe9f5e95ca87e6082e503021d2";
     name = "ginkgo-${stdenv.lib.strings.substring 0 7 rev}";
@@ -1378,6 +1384,7 @@ let
       sha256 = "07dfpwwk68rrhxmqj69gq2ncsf3kfmn0zhlwscda0gc5gb57n5x1";
     };
 
+    buildInputs = [ gcloud-golang-compute-metadata ];
     propagatedBuildInputs = [ http2 glog net protobuf oauth2 ];
   };
 


### PR DESCRIPTION
`nix-build -A pkgs.goPackages.grpc` failed to build. This also happens on Hydra: https://hydra.nixos.org/build/22490000/nixlog/1/tail-reload

I had some trouble solving this issue, since adding `gcloud-golang` as a buildInput of `grpc` would cause recursion (gcloud-golang already depends on grpc). `grpc` only needs `google.golang.org/cloud/compute/metadata`, which does not depend on `grpc`, so I made a similar package with only this sub-package in it.

Let me know if there is a better way to solve this.
