### PR TITLE
connman: 1.28 -> 1.30

### DIFF
--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "connman-${version}";
-  version = "1.28";
+  version = "1.30";
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/connman/connman.git";
     rev = "refs/tags/${version}";
-    sha256 = "13c374bfj7dzlx7zvnnigmk0ck5cy601aqi18n77mcrq9yyxw5y9";
+    sha256 = "715474351e22b52334d37c146fd5eb87d692be8501d8dac33a0e330437235295";
   };
 
   buildInputs = [ autoconf automake libtool pkgconfig openconnect polkit


### PR DESCRIPTION
Built fine, couldn't test though as I don't have a laptop around me at
the moment.

From the changelog:

```
Fix issue with pending DNS request during server change.
Fix issue with empty strings in nameservers configuration.
Fix issue with time servers during IP configuration change.
Fix issue with 4-way handshake during roaming.
Fix issue with open WiFi networks security.
Fix issue with support for WiFi AnonymousIdentity.
Fix issue with memory leak and DHCPv6 DUID handling.
Fix issue with DHCP client and P2P interaction.
Fix issue with handling provision file updates.
Fix issue with VPN state updates.
Disable 6to4 support by default.
```

cc @matejc 
