### PR TITLE
entr: add build script

### DIFF
--- a/pkgs/development/tools/entr/default.nix
+++ b/pkgs/development/tools/entr/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+let version = "3.2"; in
+
+stdenv.mkDerivation {
+    name = "entr-${version}";
+    src = fetchurl {
+        url = "http://entrproject.org/code/${name}-${version}.tar.gz";
+        sha256 = "0ikigpfzyjmr8j6snwlvxzqamrjbhlv78m8w1h0h7kzczc5f1vmi";
+    };
+
+    enableParallelBuilding = true;
+
+    meta = {
+        homepage = "http://http://entrproject.org/";
+        description = "Run arbitrary commands when files change";
+        platforms = stdenv.lib.platforms.all;
+    };
+}


### PR DESCRIPTION
[entr](http://entrproject.org/) is a project to execute arbitrary commands when a file changes, great for implementing ad-hoc auto triggering test runners.

This is my first nixpkg so please let me know if I've committed any atrocities!

I've tested the output using

```
$ nix-build pks/top-level/all-packages.nix -A entr
```

and made sure the resulting binary, `result/bin/entr`, worked correctly.

Cheers
