### PR TITLE
qt5: embed path to mesa (libGL) in Qt mkspecs file

### DIFF
--- a/pkgs/development/libraries/qt-5/5.3/0014-mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.3/0014-mkspecs-libgl.patch
@@ -1,0 +1,15 @@
+Ensure Qt knows where libGL is.
+
+Author: Bjørn Forsman <bjorn.forsman@gmail.com>
+diff -uNr qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf
+--- qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf	2014-09-11 12:48:07.000000000 +0200
++++ qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf	2015-08-23 13:03:30.617473019 +0200
+@@ -13,7 +13,7 @@
+ QMAKE_INCDIR_X11        =
+ QMAKE_LIBDIR_X11        =
+ QMAKE_INCDIR_OPENGL     =
+-QMAKE_LIBDIR_OPENGL     =
++QMAKE_LIBDIR_OPENGL     = @mesa@/lib
+ QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
+ QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL
+ QMAKE_INCDIR_EGL        =

--- a/pkgs/development/libraries/qt-5/5.3/default.nix
+++ b/pkgs/development/libraries/qt-5/5.3/default.nix
@@ -81,7 +81,8 @@ stdenv.mkDerivation rec {
       (substituteAll { src = ./0011-dlopen-openssl.patch; inherit openssl; })
       (substituteAll { src = ./0012-dlopen-dbus.patch; dbus_libs = dbus; })
       ./0013-qtwebkit-glib-2.44.patch
-    ];
+    ] ++ optional mesaSupported
+      (substituteAll { src = ./0014-mkspecs-libgl.patch; inherit mesa; });
 
   preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/qtbase/lib:$PWD/qtbase/plugins/platforms:$PWD/qttools/lib:$LD_LIBRARY_PATH"

--- a/pkgs/development/libraries/qt-5/5.4/0014-mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.4/0014-mkspecs-libgl.patch
@@ -1,0 +1,15 @@
+Ensure Qt knows where libGL is.
+
+Author: Bjørn Forsman <bjorn.forsman@gmail.com>
+diff -uNr qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf
+--- qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf	2014-09-11 12:48:07.000000000 +0200
++++ qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf	2015-08-23 13:03:30.617473019 +0200
+@@ -13,7 +13,7 @@
+ QMAKE_INCDIR_X11        =
+ QMAKE_LIBDIR_X11        =
+ QMAKE_INCDIR_OPENGL     =
+-QMAKE_LIBDIR_OPENGL     =
++QMAKE_LIBDIR_OPENGL     = @mesa@/lib
+ QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
+ QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL
+ QMAKE_INCDIR_EGL        =

--- a/pkgs/development/libraries/qt-5/5.4/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/5.4/qtbase.nix
@@ -71,7 +71,8 @@ stdenv.mkDerivation {
       (substituteAll { src = ./0011-dlopen-openssl.patch; inherit openssl; })
       (substituteAll { src = ./0012-dlopen-dbus.patch; dbus_libs = dbus; })
       ./0013-xdg_config_dirs.patch
-    ]
+    ] ++ optional mesaSupported
+      (substituteAll { src = ./0014-mkspecs-libgl.patch; inherit mesa; })
     ++ (optional decryptSslTraffic ./0100-ssl.patch);
 
   preConfigure = ''


### PR DESCRIPTION
Fixes this problem, when building apps in QtCreator:

  ...(compile output window)
  g++ -Wl,-rpath,/nix/store/1w7h7p6s2srfw2ady90k7072991lrnpp-qtbase-5.4.2/lib \
      -o qt-test3 main.o mainwindow.o moc_mainwindow.o \
      -L/nix/store/1w7h7p6s2srfw2ady90k7072991lrnpp-qtbase-5.4.2/lib \
      -lQt5Widgets -lQt5Gui -lQt5Core -lGL -lpthread
  /nix/store/b8qhjrwf8sf9ggkjxqqav7f1m6w83bh0-binutils-2.23.1/bin/ld: cannot find -lGL
  collect2: error: ld returned 1 exit status

mesa is already in the closure of Qt, so there is no size increase.

The patch is copied into both qt-5.3 and qt-5.4 directories, like other
patches are.
