### PR TITLE
Firewall and VM Overcommit Options

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -67,6 +67,22 @@ in
         description = "The port for Redis to listen to.";
       };
 
+      vmOverCommit = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Set vm.overcommit_memory to 1 (Suggested for Background Saving: http://redis.io/topics/faq)
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open ports in the firewall for the server.
+        '';
+      };
+
       bind = mkOption {
         type = with types; nullOr str;
         default = null; # All interfaces
@@ -191,6 +207,14 @@ in
   ###### implementation
 
   config = mkIf config.services.redis.enable {
+
+    boot.kernel.sysctl = mkIf cfg.vmOverCommit {
+      "vm.overcommit_memory" = "1";
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
 
     users.extraUsers.redis =
       { name = cfg.user;


### PR DESCRIPTION
Both of these are common settings we have to enable for redis when using it in production. The motivation here is that now all of our redis config can be done with 'services.redis.*' settings.
