### PR TITLE
llvm: add debug builds support

### DIFF
--- a/pkgs/development/compilers/llvm/3.3/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.3/llvm.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, groff, cmake, python, libffi, binutils }:
+{ stdenv, fetchurl, perl, groff, cmake, python, libffi, binutils, debugVersion ? false }:
 let
   version = "3.3";
 in stdenv.mkDerivation rec {
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     in "export ${LD}_LIBRARY_PATH='$$${LD}_LIBRARY_PATH:'`pwd`/lib";
 
   cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_BINUTILS_INCDIR=${binutils}/include"

--- a/pkgs/development/compilers/llvm/3.4/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.4/llvm.nix
@@ -12,6 +12,7 @@
 , version
 , zlib
 , compiler-rt_src
+, debugVersion ? false
 }:
 
 let
@@ -41,7 +42,7 @@ in stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_REQUIRES_RTTI=1"

--- a/pkgs/development/compilers/llvm/3.5/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.5/llvm.nix
@@ -12,6 +12,7 @@
 , version
 , zlib
 , compiler-rt_src
+, debugVersion ? false
 }:
 
 let
@@ -38,7 +39,7 @@ in stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_REQUIRES_RTTI=1"

--- a/pkgs/development/compilers/llvm/3.6/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.6/llvm.nix
@@ -12,6 +12,7 @@
 , version
 , zlib
 , compiler-rt_src
+, debugVersion ? false
 }:
 
 let
@@ -38,7 +39,7 @@ in stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"

--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -12,6 +12,7 @@
 , version
 , zlib
 , compiler-rt_src
+, debugVersion ? false
 }:
 
 let
@@ -38,7 +39,7 @@ in stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
     "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"


### PR DESCRIPTION
This is very helpful for actually developing anything that uses LLVM -- without it, LLVM segfaults on just about any mistake in the AST tree more subtle than undefined name without any actual error. In the name of speed, it seems! See also https://github.com/bscarlet/llvm-general/issues/104#issuecomment-44944877 .

cc @wkennington 
