### PR TITLE
python matplotlib: 1.4.3 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, buildPythonPackage, pycairo
-, which, dateutil, nose, numpy, pyparsing, tornado
+, which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3
 , enableGhostscript ? false, ghostscript ? null, gtk3
 , enableGtk2 ? false, pygtk ? null, gobjectIntrospection
@@ -10,24 +10,33 @@ assert enableGhostscript -> ghostscript != null;
 assert enableGtk2 -> pygtk != null;
 
 buildPythonPackage rec {
-  name = "matplotlib-1.4.3";
+  name = "matplotlib-${version}";
+  version = "1.5.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/matplotlib/${name}.tar.gz";
-    sha256 = "1dn05cvd0g984lzhh72wa0z93psgwshbbg93fkab6slx5m3l95av";
+    url = "https://pypi.python.org/packages/source/m/matplotlib/${name}.tar.gz";
+    sha256 = "67b08b1650a00a6317d94b76a30a47320087e5244920604c5462188cba0c2646";
   };
   
   XDG_RUNTIME_DIR = "/tmp";
 
-  buildInputs = [ python which stdenv ]
+  buildInputs = [ python which sphinx stdenv ]
     ++ stdenv.lib.optional enableGhostscript ghostscript;
 
   propagatedBuildInputs =
-    [ dateutil nose numpy pyparsing tornado freetype 
+    [ cycler dateutil nose numpy pyparsing tornado freetype 
       libpng pkgconfig mock pytz  
     ]
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ];
+
+  patchPhase = ''
+    # Failing test: ERROR: matplotlib.tests.test_style.test_use_url
+    sed -i 's/test_use_url/fails/' lib/matplotlib/tests/test_style.py
+    # Failing test: ERROR: test suite for <class 'matplotlib.sphinxext.tests.test_tinypages.TestTinyPages'>
+    sed -i 's/TestTinyPages/fails/' lib/matplotlib/sphinxext/tests/test_tinypages.py
+  '';
+
 
   meta = with stdenv.lib; {
     description = "python plotting library, making publication quality plots";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1253,6 +1253,25 @@ let
     };
   };
 
+  cycler = buildPythonPackage rec {
+    name = "cycler-${version}";
+    version = "0.9.0";
+    
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/C/Cycler/${name}.tar.gz";
+      sha256 = "96dc4ddf27ef62c09990c6196ac1167685e89168042ec0ae4db586de023355bc";
+    };
+
+    propagatedBuildInputs = with self; [ six ];
+
+    meta = {
+      description = "Composable style cycles";
+      homepage = http://github.com/matplotlib/cycler;
+      license = licenses.bsd3;
+      maintainer = with maintainers; [ fridh ];
+    };
+  };
+
   debian = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "python-debian";


### PR DESCRIPTION
Two failing tests require network.

Built successfully for all Python versions. I didn't check any of the dependents using `nox-review`.

@domenkozar 
