### PR TITLE
Add libstdc++.dylib to pure-darwin system deps

### DIFF
--- a/pkgs/stdenv/pure-darwin/default.nix
+++ b/pkgs/stdenv/pure-darwin/default.nix
@@ -14,6 +14,7 @@ let
     "/usr/lib/libauto.dylib"
     "/usr/lib/libc++abi.dylib"
     "/usr/lib/libc++.1.dylib"
+    "/usr/lib/libstdc++.dylib"
     "/usr/lib/libDiagnosticMessagesClient.dylib"
     "/usr/lib/system"
   ];


### PR DESCRIPTION
Most of the node modules with npm bindings calls `cc` with `-lstdc++`, and clang can't find the dynamic library without this patch.

But I'm not sure this patch is the way to do it, I'll be glad if someone shows a better way than depending on a system lib.

cc @pikajude 
