### PR TITLE
libxkbcommon: Remove `--version-script` from Makefile on Darwin.

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, yacc, flex, xkeyboard_config, libxcb }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   name = "libxkbcommon-0.5.0";
 
   src = fetchurl {
@@ -19,3 +19,12 @@ stdenv.mkDerivation rec {
     homepage = http://xkbcommon.org;
   };
 }
+
+// 
+
+# --version-script as an argument to `ld` is not supported on OS X
+stdenv.lib.optionalAttrs stdenv.isDarwin {
+  preBuild =  ''
+    sed -i 's/,--version-script=.*$//' Makefile
+  '';
+})


### PR DESCRIPTION
`--version-script` as an argument to `ld` is not supported on OS X.
