### PR TITLE
metis: init at 2.3

### DIFF
--- a/pkgs/applications/science/logic/metis-prover/default.nix
+++ b/pkgs/applications/science/logic/metis-prover/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, perl, mlton }:
+
+stdenv.mkDerivation rec {
+  name = "metis-prover-${version}";
+  version = "2.3";
+
+  src = fetchurl {
+    url = "http://www.gilith.com/software/metis/metis.tar.gz";
+    sha256 = "07wqhic66i5ip2j194x6pswwrxyxrimpc4vg0haa5aqv9pfpmxad";
+  };
+
+  nativeBuildInputs = [ perl ];
+  buildInputs = [ mlton ];
+
+  patchPhase = "patchShebangs scripts/mlpp";
+
+  buildPhase = "make mlton";
+
+  installPhase = ''
+    install -Dm0755 bin/mlton/metis $out/bin/metis
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Automatic theorem prover for first-order logic with equality";
+    homepage = http://www.gilith.com/research/metis/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14345,6 +14345,8 @@ let
             ocaml_mysql ocamlnet ulex08 camlzip ocaml_pcre;
   });
 
+  metis-prover = callPackage ../applications/science/logic/metis-prover { };
+
   minisat = callPackage ../applications/science/logic/minisat {};
 
   opensmt = callPackage ../applications/science/logic/opensmt { };


### PR DESCRIPTION
Unfortunately this metis theorem prover has the same name as the metis graph partioning library (packaged in `pkgs/development/libraries/science/math/metis`).  So I've used the `metisProver` attribute name here instead of just `metis`.

Should I also change the package name so that `nix-env` doesn't get confused?
