### PR TITLE
libuv: 1.5.0 -> 1.6.1

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -105,5 +105,5 @@ in
   //
   mapAttrs (v: h: mkWithAutotools stable (toVersion v) h) {
     v1_2_0 = "1nbp8qpgw64gl9nrjzxw0ndv1m64cfms0cy5a2883vw6877kizmx";
-    v1_5_0 = "1j0871mxw97680ghlqy0dpyfmr26kqa0lk26a2bgcqf4ghqap24x";
+    v1_6_1 = "10w9pjbmqcv03v04rnjd8mdh886j7v4y0svdsdklz69zskgdvvqg";
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1969,7 +1969,7 @@ let
   else
     nodePackages_0_12;
 
-  iojs = callPackage ../development/web/iojs { libuv = libuvVersions.v1_5_0; };
+  iojs = callPackage ../development/web/iojs { libuv = libuvVersions.v1_6_1; };
 
   iojsPackages = callPackage ./node-packages.nix { self = iojsPackages; nodejs = iojs; };
 
@@ -7241,7 +7241,7 @@ let
     automake = automake113x; # fails with 14
   });
 
-  libuv = libuvVersions.v1_5_0;
+  libuv = libuvVersions.v1_6_1;
 
   libv4l = lowPrio (v4l_utils.override {
     alsaLib = null;


### PR DESCRIPTION
Consists mostly of bugfixes. Builds locally. Should be API-compatible with 1.5. Any chance of getting this backported into the next stable snapshot?

cc @cstrahan
