### PR TITLE
Fix bazel package

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jdk, zip, zlib, protobuf, pkgconfig, libarchive, unzip, makeWrapper }:
+{ stdenv, fetchFromGitHub, jdk, zip, zlib, protobuf2_5, pkgconfig, libarchive, unzip, which, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "bazel-20150326.981b7bc1";
@@ -10,19 +10,20 @@ stdenv.mkDerivation rec {
     sha256 = "0i9gxgqhfmix7hmkb15s7h9f8ssln08pixqm26pd1d20g0kfyxj7";
   };
 
-  buildInputs = [ pkgconfig protobuf zlib zip jdk libarchive unzip makeWrapper ];
+  buildInputs = [ pkgconfig protobuf2_5 zlib zip jdk libarchive unzip which makeWrapper ];
 
   installPhase = ''
     PROTOC=protoc bash compile.sh
     mkdir -p $out/bin $out/share
     cp -R output $out/share/bazel
     ln -s $out/share/bazel/bazel $out/bin/bazel
-    wrapProgram $out/bin/bazel --set JAVA_HOME "${jdk}"
+    wrapProgram $out/bin/bazel --set JAVA_HOME "${jdk.home}"
   '';
 
   meta = {
     homepage = http://github.com/google/bazel/;
     description = "Build tool that builds code quickly and reliably";
     license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.philandstuff ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5283,7 +5283,7 @@ let
 
   bam = callPackage ../development/tools/build-managers/bam {};
 
-  bazel = callPackage ../development/tools/build-managers/bazel { jdk = oraclejdk8; };
+  bazel = callPackage ../development/tools/build-managers/bazel { jdk = openjdk8; };
 
   bin_replace_string = callPackage ../development/tools/misc/bin_replace_string { };
 


### PR DESCRIPTION
google/bazel@981b7bc1 depends on protobuf-2.5 and won't work with 2.6 (and in
google/bazel@bbe84fe3d upgraded straight to protobuf 3.0.0-alpha3); this commit fixes
the dependency to depend on protobuf2_5 specifically.

The bazel compile.sh needs `which` on the PATH; so this commit adds that
as a dependency.

Since this package didn't have a listed maintainer, I'm claiming it.
