### PR TITLE
ardour: 4.2 -> 4.4

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -15,7 +15,7 @@ let
   # "git describe" when _not_ on an annotated tag(!): MAJOR.MINOR-REV-HASH.
 
   # Version to build.
-  tag = "4.3";
+  tag = "4.4";
 
 in
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Ardour";
     repo = "ardour";
-    rev = "8d46cc99fe2778c5658b659f4f1fe6ac828bb9e9";
-    sha256 = "0rr55s3rirlfq455x0xzx8w09kji1fac2n8cx9p6p57qsfvxxblp";
+    rev = "b00d75adf63db155ef2873bd9d259dc8ca256be6";
+    sha256 = "1gnrcnq2ksnh7fsa301v1c4p5dqrbqpjylf02rg3za3ab58wxi7l";
   };
 
   buildInputs =

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation rec {
       makeWrapper pango perl pkgconfig python rubberband serd sord-svn sratom suil taglib vampSDK
     ];
 
+  # ardour's wscript has a "tarball" target but that required the git revision
+  # be available. Since this is an unzipped tarball fetched from github we 
+  # have to do that ourself.
   patchPhase = ''
     printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = \"${tag}-${builtins.substring 0 8 src.rev}\"; }\n' > libs/ardour/revision.cc
     sed 's|/usr/include/libintl.h|${glibc}/include/libintl.h|' -i wscript

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -15,7 +15,7 @@ let
   # "git describe" when _not_ on an annotated tag(!): MAJOR.MINOR-REV-HASH.
 
   # Version to build.
-  tag = "4.2";
+  tag = "4.3";
 
 in
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Ardour";
     repo = "ardour";
-    rev = "fe672c827cb2c08c94b1fa7e527d884c522a1af7";
-    sha256 = "12yfy9l5mnl96ix4s2qicp3m2zscli1a4bd50nk9v035pgf77s3f";
+    rev = "8d46cc99fe2778c5658b659f4f1fe6ac828bb9e9";
+    sha256 = "0rr55s3rirlfq455x0xzx8w09kji1fac2n8cx9p6p57qsfvxxblp";
   };
 
   buildInputs =
@@ -80,6 +80,6 @@ stdenv.mkDerivation rec {
     homepage = http://ardour.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = [ maintainers.goibhniu maintainers.fps ];
   };
 }


### PR DESCRIPTION
Skipping 4.3 as it had a major bug. The nix expression for the derivation is fine after all. Compiled and run locally.

Do not merge yet. Maybe there's another hotfix coming..
