### PR TITLE
libwmf: fix some security issues

### DIFF
--- a/pkgs/development/libraries/libwmf/CVE-2006-3376.patch
+++ b/pkgs/development/libraries/libwmf/CVE-2006-3376.patch
@@ -1,0 +1,28 @@
+--- libwmf-0.2.8.4.orig/src/player.c
++++ libwmf-0.2.8.4/src/player.c
+@@ -23,6 +23,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <stdint.h>
+ #include <string.h>
+ #include <math.h>
+ 
+@@ -132,8 +133,14 @@
+ 		}
+ 	}
+ 
+-/*	P->Parameters = (unsigned char*) wmf_malloc (API,(MAX_REC_SIZE(API)-3) * 2 * sizeof (unsigned char));
+- */	P->Parameters = (unsigned char*) wmf_malloc (API,(MAX_REC_SIZE(API)  ) * 2 * sizeof (unsigned char));
++	if (MAX_REC_SIZE(API) > UINT32_MAX / 2)
++	{
++		API->err = wmf_E_InsMem;
++		WMF_DEBUG (API,"bailing...");
++		return (API->err);
++	}
++
++ 	P->Parameters = (unsigned char*) wmf_malloc (API,(MAX_REC_SIZE(API)  ) * 2 * sizeof (unsigned char));
+ 
+ 	if (ERR (API))
+ 	{	WMF_DEBUG (API,"bailing...");
+

--- a/pkgs/development/libraries/libwmf/CVE-2009-1364.patch
+++ b/pkgs/development/libraries/libwmf/CVE-2009-1364.patch
@@ -1,0 +1,11 @@
+--- libwmf-0.2.8.4.orig/src/extra/gd/gd_clip.c
++++ libwmf-0.2.8.4/src/extra/gd/gd_clip.c
+@@ -70,6 +70,7 @@
+ 	{	more = gdRealloc (im->clip->list,(im->clip->max + 8) * sizeof (gdClipRectangle));
+ 		if (more == 0) return;
+ 		im->clip->max += 8;
++		im->clip->list = more;
+ 	}
+ 	im->clip->list[im->clip->count] = (*rect);
+ 	im->clip->count++;
+

--- a/pkgs/development/libraries/libwmf/CVE-2015-0848+4588+4695+4696.patch
+++ b/pkgs/development/libraries/libwmf/CVE-2015-0848+4588+4695+4696.patch
@@ -1,0 +1,186 @@
+--- libwmf-0.2.8.4.orig/src/player/meta.h
++++ libwmf-0.2.8.4/src/player/meta.h
+@@ -1565,7 +1565,7 @@ static int meta_rgn_create (wmfAPI* API,
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -2142,7 +2142,7 @@ static int meta_dib_brush (wmfAPI* API,w
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -2593,9 +2593,10 @@ static int meta_dc_restore (wmfAPI* API,
+ 		polyrect.BR = 0;
+ 
+ 		polyrect.count = 0;
++	
++		if (FR->region_clip) FR->region_clip (API,&polyrect);
+ 	}
+ 
+-	if (FR->region_clip) FR->region_clip (API,&polyrect);
+ 
+ 	return (changed);
+ }
+@@ -3067,7 +3068,7 @@ static int meta_pen_create (wmfAPI* API,
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3181,7 +3182,7 @@ static int meta_brush_create (wmfAPI* AP
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3288,7 +3289,7 @@ static int meta_font_create (wmfAPI* API
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+@@ -3396,7 +3397,7 @@ static int meta_palette_create (wmfAPI*
+ 	objects = P->objects;
+ 
+ 	i = 0;
+-	while (objects[i].type && (i < NUM_OBJECTS (API))) i++;
++	while ((i < NUM_OBJECTS (API)) && objects[i].type) i++;
+ 
+ 	if (i == NUM_OBJECTS (API))
+ 	{	WMF_ERROR (API,"Object out of range!");
+--- libwmf-0.2.8.4.orig/src/ipa/ipa.h
++++ libwmf-0.2.8.4/src/ipa/ipa.h
+@@ -48,7 +48,7 @@ static int            ReadBlobByte (BMPS
+ static unsigned short ReadBlobLSBShort (BMPSource*);
+ static unsigned long  ReadBlobLSBLong (BMPSource*);
+ static long           TellBlob (BMPSource*);
+-static void           DecodeImage (wmfAPI*,wmfBMP*,BMPSource*,unsigned int,unsigned char*);
++static int            DecodeImage (wmfAPI*,wmfBMP*,BMPSource*,unsigned int,unsigned char*);
+ static void           ReadBMPImage (wmfAPI*,wmfBMP*,BMPSource*);
+ static int            ExtractColor (wmfAPI*,wmfBMP*,wmfRGB*,unsigned int,unsigned int);
+ static void           SetColor (wmfAPI*,wmfBMP*,wmfRGB*,unsigned char,unsigned int,unsigned int);
+--- libwmf-0.2.8.4.orig/src/ipa/ipa/bmp.h
++++ libwmf-0.2.8.4/src/ipa/ipa/bmp.h
+@@ -859,7 +859,7 @@ static long TellBlob (BMPSource* src)
+ %
+ %
+ */
+-static void DecodeImage (wmfAPI* API,wmfBMP* bmp,BMPSource* src,unsigned int compression,unsigned char* pixels)
++static int DecodeImage (wmfAPI* API,wmfBMP* bmp,BMPSource* src,unsigned int compression,unsigned char* pixels)
+ {	int byte;
+ 	int count;
+ 	int i;
+@@ -870,12 +870,14 @@ static void DecodeImage (wmfAPI* API,wmf
+ 	U32 u;
+ 
+ 	unsigned char* q;
++	unsigned char* end;
+ 
+ 	for (u = 0; u < ((U32) bmp->width * (U32) bmp->height); u++) pixels[u] = 0;
+ 
+ 	byte = 0;
+ 	x = 0;
+ 	q = pixels;
++	end = pixels + bmp->width * bmp->height;
+ 
+ 	for (y = 0; y < bmp->height; )
+ 	{	count = ReadBlobByte (src);
+@@ -884,7 +886,10 @@ static void DecodeImage (wmfAPI* API,wmf
+ 		{	/* Encoded mode. */
+ 			byte = ReadBlobByte (src);
+ 			for (i = 0; i < count; i++)
+-			{	if (compression == 1)
++			{	
++				if (q == end)
++					return 0;
++			 	if (compression == 1)
+ 				{	(*(q++)) = (unsigned char) byte;
+ 				}
+ 				else
+@@ -896,13 +901,15 @@ static void DecodeImage (wmfAPI* API,wmf
+ 		else
+ 		{	/* Escape mode. */
+ 			count = ReadBlobByte (src);
+-			if (count == 0x01) return;
++			if (count == 0x01) return 1;
+ 			switch (count)
+ 			{
+ 			case 0x00:
+ 			 {	/* End of line. */
+ 				x = 0;
+ 				y++;
++				if (y >= bmp->height)
++					return 0;
+ 				q = pixels + y * bmp->width;
+ 				break;
+ 			 }
+@@ -910,13 +917,20 @@ static void DecodeImage (wmfAPI* API,wmf
+ 			 {	/* Delta mode. */
+ 				x += ReadBlobByte (src);
+ 				y += ReadBlobByte (src);
++				if (y >= bmp->height)
++					return 0;
++				if (x >= bmp->width)
++					return 0;
+ 				q = pixels + y * bmp->width + x;
+ 				break;
+ 			 }
+ 			default:
+ 			 {	/* Absolute mode. */
+ 				for (i = 0; i < count; i++)
+-				{	if (compression == 1)
++				{
++					if (q == end)
++						return 0;
++					if (compression == 1)
+ 					{	(*(q++)) = ReadBlobByte (src);
+ 					}
+ 					else
+@@ -943,7 +957,7 @@ static void DecodeImage (wmfAPI* API,wmf
+ 	byte = ReadBlobByte (src);  /* end of line */
+ 	byte = ReadBlobByte (src);
+ 
+-	return;
++	return 1;
+ }
+ 
+ /*
+@@ -1143,8 +1157,18 @@ static void ReadBMPImage (wmfAPI* API,wm
+ 		}
+ 	}
+ 	else
+-	{	/* Convert run-length encoded raster pixels. */
+-		DecodeImage (API,bmp,src,(unsigned int) bmp_info.compression,data->image);
++	{
++		if (bmp_info.bits_per_pixel == 8)	/* Convert run-length encoded raster pixels. */
++		{
++			if (!DecodeImage (API,bmp,src,(unsigned int) bmp_info.compression,data->image))
++			{	WMF_ERROR (API,"corrupt bmp");
++				API->err = wmf_E_BadFormat;
++			}
++		}
++		else
++		{	WMF_ERROR (API,"Unexpected pixel depth");
++			API->err = wmf_E_BadFormat;
++		}
+ 	}
+ 
+ 	if (ERR (API))

--- a/pkgs/development/libraries/libwmf/default.nix
+++ b/pkgs/development/libraries/libwmf/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib imagemagick libpng pkgconfig glib freetype libjpeg libxml2 ];
 
+  patches = [
+    ./CVE-2006-3376.patch ./CVE-2009-1364.patch
+    ./CVE-2015-0848+4588+4695+4696.patch
+  ];
+
   meta = {
     description = "WMF library from wvWare";
   };


### PR DESCRIPTION
The added patches (sourced from Debian) fixes the following security issues:
- CVE-2006-3376
- CVE-2009-1364
- CVE-2015-0848
- CVE-2015-4588
- CVE-2015-4695
- CVE-2015-4696
