### PR TITLE
fetchzip: respect the `name` argument

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -28,7 +28,7 @@ lib.overrideDerivation (fetchurl ({
       mkdir "$unpackDir"
       cd "$unpackDir"
 
-      renamed="$TMPDIR/${baseNameOf url}"
+      renamed="$TMPDIR/${baseNameOf name}"
       mv "$downloadedFile" "$renamed"
       unpackFile "$renamed"
 


### PR DESCRIPTION
This is a respin of #8795.
