### PR TITLE
ccache: set attribute isGNU = true

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   passthru = {
     # A derivation that provides gcc and g++ commands, but that
     # will end up calling ccache for the given cacheDir
-    links = extraConfig : (runCommand "ccache-links" { passthru.gcc = gcc; }
+    links = extraConfig : (runCommand "ccache-links" { passthru.gcc = gcc; passthru.isGNU = true; }
       ''
         mkdir -p $out/bin
         if [ -x "${gcc.cc}/bin/gcc" ]; then


### PR DESCRIPTION
`isGNU` attribute for ccache compiler wrappers was not set. Default value `false` was used. So it failed some checks. For example, #9022
