### PR TITLE
network-manager 1.0.2 -> 1.0.6

### DIFF
--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pn}/${major}/${name}.tar.xz";
-    sha256 = "1afri2zln5p59660hqzbwm2r8phx9inrm2bgp5scynzs8ddzh2kn";
+    sha256 = "1yj0m6fb9v12d0di0rfmk3hx1vmygjkiff2c476rf792sbh56kax";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ];

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "network-manager-${version}";
-  version = "1.0.2";
+  version = "1.0.6";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/1.0/NetworkManager-${version}.tar.xz";
-    sha256 = "1zq8jm1rc7n7amqa9xz1v93w2jnczg6942gyijsdpgllfiq8b4rm";
+    sha256 = "38ea002403e3b884ffa9aae25aea431d2a8420f81f4919761c83fb92648254bd";
   };
 
   preConfigure = ''
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ dbus_glib gnutls libgcrypt ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
+
+  patches = [ ./nm-platform.patch ];
 
   preInstall =
     ''

--- a/pkgs/tools/networking/network-manager/nm-platform.patch
+++ b/pkgs/tools/networking/network-manager/nm-platform.patch
@@ -1,0 +1,17 @@
+diff --git a/src/platform/nm-platform.c b/src/platform/nm-platform.c
+index 8803377..14e5726 100644
+--- a/src/platform/nm-platform.c
++++ b/src/platform/nm-platform.c
+@@ -39,6 +39,12 @@
+ #include "nm-enum-types.h"
+ #include "nm-core-internal.h"
+
++#if HAVE_LIBNL_INET6_ADDR_GEN_MODE && HAVE_KERNEL_INET6_ADDR_GEN_MODE
++#include <linux/if_link.h>
++#else
++#define IN6_ADDR_GEN_MODE_NONE  1
++#endif
++
+ #define ADDRESS_LIFETIME_PADDING 5
+
+ G_STATIC_ASSERT (sizeof ( ((NMPlatformLink *) NULL)->addr.data ) == NM_UTILS_HWADDR_LEN_MAX);

--- a/pkgs/tools/networking/network-manager/openconnect.nix
+++ b/pkgs/tools/networking/network-manager/openconnect.nix
@@ -4,7 +4,9 @@
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname = "NetworkManager-openconnect";
-  version = networkmanager.version;
+  version = "1.0.2";
+
+# FixMe: Change version back to "networkmanager.version"
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/1.0/${pname}-${version}.tar.xz";

--- a/pkgs/tools/networking/network-manager/openvpn.nix
+++ b/pkgs/tools/networking/network-manager/openvpn.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/1.0/${pname}-${version}.tar.xz";
-    sha256 = "1c2b74xhkjifc3g6n53gr2aj4s98qf0vydmqvbhl5azxqx5q4hqn";
+    sha256 = "132xwkgyfnpma7m6b06jhrd1g9xk5dlpx8alnsf03ls3z92bd0n9";
   };
 
   buildInputs = [ openvpn networkmanager libsecret ]

--- a/pkgs/tools/networking/network-manager/pptp.nix
+++ b/pkgs/tools/networking/network-manager/pptp.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/1.0/${pname}-${version}.tar.xz";
-    sha256 = "05r06f7f990z908jjnmmryrlshy28wcx7fbvnslmx9nicih7rjrp";
+    sha256 = "1gn1f8r32wznk4rsn2lg2slw1ccli00svz0fi4bx0qiylimlbyln";
   };
 
   buildInputs = [ networkmanager pptp ppp libsecret ]

--- a/pkgs/tools/networking/network-manager/vpnc.nix
+++ b/pkgs/tools/networking/network-manager/vpnc.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/1.0/${pname}-${version}.tar.xz";
-    sha256 = "0055vshgnva969vb91k8zpdan34r9gy0ck3q3b9b616k0p2vy5ry";
+    sha256 = "0hycplnc78688sgpzdh3ifra6chascrh751mckqkp1j553bri0jk";
   };
 
   buildInputs = [ vpnc networkmanager libsecret ]


### PR DESCRIPTION
Updated everything except network-manager-openconnect, as there is no newer version.
nm-platform.patch is from https://mail.gnome.org/archives/networkmanager-list/2015-July/msg00026.html
