### PR TITLE
Add missing Cocoa framework for stack cabal package on osx.

### DIFF
--- a/pkgs/tools/security/munge/add-pidfile-switch.patch
+++ b/pkgs/tools/security/munge/add-pidfile-switch.patch
@@ -1,0 +1,64 @@
+diff -uNr munge-0.5.11-orig/src/munged/conf.c munge-0.5.11/src/munged/conf.c
+--- munge-0.5.11-orig/src/munged/conf.c	2013-08-27 20:35:31.000000000 +0200
++++ munge-0.5.11/src/munged/conf.c	2015-02-26 11:30:37.984101966 +0100
+@@ -64,11 +64,12 @@
+ #define OPT_NUM_THREADS         258
+ #define OPT_AUTH_SERVER         259
+ #define OPT_AUTH_CLIENT         260
+-#define OPT_BENCHMARK           264
+ #define OPT_GROUP_CHECK         261
+ #define OPT_GROUP_UPDATE        262
+ #define OPT_SYSLOG              263
+-#define OPT_LAST                265
++#define OPT_BENCHMARK           264
++#define OPT_PID_FILE_NAME       265
++#define OPT_LAST                266
+ 
+ const char * const short_opts = ":hLVfFMS:";
+ 
+@@ -92,6 +93,7 @@
+     { "group-check-mtime", required_argument, NULL, OPT_GROUP_CHECK  },
+     { "group-update-time", required_argument, NULL, OPT_GROUP_UPDATE },
+     { "syslog",            no_argument,       NULL, OPT_SYSLOG       },
++    { "pid-file",          required_argument, NULL, OPT_PID_FILE_NAME },
+     {  NULL,               0,                 NULL,  0               }
+ };
+ 
+@@ -363,6 +365,13 @@
+             case OPT_SYSLOG:
+                 conf->got_syslog = 1;
+                 break;
++            case OPT_PID_FILE_NAME:
++                if (conf->pidfile_name)
++                    free (conf->pidfile_name);
++                if (!(conf->pidfile_name = strdup (optarg)))
++                    log_errno (EMUNGE_NO_MEMORY, LOG_ERR,
++                        "Failed to copy pidfile name string");
++                break;
+             case '?':
+                 if (optopt > 0) {
+                     log_err (EMUNGE_SNAFU, LOG_ERR,
+@@ -479,6 +488,10 @@
+     printf ("  %*s %s\n", w, "--syslog",
+             "Redirect log messages to syslog");
+ 
++    printf ("  %*s %s [%s]\n", w, "--pid-file=file",
++            "Specify PID-file name", MUNGED_PIDFILE);
++
++
+     printf ("\n");
+     return;
+ }
+diff -uNr munge-0.5.11-orig/src/munged/munged.8.in munge-0.5.11/src/munged/munged.8.in
+--- munge-0.5.11-orig/src/munged/munged.8.in	2013-08-27 20:35:31.000000000 +0200
++++ munge-0.5.11/src/munged/munged.8.in	2015-02-26 11:20:13.056951223 +0100
+@@ -87,6 +87,9 @@
+ .BI "-S, --socket " path
+ Specify the local domain socket for communicating with clients.
+ .TP
++.BI "--pid-file " path
++Specifies the file that contains the process ID of the munged daemon.
++.TP
+ .BI "--auth-server-dir " directory
+ Specify an alternate directory in which the daemon will create the pipe used
+ to authenticate clients.  The recommended permissions for this directory

--- a/pkgs/tools/security/munge/default.nix
+++ b/pkgs/tools/security/munge/default.nix
@@ -4,9 +4,11 @@ stdenv.mkDerivation rec {
   name = "munge-0.5.11";
 
   src = fetchurl {
-    url = "http://munge.googlecode.com/files/${name}.tar.bz2";
+    url = "https://github.com/dun/munge/releases/download/${name}/${name}.tar.bz2";
     sha256 = "19aijdrjij2g0xpqgl198jh131j94p4gvam047gsdc0wz0a5c1wf";
   };
+
+  patches = [ ./add-pidfile-switch.patch ];
 
   buildInputs = [ gnused perl libgcrypt zlib bzip2 ];
 
@@ -25,6 +27,6 @@ stdenv.mkDerivation rec {
       An authentication service for creating and validating credentials
     '';
     maintainers = [ stdenv.lib.maintainers.rickynils ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Building stack through nix with the latest changes to master on OS X Yosemite ends up with stack not being able to link its binary due to the Cocoa framework not being found by the linker.

For OS X add this as an explicit dependency, for non OS X stack builds as normal.

If there is a better way of doing this in the nix language let me know. New to nix the language so I may have gone about this wrong but it generates a working stack binary on OS X with these changes.
