### PR TITLE
Improve thunar/thunarx.

### DIFF
--- a/pkgs/desktops/xfce/core/thunar.nix
+++ b/pkgs/desktops/xfce/core/thunar.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
+  patches = [ ./thunarx_plugins_directory.patch ];
+
   buildInputs = [
     pkgconfig intltool
     gtk dbus_glib libstartup_notification libnotify libexif pcre udev

--- a/pkgs/desktops/xfce/core/thunarx_plugins_directory.patch
+++ b/pkgs/desktops/xfce/core/thunarx_plugins_directory.patch
@@ -1,0 +1,48 @@
+diff --git a/thunarx/thunarx-provider-factory.c b/thunarx/thunarx-provider-factory.c
+index 31b8835..a3e7f4e 100644
+--- a/thunarx/thunarx-provider-factory.c
++++ b/thunarx/thunarx-provider-factory.c
+@@ -141,12 +141,19 @@ static GList*
+ thunarx_provider_factory_load_modules (ThunarxProviderFactory *factory)
+ {
+   ThunarxProviderModule *module;
++  const gchar           *thunar_dir;
+   const gchar           *name;
+   GList                 *modules = NULL;
+   GList                 *lp;
+   GDir                  *dp;
+ 
+-  dp = g_dir_open (THUNARX_DIRECTORY, 0, NULL);
++  thunar_dir = g_getenv("THUNARX_MODULE_DIR");
++  if (NULL == thunar_dir)
++    {
++      thunar_dir = THUNARX_DIRECTORY;
++    }
++
++  dp = g_dir_open (thunar_dir, 0, NULL);
+   if (G_LIKELY (dp != NULL))
+     {
+       /* determine the types for all existing plugins */
+diff --git a/thunarx/thunarx-provider-module.c b/thunarx/thunarx-provider-module.c
+index 023ad2a..6c21997 100644
+--- a/thunarx/thunarx-provider-module.c
++++ b/thunarx/thunarx-provider-module.c
+@@ -174,10 +174,17 @@ static gboolean
+ thunarx_provider_module_load (GTypeModule *type_module)
+ {
+   ThunarxProviderModule *module = THUNARX_PROVIDER_MODULE (type_module);
++  const gchar           *thunar_dir;
+   gchar                 *path;
++    
++  thunar_dir = g_getenv("THUNARX_MODULE_DIR");
++  if (NULL == thunar_dir)
++    {
++      thunar_dir = THUNARX_DIRECTORY;
++    }
+ 
+   /* load the module using the runtime link editor */
+-  path = g_build_filename (THUNARX_DIRECTORY, type_module->name, NULL);
++  path = g_build_filename (thunar_dir, type_module->name, NULL);
+   module->library = g_module_open (path, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+   g_free (path);
+ 


### PR DESCRIPTION
Allows one to register plugins not built directly as
part of thunar by using an environment variable
instead of a build time fixed value.

This could allow one to wrap `thunar` in a `thunar-with-plugins`
package where plugins are declared instead of being found (a
bit in the same fashion as gstreamer plugins).

Note that when no environment variable present, simply
fallback to previous behavior. 
