### PR TITLE
E prover: do not build the manual

### DIFF
--- a/pkgs/applications/science/logic/eprover/default.nix
+++ b/pkgs/applications/science/logic/eprover/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, which, texLive }:
+{ stdenv, fetchurl, which }:
 let
   s = # Generated upstream information
   rec {
@@ -18,26 +18,22 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
   };
 
-  buildInputs = [which texLive];
+  buildInputs = [ which ];
 
   preConfigure = "sed -e 's@^EXECPATH\\s.*@EXECPATH = '\$out'/bin@' -i Makefile.vars";
 
   buildPhase = "make install";
 
-  # HOME=. allows to build missing TeX formats
   installPhase = ''
     mkdir -p $out/bin
     make install
-    HOME=. make documentation
-    mkdir -p $out/share/doc
-    cp -r DOC $out/share/doc/EProver
     echo eproof -xAuto --tstp-in --tstp-out '"$@"' > $out/bin/eproof-tptp
     chmod a+x $out/bin/eproof-tptp
   '';
 
   meta = {
     inherit (s) version;
-    description = "E automated theorem prover";
+    description = "Automated theorem prover for full first-order logic with equality";
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14159,13 +14159,7 @@ let
 
   ekrhyper = callPackage ../applications/science/logic/ekrhyper {};
 
-  eprover = callPackage ../applications/science/logic/eprover {
-    texLive = texLiveAggregationFun {
-      paths = [
-        texLive texLiveExtra
-      ];
-    };
-  };
+  eprover = callPackage ../applications/science/logic/eprover { };
 
   gappa = callPackage ../applications/science/logic/gappa { };
 


### PR DESCRIPTION
Rationale: closure size is 4201.25 MiB (see http://hydra.nixos.org/build/23289679#tabs-details), which is way too much (it seems that the manual depends on texlive-extra). And the manual is available online: http://www4.in.tum.de/~schulz/WORK/E_DOWNLOAD/V_1.8/eprover.pdf

cc @7c6f434c maintainer.
