### PR TITLE
Unbreak Mac OS X build of OpenSSL 1.0.2.

### DIFF
--- a/pkgs/development/libraries/openssl/1.0.2.x.nix
+++ b/pkgs/development/libraries/openssl/1.0.2.x.nix
@@ -31,9 +31,7 @@ let
     ++ stdenv.lib.optionals (stdenv.system == "x86_64-kfreebsd-gnu")
         [ ./gnu.patch
           ./kfreebsd-gnu.patch
-        ]
-
-    ++ stdenv.lib.optional isDarwin ./darwin-arch.patch;
+        ];
 
   extraPatches = stdenv.lib.optional stdenv.isCygwin ./1.0.1-cygwin64.patch;
 in


### PR DESCRIPTION
The darwin-arch.patch that was needed for previous releases doesn't
apply, and also doesn't work anymore.  It builds fine without.
