### PR TITLE
claws-mail: fix issues with hicolor-icon-theme and shared-mime-info

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = [ maintainers.khumba ];
+    priority = 10;  # Resolve the conflict with the share/mime link we create.
   };
 
   src = fetchurl {

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv
-, curl, dbus, dbus_glib, enchant, gtk, gnutls, gnupg, gpgme, libarchive
-, libcanberra, libetpan, libnotify, libsoup, libxml2, networkmanager, openldap
-, perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk2
+, curl, dbus, dbus_glib, enchant, gtk, gnutls, gnupg, gpgme, hicolor_icon_theme
+, libarchive, libcanberra, libetpan, libnotify, libsoup, libxml2, networkmanager
+, openldap , perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk2
 
 # Build options
 # TODO: A flag to build the manual.
@@ -50,7 +50,9 @@ stdenv.mkDerivation {
   patches = [ ./mime.patch ];
 
   buildInputs =
-    [ curl dbus dbus_glib gtk gnutls libetpan perl pkgconfig python ]
+    [ curl dbus dbus_glib gtk gnutls hicolor_icon_theme
+      libetpan perl pkgconfig python
+    ]
     ++ optional enableSpellcheck enchant
     ++ optionals (enablePgp || enablePluginSmime) [ gnupg gpgme ]
     ++ optional enablePluginArchive libarchive


### PR DESCRIPTION
- Claws is installing a `~/.nix-profile/share/icons/hicolor/icon-theme.cache`, which conflicts with other packages doing so, and which hicolor-icon-theme hooks should remove.
- Fixes Claws's inability to be installed in a user environment with shared-mime-info (#10156).
