### PR TITLE
ffmpeg-full: align pkgname with attrname

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -230,7 +230,7 @@ assert opensslExtlib -> gnutls == null && openssl != null && nonfreeLicensing;
 assert x11grabExtlib -> libX11 != null && libXv != null;
 
 stdenv.mkDerivation rec {
-  name = "ffmpeg-${version}";
+  name = "ffmpeg-full-${version}";
   version = "2.7.2";
 
   src = fetchurl {


### PR DESCRIPTION
Without this, users are presented with this endless loop:

```
  $ ffplay
  The program ‘ffplay’ is currently not installed. You can install it by
  typing:
    nix-env -i ffmpeg
  $ nix-env -i ffmpeg
  $ ffplay
  The program ‘ffplay’ is currently not installed. You can install it by
  typing:
    nix-env -i ffmpeg
```
