### PR TITLE
Update utop and camlp4

### DIFF
--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -1,15 +1,17 @@
-{stdenv, fetchurl, which, ocaml}:
+{stdenv, fetchzip, which, ocaml}:
 let
   ocaml_version = (stdenv.lib.getVersion ocaml);
+  version = "4.02+6";
+
 in
 
 assert stdenv.lib.versionAtLeast ocaml_version "4.02";
 
 stdenv.mkDerivation {
-  name = "camlp4-4.02.0+1";
-  src = fetchurl {
-    url = https://github.com/ocaml/camlp4/archive/4.02.0+1.tar.gz;
-    sha256 = "0055f4jiz82rgn581xhq3mr4qgq2qgdxqppmp8i2x1xnsim4h9pn";
+  name = "camlp4-${version}";
+  src = fetchzip {
+    url = "https://github.com/ocaml/camlp4/archive/${version}.tar.gz";
+    sha256 = "06yl4q0qazl7g25b0axd1gdkfd4qpqzs1gr5fkvmkrcbz113h1hj";
   };
 
   buildInputs = [ which ocaml ];
@@ -27,10 +29,6 @@ stdenv.mkDerivation {
   postConfigure = ''
     substituteInPlace camlp4/META.in \
     --replace +camlp4 $out/lib/ocaml/${ocaml_version}/site-lib/camlp4
-    substituteInPlace camlp4/config/Camlp4_config.ml \
-    --replace \
-      "Filename.concat ocaml_standard_library" \
-      "Filename.concat \"$out/lib/ocaml/${ocaml_version}/site-lib\""
   '';
 
 

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,21 +1,23 @@
 {stdenv, fetchurl, ocaml, findlib, lambdaTerm, ocaml_lwt, makeWrapper,
- ocaml_react, camomile, zed
+ ocaml_react, camomile, zed, cppo, camlp4
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.15";
+  version = "1.17";
   name = "utop-${version}";
 
   src = fetchurl {
-    url = https://github.com/diml/utop/archive/1.15.tar.gz;
-    sha256 = "106v0x6sa2x10zgmjf73mpzws7xiqanxswivd00iqnpc0bcpkmrr";
+    url = "https://github.com/diml/utop/archive/${version}.tar.gz";
+    sha256 = "0l9lz2nypl2ls3kqzmp738m02yvscabhsfpj70ckp0p98pimnnfd";
   };
 
-  buildInputs = [ ocaml findlib makeWrapper];
+  buildInputs = [ ocaml findlib makeWrapper cppo camlp4 ];
 
   propagatedBuildInputs = [ lambdaTerm ocaml_lwt ];
 
   createFindlibDestdir = true;
+
+  configureFlags = "--enable-camlp4";
 
   buildPhase = ''
     make


### PR DESCRIPTION
The current version of `camlp4` in `nixpkgs` causes some problems with `utop` and `async`. A way to reproduce it is:
- Get a shell in the latest `nixpkgs`

```
nix-shell -E 'with import ./. {}; stdenv.mkDerivation (with ocamlPackages_4_02_1; { name = "foo"; buildInputs = [ utop async findlib ]; })' "<nixpkgs>
```
- Run utop
- Check that `#utop_help;;` outputs something
- Load Async: `#require "async";;`
- `#utop_help` doesn't output anything, nor does `#topfind_log`

Just upgrading `camlp4` solves the issue, but I tried to upgrade `utop` first while debugging, so feel free to merge that too.
