### PR TITLE
llvm 3.7

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/clang/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src }:
+
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+in stdenv.mkDerivation {
+  name = "clang-${version}";
+
+  unpackPhase = ''
+    unpackFile ${fetch "cfe" "1k517b0jj74c4vgnnd4ikbrpb96na541bi8q845ckw8xm72l1msf"}
+    mv cfe-${version}.src clang
+    sourceRoot=$PWD/clang
+    unpackFile ${clang-tools-extra_src}
+    mv clang-tools-extra-* $sourceRoot/tools/extra
+  '';
+
+  buildInputs = [ cmake libedit libxml2 llvm ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_CXX_FLAGS=-std=c++11"
+  ] ++
+  # Maybe with compiler-rt this won't be needed?
+  (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
+  (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+
+  patches = [ ./purity.patch ];
+
+  postPatch = ''
+    sed -i -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/Tools.cpp
+    sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
+  '';
+
+  # Clang expects to find LLVMgold in its own prefix
+  # Clang expects to find sanitizer libraries in its own prefix
+  postInstall = ''
+    ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+    ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
+    ln -sv $out/bin/clang $out/bin/cpp
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    isClang = true;
+  } // stdenv.lib.optionalAttrs stdenv.isLinux {
+    inherit gcc;
+  };
+
+  meta = {
+    description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.7/clang/purity.patch
+++ b/pkgs/development/compilers/llvm/3.7/clang/purity.patch
@@ -1,0 +1,17 @@
+--- a/lib/Driver/Tools.cpp	2015-07-31 00:47:41.000000000 +0200
++++ b/lib/Driver/Tools.cpp	2015-09-11 21:30:50.057895565 +0200
+@@ -8150,15 +8150,6 @@
+     CmdArgs.push_back("-shared");
+   }
+ 
+-  if (Arch == llvm::Triple::arm || Arch == llvm::Triple::armeb ||
+-      Arch == llvm::Triple::thumb || Arch == llvm::Triple::thumbeb ||
+-      (!Args.hasArg(options::OPT_static) &&
+-       !Args.hasArg(options::OPT_shared))) {
+-    CmdArgs.push_back("-dynamic-linker");
+-    CmdArgs.push_back(Args.MakeArgString(
+-        D.DyldPrefix + getLinuxDynamicLinker(Args, ToolChain)));
+-  }
+-
+   CmdArgs.push_back("-o");
+   CmdArgs.push_back(Output.getFilename());

--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -1,0 +1,35 @@
+{ newScope, stdenv, isl, fetchurl, overrideCC, wrapCC }:
+let
+  callPackage = newScope (self // { inherit stdenv isl version fetch; });
+
+  version = "3.7.0";
+
+  fetch = fetch_v version;
+  fetch_v = ver: name: sha256: fetchurl {
+    url = "http://llvm.org/releases/${ver}/${name}-${ver}.src.tar.xz";
+    inherit sha256;
+  };
+
+  compiler-rt_src = fetch "compiler-rt" "02rbsqdnj1dw9q3d8w5wwmvz5gfraiv8xp18lis4kj8baacajzr2";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1k894zkx4w8grigmgv5y4q9zrcic2ypz0zfn28270ykbm6is1s4a";
+
+  self = {
+    llvm = callPackage ./llvm.nix {
+      inherit compiler-rt_src stdenv;
+    };
+
+    clang-unwrapped = callPackage ./clang {
+      inherit clang-tools-extra_src stdenv;
+    };
+
+    clang = wrapCC self.clang-unwrapped;
+
+    stdenv = overrideCC stdenv self.clang;
+
+    lldb = callPackage ./lldb.nix {};
+
+    libcxx = callPackage ./libc++ {};
+
+    libcxxabi = callPackage ./libc++abi.nix {};
+  };
+in self

--- a/pkgs/development/compilers/llvm/3.7/libc++/darwin.patch
+++ b/pkgs/development/compilers/llvm/3.7/libc++/darwin.patch
@@ -1,0 +1,30 @@
+diff -ru -x '*~' libcxx-3.4.2.src-orig/lib/CMakeLists.txt libcxx-3.4.2.src/lib/CMakeLists.txt
+--- libcxx-3.4.2.src-orig/lib/CMakeLists.txt	2013-11-15 18:18:57.000000000 +0100
++++ libcxx-3.4.2.src/lib/CMakeLists.txt	2014-09-24 14:04:01.000000000 +0200
+@@ -56,7 +56,7 @@
+       "-compatibility_version 1"
+       "-current_version ${LIBCXX_VERSION}"
+       "-install_name /usr/lib/libc++.1.dylib"
+-      "-Wl,-reexport_library,/usr/lib/libc++abi.dylib"
++      "-Wl,-reexport_library,${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
+       "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
+       "/usr/lib/libSystem.B.dylib")
+   else()
+@@ -64,14 +64,14 @@
+       list(FIND ${CMAKE_OSX_ARCHITECTURES} "armv7" OSX_HAS_ARMV7)
+       if (OSX_HAS_ARMV7)
+         set(OSX_RE_EXPORT_LINE
+-          "${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib"
++          "${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
+           "-Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++sjlj-abi.exp")
+       else()
+         set(OSX_RE_EXPORT_LINE
+-          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib")
++          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib")
+       endif()
+     else()
+-      set (OSX_RE_EXPORT_LINE "/usr/lib/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
++      set (OSX_RE_EXPORT_LINE "${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
+     endif()
+ 
+     list(APPEND link_flags

--- a/pkgs/development/compilers/llvm/3.7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetch, cmake, libcxxabi, fixDarwinDylibNames, version }:
+
+stdenv.mkDerivation rec {
+  name = "libc++-${version}";
+
+  src = fetch "libcxx" "13nh78zp5d2jf732mxnalw679zjywbjpz9942j66fznd6f1kr3y1";
+
+  postUnpack = ''
+    unpackFile ${libcxxabi.src}
+  '';
+
+  preConfigure = ''
+    # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
+    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$NIX_BUILD_TOP/libcxxabi-${version}.src/include")
+  '' +
+  stdenv.lib.optionalString stdenv.isDarwin ''
+    # instead of allowing libc++ to link with /usr/lib/libc++abi.dylib,
+    # force it to link with our copy
+    substituteInPlace lib/CMakeLists.txt \
+      --replace 'OSX_RE_EXPORT_LINE "/usr/lib/libc++abi.dylib' \
+                'OSX_RE_EXPORT_LINE "${libcxxabi}/lib/libc++abi.dylib' \
+      --replace '"''${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib"' \
+                '"${libcxxabi}/lib/libc++abi.dylib"'
+  '';
+
+  patches = [ ./darwin.patch ];
+
+  buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  cmakeFlags =
+    [ "-DCMAKE_BUILD_TYPE=Release"
+      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+      "-DLIBCXX_LIBCPPABI_VERSION=2"
+      "-DLIBCXX_CXX_ABI=libcxxabi"
+    ];
+
+  enableParallelBuilding = true;
+
+  linkCxxAbi = stdenv.isLinux;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://libcxx.llvm.org/;
+    description = "A new implementation of the C++ standard library, targeting C++11";
+    license = "BSD";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.7/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.7/libc++/setup-hook.sh
@@ -1,0 +1,3 @@
+linkCxxAbi="@linkCxxAbi@"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.7/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++abi.nix
@@ -1,0 +1,47 @@
+{ stdenv, cmake, fetch, libcxx, libunwind, llvm, version }:
+
+stdenv.mkDerivation {
+  name = "libc++abi-${version}";
+
+  src = fetch "libcxxabi" "1swvnhrf9g67579c5picg0l869f8l2bwi4xqpbcb4n296gyp9c28";
+
+  buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin) libunwind;
+
+  postUnpack = ''
+    unpackFile ${libcxx.src}
+    unpackFile ${llvm.src}
+    export NIX_CFLAGS_COMPILE+=" -I$PWD/include"
+    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_INCLUDES=$PWD/$(ls -d libcxx-*)/include"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export TRIPLE=x86_64-apple-darwin
+  '';
+
+  installPhase = if stdenv.isDarwin
+    then ''
+      for file in lib/*.dylib; do
+        # this should be done in CMake, but having trouble figuring out
+        # the magic combination of necessary CMake variables
+        # if you fancy a try, take a look at
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        install_name_tool -id $out/$file $file
+      done
+      make install
+      install -d 755 $out/include
+      install -m 644 ../include/cxxabi.h $out/include
+    ''
+    else ''
+      install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      install -m 644 ../include/cxxabi.h $out/include
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+    '';
+
+  meta = {
+    homepage = http://libcxxabi.llvm.org/;
+    description = "A new implementation of low level support for a standard C++ library";
+    license = "BSD";
+    maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.7/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.7/lldb.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, ncurses
+, swig
+, which
+, libedit
+, llvm
+, clang-unwrapped
+, python
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "lldb-${version}";
+
+  src = fetch "lldb" "1sbi9c6c4m73wfw249dn0n2974p444i03brk82m4w10iq5dm1mzl";
+
+  patchPhase = ''
+    sed -i 's|/usr/bin/env||' \
+      scripts/Python/finish-swig-Python-LLDB.sh \
+      scripts/Python/build-swig-Python.sh
+  '';
+
+  buildInputs = [ cmake python which swig ncurses zlib libedit ];
+
+  preConfigure = ''
+    export CXXFLAGS="-pthread"
+    export LDFLAGS="-ldl"
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
+    "-DLLDB_PATH_TO_CLANG_BUILD=${clang-unwrapped}"
+    "-DPYTHON_VERSION_MAJOR=2"
+    "-DPYTHON_VERSION_MINOR=7"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A next-generation high-performance debugger";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetch
+, perl
+, groff
+, cmake
+, python
+, libffi
+, binutils
+, libxml2
+, valgrind
+, ncurses
+, version
+, zlib
+, compiler-rt_src
+}:
+
+let
+  src = fetch "llvm" "0lrirklh4nrcb078qc2f6vbmmc34kxqgsy9s18a1xbfdkmgqjidb";
+in stdenv.mkDerivation rec {
+  name = "llvm-${version}";
+
+  unpackPhase = ''
+    unpackFile ${src}
+    mv llvm-${version}.src llvm
+    sourceRoot=$PWD/llvm
+    unpackFile ${compiler-rt_src}
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
+  '';
+
+  buildInputs = [ perl groff cmake libxml2 python libffi ] /* ++ stdenv.lib.optional stdenv.isLinux valgrind */;
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_BUILD_TESTS=ON"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+  ] ++ stdenv.lib.optionals (!isDarwin) [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DLLVM_BINUTILS_INCDIR=${binutils}/include"
+  ] ++ stdenv.lib.optionals ( isDarwin) [
+    "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
+    "-DCAN_TARGET_i386=false"
+  ];
+
+  postBuild = ''
+    rm -fR $out
+
+    paxmark m bin/{lli,llvm-rtdyld}
+
+    paxmark m unittests/ExecutionEngine/JIT/JITTests
+    paxmark m unittests/ExecutionEngine/MCJIT/MCJITTests
+    paxmark m unittests/Support/SupportTests
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.src = src;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3734,7 +3734,8 @@ let
 
   clang = llvmPackages.clang;
 
-  clang_36 = llvmPackages.clang;
+  clang_37 = llvmPackages_37.clang;
+  clang_36 = llvmPackages_36.clang;
   clang_35 = wrapCC llvmPackages_35.clang;
   clang_34 = wrapCC llvmPackages_34.clang;
   clang_33 = wrapCC (clangUnwrapped llvm_33 ../development/compilers/llvm/3.3/clang.nix);
@@ -4219,6 +4220,7 @@ let
 
   llvm = llvmPackages.llvm;
 
+  llvm_37 = llvmPackages_37.llvm;
   llvm_36 = llvmPackages_36.llvm;
   llvm_35 = llvmPackages_35.llvm;
   llvm_34 = llvmPackages_34.llvm;
@@ -4239,6 +4241,10 @@ let
   };
 
   llvmPackages_36 = callPackage ../development/compilers/llvm/3.6 {
+    inherit (stdenvAdapters) overrideCC;
+  };
+
+  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 {
     inherit (stdenvAdapters) overrideCC;
   };
 


### PR DESCRIPTION
Package changes from 3.6:
- CMake exports patch no longer necessary
- Cosmetic purity patch fix
- Build libc++ with private libc++abi headers visible from sources
- Work around bugs in lldb's configure scripts
