### PR TITLE
window-manager service: add notion

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -16,6 +16,7 @@ in
     ./i3.nix
     ./metacity.nix
     ./openbox.nix
+    ./notion.nix
     ./ratpoison.nix
     ./sawfish.nix
     ./stumpwm.nix

--- a/nixos/modules/services/x11/window-managers/notion.nix
+++ b/nixos/modules/services/x11/window-managers/notion.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.notion;
+in
+
+{
+  options = {
+    services.xserver.windowManager.notion = {
+      enable = mkOption {
+        default = false;
+        example = true;
+        description = "Enable the notion tiling window manager.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.windowManager = {
+      session = [{
+        name = "notion";
+        start = ''
+          ${pkgs.notion}/bin/notion &
+          waitPID=$!
+        '';
+      }];
+    };
+    environment.systemPackages = [ pkgs.notion ];
+  };
+}


### PR DESCRIPTION
Add the notion window manager to the windowManager service definition.
