### PR TITLE
libiconv: fix hash on darwin

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -64,7 +64,7 @@ let
     Libc_old        = applePackage "Libc/825_40_1.nix" "825.40.1"    "0xsx1im52gwlmcrv4lnhhhn9dyk5ci6g27k6yvibn9vj8fzjxwcf" {};
     libclosure      = applePackage "libclosure"        "63"          "083v5xhihkkajj2yvz0dwgbi0jl2qvzk22p7pqq1zp3ry85xagrx" {};
     libdispatch     = applePackage "libdispatch"       "339.92.1"    "1lc5033cmkwxy3r26gh9plimxshxfcbgw6i0j7mgjlnpk86iy5bk" {};
-    libiconv        = applePackage "libiconv"          "41"          "10q7yd35flr893nysn9i04njgks4m3gis7jivb9ra9dcb77gqdcn" {};
+    libiconv        = applePackage "libiconv"          "41"          "0sni1gx6i2h7r4r4hhwbxdir45cp039m4wi74izh4l0pfw7gywad" {};
     Libinfo         = applePackage "Libinfo"           "449.1.3"     "1ix6f7xwjnq9bqgv8w27k4j64bqn1mfhh91nc7ciiv55axpdb9hq" {};
     Libm            = applePackage "Libm"              "2026"        "02sd82ig2jvvyyfschmb4gpz6psnizri8sh6i982v341x6y4ysl7" {};
     Libnotify       = applePackage "Libnotify"         "121.20.1"    "164rx4za5z74s0mk9x0m1815r1m9kfal8dz3bfaw7figyjd6nqad" {};


### PR DESCRIPTION
The libiconv41 sha256sum seemed to be incorrect. I guess the upstream archive was changed recently?

```
patching script interpreter paths in /nix/store/xmivkll9gpswgy4s0kl8qpq8p5x4zsg5-patch-2.7.5
building path(s) ‘/nix/store/5p2cv430dlag356ryjawxvflizjhn1qm-libiconv-41.tar.gz’

trying http://www.opensource.apple.com/tarballs/libiconv/libiconv-41.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4532k  100 4532k    0     0   261k      0  0:00:17  0:00:17 --:--:--  265k
output path ‘/nix/store/5p2cv430dlag356ryjawxvflizjhn1qm-libiconv-41.tar.gz’ should have sha256 hash ‘10q7yd35flr893nysn9i04njgks4m3gis7jivb9ra9dcb77gqdcn’, instead has ‘0sni1gx6i2h7r4r4hhwbxdir45cp039m4wi74izh4l0pfw7gywad’
```

(cc @copumpkin)
