### PR TITLE
chromium: Fix widevine ppapi plugin loading

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -53,7 +53,7 @@ let
       wvDescription = "Playback of encrypted HTML audio/video content";
       wvMimeTypes = "application/x-ppapi-widevine-cdm";
       wvModule = "$widevine/lib/libwidevinecdmadapter.so";
-      wvInfo = "#${wvName}#${wvDescription}:${wvMimeTypes}";
+      wvInfo = "#${wvName}#${wvDescription};${wvMimeTypes}";
     in ''
       flashVersion="$(
         sed -n -r 's/.*"version": "([^"]+)",.*/\1/p' PepperFlash/manifest.json


### PR DESCRIPTION
See "Running a plugin in Chrome" section at:
https://www.chromium.org/developers/design-documents/pepper-plugin-implementation

The colon between the plugin's description and its mime type is indeed
supposed to be a semicolon, according to that design doc.
