### PR TITLE
mlmmj: Fixed postfix config items to make module work again

### DIFF
--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -96,8 +96,9 @@ in
       extraAliases = concatMapStrings (alias cfg.listDomain) cfg.mailLists;
 
       extraConfig = ''
-        transport = hash:${stateDir}/transports
-        virtual = hash:${stateDir}/virtuals
+        transport_maps = hash:${stateDir}/transports
+        virtual_alias_maps = hash:${stateDir}/virtuals
+        propagate_unmatched_extensions = virtual
       '';
     };
 


### PR DESCRIPTION
Hi,

current mlmmj module inserts deprecated postfix config items into the postfix config resulting in:

```
l1r4dqhqp64z-postfix-2.11.5/sbin/postconf: warning: /var/postfix/conf/main.cf: unused parameter: virtual=hash:/var/lib/mlmmj/virtuals
l1r4dqhqp64z-postfix-2.11.5/sbin/postconf: warning: /var/postfix/conf/main.cf: unused parameter: transport=hash:/var/lib/mlmmj/transports
```

Fixed by updating mlmmj module postfix.extraConfig
