### PR TITLE
pkg highlight: fix conf_dir

### DIFF
--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ getopt lua boost pkgconfig ];
 
-  preConfigure = ''makeFlags="PREFIX=$out conf_dir=$out/etc/highlight"'';
+  preConfigure = ''makeFlags="PREFIX=$out conf_dir=$out/etc/highlight/"'';
 
   meta = {
     description = "Source code highlighting tool";


### PR DESCRIPTION
This patch fixes an issue locating the default configuration directory:

``` console
$ strace highlight </dev/null 2>&1 | fgrep etc/highlight
stat("/nix/store/vksc49amxai7jzdmc1mdr90926jp81zk-highlight-3.18/etc/highlightfiletypes.conf", 0x7ffd4c801df0) = -1 ENOENT (No such file or directory)
```
