### PR TITLE
es: bugfix for man page install

### DIFF
--- a/pkgs/shells/es/default.nix
+++ b/pkgs/shells/es/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation {
   configureFlags="--with-readline --prefix=$(out) --bindir=$(out)/bin --mandir=$(out)/man";
 
   preInstall = ''
-    mkdir -p $out/{bin,man}
+    mkdir -p $out/bin
+    mkdir -p $out/man/man1
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Installing es results in an error if the man/man1 directory does not exist. This patch explicitly creates that directory.

See Issue #8487.

I've tested it with nix-build.

cc @sjmackenzie
