### PR TITLE
nixos: Minor improvements to ARM image expressions

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -26,9 +26,6 @@ in
   boot.kernelPackages = pkgs.linuxPackages_testing;
   boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
-  # FIXME: fix manual evaluation on ARM
-  services.nixosManual.enable = lib.mkOverride 0 false;
-
   # FIXME: this probably should be in installation-device.nix
   users.extraUsers.root.initialHashedPassword = "";
 

--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -22,8 +22,7 @@ in
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;
 
-  # FIXME: change this to linuxPackages_latest once v4.2 is out
-  boot.kernelPackages = pkgs.linuxPackages_testing;
+  boot.kernelPackages = pkgs.linuxPackages_latest;
   boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
   # FIXME: this probably should be in installation-device.nix

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
@@ -27,9 +27,6 @@ in
 
   boot.kernelPackages = pkgs.linuxPackages_rpi;
 
-  # FIXME: fix manual evaluation on ARM
-  services.nixosManual.enable = lib.mkOverride 0 false;
-
   # FIXME: this probably should be in installation-device.nix
   users.extraUsers.root.initialHashedPassword = "";
 


### PR DESCRIPTION
- Use `linuxPackages_latest` in ARMv7 image
  - 4.2 is out now, which includes the pcDuino3 Nano DTB (which was the original reason to use `linuxPackages_testing`).
- Don't disable manual in installation images
  - The manual now evaluates correctly due to other manual improvements.
