### PR TITLE
Update KMyMoney to the latest version

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -3,11 +3,12 @@
 , oxygen_icons, kactivities, aqbanking, perlPackages, gwenhywfar }:
 
 stdenv.mkDerivation rec {
-  name = "kmymoney-4.7.1";
+  name = "kmymoney-4.7.2";
 
   src = fetchurl {
-    url = http://kde.mirrorcatalogs.com/stable/kmymoney/4.7.1/src/kmymoney-4.7.1.tar.xz;
-    sha256 = "7749cbae146eb4adf5c92162c841ae321f971c5720bc32d0227a42a4dd4acfc4"; # v. 4.7.1
+    url = http://kde.mirrorcatalogs.com/stable/kmymoney/4.7.2/src/kmymoney-4.7.2.tar.xz;
+    #sha256 = "7749cbae146eb4adf5c92162c841ae321f971c5720bc32d0227a42a4dd4acfc4"; # v. 4.7.1
+    sha256 = "bfb2c29ff30988f46324c2dae197a06b58d07336a1947adc22bcfed3e554393d"; # v. 4.7.2
   };
 
   buildInputs = [ kdepimlibs perl boost gpgme gmpxx libalkimia libofx libical

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -3,11 +3,14 @@
 , doxygen, oxygen_icons, kactivities }:
 
 stdenv.mkDerivation rec {
-  name = "kmymoney-4.6.4";
+  name = "kmymoney-4.7.0";
+  #name = "kmymoney-4.6.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/kmymoney2/${name}.tar.xz";
-    sha256 = "04n0lgi2yrx67bgjzbdbcm10pxs7l53srmp240znzw59njnjyll9";
+#    url = "mirror://sourceforge/kmymoney2/${name}.tar.xz";
+    url = http://ftp5.gwdg.de/pub/linux/kde/stable/kmymoney/4.7.0/src/kmymoney-4.7.0.tar.xz;
+    sha256 = "e4b3ce10e2fe7d84314b7e1c77a995f41488d161b716f7d67ca8de715e833e09"; # v. 4.7.0
+#    sha256 = "04n0lgi2yrx67bgjzbdbcm10pxs7l53srmp240znzw59njnjyll9"; # v 4.6.4
   };
 
   buildInputs = [ kdepimlibs perl boost gpgme gmpxx libalkimia libofx libical

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, cmake, kdelibs, automoc4, kdepimlibs, gettext, pkgconfig
 , shared_mime_info, perl, boost, gpgme, gmpxx, libalkimia, libofx, libical
-, doxygen }:
+, doxygen, oxygen_icons, kactivities }:
 
 stdenv.mkDerivation rec {
   name = "kmymoney-4.6.4";
@@ -11,10 +11,16 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ kdepimlibs perl boost gpgme gmpxx libalkimia libofx libical
-                  doxygen ];
-  nativeBuildInputs = [ cmake automoc4 gettext shared_mime_info pkgconfig ];
+                  doxygen oxygen_icons kactivities shared_mime_info ];
+  nativeBuildInputs = [ cmake automoc4 gettext pkgconfig ]; 
 
   KDEDIRS = libalkimia;
+
+  postInstall = ''
+    ln -s ${shared_mime_info}/share/mime/application/* $out/share/mime/application/
+    ln -s ${shared_mime_info}/share/mime/inode $out/share/mime/inode
+    ln -s ${oxygen_icons}/share/icons/oxygen/ $out/share/icons/oxygen
+  '';
 
   patches = [ ./qgpgme.patch ];
 
@@ -22,5 +28,6 @@ stdenv.mkDerivation rec {
     homepage = http://kmymoney2.sourceforge.net/;
     description = "KDE personal money manager";
     inherit (kdelibs.meta) platforms maintainers;
+    priority = 100;
   };
 }

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -1,23 +1,22 @@
 { stdenv, fetchurl, cmake, kdelibs, automoc4, kdepimlibs, gettext, pkgconfig
 , shared_mime_info, perl, boost, gpgme, gmpxx, libalkimia, libofx, libical
-, doxygen, oxygen_icons, kactivities }:
+, oxygen_icons, kactivities, aqbanking, perlPackages, gwenhywfar }:
 
 stdenv.mkDerivation rec {
-  name = "kmymoney-4.7.0";
-  #name = "kmymoney-4.6.4";
+  name = "kmymoney-4.7.1";
 
   src = fetchurl {
-#    url = "mirror://sourceforge/kmymoney2/${name}.tar.xz";
-    url = http://ftp5.gwdg.de/pub/linux/kde/stable/kmymoney/4.7.0/src/kmymoney-4.7.0.tar.xz;
-    sha256 = "e4b3ce10e2fe7d84314b7e1c77a995f41488d161b716f7d67ca8de715e833e09"; # v. 4.7.0
-#    sha256 = "04n0lgi2yrx67bgjzbdbcm10pxs7l53srmp240znzw59njnjyll9"; # v 4.6.4
+    url = http://kde.mirrorcatalogs.com/stable/kmymoney/4.7.1/src/kmymoney-4.7.1.tar.xz;
+    sha256 = "7749cbae146eb4adf5c92162c841ae321f971c5720bc32d0227a42a4dd4acfc4"; # v. 4.7.1
   };
 
   buildInputs = [ kdepimlibs perl boost gpgme gmpxx libalkimia libofx libical
-                  doxygen oxygen_icons kactivities shared_mime_info ];
+                  oxygen_icons kactivities shared_mime_info aqbanking
+                  perlPackages.FinanceQuote gwenhywfar ];
   nativeBuildInputs = [ cmake automoc4 gettext pkgconfig ]; 
 
-  KDEDIRS = libalkimia;
+  #KDEDIRS = libalkimia;
+  KDEDIRS="$out:${libalkimia}:${gwenhywfar}:${aqbanking}";
 
   postInstall = ''
     ln -s ${shared_mime_info}/share/mime/application/* $out/share/mime/application/


### PR DESCRIPTION
Hi,

The NixOS/nixpkgs-version of KMyMoney is 4.6.4.
I've been using KMyMony 4.7.1 for a long time now without issues. I recently updated to 4.7.2 which officially is out/stable since 2015-04-25.

I've encountered no issues. All graphics seem to be present.

Thank you and have a nice day :)
