### PR TITLE
build-fhs-chrootenv: add /etc/os-release from host

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -95,6 +95,7 @@ let
       # symlink other core stuff
       ln -s /host-etc/localtime localtime
       ln -s /host-etc/machine-id machine-id
+      ln -s /host-etc/os-release os-release
 
       # symlink PAM stuff
       ln -s /host-etc/pam.d pam.d


### PR DESCRIPTION
This allows software inside the chroot to identify the host OS via the
standard /etc/os-release file.

---

I'm actually a bit unsure whether the chroot should be "opaque" or not, but I figure it's probably best to add /etc/os-release. (I guess there are other places where the host system info leaks in as well.)
