### PR TITLE
davfs2: Fix broken build

### DIFF
--- a/pkgs/development/libraries/neon/0.29.nix
+++ b/pkgs/development/libraries/neon/0.29.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, libxml2, pkgconfig
+, compressionSupport ? true, zlib ? null
+, sslSupport ? true, openssl ? null
+, static ? false
+, shared ? true
+}:
+
+assert compressionSupport -> zlib != null;
+assert sslSupport -> openssl != null;
+assert static || shared;
+
+let
+   inherit (stdenv.lib) optionals;
+in
+
+stdenv.mkDerivation rec {
+  version = "0.29.6";
+  name = "neon-${version}";
+
+  src = fetchurl {
+    url = "http://www.webdav.org/neon/${name}.tar.gz";
+    sha256 = "0hzbjqdx1z8zw0vmbknf159wjsxbcq8ii0wgwkqhxj3dimr0nr4w";
+  };
+
+  patches = optionals stdenv.isDarwin [ ./0.29.6-darwin-fix-configure.patch ];
+
+  buildInputs = [libxml2 pkgconfig openssl]
+    ++ stdenv.lib.optional compressionSupport zlib;
+
+  configureFlags = ''
+    ${if shared then "--enable-shared" else "--disable-shared"}
+    ${if static then "--enable-static" else "--disable-static"}
+    ${if compressionSupport then "--with-zlib" else "--without-zlib"}
+    ${if sslSupport then "--with-ssl" else "--without-ssl"}
+    --enable-shared
+  '';
+
+  passthru = {inherit compressionSupport sslSupport;};
+
+  meta = {
+    description = "An HTTP and WebDAV client library";
+    homepage = http://www.webdav.org/neon/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1204,7 +1204,9 @@ let
 
   darkstat = callPackage ../tools/networking/darkstat { };
 
-  davfs2 = callPackage ../tools/filesystems/davfs2 { };
+  davfs2 = callPackage ../tools/filesystems/davfs2 {
+    neon = neon_0_29;
+  };
 
   dbench = callPackage ../development/tools/misc/dbench { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7658,6 +7658,11 @@ let
     sslSupport = true;
   };
 
+  neon_0_29 = callPackage ../development/libraries/neon/0.29.nix {
+    compressionSupport = true;
+    sslSupport = true;
+  };
+
   nethack = callPackage ../games/nethack { };
 
   nettle = callPackage ../development/libraries/nettle { };


### PR DESCRIPTION
#10059 broke the build of davfs2, so I reverted the changes from #10059 and re-added the `neon` package in the old version and put it as build input of davfs2.

`davfs2` builds locally for me now.

@lethalman , @peti 
