### PR TITLE
WIP: update logstash to 1.5

### DIFF
--- a/nixos/modules/services/logging/logstash.nix
+++ b/nixos/modules/services/logging/logstash.nix
@@ -95,7 +95,7 @@ in
 
       filterConfig = mkOption {
         type = types.lines;
-        default = ''noop {}'';
+        default = "";
         description = "logstash filter configuration.";
         example = ''
           if [type] == "syslog" {

--- a/nixos/tests/logstash.nix
+++ b/nixos/tests/logstash.nix
@@ -19,8 +19,8 @@ import ./make-test.nix ({ pkgs, ...} : {
                 exec { command => "echo dragons" interval => 1 type => "test" }
               '';
               filterConfig = ''
-                if [type] == "test" {
-                  grep { match => ["message", "flowers"] drop => true }
+                if [type] == "test" and [message] !~ "flowers" {
+                  drop { }
                 }
               '';
               outputConfig = ''

--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.2";
+  version = "1.5.3";
   name = "logstash-${version}";
 
   src = fetchurl {
     url = "https://download.elasticsearch.org/logstash/logstash/logstash-${version}.tar.gz";
-    sha256 = "0sc0bwyf96fzs5h3d7ii65v9vvpfbm7w67vk1im9djnlz0d1ggnm";
+    sha256 = "1an476k4q2shdxvhcx4fzbrcpk6isjrrvzlb6ivxfqg5fih3cg7b";
   };
 
   dontBuild    = true;
@@ -14,25 +14,33 @@ stdenv.mkDerivation rec {
   dontStrip    = true;
   dontPatchShebangs = true;
 
+      #sed -i $f '1 s@^.*$@#!'$out'/vendor/jruby/bin/jruby@g'
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/vendor
     mkdir -p $out/lib
-    mkdir -p $out/locales
-    mkdir -p $out/patterns
     cp -a bin $out
     cp -a vendor $out
     cp -a lib $out
-    cp -a locales $out
-    cp -a patterns $out
+    cp -a Gemfile* $out
+
+    for f in $out/vendor/bundle/jruby/*/gems/bundler-*/lib/bundler/templates/Executable{,.standalone}; do
+      chmod -x $f
+    done
+
     patchShebangs $out/bin
+    patchShebangs $out/vendor
+
+    for f in $out/vendor/bundle/jruby/*/gems/bundler-*/lib/bundler/templates/Executable{,.standalone}; do
+      chmod +x $f
+    done
   '';
 
   meta = {
     description = "Open Source, Distributed, RESTful Search Engine";
     homepage    = http://www.elasticsearch.org;
-    license     = stdenv.lib.licenses.asl20;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.wjlroe ];
+    license     = lib.licenses.asl20;
+    platforms   = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ wjlroe cstrahan ];
   };
 }


### PR DESCRIPTION
This updates logstash, and fixes the logstash test.

Unfortunately, this doesn't (yet) support plugins. Logstash now uses Bundler, and so their old way of allowing you to specify a path to directory full of plugins (by modifying `$GEM_PATH`) no longer works. They provide a `bin/plugin install` mechanism to modify their Gemfile (which, remember, is arbitrary Ruby code), and then drive Bundler to install the gem alongside logstash. Yeah. So that's not going to work for us.

I'll inevitably need to rewrite this to build logstash from source using the (as of yet unreleased) new Bundler builder.
