### PR TITLE
libressl: 2.2.3 -> 2.2.4

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libressl-${version}";
-  version = "2.2.3";
+  version = "2.2.4";
 
   src = fetchurl {
     url    = "mirror://openbsd/LibreSSL/${name}.tar.gz";
-    sha256 = "10nq2rpyzgl7xhdip9mmn7hzb6hcjffbjcb04jchxmlivwdc5k51";
+    sha256 = "0zlsxw366n438dc14zqnim6fc5vh1574jj95hv1sym46prcrhh3b";
   };
 
   enableParallelBuilding = true;
@@ -15,6 +15,6 @@ stdenv.mkDerivation rec {
     description = "Free TLS/SSL implementation";
     homepage    = "http://www.libressl.org";
     platforms   = platforms.all;
-    maintainers = with maintainers; [ thoughtpolice wkennington ];
+    maintainers = with maintainers; [ thoughtpolice wkennington fpletz ];
   };
 }


### PR DESCRIPTION
This release fixes a buffer overrun and a memory leak.

See: http://ftp.openbsd.org/pub/OpenBSD/patches/5.8/common/007_obj2txt.patch.sig
