### PR TITLE
openssl: cross build improvement

### DIFF
--- a/pkgs/development/libraries/openssl/1.0.2.x.nix
+++ b/pkgs/development/libraries/openssl/1.0.2.x.nix
@@ -66,11 +66,18 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = {
+    # upstream patch: https://rt.openssl.org/Ticket/Display.html?id=2558
+    postPatch = ''
+       sed -i -e 's/[$][(]CROSS_COMPILE[)]windres/$(WINDRES)/' Makefile.shared
+    '';
     preConfigure=''
       # It's configure does not like --build or --host
       export configureFlags="${concatStringsSep " " (configureFlags ++ [ opensslCrossSystem ])}"
+      # WINDRES and RANLIB need to be prefixed when cross compiling;
+      # the openssl configure script doesn't do that for us
+      export WINDRES=${stdenv.cross.config}-windres
+      export RANLIB=${stdenv.cross.config}-ranlib
     '';
-
     configureScript = "./Configure";
   };
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -69,11 +69,18 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = {
+    # upstream patch: https://rt.openssl.org/Ticket/Display.html?id=2558
+    postPatch = ''
+       sed -i -e 's/[$][(]CROSS_COMPILE[)]windres/$(WINDRES)/' Makefile.shared
+    '';
     preConfigure=''
       # It's configure does not like --build or --host
       export configureFlags="${concatStringsSep " " (configureFlags ++ [ opensslCrossSystem ])}"
+      # WINDRES and RANLIB need to be prefixed when cross compiling;
+      # the openssl configure script doesn't do that for us
+      export WINDRES=${stdenv.cross.config}-windres
+      export RANLIB=${stdenv.cross.config}-ranlib
     '';
-
     configureScript = "./Configure";
   };
 


### PR DESCRIPTION
This fixes the mingw (and possibly also other) cross-builds of openssl. Tested with the nix shell script below. Upstream patch taken from https://rt.openssl.org/Ticket/Display.html?id=2558

Possibly the mingw openssl cross build could be added to the release test matrix?
https://github.com/NixOS/nixpkgs/blob/4232f5d219/pkgs/top-level/release-cross.nix#L142
https://github.com/NixOS/nixpkgs/blob/4232f5d219/pkgs/top-level/release-cross.nix#L163

```
with import <nixpkgs> {
  crossSystem = {
    config = "i686-w64-mingw32";
    arch = "i686";
    libc = "msvcrt";
    platform = { };
    openssl.system = "mingw";
  };
};
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [ openssl.crossDrv ];
  };
}
```
