### PR TITLE
taskwarrior: 2.4.4 -> 2.5.0

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "taskwarrior-${version}";
-  version = "2.4.4";
+  version = "2.5.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "http://www.taskwarrior.org/download/task-${version}.tar.gz";
-    sha256 = "7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b";
+    sha256 = "0dj66c4pwdmfnzdlm1r23gqim6banycyzvmq266114v9b90ng3jd";
   };
 
   nativeBuildInputs = [ cmake libuuid gnutls ];


### PR DESCRIPTION
Update came out yesterday or something.

Commit message contains the changelog from the website.
