### PR TITLE
nixuser: declarative user environments

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -224,6 +224,13 @@ rec {
       merge = mergeOneOption;
     };
 
+    relativePath = mkOptionType {
+      name = "relativePath";
+      # Hacky: there is no ‘isRelativePath’ primop.
+      check = x: builtins.substring 0 1 (toString x) != "/";
+      merge = mergeOneOption;
+    };
+
     # drop this in the future:
     list = builtins.trace "`types.list` is deprecated; use `types.listOf` instead" types.listOf;
 

--- a/nixos/modules/config/nixup.nix
+++ b/nixos/modules/config/nixup.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  resource-manager = pkgs.stdenv.mkDerivation {
+    name = "resource-manager";
+    buildInputs = with pkgs; [ openssl attr libbsd ];
+    buildCommand = ''
+      mkdir -p $out/bin
+      gcc -O2 -Wall -lssl -lbsd -o $out/bin/resource-manager ${./resource-manager.c}
+    '';
+  };
+
+in
+
+{
+
+  options.nixup.enable = mkEnableOption "NixUP";
+
+  config = mkIf config.nixup.enable {
+    security.wrappers = {
+      resource-manager.source = "${resource-manager}/bin/resource-manager";
+    };
+
+    environment.systemPackages = [ config.system.build.nixup-rebuild resource-manager ];
+
+    environment.sessionVariables = {
+      NIXUP_USER_PROFILE_DIR = "/nix/var/nix/profiles/nixup/\${USER}";
+    };
+
+    security.pam.services =
+    let
+      sessionCommand = ''
+        PATH=${pkgs.coreutils}/bin:$PATH
+
+        # Set up the per-user profile.
+        NIXUP_USER_PROFILE_DIR=/nix/var/nix/profiles/nixup/$PAM_USER
+        if ! test -e $NIXUP_USER_PROFILE_DIR; then
+            mkdir -m 0755 -p $NIXUP_USER_PROFILE_DIR
+            chown $(id -u $PAM_USER):$(id -g $PAM_USER) $NIXUP_USER_PROFILE_DIR
+        fi
+
+        if test "$(stat --printf '%u' $NIXUP_USER_PROFILE_DIR)" != "$(id -u $PAM_USER)"; then
+            echo "WARNING: bad ownership on $NIXUP_USER_PROFILE_DIR" >&2
+        fi
+
+        # Set up the per-user gcroot.
+        NIXUP_USER_GCROOTS_DIR=/nix/var/nix/gcroots/nixup/$PAM_USER
+        if ! test -e $NIXUP_USER_GCROOTS_DIR; then
+            mkdir -m 0755 -p $NIXUP_USER_GCROOTS_DIR
+            chown $(id -u $PAM_USER):$(id -g $PAM_USER) $NIXUP_USER_GCROOTS_DIR
+        fi
+
+        if test "$(stat --printf '%u' $NIXUP_USER_GCROOTS_DIR)" != "$(id -u $PAM_USER)"; then
+            echo "WARNING: bad ownership on $NIXUP_USER_GCROOTS_DIR" >&2
+        fi
+
+        # Activate nixup user profile.
+        if test -e $NIXUP_USER_PROFILE_DIR/default/activate; then
+            ${pkgs.sudo}/bin/sudo -u $PAM_USER -H NIXUP_RUNTIME_DIR="/run/user/$(id -u $PAM_USER)/nixup" $NIXUP_USER_PROFILE_DIR/default/activate
+        fi
+      '';
+    in
+    {
+      systemd-user = { sessionCommands = sessionCommand; };
+    };
+
+  };
+
+}

