### PR TITLE
rethinkdb: patch sed command on darwin

### DIFF
--- a/pkgs/servers/nosql/rethinkdb/default.nix
+++ b/pkgs/servers/nosql/rethinkdb/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ protobuf boost zlib curl icu jemalloc ];
 
+  patches = if stdenv.isDarwin then [ ./sedDarwin.patch ] else null;
+
   nativeBuildInputs = [ which m4 python ];
 
   meta = {

--- a/pkgs/servers/nosql/rethinkdb/sedDarwin.patch
+++ b/pkgs/servers/nosql/rethinkdb/sedDarwin.patch
@@ -1,0 +1,11 @@
+--- a/mk/support/pkg/re2.sh	2015-06-03 11:16:44.000000000 -0600
++++ b/mk/support/pkg/re2.sh	2015-06-03 11:16:59.000000000 -0600
+@@ -12,7 +12,7 @@
+     pkg_copy_src_to_build
+     if [[ "$OS" = Darwin ]]; then
+         # The symbol list is broken on OS X 10.7.5 with XCode 3.2.6
+-        sed -i '' 's/-exported_symbols_list libre2.symbols.darwin//' "$build_dir/Makefile"
++        sed -i 's/-exported_symbols_list libre2.symbols.darwin//' "$build_dir/Makefile"
+         CXXFLAGS="${CXXFLAGS:-} -stdlib=libc++"
+         LDFLAGS="${LDFLAGS:-} -lc++"
+     fi


### PR DESCRIPTION
RethinkDB fails to install on Darwin because the version of sed on Darwin expects different arguments. This patches the sed command to what the version of sed used in nix to build RethinkDB expects.
