### PR TITLE
containers: No device wait for ip address + test

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -110,7 +110,7 @@ in
           { description = "Address configuration of ${i.name}";
             wantedBy = [ "network-interfaces.target" ];
             before = [ "network-interfaces.target" ];
-            bindsTo = [ (subsystemDevice i.name) ];
+            bindsTo = if config.boot.isContainer then [] else [ (subsystemDevice i.name) ];
             after = [ (subsystemDevice i.name) "network-pre.target" ];
             serviceConfig.Type = "oneshot";
             serviceConfig.RemainAfterExit = true;

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -745,7 +745,7 @@ in
       { description = "Link configuration of ${i.name}";
         wantedBy = [ "network-interfaces.target" ];
         before = [ "network-interfaces.target" ];
-        bindsTo = [ (subsystemDevice i.name) ];
+        bindsTo = if config.boot.isContainer then [] else [ (subsystemDevice i.name) ];
         after = [ (subsystemDevice i.name) "network-pre.target" ];
         path = [ pkgs.iproute ];
         serviceConfig = {

--- a/nixos/tests/containers.nix
+++ b/nixos/tests/containers.nix
@@ -23,12 +23,23 @@ import ./make-test.nix ({ pkgs, ...} : {
               networking.firewall.allowPing = true;
             };
         };
+      containers.router =
+        { interfaces = [ "roeth" ];
+          config =
+            { networking.interfaces.roeth.ipAddress = "10.100.0.1";
+            };
+        };
 
       virtualisation.pathsInNixDB = [ pkgs.stdenv ];
     };
 
   testScript =
     ''
+      $machine->succeed("nixos-container list") =~ /router/ or die;
+
+      $machine->succeed("ip link add veth0 type veth peer name roeth");
+      $machine->succeed("nixos-container start router");
+
       $machine->succeed("nixos-container list") =~ /webserver/ or die;
 
       # Start the webserver container.


### PR DESCRIPTION
Setting network.interfaces.<name>.ip4 fails due to missing udev
events for non-hardware interfaces. Thus container boot fails.

This patch removes the binding for containers.
