### PR TITLE
gnuradio: rename *-wrapper and *-full attributes to *-with-packages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11343,9 +11343,7 @@ let
     fftw = fftwFloat;
   };
 
-  gnuradio-wrapper = callPackage ../applications/misc/gnuradio/wrapper.nix { };
-
-  gnuradio-full = gnuradio-wrapper.override {
+  gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {
     extraPackages = [ gnuradio-osmosdr ];
   };
 


### PR DESCRIPTION
Having both *-wrapper and *-full attribute names is rather confusing
(what's the difference?). And further, both packages are named
gnuradio-with-packages:

```
  $ nix-env -f. -qaP ".*gnuradio.*"
  gnuradio          gnuradio-3.7.7.1
  gnuradio-osmosdr  gnuradio-osmosdr-0.1.4
  gnuradio-full     gnuradio-with-packages-3.7.7.1
  gnuradio-wrapper  gnuradio-with-packages-3.7.7.1
```

Get rid of *-wrapper and rename *-full to *-with-packages, to align it
with the package name.

Now:

```
  $ nix-env -f. -qaP ".*gnuradio.*"
  gnuradio                gnuradio-3.7.7.1
  gnuradio-osmosdr        gnuradio-osmosdr-0.1.4
  gnuradio-with-packages  gnuradio-with-packages-3.7.7.1
```

And you can customize the *-with-packages variant like this:

```
  gnuradio-with-packages.override { extraPackages = [...]; }
```
