### PR TITLE
Pass platform specific find flags for executables (needed by darwin)

### DIFF
--- a/pkgs/applications/networking/copy-com/default.nix
+++ b/pkgs/applications/networking/copy-com/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation {
 
     RPATH=${libPaths}:$out/${appdir}
     echo "Updating rpaths to $RPATH in:"
-    find "$out/${appdir}" -type f -a -perm /0100 \
+    find "$out/${appdir}" -type f -a ${findExecutablesFlags:--perm /0100} \
       -print -exec patchelf --force-rpath --set-rpath "$RPATH" {} \;
   '';
 

--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -569,7 +569,7 @@ let inherit (builtins) head tail trace; in
      # Interpreters that are already in the store are left untouched.
          echo "patching script interpreter paths"
          local f
-         for f in $(find "${dir}" -xtype f -perm /0100); do
+         for f in $(find "${dir}" -xtype f ${findExecutablesFlags:--perm /0100}); do
              local oldPath=$(sed -ne '1 s,^#![ ]*\([^ ]*\).*$,\1,p' "$f")
              if test -n "$oldPath" -a "''${oldPath:0:''${#NIX_STORE}}" != "$NIX_STORE"; then
                  local newPath=$(type -P $(basename $oldPath) || true)

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -18,7 +18,7 @@ patchShebangs() {
     local oldInterpreterLine
     local newInterpreterLine
 
-    find "$dir" -type f -perm /0100 | while read f; do
+    find "$dir" -type f ${findExecutablesFlags:--perm /0100} | while read f; do
         if [ "$(head -1 "$f" | head -c +2)" != '#!' ]; then
             # missing shebang => not a script
             continue

--- a/pkgs/development/interpreters/ruby/bundler-head.nix
+++ b/pkgs/development/interpreters/ruby/bundler-head.nix
@@ -10,7 +10,7 @@ buildRubyGem {
   };
   dontPatchShebangs = true;
   postInstall = ''
-    find $out -type f -perm /0100 | while read f; do
+    find $out -type f ${findExecutablesFlags:--perm /0100} | while read f; do
       substituteInPlace $f \
          --replace "/usr/bin/env" "${coreutils}/bin/env"
     done

--- a/pkgs/development/interpreters/ruby/bundler.nix
+++ b/pkgs/development/interpreters/ruby/bundler.nix
@@ -6,7 +6,7 @@ buildRubyGem {
   sha256 = "1zkxw6699bbmsamrij2lirscbh0j58p1p3bql22jsxvx34j6w5nc";
   dontPatchShebangs = true;
   postInstall = ''
-    find $out -type f -perm /0100 | while read f; do
+    find $out -type f ${findExecutablesFlags:--perm /0100} | while read f; do
       substituteInPlace $f \
          --replace "/usr/bin/env" "${coreutils}/bin/env"
     done

--- a/pkgs/development/python-modules/generic/wrap.sh
+++ b/pkgs/development/python-modules/generic/wrap.sh
@@ -26,7 +26,7 @@ wrapPythonProgramsIn() {
     done
 
     # Find all regular files in the output directory that are executable.
-    for f in $(find "$dir" -type f -perm /0100); do
+    for f in $(find "$dir" -type f ${findExecutablesFlags:--perm /0100}); do
         # Rewrite "#! .../env python" to "#! /nix/store/.../python".
         if head -n1 "$f" | grep -q '#!.*/env.*\(python\|pypy\)'; then
             sed -i "$f" -e "1 s^.*/env[ ]*\(python\|pypy\)^#! $python^"

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -47,6 +47,7 @@ rec {
     export NIX_DONT_SET_RPATH=1
     export NIX_NO_SELF_RPATH=1
     dontFixLibtool=1
+    findExecutablesFlags="-perm +0100" # the Darwin find does not support /0100
     stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
     xargsFlags=" "
     export MACOSX_DEPLOYMENT_TARGET=10.7


### PR DESCRIPTION
Introduces findExecutablesFlags as a variable which can be used to customize
the parameters for platform. So far used for darwin because it uses a find
which does not support "-perms /0100" whereas cygwin does not support "-perms
+0100" anymore.

This is inspired by the suggestion in https://github.com/NixOS/nixpkgs/pull/9603#issuecomment-137456599
It should solve the issue https://github.com/NixOS/nixpkgs/issues/9044

Never worked with these bits of nixpkgs so far, need some hint if this goes into the right direction or is fully off ;-)
