### PR TITLE
Julia: add development version

### DIFF
--- a/pkgs/development/compilers/julia/dev.nix
+++ b/pkgs/development/compilers/julia/dev.nix
@@ -1,0 +1,172 @@
+{ stdenv, fetchgit, fetchurl
+# build tools
+, gfortran, git, m4, patchelf, perl, which
+# libjulia dependencies
+, libunwind, llvm, utf8proc, zlib
+# standard library dependencies
+, double_conversion, fftwSinglePrec, fftw, gmp, mpfr, pcre, pcre2
+, openblas, arpack, suitesparse
+, openspecfun, openlibm
+, python2
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "julia";
+  version = "0.4-20140903";
+  name = "${pname}-${version}";
+
+  src = fetchgit {
+    url = "git://github.com/JuliaLang/julia.git";
+    rev = "41128d9bf97623a61fab4dfee9df97f3d6aad18a";
+    sha256 = "1f84c582bf8132ef7e4f2c78c0b27234794dd464b30508a1502b85ae88017322";
+    #name = "julia-git-v${version}";
+  };
+
+  extraSrcs =
+    let
+      dsfmt_ver = "2.2.3";
+
+      dsfmt_src = fetchurl {
+        url = "http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-src-${dsfmt_ver}.tar.gz";
+        name = "dsfmt-${dsfmt_ver}.tar.gz";
+        md5 = "057c5a11d28296825fba584f561a4369";
+      };
+
+      rmath_ver = "0.1";
+
+      rmath_src = fetchurl {
+        url = "https://codeload.github.com/JuliaLang/Rmath-julia/legacy.tar.gz/v${rmath_ver}";
+        name = "Rmath-julia-${rmath_ver}.tar.gz";
+        md5 = "4e3f9e41e7b8cd3070225d1f5e8b21d9";
+      };
+
+      libuv_rev = "28f5f06b5ff6f010d666ec26552e0badaca5cdcd";
+
+      libuv_src = fetchurl {
+        url = "https://api.github.com/repos/JuliaLang/libuv/tarball/${libuv_rev}";
+        name = "libuv-${libuv_rev}.tar.gz";
+        md5 = "429c128e55147c8b43d6555fe406869b";
+      };
+
+      virtualenv_ver = "1.11.6";
+
+      virtualenv_src = fetchurl {
+        url = "https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${virtualenv_ver}.tar.gz";
+        name = "virtualenv-${virtualenv_ver}.tar.gz";
+        md5 = "f61cdd983d2c4e6aeabb70b1060d6f49";
+      };
+
+    in [ dsfmt_src rmath_src libuv_src virtualenv_src ];
+
+  prePatch = ''
+    copy_kill_hash(){
+      cp "$1" "$2/$(basename "$1" | sed -e 's/^[a-z0-9]*-//')"
+    }
+
+    for i in $extraSrcs; do
+      copy_kill_hash "$i" deps
+    done
+  '';
+
+  patches = [ ./fix-utf8proc-0.4.patch ];
+
+  postPatch = ''
+    patchShebangs .
+
+    # ldconfig doesn't seem to ever work on NixOS; system-wide ldconfig cache
+    # is probably not what we want anyway on non-NixOS
+    sed -e "s@/sbin/ldconfig@true@" -i src/ccall.*
+  '';
+
+  buildInputs =
+    [ libunwind llvm utf8proc zlib
+      double_conversion fftw fftwSinglePrec gmp mpfr pcre pcre2
+      openblas arpack suitesparse openspecfun openlibm
+      git
+    ];
+
+  nativeBuildInputs = [ gfortran python2 git m4 patchelf perl which ];
+
+  makeFlags =
+    let
+      arch = head (splitString "-" stdenv.system);
+      march =
+        { "x86_64-linux" = "x86-64";
+          "x86_64-darwin" = "x86-64";
+          "i686-linux" = "i686";
+        }."${stdenv.system}" or (throw "unsupported system: ${stdenv.system}");
+    in [
+      "ARCH=${arch}"
+      "MARCH=${march}"
+      "JULIA_CPU_TARGET=${march}"
+      "PREFIX=$(out)"
+      "prefix=$(out)"
+      "SHELL=${stdenv.shell}"
+
+      "USE_SYSTEM_BLAS=1"
+      "LIBBLAS=-lopenblas"
+      "LIBBLASNAME=libopenblas"
+
+      "USE_SYSTEM_LAPACK=1"
+      "LIBLAPACK=-lopenblas"
+      "LIBLAPACKNAME=libopenblas"
+
+      "USE_SYSTEM_ARPACK=1"
+      "USE_SYSTEM_FFTW=1"
+      "USE_SYSTEM_GMP=1"
+      "USE_SYSTEM_GRISU=1"
+      "USE_SYSTEM_LIBUNWIND=1"
+      "USE_SYSTEM_LLVM=1"
+      "USE_SYSTEM_MPFR=1"
+      "USE_SYSTEM_PATCHELF=1"
+      "USE_SYSTEM_PCRE=1"
+      "USE_SYSTEM_SUITESPARSE=1"
+      "USE_SYSTEM_UTF8PROC=1"
+      "USE_SYSTEM_ZLIB=1"
+      "USE_SYSTEM_OPENLIBM=1"
+      "USE_SYSTEM_OPENSPECFUN=1"
+      "USE_SYSTEM_LIBGIT2=1"
+
+      "UTF8PROC_INC=${utf8proc}/include"
+      "SUITESPARSE_INC=-I${suitesparse}/include"
+    ];
+
+  NIX_CFLAGS_COMPILE = [ "-fPIC" ];
+
+  # Julia tries to load these libraries dynamically at runtime, but they can't be found.
+  # Easier by far to link against them as usual.
+  # These go in LDFLAGS, where they affect only Julia itself, and not NIX_LDFLAGS,
+  # where they would also be used for all the private libraries Julia builds.
+  LDFLAGS = [
+    "-larpack"
+    "-lfftw3_threads"
+    "-lfftw3f_threads"
+    "-lgmp"
+    "-lmpfr"
+    "-lopenblas"
+    "-lpcre2-8"
+    "-lsuitesparse"
+    "-lsuitesparseconfig"
+    "-lopenlibm"
+    "-lz"
+  ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  enableParallelBuilding = true;
+
+  # Test fail on i686 (julia version 0.3.10)
+  #doCheck = !stdenv.isi686;
+  checkTarget = "testall";
+
+  meta = {
+    description = "High-level performance-oriented dynamical language for technical computing";
+    homepage = "http://julialang.org/";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ raskin ttuegel ];
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/development/compilers/julia/fix-utf8proc-0.4.patch
+++ b/pkgs/development/compilers/julia/fix-utf8proc-0.4.patch
@@ -1,0 +1,22 @@
+diff --git a/src/flisp/Makefile b/src/flisp/Makefile
+index bec8624..4f36777 100644
+--- a/src/flisp/Makefile
++++ b/src/flisp/Makefile
+@@ -24,9 +24,15 @@ DOBJS = $(SRCS:%.c=$(BUILDDIR)/%.dbg.obj)
+ LLTDIR = ../support
+ LLT_release = $(BUILDDIR)/$(LLTDIR)/libsupport.a
+ LLT_debug = $(BUILDDIR)/$(LLTDIR)/libsupport-debug.a
+-LIBFILES_release = $(LLT_release) $(LIBUV) $(LIBUTF8PROC)
+-LIBFILES_debug = $(LLT_debug) $(LIBUV) $(LIBUTF8PROC)
++LIBFILES_common = $(LIBUV)
+ LIBS =
++ifeq ($(USE_SYSTEM_UTF8PROC), 1)
++  LIBS += $(LIBUTF8PROC)
++else
++  LIBFILES_common += $(LIBUTF8PROC)
++endif
++LIBFILES_release = $(LLT_release) $(LIBFILES_common)
++LIBFILES_debug = $(LLT_debug) $(LIBFILES_common)
+ ifneq ($(OS),WINNT)
+ LIBS += -lpthread
+ endif

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, unicodeSupport ? true
+, windows ? null
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "pcre2-10.20";
+
+  src = fetchurl {
+    url = "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${name}.tar.bz2";
+    sha256 = "0yj8mm9ll9zj3v47rvmmqmr1ybxk72rr2lym3rymdsf905qjhbik";
+  };
+
+  configureFlags = [ "--enable-jit" ]
+                ++ stdenv.lib.optional unicodeSupport "--enable-unicode";
+
+  doCheck = with stdenv; !(isCygwin || isFreeBSD);
+    # XXX: test failure on Cygwin
+    # we are running out of stack on both freeBSDs on Hydra
+
+  crossAttrs = optionalAttrs (stdenv.cross.libc == "msvcrt") {
+    buildInputs = [ windows.mingw_w64_pthreads.crossDrv ];
+  };
+
+  meta = {
+    homepage = "http://www.pcre.org/";
+    description = "A library for Perl Compatible Regular Expressions";
+    license = stdenv.lib.licenses.bsd3;
+
+    longDescription = ''
+      The PCRE library is a set of functions that implement regular
+      expression pattern matching using the same syntax and semantics as
+      Perl 5. PCRE has its own native API, as well as a set of wrapper
+      functions that correspond to the POSIX regular expression API. The
+      PCRE library is free, even for building proprietary software.
+    '';
+
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/science/math/openlibm/default.nix
+++ b/pkgs/development/libraries/science/math/openlibm/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "openlibm-${version}";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "JuliaLang";
+    repo = "openlibm";
+    rev = "v${version}";
+    sha256 = "1s6mb00khjwqxzpxycr82nvfaicp9zcdjq6srx1dz1zdn4a349sh";
+  };
+
+  makeFlags = [ "prefix=" "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "An effort to have a high quality, portable, standalone C mathematical library";
+    homepage = "http://openlibm.org/";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbradar ];
+    license = with licenses; [ mit bsd2 isc ];
+  };
+}

