### PR TITLE
build-fhs-chrootenv: add missing /usr/include

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -182,6 +182,12 @@ let
   setupLibDirs = if isTargetBuild then setupLibDirs_target
                                   else setupLibDirs_multi;
 
+  setupIncludeDir = ''
+    if [ -x "${staticUsrProfileTarget}/include" ]
+    then
+        ln -s "${staticUsrProfileTarget}/include"
+    fi
+  '';
 
   # the target profile is the actual profile that will be used for the chroot
   setupTargetProfile = ''
@@ -192,6 +198,7 @@ let
     cd usr
     ${linkProfile staticUsrProfileTarget}
     ${setupLibDirs}
+    ${setupIncludeDir}
     cd ..
     rm -rf usr/etc usr/var
   '';


### PR DESCRIPTION
This patch brings the include/ directories of all specified packages to
appear under /usr/include in the FHS chroot. As per spec[1].

[1] http://www.pathname.com/fhs/pub/fhs-2.3.html#USRINCLUDEDIRECTORYFORSTANDARDINCLU
