### PR TITLE
Add eclipse plugins

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -219,5 +219,131 @@ you should modify
 </section>
 -->
 
+<!--============================================================-->
+
+<section xml:id="sec-eclipse">
+
+  <title>Eclipse</title>
+
+  <para>
+    The Nix expressions related to the Eclipse platform and IDE are in
+    <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/eclipse"><filename>pkgs/applications/editors/eclipse</filename></link>.
+  </para>
+
+  <para>
+    Nixpkgs provides a number of packages that will install Eclipse in
+    its various forms, these range from the bare-bones Eclipse
+    Platform to the more fully featured Eclipse SDK or Scala-IDE
+    packages and multiple version are often available. It is possible
+    to list available Eclipse packages by issuing the command:
+
+<screen>
+$ nix-env -f '&lt;nixpkgs&gt;' -qaP -A eclipses --description
+</screen>
+
+    Once an Eclipse variant is installed it can be run using the
+    <command>eclipse</command> command, as expected. From within
+    Eclipse it is then possible to install plugins in the usual manner
+    by either manually specifying an Eclipse update site or by
+    installing the Marketplace Client plugin and using it to discover
+    and install other plugins. This installation method provides an
+    Eclipse installation that closely resemble a manually installed
+    Eclipse.
+  </para>
+
+  <para>
+    If you prefer to install plugins in a more declarative manner then
+    Nixpkgs also offer a number of Eclipse plugins that can be
+    installed in an <emphasis>Eclipse environment</emphasis>. This
+    type of environment is created using the function
+    <varname>eclipseWithPlugins</varname> found inside the
+    <varname>nixpkgs.eclipses</varname> attribute set. This function
+    takes as argument <literal>{ eclipse, plugins ? [], jvmArgs ? []
+    }</literal> where <varname>eclipse</varname> is a one of the
+    Eclipse packages described above, <varname>plugins</varname> is a
+    list of plugin derivations, and <varname>jvmArgs</varname> is a
+    list of arguments given to the JVM running the Eclipse. For
+    example, say you wish to install the latest Eclipse Platform with
+    the popular Eclipse Color Theme plugin and also allow Eclipse to
+    use more RAM. You could then add
+
+<screen>
+packageOverrides = pkgs: {
+  myEclipse = with pkgs.eclipses; eclipseWithPlugins {
+    eclipse = eclipse-platform;
+    jvmArgs = [ "-Xmx2048m" ];
+    plugins = [ plugins.color-theme ];
+  };
+}
+</screen>
+
+    to your Nixpkgs configuration
+    (<filename>~/.nixpkgs/config.nix</filename>) and install it by
+    running <command>nix-env -f '&lt;nixpkgs&gt;' -iA
+    myEclipse</command> and afterward run Eclipse as usual. It is
+    possible to find out which plugins are available for installation
+    using <varname>eclipseWithPlugins</varname> by running
+
+<screen>
+$ nix-env -f '&lt;nixpkgs&gt;' -qaP -A eclipses.plugins --description
+</screen>
+  </para>
+
+  <para>
+    If there is a need to install plugins that are not available in
+    Nixpkgs then it may be possible to define these plugins outside
+    Nixpkgs using the <varname>buildEclipseUpdateSite</varname> and
+    <varname>buildEclipsePlugin</varname> functions found in the
+    <varname>nixpkgs.eclipses.plugins</varname> attribute set. Use the
+    <varname>buildEclipseUpdateSite</varname> function to install a
+    plugin distributed as an Eclipse update site. This function takes
+    <literal>{ name, src }</literal> as argument where
+    <literal>src</literal> indicates the Eclipse update site archive.
+    All Eclipse features and plugins within the downloaded update site
+    will be installed. When an update site archive is not available
+    then the <varname>buildEclipsePlugin</varname> function can be
+    used to install a plugin that consists of a pair of feature and
+    plugin JARs. This function takes an argument <literal>{ name,
+    srcFeature, srcPlugin }</literal> where
+    <literal>srcFeature</literal> and <literal>srcPlugin</literal> are
+    the feature and plugin JARs, respectively.
+  </para>
+
+  <para>
+    Expanding the previous example with two plugins using the above
+    functions we have
+<screen>
+packageOverrides = pkgs: {
+  myEclipse = with pkgs.eclipses; eclipseWithPlugins {
+    eclipse = eclipse-platform;
+    jvmArgs = [ "-Xmx2048m" ];
+    plugins = [
+      plugins.color-theme
+      (plugins.buildEclipsePlugin {
+        name = "myplugin1-1.0";
+        srcFeature = fetchurl {
+          url = "http://…/features/myplugin1.jar";
+          sha256 = "123…";
+        };
+        srcPlugin = fetchurl {
+          url = "http://…/plugins/myplugin1.jar";
+          sha256 = "123…";
+        };
+      });
+      (plugins.buildEclipseUpdateSite {
+        name = "myplugin2-1.0";
+        src = fetchurl {
+          stripRoot = false;
+          url = "http://…/myplugin2.zip";
+          sha256 = "123…";
+        };
+      });
+    ];
+  };
+}
+</screen>
+  </para>
+
+</section>
 
 </chapter>

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -342,7 +342,9 @@ in {
       # Gather up the desired plugins.
       pluginEnv = buildEnv {
         name = "eclipse-plugins";
-        paths = plugins;
+        paths =
+          with stdenv.lib;
+            filter (x: x ? isEclipsePlugin) (closePropagation plugins);
       };
 
       # Prepare the JVM arguments to add to the ini file. We here also

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -321,6 +321,22 @@ in {
     };
   };
 
