### PR TITLE
gxmessage: init at 3.4.3

### DIFF
--- a/pkgs/applications/misc/gxmessage/default.nix
+++ b/pkgs/applications/misc/gxmessage/default.nix
@@ -1,0 +1,20 @@
+{stdenv, fetchurl, gnome3, intltool, pkgconfig, texinfo}:
+
+stdenv.mkDerivation rec {
+  name = "gxmessage-${version}";
+  version = "3.4.3";
+
+  src = fetchurl {
+    url = "http://homepages.ihug.co.nz/~trmusson/stuff/${name}.tar.gz";
+    sha256 = "db4e1655fc58f31e5770a17dfca4e6c89028ad8b2c8e043febc87a0beedeef05";
+  };
+
+  buildInputs = [ intltool gnome3.gtk pkgconfig texinfo ];
+  meta = {
+    description = "a GTK enabled dropin replacement for xmessage";
+    homepage = "http://homepages.ihug.co.nz/~trmusson/programs.html#gxmessage";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [jfb];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11607,6 +11607,8 @@ let
 
   guvcview = callPackage ../os-specific/linux/guvcview { };
 
+  gxmessage = callPackage ../applications/misc/gxmessage { };
+
   hackrf = callPackage ../applications/misc/hackrf { };
 
   hello = callPackage ../applications/misc/hello/ex-2 { };


### PR DESCRIPTION
A dropin replacement for xmessage, built against GTK+3.
