### PR TITLE
postfix service: fix recipientDelimiter not to be dependent on sslCert

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -77,7 +77,8 @@ let
       smtpd_tls_key_file = ${cfg.sslKey}
 
       smtpd_use_tls = yes
-
+    ''
+    + optionalString (cfg.recipientDelimiter != "") ''
       recipient_delimiter = ${cfg.recipientDelimiter}
     ''
     + optionalString (cfg.virtual != "") ''


### PR DESCRIPTION
There's no reason I know of that these options should be tied together.
