### PR TITLE
pgcli: github owner changed from amjith to dbcli

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9359,7 +9359,7 @@ let
       sha256 = "1r34bbqbd4h72cl0cxi9w6q2nwx806wpxq220mzyiy8g45xv0ghj";
       rev = "v${version}";
       repo = "pgcli";
-      owner = "amjith";
+      owner = "dbcli";
     };
 
     propagatedBuildInputs = with self; [


### PR DESCRIPTION
The new location for pgcli is https://github.com/dbcli/pgcli (moved from https://github.com/amjith/pgcli)
