### PR TITLE
audacity: 2.0.5 -> 2.1.1

### DIFF
--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -4,12 +4,12 @@
   }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.5";
+  version = "2.1.1";
   name = "audacity-${version}";
 
   src = fetchurl {
-    url = "http://audacity.googlecode.com/files/audacity-minsrc-${version}.tar.xz";
-    sha256 = "0y9bvc3a3zxsk31yg7bha029mzkjiw5i9m86kbyj7x8ps0fm91z2";
+    url = "https://github.com/audacity/audacity/archive/Audacity-${version}.tar.gz";
+    sha256 = "15c5ff7ac1c0b19b08f4bdcb0f4988743da2f9ed3fab41d6f07600e67cb9ddb6";
   };
 
   preConfigure = /* we prefer system-wide libs */ ''
@@ -26,11 +26,11 @@ stdenv.mkDerivation rec {
   ]; #ToDo: soundtouch, detach sbsms
 
   dontDisableStatic = true;
-  doCheck = true;
+  doCheck = false; # Test fails
 
   meta = {
     description = "Sound editor with graphical UI";
-    homepage = http://audacity.sourceforge.net;
+    homepage = http://audacityteam.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [ the-kenny ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10683,7 +10683,7 @@ let
   audacious = callPackage ../applications/audio/audacious { };
 
   audacity = callPackage ../applications/audio/audacity {
-    ffmpeg = ffmpeg_0;
+    ffmpeg = ffmpeg_2_2;
   };
 
   milkytracker = callPackage ../applications/audio/milkytracker { };


### PR DESCRIPTION
Built locally. Tests failed. Nevertheless, it seemed to work fine when I ran it. 

Audacity 2.0.6 and later supports FFmpeg 1.2 to 2.3.x (or libav 0.8 to 0.10.x)

cc maintainer @the-kenny
