### PR TITLE
replace path to perl interpreter in recoll filter (closes #10286)

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, qt4, xapian, file, python
+, qt4, xapian, file, python, perl
 , djvulibre, groff, libxslt, unzip, xpdf, antiword, catdoc, lyx
 , libwpd, unrtf, untex
 , ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconv }:
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
       substituteInPlace  $f --replace unrtf         ${unrtf}/bin/unrtf
       substituteInPlace  $f --replace untex         ${untex}/bin/untex
       substituteInPlace  $f --replace wpd2html      ${libwpd}/bin/wpd2html
+      substituteInPlace  $f --replace /usr/bin/perl ${perl}/bin/perl
     done
   '';
 


### PR DESCRIPTION
Introduces a dependency on `perl` and replaces every occurance of `/usr/bin/perl` with path to the `perl` derivation.
