### PR TITLE
also generate startAt timers for systemd user units

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -713,6 +713,14 @@ in
         })
         (filterAttrs (name: service: service.startAt != "") cfg.services);
 
+    # Generate timer units for all services that have a ‘startAt’ value.
+    systemd.user.timers =
+      mapAttrs (name: service:
+        { wantedBy = [ "timers.target" ];
+          timerConfig.OnCalendar = service.startAt;
+        })
+        (filterAttrs (name: service: service.startAt != "") cfg.user.services);
+
     systemd.sockets.systemd-journal-gatewayd.wantedBy =
       optional config.services.journald.enableHttpGateway "sockets.target";
 


### PR DESCRIPTION
I tried to share the code with a let binding, but it's not allowed in this position. tested locally.

fixes #9382 
