### PR TITLE
pythonPackages.basiciw: init at 0.2.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -910,6 +910,28 @@ let
     };
   };
 
+  basiciw = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    version = "0.2.2";
+    pname = "basiciw";
+    disabled = isPy26 || isPy27;
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/b/${pname}/${name}.tar.gz";
+      sha256 = "1ajmflvvlkflrcmqmkrx0zaira84z8kv4ssb2jprfwvjh8vfkysb";
+    };
+
+    buildInputs = [ pkgs.gcc ];
+    propagatedBuildInputs = [ pkgs.wirelesstools ];
+
+    meta = {
+      description = "Get info about wireless interfaces using libiw";
+      homepage = http://github.com/enkore/basiciw;
+      platforms = platforms.linux;
+      license = licenses.gpl2;
+    };
+  };
+
   batinfo = buildPythonPackage rec {
     version = "0.2";
     name = "batinfo-${version}";


### PR DESCRIPTION
Tested through nix-shell:

``` bash
$ nix-shell -p python3Packages.basiciw -I nixpkgs=~/nixpkgs/
[nix-shell:~/nixpkgs]$ python3 -c 'import basiciw; print(basiciw.iwinfo("wlp6s0"))'
{'iface': 'wlp6s0', 'quality': {'quality_max': 70, 'quality_info': 0, 'quality': 49}, 'freq': 2437000000.0, 'essid': 'Mgts_71'}
```
