### PR TITLE
build-fhs-chrootenv: add /etc/mtab -> /proc/mounts symlink

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -98,6 +98,9 @@ let
       # symlink SSL certs
       mkdir -p ssl
       ln -s /host-etc/ssl/certs ssl/certs
+
+      # symlink /etc/mtab -> /proc/mounts (compat for old userspace progs)
+      ln -s /proc/mounts mtab
     '';
   };
 


### PR DESCRIPTION
Needed to be able to run some programs (e.g. tune2fs) in the chroot.
AFAIK, using /etc/mtab is deprecated, but programs still use it.
