### PR TITLE
nix-prefetch-scripts: fix shebang lines for portability

### DIFF
--- a/pkgs/build-support/fetchbzr/nix-prefetch-bzr
+++ b/pkgs/build-support/fetchbzr/nix-prefetch-bzr
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#!/usr/bin/env bash
+set -e
 
 url=$1
 rev=$2

--- a/pkgs/build-support/fetchcvs/nix-prefetch-cvs
+++ b/pkgs/build-support/fetchcvs/nix-prefetch-cvs
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#!/usr/bin/env bash
+set -e
 
 cvsRoot=$1
 module=$2

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#!/usr/bin/env bash
+set -e
 
 url=
 rev=

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#!/usr/bin/env bash
+set -e
 
 url=$1
 rev=$2

--- a/pkgs/build-support/fetchsvn/nix-prefetch-svn
+++ b/pkgs/build-support/fetchsvn/nix-prefetch-svn
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#!/usr/bin/env bash
+set -e
 
 url=$1
 rev=$2

--- a/pkgs/build-support/fetchzip/nix-prefetch-zip
+++ b/pkgs/build-support/fetchzip/nix-prefetch-zip
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#!/usr/bin/env bash
+set -e
 
 usage(){
     echo  >&2 "syntax: nix-prefetch-zip [OPTIONS] [URL [EXPECTED-HASH]]


### PR DESCRIPTION
In theory this is entirely moot, because these should be used after
the shebang line is rewritten, but this makes them much more likely to
work if they do get run as-is on non-NixOS systems, particularly those
that do not use bash for their /bin/sh (including Ubuntu and Debian).

Moving the -e to a separate line makes it stick even if somebody
invokes them as "bash nix-prefetch-something" for whatever reason.

This makes me wonder: is there a canonically correct shebang line
to use for shell scripts in nixpkgs?  If not, should there be one?
