### PR TITLE
nodejs: 0.12.0 -> 0.12.6

### DIFF
--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -12,7 +12,7 @@ let
     ln -sv /usr/sbin/dtrace $out/bin
   '';
 
-  version = "0.12.0";
+  version = "0.12.6";
 
   deps = {
     inherit openssl zlib libuv;
@@ -36,7 +36,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "0cifd2qhpyrbxx71a4hsagzk24qas8m5zvwcyhx69cz9yhxf404p";
+    sha256 = "1llsl7zl3080zd7jfhhy4d5s9pnhr15niw6vivp9sflpa71mlfvs";
   };
 
   configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps);


### PR DESCRIPTION
`0.12.5` and `0.12.6` were both critical security releases.
