### PR TITLE
Haskell packages not matching broken version should be allowed.

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -38,7 +38,7 @@ rec {
   disableCabalFlag = drv: x: appendConfigureFlag (removeConfigureFlag drv "-f${x}") "-f-${x}";
 
   markBroken = drv: overrideCabal drv (drv: { broken = true; });
-  markBrokenVersion = version: drv: assert drv.version == version; markBroken drv;
+  markBrokenVersion = version: drv: if drv.version == version then markBroken drv else drv;
 
   enableLibraryProfiling = drv: overrideCabal drv (drv: { enableLibraryProfiling = true; });
   disableLibraryProfiling = drv: overrideCabal drv (drv: { enableLibraryProfiling = false; });


### PR DESCRIPTION
As written, if a Haskell package does not match the broken version, the assert fails which aborts the evaluation.  I observed this with cmdlib, which is marked as broken for "0.3.5", but the new version in hackage-packages.nix is "0.3.6".  I believe that the attached captures the intent: broken packages versions are marked as broken and non-broken versions are accepted as-is.
