### PR TITLE
gateone: Fix startup

### DIFF
--- a/nixos/modules/services/networking/gateone.nix
+++ b/nixos/modules/services/networking/gateone.nix
@@ -36,8 +36,10 @@ config = mkIf cfg.enable {
     preStart = ''
       if [ ! -d ${cfg.settingsDir} ] ; then
         mkdir -m 0750 -p ${cfg.settingsDir}
-        mkdir -m 0750 -p ${cfg.pidDir}
         chown -R gateone.gateone ${cfg.settingsDir}
+      fi
+      if [ ! -d ${cfg.pidDir} ] ; then
+        mkdir -m 0750 -p ${cfg.pidDir}
         chown -R gateone.gateone ${cfg.pidDir}
       fi
       '';


### PR DESCRIPTION
Check for cfg.pidDir and create when needed.
