### PR TITLE
cvs-fast-export: don't link against librt

### DIFF
--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -30,6 +30,7 @@ mkDerivation rec {
   preBuild = ''
     makeFlagsArray=(
       XML_CATALOG_FILES="${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml ${docbook_xml_xslt}/xml/xsl/docbook/catalog.xml"
+      LIBS=""
       prefix="$out"
     )
   '';


### PR DESCRIPTION
Cherry-picked from pull request #9505, which is currently a WIP. Getting all of `reposurgeon`'s dependencies working on Darwin is going to take some more investigation, but this one in particular is  a straightforward fix for a build failure and should be merged forthwith.
