### PR TITLE
policycoreutils: fix i686-linux compilation error

### DIFF
--- a/pkgs/os-specific/linux/policycoreutils/default.nix
+++ b/pkgs/os-specific/linux/policycoreutils/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0y9l9k60iy21hj0lcvfdfxs1fxydg6d3pxp9rhy7hwr4y5vgh6dq";
   };
 
+  patches = [ ./fix-printf-type.patch ];
+
   postPatch = ''
     # Fix references to libsepol.a
     find . -name Makefile -exec sed -i 's,[^ ]*/libsepol.a,${libsepol}/lib/libsepol.a,g' {} \;

--- a/pkgs/os-specific/linux/policycoreutils/fix-printf-type.patch
+++ b/pkgs/os-specific/linux/policycoreutils/fix-printf-type.patch
@@ -1,0 +1,12 @@
+diff -Nru policycoreutils-2.4/setfiles/restore.c policycoreutils-2.4.new/setfiles/restore.c
+--- policycoreutils-2.4/setfiles/restore.c	2015-02-02 09:38:10.000000000 -0500
++++ policycoreutils-2.4.new/setfiles/restore.c	2015-08-29 20:44:13.693023222 -0400
+@@ -118,7 +118,7 @@
+ 		r_opts->count++;
+ 		if (r_opts->count % STAR_COUNT == 0) {
+ 			if (r_opts->progress == 1) {
+-				fprintf(stdout, "\r%luk", (size_t) r_opts->count / STAR_COUNT );
++				fprintf(stdout, "\r%zuk", (size_t) r_opts->count / STAR_COUNT );
+ 			} else {
+ 				if (r_opts->nfile > 0) {
+ 					progress = (r_opts->count < r_opts->nfile) ? (100.0 * r_opts->count / r_opts->nfile) : 100;


### PR DESCRIPTION
This adds a patch to quiet a compiler warning which would be harmless except that it breaks the build due to use of `-Werror`. See http://hydra.nixos.org/build/25151888/nixlog/1
