### PR TITLE
claws-mail: install desktop item, take maintainership

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -141,6 +141,7 @@
   jwilberding = "Jordan Wilberding <jwilberding@afiniate.com>";
   jzellner = "Jeff Zellner <jeffz@eml.cc>";
   kamilchm = "Kamil Chmielewski <kamil.chm@gmail.com>";
+  khumba = "Bryan Gardiner <bog@khumba.net>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
     homepage = http://www.claws-mail.org/;
     license = licenses.gpl3;
     platforms = platforms.linux;
+    maintainers = [ maintainers.khumba ];
   };
 
   src = fetchurl {

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -79,4 +79,9 @@ stdenv.mkDerivation {
     ++ optional (!enablePluginSpamReport) "--disable-spam_report-plugin"
     ++ optional (!enablePluginVcalendar) "--disable-vcalendar-plugin"
     ++ optional (!enableSpellcheck) "--disable-enchant";
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp claws-mail.desktop $out/share/applications
+  '';
 }


### PR DESCRIPTION
Tested locally, Claws appears in the KDE application menu with this patch.
