### PR TITLE
Bring hostname into scope needed by mysql_install_db

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -167,6 +167,12 @@ in
 
         unitConfig.RequiresMountsFor = "${cfg.dataDir}";
 
+        path = [
+          # Needed for the mysql_install_db command in the preStart script
+          # which calls the hostname command.
+          pkgs.nettools
+        ];
+
         preStart =
           ''
             if ! test -e ${cfg.dataDir}/mysql; then


### PR DESCRIPTION
I noticed the following in my journal when starting the mysql service:

```
mysql-pre-start[11129]: /nix/store/ap9mvgy8i7gxfws9scncnzf0q1l2d9m2-mariadb-10.0.21/bin/mysql_install_db: line 340: hostname: command not found
mysql-pre-start[11129]: WARNING: The host '' could not be looked up with resolveip.
mysql-pre-start[11129]: This probably means that your libc libraries are not 100 % compatible
mysql-pre-start[11129]: with this binary MariaDB version. The MariaDB daemon, mysqld, should work
mysql-pre-start[11129]: normally with the exception that host name resolving will not work.
mysql-pre-start[11129]: This means that you should use IP addresses instead of hostnames
mysql-pre-start[11129]: when specifying MariaDB privileges !
```

Adding nettools to the path fixes this. It might be cleaner to wrap mysql_install_db into a script that sets the PATH but this was the quickest fix I could come up with.
