### PR TITLE
Include ZFS commands in PATH for ZFS storagedriver

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -129,7 +129,8 @@ in
           LimitNPROC = 1048576;
         } // proxy_env;
 
-        path = [ pkgs.kmod ];
+        path = [ pkgs.kmod ] ++
+          (if cfg.storageDriver == "zfs" then [ pkgs.zfs ] else []) ;
         environment.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";
 
         postStart = cfg.postStart;


### PR DESCRIPTION
The docker ZFS storagedriver relies on the zfs command which is not part of a typical path.  This causes docker to eventually fail if using the ZFS storage driver because it cannot create the ZFS file systems.

This commit adds pkgs.zfs to the systemd docker path if ZFS is set as the storagedriver for docker.

This will resolve https://github.com/NixOS/nixpkgs/issues/10127
