### PR TITLE
mupdf: 1.7 -> 1.7a

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -2,12 +2,12 @@
 , libX11, libXext }:
 
 stdenv.mkDerivation rec {
-  version = "1.7";
+  version = "1.7a";
   name = "mupdf-${version}";
 
   src = fetchurl {
     url = "http://mupdf.com/download/archive/${name}-source.tar.gz";
-    sha256 = "0hjn1ywxhblqgj63qkp8x7qqjnwsgid3viw8az5i2i26dijmrgfh";
+    sha256 = "073xq6kczq331awycvznpc49b22idqzdlw4g9254zi0z07x5y0wc";
   };
 
   buildInputs = [ pkgconfig zlib freetype libjpeg jbig2dec openjpeg libX11 libXext ];


### PR DESCRIPTION
This is a bugfix release; `llpp` needs it to run (it also currently needs `openssl` to build, but that’s an other issue).

Tested locally: lgtm.
