### PR TITLE
nixos: make virtualisation.docker.storageDriver optional

### DIFF
--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -11,6 +11,8 @@ import ./make-test.nix ({ pkgs, ...} : {
       { config, pkgs, ... }:
         {
           virtualisation.docker.enable = true;
+          # FIXME: The default "devicemapper" storageDriver fails in NixOS VM
+          # tests.
           virtualisation.docker.storageDriver = "overlay";
         };
     };


### PR DESCRIPTION
Commit 9bfe92ecee ("docker: Minor improvements, fix failing test") added
this option and made it mandatory. But docker itself has a default
value, so I don't think NixOS should to force users to make up their
mind about what storage driver to use, when docker can choose one
itself.
