### PR TITLE
jwhois: fix path to lynx in $lynx/etc/jwhois.conf

### DIFF
--- a/pkgs/tools/networking/jwhois/default.nix
+++ b/pkgs/tools/networking/jwhois/default.nix
@@ -1,14 +1,17 @@
-{stdenv, fetchurl}:
+{stdenv, lynx, fetchurl}:
 
 stdenv.mkDerivation {
   name = "jwhois-4.0";
-  
+
   src = fetchurl {
     url = mirror://gnu/jwhois/jwhois-4.0.tar.gz;
     sha256 = "0knn7iaj5v0n6jpmldyv2yk4bcy9dn3kywmv63bwc5drh9kvi6zs";
   };
 
-  postInstall = "ln -s jwhois $out/bin/whois";
+  postInstall = ''
+    ln -s jwhois $out/bin/whois
+    sed -i -e "s|/usr/bin/lynx|${lynx}/bin/lynx|g" $out/etc/jwhois.conf
+  '';
 
   patches = [ ./connect.patch ];
 


### PR DESCRIPTION
Fixes issues found when jwhois attempts to launch terminal browser (lynx) for HTTP whois queries, for example:

```
$ whois blah.io
[Querying http://www.io.io/cgi-bin/whois]
[HTTP: Unable to run web browser: /usr/bin/lynx: No such file or directory]
```

Tested via:

```
grep lynx \
  /nix/store/bymgmn2vvw1n7nbb1isy87xg94s8f2ml-jwhois-4.0/etc/jwhois.conf \
  | cut -f2 -d'"' \
  | xargs stat -t
```

Should return with exit code 0.
