### PR TITLE
Update iodine's ifconfig path patch

### DIFF
--- a/pkgs/tools/networking/iodine/default.nix
+++ b/pkgs/tools/networking/iodine/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ];
 
-  patchPhase = ''sed -i "s,/sbin/ifconfig,${nettools}/bin/ifconfig,; s,/sbin/route,${nettools}/bin/route," src/tun.c'';
+  patchPhase = ''sed -i "s,/sbin/route,${nettools}/bin/route," src/tun.c'';
+
+  NIX_CFLAGS_COMPILE = "-DIFCONFIGPATH=\"${nettools}/bin/\"";
 
   installFlags = "prefix=\${out}";
 


### PR DESCRIPTION
Looks like something changed but now we can pass a #define directive via the
CFLAGS instead. Still need to patch the route path, though.
