### PR TITLE
ghc:  add haskell.compiler.ghcNokinds, for Richard Eisenberg's `nokinds` branch

### DIFF
--- a/doc/haskell-users-guide.xml
+++ b/doc/haskell-users-guide.xml
@@ -136,6 +136,7 @@ haskell.compiler.ghc763         ghc-7.6.3
 haskell.compiler.ghc784         ghc-7.8.4
 haskell.compiler.ghc7101        ghc-7.10.1
 haskell.compiler.ghcHEAD        ghc-7.11.20150402
+haskell.compiler.ghcNokinds     ghc-nokinds-7.11.20150704
 haskell.compiler.ghcjs          ghcjs-0.1.0
 haskell.compiler.jhc            jhc-0.8.2
 haskell.compiler.uhc            uhc-1.1.9.0

--- a/pkgs/development/compilers/ghc/nokinds.nix
+++ b/pkgs/development/compilers/ghc/nokinds.nix
@@ -1,0 +1,74 @@
+{ stdenv, fetchgit, ghc, perl, gmp, ncurses, libiconv, autoconf, automake, happy, alex }:
+
+let
+
+  buildMK = ''
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp}/lib"
+    libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp}/include"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses}/include"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses}/lib"
+    DYNAMIC_BY_DEFAULT = NO
+    SRC_HC_OPTS        = -H64m -O -fasm
+    GhcLibHcOpts       = -O -dcore-lint
+    GhcStage1HcOpts    = -Rghc-timing -O -fasm
+    GhcStage2HcOpts    = -Rghc-timing -O0 -DDEBUG
+    SplitObjs          = NO
+    HADDOCK_DOCS       = NO
+    BUILD_DOCBOOK_HTML = NO
+    BUILD_DOCBOOK_PS   = NO
+    BUILD_DOCBOOK_PDF  = NO
+    LAX_DEPENDENCIES   = YES
+    ${stdenv.lib.optionalString stdenv.isDarwin ''
+      libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
+      libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"
+    ''}
+  '';
+
+in
+
+stdenv.mkDerivation rec {
+  version = "7.11.20150703";
+  name = "ghc-nokinds-${version}";
+  rev = "887170ac254aaacc2d5e29f2565ac61522fd8f61";
+
+  src = fetchgit {
+    url = "https://github.com/goldfirere/ghc.git";
+    inherit rev;
+    sha256 = "010x9ckig76sz97s2ss1j1sf70czqx1cn39nj4xbh49m8n2zvsqf";
+  };
+
+  postUnpack = ''
+    pushd ghc-${builtins.substring 0 7 rev}
+    patchShebangs .
+    ./boot
+    popd
+  '';
+
+  buildInputs = [ ghc perl autoconf automake happy alex ];
+
+  preConfigure = ''
+    echo >mk/build.mk "${buildMK}"
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath $out/lib/ghc-${version}"
+  '';
+
+  configureFlags = [
+    "--with-gcc=${stdenv.cc}/bin/cc"
+    "--with-gmp-includes=${gmp}/include" "--with-gmp-libraries=${gmp}/lib"
+  ];
+
+  enableParallelBuilding = true;
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" ] ++ stdenv.lib.optional (!stdenv.isDarwin) "--keep-file-symbols";
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The dependently-typed 'nokinds' branch of the Glasgow Haskell Compiler by Richard Eisenberg";
+    maintainers = with stdenv.lib.maintainers; [ ];
+    inherit (ghc.meta) license platforms;
+  };
+
+}

