### PR TITLE
plan9port: fix interpreter paths, add perl

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -1,6 +1,7 @@
 source $stdenv/setup
 
 export PLAN9=$out/plan9
+export PLAN9_TARGET=$PLAN9
 
 configurePhase()
 {
@@ -15,12 +16,12 @@ configurePhase()
 buildPhase()
 {
     mkdir -p $PLAN9
-    ./INSTALL -b $PLAN9
+    ./INSTALL -b
 }
 
 installPhase()
 {
-    ./INSTALL -c -r $PLAN9
+    ./INSTALL -c
     # Copy sources
     cp -R * $PLAN9
 

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -1,7 +1,9 @@
 {stdenv, fetchgit, which, libX11, libXt, fontconfig
 , xproto ? null
 , xextproto ? null
-, libXext ? null }:
+, libXext ? null
+  # For building web manuals
+, perl ? null }:
 
 stdenv.mkDerivation rec {
   name = "plan9port-2015-06-29";
@@ -23,7 +25,17 @@ stdenv.mkDerivation rec {
   builder = ./builder.sh;
 
   NIX_LDFLAGS="-lgcc_s";
-  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [ which libX11 fontconfig xproto libXt xextproto libXext ];
+  buildInputs = stdenv.lib.optionals
+                  (!stdenv.isDarwin)
+                  [ which
+                    perl
+                    libX11
+                    fontconfig
+                    xproto
+                    libXt
+                    xextproto
+                    libXext
+                  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Fixing interpreter paths was done by exporting PLAN9_TARGET, which
INSTALL looks at. Giving $PLAN9 to INSTALL does not achieve this, as
INSTALL only looks at its first argument so I removed the other
arguments to avoid confusion.

Perl is an optional dependency for a script that adds URLs to man pages,
I have added it to get fewer errors during install.
