### PR TITLE
cpptest: init at 1.1.2

### DIFF
--- a/pkgs/development/libraries/cpptest/default.nix
+++ b/pkgs/development/libraries/cpptest/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "cpptest-1.1.2";
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/cpptest/cpptest/${name}/${name}.tar.gz";
+    sha256 = "09v070a9dv6zq6hgj4v67i31zsis3s96psrnhlq9g4vhdcaxykwy";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://cpptest.sourceforge.net/;
+    description = "Simple C++ unit testing framework";
+    maintainers = with maintainers; [ bosu ];
+    license = stdenv.lib.licenses.lgpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5406,6 +5406,8 @@ let
 
   framac = callPackage ../development/tools/analysis/frama-c { };
 
+  cpptest = callPackage ../development/libraries/cpptest { };
+
   cppi = callPackage ../development/tools/misc/cppi { };
 
   cproto = callPackage ../development/tools/misc/cproto { };


### PR DESCRIPTION
CppTest is a portable and powerful, yet simple, unit testing framework for handling automated tests in C++
