### PR TITLE
luaPackages: add vicious module

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -151,6 +151,7 @@
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";
   magnetophon = "Bart Brouns <bart@magnetophon.nl>";
   mahe = "Matthias Herrmann <matthias.mh.herrmann@gmail.com>";
+  makefu = "Felix Richter <makefu@syntax-fehler.de>";
   malyn = "Michael Alyn Miller <malyn@strangeGizmo.com>";
   manveru = "Michael Fellinger <m.fellinger@gmail.com>";
   marcweber = "Marc Weber <marco-oweber@gmx.de>";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -400,4 +400,29 @@ let
     '';
   };
 
+  vicious = stdenv.mkDerivation rec {
+    name = "vicious-${version}";
+    version = "2.1.3";
+
+    src = fetchzip {
+      url    = "http://git.sysphere.org/vicious/snapshot/vicious-${version}.tar.xz";
+      sha256 = "1c901siza5vpcbkgx99g1vkqiki5qgkzx2brnj4wrpbsbfzq0bcq";
+    };
+
+    meta = with stdenv.lib; {
+      description = "vicious widgets for window managers";
+      homepage    = http://git.sysphere.org/vicious/;
+      license     = licenses.gpl2;
+      maintainers = with maintainers; [ makefu ];
+      platforms   = platforms.linux;
+    };
+
+    buildInputs = [ lua ];
+    installPhase = ''
+      mkdir -p $out/lib/lua/${lua.luaversion}/
+      cp -r . $out/lib/lua/${lua.luaversion}/vicious/
+      printf "package.path = '$out/lib/lua/${lua.luaversion}/?/init.lua;' ..  package.path\nreturn require((...) .. '.init')\n" > $out/lib/lua/${lua.luaversion}/vicious.lua
+    '';
+  };
+
 }; in self


### PR DESCRIPTION
vicious is a module for creating widgets on window managers.
This commit adds the library and a wrapper lua file for easy importing.

I use the library with the awesome window manager via luaModules:

```
services.xserver.windowManager.awesome.luaModules = [
  pkgs.luaPackages.vicious
];
```
