### PR TITLE
syncthing: fixed service to follow correct defaults and additional configurability

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -36,9 +36,7 @@ in
       dataDir = mkOption {
         default = "/var/lib/syncthing";
         description = ''
-          Path where the `.syncthing` (settings and keys) and `Sync`
-          (your synced files) directories will exist. This can be your home
-          directory.
+          Path where the settings and keys will exist.
         '';
       };
 
@@ -57,18 +55,12 @@ in
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         environment.STNORESTART = "placeholder";  # do not self-restart
-        environment.HOME = "${cfg.dataDir}";
         serviceConfig = {
           User = "${cfg.user}";
           PermissionsStartOnly = true;
           Restart = "always";
-          ExecStart = "${pkgs.syncthing}/bin/syncthing -home=${cfg.dataDir}/.syncthing";
+          ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser -home=${cfg.dataDir}";
         };
-        preStart = ''
-          mkdir -p ${cfg.dataDir}
-          chown ${cfg.user} ${cfg.dataDir}
-        '';
-
       };
 
     environment.systemPackages = [ pkgs.syncthing ];


### PR DESCRIPTION
I changed a few things with the syncthing service:
- the config home is not set to `${dataDir}/.synchting` anymore because it forces users to store stuff into a `.syncthing` directory which also makes impossible to follow syncthing's default behavior of using `~/.config/syncthing`
- use `-no-browser` so syncthing doesn't even try to start the browser
- set `dataDir` to `~/.config/syncthing` because that's syncthing's default setting
- change `dataDir`'s description to match actual behavior: syncthing doesn't store the actual shared data there, only configuration files and keys
- remove `preStart` hook because it's not needed, syncthing figures it out on its own
