### PR TITLE
jruby: 1.7.12 -> 1.7.20.1 (update package for CVE patch)

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "jruby-${version}";
 
-  version = "1.7.12";
+  version = "1.7.20.1";
 
   src = fetchurl {
     url = "http://jruby.org.s3.amazonaws.com/downloads/${version}/jruby-bin-${version}.tar.gz";
-    sha1 = "056cee1138e49da40a77f179b771372692479002";
+    sha1 = "6a6e701a3a5769ec5d53a78660521c37da36e41f";
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5104,7 +5104,7 @@ let
 
   jdtsdk = callPackage ../development/eclipse/jdt-sdk { };
 
-  jruby165 = callPackage ../development/interpreters/jruby { };
+  jruby = callPackage ../development/interpreters/jruby { };
 
   jython = callPackage ../development/interpreters/jython {};
 


### PR DESCRIPTION
Security release which only updates Rubygems to version 2.4.8. Rubygems 2.4.8
addresses CVE-2015-1855 to resolve some problems with wildcard matching of
hostnames.

See following entry for more information:
http://jruby.org/2015/06/10/jruby-1-7-20-1.html