--- a/nixos/modules/config/resource-manager.c
+++ b/nixos/modules/config/resource-manager.c
@@ -1,0 +1,821 @@
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdnoreturn.h>
+#include <sys/stat.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <attr/xattr.h>
+#include <bsd/string.h>
+#include <openssl/md5.h>
+#include <ftw.h>
+
+
+
+/*
+ * Linux kernel patches to add  fsetxattrat, fgetxattrat, flistxattrat, fremovexattrat syscalls:
+ *
+ * https://lkml.org/lkml/2014/1/21/266
+ * https://lkml.org/lkml/2014/1/21/264
+ * https://lkml.org/lkml/2014/1/21/192
+ * https://lkml.org/lkml/2014/1/21/207
+ */
+
+#ifdef DEBUG
+#define DEBUG_TEST 1
+#else
+#define DEBUG_TEST 0
+#endif
+
+
+/*
+ * error handling helper functions
+ */
+
+#define RAISE(code) raise_((code), __FILE__, __LINE__)
+noreturn static inline void raise_(int code, const char *file, int line) {
+    fprintf (stderr, "%s:%d: unexpected error=%d (%s).\n", file, line, code, strerror(code));
+    abort();
+}
+
+#define ENFORCE(ret) enforce((ret), __FILE__, __LINE__)
+static inline int enforce(int ret, const char *file, int line) {
+    if (ret < 0) {
+        raise_(errno, file, line);
+    } else {
+        return ret;
+    }
+}
+
+#define debug_print(fmt, ...) do { if (DEBUG_TEST) fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, __LINE__, __func__, __VA_ARGS__); } while (0)
+
+
+//
+// global variables
+//
+#define OPEN_MAX 20
+
+#define H_STATIC 0
+#define H_VOLATILE 1
+
+static uid_t ruid, euid;
+static gid_t rgid, egid;
+
+static char target_old[PATH_MAX];
+static char target_new[PATH_MAX];
+static char home[PATH_MAX];
+
+
+
+
+//
+// symbolic link
+//
+
+static void symlink_md5_measure(int fd, char* hash) {
+    char buf[PATH_MAX];
+    ssize_t nbytes;
+
+    buf[PATH_MAX-1] = '\0';
+    nbytes = ENFORCE(readlinkat(fd, "", buf, PATH_MAX));
+
+    if (nbytes == PATH_MAX && buf[PATH_MAX-1] != '\0') {
+        RAISE(ENAMETOOLONG);
+    }
+
+    // Calculate MD5 hash of symlink target
+
+    MD5_CTX mdContext;
+    
+    MD5_Init (&mdContext);
+    MD5_Update (&mdContext, buf, nbytes);
+    MD5_Final ((unsigned char*)hash,&mdContext);
+}
+
+
+static void symlink_md5_update(const int fd, const char* path, const char* fn, int setvolatile) {
+    char hash[2*MD5_DIGEST_LENGTH];
+
+    if (setvolatile == H_STATIC) {
+        symlink_md5_measure(fd, hash);
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash[MD5_DIGEST_LENGTH]);
+
+
+        ENFORCE(seteuid(euid));
+        ENFORCE(setegid(egid));
+        // TODO: hope for fsetxattrat system call, and then use fd directly
+        ENFORCE(lsetxattr(path, "trusted.managed", hash, sizeof(char)*2*MD5_DIGEST_LENGTH, 0));
+        ENFORCE(setegid(rgid));
+        ENFORCE(seteuid(ruid));
+    } else {
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash[0]);
+
+        ENFORCE(seteuid(euid));
+        ENFORCE(setegid(egid));
+        // TODO: hope for fsetxattrat system call, and then use fd directly
+        ENFORCE(lsetxattr(path, "trusted.managed", hash, sizeof(char)*MD5_DIGEST_LENGTH, 0));
+        ENFORCE(setegid(rgid));
+        ENFORCE(seteuid(ruid));
+    }
+}
+
+
+static int symlink_md5_verify(const int fd, const char* path, const char* fn, int allowvolatile) {
+    char hash_attr[2*MD5_DIGEST_LENGTH];
+    char hash_file[2*MD5_DIGEST_LENGTH];
+    int size;
+
+
+    ENFORCE(seteuid(euid));
+    ENFORCE(setegid(egid));
+    // TODO: hope for fsetxattrat system call, and then use fd directly
+    size = ENFORCE(lgetxattr(path, "trusted.managed", hash_attr, sizeof(char)*2*MD5_DIGEST_LENGTH));
+    ENFORCE(setegid(rgid));
+    ENFORCE(seteuid(ruid));
+
+    debug_print("symlink verify: attr hash: `%i`:`%s`\n", size, hash_attr);
+
+    if (size == sizeof(char)*2*MD5_DIGEST_LENGTH) {
+        symlink_md5_measure(fd, hash_file);
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash_file[MD5_DIGEST_LENGTH]);
+
+        if (strncmp(hash_file, hash_attr, 2*MD5_DIGEST_LENGTH) == 0) {
+            return 1;
+        } else {
+            return 0;
+        }
+    } else if (allowvolatile == H_VOLATILE && size == sizeof(char)*MD5_DIGEST_LENGTH) {
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash_file[0]);
+        if (strncmp(hash_file, hash_attr, MD5_DIGEST_LENGTH) == 0) {
+            return 1;
+        } else {
+            return 0;
+        }
+    } else {
+        return 0;
+    };
+}
+
+
+
+//
+// regular file
+//
+
+static void file_md5_measure(int fd, char* hash) {
+    int fd_;
+
+    fd_ = ENFORCE(dup(fd));
+    FILE *inFile = fdopen (fd_, "rb");
+
+    if (inFile == NULL) {
+        RAISE(errno);
+    }
+
+    MD5_CTX mdContext;
+    unsigned char data[1024];
+    int bytes;
+
+    MD5_Init (&mdContext);
+    while ((bytes = fread (data, 1, 1024, inFile)) != 0)
+        MD5_Update (&mdContext, data, bytes);
+    if(ferror(inFile))
+        RAISE(ferror(inFile));
+    MD5_Final ((unsigned char*)hash,&mdContext);
+
+    ENFORCE(fclose(inFile)); // also closes fd_
+}
+
+
+static void file_md5_update(int fd, const char* fn, int setvolatile) {
+    char hash[2*MD5_DIGEST_LENGTH];
+
+
+    if (setvolatile == H_STATIC) {
+        file_md5_measure(fd, hash);
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash[MD5_DIGEST_LENGTH]);
+
+        ENFORCE(seteuid(euid));
+        ENFORCE(setegid(egid));
+        // TODO: hope for fsetxattrat system call, and then use fd directly
+        ENFORCE(fsetxattr(fd, "trusted.managed", hash, sizeof(char)*2*MD5_DIGEST_LENGTH, 0));
+        ENFORCE(setegid(rgid));
+        ENFORCE(seteuid(ruid));
+    } else {
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash[0]);
+
+        ENFORCE(seteuid(euid));
+        ENFORCE(setegid(egid));
+        // TODO: hope for fsetxattrat system call, and then use fd directly
+        ENFORCE(fsetxattr(fd, "trusted.managed", hash, sizeof(char)*MD5_DIGEST_LENGTH, 0));
+        ENFORCE(setegid(rgid));
+        ENFORCE(seteuid(ruid));
+    }
+}
+
+
+static int file_md5_verify(const int fd, const char* fn, int allowvolatile) {
+    char hash_attr[2*MD5_DIGEST_LENGTH];
+    char hash_file[2*MD5_DIGEST_LENGTH];
+    int size;
+
+    ENFORCE(seteuid(euid));
+    ENFORCE(setegid(egid));
+    size = ENFORCE(fgetxattr(fd, "trusted.managed", hash_attr, sizeof(char)*2*MD5_DIGEST_LENGTH));
+    ENFORCE(setegid(rgid));
+    ENFORCE(seteuid(ruid));
+
+    if (size == sizeof(char)*2*MD5_DIGEST_LENGTH) {
+        file_md5_measure(fd, hash_file);
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash_file[MD5_DIGEST_LENGTH]);
+
+        if (strncmp(hash_file, hash_attr, 2*MD5_DIGEST_LENGTH) == 0) {
+            return 1;
+        } else {
+            return 0;
+        }
+    } else if (allowvolatile == H_VOLATILE && size == sizeof(char)*MD5_DIGEST_LENGTH) {
+        MD5((unsigned char*)fn,strlen(fn),(unsigned char*)&hash_file[0]);
+        if (strncmp(hash_file, hash_attr, MD5_DIGEST_LENGTH) == 0) {
+            return 1;
+        } else {
+            return 0;
+        }
+    } else {
+        return 0;
+    };
+}
+
+
+static inline int fd_md5_exists(const int fd, const char* path) {
+    int err;
+    if (path == NULL) {
+        ENFORCE(seteuid(euid));
+        ENFORCE(setegid(egid));
+        err = fgetxattr(fd, "trusted.managed", NULL, 0);
+        ENFORCE(setegid(rgid));
+        ENFORCE(seteuid(ruid));
+    } else {
+        ENFORCE(seteuid(euid));
+        ENFORCE(setegid(egid));
+        // TODO: hope for fsetxattrat system call, and then use fd directly
+        err = lgetxattr(path, "trusted.managed", NULL, 0);
+        ENFORCE(setegid(rgid));
+        ENFORCE(seteuid(ruid));
+    }
+
+    if (err != -1)
+        return 1;
+    else if (errno == ENOATTR)
+        return 0;
+    else
+        RAISE(errno);
+}
+
+
+static inline int substr (const char* input, int offset, char* dest)
+{
+  int input_len = strlen (input);
+
+  if (offset > input_len)
+     return -1;
+
+  strncpy (dest, input + offset, input_len);
+  return 0;
+}
+
+
+static void create_filename(char* buffer, const char* directory, const char* subdirectory, const char* fn) {
+    // check for buffer overflow
+    if (strlen(directory) + strlen(subdirectory) + strlen(fn) + 1 > PATH_MAX)
+        RAISE(ENAMETOOLONG);
+    strcat(strcat(strcat(buffer, directory), subdirectory), fn);
+}
+
+ 
+static int dir_empty(int fd)
+{
+    struct dirent *ent;
+    int ret = 0;
+ 
+    int fd_ = dup(fd);
+    DIR *d = fdopendir(fd_);
+    if (!d)
+        RAISE(errno);
+ 
+    errno = 0;
+    while ((ent = readdir(d))) {
+        if (ent == NULL && errno != 0)
+            RAISE(errno);
+        if (!strcmp(ent->d_name, ".") || !(strcmp(ent->d_name, "..")))
+            continue;
+        ret = 1;
+        break;
+    }
+ 
+    ENFORCE(closedir(d));
+    return ret;
+}
+ 
+
+inline static int rmFiles(const char *pathname, const struct stat *sbuf, int type, struct FTW *ftwb) {
+    return remove(pathname);
+}
+
+inline static int rmtree(const char *path) {
+    // Delete the directory and its contents by traversing the tree in reverse order, without crossing mount boundaries and symbolic links
+    return nftw(path, rmFiles, OPEN_MAX, FTW_DEPTH|FTW_MOUNT|FTW_PHYS);
+}
+
+
+static unsigned int read_int(const char *fn, int octal) {
+    char line[256];
+    
+    FILE* f = fopen(fn, "r");
+    if (f == NULL)
+        RAISE(errno); 
+    if(fgets(line, sizeof(line), f) == NULL) {
+        printf("ERROR: file ‘%s’ does not contain required data...\n", fn);
+        abort();
+    }
+    line[strcspn(line, "\r\n")] = '\0';
+    ENFORCE(fclose(f));
+    unsigned int x;
+    if (octal) {
+        if (sscanf(line, "%o", &x) == EOF)
+            RAISE(errno);
+    } else {
+        if (sscanf(line, "%u", &x) == EOF)
+            RAISE(errno);
+    }
+    return x;
+}
+
+
+
+
+static int managed_unlink(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf) {
+    char fn[PATH_MAX] = "";
+    int x;
+    debug_print("fpath: `%s`...\n", fpath);
+
+    // make sure the subsequent call to substr can not have a buffer overflow
+    if (strlen(fpath) + 1 > PATH_MAX)
+        RAISE(ENAMETOOLONG);
+    x = substr(fpath, strlen(target_old) + strlen("/sources"), fn);
+
+    debug_print("filename: `%s`...\n", fn);
+
+    if (x == 0 && strlen(fn) > 0) {
+        char target_new_fn[PATH_MAX] = "";
+        create_filename(target_new_fn, target_new, "/sources", fn);
+
+        struct stat sb_target_new_fn;
+        // check if new_target also contains a file for the current path
+        x = lstat(target_new_fn, &sb_target_new_fn);
+        if (x != 0 && errno == ENOENT) {
+            char home_fn[PATH_MAX] = "";
+            create_filename(home_fn, home, "", fn);
+            debug_print("home filename: `%s`...\n", home_fn);
+
+            struct stat sb_home_fn;
+            if (lstat(home_fn, &sb_home_fn)==0) {
+                int fd_home_fn;
+                switch (sb_home_fn.st_mode & S_IFMT) {
+                    // symbolic link
+                    case S_IFLNK:
+                        fd_home_fn = ENFORCE(open(home_fn, O_RDONLY | O_PATH | O_NOFOLLOW));
+                        if (fd_md5_exists(fd_home_fn, home_fn)) {
+                            if (symlink_md5_verify(fd_home_fn, home_fn, fn, H_VOLATILE)) {
+                                printf("removing obsolete symlink ‘%s’...\n", home_fn);
+                                ENFORCE(unlinkat(fd_home_fn, "", 0));
+                            } else {
+                                printf("WARNING: obsolete symlink ‘%s’ has unmanaged target...\n", home_fn);
+                            }
+                        } else {
+                            printf("WARNING: file ‘%s’ should be managed and it would now be obsolete...\n", home_fn);
+                        }
+                        ENFORCE(close(fd_home_fn));
+                        break;
+                    // regular file
+                    case S_IFREG:
+                        fd_home_fn = ENFORCE(open(home_fn, O_RDONLY));
+                        if (fd_md5_exists(fd_home_fn, NULL)) {
+                            if (file_md5_verify(fd_home_fn, fn, H_VOLATILE)) {
+                                printf("removing obsolete and unchanged file ‘%s’...\n", home_fn);
+                                ENFORCE(unlinkat(fd_home_fn, "", 0));
+                            } else {
+                                printf("WARNING: obsolete file ‘%s’ has unmanaged content...\n", home_fn);
+                            }
+                        } else {
+                            printf("WARNING: file ‘%s’ should be managed and it would now be obsolete...\n", home_fn);
+                        }
+                        ENFORCE(close(fd_home_fn));
+                        break;
+                    // directory
+                    case S_IFDIR:
+                        fd_home_fn = ENFORCE(open(home_fn, O_RDONLY | O_DIRECTORY));
+                        if (fd_md5_exists(fd_home_fn, NULL)) {
+                            if (dir_empty(fd_home_fn) == 1) {
+                                printf("removing obsolete and empty directory ‘%s’...\n", home_fn);
+                                ENFORCE(unlinkat(fd_home_fn, "", 0));
+                            } else if (file_md5_verify(fd_home_fn, fn, H_VOLATILE)) {
+                                printf("removing obsolete and empty directory ‘%s’...\n", home_fn);
+                                ENFORCE(rmtree("$home/$fn"));
+                            } else {
+                                printf("WARNING: obsolete directory ‘%s’ contains unmanaged files...\n", home_fn);
+                            }
+                        } else {
+                            printf("WARNING: file ‘%s’ should be managed and it would now be obsolete...\n", home_fn);
+                        }
+                        ENFORCE(close(fd_home_fn));
+                        break;
+                    default:
+                        printf("WARNING: file ‘%s’ is of unmanageable type...\n", home_fn);
+                }
+            } else {
+                if (errno == ENOENT)
+                    printf("WARNING: obsolete file ‘%s’ does not exist anymore...\n", home_fn);
+                else
+                    RAISE(errno);
+            }
+        } else if (x != 0) {
+            RAISE(errno);
+        }
+        return 0;
+    } else {
+        return 0;
+    }
+}
+
+
+
+
+static inline int exists(const char* path, struct stat* sb) {
+    debug_print("check if path `%s` exists...", path);
+    int x = lstat(path, sb);
+    if (x == 0) {
+        return 1;
+    } else if (x != 0 && errno == ENOENT) {
+        return 0;
+    } else {
+        RAISE(errno);
+    }
+}
+
+
+static void atomic_switch(const char* fn, const char* home_fn_tmp, const char* home_fn) {
+    int allow_volatile;
+
+    char target_new_volatile[PATH_MAX] = "";
+    create_filename(target_new_volatile, target_new, "/volatiles", fn);
+    debug_print("target new volatile: `%s`...\n", target_new_volatile);
+            
+    struct stat sb_target_new_volatile;
+    // check if new_target also contains a file for the current path
+    if (exists(target_new_volatile, &sb_target_new_volatile)) {
+        debug_print("target new `%s` is VOLATILE...\n", home_fn);
+        allow_volatile = H_VOLATILE;
+    } else {
+        debug_print("target new `%s` is STATIC...\n", home_fn);
+        allow_volatile = H_STATIC;
+    }
+
+
+    struct stat sb_home_fn_tmp;
+    if (ENFORCE(lstat(home_fn_tmp, &sb_home_fn_tmp))==0) {
+        int fd_home_fn_tmp;
+        switch (sb_home_fn_tmp.st_mode & S_IFMT) {
+            // symbolic link
+            case S_IFLNK:
+                debug_print("switch symbolic link `%s`...\n", home_fn_tmp);
+                fd_home_fn_tmp = ENFORCE(open(home_fn_tmp, O_RDONLY | O_PATH | O_NOFOLLOW));
+                symlink_md5_update(fd_home_fn_tmp, home_fn_tmp, fn, allow_volatile);
+                ENFORCE(close(fd_home_fn_tmp));
+                break;
+            // regular file
+            case S_IFREG:
+                debug_print("switch regular file `%s`...\n", home_fn_tmp);
+                fd_home_fn_tmp = ENFORCE(open(home_fn_tmp, O_RDONLY));
+                file_md5_verify(fd_home_fn_tmp, fn, allow_volatile);
+                ENFORCE(close(fd_home_fn_tmp));
+                break;
+            // directory
+            case S_IFDIR:
+                debug_print("switch directory `%s`...\n", home_fn_tmp);
+                fd_home_fn_tmp = ENFORCE(open(home_fn_tmp, O_RDONLY | O_DIRECTORY));
+                file_md5_update(fd_home_fn_tmp, fn, allow_volatile);
+                ENFORCE(close(fd_home_fn_tmp));
+                break;
+            default:
+                printf("ERROR: file ‘%s’ is of unmanageable type...\n", home_fn_tmp);
+                exit(-1);
+        }
+    } else {
+        printf("ERROR: INTERNAL ERROR: ‘%s’ does not exist...\n", home_fn_tmp);
+        abort();
+    }
+
+
+    char buffer[PATH_MAX] = "";
+    create_filename(buffer, target_new, "/modes", fn);
+
+    struct stat sb_target_new_mode;
+    if (exists(buffer, &sb_target_new_mode)) {
+        create_filename(buffer, target_new, "/uids", fn);
+        unsigned int uid = read_int(buffer, 0);
+        
+        create_filename(buffer, target_new, "/gids", fn);
+        unsigned int gid = read_int(buffer, 0);
+        
+        create_filename(buffer, target_new, "/modes", fn);
+        unsigned int mode = read_int(buffer, 1);
+
+
+        ENFORCE(lstat(home_fn_tmp, &sb_home_fn_tmp));
+        ENFORCE(lchown(home_fn_tmp, uid, gid));
+
+        if ((sb_home_fn_tmp.st_mode & S_IFMT) != S_IFLNK);
+            ENFORCE(chmod(home_fn_tmp, mode));
+    }
+
+    ENFORCE(rename(home_fn_tmp, home_fn)); //TODO:: switch to renameat
+}
+
+
+
+static int managed_link(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf) {
+    debug_print("fpath: `%s`...\n", fpath);
+
+    char fn[PATH_MAX] = "";
+    int x;
+
+    // make sure the subsequent call to substr can not have a buffer overflow
+    if (strlen(fpath) + 1 > PATH_MAX)
+        RAISE(ENAMETOOLONG);
+    x = substr(fpath, strlen(target_new) + strlen("/sources"), fn);
+
+    debug_print("filename: `%s`...\n", fn);
+
+    if (x == 0 && strlen(fn) > 0) {
+        char home_fn[PATH_MAX] = "";
+        create_filename(home_fn, home, "", fn);
+        debug_print("home filename: `%s`...\n", home_fn);
+
+        char home_fn_tmp[PATH_MAX] = "";
+        create_filename(home_fn_tmp, home, fn, ".nixup-temporary-managed-resource");
+        debug_print("home filename tmp: `%s`...\n", home_fn_tmp);
+
+        struct stat sb_home_fn;
+        if (typeflag == FTW_D && typeflag == FTW_DP) {
+            debug_print("linking: target `%s` is a directory...\n", fpath);
+            if (!exists(home_fn, &sb_home_fn)) {
+                unlink(home_fn_tmp);
+
+                ENFORCE(mkdir(home_fn_tmp, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)); //TODO: hope for O_TMPDIR option in mkdir/open
+
+                int fd_home_fn = ENFORCE(open(home_fn, O_RDONLY | O_DIRECTORY));
+                file_md5_update(fd_home_fn, fn, H_VOLATILE);
+                ENFORCE(close(fd_home_fn));
+
+                ENFORCE(rename(home_fn_tmp, home_fn)); //TODO:: switch to renameat
+            } else {
+                return 0;
+            }
+        } else if (typeflag == FTW_F || typeflag == FTW_SL) {
+            debug_print("linking: target `%s` is a file or a symbolic link...\n", fpath);
+            // make sure no un-managed data is lost
+            // check that a managed content did not change and so can safely be overridden
+            if (exists(home_fn, &sb_home_fn)) {
+                debug_print("linking: file `%s` exists in home with mode '%lo'...\n", home_fn, (unsigned long) sb_home_fn.st_mode);
+                int fd_home_fn;
+                switch (sb_home_fn.st_mode & S_IFMT) {
+                    // symbolic link
+                    case S_IFLNK:
+                        debug_print("linking: existing file `%s` is a symbolic link...\n", home_fn);
+                        fd_home_fn = ENFORCE(open(home_fn, O_RDONLY | O_PATH | O_NOFOLLOW));
+                        if (fd_md5_exists(fd_home_fn, home_fn)) {
+                            if (1!=symlink_md5_verify(fd_home_fn, home_fn, fn, H_VOLATILE)) {
+                                printf("ERROR: managed symbolic link ‘%s’ contains an unmanaged reference...\n", home_fn);
+                                exit(-1);
+                            }
+                        } else {
+                            printf("ERROR: file ‘%s’ already exists and so path cannot be managed...\n", home_fn);
+                            exit(-1);
+                        }
+                        ENFORCE(close(fd_home_fn));
+                        break;
+                    // regular file
+                    case S_IFREG:
+                        debug_print("linking: existing file `%s` is a regular file...\n", home_fn);
+                        fd_home_fn = ENFORCE(open(home_fn, O_RDONLY));
+                        if (fd_md5_exists(fd_home_fn, NULL)) {
+                            if (1!=file_md5_verify(fd_home_fn, fn, H_VOLATILE)) {
+                                printf("ERROR: managed file ‘%s’ contains unmanaged data...\n", home_fn);
+                                exit(-1);
+                            }
+                        } else {
+                            printf("ERROR: file ‘%s’ already exists and so path cannot be managed...\n", home_fn);
+                            exit(-1);
+                        }
+                        ENFORCE(close(fd_home_fn));
+                        break;
+                    // directory
+                    case S_IFDIR:
+                        debug_print("linking: existing file `%s` is a directory...\n", home_fn);
+                        fd_home_fn = ENFORCE(open(home_fn, O_RDONLY | O_DIRECTORY));
+                        if (fd_md5_exists(fd_home_fn, NULL)) {
+                            if (file_md5_verify(fd_home_fn, fn, H_VOLATILE)) {
+                                printf("ERROR: managed directory ‘%s’ contains unmanaged data...\n", home_fn);
+                                exit(-1);
+                            }
+                        } else {
+                            printf("ERROR: directory ‘%s’ already exists and so path cannot be managed...\n", home_fn);
+                            exit(-1);
+                        }
+                        ENFORCE(close(fd_home_fn));
+                        break;
+                    default:
+                        debug_print("linking: existing file `%s` is of type `%lo`...\n", home_fn, (unsigned long) (sb_home_fn.st_mode & S_IFMT));
+                        printf("ERROR: file ‘%s’ already exists and so path cannot be managed...\n", home_fn);
+                        exit(-1);
+                }
+            }
+
+            char target_new_dynamic[PATH_MAX] = "";
+            create_filename(target_new_dynamic, target_new, "/dynamics", fn);
+            debug_print("target new dynamic: `%s`...\n", target_new_dynamic);
+            
+            struct stat sb_target_new_dynamic;
+            if (exists(target_new_dynamic, &sb_target_new_dynamic)) {
+                debug_print("new target `%s` is dynamic...\n", target_new_dynamic);
+                int pid = ENFORCE(fork());
+                int status;
+                if (pid == 0) {
+                    // TODO: check whether ftw uses O_CLOXEC and if not switch ftw to fts
+                    //       so that all file descriptors can be closed properly before execve
+                    ENFORCE(prctl(PR_SET_PDEATHSIG, SIGTERM));
+                    ENFORCE(setgroups(1, &rgid));
+                    ENFORCE(setregid(rgid, rgid));
+                    ENFORCE(setreuid(rgid, ruid));
+            
+                    char *cargv[] = { NULL, home_fn, home_fn_tmp, NULL };
+                    char *cenvp[] = { NULL };
+                    ENFORCE(execve(fpath, cargv, cenvp));
+                } else {
+                    ENFORCE(waitpid(pid, &status, 0));
+                    if (WIFEXITED(status) != 0 || WEXITSTATUS(status) != 0) {
+                        printf("ERROR: dynamically executed subroutine `%s` did not succeed...\n", fpath);
+                        abort();
+                    }
+                }
+            
+                atomic_switch(fn, home_fn_tmp, home_fn);
+            } else {
+                char target_new_fn[PATH_MAX] = "";
+                create_filename(target_new_fn, target_new, "/sources", fn);
+
+                debug_print("new target `%s` is not dynamic...\n", target_new_fn);
+
+                if ((sb_home_fn.st_mode & S_IFMT) == S_IFDIR)
+                    ENFORCE(rmtree(home_fn));
+    
+
+                char target_new_mode[PATH_MAX] = "";
+                create_filename(target_new_mode, target_new, "/modes", fn);
+
+                struct stat sb_target_new_mode;
+                if (exists(target_new_mode, &sb_target_new_mode)) {
+                    unlink(home_fn_tmp); // TODO: proper error handling
+
+                    FILE *from = fopen(target_new_fn, "r");
+                    FILE *to = fopen(home_fn_tmp, "w");
+                    char buffer[BUFSIZ];
+                    size_t n;
+
+                    debug_print("copy new target `%s` to  `%s`...\n", target_new_fn, home_fn_tmp);
+                    while ((n = fread(buffer, sizeof(char), sizeof(buffer), from)) > 0)
+                    {
+                        if (ENFORCE(fwrite(buffer, sizeof(char), n, to)) != n) {
+                            printf("ERROR: failed to copy from `%s` to `%s`...", target_new_fn, home_fn_tmp);
+                            abort();
+                        }
+                    }
+                    if (ferror(from))
+                        RAISE(ferror(from));
+
+                    atomic_switch(fn, home_fn_tmp, home_fn);
+                } else {
+                    char link[PATH_MAX];
+                    if (realpath(target_new_fn, link) == NULL)
+                        RAISE(errno);
+
+                    
+                    debug_print("create link: `%s`...\n", link);
+                    
+                    if ((sb_home_fn.st_mode & S_IFMT) == S_IFLNK) {
+                        debug_print("symbolic link `%s` already exists in home...\n", home_fn);
+                        char buf[PATH_MAX];
+                        ssize_t nbytes;
+                        
+                        buf[PATH_MAX-1] = '\0';
+                        nbytes = ENFORCE(readlink(home_fn, buf, PATH_MAX));
+                        if (nbytes == PATH_MAX && buf[PATH_MAX-1] != '\0') {
+                            RAISE(ENAMETOOLONG);
+                        }
+                        buf[nbytes] = '\0';
+
+                        if (strcmp(buf, link) != 0) {
+                            unlink(home_fn_tmp);
+                            ENFORCE(symlink(link,home_fn_tmp));
+                            atomic_switch(fn, home_fn_tmp, home_fn);
+                        } else
+                            debug_print("old symbolic link `%s` is identical to new one...\n", home_fn);
+
+                    } else {
+                        debug_print("symbolic link `%s` is new in home...\n", home_fn);
+                        unlink(home_fn_tmp);
+                        ENFORCE(symlink(link,home_fn_tmp));
+                        atomic_switch(fn, home_fn_tmp, home_fn);
+                    }
+                }
+            }
+        } else {
+            printf("ERROR: INTERNAL ERROR: only directories and files are allowed at `%s`...", fpath);
+            abort();
+        }
+    }
+    return 0;
+}
+
+
+
+
+
+int main(int argc, char* argv[])
+{
+    ruid = getuid();
+    rgid = getgid();
+    euid = geteuid();
+    egid = getegid();
+    ENFORCE(setegid(rgid));
+    ENFORCE(seteuid(ruid));
+
+
+    if (argc > 1) {
+        char* command = argv[1];
+        if (strcmp(command, "switch")==0 && argc==5) {
+            strlcpy(home, argv[2], PATH_MAX);
+            strlcpy(target_old, argv[3], PATH_MAX);
+            strlcpy(target_new, argv[4], PATH_MAX);
+
+            debug_print("home: `%s`...\n", home);
+            debug_print("target_old: `%s`...\n", target_old);
+            debug_print("target_new: `%s`...\n", target_new);
+            
+            char target_old_sources[PATH_MAX] = "";
+            create_filename(target_old_sources, target_old, "/sources", "");
+            nftw(target_old_sources, managed_unlink, OPEN_MAX, FTW_DEPTH|FTW_MOUNT|FTW_PHYS);
+
+            char target_new_sources[PATH_MAX] = "";
+            create_filename(target_new_sources, target_new, "/sources", "");
+            nftw(target_new_sources, managed_link, OPEN_MAX, FTW_MOUNT|FTW_PHYS);
+        } else if (strcmp(command, "link")==0 && argc==4) {
+            strlcpy(home, argv[2], PATH_MAX);
+            strlcpy(target_old, "", PATH_MAX);
+            strlcpy(target_new, argv[3], PATH_MAX);
+
+            char target_new_sources[PATH_MAX] = "";
+            create_filename(target_new_sources, target_new, "/sources", "");
+            nftw(target_new_sources, managed_link, OPEN_MAX, FTW_MOUNT|FTW_PHYS);
+        } else if (strcmp(command, "unlink")==0 && argc==4) {
+            strlcpy(home, argv[2], PATH_MAX);
+            strlcpy(target_old, argv[3], PATH_MAX);
+            strlcpy(target_new, "", PATH_MAX);
+
+            char target_old_sources[PATH_MAX] = "";
+            create_filename(target_old_sources, target_old, "/sources", "");
+            nftw(target_old_sources, managed_unlink, OPEN_MAX, FTW_DEPTH|FTW_MOUNT|FTW_PHYS);
+        } else if (strcmp(command, "cleanup")==0 && argc==3) {
+            strlcpy(home, argv[2], PATH_MAX);
+            strlcpy(target_old, "", PATH_MAX);
+            strlcpy(target_new, "", PATH_MAX);
+            //TODO
+        } else {
+            printf("Incorrect usage! Valid commands are 'switch', 'link', 'unlink' or 'cleanup' with the corresponding parameters\n");
+            exit(-1);
+        }
+    } else {
+        printf("Incorrect usage! Valid commands are 'switch', 'link', 'unlink' or 'cleanup' with the corresponding parameters\n");
+        exit(-1);
+    }
+
+    exit(0);
+}

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -34,7 +34,7 @@ in
     system.build.pamEnvironment = pkgs.writeText "pam-environment"
        ''
          ${concatStringsSep "\n" (
-           (mapAttrsToList (n: v: ''${n}="${concatStringsSep ":" v}"'')
+           (mapAttrsToList (n: v: ''${n} DEFAULT="${concatStringsSep ":" v}"'')
              (zipAttrsWith (const concatLists) ([ (mapAttrs (n: v: [ v ]) cfg.sessionVariables) ]))))}
        '';
 

--- a/nixos/modules/installer/tools/nixos-prepare-root.sh
+++ b/nixos/modules/installer/tools/nixos-prepare-root.sh
@@ -90,6 +90,7 @@ ln -sfn /nix/var/nix/profiles/system $mountPoint/run/current-system
 
 # Copy the NixOS/Nixpkgs sources to the target as the initial contents of the NixOS channel.
 install -m 0755 -d $mountPoint/nix/var/nix/profiles
+install -m 1777 -d $mountPoint/nix/var/nix/profiles/nixup
 install -m 1777 -d $mountPoint/nix/var/nix/profiles/per-user
 install -m 0755 -d $mountPoint/nix/var/nix/profiles/per-user/root
 

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -44,7 +44,8 @@ let
     let fallback = import ./nix-fallback-paths.nix; in
     makeProg {
       name = "nixos-rebuild";
-      src = ./nixos-rebuild.sh;
+      src = ./nix__-rebuild.sh;
+      flavour = "nixos";
       nix = config.nix.package.out;
       nix_x86_64_linux = fallback.x86_64-linux;
       nix_i686_linux = fallback.i686-linux;

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -70,6 +70,17 @@ let
     inherit (config.system) nixosVersion nixosCodeName nixosRevision;
   };
 
+  nixup-rebuild =
+    let fallback = import ./nix-fallback-paths.nix; in
+    makeProg {
+      name = "nixup-rebuild";
+      src = ./nix__-rebuild.sh;
+      flavour = "nixup";
+      nix = config.nix.package.out;
+      nix_x86_64_linux = fallback.x86_64-linux;
+      nix_i686_linux = fallback.i686-linux;
+    };
+
 in
 
 {
@@ -87,7 +98,7 @@ in
       ];
 
     system.build = {
-      inherit nixos-install nixos-prepare-root nixos-generate-config nixos-option nixos-rebuild;
+      inherit nixos-install nixos-prepare-root nixos-generate-config nixos-option nixos-rebuild nixup-rebuild;
     };
 
   };

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -12,6 +12,7 @@
   ./config/krb5/default.nix
   ./config/ldap.nix
   ./config/networking.nix
