### PR TITLE
claws-mail: 3.11.1 -> 3.12.0, remove priority workaround

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -29,7 +29,7 @@
 
 with stdenv.lib;
 
-let version = "3.11.1"; in
+let version = "3.12.0"; in
 
 stdenv.mkDerivation {
   name = "claws-mail-${version}";
@@ -40,15 +40,19 @@ stdenv.mkDerivation {
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = [ maintainers.khumba ];
-    priority = 10;  # Resolve the conflict with the share/mime link we create.
   };
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/claws-mail/Claws%20Mail/${version}/claws-mail-${version}.tar.bz2";
-    sha256 = "0w13xzri9d3165qsxf1dig1f0gxn3ib4lysfc9pgi4zpyzd0zgrw";
+    url = "http://www.claws-mail.org/download.php?file=releases/claws-mail-3.12.0.tar.xz";
+    sha256 = "1jnnwivpcplv8x4w0ibb1qcnasl37fr53lbfybhgb936l2mdcai7";
   };
 
   patches = [ ./mime.patch ];
+
+  postPatch = ''
+    substituteInPlace src/procmime.c \
+        --subst-var-by MIMEROOTDIR ${shared_mime_info}/share
+  '';
 
   buildInputs =
     [ curl dbus dbus_glib gtk gnutls hicolor_icon_theme
@@ -90,7 +94,5 @@ stdenv.mkDerivation {
   postInstall = ''
     mkdir -p $out/share/applications
     cp claws-mail.desktop $out/share/applications
-
-    ln -sT ${shared_mime_info}/share/mime $out/share/mime
   '';
 }

--- a/pkgs/applications/networking/mailreaders/claws-mail/mime.patch
+++ b/pkgs/applications/networking/mailreaders/claws-mail/mime.patch
@@ -1,14 +1,15 @@
---- a/src/procmime.c	2015-09-18 04:03:11.767654094 -0700
-+++ b/src/procmime.c	2015-09-18 04:08:38.834503034 -0700
+--- a/src/procmime.c	2015-10-01 23:02:16.629908590 -0700
++++ b/src/procmime.c	2015-10-01 23:02:46.932001337 -0700
 @@ -1196,11 +1196,7 @@
  	if (mime_type_list) 
  		return mime_type_list;
  	
 -#if defined(__NetBSD__) || defined(__OpenBSD__) || defined(__FreeBSD__)
- 	if ((fp = procmime_fopen(DATAROOTDIR "/mime/globs", "rb")) == NULL) 
+-	if ((fp = procmime_fopen(DATAROOTDIR "/mime/globs", "rb")) == NULL) 
 -#else
 -	if ((fp = procmime_fopen("/usr/share/mime/globs", "rb")) == NULL) 
 -#endif
++	if ((fp = procmime_fopen("@MIMEROOTDIR@/mime/globs", "rb")) == NULL) 
  	{
  		fp_is_glob_file = FALSE;
  		if ((fp = procmime_fopen("/etc/mime.types", "rb")) == NULL) {


### PR DESCRIPTION
I've been using Claws 3.12.0 for about a week without problems, and I don't see any blockers upstream.
