### PR TITLE
darwin support for password-store

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -2,8 +2,7 @@
 , coreutils, gnused, getopt, pwgen, git, tree, gnupg, which
 , makeWrapper
 
-, xclip ? null, xdotool ? null, dmenu ? null
-, x11Support ? true
+, x11Support ? if stdenv.isDarwin then false else true, xclip, xdotool, dmenu
 }:
 
 assert x11Support -> xclip != null


### PR DESCRIPTION
> This is my first change of a nix pkg and I barely know what I'm doing :wink: 

Wanted to install `password-store` but couldn't get it listed as available without these changes.
