### PR TITLE
Add playonlinux derivation.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -7,6 +7,7 @@
      so it's easy to ping a package @maintainer.
   */
 
+  a1russell = "Adam Russell <adamlr6+pub@gmail.com>";
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
   adev	   = "Adrien Devresse <adev@adev.name>";

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -1,0 +1,114 @@
+{ stdenv
+, makeWrapper
+, fetchurl
+, wxPython
+, libXmu
+, cabextract
+, gettext
+, glxinfo
+, gnupg1compat
+, icoutils
+, imagemagick
+, netcat
+, p7zip
+, python
+, unzip
+, wget
+, wine
+, xdg-user-dirs
+, xterm
+}:
+
+stdenv.mkDerivation rec {
+  name = "playonlinux-${version}";
+  version = "4.2.8";
+
+  src = fetchurl {
+    url = "https://www.playonlinux.com/script_files/PlayOnLinux/${version}/PlayOnLinux_${version}.tar.gz";
+    sha256 = "2ae8d5132706f3c697d0a53573c5835938dd042b620eb76790181b285797985c";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs =
+    [ wxPython
+      libXmu
+      cabextract
+      gettext
+      glxinfo
+      gnupg1compat
+      icoutils
+      imagemagick
+      netcat
+      p7zip
+      python
+      unzip
+      wget
+      wine
+      xdg-user-dirs
+      xterm
+    ];
+
+  patchPhase = ''
+    PYFILES="python/*.py python/lib/*.py tests/python/*.py"
+    sed -i "s/env python[0-9.]*/python/" $PYFILES
+    sed -i "s/ %F//g" etc/PlayOnLinux.desktop
+  '';
+
+  installPhase = ''
+    install -d $out/share/playonlinux
+    install -d $out/bin
+    cp -r . $out/share/playonlinux/
+
+    echo "#!${stdenv.shell}" > $out/bin/playonlinux
+    echo "$prefix/share/playonlinux/playonlinux \"\$@\"" >> $out/bin/playonlinux
+    chmod +x $out/bin/playonlinux
+
+    install -D -m644 etc/PlayOnLinux.desktop $out/share/applications/playonlinux.desktop
+  '';
+
+  preFixupPhases = [ "preFixupPhase" ];
+
+  preFixupPhase = ''
+    for f in $out/bin/*; do
+      wrapProgram $f \
+        --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
+        --prefix PATH : \
+    ${cabextract}/bin:\
+    ${gettext}/bin:\
+    ${glxinfo}/bin:\
+    ${gnupg1compat}/bin:\
+    ${icoutils}/bin:\
+    ${imagemagick}/bin:\
+    ${netcat}/bin:\
+    ${p7zip}/bin:\
+    ${python}/bin:\
+    ${unzip}/bin:\
+    ${wget}/bin:\
+    ${wine}/bin:\
+    ${xdg-user-dirs}/bin:\
+    ${xterm}/bin
+
+    done
+
+    for f in $out/share/playonlinux/bin/*; do
+      bunzip2 $f
+    done
+  '';
+
+  postFixupPhases = [ "postFixupPhase" ];
+
+  postFixupPhase = ''
+    for f in $out/share/playonlinux/bin/*; do
+      bzip2 $f
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GUI for managing Windows programs under linux";
+    homepage = https://www.playonlinux.com/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.a1russell ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12240,6 +12240,8 @@ let
 
   pig = callPackage ../applications/networking/cluster/pig { };
 
+  playonlinux = callPackage ../applications/misc/playonlinux { };
+
   shotcut = callPackage ../applications/video/shotcut { mlt = mlt-qt5; };
 
   smplayer = callPackage ../applications/video/smplayer { };


### PR DESCRIPTION
I'd like to add a derivation for [PlayOnLinux](https://www.playonlinux.com). This is my first contribution here, so please let me know if there's anything I should change. My nixos-version is `15.08pre67375.f423ba3 (Dingo)`.

_Edit: the below problem is solved now, so you can now ignore it._

Actually, the derivation as it is has some issues, and I do need some help working them out. After installing and launching playonlinux, I receive errors both via a GUI dialog and on the console.

The first GUI dialog error I receive:

> PlayOnLinux is unable to find 32bits OpenGL libraries.
> You might encounter problem with your games
> [OK]

Looking at the console, there is this exception:

> [Check_OpenGL] Warning:
> /nix/store/<hash>-playonlinux-4.2.8/share/playonlinux/bash/check_gl: line 42: /home/<me>/.PlayOnLinux//tmp/check_dd_x86: No such file or directory

Alright, so I click OK on the GUI dialog, and I get a second, very similar dialog:

> PlayOnLinux is unable to find 32bits OpenGL libraries.
> You might encounter problem with your games
> [OK]

And also another exception on the console:

> [Check_OpenGL] Warning:
> /nix/store/<hash>-playonlinux-4.2.8/share/playonlinux/bash/check_gl: line 42: /home/<me>/.PlayOnLinux//tmp/check_dd_amd64: No such file or directory

For what it's worth, those `check_dd_*` files definitely exist. I can't tell how to make them work though.

Any help?
