### PR TITLE
curl: update7.42.1 -> 7.43 version bump

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -16,7 +16,7 @@ assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.42.1";
+  name = "curl-7.43";
 
   src = fetchurl {
     url = "http://curl.haxx.se/download/${name}.tar.bz2";


### PR DESCRIPTION
Changelog for curl version bump found here: http://curl.haxx.se/changes.html#7_43_0
