### PR TITLE
services.nsd.zones.<name>.data: Do not interpret '$' sign.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -200,6 +200,27 @@ nix-env -f &quot;&lt;nixpkgs&gt;&quot; -iA haskellPackages.cabal-install
   </para>
 </listitem>
 
+<listitem>
+  <para>
+    The option <option>services.nsd.zones.&lt;name&gt;.data</option> no
+    longer interpret the dollar sign ($) as a shell variable, as such it
+    should not be escaped anymore.  Thus the following zone data:
+  </para>
+  <programlisting>
+\$ORIGIN example.com.
+\$TTL 1800
+@       IN      SOA     ns1.vpn.nbp.name.      admin.example.com. (
+  </programlisting>
+  <para>
+    Should modified to look like the actual file expected by nsd:
+  </para>
+  <programlisting>
+$ORIGIN example.com.
+$TTL 1800
+@       IN      SOA     ns1.vpn.nbp.name.      admin.example.com. (
+  </programlisting>
+</listitem>
+
 </itemizedlist>
 </para>
 

--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -45,6 +45,8 @@ in import ./make-test.nix ({ pkgs, ...} : {
         ns AAAA dead:beef::1
       '';
       services.nsd.zones."deleg.example.com.".data = ''
+        $ORIGIN deleg.example.com.
+        $TTL 3600
         @ SOA ns.example.com noc.example.com 666 7200 3600 1209600 3600
         @ A 9.8.7.6
         @ AAAA fedc::bbaa

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -55,6 +55,23 @@ rec {
       '';
 
 
+  # This is identical to symlinkJoin, except that in some cases program do
+  # not trust symbolic links for security reasons, so we have to copy files.
+  copyJoin = name: paths:
+    runCommand name { inherit paths; }
+      ''
+        set -x
+        mkdir -p $out
+        for i in $paths; do
+          (cd $i; find . -type d) | while read d; do
+            mkdir -p $out/$dir
+          done
+          (cd $i; find . \! -type d) | while read f; do
+            cp $i/$f $out/$f
+          done
+        done
+      '';
+
   # Make a package that just contains a setup hook with the given contents.
   makeSetupHook = { deps ? [], substitutions ? {} }: script:
     runCommand "hook" substitutions


### PR DESCRIPTION
This patch make sure that dollar sign are not interpreted, and kept as-is, which is necessary if people are migrating their zone files from Ubuntu, and followed the following how to:

https://www.digitalocean.com/community/tutorials/how-to-use-nsd-an-authoritative-only-dns-server-on-ubuntu-14-04

No having this will change the file content by interpreting the `$ORIGIN` and `$TTL` shell variables which are empty when running the `zoneFiles` derivation.  This patch replaces this derivation by a copy of the `writeTextDir` of each zone.

cc @aszlig 
