### PR TITLE
dtc: init at 1.4.1

### DIFF
--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, flex, bison }:
+
+stdenv.mkDerivation rec {
+  name = "dtc-${version}";
+  version = "1.4.1";
+
+  src = fetchgit {
+    url = "git://git.kernel.org/pub/scm/utils/dtc/dtc.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "0z7yrv0sdhsh5wwy7yd1fvs4pqaq0n9m5i8w65lyibg77ahkasdg";
+  };
+
+  buildInputs = [ flex bison ];
+
+  installFlags = [ "INSTALL=install" "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Device Tree Compiler";
+    homepage = https://git.kernel.org/cgit/utils/dtc/dtc.git;
+    license = licenses.gpl2; # dtc itself is GPLv2, libfdt is dual GPL/BSD
+    maintainers = [ maintainers.dezgeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1318,6 +1318,8 @@ let
 
   dtach = callPackage ../tools/misc/dtach { };
 
+  dtc = callPackage ../development/compilers/dtc { };
+
   dub = callPackage ../development/tools/build-managers/dub { };
 
   duff = callPackage ../tools/filesystems/duff { };


### PR DESCRIPTION
Compiling U-Boot for the Jetson TK1 board requires this.
