### PR TITLE
steam: added libdrm to chrootenv.

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -51,6 +51,7 @@ buildFHSUserEnv {
       pkgs.mesa
       pkgs.SDL
       pkgs.SDL2
+      pkgs.libdrm
 
       pkgs.libgcrypt
       pkgs.zlib


### PR DESCRIPTION
The game Trine 2 will not launch without it.
