### PR TITLE
nvidiabl: fix for kernel >= 4

### DIFF
--- a/pkgs/os-specific/linux/nvidiabl/default.nix
+++ b/pkgs/os-specific/linux/nvidiabl/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation {
     sha256 = "1c7ar39wc8jpqh67sw03lwnyp0m9l6dad469ybqrgcywdiwxspwj";
   };
 
+  patches = [ ./linux4compat.patch ];
+
   preConfigure = ''
     sed -i 's|/sbin/depmod|#/sbin/depmod|' Makefile
   '';

--- a/pkgs/os-specific/linux/nvidiabl/linux4compat.patch
+++ b/pkgs/os-specific/linux/nvidiabl/linux4compat.patch
@@ -1,0 +1,22 @@
+From 2bf6f08b2492cc04a2c39fdcb22a2d0c18963d1c Mon Sep 17 00:00:00 2001
+From: sonic414 <sonic414@gmail.com>
+Date: Tue, 28 Apr 2015 19:30:15 +0530
+Subject: [PATCH] strnicmp to strncasecmp in Linux 4.0.0
+
+---
+ nvidiabl-module.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nvidiabl-module.c b/nvidiabl-module.c
+index b789ea4..b306579 100644
+--- a/nvidiabl-module.c
++++ b/nvidiabl-module.c
+@@ -214,7 +214,7 @@ static int __init nvidiabl_init(void)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39)
+ 	
+ 	for (iii = 0 ; iii < sizeof(backlight_type_ids) ; iii++) {
+-		if (strnicmp(bl_type, backlight_type_ids[iii].id, sizeof(bl_type)) == 0) {
++		if (strncasecmp(bl_type, backlight_type_ids[iii].id, sizeof(bl_type)) == 0) {
+ 			props.type = backlight_type_ids[iii].type;
+ 			printk(KERN_INFO "nvidiabl: backlight type is %s\n", backlight_type_ids[iii].id);
+ 		}


### PR DESCRIPTION
This patch allows `nvidiabl` to compile with `linux >= 4`, while still continuing to compile with older versions. I tried locally with `linuxPackages` (3.18) and `linuxPackages_4_2`.

The patch has been reported upstream already https://github.com/guillaumezin/nvidiabl/pull/105

I would appreciate it if this patch can find its way into the `release-15.09` branch too (assuming that's where the `nixos-15.09` gets its updates from). 
