### PR TITLE
texlive-{core,extra}: remove docs and sources

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/beamer.nix
+++ b/pkgs/tools/typesetting/tex/texlive/beamer.nix
@@ -18,6 +18,8 @@ rec {
     ln -s $out/texmf* $out/share/
   '') ["minInit" "doUnpack" "defEnsureDir" "addInputs"];
 
+  preferLocalBuild = true;
+
   meta = {
     description = "Extra components for TeXLive: beamer class";
     maintainers = [ stdenv.lib.maintainers.mornfall stdenv.lib.maintainers.jwiegley ];

--- a/pkgs/tools/typesetting/tex/texlive/cm-super.nix
+++ b/pkgs/tools/typesetting/tex/texlive/cm-super.nix
@@ -23,7 +23,8 @@ rec {
 
     ln -s $out/texmf* $out/share/
   '') ["minInit" "doUnpack" "defEnsureDir" "addInputs"];
-  buildInputs = [texLive];
+
+  preferLocalBuild = true;
 
   meta = {
     description = "Extra components for TeXLive: CM-Super fonts";

--- a/pkgs/tools/typesetting/tex/texlive/context.nix
+++ b/pkgs/tools/typesetting/tex/texlive/context.nix
@@ -6,7 +6,6 @@ rec {
     sha256 = "1d744xrsjyl52x2xbh87k5ad826mzz8yqmhdznrmqrhk3qpjkzic";
   };
 
-  buildInputs = [texLive];
   phaseNames = ["doCopy"];
   doCopy = fullDepEntry (''
     mkdir -p $out/share/
@@ -16,6 +15,8 @@ rec {
 
     ln -s $out/texmf* $out/share/
   '') ["minInit" "doUnpack" "defEnsureDir" "addInputs"];
+
+  preferLocalBuild = true;
 
   meta = {
     description = "ConTEXt TeX wrapper";

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -18,7 +18,7 @@ rec {
     sha256 = "1ydz5m1v40n34g1l31r3vqg74rbr01x2f80drhz4igh21fm7zzpa";
   };
 
-  passthru = { inherit texmfSrc langTexmfSrc; };
+  passthru = { inherit texmfSrc langTexmfSrc doCleanInstall; };
 
   setupHook = ./setup-hook.sh;
 
@@ -138,7 +138,12 @@ rec {
       "--disable-dvisvgm"
     ];
 
-  phaseNames = [ "addInputs" "doMainBuild" "doMakeInstall" "doPostInstall" ];
+  phaseNames = [ "addInputs" "doMainBuild" "doMakeInstall" "doPostInstall" "doCleanInstall" ];
+
+  # remove docs and sources of packages
+  doCleanInstall = fullDepEntry ''
+    rm -rf "$out"/share/texmf-dist/{doc,source}
+  '' [];
 
   name = "texlive-core-2014";
 

--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -8,7 +8,7 @@ rec {
     sha256 = "190p5v6madcgkxjmfal0pcylfz88zi6yaixky0vrcz1kbvxqlcb9";
   };
 
-  buildInputs = [texLive xz];
+  buildInputs = [xz];
   phaseNames = ["doCopy" "doCleanInstall"];
   doCopy = fullDepEntry (''
     mkdir -p $out/share
@@ -17,6 +17,8 @@ rec {
   '') ["minInit" "doUnpack" "defEnsureDir" "addInputs"];
 
   inherit (texLive) doCleanInstall;
+
+  preferLocalBuild = true;
 
   meta = {
     description = "Extra components for TeXLive";

--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -9,12 +9,14 @@ rec {
   };
 
   buildInputs = [texLive xz];
-  phaseNames = ["doCopy"];
+  phaseNames = ["doCopy" "doCleanInstall"];
   doCopy = fullDepEntry (''
     mkdir -p $out/share
     cp -r texmf* $out/
     ln -s $out/texmf* $out/share
   '') ["minInit" "doUnpack" "defEnsureDir" "addInputs"];
+
+  inherit (texLive) doCleanInstall;
 
   meta = {
     description = "Extra components for TeXLive";

--- a/pkgs/tools/typesetting/tex/texlive/moderncv.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderncv.nix
@@ -7,7 +7,7 @@ rec {
     sha256 = "0k26s0z8hmw3h09vnpndim7gigwh8q6n9nbbihb5qbrw5qg2yqck";
   };
 
-  buildInputs = [texLive unzip];
+  buildInputs = [unzip];
   phaseNames = ["doCopy"];
   doCopy = fullDepEntry (''
     mkdir -p $out/texmf-dist/tex/latex/moderncv $out/texmf-dist/doc $out/share
@@ -15,6 +15,8 @@ rec {
     mv examples $out/texmf-dist/doc/moderncv
     ln -s $out/texmf* $out/share/
   '') ["minInit" "addInputs" "doUnpack" "defEnsureDir"];
+
+  preferLocalBuild = true;
 
   meta = {
     description = "the moderncv class for TeXLive";

--- a/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
@@ -10,7 +10,7 @@ rec {
     sha256 = "0y2m0qd0izrfjcwrmf3nvzkqmrhkdhzbv29s4c0knksdnfgcchc8";
   };
 
-  buildInputs = [texLive unzip];
+  buildInputs = [unzip];
   phaseNames = ["doCopy"];
   doCopy = fullDepEntry (''
     mkdir -p $out/texmf-dist/tex/latex/moderntimeline $out/texmf-dist/doc/moderntimeline $out/share
@@ -18,6 +18,8 @@ rec {
     mv *.pdf $out/texmf-dist/doc/moderntimeline/
     ln -s $out/texmf* $out/share/
   '') ["minInit" "addInputs" "doUnpack" "defEnsureDir"];
+
+  preferLocalBuild = true;
 
   meta = {
     description = "the moderntimeline extensions for moderncv";

--- a/pkgs/tools/typesetting/tex/texlive/xcolor.nix
+++ b/pkgs/tools/typesetting/tex/texlive/xcolor.nix
@@ -6,7 +6,6 @@ rec {
     sha256 = "0z78xfn5iq5ncg82sd6v2qrxs8p9hs3m4agaz90p4db5dvk2w0mn";
   };
 
-  buildInputs = [texLive];
   phaseNames = ["doCopy"];
   doCopy = fullDepEntry (''
     export HOME=$PWD
@@ -30,6 +29,8 @@ rec {
 
     ln -s $out/texmf* $out/share/
   '') ["minInit" "doUnpack" "defEnsureDir" "addInputs"];
+
+  preferLocalBuild = true;
 
   meta = {
     description = "Extra components for TeXLive: LaTeX color support";


### PR DESCRIPTION
Documentation of packages and sources to build stuff don't seem to be needed in typical use cases, and they took quite some space, going from:

```
1.6G    /nix/store/jj5inbfzzvm8sz278vk6izlqxym718i0-texlive-core-2014
2.0G    /nix/store/b2b67jphwkhnmcl7vsqpczsnh9zcbr7p-texlive-extra-2014
3.5G    total
```

to:

```
926M    /nix/store/fg3sq8py57za1l5gqcyds9zi8as3yy5l-texlive-core-2014
818M    /nix/store/cy067520l5b5bl2v1yfwfmwkbr5kzh52-texlive-extra-2014
1.8G    total
```

I tested building asymptote, eprover, and some LaTeX and LyX stuff of mine.

Maintainers @7c6f434c, @jwiegley, @lovek323; perhaps also @peti is interested. If you have any good test cases, it would be good to try them.

After this reduction, it might be conceivable to build the `texLive` attribute on Hydra. /cc @edolstra, see 7f54f9965 discussion. (For the other unpack-only texLive packages it's still useless.)
