### PR TITLE
mygui: 3.2.0 -> 3.2.2

### DIFF
--- a/pkgs/development/libraries/mygui/default.nix
+++ b/pkgs/development/libraries/mygui/default.nix
@@ -1,16 +1,19 @@
-{stdenv, fetchurl, unzip, ogre, cmake, ois, freetype, libuuid, boost, pkgconfig}:
+{stdenv, fetchFromGitHub, libX11, unzip, ogre, cmake, ois, freetype, libuuid, boost, pkgconfig}:
 
 stdenv.mkDerivation rec {
-  name = "mygui-3.2.0";
+  name = "mygui-${version}";
+  version = "3.2.2";
   
-  src = fetchurl {
-    url = mirror://sourceforge/my-gui/MyGUI_3.2.0.zip;
-    sha256 = "16m1xrhx13qbwnp9gds2amlwycq8q5npr0665hnknwsb6rph010p";
+  src = fetchFromGitHub {
+    owner = "MyGUI";
+    repo = "mygui";
+    rev = "MyGUI${version}";
+    sha256 = "1wk7jmwm55rhlqqcyvqsxdmwvl70bysl9azh4kd9n57qlmgk3zmw";
   };
 
   enableParallelBuilding = true;
 
-  buildInputs = [ unzip ogre cmake ois freetype libuuid boost pkgconfig ];
+  buildInputs = [ libX11 unzip ogre cmake ois freetype libuuid boost pkgconfig ];
 
   meta = {
     homepage = http://mygui.info/;


### PR DESCRIPTION
**Note:** the old 3.2.0 expression was also broken (download link dead) because the project moved from sourceforge to github.

Added `libX11` dependency because it would not build without it
