### PR TITLE
dropbox: 3.6.7 -> 3.6.9 [stable backport]

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -18,11 +18,11 @@
 # them with our own.
 
 let
-  version = "3.6.7";
+  version = "3.6.9";
   sha256 =
     {
-      "x86_64-linux" = "1jwzrpw382amx0jap9m411a3yvkc9iwnw6n35kwq3infmbwjs6q8";
-      "i686-linux" = "0rjd908bhfk00qh6gvizf2fyfb3cccd78spyvh435z377x2pmxzy";
+      "x86_64-linux" = "1i260mi40siwcx9b2sj4zwszxmj1l88mpmyqncsfa72k02jz22j3";
+      "i686-linux" = "0qqc8qbfaighbhjq9y22ka6n6apl8b6cr80a9rkpk2qsk99k8h1z";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
This is the backport of #8921
The version has been tested against unstable-channel, please somebody running a stable system, test it too.
