### PR TITLE
Update ocaml to 4.02.1

### DIFF
--- a/pkgs/applications/editors/emacs-modes/ocaml/default.nix
+++ b/pkgs/applications/editors/emacs-modes/ocaml/default.nix
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
   # a quick configure to get the Makefile generated. Since
   # we do not build the ocaml itself, we don't really
   # need it to support any features.
-  configureFlags = [ "-no-tk" "-no-curses" "-no-pthread" ];
+  configureFlags = [ "-no-curses" "-no-pthread" ];
 
   buildInputs = [ emacs ];
   dontBuild = true;

--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchgit, ocaml, zlib, neko }:
+{ stdenv, fetchgit, ocaml, zlib, neko, camlp4 }:
 
 stdenv.mkDerivation {
   name = "haxe-3.1.3";
 
-  buildInputs = [ocaml zlib neko];
+  buildInputs = [ocaml zlib neko camlp4];
 
   src = fetchgit {
     url = "https://github.com/HaxeFoundation/haxe.git";

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
-  propagatedbuildInputs = [ mysql.lib ];
+  propagatedBuildInputs = [ mysql.lib ];
 
   preConfigure = ''
     export LDFLAGS="-L${mysql.lib}/lib/mysql"

--- a/pkgs/tools/misc/wyrd/default.nix
+++ b/pkgs/tools/misc/wyrd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, ncurses, remind }:
+{ stdenv, fetchurl, ocaml, ncurses, remind, camlp4 }:
 
 stdenv.mkDerivation rec {
   version = "1.4.6";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zlrg602q781q8dij62lwdprpfliyy9j1rqfqcz8p2wgndpivddj";
   };
 
-  buildInputs = [ ocaml ncurses remind ];
+  buildInputs = [ ocaml ncurses remind camlp4 ];
 
   preferLocalBuild = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3958,7 +3958,9 @@ let
     overrides = config.haskellPackageOverrides or (self: super: {});
   };
 
-  haxe = callPackage ../development/compilers/haxe { };
+  haxe = callPackage ../development/compilers/haxe {
+    inherit (ocamlPackages) camlp4;
+  };
   hxcpp = callPackage ../development/compilers/haxe/hxcpp.nix { };
 
   hhvm = callPackage ../development/compilers/hhvm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4615,7 +4615,7 @@ let
 
   };
 
-  ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;
+  ocamlPackages = recurseIntoAttrs ocamlPackages_4_02_1;
   ocamlPackages_3_10_0 = (mkOcamlPackages ocaml_3_10_0 pkgs.ocamlPackages_3_10_0)
   // { lablgtk = ocamlPackages_3_10_0.lablgtk_2_14; };
   ocamlPackages_3_11_2 = (mkOcamlPackages ocaml_3_11_2 pkgs.ocamlPackages_3_11_2)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3434,7 +3434,9 @@ let
 
   wv2 = callPackage ../tools/misc/wv2 { };
 
-  wyrd = callPackage ../tools/misc/wyrd { };
+  wyrd = callPackage ../tools/misc/wyrd {
+    inherit (ocamlPackages) camlp4;
+  };
 
   x86info = callPackage ../os-specific/linux/x86info { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4236,7 +4236,9 @@ let
 
     base64 = callPackage ../development/ocaml-modules/base64 { };
 
-    bolt = callPackage ../development/ocaml-modules/bolt { };
+    bolt = callPackage ../development/ocaml-modules/bolt {
+      ocaml = ocamlPackages_4_01_0.ocaml;
+    };
 
     bitstring_2_0_4 = callPackage ../development/ocaml-modules/bitstring/2.0.4.nix { };
     bitstring_git   = callPackage ../development/ocaml-modules/bitstring { };
@@ -4619,7 +4621,27 @@ let
 
   };
 
