### PR TITLE
`desktopManagerHandlesLidAndPower default `false`

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/README
+++ b/nixos/modules/services/x11/desktop-managers/README
@@ -1,0 +1,1 @@
+Each desktop manager should explicitly specify a value for `services.xserver.displayManager.desktopManagerHandlesLidAndPower`.

--- a/nixos/modules/services/x11/desktop-managers/e19.nix
+++ b/nixos/modules/services/x11/desktop-managers/e19.nix
@@ -62,6 +62,7 @@ in
         waitPID=$!
       '';
     }];
+    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     security.setuidPrograms = [ "e19_freqset" ];
 

--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -111,6 +111,7 @@ in
             exec ${kde_workspace}/bin/startkde
           '';
       };
+    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     security.setuidOwners = singleton
       { program = "kcheckpass";

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -78,6 +78,7 @@ in
       bgSupport = true;
       start = ''exec ${plasma5.plasma-workspace}/bin/startkde;'';
     };
+    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     security.setuidOwners = singleton {
       program = "kcheckpass";

--- a/nixos/modules/services/x11/desktop-managers/kodi.nix
+++ b/nixos/modules/services/x11/desktop-managers/kodi.nix
@@ -25,6 +25,7 @@ in
         waitPID=$!
       '';
     }];
+    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     environment.systemPackages = [ pkgs.kodi ];
   };

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -37,6 +37,7 @@ in
             exec ${pkgs.stdenv.shell} ${pkgs.xfce.xinitrc}
           '';
       };
+    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     environment.systemPackages =
       [ pkgs.gtk # To get GTK+'s themes.

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -229,7 +229,7 @@ in
 
       desktopManagerHandlesLidAndPower = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Whether the display manager should prevent systemd from handling
           lid and power events. This is normally handled by the desktop


### PR DESCRIPTION
Changes the option and explicitely sets it for each desktopManager.

Reasoning: Currently,
services.xserver.displayManager.desktopManagerHandlesLidAndPower is set
to true by default. This creates a problem for users without desktop
environments activated, since lid management simply doesn't work
(and they have to be lucky to find this option).

See issue #9571
