### PR TITLE
neon: 0.29.6 -> 0.30.1

### DIFF
--- a/pkgs/development/libraries/neon/default.nix
+++ b/pkgs/development/libraries/neon/default.nix
@@ -14,7 +14,8 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "neon-0.30.1";
+  version = "0.30.1";
+  name = "neon-${version}";
 
   src = fetchurl {
     url = "http://www.webdav.org/neon/${name}.tar.gz";

--- a/pkgs/development/libraries/neon/default.nix
+++ b/pkgs/development/libraries/neon/default.nix
@@ -14,11 +14,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "neon-0.29.6";
+  name = "neon-0.30.1";
 
   src = fetchurl {
     url = "http://www.webdav.org/neon/${name}.tar.gz";
-    sha256 = "0hzbjqdx1z8zw0vmbknf159wjsxbcq8ii0wgwkqhxj3dimr0nr4w";
+    sha256 = "1pawhk02x728xn396a1kcivy9gqm94srmgad6ymr9l0qvk02dih0";
   };
 
   patches = optionals stdenv.isDarwin [ ./0.29.6-darwin-fix-configure.patch ];


### PR DESCRIPTION
Test build.

It is my update of a library package, so I'm not sure how to test this properly (as it can not be test started, obviousely).
