### PR TITLE
oraclejdk: 8u45 -> 8u51

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "45";
+  patchVersion = "51";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1y1zymydd1azv14r0hh12zjr8k64wa8wfdbz8sn1css84aqwl87d";
-  sha256_x86_64 = "0v9ilahx03isxdzh4ryv1bqmmzppckickz22hvgzs785769cm67j";
+  sha256_i686 = "0awzgs090n2cj6a5mlla0pgxk0y6aslhm6024pqrnxgai1fkmm1z";
+  sha256_x86_64 = "1wggrcr2gjwkv5bawgcw86h6rhyzw0jphxm1sfwcvhjirh99056p";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
“This release includes important security fixes. Oracle strongly recommends that all Java SE 8 users upgrade to this release”
http://www.oracle.com/technetwork/java/javase/downloads/index.html

Tested for x86_64 platform. Swing and AWT are working.

Oracle JDK 7 is in “End of Public Updates” state. No updates are publicly available.
