### PR TITLE
texlive-moderntimeline: 0.8 (broken) -> 0.9

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
@@ -1,13 +1,10 @@
 args: with args;
 rec {
-  version = "0.8";
+  version = "0.9";
   name = "moderntimeline-${version}";
   src = fetchurl {
-    urls = [
-      "http://www.ctan.org/tex-archive/macros/latex/contrib/moderntimeline.zip"
-      "http://mirror.ctan.org/macros/latex/contrib/moderntimeline.zip"
-    ];
-    sha256 = "0y2m0qd0izrfjcwrmf3nvzkqmrhkdhzbv29s4c0knksdnfgcchc8";
+    url = "https://github.com/raphink/moderntimeline/archive/v0.9.zip";
+    sha256 = "1h1sfdh0whb74y6f999hs80flwpdbs2n4n2b9c450rvs1y7abcml";
   };
 
   buildInputs = [texLive unzip];
@@ -15,7 +12,7 @@ rec {
   doCopy = fullDepEntry (''
     mkdir -p $out/texmf-dist/tex/latex/moderntimeline $out/texmf-dist/doc/moderntimeline $out/share
     mv *.dtx *.ins $out/texmf-dist/tex/latex/moderntimeline/
-    mv *.pdf $out/texmf-dist/doc/moderntimeline/
+    mv *.md $out/texmf-dist/doc/moderntimeline/
     ln -s $out/texmf* $out/share/
   '') ["minInit" "addInputs" "doUnpack" "defEnsureDir"];
 


### PR DESCRIPTION
The v0.8 build was broken because the CTAN package updated to v0.9 and
CTAN doesn't keep old versions of packages.

Besides bumping the version, this commit changes the src url from the
unversioned CTAN link (which would break the derivation every time a new
version of the package released, as it did yesterday) to the versioned
Github release link.
