### PR TITLE
Sane config: Fix config generation to work with the hplip backend in NixOS.

### DIFF
--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 let installSanePath = path: ''
       if test -e "${path}/lib/sane"; then
-        find "${path}/lib/sane" -not -type d -maxdepth 1 | while read backend; do
+        find "${path}/lib/sane" -maxdepth 1 -not -type d | while read backend; do
           ln -s $backend $out/lib/sane/$(basename $backend)
         done
       fi
 
       if test -e "${path}/etc/sane.d"; then
-        find "${path}/etc/sane.d" -not -type d -maxdepth 1 | while read conf; do
+        find "${path}/etc/sane.d" -maxdepth 1 -not -type d | while read conf; do
           if test $(basename $conf) = "dll.conf"; then
             cat $conf >> $out/etc/sane.d/dll.conf
           else
@@ -21,7 +21,7 @@ let installSanePath = path: ''
       fi
 
       if test -e "${path}/etc/sane.d/dll.d"; then
-        find "${path}/etc/sane.d/dll.d" -not -type d -maxdepth 1 | while read conf; do
+        find "${path}/etc/sane.d/dll.d" -maxdepth 1 -not -type d | while read conf; do
           ln -s $conf $out/etc/sane.d/dll.d/$(basename $conf)
         done
       fi

--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -4,17 +4,27 @@
 
 with stdenv.lib;
 let installSanePath = path: ''
-      find "${path}/lib/sane" -not -type d -maxdepth 1 | while read backend; do
-        ln -s $backend $out/lib/sane/$(basename $backend)
-      done
+      if test -e "${path}/lib/sane"; then
+        find "${path}/lib/sane" -not -type d -maxdepth 1 | while read backend; do
+          ln -s $backend $out/lib/sane/$(basename $backend)
+        done
+      fi
 
-      find "${path}/etc/sane.d" -not -type d -maxdepth 1 | while read conf; do
-        ln -s $conf $out/etc/sane.d/$(basename $conf)
-      done
+      if test -e "${path}/etc/sane.d"; then
+        find "${path}/etc/sane.d" -not -type d -maxdepth 1 | while read conf; do
+          if test $(basename $conf) = "dll.conf"; then
+            cat $conf >> $out/etc/sane.d/dll.conf
+          else
+            ln -s $conf $out/etc/sane.d/$(basename $conf)
+          fi
+        done
+      fi
 
-      find "${path}/etc/sane.d/dll.d" -not -type d -maxdepth 1 | while read conf; do
-        ln -s $conf $out/etc/sane.d/dll.d/$(basename $conf)
-      done
+      if test -e "${path}/etc/sane.d/dll.d"; then
+        find "${path}/etc/sane.d/dll.d" -not -type d -maxdepth 1 | while read conf; do
+          ln -s $conf $out/etc/sane.d/dll.d/$(basename $conf)
+        done
+      fi
     '';
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
cc @ttuegel ,

The generation of the sane-config failed because we attempted to link a second time dll.conf, which I presumed should be the result of the concatenation of the backend.

Also, the generation failed, because the hplip backend does not have a `/etc/sane.d/dll.d` directory, and the find command failed and cause the job to exit.

The second patch removes a `find` command warning about the fact the `-maxdepth` applies globally.

This configuration works well for me, with the `hplip` backend.
