### PR TITLE
Remove nodejs-unstable package

### DIFF
--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openssl, python, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool, unstableVersion ? false
+, pkgconfig, runCommand, which, libtool
 }:
 
 # nodejs 0.12 can't be built on armv5tel. Armv6 with FPU, minimum I think.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2015,7 +2015,6 @@ let
     libuv = libuvVersions.v1_6_1;
     libtool = darwin.cctools;
   };
-  nodejs-unstable = callPackage ../development/web/nodejs { libuv = libuvVersions.v1_2_0; unstableVersion = true; };
   nodejs-0_10 = callPackage ../development/web/nodejs/v0_10.nix {
     libtool = darwin.cctools;
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices Carbon Foundation;


### PR DESCRIPTION
This package was same as the main nodejs package since the given
unstableVersion flag is noop.

Just doing `nodejs-unstable = nodejs` was probably a little bit safer, but nothing else on nixpkgs uses it and if someone does, it's better to just replace it with `nodejs` I think.

cc @cillianderoiste @Havvy
