### PR TITLE
qt54: fix setup-hook.sh, lib/ was not populated in some cases

### DIFF
--- a/pkgs/development/libraries/qt-5/5.4/setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/5.4/setup-hook.sh
@@ -20,9 +20,11 @@ addQtModule() {
             fi
         fi
 
-        if [[ -n $qtSubmodule ]] && [[ -d "$1/lib" ]]; then
+        if [[ -d "$1/lib" ]]; then
             @lndir@/bin/lndir -silent "$1/lib" "$qtOut/lib"
-            find "$1/lib" -printf 'lib/%P\n' >> "$qtOut/nix-support/qt-inputs"
+            if [[ -n $qtSubmodule ]]; then
+                find "$1/lib" -printf 'lib/%P\n' >> "$qtOut/nix-support/qt-inputs"
+            fi
         fi
     fi
 }


### PR DESCRIPTION
While trying to fix #7897 I noticed that `qmake-calibre-2.28.0/lib` was empty, while the other directories were correctly populated. This patch fixes this problem. However I don't know much about the qt5 expression, so this change might break other things.

cc  @ttuegel @qknight 
