### PR TITLE
Fix libcxxStdenv on Linux

### DIFF
--- a/pkgs/development/compilers/llvm/3.5/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.5/libc++/setup-hook.sh
@@ -1,4 +1,2 @@
-export NIX_CFLAGS_COMPILE+=" -isystem @out@/include/c++/v1"
-
-export NIX_CXXSTDLIB_COMPILE=" -stdlib=libc++"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -lc++ -lc++abi"

--- a/pkgs/development/compilers/llvm/3.6/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.6/libc++/setup-hook.sh
@@ -1,4 +1,2 @@
-export NIX_CFLAGS_COMPILE+=" -isystem @out@/include/c++/v1"
-
-export NIX_CXXSTDLIB_COMPILE=" -stdlib=libc++"
-export NIX_CXXSTDLIB_LINK=" -stdlib=libc++"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -lc++ -lc++abi"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3531,7 +3531,7 @@ let
     libc = glibc;
     binutils = binutils;
     inherit coreutils zlib;
-    extraPackages = [ libcxx ];
+    extraPackages = [ libcxx libcxxabi ];
     nativeTools = false;
     nativeLibc = false;
   };


### PR DESCRIPTION
This corrects linkage failures arising from missing -lc++abi and resolves "unused argument" warnings arising due to -stdlib=libc++ serving no purpose when search paths are being supplied explicitly.

Tested libcxxStdenv locally, C++ libraries and programs build and run correctly.

cc @shlevy
