### PR TITLE
iojs: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/web/iojs/default.nix
+++ b/pkgs/development/web/iojs/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, python, utillinux, openssl_1_0_2, http-parser, zlib, libuv }:
 
 let
-  version = "3.0.0";
+  version = "3.1.0";
   inherit (stdenv.lib) optional maintainers licenses platforms;
 in stdenv.mkDerivation {
   name = "iojs-${version}";
 
   src = fetchurl {
     url = "https://iojs.org/dist/v${version}/iojs-v${version}.tar.gz";
-    sha256 = "0maxxmr6y7z3y3r88nhcnfzmpvbhs5p8knyz886bh2shgzd6nzqf";
+    sha256 = "15qh5pscg3588hyf4yfhma34gjkg87v5i4xzxj804g6m52m6y727";
   };
 
   prePatch = ''


### PR DESCRIPTION
Built and tested locally.
