### PR TITLE
gup: new package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -104,6 +104,7 @@
   garrison = "Jim Garrison <jim@garrison.cc>";
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
+  gfxmonk = "Tim Cuthbertson <tim@gfxmonk.net>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   globin = "Robin Gloster <robin@glob.in>";
   goibhniu = "Cillian de Róiste <cillian.deroiste@gmail.com>";

--- a/pkgs/development/tools/build-managers/gup/build.nix
+++ b/pkgs/development/tools/build-managers/gup/build.nix
@@ -1,0 +1,16 @@
+# NOTE: this file is copied from the upstream repository for this package.
+# Please submit any changes you make here to https://github.com/gfxmonk/gup/
+
+{ stdenv, lib, python, which, pychecker ? null }:
+{ src, version, meta ? {} }:
+stdenv.mkDerivation {
+  inherit src meta;
+  name = "gup-${version}";
+  buildInputs = lib.remove null [ python which pychecker ];
+  SKIP_PYCHECKER = pychecker == null;
+  buildPhase = "make python";
+  installPhase = ''
+    mkdir $out
+    cp -r python/bin $out/bin
+  '';
+}

--- a/pkgs/development/tools/build-managers/gup/default.nix
+++ b/pkgs/development/tools/build-managers/gup/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchgit, lib, python, which }:
+let
+  version = "0.5.1";
+  src = fetchgit {
+    url = "https://github.com/gfxmonk/gup.git";
+    rev = "f185052e2177ed5e46720e6c6cfb529b96cd17e2";
+    sha256 = "c2e27cdba2231017ceb4868f58f5c3b224be0491b81558b4e59bb08a952ad1a5";
+  };
+in
+import ./build.nix
+  { inherit stdenv lib python which; }
+  { inherit src version;
+    meta = {
+      description = "A better make, inspired by djb's redo";
+      homepage = https://github.com/gfxmonk/gup;
+      license = stdenv.lib.licenses.lgpl2Plus;
+      maintainers = [ stdenv.lib.maintainers.gfxmonk ];
+      platforms = stdenv.lib.platforms.all;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1805,6 +1805,8 @@ let
 
   gummiboot = callPackage ../tools/misc/gummiboot { };
 
+  gup = callPackage ../development/tools/build-managers/gup {};
+
   gupnp = callPackage ../development/libraries/gupnp {
     inherit (gnome) libsoup;
   };


### PR DESCRIPTION
Tested on nixpkgs unstable.

Since I'm both the maintainer and upstream author, I wanted to reuse the .nix expressions from upstream, so I'm importing them directly. There was some recent discussion on the mailing list encouraging this (which is the only reason I realised this was seen possible), but let me know if there's anything wrong with it.

The upstream nix expression is here, if you want to see that too: https://github.com/gfxmonk/gup/blob/f185052e2177ed5e46720e6c6cfb529b96cd17e2/nix/gup-python.nix
