### PR TITLE
php70: init at 7.0beta1

### DIFF
--- a/pkgs/development/interpreters/php/7.0.nix
+++ b/pkgs/development/interpreters/php/7.0.nix
@@ -1,0 +1,8 @@
+{ callPackage, apacheHttpd  }:
+callPackage ./generic.nix {
+  phpVersion = "7.0.0beta1";
+  url = "https://downloads.php.net/~ab/php-7.0.0beta1.tar.bz2";
+  sha = "1pj3ysfhswg2r370ivp33fv9zbcl3yvhmxgnc731k08hv6hmd984";
+  apacheHttpd = apacheHttpd;
+  php7 = true;
+}

--- a/pkgs/development/interpreters/php/fix-paths-php7.patch
+++ b/pkgs/development/interpreters/php/fix-paths-php7.patch
@@ -1,0 +1,23 @@
+--- php-7.0.0beta1/configure	    2015-07-10 12:11:41.810045613 +0000
++++ php-7.0.0beta1-new/configure	2015-07-17 16:10:21.775528267 +0000
+@@ -6172,7 +6172,7 @@
+     as_fn_error $? "Please note that Apache version >= 2.0.44 is required" "$LINENO" 5
+   fi
+ 
+-  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++  APXS_LIBEXECDIR="$prefix/modules"
+   if test -z `$APXS -q SYSCONFDIR`; then
+     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+@@ -37303,9 +37303,7 @@
+ 
+ 
+ if test "$PHP_GETTEXT" != "no"; then
+-  for i in $PHP_GETTEXT /usr/local /usr; do
+-    test -r $i/include/libintl.h && GETTEXT_DIR=$i && break
+-  done
++  GETTEXT_DIR=$PHP_GETTEXT
+ 
+   if test -z "$GETTEXT_DIR"; then
+     as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5
+

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -4,7 +4,8 @@
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
 , uwimap, pam, gmp
 
-, phpVersion, apacheHttpd, sha }:
+, phpVersion, apacheHttpd, sha
+, php7 ? false, url ? null }:
 
 let
   libmcryptOverride = libmcrypt.override { disablePosixThreads = true; };
@@ -212,7 +213,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     imapSupport = config.php.imap or true;
     ldapSupport = config.php.ldap or true;
     mhashSupport = config.php.mhash or true;
-    mysqlSupport = config.php.mysql or true;
+    mysqlSupport = (!php7) && (config.php.mysql or true);
     mysqliSupport = config.php.mysqli or true;
     pdo_mysqlSupport = config.php.pdo_mysql or true;
     libxml2Support = config.php.libxml2 or true;
@@ -220,7 +221,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     bcmathSupport = config.php.bcmath or true;
     socketsSupport = config.php.sockets or true;
     curlSupport = config.php.curl or true;
-    curlWrappersSupport = config.php.curlWrappers or true;
+    curlWrappersSupport = (!php7) && (config.php.curlWrappers or true);
     gettextSupport = config.php.gettext or true;
     pcntlSupport = config.php.pcntl or true;
     postgresqlSupport = config.php.postgresql or true;
@@ -241,7 +242,7 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     ftpSupport = config.php.ftp or true;
     fpmSupport = config.php.fpm or true;
     gmpSupport = config.php.gmp or true;
-    mssqlSupport = config.php.mssql or (!stdenv.isDarwin);
+    mssqlSupport = (!php7) && (config.php.mssql or (!stdenv.isDarwin));
     ztsSupport = config.php.zts or false;
     calendarSupport = config.php.calendar or true;
   };
@@ -267,7 +268,10 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
   '';
 
   src = fetchurl {
-    url = "http://www.php.net/distributions/php-${version}.tar.bz2";
+    url = if url == null then
+      "http://www.php.net/distributions/php-${version}.tar.bz2"
+    else
+      url;
     sha256 = sha;
   };
 
@@ -278,6 +282,10 @@ composableDerivation.composableDerivation {} ( fixed : let inherit (fixed.fixed)
     maintainers = with maintainers; [ globin ];
   };
 
-  patches = [ ./fix-paths.patch ];
+  patches = if !php7 then
+    [ ./fix-paths.patch ]
+  else
+    [ ./fix-paths-php7.patch ]
+  ;
 
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5003,6 +5003,8 @@ let
 
   php56 = callPackage ../development/interpreters/php/5.6.nix { };
 
+  php70 = callPackage ../development/interpreters/php/7.0.nix { };
+
   picoc = callPackage ../development/interpreters/picoc {};
 
   picolisp = callPackage ../development/interpreters/picolisp {};


### PR DESCRIPTION
The first beta of php7 has been released. This enables developers to
test their code for breakage in preparation for the stable release and
allows us to make sure we don't have any bugs in the packaging prior to
the stable release.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/8871)

<!-- Reviewable:end -->
