### PR TITLE
spyder: 2.2.5 -> 2.3.6

### DIFF
--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -8,20 +8,28 @@
 }:
 
 buildPythonPackage rec {
-  name = "spyder-2.2.5";
+  name = "spyder-${version}";
+  version = "2.3.6";
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://spyderlib.googlecode.com/files/${name}.zip";
-    sha256 = "1bxc5qs2bqc21s6kxljsfxnmwgrgnyjfr9mkwzg9njpqsran3bp2";
+    url = "https://pypi.python.org/packages/source/s/spyder/${name}.zip";
+    sha256 = "0e6502e0d3f270ea8916d1a3d7ca29915801d31932db399582bc468c01d535e2";
   };
+  
+  
 
   buildInputs = [ unzip ];
   propagatedBuildInputs =
-    [ pyside pyflakes rope sphinx numpy scipy matplotlib ipython pylint pep8 ];
+    [ pyside pyflakes sphinx numpy scipy matplotlib ipython pylint pep8 ];
 
   # There is no test for spyder
   doCheck = false;
+  
+  # Use setuptools instead of distutils.
+  preConfigure = ''
+    export USE_SETUPTOOLS=True
+  '';
 
   desktopItem = makeDesktopItem {
     name = "Spyder";
@@ -49,7 +57,7 @@ buildPythonPackage rec {
       environment for the Python language with advanced editing, interactive
       testing, debugging and introspection features.
     '';
-    homepage = https://code.google.com/p/spyderlib/;
+    homepage = https://github.com/spyder-ide/spyder/;
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13262,6 +13262,8 @@ let
     };
   });
 
+  spyder = callPackage ../applications/science/spyder {};
+  
   sqlalchemy = self.sqlalchemy9.override rec {
     name = "SQLAlchemy-0.7.10";
     disabled = isPy34;


### PR DESCRIPTION
This upgrades spyder to the latest version.

Currently, spyder on Nix is only available for Python 2 while it can work with Python 3 as well.
Therefore, I added `spyder = callPackage ../applications/science/spyder {};`.

The module `rope` is recommended but not (yet) ported to Python 3. Therefore, I removed it from the list of requirements. It might be nice to optionally add it for Python 2. Also, how to handle the rope option on the top?

It built and worked fine on Python 3. However, on Python 2 installation failed with `error: option --old-and-unmanageable not recognized`.
