### PR TITLE
horst: init at git-2015-07-22

### DIFF
--- a/pkgs/tools/networking/horst/default.nix
+++ b/pkgs/tools/networking/horst/default.nix
@@ -1,0 +1,32 @@
+{stdenv, fetchFromGitHub, pkgconfig, ncurses, libnl }:
+
+stdenv.mkDerivation rec {
+  name = "horst-${version}";
+  version = "git-2015-07-22";
+
+  src = fetchFromGitHub {
+    owner = "br101";
+    repo = "horst";
+    rev = "b62fc20b98690061522a431cb278d989e21141d8";
+    sha256 = "176yma8v2bsab2ypgmgzvjg0bsbnk9sga3xpwkx33mwm6q79kd6g";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ ncurses libnl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv horst $out/bin
+
+    mkdir -p $out/man/man1
+    cp horst.1 $out/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Small and lightweight IEEE802.11 wireless LAN analyzer with a text interface";
+    homepage = http://br1.einfach.org/tech/horst/;
+    maintainers = [ maintainers.fpletz ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1836,6 +1836,8 @@ let
 
   honcho = callPackage ../tools/system/honcho { };
 
+  horst = callPackage ../tools/networking/horst { };
+
   host = callPackage ../tools/networking/host { };
 
   hping = callPackage ../tools/networking/hping { };


### PR DESCRIPTION
From http://br1.einfach.org/tech/horst/:

> “horst” is a small, lightweight IEEE802.11 wireless LAN analyzer with a text interface. Its basic function is similar to tcpdump, Wireshark or Kismet, but it’s much smaller and shows different, aggregated information which is not easily available from other tools. It is mainly targeted at debugging wireless LANs with a focus on ad-hoc (IBSS) mode in larger mesh networks. It can be useful to get a quick overview of what’s going on on all wireless LAN channels and to identify problems.
