### PR TITLE
language-support python: propagatedBuildInputs

### DIFF
--- a/doc/language-support.xml
+++ b/doc/language-support.xml
@@ -341,7 +341,16 @@ twisted = buildPythonPackage {
   <para>By default <varname>doCheck = true</varname> is set and tests are run with
   <literal>${python.interpreter} setup.py test</literal> command in <varname>checkPhase</varname>.</para>
 
-  <para><varname>propagatedBuildInputs</varname> packages are propagated to user environment.</para>
+  <para><varname>propagatedBuildInputs</varname> packages are propagated to the user environment.</para>
+
+  <para>
+    As in Perl, dependencies on other Python packages can be specified in the
+    <varname>buildInputs</varname> and
+    <varname>propagatedBuildInputs</varname> attributes.  If something is
+    exclusively a build-time dependency, use
+    <varname>buildInputs</varname>; if it’s (also) a runtime dependency,
+    use <varname>propagatedBuildInputs</varname>.
+  </para>
 
   <para>
     By default <varname>meta.platforms</varname> is set to the same value

--- a/doc/language-support.xml
+++ b/doc/language-support.xml
@@ -1,3 +1,4 @@
+
 <chapter xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xml:id="chap-language-support">
@@ -340,8 +341,6 @@ twisted = buildPythonPackage {
 
   <para>By default <varname>doCheck = true</varname> is set and tests are run with
   <literal>${python.interpreter} setup.py test</literal> command in <varname>checkPhase</varname>.</para>
-
-  <para><varname>propagatedBuildInputs</varname> packages are propagated to the user environment.</para>
 
   <para>
     As in Perl, dependencies on other Python packages can be specified in the


### PR DESCRIPTION
Explain difference between buildInputs and propagatedBuildInputs.
Shamefully steal wording from Perl.
