### PR TITLE
emacs24PackagesNg.org2jekyll: init at 0.1.8

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1021,6 +1021,23 @@ let self = _self // overrides;
     inherit lib;
   };
 
+  org2jekyll = melpaBuild rec {
+    pname   = "org2jekyll";
+    version = "0.1.8";
+    src = fetchFromGitHub {
+      owner = "ardumont";
+      repo = pname;
+      rev = "a12173b9507b3ef54dfebb5751503ba1ee93c6aa";
+      sha256 = "064kw64w9snm0lbshxn8d6yd9xvyislhg37fmhq1w7vy8lm61xvf";
+    };
+    packageRequires = [ dash-functional s deferred ];
+    files = [ "${pname}.el" ];
+    meta = {
+      description = "Blogging with org-mode and jekyll without alien yaml headers";
+      license = gpl3Plus;
+    };
+  };
+
   org-plus-contrib = melpaBuild rec {
     pname   = "org-plus-contrib";
     version = "20150406";


### PR DESCRIPTION
Hello,

My tests, build, install + runtime:

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:init-org2jekyll o [18:25:47]
$ nix-build -A emacs24PackagesNg.org2jekyll
/nix/store/scangc9afbjq89h873wp6i6ranj4w7dw-emacs-org2jekyll-0.1.8

# tony at corellia in ~/repo/perso/nixpkgs on git:init-org2jekyll o [18:25:53]
$ tree result
result
├── nix-support
│   ├── propagated-native-build-inputs
│   ├── propagated-user-env-packages
│   └── setup-hook
└── share
└── emacs
└── site-lisp
└── elpa
└── org2jekyll-0.1.8
├── org2jekyll-autoloads.el
├── org2jekyll-autoloads.el~
├── org2jekyll.el
├── org2jekyll.elc
├── org2jekyll-pkg.el
└── org2jekyll-pkg.elc

6 directories, 9 files

# tony at corellia in ~/repo/perso/nixpkgs on git:init-org2jekyll o [18:28:33]
$ nix-env -f . -iA emacs24PackagesNg.org2jekyll
installing ‘emacs-org2jekyll-0.1.8’
building path (s) ‘/nix/store/y3h0wpx9z30cp13qg8f7anpysm5lbygh-user-environment’
created 365 symlinks in user environment

# tony at corellia in ~/repo/perso/nixpkgs on git:init-org2jekyll o [18:29:00]
$ tree $ (f ~/.nix-profile/ org2jekyll)
/home/tony/.nix-profile/share/emacs/site-lisp/elpa/org2jekyll-0.1.8
├── org2jekyll-autoloads.el
├── org2jekyll-autoloads.el~
├── org2jekyll.el
├── org2jekyll.elc
├── org2jekyll-pkg.el
└── org2jekyll-pkg.elc

0 directories, 6 files
```

(EDIT) - in emacs,  `M-x org2jekyll-TAB` returns the org2jekyll possibilities

Cheers,
