### PR TITLE
zfs + zfs_git: 0.6.5 -> 0.6.5.1

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -1,13 +1,13 @@
 { callPackage, fetchFromGitHub, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "0.6.5";
+  version = "0.6.5.1";
 
   src = fetchFromGitHub {
     owner = "zfsonlinux";
     repo = "zfs";
     rev = "zfs-${version}";
-    sha256 = "1jqm2a9mldp4km5m454zszsw6p8hrqd7xrbf52pgp82kf5w3d6wz";
+    sha256 = "0lbii5kc3b68zj8mvvznl05czwdkr0ld3a2javbkngfvrcn09rz2";
   };
 
   patches = [ ./nix-build.patch ];

--- a/pkgs/os-specific/linux/zfs/git.nix
+++ b/pkgs/os-specific/linux/zfs/git.nix
@@ -1,13 +1,13 @@
 { callPackage, stdenv, fetchFromGitHub, spl_git, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "2015-09-11";
+  version = "2015-09-19";
 
   src = fetchFromGitHub {
     owner = "zfsonlinux";
     repo = "zfs";
-    rev = "7a27ad00ae142b38d4aef8cc0af7a72b4c0e44fe";
-    sha256 = "1jqm2a9mldp4km5m454zszsw6p8hrqd7xrbf52pgp82kf5w3d6wz";
+    rev = "3af56fd95fbe8b417d7ed7c9c25ef59d6f1ee161";
+    sha256 = "08sx1jzwrsdyvvlcf5as7rkglgbx5x6zvfn8ps8gk4miqfckq4z0";
   };
 
   patches = [ ./nix-build.patch ];


### PR DESCRIPTION
Cherry-pick this critical bug fix release into 15.09, see [ZoL's release notes](https://github.com/zfsonlinux/zfs/releases/tag/zfs-0.6.5.1).
