### PR TITLE
nixos-install: Don't use NIX_BUILD_HOOK from caller's environment

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -188,6 +188,9 @@ mkdir -m 0755 -p $mountPoint/bin
 ln -sf @shell@ $mountPoint/bin/sh
 
 
+# Build hooks likely won't function correctly in the minimal chroot; just disable them.
+unset NIX_BUILD_HOOK
+
 # Make the build below copy paths from the CD if possible.  Note that
 # /tmp/root in the chroot is the root of the CD.
 export NIX_OTHER_STORES=/tmp/root/nix:$NIX_OTHER_STORES


### PR DESCRIPTION
If nixos-install is run on a machine with `nix.distributedBuilds = true`
the installation will fail at some point like this:

```
Died at /nix/store/4frhrl31cl7iahlz6vyvysy5dmr6xnh3-nix-1.10/libexec/nix/build-remote.pl line 115, <STDIN> line 1.
```

This is due to `nix.distributedBuilds` setting
`NIX_BUILD_HOOK=/nix/store/.../build-remote.pl` in the global environment,
which then gets confused in the minimal chroot created by nixos-install.

To avoid these kinds of issues with build hooks, just disable them in
the chroot.
