### PR TITLE
xfce4-pulseaudio-plugin: init at 0.2.3

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, xfconf
-, libglade, libstartup_notification }:
+, libglade, libstartup_notification
+, withGtk3 ? false, gtk3
+}:
+
+with { inherit (stdenv.lib) optional; };
 
 stdenv.mkDerivation rec {
   p_name  = "libxfce4ui";
@@ -14,15 +18,14 @@ stdenv.mkDerivation rec {
 
   #TODO: gladeui
   # Install into our own prefix instead.
-  preConfigure =
-    ''
-      configureFlags="--with-libglade-module-path=$out/lib/libglade/2.0"
-    '';
+  configureFlags = [
+    "--with-libglade-module-path=$out/lib/libglade/2.0"
+  ] ++ optional withGtk3 "--enable-gtk3";
 
   buildInputs =
     [ pkgconfig intltool gtk libxfce4util xfconf libglade
       libstartup_notification
-    ];
+    ] ++ optional withGtk3 gtk3;
 
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -1,6 +1,10 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
-, libwnck, exo, garcon, xfconf, libstartup_notification
-, makeWrapper, xfce4mixer }:
+, libxfce4ui_gtk3, libwnck, exo, garcon, xfconf, libstartup_notification
+, makeWrapper, xfce4mixer
+, withGtk3 ? false, gtk3
+}:
+
+with { inherit (stdenv.lib) optional; };
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-panel";
@@ -16,11 +20,15 @@ stdenv.mkDerivation rec {
   patches = [ ./xfce4-panel-datadir.patch ];
   patchFlags = "-p1";
 
+  configureFlags = optional withGtk3 "--enable-gtk3";
+
   buildInputs =
     [ pkgconfig intltool gtk libxfce4util exo libwnck
       garcon xfconf libstartup_notification makeWrapper
-    ] ++ xfce4mixer.gst_plugins;
-  propagatedBuildInputs = [ libxfce4ui ];
+    ] ++ xfce4mixer.gst_plugins
+      ++ optional withGtk3 gtk3;
+
+  propagatedBuildInputs = [ (if withGtk3 then libxfce4ui_gtk3 else libxfce4ui) ];
 
   postInstall = ''
     wrapProgram "$out/bin/xfce4-panel" \

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -79,15 +79,13 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4_eyes_plugin        = callPackage ./panel-plugins/xfce4-eyes-plugin.nix        { };
   xfce4_fsguard_plugin     = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix     { };
   xfce4_genmon_plugin      = callPackage ./panel-plugins/xfce4-genmon-plugin.nix      { };
-
   xfce4_netload_plugin     = callPackage ./panel-plugins/xfce4-netload-plugin.nix     { };
   xfce4_notes_plugin       = callPackage ./panel-plugins/xfce4-notes-plugin.nix       { };
   xfce4_systemload_plugin  = callPackage ./panel-plugins/xfce4-systemload-plugin.nix  { };
   xfce4_verve_plugin       = callPackage ./panel-plugins/xfce4-verve-plugin.nix       { };
   xfce4_xkb_plugin         = callPackage ./panel-plugins/xfce4-xkb-plugin.nix         { };
-
   xfce4_whiskermenu_plugin = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix { };
-
+  xfce4_pulseaudio_plugin  = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix  { };
 
 }; # xfce_self
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -22,6 +22,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   garcon          = callPackage ./core/garcon.nix { };
   gtk_xfce_engine = callPackage ./core/gtk-xfce-engine.nix { }; # ToDo: when should be used?
   libxfce4ui      = callPackage ./core/libxfce4ui.nix { };
+  libxfce4ui_gtk3 = libxfce4ui.override { withGtk3 = true; };
   libxfce4util    = callPackage ./core/libxfce4util.nix { };
   libxfcegui4     = callPackage ./core/libxfcegui4.nix { };
   thunar          = callPackage ./core/thunar.nix { };
@@ -32,6 +33,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
                   = callPackage ./thunar-plugins/dropbox { };
   tumbler         = callPackage ./core/tumbler.nix { };
   xfce4panel      = callPackage ./core/xfce4-panel.nix { }; # ToDo: impure plugins from /run/current-system/sw/lib/xfce4
+  xfce4panel_gtk3 = xfce4panel.override { withGtk3 = true; };
   xfce4session    = callPackage ./core/xfce4-session.nix { };
   xfce4settings   = callPackage ./core/xfce4-settings.nix { };
   xfce4_power_manager = callPackage ./core/xfce4-power-manager.nix { };
@@ -66,7 +68,6 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4icontheme  = callPackage ./art/xfce4-icon-theme.nix { };
 
   #### PANEL PLUGINS        from "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.{bz2,gz}"
-
 
   xfce4_battery_plugin     = callPackage ./panel-plugins/xfce4-battery-plugin.nix     { };
   xfce4_clipman_plugin     = callPackage ./panel-plugins/xfce4-clipman-plugin.nix     { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel_gtk3, xfconf
+, gtk3, libpulseaudio
+, withKeybinder ? true, keybinder3
+, withLibnotify ? true, libnotify
+}:
+
+assert withKeybinder -> keybinder3 != null;
+assert withLibnotify -> libnotify != null;
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  p_name  = "xfce4-pulseaudio-plugin";
+  ver_maj = "0.2";
+  ver_min = "3";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "e82836bc8cf7d905b4e60d43dc630ba8e32dea785989700c71d4aeee9f583b33";
+  };
+  name = "${p_name}-${ver_maj}.${ver_min}";
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ libxfce4util xfce4panel_gtk3 xfconf gtk3 libpulseaudio ]
+    ++ optional withKeybinder keybinder3
+    ++ optional withLibnotify libnotify;
+
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+
+  meta = {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    description = "Adjust the audio volume of the PulseAudio sound system";
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Added pulseaudio volume control xfce panel plugin.

A couple notes about this:
1. This plugin requires gtk3 so I added packages `libxfce4ui_gtk3` and `xfce4panel_gtk3` to `pkgs.xfce` and left `libxfce4ui` and `xfce4panel` to use gtk2. I am not sure that was the right move. It's tempting to enable gtk3 in those packages by default but I am not sure and I'd like to hear what others think about this. One of the problems with leaving both gtk2 and gtk3 versions is that most of the users who want to use `xfce4_pulseaudio_plugin` will need to add `xfce.xfce4panel = pkgs.xfce.xfce4panel_gtk3` to their `packageOverrides` because it's what nixos configuration uses when desktopManager is xfce.
2. This plugin has optional dependencies on `libnotify` and `keybinder` to enable volume change notifications and volume control with multimedia buttons on keyboard. When they both enabled plugin essentially replicates behavior of xfce4-volumed which runs on startup by default. Most users will want to disable xfce4-volumed after installing this plugin. A nice thing about pulseaudio-plugin compared to xfce4-volumed is that it respects default output device setting that is set in pavucontrol and controls volume of that device. That's why I enabled these dependencies by default.

Tested locally. Note, that because `xfce4panel` currently looks for plugins only in `/run/current-system/sw/lib/xfce4/panel/plugins/` it's required that this package is installed system-wide (as well as all other xfce4-panel plugins).
