### PR TITLE
ghcjs-dom bump

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -78,6 +78,13 @@ self: super: {
 
   ghcjs-dom = overrideCabal super.ghcjs-dom (drv: {
     buildDepends = [ self.base self.mtl self.text self.ghcjs-base ];
+    libraryHaskellDepends = [ ];
+    src = pkgs.fetchFromGitHub {
+      owner = "ghcjs";
+      repo = "ghcjs-dom";
+      rev = "8d77202b46cbf0aed77bb1f1e8d827f27dee90d7";
+      sha256 = "01npi286mwg7yr3h9qhxnylnjzbjb4lg5235v5lqfwy76hmmb9lp";
+    };
   });
 
   ghc-paths = overrideCabal super.ghc-paths (drv: {


### PR DESCRIPTION
It built just fine in my computer.

Note 01f5c466ab6fbf3e9d34950d3684e8213ee83897 is introduced by #10011. In other words, this pull-request depends on #10011.

Thanks to @mayhewluke for his suggestions on how to package this.
