### PR TITLE
haskellPackages: skip hsparql checks

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -402,6 +402,7 @@ self: super: {
   hs2048 = dontCheck super.hs2048;
   hsbencher = dontCheck super.hsbencher;
   hsexif = dontCheck super.hsexif;
+  hsparql = dontCheck super.hsparql; # https://github.com/robstewart57/hsparql/issues/15
   hspec-server = dontCheck super.hspec-server;
   HTF = dontCheck super.HTF;
   HTF_0_12_2_3 = dontCheck super.HTF_0_12_2_3;
@@ -442,6 +443,7 @@ self: super: {
   punycode = dontCheck super.punycode;
   pwstore-cli = dontCheck super.pwstore-cli;
   quantities = dontCheck super.quantities;
+  rdf4h = dontCheck super.rdf4h; # https://github.com/robstewart57/rdf4h/issues/32
   redis-io = dontCheck super.redis-io;
   rethinkdb = dontCheck super.rethinkdb;
   Rlang-QQ = dontCheck super.Rlang-QQ;


### PR DESCRIPTION
The tests seem to be broken upstream and need to be skipped until that is fixed.
