### PR TITLE
haskell-network-uri: re-enable tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -112,9 +112,6 @@ self: super: {
   # https://github.com/haskell/time/issues/23
   time_1_5_0_1 = dontCheck super.time_1_5_0_1;
 
-  # Cannot compile its own test suite: https://github.com/haskell/network-uri/issues/10.
-  network-uri = dontCheck super.network-uri;
-
   # Help libconfig find it's C language counterpart.
   libconfig = (dontCheck super.libconfig).override { config = pkgs.libconfig; };
 


### PR DESCRIPTION
The issue causing compilation failure seems to have been resolved. With the tests enabled these all run fine for me.

```
nix-build -A haskell.packages.ghc7101.network-uri
nix-build -A haskell.packages.ghc784.network-uri
nix-build -A haskell.packages.ghc763.network-uri
```
