### PR TITLE
python llmvlite: enum34 also for python 3.5

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8294,7 +8294,7 @@ let
 
     llvm = pkgs.llvm;
 
-    propagatedBuildInputs = with self; [ llvm ] ++ optional (!isPy34) enum34;
+    propagatedBuildInputs = with self; [ llvm ] ++ optional (pythonOlder "3.4") enum34;
 
     # Disable static linking
     # https://github.com/numba/llvmlite/issues/93


### PR DESCRIPTION
This allows building llvmlite and numba on Python 3.5

@domenkozar 
