### PR TITLE
supertux-editor: init at git-2014-08-20

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -158,6 +158,7 @@
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
   maurer = "Matthew Maurer <matthew.r.maurer+nix@gmail.com>";
   matejc = "Matej Cotman <cotman.matej@gmail.com>";
+  mathnerd314 = "Mathnerd314 <mathnerd314.gph+hs@gmail.com>";
   matthiasbeyer = "Matthias Beyer <mail@beyermatthias.de>";
   mbakke = "Marius Bakke <ymse@tuta.io>";
   meditans = "Carlo Nucera <meditans@gmail.com>";

--- a/pkgs/applications/editors/supertux-editor/default.nix
+++ b/pkgs/applications/editors/supertux-editor/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, mono, gtk-sharp, pkgconfig, makeWrapper, gnome, gtk }:
+stdenv.mkDerivation rec {
+  version = "git-2014-08-20";
+  name = "supertux-editor-${version}";
+
+  src = fetchFromGitHub {
+    owner = "SuperTux";
+    repo = "supertux-editor";
+    rev = "0c666e8ccc7daf9e9720fe79abd63f8fa979c5e5";
+    sha256 = "08y5haclgxvcii3hpdvn1ah8qd0f3n8xgxxs8zryj02b8n7cz3vx";
+  };
+
+  buildInputs = [mono gtk-sharp pkgconfig makeWrapper gnome.libglade gtk ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/supertux-editor
+    cp *.{dll,dll.config,exe} $out/lib/supertux-editor
+    makeWrapper "${mono}/bin/mono" $out/bin/supertux-editor \
+      --add-flags "$out/lib/supertux-editor/supertux-editor.exe" \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp} \
+      --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //')
+
+    makeWrapper "${mono}/bin/mono" $out/bin/supertux-editor-debug \
+      --add-flags "--debug $out/lib/supertux-editor/supertux-editor.exe" \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp} \
+      --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //')
+  '';
+
+  # Always needed on Mono, otherwise nothing runs
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    description = "Level editor for SuperTux";
+    homepage = https://github.com/SuperTux/supertux-editor;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mathnerd314 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3049,6 +3049,8 @@ let
 
   super = callPackage ../tools/security/super { };
 
+  supertux-editor = callPackage ../applications/editors/supertux-editor { };
+
   super-user-spark = haskellPackages.callPackage ../applications/misc/super_user_spark { };
 
   ssdeep = callPackage ../tools/security/ssdeep { };


### PR DESCRIPTION
There's probably a better way of generating LD_LIBRARY_PATH, but I haven't found it (listing out the packages results in a mysterious "opengl.dll not found" error)
