### PR TITLE
systemd.services scripts: Allow languages besides shell

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -1,5 +1,7 @@
 {stdenv, fetchurl, python27, python27Packages, makeWrapper}:
 
+with python27Packages;
+
 stdenv.mkDerivation rec {
   version = "0.9.82";
   name = "google-cloud-sdk-${version}";
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
         wrapper="$out/bin/$program"
         makeWrapper "$programPath" "$wrapper" \
             --set CLOUDSDK_PYTHON "${python27}/bin/python" \
-            --prefix PYTHONPATH : "$(toPythonPath ${python27Packages.crcmod})"
+            --prefix PYTHONPATH : "$(toPythonPath ${cffi}):$(toPythonPath ${cryptography}):$(toPythonPath ${pyopenssl}):$(toPythonPath ${crcmod})"
     done
 
     # install man pages


### PR DESCRIPTION
This lets me write

```
systemd.services.hstest.script = {
  text = ''
    {-# LANGUAGE OverloadedStrings #-}
    import Prelude hiding (FilePath)
    import Turtle

    main = do
      output "/root/turtleout" (fromString . show <$> ls "/var")
      sleep 600
  '';
language = "haskell";
env = pkgs.haskellPackages.ghcWithPackages (p: [ p.turtle ]);
```

  };

Supports only haskell at the moment, but it won't be too hard to add others.
