### PR TITLE
Make it possible to boot NixOS from a SCSI Disk on KVM

### DIFF
--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -4,7 +4,7 @@
 { config, pkgs, ... }:
 
 {
-  boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_blk" "9p" "9pnet_virtio" ];
+  boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_blk" "virtio_scsi" "9p" "9pnet_virtio" ];
   boot.initrd.kernelModules = [ "virtio_balloon" "virtio_console" "virtio_rng" ];
 
   boot.initrd.postDeviceCommands =


### PR DESCRIPTION
Currently NixOS can't boot from a SCSI disk as a KVM Guest.
I found this out while installing it on the new [Linode KVM
platform](https://www.linode.com/docs/platform/kvm#custom-kernel-configuration).
