### PR TITLE
pass: Fix for Darwin

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -3,7 +3,7 @@
 , makeWrapper
 
 , xclip ? null, xdotool ? null, dmenu ? null
-, x11Support ? true
+, x11Support ? !stdenv.isDarwin
 }:
 
 assert x11Support -> xclip != null


### PR DESCRIPTION
On Darwin `pass` fails to install:

```
error: Package ‘xdotool-2.20110530.1’ in ‘/Users/.../nixpkgs/pkgs/tools/X11/xdotool/default.nix:19’ is not supported on ‘x86_64-darwin’, refusing to evaluate.
```

This pull request fixes this.
