### PR TITLE
vimus: disable on 32 bit linux

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -891,4 +891,6 @@ self: super: {
   # Hydra no longer allows building texlive packages.
   lhs2tex = dontDistribute super.lhs2tex;
 
+  # https://ghc.haskell.org/trac/ghc/ticket/9825
+  vimus = overrideCabal super.vimus (drv: { broken = pkgs.stdenv.isLinux && pkgs.stdenv.isi686; });
 }


### PR DESCRIPTION
A port of https://github.com/NixOS/nixpkgs/commit/57c5b8f5e179a758d9e9eb7f856e5f5bdb2fc5a3

@peti, is this okay?
