### PR TITLE
keychain: support Darwin as a platform

### DIFF
--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, makeWrapper, coreutils, openssh, gnupg
-, perl, procps, gnugrep, gawk, findutils, gnused }:
+, perl, procps, gnugrep, gawk, findutils, gnused
+, withProcps ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
   name = "keychain-${version}";
@@ -26,12 +27,16 @@ stdenv.mkDerivation rec {
       --prefix PATH ":" "${gnused}/bin" \
       --prefix PATH ":" "${findutils}/bin" \
       --prefix PATH ":" "${gawk}/bin" \
-      --prefix PATH ":" "${procps}/bin"
+      ${if withProcps then ("--prefix PATH \":\" ${procps}/bin") else ""}
   '';
 
   meta = {
     description = "Keychain management tool";
     homepage = "http://www.funtoo.org/Keychain";
     license = stdenv.lib.licenses.gpl2;
+    # other platforms are untested (AFAIK)
+    platforms =
+      with stdenv.lib;
+      platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
This change provides support for Darwin as a platform by making the
`procps` parameter optional. If the platform is linux, then
`procps`/bin is added to the wrapped keychain's PATH, else not.

Tested on:
- [X] darwin (OS X 10.10.3)
- [X] linux

edit: update tested platforms.
