### PR TITLE
Mark Python 2.6 broken since it is not receiving security updates

### DIFF
--- a/pkgs/development/interpreters/python/2.6/default.nix
+++ b/pkgs/development/interpreters/python/2.6/default.nix
@@ -9,7 +9,6 @@ let
   majorVersion = "2.6";
   version = "${majorVersion}.9";
 
-  # python 2.6 will receive security fixes until Oct 2013
   src = fetchurl {
     url = "http://www.python.org/ftp/python/${version}/Python-${version}.tar.xz";
     sha256 = "0hbfs2691b60c7arbysbzr0w9528d5pl8a4x7mq5psh6a2cvprya";
@@ -118,6 +117,10 @@ let
       license = stdenv.lib.licenses.psfl;
       platforms = stdenv.lib.platforms.all;
       maintainers = with stdenv.lib.maintainers; [ simons chaoflow iElectric ];
+      # If you want to use Python 2.6, remove "broken = true;" at your own
+      # risk.  Python 2.6 has known security vulnerabilities is not receiving
+      # security updates as of October 2013.
+      broken = true;
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1188,12 +1188,10 @@ let
 
   cudatoolkit65 = import ../development/compilers/cudatoolkit/6.5.nix {
     inherit callPackage;
-    python = python26;
   };
 
   cudatoolkit7 = import ../development/compilers/cudatoolkit/7.0.nix {
     inherit callPackage;
-    python = python26;
   };
 
   cudatoolkit = cudatoolkit5;


### PR DESCRIPTION
See discussion at https://github.com/NixOS/nixpkgs/pull/8733. This is gentler than removing the package, since people who want to take the risk can revert this commit on their local branch (hopefully, the standard override mechanism works too).

I believe there exist Python vulnerabilities (such as [CVE-2014-1912](http://www.cvedetails.com/cve/CVE-2014-1912/) to pick a random example) that were never fixed for Python 2.6.
