### PR TITLE
nixos/tests/lightdm: Fix waiting for the login to succeed

### DIFF
--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -22,7 +22,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     $machine->waitForText(qr/${user.description}/);
     $machine->screenshot("lightdm");
     $machine->sendChars("${user.password}\n");
-    $machine->waitForText(qr/^\d{2}(?::\d{2}){2} (?:AM|PM)$/m);
+    $machine->waitForWindow("^IceWM ");
     $machine->screenshot("session");
   '';
 })


### PR DESCRIPTION
Currently the lightdm test detects a successful login by OCR'ing the
screen and searching for the clock widget's text.  Since the last
IceWM update (commit bdd20ced), either the font or the colors of the
clock changed such that the OCR doesn't pick it up anymore:
http://hydra.nixos.org/build/24748219 (BTW, a timeout of 10 hours 
sounds a bit excessive).

Instead, just look for a matching (root) window title, e.g.
"IceWM 1.3.9 (Linux/i686)"
