### PR TITLE
pythonPackages.django-modelcluster: init at 0.6.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5482,6 +5482,25 @@ let
     };
   };
 
+  django_modelcluster = buildPythonPackage rec {
+    name = "django-modelcluster-${version}";
+    version = "0.6.2";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/d/django-modelcluster/django-modelcluster-${version}.tar.gz";
+      sha256 = "1plsdi44dvsj2sfx79lsrccjfg0ymajcsf5n0mln4cwd4qi5mwpx";
+    };
+
+    propagatedBuildInputs = with self; [ pytz six ];
+
+    meta = {
+      description = "Django extension to allow working with 'clusters' of models as a single unit, independently of the database";
+      homepage = https://github.com/torchbox/django-modelcluster/;
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ desiderius ];
+    };
+  };
+
   djangorestframework = buildPythonPackage rec {
     name = "djangorestframework-${version}";
     version = "3.2.3";


### PR DESCRIPTION
Django extension to allow working with 'clusters' of models as
a single unit, independently of the database.

Tested on PyPy and Python 2.7 -> 3.4.
