### PR TITLE
scsh: 0.6.7 -> 0.7 pre-release

### DIFF
--- a/pkgs/development/interpreters/scsh/default.nix
+++ b/pkgs/development/interpreters/scsh/default.nix
@@ -1,26 +1,22 @@
-{stdenv, fetchurl}:
-
-let
-  pname = "scsh";
-  version = "0.6.7";
-  name = "${pname}-${version}";
-in
+{ stdenv, fetchgit, autoconf, automake, autoreconfHook, scheme48 }:
 
 stdenv.mkDerivation {
-  inherit name;
+  name = "scsh-0.7pre";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${name}.tar.gz";
-    sha256 = "c4a9f7df2a0bb7a7aa3dafc918aa9e9a566d4ad33a55f0192889de172d1ddb7f";
+  src = fetchgit {
+    url = "git://github.com/scheme/scsh.git";
+    rev = "f99b8c5293628cfeaeb792019072e3a96841104f";
+    fetchSubmodules = true;
+    sha256 = "0fz1r0bmiii9ld91r84dqkqwhnqk0h6drdycq93zcy5ndyn12fqp";
   };
 
-  meta = {
+  buildInputs = [ autoconf automake autoreconfHook scheme48 ];
+  configureFlags = ''--with-scheme48=${scheme48}'';
+
+  meta = with stdenv.lib; {
     description = "A Scheme shell";
-    longDescription = ''
-      SCSH is an implementation of the Scheme shell.  It is implemented as
-      a heap image which is interpreted by the Scheme 48 virtual machine.
-    '';
     homepage = http://www.scsh.net/;
-    license = stdenv.lib.licenses.bsd3;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ joachifm ];
   };
 }


### PR DESCRIPTION
The scsh HEAD is buildable, whereas 0.6.7 segfaults during image creation.

Tested briefly, works as advertised for me.

If accepted, this PR supersedes https://github.com/NixOS/nixpkgs/pull/8893
