### PR TITLE
elm: add the platform and helpful scripts

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -346,4 +346,24 @@ packageOverrides = pkgs: {
 
 </section>
 
+<section xml:id="sec-elm">
+
+<title>Elm</title>
+
+<para>
+The Nix expressions for Elm reside in
+<filename>pkgs/development/compilers/elm</filename>. They are generated
+automatically by <command>update-elm.rb</command> script. One should
+specify versions of Elm packages inside the script, clear the
+<filename>packages</filename> directory and run the script from inside it.
+<literal>elm-reactor</literal> is special because it also has Elm package
+dependencies. The process is not automated very much for now -- you should
+get the <literal>elm-reactor</literal> source tree (e.g. with
+<command>nix-shell</command>) and run <command>elm2nix.rb</command> inside
+it. Place the resulting <filename>package.nix</filename> file into
+<filename>packages/elm-reactor-elm.nix</filename>.
+</para>
+
+</section>
+
 </chapter>

--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -80,6 +80,9 @@ was accordingly renamed to <literal>bomi</literal>
 was accordingly renamed to <literal>electron</literal>
 </para></listitem>
 
+<listitem><para>Elm is not released on Hackage anymore. You should now use <literal>elmPackages.elm</literal>
+which contains the latest Elm platform.</para></listitem>
+
 <listitem>
   <para>
 	The CUPS printing service has been updated to version <literal>2.0.2</literal>.

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -1,0 +1,81 @@
+{ lib, stdenv, buildEnv, haskell, nodejs, fetchurl, fetchpatch, makeWrapper }:
+
+let
+  makeElmStuff = deps:
+    let json = builtins.toJSON (lib.mapAttrs (name: info: info.version) deps);
+        cmds = lib.mapAttrsToList (name: info: let
+                 pkg = stdenv.mkDerivation {
+
+                   name = lib.replaceChars ["/"] ["-"] name + "-${info.version}";
+
+                   src = fetchurl {
+                     url = "https://github.com/${name}/archive/${info.version}.tar.gz";
+                     meta.homepage = "https://github.com/${name}/";
+                     inherit (info) sha256;
+                   };
+
+                   phases = [ "unpackPhase" "installPhase" ];
+
+                   installPhase = ''
+                     mkdir -p $out
+                     cp -r * $out
+                   '';
+
+                 };
+               in ''
+                 mkdir -p elm-stuff/packages/${name}
+                 ln -s ${pkg} elm-stuff/packages/${name}/${info.version}
+               '') deps;
+    in ''
+      export HOME=/tmp
+      mkdir elm-stuff
+      cat > elm-stuff/exact-dependencies.json <<EOF
+      ${json}
+      EOF
+    '' + lib.concatStrings cmds;
+
+  hsPkgs = haskell.packages.ghc7102.override {
+    overrides = self: super:
+      let hlib = haskell.lib;
+          elmRelease = import ./packages/release.nix { inherit (self) callPackage; };
+          elmPkgs' = elmRelease.packages;
+          elmPkgs = elmPkgs' // {
+
+            elm-reactor = hlib.overrideCabal elmPkgs'.elm-reactor (drv: {
+              buildTools = drv.buildTools or [] ++ [ self.elm-make ];
+              patches = [ (fetchpatch {
+                url = "https://github.com/elm-lang/elm-reactor/commit/ca4d91d3fc7c6f72aa802d79fd1563ab5f3c4f2c.patch";
+                sha256 = "1msq7rvjid27m11lwcz9r1vyczlk7bfknyywqln300c8bgqyl45j";
+              }) ];
+              preConfigure = makeElmStuff (import ./packages/elm-reactor-elm.nix);
+            });
+
+            elm-package = hlib.appendPatch elmPkgs'.elm-package (fetchpatch {
+              url = "https://github.com/elm-lang/elm-package/commit/af517f2ffe15f8ec1d8c38f01ce188bbdefea47a.patch";
+              sha256 = "0yq5vawmp9qq5w6qfy12r32ahpvccra749pnhg0zdykrj369m8a8";
+            });
+
+            elm-repl = hlib.overrideCabal elmPkgs'.elm-repl (drv: {
+              doCheck = false;
+              buildTools = drv.buildTools or [] ++ [ makeWrapper ];
+              postInstall =
+                let bins = lib.makeSearchPath "bin" [ nodejs self.elm-make ];
+                in ''
+                  wrapProgram $out/bin/elm-repl \
+                    --prefix PATH ':' ${bins}
+                '';
+            });
+
+          };
+      in elmPkgs // {
+        inherit elmPkgs;
+        elmVersion = elmRelease.version;
+      };
+  };
+in hsPkgs.elmPkgs // {
+  elm = buildEnv {
+    name = "elm-${hsPkgs.elmVersion}";
+    paths = lib.mapAttrsToList (name: pkg: pkg) hsPkgs.elmPkgs;
+    pathsToLink = [ "/bin" ];
+  };
+}

