### PR TITLE
Update io.js (2.2.1->2.3.1)

### DIFF
--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, python, utillinux, openssl_1_0_2, http-parser, zlib, libuv }:
 
 let
-  version = "2.2.1";
+  version = "2.3.1";
   inherit (stdenv.lib) optional maintainers licenses platforms;
 in stdenv.mkDerivation {
   name = "iojs-${version}";
 
   src = fetchurl {
     url = "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
-    sha256 = "1ylmj69nwhqqwn1grphlrzny9dp4bspx4172q41izr6dyk29rrsm";
+    sha256 = "1vkahs7ky551gl52l8j8f2w8ajasjblqqmhird5ll87wccx8w6f2";
   };
 
   prePatch = ''


### PR DESCRIPTION
Simple update now that libuv and openssl-1.0.2 are updated.
