### PR TITLE
nixos: show the manual in system's /share/doc

### DIFF
--- a/nixos/modules/services/misc/nixos-manual.nix
+++ b/nixos/modules/services/misc/nixos-manual.nix
@@ -93,7 +93,7 @@ in
 
     system.build.manual = manual;
 
-    environment.systemPackages = [ manual.manpages help ];
+    environment.systemPackages = [ manual.manpages manual.manual help ];
 
     boot.extraTTYs = mkIf cfg.showManual ["tty${cfg.ttyNumber}"];
 


### PR DESCRIPTION
`nixos-help` is nice, but a static path is better
