### PR TITLE
kbd: really do include neo layout

### DIFF
--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     ''
       mkdir -p data/keymaps/i386/neo
       cat "$neoSrc" > data/keymaps/i386/neo/neo.map
-      sed -i -e 's,^KEYMAPSUBDIRS *= *,&i386/neo ,' data/Makefile.in
+      sed -i -e 's,^KEYMAPSUBDIRS *= *,&i386/neo ,' data/Makefile.am
 
       # Add the dvp keyboard in the dvorak folder
       ${gzip}/bin/gzip -c -d ${dvpSrc} > data/keymaps/i386/dvorak/dvp.map


### PR DESCRIPTION
`.am` overwrites `.in`, so that didn’t really do anything.

CC @aszlig 
