### PR TITLE
atom-shell: renamed to electron and updated 0.19.1 -> 0.28.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -226,6 +226,7 @@
   thoughtpolice = "Austin Seipp <aseipp@pobox.com>";
   titanous = "Jonathan Rudenberg <jonathan@titanous.com>";
   tomberek = "Thomas Bereknyei <tomberek@gmail.com>";
+  travisbhartwell = "Travis B. Hartwell <nafai@travishartwell.net>";
   trino = "Hubert Mühlhans <muehlhans.hubert@ekodia.de>";
   tstrobel = "Thomas Strobel <ts468@cam.ac.uk>";
   ttuegel = "Thomas Tuegel <ttuegel@gmail.com>";

--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -59,6 +59,10 @@ and old <literal>steam</literal> package -- to <literal>steamOriginal</literal>.
 was accordingly renamed to <literal>bomi</literal>
 </para></listitem>
 
+<listitem><para>Atom Shell has been renamed to Electron upstream.  Package <literal>atom-shell</literal>
+was accordingly renamed to <literal>electron</literal>
+</para></listitem>
+
 <listitem>
     <para>
         The default <literal>NIX_PATH</literal> for NixOS now includes

--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, buildEnv, makeDesktopItem, makeWrapper, zlib, glib, alsaLib
 , dbus, gtk, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
 , cairo, cups, expat, libgpgerror, nspr, gconf, nss, xlibs, libcap, unzip
+, systemd
 }:
 let
   atomEnv = buildEnv {
@@ -10,16 +11,16 @@ let
       fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
       xlibs.libXrender xlibs.libX11 xlibs.libXext xlibs.libXdamage xlibs.libXtst
       xlibs.libXcomposite xlibs.libXi xlibs.libXfixes xlibs.libXrandr
-      xlibs.libXcursor libcap
+      xlibs.libXcursor libcap systemd
     ];
   };
 in stdenv.mkDerivation rec {
-  name = "atom-shell-${version}";
-  version = "0.19.1";
+  name = "electron-${version}";
+  version = "0.28.2";
 
   src = fetchurl {
-    url = "https://github.com/atom/atom-shell/releases/download/v0.19.1/atom-shell-v0.19.1-linux-x64.zip";
-    sha256 = "10q1slwv2lkiqqxpv0m5a1k0gj2yp8bi9a7ilb05zz1wg7j3yw4y";
+    url = "https://github.com/atom/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
+    sha256 = "55b0880e2f78a60d95a58e83cd75006c34cb6ed90836e1f34e3359c3e5d0b8f0";
     name = "${name}.zip";
   };
 
@@ -33,15 +34,14 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/bin
     unzip -d $out/bin $src
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-    $out/bin/atom
-    mv $out/bin/atom $out/bin/atom-shell
-    wrapProgram $out/bin/atom-shell \
+    $out/bin/electron
+    wrapProgram $out/bin/electron \
     --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64"
   '';
 
   meta = with stdenv.lib; {
     description = "Cross platform desktop application shell";
-    homepage = https://github.com/atom/atom-shell;
+    homepage = https://github.com/atom/electron;
     license = licenses.mit;
     maintainers = [ maintainers.fluffynukeit ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     description = "Cross platform desktop application shell";
     homepage = https://github.com/atom/electron;
     license = licenses.mit;
-    maintainers = [ maintainers.fluffynukeit ];
+    maintainers = [ maintainers.travisbhartwell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5143,7 +5143,7 @@ let
 
   astyle = callPackage ../development/tools/misc/astyle { };
 
-  atom-shell = callPackage ../development/tools/atom-shell {
+  electron = callPackage ../development/tools/electron {
     gconf = pkgs.gnome.GConf;
   };
 


### PR DESCRIPTION
Added systemd to buildEnv path because of new libudev dependency.
Renamed package to reflect upstream name change.  Added note to effect in release notes.

Tested that I could install and launch on my NixOS machine running the unstable channel.
