### PR TITLE
wordpress: execute the extraConfig before loading wp-settings.php

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
@@ -17,10 +17,10 @@ let
     define('DB_HOST',     '${config.dbHost}');
     define('DB_CHARSET',  'utf8');
     $table_prefix  = '${config.tablePrefix}';
+    ${config.extraConfig}
     if ( !defined('ABSPATH') )
     	define('ABSPATH', dirname(__FILE__) . '/');
     require_once(ABSPATH . 'wp-settings.php');
-    ${config.extraConfig}
   '';
 
   # .htaccess to support pretty URLs


### PR DESCRIPTION
This is needed so that settings defined in `extraConfig` actually get handled.

I spend several hours figuring out why my `extraConfig` wasn't working so it would be great if this could be merged.

@qknight: do you think this makes sense?
