### PR TITLE
haskell-lucid: disable tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -430,6 +430,7 @@ self: super: {
   language-slice = dontCheck super.language-slice;
   lensref = dontCheck super.lensref;
   liquidhaskell = dontCheck super.liquidhaskell;
+  lucid = dontCheck super.lucid; #https://github.com/chrisdone/lucid/issues/25
   lvmrun = dontCheck super.lvmrun;
   memcache = dontCheck super.memcache;
   milena = dontCheck super.milena;


### PR DESCRIPTION
They buggily make assumptions about the order in which strings appear in a hash table and thereby fail on `i686-linux`. See http://hydra.nixos.org/build/25132604/log/raw and https://github.com/chrisdone/lucid/issues/25.
