### PR TITLE
lxappearance: 0.5.5 -> 0.6.1

### DIFF
--- a/pkgs/applications/misc/lxappearance/default.nix
+++ b/pkgs/applications/misc/lxappearance/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, intltool, pkgconfig, libX11, gtk }:
 
 stdenv.mkDerivation rec {
-  name = "lxappearance-0.5.5";
+  name = "lxappearance-0.6.1";
   src = fetchurl{
     url = "http://downloads.sourceforge.net/project/lxde/LXAppearance/${name}.tar.xz";
-    sha256 = "8cae82e6425ba8a0267774e4d10096df2d91b0597520058331684a5ece068b4c";
+    sha256 = "1phnv1b2jdj2vlibjyc9z01izcf3k5zxj8glsaf0i3vh77zqmqq9";
   };
   buildInputs = [ intltool libX11 pkgconfig gtk ];
   meta = {


### PR DESCRIPTION
No changelog found. Built and run successfully.
