### PR TITLE
emacs: fix to use \${gettext}/share/locale/locale.alias

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ncurses, x11, libXaw, libXpm, Xaw3d
-, pkgconfig, gtk, libXft, dbus, libpng, libjpeg, libungif
+, pkgconfig, gettext, gtk, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
 , alsaLib, cairo, acl, gpm
 , withX ? !stdenv.isDarwin
@@ -35,8 +35,12 @@ stdenv.mkDerivation rec {
     ./at-fdcwd.patch
   ];
 
+  postPatch = ''
+    sed -i 's|/usr/share/locale|${gettext}/share/locale|g' lisp/international/mule-cmds.el
+  '';
+
   buildInputs =
-    [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo acl gpm ]
+    [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo acl gpm gettext ]
     ++ stdenv.lib.optional stdenv.isLinux dbus
     ++ stdenv.lib.optionals withX
       [ x11 libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft


### PR DESCRIPTION
Not sure if this is the right or best way.

The fixed issue is that lisp/international/mule-cmds.el contains hardcoded path to /usr/share/locale/locale.alias causing emacs to not build (at least) on darwin with chroot / sandbox enabled.
