### PR TITLE
shellinabox: fix ssl/tls support

### DIFF
--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -1,29 +1,38 @@
-{ stdenv, fetchurl, pam, openssl, openssh, shadow }:
+{ stdenv, fetchurl, pam, openssl, openssh, shadow, makeWrapper }:
 
-stdenv.mkDerivation {
-  name = "shellinabox-2.14";
+stdenv.mkDerivation rec {
+  version = "2.14";
+  name = "shellinabox-${version}";
 
   src = fetchurl {
-    url = "https://shellinabox.googlecode.com/files/shellinabox-2.14.tar.gz";
+    url = "https://shellinabox.googlecode.com/files/shellinabox-${version}.tar.gz";
     sha1 = "9e01f58c68cb53211b83d0f02e676e0d50deb781";
   };
 
-  buildInputs = [pam openssl openssh];
+  buildInputs = [ pam openssl openssh makeWrapper ];
 
   patches = [ ./shellinabox-minus.patch ];
 
-  # Disable GSSAPIAuthentication errors as well as correct hardcoded path. Take /usr/games's place. 
+  # Disable GSSAPIAuthentication errors. Also, paths in certain source files are
+  # hardcoded. Replace the hardcoded paths with correct paths.
   preConfigure = ''
     substituteInPlace ./shellinabox/service.c --replace "-oGSSAPIAuthentication=no" ""
     substituteInPlace ./shellinabox/launcher.c --replace "/usr/games" "${openssh}/bin"
     substituteInPlace ./shellinabox/service.c --replace "/bin/login" "${shadow}/bin/login"
     substituteInPlace ./shellinabox/launcher.c --replace "/bin/login" "${shadow}/bin/login"
+    substituteInPlace ./libhttp/ssl.c --replace "/usr/bin" "${openssl}/bin"
     '';
-  meta = {
+
+  postInstall = ''
+    wrapProgram $out/bin/shellinaboxd \
+    --prefix LD_LIBRARY_PATH : ${openssl}/lib \
+  '';
+
+  meta = with stdenv.lib; {
     homepage = https://code.google.com/p/shellinabox;
     description = "Web based AJAX terminal emulator";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [stdenv.lib.maintainers.tomberek];
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tomberek lihop ];
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
`shellinboxd` was not finding `libssl.so` in it's library path, so it was falling back to ssl disabled mode. Also, the path to `openssl` was hardcoded to `/usr/bin/openssl`, so `shellinaboxd` could not generate SSL certificates once `libssl.so` was added to `LD_LIBRARY_PATH`. 

I also added myself as a maintainer as I'm interested in making a module for this package and want to it's health.

Cheers
