### PR TITLE
Intercal: a quick fix to find gcc

### DIFF
--- a/pkgs/development/compilers/intercal/default.nix
+++ b/pkgs/development/compilers/intercal/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl
 , pkgconfig
-, bison, flex }:
+, bison, flex
+, makeWrapper }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -14,7 +15,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-  [ pkgconfig bison flex ];
+  [ pkgconfig bison flex makeWrapper ];
+
+  # Intercal invokes gcc, so we need an explicit PATH
+  postInstall = ''
+    wrapProgram $out/bin/ick --suffix PATH ':' ${stdenv.cc}/bin
+  '';
 
   meta = {
     description = "The original esoteric programming language";
@@ -33,3 +39,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
+# TODO: investigate if LD_LIBRARY_PATH needs to be set


### PR DESCRIPTION
Intercal needs gcc to build any executable, and in Nix/NixOS it needs to
be explicitly set in PATH environment variable. So, now ick is
conveniently wrapped.
