### PR TITLE
cups-filters: make shell string longer

### DIFF
--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -10,11 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "07wwlqcykfjfqcwj1bxk60ggahyaw7wcx32n5s104d1qkhham01i";
   };
 
-  patches = [(fetchpatch { # drop on update
-    name = "poppler-0.34.patch";
-    url = "https://bugs.linuxfoundation.org/attachment.cgi?id=493";
-    sha256 = "18za83q0b0n4hpvvw76jsv0hm89zmijvps2z5kg1srickqlxj891";
-  })];
+  patches = [
+    ./longer-shell-path.patch
+    (fetchpatch { # drop on update
+      name = "poppler-0.34.patch";
+      url = "https://bugs.linuxfoundation.org/attachment.cgi?id=493";
+      sha256 = "18za83q0b0n4hpvvw76jsv0hm89zmijvps2z5kg1srickqlxj891";
+    })
+  ];
 
   buildInputs = [
     pkgconfig cups poppler poppler_utils fontconfig libjpeg libpng perl

--- a/pkgs/misc/cups/longer-shell-path.patch
+++ b/pkgs/misc/cups/longer-shell-path.patch
@@ -1,0 +1,13 @@
+diff --git a/filter/foomatic-rip/foomaticrip.c b/filter/foomatic-rip/foomaticrip.c
+index 90a851c..689a2bd 100644
+--- a/filter/foomatic-rip/foomaticrip.c
++++ b/filter/foomatic-rip/foomaticrip.c
+@@ -174,7 +174,7 @@ char cupsfilterpath[PATH_MAX] = "/usr/local/lib/cups/filter:"
+                                 "/opt/cups/filter:"
+                                 "/usr/lib/cups/filter";
+
+-char modern_shell[64] = SHELL;
++char modern_shell[] = SHELL;
+
+ void config_set_option(const char *key, const char *value)
+ {


### PR DESCRIPTION
The cstring for the shell path is too short for nixos in cups-filters, causing it to be truncated.  This was previously fixed in #5428, but regressed.  This lets me print again.
