### PR TITLE
make-tarball.nix: Fail if nixpkgs doesn't evaluate without warnings

### DIFF
--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -49,12 +49,20 @@ releaseTools.sourceTarball rec {
         exit 1
     fi
 
-    # Check that all-packages.nix evaluates on a number of platforms.
+    # Check that all-packages.nix evaluates on a number of platforms without any warnings.
     for platform in i686-linux x86_64-linux x86_64-darwin; do
         header "checking pkgs/top-level/all-packages.nix on $platform"
+
         NIXPKGS_ALLOW_BROKEN=1 nix-env -f pkgs/top-level/all-packages.nix \
             --show-trace --argstr system "$platform" \
-            -qa --drv-path --system-filter \* --system > /dev/null
+            -qa --drv-path --system-filter \* --system 2>&1 >/dev/null | tee eval-warnings.log
+
+        if [ -s eval-warnings.log ]; then
+            echo "pkgs/top-level/all-packages.nix on $platform evaluated with warnings, aborting"
+            exit 1
+        fi
+        rm eval-warnings.log
+
         NIXPKGS_ALLOW_BROKEN=1 nix-env -f pkgs/top-level/all-packages.nix \
             --show-trace --argstr system "$platform" \
             -qa --drv-path --system-filter \* --system --meta --xml > /dev/null


### PR DESCRIPTION
Commit 3d6110d2217f40225debc2f1902b0f22142e6f66 added a well-meaning
warning message, which unfortunately would also show up each time
`nix-env -qa` was run. It has been since fixed, but let's add a check
to prevent such errors from reaching the nixpkgs channel in the future.

Tested by reverting e6eb42912856beba737b3225a3c7f41068a173ca on top of this,
and observed that `nix-build pkgs/top-level/release.nix  -A tarball` fails as expected.
