### PR TITLE
ffmpeg: 2.7.2 -> 2.8.1

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -231,11 +231,11 @@ assert x11grabExtlib -> libX11 != null && libXv != null;
 
 stdenv.mkDerivation rec {
   name = "ffmpeg-full-${version}";
-  version = "2.7.2";
+  version = "2.8.1";
 
   src = fetchurl {
     url = "https://www.ffmpeg.org/releases/ffmpeg-${version}.tar.bz2";
-    sha256 = "1wlygd0jp34dk4qagi4h9psn4yk8zgyj7zy9lrpm5332mm87bsvw";
+    sha256 = "1qk6g2h993i0wgs9d2p3ahdc5bqr03mp74bk6r1zj6pfinr5mvg2";
   };
 
   patchPhase = ''patchShebangs .'';

--- a/pkgs/development/libraries/ffmpeg/2.8.nix
+++ b/pkgs/development/libraries/ffmpeg/2.8.nix
@@ -1,0 +1,7 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "${branch}.1";
+  branch = "2.8";
+  sha256 = "1qk6g2h993i0wgs9d2p3ahdc5bqr03mp74bk6r1zj6pfinr5mvg2";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6152,10 +6152,11 @@ let
   ffmpeg_2_2 = callPackage ../development/libraries/ffmpeg/2.2.nix { };
   ffmpeg_2_6 = callPackage ../development/libraries/ffmpeg/2.6.nix { };
   ffmpeg_2_7 = callPackage ../development/libraries/ffmpeg/2.7.nix { };
+  ffmpeg_2_8 = callPackage ../development/libraries/ffmpeg/2.8.nix { };
   # Aliases
   ffmpeg_0 = ffmpeg_0_10;
   ffmpeg_1 = ffmpeg_1_2;
-  ffmpeg_2 = ffmpeg_2_7;
+  ffmpeg_2 = ffmpeg_2_8;
   ffmpeg = ffmpeg_2;
 
   ffmpeg-full = callPackage ../development/libraries/ffmpeg-full {


### PR DESCRIPTION
Tested with `nix-build -A ffmpeg` and `nix-build -A ffmpeg-full`.

Looks like 2.6.x is still in use:

```
andy@nixos:~/dev/nixpkgs$ grep -RI ffmpeg_2_6
pkgs/applications/video/kodi/default.nix:  ffmpeg_2_6_4 = fetchurl {
pkgs/applications/video/kodi/default.nix:      cp ${ffmpeg_2_6_4} tools/depends/target/ffmpeg/ffmpeg-2.6.4-${rel}.tar.gz
pkgs/top-level/all-packages.nix:  ffmpeg_2_6 = callPackage ../development/libraries/ffmpeg/2.6.nix { };
```

But 2.7.x is not:

```
andy@nixos:~/dev/nixpkgs$ grep -RI ffmpeg_2_7
pkgs/top-level/all-packages.nix:  ffmpeg_2_7 = callPackage ../development/libraries/ffmpeg/2.7.nix { };
```

cc @codyopel
cc @Fuuzetsu 
