### PR TITLE
nginx: factor out modules into a separate file, add new "pam" module

### DIFF
--- a/pkgs/servers/http/nginx/default.nix
+++ b/pkgs/servers/http/nginx/default.nix
@@ -1,16 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt, expat
-, gd, geoip, luajit
-, curl, apr, aprutil, apacheHttpd, yajl, libcap, modsecurity_standalone
-, rtmp ? false
-, fullWebDAV ? false
-, syslog ? false
-, moreheaders ? false
-, echo ? false
-, modsecurity ? false
-, ngx_lua ? modsecurity || false
-, set_misc ? false
-, fluent ? false
-, extraModules ? []
+, gd, geoip
+, modules ? []
 }:
 
 with stdenv.lib;
@@ -22,72 +12,6 @@ let
     sha256 = "1mgkkmmwkhmpn68sdvbd73ssv6lpqhh864fsyvc1ij4hk4is3k13";
   };
 
-  rtmp-ext = fetchFromGitHub {
-    owner = "arut";
-    repo = "nginx-rtmp-module";
-    rev = "v1.1.7";
-    sha256 = "0i0fa1znkj7cipy5nlkw4k40klhp9jzk28wxy2vrvd2jvh91x3ma";
-  };
-
-  dav-ext = fetchFromGitHub {
-    owner = "arut";
-    repo = "nginx-dav-ext-module";
-    rev = "v0.0.3";
-    sha256 = "1qck8jclxddncjad8yv911s9z7lrd58bp96jf13m0iqk54xghx91";
-  };
-
-  syslog-ext = fetchFromGitHub {
-    owner = "yaoweibin";
-    repo = "nginx_syslog_patch";
-    rev = "3ca5ba65541637f74467038aa032e2586321d0cb";
-    sha256 = "0y8dxkx8m1jw4v5zsvw1gfah9vh3ryq0hfmrcbjzcmwp5b5lb1i8";
-  };
-
-  moreheaders-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "headers-more-nginx-module";
-    rev = "v0.26";
-    sha256 = "01wkqhk8mk8jgmzi7jbzmg5kamffx3lmhj5yfwryvnvs6xqs74wn";
-  };
-
-  modsecurity-ext = modsecurity_standalone.nginx;
-
-  echo-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "echo-nginx-module";
-    rev = "v0.57";
-    sha256 = "1q0f0zprcn0ypl2qh964cq186l3f40p0z7n7x22m8cxj367vf000";
-  };
-
-  lua-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "lua-nginx-module";
-    rev = "v0.9.16";
-    sha256 = "0dvdam228jhsrayb22ishljdkgib08bakh8ygn84sq0c2xbidzlp";
-  };
-
-  set-misc-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "set-misc-nginx-module";
-    rev = "v0.28";
-    sha256 = "1vixj60q0liri7k5ax85grj7q9vvgybkx421bwphbhai5xrjip96";
-  };
-
-  fluentd = fetchFromGitHub {
-    owner = "fluent";
-    repo = "nginx-fluentd-module";
-    rev = "8af234043059c857be27879bc547c141eafd5c13";
-    sha256 = "1ycb5zd9sw60ra53jpak1m73zwrjikwhrrh9q6266h1mlyns7zxm";
-  };
-
-  develkit-ext = fetchFromGitHub {
-    owner = "simpl";
-    repo = "ngx_devel_kit";
-    rev = "v0.2.19";
-    sha256 = "1cqcasp4lc6yq5pihfcdw4vp4wicngvdc3nqg3bg52r63c1qrz76";
-  };
-
-
 in
 
 stdenv.mkDerivation rec {
@@ -95,15 +19,8 @@ stdenv.mkDerivation rec {
   src = mainSrc;
 
   buildInputs =
-    [ openssl zlib pcre libxml2 libxslt gd geoip
-    ] ++ optional fullWebDAV expat
-      ++ optional ngx_lua luajit
-      ++ optionals modsecurity [ curl apr aprutil apacheHttpd yajl ];
-
-  LUAJIT_LIB = if ngx_lua then "${luajit}/lib" else "";
-  LUAJIT_INC = if ngx_lua then "${luajit}/include/luajit-2.0" else "";
-
-  patches = if syslog then [ "${syslog-ext}/syslog-1.5.6.patch" ] else [];
+    [ openssl zlib pcre libxml2 libxslt gd geoip ]
+    ++ concatMap (mod: mod.inputs or []) modules;
 
   configureFlags = [
     "--with-select_module"
@@ -130,27 +47,13 @@ stdenv.mkDerivation rec {
     "--with-ipv6"
     # Install destination problems
     # "--with-http_perl_module"
-  ] ++ optional rtmp "--add-module=${rtmp-ext}"
-    ++ optional fullWebDAV "--add-module=${dav-ext}"
-    ++ optional syslog "--add-module=${syslog-ext}"
-    ++ optional moreheaders "--add-module=${moreheaders-ext}"
-    ++ optional echo "--add-module=${echo-ext}"
-    ++ optional ngx_lua "--add-module=${develkit-ext} --add-module=${lua-ext}"
-    ++ optional set_misc "--add-module=${set-misc-ext}"
-    ++ optionals (elem stdenv.system (with platforms; linux ++ freebsd))
+  ] ++ optionals (elem stdenv.system (with platforms; linux ++ freebsd))
         [ "--with-file-aio" "--with-aio_module" ]
-    ++ optional fluent "--add-module=${fluentd}"
-    ++ optional modsecurity "--add-module=${modsecurity-ext}/nginx/modsecurity"
-    ++ (map (m: "--add-module=${m}") extraModules);
+    ++ map (mod: "--add-module=${mod.src}") modules;
 
+  NIX_CFLAGS_COMPILE = [ "-I${libxml2}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations -Wno-error=conditional-uninitialized";
 
-  additionalFlags = optionalString stdenv.isDarwin "-Wno-error=deprecated-declarations -Wno-error=conditional-uninitialized";
-
-  NIX_CFLAGS_COMPILE = optionalString modsecurity "-I${aprutil}/include/apr-1 -I${apacheHttpd}/include -I${apr}/include/apr-1 -I${yajl}/include";
-
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${libxml2}/include/libxml2 $additionalFlags"
-  '';
+  preConfigure = concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules;
 
   meta = {
     description = "A reverse proxy and lightweight webserver";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -1,0 +1,101 @@
+{ fetchFromGitHub, pkgs }:
+
+{
+  rtmp = {
+    src = fetchFromGitHub {
+      owner = "arut";
+      repo = "nginx-rtmp-module";
+      rev = "v1.1.7";
+      sha256 = "0i0fa1znkj7cipy5nlkw4k40klhp9jzk28wxy2vrvd2jvh91x3ma";
+    };
+  };
+
+  dav = {
+    src = fetchFromGitHub {
+      owner = "arut";
+      repo = "nginx-dav-ext-module";
+      rev = "v0.0.3";
+      sha256 = "1qck8jclxddncjad8yv911s9z7lrd58bp96jf13m0iqk54xghx91";
+    };
+    inputs = [ pkgs.expat ];
+  };
+
+  syslog = rec {
+    src = fetchFromGitHub {
+      owner = "yaoweibin";
+      repo = "nginx_syslog_patch";
+      rev = "3ca5ba65541637f74467038aa032e2586321d0cb";
+      sha256 = "0y8dxkx8m1jw4v5zsvw1gfah9vh3ryq0hfmrcbjzcmwp5b5lb1i8";
+    };
+    preConfigure = ''
+      patch -p1 < "${src}/syslog-1.7.0.patch"
+    '';
+  };
+
+  moreheaders = {
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "headers-more-nginx-module";
+      rev = "v0.26";
+      sha256 = "01wkqhk8mk8jgmzi7jbzmg5kamffx3lmhj5yfwryvnvs6xqs74wn";
+    };
+  };
+
+  modsecurity = {
+    src = "${pkgs.modsecurity_standalone.nginx}/nginx/modsecurity";
+    inputs = [ pkgs.curl pkgs.apr pkgs.aprutil pkgs.apacheHttpd pkgs.yajl ];
+    preConfigure = ''
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${pkgs.aprutil}/include/apr-1 -I${pkgs.apacheHttpd}/include -I${pkgs.apr}/include/apr-1 -I${pkgs.yajl}/include"
+    '';
+  };
+
+  echo = {
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "echo-nginx-module";
+      rev = "v0.57";
+      sha256 = "1q0f0zprcn0ypl2qh964cq186l3f40p0z7n7x22m8cxj367vf000";
+    };
+  };
+
+  develkit = {
+    src = fetchFromGitHub {
+      owner = "simpl";
+      repo = "ngx_devel_kit";
+      rev = "v0.2.19";
+      sha256 = "1cqcasp4lc6yq5pihfcdw4vp4wicngvdc3nqg3bg52r63c1qrz76";
+    };
+  };
+
+  lua = {
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "lua-nginx-module";
+      rev = "v0.9.16";
+      sha256 = "0dvdam228jhsrayb22ishljdkgib08bakh8ygn84sq0c2xbidzlp";
+    };
+    inputs = [ pkgs.luajit ];
+    preConfigure = ''
+      export LUAJIT_LIB="${pkgs.luajit}/lib"
+      export LUAJIT_INC="${pkgs.luajit}/include/luajit-2.0"
+    '';
+  };
+
+  set-misc = {
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "set-misc-nginx-module";
+      rev = "v0.28";
+      sha256 = "1vixj60q0liri7k5ax85grj7q9vvgybkx421bwphbhai5xrjip96";
+    };
+  };
+
+  fluentd = {
+    src = fetchFromGitHub {
+      owner = "fluent";
+      repo = "nginx-fluentd-module";
+      rev = "8af234043059c857be27879bc547c141eafd5c13";
+      sha256 = "1ycb5zd9sw60ra53jpak1m73zwrjikwhrrh9q6266h1mlyns7zxm";
+    };
+  };
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -98,4 +98,14 @@
       sha256 = "1ycb5zd9sw60ra53jpak1m73zwrjikwhrrh9q6266h1mlyns7zxm";
     };
   };
