### PR TITLE
tilda: 1.2.2 -> 1.2.4

### DIFF
--- a/pkgs/applications/misc/tilda/default.nix
+++ b/pkgs/applications/misc/tilda/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
 
   name = "tilda-${version}";
-  version = "1.2.2";
+  version = "1.2.4";
 
   src = fetchurl {
     url = "https://github.com/lanoxx/tilda/archive/${name}.tar.gz";
-    sha256 = "1mzly0llsrxpc2yd1hml3gmwm023my2j3aszjw383pp34dab2nl5";
+    sha256 = "1f7b52c5d8cfd9038ad2e41fc633fce935f420fa657ed15e3942722c8570751e";
   };
 
   buildInputs = [ pkgconfig autoreconfHook gettext confuse vte gtk makeWrapper ];


### PR DESCRIPTION
Bump to the latest version of Tilda, which includes a fix for the issue with transparency in Gnome Shell.
