### PR TITLE
sshd service: allow override of AuthorizedKeysFiles

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -192,8 +192,8 @@ in
 
       authorizedKeysFiles = mkOption {
         type = types.listOf types.str;
-        default = [];
-        description = "Files from with authorized keys are read.";
+        default = [ ".ssh/authorized_keys" ".ssh/authorized_keys2" "/etc/ssh/authorized_keys.d/%u" ];
+        description = "Files from which authorized keys are read.";
       };
 
       extraConfig = mkOption {
@@ -298,9 +298,6 @@ in
         showMotd = true;
         unixAuth = cfg.passwordAuthentication;
       };
-
-    services.openssh.authorizedKeysFiles =
-      [ ".ssh/authorized_keys" ".ssh/authorized_keys2" "/etc/ssh/authorized_keys.d/%u" ];
 
     services.openssh.extraConfig =
       ''


### PR DESCRIPTION
When this option was added in 2012, the default passed to mkOption was an empty list, which was reflected in the documentation, but the actual setting was hardcoded so that it could not be overridden.

It may be useful to add a note that if services.openssh.authorizedKeysFiles is overridden,

``` nix
users.users.<name?>.openssh.authorizedKeys
```

values may not work.
