### PR TITLE
multimarkdown: init at 4.7.1

### DIFF
--- a/pkgs/tools/typesetting/multimarkdown/default.nix
+++ b/pkgs/tools/typesetting/multimarkdown/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchgit, perl }:
+
+stdenv.mkDerivation rec {
+  name = "multimarkdown-${version}";
+  version = "4.7.1";
+
+  src = fetchgit {
+    url = "https://github.com/fletcher/MultiMarkdown-4.git";
+    fetchSubmodules = true;
+    rev = "dd060247518715ef2b52be22b8f49d0e6d2c3a8b";
+    sha256 = "0s7rcxgmv1almlic7bky426x52h7g1pjdhi3y8wf84fpx8c7b6g2";
+  };
+
+  preBuild = ''
+    substituteInPlace enumsToPerl.pl --replace "/usr/bin/perl" "${perl}/bin/perl"
+  '';
+
+  buildInputs = [ stdenv ];
+  checkPhase = "make test-all";
+  installPhase = "make pkg-install prefix='' DESTDIR=$out; make pkg-install-scripts prefix='' DESTDIR=$out";
+
+  meta = with stdenv.lib; {
+    description = "A derivative of Markdown that adds new syntax features";
+    longDescription = ''
+      MultiMarkdown is a lightweight markup language created by
+      Fletcher T. Penney and based on Markdown, which supports
+      more export-formats (html, latex, beamer, memoir, odf, opml,
+      lyx, mmd) and implements some added features currently not
+      available with plain Markdown syntax.
+
+      It adds the following features to Markdown:
+
+      footnotes
+      tables
+      citations and bibliography (works best in LaTeX using BibTeX)
+      math support
+      automatic cross-referencing ability
+      smart typography, with support for multiple languages
+      image attributes
+      table and image captions
+      definition lists
+      glossary entries (LaTeX only)
+      document metadata (e.g. title, author, date, etc.)
+    '';
+    homepage = "http://fletcherpenney.net/multimarkdown/";
+    # licensed under GPLv2+ or MIT:
+    # https://raw.githubusercontent.com/fletcher/MultiMarkdown-4/master/LICENSE
+    license = with stdenv.lib.licenses; [ gpl2Plus ];
+    hydraPlatforms = platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ lowfatcomputing ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12228,6 +12228,8 @@ let
     inherit (lua51Packages) luafilesystem lrexlib luazip luasqlite3;
   };
 
+  multimarkdown = callPackage ../tools/typesetting/multimarkdown { };
+
   multimon-ng = callPackage ../applications/misc/multimon-ng { };
 
   multisync = callPackage ../applications/misc/multisync {


### PR DESCRIPTION
Added package for the new (v4) multimarkdown. You can ignore NixOS/nixpkgs/pull/9567.
