### PR TITLE
{lib}mediainfo{-gui}: 0.7.75 -> 0.7.76

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.75";
+  version = "0.7.76";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1xdsy5z7x7bd251m26h5hcwcmgl6gklxj6h9q025mlnfmcs7pbdy";
+    sha256 = "14vy2a9bjjwxyk8zh0ysin8fb1lj9yz17yd82vxrp1zvxsgyg5ck";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];
 
   sourceRoot = "./MediaInfo/Project/GNU/GUI/";
 
-  preConfigure = "sh autogen";
+  preConfigure = "sh autogen.sh";
 
   meta = {
     description = "Supplies technical and tag information about a video or audio file (GUI version)";

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.75";
+  version = "0.7.76";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1xdsy5z7x7bd251m26h5hcwcmgl6gklxj6h9q025mlnfmcs7pbdy";
+    sha256 = "14vy2a9bjjwxyk8zh0ysin8fb1lj9yz17yd82vxrp1zvxsgyg5ck";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "./MediaInfo/Project/GNU/CLI/";
 
   configureFlags = [ "--with-libmediainfo=${libmediainfo}" ];
-  preConfigure = "sh autogen";
+  preConfigure = "sh autogen.sh";
 
   meta = {
     description = "Supplies technical and tag information about a video or audio file";

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.75";
+  version = "0.7.76";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "1im39kd595ia6g41qvwgvszn1s10nwa3q5r2lj2g5fm4kgi0dwhr";
+    sha256 = "088hxj3x12ww8zym3g6izz1w9m6wxgdy7hc2m089cd4sv9dlccnq";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "./MediaInfoLib/Project/GNU/Library/";
 
   configureFlags = [ "--enable-shared" ];
-  preConfigure = "sh autogen";
+  preConfigure = "sh autogen.sh";
 
   postInstall = ''
     install -vD -m 644 libmediainfo.pc "$out/lib/pkgconfig/libmediainfo.pc"


### PR DESCRIPTION
From the changelog:

```
Version 0.7.76, 2015-08-06

+ XML output: line breaks and indents in between attributes for readability
+ Trace feature: XML trace update, only if compiled with trace feature
+ Amazon S3 support (REST API v2), CLI/DLL only and if compiled with
  libcurl support
+ FFV1: improved slice analysis (currently activated only with trace
  feature and for 1st frame)
x MXF: optimization of the parsing, reading a lot less data (e.g. can be
  reduced from 1 GB to 10 MB with some UHD files)
x MXF: wrong frame count with files not having the video stream as the
  first stream
x Dolby E in MPEG-TS: "SMPTE ST 302" information was accidentally removed
x MPEG-TS: avoid filling delay from file name, not applicable on MPEG-TS
x MXF: better handling of huge padding blocks, better handling of
  descriptors without link to a TrackID
x IMX: streams claiming that they are IMX are actually pure MPEG Video,
  probing both IMX and MPEG Video

```
