### PR TITLE
NixOS: Make it possible to disable running resolvconf in an activation script.

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -38,6 +38,15 @@ in
         /etc/resolv.conf. This option enables that.
       '';
     };
+    
+    networking.runResolvconfAtActivation = lib.mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to perform a resolvconf update as part of a profile activation script.
+        You may want to disable this if you use software that manages resolv.conf directly.
+      '';
+    };
 
     networking.proxy = {
 
@@ -198,8 +207,9 @@ in
           ln -s /run/systemd/resolve/resolv.conf /run/resolvconf/interfaces/systemd
         ''}
 
-        # Make sure resolv.conf is up to date if not managed by systemd
-        ${optionalString (!config.services.resolved.enable) ''
+        # Make sure resolv.conf is up to date, if this is needed.
+        # For example, systemd resolved will disable it.
+        ${optionalString config.networking.runResolvconfAtActivation ''
           ${pkgs.openresolv}/bin/resolvconf -u
         ''}
       '';

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -32,6 +32,8 @@ with lib;
 
     users.extraUsers.systemd-resolve.uid = config.ids.uids.systemd-resolve;
     users.extraGroups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
+    
+    networking.runResolvconfAtActivation = false;
 
   };
 


### PR DESCRIPTION
I use my own network configuration system which directly manages resolv.conf, and this activation scripts breaks my DNS configuration every time I run nixos-rebuild switch.
