### PR TITLE
kdelibs: improvements

### DIFF
--- a/pkgs/applications/kde-apps-15.08/kdelibs/0003-remove_xdg_impurities.patch
+++ b/pkgs/applications/kde-apps-15.08/kdelibs/0003-remove_xdg_impurities.patch
@@ -1,0 +1,47 @@
+diff --git a/kdecore/kernel/kstandarddirs.cpp b/kdecore/kernel/kstandarddirs.cpp
+index ab8f76d..2ae5089 100644
+--- a/kdecore/kernel/kstandarddirs.cpp
++++ b/kdecore/kernel/kstandarddirs.cpp
+@@ -1768,12 +1768,6 @@ void KStandardDirs::addKDEDefaults()
+     else
+     {
+         xdgdirList.clear();
+-        xdgdirList.append(QString::fromLatin1("/etc/xdg"));
+-#ifdef Q_WS_WIN
+-        xdgdirList.append(installPath("kdedir") + QString::fromLatin1("etc/xdg"));
+-#else
+-        xdgdirList.append(QFile::decodeName(KDESYSCONFDIR "/xdg"));
+-#endif
+     }
+ 
+     QString localXdgDir = readEnvPath("XDG_CONFIG_HOME");
+@@ -1821,10 +1815,6 @@ void KStandardDirs::addKDEDefaults()
+         }
+     } else {
+         xdgdirList = kdedirDataDirs;
+-#ifndef Q_WS_WIN
+-        xdgdirList.append(QString::fromLatin1("/usr/local/share/"));
+-        xdgdirList.append(QString::fromLatin1("/usr/share/"));
+-#endif
+     }
+ 
+     localXdgDir = readEnvPath("XDG_DATA_HOME");
+diff --git a/solid/solid/xdgbasedirs.cpp b/solid/solid/xdgbasedirs.cpp
+index 4c9cad9..6849d45 100644
+--- a/solid/solid/xdgbasedirs.cpp
++++ b/solid/solid/xdgbasedirs.cpp
+@@ -70,12 +70,12 @@ QStringList Solid::XdgBaseDirs::systemPathList( const char *resource )
+ {
+   if ( qstrncmp( "data", resource, 4 ) == 0 ) {
+     if ( instance()->mDataDirs.isEmpty() ) {
+-      instance()->mDataDirs = instance()->systemPathList( "XDG_DATA_DIRS", "/usr/local/share:/usr/share" );
++      instance()->mDataDirs = instance()->systemPathList( "XDG_DATA_DIRS", "" );
+     }
+     return instance()->mDataDirs;
+   } else if ( qstrncmp( "config", resource, 6 ) == 0 ) {
+     if ( instance()->mConfigDirs.isEmpty() ) {
+-      instance()->mConfigDirs = instance()->systemPathList( "XDG_CONFIG_DIRS", "/etc/xdg" );
++      instance()->mConfigDirs = instance()->systemPathList( "XDG_CONFIG_DIRS", "" );
+     }
+     return instance()->mConfigDirs;
+   }

--- a/pkgs/applications/kde-apps-15.08/kdelibs/default.nix
+++ b/pkgs/applications/kde-apps-15.08/kdelibs/default.nix
@@ -21,6 +21,7 @@ kdeApp {
   patches = [
     ./0001-old-kde4-cmake-policies.patch
     ./0002-polkit-install-path.patch
+    ./0003-remove_xdg_impurities.patch
   ];
 
   # cmake does not detect path to `ilmbase`


### PR DESCRIPTION
Removed impurities automatically added
to listings derived from both `XDG_CONFIG_DIRS`
and `XDG_DATA_DIRS` that refers to hardcoded
paths.

This shoud allow us to use `kbuildsycoca4` tool
at build time, generating identical builds of
the database independent on the distribution
nix is based on.

Tests:
-  Built as part of digikam package which make use
  of this syscoca builder tool at build time to
  generate an immutable database. Everything still
  run fine.
