### PR TITLE
Make mariadb conform to multiple-outputs

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib, qtscriptgenerator, perl, gettext, curl
-, libxml2, mysql, taglib, taglib_extras, loudmouth , kdelibs
+, libxml2, libmysql, taglib, taglib_extras, loudmouth , kdelibs
 , qca2, libmtp, liblastfm, libgpod, pkgconfig, automoc4, phonon
 , strigi, soprano, qjson, ffmpeg, libofa, nepomuk_core ? null }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   QT_PLUGIN_PATH="${qtscriptgenerator}/lib/qt4/plugins";
 
   buildInputs = [ qtscriptgenerator stdenv.cc.libc gettext curl
-    libxml2 mysql.lib taglib taglib_extras loudmouth kdelibs automoc4 phonon strigi
+    libxml2 libmysql taglib taglib_extras loudmouth kdelibs automoc4 phonon strigi
     soprano qca2 libmtp liblastfm libgpod pkgconfig qjson ffmpeg libofa nepomuk_core ];
 
   cmakeFlags = "-DKDE4_BUILD_TESTS=OFF";

--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, automoc4, boost, shared_desktop_ontologies, cmake
 , eigen, lcms, gettext, jasper, kdelibs, kdepimlibs, lensfun
 , libgphoto2, libjpeg, libkdcraw, libkexiv2, libkipi, libpgf, libtiff
-, libusb1, liblqr1, marble, mysql, opencv, phonon, pkgconfig, qca2
+, libusb1, liblqr1, marble, libmysql, opencv, phonon, pkgconfig, qca2
 , qimageblitz, qjson, qt4, soprano
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost eigen gettext jasper kdelibs kdepimlibs lcms lensfun
     libgphoto2 libjpeg libkdcraw libkexiv2 libkipi liblqr1 libpgf
-    libtiff marble mysql.lib opencv phonon qca2 qimageblitz qjson qt4
+    libtiff marble libmysql opencv phonon qca2 qimageblitz qjson qt4
     shared_desktop_ontologies soprano
   ];
 

--- a/pkgs/applications/misc/grass/default.nix
+++ b/pkgs/applications/misc/grass/default.nix
@@ -87,10 +87,10 @@ a.composableDerivation.composableDerivation {} (fix: {
   // wwf {
     name = "mysql";
     enable = {
-      buildInputs = [ a.mysql.lib ];
+      buildInputs = [ a.libmysql ];
       configureFlags = [
-        "--with-mysql-libs=${a.mysql.lib}/lib/mysql"
-        "--with-mysql-includes=${a.mysql.lib}/include/mysql"
+        "--with-mysql-libs=${a.libmysql.lib}/lib"
+        "--with-mysql-includes=${a.libmysql.dev}/include/mysql"
       ];
     };
   }

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -2,7 +2,7 @@
 , glib, glibc, libgnome_keyring, gnome_keyring, gtk, gtkmm, intltool
 , libctemplate, libglade
 , libiodbc
-, libgnome, libsigcxx, libtool, libuuid, libxml2, libzip, lua, mesa, mysql
+, libgnome, libsigcxx, libtool, libuuid, libxml2, libzip, lua, mesa, libmysql
 , pango, paramiko, pcre, pexpect, pkgconfig, pycrypto, python, sqlite, sudo
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ autoconf automake boost file gettext glib glibc libgnome_keyring gtk gtkmm intltool
     libctemplate libglade libgnome libiodbc libsigcxx libtool libuuid libxml2 libzip lua makeWrapper mesa
-    mysql.lib paramiko pcre pexpect pkgconfig pycrypto python sqlite ];
+    libmysql paramiko pcre pexpect pkgconfig pycrypto python sqlite ];
 
   preConfigure = ''
     substituteInPlace $(pwd)/frontend/linux/workbench/mysql-workbench.in --replace "catchsegv" "${glibc}/bin/catchsegv"

--- a/pkgs/applications/misc/stardict/stardict.nix
+++ b/pkgs/applications/misc/stardict/stardict.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, gtk, glib, zlib, libxml2, intltool, gnome_doc_utils, libgnomeui, scrollkeeper, mysql, pcre, which, libxslt}:
+{stdenv, fetchurl, pkgconfig, gtk, glib, zlib, libxml2, intltool, gnome_doc_utils, libgnomeui, scrollkeeper, libmysql, pcre, which, libxslt}:
 stdenv.mkDerivation rec {
   name= "stardict-3.0.3";
 
@@ -7,13 +7,13 @@ stdenv.mkDerivation rec {
     sha256 = "0wrb8xqy6x9piwrn0vw5alivr9h3b70xlf51qy0jpl6d7mdhm8cv";
   };
 
-  buildInputs = [ pkgconfig gtk glib zlib libxml2 intltool gnome_doc_utils libgnomeui scrollkeeper mysql.lib pcre which libxslt];
+  buildInputs = [ pkgconfig gtk glib zlib libxml2 intltool gnome_doc_utils libgnomeui scrollkeeper libmysql pcre which libxslt];
 
   postPatch = ''
     # mysql hacks: we need dynamic linking as there is no libmysqlclient.a
-    substituteInPlace tools/configure --replace '/usr/local/include/mysql' '${mysql.lib}/include/mysql/'
+    substituteInPlace tools/configure --replace '/usr/local/include/mysql' '${libmysql.dev}/include/mysql'
     substituteInPlace tools/configure --replace 'AC_FIND_FILE([libmysqlclient.a]' 'AC_FIND_FILE([libmysqlclient.so]'
-    substituteInPlace tools/configure --replace '/usr/local/lib/mysql' '${mysql.lib}/lib/mysql/'
+    substituteInPlace tools/configure --replace '/usr/local/lib/mysql' '${libmysql.lib}/lib'
     substituteInPlace tools/configure --replace 'for y in libmysqlclient.a' 'for y in libmysqlclient.so'
     substituteInPlace tools/configure --replace 'libmysqlclient.a' 'libmysqlclient.so'
 

--- a/pkgs/applications/office/calligra/default.nix
+++ b/pkgs/applications/office/calligra/default.nix
@@ -2,7 +2,7 @@
 , kdepimlibs, createresources ? null, eigen, qca2, exiv2, soprano, marble, lcms2
 , fontconfig, freetype, sqlite, icu, libwpd, libwpg, pkgconfig, poppler_qt4
 , libkdcraw, libxslt, fftw, glew, gsl, shared_desktop_ontologies, okular
-, libvisio, kactivities, mysql, postgresql, freetds, xbase, openexr, ilmbase
+, libvisio, kactivities, libmysql, postgresql, freetds, xbase, openexr, ilmbase
 , libodfgen, opencolorio, openjpeg, pstoedit, librevenge
  }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     createresources eigen qca2 exiv2 soprano marble lcms2 fontconfig freetype
     sqlite icu libwpd libwpg poppler_qt4 libkdcraw libxslt fftw glew gsl
     shared_desktop_ontologies okular libodfgen opencolorio openjpeg
