### PR TITLE
Fix #7272 - Allow users to override importsArgs in eval-config.nix.

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -20,7 +20,7 @@ rec {
                 , # This should only be used for special arguments that need to be evaluated
                   # when resolving module structure (like in imports). For everything else,
                   # there's _module.args.
-                  specialArgs ? {}
+                  importsArgs ? {}
                 , # This would be remove in the future, Prefer _module.args option instead.
                   args ? {}
                 , # This would be remove in the future, Prefer _module.check option instead.
@@ -55,7 +55,7 @@ rec {
         };
       };
 
-      closed = closeModules (modules ++ [ internalModule ]) (specialArgs // { inherit config options; lib = import ./.; });
+      closed = closeModules (modules ++ [ internalModule ]) (importsArgs // { inherit config options; lib = import ./.; });
 
       # Note: the list of modules is reversed to maintain backward
       # compatibility with the old module system.  Not sure if this is

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -17,6 +17,9 @@
   baseModules ? import ../modules/module-list.nix
 , # !!! See comment about args in lib/modules.nix
   extraArgs ? {}
+, # !!! See comment in lib/modules.nix
+  # This are attributes which are used for importing modules.
+  importsArgs ? {}
 , modules
 , # !!! See comment about check in lib/modules.nix
   check ? true
@@ -47,7 +50,7 @@ in rec {
     inherit prefix check;
     modules = modules ++ extraModules ++ baseModules ++ [ pkgsModule ];
     args = extraArgs;
-    specialArgs = { modulesPath = ../modules; };
+    importsArgs = { modulesPath = ../modules; } // importsArgs;
   }) config options;
 
   # These are the extra arguments passed to every module.  In


### PR DESCRIPTION
These changes renames the `lib.evalModules` argument attribute from `specialArgs` into `importsArgs`, to represent the actual use of this argument.  Also, this change modify nixos `lib/eval-config.nix` to expose this argument and to use it to override the default set of arguments defined in this file.

This would solve the issue #7272, by renaming `extraArgs` into `importsArgs`.  The difference between the 2 arguments is that `extraArgs` is now evaluated as `_module.args`, and `importsArgs` is for arguments which are used for the resolution of `imports` attributes value.

cc @edolstra , @shlevy 
