### PR TITLE
Rofi updates

### DIFF
--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,17 +1,15 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig
+{ stdenv, fetchurl, autoconf, automake, pkgconfig
 , libX11, libXinerama, libXft, pango
 , i3Support ? false, i3
 }:
 
 stdenv.mkDerivation rec {
   name = "rofi-${version}";
-  version = "0.15.2";
+  version = "0.15.5";
 
-  src = fetchFromGitHub {
-    repo = "rofi";
-    owner = "DaveDavenport";
-    rev = "${version}";
-    sha256 = "0b8k5g2fpqrz1yac09kmfk4caxcc107qq4yhncnl159xdxw66vz8";
+  src = fetchurl {
+    url = "https://github.com/DaveDavenport/rofi/archive/${version}.tar.gz";
+    sha256 = "16dffwxqxcx5krb6v1m6gh0r6d0a4hwl0jq4fdyblcv9xid5hxf5";
   };
 
   buildInputs = [ autoconf automake pkgconfig libX11 libXinerama libXft pango
@@ -25,5 +23,6 @@ stdenv.mkDerivation rec {
       description = "Window switcher, run dialog and dmenu replacement";
       homepage = https://davedavenport.github.io/rofi;
       license = stdenv.lib.licenses.mit;
+      maintainers = [ stdenv.lib.maintainers.mbakke ];
   };
 }

--- a/pkgs/applications/misc/rofi/pass.nix
+++ b/pkgs/applications/misc/rofi/pass.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, rofi, wmctrl, xprop, xdotool}:
 
 stdenv.mkDerivation rec {
-  name = "rofi-${version}";
+  name = "rofi-pass-${version}";
   version = "2015-06-08";
 
   src = fetchgit {


### PR DESCRIPTION
Update rofi to 0.15.5 and switch to prepackaged archive. Also took the liberty of renaming rofi-pass to avoid name conflict (ping @hiberno). Requires #8394 for maintainers update.
