### PR TITLE
ecryptfs

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -251,9 +251,9 @@ let
           ${optionalString (!(config.security.pam.enableEcryptfs || cfg.pamMount)) "auth required pam_deny.so"}
 
           # Password management.
+          password requisite pam_unix.so nullok sha512
           ${optionalString config.security.pam.enableEcryptfs
               "password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
-          password requisite pam_unix.so nullok sha512
           ${optionalString cfg.pamMount
               "password optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
           ${optionalString config.users.ldap.enable

--- a/pkgs/tools/security/ecryptfs/default.nix
+++ b/pkgs/tools/security/ecryptfs/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, perl, utillinux, keyutils, nss, nspr, python, pam
-, intltool, makeWrapper, coreutils, bash, gettext, cryptsetup, lvm2, rsync, which }:
+, intltool, makeWrapper, coreutils, bash, gettext, cryptsetup, lvm2, rsync, which, lsof }:
 
 stdenv.mkDerivation rec {
   name = "ecryptfs-${version}";
-  version = "106";
+  version = "108";
 
   src = fetchurl {
     url = "http://launchpad.net/ecryptfs/trunk/${version}/+download/ecryptfs-utils_${version}.orig.tar.gz";
-    sha256 = "1d5nlzcbl8ch639zi3lq6d14gkk4964j6dqhfs87i67867fhlghp";
+    sha256 = "1pfpzc907m4qi5h2rxmkqq072c6g22pik2rilj4bl4qishd8p0sj";
   };
 
   #TODO: replace wrapperDir below with from <nixos> config.security.wrapperDir;
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
         --prefix PATH ":" "${rsync}/bin" \
         --prefix PATH ":" "${keyutils}/bin" \
         --prefix PATH ":" "${which}/bin" \
+        --prefix PATH ":" "${lsof}/bin" \
         --prefix PATH ":" "$out/bin"
     done
   '';


### PR DESCRIPTION
- upgrade 106 -> 108
- fix passphrase rewrapper (password changing should now work fine) as
  discussed on https://bugs.launchpad.net/ecryptfs/+bug/1486470
- add lsof dependency so ecryptfs-migrate-home should work out of the
  box
