### PR TITLE
[emacs-package] org-trello: 0.6.9.3 -> 0.7.5, dash-functional: init at 2.11.0 (dep)

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -385,6 +385,23 @@ let self = _self // overrides;
     };
   };
 
+  dash-functional = melpaBuild rec {
+    pname = "dash-functional";
+      version = "2.11.0";
+      src = fetchFromGitHub {
+      owner  = "magnars";
+      repo   = "dash.el";
+      rev    = version;
+      sha256 = "02gfrcda7gj3j5yx71dz40xylrafl4pcaj7bgfajqi9by0w2nrnx";
+    };
+    packageRequires = [ dash ];
+    files = [ "dash-functional.el" ];
+    meta = {
+      description = "Collection of useful combinators for Emacs Lisp.";
+      license = gpl3Plus;
+    };
+  };
+
   deferred = melpaBuild rec {
     version = "0.3.2";
     pname = "deferred";

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1036,14 +1036,14 @@ let self = _self // overrides;
 
   org-trello = melpaBuild rec {
     pname = "org-trello";
-    version = "0.6.9.3";
+    version = "0.7.5";
     src = fetchFromGitHub {
       owner = "org-trello";
       repo = pname;
-      rev = "f1e1401a373dd492eee49fb131b1cd66b3a9ac37";
-      sha256 = "003gdh8rgdl3k8h20wgbciqyacyqr64w1wfdqvwm9qdz414q5yj3";
+      rev = "3718ed704094e5e5a491749f1f722d76ba4b7d73";
+      sha256 = "1561nxjva8892via0l8315y3fih4r4q9gzycmvh33db8gqzq4l86";
     };
-    packageRequires = [ request-deferred deferred dash s ];
+    packageRequires = [ request-deferred deferred dash-functional s ];
     files = [ "org-trello-*.el" ];
     meta = {
       description = "Org minor mode - 2-way sync org & trello";


### PR DESCRIPTION
# Summary
- dash-functional: init at 2.11.0 (org-trello dependency)
- org-trello: 0.6.9.3 -> 0.7.5
# Test

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:update-org-trello o [17:04:08]
$ nix-build -A emacs24PackagesNg.org-trello -A emacs24PackagesNg.dash-functional
/nix/store/1a3qnhrq2qcmg4m1vvjzq04wqymk0gh2-emacs-org-trello-0.7.5
/nix/store/y4mw6yldmzdpc2n2qrkrgisifca90aql-emacs-dash-functional-2.11.0

# tony at corellia in ~/repo/perso/nixpkgs on git:update-org-trello o [17:04:10]
$ tree result result-2
result
├── nix-support
│   ├── propagated-native-build-inputs
│   ├── propagated-user-env-packages
│   └── setup-hook
└── share
    └── emacs
        └── site-lisp
            └── elpa
                └── org-trello-0.7.5
                    ├── org-trello-action.el
                    ├── org-trello-action.elc
                    ├── org-trello-api.el
                    ├── org-trello-api.elc
                    ├── org-trello-autoloads.el
                    ├── org-trello-autoloads.el~
                    ├── org-trello-backend.el
                    ├── org-trello-backend.elc
                    ├── org-trello-buffer.el
                    ├── org-trello-buffer.elc
                    ├── org-trello-cbx.el
                    ├── org-trello-cbx.elc
                    ├── org-trello-controller.el
                    ├── org-trello-controller.elc
                    ├── org-trello-data.el
                    ├── org-trello-data.elc
                    ├── org-trello-date.el
                    ├── org-trello-date.elc
                    ├── org-trello-deferred.el
                    ├── org-trello-deferred.elc
                    ├── org-trello-entity.el
                    ├── org-trello-entity.elc
                    ├── org-trello-hash.el
                    ├── org-trello-hash.elc
                    ├── org-trello-input.el
                    ├── org-trello-input.elc
                    ├── org-trello-log.el
                    ├── org-trello-log.elc
                    ├── org-trello-pkg.el
                    ├── org-trello-proxy.el
                    ├── org-trello-proxy.elc
                    ├── org-trello-query.el
                    ├── org-trello-query.elc
                    ├── org-trello-setup.el
                    ├── org-trello-setup.elc
                    ├── org-trello-tools.el
                    ├── org-trello-tools-test.el
                    ├── org-trello-utils.el
                    └── org-trello-utils.elc
result-2
├── nix-support
│   ├── propagated-native-build-inputs
│   ├── propagated-user-env-packages
│   └── setup-hook
└── share
    └── emacs
        └── site-lisp
            └── elpa
                └── dash-functional-2.11.0
                    ├── dash-functional-autoloads.el
                    ├── dash-functional-autoloads.el~
                    ├── dash-functional.el
                    ├── dash-functional.elc
                    ├── dash-functional-pkg.el
                    └── dash-functional-pkg.elc

12 directories, 51 files
```

Once installed (`nix-env -f . -A ...`) :

``` sh
# tony at corellia in ~ [17:12:22]
$ f ~/.nix-profile/share/emacs/ org-trello
/home/tony/.nix-profile/share/emacs/site-lisp/elpa/org-trello-0.6.9.3
/home/tony/.nix-profile/share/emacs/site-lisp/elpa/org-trello-0.7.5
```

Note:
- f is an alias on find
- 0.6.9.3 is the current installed version from my `emacs-env`.
