### PR TITLE
obs-studio: 0.11.1 -> 0.12.0

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -17,11 +17,11 @@ let
   optional = stdenv.lib.optional;
 in stdenv.mkDerivation rec {
   name = "obs-studio-${version}";
-  version = "0.11.1";
+  version = "0.12.0";
 
   src = fetchurl {
     url = "https://github.com/jp9000/obs-studio/archive/${version}.tar.gz";
-    sha256 = "12g1y6y8ixvgvwk75x7qgq0j06d5khd0w3if6kahswlc58q65fm8";
+    sha256 = "0nkfzy9wzsy7y0r02vc0648gx2aa6f7ibahrv89hxqr4x6x8d7di";
   };
 
   buildInputs = [ cmake

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12388,7 +12388,7 @@ let
   };
 
   obs-studio = callPackage ../applications/video/obs-studio {
-    pulseaudioSupport = config.pulseaudio or false;
+    pulseaudioSupport = config.pulseaudio or true;
   };
 
   ocrad = callPackage ../applications/graphics/ocrad { };


### PR DESCRIPTION
Also enable PulseAudio support if unspecified.

Tested with `nix-build -A obs-studio`.
