### PR TITLE
kernel: Enable DRM_LOAD_EDID_FIRMWARE

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -141,6 +141,8 @@ with stdenv.lib;
   # Video configuration.
   # Enable KMS for devices whose X.org driver supports it.
   DRM_I915_KMS y
+  # Allow specifying custom EDID on the kernel command line
+  DRM_LOAD_EDID_FIRMWARE y
   ${optionalString (versionOlder version "3.9") ''
     DRM_RADEON_KMS? y
   ''}


### PR DESCRIPTION
This allows specifying `drm_kms_helper.edid_firmware` to work around displays that provide bad EDID data.

Documentation: https://www.osadl.org/Single-View.111+M5ec938a7b3b.0.html
