### PR TITLE
release-15.09 asterisk: fix service installation and upgrade to 13.6.0

### DIFF
--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -201,6 +201,7 @@ in
         for d in '${varlibdir}' '${spooldir}' '${logdir}'; do
           # TODO: Make exceptions for /var directories that likely should be updated
           if [ ! -e "$d" ]; then
+            mkdir -p "$d"
             cp --recursive ${pkgs.asterisk}/"$d" "$d"
             chown --recursive ${asteriskUser} "$d"
             find "$d" -type d | xargs chmod 0755

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "asterisk-${version}";
-  version = "13.3.2";
+  version = "13.6.0";
 
   src = fetchurl {
     url = "http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-${version}.tar.gz";
-    sha256 = "19dafvy6ch4v8949bjim64fff456k78156m30dy2yvhm94m5k1zz";
+    sha256 = "0nh0fnqx84as92kk9d73s0386cndd17l06y1c72jl2bdjhyba0ca";
   };
 
   # Note that these sounds are included with the release tarball. They are


### PR DESCRIPTION
cherry-pick from master.
As of today the Asterisk 13.3.2 tarball 404s, breaking the package and service in 15.09.

I propose to include Certified Asterisk releases in future stable releases, as they are made less frequently (2-4 times per year vs. every 6-8 weeks, see http://www.asterisk.org/downloads/asterisk/all-asterisk-versions)
