### PR TITLE
Added NL tax application for individuals and entrepreneurs

### DIFF
--- a/pkgs/applications/taxes/aangifte-2013-wa/default.nix
+++ b/pkgs/applications/taxes/aangifte-2013-wa/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, makeWrapper, xdg_utils, libX11, libXext, libSM }:
+
+stdenv.mkDerivation {
+  name = "aangifte2013-wa";
+
+  src = fetchurl {
+    url = http://download.belastingdienst.nl/belastingdienst/apps/linux/wa2013_linux.tar.gz;
+    sha256 = "1bx6qnxikzpzrn8r66qxcind3k9yznwgp05dm549ph0w4rjbhgc9";
+  };
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase =
+    ''
+      for i in bin/*; do
+          patchelf \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-cc)/lib \
+              $i
+      done
+    '';
+
+  installPhase =
+    ''
+      mkdir -p $out
+      cp -prvd * $out/
+      wrapProgram $out/bin/wa2013ux --prefix PATH : ${xdg_utils}/bin \
+                                    --prefix LD_PRELOAD : $(cat $NIX_CC/nix-support/orig-cc)/lib/libgcc_s.so.1
+    '';
+
+  meta = {
+    description = "Elektronische aangifte WA 2013 (Dutch Tax Return Program)";
+    url = http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/themaoverstijgend/programmas_en_formulieren/aangifteprogramma_2013_linux;
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/applications/taxes/aangifte-2014-wa/default.nix
+++ b/pkgs/applications/taxes/aangifte-2014-wa/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, makeWrapper, xdg_utils, libX11, libXext, libSM }:
+
+stdenv.mkDerivation {
+  name = "aangifte2014-wa";
+
+  src = fetchurl {
+    url = http://download.belastingdienst.nl/belastingdienst/apps/linux/wa2014_linux.tar.gz;
+    sha256 = "0ckwk190vyvwgv8kq0xxsxvm1kniv3iip4l5aycjx1wcyic2289x";
+  };
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase =
+    ''
+      for i in bin/*; do
+          patchelf \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-cc)/lib \
+              $i
+      done
+    '';
+
+  installPhase =
+    ''
+      mkdir -p $out
+      cp -prvd * $out/
+      wrapProgram $out/bin/wa2014ux --prefix PATH : ${xdg_utils}/bin \
+                                    --prefix LD_PRELOAD : $(cat $NIX_CC/nix-support/orig-cc)/lib/libgcc_s.so.1
+    '';
+
+  meta = {
+    description = "Elektronische aangifte WA 2014 (Dutch Tax Return Program)";
+    url = http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/themaoverstijgend/programmas_en_formulieren/aangifteprogramma_2014_linux;
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/applications/taxes/aangifte-2014/default.nix
+++ b/pkgs/applications/taxes/aangifte-2014/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, makeWrapper, xdg_utils, libX11, libXext, libSM }:
+
+stdenv.mkDerivation {
+  name = "aangifte2014-1";
+
+  src = fetchurl {
+    url = http://download.belastingdienst.nl/belastingdienst/apps/linux/ib2014_linux.tar.gz;
+    sha256 = "1lkpfn9ban122hw27vvscdlg3933i2lqcdhp7lk26f894jbwzq3j";
+  };
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase =
+    ''
+      for i in bin/*; do
+          patchelf \
+              --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              --set-rpath ${stdenv.lib.makeLibraryPath [ libX11 libXext libSM ]}:$(cat $NIX_CC/nix-support/orig-cc)/lib \
+              $i
+      done
+    '';
+
+  installPhase =
+    ''
+      mkdir -p $out
+      cp -prvd * $out/
+      wrapProgram $out/bin/ib2014ux --prefix PATH : ${xdg_utils}/bin \
+                                    --prefix LD_PRELOAD : $(cat $NIX_CC/nix-support/orig-cc)/lib/libgcc_s.so.1
+    '';
+
+  meta = {
+    description = "Elektronische aangifte IB 2014 (Dutch Tax Return Program)";
+    url = http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/themaoverstijgend/programmas_en_formulieren/aangifteprogramma_2014_linux;
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10775,6 +10775,12 @@ let
 
   aangifte2013 = callPackage_i686 ../applications/taxes/aangifte-2013 { };
 
+  aangifte2014 = callPackage_i686 ../applications/taxes/aangifte-2014 { };
+
+  aangifte2013wa = callPackage_i686 ../applications/taxes/aangifte-2013-wa { };
+
+  aangifte2014wa = callPackage_i686 ../applications/taxes/aangifte-2014-wa { };
+
   abcde = callPackage ../applications/audio/abcde {
     inherit (perlPackages) DigestSHA MusicBrainz MusicBrainzDiscID;
     inherit (pythonPackages) eyeD3;


### PR DESCRIPTION
There is a distinctive version of the desktop software to file taxes for regular individuals and those that operate a business. The applications for both are included for both 2013 and 2014. No changes to the nix recipe of the previous years, apart from the location of the new software. Tested.
