### PR TITLE
inconsolata-lgc:  init at 30bbc1b

### DIFF
--- a/pkgs/data/fonts/aurulent-sans/default.nix
+++ b/pkgs/data/fonts/aurulent-sans/default.nix
@@ -2,17 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "aurulent-sans-0.1";
+
   src = fetchgit {
     url = "https://github.com/deepfire/hartke-aurulent-sans.git";
     rev = "refs/tags/${name}";
     sha256 = "01hvpvbrks40g9k1xr2f1gxnd5wd0sxidgfbwrm94pdi1a36xxrk";
   };
+
   buildPhase = "true";
-  installPhase = "
+
+  installPhase = ''
     fontDir=$out/share/fonts/opentype
     mkdir -p $fontDir
     cp *.otf $fontDir
-  ";
+  '';
+
   meta = {
     description = "Aurulent Sans";
     longDescription = "Aurulent Sans is a humanist sans serif intended to be used as an interface font.";

--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/dejavu/dejavu-fonts-${version}.tar.bz2";
     sha256 = "1xdbi4llrq1qbkd73352ibrfqcbz93dww8hab216qz5szd95yvv4";
   };
+
   buildFlags = "full-ttf";
+
   preBuild = ''
     sed -e s@/usr/bin/env@$(type -tP env)@ -i scripts/*
     sed -e s@/usr/bin/perl@$(type -tP perl)@ -i scripts/*
@@ -30,6 +32,7 @@ stdenv.mkDerivation rec {
     ln -s ${unicodeData} resources/UnicodeData.txt
     ln -s ${blocks} resources/Blocks.txt
   '';
+
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
     for i in $(find build -name '*.ttf'); do

--- a/pkgs/data/fonts/font-awesome-ttf/default.nix
+++ b/pkgs/data/fonts/font-awesome-ttf/default.nix
@@ -16,15 +16,12 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Font Awesome - TTF font";
-
     longDescription = ''
       Font Awesome gives you scalable vector icons that can instantly be customized.
       This package includes only the TTF font. For full CSS etc. see the project website.
     '';
-
     homepage = "http://fortawesome.github.io/Font-Awesome/";
     license = stdenv.lib.licenses.ofl;
-
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.abaldeau ];
   };

--- a/pkgs/data/fonts/fontWrap/default.nix
+++ b/pkgs/data/fonts/fontWrap/default.nix
@@ -1,31 +1,31 @@
 args @ { fetchurl, stdenv, builderDefs, paths, mkfontdir, mkfontscale }:
 with args;
-	let localDefs = builderDefs.passthru.function {
-		src =""; /* put a fetchurl here */
-		buildInputs = [mkfontdir mkfontscale];
-		configureFlags = [];
-	};
-	in with localDefs;
+  let localDefs = builderDefs.passthru.function {
+    src =""; /* put a fetchurl here */
+    buildInputs = [mkfontdir mkfontscale];
+    configureFlags = [];
+  };
+  in with localDefs;
 let
-	doInstall = fullDepEntry ("
-		mkdir -p \$out/share/fonts/
-		cd \$out/share/fonts
-		for i in ${toString paths}; do
-			find \$i -type f -exec ln -s '{}' . ';' ;
-		done
-		mkfontdir 
-		mkfontscale
-	") [minInit addInputs defEnsureDir] ;
+  doInstall = fullDepEntry ("
+    mkdir -p \$out/share/fonts/
+    cd \$out/share/fonts
+    for i in ${toString paths}; do
+      find \$i -type f -exec ln -s '{}' . ';' ;
+    done
+    mkfontdir 
+    mkfontscale
+  ") [minInit addInputs defEnsureDir] ;
 in
 stdenv.mkDerivation rec {
-	name = "wrapped-font-dir";
-	builder = writeScript (name + "-builder")
-		(textClosure localDefs [ doInstall doForceShare doPropagate]);
+  name = "wrapped-font-dir";
+  builder = writeScript (name + "-builder")
+    (textClosure localDefs [ doInstall doForceShare doPropagate]);
   preferLocalBuild = true;
-	meta = {
-		description = "
-		Just a wrapper to create fonts.dir and fonts.scale .
+  meta = {
+    description = "
+    Just a wrapper to create fonts.dir and fonts.scale .
 ";
-		inherit src;
-	};
+    inherit src;
+  };
 }

--- a/pkgs/data/fonts/freefont-ttf/default.nix
+++ b/pkgs/data/fonts/freefont-ttf/default.nix
@@ -17,17 +17,14 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU Free UCS Outline Fonts";
-
     longDescription = ''
       The GNU Freefont project aims to provide a set of free outline
       (PostScript Type0, TrueType, OpenType...) fonts covering the ISO
       10646/Unicode UCS (Universal Character Set).
     '';
-
     homepage = http://www.gnu.org/software/freefont/;
     license = stdenv.lib.licenses.gpl3Plus;
-
     platforms = stdenv.lib.platforms.all;
-    maintainers = [ ];
+    maintainers = [];
   };
 }

