### PR TITLE
vimPlugins: add vim-sleuth and CSApprox

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -887,6 +887,17 @@ rec {
 
   };
 
+  sleuth = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "sleuth-2015-06-07";
+    src = fetchgit {
+      url = "git://github.com/tpope/vim-sleuth";
+      rev = "a17462708aa40a7fc0afd4effa559087d8a2c908";
+      sha256 = "72f4b7c5e60c942592e624806960736e71b9f109fbbfa3a5a2a37970b90f6025";
+    };
+    dependencies = [];
+
+  };
+
   snipmate = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "snipmate-2015-04-04";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -82,6 +82,17 @@ rec {
   webapi-vim          = WebAPI;
   yankring            = YankRing;
 
+  CSApprox = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "CSApprox-2013-07-26";
+    src = fetchgit {
+      url = "git://github.com/godlygeek/csapprox";
+      rev = "7981dac51d8b6776985aa08cb7b5ee98ea7f2ddd";
+      sha256 = "8ccb47eb79c7ab63109d32158388812bdca340985527af4f2a5489ff8683389f";
+    };
+    dependencies = [];
+
+  };
+
   Gist = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "Gist-2015-06-24";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -1,3 +1,4 @@
+"CSApprox"
 "Gist"
 "Gundo"
 "Hoogle"

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -64,6 +64,7 @@
 "quickfixstatus"
 "rainbow_parentheses"
 "rust"
+"sleuth"
 "sensible"
 "snipmate"
 "sourcemap"


### PR DESCRIPTION
Adds two new vim plugins:
- [**vim-sleuth**](https://github.com/tpope/vim-sleuth): plugin which heuristically sets buffer options. 
- [**CSApprox**](https://github.com/godlygeek/csapprox): plugin which make gvim only color schemes work in the terminal.
