### PR TITLE
Fix typo in nixos/modules/tasks/filesystems/nfs.nix.

### DIFF
--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -90,7 +90,7 @@ in
         serviceConfig.Type = "forking";
         serviceConfig.ExecStart = ''
           @${pkgs.nfs-utils}/sbin/rpc.statd rpc.statd --no-notify \
-              ${if cfg.statdPort != null then "-p ${toString statdPort}" else ""}
+              ${if cfg.statdPort != null then "-p ${toString cfg.statdPort}" else ""}
         '';
         serviceConfig.Restart = "always";
       };


### PR DESCRIPTION
**statd** should be **cfg.statd**.
