### PR TITLE
oraclejdk: 8u60 -> 8u66

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "60";
+  patchVersion = "66";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "e6a36b458351ed35bd7943739ba93d9a246e08a86433e148ff68b1b40d74c2e5";
-  sha256_x86_64 = "ebe51554d2f6c617a4ae8fc9a8742276e65af01bd273e96848b262b3c05424e5";
+  sha256_i686 = "21026a8d789f479d3905a4ead0c97fd5190aa9b4d1bfc66413e9136513ca84a2";
+  sha256_x86_64 = "7e95ad5fa1c75bc65d54aaac9e9986063d0a442f39a53f77909b044cef63dc0a";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
Bumping Oracle JDK patch version from 60 to 66.

There is no publicly available download for patch version 60 anymore. The URL given only provides 8u65 and 8u66.
