### PR TITLE
qtpass: init at 0.8.4

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, git, gnupg, makeWrapper, pass, qt5 }:
+
+stdenv.mkDerivation rec {
+  name = "qtpass-${version}";
+  version = "0.8.4";
+
+  src = fetchurl {
+    url = "https://github.com/IJHack/qtpass/archive/v${version}.tar.gz";
+    sha256 = "14avh04q559p64ska1w814pbwv0742aaqln036pw99fjxav685g0";
+  };
+
+  buildInputs = [ git gnupg makeWrapper pass qt5.base ];
+
+  configurePhase = "qmake CONFIG+=release PREFIX=$out DESTDIR=$out";
+
+  installPhase = ''
+    mkdir $out/bin
+    mv $out/qtpass $out/bin
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/qtpass \
+        --suffix PATH : ${git}/bin \
+        --suffix PATH : ${gnupg}/bin \
+        --suffix PATH : ${pass}/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A multi-platform GUI for pass, the standard unix password manager";
+    homepage = https://github.com/IJHack/qtpass;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.hrdinka ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12266,6 +12266,8 @@ let
 
   qtox = callPackage ../applications/networking/instant-messengers/qtox { };
 
+  qtpass = callPackage ../applications/misc/qtpass { };
+
   qtpfsgui = callPackage ../applications/graphics/qtpfsgui { };
 
   qtractor = callPackage ../applications/audio/qtractor { };


### PR DESCRIPTION
This patch adds a package for qtpass a multi-platform GUI for pass (cli password manager). I am using it for a few days right now and everything is working correctly.
