### PR TITLE
apacheHttpd: 2.4.16 -> 2.4.17

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -14,12 +14,12 @@ assert sslSupport -> aprutil.sslSupport && openssl != null;
 assert ldapSupport -> aprutil.ldapSupport && openldap != null;
 
 stdenv.mkDerivation rec {
-  version = "2.4.16";
+  version = "2.4.17";
   name = "apache-httpd-${version}";
 
   src = fetchurl {
     url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-    sha256 = "0hrpy6gjwma0kba7p7m61vwh82qcnkf08123lrwpg257m93hnrmc";
+    sha256 = "165p5qgwyk1dwjypgcx5vb47xadiszs3dw28n2axplw1xifh67ik";
   };
 
   buildInputs = [perl] ++


### PR DESCRIPTION
Fixes compilation with libressl 2.3
