### PR TITLE
kibana: fix url and hash

### DIFF
--- a/pkgs/development/tools/misc/kibana/default.nix
+++ b/pkgs/development/tools/misc/kibana/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   version = "4.1.2";
 
   src = fetchurl {
-    url = "http://download.elastic.co/kibana/kibana-snapshot/kibana-4.2.0-snapshot-linux-x86.tar.gz";
-    sha256 = "1sa92laawxc05abiysvp12v5nzrqggmls592mkprwnbkkkbwsm5x";
+    url = "http://download.elastic.co/kibana/kibana-snapshot/${name}-snapshot-linux-x86.tar.gz";
+    sha256 = "00ag4wnlw6h2j6zcz0irz6j1s51fr9ix2g1smrhrdw44z5gb6wrh";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
the package now builds successfully on linux x86_64.

but i don't know if it's actual usable. i don't know the software and how to use it.

```
$ kibana
/nix/store/sdi8713i9av6rx4pkydggqyidp7mdc08-kibana-4.1.2/libexec/kibana/bin/kibana: Zeile 20: /nix/store/sdi8713i9av6rx4pkydggqyidp7mdc08-kibana-4.1.2/libexec/kibana/bin/../node/bin/node: No such file or directory
```

it seams it needs nodejs as a dependency.

build:

```
unpacking source archive /nix/store/kmx1sr29nnji0h76845qqj9r3n8b54f8-kibana-4.1.2-snapshot-linux-x86.tar.gz
source root is kibana-4.1.2-snapshot-linux-x86
patching sources
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
post-installation fixup
patching ELF executables and libraries in /nix/store/sdi8713i9av6rx4pkydggqyidp7mdc08-kibana-4.1.2
/nix/store/sdi8713i9av6rx4pkydggqyidp7mdc08-kibana-4.1.2/bin/kibana
not an ELF executable
```

@offlinehacker @rickynils 
