### PR TITLE
cassandra: add procps depencency

### DIFF
--- a/pkgs/servers/nosql/cassandra/2.0.nix
+++ b/pkgs/servers/nosql/cassandra/2.0.nix
@@ -6,6 +6,7 @@
 , gawk
 , bash
 , getopt
+, procps
 }:
 
 let
@@ -34,7 +35,8 @@ stdenv.mkDerivation rec {
         --set JAVA_HOME ${jre} \
         --prefix PATH : ${bash}/bin \
         --prefix PATH : ${getopt}/bin \
-        --prefix PATH : ${gawk}/bin
+        --prefix PATH : ${gawk}/bin \
+        --prefix PATH : ${procps}/bin
     done
 
     wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin

--- a/pkgs/servers/nosql/cassandra/2.1.nix
+++ b/pkgs/servers/nosql/cassandra/2.1.nix
@@ -6,6 +6,7 @@
 , gawk
 , bash
 , getopt
+, procps
 }:
 
 let
@@ -34,7 +35,8 @@ stdenv.mkDerivation rec {
         --set JAVA_HOME ${jre} \
         --prefix PATH : ${bash}/bin \
         --prefix PATH : ${getopt}/bin \
-        --prefix PATH : ${gawk}/bin
+        --prefix PATH : ${gawk}/bin \
+        --prefix PATH : ${procps}/bin
     done
 
     wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin


### PR DESCRIPTION
${cassandra}/conf/cassandra-env.sh calls free program on Linux systems in calculate_heap_sizes().

Adding procps to the path makes the free program available.
