### PR TITLE
firejail: Fix source URL (ZHF)

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -6,7 +6,7 @@ let
     version="0.9.26";
     name="${baseName}-${version}";
     hash="12n0kj95hfkzv4jir7j9x0mdpg20bq0fgifjsz1dbsmqi2cspdlq";
-    url="http://softlayer-ams.dl.sourceforge.net/project/firejail/firejail/firejail-0.9.26-rc2.tar.bz2";
+    url="mirror://sourceforge/firejail/firejail/firejail-0.9.26-rc2.tar.bz2";
     sha256="12n0kj95hfkzv4jir7j9x0mdpg20bq0fgifjsz1dbsmqi2cspdlq";
   };
   buildInputs = [


### PR DESCRIPTION
This particular sf.net mirror is down.
