### PR TITLE
nix-prefetch-git: pull all tags from remote when checkouting by revision

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -109,7 +109,7 @@ checkout_hash(){
         hash=$(hash_from_ref $ref)
     fi
 
-    git fetch ${builder:+--progress} origin || return 1
+    git fetch -t ${builder:+--progress} origin || return 1
     git checkout -b $branchName $hash || return 1
 }
 


### PR DESCRIPTION
This fixes fetching for a nasty combination:
1. To be checkouted is a revision which corresponds to a tag in form "<tag>^{}".
2. This revision is not fetched by default.

I've stumbled upon this while trying to fetch Julia's complete package repository.
