### PR TITLE
nixos: Provide users.setupHomeScript option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1509.xml
+++ b/nixos/doc/manual/release-notes/rl-1509.xml
@@ -32,6 +32,18 @@
         <literal>services.openssh.moduliFile</literal> option.
       </para>
     </listitem>
+    <listitem>
+      <para>
+        Support for declarative user management has been improved. It
+        is now possible by means of the new option
+        <literal>users.initialHomeSetup</literal> to setup home directory
+        contents for newly created users in addition to just creating them.
+        This way you can provide basic dot files in the user's home directory
+        or even clone your home git repository from a server!
+
+        Set up the configuration, run nixos-install, log in and have everything ready.
+      </para>
+    </listitem>
   </itemizedlist>
 
 </para>

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -446,6 +446,30 @@ in {
       options = [ groupOpts ];
     };
 
+
+    users.initialHomeSetup = mkOption {
+      type = types.string;
+      default = "";
+      description = ''
+        The specified script will be called when the home directory of the user
+        gets created. It will not be called if the directory already exists.
+
+        The script gets passed two arguments, the first one is the user's
+        staging home directory, the second one is the user's name. The staging
+        directory will be renamed to the user's home directory when the
+        "initialHomeSetup" script succeeds. Your script should operate in the
+        passed staging directory and not in the actual user's home directory,
+        which does not even exist when the script is run.
+
+        After your script is run, owner and group of all files in the staging
+        directory will be set to the values specified in the NixOS
+        configuration.
+
+        Operating with a staging home directory ensures that the home directory
+        is either set up completely or not at all.
+        '';
+    };
+
     # FIXME: obsolete - will remove.
     security.initialRootPassword = mkOption {
       type = types.str;
@@ -506,7 +530,7 @@ in {
         ${pkgs.perl}/bin/perl -w \
           -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl \
           -I${pkgs.perlPackages.JSON}/lib/perl5/site_perl \
-          ${./update-users-groups.pl} ${spec}
+          ${./update-users-groups.pl} ${spec} ${config.users.initialHomeSetup}
       '';
 
     # for backwards compatibility


### PR DESCRIPTION
Provide a new option which allows the user to fill a user's home
directory with initial content.

Tested it thoroughly on my system - Worked like a charm :-)

The perl code can possibly be improved - I never wrote any perl before.
