### PR TITLE
haskell-generic-builder: stop pre-pending "haskell-" to package names

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -130,7 +130,7 @@ in
 assert allPkgconfigDepends != [] -> pkgconfig != null;
 
 stdenv.mkDerivation ({
-  name = "${optionalString (hasActiveLibrary && pname != "ghcjs") "haskell-"}${pname}-${version}";
+  name = "${pname}-${version}";
 
   pos = builtins.unsafeGetAttrPos "pname" args;
 


### PR DESCRIPTION
A derivation of the Hackage package "foo" is called "haskell-foo" if it is a
library, but only "foo" if it is an executable (without a library). This
distinction used to be fine when Haskell packages where visible to operations
like "nix-env -qa" or "nix-env -i", but after our switch to Haskell NG it has
no more purpose. Consequently, this patch removes the name prefix from all
Haskell packages -- every Haskell package is now called exactly like it's
called on Hackage.
