### PR TITLE
fix updmap invocation in texLive

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/aggregate.nix
+++ b/pkgs/tools/typesetting/tex/texlive/aggregate.nix
@@ -53,7 +53,7 @@ rec {
 
     rm -f $out/texmf*/ls-R
     for i in web2c texconfig fonts/map; do
-        mkdir -p $out/texmf-config/$i 
+        mkdir -p $out/texmf-config/$i
         cp -Lr $out/texmf*/$i/* $out/texmf-config/$i || true
     done
     chmod -R u+w $out/texmf-config

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -81,7 +81,7 @@ rec {
 
     PATH=$PATH:$out/bin mktexlsr $out/share/texmf*
 
-    HOME=. PATH=$PATH:$out/bin updmap-sys --syncwithtrees
+    yes | HOME=. PATH=$PATH:$out/bin updmap-sys --syncwithtrees || echo $?
 
     # Prebuild the format files, as it used to be done with TeXLive 2007.
     # Luatex currently fails this way:

--- a/pkgs/tools/typesetting/tex/texlive/xcolor.nix
+++ b/pkgs/tools/typesetting/tex/texlive/xcolor.nix
@@ -14,7 +14,7 @@ rec {
 
     mkdir -p $out/texmf-dist/tex/latex/xcolor
     mkdir -p $out/texmf-dist/dvips/xcolor
-    latex xcolor.ins 
+    latex xcolor.ins
     cp *.sty *.def $out/texmf-dist/tex/latex/xcolor
     cp *.pro $out/texmf-dist/dvips/xcolor
 


### PR DESCRIPTION
fixes #9318 

this fixes a build-time failure in xcolor and a runtime failure in texlive-core. I guess there's work underway to overhaul all the tex infrastructure; however this may be a useful patch in the meantime
