### PR TITLE
nixos: fix formatting of option examples

### DIFF
--- a/nixos/modules/config/vpnc.nix
+++ b/nixos/modules/config/vpnc.nix
@@ -17,16 +17,16 @@ in
       services = mkOption {
        type = types.attrsOf types.str;
        default = {};
-       example = {
-         test = 
-          ''
-           IPSec gateway 192.168.1.1 
-           IPSec ID someID
-           IPSec secret secretKey
-           Xauth username name
-           Xauth password pass
-          '';
-       };
+       example = literalExample ''
+         { test = '''
+             IPSec gateway 192.168.1.1
+             IPSec ID someID
+             IPSec secret secretKey
+             Xauth username name
+             Xauth password pass
+           ''';
+         }
+       '';
        description = 
          ''
            The names of cisco VPNs and their associated definitions

--- a/nixos/modules/programs/freetds.nix
+++ b/nixos/modules/programs/freetds.nix
@@ -17,14 +17,14 @@ in
     environment.freetds = mkOption {
       type = types.attrsOf types.str;
       default = {};
-      example = {
-        MYDATABASE = 
-          ''
-          host = 10.0.2.100
-          port = 1433
-          tds version = 7.2
-          '';
-      };
+      example = literalExample ''
+        { MYDATABASE = '''
+            host = 10.0.2.100
+            port = 1433
+            tds version = 7.2
+          ''';
+        }
+      '';
       description = 
         ''
         Configure freetds database entries. Each attribute denotes

--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -35,14 +35,17 @@ in
     security.pki.certificates = mkOption {
       type = types.listOf types.str;
       default = [];
-      example = singleton ''
-        NixOS.org
-        =========
-        -----BEGIN CERTIFICATE-----
-        MIIGUDCCBTigAwIBAgIDD8KWMA0GCSqGSIb3DQEBBQUAMIGMMQswCQYDVQQGEwJJ
-        TDEWMBQGA1UEChMNU3RhcnRDb20gTHRkLjErMCkGA1UECxMiU2VjdXJlIERpZ2l0
-        ...
-        -----END CERTIFICATE-----
+      example = literalExample ''
+        [ '''
+            NixOS.org
+            =========
+            -----BEGIN CERTIFICATE-----
+            MIIGUDCCBTigAwIBAgIDD8KWMA0GCSqGSIb3DQEBBQUAMIGMMQswCQYDVQQGEwJJ
+            TDEWMBQGA1UEChMNU3RhcnRDb20gTHRkLjErMCkGA1UECxMiU2VjdXJlIERpZ2l0
+            ...
+            -----END CERTIFICATE-----
+          '''
+        ]
       '';
       description = ''
         A list of trusted root certificates in PEM format.

--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -621,34 +621,37 @@ in
       zones = mkOption {
         type        = types.attrsOf zoneOptions;
         default     = {};
-        example     = {
-          "serverGroup1" = {
-            provideXFR = [ "10.1.2.3 NOKEY" ];
-            children = {
-              "example.com." = {
-                data = ''
-                  $ORIGIN example.com.
-                  $TTL    86400
-                  @ IN SOA a.ns.example.com. admin.example.com. (
-                  ...
-                '';
-              };
-              "example.org." = {
-                data = ''
-                  $ORIGIN example.org.
-                  $TTL    86400
-                  @ IN SOA a.ns.example.com. admin.example.com. (
-                  ...
-                '';
+        example     = literalExample ''
+          { "serverGroup1" = {
+              provideXFR = [ "10.1.2.3 NOKEY" ];
+              children = {
+                "example.com." = {
+                  data = '''
+                    $ORIGIN example.com.
+                    $TTL    86400
+                    @ IN SOA a.ns.example.com. admin.example.com. (
+                    ...
+                  ''';
+                };
+                "example.org." = {
+                  data = '''
+                    $ORIGIN example.org.
+                    $TTL    86400
+                    @ IN SOA a.ns.example.com. admin.example.com. (
+                    ...
+                  ''';
+                };
               };
             };
-          };
 
-          "example.net." = {
-            provideXFR = [ "10.3.2.1 NOKEY" ];
-            data = ''...'';
-          };
-        };
+            "example.net." = {
+              provideXFR = [ "10.3.2.1 NOKEY" ];
+              data = '''
+                ...
+              ''';
+            };
+          }
+        '';
         description = ''
           Define your zones here. Zones can cascade other zones and therefore
           inherit settings from parent zones. Look at the definition of

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -50,20 +50,20 @@ in
 
       jails = mkOption {
         default = { };
-        example =
-          { "apache-nohome-iptables" =
-              ''
-                # Block an IP address if it accesses a non-existent
-                # home directory more than 5 times in 10 minutes,
-                # since that indicates that it's scanning.
-                filter   = apache-nohome
-                action   = iptables-multiport[name=HTTP, port="http,https"]
-                logpath  = /var/log/httpd/error_log*
-                findtime = 600
-                bantime  = 600
-                maxretry = 5
-              '';
-          };
+        example = literalExample ''
+          { apache-nohome-iptables = '''
+              # Block an IP address if it accesses a non-existent
+              # home directory more than 5 times in 10 minutes,
+              # since that indicates that it's scanning.
+              filter   = apache-nohome
+              action   = iptables-multiport[name=HTTP, port="http,https"]
+              logpath  = /var/log/httpd/error_log*
+              findtime = 600
+              bantime  = 600
+              maxretry = 5
+            ''';
+          }
+        '';
         type = types.attrsOf types.lines;
         description =
           ''

--- a/nixos/modules/services/web-servers/phpfpm.nix
+++ b/nixos/modules/services/web-servers/phpfpm.nix
@@ -52,18 +52,19 @@ in {
       poolConfigs = mkOption {
         type = types.attrsOf types.lines;
         default = {};
-        example = {
-          mypool = ''
-            listen = /run/phpfpm/mypool
-            user = nobody
-            pm = dynamic
-            pm.max_children = 75
-            pm.start_servers = 10
-            pm.min_spare_servers = 5
-            pm.max_spare_servers = 20
-            pm.max_requests = 500
-          '';
-        };
+        example = literalExample ''
+          { mypool = '''
+              listen = /run/phpfpm/mypool
+              user = nobody
+              pm = dynamic
+              pm.max_children = 75
+              pm.start_servers = 10
+              pm.min_spare_servers = 5
+              pm.max_spare_servers = 20
+              pm.max_requests = 500
+            ''';
+          }
+        '';
         description = ''
           A mapping between PHP FPM pool names and their configurations.
           See the documentation on <literal>php-fpm.conf</literal> for

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -156,13 +156,16 @@ in
       inputClassSections = mkOption {
         type = types.listOf types.lines;
         default = [];
-        example = [ ''
-           Identifier      "Trackpoint Wheel Emulation"
-           MatchProduct    "ThinkPad USB Keyboard with TrackPoint"
-           Option          "EmulateWheel"          "true
-           Option          "EmulateWheelButton"    "2"
-           Option          "Emulate3Buttons"       "false"
-          '' ];
+        example = literalExample ''
+          [ '''
+              Identifier      "Trackpoint Wheel Emulation"
+              MatchProduct    "ThinkPad USB Keyboard with TrackPoint"
+              Option          "EmulateWheel"          "true
+              Option          "EmulateWheelButton"    "2"
+              Option          "Emulate3Buttons"       "false"
+            '''
+          ]
+        '';
         description = "Content of additional InputClass sections of the X server configuration file.";
       };
 

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -30,18 +30,19 @@ in
     system.activationScripts = mkOption {
       default = {};
 
-      example = {
-        stdio = {
-          text = ''
-            # Needed by some programs.
-            ln -sfn /proc/self/fd /dev/fd
-            ln -sfn /proc/self/fd/0 /dev/stdin
-            ln -sfn /proc/self/fd/1 /dev/stdout
-            ln -sfn /proc/self/fd/2 /dev/stderr
-          '';
-          deps = [];
-        };
-      };
+      example = literalExample ''
+        { stdio = {
+            text = '''
+              # Needed by some programs.
+              ln -sfn /proc/self/fd /dev/fd
+              ln -sfn /proc/self/fd/0 /dev/stdin
+              ln -sfn /proc/self/fd/1 /dev/stdout
+              ln -sfn /proc/self/fd/2 /dev/stderr
+            ''';
+            deps = [];
+          };
+        }
+      '';
 
       description = ''
         A set of shell script fragments that are executed when a NixOS


### PR DESCRIPTION
A number of option examples in the Configuration Options section of the manual are badly formatted.
For instance, the [services.fail2ban.jails](https://nixos.org/nixos/manual/ch-options.html#opt-services.fail2ban.jails) option example looks like this (the image cuts off the full example):

![fail2ban-before](https://cloud.githubusercontent.com/assets/3696783/8507070/09ddefac-2287-11e5-918f-67f7f614a772.png)

I found eight other examples in the manual which are also badly formatted:
- [networking.vpnc.services](https://nixos.org/nixos/manual/ch-options.html#opt-networking.vpnc.services)
- [environment.freetds](https://nixos.org/nixos/manual/ch-options.html#opt-environment.freetds)
- [security.pki.certificates](https://nixos.org/nixos/manual/ch-options.html#opt-security.pki.certificates)
- [services.nsd.zones](https://nixos.org/nixos/manual/ch-options.html#opt-services.nsd.zones)
- [services.phpfpm.poolConfigs](https://nixos.org/nixos/manual/ch-options.html#opt-services.phpfpm.poolConfigs)
- [services.zope2.instances](https://nixos.org/nixos/manual/ch-options.html#opt-services.zope2.instances)
- [services.xserver.inputClassSections](https://nixos.org/nixos/manual/ch-options.html#opt-services.xserver.inputClassSections)
- [system.activationScripts](https://nixos.org/nixos/manual/ch-options.html#opt-system.activationScripts)

These commits use the `literalExample` function to properly format the examples like so:

![fail2ban-after](https://cloud.githubusercontent.com/assets/3696783/8507068/02de3374-2287-11e5-9de2-16e3c1965cbd.png)

The manual has been built on master and checked.

I thought it would be cleaner to make a separate commit for each module, but I can squash the commits into one if you would prefer.

Cheers
