### PR TITLE
steam: add xrandr binary to env

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -13,6 +13,7 @@ buildFHSUserEnv {
       pkgs.python
       pkgs.gnome2.zenity
       pkgs.xdg_utils
+      pkgs.xlibs.xrandr
     ]
     ++ lib.optional (config.steam.java or false) pkgs.jdk
     ++ lib.optional (config.steam.primus or false) pkgs.primus


### PR DESCRIPTION
Games utilizing LWJGL >= 2.4 && < 3.0 need this as the framework parses
display information from the command line output of xrandr[1](https://github.com/LWJGL/lwjgl/blob/46f602f0c680a92349b4185f886609200d614990/src/java/org/lwjgl/opengl/XRandR.java#L72) on Linux.
There are a number of LWJGL games on Steam currently.
