### PR TITLE
owncloud: 7.0.5 -> 8.1.0

### DIFF
--- a/pkgs/servers/owncloud/default.nix
+++ b/pkgs/servers/owncloud/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 stdenv.mkDerivation rec {
   name= "owncloud-${version}";
-  version = "7.0.5";
+  version = "8.1.0";
 
   src = fetchurl {
     url = "https://download.owncloud.org/community/${name}.tar.bz2";
-    sha256 = "1j21b7ljvbhni9l0b1cpzlhsjy36scyas1l1j222mqdg2srfsi9y";
+    sha256 = "1vkly4xv1wdswvjss8pr6vxvfrmvsk663r6xpygwm0vh7lxqsc1x";
   };
 
   installPhase =


### PR DESCRIPTION
This updates owncloud.

Applied to my channel-unstable branch and test-building worked. I do not have a local owncloud installation though, so one of you might test this with a real installation?
