### PR TITLE
nodejs: Don't apply no-darwin-cflags

### DIFF
--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -47,9 +47,6 @@ in stdenv.mkDerivation {
 
   patches = if stdenv.isDarwin then [ ./no-xcode.patch ] else null;
 
-  postPatch = if stdenv.isDarwin then ''
-    (cd tools/gyp; patch -Np1 -i ${../../python-modules/gyp/no-darwin-cflags.patch})
-  '' else null;
 
   buildInputs = [ python which ]
     ++ (optional stdenv.isLinux utillinux)


### PR DESCRIPTION
The no-darwin-cflags patch does not apply cleanly anymore, but apparently it's also not necessary.

Fixes #8562
