### PR TITLE
emacs24PackagesNg.markdown-toc: init at 0.0.8

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -982,6 +982,27 @@ let self = _self // overrides;
     meta = { license = gpl3Plus; };
   };
 
+  markdown-toc = melpaBuild rec {
+    pname = "markdown-toc";
+    version = "0.0.8";
+    src = fetchFromGitHub {
+      owner = "ardumont";
+      repo = pname;
+      rev = "06903e24457460a8964a978ace709c69afc36692";
+      sha256 = "07w0w9g81c6c404l3j7gb420wc2kjmah728w84mdymscdl5w3qyl";
+    };
+    packageRequires = [ markdown-mode dash s ];
+    files = [ "${pname}.el" ];
+    meta = {
+      description = "Generate a TOC in markdown file";
+      longDescription = ''
+        A simple mode to create TOC in a markdown file.
+      '';
+      homepage = https://github.com/ardumont/mardown-toc;
+      license = gpl3Plus;
+    };
+  };
+
   moe-theme = melpaBuild rec {
     pname   = "moe-theme";
     version = "1.0";


### PR DESCRIPTION
Hello,

My tests:

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:init-markdown-toc x [18:40:33]
$ nix-build -A emacs24PackagesNg.markdown-toc 
/nix/store/skpycxhhinyw1fvz2xfmdfajsjwcwr9r-emacs-markdown-toc-0.0.8

# tony at corellia in ~/repo/perso/nixpkgs on git:init-markdown-toc x [18:40:44]
$ tree result
result
├── nix-support
│   ├── propagated-native-build-inputs
│   ├── propagated-user-env-packages
│   └── setup-hook
└── share
└── emacs
└── site-lisp
└── elpa
└── markdown-toc-0.0.8
├── markdown-toc-autoloads.el
├── markdown-toc-autoloads.el~
├── markdown-toc.el
├── markdown-toc.elc
├── markdown-toc-pkg.el
└── markdown-toc-pkg.elc

6 directories, 9 files


# tony at corellia in ~/repo/perso/nixpkgs on git:init-markdown-toc x [18:43:07]
$ f ~/.nix-profile/ "markdown-toc"
/home/tony/.nix-profile/share/emacs/site-lisp/elpa/markdown-toc-0.0.8

# tony at corellia in ~/repo/perso/nixpkgs on git:init-markdown-toc x [18:43:10]
$ tree $ (f ~/.nix-profile/ "markdown-toc")
/home/tony/.nix-profile/share/emacs/site-lisp/elpa/markdown-toc-0.0.8
├── markdown-toc-autoloads.el
├── markdown-toc-autoloads.el~
├── markdown-toc.el
├── markdown-toc.elc
├── markdown-toc-pkg.el
└── markdown-toc-pkg.elc

0 directories, 6 files
```
