### PR TITLE
perl-BoostGeometryUtils: fix OOM in tests

### DIFF
--- a/pkgs/development/perl-modules/boost-geometry-utils-fix-oom.patch
+++ b/pkgs/development/perl-modules/boost-geometry-utils-fix-oom.patch
@@ -1,0 +1,34 @@
+From a46f0e41056b48a56c572fe8884d4b5104a8343e Mon Sep 17 00:00:00 2001
+From: Niko Tyni <ntyni@debian.org>
+Date: Sun, 29 Jun 2014 21:51:15 +0300
+Subject: [PATCH] multi_linestring2perl: only extend the array if needed
+
+When the size is 0, we end up extending the stack with
+a negative value. As of Perl 5.19.4, more precisely
+ http://perl5.git.perl.org/perl.git/commit/fc16c3924bd6aa054f21ad5445fecf9b7f39dc36
+this ends up allocating memory for 4G-1 elements.
+
+See Dave Mitchell's comments on perl5-porters:
+ Message-ID: <20140522115758.GX15438@iabyn.com>
+ http://marc.info/?l=perl5-porters&m=140075990913228&w=2
+---
+ src/mline2av.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/mline2av.h b/src/mline2av.h
+index e4b3fc2..d7bacee 100644
+--- a/src/mline2av.h
++++ b/src/mline2av.h
+@@ -9,7 +9,8 @@ multi_linestring2perl(pTHX_ const multi_linestring& mls)
+ {
+   AV* av = newAV();
+   const unsigned int size = mls.size();
+-  av_extend(av, size-1);
++  if (size > 0)
++    av_extend(av, size-1);
+ 
+   for (int i = 0; i < size; i++) {
+     AV* lineav = newAV();
+-- 
+2.0.0
+

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -484,6 +484,10 @@ let self = _self // overrides; _self = with self; {
       sha256 = "1jnihz3029x51a455nxa0jx2z125x38q3vkkggsgdlrvawzxsm00";
     };
     propagatedBuildInputs = [ ModuleBuildWithXSpp ExtUtilsTypemapsDefault ];
+    patches = [
+      # Fix out of memory error on Perl 5.19.4 and later.
+      ../development/perl-modules/boost-geometry-utils-fix-oom.patch
+    ];
   };
 
   BusinessISBN = buildPerlPackage {


### PR DESCRIPTION
The included patch from Debian resolves an out-of-memory error occurring when running the test suite with Perl version 5.19.4 or later.
