### PR TITLE
stow: patch that removes warning for 2.2.0

### DIFF
--- a/pkgs/tools/misc/stow/default.nix
+++ b/pkgs/tools/misc/stow/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ perl perlPackages.TestOutput ];
 
+  patches = [ ./precedence-issue.patch ];
+
   doCheck = true;
 
   meta = {

--- a/pkgs/tools/misc/stow/precedence-issue.patch
+++ b/pkgs/tools/misc/stow/precedence-issue.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/Stow.pm.in b/lib/Stow.pm.in
+index 101a422..f80b1ac 100755
+--- a/lib/Stow.pm.in
++++ b/lib/Stow.pm.in
+@@ -1732,8 +1732,8 @@ sub read_a_link {
+     }
+     elsif (-l $path) {
+         debug(4, "  read_a_link($path): real link");
+-        return readlink $path
+-            or error("Could not read link: $path");
++        my $target = readlink $path or error("Could not read link: $path ($!)");
++        return $target;
+     }
+     internal_error("read_a_link() passed a non link path: $path\n");
+ }


### PR DESCRIPTION
This removes an annoying warning that is only going to be patched with the next release, which could be quite a while. See http://git.savannah.gnu.org/cgit/stow.git/commit/?id=d788ce0c1c59b3158270143659f7a4363da73056
