### PR TITLE
tilda: ensure wrapped executable is named "tilda"

### DIFF
--- a/pkgs/applications/misc/tilda/default.nix
+++ b/pkgs/applications/misc/tilda/default.nix
@@ -17,8 +17,12 @@ stdenv.mkDerivation rec {
 
   LD_LIBRARY_PATH = "${expat}/lib"; # ugly hack for xgettext to work during build
 
+  # The config locking scheme relies on the binary being called "tilda",
+  # (`pgrep -C tilda`), so a simple `wrapProgram` won't suffice:
   postInstall = ''
-    wrapProgram "$out/bin/tilda" \
+    mkdir $out/bin/wrapped
+    mv "$out/bin/tilda" "$out/bin/wrapped/tilda"
+    makeWrapper "$out/bin/wrapped/tilda" "$out/bin/tilda" \
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
   '';
 


### PR DESCRIPTION
Previously the executable name ended up as `.tilda-wrapped`, which messes up the lock code in https://github.com/lanoxx/tilda/blob/f1e6ec9b5da3d631664256a28addeb888c9f05ae/src/tilda.c#L233
because it looks for processes named "tilda".
