### PR TITLE
canto-{curses,daemon}: {0.9.4,0.9.3} -> {0.9.6,0.9.5}

### DIFF
--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python34Packages, readline, ncurses, canto-daemon }:
 
 python34Packages.buildPythonPackage rec {
-  version = "0.9.4";
+  version = "0.9.6";
   name = "canto-curses-${version}";
 
   src = fetchFromGitHub {
     owner = "themoken";
     repo = "canto-curses";
     rev = "v${version}";
-    sha256 = "0g1ckcb9xcfb0af17zssiqcrfry87agx578vd40nb6gbw90ql4fn";
+    sha256 = "0hxzpx314cflxq68gswjf2vrqf1z1ci9mxhxgwrk7sa6di86ygy0";
   };
 
   buildInputs = [ readline ncurses canto-daemon ];

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python34Packages, }:
 
 python34Packages.buildPythonPackage rec {
-  version = "0.9.3";
+  version = "0.9.5";
   name = "canto-daemon-${version}";
   namePrefix = "";
 
@@ -9,7 +9,7 @@ python34Packages.buildPythonPackage rec {
     owner = "themoken";
     repo = "canto-next";
     rev = "v${version}";
-    sha256 = "1x875qdyhab89nwwa2bzbfvcrkx34zwyy8dlbxm8wg3vz9b78l61";
+    sha256 = "1ycwrg5n2il833mdxgzz07r0vb4rxz89rk5c6l9g5x33ifinykdq";
   };
 
   propagatedBuildInputs = with python34Packages; [ feedparser ];


### PR DESCRIPTION
Built and tested locally. The changelog can be found here:
http://codezen.org/canto-ng/news/
