### PR TITLE
Add `which` command to steam's environment

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -14,6 +14,7 @@ buildFHSUserEnv {
       pkgs.gnome2.zenity
       pkgs.xdg_utils
       pkgs.xlibs.xrandr
+      pkgs.which 
     ]
     ++ lib.optional (config.steam.java or false) pkgs.jdk
     ++ lib.optional (config.steam.primus or false) pkgs.primus


### PR DESCRIPTION
Some games use it in their starting scripts (notably FTL does that).
This fixes #8766
