### PR TITLE
jekyll: add RedCloth dependency for textile support

### DIFF
--- a/pkgs/applications/misc/jekyll/Gemfile
+++ b/pkgs/applications/misc/jekyll/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'jekyll'
 gem 'rdiscount'
+gem 'RedCloth'

--- a/pkgs/applications/misc/jekyll/Gemfile.lock
+++ b/pkgs/applications/misc/jekyll/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    RedCloth (4.2.9)
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -68,5 +69,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  RedCloth
   jekyll
   rdiscount
+
+BUNDLED WITH
+   1.10.6

--- a/pkgs/applications/misc/jekyll/gemset.nix
+++ b/pkgs/applications/misc/jekyll/gemset.nix
@@ -1,4 +1,11 @@
 {
+  "RedCloth" = {
+    version = "4.2.9";
+    source = {
+      type = "gem";
+      sha256 = "06pahxyrckhgb7alsxwhhlx1ib2xsx33793finj01jk8i054bkxl";
+    };
+  };
   "blankslate" = {
     version = "2.1.2.4";
     source = {


### PR DESCRIPTION
This allows jekyll to be used with textile markup.  Tested on my blog that has textile, and it appears to work fine.
