### PR TITLE
dropbox: 3.4.6 -> 3.6.7 (stable backport)

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -18,11 +18,11 @@
 # them with our own.
 
 let
-  version = "3.4.6";
+  version = "3.6.7";
   sha256 =
     {
-      "x86_64-linux" = "0crhv21q48lwa86qcqgbcd9g73biibfrc2vgbavi67cwxvzcskky";
-      "i686-linux" = "0kli84kzg1wcwszjni948zb4qih8mynmyqhdwyiv1l7v5lrhb8k2";
+      "x86_64-linux" = "1jwzrpw382amx0jap9m411a3yvkc9iwnw6n35kwq3infmbwjs6q8";
+      "i686-linux" = "0rjd908bhfk00qh6gvizf2fyfb3cccd78spyvh435z377x2pmxzy";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
cc @ttuegel 
