### PR TITLE
zimwriterfs: init at 20150710.

### DIFF
--- a/pkgs/tools/text/zimwriterfs/default.nix
+++ b/pkgs/tools/text/zimwriterfs/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchgit, automake, autoconf, libtool, lzma, pkgconfig, zimlib, file, zlib }:
+
+stdenv.mkDerivation {
+  name = "zimwriterfs";
+  version = "20150710";
+
+  src = fetchgit {
+    url = https://gerrit.wikimedia.org/r/p/openzim.git;
+    rev = "165eab3e154c60b5b6436d653dc7c90f56cf7456";
+    sha256 = "0x0d3rx6zcc8k66nqkacmwdvslrz70h9bliqawzv90ribq3alb0q";
+  };
+
+  buildInputs = [ automake autoconf libtool lzma pkgconfig zimlib file zlib ];
+  setSourceRoot = "cd openzim-*/zimwriterfs; export sourceRoot=`pwd`";
+  preConfigurePhases = [ "./autogen.sh" ];
+
+  meta = {
+    description = "A console tool to create ZIM files";
+    homepage = http://git.wikimedia.org/log/openzim;
+    maintainers = with stdenv.lib.maintainers; [ robbinch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3561,6 +3561,8 @@ let
   zinnia = callPackage ../tools/inputmethods/zinnia { };
   tegaki-zinnia-japanese = callPackage ../tools/inputmethods/tegaki-zinnia-japanese { };
 
+  zimwriterfs = callPackage ../tools/text/zimwriterfs { };
+
   zip = callPackage ../tools/archivers/zip { };
 
   zpaq = callPackage ../tools/archivers/zpaq { };


### PR DESCRIPTION
This adds zimwriterfs, a console tool to create ZIM (http://www.openzim.org)
files from a locally stored directory containing 'self-sufficient'
HTML content (with pictures, javascript, stylesheets).
