### PR TITLE
stage-1: fix typo that breaks resume

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -184,7 +184,7 @@ if test -e /sys/power/resume -a -e /sys/power/disk; then
             # https://bugs.launchpad.net/ubuntu/+source/pm-utils/+bug/923326/comments/1
             # when there are multiple swap devices, we can't know where the hibernate
             # image will reside. We can check all of them for swsuspend blkid.
-            resumeInfo="$(test -e "$d" && udevadm info -q property "$sd")"
+            resumeInfo="$(test -e "$sd" && udevadm info -q property "$sd")"
             if [ "$(echo "$resumeInfo" | sed -n 's/^ID_FS_TYPE=//p')" = "swsuspend" ]; then
                 resumeDev="$sd"
                 break


### PR DESCRIPTION
$d should be $sd, this causes resume from hibernate to fail if
resumeDevice is not explicitly set in config.  Introduced in commit:
'stage-1: Shut up warnings about swap devices that don't exist yet'

Resume stopped working after a recent update, and this commit fixes it for me.  I tested this against current nixos-unstable, but I have not tested the change after rebasing on master.
