### PR TITLE
mp3val: Better installPhase

### DIFF
--- a/pkgs/applications/audio/mp3val/default.nix
+++ b/pkgs/applications/audio/mp3val/default.nix
@@ -12,8 +12,7 @@ stdenv.mkDerivation rec {
   makefile = "Makefile.linux";
 
   installPhase = ''
-    mkdir -p $out/bin/
-    cp mp3val $out/bin/
+    install -Dv mp3val "$out/bin/mp3val"
   '';
 
   meta = {
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://mp3val.sourceforge.net/index.shtml;
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.devhell ];
   };
 }


### PR DESCRIPTION
As mentioned by @aszlig, it's more elegant and sane to use coreutils'
`install`. This commit also changes `platforms` to `unix` since this
should also compile on Darwin for example.
