### PR TITLE
nixos/jenkins: rework environment handling

### DIFF
--- a/nixos/modules/services/continuous-integration/jenkins/default.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/default.nix
@@ -65,11 +65,14 @@ in {
       };
 
       environment = mkOption {
-        default = { NIX_REMOTE = "daemon"; };
+        default = { };
         type = with types; attrsOf str;
         description = ''
           Additional environment variables to be passed to the jenkins process.
-          The environment will always include JENKINS_HOME.
+          This setting will merge with everything in
+          <option>config.environment.sessionVariables</option>,
+          JENKINS_HOME and NIX_REMOTE. This option takes precedence and can
+          override any previously set environment variable.
         '';
       };
 
@@ -106,9 +109,12 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      environment = {
-        JENKINS_HOME = cfg.home;
-      } // cfg.environment;
+      environment =
+        config.environment.sessionVariables //
+        { JENKINS_HOME = cfg.home;
+          NIX_REMOTE = "daemon";
+        } //
+        cfg.environment;
 
       path = cfg.packages;
 


### PR DESCRIPTION
Jenkins gets (by default) an additional environment of

  { NIX_REMOTE = "daemon"; }

This has the following problems:
1. NIX_REMOTE disappears when users specify additional environment
    variables, because defaults have low merge priority.
2. nix cannot be used without additional NIX_PATH envvar, which is
    currently missing.
3. If you try to use HTTPS, you'll see that jenkins lacks
    SSL_CERT_FILE, causing it to fail.

This commit adds config.environment.sessionVariables and NIX_REMOTE to
the set of variables that are always there for jenkins, making nix and
HTTPS work out of the box.

services.jenkins.environment is now empty by default.