+  ./config/nixup.nix
   ./config/no-x-libs.nix
   ./config/nsswitch.nix
   ./config/power-management.nix

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -15,6 +15,8 @@ with lib;
         PAGER = mkDefault "less -R";
         EDITOR = mkDefault "nano";
         XCURSOR_PATH = [ "$HOME/.icons" ];
+      } // optionalAttrs config.nixup.enable {
+        NIXUP_API = "${config.system.build.nixup-rebuild}";
       };
 
     environment.profiles =
@@ -52,6 +54,10 @@ with lib;
 
          export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
          export NIX_PROFILES="${concatStringsSep " " (reverseList config.environment.profiles)}"
+         ${optionalString config.nixup.enable ''
+           export NIXUP_CONFIG="''${XDG_CONFIG_HOME:-$HOME/.config}/nixup/profile.nix"
+           export NIXUP_RUNTIME_DIR="''${XDG_RUNTIME_DIR:-/run/user/$(id -u $USER)}/nixup"
+         ''}
       '';
 
   };

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -6,12 +6,6 @@
 
 with lib;
 
-let
-
-  cfg = config.environment;
-
-in
-
 {
 
   config = {
@@ -50,14 +44,14 @@ in
     environment.extraInit =
       ''
          unset ASPELL_CONF
-         for i in ${concatStringsSep " " (reverseList cfg.profiles)} ; do
+         for i in ${concatStringsSep " " (reverseList config.environment.profiles)} ; do
            if [ -d "$i/lib/aspell" ]; then
              export ASPELL_CONF="dict-dir $i/lib/aspell"
            fi
          done
 
          export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
-         export NIX_PROFILES="${concatStringsSep " " (reverseList cfg.profiles)}"
+         export NIX_PROFILES="${concatStringsSep " " (reverseList config.environment.profiles)}"
       '';
 
   };

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -4,12 +4,6 @@
 
 with lib;
 
-let
-
-  cfg = config.environment;
-
-in
-
 {
 
   config = {

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -315,7 +315,7 @@ let
 
           # Session management.
           ${optionalString cfg.setEnvironment ''
-            session required pam_env.so envfile=${config.system.build.pamEnvironment}
+            session required pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
           ''}
           session required pam_unix.so
           ${optionalString cfg.setLoginUid

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -448,6 +448,8 @@ in
           /nix/var/log/nix/drvs \
           /nix/var/nix/channel-cache
         mkdir -m 1777 -p \
+          /nix/var/nix/gcroots/nixup \
+          /nix/var/nix/profiles/nixup \
           /nix/var/nix/gcroots/per-user \
           /nix/var/nix/profiles/per-user \
           /nix/var/nix/gcroots/tmp

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -185,7 +185,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = gdm
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         session  optional       ${pkgs.systemd}/lib/security/pam_systemd.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so
@@ -193,7 +193,7 @@ in
 
       gdm.text = ''
         auth     requisite      pam_nologin.so
-        auth     required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        auth     required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
 
         auth     required       pam_succeed_if.so uid >= 1000 quiet
         auth     optional       ${pkgs.gnome3.gnome_keyring}/lib/security/pam_gnome_keyring.so
@@ -210,7 +210,7 @@ in
         ${optionalString config.security.pam.enableEcryptfs
           "password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
 
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         session  required       pam_unix.so
         ${optionalString config.security.pam.enableEcryptfs
           "session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
@@ -221,7 +221,7 @@ in
 
       gdm-password.text = ''
         auth     requisite      pam_nologin.so
-        auth     required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        auth     required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
 
         auth     required       pam_succeed_if.so uid >= 1000 quiet
         auth     optional       ${pkgs.gnome3.gnome_keyring}/lib/security/pam_gnome_keyring.so
@@ -237,7 +237,7 @@ in
         ${optionalString config.security.pam.enableEcryptfs
           "password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
 
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         session  required       pam_unix.so
         ${optionalString config.security.pam.enableEcryptfs
           "session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
@@ -257,7 +257,7 @@ in
         password requisite      pam_unix.so nullok sha512
 
         session  optional       pam_keyinit.so revoke
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         session  required       pam_unix.so
         session  required       pam_loginuid.so
         session  optional       ${pkgs.systemd}/lib/security/pam_systemd.so

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -216,14 +216,14 @@ in
       allowNullPassword = true;
       startSession = true;
       text = ''
-        auth     required pam_env.so envfile=${config.system.build.pamEnvironment}
+        auth     required pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         auth     required pam_permit.so
 
         account  required pam_permit.so
 
         password required pam_deny.so
 
-        session  required pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         session  required pam_unix.so
         session  optional ${pkgs.systemd}/lib/security/pam_systemd.so
       '';

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -234,7 +234,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = sddm
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so readenv=0 conffile=${config.system.build.pamEnvironment}
         session  optional       ${pkgs.systemd}/lib/security/pam_systemd.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -126,6 +126,7 @@ let
 
       # Needed by switch-to-configuration.
       perl = "${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl";
+      flavour = "nixos";
   } else throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failed)}");
 
   # Replace runtime dependencies

--- a/nixos/modules/virtualisation/container-config.nix
+++ b/nixos/modules/virtualisation/container-config.nix
@@ -11,7 +11,7 @@ with lib;
     services.udisks2.enable = mkDefault false;
     powerManagement.enable = mkDefault false;
 
-    networking.useHostResolvConf = true;
+    networking.useHostResolvConf = mkDefault true;
 
     # Containers should be light-weight, so start sshd on demand.
     services.openssh.startWhenNeeded = mkDefault true;

--- a/nixup/default.nix
+++ b/nixup/default.nix
@@ -1,0 +1,17 @@
+{ configuration ? import ../nixos/lib/from-env.nix "NIXUP_CONFIG" <nixup-config>
+, system ? builtins.currentSystem
+}:
+
+let
+
+  eval = import ./lib/eval-config.nix {
+    modules = [ configuration { nixpkgs.system = system; } ];
+  };
+
+in
+
+{
+  inherit (eval) config options;
+
+  profile = eval.config.nixup.build.profile;
+}

--- a/nixup/lib/eval-config.nix
+++ b/nixup/lib/eval-config.nix
@@ -1,0 +1,58 @@
+# From an end-user configuration file (`configuration'), build a NixUP
+# configuration object (`config') from which we can retrieve option
+# values.
+
+# !!! Please think twice before adding to this argument list!
+# Ideally eval-config.nix would be an extremely thin wrapper
+# around lib.evalModules, so that modular systems that have nixos configs
+# as subcomponents (e.g. the container feature, or nixops if network
+# expressions are ever made modular at the top level) can just use
+# types.submodule instead of using eval-config.nix
+{ # !!! system can be set modularly, would be nice to remove
+  system ? builtins.currentSystem
+, # !!! is this argument needed any more? The pkgs argument can
+  # be set modularly anyway.
+  pkgs ? null
+, # !!! what do we gain by making this configurable?
+  baseModules ? import ../modules/module-list.nix
+, # !!! See comment about args in lib/modules.nix
+  extraArgs ? {}
+, modules
+, # !!! See comment about check in lib/modules.nix
+  check ? true
+, prefix ? []
+, lib ? import <nixpkgs/lib>
+}:
+
+let extraArgs_ = extraArgs; pkgs_ = pkgs; system_ = system;
+in
+
+let
+  pkgsModule = rec {
+    _file = ./eval-config.nix;
+    key = _file;
+    config = {
+      nixpkgs.system = lib.mkDefault system_;
+      _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
+    };
+  };
+
+in rec {
+
+  # Merge the option definitions in all modules, forming the full
+  # system configuration.
+  inherit (lib.evalModules {
+    inherit prefix check;
+    modules = modules ++ baseModules ++ [ pkgsModule ];
+    args = extraArgs;
+    specialArgs = { modulesPath = ../modules; };
+  }) config options;
+
+  # These are the extra arguments passed to every module.  In
+  # particular, Nixpkgs is passed through the "pkgs" argument.
+  extraArgs = extraArgs_ // {
+    inherit modules baseModules;
+  };
+
+  inherit (config._module.args) pkgs;
+}

--- a/nixup/modules/config/nix.nix
+++ b/nixup/modules/config/nix.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+
+  options = {
+
+    nix.package = mkOption {
+      type = types.package;
+      default = pkgs.nix;
+      description = ''
+        This option specifies the Nix package instance to use
+        within the nixuser-rebuild command.
+      '';
+    };
+
+  };
+
+}

--- a/nixup/modules/config/packages.nix
+++ b/nixup/modules/config/packages.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  userPath = pkgs.buildEnv {
+    name = "user-path";
+    paths = config.user.packages;
+    pathsToLink = config.user.pathsToLink;
+    ignoreCollisions = true;
+    # !!! Hacky, should modularise.
+    postBuild =
+      ''
+        if [ -x $out/bin/update-mime-database -a -w $out/share/mime/packages ]; then
+            XDG_DATA_DIRS=$out/share $out/bin/update-mime-database -V $out/share/mime > /dev/null
+        fi
+
+        if [ -x $out/bin/gtk-update-icon-cache -a -f $out/share/icons/hicolor/index.theme ]; then
+            $out/bin/gtk-update-icon-cache $out/share/icons/hicolor
+        fi
+
+        if [ -x $out/bin/glib-compile-schemas -a -w $out/share/glib-2.0/schemas ]; then
+            $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+        fi
+
+        if [ -x $out/bin/update-desktop-database -a -w $out/share/applications ]; then
+            $out/bin/update-desktop-database $out/share/applications
+        fi
+      '';
+  };
+
+in
+
+{
+
+  options = {
+
+    user.packages = mkOption {
+      default = [];
+      type = types.listOf types.path;
+      example = literalExample "with config.nixpkgs.pkgs; [ firefox thunderbird ]";
+      description = ''
+        The set of packages that appear in
+        <filename>$XDG_RUNTIME_DIR/nixup/active-profile/sw</filename>. These packages are
+        automatically updated every time you rebuild the user profile.
+      '';
+    };
+
+    user.pathsToLink = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "/bin"
+        "/etc/xdg"
+        "/info"
+        "/man"
+        "/sbin"
+        "/share/emacs"
+        "/share/vim-plugins"
+        "/share/org"
+        "/share/info"
+        "/share/terminfo"
+        "/share/man"
+      ];
+      example = ["/"];
+      description = ''
+        List of directories to be symlinked in <filename>$XDG_RUNTIME_DIR/nixup/active-profile/sw</filename>.
+      '';
+    };
+
+  };
+
+  config = {
+    nixup.build.userPath = userPath;
+    nixup.buildCommands = ''
+      ln -s ${userPath} $out/sw
+    '';
+  };
+}

--- a/nixup/modules/misc/legacy-nixpkgs-config.nix
+++ b/nixup/modules/misc/legacy-nixpkgs-config.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.nixpkgs;
+
+
+  # The contents of the configuration file found at $NIXPKGS_CONFIG or
+  # $HOME/.nixpkgs/config.nix.
+  # for NIXOS (nixos-rebuild): use nixpkgs.config option
+  nixpkgs_config =
+    let
+      toPath = builtins.toPath;
+      getEnv = x: if builtins ? getEnv then builtins.getEnv x else "";
+      pathExists = name:
+        builtins ? pathExists && builtins.pathExists (toPath name);
+
+      configFile = getEnv "NIXPKGS_CONFIG";
+      homeDir = getEnv "HOME";
+      configFile2 = homeDir + "/.nixpkgs/config.nix";
+
+      configExpr =
+        if configFile != "" && pathExists configFile then import (toPath configFile)
+        else if homeDir != "" && pathExists configFile2 then import (toPath configFile2)
+        else {};
+
+    in
+      # allow both:
+      # { /* the config */ } and
+      # { pkgs, ... } : { /* the config */ }
+      if builtins.isFunction configExpr
+        then configExpr { inherit pkgs; }
+        else configExpr;
+
+in
+
+{
+  options = {
+
+    nixpkgs.includeLegacyConfig = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Merge legacy nixpkgs configuration from "~/.nixpkgs/config.nix"
+        into the "nixpkgs.config" option.
+        NOTE: The option will default to "false" after a transition period.
+              So move your configuration from "~/.nixpkgs/config.nix" into
+              "$XDG_CONFIG_HOME/nixup/profile.nix" under the "nixpkgs.config" option.
+      '';
+    };
+
+  };
+
+  config = {
+
+    nixpkgs.config = mkIf cfg.includeLegacyConfig nixpkgs_config;
+
+  };
+}

