### PR TITLE
python: h5py update and new package pkgconfig

### DIFF
--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, buildPythonPackage
-, numpy, hdf5, cython
+, numpy, hdf5, cython, six, pkgconfig
 , mpiSupport ? false, mpi4py ? null, mpi ? null }:
 
 assert mpiSupport == hdf5.mpiSupport;
@@ -12,24 +12,26 @@ assert mpiSupport -> mpi != null
 with stdenv.lib;
 
 buildPythonPackage rec {
-  name = "h5py-2.3.1";
+  name = "h5py-${version}";
+  version = "2.5.0";
 
   src = fetchurl {
     url = "https://pypi.python.org/packages/source/h/h5py/${name}.tar.gz";
-    md5 = "8f32f96d653e904d20f9f910c6d9dd91";
+    sha256 = "9833df8a679e108b561670b245bcf9f3a827b10ccb3a5fa1341523852cfac2f6";
   };
 
-  setupPyBuildFlags = [ "--hdf5=${hdf5}" ]
-    ++ optional mpiSupport "--mpi"
-    ;
-  setupPyInstallFlags = setupPyBuildFlags;
+  configure_flags = "--hdf5=${hdf5}" + optionalString mpiSupport " --mpi";
+
+  postConfigure = ''
+    ${python.executable} setup.py configure ${configure_flags}
+  '';
 
   preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
 
-  buildInputs = [ hdf5 cython ]
+  buildInputs = [ hdf5 cython pkgconfig ]
     ++ optional mpiSupport mpi
     ;
-  propagatedBuildInputs = [ numpy ]
+  propagatedBuildInputs = [ numpy six]
     ++ optional mpiSupport mpi4py
     ;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10784,6 +10784,37 @@ let
     };
   };
 
+  pkgconfig = buildPythonPackage rec {
+    name = "pkgconfig-${version}";
+    version = "1.1.0";
+
+    # pypy: SyntaxError: __future__ statements must appear at beginning of file
+    disabled = isPyPy;
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/pkgconfig/${name}.tar.gz";
+      sha256 = "709daaf077aa2b33bedac12706373412c3683576a43013bbaa529fc2769d80df";
+    };
+
+    buildInputs = with self; [ nose ];
+
+    propagatedBuildInputs = with self; [pkgs.pkgconfig];
+
+    meta = {
+      description = "Interface Python with pkg-config";
+      homepage = http://github.com/matze/pkgconfig;
+      license = licenses.mit;
+    };
+
+    # nosetests needs to be run explicitly.
+    # Note that the distributed archive does not actually contain any tests.
+    # https://github.com/matze/pkgconfig/issues/9
+    checkPhase = ''
+      nosetests
+    '';
+
+  };
+
   plumbum = buildPythonPackage rec {
     name = "plumbum-1.5.0";
 


### PR DESCRIPTION
Since I think 2.4 h5py introduced a new way to configure mpi. Therefore,
the BuildFlags are removed.

I built h5py and h5py-mpi packages successfully. Not sure though whether
the mpi version does actually work correctly since I don't use it.
