### PR TITLE
evolution-data-server: Fix crash

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/evolution-data-server/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with gnome3;
     [ pkgconfig glib python intltool libsoup libxml2 gtk gnome_online_accounts
-      gcr p11_kit libgweather libgdata gperf makeWrapper icu sqlite ]
+      gcr p11_kit libgweather libgdata gperf makeWrapper icu sqlite gsettings_desktop_schemas ]
     ++ stdenv.lib.optional valaSupport vala;
 
   propagatedBuildInputs = [ libsecret nss nspr libical db ];


### PR DESCRIPTION
In journalctl, several hundred times:

```
Aug 28 08:33:44 nixos org.gnome.Shell.CalendarServer[913]: (.gnome-shell-calendar-server-wrapped:3103): ShellCalendarServer-CRITICAL **: create_client_for_source: assertion 'client == NULL' failed
Aug 28 08:33:42 nixos org.gnome.Shell.CalendarServer[913]: (.gnome-shell-calendar-server-wrapped:3103): ShellCalendarServer-WARNING **: The calendar backend for 'Tasks' has crashed.
Aug 28 08:33:42 nixos kernel: traps: .evolution-cale[3150] trap int3 ip:7f8e21e655b0 sp:7ffd0f1c8fa0 error:0
Aug 28 08:33:42 nixos org.gnome.evolution.dataserver.Calendar7[913]: (.evolution-calendar-factory-subprocess-wrapped:3150): GLib-GIO-ERROR **: Settings schema 'org.gnome.system.proxy' is not installed
```

Basically, gnome-shell starts .evolution-calendar-factory-subprocess-wrapped, it crashes due to lack of gsettings, gnome-shell sees it crashed, restarts it, etc.
