### PR TITLE
{lib}mediainfo{-gui}: 0.7.76 -> 0.7.77

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.76";
+  version = "0.7.77";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "14vy2a9bjjwxyk8zh0ysin8fb1lj9yz17yd82vxrp1zvxsgyg5ck";
+    sha256 = "0n15z1jlj5s69pwk3mdv4r5c8ncfy7qjbdw5wfwynwypkl5382pn";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.76";
+  version = "0.7.77";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "14vy2a9bjjwxyk8zh0ysin8fb1lj9yz17yd82vxrp1zvxsgyg5ck";
+    sha256 = "0n15z1jlj5s69pwk3mdv4r5c8ncfy7qjbdw5wfwynwypkl5382pn";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.76";
+  version = "0.7.77";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "088hxj3x12ww8zym3g6izz1w9m6wxgdy7hc2m089cd4sv9dlccnq";
+    sha256 = "1znxdn1jpqkiwshq9s514ak1z9wkrh9flky4s3q8z2xl68jpralq";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
Local build and run successful.

From the ChangeLog:

```
Version 0.7.77, 2015-09-02

+ #B941, MXF: files having only a video stream and an ancillary data
  stream were having incorrect second video stream
+ MOV: detection of r210 CodecID as raw RGB
+ Ancillary data: detection of all metadata blocks (previously: only the
  first one was detected)
x MPEG-TS: Wrong demux of TSP (188+16 TS) files having PES with only
  padding x MediaTrace #2: XML malformed with Flags items (hotfix, flags
  meaning disabled in XML output)
x MediaTrace #3: XML malformed with some MP4 files
x MediaTrace #6: XML duplicated attributes
x MediaTrace #10: versioned xsd, creating library name and version
x MediaTrace: XML content was not escaped
x #B947, Amazon S3 support (REST API v2), CLI/DLL only and if compiled
  with libcurl support: Analyze file on s3 was not working if secret key
  contains / character
```
