### PR TITLE
fuppes: mark as broken

### DIFF
--- a/pkgs/tools/networking/fuppes/default.nix
+++ b/pkgs/tools/networking/fuppes/default.nix
@@ -50,5 +50,7 @@ stdenv.mkDerivation rec {
 
     maintainers = [ stdenv.lib.maintainers.pierron ];
     platforms = stdenv.lib.platforms.all;
+
+    broken = true;
   };
 }


### PR DESCRIPTION
This package has been broken since 2014-01-20, according to Hydra [1](https://hydra.nixos.org/build/25188337). I tried
various ad-hoc patching & adding missing dependencies, uncovering yet more
errors. Updating is also out of the question, as nixpkgs already contains the
latest version.
