### PR TITLE
nixos: provide default console_cmd for slim

### DIFF
--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -19,6 +19,7 @@ let
       reboot_cmd ${config.systemd.package}/sbin/shutdown -r now
       ${optionalString (cfg.defaultUser != null) ("default_user " + cfg.defaultUser)}
       ${optionalString cfg.autoLogin "auto_login yes"}
+      ${optionalString (cfg.consoleCmd != null) "console_cmd ${cfg.consoleCmd}"}
       ${cfg.extraConfig}
     '';
 
@@ -99,6 +100,18 @@ in
         '';
       };
 
+      consoleCmd = mkOption {
+        type = types.nullOr types.str;
+        default = ''
+          ${pkgs.xterm}/bin/xterm -C -fg white -bg black +sb -T "Console login" -e ${pkgs.shadow}/bin/login
+        '';
+        defaultText = ''
+          ''${pkgs.xterm}/bin/xterm -C -fg white -bg black +sb -T "Console login" -e ''${pkgs.shadow}/bin/login
+        '';
+        description = ''
+          The command to run when "console" is given as the username.
+        '';
+      };
     };
 
   };


### PR DESCRIPTION
This provides a default console_cmd for the slim display-manager.

When the user enters "console" as the user name, slim will run this
command.

Having a default is rather important; the virtual terminals don't work
with some display drivers, so having a broken X session can leave you
locked out of your machine.
