### PR TITLE
Add triumph-adler printing driver

### DIFF
--- a/pkgs/misc/cups/drivers/triumph-adler/default.nix
+++ b/pkgs/misc/cups/drivers/triumph-adler/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, patchelf, cups, gcc }:
+
+let
+  arch = if stdenv.system == "x86_64-linux" then "64bit" else "32bit";
+  region = "Global";
+  lang = "English";
+in
+
+stdenv.mkDerivation rec {
+  name = "triumph-adler-${version}";
+  version = "20140115";
+
+  src = fetchurl {
+    url = "http://www.triumph-adler.de/C125712200447418/vwLookupDownloads/TALinuxPackages_cCD-cLP_${version}.tar.gz/$FILE/TALinuxPackages_cCD-cLP_${version}.tar.gz";
+    sha256 = "1bbjw62y2j2ya0xdh9d9pnmfi4rc16dv3yf910pr2ri2nf1140ym";
+  };
+
+  buildInputs = [ cups patchelf gcc ];
+
+  installPhase = ''
+    # Install all PPD files
+    mkdir -p "$out/share/cups/model/UTAX_TA/"
+    find */${arch}/${region}/${lang}/ -type f -name "*.PPD" \
+      -exec cp {} $out/share/cups/model/UTAX_TA/ \;
+
+    # There are hundreds of filters but they don't differ from each other so we
+    # just pick the first one.
+    mkdir -p "$out/lib/cups/filter/"
+    cp "206ci series/${arch}/${region}/${lang}/kyofilter_B" \
+      $out/lib/cups/filter/
+    chmod a+x $out/lib/cups/filter/kyofilter_B
+  '';
+
+  preFixup = ''
+    # Remove hard coded prefixes
+    for file in $out/share/cups/model/UTAX_TA/*; do
+      substituteInPlace "$file" \
+        --replace /usr/lib/cups/filter/ ""
+    done
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath $cups/lib:$gcc/lib \
+      $out/lib/cups/filter/kyofilter_B
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CUPS driver for TA Triumph-Adler printers";
+    homepage = https://www.triumph-adler.de;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jgeerds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14637,6 +14637,8 @@ let
 
   thinkfan = callPackage ../tools/system/thinkfan { };
 
+  triumphAdler = callPackage ../misc/cups/drivers/triumph-adler { };
+
   tup = callPackage ../development/tools/build-managers/tup { };
 
   utf8proc = callPackage ../development/libraries/utf8proc { };


### PR DESCRIPTION
I'm currently trying to package the `triumph-adler` CUPS printing driver and need some help with  patchelf stuff. 

When I don't manually patch the `kyofilter_B` cups filter I get the following error:

```
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Job stopped due to filter errors; please consult the error_log file for details.
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] The following messages were recorded from 11:04:06 to 11:04:09
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Adding start banner page "none".
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Adding end banner page "none".
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] File of type application/vnd.cups-pdf-banner queued by "jascha".
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] hold_until=0
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Queued on "NM887FD8" by "jascha".
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] time-at-processing=1434704646
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] 4 filters for job:
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] bannertopdf (application/vnd.cups-pdf-banner to application/pdf, cost 32)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] pdftopdf (application/pdf to application/vnd.cups-pdf, cost 66)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] pdftops (application/vnd.cups-pdf to application/vnd.cups-postscript, cost 100)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] /nix/store/3p9bs24jiyzbsv77mslw3znrm6zcqlyv-triumph-adler-20140115/lib/cups/filter/kyofilter_B (application/vnd.cups-postscript to printer/NM887FD8, cost 0)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] job-sheets=none,none
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[0]="NM887FD8"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[1]="18"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[2]="jascha"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[3]="Test Page"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[4]="1"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[5]="job-uuid=urn:uuid:6c613bcd-6f65-38fc-7482-6ccda2d44657 job-originating-host-name=localhost time-at-creation=1434704646 time-at-processing=1434704646"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] argv[6]="/var/spool/cups/d00018-001"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[0]="PATH=/nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups/filter:/nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/bin:/nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[1]="CUPS_CACHEDIR=/var/cache/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[2]="CUPS_DATADIR=/nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/share/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[3]="CUPS_DOCROOT=/nix/store/lsylfzxplcc06qky5w3qmv9rkhjibb2l-cups-2.0.2/share/doc/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[4]="CUPS_FONTPATH=/nix/store/lsylfzxplcc06qky5w3qmv9rkhjibb2l-cups-2.0.2/share/cups/fonts"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[5]="CUPS_REQUESTROOT=/var/spool/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[6]="CUPS_SERVERBIN=/nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[7]="CUPS_SERVERROOT=/etc/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[8]="CUPS_STATEDIR=/var/run/cups"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[9]="HOME=/tmp"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[10]="SERVER_ADMIN=root@dione"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[11]="SOFTWARE=CUPS/2.0.2"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[12]="TMPDIR=/tmp"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[13]="USER=root"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[14]="CUPS_MAX_MESSAGE=2047"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[15]="CUPS_SERVER=/var/run/cups/cups.sock"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[16]="CUPS_ENCRYPTION=IfRequested"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[17]="IPP_PORT=631"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[18]="CHARSET=utf-8"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[19]="LANG=de.UTF-8"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[20]="PPD=/etc/cups/ppd/NM887FD8.ppd"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[21]="RIP_MAX_CACHE=128m"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[22]="CONTENT_TYPE=application/vnd.cups-pdf-banner"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[23]="DEVICE_URI=dnssd://NM887FD8._ipp._tcp.local/"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[24]="PRINTER_INFO=UTAX_TA UTAX_TA 2550ci (KPDL)"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[25]="PRINTER_LOCATION=Local Printer"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[26]="PRINTER=NM887FD8"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[27]="PRINTER_STATE_REASONS=none"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[28]="CUPS_FILETYPE=document"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[29]="FINAL_CONTENT_TYPE=application/vnd.cups-postscript"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] envp[30]="AUTH_I****"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Started filter /nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups/filter/bannertopdf (PID 7152)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Started filter /nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups/filter/pdftopdf (PID 7153)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Started filter /nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups/filter/pdftops (PID 7154)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Started filter /nix/store/3p9bs24jiyzbsv77mslw3znrm6zcqlyv-triumph-adler-20140115/lib/cups/filter/kyofilter_B (PID 7155)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Started backend /nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups/backend/dnssd (PID 7156)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] PID 7155 (/nix/store/3p9bs24jiyzbsv77mslw3znrm6zcqlyv-triumph-adler-20140115/lib/cups/filter/kyofilter_B) stopped with status 102 (No such file or directory)
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Hint: Try setting the LogLevel to "debug" to find out more.
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] pdftops - copying to temp print file "/tmp/01bf2559277ad"
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] execv failed: No such file or directory
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Resolving "NM887FD8._ipp._tcp.local"...
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] STATE: +connecting-to-device
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Resolving "NM887FD8", regtype="_ipp._tcp", domain="local."...
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] PDF template file doesn't have form. It's okay.
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] PID 7152 (/nix/store/f1hc4sfyyy5wdxb0ijsdzgiij198swmz-cups-progs/lib/cups/filter/bannertopdf) exited with no errors.
Jun 19 11:04:09 dione cupsd[6465]: [Job 18] Printer make and model: Kyocera CD 5240L_DC 6240L
[...]
```

and with patched `kyofilter_B`:

```
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Job stopped due to filter errors; please consult the error_log file for details.
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] The following messages were recorded from 11:52:46 to 11:52:48
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Adding start banner page "none".
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Adding end banner page "none".
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] File of type application/vnd.cups-pdf-banner queued by "jascha".
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] hold_until=0
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Queued on "NM887FD8" by "jascha".
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] time-at-processing=1434707566
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] 4 filters for job:
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] bannertopdf (application/vnd.cups-pdf-banner to application/pdf, cost 32)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] pdftopdf (application/pdf to application/vnd.cups-pdf, cost 66)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] pdftops (application/vnd.cups-pdf to application/vnd.cups-postscript, cost 100)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] kyofilter_B (application/vnd.cups-postscript to printer/NM887FD8, cost 0)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] job-sheets=none,none
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[0]="NM887FD8"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[1]="23"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[2]="jascha"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[3]="Test Page"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[4]="1"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[5]="job-uuid=urn:uuid:9fbd9fec-d373-3106-59c9-13c9cff576ef job-originating-host-name=localhost time-at-creation=1434707566 time-at-processing=1434707566"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] argv[6]="/var/spool/cups/d00023-001"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[0]="PATH=/nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/filter:/nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/bin:/nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[1]="CUPS_CACHEDIR=/var/cache/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[2]="CUPS_DATADIR=/nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/share/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[3]="CUPS_DOCROOT=/nix/store/lsylfzxplcc06qky5w3qmv9rkhjibb2l-cups-2.0.2/share/doc/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[4]="CUPS_FONTPATH=/nix/store/lsylfzxplcc06qky5w3qmv9rkhjibb2l-cups-2.0.2/share/cups/fonts"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[5]="CUPS_REQUESTROOT=/var/spool/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[6]="CUPS_SERVERBIN=/nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[7]="CUPS_SERVERROOT=/etc/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[8]="CUPS_STATEDIR=/var/run/cups"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[9]="HOME=/tmp"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[10]="SERVER_ADMIN=root@dione"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[11]="SOFTWARE=CUPS/2.0.2"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[12]="TMPDIR=/tmp"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[13]="USER=root"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[14]="CUPS_MAX_MESSAGE=2047"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[15]="CUPS_SERVER=/var/run/cups/cups.sock"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[16]="CUPS_ENCRYPTION=IfRequested"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[17]="IPP_PORT=631"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[18]="CHARSET=utf-8"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[19]="LANG=de.UTF-8"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[20]="PPD=/etc/cups/ppd/NM887FD8.ppd"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[21]="RIP_MAX_CACHE=128m"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[22]="CONTENT_TYPE=application/vnd.cups-pdf-banner"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[23]="DEVICE_URI=dnssd://NM887FD8._ipp._tcp.local/"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[24]="PRINTER_INFO=UTAX_TA UTAX_TA 2550ci (KPDL)"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[25]="PRINTER_LOCATION=Local Printer"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[26]="PRINTER=NM887FD8"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[27]="PRINTER_STATE_REASONS=none"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[28]="CUPS_FILETYPE=document"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[29]="FINAL_CONTENT_TYPE=application/vnd.cups-postscript"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] envp[30]="AUTH_I****"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Started filter /nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/filter/bannertopdf (PID 26024)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Started filter /nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/filter/pdftopdf (PID 26025)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Started filter /nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/filter/pdftops (PID 26026)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Started filter /nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/filter/kyofilter_B (PID 26027)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Started backend /nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/backend/dnssd (PID 26028)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] PID 26027 (/nix/store/clr21dvrs8jf3rkyrzvqlnk8jf7r6vka-cups-progs/lib/cups/filter/kyofilter_B) stopped with status 127 (File too large)
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Hint: Try setting the LogLevel to "debug" to find out more.
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] NM887FD8: error while loading shared libraries: libcups.so.2: cannot open shared object file: No such file or directory
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] pdftops - copying to temp print file "/tmp/065aa5587d90a"
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Resolving "NM887FD8._ipp._tcp.local"...
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] STATE: +connecting-to-device
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] Resolving "NM887FD8", regtype="_ipp._tcp", domain="local."...
Jun 19 11:52:48 dione cupsd[25987]: [Job 23] PDF template file doesn't have form. It's okay.
[...]
```

Am I missing something? Is it a bug in patchelf?