-    libvisio kactivities mysql.lib postgresql freetds xbase openexr pstoedit
+    libvisio kactivities libmysql postgresql freetds xbase openexr pstoedit
     librevenge
   ];
 

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -13,7 +13,7 @@
 , libmpeg2, libsamplerate, libmad
 , libogg, libvorbis, flac, libxslt
 , lzo, libcdio, libmodplug, libass, libbluray
-, sqlite, mysql, nasm, gnutls, libva, wayland
+, sqlite, libmysql, nasm, gnutls, libva, wayland
 , curl, bzip2, zip, unzip, glxinfo, xdpyinfo
 , dbus_libs ? null, dbusSupport ? true
 , udev, udevSupport ? true
@@ -67,7 +67,7 @@ in stdenv.mkDerivation rec {
       libmpeg2 libsamplerate libmad
       libogg libvorbis flac libxslt systemd
       lzo libcdio libmodplug libass libbluray
-      sqlite mysql.lib nasm avahi libdvdcss lame
+      sqlite libmysql nasm avahi libdvdcss lame
       curl bzip2 zip unzip glxinfo xdpyinfo
     ]
     ++ lib.optional dbusSupport dbus_libs

--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -2,7 +2,7 @@
 , libevent, gd, curl, libxml2, icu, flex, bison, openssl, zlib, php, re2c
 , expat, libcap, oniguruma, libdwarf, libmcrypt, tbb, gperftools, glog, libkrb5
 , bzip2, openldap, readline, libelf, uwimap, binutils, cyrus_sasl, pam, libpng
-, libxslt, ocaml, freetype, gdb, git, perl, mariadb, gmp, libyaml, libedit
+, libxslt, ocaml, freetype, gdb, git, perl, libmysql, gmp, libyaml, libedit
 , libvpx, imagemagick, fribidi
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ cmake pkgconfig boost libunwind mariadb libmemcached pcre gdb git perl
+    [ cmake pkgconfig boost libunwind libmysql libmemcached pcre gdb git perl
       libevent gd curl libxml2 icu flex bison openssl zlib php expat libcap
       oniguruma libdwarf libmcrypt tbb gperftools bzip2 openldap readline
       libelf uwimap binutils cyrus_sasl pam glog libpng libxslt ocaml libkrb5
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
   dontUseCmakeBuildDir = true;
   NIX_LDFLAGS = "-lpam -L${pam}/lib";
-  MYSQL_INCLUDE_DIR="${mariadb}/include/mysql";
-  MYSQL_DIR=mariadb;
+  MYSQL_INCLUDE_DIR="${libmysql.dev}/include/mysql";
+  MYSQL_DIR=libmysql;
 
   # work around broken build system
   NIX_CFLAGS_COMPILE = "-I${freetype}/include/freetype2";

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, file, openssl, mlton, mysql, postgresql, sqlite }:
+{ stdenv, fetchurl, file, openssl, mlton, libmysql, postgresql, sqlite }:
 
 stdenv.mkDerivation rec {
   pname = "urweb";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "f7b7587fe72c04f14581ded11588777f7bb61e392634966cc0354e13d69f236d";
   };
 
-  buildInputs = [ stdenv.cc file openssl mlton mysql postgresql sqlite ];
+  buildInputs = [ stdenv.cc file openssl mlton libmysql postgresql sqlite ];
 
   prePatch = ''
     sed -e 's@/usr/bin/file@${file}/bin/file@g' -i configure
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
     ''
       export CC="${stdenv.cc}/bin/gcc";
       export CCARGS="-I$out/include \
-                      -L${mysql.lib}/lib/mysql -L${postgresql}/lib -L${sqlite}/lib";
+                      -L${libmysql.lib}/lib -L${postgresql}/lib -L${sqlite}/lib";
 
       export PGHEADER="${postgresql}/include/libpq-fe.h";
-      export MSHEADER="${mysql.lib}/include/mysql/mysql.h";
+      export MSHEADER="${libmysql.dev}/include/mysql/mysql.h";
       export SQHEADER="${sqlite}/include/sqlite3.h";
     '';
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -29,7 +29,7 @@ self: super: {
   hslua = super.hslua.override { lua = pkgs.lua5_1; };
 
   # Use the default version of mysql to build this package (which is actually mariadb).
-  mysql = super.mysql.override { mysql = pkgs.mysql.lib; };
+  mysql = super.mysql.override { mysql = pkgs.libmysql; };
 
   # Please also remove optparse-applicative special case from
   # cabal2nix/hackage2nix.hs when removing the following.

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, composableDerivation, autoconf, automake, flex, bison
-, mysql, libxml2, readline, zlib, curl, postgresql, gettext
+, libmysql, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pkgconfig, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
 , uwimap, pam, gmp
@@ -96,13 +96,13 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     };
 
     mysql = {
-      configureFlags = ["--with-mysql=${mysql.lib}"];
-      buildInputs = [ mysql.lib ];
+      configureFlags = ["--with-mysql=${libmysql}"];
+      buildInputs = [ libmysql ];
     };
 
     mysqli = {
-      configureFlags = ["--with-mysqli=${mysql.lib}/bin/mysql_config"];
-      buildInputs = [ mysql.lib ];
+      configureFlags = ["--with-mysqli=${libmysqld.dev}/bin/mysql_config"];
+      buildInputs = [ libmysql ];
     };
 
     mysqli_embedded = {
@@ -112,8 +112,8 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     };
 
     pdo_mysql = {
-      configureFlags = ["--with-pdo-mysql=${mysql.lib}"];
-      buildInputs = [ mysql.lib ];
+      configureFlags = ["--with-pdo-mysql=${libmysql}"];
+      buildInputs = [ libmysql ];
     };
 
     bcmath = {

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -101,7 +101,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     };
 
     mysqli = {
-      configureFlags = ["--with-mysqli=${libmysqld.dev}/bin/mysql_config"];
+      configureFlags = ["--with-mysqli=${libmysql.dev}/bin/mysql_config"];
       buildInputs = [ libmysql ];
     };
 

--- a/pkgs/development/interpreters/ruby/bundler-env/default-gem-config.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default-gem-config.nix
@@ -20,7 +20,7 @@
 { lib, fetchurl, writeScript, ruby, libxml2, libxslt, python, stdenv, which
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
-, cmake, libssh2, openssl, mysql
+, cmake, libssh2, openssl, libmysql
 }:
 
 let