--- a/nixup/modules/module-list.nix
+++ b/nixup/modules/module-list.nix
@@ -5,6 +5,7 @@
   ./misc/legacy-nixpkgs-config.nix
   ./nixup/activation.nix
   ./nixup/build.nix
+  ./nixup/nixup-tools.nix
   ./nixup/resource-files.nix
   ./nixup/switch-to-configuration.nix
   ./nixup/systemd.nix

--- a/nixup/modules/module-list.nix
+++ b/nixup/modules/module-list.nix
@@ -1,0 +1,11 @@
+[ ./nixpkgs.nix
+  ./config/nix.nix
+  ./config/packages.nix
+  ../../nixos/modules/misc/assertions.nix
+  ./misc/legacy-nixpkgs-config.nix
+  ./nixup/activation.nix
+  ./nixup/build.nix
+  ./nixup/resource-files.nix
+  ./nixup/switch-to-configuration.nix
+  ./nixup/systemd.nix
+]

--- a/nixup/modules/nixpkgs.nix
+++ b/nixup/modules/nixpkgs.nix
@@ -1,0 +1,92 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+
+  isConfig = x:
+    builtins.isAttrs x || builtins.isFunction x;
+
+  optCall = f: x:
+    if builtins.isFunction f
+    then f x
+    else f;
+
+  mergeConfig = lhs_: rhs_:
+    let
+      lhs = optCall lhs_ { inherit pkgs; };
+      rhs = optCall rhs_ { inherit pkgs; };
+    in
+    lhs // rhs //
+    optionalAttrs (lhs ? packageOverrides) {
+      packageOverrides = pkgs:
+        optCall lhs.packageOverrides pkgs //
+        optCall (attrByPath ["packageOverrides"] ({}) rhs) pkgs;
+    };
+
+  configType = mkOptionType {
+    name = "nixpkgs config";
+    check = traceValIfNot isConfig;
+    merge = args: fold (def: mergeConfig def.value) {};
+  };
+
+in
+
+{
+  options = {
+    nixpkgs.path = mkOption {
+      type = types.path;
+      example = "/home/user/dev/nixpkgs";
+      description = ''
+        Location of the collection of packages which is used for building
+        the current user profile.  This is also useful for building profile
+        against either bleeding-edge recipes or archived version of the
+        recipes.
+      '';
+    };
+
+    nixpkgs.config = mkOption {
+      default = {};
+      example = literalExample
+        ''
+          { firefox.enableGeckoMediaPlayer = true;
+            packageOverrides = pkgs: {
+              firefox60Pkgs = pkgs.firefox60Pkgs.override {
+                enableOfficialBranding = true;
+              };
+            };
+          }
+        '';
+      type = configType;
+      description = ''
+        The configuration of the Nix Packages collection.  (For
+        details, see the Nixpkgs documentation.)  It allows you to set
+        package configuration options, and to override packages
+        globally through the <varname>packageOverrides</varname>
+        option.  The latter is a function that takes as an argument
+        the <emphasis>original</emphasis> Nixpkgs, and must evaluate
+        to a set of new or overridden packages.
+      '';
+    };
+
+    nixpkgs.system = mkOption {
+      type = types.str;
+      example = "i686-linux";
+      description = ''
+        Specifies the Nix platform type for which NixOS should be built.
+        If unset, it defaults to the platform type of your host system.
+        Specifying this option is useful when doing distributed
+        multi-platform deployment, or when building virtual machines.
+      '';
+    };
+
+  };
+
+  config = {
+    nixpkgs.path = <nixpkgs>;
+
+    _module.args.pkgs = import config.nixpkgs.path {
+      inherit (config.nixpkgs) system config;
+    };
+  };
+}

