### PR TITLE
Add sitePackages to pypy's passthru

### DIFF
--- a/pkgs/development/interpreters/pypy/default.nix
+++ b/pkgs/development/interpreters/pypy/default.nix
@@ -114,6 +114,7 @@ let
       isPypy = true;
       buildEnv = callPackage ../python/wrapper.nix { python = self; };
       interpreter = "${self}/bin/${executable}";
+      sitePackages = "lib/${libPrefix}/site-packages";
     };
 
     enableParallelBuilding = true;  # almost no parallelization without STM


### PR DESCRIPTION
This should fix the problem of nox-review crashing with

```
error: attribute ‘sitePackages’ missing, at /home/blah/.nox/nixpkgs/pkgs/top-level/python-packages.nix:7513:19
```
