### PR TITLE
clib: a micro-package manager for C

### DIFF
--- a/pkgs/tools/package-management/clib/default.nix
+++ b/pkgs/tools/package-management/clib/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchzip, curl  }:
+
+stdenv.mkDerivation rec {
+  version = "1.4.2";
+  name = "clib-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/clibs/clib/archive/${version}.zip";
+    sha256 = "0hbi5hf4w0iim96h89j7krxv61x92ffxjbldxp3zk92m5sgpldnm";
+  };
+
+  makeFlags = "PREFIX=$(out)";
+
+  buildInputs = [ curl ];
+
+  meta = with stdenv.lib; {
+    description = "C micro-package manager";
+    homepage = https://github.com/clibs/clib;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jb55 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -789,6 +789,8 @@ let
 
   cloud-init = callPackage ../tools/virtualization/cloud-init { };
 
+  clib = callPackage ../tools/package-management/clib { };
+
   consul = goPackages.consul;
 
   consul-ui = callPackage ../servers/consul/ui.nix { };


### PR DESCRIPTION
[clib](https://github.com/clibs/clib) makes it easy to find and install snippets of C code, typically for static linking in your program.
