### PR TITLE
nvidia-x11: add a symlink for libGLESv2.so.2

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -61,6 +61,12 @@ installPhase() {
       patchelf --set-rpath "$out/lib:$allLibPath" "$libname"
 
       libname_short=`echo -n "$libname" | sed 's/so\..*/so/'`
+
+      # nvidia's EGL stack seems to expect libGLESv2.so.2 to be available
+      if [ $(basename "$libname_short") == "libGLESv2.so" ]; then
+          ln -srnf "$libname" "$libname_short.2"
+      fi
+
       ln -srnf "$libname" "$libname_short"
       ln -srnf "$libname" "$libname_short.1"
     done


### PR DESCRIPTION
nvidia's EGL stack looks for libGLESv2.so.2 at runtime (confirmed by
watching strace), however builder.sh only provides a libGLESv2.so.1
symlink.

On my system (and I suspect others) the nvidia EGL stack does not work.  You can test it by running weston in an X11 session -- it will probably fail with a message that it couldn't create an EGL context.  I had a look at the strace output and found attempts to locate libGLESv2.so.2.  On a hunch I hacked up the installer to leave a symlink from libGLESv2.so.2 to libGLESv2.so.XXX, which has fixed the problem with weston at least.

I'm not exactly confident that this is the correct fix so this patch probably needs further review.  Feel free to ping me (sjanssen) on IRC if you'd like.

I also confirmed that the patch builds against latest master.

cc @vcunat 
