### PR TITLE
[python+emacs packages] Update elpy environment

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11287,6 +11287,7 @@ let
 
     external = {
       inherit (haskellPackages) ghc-mod structured-haskell-mode Agda;
+      inherit (pythonPackages) elpy;
     };
   };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -442,7 +442,7 @@ let self = _self // overrides;
 
   elpy = melpaBuild rec {
     pname   = "elpy";
-    version = "1.9.0";
+    version = external.elpy.version;
     src = fetchFromGitHub {
       owner  = "jorgenschaefer";
       repo   = pname;
@@ -464,6 +464,8 @@ let self = _self // overrides;
     packageRequires = [
       company find-file-in-project highlight-indentation pyvenv yasnippet
     ];
+
+    propagatedUserEnvPkgs = [ external.elpy ] ++ packageRequires;
 
     meta = {
       description = "Emacs Python Development Environment";

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -440,6 +440,42 @@ let self = _self // overrides;
     };
   };
 
+  elpy = melpaBuild rec {
+    pname   = "elpy";
+    version = "1.9.0";
+    src = fetchFromGitHub {
+      owner  = "jorgenschaefer";
+      repo   = pname;
+      rev    = "39ea47c73f040ce8dcc1c2d2639ebc0eb57ab8c8";
+      sha256 = "0q3av1qv4m6aj4bil608f688hjpr5px8zqnnrdqx784nz98rpjrs";
+    };
+
+    patchPhase = ''
+      for file in elpy.el elpy-pkg.el; do
+        substituteInPlace $file \
+            --replace "company \"0.8.2\"" "company \"${company.version}\"" \
+            --replace "find-file-in-project \"3.3\"" "find-file-in-project \"${find-file-in-project.version}\"" \
+            --replace "highlight-indentation \"0.5.0\"" "highlight-indentation \"${highlight-indentation.version}\"" \
+            --replace "pyvenv \"1.3\"" "pyvenv \"${pyvenv.version}\"" \
+            --replace "yasnippet \"0.8.0\"" "yasnippet \"${yasnippet.version}\""
+     done
+    '';
+
+    packageRequires = [
+      company find-file-in-project highlight-indentation pyvenv yasnippet
+    ];
+
+    meta = {
+      description = "Emacs Python Development Environment";
+      longDescription = ''
+        Elpy is an Emacs package to bring powerful Python editing to Emacs.
+        It combines a number of other packages, both written in Emacs Lisp as
+        well as Python.
+      '';
+      license = gpl3Plus;
+    };
+  };
+
   engine-mode = melpaBuild rec {
     pname = "engine-mode";
     version = "1.0.0";

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -852,6 +852,30 @@ let self = _self // overrides;
     meta = { license = gpl3Plus; };
   };
 
+  highlight-indentation = melpaBuild rec {
+    pname = "highlight-indentation";
+    version = "0.7.0";
+    src = fetchFromGitHub {
+      owner = "antonj";
+      repo = "Highlight-Indentation-for-Emacs";
+      rev = "v${version}";
+      sha256 = "00l54k75qk24a0znzl4ij3s3nrnr2wy9ha3za8apphzlm98m907k";
+    };
+    meta = {
+      description = "Minor modes to highlight indentation guides in emacs";
+      longDescription = ''
+        Provides two minor modes highlight-indentation-mode and
+        highlight-indentation-current-column-mode
+
+        - highlight-indentation-mode displays guidelines indentation
+        (space indentation only).
+        - highlight-indentation-current-column-mode displays guidelines for the
+        current-point indentation (space indentation only).
+      '';
+      license = gpl2Plus;
+    };
+  };
+
   ibuffer-vc = melpaBuild rec {
     pname   = "ibuffer-vc";
     version = "0.10";

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1506,6 +1506,29 @@ let self = _self // overrides;
     meta = { license = gpl3Plus; };
   };
 
+  yasnippet = melpaBuild rec {
+    pname = "yasnippet";
+    version = "0.8.1";
+    src = fetchFromGitHub {
+      owner  = "capitaomorte";
+      repo   = pname;
+      rev    = "01139a2deb9eda272b9b771fbbe15d096061efa4";
+      sha256 = "1b0bxzkmw7yd1yf6326zf52aq63n283vy57pysj8cc34d9bk6nnk";
+    };
+    meta = {
+      description = "A template system for Emacs";
+      longDescription = ''
+        YASnippet is a template system for Emacs.
+        It allows you to type an abbreviation and automatically expand it into
+        function templates. Bundled language templates include: C, C++, C#,
+        Perl, Python, Ruby, SQL, LaTeX, HTML, CSS and more.
+        The snippet syntax is inspired from TextMate's syntax, you can even import
+        most TextMate templates to YASnippet.
+      '';
+      license = gpl2Plus;
+    };
+  };
+
   zenburn-theme = melpaBuild rec {
     pname   = "zenburn-theme";
     version = "2.2";

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1233,6 +1233,25 @@ let self = _self // overrides;
     meta = { license = gpl3Plus; };
   };
 
+  pyvenv = melpaBuild rec {
+    pname = "pyvenv";
+    version = "1.7";
+    src = fetchFromGitHub {
+      owner  = "jorgenschaefer";
+      repo   = pname;
+      rev    = "e4f2fa7a32cf480f34d628d8eb5b9b60374d0e8e";
+      sha256 = "1669id1p69kpq8zzldxj1p6iyz68701snn462g22k2acfzc2bfha";
+    };
+    meta = {
+      description = "Python virtual environment interface for Emacs";
+      longDescription = ''
+        This is a simple global minor mode which will replicate the changes done
+        by virtualenv activation inside Emacs.
+      '';
+      license = gpl2Plus;
+    };
+  };
+
   rainbow-delimiters = melpaBuild rec {
     pname = "rainbow-delimiters";
     version = "2.1.1";

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -571,6 +571,26 @@ let self = _self // overrides;
     };
   };
 
