### PR TITLE
Apache configuration improvements

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -577,7 +577,7 @@ in
       enablePHP = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether to enable the PHP module.";
+        description = "Enable the PHP module.";
       };
 
       phpOptions = mkOption {
@@ -626,7 +626,7 @@ in
       enableCompression = mkOption {
         type = types.bool;
         default = false;
-        description = "Enable compression of responses using mod_deflate.";
+        description = "Enable compression of responses using <literal>mod_deflate</literal>.";
       };
 
       verifyConfig = mkOption {

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -10,7 +10,7 @@ let
 
   version24 = !versionOlder httpd.version "2.4";
 
-  httpdConf = mainCfg.configFile;
+  httpdConf = if mainCfg.verifyConfig then verifiedConf else mainCfg.configFile;
 
   php = pkgs.php.override { apacheHttpd = httpd; };
 
@@ -417,6 +417,19 @@ let
     }
   '';
 
+  verifiedConf = pkgs.runCommand "apache.conf" {} ''
+    c=${mainCfg.configFile}
+    trap "echo '==> configuration error, see $c'" ERR
+
+    # Allow testing in sandbox
+    sed -e "s:/run/httpd:$PWD:" -e "/^User /d" -e "/^Group /d" < $c > test-conf.conf
+    mkdir runtime
+
+    echo "verifying Apache configuration, ignore warnings about missing directories"
+    ${httpd}/bin/httpd -f $PWD/test-conf.conf -t
+    cp $c $out
+  '';
+
 
   enablePHP = mainCfg.enablePHP || any (svc: svc.enablePHP) allSubservices;
 
@@ -614,6 +627,12 @@ in
         type = types.bool;
         default = false;
         description = "Enable compression of responses using mod_deflate.";
+      };
+
+      verifyConfig = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Verify generated configuration.";
       };
     }
 

--- a/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
@@ -36,7 +36,7 @@ with lib;
   enableSSL = mkOption {
     type = types.bool;
     default = false;
-    description = "Whether to enable SSL (https) support.";
+    description = "Enable SSL (https) support.";
   };
 
   # Note: sslServerCert and sslServerKey can be left empty, but this
@@ -115,7 +115,7 @@ with lib;
       </Directory>
     '';
     description = ''
-      These lines go to httpd.conf verbatim. They will go after
+      These lines go to <filename>httpd.conf</filename> verbatim. They will go after
       directories and directory aliases defined by default.
     '';
   };
@@ -130,7 +130,7 @@ with lib;
     type = types.bool;
     default = false;
     description = ''
-      Whether to enable serving <filename>~/public_html</filename> as
+      Enable serving <filename>~/public_html</filename> as
       <literal>/~<replaceable>username</replaceable></literal>.
     '';
   };


### PR DESCRIPTION
- Verify configuration with httpd -t
- Some minor editing of option descriptions
- Make Event MPM the default on v2.4 

@edolstra any objections? The config check can be turned off and Event is good starting with kernel 2.6...
