### PR TITLE
Split all-packages.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,4 +4,4 @@ if ! builtins ? nixVersion || builtins.compareVersions "1.8" builtins.nixVersion
 
 else
 
-  import ./pkgs/top-level/all-packages.nix
+  import ./pkgs/top-level/all-packages-wrapper.nix

--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -15,7 +15,7 @@ Usage:
   Attention:
 
   let
-    pkgs = (import /etc/nixos/nixpkgs/pkgs/top-level/all-packages.nix) {};
+    pkgs = (import <nixpkgs>) {};
   in let
     inherit (pkgs.stringsWithDeps) fullDepEntry packEntry noDepEntry textClosureMap;
     inherit (pkgs.lib) id;

--- a/pkgs/build-support/vm/windows/cygwin-iso/default.nix
+++ b/pkgs/build-support/vm/windows/cygwin-iso/default.nix
@@ -16,7 +16,7 @@ let
     sha256 = "1slyj4qha7x649ggwdski9spmyrbs04z2d46vgk8krllg0kppnjv";
   };
 
-  cygwinCross = (import ../../../../top-level/all-packages.nix {
+  cygwinCross = (import ../../../../top-level/all-packages-wrapper.nix {
     inherit (stdenv) system;
     crossSystem = {
       libc = "msvcrt";

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1,11 +1,11 @@
 { system      ? builtins.currentSystem
-, allPackages ? import ../../top-level/all-packages.nix
+, allPackages ? import ../../top-level/all-packages-wrapper.nix
 , platform    ? null
 , config      ? {}
 }:
 
 rec {
-  allPackages = import ../../top-level/all-packages.nix;
+  allPackages = import ../../top-level/all-packages-wrapper.nix;
 
   bootstrapTools = derivation {
     inherit system;

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -1,6 +1,6 @@
 {system ? builtins.currentSystem}:
 
-with import ../../top-level/all-packages.nix {inherit system;};
+with import ../../top-level/all-packages-wrapper.nix {inherit system;};
 
 rec {
   # We want coreutils without ACL support.

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -3,9 +3,9 @@
 let buildFor = toolsArch: (
 
 let
-  pkgsFun = import ../../top-level/all-packages.nix;
+  pkgsFun = import ../../top-level/all-packages-wrapper.nix;
   pkgsNoParams = pkgsFun {};
-  
+
   sheevaplugCrossSystem = {
     crossSystem = rec {
       config = "armv5tel-unknown-linux-gnueabi";

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -1,6 +1,6 @@
 { system ? builtins.currentSystem }:
 
-with import ../../top-level/all-packages.nix {inherit system;};
+with import ../../top-level/all-packages-wrapper.nix {inherit system;};
 
 rec {
 

--- a/pkgs/stdenv/pure-darwin/default.nix
+++ b/pkgs/stdenv/pure-darwin/default.nix
@@ -1,5 +1,5 @@
 { system      ? builtins.currentSystem
-, allPackages ? import ../../top-level/all-packages.nix
+, allPackages ? import ../../top-level/all-packages-wrapper.nix
 , platform    ? null
 , config      ? {}
 }:
@@ -34,7 +34,7 @@ let
   };
   tarball = fetch { file = "bootstrap-tools.9.cpio.bz2"; sha256 = "1xim0wm4ld45ysdmgpsa6b1f6srdnfj054ilv86k0pa5plvcmsf4"; };
 in rec {
-  allPackages = import ../../top-level/all-packages.nix;
+  allPackages = import ../../top-level/all-packages-wrapper.nix;
 
   commonPreHook = ''
     export NIX_ENFORCE_PURITY=1

--- a/pkgs/stdenv/pure-darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/pure-darwin/make-bootstrap-tools.nix
@@ -1,6 +1,6 @@
 {system ? builtins.currentSystem}:
 
-with import ../../top-level/all-packages.nix {inherit system;};
+with import ../../top-level/all-packages-wrapper.nix {inherit system;};
 
 rec {
   # We want coreutils without ACL support.

--- a/pkgs/test/mkOption/keep.nix
+++ b/pkgs/test/mkOption/keep.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import ../../top-level/all-packages.nix {};
+  pkgs = import ../../top-level/all-packages-wrapper.nix {};
   config = import ./declare.nix;
 in
   with (pkgs.lib);

--- a/pkgs/test/mkOption/merge.nix
+++ b/pkgs/test/mkOption/merge.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import ../../top-level/all-packages.nix {};
+  pkgs = import ../../top-level/all-packages-wrapper.nix {};
   config = import ./declare.nix;
 
   # Define the handler of unbound options.

--- a/pkgs/top-level/all-packages-aliases.nix
+++ b/pkgs/top-level/all-packages-aliases.nix
@@ -1,0 +1,44 @@
+pkgs: with pkgs;
+
+      ### Deprecated aliases - for backward compatibility
+
+rec {
+  adobeReader = adobe-reader;
+  arduino_core = arduino-core;  # added 2015-02-04
+  asciidocFull = asciidoc-full;  # added 2014-06-22
+  bridge_utils = bridge-utils;  # added 2015-02-20
+  buildbotSlave = buildbot-slave;  # added 2014-12-09
+  cheetahTemplate = pythonPackages.cheetah; # 2015-06-15
+  clangAnalyzer = clang-analyzer;  # added 2015-02-20
+  cool-old-term = cool-retro-term; # added 2015-01-31
+  cv = progress; # added 2015-09-06
+  enblendenfuse = enblend-enfuse;	# 2015-09-30
+  exfat-utils = exfat;                  # 2015-09-11
+  firefoxWrapper = firefox-wrapper;
+  fuse_exfat = exfat;                   # 2015-09-11
+  haskell-ng = haskell;                 # 2015-04-19
+  haskellngPackages = haskellPackages;  # 2015-04-19
+  htmlTidy = html-tidy;  # added 2014-12-06
+  inherit (haskell.compiler) jhc uhc;   # 2015-05-15
+  inotifyTools = inotify-tools;
+  jquery_ui = jquery-ui;  # added 2014-09-07
+  libtidy = html-tidy;  # added 2014-12-21
+  lttngTools = lttng-tools;  # added 2014-07-31
+  lttngUst = lttng-ust;  # added 2014-07-31
+  nfsUtils = nfs-utils;  # added 2014-12-06
+  quassel_qt5 = kf5Packages.quassel_qt5; # added 2015-09-30
+  quasselClient_qt5 = kf5Packages.quasselClient_qt5; # added 2015-09-30
+  quasselDaemon_qt5 = kf5Packages.quasselDaemon; # added 2015-09-30
+  quassel_kf5 = kf5Packages.quassel; # added 2015-09-30
+  quasselClient_kf5 = kf5Packages.quasselClient; # added 2015-09-30
+  rdiff_backup = rdiff-backup;  # added 2014-11-23
+  rssglx = rss-glx; #added 2015-03-25
+  rxvt_unicode_with-plugins = rxvt_unicode-with-plugins; # added 2015-04-02
+  speedtest_cli = speedtest-cli;  # added 2015-02-17
+  sqliteInteractive = sqlite-interactive;  # added 2014-12-06
+  x11 = xlibsWrapper; # added 2015-09
+  xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
+  xlibs = xorg; # added 2015-09
+  youtube-dl = pythonPackages.youtube-dl; # added 2015-06-07
+  youtubeDL = youtube-dl;  # added 2014-10-26
+}

--- a/pkgs/top-level/all-packages-wrapper.nix
+++ b/pkgs/top-level/all-packages-wrapper.nix
@@ -1,0 +1,134 @@
+/* This file composes the Nix Packages collection.  That is, it
+   imports the functions that build the various packages, and calls
+   them with appropriate arguments.  The result is a set of all the
+   packages in the Nix Packages collection for some particular
+   platform. */
+
+
+{ # The system (e.g., `i686-linux') for which to build the packages.
+  system ? builtins.currentSystem
+
+, # The standard environment to use.  Only used for bootstrapping.  If
+  # null, the default standard environment is used.
+  bootStdenv ? null
+
+, # Non-GNU/Linux OSes are currently "impure" platforms, with their libc
+  # outside of the store.  Thus, GCC, GFortran, & co. must always look for
+  # files in standard system directories (/usr/include, etc.)
+  noSysDirs ? (system != "x86_64-freebsd" && system != "i686-freebsd"
+               && system != "x86_64-kfreebsd-gnu")
+
+  # More flags for the bootstrapping of stdenv.
+, gccWithCC ? true
+, gccWithProfiling ? true
+
+, # Allow a configuration attribute set to be passed in as an
+  # argument.  Otherwise, it's read from $NIXPKGS_CONFIG or
+  # ~/.nixpkgs/config.nix.
+  config ? null
+
+, crossSystem ? null
+, platform ? null
+}:
+
+
+let config_ = config; platform_ = platform; in # rename the function arguments
+
+let
+
+  lib = import ../../lib;
+
+  # The contents of the configuration file found at $NIXPKGS_CONFIG or
+  # $HOME/.nixpkgs/config.nix.
+  # for NIXOS (nixos-rebuild): use nixpkgs.config option
+  config =
+    let
+      toPath = builtins.toPath;
+      getEnv = x: if builtins ? getEnv then builtins.getEnv x else "";
+      pathExists = name:
+        builtins ? pathExists && builtins.pathExists (toPath name);
+
+      configFile = getEnv "NIXPKGS_CONFIG";
+      homeDir = getEnv "HOME";
+      configFile2 = homeDir + "/.nixpkgs/config.nix";
+
+      configExpr =
+        if config_ != null then config_
+        else if configFile != "" && pathExists configFile then import (toPath configFile)
+        else if homeDir != "" && pathExists configFile2 then import (toPath configFile2)
+        else {};
+
+    in
+      # allow both:
+      # { /* the config */ } and
+      # { pkgs, ... } : { /* the config */ }
+      if builtins.isFunction configExpr
+        then configExpr { inherit pkgs; }
+        else configExpr;
+
+  # Allow setting the platform in the config file. Otherwise, let's use a reasonable default (pc)
+
+  platformAuto = let
+      platforms = (import ./platforms.nix);
+    in
+      if system == "armv6l-linux" then platforms.raspberrypi
+      else if system == "armv7l-linux" then platforms.armv7l-hf-multiplatform
+      else if system == "armv5tel-linux" then platforms.sheevaplug
+      else if system == "mips64el-linux" then platforms.fuloong2f_n32
+      else if system == "x86_64-linux" then platforms.pc64
+      else if system == "i686-linux" then platforms.pc32
+      else platforms.pcBase;
+
+  platform = if platform_ != null then platform_
+    else config.platform or platformAuto;
+
+  # Allow packages to be overriden globally via the `packageOverrides'
+  # configuration option, which must be a function that takes `pkgs'
+  # as an argument and returns a set of new or overriden packages.
+  # The `packageOverrides' function is called with the *original*
+  # (un-overriden) set of packages, allowing packageOverrides
+  # attributes to refer to the original attributes (e.g. "foo =
+  # ... pkgs.foo ...").
+  pkgs = applyGlobalOverrides (config.packageOverrides or (pkgs: {}));
+
+  mkOverrides = pkgsOrig: overrides: overrides //
+        (lib.optionalAttrs (pkgsOrig.stdenv ? overrides && crossSystem == null) (pkgsOrig.stdenv.overrides pkgsOrig));
+
+  # Return the complete set of packages, after applying the overrides
+  # returned by the `overrider' function (see above).  Warning: this
+  # function is very expensive!
+  applyGlobalOverrides = overrider:
+    let
+      # Call the overrider function.  We don't want stdenv overrides
+      # in the case of cross-building, or otherwise the basic
+      # overrided packages will not be built with the crossStdenv
+      # adapter.
+      overrides = mkOverrides pkgsOrig (overrider pkgsOrig);
+
+      # The un-overriden packages, passed to `overrider'.
+      pkgsOrig = pkgsFun pkgs {};
+
+      # The overriden, final packages.
+      pkgs = pkgsFun pkgs overrides;
+    in pkgs;
+
+  # The package compositions.
+  pkgsFun = pkgs: overrides:
+    let
+      self = self_ // overrides;
+      self_ = import ./all-packages.nix {
+        inherit self pkgs;
+        inherit system crossSystem platform bootStdenv noSysDirs gccWithCC
+                gccWithProfiling config;
+      };
+
+      aliases = import ./all-packages-aliases.nix self;
+
+      tweakAlias = _n: alias: with lib;
+        if alias.recurseForDerivations or false then
+          removeAttrs alias ["recurseForDerivations"]
+        else alias;
+
+    in lib.mapAttrs tweakAlias aliases // self;
+
+in pkgs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29,6 +29,10 @@
   # argument.  Otherwise, it's read from $NIXPKGS_CONFIG or
   # ~/.nixpkgs/config.nix.
   config
+
+, # These are used by overridePackages
+  mkOverrides
+, pkgsFun
 }:
 
 let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1,86 +1,38 @@
-/* This file composes the Nix Packages collection.  That is, it
-   imports the functions that build the various packages, and calls
-   them with appropriate arguments.  The result is a set of all the
-   packages in the Nix Packages collection for some particular
-   platform. */
+{ # Self-reference which is mutated by the user configuration, and from
+  # which all dependencies are infered. This self-reference is similar to
+  # the `rec` keyword with overwritten packages.
+  self
 
+, # Another self-reference which is used to build the original set of
+  # packages with the overwritten dependencies.
+  pkgs
 
-{ # The system (e.g., `i686-linux') for which to build the packages.
-  system ? builtins.currentSystem
+, # The system (e.g., `i686-linux') for which to build the packages.
+  system
+, crossSystem
+, platform
 
 , # The standard environment to use.  Only used for bootstrapping.  If
   # null, the default standard environment is used.
-  bootStdenv ? null
+  bootStdenv
 
 , # Non-GNU/Linux OSes are currently "impure" platforms, with their libc
   # outside of the store.  Thus, GCC, GFortran, & co. must always look for
   # files in standard system directories (/usr/include, etc.)
-  noSysDirs ? (system != "x86_64-freebsd" && system != "i686-freebsd"
-               && system != "x86_64-kfreebsd-gnu")
+  noSysDirs
 
   # More flags for the bootstrapping of stdenv.
-, gccWithCC ? true
-, gccWithProfiling ? true
+, gccWithCC
+, gccWithProfiling
 
 , # Allow a configuration attribute set to be passed in as an
   # argument.  Otherwise, it's read from $NIXPKGS_CONFIG or
   # ~/.nixpkgs/config.nix.
-  config ? null
-
-, crossSystem ? null
-, platform ? null
+  config
 }:
 
-
-let config_ = config; platform_ = platform; in # rename the function arguments
-
 let
-
   lib = import ../../lib;
-
-  # The contents of the configuration file found at $NIXPKGS_CONFIG or
-  # $HOME/.nixpkgs/config.nix.
-  # for NIXOS (nixos-rebuild): use nixpkgs.config option
-  config =
-    let
-      toPath = builtins.toPath;
-      getEnv = x: if builtins ? getEnv then builtins.getEnv x else "";
-      pathExists = name:
-        builtins ? pathExists && builtins.pathExists (toPath name);
-
-      configFile = getEnv "NIXPKGS_CONFIG";
-      homeDir = getEnv "HOME";
-      configFile2 = homeDir + "/.nixpkgs/config.nix";
-
-      configExpr =
-        if config_ != null then config_
-        else if configFile != "" && pathExists configFile then import (toPath configFile)
-        else if homeDir != "" && pathExists configFile2 then import (toPath configFile2)
-        else {};
-
-    in
-      # allow both:
-      # { /* the config */ } and
-      # { pkgs, ... } : { /* the config */ }
-      if builtins.isFunction configExpr
-        then configExpr { inherit pkgs; }
-        else configExpr;
-
-  # Allow setting the platform in the config file. Otherwise, let's use a reasonable default (pc)
-
-  platformAuto = let
-      platforms = (import ./platforms.nix);
-    in
-      if system == "armv6l-linux" then platforms.raspberrypi
-      else if system == "armv7l-linux" then platforms.armv7l-hf-multiplatform
-      else if system == "armv5tel-linux" then platforms.sheevaplug
-      else if system == "mips64el-linux" then platforms.fuloong2f_n32
-      else if system == "x86_64-linux" then platforms.pc64
-      else if system == "i686-linux" then platforms.pc32
-      else platforms.pcBase;
-
-  platform = if platform_ != null then platform_
-    else config.platform or platformAuto;
 
   # Helper functions that are exported through `pkgs'.
   helperFunctions =
@@ -90,43 +42,15 @@ let
   stdenvAdapters =
     import ../stdenv/adapters.nix pkgs;
 
+  # Default scope of packages used by callPackages to fill the named
+  # arguments of the functions which are imported by each package
+  # expression.
+  defaultScope = pkgs // pkgs.xorg;
+in
 
-  # Allow packages to be overriden globally via the `packageOverrides'
-  # configuration option, which must be a function that takes `pkgs'
-  # as an argument and returns a set of new or overriden packages.
-  # The `packageOverrides' function is called with the *original*
-  # (un-overriden) set of packages, allowing packageOverrides
-  # attributes to refer to the original attributes (e.g. "foo =
-  # ... pkgs.foo ...").
-  pkgs = applyGlobalOverrides (config.packageOverrides or (pkgs: {}));
+with self;
 
-  mkOverrides = pkgsOrig: overrides: overrides //
-        (lib.optionalAttrs (pkgsOrig.stdenv ? overrides && crossSystem == null) (pkgsOrig.stdenv.overrides pkgsOrig));
-
-  # Return the complete set of packages, after applying the overrides
-  # returned by the `overrider' function (see above).  Warning: this
-  # function is very expensive!
-  applyGlobalOverrides = overrider:
-    let
-      # Call the overrider function.  We don't want stdenv overrides
-      # in the case of cross-building, or otherwise the basic
-      # overrided packages will not be built with the crossStdenv
-      # adapter.
-      overrides = mkOverrides pkgsOrig (overrider pkgsOrig);
-
-      # The un-overriden packages, passed to `overrider'.
-      pkgsOrig = pkgsFun pkgs {};
-
-      # The overriden, final packages.
-      pkgs = pkgsFun pkgs overrides;
-    in pkgs;
-
-
-  # The package compositions.  Yes, this isn't properly indented.
-  pkgsFun = pkgs: overrides:
-    with helperFunctions;
-    let defaultScope = pkgs // pkgs.xorg; self = self_ // overrides;
-    self_ = with self; helperFunctions // {
+helperFunctions // {
 
   # Make some arguments passed to all-packages.nix available
   inherit system platform;
@@ -163,7 +87,7 @@ let
     in newpkgs;
 
   # Override system. This is useful to build i686 packages on x86_64-linux.
-  forceSystem = system: kernel: (import ./all-packages.nix) {
+  forceSystem = system: kernel: (import ./all-packages-wrapper.nix) {
     inherit system;
     platform = platform // { kernelArch = kernel; };
     inherit bootStdenv noSysDirs gccWithCC gccWithProfiling config
@@ -211,7 +135,7 @@ let
 
   allStdenvs = import ../stdenv {
     inherit system platform config lib;
-    allPackages = args: import ./all-packages.nix ({ inherit config system; } // args);
+    allPackages = args: import ./all-packages-wrapper.nix ({ inherit config system; } // args);
   };
 
   defaultStdenv = allStdenvs.stdenv // { inherit platform; };
@@ -228,7 +152,7 @@ let
         in if changer != null then
           changer {
             # We import again all-packages to avoid recursivities.
-            pkgs = import ./all-packages.nix {
+            pkgs = import ./all-packages-wrapper.nix {
               # We remove packageOverrides to avoid recursivities
               config = removeAttrs config [ "replaceStdenv" ];
             };
@@ -3500,7 +3424,7 @@ let
     # load into the Ben Nanonote
     gccCross =
       let
-        pkgsCross = (import ./all-packages.nix) {
+        pkgsCross = (import ./all-packages-wrapper.nix) {
           inherit system;
           inherit bootStdenv noSysDirs gccWithCC gccWithProfiling config;
           # Ben Nanonote system
@@ -15134,56 +15058,4 @@ let
 
   mg = callPackage ../applications/editors/mg { };
 
-}; # self_ =
-
-
-  ### Deprecated aliases - for backward compatibility
-
-aliases = with self; rec {
-  adobeReader = adobe-reader;
-  arduino_core = arduino-core;  # added 2015-02-04
-  asciidocFull = asciidoc-full;  # added 2014-06-22
-  bridge_utils = bridge-utils;  # added 2015-02-20
-  buildbotSlave = buildbot-slave;  # added 2014-12-09
-  cheetahTemplate = pythonPackages.cheetah; # 2015-06-15
-  clangAnalyzer = clang-analyzer;  # added 2015-02-20
-  cool-old-term = cool-retro-term; # added 2015-01-31
-  cv = progress; # added 2015-09-06
-  enblendenfuse = enblend-enfuse;	# 2015-09-30
-  exfat-utils = exfat;                  # 2015-09-11
-  firefoxWrapper = firefox-wrapper;
-  fuse_exfat = exfat;                   # 2015-09-11
-  haskell-ng = haskell;                 # 2015-04-19
-  haskellngPackages = haskellPackages;  # 2015-04-19
-  htmlTidy = html-tidy;  # added 2014-12-06
-  inherit (haskell.compiler) jhc uhc;   # 2015-05-15
-  inotifyTools = inotify-tools;
-  jquery_ui = jquery-ui;  # added 2014-09-07
-  libtidy = html-tidy;  # added 2014-12-21
-  lttngTools = lttng-tools;  # added 2014-07-31
-  lttngUst = lttng-ust;  # added 2014-07-31
-  nfsUtils = nfs-utils;  # added 2014-12-06
-  quassel_qt5 = kf5Packages.quassel_qt5; # added 2015-09-30
-  quasselClient_qt5 = kf5Packages.quasselClient_qt5; # added 2015-09-30
-  quasselDaemon_qt5 = kf5Packages.quasselDaemon; # added 2015-09-30
-  quassel_kf5 = kf5Packages.quassel; # added 2015-09-30
-  quasselClient_kf5 = kf5Packages.quasselClient; # added 2015-09-30
-  rdiff_backup = rdiff-backup;  # added 2014-11-23
-  rssglx = rss-glx; #added 2015-03-25
-  rxvt_unicode_with-plugins = rxvt_unicode-with-plugins; # added 2015-04-02
-  speedtest_cli = speedtest-cli;  # added 2015-02-17
-  sqliteInteractive = sqlite-interactive;  # added 2014-12-06
-  x11 = xlibsWrapper; # added 2015-09
-  xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
-  xlibs = xorg; # added 2015-09
-  youtube-dl = pythonPackages.youtube-dl; # added 2015-06-07
-  youtubeDL = youtube-dl;  # added 2014-10-26
-};
-
-tweakAlias = _n: alias: with lib;
-  if alias.recurseForDerivations or false then
-    removeAttrs alias ["recurseForDerivations"]
-  else alias;
-
-in lib.mapAttrs tweakAlias aliases // self; in pkgs
-
+}

--- a/pkgs/top-level/guile-2-test.nix
+++ b/pkgs/top-level/guile-2-test.nix
@@ -4,7 +4,7 @@
    -- ludo@gnu.org  */
 
 let
-  allPackages = import ./all-packages.nix;
+  allPackages = import ./all-packages-wrapper.nix;
 
   pkgsFun = { system ? builtins.currentSystem }:
     allPackages {

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -35,8 +35,8 @@ releaseTools.sourceTarball rec {
     # Make sure that derivation paths do not depend on the Nixpkgs path.
     mkdir $TMPDIR/foo
     ln -s $(readlink -f .) $TMPDIR/foo/bar
-    p1=$(nix-instantiate pkgs/top-level/all-packages.nix --dry-run -A firefox)
-    p2=$(nix-instantiate $TMPDIR/foo/bar/pkgs/top-level/all-packages.nix --dry-run -A firefox)
+    p1=$(nix-instantiate pkgs/top-level/all-packages-wrapper.nix --dry-run -A firefox)
+    p2=$(nix-instantiate $TMPDIR/foo/bar/pkgs/top-level/all-packages-wrapper.nix --dry-run -A firefox)
     if [ "$p1" != "$p2" ]; then
         echo "Nixpkgs evaluation depends on Nixpkgs path ($p1 vs $p2)!"
         exit 1
@@ -49,13 +49,13 @@ releaseTools.sourceTarball rec {
         exit 1
     fi
 
-    # Check that all-packages.nix evaluates on a number of platforms.
+    # Check that all-packages-wrapper.nix evaluates on a number of platforms.
     for platform in i686-linux x86_64-linux x86_64-darwin; do
-        header "checking pkgs/top-level/all-packages.nix on $platform"
-        NIXPKGS_ALLOW_BROKEN=1 nix-env -f pkgs/top-level/all-packages.nix \
+        header "checking pkgs/top-level/all-packages-wrapper.nix on $platform"
+        NIXPKGS_ALLOW_BROKEN=1 nix-env -f pkgs/top-level/all-packages-wrapper.nix \
             --show-trace --argstr system "$platform" \
             -qa --drv-path --system-filter \* --system > /dev/null
-        NIXPKGS_ALLOW_BROKEN=1 nix-env -f pkgs/top-level/all-packages.nix \
+        NIXPKGS_ALLOW_BROKEN=1 nix-env -f pkgs/top-level/all-packages-wrapper.nix \
             --show-trace --argstr system "$platform" \
             -qa --drv-path --system-filter \* --system --meta --xml > /dev/null
         stopNest

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,4 +1,4 @@
-{ supportedSystems, packageSet ? (import ./all-packages.nix), allowTexliveBuilds ? false }:
+{ supportedSystems, packageSet ? (import ./all-packages-wrapper.nix), allowTexliveBuilds ? false }:
 
 with import ../../lib;
 

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -3,7 +3,7 @@
    $ nix-build pkgs/top-level/release-python.nix
 */
 
-{ nixpkgs ? { outPath = (import ./all-packages.nix {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
 , # The platforms for which we build Nixpkgs.
   supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "x86_64-freebsd" "i686-freebsd" ]

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -1,7 +1,7 @@
 /* A small release file, with few packages to be built.  The aim is to reduce
    the load on Hydra when testing the `stdenv-updates' branch. */
 
-{ nixpkgs ? { outPath = (import ./all-packages.nix {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" ]
 }:
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -9,7 +9,7 @@
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
 
-{ nixpkgs ? { outPath = (import ./all-packages.nix {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
 , # The platforms for which we build Nixpkgs.
   supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" ]


### PR DESCRIPTION
This patch is moves the header & footer of `all-packages.nix` into a separated file named `all-packages-wrapper.nix`.  To do so, I added a new list of arguments to the `all-packages.nix` which is the explicit list of dependencies, and that we can reduce over time by making it part of the list of paclkages. (`system`, `bootStdenv`, `noSysDir`, …)

Later we should change the way we handle self-references (`self` & `pkgs`) such that we can follow the same scheme as done in haskellPackages (`self` & `super`).

These modifications are made to simplify the way we can add additional logic to our list of packages.

Note: This patch does not change the sha1 of derivations.
Note: This patch fix the indentation issue of `all-packages.nix`.
cc @peti @domenkozar @edolstra
