### PR TITLE
handbrake: 0.9.9 -> 0.10.2

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -28,7 +28,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.9";
+  version = "0.10.2";
   name = "handbrake-${version}";
 
   # ToDo: doesn't work (yet)


### PR DESCRIPTION
The changelog is quite extensive, for more information please find the
changes documented here:
https://github.com/HandBrake/HandBrake/blob/master/NEWS

Built and run successfully on local.
