### PR TITLE
mlmmj: fixing reply-to field in customheaders

### DIFF
--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -14,7 +14,7 @@ let
   alias = domain: list: "${list}: \"|${pkgs.mlmmj}/bin/mlmmj-receive -L ${listDir domain list}/\"";
   subjectPrefix = list: "[${list}]";
   listAddress = domain: list: "${list}@${domain}";
-  customHeaders = list: domain: [ "List-Id: ${list}" "Reply-To: ${list}@${domain}" ];
+  customHeaders = domain: list: [ "List-Id: ${list}" "Reply-To: ${list}@${domain}" ];
   footer = domain: list: "To unsubscribe send a mail to ${list}+unsubscribe@${domain}";
   createList = d: l: ''
     ${pkgs.coreutils}/bin/mkdir -p ${listCtl d l}


### PR DESCRIPTION
Hi,

currently, the customheaders will be generated the other way around

```
cat /var/spool/mlmmj/k4cg.org/k4cg/control/customheaders
List-Id: k4cg
Reply-To: k4cg.org@k4cg
```

The following commit fixes that behavoir. 