--- a/pkgs/data/fonts/gyre/default.nix
+++ b/pkgs/data/fonts/gyre/default.nix
@@ -21,17 +21,15 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "OpenType fonts from the Gyre project, suitable for use with (La)TeX";
-
-    longDescription = ''The Gyre project started in 2006, and will
-    eventually include enhanced releases of all 35 freely available
-    PostScript fonts distributed with Ghostscript v4.00.  These are
-    being converted to OpenType and extended with diacritical marks
-    covering all modern European languages and then some'';
-
+    longDescription = ''
+      The Gyre project started in 2006, and will
+      eventually include enhanced releases of all 35 freely available
+      PostScript fonts distributed with Ghostscript v4.00.  These are
+      being converted to OpenType and extended with diacritical marks
+      covering all modern European languages and then some
+    '';
     homepage = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/index_html#Readings";
-
     license = stdenv.lib.licenses.lppl13c;
-
     platforms = stdenv.lib.platforms.all;
     maintainers = with stdenv.lib.maintainers; [ bergey ];
   };

--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation {
       the license is available in LICENSE.md" (From the GitHub page)
     */
     license = licenses.free;
-
     platforms = platforms.all;
     maintainers = with maintainers; [ nckx ];
   };

--- a/pkgs/data/fonts/inconsolata/lgc.nix
+++ b/pkgs/data/fonts/inconsolata/lgc.nix
@@ -1,0 +1,59 @@
+{stdenv, fetchFromGitHub, fontforge}:
+
+stdenv.mkDerivation rec {
+  name = "inconsolata-lgc-${version}";
+  version = "git-2015-04-18";
+
+  src = fetchFromGitHub {
+    owner = "MihailJP";
+    repo = "Inconsolata-LGC";
+    rev = "30bbc1bd82502bf76f1cc5553f17388da2ba20e7";
+    sha256 = "02af2gpksdxdp7zfh5qhgfqzc6gvah9v4ph818irwhs9gcq8833c";
+  };
+
+  buildInputs = [ fontforge ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -v $(find . -name '*.ttf') $out/share/fonts/truetype
+
+    mkdir -p $out/share/fonts/opentype
+    cp -v $(find . -name '*.otf') $out/share/fonts/opentype
+
+    mkdir -p "$out/doc/${name}"
+    cp -v AUTHORS ChangeLog COPYING License.txt README "$out/doc/${name}" || true
+  '';
+
+  meta = {
+    description = "Fork of Inconsolata font, with proper support of Cyrillic and Greek";
+    longDescription = ''
+      Inconsolata is one of the most suitable font for programmers created by Raph
+      Levien. Since the original Inconsolata does not contain Cyrillic alphabet,
+      it was slightly inconvenient for not a few programmers from Russia.
+
+      Inconsolata LGC is a modified version of Inconsolata with added the Cyrillic
+      alphabet which directly descends from Inconsolata Hellenic supporting modern
+      Greek.
+
+      Inconsolata LGC is licensed under SIL OFL.
+
+
+      Inconsolata LGC changes:
+      * Cyrillic glyphs added.
+      * Italic and Bold font added.
+
+      Changes inherited from Inconsolata Hellenic:
+      * Greek glyphs.
+
+      Changes inherited from Inconsolata-dz:
+      * Straight quotation marks.
+    '';
+
+    # See `License.txt' for details.
+    license = stdenv.lib.licenses.ofl;
+    homepage = https://github.com/MihailJP/Inconsolata-LGC;
+    maintainers = [
+      stdenv.lib.maintainers.avnik
+    ];
+  };
+}

--- a/pkgs/data/fonts/mph-2b-damase/default.nix
+++ b/pkgs/data/fonts/mph-2b-damase/default.nix
@@ -2,14 +2,18 @@
 
 stdenv.mkDerivation {
   name = "MPH-2B-Damase";
+
   src = fetchurl {
     url = http://www.wazu.jp/downloads/damase_v.2.zip;
     sha256 = "0y7rakbysjjrzcc5y100hkn64j7js434x20pyi6rllnw2w2n1y1h";
   };
+
   buildInputs = [unzip];
+
   unpackPhase = ''
     unzip $src;
   '';
+
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype

--- a/pkgs/data/fonts/nafees/default.nix
+++ b/pkgs/data/fonts/nafees/default.nix
@@ -40,19 +40,18 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "OpenType Urdu font from the Center for Research in Urdu Language Processing";
-
-    longDescription = '' The Nafees font family is developed according
-    to calligraphic rules, following the style of Syed Nafees
-    Al-Hussaini (Nafees Raqam) one of the finest calligraphers of
-    Pakistan '';
-
+    longDescription = ''
+      The Nafees font family is developed according
+      to calligraphic rules, following the style of Syed Nafees
+      Al-Hussaini (Nafees Raqam) one of the finest calligraphers of
+      Pakistan
+    '';
     homepage = "http://www.cle.org.pk/software/localization.htm";
 
     # Used to be GPLv2.  The license distributed with the fonts looks
     # more like a modified BSD, but still contains the GPLv2 embedded
     # font exception, and some not-for-resale language.
     license = "unknown";
-
     platforms = stdenv.lib.platforms.all;
     maintainers = with stdenv.lib.maintainers; [ bergey ];
   };

--- a/pkgs/data/fonts/opensans-ttf/default.nix
+++ b/pkgs/data/fonts/opensans-ttf/default.nix
@@ -19,15 +19,12 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Open Sans fonts";
-
     longDescription = ''
       Open Sans is a humanist sans serif typeface designed by Steve Matteson,
       Type Director of Ascender Corp.
     '';
-
     homepage = "http://en.wikipedia.org/wiki/Open_Sans";
     license = stdenv.lib.licenses.asl20;
-
     platforms = stdenv.lib.platforms.all;
     maintainers = [ ];
   };

