### PR TITLE
git-cola: update from 2.1.1 to 2.2.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonPackage rec {
   name = "git-cola-${version}";
-  version = "2.1.1";
+  version = "2.2.1";
 
   src = fetchurl {
     url = "https://github.com/git-cola/git-cola/archive/v${version}.tar.gz";
-    sha256 = "0fpi5nvhyqkx67ak5pfcpgxbc3m19dqlvdh2c9igv2j0vp5rzkj1";
+    sha256 = "1v1s9gx16xihdcck4qp92bdci8zc6pb5a3z3y8k9jqj97hfkw2nz";
   };
 
   buildInputs = [ makeWrapper gettext ];


### PR DESCRIPTION
From [monitor.nixpkgs.org](http://monitor.nixos.org/vulnerable?mc=&c=&vulnerable=on&outdated=on&outdated_minor=on&outdated_major=on&m=Bob+van+der+Linden).
Potentially fixes CVE-2012-0845, CVE-2012-1150, CVE-2014-9365.
