### PR TITLE
Add the hg version of pygame for python3 support

### DIFF
--- a/pkgs/development/python-modules/pygame/py3.nix
+++ b/pkgs/development/python-modules/pygame/py3.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchhg, buildPythonPackage, pkgconfig, smpeg, libX11
+, SDL, SDL_image, SDL_mixer, SDL_ttf, libpng, libjpeg, portmidi
+, ffmpeg
+}:
+
+buildPythonPackage {
+  name = "pygame-1.9.2";
+
+  src = fetchhg {
+    url = "https://bitbucket.org/pygame/pygame";
+    rev = "8bdcd449963f";
+    sha256 = "1mhwh6lggfiyz22njxxr14p16ms0apfg14n1hmczqh4d6pdz8l2p";
+  };
+
+  buildInputs = [
+    pkgconfig SDL SDL_image SDL_mixer SDL_ttf libpng libjpeg
+    smpeg portmidi libX11 ffmpeg
+  ];
+
+  preConfigure = ''
+    for i in ${SDL_image} ${SDL_mixer} ${SDL_ttf} ${libpng} ${libjpeg} ${portmidi} ${libX11} ${ffmpeg}; do
+      sed -e "/origincdirs =/a'$i/include'," -i config_unix.py
+      sed -e "/origlibdirs =/aoriglibdirs += '$i/lib'," -i config_unix.py
+    done
+
+    LOCALBASE=/ python3 config.py
+  '';
+
+  
+  meta = {
+    description = "Python library for games";
+    homepage = "http://www.pygame.org/";
+    license = stdenv.lib.licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7896,6 +7896,8 @@ let
 
   pygame = callPackage ../development/python-modules/pygame { };
 
+  pygame3 = callPackage ../development/python-modules/pygame/py3.nix { inherit (python3Packages) buildPythonPackage; };
+
   pygobject = pythonPackages.pygobject;
 
   pygobject3 = pythonPackages.pygobject3;


### PR DESCRIPTION
ubuntu and other distributions have a version of pygame that works with python3, taking it off the hg repository. This is the same for nixpkgs.
