### PR TITLE
Rewrite `fetchgitLocal`

### DIFF
--- a/pkgs/build-support/fetchgitlocal/default.nix
+++ b/pkgs/build-support/fetchgitlocal/default.nix
@@ -1,23 +1,40 @@
 { runCommand, git, nix }: src:
 
-let hash = import (runCommand "head-hash.nix"
-  { dummy = builtins.currentTime;
-    preferLocalBuild = true; }
-''
-  cd ${toString src}
-  (${git}/bin/git show && ${git}/bin/git diff) > $out
-  hash=$(${nix}/bin/nix-hash $out)
-  echo "\"$hash\"" > $out
-''); in
+let
+  srcStr = toString src;
 
-runCommand "local-git-export"
-  { dummy = hash;
-    preferLocalBuild = true; }
-''
-  cd ${toString src}
-  mkdir -p "$out"
-  for file in $(${git}/bin/git ls-files); do
-    mkdir -p "$out/$(dirname $file)"
-    cp -d $file "$out/$file" || true # don't fail when trying to copy a directory
-  done
-''
+  # Adds the current directory (respecting ignored files) to the git store, and returns the hash
+  gitHashFile = runCommand "put-in-git" {
+      nativeBuildInputs = [ git ];
+      dummy = builtins.currentTime; # impure, do every time
+      preferLocalBuild = true;
+    } ''
+      cd ${srcStr}
+      ROOT=$(git rev-parse --show-toplevel) # path to repo
+
+      cp $ROOT/.git/index $ROOT/.git/index-user # backup index
+      git reset # reset index
+      git add . # add current directory
+
+      # hash of current directory
+      # remove trailing newline
+      git rev-parse $(git write-tree) \
+        | tr -d '\n' > $out
+
+      mv $ROOT/.git/index-user $ROOT/.git/index # restore index
+    '';
+
+  gitHash = builtins.readFile gitHashFile; # cache against git hash
+
+  nixPath = runCommand "put-in-nix" {
+      nativeBuildInputs = [ git ];
+      preferLocalBuild = true;
+    } ''
+      mkdir $out
+
+      # dump tar of *current directory* at given revision
+      git -C ${srcStr} archive --format=tar ${gitHash} \
+        | tar xvf - -C $out
+    '';
+
+in nixPath


### PR DESCRIPTION
For practical purposes, here are the changes in behavior:
- When fetching from a subdirectory of a repo, do not rebuild because of
  changes elsewhere in the repo
- Fetch (not-ignored) untracked files too

It does this by letting git hash and export the directory in question, which I believes makes for a cleaner implementation than the ad-hoc copying and hashing that was there before.

We have multiple library in our repo (see https://github.com/unisonweb/platform/blob/master/env.nix) and it was very annoying to needless rebuild everything if anything changes.

@pchiusano
