### PR TITLE
Explanation to desktopManagerHandlesLidAndPower

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -56,7 +56,7 @@ let
         if [ -z "$_INHIBITION_LOCK_TAKEN" ]; then
           export _INHIBITION_LOCK_TAKEN=1
           if ! ${config.systemd.package}/bin/loginctl show-session $XDG_SESSION_ID | grep -q '^RemoteHost='; then
-            exec ${config.systemd.package}/bin/systemd-inhibit --what=handle-lid-switch:handle-power-key "$0" "$sessionType"
+            exec ${config.systemd.package}/bin/systemd-inhibit --what=handle-lid-switch:handle-power-key --why="See NixOS configuration option 'services.xserver.displayManager.desktopManagerHandlesLidAndPower' for more information." "$0" "$sessionType"
           fi
         fi
 


### PR DESCRIPTION
With this patch, systemd-inhibit outputs a descriptive message when
desktopManagerHandlesLidAndPower=true (the default).

Before the patch:

```
$ systemd-inhibit
     Who: /nix/store/[...]-xsession [...] (UID 1000/cassou, PID 18561/systemd-inhibit)
    What: handle-power-key:handle-lid-switch
     Why: Unknown reason
    Mode: block
```

After the patch:

```
$ systemd-inhibit
     Who: /nix/store/[...]-xsession [...] (UID 1000/cassou, PID 18561/systemd-inhibit)
    What: handle-power-key:handle-lid-switch
     Why: See NixOS configuration option 'services.xserver.displayManager.desktopManagerHandlesLidAndPower' for more information.
    Mode: block
```