--- a/pkgs/development/compilers/elm/elm2nix.rb
+++ b/pkgs/development/compilers/elm/elm2nix.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+system("elm-package install -y")
+depsSrc = JSON.parse(File.read("elm-stuff/exact-dependencies.json"))
+deps = Hash[ depsSrc.map { |pkg, ver|
+  url = "https://github.com/#{pkg}/archive/#{ver}.tar.gz"
+  sha256 = `nix-prefetch-url #{url}`
+
+  [ pkg, { version: ver,
+           sha256: sha256.strip
+         }
+  ]
+} ]
+
+File.open("package.nix", 'w') do |file|
+  file.puts "{"
+    for pkg, info in deps
+      file.puts "  \"#{pkg}\" = {"
+      file.puts "    version = \"#{info[:version]}\";"
+      file.puts "    sha256 = \"#{info[:sha256]}\";"
+      file.puts "  };"
+    end
+  file.puts "}"
+end

--- a/pkgs/development/compilers/elm/packages/elm-compiler.nix
+++ b/pkgs/development/compilers/elm/packages/elm-compiler.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, aeson, aeson-pretty, ansi-terminal, base, binary
+, blaze-html, blaze-markup, bytestring, cmdargs, containers
+, directory, edit-distance, fetchgit, filemanip, filepath, HUnit
+, indents, language-ecmascript, language-glsl, mtl, parsec, pretty
+, process, QuickCheck, stdenv, test-framework, test-framework-hunit
+, test-framework-quickcheck2, text, transformers, union-find
+, unordered-containers
+}:
+mkDerivation {
+  pname = "elm-compiler";
+  version = "0.15.1";
+  src = fetchgit {
+    url = "https://github.com/elm-lang/elm-compiler";
+    sha256 = "379a38db4f240ab206a2bbedc49d4768d7cf6fdf497b2d25dea71fca1d58efaa";
+    rev = "7fbdee067b494c0298d07c944629aaa5d3fa82f5";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    aeson aeson-pretty ansi-terminal base binary blaze-html
+    blaze-markup bytestring cmdargs containers directory edit-distance
+    filepath indents language-ecmascript language-glsl mtl parsec
+    pretty process text transformers union-find unordered-containers
+  ];
+  testDepends = [
+    aeson aeson-pretty ansi-terminal base binary blaze-html
+    blaze-markup bytestring cmdargs containers directory edit-distance
+    filemanip filepath HUnit indents language-ecmascript language-glsl
+    mtl parsec pretty process QuickCheck test-framework
+    test-framework-hunit test-framework-quickcheck2 text transformers
+    union-find
+  ];
+  jailbreak = true;
+  homepage = "http://elm-lang.org";
+  description = "Values to help with elm-package, elm-make, and elm-lang.org.";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-make.nix
+++ b/pkgs/development/compilers/elm/packages/elm-make.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, aeson, ansi-wl-pprint, base, binary, blaze-html
+, blaze-markup, bytestring, containers, directory, elm-compiler
+, elm-package, fetchgit, filepath, mtl, optparse-applicative
+, stdenv, text
+}:
+mkDerivation {
+  pname = "elm-make";
+  version = "0.2";
+  src = fetchgit {
+    url = "https://github.com/elm-lang/elm-make";
+    sha256 = "b618e827ca01ddeae38624f4bf5baa3dc4cb6e9e3c9bf15f2dda5a7c756bca33";
+    rev = "d9bedfdadc9cefce8e5249db6a316a5e712158d0";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  buildDepends = [
+    aeson ansi-wl-pprint base binary blaze-html blaze-markup bytestring
+    containers directory elm-compiler elm-package filepath mtl
+    optparse-applicative text
+  ];
+  jailbreak = true;
+  homepage = "http://elm-lang.org";
+  description = "A build tool for Elm projects";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-package.nix
+++ b/pkgs/development/compilers/elm/packages/elm-package.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, aeson-pretty, ansi-wl-pprint, base, binary
+, bytestring, containers, directory, elm-compiler, fetchgit
+, filepath, HTTP, http-client, http-client-tls, http-types, mtl
+, network, optparse-applicative, pretty, process, stdenv, text
+, time, unordered-containers, vector, zip-archive
+}:
+mkDerivation {
+  pname = "elm-package";
+  version = "0.5.1";
+  src = fetchgit {
+    url = "https://github.com/elm-lang/elm-package";
+    sha256 = "0d69e68831f4a86c6c02aed33fc3a6aca87636a7fb0bb6e39ffc74ddd15b5435";
+    rev = "365e2d86a8222c92e50951c7d30b3c5db44c383d";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    aeson aeson-pretty ansi-wl-pprint base binary bytestring containers
+    directory elm-compiler filepath HTTP http-client http-client-tls
+    http-types mtl network optparse-applicative pretty process text
+    time unordered-containers vector zip-archive
+  ];
+  jailbreak = true;
+  homepage = "http://github.com/elm-lang/elm-package";
+  description = "Package manager for Elm libraries";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
@@ -1,0 +1,18 @@
+{
+  "evancz/virtual-dom" = {
+    version = "1.2.3";
+    sha256 = "03iv9fpng3gvia00v3gl8rs83j5b112hx0vm36az13zjr378b1jr";
+  };
+  "evancz/elm-markdown" = {
+    version = "1.1.5";
+    sha256 = "01vdaz56i064lah7kd8485j0y33di8wa134sr4292wb3na990a8r";
+  };
+  "evancz/elm-html" = {
+    version = "3.0.0";
+    sha256 = "0a2iw45x3qwxkgibkc6qx1csfa06gpkfc9b04vkq1h7ynw2g5577";
+  };
+  "elm-lang/core" = {
+    version = "2.1.0";
+    sha256 = "10fg7bcc310b5bwv6sq7gjhy9r5xzc98nbk4zhs4jqykn36i6l43";
+  };
+}

--- a/pkgs/development/compilers/elm/packages/elm-reactor.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, base, blaze-html, blaze-markup, bytestring, cmdargs
+, containers, directory, elm-compiler, fetchgit, filepath, fsnotify
+, HTTP, mtl, process, snap-core, snap-server, stdenv
+, system-filepath, text, time, transformers, unordered-containers
+, websockets, websockets-snap
+}:
+mkDerivation {
+  pname = "elm-reactor";
+  version = "0.3.2";
+  src = fetchgit {
+    url = "https://github.com/elm-lang/elm-reactor";
+    sha256 = "a7775971ea6634f13436f10098c462d39c6e115dbda79e537831a71975451e9a";
+    rev = "b6c11be539734e72015ce151a9189d06dfc9db76";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  buildDepends = [
+    base blaze-html blaze-markup bytestring cmdargs containers
+    directory elm-compiler filepath fsnotify HTTP mtl process snap-core
+    snap-server system-filepath text time transformers
+    unordered-containers websockets websockets-snap
+  ];
+  jailbreak = true;
+  homepage = "http://elm-lang.org";
+  description = "Interactive development tool for Elm programs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/elm-repl.nix
+++ b/pkgs/development/compilers/elm/packages/elm-repl.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, base, binary, bytestring, bytestring-trie, cmdargs
+, containers, directory, elm-compiler, elm-package, fetchgit
+, filepath, haskeline, HUnit, mtl, parsec, process, QuickCheck
+, stdenv, test-framework, test-framework-hunit
+, test-framework-quickcheck2
+}:
+mkDerivation {
+  pname = "elm-repl";
+  version = "0.4.2";
+  src = fetchgit {
+    url = "https://github.com/elm-lang/elm-repl";
+    sha256 = "a6eadbef7886c4c65243723f101910909bb0d53b2c48454ed7b39cf700f9649c";
+    rev = "0c434fdb24b86a93b06c33c8f26857ce47caf165";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  buildDepends = [
+    base binary bytestring bytestring-trie cmdargs containers directory
+    elm-compiler elm-package filepath haskeline mtl parsec process
+  ];
+  testDepends = [
+    base bytestring bytestring-trie cmdargs directory elm-compiler
+    elm-package filepath haskeline HUnit mtl parsec process QuickCheck
+    test-framework test-framework-hunit test-framework-quickcheck2
+  ];
+  jailbreak = true;
+  homepage = "https://github.com/elm-lang/elm-repl";
+  description = "a REPL for Elm";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/packages/release.nix
+++ b/pkgs/development/compilers/elm/packages/release.nix
@@ -1,0 +1,11 @@
+{ callPackage }:
+{
+  version = "0.15.1";
+  packages = {
+    elm-compiler = callPackage ./elm-compiler.nix { };
+    elm-package = callPackage ./elm-package.nix { };
+    elm-make = callPackage ./elm-make.nix { };
+    elm-reactor = callPackage ./elm-reactor.nix { };
+    elm-repl = callPackage ./elm-repl.nix { };
+  };
+}

--- a/pkgs/development/compilers/elm/update-elm.rb
+++ b/pkgs/development/compilers/elm/update-elm.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+# Take those from https://github.com/elm-lang/elm-platform/blob/master/installers/BuildFromSource.hs
+$elm_version = "0.15.1"
+$elm_packages = { "elm-compiler" => "0.15.1",
+                  "elm-package" => "0.5.1",
+                  "elm-make" => "0.2",
+                  "elm-reactor" => "0.3.2",
+                  "elm-repl" => "0.4.2"
+                }
+
+for pkg, ver in $elm_packages
+  system "cabal2nix https://github.com/elm-lang/#{pkg} --revision refs/tags/#{ver} --jailbreak > #{pkg}.nix"
+end
+
+File.open("release.nix", 'w') do |file|
+  file.puts "{"
+  file.puts "  version = \"#{$elm_version}\";"
+  file.puts "  packages = {"
+  for pkg, ver in $elm_packages
+    file.puts "    #{pkg} = callPackage ./#{pkg}.nix { };"
+  end
+  file.puts "  };"
+  file.puts "}"
+end

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -910,12 +910,9 @@ self: super: {
 
   # Elm is no longer actively maintained on Hackage: https://github.com/NixOS/nixpkgs/pull/9233.
   Elm = markBroken super.Elm;
-  elm-bridge = markBroken super.elm-bridge;
   elm-build-lib = markBroken super.elm-build-lib;
   elm-compiler = markBroken super.elm-compiler;
-  elm-core-sources = markBroken super.elm-core-sources;
   elm-get = markBroken super.elm-get;
-  elm-init = markBroken super.elm-init;
   elm-make = markBroken super.elm-make;
   elm-package = markBroken super.elm-package;
   elm-reactor = markBroken super.elm-reactor;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3729,6 +3729,8 @@ let
 
   eql = callPackage ../development/compilers/eql {};
 
+  elmPackages = callPackage ../development/compilers/elm { };
+
   adobe_flex_sdk = callPackage ../development/compilers/adobe-flex-sdk { };
 
   fpc = callPackage ../development/compilers/fpc { };


### PR DESCRIPTION
cc @peti -- I haven't integrated this into haskell-modules, instead using overrides to add needed packages. Maybe we want to do this some other way?

TODO:
- Documentation
- A way to package elm modules? (don't see any use case for now)
