### PR TITLE
direnv: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -1,14 +1,14 @@
 { fetchurl, stdenv, go }:
 
 let
-  version = "2.6.0";
+  version = "2.7.0";
 in
 stdenv.mkDerivation {
   name = "direnv-${version}";
   src = fetchurl {
     url = "http://github.com/zimbatm/direnv/archive/v${version}.tar.gz";
     name = "direnv-${version}.tar.gz";
-    sha256 = "b85aac4d6a4ddf2daf193aabb3b2faf89e56507d33d763ab74cc7eb0b524ac03";
+    sha256 = "3cfa8f41e740c0dc09d854f3833058caec0ea0d67d19e950f97eee61106b0daf";
   };
 
   buildInputs = [ go ];


### PR DESCRIPTION
Just another release. This one has support for loading environment variables from the nix-shell.
