### PR TITLE
qgis: fix python console and processing plugin

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, gdal, cmake, qt4, flex, bison, proj, geos, x11, sqlite, gsl,
-  pyqt4, qwt, fcgi, pythonPackages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper }:
+  qwt, fcgi, pythonPackages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "qgis-2.10.1";
 
-  buildInputs = [ gdal qt4 flex bison proj geos x11 sqlite gsl pyqt4 qwt qscintilla
+  buildInputs = [ gdal qt4 flex bison proj geos x11 sqlite gsl qwt qscintilla
     fcgi libspatialindex libspatialite postgresql ] ++
-    (with pythonPackages; [ numpy psycopg2 ]);
+    (with pythonPackages; [ numpy psycopg2 ]) ++ [ pythonPackages.qscintilla ];
 
   nativeBuildInputs = [ cmake makeWrapper ];
 


### PR DESCRIPTION
This PR addresses #9121.

It seems that python module `PyQt4.Qsci` has to be put in the same directory as `PyQt4` itself. Hence the symlinks. Suggestions are welcome.

I haven’t tested the processing plugin, just checked that the error messages have disappeared. @mucaho: would you like to test it?
