### PR TITLE
haskell-packages: bring hoogle and haddock to the masses

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -47,18 +47,29 @@ let
       defaultScope = mkScope self;
       callPackage = drv: args: callPackageWithScope defaultScope drv args;
 
+      withPackages = packages: callPackage ./with-packages-wrapper.nix {
+        inherit (self) llvmPackages;
+        haskellPackages = self;
+        inherit packages;
+      };
+
     in
       import ./hackage-packages.nix { inherit pkgs stdenv callPackage; } self // {
 
         inherit mkDerivation callPackage;
 
-        ghcWithPackages = pkgs: callPackage ./with-packages-wrapper.nix {
-          inherit (self) llvmPackages;
-          haskellPackages = self;
-          packages = pkgs self;
-        };
+        ghcWithPackages = selectFrom: withPackages (selectFrom self);
 
-        ghc = ghc // { withPackages = self.ghcWithPackages; };
+        ghcWithHoogle = selectFrom:
+          let
+            packages = selectFrom self;
+            hoogle = callPackage ./hoogle.nix { inherit packages; };
+          in withPackages (packages ++ [ hoogle ]);
+
+        ghc = ghc // {
+          withPackages = self.ghcWithPackages;
+          withHoogle = self.ghcWithHoogle;
+        };
 
       };
 

--- a/pkgs/development/haskell-modules/hoogle-local-wrapper.sh
+++ b/pkgs/development/haskell-modules/hoogle-local-wrapper.sh
@@ -2,5 +2,4 @@
 
 COMMAND=$1
 shift
-HOOGLE_DOC_PATH=@out@/share/hoogle/doc exec @hoogle@/bin/hoogle \
-    "$COMMAND" -d @out@/share/hoogle "$@"
+exec @hoogle@/bin/hoogle "$COMMAND" -d @out@/share/doc/hoogle "$@"

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -23,7 +23,7 @@
 # This will build mmorph and monadControl, and have the hoogle installation
 # refer to their documentation via symlink so they are not garbage collected.
 
