### PR TITLE
nasty: init at 0.6

### DIFF
--- a/pkgs/tools/security/nasty/default.nix
+++ b/pkgs/tools/security/nasty/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, gpgme }:
+
+stdenv.mkDerivation rec {
+  name = "nasty-${version}";
+  version = "0.6";
+
+  src = fetchurl {
+    url = "http://www.vanheusden.com/nasty/${name}.tgz";
+    sha256 = "1dznlxr728k1pgy1kwmlm7ivyl3j3rlvkmq34qpwbwbj8rnja1vn";
+  };
+
+  buildInputs = [ gpgme ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp nasty $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Recover the passphrase of your PGP or GPG-key";
+    longDescription = ''
+    Nasty is a program that helps you to recover the passphrase of your PGP or GPG-key
+    in case you forget or lost it. It is mostly a proof-of-concept: with a different implementation
+    this program could be at least 100x faster.
+    '';
+    homepage = http://www.vanheusden.com/nasty/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; davidak;
+    platforms = with platforms; unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2292,6 +2292,8 @@ let
 
   namazu = callPackage ../tools/text/namazu { };
 
+  nasty = callPackage ../tools/security/nasty { };
+
   nbd = callPackage ../tools/networking/nbd { };
 
   ndjbdns = callPackage ../tools/networking/ndjbdns { };


### PR DESCRIPTION
it compiles and can get started, but don't work.

always the gpg-agent get's started and asks for the password.
this is a known problem of this program: http://manpages.ubuntu.com/manpages/trusty/man1/nasty.1.html

i tried one hour to fix it but it isn't worth the time since it is just a proof-of-concept.

if someone want to use it, one have to disable the asking for the passphrase.

you can `nix-env -iA nixos.pinentry` and create the file `~/.gnupg/gpg-agent.conf`
get the path `whereis pinentry-curses`
and put it in the file like:
`pinentry-program /nix/store/379aaq5g4mjfg34pkz1rx5h02f3zk6sx-user-environment/bin/pinentry-curses`
this way not a windows opens but you get asked on the console. nasty still don't do anything...

https://dilawarnotes.wordpress.com/2013/02/13/disable-gpg-gui-asking-for-paraphrase/

maybe we don't add this to nixpkgs or mark it as broken?
