### PR TITLE
encrypted-devices service: Fix keyed mount, clarify descriptions.

### DIFF
--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -6,6 +6,7 @@ let
   fileSystems = attrValues config.fileSystems ++ config.swapDevices;
   encDevs = filter (dev: dev.encrypted.enable) fileSystems;
   keyedEncDevs = filter (dev: dev.encrypted.keyFile != null) encDevs;
+  keylessEncDevs = filter (dev: dev.encrypted.keyFile == null) encDevs;
   isIn = needle: haystack: filter (p: p == needle) haystack != [];
   anyEncrypted =
     fold (j: v: v || j.encrypted.enable) false encDevs;
@@ -29,15 +30,15 @@ let
       label = mkOption {
         default = null;
         example = "rootfs";
-        type = types.nullOr types.str;
-        description = "Label of the backing encrypted device.";
+        type = types.uniq (types.nullOr types.str);
+        description = "Label of the unlocked encrypted device. Set <literal>fileSystems.&lt;name?&gt;.device</literal> to <literal>/dev/mapper/&lt;label&gt;</literal> to mount the unlocked device.";
       };
 
       keyFile = mkOption {
         default = null;
         example = "/root/.swapkey";
         type = types.nullOr types.str;
-        description = "File system location of keyfile.";
+        description = "File system location of keyfile. This unlocks the drive after the root has been mounted to <literal>/mnt-root</literal>.";
       };
     };
   };
@@ -58,11 +59,11 @@ in
     boot.initrd = {
       luks = {
         devices =
-          map (dev: { name = dev.encrypted.label; device = dev.encrypted.blkDev; } ) encDevs;
+          map (dev: { name = dev.encrypted.label; device = dev.encrypted.blkDev; } ) keylessEncDevs;
         cryptoModules = [ "aes" "sha256" "sha1" "xts" ];
       };
       postMountCommands =
-        concatMapStrings (dev: "cryptsetup luksOpen --key-file ${dev.encrypted.keyFile} ${dev.encrypted.label};\n") keyedEncDevs;
+        concatMapStrings (dev: "cryptsetup luksOpen --key-file ${dev.encrypted.keyFile} ${dev.encrypted.blkDev} ${dev.encrypted.label};\n") keyedEncDevs;
     };
   };
 }


### PR DESCRIPTION
Not enough arguments were supplied to cryptsetup when a key-file was
specified. Also don't try to unlock keyedEncDevs with a password.

@oxij Making encrypted.label unique as cryptsetup only works with unique
mappings, this was the old behaviour before commit
6eadb16022b6e52f3cdb2167aaa7b82e221bfc1a, is my reasoning wrong?

@edwtjo I am fixing it to how I think should work but you should have a look at
it too as you are the original author.
