### PR TITLE
stumpwm: use full-path of xdpyinfo

### DIFF
--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     cp -r --no-preserve=mode ${contrib} modules
+    substituteInPlace  head.lisp \
+      --replace 'run-shell-command "xdpyinfo' 'run-shell-command "${xdpyinfo}/bin/xdpyinfo'
   '';
 
   installPhase = ''


### PR DESCRIPTION
cc @hiberno @the-kenny 
