### PR TITLE
dmenu: build with Xft

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10793,7 +10793,7 @@ let
   djview4 = pkgs.djview;
 
   dmenu = callPackage ../applications/misc/dmenu {
-    enableXft = config.dmenu.enableXft or false;
+    enableXft = true;
   };
 
   dmenu2 = callPackage ../applications/misc/dmenu2 { };


### PR DESCRIPTION
It doesn’t make any sense to build dmenu without Xft. Really.
Extra bonus: getting rid of deprecated config.
