### PR TITLE
python mock: enable for python 3.5

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8897,7 +8897,6 @@ let
 
   mock = buildPythonPackage (rec {
     name = "mock-1.3.0";
-    disabled = isPy35;
 
     src = pkgs.fetchurl {
       url = "http://pypi.python.org/packages/source/m/mock/${name}.tar.gz";


### PR DESCRIPTION
Seems to work, at least, no tests fail.
