### PR TITLE
ag: init at 0.30.0

### DIFF
--- a/pkgs/tools/misc/ag/default.nix
+++ b/pkgs/tools/misc/ag/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, pkgs }:
+
+stdenv.mkDerivation rec {
+  version = "0.30.0";
+  name = "ag-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/ggreer/the_silver_searcher/archive/${version}.tar.gz";
+    sha256 = "1nx5glgd0x55z073qcaazav5sm0jfvxai2bykkldniv6z601pdm3";
+  };
+
+  buildInputs = with pkgs; [ autoconf automake pkgconfig gnugrep.pcre lzma ];
+
+  configurePhase = ''
+    sed -i 's,:/usr/local/bin/,,' build.sh
+    ./build.sh PREFIX=$out
+  '';
+
+  buildPhase = ''
+    make PREFIX=$out
+  '';
+
+  installPhase = ''
+    make PREFIX=$out prefix=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A code-searching tool similar to ack, but faster";
+    homepage = "http://geoff.greer.fm/ag/";
+    license = license.asl20;
+    platforms = platforms.linux; # can only test on linux
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5831,6 +5831,8 @@ let
 
   afflib = callPackage ../development/libraries/afflib { };
 
+  ag = callPackage ../tools/misc/ag { };
+
   agg = callPackage ../development/libraries/agg { };
 
   allegro = callPackage ../development/libraries/allegro {};


### PR DESCRIPTION
It feels a bit clumsy how I packaged this one (autotools suck, really), suggestions welcome!

Note: This package is also known as the "silver surfer" - maybe we want to package it with this name? Other distros package it with "silversurfer" or something.
