### PR TITLE
virtualbox: place mount.vboxsf in bin/ instead of sbin/

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -87,8 +87,9 @@ stdenv.mkDerivation {
     sed -i -e "s|/usr/bin|$out/bin|" bin/VBoxClient-all
 
     # Install binaries
+    mkdir -p $out/bin
+    install -m 4755 lib/VBoxGuestAdditions/mount.vboxsf $out/bin/mount.vboxsf
     mkdir -p $out/sbin
-    install -m 4755 lib/VBoxGuestAdditions/mount.vboxsf $out/sbin/mount.vboxsf
     install -m 755 sbin/VBoxService $out/sbin
 
     mkdir -p $out/bin


### PR DESCRIPTION
The mount tools aren't looking in sbin/ any longer.
