### PR TITLE
canto-{curses,daemon}: 0.9.{3,1} -> 0.9.{4,3}

### DIFF
--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python34Packages, readline, ncurses, canto-daemon }:
 
 python34Packages.buildPythonPackage rec {
-  version = "0.9.3";
+  version = "0.9.4";
   name = "canto-curses-${version}";
 
   src = fetchFromGitHub {
     owner = "themoken";
     repo = "canto-curses";
     rev = "v${version}";
-    sha256 = "1k3rbniyfdbqhbkclgrrvfjgvfl5if4c2rbgpcb6l2l5v6i1y742";
+    sha256 = "0g1ckcb9xcfb0af17zssiqcrfry87agx578vd40nb6gbw90ql4fn";
   };
 
   buildInputs = [ readline ncurses canto-daemon ];

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python34Packages, }:
 
 python34Packages.buildPythonPackage rec {
-  version = "0.9.1";
+  version = "0.9.3";
   name = "canto-daemon-${version}";
   namePrefix = "";
 
@@ -9,7 +9,7 @@ python34Packages.buildPythonPackage rec {
     owner = "themoken";
     repo = "canto-next";
     rev = "v${version}";
-    sha256 = "14lh6x0yz2asspwdi1ims01589r79q0dv77vq61gfjk5wiwfbdwa";
+    sha256 = "1x875qdyhab89nwwa2bzbfvcrkx34zwyy8dlbxm8wg3vz9b78l61";
   };
 
   propagatedBuildInputs = with python34Packages; [ feedparser ];


### PR DESCRIPTION
A very detailed changelog and discussion can be found here:

http://codezen.org/canto-ng/news/

This change was built locally and tested by me. There will be changes
noticable in the `canto-curses` interface since color support has been
reworked. For more details follow the hint in `canto-curses` or read the
changelog/manual liked to above. There also have been many
under-the-hood improvements which can also be found in the link above.
