### PR TITLE
taskserver: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/servers/misc/taskserver/default.nix
+++ b/pkgs/servers/misc/taskserver/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "taskserver-${version}";
-  version = "1.0.0";
+  version = "1.1.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "http://www.taskwarrior.org/download/taskd-${version}.tar.gz";
-    sha256 = "162ef1eec48f8145870ef0dbe0121b78a6da99815bc18af77de07fbb0abe02d0";
+    sha256 = "1d110q9vw8g5syzihxymik7hd27z1592wkpz55kya6lphzk8i13v";
   };
 
   nativeBuildInputs = [ cmake libuuid gnutls ];
@@ -18,5 +18,6 @@ stdenv.mkDerivation rec {
     homepage = http://taskwarrior.org;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
   };
 }


### PR DESCRIPTION
Test build succeeded on my machine.

Not test-run, though.

Also required for my work on #7771 
