### PR TITLE
haskell-purescript: Disable tests.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -680,6 +680,10 @@ self: super: {
     '';
   });
 
+  # Tests attempt to use NPM to install from the network into
+  # /homeless-shelter. Disabled.
+  purescript = dontCheck super.purescript;
+
   # Broken by GLUT update.
   Monadius = markBroken super.Monadius;
 


### PR DESCRIPTION
Tests need network + /homeless-shelter.

Fixes https://github.com/NixOS/nixpkgs/pull/9167
