### PR TITLE
wrapPythonPrograms: fix sys.argv[0] regression

### DIFF
--- a/pkgs/development/python-modules/generic/wrap.sh
+++ b/pkgs/development/python-modules/generic/wrap.sh
@@ -13,7 +13,7 @@ wrapPythonProgramsIn() {
     local pythonPath="$2"
     local python="@executable@"
     local path
-    local f
+    local i
 
     # Create an empty table of python paths (see doc on _addToPythonPath
     # for how this is used). Build up the program_PATH and program_PYTHONPATH
@@ -26,22 +26,22 @@ wrapPythonProgramsIn() {
     done
 
     # Find all regular files in the output directory that are executable.
-    for f in $(find "$dir" -type f -perm +0100); do
+    for i in $(find "$dir" -type f -perm +0100); do
         # Rewrite "#! .../env python" to "#! /nix/store/.../python".
-        if head -n1 "$f" | grep -q '#!.*/env.*\(python\|pypy\)'; then
-            sed -i "$f" -e "1 s^.*/env[ ]*\(python\|pypy\)^#! $python^"
+        if head -n1 "$i" | grep -q '#!.*/env.*\(python\|pypy\)'; then
+            sed -i "$i" -e "1 s^.*/env[ ]*\(python\|pypy\)^#! $python^"
         fi
 
         # catch /python and /.python-wrapped
-        if head -n1 "$f" | grep -q '/\.\?\(python\|pypy\)'; then
+        if head -n1 "$i" | grep -q '/\.\?\(python\|pypy\)'; then
             # dont wrap EGG-INFO scripts since they are called from python
-            if echo "$f" | grep -qv EGG-INFO/scripts; then
-                echo "wrapping \`$f'..."
-                sed -i "$f" -re '@magicalSedExpression@'
+            if echo "$i" | grep -qv EGG-INFO/scripts; then
+                echo "wrapping \`$i'..."
+                sed -i "$i" -re '@magicalSedExpression@'
                 # wrapProgram creates the executable shell script described
                 # above. The script will set PYTHONPATH and PATH variables.!
                 # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
-                local wrap_args="$f \
+                local wrap_args="$i \
                                  --prefix PYTHONPATH ':' $program_PYTHONPATH \
                                  --prefix PATH ':' $program_PATH"
 


### PR DESCRIPTION
Commit 5f557885313088a235762d3c ("adding docs to python wrap.sh") had the
unfortunate side-effect of changing sys.argv[0] in wrapped python programs.

Here is an example from the 'pytest' package, before commit 5f55788 (note
sys.argv[0] = 'py.test'):

  $ head $(head $(nix-build -A pythonPackages.pytest)/bin/py.test | tail -1 | awk '{print $2}')
  #!/nix/store/fzsbv209kna7bz6c89g9h1b2q3hmkaaz-python-2.7.9/bin/python2.7
  # EASY-INSTALL-ENTRY-SCRIPT: 'pytest==2.6.2','console_scripts','py.test'
  import sys; sys.argv[0] = 'py.test'

And after commit 5f55788 (note sys.argv[0] = 'pytest-2.6.2'):

  $ head $(head $(nix-build -A pythonPackages.pytest)/bin/py.test | tail -1 | awk '{print $2}')
  #!/nix/store/fzsbv209kna7bz6c89g9h1b2q3hmkaaz-python-2.7.9/bin/python2.7
  # EASY-INSTALL-ENTRY-SCRIPT: 'pytest==2.6.2','console_scripts','py.test'
  import sys; sys.argv[0] = 'pytest-2.6.2'

This change in turn broke the 'argh' module, because its tests expect
sys.argv[0] to be "py.test ...", and not "pytest-2.6.2 ..." (rightfully so).

Fix by renaming variable $f back to $i, because $i is used by
@magicalSedExpression@ to inject sys.argv[0].
