### PR TITLE
zerotierone: 1.0.2 -> 1.0.4 and fix for hardcoded path

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, openssl, lzo, zlib, gcc }:
+{ stdenv, fetchurl, openssl, lzo, zlib, gcc, iproute }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.0.2";
+  version = "1.0.4";
   name = "zerotierone";
 
   src = fetchurl {
     url = "https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz";
-    sha256 = "002ay4f6l9h79j1708klwjvinsv6asv24a0hql85jq27587sv6mq";
+    sha256 = "1klnsjajlas71flbf6w2q3iqhhqrmzqpd2g4qw9my66l7kcsbxfd";
   };
 
   preConfigure = ''
@@ -16,12 +16,16 @@ stdenv.mkDerivation rec {
           --replace 'CC=$(shell which clang gcc cc 2>/dev/null | head -n 1)' "CC=${gcc}/bin/gcc";
       substituteInPlace ./make-linux.mk \
           --replace 'CXX=$(shell which clang++ g++ c++ 2>/dev/null | head -n 1)' "CC=${gcc}/bin/g++";
+      substituteInPlace ./osdep/LinuxEthernetTap.cpp \
+          --replace '/sbin/ip' "${iproute}/bin/ip"
   '';
 
-  buildInputs = [ openssl lzo zlib gcc ];
+  buildInputs = [ openssl lzo zlib gcc iproute ];
 
   installPhase = ''
     installBin zerotier-one
+    ln -s $out/bin/zerotier-one $out/bin/zerotier-idtool
+    ln -s $out/bin/zerotier-one $out/bin/zerotier-cli
   '';
 
   meta = {


### PR DESCRIPTION
Zerotier-one has a hardcoded path for /sbin/ip that it uses to set the IP address after connecting. This should fix that. Also, I added symlinks for the two helper scripts.

This is my first PR for nixpkgs, so let me know if I'm missing anything important.

cc @sjmackenzie 
