### PR TITLE
gtkpod: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/applications/audio/gtkpod/default.nix
+++ b/pkgs/applications/audio/gtkpod/default.nix
@@ -3,12 +3,12 @@
   libvorbis, hicolor_icon_theme, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
-  version = "2.1.4";
+  version = "2.1.5";
   name = "gtkpod-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/gtkpod/${name}.tar.gz";
-    sha256 = "ba12b35f3f24a155b68f0ffdaf4d3c5c7d1b8df04843a53306e1c83fc811dfaa";
+    sha256 = "0xisrpx069f7bjkyc8vqxb4k0480jmx1wscqxr6cpq1qj6pchzd5";
   };
 
   propagatedUserEnvPkgs = [ gnome.gnome_themes_standard ];


### PR DESCRIPTION
This fixes some issues with libanjuta. The previous version spitted out hundrets
of error messages whenever gtkpod changed the progressbar. This issue is fixed
in 2.1.5.
