### PR TITLE
ansible: fix constants.py patching, do not propagate pythonpaths

### DIFF
--- a/pkgs/tools/system/ansible/default.nix
+++ b/pkgs/tools/system/ansible/default.nix
@@ -11,7 +11,7 @@ pythonPackages.buildPythonPackage rec {
   };
 
   prePatch = ''
-    sed -i "s,\/usr\/share\/ansible\/,$out/share/ansible," lib/ansible/constants.py
+    sed -i "s,/usr/,$out," lib/ansible/constants.py
   '';
 
   doCheck = false;
@@ -19,13 +19,9 @@ pythonPackages.buildPythonPackage rec {
   dontPatchELF = true;
   dontPatchShebangs = true;
 
-  propagatedBuildInputs = with pythonPackages; [
+  pythonPath = with pythonPackages; [
     paramiko jinja2 pyyaml httplib2 boto six
   ] ++ stdenv.lib.optional windowsSupport pywinrm;
-
-  postFixup = ''
-      wrapPythonProgramsIn $out/bin "$out $pythonPath"
-  '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.ansible.com";


### PR DESCRIPTION
There isn't a need to propagate pythonpaths from ansible, since the executables are already wrapped with it and they pollute the environment of packages that depend on them. In addition the `sed` expression to patch `constants.py` was incorrect and not patching anything.

I'm not sure who I should tag on this PR. 
