### PR TITLE
tribler: strip pngs

### DIFF
--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, makeWrapper, nettools, libtorrentRasterbar
+{ stdenv, fetchurl, pythonPackages, makeWrapper, nettools, libtorrentRasterbar, imagemagick
 , enablePlayer ? false, vlc ? null }:
 
 
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     pythonPackages.python
     pythonPackages.wrapPython
     makeWrapper
+    imagemagick
   ];
 
   pythonPath = [
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
 
   installPhase =
     ''
+      find . -name '*.png' -exec convert -strip {} {} \;
       # Nasty hack; call wrapPythonPrograms to set program_PYTHONPATH.
       wrapPythonPrograms
 


### PR DESCRIPTION
This prevents libpng exceptions from being thrown.

Upstream pull request: https://github.com/Tribler/tribler/pull/1561

cc: @vcunat @pSub
