### PR TITLE
postfix: 2.11.5 -> 3.0.3

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -11,6 +11,8 @@ let
 
   mainCf =
     ''
+      compatibility_level = 2
+
       queue_directory = /var/postfix/queue
       command_directory = ${pkgs.postfix}/sbin
       daemon_directory = ${pkgs.postfix}/libexec/postfix
@@ -31,10 +33,7 @@ let
           mynetworks_style = ${cfg.networksStyle}
         ''
       else
-        # Postfix default is subnet, but let's play safe
-        ''
-          mynetworks_style = host
-        '')
+        "")
     + optionalString (cfg.hostname != "") ''
       myhostname = ${cfg.hostname}
     ''
@@ -89,7 +88,7 @@ let
   masterCf = ''
     # ==========================================================================
     # service type  private unpriv  chroot  wakeup  maxproc command + args
-    #               (yes)   (yes)   (yes)   (never) (100)
+    #               (yes)   (yes)   (no)    (never) (100)
     # ==========================================================================
     smtp      inet  n       -       n       -       -       smtpd
     #submission inet n       -       n       -       -       smtpd
@@ -232,8 +231,7 @@ in
         default = null;
         example = ["localdomain"];
         description = "
-          List of domains we agree to relay to. Default is the same as
-          destination.
+          List of domains we agree to relay to. Default is empty.
         ";
       };
 
@@ -357,23 +355,20 @@ in
         }
       ];
 
-    jobs.postfix =
-      # I copy _lots_ of shipped configuration filed
-      # that can be left as is. I am afraid the exact
-      # will list slightly change in next Postfix
-      # release, so listing them all one-by-one in an
-      # accurate way is unlikely to be better.
+    systemd.services.postfix =
       { description = "Postfix mail server";
 
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
 
-        daemonType = "fork";
+        serviceConfig = {
+          Type = "forking";
+          Restart = "always";
+          PIDFile = "/var/postfix/queue/pid/master.pid";
+        };
 
         preStart = ''
-          if ! [ -d /var/spool/postfix ]; then
-            ${pkgs.coreutils}/bin/mkdir -p /var/spool/mail /var/postfix/conf /var/postfix/queue
-          fi
+          ${pkgs.coreutils}/bin/mkdir -p /var/spool/mail /var/postfix/conf /var/postfix/queue
 
           ${pkgs.coreutils}/bin/chown -R ${user}:${group} /var/postfix
           ${pkgs.coreutils}/bin/chown -R ${user}:${setgidGroup} /var/postfix/queue
@@ -382,7 +377,7 @@ in
           ${pkgs.coreutils}/bin/chmod a+rwxt /var/spool/mail
           ${pkgs.coreutils}/bin/ln -sf /var/spool/mail /var/mail
 
-          ln -sf "${pkgs.postfix}/etc/postfix/"* /var/postfix/conf
+          ln -sf ${pkgs.postfix}/etc/postfix/postfix-files /var/postfix/conf
 
           ln -sf ${aliasesFile} /var/postfix/conf/aliases
           ln -sf ${virtualFile} /var/postfix/conf/virtual
@@ -391,12 +386,18 @@ in
 
           ${pkgs.postfix}/sbin/postalias -c /var/postfix/conf /var/postfix/conf/aliases
           ${pkgs.postfix}/sbin/postmap -c /var/postfix/conf /var/postfix/conf/virtual
+        '';
 
+        script = ''
           ${pkgs.postfix}/sbin/postfix -c /var/postfix/conf start
         '';
 
+        reload = ''
+          ${pkgs.postfix}/sbin/postfix -c /var/postfix/conf reload
+        '';
+
         preStop = ''
-            ${pkgs.postfix}/sbin/postfix -c /var/postfix/conf stop
+          ${pkgs.postfix}/sbin/postfix -c /var/postfix/conf stop
         '';
 
       };

--- a/pkgs/servers/mail/postfix/3.0.nix
+++ b/pkgs/servers/mail/postfix/3.0.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, makeWrapper, gnused, db, openssl, cyrus_sasl, coreutils
+, findutils, gnugrep, gawk, icu
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "postfix-${version}";
+
+  version = "3.0.3";
+
+  src = fetchurl {
+    url = "ftp://ftp.cs.uu.nl/mirror/postfix/postfix-release/official/${name}.tar.gz";
+    sha256 = "00mc12k5p1zlrlqcf33vh5zizaqr5ai8q78dwv69smjh6kn4c7j0";
+  };
+
+  buildInputs = [ makeWrapper gnused db openssl cyrus_sasl icu ];
+
+  preBuild = ''
+    sed -e '/^PATH=/d' -i postfix-install
+
+    export command_directory=$out/sbin
+    export config_directory=/etc/postfix
+    export daemon_directory=$out/libexec/postfix
+    export data_directory=/var/lib/postfix
+    export html_directory=$out/share/postfix/doc/html
+    export mailq_path=$out/bin/mailq
+    export manpage_directory=$out/share/man
+    export newaliases_path=$out/bin/newaliases
+    export queue_directory=/var/spool/postfix
+    export readme_directory=$out/share/postfix/doc
+    export sendmail_path=$out/bin/sendmail
+
+    make makefiles \
+      CCARGS='-DUSE_TLS -DUSE_SASL_AUTH -DUSE_CYRUS_SASL -I${cyrus_sasl}/include/sasl \
+              -DHAS_DB_BYPASS_MAKEDEFS_CHECK \
+              -fPIE -fstack-protector-all --param ssp-buffer-size=4 -O2 -D_FORTIFY_SOURCE=2' \
+      AUXLIBS='-ldb -lnsl -lresolv -lsasl2 -lcrypto -lssl -pie -Wl,-z,relro,-z,now'
+  '';
+
+  installTargets = [ "non-interactive-package" ];
+
+  installFlags = [ " install_root=installdir " ];
+
+  postInstall = ''
+    mkdir -p $out
+    mv -v installdir/$out/* $out/
+    mv -v installdir/etc $out/etc
+    sed -e '/^PATH=/d' -i $out/libexec/postfix/post-install
+    wrapProgram $out/libexec/postfix/post-install \
+      --prefix PATH ":" ${coreutils}/bin:${findutils}/bin:${gnugrep}/bin
+    wrapProgram $out/libexec/postfix/postfix-script \
+      --prefix PATH ":" ${coreutils}/bin:${findutils}/bin:${gnugrep}/bin:${gawk}/bin:${gnused}/bin
+  '';
+
+  meta = {
+    homepage = "http://www.postfix.org/";
+    description = "A fast, easy to administer, and secure mail server";
+    license = stdenv.lib.licenses.bsdOriginal;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.rickynils ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9174,10 +9174,9 @@ let
   popa3d = callPackage ../servers/mail/popa3d { };
 
   postfix28 = callPackage ../servers/mail/postfix { };
-
   postfix211 = callPackage ../servers/mail/postfix/2.11.nix { };
-
-  postfix = postfix211;
+  postfix30 = callPackage ../servers/mail/postfix/3.0.nix { };
+  postfix = postfix30;
 
   pshs = callPackage ../servers/http/pshs { };
 


### PR DESCRIPTION
There have been a few backwards-incompatible changes in the configuration options.  I have updated the nixos module to generate config files for the new version.  I have tested it both on a clean VM, and one that was running postfix 2.11 before.

Given that the nixos module doesn't work with postfix 2.8 and 2.11 anymore, is there any reason to keep the old versions?
