### PR TITLE
mozart: fix tcl/tk issues and clean up

### DIFF
--- a/pkgs/development/compilers/mozart/binary.nix
+++ b/pkgs/development/compilers/mozart/binary.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, bash, makeWrapper, coreutils, emacs, tcl, tk, boost, gmp, cacert }:
-
-assert stdenv.isLinux;
+{ stdenv, fetchurl, boost, emacs, gmp, makeWrapper
+, tcl-8_5, tk-8_5
+}:
 
 let
+
   version = "2.0.0";
-in
-stdenv.mkDerivation {
+
+in stdenv.mkDerivation {
   name = "mozart-binary-${version}";
 
   src = fetchurl {
@@ -14,7 +15,15 @@ stdenv.mkDerivation {
   };
 
   libPath = stdenv.lib.makeLibraryPath
-    [stdenv.cc.cc emacs tk tcl boost gmp];
+    [ stdenv.cc.cc
+      boost
+      emacs
+      gmp
+      tcl-8_5
+      tk-8_5
+    ];
+
+  TK_LIBRARY = "${tk-8_5}/lib/tk8.5";
 
   builder = ./builder.sh;
 

--- a/pkgs/development/compilers/mozart/builder.sh
+++ b/pkgs/development/compilers/mozart/builder.sh
@@ -12,13 +12,15 @@ mv mozart*linux/share/* $out/share
 patchShebangs $out
 
 for f in $out/bin/*; do
-  b=$(basename $f)
-  if [ $b == "ozemulator" ] || [ $b == "ozwish" ]; then
-     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-	 --set-rpath $libPath \
-	 $f
-    continue;
-  fi
-  wrapProgram $f \
-    --set OZHOME $out
+    b=$(basename $f)
+
+    if [ $b == "ozemulator" ] || [ $b == "ozwish" ]; then
+        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+                 --set-rpath $libPath \
+                 $f
+        continue;
+    fi
+
+    wrapProgram $f --set OZHOME $out \
+                   --set TK_LIBRARY $TK_LIBRARY
 done


### PR DESCRIPTION
The binaries installed by the Mozart expression need Tcl/Tk version 8.5 and the `ozwish` binary also needs `TK_LIBRARY` set to the correct path in order to work properly.
