### PR TITLE
haskell: shared libs must be enabled for new ghcs

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -49,6 +49,12 @@
 
 assert editedCabalFile != null -> revision != null;
 
+# GHC >= 7.8 uses the platform's dynamic loader for loading packages
+# at runtime (used for interactive code evaluation, like done by GHCi
+# or TemplateHaskell), which requires that we build shared libraries
+# as well.
+assert (!(ghc.isGhcjs or false) && stdenv.lib.versionOlder "7.7" ghc.version) -> enableSharedLibraries;
+
 let
 
   inherit (stdenv.lib) optional optionals optionalString versionOlder


### PR DESCRIPTION
As noted in the comments, newer GHCs require that shared libraries are available for TH to work. Not enabling shared libraries leads to errors where GHC complains about missing shared libraries. This only adds an assertion, so it doesn't cause any rebuilts. 

/cc @peti
