### PR TITLE
fetchgit: import impure GIT_PROXY_COMMAND and SOCKS_SERVER

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
     # easy proxy configuration.  This is impure, but a fixed-output
     # derivation like fetchurl is allowed to do so since its result is
     # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
+    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy" "GIT_PROXY_COMMAND" "SOCKS_SERVER"
     ];
 
   preferLocalBuild = true;


### PR DESCRIPTION
(This was rebased against staging. Old PR: https://github.com/NixOS/nixpkgs/pull/5796)

These environment variables allow using fetchgit with git:// URLs using
the SOCKS proxy technique described in 'Using Git with a SOCKS proxy':

  http://www.patthoyts.tk/blog/using-git-with-socks-proxy.html

Briefly, GIT_PROXY_COMMAND is set to a script which invokes connect[1],
which reads SOCKS_PROXY, which might be pointing to a local instance of
'ssh -D'.

[1] pkgs/tools/networking/connect
