### PR TITLE
emacs-moe-theme: init at 1.0

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -839,6 +839,18 @@ let self = _self // overrides;
     meta = { license = gpl3Plus; };
   };
 
+  moe-theme = melpaBuild rec {
+    pname   = "moe-theme";
+    version = "1.0";
+    src = fetchFromGitHub {
+      owner  = "kuanyui";
+      repo   = "${pname}.el";
+      rev    = "39384a7a9e6886f3a3d79efac4009fcd800a4a14";
+      sha256 = "0i7m15x9sij5wh0gwbijsis8a4jm8izywj7xprk21644ndskvfiz";
+    };
+    meta = { license = gpl3Plus; };
+  };
+
   monokai-theme = melpaBuild rec {
     pname   = "monokai-theme";
     version = "1.0.0";


### PR DESCRIPTION
Very simple, just adds another emacs theme.

I have built and tested it with no problems.
