### PR TITLE
nibabel: remove failing test

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8406,11 +8406,17 @@ let
       nose
       modules.sqlite3
     ];
+    
+    # Test does not work on Py3k because it calls 'python'.
+    # https://github.com/nipy/nibabel/issues/341
+    preCheck = ''
+      rm nisext/tests/test_testers.py
+    '';
 
     meta = {
       homepage = http://nipy.org/nibabel/;
       description = "Access a multitude of neuroimaging data formats";
-      license = "BSD";
+      license = licenses.mit;
     };
   };
 


### PR DESCRIPTION
One of the tests explicitly calls python, which will fail with python3.
The issue has been reported upstream,
https://github.com/nipy/nibabel/issues/341
For now, remove the test.

Fix also the license type.
#9471
