### PR TITLE
colordiff: support Darwin as a platform

### DIFF
--- a/pkgs/tools/text/colordiff/default.nix
+++ b/pkgs/tools/text/colordiff/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     description = "Wrapper for 'diff' that produces the same output but with pretty 'syntax' highlighting";
     homepage = http://www.colordiff.org/;
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainer = with maintainers; [ nckx ];
   };
 }


### PR DESCRIPTION
This change just adds darwin to the supported platforms attribute of
the package.

Tested on OS X 10.10.3

@nckx for review.
