### PR TITLE
glibcLocales: fix tarball on Darwin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6307,7 +6307,7 @@ let
   libcCross = assert crossSystem != null; libcCrossChooser crossSystem.libc;
 
   # Only supported on Linux
-  glibcLocales = if stdenv.isLinux then callPackage ../development/libraries/glibc/locales.nix { } else null;
+  glibcLocales = assert stdenv.isLinux; callPackage ../development/libraries/glibc/locales.nix { };
 
   glibcInfo = callPackage ../development/libraries/glibc/info.nix { };
 


### PR DESCRIPTION
https://hydra.nixos.org/build/26376016/nixlog/1/raw

I'm not sure why it worked before.
