### PR TITLE
Vagrant: 1.7.3 -> 1.7.4 (ZHF)

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -4,7 +4,7 @@
 assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
 
 let
-  version = "1.7.3";
+  version = "1.7.4";
   rake = buildRubyGem {
     inherit ruby;
     name = "rake-10.3.2";
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url    = "https://dl.bintray.com/mitchellh/vagrant/vagrant_${version}_x86_64.deb";
-        sha256 = "0zg2sdxgrmwqvzqw4z8d6ji8d0cby33nggv0n9ncjxp0wjiv8nkm";
+        sha256 = "0dl3cskpz7d8mmv0ah86426vlx0lj1wkjdlb5gc868dfsysw5lnw";
       }
     else
       fetchurl {
         url    = "https://dl.bintray.com/mitchellh/vagrant/vagrant_${version}_i686.deb";
-        sha256 = "0r23w49jwl3c3g4nns5xnrsrqyfkqsgln91cj30hxkw50d0ldpvs";
+        sha256 = "0sns9q48c6b2sabp6bwkppx8ffp774jhv69jrv225qrnifx12105";
       };
 
   meta = with stdenv.lib; {
@@ -93,12 +93,12 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     # 'hide' the template file from shebang-patching
-    chmod -x $out/opt/vagrant/embedded/gems/gems/bundler-1.7.11/lib/bundler/templates/Executable
+    chmod -x $out/opt/vagrant/embedded/gems/gems/bundler-1.10.5/lib/bundler/templates/Executable
     chmod -x $out/opt/vagrant/embedded/gems/gems/vagrant-${version}/plugins/provisioners/salt/bootstrap-salt.sh
   '';
 
   postFixup = ''
-    chmod +x $out/opt/vagrant/embedded/gems/gems/bundler-1.7.11/lib/bundler/templates/Executable
+    chmod +x $out/opt/vagrant/embedded/gems/gems/bundler-1.10.5/lib/bundler/templates/Executable
     chmod +x $out/opt/vagrant/embedded/gems/gems/vagrant-${version}/plugins/provisioners/salt/bootstrap-salt.sh
   '';
 }


### PR DESCRIPTION
Update Vagrant to 1.7.4 version and fix embedded bundler path, so the build wouldn't fail. Built and tested on x86_64.
