### PR TITLE
darkice: Fix build with opus and vorbis support

### DIFF
--- a/pkgs/tools/audio/darkice/default.nix
+++ b/pkgs/tools/audio/darkice/default.nix
@@ -1,8 +1,14 @@
-{ stdenv, fetchurl, alsaLib, faac, libjack2, lame, libopus, libpulseaudio, libsamplerate, libvorbis }:
+{ stdenv, buildEnv, fetchurl, alsaLib, faac, libjack2, lame, libogg, libopus, libpulseaudio, libsamplerate, libvorbis }:
 
-with stdenv.lib;
+let
+  oggEnv = buildEnv {
+    name = "env-darkice-ogg";
+    paths = [
+      libopus libvorbis libogg
+    ];
+  };
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "darkice-${version}";
   version = "1.2";
 
@@ -16,10 +22,10 @@ stdenv.mkDerivation rec {
     "--with-faac-prefix=${faac}"
     "--with-jack-prefix=${libjack2}"
     "--with-lame-prefix=${lame}"
-    "--with-opus-prefix=${libopus}"
+    "--with-opus-prefix=${oggEnv}"
     "--with-pulseaudio-prefix=${libpulseaudio}"
     "--with-samplerate-prefix=${libsamplerate}"	
-    "--with-vorbis-prefix=${libvorbis}"
+    "--with-vorbis-prefix=${oggEnv}"
 #    "--with-aacplus-prefix=${aacplus}" ### missing: aacplus
 #    "--with-twolame-prefix=${twolame}" ### missing: twolame
   ];


### PR DESCRIPTION
The configure script requires libogg in both the paths of libopus and libvorbis. Because is isn't true for the libopus and libvorbis derivations in NixOS and patching the configure script is a bit tedious, a temporary environment with libogg, libvorbis & libopus is used.

/cc @ikervagyok
