### PR TITLE
makeWrapper: accept `--argv0` flag

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -99,6 +99,7 @@ stdenv.mkDerivation rec {
     '' + lib.optionalString enableGTK3
     ''
       wrapProgram "$out/bin/firefox" \
+        --argv0 "$out/bin/firefox" \  # argv[0] must point to firefox itself
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:" \
         --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
     '';

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -2,7 +2,7 @@ makeWrapper() {
     local original=$1
     local wrapper=$2
     local params varName value command separator n fileNames
-    local flagsBefore flags
+    local argv0 flagsBefore flags
 
     mkdir -p "$(dirname $wrapper)"
 
@@ -68,11 +68,17 @@ makeWrapper() {
             n=$((n + 1))
             flagsBefore="$flagsBefore $flags"
         fi
+
+        if test "$p" = "--argv0"; then
+            argv0=${params[$((n + 1))]}
+            n=$((n + 1))
+        fi
     done
 
     # Note: extraFlagsArray is an array containing additional flags
     # that may be set by --run actions.
-    echo exec -a '"$0"' "$original" $flagsBefore '"${extraFlagsArray[@]}"' '"$@"' >> $wrapper
+    echo exec ${argv0:+-a $argv0} "$original" \
+         $flagsBefore '"${extraFlagsArray[@]}"' '"$@"' >> $wrapper
 
     chmod +x $wrapper
 }
@@ -98,5 +104,5 @@ wrapProgram() {
     local prog="$1"
     local hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
     mv $prog $hidden
-    makeWrapper $hidden $prog "$@"
+    makeWrapper $hidden $prog --argv0 '"$0"' "$@"
 }


### PR DESCRIPTION
This flag allows setting the argv[0] parameter given to the wrapped executable, in case the new argv[0] passthrough functionality is not desired. The argv[0] parameter can be given explicitly, or the old behavior can be recovered by passing an empty argv[0], i.e. `makeWrapper --argv0 "" ...`.

This would rebuild 7514 packages.

We need this for a proper fix for a Conkeror bug. There is a workaround which I will apply if this patch is rejected from the `release-15.09` branch. If accepted, I would also merge this into master.
