### PR TITLE
ranger: works fine on Darwin

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
     description = "File manager with minimalistic curses interface";
     homepage = "http://ranger.nongnu.org/";
     license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ iyzsong ];
   };
 


### PR DESCRIPTION
Verified that `ranger` works fine on Darwin, set the platforms accordingly.
