### PR TITLE
i18n: add color scheme option

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -74,6 +74,23 @@ in
         '';
       };
 
+      consoleColors = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [
+          "002b36" "dc322f" "859900" "b58900"
+          "268bd2" "d33682" "2aa198" "eee8d5"
+          "002b36" "cb4b16" "586e75" "657b83"
+          "839496" "6c71c4" "93a1a1" "fdf6e3"
+        ];
+        description = ''
+          The 16 colors palette used by the virtual consoles.
+          Leave empty to use the default colors.
+          Colors must be in hexadecimal format and listed in
+          order from color 0 to color 15.
+        '';
+      };
+
     };
 
   };

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -4,11 +4,13 @@ with lib;
 
 let
 
+  makeColor = n: value: "COLOR_${toString n}=${value}";
+
   vconsoleConf = pkgs.writeText "vconsole.conf"
     ''
       KEYMAP=${config.i18n.consoleKeyMap}
       FONT=${config.i18n.consoleFont}
-    '';
+    '' + concatImapStringsSep "\n" makeColor config.i18n.consoleColors;
 
 in
 


### PR DESCRIPTION
I haven't really tested this because I don't know how to but the `vconsole.conf` file being generated is valid.
