### PR TITLE
cassandra-driver: fix package attribute name

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1710,7 +1710,7 @@ let
     };
   };
 
-  cassandraDriver = buildPythonPackage rec {
+  cassandra-driver = buildPythonPackage rec {
     name = "cassandra-driver-2.6.0c2";
 
     src = pkgs.fetchurl {


### PR DESCRIPTION
Use a hyphen instead of camelCase.

See https://github.com/NixOS/nixpkgs/commit/90b4054aa00353f06011e85719edc1c9eff23b04#commitcomment-12080357
