### PR TITLE
reposurgeon: init at 3.28

### DIFF
--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -1,0 +1,47 @@
+{stdenv, fetchurl, makeWrapper, flex, bison,
+ asciidoc, docbook_xml_dtd_45, docbook_xml_xslt,
+ libxml2, libxslt,
+ python27, rcs, cvs, git,
+ coreutils, rsync}:
+with stdenv; with lib;
+mkDerivation rec {
+  name = "cvs-fast-export-${meta.version}";
+  meta = {
+    version = "1.32";
+    description = "Export an RCS or CVS history as a fast-import stream";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dfoxfranke ];
+    homepage = "http://www.catb.org/esr/cvs-fast-export/";
+    platforms = platforms.all;
+  };
+
+  src = fetchurl {
+    url = "http://www.catb.org/~esr/cvs-fast-export/cvs-fast-export-1.32.tar.gz";
+    sha256 = "5bfb9a5650517d337a96a598795b50bc40ce12172854a6581267e7be3dbcfb97";
+  };
+
+  buildInputs = [
+    flex bison asciidoc docbook_xml_dtd_45 docbook_xml_xslt libxml2 libxslt
+    python27 rcs cvs git makeWrapper
+  ];
+
+  preBuild = ''
+    makeFlagsArray=(
+      XML_CATALOG_FILES="${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xml_xslt}/xml/xsl/docbook/catalog.xml"
+      prefix="$out"
+    )
+  '';
+
+  doCheck = true;
+
+  postInstall =
+    let
+      binpath = makeSearchPath "bin" [ out rcs cvs git coreutils rsync ];
+    in ''
+      for prog in cvs-fast-export cvsconvert cvssync; do
+        wrapProgram $out/bin/$prog \
+          --prefix PATH : ${binpath}
+      done
+    ''
+  ;
+}

--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -25,6 +25,8 @@ mkDerivation rec {
     python27 rcs cvs git makeWrapper
   ];
 
+  postPatch = "patchShebangs .";
+
   preBuild = ''
     makeFlagsArray=(
       XML_CATALOG_FILES="${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xml_xslt}/xml/xsl/docbook/catalog.xml"

--- a/pkgs/applications/version-management/reposurgeon/default.nix
+++ b/pkgs/applications/version-management/reposurgeon/default.nix
@@ -1,0 +1,66 @@
+{stdenv, fetchurl, makeWrapper, python27, python27Packages, git,
+ docbook_xml_dtd_412, docbook_xml_xslt, asciidoc, xmlto,
+ cython ? null,
+ bazaar ? null, cvs ? null, darcs ? null, fossil ? null,
+ mercurial ? null, monotone ? null, rcs ? null, src ? null,
+ subversion ? null, cvs_fast_export ? null }:
+with stdenv; with lib;
+mkDerivation rec {
+  name = "reposurgeon-${meta.version}";
+  meta = {
+    description = "A tool for editing version-control repository history";
+    version = "3.28";
+    license = licenses.bsd3;
+    homepage = "http://www.catb.org/esr/reposurgeon/";
+    maintainers = with maintainers; [ dfoxfranke ];
+    platforms = platforms.all;
+  };
+
+  src = fetchurl {
+    url = "http://www.catb.org/~esr/reposurgeon/reposurgeon-3.28.tar.gz";
+    sha256 = "3225b44109b8630310a0ea6fe63a3485d27aa46deaf80e8d07820e01a6f62626";
+  };
+
+  # See https://gitlab.com/esr/reposurgeon/issues/17
+  patches = [ ./fix-preserve-type.patch ];  
+
+  buildInputs =
+    [ docbook_xml_dtd_412 docbook_xml_xslt asciidoc xmlto makeWrapper ] ++
+    optional (cython != null) cython
+  ;
+
+  preBuild = ''
+    makeFlagsArray=(
+      XML_CATALOG_FILES="${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml ${docbook_xml_xslt}/xml/xsl/docbook/catalog.xml"
+      prefix="$out"
+      pyinclude="-I${python27}/include/python2.7"
+      pylib="-L${python27}/lib -lpython2.7"
+    )
+  '';
+
+  buildFlags = "all" + (if cython != null then " cyreposurgeon" else "");
+
+  installTargets =
+    "install" + (if cython != null then " install-cyreposurgeon" else "")
+  ;
+
+  postInstall =
+    let
+      binpath = makeSearchPath "bin" (
+        filter (x: x != null)
+        [ out git bazaar cvs darcs fossil mercurial
+          monotone rcs src subversion cvs_fast_export ]
+      );
+      pythonpath = makeSearchPath (python27.sitePackages) (
+        filter (x: x != null)
+        [ python27Packages.readline or null python27Packages.hglib or null ]
+      );
+    in ''
+      for prog in reposurgeon repodiffer repotool; do
+        wrapProgram $out/bin/$prog \
+          --prefix PATH : "${binpath}" \
+          --prefix PYTHONPATH : "${pythonpath}"
+      done
+    ''
+  ;    
+}

--- a/pkgs/applications/version-management/reposurgeon/fix-preserve-type.patch
+++ b/pkgs/applications/version-management/reposurgeon/fix-preserve-type.patch
@@ -1,0 +1,12 @@
+diff -Nru reposurgeon-3.28/reposurgeon reposurgeon-3.28-new/reposurgeon
+--- reposurgeon-3.28/reposurgeon	2015-07-05 15:17:13.000000000 -0400
++++ reposurgeon-3.28-new/reposurgeon	2015-08-25 18:23:11.347591137 -0400
+@@ -193,7 +193,7 @@
+         importer=b"git fast-import --quiet",
+         checkout=b"git checkout",
+         lister=b"git ls-files",
+-        preserve=(b'.git/config', b'.git/hooks'),
++        preserve=set((b'.git/config', b'.git/hooks')),
+         authormap=b".git/cvs-authors",
+         ignorename=b".gitignore",
+         dfltignores=b"",	# Has none

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1242,6 +1242,8 @@ let
 
   cutter = callPackage ../tools/networking/cutter { };
 
+  cvs_fast_export = callPackage ../applications/version-management/cvs-fast-export { };
+
   dadadodo = callPackage ../tools/text/dadadodo { };
 
   daemonize = callPackage ../tools/system/daemonize { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2842,6 +2842,8 @@ let
 
   replace = callPackage ../tools/text/replace { };
 
+  reposurgeon = callPackage ../applications/version-management/reposurgeon { };
+
   reptyr = callPackage ../os-specific/linux/reptyr {};
 
   rescuetime = callPackage ../applications/misc/rescuetime { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3698,6 +3698,24 @@ let
     };
   };
 
+  hglib = buildPythonPackage rec {
+    version = "1.7";
+    name = "hglib-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/python-hglib/python-hglib-${version}.tar.gz";
+      sha256 = "0dc087d15b774cda82d3c8096fb0e514caeb2ddb60eed38e9056b16e279ba3c5";
+    };
+
+    meta = {
+      description = "Mercurial Python library";
+      homepage = "http://selenic.com/repo/python-hglib";
+      license = licenses.mit;
+      maintainers = with maintainers; [ dfoxfranke ];
+      platforms = platforms.all;
+    };
+  };
+
   humanize = buildPythonPackage rec {
     version = "0.5.1";
     name = "humanize-${version}";


### PR DESCRIPTION
This also packages its (optional) dependencies `cvs-fast-export` and `hglib`.
