### PR TITLE
[WIP] R: 3.2.1 -> 3.2.2

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -6,11 +6,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "R-3.2.1";
+  name = "R-3.2.2";
 
   src = fetchurl {
     url = "http://cran.r-project.org/src/base/R-3/${name}.tar.gz";
-    sha256 = "d59dbc3f04f4604a5cf0fb210b8ea703ef2438b3ee65fd5ab536ec5234f4c982";
+    sha256 = "9c9152e74134b68b0f3a1c7083764adc1cb56fd8336bec003fd0ca550cd2461d";
   };
 
   buildInputs = [ bzip2 gfortran libX11 libXmu libXt


### PR DESCRIPTION
My build fails with 

```
make[3]: Entering directory '/tmp/nix-build-R-3.2.2.drv-0/R-3.2.2/tests'
running code in 'reg-tests-1a.R' ... OK
running code in 'reg-tests-1b.R' ... OK
running code in 'reg-tests-1c.R' ... OK
running code in 'reg-tests-2.R' ... OK
  comparing 'reg-tests-2.Rout' to './reg-tests-2.Rout.save' ... OK
running code in 'reg-examples1.R' ... OK
running code in 'reg-examples2.R' ... OK
running code in 'reg-packages.R' ...Makefile.common:93: recipe for target 'reg-packages.Rout' failed
```

Not sure how to address this. Is this an upstream bug or related to our build?

cc @peti 