@@ -48,7 +48,7 @@ in
   };
 
   mysql2 = attrs: {
-    buildInputs = [ mysql.lib zlib openssl ];
+    buildInputs = [ libmysql zlib openssl ];
   };
 
   ncursesw = attrs: {

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, composableDerivation, unzip, libjpeg, libtiff, zlib
-, postgresql, mysql, libgeotiff, python, pythonPackages, proj, geos, openssl
+, postgresql, libmysql, libgeotiff, python, pythonPackages, proj, geos, openssl
 , libpng }:
 
 composableDerivation.composableDerivation {} (fixed: rec {
@@ -30,7 +30,7 @@ composableDerivation.composableDerivation {} (fixed: rec {
     "--with-libz=${zlib}"       # optional
 
     "--with-pg=${postgresql}/bin/pg_config"
-    "--with-mysql=${mysql.lib}/bin/mysql_config"
+    "--with-mysql=${libmysql}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
     "--with-python"               # optional
     "--with-static-proj4=${proj}" # optional

--- a/pkgs/development/libraries/groonga-normalizer-mysql/default.nix
+++ b/pkgs/development/libraries/groonga-normalizer-mysql/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libgroonga }:
+
+stdenv.mkDerivation rec {
+  name = "groonga-normalizer-mysql-${version}";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "groonga";
+    repo = "groonga-normalizer-mysql";
+    rev = "v${version}";
+    sha256 = "1s7yzggp25jajl8i28da2bz0nys90llwg5gvpyhsdqv3w3n1dysy";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libgroonga ];
+
+  preConfigure = ''
+    export GROONGA_PLUGINS_DIR="$out/lib/groonga/plugins"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/groonga/groonga-normalizer-mysql;
+    description = "provides MySQL compatible normalizers and a custom normalizers to Groonga";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ wkennington ];
+  };
+}

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
     "--with-dbi-libdir=${libdbi}/lib"
   ] ++ optionals (libmysql != null) [
     "--with-mysql"
-    "--with-mysql-incdir=${libmysql}/include/mysql"
-    "--with-mysql-libdir=${libmysql}/lib/mysql"
+    "--with-mysql-incdir=${libmysql.dev}/include/mysql"
+    "--with-mysql-libdir=${libmysql.lib}/lib"
   ] ++ optionals (postgresql != null) [
     "--with-pgsql"
     "--with-pgsql_incdir=${postgresql}/include"

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, openssl, libxslt, perl
 , curl, pcre, libxml2, librdf_rasqal
-, mysql, withMysql ? false
+, libmysql, withMysql ? false
 , postgresql, withPostgresql ? false
 , sqlite, withSqlite ? true
 , db, withBdb ? false
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl pkgconfig ];
 
   buildInputs = [ openssl libxslt curl pcre libxml2 ]
-    ++ stdenv.lib.optional withMysql mysql
+    ++ stdenv.lib.optional withMysql libmysql
     ++ stdenv.lib.optional withSqlite sqlite
     ++ stdenv.lib.optional withPostgresql postgresql
     ++ stdenv.lib.optional withBdb db;

--- a/pkgs/development/libraries/opendbx/default.nix
+++ b/pkgs/development/libraries/opendbx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, readline, mysql, postgresql, sqlite }:
+{ stdenv, fetchurl, readline, libmysql, postgresql, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "opendbx-1.4.6";
@@ -9,10 +9,9 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    export CPPFLAGS="-I${mysql.lib}/include/mysql"
-    export LDFLAGS="-L${mysql.lib}/lib/mysql"
+    export CPPFLAGS="-I${libmysql.dev}/include/mysql"
     configureFlagsArray=(--with-backends="mysql pgsql sqlite3")
   '';
 
-  buildInputs = [ readline mysql.lib postgresql sqlite ];
+  buildInputs = [ readline libmysql postgresql sqlite ];
 }

--- a/pkgs/development/libraries/qt-3/default.nix
+++ b/pkgs/development/libraries/qt-3/default.nix
@@ -5,7 +5,7 @@
 , xineramaSupport ? true, libXinerama ? null
 , cursorSupport ? true, libXcursor ? null
 , threadSupport ? true
-, mysqlSupport ? false, mysql ? null
+, mysqlSupport ? false, libmysql ? null
 , openglSupport ? false, mesa ? null, libXmu ? null
 , x11, xextproto, zlib, libjpeg, libpng, which
 }:
@@ -14,7 +14,7 @@ assert xftSupport -> libXft != null;
 assert xrenderSupport -> xftSupport && libXrender != null;
 assert xrandrSupport -> libXrandr != null && randrproto != null;
 assert cursorSupport -> libXcursor != null;
