### PR TITLE
python: add .env for convenient nix-shell's

### DIFF
--- a/doc/language-support.xml
+++ b/doc/language-support.xml
@@ -464,6 +464,27 @@ python.buildEnv.override {
     with wrapped binaries in <filename>bin/</filename>.
   </para>
 
+  <para>
+  You can also use <varname>env</varname> attribute to create local
+  environments with needed packages installed (somewhat comparable to
+  <literal>virtualenv</literal>). For example, with the following
+  <filename>shell.nix</filename>:
+
+<programlisting language="nix">
+<![CDATA[with import <nixpkgs> {};
+
+(python3.buildEnv.override {
+  extraLibs = with python3Packages;
+    [ numpy
+      requests
+    ];
+}).env]]>
+</programlisting>
+
+  Running <command>nix-shell</command> will drop you into a shell where
+  <command>python</command> will have specified packages in its path.
+  </para>
+
   <variablelist>
     <title>
       <function>python.buildEnv</function> arguments

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -6,28 +6,40 @@
 # Create a python executable that knows about additional packages.
 let
   recursivePthLoader = import ../../python-modules/recursive-pth-loader/default.nix { stdenv = stdenv; python = python; };
-in
-(buildEnv {
-  name = "${python.name}-env";
-  paths = stdenv.lib.filter (x : x ? pythonPath) (stdenv.lib.closePropagation extraLibs) ++ [ python recursivePthLoader ];
+  env = (buildEnv {
+    name = "${python.name}-env";
+    paths = stdenv.lib.filter (x : x ? pythonPath) (stdenv.lib.closePropagation extraLibs) ++ [ python recursivePthLoader ];
 
-  inherit ignoreCollisions;
+    inherit ignoreCollisions;
 
-  postBuild = ''
-    . "${makeWrapper}/nix-support/setup-hook"
+    postBuild = ''
+      . "${makeWrapper}/nix-support/setup-hook"
 
-    if [ -L "$out/bin" ]; then
-        unlink "$out/bin"
-    fi
-    mkdir -p "$out/bin"
+      if [ -L "$out/bin" ]; then
+          unlink "$out/bin"
+      fi
+      mkdir -p "$out/bin"
 
-    cd "${python}/bin"
-    for prg in *; do
-      rm -f "$out/bin/$prg"
-      makeWrapper "${python}/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out"
-    done
-  '' + postBuild;
-}) // {
-  inherit python;
-  inherit (python) meta;
-}
+      cd "${python}/bin"
+      for prg in *; do
+        rm -f "$out/bin/$prg"
+        makeWrapper "${python}/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out"
+      done
+    '' + postBuild;
+
+    passthru.env = stdenv.mkDerivation {
+      name = "interactive-${python.name}-environment";
+      nativeBuildInputs = [ env ];
+
+      buildCommand = ''
+        echo >&2 ""
+        echo >&2 "*** Python 'env' attributes are intended for interactive nix-shell sessions, not for building! ***"
+        echo >&2 ""
+        exit 1
+      '';
+    };
+  }) // {
+    inherit python;
+    inherit (python) meta;
+  };
+in env


### PR DESCRIPTION
Idea shamelessly stolen from @peti's wonderful Haskell NG. Use it like this:

```
with import <nixpkgs> {};

(python3.buildEnv.override {
  extraLibs = with python3Packages;
    [ numpy
      requests
    ];
}).env
```

to have all needed libraries in Python's path.

cc @domenkozar 
