### PR TITLE
i3-py: init at 0.6.4

### DIFF
--- a/pkgs/tools/misc/i3minator/default.nix
+++ b/pkgs/tools/misc/i3minator/default.nix
@@ -1,19 +1,6 @@
 { stdenv, fetchurl, buildPythonPackage, pythonPackages, python }:
 
-let
-  i3-py = buildPythonPackage rec {
-    version = "0.6.4";
-    name = "i3-py-${version}";
-
-    src = fetchurl {
-      url = "https://pypi.python.org/packages/source/i/i3-py/i3-py-${version}.tar.gz";
-      sha256 = "1sgl438jrb4cdyl7hbc3ymwsf7y3zy09g1gh7ynilxpllp37jc8y";
-    };
-
-    # no tests in tarball
-    doCheck = false;
-  };
-in buildPythonPackage rec {
+buildPythonPackage rec {
   name = "i3minator-${version}";
   version = "0.0.4";
 
@@ -22,7 +9,7 @@ in buildPythonPackage rec {
     sha256 = "11dn062788kwfs8k2ry4v8zr2gn40r6lsw770s9g2gvhl5n469dw";
   };
 
-  propagatedBuildInputs = [ pythonPackages.pyyaml i3-py ];
+  propagatedBuildInputs = [ pythonPackages.pyyaml pythonPackages.i3-py ];
 
   meta = with stdenv.lib; {
     description = "i3 project manager similar to tmuxinator";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3410,6 +3410,26 @@ let
     };
   };
 
+  i3-py = buildPythonPackage rec {
+    version = "0.6.4";
+    name = "i3-py-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/i/i3-py/i3-py-${version}.tar.gz";
+      sha256 = "1sgl438jrb4cdyl7hbc3ymwsf7y3zy09g1gh7ynilxpllp37jc8y";
+    };
+
+    # no tests in tarball
+    doCheck = false;
+
+    meta = {
+      description = "tools for i3 users and developers";
+      homepage =  "https://github.com/ziberna/i3-py";
+      license = licenses.gpl3;
+      platforms = platforms.linux;
+    };
+  };
+
   jsonpatch = buildPythonPackage rec {
     name = "jsonpatch-1.8";
 


### PR DESCRIPTION
Extract i3-py from i3minator so it can be installed on its own.

Updated the i3minator package to use this.

cc @domenkozar -- this is per our conversation on #nixos on June 15th, I'm Nafai on IRC.
