### PR TITLE
lmdb: fix build on OSX

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchzip }:
 
-stdenv.mkDerivation rec {
+let optional = stdenv.lib.optional;
+in stdenv.mkDerivation rec {
   name = "lmdb-${version}";
   version = "0.9.16";
 
@@ -11,7 +12,8 @@ stdenv.mkDerivation rec {
 
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = ["prefix=$(out)"]
+              ++ optional stdenv.cc.isClang "CC=clang";
 
   doCheck = true;
   checkPhase = "make test";


### PR DESCRIPTION
Fixes:

```
gcc -pthread -O2 -g -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized   -c mdb.c
/nix/store/av9ybf7c0dr2mscxs5ccp8506ckvnj3l-bash-4.3-p42/bin/bash: gcc: command not found
```

I'm not too familar with nix on osx but I guess gcc isn't symlinked to clang in builds for some reason? Seems weird that I have to do this.
