### PR TITLE
{lib}mediainfo{-gui}: 0.7.74 -> 0.7.75

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.74";
+  version = "0.7.75";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
-    url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
-    sha256 = "06r6inggkb3gmxax182y4y39icxry5hdcvq7syb060l8wxrk14ky";
+    url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
+    sha256 = "1xdsy5z7x7bd251m26h5hcwcmgl6gklxj6h9q025mlnfmcs7pbdy";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.74";
+  version = "0.7.75";
   name = "mediainfo-${version}";
   src = fetchurl {
-    url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.bz2";
-    sha256 = "06r6inggkb3gmxax182y4y39icxry5hdcvq7syb060l8wxrk14ky";
+    url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
+    sha256 = "1xdsy5z7x7bd251m26h5hcwcmgl6gklxj6h9q025mlnfmcs7pbdy";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.74";
+  version = "0.7.75";
   name = "libmediainfo-${version}";
   src = fetchurl {
-    url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.bz2";
-    sha256 = "1dn7zwqkl08vafc979i1mx63r2jlr95gfazg4d2cc9v3pav28zpk";
+    url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
+    sha256 = "1im39kd595ia6g41qvwgvszn1s10nwa3q5r2lj2g5fm4kgi0dwhr";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
Changelog:

```
Version 0.7.75, 2015-06-30
+ MXF: consideraing 60 fps timecode tracks with 2 components having a difference of 2 frames as a single timecode
+ EBUCore 1.6: switch to the link of the final XSD
x XDCAM: some directory structures were wrongly detected as XDCAM structure having a XML file
x MXF: SDTI 60 fps times were wrong
x #B927, DPX: date/time specific DPX format was used instead of the ISO-like one
x #B927, EBUCore: invalid content in attribute startDate
x ProRes: streams with apcs CodecID were displayed with an incoherent bit depth instead of no bit depth
```
