### PR TITLE
monitor.nixos.org broken patch for rtv 1.4 -> 1.4.1 and CVE-2014-5979

### DIFF
--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, pkgs, python, pythonPackages }:
 
 pythonPackages.buildPythonPackage rec {
-  version = "1.4";
+  version = "1.4.1";
   name = "rtv-${version}";
 
   src = fetchFromGitHub {
     owner = "michael-lazar";
     repo = "rtv";
     rev = "v${version}";
-    sha256 = "071p7idprknpra6mrdjjka8lrr80ykag62rhbsaf6zcz1d9p55cp";
+    sha256 = "0jh7gcj7fdclfjcyh6kzvz25p5ivw5jn5b1fy863223f7fm4j7fz";
   };
 
   propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
Brought to you by [nixos-scripts](https://github.com/matthiasbeyer/nixos-scripts). :smile: 