--- a/pkgs/development/libraries/science/math/openspecfun/default.nix
+++ b/pkgs/development/libraries/science/math/openspecfun/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, gfortran }:
+
+stdenv.mkDerivation rec {
+  name = "openspecfun-${version}";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "JuliaLang";
+    repo = "openspecfun";
+    rev = "v${version}";
+    sha256 = "1h1pdin6p8wm9rq19bin97bnb532j8711r238mrj3pmh571zx58m";
+  };
+
+  nativeBuildInputs = [ gfortran ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of special mathematical functions";
+    homepage = "https://github.com/JuliaLang/openspecfun";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbradar ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     sha256 = "1zdn1y0ij6amj7smmcslkqgbqv9yy5cwmbyzqc9v6drzdzllgbpj";
   };
 
+  patches = [ ./shared_suitesparseconfig.patch ];
+
   preConfigure = ''
     mkdir -p $out/lib
     mkdir -p $out/include

--- a/pkgs/development/libraries/science/math/suitesparse/shared_suitesparseconfig.patch
+++ b/pkgs/development/libraries/science/math/suitesparse/shared_suitesparseconfig.patch
@@ -1,0 +1,39 @@
+diff -ru3 SuiteSparse.old/SuiteSparse_config/Makefile SuiteSparse/SuiteSparse_config/Makefile
+--- SuiteSparse.old/SuiteSparse_config/Makefile	2015-08-27 23:15:02.905837087 +0300
++++ SuiteSparse/SuiteSparse_config/Makefile	2015-08-27 23:29:19.126448284 +0300
+@@ -8,17 +8,21 @@
+ 
+ include SuiteSparse_config.mk
+ 
+-ccode: libsuitesparseconfig.a
++ccode: libsuitesparseconfig.a libsuitesparseconfig.so
+ 
+-all: libsuitesparseconfig.a
++all: libsuitesparseconfig.a libsuitesparseconfig.so
+ 
+-library: libsuitesparseconfig.a
++library: libsuitesparseconfig.a libsuitesparseconfig.so
+ 
+-libsuitesparseconfig.a: SuiteSparse_config.c SuiteSparse_config.h
++SuiteSparse_config.o: SuiteSparse_config.c SuiteSparse_config.h
+ 	$(CC) $(CF) -c SuiteSparse_config.c
++
++libsuitesparseconfig.a: SuiteSparse_config.o
+ 	$(ARCHIVE) libsuitesparseconfig.a SuiteSparse_config.o
+ 	$(RANLIB) libsuitesparseconfig.a
+-	- $(RM) SuiteSparse_config.o
++
++libsuitesparseconfig.so: SuiteSparse_config.o
++	$(LD) -shared -o libsuitesparseconfig.so SuiteSparse_config.o
+ 
+ distclean: purge
+ 
+@@ -32,6 +36,8 @@
+ install:
+ 	$(CP) libsuitesparseconfig.a $(INSTALL_LIB)/libsuitesparseconfig.$(VERSION).a
+ 	( cd $(INSTALL_LIB) ; ln -sf libsuitesparseconfig.$(VERSION).a libsuitesparseconfig.a )
++	$(CP) libsuitesparseconfig.so $(INSTALL_LIB)/libsuitesparseconfig.$(VERSION).so
++	( cd $(INSTALL_LIB) ; ln -sf libsuitesparseconfig.$(VERSION).so libsuitesparseconfig.so )
+ 	$(CP) SuiteSparse_config.h $(INSTALL_INCLUDE)
+ 	chmod 644 $(INSTALL_LIB)/libsuitesparseconfig*.a
+ 	chmod 644 $(INSTALL_INCLUDE)/SuiteSparse_config.h

