### PR TITLE
xf86-video-ast: 0.98.0 -> 1.1.5

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1518,11 +1518,11 @@ let
   }) // {inherit fontsproto libpciaccess xextproto xorgserver xproto ;};
 
   xf86videoast = (mkDerivation "xf86videoast" {
-    name = "xf86-video-ast-0.98.0";
+    name = "xf86-video-ast-1.1.5";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-video-ast-0.98.0.tar.bz2;
-      sha256 = "188nv73w0p5xhfxz2dffli44yzyn1qhhq3qkwc8wva9dhg25n8lh";
+      url = mirror://xorg/individual/driver/xf86-video-ast-1.1.5.tar.bz2;
+      sha256 = "1pm2cy81ma7ldsw0yfk28b33h9z2hcj5rccrxhfxfgvxsiavrnqy";
     };
     buildInputs = [pkgconfig fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ];
   }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -127,7 +127,7 @@ mirror://xorg/individual/driver/xf86-input-synaptics-1.8.2.tar.bz2
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.1.0.tar.bz2
 mirror://xorg/individual/driver/xf86-input-void-1.4.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ark-0.7.5.tar.bz2
-mirror://xorg/individual/driver/xf86-video-ast-0.98.0.tar.bz2
+mirror://xorg/individual/driver/xf86-video-ast-1.1.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ati-7.5.0.tar.bz2
 mirror://xorg/individual/driver/glamor-egl-0.6.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-nouveau-1.0.11.tar.bz2


### PR DESCRIPTION
Fix failure of 0.98.0 to compile with NixOS 15.09 (due to referencing a
symbol `IOADDRESS` that has been removed from X.org drivers).
