### PR TITLE
wavpack: disabled asm for Darwin

### DIFF
--- a/pkgs/development/libraries/wavpack/default.nix
+++ b/pkgs/development/libraries/wavpack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "wavpack-${version}";
@@ -6,9 +6,19 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  patches = [
+    # backported from
+    # https://github.com/dbry/WavPack/commit/12867b33e2de3e95b88d7cb6f449ce0c5c87cdd5
+    ./wavpack_clang.patch
+  ];
+
   preConfigure = ''
     sed -i '2iexec_prefix=@exec_prefix@' wavpack.pc.in
   '';
+
+  # --disable-asm is required for clang
+  # https://github.com/dbry/WavPack/issues/3
+  configureFlags = lib.optionalString stdenv.cc.isClang "--disable-asm";
 
   src = fetchurl {
     url = "http://www.wavpack.com/${name}.tar.bz2";

--- a/pkgs/development/libraries/wavpack/wavpack_clang.patch
+++ b/pkgs/development/libraries/wavpack/wavpack_clang.patch
@@ -1,0 +1,25 @@
+diff -ru -x '*~' wavpack-4.75.0_orig/src/wavpack_local.h wavpack-4.75.0/src/wavpack_local.h
+--- wavpack-4.75.0_orig/src/wavpack_local.h	2015-05-21 06:50:26.000000000 +0900
++++ wavpack-4.75.0/src/wavpack_local.h	2015-09-14 21:48:09.000000000 +0900
+@@ -650,9 +650,9 @@
+ void scan_word (WavpackStream *wps, int32_t *samples, uint32_t num_samples, int dir);
+ void update_error_limit (WavpackStream *wps);
+ 
+-const uint32_t bitset [32];
+-const uint32_t bitmask [32];
+-const char nbits_table [256];
++extern const uint32_t bitset [32];
++extern const uint32_t bitmask [32];
++extern const char nbits_table [256];
+ 
+ int log2s (int32_t value);
+ int32_t exp2s (int log);
+@@ -734,7 +734,7 @@
+ /////////////////////////////////// common utilities ////////////////////////////////////
+ // module: common_utils.c
+ 
+-const uint32_t sample_rates [16];
++extern const uint32_t sample_rates [16];
+ uint32_t WavpackGetLibraryVersion (void);
+ const char *WavpackGetLibraryVersionString (void);
+ uint32_t WavpackGetSampleRate (WavpackContext *wpc);


### PR DESCRIPTION
@codyopel
The current version of WavPack is not compatible with clang. This commit works around it by disabling asm and a small patch.
https://github.com/dbry/WavPack/issues/3

Tested on OX 10.10.5.
