### PR TITLE
openmw: init at 0.36.1

### DIFF
--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, qt4, ogre, mygui, bullet, ffmpeg, boost, cmake, SDL2, unshield, openal, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  version = "0.36.1";
+  name = "openmw-${version}";
+
+  mygui_ = mygui.overrideDerivation (oldAttrs: {
+    name = "mygui-3.2.1";
+    version = "3.2.1";
+
+    src = fetchFromGitHub {
+      owner = "MyGUI";
+      repo = "mygui";
+      rev = "MyGUI3.2.1";
+      sha256 = "1ic4xwyh2akfpqirrbyvicc56yy2r268rzgcgx16yqb4nrldy2p0";
+    };
+  });
+
+  src = fetchFromGitHub {
+    owner = "OpenMW";
+    repo = "openmw";
+    rev = name;
+    sha256 = "0yfiilad6izmingc0nhvkvn6dpybps04xwj4k1h13ymip6awm80x";
+  };
+
+  buildInputs = [ cmake boost ffmpeg qt4 bullet mygui_ ogre SDL2 unshield openal pkgconfig ];
+
+  meta = {
+    description = "An unofficial open source engine reimplementation of the game Morrowind";
+    homepage = "http://openmw.org";
+    license = stdenv.lib.licenses.gpl3;
+  };
+  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13607,6 +13607,8 @@ let
 
   oilrush = callPackage ../games/oilrush { };
 
+  openmw = callPackage ../games/openmw { };
+
   openra = callPackage ../games/openra { lua = lua5_1; };
 
   openttd = callPackage ../games/openttd {


### PR DESCRIPTION
Hello, this is a package for [openmw](http://openmw.org/en/) which is a fully playable reimplementation of the game engine from The Elder Scrolls III: Morrowind

requires #10079 and #10080 to be merged (both `mygui` and `ogre` are broken right now)

it builds fine and launches on my machine. Not tried gameplay yet, but I will soon (need to download game data)
