### PR TITLE
python: nbconvert update and new tabulate package

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9368,12 +9368,12 @@ let
   };
 
   nbconvert = buildPythonPackage rec {
-    version = "4.0.0";
+    version = "4.1.0";
     name = "nbconvert-${version}";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/n/nbconvert/${name}.tar.gz";
-      sha256 = "472ad15d1a71f1ef00c4094c11bb93638858fc89fb2c5838b3aa6b67d981b437";
+      sha256 = "e0296e45293dd127d028f678e3b6aba3f1db3283a134178bdb49eea402d4cf1c";
     };
 
     buildInputs = with self; [nose];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16665,6 +16665,29 @@ let
   #   doCheck = false;
   # };
 
+  tabulate = buildPythonPackage rec {
+    version = "0.7.5";
+    name = "tabulate-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/t/tabulate/${name}.tar.gz";
+      sha256 = "9071aacbd97a9a915096c1aaf0dc684ac2672904cd876db5904085d6dac9810e";
+    };
+
+    buildInputs = with self; [ nose ];
+
+    # Tests: cannot import common (relative import).
+    doCheck = false;
+
+    meta = {
+      description = "Pretty-print tabular data";
+      homepage = https://bitbucket.org/astanin/python-tabulate;
+      license = licenses.mit;
+      maintainer = with maintainers; [ fridh ];
+    };
+
+  };
+
   targetcli_fb = buildPythonPackage rec {
     version = "2.1.fb33";
     name = "targetcli-fb-${version}";


### PR DESCRIPTION
Tabulate tests disabled since test can't import relative module inside tests folder.
Module works fine though
(they should add `import sys; sys.path.append('..')` or something)

@domenkozar 