-assert mysqlSupport -> mysql != null;
+assert mysqlSupport -> libmysql != null;
 assert openglSupport -> mesa != null && libXmu != null;
 
 stdenv.mkDerivation {
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
       -I${randrproto}/include" else "-no-xrandr"}
     ${if xineramaSupport then "-xinerama -L${libXinerama}/lib -I${libXinerama}/include" else "-no-xinerama"}
     ${if cursorSupport then "-L${libXcursor}/lib -I${libXcursor}/include" else ""}
-    ${if mysqlSupport then "-qt-sql-mysql -L${mysql.lib}/lib/mysql -I${mysql.lib}/include/mysql" else ""}
+    ${if mysqlSupport then "-qt-sql-mysql -L${libmysql.lib}/lib -I${libmysql.dev}/include/mysql" else ""}
     ${if xftSupport then "-xft
       -L${libXft}/lib -I${libXft}/include
       -L${libXft.freetype}/lib -I${libXft.freetype}/include

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -2,7 +2,7 @@
 , libXrender, libXinerama, libXcursor, libXmu, libXv, libXext
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
-, libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
+, libtiff, glib, icu, libmysql, postgresql, sqlite, perl, coreutils, libXi
 , buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst_plugins_base
 , buildWebkit ? stdenv.isLinux
 , flashplayerFix ? false, gdk_pixbuf
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
       -opengl -xrender -xrandr -xinerama -xcursor -xinput -xfixes -fontconfig
       -qdbus -${if cups == null then "no-" else ""}cups -glib -dbus-linked -openssl-linked
 
-      ${if mysql != null then "-plugin" else "-no"}-sql-mysql -system-sqlite
+      ${if libmysql != null then "-plugin" else "-no"}-sql-mysql -system-sqlite
 
       -exceptions -xmlpatterns
 
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
   # The following libraries are only used in plugins
   buildInputs =
     [ cups # Qt dlopen's libcups instead of linking to it
-      mysql.lib postgresql sqlite libjpeg libmng libtiff icu ]
+      libmysql postgresql sqlite libjpeg libmng libtiff icu ]
     ++ optionals gtkStyle [ gtk gdk_pixbuf ];
 
   nativeBuildInputs = [ perl pkgconfig which ];

--- a/pkgs/development/libraries/qt-5/5.3/default.nix
+++ b/pkgs/development/libraries/qt-5/5.3/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll, libXrender, libXext
 , libXfixes, freetype, fontconfig, zlib, libjpeg, libpng
 , mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
-, libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
+, libtiff, glib, icu, libmysql, postgresql, sqlite, perl, coreutils, libXi
 , gdk_pixbuf, python, gdb, xlibs, libX11, libxcb, xcbutil, xcbutilimage
 , xcbutilkeysyms, xcbutilwm, udev, libxml2, libxslt, pcre, libxkbcommon
 , alsaLib, gstreamer, gst_plugins_base
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     -dbus-linked
 
     -system-sqlite
-    -${if mysql != null then "plugin" else "no"}-sql-mysql
+    -${if libmysql != null then "plugin" else "no"}-sql-mysql
     -${if postgresql != null then "plugin" else "no"}-sql-psql
 
     -make libs
@@ -155,7 +155,7 @@ stdenv.mkDerivation rec {
   # doesn't remain a runtime-dep if not used
   ++ optionals mesaSupported [ mesa mesa_glu ]
   ++ optional (cups != null) cups
-  ++ optional (mysql != null) mysql.lib
+  ++ optional (libmysql != null) libmysql
   ++ optional (postgresql != null) postgresql
   ++ optionals gtkStyle [gnome_vfs libgnomeui gtk GConf];
 

--- a/pkgs/development/libraries/qt-5/5.4/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/5.4/qtbase.nix
@@ -11,7 +11,7 @@
 
 # optional dependencies
 , cups ? null
-, mysql ? null, postgresql ? null
+, libmysql ? null, postgresql ? null
 
 # options
 , mesaSupported, mesa, mesa_glu
@@ -133,7 +133,7 @@ stdenv.mkDerivation {
     -dbus-linked
 
     -system-sqlite
-    -${if mysql != null then "plugin" else "no"}-sql-mysql
+    -${if libmysql != null then "plugin" else "no"}-sql-mysql
     -${if postgresql != null then "plugin" else "no"}-sql-psql
 
     -make libs
@@ -152,7 +152,7 @@ stdenv.mkDerivation {
   # doesn't remain a runtime-dep if not used
   ++ optionals mesaSupported [ mesa mesa_glu ]
   ++ optional (cups != null) cups
-  ++ optional (mysql != null) mysql.lib
+  ++ optional (libmysql != null) libmysql
   ++ optional (postgresql != null) postgresql
   ++ optionals gtkStyle [gnome_vfs libgnomeui gtk GConf];
 

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -193,7 +193,7 @@ let lispPackages = rec {
     version = "git-20150514";
     description = "Common Lisp SQL Interface library";
     deps = [uffi];
-    buildInputs = [pkgs.mysql.lib pkgs.zlib];
+    buildInputs = [pkgs.libmysql pkgs.zlib];
     # Source type: git
     src = pkgs.fetchgit {
       url =
@@ -205,8 +205,7 @@ let lispPackages = rec {
     };
     overrides = x:{
       preConfigure = ''
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${pkgs.mysql.lib}/include/mysql"
-        export NIX_LDFLAGS="$NIX_LDFLAGS -L${pkgs.mysql.lib}/lib/mysql"
+        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${pkgs.libmysql.dev}/include/mysql"
       '';
     };
   };

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, mysql, camlp4 }:
+{ stdenv, fetchurl, ocaml, findlib, libmysql, camlp4 }:
 
 # TODO: la versione stabile da' un errore di compilazione dovuto a
 # qualche cambiamento negli header .h
@@ -23,15 +23,11 @@ stdenv.mkDerivation {
      "--libdir=$out/lib/ocaml/${ocaml_version}/site-lib/mysql"
   ];
 
-  buildInputs = [ocaml findlib mysql.lib camlp4 ];
+  buildInputs = [ ocaml findlib libmysql camlp4 ];
 
   createFindlibDestdir = true;
 
-  propagatedbuildInputs = [ mysql.lib ];
-
-  preConfigure = ''
-    export LDFLAGS="-L${mysql.lib}/lib/mysql"
-  '';
+  propagatedbuildInputs = [ libmysql ];
 
   buildPhase = ''
     make

--- a/pkgs/development/perl-modules/DBD-mysql/default.nix
+++ b/pkgs/development/perl-modules/DBD-mysql/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, buildPerlPackage, DBI, mysql }:
+{ fetchurl, buildPerlPackage, DBI, libmysql }:
 
 buildPerlPackage rec {
   name = "DBD-mysql-4.031";
@@ -8,7 +8,7 @@ buildPerlPackage rec {
     sha256 = "1lngnkfi71gcpfk93xhil2x9i3w3rqjpxlvn5n92jd5ikwry8bmf";
   };
 
-  buildInputs = [ mysql.lib ] ;
+  buildInputs = [ libmysql ] ;
   propagatedBuildInputs = [ DBI ];
 
   doCheck = false;

--- a/pkgs/development/pure-modules/glpk/default.nix
+++ b/pkgs/development/pure-modules/glpk/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
     preConfigure = ''
       substituteInPlace configure \
-        --replace /usr/include/mysql ${libmysql}/include/mysql
+        --replace /usr/include/mysql ${libmysql.dev}/include/mysql
     '';
     configureFlags = [ "--enable-dl"
                        "--enable-odbc"

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -302,7 +302,7 @@ let
     rmatio = [ pkgs.zlib ];
     Rmpfr = [ pkgs.gmp pkgs.mpfr ];
     Rmpi = [ pkgs.openmpi ];
-    RMySQL = [ pkgs.zlib pkgs.mysql.lib ];
+    RMySQL = [ pkgs.zlib pkgs.libmysql ];
     RNetCDF = [ pkgs.netcdf pkgs.udunits ];
     RODBCext = [ pkgs.libiodbc ];
     RODBC = [ pkgs.libiodbc ];
@@ -1573,7 +1573,7 @@ let
 
     RMySQL = old.RMySQL.overrideDerivation (attrs: {
       patches = [ ./patches/RMySQL.patch ];
-      MYSQL_DIR="${pkgs.mysql.lib}";
+      MYSQL_DIR="${pkgs.libmysql}";
     });
 
     devEMF = old.devEMF.overrideDerivation (attrs: {

--- a/pkgs/games/zod/default.nix
+++ b/pkgs/games/zod/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ unrar unzip SDL SDL_image SDL_ttf SDL_mixer libmysql
     makeWrapper ];
 
-  NIX_LDFLAGS="-L${libmysql}/lib/mysql";
-
   installPhase = ''
     mkdir -p $out/bin $out/share/zod
     pushd $out/share/zod

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, munge, perl, pam, openssl, mysql }:
+{ stdenv, fetchurl, python, munge, perl, pam, openssl, libmysql }:
 
 #TODO: add sview support based on gtk2
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0xx1q9ximsyyipl0xbj8r7ajsz4xrxik8xmhcb1z9nv0aza1rff2";
   };
 
-  buildInputs = [ python munge perl pam openssl mysql.lib ];
+  buildInputs = [ python munge perl pam openssl libmysql ];
 
   configureFlags = ''
     --with-munge=${munge}

--- a/pkgs/servers/games/ghost-one/default.nix
+++ b/pkgs/servers/games/ghost-one/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, gmp, zlib, bzip2, boost, mysql }:
+{ stdenv, fetchurl, unzip, gmp, zlib, bzip2, boost, libmysql }:
 stdenv.mkDerivation rec {
 
   name = "ghost-one-${version}";
@@ -9,10 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1sm2ca3lcdr4vjg7v94d8zhqz8cdp44rg8yinzzwkgsr0hj74fv2";
   };
 
-  buildInputs = [ unzip gmp zlib bzip2 boost mysql.lib ];
+  buildInputs = [ unzip gmp zlib bzip2 boost libmysql ];
 
   patchPhase = ''
-    substituteInPlace ghost/Makefile --replace "/usr/local/lib/mysql" "${mysql.lib}/lib/mysql"
+    substituteInPlace ghost/Makefile --replace "/usr/local/lib/mysql" "${libmysql.lib}/lib"
   '';
 
   buildPhase = ''

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, pkgconfig, pcre, libxml2, zlib, attr, bzip2, which, file
 , openssl, enableMagnet ? false, lua5_1 ? null
-, enableMysql ? false, mysql ? null
+, enableMysql ? false, libmysql ? null
 }:
 
 assert enableMagnet -> lua5_1 != null;
-assert enableMysql -> mysql != null;
+assert enableMysql -> libmysql != null;
 
 stdenv.mkDerivation rec {
   name = "lighttpd-1.4.35";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig pcre libxml2 zlib attr bzip2 which file openssl ]
              ++ stdenv.lib.optional enableMagnet lua5_1
-             ++ stdenv.lib.optional enableMysql mysql.lib;
+             ++ stdenv.lib.optional enableMysql libmysql;
 
   configureFlags = [ "--with-openssl" ]
                 ++ stdenv.lib.optional enableMagnet "--with-lua"

--- a/pkgs/servers/restund/default.nix
+++ b/pkgs/servers/restund/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, openssl, libre, librem, mysql }:
+{ stdenv, fetchurl, zlib, openssl, libre, librem, libmysql }:
 stdenv.mkDerivation rec {
   version = "0.4.2";
   name = "restund-${version}";
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
     url = "http://www.creytiv.com/pub/restund-${version}.tar.gz";
     sha256 = "db5260939d40cb2ce531075bef02b9d6431067bdd52f3168a6f25246bdf7b9f2";
   };
-  buildInputs = [ zlib openssl libre librem mysql.lib ];
+  buildInputs = [ zlib openssl libre librem libmysql ];
   makeFlags = [
     "LIBRE_MK=${libre}/share/re/re.mk"
     "LIBRE_INC=${libre}/include/re"
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optional (stdenv.cc.cc != null) "SYSROOT_ALT=${stdenv.cc.cc}"
   ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.cc.libc}"
   ;
-  NIX_LDFLAGS='' -L${mysql.lib}/lib/mysql '';
   meta = {
     homepage = "http://www.creytiv.com/restund.html";
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -1,0 +1,142 @@
+{ stdenv, fetchurl, pkgconfig, libedit, zlib, lz4, jemalloc, zeromq, libevent, libmsgpack, pcre }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "groonga-${version}";
+  version = "5.0.4";
+
+  src = fetchurl {
+    url = "http://packages.groonga.org/source/groonga/${name}.tar.gz";
+    sha256 = "047ynici24b188cm6xmrxr26ar7ym5apl56jclzcyvbg3s97m2rk";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libedit zlib lz4 jemalloc zeromq libevent libmsgpack pcre ];
+
+  preConfigure = ''
+    configureFlagsArray+=("--exec_prefix=$bin")
+    configureFlagsArray+=("--libdir=$lib/lib")
+    configureFlagsArray+=("--includedir=$dev/include")
+    configureFlagsArray+=("--datarootdir=$data/share")
+    configureFlagsArray+=("--mandir=$man/share/man")
+    configureFlagsArray+=("--docdir=$doc/share/doc")
+    configureFlagsArray+=("--infodir=$doc/share/info")
+
+    export PKG_CONFIG_LIBDIR="$dev/lib/pkgconfig"
+  '';
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--disable-benchmark"
+    "--without-inkscape"
+    "--with-jemalloc"
+    "--without-mecab"
+    "--disable-groonga-httpd"
+    "--disable-mruby"
+  ] ++ optionals stdenv.isLinux [
+    "--enable-futex"
+  ];
+
+  outputs = [ "out" "bin" "dev" "lib" "data" "man" "doc" ];
+
+  installFlags = [
+    "sysconfdir=\${data}/etc"
+    "pkgconfigdir=\${dev}/lib/pkgconfig"
+  ];
+
+  postInstall = ''
+    # Make dev propagate libs so that linking works
+    mkdir -p $dev/nix-support
+    echo "$lib" >> $dev/nix-support/propagated-native-build-inputs
+
+    # We expect to be storing nothing in out
+    # rmdir should therefore succeed
+    if ! rmdir $out; then
+      echo "$out unexpected contained files"
+      exit 1
+    fi
+
+    # Out needs to propagate the expected installed files
+    mkdir -p $out/nix-support
+    echo "$bin" >> $out/nix-support/propagated-native-build-inputs
+    echo "$man" >> $out/nix-support/propagated-native-build-inputs
+  '';
+
+  preFixup = ''
+    # Fix the groonga executable to not include paths
+    # It writes the entire config string into the --version option
+    for output in "$out" "$dev" "$man" "$doc"; do
+      sed -i "s,$output,$(echo "$output" | sed 's/./x/g'),g" $bin/bin/groonga
+    done
+    sed -i "/prefix=/d" $bin/sbin/groonga-httpd-restart
+
+    # Fix the groonga.pc having $out references
+    sed -i '/^\(libdir\|includedir\)/!s/^[a-z_]*=.*//g' $dev/lib/pkgconfig/groonga.pc
+  '' + optionalString (!stdenv.isDarwin) ''
+    # Fix the .la file from linking against missing libraries
+    sed \
+      -e "s, -lmsgpack[ '], -L${libmsgpack}/lib\0,g" \
+      -e "s, -llz4[ '], -L${lz4}/lib\0,g" \
+      -e "s, -ljemalloc[ '], -L${jemalloc}/lib\0,g" \
+      -e "s, -lz[ '], -L${zlib}/lib\0,g" \
+      -i $lib/lib/libgroonga.la
+  '';
+
+  postFixup = ''
+    # Make sure there are no extraneous references
+    check_references () {
+      if grep -qr "$1" "$2"; then
+        echo "Extraneous $1 in $2" >&2
+        exit 1
+      fi
+    }
+
+    check_references "$dev" "$out"
+    check_references "$doc" "$out"
+
+    check_references "$out" "$bin"
+    check_references "$dev" "$bin"
+    check_references "$man" "$bin"
+    check_references "$doc" "$bin"
+
+    check_references "$out" "$dev"
+    check_references "$bin" "$dev"
+    check_references "$man" "$dev"
+    check_references "$doc" "$dev"
+
+    check_references "$out" "$lib"
+    check_references "$bin" "$lib"
+    check_references "$dev" "$lib"
+    check_references "$man" "$lib"
+    check_references "$doc" "$lib"
+
+    check_references "$out" "$data"
+    check_references "$bin" "$data"
+    check_references "$dev" "$data"
+    check_references "$lib" "$data"
+    check_references "$man" "$data"
+    check_references "$doc" "$data"
+
+    check_references "$out" "$man"
+    check_references "$bin" "$man"
+    check_references "$dev" "$man"
+    check_references "$lib" "$man"
+    check_references "$data" "$man"
+    check_references "$doc" "$man"
+
+    check_references "$out" "$doc"
+    check_references "$dev" "$doc"
+    check_references "$man" "$doc"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://groonga.org/;
+    description = "an open-source fulltext search engine and column store";
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ wkennington ];
+  };
+}

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, cmake, ncurses, zlib, openssl, pcre, boost, judy, bison, libxml2
-, libaio, libevent, groff, jemalloc, perl, fixDarwinDylibNames
+{ stdenv, fetchurl, cmake, ncurses, zlib, bzip2, lzma, lzo, lz4, openssl, pcre
+, boost, judy, bison, libxml2, libaio, libevent, groff, jemalloc, perl, readline
+, libgroonga, groonga-normalizer-mysql, fixDarwinDylibNames, pkgconfig
 }:
 
 with stdenv.lib;
