### PR TITLE
xpra: 0.14.19 -> 0.15.3

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -6,12 +6,12 @@
 , libfakeXinerama }:
 
 buildPythonPackage rec {
-  name = "xpra-0.14.19";
+  name = "xpra-0.15.3";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://www.xpra.org/src/${name}.tar.xz";
-    sha256 = "0jifaysz4br1v0zibnzgd0k02rgybbsysvwrgbar1452sjb3db5m";
+    sha256 = "1671r4ah2h0i3qbp27csck506n5y1zr9fv0869cv09knspa358i4";
   };
 
   buildInputs = [


### PR DESCRIPTION
Update xpra from 0.14.19 to 0.15.3
Also preferably, if someone, who already used xpra test new version.
