### PR TITLE
thunar: improvements

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -18,6 +18,14 @@ in
       description = "Enable the Xfce desktop environment.";
     };
 
+    services.xserver.desktopManager.xfce.thunarPlugins = mkOption {
+      default = [];
+      type = types.listOf types.package;
+      example = literalExample "[ pkgs.xfce.thunar-archive-plugin ]";
+      description = ''
+        A list of plugin that should be installed with Thunar.
+      '';
+    };
   };
 
 
@@ -49,7 +57,7 @@ in
         pkgs.xfce.mousepad
         pkgs.xfce.ristretto
         pkgs.xfce.terminal
-        pkgs.xfce.thunar
+       (pkgs.xfce.thunar.override { thunarPlugins = cfg.thunarPlugins; })
         pkgs.xfce.xfce4icontheme
         pkgs.xfce.xfce4panel
         pkgs.xfce.xfce4session

--- a/pkgs/desktops/xfce/core/thunar-build.nix
+++ b/pkgs/desktops/xfce/core/thunar-build.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, intltool
+, gtk, dbus_glib, libstartup_notification, libnotify, libexif, pcre, udev
+, exo, libxfce4util, xfconf, xfce4panel
+}:
+
+stdenv.mkDerivation rec {
+  p_name  = "thunar";
+  ver_maj = "1.6";
+  ver_min = "10";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/xfce/${p_name}/${ver_maj}/Thunar-${ver_maj}.${ver_min}.tar.bz2";
+    sha256 = "7e9d24067268900e5e44d3325e60a1a2b2f8f556ec238ec12574fbea15fdee8a";
+  };
+
+  name = "${p_name}-build-${ver_maj}.${ver_min}";
+
+  patches = [ ./thunarx_plugins_directory.patch ];
+
+  buildInputs = [
+    pkgconfig intltool
+    gtk dbus_glib libstartup_notification libnotify libexif pcre udev
+    exo libxfce4util xfconf xfce4panel
+  ];
+  # TODO: optionality?
+
+  enableParallelBuilding = true;
+
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+
+  meta = {
+    homepage = http://thunar.xfce.org/;
+    description = "Xfce file manager";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.eelco ];
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -24,7 +24,9 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   libxfce4ui      = callPackage ./core/libxfce4ui.nix { };
   libxfce4util    = callPackage ./core/libxfce4util.nix { };
   libxfcegui4     = callPackage ./core/libxfcegui4.nix { };
+  thunar-build    = callPackage ./core/thunar-build.nix { };
   thunar          = callPackage ./core/thunar.nix { };
+  thunarx-2-dev   = thunar-build; # Plugins need only the `thunarx-2` part of the package. Awaiting multiple outputs.
   thunar_volman   = callPackage ./core/thunar-volman.nix { }; # ToDo: probably inside Thunar now
   thunar-archive-plugin 
                   = callPackage ./thunar-plugins/archive { };

--- a/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pkgconfig, xfce4_dev_tools
 , gtk
-, thunar
+, thunarx-2-dev
 , exo, libxfce4util, libxfce4ui
 , xfconf, udev, libnotify
 }:
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     pkgconfig
     xfce4_dev_tools
-    thunar
+    thunarx-2-dev
     exo gtk libxfce4util libxfce4ui
     xfconf udev libnotify
   ];

--- a/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig
 , gtk
-, thunar, python2
+, thunarx-2-dev, python2
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     pkgconfig
     gtk
-    thunar python2
+    thunarx-2-dev python2
   ];
 
   configurePhase = "python2 waf configure --prefix=$out";


### PR DESCRIPTION
Add the possibility to specify plugin set to
be used as overridable `thunar` derivation argument.

New nixos config attribute:
`services.xserver.desktopManager.xfce.thunarPlugins`
that allows user to specify plugins in the context
of nixos.

Tests:
-  With and without plugins.
-  Using the nixos attributes.
