### PR TITLE
mesa_noglu: Bump LLVM version

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7561,7 +7561,7 @@ let
     # makes it slower, but during runtime we link against just mesa_drivers
     # through /run/opengl-driver*, which is overriden according to config.grsecurity
     grsecEnabled = true;
-    llvmPackages = llvmPackages_36;
+    llvmPackages = llvmPackages_37;
   });
   mesa_glu =  mesaDarwinOr (callPackage ../development/libraries/mesa-glu { });
   mesa_drivers = mesaDarwinOr (


### PR DESCRIPTION
Currently the gnome3 x86 test is failing, most likely due to the following line:

```
gnome-session[939]: LLVM ERROR: Do not know how to split the result of this operator!
```

This is due to LLVM not correctly detecting QEMU's CPU features: https://llvm.org/bugs/show_bug.cgi?id=23201
The referenced commits are included in LLVM 3.7 so updating mesa's LLVM should fix it.
