### PR TITLE
ibus-anthy: fixup path in share/ibus/component/anthy.xml

### DIFF
--- a/pkgs/tools/inputmethods/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-anthy/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper ibus anthy intltool pkgconfig glib gobjectIntrospection python pythonPackages.pygobject3 ];
 
   postFixup = ''
+    substituteInPlace $out/share/ibus/component/anthy.xml --replace \$\{exec_prefix\} $out
     for file in "$out"/libexec/*; do
       wrapProgram "$file" \
         --prefix PYTHONPATH : $PYTHONPATH \


### PR DESCRIPTION
Apparently due to [this commit](https://github.com/ibus/ibus-anthy/commit/51ff84e0ffce0eb72dd093a890dd4f4cfdbc6c61) we now have a variable instead of a store path in `$out/share/ibus/component/anthy.xml`:

``` xml
        <exec>${exec_prefix}/libexec/ibus-engine-anthy --ibus</exec>
```

Fixes #9676.
