### PR TITLE
Fix Google Music Manager

### DIFF
--- a/pkgs/applications/audio/google-musicmanager/default.nix
+++ b/pkgs/applications/audio/google-musicmanager/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, readline, patchelf, ncurses, qt48, libidn, expat, flac
 , libvorbis }:
 
-assert stdenv.system == "x86_64-linux" || stdenv.system == "1686-linux";
+assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
 let
   archUrl = name: arch: "http://dl.google.com/linux/musicmanager/deb/pool/main/g/google-musicmanager-beta/${name}_${arch}.deb";
 in
 stdenv.mkDerivation rec {
-  version = "beta_1.0.182.3607-r0"; # friendly to nix-env version sorting algo
+  version = "beta_1.0.221.5230-r0"; # friendly to nix-env version sorting algo
   product = "google-musicmanager";
   name    = "${product}-${version}";
 
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
   src = if stdenv.system == "x86_64-linux"
     then fetchurl {
       url    = archUrl name "amd64";
-      sha256 = "141x986haxg3r72ggh8prz0qg298jkad1ys8sdvsac92p4adcqx4";
+      sha256 = "1h0ssbz6y9xi2szalgb5wcxi8m1ylg4qf2za6zgvi908hpan7q37";
     }
     else fetchurl {
         url    = archUrl name "i386";
-        sha256 = "076iaa7pxhj8b1hlg5ah9jfm4qgzgjc9ivvg2l18wp045gnycv1l";
+        sha256 = "0q8cnzx7s25bpqlbp40d43mwd6m8kvhvdifkqlgc9phpydnqpd1i";
     };
 
   unpackPhase = ''


### PR DESCRIPTION
The previous version was 404

Also fixes i686 typo
