### PR TITLE
source-han-sans: 1.001 -> 1.004

### DIFF
--- a/pkgs/data/fonts/source-han-sans/default.nix
+++ b/pkgs/data/fonts/source-han-sans/default.nix
@@ -1,23 +1,29 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, unzip}:
 
 let
-  makePackage = {language, region, description}: stdenv.mkDerivation rec {
-    version = "1.001R";
-    name = "source-han-sans-${language}-${version}";
+  makePackage = {variant, language, region, sha256}: stdenv.mkDerivation rec {
+    version = "1.004R";
+    name = "source-han-sans-${variant}-${version}";
+    revision = "5f5311e71cb628321cc0cffb51fb38d862b726aa";
+
+    buildInputs = [ unzip ];
 
     src = fetchurl {
-      url = "https://github.com/adobe-fonts/source-han-sans/archive/${version}.tar.gz";
-      sha256 = "0cwz3d8jancl0a7vbjxhnh1vgwsjba62lahfjya9yrjkp1ndxlap";
+      url = "https://github.com/adobe-fonts/source-han-sans/raw/${revision}/SubsetOTF/SourceHanSans${region}.zip";
+      inherit sha256;
     };
+
+    setSourceRoot = ''
+      sourceRoot=$( echo SourceHanSans* )
+    '';
 
     installPhase = ''
       mkdir -p $out/share/fonts/opentype
-      cp $( find SubsetOTF/${region} -name '*.otf' ) $out/share/fonts/opentype
+      cp $( find . -name '*.otf' ) $out/share/fonts/opentype
     '';
 
     meta = {
-      inherit description;
-
+      description = "${language} subset of an open source Pan-CJK typeface";
       homepage = https://github.com/adobe-fonts/source-han-sans;
       license = stdenv.lib.licenses.asl20;
     };
@@ -25,23 +31,27 @@ let
 in
 {
   japanese = makePackage {
-    language = "japanese";
+    variant = "japanese";
+    language = "Japanese";
     region = "JP";
-    description = "Japanese subset of an open source Pan-CJK typeface";
+    sha256 = "0m1zprwqnqp3za42firg53hyzir6p0q73fl8mh5j4px3zgivlvfw";
   };
   korean = makePackage {
-    language = "korean";
+    variant = "korean";
+    language = "Korean";
     region = "KR";
-    description = "Korean subset of an open source Pan-CJK typeface";
+    sha256 = "1bz6n2sd842vgnqky0i7a3j3i2ixhzzkkbx1m8plk04r1z41bz9q";
   };
   simplified-chinese = makePackage {
-    language = "simplified-chinese";
+    variant = "simplified-chinese";
+    language = "Simplified Chinese";
     region = "CN";
-    description = "Simplified Chinese subset of an open source Pan-CJK typeface";
+    sha256 = "0ksafcwmnpj3yxkgn8qkqkpw10ivl0nj9n2lsi9c6fw3aa71s3ha";
   };
   traditional-chinese = makePackage {
-    language = "traditional-chinese";
+    variant = "traditional-chinese";
+    language = "Traditional Chinese";
     region = "TW";
-    description = "Traditional Chinese subset of an open source Pan-CJK typeface";
+    sha256 = "1l4zymd5n4nl9gmja707xq6bar88dxki2mwdixdfrkf544cidflj";
   };
 }


### PR DESCRIPTION
This patch updates from 1.001 to 1.004. Switched from a huge monolithic archive to separated archives for each languages.
Also fixes unzipping problem, that is, the default unpack function does not handle ZIP archives. The archives contain __MACOSX directory, so that we need a explicit setSourceRoot hook.

Tested on x86_64 Linux.
