### PR TITLE
rkt: bump to v0.10.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -266,6 +266,7 @@
   sprock = "Roger Mason <rmason@mun.ca>";
   spwhitt = "Spencer Whitt <sw@swhitt.me>";
   stephenmw = "Stephen Weinberg <stephen@q5comm.com>";
+  steveej = "Stefan Junker <mail@stefanjunker.de>";
   szczyp = "Szczyp <qb@szczyp.com>";
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";
   tailhook = "Paul Colomiets <paul@colomiets.name>";

--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -2,47 +2,53 @@
 , fetchurl, fetchFromGitHub }:
 
 let
-  coreosImageRelease = "738.1.0";
+  coreosImageRelease = "794.1.0";
+  coreosImageSystemdVersion = "222";
+  stage1Flavour = "coreos";
 
 in stdenv.mkDerivation rec {
-  version = "0.8.0";
+  version = "0.10.0";
   name = "rkt-${version}";
+  BUILDDIR="build-${name}";
 
   src = fetchFromGitHub {
       rev = "v${version}";
       owner = "coreos";
       repo = "rkt";
-      sha256 = "1abv9psd5w0m8p2kvrwyjnrclzajmrpbwfwmkgpnkydhmsimhnn0";
+      sha256 = "1d9n00wkzib4v5mfl46f2mqc8zfpv33kqixifmv8p4azqv78cbxn";
   };
 
-  stage1image = fetchurl {
+  stage1BaseImage = fetchurl {
     url = "http://alpha.release.core-os.net/amd64-usr/${coreosImageRelease}/coreos_production_pxe_image.cpio.gz";
-    sha256 = "1rnb9rwms5g7f142d9yh169a5k2hxiximpgk4y4kqmc1294lqnl0";
+    sha256 = "05nzl3av6cawr8v203a8c95c443g6h1nfy2n4jmgvn0j4iyy44ym";
   };
 
   buildInputs = [ autoconf automake go file git wget gnupg1 squashfsTools cpio ];
 
   preConfigure = ''
     ./autogen.sh
+    configureFlagsArray=(
+      --with-stage1=${stage1Flavour}
+      --with-stage1-image-path=$out/stage1-${stage1Flavour}.aci
+      --with-coreos-local-pxe-image-path=${stage1BaseImage}
+      --with-coreos-local-pxe-image-systemd-version=v${coreosImageSystemdVersion}
+    );
   '';
 
   preBuild = ''
-    # hack to avoid downloading image during build, this has been
-    # improved in rkt master
-    mkdir -p build-rkt-0.8.0/tmp/usr_from_coreos
-    cp -v ${stage1image} build-rkt-0.8.0/tmp/usr_from_coreos/pxe.img
+    export BUILDDIR
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -Rv build-rkt-${version}/bin/* $out/bin
+    cp -Rv $BUILDDIR/bin/* $out/bin
   '';
 
   meta = with lib; {
     description = "A fast, composable, and secure App Container runtime for Linux";
-    homepage = http://rkt.io;
+    homepage = https://github.com/coreos/rkt;
     license = licenses.asl20;
-    maintainers = with maintainers; [ ragge ];
+    maintainers = with maintainers; [ ragge steveej ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
- bump stage1 base image to v794.1.0 according to upstream release
- make use of BUILDDIR environment variable to control output path
- make use of the configure option for the stage1 image path and the stage1 base image path
- add myself to the list of maintianers
