### PR TITLE
sqlitebrowser: init at 3.7.0

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchzip, qt4, sqlite, cmake }:
+
+stdenv.mkDerivation rec {
+  version = "3.7.0";
+  name = "sqlitebrowser-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/sqlitebrowser/sqlitebrowser/archive/v${version}.tar.gz";
+    sha256 = "1zsgylnxk4lyg7p6k6pv8d3mh1k0wkfcplh5c5da3x3i9a3qs78j";
+  };
+
+  buildInputs = [ qt4 sqlite cmake ];
+
+  meta = with stdenv.lib; {
+    description = "DB Browser for SQLite";
+    homepage = "http://sqlitebrowser.org/";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux; # can only test on linux
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5732,6 +5732,8 @@ let
     flex = flex_2_5_35;
   };
 
+  sqlitebrowser = callPackage ../development/tools/database/sqlitebrowser { };
+
   sselp = callPackage ../tools/X11/sselp{ };
 
   stm32flash = callPackage ../development/tools/misc/stm32flash { };


### PR DESCRIPTION
This adds sqlitebrowser.

I test build this (with the commit rebased onto the unstable channel, of course. I don't want to build Qt :smile: ) and test started it. Worked for me.
