### PR TITLE
subsonic: init at 5.2.1

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -225,6 +225,7 @@
       uwsgi = 201;
       gitit = 202;
       riemanntools = 203;
+      subsonic = 204;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -428,6 +429,7 @@
       uwsgi = 201;
       gitit = 202;
       riemanntools = 203;
+      subsonic = 204;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -218,6 +218,7 @@
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
   ./services/misc/siproxd.nix
+  ./services/misc/subsonic.nix
   ./services/misc/svnserve.nix
   ./services/misc/synergy.nix
   ./services/misc/uhub.nix

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -1,0 +1,157 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.subsonic;
+  homeDir = "/var/subsonic";
+
+in
+{
+  options = {
+    services.subsonic = {
+      enable = mkEnableOption "Subsonic daemon";
+
+      home = mkOption {
+        type = types.path;
+        default = "${homeDir}";
+        description = ''
+          The directory where Subsonic will create files.
+          Make sure it is writable.
+        '';
+      };
+
+      host = mkOption {
+        type = types.string;
+        default = "0.0.0.0";
+        description = ''
+          The host name or IP address on which to bind Subsonic.
+          Only relevant if you have multiple network interfaces and want
+          to make Subsonic available on only one of them. The default value
+          will bind Subsonic to all available network interfaces.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 4040;
+        description = ''
+          The port on which Subsonic will listen for
+          incoming HTTP traffic. Set to 0 to disable.
+        '';
+      };
+
+      httpsPort = mkOption {
+        type = types.int;
+        default = 0;
+        description = ''
+          The port on which Subsonic will listen for
+          incoming HTTPS traffic. Set to 0 to disable.
+        '';
+      };
+
+      contextPath = mkOption {
+        type = types.path;
+        default = "/";
+        description = ''
+          The context path, i.e., the last part of the Subsonic
+          URL. Typically '/' or '/subsonic'. Default '/'
+        '';
+      };
+
+      maxMemory = mkOption {
+        type = types.int;
+        default = 100;
+        description = ''
+          The memory limit (max Java heap size) in megabytes.
+          Default: 100
+        '';
+      };
+
+      defaultMusicFolder = mkOption {
+        type = types.path;
+        default = "/var/music";
+        description = ''
+          Configure Subsonic to use this folder for music.  This option
+          only has effect the first time Subsonic is started.
+        '';
+      };
+
+      defaultPodcastFolder = mkOption {
+        type = types.path;
+        default = "/var/music/Podcast";
+        description = ''
+          Configure Subsonic to use this folder for Podcasts.  This option
+          only has effect the first time Subsonic is started.
+        '';
+      };
+
+      defaultPlaylistFolder = mkOption {
+        type = types.path;
+        default = "/var/playlists";
+        description = ''
+          Configure Subsonic to use this folder for playlists.  This option
+          only has effect the first time Subsonic is started.
+        '';
+      };
+
+      transcoders = mkOption {
+        type = types.listOf types.path;
+        default = [ "${pkgs.ffmpeg}/bin/ffmpeg" ];
+        description = ''
+          List of paths to transcoder executables that should be accessible
+          from Subsonic. Symlinks will be created to each executable inside
+          ${cfg.home}/transcoders.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.subsonic = {
+      description = "Personal media streamer";
+      after = [ "local-fs.target" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
+            -Dsubsonic.home=${cfg.home} \
+            -Dsubsonic.host=${cfg.host} \
+            -Dsubsonic.port=${toString cfg.port} \
+            -Dsubsonic.httpsPort=${toString cfg.httpsPort} \
+            -Dsubsonic.contextPath=${cfg.contextPath} \
+            -Dsubsonic.defaultMusicFolder=${cfg.defaultMusicFolder} \
+            -Dsubsonic.defaultPodcastFolder=${cfg.defaultPodcastFolder} \
+            -Dsubsonic.defaultPlaylistFolder=${cfg.defaultPlaylistFolder} \
+            -Djava.awt.headless=true \
+            -verbose:gc \
+            -jar ${pkgs.subsonic}/subsonic-booter-jar-with-dependencies.jar
+        '';
+        # Install transcoders.
+        ExecStartPre = ''
+          ${pkgs.coreutils}/bin/rm -rf ${cfg.home}/transcode ; \
+          ${pkgs.coreutils}/bin/mkdir -p ${cfg.home}/transcode ; \
+          ${pkgs.bash}/bin/bash -c ' \
+            for exe in "$@"; do \
+              ${pkgs.coreutils}/bin/ln -sf "$exe" ${cfg.home}/transcode; \
+            done' IGNORED_FIRST_ARG ${toString cfg.transcoders}
+        '';
+        # Needed for Subsonic to find subsonic.war.
+        WorkingDirectory = "${pkgs.subsonic}";
+        Restart = "always";
+        User = "subsonic";
+        UMask = "0022";
+      };
+    };
+
+    users.extraUsers.subsonic = {
+      description = "Subsonic daemon user";
+      home = homeDir;
+      createHome = true;
+      group = "subsonic";
+      uid = config.ids.uids.subsonic;
+    };
+
+    users.extraGroups.subsonic.gid = config.ids.gids.subsonic;
+  };
+}

--- a/pkgs/servers/misc/subsonic/default.nix
+++ b/pkgs/servers/misc/subsonic/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, jre }:
+
+let version = "5.2.1"; in
+
+stdenv.mkDerivation rec {
+  name = "subsonic-${version}";
+  inherit version;
+
+  src = fetchurl {
+    url = "mirror://sourceforge/subsonic/subsonic-${version}-standalone.tar.gz";
+    sha256 = "523fa8357c961c1ae742a15f0ceaabdd41fcba9137c29d244957922af90ee791";
+  };
+
+  inherit jre;
+
+  # Create temporary directory to extract tarball into to satisfy Nix's need
+  # for a directory to be created in the unpack phase.
+  unpackPhase = ''
+    mkdir ${name}
+    tar -C ${name} -xzf $src
+  '';
+  installPhase = ''
+    mkdir $out
+    cp -r ${name}/* $out
+  '';
+
+  meta = {
+    homepage = http://subsonic.org;
+    description = "Personal media streamer";
+    license = stdenv.lib.licenses.gpl3;
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3002,6 +3002,8 @@ let
 
   su = shadow.su;
 
+  subsonic = callPackage ../servers/misc/subsonic { };
+
   surfraw = callPackage ../tools/networking/surfraw { };
 
   swec = callPackage ../tools/networking/swec {


### PR DESCRIPTION
Add a package and NixOS service for the [Subsonic media streamer](http://subsonic.org), version 5.2.1, by downloading its tarball from the Sourceforge download link on the Subsonic site. The tarball includes a wrapper script to pass the right Java arguments to the server, but I've decided to run the server directly as a systemd service without the wrapper to remove the need to run it as a forking service and to more easily capture the server's logging output on standard error for the journal. I've tested this by installing and running it on my own system.
