### PR TITLE
emacs: Emacs now can access all NixOS info files

### DIFF
--- a/pkgs/applications/editors/emacs-24/site-start.el
+++ b/pkgs/applications/editors/emacs-24/site-start.el
@@ -11,6 +11,23 @@
                                   (split-string (or (getenv "NIX_PROFILES") ""))))
                  woman-manpath)))
 
+;;; Generate a global 'dir' file out of the paths in INFOPATH. This is
+;;; equivalent to what is done in
+;;; <nixpkgs>/nixos/modules/programs/info.nix.
+(eval-after-load 'info
+  '(progn
+     ;; Emacs relies on the INFOPATH ending in `path-separator' to add
+     ;; `Info-default-directory-list' to the list of info paths.
+     (unless (string-match ":$" (getenv "INFOPATH"))
+       (setenv "INFOPATH" (concat (getenv "INFOPATH") ":")))
+     (info-initialize)
+     (let* ((tmp-directory (make-temp-file "emacs-info-dir" t))
+            (dir-file (expand-file-name "dir" tmp-directory)))
+       (dolist (path Info-directory-list)
+         (dolist (info-file (directory-files path t "\.info$" t))
+           (call-process "install-info" nil nil nil info-file dir-file)))
+       (add-to-list 'Info-directory-list tmp-directory))))
+
 ;; Make tramp work for remote NixOS machines
 ;;; NOTE: You might want to add 
 (eval-after-load 'tramp


### PR DESCRIPTION
On NixOS, there is no global `dir` file referencing all `.info` files of the system. NixOS patches the `info` command to make it work (see `<nixpkgs>/nixos/modules/programs/info.nix`): it does so by generating a global `dir` file when `info` is launched.

This patch applies the same trick for the Emacs `info` command.

The problem with this patch is that it affects non-nixos nix installations too. I think this shouldn't be a problem, but someone may want to check (I only checked on nixos).

cc @chaoflow @lovek323 @peti @the-kenny
