### PR TITLE
Fix python-web.py: disable Py3k interpreter

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14828,6 +14828,7 @@ let
   web = buildPythonPackage rec {
     version = "0.37";
     name = "web.py-${version}";
+    disabled = isPy3k;
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/w/web.py/web.py-${version}.tar.gz";


### PR DESCRIPTION
This fixes hydra failures, as web.py is not (yet ?) py3k ready.
