### PR TITLE
Update io.js (v2.3.3 -> v2.3.4)

### DIFF
--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, python, utillinux, openssl_1_0_2, http-parser, zlib, libuv }:
 
 let
-  version = "2.3.3";
+  version = "2.3.4";
   inherit (stdenv.lib) optional maintainers licenses platforms;
 in stdenv.mkDerivation {
   name = "iojs-${version}";
 
   src = fetchurl {
     url = "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
-    sha256 = "12fdz0as1sa34bq4a701qwrznpn7y1wq0yxlr5yw494ifchfm103";
+    sha256 = "1h9cjrs93c8rdycc0ahhc27wv826211aljvfmxfg8jdmg6nvibhq";
   };
 
   prePatch = ''


### PR DESCRIPTION
This alone does **not** fix CVE-2015-1793. For that, the [openssl 1.0.2 package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/openssl/1.0.2.x.nix) needs to be updated. There's an [update](https://github.com/NixOS/nixpkgs/commit/5e156b9db78a7639c7a7de6964b7a9188431f895) on staging.

The only user facing change is "npm: Upgraded to v2.12.1".
