### PR TITLE
Add pkgs.overridePackages

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -1,0 +1,57 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+	 xmlns:xlink="http://www.w3.org/1999/xlink"
+	 xml:id="chap-functions">
+
+<title>Functions reference</title>
+
+<para>
+  The nixpkgs repository has several utility functions to manipulate Nix expressions.
+</para>
+
+<section xml:id="sec-pkgs-overridePackages">
+  <title>pkgs.overridePackages</title>
+
+  <para>
+    This function inside the nixpkgs expression (<varname>pkgs</varname>)
+    can be used to override the set of packages itself.
+  </para>
+  <para>
+    Warning: this function is expensive and must not be used from within
+    the nixpkgs repository.
+  </para>
+  <para>
+    Example usage:
+
+    <programlisting>let
+  pkgs = import &lt;nixpkgs&gt; {};
+  newpkgs = pkgs.overridePackages (self: super: {
+    foo = super.foo.override { ... };
+  };
+in ...</programlisting>
+  </para>
+
+  <para>
+    The resulting <varname>newpkgs</varname> will have the new <varname>foo</varname>
+    expression, and all other expressions depending on <varname>foo</varname> will also
+    use the new <varname>foo</varname> expression.
+  </para>
+
+  <para>
+    The behavior of this function is similar to <link 
+    linkend="sec-modify-via-packageOverrides">config.packageOverrides</link>.
+  </para>
+
+  <para>
+    The <varname>self</varname> parameter refers to the final package set with the
+    applied overrides. Using this parameter may lead to infinite recursion if not
+    used consciously.
+  </para>
+
+  <para>
+    The <varname>super</varname> parameter refers to the old package set.
+    It's equivalent to <varname>pkgs</varname> in the above example.
+  </para>
+
+</section>
+
+</chapter>

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -13,6 +13,7 @@
   <xi:include href="quick-start.xml" />
   <xi:include href="stdenv.xml" />
   <xi:include href="packageconfig.xml" />
+  <xi:include href="functions.xml" />
   <xi:include href="meta.xml" />
   <xi:include href="language-support.xml" />
   <xi:include href="package-notes.xml" />


### PR DESCRIPTION
Rationale:
1. There's no way to override an already existing `pkgs` set, AFAIK.
2. If you want to import `<nixpkgs>` with an overridden `config.packageOverrides` you lose the `config.nix` overrides, unless you merge with the default config.

This is similar to what I'm doing with `gnome3.overridePackages` nowadays. It's very useful, and doesn't hurt the existing pkgs, but will help a lot when composing pkgs with third-party packages or making more complex overrides.

Compared to the `packageOverrides` it also defines a `self` parameter, which is quite usual nowadays, e.g. in most GNOME or Haskell. Because when doing overrides you might want to refer to the final overridden set, not only the old set.

I will write proper documentation in nixpkgs once it gets accepted.

cc @edolstra @domenkozar @peti @nbp 
