### PR TITLE
redshift: build user service file

### DIFF
--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -88,11 +88,9 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    systemd.services.redshift = {
+  config = 
+    let redshift = {
       description = "Redshift colour temperature adjuster";
-      requires = [ "display-manager.service" ];
-      after = [ "display-manager.service" ];
       wantedBy = [ "graphical.target" ];
       serviceConfig.ExecStart = ''
         ${cfg.package}/bin/redshift \
@@ -104,6 +102,15 @@ in {
       environment = { DISPLAY = ":0"; };
       serviceConfig.Restart = "always";
     };
-  };
+    in mkMerge [
+      (mkIf cfg.enable {
+        # user systemd doesn’t know display-manager.service
+        systemd.services.redshift = redshift // {
+            requires = [ "display-manager.service" ];
+            after = [ "display-manager.service" ];
+          };
+      })
+      { systemd.user.services.redshift = redshift; }
+    ];
 
 }


### PR DESCRIPTION
Is it okay to leave out display-manager.service for the user service? Maybe I misread the problem.
