### PR TITLE
freeciv: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -9,13 +9,14 @@ let
   sdlName = if sdlClient then "-sdl" else "";
   gtkName = if gtkClient then "-gtk" else "";
 
-  baseName = "freeciv-2.5.0";
+  name = "freeciv";
+  version = "2.5.0";
 in
 stdenv.mkDerivation {
-  name = baseName + sdlName + gtkName;
+  name = "${name}${sdlName}${gtkName}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/freeciv/${baseName}.tar.bz2";
+    url = "mirror://sourceforge/freeciv/${name}-${version}.tar.bz2";
     sha256 = "bd9f7523ea79b8d2806d0c1844a9f48506ccd18276330580319913c43051210b";
     # sha1 = "477b60e02606e47b31a019b065353c1a6da6c305";
     # md5 = "8a61ecd986853200326711446c573f1b";

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,31 +1,37 @@
 { stdenv, fetchurl, zlib, bzip2, pkgconfig, curl, lzma, gettext
-, sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype
+, sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
 , gtkClient ? false, gtk
 , server ? true, readline }:
 
 let
   inherit (stdenv.lib) optional optionals;
-  client = sdlClient || gtkClient;
 
   sdlName = if sdlClient then "-sdl" else "";
   gtkName = if gtkClient then "-gtk" else "";
 
-  baseName = "freeciv-2.4.0";
+  baseName = "freeciv-2.5.0";
 in
 stdenv.mkDerivation {
   name = baseName + sdlName + gtkName;
 
   src = fetchurl {
     url = "mirror://sourceforge/freeciv/${baseName}.tar.bz2";
-    sha256 = "1bc01pyihsrby6w95n49gi90ggp40dyxsy4kmlmwcakxfxprwakv";
+    sha256 = "bd9f7523ea79b8d2806d0c1844a9f48506ccd18276330580319913c43051210b";
+    # sha1 = "477b60e02606e47b31a019b065353c1a6da6c305";
+    # md5 = "8a61ecd986853200326711446c573f1b";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ zlib bzip2 curl lzma gettext ]
-    ++ optionals sdlClient [ SDL SDL_mixer SDL_image SDL_ttf SDL_gfx freetype ]
-    ++ optional gtkClient gtk
+    ++ optionals sdlClient [ SDL SDL_mixer SDL_image SDL_ttf SDL_gfx freetype fluidsynth ]
+    ++ optionals gtkClient [ gtk ]
     ++ optional server readline;
+
+  configureFlags = []
+    ++ optional sdlClient "--enable-client=sdl"
+    ++ optional (!gtkClient) "--enable-fcmp=cli"
+    ++ optional (!server) "--disable-server";
 
   meta = with stdenv.lib; {
     description = "Multiplayer (or single player), turn-based strategy game";


### PR DESCRIPTION
Update freeciv version to 2.5.0.
Remove the gtk switch as it is expected to be present by default.
