### PR TITLE
all-packages: Use callPackage where possible

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,6 +1,9 @@
 # TODO tidy up eg The patchelf code is patching gvim even if you don't build it..
 # but I have gvim with python support now :) - Marc
-args@{pkgs, source ? "default", ...}: with args;
+args@{pkgs, source ? "default", fetchurl, fetchhg, stdenv, ncurses, pkgconfig, gettext
+, composableDerivation, lib, config, glib, gtk, python, perl, tcl, ruby
+, libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
+, libICE, ... }: with args;
 
 
 let inherit (args.composableDerivation) composableDerivation edf;

--- a/pkgs/applications/editors/vim/qvim.nix
+++ b/pkgs/applications/editors/vim/qvim.nix
@@ -1,4 +1,7 @@
-args@{...}: with args;
+args@{ fetchgit, stdenv, ncurses, pkgconfig, gettext
+, composableDerivation, lib, config, python, perl, tcl, ruby, qt4
+, libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
+, libICE, ... }: with args;
 
 let tag = "20140827";
     sha256 = "02adf2212872db3c5d133642d2c12fbfc28b506e4c0c42552e3d079756f63f65";

--- a/pkgs/applications/graphics/xaos/default.nix
+++ b/pkgs/applications/graphics/xaos/default.nix
@@ -1,4 +1,4 @@
-a :
+a @ { libXt, libX11, libXext, xextproto, xproto, gsl, aalib, zlib, intltool, gettext, perl, ... }:
 let
   fetchurl = a.fetchurl;
 

--- a/pkgs/applications/misc/gphoto2/gphotofs.nix
+++ b/pkgs/applications/misc/gphoto2/gphotofs.nix
@@ -1,4 +1,4 @@
-a :
+a @ { libgphoto2, fuse, pkgconfig, glib, libtool, ... } :
 let
   fetchurl = a.fetchurl;
   s = import ./src-info-for-gphotofs.nix;

--- a/pkgs/applications/misc/grass/default.nix
+++ b/pkgs/applications/misc/grass/default.nix
@@ -1,4 +1,11 @@
-{ config, ... }@a:
+{ config, libXmu, libXext, libXp, libX11, libXt, libSM, libICE, libXpm
+   , libXaw, libXrender
+  , composableDerivation, stdenv, fetchurl
+   , lib, flex, bison, cairo, fontconfig
+   , gdal, zlib, ncurses, gdbm, proj, pkgconfig, swig
+   , blas, liblapack, libjpeg, libpng, mysql, unixODBC, mesa, postgresql, python
+   , readline, sqlite, tcl, tk, libtiff, freetype, makeWrapper, wxGTK, ffmpeg, fftw
+   , wxPython, motif, opendwg }@a:
 
 # You can set gui by exporting GRASS_GUI=..
 # see http://grass.itc.it/gdp/html_grass64/g.gui.html
