### PR TITLE
python-packages numba: init at 0.21.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8654,6 +8654,32 @@ let
     };
   };
 
+  numba = buildPythonPackage rec {
+    version = "0.21.0";
+    name = "numba-${version}";
+    
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/n/numba/${name}.tar.gz";
+      sha256 = "1806d2f6ad49ad891e9ac6fed0cc0b0489cbfcd9ba2dc81081c1c30091e77604";
+    };
+    
+    propagatedBuildInputs = with self; [numpy llvmlite argparse] ++ optional (!isPy3k) funcsigs ++ optional (isPy27 || isPy33) singledispatch;
+    # Future work: add Cuda support.
+    #propagatedBuildInputs = with self; [numpy llvmlite argparse pkgs.cudatoolkit6];
+    #buildPhase = ''
+    #  export NUMBAPRO_CUDA_DRIVER=
+    #  export NUMBAPRO_NVVM=${pkgs.cudatoolkit6}
+    #  export NUMBAPRO_LIBDEVICE=
+    #'';
+
+    meta = {
+      homepage = http://numba.pydata.org/;
+      license = licenses.bsd2;
+      description = "Compiling Python code using LLVM";
+      maintainers = with maintainers; [ fridh ];
+    };
+  };
+  
   numexpr = buildPythonPackage rec {
     version = "2.4.3";
     name = "numexpr-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7347,7 +7347,43 @@ let
       description = "A load testing tool";
     };
   };
+  
+  llvmlite = buildPythonPackage rec {
+    name = "llvmlite-${version}";
+    version = "0.7.0";
+    
+    disabled = isPyPy;
+    
+    src = pkgs.fetchurl { 
+      url = "https://pypi.python.org/packages/source/l/llvmlite/${name}.tar.gz";
+      sha256 = "6d780980da05d2d82465991bce42c1b4625018d67feae17c672c6a9d5ad0bb1a";
+    };
 
+    llvm = pkgs.llvm;
+    
+    propagatedBuildInputs = with self; [ llvm ] ++ optional (!isPy34) enum34;
+
+    # Disable static linking
+    # https://github.com/numba/llvmlite/issues/93
+    patchPhase = ''
+      substituteInPlace ffi/Makefile.linux --replace "-static-libstdc++" ""
+    '';
+    # Set directory containing llvm-config binary
+    preConfigure = ''
+      export LLVM_CONFIG=${llvm}/bin/llvm-config
+    '';
+    checkPhase = ''
+      ${self.python.executable} runtests.py
+    '';
+    
+    meta = {
+      description = "A lightweight LLVM python binding for writing JIT compilers";
+      homepage = "http://llvmlite.pydata.org/";
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ fridh ];
+    };
+  };
+  
   lockfile = buildPythonPackage rec {
     name = "lockfile-0.9.1";
 


### PR DESCRIPTION
This is an attempt at packaging numba, a Python JIT using LLVM.
Unfortunately llvmlite, the bindings, seem to segfault.
