### PR TITLE
ruby: adjust the libPath

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -129,7 +129,7 @@ let
           inherit majorVersion minorVersion teenyVersion patchLevel;
           rubyEngine = "ruby";
           baseRuby = baseruby;
-          libPath = "lib/${versionNoPatch}";
+          libPath = "lib/${rubyEngine}/${versionNoPatch}";
           gemPath = "lib/${rubyEngine}/gems/${versionNoPatch}";
         };
       }


### PR DESCRIPTION
Doesn't cause a rebuild of ruby or ruby-based package.

Tested on my OSX Mavericks machine

cc @cstrahan @pikajude 