--- a/nixup/modules/nixup/activation.nix
+++ b/nixup/modules/nixup/activation.nix
@@ -1,0 +1,128 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  addAttributeName = mapAttrs (a: v: v // {
+    text = ''
+      #### Activation script snippet ${a}:
+      ${v.text}
+    '';
+  });
+
+  path = [ pkgs.coreutils ];
+
+  activateScript = pkgs.writeScript "user-profile-activate" config.nixup.activationScripts;
+
+in
+
+{
+
+  options = {
+
+    nixup.activationScripts = mkOption {
+      default = {};
+
+      example = {
+        aliasIfconfig = {
+          text = ''
+            # Some local configuration
+            if ifconfig > /dev/null 2>&1; then
+              :
+            elif test -x /sbin/ifconfig; then
+              ln -s /sbin/ifconfig ~/.usr/bin/ifconfig
+            fi
+          '';
+          deps = [ "setupLocalUsr" ];
+        };
+      };
+
+      description = ''
+        A set of shell script fragments that are executed when a NixUP
+        user configuration is activated. Since these
+        are executed every time you login or run
+        <command>nixup-rebuild</command>, it's important that they are
+        idempotent and fast.
+      '';
+
+      type = types.attrsOf types.unspecified; # FIXME
+
+      apply = set:
+        ''
+          #! ${pkgs.stdenv.shell}
+
+          if [ -n "''${NIXUP_RUNTIME_DIR:?'NIXUP_RUNTIME_DIR not set'}" ]; then
+              echo "Activating NixUP user environment..."
+          fi
+
+          export PATH=/empty
+          for i in ${toString path}; do
+              PATH=$PATH:$i/bin:$i/sbin
+          done
+
+          _status=0
+          trap "_status=1" ERR
+
+          # Ensure a consistent umask.
+          umask 0022
+
+          # NixUP runtime directory.
+          mkdir -m 0755 -p $NIXUP_RUNTIME_DIR
+
+          # NixUP garbage collector roots directory.
+          export NIXUP_USER_GCROOTS_DIR=/nix/var/nix/gcroots/nixup/$USER
+
+          # Clean up a previously failed activation
+          rm -f $NIXUP_RUNTIME_DIR/old-active-profile
+          rm -f $NIXUP_USER_GCROOTS_DIR/old-active-profile
+
+          # Move currently active profile out of the way
+          if [ -e $NIXUP_RUNTIME_DIR/active-profile ]; then
+              cp -d $NIXUP_RUNTIME_DIR/active-profile $NIXUP_RUNTIME_DIR/old-active-profile
+          fi
+          if [ -e $NIXUP_USER_GCROOTS_DIR/active-profile ]; then
+              mv $NIXUP_USER_GCROOTS_DIR/active-profile $NIXUP_USER_GCROOTS_DIR/old-active-profile
+          fi
+
+          # Prevent the current configuration from being garbage-collected.
+          ln -sfn @out@ $NIXUP_USER_GCROOTS_DIR/active-profile
+
+          # Set new active profile.
+          ln -sfn @out@ $NIXUP_RUNTIME_DIR/active-profile
+
+          ${
+            let
+              set' = mapAttrs (n: v: if isString v then noDepEntry v else v) set;
+              withHeadlines = addAttributeName set';
+            in textClosureMap id (withHeadlines) (attrNames withHeadlines)
+          }
+
+          # Mark old configuration for garbage collection.
+          rm -f $NIXUP_USER_GCROOTS_DIR/old-active-profile
+
+          # Allow to keep old profile for later use in, e.g., switch-to-configuration.pl
+          if [ -z $NIXUP_ACTIVATE_NO_CLEANUP ]; then
+              # Remove old configuration.
+              rm -f $NIXUP_RUNTIME_DIR/old-active-profile
+          fi
+
+          # Make his configuration the current configuration.
+          ln -sfn "$NIXUP_RUNTIME_DIR/active-profile/sw" $HOME/.nix-profile
+
+          exit $_status
+        '';
+
+    };
+
+  };
+
+  config = {
+    nixup.buildCommands = ''
+      cp ${toString activateScript} $out/activate
+      substituteInPlace $out/activate --subst-var out
+      chmod u+x $out/activate
+      unset activationScript
+    '';
+  };
+}

