### PR TITLE
ruby: change the default gem download location

### DIFF
--- a/pkgs/development/interpreters/ruby/bundler-env/default.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default.nix
@@ -25,7 +25,7 @@ let
 
   fetchers.path = attrs: attrs.source.path;
   fetchers.gem = attrs: fetchurl {
-    url = "${attrs.source.source or "https://rubygems.org"}/downloads/${gemName attrs}";
+    url = "${attrs.source.source or "https://rubygems.org"}/gems/${gemName attrs}";
     inherit (attrs.source) sha256;
   };
   fetchers.git = attrs: fetchgit {

--- a/pkgs/development/interpreters/ruby/gem.nix
+++ b/pkgs/development/interpreters/ruby/gem.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (attrs // {
   src = if attrs ? src
     then attrs.src
     else fetchurl {
-      url = "http://rubygems.org/downloads/${attrs.name}.gem";
+      url = "http://rubygems.org/gems/${attrs.name}.gem";
       inherit (attrs) sha256;
     };
 

--- a/pkgs/development/interpreters/ruby/load-ruby-env.nix
+++ b/pkgs/development/interpreters/ruby/load-ruby-env.nix
@@ -33,7 +33,7 @@ let
 
   fetchers.path = attrs: attrs.src.path;
   fetchers.gem = attrs: fetchurl {
-    url = "${attrs.src.source or "https://rubygems.org"}/downloads/${attrs.name}-${attrs.version}.gem";
+    url = "${attrs.src.source or "https://rubygems.org"}/gems/${attrs.name}-${attrs.version}.gem";
     inherit (attrs.src) sha256;
   };
   fetchers.git = attrs: fetchgit {


### PR DESCRIPTION
Triggers a massive rebuild of gem-based packages.

Using `${baseRemote}/gems/${name}-${version}.gem` will make the fetchers
work against private gem repositories like Sonatype Nexua and Geminabox.

Rubygems use this base location by default as written in
https://github.com/rubygems/rubygems/blob/master/lib/rubygems/remote_fetcher.rb#L173 .
