### PR TITLE
nfs-utils, rpcbind: Update packages to fix nfs3 test

### DIFF
--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -1,18 +1,18 @@
 { fetchurl, stdenv, tcp_wrappers, utillinux, libcap, libtirpc, libevent, libnfsidmap
-, lvm2, e2fsprogs, python
+, lvm2, e2fsprogs, python, sqlite
 }:
 
 stdenv.mkDerivation rec {
-  name = "nfs-utils-1.2.5";
+  name = "nfs-utils-1.3.2"; # NOTE: when updating, remove the HACK BUG FIX below
 
   src = fetchurl {
     url = "mirror://sourceforge/nfs/${name}.tar.bz2";
-    sha256 = "16ssfkj36ljifyaskgwpd3ys8ylhi5gasq88aha3bhg5dr7yv59m";
+    sha256 = "1xwilpdr1vizq2yhpzxpwqqr9f8kn0dy2wcpc626mf30ybp7572v";
   };
 
   buildInputs =
     [ tcp_wrappers utillinux libcap libtirpc libevent libnfsidmap
-      lvm2 e2fsprogs python
+      lvm2 e2fsprogs python sqlite
     ];
 
   # FIXME: Add the dependencies needed for NFSv4 and TI-RPC.
@@ -32,14 +32,15 @@ stdenv.mkDerivation rec {
       done
       sed -i s,/usr/sbin,$out/sbin, utils/statd/statd.c
 
-      # https://bugzilla.redhat.com/show_bug.cgi?id=749195
-      sed -i s,PAGE_SIZE,getpagesize\(\), utils/blkmapd/device-process.c
+      # HACK BUG FIX: needed for 1.3.2
+      # http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=commit;h=17a3e5bffb7110d46de1bf42b64b90713ff5ea50
+      sed -e 's,daemon_init(!,daemon_init(,' -i utils/statd/statd.c
     '';
 
   preBuild =
     ''
       makeFlags="sbindir=$out/sbin"
-      installFlags="statedir=$TMPDIR" # hack to make `make install' work
+      installFlags="statedir=$TMPDIR statdpath=$TMPDIR" # hack to make `make install' work
     '';
 
   # One test fails on mips.

--- a/pkgs/servers/rpcbind/default.nix
+++ b/pkgs/servers/rpcbind/default.nix
@@ -1,16 +1,19 @@
 { fetchurl, stdenv, pkgconfig, libtirpc
 , useSystemd ? true, systemd }:
 
-let version = "0.2.3";
+let version = "1.0.7";
 in stdenv.mkDerivation rec {
   name = "rpcbind-${version}";
   
   src = fetchurl {
     url = "mirror://sourceforge/rpcbind/${version}/${name}.tar.bz2";
-    sha256 = "0yyjzv4161rqxrgjcijkrawnk55rb96ha0pav48s03l2klx855wq";
+    sha256 = "14vl0kmavc1fay630f4w8l1hjfzhmcqm8d0akzahhgymh5fw1f7r";
   };
 
   patches = [ ./sunrpc.patch ];
+  postPatch = ''
+    sed -e 's|/usr/include/tirpc|${libtirpc}/include/tirpc|' -i src/Makefile.am -i src/Makefile.in
+  '';
 
   buildInputs = [ libtirpc ]
              ++ stdenv.lib.optional useSystemd systemd;


### PR DESCRIPTION
Unbreaks the NFSv3 test, which has started to fail since the staging merge due to `rpc.mountd` segfaulting: http://hydra.nixos.org/build/23867058/nixlog/1/raw. I don't know particularly why it was broken there, but updating the packages seems to make it work.
