### PR TITLE
bcprov: init at 1.53, bcpkix: init at 1.53, portecle: init at 1.9, android-backup-extractor: init at git-2015-06-12

### DIFF
--- a/pkgs/applications/misc/portecle/default.nix
+++ b/pkgs/applications/misc/portecle/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, makeWrapper, unzip, bcprov, bcpkix, ant, jdk } :
+stdenv.mkDerivation rec {
+  name = "portecle-1.9";
+  src = fetchurl {
+    url = "mirror://sourceforge/portecle/${name}-src.zip";
+    sha256 = "43efae9c9d20dd373f0a371c1506314afe5a10f88382e45671e06c2d0547b5e0";
+  };
+  nativeBuildInputs = [ ant jdk unzip makeWrapper ];
+  patches = [ ./remove-pack200.patch ];
+  buildPhase = ''
+    rm lib/*.jar
+    ln -s ${bcprov}/share/java/*.jar lib/bcprov-jdk15on-152.jar
+    ln -s ${bcpkix}/share/java/*.jar lib/bcpkix-jdk15on-152.jar
+    ant
+  '';
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/portecle
+    cp build/portecle.jar $out/lib/portecle
+    ln -s ${bcprov}/share/java/*.jar $out/lib/portecle/bcprov.jar
+    ln -s ${bcpkix}/share/java/*.jar $out/lib/portecle/bcpkix.jar
+    makeWrapper ${jdk.jre}/bin/java $out/bin/portecle --add-flags "-jar $out/lib/portecle/portecle.jar"
+  '';
+  meta = {
+    description = "A user friendly GUI for creating, managing and examining keystores, keys etc.";
+    homepage = "http://portecle.sourceforge.net/";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/misc/portecle/remove-pack200.patch
+++ b/pkgs/applications/misc/portecle/remove-pack200.patch
@@ -1,0 +1,54 @@
+diff --git a/build.xml b/build.xml
+index 5517939..b67bb8b 100644
+--- a/build.xml
++++ b/build.xml
+@@ -26,7 +26,7 @@
+ 
+   <property name="bcprov.jar" value="${lib}/bcprov-jdk15on-152.jar" />
+   <property name="bcpkix.jar" value="${lib}/bcpkix-jdk15on-152.jar" />
+-  <property name="pack200.jar" value="${lib}/deployment-ant-pack200-1.0.jar"/>
++ <!-- <property name="pack200.jar" value="${lib}/deployment-ant-pack200-1.0.jar"/> -->
+ 
+   <property name="build.debug" value="true" />
+   <property name="build.debuglevel" value="lines,source" />
+@@ -45,8 +45,8 @@
+     <pathelement location="${bcpkix.jar}" />
+   </path>
+ 
+-  <typedef resource="org/jdesktop/deployment/ant/pack200/antlib.xml"
+-           classpath="${pack200.jar}"/>
++<!--  <typedef resource="org/jdesktop/deployment/ant/pack200/antlib.xml"
++           classpath="${pack200.jar}"/> -->
+ 
+   <presetdef name="signjar" uri="urn:net.sf.portecle">
+     <signjar
+@@ -58,9 +58,9 @@
+       sigfile="PORTECLE"/>
+   </presetdef>
+ 
+-  <presetdef name="pack200" uri="urn:net.sf.portecle">
++<!--  <presetdef name="pack200" uri="urn:net.sf.portecle">
+     <pack200 effort="9"/>
+-  </presetdef>
++  </presetdef> -->
+ 
+   <presetdef name="zip" uri="urn:net.sf.portecle">
+     <zip level="9"/>
+@@ -138,7 +138,7 @@
+     </jar>
+   </target>
+ 
+-  <target name="webstart" depends="jar" description="Builds Java Web Start dir">
++ <!-- <target name="webstart" depends="jar" description="Builds Java Web Start dir">
+     <mkdir dir="${build}/webstart"/>
+ 
+     <copy todir="${build}/webstart" flatten="true" preservelastmodified="true">
+@@ -198,7 +198,7 @@
+     </copy>
+     <xmlvalidate file="${build}/webstart/portecle.jnlp"/>
+ 
+-  </target>
++  </target> -->
+ 
+   <target name="javadoc">
+     <mkdir dir="${build}/api" />

--- a/pkgs/development/libraries/java/bcpkix/default.nix
+++ b/pkgs/development/libraries/java/bcpkix/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, unzip, jdk, bcprov }:
+stdenv.mkDerivation rec {
+  name = "bcpkix-jdk15on-153";
+  nativeBuildInputs = [ unzip jdk ];
+  src = fetchurl {
+    url = "http://www.bouncycastle.org/download/bcpkix-jdk15on-153.tar.gz";
+    sha256 = "140b1b6a75171a0476e1f148946de01ccd0ae9025e14ff6b748846901efab151";
+  };
+  buildInputs = [ bcprov ];
+  buildPhase = "
+    unpackFile src.zip
+    find org -name 'test' -prune -o -name '*.java' -print0 | xargs -0 javac -encoding UTF-8
+    mkdir build
+    find org -name '*.class' -print0 | xargs -0 cp --parents -t build
+    jar cf ${name}.jar -C build .
+  ";
+  installPhase = ''
+    mkdir -p "$out/share/java";
+    cp ${name}.jar $out/share/java
+  '';
+  meta = {
+    description = "A Java implementation of PKIX/CMS/EAC/PKCS/OCSP/TSP/OPENSSL algorithms";
+    homepage = "http://www.bouncycastle.org/java.html";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/libraries/java/bcprov/default.nix
+++ b/pkgs/development/libraries/java/bcprov/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, unzip, jdk }:
+stdenv.mkDerivation rec {
+  name = "bcprov-jdk15on-153";
+  nativeBuildInputs = [ unzip jdk ];
+  src = fetchurl {
+    url = "http://www.bouncycastle.org/download/bcprov-jdk15on-153.tar.gz";
+    sha256 = "ef4a4fdb2777ee62a787304afe17c5401df869dc5d74cc5306f1270e3cb69615";
+  };
+  buildPhase = "
+    unpackFile src.zip
+    find org -name 'test' -prune -o -name '*.java' -print0 | xargs -0 javac -encoding UTF-8
+    mkdir build
+    find org -name '*.class' -print0 | xargs -0 cp --parents -t build
+    jar cf ${name}.jar -C build .
+  ";
+  installPhase = ''
+    mkdir -p "$out/share/java";
+    cp ${name}.jar $out/share/java
+  '';
+  meta = {
+    description = "A Java implementation of cryptographic algorithms";
+    homepage = "http://www.bouncycastle.org/java.html";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/backup/android-backup-extractor/default.nix
+++ b/pkgs/tools/backup/android-backup-extractor/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, makeWrapper, ant, jdk, bcprov } :
+stdenv.mkDerivation {
+  name = "android-backup-extractor-git-2015-06-12";
+  src = fetchgit {
+    url = "https://github.com/nelenkov/android-backup-extractor.git";
+    rev = "434afd12e8b59aa335888352c1ab5756c7778061";
+    sha256 = "a6da00c8fcc5a4ff0a4498fe03c67f8b18b1755546061969adc58ba168f38eb9";
+  };
+  nativeBuildInputs = [ ant jdk makeWrapper ];
+  buildPhase = "
+    # build.xml expects this name for the bcprov library
+    ln -s ${bcprov}/share/java/*.jar lib/bcprov-jdk15on-150.jar
+    ant
+  ";
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/android-backup-extractor
+    cp abe.jar $out/lib/android-backup-extractor
+    makeWrapper ${jdk.jre}/bin/java $out/bin/abe --add-flags "-cp $out/lib/android-backup-extractor/abe.jar org.nick.abe.Main"
+  '';
+  meta = {
+    description = "Utility to extract and repack Android backups created with adb backup";
+    homepage = "https://github.com/nelenkov/android-backup-extractor";
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5932,6 +5932,8 @@ let
 
   babl = callPackage ../development/libraries/babl { };
 
+  bcpkix = callPackage ../development/libraries/java/bcpkix { };
+
   bcprov = callPackage ../development/libraries/java/bcprov { };
 
   beecrypt = callPackage ../development/libraries/beecrypt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12499,6 +12499,8 @@ let
 
   ponymix = callPackage ../applications/audio/ponymix { };
 
+  portecle = callPackage ../applications/misc/portecle { };
+
   potrace = callPackage ../applications/graphics/potrace {};
 
   posterazor = callPackage ../applications/misc/posterazor { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5930,6 +5930,8 @@ let
 
   babl = callPackage ../development/libraries/babl { };
 
+  bcprov = callPackage ../development/libraries/java/bcprov { };
+
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
   belle-sip = callPackage ../development/libraries/belle-sip { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -478,6 +478,8 @@ let
 
   abduco = callPackage ../tools/misc/abduco { };
 
+  android-backup-extractor = callPackage ../tools/backup/android-backup-extractor { };
+
   acct = callPackage ../tools/system/acct { };
 
   acoustidFingerprinter = callPackage ../tools/audio/acoustid-fingerprinter {


### PR DESCRIPTION
Tested on Linux x86_64.
Seems to work.
This compiles the Bouncy Castle cryptographic libraries from the source, instead of using pre-compiled binaries.
