### PR TITLE
uhc: Update to 1.1.9.1

### DIFF
--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -1,18 +1,18 @@
 { stdenv, coreutils, fetchgit, m4, libtool, clang, ghcWithPackages }:
 
-let wrappedGhc = ghcWithPackages (hpkgs: with hpkgs; [shuffle hashable mtl network uhc-util uulib] );
+let wrappedGhc = ghcWithPackages (hpkgs: with hpkgs; [fgl vector syb uulib network binary hashable uhc-util mtl transformers directory containers array process filepath shuffle uuagc] );
 in stdenv.mkDerivation rec {
   # Important:
   # The commits "Fixate/tag v..." are the released versions.
   # Ignore the "bumped version to ...." commits, they do not
   # correspond to releases.
-  version = "1.1.9.1.20150611";
+  version = "1.1.9.1";
   name = "uhc-${version}";
 
   src = fetchgit {
     url = "https://github.com/UU-ComputerScience/uhc.git";
-    rev = "b80098e07d12900f098ea964b1d2b3f38e5c9900";
-    sha256 = "14qg1fd9pgbczcmn5ggkd9674qadx1izmz8363ps7c207dg94f9x";
+    rev = "ce93d01486972c994ea2bbbd3d43859911120c39";
+    sha256 = "1y670sc6ky74l3msayzqjlkjv1kpv3g35pirsq3q79klzvnpyj2x";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/EHC";
@@ -50,6 +50,5 @@ in stdenv.mkDerivation rec {
     # On Darwin, the GNU libtool is used, which does not
     # support the -static flag and thus breaks the build.
     platforms = ["x86_64-linux"];
-    broken = true; # https://github.com/UU-ComputerScience/uhc/issues/60
   };
 }


### PR DESCRIPTION
Update to new UHC release.

Fixes the UHC build in nixpkgs. See also https://github.com/UU-ComputerScience/uhc/issues/60 .
