### PR TITLE
go-modules: Fix copy of go modules src

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -117,7 +117,7 @@ go.stdenv.mkDerivation (
         find . -type f | while read f; do
           echo "$f" | grep -q '^./\(src\|pkg/[^/]*\)/${goPackagePath}' || continue
           mkdir -p "$(dirname "$out/share/go/$f")"
-          cp $NIX_BUILD_TOP/go/$f $out/share/go/$f
+          cp "$NIX_BUILD_TOP/go/$f" "$out/share/go/$f"
         done)
     fi
 


### PR DESCRIPTION
This patch fixes an error with copying sources during installPhase if src of go module conatins file with spaces
