### PR TITLE
[WIP] vpython: init at 6.11

### DIFF
--- a/pkgs/development/python-modules/vpython/default.nix
+++ b/pkgs/development/python-modules/vpython/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchzip, buildPythonPackage, pkgconfig, boost, gtkglextmm
+, pangox_compat, libXmu, numpy, wxPython30, polygon2, fonttools, ttfquery
+}:
+
+buildPythonPackage rec {
+  name = "vpython-${version}";
+  version = "6.11";
+
+  src = fetchzip {
+    name = "${name}-src";
+    url = "https://github.com/BruceSherwood/vpython-wx/archive/v${version}.tar.gz";
+    sha256 = "0ynyjwdz15s6dxsxb73zvqiz4ra1lc9wm0qr630dzin2h1sdm13j";
+  };
+
+  buildInputs = [ pkgconfig pangox_compat boost libXmu gtkglextmm ];
+
+  propagatedBuildInputs = [ numpy wxPython30 polygon2 fonttools ttfquery ];
+
+  # rename library dependency: boost_python-py<version> => boost_python
+  preBuild = ''
+    sed -i -e "s/boost_python-py.*/boost_python')/" setup.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "3D scientific visualization library";
+    longDescription = ''
+      VPython is the Python programming language plus a 3D graphics module
+      called "Visual" originated by David Scherer in 2000. VPython makes it
+      easy to create navigable 3D displays and animations, even for those with
+      limited programming experience. Because it is based on Python, it also
+      has much to offer for experienced programmers and researchers.
+    '';
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8741,6 +8741,11 @@ let
 
   slowaes = callPackage ../development/python-modules/slowaes { };
 
+  vpython = callPackage ../development/python-modules/vpython {
+    inherit (pythonPackages) numpy wxPython30 polygon2 fonttools ttfquery;
+    inherit (gnome2) gtkglextmm;
+  };
+
   wxPython = pythonPackages.wxPython;
   wxPython28 = pythonPackages.wxPython28;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13586,6 +13586,28 @@ let
    };
 
 
+  ttfquery = buildPythonPackage rec {
+    name = "ttfquery-${version}";
+    version = "1.0.5";
+
+    disabled = isPy3k;
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/T/TTFQuery/TTFQuery-${version}.tar.gz";
+      sha256 = "0kbymjlxj0wmhsj3ckj84k8qcm53ivg2g7w1852pbqiyj1lx7f6m";
+    };
+
+    #propagatedBuildInputs = with pythonPackages; [  ];
+
+    meta = with stdenv.lib; {
+      description = "FontTools-based package for querying system fonts";
+      homepage = http://ttfquery.sourceforge.net/;
+      #license = unknown;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   turses = buildPythonPackage (rec {
     name = "turses-0.2.23";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9361,6 +9361,27 @@ let
   };
 
 
+  polygon2 = pythonPackages.buildPythonPackage rec {
+    name = "polygon2-2.0.7";
+
+    disabled = isPy3k;
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/P/Polygon2/Polygon2-2.0.7.zip";
+      sha256 = "091z8m333kfsb5r6frx0v1cnhk4w85n8jrsr39pmia2q4a7kfyd7";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Handles polygonal shapes in 2D";
+      homepage = http://www.j-raedler.de/projects/polygon;
+      # This package also includes a (modified) copy of 'gpc', which has its
+      # own license (free for non-commercial use), see homepage.
+      license = licenses.lgpl2;
+      maintainers = [ maintainers.bjornfor ];
+    };
+  };
+
+
   polylint = buildPythonPackage rec {
     name = "polylint-${version}";
     version = "158125c6ab";


### PR DESCRIPTION
VPython is the Python programming language plus a 3D graphics module
called "visual" originated by David Scherer in 2000. VPython makes it
easy to create navigable 3D displays and animations, even for those with
limited programming experience.

http://vpython.org/

Note that there is a warning when importing 'visual':

> > > import visual
> > >   /nix/store/...-wxPython-3.0.0.0/lib/python2.7/site-packages/wx-3.0-gtk2/wx/_core.py:16632:
> > >   UserWarning: wxPython/wxWidgets release number mismatch
> > >     warnings.warn("wxPython/wxWidgets release number mismatch")

Also, the main reason this is WIP: the gui is all grey, there are no 3D objects (FIXME).