--- a/pkgs/development/libraries/utf8proc/default.nix
+++ b/pkgs/development/libraries/utf8proc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "utf8proc-${version}";
-  version = "v1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "JuliaLang";
     repo = "utf8proc";
-    rev = "${version}";
-    sha256 = "1ryjlcnpfm7fpkq6444ybi576hbnh2l0w7kjhbqady5lxwjyg3pf";
+    rev = "v${version}";
+    sha256 = "0z24pfdym2m0f92qyf2wc8rai91q5bv021jxhxankdhb3f8hmqf9";
   };
 
   makeFlags = [ "prefix=$(out)" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14416,6 +14416,8 @@ let
   # standard BLAS and LAPACK.
   openblasCompat = openblas.override { blas64 = false; };
 
+  openlibm = callPackage ../development/libraries/science/math/openlibm { };
+
   mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7889,6 +7889,10 @@ let
     unicodeSupport = config.pcre.unicode or true;
   };
 
+  pcre2 = callPackage ../development/libraries/pcre2 {
+    unicodeSupport = config.pcre.unicode or true;
+  };
+
   pdf2xml = callPackage ../development/libraries/pdf2xml {} ;
 
   phonon = callPackage ../development/libraries/phonon/qt4 {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14418,6 +14418,8 @@ let
 
   openlibm = callPackage ../development/libraries/science/math/openlibm { };
 
+  openspecfun = callPackage ../development/libraries/science/math/openspecfun { };
+
   mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4206,6 +4206,9 @@ let
   julia03 = callPackage ../development/compilers/julia/0.3.nix {
     llvm = llvm_33;
   };
+
+  julia-dev = callPackage ../development/compilers/julia/dev.nix { };
+
   julia = julia03;
 
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {


### PR DESCRIPTION
This version requires many new packages, and even after adding them I've failed at building it -- it tries to set up a Python virtualenv and install packages during a documentation build, which is a nightmare for Nix. I haven't found any shortcut around this, nor I found any way to disable documentation -- perhaps we can just patch it out.
