### PR TITLE
vimUtils.pluginnames2nix: fixes for non-nixos systems

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -1,6 +1,7 @@
-{stdenv, vim, vimPlugins, vim_configurable, buildEnv, writeText, writeScriptBin}:
+{stdenv, vim, vimPlugins, vim_configurable, buildEnv, writeText, writeScriptBin
+, nix-prefetch-scripts }:
 
-/* 
+/*
 
 USAGE EXAMPLE
 =============
@@ -309,8 +310,8 @@ rec {
         echom repeat("=", 80)
       endif
       let opts = {}
-      let opts.nix_prefetch_git = "${../../../pkgs/build-support/fetchgit/nix-prefetch-git}"
-      let opts.nix_prefetch_hg  = "${../../../pkgs/build-support/fetchhg/nix-prefetch-hg}"
+      let opts.nix_prefetch_git = "${nix-prefetch-scripts}/bin/nix-prefetch-git"
+      let opts.nix_prefetch_hg  = "${nix-prefetch-scripts}/bin/nix-prefetch-hg"
       let opts.cache_file = g:vim_addon_manager.plugin_root_dir.'/cache'
       let opts.plugin_dictionaries = []
       ${lib.concatMapStrings (file: "let opts.plugin_dictionaries += map(readfile(\"${file}\"), 'eval(v:val)')\n") namefiles }


### PR DESCRIPTION
Now referring to the nix prefetch scripts through their nixpkgs
derivation in order to make sure their shebang lines are rewritten
properly.  Otherwise nix-prefetch-hg fails on Ubuntu (and probably
Debian) systems, where /bin/sh is not bash.
