### PR TITLE
zc_buildout_nix: 2.2.1 -> 2.4.0 | fix to prefer "system" packages

### DIFF
--- a/pkgs/development/python-modules/buildout-nix/default.nix
+++ b/pkgs/development/python-modules/buildout-nix/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, buildPythonPackage }:
 
 buildPythonPackage {
-  name = "zc.buildout-nix-2.2.1";
+  name = "zc.buildout-nix-2.4.0";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/z/zc.buildout/zc.buildout-2.2.1.tar.gz";
-    md5 = "476a06eed08506925c700109119b6e41";
+    url = "https://pypi.python.org/packages/source/z/zc.buildout/zc.buildout-2.4.0.tar.gz";
+    md5 = "b8323b1ad285544de0c3dc14ee76ddd3";
   };
 
   patches = [ ./nix.patch ];

--- a/pkgs/development/python-modules/buildout-nix/nix.patch
+++ b/pkgs/development/python-modules/buildout-nix/nix.patch
@@ -1,38 +1,15 @@
 --- a/src/zc/buildout/easy_install.py	2013-08-27 22:28:40.233718116 +0200
 +++ b/src/zc/buildout/easy_install.py   2013-10-07 00:29:31.077413935 +0200
-@@ -508,16 +508,31 @@
-                         self._dest, os.path.basename(dist.location))
+@@ -227,6 +227,12 @@
  
-                     if os.path.isdir(dist.location):
--                        # we got a directory. It must have been
--                        # obtained locally.  Just copy it.
--                        shutil.copytree(dist.location, newloc)
-+                        # Replace links to garbage collected eggs in
-+                        # /nix/store
-+                        if os.path.islink(newloc):
-+                            # It seems necessary to jump through these
-+                            # hoops, otherwise we end up in an
-+                            # infinite loop because
-+                            # self._env.best_match fails to find the dist
-+                            os.remove(newloc)
-+                            dist = self._fetch(avail, tmp, self._download_cache)
-+                            os.symlink(dist.location, newloc)
-+                            newdist = pkg_resources.Distribution.from_filename(
-+                                newloc)
-+                            self._env.add(newdist)
-+                            logger.info("Updated link to %s" %dist.location)
-+                        # Symlink to the egg in /nix/store
-+                        elif not os.path.exists(newloc):
-+                            os.symlink(dist.location, newloc)
-+                            logger.info("Created link to %s" %dist.location)
-                     else:
- 
- 
-                         setuptools.archive_util.unpack_archive(
-                             dist.location, newloc)
- 
--                    redo_pyc(newloc)
-+                        redo_pyc(newloc)
- 
-                     # Getting the dist from the environment causes the
-                     # distribution meta data to be read.  Cloning isn't
+     def _satisfied(self, req, source=None):
+         dists = [dist for dist in self._env[req.project_name] if dist in req]
++        try:
++            dists = ([dist for dist in dists
++                     if dist.precedence == pkg_resources.DEVELOP_DIST]
++                     + [pkg_resources.get_distribution(req.project_name)])
++        except pkg_resources.DistributionNotFound:
++            pass
+         if not dists:
+             logger.debug('We have no distributions for %s that satisfies %r.',
+                          req.project_name, str(req))


### PR DESCRIPTION
@cillianderoiste promised to review this

This updates zc.buildout from 2.2.1 to 2.4.0 and changes the patch to simply pick existing "system" distributions instead of buildout installed ones. Developed packages are always used from buildout. In practice, when buildout-nix is run within a Python environment with some required packages, buildout will generate scripts with /nix/store paths. No more symlinks.

For, example, if I want to build package requiring Pillow, lxml and python-ldap, I can use those from nix (with installing the rest with buildout) by the following default.nix

```
with import <nixpkgs> {}; {
  myEnv = stdenv.mkDerivation {
    name = "myEnv";
    buildInputs = [
      pythonPackages.ldap
      pythonPackages.lxml
      pythonPackages.pillow
      pythonPackages.readline
      pythonPackages.zc_buildout_nix
    ];
    shellHook = ''
      export SSL_CERT_FILE=~/.nix-profile/etc/ca-bundle.crt
    '';
  };
}
```

and

```
nix-shell --run buildout-nix
```
