### PR TITLE
linuxPackages_*.perf: Fix build after kernel 4.1

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -23,10 +23,13 @@ stdenv.mkDerivation {
   # perf refers both to newt and slang
   # binutils is required for libbfd.
   nativeBuildInputs = [ asciidoc xmlto docbook_xsl docbook_xml_dtd_45 libxslt flex bison ];
-  buildInputs = [ elfutils python perl newt slang pkgconfig libunwind binutils ] ++
+  buildInputs = [ python perl newt slang pkgconfig libunwind binutils ] ++
     stdenv.lib.optional withGtk gtk;
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
+  # Note: we don't add elfutils to buildInputs, since it provides a
+  # bad `ld' and other stuff.
+  NIX_CFLAGS_COMPILE = "-I${elfutils}/include -Wno-error=cpp";
+  NIX_CFLAGS_LINK = "-L${elfutils}/lib";
 
   installFlags = "install install-man ASCIIDOC8=1";
 


### PR DESCRIPTION
In 4.1, the build system changed, and it now wants to execute ld like this:

```
ld -r -o util/scripting-engines/libperf-in.o util/scripting-engines/trace-event-perl.o util/scripting-engines/trace-event-python.o
```

The actual problem seems to be that `buildInputs = [elfutils ...]`
causes 'ld' to point to elfutils in PATH instead of the usual binutils.

So remove elfutils from buildInputs and set NIX_CFLAGS_\* manually. This
is a slight hack, but there is some precedent:
https://github.com/NixOS/nixpkgs/blob/0761f81da71fc6a940c7f51129b6c7717db78e87/pkgs/tools/package-management/rpm/default.nix#L13

Fixes #9095.
