### PR TITLE
texLiveAuctex: init at 11.88

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/auctex.nix
+++ b/pkgs/tools/typesetting/tex/texlive/auctex.nix
@@ -1,0 +1,13 @@
+{ lib, auctex }:
+lib.overrideDerivation auctex (x: {
+  preConfigure = ''
+    mkdir -p $out/texmf-dist
+  '';
+  configureFlags = [
+    "--with-lispdir=\${out}/share/emacs/site-lisp"
+    "--with-texmf-dir=\${out}/texmf-dist"
+  ];
+  postInstall = ''
+    ln -s $out/share/info $out/
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15108,6 +15108,8 @@ let
     inherit texLive unzip;
   };
 
+  texLiveAuctex = callPackage ../tools/typesetting/tex/texlive/auctex.nix { };
+
   thermald = callPackage ../tools/system/thermald { };
 
   thinkfan = callPackage ../tools/system/thinkfan { };


### PR DESCRIPTION
This adds latex-preview for texLive, which is disabled in the default auctex derivation (and which texLiveAggregationFun expects to be found in $out/texmf-dist, which must exist before configuration).

Just tell, if this would be better declared in some other way.
