### PR TITLE
darwin: gfortran: add needed inputs, patches, flags and other fixes

### DIFF
--- a/pkgs/development/compilers/gcc/gfortran-darwin.nix
+++ b/pkgs/development/compilers/gcc/gfortran-darwin.nix
@@ -1,20 +1,35 @@
-# This is a derivation specific to OS X (Darwin). It may work on other
-# systems as well but has not been tested.
-{gmp, mpfr, libmpc, fetchurl, stdenv}:
+# This is a derivation specific to OS X (Darwin)
+{gmp, mpfr, libmpc, isl_0_14, cloog, zlib, fetchurl, stdenv
+
+, Libsystem
+}:
 
 stdenv.mkDerivation rec {
   name = "gfortran-${version}";
   version = "5.1.0";
-  buildInputs = [gmp mpfr libmpc];
+  buildInputs = [gmp mpfr libmpc isl_0_14 cloog zlib];
   src = fetchurl {
     url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
     sha256 = "1bd5vj4px3s8nlakbgrh38ynxq4s654m6nxz7lrj03mvkkwgvnmp";
   };
+  patches = ./gfortran-darwin.patch;
   configureFlags = ''
-    --enable-languages=fortran --enable-checking=release --disable-bootstrap
+    --disable-bootstrap
+    --disable-cloog-version-check
+    --disable-isl-version-check
+    --disable-multilib
+    --enable-checking=release
+    --enable-languages=fortran
+    --with-cloog=${cloog}
     --with-gmp=${gmp}
-    --with-mpfr=${mpfr}
+    --with-isl=${isl_0_14}
     --with-mpc=${libmpc}
+    --with-mpfr=${mpfr}
+    --with-native-system-header-dir=${Libsystem}/include
+    --with-system-zlib
+  '';
+  postConfigure = ''
+    export DYLD_LIBRARY_PATH=`pwd`/`uname -m`-apple-darwin`uname -r`/libgcc
   '';
   makeFlags = ["CC=clang"];
   passthru.cc = stdenv.cc.cc;

--- a/pkgs/development/compilers/gcc/gfortran-darwin.patch
+++ b/pkgs/development/compilers/gcc/gfortran-darwin.patch
@@ -1,0 +1,26 @@
+--- a/gcc/config/darwin-c.c	2015-01-09 22:18:42.000000000 +0200
++++ b/gcc/config/darwin-c.c	2015-06-27 04:17:58.000000000 +0300
+@@ -490,8 +490,7 @@
+ 
+ static const char *framework_defaults [] =
+   {
+-    "/System/Library/Frameworks",
+-    "/Library/Frameworks",
++// stdenvDarwinPure
+   };
+ 
+ /* Register the GNU objective-C runtime include path if STDINC.  */
+ 
+ /* Register the GNU objective-C runtime include path if STDINC.  */
+--- a/gcc/cppdefault.c	2015-01-05 14:33:28.000000000 +0200
++++ b/gcc/cppdefault.c	2015-06-27 04:16:15.000000000 +0300
+@@ -35,6 +35,9 @@
+ # undef CROSS_INCLUDE_DIR
+ #endif
+ 
++// stdenvDarwinPure
++# undef LOCAL_INCLUDE_DIR
++
+ const struct default_include cpp_include_defaults[]
+ #ifdef INCLUDE_DEFAULTS
+ = INCLUDE_DEFAULTS;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3919,7 +3919,9 @@ let
   }));
 
   gfortran = if !stdenv.isDarwin then gfortran49
-             else callPackage ../development/compilers/gcc/gfortran-darwin.nix {};
+             else callPackage ../development/compilers/gcc/gfortran-darwin.nix {
+    inherit (darwin) Libsystem;
+  };
 
   gfortran48 = wrapCC (gcc48.cc.override {
     name = "gfortran";


### PR DESCRIPTION
AFAIK gfortran for darwin has been broken for some time. This adds input for the new darwin stdenv, patches hardcoded paths from sources, uses configure flags from homebrew recipe. I've been using this with mathplotlib (or was it scipy, who required gfortran) and R.
