### PR TITLE
dnsmasq restarts if /etc/hosts file is changed by nixos-rebuild

### DIFF
--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -98,6 +98,7 @@ in
           ExecStart = "${dnsmasq}/bin/dnsmasq -k --enable-dbus --user=dnsmasq -C ${dnsmasqConf}";
           ExecReload = "${dnsmasq}/bin/kill -HUP $MAINPID";
         };
+        restartTriggers = [ config.environment.etc.hosts.source ];
     };
 
   };


### PR DESCRIPTION
fixes issue #8874. Tested locally by changing networking.extraHosts and verifying that 'nixos-rebuild switch' caused the service to restart
