### PR TITLE
mupdf: desktop file fix

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     Version=1.0
     Name=mupdf
     Comment=PDF viewer
-    Exec=$out/bin/mupdf-x11
+    Exec=$out/bin/mupdf-x11 %f
     Terminal=false
     EOF
   '';


### PR DESCRIPTION
Fix for mupdf desktop file to make it work nicely with `xdg-open`.
see #9151 for details.
