### PR TITLE
nixos/deluge: restart daemon if it's stopped from GUI

### DIFF
--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -36,6 +36,8 @@ in {
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.pythonPackages.deluge ];
       serviceConfig.ExecStart = "${pkgs.pythonPackages.deluge}/bin/deluged -d";
+      # To prevent "Quit & shutdown daemon" from working; we want systemd to manage it!
+      serviceConfig.Restart = "on-success";
       serviceConfig.User = "deluge";
       serviceConfig.Group = "deluge";
     };


### PR DESCRIPTION
Because we control daemon with systemd and run it system-wise (e.g. on a server), we don't want to be able to stop it from GUI ("Quit & shutdown daemon" option); if we want to stop it, it should be done properly though systemd.

Someone might find this feature useful though, so I'd like to put this for discussion for some time.

cc @domenkozar 
