### PR TITLE
ccache: create symlinks to gcc utils in ccache-links bin directory

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -42,6 +42,11 @@ stdenv.mkDerivation {
         EOF
           chmod +x $out/bin/g++
         fi
+        for executable in $(ls ${gcc.cc}/bin); do
+          if [ ! -x "$out/bin/$executable" ]; then
+            ln -s ${gcc.cc}/bin/$executable $out/bin/$executable
+          fi
+        done
       '');
   };
 


### PR DESCRIPTION
When using ccache some compiler utils are missing. For example, build of `spl` requires `cpp`. This patch makes symlinks in `ccache-links/bin` folder for every compiler binary.
