### PR TITLE
camlp5: 6.12 → 6.14

### DIFF
--- a/pkgs/applications/science/logic/hol_light/Makefile.patch
+++ b/pkgs/applications/science/logic/hol_light/Makefile.patch
@@ -1,0 +1,13 @@
+Index: Makefile
+===================================================================
+--- a/Makefile	(révision 199)
++++ b/Makefile	(copie de travail)
+@@ -59,7 +59,7 @@
+              then cp pa_j_3.1x_6.02.1.ml pa_j.ml; \
+              else if test ${CAMLP5_VERSION} = "6.02.2" -o ${CAMLP5_VERSION} = "6.02.3" -o ${CAMLP5_VERSION} = "6.03" -o ${CAMLP5_VERSION} = "6.04" -o ${CAMLP5_VERSION} = "6.05" -o ${CAMLP5_VERSION} = "6.06" ; \
+                   then cp pa_j_3.1x_6.02.2.ml pa_j.ml; \
+-                  else if test ${CAMLP5_VERSION} = "6.06" -o ${CAMLP5_VERSION} = "6.07" -o ${CAMLP5_VERSION} = "6.08" -o ${CAMLP5_VERSION} = "6.09" -o ${CAMLP5_VERSION} = "6.10" -o ${CAMLP5_VERSION} = "6.11" -o ${CAMLP5_VERSION} = "6.12" ; \
++                  else if test ${CAMLP5_VERSION} = "6.06" -o ${CAMLP5_VERSION} = "6.07" -o ${CAMLP5_VERSION} = "6.08" -o ${CAMLP5_VERSION} = "6.09" -o ${CAMLP5_VERSION} = "6.10" -o ${CAMLP5_VERSION} = "6.11" -o ${CAMLP5_VERSION} = "6.12" -o ${CAMLP5_VERSION} = "6.13" -o ${CAMLP5_VERSION} = "6.14" ; \
+                        then cp pa_j_3.1x_6.11.ml pa_j.ml; \
+                        else cp pa_j_3.1x_${CAMLP5_BINARY_VERSION}.xx.ml pa_j.ml; \
+                        fi \

--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml camlp5 ];
 
+  patches = [ ./Makefile.patch ];
+
   installPhase = ''
     mkdir -p "$out/lib/hol_light" "$out/bin"
     cp -a  . $out/lib/hol_light

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -7,11 +7,11 @@ in
 
 stdenv.mkDerivation {
 
-  name = "camlp5${if transitional then "_transitional" else ""}-6.12";
+  name = "camlp5${if transitional then "_transitional" else ""}-6.14";
 
   src = fetchurl {
-    url = http://camlp5.gforge.inria.fr/distrib/src/camlp5-6.12.tgz;
-    sha256 = "00jwgp6w4g64lfqjx77xziy532091fy00c42fsy0b4i892rch5mp";
+    url = http://camlp5.gforge.inria.fr/distrib/src/camlp5-6.14.tgz;
+    sha256 = "1ql04iyvclpyy9805kpddc4ndjb5d0qg4shhi2fc6bixi49fvy89";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
Changes in `camlp5` (see http://camlp5.gforge.inria.fr/CHANGES) mostly amount to added compatibility with recent versions of OCaml. It shouldn’t break anything.

Tested locally on Linux x86_64: reverse dependencies of `camlp5` build fine.
