### PR TITLE
lttng-modules: 2.6.0-5 -> 2.6.2-1, fixes build on kernel 3.18

### DIFF
--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchgit, kernel }:
+{ stdenv, fetchFromGitHub, kernel }:
 
 assert stdenv.lib.versionAtLeast kernel.version "3.4";  # fails on 3.2
 
 stdenv.mkDerivation rec {
   pname = "lttng-modules-${version}";
   name = "${pname}-${kernel.version}";
-  version = "2.6.0-5-g1b2a542";
+  version = "2.6.2-1-g7a88f8b";
 
-  src = fetchgit {
-    url = "https://github.com/lttng/lttng-modules.git";
-    rev = "1b2a5429de815c95643df2eadf91253909708728";
-    sha256 = "0zccaiadnk0xl6xrqaqlg9rpkwjgbq2fiyc3psylzqimnx0ydxc2";
+  src = fetchFromGitHub {
+    owner = "lttng";
+    repo = "lttng-modules";
+    rev = "7a88f8b50696dd71e80c08661159caf8e119bf51";
+    sha256 = "1i185dvk4wn7fmmx1zfv6g15x8wi38jmav2dmq0mmy8cvriajq8h";
   };
 
   preConfigure = ''


### PR DESCRIPTION
cc @bjornfor 

Built also on 3.10 and 4.1, didn't test others.
