### PR TITLE
all-packages: Apply packageOverrides package-by-package

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -64,7 +64,7 @@ let
       # { /* the config */ } and
       # { pkgs, ... } : { /* the config */ }
       if builtins.isFunction configExpr
-        then configExpr { inherit pkgs; }
+        then configExpr { pkgs = pkgsFinal; }
         else configExpr;
 
   # Allow setting the platform in the config file. Otherwise, let's use a reasonable default (pc)
@@ -83,51 +83,38 @@ let
   platform = if platform_ != null then platform_
     else config.platform or platformAuto;
 
-  # Helper functions that are exported through `pkgs'.
-  helperFunctions =
-    stdenvAdapters //
-    (import ../build-support/trivial-builders.nix { inherit lib; inherit (pkgs) stdenv; inherit (pkgs.xorg) lndir; });
+  # The complete set of packages, after applying the overrides
+  pkgsFinal = lib.fix' (lib.extends configOverrides (lib.extends stdenvOverrides pkgsFun));
 
-  stdenvAdapters =
-    import ../stdenv/adapters.nix pkgs;
+  stdenvOverrides =
+    # We don't want stdenv overrides in the case of cross-building,
+    # or otherwise the basic overrided packages will not be built
+    # with the crossStdenv adapter.
+    if crossSystem == null
+      then self: super: lib.optionalAttrs (super.stdenv ? overrides) (super.stdenv.overrides super)
+      else self: super: {};
 
-
-  # Allow packages to be overriden globally via the `packageOverrides'
+  # Packages can be overriden globally via the `packageOverrides'
   # configuration option, which must be a function that takes `pkgs'
   # as an argument and returns a set of new or overriden packages.
-  # The `packageOverrides' function is called with the *original*
-  # (un-overriden) set of packages, allowing packageOverrides
-  # attributes to refer to the original attributes (e.g. "foo =
-  # ... pkgs.foo ...").
-  pkgs = applyGlobalOverrides (config.packageOverrides or (pkgs: {}));
-
-  mkOverrides = pkgsOrig: overrides: overrides //
-        (lib.optionalAttrs (pkgsOrig.stdenv ? overrides && crossSystem == null) (pkgsOrig.stdenv.overrides pkgsOrig));
-
-  # Return the complete set of packages, after applying the overrides
-  # returned by the `overrider' function (see above).  Warning: this
-  # function is very expensive!
-  applyGlobalOverrides = overrider:
-    let
-      # Call the overrider function.  We don't want stdenv overrides
-      # in the case of cross-building, or otherwise the basic
-      # overrided packages will not be built with the crossStdenv
-      # adapter.
-      overrides = mkOverrides pkgsOrig (overrider pkgsOrig);
-
-      # The un-overriden packages, passed to `overrider'.
-      pkgsOrig = pkgsFun pkgs {};
-
-      # The overriden, final packages.
-      pkgs = pkgsFun pkgs overrides;
-    in pkgs;
-
+  # The recommended usage follows this snippet:
+  #   packageOverrides = super: let self = super.pkgs in ...
+  # `super' is the *original* (un-overriden) set of packages,
+  # while `self' refers to the final (overriden) set of packages.
+  configOverrides =
+      if config ? packageOverrides && bootStdenv == null # don't apply config overrides in stdenv boot
+        then self: config.packageOverrides
+        else self: super: {};
 
   # The package compositions.  Yes, this isn't properly indented.
