### PR TITLE
qt5: add missing mesa include dir

### DIFF
--- a/pkgs/development/libraries/qt-5/5.4/0014-mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.4/0014-mkspecs-libgl.patch
@@ -4,11 +4,13 @@ Author: Bjørn Forsman <bjorn.forsman@gmail.com>
 diff -uNr qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf
 --- qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf	2014-09-11 12:48:07.000000000 +0200
 +++ qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf	2015-08-23 13:03:30.617473019 +0200
-@@ -13,7 +13,7 @@
+@@ -12,8 +12,8 @@
+ QMAKE_LIBDIR            =
  QMAKE_INCDIR_X11        =
  QMAKE_LIBDIR_X11        =
- QMAKE_INCDIR_OPENGL     =
+-QMAKE_INCDIR_OPENGL     =
 -QMAKE_LIBDIR_OPENGL     =
++QMAKE_INCDIR_OPENGL     = @mesa@/include
 +QMAKE_LIBDIR_OPENGL     = @mesa@/lib
  QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
  QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/0014-mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/0014-mkspecs-libgl.patch
@@ -1,0 +1,17 @@
+Ensure Qt knows where libGL is.
+
+Author: Bjørn Forsman <bjorn.forsman@gmail.com>
+diff -uNr qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf
+--- qt-everywhere-opensource-src-5.3.2.orig/qtbase/mkspecs/common/linux.conf	2014-09-11 12:48:07.000000000 +0200
++++ qt-everywhere-opensource-src-5.3.2/qtbase/mkspecs/common/linux.conf	2015-08-23 13:03:30.617473019 +0200
+@@ -12,8 +12,8 @@
+ QMAKE_LIBDIR            =
+ QMAKE_INCDIR_X11        =
+ QMAKE_LIBDIR_X11        =
+-QMAKE_INCDIR_OPENGL     =
+-QMAKE_LIBDIR_OPENGL     =
++QMAKE_INCDIR_OPENGL     = @mesa@/include
++QMAKE_LIBDIR_OPENGL     = @mesa@/lib
+ QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
+ QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL
+ QMAKE_INCDIR_EGL        =

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
@@ -83,12 +83,17 @@ stdenv.mkDerivation {
         };
         xdg-config-dirs = ./0008-xdg-config-dirs.patch;
         decrypt-ssl-traffic = ./0009-decrypt-ssl-traffic.patch;
+        mkspecs-libgl = substituteAll {
+          src = ./0014-mkspecs-libgl.patch;
+          inherit mesa;
+        };
     in [
       dlopen-resolv dlopen-gl tzdir dlopen-libXcursor dlopen-openssl
       dlopen-dbus xdg-config-dirs
     ]
     ++ optional gtkStyle dlopen-gtkstyle
-    ++ optional decryptSslTraffic decrypt-ssl-traffic;
+    ++ optional decryptSslTraffic decrypt-ssl-traffic
+    ++ optional mesaSupported mkspecs-libgl;
 
   preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/qtbase/lib:$PWD/qtbase/plugins/platforms:$PWD/qttools/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Try to build e.g. the Qt5 Camera Example[1] and see that qmake fails to
find <GL/gl.h>. This fixes it.

[1] http://doc.qt.io/qt-5/qtmultimediawidgets-camera-example.html
(Although since nixpkgs qtcreator still lacks 'examples', we have to
download the sources manually and use "qmake && make".)
