### PR TITLE
postgresql94: enable uuid-ossp on Darwin

### DIFF
--- a/pkgs/servers/sql/postgresql/9.4.x.nix
+++ b/pkgs/servers/sql/postgresql/9.4.x.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "world" ];
 
   configureFlags = [ "--with-openssl" ]
+                   ++ optional (stdenv.isDarwin)  "--with-uuid=e2fs"
                    ++ optional (!stdenv.isDarwin) "--with-ossp-uuid";
 
   patches = [ ./disable-resolve_symlinks-94.patch ./less-is-more.patch ];


### PR DESCRIPTION
Enable uuid-ossp in Postgres 9.4 on Darwin, based on documentation section F.44.2 at
http://www.postgresql.org/docs/9.4/static/uuid-ossp.html

Tested build on Darwin (OS X 10.10.3).
