### PR TITLE
firefox sync-server service: make path to paster executable absolute

### DIFF
--- a/nixos/modules/services/networking/firefox/sync-server.nix
+++ b/nixos/modules/services/networking/firefox/sync-server.nix
@@ -135,7 +135,7 @@ in
           echo >> ${cfg.privateConfig} "secret = $(head -c 20 /dev/urandom | sha1sum | tr -d ' -')"
         fi
       '';
-      serviceConfig.ExecStart = "paster serve ${syncServerIni}";
+      serviceConfig.ExecStart = "${pkgs.pythonPackages.pasteScript}/bin/paster serve ${syncServerIni}";
     };
 
   };


### PR DESCRIPTION
The systemd service fails because the path to the paster executable is not absolute:

```
[/nix/store/2g3a3d09pwjlih4llad2lcymjd78szzk-unit-syncserver.service/syncserver.service:13] Executable path is not absolute, ignoring: paster serve /nix/store/r9r63q9lfhib4h5i8kvc4jg6sb4ap6l7-syncserver.ini
syncserver.service lacks both ExecStart= and ExecStop= setting. Refusing.
```

The service works after making the path to the paster executable absolute. Tested on nixos-unstable.

cc @nbp 
