### PR TITLE
pixman: Enable '--disable-arm-iwmmxt' on ARM

### DIFF
--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.optional stdenv.isDarwin ./fix-clang36.patch;
 
+  configureFlags = if stdenv.isArm then ["--disable-arm-iwmmxt"] else null;
+
   meta = {
     homepage = http://pixman.org;
     description = "A low-level library for pixel manipulation";


### PR DESCRIPTION
Otherwise the build fails on ARMv6:

```
  CC       libpixman_iwmmxt_la-pixman-mmx.lo
pixman-mmx.c: In function 'mmx_fetch_x8r8g8b8':
pixman-mmx.c:3812:1: internal compiler error: Max. number of generated reload insns per insn is achieved (90)
```

This could be shortened with `lib.optional stdenv.isArm ...`, but the `if stdenv.isArm then ... else null` approach doesn't cause any recompilation on non-ARM, so I chose it.
