### PR TITLE
wordpress: use the correct mysql pidDir

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
@@ -248,7 +248,7 @@ in
     if [ ! -d ${serverInfo.fullConfig.services.mysql.dataDir}/${config.dbName} ]; then
       echo "Need to create the database '${config.dbName}' and grant permissions to user named '${config.dbUser}'."
       # Wait until MySQL is up
-      while [ ! -e /var/run/mysql/mysqld.pid ]; do
+      while [ ! -e ${serverInfo.fullConfig.services.mysql.pidDir}/mysqld.pid ]; do
         sleep 1
       done
       ${pkgs.mysql}/bin/mysql -e 'CREATE DATABASE ${config.dbName};'


### PR DESCRIPTION
- mysql uses `/run/mysqld` instead of `/var/run/mysql`.
- if users change the mysql pidDir wordpress doesn't break.
