### PR TITLE
added popcorntime package

### DIFF
--- a/pkgs/applications/video/popcorntime/default.nix
+++ b/pkgs/applications/video/popcorntime/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, pkgs, fetchurl, runCommand, makeWrapper, node_webkit_0_9
+}:
+
+let
+  node-webkit = node_webkit_0_9;
+  version = "0.3.7.2";
+  popcorntimePackage = stdenv.mkDerivation rec {
+    name = "popcorntime-package-${version}";
+    src = fetchurl {
+      url = "https://get.popcorntime.io/build/Popcorn-Time-${version}-Linux64.tar.xz";
+     sha256 = "0lm9k4fr73a9p00i3xj2ywa4wvjf9csadm0pcz8d6imwwq44sa8b";
+    };
+    sourceRoot = ".";
+    installPhase = ''
+      mkdir -p $out
+      cp -r *.so *.pak $out/
+      cat ${node-webkit}/bin/nw package.nw > $out/Popcorn-Time
+      chmod 555 $out/Popcorn-Time
+    '';
+  };
+in
+  runCommand "popcorntime-${version}" {
+    buildInputs = [ makeWrapper ];
+    meta = with stdenv.lib; {
+      homepage = http://popcorntime.io/;
+      description = "An application that streams movies and TV shows from torrents";
+      license = stdenv.lib.licenses.gpl3;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ bobvanderlinden ];
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    makeWrapper ${popcorntimePackage}/Popcorn-Time $out/bin/popcorntime
+  ''

--- a/pkgs/applications/video/popcorntime/default.nix
+++ b/pkgs/applications/video/popcorntime/default.nix
@@ -4,12 +4,21 @@
 let
   node-webkit = node_webkit_0_9;
   version = "0.3.7.2";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://get.popcorntime.io/build/Popcorn-Time-${version}-Linux64.tar.xz";
+      sha256 = "0lm9k4fr73a9p00i3xj2ywa4wvjf9csadm0pcz8d6imwwq44sa8b";
+    };
+    i686-linux = fetchurl {
+      url = "https://get.popcorntime.io/build/Popcorn-Time-${version}-Linux32.tar.xz";
+      sha256 = "1dz1cp31qbwamm9pf8ydmzzhnb6d9z73bigdv3y74dgicz3dpr91";
+    };
+  };
+
   popcorntimePackage = stdenv.mkDerivation rec {
     name = "popcorntime-package-${version}";
-    src = fetchurl {
-      url = "https://get.popcorntime.io/build/Popcorn-Time-${version}-Linux64.tar.xz";
-     sha256 = "0lm9k4fr73a9p00i3xj2ywa4wvjf9csadm0pcz8d6imwwq44sa8b";
-    };
+    src = srcs."${stdenv.system}";
     sourceRoot = ".";
     installPhase = ''
       mkdir -p $out

--- a/pkgs/applications/video/popcorntime/default.nix
+++ b/pkgs/applications/video/popcorntime/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, pkgs, fetchurl, runCommand, makeWrapper, node_webkit_0_9
+{ stdenv, pkgs, fetchurl, runCommand, makeWrapper, node_webkit ? pkgs.node_webkit_0_9
 }:
 
 let
-  node-webkit = node_webkit_0_9;
   version = "0.3.7.2";
 
   srcs = {
@@ -23,7 +22,7 @@ let
     installPhase = ''
       mkdir -p $out
       cp -r *.so *.pak $out/
-      cat ${node-webkit}/bin/nw package.nw > $out/Popcorn-Time
+      cat ${node_webkit}/bin/nw package.nw > $out/Popcorn-Time
       chmod 555 $out/Popcorn-Time
     '';
   };

--- a/pkgs/applications/video/popcorntime/default.nix
+++ b/pkgs/applications/video/popcorntime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, runCommand, makeWrapper, node_webkit ? pkgs.node_webkit_0_9
+{ stdenv, fetchurl, runCommand, makeWrapper, node_webkit_0_9
 }:
 
 let
@@ -22,7 +22,7 @@ let
     installPhase = ''
       mkdir -p $out
       cp -r *.so *.pak $out/
-      cat ${node_webkit}/bin/nw package.nw > $out/Popcorn-Time
+      cat ${node_webkit_0_9}/bin/nw package.nw > $out/Popcorn-Time
       chmod 555 $out/Popcorn-Time
     '';
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2582,6 +2582,8 @@ let
 
   polkit_gnome = callPackage ../tools/security/polkit-gnome { };
 
+  popcorntime = callPackage ../applications/video/popcorntime { };
+
   ponysay = callPackage ../tools/misc/ponysay { };
 
   povray = callPackage ../tools/graphics/povray {


### PR DESCRIPTION
This adds popcorntime to nixpkgs. Popcorntime is based on node-webkit and is distributed as a .tar.xz, which includes:
- `package.nw`: a zip including all html/css/js
- `Popcorn-Time`: a concatonation of the `nw` binary and `package.nw`
-  `libffmpegsumo.so`: library from Chrome containing the right codecs
- `nw.pak`: a required file related to node-webkit

`Popcorn-Time`, `nw.pak` and `libffmpegsumo.so` must be located in the same directory so that node-webkit will use these files. This is why I used a wrapper script.

The `Popcorn-Time` binary does not run on NixOS, since it links to different library/paths. I build a new `Popcorn-Time` binary from the `nw` binary of NixOS.

I realize using binaries like this isn't the best way to go. I have tried to build `package.nw` through nix, but this took quite a bit of work and reworking the build system (bower + grunt + npm). It eventually didn't result in a correct output (runtime javascript errors).
The work on this can be found here: https://github.com/bobvanderlinden/nixpkgs/tree/popcorntime-source

I've also tried to use `libffmpegsumo.so` of node-webkit in nixpkgs (`${node_webkit_0_9}/share/node-webkit/libffmpegsumo.so`), but it somehow isn't compatible with Popcorntime. In this case the video player does not load correctly. It should be possible to build this file through nix, but I saw this also wasn't the case for node-webkit package. Let me know what is right here.

---

Binary-based version: https://github.com/bobvanderlinden/nixpkgs/tree/popcorntime-binary
Source-based version: https://github.com/bobvanderlinden/nixpkgs/tree/popcorntime-source
