### PR TITLE
Latest llvm-general now requires llvm 3.5

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -635,8 +635,8 @@ self: super: {
   # Uses OpenGL in testing
   caramia = dontCheck super.caramia;
 
-  # Supports only 3.4 for now, https://github.com/bscarlet/llvm-general/issues/144
-  llvm-general = super.llvm-general.override { llvm-config = pkgs.llvm_34; };
+  # Supports only 3.5 for now, https://github.com/bscarlet/llvm-general/issues/142
+  llvm-general = super.llvm-general.override { llvm-config = pkgs.llvm_35; };
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool super.spaceprobe self.llvmPackages.llvm;


### PR DESCRIPTION
The latest version of llvm-general on hackage won't build anymore because it requires llvm 3.5 instead of 3.4.
