### PR TITLE
upgrade android-support-repository to 16

### DIFF
--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "14";
+  version = "16";
   name = "android-support-repository-r${version}";
   src = fetchurl {
-    url = "http://dl-ssl.google.com/android/repository/android_m2repository_r${version}.zip";
-    sha256 = "027mmfzvs07nbp28vn6c6cgszqdrmmgwdfzda87936lpi5dwg34p";
+    url = "https://dl-ssl.google.com/android/repository/android_m2repository_r${version}.zip";
+    sha256 = "12sa66amisk4g9wlvwlmgrrkrv3iy70kpridhk4gjci7gsksalks";
   };
 
   buildCommand = ''


### PR DESCRIPTION
This upgrade from release 14 to release 16 introduces Android Design Support Library (Material design). 
