### PR TITLE
zimreader: init at 20150710.

### DIFF
--- a/pkgs/tools/text/zimreader/default.nix
+++ b/pkgs/tools/text/zimreader/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchgit, fetchurl, automake, autoconf, libtool
+, zlib, openssl, zip, zimlib
+}:
+
+let
+  cxxtools = stdenv.mkDerivation rec {
+    name = "cxxtools-${version}";
+    version = "2.1.1";
+    src = fetchurl {
+      url = "http://www.tntnet.org/download/cxxtools-${version}.tar.gz";
+      sha256 = "0jh5wrk9mviz4xrp1wv617gwgl4b5mc21h21wr2688kjmc0i1q4d";
+    };
+  };
+  tntnet = stdenv.mkDerivation rec {
+    name = "tntnet-${version}";
+    version = "2.1";
+    src = fetchurl {
+      url = "http://www.tntnet.org/download/tntnet-${version}.tar.gz";
+      sha256 = "1dhs10yhpmdqyykyh8jc67m5xgsgm1wrpd58fdps2cp5g1gjf8w6";
+    };
+    buildInputs = [ zlib cxxtools openssl zip ];
+  };
+
+in stdenv.mkDerivation rec {
+  name = "zimreader-${version}";
+  version = "20150710";
+
+  src = fetchgit {
+    url = https://gerrit.wikimedia.org/r/p/openzim.git;
+    rev = "165eab3e154c60b5b6436d653dc7c90f56cf7456";
+    sha256 = "0x0d3rx6zcc8k66nqkacmwdvslrz70h9bliqawzv90ribq3alb0q";
+  };
+
+  buildInputs = [ automake autoconf libtool zimlib cxxtools tntnet ];
+  setSourceRoot = "cd openzim-*/zimreader; export sourceRoot=`pwd`";
+  preConfigurePhases = [ "./autogen.sh" ];
+
+  meta = {
+    description = "A tool to serve ZIM files using HTTP";
+    homepage = http://git.wikimedia.org/log/openzim;
+    maintainers = with stdenv.lib.maintainers; [ robbinch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3570,6 +3570,8 @@ let
   zinnia = callPackage ../tools/inputmethods/zinnia { };
   tegaki-zinnia-japanese = callPackage ../tools/inputmethods/tegaki-zinnia-japanese { };
 
+  zimreader = callPackage ../tools/text/zimreader { };
+
   zimwriterfs = callPackage ../tools/text/zimwriterfs { };
 
   zip = callPackage ../tools/archivers/zip { };


### PR DESCRIPTION
This adds zimreader, a tool to serve ZIM files using HTTP.

Its dependencies, cxxtools and tntnet are included in this derivation
because zimreader needs specific (not latest) versions of them
to compile.
