### PR TITLE
apache-httpd: adopt mozilla's SSL configuration recommendation

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -173,7 +173,8 @@ let
     SSLRandomSeed connect builtin
 
     SSLProtocol All -SSLv2 -SSLv3
-    SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!EXP
+    SSLCipherSuite HIGH:!aNULL:!MD5:!EXP
+    SSLHonorCipherOrder on
   '';
 
 


### PR DESCRIPTION
A couple of tweaks on the SSL cipher list. The list is coming from
https://mozilla.github.io/server-side-tls/ssl-config-generator

Without the change, servers configured with Nix are capped at Grade B on https://www.ssllabs.com/ssltest/index.html

Disabled RC4 which is now considered broken.
https://community.qualys.com/blogs/securitylabs/2013/03/19/rc4-in-tls-is-broken-now-what

Enabled Forward Secrecy for modern browsers.
https://en.wikipedia.org/wiki/Forward_secrecy
