### PR TITLE
Add 5.12.1 version of Apache ActiveMQ in addition to 5.8.0

### DIFF
--- a/pkgs/development/libraries/apache-activemq/5.12.nix
+++ b/pkgs/development/libraries/apache-activemq/5.12.nix
@@ -1,0 +1,6 @@
+import ./recent.nix
+  rec {
+    version = "5.12.1";
+    sha256 = "1hn6pls12dzc2fngz6lji7kmz7blvd3z1dq4via8gd4fjflmw5c9";
+    mkUrl = name: "mirror://apache/activemq/${version}/${name}-bin.tar.gz";
+  }

--- a/pkgs/development/libraries/apache-activemq/5.8.nix
+++ b/pkgs/development/libraries/apache-activemq/5.8.nix
@@ -1,0 +1,6 @@
+import ./recent.nix
+  rec {
+    version = "5.8.0";
+    sha256 = "12a1lmmqapviqdgw307jm07vw1z5q53r56pkbp85w9wnqwspjrbk";
+    mkUrl = name: "mirror://apache/activemq/apache-activemq/${version}/${name}-bin.tar.gz";
+  }

--- a/pkgs/development/libraries/apache-activemq/recent.nix
+++ b/pkgs/development/libraries/apache-activemq/recent.nix
@@ -1,12 +1,13 @@
+{ version, sha256, mkUrl }:
+# use a function to make the source url, because the url schemes differ between 5.8.0 and greater
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "apache-activemq-${version}";
-  version = "5.8.0";
 
   src = fetchurl {
-    url = "mirror://apache/activemq/apache-activemq/${version}/${name}-bin.tar.gz";
-    sha256 = "12a1lmmqapviqdgw307jm07vw1z5q53r56pkbp85w9wnqwspjrbk";
+    url = mkUrl name;
+    inherit sha256;
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5981,7 +5981,7 @@ let
 
   acl = callPackage ../development/libraries/acl { };
 
-  activemq = callPackage ../development/libraries/apache-activemq { };
+  activemq = callPackage ../development/libraries/apache-activemq/5.8.nix { };
 
   adns = callPackage ../development/libraries/adns { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5983,6 +5983,8 @@ let
 
   activemq = callPackage ../development/libraries/apache-activemq/5.8.nix { };
 
+  activemq512 = callPackage ../development/libraries/apache-activemq/5.12.nix { };
+
   adns = callPackage ../development/libraries/adns { };
 
   afflib = callPackage ../development/libraries/afflib { };


### PR DESCRIPTION
The Apache ActiveMQ version is currently at `5.8.0`, the most recent stable version is `5.12.1`.

I looked at the `tomcat` `.nix` files and used that as a template to add another entry for activemq 5.12.1, without overwriting the 5.8.0 version.

If there is no reason to keep the old 5.8.0 version around an alternative would be to just bump that one.
