### PR TITLE
Issue 8152 - Reduce number of attribute set created by replaceChars.

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -107,11 +107,13 @@ rec {
   # replaceChars ["<" ">"] ["&lt;" "&gt;"] "<foo>" returns "&lt;foo&gt;".
   replaceChars = del: new: s:
     let
+      substList = lib.zipLists del new;
       subst = c:
-        (lib.fold
-          (sub: res: if sub.fst == c then sub else res)
-          {fst = c; snd = c;} (lib.zipLists del new)
-        ).snd;
+        let found = lib.findFirst (sub: sub.fst == c) null substList; in
+        if found == null then
+          c
+        else
+          found.snd;
     in
       stringAsChars subst s;
 


### PR DESCRIPTION
This patch reduce the number of attribute sets created by `replaceChars` by replacing the `fold` logic into a `findFirst`, and check if there is any results instead of creating a default one.

Note that this implies that we are using `replaceChars` over ~270000 characters, which is probably another issue on its own.

see https://github.com/NixOS/nixpkgs/issues/8152#issuecomment-121069562 .

@edolstra , merging?
