### PR TITLE
fio: Minor refactor

### DIFF
--- a/pkgs/tools/system/fio/default.nix
+++ b/pkgs/tools/system/fio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libaio, zlib }:
+{ stdenv, fetchFromGitHub, libaio, python, zlib }:
 
 let version = "2.2.10"; in
 
@@ -12,23 +12,18 @@ stdenv.mkDerivation rec {
     sha256 = "0hg72k8cifw6lc46kyiic7ai4gqn2819d6g998vmx01jnlcixp8q";
   };
 
-  buildInputs = [ libaio zlib ];
+  buildInputs = [ libaio python zlib ];
 
   enableParallelBuilding = true;
 
-  configurePhase = ''
-    substituteInPlace tools/plot/fio2gnuplot \
-      --replace /usr/share/fio $out/share/fio
-    ./configure
+  postPatch = ''
+    substituteInPlace tools/plot/fio2gnuplot --replace /usr/share/fio $out/share/fio
   '';
 
-  installPhase = ''
-    make install prefix=$out
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://git.kernel.dk/?p=fio.git;a=summary";
     description = "Flexible IO Tester - an IO benchmark tool";
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
- Use postPatch for patching, so don't need to manually override
  configurePhase and installPhase.
- Add python to buildInputs, so fio2gnuplot gets patchShebangs'd.
- Add platforms, so it gets built by Hydra.
