### PR TITLE
weston: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -6,11 +6,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "weston-${wayland.version}";
+  name = "weston-${version}";
+  version = "1.8.0";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1kb6a494j56sh7iy43xwkjlr3bh0nnkq4bkimwj6qirzbya12i8w";
+    sha256 = "04nkbbdglh0pqznxkdqvak3pc53jmz24d0658bn5r0cf6agycqw9";
   };
 
   buildInputs = [


### PR DESCRIPTION
Wayland was updated from 1.7.0 to 1.8.1, however there is no
corresponding 1.8.1 release for Weston.

Tested build against current master.

cc @wkennington 
