### PR TITLE
containers: add interfaces config option.

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -120,6 +120,15 @@ in
               '';
             };
 
+            interfaces = mkOption {
+              type = types.listOf types.string;
+              default = null;
+              example = [ "eth1" "eth2" ];
+              description = ''
+                The list of interfaces to be moved into the container.
+              '';
+            };
+
             autoStart = mkOption {
               type = types.bool;
               default = false;
@@ -217,6 +226,10 @@ in
             if [ "$PRIVATE_NETWORK" = 1 ]; then
               extraFlags+=" --network-veth"
             fi
+
+            for iface in $INTERFACES; do
+              extraFlags+=" --network-interface=$iface"
+            done
 
             for iface in $MACVLANS; do
               extraFlags+=" --network-macvlan=$iface"
@@ -331,6 +344,9 @@ in
                 LOCAL_ADDRESS=${cfg.localAddress}
               ''}
             ''}
+           ${optionalString (cfg.interfaces != null) ''
+             INTERFACES="${toString cfg.interfaces}"
+           ''}
            ${optionalString cfg.autoStart ''
              AUTO_START=1
            ''}


### PR DESCRIPTION
It uses systemd-nspawn's --network-interface to move
existing interfaces into the container.
