### PR TITLE
pipelight: Add support for 32 bit linux.

### DIFF
--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit, autoconf, automake, wineStaging, perl, xlibs
-  , gnupg, gcc_multi, mesa, curl, bash, cacert, cabextract, utillinux, attr
+  , gnupg, stdenv_32bit, mesa, curl, bash, cacert, cabextract, utillinux, attr
   }:
 
 let
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1i440rf22fmd2w86dlm1mpi3nb7410rfczc0yldnhgsvp5p3sm5f";
   };
 
-  buildInputs = [ wine_custom xlibs.libX11 gcc_multi mesa curl ];
+  buildInputs = [ wine_custom xlibs.libX11 stdenv_32bit.cc mesa curl ];
   propagatedbuildInputs = [ curl cabextract ];
 
   patches = [ ./pipelight.patch ];


### PR DESCRIPTION
Done so by using the 32 bit stdenv as the requirement
of this package was to be provided with a 32 bit
compiler.
