### PR TITLE
vultr: init at 0.1.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13568,6 +13568,31 @@ let
     };
   });
 
+  vultr = buildPythonPackage rec {
+    version = "0.1.2";
+    name = "vultr-${version}";
+
+    src = pkgs.fetchFromGitHub {
+        owner = "spry-group";
+        repo = "python-vultr";
+        rev = "${version}";
+        sha256 = "1qjvvr2v9gfnwskdl0ayazpcmiyw9zlgnijnhgq9mcri5gq9jw5h";
+    };
+
+    propagatedBuildInputs = with self; [ requests2 ];
+
+    # Tests disabled. They fail because they try to access the network
+    doCheck = false;
+
+    meta = {
+      description = "Vultr.com API Client";
+      homepage = "https://github.com/spry-group/python-vultr";
+      license = licenses.mit;
+      maintainers = with maintainers; [ lihop ];
+      platforms = platforms.all;
+    };
+  };
+
   waitress = buildPythonPackage rec {
     name = "waitress-0.8.9";
 


### PR DESCRIPTION
Python API for the vultr VPS provider. Vulltr is very similar to digital ocean in terms of pricing, plans, etc, but what sets them apart is that they allow you to upload custom ISOs, meaning that it's really easy to install NixOS, as [this guide](https://www.vultr.com/docs/install-nixos-on-vultr) from their website shows.

Package has been built and tested off of the nixos-unstable branch. Building on master requires pypy recompilation which takes forever and causes Travis to timeout.
