### PR TITLE
gnome-terminal: use GIO_EXTRA_MODULES in wrapper

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/gnome-terminal/default.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     for f in "$out/libexec/gnome-terminal-server"; do
-      wrapProgram "$f" --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH"
+      wrapProgram "$f" \
+        --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
+        --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
     done
   '';
 


### PR DESCRIPTION
I'm using gnome-terminal outside of a Gnome session (in xmonad) and it fails to persist settings across restarts.  I get a message `Using the 'memory' GSettings backend.`

I've made the fix referenced in #5433 and #6331, which has fixed the issue for me.

Build has been tested against latest master.

cc @lethalman 
