### PR TITLE
overrideDerivation: fix meta handling

### DIFF
--- a/pkgs/applications/networking/cluster/panamax/api/default.nix
+++ b/pkgs/applications/networking/cluster/panamax/api/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     lockfile = ./Gemfile.lock;
     buildInputs = [ openssl ];
   };
-  bundler = bundler_HEAD.override { inherit ruby; };
+  bundler = bundler_HEAD.overrideDerivation { inherit ruby; };
 
   database_yml = builtins.toFile "database.yml" ''
     production:

--- a/pkgs/applications/networking/cluster/panamax/ui/default.nix
+++ b/pkgs/applications/networking/cluster/panamax/ui/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     buildInputs = [ openssl ];
   };
 
-  bundler = bundler_HEAD.override { inherit ruby; };
+  bundler = bundler_HEAD.overrideDerivation { inherit ruby; };
 
   src = fetchgit {
     rev = "refs/tags/v${version}";

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -50,4 +50,4 @@ lib.overrideDerivation (fetchurl ({
     '');
 } // removeAttrs args [ "stripRoot" ]))
 # Hackety-hack: we actually need unzip hooks, too
-(x: {nativeBuildInputs = x.nativeBuildInputs++ [unzip];})
+(x: {buildInputs = x.buildInputs++ [unzip];})

--- a/pkgs/development/interpreters/ruby/bundler-env/default.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default.nix
@@ -18,7 +18,7 @@ let
 
   shellEscape = x: "'${lib.replaceChars ["'"] [("'\\'" + "'")] x}'";
   const = x: y: x;
-  bundler = bundler_HEAD.override { inherit ruby; };
+  bundler = bundler_HEAD.overrideDerivation { inherit ruby; };
   inherit (builtins) attrValues;
 
   gemName = attrs: "${attrs.name}-${attrs.version}.gem";

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -87,7 +87,7 @@ let
 
   # Add a utility function to produce derivations that use this
   # stdenv and its shell.
-  mkDerivation =
+  mkDerivation_ =
     { buildInputs ? []
     , nativeBuildInputs ? []
     , propagatedBuildInputs ? []
@@ -273,7 +273,7 @@ let
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;
 
-      inherit mkDerivation;
+      mkDerivation = lib.makeOverridable mkDerivation_;
 
       # For convenience, bring in the library functions in lib/ so
       # packages don't have to do that themselves.


### PR DESCRIPTION
I checked a few uses of overrideDerivation; the majority did not change at all, while the ones that had `builder = {bash}/bin/sh` became `builder = {bash}/bin/bash` (i.e. `stdenv.shell`). But there could be some breakage.
