### PR TITLE
lib.updateName: use a different mechanism

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -28,7 +28,8 @@ rec {
      Example:
        updateName (oldName: oldName + "-experimental") somePkg
   */
-  updateName = updater: drv: drv // {name = updater (drv.name);};
+  updateName = updater: drv: drv.overrideDerivation
+    (args: {name = updater args.name;});
 
 
   /* Append a suffix to the name of a package (before the version

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -20,8 +20,7 @@ rec {
   /* Change the symbolic name of a package for presentation purposes
      (i.e., so that nix-env users can tell them apart).
   */
-  setName = name: drv: drv // {inherit name;};
-
+  setName = name: updateName (_oldName: name);
 
   /* Like `setName', but takes the previous name as an argument.
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14992,9 +14992,10 @@ let
   You need to use texLiveAggregationFun to regenerate, say, ls-R (TeX-related file list)
   Just installing a few packages doesn't work.
   */
-  texLiveAggregationFun = params:
+  texLiveAggregationFun = makeOverridable (params:
     builderDefsPackage (import ../tools/typesetting/tex/texlive/aggregate.nix)
-      ({inherit poppler perl makeWrapper;} // params);
+      ({inherit poppler perl makeWrapper;} // params)
+  );
 
   texDisser = callPackage ../tools/typesetting/tex/disser {};
 


### PR DESCRIPTION
_I'm merging in a few days if there are no objections._

I found it slightly confusing that the paths of packages like `bashInteractive` didn't reflect the name seen by nix-env.  I really prefer to keep these names equal.

Now `appendToName` changes also the name-part in $out and drv paths. Name changes will cause a rebuild now, but it's a custom to use it for differently configured variants, i.e. the rebuild would happen anyway.
