### PR TITLE
htmlize: update source location

### DIFF
--- a/pkgs/applications/editors/emacs-modes/htmlize/builder.sh
+++ b/pkgs/applications/editors/emacs-modes/htmlize/builder.sh
@@ -1,4 +1,0 @@
-source $stdenv/setup
-
-mkdir -p $out/share/emacs/site-lisp
-cp $src $out/share/emacs/site-lisp/htmlize.el

--- a/pkgs/applications/editors/emacs-modes/htmlize/default.nix
+++ b/pkgs/applications/editors/emacs-modes/htmlize/default.nix
@@ -1,14 +1,20 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   name = "htmlize-1.47";
 
-  builder = ./builder.sh;
-
-  src = fetchurl {
-    url = http://fly.srk.fer.hr/~hniksic/emacs/htmlize.el.cgi;
-    sha256 = "0m7lby95w9sj0xlqv39imlbp80x8ajd295cs6079jyhmryf6mr10";
+  src = fetchFromGitHub {
+    owner = "emacsmirror";
+    repo = "htmlize";
+    rev = "release/1.47";
+    name = "htmlize-1.47-src";
+    sha256 = "1vkqxgirc82vc44g7xhhr041arf93yirjin3h144kjyfkgkplnkp";
   };
+
+  installPhase = ''
+     mkdir -p $out/share/emacs/site-lisp
+     cp htmlize.el $out/share/emacs/site-lisp/
+  '';
 
   meta = {
     description = "Convert buffer text and decorations to HTML";


### PR DESCRIPTION
The original location of the htmlize source (which appears to be a student subdirectory of a university site) is no longer resolving.  This updates the package to retrieve htmlize from the github emacsmirror (which is where the author appears to be maintaining it).
