### PR TITLE
steam: added libcxxabi workaround

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -15,6 +15,7 @@ buildFHSUserEnv {
       pkgs.xdg_utils
       pkgs.xorg.xrandr
       pkgs.which
+      pkgs.libcxxabi
     ]
     ++ lib.optional (config.steam.java or false) pkgs.jdk
     ++ lib.optional (config.steam.primus or false) pkgs.primus
@@ -45,6 +46,8 @@ buildFHSUserEnv {
       pkgs.xorg.libXScrnSaver
       pkgs.xorg.libXtst
       pkgs.xorg.libXxf86vm
+      
+      pkgs.libcxxabi
 
       pkgs.ffmpeg
       pkgs.libpng12
@@ -74,6 +77,8 @@ buildFHSUserEnv {
     export LD_PRELOAD=/lib32/libpulse.so:/lib64/libpulse.so:/lib32/libasound.so:/lib64/libasound.so:$LD_PRELOAD
     # Another one for https://github.com/ValveSoftware/steam-for-linux/issues/3801
     export LD_PRELOAD=/lib32/libstdc++.so:/lib64/libstdc++.so:$LD_PRELOAD
+    # An ugly fix to get Sid Meier's Civilization V to launch.
+    export LD_PRELOAD=/lib32/libc++abi.so:/lib64/libc++abi.so:$LD_PRELOAD
   '';
 
   runScript = "steam";


### PR DESCRIPTION
Changes tested on unstable 68bd8e4M and they work to allow launching Sid Meier's Civilization V.
