### PR TITLE
build the crontab localy, there is nothing to gain from building it remotely

### DIFF
--- a/nixos/modules/services/scheduling/cron.nix
+++ b/nixos/modules/services/scheduling/cron.nix
@@ -100,7 +100,7 @@ in
       environment.systemPackages = [ cronNixosPkg ];
 
       environment.etc.crontab =
-        { source = pkgs.runCommand "crontabs" { inherit allFiles; }
+        { source = pkgs.runCommand "crontabs" { inherit allFiles; preferLocalBuild = true; }
             ''
               touch $out
               for i in $allFiles; do


### PR DESCRIPTION
i discovered this after nix copied the entire system closure just to copy a one crontab input file to the output
