### PR TITLE
Build i686 mesa with llvm 3.4

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7601,7 +7601,11 @@ let
     # makes it slower, but during runtime we link against just mesa_drivers
     # through /run/opengl-driver*, which is overriden according to config.grsecurity
     grsecEnabled = true;
-    llvmPackages = llvmPackages_36;
+    llvmPackages = if system == "i686-linux"
+      # quake3 test (and llvmpipe?) breaks on i686 with LLVM 3.5 and 3.6, showing:
+      # "LLVM ERROR: Do not know how to split the result of this operator!"
+      then llvmPackages_34
+      else llvmPackages_36;
   });
   mesa_glu =  mesaDarwinOr (callPackage ../development/libraries/mesa-glu { });
   mesa_drivers = mesaDarwinOr (


### PR DESCRIPTION
This fixes the quake3 test.
It was suggested in #9471 that llvm 3.7 might also fix this. Would backporting 3.7 from master be a better approach? Is this fix good enough for 15.09?
