### PR TITLE
fmit: add missing mesa dependency

### DIFF
--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -1,6 +1,6 @@
 # FIXME: upgrading qt5Full (Qt 5.3) to qt5.{base,multimedia} (Qt 5.4) breaks
 # the default Qt audio capture source!
-{ stdenv, fetchFromGitHub, fftw, freeglut, qt5Full
+{ stdenv, fetchFromGitHub, fftw, freeglut, qt5Full, mesa
 , alsaSupport ? false, alsaLib ? null
 , jackSupport ? false, libjack2 ? null }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     owner = "gillesdegottex";
   };
 
-  buildInputs = [ fftw freeglut qt5Full ]
+  buildInputs = [ fftw freeglut qt5Full mesa ]
     ++ stdenv.lib.optional alsaSupport [ alsaLib ]
     ++ stdenv.lib.optional jackSupport [ libjack2 ];
 


### PR DESCRIPTION
This fixes the build error seen in http://hydra.nixos.org/build/25291508/nixlog/2.

cc @nckx
