### PR TITLE
chrony: 2.1.1 -> 2.2 & service improvements

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -303,7 +303,7 @@
       nslcd = 58;
       scanner = 59;
       nginx = 60;
-      #chrony = 61; # unused
+      chrony = 61;
       systemd-journal = 62;
       smtpd = 63;
       smtpq = 64;

--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -47,12 +47,7 @@ in
       };
 
       servers = mkOption {
-        default = [
-          "0.nixos.pool.ntp.org"
-          "1.nixos.pool.ntp.org"
-          "2.nixos.pool.ntp.org"
-          "3.nixos.pool.ntp.org"
-        ];
+        default = config.services.ntp.servers;
         description = ''
           The set of NTP servers from which to synchronise.
         '';
@@ -90,6 +85,8 @@ in
     # Make chronyc available in the system path
     environment.systemPackages = [ pkgs.chrony ];
 
+    systemd.services.ntpd.enable = false;
+
     users.extraUsers = singleton
       { name = chronyUser;
         uid = config.ids.uids.chrony;
@@ -102,6 +99,7 @@ in
 
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
+        conflicts = [ "ntpd.service" "systemd-timesyncd.service" ];
 
         path = [ chrony ];
 

--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -8,25 +8,9 @@ let
 
   stateDir = "/var/lib/chrony";
 
-  chronyUser = "chrony";
+  keyFile = "/etc/chrony.keys";
 
   cfg = config.services.chrony;
-
-  configFile = pkgs.writeText "chrony.conf" ''
-    ${toString (map (server: "server " + server + "\n") cfg.servers)}
-
-    ${optionalString cfg.initstepslew.enabled ''
-      initstepslew ${toString cfg.initstepslew.threshold} ${toString (map (server: server + " ") cfg.initstepslew.servers)}
-    ''}
-
-    driftfile ${stateDir}/chrony.drift
-
-    ${optionalString (!config.time.hardwareClockInLocalTime) "rtconutc"}
-
-    ${cfg.extraConfig}
-  '';
-
-  chronyFlags = "-m -f ${configFile} -u ${chronyUser}";
 
 in
 
@@ -85,31 +69,60 @@ in
     # Make chronyc available in the system path
     environment.systemPackages = [ pkgs.chrony ];
 
-    systemd.services.ntpd.enable = false;
+    environment.etc."chrony.conf".text =
+      ''
+        ${concatMapStringsSep "\n" (server: "server " + server) cfg.servers}
+
+        ${optionalString
+          cfg.initstepslew.enabled
+          "initstepslew ${toString cfg.initstepslew.threshold} ${concatStringsSep " " cfg.initstepslew.servers}"
+        }
+
+        driftfile ${stateDir}/chrony.drift
+
+        keyfile ${keyFile}
+        generatecommandkey
+
+        ${optionalString (!config.time.hardwareClockInLocalTime) "rtconutc"}
+
+        ${cfg.extraConfig}
+      '';
+
+    users.extraGroups = singleton
+      { name = "chrony";
+        gid = config.ids.gids.chrony;
+      };
 
     users.extraUsers = singleton
-      { name = chronyUser;
+      { name = "chrony";
         uid = config.ids.uids.chrony;
+        group = "chrony";
         description = "chrony daemon user";
         home = stateDir;
       };
 
-    jobs.chronyd =
-      { description = "chrony daemon";
+    systemd.services.ntpd.enable = false;
+
+    systemd.services.chronyd =
+      { description = "chrony NTP daemon";
 
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         conflicts = [ "ntpd.service" "systemd-timesyncd.service" ];
 
-        path = [ chrony ];
+        path = [ pkgs.chrony ];
 
         preStart =
           ''
             mkdir -m 0755 -p ${stateDir}
-            chown ${chronyUser} ${stateDir}
+            touch ${keyFile}
+            chmod 0640 ${keyFile}
+            chown chrony:chrony ${stateDir} ${keyFile}
           '';
 
-        exec = "chronyd -n ${chronyFlags}";
+        serviceConfig =
+          { ExecStart = "${pkgs.chrony}/bin/chronyd -n -m -u chrony";
+          };
       };
 
   };

--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     repository.git = git://git.tuxfamily.org/gitroot/chrony/chrony.git;
     license = licenses.gpl2;
     platforms = with platforms; linux ++ freebsd ++ openbsd;
-    maintainers = [ maintainers.rickynils ];
+    maintainers = with maintainers; [ rickynils fpletz ];
 
     longDescription = ''
       Chronyd is a daemon which runs in background on the system. It obtains measurements via the network of the system clock’s offset relative to time servers on other systems and adjusts the system time accordingly. For isolated systems, the user can periodically enter the correct time by hand (using Chronyc). In either case, Chronyd determines the rate at which the computer gains or loses time, and compensates for this. Chronyd implements the NTP protocol and can act as either a client or a server.

--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = [
-    "--sysconfdir=$(out)/etc"
     "--chronyvardir=$(out)/var/lib/chrony"
   ];
 

--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -5,13 +5,13 @@ assert stdenv.isLinux -> libcap != null;
 stdenv.mkDerivation rec {
   name = "chrony-${version}";
 
-  version = "2.1.1";
-  
+  version = "2.2";
+
   src = fetchurl {
     url = "http://download.tuxfamily.org/chrony/${name}.tar.gz";
-    sha256 = "b0565148eaa38e971291281d76556c32f0138ec22e9784f8bceab9c65f7ad7d4";
+    sha256 = "1194maargy4hpl2a3vy5mbrrswzajjdn92p4w17gbb9vlq7q5zfk";
   };
-  
+
   buildInputs = [ readline texinfo ] ++ stdenv.lib.optional stdenv.isLinux libcap;
 
   configureFlags = [

--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libcap, readline, texinfo }:
+{ stdenv, fetchurl, pkgconfig, libcap, readline, texinfo, nss, nspr }:
 
 assert stdenv.isLinux -> libcap != null;
 
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1194maargy4hpl2a3vy5mbrrswzajjdn92p4w17gbb9vlq7q5zfk";
   };
 
-  buildInputs = [ readline texinfo ] ++ stdenv.lib.optional stdenv.isLinux libcap;
+  buildInputs = [ readline texinfo nss nspr ] ++ stdenv.lib.optional stdenv.isLinux libcap;
+  nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = [
     "--sysconfdir=$(out)/etc"


### PR DESCRIPTION
This pull request updates chrony to ~~2.1.1~~ 2.2 and brings the service module in better shape.

Disabling `ntpd.service` and fetching `services.ntp.servers` as default was done to mimic the behavior of the timesyncd service module.

cc @rickynils 
