### PR TITLE
Moving llvm 3.5.0 to llvm 3.5.2

### DIFF
--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -5,7 +5,7 @@ in stdenv.mkDerivation {
   name = "clang-${version}";
 
   unpackPhase = ''
-    unpackFile ${fetch "cfe" "12yv3jwdjcbkrx7zjm8wh4jrvb59v8fdw4mnmz3zc1jb00p9k07w"}
+    unpackFile ${fetch "cfe" "0846h8vn3zlc00jkmvrmy88gc6ql6014c02l4jv78fpvfigmgssg"}
     mv cfe-${version}.src clang
     sourceRoot=$PWD/clang
     unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/3.5/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/default.nix
@@ -1,8 +1,8 @@
-{ pkgs, newScope, stdenv, isl, fetchurl }:
+{ pkgs, newScope, stdenv, isl, fetchurl, gcc }:
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
-  version = "3.5.0";
+  version = "3.5.2";
 
   fetch = fetch_v version;
   fetch_v = ver: name: sha256: fetchurl {
@@ -10,18 +10,18 @@ let
     inherit sha256;
   };
 
-  compiler-rt_src = fetch "compiler-rt" "0dl1kbrhz96djsxqr61iw5h788s7ncfpfb7aayixky1bhdaydcx4";
-  clang-tools-extra_src = fetch "clang-tools-extra" "0s8zjgxg8bj15nnqcw1cj1zffcralhh7f0gda1famddgg2rvx099";
+  compiler-rt_src = fetch "compiler-rt" "1hsdnzzdr5kglz6fnv3lcsjs222zjsy14y8ax9dy6zqysanplbal";
+  clang-tools-extra_src = fetch "clang-tools-extra" "01607w6hdf1pjgaapn9fy6smk22i3d4ncqjlhk4xi55ifi6kf6pj";
 
   self = {
     llvm = callPackage ./llvm.nix rec {
-      version = "3.5.0";
+      version = "3.5.2";
       fetch = fetch_v version;
       inherit compiler-rt_src;
     };
 
     clang = callPackage ./clang.nix rec {
-      version = "3.5.0";
+      version = "3.5.2";
       fetch = fetch_v version;
       inherit clang-tools-extra_src;
     };
@@ -31,11 +31,14 @@ let
     lldb = callPackage ./lldb.nix {};
 
     polly = callPackage ./polly.nix {};
-
-    dragonegg = callPackage ./dragonegg.nix {};
+    
+    #Dragonegg is borked in 3.5 
+    #dragonegg = callPackage ./dragonegg.nix {};
 
     libcxx = callPackage ./libc++ { stdenv = pkgs.clangStdenv; };
 
     libcxxabi = callPackage ./libc++abi { stdenv = pkgs.clangStdenv; };
+    
+    #openmp = callPackage ./openmp {};
   };
 in self

--- a/pkgs/development/compilers/llvm/3.5/dragonegg.nix
+++ b/pkgs/development/compilers/llvm/3.5/dragonegg.nix
@@ -1,26 +1,26 @@
-{stdenv, fetch, fetchpatch, llvm, gmp, mpfr, libmpc, ncurses, zlib, version}:
+#{stdenv, fetch, fetchpatch, llvm, gmp, mpfr, libmpc, ncurses, zlib, version, gcc}:
 
-stdenv.mkDerivation rec {
-  name = "dragonegg-${version}";
+#stdenv.mkDerivation rec {
+#  name = "dragonegg-${version}";
 
-  src = fetch "dragonegg" "1v1lc9h2nfk3lsk9sx1k4ckwddz813hqjmlp2bx2kwxx9hw364ar";
+#  src = fetch "dragonegg" "1va4wv2b1dj0dpzsksnpnd0jic52q7pqj79w3m9jwdb58h7104dw";
 
   # The gcc the plugin will be built for (the same used building dragonegg)
-  GCC = "gcc";
+#  GCC = "gcc";
 
-  buildInputs = [ llvm gmp mpfr libmpc ncurses zlib ];
+#  buildInputs = [ llvm gmp mpfr libmpc ncurses zlib gcc ];
 
-  installPhase = ''
-    mkdir -p $out/lib $out/share/doc/${name}
-    cp -d dragonegg.so $out/lib
-    cp README COPYING $out/share/doc/${name}
-  '';
+#  installPhase = ''
+#    mkdir -p $out/lib $out/share/doc/${name}
+#    cp -d dragonegg.so $out/lib
+#    cp README COPYING $out/share/doc/${name}
+#  '';
 
-  meta = {
-    homepage = http://dragonegg.llvm.org/;
-    description = "gcc plugin that replaces gcc's optimizers and code generators by those in LLVM";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
-  };
-}
+#  meta = {
+#    homepage = http://dragonegg.llvm.org/;
+#    description = "gcc plugin that replaces gcc's optimizers and code generators by those in LLVM";
+#    license = stdenv.lib.licenses.gpl2Plus;
+#    maintainers = with stdenv.lib.maintainers; [viric];
+#    platforms = with stdenv.lib.platforms; linux;
+#  };
+#}

--- a/pkgs/development/compilers/llvm/3.5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchurl, cmake, libcxxabi, fixDarwinDylibNames }:
 
