### PR TITLE
U-Boot: 2015.07 -> 2015.10

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -22,11 +22,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "uboot-${defconfig}-${version}";
-  version = "2015.07";
+  version = "2015.10";
 
   src = fetchurl {
     url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-    sha256 = "1nclmyii5a1igvgjc4kxvi1fk2y82hp2iy4iywp34b3zf6ywjj0b";
+    sha256 = "0m8r08izci0lzzjn5c5g5manp2rc7yc5swww0lxr7bamjigqvimx";
   };
 
   patches = [ ./vexpress-Use-config_distro_bootcmd.patch ];

--- a/pkgs/misc/uboot/vexpress-Use-config_distro_bootcmd.patch
+++ b/pkgs/misc/uboot/vexpress-Use-config_distro_bootcmd.patch
@@ -1,4 +1,4 @@
-From 1fb764e1866513a69b4a0c29b69f8e78ea1df7fa Mon Sep 17 00:00:00 2001
+From 98f62c27fe481dc2d444d70265268d2369d8a998 Mon Sep 17 00:00:00 2001
 From: Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>
 Date: Mon, 8 Jun 2015 22:29:23 +0300
 Subject: [PATCH] vexpress: Use config_distro_bootcmd
@@ -8,12 +8,11 @@ cli_readline_into_buffer doesn't respect the timeout.
 ---
  common/cli_readline.c             | 12 +++++++++++-
  configs/vexpress_ca9x4_defconfig  |  2 --
- include/configs/vexpress_ca9x4.h  |  1 -
- include/configs/vexpress_common.h | 34 ++++++++++++++++++++++------------
- 4 files changed, 33 insertions(+), 16 deletions(-)
+ include/configs/vexpress_common.h |  2 +-
+ 3 files changed, 12 insertions(+), 4 deletions(-)
 
 diff --git a/common/cli_readline.c b/common/cli_readline.c
-index 9a9fb35..ca997a9 100644
+index c1476e4..5063a0a 100644
 --- a/common/cli_readline.c
 +++ b/common/cli_readline.c
 @@ -517,6 +517,7 @@ int cli_readline_into_buffer(const char *const prompt, char *buffer,
@@ -58,100 +57,26 @@ index 2947fc1..9a5123d 100644
  # CONFIG_CMD_ITEST is not set
  # CONFIG_CMD_SETEXPR is not set
  # CONFIG_CMD_NFS is not set
-diff --git a/include/configs/vexpress_ca9x4.h b/include/configs/vexpress_ca9x4.h
-index 38ac4ed..993398c 100644
---- a/include/configs/vexpress_ca9x4.h
-+++ b/include/configs/vexpress_ca9x4.h
-@@ -13,6 +13,5 @@
- 
- #define CONFIG_VEXPRESS_ORIGINAL_MEMORY_MAP
- #include "vexpress_common.h"
--#define CONFIG_BOOTP_VCI_STRING     "U-boot.armv7.vexpress_ca9x4"
- 
- #endif /* VEXPRESS_CA9X4_H */
 diff --git a/include/configs/vexpress_common.h b/include/configs/vexpress_common.h
-index 0c1da01..72850d0 100644
+index 98f6ae9..062532a 100644
 --- a/include/configs/vexpress_common.h
 +++ b/include/configs/vexpress_common.h
-@@ -123,7 +123,6 @@
- #define CONFIG_SYS_L2CACHE_OFF		1
- #define CONFIG_INITRD_TAG		1
- #define CONFIG_SYS_GENERIC_BOARD
--#define CONFIG_OF_LIBFDT		1
- 
- /* Size of malloc() pool */
- #define CONFIG_SYS_MALLOC_LEN		(CONFIG_ENV_SIZE + 128 * 1024)
-@@ -152,6 +151,7 @@
- #define CONFIG_SYS_SERIAL0		V2M_UART0
- #define CONFIG_SYS_SERIAL1		V2M_UART1
- 
-+#include <config_distro_defaults.h>
- /* Command line configuration */
- #define CONFIG_CMD_DHCP
- #define CONFIG_CMD_PXE
-@@ -163,7 +163,6 @@
- #define CONFIG_SUPPORT_RAW_INITRD
- 
- #define CONFIG_CMD_FAT
--#define CONFIG_DOS_PARTITION		1
- #define CONFIG_MMC			1
- #define CONFIG_CMD_MMC
- #define CONFIG_GENERIC_MMC
-@@ -201,17 +200,28 @@
+@@ -185,7 +185,6 @@
+ 					 CONFIG_SYS_INIT_RAM_SIZE - \
  					 GENERATED_GBL_DATA_SIZE)
  #define CONFIG_SYS_INIT_SP_ADDR		CONFIG_SYS_GBL_DATA_OFFSET
