### PR TITLE
gnugpg: Add libiconv dependency.

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba, npth
+{ fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba, libiconv, npth
 , autoreconfHook, gettext, texinfo, pcsclite
 
 # Each of the dependencies below are optional.
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    pkgconfig libgcrypt libassuan libksba npth
+    pkgconfig libgcrypt libassuan libksba libiconv npth
     autoreconfHook gettext texinfo
     readline libusb gnutls adns openldap zlib bzip2
   ];


### PR DESCRIPTION
Using the pure-darwin alternate stdenv on Yosemite, I need this change for gnupg to build. Otherwise, I get this error:

```
configure:
***
*** The system does not provide a working iconv function.  Please
*** install a suitable library; for example GNU Libiconv which is
*** available at:
***   http://ftp.gnu.org/gnu/libiconv/
***
configure: error: 
***
*** Required libraries not found. Please consult the above messages
*** and install them before running configure again.
***
builder for ‘/nix/store/pvzqmfzc05ifmvi0vglyl2xlkcdgh6c2-gnupg-2.1.6.drv’ failed with exit code 1
```
