### PR TITLE
WIP: qtcreator: fix examples (make them visible)

### DIFF
--- a/pkgs/development/libraries/qt-5/5.4/default.nix
+++ b/pkgs/development/libraries/qt-5/5.4/default.nix
@@ -19,6 +19,9 @@
 , gnome
 
 # options
+, buildDocs ? false
+, buildExamples ? false
+, buildTests ? false
 , developerBuild ? false
 , decryptSslTraffic ? false
 }:
@@ -67,7 +70,8 @@ let
         # GNOME dependencies are not used unless gtkStyle == true
         inherit (gnome) libgnomeui GConf gnome_vfs;
         bison = bison2; # error: too few arguments to function 'int yylex(...
-        inherit developerBuild srcs version decryptSslTraffic;
+        inherit srcs version buildDocs buildExamples buildTests developerBuild
+                decryptSslTraffic;
       };
 
       connectivity = callPackage

--- a/pkgs/development/libraries/qt-5/5.4/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/5.4/qtbase.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
     sed -i 's/PATHS.*NO_DEFAULT_PATH//' "qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in"
 
     export configureFlags+="-plugindir $out/lib/qt5/plugins -importdir $out/lib/qt5/imports -qmldir $out/lib/qt5/qml"
-    export configureFlags+=" -docdir $out/share/doc/qt5"
+    export configureFlags+=" -docdir $out/share/doc/qt5 -examplesdir $out/share/doc/qt5/examples"
   '';
 
   prefixKey = "-prefix ";

--- a/pkgs/development/libraries/qt-5/qt-env.nix
+++ b/pkgs/development/libraries/qt-5/qt-env.nix
@@ -14,6 +14,8 @@ Plugins = lib/qt5/plugins
 Imports = lib/qt5/imports
 Qml2Imports = lib/qt5/qml
 Documentation = share/doc/qt5
+Examples = share/doc/qt5/examples
+Help/InstalledExamples = share/doc/qt5/examples
 EOF
 
 for pkg in $paths $qtbase; do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7906,9 +7906,11 @@ let
   qtEnv = callPackage ../development/libraries/qt-5/qt-env.nix {};
 
   qt5Full = appendToName "full" (qtEnv {
-    qtbase = qt5.base;
-    paths = lib.filter lib.isDerivation (lib.attrValues qt5);
+    qtbase = qt5-with-docs.base;
+    paths = lib.filter lib.isDerivation (lib.attrValues qt5-with-docs);
   });
+
+  qt5-with-docs = qt5.override { buildDocs = true; buildExamples = true; };
 
   qtcreator = callPackage ../development/qtcreator {
     qtLib = qt54.override { buildDocs = true; buildExamples = true; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7911,7 +7911,7 @@ let
   });
 
   qtcreator = callPackage ../development/qtcreator {
-    qtLib = qt54;
+    qtLib = qt54.override { buildDocs = true; buildExamples = true; };
     withDocumentation = true;
   };
 


### PR DESCRIPTION
This is an attempt to make it possible to run QtCreator and browse (and build) examples directly from the IDE. Currently the examples page is empty, and I'm stuck.

EDIT: DON'T MERGE YET.
