### PR TITLE
stevedore: add pbr to propagatedBuildInputs

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13010,8 +13010,8 @@ let
 
     doCheck = false;
 
-    buildInputs = with self; [ pbr oslosphinx ];
-    propagatedBuildInputs = with self; [ six argparse ];
+    buildInputs = with self; [ oslosphinx ];
+    propagatedBuildInputs = with self; [ pbr six argparse ];
 
     meta = {
       description = "Manage dynamic plugins for Python applications";


### PR DESCRIPTION
This fixes a crash in flexget and possibly other packages. I think the
issue was introduced in fc1165b0d94ec8b1b01b7522ed3143bd3dd03e5c

Without this patch, flexget gives an error at start about not being able to locate pbr.  This fixes it on my system.  I don't know enough about these packages or Python to be completely sure whether this is the correct fix.

cc @domenkozar @jagajaga @mbakke 
