### PR TITLE
Revert "mass-replace deprecated usage of find -perm (Fixes #9044)"

### DIFF
--- a/pkgs/applications/networking/copy-com/default.nix
+++ b/pkgs/applications/networking/copy-com/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation {
 
     RPATH=${libPaths}:$out/${appdir}
     echo "Updating rpaths to $RPATH in:"
-    find "$out/${appdir}" -type f -a -perm /0100 \
+    find "$out/${appdir}" -type f -a -perm +0100 \
       -print -exec patchelf --force-rpath --set-rpath "$RPATH" {} \;
   '';
 

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -101,12 +101,12 @@ in stdenv.mkDerivation {
     rm "$out/${appdir}/qt.conf"
     rm -fr "$out/${appdir}/plugins"
 
-    find "$out/${appdir}" -type f -a -perm /0100 \
+    find "$out/${appdir}" -type f -a -perm +0100 \
       -print -exec patchelf --set-interpreter ${stdenv.glibc}/lib/${interpreter} {} \;
 
     RPATH=${ldpath}:${gcc.cc}/lib:$out/${appdir}
     echo "updating rpaths to: $RPATH"
-    find "$out/${appdir}" -type f -a -perm /0100 \
+    find "$out/${appdir}" -type f -a -perm +0100 \
       -print -exec patchelf --force-rpath --set-rpath "$RPATH" {} \;
 
     mkdir -p "$out/share/applications"

--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -569,7 +569,7 @@ let inherit (builtins) head tail trace; in
      # Interpreters that are already in the store are left untouched.
          echo "patching script interpreter paths"
          local f
-         for f in $(find "${dir}" -xtype f -perm /0100); do
+         for f in $(find "${dir}" -xtype f -perm +0100); do
              local oldPath=$(sed -ne '1 s,^#![ ]*\([^ ]*\).*$,\1,p' "$f")
              if test -n "$oldPath" -a "''${oldPath:0:''${#NIX_STORE}}" != "$NIX_STORE"; then
                  local newPath=$(type -P $(basename $oldPath) || true)

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -18,7 +18,7 @@ patchShebangs() {
     local oldInterpreterLine
     local newInterpreterLine
 
-    find "$dir" -type f -perm /0100 | while read f; do
+    find "$dir" -type f -perm +0100 | while read f; do
         if [ "$(head -1 "$f" | head -c +2)" != '#!' ]; then
             # missing shebang => not a script
             continue

--- a/pkgs/development/interpreters/ruby/bundler-head.nix
+++ b/pkgs/development/interpreters/ruby/bundler-head.nix
@@ -10,7 +10,7 @@ buildRubyGem {
   };
   dontPatchShebangs = true;
   postInstall = ''
-    find $out -type f -perm /0100 | while read f; do
+    find $out -type f -perm +0100 | while read f; do
       substituteInPlace $f \
          --replace "/usr/bin/env" "${coreutils}/bin/env"
     done

--- a/pkgs/development/interpreters/ruby/bundler.nix
+++ b/pkgs/development/interpreters/ruby/bundler.nix
@@ -6,7 +6,7 @@ buildRubyGem {
   sha256 = "1zkxw6699bbmsamrij2lirscbh0j58p1p3bql22jsxvx34j6w5nc";
   dontPatchShebangs = true;
   postInstall = ''
-    find $out -type f -perm /0100 | while read f; do
+    find $out -type f -perm +0100 | while read f; do
       substituteInPlace $f \
          --replace "/usr/bin/env" "${coreutils}/bin/env"
     done

--- a/pkgs/development/python-modules/generic/wrap.sh
+++ b/pkgs/development/python-modules/generic/wrap.sh
@@ -26,7 +26,7 @@ wrapPythonProgramsIn() {
     done
 
     # Find all regular files in the output directory that are executable.
-    for f in $(find "$dir" -type f -perm /0100); do
+    for f in $(find "$dir" -type f -perm +0100); do
         # Rewrite "#! .../env python" to "#! /nix/store/.../python".
         if head -n1 "$f" | grep -q '#!.*/env.*\(python\|pypy\)'; then
             sed -i "$f" -e "1 s^.*/env[ ]*\(python\|pypy\)^#! $python^"

--- a/pkgs/development/tools/misc/patchelf/setup-hook.sh
+++ b/pkgs/development/tools/misc/patchelf/setup-hook.sh
@@ -9,7 +9,7 @@ patchELF() {
     if [ -e "$prefix" ]; then
         find "$prefix" \( \
             \( -type f -a -name "*.so*" \) -o \
-            \( -type f -a -perm /0100 \) \
+            \( -type f -a -perm +0100 \) \
             \) -print -exec patchelf --shrink-rpath '{}' \;
     fi
     stopNest

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       patchelf --set-rpath "$out/usr/lib/plexmediaserver" "$out/usr/lib/plexmediaserver/$bin"
     done
 
-    find $out/usr/lib/plexmediaserver/Resources -type f -a -perm /0100 \
+    find $out/usr/lib/plexmediaserver/Resources -type f -a -perm +0100 \
         -print -exec patchelf --set-interpreter "${glibc}/lib/ld-linux-x86-64.so.2" '{}' \;
 
 


### PR DESCRIPTION
This makes find unusable on darwin, breaking most of the builds.

This reverts commit 862900e42e00dbc83215def6df1091f5129a8930.

see #9044

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/9603)

<!-- Reviewable:end -->
