### PR TITLE
numix-icon-theme: Don't use fetchurl on dynamically generated GitHub tarballs (ZHF)

### DIFF
--- a/pkgs/data/icons/numix-icon-theme/default.nix
+++ b/pkgs/data/icons/numix-icon-theme/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   version = "2c11fbfcee";
 
   package-name = "numix-icon-theme";
-  
+
   name = "${package-name}-20150302";
 
-  buildInputs = [ unzip ];
-  
-  src = fetchurl {
-    url = "https://github.com/numixproject/${package-name}/archive/${version}.zip";
-    sha256 = "61dc170b8a70b20a9075f06e1668d6bd8907a6db0ef9e3568c473296d0f351e1";
+  src = fetchFromGitHub {
+    owner = "numixproject";
+    repo = package-name;
+    rev = version;
+    sha256 = "1bjh2j4vqk9s31syv7ig3hwpp5z0n6sx74iz332y0wdz6ngj5x08";
   };
 
   dontBuild = true;
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     install -dm 755 $out/share/icons
     cp -dr --no-preserve='ownership' Numix{,-Light} $out/share/icons/
   '';
-  
+
   meta = {
     description = "Numix icon theme";
     homepage = https://numixproject.org;


### PR DESCRIPTION
Fixes hydra failure: http://hydra.nixos.org/build/23524342/nixlog/5/raw
