### PR TITLE
mbedtls: Fix build on staging

### DIFF
--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -22,13 +22,6 @@ stdenv.mkDerivation rec {
     "DESTDIR=\${out}"
   ];
 
-  postInstall = ''
-    rm $out/lib/lib{mbedtls.so.8,polarssl.{a,so}}
-    ln -s libmbedtls.so $out/lib/libmbedtls.so.8
-    ln -s libmbedtls.so $out/lib/libpolarssl.so
-    ln -s libmbedtls.a $out/lib/libpolarssl.a
-  '';
-
   doCheck = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
'rm libmbedtls.so.8' in postInstall is failing since the .so version is
now 9, which breaks the build due to #7524. Conveniently it looks like
the whole postInstall script can be dropped, as installPhase seems to be
already doing the right thing:

```
-r--r--r-- 1 root nixbld 792448 Jan  1  1970 libmbedtls.a
lrwxrwxrwx 1 root nixbld     15 Jan  1  1970 libmbedtls.so -> libmbedtls.so.9
-r-xr-xr-x 1 root nixbld 623571 Jan  1  1970 libmbedtls.so.9
lrwxrwxrwx 1 root nixbld     12 Jan  1  1970 libpolarssl.a -> libmbedtls.a
lrwxrwxrwx 1 root nixbld     13 Jan  1  1970 libpolarssl.so -> libmbedtls.so
```
