### PR TITLE
plan9port: 20140306 -> git-2015-06-29

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -1,23 +1,34 @@
 source $stdenv/setup
 
-tar xvfz $src
-
-cd plan9port
-
-echo CFLAGS=\"-I${fontconfig}/include -I${libXt}/include\" > LOCAL.config
-echo X11=\"${libXt}/include\" >> LOCAL.config
-
-for p in $patches; do
-  echo "applying patch $p"
-  patch -p1 < $p
-done
-
 export PLAN9=$out/plan9
-mkdir -p $PLAN9
 
-for f in `grep -l -r /usr/local/plan9`; do
-  sed "s,/usr/local/plan9,${PLAN9},g" -i $f
-done
+configurePhase()
+{
+    echo CFLAGS=\"-I${fontconfig}/include -I${libXt}/include\" > LOCAL.config
+    echo X11=\"${libXt}/include\" >> LOCAL.config
 
-./INSTALL -r $PLAN9
-cp -R * $PLAN9
+    for f in `grep -l -r /usr/local/plan9`; do
+        sed "s,/usr/local/plan9,${PLAN9},g" -i $f
+    done
+}
+
+buildPhase()
+{
+    mkdir -p $PLAN9
+    ./INSTALL -b $PLAN9
+}
+
+installPhase()
+{
+    ./INSTALL -c -r $PLAN9
+    # Copy sources
+    cp -R * $PLAN9
+
+    # Copy the `9' utility. This way you can use
+    # $ 9 awk
+    # to use the plan 9 awk
+    mkdir $out/bin
+    ln -s $PLAN9/bin/9 $out/bin
+}
+
+genericBuild

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -1,10 +1,17 @@
-{stdenv, fetchurl, which, libX11, libXt, fontconfig
+{stdenv, fetchgit, which, libX11, libXt, fontconfig
 , xproto ? null
 , xextproto ? null
 , libXext ? null }:
 
 stdenv.mkDerivation rec {
-  name = "plan9port-20140306";
+  name = "plan9port-2015-06-29";
+
+  src = fetchgit {
+    # Latest, same as on github, google code is old
+    url = "https://plan9port.googlesource.com/plan9";
+    rev = "71de840";
+    sha256 = "1ffece7c0a5775a8bde6a0618c7ae3da4048449008a19e6623e8e5553f133b4c";
+  };
 
   patches = [ ./fontsrv.patch ];
   postPatch =
@@ -15,13 +22,6 @@ stdenv.mkDerivation rec {
 
   builder = ./builder.sh;
 
-  src = fetchurl {
-    url = "https://plan9port.googlecode.com/files/${name}.tgz";
-    # Google code is much faster than swtch
-    # url = "http://swtch.com/plan9port/${name}.tgz";
-    sha256 = "1sza12j3db7i54r3pzli8wmby6aiyzmyfj8w0nidmawkwv6jdf6b";
-  };
-
   NIX_LDFLAGS="-lgcc_s";
   buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [ which libX11 fontconfig xproto libXt xextproto libXext ];
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "http://swtch.com/plan9port/";
     description = "Plan 9 from User Space";
     license = licenses.lpl-102;
-    maintainers = [ stdenv.lib.maintainers.ftrvxmtrx ];
+    maintainers = with stdenv.lib.maintainers; [ ftrvxmtrx kovirobi ];
     platforms = platforms.unix;
   };
 


### PR DESCRIPTION
We were already using snapshots, but development moved to github.
Also add "9" to $out/bin as it is the recommended practice, see
install.txt. Tested it on my system.
cc @ftrvxmtrx
