### PR TITLE
vimproc: Improve build determinism

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -706,7 +706,7 @@ rec {
         --replace vimproc_mac.so vimproc_unix.so \
         --replace vimproc_linux64.so vimproc_unix.so \
         --replace vimproc_linux32.so vimproc_unix.so
-      make -f make_unix.mak
+      make TARGET="autoload/vimproc_unix.so" -f make_unix.mak
     '';
   };
 


### PR DESCRIPTION
The makefile changes the name of the library that it builds based on
the presence or absence of /lib_/ld-linux_.so.2, which means it can
break when building on non-NixOS systems.
