### PR TITLE
Xen fixes

### DIFF
--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -152,6 +152,9 @@ stdenv.mkDerivation {
         --replace /etc/xen/scripts/hotplugpath.sh $out/etc/xen/scripts/hotplugpath.sh \
         --replace /bin/ls ls
 
+      substituteInPlace tools/hotplug/Linux/xendomains \
+        --replace /bin/ls ls
+
       # Xen's tools and firmares need various git repositories that it
       # usually checks out at time using git.  We can't have that.
       ${flip concatMapStrings xenConfig.toolsGits (x: let src = fetchgit x; in ''

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,13 +15,15 @@ let
   buildInputs = [
     fuse bison flex_2_5_35 openssl python ncurses readline
     autoconf automake libtool pkgconfig zlib libaio libxml2
-    acl sqlite liburcu attr
+    sqlite liburcu attr
   ];
+  propagatedBuildInputs = [ acl ];
 in
 stdenv.mkDerivation
 rec {
   inherit (s) name version;
   inherit buildInputs;
+  inherit propagatedBuildInputs;
 
   preConfigure = ''
     ./autogen.sh


### PR DESCRIPTION
Here are fixes I needed to make in order to get Xen running.

To run an example Xen virtual machine, https://nixos.org/wiki/NixOS_and_Xen need to be slightly altered. The following guest configuration worked for me (you should replace the uuid with the uuid of your partition):

```
{ config, pkgs, modulesPath, ... }:

{
  require = [ <nixpkgs/nixos/modules/virtualisation/xen-domU.nix> ];

  fileSystems =
    [ { mountPoint = "/";
        device = "/dev/disk/by-uuid/b3f4a47f-2058-4546-b620-23bbf66a61cf";
      }
    ];
}
```

This is the configuration file that can be placed in `/etc/xen/auto`. The kernel image is a hardcoded nix path, since I haven't found another way of specifying it. This configuration assumes that your boot partition is the lvm partition at /dev/lvm_main/xen1.

```
memory = 512
kernel = '/nix/store/8zz6193wqm8b5i7f0c086cy48cwkc4a1-xen-4.5.0/lib/xen/boot/pv-grub-x86_64.gz'
name = "xen1"
extra = '(hd0)/boot/grub/menu.lst'
disk = [ 'phy:/dev/lvm_main/xen1,xvda1,w' ]
vif = [ '' ]
```

I'm neither a Xen nor a Nix expert, so please review the changes before applying them.
