### PR TITLE
ncurses: revived clang patch

### DIFF
--- a/pkgs/development/libraries/ncurses/clang.patch
+++ b/pkgs/development/libraries/ncurses/clang.patch
@@ -1,0 +1,42 @@
+diff -ruNp ncurses-5.8.orig/c++/cursesf.h ncurses-5.8/c++/cursesf.h
+--- ncurses-5.8.orig/c++/cursesf.h	2005-08-13 21:08:24.000000000 +0300
++++ ncurses-5.8/c++/cursesf.h	2011-04-03 18:29:29.000000000 +0300
+@@ -681,7 +681,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, with_frame, autoDelete_Fields) {
++    : NCursesForm (&Fields, with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -694,7 +694,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, nlines, ncols, begin_y, begin_x,
++    : NCursesForm (&Fields, nlines, ncols, begin_y, begin_x,
+ 		   with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+diff -ruNp ncurses-5.8.orig/c++/cursesm.h ncurses-5.8/c++/cursesm.h
+--- ncurses-5.8.orig/c++/cursesm.h	2005-08-13 21:10:36.000000000 +0300
++++ ncurses-5.8/c++/cursesm.h	2011-04-03 18:31:42.000000000 +0300
+@@ -639,7 +639,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Items=FALSE)
+-    : NCursesMenu (Items, with_frame, autoDelete_Items) {
++    : NCursesMenu (&Items, with_frame, autoDelete_Items) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -651,7 +651,7 @@ public:
+ 		   int begin_x = 0,
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE)
+-    : NCursesMenu (Items, nlines, ncols, begin_y, begin_x, with_frame) {
++    : NCursesMenu (&Items, nlines, ncols, begin_y, begin_x, with_frame) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   # gcc-5.patch should be removed after 5.9
-  patches = [ ./gcc-5.patch ];
+  patches = [ ./clang.patch ./gcc-5.patch ];
 
   configureFlags = [
     "--with-shared"


### PR DESCRIPTION
This patch was introduced by 3e8344d334d42824ac3061a919ac15b19a1bf21d (#3661, Aug 17), then deleted by 0a32eab91e7a547325958da2581933a98095d50c (staging branch, Oct 5). I cannot bootstrap from staging branch on Darwin without this patch. I have no idea why the patch was deleted.

See also #2986.

Tested on OS X 10.11, staging branch with #10621 applied.
