### PR TITLE
Fully support large file on x86-32

### DIFF
--- a/pkgs/tools/networking/vde2/default.nix
+++ b/pkgs/tools/networking/vde2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, libpcap, python }:
+{ stdenv, fetchurl, openssl, libpcap, python, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "vde2-2.3.2";
@@ -8,7 +8,24 @@ stdenv.mkDerivation rec {
     sha256 = "14xga0ib6p1wrv3hkl4sa89yzjxv7f1vfqaxsch87j6scdm59pr2";
   };
 
-  buildInputs = [ openssl libpcap python ];
+  buildInputs = [ openssl libpcap python autoreconfHook ];
+
+  # Fixes:
+  # Cannot resolve ctl dir path '...': Value too large for defined data type
+  # Do not apply to vdetaplib
+
+  postPatch = ''
+    for f in $(find . -name Makefile.am); do
+      if echo $f|grep -q vdetaplib; then
+        continue
+      fi
+
+      sed \
+        -e 's/AM_CPPFLAGS =/AM_CPPFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE/' \
+        -e 's/AM_CFLAGS =/AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE/' \
+        -i $f
+    done
+  '';
 
   meta = {
     homepage = http://vde.sourceforge.net/;


### PR DESCRIPTION
Need some feedback here.

I'm trying to run i686 nixos tests on my x64 machine. However the inodes on my filesystem are greater than 4gb hence I get this error:

```
Cannot resolve ctl dir path '/tmp/nix-build-vm-test-run-gnome3.drv-0/vde1.ctl': Value too 
large for defined data type
```

Which happens when tools (`vde_switch`) in this case, are not compiled with `-D_FILE_OFFSET_BITS=64`.

Also note that our stdenv tools also have problems when building nix packages itself, I sometimes see that error while building packages.

With this PR vde seems work fine on 64-bit filesystems, however somehow I broke qemu i686:

```
configure flags: --prefix=/nix/store/bb2db1gpi75zv2bd6zs5ga1vaga7mcq7-qemu-x86-only-2.4.0 --ena
ble-seccomp --smbd=smbd --audio-drv-list=alsa,pa,sdl, --sysconfdir=/etc --localstatedir=/var --
enable-spice --target-list=i386-softmmu,x86_64-softmmu --enable-linux-aio 
Disabling libtool due to broken toolchain support

ERROR: User requested feature libseccomp
       configure was not able to find it.
       Install libseccomp devel >= 2.1.1

builder for ‘/nix/store/cqjc0msqcg9fjf1zvybhkgrpjvp0pbgm-qemu-x86-only-2.4.0.drv’ failed with e
xit code 1
```

Now, before I keep digging and finding why qemu is failing to configure, do you have any hints on this? Is this the best way to patch software for 64-bit inode support? Why nobody else cared about this issue upstream? 

I don't want to run a 32-bit VM with nix inside to test i686 builds... especially because inside a VM, I don't think I will be able to run another VM.

Until we fix our i686 build tools to run on 64-bit filesystems I will personally ignore i686 hydra failures.

cc @vcunat @edolstra 
