### PR TITLE
Update location for htmlize source

### DIFF
--- a/pkgs/applications/editors/emacs-modes/htmlize/builder.sh
+++ b/pkgs/applications/editors/emacs-modes/htmlize/builder.sh
@@ -1,4 +1,0 @@
-source $stdenv/setup
-
-mkdir -p $out/share/emacs/site-lisp
-cp $src $out/share/emacs/site-lisp/htmlize.el

--- a/pkgs/applications/editors/emacs-modes/htmlize/default.nix
+++ b/pkgs/applications/editors/emacs-modes/htmlize/default.nix
@@ -1,14 +1,20 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   name = "htmlize-1.47";
 
-  builder = ./builder.sh;
-
-  src = fetchurl {
-    url = http://fly.srk.fer.hr/~hniksic/emacs/htmlize.el.cgi;
-    sha256 = "0m7lby95w9sj0xlqv39imlbp80x8ajd295cs6079jyhmryf6mr10";
+  src = fetchFromGitHub {
+    owner = "emacsmirror";
+    repo = "htmlize";
+    rev = "release/1.47";
+    name = "htmlize-1.47-src";
+    sha256 = "1vkqxgirc82vc44g7xhhr041arf93yirjin3h144kjyfkgkplnkp";
   };
+
+  installPhase = ''
+     mkdir -p $out/share/emacs/site-lisp
+     cp htmlize.el $out/share/emacs/site-lisp/
+  '';
 
   meta = {
     description = "Convert buffer text and decorations to HTML";

--- a/pkgs/applications/editors/emacs-modes/htmlize/default.nix
+++ b/pkgs/applications/editors/emacs-modes/htmlize/default.nix
@@ -3,12 +3,17 @@
 stdenv.mkDerivation {
   name = "htmlize-1.47";
 
-  builder = ./builder.sh;
-
   src = fetchurl {
-    url = http://fly.srk.fer.hr/~hniksic/emacs/htmlize.el.cgi;
+    url = https://raw.githubusercontent.com/emacsmirror/htmlize/master/htmlize.el;
     sha256 = "0m7lby95w9sj0xlqv39imlbp80x8ajd295cs6079jyhmryf6mr10";
   };
+
+  unpackPhase = ":;";
+    
+  installPhase = ''
+     mkdir -p $out/share/emacs/site-lisp
+     cp $src $out/share/emacs/site-lisp/htmlize.el
+  '';
 
   meta = {
     description = "Convert buffer text and decorations to HTML";

--- a/pkgs/applications/editors/emacs-modes/htmlize/default.nix
+++ b/pkgs/applications/editors/emacs-modes/htmlize/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
      mkdir -p $out/share/emacs/site-lisp
-     cp $src $out/share/emacs/site-lisp/htmlize.el
+     cp htmlize.el $out/share/emacs/site-lisp/
   '';
 
   meta = {

--- a/pkgs/applications/editors/emacs-modes/htmlize/default.nix
+++ b/pkgs/applications/editors/emacs-modes/htmlize/default.nix
@@ -4,12 +4,10 @@ stdenv.mkDerivation {
   name = "htmlize-1.47";
 
   src = fetchurl {
-    url = https://raw.githubusercontent.com/emacsmirror/htmlize/master/htmlize.el;
-    sha256 = "0m7lby95w9sj0xlqv39imlbp80x8ajd295cs6079jyhmryf6mr10";
+    url = https://github.com/emacsmirror/htmlize/archive/release/1.47.tar.gz;
+    sha256 = "1l5idp957z4zq6az06ljb48qkfnciihdi8k347p46mdfdbh5akv0";
   };
 
-  unpackPhase = ":;";
-    
   installPhase = ''
      mkdir -p $out/share/emacs/site-lisp
      cp $src $out/share/emacs/site-lisp/htmlize.el


### PR DESCRIPTION
The original documented web location for emacs htmlize (a student webpage at a university) is no longer alive.  This patch switches the htmlize source directly to github where that same original developer has it now.
