### PR TITLE
WIP: buildRubyGem: Don't use fetchgit with leaveDotGit

### DIFF
--- a/pkgs/development/interpreters/ruby/bundix/gemset.nix
+++ b/pkgs/development/interpreters/ruby/bundix/gemset.nix
@@ -5,7 +5,7 @@
       type = "git";
       url = "https://github.com/cstrahan/bundix.git";
       rev = "c879cf901ff8084b4c97aaacfb5ecbdb0f95cc03";
-      sha256 = "05kmdnq4qa5h8l3asv05cjpnyplnqqx6hrqybj2cjlzmdxnkkgyj";
+      sha256 = "1v0mg5wq09bvdv2lf9gb7an2ak7i5jr3lrv23q0k0q122jb64zfv";
       fetchSubmodules = false;
     };
     dependencies = [

--- a/pkgs/development/interpreters/ruby/bundler-env/default.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default.nix
@@ -30,7 +30,6 @@ let
   };
   fetchers.git = attrs: fetchgit {
     inherit (attrs.source) url rev sha256 fetchSubmodules;
-    leaveDotGit = true;
   };
 
   applySrc = attrs:

--- a/pkgs/development/interpreters/ruby/bundler-head.nix
+++ b/pkgs/development/interpreters/ruby/bundler-head.nix
@@ -5,8 +5,7 @@ buildRubyGem {
   src = fetchgit {
     url = "https://github.com/bundler/bundler.git";
     rev = "a2343c9eabf5403d8ffcbca4dea33d18a60fc157";
-    sha256 = "1p7kzhmicfljy9n7nq3qh6lvrsckiq76ddypf6s55gfh1l98z4k9";
-    leaveDotGit = true;
+    sha256 = "016awzfr27sb6112pq3xl0gi8jisnzph7kdhxa6767p09yz09bgj";
   };
   dontPatchShebangs = true;
   postInstall = ''

--- a/pkgs/development/interpreters/ruby/load-ruby-env.nix
+++ b/pkgs/development/interpreters/ruby/load-ruby-env.nix
@@ -38,7 +38,6 @@ let
   };
   fetchers.git = attrs: fetchgit {
     inherit (attrs.src) url rev sha256 fetchSubmodules;
-    leaveDotGit = true;
   };
 
   instantiate = (attrs:


### PR DESCRIPTION
fetchgit used with the leaveDotGit option is currently extremely
nondeterministic (issue #8567), so we should get rid of it.
However, Ruby gems currently use leaveDotGit since it's standard
practice to use `git ls-files -z` in gemspecs. So add a fake 'git'
command to the gem builder's path that emulates it.

TODO: this currently breaks bundix, didn't investigate that yet.

Another issue is that seemingly no one bothers to check if calling 'git' fails,
leading to silent incorrect builds. Maybe we should `kill -9` the parent process
instead of doing `exit 1`? :P
