### PR TITLE
nixos: add services.printing.snmpConf option

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -160,6 +160,17 @@ in
         '';
       };
 
+      snmpConf = mkOption {
+        type = types.lines;
+        default = ''
+          Address @LOCAL
+        '';
+        description = ''
+          The contents of <filename>/etc/cups/snmp.conf</filename>. See "man
+          cups-snmp.conf" for a complete description.
+        '';
+      };
+
       drivers = mkOption {
         type = types.listOf types.path;
         example = literalExample "[ pkgs.splix ]";
@@ -199,6 +210,7 @@ in
     environment.etc."cups/cups-files.conf".text = cfg.cupsFilesConf;
     environment.etc."cups/cupsd.conf".text = cfg.cupsdConf;
     environment.etc."cups/cups-browsed.conf".text = cfg.browsedConf;
+    environment.etc."cups/snmp.conf".text = cfg.snmpConf;
 
     services.dbus.packages = [ cups ];
 


### PR DESCRIPTION
And set the default value to "Address @LOCAL". This change is needed to
find printers at my workplace (with "lpinfo -v" or the
"system-config-printer" GUI). Ubuntu 14.04 also has this as default.

snmp.conf does not seem to be needed in restartTriggers, because it is
not the cups daemon itself that reads it, but some helper programs that
it spawns on demand.
