### PR TITLE
symbola: update for new distribution format (15.09)

### DIFF
--- a/pkgs/data/fonts/symbola/default.nix
+++ b/pkgs/data/fonts/symbola/default.nix
@@ -5,11 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://users.teilar.gr/~g1951d/Symbola.zip";
-    sha256 = "07bczpl3vqdpg2gakfddhzzgpb6v2wpasv7rwqxkyg9yd9lmbr0s";
-  };
-  docs_pdf = fetchurl {
-    url = "http://users.teilar.gr/~g1951d/Symbola.pdf";
-    sha256 = "1zmq1ijl0k5hrc6vpa2xp9n1x2zrrd7ng3jwc9yf0qsi3pmkpk0p";
+    sha256 = "0d568882ca4f38a8e7d487367c75f4d8d7cb9f902b9675b7f6620c139014dad1";
   };
 
   buildInputs = [ unzip ];
@@ -24,8 +20,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p "$out/doc/${name}"
     cp -v Symbola.docx "$out/doc/${name}/"
-    cp -v Symbola.htm "$out/doc/${name}/"
-    cp -v "$docs_pdf" "$out/doc/${name}/${docs_pdf.name}"
+    cp -v Symbola.pdf "$out/doc/${name}/"
   '';
 
   meta = {


### PR DESCRIPTION
Fixing a build failure (404 trying to fetch the pdf, and wrong sha256 sum of the zip)

Looks like the host of this font has changed some things since the Nix package was last updated:
- The HTML documentation is now gone.
- The PDF documentation has been moved into the zip file.
