### PR TITLE
dropbox: 3.8.5 -> 3.6.9 [nixos-stable]

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -18,11 +18,11 @@
 # them with our own.
 
 let
-  version = "3.8.5";
+  version = "3.6.9";
   sha256 =
     {
-      "x86_64-linux" = "1r0wz2fsx2piasl04qsgwbl88bi0ajr0dm2swbslxwkf789vk18y";
-      "i686-linux" = "1dvfgp9dg3frhwmchwa6fyws4im9vgicchfsv0zzflvc7rm9fcig";
+      "x86_64-linux" = "1i260mi40siwcx9b2sj4zwszxmj1l88mpmyqncsfa72k02jz22j3";
+      "i686-linux" = "0qqc8qbfaighbhjq9y22ka6n6apl8b6cr80a9rkpk2qsk99k8h1z";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
dropbox as of 3.8.4 depends on qt 5.4, while nixos-14.12 is on qt 5.3
https://www.dropboxforum.com/hc/en-us/community/posts/204541685-Release-Candidate-3-8-4

This reverts commit f961f3d7939805270d3983769198f7f20834b884.
fixes #9338
