### PR TITLE
python-packages: importmagic init at 0.1.3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18440,4 +18440,24 @@ let
     };
   };
 
+  importmagic = buildPythonPackage rec {
+    simpleName = "importmagic";
+    name = "${simpleName}-${version}";
+    version = "0.1.3";
+    doCheck = false;  # missing json file from tarball
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/i/${simpleName}/${name}.tar.gz";
+      sha256 = "194bl8l8sc2ibwi6g5kz6xydkbngdqpaj6r2gcsaw1fc73iswwrj";
+    };
+
+    propagatedBuildInputs = with self; [ six ];
+
+    meta = {
+      description = "Python Import Magic - automagically add, remove and manage imports";
+      homepage = http://github.com/alecthomas/importmagic;
+      license = "bsd";
+    };
+  };
+
 }; in pythonPackages


### PR DESCRIPTION
Build and install ok.

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:python-packages-init-importmagic o [10:36:32]
$ nix-build -A python34Packages.importmagic
/nix/store/pf6ymxiwb0ai3a0m87x2awjm2s31iqcj-python3.4-importmagic-0.1.3

# tony at corellia in ~/repo/perso/nixpkgs on git:python-packages-init-importmagic o [10:36:38]
$ tree result
result
├── lib
│   └── python3.4
│       └── site-packages
│           ├── importmagic
│           │   ├── conftest.py
│           │   ├── importer.py
│           │   ├── importer_test.py
│           │   ├── index.py
│           │   ├── index_test.py
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── conftest.cpython-34.pyc
│           │   │   ├── importer.cpython-34.pyc
│           │   │   ├── importer_test.cpython-34.pyc
│           │   │   ├── index.cpython-34.pyc
│           │   │   ├── index_test.cpython-34.pyc
│           │   │   ├── __init__.cpython-34.pyc
│           │   │   ├── six.cpython-34.pyc
│           │   │   ├── symbols.cpython-34.pyc
│           │   │   ├── symbols_test.cpython-34.pyc
│           │   │   └── util.cpython-34.pyc
│           │   ├── six.py
│           │   ├── symbols.py
│           │   ├── symbols_test.py
│           │   └── util.py
│           ├── importmagic-0.1.3-py3.4.egg-info
│           │   ├── dependency_links.txt
│           │   ├── PKG-INFO
│           │   ├── requires.txt
│           │   ├── SOURCES.txt
│           │   └── top_level.txt
│           └── python3.4-importmagic-0.1.3-nix-python-propagated-native-build-inputs.pth
└── nix-support
└── propagated-native-build-inputs

7 directories, 27 files

# tony at corellia in ~/repo/perso/nixpkgs on git:python-packages-init-importmagic o [10:36:41]
$ nix-env -f . -iA python34Packages.importmagic
installing ‘python3.4-importmagic-0.1.3’
building path (s) ‘/nix/store/zfj6lb44xjsmr9b40fz6dnj00lhzb6v7-user-environment’
created 3937 symlinks in user environment

# tony at corellia in ~/repo/perso/nixpkgs on git:python-packages-init-importmagic o [10:37:00]
$ f ~/.nix-profile/ importmagic
/home/tony/.nix-profile/lib/python3.4/site-packages/importmagic-0.1.3-py3.4.egg-info
/home/tony/.nix-profile/lib/python3.4/site-packages/importmagic
/home/tony/.nix-profile/lib/python3.4/site-packages/python3.4-importmagic-0.1.3-nix-python-propagated-native-build-inputs.pth
```

Note:
- I deactivated the tests `doCheck = False` because the tarball do not contain the .json files needed for the tests to work.
- It's related to the #10043 as this is an optional runtime dependencies on elpy.

Cheers,
