### PR TITLE
powertop: Patch out path to /sbin/modprobe

### DIFF
--- a/pkgs/os-specific/linux/powertop/default.nix
+++ b/pkgs/os-specific/linux/powertop/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gettext libnl ncurses pciutils pkgconfig zlib ];
 
+  patchPhase = ''
+    substituteInPlace src/main.cpp --replace "/sbin/modprobe" "modprobe"
+  '';
+
   meta = {
     description = "Analyze power consumption on Intel-based laptops";
     license = stdenv.lib.licenses.gpl2;


### PR DESCRIPTION
Fixes #5424.
