### PR TITLE
android-sdk: 24.3.4 -> 24.4, android-ndk: r10c -> r10e

### DIFF
--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -1019,11 +1019,11 @@ August 15, 2011
     <!-- EXTRAS VENDOR=ANDROID ........................ -->
 
     <sdk:extra>
-        <!-- Generated at Thu Sep  3 11:26:43 2015 from git_mnc-sdk-release @ 2221987 -->
+        <!-- Generated at Tue Oct 13 17:53:10 2015 from git_mnc-supportlib-release @ 2337128 -->
         <sdk:revision>
             <sdk:major>23</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
+            <sdk:minor>1</sdk:minor>
+            <sdk:micro>0</sdk:micro>
         </sdk:revision>
         <sdk:vendor-display>Android</sdk:vendor-display>
         <sdk:vendor-id>android</sdk:vendor-id>
@@ -1032,18 +1032,18 @@ August 15, 2011
         <sdk:old-paths>compatibility</sdk:old-paths>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>9553739</sdk:size>
-                <sdk:checksum type="sha1">fbe529716943053d0ce0d7f058d79f1a848cdff9</sdk:checksum>
-                <sdk:url>support_r23.0.1.zip</sdk:url>
+                <sdk:size>10217600</sdk:size>
+                <sdk:checksum type="sha1">c43a56fcd1c2aa620f6178a0ef529623ed77b3c7</sdk:checksum>
+                <sdk:url>support_r23.1.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>
     </sdk:extra>
 
     <sdk:extra>
-        <!-- Manually picked up at Fri Oct  2 13:50:00 2015 from ub-support-test-release @ 2304053 -->
+        <!-- Generated at Thu Oct 15 13:57:59 2015 from git_mnc-supportlib-release @ 2343687 -->
         <sdk:revision>
-            <sdk:major>21</sdk:major>
+            <sdk:major>24</sdk:major>
         </sdk:revision>
         <sdk:vendor-display>Android</sdk:vendor-display>
         <sdk:vendor-id>android</sdk:vendor-id>
@@ -1052,9 +1052,9 @@ August 15, 2011
         <sdk:path>m2repository</sdk:path>
         <sdk:archives>
             <sdk:archive>
-                <sdk:size>142136028</sdk:size>
-                <sdk:checksum type="sha1">acb915c5d2c730bf98303c0cd0122bedb2954cb3</sdk:checksum>
-                <sdk:url>android_m2repository_r21.zip</sdk:url>
+                <sdk:size>149070460</sdk:size>
+                <sdk:checksum type="sha1">5b6d328a572172ec51dc25c3514392760e49bb81</sdk:checksum>
+                <sdk:url>android_m2repository_r24.zip</sdk:url>
             </sdk:archive>
         </sdk:archives>
         <sdk:uses-license ref="android-sdk-license"/>

--- a/pkgs/development/mobile/androidenv/addons.nix
+++ b/pkgs/development/mobile/androidenv/addons.nix
@@ -259,8 +259,8 @@ in
   android_support_extra = buildGoogleApis {
     name = "android_support_extra";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/support_r23.0.1.zip;
-      sha1 = "fbe529716943053d0ce0d7f058d79f1a848cdff9";
+      url = https://dl.google.com/android/repository/support_r23.1.zip;
+      sha1 = "c43a56fcd1c2aa620f6178a0ef529623ed77b3c7";
     };
     meta = {
       description = "Android Support Library";

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -6,16 +6,16 @@
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "android-ndk-r10c";
+  name = "android-ndk-r10e";
 
   src = if stdenv.system == "i686-linux"
     then fetchurl {
       url = "http://dl.google.com/android/ndk/${name}-linux-x86.bin";
-      sha256 = "0gyq68zrpzj3gkh81czs6r0jmikg5rwzh1bqg4rk16g2nxm4lll3";
+      sha256 = "1xbxra5v3bm6cmxyx8yyya5r93jh5m064aibgwd396xdm8jpvc4j";
     }
     else if stdenv.system == "x86_64-linux" then fetchurl {
       url = "http://dl.google.com/android/ndk/${name}-linux-x86_64.bin";
-      sha256 = "126rqzkmf8xz1hqdziwx81yln17hpivs2j45rxhzdr45iw9b758c";
+      sha256 = "0nhxixd0mq4ib176ya0hclnlbmhm8f2lab6i611kiwbzyqinfb8h";
     }
     else throw "platform ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -9,16 +9,16 @@
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "24.3.4";
+  version = "24.4";
 
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "http://dl.google.com/android/android-sdk_r${version}-linux.tgz";
-      sha1 = "fb293d7bca42e05580be56b1adc22055d46603dd";
+      sha1 = "eec87cdb9778718e4073b4ca326a46cdd084f901";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "http://dl.google.com/android/android-sdk_r${version}-macosx.zip";
-      sha1 = "128f10fba668ea490cc94a08e505a48a608879b9";
+      sha1 = "a9b6f025a9691aef430b19b52e01844dbbcbf6b4";
     }
     else throw "platform not ${stdenv.system} supported!";
 

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -164,6 +164,14 @@ rec {
     useGoogleAPIs = true;
   };
 
+  androidsdk_6_0_extras = androidsdk {
+    platformVersions = [ "23" ];
+    abiVersions = [ "armeabi-v7a" "x86" "x86_64"];
+    useGoogleAPIs = true;
+    useExtraSupportLibs = true;
+    useGooglePlayServices = true;
+  };
+
   androidndk = import ./androidndk.nix {
     inherit (pkgs) stdenv fetchurl zlib ncurses p7zip lib makeWrapper;
     inherit (pkgs) coreutils file findutils gawk gnugrep gnused jdk which;

--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "21";
+  version = "24";
   name = "android-support-repository-r${version}";
   src = fetchurl {
     url = "http://dl.google.com/android/repository/android_m2repository_r${version}.zip";
-    sha1 = "acb915c5d2c730bf98303c0cd0122bedb2954cb3";
+    sha1 = "5b6d328a572172ec51dc25c3514392760e49bb81";
   };
 
   buildCommand = ''

--- a/pkgs/development/mobile/androidenv/support.nix
+++ b/pkgs/development/mobile/androidenv/support.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "23.0.1";
+  version = "23.1";
   name = "android-support-r${version}";
   src = fetchurl {
     url = "https://dl.google.com/android/repository/support_r${version}.zip";
-    sha1 = "fbe529716943053d0ce0d7f058d79f1a848cdff9";
+    sha1 = "c43a56fcd1c2aa620f6178a0ef529623ed77b3c7";
   };
   
   buildCommand = ''


### PR DESCRIPTION
Android SDK: 24.3.4 -> 24.4
Support Repository: 21 -> 24
Support Library: 23.0.1 -> 23.1
Android NDK: r10c -> r10e

The latest version of Android SDK Platform-tools and Android SDK Build-tools seem to be 23.0.1.

Tested on x86_64 Linux.
