### PR TITLE
xfig: Fix build failure on staging now visible due to #7524

### DIFF
--- a/pkgs/applications/graphics/xfig/builder.sh
+++ b/pkgs/applications/graphics/xfig/builder.sh
@@ -5,8 +5,7 @@ makeFlags="XAWLIB=-lXaw3d BINDIR=$out/bin XAPPLOADDIR=$out/etc/X11/app-defaults 
 # We need chmod +wx on dirs, not just chmod +w
 dontMakeSourcesWritable=1
 postUnpack() {
-	find . -type d | xargs -n1 chmod +x
-	find . -type d | xargs -n1 chmod +x
+    find . -type d -exec chmod +x '{}' \;
 }
 
 preBuild() {


### PR DESCRIPTION
The first 'find' command in postUnpack that attempts to add +x
permissions fails, because the +x permission is needed by the find
itself, and with the xargs method it's added too late.