@@ -12,35 +13,61 @@ stdenv.mkDerivation rec {
     sha256 = "0cm1j4805ypbmrhajn4ar5rqsis1p5haxs7c04b6k540gmfmxgrg";
   };
 
-  buildInputs = [ cmake ncurses openssl zlib pcre libxml2 boost judy bison libevent ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ jemalloc libaio ]
+  nativeBuildInputs = [ pkgconfig bison cmake ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ perl fixDarwinDylibNames ];
+  buildInputs = [
+    ncurses openssl zlib bzip2 lzma lzo lz4 pcre libxml2 boost judy libevent
+    readline libgroonga groonga-normalizer-mysql
+  ] ++ stdenv.lib.optionals stdenv.isLinux [ jemalloc libaio ];
 
   patches = stdenv.lib.optional stdenv.isDarwin ./my_context_asm.patch;
 
+  preConfigure = ''
+    # Install Paths
+    cmakeFlagsArray+=("-DINSTALL_BINDIR=$bin/bin")
+    cmakeFlagsArray+=("-DINSTALL_SBINDIR=$bin/sbin")
+    cmakeFlagsArray+=("-DINSTALL_SCRIPTDIR=$bin/bin")
+    cmakeFlagsArray+=("-DINSTALL_SYSCONFDIR=/etc")
+    cmakeFlagsArray+=("-DINSTALL_SYSCONF2DIR=/etc/my.cnf.d")
+
+    cmakeFlagsArray+=("-DINSTALL_LIBDIR=$lib/lib")
+    cmakeFlagsArray+=("-DINSTALL_PLUGINDIR=$lib/lib/mysql/plugin")
+
+    cmakeFlagsArray+=("-DINSTALL_INCLUDEDIR=$dev/include/mysql")
+
+    cmakeFlagsArray+=("-DINSTALL_DOCDIR=$doc/share/doc")
+    cmakeFlagsArray+=("-DINSTALL_DOCREADMEDIR=$doc/share/doc")
+    cmakeFlagsArray+=("-DINSTALL_MANDIR=$man/share/man")
+    cmakeFlagsArray+=("-DINSTALL_INFODIR=$doc/share/info")
+
+    cmakeFlagsArray+=("-DINSTALL_SHAREDIR=$data/share")
+    cmakeFlagsArray+=("-DINSTALL_MYSQLSHAREDIR=$data/share/mysql")
+    cmakeFlagsArray+=("-DINSTALL_SUPPORTFILESDIR=$data/share/mysql")
+    cmakeFlagsArray+=("-DINSTALL_MYSQLTESTDIR=$TMPDIR")
+    cmakeFlagsArray+=("-DINSTALL_SQLBENCHDIR=$TMPDIR")
+  '';
+
   cmakeFlags = [
+    # Don't use an install prefix because this breaks the install
+    # since mariadb then treats all other paths as relative
+    "-DCMAKE_INSTALL_PREFIX=/"
+
+    # Other Path Options
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+
+    # General Build Options
     "-DBUILD_CONFIG=mysql_release"
+    "-DWITH_UNIT_TESTS=OFF"
     "-DDEFAULT_CHARSET=utf8"
     "-DDEFAULT_COLLATION=utf8_general_ci"
     "-DENABLED_LOCAL_INFILE=ON"
-    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
-    "-DMYSQL_DATADIR=/var/lib/mysql"
-    "-DINSTALL_SYSCONFDIR=etc/mysql"
-    "-DINSTALL_INFODIR=share/mysql/docs"
-    "-DINSTALL_MANDIR=share/man"
-    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
-    "-DINSTALL_SCRIPTDIR=bin"
-    "-DINSTALL_INCLUDEDIR=include/mysql"
-    "-DINSTALL_DOCREADMEDIR=share/mysql"
-    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
-    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
-    "-DINSTALL_DOCDIR=share/mysql/docs"
-    "-DINSTALL_SHAREDIR=share/mysql"
+
+    # Features
     "-DWITH_READLINE=ON"
     "-DWITH_ZLIB=system"
     "-DWITH_SSL=system"
     "-DWITH_PCRE=system"
-    "-DWITH_EMBEDDED_SERVER=yes"
     "-DWITH_EXTRA_CHARSETS=complex"
     "-DWITH_EMBEDDED_SERVER=ON"
     "-DWITH_ARCHIVE_STORAGE_ENGINE=1"
@@ -55,54 +82,122 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "out" "lib" ];
+  outputs = [ "out" "bin" "dev" "lib" "data" "man" "doc" ];
 
   prePatch = ''
     substituteInPlace cmake/libutils.cmake \
       --replace /usr/bin/libtool libtool
