### PR TITLE
texlive/moderntimeline: 0.8 -> 0.9

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
@@ -1,13 +1,13 @@
 args: with args;
 rec {
-  version = "0.8";
+  version = "0.9";
   name = "moderntimeline-${version}";
   src = fetchurl {
     urls = [
       "http://www.ctan.org/tex-archive/macros/latex/contrib/moderntimeline.zip"
       "http://mirror.ctan.org/macros/latex/contrib/moderntimeline.zip"
     ];
-    sha256 = "0y2m0qd0izrfjcwrmf3nvzkqmrhkdhzbv29s4c0knksdnfgcchc8";
+    sha256 = "155c3m9qk8pzbkvy60pan5byfzf1wn6pd43fq7k3732g9zjzrsak";
   };
 
   buildInputs = [texLive unzip];


### PR DESCRIPTION
Before:

```
% nix-env --file $NIXPKGS -iA texLiveFull
replacing old ‘texlive-full’
installing ‘texlive-full’
these derivations will be built:
  /nix/store/qljxmyvigspy373fyb72znc4jq2pwz0c-moderntimeline.zip.drv
  /nix/store/ry75pi265pd23vvskzi9d0hyi2z5jnx4-moderntimeline-0.8.drv
  /nix/store/x3iqg14dyab40n0z1rpx4bqfi3sz53cw-TeXLive-linkdir.drv
building path(s) ‘/nix/store/in98i5f7sy9za0hnq81zpbhwix3h54fa-moderntimeline.zip’

trying http://www.ctan.org/tex-archive/macros/latex/contrib/moderntimeline.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   353  100   353    0     0    453      0 --:--:-- --:--:-- --:--:--     0
100  184k  100  184k    0     0   167k      0  0:00:01  0:00:01 --:--:--  167k
output path ‘/nix/store/in98i5f7sy9za0hnq81zpbhwix3h54fa-moderntimeline.zip’ should have sha256 hash ‘0y2m0qd0izrfjcwrmf3nvzkqmrhkdhzbv29s4c0knksdnfgcchc8’, instead has ‘155c3m9qk8pzbkvy60pan5byfzf1wn6pd43fq7k3732g9zjzrsak’
cannot build derivation ‘/nix/store/ry75pi265pd23vvskzi9d0hyi2z5jnx4-moderntimeline-0.8.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/x3iqg14dyab40n0z1rpx4bqfi3sz53cw-TeXLive-linkdir.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/x3iqg14dyab40n0z1rpx4bqfi3sz53cw-TeXLive-linkdir.drv’ failed
```

After:

```
% nix-env --file $NIXPKGS -iA texLiveFull
replacing old ‘texlive-full’
installing ‘texlive-full’
```
