### PR TITLE
parallel: no dependency on `procps` on Darwin

### DIFF
--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sed -i 's,#![ ]*/usr/bin/env[ ]*perl,#!${perl}/bin/perl,' $out/bin/*
 
     wrapProgram $out/bin/parallel \
-      --prefix PATH : "${procps}/bin" \
+      ${if stdenv.isLinux then ("--prefix PATH \":\" ${procps}/bin") else ""} \
       --prefix PATH : "${perl}/bin" \
   '';
 


### PR DESCRIPTION
Fixes #9592 

`parallel` is also required for building go packages.

This does not implement @copumpkin's suggestion in #9592. Instead it's a temporary workaround until a logical `ps` attribute is provided (I'm not confident enough for this suggestion just yet).
