### PR TITLE
jitsi: patch RPATHs for missing libraries

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, makeDesktopItem, unzip, ant, jdk }:
+{ stdenv, lib, fetchurl, makeDesktopItem, unzip, ant, jdk
+# Optional, Jitsi still runs without, but you may pass null:
+, alsaLib, dbus_libs, gtk2, libpulseaudio, openssl, xlibs
+}:
 
 stdenv.mkDerivation rec {
 
@@ -22,6 +25,21 @@ stdenv.mkDerivation rec {
     categories = "Application;Internet;";
   };
 
+  libPath = lib.makeLibraryPath ([
+    stdenv.cc.cc  # For libstdc++.
+  ] ++ lib.filter (x: x != null) [
+    alsaLib
+    dbus_libs
+    gtk2
+    libpulseaudio
+    openssl
+  ] ++ lib.optionals (xlibs != null) [
+    xlibs.libX11
+    xlibs.libXext
+    xlibs.libXScrnSaver
+    xlibs.libXv
+  ]);
+
   buildInputs = [unzip ant jdk];
 
   buildPhase = ''ant make'';
@@ -35,6 +53,12 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/jitsi
     sed -i 's| java | ${jdk}/bin/java |' $out/bin/jitsi
     patchShebangs $out
+
+    libPath="$libPath:${jdk.jre.home}/lib/${jdk.architecture}"
+    find $out/ -type f -name '*.so' | while read file; do
+      patchelf --set-rpath "$libPath" "$file" && \
+          patchelf --shrink-rpath "$file"
+    done
   '';
 
   meta = {

--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
     description = "Open Source Video Calls and Chat";
     license = stdenv.lib.licenses.lgpl21Plus.shortName;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.khumba ];
   };
 
 }

--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     cp resources/install/generic/run.sh $out/bin/jitsi
     chmod +x $out/bin/jitsi
-    sed -i 's| java | ${jdk}/bin/java |' $out/bin/jitsi
+    substituteInPlace $out/bin/jitsi --replace '@JAVA@' '${jdk}/bin/java'
     patchShebangs $out
 
     libPath="$libPath:${jdk.jre.home}/lib/${jdk.architecture}"

--- a/pkgs/applications/networking/instant-messengers/jitsi/jitsi.patch
+++ b/pkgs/applications/networking/instant-messengers/jitsi/jitsi.patch
@@ -24,4 +24,4 @@
  
  export PATH=$PATH:native
 -java $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=native -Dfelix.config.properties=file:./lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator
-+exec java $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=$NATIVELIBS -Dfelix.config.properties=file:lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator
++exec @JAVA@ $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=$NATIVELIBS -Dfelix.config.properties=file:lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -5,6 +5,18 @@
 }:
 
 let
+
+  /**
+   * The JRE libraries are in directories that depend on the CPU.
+   */
+  architecture =
+    if stdenv.system == "i686-linux" then
+      "i386"
+    else if stdenv.system == "x86_64-linux" then
+      "amd64"
+    else
+      throw "openjdk requires i686-linux or x86_64 linux";
+
   update = "60";
   build = "24";
   baseurl = "http://hg.openjdk.java.net/jdk8u/jdk8u";
@@ -204,6 +216,9 @@ let
       platforms = platforms.linux;
     };
 
-    passthru.home = "${openjdk8}/lib/openjdk";
+    passthru = {
+      inherit architecture;
+      home = "${openjdk8}/lib/openjdk";
+    };
   };
 in openjdk8


### PR DESCRIPTION
Jitsi bundles some .so files for Linux that need RPATHs to function correctly.  Otherwise, Jitsi will still start (if installed in a user environment, #9754), but with missing functionality, for example without audio because no audio libraries are found.

CC @edwtjo as the maintainer of openjdk8: Is it alright for me to add an `architecture` passthru variable as there is in the openjdk7 expression (openjdk/default.nix)?  Could you please confirm that this is still valid (and in particular, the name of the i386 directory)?  I'm running 64-bit and haven't tested with a 32-bit system.  Also, `jdk.jre.home` has the same value as `jdk.home`, is using `jdk.jre.home` preferred?

Thanks.
