### PR TITLE
wrap sbt with $JAVA_HOME

### DIFF
--- a/pkgs/development/tools/build-managers/sbt/default.nix
+++ b/pkgs/development/tools/build-managers/sbt/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cat > $out/bin/sbt << EOF
     #! ${stdenv.shell}
+    if [ ! -v JAVA_HOME ]; then
+        export JAVA_HOME="${jre.home}"
+    fi
     ${jre}/bin/java \$SBT_OPTS -jar ${src} "\$@"
     EOF
     chmod +x $out/bin/sbt


### PR DESCRIPTION
sbt needs to know JAVA_HOME for some applications (e.g. executing `ensime-gen` as in https://github.com/ensime/ensime-emacs/wiki/Quick-Start-Guide).
