### PR TITLE
cromfs: build with gcc48

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1191,7 +1191,9 @@ let
 
   crackxls = callPackage ../tools/security/crackxls { };
 
-  cromfs = callPackage ../tools/archivers/cromfs { };
+  cromfs = callPackage ../tools/archivers/cromfs {
+    stdenv = overrideCC stdenv gcc48;
+  };
 
   cron = callPackage ../tools/system/cron { };
 


### PR DESCRIPTION
`gcc49` fails with an internal error on `i686-linux`: http://hydra.nixos.org/build/25154196/nixlog/1
