### PR TITLE
oraclejdk8jce oraclejre8jce: add JCE versions JDK8 & JRE8

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -133,7 +133,8 @@ let result = stdenv.mkDerivation rec {
 
     if test -n "${jce}"; then
       unzip ${jce}
-      cp -v UnlimitedJCEPolicy*/*.jar $jrePath/lib/security
+      mkdir -p $jrePath/lib/security
+      cp -v UnlimitedJCEPolicy*/*.jar $jrePath/lib/security/
     fi
 
     rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/jli

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4076,7 +4076,9 @@ let
 
   oraclejdk7psu = pkgs.oraclejdk7psu_distro true false;
 
-  oraclejdk8 = pkgs.oraclejdk8distro true false;
+  oraclejdk8 = pkgs.oraclejdk8distro true false false;
+
+  oraclejdk8jce = pkgs.oraclejdk8distro true true false;
 
   oraclejre = lowPrio (pkgs.jdkdistro false false);
 
@@ -4084,7 +4086,9 @@ let
 
   oraclejre7psu = lowPrio (pkgs.oraclejdk7psu_distro false false);
 
-  oraclejre8 = lowPrio (pkgs.oraclejdk8distro false false);
+  oraclejre8 = lowPrio (pkgs.oraclejdk8distro false false false);
+
+  oraclejre8jce = lowPrio (pkgs.oraclejdk8distro false true false);
 
   jrePlugin = lowPrio (pkgs.jdkdistro false true);
 
@@ -4107,10 +4111,10 @@ let
     (if pluginSupport then appendToName "with-plugin" else x: x)
       (callPackage ../development/compilers/oraclejdk/jdk7psu-linux.nix { inherit installjdk; });
 
-  oraclejdk8distro = installjdk: pluginSupport:
+  oraclejdk8distro = installjdk: installjce: pluginSupport:
     assert supportsJDK;
     (if pluginSupport then appendToName "with-plugin" else x: x)
-      (callPackage ../development/compilers/oraclejdk/jdk8-linux.nix { inherit installjdk; });
+      (callPackage ../development/compilers/oraclejdk/jdk8-linux.nix { inherit installjdk installjce; });
 
   jikes = callPackage ../development/compilers/jikes { };
 


### PR DESCRIPTION
Currently not JCE installed version of Oracle JDK8 or JRE8 are provided. This change addresses that by added new packages named:
- `oraclejdk8jce`: this is the JCE installed version of oraclejdk8
- `oraclejre8jce`: this is the JCE installed version of oraclejre8

This also fixes the `installjce` logic where in JDK/JRE8 the name of the unlimited JCE policy directory added a suffix of JDK8 by adding wildcard.

I tested this off of commit `1357692` with this patch applied checking the JARs in `jre/lib/security` subdir are different in the non-JCE version with the JCE installed version like so:

``` bash
nix-env -f . -iA oraclejdk8
declare jhome=$(dirname $(readlink -f $(which java)))/..
shasum ${jhome}/jre/lib/security/*.jar

# check that these SHA sums are different to following:

nix-env -f . -iA oraclejdk8jce
declare jhome=$(dirname $(readlink -f $(which java)))/..
shasum ${jhome}/jre/lib/security/*.jar
```

Cheers.