--- a/nixup/modules/nixup/build.nix
+++ b/nixup/modules/nixup/build.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  profile = pkgs.stdenv.mkDerivation {
+    name = "nixup-profile";
+    preferLocalBuild = true;
+    buildCommand = ''
+      mkdir $out
+
+      ${config.nixup.buildCommands}
+    '';
+  };
+
+in
+
+{
+  options = {
+    nixup.build = mkOption {
+      internal = true;
+      type = types.attrsOf types.package;
+      default = {};
+      description = ''
+        Attribute set of derivations used to setup the system.
+      '';
+    };
+
+    nixup.buildCommands = mkOption {
+      internal = true;
+      type = types.lines;
+      default = [];
+      example = literalExample ''
+        "ln -s ${pkgs.firefox} $out/firefox-stable"
+     '';
+      description = ''
+        List of commands to build and install the content of the profile
+        directory.
+      '';
+    };
+  };
+
+  config = {
+
+    nixup.build.profile = profile;
+
+  };
+}

--- a/nixup/modules/nixup/make-managed.sh
+++ b/nixup/modules/nixup/make-managed.sh
@@ -1,0 +1,66 @@
+source $stdenv/setup
+
+mkdir -p $out/sources
+mkdir -p $out/dynamics
+mkdir -p $out/volatiles
+mkdir -p $out/modes
+mkdir -p $out/uids
+mkdir -p $out/gids
+
+set -f
+targets_=($targets)
+sources_=($sources)
+dynamics_=($dynamics)
+volatiles_=($volatiles)
+modes_=($modes)
+users_=($users)
+groups_=($groups)
+set +f
+
+for ((i = 0; i < ${#targets_[@]}; i++)); do
+    source="${sources_[$i]}"
+    target="${targets_[$i]}"
+
+    if [[ "$source" =~ '*' ]]; then
+
+        # If the source name contains '*', perform globbing.
+        mkdir -p $out/sources/$target
+        for fn in $source; do
+            ln -s "$fn" $out/sources/$target/
+        done
+
+    else
+        
+        mkdir -p $out/sources/$(dirname $target)
+        if ! [ -e $out/sources/$target ]; then
+            ln -s $source $out/sources/$target
+        else
+            echo "duplicate entry $target -> $source"
+            if test "$(readlink $out/sources/$target)" != "$source"; then
+                echo "mismatched duplicate entry $(readlink $out/sources/$target) <-> $source"
+                exit 1
+            fi
+        fi
+
+        if test "${dynamics_[$i]}" == true; then
+            mkdir -p $out/dynamics/$(dirname $target)
+            touch $out/dynamics/$target
+        fi
+
+        if test "${volatiles_[$i]}" == true; then
+            mkdir -p $out/volatiles/$(dirname $target)
+            touch $out/volatiles/$target
+        fi
+
+        if test "${modes_[$i]}" != symlink; then
+            mkdir -p $out/modes/$(dirname $target)
+            echo "${modes_[$i]}"  > $out/modes/$target
+            mkdir -p $out/uids/$(dirname $target)
+            echo "${users_[$i]}"  > $out/uids/$target
+            mkdir -p $out/gids/$(dirname $target)
+            echo "${groups_[$i]}" > $out/gids/$target
+        fi
+        
+    fi
+done
+

--- a/nixup/modules/nixup/nixup-tools.nix
+++ b/nixup/modules/nixup/nixup-tools.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.nixup-tools;
+
+  managed-packages =
+    let
+      packagesString = if cfg.managed-packages-path == null
+                       then let xdg_config_home_ = builtins.getEnv "XDG_CONFIG_HOME";
+                                xdg_config_home = if xdg_config_home_ == "" then "${builtins.getEnv "HOME"}/.config" else xdg_config_home_;
+                            in
+                            if builtins.pathExists "${xdg_config_home}/nixup/packages.nix"
+                            then readFile (builtins.toPath "${xdg_config_home}/nixup/packages.nix")
+                            else ""
+                       else if builtins.pathExists (builtins.toPath cfg.managed-packages-path)
+                            then readFile (builtins.toPath cfg.managed-packages-path)
+                            else "";
+    in
+      map (x : getAttr x pkgs) (remove "" (map (x: replaceChars ["\n"] [""] x) (splitString "\n" packagesString)));
+
+in
+
+{
+  options = {
+
+    nixup-tools = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable special tooling for NixUP.
+        '';
+      };
+      managed-packages-path = mkOption {
+        default = null;
+        type = types.nullOr types.path;
+        description = ''
+          Path of file to include into "user.packages".
+          "null" uses "$XDG_CONFIG_HOME/nixup/packages.nix".
+        '';
+      };
+    };
+  };
+
+  config = {
+
+    user.packages = mkIf cfg.enable ([ pkgs.nixup-tools ] ++ managed-packages);
+
+  };
+}

--- a/nixup/modules/nixup/resource-files.nix
+++ b/nixup/modules/nixup/resource-files.nix
@@ -1,0 +1,200 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  managed' = filter (f: f.enable) (attrValues config.user.files);
+
+  managed = pkgs.stdenvNoCC.mkDerivation {
+    name = "managed";
+
+    builder = ./make-managed.sh;
+
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+
+    /* !!! Use toXML. */
+    targets = map (x: x.target) managed';
+    sources = map (x: x.source) managed';
+    dynamics = map (x: x.dynamic) managed';
+    volatiles = map (x: x.volatile) managed';
+    modes = map (x: x.mode) managed';
+    users  = map (x: x.user) managed';
+    groups  = map (x: x.group) managed';
+  };
+in
+
+{
+  options = {
+    user.files = mkOption rec {
+      default = {};
+      type = types.loaOf (types.submodule options);
+      example = literalExample ''
+        [ { target = ".ssh/config";
+            content = "
+              Host home.my-domain.name
+              User seti
+            ";
+          }
+          { target = ".gitconfig";
+            source = ./gitconfig;
+          }
+        ]
+      '';
+      description = ''
+        Set of files that have to be linked in the home directory.
+      '';
+
+      options = { name, config, ... }: {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Whether this <filename>~/.</filename> file should be generated.  This
+              option allows specific <filename>~/.</filename> files to be disabled.
+            '';
+          };
+
+          target = mkOption {
+            type = types.relativePath;
+            description = ''
+              Name of symlink (relative to <filename>~/.</filename>).
+              Defaults to the attribute name.
+            '';
+          };
+
+          dynamic = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              WARNING: USE WITH CARE!!
+
+              Execute the file instead of linking or copying it.
+
+              The file is expected to be an executable that receives the "target" filename
+              as its only input parameter and then generates the "target" file dynamically.
+              So it is possible for the executable to alter its behaviour depending on the
+              current "target" file and e.g. initialize, upgrade or reset an existing file.
+              The executable is re-executed with every run of the top-level activation script
+              and is expected to behave as idempotent as sensible.
+            '';
+          };
+
+          volatile = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Expect the content of the file to change after being generated.
+              That option disables warnings if the managed file is modified directly.
+            '';
+          };
+
+          content = mkOption {
+            default = null;
+            type = types.nullOr types.lines;
+            description = "Content of the file.";
+          };
+
+          source = mkOption {
+            type = types.path;
+            description = "Path of the source file.";
+          };
+
+          mode = mkOption {
+            type = types.str;
+            default = "symlink";
+            example = "0600";
+            description = ''
+              If set to something else than <literal>symlink</literal>,
+              the file is copied instead of symlinked, with the given
+              file mode.
+            '';
+          };
+
+          uid = mkOption {
+            default = 0;
+            type = types.int;
+            description = ''
+              UID of created file. Only takes affect when the file is
+              copied (that is, the mode is not 'symlink').
+              '';
+          };
+
+          gid = mkOption {
+            default = 0;
+            type = types.int;
+            description = ''
+              GID of created file. Only takes affect when the file is
+              copied (that is, the mode is not 'symlink').
+            '';
+          };
+
+          user = mkOption {
+            default = "+${toString config.uid}";
+            type = types.str;
+            description = ''
+              User name of created file.
+              Only takes affect when the file is copied (that is, the mode is not 'symlink').
+              Changing this option takes precedence over <literal>uid</literal>.
+            '';
+          };
+
+          group = mkOption {
+            default = "+${toString config.gid}";
+            type = types.str;
+            description = ''
+              Group name of created file.
+              Only takes affect when the file is copied (that is, the mode is not 'symlink').
+              Changing this option takes precedence over <literal>gid</literal>.
+            '';
+          };
+
+        };
+
+        config = {
+          target = mkDefault name;
+          source = mkIf (config.content != null)
+            (mkDefault (pkgs.writeText "managed-${name}" config.content));
+        };
+      };
+
+    };
+  };
+
+  config = {
+    nixup.buildCommands = ''
+      mkdir -p $out
+      ln -s ${managed} $out/resources
+
+      ##
+      ## create resource linking/unlinking/switching commands
+      ## NOTE: The commands link directly to the derivation of the profile, and not to $NIXUP_RUNTIME_DIR/active-profile!
+      ##
+      mkdir -p $out/bin
+
+      echo "#! ${pkgs.stdenv.shell}" > $out/bin/nixup-resources-link
+      echo "/run/wrappers/bin/resource-manager link \$HOME ${managed}" >> $out/bin/nixup-resources-link
+      chmod +x $out/bin/nixup-resources-link
+
+      echo "#! ${pkgs.stdenv.shell}" > $out/bin/nixup-resources-unlink
+      echo "/run/wrappers/bin/resource-manager unlink \$HOME ${managed}" >> $out/bin/nixup-resources-unlink
+      chmod +x $out/bin/nixup-resources-unlink
+
+      echo "#! ${pkgs.stdenv.shell}" > $out/bin/nixup-resources-cleanup
+      echo "/run/wrappers/bin/resource-manager cleanup \$HOME" >> $out/bin/nixup-resources-cleanup
+      chmod +x $out/bin/nixup-resources-cleanup
+    '';
+
+    nixup.activationScripts.resourceFiles = ''
+      echo "Setting up resource files ..."
+      if [ -L "$NIXUP_USER_GCROOTS_DIR/old-active-profile" ];
+      then
+          /run/wrappers/bin/resource-manager switch $HOME `${pkgs.coreutils}/bin/readlink $NIXUP_USER_GCROOTS_DIR/old-active-profile/resources` ${managed}
+      else
+          #TODO: implement "cleanup"# /run/wrappers/bin/resource-manager cleanup $HOME ${managed}
+          /run/wrappers/bin/resource-manager link $HOME ${managed}
+      fi
+    '';
+  };
+}

