### PR TITLE
libxcomp: Fix build in staging

### DIFF
--- a/pkgs/development/libraries/libxcomp/default.nix
+++ b/pkgs/development/libraries/libxcomp/default.nix
@@ -25,11 +25,4 @@ stdenv.mkDerivation {
   '';
 
   enableParallelBuilding = true;
-
-  postInstall = ''
-    mkdir $out/lib
-    cp libXcomp.so* $out/lib
-    mkdir $out/include
-    cp NX.h $out/include
-  '';
 }


### PR DESCRIPTION
The mkdirs were failing since the 'out' and 'lib' directories are
already created by 'make install' (#7524 fallout). And in fact, the
entire postInstall script is doing the exact same thing as installPhase,
so it can be simply dropped.
