### PR TITLE
kmod-debian-aliases: init at 21-1

### DIFF
--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -85,11 +85,7 @@ with lib;
         '')}
         ${config.boot.extraModprobeConfig}
       '';
-    environment.etc."modprobe.d/usb-load-ehci-first.conf".text =
-      ''
-        softdep uhci_hcd pre: ehci_hcd
-        softdep ohci_hcd pre: ehci_hcd
-      '';
+    environment.etc."modprobe.d/debian.conf".source = pkgs.kmod-debian-aliases;
 
     environment.systemPackages = [ config.system.sbin.modprobe pkgs.kmod ];
 

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -241,6 +241,9 @@ let
           };
           symlink = "/etc/modprobe.d/ubuntu.conf";
         }
+        { object = pkgs.kmod-debian-aliases;
+          symlink = "/etc/modprobe.d/debian.conf";
+        }
       ];
   };
 

--- a/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
+++ b/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, lib }:
+let
+  version = "21-1";
+in
+stdenv.mkDerivation {
+  name = "kmod-debian-aliases-${version}.conf";
+
+  src = fetchurl {
+    url = "mirror://debian/pool/main/k/kmod/kmod_${version}.debian.tar.xz";
+    sha256 = "1abpf8g3yx972by2xpmz6dwwyc1pgh6gjbvrivmrsws69vs0xjsy";
+  };
+
+  installPhase = ''
+    patch -i patches/aliases_conf
+    cp aliases.conf $out
+  '';
+
+  meta = {
+    homepage = https://packages.debian.org/source/sid/kmod;
+    description = "Linux configuration file for modprobe";
+    maintainers = with lib.maintainers; [ mathnerd314 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10057,6 +10057,8 @@ let
 
   kmod-blacklist-ubuntu = callPackage ../os-specific/linux/kmod-blacklist-ubuntu { };
 
+  kmod-debian-aliases = callPackage ../os-specific/linux/kmod-debian-aliases { };
+
   kvm = qemu_kvm;
 
   libcap = callPackage ../os-specific/linux/libcap { };


### PR DESCRIPTION
This is a continuation of #3180; as said in the comments there, the rules need to be applied in stage 1 (and they weren't; but the message shows up randomly so I didn't notice it until now).

This also uses Debian's configuration file, instead of a hand-written one. The needed file also shows up in Ubuntu's package, but that is an old version due to https://github.com/NixOS/nixpkgs/commit/9f7d7adb052ceed89d817b46facbe7c192e36ce0.