--- a/nixup/modules/nixup/switch-to-configuration.nix
+++ b/nixup/modules/nixup/switch-to-configuration.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+
+  config = {
+
+    nixup.buildCommands = ''
+      mkdir -p $out/bin
+      export perl="${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl";
+      export coreutils=${pkgs.coreutils}
+      export systemd=${config.systemd.package}
+      export flavour='nixup'
+      export installBootLoader='/dev/null'
+      export utillinux='/dev/null'
+      substituteAll ${../../../nixos/modules/system/activation/switch-to-configuration.pl} $out/bin/switch-to-configuration
+      chmod +x $out/bin/switch-to-configuration
+    '';
+
+    nixup.activationScripts.resourceFiles = ''
+      echo "Setting up systemd user services ..."
+      mkdir -p ''${XDG_RUNTIME_DIR:-/run/user/$(id -u $USER)}/systemd
+      if [ ! -L "''${XDG_RUNTIME_DIR:-/run/user/$(id -u $USER)}/systemd/user" ]; then
+          ln -sf $NIXUP_RUNTIME_DIR/active-profile/systemd ''${XDG_RUNTIME_DIR:-/run/user/$(id -u $USER)}/systemd/user
+      fi
+    '';
+
+  };
+
+}

--- a/nixup/modules/nixup/systemd.nix
+++ b/nixup/modules/nixup/systemd.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, utils, ... }:
+
+let
+  config_ = {
+    systemd = config.systemd // { user = config.user; };
+  };
+
+  wrapper = import ../../../nixos/modules/system/boot/systemd.nix { config=config_; inherit lib pkgs utils; };
+
+  systemd-lib = import ../../../nixos/modules/system/boot/systemd-lib.nix { config=config_; inherit lib pkgs; };
+in
+
+{
+  options = {
+    systemd = { inherit (wrapper.options.systemd) package packages defaultUnit ctrlAltDelUnit globalEnvironment; };
+
+    user = wrapper.options.systemd.user;
+  };
+
+  config = {
+    nixup.buildCommands = ''
+      ln -s ${config.nixup.build.systemd} $out/systemd
+    '';
+
+    nixup.build.systemd = systemd-lib.generateUnits "user" config.user.units [] [];
+
+    user = { inherit (wrapper.config.systemd.user) units timers; };
+  };
+}

