### PR TITLE
Noto fonts

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -1,0 +1,119 @@
+{ stdenv, fetchurl, fetchFromGitHub, optipng, cairo, unzip, fontforge, pythonPackages, pkgconfig }:
+rec {
+  # 18MB
+  noto-fonts = let version = "git-2015-09-08"; in stdenv.mkDerivation {
+    name = "noto-fonts-${version}";
+    src = fetchFromGitHub {
+      owner = "googlei18n";
+      repo = "noto-fonts";
+      rev = "9d677e7e47a13f6e88052833277783fe4f27671f";
+      sha256 = "1dw1142znlk19a4mzhfi9pg3jzmz8pl1ivix7sd2grg70vxscxqc";
+    };
+    phases = "unpackPhase installPhase";
+    installPhase = ''
+      mkdir -p $out/share/fonts/noto
+      cp hinted/*.ttf $out/share/fonts/noto
+      # Also copy unhinted & alpha fonts for better glyph coverage,
+      # if they don't have a hinted version
+      # (see https://groups.google.com/d/msg/noto-font/ZJSkZta4n5Y/tZBnLcPdbS0J)
+      cp -n unhinted/*.ttf $out/share/fonts/noto
+      cp -n alpha/*.ttf $out/share/fonts/noto
+    '';
+    meta = with stdenv.lib; {
+      inherit version;
+      description = "Beautiful and free fonts for many languages";
+      homepage = https://www.google.com/get/noto/;
+      longDescription =
+      ''
+        When text is rendered by a computer, sometimes characters are displayed as
+        “tofu”. They are little boxes to indicate your device doesn’t have a font to
+        display the text.
+
+        Google has been developing a font family called Noto, which aims to support all
+        languages with a harmonious look and feel. Noto is Google’s answer to tofu. The
+        name noto is to convey the idea that Google’s goal is to see “no more tofu”.
+        Noto has multiple styles and weights, and freely available to all.
+
+        This package also includes the Arimo, Cousine, and Tinos fonts.
+      '';
+      license = licenses.asl20;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ mathnerd314 ];
+    };
+  };
+  # 89MB
+  noto-fonts-cjk = let version = "1.004"; in stdenv.mkDerivation {
+    name = "noto-fonts-cjk-${version}";
+
+    src = fetchurl {
+      # Same as https://noto-website.storage.googleapis.com/pkgs/NotoSansCJK.ttc.zip but versioned & with no extra SIL license file
+      url = "https://raw.githubusercontent.com/googlei18n/noto-cjk/40d9f5b179a59a06b98373c76bdc3e2119e4e6b2/NotoSansCJK.ttc.zip";
+      sha256 = "1vg3si6slvk8cklq6s5c76s84kqjc4wvwzr4ysljzjpgzra2rfn6";
+    };
+
+    buildInputs = [ unzip ];
+
+    phases = "unpackPhase installPhase";
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      mkdir -p $out/share/fonts/noto
+      cp *.ttc $out/share/fonts/noto
+    '';
+
+    preferLocalBuild = true;
+
+    meta = with stdenv.lib; {
+      inherit version;
+      description = "Beautiful and free fonts for CJK languages";
+      homepage = https://www.google.com/get/noto/help/cjk/;
+      longDescription =
+      ''
+        Noto Sans CJK is a sans serif typeface designed as an intermediate style
+        between the modern and traditional. It is intended to be a multi-purpose
+        digital font for user interface designs, digital content, reading on laptops,
+        mobile devices, and electronic books. Noto Sans CJK comprehensively covers
+        Simplified Chinese, Traditional Chinese, Japanese, and Korean in a unified font
+        family. It supports regional variants of ideographic characters for each of the
+        four languages. In addition, it supports Japanese kana, vertical forms, and
+        variant characters (itaiji); it supports Korean hangeul — both contemporary and
+        archaic.
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ mathnerd314 ];
+    };
+  };
+  # 12MB
+  noto-fonts-emoji = let version = "git-2015-08-17"; in stdenv.mkDerivation {
+    name = "noto-fonts-emoji-${version}";
+
+    src = fetchFromGitHub {
+      owner = "googlei18n";
+      repo = "noto-emoji";
+      rev = "ffd7cfd0c84b7bf37210d0908ac94adfe3259ff2";
+      sha256 = "1pa94gw2y0b6p8r81zbjzcjgi5nrx4dqrqr6mk98wj6jbi465sh2";
+    };
+
+    buildInputs = [ optipng cairo fontforge pythonPackages.nototools pythonPackages.fonttools pkgconfig ];
+
+    preBuild = ''
+      export PYTHONPATH=$PYTHONPATH:$PWD
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/fonts/noto
+      cp NotoColorEmoji.ttf NotoEmoji-Regular.ttf $out/share/fonts/noto
+    '';
+
+    meta = with stdenv.lib; {
+      inherit version;
+      description = "Color and Black-and-White emoji fonts";
+      homepage = https://github.com/googlei18n/noto-emoji;
+      license = licenses.asl20;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ mathnerd314 ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10439,6 +10439,9 @@ let
 
   nafees = callPackage ../data/fonts/nafees { };
 
+  inherit (callPackages ../data/fonts/noto-fonts {})
+    noto-fonts noto-fonts-cjk noto-fonts-emoji;
+
   numix-icon-theme = callPackage ../data/icons/numix-icon-theme { };
 
   numix-icon-theme-circle = callPackage ../data/icons/numix-icon-theme-circle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8248,6 +8248,29 @@ let
     };
   };
 
+  nototools = buildPythonPackage rec {
+    version = "git-2015-09-16";
+    name = "nototools-${version}";
+    disabled = isPy3k;
+
+    pythonPath = with self; [ fonttools numpy ];
+
+    postPatch = ''
+      sed -ie "s^join(_DATA_DIR_PATH,^join(\"$out/third_party/ucd\",^" nototools/unicode_data.py
+    '';
+
+    postInstall = ''
+      cp -r third_party $out
+    '';
+
+    src = pkgs.fetchFromGitHub {
+      owner = "googlei18n";
+      repo = "nototools";
+      rev = "5a79bee819941849da7b414447929fc7ba6c2c08";
+      sha256 = "0srrmyrjgksk4c6smgi1flyq325r4ma8r6bpkvbn731q3yykhmaa";
+    };
+  };
+
   rainbowstream = buildPythonPackage rec {
     name = "rainbowstream-${version}";
     version = "1.2.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6231,13 +6231,12 @@ let
   });
 
   fonttools = buildPythonPackage (rec {
-    version = "2.4";
+    version = "3.0";
     name = "fonttools-${version}";
-    disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/FontTools/FontTools-${version}.tar.gz";
-      sha256 = "13ggkzcj34kcca6bsxjkaqsxkp2bvxxf6ijiyhq1xlyb0z37z4qa";
+      url = "https://pypi.python.org/packages/source/F/FontTools/fonttools-${version}.tar.gz";
+      sha256 = "0f4iblpbf3y3ghajiccvdwk2f46cim6dsj6fq1kkrbqfv05dr4nz";
     };
 
     buildInputs = with self; [
@@ -6245,7 +6244,7 @@ let
     ];
 
     meta = {
-      homepage = "http://sourceforge.net/projects/fonttools/";
+      homepage = "https://github.com/behdad/fonttools";
       description = "Font file processing tools";
     };
   });


### PR DESCRIPTION
Fedora has these split up into 100 packages; I don't think they're worth that much effort.

The CJK font is the super-TTC (one file with 36 fonts).
