### PR TITLE
mercurial: Move hg-git support to mercurialFull

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, python, makeWrapper, docutils, unzip, hg-git, dulwich
-, guiSupport ? false, tk ? null, curses, cacert
-
+{ stdenv, fetchurl, python, makeWrapper, docutils, unzip, curses, cacert
+, guiSupport ? false, tk ? null
+, gitSupport ? false, hg-git ? null, dulwich ? null
 , ApplicationServices }:
 
 let
@@ -41,7 +41,8 @@ stdenv.mkDerivation {
     ''
       for i in $(cd $out/bin && ls); do
         wrapProgram $out/bin/$i \
-          --prefix PYTHONPATH : "$(toPythonPath "$out ${curses}"):$(toPythonPath "$out ${hg-git}"):$(toPythonPath "$out ${dulwich}")" \
+          --prefix PYTHONPATH : "$(toPythonPath "$out ${curses}")${stdenv.lib.optionalString gitSupport
+            '':$(toPythonPath "$out ${hg-git}"):$(toPythonPath "$out ${dulwich}")'' }" \
           $WRAP_TK
       done
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11947,12 +11947,17 @@ let
   mendeley = callPackage ../applications/office/mendeley { };
 
   mercurial = callPackage ../applications/version-management/mercurial {
-    inherit (pythonPackages) curses docutils hg-git dulwich;
+    inherit (pythonPackages) curses docutils;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
     guiSupport = false; # use mercurialFull to get hgk GUI
+    gitSupport = false; # use mercurialFull to get hg-git
   };
 
-  mercurialFull = appendToName "full" (pkgs.mercurial.override { guiSupport = true; });
+  mercurialFull = appendToName "full" (pkgs.mercurial.override {
+    guiSupport = true;
+    gitSupport = true;
+    inherit (pythonPackages) hg-git dulwich;
+  });
 
   merkaartor = callPackage ../applications/misc/merkaartor { };
 


### PR DESCRIPTION
hg-git and dulwich do not build on darwin, making the changes introduced
in 922c555 disable any package that depends on mercurial on darwin.

Instead of requiring this in the main mercurial package it has been
moved to the mercurialFull package, a more feature complete version of
mercurial.

Fixes #8728
