### PR TITLE
accelio: fix i686-linux build

### DIFF
--- a/pkgs/development/libraries/accelio/default.nix
+++ b/pkgs/development/libraries/accelio/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "172frqk2n43g0arhazgcwfvj0syf861vdzdpxl7idr142bb0ykf7";
   };
 
+  patches = [ ./fix-printfs.patch ];
+
   postPatch = ''
     # Don't build broken examples
     sed -i '/AC_CONFIG_SUBDIRS(\[\(examples\|tests\).*\/kernel/d' configure.ac

--- a/pkgs/development/libraries/accelio/default.nix
+++ b/pkgs/development/libraries/accelio/default.nix
@@ -18,9 +18,6 @@ stdenv.mkDerivation rec {
   patches = [ ./fix-printfs.patch ];
 
   postPatch = ''
-    # Don't build broken examples
-    sed -i '/AC_CONFIG_SUBDIRS(\[\(examples\|tests\).*\/kernel/d' configure.ac
-
     # Allow the installation of xio kernel headers
     sed -i 's,/opt/xio,''${out},g' src/kernel/xio/Makefile.in
 
@@ -28,6 +25,8 @@ stdenv.mkDerivation rec {
     sed -i '\,/etc/ld.so.conf.d/libxio.conf,d' src/usr/Makefile.am
     sed -i '\,/sbin/ldconfig,d' src/usr/Makefile.am
   '';
+
+  doCheck = true;
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libevent ];

--- a/pkgs/development/libraries/accelio/fix-printfs.patch
+++ b/pkgs/development/libraries/accelio/fix-printfs.patch
@@ -1,0 +1,615 @@
+diff -rup accelio/benchmarks/usr/xio_perftest/xio_perftest_client.c accelio.new/benchmarks/usr/xio_perftest/xio_perftest_client.c
+--- accelio/benchmarks/usr/xio_perftest/xio_perftest_client.c	2015-09-03 19:36:25.610337514 -0400
++++ accelio.new/benchmarks/usr/xio_perftest/xio_perftest_client.c	2015-09-03 19:59:13.258697472 -0400
+@@ -246,7 +246,7 @@ static void *worker_thread(void *data)
+ 		} else {
+ 			vmsg_sglist_set_nents(&msg->out, 0);
+ 		}
+-		msg->user_context = (void *)get_cycles();
++		msg->user_context = (void *)(intptr_t)get_cycles();
+ 		/* send first message */
+ 		if (xio_send_request(tdata->conn, msg) == -1) {
+ 			if (xio_errno() != EAGAIN)
+@@ -330,7 +330,7 @@ static int on_response(struct xio_sessio
+ {
+ 	struct thread_data  *tdata = (struct thread_data *)cb_user_context;
+ 
+-	cycles_t rtt = (get_cycles()-(cycles_t)msg->user_context);
++	cycles_t rtt = (get_cycles()-(cycles_t)(intptr_t)msg->user_context);
+ 
+ 	if (tdata->do_stat) {
+ 		if (rtt > tdata->stat.max_rtt)
+@@ -358,7 +358,7 @@ static int on_response(struct xio_sessio
+ 	msg->in.header.iov_len = 0;
+ 	vmsg_sglist_set_nents(&msg->in, 0);
+ 
+-	msg->user_context = (void *)get_cycles();
++	msg->user_context = (void *)(intptr_t)get_cycles();
+ 	if (xio_send_request(tdata->conn, msg) == -1) {
+ 		if (xio_errno() != EAGAIN)
+ 			printf("**** [%p] Error - xio_send_request " \
+@@ -559,7 +559,7 @@ int run_client_test(struct perf_paramete
+ 		       sess_data.min_lat_us,
+ 		       sess_data.max_lat_us);
+ 		if (fd)
+-			fprintf(fd, "%lu, %d, %lu, %.2lf, %.2lf\n",
++			fprintf(fd, "%" PRIu64 ", %d, %" PRIu64 ", %.2lf, %.2lf\n",
+ 				data_len,
+ 				threads_iter,
+ 				sess_data.tps,
+diff -rup accelio/benchmarks/usr/xio_perftest/xio_perftest_parameters.h accelio.new/benchmarks/usr/xio_perftest/xio_perftest_parameters.h
+--- accelio/benchmarks/usr/xio_perftest/xio_perftest_parameters.h	2015-09-03 19:36:25.610337514 -0400
++++ accelio.new/benchmarks/usr/xio_perftest/xio_perftest_parameters.h	2015-09-03 19:57:30.856215123 -0400
+@@ -90,7 +90,7 @@ typedef enum { READ, WRITE} Verb;
+ /* The format of the results */
+ #define RESULT_FMT		" #bytes     #threads   #TPS       BW average[MBps]   Latency average[usecs]   Latency low[usecs]   Latency peak[usecs]\n"
+ /* Result print format */
+-#define REPORT_FMT		" %-7lu     %-2d         %-9.2lu	  %-9.2lf     %-9.2lf                  %-9.2lf              %-9.2lf\n"
++#define REPORT_FMT		" %-7" PRIu64 "     %-2d         %-9.2" PRIu64 "	  %-9.2lf     %-9.2lf                  %-9.2lf              %-9.2lf\n"
+ 
+ 
+ struct perf_parameters {
+diff -rup accelio/examples/usr/hello_world_iov/xio_client.c accelio.new/examples/usr/hello_world_iov/xio_client.c
+--- accelio/examples/usr/hello_world_iov/xio_client.c	2015-09-03 19:36:25.611337519 -0400
++++ accelio.new/examples/usr/hello_world_iov/xio_client.c	2015-09-03 19:42:19.983984370 -0400
+@@ -224,7 +224,7 @@ static void process_response(struct sess
+ 				len = 64;
+ 			tmp = str[len];
+ 			str[len] = '\0';
+-			printf("message header : [%lu] - %s\n",
++			printf("message header : [%" PRIu64 "] - %s\n",
+ 			       (rsp->request->sn + 1), str);
+ 			str[len] = tmp;
+ 		}
+@@ -236,7 +236,7 @@ static void process_response(struct sess
+ 					len = 64;
+ 				tmp = str[len];
+ 				str[len] = '\0';
+-				printf("message data: [%lu][%d][%zd] - %s\n",
++				printf("message data: [%" PRIu64 "][%d][%zd] - %s\n",
+ 				       (rsp->request->sn + 1), i, sglist[i].iov_len, str);
+ 				str[len] = tmp;
+ 			}
+diff -rup accelio/examples/usr/hello_world_iov/xio_server.c accelio.new/examples/usr/hello_world_iov/xio_server.c
+--- accelio/examples/usr/hello_world_iov/xio_server.c	2015-09-03 19:36:25.611337519 -0400
++++ accelio.new/examples/usr/hello_world_iov/xio_server.c	2015-09-03 19:43:07.353204184 -0400
+@@ -203,7 +203,7 @@ static void process_request(struct serve
+ 				len = 64;
+ 			tmp = str[len];
+ 			str[len] = '\0';
+-			printf("message header : [%lu] - %s\n",
++			printf("message header : [%" PRIu64 "] - %s\n",
+ 			       (req->sn + 1), str);
+ 			str[len] = tmp;
+ 		}
+@@ -215,7 +215,7 @@ static void process_request(struct serve
+ 					len = 64;
+ 				tmp = str[len];
+ 				str[len] = '\0';
+-				printf("message data: [%lu][%d][%zd] - %s\n",
++				printf("message data: [%" PRIu64 "][%d][%zd] - %s\n",
+ 				       (req->sn + 1), i, sglist[i].iov_len, str);
+ 				str[len] = tmp;
+ 			}
+@@ -360,11 +360,11 @@ static int on_msg_error(struct xio_sessi
+ 	struct server_data *sdata = (struct server_data *)cb_user_context;
+ 
+ 	if (direction == XIO_MSG_DIRECTION_OUT) {
+-		printf("**** [%p] message %lu failed. reason: %s\n",
++		printf("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, msg->sn, xio_strerror(error));
+ 	} else {
+ 		xio_release_response(msg);
+-		printf("**** [%p] message %lu failed. reason: %s\n",
++		printf("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, msg->request->sn, xio_strerror(error));
+ 	}
+ 
+diff -rup accelio/examples/usr/hello_world_libevent/xio_client.c accelio.new/examples/usr/hello_world_libevent/xio_client.c
+--- accelio/examples/usr/hello_world_libevent/xio_client.c	2015-09-03 19:36:25.612337524 -0400
++++ accelio.new/examples/usr/hello_world_libevent/xio_client.c	2015-09-03 19:43:32.748322028 -0400
+@@ -87,7 +87,7 @@ static void process_response(struct sess
+ {
+ 	if (++session_data->cnt == PRINT_COUNTER) {
+ 		((char *)(rsp->in.header.iov_base))[rsp->in.header.iov_len] = 0;
+-		printf("message: [%lu] - %s\n",
++		printf("message: [%" PRIu64 "] - %s\n",
+ 		       (rsp->request->sn + 1), (char *)rsp->in.header.iov_base);
+ 		session_data->cnt = 0;
+ 	}
+diff -rup accelio/examples/usr/hello_world_libevent/xio_server.c accelio.new/examples/usr/hello_world_libevent/xio_server.c
+--- accelio/examples/usr/hello_world_libevent/xio_server.c	2015-09-03 19:36:25.612337524 -0400
++++ accelio.new/examples/usr/hello_world_libevent/xio_server.c	2015-09-03 19:43:50.556404665 -0400
+@@ -82,7 +82,7 @@ static void process_request(struct serve
+ 				len = 64;
+ 			tmp = str[len];
+ 			str[len] = '\0';
+-			printf("message header : [%lu] - %s\n",
++			printf("message header : [%" PRIu64 "] - %s\n",
+ 			       (req->sn + 1), str);
+ 			str[len] = tmp;
+ 		}
+@@ -94,7 +94,7 @@ static void process_request(struct serve
+ 					len = 64;
+ 				tmp = str[len];
+ 				str[len] = '\0';
+-				printf("message data: [%lu][%d][%d] - %s\n",
++				printf("message data: [%" PRIu64 "][%d][%d] - %s\n",
+ 				       (req->sn + 1), i, len, str);
+ 				str[len] = tmp;
+ 			}
+diff -rup accelio/examples/usr/hello_world_mt/xio_mt_client.c accelio.new/examples/usr/hello_world_mt/xio_mt_client.c
+--- accelio/examples/usr/hello_world_mt/xio_mt_client.c	2015-09-03 19:36:25.611337519 -0400
++++ accelio.new/examples/usr/hello_world_mt/xio_mt_client.c	2015-09-03 19:41:13.493675827 -0400
+@@ -40,6 +40,7 @@
+ #include <string.h>
+ #include <inttypes.h>
+ #include <sched.h>
++#include <inttypes.h>
+ 
+ #include "libxio.h"
+ 
+@@ -133,7 +134,7 @@ static void process_response(struct thre
+ {
+ 	if (++tdata->cnt == PRINT_COUNTER) {
+ 		((char *)(rsp->in.header.iov_base))[rsp->in.header.iov_len] = 0;
+-		printf("thread [%d] - tid:%p  - message: [%lu] - %s\n",
++		printf("thread [%d] - tid:%p  - message: [%" PRIu64 "] - %s\n",
+ 		       tdata->affinity,
+ 		      (void *)pthread_self(),
+ 		       (rsp->request->sn + 1), (char *)rsp->in.header.iov_base);
+diff -rup accelio/examples/usr/hello_world_mt/xio_mt_server.c accelio.new/examples/usr/hello_world_mt/xio_mt_server.c
+--- accelio/examples/usr/hello_world_mt/xio_mt_server.c	2015-09-03 19:36:25.611337519 -0400
++++ accelio.new/examples/usr/hello_world_mt/xio_mt_server.c	2015-09-03 19:41:31.730760455 -0400
+@@ -104,7 +104,7 @@ static void process_request(struct threa
+ 			    struct xio_msg *req)
+ {
+ 	if (++tdata->cnt == PRINT_COUNTER) {
+-		printf("thread [%d] tid:%p - message: [%lu] - %s\n",
++		printf("thread [%d] tid:%p - message: [%" PRIu64 "] - %s\n",
+ 		       tdata->affinity,
+ 		       (void *)pthread_self(),
+ 		       (req->sn + 1), (char *)req->in.header.iov_base);
+diff -rup accelio/regression/usr/reg_basic_mt/reg_basic_mt_client.c accelio.new/regression/usr/reg_basic_mt/reg_basic_mt_client.c
+--- accelio/regression/usr/reg_basic_mt/reg_basic_mt_client.c	2015-09-03 19:36:25.603337482 -0400
++++ accelio.new/regression/usr/reg_basic_mt/reg_basic_mt_client.c	2015-09-03 20:00:15.169989095 -0400
+@@ -416,11 +416,11 @@ static int on_msg_error(struct xio_sessi
+ 	struct thread_data	*tdata		= conn_entry->tdata;
+ 
+ 	if (direction == XIO_MSG_DIRECTION_OUT) {
+-		DEBUG("**** [%p] message %lu failed. reason: %s\n",
++		DEBUG("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, req->sn, xio_strerror(error));
+ 	} else {
+ 		xio_release_response(req);
+-		DEBUG("**** [%p] message %lu failed. reason: %s\n",
++		DEBUG("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, req->request->sn, xio_strerror(error));
+ 	}
+ 	obj_pool_put(tdata->req_pool, req);
+diff -rup accelio/src/tools/usr/xio_if_numa_cpus.c accelio.new/src/tools/usr/xio_if_numa_cpus.c
+--- accelio/src/tools/usr/xio_if_numa_cpus.c	2015-09-03 19:36:25.603337482 -0400
++++ accelio.new/src/tools/usr/xio_if_numa_cpus.c	2015-09-03 19:40:06.398364476 -0400
+@@ -43,6 +43,7 @@
+ #include <net/if.h>
+ #include <stdio.h>
+ #include <numa.h>
++#include <inttypes.h>
+ 
+ #define cpusmask_test_bit(nr, addr)	(*(addr) & (1ULL << (nr)))
+ #define cpusmask_set_bit(nr, addr)	(*(addr) |=  (1ULL << (nr)))
+@@ -244,7 +245,7 @@ int main(int argc, char *argv[])
+ 		}
+ 		intf_cpusmask_str(cpusmask, cpusnum, cpus_str);
+ 
+-		printf("%-10s %-16s %-30s %-5d 0x%-8lx %-4s[%d] - %s\n",
++		printf("%-10s %-16s %-30s %-5d 0x%-8" PRIx64 " %-4s[%d] - %s\n",
+ 		       ifa->ifa_name, host, flags, numa_node, cpusmask,
+ 		       "cpus",  cpusnum, cpus_str);
+ 	}
+diff -rup accelio/src/tools/usr/xio_mem_usage.c accelio.new/src/tools/usr/xio_mem_usage.c
+--- accelio/src/tools/usr/xio_mem_usage.c	2015-09-03 19:36:25.603337482 -0400
++++ accelio.new/src/tools/usr/xio_mem_usage.c	2015-09-03 19:38:57.596044838 -0400
+@@ -73,7 +73,7 @@
+ 	while (i++ < 48) { \
+ 		printf("."); \
+ 	} \
+-	printf(" %6lu\n", sizeof(type)); \
++	printf(" %zu\n", sizeof(type)); \
+ }
+ 
+ int main(int argc, char **argv)
+diff -rup accelio/tests/portable/direct_rdma_test/xio_rdma_common.c accelio.new/tests/portable/direct_rdma_test/xio_rdma_common.c
+--- accelio/tests/portable/direct_rdma_test/xio_rdma_common.c	2015-09-03 19:36:25.610337514 -0400
++++ accelio.new/tests/portable/direct_rdma_test/xio_rdma_common.c	2015-09-03 19:56:25.521908028 -0400
+@@ -90,7 +90,7 @@ static int publish_our_buffer(struct xio
+ 	 * this flag must be on */
+ 	rsp->flags = XIO_MSG_FLAG_IMM_SEND_COMP;
+ 
+-	rdma_test_buf.addr = (uint64_t)rdma_reg_mem.addr;
++	rdma_test_buf.addr = (intptr_t)rdma_reg_mem.addr;
+ 	rdma_test_buf.length = rdma_reg_mem.length;
+ 	rdma_test_buf.rkey = xio_lookup_rkey_by_response(&rdma_reg_mem, rsp);
+ 
+diff -rup accelio/tests/usr/hello_test/xio_client.c accelio.new/tests/usr/hello_test/xio_client.c
+--- accelio/tests/usr/hello_test/xio_client.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test/xio_client.c	2015-09-03 19:45:43.055926711 -0400
+@@ -181,13 +181,13 @@ static void process_response(struct test
+ 
+ 		double txbw = (1.0*pps*test_params->stat.txlen/ONE_MB);
+ 		double rxbw = (1.0*pps*test_params->stat.rxlen/ONE_MB);
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "TX %.2f MB/s, RX: %.2f MB/s, length: TX: %zd B, RX: %zd B\n",
+ 		       pps, txbw, rxbw,
+ 		       test_params->stat.txlen, test_params->stat.rxlen);
+ 		get_time(timeb, 40);
+ 
+-		printf("**** [%s] - message [%zd] %s - %s\n",
++		printf("**** [%s] - message [%" PRIu64 "] %s - %s\n",
+ 		       timeb, (rsp->request->sn + 1),
+ 		       (char *)rsp->in.header.iov_base,
+ 		       (char *)(inents > 0 ? isglist[0].iov_base : NULL));
+@@ -212,8 +212,8 @@ static int on_session_event(struct xio_s
+ 
+ 	switch (event_data->event) {
+ 	case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
+-		printf("nsent:%lu, nrecv:%lu, " \
+-		       "delta:%lu\n",
++		printf("nsent:%" PRIu64 ", nrecv:%" PRIu64 ", " \
++		       "delta:%" PRIu64 "\n",
+ 		       test_params->nsent, test_params->nrecv,
+ 		       test_params->nsent-test_params->nrecv);
+ 
+@@ -370,11 +370,11 @@ static int on_msg_error(struct xio_sessi
+ 	struct test_params *test_params = (struct test_params *)cb_user_context;
+ 
+ 	if (direction == XIO_MSG_DIRECTION_OUT) {
+-		printf("**** [%p] message %lu failed. reason: %s\n",
++		printf("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, msg->sn, xio_strerror(error));
+ 	} else {
+ 		xio_release_response(msg);
+-		printf("**** [%p] message %lu failed. reason: %s\n",
++		printf("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, msg->request->sn, xio_strerror(error));
+ 	}
+ 
+diff -rup accelio/tests/usr/hello_test/xio_server.c accelio.new/tests/usr/hello_test/xio_server.c
+--- accelio/tests/usr/hello_test/xio_server.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test/xio_server.c	2015-09-03 19:46:35.777171360 -0400
+@@ -112,7 +112,7 @@ static void process_request(struct xio_m
+ 	if (++cnt == PRINT_COUNTER) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&msg->in);
+ 
+-		printf("**** message [%lu] %s - %s\n",
++		printf("**** message [%" PRIu64 "] %s - %s\n",
+ 		       (msg->sn+1),
+ 		       (char *)msg->in.header.iov_base,
+ 		       (char *)sglist[0].iov_base);
+@@ -146,8 +146,8 @@ static int on_session_event(struct xio_s
+ 		break;
+ 	case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
+ 		if (event_data->reason != XIO_E_SESSION_REJECTED) {
+-			printf("last sent:%lu, last comp:%lu, " \
+-			       "delta:%lu\n",
++			printf("last sent:%" PRIu64 ", last comp:%" PRIu64 ", " \
++			       "delta:%" PRIu64 "\n",
+ 			       test_params->nsent,  test_params->ncomp,
+ 			       test_params->nsent-test_params->ncomp);
+ 			test_params->connection = NULL;
+@@ -257,7 +257,7 @@ static int on_msg_error(struct xio_sessi
+ {
+ 	struct test_params *test_params = (struct test_params *)cb_user_context;
+ 
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->request->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(test_params->pool, msg);
+diff -rup accelio/tests/usr/hello_test_bidi/xio_bidi_client.c accelio.new/tests/usr/hello_test_bidi/xio_bidi_client.c
+--- accelio/tests/usr/hello_test_bidi/xio_bidi_client.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test_bidi/xio_bidi_client.c	2015-09-03 19:49:10.164887785 -0400
+@@ -114,7 +114,7 @@ static void process_request(struct xio_m
+ 	if (++cnt == print_counter) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&req->in);
+ 
+-		printf("**** request [%lu] %s - %s\n",
++		printf("**** request [%" PRIu64 "] %s - %s\n",
+ 		       (req->sn+1),
+ 		       (char *)req->in.header.iov_base,
+ 		       (char *)sglist[0].iov_base);
+@@ -171,11 +171,11 @@ static void process_response(struct xio_
+ 		double txbw = (1.0*pps*txlen/ONE_MB);
+ 		double rxbw = (1.0*pps*rxlen/ONE_MB);
+ 
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "TX %.2f MB/s, RX: %.2f MB/s, length: TX: %zd B, RX: %zd B\n",
+ 		       pps, txbw, rxbw, txlen, rxlen);
+ 		get_time(timeb, 40);
+-		printf("**** [%s] - response [%lu] %s - %s\n",
++		printf("**** [%s] - response [%" PRIu64 "] %s - %s\n",
+ 		       timeb, (rsp->request->sn + 1),
+ 		       (char *)rsp->in.header.iov_base,
+ 		       (char *)(inents > 0 ? isglist[0].iov_base : NULL));
+@@ -357,7 +357,7 @@ static int on_msg_error(struct xio_sessi
+ {
+ 	switch (msg->type) {
+ 	case XIO_MSG_TYPE_REQ:
+-		printf("**** [%p] message [%lu] failed. reason: %s\n",
++		printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 		       session, msg->sn, xio_strerror(error));
+ 		msg_pool_put(pool, msg);
+ 		switch (error) {
+@@ -369,7 +369,7 @@ static int on_msg_error(struct xio_sessi
+ 		};
+ 		break;
+ 	case XIO_MSG_TYPE_RSP:
+-		printf("**** [%p] message [%lu] failed. reason: %s\n",
++		printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 		       session, msg->request->sn, xio_strerror(error));
+ 		/* message is no longer needed */
+ 		switch (error) {
+diff -rup accelio/tests/usr/hello_test_bidi/xio_bidi_server.c accelio.new/tests/usr/hello_test_bidi/xio_bidi_server.c
+--- accelio/tests/usr/hello_test_bidi/xio_bidi_server.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test_bidi/xio_bidi_server.c	2015-09-03 19:49:52.860085909 -0400
+@@ -143,11 +143,11 @@ static void process_response(struct xio_
+ 		double txbw = (1.0*pps*txlen/ONE_MB);
+ 		double rxbw = (1.0*pps*rxlen/ONE_MB);
+ 
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "TX %.2f MB/s, RX: %.2f MB/s, length: TX: %zd B, RX: %zd B\n",
+ 		       pps, txbw, rxbw, txlen, rxlen);
+ 		get_time(timeb, 40);
+-		printf("**** [%s] - response complete [%lu] %s - %s\n",
++		printf("**** [%s] - response complete [%" PRIu64 "] %s - %s\n",
+ 		       timeb, (rsp->request->sn + 1),
+ 		       (char *)rsp->in.header.iov_base,
+ 		       (char *)(inents > 0 ? isglist[0].iov_base : NULL));
+@@ -171,7 +171,7 @@ static void process_request(struct xio_m
+ 	if (++cnt == print_counter) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&req->in);
+ 
+-		printf("**** request complete [%lu] %s - %s [%zd]\n",
++		printf("**** request complete [%" PRIu64 "] %s - %s [%zd]\n",
+ 		       (req->sn+1),
+ 		       (char *)req->in.header.iov_base,
+ 		       (char *)sglist[0].iov_base,
+@@ -409,7 +409,7 @@ static int on_msg_error(struct xio_sessi
+ {
+ 	switch (msg->type) {
+ 	case XIO_MSG_TYPE_REQ:
+-		printf("**** [%p] message [%lu] failed. reason: %s\n",
++		printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 		       session, msg->sn, xio_strerror(error));
+ 		msg_pool_put(pool, msg);
+ 		switch (error) {
+@@ -422,7 +422,7 @@ static int on_msg_error(struct xio_sessi
+ 		};
+ 		break;
+ 	case XIO_MSG_TYPE_RSP:
+-		printf("**** [%p] message [%lu] failed. reason: %s\n",
++		printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 		       session, msg->request->sn, xio_strerror(error));
+ 		/* message is no longer needed */
+ 		switch (error) {
+diff -rup accelio/tests/usr/hello_test_lat/xio_lat_client.c accelio.new/tests/usr/hello_test_lat/xio_lat_client.c
+--- accelio/tests/usr/hello_test_lat/xio_lat_client.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test_lat/xio_lat_client.c	2015-09-03 19:50:51.111356220 -0400
+@@ -139,7 +139,7 @@ static void process_response(struct xio_
+ 		double rxbw = (1.0*pps*rxlen/ONE_MB);
+ 		double lat = (1000000.0/pps);
+ 
+-		printf("transactions per second: %lu, lat: %.2f us, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", lat: %.2f us, bandwidth: " \
+ 		       "TX %.2f MB/s, RX: %.2f MB/s, length: TX: %zd B, RX: %zd B\n",
+ 		       pps, lat, txbw, rxbw, txlen, rxlen);
+ 		get_time(timeb, 40);
+@@ -312,7 +312,7 @@ static int on_msg_error(struct xio_sessi
+ 			struct xio_msg  *msg,
+ 			void *cb_user_context)
+ {
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(pool, msg);
+diff -rup accelio/tests/usr/hello_test_lat/xio_lat_server.c accelio.new/tests/usr/hello_test_lat/xio_lat_server.c
+--- accelio/tests/usr/hello_test_lat/xio_lat_server.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test_lat/xio_lat_server.c	2015-09-03 19:51:16.803475442 -0400
+@@ -103,7 +103,7 @@ static void process_request(struct xio_m
+ 	if (++cnt == PRINT_COUNTER) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&msg->in);
+ 
+-		printf("**** message [%lu] %s - %s\n",
++		printf("**** message [%" PRIu64 "] %s - %s\n",
+ 		       (msg->sn+1),
+ 		       (char *)msg->in.header.iov_base,
+ 		       (char *)sglist[0].iov_base);
+@@ -209,7 +209,7 @@ static int on_msg_error(struct xio_sessi
+ 			struct xio_msg  *msg,
+ 			void *cb_user_context)
+ {
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(pool, msg);
+diff -rup accelio/tests/usr/hello_test_mt/xio_mt_client.c accelio.new/tests/usr/hello_test_mt/xio_mt_client.c
+--- accelio/tests/usr/hello_test_mt/xio_mt_client.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test_mt/xio_mt_client.c	2015-09-03 19:47:39.218465755 -0400
+@@ -179,12 +179,12 @@ static void process_response(struct thre
+ 		double txbw = (1.0*pps*tdata->stat.txlen/ONE_MB);
+ 		double rxbw = (1.0*pps*tdata->stat.rxlen/ONE_MB);
+ 
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "TX %.2f MB/s, RX: %.2f MB/s, length: TX: %zd B, " \
+ 		       "RX: %zd B\n",
+ 		       pps, txbw, rxbw, tdata->stat.txlen, tdata->stat.rxlen);
+ 		get_time(timeb, 40);
+-		printf("[%s] thread [%d] - tid:%p  - message [%lu] " \
++		printf("[%s] thread [%d] - tid:%p  - message [%" PRIu64 "] " \
+ 		       "%s - %s\n",
+ 		       timeb,
+ 		       tdata->affinity,
+@@ -416,11 +416,11 @@ static int on_msg_error(struct xio_sessi
+ 	struct thread_data  *tdata = (struct thread_data *)cb_user_context;
+ 
+ 	if (direction == XIO_MSG_DIRECTION_OUT) {
+-		printf("**** [%p] message %lu failed. reason: %s\n",
++		printf("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, msg->sn, xio_strerror(error));
+ 	} else {
+ 		xio_release_response(msg);
+-		printf("**** [%p] message %lu failed. reason: %s\n",
++		printf("**** [%p] message %" PRIu64 " failed. reason: %s\n",
+ 		       session, msg->request->sn, xio_strerror(error));
+ 	}
+ 
+diff -rup accelio/tests/usr/hello_test_mt/xio_mt_server.c accelio.new/tests/usr/hello_test_mt/xio_mt_server.c
+--- accelio/tests/usr/hello_test_mt/xio_mt_server.c	2015-09-03 19:36:25.608337505 -0400
++++ accelio.new/tests/usr/hello_test_mt/xio_mt_server.c	2015-09-03 19:48:02.876575538 -0400
+@@ -171,7 +171,7 @@ static void process_request(struct threa
+ 	if (++tdata->stat.cnt == PRINT_COUNTER) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&msg->in);
+ 
+-		printf("thread [%d] - message [%lu] %s - %s\n",
++		printf("thread [%d] - message [%" PRIu64 "] %s - %s\n",
+ 		       tdata->affinity,
+ 		       (msg->sn+1),
+ 		       (char *)msg->in.header.iov_base,
+@@ -260,7 +260,7 @@ static int on_msg_error(struct xio_sessi
+ {
+ 	struct thread_data	*tdata = (struct thread_data *)cb_user_context;
+ 
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->request->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(tdata->pool, msg);
+diff -rup accelio/tests/usr/hello_test_oneway/xio_oneway_client.c accelio.new/tests/usr/hello_test_oneway/xio_oneway_client.c
+--- accelio/tests/usr/hello_test_oneway/xio_oneway_client.c	2015-09-03 19:36:25.609337510 -0400
++++ accelio.new/tests/usr/hello_test_oneway/xio_oneway_client.c	2015-09-03 19:54:18.142316932 -0400
+@@ -150,11 +150,11 @@ static void process_rx_message(struct ow
+ 
+ 		double rxbw = (1.0*pps*ow_params->rx_stat.xlen/ONE_MB);
+ 
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "RX: %.2f MB/s, RX: %zd B\n",
+ 		       pps, rxbw, ow_params->rx_stat.xlen);
+ 		get_time(timeb, 40);
+-		printf("**** [%s] - message [%lu] %s - %s\n",
++		printf("**** [%s] - message [%" PRIu64 "] %s - %s\n",
+ 		       timeb, (msg->sn + 1),
+ 		       (char *)msg->in.header.iov_base,
+ 		       (char *)(inents > 0 ? isglist[0].iov_base : NULL));
+@@ -202,11 +202,11 @@ static void process_tx_message(struct ow
+ 
+ 		double txbw = (1.0*pps*ow_params->tx_stat.xlen/ONE_MB);
+ 
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "TX %.2f MB/s,length: TX: %zd B\n",
+ 		       pps, txbw, ow_params->tx_stat.xlen);
+ 		get_time(timeb, 40);
+-		printf("**** [%s] - message [%lu] %s - %s\n",
++		printf("**** [%s] - message [%" PRIu64 "] %s - %s\n",
+ 		       timeb, (msg->sn + 1),
+ 		       (char *)msg->out.header.iov_base,
+ 		       (char *)(onents > 0 ? osglist[0].iov_base : NULL));
+@@ -349,7 +349,7 @@ static int on_msg_error(struct xio_sessi
+ 	struct ow_test_params *ow_params =
+ 				(struct ow_test_params *)cb_user_context;
+ 
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(ow_params->pool, msg);
+diff -rup accelio/tests/usr/hello_test_oneway/xio_oneway_server.c accelio.new/tests/usr/hello_test_oneway/xio_oneway_server.c
+--- accelio/tests/usr/hello_test_oneway/xio_oneway_server.c	2015-09-03 19:36:25.609337510 -0400
++++ accelio.new/tests/usr/hello_test_oneway/xio_oneway_server.c	2015-09-03 19:54:32.797384938 -0400
+@@ -112,7 +112,7 @@ static void process_request(struct xio_m
+ 	if (++cnt == PRINT_COUNTER) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&msg->in);
+ 
+-		printf("**** message [%lu] %s - %s\n",
++		printf("**** message [%" PRIu64 "] %s - %s\n",
+ 		       (msg->sn+1),
+ 		       (char *)msg->in.header.iov_base,
+ 		       (char *)sglist[0].iov_base);
+@@ -299,7 +299,7 @@ static int on_msg_error(struct xio_sessi
+ 	struct ow_test_params *ow_params =
+ 				(struct ow_test_params *)cb_user_context;
+ 
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(ow_params->pool, msg);
+diff -rup accelio/tests/usr/hello_test_ow/xio_ow_client.c accelio.new/tests/usr/hello_test_ow/xio_ow_client.c
+--- accelio/tests/usr/hello_test_ow/xio_ow_client.c	2015-09-03 19:36:25.609337510 -0400
++++ accelio.new/tests/usr/hello_test_ow/xio_ow_client.c	2015-09-03 19:52:24.905791466 -0400
+@@ -152,7 +152,7 @@ for (i = 0; i < onents; i++)
+ 
+ 		double txbw = (1.0*pps*test_params->stat.txlen/ONE_MB);
+ 
+-		printf("transactions per second: %lu, bandwidth: " \
++		printf("transactions per second: %" PRIu64 ", bandwidth: " \
+ 		       "TX %.2f MB/s, length: TX: %zd B\n",
+ 		       pps, txbw,
+ 		       test_params->stat.txlen);
+@@ -181,8 +181,8 @@ static int on_session_event(struct xio_s
+ 		test_params->closed = 1;
+ 		break;
+ 	case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
+-		printf("nsent:%lu, ncomp:%lu, " \
+-		       "delta:%lu\n",
++		printf("nsent:%" PRIu64 ", ncomp:%" PRIu64 ", " \
++		       "delta:%" PRIu64 "\n",
+ 		       test_params->nsent, test_params->ncomp,
+ 		       test_params->nsent-test_params->ncomp);
+ 
+@@ -357,7 +357,7 @@ static int on_msg_error(struct xio_sessi
+ {
+ 	struct test_params *test_params = (struct test_params *)cb_user_context;
+ 
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->sn, xio_strerror(error));
+ 
+ 	msg_pool_put(test_params->pool, msg);
+diff -rup accelio/tests/usr/hello_test_ow/xio_ow_server.c accelio.new/tests/usr/hello_test_ow/xio_ow_server.c
+--- accelio/tests/usr/hello_test_ow/xio_ow_server.c	2015-09-03 19:36:25.609337510 -0400
++++ accelio.new/tests/usr/hello_test_ow/xio_ow_server.c	2015-09-03 19:52:57.947944796 -0400
+@@ -110,7 +110,7 @@ static void process_request(struct xio_m
+ 	if (++cnt == PRINT_COUNTER) {
+ 		struct xio_iovec_ex *sglist = vmsg_sglist(&msg->in);
+ 
+-		printf("**** message [%lu] %s - %s\n",
++		printf("**** message [%" PRIu64 "] %s - %s\n",
+ 		       (msg->sn+1),
+ 		       (char *)msg->in.header.iov_base,
+ 		       (char *)sglist[0].iov_base);
+@@ -145,7 +145,7 @@ static int on_session_event(struct xio_s
+ 		xio_disconnect(event_data->conn);
+ 		break;
+ 	case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
+-		printf("last recv:%lu\n",
++		printf("last recv:%" PRIu64 "\n",
+ 		       test_params->nrecv);
+ 
+ 		xio_connection_destroy(event_data->conn);
+@@ -215,7 +215,7 @@ static int on_msg_error(struct xio_sessi
+ 			struct xio_msg  *msg,
+ 			void *cb_user_context)
+ {
+-	printf("**** [%p] message [%lu] failed. reason: %s\n",
++	printf("**** [%p] message [%" PRIu64 "] failed. reason: %s\n",
+ 	       session, msg->request->sn, xio_strerror(error));
+ 
+ 	return 0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5944,7 +5944,7 @@ let
 
   aalib = callPackage ../development/libraries/aalib { };
 
-  accelio = callPackage ../development/libraries/accelio { };
+  accelio = callPackage ../development/libraries/accelio { stdenv = overrideCC stdenv gcc5; };
 
   accounts-qt = callPackage ../development/libraries/accounts-qt { };
 


### PR DESCRIPTION
- Compile with gcc5 to avoid the compiler bug described in https://gcc.gnu.org/ml/gcc-patches/2014-05/msg02560.html
- Add a patch to fix the many incorrect printf format specifiers and other sloppy type conversions that gcc5 catches and warns on (erroring out due to -Werror).

cc @wkennington
