### PR TITLE
chromium: include WideVine patch to get NetFlix

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/source/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/source/default.nix
@@ -45,10 +45,11 @@ in stdenv.mkDerivation {
   '';
 
   patches =
-    if versionOlder version "45.0.0.0"
-    then singleton ./nix_plugin_paths_44.patch
-    else singleton ./nix_plugin_paths_46.patch ++
-         optional (!versionOlder version "46.0.0.0") ./build_fixes_46.patch;
+    (if versionOlder version "45.0.0.0"
+     then singleton ./nix_plugin_paths_44.patch
+     else singleton ./nix_plugin_paths_46.patch ++
+          optional (!versionOlder version "46.0.0.0") ./build_fixes_46.patch) ++
+    singleton ./widevine.patch;
 
   patchPhase = let
     diffmod = sym: "/^${sym} /{s/^${sym} //;${transform ""};s/^/${sym} /}";

--- a/pkgs/applications/networking/browsers/chromium/source/widevine.patch
+++ b/pkgs/applications/networking/browsers/chromium/source/widevine.patch
@@ -1,0 +1,12 @@
+diff -upr chromium-42.0.2311.90.orig/third_party/widevine/cdm/widevine_cdm_version.h chromium-42.0.2311.90/third_party/widevine/cdm/widevine_cdm_version.h
+--- chromium-42.0.2311.90.orig/third_party/widevine/cdm/widevine_cdm_version.h	2015-04-15 01:18:59.000000000 +0300
++++ chromium-42.0.2311.90/third_party/widevine/cdm/widevine_cdm_version.h	2015-04-15 09:09:49.157260050 +0300
+@@ -14,4 +14,8 @@
+ //  - WIDEVINE_CDM_VERSION_STRING (with the version of the CDM that's available
+ //    as a string, e.g., "1.0.123.456").
+ 
++#include "third_party/widevine/cdm/widevine_cdm_common.h"
++#define WIDEVINE_CDM_AVAILABLE
++#define WIDEVINE_CDM_VERSION_STRING "@WIDEVINE_VERSION@"
++
+ #endif  // WIDEVINE_CDM_VERSION_H_


### PR DESCRIPTION
For some reason it's more involved than just setting gyp configuration,
we also have to set some definitions in widevine_cdm_version.h according
to the comments left in the file. Arch Linux does this already and so we
should probably just use the patch they created while getting Netflix to
work:

https://code.google.com/p/chromium/issues/detail?id=429452#c16

---

This fixes #8479 and lets us play Netflix and YouTube paid content with Chromium! :fireworks: 
