### PR TITLE
hyperdex: blindly fix hashes of local dependencies

### DIFF
--- a/pkgs/servers/nosql/hyperdex/busybee.nix
+++ b/pkgs/servers/nosql/hyperdex/busybee.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/rescrv/busybee/archive/releases/${version}.zip";
-    sha256 = "0gr5h2j9rzwarblgcgddnxj39i282rvgn9vqlrcd60dx8c4dkm29";
+    sha256 = "0b51h1kmkf0s3d9y7wjqgp1pk1rk9i7n8bcgyj01kflzdgafbl0b";
   };
   buildInputs = [
     autoconf

--- a/pkgs/servers/nosql/hyperdex/default.nix
+++ b/pkgs/servers/nosql/hyperdex/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/rescrv/HyperDex/archive/releases/${version}.zip";
-    sha256 = "0s1capy2hj45f5rmdb4fk0wxy7vz69krplhba57f6wrkpcz1zb57";
+    sha256 = "0l7w3x6c4nslz5ijmj8xys0k1slwi3s4crxmi16ml1x32bqgzhj7";
   };
 
   buildInputs = [

--- a/pkgs/servers/nosql/hyperdex/hyperleveldb.nix
+++ b/pkgs/servers/nosql/hyperdex/hyperleveldb.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/rescrv/HyperLevelDB/archive/releases/${version}.zip";
-    sha256 = "0xrzhwkrm7f2wz3jn4iqn1dim2pmgjhmpb1fy23fwa06v0q18hw8";
+    sha256 = "0m5fwl9sc7c6m2zm3zjlxxg7f602gnaryikxgflahhdccdvvr56y";
   };
   buildInputs = [ unzip autoconf automake libtool ];
   preConfigure = "autoreconf -i";

--- a/pkgs/servers/nosql/hyperdex/libe.nix
+++ b/pkgs/servers/nosql/hyperdex/libe.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation rec {
   version = "0.8.1";
 
   src = fetchurl {
-    url = "https://github.com/rescrv/e/archive/releases/0.8.1.zip";
-    sha256 = "1l13axsi52j2qaxbdnszdvfxksi7rwm2j1rrf0nlh990m6a3yg3s";
+    url = "https://github.com/rescrv/e/archive/releases/${version}.zip";
+    sha256 = "18xm0hcnqdf0ipfn19jrgzqsxij5xjbbnihhzc57n4v7yfdca1w3";
   };
   buildInputs = [ unzip autoconf automake libtool libpo6 pkgconfig ];
   preConfigure = "autoreconf -i";

--- a/pkgs/servers/nosql/hyperdex/libmacaroons.nix
+++ b/pkgs/servers/nosql/hyperdex/libmacaroons.nix
@@ -2,11 +2,11 @@
   pkgconfig, libsodium, python }:
 stdenv.mkDerivation rec {
   name = "libmacaroons-${version}";
-  version = "HEAD";
+  version = "0.3.0";
 
   src = fetchurl {
-    url = "https://github.com/rescrv/libmacaroons/archive/6febf3ce6c4c77a46d24b40ed29b03ffbfb175a7.zip";
-    sha256 = "0b4qgim87398chvc3qhxfqv2l1cyl65rhyknln8lk0gq9y00p1ik";
+    url = "https://github.com/rescrv/libmacaroons/archive/releases/${version}.zip";
+    sha256 = "18c44424jri0p5la6jgrnlz5p937hk7ws2mldhzjwisqyf5qld43";
   };
   buildInputs = [ unzip autoconf automake libtool python libsodium pkgconfig ];
   preConfigure = "autoreconf -i";

--- a/pkgs/servers/nosql/hyperdex/libpo6.nix
+++ b/pkgs/servers/nosql/hyperdex/libpo6.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/rescrv/po6/archive/releases/${version}.zip";
-    sha256 = "14g3ichshnc4wd0iq3q3ymgaq84gjsbqcyn6lri7c7djgkhqijjx";
+    sha256 = "17grzkh6aw1f68qvkhivbb6vwbm6jd41ysbfn88pypf5lczxrxly";
   };
   buildInputs = [ unzip autoconf automake libtool ];
   preConfigure = "autoreconf -i";

--- a/pkgs/servers/nosql/hyperdex/replicant.nix
+++ b/pkgs/servers/nosql/hyperdex/replicant.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "replicant-${version}";
-  version = "0.5.2";
+  version = "0.6.3";
 
   src = fetchurl {
-    url = "https://github.com/rescrv/Replicant/archive/releases/0.6.3.zip";
-    sha256 = "1fbagz0nbvinkqr5iw5y187dm4klkswrxnl5ysq8waglg2nj8zzi";
+    url = "https://github.com/rescrv/Replicant/archive/releases/${version}.zip";
+    sha256 = "1q3pdq2ndpj70yd1578bn4grlrp77gl8hv2fz34jpx34qmlalda4";
   };
   buildInputs = [
     autoconf


### PR DESCRIPTION
This patch blindly fixes the source archive checksums for the local dependencies of hyperdex. I have not looked into why those hashes changed, but I have verified that the hyperdex package now builds successfully.

@teh added these packages and so might care to look into this in more detail
