### PR TITLE
Add erlang-mode for emacs

### DIFF
--- a/pkgs/applications/editors/emacs-modes/erlang/default.nix
+++ b/pkgs/applications/editors/emacs-modes/erlang/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, erlang }:
+
+stdenv.mkDerivation {
+
+  name = "erlang-mode-${erlang.version}";
+
+  buildInputs = [ ];
+
+  inherit erlang;
+
+  buildCommand = ''
+    mkdir -p "$out/share/emacs/site-lisp"
+    cp "$erlang/lib/erlang/lib/tools"*/emacs/*.el $out/share/emacs/site-lisp/
+  '';
+
+  # emacs highlighting */
+
+  meta = {
+    homepage = "http://github.com/erlang/otp";
+    description = "Erlang mode for Emacs";
+    licence = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ "Samuel Rivas <samuelrivas@gmail.com>" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11179,6 +11179,8 @@ let
 
     ensime = callPackage ../applications/editors/emacs-modes/ensime { };
 
+    erlangMode = callPackage ../applications/editors/emacs-modes/erlang { };
+
     ess = callPackage ../applications/editors/emacs-modes/ess { };
 
     flycheck = callPackage ../applications/editors/emacs-modes/flycheck { };


### PR DESCRIPTION
Just for convenience when working with emacs extensions, otherwise one needs to
know where the emacs mode is (and the path depends on the version of Erlang
used)
