### PR TITLE
remind: 3.1.14 -> 3.1.15

### DIFF
--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl} :
 
 stdenv.mkDerivation {
-  name = "remind-3.1.14";
+  name = "remind-3.1.15";
   src = fetchurl {
-    url = http://www.roaringpenguin.com/files/download/remind-03.01.14.tar.gz;
-    sha256 = "1b9ij3r95lf14q6dyh8ilzc3y5yxxc1iss8wj3i49n6zjvklml8a";
+    url = http://www.roaringpenguin.com/files/download/remind-03.01.15.tar.gz;
+    sha256 = "1hcfcxz5fjzl7606prlb7dgls5kr8z3wb51h48s6qm8ang0b9nla";
   };
 
   meta = {


### PR DESCRIPTION
Changes (from docs/WHATSNEW):
- BUG FIX: Fix a buffer overflow found by Alexander Keller
- BUG FIX: Fix a typo in this file: was 2014 instead of 2015.
- BUG FIX: Make parser reject an AT followed by more than one time.
- BUG FIX: Make parser reject epeated delta or *repeat values.
