### PR TITLE
Darwin fixes for reposurgeon and cvs-fast-export

### DIFF
--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -30,6 +30,7 @@ mkDerivation rec {
   preBuild = ''
     makeFlagsArray=(
       XML_CATALOG_FILES="${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xml_xslt}/xml/xsl/docbook/catalog.xml"
+      LIBS=""
       prefix="$out"
     )
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6241,7 +6241,7 @@ let
       description = "Coroutine-based networking library";
       homepage = http://www.gevent.org/;
       license = licenses.mit;
-      platforms = platforms.linux;
+      platforms = platforms.unix;
       maintainers = with maintainers; [ bjornfor ];
     };
   };


### PR DESCRIPTION
This fixes the `cvs-fast-export` error seen in http://hydra.nixos.org/build/25203299/nixlog/1, and tells Hydra not to build `reposurgeon` on Darwin due to a bug in one of its dependencies (see 5a6ebe6 commit message for details).
