### PR TITLE
dfu-util: init at 0.8

### DIFF
--- a/pkgs/development/tools/misc/dfu-util/default.nix
+++ b/pkgs/development/tools/misc/dfu-util/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgconfig, libusb1 }:
+
+stdenv.mkDerivation rec {
+  name="dfu-util-${version}";
+  version = "0.8";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libusb1 ];
+
+  src = fetchurl {
+    url = "mirror://debian/pool/main/d/dfu-util/dfu-util_0.8.orig.tar.gz";
+    sha256 = "0n7h08avlzin04j93m6hkq9id6hxjiiix7ff9gc2n89aw6dxxjsm";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Device firmware update (DFU) USB programmer";
+    longDescription = ''
+      dfu-util is a program that implements the host (PC) side of the USB
+      DFU 1.0 and 1.1 (Universal Serial Bus Device Firmware Upgrade) protocol.
+
+      DFU is intended to download and upload firmware to devices connected over
+      USB. It ranges from small devices like micro-controller boards up to mobile
+      phones. With dfu-util you are able to download firmware to your device or
+      upload firmware from it.
+    '';
+    homepage = http://dfu-util.gnumonks.org/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.fpletz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5423,6 +5423,8 @@ let
 
   dfu-programmer = callPackage ../development/tools/misc/dfu-programmer { };
 
+  dfu-util = callPackage ../development/tools/misc/dfu-util { };
+
   ddd = callPackage ../development/tools/misc/ddd { };
 
   distcc = callPackage ../development/tools/misc/distcc { };


### PR DESCRIPTION
Since the website and Sourceforge are currently down, the source tarball is fetched from Debian mirrors.

This package is needed to flash the rad1o badge of CCCamp 2015. https://rad1o.badge.events.ccc.de/
