### PR TITLE
update emacs solarized theme and fix the name

### DIFF
--- a/pkgs/applications/editors/emacs-modes/color-theme-solarized/default.nix
+++ b/pkgs/applications/editors/emacs-modes/color-theme-solarized/default.nix
@@ -1,12 +1,14 @@
-{stdenv, fetchgit, emacs, colorTheme}:
-
+{stdenv, fetchzip, emacs, colorTheme}:
+let
+  commit = "412713a0fcedd520d208a7b783fea03d710bcc61";
+in
 stdenv.mkDerivation rec {
-  name = "color-theme-6.5.5";
+  name = "color-theme-solarized-1.0.0";
 
-  src = fetchgit {
-    url = https://github.com/sellout/emacs-color-theme-solarized.git;
-    rev = "6a2c7ca0181585858e6e8054cb99db837e2ef72f";
-    sha256 = "3c46a3d66c75ec4456209eeafdb03282148b289b12e8474f6a8962f3894796e8";
+  src = fetchzip {
+
+    url = "https://github.com/sellout/emacs-color-theme-solarized/archive/${commit}.zip";
+    sha256 = "1xd2yk7p39zxgcf91s80pqknzdxw9d09cppjb87g7ihj6f0wxqjv";
   };
 
   buildInputs = [ emacs ];
@@ -25,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Precision colors for machines and people";
     homepage = http://ethanschoonover.com/solarized;
+    maintainer = "Samuel Rivas <samuelrivas@gmail.com>";
     license = stdenv.lib.licenses.mit;
 
     platforms = stdenv.lib.platforms.all;


### PR DESCRIPTION
I am not sure if this is the best way forward, as it changes the name of the package, but I believe the former name is a mistake.

Also, this version of the solarized theme changes the api slightly, instead of having two themes, one dark and one light, it has just one and the background is controlled with a customisable variable.

Bottom line, this will break people's .emacs since they cannot do `(load-theme solarized-dark)` any more
