### PR TITLE
darwin: pyqt4: add needed inputs

### DIFF
--- a/pkgs/development/python-modules/pyqt/4.x.nix
+++ b/pkgs/development/python-modules/pyqt/4.x.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, python, pythonPackages, qt4, pythonDBus, pkgconfig, lndir, makeWrapper }:
+{ stdenv, fetchurl, python, pythonPackages, qt4, pythonDBus, pkgconfig, lndir, makeWrapper
+, ApplicationServices
+}:
 
 let version = "4.11.3";
 in
@@ -9,6 +11,14 @@ stdenv.mkDerivation {
     url = "mirror://sourceforge/pyqt/PyQt4/PyQt-${version}/PyQt-x11-gpl-${version}.tar.gz";
     sha256 = "11jnfjw79s0b0qdd9s6kd69w87vf16dhagbhbmwbmrp2vgf80dw5";
   };
+
+  NIX_CFLAGS_COMPILE =
+    stdenv.lib.optionalString stdenv.isDarwin "-mmacosx-version-min=10.7";
+
+  __impureHostDeps = stdenv.lib.optionals stdenv.isDarwin [
+    "/usr/lib/libiconv.dylib"
+    "/usr/lib/libiconv.2.4.0.dylib"
+  ];
 
   configurePhase = ''
     mkdir -p $out
@@ -28,7 +38,8 @@ stdenv.mkDerivation {
     ${python.executable} configure.py $configureFlags "''${configureFlagsArray[@]}"
   '';
 
-  buildInputs = [ python pkgconfig makeWrapper qt4 lndir ];
+  buildInputs = [ python pkgconfig makeWrapper qt4 lndir ]
+    ++  stdenv.lib.optionals stdenv.isDarwin [ ApplicationServices ];
 
   propagatedBuildInputs = [ pythonPackages.sip_4_16 ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8915,7 +8915,9 @@ let
 
   rhpl = callPackage ../development/python-modules/rhpl { };
 
-  pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix { };
+  pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
+    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices;
+  };
 
   pysideApiextractor = callPackage ../development/python-modules/pyside/apiextractor.nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -154,6 +154,7 @@ let
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
     pythonDBus = self.dbus;
     pythonPackages = self;
+    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
   pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix {


### PR DESCRIPTION
Requires qt4 to be fixed for darwin, but @pikajude is working on one.

Could be that needed darwin framework could be propagated from Qt, but that could also be fixed later.

Required new impure host paths was weird, because "/usr/lib/libiconv.2.dylib" was already in impore paths for CoreServices framework (and inherited for required ApplicationServices). Possibly those should be moved there. Not sure.
