### PR TITLE
pythonPackages.geventhttpclient: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6585,11 +6585,11 @@ let
 
   geventhttpclient = buildPythonPackage rec {
     name = "geventhttpclient-${version}";
-    version = "1.1.0";
+    version = "1.2.0";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/g/geventhttpclient/${name}.tar.gz";
-      sha256 = "1k7s4dnkmcfqqkmbqi0vvb2ns53r9cl2652mq20bgg65zj26j2l6";
+      sha256 = "0s1qd1qz0zyzksd5h38ynw06d1012h0k7z8522zhb6mzaq4144yz";
     };
 
     propagatedBuildInputs = with self; [ gevent certifi backports_ssl_match_hostname_3_4_0_2 ];


### PR DESCRIPTION
This fixes a potential security vulnerability of it hard-coding SSLv3
https://github.com/gwik/geventhttpclient/issues/55

Affects dulwich, therefor mercurial, rabbitvcs, hg-git, klaus
