### PR TITLE
kiwix: init at 0.9.

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,0 +1,102 @@
+{ stdenv, fetchurl, pkgconfig, zip, python, zlib, xapian, which
+, icu, libmicrohttpd , lzma, zimlib, ctpp2, aria2, wget
+, bc, libuuid , glibc, libX11, libXext, libXt, libXrender
+, glib, dbus, dbus_glib, gtk, gdk_pixbuf, pango, cairo
+, freetype, fontconfig, alsaLib, atk
+}:
+
+let
+  xulrunner64_tar = fetchurl {
+    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-x86_64.tar.bz2;
+    sha256 = "0i3m30gm5z7qmas14id6ypvbmnb2k7jhz8aby2wz5vvv49zqmx3s";
+  };
+  xulrunnersdk64_tar = fetchurl {
+    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-x86_64.sdk.tar.bz2;
+    sha256 = "0z90v7c4mq15g5klmsj8vs2r10fbygj3qzynx4952hkv8ihw8n3a";
+  };
+  xulrunner32_tar = fetchurl {
+    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-i686.tar.bz2;
+    sha256 = "0yln6pxz8f6b9wm9124sx049z8mgi17lgd63rcv2hnix825y8gjb";
+  };
+  xulrunnersdk32_tar = fetchurl {
+    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-i686.sdk.tar.bz2;
+    sha256 = "1h9vcbvf8wgds6i2z20y7krpys0mqsqhv1ijyfljanp6vyll9fvi";
+  };
+
+  xulrunner_tar = if stdenv.system == "x86_64-linux" then xulrunner64_tar else xulrunner32_tar;
+  xulrunnersdk_tar = if stdenv.system == "x86_64-linux" then xulrunnersdk64_tar else xulrunnersdk32_tar;
+  pugixml_tar = fetchurl {
+    url = http://download.kiwix.org/dev/pugixml-1.2.tar.gz;
+    sha256 = "0sqk0vdwjq44jxbbkj1cy8qykrmafs1sickzldb2w2nshsnjshhg";
+  };
+in stdenv.mkDerivation rec {
+  name = "kiwix-${version}";
+  version = "0.9";
+
+  src = fetchurl {
+    url = "http://download.kiwix.org/src/kiwix-${version}-src.tar.xz";
+    sha256 = "0577phhy2na59cpcqjgldvksp0jwczyg0l6c9ghnr19i375l7yqc";
+  };
+
+  buildInputs = [
+    zip
+    pkgconfig
+    python
+    zlib
+    xapian
+    which
+    icu
+    libmicrohttpd
+    lzma
+    zimlib
+    ctpp2
+    aria2
+    wget
+    bc
+    libuuid
+  ];
+
+  patchPhase = ''
+    mkdir static
+    cp Makefile.in static/
+  '';
+
+  configureFlags = "--with-libpugixml=SELF";
+
+  buildPhase = ''
+    cd src/dependencies
+    cp ${pugixml_tar} pugixml-1.2.tar.gz
+    make pugixml-1.2/libpugixml.a
+
+    tar -xf ${xulrunner_tar}
+    tar -xf ${xulrunnersdk_tar}
+
+    cd ../..
+    ./configure $configureFlags
+
+    make
+  '';
+
+  installPhase = ''
+    make install
+    cp -r src/dependencies/xulrunner $out/lib/kiwix
+
+    patchelf --set-interpreter ${glibc}/lib/ld-linux${stdenv.lib.optionalString (stdenv.system == "x86_64-linux") "-x86-64"}.so.2 $out/lib/kiwix/xulrunner/xulrunner
+
+    rm $out/bin/kiwix
+    cat <<EOF >$out/bin/kiwix
+    #!/bin/sh
+    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:`cat ${stdenv.cc}/nix-support/orig-cc`/lib:${stdenv.lib.makeLibraryPath [libX11 libXext libXt libXrender glib dbus dbus_glib gtk gdk_pixbuf pango cairo freetype fontconfig alsaLib atk]}
+    export PATH=\$PATH:${aria2}/bin
+
+    exec $out/lib/kiwix/kiwix-launcher
+    EOF
+    chmod +x $out/bin/kiwix
+  '';
+
+  meta = {
+    description = "An offline reader for Web content";
+    homepage = http://kiwix.org;
+    maintainers = with stdenv.lib.maintainers; [ robbinch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11768,6 +11768,8 @@ let
     inherit (gnome) libglade;
   };
 
+  kiwix = callPackage ../applications/misc/kiwix { };
+
   koji = callPackage ../tools/package-management/koji { };
 
   ksuperkey = callPackage ../tools/X11/ksuperkey { };


### PR DESCRIPTION
This adds kiwix, an offline reader for Web content (like Wikipedia).

xulrunner is included here because it needs a specific version to compile and run.
Likewise for pugixml.