--- a/pkgs/applications/misc/nixup-tools/default.nix
+++ b/pkgs/applications/misc/nixup-tools/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, coreutils, gnused, nix }:
+
+stdenv.mkDerivation rec {
+  name = "nixup-${version}";
+  version = "0.0.1";
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    shell=${stdenv.shell}
+    export coreutils=${coreutils}
+    export gnused=${gnused}
+    export nix=${nix}
+    substituteAll ${./nixup.sh} $out/bin/nixup
+    chmod +x $out/bin/nixup
+  '';
+}
+

--- a/pkgs/applications/misc/nixup-tools/nixup.sh
+++ b/pkgs/applications/misc/nixup-tools/nixup.sh
@@ -1,0 +1,84 @@
+#! @shell@
+
+CONFIG_FILE=${XDG_CONFIG_HOME:-$HOME/.config}/nixup/packages.nix
+PACKAGE_NAME=$package
+
+ACTION=
+
+while [[ "$#" -gt 0 ]]; do
+    i="$1"; shift 1
+    case "$i" in
+      package)
+        j="$1"; shift 1
+        case "$j" in
+          install|remove)
+            ACTION="$i"-"$j"
+            PACKAGE_NAME="$1"; shift 1
+            ;;
+          *)
+            echo "$0: unknown option \`$j'"
+            exit 1
+            ;;
+        esac
+        ;;
+      switch|build)
+        ACTION="$i"
+        ;;
+      *)
+        echo "$0: unknown command \`$i'"
+        exit 1
+        ;;
+    esac
+done
+
+if [ "$ACTION" = "switch" ]; then
+    ${NIXUP_API:?}/bin/nixup-rebuild switch
+fi
+
+if [ "$ACTION" = "build" ]; then
+    ${NIXUP_API:?}/bin/nixup-rebuild build
+fi
+
+if [ "$ACTION" = "package-remove" ]; then
+    if [[ -e $CONFIG_FILE ]]; then
+        @gnused@/bin/sed -n "/^$PACKAGE_NAME\$/q 1" "$CONFIG_FILE"
+        if [[ $? == 1 ]]; then
+            echo "Removing $PACKAGE_NAME..."
+            @gnused@/bin/sed -i "/^$PACKAGE_NAME\$/d" "$CONFIG_FILE"
+            @gnused@/bin/sed -i '/^[[:space:]]*$/d' "$CONFIG_FILE"
+            ${NIXUP_API:?}/bin/nixup-rebuild switch
+        else
+            echo "ERROR: $PACKAGE_NAME is not installed!"
+            exit 1
+        fi
+    else
+        echo "ERROR: $PACKAGE_NAME is not installed!"
+        exit 1
+    fi
+fi
+
+
+if [[ "$ACTION" = "package-install" ]]; then
+    isAvailable=$(@nix@/bin/nix-instantiate --eval -E "builtins.hasAttr \"$PACKAGE_NAME\" (import <nixpkgs> {})")
+    if [[ "$isAvailable" == "false" ]]; then
+        echo "ERROR: Package is not available."
+        exit 1
+    fi
+    if [[ -e $CONFIG_FILE ]]; then
+        @gnused@/bin/sed -n "/^$PACKAGE_NAME\$/q 1" "$CONFIG_FILE"
+        if [ $? == 0 ]; then
+            echo "Installing $PACKAGE_NAME..."
+            echo "$PACKAGE_NAME" >> "$CONFIG_FILE"
+            @gnused@/bin/sed -i '/^[[:space:]]*$/d' "$CONFIG_FILE"
+            ${NIXUP_API:?}/bin/nixup-rebuild switch
+        else
+            echo "WARNING: $PACKAGE_NAME is already installed!"
+            exit 1
+        fi
+    else
+        @coreutils@/bin/mkdir -p "$(dirname "$CONFIG_FILE")"
+        echo "Installing $PACKAGE_NAME..."
+        echo "$PACKAGE_NAME" > "$CONFIG_FILE"
+        ${NIXUP_API:?}/bin/nixup-rebuild switch
+    fi
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3056,6 +3056,8 @@ with pkgs;
 
   ninka = callPackage ../development/tools/misc/ninka { };
 
+  nixup-tools = callPackage ../applications/misc/nixup-tools { };
+
   nodejs = hiPrio nodejs-6_x;
 
   nodejs-slim = nodejs-slim-6_x;


### PR DESCRIPTION
What is Nix User Profile (NixUP)? NixUP is a declarative configuration for the user environment. It is an equivalent to the NixOS configuration method that is based around 'nixos-rebuild' and '/etc/nixos/configuration.nix'. NixUP provides a module system for configuring the user environment and is intended as a replacement for the imperative 'nix-env' commands. NixUP allows to, e.g., install packages, manage user defined services and to manage resources.

NixUP consists of a new program, called 'nixup' and a declarative configuration rooted at '$XDG_CONFIG_HOME/nixup/profile.nix' (e.g. ~/.config/nixup/profile.nix). Basically, the workflow for managing the NixUP user profile is the same as how the NixOS system configuration is being managed. The 'profile.nix' is edited by the user, and then turned into an active environment through 'nixup'.

The important commands for using 'nixup' are:

nixup build
  -- Builds a user profile. By default the profile is defined
     in $XDG_CONFIG_HOME/nixup/profile.nix.

nixup login
  -- Builds a user profile that will be activated on the next login.
     That is similar to nixos-rebuild boot.

nixup switch
  -- Builds a user profile and immediately switches to it.

nixup edit
  -- Opens an editor with the current configuration.

NixUP also brings an small program that helps to install and to remove software packages. If 'config.imperativeNix.enable=true' is set in the 'profile.nix' configuration, then a program 'nix-package' becomes available that manages a list of packages to be installed into the user environment. By default the list is maintained at '$XDG_CONFIG_HOME/nixup/packages.nix', from where the list is read by a module of the NixUP system.

The commands for using 'nix-package' are:

nix-package install hello

nix-package remove hello

Note that the packages are not pinned at a particular version but are linked to the currently active nixpkgs channel. A way to pin a package will be provided later.

Besides managing software packages, NixUP also provides a way to manage user controlled services. NixUP allows to define services for 'systemd --user', similarly to how NixOS allows to define services for 'systemd'. That means that the feature of managing services within NixUP is bound very tightly to 'systemd', and will not be available on other platforms like OSX or Windows.

The last interesting feature of NixUP is that is allows to manage resources. That means, it allows to define files in 'profile.nix' that are then linked into the $HOME directory of a user, or into any sub-directory of $HOME. The necessary sub-directories and links are created as needed, and automatically removed when the 'profile.nix' changes. Automatically created sub-directories are removed if they are empty after all links have been removed. So NixUP has a built-in way for managing, e.g., dot-files. 
