### PR TITLE
vim: use example vimrc as default, fixes #10233

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -31,7 +31,11 @@ stdenv.mkDerivation rec {
     "--enable-nls"
   ];
 
-  postInstall = "ln -s $out/bin/vim $out/bin/vi";
+  postInstall = ''
+    ln -s $out/bin/vim $out/bin/vi
+    # use cp if you want to edit the file
+    ln -s $out/share/vim/vim*/vimrc_example.vim $out/share/vim/vimrc
+  '';
 
   crossAttrs = {
     configureFlags = [


### PR DESCRIPTION
works on NixOS x86_64.

```
$ vim -V
[...]
Lesen von $VIM/vimrc beendet
```

maybe there is a more elegant way where you don't have to change `.../vim74/...` on updates, but it fixes the problem for now.

cc @lovek323 @edolstra 
