### PR TITLE
qutebrowser: youtube support

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchgit, python, buildPythonPackage, qt5, pyqt5, jinja2, pygments, pyyaml, pypeg2 }:
+{ stdenv, fetchgit, python, buildPythonPackage, qt5, pyqt5, jinja2, pygments, pyyaml, pypeg2,
+  gst_plugins_base, gst_plugins_good, gst_ffmpeg }:
 
 let version = "0.4.0"; in
 
@@ -18,6 +19,12 @@ buildPythonPackage {
   propagatedBuildInputs = [
     python pyyaml pyqt5 jinja2 pygments pypeg2
   ];
+
+  makeWrapperArgs = ''
+    --prefix GST_PLUGIN_PATH : "${stdenv.lib.makeSearchPath "lib/gstreamer-0.10"
+       [ gst_plugins_base gst_plugins_good gst_ffmpeg ]}"
+    --prefix QT_PLUGIN_PATH : "${qt5.multimedia}/lib/qt5/plugins"
+  '';
 
   meta = {
     homepage = https://github.com/The-Compiler/qutebrowser;

--- a/pkgs/development/libraries/qt-5/5.4/default.nix
+++ b/pkgs/development/libraries/qt-5/5.4/default.nix
@@ -152,7 +152,7 @@ let
 
       multimedia = callPackage
         (
-          { qtSubmodule, base, declarative
+          { qtSubmodule, base, declarative, pkgconfig
           , alsaLib, gstreamer, gst_plugins_base, libpulseaudio
           }:
 
@@ -160,7 +160,7 @@ let
             name = "qtmultimedia";
             qtInputs = [ base declarative ];
             buildInputs = [
-              alsaLib gstreamer gst_plugins_base libpulseaudio
+              pkgconfig alsaLib gstreamer gst_plugins_base libpulseaudio
             ];
           }
         )


### PR DESCRIPTION
Without this patch, viewing any video (e.g. on youtube) fails with:

```
WARNING: defaultServiceProvider::requestService(): no service found for - "org.qt-project.qt.mediaplayer"
  File "/nix/store/g2chx7wlkndp0fg59i57xzdviw7ka5j1-qutebrowser-0.4.0/bin/.qutebrowser-wrapped", line 10, in <module>
    load_entry_point('qutebrowser==0.4.0', 'gui_scripts', 'qutebrowser')()
  File "/nix/store/g2chx7wlkndp0fg59i57xzdviw7ka5j1-qutebrowser-0.4.0/lib/python3.4/site-packages/qutebrowser/qutebrowser.py", line 149, in main
    return app.run(args)
  File "/nix/store/g2chx7wlkndp0fg59i57xzdviw7ka5j1-qutebrowser-0.4.0/lib/python3.4/site-packages/qutebrowser/app.py", line 109, in run
    ret = qt_mainloop()
  File "/nix/store/g2chx7wlkndp0fg59i57xzdviw7ka5j1-qutebrowser-0.4.0/lib/python3.4/site-packages/qutebrowser/app.py", line 119, in qt_mainloop
    return qApp.exec_()
  File "/nix/store/g2chx7wlkndp0fg59i57xzdviw7ka5j1-qutebrowser-0.4.0/lib/python3.4/site-packages/qutebrowser/utils/log.py", line 323, in qt_message_handler
    stack = ''.join(traceback.format_stack())
```

This is caused by two issues:
- The qt5.multimedia package doesn't contain the gstreamer mediaplayer plugin.  It is not built because the qt build requires pkg-config to find the gstreamer libraries.
- The gstreamer and qt plugins are not found at runtime by qutebrowser unless you correctly set the QT_PLUGIN_PATH and GST_PLUGIN_PATH environment variables.
