### PR TITLE
gnugrep: fix cross-compilation (buildInputs -> nativeBuildInputs)

### DIFF
--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   patches = [ ./cve-2015-1345.patch ];
 
-  buildInputs = [ pcre libiconv ];
+  nativeBuildInputs = [ pcre libiconv ];
 
   # cygwin: FAIL: multibyte-white-space
   doCheck = !stdenv.isDarwin && !stdenv.isCygwin;


### PR DESCRIPTION
Now I can finally build bootstrap-tools-cross:

  $ nix-build pkgs/stdenv/linux/make-bootstrap-tools-cross.nix -A armv7l
  /nix/store/59zrljz7hrjfliychv62r386y3yrfrah-build
  /nix/store/4701h00w1rynd0n8s1ax490ygl8v75z5-busybox-1.23.2-armv7l-unknown-linux-gnueabi
  /nix/store/37bsa3sk07lp714gryny9z8q0pj6bfha-coreutils-8.23-armv7l-unknown-linux-gnueabi
  /nix/store/wy9xvcfd6mwlzskpc0wf0zv6wm88haaz-curl-7.42.1-armv7l-unk

Instead of this (current) build error:

  $ nix-build pkgs/stdenv/linux/make-bootstrap-tools-cross.nix -A armv7l
  ...
  checking whether we are cross compiling... yes
  checking for suffix of object files... o
  checking whether we are using the GNU C compiler... no
  configure: error: in `/tmp/nix-build-gnugrep-2.21-armv7l-unknown-linux-gnueabi.drv-4/grep-2.21':
  configure: error: C compiler cannot create executables
  See`config.log' for more details

config.log shows that it failed due to host glibc being used instead of target
glibc.

---

Questions:
- The gnugrep expression seems to have had this buildInput for a long time. How did you NixOS + ARM users out there bootstrap this thing (without this fix)?
- According to the NixOS wiki[1],

```
nativeBuildInputs: derivations built for the build system (native builds), needed for the actual cross-build.
buildInputs: derivations built for the host-system (to be run in the target), needed for the actual cross-build.
```

Well that sounds to me like the opposite of what's really happening; cross-compiling gnugrep fails because host glibc is picked up from buildInputs. To fix it I had to change it to nativeBuildInputs. Confused :-/  Well, it could be a special case since it's the _cross-compiler_ that fails... I don't know.

[1] https://nixos.org/wiki/CrossCompiling
