### PR TITLE
urjtag: path fixes, more useflags, and enabled features

### DIFF
--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoconf, automake, pkgconfig, gettext, intltool, libtool, bison
-, flex, fetchgit, makeWrapper
+, flex, which, subversion, fetchsvn, makeWrapper
 , jedecSupport ? false
 , pythonBindings ? false
 , python3 ? null
@@ -9,23 +9,21 @@ stdenv.mkDerivation rec {
   version = "0.10";
   name = "urjtag-${version}";
 
-  src = fetchgit {
-    url = "git://git.code.sf.net/p/urjtag/git";
-    rev = "7ba12da7845af7601e014a2a107670edc5d6997d";
-    sha256 = "834401d851728c48f1c055d24dc83b6173c701bf352d3a964ec7ff1aff3abf6a";
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/urjtag/svn/trunk/urjtag";
+    rev = "2051";
+    sha256 = "0pyl0y27136nr8mmjdml7zjnfnpbjmgqzkjk99j3hvj38k10wq7f";
   };
 
-  buildInputs = [ gettext pkgconfig autoconf automake libtool makeWrapper ]
+  buildInputs = [ gettext pkgconfig autoconf automake libtool bison flex which subversion makeWrapper ]
     ++ stdenv.lib.optional pythonBindings python3;
 
   configureFlags = ''
-    --prefix=/
     ${if jedecSupport then "--enable-jedec-exp" else "--disable-jedec-exp"}
     ${if pythonBindings then "--enable-python" else "--disable-python"}
   '';
-  preConfigure = "cd urjtag; ./autogen.sh";
 
-  makeFlags = [ "DESTDIR=$(out)" ];
+  preConfigure = "./autogen.sh";
 
   meta = {
     description = "Enhanced, modern tool for communicating over JTAG with flash chips, CPUs,and many more";

--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -1,8 +1,10 @@
 { stdenv, autoconf, automake, pkgconfig, gettext, intltool, libtool, bison
-, flex, which, subversion, fetchsvn, makeWrapper
+, flex, which, subversion, fetchsvn, makeWrapper, libftdi, libusb, readline
+, python3
+, svfSupport ? false
+, bsdlSupport ? false
+, staplSupport ? false
 , jedecSupport ? false
-, pythonBindings ? false
-, python3 ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -15,12 +17,14 @@ stdenv.mkDerivation rec {
     sha256 = "0pyl0y27136nr8mmjdml7zjnfnpbjmgqzkjk99j3hvj38k10wq7f";
   };
 
-  buildInputs = [ gettext pkgconfig autoconf automake libtool bison flex which subversion makeWrapper ]
-    ++ stdenv.lib.optional pythonBindings python3;
+  buildInputs = [ gettext pkgconfig autoconf automake libtool bison flex which
+    subversion makeWrapper readline libftdi libusb python3 ];
 
   configureFlags = ''
+    ${if svfSupport then "--enable-svf" else "--disable-svf"}
+    ${if bsdlSupport then "--enable-bsdl" else "--disable-bsdl"}
+    ${if staplSupport then "--enable-stapl" else "--disable-stapl"}
     ${if jedecSupport then "--enable-jedec-exp" else "--disable-jedec-exp"}
-    ${if pythonBindings then "--enable-python" else "--disable-python"}
   '';
 
   preConfigure = "./autogen.sh";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3476,8 +3476,10 @@ let
   uptimed = callPackage ../tools/system/uptimed { };
 
   urjtag = callPackage ../tools/misc/urjtag {
+    svfSupport = true;
+    bsdlSupport = true;
+    staplSupport = true;
     jedecSupport = true;
-    pythonBindings = true;
   };
 
   urlwatch = callPackage ../tools/networking/urlwatch { };


### PR DESCRIPTION
After trying to use the UrJTAG package I submitted earlier some problems with it became apparent and are now fixed with this commit.
- fixed paths to `MANUFACTURERS` file, etc (for urjtag `detect` command) file by removing `DESTDIR=$(out)` _and_ removing `--prefix=/` [You were right](https://github.com/NixOS/nixpkgs/pull/9533#discussion_r38264576), @bjornfor 
- added more useflags
- enabled those features that work (such as readline support)
- switched to `svn` URL so that rev number can be included in version string: `UrJTAG 0.10 #2051` and so that one doesn't need to download the `web/` subdirectory.