+  find-file-in-project = melpaBuild rec {
+    pname = "find-file-in-project";
+    version = "3.5";
+    src = fetchFromGitHub {
+      owner  = "technomancy";
+      repo   = pname;
+      rev    = "53a8d8174f915d9dcf5ac6954b1c0cae61266177";
+      sha256 = "0wky8vqg08iw34prbz04bqmhfhj82y93swb8zkz6la2vf9da0gmd";
+    };
+    meta = {
+      description = "Quick access to project files in Emacs";
+      longDescription = ''
+        Find files in a project quickly.
+        This program provides a couple methods for quickly finding any file in a
+        given project. It depends on GNU find.
+      '';
+      license = gpl3Plus;
+    };
+  };
+
   flim = melpaBuild rec {
     pname = "flim";
     version = "1.14.9"; # 20141216

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5820,10 +5820,11 @@ let
 
 
   elpy = buildPythonPackage rec {
-    name = "elpy-1.0.1";
+    name = "elpy-${version}";
+    version = "1.9.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/elpy/elpy-1.0.1.tar.gz";
-      md5 = "5453f085f7871ed8fc11d51f0b68c785";
+      url = "https://pypi.python.org/packages/source/e/elpy/${name}.tar.gz";
+      md5 = "651f6f46767b7132e5c0f83d5ac3b1f7";
     };
     propagatedBuildInputs = with self; [ flake8 ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18470,4 +18470,24 @@ let
     };
   };
 
+  importmagic = buildPythonPackage rec {
+    simpleName = "importmagic";
+    name = "${simpleName}-${version}";
+    version = "0.1.3";
+    doCheck = false;  # missing json file from tarball
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/i/${simpleName}/${name}.tar.gz";
+      sha256 = "194bl8l8sc2ibwi6g5kz6xydkbngdqpaj6r2gcsaw1fc73iswwrj";
+    };
+
+    propagatedBuildInputs = with self; [ six ];
+
+    meta = {
+      description = "Python Import Magic - automagically add, remove and manage imports";
+      homepage = http://github.com/alecthomas/importmagic;
+      license = "bsd";
+    };
+  };
+
 }; in pythonPackages

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5826,7 +5826,8 @@ let
       url = "https://pypi.python.org/packages/source/e/elpy/${name}.tar.gz";
       md5 = "651f6f46767b7132e5c0f83d5ac3b1f7";
     };
-    propagatedBuildInputs = with self; [ flake8 ];
+    python2Deps = if isPy3k then [ ] else [ self.rope ];
+    propagatedBuildInputs = with self; [ flake8 autopep8 jedi importmagic ] ++ python2Deps;
 
     doCheck = false; # there are no tests
 


### PR DESCRIPTION
Add necessary runtime python and emacs-mode dependencies to have an elpy that works out of the box:
- [X] python-packages: importmagic init at 0.1.3  
- [X] python-packages: elpy 1.0.1 -> 1.9.0  
- [X] python-packages: elpy add runtime dependencies
- [X] emacs-packages: yasnippet init at 0.8.1  
- [X] emacs-packages: find-file-in-project init at 3.5  
- [X] emacs-packages: highlight-indentation init at 0.7.0  
- [X] emacs-packages: pyvenv init at 1.7  
- [X] emacs-packages: elpy init at 1.9.0  
- [X] emacs-packages: elpy add runtime dependencies on pythonpackages.elpy
