### PR TITLE
nixos-generate-config: Don't enable vbox guest via deprecated option

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -235,7 +235,7 @@ chomp $virt;
 # Check if we're a VirtualBox guest.  If so, enable the guest
 # additions.
 if ($virt eq "oracle") {
-    push @attrs, "services.virtualboxGuest.enable = true;"
+    push @attrs, "virtualisation.virtualbox.guest.enable = true;"
 }
 
 


### PR DESCRIPTION
Avoids this warning when running `nixos-rebuild switch`:

```
building Nix...
building the system configuration...
trace: Obsolete option `services.virtualboxGuest.enable' is used. It was renamed to `virtualisation.virtualbox.guest.enable'.
```
