### PR TITLE
iptraf-ng: init at 1.1.4

### DIFF
--- a/pkgs/applications/networking/iptraf-ng/default.nix
+++ b/pkgs/applications/networking/iptraf-ng/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.4";
+  name = "iptraf-ng-${version}";
+
+  src = fetchurl {
+    url = "https://fedorahosted.org/releases/i/p/iptraf-ng/${name}.tar.gz";
+    sha256 = "02gb8z9h2s6s1ybyikywz7jgb1mafdx88hijfasv3khcgkq0q53r";
+  };
+
+  buildInputs = [ ncurses ];
+
+  configurePhase = ''
+    ./configure --prefix=$out/usr --sysconfdir=$out/etc \
+                --localstatedir=$out/var --sbindir=$out/bin
+  '';
+
+  meta = {
+    description = "A console-based network monitoring utility (fork of iptraf)";
+    longDescription = ''
+      IPTraf-ng is a console-based network monitoring utility. IPTraf-ng
+      gathers data like TCP connection packet and byte counts, interface
+      statistics and activity indicators, TCP/UDP traffic breakdowns, and LAN
+      station packet and byte counts. IPTraf-ng features include an IP traffic
+      monitor which shows TCP flag information, packet and byte counts, ICMP
+      details, OSPF packet types, and oversized IP packet warnings; interface
+      statistics showing IP, TCP, UDP, ICMP, non-IP and other IP packet counts,
+      IP checksum errors, interface activity and packet size counts; a TCP and
+      UDP service monitor showing counts of incoming and outgoing packets for
+      common TCP and UDP application ports, a LAN statistics module that
+      discovers active hosts and displays statistics about their activity; TCP,
+      UDP and other protocol display filters so you can view just the traffic
+      you want; logging; support for Ethernet, FDDI, ISDN, SLIP, PPP, and
+      loopback interfaces; and utilization of the built-in raw socket interface
+      of the Linux kernel, so it can be used on a wide variety of supported
+      network cards.
+    '';
+    homepage = https://fedorahosted.org/iptraf-ng/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11775,6 +11775,8 @@ let
 
   iptraf = callPackage ../applications/networking/iptraf { };
 
+  iptraf-ng = callPackage ../applications/networking/iptraf-ng { };
+
   irssi = callPackage ../applications/networking/irc/irssi { };
 
   irssi_fish = callPackage ../applications/networking/irc/irssi/fish { };


### PR DESCRIPTION
This commit adds `iptraf-ng` which is a fork of `iptraf`. The original
has not been updated in ~10 years. This fork is more modern but
development is a bit slow (last update to master 15 months ago).
Nevertheless, unlike `iptraf` this one doesn't barf around and works
properly.
