### PR TITLE
musescore: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig
+{ stdenv, fetchzip, cmake, pkgconfig
 , alsaLib, freetype, libjack2, lame, libogg, libpulseaudio, libsndfile, libvorbis
 , portaudio, qtbase, qtdeclarative, qtenginio, qtscript, qtsvg, qttools
 , qtwebkit, qtxmlpatterns
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "musescore-${version}";
-  version = "2.0.1";
+  version = "2.0.2";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/musescore/MuseScore/archive/v${version}.tar.gz";
-    sha256 = "0n4xk35jggdq2dcizqjq1kdpclih4scpl93ymmxahvfa1vvwn5iw";
+    sha256 = "12a83v4i830gj76z5744034y1vvwzgy27mjbjp508yh9bd328yqw";
   };
 
   makeFlags = [
@@ -33,7 +33,13 @@ stdenv.mkDerivation rec {
     make lrelease
   '';
 
+  postBuild = ''
+    make manpages
+  '';
+
   nativeBuildInputs = [ cmake pkgconfig ];
+
+  enableParallelBuilding = true;
 
   buildInputs = [
     alsaLib libjack2 freetype lame libogg libpulseaudio libsndfile libvorbis


### PR DESCRIPTION
Tested on linux x86_64: builds and runs.
