### PR TITLE
clamav: Use freshclam.conf defined by clamav-updater module if enabled

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl
-, libmilter, pcre }:
+, libmilter, pcre, freshclamConf ? null }:
+
 stdenv.mkDerivation rec {
   name = "clamav-${version}";
   version = "0.99";
@@ -23,6 +24,8 @@ stdenv.mkDerivation rec {
     "--enable-milter"
     "--disable-clamav"
   ];
+
+  fixupPhase = if (freshclamConf != null) then ''echo "${freshclamConf}" > $out/etc/freshclam.conf'' else "";
 
   meta = with stdenv.lib; {
     homepage = http://www.clamav.net;


### PR DESCRIPTION
clamav dosen't work at all without a freshclam.conf file (running clamscan complains about missing files, then reports zero files scanned). clamav-updater defines one, so if it's enabled then it should be used.