+-#define CONFIG_CMD_ECHO
  
-+#define BOOT_TARGET_DEVICES(func) \
-+	func(MMC, mmc, 0)
-+#include <config_distro_bootcmd.h>
-+
- /* Basic environment settings */
--#define CONFIG_BOOTCOMMAND		"run bootflash;"
- #ifdef CONFIG_VEXPRESS_ORIGINAL_MEMORY_MAP
-+/*
-+ * RAM starts at 0x6000_0000
-+ *  - U-Boot loaded @ 8M
-+ *  - Kernel loaded @ 32M
-+ *  - Initrd loaded @ 128M
-+ *  - DTB    loaded @ 240M
-+ */
- #define CONFIG_PLATFORM_ENV_SETTINGS \
--		"loadaddr=0x80008000\0" \
--		"ramdisk_addr_r=0x61000000\0" \
--		"kernel_addr=0x44100000\0" \
--		"ramdisk_addr=0x44800000\0" \
--		"maxramdisk=0x1800000\0" \
--		"pxefile_addr_r=0x88000000\0" \
--		"kernel_addr_r=0x80008000\0"
+ #include <config_distro_defaults.h>
+ 
+@@ -225,6 +224,7 @@
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+ 		CONFIG_PLATFORM_ENV_SETTINGS \
+                 BOOTENV \
 +		"fdtfile=vexpress-v2p-ca9.dtb\0" \
-+		"kernel_addr_r=0x62000000\0" \
-+		"ramdisk_addr_r=0x68000000\0" \
-+		"maxramdisk=0x06000000\0" \
-+		"fdt_addr_r=0x6f000000\0" \
-+		"loadaddr=0x70000000\0" \
-+		"pxefile_addr_r=0x71000000\0" \
-+		"scriptaddr=0x72000000\0"
- #elif defined(CONFIG_VEXPRESS_EXTENDED_MEMORY_MAP)
- #define CONFIG_PLATFORM_ENV_SETTINGS \
- 		"loadaddr=0xa0008000\0" \
-@@ -234,7 +244,8 @@
- 			"devtmpfs.mount=0  vmalloc=256M\0" \
- 		"bootflash=run flashargs; " \
- 			"cp ${ramdisk_addr} ${ramdisk_addr_r} ${maxramdisk}; " \
--			"bootm ${kernel_addr} ${ramdisk_addr_r}\0"
-+			"bootm ${kernel_addr} ${ramdisk_addr_r}\0" \
-+                BOOTENV
- 
- /* FLASH and environment organization */
- #define PHYS_FLASH_SIZE			0x04000000	/* 64MB */
-@@ -287,7 +298,6 @@
- 
- #define CONFIG_SYS_BARGSIZE		CONFIG_SYS_CBSIZE /* Boot args buffer */
- #define CONFIG_SYS_LONGHELP
--#define CONFIG_CMDLINE_EDITING		1
- #define CONFIG_SYS_MAXARGS		16	/* max command args */
- 
- #endif /* VEXPRESS_COMMON_H */
+ 		"console=ttyAMA0,38400n8\0" \
+ 		"dram=1024M\0" \
+ 		"root=/dev/sda1 rw\0" \
 -- 
-2.4.5
+2.6.0
 


### PR DESCRIPTION
Someone submitted conflicting (and non-complete) distro bootconfig
support for the Versatile board, so the patch needs changing, yet again.
But at least it's getting smaller.
