### PR TITLE
rkt: Don't download stage1 image during build.

### DIFF
--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -3,7 +3,7 @@
 
 let
   coreosImageRelease = "738.1.0";
-  
+
 in stdenv.mkDerivation rec {
   version = "0.8.0";
   name = "rkt-${version}";
@@ -19,20 +19,25 @@ in stdenv.mkDerivation rec {
     url = "http://alpha.release.core-os.net/amd64-usr/${coreosImageRelease}/coreos_production_pxe_image.cpio.gz";
     sha256 = "1rnb9rwms5g7f142d9yh169a5k2hxiximpgk4y4kqmc1294lqnl0";
   };
-  
+
   buildInputs = [ autoconf automake go file git wget gnupg1 squashfsTools cpio ];
-  
+
   preConfigure = ''
     ./autogen.sh
   '';
 
-  configureFlags = "--with-stage1-image-path=${stage1image}";
-  
+  preBuild = ''
+    # hack to avoid downloading image during build, this has been
+    # improved in rkt master
+    mkdir -p build-rkt-0.8.0/tmp/usr_from_coreos
+    cp -v ${stage1image} build-rkt-0.8.0/tmp/usr_from_coreos/pxe.img
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     cp -Rv build-rkt-${version}/bin/* $out/bin
   '';
-    
+
   meta = with lib; {
     description = "A fast, composable, and secure App Container runtime for Linux";
     homepage = http://rkt.io;


### PR DESCRIPTION
Second attempt to resolve this issue. Copies stage1 image into expected
place manually. This has been improved in rkt master where there is a
configure option for specifying the location of this file. Can update
when next stable rkt is released.
