### PR TITLE
bump nix version requirement to 1.10, fixes #10337

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,12 @@
-if ! builtins ? nixVersion || builtins.compareVersions "1.8" builtins.nixVersion == 1 then
+let
+  minVersion = "1.10";
+in
+  with builtins;
+  if ! builtins ? nixVersion || compareVersions minVersion nixVersion == 1 then
 
-  abort "This version of Nixpkgs requires Nix >= 1.8, please upgrade! See https://nixos.org/wiki/How_to_update_when_nix_is_too_old_to_evaluate_nixpkgs"
+    abort ("This version of Nixpkgs requires Nix >= ${minVersion}, please upgrade!"
+      + " See https://nixos.org/wiki/How_to_update_when_nix_is_too_old_to_evaluate_nixpkgs")
 
-else
+  else
 
-  import ./pkgs/top-level/all-packages.nix
+    import ./pkgs/top-level/all-packages.nix


### PR DESCRIPTION
Since 2d9885d we encourage to use 1.10 features (and we do use them),
but we only check for 1.8. This goes for both master and 15.09 nixpkgs versions.

@edolstra: I assume it was meant that 15.09 requires nix-1.10.
