### PR TITLE
Improve hdf5 options

### DIFF
--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -1,6 +1,8 @@
 
 { stdenv
 , fetchurl
+, cpp ? false
+, gfortran ? null
 , zlib ? null
 , szip ? null
 , mpi ? null
@@ -20,6 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = []
+    ++ stdenv.lib.optional (gfortran != null) gfortran
     ++ stdenv.lib.optional (zlib != null) zlib
     ++ stdenv.lib.optional (szip != null) szip;
 
@@ -27,6 +30,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (mpi != null) mpi;
 
   configureFlags = "
+    ${if cpp then "--enable-cxx" else ""}
+    ${if gfortran != null then "--enable-fortran" else ""}
     ${if szip != null then "--with-szlib=${szip}" else ""}
     ${if mpi != null then "--enable-parallel" else ""}
     ${if enableShared then "--enable-shared" else ""}

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -9,11 +9,11 @@
 , enableShared ? true
 }:
 stdenv.mkDerivation rec {
-  version = "1.8.14";
+  version = "1.8.15-patch1";
   name = "hdf5-${version}";
   src = fetchurl {
     url = "http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${version}/src/hdf5-${version}.tar.gz";
-    sha256 = "0f86gv32pjrrphvamgims1dd7f3bp46hjarbcdy8k4gmyzpgxghx";
+    sha256 = "19k39da6zzxyr0fnffn4iqlls9v1fsih877rznq8ypqy8mzf5dci";
  };
 
   passthru = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1819,18 +1819,18 @@ let
     mpi = null;
   };
 
-  hdf5-mpi = hdf5.override {
+  hdf5-mpi = appendToName "mpi" (hdf5.override {
     szip = null;
     mpi = pkgs.openmpi;
-  };
+  });
 
-  hdf5-cpp = hdf5.override {
+  hdf5-cpp = appendToName "cpp" (hdf5.override {
     cpp = true;
-  };
+  });
 
-  hdf5-fortran = hdf5.override {
+  hdf5-fortran = appendToName "fortran" (hdf5.override {
     inherit gfortran;
-  };
+  });
 
   heimdall = callPackage ../tools/misc/heimdall { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1814,6 +1814,7 @@ let
   hddtemp = callPackage ../tools/misc/hddtemp { };
 
   hdf5 = callPackage ../tools/misc/hdf5 {
+    gfortran = null;
     szip = null;
     mpi = null;
   };
@@ -1821,6 +1822,14 @@ let
   hdf5-mpi = hdf5.override {
     szip = null;
     mpi = pkgs.openmpi;
+  };
+
+  hdf5-cpp = hdf5.override {
+    cpp = true;
+  };
+
+  hdf5-fortran = hdf5.override {
+    inherit gfortran;
   };
 
   heimdall = callPackage ../tools/misc/heimdall { };


### PR DESCRIPTION
While adding options to the function, I also provided some default derivations in `pkgs/top-level/all-packages.nix` (`hdf5-cpp` and `hdf5-fortran`).

I am not sure if this is the best way to proceed. Those options are mainly used to build libraries, and can easily be overridden by any derivation that needs the library. Only a subset of the possible derivations is described in `all-packages.nix`. On the other hand, having the  derivations available here is kind of way to let user know that those options exists for the library…

What would be the “canonical” approach to write this derivation?
