### PR TITLE
cliapp: 1.20140719 -> 1.20150305

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18444,12 +18444,13 @@ let
 
   cliapp = buildPythonPackage rec {
     name = "cliapp-${version}";
-    version = "1.20140719";
+    version = "1.20150305";
     disabled = isPy3k;
 
-    src = pkgs.fetchurl rec {
-      url = "http://code.liw.fi/debian/pool/main/p/python-cliapp/python-cliapp_${version}.orig.tar.gz";
-      sha256 = "0kxl2q85n4ggvbw2m8crl11x8n637mx6y3a3b5ydw8nhlsiqijgp";
+    src = pkgs.fetchgit {
+        url = "http://git.liw.fi/cgi-bin/cgit/cgit.cgi/cliapp";
+        rev = "569df8a5959cd8ef46f78c9497461240a5aa1123";
+        sha256 = "882c5daf933e4cf089842995efc721e54361d98f64e0a075e7373b734cd899f3";
     };
 
     buildInputs = with self; [ sphinx ];


### PR DESCRIPTION
This updates cliapp to the latest stable release,
and also switches to fetching the source from git, instead of from a tarball.

This has been tested by running nix-shell on a python derivation
that includes cliapp as a build input, running python within the shell,
importing cliapp and checking that `cliapp.__version__` has the expected value.

It has also been tested by building and running obnam (which runtime depends on cliapp)
with `nix-shell -I "nixpkgs=$HOME/repos/nixpkgs" --pure -p obnam` and then using obnam in the resulting shell to perform a backup.

Hope this helps,
Richard Ipsum
