### PR TITLE
fetch-cargo-deps: sh -> bash

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-deps
+++ b/pkgs/build-support/rust/fetch-cargo-deps
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 source $stdenv/setup
 


### PR DESCRIPTION
`fetch-cargo-deps` actually uses `bash` features, and should invoke `bash` instead.

I noticed this while using a nix-daemon on a Debian system and noticing a non-reproducible build failure since `fetch-cargo-deps` is run from within nix rather than as part of the build process, and so `/bin/sh` was not rewritten to a nix `/bin/sh`. On Debian `/bin/sh` points to `dash`, which does not have full `bash` compatibility.

While we should probably find a way to make it use `/bin/sh` from nix rather than the system one, it should at a minimum be using `bash` since it uses `bash` only features.
