### PR TITLE
Add error context on module arguments evaluation.

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -91,9 +91,11 @@ rec {
     let
       toClosureList = file: parentKey: imap (n: x:
         if isAttrs x || isFunction x then
-          unifyModuleSyntax file "${parentKey}:anon-${toString n}" (unpackSubmodule applyIfFunction x args)
+          let key = "${parentKey}:anon-${toString n}"; in
+          unifyModuleSyntax file key (unpackSubmodule (applyIfFunction key) x args)
         else
-          unifyModuleSyntax (toString x) (toString x) (applyIfFunction (import x) args));
+          let file = toString x; key = toString x; in
+          unifyModuleSyntax file key (applyIfFunction key (import x) args));
     in
       builtins.genericClosure {
         startSet = toClosureList unknownModule "" modules;
@@ -122,7 +124,7 @@ rec {
         config = removeAttrs m ["key" "_file" "require" "imports"];
       };
 
-  applyIfFunction = f: arg@{ config, options, lib, ... }: if isFunction f then
+  applyIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then
     let
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the
@@ -137,11 +139,18 @@ rec {
       # not their values.  The values are forwarding the result of the
       # evaluation of the option.
       requiredArgs = builtins.attrNames (builtins.functionArgs f);
+      context = name: ''while evaluating the module argument `${name}' in "${key}":'';
       extraArgs = builtins.listToAttrs (map (name: {
         inherit name;
-        value = config._module.args.${name};
+        value = addErrorContext (context name)
+          (args.${name} or config._module.args.${name});
       }) requiredArgs);
-    in f (extraArgs // arg)
+
+      # Note: we append in the opposite order such that we can add an error
+      # context on the explicited arguments of "args" too. This update
+      # operator is used to make the "args@{ ... }: with args.lib;" notation
+      # works.
+    in f (args // extraArgs)
   else
     f;
 

--- a/lib/tests/modules/define-_module-args-custom.nix
+++ b/lib/tests/modules/define-_module-args-custom.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+
+{
+  config = {
+    _module.args.custom = true;
+  };
+}

--- a/lib/tests/modules/define-enable-with-custom-arg.nix
+++ b/lib/tests/modules/define-enable-with-custom-arg.nix
@@ -2,7 +2,6 @@
 
 {
   config = {
-    _module.args.custom = true;
     enable = custom;
   };
 }

--- a/lib/tests/modules/import-custom-arg.nix
+++ b/lib/tests/modules/import-custom-arg.nix
@@ -1,0 +1,6 @@
+{ lib, custom, ... }:
+
+{
+  imports = []
+  ++ lib.optional custom ./define-enable-force.nix;
+}


### PR DESCRIPTION
This patch adds additional error context to the evaluation of module arguments.  This display one extra line when `--show-trace` is used.

```
while evaluating the module argument `pkgs' in "/home/nicolas/nixos-dev/nixpkgs/foo.nix":
infinite recursion encountered
```

This way, this would be easier for users to analyze the error messages caused by the recent changes.
This patch add tests to ensure that both lines appear in the output, when an argument is used for computing `imports`-ed files, or used for computing `with pkgs.lib;`.

cc @shlevy @edolstra.
