### PR TITLE
xen: fixes (authored by michalpalka)

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -121,6 +121,10 @@ in
         "xenfs"
       ];
 
+    # The xenfs module is needed in system.activationScripts.xen, but
+    # the modprobe command there fails silently. Include xenfs in the
+    # initrd as a work around.
+    boot.initrd.kernelModules = [ "xenfs" ];
 
     # The radeonfb kernel module causes the screen to go black as soon
     # as it's loaded, so don't load it.
@@ -182,6 +186,9 @@ in
         { source = "${pkgs.xen}/etc/xen/scripts";
           target = "xen/scripts";
         }
+        { source = "${pkgs.xen}/etc/default/xendomains";
+          target = "default/xendomains";
+        }
       ];
 
     # Xen provides udev rules.
@@ -199,7 +206,8 @@ in
         rm -f "$XENSTORED_ROOTDIR"/tdb* &>/dev/null
 
         mkdir -p /var/run
-        ${optionalString cfg.trace "mkdir -p /var/log/xen"}
+        mkdir -p /var/log/xen # Running xl requires /var/log/xen and /var/lib/xen,
+        mkdir -p /var/lib/xen # so we create them here unconditionally.
         grep -q control_d /proc/xen/capabilities
         '';
       serviceConfig.ExecStart = ''

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -147,6 +147,9 @@ stdenv.mkDerivation {
         --replace /etc/xen/scripts/hotplugpath.sh $out/etc/xen/scripts/hotplugpath.sh \
         --replace /bin/ls ls
 
+      substituteInPlace tools/hotplug/Linux/xendomains \
+        --replace /bin/ls ls
+
       # Xen's tools and firmares need various git repositories that it
       # usually checks out at time using git.  We can't have that.
       ${flip concatMapStrings xenConfig.toolsGits (x: let src = fetchgit x.git; in ''


### PR DESCRIPTION
Xen required a few changes in order to be usable:
- Include xenfs module in initrd as loading it in the activation
  script was failing.
- Include /etc/default/xendomains, which is needed by
  xen-domains service.
- Create /var/log/xen and /var/lib/xen directories in
  the xen-store service, which are needed by the xl command.
  The directories could be created by any other script as long as
  they are guaranteed to exist before xl is called.
- Fix a reference to /bin/ls in the xendomains script.
