### PR TITLE
libao: enable libcap only on Linux

### DIFF
--- a/pkgs/development/libraries/libao/default.nix
+++ b/pkgs/development/libraries/libao/default.nix
@@ -10,8 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig libcap ] ++
-    lib.optional stdenv.isLinux (if usePulseAudio then libpulseaudio else alsaLib);
+    [ pkgconfig ] ++
+    lib.optional stdenv.isLinux (if usePulseAudio then libpulseaudio else alsaLib) ++
+    lib.optional stdenv.isLinux libcap;
 
   meta = {
     longDescription = ''


### PR DESCRIPTION
@Fuuzetsu 
libcap is not compatible with Darwin.
Tested on OS X 10.10.4 (i.e. sox is working).
