### PR TITLE
nixos-generate-config: Fix parsing 'btrfs subvolume show' of btrfs-progs 4.1

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -354,7 +354,7 @@ EOF
         if ($status != 0 || join("", @msg) =~ /ERROR:/) {
             die "Failed to retrieve subvolume info for $mountPoint\n";
         }
-        my @ids = join("", @id_info) =~ m/Object ID:[ \t\n]*([^ \t\n]*)/;
+        my @ids = join("", @id_info) =~ m/Subvolume ID:[ \t\n]*([^ \t\n]*)/;
         if ($#ids > 0) {
             die "Btrfs subvol name for $mountPoint listed multiple times in mount\n"
         } elsif ($#ids == 0) {


### PR DESCRIPTION
Since the update of btrfs-progs to 4.1, btrfs subvolume related tests
are failing since nixos-generate-config isn't detecting btrfs subvolume
options anymore:

Good build: http://hydra.nixos.org/build/23347516/log/raw

```
machine#   fileSystems."/" =
machine#     { device = "/dev/disk/by-uuid/33a12c46-f802-4f50-8489-e946bf9ad2b5";
machine#       fsType = "btrfs";
machine#       options = "subvol=nixos";
machine#     };
```

Bad build: http://hydra.nixos.org/build/23427059/nixlog/2/raw

```
machine#   fileSystems."/" =
machine#     { device = "/dev/disk/by-uuid/56df7e14-d6ee-4a88-9e13-445c79b344de";
machine#       fsType = "btrfs";
machine#     };
```

This apparently happens due to change of field names in the output of
'btrfs subvolume show'.
