### PR TITLE
kernel: enable support for brcmfmac driver

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -119,6 +119,11 @@ with stdenv.lib;
     B43_PHY_HT? y
   ''}
   BCMA_HOST_PCI? y
+  ${if versionAtLeast version "3.17" then ''
+    BRCMFMAC_SDIO y
+    BRCMFMAC_USB y
+    BRCMFMAC_PCIE y
+  ''}
 
   # Enable various FB devices.
   FB y


### PR DESCRIPTION
This enables a couple options necessary for the brcmfmac wireless
driver.

With this commit, wireless will work on mid-2015 MacBook Pros with the
default kernel configuration in NixOS.

For more details about this driver, see:
https://wireless.wiki.kernel.org/en/users/Drivers/brcm80211#brcmfmac

Fixes #9948
