### PR TITLE
deisctl: init at 1.10.0

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -812,6 +812,8 @@ let
 
   ddate = callPackage ../tools/misc/ddate { };
 
+  deis = goPackages.deis.bin // { outputs = [ "bin" ]; };
+
   dfilemanager = callPackage ../applications/misc/dfilemanager { };
 
   diagrams-builder = callPackage ../tools/graphics/diagrams-builder {

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -490,6 +490,20 @@ let
     };
   };
 
+  deis = buildFromGitHub {
+    rev = "v1.10.0";
+    owner = "deis";
+    repo = "deis";
+    sha256 = "0qji0dcfqgvjrfn5fjagjib606n24iy9qank2ckh202s75rxx5w9";
+    subPackages = [ "client" ];
+    buildInputs = [ docopt-go crypto yaml-v2 ];
+    postInstall = ''
+      if [ -f "$bin/bin/client" ]; then
+        mv "$bin/bin/client" "$bin/bin/deis"
+      fi
+    '';
+  };
+
   dns = buildFromGitHub {
     rev    = "e59f851c912767b1db587dcabee6e6652e495c75";
     date   = "2015-07-22";


### PR DESCRIPTION
I need the deis client for work but unfortunately I've no experience in Go projects. Would someone be so nice and help me with it? Should I use `go2nix` or `GoDep`?

The build finishes without errors but the output doesn't contain the `deisctl` binary.

Here is the official documentation:
http://docs.deis.io/en/latest/installing_deis/install-deisctl/#building-from-source

CC: @lethalman 
