### PR TITLE
ulex: enable mac building

### DIFF
--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     homepage = http://www.cduce.org/download.html;
     description = "A lexer generator for Unicode and OCaml";
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = ocaml.meta.platforms;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
   };
 }


### PR DESCRIPTION
I've tested that ulex builds (and works) on OSX, and see no reason
it would not do so on other platforms, so I'm lifting the linux
restriction in platforms.
