### PR TITLE
coreclr: disable i686 build

### DIFF
--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://dotnet.github.io/core/;
     description = ".NET is a general purpose development platform.";
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with stdenv.lib.maintainers; [ obadz ];
     license = stdenv.lib.licenses.mit;
   };


### PR DESCRIPTION
The hydra build [1](https://hydra.nixos.org/build/23871656) fails with

  error: Detected non x86_64 target processor.  Not supported!
