### PR TITLE
oidentd: listen on IPv6

### DIFF
--- a/nixos/modules/services/networking/oidentd.nix
+++ b/nixos/modules/services/networking/oidentd.nix
@@ -28,7 +28,9 @@ with lib;
     jobs.oidentd =
       { startOn = "started network-interfaces";
         daemonType = "fork";
-        exec = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup";
+        exec = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup" +
+          optionalString config.networking.enableIPv6 " -a ::"
+        ;
       };
 
     users.extraUsers.oidentd = {


### PR DESCRIPTION
If IPv6 is enabled, run oidentd with `-a ::` so that it will listen and accept connections on IPv6 interface addresses.
