### PR TITLE
flashplayer: 11.2.202.508 -> 11.2.202.521 security

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -90,6 +90,7 @@
   eikek = "Eike Kettner <eike.kettner@posteo.de>";
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
   emery = "Emery Hemingway <emery@vfemail.net>";
+  enolan = "Echo Nolan <echo@echonolan.net>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";
   ericbmerritt = "Eric Merritt <eric@afiniate.com>";
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -91,5 +91,6 @@ stdenv.mkDerivation {
     description = "Adobe Flash Player browser plugin";
     homepage = http://www.adobe.com/products/flashplayer/;
     license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.enolan ];
   };
 }

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -36,7 +36,7 @@
 
 let
   # -> http://get.adobe.com/flashplayer/
-  version = "11.2.202.508";
+  version = "11.2.202.521";
 
   src =
     if stdenv.system == "x86_64-linux" then
@@ -47,7 +47,7 @@ let
       else rec {
         inherit version;
         url = "http://fpdownload.adobe.com/get/flashplayer/pdc/${version}/install_flash_player_11_linux.x86_64.tar.gz";
-        sha256 = "1i0301vnz94pxcwm9wk1jjyv7gwywy6p7z26ikd5cg259myxbg75";
+        sha256 = "1fckmapjy7rvy1g5jr71x69j7vviy9262wwpwk6cipym2fi7zvid";
       }
     else if stdenv.system == "i686-linux" then
       if debug then


### PR DESCRIPTION
Several CVEs, listed here:
https://helpx.adobe.com/security/products/flash-player/apsb15-23.html

Tested by installing firefox-wrapper with nix-env and running twitch.tv
and a flash game.

Also add me to maintainers, cause somebody has to do it.
