### PR TITLE
jitsi: fix the run script to work when installed via systemPackages

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jitsi/jitsi.patch
+++ b/pkgs/applications/networking/instant-messengers/jitsi/jitsi.patch
@@ -7,7 +7,7 @@
 +
 +#mkdir -p $HOME/.sip-communicator/log
 +
-+cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )"
++cd "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
  
  # Get architecture
  ARCH=`uname -m | sed -e s/x86_64/64/ -e s/i.86/32/`


### PR DESCRIPTION
Otherwise, the wrong directory is changed into, and trying to start Jitsi gives:

```
$ jitsi
Error: Could not find or load main class net.java.sip.communicator.launcher.SIPCommunicator
```

(After this, I hit #3482.)
