### PR TITLE
xonotic: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -8,11 +8,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "xonotic-0.8.0";
+  name = "xonotic-0.8.1";
 
   src = fetchurl {
     url = "http://dl.xonotic.org/${name}.zip";
-    sha256 = "0w336750sq8nwqljlcj3znk4iaj3nvn6id144d7j72vsh84ci1qa";
+    sha256 = "0vy4hkrbpz9g91gb84cbv4xl845qxaknak6hshk2yflrw90wr2xy";
   };
 
   buildInputs = [


### PR DESCRIPTION
Just changed the version to 0.8.1 and changed the hash. This package has some issues with fonts. They look quite funky compared to the prebuilt release packages from xonotic.org. I guess we might file a separate issue against the package.

Built and run locally. Except for the font issue it looks fine.
