### PR TITLE
antimicro: init at 2.18

### DIFF
--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, cmake, pkgconfig, SDL2, qt5, xlibs, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "antimicro-${version}";
+  version = "2.18";
+
+  src = fetchzip {
+    url    = "https://github.com/Ryochan7/antimicro/archive/${version}.tar.gz";
+    sha256 = "0kyl4xl2am50v2xscgy2irpcdj78f7flgfhljyjck4ynf8d40vb7";
+  };
+
+  buildInputs = [
+    cmake pkgconfig SDL2 qt5.base qt5.tools xlibs.libXtst
+  ];
+
+  meta = with stdenv.lib; {
+    description = "GUI for mapping keyboard and mouse controls to a gamepad";
+    homepage = "https://github.com/Ryochan7/antimicro";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14692,6 +14692,8 @@ let
 
   ### MISC
 
+  antimicro = callPackage ../tools/misc/antimicro { };
+
   atari800 = callPackage ../misc/emulators/atari800 { };
 
   ataripp = callPackage ../misc/emulators/atari++ { };


### PR DESCRIPTION
antimicro is a graphical program used to map keyboard keys and mouse controls
to a gamepad. Useful for playing PC games with no gamepad or poor gamepad
support.
