### PR TITLE
pkginfo: init at 1.2.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2272,6 +2272,33 @@ let
     };
   };
 
+  pkginfo = buildPythonPackage rec {
+    version = "1.2.1";
+    name = "pkginfo-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/pkginfo/${name}.tar.gz";
+      sha256 = "0g0g6avplfqw1adzqybbrh1a2z0kfjl8qn3annkrc7w3ibz6sgxd";
+    };
+
+    doCheck = false; # I don't know why, but with doCheck = true it fails.
+
+    meta = {
+      homepage = https://pypi.python.org/pypi/pkginfo;
+      license = licenses.mit;
+      description = "Query metadatdata from sdists / bdists / installed packages.";
+
+      longDescription = ''
+        This package provides an API for querying the distutils metadata
+        written in the PKG-INFO file inside a source distriubtion (an sdist)
+        or a binary distribution (e.g., created by running bdist_egg). It can
+        also query the EGG-INFO directory of an installed distribution, and the
+        *.egg-info stored in a “development checkout” (e.g, created by running
+        setup.py develop).
+      '';
+    };
+  };
+
   pretend = buildPythonPackage rec {
     name = "pretend-1.0.8";
 


### PR DESCRIPTION
Test build based on unstable.

I guess we should wait with merging this until the branch off of release-15.07 happened. Also I don't know why I have to `doCheck = false;` here. Maybe some python guy can investigate?

(I need this package for an update of `khal` from 0.5.0 to 0.6.0)
