### PR TITLE
rainbowstream: purify

### DIFF
--- a/pkgs/development/python-modules/rainbowstream/image.patch
+++ b/pkgs/development/python-modules/rainbowstream/image.patch
@@ -1,0 +1,18 @@
+diff --git a/rainbowstream/c_image.py b/rainbowstream/c_image.py
+index f050150..a0fb77d 100644
+--- a/rainbowstream/c_image.py
++++ b/rainbowstream/c_image.py
+@@ -12,11 +12,7 @@ def call_c():
+     """
+     Call the C program for converting RGB to Ansi colors
+     """
+-    library = expanduser('~/.image.so')
+-    sauce = join(dirname(__file__), 'image.c')
+-    if not exists(library) or getmtime(sauce) > getmtime(library):
+-        build = "cc -fPIC -shared -o %s %s" % (library, sauce)
+-        os.system(build + " >/dev/null 2>&1")
++    library = '@CLIB@'
+     image_c = ctypes.cdll.LoadLibrary(library)
+     image_c.init()
+     return image_c.rgb_to_ansi
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7337,11 +7337,23 @@ let
 
     doCheck = false;
 
+    patches = [
+      ../development/python-modules/rainbowstream/image.patch
+    ];
+
+    postPatch = ''
+      clib=$out/${python.sitePackages}/rainbowstream/image.so
+      substituteInPlace rainbowstream/c_image.py \
+        --replace @CLIB@ $clib
+    '';
+
     preBuild = ''
       export LC_ALL="en_US.UTF-8"
     '';
 
     postInstall = ''
+      mkdir -p $out/lib
+      cc -fPIC -shared -o $clib rainbowstream/image.c
       for prog in "$out/bin/"*; do
         wrapProgram "$prog" \
           --prefix PYTHONPATH : "$PYTHONPATH"


### PR DESCRIPTION
This obviates the need for `cc` to be available at run time.
