### PR TITLE
(not yet tested) gdk-pixbuf: Patch for CVE-2015-7674.

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/CVE-2015-7674.patch
+++ b/pkgs/development/libraries/gdk-pixbuf/CVE-2015-7674.patch
@@ -1,0 +1,35 @@
+From e9a5704edaa9aee9498f1fbf6e1b70fcce2e55aa Mon Sep 17 00:00:00 2001
+From: Benjamin Otte <otte@redhat.com>
+Date: Tue, 22 Sep 2015 22:44:51 +0200
+Subject: pixops: Don't overflow variables when shifting them
+
+If we shift by 16 bits we need to be sure those 16 bits actually exist.
+They do now.
+---
+ gdk-pixbuf/pixops/pixops.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gdk-pixbuf/pixops/pixops.c b/gdk-pixbuf/pixops/pixops.c
+index 4cdb5df..b0abecd 100644
+--- a/gdk-pixbuf/pixops/pixops.c
++++ b/gdk-pixbuf/pixops/pixops.c
+@@ -264,11 +264,11 @@ pixops_scale_nearest (guchar        *dest_buf,
+ 		      double         scale_x,
+ 		      double         scale_y)
+ {
+-  int i;
+-  int x;
+-  int x_step = (1 << SCALE_SHIFT) / scale_x;
+-  int y_step = (1 << SCALE_SHIFT) / scale_y;
+-  int xmax, xstart, xstop, x_pos, y_pos;
++  gint64 i;
++  gint64 x;
++  gint64 x_step = (1 << SCALE_SHIFT) / scale_x;
++  gint64 y_step = (1 << SCALE_SHIFT) / scale_y;
++  gint64 xmax, xstart, xstop, x_pos, y_pos;
+   const guchar *p;
+ 
+ #define INNER_LOOP(SRC_CHANNELS,DEST_CHANNELS,ASSIGN_PIXEL)     \
+-- 
+cgit v0.11.2
+

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib libtiff libjpeg libpng jasper ];
 
+  patches = [ ./CVE-2015-7673_0.patch ./CVE-2015-7673_1.patch
+              ./CVE-2015-7673_2.patch ./CVE-2015-7674.patch ];
+
   configureFlags = "--with-libjasper --with-x11"
     + stdenv.lib.optionalString (gobjectIntrospection != null) " --enable-introspection=yes"
     ;


### PR DESCRIPTION
Fixes #10441 on staging.
