### PR TITLE
apache-httpd: update minor versions of both 2.2 and 2.4 for security-related fixes

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -12,12 +12,12 @@ assert ldapSupport -> aprutil.ldapSupport && openldap != null;
 assert mpm == "prefork" || mpm == "worker" || mpm == "event";
 
 stdenv.mkDerivation rec {
-  version = "2.2.29";
+  version = "2.2.31";
   name = "apache-httpd-${version}";
 
   src = fetchurl {
     url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-    sha1 = "1d6a8fbc1391d358cc6fe430edc16222b97258d5";
+    sha256 = "1b165zi7jrrlz5wmyy3b34lcs3dl4g0dymfb0qxwdnimylcrsbzk";
   };
 
   buildInputs = [perl apr aprutil pcre] ++

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -14,12 +14,12 @@ assert sslSupport -> aprutil.sslSupport && openssl != null;
 assert ldapSupport -> aprutil.ldapSupport && openldap != null;
 
 stdenv.mkDerivation rec {
-  version = "2.4.12";
+  version = "2.4.16";
   name = "apache-httpd-${version}";
 
   src = fetchurl {
     url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-    sha256 = "1r7a63ka41vlswrqbb21vall6sc7svwgd497kb6dh8a6zvnkjvdd";
+    sha256 = "0hrpy6gjwma0kba7p7m61vwh82qcnkf08123lrwpg257m93hnrmc";
   };
 
   buildInputs = [perl] ++


### PR DESCRIPTION
Latest available versions of both.

Should probably back-port these to stable too, but 2.4.12->2.4.16 might be a bit of a jump for stable. Possibly the right thing to do is to bring it up to just 2.4.14 on stable, which is the last release including security fixes.

?
