### PR TITLE
Fix broken patch to nodejs-4-1 when building on Darwin

### DIFF
--- a/pkgs/development/web/nodejs/no-xcode.patch
+++ b/pkgs/development/web/nodejs/no-xcode.patch
@@ -70,24 +70,3 @@ diff -Naur a/tools/gyp/pylib/gyp/xcode_emulation.py b/tools/gyp/pylib/gyp/xcode_
  
    def AdjustLibraries(self, libraries, config_name=None):
      """Transforms entries like 'Cocoa.framework' in libraries into entries like
-@@ -1018,12 +1033,16 @@
-     # Since the value returned by this function is only used when ARCHS is not
-     # set, then on iOS we return "i386", as the default xcode project generator
-     # does not set ARCHS if it is not set in the .gyp file.
--    if self.isIOS:
-+    
-+    try:
-+      if self.isIOS:
-+        return 'i386'
-+      version, build = self._XcodeVersion()
-+      if version >= '0500':
-+        return 'x86_64'
-       return 'i386'
--    version, build = self._XcodeVersion()
--    if version >= '0500':
-+    except:
-       return 'x86_64'
--    return 'i386'
- 
- class MacPrefixHeader(object):
-   """A class that helps with emulating Xcode's GCC_PREFIX_HEADER feature.


### PR DESCRIPTION
This bug was introduced by #9941.

The last hunk on the patch was obsolete, just removed it.
