### PR TITLE
jackmix: add to nixpkgs

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -144,6 +144,7 @@
   jwilberding = "Jordan Wilberding <jwilberding@afiniate.com>";
   jzellner = "Jeff Zellner <jeffz@eml.cc>";
   kamilchm = "Kamil Chmielewski <kamil.chm@gmail.com>";
+  kampfschlaefer = "Arnold Krille <arnold@arnoldarts.de>";
   khumba = "Bryan Gardiner <bog@khumba.net>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   koral = "Koral <koral@mailoo.org>";

--- a/pkgs/applications/audio/jackmix/default.nix
+++ b/pkgs/applications/audio/jackmix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgs }:
+{ stdenv, fetchurl, pkgs, jack ? pkgs.libjack2 }:
 
 stdenv.mkDerivation rec {
   name = "jackmix-0.5.2";
@@ -11,9 +11,8 @@ stdenv.mkDerivation rec {
     pkgs.pkgconfig
     pkgs.scons
     pkgs.kde4.qt4
-    pkgs.jack1
     pkgs.lash
-    pkgs.libuuid # should be a propagatedBuildInput on jack1
+    jack
   ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/jackmix/default.nix
+++ b/pkgs/applications/audio/jackmix/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgs }:
+
+stdenv.mkDerivation rec {
+  name = "jackmix-0.5.2";
+  src = fetchurl {
+    url = https://github.com/kampfschlaefer/jackmix/archive/v0.5.2.tar.gz;
+    sha256 = "18f5v7g66mgarhs476frvayhch7fy4nyjf2xivixc061ipn0m82j";
+  };
+
+  buildInputs = [
+    pkgs.pkgconfig
+    pkgs.scons
+    pkgs.kde4.qt4
+    pkgs.jack1
+    pkgs.lash
+    pkgs.libuuid # should be a propagatedBuildInput on jack1
+  ];
+
+  buildPhase = ''
+    scons
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp jackmix/jackmix $out/bin
+  '';
+
+  meta = {
+    description = "Matrix-Mixer for the Jack-Audio-connection-Kit";
+    homepage = http://www.arnoldarts.de/jackmix/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.kampfschlaefer ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}
+
+

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, python, makeWrapper
-, bash, libsamplerate, libsndfile, readline
+, bash, libsamplerate, libsndfile, libuuid, readline
 
 # Optional Dependencies
 , dbus ? null, pythonDBus ? null, libffado ? null, alsaLib ? null
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
 
     optDbus optPythonDBus optLibffado optAlsaLib optLibopus
   ];
+  propagatedBuildInputs = [ libuuid ];
 
   prePatch = ''
     substituteInPlace svnversion_regenerate.sh --replace /bin/bash ${bash}/bin/bash

--- a/pkgs/misc/jackaudio/jack1.nix
+++ b/pkgs/misc/jackaudio/jack1.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ optAlsaLib optDb optLibuuid optLibffado optCelt ];
+  buildInputs = [ optAlsaLib optDb optLibffado optCelt ];
+  propagatedBuildInputs = [ optLibuuid ];
   
   meta = with stdenv.lib; {
     description = "JACK audio connection kit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11803,6 +11803,7 @@ let
   jackmeter = callPackage ../applications/audio/jackmeter { };
 
   jackmix = callPackage ../applications/audio/jackmix { };
+  jackmix_jack1 = jackmix.override { jack = jack1; };
 
   jalv = callPackage ../applications/audio/jalv { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11802,6 +11802,8 @@ let
 
   jackmeter = callPackage ../applications/audio/jackmeter { };
 
+  jackmix = callPackage ../applications/audio/jackmix { };
+
   jalv = callPackage ../applications/audio/jalv { };
 
   jedit = callPackage ../applications/editors/jedit { };


### PR DESCRIPTION
My first real nix package.

One question (also in the source): jack needs libuuid, thus all packages compiling against it also need libuuid (for the headers). So shouldn't libuuid be a propagatedBuildInput for jack[12] instead of a buildInput?

Thanks to @garbas and the devops-sprint in Halle;-)
