### PR TITLE
source-code-pro version 2.010

### DIFF
--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -2,11 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "source-code-pro-${version}";
-  version = "1.017";
+  version = "2.010";
+  version_italic = "1.030";
 
   src = fetchurl {
-    url="https://github.com/adobe-fonts/source-code-pro/archive/${version}R.tar.gz";
-    sha256="03q4a0f142c6zlngv6kjaik52y0yzwq5z5qj3j0fvvcbfy9sanjr";
+    url="https://github.com/adobe-fonts/source-code-pro/archive/${version}R-ro/${version_italic}R-it.tar.gz";
+    sha256="12wijgxrdzqxpw2q420nsq9aj454vhg3rq6n81jbqvgzxhxjpf7w";
   };
 
   phases = "unpackPhase installPhase";


### PR DESCRIPTION
The font includes a separate versioning scheme for the italic fonts, so
we encode that as well.
