### PR TITLE
ghcWithPackages: change name to differentiate from ghc

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -47,7 +47,7 @@ let
 in
 if paths == [] && !withLLVM then ghc else
 buildEnv {
-  inherit (ghc) name;
+  name = "ghc-with-packages-${ghc.version}";
   paths = paths ++ [ghc];
   inherit ignoreCollisions;
   postBuild = ''


### PR DESCRIPTION
Whenever I see `building /nix/store/${hash}-ghc-${version}`, I fear I've done something wrong. Using "-wrapper-"  might be another way, but I took what is in the attribute name. It's also unclear to me whether to preserve the version in the name.

/cc @peti. This is also meant for 15.09.
