### PR TITLE
indicator libraries: init at 12.10

### DIFF
--- a/pkgs/development/libraries/indicator-application/gtk2.nix
+++ b/pkgs/development/libraries/indicator-application/gtk2.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, lib, file
+, pkgconfig, autoconf
+, glib, dbus_glib, json_glib
+, gtk2, libindicator-gtk2, libdbusmenu-gtk2, libappindicator-gtk2 }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "indicator-application-gtk2-${version}";
+  version = "12.10.0.1";
+
+  src = fetchurl {
+    url = "${meta.homepage}/indicator-application-gtk2/i-a-${version}/+download/indicator-application-${version}.tar.gz";
+    sha256 = "1xqsb6c1pwawabw854f7aybjrgyhc2r1316i9lyjspci51zk5m7v";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoconf ];
+
+  buildInputs = [
+    glib dbus_glib json_glib
+    gtk2 libindicator-gtk2 libdbusmenu-gtk2 libappindicator-gtk2
+  ];
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace 'DBUSSERVICEDIR=`$PKG_CONFIG --variable=session_bus_services_dir dbus-1`' \
+                "DBUSSERVICEDIR=$out/share/dbus-1/services"
+    autoconf
+    substituteInPlace {configure,ltmain.sh,m4/libtool.m4} \
+      --replace /usr/bin/file ${file}/bin/file
+    substituteInPlace src/Makefile.in \
+      --replace 'applicationlibdir = $(INDICATORDIR)' "applicationlibdir = $out/lib"
+  '';
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ];
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  meta = {
+    description = "Indicator to take menus from applications and place them in the panel (GTK+ 2 library for Xfce/LXDE)";
+    homepage = "https://launchpad.net/indicators-gtk2";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/development/libraries/indicator-application/gtk3.nix
+++ b/pkgs/development/libraries/indicator-application/gtk3.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, lib, file
+, pkgconfig, autoconf
+, glib, dbus_glib, json_glib
+, gtk3, libindicator-gtk3, libdbusmenu-gtk3, libappindicator-gtk3 }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "indicator-application-gtk3-${version}";
+  version = "${versionMajor}.${versionMinor}";
+  versionMajor = "12.10";
+  versionMinor = "0";
+
+  src = fetchurl {
+    url = "${meta.homepage}/${versionMajor}/${version}/+download/indicator-application-${version}.tar.gz";
+    sha256 = "1z8ar0k47l4his7zvffbc2kn658nid51svqnfv0dms601w53gbpr";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoconf ];
+
+  buildInputs = [
+    glib dbus_glib json_glib
+    gtk3 libindicator-gtk3 libdbusmenu-gtk3 libappindicator-gtk3
+  ];
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace 'DBUSSERVICEDIR=`$PKG_CONFIG --variable=session_bus_services_dir dbus-1`' \
+                "DBUSSERVICEDIR=$out/share/dbus-1/services"
+    autoconf
+    substituteInPlace {configure,ltmain.sh,m4/libtool.m4} \
+      --replace /usr/bin/file ${file}/bin/file
+    substituteInPlace src/Makefile.in \
+      --replace 'applicationlibdir = $(INDICATORDIR)' "applicationlibdir = $out/lib"
+  '';
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ];
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  meta = {
+    description = "Indicator to take menus from applications and place them in the panel";
+    homepage = "https://launchpad.net/indicator-application";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/development/libraries/libappindicator/default.nix
+++ b/pkgs/development/libraries/libappindicator/default.nix
@@ -1,0 +1,67 @@
+# TODO: Resolve the issues with the Mono bindings.
+
+{ stdenv, fetchurl, lib, file
+, pkgconfig, autoconf
+, glib, dbus_glib, gtkVersion
+, gtk2 ? null, libindicator-gtk2 ? null, libdbusmenu-gtk2 ? null
+, gtk3 ? null, libindicator-gtk3 ? null, libdbusmenu-gtk3 ? null
+, python, pygobject, pygtk, gobjectIntrospection, vala
+, monoSupport ? false, mono ? null, gtk-sharp ? null
+ }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = let postfix = if gtkVersion == "2" && monoSupport then "sharp" else "gtk${gtkVersion}";
+          in "libappindicator-${postfix}-${version}";
+  version = "${versionMajor}.${versionMinor}";
+  versionMajor = "12.10";
+  versionMinor = "0";
+
+  src = fetchurl {
+    url = "${meta.homepage}/${versionMajor}/${version}/+download/libappindicator-${version}.tar.gz";
+    sha256 = "17xlqd60v0zllrxp8bgq3k5a1jkj0svkqn8rzllcyjh8k0gpr46m";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoconf ];
+
+  buildInputs = [
+    glib dbus_glib
+    python pygobject pygtk gobjectIntrospection vala
+  ] ++ (if gtkVersion == "2"
+    then [ gtk2 libindicator-gtk2 libdbusmenu-gtk2 ] ++ optionals monoSupport [ mono gtk-sharp ]
+    else [ gtk3 libindicator-gtk3 libdbusmenu-gtk3 ]);
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0'
+    autoconf
+    substituteInPlace {configure,ltmain.sh,m4/libtool.m4} \
+      --replace /usr/bin/file ${file}/bin/file
+  '';
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-gtk=${gtkVersion}"
+  ];
+
+  postConfigure = ''
+    substituteInPlace configure \
+      --replace /usr/bin/file ${file}/bin/file
+  '';
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  meta = {
+    description = "A library to allow applications to export a menu into the Unity Menu bar";
+    homepage = "https://launchpad.net/libappindicator";
+    license = with licenses; [ lgpl21 lgpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/development/libraries/libdbusmenu/default.nix
+++ b/pkgs/development/libraries/libdbusmenu/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchurl, lib, file
+, pkgconfig, intltool
+, glib, dbus_glib, json_glib
+, gobjectIntrospection, vala, gnome_doc_utils
+, gtkVersion ? null, gtk2 ? null, gtk3 ? null }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = let postfix = if gtkVersion == null then "glib" else "gtk${gtkVersion}";
+          in "libdbusmenu-${postfix}-${version}";
+  version = "${versionMajor}.${versionMinor}";
+  versionMajor = "12.10";
+  versionMinor = "2";
+
+  src = fetchurl {
+    url = "${meta.homepage}/${versionMajor}/${version}/+download/libdbusmenu-${version}.tar.gz";
+    sha256 = "9d6ad4a0b918b342ad2ee9230cce8a095eb601cb0cee6ddc1122d0481f9d04c9";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [
+    glib dbus_glib json_glib
+    gobjectIntrospection vala gnome_doc_utils
+  ] ++ optional (gtkVersion != null) (if gtkVersion == "2" then gtk2 else gtk3);
+
+  postPatch = ''
+    substituteInPlace {configure,ltmain.sh,m4/libtool.m4} \
+      --replace /usr/bin/file ${file}/bin/file
+  '';
+
+  # https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/libdbusmenu
+  preConfigure = ''
+    export HAVE_VALGRIND_TRUE="#"
+    export HAVE_VALGRIND_FALSE=""
+  '';
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    (if gtkVersion == null then "--disable-gtk" else "--with-gtk=${gtkVersion}")
+    "--disable-scrollkeeper"
+  ] ++ optional (gtkVersion != "2") "--disable-dumper";
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  meta = {
+    description = "A library for passing menu structures across DBus";
+    homepage = "https://launchpad.net/dbusmenu";
+    license = with licenses; [ gpl3 lgpl21 lgpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/development/libraries/libindicate/default.nix
+++ b/pkgs/development/libraries/libindicate/default.nix
@@ -1,0 +1,62 @@
+# TODO: Resolve the issues with the Mono bindings.
+
+{ stdenv, fetchurl, lib, file
+, pkgconfig, autoconf
+, glib, dbus_glib, libdbusmenu-glib
+, gtkVersion, gtk2 ? null, gtk3 ? null
+, python, pygobject, pygtk, gobjectIntrospection, vala, gnome_doc_utils
+, monoSupport ? false, mono ? null, gtk-sharp ? null
+ }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = let postfix = if gtkVersion == "2" && monoSupport then "sharp" else "gtk${gtkVersion}";
+          in "libindicate-${postfix}-${version}";
+  version = "${versionMajor}.${versionMinor}";
+  versionMajor = "12.10";
+  versionMinor = "1";
+
+  src = fetchurl {
+    url = "${meta.homepage}/${versionMajor}/${version}/+download/libindicate-${version}.tar.gz";
+    sha256 = "10am0ymajx633b33anf6b79j37k61z30v9vaf5f9fwk1x5cw1q21";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoconf ];
+
+  buildInputs = [
+    glib dbus_glib libdbusmenu-glib
+    python pygobject pygtk gobjectIntrospection vala gnome_doc_utils
+  ] ++ (if gtkVersion == "2"
+    then [ gtk2 ] ++ optionals monoSupport [ mono gtk-sharp ]
+    else [ gtk3 ]);
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0' \
+      --replace 'pyglib-2.0-python$PYTHON_VERSION' 'pyglib-2.0-python'
+    autoconf
+    substituteInPlace {configure,ltmain.sh,m4/libtool.m4} \
+      --replace /usr/bin/file ${file}/bin/file
+  '';
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-gtk=${gtkVersion}"
+  ];
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  meta = {
+    description = "Library for raising indicators via DBus";
+    homepage = "https://launchpad.net/libindicate";
+    license = with licenses; [ lgpl21 lgpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/development/libraries/libindicator/default.nix
+++ b/pkgs/development/libraries/libindicator/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, lib, file
+, pkgconfig
+, gtkVersion, gtk2 ? null, gtk3 ? null }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "libindicator-gtk${gtkVersion}-${version}";
+  version = "${versionMajor}.${versionMinor}";
+  versionMajor = "12.10";
+  versionMinor = "1";
+
+  src = fetchurl {
+    url = "${meta.homepage}/${versionMajor}/${version}/+download/libindicator-${version}.tar.gz";
+    sha256 = "b2d2e44c10313d5c9cd60db455d520f80b36dc39562df079a3f29495e8f9447f";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ (if gtkVersion == "2" then gtk2 else gtk3) ];
+
+  postPatch = ''
+    substituteInPlace configure \
+      --replace 'LIBINDICATOR_LIBS+="$LIBM"' 'LIBINDICATOR_LIBS+=" $LIBM"'
+    substituteInPlace {build-aux/ltmain.sh,configure,m4/libtool.m4} \
+      --replace /usr/bin/file ${file}/bin/file
+  '';
+
+  configureFlags = [
+    "CFLAGS=-Wno-error"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-gtk=${gtkVersion}"
+  ];
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  meta = {
+    description = "A set of symbols and convenience functions for Ayatana indicators";
+    homepage = "https://launchpad.net/libindicator";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6623,6 +6623,9 @@ let
 
   incrtcl = callPackage ../development/libraries/incrtcl { };
 
+  indicator-application-gtk2 = callPackage ../development/libraries/indicator-application/gtk2.nix { };
+  indicator-application-gtk3 = callPackage ../development/libraries/indicator-application/gtk3.nix { };
+
   indilib = callPackage ../development/libraries/indilib { };
 
   iniparser = callPackage ../development/libraries/iniparser { };
@@ -6774,6 +6777,9 @@ let
 
   libantlr3c = callPackage ../development/libraries/libantlr3c {};
 
+  libappindicator-gtk2 = callPackage ../development/libraries/libappindicator { gtkVersion = "2"; };
+  libappindicator-gtk3 = callPackage ../development/libraries/libappindicator { gtkVersion = "3"; };
+
   libarchive = callPackage ../development/libraries/libarchive { };
 
   libasr = callPackage ../development/libraries/libasr { };
@@ -6876,6 +6882,10 @@ let
   libdbiDrivers = libdbiDriversBase.override {
     inherit sqlite libmysql;
   };
+
+  libdbusmenu-glib = callPackage ../development/libraries/libdbusmenu { };
+  libdbusmenu-gtk2 = callPackage ../development/libraries/libdbusmenu { gtkVersion = "2"; };
+  libdbusmenu-gtk3 = callPackage ../development/libraries/libdbusmenu { gtkVersion = "3"; };
 
   libdbusmenu_qt = callPackage ../development/libraries/libdbusmenu-qt { };
 
@@ -7057,6 +7067,12 @@ let
   libicns = callPackage ../development/libraries/libicns { };
 
   libimobiledevice = callPackage ../development/libraries/libimobiledevice { };
+
+  libindicate-gtk2 = callPackage ../development/libraries/libindicate { gtkVersion = "2"; };
+  libindicate-gtk3 = callPackage ../development/libraries/libindicate { gtkVersion = "3"; };
+
+  libindicator-gtk2 = callPackage ../development/libraries/libindicator { gtkVersion = "2"; };
+  libindicator-gtk3 = callPackage ../development/libraries/libindicator { gtkVersion = "3"; };
 
   libiodbc = callPackage ../development/libraries/libiodbc {
     useGTK = config.libiodbc.gtk or false;


### PR DESCRIPTION
The indicator libraries for GTK2 and GTK3.

The bindings for Mono do not work yet because of some issues with Perl in
gtk-sharp-2 and an Unhandled Exception caused by building with multiple cores:
https://aur.archlinux.org/packages/libindicate-sharp/#comment-290385

Some packages have TODOs for the indicator libraries,
since it is an optional dependency for most packages.
These packages have not been updated by this commit.