-let version = "3.5.0"; in
+let version = "3.5.2"; in
 
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
   src = fetchurl {
     url = "http://llvm.org/releases/${version}/libcxx-${version}.src.tar.xz";
-    sha256 = "1h5is2jd802344kddm45jcm7bra51llsiv9r34h0rrb3ba2dlic0";
+    sha256 = "0irnl54fwzh2hzn9x4jfvnfyq5kd0zn0iwbzdivgwhqzw6fjdwdv";
   };
 
   # instead of allowing libc++ to link with /usr/lib/libc++abi.dylib,

--- a/pkgs/development/compilers/llvm/3.5/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++abi/default.nix
@@ -1,7 +1,7 @@
 { stdenv, cmake, fetchurl, libcxx, libunwind, llvm }:
 
 let
-  version = "3.5.0";
+  version = "3.5.2";
   cmakeLists = fetchurl {
     name   = "CMakeLists.txt";
     url    = "http://llvm.org/svn/llvm-project/libcxxabi/trunk/CMakeLists.txt?p=217324";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url    = "http://llvm.org/releases/${version}/libcxxabi-${version}.src.tar.xz";
-    sha256 = "1ndcpw3gfrzh7m1jac2qadhkrqgvb65cns69j9niydyj5mmbxijk";
+    sha256 = "1c6rv0zx0na1w4hdmdfq2f6nj7limb7d1krrknwajxxkcn4yws92";
   };
 
   buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin) libunwind;

--- a/pkgs/development/compilers/llvm/3.5/lld.nix
+++ b/pkgs/development/compilers/llvm/3.5/lld.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "1sd4scqynryfrmcc4h0ljgwn2dgjmbbmf38z50ya6l0janpd2nxx";
+  src = fetch "lld" "1hpqawg1sc8mdqxqaxqmlzbrn69w1pkj8rxhjgqgmwra6c0xky89";
 
   preUnpack = ''
     # !!! Hopefully won't be needed for 3.5
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     export cmakeFlags="$cmakeFlags -DLLD_PATH_TO_LLVM_SOURCE="`ls -d $PWD/llvm-*`
   '';
 
-  buildInputs = [ cmake ncurses zlib python ];
+  buildInputs = [ cmake ncurses zlib python];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/development/compilers/llvm/3.5/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.5/lldb.nix
@@ -15,7 +15,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "0h8cmjrhjhigk7k2qll1pcf6jfgmbdzkzfz2i048pkfg851s0x44";
+  src = fetch "lldb" "0ffi9jn4k3yd0hvxs1v4n710x8siq21lb49v3351d7j5qinrpgi7";
 
   patchPhase = ''
     sed -i 's|/usr/bin/env||' \

--- a/pkgs/development/compilers/llvm/3.5/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.5/llvm.nix
@@ -12,10 +12,11 @@
 , version
 , zlib
 , compiler-rt_src
+, gcc
 }:
 
 let
-  src = fetch "llvm" "00swb43mzlvda8306arlg2jw7g6k3acwfccgf1k4c2pgd3rrkq98";
+  src = fetch "llvm" "0xf5q17kkxsrm2gsi93h4pwlv663kji73r2g4asb97klsmb626a4";
 in stdenv.mkDerivation rec {
   name = "llvm-${version}";
 
@@ -27,7 +28,7 @@ in stdenv.mkDerivation rec {
     mv compiler-rt-* $sourceRoot/projects/compiler-rt
   '';
 
-  buildInputs = [ perl groff cmake libxml2 python libffi ] ++ stdenv.lib.optional stdenv.isLinux valgrind;
+  buildInputs = [ perl groff cmake libxml2 python libffi gcc] ++ stdenv.lib.optional stdenv.isLinux valgrind;
 
   propagatedBuildInputs = [ ncurses zlib ];
 

--- a/pkgs/development/compilers/llvm/3.5/polly.nix
+++ b/pkgs/development/compilers/llvm/3.5/polly.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "polly-${version}";
 
-  src =  fetch "polly" "1rqflmgzg1vzjm0r32c5ck8x3q0qm3g0hh8ggbjazh6x7nvmy6ll";
+  src =  fetch "polly" "1s6v54czmgq626an4yk2k34lrzkwmz1bjrbiafh7j23yc2w4nalx";
 
   patches = [ ./polly-separate-build.patch ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4190,7 +4190,10 @@ let
     isl = isl_0_12;
   };
 
-  llvmPackages_35 = callPackage ../development/compilers/llvm/3.5 { };
+  llvmPackages_35 = callPackage ../development/compilers/llvm/3.5 { 
+    isl = isl_0_14;
+    gcc = gcc5;
+  };
 
   llvmPackages_36 = callPackage ../development/compilers/llvm/3.6 {
     inherit (stdenvAdapters) overrideCC;
@@ -6121,7 +6124,7 @@ let
 
   dssi = callPackage ../development/libraries/dssi {};
 
-  dragonegg = llvmPackages_35.dragonegg;
+  #dragonegg = llvmPackages_35.dragonegg;
 
   dxflib = callPackage ../development/libraries/dxflib {};
 


### PR DESCRIPTION
Moving 3.5.0 to 3.5.2. I fixed Polly, by the way. And I commented out dragonegg, because it's screwed for 3.4 and 3.5.
