### PR TITLE
fetchzip: respect the `name` argument

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -12,14 +12,15 @@
 , url
 , ... } @ args:
 
-lib.overrideDerivation (fetchurl ({
+lib.overrideDerivation (fetchurl (rec {
   name = args.name or (baseNameOf url);
 
   recursiveHash = true;
 
   downloadToTemp = true;
 
-  postFetch =
+
+  postFetch = let baseName = baseNameOf ("/" + name); in
     ''
       export PATH=${unzip}/bin:$PATH
       mkdir $out
@@ -28,7 +29,9 @@ lib.overrideDerivation (fetchurl ({
       mkdir "$unpackDir"
       cd "$unpackDir"
 
-      renamed="$TMPDIR/${baseNameOf url}"
+      # FIXME: Uncomment and drop `let baseName =` when NixOS/nix#582 is merged
+      #renamed="$TMPDIR/[dollar]{baseNameOf name}"
+      renamed="$TMPDIR/${baseName}"
       mv "$downloadedFile" "$renamed"
       unpackFile "$renamed"
 


### PR DESCRIPTION
Without this `fetchzip` breaks if `url` doesn’t end with `.zip`, even if proper `name` was given.

The proper fix is to replace `baseNameOf url` with `baseNameOf name`, but this doesn’t work currently due to NixOS/nix#574.
