### PR TITLE
xf86-input-synaptics: make use of 50-synaptics.conf

### DIFF
--- a/nixos/modules/services/x11/hardware/synaptics.nix
+++ b/nixos/modules/services/x11/hardware/synaptics.nix
@@ -18,6 +18,8 @@ let cfg = config.services.xserver.synaptics;
       Option "TapButton2" "0"
       Option "TapButton3" "0"
     '';
+  pkg = pkgs.xorg.xf86inputsynaptics;
+  etcFile = "X11/xorg.conf.d/50-synaptics.conf";
 in {
 
   options = {
@@ -146,9 +148,12 @@ in {
 
   config = mkIf cfg.enable {
 
-    services.xserver.modules = [ pkgs.xorg.xf86inputsynaptics ];
+    services.xserver.modules = [ pkg ];
 
-    environment.systemPackages = [ pkgs.xorg.xf86inputsynaptics ];
+    environment.etc."${etcFile}".source =
+      "${pkg}/share/X11/xorg.conf.d/50-synaptics.conf";
+
+    environment.systemPackages = [ pkg ];
 
     services.xserver.config =
       ''


### PR DESCRIPTION
The default synaptics functionality without this file is limited for clickpads: the right soft button area in the bottom right isn't active by default, so the entire pad generates left-clicks (with a single finger).  There is no way to right-drag.

This file defines soft button areas and provides some matching rules.  These settings don't conflict with the synaptics options that NixOS provides.

I would also be happy to add an option for this (`enableUpstreamConfig`, default true?).  CC @abbradar for review.
