### PR TITLE
vigra: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -1,28 +1,31 @@
-{ stdenv, fetchurl, cmake, libtiff, libpng, libjpeg, doxygen, python,
-  fftw, fftwSinglePrec, hdf5, boost, numpy }:
+{ stdenv, fetchurl, boost, cmake, doxygen, fftw, fftwSinglePrec, hdf5, ilmbase
+, libjpeg, libpng, libtiff, numpy, openexr, python }:
+
 stdenv.mkDerivation rec {
-  name = "vigra-1.9.0";
+  name = "vigra-${version}";
+  version = "1.10.0";
 
   src = fetchurl {
-    urls = [
-      "${meta.homepage}/${name}-src.tar.gz"
-      "${meta.homepage}-old-versions/${name}-src.tar.gz"
-      ];
-    sha256 = "00fg64da6dj9k42d90dz6y7x91xw1xqppcla14im74m4afswrgcg";
+    url = "https://github.com/ukoethe/vigra/archive/Version-${stdenv.lib.replaceChars ["."] ["-"] version}.tar.gz";
+    sha256 = "1y3yii8wnyz68n0mzcmjylwd6jchqa3l913v39l2zsd2rv5nyvs0";
   };
 
-  buildInputs = [ cmake fftw fftwSinglePrec libtiff libpng libjpeg python boost
-    numpy hdf5 ];
+  NIX_CFLAGS_COMPILE = "-I${ilmbase}/include/OpenEXR";
+
+  buildInputs = [ boost cmake fftw fftwSinglePrec hdf5 ilmbase libjpeg libpng
+                  libtiff numpy openexr python ];
 
   preConfigure = "cmakeFlags+=\" -DVIGRANUMPY_INSTALL_DIR=$out/lib/${python.libPrefix}/site-packages\"";
-  cmakeFlags = stdenv.lib.optionals (stdenv.system == "x86_64-linux")
-      [ "-DCMAKE_CXX_FLAGS=-fPIC" "-DCMAKE_C_FLAGS=-fPIC" ];
 
-  meta = {
+  cmakeFlags = [ "-DWITH_OPENEXR=1" ]
+            ++ stdenv.lib.optionals (stdenv.system == "x86_64-linux")
+                  [ "-DCMAKE_CXX_FLAGS=-fPIC" "-DCMAKE_C_FLAGS=-fPIC" ];
+
+  meta = with stdenv.lib; {
     description = "Novel computer vision C++ library with customizable algorithms and data structures";
     homepage = http://hci.iwr.uni-heidelberg.de/vigra;
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.mit;
+    maintainers = [ maintainers.viric ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This patch updates vigra to version 0.10.0. Further it adds support for openexr enabling HDR processing. Currently hugin fails producing HDR images because it is using vigra for this. This patch will fix this as well.

@viric 
