### PR TITLE
Fixed wrong documentation for Wake-On-LAN feature

### DIFF
--- a/nixos/modules/services/networking/wakeonlan.nix
+++ b/nixos/modules/services/networking/wakeonlan.nix
@@ -40,7 +40,7 @@ in
       ];
       description = ''
         Interfaces where to enable Wake-On-LAN, and how. Two methods available:
-        "magickey" and "password". The password has the shape of six bytes
+        "magicpacket" and "password". The password has the shape of six bytes
         in hexadecimal separated by a colon each. For more information,
         check the ethtool manual.
       '';


### PR DESCRIPTION
The documentation for the wake-on-lan feature described the method "magickey", whilst the code expected "magicpacket".
This commit aligns the documentation and code.
