### PR TITLE
gnuradio-nacl: new package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -192,6 +192,7 @@
   mirdhyn = "Merlin Gaillard <mirdhyn@gmail.com>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";
   modulistic = "Pablo Costa <modulistic@gmail.com>";
+  mog = "Matthew O'Gorman <mog-lists@rldn.net>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";

--- a/pkgs/applications/misc/gnuradio-nacl/default.nix
+++ b/pkgs/applications/misc/gnuradio-nacl/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio, uhd
+, makeWrapper, libsodium, cppunit
+, pythonSupport ? true, python, swig
+}:
+
+assert pythonSupport -> python != null && swig != null;
+
+stdenv.mkDerivation rec {
+  name = "gnuradio-nacl-${version}";
+  version = "2015-11-05";
+
+  src = fetchFromGitHub {
+    owner = "stwunsch";
+    repo = "gr-nacl";
+    rev = "d6dd3c02dcda3f601979908b61b1595476f6bf95";
+    sha256 = "0q28lgkndcw9921hm6cw5ilxd83n65hjajwl78j50mh6yc3bim35";
+  };
+
+  buildInputs = [
+    cmake pkgconfig boost gnuradio uhd makeWrapper libsodium cppunit
+  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+
+  postInstall = ''
+    for prog in "$out"/bin/*; do
+        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:$(toPythonPath "$out")
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnuradio block for encryption";
+    homepage = https://github.com/stwunsch/gr-nacl;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers;  [ mog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11503,8 +11503,10 @@ let
   };
 
   gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {
-    extraPackages = [ gnuradio-osmosdr ];
+    extraPackages = [ gnuradio-nacl gnuradio-osmosdr ];
   };
+
+  gnuradio-nacl = callPackage ../applications/misc/gnuradio-nacl { };
 
   gnuradio-osmosdr = callPackage ../applications/misc/gnuradio-osmosdr { };
 


### PR DESCRIPTION
Hi This is my first nix package, so feel free to tell me things to change to bring it into spec.   This adds encryption blocks to gnuradio companion.  It is only useful to install as part of gnuradio-with-plugins.  I didn't know how to make it work if you install it by itself.