@@ -28,7 +35,7 @@ a.composableDerivation.composableDerivation {} (fix: {
   name = "grass-6.4.0RC6";
 
   buildInputs = [
-    # gentoos package depends on gmath ? 
+    # gentoos package depends on gmath ?
     a.pkgconfig
     a.flex a.bison a.libXmu a.libXext a.libXp a.libX11 a.libXt a.libSM a.libICE
     a.libXpm a.libXaw a.flex a.bison a.gdbm
@@ -72,7 +79,7 @@ a.composableDerivation.composableDerivation {} (fix: {
       configureFlags = [ "--with-python=${a.python}/bin/python-config" ];
       buildInputs = [a.python a.swig];
     };
-    
+
   }
   // edf { name = "_64bit"; feat = "64bit"; }
   // wwfp a.ncurses { name = "curses"; }
@@ -119,7 +126,7 @@ a.composableDerivation.composableDerivation {} (fix: {
   // wwfp a.unixODBC { name = "odbc"; }
   // wwfp a.fftw { name = "fftw"; }
   // wwf {
-    name = "blas"; 
+    name = "blas";
     enable.configureFlags = [ "--with-blas-libs=${a.blas}/lib" ];
   }
   // wwf {

--- a/pkgs/applications/networking/instant-messengers/carrier/2.5.0.nix
+++ b/pkgs/applications/networking/instant-messengers/carrier/2.5.0.nix
@@ -1,11 +1,15 @@
-args : with args; 
+args @ { fetchurl, stdenv, pkgconfig, perl, perlXMLParser, libxml2, openssl, nss
+, gtkspell, aspell, gettext, ncurses, avahi, dbus, dbus_glib, python
+, libtool, automake, autoconf, gstreamer
+, gtk, glib
+, libXScrnSaver, scrnsaverproto, libX11, xproto, kbproto, ... }: with args;
 /*
   arguments: all buildInputs
-  optional: purple2Source: purple-2 source - place to copy libpurple from 
+  optional: purple2Source: purple-2 source - place to copy libpurple from
     (to use a fresher pidgin build)
 */
-let 
-  externalPurple2 = (lib.attrByPath ["purple2Source"] null args) != null; 
+let
+  externalPurple2 = (lib.attrByPath ["purple2Source"] null args) != null;
 in
 rec {
   src = fetchurl {
@@ -16,9 +20,9 @@ rec {
   buildInputs = [gtkspell aspell
     gstreamer startupnotification
     libxml2 openssl nss
-    libXScrnSaver ncurses scrnsaverproto 
+    libXScrnSaver ncurses scrnsaverproto
     libX11 xproto kbproto GConf avahi
-    dbus dbus_glib glib python 
+    dbus dbus_glib glib python
     autoconf libtool automake];
 
   propagatedBuildInputs = [
@@ -38,11 +42,11 @@ rec {
   phaseNames = ["doConfigure" "preBuild" "doMakeInstall"]
     ++ (lib.optional externalPurple2 "postInstall")
   ;
-      
+
   name = "carrier-2.5.0";
   meta = {
     description = "PidginIM GUI fork with user-friendly development model";
-    homepage = http://funpidgin.sf.net; 
+    homepage = http://funpidgin.sf.net;
   };
 } // (if externalPurple2 then {
   postInstall = fullDepEntry (''

--- a/pkgs/applications/science/geometry/drgeo/default.nix
+++ b/pkgs/applications/science/geometry/drgeo/default.nix
@@ -1,4 +1,4 @@
-args : with args; 
+args @ { libxml2, perl, intltool, libtool, pkgconfig, gtk, ... } : with args;
 let version = lib.attrByPath ["version"] "1.1.0" args; in
 rec {
   src = fetchurl {
@@ -17,7 +17,7 @@ rec {
   doPreBuild = fullDepEntry (''
     cp drgeo.desktop.in drgeo.desktop
   '') ["minInit" "doUnpack"];
-      
+
   name = "drgeo-" + version;
   meta = {
     description = "Interactive geometry program";

--- a/pkgs/applications/science/math/content/default.nix
+++ b/pkgs/applications/science/math/content/default.nix
@@ -1,10 +1,10 @@
-a :  
-let 
+a @ { mesa, lesstif, libX11, libXaw, xproto, libXt, libSM, libICE, libXmu, libXext, libXcursor, ... } :
+let
   fetchurl = a.fetchurl;
 
-  version = "1.5"; 
+  version = "1.5";
   buildInputs = with a; [
-    mesa lesstif libX11 libXaw xproto libXt libSM libICE 
+    mesa lesstif libX11 libXaw xproto libXt libSM libICE
       libXmu libXext libXcursor
   ];
 in
@@ -28,9 +28,9 @@ rec {
   configureFlags = [];
 
   /* doConfigure should be removed if not needed */
-  phaseNames = ["unpackTarballs" 
+  phaseNames = ["unpackTarballs"
     "setPlatform" "extraVars"
-    "buildVibrant" "buildContent" 
+    "buildVibrant" "buildContent"
     "install"];
 
   unpackTarballs = a.fullDepEntry (''
@@ -42,10 +42,10 @@ rec {
     sed -e s/SGI=/SGI=no/ -i content/makefile_v
   '') ["minInit"];
 
-  platformTLAContent = if a.stdenv.isLinux then "LIN" else 
+  platformTLAContent = if a.stdenv.isLinux then "LIN" else
     throw "Three-letter code for the platform is not known";
 
-  platformTLAVibrant = if a.stdenv.isLinux then "lnx" else 
+  platformTLAVibrant = if a.stdenv.isLinux then "lnx" else
     throw "Three-letter code for the platform is not known";
 
   setPlatform = a.fullDepEntry (''

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -1,7 +1,7 @@
 /* moving all git tools into one attribute set because git is unlikely to be
  * referenced by other packages and you can get a fast overview.
 */
-args: with args; with pkgs;
+args @ {pkgs}: with args; with pkgs;
 let
   inherit (pkgs) stdenv fetchgit fetchurl subversion;
 

--- a/pkgs/applications/version-management/monotone-viz/mtn-head.nix
+++ b/pkgs/applications/version-management/monotone-viz/mtn-head.nix
@@ -1,4 +1,4 @@
-args : with args; 
+args @ { graphviz, pkgconfig, autoconf, automake, libtool, glib, gtk, ... }: with args;
 rec {
   srcDrv = fetchmtn {
     name = "monotone-viz-mtn-checkout";
@@ -9,7 +9,7 @@ rec {
   };
   src = srcDrv + "/";
 
-  buildInputs = [ocaml lablgtk libgnomecanvas gtk graphviz glib 
+  buildInputs = [ocaml lablgtk libgnomecanvas gtk graphviz glib
     pkgconfig autoconf automake libtool];
   configureFlags = ["--with-lablgtk-dir=$(echo ${lablgtk}/lib/ocaml/*/site-lib/lablgtk2)"];
 

--- a/pkgs/applications/version-management/tailor/default.nix
+++ b/pkgs/applications/version-management/tailor/default.nix
@@ -1,4 +1,4 @@
-args : with args; 
+args @ { makeWrapper, python, ... }: with args;
 let version = if args ? version then args.version else "0.9.35"; in
 rec {
   src = fetchurl {
@@ -14,10 +14,10 @@ rec {
 
   /* doConfigure should be specified separately */
   phaseNames = ["installPythonPackage" "wrapBinContentsPython"];
-      
+
   name = "tailor-" + version;
   meta = {
     description = "Version control tools integration tool";
   };
 }
- 
+

--- a/pkgs/applications/version-management/viewmtn/0.10.nix
+++ b/pkgs/applications/version-management/viewmtn/0.10.nix
@@ -1,5 +1,4 @@
-
-args : with args; 
+args @ { monotone, cheetahTemplate, highlight, ctags, makeWrapper, graphviz, which, python, ... }: with args;
 rec {
   src = fetchurl {
     url = http://viewmtn.1erlei.de/downloads/viewmtn-0.10.tgz;

--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -1,26 +1,26 @@
-args: with args; with stringsWithDeps; with lib;
+args @ {stringsWithDeps, lib, stdenv, writeScript, fetchurl, fetchmtn, fetchgit, ...}: with args; with stringsWithDeps; with lib;
 let inherit (builtins) head tail trace; in
 (rec
 {
-        inherit writeScript; 
+        inherit writeScript;
 
         src = attrByPath ["src"] "" args;
 
         addSbinPath = attrByPath ["addSbinPath"] false args;
 
         forceShare = if args ? forceShare then args.forceShare else ["man" "doc" "info"];
-        forceCopy = ["COPYING" "LICENSE" "DISTRIBUTION" "LEGAL" 
-          "README" "AUTHORS" "ChangeLog" "CHANGES" "LICENCE" "COPYRIGHT"] ++ 
-          (optional (attrByPath ["forceCopyDoc"] true args) "doc"); 
+        forceCopy = ["COPYING" "LICENSE" "DISTRIBUTION" "LEGAL"
+          "README" "AUTHORS" "ChangeLog" "CHANGES" "LICENCE" "COPYRIGHT"] ++
+          (optional (attrByPath ["forceCopyDoc"] true args) "doc");
 
         hasSuffixHack = a: b: hasSuffix (a+(substring 0 0 b)) ((substring 0 0 a)+b);
-        
-        archiveType = s: 
+
+        archiveType = s:
                 (if hasSuffixHack ".tar" s then "tar"
-                else if (hasSuffixHack ".tar.gz" s) || (hasSuffixHack ".tgz" s) then "tgz" 
-                else if (hasSuffixHack ".tar.bz2" s) || (hasSuffixHack ".tbz2" s) || 
+                else if (hasSuffixHack ".tar.gz" s) || (hasSuffixHack ".tgz" s) then "tgz"
+                else if (hasSuffixHack ".tar.bz2" s) || (hasSuffixHack ".tbz2" s) ||
 			(hasSuffixHack ".tbz" s) then "tbz2"
-                else if hasSuffixHack ".tar.Z" s then "tZ" 
+                else if hasSuffixHack ".tar.Z" s then "tZ"
                 else if hasSuffixHack ".tar.lzma" s then "tar.lzma"
                 else if hasSuffixHack ".tar.xz" s then "tar.xz"
                 else if hasSuffixHack ".rar" s then "rar"

--- a/pkgs/build-support/emacs/trivial.nix
+++ b/pkgs/build-support/emacs/trivial.nix
@@ -1,6 +1,6 @@
 # trivial builder for Emacs packages
 
-{ lib, ... }@envargs:
+{ lib, stdenv, texinfo, ... }@envargs:
 
 with lib;
 

--- a/pkgs/data/fonts/fontWrap/default.nix
+++ b/pkgs/data/fonts/fontWrap/default.nix
@@ -1,4 +1,5 @@
-args : with args;
+args @ { fetchurl, stdenv, builderDefs, paths, mkfontdir, mkfontscale }:
+with args;
 	let localDefs = builderDefs.passthru.function {
 		src =""; /* put a fetchurl here */
 		buildInputs = [mkfontdir mkfontscale];

--- a/pkgs/data/fonts/libertine/default.nix
+++ b/pkgs/data/fonts/libertine/default.nix
@@ -1,4 +1,4 @@
-args: with args; rec {
+args @ { fetchurl, fontforge, lib, ... }: with args; rec {
   name = "linux-libertine-5.3.0";
 
   src = fetchurl {

--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -1,11 +1,13 @@
-a :  
-let 
+a @ { mpfr, m4, binutils, fetchcvs, emacs, zlib, which
+, texinfo, libX11, xproto, inputproto, libXi
+, libXext, xextproto, libXt, libXaw, libXmu, stdenv, ... } :
+let
   buildInputs = with a; [
     mpfr m4 binutils emacs gmp
-    libX11 xproto inputproto libXi 
+    libX11 xproto inputproto libXi
     libXext xextproto libXt libXaw libXmu
     zlib which texinfo texLive
-  ]; 
+  ];
 in
 
 (
@@ -40,7 +42,7 @@ rec {
   '') ["minInit" "doUnpack" "addInputs"];
 
   /* doConfigure should be removed if not needed */
-  phaseNames = ["setVars" "doUnpack" "preBuild" 
+  phaseNames = ["setVars" "doUnpack" "preBuild"
     "doConfigure" "doMakeInstall"];
 }) // {
   meta = {
@@ -48,7 +50,7 @@ rec {
     maintainers = [
       a.lib.maintainers.raskin
     ];
-    platforms = with a.lib.platforms; 
+    platforms = with a.lib.platforms;
       linux;
   };
 }

--- a/pkgs/development/interpreters/ruby/rubygems.nix
+++ b/pkgs/development/interpreters/ruby/rubygems.nix
@@ -1,4 +1,4 @@
-args : with args; 
+args @ { makeWrapper, ruby, ... }: with args;
 
 rec {
   name = "rubygems-" + version;
@@ -23,7 +23,7 @@ rec {
 
   /* doConfigure should be specified separately */
   phaseNames = ["doPatch" "doInstall"];
-      
+
   meta = {
     description = "Ruby gems package collection";
     longDescription = ''

--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -3,9 +3,9 @@ x@{builderDefsPackage
   , inputproto, libXi, fetchsvn, pkgconfig
   , ...}:
 builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
+(a :
+let
+  helperArgNames = ["stdenv" "fetchsvn" "builderDefsPackage"] ++
     [];
 
   buildInputs = map (n: builtins.getAttr n x)

--- a/pkgs/development/libraries/ncbi/default.nix
+++ b/pkgs/development/libraries/ncbi/default.nix
@@ -1,11 +1,11 @@
-a :  
-let 
+a @ { tcsh, mesa, lesstif, libX11, libXaw, xproto, libXt, libSM, libICE, libXmu, libXext, ... }:
+let
   fetchurl = a.fetchurl;
 
-  version = "20090809"; 
+  version = "20090809";
   buildInputs = with a; [
-    tcsh libX11 libXaw lesstif xproto mesa libXt 
-    libSM libICE libXmu libXext 
+    tcsh libX11 libXaw lesstif xproto mesa libXt
+    libSM libICE libXmu libXext
   ];
 in
 rec {

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,4 @@
-args : with args;
+{fetchurl, stdenv, unixODBC, glibc, libtool, openssl, zlib, postgresql, mysql, sqlite}:
 # each attr contains the name deriv referencing the derivation and ini which
 # evaluates to a string which can be appended to the global unix odbc ini file
 # to register the driver
@@ -9,7 +9,7 @@ args : with args;
     deriv = stdenv.mkDerivation {
       name = "unix-odbc-pg-odbcng-0.90.101";
       buildInputs = [ unixODBC glibc libtool postgresql ];
-      # added -ltdl to resolve missing references `dlsym' `dlerror' `dlopen' `dlclose' 
+      # added -ltdl to resolve missing references `dlsym' `dlerror' `dlopen' `dlclose'
       preConfigure="
         export CPPFLAGS=-I${unixODBC}/include
         export LDFLAGS='-L${unixODBC}/lib -lltdl'
@@ -37,7 +37,7 @@ args : with args;
       export CPPFLAGS=-I${unixODBC}/include
       export LDFLAGS='-L${unixODBC}/lib -lltdl'
     ";
-    # added -ltdl to resolve missing references `dlsym' `dlerror' `dlopen' `dlclose' 
+    # added -ltdl to resolve missing references `dlsym' `dlerror' `dlopen' `dlclose'
     src = fetchurl {
       url = "http://ftp.postgresql.org/pub/odbc/versions/src/${name}.tar.gz";
       sha256 = "0mh10chkmlppidnmvgbp47v5jnphsrls28zwbvyk2crcn8gdx9q1";
@@ -48,7 +48,7 @@ args : with args;
         license = "LGPL";
     };
   };
-  ini = 
+  ini =
     "[PostgreSQL]\n" +
     "Description     = official PostgreSQL driver for Linux & Win32\n" +
     "Driver          = ${deriv}/lib/psqlodbcw.so\n" +
@@ -97,7 +97,7 @@ args : with args;
         mv "$out"/*.la "$out/lib"
       '';
 
-      meta = { 
+      meta = {
         description = "ODBC driver for SQLite";
         homepage = http://www.ch-werner.de/sqliteodbc;
         license = stdenv.lib.licenses.bsd2;

--- a/pkgs/development/python-modules/irclib/default.nix
+++ b/pkgs/development/python-modules/irclib/default.nix
@@ -1,8 +1,8 @@
-a :  
-let 
+a @ {python, ...} :
+let
   fetchurl = a.fetchurl;
 
-  version = a.lib.attrByPath ["version"] "0.4.8" a; 
+  version = a.lib.attrByPath ["version"] "0.4.8" a;
   buildInputs = with a; [
     python
   ];
@@ -24,7 +24,7 @@ rec {
 
   /* doConfigure should be removed if not needed */
   phaseNames = ["doPatch" "installPythonPackage"];
-      
+
   name = "python-irclib-" + version;
   meta = {
     description = "Python IRC library";

--- a/pkgs/development/python-modules/libsexy/default.nix
+++ b/pkgs/development/python-modules/libsexy/default.nix
@@ -1,8 +1,8 @@
-a :  
-let 
+a @ { python, libsexy, pkgconfig, libxml2, pygtk, pango, gtk, glib, ... } :
+let
   fetchurl = a.fetchurl;
 
-  version = a.lib.attrByPath ["version"] "0.1.9" a; 
+  version = a.lib.attrByPath ["version"] "0.1.9" a;
   buildInputs = with a; [
     pkgconfig pygtk
   ];

--- a/pkgs/development/python-modules/xmpppy/default.nix
+++ b/pkgs/development/python-modules/xmpppy/default.nix
@@ -1,8 +1,8 @@
-a :  
-let 
+a @ {python, setuptools, ... } :
+let
   fetchurl = a.fetchurl;
 
-  version = a.lib.attrByPath ["version"] "0.5.0rc1" a; 
+  version = a.lib.attrByPath ["version"] "0.5.0rc1" a;
   buildInputs = with a; [
     python setuptools
   ];
@@ -22,7 +22,7 @@ rec {
     mkdir -p $out/bin $out/lib $out/share $(toPythonPath $out)
     export PYTHONPATH=$PYTHONPATH:$(toPythonPath $out)
   '') ["defEnsureDir" "addInputs"];
-      
+
   name = "xmpp.py-" + version;
   meta = {
     description = "XMPP python library";

--- a/pkgs/games/jamp/default.nix
+++ b/pkgs/games/jamp/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ { mesa, SDL, SDL_image, SDL_mixer, ... } :
+let
   s = import ./src-for-default.nix;
   buildInputs = with a; [
     mesa SDL SDL_mixer SDL_image
@@ -21,7 +21,7 @@ rec {
 
   /* doConfigure should be removed if not needed */
   phaseNames = ["preBuild" "doMakeInstall"];
-      
+
   meta = {
     description = "A physics-based game";
     maintainers = [ a.lib.maintainers.raskin ];

--- a/pkgs/games/lincity/default.nix
+++ b/pkgs/games/lincity/default.nix
@@ -1,7 +1,7 @@
-args : with args; 
-let 
-  version = lib.attrByPath ["version"] "1.12.1" args; 
-  sha256 = lib.attrByPath ["sha256"] 
+args @ { libX11, libXext, xextproto, libICE, libSM, xproto, libpng, zlib, ... }: with args;
+let
+  version = lib.attrByPath ["version"] "1.12.1" args;
+  sha256 = lib.attrByPath ["sha256"]
     "0xmrp7vkkp1hfblb6nl3rh2651qsbcm21bnncpnma1sf40jaf8wj" args;
   pkgName = "lincity";
 in
@@ -17,7 +17,7 @@ rec {
 
   /* doConfigure should be specified separately */
   phaseNames = ["doConfigure" "doMakeInstall"];
-      
+
   name = "${pkgName}-" + version;
   meta = {
     description = "City simulation game";

--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -1,11 +1,16 @@
-a :  
-let 
+a @ { xproto, libX11, libXrender
+, gmp, mesa, libjpeg, libpng
+, expat, gettext, perl
+, SDL, SDL_image, SDL_mixer, SDL_ttf
+, curl, sqlite
+, libogg, libvorbis, libcaca, csound, cunit, ... } :
+let
   buildInputs = with a; [
     xproto libX11 gmp guile
     mesa libjpeg libpng
     expat gettext perl
     SDL SDL_image SDL_mixer SDL_ttf
-    curl sqlite 
+    curl sqlite
     libogg libvorbis csound
     libXrender libcaca cunit
   ];
@@ -27,13 +32,13 @@ rec {
   setVars = a.noDepEntry (''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${a.SDL}/include/SDL"
   '');
-      
+
   meta = {
     description = "Quick tactics game";
     maintainers = [
       a.lib.maintainers.raskin
     ];
-    platforms = with a.lib.platforms; 
+    platforms = with a.lib.platforms;
       linux;
   homepage = "http://www.gnu.org/software/liquidwar6/";
   version = "0.6.3902";

--- a/pkgs/games/xsokoban/default.nix
+++ b/pkgs/games/xsokoban/default.nix
@@ -1,4 +1,4 @@
-a :
+a @ {libX11, xproto, libXpm, libXt, ...} :
 let
   fetchurl = a.fetchurl;
 

--- a/pkgs/games/zangband/default.nix
+++ b/pkgs/games/zangband/default.nix
@@ -1,4 +1,4 @@
-a :
+a @ { ncurses, flex, bison, autoconf, automake, m4, coreutils, ... } :
 let
   fetchurl = a.fetchurl;
 

--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -6,7 +6,7 @@
 # };
 # Make additional configurations on demand:
 # wine.override { wineBuild = "wine32"; wineRelease = "staging"; };
-{ lib, pkgs, system, callPackage,
+{ lib, pkgs, system, callPackage, wineUnstable,
   wineRelease ? "stable",
   wineBuild ? (if system == "x86_64-linux" then "wineWow" else "wine32"),
   libtxc_dxtn_Name ? "libtxc_dxtn_s2tc" }:
@@ -14,7 +14,7 @@
 if wineRelease == "staging" then
   callPackage ./staging.nix {
     inherit libtxc_dxtn_Name;
-    wine = lib.getAttr wineBuild (callPackage ./packages.nix { wineRelease = "unstable"; });
+    wine = wineUnstable;
   }
 else
   lib.getAttr wineBuild (callPackage ./packages.nix {

--- a/pkgs/os-specific/linux/directvnc/default.nix
+++ b/pkgs/os-specific/linux/directvnc/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ { libjpeg, pkgconfig, zlib, directfb, xproto, ... } :
+let
   s = import ./src-for-default.nix;
   buildInputs = with a; [
     directfb zlib libjpeg pkgconfig xproto
@@ -14,13 +14,13 @@ rec {
 
   /* doConfigure should be removed if not needed */
   phaseNames = ["doConfigure" "doMakeInstall"];
-      
+
   meta = {
     description = "DirectFB VNC client";
     maintainers = [
       a.lib.maintainers.raskin
     ];
-    platforms = with a.lib.platforms; 
+    platforms = with a.lib.platforms;
       linux;
   };
 }

--- a/pkgs/os-specific/linux/kernel/linux-3.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.10.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "3.10.87";

--- a/pkgs/os-specific/linux/kernel/linux-3.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.12.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "3.12.47";

--- a/pkgs/os-specific/linux/kernel/linux-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "3.14.51";

--- a/pkgs/os-specific/linux/kernel/linux-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "3.18.21";

--- a/pkgs/os-specific/linux/kernel/linux-4.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.1.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.1.6";

--- a/pkgs/os-specific/linux/kernel/linux-4.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.2";

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 let
 

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ... } @ args:
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
   version = "4.2-rc5";

--- a/pkgs/servers/squid/squids.nix
+++ b/pkgs/servers/squid/squids.nix
@@ -1,4 +1,6 @@
-args: with args;
+args @ { fetchurl, stdenv, perl, lib, composableDerivation
+, openldap, pam, db, cyrus_sasl, kerberos, libcap, expat, libxml2, libtool
+, openssl, ... }: with args;
 let edf = composableDerivation.edf; in
 rec {
   squid30 = composableDerivation.composableDerivation {} {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,5 +1,8 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
-args: with args;
+args @ { clangStdenv, fetchurl, fetchgit, fetchpatch, stdenv, pkgconfig, intltool, freetype, fontconfig
+, libxslt, expat, libpng, zlib, perl, mesa_drivers, spice_protocol
+, dbus, libuuid, openssl, gperf, m4, libevdev, tradcpp, libinput, mcpp, makeWrapper, autoreconfHook
+, autoconf, automake, libtool, xmlto, asciidoc, flex, bison, python, mtdev, pixman, ... }: with args;
 
 let
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -229,7 +229,10 @@ open OUT, ">default.nix";
 print OUT "";
 print OUT <<EOF;
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
-args: with args;
+args @ { clangStdenv, fetchurl, fetchgit, fetchpatch, stdenv, pkgconfig, intltool, freetype, fontconfig
+, libxslt, expat, libpng, zlib, perl, mesa_drivers, spice_protocol
+, dbus, libuuid, openssl, gperf, m4, libevdev, tradcpp, libinput, mcpp, makeWrapper, autoreconfHook
+, autoconf, automake, libtool, xmlto, asciidoc, flex, bison, python, mtdev, pixman, ... }: with args;
 
 let
 

--- a/pkgs/servers/xmpp/pyIRCt/default.nix
+++ b/pkgs/servers/xmpp/pyIRCt/default.nix
@@ -1,8 +1,8 @@
-a :  
-let 
+a @ { xmpppy, pythonIRClib, python, makeWrapper, ... } :
+let
   fetchurl = a.fetchurl;
 
-  version = a.lib.attrByPath ["version"] "0.4" a; 
+  version = a.lib.attrByPath ["version"] "0.4" a;
   buildInputs = with a; [
     xmpppy pythonIRClib python makeWrapper
   ];
@@ -30,7 +30,7 @@ rec {
     echo "./irc.py \"$@\"" >> $out/bin/pyIRCt
     chmod a+rx  $out/bin/pyIRCt $out/share/${name}/irc.py
   '') ["minInit" "addInputs" "doUnpack" "defEnsureDir"];
-      
+
   name = "pyIRCt-" + version;
   meta = {
     description = "IRC transport module for XMPP";

--- a/pkgs/servers/xmpp/pyMAILt/default.nix
+++ b/pkgs/servers/xmpp/pyMAILt/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ { xmpppy, python, makeWrapper, fetchcvs, ... } :
+let
   fetchurl = a.fetchurl;
 
   buildInputs = with a; [
@@ -32,7 +32,7 @@ rec {
     echo "./mail.py \"$@\"" >> $out/bin/pyMAILt
     chmod a+rx  $out/bin/pyMAILt $out/share/${name}/mail.py
   '') ["minInit" "addInputs" "doUnpack" "defEnsureDir"];
-      
+
   name = "pyMAILt-20090101";
   meta = {
     description = "Email transport module for XMPP";

--- a/pkgs/tools/admin/webdruid/default.nix
+++ b/pkgs/tools/admin/webdruid/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ { zlib, libpng, freetype, gd, which, libxml2, geoip, ... } :
+let
   s = import ./src-for-default.nix;
   buildInputs = with a; [
     zlib libpng freetype gd which libxml2
@@ -15,7 +15,7 @@ rec {
 
   /* doConfigure should be removed if not needed */
   phaseNames = ["doConfigure" "doMakeInstall" "doLinks"];
-      
+
   doLinks = a.fullDepEntry (''
     ln -s shared_en.xsl $out/share/webdruid/classic/shared.xsl
   '') ["minInit"];

--- a/pkgs/tools/graphics/cuneiform/default.nix
+++ b/pkgs/tools/graphics/cuneiform/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ { cmake, patchelf, imagemagick, ... } :
+let
   fetchurl = a.fetchurl;
 
   version = "1.1.0";
@@ -27,7 +27,7 @@ rec {
     export NIX_LDFLAGS="$NIX_LDFLAGS -ldl -L$out/lib"
     cmake .. -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=$out -DDL_LIB=${libc}/lib
   '') ["minInit" "addInputs" "doUnpack" "defEnsureDir"];
-      
+
   needLib64 = a.stdenv.system == "x86_64-linux";
 
   postInstall = a.fullDepEntry(''

--- a/pkgs/tools/misc/gnokii/default.nix
+++ b/pkgs/tools/misc/gnokii/default.nix
@@ -1,8 +1,8 @@
-a :  
-let 
+a @ { intltool, perl, gettext, libusb, pkgconfig, bluez, readline, pcsclite, libical, gtk, glib, libXpm, ... } :
+let
   fetchurl = a.fetchurl;
 
-  s = import ./src-for-default.nix; 
+  s = import ./src-for-default.nix;
   buildInputs = with a; [
     perl intltool gettext libusb
     glib gtk pkgconfig bluez readline

--- a/pkgs/tools/networking/gvpe/default.nix
+++ b/pkgs/tools/networking/gvpe/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ { openssl, gmp, nettools, iproute, zlib, ... } :
+let
   s = import ./src-for-default.nix;
   buildInputs = with a; [
     openssl gmp zlib
@@ -22,7 +22,7 @@ rec {
     sed -e 's@"/sbin/ifconfig.*"@"${a.iproute}/sbin/ip link set $IFNAME address $MAC mtu $MTU"@' -i src/device-linux.C
     sed -e 's@/sbin/ifconfig@${a.nettools}/sbin/ifconfig@g' -i src/device-*.C
   '') ["minInit" "doUnpack"];
-      
+
   meta = {
     description = "A proteted multinode virtual network";
     maintainers = [

--- a/pkgs/tools/networking/rp-pppoe/default.nix
+++ b/pkgs/tools/networking/rp-pppoe/default.nix
@@ -1,10 +1,10 @@
-a :  
-let 
+a @ {ppp, ...} :
+let
   fetchurl = a.fetchurl;
 
   version = a.lib.attrByPath ["version"] "3.11" a;
   buildInputs = with a; [
-    ppp   
+    ppp
   ];
 in
 rec {

--- a/pkgs/tools/security/bmrsa/11.nix
+++ b/pkgs/tools/security/bmrsa/11.nix
@@ -1,5 +1,5 @@
-args :  
-let 
+args @ {unzip, ... } :
+let
   lib = args.lib;
   fetchurl = args.fetchurl;
   fullDepEntry = args.fullDepEntry;

--- a/pkgs/tools/security/metasploit/3.1.nix
+++ b/pkgs/tools/security/metasploit/3.1.nix
@@ -1,4 +1,4 @@
-args : with args; 
+args @ { makeWrapper, ... }: with args;
 rec {
   src = fetchurl {
     url = http://www.packetstormsecurity.nl/UNIX/utilities/framework-3.1.tar.gz;
@@ -21,7 +21,7 @@ rec {
 
   /* doConfigure should be specified separately */
   phaseNames = ["doInstall" (doPatchShebangs "$out/share/msf")];
-      
+
   name = "metasploit-framework-3.1";
   meta = {
     description = "Metasploit Framework - a collection of exploits";

--- a/pkgs/tools/system/setserial/default.nix
+++ b/pkgs/tools/system/setserial/default.nix
@@ -1,8 +1,8 @@
-a :  
-let 
+a @ { groff, ... } :
+let
   fetchurl = a.fetchurl;
 
-  version = a.lib.attrByPath ["version"] "2.17" a; 
+  version = a.lib.attrByPath ["version"] "2.17" a;
   buildInputs = with a; [
     groff
   ];
@@ -26,7 +26,7 @@ rec {
   '') ["minInit" "doUnpack" "doConfigure"];
 
   neededDirs = ["$out/bin" "$out/share/man/man8"];
-      
+
   name = "setserial-" + version;
   meta = {
     description = "Serial port configuration utility";

--- a/pkgs/tools/system/vbetool/default.nix
+++ b/pkgs/tools/system/vbetool/default.nix
@@ -1,5 +1,5 @@
-a :  
-let 
+a @ {pciutils, libx86, zlib, ...} :
+let
   s = import ./src-for-default.nix;
   buildInputs = with a; [
     libx86 pciutils zlib
@@ -19,13 +19,13 @@ rec {
     sed -e 's@$(libdir)/libpci.a@${a.pciutils}/lib/libpci.so@' -i Makefile.in
     export NIX_LDFLAGS="$NIX_LDFLAGS -lpci"
   '') ["doUnpack" "minInit"];
-      
+
   meta = {
     description = "Video BIOS execution tool";
     maintainers = [
       a.lib.maintainers.raskin
     ];
-    platforms = with a.lib.platforms; 
+    platforms = with a.lib.platforms;
       linux;
   };
 }

--- a/pkgs/tools/typesetting/tex/texlive/aggregate.nix
+++ b/pkgs/tools/typesetting/tex/texlive/aggregate.nix
@@ -1,4 +1,4 @@
-args : with args;
+args @ {poppler, perl, makeWrapper, ... }: with args;
 rec {
   name = "TeXLive-linkdir";
 

--- a/pkgs/tools/typesetting/tex/texlive/beamer.nix
+++ b/pkgs/tools/typesetting/tex/texlive/beamer.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ {texLiveLatexXColor, texLivePGF, texLive, ...}: with args;
 rec {
   name = "texlive-beamer-2013";
   src = fetchurl {

--- a/pkgs/tools/typesetting/tex/texlive/cm-super.nix
+++ b/pkgs/tools/typesetting/tex/texlive/cm-super.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ {texLive, ...}: with args;
 rec {
   name = "texlive-cm-super-2009";
   src = fetchurl {
@@ -29,7 +29,7 @@ rec {
     description = "Extra components for TeXLive: CM-Super fonts";
     maintainers = [ args.lib.maintainers.raskin ];
 
-    # Actually, arch-independent.. 
+    # Actually, arch-independent..
     hydraPlatforms = [];
   };
 }

--- a/pkgs/tools/typesetting/tex/texlive/context.nix
+++ b/pkgs/tools/typesetting/tex/texlive/context.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ { texLive, ... }: with args;
 rec {
   name = "context-2014.05.21";
   src = fetchurl {
@@ -22,4 +22,4 @@ rec {
   };
 
 }
- 
+

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -1,4 +1,11 @@
-args : with args;
+args @ {
+builderDefs, zlib, bzip2, ncurses, libpng, ed, lesstif, ruby, potrace
+, gd, t1lib, freetype, icu, perl, expat, curl, xz, pkgconfig, zziplib, texinfo
+, libjpeg, bison, python, fontconfig, flex, poppler, libpaper, graphite2
+, makeWrapper, gmp, mpfr, xpdf, config
+, libXaw, libX11, xproto, libXt, libXpm
+, libXmu, libXext, xextproto, libSM, libICE
+, ... }: with args;
 
 rec {
   src = assert config.allowTexliveBuilds or true; fetchurl {

--- a/pkgs/tools/typesetting/tex/texlive/extra.nix
+++ b/pkgs/tools/typesetting/tex/texlive/extra.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ { texLive, xz, ... }: with args;
 rec {
   name    = "texlive-extra-2014";
   version = "2014.20141024";

--- a/pkgs/tools/typesetting/tex/texlive/moderncv.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderncv.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ {texLive, unzip, ...}: with args;
 rec {
   version = "1.5.1";
   name = "moderncv-${version}";

--- a/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
+++ b/pkgs/tools/typesetting/tex/texlive/moderntimeline.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ {texLive, unzip, ...}: with args;
 rec {
   version = "0.9";
   name = "moderntimeline-${version}";

--- a/pkgs/tools/typesetting/tex/texlive/xcolor.nix
+++ b/pkgs/tools/typesetting/tex/texlive/xcolor.nix
@@ -1,4 +1,4 @@
-args: with args;
+args @ {texLive, ... }: with args;
 rec {
   name = "texlive-latex-xcolor-2007";
   src = fetchurl {

--- a/pkgs/tools/video/vncrec/default.nix
+++ b/pkgs/tools/video/vncrec/default.nix
@@ -1,10 +1,12 @@
-a :  
-let 
+a @ {imake, libX11, xproto, gccmakedep, libXt
+, libXmu, libXaw, libXext, xextproto, libSM, libICE, libXpm
+, libXp, ...} :
+let
   fetchurl = a.fetchurl;
 
   buildInputs = with a; [
     libX11 xproto imake gccmakedep libXt libXmu libXaw
-    libXext xextproto libSM libICE libXpm libXp 
+    libXext xextproto libSM libICE libXpm libXp
   ];
 in
 rec {
@@ -29,7 +31,7 @@ rec {
   doXMKMF = a.fullDepEntry (''
     xmkmf
   '') ["doUnpack" "minInit" "addInputs"];
-      
+
   name = "vncrec-0.2"; # version taken from Arch AUR
   meta = {
     description = "VNC recorder";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -203,10 +203,7 @@ let
   # inside the set for derivations.
   recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
 
-  builderDefs = lib.composedArgsAndFun (import ../build-support/builder-defs/builder-defs.nix) {
-    inherit stringsWithDeps lib stdenv writeScript
-      fetchurl fetchmtn fetchgit;
-  };
+  builderDefs = lib.composedArgsAndFun (callPackage ../build-support/builder-defs/builder-defs.nix) {};
 
   builderDefsPackage = builderDefs.builderDefsPackage builderDefs;
 
@@ -265,8 +262,7 @@ let
 
   ### BUILD SUPPORT
 
-  attrSetToDir = arg: import ../build-support/upstream-updater/attrset-to-dir.nix {
-    inherit writeTextFile stdenv lib;
+  attrSetToDir = arg: callPackage ../build-support/upstream-updater/attrset-to-dir.nix {
     theAttrSet = arg;
   };
 
@@ -276,9 +272,7 @@ let
     { substitutions = { inherit autoconf automake libtool gettext; }; }
     ../build-support/setup-hooks/autoreconf.sh;
 
-  buildEnv = import ../build-support/buildenv {
-    inherit (pkgs) runCommand perl;
-  };
+  buildEnv = callPackage ../build-support/buildenv {};
 
   buildFHSEnv = callPackage ../build-support/build-fhs-chrootenv/env.nix {
     nixpkgs      = pkgs;
@@ -301,13 +295,12 @@ let
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
-  dotnetenv = import ../build-support/dotnetenv {
-    inherit stdenv;
+  dotnetenv = callPackage ../build-support/dotnetenv {
     dotnetfx = dotnetfx40;
   };
 
-  dotnetbuildhelpers = import ../build-support/dotnetbuildhelpers {
-    inherit mono helperFunctions pkgconfig;
+  dotnetbuildhelpers = callPackage ../build-support/dotnetbuildhelpers {
+    inherit helperFunctions;
   };
 
   scatterOutputHook = makeSetupHook {} ../build-support/setup-hooks/scatter_output.sh;
@@ -316,8 +309,7 @@ let
     vs = vs90wrapper;
   };
 
-  fetchadc = import ../build-support/fetchadc {
-    inherit curl stdenv;
+  fetchadc = callPackage ../build-support/fetchadc {
     adc_user = if config ? adc_user
       then config.adc_user
       else throw "You need an adc_user attribute in your config to download files from Apple Developer Connection";
@@ -326,37 +318,25 @@ let
       else throw "You need an adc_pass attribute in your config to download files from Apple Developer Connection";
   };
 
-  fetchbower = import ../build-support/fetchbower {
-    inherit stdenv git;
+  fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) fetch-bower;
   };
 
-  fetchbzr = import ../build-support/fetchbzr {
-    inherit stdenv bazaar;
-  };
+  fetchbzr = callPackage ../build-support/fetchbzr { };
 
-  fetchcvs = import ../build-support/fetchcvs {
-    inherit stdenv cvs;
-  };
+  fetchcvs = callPackage ../build-support/fetchcvs { };
 
-  fetchdarcs = import ../build-support/fetchdarcs {
-    inherit stdenv darcs nix;
-  };
+  fetchdarcs = callPackage ../build-support/fetchdarcs { };
 
-  fetchgit = import ../build-support/fetchgit {
-    inherit stdenv cacert;
+  fetchgit = callPackage ../build-support/fetchgit {
     git = gitMinimal;
   };
 
-  fetchgitPrivate = import ../build-support/fetchgit/private.nix {
-    inherit fetchgit writeScript openssh stdenv;
-  };
+  fetchgitPrivate = callPackage ../build-support/fetchgit/private.nix { };
 
   fetchgitrevision = import ../build-support/fetchgitrevision runCommand git;
 
-  fetchgitLocal = import ../build-support/fetchgitlocal {
-    inherit runCommand git nix;
-  };
+  fetchgitLocal = callPackage ../build-support/fetchgitlocal { };
 
   fetchmtn = callPackage ../build-support/fetchmtn (config.fetchmtn or {});
 
@@ -364,21 +344,17 @@ let
 
   fetchpatch = callPackage ../build-support/fetchpatch { };
 
-  fetchsvn = import ../build-support/fetchsvn {
-    inherit stdenv subversion openssh;
+  fetchsvn = callPackage ../build-support/fetchsvn {
     sshSupport = true;
   };
 
   fetchsvnrevision = import ../build-support/fetchsvnrevision runCommand subversion;
 
-  fetchsvnssh = import ../build-support/fetchsvnssh {
-    inherit stdenv subversion openssh expect;
+  fetchsvnssh = callPackage ../build-support/fetchsvnssh {
     sshSupport = true;
   };
 
-  fetchhg = import ../build-support/fetchhg {
-    inherit stdenv mercurial nix;
-  };
+  fetchhg = callPackage ../build-support/fetchhg { };
 
   # `fetchurl' downloads a file from the network.
   fetchurl = import ../build-support/fetchurl {
@@ -392,7 +368,7 @@ let
   # linked curl in the case of stdenv-linux).
   fetchurlBoot = stdenv.fetchurlBoot;
 
-  fetchzip = import ../build-support/fetchzip { inherit lib fetchurl unzip; };
+  fetchzip = callPackage ../build-support/fetchzip { };
 
   fetchFromGitHub = { owner, repo, rev, sha256, name ? "${repo}-${rev}-src" }: fetchzip {
     inherit name sha256;
@@ -434,8 +410,8 @@ let
     meta.homepage = "http://repo.or.cz/${repo}.git/";
   };
 
-  fetchNuGet = import ../build-support/fetchnuget { inherit stdenv fetchurl buildDotnetPackage unzip; };
-  buildDotnetPackage = import ../build-support/build-dotnet-package { inherit stdenv lib makeWrapper mono pkgconfig dotnetbuildhelpers; };
+  fetchNuGet = callPackage ../build-support/fetchnuget { };
+  buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
@@ -444,56 +420,37 @@ let
 
   libredirect = callPackage ../build-support/libredirect { };
 
-  makeDesktopItem = import ../build-support/make-desktopitem {
-    inherit stdenv;
-  };
+  makeDesktopItem = callPackage ../build-support/make-desktopitem { };
 
-  makeAutostartItem = import ../build-support/make-startupitem {
-    inherit stdenv;
-    inherit lib;
-  };
+  makeAutostartItem = callPackage ../build-support/make-startupitem { };
 
   makeInitrd = { contents, compressor ? "gzip -9n", prepend ? [ ] }:
-    import ../build-support/kernel/make-initrd.nix {
-      inherit stdenv perl perlArchiveCpio cpio contents ubootChooser compressor prepend;
-    };
+    callPackage ../build-support/kernel/make-initrd.nix { };
 
   makeWrapper = makeSetupHook { } ../build-support/setup-hooks/make-wrapper.sh;
 
   makeModulesClosure = { kernel, rootModules, allowMissing ? false }:
-    import ../build-support/kernel/modules-closure.nix {
-      inherit stdenv kmod kernel nukeReferences rootModules allowMissing;
+    callPackage ../build-support/kernel/modules-closure.nix {
+      inherit kernel rootModules allowMissing;
     };
 
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
 
-  srcOnly = args: (import ../build-support/src-only) ({inherit stdenv; } // args);
+  srcOnly = args: callPackage ../build-support/src-only args;
 
-  substituteAll = import ../build-support/substitute/substitute-all.nix {
-    inherit stdenv;
-  };
+  substituteAll = callPackage ../build-support/substitute/substitute-all.nix { };
 
-  substituteAllFiles = import ../build-support/substitute-files/substitute-all-files.nix {
-    inherit stdenv;
-  };
+  substituteAllFiles = callPackage ../build-support/substitute-files/substitute-all-files.nix { };
 
-  replaceDependency = import ../build-support/replace-dependency.nix {
-    inherit runCommand nix lib;
-  };
+  replaceDependency = callPackage ../build-support/replace-dependency.nix { };
 
   nukeReferences = callPackage ../build-support/nuke-references/default.nix { };
 
-  vmTools = import ../build-support/vm/default.nix {
-    inherit pkgs;
-  };
+  vmTools = callPackage ../build-support/vm/default.nix { };
 
-  releaseTools = import ../build-support/release/default.nix {
-    inherit pkgs;
-  };
+  releaseTools = callPackage ../build-support/release/default.nix { };
 
-  composableDerivation = (import ../../lib/composable-derivation.nix) {
-    inherit pkgs lib;
-  };
+  composableDerivation = callPackage ../../lib/composable-derivation.nix { };
 
   platforms = import ./platforms.nix;
 
@@ -605,9 +562,7 @@ let
 
   arp-scan = callPackage ../tools/misc/arp-scan { };
 
-  artyFX = callPackage ../applications/audio/artyFX {
-    inherit (xlibs) libpthreadstubs;
-  };
+  artyFX = callPackage ../applications/audio/artyFX {};
 
   ascii = callPackage ../tools/text/ascii { };
 
@@ -645,8 +600,7 @@ let
     client = true;
   });
 
-  androidenv = import ../development/mobile/androidenv {
-    inherit pkgs;
+  androidenv = callPackage ../development/mobile/androidenv {
     pkgs_i686 = pkgsi686Linux;
   };
 
@@ -672,7 +626,6 @@ let
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   titaniumenv = callPackage ../development/mobile/titaniumenv {
-    inherit pkgs;
     pkgs_i686 = pkgsi686Linux;
   };
 
@@ -689,9 +642,7 @@ let
 
   autojump = callPackage ../tools/misc/autojump { };
 
-  autorandr = callPackage ../tools/misc/autorandr {
-    inherit (xorg) xrandr xdpyinfo;
-  };
+  autorandr = callPackage ../tools/misc/autorandr {};
 
   avahi = callPackage ../development/libraries/avahi {
     qt4Support = config.avahi.qt4Support or false;
@@ -1011,9 +962,7 @@ let
     inherit (pythonPackages) notify;
   };
 
-  bmrsa = builderDefsPackage (import ../tools/security/bmrsa/11.nix) {
-    inherit unzip;
-  };
+  bmrsa = builderDefsPackage (callPackage ../tools/security/bmrsa/11.nix) { };
 
   bogofilter = callPackage ../tools/misc/bogofilter { };
 
@@ -1074,9 +1023,7 @@ let
   ceph-dev = lowPrio (callPackage ../tools/filesystems/ceph/dev.nix { });
   ceph-git = lowPrio (callPackage ../tools/filesystems/ceph/git.nix { });
 
-  cfdg = builderDefsPackage ../tools/graphics/cfdg {
-    inherit libpng bison flex ffmpeg;
-  };
+  cfdg = builderDefsPackage (callPackage ../tools/graphics/cfdg) {};
 
   checkinstall = callPackage ../tools/package-management/checkinstall { };
 
@@ -1199,23 +1146,17 @@ let
 
   cron = callPackage ../tools/system/cron { };
 
-  cudatoolkit5 = import ../development/compilers/cudatoolkit/5.5.nix {
-    inherit callPackage;
+  cudatoolkit5 = callPackage ../development/compilers/cudatoolkit/5.5.nix {
     python = python26;
   };
 
-  cudatoolkit6 = import ../development/compilers/cudatoolkit/6.0.nix {
-    inherit callPackage;
+  cudatoolkit6 = callPackage ../development/compilers/cudatoolkit/6.0.nix {
     python = python26;
   };
 
-  cudatoolkit65 = import ../development/compilers/cudatoolkit/6.5.nix {
-    inherit callPackage;
-  };
+  cudatoolkit65 = callPackage ../development/compilers/cudatoolkit/6.5.nix { };
 
-  cudatoolkit7 = import ../development/compilers/cudatoolkit/7.0.nix {
-    inherit callPackage;
-  };
+  cudatoolkit7 = callPackage ../development/compilers/cudatoolkit/7.0.nix { };
 
   cudatoolkit = cudatoolkit7;
 
@@ -1323,7 +1264,6 @@ let
 
   dir2opus = callPackage ../tools/audio/dir2opus {
     inherit (pythonPackages) mutagen python wrapPython;
-    inherit opusTools;
   };
 
   wgetpaste = callPackage ../tools/text/wgetpaste { };
@@ -1396,10 +1336,7 @@ let
 
   ecryptfs = callPackage ../tools/security/ecryptfs { };
 
-  editres = callPackage ../tools/graphics/editres {
-    inherit (xlibs) libXt libXaw;
-    inherit (xorg) utilmacros;
-  };
+  editres = callPackage ../tools/graphics/editres { };
 
   edk2 = callPackage ../development/compilers/edk2 { };
 
@@ -1655,11 +1592,7 @@ let
 
   gnaural = callPackage ../applications/audio/gnaural { };
 
-  gnokii = builderDefsPackage (import ../tools/misc/gnokii) {
-    inherit intltool perl gettext libusb pkgconfig bluez readline pcsclite
-      libical gtk glib;
-    inherit (xorg) libXpm;
-  };
+  gnokii = builderDefsPackage (callPackage ../tools/misc/gnokii) { };
 
   gnuapl = callPackage ../development/interpreters/gnu-apl { };
 
@@ -1821,9 +1754,7 @@ let
 
   gupnptools = callPackage ../tools/networking/gupnp-tools {};
 
-  gvpe = builderDefsPackage ../tools/networking/gvpe {
-    inherit openssl gmp nettools iproute zlib;
-  };
+  gvpe = builderDefsPackage (callPackage ../tools/networking/gvpe) {};
 
   gvolicon = callPackage ../tools/audio/gvolicon {};
 
@@ -2301,9 +2232,7 @@ let
 
   mscgen = callPackage ../tools/graphics/mscgen { };
 
-  msf = builderDefsPackage (import ../tools/security/metasploit/3.1.nix) {
-    inherit ruby makeWrapper;
-  };
+  msf = builderDefsPackage (callPackage ../tools/security/metasploit/3.1.nix) { };
 
   mssys = callPackage ../tools/misc/mssys { };
 
@@ -2393,9 +2322,7 @@ let
 
   newsbeuter-dev = callPackage ../applications/networking/feedreaders/newsbeuter/dev.nix { };
 
-  ngrep = callPackage ../tools/networking/ngrep {
-    inherit gnumake3;
-  };
+  ngrep = callPackage ../tools/networking/ngrep { };
 
   ngrok = goPackages.ngrok.bin // { outputs = [ "bin" ]; };
 
@@ -2410,7 +2337,6 @@ let
   pnmixer = callPackage ../tools/audio/pnmixer { };
 
   pwsafe = callPackage ../applications/misc/pwsafe {
-    inherit (xlibs) libXt libXtst libXi xextproto;
     wxGTK = wxGTK30;
   };
 
@@ -2785,13 +2711,9 @@ let
 
   pythonDBus = dbus_python;
 
-  pythonIRClib = builderDefsPackage (import ../development/python-modules/irclib) {
-    inherit python;
-  };
+  pythonIRClib = builderDefsPackage (callPackage ../development/python-modules/irclib) { };
 
-  pythonSexy = builderDefsPackage (import ../development/python-modules/libsexy) {
-    inherit python libsexy pkgconfig libxml2 pygtk pango gtk glib;
-  };
+  pythonSexy = builderDefsPackage (callPackage ../development/python-modules/libsexy) { };
 
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
@@ -2913,9 +2835,7 @@ let
 
   rosegarden = callPackage ../applications/audio/rosegarden { };
 
-  rpPPPoE = builderDefsPackage (import ../tools/networking/rp-pppoe) {
-    inherit ppp;
-  };
+  rpPPPoE = builderDefsPackage (callPackage ../tools/networking/rp-pppoe) { };
 
   rpm = callPackage ../tools/package-management/rpm { };
 
@@ -2985,9 +2905,7 @@ let
 
   seccure = callPackage ../tools/security/seccure { };
 
-  setserial = builderDefsPackage (import ../tools/system/setserial) {
-    inherit groff;
-  };
+  setserial = builderDefsPackage (callPackage ../tools/system/setserial) { };
 
   seqdiag = pythonPackages.seqdiag;
 
@@ -3312,9 +3230,7 @@ let
 
   vidalia = callPackage ../tools/security/vidalia { };
 
-  vbetool = builderDefsPackage ../tools/system/vbetool {
-    inherit pciutils libx86 zlib;
-  };
+  vbetool = builderDefsPackage (callPackage ../tools/system/vbetool) { };
 
   vde2 = callPackage ../tools/networking/vde2 { };
 
@@ -3337,11 +3253,7 @@ let
 
   vnc2flv = callPackage ../tools/video/vnc2flv {};
 
-  vncrec = builderDefsPackage ../tools/video/vncrec {
-    inherit (xlibs) imake libX11 xproto gccmakedep libXt
-      libXmu libXaw libXext xextproto libSM libICE libXpm
-      libXp;
-  };
+  vncrec = builderDefsPackage (callPackage ../tools/video/vncrec) {};
 
   vobcopy = callPackage ../tools/cd-dvd/vobcopy { };
 
@@ -3397,7 +3309,6 @@ let
   tigervnc = callPackage ../tools/admin/tigervnc {
     fontDirectories = [ xorg.fontadobe75dpi xorg.fontmiscmisc xorg.fontcursormisc
       xorg.fontbhlucidatypewriter75dpi ];
-    inherit (xorg) xorgserver;
     fltk = fltk13;
   };
 
@@ -3412,14 +3323,10 @@ let
 
   qfsm = callPackage ../applications/science/electronics/qfsm { };
 
-  tkgate = callPackage ../applications/science/electronics/tkgate/1.x.nix {
-    inherit (xlibs) libX11 imake xproto gccmakedep;
-  };
+  tkgate = callPackage ../applications/science/electronics/tkgate/1.x.nix { };
 
   # The newer package is low-priority because it segfaults at startup.
-  tkgate2 = lowPrio (callPackage ../applications/science/electronics/tkgate/2.x.nix {
-    inherit (xlibs) libX11;
-  });
+  tkgate2 = lowPrio (callPackage ../applications/science/electronics/tkgate/2.x.nix { });
 
   tm = callPackage ../tools/system/tm { };
 
@@ -3510,10 +3417,7 @@ let
 
   webalizer = callPackage ../tools/networking/webalizer { };
 
-  webdruid = builderDefsPackage ../tools/admin/webdruid {
-    inherit zlib libpng freetype gd which
-      libxml2 geoip;
-  };
+  webdruid = builderDefsPackage (callPackage ../tools/admin/webdruid) {};
 
   weighttp = callPackage ../tools/networking/weighttp { };
 
@@ -3529,7 +3433,6 @@ let
 
   wkhtmltopdf = callPackage ../tools/graphics/wkhtmltopdf {
     overrideDerivation = lib.overrideDerivation;
-    inherit (xlibs) libX11 libXext libXrender;
   };
 
   wml = callPackage ../development/web/wml { };
@@ -3548,8 +3451,7 @@ let
 
   x11_ssh_askpass = callPackage ../tools/networking/x11-ssh-askpass { };
 
-  xbursttools = assert stdenv ? glibc; import ../tools/misc/xburst-tools {
-    inherit stdenv fetchgit autoconf automake confuse pkgconfig libusb libusb1;
+  xbursttools = assert stdenv ? glibc; callPackage ../tools/misc/xburst-tools {
     # It needs a cross compiler for mipsel to build the firmware it will
     # load into the Ben Nanonote
     gccCross =
@@ -3606,9 +3508,7 @@ let
 
   xmltv = callPackage ../tools/misc/xmltv { };
 
-  xmpppy = builderDefsPackage (import ../development/python-modules/xmpppy) {
-    inherit python setuptools;
-  };
+  xmpppy = builderDefsPackage (callPackage ../development/python-modules/xmpppy) {};
 
   xorriso = callPackage ../tools/cd-dvd/xorriso { };
 
@@ -3624,9 +3524,7 @@ let
 
   xvfb_run = callPackage ../tools/misc/xvfb-run { inherit (texFunctions) fontsConf; };
 
-  xvkbd = callPackage ../tools/X11/xvkbd {
-    inherit (xlibs) libXt libXaw libXtst xextproto libXi libXpm gccmakedep;
-  };
+  xvkbd = callPackage ../tools/X11/xvkbd {};
 
   xwinmosaic = callPackage ../tools/X11/xwinmosaic {};
 
@@ -3702,8 +3600,8 @@ let
     abcPatchable [];
 
   abcPatchable = patches :
-    import ../development/compilers/abc/default.nix {
-      inherit stdenv fetchurl patches jre apacheAnt;
+    callPackage ../development/compilers/abc/default.nix {
+      inherit patches;
       javaCup = callPackage ../development/libraries/java/cup { };
     };
 
@@ -3749,19 +3647,15 @@ let
     llvmPackages = llvmPackages_34;
   };
 
-  clangUnwrapped = llvm: pkg: callPackage pkg {
-    inherit stdenv llvm;
-  };
+  clangUnwrapped = llvm: pkg: callPackage pkg { inherit llvm; };
 
   clangSelf = clangWrapSelf llvmPackagesSelf.clang;
 
-  clangWrapSelf = build: (import ../build-support/cc-wrapper) {
+  clangWrapSelf = build: callPackage ../build-support/cc-wrapper {
     cc = build;
     isClang = true;
     stdenv = clangStdenv;
     libc = glibc;
-    binutils = binutils;
-    inherit coreutils zlib;
     extraPackages = [ libcxx libcxxabi ];
     nativeTools = false;
     nativeLibc = false;
@@ -3808,8 +3702,8 @@ let
         extraBuildCommands = ''
           echo "dontMoveLib64=1" >> $out/nix-support/setup-hook
         '';
-      in wrapCCWith (import ../build-support/cc-wrapper) glibc_multi extraBuildCommands (gcc.cc.override {
-        stdenv = overrideCC stdenv (wrapCCWith (import ../build-support/cc-wrapper) glibc_multi "" gcc.cc);
+      in wrapCCWith (callPackage ../build-support/cc-wrapper) glibc_multi extraBuildCommands (gcc.cc.override {
+        stdenv = overrideCC stdenv (wrapCCWith (callPackage ../build-support/cc-wrapper) glibc_multi "" gcc.cc);
         profiledCompiler = false;
         enableMultilib = true;
       }))
@@ -3869,8 +3763,7 @@ let
   }));
 
   gcc45 = lowPrio (wrapCC (callPackage ../development/compilers/gcc/4.5 {
-    inherit fetchurl stdenv gmp mpfr libmpc libelf zlib perl
-      gettext which noSysDirs;
+    inherit noSysDirs;
     texinfo = texinfo4;
 
     ppl = null;
@@ -4001,9 +3894,7 @@ let
     ppl = null;
   });
 
-  gnatboot = wrapGCC-old (import ../development/compilers/gnatboot {
-    inherit fetchurl stdenv;
-  });
+  gnatboot = wrapGCC-old (callPackage ../development/compilers/gnatboot {});
 
   gnu-smalltalk = callPackage ../development/compilers/gnu-smalltalk {
     emacsSupport = config.emacsSupport or false;
@@ -4039,13 +3930,8 @@ let
 
   ghdl_mcode = callPackage ../development/compilers/ghdl { };
 
-  gcl = builderDefsPackage ../development/compilers/gcl {
-    inherit mpfr m4 binutils fetchcvs emacs zlib which
-      texinfo;
+  gcl = builderDefsPackage (callPackage ../development/compilers/gcl) {
     gmp = gmp4;
-    inherit (xlibs) libX11 xproto inputproto libXi
-      libXext xextproto libXt libXaw libXmu;
-    inherit stdenv;
     texLive = texLiveAggregationFun {
       paths = [
         texLive texLiveExtra
@@ -4094,7 +3980,7 @@ let
 
   fsharp = callPackage ../development/compilers/fsharp {};
 
-  dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix { inherit stdenv fetchNuGet; });
+  dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
   go_1_4 = callPackage ../development/compilers/go/1.4.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -4265,9 +4151,7 @@ let
 
   mlton = callPackage ../development/compilers/mlton { };
 
-  mono = callPackage ../development/compilers/mono {
-    inherit (xlibs) libX11;
-  };
+  mono = callPackage ../development/compilers/mono {};
 
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
@@ -4577,9 +4461,7 @@ let
 
     ocaml_optcomp = callPackage ../development/ocaml-modules/optcomp { };
 
-    ocaml_pcre = callPackage ../development/ocaml-modules/pcre {
-      inherit pcre;
-    };
+    ocaml_pcre = callPackage ../development/ocaml-modules/pcre {};
 
     pgocaml = callPackage ../development/ocaml-modules/pgocaml {};
 
@@ -4865,32 +4747,30 @@ let
     nativeLibc = stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
     cc = baseCC;
-    libc = libc;
     dyld = if stdenv.isDarwin then darwin.dyld else null;
     isGNU = baseCC.isGNU or false;
     isClang = baseCC.isClang or false;
-    inherit stdenv binutils coreutils zlib extraBuildCommands;
+    inherit libc extraBuildCommands;
   };
 
-  wrapCC = wrapCCWith (makeOverridable (import ../build-support/cc-wrapper)) stdenv.cc.libc "";
+  wrapCC = wrapCCWith (callPackage ../build-support/cc-wrapper) stdenv.cc.libc "";
   # legacy version, used for gnat bootstrapping
-  wrapGCC-old = baseGCC: (makeOverridable (import ../build-support/gcc-wrapper-old)) {
+  wrapGCC-old = baseGCC: callPackage ../build-support/gcc-wrapper-old {
     nativeTools = stdenv.cc.nativeTools or false;
     nativeLibc = stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
     gcc = baseGCC;
     libc = glibc;
-    inherit stdenv binutils coreutils zlib;
   };
 
   wrapGCCCross =
     {gcc, libc, binutils, cross, shell ? "", name ? "gcc-cross-wrapper"}:
 
-    forceNativeDrv (import ../build-support/gcc-cross-wrapper {
+    forceNativeDrv (callPackage ../build-support/gcc-cross-wrapper {
       nativeTools = false;
       nativeLibc = false;
       noLibc = (libc == null);
-      inherit stdenv gcc binutils libc shell name cross;
+      inherit gcc binutils libc shell name cross;
     });
 
   # prolog
@@ -4901,7 +4781,7 @@ let
 
   ### DEVELOPMENT / INTERPRETERS
 
-  acl2 = builderDefsPackage ../development/interpreters/acl2 {
+  acl2 = builderDefsPackage (callPackage ../development/interpreters/acl2) {
     sbcl = sbcl_1_2_0;
   };
 
@@ -5071,12 +4951,9 @@ let
 
   php = php56;
 
-  phpPackages = recurseIntoAttrs (import ./php-packages.nix {
-    inherit php pkgs;
-  });
+  phpPackages = recurseIntoAttrs (callPackage ./php-packages.nix {});
 
-  php55Packages = recurseIntoAttrs (import ./php-packages.nix {
-    inherit pkgs;
+  php55Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
     php = php55;
   });
 
@@ -5097,9 +4974,7 @@ let
   pure = callPackage ../development/interpreters/pure {
     llvm = llvm_35;
   };
-  purePackages = recurseIntoAttrs (import ./pure-packages.nix {
-    inherit callPackage;
-  });
+  purePackages = recurseIntoAttrs (callPackage ./pure-packages.nix {});
 
   python = python2;
   python2 = python27;
@@ -5144,9 +5019,7 @@ let
 
   python2nix = callPackage ../tools/package-management/python2nix { };
 
-  pythonDocs = recurseIntoAttrs (import ../development/interpreters/python/docs {
-    inherit stdenv fetchurl lib;
-  });
+  pythonDocs = recurseIntoAttrs (callPackage ../development/interpreters/python/docs {});
 
   pypi2nix = python27Packages.pypi2nix;
 
@@ -5206,8 +5079,8 @@ let
   ruby_2_1 = ruby_2_1_6;
   ruby_2_2 = ruby_2_2_2;
 
-  rubygemsFun = ruby: builderDefsPackage (import ../development/interpreters/ruby/rubygems.nix) {
-    inherit ruby makeWrapper;
+  rubygemsFun = ruby: builderDefsPackage (callPackage ../development/interpreters/ruby/rubygems.nix) {
+    inherit ruby;
   };
   rubygems = hiPrio (rubygemsFun ruby);
 
@@ -5273,9 +5146,7 @@ let
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
 
-  sourceFromHead = import ../build-support/source-from-head-fun.nix {
-    inherit config;
-  };
+  sourceFromHead = callPackage ../build-support/source-from-head-fun.nix {};
 
   ecj = callPackage ../development/eclipse/ecj { };
 
@@ -5308,9 +5179,7 @@ let
   srecord = callPackage ../development/tools/misc/srecord { };
 
   windowssdk = (
-    import ../development/misc/windows-sdk {
-      inherit fetchurl stdenv cabextract;
-    });
+    callPackage ../development/misc/windows-sdk {});
 
   xidel = callPackage ../tools/text/xidel { };
 
@@ -5471,9 +5340,7 @@ let
 
   ctags = callPackage ../development/tools/misc/ctags { };
 
-  ctagsWrapped = import ../development/tools/misc/ctags/wrapped.nix {
-    inherit pkgs ctags writeScriptBin;
-  };
+  ctagsWrapped = callPackage ../development/tools/misc/ctags/wrapped.nix {};
 
   ctodo = callPackage ../applications/misc/ctodo { };
 
@@ -5658,9 +5525,7 @@ let
 
   inotify-tools = callPackage ../development/tools/misc/inotify-tools { };
 
-  intel-gpu-tools = callPackage ../development/tools/misc/intel-gpu-tools {
-    inherit (xorg) libpciaccess dri2proto libX11 libXext libXv libXrandr;
-  };
+  intel-gpu-tools = callPackage ../development/tools/misc/intel-gpu-tools {};
 
   ired = callPackage ../development/tools/analysis/radare/ired.nix { };
 
@@ -5978,9 +5843,7 @@ let
 
   aspell = callPackage ../development/libraries/aspell { };
 
-  aspellDicts = recurseIntoAttrs (import ../development/libraries/aspell/dictionaries.nix {
-    inherit fetchurl stdenv aspell which;
-  });
+  aspellDicts = recurseIntoAttrs (callPackages ../development/libraries/aspell/dictionaries.nix {});
 
   aterm = aterm25;
 
@@ -6064,9 +5927,7 @@ let
 
   check = callPackage ../development/libraries/check { };
 
-  chipmunk = callPackage ../development/libraries/chipmunk {
-    inherit (xlibs) libX11 xproto inputproto libXi libXmu;
-  };
+  chipmunk = callPackage ../development/libraries/chipmunk {};
 
   chmlib = callPackage ../development/libraries/chmlib { };
 
@@ -6198,9 +6059,7 @@ let
 
   enginepkcs11 = callPackage ../development/libraries/enginepkcs11 { };
 
-  epoxy = callPackage ../development/libraries/epoxy {
-    inherit (xorg) utilmacros libX11;
-  };
+  epoxy = callPackage ../development/libraries/epoxy {};
 
   esdl = callPackage ../development/libraries/esdl { };
 
@@ -6230,11 +6089,11 @@ let
 
   fcgi = callPackage ../development/libraries/fcgi { };
 
-  ffmpeg_0_10 = import ../development/libraries/ffmpeg/0.10.nix { inherit callPackage; };
-  ffmpeg_1_2 = import ../development/libraries/ffmpeg/1.2.nix { inherit callPackage; };
-  ffmpeg_2_2 = import ../development/libraries/ffmpeg/2.2.nix { inherit callPackage; };
-  ffmpeg_2_6 = import ../development/libraries/ffmpeg/2.6.nix { inherit callPackage; };
-  ffmpeg_2_7 = import ../development/libraries/ffmpeg/2.7.nix { inherit callPackage; };
+  ffmpeg_0_10 = callPackage ../development/libraries/ffmpeg/0.10.nix { };
+  ffmpeg_1_2 = callPackage ../development/libraries/ffmpeg/1.2.nix { };
+  ffmpeg_2_2 = callPackage ../development/libraries/ffmpeg/2.2.nix { };
+  ffmpeg_2_6 = callPackage ../development/libraries/ffmpeg/2.6.nix { };
+  ffmpeg_2_7 = callPackage ../development/libraries/ffmpeg/2.7.nix { };
   # Aliases
   ffmpeg_0 = ffmpeg_0_10;
   ffmpeg_1 = ffmpeg_1_2;
@@ -6298,18 +6157,15 @@ let
   folly = callPackage ../development/libraries/folly { };
 
   makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
-    import ../development/libraries/fontconfig/make-fonts-conf.nix {
-      inherit runCommand libxslt fontconfig fontDirectories;
-      inherit (xorg) fontbhttf;
+    callPackage ../development/libraries/fontconfig/make-fonts-conf.nix {
+      inherit fontconfig fontDirectories;
     };
 
   freealut = callPackage ../development/libraries/freealut { };
 
   freeglut = callPackage ../development/libraries/freeglut { };
 
-  freenect = callPackage ../development/libraries/freenect {
-      inherit (xlibs) libXi libXmu;
-  };
+  freenect = callPackage ../development/libraries/freenect { };
 
   freetype = callPackage ../development/libraries/freetype { };
 
@@ -6418,8 +6274,7 @@ let
   glibcInfo = callPackage ../development/libraries/glibc/info.nix { };
 
   glibc_multi = callPackage ../development/libraries/glibc/multi.nix {
-    inherit glibc;
-    glibc32 = (import ./all-packages.nix {system = "i686-linux";}).glibc;
+    glibc32 = pkgsi686Linux.glibc;
   };
 
   glm = callPackage ../development/libraries/glm { };
@@ -6654,13 +6509,9 @@ let
 
   hunspell = callPackage ../development/libraries/hunspell { };
 
-  hunspellDicts = recurseIntoAttrs (import ../development/libraries/hunspell/dictionaries.nix {
-    inherit stdenv fetchurl unzip;
-  });
+  hunspellDicts = recurseIntoAttrs (callPackages ../development/libraries/hunspell/dictionaries.nix {});
 
-  hwloc = callPackage ../development/libraries/hwloc {
-    inherit (xlibs) libX11;
-  };
+  hwloc = callPackage ../development/libraries/hwloc {};
 
   hydraAntLogger = callPackage ../development/libraries/java/hydra-ant-logger { };
 
@@ -6701,9 +6552,7 @@ let
 
   itk = callPackage ../development/libraries/itk { };
 
-  jamp = builderDefsPackage ../games/jamp {
-    inherit mesa SDL SDL_image SDL_mixer;
-  };
+  jamp = builderDefsPackage (callPackage ../games/jamp) {};
 
   jasper = callPackage ../development/libraries/jasper { };
 
@@ -6771,9 +6620,7 @@ let
     python = python2;
   };
 
-  lensfun = callPackage ../development/libraries/lensfun {
-    inherit gnumake3;
-  };
+  lensfun = callPackage ../development/libraries/lensfun {};
 
   lesstif = callPackage ../development/libraries/lesstif { };
 
@@ -6926,10 +6773,7 @@ let
 
   libdnet = callPackage ../development/libraries/libdnet { };
 
-  libdrm = callPackage ../development/libraries/libdrm {
-    inherit fetchurl stdenv pkgconfig;
-    inherit (xorg) libpthreadstubs;
-  };
+  libdrm = callPackage ../development/libraries/libdrm { };
 
   libdv = callPackage ../development/libraries/libdv { };
 
@@ -6963,9 +6807,7 @@ let
 
   libfaketime = callPackage ../development/libraries/libfaketime { };
 
-  libfakekey = callPackage ../development/libraries/libfakekey {
-    inherit (xlibs) libX11 libXi xextproto;
-  };
+  libfakekey = callPackage ../development/libraries/libfakekey { };
 
   libfm = callPackage ../development/libraries/libfm { };
   libfm-extra = callPackage ../development/libraries/libfm {
@@ -7574,14 +7416,7 @@ let
 
   liquidfun = callPackage ../development/libraries/liquidfun { };
 
-  liquidwar = builderDefsPackage ../games/liquidwar {
-    inherit (xlibs) xproto libX11 libXrender;
-    inherit gmp mesa libjpeg libpng
-      expat gettext perl
-      SDL SDL_image SDL_mixer SDL_ttf
-      curl sqlite
-      libogg libvorbis libcaca csound cunit
-      ;
+  liquidwar = builderDefsPackage (callPackage ../games/liquidwar) {
     guile = guile_1_8;
   };
 
@@ -7764,7 +7599,7 @@ let
 
   nvidia-texture-tools = callPackage ../development/libraries/nvidia-texture-tools { };
 
-  ode = builderDefsPackage (import ../development/libraries/ode) { };
+  ode = builderDefsPackage (callPackage ../development/libraries/ode) { };
 
   ogre = callPackage ../development/libraries/ogre {};
 
@@ -7872,7 +7707,6 @@ let
 
   pcl = callPackage ../development/libraries/pcl {
     vtk = vtkWithQt4;
-    inherit (xorg) libXt;
   };
 
   pcre = callPackage ../development/libraries/pcre {
@@ -7915,13 +7749,10 @@ let
     spidermonkey = spidermonkey_17;
   };
 
-  polkit_qt4 = callPackage ../development/libraries/polkit-qt-1 {
-    inherit qt4;
-  };
+  polkit_qt4 = callPackage ../development/libraries/polkit-qt-1 { };
 
   polkit_qt5 = callPackage ../development/libraries/polkit-qt-1 {
     withQt5 = true;
-    inherit qt5;
   };
 
   policykit = callPackage ../development/libraries/policykit { };
@@ -7929,14 +7760,12 @@ let
   poppler = callPackage ../development/libraries/poppler { lcms = lcms2; };
 
   poppler_qt4 = poppler.override {
-    inherit qt4;
     qt4Support = true;
     suffix = "qt4";
   };
 
   poppler_qt5 = poppler.override {
     qt5Support = true;
-    inherit qt5;
     suffix = "qt5";
   };
 
@@ -8226,7 +8055,6 @@ let
 
   spice = callPackage ../development/libraries/spice {
     celt = celt_0_5_1;
-    inherit (xlibs) libXrandr libXfixes libXext libXrender libXinerama;
     inherit (pythonPackages) pyparsing;
   };
 
@@ -8356,10 +8184,7 @@ let
 
   unixODBC = callPackage ../development/libraries/unixODBC { };
 
-  unixODBCDrivers = recurseIntoAttrs (import ../development/libraries/unixODBCDrivers {
-    inherit fetchurl stdenv unixODBC glibc libtool openssl zlib;
-    inherit postgresql mysql sqlite;
-  });
+  unixODBCDrivers = recurseIntoAttrs (callPackages ../development/libraries/unixODBCDrivers {});
 
   urt = callPackage ../development/libraries/urt { };
 
@@ -8436,7 +8261,6 @@ let
 
   webkitgtk = callPackage ../development/libraries/webkitgtk {
     harfbuzz = harfbuzz-icu;
-    inherit (xorg) libpthreadstubs;
     gst-plugins-base = gst_all_1.gst-plugins-base;
   };
 
@@ -8542,9 +8366,7 @@ let
     qt = qt4;
   };
 
-  zangband = builderDefsPackage (import ../games/zangband) {
-    inherit ncurses flex bison autoconf automake m4 coreutils;
-  };
+  zangband = builderDefsPackage (callPackage ../games/zangband) {};
 
   zeitgeist = callPackage ../development/libraries/zeitgeist { };
 
@@ -8581,7 +8403,6 @@ let
     glibcLocales = if pkgs.stdenv.isLinux then pkgs.glibcLocales else null;
     extension = self : super : { };
     inherit (haskellPackages) Agda;
-    inherit writeScriptBin;
   };
 
   agdaBase = callPackage ../development/libraries/agda/agda-base { };
@@ -8689,20 +8510,18 @@ let
 
   go14Packages = recurseIntoAttrs (callPackage ./go-packages.nix {
     go = go_1_4;
-    buildGoPackage = import ../development/go-modules/generic {
+    buildGoPackage = callPackage ../development/go-modules/generic {
       go = go_1_4;
       govers = go14Packages.govers.bin;
-      inherit parallel lib;
     };
     overrides = (config.goPackageOverrides or (p: {})) pkgs;
   });
 
   go15Packages = recurseIntoAttrs (callPackage ./go-packages.nix {
     go = go_1_5;
-    buildGoPackage = import ../development/go-modules/generic {
+    buildGoPackage = callPackage ../development/go-modules/generic {
       go = go_1_5;
       govers = go15Packages.govers.bin;
-      inherit parallel lib;
     };
     overrides = (config.goPackageOverrides or (p: {})) pkgs;
   });
@@ -8730,10 +8549,9 @@ let
 
   ### DEVELOPMENT / PERL MODULES
 
-  buildPerlPackage = import ../development/perl-modules/generic perl;
+  buildPerlPackage = callPackage ../development/perl-modules/generic perl;
 
   perlPackages = recurseIntoAttrs (callPackage ./perl-packages.nix {
-    inherit pkgs;
     overrides = (config.perlPackageOverrides or (p: {})) pkgs;
   });
 
@@ -8748,7 +8566,6 @@ let
   planetary_annihilation = callPackage ../games/planetaryannihilation { };
 
   sqitchPg = callPackage ../development/tools/misc/sqitch {
-    inherit stdenv perl makeWrapper;
     name = "sqitch-pg";
     databaseModule = perlPackages.DBDPg;
     sqitchModule = perlPackages.AppSqitch;
@@ -8865,7 +8682,6 @@ let
   ### DEVELOPMENT / R MODULES
 
   R = callPackage ../applications/science/math/R {
-    inherit (xlibs) libX11 libXt;
     texLive = texLiveAggregationFun { paths = [ texLive texLiveExtra ]; };
     openblas = openblasCompat;
     withRecommendedPackages = false;
@@ -8963,13 +8779,9 @@ let
       libmaa = callPackage ../servers/dict/libmaa.nix {};
   };
 
-  dictdDBs = recurseIntoAttrs (import ../servers/dict/dictd-db.nix {
-    inherit builderDefs;
-  });
+  dictdDBs = recurseIntoAttrs (callPackages ../servers/dict/dictd-db.nix {});
 
-  dictDBCollector = import ../servers/dict/dictd-db-collector.nix {
-    inherit stdenv lib dict;
-  };
+  dictDBCollector = callPackage ../servers/dict/dictd-db-collector.nix {};
 
   dictdWiktionary = callPackage ../servers/dict/dictd-wiktionary.nix {};
 
@@ -9174,8 +8986,7 @@ let
 
   hyperdex = callPackage ../servers/nosql/hyperdex { };
 
-  mysql51 = import ../servers/sql/mysql/5.1.x.nix {
-    inherit fetchurl ncurses zlib perl openssl stdenv;
+  mysql51 = callPackage ../servers/sql/mysql/5.1.x.nix {
     ps = procps; /* !!! Linux only */
   };
 
@@ -9252,13 +9063,9 @@ let
 
   psqlodbc = callPackage ../servers/sql/postgresql/psqlodbc { };
 
-  pyIRCt = builderDefsPackage (import ../servers/xmpp/pyIRCt) {
-    inherit xmpppy pythonIRClib python makeWrapper;
-  };
+  pyIRCt = builderDefsPackage (callPackage ../servers/xmpp/pyIRCt) {};
 
-  pyMAILt = builderDefsPackage (import ../servers/xmpp/pyMAILt) {
-    inherit xmpppy python makeWrapper fetchcvs;
-  };
+  pyMAILt = builderDefsPackage (callPackage ../servers/xmpp/pyMAILt) {};
 
   qpid-cpp = callPackage ../servers/amqp/qpid-cpp { };
 
@@ -9342,11 +9149,7 @@ let
 
   spawn_fcgi = callPackage ../servers/http/spawn-fcgi { };
 
-  squids = recurseIntoAttrs( import ../servers/squid/squids.nix {
-    inherit fetchurl stdenv perl lib composableDerivation
-      openldap pam db cyrus_sasl kerberos libcap expat libxml2 libtool
-      openssl;
-  });
+  squids = recurseIntoAttrs (callPackages ../servers/squid/squids.nix {});
   squid = squids.squid31; # has ipv6 support
 
   sslh = callPackage ../servers/sslh { };
@@ -9392,11 +9195,7 @@ let
   xquartz = callPackage ../servers/x11/xquartz { };
   quartz-wm = callPackage ../servers/x11/quartz-wm { stdenv = clangStdenv; };
 
-  xorg = recurseIntoAttrs (import ../servers/x11/xorg/default.nix {
-    inherit clangStdenv fetchurl fetchgit fetchpatch stdenv pkgconfig intltool freetype fontconfig
-      libxslt expat libpng zlib perl mesa_drivers spice_protocol
-      dbus libuuid openssl gperf m4 libevdev tradcpp libinput mcpp makeWrapper autoreconfHook
-      autoconf automake libtool xmlto asciidoc flex bison python mtdev pixman;
+  xorg = recurseIntoAttrs (lib.callPackagesWith pkgs ../servers/x11/xorg/default.nix {
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
     mesa = mesa_noglu;
     udev = if stdenv.isLinux then udev else null;
@@ -9407,13 +9206,11 @@ let
 
   xorgVideoUnichrome = callPackage ../servers/x11/xorg/unichrome/default.nix { };
 
-  xwayland = with xorg; callPackage ../servers/x11/xorg/xwayland.nix { };
+  xwayland = callPackage ../servers/x11/xorg/xwayland.nix { };
 
   yaws = callPackage ../servers/http/yaws { erlang = erlangR17; };
 
-  zabbix = recurseIntoAttrs (import ../servers/monitoring/zabbix {
-    inherit fetchurl stdenv pkgconfig postgresql curl openssl zlib;
-  });
+  zabbix = recurseIntoAttrs (callPackages ../servers/monitoring/zabbix {});
 
   zabbix20 = callPackage ../servers/monitoring/zabbix/2.0.nix { };
   zabbix22 = callPackage ../servers/monitoring/zabbix/2.2.nix { };
@@ -9525,7 +9322,7 @@ let
 
   darwin = let
     cmdline = callPackage ../os-specific/darwin/command-line-tools {};
-    apple-source-releases = import ../os-specific/darwin/apple-source-releases { inherit stdenv fetchurl pkgs; };
+    apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
   in apple-source-releases // rec {
     cctools_cross = callPackage (forceNativeDrv (callPackage ../os-specific/darwin/cctools/port.nix {}).cross) {
       cross = assert crossSystem != null; crossSystem;
@@ -9576,10 +9373,7 @@ let
 
   dietlibc = callPackage ../os-specific/linux/dietlibc { };
 
-  directvnc = builderDefsPackage ../os-specific/linux/directvnc {
-    inherit libjpeg pkgconfig zlib directfb;
-    inherit (xlibs) xproto;
-  };
+  directvnc = builderDefsPackage (callPackage ../os-specific/linux/directvnc) {};
 
   dmraid = callPackage ../os-specific/linux/dmraid {
     devicemapper = devicemapper.override {enable_dmeventd = true;};
@@ -9730,13 +9524,11 @@ let
 
   linuxHeaders = linuxHeaders_3_12;
 
-  linuxHeaders24Cross = forceNativeDrv (import ../os-specific/linux/kernel-headers/2.4.nix {
-    inherit stdenv fetchurl perl;
+  linuxHeaders24Cross = forceNativeDrv (callPackage ../os-specific/linux/kernel-headers/2.4.nix {
     cross = assert crossSystem != null; crossSystem;
   });
 
-  linuxHeaders26Cross = forceNativeDrv (import ../os-specific/linux/kernel-headers/3.12.nix {
-    inherit stdenv fetchurl perl;
+  linuxHeaders26Cross = forceNativeDrv (callPackage ../os-specific/linux/kernel-headers/3.12.nix {
     cross = assert crossSystem != null; crossSystem;
   });
 
@@ -9754,13 +9546,11 @@ let
 
   kernelPatches = callPackage ../os-specific/linux/kernel/patches.nix { };
 
-  linux_rpi = makeOverridable (import ../os-specific/linux/kernel/linux-rpi.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_rpi = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ];
   };
 
-  linux_3_10 = makeOverridable (import ../os-specific/linux/kernel/linux-3.10.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_3_10 = callPackage ../os-specific/linux/kernel/linux-3.10.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9769,8 +9559,7 @@ let
       ];
   };
 
-  linux_3_12 = makeOverridable (import ../os-specific/linux/kernel/linux-3.12.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_3_12 = callPackage ../os-specific/linux/kernel/linux-3.12.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper kernelPatches.crc_regression ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9779,8 +9568,7 @@ let
       ];
   };
 
-  linux_3_14 = makeOverridable (import ../os-specific/linux/kernel/linux-3.14.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_3_14 = callPackage ../os-specific/linux/kernel/linux-3.14.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9789,8 +9577,7 @@ let
       ];
   };
 
-  linux_3_18 = makeOverridable (import ../os-specific/linux/kernel/linux-3.18.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_3_18 = callPackage ../os-specific/linux/kernel/linux-3.18.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9799,8 +9586,7 @@ let
       ];
   };
 
-  linux_4_1 = makeOverridable (import ../os-specific/linux/kernel/linux-4.1.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_4_1 = callPackage ../os-specific/linux/kernel/linux-4.1.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9809,8 +9595,7 @@ let
       ];
   };
 
-  linux_4_2 = makeOverridable (import ../os-specific/linux/kernel/linux-4.2.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_4_2 = callPackage ../os-specific/linux/kernel/linux-4.2.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9819,8 +9604,7 @@ let
       ];
   };
 
-  linux_testing = makeOverridable (import ../os-specific/linux/kernel/linux-testing.nix) {
-    inherit fetchurl stdenv perl buildLinux;
+  linux_testing = callPackage ../os-specific/linux/kernel/linux-testing.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
@@ -9845,9 +9629,8 @@ let
   grFlavors = import ../build-support/grsecurity/flavors.nix;
 
   mkGrsecurity = opts:
-    (import ../build-support/grsecurity {
+    (callPackage ../build-support/grsecurity {
       grsecOptions = opts;
-      inherit pkgs lib;
     });
 
   grKernel  = opts: (mkGrsecurity opts).grsecKernel;
@@ -10021,9 +9804,7 @@ let
 
   # A function to build a manually-configured kernel
   linuxManualConfig = pkgs.buildLinux;
-  buildLinux = import ../os-specific/linux/kernel/manual-config.nix {
-    inherit (pkgs) stdenv runCommand nettools bc perl kmod writeTextFile ubootChooser;
-  };
+  buildLinux = callPackage ../os-specific/linux/kernel/manual-config.nix {};
 
   keyutils = callPackage ../os-specific/linux/keyutils { };
 
@@ -10103,7 +9884,6 @@ let
   numactl = callPackage ../os-specific/linux/numactl { };
 
   open-vm-tools = callPackage ../applications/virtualization/open-vm-tools {
-    inherit (xlibs) libXinerama libXi libXrender libXrandr libXtst;
     inherit (gnome) gtk gtkmm;
   };
 
@@ -10326,7 +10106,6 @@ let
   uclibc = callPackage ../os-specific/linux/uclibc { };
 
   uclibcCross = lowPrio (callPackage ../os-specific/linux/uclibc {
-    inherit fetchzip stdenv libiconvReal;
     linuxHeaders = linuxHeadersCross;
     gccCross = gccCrossStageStatic;
     cross = assert crossSystem != null; crossSystem;
@@ -10434,18 +10213,14 @@ let
 
   xbomb = callPackage ../games/xbomb { };
 
-  xf86_input_mtrack = callPackage ../os-specific/linux/xf86-input-mtrack {
-    inherit (xorg) utilmacros xproto inputproto xorgserver;
-  };
+  xf86_input_mtrack = callPackage ../os-specific/linux/xf86-input-mtrack { };
 
   xf86_input_multitouch =
     callPackage ../os-specific/linux/xf86-input-multitouch { };
 
   xf86_input_wacom = callPackage ../os-specific/linux/xf86-input-wacom { };
 
-  xf86_video_nested = callPackage ../os-specific/linux/xf86-video-nested {
-    inherit (xorg) fontsproto renderproto utilmacros xorgserver;
-  };
+  xf86_video_nested = callPackage ../os-specific/linux/xf86-video-nested { };
 
   xf86_video_nouveau = xorg.xf86videonouveau;
 
@@ -10474,7 +10249,7 @@ let
 
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
-  arkpandora_ttf = builderDefsPackage (import ../data/fonts/arkpandora) { };
+  arkpandora_ttf = builderDefsPackage (callPackage ../data/fonts/arkpandora) { };
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };
 
@@ -10500,10 +10275,7 @@ let
 
   corefonts = callPackage ../data/fonts/corefonts { };
 
-  wrapFonts = paths : ((import ../data/fonts/fontWrap) {
-    inherit fetchurl stdenv builderDefs paths;
-    inherit (xorg) mkfontdir mkfontscale;
-  });
+  wrapFonts = paths : (callPackage ../data/fonts/fontWrap { inherit paths; });
 
   clearlyU = callPackage ../data/fonts/clearlyU { };
 
@@ -10593,9 +10365,7 @@ let
   liberation_ttf_binary = callPackage ../data/fonts/redhat-liberation-fonts/binary.nix { };
   liberation_ttf = liberation_ttf_binary;
 
-  libertine = builderDefsPackage (import ../data/fonts/libertine) {
-    inherit fetchurl fontforge lib;
-  };
+  libertine = builderDefsPackage (callPackage ../data/fonts/libertine) { };
 
   lmmath = callPackage ../data/fonts/lmodern/lmmath.nix {};
 
@@ -10687,9 +10457,7 @@ let
 
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme { };
 
-  themes = name: import (../data/misc/themes + ("/" + name + ".nix")) {
-    inherit fetchurl;
-  };
+  themes = name: callPackage (../data/misc/themes + ("/" + name + ".nix")) {};
 
   theano = callPackage ../data/fonts/theano { };
 
@@ -10764,7 +10532,6 @@ let
   aewan = callPackage ../applications/editors/aewan { };
 
   afterstep = callPackage ../applications/window-managers/afterstep {
-    inherit (xlibs) libX11 libXext libICE;
     fltk = fltk13;
     gtk = gtk2;
   };
@@ -10941,13 +10708,8 @@ let
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
-  carrier = builderDefsPackage (import ../applications/networking/instant-messengers/carrier/2.5.0.nix) {
-    inherit fetchurl stdenv pkgconfig perl perlXMLParser libxml2 openssl nss
-      gtkspell aspell gettext ncurses avahi dbus dbus_glib python
-      libtool automake autoconf gstreamer;
-    inherit gtk glib;
+  carrier = builderDefsPackage (callPackage ../applications/networking/instant-messengers/carrier/2.5.0.nix) {
     inherit (gnome) startupnotification GConf ;
-    inherit (xlibs) libXScrnSaver scrnsaverproto libX11 xproto kbproto;
   };
   funpidgin = carrier;
 
@@ -11053,10 +10815,7 @@ let
 
   csdp = callPackage ../applications/science/math/csdp { };
 
-  cuneiform = builderDefsPackage (import ../tools/graphics/cuneiform) {
-    inherit cmake patchelf;
-    imagemagick = imagemagick;
-  };
+  cuneiform = builderDefsPackage (callPackage ../tools/graphics/cuneiform) {};
 
   cutecom = callPackage ../tools/misc/cutecom { };
 
@@ -11128,14 +10887,14 @@ let
 
   dmtx = dmtx-utils;
 
-  dmtx-utils = callPackage (import ../tools/graphics/dmtx-utils) {
+  dmtx-utils = callPackage (callPackage ../tools/graphics/dmtx-utils) {
   };
 
   docker = callPackage ../applications/virtualization/docker { go = go_1_4; };
 
   doodle = callPackage ../applications/search/doodle { };
 
-  drumgizmo = callPackage ../applications/audio/drumgizmo { inherit (xlibs) libX11; };
+  drumgizmo = callPackage ../applications/audio/drumgizmo { };
 
   dunst = callPackage ../applications/misc/dunst { };
 
@@ -11367,17 +11126,17 @@ let
 
   emacs24Packages = recurseIntoAttrs (emacsPackagesGen emacs24 pkgs.emacs24Packages);
 
-  emacsPackagesNgGen = emacs: import ./emacs-packages.nix {
+  emacsPackagesNgGen = emacs: callPackage ./emacs-packages.nix {
     overrides = (config.emacsPackageOverrides or (p: {})) pkgs;
 
-    inherit lib stdenv fetchurl fetchgit fetchFromGitHub fetchhg emacs;
+    inherit emacs;
 
-    trivialBuild = import ../build-support/emacs/trivial.nix {
-      inherit lib stdenv emacs texinfo;
+    trivialBuild = callPackage ../build-support/emacs/trivial.nix {
+      inherit emacs;
     };
 
-    melpaBuild = import ../build-support/emacs/melpa.nix {
-      inherit lib stdenv fetchurl emacs texinfo;
+    melpaBuild = callPackage ../build-support/emacs/melpa.nix {
+      inherit emacs;
     };
 
     external = {
@@ -11481,14 +11240,7 @@ let
 
   gqrx = callPackage ../applications/misc/gqrx { };
 
-  grass = import ../applications/misc/grass {
-    inherit (xlibs) libXmu libXext libXp libX11 libXt libSM libICE libXpm
-      libXaw libXrender;
-    inherit config composableDerivation stdenv fetchurl
-      lib flex bison cairo fontconfig
-      gdal zlib ncurses gdbm proj pkgconfig swig
-      blas liblapack libjpeg libpng mysql unixODBC mesa postgresql python
-      readline sqlite tcl tk libtiff freetype makeWrapper wxGTK;
+  grass = callPackage ../applications/misc/grass {
     fftw = fftwSinglePrec;
     ffmpeg = ffmpeg_0;
     motif = lesstif;
@@ -11545,13 +11297,10 @@ let
   firefox-bin = callPackage ../applications/networking/browsers/firefox-bin {
     gconf = pkgs.gnome.GConf;
     inherit (pkgs.gnome) libgnome libgnomeui;
-    inherit (pkgs.xlibs) libX11 libXScrnSaver libXcomposite libXdamage libXext
-      libXfixes libXinerama libXrender libXt;
   };
 
   firestr = callPackage ../applications/networking/p2p/firestr
     { boost = boost155;
-      inherit (xlibs) libXScrnSaver;
     };
 
   flac = callPackage ../applications/audio/flac { };
@@ -11564,7 +11313,6 @@ let
 
   fme = callPackage ../applications/misc/fme {
     inherit (gnome) libglademm;
-    inherit pkgconfig autoconf automake gettext;
   };
 
   fomp = callPackage ../applications/audio/fomp { };
@@ -11613,13 +11361,9 @@ let
 
   gimp = gimp_2_8;
 
-  gimpPlugins = recurseIntoAttrs (import ../applications/graphics/gimp/plugins {
-    inherit pkgs gimp;
-  });
+  gimpPlugins = recurseIntoAttrs (callPackage ../applications/graphics/gimp/plugins {});
 
-  gitAndTools = recurseIntoAttrs (import ../applications/version-management/git-and-tools {
-    inherit pkgs;
-  });
+  gitAndTools = recurseIntoAttrs (callPackage ../applications/version-management/git-and-tools {});
 
   inherit (gitAndTools) git gitFull gitSVN git-cola svn2git git-radar;
 
@@ -11658,7 +11402,7 @@ let
     libart = pkgs.gnome2.libart_lgpl;
   };
 
-  idea = recurseIntoAttrs (callPackage ../applications/editors/idea { androidsdk = androidsdk_4_4; });
+  idea = recurseIntoAttrs (callPackages ../applications/editors/idea { androidsdk = androidsdk_4_4; });
 
   libquvi = callPackage ../applications/video/quvi/library.nix { };
 
@@ -11703,9 +11447,7 @@ let
 
   gphoto2 = callPackage ../applications/misc/gphoto2 { };
 
-  gphoto2fs = builderDefsPackage ../applications/misc/gphoto2/gphotofs.nix {
-    inherit libgphoto2 fuse pkgconfig glib libtool;
-  };
+  gphoto2fs = builderDefsPackage (callPackage ../applications/misc/gphoto2/gphotofs.nix) {};
 
   gramps = callPackage ../applications/misc/gramps { };
 
@@ -11725,7 +11467,7 @@ let
     java = if stdenv.isLinux then jre else jdk;
   };
 
-  qrdecode = builderDefsPackage (import ../tools/graphics/qrdecode) {
+  qrdecode = builderDefsPackage (callPackage ../tools/graphics/qrdecode) {
     libpng = libpng12;
     opencv = opencv_2_1;
   };
@@ -11743,9 +11485,7 @@ let
 
   gqview = callPackage ../applications/graphics/gqview { };
 
-  gmpc = callPackage ../applications/audio/gmpc {
-    inherit (xlibs) libSM libICE;
-  };
+  gmpc = callPackage ../applications/audio/gmpc {};
 
   gmtk = callPackage ../applications/networking/browsers/mozilla-plugins/gmtk {
     inherit (gnome) GConf;
@@ -11825,7 +11565,6 @@ let
   };
 
   i3lock = callPackage ../applications/window-managers/i3/lock.nix {
-    inherit (xorg) libxkbfile;
     cairo = cairo.override { xcbSupport = true; };
   };
 
@@ -11835,10 +11574,7 @@ let
 
   i810switch = callPackage ../os-specific/linux/i810switch { };
 
-  icewm = callPackage ../applications/window-managers/icewm {
-    inherit (xlibs) libX11 libXft libXext libXinerama
-      libXrandr libICE libSM;
-  };
+  icewm = callPackage ../applications/window-managers/icewm {};
 
   id3v2 = callPackage ../applications/audio/id3v2 { };
 
@@ -12195,8 +11931,7 @@ let
     lua = lua5;
   };
 
-  monotoneViz = builderDefsPackage (import ../applications/version-management/monotone-viz/mtn-head.nix) {
-    inherit graphviz pkgconfig autoconf automake libtool glib gtk;
+  monotoneViz = builderDefsPackage (callPackage ../applications/version-management/monotone-viz/mtn-head.nix) {
     inherit (ocamlPackages_4_01_0) lablgtk ocaml;
     inherit (gnome) libgnomecanvas;
   };
@@ -12209,9 +11944,7 @@ let
 
   mopidy-mopify = callPackage ../applications/audio/mopidy-mopify { };
 
-  mozplugger = callPackage ../applications/networking/browsers/mozilla-plugins/mozplugger {
-    inherit (xlibs) libX11 xproto;
-  };
+  mozplugger = callPackage ../applications/networking/browsers/mozilla-plugins/mozplugger {};
 
   easytag = callPackage ../applications/audio/easytag { };
 
@@ -12243,7 +11976,6 @@ let
   MPlayerPlugin = browser:
     callPackage ../applications/networking/browsers/mozilla-plugins/mplayerplug-in {
       inherit browser;
-      inherit (xlibs) libXpm;
       # !!! should depend on MPlayer
     };
 
@@ -12303,9 +12035,7 @@ let
 
   openshift = callPackage ../applications/networking/cluster/openshift { };
 
-  oroborus = callPackage ../applications/window-managers/oroborus {
-    inherit (xlibs) libSM libICE libXt libXaw libXmu libXext libXft libXpm libXrandr libXrender xextproto libXinerama;
-  };
+  oroborus = callPackage ../applications/window-managers/oroborus {};
 
   panamax_api = callPackage ../applications/networking/cluster/panamax/api {
     ruby = ruby_2_1;
@@ -12391,7 +12121,7 @@ let
   };
 
   netsurfBrowser = netsurf.browser;
-  netsurf = recurseIntoAttrs (import ../applications/networking/browsers/netsurf { inherit pkgs; });
+  netsurf = recurseIntoAttrs (callPackage ../applications/networking/browsers/netsurf {});
 
   notmuch = callPackage ../applications/networking/mailreaders/notmuch {
     # No need to build Emacs - notmuch.el works just fine without
@@ -12500,7 +12230,6 @@ let
     gnutls = if config.pidgin.gnutls or false then gnutls else null;
     libgcrypt = if config.pidgin.gnutls or false then libgcrypt else null;
     startupnotification = libstartup_notification;
-    inherit (xlibs) libXext libICE libSM;
   };
 
   pidgin-with-plugins = callPackage ../applications/networking/instant-messengers/pidgin/wrapper.nix {
@@ -12545,9 +12274,7 @@ let
 
   poezio = python3Packages.poezio;
 
-  pommed = callPackage ../os-specific/linux/pommed {
-    inherit (xorg) libXpm;
-  };
+  pommed = callPackage ../os-specific/linux/pommed {};
 
   pond = goPackages.pond.bin // { outputs = [ "bin" ]; };
 
@@ -12562,7 +12289,6 @@ let
   qiv = callPackage ../applications/graphics/qiv { };
 
   processing = callPackage ../applications/graphics/processing {
-    inherit (xorg) libXxf86vm;
     jdk = jdk7;
   };
 
@@ -12675,7 +12401,6 @@ let
   };
 
   rakarrack = callPackage ../applications/audio/rakarrack {
-    inherit (xorg) libXpm libXft;
     fltk = fltk13;
   };
 
@@ -12876,9 +12601,7 @@ let
 
   smartgithg = callPackage ../applications/version-management/smartgithg { };
 
-  slimThemes = recurseIntoAttrs (import ../applications/display-managers/slim/themes.nix {
-    inherit stdenv fetchurl slim;
-  });
+  slimThemes = recurseIntoAttrs (callPackage ../applications/display-managers/slim/themes.nix {});
 
   smartdeblur = callPackage ../applications/graphics/smartdeblur { };
 
@@ -12892,7 +12615,6 @@ let
 
   sonic-visualiser = callPackage ../applications/audio/sonic-visualiser {
     inherit (pkgs.vamp) vampSDK;
-    inherit (pkgs.xlibs) libX11;
   };
 
   sox = callPackage ../applications/misc/audio/sox { };
@@ -12979,9 +12701,7 @@ let
       numpy pyasn1 mock;
   };
 
-  tailor = builderDefsPackage (import ../applications/version-management/tailor) {
-    inherit makeWrapper python;
-  };
+  tailor = builderDefsPackage (callPackage ../applications/version-management/tailor) {};
 
   tangogps = callPackage ../applications/misc/tangogps {
     gconf = gnome.GConf;
@@ -13041,8 +12761,6 @@ let
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin {
     gconf = pkgs.gnome.GConf;
     inherit (pkgs.gnome) libgnome libgnomeui;
-    inherit (pkgs.xlibs) libX11 libXScrnSaver libXcomposite libXdamage libXext
-      libXfixes libXinerama libXrender libXt;
   };
 
   tig = gitAndTools.tig;
@@ -13145,10 +12863,8 @@ let
 
   veracity = callPackage ../applications/version-management/veracity {};
 
-  viewMtn = builderDefsPackage (import ../applications/version-management/viewmtn/0.10.nix)
+  viewMtn = builderDefsPackage (callPackage ../applications/version-management/viewmtn/0.10.nix)
   {
-    inherit monotone cheetahTemplate highlight ctags
-      makeWrapper graphviz which python;
     flup = pythonPackages.flup;
   };
 
@@ -13162,11 +12878,6 @@ let
   vimHugeX = vim_configurable;
 
   vim_configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
-    inherit (pkgs) fetchurl fetchhg stdenv ncurses pkgconfig gettext
-      composableDerivation lib config glib gtk python perl tcl ruby;
-    inherit (pkgs.xlibs) libX11 libXext libSM libXpm libXt libXaw libXau libXmu
-      libICE;
-
     features = "huge"; # one of  tiny, small, normal, big or huge
     lua = pkgs.lua5_1;
     gui = config.vim.gui or "auto";
@@ -13182,13 +12893,6 @@ let
   qtile = callPackage ../applications/window-managers/qtile { };
 
   qvim = lowPrio (callPackage ../applications/editors/vim/qvim.nix {
-    inherit (pkgs) fetchgit stdenv ncurses pkgconfig gettext
-      composableDerivation lib config python perl tcl ruby qt4;
-    inherit (pkgs.xlibs) libX11 libXext libSM libXpm libXt libXaw libXau libXmu
-      libICE;
-
-    inherit (pkgs) stdenvAdapters;
-
     features = "huge"; # one of  tiny, small, normal, big or huge
     lua = pkgs.lua5;
     flags = [ "python" "X11" ]; # only flag "X11" by now
@@ -13244,18 +12948,14 @@ let
     useDisplayDevice = true;
   };
 
-  vkeybd = callPackage ../applications/audio/vkeybd {
-    inherit (xlibs) libX11;
-  };
+  vkeybd = callPackage ../applications/audio/vkeybd {};
 
   vlc = callPackage ../applications/video/vlc {
     ffmpeg = ffmpeg_2;
   };
 
   vlc_qt5 = vlc.override {
-    qt4 = null;
     withQt5 = true;
-    inherit qt5;
   };
 
   vmpk = callPackage ../applications/audio/vmpk { };
@@ -13334,8 +13034,8 @@ let
       jre = cfg.jre or false;
       icedtea = cfg.icedtea or false;
     in
-    import ../applications/networking/browsers/firefox/wrapper.nix {
-      inherit stdenv lib makeWrapper makeDesktopItem browser browserName desktopName nameSuffix icon;
+    callPackage ../applications/networking/browsers/firefox/wrapper.nix {
+      inherit browser browserName desktopName nameSuffix icon;
       libtrick = true;
       plugins =
          assert !(enableGnash && enableAdobeFlash);
@@ -13390,13 +13090,13 @@ let
       ++ optional (cfg.enableVbaM or false) vba-m
       );
 
-  wrapRetroArch = { retroarch }: import ../misc/emulators/retroarch/wrapper.nix {
-    inherit stdenv lib makeWrapper retroarch;
+  wrapRetroArch = { retroarch }: callPackage ../misc/emulators/retroarch/wrapper.nix {
+    inherit retroarch;
     cores = retroArchCores;
   };
 
-  wrapKodi = { kodi }: import ../applications/video/kodi/wrapper.nix {
-    inherit stdenv lib makeWrapper kodi;
+  wrapKodi = { kodi }: callPackage ../applications/video/kodi/wrapper.nix {
+    inherit kodi;
     plugins = let inherit (lib) optional; in with kodiPlugins;
       ([]
       ++ optional (config.kodi.enableAdvancedLauncher or false) advanced-launcher
@@ -13409,7 +13109,6 @@ let
 
   wxcam = callPackage ../applications/video/wxcam {
     inherit (gnome) libglade;
-    inherit intltool;
     wxGTK = wxGTK28;
     gtk = gtk2;
   };
@@ -13422,9 +13121,7 @@ let
 
   x42-plugins = callPackage ../applications/audio/x42-plugins { };
 
-  xaos = builderDefsPackage (import ../applications/graphics/xaos) {
-    inherit (xlibs) libXt libX11 libXext xextproto xproto;
-    inherit gsl aalib zlib intltool gettext perl;
+  xaos = builderDefsPackage (callPackage ../applications/graphics/xaos) {
     libpng = libpng12;
   };
 
@@ -13563,7 +13260,7 @@ let
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix { };
 
   xpra = callPackage ../tools/X11/xpra { inherit (texFunctions) fontsConf; };
-  libfakeXinerama = callPackage ../tools/X11/xpra/libfakeXinerama.nix { inherit (xlibs) libXinerama; };
+  libfakeXinerama = callPackage ../tools/X11/xpra/libfakeXinerama.nix { };
   #TODO: 'pil' is not available for python3, yet
   xpraGtk3 = callPackage ../tools/X11/xpra/gtk3.nix { inherit (texFunctions) fontsConf; inherit (python3Packages) buildPythonPackage python cython pygobject3 pycairo; };
 
@@ -13623,12 +13320,11 @@ let
     fltk = fltk13.override { cfg.xftSupport = true; };
   };
 
-  zam-plugins = callPackage ../applications/audio/zam-plugins { inherit (xlibs) libX11; };
+  zam-plugins = callPackage ../applications/audio/zam-plugins { };
 
   zathuraCollection = recurseIntoAttrs
-    (let callPackage = newScope pkgs.zathuraCollection; in
-      import ../applications/misc/zathura {
-        inherit stdenv callPackage pkgs fetchurl lib;
+    (callPackage ../applications/misc/zathura {
+        callPackage = newScope pkgs.zathuraCollection;
         useMupdf = config.zathura.useMupdf or false;
       });
 
@@ -13810,11 +13506,7 @@ let
 
   lgogdownloader = callPackage ../games/lgogdownloader { };
 
-  lincity = builderDefsPackage (import ../games/lincity) {
-    inherit (xlibs) libX11 libXext xextproto
-      libICE libSM xproto;
-    inherit libpng zlib;
-  };
+  lincity = builderDefsPackage (callPackage ../games/lincity) {};
 
   lincity_ng = callPackage ../games/lincity/ng.nix {};
 
@@ -13903,7 +13595,7 @@ let
 
   sdlmame = callPackage ../games/sdlmame { };
 
-  sgtpuzzles = callPackage (import ../games/sgt-puzzles) { };
+  sgtpuzzles = callPackage (callPackage ../games/sgt-puzzles) { };
 
   simutrans = callPackage ../games/simutrans { };
   # get binaries without data built by Hydra
@@ -14039,9 +13731,7 @@ let
 
   xsnow = callPackage ../games/xsnow { };
 
-  xsokoban = builderDefsPackage (import ../games/xsokoban) {
-    inherit (xlibs) libX11 xproto libXpm libXt;
-  };
+  xsokoban = builderDefsPackage (callPackage ../games/xsokoban) {};
 
   zandronum = callPackage ../games/zandronum { };
   zandronum-server = callPackage ../games/zandronum/server.nix { };
@@ -14082,10 +13772,9 @@ let
 
   enlightenment = callPackage ../desktops/enlightenment { };
 
-  e19 = recurseIntoAttrs (
-    let callPackage = newScope pkgs.e19; in
-    import ../desktops/e19 { inherit callPackage pkgs; }
-  );
+  e19 = recurseIntoAttrs (callPackage ../desktops/e19 {
+    callPackage = newScope pkgs.e19;
+  });
 
   gnome2 = callPackage ../desktops/gnome-2 {
     callPackage = pkgs.newScope pkgs.gnome2;
@@ -14335,7 +14024,7 @@ let
 
   numix-gtk-theme = callPackage ../misc/themes/gtk3/numix-gtk-theme { };
 
-  plasma53 = recurseIntoAttrs (callPackage ../desktops/plasma-5.3 { inherit pkgs newScope; });
+  plasma53 = recurseIntoAttrs (callPackage ../desktops/plasma-5.3 { });
   plasma5_latest = plasma53;
   plasma5_stable = plasma53;
 
@@ -14344,7 +14033,7 @@ let
   theme-vertex = callPackage ../misc/themes/vertex { };
 
   xfce = xfce4-12;
-  xfce4-12 = recurseIntoAttrs (import ../desktops/xfce { inherit config pkgs newScope; });
+  xfce4-12 = recurseIntoAttrs (callPackage ../desktops/xfce { });
 
   xrandr-invert-colors = callPackage ../applications/misc/xrandr-invert-colors { };
 
@@ -14352,9 +14041,8 @@ let
 
   ### SCIENCE/GEOMETRY
 
-  drgeo = builderDefsPackage (import ../applications/science/geometry/drgeo) {
+  drgeo = builderDefsPackage (callPackage ../applications/science/geometry/drgeo) {
     inherit (gnome) libglade;
-    inherit libxml2 perl intltool libtool pkgconfig gtk;
     guile = guile_1_8;
   };
 
@@ -14373,11 +14061,7 @@ let
 
   mrbayes = callPackage ../applications/science/biology/mrbayes { };
 
-  ncbiCTools = builderDefsPackage ../development/libraries/ncbi {
-    inherit tcsh mesa lesstif;
-    inherit (xlibs) libX11 libXaw xproto libXt libSM libICE
-      libXmu libXext;
-  };
+  ncbiCTools = builderDefsPackage (callPackage ../development/libraries/ncbi) {};
 
   ncbi_tools = callPackage ../applications/science/biology/ncbi-tools { };
 
@@ -14406,11 +14090,7 @@ let
 
   blas = callPackage ../development/libraries/science/math/blas { };
 
-  content = builderDefsPackage ../applications/science/math/content {
-    inherit mesa lesstif;
-    inherit (xlibs) libX11 libXaw xproto libXt libSM libICE
-      libXmu libXext libXcursor;
-  };
+  content = builderDefsPackage (callPackage ../applications/science/math/content) {};
 
   jags = callPackage ../applications/science/math/jags { };
 
@@ -14573,8 +14253,7 @@ let
 
   hologram = goPackages.hologram.bin // { outputs = [ "bin" ]; };
 
-  isabelle = import ../applications/science/logic/isabelle {
-    inherit (pkgs) stdenv fetchurl nettools perl polyml;
+  isabelle = callPackage ../applications/science/logic/isabelle {
     inherit (pkgs.emacs24Packages) proofgeneral;
     java = if stdenv.isLinux then jre else jdk;
   };
@@ -14736,7 +14415,6 @@ let
 
   celestia = callPackage ../applications/science/astronomy/celestia {
     lua = lua5_1;
-    inherit (xlibs) libXmu;
     inherit (pkgs.gnome) gtkglext;
   };
 
@@ -14755,7 +14433,6 @@ let
   spyder = callPackage ../applications/science/spyder {
     inherit (pythonPackages) pyflakes rope sphinx numpy scipy matplotlib; # recommended
     inherit (pythonPackages) ipython pep8; # optional
-    inherit pylint;
   };
 
   stellarium = callPackage ../applications/science/astronomy/stellarium { };
@@ -14782,7 +14459,6 @@ let
 
     # Optional system packages, otherwise internal GEANT4 packages are used.
     clhep = null;
-    expat = expat;
     zlib  = null;
 
     # For enableGDML.
@@ -14793,11 +14469,6 @@ let
 
     # For enableXM.
     motif = null; # motif or lesstif
-
-    # For enableQT, enableXM, enableOpenGLX11, enableRaytracerX11.
-    mesa = mesa;
-    x11  = x11;
-    inherit (xlibs) libXmu;
   };
 
   g4py = callPackage ../development/libraries/physics/geant4/g4py { };
@@ -15058,9 +14729,7 @@ let
 
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
-  samsungUnifiedLinuxDriver = import ../misc/cups/drivers/samsung {
-    inherit fetchurl stdenv;
-    inherit cups ghostscript glibc patchelf;
+  samsungUnifiedLinuxDriver = callPackage ../misc/cups/drivers/samsung {
     gcc = import ../development/compilers/gcc/4.4 {
       inherit stdenv fetchurl gmp mpfr noSysDirs gettext which;
       texinfo = texinfo4;
@@ -15091,8 +14760,7 @@ let
 
   soundOfSorting = callPackage ../misc/sound-of-sorting { };
 
-  sourceAndTags = import ../misc/source-and-tags {
-    inherit pkgs stdenv unzip lib ctags;
+  sourceAndTags = callPackage ../misc/source-and-tags {
     hasktags = haskellPackages.hasktags;
   };
 
@@ -15108,15 +14776,9 @@ let
 
   tex4ht = callPackage ../tools/typesetting/tex/tex4ht { };
 
-  texFunctions = import ../tools/typesetting/tex/nix pkgs;
+  texFunctions = callPackage ../tools/typesetting/tex/nix pkgs;
 
-  texLive = builderDefsPackage (import ../tools/typesetting/tex/texlive) {
-    inherit builderDefs zlib bzip2 ncurses libpng ed lesstif ruby potrace
-      gd t1lib freetype icu perl expat curl xz pkgconfig zziplib texinfo
-      libjpeg bison python fontconfig flex poppler libpaper graphite2
-      makeWrapper gmp mpfr xpdf config;
-    inherit (xlibs) libXaw libX11 xproto libXt libXpm
-      libXmu libXext xextproto libSM libICE;
+  texLive = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive) {
     ghostscript = ghostscriptX;
     harfbuzz = harfbuzz.override {
       withIcu = true; withGraphite2 = true;
@@ -15142,40 +14804,25 @@ let
   Just installing a few packages doesn't work.
   */
   texLiveAggregationFun = params:
-    builderDefsPackage (import ../tools/typesetting/tex/texlive/aggregate.nix)
-      ({inherit poppler perl makeWrapper;} // params);
+    builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/aggregate.nix) params;
 
   texDisser = callPackage ../tools/typesetting/tex/disser {};
 
-  texLiveContext = builderDefsPackage (import ../tools/typesetting/tex/texlive/context.nix) {
-    inherit texLive;
-  };
+  texLiveContext = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/context.nix) {};
 
-  texLiveExtra = builderDefsPackage (import ../tools/typesetting/tex/texlive/extra.nix) {
-    inherit texLive xz;
-  };
+  texLiveExtra = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/extra.nix) {};
 
-  texLiveCMSuper = builderDefsPackage (import ../tools/typesetting/tex/texlive/cm-super.nix) {
-    inherit texLive;
-  };
+  texLiveCMSuper = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/cm-super.nix) {};
 
-  texLiveLatexXColor = builderDefsPackage (import ../tools/typesetting/tex/texlive/xcolor.nix) {
-    inherit texLive;
-  };
+  texLiveLatexXColor = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/xcolor.nix) {};
 
   texLivePGF = pgf3;
 
-  texLiveBeamer = builderDefsPackage (import ../tools/typesetting/tex/texlive/beamer.nix) {
-    inherit texLiveLatexXColor texLivePGF texLive;
-  };
+  texLiveBeamer = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/beamer.nix) {};
 
-  texLiveModerncv = builderDefsPackage (import ../tools/typesetting/tex/texlive/moderncv.nix) {
-    inherit texLive unzip;
-  };
+  texLiveModerncv = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/moderncv.nix) {};
 
-  texLiveModerntimeline = builderDefsPackage (import ../tools/typesetting/tex/texlive/moderntimeline.nix) {
-    inherit texLive unzip;
-  };
+  texLiveModerntimeline = builderDefsPackage (callPackage ../tools/typesetting/tex/texlive/moderntimeline.nix) {};
 
   thermald = callPackage ../tools/system/thermald { };
 
@@ -15189,9 +14836,7 @@ let
 
   vault = goPackages.vault.bin // { outputs = [ "bin" ]; };
 
-  vbam = callPackage ../misc/emulators/vbam {
-    inherit (xlibs) libpthreadstubs;
-  };
+  vbam = callPackage ../misc/emulators/vbam {};
 
   vice = callPackage ../misc/emulators/vice {
     libX11 = xlibs.libX11;
@@ -15200,7 +14845,7 @@ let
 
   viewnior = callPackage ../applications/graphics/viewnior { };
 
-  vimUtils = callPackage ../misc/vim-plugins/vim-utils.nix { inherit writeText; };
+  vimUtils = callPackage ../misc/vim-plugins/vim-utils.nix { };
 
   vimPlugins = recurseIntoAttrs (callPackage ../misc/vim-plugins { });
 
@@ -15255,9 +14900,7 @@ let
 
   xhyve = callPackage ../applications/virtualization/xhyve { };
 
-  xinput_calibrator = callPackage ../tools/X11/xinput_calibrator {
-    inherit (xlibs) libXi inputproto;
-  };
+  xinput_calibrator = callPackage ../tools/X11/xinput_calibrator {};
 
   xosd = callPackage ../misc/xosd { };
 
@@ -15280,8 +14923,7 @@ let
 
   zopfli = callPackage ../tools/compression/zopfli { };
 
-  myEnvFun = import ../misc/my-env {
-    inherit substituteAll pkgs;
+  myEnvFun = callPackage ../misc/my-env {
     inherit (stdenv) mkDerivation;
   };
 
@@ -15324,7 +14966,7 @@ let
     guiToolkit = config.higan.guiToolkit or "gtk";
   };
 
-  misc = import ../misc/misc.nix { inherit pkgs stdenv; };
+  misc = callPackage ../misc/misc.nix { };
 
   bullet = callPackage ../development/libraries/bullet {};
 


### PR DESCRIPTION
This creates no new derivations, although it does add (identical) copies of pixman and squid-3.5.1 due to the use of callPackages.

I also have to add explicit arguments to builderDefs packages; this is apparently a good thing.
