### PR TITLE
profanity: 0.4.6 -> 0.4.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat
-, ncurses, libotr, curl, libstrophe
+, ncurses, libotr, curl, libstrophe, readline, libuuid
 
 , autoAwaySupport ? false, libXScrnSaver ? null, libX11 ? null
 , notifySupport ? false,   libnotify ? null, gdk_pixbuf ? null
@@ -12,15 +12,15 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "profanity-${version}";
-  version = "0.4.6";
+  version = "0.4.7";
 
   src = fetchurl {
     url = "http://www.profanity.im/profanity-${version}.tar.gz";
-    sha256 = "17ra53c1m0w0lzm5bj63y1ysx8bv119z5h0csisxsn4r85z6cwln";
+    sha256 = "1p8ixvxacvf63r6lnf6iwlyz4pgiyp6widna1h2l2jg8kw14wb5h";
   };
 
   buildInputs = [
-    automake autoconf pkgconfig
+    automake autoconf pkgconfig readline libuuid
     glib openssl expat ncurses libotr curl libstrophe
   ] ++ optionals autoAwaySupport [ libXScrnSaver libX11 ]
     ++ optionals notifySupport   [ libnotify gdk_pixbuf ];


### PR DESCRIPTION
Built and run successfully on local.

From the Changelog:

```
- GNU Readline
- OpenPGP support
- Message Carbons (xep-0280)
- Message Delivery Receipts (xep-0184)
- MUC Mediated Invitation support
- Configurable time formatting
- Option to show JIDs in roster
- Option to hide empty groups in roster
- Generate UUID for unnamed new MUC rooms
- Themable UI preference to indicate OTR and PGP messages
- Reformatted help
- devel: Added functional tests using libexpect and libstabber
```