-    sed -i "s,SET(DEFAULT_MYSQL_HOME.*$,SET(DEFAULT_MYSQL_HOME /not/a/real/dir),g" CMakeLists.txt
-    sed -i "s,SET(PLUGINDIR.*$,SET(PLUGINDIR $lib/lib/mysql/plugin),g" CMakeLists.txt
 
-    sed -i "s,SET(pkgincludedir.*$,SET(pkgincludedir $lib/include),g" scripts/CMakeLists.txt
-    sed -i "s,SET(pkglibdir.*$,SET(pkglibdir $lib/lib),g" scripts/CMakeLists.txt
-    sed -i "s,SET(pkgplugindir.*$,SET(pkgplugindir $lib/lib/mysql/plugin),g" scripts/CMakeLists.txt
+    # We are providing our own version of groonga so don't build the bundled version
+    rm -r storage/mroonga/vendor
 
-    sed -i "s,set(libdir.*$,SET(libdir $lib/lib),g" storage/mroonga/vendor/groonga/CMakeLists.txt
-    sed -i "s,set(includedir.*$,SET(includedir $lib/include),g" storage/mroonga/vendor/groonga/CMakeLists.txt
-    sed -i "/\"\$[{]CMAKE_INSTALL_PREFIX}\/\$[{]GRN_RELATIVE_PLUGINS_DIR}\"/d" storage/mroonga/vendor/groonga/CMakeLists.txt
-    sed -i "s,set(GRN_PLUGINS_DIR.*$,SET(GRN_PLUGINS_DIR $lib/\$\{GRN_RELATIVE_PLUGINS_DIR}),g" storage/mroonga/vendor/groonga/CMakeLists.txt
-    sed -i 's,[^"]*/var/log,/var/log,g' storage/mroonga/vendor/groonga/CMakeLists.txt
+    # We need to override these SET calls because they hardcode paths within DEFAULT_MYSQL_HOME
+    sed -i "s,SET(DEFAULT_MYSQL_HOME.*$,SET(DEFAULT_MYSQL_HOME \"$data\"),g" CMakeLists.txt
+    sed -i "s,SET(SHAREDIR.*$,SET(SHAREDIR \"\''${INSTALL_MYSQLSHAREDIR}\"),g" CMakeLists.txt
+    sed -i "s,SET(PLUGINDIR.*$,SET(PLUGINDIR \"\''${INSTALL_PLUGINDIR}\"),g" CMakeLists.txt
+
+    # Don't install data files, this breaks the build as it tries to install in /data
+    sed -i '/INSTALL.*DESTINATION data/d' sql/CMakeLists.txt
+
+    # Install all of the etc files to $doc/etc instead of /etc
+    sed -e "s,\''${INSTALL_SYSCONF,$doc/\0,g" \
+      -i support-files/CMakeLists.txt \
+      -i storage/tokudb/CMakeLists.txt
+  '';
+
+  preInstall = ''
+    # Create output directories that mariadb doesn't
+    mkdir -p $bin/{bin,sbin}
   '';
 
   postInstall = ''
