### PR TITLE
numlockx: init at 1.2

### DIFF
--- a/pkgs/tools/X11/numlockx/default.nix
+++ b/pkgs/tools/X11/numlockx/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, libX11, libXext, autoconf }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  version = "1.2";
+  pname = "numlockx";
+
+  src = fetchFromGitHub {
+    owner = "rg3";
+    repo = pname;
+    rev = "9159fd3c5717c595dadfcb33b380a85c88406185";
+    sha256 = "1w49fayhwzn5rx0z1q2lrvm7z8jrd34lgb89p853a024bixc3cf2";
+  };
+
+  buildInputs = [ libX11 libXext autoconf ];
+
+  meta = with stdenv.lib; {
+    description = "Allows to start X with NumLock turned on";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2426,6 +2426,8 @@ let
 
   numdiff = callPackage ../tools/text/numdiff { };
 
+  numlockx = callPackage ../tools/X11/numlockx { };
+
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
   nwdiag = pythonPackages.nwdiag;


### PR DESCRIPTION
I've tested locally without issues.
The original homepage is not accessible, and I didn't insert it into the meta.
