### PR TITLE
borgbackup: bump to 0.27.0 and rename to correct name borgbackup

### DIFF
--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -1,21 +1,23 @@
-{ stdenv, fetchzip, python3Packages, openssl, acl }:
+{ stdenv, fetchurl, python3Packages, openssl, acl, lz4 }:
 
 python3Packages.buildPythonPackage rec {
-  name = "borg-${version}";
-  version = "0.23.0";
+  name = "borgbackup-${version}";
+  version = "0.27.0";
   namePrefix = "";
 
-  src = fetchzip {
-    name = "${name}-src";
-    url = "https://github.com/borgbackup/borg/archive/${version}.tar.gz";
-    sha256 = "1ns00bhrh4zm1s70mm32gnahj7yh4jdpkb8ziarhvcnknz7aga67";
+  src = fetchurl {
+    url = "https://pypi.python.org/packages/source/b/borgbackup/borgbackup-${version}.tar.gz";
+    sha256 = "04iizidag4fwy6kx1747d633s1amr81slgk743qsfbwixaxfjq9b";
   };
 
   propagatedBuildInputs = with python3Packages;
-    [ cython msgpack openssl acl llfuse tox detox ];
+    [ cython msgpack openssl acl llfuse tox detox lz4 setuptools_scm ];
 
   preConfigure = ''
     export BORG_OPENSSL_PREFIX="${openssl}"
+    export BORG_LZ4_PREFIX="${lz4}"
+    # note: fix for this issue already upstream and probably in 0.27.1 (or whatever the next release is called)
+    substituteInPlace setup.py --replace "possible_openssl_prefixes.insert(0, os.environ.get('BORG_LZ4_PREFIX'))" "possible_lz4_prefixes.insert(0, os.environ.get('BORG_LZ4_PREFIX'))"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -763,7 +763,7 @@ let
 
   bochs = callPackage ../applications/virtualization/bochs { };
 
-  borg = callPackage ../tools/backup/borg { };
+  borgbackup = callPackage ../tools/backup/borg { };
 
   boomerang = callPackage ../development/tools/boomerang { };
 


### PR DESCRIPTION
what i did:
- version bump to 0.27.0
- renamed from borg to borgbackup (which is the proper name)
- fixed a bug in borgbackup
- i compiles and main program, borg, seems to execute but did not do much further testing

i think it is save to merge.
