### PR TITLE
claws-mail: fix attachment MIME detection, enable parallel build

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -80,6 +80,8 @@ stdenv.mkDerivation {
     ++ optional (!enablePluginVcalendar) "--disable-vcalendar-plugin"
     ++ optional (!enableSpellcheck) "--disable-enchant";
 
+  enableParallelBuilding = true;
+
   postInstall = ''
     mkdir -p $out/share/applications
     cp claws-mail.desktop $out/share/applications

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv
 , curl, dbus, dbus_glib, enchant, gtk, gnutls, gnupg, gpgme, libarchive
 , libcanberra, libetpan, libnotify, libsoup, libxml2, networkmanager, openldap
-, perl, pkgconfig, poppler, python, webkitgtk2
+, perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk2
 
 # Build options
 # TODO: A flag to build the manual.
@@ -47,6 +47,8 @@ stdenv.mkDerivation {
     sha256 = "0w13xzri9d3165qsxf1dig1f0gxn3ib4lysfc9pgi4zpyzd0zgrw";
   };
 
+  patches = [ ./mime.patch ];
+
   buildInputs =
     [ curl dbus dbus_glib gtk gnutls libetpan perl pkgconfig python ]
     ++ optional enableSpellcheck enchant
@@ -85,5 +87,7 @@ stdenv.mkDerivation {
   postInstall = ''
     mkdir -p $out/share/applications
     cp claws-mail.desktop $out/share/applications
+
+    ln -sT ${shared_mime_info}/share/mime $out/share/mime
   '';
 }

--- a/pkgs/applications/networking/mailreaders/claws-mail/mime.patch
+++ b/pkgs/applications/networking/mailreaders/claws-mail/mime.patch
@@ -1,0 +1,14 @@
+--- a/src/procmime.c	2015-09-18 04:03:11.767654094 -0700
++++ b/src/procmime.c	2015-09-18 04:08:38.834503034 -0700
+@@ -1196,11 +1196,7 @@
+ 	if (mime_type_list) 
+ 		return mime_type_list;
+ 	
+-#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+ 	if ((fp = procmime_fopen(DATAROOTDIR "/mime/globs", "rb")) == NULL) 
+-#else
+-	if ((fp = procmime_fopen("/usr/share/mime/globs", "rb")) == NULL) 
+-#endif
+ 	{
+ 		fp_is_glob_file = FALSE;
+ 		if ((fp = procmime_fopen("/etc/mime.types", "rb")) == NULL) {


### PR DESCRIPTION
Adds support for shared-mime-info to Claws, to fix attachments in
outgoing messages always having MIME type application/octet-stream
because Claws doesn't know where to look, instead complaining:

/nix/store/...-claws-mail-3.11.1/etc/mime.types: fopen: No such file or directory

Moreover, Claws relies on incoming MIME types for knowing when e.g. to
display an attached image, so sending application/octet-stream
unnecessarily is bad.

Also turns on `enableParallelBuilding`.

Tested against release-15.09.
