### PR TITLE
travis-nox-review-pr: Try to detect if the build ran out of memory

### DIFF
--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -31,7 +31,15 @@ elif [[ $1 == build ]]; then
         echo "=== Not a pull request"
     else
         echo "=== Checking PR"
-        nox-review pr ${TRAVIS_PULL_REQUEST}
+
+        if ! nox-review pr ${TRAVIS_PULL_REQUEST}; then
+            if sudo dmesg | egrep 'Out of memory|Killed process' > /tmp/oom-log; then
+                echo "=== The build failed due to running out of memory:"
+                cat /tmp/oom-log
+                echo "=== Please disregard the result of this Travis build."
+            fi
+            exit 1
+        fi
     fi
     # echo "=== Checking tarball creation"
     # nix-build pkgs/top-level/release.nix -A tarball


### PR DESCRIPTION
Travis builds sometimes fail because Travis doesn't have much memory.
When it happens, the failure reason is often hard to see in the logs and
is confusing (especially for new contributors).

Try to detect OOM errors in dmesg and give a warning when it happens.
