### PR TITLE
pinta: 1.4 -> 1.6

### DIFF
--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -1,44 +1,63 @@
-{stdenv, fetchurl, mono, gtksharp, pkgconfig}:
+{ stdenv, fetchFromGitHub, buildDotnetPackage, dotnetPackages, gtksharp }:
 
-stdenv.mkDerivation {
-  name = "pinta-1.4";
+let
+  mono-addins = dotnetPackages.MonoAddins;
+in
+buildDotnetPackage rec {
+  name = "pinta-1.6";
 
-  src = fetchurl {
-    url = "https://github.com/PintaProject/Pinta/tarball/3f7ccfa93d";
-    name = "pinta-1.4.tar.gz";
-    sha256 = "1kgb4gy5l6bd0akniwhiqqkvqayr5jgdsvn2pgg1038q9raafnpn";
+  baseName = "Pinta";
+  version = "1.6";
+  outputFiles = [ "bin/*" ];
+  buildInputs = [ gtksharp mono-addins ];
+  xBuildFiles = [ "Pinta.sln" ];
+
+  src = fetchFromGitHub {
+    owner = "PintaProject";
+    repo = "Pinta";
+    rev = version;
+    sha256 = "0vgswy981c7ys4q7js5k85sky7bz8v32wsfq3br4j41vg92pw97d";
   };
 
-  buildInputs = [mono gtksharp pkgconfig];
+  # Remove version information from nodes <Reference Include="... Version=... ">
+  postPatch = with stdenv.lib; let
+    csprojFiles = [
+      "Pinta/Pinta.csproj"
+      "Pinta.Core/Pinta.Core.csproj"
+      "Pinta.Effects/Pinta.Effects.csproj"
+      "Pinta.Gui.Widgets/Pinta.Gui.Widgets.csproj"
+      "Pinta.Resources/Pinta.Resources.csproj"
+      "Pinta.Tools/Pinta.Tools.csproj"
+    ];
+    versionedNames = [
+      "Mono\\.Addins"
+      "Mono\\.Posix"
+      "Mono\\.Addins\\.Gui"
+      "Mono\\.Addins\\.Setup"
+    ];
 
-  buildPhase = ''
-    # xbuild understands pkgconfig, but gtksharp does not give .pc for gdk-sharp
-    # So we have to go the GAC-way
-    export MONO_GAC_PREFIX=${gtksharp}
-    xbuild Pinta.sln
-  '';
+    stripVersion = name: file: let
+        match = ''<Reference Include="${name}([ ,][^"]*)?"'';
+        replace = ''<Reference Include="${name}"'';
+      in "sed -i -re 's/${match}/${replace}/g' ${file}\n";
 
-  # Very ugly - I don't know enough Mono to improve this. Isn't there any rpath in binaries?
-  installPhase = ''
-    mkdir -p $out/lib/pinta $out/bin
-    cp bin/*.{dll,exe} $out/lib/pinta
-    cat > $out/bin/pinta << EOF
-    #!/bin/sh
-    export MONO_GAC_PREFIX=${gtksharp}:\$MONO_GAC_PREFIX
-    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${gtksharp}/lib:${gtksharp.gtk}/lib:${mono}/lib
-    exec ${mono}/bin/mono $out/lib/pinta/Pinta.exe
-    EOF
-    chmod +x $out/bin/pinta
-  '';
+    # Map all possible pairs of two lists
+    map2 = f: listA: listB: concatMap (a: map (f a) listB) listA;
+    concatMap2Strings = f: listA: listB: concatStrings (map2 f listA listB);
+  in
+    concatMap2Strings stripVersion versionedNames csprojFiles;
 
-  # Always needed on Mono, otherwise nothing runs
-  dontStrip = true; 
+  makeWrapperArgs = [
+    ''--prefix MONO_GAC_PREFIX ':' "${gtksharp}"''
+    ''--prefix LD_LIBRARY_PATH ':' "${gtksharp}/lib"''
+    ''--prefix LD_LIBRARY_PATH ':' "${gtksharp.gtk}/lib"''
+  ];
 
   meta = {
     homepage = http://www.pinta-project.com/;
     description = "Drawing/editing program modeled after Paint.NET";
     license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/build-support/build-dotnet-package/default.nix
+++ b/pkgs/build-support/build-dotnet-package/default.nix
@@ -9,6 +9,9 @@ attrsOrig @
 , outputFiles ? [ "bin/Release/*" ]
 , dllFiles ? [ "*.dll" ]
 , exeFiles ? [ "*.exe" ]
+# Additional arguments to pass to the makeWrapper function, which wraps
+# generated binaries.
+, makeWrapperArgs ? [ ]
 , ... }:
   let
     arrayToShell = (a: toString (map (lib.escape (lib.stringToCharacters "\\ ';$`()|<>\t") ) a));
@@ -98,7 +101,10 @@ attrsOrig @
             [ -f "$exe" ] || continue
             mkdir -p "$out"/bin
             commandName="$(basename -s .exe "$(echo "$exe" | tr "[A-Z]" "[a-z]")")"
-            makeWrapper "${mono}/bin/mono \"$exe\"" "$out"/bin/"$commandName"
+            makeWrapper \
+              "${mono}/bin/mono \"$exe\"" \
+              "$out"/bin/"$commandName" \
+              ''${makeWrapperArgs}
           done
         done
 

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -420,6 +420,38 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     };
   };
 
+  MonoAddins = buildDotnetPackage rec {
+    baseName = "Mono.Addins";
+    version = "1.2";
+
+    xBuildFiles = [
+      "Mono.Addins/Mono.Addins.csproj"
+      "Mono.Addins.Setup/Mono.Addins.Setup.csproj"
+      "Mono.Addins.Gui/Mono.Addins.Gui.csproj"
+      "Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj"
+    ];
+    outputFiles = [ "bin/*" ];
+
+    src = fetchFromGitHub {
+      owner = "mono";
+      repo = "mono-addins";
+      rev = "mono-addins-${version}";
+      sha256 = "1hnn0a2qsjcjprsxas424bzvhsdwy0yc2jj5xbp698c0m9kfk24y";
+    };
+
+    buildInputs = [ pkgs.gtk-sharp ];
+
+    meta = {
+      description = "A generic framework for creating extensible applications";
+      homepage = http://www.mono-project.com/Mono.Addins;
+      longDescription = ''
+        A generic framework for creating extensible applications,
+        and for creating libraries which extend those applications.
+      '';
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   MonoDevelopFSharpBinding = buildDotnetPackage rec {
     baseName = "MonoDevelop.FSharpBinding";
     version = "git-a09c8185eb";


### PR DESCRIPTION
There are three distinct changes:
1. Updated pinta to version 1.6. Note, that package now uses `buildDotnetPackage` instead of plain `mkDerivation`. Also added manpages and .desktop file.
CC maintainer: @viric

In order to do 1., I needed:
2. Add dotnet package Mono.Addins (init at 1.2)
3. Add `makeWrapperArgs` argument to `buildDotnetPackage` (we have the same thing in `buildPythonPackage` and I think it should be often useful)
CC maintainer: @obadz

I stripped  `Version`, `Culture` and `PublicKeyToken` attributes from `<Reference Include="..." />`  in Pinta's .csproj files, so that `xbuild` could find those libraries. I don't know if that was a correct way to resolve that issue but something very similar happens in this monodevelop patch: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/dotnet-modules/patches/monodevelop-fsharpbinding.references.patch

I tested it locally just in case for both system="i686-linux" and system="x86_64-linux".

EDIT: removed unnecessary comment
