### PR TITLE
init: meterbridge 0.9.2

### DIFF
--- a/pkgs/applications/audio/meterbridge/buf_rect.patch
+++ b/pkgs/applications/audio/meterbridge/buf_rect.patch
@@ -1,0 +1,12 @@
+--- ../tmp-orig/meterbridge-0.9.2/src/main.h	2003-06-05 11:42:41.000000000 +0200
++++ ./src/main.h	2004-12-29 10:27:24.160912488 +0100
+@@ -8,7 +8,7 @@
+ 
+ extern SDL_Surface *screen;
+ extern SDL_Surface *image, *meter, *meter_buf;
+-extern SDL_Rect win, buf_rect[MAX_METERS], dest[MAX_METERS];
++extern SDL_Rect win, dest[MAX_METERS];
+ 
+ extern jack_port_t *input_ports[MAX_METERS];
+ extern jack_port_t *output_ports[MAX_METERS];
+

--- a/pkgs/applications/audio/meterbridge/default.nix
+++ b/pkgs/applications/audio/meterbridge/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pkgconfig, SDL, SDL_image, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.9.2";
+  name = "meterbridge-${version}";
+
+  src = fetchurl {
+    url = "http://plugin.org.uk/meterbridge/${name}.tar.gz";
+    sha256 = "0jb6g3kbfyr5yf8mvblnciva2bmc01ijpr51m21r27rqmgi8gj5k";
+  };
+
+  patches = [ ./buf_rect.patch ];
+
+  buildInputs =
+    [ pkgconfig SDL SDL_image libjack2
+    ];
+
+  meta = with stdenv.lib; {
+    description = "Various meters (VU, PPM, DPM, JF, SCO) for Jack Audio Connection Kit";
+    homepage = http://plugin.org.uk/meterbridge/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.nico202 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7576,6 +7576,8 @@ let
     paths = [ mesa_noglu mesa_glu ];
   });
 
+  meterbridge = callPackage ../applications/audio/meterbridge { };
+
   metaEnvironment = recurseIntoAttrs (let callPackage = newScope pkgs.metaEnvironment; in rec {
     sdfLibrary    = callPackage ../development/libraries/sdf-library { aterm = aterm28; };
     toolbuslib    = callPackage ../development/libraries/toolbuslib { aterm = aterm28; inherit (windows) w32api; };


### PR DESCRIPTION
Website: http://plugin.org.uk/meterbridge/
The source is a bit outdated (even if it's the latest version) so compiling encounter this bug:
https://bbs.archlinux.org/viewtopic.php?id=81533

I added the following patch: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=287641
that fixes the compilation problem
