### PR TITLE
obs-studio: 0.11.1 -> 0.12.0

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -17,11 +17,11 @@ let
   optional = stdenv.lib.optional;
 in stdenv.mkDerivation rec {
   name = "obs-studio-${version}";
-  version = "0.11.1";
+  version = "0.12.0";
 
   src = fetchurl {
     url = "https://github.com/jp9000/obs-studio/archive/${version}.tar.gz";
-    sha256 = "12g1y6y8ixvgvwk75x7qgq0j06d5khd0w3if6kahswlc58q65fm8";
+    sha256 = "0nkfzy9wzsy7y0r02vc0648gx2aa6f7ibahrv89hxqr4x6x8d7di";
   };
 
   buildInputs = [ cmake
@@ -53,3 +53,4 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl2;
   };
 }
+


### PR DESCRIPTION
it does compile on x86_64 but doesn't start (at least in VirtualBox, like the previous version).

could someone test it on real hardware? `nox-review pr 10105`

maybe the video driver must be included in the Input?

also, is there an option that the build knows it's correct version? `info: OBS 0.0.1 (linux)`

@jb55 

```
[davidak@nixos:~]$ obs 
Attempted path: share/obs/obs-studio/locale/en-US.ini
Attempted path: /nix/store/4jrqmzjaqxjm42ppwalnpkaq8cz1hm7y-obs-studio-0.12.0/share/obs/obs-studio/locale/en-US.ini
Attempted path: share/obs/obs-studio/locale.ini
Attempted path: /nix/store/4jrqmzjaqxjm42ppwalnpkaq8cz1hm7y-obs-studio-0.12.0/share/obs/obs-studio/locale.ini
Attempted path: share/obs/obs-studio/locale/de-DE.ini
Attempted path: /nix/store/4jrqmzjaqxjm42ppwalnpkaq8cz1hm7y-obs-studio-0.12.0/share/obs/obs-studio/locale/de-DE.ini
info: Using preferred locale 'de-DE'
Attempted path: share/obs/obs-studio/themes/Default.qss
Attempted path: /nix/store/4jrqmzjaqxjm42ppwalnpkaq8cz1hm7y-obs-studio-0.12.0/share/obs/obs-studio/themes/Default.qss
Attempted path: share/obs/obs-studio/license/gplv2.txt
Attempted path: /nix/store/4jrqmzjaqxjm42ppwalnpkaq8cz1hm7y-obs-studio-0.12.0/share/obs/obs-studio/license/gplv2.txt
info: Processor: 8 logical cores
info: Processor: Intel(R) Core(TM) i7 CPU         870  @ 2.93GHz
info: Physical Memory: 2006MB Total
info: Kernel Version: Linux 3.18.21
info: Distribution: NixOS "15.09.343.1b83abb"
QObject::connect: invalid null parameter
info: OBS 0.0.1 (linux)
info: ---------------------------------
info: ---------------------------------
info: audio settings reset:
    samples per sec: 44100
    speakers:        2
    buffering (ms):  1000
pci id for fd 13: 80ee:beef, driver (null)
libGL error: unable to load driver: vboxvideo_dri.so
libGL error: driver pointer missing
libGL error: failed to load driver: vboxvideo
error: ARB_GLX_create_context not supported!
error: Failed to create context!
error: device_create (GL) failed
error: Failed to initialize video:  Unspecified error
pci id for fd 12: 80ee:beef, driver (null)
libGL error: unable to load driver: vboxvideo_dri.so
libGL error: driver pointer missing
libGL error: failed to load driver: vboxvideo
info: Freeing OBS context data
info: == Profiler Results =============================
info: run_program_init: 24254,2 ms
info:  ┣OBSApp::AppInit: 1,71 ms
info:  ┃ ┗OBSApp::InitLocale: 1,347 ms
info:  ┗OBSApp::OBSInit: 1306,64 ms
info:    ┣obs_startup: 83,3 ms
info:    ┗OBSBasic::OBSInit: 541,636 ms
info:      ┣OBSBasic::InitBasicConfig: 0,963 ms
info:      ┣OBSBasic::ResetAudio: 0,238 ms
info:      ┗OBSBasic::ResetVideo: 540,309 ms
info: obs_hotkey_thread(25 ms): min=0,437 ms, median=0,765 ms, max=34,64 ms, 99th percentile=2,616 ms, 99,8836% below 25 ms
info: audio_thread(Audio): min=0,006 ms, median=0,012 ms, max=1,681 ms, 99th percentile=0,093 ms
info: =================================================
info: == Profiler Time Between Calls ==================
info: obs_hotkey_thread(25 ms): min=25,606 ms, median=26,043 ms, max=59,85 ms, 0% within ±2% of 25 ms (0% lower, 100% higher)
info: =================================================
info: Number of memory leaks: 124
```
