### PR TITLE
stage-1: fix ZFS root mount

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -290,6 +290,13 @@ mountFS() {
         if [ -z "$fsType" ]; then fsType=auto; fi
     fi
 
+    if [ "$fsType" = zfs ]; then
+        echo "mounting $device on $mountPoint..."
+        mkdir -p "/mnt-root$mountPoint" || true
+        mount -t zfs -o zfsutil "$device" "/mnt-root$mountPoint"
+        return
+    fi
+    
     echo "$device /mnt-root$mountPoint $fsType $options" >> /etc/fstab
 
     checkFS "$device" "$fsType"


### PR DESCRIPTION
Fixes #9904, although `stage-2-init.sh` still tries to remount `/` rw, then complains about not being able to do so.

Signed-off-by: Hajo Möller dasjoe@gmail.com
