### PR TITLE
nixos-generate-config: look at mmc_host for device drivers

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -233,8 +233,8 @@ foreach my $path (glob "/sys/bus/usb/devices/*") {
 }
 
 
-# Add the modules for all block devices.
-foreach my $path (glob "/sys/class/block/*") {
+# Add the modules for all block and MMC devices.
+foreach my $path (glob "/sys/class/{block,mmc_host}/*") {
     my $module;
     if (-e "$path/device/driver/module") {
         $module = basename `readlink -f $path/device/driver/module`;


### PR DESCRIPTION
I needed to add sdhci_acpi and mmc_block to my initrd modules in order to boot
my Chromebook. Looking under /sys/class/mmc_host/*/device/driver/module will
give us the sdhci_acpi dependency.
