### PR TITLE
gnome3 test: increase timeout

### DIFF
--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -28,7 +28,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       $machine->succeed("su - alice -c 'DISPLAY=:0.0 gnome-terminal &'");
       $machine->waitForWindow(qr/Terminal/);
-      $machine->mustSucceed("timeout 60 bash -c 'journalctl -f|grep -m 1 \"GNOME Shell started\"'");
+      $machine->mustSucceed("timeout 900 bash -c 'journalctl -f|grep -m 1 \"GNOME Shell started\"'");
       $machine->sleep(10);
       $machine->screenshot("screen");
     '';


### PR DESCRIPTION
The gnome3 test has been failing recently ([1](http://hydra.nixos.org/build/26608126/nixlog/1/raw) [2](http://hydra.nixos.org/build/26605926/nixlog/1/raw)); this is due to exit code 124 which is [the command timing out](https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html).

This increases the timeout to 900, to align with the similar timeout in https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/test-driver/Machine.pm#L222
