### PR TITLE
quake3: add botlib patch for amd64

### DIFF
--- a/pkgs/games/quake3/game/botlib.patch
+++ b/pkgs/games/quake3/game/botlib.patch
@@ -1,0 +1,51 @@
+Retrieved from https://bugzilla.icculus.org/show_bug.cgi?id=4331,
+removed path prefix.
+
+  -- nckx <tobias.geerinckx.rice@gmail.com>
+
+PATCH: Bots don't work on 64 bit Intel CPU's
+
+botlib abuses strcpy (source and dest overlap), and the strcpy function for 64
+bit intel CPU's in the latest glibc, does not like this causing the bots to not
+load.
+
+The attached patch fixes this.
+
+Note this patch should be credited to: Andreas Bierfert (andreas.bierfert at
+lowlatency.de)
+
+See: http://bugzilla.redhat.com/show_bug.cgi?id=526338
+
+diff -up quake3-1.36/code/botlib/l_precomp.c~ quake3-1.36/code/botlib/l_precomp.c
+--- code/botlib/l_precomp.c~	2009-04-27 08:42:37.000000000 +0200
++++ code/botlib/l_precomp.c	2009-11-03 21:03:08.000000000 +0100
+@@ -948,7 +948,7 @@ void PC_ConvertPath(char *path)
+ 		if ((*ptr == '\\' || *ptr == '/') &&
+ 				(*(ptr+1) == '\\' || *(ptr+1) == '/'))
+ 		{
+-			strcpy(ptr, ptr+1);
++			memmove(ptr, ptr+1, strlen(ptr));
+ 		} //end if
+ 		else
+ 		{
+diff -up quake3-1.36/code/botlib/l_script.c~ quake3-1.36/code/botlib/l_script.c
+--- code/botlib/l_script.c~	2009-04-27 08:42:37.000000000 +0200
++++ code/botlib/l_script.c	2009-11-03 21:06:11.000000000 +0100
+@@ -1118,7 +1118,7 @@ void StripDoubleQuotes(char *string)
+ {
+ 	if (*string == '\"')
+ 	{
+-		strcpy(string, string+1);
++		memmove(string, string+1, strlen(string));
+ 	} //end if
+ 	if (string[strlen(string)-1] == '\"')
+ 	{
+@@ -1135,7 +1135,7 @@ void StripSingleQuotes(char *string)
+ {
+ 	if (*string == '\'')
+ 	{
+-		strcpy(string, string+1);
++		memmove(string, string+1, strlen(string));
+ 	} //end if
+ 	if (string[strlen(string)-1] == '\'')
+ 	{

--- a/pkgs/games/quake3/game/default.nix
+++ b/pkgs/games/quake3/game/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation {
     # Do an exit() instead of _exit().  This is nice for gcov.
     # Upstream also seems to do this.
     ./exit.patch
+
+    # No bots on amd64 without this patch.
+    ./botlib.patch
   ];
 
   buildInputs = [ x11 SDL mesa openal gcc46 ];


### PR DESCRIPTION
botlib abuses strcpy (source and dest overlap), and the strcpy function for 64
bit intel CPU's in the latest glibc, does not like this causing the bots to not
load.

cc maintainer @edolstra.
