### PR TITLE
dragonegg: does not build with gcc49

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6192,8 +6192,6 @@ let
 
   dssi = callPackage ../development/libraries/dssi {};
 
-  dragonegg = llvmPackages_35.dragonegg;
-
   dxflib = callPackage ../development/libraries/dxflib {};
 
   eigen = callPackage ../development/libraries/eigen {};


### PR DESCRIPTION
https://llvm.org/bugs/show_bug.cgi?id=19847

not sure how to handle this? i guess removing (as in this PR) is one option. maybe somebody can figure this out.

/cc @viric

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/9624)

<!-- Reviewable:end -->
