### PR TITLE
pythonPackages.django-taggit: init at 0.17.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5521,6 +5521,24 @@ let
     };
   };
 
+  django_taggit = buildPythonPackage rec {
+    name = "django-taggit-${version}";
+    version = "0.17.0";
+    disabled = pythonOlder "2.7";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/d/django-taggit/django-taggit-${version}.tar.gz";
+      sha256 = "1xy4mm1y6z6bpakw907859wz7fiw7jfm586dj89w0ggdqlb0767b";
+    };
+
+    meta = {
+      description = "django-taggit is a reusable Django application for simple tagging";
+      homepage = http://github.com/alex/django-taggit/tree/master/;
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ desiderius ];
+    };
+  };
+
   django_treebeard = buildPythonPackage rec {
     name = "django-treebeard-${version}";
     version = "3.0";


### PR DESCRIPTION
django-taggit is a reusable Django application for simple tagging.

Tested on PyPy and Python 2.7 -> 3.4.
