### PR TITLE
darwin: cryptography: add needed inputs and fix darwin builtools check

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2430,8 +2430,15 @@ let
       sha256 = "1jmcidddbbgdavvnvjjc0pda4b9a5i9idsivchn69pqxx68x8k6n";
     };
 
+    # Skip compiler check on Darwin
+    prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace setup.py --replace 'if cc_is_available()' 'if True';
+    '';
+
     buildInputs = [ pkgs.openssl self.pretend self.cryptography_vectors
-                    self.iso8601 self.pyasn1 self.pytest self.py ];
+                    self.iso8601 self.pyasn1 self.pytest self.py ]
+     ++ stdenv.lib.optionals stdenv.isDarwin [
+                    pkgs.darwin.apple_sdk.frameworks.Security ];
     propagatedBuildInputs = [ self.six self.idna self.ipaddress self.pyasn1 ]
      ++ optional (!isPyPy) self.cffi
      ++ optional (pythonOlder "3.4") self.enum34;


### PR DESCRIPTION
This may not pass on 10.11 without updating impure deps for frameworks.

@pikajude I had to add the following impure-desp to make this build for pythonPackages.cryptography pass on 10.11 (otherwise it failed during tests):

```
    "/usr/lib/libOpenScriptingUtil.dylib"
    "/usr/lib/libenergytrace.dylib"
```

Not sure, into which framework those belong to.
