### PR TITLE
shake: add new package

### DIFF
--- a/pkgs/development/tools/build-managers/shake/default.nix
+++ b/pkgs/development/tools/build-managers/shake/default.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, base, binary, bytestring, deepseq, directory, extra
+, filepath, hashable, js-flot, js-jquery, old-time, process
+, QuickCheck, random, stdenv, time, transformers, unix
+, unordered-containers, utf8-string
+, gcc
+}:
+mkDerivation {
+  pname = "shake";
+  version = "0.15.4";
+  sha256 = "189qyxvy6rxlkgmssy2v66f7anp4q9xjmwqcpwxq86h0pj7vr3i9";
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    base binary bytestring deepseq directory extra filepath hashable
+    js-flot js-jquery old-time process random time transformers unix
+    unordered-containers utf8-string
+  ];
+  testDepends = [
+    base binary bytestring deepseq directory extra filepath hashable
+    js-flot js-jquery old-time process QuickCheck random time
+    transformers unix unordered-containers utf8-string
+    gcc
+  ];
+  homepage = http://shakebuild.com;
+  description = "Build system library, like Make, but more accurate dependencies";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14855,6 +14855,8 @@ let
 
   seafile-shared = callPackage ../misc/seafile-shared { };
 
+  shake = haskellPackages.callPackage ../development/tools/build-managers/shake { };
+
   slock = callPackage ../misc/screensavers/slock { };
 
   soundOfSorting = callPackage ../misc/sound-of-sorting { };


### PR DESCRIPTION
Hi,

shake is a build tool written in Haskell. Since the build tool is not limited
to haskell projects I took the liberty of putting it in the top-level. Is that
alright ?

shake's default.nix is generated with `cabal2nix cabal://shake > default.nix`
but was missing gcc as a test dependency. Is there a better way to add gcc as a
dependency without having to add it back on the next shake update ?
