### PR TITLE
vino: updated the dependencies

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/core/vino/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/vino/default.nix
@@ -1,5 +1,13 @@
-{ stdenv, intltool, fetchurl, gtk3, glib, libsoup, pkgconfig, makeWrapper
-, gnome3, libnotify, file, telepathy_glib, dbus_glib }:
+{ stdenv, fetchurl, lib, makeWrapper
+, pkgconfig, gnome3, gtk3, glib, intltool, libXtst, libnotify, libsoup
+, telepathySupport ? false, dbus_glib ? null, telepathy_glib ? null
+, libsecret ? null, gnutls ? null, libgcrypt ? null, avahi ? null
+, zlib ? null, libjpeg ? null
+, libXdamage ? null, libXfixes ? null, libXext ? null
+, gnomeKeyringSupport ? false, libgnome_keyring3 ? null
+, networkmanager ? null }:
+
+with lib;
 
 stdenv.mkDerivation rec {
   name = "vino-${versionMajor}.${versionMinor}";
@@ -13,9 +21,15 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  buildInputs = [ gtk3 intltool glib libsoup pkgconfig libnotify
-                  gnome3.defaultIconTheme dbus_glib telepathy_glib file
-                  makeWrapper ];
+  buildInputs = [
+    makeWrapper
+    pkgconfig gnome3.defaultIconTheme gtk3 glib intltool libXtst libnotify libsoup
+  ] ++ optionals telepathySupport [ dbus_glib telepathy_glib ]
+    ++ optional gnomeKeyringSupport libgnome_keyring3
+    ++ filter (p: p != null) [
+      libsecret gnutls libgcrypt avahi zlib libjpeg
+      libXdamage libXfixes libXext networkmanager
+    ];
 
   preFixup = ''
     wrapProgram "$out/libexec/vino-server" \


### PR DESCRIPTION
The libXtst dependency was missing, which was required to enable remote control. The other dependencies have been updated as well to reflect the dependencies stated at:
https://wiki.gnome.org/Projects/Vino
https://git.gnome.org/browse/vino/tree/configure.ac
