### PR TITLE
haskell: make `ghc` and `cabal-install` visible

### DIFF
--- a/doc/haskell-users-guide.xml
+++ b/doc/haskell-users-guide.xml
@@ -11,14 +11,13 @@
     registered on
     <link xlink:href="http://hackage.haskell.org/">Hackage</link>, but
     strangely enough normal Nix package lookups don't seem to discover
-    any of them:
+    any of them, except for the default version of ghc and cabal-install:
   </para>
   <programlisting>
-$ nix-env -qa cabal-install
-error: selector ‘cabal-install’ matches no derivations
-
-$ nix-env -i ghc
-error: selector ‘ghc’ matches no derivations
+$ nix-env -i alex
+error: selector ‘alex’ matches no derivations
+$ nix-env -qa ghc
+ghc-7.10.2
 </programlisting>
   <para>
     The Haskell package set is not registered in the top-level namespace

--- a/nixos/doc/manual/release-notes/rl-1509.xml
+++ b/nixos/doc/manual/release-notes/rl-1509.xml
@@ -121,10 +121,8 @@ which contains the latest Elm platform.</para></listitem>
 
 <listitem>
   <para>
-    Haskell packages can no longer be found by name, i.e. the commands
-    <literal>nix-env -qa cabal-install</literal> and <literal>nix-env -i
-    ghc</literal> will fail, even though we <emphasis>do</emphasis> ship
-    both <literal>cabal-install</literal> and <literal>ghc</literal>.
+    Haskell packages can no longer be found by name, except for
+    <literal>cabal-install</literal> and <literal>ghc</literal>.
     The reason for this inconvenience is the sheer size of the Haskell
     package set: name-based lookups such as these would become much
     slower than they are today if we'd add the entire Hackage database

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3984,6 +3984,7 @@ let
   haskellPackages = haskell.packages.ghc7102.override {
     overrides = config.haskellPackageOverrides or (self: super: {});
   };
+  inherit (haskellPackages) ghc cabal-install;
 
   haxe = callPackage ../development/compilers/haxe {
     inherit (ocamlPackages) camlp4;


### PR DESCRIPTION
I will merge and port to 15.09 in a few days.
