### PR TITLE
lxd: fix to include lxd-images

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1614,7 +1614,11 @@ let
     buildInputs = [
       gettext-go websocket crypto log15 go-lxc yaml-v2 tomb protobuf pongo2
       lxd-go-systemd go-uuid tablewriter golang-petname mux go-sqlite3 goproxy
+      pkgs.python3
     ];
+    postInstall = ''
+      cp go/src/$goPackagePath/scripts/lxd-images $bin/bin
+    '';
   };
 
   mapstructure = buildFromGitHub {


### PR DESCRIPTION
Is using `nativeBuildInputs` for ensuring availability of python3 at runtime correct?

This change is tested locally.

cc @wkennington 
