### PR TITLE
WIP: cudatoolkit: add version 7.5

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/7.5.nix
+++ b/pkgs/development/compilers/cudatoolkit/7.5.nix
@@ -1,0 +1,7 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "7.5.18";
+  sha256 = "1i8rx7bc1v01v3lmcbi26hwyqkrqsdiinfmfz0ix6s9b3rngnpr4";
+  url = "http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1217,6 +1217,10 @@ let
     inherit callPackage;
   };
 
+  cudatoolkit75 = import ../development/compilers/cudatoolkit/7.5.nix {
+    inherit callPackage;
+  };
+
   cudatoolkit = cudatoolkit7;
 
   curlFull = curl.override {


### PR DESCRIPTION
TODO: Fix nsight startup error:

 $ ./result/bin/nsight
 CompilerOracle: exclude java/lang/reflect/Array.newInstance
 java.lang.NoClassDefFoundError: Could not initialize class
 sun.util.calendar.ZoneInfoFile
         at sun.util.calendar.ZoneInfo.getTimeZone(ZoneInfo.java:663)
         at java.util.TimeZone.getTimeZone(TimeZone.java:560)
         at java.util.TimeZone.setDefaultZone(TimeZone.java:657)
         at java.util.TimeZone.getDefaultRef(TimeZone.java:624)
         at java.util.Date.normalize(Date.java:1193)
         at java.util.Date.toString(Date.java:1027)
         at org.eclipse.equinox.launcher.Main.log(Main.java:2423)
         at org.eclipse.equinox.launcher.Main.run(Main.java:1476)
         at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
