### PR TITLE
Erlang with wxSupport using wxmac on darwin

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -133,6 +133,7 @@
   lhvwb = "Nathaniel Baxter <nathaniel.baxter@gmail.com>";
   linquize = "Linquize <linquize@yahoo.com.hk>";
   linus = "Linus Arver <linusarver@gmail.com>";
+  lnl7 = "Daiderd Jordan <daiderd@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";

--- a/pkgs/development/libraries/wxmac/default.nix
+++ b/pkgs/development/libraries/wxmac/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, setfile, rez, derez,
+  expat, libjpeg, libpng, libtiff, zlib
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "3.0.2";
+  name = "wxmac-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/wxwindows/wxWidgets-${version}.tar.bz2";
+    sha256 = "346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d";
+  };
+
+  patches = [ ./wx.patch ];
+
+  buildInputs = [ setfile rez derez expat libjpeg libpng libtiff zlib ];
+
+  configureFlags = [
+    "--enable-unicode"
+    "--with-osx_cocoa"
+    "--enable-std_string"
+    "--enable-display"
+    "--with-opengl"
+    "--with-libjpeg"
+    "--with-libtiff"
+    "--without-liblzma"
+    "--with-libpng"
+    "--with-zlib"
+    "--enable-dnd"
+    "--enable-clipboard"
+    "--enable-webkit"
+    "--enable-svg"
+    "--enable-graphics_ctx"
+    "--enable-controls"
+    "--enable-dataviewctrl"
+    "--with-expat"
+    "--disable-precomp-headers"
+    "--disable-mediactrl"
+  ];
+
+  checkPhase = ''
+    ./wx-config --libs
+  '';
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  meta = {
+    platforms = platforms.darwin;
+    maintainers = [ maintainers.lnl7 ];
+  };
+}

--- a/pkgs/development/libraries/wxmac/default.nix
+++ b/pkgs/development/libraries/wxmac/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, setfile, rez, derez,
-  expat, libjpeg, libpng, libtiff, zlib
+  expat, libiconv, libjpeg, libpng, libtiff, zlib
 }:
 
 with stdenv.lib;
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./wx.patch ];
 
-  buildInputs = [ setfile rez derez expat libjpeg libpng libtiff zlib ];
+  buildInputs = [ setfile rez derez expat libiconv libjpeg libpng libtiff zlib ];
 
   configureFlags = [
     "--enable-unicode"

--- a/pkgs/development/libraries/wxmac/wx.patch
+++ b/pkgs/development/libraries/wxmac/wx.patch
@@ -1,0 +1,59 @@
+diff --git a/include/wx/defs.h b/include/wx/defs.h
+index 397ddd7..d128083 100644
+--- a/include/wx/defs.h
++++ b/include/wx/defs.h
+@@ -3169,12 +3169,20 @@ DECLARE_WXCOCOA_OBJC_CLASS(UIImage);
+ DECLARE_WXCOCOA_OBJC_CLASS(UIEvent);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSSet);
+ DECLARE_WXCOCOA_OBJC_CLASS(EAGLContext);
++DECLARE_WXCOCOA_OBJC_CLASS(UIWebView);
+ 
+ typedef WX_UIWindow WXWindow;
+ typedef WX_UIView WXWidget;
+ typedef WX_EAGLContext WXGLContext;
+ typedef WX_NSString* WXGLPixelFormat;
+ 
++typedef WX_UIWebView OSXWebViewPtr;
++
++#endif
++
++#if wxOSX_USE_COCOA_OR_CARBON
++DECLARE_WXCOCOA_OBJC_CLASS(WebView);
++typedef WX_WebView OSXWebViewPtr;
+ #endif
+ 
+ #endif /* __WXMAC__ */
+diff --git a/include/wx/html/webkit.h b/include/wx/html/webkit.h
+index 8700367..f805099 100644
+--- a/include/wx/html/webkit.h
++++ b/include/wx/html/webkit.h
+@@ -18,7 +18,6 @@
+ #endif
+ 
+ #include "wx/control.h"
+-DECLARE_WXCOCOA_OBJC_CLASS(WebView); 
+ 
+ // ----------------------------------------------------------------------------
+ // Web Kit Control
+@@ -107,7 +106,7 @@ private:
+     wxString m_currentURL;
+     wxString m_pageTitle;
+ 
+-    WX_WebView m_webView;
++    OSXWebViewPtr m_webView;
+ 
+     // we may use this later to setup our own mouse events,
+     // so leave it in for now.
+diff --git a/include/wx/osx/webview_webkit.h b/include/wx/osx/webview_webkit.h
+index 803f8b0..438e532 100644
+--- a/include/wx/osx/webview_webkit.h
++++ b/include/wx/osx/webview_webkit.h
+@@ -158,7 +158,7 @@ private:
+     wxWindowID m_windowID;
+     wxString m_pageTitle;
+ 
+-    wxObjCID m_webView;
++    OSXWebViewPtr m_webView;
+ 
+     // we may use this later to setup our own mouse events,
+     // so leave it in for now.

