### PR TITLE
udisks2 service: Fix ExecStart path

### DIFF
--- a/nixos/modules/services/hardware/udisks2.nix
+++ b/nixos/modules/services/hardware/udisks2.nix
@@ -46,7 +46,7 @@ with lib;
       serviceConfig = {
         Type = "dbus";
         BusName = "org.freedesktop.UDisks2";
-        ExecStart = "${pkgs.udisks2}/lib/udisks2/udisksd --no-debug";
+        ExecStart = "${pkgs.udisks2}/libexec/udisks2/udisksd --no-debug";
       };
     };
   };


### PR DESCRIPTION
It seems that with the latest update to `udisks2`, the ExecStart path
for the daemon changed from `/lib/udisks2/` to `/libexec/udisks2/`. This
commit reflects that change for our purposes.
