### PR TITLE
networkmanager: build with dnsmasq

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-distro=exherbo"
     "--with-dhclient=${dhcp}/bin/dhclient"
+    "--with-dnsmasq=${dnsmasq}/bin/dnsmasq"
     # Upstream prefers dhclient, so don't add dhcpcd to the closure
     #"--with-dhcpcd=${dhcpcd}/sbin/dhcpcd"
     "--with-dhcpcd=no"


### PR DESCRIPTION
Networkmanager requires dnsmasq for network sharing
