### PR TITLE
Use shared libsass for hsass

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -977,4 +977,12 @@ self: super: {
   # https://github.com/bos/configurator/issues/22
   configurator = dontCheck super.configurator;
 
+  # Use global libsass library in order to use hsass in the repl
+  hlibsass = overrideCabal super.hlibsass (drv: {
+    configureFlags = drv.configureFlags or [] ++ ["-fexternalLibsass"];
+    extraLibraries = drv.extraLibraries or [] ++ [ pkgs.libsass ];
+  });
+
+  # Use global libsass library in order to use hsass in the repl
+  hsass = hsass.overrideScope (self: super: { hlibsass = self.hlibsass; });
 }


### PR DESCRIPTION
So, this doesn't actually work at the moment– I'm trying to understand why. Even with this modification, using my nixpkgs fork with `nix-shell -v -I ~/nixpkgs --command "cabal configure"` on a package that depends on hsass doesn't seem to be using the flag like I'd like:

```
Configuring hlibsass-0.1.4.0...
Flags chosen: sharedlibsass=False, externallibsass=False
Dependency base >=4.7 && <5: using base-4.8.0.0
Dependency hlibsass -any: using hlibsass-0.1.4.0
```
