### PR TITLE
lttng-modules: 2.6.2-1-g7a88f8b -> 2.6.3

### DIFF
--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -1,17 +1,13 @@
-{ stdenv, fetchFromGitHub, kernel }:
-
-assert stdenv.lib.versionAtLeast kernel.version "3.4";  # fails on 3.2
+{ stdenv, fetchurl, kernel }:
 
 stdenv.mkDerivation rec {
   pname = "lttng-modules-${version}";
   name = "${pname}-${kernel.version}";
-  version = "2.6.2-1-g7a88f8b";
+  version = "2.6.3";
 
-  src = fetchFromGitHub {
-    owner = "lttng";
-    repo = "lttng-modules";
-    rev = "7a88f8b50696dd71e80c08661159caf8e119bf51";
-    sha256 = "1i185dvk4wn7fmmx1zfv6g15x8wi38jmav2dmq0mmy8cvriajq8h";
+  src = fetchurl {
+    url = "http://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
+    sha256 = "0sk7cyjf5ylmxqrrrz5zmmw4c0dmxh1f98aj870gmcnxfa76y4mx";
   };
 
   preConfigure = ''


### PR DESCRIPTION
This also drops the assertion about kernel.version - we don't have
anything older than 3.4 in nixpkgs anyway.

This is a cherry-pick from https://github.com/NixOS/nixpkgs/pull/9816
