### PR TITLE
buildEnv: improvements

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -261,7 +261,7 @@ let
     { substitutions = { inherit autoconf automake gettext libtool; }; }
     ../build-support/setup-hooks/autoreconf.sh;
 
-  buildEnv = callPackage ../build-support/buildenv {};
+  buildEnv = callPackage ../build-support/buildenv { inherit lib; };
 
   buildFHSEnv = callPackage ../build-support/build-fhs-chrootenv/env.nix {
     nixpkgs      = pkgs;


### PR DESCRIPTION
Add the possibility to specify arbitrary arguments
(same as with other derivation helpers).

This allows one to use a buildEnv helper to define a
package.

Tests:
-  Using fixed attribute throws an error.
-  Using an arbitrary attribute such as `nativeBuildInputs`,
  `meta`, `dontPatchELF` or `dontStrip` work fine.
