### PR TITLE
go: 1.5 darwin

### DIFF
--- a/pkgs/development/compilers/go/1.5.nix
+++ b/pkgs/development/compilers/go/1.5.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation rec {
   patches = [
     ./cacert-1.5.patch
     ./remove-tools-1.5.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    ./assume-darwin-amd64-1.5.patch
   ];
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";

--- a/pkgs/development/compilers/go/1.5.nix
+++ b/pkgs/development/compilers/go/1.5.nix
@@ -73,6 +73,11 @@ stdenv.mkDerivation rec {
     sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
 
     touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+
+    # Hack, dsymutil is an empty shim in the Darwin stdenv but we need it here
+    mkdir tmp
+    ln -s /usr/bin/dsymutil tmp/dsymutil
+    export PATH="$PWD/tmp:$PATH"
   '';
 
   patches = [

--- a/pkgs/development/compilers/go/assume-darwin-amd64-1.5.patch
+++ b/pkgs/development/compilers/go/assume-darwin-amd64-1.5.patch
@@ -1,0 +1,33 @@
+diff --git a/src/cmd/dist/util.go b/src/cmd/dist/util.go
+index f13210f..8099a26 100644
+--- a/src/cmd/dist/util.go
++++ b/src/cmd/dist/util.go
+@@ -404,9 +404,9 @@ func main() {
+ 	switch gohostos {
+ 	case "darwin":
+ 		// Even on 64-bit platform, darwin uname -m prints i386.
+-		if strings.Contains(run("", CheckExit, "sysctl", "machdep.cpu.extfeatures"), "EM64T") {
+-			gohostarch = "amd64"
+-		}
++		// if strings.Contains(run("", CheckExit, "sysctl", "machdep.cpu.extfeatures"), "EM64T") {
++		gohostarch = "amd64"
++		// }
+ 	case "solaris":
+ 		// Even on 64-bit platform, solaris uname -m prints i86pc.
+ 		out := run("", CheckExit, "isainfo", "-n")
+diff --git a/src/race.bash b/src/race.bash
+index e091736..ee963e7 100755
+--- a/src/race.bash
++++ b/src/race.bash
+@@ -16,9 +16,9 @@ function usage {
+ case $(uname) in
+ "Darwin")
+ 	# why Apple? why?
+-	if sysctl machdep.cpu.extfeatures | grep -qv EM64T; then
++	# if sysctl machdep.cpu.extfeatures | grep -qv EM64T; then
+ 		usage
+-	fi 
++	# fi 
+ 	;;
+ "Linux")
+ 	if [ $(uname -m) != "x86_64" ]; then


### PR DESCRIPTION
Fixes build issues on Darwin.

I would prefer to keep CGO enabled but it seems like go 1.5 now depends on dsymutil and the Darwin stdenv provides a [dummy version of it](https://github.com/NixOS/nixpkgs/blob/fa9c81f69468098e0dd0ca79ea4d2ef74ec6bc0c/pkgs/os-specific/darwin/binutils/default.nix#L15.

Related issues:
- https://github.com/NixOS/nixpkgs/issues/9437
- https://github.com/golang/go/issues/11887
- https://github.com/golang/go/issues/11994
