### PR TITLE
gettext: 0.19.5.1 -> 0.19.6

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libiconv, xz }:
 
 stdenv.mkDerivation (rec {
-  name = "gettext-0.19.5.1";
+  name = "gettext-0.19.6";
 
   src = fetchurl {
     url = "mirror://gnu/gettext/${name}.tar.gz";
-    sha256 = "0cbp498ckjwj7qr8b9pmkry8hkhldgkvg5yix8hi9c8z1hxxb651";
+    sha256 = "0pb9vp4ifymvdmc31ks3xxcnfqgzj8shll39czmk8c1splclqjzd";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
http://lists.gnu.org/archive/html/bug-gettext/2015-09/msg00008.html

This will triggers a mass rebuild I think…
