### PR TITLE
xrdb: Use mcpp as the preprocessor (fixes #9480)

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -421,4 +421,8 @@ in
     outputs = [ "out" "doc" ];
   };
 
+  xrdb = attrs: attrs // {
+    configureFlags = "--with-cpp=${args.mcpp}/bin/mcpp";
+  };
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9375,7 +9375,7 @@ let
   xorg = recurseIntoAttrs (import ../servers/x11/xorg/default.nix {
     inherit clangStdenv fetchurl fetchgit fetchpatch stdenv pkgconfig intltool freetype fontconfig
       libxslt expat libpng zlib perl mesa_drivers spice_protocol
-      dbus libuuid openssl gperf m4 libevdev tradcpp libinput makeWrapper autoreconfHook
+      dbus libuuid openssl gperf m4 libevdev tradcpp libinput mcpp makeWrapper autoreconfHook
       autoconf automake libtool xmlto asciidoc flex bison python mtdev pixman;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
     mesa = mesa_noglu;


### PR DESCRIPTION
By default, xrdb uses GCC as the preprocessor at runtime for X resource files.
However, gcc is a large dependency, so replace it with mcpp, a much smaller
preprocessor (currently under a megabyte on i686).

Arch Linux already does this as well, so this should be relatively safe:
https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/xorg-xrdb

I tested this by copying https://github.com/solarized/xresources/blob/master/Xresources.dark as `~/.Xresources` and lauching a xterm, which came up with the dark theme as expected.
