### PR TITLE
buildenv: support very long `paths`

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -117,10 +117,20 @@ sub addPkg {
     }
 }
 
+# Read packages list.
+my $pkgs;
+
+if (exists $ENV{"pkgsPath"}) {
+    open FILE, $ENV{"pkgsPath"};
+    $pkgs = <FILE>;
+    close FILE;
+} else {
+    $pkgs = $ENV{"pkgs"}
+}
 
 # Symlink to the packages that have been installed explicitly by the
 # user.
-for my $pkg (@{decode_json $ENV{"pkgs"}}) {
+for my $pkg (@{decode_json $pkgs}) {
     for my $path (@{$pkg->{paths}}) {
         addPkg($path, $ENV{"ignoreCollisions"} eq "1", $pkg->{priority}) if -e $path;
     }

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -34,12 +34,14 @@
 }:
 
 runCommand name
-  { inherit manifest ignoreCollisions passthru pathsToLink extraPrefix postBuild buildInputs;
-    pkgs = builtins.toJSON (map (drv: {
-      paths = [ drv ]; # FIXME: handle multiple outputs
-      priority = drv.meta.priority or 5;
-    }) paths);
-    preferLocalBuild = true;
+  rec { inherit manifest ignoreCollisions passthru pathsToLink extraPrefix postBuild buildInputs;
+        pkgs = builtins.toJSON (map (drv: {
+          paths = [ drv ]; # FIXME: handle multiple outputs
+          priority = drv.meta.priority or 5;
+        }) paths);
+        preferLocalBuild = true;
+        # XXX: The size is somewhat arbitrary
+        passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else null;
   }
   ''
     ${perl}/bin/perl -w ${./builder.pl}


### PR DESCRIPTION
This fixes #9757, given that patch #9757 (comment) is applied. The size limit for passing via environment is selected somewhat arbitrary (it's highly platform-specific and stack size specific as far as I remember).
It causes a mass rebuild for my system; I assume it would for others.

NOTE: I don't know Perl and have been mostly following solutions from the Internet, so this might be ugly; any fixes from Perl practitioners would be very appreciated!

cc @vcunat @edolstra. Copy of #10400, based on `staging` now since this is a mass rebuild.