-{ stdenv, hoogle, rehoo
+{ lib, stdenv, hoogle, rehoo
 , ghc, packages ? [ ghc.ghc ]
 }:
 
@@ -35,62 +35,76 @@ stdenv.mkDerivation {
   name = "hoogle-local-0.1";
   buildInputs = [hoogle rehoo];
 
-  phases = [ "installPhase" ];
+  phases = [ "buildPhase" ];
 
-  docPackages = packages;
-  installPhase = ''
+  docPackages = (lib.closePropagation packages);
+
+  buildPhase = ''
     if [ -z "$docPackages" ]; then
         echo "ERROR: The packages attribute has not been set"
         exit 1
     fi
 
-    mkdir -p $out/share/hoogle/doc
-    export HOOGLE_DOC_PATH=$out/share/hoogle/doc
-
-    cd $out/share/hoogle
+    mkdir -p $out/share/doc/hoogle
 
     function import_dbs() {
         find $1 -name '*.txt' | while read f; do
           newname=$(basename "$f" | tr '[:upper:]' '[:lower:]')
           if [[ -f $f && ! -f ./$newname ]]; then
-            cp -p $f ./$newname
+            cp -p $f "./$newname"
             hoogle convert -d "$(dirname $f)" "./$newname"
           fi
         done
     }
 
-    for i in $docPackages; do
-        findInputs $i docPackages propagated-native-build-inputs
-        findInputs $i docPackages propagated-build-inputs
+    echo importing builtin packages
+    for docdir in ${ghc}/share/doc/ghc*/html/libraries/*; do
+      if [[ -d $docdir ]]; then
+        import_dbs $docdir
+        ln -sfn $docdir $out/share/doc/hoogle
+      fi
     done
 
+    echo importing other packages
     for i in $docPackages; do
       if [[ ! $i == $out ]]; then
         for docdir in $i/share/doc/*-ghc-*/* $i/share/doc/*; do
+          name=`basename $docdir`
+          docdir=$docdir/html
           if [[ -d $docdir ]]; then
             import_dbs $docdir
-            ln -sf $docdir $out/share/hoogle/doc
+            ln -sfn $docdir $out/share/doc/hoogle/$name
           fi
         done
       fi
     done
 
-    import_dbs ${ghc}/share/doc/ghc*/html/libraries
-    ln -sf ${ghc}/share/doc/ghc*/html/libraries/* $out/share/hoogle/doc
-
+    echo building hoogle database
+    # FIXME: rehoo is marked as depricated on Hackage
     chmod 644 *.hoo *.txt
     rehoo -j4 -c64 .
 
-    rm -fr downloads *.dep *.txt
-    mv default.hoo x || exit 0
-    rm -f *.hoo
-    mv x default.hoo || exit 1
+    mv default.hoo .x
+    rm -fr downloads *.dep *.txt *.hoo
+    mv .x $out/share/doc/hoogle/default.hoo
 
-    if [ ! -f default.hoo ]; then
-        echo "Unable to build the default Hoogle database"
-        exit 1
-    fi
+    echo building haddock index
+    # adapted from GHC's gen_contents_index
+    cd $out/share/doc/hoogle
 
+    args=
+    for hdfile in `ls -1 */*.haddock | grep -v '/ghc\.haddock' | sort`
+    do
+        name_version=`echo "$hdfile" | sed 's#/.*##'`
+        args="$args --read-interface=$name_version,$hdfile"
+    done
+
+    ${ghc}/bin/haddock --gen-index --gen-contents -o . \
+         -t "Haskell Hierarchical Libraries" \
+         -p ${ghc}/share/doc/ghc*/html/libraries/prologue.txt \
+         $args
+
+    echo finishing up
     mkdir -p $out/bin
     substitute ${wrapper} $out/bin/hoogle \
         --subst-var out --subst-var-by shell ${stdenv.shell} \

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -98,6 +98,10 @@ stdenv.mkDerivation {
     chmod +x $out/bin/hoogle
   '';
 
+  passthru = {
+    isHaskellLibrary = false; # for the filter in ./with-packages-wrapper.nix
+  };
+
   meta = {
     description = "A local Hoogle database";
     platforms = ghc.meta.platforms;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -82,11 +82,6 @@ rec {
 
   triggerRebuild = drv: i: overrideCabal drv (drv: { postUnpack = ": trigger rebuild ${toString i}"; });
 
-  withHoogle = haskellEnv: with haskellEnv.haskellPackages;
-    import ./hoogle.nix {
-      inherit (pkgs) stdenv;
-      inherit (pkgs.stdenv) lib;
-      inherit hoogle rehoo ghc;
-      packages = haskellEnv.paths;
-    };
+  #FIXME: throw this away sometime in the future. added 2015-08-18
+  withHoogle = throw "withHoogle is no longer supported, use ghcWithHoogle instead";
 }

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -85,6 +85,7 @@ rec {
   withHoogle = haskellEnv: with haskellEnv.haskellPackages;
     import ./hoogle.nix {
       inherit (pkgs) stdenv;
+      inherit (pkgs.stdenv) lib;
       inherit hoogle rehoo ghc;
       packages = haskellEnv.paths;
     };


### PR DESCRIPTION
With this, using `ghcWithHoogle` instead of `ghcWithPackages` does everything you'd expect it to do, and generates documentation indexes for all the packages.

When combined with the first patch from #9326 directing a browser of your choice to `/run/current-system/sw/share/doc/hoogle/index.html` brings up a module index (like https://downloads.haskell.org/~ghc/latest/docs/html/libraries/index.html) for all installed packages.

Also try adding this to `~/.ghc/ghci.conf`:

```
:def hoogle \s -> return $ ":! hoogle search -cl --count=15 \"" ++ s ++ "\""
:def doc \s -> return $ ":! hoogle search -cl --info \"" ++ s ++ "\""
```

and then in `ghci`:

```
:hoogle a -> a
:doc a -> a
```

or maybe run

```
hoogle server -p 8080
```

and then navigate to `http://localhost:8080/`
