### PR TITLE
can-utils: updated homepage url

### DIFF
--- a/pkgs/os-specific/linux/can-utils/default.nix
+++ b/pkgs/os-specific/linux/can-utils/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "CAN userspace utilities and tools (for use with Linux SocketCAN)";
-    homepage = "https://gitorious.org/linux-can/can-utils";
+    homepage = "https://github.com/linux-can/can-utils";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];


### PR DESCRIPTION
Gitorious is not used anymore. Updated url to github.
