### PR TITLE
firefoxWrapper: switch to GStreamer 1.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
         --suffix-each LD_LIBRARY_PATH ':' "$libs" \
         --suffix-each GTK_PATH ':' "$gtk_modules" \
         --suffix-each LD_PRELOAD ':' "$(cat $(filterExisting $(addSuffix /extra-ld-preload $plugins)))" \
-        --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
+        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
         --prefix-contents PATH ':' "$(filterExisting $(addSuffix /extra-bin-path $plugins))" \
         --set MOZ_OBJDIR "$(ls -d "${browser}/lib/${browserName}"*)"
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13259,10 +13259,10 @@ let
           ++ lib.optional (cfg.enableTrezor or false) trezor-bridge
           ++ lib.optional (cfg.enableBluejeans or false) bluejeans
          );
-      libs = [ gstreamer gst_plugins_base ] ++ lib.optionals (cfg.enableQuakeLive or false)
+      libs = (with gst_all_1; [ gstreamer gst-plugins-base ]) ++ lib.optionals (cfg.enableQuakeLive or false)
              (with xlibs; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ])
              ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash;
-      gst_plugins = [ gst_plugins_base gst_plugins_good gst_plugins_bad gst_plugins_ugly gst_ffmpeg ];
+      gst_plugins = with gst_all_1; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-vaapi ];
       gtk_modules = [ libcanberra ];
     };
 


### PR DESCRIPTION
wkennington@f6c1004 switched Firefox to GStreamer 1.0 by changing its
buildInput _only_, but that is not enough. We need to fix Firefox
wrappers by changing their buildInputs and set GST_PLUGIN_SYSTEM_PATH_1_0
instead of GST_PLUGIN_SYSTEM_PATH.

With above changes playing H.264/MP4 media works in firefoxWrapper and
conkerorWrapper as tested with
http://www.quirksmode.org/html5/tests/video.html and
https://soundcloud.com/immclovin33/synthetix-sundays-53-with-marko-maric-19715

It should help with #9247 cc @peti

Reviewed-by: kmicu kmicu@protonmail.ch
Tested-by: kmicu kmicu@protonmail.ch