+
+  pam = {
+    src = fetchFromGitHub {
+      owner = "stogh";
+      repo = "ngx_http_auth_pam_module";
+      rev = "v1.4";
+      sha256 = "068zwyrc1dji55rlaj2kx6n0v2n5rpj7nz26ipvz26ida712md35";
+    };
+    inputs = [ pkgs.pam ];
+  };
 }

--- a/pkgs/servers/http/nginx/unstable.nix
+++ b/pkgs/servers/http/nginx/unstable.nix
@@ -1,12 +1,8 @@
 { stdenv, fetchurl, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt, expat
-, gd, geoip, luajit
-, rtmp ? false
-, fullWebDAV ? false
-, syslog ? false
-, moreheaders ? false
-, echo ? false
-, ngx_lua ? false
-, withStream ? false }:
+, gd, geoip
+, withStream ? false
+, modules ? []
+}:
 
 with stdenv.lib;
 
@@ -17,55 +13,6 @@ let
     sha256 = "1a1bixw2a4s5c3qzw3583s4a4y6i0sdzhihhlbab5rkyfh1hr6s7";
   };
 
-  rtmp-ext = fetchFromGitHub {
-    owner = "arut";
-    repo = "nginx-rtmp-module";
-    rev = "v1.1.5";
-    sha256 = "1d9ws4prxz22yq3nhh5h18jrs331zivrdh784l6wznc1chg3gphn";
-  };
-
-  dav-ext = fetchFromGitHub {
-    owner = "arut";
-    repo = "nginx-dav-ext-module";
-    rev = "v0.0.3";
-    sha256 = "1qck8jclxddncjad8yv911s9z7lrd58bp96jf13m0iqk54xghx91";
-  };
-
-  syslog-ext = fetchFromGitHub {
-    owner = "yaoweibin";
-    repo = "nginx_syslog_patch";
-    rev = "v0.25";
-    sha256 = "0734f884838wcjyrrddn8wzj834wid1zffrk093jrx18447cryxl";
-  };
-
-  moreheaders-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "headers-more-nginx-module";
-    rev = "v0.25";
-    sha256 = "1d71y1i0smi4gkzz731fhn58gr03b3s6jz6ipnfzxxaizmgxm3rb";
-  };
-
-  echo-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "echo-nginx-module";
-    rev = "v0.56";
-    sha256 = "03vaf1ffhkj2s089f90h45n079h3zw47h6y5zpk752f4ydiagpgd";
-  };
-
-  develkit-ext = fetchFromGitHub {
-    owner = "simpl";
-    repo = "ngx_devel_kit";
-    rev = "v0.2.19";
-    sha256 = "1cqcasp4lc6yq5pihfcdw4vp4wicngvdc3nqg3bg52r63c1qrz76";
-  };
-
-  lua-ext = fetchFromGitHub {
-    owner = "openresty";
-    repo = "lua-nginx-module";
-    rev = "v0.9.16";
-    sha256 = "0dvdam228jhsrayb22ishljdkgib08bakh8ygn84sq0c2xbidzlp";
-  };
-
 in
 
 stdenv.mkDerivation rec {
@@ -73,14 +20,8 @@ stdenv.mkDerivation rec {
   src = mainSrc;
 
   buildInputs =
-    [ openssl zlib pcre libxml2 libxslt gd geoip
-    ] ++ optional fullWebDAV expat
-      ++ optional ngx_lua luajit;
-
-  LUAJIT_LIB = if ngx_lua then "${luajit}/lib" else "";
-  LUAJIT_INC = if ngx_lua then "${luajit}/include/luajit-2.0" else "";
-
-  patches = if syslog then [ "${syslog-ext}/syslog-1.5.6.patch" ] else [];
+    [ openssl zlib pcre libxml2 libxslt gd geoip ]
+    ++ concatMap (mod: mod.inputs or []) modules;
 
   configureFlags = [
     "--with-http_ssl_module"
@@ -104,21 +45,13 @@ stdenv.mkDerivation rec {
     "--with-ipv6"
     # Install destination problems
     # "--with-http_perl_module"
-  ] ++ optional rtmp "--add-module=${rtmp-ext}"
-    ++ optional fullWebDAV "--add-module=${dav-ext}"
-    ++ optional syslog "--add-module=${syslog-ext}"
-    ++ optional moreheaders "--add-module=${moreheaders-ext}"
-    ++ optional echo "--add-module=${echo-ext}"
-    ++ optional ngx_lua "--add-module=${develkit-ext} --add-module=${lua-ext}"
-    ++ optional withStream "--with-stream"
-    ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio";
+  ] ++ optional withStream "--with-stream"
+    ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio"
+    ++ map (mod: "--add-module=${mod.src}") modules;
 
+  NIX_CFLAGS_COMPILE = [ "-I${libxml2}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
 
-  additionalFlags = optionalString stdenv.isDarwin "-Wno-error=deprecated-declarations";
-
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${libxml2}/include/libxml2 $additionalFlags"
-  '';
+  preConfigure = concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules;
 
   postInstall = ''
     mv $out/sbin $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9093,16 +9093,16 @@ let
   neard = callPackage ../servers/neard { };
 
   nginx = callPackage ../servers/http/nginx {
-    rtmp        = true;
-    fullWebDAV  = true;
-    syslog      = false; # the patch is not found
-    moreheaders = true;
+    # We don't use `with` statement here on purpose!
+    # See https://github.com/NixOS/nixpkgs/pull/10474/files#r42369334
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
   };
+
   nginxUnstable = callPackage ../servers/http/nginx/unstable.nix {
-    fullWebDAV  = true;
-    syslog      = false; # the patch is not found
-    moreheaders = true;
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
   };
+
+  nginxModules = callPackage ../servers/http/nginx/modules.nix { };
 
   ngircd = callPackage ../servers/irc/ngircd { };
 


### PR DESCRIPTION
This change removes much of the duplication created by separated handling of all `nginx` modules for stable and unstable releases. We now accept `modules` input, which should contain list of attribution sets. Those sets should have an `src` field and optionally `inputs` and `preConfigure`. All the modules have been moved into a separate `nginxModules` set. They all have been tested, and apart from the (broken) `log` module build fine.

I've also added a new `pam` module (this change was done in the first place because I didn't want to duplicate yet another module between two files).

This breaks compatibility of `nginx` derivations -- they now don't accept a bunch of flags and expect only a `modules` list instead. I believe this is a good change and we are early in the release cycle to break things.

cc @thoughtpolice @7c6f434c (maintainers)
also @offlinehacker @rickynils @wkennington (authors of recent non-Darwin-related changes)