-    substituteInPlace $out/bin/mysql_install_db \
-      --replace basedir=\"\" basedir=\"$out\"
+    substituteInPlace $bin/bin/mysql_install_db \
+      --replace basedir=\"\" basedir=\"$bin\"
 
     # Remove superfluous files
-    rm -r $out/mysql-test $out/sql-bench $out/data # Don't need testing data
-    rm $out/share/man/man1/mysql-test-run.pl.1
-    rm $out/bin/rcmysql # Not needed with nixos units
-    rm $out/bin/mysqlbug # Encodes a path to gcc and not really useful
-    find $out/bin -name \*test\* -exec rm {} \;
+    rm $bin/sbin/rcmysql # Not needed with nixos units
+    rm $bin/bin/mysqlbug # Encodes a path to gcc and not really useful
+    rm -r $doc/etc/{logrotate,init}.d
 
-    # Separate libs and includes into their own derivation
-    mkdir -p $lib
-    mv $out/lib $lib
-    mv $out/include $lib
+    # Move some helper scripts into bin
+    mv $data/share/mysql/mysql{-log-rotate,.server} $bin/bin
+    rm $data/share/mysql/{binary-configure,mysqld_multi.server}
 
-    # Fix the mysql_config
-    sed -i $out/bin/mysql_config \
-      -e 's,-lz,-L${zlib}/lib -lz,g' \
-      -e 's,-lssl,-L${openssl}/lib -lssl,g'
+    # Add mysql_config to dev since configure scripts use it
+    mkdir -p $dev/bin
+    mv $bin/bin/mysql_config $dev/bin
+    sed -i "/\(execdir\|bindir\)/ s,'[^\"']*',$dev/bin,g" $dev/bin/mysql_config
 
-    # Add mysql_config to libs since configure scripts use it
-    mkdir -p $lib/bin
-    cp $out/bin/mysql_config $lib/bin
-    sed -i "/\(execdir\|bindir\)/ s,'[^\"']*',$lib/bin,g" $lib/bin/mysql_config
+    # Make dev propagate libs so that linking works
+    mkdir -p $dev/nix-support
+    echo "$lib" >> $dev/nix-support/propagated-native-build-inputs
 
-    # Make sure to propagate lib for compatability
+    # We expect to be storing nothing in out
+    # rmdir should therefore succeed
+    if ! rmdir $out; then
+      echo "$out unexpected contained files"
+      exit 1
+    fi
+
+    # Out needs to propagate the expected installed files
     mkdir -p $out/nix-support
