### PR TITLE
mlmmj: Fix invalid mailman entry and update dbs

### DIFF
--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -109,9 +109,10 @@ in
           ${pkgs.coreutils}/bin/chown -R ${cfg.user}:${cfg.group} ${spoolDir}
           ${lib.concatMapStrings (createList cfg.listDomain) cfg.mailLists}
           echo ${lib.concatMapStrings (virtual cfg.listDomain) cfg.mailLists} > ${stateDir}/virtuals
-          echo ${cfg.listDomain} mailman: > ${stateDir}/transports
-          echo ${lib.concatMapStrings (transport cfg.listDomain) cfg.mailLists} >> ${stateDir}/transports
-    '';
+          echo ${lib.concatMapStrings (transport cfg.listDomain) cfg.mailLists} > ${stateDir}/transports
+          ${pkgs.postfix}/bin/postmap ${stateDir}/virtuals
+          ${pkgs.postfix}/bin/postmap ${stateDir}/transports
+      '';
 
     systemd.services."mlmmj-maintd" = {
       description = "mlmmj maintenance daemon";


### PR DESCRIPTION
Hi,

two things are contained in this PR that are somehow related.
### Invalid Mailman Command

There is a "$domain mailman:" entry generated on creation which ends up in a warning and messages that cannot be delivered due to "mail transport unavailables"

```
Sep 16 09:22:05 nixe.k4cg.org postfix/qmgr[23117]: warning: connect to transport private/mailman: No such file or directory
Sep 16 09:22:05 nixe.k4cg.org postfix/error[23227]: 8973C8975E6C: to=<$mailaddr>, relay=none, delay=0.03, delays=0.02/0/0/0, dsn=4.3.0, status=deferred (mail transport unavailable)
```
### virtual and transports databases are not updated

when new content is coming (or changed) the belonging virtuals.db and transports.db are not being updated by module

```
warning: database /var/lib/mlmmj/transports.db is older than source file /var/lib/mlmmj/transports
```

Both of these errors are fixed in the PR
