### PR TITLE
openfire: Fix JVM test

### DIFF
--- a/pkgs/servers/xmpp/openfire/default.nix
+++ b/pkgs/servers/xmpp/openfire/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ jre ];
 
   installPhase = ''
-    sed -e 's@\(common_jvm_locations\)=.*@\1${jre}@' -i bin/openfire
+    sed -e 's@\(common_jvm_locations=\).*@\1${jre}@' -i bin/openfire
     cp -r . $out
     rm -r $out/logs
     mv $out/conf $out/conf.inst


### PR DESCRIPTION
The openfire expression deletes an `=` symbol in the openfire launch script, thereby breaking it.  This PR fixes it.