--- a/pkgs/data/fonts/poly/default.nix
+++ b/pkgs/data/fonts/poly/default.nix
@@ -30,14 +30,14 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Medium contrast serif font";
     longDescription = ''
-    With short ascenders and a very high x-height, Poly is efficient in small
-    sizes. Thanks to its careful balance between the x-height and glyph widths,
-    it allows more economy and legibility than standard web serifs, even in
-    small sizes. The aglutinative language for which it was designed contains
-    very long words. The goal was to develop a typeface that would tolerate
-    cramped tracking and that would increase the number of letters on a single
-    line. Poly is a Unicode typeface family that supports Open Type features
-    and languages that use the Latin script and its variants.
+      With short ascenders and a very high x-height, Poly is efficient in small
+      sizes. Thanks to its careful balance between the x-height and glyph widths,
+      it allows more economy and legibility than standard web serifs, even in
+      small sizes. The aglutinative language for which it was designed contains
+      very long words. The goal was to develop a typeface that would tolerate
+      cramped tracking and that would increase the number of letters on a single
+      line. Poly is a Unicode typeface family that supports Open Type features
+      and languages that use the Latin script and its variants.
     '';
     homepage = http://www.fontsquirrel.com/fonts/poly;
     license = stdenv.lib.licenses.ofl;

--- a/pkgs/data/fonts/redhat-liberation-fonts/binary.nix
+++ b/pkgs/data/fonts/redhat-liberation-fonts/binary.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Liberation Fonts, replacements for Times New Roman, Arial, and Courier New";
-
     longDescription = ''
       The Liberation Fonts are intended to be replacements for the three most
       commonly used fonts on Microsoft systems: Times New Roman, Arial, and
@@ -38,9 +37,7 @@ stdenv.mkDerivation rec {
 
     # See `License.txt' for details.
     license = stdenv.lib.licenses.gpl2Oss;
-
     homepage = https://fedorahosted.org/liberation-fonts/;
-
     maintainers = [
       stdenv.lib.maintainers.raskin
     ];

--- a/pkgs/data/fonts/redhat-liberation-fonts/default.nix
+++ b/pkgs/data/fonts/redhat-liberation-fonts/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Liberation Fonts, replacements for Times New Roman, Arial, and Courier New";
-
     longDescription = ''
       The Liberation Fonts are intended to be replacements for the three most
       commonly used fonts on Microsoft systems: Times New Roman, Arial, and
@@ -40,9 +39,7 @@ stdenv.mkDerivation rec {
 
     # See `License.txt' for details.
     license = stdenv.lib.licenses.gpl2Oss;
-
     homepage = https://fedorahosted.org/liberation-fonts/;
-
     maintainers = [
       stdenv.lib.maintainers.raskin
     ];

--- a/pkgs/data/fonts/ttf-bitstream-vera/default.nix
+++ b/pkgs/data/fonts/ttf-bitstream-vera/default.nix
@@ -2,11 +2,14 @@
 
 stdenv.mkDerivation {
   name = "ttf-bitstream-vera-1.10";
+
   src = fetchurl {
     url = mirror://gnome/sources/ttf-bitstream-vera/1.10/ttf-bitstream-vera-1.10.tar.bz2;
     sha256 = "1p3qs51x5327gnk71yq8cvmxc6wgx79sqxfvxcv80cdvgggjfnyv";
   };
+
   buildPhase = "true";
+
   installPhase = "
     fontDir=$out/share/fonts/truetype
     mkdir -p $fontDir

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10400,6 +10400,7 @@ let
   hicolor_icon_theme = callPackage ../data/icons/hicolor-icon-theme { };
 
   inconsolata = callPackage ../data/fonts/inconsolata {};
+  inconsolata-lgc = callPackage ../data/fonts/inconsolata/lgc.nix {};
 
   ipafont = callPackage ../data/fonts/ipafont {};
 


### PR DESCRIPTION
Add Inconsolata-LGC, fork of Inconsolata font with improved Cyrillic
and Greek support.
