### PR TITLE
update rubygems to 2.4.8

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems.nix
+++ b/pkgs/development/interpreters/ruby/rubygems.nix
@@ -2,10 +2,10 @@ args : with args;
 
 rec {
   name = "rubygems-" + version;
-  version = "2.4.1";
+  version = "2.4.8";
   src = fetchurl {
     url = "http://production.cf.rubygems.org/rubygems/${name}.tgz";
-    sha256 = "0cpr6cx3h74ykpb0cp4p4xg7a8j0bhz3sk271jq69l4mm4zy4h4f";
+    sha256 = "0pl4civyf0vhqsqbqaivvxrb3fsg8sid9a8jv5vfnk4hypz3ahss";
   };
 
   buildInputs = [ruby makeWrapper];


### PR DESCRIPTION
There are certificate issues with 2.4.1 which cause gem install failures:

```
Gem::RemoteFetcher::FetchError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (https://rubygems.org/gems/rake-0.9.2.gem)
```

This might be worth backporting to other branches, since it's unlikely that the https version of rubygems works with any rubygems version before 2.4.4.
