### PR TITLE
teamviewer: fix the expressions

### DIFF
--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -29,6 +29,7 @@ in
 
       wantedBy = [ "graphical.target" ];
       after = [ "NetworkManager-wait-online.service" "network.target" ];
+      preStart = "mkdir -pv /var/tmp/teamviewer10/{logs,config}";
 
       serviceConfig = {
         Type = "forking";


### PR DESCRIPTION
teamviewerd attempts to write to logfiles/configfiles that are in the store, the symlinks solve that issue
and the fixupPhase undid some rpath fixes, so i had to move that to after fixupPhase
