### PR TITLE
capnproto: 0.5.1.2 -> 0.5.3

### DIFF
--- a/pkgs/development/libraries/capnproto/default.nix
+++ b/pkgs/development/libraries/capnproto/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "capnproto-${version}";
-  version = "0.5.1.2";
+  version = "0.5.3";
 
   src = fetchurl {
     url = "https://capnproto.org/capnproto-c++-${version}.tar.gz";
-    sha256 = "0a89v6sigsyj9vii0d5kqs2fdv73r71f8czzhdvqdvk3p0mlcgx2";
+    sha256 = "1yvaadhgakskqq5wpv53hd6fc3pp17mrdldw4i5cvgck4iwprcfd";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Bump revision of capnproto to the latest.
