### PR TITLE
Fix NetworkManager connection sharing

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -6,7 +6,8 @@ with lib;
 let
   cfg = config.networking.networkmanager;
 
-  stateDirs = "/var/lib/NetworkManager /var/lib/dhclient";
+  # /var/lib/misc is for dnsmasq.leases.
+  stateDirs = "/var/lib/NetworkManager /var/lib/dhclient /var/lib/misc";
 
   configFile = writeText "NetworkManager.conf" ''
     [main]

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   # TODO: Patch epoll so that the dbus actually responds
   # TODO: Figure out how to get privsep working, currently getting SIGBUS
   extraConfig = ''
+    CONFIG_AP=y
     CONFIG_LIBNL32=y
     CONFIG_EAP_FAST=y
     CONFIG_EAP_PWD=y

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ wirelesstools udev libnl libuuid polkit ppp libndp
-                  xz bluez5 gobjectIntrospection modemmanager readline newt libsoup ];
+                  xz bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup ];
 
   propagatedBuildInputs = [ dbus_glib gnutls libgcrypt ];
 


### PR DESCRIPTION
NetworkManager's connection sharing doesn't work for me on the current nixos-14.12 channel (8f11a84), partly because of bug #7593.  Here are the fixes I made to get it working again.  This allows NM to create networks in ad-hoc and access point modes.  I applied these patches on top of 8f11a84, successfully created ad-hoc and AP networks, and connected a Wii U to the AP network.  I haven't tested these patches against master because of the large build required (it's not convenient for me to do that right now).
