### PR TITLE
Move licenseAllowed check into the builder attribute (fixes #7541)

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -131,8 +131,6 @@ let
         else true;
 
     in
-      assert licenseAllowed attrs;
-
       lib.addPassthru (derivation (
         (removeAttrs attrs
           ["meta" "passthru" "crossAttrs" "pos"
@@ -152,7 +150,7 @@ let
           computedPropagatedImpureHostDeps = lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (propagatedBuildInputs ++ propagatedNativeBuildInputs));
         in
         {
-          builder = attrs.realBuilder or shell;
+          builder = assert licenseAllowed attrs; attrs.realBuilder or shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
           stdenv = result;
           system = result.system;


### PR DESCRIPTION
As said in the bug, it was too strict before.

Note that this only works with overrideCabal (and possibly autonix's overrideDerivation) because lib.overrideDerivation's meta handling is broken (#7425).
