### PR TITLE
gnupg: fix build on darwin

### DIFF
--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
 
   buildInputs
     = [ readline zlib libgpgerror libgcrypt libassuan libksba pth
-        openldap bzip2 libusb curl libiconv ];
+        openldap bzip2 curl libiconv ]
+        ++ stdenv.lib.optional (!stdenv.isDarwin) libusb;
 
   patchPhase = ''
     find tests -type f | xargs sed -e 's@/bin/pwd@${coreutils}&@g' -i


### PR DESCRIPTION
Can't use libusb on darwin
