### PR TITLE
edk2, OVMF: Fix build on GCC 4.9

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -46,7 +46,7 @@ edk2 = stdenv.mkDerivation {
       configurePhase = ''
         mkdir -v Conf
         sed -e 's|Nt32Pkg/Nt32Pkg.dsc|${projectDscPath}|' -e \
-          's|MYTOOLS|GCC48|' -e 's|IA32|${targetArch}|' -e 's|DEBUG|RELEASE|'\
+          's|MYTOOLS|GCC49|' -e 's|IA32|${targetArch}|' -e 's|DEBUG|RELEASE|'\
           < ${edk2}/BaseTools/Conf/target.template > Conf/target.txt
         sed -e 's|DEFINE GCC48_IA32_PREFIX       = /usr/bin/|DEFINE GCC48_IA32_PREFIX       = ""|' \
           -e 's|DEFINE GCC48_X64_PREFIX        = /usr/bin/|DEFINE GCC48_X64_PREFIX        = ""|' \


### PR DESCRIPTION
The toolchain must be correctly specified in the OVMF build or it fails
with 'Unsupported section alignment':

http://hydra.nixos.org/build/23859056

Tested with `tests.bootUefiUsb.x86_64-linux` and `tests.bootUefiCdrom.x86_64-linux`.
