### PR TITLE
libev:  make the url stable

### DIFF
--- a/pkgs/development/libraries/libev/default.nix
+++ b/pkgs/development/libraries/libev/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libev-${version}";
   version="4.19";
   src = fetchurl {
-    url = "http://dist.schmorp.de/libev/${name}.tar.gz";
+    url = "http://dist.schmorp.de/libev/Attic/${name}.tar.gz";
     sha256 = "1jyw7qbl0spxqa0dccj9x1jsw7cj7szff43cq4acmklnra4mzz48";
   };
 


### PR DESCRIPTION
The libev upstream moves all but the last versions of the tarball into the `Attic` subdirectory.  Funnily enough, the latest version is present there as well.

This commit makes the URL stable, by descending (ascending?) into `Attic`.
