### PR TITLE
rsyslog: 8.9.0 -> 8.10.0

### DIFF
--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -11,11 +11,11 @@ let
   mkFlag = cond: name: if cond then "--enable-${name}" else "--disable-${name}";
 in
 stdenv.mkDerivation rec {
-  name = "rsyslog-8.9.0";
+  name = "rsyslog-8.10.0";
 
   src = fetchurl {
     url = "http://www.rsyslog.com/files/download/rsyslog/${name}.tar.gz";
-    sha256 = "1p3saxfs723479rbsdyvqwfrblcp0bw6mkz2ncrxvnccfn70xc7a";
+    sha256 = "04k90v7fm1czg3lm5anfnf5cnxcxyhxldkgwzzi1k0hhczrz6bdr";
   };
 
   buildInputs = [


### PR DESCRIPTION
This should finally unblock nixos-unstable-small.
