### PR TITLE
parse-cli-bin: init at 3.0.1

### DIFF
--- a/pkgs/development/tools/parse-cli-bin/default.nix
+++ b/pkgs/development/tools/parse-cli-bin/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "3.0.1";
+
+in stdenv.mkDerivation rec {
+
+  name = "parse-cli-bin-${version}";
+
+  src = fetchurl {
+    url    = "https://github.com/ParsePlatform/parse-cli/releases/download/release_${version}/parse_linux";
+    sha256 = "d68eccc1d9408b60901b149d2b4710f3cfd0eabe5772d2e222c06870fdeca3c7";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Parse Command Line Interface";
+    homepage    = "https://parse.com";
+    platforms   = platforms.linux;
+  };
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp "$src" "$out/bin/parse"
+    chmod +x "$out/bin/parse"
+  '';
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5728,6 +5728,8 @@ let
 
   oprofile = callPackage ../development/tools/profiling/oprofile { };
 
+  parse-cli-bin = callPackage ../development/tools/parse-cli-bin { };
+
   patchelf = callPackage ../development/tools/misc/patchelf { };
 
   peg = callPackage ../development/tools/parsing/peg { };


### PR DESCRIPTION
[Parse](https://parse.com)'s [installation instructions](https://parse.com/apps/quickstart#cloud_code/unix) point to a [shell script](https://www.parse.com/downloads/cloud_code/installer.sh) which simply downloads the [release from github](https://github.com/ParsePlatform/parse-cli/releases/), so this ends up being a very straightforward package.