--- a/pkgs/development/haskell-modules/configuration-ghc-nokinds.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-nokinds.nix
@@ -1,0 +1,104 @@
+{ pkgs }:
+
+with import ./lib.nix { inherit pkgs; };
+
+self: super: {
+
+  # Use the latest LLVM.
+  inherit (pkgs) llvmPackages;
+
+  # Disable GHC 7.11.x core libraries.
+  array = null;
+  base = null;
+  binary = null;
+  bin-package-db = null;
+  bytestring = null;
+  Cabal = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  filepath = null;
+  ghc-prim = null;
+  haskeline = null;
+  hoopl = null;
+  hpc = null;
+  integer-gmp = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  template-haskell = null;
+  terminfo = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+
+  # Don't use jailbreak built with Cabal 1.22.x because of https://github.com/peti/jailbreak-cabal/issues/9.
+  jailbreak-cabal = pkgs.haskell.packages.ghc784.jailbreak-cabal;
+
+  # GHC 7.10.x's Haddock binary cannot generate hoogle files.
+  # https://ghc.haskell.org/trac/ghc/ticket/9921
+  mkDerivation = drv: super.mkDerivation (drv // { doHoogle = false; doHaddock = false; });
+
+  # haddock: No input file(s).
+  nats = dontHaddock super.nats;
+  bytestring-builder = dontHaddock super.bytestring-builder;
+
+  alex = dontCheck super.alex;
+
+  # We have time 1.5
+  aeson = disableCabalFlag super.aeson "old-locale";
+
+  # Show works differently for record syntax now, breaking haskell-src-exts' parser tests
+  # https://github.com/haskell-suite/haskell-src-exts/issues/224
+  haskell-src-exts = dontCheck super.haskell-src-exts;
+
+  mono-traversable = appendPatch super.mono-traversable (pkgs.fetchpatch {
+    url = "https://github.com/snoyberg/mono-traversable/pull/77.patch";
+    sha256 = "1qrvrh3cqfkymi5yb9y9z88rq4n7ag0ac2k00mcnqh4dz1vh4fg1";
+  });
+  yesod-auth = appendPatch super.yesod-auth (pkgs.fetchpatch {
+    url = "https://github.com/yesodweb/yesod/pull/1006.patch";
+    sha256 = "0l6wjj8cfz6jy6j92kywsccafyffhlm5240q82bzirb278adqvar";
+    stripLen = 1;
+  });
+
+  # Setup: At least the following dependencies are missing: base <4.8
+  hspec-expectations = overrideCabal super.hspec-expectations (drv: {
+    patchPhase = "sed -i -e 's|base < 4.8|base|' hspec-expectations.cabal";
+  });
+  utf8-string = overrideCabal super.utf8-string (drv: {
+    patchPhase = "sed -i -e 's|base >= 3 && < 4.8|base|' utf8-string.cabal";
+  });
+
+  # bos/attoparsec#92
+  attoparsec = dontCheck super.attoparsec;
+
+  # test suite hangs silently for at least 10 minutes
+  split = dontCheck super.split;
+
+  # Test suite fails with some (seemingly harmless) error.
+  # https://code.google.com/p/scrapyourboilerplate/issues/detail?id=24
+  syb = dontCheck super.syb;
+
+  # Test suite has stricter version bounds
+  retry = dontCheck super.retry;
+
+  # Test suite fails with time >= 1.5
+  http-date = dontCheck super.http-date;
+
+  # Version 1.19.5 fails its test suite.
+  happy = dontCheck super.happy;
+
+  # Workaround for a workaround, see comment for "ghcjs" flag.
+  jsaddle = let jsaddle' = disableCabalFlag super.jsaddle "ghcjs";
+            in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
+                                          self.webkitgtk3-javascriptcore ];
+
+  # The compat library is empty in the presence of mtl 2.2.x.
+  mtl-compat = dontHaddock super.mtl-compat;
+
+  # Won't work with LLVM 3.5.
+  llvm-general = markBrokenVersion "3.4.5.3" super.llvm-general;
+
+}

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -40,6 +40,9 @@ rec {
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix ({ inherit (packages.ghc784) ghc alex happy; } // stdenv.lib.optionalAttrs stdenv.isDarwin {
       libiconv = pkgs.darwin.libiconv;
     });
+    ghcNokinds = callPackage ../development/compilers/ghc/nokinds.nix ({ inherit (packages.ghc784) ghc alex happy; } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+      libiconv = pkgs.darwin.libiconv;
+    });
 
     ghcjs = packages.ghc7101.callPackage ../development/compilers/ghcjs {
       ghc = compiler.ghc7101;
@@ -94,6 +97,10 @@ rec {
     ghcHEAD = callPackage ../development/haskell-modules {
       ghc = compiler.ghcHEAD;
       packageSetConfig = callPackage ../development/haskell-modules/configuration-ghc-head.nix { };
+    };
+    ghcNokinds = callPackage ../development/haskell-modules {
+      ghc = compiler.ghcNokinds;
+      packageSetConfig = callPackage ../development/haskell-modules/configuration-ghc-nokinds.nix { };
     };
     ghcjs = callPackage ../development/haskell-modules {
       ghc = compiler.ghcjs;


### PR DESCRIPTION
A variant of ghcHEAD, with the `nokinds` branch by Richard Eisenberg.

This allows wide experimentation with the state-of-art implementation of dependent typing in Haskell.

Differences from ghcHEAD:
- `devel2` configuration was pratically inlined into `buildMK`, `-fasm` was turned on unconditionally
- `doHaddock` was globally disabled in `mkDerivation` for all packages
