### PR TITLE
compcert: 2.4 -> 2.5

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -1,22 +1,36 @@
-{ stdenv, fetchurl, coq, ocaml, ocamlPackages }:
+{ stdenv, fetchurl, coq, ocamlPackages
+, tools ? stdenv.cc
+}:
 
 stdenv.mkDerivation rec {
   name    = "compcert-${version}";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchurl {
     url    = "http://compcert.inria.fr/release/${name}.tgz";
-    sha256 = "1qrb1cplx3v5wxn1c46kx67v1j52yznvjm2hkrsdybphhki2pyia";
+    sha256 = "15gxarl2a8mz33fdn8pycj0ccazgmllbg2940n7aqdjlz807p11n";
   };
 
-  buildInputs = [ coq ocaml ocamlPackages.menhir ];
+  buildInputs = [ coq ] ++ (with ocamlPackages; [ ocaml menhir ]);
 
   enableParallelBuilding = true;
 
   configurePhase = ''
     substituteInPlace ./configure --replace '{toolprefix}gcc' '{toolprefix}cc'
-    ./configure -prefix $out -toolprefix ${stdenv.cc}/bin/ '' +
+    ./configure -prefix $out -toolprefix ${tools}/bin/ '' +
     (if stdenv.isDarwin then "ia32-macosx" else "ia32-linux");
+
+  installTargets = "documentation install";
+
+  postInstall = ''
+    mkdir -p $lib/share/doc/compcert
+    mv doc/html $lib/share/doc/compcert/
+    mkdir -p $lib/lib/coq/${coq.coq-version}/user-contrib/compcert/
+    mv backend cfrontend common cparser driver flocq ia32 lib \
+      $lib/lib/coq/${coq.coq-version}/user-contrib/compcert/
+  '';
+
+  outputs = [ "out" "lib" ];
 
   meta = with stdenv.lib; {
     description = "Formally verified C compiler";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3646,7 +3646,11 @@ let
 
   cmucl_binary = callPackage ../development/compilers/cmucl/binary.nix { };
 
-  compcert = callPackage ../development/compilers/compcert {};
+  compcert = callPackage ../development/compilers/compcert (
+    if system == "x86_64-linux"
+    then { tools = pkgsi686Linux.stdenv.cc; }
+    else {}
+  );
 
   cryptol = haskellPackages.cryptol;
 


### PR DESCRIPTION
Also adds an option to install the Coq library.

And make sure that, on linux-x86_64, CompCert comes with 32-bit tooling (standard header files, libc). Otherwise, compiling with CompCert often results in:

```
/nix/store/…-glibc-2.21/include/gnu/stubs.h:7:27: fatal error: gnu/stubs-32.h: No such file or directory
```

Tested on linux-x86_64.
