### PR TITLE
glob2: fix build failure

### DIFF
--- a/pkgs/games/globulation/default.nix
+++ b/pkgs/games/globulation/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "1f0l2cqp2g3llhr9jl6jj15k0wb5q8n29vqj99xy4p5hqs78jk8g";
   };
 
-  patches = [ ./header-order.patch ];
+  patches = [ ./header-order.patch ./public-buildproject.patch ];
 
   postPatch = ''
     cp campaigns/tutorial-part4.map{,.orig}

--- a/pkgs/games/globulation/public-buildproject.patch
+++ b/pkgs/games/globulation/public-buildproject.patch
@@ -1,0 +1,21 @@
+diff -Nru glob2-0.9.4.4/src/Game.h glob2-0.9.4.4.new/src/Game.h
+--- glob2-0.9.4.4/src/Game.h	2009-08-29 16:39:06.000000000 -0400
++++ glob2-0.9.4.4.new/src/Game.h	2015-08-29 00:59:07.843398596 -0400
+@@ -148,7 +148,7 @@
+ 		TOP_TO_BOTTOM,
+ 		BOTTOM_TO_TOP
+ 	};
+-	
++public:	
+ 	struct BuildProject
+ 	{
+ 		int posX;
+@@ -158,7 +158,7 @@
+ 		int unitWorking;
+ 		int unitWorkingFuture;
+ 	};
+-	
++private:	
+ 	///Initiates Game
+ 	void init(GameGUI *gui, MapEdit* edit);
+ 


### PR DESCRIPTION
The same issue was reported here to Debian:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=746854

Apparently this failure only cropped up with g++-4.9, but looking at
the code I have no idea how it ever worked without this patch.

cc @7c6f434c 
