### PR TITLE
darwin: stringi: fix broken configure on darwin

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2159,6 +2159,9 @@ let
 
   otherOverrides = old: new: {
     stringi = old.stringi.overrideDerivation (attrs: {
+      preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+        substituteInPlace configure --replace "CPP_OK=0" "CPP_OK=1"
+      '';
       postInstall = let
         icuName = "icudt52l";
         icuSrc = pkgs.fetchzip {


### PR DESCRIPTION
stringi configure doesn't properly detect clang for some reason (configure tries to use clang instead of clang++ for checking existense of c++ libraries) and I couldn't find any configure options to fix it, other than patching the flag used in configure for darwin
