### PR TITLE
gnome-encfs-manager: init at 1.8.15

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/core/libgee/libgee-1.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/libgee/libgee-1.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, autoconf, vala, pkgconfig, glib, gobjectIntrospection, gnome3 }:
+let
+  ver_maj = "0.6";
+  ver_min = "8";
+in
+stdenv.mkDerivation rec {
+  name = "libgee-${ver_maj}.${ver_min}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/libgee/${ver_maj}/${name}.tar.xz";
+    sha256 = "1lzmxgz1bcs14ghfp8qqzarhn7s64ayx8c508ihizm3kc5wqs7x6";
+  };
+
+  doCheck = true;
+
+  patches = [ ./fix_introspection_paths.patch ];
+
+  buildInputs = [ autoconf vala pkgconfig glib gobjectIntrospection ];
+
+  meta = with stdenv.lib; {
+    description = "Utility library providing GObject-based interfaces and classes for commonly used data structures";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.spacefrogg ] ++ gnome3.maintainers;
+  };
+}

--- a/pkgs/desktops/gnome-3/3.16/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/default.nix
@@ -176,6 +176,7 @@ let
   libcroco = callPackage ./core/libcroco {};
 
   libgee = callPackage ./core/libgee { };
+  libgee_1 = callPackage ./core/libgee/libgee-1.nix { };
 
   libgdata = callPackage ./core/libgdata { };
 

--- a/pkgs/tools/security/gencfsm/default.nix
+++ b/pkgs/tools/security/gencfsm/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, autoconf, automake, intltool, libtool, pkgconfig, encfs
+, glib , gnome3, gtk3, libgnome_keyring, vala, wrapGAppsHook, xorg }:
+
+stdenv.mkDerivation rec {
+  version = "1.8.15";
+  name = "gnome-encfs-manager-${version}";
+
+  src = fetchurl {
+    url = "https://launchpad.net/gencfsm/trunk/1.8/+download/gnome-encfs-manager_${version}.tar.gz";
+    sha256 = "1iryli6fgw6a45abkrjacfac7dwjhbrhw652rqf0s183373db0mx";
+  };
+
+  buildInputs = [ autoconf automake intltool libtool pkgconfig vala glib encfs
+    gtk3 libgnome_keyring gnome3.libgee_1 xorg.libSM xorg.libICE
+    wrapGAppsHook ];
+
+  patches = [ ./makefile-mkdir.patch ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [ "--disable-appindicator" ];
+
+  preFixup = ''gappsWrapperArgs+=(--prefix PATH : ${encfs}/bin)'';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.libertyzero.com/GEncfsM/;
+    description = "EncFS manager and mounter with GNOME3 integration";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.spacefrogg ];
+  };
+}

--- a/pkgs/tools/security/gencfsm/makefile-mkdir.patch
+++ b/pkgs/tools/security/gencfsm/makefile-mkdir.patch
@@ -1,0 +1,14 @@
+--- a/dist/Makefile.am
++++ b/dist/Makefile.am
+@@ -10,9 +10,9 @@ install-data-hook:
+ 	chmod 0755 $(shell find $(dist) -type d)
+ 	chmod 0644 $(shell find $(dist) -type f)
+ 	chmod 0755 $(shell find "scripts" -type f)
+-	test -z "$(DESTDIR)$(datadir)/dbus-1/services/" || /bin/mkdir -p "$(DESTDIR)$(datadir)/dbus-1/services/"
++	test -z "$(DESTDIR)$(datadir)/dbus-1/services/" || $(MKDIR_P) "$(DESTDIR)$(datadir)/dbus-1/services/"
+ 	cp "extra/com.libertyzero.gnome-encfs-manager.service" "$(DESTDIR)$(datadir)/dbus-1/services/"
+-	test -z "$(gencfsmdir)" || /bin/mkdir -p "$(gencfsmdir)"
++	test -z "$(gencfsmdir)" || $(MKDIR_P) "$(gencfsmdir)"
+ 	cp --parent -rf $(dist) "$(gencfsmdir)"
+ 	cp --parent -rf $(icons) $(DESTDIR)$(datadir)
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -843,6 +843,8 @@ let
 
   fzf = goPackages.fzf.bin // { outputs = [ "bin" ]; };
 
+  gencfsm = callPackage ../tools/security/gencfsm { };
+
   gist = callPackage ../tools/text/gist { };
 
   gmic = callPackage ../tools/graphics/gmic { };


### PR DESCRIPTION
A Gnome EncFS GUI. It uses a deprecated version of libgee which made addition of a libgee-1 library alternative necessary. Fixed calls to gappsWrapHook and integrated libgee-1 into core/libgee/.
