### PR TITLE
notmuch: fix gpg path in notmuch-config.c

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
 
     for src in \
       crypto.c \
+      notmuch-config.c \
       emacs/notmuch-crypto.el
     do
       substituteInPlace "$src" \


### PR DESCRIPTION
Fixes errors when attempting to decrypt an encrypted message.
I'm not sure that `crypto.c` needs to be patched after this, since this setting
should propagate there, but let's play it safe.