-  ocamlPackages = recurseIntoAttrs ocamlPackages_4_02_1;
+  ocamlPackages = (recurseIntoAttrs ocamlPackages_4_02_1)
+  // { # Don't compile correctly on 4.02 (need fixing)
+       inherit (ocamlPackages_4_01_0)
+       camlimages_4_0
+       bolt
+       ocaml_optcomp
+       eliom
+       ocpBuild
+       ocpIndent
+       ulex
+       ocp-index;
+
+       # Depend on things in the list above
+       inherit (ocamlPackages_4_01_0)
+       ocsigen_deriving
+       js_of_ocaml
+       vg
+       mezzo
+       ojquery
+       acgtk;
+     };
   ocamlPackages_3_10_0 = (mkOcamlPackages ocaml_3_10_0 pkgs.ocamlPackages_3_10_0)
   // { lablgtk = ocamlPackages_3_10_0.lablgtk_2_14; };
   ocamlPackages_3_11_2 = (mkOcamlPackages ocaml_3_11_2 pkgs.ocamlPackages_3_11_2)
@@ -4633,13 +4655,17 @@ let
 
   ocaml_make = callPackage ../development/ocaml-modules/ocamlmake { };
 
-  ocaml-top = callPackage ../development/tools/ocaml/ocaml-top { };
+  ocaml-top = callPackage ../development/tools/ocaml/ocaml-top {
+    ocamlPackages = ocamlPackages_4_01_0;
+  };
 
   opa = callPackage ../development/compilers/opa {
     ocamlPackages = ocamlPackages_4_00_1;
   };
 
-  opam_1_0_0 = callPackage ../development/tools/ocaml/opam/1.0.0.nix { };
+  opam_1_0_0 = callPackage ../development/tools/ocaml/opam/1.0.0.nix {
+    inherit (ocamlPackages_4_01_0) ocaml;
+  };
   opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix {
     inherit (ocamlPackages_4_01_0) ocaml;
   };
@@ -5612,6 +5638,7 @@ let
   noweb = callPackage ../development/tools/literate-programming/noweb { };
 
   omake = callPackage ../development/tools/ocaml/omake { };
+
   omake_rc1 = callPackage ../development/tools/ocaml/omake/0.9.8.6-rc1.nix { };
 
   opengrok = callPackage ../development/tools/misc/opengrok { };
@@ -6307,10 +6334,10 @@ let
   glpk = callPackage ../development/libraries/glpk { };
 
   glsurf = callPackage ../applications/science/math/glsurf {
-    inherit (ocamlPackages) lablgl findlib ocaml_mysql mlgmp;
+    inherit (ocamlPackages_4_01_0) ocaml lablgl findlib ocaml_mysql mlgmp;
     libpng = libpng12;
     giflib = giflib_4_1;
-    camlimages = ocamlPackages.camlimages_4_0;
+    camlimages = ocamlPackages_4_01_0.camlimages_4_0;
   };
 
   gmime = callPackage ../development/libraries/gmime { };
@@ -12010,7 +12037,9 @@ let
 
   mjpg-streamer = callPackage ../applications/video/mjpg-streamer { };
 
-  mldonkey = callPackage ../applications/networking/p2p/mldonkey { };
+  mldonkey = callPackage ../applications/networking/p2p/mldonkey {
+    inherit (ocamlPackages_4_01_0) ocaml;
+  };
 
   mmex = callPackage ../applications/office/mmex { };
 
@@ -14354,7 +14383,9 @@ let
 
   lean = callPackage ../applications/science/logic/lean {};
 
-  leo2 = callPackage ../applications/science/logic/leo2 {};
+  leo2 = callPackage ../applications/science/logic/leo2 {
+    inherit (ocamlPackages_4_01_0) ocaml;
+  };
 
   logisim = callPackage ../applications/science/logic/logisim {};
 


### PR DESCRIPTION
Moving to ocaml 4.02, but some packages won't compile easily. I plan to fix those things that are failing, but first I wanted to have an idea of the scope of fixing that, so this PR just makes them compile with the previous version.

I am not sure this is the best way to proceed, maybe is better to remove the failing packages from ocamlPackages_4_02_1 (they are broken anyway)?

Also, this contains some slightly unrelated bugs that were pointed out by nox. I am not sure why emacsmode and mysql are passing in hydra...
