### PR TITLE
bundler_HEAD: correct sha mismatch

### DIFF
--- a/pkgs/development/interpreters/ruby/bundler-head.nix
+++ b/pkgs/development/interpreters/ruby/bundler-head.nix
@@ -5,7 +5,7 @@ buildRubyGem {
   src = fetchgit {
     url = "https://github.com/bundler/bundler.git";
     rev = "a2343c9eabf5403d8ffcbca4dea33d18a60fc157";
-    sha256 = "1vzm21fc37w89psxfk2fzi64zyb3gyhzr9smd6jk2r2kvgp6d38b";
+    sha256 = "1p7kzhmicfljy9n7nq3qh6lvrsckiq76ddypf6s55gfh1l98z4k9";
     leaveDotGit = true;
   };
   dontPatchShebangs = true;


### PR DESCRIPTION
While trying to install bundix on osx/darwin I ran into a sha mismatch: https://gist.github.com/miah/e2ee1d82096a2e8b5e9c

Thanks to help from @bendlas on irc, I think this may be the resolution.

```
nixpkgs/pkgs/build-support/fetchgit$: ./nix-prefetch-git --url https://github.com/bundler/bundler.git --rev a2343c9eabf5403d8ffcbca4dea33d18a60fc157
...
* [new tag]         v1.9.9     -> v1.9.9
Switched to a new branch 'fetchgit'
git revision is a2343c9eabf5403d8ffcbca4dea33d18a60fc157
git human-readable version is v1.7.9-390-ga2343c9
Commit date is 2015-01-11 17:25:27 -0800
removing `.git'...
hash is f2ad04be4fe01e738ceab0cd03efb73a4a141fa07de02b42304b1f91dde7ca04
path is /nix/store/yg9ygrrf644g5sf9yk7v3n05j05pqnqh-git-export
f2ad04be4fe01e738ceab0cd03efb73a4a141fa07de02b42304b1f91dde7ca04
```
