### PR TITLE
charybdis service: fix preStart script

### DIFF
--- a/nixos/modules/services/networking/charybdis.nix
+++ b/nixos/modules/services/networking/charybdis.nix
@@ -85,10 +85,8 @@ in
         PermissionsStartOnly = true; # preStart needs to run with root permissions
       };
       preStart = ''
-        if ! test -d /var/lib/charybdis; then
-          ${coreutils}/bin/mkdir -p ${cfg.statedir}
-          ${coreutils}/bin/chown ${cfg.user}:${cfg.group} ${cfg.statedir}
-        fi
+        ${coreutils}/bin/mkdir -p ${cfg.statedir}
+        ${coreutils}/bin/chown ${cfg.user}:${cfg.group} ${cfg.statedir}
       '';
 
     };


### PR DESCRIPTION
Before this patch, it was not possible to change Charybdis's state directory, user, or group.  

The patch was _not tested_ by me.

cc @Lassulus 
