### PR TITLE
dont test i3

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -24,7 +24,13 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  doCheck = stdenv.system == "x86_64-linux";
+  # Tests have been failing (at least for some people in some cases)
+  # and have been disabled until someone wants to fix them. Some
+  # initial digging uncovers that the tests call out to `git`, which
+  # they shouldn't, and then even once that's fixed have some
+  # perl-related errors later on. For more, see
+  # https://github.com/NixOS/nixpkgs/issues/7957
+  doCheck = false; # stdenv.system == "x86_64-linux";
 
   checkPhase = stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
   ''
@@ -60,4 +66,3 @@ stdenv.mkDerivation rec {
   };
 
 }
-


### PR DESCRIPTION
i3 has sporadically failed to build for over a month due to something pointless with the test (https://github.com/NixOS/nixpkgs/issues/7957). I don't know the perl to fix it, but until someone does so, I think it's best to disable tests and allow it to continue to build. I've witnessed this causing some issues for newcomers.

This is the patch I've been using locally.
