### PR TITLE
scilab-bin: init at 5.5.2

### DIFF
--- a/pkgs/applications/science/math/scilab-bin/default.nix
+++ b/pkgs/applications/science/math/scilab-bin/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchurl, lib, xlibs }:
+
+let
+  name = "scilab-bin-${ver}";
+
+  ver = "5.5.2";
+
+  majorVer = builtins.elemAt (lib.splitString "." ver) 0;
+
+  badArch = throw "${name} requires i686-linux or x86_64-linux";
+
+  architecture =
+    if stdenv.system == "i686-linux" then
+      "i686"
+    else if stdenv.system == "x86_64-linux" then
+      "x86_64"
+    else
+      badArch;
+in
+stdenv.mkDerivation rec {
+  inherit name;
+
+  src = fetchurl {
+    url = "http://www.scilab.org/download/${ver}/scilab-${ver}.bin.linux-${architecture}.tar.gz";
+    sha256 =
+      if stdenv.system == "i686-linux" then
+        "6143a95ded40411a35630a89b365875a6526cd4db1e2865ac5612929a7db937a"
+      else if stdenv.system == "x86_64-linux" then
+        "c0dd7a5f06ec7a1df7a6b1b8b14407ff7f45e56821dff9b3c46bd09d4df8d350"
+      else
+        badArch;
+  };
+
+  libPath = lib.makeLibraryPath [
+    stdenv.cc.cc
+    xlibs.libX11
+    xlibs.libXext
+    xlibs.libXi
+    xlibs.libXrender
+    xlibs.libXtst
+    xlibs.libXxf86vm
+  ];
+
+  phases = [ "unpackPhase" "fixupPhase" "installPhase" ];
+
+  fixupPhase = ''
+    sed -i 's|\$(/bin/|$(|g' bin/scilab
+    sed -i 's|/usr/bin/||g' bin/scilab
+
+    sci="$out/opt/scilab-${ver}"
+    fullLibPath="$sci/lib/scilab:$sci/lib/thirdparty:$libPath"
+    fullLibPath="$fullLibPath:$sci/lib/thirdparty/redist"
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+             --set-rpath "$fullLibPath" bin/scilab-bin
+    find . -name '*.so' -type f | while read file; do
+      patchelf --set-rpath "$fullLibPath" "$file" 2>/dev/null
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/opt/scilab-${ver}"
+    cp -r . "$out/opt/scilab-${ver}/"
+    mkdir "$out/bin"
+    ln -s "$out/opt/scilab-${ver}/bin/scilab" "$out/bin/scilab-${ver}"
+    ln -s "scilab-${ver}" "$out/bin/scilab-${majorVer}"
+  '';
+
+  meta = {
+    homepage = http://www.scilab.org/;
+    description = "Scientific software package for numerical computations (Matlab lookalike)";
+    # see http://www.scilab.org/legal_notice
+    license = "Scilab";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16761,6 +16761,8 @@ in
     withX = true;
   };
 
+  scilab-bin = callPackage ../applications/science/math/scilab-bin {};
+
   scotch = callPackage ../applications/science/math/scotch { };
 
   msieve = callPackage ../applications/science/math/msieve { };


### PR DESCRIPTION
How does Nixpkgs feel about binary packages?  Here's a derivation for the binary version of Scilab 5.5.2.  A built-from-source Scilab 5 package looks to be a lot more work, and some dependencies are missing from Nixpkgs, but the binary version with bundled dependencies works.

I've been using this on x86_64 with this commit applied on top of my current nix-channel commit (bb79e19) with only a trivial change (`stdenv.gcc.gcc` became `stdenv.cc.cc` on master), and have had no problems with Scilab.  I haven't tested on 32-bit.  I tried to build on top of master, but got this error.  Is this a problem with the package, or a problem with mixing master and stable?

```
~/nix/nixpkgs.git $ nix-build . -A scilab-bin
these derivations will be built:
  /nix/store/mm7r1bm6lhjwr03rrvpsljgrsdkhljk0-scilab-bin-5.5.2.drv
building path(s) ‘/nix/store/0lkjr88x086vb180xw0bzmbwc7cg32sr-scilab-bin-5.5.2’
unpacking sources
unpacking source archive /nix/store/1a5sn050100ndgqzyda9snrcpl7nynzg-scilab-5.5.2.bin.linux-x86_64.tar.gz
source root is scilab-5.5.2
post-installation fixup
cat: /nix-support/dynamic-linker: No such file or directory
stat: No such file or directory
builder for ‘/nix/store/mm7r1bm6lhjwr03rrvpsljgrsdkhljk0-scilab-bin-5.5.2.drv’ failed with exit code 1
error: build of ‘/nix/store/mm7r1bm6lhjwr03rrvpsljgrsdkhljk0-scilab-bin-5.5.2.drv’ failed
```

Thanks!
