### PR TITLE
python pandas: disable specific test for darwin

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11489,7 +11489,7 @@ let
       # The flag `-A 'not network'` will disable tests that use internet.
       # The `-e` flag disables a few problematic tests.
       ${python.executable} setup.py nosetests -A 'not network' --stop \
-        -e 'test_data|test_excel|test_html|test_json|test_frequencies|test_frame' --verbosity=3
+        -e 'test_data|test_excel|test_html|test_json|test_frequencies|test_frame|test_read_clipboard_infer_excel' --verbosity=3
 
       runHook postCheck
     '';


### PR DESCRIPTION
Disable specific test that failed on darwin. See also #9207 
@datakurre @sanbor @domenkozar 

By the way, pandas did build without problems for Python 3.4 on x86-64. I can't explain why Hydra wasn't able to build it.
