### PR TITLE
vifm: 0.7.8 -> 0.8

### DIFF
--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -2,14 +2,14 @@
 
 let
   name = "vifm-${version}";
-  version = "0.7.8";
+  version = "0.8";
 
 in stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "mirror://sourceforge/project/vifm/vifm/${name}.tar.bz2";
-    sha256 = "00vnkr60ci6qwh95kzx399xm97g26svxl9i0y77qv99q41nb5ysx";
+    sha256 = "1syyvdcgwnvjxzmpf9f4gfi0ipwmlavg11zr7wiz8qplvi86psv9";
   };
 
   buildInputs = [ utillinux ncurses file libX11 which groff ];


### PR DESCRIPTION
I did test build this, but only with `nix-build -A`. Actually, the `vifm` executeable tries to call another executeable from the package which converts the RC file or something, but as I do not use vifm, I haven't one.

Someone with vifm in use can test this, please?
