### PR TITLE
r-modules: init IRkernel packages

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -33,7 +33,7 @@ let
     meta.broken = broken;
   });
 
-  # Templates for generating Bioconductor and CRAN packages
+  # Templates for generating Bioconductor, CRAN and IRkernel packages
   # from the name, version, sha256, and optional per-package arguments above
   #
   deriveBioc = mkDerive {
@@ -46,6 +46,10 @@ let
       "mirror://cran/src/contrib/${name}_${version}.tar.gz"
       "mirror://cran/src/contrib/00Archive/${name}/${name}_${version}.tar.gz"
     ];
+  };
+  deriveIRkernel = mkDerive {
+    mkHomepage = name: "http://irkernel.github.io/";
+    mkUrls = {name, version}: [ "http://irkernel.github.io/src/contrib/${name}_${version}.tar.gz" ];
   };
 
   # Overrides package definitions with nativeBuildInputs.
@@ -206,7 +210,8 @@ let
   # packages in `_self` may depends on overridden packages.
   self = (defaultOverrides _self self) // overrides;
   _self = import ./bioc-packages.nix { inherit self; derive = deriveBioc; } //
-          import ./cran-packages.nix { inherit self; derive = deriveCran; };
+          import ./cran-packages.nix { inherit self; derive = deriveCran; } //
+          import ./irkernel-packages.nix { inherit self; derive = deriveIRkernel; };
 
   # tweaks for the individual packages and "in self" follow
 

--- a/pkgs/development/r-modules/generate-r-packages.R
+++ b/pkgs/development/r-modules/generate-r-packages.R
@@ -1,17 +1,17 @@
 #!/usr/bin/env Rscript
-
 library(data.table)
 library(parallel)
 cl <- makeCluster(10)
 
 mirrorType <- commandArgs(trailingOnly=TRUE)[1]
-stopifnot(mirrorType %in% c("bioc","cran"))
+stopifnot(mirrorType %in% c("bioc","cran", "irkernel"))
 
 packagesFile <- paste(mirrorType, 'packages.nix', sep='-')
 readFormatted <- as.data.table(read.table(skip=6, sep='"', text=head(readLines(packagesFile), -1)))
 
 mirrorUrls <- list( bioc="http://bioconductor.statistik.tu-dortmund.de/packages/3.2/bioc/src/contrib/"
                   , cran="http://cran.r-project.org/src/contrib/"
+                  , irkernel="http://irkernel.github.io/src/contrib/"
                   )
 mirrorUrl <- mirrorUrls[mirrorType][[1]]
 knownPackages <- lapply(mirrorUrls, function(url) as.data.table(available.packages(url, filters=c("R_version", "OS_type", "duplicates"))))

--- a/pkgs/development/r-modules/irkernel-packages.nix
+++ b/pkgs/development/r-modules/irkernel-packages.nix
@@ -1,0 +1,11 @@
+# This file is generated from generate-r-packages.R. DO NOT EDIT.
+# Execute the following command to update the file.
+#
+# Rscript generate-r-packages.R irkernel >new && mv new irkernel-packages.nix
+
+{ self, derive }: with self; {
+IRdisplay = derive { name="IRdisplay"; version="0.3"; sha256="0aa7v3x6s9jd5kzwfh4659gm3dqkmadbk40a0jdpm856mf9r5w6s"; depends=[base64enc repr]; };
+IRkernel = derive { name="IRkernel"; version="0.5"; sha256="0v9f01j1ysadq2f8d4mpbimrspj7051cncl0rd1n97rb8wlb9rrf"; depends=[digest evaluate IRdisplay jsonlite repr rzmq uuid]; };
+repr = derive { name="repr"; version="0.4"; sha256="1mhvslkxr5nkxiijapzm29jpmjnhhjs1v9s84xvhqpxlcav8dsn6"; depends=[]; };
+rzmq = derive { name="rzmq"; version="0.7.7"; sha256="0cds9wsbfb7lhgfjjfisv1i3905ny7x3i2wbb1rcih03ba4a1ij3"; depends=[]; };
+}


### PR DESCRIPTION
This pull adds IRkernel (jupyter R-kernel) modules next to cran cran and bioc.
