### PR TITLE
oraclejdk: added architecture attribute

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -182,6 +182,8 @@ let result = stdenv.mkDerivation rec {
 
   passthru.home = result;
 
+  passthru.architecture = architecture;
+
   meta = with stdenv.lib; {
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" ]; # some inherit jre.meta.platforms


### PR DESCRIPTION
This attribute is needed by some other packages (in particular [jitsi](https://github.com/NixOS/nixpkgs/blob/788800e437c4a0a25d95e217540bded68804b25e/pkgs/applications/networking/instant-messengers/jitsi/default.nix#L62)).  lack of this attribute makes nox-review
fail on a system where `jdk = oraclejdk7;`.
