### PR TITLE
mlmmj: postfix master config uses deprecated nextHop instead of nexthop

### DIFF
--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -90,7 +90,7 @@ in
       enable = true;
       recipientDelimiter= "+";
       extraMasterConf = ''
-        mlmmj unix - n n - - pipe flags=ORhu user=mlmmj argv=${pkgs.mlmmj}/bin/mlmmj-receive -F -L ${spoolDir}/$nextHop
+        mlmmj unix - n n - - pipe flags=ORhu user=mlmmj argv=${pkgs.mlmmj}/bin/mlmmj-receive -F -L ${spoolDir}/$nexthop
       '';
 
       extraAliases = concatMapStrings (alias cfg.listDomain) cfg.mailLists;


### PR DESCRIPTION
Hi,

this wrong variable name causes mlmmj/postfix to fail with:

```
Sep 11 13:20:30 host postfix/pipe[34899]: warning: file /var/postfix/conf/master.cf: service mlmmj: unknown macro name: "nextHop"
```

as a result, messages will not be delivered
