### PR TITLE
Update and fix ruby

### DIFF
--- a/pkgs/development/interpreters/ruby/ruby-1.9.3.nix
+++ b/pkgs/development/interpreters/ruby/ruby-1.9.3.nix
@@ -25,10 +25,10 @@ stdenv.mkDerivation rec {
     owner  = "ruby";
     repo   = "ruby";
     rev    = "v1_9_3_${passthru.patchLevel}";
-    sha256 = "040x67snfjrql5j7blizpm9j58jhwvh00v8h1h59aq90h52lkj68";
+    sha256 = "1r9xzzxmci2ajb34qb4y1w424mz878zdgzxkfp9w60agldxnb36s";
   } else fetchurl {
     url = "http://cache.ruby-lang.org/pub/ruby/1.9/${name}.tar.bz2";
-    sha256 = "0k7g0ahicjnd4sij2pml1p1dcb95ms3k3j1k3169n02kzz9qwn7g";
+    sha256 = "07kpvv2z7g6shflls7fyfga8giifahwlnl30l49qdm9i6izf7idh";
   };
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
@@ -54,24 +54,25 @@ stdenv.mkDerivation rec {
     ./ruby19-parallel-install.patch
     ./bitperfect-rdoc.patch
   ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/01-fix-make-clean.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/02-railsbench-gc.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/04-fork-support-for-gc-logging.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/05-track-live-dataset-size.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/06-webrick_204_304_keep_alive_fix.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/07-export-a-few-more-symbols-for-ruby-prof.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/08-thread-variables.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/09-faster-loading.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/10-falcon-st-opt.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/11-falcon-sparse-array.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/12-falcon-array-queue.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/13-railsbench-gc-fixes.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/14-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/15-configurable-fiber-stack-sizes.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/16-backport-psych-20.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/17-fix-missing-c-return-event.patch"
-    "${patchSet}/patches/ruby/1.9.3/p547/railsexpress/18-fix-process-daemon-call.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/01-fix-make-clean.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/02-zero-broken-tests.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/03-railsbench-gc.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/04-display-more-detailed-stack-trace.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/05-fork-support-for-gc-logging.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/06-track-live-dataset-size.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/07-webrick_204_304_keep_alive_fix.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/08-export-a-few-more-symbols-for-ruby-prof.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/09-thread-variables.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/10-faster-loading.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/11-falcon-st-opt.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/12-falcon-sparse-array.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/13-falcon-array-queue.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/14-railsbench-gc-fixes.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/15-show-full-backtrace-on-stack-overflow.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/16-configurable-fiber-stack-sizes.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/17-backport-psych-20.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/18-fix-missing-c-return-event.patch"
+    "${patchSet}/patches/ruby/1.9.3/p${passthru.patchLevel}/railsexpress/19-fix-process-daemon-call.patch"
   ];
 
   configureFlags = [ "--enable-shared" "--enable-pthread" ]
@@ -115,7 +116,7 @@ stdenv.mkDerivation rec {
     majorVersion = "1";
     minorVersion = "9";
     teenyVersion = "3";
-    patchLevel = "547";
+    patchLevel = "551";
     rubyEngine = "ruby";
     libPath = "lib/${rubyEngine}/${majorVersion}.${minorVersion}.${teenyVersion}";
     gemPath = "lib/${rubyEngine}/gems/${majorVersion}.${minorVersion}.${teenyVersion}";

--- a/pkgs/development/interpreters/ruby/ruby-2.2.0.nix
+++ b/pkgs/development/interpreters/ruby/ruby-2.2.0.nix
@@ -59,9 +59,8 @@ stdenv.mkDerivation rec {
     "${patchSet}/patches/ruby/2.2.0/railsexpress/05-fix-packed-bitfield-compat-warning-for-older-gccs.patch"
   ];
 
-  # Ruby >= 2.1.0 tries to download config.{guess,sub}
-  postPatch = ''
-    rm tool/config_files.rb
+  postPatch = ops useRailsExpress ''
+    sed -i configure.in -e '/config.guess/d'
     cp ${config}/config.guess tool/
     cp ${config}/config.sub tool/
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5034,6 +5034,7 @@ let
   ruby_2_1_3 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.3.nix { });
   ruby_2_1_6 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.1.6.nix { });
   ruby_2_2_0 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.2.0.nix { });
+  ruby_2_2_2 = lowPrio (callPackage ../development/interpreters/ruby/ruby-2.2.2.nix { });
 
   # Ruby aliases
   ruby = ruby_2_1;


### PR DESCRIPTION
- Fixes Ruby 2.2.0
- Adds Ruby 2.2.2
- Uses latest RVM patchset
- 1.9.3-p547 -> 1.9.3-p551
- 2.0.0-p481 -> 2.0.0-p645

Here you go, @wkennington :)

If we're going to bump our default version or Ruby, I would suggest going with 2.2.2 - it's going to be the required minimum version for Rails 5, which is coming out this fall, and I'm not aware of any big backwards comparability concerns.
