### PR TITLE
darwin: matplotlib: add needed inputs and set framework flag for darwin

### DIFF
--- a/pkgs/development/python-modules/matplotlib/darwin-stdenv.patch
+++ b/pkgs/development/python-modules/matplotlib/darwin-stdenv.patch
@@ -1,0 +1,11 @@
+--- a/src/_macosx.m	2015-06-30 12:18:48.000000000 +0300
++++ b/src/_macosx.m	2015-06-30 12:19:12.000000000 +0300
+@@ -5,6 +5,8 @@
+ #include "numpy/arrayobject.h"
+ #include "path_cleanup.h"
+ 
++#define WITH_NEXT_FRAMEWORK 1
++
+ #if PY_MAJOR_VERSION >= 3
+ #define PY3K 1
+ #else

--- a/pkgs/development/python-modules/matplotlib/darwin-stdenv.patch
+++ b/pkgs/development/python-modules/matplotlib/darwin-stdenv.patch
@@ -1,11 +1,10 @@
---- a/src/_macosx.m	2015-06-30 12:18:48.000000000 +0300
-+++ b/src/_macosx.m	2015-06-30 12:19:12.000000000 +0300
-@@ -5,6 +5,8 @@
- #include "numpy/arrayobject.h"
- #include "path_cleanup.h"
+--- a/src/_macosx.m	2015-10-30 00:46:20.000000000 +0200
++++ b/src/_macosx.m	2015-11-01 14:52:25.000000000 +0200
+@@ -6264,6 +6264,7 @@
  
-+#define WITH_NEXT_FRAMEWORK 1
-+
- #if PY_MAJOR_VERSION >= 3
- #define PY3K 1
- #else
+ static bool verify_framework(void)
+ {
++    return true;  /* nixpkgs darwin stdenv */
+ #ifdef COMPILING_FOR_10_6
+     NSRunningApplication* app = [NSRunningApplication currentApplication];
+     NSApplicationActivationPolicy activationPolicy = [app activationPolicy];

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -37,13 +37,12 @@ buildPythonPackage rec {
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv.patch ];
 
-  patchPhase = ''
+  prePatch = ''
     # Failing test: ERROR: matplotlib.tests.test_style.test_use_url
     sed -i 's/test_use_url/fails/' lib/matplotlib/tests/test_style.py
     # Failing test: ERROR: test suite for <class 'matplotlib.sphinxext.tests.test_tinypages.TestTinyPages'>
     sed -i 's/TestTinyPages/fails/' lib/matplotlib/sphinxext/tests/test_tinypages.py
   '';
-
 
   meta = with stdenv.lib; {
     description = "python plotting library, making publication quality plots";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8621,6 +8621,8 @@ let
   matplotlib = callPackage ../development/python-modules/matplotlib/default.nix {
     stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
     enableGhostscript = true;
+    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa Foundation CoreData;
+    inherit (pkgs.darwin) cf-private libobjc;
   };
 
 


### PR DESCRIPTION
Should fix pythonPackages.matplotlib on darwin.

Not completely sure, why I need to add "-I${libcxx}/include/c++/v1" to make those headers available on darwin.

Patch is required to skip matplotlib's dummy check for system python, which is not available in darwin sandbox. (matplotlib would build without it, but raise RuntimeErrors later.)
