### PR TITLE
python-packages: elpy 1.0.1 -> 1.9.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5820,10 +5820,11 @@ let
 
 
   elpy = buildPythonPackage rec {
-    name = "elpy-1.0.1";
+    name = "elpy-${version}";
+    version = "1.9.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/elpy/elpy-1.0.1.tar.gz";
-      md5 = "5453f085f7871ed8fc11d51f0b68c785";
+      url = "https://pypi.python.org/packages/source/e/elpy/${name}.tar.gz";
+      md5 = "651f6f46767b7132e5c0f83d5ac3b1f7";
     };
     propagatedBuildInputs = with self; [ flake8 ];
 


### PR DESCRIPTION
Builds ok:

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:python-packages-update-elpy x [18:19:34]
$ nix-build -A python34Packages.elpy
/nix/store/fnc8iclbd9mfnh3n45maj57zvplwzfph-python3.4-elpy-1.9.0

# tony at corellia in ~/repo/perso/nixpkgs on git:python-packages-update-elpy x [18:19:37]
$ tree result
result
├── lib
│   └── python3.4
│       └── site-packages
│           ├── elpy
│           │   ├── auto_pep8.py
│           │   ├── compat.py
│           │   ├── impmagic.py
│           │   ├── __init__.py
│           │   ├── jedibackend.py
│           │   ├── __main__.py
│           │   ├── __pycache__
│           │   │   ├── auto_pep8.cpython-34.pyc
│           │   │   ├── compat.cpython-34.pyc
│           │   │   ├── impmagic.cpython-34.pyc
│           │   │   ├── __init__.cpython-34.pyc
│           │   │   ├── jedibackend.cpython-34.pyc
│           │   │   ├── __main__.cpython-34.pyc
│           │   │   ├── pydocutils.cpython-34.pyc
│           │   │   ├── refactor.cpython-34.pyc
│           │   │   ├── ropebackend.cpython-34.pyc
│           │   │   ├── rpc.cpython-34.pyc
│           │   │   └── server.cpython-34.pyc
│           │   ├── pydocutils.py
│           │   ├── refactor.py
│           │   ├── ropebackend.py
│           │   ├── rpc.py
│           │   ├── server.py
│           │   └── tests
│           │       ├── compat.py
│           │       ├── __init__.py
│           │       ├── __pycache__
│           │       │   ├── compat.cpython-34.pyc
│           │       │   ├── __init__.cpython-34.pyc
│           │       │   ├── support.cpython-34.pyc
│           │       │   ├── test_auto_pep8.cpython-34.pyc
│           │       │   ├── test_impmagic.cpython-34.pyc
│           │       │   ├── test_jedibackend.cpython-34.pyc
│           │       │   ├── test_pydocutils.cpython-34.pyc
│           │       │   ├── test_refactor.cpython-34.pyc
│           │       │   ├── test_ropebackend.cpython-34.pyc
│           │       │   ├── test_rpc.cpython-34.pyc
│           │       │   ├── test_server.cpython-34.pyc
│           │       │   └── test_support.cpython-34.pyc
│           │       ├── support.py
│           │       ├── test_auto_pep8.py
│           │       ├── test_impmagic.py
│           │       ├── test_jedibackend.py
│           │       ├── test_pydocutils.py
│           │       ├── test_refactor.py
│           │       ├── test_ropebackend.py
│           │       ├── test_rpc.py
│           │       ├── test_server.py
│           │       └── test_support.py
│           ├── elpy-1.9.0-py3.4.egg-info
│           │   ├── dependency_links.txt
│           │   ├── PKG-INFO
│           │   ├── requires.txt
│           │   ├── SOURCES.txt
│           │   └── top_level.txt
│           └── python3.4-elpy-1.9.0-nix-python-propagated-native-build-inputs.pth
└── nix-support
└── propagated-native-build-inputs

9 directories, 53 files
```

Related to #10043 for compatibility.

Cheers,
