### PR TITLE
ctpp2: init at 2.8.3.

### DIFF
--- a/pkgs/development/libraries/ctpp2/default.nix
+++ b/pkgs/development/libraries/ctpp2/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, gcc48 }:
+
+stdenv.mkDerivation rec {
+  name = "ctpp2";
+  version = "2.8.3";
+
+  src = fetchurl {
+    url = "http://ctpp.havoc.ru/download/ctpp2-${version}.tar.gz";
+    sha256 = "1z22zfw9lb86z4hcan9hlvji49c9b7vznh7gjm95gnvsh43zsgx8";
+  };
+
+  buildInputs = [ cmake gcc48 ];
+
+  patchPhase = ''
+    # include <unistd.h> to fix undefined getcwd
+    sed -ie 's/<stdlib.h>/<stdlib.h>\n#include <unistd.h>/' src/CTPP2FileSourceLoader.cpp
+  '';
+
+  meta = {
+    description = "A high performance templating engine";
+    homepage = http://ctpp.havoc.ru;
+    maintiainers = with stdenv.lib.maintainers; [ robbinch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6022,6 +6022,8 @@ let
 
   ctl = callPackage ../development/libraries/ctl { };
 
+  ctpp2 = callPackage ../development/libraries/ctpp2 { };
+
   cpp-netlib = callPackage ../development/libraries/cpp-netlib { };
 
   cppunit = callPackage ../development/libraries/cppunit { };


### PR DESCRIPTION
This adds ctpp2, a high performance templating engine.
