### PR TITLE
jitsi: fix the system tray icon

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jitsi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi/default.nix
@@ -51,7 +51,9 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     cp resources/install/generic/run.sh $out/bin/jitsi
     chmod +x $out/bin/jitsi
-    substituteInPlace $out/bin/jitsi --replace '@JAVA@' '${jdk}/bin/java'
+    substituteInPlace $out/bin/jitsi \
+        --subst-var-by JAVA ${jdk}/bin/java \
+        --subst-var-by EXTRALIBS ${gtk2}/lib
     patchShebangs $out
 
     libPath="$libPath:${jdk.jre.home}/lib/${jdk.architecture}"

--- a/pkgs/applications/networking/instant-messengers/jitsi/jitsi.patch
+++ b/pkgs/applications/networking/instant-messengers/jitsi/jitsi.patch
@@ -24,4 +24,4 @@
  
  export PATH=$PATH:native
 -java $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=native -Dfelix.config.properties=file:./lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator
-+exec @JAVA@ $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=$NATIVELIBS -Dfelix.config.properties=file:lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator
++LD_LIBRARY_PATH=@EXTRALIBS@ exec @JAVA@ $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=$NATIVELIBS -Dfelix.config.properties=file:lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator


### PR DESCRIPTION
Java's desktop integration on Linux relies on dlopen'ing some libraries (gtk2 or
gnome).  This commit makes Java able to find gtk2, fixing the problem of Jitsi's
system tray icon not appearing.

Tested against release-15.09.  Part of bug #4014.
