### PR TITLE
Add xfce.thunar-dropbox-plugin

### DIFF
--- a/pkgs/desktops/xfce/core/thunarx-2-dev.nix
+++ b/pkgs/desktops/xfce/core/thunarx-2-dev.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, intltool
+, gtk, dbus_glib, libstartup_notification, libnotify, libexif, pcre, udev
+, exo, libxfce4util
+, xfconf, libxfce4ui
+}:
+
+stdenv.mkDerivation rec {
+  host_p_name = "thunar";
+  p_name = "thunarx-2-dev";
+  ver_maj = "1.6";
+  ver_min = "6";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/xfce/${host_p_name}/${ver_maj}/Thunar-${ver_maj}.${ver_min}.tar.bz2";
+    sha256 = "1cl9v3rdzipyyxml3pyrzspxfmmssz5h5snpj18irq4an42539dr";
+  };
+  name = "${p_name}-${ver_maj}.${ver_min}";
+
+  preBuild = ''
+    cd thunarx
+  '';
+
+  buildInputs = [
+    pkgconfig intltool
+    gtk dbus_glib libstartup_notification libnotify libexif pcre udev
+    exo libxfce4util 
+    xfconf libxfce4ui
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://thunar.xfce.org/;
+    description = "Thunar Extension Framework";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -25,8 +25,11 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   libxfce4util    = callPackage ./core/libxfce4util.nix { };
   libxfcegui4     = callPackage ./core/libxfcegui4.nix { };
   thunar          = callPackage ./core/thunar.nix { };
+  thunarx-2-dev   = callPackage ./core/thunarx-2-dev.nix { };
   thunar_volman   = callPackage ./core/thunar-volman.nix { }; # ToDo: probably inside Thunar now
   thunar_archive_plugin  = callPackage ./core/thunar-archive-plugin.nix { };
+  thunar-dropbox-plugin 
+                  = callPackage ./thunar-plugins/dropbox { };
   tumbler         = callPackage ./core/tumbler.nix { };
   xfce4panel      = callPackage ./core/xfce4-panel.nix { }; # ToDo: impure plugins from /run/current-system/sw/lib/xfce4
   xfce4session    = callPackage ./core/xfce4-session.nix { };

--- a/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, pkgconfig
+, gtk
+, thunarx-2-dev, python2
+}:
+
+stdenv.mkDerivation rec {
+  p_name  = "thunar-dropbox-plugin";
+  ver_maj = "0.2";
+  ver_min = "1";
+  name = "${p_name}-${ver_maj}.${ver_min}";
+
+  src = fetchurl {
+    url = "http://softwarebakery.com/maato/files/thunar-dropbox/thunar-dropbox-${ver_maj}.${ver_min}.tar.bz2";
+    sha256 = "08vhzzzwshyz371yl7fzfylmhvchhv3s5kml3dva4v39jhvrpnkf";
+  };
+
+  buildInputs = [
+    pkgconfig
+    gtk
+    thunarx-2-dev python2
+  ];
+
+  configurePhase = "python2 waf configure --prefix=$out";
+
+  buildPhase = "python2 waf";
+
+  installPhase = ''
+    python2 waf install
+  '';
+
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://softwarebakery.com/maato/thunar-dropbox.html;
+    description = "A plugin for thunar that adds context-menu items from dropbox";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
A thunar dropbox plugin that allows to copy links and
add files to dropbox.

Depends on new `xfce.thunarx-2-dev` plugin sdk package instead of
thunar. Doing so seem standard on other distributions such as
Ubuntu and narrows depedencies to only the sdk headers (i.e.:
what's needed by plugins).

Note that replacing the `xfce.thunarx-2-dev` dependency directly
by `xfce.thunar` work equally well. However it now would be
impossible for the `thunar` executable to depend on the plugin.
