### PR TITLE
lash: Add propagated build input

### DIFF
--- a/pkgs/applications/audio/lash/default.nix
+++ b/pkgs/applications/audio/lash/default.nix
@@ -15,8 +15,9 @@ stdenv.mkDerivation  rec {
   # http://permalink.gmane.org/gmane.linux.redhat.fedora.extras.cvs/822346
   patches = [ ./socket.patch ./gcc-47.patch ];
 
-  buildInputs = [ alsaLib gtk libjack2 libuuid libxml2 makeWrapper
+  buildInputs = [ alsaLib gtk libjack2 libxml2 makeWrapper
     pkgconfig readline ];
+  propagatedBuildInputs = [ libuuid ];
 
   postInstall = ''
     for i in lash_control lash_panel


### PR DESCRIPTION
At least for jackmix to build successfully against jack2 (which doesn't use libuuid), the libuuid used by lash needs to be propagated build input.

Tested locally on x86_64.
