### PR TITLE
Don't fail if env-vars cannot be written to

### DIFF
--- a/pkgs/build-support/builder-defs/builder-defs.nix
+++ b/pkgs/build-support/builder-defs/builder-defs.nix
@@ -336,7 +336,7 @@ let inherit (builtins) head tail trace; in
 
         doDump = n: noDepEntry "echo Dump number ${n}; set";
 
-	saveEnv = noDepEntry ''export > $TMP/env-vars'';
+	saveEnv = noDepEntry ''export > "$TMP/env-vars" || true'';
 
 	doDumpBuildInputs = noDepEntry (''
 	  echo "${toString realBuildInputs}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -450,7 +450,7 @@ substituteAllInPlace() {
 # the environment used for building.
 dumpVars() {
     if [ "$noDumpEnvVars" != 1 ]; then
-        export > "$NIX_BUILD_TOP/env-vars"
+        export > "$NIX_BUILD_TOP/env-vars" || true
     fi
 }
 


### PR DESCRIPTION
env-vars is a debugging aid, see
https://github.com/NixOS/nix/commit/3e5dbb24337d8416cfe46484eb2692811546a9c1
for a rationale for this change.
