### PR TITLE
scikit-learn: fix i686 build failures

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12460,6 +12460,13 @@ let
     buildInputs = with self; [ nose pillow pkgs.gfortran pkgs.glibcLocales ];
     propagatedBuildInputs = with self; [ numpy scipy pkgs.openblas ];
 
+    # doctests fail on i686
+    # https://github.com/NixOS/nixpkgs/issues/9472
+    # https://github.com/scikit-learn/scikit-learn/issues/5177
+    patchPhase = ''
+      substituteInPlace setup.cfg --replace 'with-doctest = 1' 'with-doctest = 0'
+    '';
+
     buildPhase = ''
       ${self.python.executable} setup.py build_ext -i --fcompiler='gnu95'
     '';


### PR DESCRIPTION
Currently i686 builds fail because a couple of doctests fail.
The values are correct, but the dtype is missing.
This commit disables doctests.

This patch should also be applied to the 15.09 branch.
#9471 #9472

I built locally on x86-64, but couldn't tell whether the doctests really were disabled or not.
