### PR TITLE
python27: ensure multiprocessing being built with darwin sandbox

### DIFF
--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -80,6 +80,7 @@ let
     "ac_cv_func_bind_textdomain_codeset=yes"
   ] ++ optionals stdenv.isDarwin [
     "--disable-toolbox-glue"
+    "ac_cv_posix_semaphores_enabled=yes"
   ];
 
   postConfigure = if stdenv.isCygwin then ''


### PR DESCRIPTION
Would fix #10092

Without this, when python is built with chroot enabled on darwin with stdenvDarwinPure, python is built without multiuprocessing support, because configure fails to test platform semaphore support, effectively resulting

```
>>> import multiprocessing
>>> multiprocessing.RLock()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/nr4yvydamabs72m4yzr8xzjniqfk9vjj-python-2.7.10/lib/python2.7/multiprocessing/__init__.py", line 182, in RLock
    from multiprocessing.synchronize import RLock
  File "/nix/store/nr4yvydamabs72m4yzr8xzjniqfk9vjj-python-2.7.10/lib/python2.7/multiprocessing/synchronize.py", line 59, in <module>
    " function, see issue 3770.")
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.
```

This enforces the required configure flag to always build multiprocessing on darwin.
