### PR TITLE
metis: init at 5.1.0

### DIFF
--- a/pkgs/development/libraries/science/math/metis/default.nix
+++ b/pkgs/development/libraries/science/math/metis/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, unzip, cmake }:
+
+stdenv.mkDerivation {
+  name = "metis-5.1.0";
+
+  src = fetchurl {
+    url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz";
+    sha256 = "1cjxgh41r8k6j029yxs8msp3z6lcnpm16g5pvckk35kc7zhfpykn";
+  };
+
+  cmakeFlags = [ "-DGKLIB_PATH=../GKlib" ];
+  buildInputs = [ unzip cmake ];
+
+  meta = {
+    description = "Serial graph partitioning and fill-reducing matrix ordering";
+    homepage = http://glaros.dtc.umn.edu/gkhome/metis/metis/overview;
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14316,6 +14316,8 @@ let
 
   sage = callPackage ../applications/science/math/sage { };
 
+  metis = callPackage ../development/libraries/science/math/metis {};
+
   suitesparse_4_2 = callPackage ../development/libraries/science/math/suitesparse/4.2.nix { };
   suitesparse_4_4 = callPackage ../development/libraries/science/math/suitesparse {};
   suitesparse = suitesparse_4_4;


### PR DESCRIPTION
This PR adds the library metis, for serial partitioning of graphs and especially finite element meshes. It is a dependency for numerous scientific libraries.
