### PR TITLE
linux: Add 4.2.0 (backport to release-15.09)

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.2.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "4.2";
+  modDirVersion = "4.2.0";
+  extraMeta.branch = "4.2";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+    sha256 = "1syv8n5hwzdbx69rsj4vayyzskfq1w5laalg5jjd523my52f086g";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -1,17 +1,13 @@
-{ stdenv, fetchFromGitHub, kernel }:
-
-assert stdenv.lib.versionAtLeast kernel.version "3.4";  # fails on 3.2
+{ stdenv, fetchurl, kernel }:
 
 stdenv.mkDerivation rec {
   pname = "lttng-modules-${version}";
   name = "${pname}-${kernel.version}";
-  version = "2.6.2-1-g7a88f8b";
+  version = "2.6.3";
 
-  src = fetchFromGitHub {
-    owner = "lttng";
-    repo = "lttng-modules";
-    rev = "7a88f8b50696dd71e80c08661159caf8e119bf51";
-    sha256 = "1i185dvk4wn7fmmx1zfv6g15x8wi38jmav2dmq0mmy8cvriajq8h";
+  src = fetchurl {
+    url = "http://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
+    sha256 = "0sk7cyjf5ylmxqrrrz5zmmw4c0dmxh1f98aj870gmcnxfa76y4mx";
   };
 
   preConfigure = ''

--- a/pkgs/servers/openafs-client/default.nix
+++ b/pkgs/servers/openafs-client/default.nix
@@ -1,13 +1,25 @@
-{ stdenv, fetchurl, which, autoconf, automake, flex, yacc,
+{ stdenv, fetchurl, fetchgit, which, autoconf, automake, flex, yacc,
   kernel, glibc, ncurses, perl, kerberos }:
 
+let
+  version = if stdenv.lib.versionAtLeast kernel.version "4.2"
+    then "1.6.14-1-602130"
+    else "1.6.14";
+in
 stdenv.mkDerivation {
-  name = "openafs-1.6.14-${kernel.version}";
+  name = "openafs-${version}-${kernel.version}";
 
-  src = fetchurl {
-    url = http://www.openafs.org/dl/openafs/1.6.14/openafs-1.6.14-src.tar.bz2;
-    sha256 = "3e62c798a7f982c4f88d85d32e46bee6a47848d207b1e318fe661ce44ae4e01f";
-  };
+  src = if version == "1.6.14-1-602130"
+    # 1.6.14 + patches to run on linux 4.2 that will get into 1.6.15
+    then fetchgit {
+      url = "git://git.openafs.org/openafs.git";
+      rev = "feab09080ec050b3026eff966352b058e2c2295b";
+      sha256 = "03j71c7y487jbjmm6ydr1hw38pf43j2dz153xknndf4x4v21nnp2";
+    }
+    else fetchurl {
+      url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
+      sha256 = "3e62c798a7f982c4f88d85d32e46bee6a47848d207b1e318fe661ce44ae4e01f";
+    };
 
   buildInputs = [ autoconf automake flex yacc ncurses perl which ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9779,6 +9779,16 @@ let
       ];
   };
 
+  linux_4_2 = makeOverridable (import ../os-specific/linux/kernel/linux-4.2.nix) {
+    inherit fetchurl stdenv perl buildLinux;
+    kernelPatches = [ kernelPatches.bridge_stp_helper ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
   linux_testing = makeOverridable (import ../os-specific/linux/kernel/linux-testing.nix) {
     inherit fetchurl stdenv perl buildLinux;
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
@@ -9944,7 +9954,7 @@ let
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!
-  linuxPackages_latest = pkgs.linuxPackages_4_1;
+  linuxPackages_latest = pkgs.linuxPackages_4_2;
   linux_latest = linuxPackages_latest.kernel;
 
   # Build the kernel modules for the some of the kernels.
@@ -9955,6 +9965,7 @@ let
   linuxPackages_3_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_14 linuxPackages_3_14);
   linuxPackages_3_18 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_18 linuxPackages_3_18);
   linuxPackages_4_1 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_1 linuxPackages_4_1);
+  linuxPackages_4_2 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_2 linuxPackages_4_2);
   linuxPackages_testing = recurseIntoAttrs (linuxPackagesFor pkgs.linux_testing linuxPackages_testing);
   linuxPackages_custom = {version, src, configfile}:
                            let linuxPackages_self = (linuxPackagesFor (pkgs.linuxManualConfig {inherit version src configfile;


### PR DESCRIPTION
As there's already 4.2.0-rc5 in 15.09, I think the stable version should be available too.
This patch is a cherry-pick from master.
