### PR TITLE
nodejs: 4.1.0 -> 4.1.2

### DIFF
--- a/pkgs/development/web/nodejs/default.nix
+++ b/pkgs/development/web/nodejs/default.nix
@@ -7,7 +7,7 @@
 assert stdenv.system != "armv5tel-linux";
 
 let
-  version = "4.1.0";
+  version = "4.1.2";
 
   deps = {
     inherit openssl zlib libuv;
@@ -31,7 +31,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "453005f64ee529f7dcf1237eb27ee2fa2415c49f5c9e7463e8b71fba61c5b408";
+    sha256 = "0j9ca1fjgljzh4m9l9d8g81510j0ljvaf031qij9psiz79qc7gpy";
   };
 
   configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ];


### PR DESCRIPTION
Fixes a major CVE from io.js 3.x onwards.

Build and tested on my machine.
