### PR TITLE
python-packages: pygit2 0.21.2 -> 0.23.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10940,11 +10940,11 @@ let
   };
 
   pygit2 = buildPythonPackage rec {
-    name = "pygit2-0.21.2";
+    name = "pygit2-0.23.1";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/p/pygit2/${name}.tar.gz";
-      sha256 = "0lya4v91d4y5fwrb55n8m8avgmz0l81jml2spvx6r7j1czcx3zic";
+      sha256 = "04201vcal7jq8lbpk9ylscrhjxdcf2aihiw25k4imjjqgfmvldf7";
     };
 
     preConfigure = ( if stdenv.isDarwin then ''


### PR DESCRIPTION
Update pygit2 with latest and compatible version with libgit2 (in master at [0.23.2](https://github.com/NixOS/nixpkgs/blob/4f798100d82d346c6983c68969cb449ad1c53bac/pkgs/development/libraries/git2/default.nix#L4)).

There is a compatibility requirement according to [their documentation](http://www.pygit2.org/install.html#requirements) and it's real :D.

``` sh
# tony at corellia in ~/repo/perso/nixpkgs on git:update-python-package-pygit2 x [12:04:59]
$ nix-build -A python3Packages.pygit2
/nix/store/h7symli8zhh9p8ign279i5bybgj62c2z-python3.4-pygit2-0.23.1

# tony at corellia in ~/repo/perso/nixpkgs on git:update-python-package-pygit2 x [12:05:00]
$ tree result
result
├── lib
│   └── python3.4
│       └── site-packages
│           ├── pygit2
│           │   ├── blame.py
│           │   ├── config.py
│           │   ├── credentials.py
│           │   ├── decl.h
│           │   ├── errors.py
│           │   ├── ffi.py
│           │   ├── index.py
│           │   ├── __init__.py
│           │   ├── libgit2_build.py
│           │   ├── _libgit2.cpython-34m.so
│           │   ├── py2.py
│           │   ├── py3.py
│           │   ├── __pycache__
│           │   │   ├── blame.cpython-34.pyc
│           │   │   ├── config.cpython-34.pyc
│           │   │   ├── credentials.cpython-34.pyc
│           │   │   ├── errors.cpython-34.pyc
│           │   │   ├── ffi.cpython-34.pyc
│           │   │   ├── index.cpython-34.pyc
│           │   │   ├── __init__.cpython-34.pyc
│           │   │   ├── libgit2_build.cpython-34.pyc
│           │   │   ├── py2.cpython-34.pyc
│           │   │   ├── py3.cpython-34.pyc
│           │   │   ├── refspec.cpython-34.pyc
│           │   │   ├── remote.cpython-34.pyc
│           │   │   ├── repository.cpython-34.pyc
│           │   │   ├── settings.cpython-34.pyc
│           │   │   ├── submodule.cpython-34.pyc
│           │   │   └── utils.cpython-34.pyc
│           │   ├── refspec.py
│           │   ├── remote.py
│           │   ├── repository.py
│           │   ├── settings.py
│           │   ├── submodule.py
│           │   └── utils.py
│           ├── pygit2-0.23.1-py3.4.egg-info
│           │   ├── dependency_links.txt
│           │   ├── not-zip-safe
│           │   ├── PKG-INFO
│           │   ├── requires.txt
│           │   ├── SOURCES.txt
│           │   └── top_level.txt
│           ├── _pygit2.cpython-34m.so
│           └── python3.4-pygit2-0.23.1-nix-python-propagated-native-build-inputs.pth
└── nix-support
└── propagated-native-build-inputs

7 directories, 43 files
```
