### PR TITLE
nox: use propagatedBuildInputs instead of pythonPath

### DIFF
--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -12,7 +12,7 @@ pythonPackages.buildPythonPackage rec {
 
   buildInputs = [ pythonPackages.pbr ];
 
-  pythonPath = with pythonPackages; [
+  propagatedBuildInputs = with pythonPackages; [
       dogpile_cache
       click
       requests2


### PR DESCRIPTION
This way, when accessing Nox via Python, the dependencies will be
available.

cc @madjar
