### PR TITLE
broadcom-sta: fix build on kernel >= 4.2

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/linux-recent.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-recent.patch
@@ -79,7 +79,19 @@
  
  	if (unlikely(!cbss))
  		return -ENOMEM;
-@@ -2071,7 +2096,26 @@
+@@ -2047,7 +2072,11 @@
+ 		}
+ 		else if ((event == WLC_E_LINK && ~(flags & WLC_EVENT_MSG_LINK)) ||
+ 			event == WLC_E_DEAUTH_IND || event == WLC_E_DISASSOC_IND) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
++			cfg80211_disconnected(ndev, 0, NULL, 0, false, GFP_KERNEL);
++#else
+ 			cfg80211_disconnected(ndev, 0, NULL, 0, GFP_KERNEL);
++#endif
+ 			clear_bit(WL_STATUS_CONNECTED, &wl->status);
+ 			wl_link_down(wl);
+ 			wl_init_prof(wl->profile);
+@@ -2071,7 +2100,26 @@
  			wl_get_assoc_ies(wl);
  			memcpy(&wl->bssid, &e->addr, ETHER_ADDR_LEN);
  			wl_update_bss_info(wl);
@@ -106,7 +118,7 @@
  			set_bit(WL_STATUS_CONNECTED, &wl->status);
  			wl->profile->active = true;
  		}
-@@ -2629,7 +2673,15 @@
+@@ -2629,7 +2677,15 @@
  
  void wl_cfg80211_detach(struct net_device *ndev)
  {

--- a/pkgs/os-specific/linux/kernel/flush_workqueue-export.patch
+++ b/pkgs/os-specific/linux/kernel/flush_workqueue-export.patch
@@ -1,0 +1,13 @@
+diff --git a/kernel/workqueue.c b/kernel/workqueue.c
+index 4c4f061..a413acb 100644
+--- a/kernel/workqueue.c
++++ b/kernel/workqueue.c
+@@ -2614,7 +2614,7 @@ void flush_workqueue(struct workqueue_struct *wq)
+ out_unlock:
+ 	mutex_unlock(&wq->mutex);
+ }
+-EXPORT_SYMBOL_GPL(flush_workqueue);
++EXPORT_SYMBOL(flush_workqueue);
+ 
+ /**
+  * drain_workqueue - drain a workqueue

--- a/pkgs/os-specific/linux/kernel/linux-4.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.2.nix
@@ -15,4 +15,12 @@ import ./generic.nix (args // rec {
   features.needsCifsUtils = true;
   features.canDisableNetfilterConntrackHelpers = true;
   features.netfilterRPFilter = true;
+
+  # cherry-pick from upstream to resolve a licensing problem that prevents
+  # compiling the broadcom-sta wireless driver on kernels >= 4.2
+  # see: https://github.com/longsleep/bcmwl-ubuntu/issues/6
+  kernelPatches = [ {
+    name = "flush-workqueue-export";
+    patch = ./flush_workqueue-export.patch;
+  } ];
 } // (args.argsOverride or {}))


### PR DESCRIPTION
Also cherry-pick a licensing fix from torvalds/linux@7d3e2eb1786
necessary for building broadcom-sta on kernel 4.2.

For more details, see:
https://github.com/longsleep/bcmwl-ubuntu/issues/6

Closes #9948
