### PR TITLE
expect: fix Darwin linkage

### DIFF
--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -23,19 +23,26 @@ stdenv.mkDerivation {
     "--exec-prefix=\${out}"
   ];
 
-  postInstall = ''
-    for i in $out/bin/*; do
-      wrapProgram $i \
-        --prefix PATH : "${tcl}/bin" \
-        --prefix TCLLIBPATH ' ' $out/lib/*
-    done
-  '';
+  postInstall =
+    let darwinFlags =
+      if stdenv.isDarwin
+      then "--prefix DYLD_LIBRARY_PATH : $out/lib/expect${version}"
+      else "";
+    in ''
+      for i in $out/bin/*; do
+        wrapProgram $i \
+          --prefix PATH : "${tcl}/bin" \
+          --prefix TCLLIBPATH ' ' $out/lib/* \
+          ${darwinFlags}
+      done
+    ''
+  ;
 
   meta = with stdenv.lib; {
     description = "A tool for automating interactive applications";
     homepage = http://expect.nist.gov/;
     license = "Expect";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ wkennington ];
   };
 }


### PR DESCRIPTION
`expect`'s build system doesn't seem to provide the proper linker flags
for the expect programs to be able to find `libexpect` on Darwin. (Stuff
like this should really just use `libtool`. *sigh*). Setting
`DYLD_LIBRARY_PATH` is an inelegant hack, but it gets the job done
without risking affecting other platforms.

cc @wkennington