-  pkgsFun = pkgs: overrides:
-    with helperFunctions;
-    let defaultScope = pkgs // pkgs.xorg; self = self_ // overrides;
-    self_ = with self; helperFunctions // {
+  pkgsFun = pkgs:
+    let defaultScope = pkgs // pkgs.xorg;
+        helperFunctions = pkgs_.stdenvAdapters // pkgs_.trivial-builders;
+        pkgsRet = helperFunctions // pkgs_;
+        pkgs_ = with pkgs; {
+  # Helper functions that are exported through `pkgs'.
+  trivial-builders = import ../build-support/trivial-builders.nix { inherit lib; inherit stdenv; inherit (xorg) lndir; };
+  stdenvAdapters = import ../stdenv/adapters.nix pkgs;
 
   # Make some arguments passed to all-packages.nix available
   inherit system platform;
@@ -157,11 +144,7 @@ let
   #
   # The result is `pkgs' where all the derivations depending on `foo'
   # will use the new version.
-  overridePackages = f:
-    let
-      newpkgs = pkgsFun newpkgs overrides;
-      overrides = mkOverrides pkgs (f newpkgs pkgs);
-    in newpkgs;
+  overridePackages = f: lib.fix' (lib.extends f pkgs.__unfix__);
 
   # Override system. This is useful to build i686 packages on x86_64-linux.
   forceSystem = system: kernel: (import ./all-packages.nix) {
@@ -183,7 +166,7 @@ let
 
 
   ### Helper functions.
-  inherit lib config stdenvAdapters;
+  inherit lib config;
 
   inherit (lib) lowPrio hiPrio appendToName makeOverridable;
   inherit (misc) versionedDerivation;
@@ -214,7 +197,8 @@ let
     allPackages = args: import ./all-packages.nix ({ inherit config system; } // args);
   };
 
-  defaultStdenv = allStdenvs.stdenv // { inherit platform; };
+  # We use pkgs_ because accessing pkgs would lead to an infinite recursion in stdenvOverrides
+  defaultStdenv = pkgs_.allStdenvs.stdenv // { inherit platform; };
 
   stdenvCross = lowPrio (makeStdenvCross defaultStdenv crossSystem binutilsCross gccCrossStageFinal);
 
@@ -234,7 +218,7 @@ let
             };
           }
       else
-        defaultStdenv;
+        pkgs_.defaultStdenv;
 
   forceNativeDrv = drv : if crossSystem == null then drv else
     (drv // { crossDrv = drv.nativeDrv; });
@@ -5927,8 +5911,8 @@ let
   gotty = goPackages.gotty.bin // { outputs = [ "bin" ]; };
 
   gradleGen = callPackage ../development/tools/build-managers/gradle { };
-  gradle = self.gradleGen.gradleLatest;
-  gradle25 = self.gradleGen.gradle25;
+  gradle = gradleGen.gradleLatest;
+  gradle25 = gradleGen.gradle25;
 
   gperf = callPackage ../development/tools/misc/gperf { };
 
@@ -11761,7 +11745,7 @@ let
       AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit
       ImageCaptureCore GSS ImageIO;
   });
-  emacs24Macport = self.emacs24Macport_24_5;
+  emacs24Macport = emacs24Macport_24_5;
 
   emacs25pre = lowPrio (callPackage ../applications/editors/emacs-25 {
     # use override to enable additional features
@@ -16103,12 +16087,13 @@ let
 
   mg = callPackage ../applications/editors/mg { };
 
-}; # self_ =
+};
+# end pkgs_ =
 
 
   ### Deprecated aliases - for backward compatibility
 
-aliases = with self; rec {
+aliases = with pkgs; {
   accounts-qt = qt5.accounts-qt;  # added 2015-12-19
   adobeReader = adobe-reader;
   arduino_core = arduino-core;  # added 2015-02-04
@@ -16195,4 +16180,7 @@ tweakAlias = _n: alias: with lib;
     removeAttrs alias ["recurseForDerivations"]
   else alias;
 
-in lib.mapAttrs tweakAlias aliases // self; in pkgs
+in lib.mapAttrs tweakAlias aliases // pkgsRet;
+# end pkgsFun
+
+in pkgsFinal


### PR DESCRIPTION
This commit rewrites the package recursion so that, rather than a package expression seeing all of the un-overriden packages, it sees all of the overriden packages except for the package that is currently being evaluated.

It also implements recursive merging, but this isn't useful yet because the meta-package has to use 'with pkgs.x' instead of rec.

Also note that this is not a mass-rebuild (hashes are identical).
