### PR TITLE
cassandra: init at 1.2.19

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -35,6 +35,7 @@
   aycanirican = "Aycan iRiCAN <iricanaycan@gmail.com>";
   balajisivaraman = "Balaji Sivaraman<sivaraman.balaji@gmail.com>";
   bbenoist = "Baptist BENOIST <return_0@live.com>";
+  bcarrell = "Brandon Carrell <brandoncarrell@gmail.com>";
   bcdarwin = "Ben Darwin <bcdarwin@gmail.com>";
   bdimcheff = "Brandon Dimcheff <brandon@dimcheff.com>";
   bennofs = "Benno Fünfstück <benno.fuenfstueck@gmail.com>";

--- a/pkgs/servers/nosql/cassandra/1.2.nix
+++ b/pkgs/servers/nosql/cassandra/1.2.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchurl
+, jre
+, python
+, makeWrapper
+, gawk
+, bash
+, getopt
+, procps
+}:
+
+let
+
+  version = "1.2.19";
+  sha256 = "0zkq3ggpk8ra2siar43vmrn6lmvn902p1g2lrgb46ak1vii6w30w";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "cassandra-${version}";
+
+  src = fetchurl {
+    inherit sha256;
+    url = "http://apache.cs.utah.edu/cassandra/${version}/apache-${name}-bin.tar.gz";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir $out
+    mv * $out
+
+    for cmd in cassandra nodetool sstablekeys sstableloader sstableupgrade
+      do wrapProgram $out/bin/$cmd \
+        --set JAVA_HOME ${jre} \
+        --prefix PATH : ${bash}/bin \
+        --prefix PATH : ${getopt}/bin \
+        --prefix PATH : ${gawk}/bin \
+        --prefix PATH : ${procps}/bin
+    done
+
+    wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://cassandra.apache.org/;
+    description = "A massively scalable open source NoSQL database";
+    platforms = with platforms; all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcarrell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8798,6 +8798,7 @@ let
 
   cadvisor = callPackage ../servers/monitoring/cadvisor { };
 
+  cassandra_1_2 = callPackage ../servers/nosql/cassandra/1.2.nix { };
   cassandra_2_0 = callPackage ../servers/nosql/cassandra/2.0.nix { };
   cassandra_2_1 = callPackage ../servers/nosql/cassandra/2.1.nix { };
   cassandra = cassandra_2_1;


### PR DESCRIPTION
Cassandra 1.2 is currently not available (only 2+), so I made an attempt at packaging it.  Disclaimer:  I'm entirely new at this.

The expression is nearly entirely cloned from the 2.0+ versions, but it appears to work fine for 1.2 as well.
