### PR TITLE
quassel: Start after its databases

### DIFF
--- a/nixos/modules/services/networking/quassel.nix
+++ b/nixos/modules/services/networking/quassel.nix
@@ -78,7 +78,8 @@ in
       { description = "Quassel IRC client daemon";
 
         wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ];
+        after = [ "network.target" ] ++ optional config.services.postgresql.enable "postgresql.service"
+                                     ++ optional config.services.mysql.enable "mysql.service";
 
         preStart = ''
           mkdir -p ${cfg.dataDir}


### PR DESCRIPTION
Like in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=701943
