### PR TITLE
neovim: Create symlink to correct python3 binary

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -103,7 +103,7 @@ let
     '' + optionalString withPython ''
       ln -s ${pythonEnv}/bin/python $out/bin/nvim-python
     '' + optionalString withPython3 ''
-      ln -s ${python3Env}/bin/python $out/bin/nvim-python3
+      ln -s ${python3Env}/bin/python3 $out/bin/nvim-python3
     '' + optionalString (withPython || withPython3) ''
         wrapProgram $out/bin/nvim --add-flags "${
           (optionalString withPython


### PR DESCRIPTION
The symlink being created pointed to 'python' rather than 'python3'
