### PR TITLE
tmux: Homepage & releases no longer hosted at sourceforge

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, ncurses, libevent, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "tmux-2.0";
+  name = "tmux-${version}";
+  version = "2.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/tmux/${name}.tar.gz";
+    url = "https://github.com/tmux/tmux/releases/download/${version}/${name}.tar.gz";
     sha256 = "0qnkda8kb747vmbldjpb23ksv9pq3s65xhh1ja5rdsmh8r24npvr";
   };
 
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://tmux.sourceforge.net/;
+    homepage = http://tmux.github.io/;
     description = "Terminal multiplexer";
 
     longDescription =


### PR DESCRIPTION
See https://github.com/tmux/tmux/commit/d2b35e19cdd61d163d26c4babccc1550e72a9623
