### PR TITLE
Add phantomjs2

### DIFF
--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl,
+  bison2, flex, fontconfig, freetype, gperf, icu, openssl, libjpeg, libpng, perl, python, ruby, sqlite
+}:
+
+stdenv.mkDerivation rec {
+  name = "phantomjs-${version}";
+  version = "2.0.0-20150528";
+
+  src = fetchurl {
+    url = "https://github.com/bprodoehl/phantomjs/archive/v2.0.0-20150528.tar.gz";
+    sha256 = "18h37bxxg25lacry9k3vb5yim057bqcxmsifw97jrjp7gzfx56v5";
+  };
+
+  buildInputs = [ bison2 flex fontconfig freetype gperf icu openssl libjpeg libpng perl python ruby sqlite ];
+
+  patchPhase = ''
+    patchShebangs .
+    sed -i -e 's|/bin/pwd|pwd|' src/qt/qtbase/configure 
+  '';
+
+  buildPhase = "./build.sh --confirm";
+
+  installPhase = ''
+    mkdir -p $out/share/doc/phantomjs
+    cp -a bin $out
+    cp -a ChangeLog examples LICENSE.BSD README.md third-party.txt $out/share/doc/phantomjs
+  '';
+
+  meta = {
+    description = "Headless WebKit with JavaScript API";
+    longDescription = ''
+      PhantomJS2 is a headless WebKit with JavaScript API.
+      It has fast and native support for various web standards:
+      DOM handling, CSS selector, JSON, Canvas, and SVG.
+
+      PhantomJS is an optimal solution for:
+      - Headless Website Testing
+      - Screen Capture
+      - Page Automation
+      - Network Monitoring
+    '';
+
+    homepage = http://phantomjs.org/;
+    license = stdenv.lib.licenses.bsd3;
+
+    maintainers = [ stdenv.lib.maintainers.aflatter ];
+    platforms = with stdenv.lib.platforms; darwin ++ linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5629,6 +5629,8 @@ let
 
   phantomjs = callPackage ../development/tools/phantomjs { };
 
+  phantomjs2 = callPackage ../development/tools/phantomjs2 { };
+
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
   /* Make pkgconfig always return a nativeDrv, never a proper crossDrv,


### PR DESCRIPTION
This builds PhantomJS 2 from source in contrast to PhantomJS 1, for which static binary builds are available.

See https://github.com/NixOS/nixpkgs/issues/7136
