### PR TITLE
swig3: re-enable darwin builds

### DIFF
--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     # Licensing is a mess: http://www.swig.org/Release/LICENSE .
     license = "BSD-style";
 
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
 
     maintainers = with stdenv.lib.maintainers; [ urkud ];
   };


### PR DESCRIPTION
It seems to build and work fine on my macs, at least.
