### PR TITLE
darwin: qt4: add required inputs

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -11,6 +11,7 @@
 , docs ? false
 , examples ? false
 , demos ? false
+, AGL, ApplicationServices, Cocoa, libcxx
 }:
 
 with stdenv.lib;
@@ -122,14 +123,19 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ cups # Qt dlopen's libcups instead of linking to it
       mysql.lib postgresql sqlite libjpeg libmng libtiff icu ]
-    ++ optionals gtkStyle [ gtk gdk_pixbuf ];
+    ++ optionals gtkStyle [ gtk gdk_pixbuf ]
+    ++ optionals stdenv.isDarwin [ AGL ApplicationServices Cocoa ];
 
   nativeBuildInputs = [ perl pkgconfig which ];
 
   enableParallelBuilding = false;
 
-  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin
-    "-I${glib}/include/glib-2.0 -I${glib}/lib/glib-2.0/include";
+  NIX_CFLAGS_COMPILE = optionals stdenv.isDarwin [
+    "-mmacosx-version-min=10.7"
+    "-I${glib}/include/glib-2.0"
+    "-I${glib}/lib/glib-2.0/include"
+    "-I${libcxx}/include/c++/v1"
+  ];
 
   NIX_LDFLAGS = optionalString stdenv.isDarwin
     "-lglib-2.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8054,6 +8054,7 @@ let
     # GNOME dependencies are not used unless gtkStyle == true
     mesa = mesa_noglu;
     inherit (pkgs.gnome) libgnomeui GConf gnome_vfs;
+    inherit (darwin.apple_sdk.frameworks) AGL ApplicationServices Cocoa;
     cups = if stdenv.isLinux then cups else null;
   };
 


### PR DESCRIPTION
Somewhat fixes qt4 build on the new darwin stdenv with sandbox. At least it gets built.

There must be something wrong with configure, because I have to add libcxx to make build find all the headers. Also, this don't yet produce working GUI Apps.
