### PR TITLE
emacs24PackagesNg.org-trello: fix inclusion files pattern

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1044,7 +1044,7 @@ let self = _self // overrides;
       sha256 = "1561nxjva8892via0l8315y3fih4r4q9gzycmvh33db8gqzq4l86";
     };
     packageRequires = [ request-deferred deferred dash-functional s ];
-    files = [ "org-trello-*.el" ];
+    files = [ "org-trello*.el" ];
     meta = {
       description = "Org minor mode - 2-way sync org & trello";
       longDescription = ''


### PR DESCRIPTION
The main file `org-trello.el` was missing from the package so org-trello did not actually load.
I missed one runtime test before... (sorry)

So this time, my tests:
- build
- install

``` lisp
# tony at corellia in ~ [19:54:05]
$ tree $ (f ~/.nix-profile/ org-trello)
/home/tony/.nix-profile/share/emacs/site-lisp/elpa/org-trello-0.7.5
├── org-trello-action.el
├── org-trello-action.elc
├── org-trello-api.el
├── org-trello-api.elc
├── org-trello-autoloads.el
├── org-trello-autoloads.el~
├── org-trello-backend.el
├── org-trello-backend.elc
├── org-trello-buffer.el
├── org-trello-buffer.elc
├── org-trello-cbx.el
├── org-trello-cbx.elc
├── org-trello-controller.el
├── org-trello-controller.elc
├── org-trello-data.el
├── org-trello-data.elc
├── org-trello-date.el
├── org-trello-date.elc
├── org-trello-deferred.el
├── org-trello-deferred.elc
├── org-trello.el
├── org-trello.elc
├── org-trello-entity.el
├── org-trello-entity.elc
├── org-trello-hash.el
├── org-trello-hash.elc
├── org-trello-input.el
├── org-trello-input.elc
├── org-trello-log.el
├── org-trello-log.elc
├── org-trello-pkg.el
├── org-trello-proxy.el
├── org-trello-proxy.elc
├── org-trello-query.el
├── org-trello-query.elc
├── org-trello-setup.el
├── org-trello-setup.elc
├── org-trello-tools.el
├── org-trello-tools-test.el
├── org-trello-utils.el
└── org-trello-utils.elc

0 directories, 74 files
```
- trigger emacs, `M-x org-trello-version RET` -> 0.7.5 (the package loads and display version, ok!)
