### PR TITLE
fetchgit: add record-playback

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -262,7 +262,8 @@ clone_user_rev() {
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
     if test -z "$leaveDotGit"; then
         echo "removing \`.git'..." >&2
-        find $dir -name .git\* | xargs rm -rf
+        # don't remove .gitignore
+        find $dir -name .git | xargs rm -rf
     else
         find $dir -name .git | while read gitdir; do
             make_deterministic_repo "$(readlink -f "$gitdir/..")"

--- a/pkgs/build-support/fetchgit/record.nix
+++ b/pkgs/build-support/fetchgit/record.nix
@@ -1,0 +1,15 @@
+{ fetchgit, record-playback, stdenv }: { recordCommands ? [], ... }@allargs:
+with stdenv.lib;
+let
+
+  args = filterAttrs (name: v: name != "recordCommands") allargs;
+
+  script = map (cmd: "(cd $out && record-command git ${cmd})") recordCommands;
+
+in overrideDerivation (fetchgit args) (attrs: {
+
+  buildInputs = (attrs.buildInputs or []) ++ [ record-playback ];
+
+  NIX_PREFETCH_GIT_CHECKOUT_HOOK = concatStringsSep "\n" script;
+
+})

--- a/pkgs/build-support/record-playback/default.nix
+++ b/pkgs/build-support/record-playback/default.nix
@@ -1,0 +1,22 @@
+{ stdenv }:
+
+stdenv.mkDerivation rec {
+
+  name = "record-playback";
+
+  version = "1.0";
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  src = ./.;
+
+  installPhase = ''
+    mkdir -p "$out"/bin
+    install record-command "$out"/bin/record-command
+    install playback-command "$out"/bin/playback-command
+    mkdir -p "$out"/nix-support
+    install setup-hook "$out"/nix-support/setup-hook
+    substituteAllInPlace "$out"/nix-support/setup-hook
+  '';
+
+}

--- a/pkgs/build-support/record-playback/playback-command
+++ b/pkgs/build-support/record-playback/playback-command
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec record-command --playback "$(basename "$0")" "$@"

--- a/pkgs/build-support/record-playback/record-command
+++ b/pkgs/build-support/record-playback/record-command
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+if [ "$1" = "--playback" ]; then
+  shift
+  PLAYBACK=1
+fi
+
+cmd="$1"; shift
+shortargs="$(printf %s "$*" | tr -d '[:space:]')"
+dir=".record-playback/$cmd/$shortargs"
+
+if [ -n "$PLAYBACK" ]; then
+  printf "playing back \`%s %s' from %s...\n" "$cmd" "$*" "$dir" >&2
+  (exec cat "$dir"/stdout) &
+  (exec cat "$dir"/stderr >&2) &
+  wait
+  exit "$(cat "$dir"/exitval)"
+else
+  printf "recording \`%s %s' in %s...\n" "$cmd" "$*" "$dir" >&2
+  mkdir -p "$dir"
+  exitval=0
+  "$cmd" "$@" 1>"$dir"/stdout 2>"$dir"/stderr || exitval="$?"
+  printf %s "$exitval" >"$dir"/exitval
+fi

--- a/pkgs/build-support/record-playback/record-command
+++ b/pkgs/build-support/record-playback/record-command
@@ -9,8 +9,13 @@ fi
 # played-back stderr is not interfered with
 [ -n "${RECORD_PLAYBACK_LOG_FD:-}" ] || RECORD_PLAYBACK_LOG_FD=2
 
+# If someone can explain why wrapping the printfs in curly braces and
+# directing fd2 to /dev/null is necessary to avoid "Bad file
+# descriptor" error when invoked from buildRubyGems's 'gem build', I'd
+# much appreciate it. (Observed on darwin, so maybe that's to blame.)
 warn() {
-  { printf "$@"; printf "\n"; } >&$RECORD_PLAYBACK_LOG_FD
+  { printf "$@" >&$RECORD_PLAYBACK_LOG_FD; } 2>/dev/null
+  { printf "\n" >&$RECORD_PLAYBACK_LOG_FD; } 2>/dev/null
 }
 
 cmd="$1"; shift

--- a/pkgs/build-support/record-playback/record-command
+++ b/pkgs/build-support/record-playback/record-command
@@ -5,19 +5,32 @@ if [ "$1" = "--playback" ]; then
   PLAYBACK=1
 fi
 
+# setup-hook opens a file descriptor directing to stderr so that the
+# played-back stderr is not interfered with
+[ -n "${RECORD_PLAYBACK_LOG_FD:-}" ] || RECORD_PLAYBACK_LOG_FD=2
+
+warn() {
+  { printf "$@"; printf "\n"; } >&$RECORD_PLAYBACK_LOG_FD
+}
+
 cmd="$1"; shift
-shortargs="$(printf %s "$*" | tr -d '[:space:]')"
-dir=".record-playback/$cmd/$shortargs"
+dir=".record-playback/$cmd/$(printf %s "$*" | sha256sum | cut -d' ' -f1)"
 
 if [ -n "$PLAYBACK" ]; then
-  printf "playing back \`%s %s' from %s...\n" "$cmd" "$*" "$dir" >&2
+  if [ ! -d "$dir" ]; then
+    warn "failed to playback \`%s %s': %.28s...: no recorded output found" "$cmd" "$*" "$dir"
+    exit 100
+  fi
+
+  warn "playing back \`%s %s' from %.28s..." "$cmd" "$*" "$dir"
   (exec cat "$dir"/stdout) &
   (exec cat "$dir"/stderr >&2) &
   wait
   exit "$(cat "$dir"/exitval)"
 else
-  printf "recording \`%s %s' in %s...\n" "$cmd" "$*" "$dir" >&2
+  warn "recording \`%s %s' in %.28s..." "$cmd" "$*" "$dir"
   mkdir -p "$dir"
+  printf "%s" "$*" > "$dir"/args
   exitval=0
   "$cmd" "$@" 1>"$dir"/stdout 2>"$dir"/stderr || exitval="$?"
   printf %s "$exitval" >"$dir"/exitval

--- a/pkgs/build-support/record-playback/setup-hook
+++ b/pkgs/build-support/record-playback/setup-hook
@@ -8,6 +8,8 @@ intercept-commands-for-playback() {
     ln -s @out@/bin/playback-command "$bin/$(basename "$dir")"
   done
 
+  exec {RECORD_PLAYBACK_LOG_FD}>&2
+  export RECORD_PLAYBACK_LOG_FD
   export PATH="$bin${PATH:+:}$PATH"
 }
 

--- a/pkgs/build-support/record-playback/setup-hook
+++ b/pkgs/build-support/record-playback/setup-hook
@@ -1,0 +1,14 @@
+intercept-commands-for-playback() {
+  local bin="$PWD/.record-playback/bin"
+  local dir
+
+  mkdir -p "$bin"
+
+  for dir in "$src"/.record-playback/*; do
+    ln -s @out@/bin/playback-command "$bin/$(basename "$dir")"
+  done
+
+  export PATH="$bin${PATH:+:}$PATH"
+}
+
+intercept-commands-for-playback

--- a/pkgs/development/interpreters/ruby/bundler-head.nix
+++ b/pkgs/development/interpreters/ruby/bundler-head.nix
@@ -1,13 +1,14 @@
-{ buildRubyGem, coreutils, fetchgit }:
+{ buildRubyGem, coreutils, fetchgitRecord, record-playback }:
 
 buildRubyGem {
   name = "bundler-2015-01-11";
-  src = fetchgit {
+  src = fetchgitRecord {
     url = "https://github.com/bundler/bundler.git";
     rev = "a2343c9eabf5403d8ffcbca4dea33d18a60fc157";
-    sha256 = "06qsai4ac3i2xlr7nbc4anh4cy6jd9jjf3rpj254g9gwshqv0qgr";
-    leaveDotGit = true;
+    sha256 = "11s7mpx330lp1c640pq21rd60iz799838kjykf360lphq02y1d45";
+    recordCommands = [ "ls-files -z" ];
   };
+  buildInputs = [ record-playback ];
   dontPatchShebangs = true;
   postInstall = ''
     find $out -type f -perm -0100 | while read f; do

--- a/pkgs/development/interpreters/ruby/gem.nix
+++ b/pkgs/development/interpreters/ruby/gem.nix
@@ -1,4 +1,4 @@
-{ lib, ruby, rubygemsFun, fetchurl, makeWrapper, git } @ defs:
+{ lib, ruby, rubygemsFun, fetchurl, makeWrapper } @ defs:
 
 lib.makeOverridable (
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation (attrs // {
   inherit ruby rubygems;
   inherit doCheck;
 
-  buildInputs = [ ruby rubygems makeWrapper git ] ++ buildInputs;
+  buildInputs = [ ruby rubygems makeWrapper ] ++ buildInputs;
 
   name = namePrefix + name;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -324,6 +324,10 @@ let
 
   fetchgitPrivate = callPackage ../build-support/fetchgit/private.nix { };
 
+  fetchgitRecord = callPackage ../build-support/fetchgit/record.nix { };
+
+  record-playback = callPackage ../build-support/record-playback { };
+
   fetchgitrevision = import ../build-support/fetchgitrevision runCommand git;
 
   fetchgitLocal = callPackage ../build-support/fetchgitlocal { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5126,9 +5126,9 @@ let
     ruby = ruby_2_1_3;
   };
   bundler = callPackage ../development/interpreters/ruby/bundler.nix { };
-  bundler_HEAD = callPackage ../development/interpreters/ruby/bundler-head.nix { };
-  #  inherit buildRubyGem coreutils fetchgit;
-  #};
+  bundler_HEAD = import ../development/interpreters/ruby/bundler-head.nix {
+    inherit buildRubyGem coreutils fetchgitRecord record-playback;
+  };
   defaultGemConfig = callPackage ../development/interpreters/ruby/bundler-env/default-gem-config.nix { };
   buildRubyGem = callPackage ../development/interpreters/ruby/gem.nix { };
   bundlerEnv = callPackage ../development/interpreters/ruby/bundler-env { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5126,9 +5126,9 @@ let
     ruby = ruby_2_1_3;
   };
   bundler = callPackage ../development/interpreters/ruby/bundler.nix { };
-  bundler_HEAD = import ../development/interpreters/ruby/bundler-head.nix {
-    inherit buildRubyGem coreutils fetchgit;
-  };
+  bundler_HEAD = callPackage ../development/interpreters/ruby/bundler-head.nix { };
+  #  inherit buildRubyGem coreutils fetchgit;
+  #};
   defaultGemConfig = callPackage ../development/interpreters/ruby/bundler-env/default-gem-config.nix { };
   buildRubyGem = callPackage ../development/interpreters/ruby/gem.nix { };
   bundlerEnv = callPackage ../development/interpreters/ruby/bundler-env { };


### PR DESCRIPTION
(This is just a proof-of-concept; requesting feedback)

Many build scripts assume the ability to run git commands such as
'ls-files' or 'describe'. But unless fetchgit removes `.git`, the source
is non-deterministic (see https://github.com/NixOS/nixpkgs/issues/8567).

This patch arranges for fetchgit to record the output of various
commands at fetch time, and playback that output at build time.

TODO: fetchgit currently requires leaveDotGit when deepClone is used,
the latter giving a functioning `git describe`. But with
record-playback, the `.git` should still be removed.

Example:

```
{ stdenv, fetchgitRecord, record-playback }:

in stdenv.mkDerivation rec {

  src = fetchgitRecord {
    url = "git://someurl";
    rev = "some-revision";
    sha256 = "xxxxxxx";
    recordCommands = [ "ls-files -z" ];
  };

  buildInputs = [ record-playback ];

  ...
}
```
