### PR TITLE
Build popcorntime from ci until yts movie outage is fixed

### DIFF
--- a/pkgs/applications/video/popcorntime/default.nix
+++ b/pkgs/applications/video/popcorntime/default.nix
@@ -1,24 +1,39 @@
-{ stdenv, fetchurl, runCommand, makeWrapper, node_webkit_0_9
+{ lib, stdenv, fetchurl, runCommand, makeWrapper, node_webkit_0_9,
+  fromCi ? true,
+  build ? "652",
+  version ? if fromCi then "0.3.7-2-0ac62b848" else "0.3.7.2"
 }:
 
 let
-  version = "0.3.7.2";
+  config = 
+    if stdenv.system == "x86_64-linux" then 
+      {sys = "Linux32"; 
+       sha256 = 
+          if fromCi then "06av40b68xy2mv2fp9qg8npqmnvkl00p2jvbm2fdfnpc9jj746iy"
+                    else "0lm9k4fr73a9p00i3xj2ywa4wvjf9csadm0pcz8d6imwwq44sa8b";
+      }
+    else if stdenv.system == "i686-linux" then 
+      {sys = "Linux64"; 
+       sha256 = 
+        if fromCi then "1nr2zaixdr5vqynga7jig3fw9dckcnzcbdmbr8haq4a486x2nq0f"
+                  else "1dz1cp31qbwamm9pf8ydmzzhnb6d9z73bigdv3y74dgicz3dpr91";
+      }
+    else throw "Unsupported system ${stdenv.system}";
+
+  fetchurlConf = 
+    let
+      ciBase = "https://ci.popcorntime.io/job/Popcorn-Experimental/652/artifact/build/releases/Popcorn-Time";
+      relBase = "https://get.popcorntime.io/build";
+    in {
+      url = 
+        if fromCi then "${ciBase}/${lib.toLower config.sys}/Popcorn-Time-${version}-${config.sys}.tar.xz"
+        else "${relBase}/Popcorn-Time-${version}-Linux64.tar.xz";
+      sha256 = config.sha256;
+    };
 
   popcorntimePackage = stdenv.mkDerivation rec {
     name = "popcorntime-package-${version}";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = "https://get.popcorntime.io/build/Popcorn-Time-${version}-Linux64.tar.xz";
-          sha256 = "0lm9k4fr73a9p00i3xj2ywa4wvjf9csadm0pcz8d6imwwq44sa8b";
-        }
-      else if stdenv.system == "i686-linux" then
-        fetchurl {
-          url = "https://get.popcorntime.io/build/Popcorn-Time-${version}-Linux32.tar.xz";
-          sha256 = "1dz1cp31qbwamm9pf8ydmzzhnb6d9z73bigdv3y74dgicz3dpr91";
-        }
-      else
-        throw "Unsupported system ${stdenv.system}";
+    src = fetchurl fetchurlConf;
     sourceRoot = ".";
     installPhase = ''
       mkdir -p $out


### PR DESCRIPTION
Currently the movie tab is broken. It's fixed in the experimental branch (master)

http://status.popcorntime.io/

> - Update - Issue with the subtitles API affects Release 0.3.7-2, Experimental builds are fine
>   May 13, 22:54 EDT
>   [...]
> - Identified - The issue with the YTS API (Movies) seems to be related to a bad response for one of the movies. The movies page will continue to be intermittent until the issue is resolved.
>   May 10, 21:29 EDT
> - Investigating - YTS (Movies) is currently unavailable for Popcorn Time release 0.3.7-2, but is still working for the experimental builds. We're looking into what the issue could be and why it's only affecting release 0.3.7-2
>   May 10, 18:34 EDT