+  eclipse-platform = buildEclipse {
+    name = "eclipse-platform-4.5";
+    description = "Eclipse platform";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk-x86_64.tar.gz";
+          sha256 = "1510j41yr86pbzwf48kjjdd46nkpkh8zwn0hna0cqvsw1gk2vqcg";
+
+        };
+      "i686-linux" = fetchurl {
+          url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk.tar.gz";
+          sha256 = "1f97jd3qbi3830y3djk8bhwzd9whsq8gzfdk996chxc55prn0qbd";
+        };
+    };
+  };
+
   eclipseWithPlugins = { eclipse, plugins ? [], jvmArgs ? [] }:
     let
       # Gather up the desired plugins.

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -2,6 +2,7 @@
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
 , glib, gtk, libXtst, jre
 , webkitgtk2 ? null  # for internal web browser
+, buildEnv, writeText, runCommand
 }:
 
 assert stdenv ? glibc;
@@ -318,4 +319,38 @@ in {
         };
     };
   };
+
+  eclipseWithPlugins = { eclipse, plugins ? [], jvmArgs ? [] }:
+    let
+      # Gather up the desired plugins.
+      pluginEnv = buildEnv {
+        name = "eclipse-plugins";
+        paths = plugins;
+      };
+
+      # Prepare the JVM arguments to add to the ini file. We here also
+      # add the property indicating the plugin directory.
+      dropinPropName = "org.eclipse.equinox.p2.reconciler.dropins.directory";
+      dropinProp = "-D${dropinPropName}=${pluginEnv}/eclipse/dropins";
+      jvmArgsText = stdenv.lib.concatStringsSep "\n" (jvmArgs ++ [dropinProp]);
+
+      # Prepare an eclipse.ini with the plugin directory.
+      origEclipseIni = builtins.readFile "${eclipse}/eclipse/eclipse.ini";
+      eclipseIniFile = writeText "eclipse.ini" ''
+        ${origEclipseIni}
+        ${jvmArgsText}
+      '';
+
+      # Base the derivation name on the name of the underlying
+      # Eclipse.
+      name = (stdenv.lib.meta.appendToName "with-plugins" eclipse).name;
+    in
+      runCommand name { buildInputs = [ makeWrapper ]; } ''
+        mkdir -p $out/bin
+        makeWrapper ${eclipse}/bin/eclipse $out/bin/eclipse \
+          --add-flags "--launcher.ini ${eclipseIniFile}"
+
+        ln -s ${eclipse}/share $out/
+      '';
+
 }

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -3,7 +3,7 @@
 , glib, gtk, libXtst, jre
 , webkitgtk2 ? null  # for internal web browser
 , buildEnv, writeText, runCommand
-, recurseIntoAttrs, callPackage
+, callPackage
 }:
 
 assert stdenv ? glibc;
