### PR TITLE
calamares: Patch out all file references to /usr

### DIFF
--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchgit, cmake, qt5, polkit_qt5, libyamlcpp, python, boost, parted
-, extra-cmake-modules, kconfig, ki18n, kcoreaddons, solid, utillinux, libatasmart }:
+, extra-cmake-modules, kconfig, ki18n, kcoreaddons, solid, utillinux, libatasmart
+, ckbcomp, glibc, tzdata, xkeyboard_config }:
 
 stdenv.mkDerivation rec {
   name = "calamares-${version}";
@@ -21,6 +22,25 @@ stdenv.mkDerivation rec {
     "-DPYTHON_INCLUDE_DIR=${python}/include/python${python.majorVersion}m"
     "-DWITH_PARTITIONMANAGER=1"
   ];
+
+  patchPhase = ''
+      sed -e "s,/usr/bin/calamares,$out/bin/calamares," \
+          -i calamares.desktop \
+          -i com.github.calamares.calamares.policy
+
+      sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
+          -i src/modules/locale/timezonewidget/localeconst.h \
+          -i src/modules/locale/SetTimezoneJob.cpp
+
+      sed -e 's,/usr/share/i18n/locales,${glibc}/share/i18n/locales,' \
+          -i src/modules/locale/timezonewidget/localeconst.h
+
+      sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
+          -i src/modules/keyboard/keyboardwidget/keyboardglobal.h
+
+      sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
+          -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp
+  '';
 
   preInstall = ''
     substituteInPlace cmake_install.cmake --replace "${polkit_qt5}" "$out"


### PR DESCRIPTION
This makes the timezone selection page as well as the keyboard layout
selection page work correctly.

cc @ts468 
