### PR TITLE
darwin: argh: disable tests on darwin

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14101,6 +14101,8 @@ let
       sha256 = "1nqham81ihffc9xmw85dz3rg3v90rw7h0dp3dy0bh3qkp4n499q6";
     };
 
+    doCheck = !pkgs.stdenv.isDarwin;  # fails with UnicodeDecodeError
+
     checkPhase = ''
       export LANG="en_US.UTF-8"
       py.test


### PR DESCRIPTION
The test error looked like:

```
test/test_interaction.py:67: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
argh/interaction.py:72: in confirm
    choice = safe_input(prompt)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

prompt = '\u043f\u0440\u0438\u0432\u0435\u0442? (y/n)'

    def safe_input(prompt):
        """
        Prompts user for input. Correctly handles prompt message encoding.
        """

        if sys.version_info < (3,0):
            if isinstance(prompt, compat.text_type):
                # Python 2.x: unicode →  bytes
                encoding = locale.getpreferredencoding() or 'utf-8'
>               prompt = prompt.encode(encoding)
E               UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not i
n range(128)

argh/io.py:41: UnicodeEncodeError
```
