### PR TITLE
perl-LWP: enable tests + a few version bumps

### DIFF
--- a/pkgs/development/perl-modules/lwp-test-with-localhost.patch
+++ b/pkgs/development/perl-modules/lwp-test-with-localhost.patch
@@ -1,0 +1,75 @@
+From 2d7a479b39bb20a0d61f067ba6c2df92117fcb8c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Wed, 23 Apr 2014 12:45:38 +0200
+Subject: [PATCH] Connect to localhost instead of hostname
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The hostname does not have to be resolvable nor reachable. It's just
+a machine name.
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ t/local/http.t   | 2 +-
+ t/robot/ua-get.t | 2 +-
+ t/robot/ua.t     | 2 +-
+ talk-to-ourself  | 3 +--
+ 4 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/t/local/http.t b/t/local/http.t
+index 779cc21..534b4c8 100644
+--- a/t/local/http.t
++++ b/t/local/http.t
+@@ -20,7 +20,7 @@ if ($D eq 'daemon') {
+ 
+     require HTTP::Daemon;
+ 
+-    my $d = HTTP::Daemon->new(Timeout => 10);
++    my $d = HTTP::Daemon->new(Timeout => 10, LocalAddr => 'localhost');
+ 
+     print "Please to meet you at: <URL:", $d->url, ">\n";
+     open(STDOUT, $^O eq 'VMS'? ">nl: " : ">/dev/null");
+diff --git a/t/robot/ua-get.t b/t/robot/ua-get.t
+index 5754c4b..bf24589 100644
+--- a/t/robot/ua-get.t
++++ b/t/robot/ua-get.t
+@@ -19,7 +19,7 @@ if ($D eq 'daemon') {
+ 
+     require HTTP::Daemon;
+ 
+-    my $d = new HTTP::Daemon Timeout => 10;
++    my $d = new HTTP::Daemon Timeout => 10, LocalAddr => 'localhost';
+ 
+     print "Please to meet you at: <URL:", $d->url, ">\n";
+     open(STDOUT, $^O eq 'MSWin32' ?  ">nul" : $^O eq 'VMS' ? ">NL:"  : ">/dev/null");
+diff --git a/t/robot/ua.t b/t/robot/ua.t
+index 21ad5c8..11fafa8 100644
+--- a/t/robot/ua.t
++++ b/t/robot/ua.t
+@@ -19,7 +19,7 @@ if ($D eq 'daemon') {
+ 
+     require HTTP::Daemon;
+ 
+-    my $d = new HTTP::Daemon Timeout => 10;
++    my $d = new HTTP::Daemon Timeout => 10, LocalAddr => 'localhost';
+ 
+     print "Please to meet you at: <URL:", $d->url, ">\n";
+     open(STDOUT, $^O eq 'MSWin32' ?  ">nul" : $^O eq 'VMS' ? ">NL:"  : ">/dev/null");
+diff --git a/talk-to-ourself b/talk-to-ourself
+index 6c0257a..b4acda2 100644
+--- a/talk-to-ourself
++++ b/talk-to-ourself
+@@ -9,8 +9,7 @@ require IO::Socket;
+ 
+ if (@ARGV >= 2 && $ARGV[0] eq "--port") {
+     my $port = $ARGV[1];
+-    require Sys::Hostname;
+-    my $host = Sys::Hostname::hostname();
++    my $host = 'localhost';
+     if (my $socket = IO::Socket::INET->new(PeerAddr => "$host:$port", Timeout => 5)) {
+ 	require IO::Select;
+ 	if (IO::Select->new($socket)->can_read(1)) {
+-- 
+1.9.0
+

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5384,8 +5384,8 @@ let self = _self // overrides; _self = with self; {
       url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
       sha256 = "1cpqjl59viw50bnbdyn8xzrwzg7g54b2rszw0fifacqrppp17gaz";
     };
-    propagatedBuildInputs = [ EncodeLocale FileListing HTMLParser HTTPCookies HTTPDaemon HTTPDate HTTPNegotiate HTTPMessage LWPMediaTypes NetHTTP URI WWWRobotRules ];
-    doCheck = false; # tries to start a daemon
+    patches = [ ../development/perl-modules/lwp-test-with-localhost.patch ];
+    propagatedBuildInputs = [ EncodeLocale FileListing HTMLParser HTTPCookies HTTPDaemon HTTPDate HTTPMessage HTTPNegotiate LWPMediaTypes NetHTTP URI WWWRobotRules ];
     meta = {
       description = "The World-Wide Web library for Perl";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4738,15 +4738,15 @@ let self = _self // overrides; _self = with self; {
   };
 
   IOHTML = buildPerlPackage {
-    name = "IO-HTML-0.04";
+    name = "IO-HTML-1.001";
     src = fetchurl {
-      url = mirror://cpan/authors/id/C/CJ/CJM/IO-HTML-0.04.tar.gz;
-      sha256 = "0c4hc76c1gypdwfasnibr2qlf9x3bnhyw357lhqlrczbm6vn8hw5";
+      url = mirror://cpan/authors/id/C/CJ/CJM/IO-HTML-1.001.tar.gz;
+      sha256 = "ea78d2d743794adc028bc9589538eb867174b4e165d7d8b5f63486e6b828e7e0";
     };
     meta = {
-      homepage = http://search.cpan.org/perldoc?CPAN::Meta::Spec;
       description = "Open an HTML file with automatic charset detection";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.rycee ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6994,14 +6994,16 @@ let self = _self // overrides; _self = with self; {
   };
 
   NetHTTP = buildPerlPackage {
-    name = "Net-HTTP-6.06";
+    name = "Net-HTTP-6.09";
     src = fetchurl {
-      url = mirror://cpan/authors/id/G/GA/GAAS/Net-HTTP-6.06.tar.gz;
-      sha256 = "1m1rvniffadq99gsy25298ia3lixwymr6kan64jd3ylyi7nkqkhx";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Net-HTTP-6.09.tar.gz;
+      sha256 = "52762b939d84806908ba544581c5708375f7938c3c0e496c128ca3fbc425e58d";
     };
+    propagatedBuildInputs = [ URI ];
     meta = {
       description = "Low-level HTTP connection (client)";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.rycee ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10380,14 +10380,15 @@ let self = _self // overrides; _self = with self; {
   };
 
   URI = buildPerlPackage {
-    name = "URI-1.60";
+    name = "URI-1.68";
     src = fetchurl {
-      url = mirror://cpan/authors/id/G/GA/GAAS/URI-1.60.tar.gz;
-      sha256 = "0xr31mf7lfrwhyvlx4pzp6p7alls5gi4bj8pk5g89f5cckfd74hz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/URI-1.68.tar.gz;
+      sha256 = "c840d30f7657bfd4b2acbb311bd764232911cd3dc97e92415fbd0a242185c358";
     };
     meta = {
       description = "Uniform Resource Identifiers (absolute and relative)";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.rycee ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3401,16 +3401,21 @@ let self = _self // overrides; _self = with self; {
   };
 
   EncodeLocale = buildPerlPackage rec {
-    name = "Encode-Locale-1.03";
+    name = "Encode-Locale-1.05";
     src = fetchurl {
       url = "mirror://cpan/modules/by-module/Encode/${name}.tar.gz";
-      sha256 = "0m9d1vdphlyzybgmdanipwd9ndfvyjgk3hzw250r299jjgh3fqzp";
+      sha256 = "176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1";
     };
     preCheck = if stdenv.isCygwin then ''
       sed -i"" -e "s@plan tests => 13@plan tests => 10@" t/env.t
       sed -i"" -e "s@ok(env(\"\\\x@#ok(env(\"\\\x@" t/env.t
       sed -i"" -e "s@ok(\$ENV{\"\\\x@#ok(\$ENV{\"\\\x@" t/env.t
     '' else null;
+    meta = {
+      description = "Determine the locale encoding";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.rycee ];
+    };
   };
 
   EnvPath = buildPerlPackage {


### PR DESCRIPTION
This PR adds a patch that will enable the LWP test suite to run. It also includes a few version bumps of some LWP dependencies. I added these since the LWP change will cause fair number of packages to rebuild and it might be good to get these in at the same time.
