### PR TITLE
ibus-table: init at 1.9.6 & ibus-table-others: init at 1.3.7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -156,6 +156,7 @@
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mtreskin = "Max Treskin <zerthurd@gmail.com>";
+  mudri = "James Wood <lamudri@gmail.com>";
   muflax = "Stefan Dorn <mail@muflax.com>";
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";

--- a/pkgs/tools/inputmethods/ibus-table-others/default.nix
+++ b/pkgs/tools/inputmethods/ibus-table-others/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, ibus, ibus-table, pkgconfig, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "ibus-table-others-${version}";
+  version = "1.3.7";
+
+  meta = with stdenv.lib; {
+    description = "Various table-based input methods for IBus";
+    homepage    = https://github.com/moebiuscurve/ibus-table-others;
+    license     = licenses.gpl3;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ mudri ];
+  };
+
+  buildInputs = [ ibus ibus-table pkgconfig python3 ];
+
+  preBuild = ''
+    export HOME=/tmp/ibus-table-others
+  '';
+
+  postFixup = ''
+    rm -rf /tmp/ibus-table-others
+  '';
+
+  src = fetchurl {
+    url = "https://github.com/moebiuscurve/ibus-table-others/releases/download/${version}/${name}.tar.gz";
+    sha256 = "0vmz82il796062jbla5pawsr5dqyhs7ald7xjp84zfccc09dg9kx";
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-table/default.nix
+++ b/pkgs/tools/inputmethods/ibus-table/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, ibus, pkgconfig, python3, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name = "ibus-table-${version}";
+  version = "1.9.6";
+
+  meta = with stdenv.lib; {
+    description = "An IBus framework for table-based input methods";
+    homepage    = https://github.com/kaio/ibus-table/wiki;
+    license     = licenses.lgpl21;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ mudri ];
+  };
+
+  buildInputs = [ ibus pkgconfig python3 pythonPackages.pygobject3 ];
+
+  src = fetchurl {
+    url = "https://github.com/kaio/ibus-table/releases/download/${version}/${name}.tar.gz";
+    sha256 = "0xygfscmsx0x80c4d4v40k9bc7831kgdsc74mc84ljxbjg9p9lcf";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1108,6 +1108,8 @@ let
 
   ibus-table = callPackage ../tools/inputmethods/ibus-table { };
 
+  ibus-table-others = callPackage ../tools/inputmethods/ibus-table-others { };
+
   biosdevname = callPackage ../tools/networking/biosdevname { };
 
   checkbashism = callPackage ../development/tools/misc/checkbashisms { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1106,6 +1106,8 @@ let
 
   ibus-anthy = callPackage ../tools/inputmethods/ibus-anthy { };
 
+  ibus-table = callPackage ../tools/inputmethods/ibus-table { };
+
   biosdevname = callPackage ../tools/networking/biosdevname { };
 
   checkbashism = callPackage ../development/tools/misc/checkbashisms { };


### PR DESCRIPTION
Hi. This is my first pull request here. It was probably a mistake to do two things in one PR, but I'm not confident enough to unravel it all. Tell me if there's anything else I did wrong.

Both build, but are untested because I can't get ibus working (even with just ibus-anthy).
