### PR TITLE
opensmtpd: 5.4.5p1 -> 5.7.1p1

### DIFF
--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -46,6 +46,17 @@ in {
           is left empty, the OpenSMTPD server will not start.
         '';
       };
+
+      procPackages = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          Packages to search for filters, tables, queues, and schedulers.
+
+          Add OpenSMTPD-extras here if you want to use the filters, etc. from
+          that package.
+        '';
+      };
     };
 
   };
@@ -72,12 +83,19 @@ in {
       };
     };
 
-    systemd.services.opensmtpd = {
+    systemd.services.opensmtpd = let
+      procEnv = pkgs.buildEnv {
+        name = "opensmtpd-procs";
+        paths = [ opensmtpd ] ++ cfg.procPackages;
+        pathsToLink = [ "/libexec/opensmtpd" ];
+      };
+    in {
       wantedBy = [ "multi-user.target" ];
       wants = [ "network.target" ];
       after = [ "network.target" ];
       preStart = "mkdir -p /var/spool";
       serviceConfig.ExecStart = "${opensmtpd}/sbin/smtpd -d -f ${conf} ${args}";
+      environment.OPENSMTPD_PROC_PATH = "${procEnv}/libexec/opensmtpd";
     };
 
     environment.systemPackages = [ (pkgs.runCommand "opensmtpd-sendmail" {} ''

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   name = "opensmtpd-${version}";
-  version = "5.4.5p1";
+  version = "5.7.1p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib openssl db pam ];
 
   src = fetchurl {
     url = "http://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "15sicrpqsgg72igdckkwpmbgrapcjbfjsdrvm0zl8z13kgp6r4ks";
+    sha256 = "67e9dd9682ca8c181e84e66c76245a4a8f6205834f915a2c021cdfeb22049e3a";
   };
 
   configureFlags = [
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     "--with-privsep-user=smtpd"
     "--with-queue-user=smtpq"
     "--with-ca-file=/etc/ssl/certs/ca-certificates.crt"
+    "--with-libevent-dir=${libevent}"
   ];
 
   installFlags = [

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "67e9dd9682ca8c181e84e66c76245a4a8f6205834f915a2c021cdfeb22049e3a";
   };
 
+  patches = [ ./proc_path.diff ];
+
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"

--- a/pkgs/servers/mail/opensmtpd/extras.nix
+++ b/pkgs/servers/mail/opensmtpd/extras.nix
@@ -1,0 +1,79 @@
+{ stdenv, fetchurl, openssl, libevent, libasr,
+  python2, pkgconfig, lua5, perl, mariadb, postgresql, sqlite, hiredis }:
+stdenv.mkDerivation rec {
+  name = "opensmtpd-extras-${version}";
+  version = "5.7.1";
+
+  src = fetchurl {
+    url = "https://www.opensmtpd.org/archives/${name}.tar.gz";
+    sha256 = "1kld4hxgz792s0cb2gl7m2n618ikzqkj88w5dhaxdrxg4x2c4vdm";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl libevent
+    libasr python2 lua5 perl mariadb postgresql sqlite hiredis ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-privsep-user=smtpd"
+    "--with-libevent-dir=${libevent}"
+
+    "--with-filter-clamav"
+    "--with-filter-dkim-signer"
+    "--with-filter-dnsbl"
+    "--with-filter-monkey"
+    "--with-filter-pause"
+    "--with-filter-regex"
+    "--with-filter-spamassassin"
+    "--with-filter-stub"
+    "--with-filter-trace"
+    "--with-filter-void"
+    "--with-queue-null"
+    "--with-queue-ram"
+    "--with-queue-stub"
+    "--with-table-ldap"
+    "--with-table-socketmap"
+    "--with-table-passwd"
+    "--with-table-stub"
+    "--with-scheduler-ram"
+    "--with-scheduler-stub"
+
+  ] ++ stdenv.lib.optional (python2 != null) [
+    "--with-python=${python2}"
+    "--with-filter-python"
+    "--with-queue-python"
+    "--with-table-python"
+    "--with-scheduler-python"
+
+  ] ++ stdenv.lib.optional (lua5 != null) [
+    "--with-lua=${pkgconfig}"
+    "--with-filter-lua"
+
+  ] ++ stdenv.lib.optional (perl != null) [
+    "--with-perl=${perl}"
+    "--with-filter-perl"
+
+  ] ++ stdenv.lib.optional (mariadb != null) [
+    "--with-table-mysql"
+
+  ] ++ stdenv.lib.optional (postgresql != null) [
+    "--with-table-postgres"
+
+  ] ++ stdenv.lib.optional (sqlite != null) [
+    "--with-table-sqlite"
+
+  ] ++ stdenv.lib.optional (hiredis != null) [
+    "--with-table-redis"
+  ];
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional (hiredis != null) [ "-I${hiredis}/include/hiredis" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://www.opensmtpd.org/;
+    description = "Extra plugins for the OpenSMTPD mail server";
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/servers/mail/opensmtpd/proc_path.diff
+++ b/pkgs/servers/mail/opensmtpd/proc_path.diff
@@ -1,0 +1,76 @@
+diff -Naur opensmtpd-5.7.1p1/smtpd/parse.y opensmtpd-5.7.1p1.patched/smtpd/parse.y
+--- opensmtpd-5.7.1p1/smtpd/parse.y	2015-06-30 10:13:34.000000000 +0200
++++ opensmtpd-5.7.1p1.patched/smtpd/parse.y	2015-09-26 08:41:17.012472516 +0200
+@@ -2519,13 +2519,19 @@
+ {
+ 	struct filter_conf	*f;
+ 	char			*path;
++        const char              *proc_path;
+ 
+ 	if (dict_get(&conf->sc_filters, name)) {
+ 		yyerror("filter \"%s\" already defined", name);
+ 		return (NULL);
+ 	}
+ 
+-	if (asprintf(&path, "%s/filter-%s", PATH_LIBEXEC, prog) == -1) {
++        proc_path = getenv("OPENSMTPD_PROC_PATH");
++        if (proc_path == NULL) {
++                proc_path = PATH_LIBEXEC;
++        }
++
++	if (asprintf(&path, "%s/filter-%s", proc_path, prog) == -1) {
+ 		yyerror("filter \"%s\" asprintf failed", name);
+ 		return (0);
+ 	}
+diff -Naur opensmtpd-5.7.1p1/smtpd/smtpd.c opensmtpd-5.7.1p1.patched/smtpd/smtpd.c
+--- opensmtpd-5.7.1p1/smtpd/smtpd.c	2015-06-30 10:13:34.000000000 +0200
++++ opensmtpd-5.7.1p1.patched/smtpd/smtpd.c	2015-09-26 08:41:16.998472557 +0200
+@@ -854,6 +854,7 @@
+ 	char		path[PATH_MAX];
+ 	char		name[PATH_MAX];
+ 	char		*arg;
++        char            *proc_path;
+ 
+ 	if (strlcpy(name, conf, sizeof(name)) >= sizeof(name)) {
+ 		log_warnx("warn: %s-proc: conf too long", key);
+@@ -864,7 +865,12 @@
+ 	if (arg)
+ 		*arg++ = '\0';
+ 
+-	if (snprintf(path, sizeof(path), PATH_LIBEXEC "/%s-%s", key, name) >=
++        proc_path = getenv("OPENSMTPD_PROC_PATH");
++        if (proc_path == NULL) {
++                proc_path = PATH_LIBEXEC;
++        }
++
++	if (snprintf(path, sizeof(path), "%s/%s-%s", proc_path, key, name) >=
+ 	    (ssize_t)sizeof(path)) {
+ 		log_warn("warn: %s-proc: exec path too long", key);
+ 		return (-1);
+diff -Naur opensmtpd-5.7.1p1/smtpd/table.c opensmtpd-5.7.1p1.patched/smtpd/table.c
+--- opensmtpd-5.7.1p1/smtpd/table.c	2015-06-30 10:13:34.000000000 +0200
++++ opensmtpd-5.7.1p1.patched/smtpd/table.c	2015-09-26 08:41:17.005472536 +0200
+@@ -201,6 +201,7 @@
+ 	struct table_backend	*tb;
+ 	char			 buf[LINE_MAX];
+ 	char			 path[LINE_MAX];
++        const char              *proc_path;
+ 	size_t			 n;
+ 	struct stat		 sb;
+ 
+@@ -215,8 +216,14 @@
+ 	if (name && table_find(name, NULL))
+ 		fatalx("table_create: table \"%s\" already defined", name);
+ 
++        proc_path = getenv("OPENSMTPD_PROC_PATH");
++        if (proc_path == NULL) {
++                proc_path = PATH_LIBEXEC;
++        }
++
+ 	if ((tb = table_backend_lookup(backend)) == NULL) {
+-		if ((size_t)snprintf(path, sizeof(path), PATH_LIBEXEC "/table-%s",
++		if ((size_t)snprintf(path, sizeof(path), "%s/table-%s",
++                    proc_path,
+ 		    backend) >= sizeof(path)) {
+ 			fatalx("table_create: path too long \""
+ 			    PATH_LIBEXEC "/table-%s\"", backend);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9067,6 +9067,7 @@ let
   openresty = callPackage ../servers/http/openresty { };
 
   opensmtpd = callPackage ../servers/mail/opensmtpd { };
+  opensmtpd-extras = callPackage ../servers/mail/opensmtpd/extras.nix { };
 
   openxpki = callPackage ../servers/openxpki { };
 


### PR DESCRIPTION
OpenSMTPD now supports external filters, which are distributed in a separate `opensmtpd-extras` package, and usually installed as binaries in `/usr/libexec/opensmtpd/filter-*`.  However they don't work with our package yet since [OpenSMTPD looks for them in `/nix/store/*-opensmtpd-5.7.1p1/libexec/opensmtpd/`](https://github.com/OpenSMTPD/OpenSMTPD/blob/master/smtpd/parse.y#L2532), where you can't install them:

```
    if (asprintf(&path, "%s/filter-%s", PATH_LIBEXEC, prog) == -1) {
```

Any ideas on how to fix that?  Look in `/run/current-system/sw/libexec`?  Add an environment variable?
