### PR TITLE
Pass platform specific find flags for executables (needed by darwin)

### DIFF
--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -569,7 +569,7 @@ let inherit (builtins) head tail trace; in
      # Interpreters that are already in the store are left untouched.
          echo "patching script interpreter paths"
          local f
-         for f in $(find "${dir}" -xtype f -perm /0100); do
+         for f in $(find "${dir}" -xtype f ''${findExecutablesFlags:--perm /0100}); do
              local oldPath=$(sed -ne '1 s,^#![ ]*\([^ ]*\).*$,\1,p' "$f")
              if test -n "$oldPath" -a "''${oldPath:0:''${#NIX_STORE}}" != "$NIX_STORE"; then
                  local newPath=$(type -P $(basename $oldPath) || true)

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -18,7 +18,7 @@ patchShebangs() {
     local oldInterpreterLine
     local newInterpreterLine
 
-    find "$dir" -type f -perm /0100 | while read f; do
+    find "$dir" -type f ${findExecutablesFlags:--perm /0100} | while read f; do
         if [ "$(head -1 "$f" | head -c +2)" != '#!' ]; then
             # missing shebang => not a script
             continue

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -47,6 +47,7 @@ rec {
     export NIX_DONT_SET_RPATH=1
     export NIX_NO_SELF_RPATH=1
     dontFixLibtool=1
+    findExecutablesFlags="-perm +0100" # the Darwin find does not support /0100
     stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
     xargsFlags=" "
     export MACOSX_DEPLOYMENT_TARGET=10.7


### PR DESCRIPTION
**Resolved TL;DR: works in the staging branch now.**

Introduces findExecutablesFlags as a variable which can be used to customize
the parameters for platform. So far used for darwin because it uses a find
which does not support "-perms /0100" whereas cygwin does not support "-perms
+0100" anymore.

Rebased on staging and stripped down version of https://github.com/NixOS/nixpkgs/pull/9666
Trying to address https://github.com/NixOS/nixpkgs/issues/9044
