### PR TITLE
pythonPackages.gevent: works just fine on Darwin

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6255,7 +6255,7 @@ let
       description = "Coroutine-based networking library";
       homepage = http://www.gevent.org/;
       license = licenses.mit;
-      platforms = platforms.linux;
+      platforms = platforms.unix;
       maintainers = with maintainers; [ bjornfor ];
     };
   };


### PR DESCRIPTION
Closes #8569, #7275, and #5782. Obviates #8730. As asserted by
@lethalman and observed by @aflatter and @ecyrb, this package
is currently building just fine on Darwin.

cc @bjornfor
