### PR TITLE
oraclejdk8: Fix installation of JCE

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -133,7 +133,7 @@ let result = stdenv.mkDerivation rec {
 
     if test -n "${jce}"; then
       unzip ${jce}
-      cp -v UnlimitedJCEPolicy/*.jar $jrePath/lib/security
+      cp -v UnlimitedJCEPolicy*/*.jar $jrePath/lib/security
     fi
 
     rpath=$rpath''${rpath:+:}$jrePath/lib/${architecture}/jli


### PR DESCRIPTION
Oracle changed the path of the files.

Previous versions looked like:

```
$ jar tf UnlimitedJCEPolicyJDK7.zip
UnlimitedJCEPolicy/
UnlimitedJCEPolicy/US_export_policy.jar
UnlimitedJCEPolicy/local_policy.jar
UnlimitedJCEPolicy/README.txt
```

The new version looks like:

```
$ jar tf jce_policy-8.zip
UnlimitedJCEPolicyJDK8/
UnlimitedJCEPolicyJDK8/local_policy.jar
UnlimitedJCEPolicyJDK8/README.txt
UnlimitedJCEPolicyJDK8/US_export_policy.jar
```

A better solution is probably just to trim the directory off completely.