@@ -372,6 +372,6 @@ in {
         ln -s ${eclipse}/share $out/
       '';
 
-  plugins = recurseIntoAttrs (callPackage ./plugins.nix { });
+  plugins = callPackage ./plugins.nix { };
 
 }

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -3,6 +3,7 @@
 , glib, gtk, libXtst, jre
 , webkitgtk2 ? null  # for internal web browser
 , buildEnv, writeText, runCommand
+, recurseIntoAttrs, callPackage
 }:
 
 assert stdenv ? glibc;
@@ -352,5 +353,7 @@ in {
 
         ln -s ${eclipse}/share $out/
       '';
+
+  plugins = recurseIntoAttrs (callPackage ./plugins.nix { });
 
 }

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -51,6 +51,30 @@ in {
     };
   };
 
+  color-theme = buildEclipsePlugin rec {
+    name = "color-theme-${version}";
+    version = "1.0.0.201410260308";
+    javaName = "com.github.eclipsecolortheme";
+
+    srcFeature = fetchurl {
+      url = "https://eclipse-color-theme.github.io/update/features/${javaName}.feature_${version}.jar";
+      sha256 = "128b9b1cib5ff0w1114ns5mrbrhj2kcm358l4dpnma1s8gklm8g2";
+    };
+
+    srcPlugin = fetchurl {
+      url = "https://eclipse-color-theme.github.io/update/plugins/${javaName}_${version}.jar";
+      sha256 = "0wz61909bhqwzpqwll27ia0cn3anyp81haqx3rj1iq42cbl42h0y";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = http://eclipsecolorthemes.org/;
+      description = "Plugin to switch color themes conveniently and without side effects";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
   emacsplus = buildEclipsePlugin rec {
     name = "emacsplus-${version}";
     version = "4.2.0";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -207,6 +207,24 @@ in {
     };
   };
 
+  scala = buildEclipseUpdateSite rec {
+    name = "scala-${version}";
+    version = "4.1.0";
+
+    src = fetchzip {
+      url = "http://download.scala-ide.org/sdk/lithium/e44/scala211/stable/update-site.zip";
+      sha256 = "1z3pl88kw9qyhhsi8sqwz30c12l7zg8jiz6bz1js7jzpjbs8v70f";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = "http://scala-ide.org/";
+      description = "The Scala IDE for Eclipse";
+      license = licenses.bsd3;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
   testng = buildEclipsePlugin rec {
     name = "testng-${version}";
     version = "6.9.5.201506120235";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -75,4 +75,28 @@ in {
     };
   };
 
+  findbugs = buildEclipsePlugin rec {
+    name = "findbugs-${version}";
+    version = "3.0.1.20150306-5afe4d1";
+    javaName = "edu.umd.cs.findbugs.plugin.eclipse";
+
+    srcFeature = fetchurl {
+      url = "http://findbugs.cs.umd.edu/eclipse/features/${javaName}_${version}.jar";
+      sha256 = "1m9fav2xlb9wrx2d00lpnh2sy0w5yzawynxm6xhhbfdzd0vpfr9v";
+    };
+
+    srcPlugin = fetchurl {
+      url = "http://findbugs.cs.umd.edu/eclipse/plugins/${javaName}_${version}.jar";
+      sha256 = "10p3mrbp9wi6jhlmmc23qv7frh605a23pqsc7w96569bsfb5wa8q";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = http://findbugs.sourceforge.net/;
+      description = "Plugin that uses static analysis to look for bugs in Java code";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
 }

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, unzip }:
+
+let
+
+  # Helper for the common case where we have separate feature and
+  # plugin JARs.
+  buildEclipsePlugin = { name, version, javaName, srcFeature, srcPlugin, meta }:
+    stdenv.mkDerivation {
+      name = "eclipse-" + name;
+      inherit meta;
+
+      srcs = [ srcFeature srcPlugin ];
+
+      buildInputs = [ unzip ];
+      phases = [ "installPhase" ];
+
+      installPhase = ''
+        dropinDir="$out/eclipse/dropins/${name}"
+        mkdir -p $dropinDir/features/${javaName}_${version}
+        unzip ${srcFeature} -d $dropinDir/features/${javaName}_${version}
+
+        mkdir -p $dropinDir/plugins
+        cp -v ${srcPlugin} $dropinDir/plugins/${javaName}_${version}.jar
+      '';
+
+    };
+
+in {
+
+  anyedittools = buildEclipsePlugin rec {
+    name = "anyedit-${version}";
+    version = "2.4.15.201504172030";
+    javaName = "de.loskutov.anyedit.AnyEditTools";
+
+    srcFeature = fetchurl {
+      url = "http://andrei.gmxhome.de/eclipse/features/AnyEditTools_${version}.jar";
+      sha256 = "19hbwgqn02ghflbcp5cw3qy203mym5kwgzq4xrn0xcl8ckl5s2pp";
+    };
+
+    srcPlugin = fetchurl {
+      url = "http://dl.bintray.com/iloveeclipse/plugins/${javaName}_${version}.jar";
+      sha256 = "1i3ghf2mhdfhify30hlyxqmyqcp40pkd5zhsiyg6finn4w81sxv2";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = http://andrei.gmxhome.de/anyedit/;
+      description = "Adds new tools to the context menu of text-based editors";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
+}

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -49,16 +49,35 @@ rec {
       installPhase = ''
         dropinDir="$out/eclipse/dropins/${name}"
 
+        # Install features.
         cd features
         for feature in *.jar; do
-          feat=''${feature%.jar}
-          mkdir -p $dropinDir/features/$feat
-          unzip $feature -d $dropinDir/features/$feat
+          featureName=''${feature%.jar}
+          mkdir -p $dropinDir/features/$featureName
+          unzip $feature -d $dropinDir/features/$featureName
         done
         cd ..
 
+        # Install plugins.
         mkdir -p $dropinDir/plugins
-        cp -v "plugins/"*.jar $dropinDir/plugins/
+
+        # A bundle should be unpacked if the manifest matches this
+        # pattern.
+        unpackPat="Eclipse-BundleShape:\\s*dir"
+
+        cd plugins
+        for plugin in *.jar ; do
+          pluginName=''${plugin%.jar}
+          manifest=$(unzip -p $plugin META-INF/MANIFEST.MF)
+
+          if [[ $manifest =~ $unpackPat ]] ; then
+            mkdir $dropinDir/plugins/$pluginName
+            unzip $plugin -d $dropinDir/plugins/$pluginName
+          else
+            cp -v $plugin $dropinDir/plugins/
+          fi
+        done
+        cd ..
       '';
     });
 

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -188,6 +188,25 @@ in {
     };
   };
 
+  jdt = buildEclipseUpdateSite rec {
+    name = "jdt-${version}";
+    version = "4.5";
+
+    src = fetchzip {
+      stripRoot = false;
+      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/org.eclipse.jdt-4.5.zip";
+      sha256 = "0zrdn26f7qsms2xfiyc049bhhh0czsbf989pgyq736b8hfmmh9iy";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://www.eclipse.org/jdt/;
+      description = "Eclipse Java development tools";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
   testng = buildEclipsePlugin rec {
     name = "testng-${version}";
     version = "6.9.5.201506120235";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchzip, unzip }:
 
-let
+rec {
 
   buildEclipsePluginBase =  { name
                             , buildInputs ? []
@@ -61,8 +61,6 @@ let
         cp -v "plugins/"*.jar $dropinDir/plugins/
       '';
     };
-
-in {
 
   anyedittools = buildEclipsePlugin rec {
     name = "anyedit-${version}";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -188,4 +188,28 @@ in {
     };
   };
 
+  testng = buildEclipsePlugin rec {
+    name = "testng-${version}";
+    version = "6.9.5.201506120235";
+    javaName = "org.testng.eclipse";
+
+    srcFeature = fetchurl {
+      url = "http://beust.com/eclipse/features/org.testng.eclipse_6.9.5.201506120235.jar";
+      sha256 = "02imv0rw10pik55a7p00jin65shvhfpzgna02ky94yx7dlf9fyy9";
+    };
+
+    srcPlugin = fetchurl {
+      url = "http://beust.com/eclipse/plugins/org.testng.eclipse_6.9.5.201506120235.jar";
+      sha256 = "0ni1ky4p5l1qzph0np1qw9pcyhrvy6zmn9c8q1b5rm5xv1fcvji4";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = http://testng.org/;
+      description = "Eclipse plugin for the TestNG testing framework";
+      license = licenses.asl20;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
 }

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -62,6 +62,30 @@ rec {
       '';
     };
 
+  acejump = buildEclipsePlugin rec {
+    name = "acejump-${version}";
+    version = "1.0.0.201501181511";
+    javaName = "acejump";
+
+    srcFeature = fetchurl {
+      url = "https://tobiasmelcher.github.io/acejumpeclipse/features/${javaName}.feature_${version}.jar";
+      sha256 = "127xqrnns4h96g21c9zg0iblxprx3fg6fg0w5f413rf84415z884";
+    };
+
+    srcPlugin = fetchurl {
+      url = "https://tobiasmelcher.github.io/acejumpeclipse/plugins/${javaName}_${version}.jar";
+      sha256 = "0mz79ca32yryidd1wijirvnmfg4j5q4g84vdspdi56z0r4xrja13";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/tobiasmelcher/EclipseAceJump;
+      description = "Provides fast jumps to text based on initial letter";
+      license = licenses.mit;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
   anyedittools = buildEclipsePlugin rec {
     name = "anyedit-${version}";
     version = "2.4.15.201504172030";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -51,4 +51,28 @@ in {
     };
   };
 
+  emacsplus = buildEclipsePlugin rec {
+    name = "emacsplus-${version}";
+    version = "4.2.0";
+    javaName = "com.mulgasoft.emacsplus";
+
+    srcFeature = fetchurl {
+      url = "http://www.mulgasoft.com/emacsplus/e4/update-site/features/${javaName}.feature_${version}.jar";
+      sha256 = "0wja3cd7gq8w25797fxnafvcncjnmlv8qkl5iwqj7zja2f45vka8";
+    };
+
+    srcPlugin = fetchurl {
+      url = "http://www.mulgasoft.com/emacsplus/e4/update-site/plugins/${javaName}_${version}.jar";
+      sha256 = "08yw45nr90mlpdzim74vsvdaxj41sgpxcrqk5ia6l2dzvrqlsjs1";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = http://www.mulgasoft.com/emacsplus/;
+      description = "Provides a more Emacs-like experience in the Eclipse text editors";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
 }

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -121,6 +121,25 @@ in {
     };
   };
 
+  eclemma = buildEclipseUpdateSite rec {
+    name = "eclemma-${version}";
+    version = "2.3.2.201409141915";
+
+    src = fetchzip {
+      stripRoot = false;
+      url = "mirror://sourceforge/project/eclemma/01_EclEmma_Releases/2.3.2/eclemma-2.3.2.zip";
+      sha256 = "0w1kwcjh45p7msv5vpc8i6dsqwrnfmjama6vavpnxlji56jd3c43";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = http://www.eclemma.org/;
+      description = "EclEmma is a free Java code coverage tool for Eclipse";
+      license = licenses.epl10;
+      platforms = platforms.all;
+      maintainers = [ maintainers.rycee ];
+    };
+  };
+
   emacsplus = buildEclipsePlugin rec {
     name = "emacsplus-${version}";
     version = "4.2.0";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -237,11 +237,11 @@ rec {
 
   scala = buildEclipseUpdateSite rec {
     name = "scala-${version}";
-    version = "4.1.0";
+    version = "4.1.1";
 
     src = fetchzip {
       url = "http://download.scala-ide.org/sdk/lithium/e44/scala211/stable/update-site.zip";
-      sha256 = "1z3pl88kw9qyhhsi8sqwz30c12l7zg8jiz6bz1js7jzpjbs8v70f";
+      sha256 = "0p2dbf56rw733dhsxy9hdwmbzqlk01j8f2hci21bsipq5w2144x6";
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
This PR adds a function to create a `bin/eclipse` file for a given Eclipse derivation such that a given list of plugins are available to that Eclipse. A number of initial plugins are provided. Example usage:

``` nix
{
  myEclipse = with eclipses; eclipseWithPlugins {
    eclipse = eclipse_sdk_45;
    plugins = with plugins; [
      anyedittools emacsplus
      findbugs color-theme
      checkstyle eclemma testng
    ];
  };
}
```
