### PR TITLE
picocom: 1.8 -> 2.0

### DIFF
--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "picocom-${version}";
-  version = "1.8";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "npat-efault";
     repo = "picocom";
     rev = version;
-    sha256 = "1954hnmnnr9yj5skynj2x5wjap8vlr4ski2rhwr36p5pzwmr9gni";
+    sha256 = "0s990jiqlbcg3isvhr3bn4sb7b0k6qqbf1jdvs1fyy9h0iiwprjw";
   };
 
   buildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/man/man8
+    mkdir -p $out/bin $out/share/man/man1
     cp picocom $out/bin
-    cp picocom.8 $out/share/man/man8
+    cp picocom.1 $out/share/man/man1
 
     wrapProgram $out/bin/picocom \
       --prefix PATH ":" "${lrzsz}/bin"
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Minimal dumb-terminal emulation program";
-    homepage = http://code.google.com/p/picocom/;
+    homepage = https://github.com/npat-efault/picocom/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.gnu;  # arbitrary choice
   };


### PR DESCRIPTION
- Upstream changed manpage filename
- Home page no longer at Google Code

Tested with a USB serial adapter connected to an ARM board.
