### PR TITLE
haskellPackages.vcache: unmark broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -617,10 +617,6 @@ self: super: {
   # https://code.google.com/p/linux-music-player/issues/detail?id=1
   mp = markBroken super.mp;
 
-  # Depends on broken lmdb package.
-  vcache = markBroken super.vcache;
-  vcache-trie = markBroken super.vcache-trie;
-
   # https://github.com/afcowie/http-streams/issues/80
   http-streams = dontCheck super.http-streams;
 


### PR DESCRIPTION
- unmark haskellPackages.vcache as broken
- unmark haskellPackages.vcache-trie as broken

No longer broken since the addition of lmdb in

9d85874aeb6f17bc1b13c1a248f319e1908e1210
