### PR TITLE
smartgithg: 7.0.0 -> 7.0.2

### DIFF
--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   name = "smartgithg-${version}";
-  version = "7_0_0";
+  version = "7_0_2";
 
   src = fetchurl {
     url = "http://www.syntevo.com/downloads/smartgit/smartgit-generic-${version}.tar.gz";
-    sha256 = "099hnpczh2c0s86nsdybymmm4903n0bsjdq1fpdmm0x5w4216iy6";
+    sha256 = "1jpi424aqy6niq31j750rgbspwii013c8kbi965i4jzjpba1pagi";
   };
 
   buildInputs = [
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   buildCommand = let
     pkg_path = "$out/${name}";
     bin_path = "$out/bin";
+    install_freedesktop_items = ./install_freedesktop_items.sh;
     runtime_paths = lib.makeSearchPath "bin" [
       jre
       git mercurial subversion
@@ -48,6 +49,8 @@ stdenv.mkDerivation rec {
       --prefix SMARTGITHG_JAVA_HOME : ${jre}
     patchShebangs $out
     cp ${bin_path}/smartgit ${bin_path}/smartgithg
+
+    ${install_freedesktop_items} "${pkg_path}/bin" "$out"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/smartgithg/install_freedesktop_items.sh
+++ b/pkgs/applications/version-management/smartgithg/install_freedesktop_items.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+inBinDir=$1
+out=$2
+
+cat $inBinDir/add-menuitem.sh | \
+sed -re 's#xdg-icon-resource[ ]+install[ ]+--size[ ]+([0-9]+)[ ]+("[^"]+")[ ]+([$0-9a-zA-Z_]+)#mkdir -p '${out}'/share/icons/hicolor/\1x\1/apps \&\& cp \2 '${out}'/share/icons/hicolor/\1x\1/apps/\3\.png #' | \
+sed -re 's#xdg-desktop-menu[ ]+install[ ]+([$0-9a-zA-Z_]+)#mkdir -p '${out}'/share/applications \&\& cp \1 '${out}'/share/applications/#' | \
+sed -re 's#Exec="[^"]+"#Exec=smartgit#' |
+sed -re 's#SMARTGIT_BIN=.*#'SMARTGIT_BIN=${inBinDir}'#' \
+| bash


### PR DESCRIPTION
Also adapted package's freedesktop item install
script so that it works in the context of nix.
(i.e.: icons and `*.desktop` file now properly
installed by the package).

Tests:
-  Launched the application and worked with it for a while.
-  Uses the `*.desktop` as a panel shortcut successfully. Icon
  is properly displayed.
-  Rebuilt successfully after rebase.
