### PR TITLE
darwin: R: add needed inputs and flags

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -55,9 +55,10 @@ stdenv.mkDerivation rec {
       R_SHELL="${stdenv.shell}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
       --without-tcltk
+      --without-aqua
       --disable-R-framework
       CC="clang"
-      CXX="clang"
+      CXX="clang++"
       OBJC="clang"
   '' + ''
     )

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -4,7 +4,7 @@
 , imake, which, jdk, openblas, curl
 , tzdata
 , withRecommendedPackages ? true
-, Cocoa, Foundation, libobjc
+, Cocoa, Foundation, cf-private, libobjc
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     texLive xz zlib less texinfo graphviz icu pkgconfig bison imake
     which jdk openblas curl ]
     ++ stdenv.lib.optionals (!stdenv.isDarwin) [ tcl tk ]
-    ++ stdenv.lib.optionals stdenv.isDarwin (darwinFrameworks ++ [ Cocoa Foundation libobjc ]);
+    ++ stdenv.lib.optionals stdenv.isDarwin (darwinFrameworks ++ [ Cocoa Foundation cf-private libobjc ]);
 
   patches = [ ./no-usr-local-search-paths.patch ];
 

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -1,10 +1,14 @@
-{ stdenv, R, xvfb_run, utillinux }:
+{ stdenv, R, tzdata, gettext, gfortran, libcxx, xvfb_run, utillinux }:
 
 { name, buildInputs ? [], ... } @ attrs:
 
 stdenv.mkDerivation ({
-  buildInputs = buildInputs ++ [R] ++
-                stdenv.lib.optionals attrs.requireX [utillinux xvfb_run];
+  buildInputs = buildInputs ++ [ R tzdata gettext gfortran ] ++
+                stdenv.lib.optionals attrs.requireX [utillinux xvfb_run] ++
+                stdenv.lib.optionals stdenv.isDarwin R.darwinFrameworks;
+
+  NIX_CFLAGS_COMPILE =
+    stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -1,9 +1,13 @@
-{ stdenv, R, makeWrapper, recommendedPackages, packages }:
+{ stdenv, R, libcxx, makeWrapper, recommendedPackages, packages }:
 
 stdenv.mkDerivation {
   name = R.name + "-wrapper";
 
-  buildInputs = [makeWrapper R] ++ recommendedPackages ++ packages;
+  buildInputs = [makeWrapper R] ++ recommendedPackages ++ packages
+    ++ stdenv.lib.optionals stdenv.isDarwin R.darwinFrameworks;
+
+  NIX_CFLAGS_COMPILE =
+    stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   unpackPhase = ":";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9091,7 +9091,7 @@ let
     openblas = openblasCompat;
     withRecommendedPackages = false;
     inherit (darwin.apple_sdk.frameworks) Cocoa Foundation;
-    inherit (darwin) libobjc;
+    inherit (darwin) cf-private libobjc;
   };
 
   rWrapper = callPackage ../development/r-modules/wrapper.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9090,6 +9090,8 @@ let
     };
     openblas = openblasCompat;
     withRecommendedPackages = false;
+    inherit (darwin.apple_sdk.frameworks) Cocoa Foundation;
+    inherit (darwin) libobjc;
   };
 
   rWrapper = callPackage ../development/r-modules/wrapper.nix {


### PR DESCRIPTION
Needed to disalbe tcltk on darwin. Could not figure out, why it fails in tests with:

```
> require('tcltk')
Loading required package: tcltk
Error : .onLoad failed in loadNamespace() for 'tcltk', details:
  call: dyn.load(file, DLLpath = DLLpath, ...)
  error: unable to load shared object '/private/var/folders/y6/2zdynm9x3nv6sq5p6780dwdc0000gn/T/nix-build-R-3.2.2.drv-0/R-3.2.2/library/tcltk/libs/tcltk.so':
  dlopen(/private/var/folders/y6/2zdynm9x3nv6sq5p6780dwdc0000gn/T/nix-build-R-3.2.2.drv-0/R-3.2.2/library/tcltk/libs/tcltk.so, 10): Library not loaded: /nix/store/c2cbzc12azf3in7pcvk5c92j6kp6i4iv-tk-8.6.4/lib:/nix/store/wq6iqsri9g0bdg2a9w9a42appspdynma-tcl-8.6.4/lib/libtk8.6.dylib
  Referenced from: /private/var/folders/y6/2zdynm9x3nv6sq5p6780dwdc0000gn/T/nix-build-R-3.2.2.drv-0/R-3.2.2/library/tcltk/libs/tcltk.so
  Reason: image not found
```

Needed to add tzdata to use it instead of hardcoded zoneinfo paths on darwin.

This still has runtime issues on darwin. Rscript works, but R console segfaults on start.

To test this on darwin, also gfortran should be fixed, e.g. https://github.com/NixOS/nixpkgs/pull/10532
