### PR TITLE
{lib}mediainfo{-gui}: 0.7.77 -> 0.7.78

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.77";
+  version = "0.7.78";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0n15z1jlj5s69pwk3mdv4r5c8ncfy7qjbdw5wfwynwypkl5382pn";
+    sha256 = "0458rxla3nhw9rbb2psak8qvxwr0drfhdl82k6wvb3a38xb0qij3";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.77";
+  version = "0.7.78";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0n15z1jlj5s69pwk3mdv4r5c8ncfy7qjbdw5wfwynwypkl5382pn";
+    sha256 = "0458rxla3nhw9rbb2psak8qvxwr0drfhdl82k6wvb3a38xb0qij3";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.77";
+  version = "0.7.78";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "1znxdn1jpqkiwshq9s514ak1z9wkrh9flky4s3q8z2xl68jpralq";
+    sha256 = "0ai4al5h3qbfq5f1b24ixk5v1fpln2kw1zmdj4hxjz40rj18qzka";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
Built and run locally.

From the Changelog:

```
Version 0.7.78, 2015-10-02

+ MOV: AVrp CodecID support
+ Video Stored_Width/Stored_Height and Sampled_Width/Sampled_Height
  added (hidden by default)
+ Speed optimization for the parsing of tiny files e.g. JPEG files
+ Option (command line / DLL) --Legacy=0 for disabling some legacy fields
+ Option (command line / DLL) --Output=MAXML, XML with MediaInfo and
  MediaTrace output together, technology preview (not for production)
x MPEG-TS: Teletext and Teletext Subtitle were missing in the menu list
x Chroma subsampling "4:4:4" was sometimes indicated for RGB, which is
  not useful
```
