### PR TITLE
Fix libxcb missing xinput support

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -72,7 +72,7 @@ in
 
   libxcb = attrs : attrs // {
     nativeBuildInputs = [ args.python ];
-    configureFlags = "--enable-xkb";
+    configureFlags = "--enable-xkb --enable-xinput";
     outputs = [ "out" "doc" "man" ];
   };
 


### PR DESCRIPTION
For some reason, libxcb does not have xinput enabled by default. This change explicitly enables it, making it possible to build applications that use xinput with xcb on nix.
