### PR TITLE
syncthing: update systemd service config according to upstream example

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -54,12 +54,15 @@ in
         description = "Syncthing service";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
-        environment.STNORESTART = "placeholder";  # do not self-restart
+        environment.STNORESTART = "yes";  # do not self-restart
+        environment.STNOUPGRADE = "yes";
         serviceConfig = {
           User = "${cfg.user}";
           PermissionsStartOnly = true;
-          Restart = "always";
+          Restart = "on-failure";
           ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser -home=${cfg.dataDir}";
+          SuccessExitStatus = "2 3 4";
+          RestartForceExitStatus="3 4";
         };
       };
 


### PR DESCRIPTION
The example service config were taken from the syncthing repo:
https://github.com/syncthing/syncthing/blob/master/etc/linux-systemd/system/syncthing@.service
