### PR TITLE
eagle 6.5.0 -> 6.6.0

### DIFF
--- a/pkgs/applications/science/electronics/eagle/default.nix
+++ b/pkgs/applications/science/electronics/eagle/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "eagle-${version}";
-  version = "6.5.0";
+  version = "6.6.0";
 
   src = fetchurl {
-    url = "ftp://ftp.cadsoft.de/eagle/program/6.5/eagle-lin-${version}.run";
-    sha256 = "17plwx2p8q2ylk0nzj5crfbdm7jc35pw7v3j8f4j81yl37l7bj22";
+    url = "ftp://ftp.cadsoft.de/eagle/program/6.6/eagle-lin-${version}.run";
+    sha256 = "0m5289daah85b2rwpivnh2z1573v6j4alzjy9hg78fkb9jdgbn0x";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
CC @bjornfor:

Version 6.5.0 has disappeared from Cadsoft's FTP site. This is the
closest version that's still available. Not extensively tested, but
works fine here.

Current version is 7.3.0. I leave that to someone more interested.
