### PR TITLE
nixos module for accepting licenses

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -347,6 +347,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "OpenSSL License";
   };
 
+  oraclejavabcl = {
+    fullName = "Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX";
+    url = "http://www.oracle.com/technetwork/java/javase/terms/license/index.html";
+  };
+
   php301 = spdx {
     spdxId = "PHP-3.01";
     fullName = "PHP License v3.01";

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -52,11 +52,6 @@ in rec {
 
   # These are the extra arguments passed to every module.  In
   # particular, Nixpkgs is passed through the "pkgs" argument.
-  # FIXME: we enable config.allowUnfree to make packages like
-  # nvidia-x11 available. This isn't a problem because if the user has
-  # ‘nixpkgs.config.allowUnfree = false’, then evaluation will fail on
-  # the 64-bit package anyway. However, it would be cleaner to respect
-  # nixpkgs.config here.
   extraArgs = extraArgs_ // {
     inherit modules baseModules;
   };

--- a/nixos/modules/misc/extra-arguments.nix
+++ b/nixos/modules/misc/extra-arguments.nix
@@ -4,7 +4,7 @@
   _module.args = {
     pkgs_i686 = import ../../.. {
       system = "i686-linux";
-      config.allowUnfree = true;
+      config.allowUnfree = config.nixpkgs.licenses.allowUnfree;
     };
 
     utils = import ../../lib/utils.nix pkgs;

--- a/nixos/modules/misc/licenses.nix
+++ b/nixos/modules/misc/licenses.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.nixpkgs.licenses;
 
+  accept = x: x == "accept";
+
 in
 
 {
@@ -22,6 +24,19 @@ in
         '';
       };
 
+      oracleBinaryCodeLicenseForJava = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Say "accept" if you accept the:
+
+          Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
+ 
+          The full license text is at:
+          http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+        '';
+      };
+
     };
 
   };
@@ -32,6 +47,9 @@ in
     nixpkgs.config = {
 
       allowUnfree = cfg.allowUnfree;
+
+      blacklistedLicenses = []
+        ++ lib.optional (!accept cfg.oracleBinaryCodeLicenseForJava) lib.licenses.oraclejavabcl;
 
     };
 

