### PR TITLE
Update node.js (v.0.12.0 -> v.0.12.6)

### DIFF
--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -12,7 +12,7 @@ let
     ln -sv /usr/sbin/dtrace $out/bin
   '';
 
-  version = "0.12.0";
+  version = "0.12.6";
 
   deps = {
     inherit openssl zlib libuv;
@@ -36,7 +36,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "0cifd2qhpyrbxx71a4hsagzk24qas8m5zvwcyhx69cz9yhxf404p";
+    sha256 = "1llsl7zl3080zd7jfhhy4d5s9pnhr15niw6vivp9sflpa71mlfvs";
   };
 
   configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps);


### PR DESCRIPTION
AFAICT, I'm the only person still updating node.js at this time...

I tested this locally, it works. Please place some trust in me and merge it.

My previous PR for node.js sat until two more node.js releases went by (both security critical). You accept my io.js updates, and that's practically the same as my node.js updates...
