### PR TITLE
strace: add stack trace support

### DIFF
--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchurl, perl, stacktraceSupport ? true, libunwind }:
+
+let optional = stdenv.lib.optional;
+    optionalString = stdenv.lib.optionalString;
+in
+
+assert stacktraceSupport -> libunwind != null;
 
 stdenv.mkDerivation rec {
   name = "strace-4.10";
@@ -9,6 +15,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ perl ];
+
+  buildInputs = optional stacktraceSupport libunwind;
+
+  configureFlags = ''
+    ${optionalString stacktraceSupport "--with-libunwind"}
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://strace.sourceforge.net/;


### PR DESCRIPTION
strace command has option "-k" (print the execution stack trace) which is available only when strace is built with "--with-libunwind". Added this as possible option to configure step and made it enabled by default. Tested it locally.

CC maintainers: @mornfall @geerds 