--- a/nixos/modules/misc/licenses.nix
+++ b/nixos/modules/misc/licenses.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.nixpkgs.licenses;
+
+in
+
+{
+  options = {
+
+    nixpkgs.licenses = {
+
+      allowUnfree = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Allow all unfree licenses. If false packages with an
+          unfree license cannot be installed from nixpkgs.
+        '';
+      };
+
+    };
+
+  };
+
+
+  config = {
+
+    nixpkgs.config = {
+
+      allowUnfree = cfg.allowUnfree;
+
+    };
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -49,6 +49,7 @@
   ./misc/extra-arguments.nix
   ./misc/ids.nix
   ./misc/lib.nix
+  ./misc/licenses.nix
   ./misc/locate.nix
   ./misc/meta.nix
   ./misc/nixpkgs.nix

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -9,7 +9,7 @@ source $mirrorsFile
 # cryptographic hash of the output anyway).
 curl="curl \
  --location --max-redirs 20 \
- --retry 3
+ --retry 3 \
  --disable-epsv \
  --cookie-jar cookies \
  --insecure \
@@ -32,7 +32,7 @@ tryDownload() {
     # if we get error code 18, resume partial download
     while [ $curlexit -eq 18 ]; do
        # keep this inside an if statement, since on failure it doesn't abort the script
-       if $curl -C - --fail "$url" --output "$downloadedFile"; then
+       if eval $curl -C - --fail "$url" --output "$downloadedFile"; then
           success=1
           break
        else
@@ -58,7 +58,7 @@ tryHashedMirrors() {
 
     for mirror in $hashedMirrors; do
         url="$mirror/$outputHashAlgo/$outputHash"
-        if $curl --retry 0 --connect-timeout "${NIX_CONNECT_TIMEOUT:-15}" \
+        if eval $curl --retry 0 --connect-timeout "${NIX_CONNECT_TIMEOUT:-15}" \
             --fail --silent --show-error --head "$url" \
             --write-out "%{http_code}" --output /dev/null > code 2> log; then
             tryDownload "$url"

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -1,16 +1,16 @@
 { productVersion
 , patchVersion
-, downloadUrl
+, url_i686
+, url_x86_64
 , sha256_i686
 , sha256_x86_64
-, jceName
-, jceDownloadUrl
+, urlJCE
 , sha256JCE
 }:
 
 { swingSupport ? true
 , stdenv
-, requireFile
+, fetchurl
 , unzip
 , file
 , xlibs ? null
@@ -51,10 +51,10 @@ let
 
   jce =
     if installjce then
-      requireFile {
-        name = jceName;
-        url = jceDownloadUrl;
+      fetchurl {
+        url = urlJCE;
         sha256 = sha256JCE;
+        curlOpts = "-H \`echo 'Cookie: oraclelicense=accept-securebackup-cookie'\`";
       }
     else
       "";
@@ -66,16 +66,16 @@ let result = stdenv.mkDerivation rec {
 
   src =
     if stdenv.system == "i686-linux" then
-      requireFile {
-        name = "jdk-${productVersion}u${patchVersion}-linux-i586.tar.gz";
-        url = downloadUrl;
+      fetchurl {
+        url = url_i686;
         sha256 = sha256_i686;
+        curlOpts = "-H 'Cookie: oraclelicense=accept-securebackup-cookie'";
       }
     else if stdenv.system == "x86_64-linux" then
-      requireFile {
-        name = "jdk-${productVersion}u${patchVersion}-linux-x64.tar.gz";
-        url = downloadUrl;
+      fetchurl {
+        url = url_x86_64;
         sha256 = sha256_x86_64;
+        curlOpts = "-H 'Cookie: oraclelicense=accept-securebackup-cookie'";
       }
     else
       abort "jdk requires i686-linux or x86_64 linux";
@@ -182,6 +182,6 @@ let result = stdenv.mkDerivation rec {
 
   passthru.home = result;
 
-  meta.license = stdenv.lib.licenses.unfree;
+  meta.license = stdenv.lib.licenses.oraclejavabcl;
 
 }; in result

--- a/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
   patchVersion = "79";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
+  url_i686 = http://download.oracle.com/otn-pub/java/jdk/7u79-b15/jdk-7u79-linux-i586.tar.gz;
+  url_x86_64 = http://download.oracle.com/otn-pub/java/jdk/7u79-b15/jdk-7u79-linux-x64.tar.gz;
   sha256_i686 = "1hv9bmj08y8gavhhkip5w5dg96b1dy4sc2cidpjcbwpb2mzh5lhs";
   sha256_x86_64 = "140xl5kfdrlmh8wh2x3j23x53dbil8qxsvc7gf3138mz4805vmr9";
-  jceName = "UnlimitedJCEPolicyJDK7.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
+  urlJCE = http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";
 }

--- a/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "7";
   patchVersion = "80";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html;
+  url_i686 = http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-i586.tar.gz;
+  url_x86_64 = http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.tar.gz;
   sha256_i686 = "1fjpm8pa74c4vgv93lnky6pd3igln56yxdn4kbhgcg12lwc17vcx";
   sha256_x86_64 = "08wn62sammvsvlqac0n8grrikl0ykh9ikqdy823i2mcnccqsgnds";
-  jceName = "UnlimitedJCEPolicyJDK7.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
+  urlJCE = http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";
 }

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
   patchVersion = "51";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
+  url_i686 = http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-8u51-linux-i586.tar.gz;
+  url_x86_64 = http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-8u51-linux-x64.tar.gz;
   sha256_i686 = "0awzgs090n2cj6a5mlla0pgxk0y6aslhm6024pqrnxgai1fkmm1z";
   sha256_x86_64 = "1wggrcr2gjwkv5bawgcw86h6rhyzw0jphxm1sfwcvhjirh99056p";
-  jceName = "jce_policy-8.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
+  urlJCE = http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -19,7 +19,7 @@ let
   allowUnfree = config.allowUnfree or false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
 
   whitelist = config.whitelistedLicenses or [];
-  blacklist = config.blacklistedLicenses or [];
+  blacklist = config.blacklistedLicenses or [ lib.licenses.oraclejavabcl ];
 
   ifDarwin = attrs: if system == "x86_64-darwin" then attrs else {};
 


### PR DESCRIPTION
A general module where nixpkgs related licenses can be accepted.
The module also helps to documents the available options.

For example, the "allowUnfree" nixpkgs option can now be accepted
by the following configuration in the "nixos/configuration.nix".
  nixpkgs = {
    licenses = {
      allowUnfree = true;
    };
  };

The module also fixes the issue of passing "allowUnfree=true" to
the i686 package tree within x86_64 systems.

NOTE: The module only affects the evaluation of the system wide
      configuration. User initiated "nix-env" commands are not in-
      fluenced. A future "nixuser" program will take care of that.

As an example, the installation of oraclejdk is handled by the new
module.
The license of the oraclejdk{7,7psu,8} packages have been changed
to the "Oracle Binary Code License Agreement for the Java SE Platform
Products and JavaFX". The packages can now only be installed once the
license is accepted, e.g., within the "nixos/modules/misc/licenses.nix"
module.
To accept the license for nixos system wide evaluations, the following can
be added to the nixos/configuration.nix file:
  nixpkgs = {
    licenses = {
      oracleBinaryCodeLicenseForJava = "accept";
    };
  };
