### PR TITLE
[new] github-release

### DIFF
--- a/pkgs/development/tools/github/github-release/default.nix
+++ b/pkgs/development/tools/github/github-release/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl }:
+
+let
+  linuxPredicate = stdenv.system == "x86_64-linux";
+  bsdPredicate = stdenv.system == "x86_64-freebsd";
+  darwinPredicate = stdenv.system == "x86_64-darwin";
+  metadata = assert linuxPredicate || bsdPredicate || darwinPredicate;
+    if linuxPredicate then
+      { arch = "linux-amd64";
+        sha256 = "0b3h0d0qsrjx99kcd2cf71xijh44wm5rpm2sr54snh3f7macj2p1";
+        archiveBinaryPath = "linux/amd64"; }
+    else if bsdPredicate then
+      { arch = "freebsd-amd64";
+        sha256 = "1yydm4ndkh80phiwk41kcf6pizvwrfhsfk3jwrrgr42wsnkkgj0q";
+        archiveBinaryPath = "freebsd/amd64"; }
+    else
+      { arch = "darwin-amd64";
+        sha256 = "1dj74cf1ahihia2dr9ii9ky0cpmywn42z2iq1vkbrrcggjvyrnlf";
+        archiveBinaryPath = "darwin/amd64"; };
+in stdenv.mkDerivation rec {
+  shortname = "github-release";
+  name = "${shortname}-${version}";
+  version = "0.6.2";
+
+  src = fetchurl {
+    url = "https://github.com/aktau/github-release/releases/download/v${version}/${metadata.arch}-${shortname}.tar.bz2";
+    sha256 = metadata.sha256;
+  };
+
+  buildInputs = [ ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp "${metadata.archiveBinaryPath}/github-release" "$out/bin/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Commandline app to create and edit releases on Github (and upload artifacts)";
+    longDescription = ''
+      A small commandline app written in Go that allows you to easily create and
+      delete releases of your projects on Github.
+      In addition it allows you to attach files to those releases.
+    '';
+
+    license = licenses.mit;
+    homepage = https://github.com/aktau/github-release;
+    maintainers = with maintainers; [ ardumont ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13073,6 +13073,8 @@ let
 
   tribler = callPackage ../applications/networking/p2p/tribler { };
 
+  github-release = callPackage ../development/tools/github/github-release { };
+
   tuxguitar = callPackage ../applications/editors/music/tuxguitar { };
 
   twister = callPackage ../applications/networking/p2p/twister { };


### PR DESCRIPTION
Hello,

It's an:
- installation of the binary released in a tarball (from github releases page of the repository). 
- BSD, Darwin and Linux (for bsd and darwin, i only checked the binary was installed correcly).

After build (linux x86-64):

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:master x [19:34:22]
$ ls result/bin/github-release
result/bin/github-release

# tony at corellia in ~/repo/perso/nixpkgs on git:master x [19:34:24]
$ result/bin/github-release -h
Usage: github-release [global options] <verb> [verb options]

Global options:
-h, --help           Show this help
-v, --verbose        Be verbose
-q, --quiet          Do not print anything, even errors (except if --verbose is specified)

Verbs:
delete:
-s, --security-token Github token (required if $GITHUB_TOKEN not set)
-u, --user           Github user (required if $GITHUB_USER not set)
-r, --repo           Github repo (required if $GITHUB_REPO not set)
-t, --tag            Git tag of release to delete (*)
download:
-s, --security-token Github token ($GITHUB_TOKEN if set). required if repo is private.
-u, --user           Github user (required if $GITHUB_USER not set)
-r, --repo           Github repo (required if $GITHUB_REPO not set)
-t, --tag            Git tag to upload for (*)
-n, --name           Name of the file (*)
edit:
-s, --security-token Github token (required if $GITHUB_TOKEN not set)
-u, --user           Github user (required if $GITHUB_USER not set)
-r, --repo           Github repo (required if $GITHUB_REPO not set)
-t, --tag            Git tag to edit the release of (*)
-n, --name           New name of the release (defaults to tag)
-d, --description    New description of the release (defaults to tag)
--draft          The release is a draft
-p, --pre-release    The release is a pre-release
info:
-s, --security-token Github token ($GITHUB_TOKEN if set). required if repo is private.
-u, --user           Github user (required if $GITHUB_USER not set)
-r, --repo           Github repo (required if $GITHUB_REPO not set)
-t, --tag            Git tag to query (optional)
release:
-s, --security-token Github token (required if $GITHUB_TOKEN not set)
-u, --user           Github user (required if $GITHUB_USER not set)
-r, --repo           Github repo (required if $GITHUB_REPO not set)
-t, --tag            Git tag to create a release from (*)
-n, --name           Name of the release (defaults to tag)
-d, --description    Description of the release (defaults to tag)
--draft          The release is a draft
-p, --pre-release    The release is a pre-release
upload:
-s, --security-token Github token (required if $GITHUB_TOKEN not set)
-u, --user           Github user (required if $GITHUB_USER not set)
-r, --repo           Github repo (required if $GITHUB_REPO not set)
-t, --tag            Git tag to upload for (*)
-n, --name           Name of the file (*)
-f, --file           File to upload (use - for stdin) (*)

```

After installation:

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:add-github-release o [19:40:45]
$ nix-env -f . -iA github-release
installing ‘github-release-0.6.2’
building path (s) ‘/nix/store/yfwiz6njw299vwyn96c1n93rj3idqy0w-user-environment’
created 294 symlinks in user environment

# tony at corellia in ~/repo/perso/nixpkgs on git:add-github-release o [19:41:04]
$ which github-release
/home/tony/.nix-profile/bin/github-release

# tony at corellia in ~/repo/perso/nixpkgs on git:add-github-release o [19:41:09]
$ github-release -h
Usage: github-release [global options] <verb> [verb options]

Global options:
-h, --help           Show this help
-v, --verbose        Be verbose
-q, --quiet          Do not print anything, even errors (except if --verbose is specified)
```

Cheers,
