### PR TITLE
sox: enable libsndfile, amr-nb, amr-wb

### DIFF
--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -6,6 +6,9 @@
 , enableLibogg ? true, libogg ? null, libvorbis ? null
 , enableFLAC ? true, flac ? null
 , enablePNG ? true, libpng ? null
+, enableLibsndfile ? true, libsndfile ? null
+# amrnb and amrwb are unfree, disabled by default
+, enableAMR ? false, amrnb ? null, amrwb ? null
 }:
 
 with stdenv.lib;
@@ -32,13 +35,15 @@ stdenv.mkDerivation rec {
     optional enableLibmad libmad ++
     optionals enableLibogg [ libogg libvorbis ] ++
     optional enableFLAC flac ++
-    optional enablePNG libpng;
+    optional enablePNG libpng ++
+    optional enableLibsndfile libsndfile ++
+    optionals enableAMR [ amrnb amrwb ];
 
   meta = {
     description = "Sample Rate Converter for audio";
     homepage = http://sox.sourceforge.net/;
     maintainers = [ lib.maintainers.marcweber ];
-    license = lib.licenses.gpl2Plus;
+    license = if enableAMR then lib.licenses.unfree else lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
@MarcWeber

Tested on OS X 10.10.4 and Linux x86_64.

This depends on  #9823.
