### PR TITLE
xdotool: 2.20110530.1 -> 3.20150503.1

### DIFF
--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -44,6 +44,8 @@ import ./make-test.nix (
           search --onlyvisible --name "startup done"
           windowfocus --sync
           windowactivate --sync
+        ''}");
+        $machine->execute("${xdo "new-window" ''
           key Ctrl+n
         ''}");
       });
@@ -55,6 +57,8 @@ import ./make-test.nix (
           search --onlyvisible --name "new tab"
           windowfocus --sync
           windowactivate --sync
+        ''}");
+        $machine->execute("${xdo "close-window" ''
           key Ctrl+w
         ''}");
         for (1..20) {
@@ -155,6 +159,8 @@ import ./make-test.nix (
           $machine->succeed("${xdo "submit-url" ''
             search --sync --onlyvisible --name "sandbox status"
             windowfocus --sync
+          ''}");
+          $machine->succeed("${xdo "submit-url" ''
             key --delay 1000 Ctrl+a Ctrl+c
           ''}");
 

--- a/pkgs/tools/X11/keynav/default.nix
+++ b/pkgs/tools/X11/keynav/default.nix
@@ -1,16 +1,25 @@
-{ stdenv, fetchurl, pkgconfig, libX11, xextproto, libXtst, libXi, libXext
+{ stdenv, fetchFromGitHub, pkgconfig, libX11, xextproto, libXtst, libXi, libXext
 , libXinerama, glib, cairo, xdotool }:
 
+let release = "20150730"; in
 stdenv.mkDerivation rec {
-  name = "keynav-0.20110708.0";
+  name = "keynav-0.${release}.0";
 
-  src = fetchurl {
-    url = "https://semicomplete.googlecode.com/files/${name}.tar.gz";
-    sha256 = "1gizjhji3yspxxxvb90js3z1bv18rbf5phxg8rciixpj3cccff8z";
+  src = fetchFromGitHub {
+    owner = "jordansissel";
+    repo = "keynav";
+    rev = "4ae486db6697877e84b66583a0502afc7301ba16";
+    sha256 = "0v1m8w877fcrk918p6b6q3753dsz8i1f4mb9bi064cp11kh85nq5";
   };
 
   buildInputs = [ pkgconfig libX11 xextproto libXtst libXi libXext libXinerama
                   glib cairo xdotool ];
+
+  patchPhase = ''
+    echo >>VERSION MAJOR=0
+    echo >>VERSION RELEASE=${release}
+    echo >>VERSION REVISION=0
+  '';
 
   installPhase =
     ''

--- a/pkgs/tools/X11/xdotool/default.nix
+++ b/pkgs/tools/X11/xdotool/default.nix
@@ -1,18 +1,17 @@
-{ stdenv, fetchurl, libX11, perl, libXtst, xextproto, libXi, libXinerama }:
+{ stdenv, fetchurl, pkgconfig, libX11, perl, libXtst, xextproto, libXi, libXinerama, libxkbcommon }:
 
-let version = "2.20110530.1"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "xdotool-${version}";
+  version = "3.20150503.1";
   src = fetchurl {
-    url = "http://semicomplete.googlecode.com/files/xdotool-${version}.tar.gz";
-    sha256 = "0rxggg1cy7nnkwidx8x2w3c5f3pk6dh2b6q0q7hp069r3n5jrd77";
+    url = "https://github.com/jordansissel/xdotool/releases/download/v${version}/xdotool-${version}.tar.gz";
+    sha256 = "1lcngsw33fy9my21rdiz1gs474bfdqcfxjrnfggbx4aypn1nhcp8";
   };
 
-  buildInputs = [ libX11 perl libXtst xextproto libXi libXinerama ];
+  nativeBuildInputs = [ pkgconfig perl ];
+  buildInputs = [ libX11 libXtst xextproto libXi libXinerama libxkbcommon ];
 
-  configurePhase = ''
-    export makeFlags="PREFIX=$out";
-  '';
+  makeFlags = "PREFIX=$(out)";
 
   meta = {
     homepage = http://www.semicomplete.com/projects/xdotool/;


### PR DESCRIPTION
The new version is required by `rofi-pass`.

However it seems to have a bug with [sending ctrl+key](https://github.com/jordansissel/xdotool/issues/52), so I adapted the chromium test to work around that.
