### PR TITLE
blas: fixes #10420 hash mismatch

### DIFF
--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "blas-20110419";
   src = fetchurl {
     url = "http://www.netlib.org/blas/blas.tgz";
-    sha256 = "1d931d91byv2svydpj2ipjh1f2sm1h9ns8ik2w5fwaa8qinxz1za";
+    sha256 = "096a3apnh899abjymjjg8m34hncagkzp9qxw08cms98g71fpfzgg";
   };
 
   buildInputs = [gfortran];


### PR DESCRIPTION
now it builds sucessfully on NixOS.
