### PR TITLE
oraclejdk: 8u60 -> 8u65, 8u66

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "65";
+  patchVersion = "66";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1shri8mw648piivyparbpzskiq4i0z6kain9kr7ylav5mv7h66fg";
-  sha256_x86_64 = "1rr6g2sb0f1vyf3l9nvj49ah28bsid92z0lj9pfjlb12vjn2mnw8";
+  sha256_i686 = "18l4r89na4z92djcdgyinjlhl6fmgz4x1sm40lwrsiwzg26nl0i1";
+  sha256_x86_64 = "02nwcgplq14vj1vkz99r5x20lg86hscrxb5aaifwcny7l5gsv5by";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4122,6 +4122,8 @@ let
 
   oraclejdk8 = pkgs.oraclejdk8distro true false;
 
+  oraclejdk8psu = pkgs.oraclejdk8psu_distro true false;
+
   oraclejre = lowPrio (pkgs.jdkdistro false false);
 
   oraclejre7 = lowPrio (pkgs.oraclejdk7distro false false);
@@ -4129,6 +4131,8 @@ let
   oraclejre7psu = lowPrio (pkgs.oraclejdk7psu_distro false false);
 
   oraclejre8 = lowPrio (pkgs.oraclejdk8distro false false);
+
+  oraclejre8psu = lowPrio (pkgs.oraclejdk8psu_distro false false);
 
   jrePlugin = lowPrio (pkgs.jdkdistro false true);
 
@@ -4155,6 +4159,11 @@ let
     assert supportsJDK;
     (if pluginSupport then appendToName "with-plugin" else x: x)
       (callPackage ../development/compilers/oraclejdk/jdk8-linux.nix { inherit installjdk; });
+
+  oraclejdk8psu_distro = installjdk: pluginSupport:
+    assert supportsJDK;
+    (if pluginSupport then appendToName "with-plugin" else x: x)
+      (callPackage ../development/compilers/oraclejdk/jdk8psu-linux.nix { inherit installjdk; });
 
   jikes = callPackage ../development/compilers/jikes { };
 


### PR DESCRIPTION
8u65 is a Critical Patch Update (CPU), contains critical security updates.
8u66 is a Patch Set Update (PSU), contains all updates of the CPU, plus additional fixes.

Oracle recommends using CPU version unless users are affected by the bugs fixed by the PSU, so that I made separate packages for each versions and made CPU version as the defaults (without postfix).
http://www.oracle.com/technetwork/java/javase/cpu-psu-explained-2331472.html

8u65 release notes: http://www.oracle.com/technetwork/java/javase/8u65-relnotes-2687063.html
8u66 release notes: http://www.oracle.com/technetwork/java/javase/8u66-relnotes-2692847.html

Both tested on x86_64.
