### PR TITLE
fixed: mlmmj-recieve: No such file or directory

### DIFF
--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -11,7 +11,7 @@ let
   listCtl = domain: list: "${listDir domain list}/control";
   transport = domain: list: "${domain}--${list}@local.list.mlmmj mlmmj:${domain}/${list}";
   virtual = domain: list: "${list}@${domain} ${domain}--${list}@local.list.mlmmj";
-  alias = domain: list: "${list}: \"|${pkgs.mlmmj}/mlmmj-receive -L ${listDir domain list}/\"";
+  alias = domain: list: "${list}: \"|${pkgs.mlmmj}/bin/mlmmj-receive -L ${listDir domain list}/\"";
   subjectPrefix = list: "[${list}]";
   listAddress = domain: list: "${list}@${domain}";
   customHeaders = list: domain: [ "List-Id: ${list}" "Reply-To: ${list}@${domain}" ];


### PR DESCRIPTION
Hi,

currently the mlmmj service does not work because of a wrong path in the module. 

```
Aug 25 13:16:47 hostname local[48781]: fatal: execvp /nix/store/jb0l4ahlsdx7ldfawi42vkqra68vj0p3-mlmmj-1.2.18.1/mlmmj-receive: No such file or directory
Aug 25 13:16:47 hostname postfix/local[48780]: 7FFB284835A0: to=<mail@example.org>, relay=local, delay=0.03, delays=0.02/0/0/0, dsn=4.3.0, status=deferred (temporary failure. Command output: local: fatal: execvp /nix/store/jb0l4ahlsdx7ldfawi42vkqra68vj0p3-mlmmj-1.2.18.1/mlmmj-receive: No such file or directory )
```
