### PR TITLE
pythonPackages.bepasty-server: init at 0.4.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18587,6 +18587,33 @@ let
     };
   };
 
+  bepasty-server = buildPythonPackage rec {
+    name = "bepasty-server-${version}";
+    version = "0.4.0";
+    propagatedBuildInputs = with self;[
+      flask
+      pygments
+      xstatic
+      xstatic-bootbox
+      xstatic-bootstrap
+      xstatic-jquery
+      xstatic-jquery-file-upload
+      xstatic-jquery-ui
+      xstatic-pygments
+    ];
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/b/bepasty/bepasty-${version}.tar.gz";
+      sha256 = "0bs79pgrjlnkmjfyj2hllbx3rw757va5w2g2aghi9cydmsl7gyi4";
+    };
+
+    meta = {
+      homepage = http://github.com/bepasty/bepasty-server;
+      description = "binary pastebin server";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
   xstatic = buildPythonPackage rec {
     name = "XStatic-${version}";
     version = "1.0.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18587,4 +18587,117 @@ let
     };
   };
 
+  xstatic = buildPythonPackage rec {
+    name = "XStatic-${version}";
+    version = "1.0.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic/XStatic-${version}.tar.gz";
+      sha256 = "09npcsyf1ccygjs0qc8kdsv4qqy8gm1m6iv63g9y1fgbcry3vj8f";
+    };
+    meta = {
+      homepage = http://bitbucket.org/thomaswaldmann/xstatic;
+      description = "base packaged static files for python";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
+  xstatic-bootbox = buildPythonPackage rec {
+    name = "XStatic-Bootbox-${version}";
+    version = "4.3.0.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic-Bootbox/XStatic-Bootbox-${version}.tar.gz";
+      sha256 = "0wks1lsqngn3gvlhzrvaan1zj8w4wr58xi0pfqhrzckbghvvr0gj";
+    };
+
+    meta = {
+      homepage =  http://bootboxjs.com;
+      description = "bootboxjs packaged static files for python";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
+  xstatic-bootstrap = buildPythonPackage rec {
+    name = "XStatic-Bootstrap-${version}";
+    version = "3.3.5.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic-Bootstrap/XStatic-Bootstrap-${version}.tar.gz";
+      sha256 = "0jzjq3d4vp2shd2n20f9y53jnnk1cvphkj1v0awgrf18qsy2bmin";
+    };
+
+    meta = {
+      homepage =  http://getbootstrap.com;
+      description = "bootstrap packaged static files for python";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
+  xstatic-jquery = buildPythonPackage rec {
+    name = "XStatic-jQuery-${version}";
+    version = "1.10.2.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic-jQuery/XStatic-jQuery-${version}.tar.gz";
+      sha256 = "018kx4zijflcq8081xx6kmiqf748bsjdq7adij2k91bfp1mnlhc3";
+    };
+
+    meta = {
+      homepage =  http://jquery.org;
+      description = "jquery packaged static files for python";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
+  xstatic-jquery-file-upload = buildPythonPackage rec {
+    name = "XStatic-jQuery-File-Upload-${version}";
+    version = "9.7.0.1";
+    propagatedBuildInputs = with self;[ xstatic-jquery ];
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic-jQuery-File-Upload/XStatic-jQuery-File-Upload-${version}.tar.gz";
+      sha256 = "0d5za18lhzhb54baxq8z73wazq801n3qfj5vgcz7ri3ngx7nb0cg";
+    };
+
+    meta = {
+      homepage =  http://plugins.jquery.com/project/jQuery-File-Upload;
+      description = "jquery-file-upload packaged static files for python";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
+  xstatic-jquery-ui = buildPythonPackage rec {
+    name = "XStatic-jquery-ui-${version}";
+    version = "1.11.0.1";
+    propagatedBuildInputs = with self; [ xstatic-jquery ];
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic-jquery-ui/XStatic-jquery-ui-${version}.tar.gz";
+      sha256 = "0n6sgg9jxrqfz4zg6iqdmx1isqx2aswadf7mk3fbi48dxcv1i6q9";
+    };
+
+    meta = {
+      homepage = http://jqueryui.com/;
+      description = "jquery-ui packaged static files for python";
+      license = licenses.mit;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
+  xstatic-pygments = buildPythonPackage rec {
+    name = "XStatic-Pygments-${version}";
+    version = "1.6.0.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/X/XStatic-Pygments/XStatic-Pygments-${version}.tar.gz";
+      sha256 = "0fjqgg433wfdnswn7fad1g6k2x6mf24wfnay2j82j0fwgkdxrr7m";
+    };
+
+    meta = {
+      homepage = http://pygments.org;
+      description = "pygments packaged static files for python";
+      license = licenses.bsd2;
+      maintainers = [ maintainers.makefu ];
+    };
+  };
+
 }; in pythonPackages


### PR DESCRIPTION
The pull-request is split in 2 commits:
the first one introduces all xstatic build dependencies for bepasty-server, these dependencies can be used without the main package.
The second commit introduces the bepasty-server in its most recent version 0.4.0.

The package is built and tested locally.
