### PR TITLE
zbackup: init at 1.4.4, fetchhg: fixed nix-prefetch-hg interpreter, textadept: 8.0 -> 8.2, geany: add geany-with-vte to use the terminal

### DIFF
--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -1,0 +1,6 @@
+{ runCommand, makeWrapper, geany, gnome }:
+let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
+in
+runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; } "
+   makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome.vte}/lib
+"

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -20,14 +20,14 @@ let
   '';
 in
 stdenv.mkDerivation rec{
-  version = "8.0";
-  scintillua_version = "3.5.5-1";
+  version = "8.2";
+  scintillua_version = "3.6.0-1";
   name = "textadept-${version}";
   inherit buildInputs;
   src = fetchhg {
     url = http://foicica.com/hg/textadept;
     rev = "textadept_${version}";
-    sha256 = "18kcphqkn0l77dbcyvywy3wh13ib280bb0qsffaqy439gk5zr7ql";
+    sha256 = "1vb6a15fyk7ixcv5fy0g400lxbj6dp5ndbmyx53d28idbdkz9ap1";
   };
   preConfigure = ''
     cd src
@@ -35,16 +35,17 @@ stdenv.mkDerivation rec{
     echo '#! ${stdenv.shell}' > wget/wget
     chmod a+x wget/wget
     export PATH="$PATH:$PWD/wget"
-    ${get_url http://prdownloads.sourceforge.net/scintilla/scintilla355.tgz "11n49h58xh35vj1j85cxasl93rjiv699c5cs5lpv19skfsgs3sb4"}
+    ${get_url http://prdownloads.sourceforge.net/scintilla/scintilla360.tgz "07ib4w3n9kqfaia2yngj2q7ab5r55zn0hccfzph6vas9hl8vk9zf"}
     ${get_url http://foicica.com/scinterm/download/scinterm_1.6.zip "0ixwj9il6ri1xl4nvb6f108z4qhrahysza6frbbaqmbdz21hnmcl"}
-    ${get_url http://foicica.com/scintillua/download/scintillua_3.5.5-1.zip "0bpz5rmgaisbimhm6rpn961mbv30cwqid7kh9lad94v3y9ppvf35"}
-    ${get_url http://www.lua.org/ftp/lua-5.3.0.tar.gz "00fv1p6dv4701pyjrlvkrr6ykzxqy9hy1qxzj6qmwlb0ssr5wjmf"}
+    ${get_url http://foicica.com/scintillua/download/scintillua_3.6.0-1.zip "0zk1ciyyi0d3dz4dzzq5fa74505pvqf0w5yszl7l29c1l4hkk561"}
+    ${get_url http://www.lua.org/ftp/lua-5.3.1.tar.gz "05xczy5ws6d7ic3f9h9djwg983bpa4pmds3698264bncssm6f9q7"}
     ${get_url http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-0.12.2.tar.gz "01002avq90yc8rgxa5z9a1768jm054iid3pnfpywdcfij45jgbba"}
     ${get_url_zip http://github.com/keplerproject/luafilesystem/archive/v_1_6_3.zip "1hxcnqj53540ysyw8fzax7f09pl98b8f55s712gsglcdxp2g2pri"}
     ${get_url http://foicica.com/lspawn/download/lspawn_1.2.zip "1fhfi274bxlsdvva5q5j0wv8hx68cmf3vnv9spllzad4jdvz82xv"}
     ${get_url http://luajit.org/download/LuaJIT-2.0.3.tar.gz "0ydxpqkmsn2c341j4r2v6r5r0ig3kbwv3i9jran3iv81s6r6rgjm"}
     ${get_url http://foicica.com/gtdialog/download/gtdialog_1.2.zip "0nvcldyhj8abr8jny9pbyfjwg8qfp9f2h508vjmrvr5c5fqdbbm0"}
-    ${get_url http://invisible-island.net/datafiles/release/cdk.tar.gz "00s87kq5x10x22azr6q17b663syk169y3dk3kaj8z6dlk2b8vknp"}
+    ${get_url ftp://invisible-island.net/cdk/cdk-5.0-20150928.tgz "028da75d5f777a1c4184f88e34918bd273bd83bbe3c959bc11710c4f0ea2e448"}
+    mv cdk-*.tgz cdk.tar.gz
     ${get_url_zip http://foicica.com/hg/bombay/archive/d704272c3629.zip "19dg3ky87rfy0a3319vmv18hgn9spplpznvlqnk3djh239ddpplw"}
     mv d704*.zip bombay.zip
     ${get_url http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.17.tar.gz "12gkrv1ldwk945qbpprnyawh0jz7rmqh18fyndbxiajyxmj97538"}

--- a/pkgs/build-support/fetchhg/nix-prefetch-hg
+++ b/pkgs/build-support/fetchhg/nix-prefetch-hg
@@ -1,4 +1,5 @@
-#! /bin/sh -e
+#! /usr/bin/env bash
+set -e
 
 url=$1
 rev=$2

--- a/pkgs/tools/backup/zbackup/default.nix
+++ b/pkgs/tools/backup/zbackup/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, cmake, zlib, openssl, protobuf, protobufc, lzo, libunwind } :
+stdenv.mkDerivation rec {
+  name = "zbackup-${version}";
+  version = "1.4.4";
+  src = fetchurl {
+    url = "https://github.com/zbackup/zbackup/archive/1.4.4.tar.gz";
+    sha256 = "11csla7n44lg7x6yqg9frb21vnkr8cvnh6ardibr3nj5l39crk7g";
+  };
+  buildInputs = [ zlib openssl protobuf lzo libunwind ];
+  nativeBuildInputs = [ cmake protobufc ];
+  meta = {
+    description = "A versatile deduplicating backup tool";
+    homepage = "http://zbackup.org/";
+    meta.platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3571,6 +3571,8 @@ let
   # To expose more packages for Yi, override the extraPackages arg.
   yi = callPackage ../applications/editors/yi/wrapper.nix { };
 
+  zbackup = callPackage ../tools/backup/zbackup {};
+
   zbar = callPackage ../tools/graphics/zbar {
     pygtk = lib.overrideDerivation pygtk (x: {
       gtk = gtk2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11374,6 +11374,7 @@ let
   fvwm = callPackage ../applications/window-managers/fvwm { };
 
   geany = callPackage ../applications/editors/geany { };
+  geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { };
 
   gksu = callPackage ../applications/misc/gksu { };
 


### PR DESCRIPTION
Tested on x86_64 Linux, seems to work.
The script nix-prefetch-hg used the == operator with test, which is not necessarily supported by /bin/sh.
cc @jagajaga @pSub 
