### PR TITLE
python-packages statsmodels: init at 0.6.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16665,6 +16665,30 @@ let
     };
   };
 
+  statsmodels = buildPythonPackage rec {
+    name = "statsmodels-${version}";
+    version = "0.6.1";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/s/statsmodels/${name}.tar.gz";
+      sha256 = "be4e44374aec9e848b73e5a230dee190ac0c4519e1d40f69a5813190b13ec676";
+    };
+
+    buildInputs = with self; [ nose ];
+    propagatedBuildInputs = with self; [numpy scipy pandas patsy cython matplotlib];
+
+    meta = {
+      description = "Statistical computations and models for use with SciPy";
+      homepage = "https://www.github.com/statsmodels/statsmodels";
+      license = licenses.bsd3;
+      maintainer = with maintainers; [ fridh ];
+    };
+    
+    # Many tests fail when using latest numpy and pandas.
+    # See also https://github.com/statsmodels/statsmodels/issues/2602
+    doCheck = false;
+  };
+
   python_statsd = buildPythonPackage rec {
     name = "python-statsd-${version}";
     version = "1.6.0";
@@ -16681,6 +16705,7 @@ let
       description = "A client for Etsy's node-js statsd server";
       homepage = https://github.com/WoLpH/python-statsd;
       license = licenses.bsd3;
+      maintainers = with maintainers; [ fridh ];
     };
   };
 


### PR DESCRIPTION
Requires #8635

I've disabled the tests, because one test requires an optional dependency. The optional dependency is X-13 ARIMA, which isn't available in nixpkgs. 
