### PR TITLE
abcde: update to 2.7 and fix mp3 tagging

### DIFF
--- a/pkgs/applications/audio/abcde/default.nix
+++ b/pkgs/applications/audio/abcde/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchurl, libcdio, cddiscid, wget, bash, vorbisTools, id3v2, lame, flac, eject, mkcue
+{ stdenv, fetchurl, libcdio, cddiscid, wget, bash, vorbisTools, id3v2, eyeD3
+, lame, flac, eject, mkcue
 , perl, DigestSHA, MusicBrainz, MusicBrainzDiscID
 , makeWrapper }:
 
-let version = "2.6";
+let version = "2.7";
 in
   stdenv.mkDerivation {
     name = "abcde-${version}";
     src = fetchurl {
-      url = "mirror://debian/pool/main/a/abcde/abcde_${version}.orig.tar.gz";
-      sha256 = "0y2cg233n2hixs0ji76dggpzgf52v4c4mnpwiai889ql2piafgk8";
+      url = "http://abcde.einval.com/download/abcde-${version}.tar.gz";
+      sha256 = "0ikpffzvacadh6vj9qlary8126j1zrd2knp9gvivmp7y1656jj01";
     };
 
-    # FIXME: This package does not support MP3 encoding (only Ogg),
-    # nor `distmp3', `eject', etc.
+    # FIXME: This package does not support `distmp3', `eject', etc.
 
     patches = [ ./abcde.patch ];
 
@@ -50,7 +50,7 @@ in
          --replace '#!/usr/bin/perl' '#!${perl}/bin/perl'
 
       wrapProgram "$out/bin/abcde" --prefix PATH ":" \
-        "$out/bin:${libcdio}/bin:${cddiscid}/bin:${wget}/bin:${vorbisTools}/bin:${id3v2}/bin:${lame}/bin"
+        "$out/bin:${libcdio}/bin:${cddiscid}/bin:${wget}/bin:${vorbisTools}/bin:${id3v2}/bin:${eyeD3}/bin:${lame}/bin"
 
       wrapProgram "$out/bin/cddb-tool" --prefix PATH ":" \
         "${wget}/bin"
@@ -60,7 +60,7 @@ in
     '';
 
     meta = {
-      homepage = "http://lly.org/~rcw/abcde/page/";
+      homepage = http://abcde.einval.com/wiki/;
       license = stdenv.lib.licenses.gpl2Plus;
       description = "Command-line audio CD ripper";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10407,6 +10407,7 @@ let
 
   abcde = callPackage ../applications/audio/abcde {
     inherit (perlPackages) DigestSHA MusicBrainz MusicBrainzDiscID;
+    inherit (pythonPackages) eyeD3;
     libcdio = libcdio082;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3006,20 +3006,21 @@ let
 
 
   eyeD3 = buildPythonPackage rec {
-    version = "0.7.4";
+    version = "0.7.8";
     name    = "eyeD3-${version}";
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "http://eyed3.nicfit.net/releases/${name}.tgz";
-      sha256 = "001hzgqqnf2ig432mq78jsxidpky2rl2ilm28xwjp32vzphycf51";
+      url = "http://eyed3.nicfit.net/releases/${name}.tar.gz";
+      sha256 = "1nv7nhfn1d0qm7rgkzksbccgqisng8klf97np0nwaqwd5dbmdf86";
     };
 
     buildInputs = with self; [ paver ];
 
     postInstall = ''
       for prog in "$out/bin/"*; do
-        wrapProgram "$prog" --prefix PYTHONPATH : "$PYTHONPATH"
+        wrapProgram "$prog" --prefix PYTHONPATH : "$PYTHONPATH" \
+                            --prefix PATH : ${python}/bin
       done
     '';
 


### PR DESCRIPTION
First time that I touch python: I modified directly python-packages.nix. Guess that's ok.
