### PR TITLE
VirtualBox Extension Pack -> 102096.

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -35,7 +35,7 @@ let
   '';
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
-  extpackRevision = "101573";
+  extpackRevision = "102096";
   extensionPack = requireFile rec {
     name = "Oracle_VM_VirtualBox_Extension_Pack-${version}-${extpackRevision}.vbox-extpack";
     # IMPORTANT: Hash must be base16 encoded because it's used as an input to


### PR DESCRIPTION
Update VirtualBox Extension Pack Revision to match 5.0.2.

Current VirtualBox version in Unstable Channel is uninstallable if you use the extension pack because this is not correct.
