### PR TITLE
syncthing: 0.11.21 -> 0.11.22

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -4,12 +4,12 @@ with goPackages;
 
 buildGoPackage rec {
   name = "syncthing-${version}";
-  version = "0.11.21";
+  version = "0.11.22";
   goPackagePath = "github.com/syncthing/syncthing";
   src = fetchgit {
     url = "git://github.com/syncthing/syncthing.git";
     rev = "refs/tags/v${version}";
-    sha256 = "2e7faf1002570a64ef76c6bbdde781c550db6c45b30f4fa1c394102809cad977";
+    sha256 = "0zdk5ppsq35s10chf8m3rw3sk9d77ms7x1vj3inw4lrm1h13w9wk";
   };
 
   subPackages = [ "cmd/syncthing" ];


### PR DESCRIPTION
doesn't build on master as of now because of go1.5 issues, but it works fine on top of unstable.
