### PR TITLE
Don't block the system after starting stumpwm

### DIFF
--- a/nixos/modules/services/x11/window-managers/stumpwm.nix
+++ b/nixos/modules/services/x11/window-managers/stumpwm.nix
@@ -21,9 +21,10 @@ in
   config = mkIf cfg.enable {
     services.xserver.windowManager.session = singleton {
       name = "stumpwm";
-      start = "
-        ${pkgs.stumpwm}/bin/stumpwm
-      ";
+      start = ''
+        ${pkgs.stumpwm}/bin/stumpwm &
+        waitPID=$!
+      '';
     };
     environment.systemPackages = [ pkgs.stumpwm ];
   };


### PR DESCRIPTION
This is important to let nixos configure everything, e.g., a desktop manager.

cc @the-kenny @hiberno 
