### PR TITLE
nixos containers: fix system path when reloading

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -299,7 +299,7 @@ in
             ''
               #! ${pkgs.stdenv.shell} -e
               ${nixos-container}/bin/nixos-container run "$INSTANCE" -- \
-                bash --login -c "/nix/var/nix/profiles/system/bin/switch-to-configuration test"
+                bash --login -c "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/bin/switch-to-configuration test"
             '';
 
           SyslogIdentifier = "container %i";


### PR DESCRIPTION
cc @edolstra reload is broken for declarative containers, `/nix/var/nix/profiles/system` just doesn't exist. I've tested this change briefly and seems to work correctly.

This is quite a blocker for declarative containers, currently they can only be restarted.

I'm not sure if this also applies to imperative containers though.
