### PR TITLE
Remove desktopManagerHandlesLidAndPower

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/e19.nix
+++ b/nixos/modules/services/x11/desktop-managers/e19.nix
@@ -62,7 +62,6 @@ in
         waitPID=$!
       '';
     }];
-    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     security.setuidPrograms = [ "e19_freqset" ];
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -99,7 +99,6 @@ in {
     networking.networkmanager.enable = mkDefault true;
     services.upower.enable = config.powerManagement.enable;
     hardware.bluetooth.enable = mkDefault true;
-    services.xserver.displayManager.desktopManagerHandlesLidAndPower = false; # true doesn't make sense here, GNOME just doesn't handle it anymore
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell_fonts ];
 

--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -111,7 +111,6 @@ in
             exec ${kde_workspace}/bin/startkde
           '';
       };
-    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     security.setuidOwners = singleton
       { program = "kcheckpass";

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -78,7 +78,6 @@ in
       bgSupport = true;
       start = ''exec ${plasma5.plasma-workspace}/bin/startkde;'';
     };
-    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     security.setuidOwners = singleton {
       program = "kcheckpass";

--- a/nixos/modules/services/x11/desktop-managers/kodi.nix
+++ b/nixos/modules/services/x11/desktop-managers/kodi.nix
@@ -25,7 +25,6 @@ in
         waitPID=$!
       '';
     }];
-    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     environment.systemPackages = [ pkgs.kodi ];
   };

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -37,7 +37,6 @@ in
             exec ${pkgs.stdenv.shell} ${pkgs.xfce.xinitrc}
           '';
       };
-    services.xserver.displayManager.desktopManagerHandlesLidAndPower = true;
 
     environment.systemPackages =
       [ pkgs.gtk # To get GTK+'s themes.


### PR DESCRIPTION
After #9590 my configuration.nix broke:

```
  services.xserver.desktopManager.kde4.enable = true;
  services.xserver.desktopManager.gnome3.enable = true;

The option `services.xserver.displayManager.desktopManagerHandlesLidAndPower' has conflicting definitions, in <...>
```

On further research it seems that no desktop managers need this workaround anymore, because they implemented it themselves:
https://bugs.kde.org/show_bug.cgi?id=307412 (both 4 and 5)
https://bugzilla.xfce.org/show_bug.cgi?id=11767
http://sourceforge.net/p/enlightenment/mailman/message/31299858/
https://github.com/xbmc/xbmc/blob/master/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp

So just remove it.
