### PR TITLE
powerline: 2.1->2.1.4

### DIFF
--- a/pkgs/development/python-modules/gyp/no-darwin-cflags.patch
+++ b/pkgs/development/python-modules/gyp/no-darwin-cflags.patch
@@ -1,8 +1,8 @@
 Index: gyp/pylib/gyp/xcode_emulation.py
 ===================================================================
---- gyp/pylib/gyp/xcode_emulation.py	(revision 1635)
-+++ gyp/pylib/gyp/xcode_emulation.py	(working copy)
-@@ -280,9 +280,6 @@
+--- gyp/pylib/gyp/xcode_emulation.py
++++ gyp/pylib/gyp/xcode_emulation.py
+@@ -483,9 +483,6 @@
      if self._Test('GCC_CHAR_IS_UNSIGNED_CHAR', 'YES', default='NO'):
        cflags.append('-funsigned-char')
  
@@ -12,7 +12,7 @@ Index: gyp/pylib/gyp/xcode_emulation.py
      if 'GCC_DYNAMIC_NO_PIC' in self._Settings():
        if self._Settings()['GCC_DYNAMIC_NO_PIC'] == 'YES':
          cflags.append('-mdynamic-no-pic')
-@@ -292,9 +289,6 @@
+@@ -495,9 +492,6 @@
        # mdynamic-no-pic by default for executable and possibly static lib
        # according to mento
  
@@ -22,7 +22,7 @@ Index: gyp/pylib/gyp/xcode_emulation.py
      self._Appendf(cflags, 'GCC_OPTIMIZATION_LEVEL', '-O%s', default='s')
  
      if self._Test('GCC_GENERATE_DEBUGGING_SYMBOLS', 'YES', default='YES'):
-@@ -311,12 +305,6 @@
+@@ -519,12 +513,6 @@
      if self._Test('GCC_SYMBOLS_PRIVATE_EXTERN', 'YES', default='NO'):
        cflags.append('-fvisibility=hidden')
  
@@ -32,10 +32,10 @@ Index: gyp/pylib/gyp/xcode_emulation.py
 -    if self._Test('GCC_WARN_ABOUT_MISSING_NEWLINE', 'YES', default='NO'):
 -      cflags.append('-Wnewline-eof')
 -
-     self._AppendPlatformVersionMinFlags(cflags)
- 
-     # TODO:
-@@ -334,7 +322,6 @@
+     # In Xcode, this is only activated when GCC_COMPILER_VERSION is clang or
+     # llvm-gcc. It also requires a fairly recent libtool, and
+     # if the system clang isn't used, DYLD_LIBRARY_PATH needs to contain the
+@@ -553,7 +541,6 @@
        # TODO: Supporting fat binaries will be annoying.
        self._WarnUnimplemented('ARCHS')
        archs = ['i386']
@@ -43,7 +43,7 @@ Index: gyp/pylib/gyp/xcode_emulation.py
  
      if archs[0] in ('i386', 'x86_64'):
        if self._Test('GCC_ENABLE_SSE3_EXTENSIONS', 'YES', default='NO'):
-@@ -570,7 +557,6 @@
+@@ -811,7 +798,6 @@
        # TODO: Supporting fat binaries will be annoying.
        self._WarnUnimplemented('ARCHS')
        archs = ['i386']

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8862,12 +8862,12 @@ let
 
 
   powerline = buildPythonPackage rec {
-    rev  = "8164f42fb924f38dc5b9dd6d32063e8c3d41e504";
-    name = "powerline-2.1";
+    rev  = "2.1.4";
+    name = "powerline-${rev}";
     src = pkgs.fetchurl {
-      url    = "https://github.com/powerline/powerline/tarball/${rev}";
-      name   = "${name}.tar.bz";
-      sha256 = "0xrasj1lh9ypz1q6q4k997rfym9r16bclfbpzjqj8qfkp4i62lz6";
+      url    = "https://github.com/powerline/powerline/archive/${rev}.tar.gz";
+      name   = "${name}.tar.gz";
+      sha256 = "0gnh5yyackmqcphiympan48dm5lc834yzspss1lp4g1wq3vpyraf";
     };
 
     propagatedBuildInputs = with self; [ pkgs.git pkgs.mercurial pkgs.bazaar self.psutil self.pygit2 ];


### PR DESCRIPTION
Also required me to fix cflags on gyp. Together, these commits make powerline work with tmux 2.0.

Tested on darwin.
