### PR TITLE
edbrowse: 3.5.2 -> 3.5.4.1

### DIFF
--- a/pkgs/applications/editors/edbrowse/default.nix
+++ b/pkgs/applications/editors/edbrowse/default.nix
@@ -1,17 +1,24 @@
 { stdenv, fetchurl, spidermonkey_24, unzip, curl, pcre, readline, openssl }:
 stdenv.mkDerivation rec {
-  name = "edbrowse-3.5.2";
-  buildInputs = [ unzip curl pcre readline openssl spidermonkey_24 ];
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${spidermonkey_24}/include/mozjs-24"
-    '';
-  installPhase = "installBin src/edbrowse";
+  name = "edbrowse-${version}";
+  version = "3.5.4.1";
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ curl pcre readline openssl spidermonkey_24 ];
+
+  patchPhase = ''
+    substituteInPlace src/ebjs.c --replace \"edbrowse-js\" \"$out/bin/edbrowse-js\"
+  '';
+
+  NIX_CFLAGS_COMPILE = "-I${spidermonkey_24}/include/mozjs-24";
+  makeFlags = "-C src prefix=$(out)";
+
   src = fetchurl {
-    url = "http://the-brannons.com/edbrowse/${name}.zip";
-    sha256 = "5f1ac927d126b8c8fd411231cffa9eba5405013e64994e55e1864b2f85d52714";
+    url = "http://edbrowse.org/${name}.zip";
+    sha256 = "0fpzaalwvgwbns7yxq4a4i6hpdljmcjfyvx19r1dlb3vdfw0vx5l";
   };
   meta = {
-    description = "Edbrowse, a Command Line Editor Browser";
+    description = "Command Line Editor Browser";
     longDescription = ''
       Edbrowse is a combination editor, browser, and mail client that is 100% text based.
       The interface is similar to /bin/ed, though there are many more features, such as editing multiple files simultaneously, and rendering html.
@@ -20,7 +27,7 @@ stdenv.mkDerivation rec {
       edbrowse can also tap into databases through odbc. It was primarily written by Karl Dahlke.
       '';
     license = stdenv.lib.licenses.gpl1Plus;
-    homepage = http://the-brannons.com/edbrowse/;
+    homepage = http://edbrowse.org/;
     maintainers = [ stdenv.lib.maintainers.schmitthenner ];
   };
 }


### PR DESCRIPTION
This update also fixes javascript support by installing the edbrowse-js binary and replacing the path in the `exec("edbrowse-js")` call with the nix store path.
