### PR TITLE
sublime3: make sublime text work with pkexec and gksudo

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -76,6 +76,7 @@
   dbohdan = "Danyil Bohdan <danyil.bohdan@gmail.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";
   deepfire = "Kosyrev Serge <_deepfire@feelingofgreen.ru>";
+  demin-dmitriy = "Dmitriy Demin <demindf@gmail.com>";
   desiderius = "Didier J. Devroye <didier@devroye.name>";
   devhell = "devhell <\"^\"@regexmail.net>";
   dezgeg = "Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>";

--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -1,10 +1,15 @@
-{ fetchurl, stdenv, glib, xorg, cairo, gtk, pango, makeWrapper, openssl, bzip2 }:
+{ fetchurl, stdenv, glib, xorg, cairo, gtk, pango, makeWrapper, openssl, bzip2,
+  pkexecPath ? "/var/setuid-wrappers/pkexec", libredirect,
+  gksuSupport ? false, gksu}:
 
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
+assert gksuSupport -> gksu != null;
 
 let
   build = "3083";
   libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk cairo pango];
+  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
+    ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
 in let
   # package with just the binaries
   sublime = stdenv.mkDerivation {
@@ -35,6 +40,9 @@ in let
           --set-rpath ${libPath}:${stdenv.cc.cc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
           $i
       done
+
+      # Rewrite pkexec|gksudo argument. Note that we can't delete bytes in binary.
+      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' sublime_text
     '';
 
     installPhase = ''
@@ -43,6 +51,10 @@ in let
 
       mkdir -p $out
       cp -prvd * $out/
+
+      wrapProgram $out/sublime_text \
+        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+        --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects}
 
       # Without this, plugin_host crashes, even though it has the rpath
       wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.cc}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${openssl}/lib/libssl.so:${bzip2}/lib/libbz2.so

--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -76,7 +76,7 @@ in stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Sophisticated text editor for code, markup and prose";
     homepage = https://www.sublimetext.com/;
-    maintainers = with maintainers; [ wmertens ];
+    maintainers = with maintainers; [ wmertens demin-dmitriy ];
     license = licenses.unfree;
     platforms = platforms.linux;
   };

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <string.h>
+#include <spawn.h>
 
 #define MAX_REDIRECTS 128
 
@@ -103,9 +104,29 @@ int __xstat(int ver, const char * path, struct stat * st)
     return __xstat_real(ver, rewrite(path, buf), st);
 }
 
+int __xstat64(int ver, const char * path, struct stat64 * st)
+{
+    int (*__xstat64_real) (int ver, const char *, struct stat64 *) = dlsym(RTLD_NEXT, "__xstat64");
+    char buf[PATH_MAX];
+    return __xstat64_real(ver, rewrite(path, buf), st);
+}
+
 int * access(const char * path, int mode)
 {
     int * (*access_real) (const char *, int mode) = dlsym(RTLD_NEXT, "access");
     char buf[PATH_MAX];
     return access_real(rewrite(path, buf), mode);
+}
+
+int posix_spawn(pid_t * pid, const char * path,
+    const posix_spawn_file_actions_t * file_actions,
+    const posix_spawnattr_t * attrp,
+    char * const argv[], char * const envp[])
+{
+    int (*posix_spawn_real) (pid_t *, const char *,
+        const posix_spawn_file_actions_t *,
+        const posix_spawnattr_t *,
+        char * const argv[], char * const envp[]) = dlsym(RTLD_NEXT, "posix_spawn");
+    char buf[PATH_MAX];
+    return posix_spawn_real(pid, rewrite(path, buf), file_actions, attrp, argv, envp);
 }


### PR DESCRIPTION
When sublime doesn't have rights to write a file, it asks for root rights by calling either
`/usr/bin/gksudo /bin/cp TMP_FILE FILE`
or
`/usr/bin/pkexec /bin/cp TMP_FILE FILE`
whichever it finds first.
Paths `/usr/bin/pkexec`, `/usr/bin/gksudo` and `/bin/cp` are all hardcoded in sublime_text binary. `/bin/cp` can be simply replaced by `cp` in binary itself (and padded with necessary amount of zero bytes), but to deal with `/usr/bin/pkexec` and `/usr/bin/gksudo` we have to use LD_PRELOAD trick to intercept glibc calls.

Tested it locally with system="i686-linux" and system="x86_64-linux".

cc @wmertens.
