### PR TITLE
crackxls: Fix build on staging

### DIFF
--- a/pkgs/tools/security/crackxls/default.nix
+++ b/pkgs/tools/security/crackxls/default.nix
@@ -13,9 +13,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig autoconf automake openssl libgsf gmp ];
 
+  patchPhase =
+  ''
+    substituteInPlace Makefile.in --replace '-march=native' ""
+    substituteInPlace Makefile.in --replace '-mtune=native' ""
+  '';
+
   installPhase =
   ''
-    mkdir $out/bin
+    mkdir -p $out/bin
     cp crackxls2003 $out/bin/
   '';
 


### PR DESCRIPTION
$out doesn't exist by default, so need to use 'mkdir -p'. More #7524.

While at it, patch out some evil optimization flags.
