### PR TITLE
postfix: fix recipient_delimiter option

### DIFF
--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -88,6 +88,7 @@ in
 
     services.postfix = {
       enable = true;
+      recipientDelimiter= "+";
       extraMasterConf = ''
         mlmmj unix - n n - - pipe flags=ORhu user=mlmmj argv=${pkgs.mlmmj}/bin/mlmmj-receive -F -L ${spoolDir}/$nextHop
       '';

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -77,6 +77,8 @@ let
       smtpd_tls_key_file = ${cfg.sslKey}
 
       smtpd_use_tls = yes
+
+      recipient_delimiter = ${cfg.recipientDelimiter}
     ''
     + optionalString (cfg.virtual != "") ''
       virtual_alias_maps = hash:/etc/postfix/virtual
@@ -287,6 +289,14 @@ in
       sslKey = mkOption {
         default = "";
         description = "SSL key to use.";
+      };
+
+      recipientDelimiter = mkOption {
+        default = "";
+        example = "+";
+        description = "
+          Delimiter for address extension: so mail to user+test can be handled by ~user/.forward+test
+        ";
       };
 
       virtual = mkOption {


### PR DESCRIPTION
This reverts commit 88f4b75a00855c878624e465e1a83930aaa92858 and fixes the
recipientDelimiter config option. Till then the camel case variant was used
while recipient_delimiter would have been right.

Due the revert this will also re-add the recipientDelimiter option within mlmmj.nix.
