### PR TITLE
nixos/bash: use simple prompt for dumb terminals

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -90,12 +90,14 @@ in
 
       promptInit = mkOption {
         default = ''
-          # Provide a nice prompt.
-          PROMPT_COLOR="1;31m"
-          let $UID && PROMPT_COLOR="1;32m"
-          PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
-          if test "$TERM" = "xterm"; then
-            PS1="\[\033]2;\h:\u:\w\007\]$PS1"
+          if test "$TERM" != "dumb"; then
+            # Provide a nice prompt.
+            PROMPT_COLOR="1;31m"
+            let $UID && PROMPT_COLOR="1;32m"
+            PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
+            if test "$TERM" = "xterm"; then
+              PS1="\[\033]2;\h:\u:\w\007\]$PS1"
+            fi
           fi
         '';
         description = ''


### PR DESCRIPTION
This fixes connecting to NixOS hosts with Tramp (Emacs' SSH plugin), possibly other software that expects dumbed-down prompts on `TERM=dumb`. I _think_ that Arch Linux and possibly Fedora already do this because I had no trouble connecting to such hosts in the past.

cc @edolstra @domenkozar 
