### PR TITLE
nixos-generate-config: detect brcmfmac requirement

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -152,6 +152,23 @@ sub pciCheck {
         push @kernelModules, "wl";
      }
 
+    # broadcom FullMac driver
+    # list taken from
+    # https://wireless.wiki.kernel.org/en/users/Drivers/brcm80211#brcmfmac
+    if ($vendor eq "0x14e4" &&
+        ($device eq "0x43a3" || $device eq "0x43df" || $device eq "0x43ec" ||
+         $device eq "0x43d3" || $device eq "0x43d9" || $device eq "0x43e9" ||
+         $device eq "0x43ba" || $device eq "0x43bb" || $device eq "0x43bc" ||
+         $device eq "0xaa52" || $device eq "0x43ca" || $device eq "0x43cb" ||
+         $device eq "0x43cc" || $device eq "0x43c3" || $device eq "0x43c4" ||
+         $device eq "0x43c5"
+        ) )
+    {
+        push @kernelModules, "brcmfmac";
+        # we need e.g. brcmfmac43602-pcie.bin
+        push @imports, "<nixos/modules/hardware/network/broadcom-43xx.nix>";
+    }
+
     # Can't rely on $module here, since the module may not be loaded
     # due to missing firmware.  Ideally we would check modules.pcimap
     # here.


### PR DESCRIPTION
This makes `nixos-generate-config` list the `brcmfmac` wireless module
in `kernelModules` when necessary.

See #9948