-    echo "$lib" > $out/nix-support/propagated-native-build-inputs
+    echo "$bin" >> $out/nix-support/propagated-native-build-inputs
+    echo "$man" >> $out/nix-support/propagated-native-build-inputs
+  '';
+
+  preFixup = ''
+    # Fix the mysql_config link time library options
+    sed \
+      -e 's,-lz,-L${zlib}/lib -lz,g' \
+      -e 's,-lssl,-L${openssl}/lib -lssl,g' \
+      -i $dev/bin/mysql_config
+  '';
+
+  postFixup = ''
+    # Make sure there are no extraneous references
+    check_references () {
+      if grep -qr "$1" "$2"; then
+        echo "Extraneous $1 in $2" >&2
+        exit 1
+      fi
+    }
+
+    check_references "$dev" "$out"
+    check_references "$doc" "$out"
+
+    check_references "$out" "$bin"
+    check_references "$dev" "$bin"
+    check_references "$man" "$bin"
+    check_references "$doc" "$bin"
+
+    check_references "$out" "$dev"
+    check_references "$bin" "$dev"
+    check_references "$man" "$dev"
+    check_references "$doc" "$dev"
+
+    check_references "$out" "$lib"
+    check_references "$bin" "$lib"
+    check_references "$dev" "$lib"
+    check_references "$man" "$lib"
+    check_references "$doc" "$lib"
+
+    check_references "$out" "$data"
+    check_references "$bin" "$data"
+    check_references "$dev" "$data"
+    check_references "$lib" "$data"
+    check_references "$man" "$data"
+    check_references "$doc" "$data"
+
+    check_references "$out" "$man"
+    check_references "$bin" "$man"
+    check_references "$dev" "$man"
+    check_references "$lib" "$man"
+    check_references "$data" "$man"
+    check_references "$doc" "$man"
+
+    check_references "$out" "$doc"
+    check_references "$dev" "$doc"
+    check_references "$man" "$doc"
   '';
 
   passthru.mysqlVersion = "5.6";

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -6,11 +6,11 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "mariadb-${version}";
-  version = "10.0.19";
+  version = "10.0.20";
 
   src = fetchurl {
     url    = "https://downloads.mariadb.org/interstitial/mariadb-${version}/source/mariadb-${version}.tar.gz";
-    sha256 = "0cm1j4805ypbmrhajn4ar5rqsis1p5haxs7c04b6k540gmfmxgrg";
+    sha256 = "0ywb730l68mxvmpik1x2ndbdaaks6dmc17pxspspm5wlqxinjkrs";
   };
 
   nativeBuildInputs = [ pkgconfig bison cmake ]

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, gettext, gdbm, libtool, pam, readline
-, ncurses, gnutls, mysql, guile, texinfo, gnum4, dejagnu, sendmailPath ? "/var/setuid-wrappers/sendmail" }:
+, ncurses, gnutls, libmysql, guile, texinfo, gnum4, dejagnu, sendmailPath ? "/var/setuid-wrappers/sendmail" }:
 
 /* TODO: Add GNU SASL, GNU GSSAPI, and FreeBidi.  */
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
    [ gettext gdbm libtool pam readline ncurses
-     gnutls mysql.lib guile texinfo gnum4 ]
+     gnutls libmysql guile texinfo gnum4 ]
    ++ stdenv.lib.optional doCheck dejagnu;
 
   # Tests fail since gcc 4.8

--- a/pkgs/tools/package-management/disnix/dysnomia/default.nix
+++ b/pkgs/tools/package-management/disnix/dysnomia/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, ejabberd ? null, mysql ? null, postgresql ? null, subversion ? null, mongodb ? null
+, ejabberd ? null, libmysql ? null, postgresql ? null, subversion ? null, mongodb ? null
 , enableApacheWebApplication ? false
 , enableAxis2WebService ? false
 , enableEjabberdDump ? false
@@ -13,7 +13,7 @@
 , getopt
 }:
 
-assert enableMySQLDatabase -> mysql != null;
+assert enableMySQLDatabase -> libmysql != null;
 assert enablePostgreSQLDatabase -> postgresql != null;
 assert enableSubversionRepository -> subversion != null;
 assert enableEjabberdDump -> ejabberd != null;
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
   
   buildInputs = [ getopt ]
     ++ stdenv.lib.optional enableEjabberdDump ejabberd
-    ++ stdenv.lib.optional enableMySQLDatabase mysql.out
+    ++ stdenv.lib.optional enableMySQLDatabase libmysql
     ++ stdenv.lib.optional enablePostgreSQLDatabase postgresql
     ++ stdenv.lib.optional enableSubversionRepository subversion
     ++ stdenv.lib.optional enableMongoDatabase mongodb;

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -16,7 +16,7 @@
 , libxml2 ? null
 , lm_sensors ? null
 , lvm2 ? null
-, mysql ? null
+, libmysql ? null
 , postgresql ? null
 , protobufc ? null
 , rabbitmq-c ? null
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     pkgconfig curl iptables libcredis libdbi libgcrypt libmemcached cyrus_sasl
     libmodbus libnotify gdk_pixbuf liboping libpcap libsigrok libvirt
-    lm_sensors libxml2 lvm2 mysql.lib postgresql protobufc rabbitmq-c rrdtool
+    lm_sensors libxml2 lvm2 libmysql postgresql protobufc rabbitmq-c rrdtool
     varnish yajl
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1711,6 +1711,9 @@ let
     inherit (kf5_stable) extra-cmake-modules kconfig ki18n kcoreaddons solid;
   };
 
+  groonga = callPackage ../servers/search/groonga { };
+  libgroonga = groonga.dev;
+
   grub = callPackage_i686 ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
     automake = automake112x; # fails with 13 and 14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1714,6 +1714,8 @@ let
   groonga = callPackage ../servers/search/groonga { };
   libgroonga = groonga.dev;
 
+  groonga-normalizer-mysql = callPackage ../development/libraries/groonga-normalizer-mysql { };
+
   grub = callPackage_i686 ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
     automake = automake112x; # fails with 13 and 14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9041,7 +9041,7 @@ let
   mysql55 = callPackage ../servers/sql/mysql/5.5.x.nix { };
 
   mysql = mariadb;
-  libmysql = mysql.lib;
+  libmysql = mysql.dev;
 
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7716,7 +7716,7 @@ let
 
     buildInputs = with self; [ nose pkgs.openssl ];
 
-    propagatedBuildInputs = with self; [ pkgs.mysql.lib pkgs.zlib ];
+    propagatedBuildInputs = with self; [ pkgs.libmysql pkgs.zlib ];
 
     meta = {
       description = "MySQL database binding for Python";


### PR DESCRIPTION
This should also fix issues where mariadb is missing references to the data directory which was set to /not/a/real/path before. It also splits out the build time dependency on groonga into a separate package instead of building the bundled version.
