### PR TITLE
urjtag: new package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -151,6 +151,7 @@
   linus = "Linus Arver <linusarver@gmail.com>";
   lnl7 = "Daiderd Jordan <daiderd@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
+  lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";
   lsix = "Lancelot SIX <lsix@lancelotsix.com>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";

--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, autoconf
+, automake
+, pkgconfig
+, gettext
+, intltool
+, libtool
+, bison
+, flex
+, fetchgit
+, makeWrapper
+, jedecSupport ? false
+, pythonBindings ? false
+, python3 ? null
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.10";
+  name = "urjtag-${version}";
+
+  src = fetchgit {
+    url = "git://git.code.sf.net/p/urjtag/git";
+    rev = "7ba12da7845af7601e014a2a107670edc5d6997d";
+    sha256 = "834401d851728c48f1c055d24dc83b6173c701bf352d3a964ec7ff1aff3abf6a";
+  };
+
+  buildInputs = [ gettext pkgconfig autoconf automake libtool makeWrapper ]
+    ++ stdenv.lib.optional pythonBindings python3;
+
+  configureFlags = ''
+    --prefix=/
+    ${if jedecSupport then "--enable-jedec-exp" else "--disable-jedec-exp"}
+    ${if pythonBindings then "--enable-python" else "--disable-python"}
+  '';
+  preConfigure = "cd urjtag; ./autogen.sh";
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = {
+    description = "Enhanced, modern tool for communicating over JTAG with flash chips, CPUs,and many more";
+    homepage = "http://urjtag.org/";
+    license = with stdenv.lib.licenses; [ gpl2Plus lgpl21Plus ];
+    platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
+    maintainers = with stdenv.lib.maintainers; [ lowfatcomputing ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3453,6 +3453,11 @@ let
 
   uptimed = callPackage ../tools/system/uptimed { };
 
+  urjtag = callPackage ../tools/misc/urjtag {
+    jedecSupport = true;
+    pythonBindings = true;
+  };
+
   urlwatch = callPackage ../tools/networking/urlwatch { };
 
   varnish = callPackage ../servers/varnish { };


### PR DESCRIPTION
- Added UrJTAG package
- Added some "use flags" http://blog.lastlog.de/posts/useflags_in_nixos/ (but not yet all possible flags)
- Added myself to maintainers.nix

First package, I'm new to NixOS (coming from ArchLinux).
UrJTAG tends to have very infrequent releases which lag far behind the vcs activity. Is there a way to update to the latest git commit hash without submitting a new merge request here?
