### PR TITLE
Consul Startup Dependency

### DIFF
--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -160,7 +160,7 @@ in
 
       systemd.services.consul = {
         wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" ] ++ systemdDevices;
+        after = [ "network.target" "systemd-udev-settle.service" ] ++ systemdDevices;
         bindsTo = systemdDevices;
         restartTriggers = [ config.environment.etc."consul.json".source ]
           ++ mapAttrsToList (_: d: d.source)


### PR DESCRIPTION
Consul depends on some devices provided by udev. Without this, consul would start and then exit ~10% of the time in certain environments.