--- a/pkgs/os-specific/darwin/derez/default.nix
+++ b/pkgs/os-specific/darwin/derez/default.nix
@@ -1,0 +1,34 @@
+{ stdenv }:
+
+# this tool only exists on darwin
+assert stdenv.isDarwin;
+
+stdenv.mkDerivation {
+  name = "derez";
+
+  src = "/usr/bin/DeRez";
+
+  unpackPhase = "true";
+  configurePhase = "true";
+  buildPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    ln -s $src "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Decompiles resources";
+    homepage    = "https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/DeRez.1.html";
+    maintainers = [ maintainers.lnl7 ];
+    platforms   = platforms.darwin;
+
+    longDescription = ''
+      The DeRez tool decompiles the resource fork of resourceFile according to the type declarations
+      supplied by the type declaration files. The resource description produced by this decompilation
+      contains the resource definitions (resource and data statements) associated with these type
+      declarations. If for some reason it cannot reproduce the appropriate resource statements, DeRez
+      generates hexadecimal data statements instead.
+    '';
+  };
+}

--- a/pkgs/os-specific/darwin/rez/default.nix
+++ b/pkgs/os-specific/darwin/rez/default.nix
@@ -1,0 +1,33 @@
+{ stdenv }:
+
+# this tool only exists on darwin
+assert stdenv.isDarwin;
+
+stdenv.mkDerivation {
+  name = "rez";
+
+  src = "/usr/bin/Rez";
+
+  unpackPhase = "true";
+  configurePhase = "true";
+  buildPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    ln -s $src "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Compiles resources";
+    homepage    = "https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/Rez.1.html";
+    maintainers = [ maintainers.lnl7 ];
+    platforms   = platforms.darwin;
+
+    longDescription = ''
+      The Rez tool compiles the resource fork of a file according to the textual description contained in
+      the resource description files. These resource description files must contain both the type
+      declarations and the resource definitions needed to compile the resources. This data can come
+      directly from the resource description files.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -635,6 +635,9 @@ let
 
   oracle-instantclient = callPackage ../development/libraries/oracle-instantclient { };
 
+  derez = callPackage ../os-specific/darwin/derez { };
+  rez = callPackage ../os-specific/darwin/rez { };
+
   setfile = callPackage ../os-specific/darwin/setfile { };
 
   install_name_tool = callPackage ../os-specific/darwin/install_name_tool { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8227,6 +8227,8 @@ let
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
   };
 
+  wxmac = callPackage ../development/libraries/wxmac { };
+
   wtk = callPackage ../development/libraries/wtk { };
 
   x264 = callPackage ../development/libraries/x264 { };


### PR DESCRIPTION
- add rez and derez tools (based on setfile)
- add wxmac (based on the formula in homebrew)
- erlang uses wxmac instead of wxGTK when running darwin
