### PR TITLE
 audiofile: fix CVE-2015-7747

### DIFF
--- a/pkgs/development/libraries/audiofile/CVE-2015-7747.patch
+++ b/pkgs/development/libraries/audiofile/CVE-2015-7747.patch
@@ -1,0 +1,161 @@
+Description: fix buffer overflow when changing both sample format and
+ number of channels
+Origin: backport, https://github.com/mpruett/audiofile/pull/25
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/audiofile/+bug/1502721
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801102
+
+Index: audiofile-0.3.6/libaudiofile/modules/ModuleState.cpp
+===================================================================
+--- audiofile-0.3.6.orig/libaudiofile/modules/ModuleState.cpp	2015-10-20 08:00:58.036128202 -0400
++++ audiofile-0.3.6/libaudiofile/modules/ModuleState.cpp	2015-10-20 08:00:58.036128202 -0400
+@@ -402,7 +402,7 @@
+		addModule(new Transform(outfc, in.pcm, out.pcm));
+
+	if (in.channelCount != out.channelCount)
+-		addModule(new ApplyChannelMatrix(infc, isReading,
++		addModule(new ApplyChannelMatrix(outfc, isReading,
+			in.channelCount, out.channelCount,
+			in.pcm.minClip, in.pcm.maxClip,
+			track->channelMatrix));
+Index: audiofile-0.3.6/test/Makefile.am
+===================================================================
+--- audiofile-0.3.6.orig/test/Makefile.am	2015-10-20 08:00:58.036128202 -0400
++++ audiofile-0.3.6/test/Makefile.am	2015-10-20 08:00:58.036128202 -0400
+@@ -26,6 +26,7 @@
+	VirtualFile \
+	floatto24 \
+	query2 \
++	sixteen-stereo-to-eight-mono \
+	sixteen-to-eight \
+	testchannelmatrix \
+	testdouble \
+@@ -139,6 +140,7 @@
+ printmarkers_LDADD = $(LIBAUDIOFILE) -lm
+
+ sixteen_to_eight_SOURCES = sixteen-to-eight.c TestUtilities.cpp TestUtilities.h
++sixteen_stereo_to_eight_mono_SOURCES = sixteen-stereo-to-eight-mono.c TestUtilities.cpp TestUtilities.h
+
+ testchannelmatrix_SOURCES = testchannelmatrix.c TestUtilities.cpp TestUtilities.h
+
+Index: audiofile-0.3.6/test/sixteen-stereo-to-eight-mono.c
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ audiofile-0.3.6/test/sixteen-stereo-to-eight-mono.c	2015-10-20 08:33:57.512286416 -0400
+@@ -0,0 +1,117 @@
++/*
++	Audio File Library
++
++	Copyright 2000, Silicon Graphics, Inc.
++
++	This program is free software; you can redistribute it and/or modify
++	it under the terms of the GNU General Public License as published by
++	the Free Software Foundation; either version 2 of the License, or
++	(at your option) any later version.
++
++	This program is distributed in the hope that it will be useful,
++	but WITHOUT ANY WARRANTY; without even the implied warranty of
++	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++	GNU General Public License for more details.
++
++	You should have received a copy of the GNU General Public License along
++	with this program; if not, write to the Free Software Foundation, Inc.,
++	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++*/
++
++/*
++	sixteen-stereo-to-eight-mono.c
++
++	This program tests the conversion from 2-channel 16-bit integers to
++	1-channel 8-bit	integers.
++*/
++
++#ifdef HAVE_CONFIG_H
++#include <config.h>
++#endif
++
++#include <stdint.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <limits.h>
++
++#include <audiofile.h>
++
++#include "TestUtilities.h"
++
++int main (int argc, char **argv)
++{
++	AFfilehandle file;
++	AFfilesetup setup;
++	int16_t frames16[] = {14298, 392, 3923, -683, 958, -1921};
++	int8_t frames8[] = {28, 6, -2};
++	int i, frameCount = 3;
++	int8_t byte;
++	AFframecount result;
++
++	setup = afNewFileSetup();
++
++	afInitFileFormat(setup, AF_FILE_WAVE);
++
++	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 16);
++	afInitChannels(setup, AF_DEFAULT_TRACK, 2);
++
++	char testFileName[PATH_MAX];
++	if (!createTemporaryFile("sixteen-to-eight", testFileName))
++	{
++		fprintf(stderr, "Could not create temporary file.\n");
++		exit(EXIT_FAILURE);
++	}
++
++	file = afOpenFile(testFileName, "w", setup);
++	if (file == AF_NULL_FILEHANDLE)
++	{
++		fprintf(stderr, "could not open file for writing\n");
++		exit(EXIT_FAILURE);
++	}
++
++	afFreeFileSetup(setup);
++
++	afWriteFrames(file, AF_DEFAULT_TRACK, frames16, frameCount);
++
++	afCloseFile(file);
++
++	file = afOpenFile(testFileName, "r", AF_NULL_FILESETUP);
++	if (file == AF_NULL_FILEHANDLE)
++	{
++		fprintf(stderr, "could not open file for reading\n");
++		exit(EXIT_FAILURE);
++	}
++
++	afSetVirtualSampleFormat(file, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 8);
++	afSetVirtualChannels(file, AF_DEFAULT_TRACK, 1);
++
++	for (i=0; i<frameCount; i++)
++	{
++		/* Read one frame. */
++		result = afReadFrames(file, AF_DEFAULT_TRACK, &byte, 1);
++
++		if (result != 1)
++			break;
++
++		/* Compare the byte read with its precalculated value. */
++		if (memcmp(&byte, &frames8[i], 1) != 0)
++		{
++			printf("error\n");
++			printf("expected %d, got %d\n", frames8[i], byte);
++			exit(EXIT_FAILURE);
++		}
++		else
++		{
++#ifdef DEBUG
++			printf("got what was expected: %d\n", byte);
++#endif
++		}
++	}
++
++	afCloseFile(file);
++	unlink(testFileName);
++
++	exit(EXIT_SUCCESS);
++}

--- a/pkgs/development/libraries/audiofile/default.nix
+++ b/pkgs/development/libraries/audiofile/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0rb927zknk9kmhprd8rdr4azql4gn2dp75a36iazx2xhkbqhvind";
   };
 
+  patches = [ ./CVE-2015-7747.patch ];
+
   meta = with stdenv.lib; {
     description = "Library for reading and writing audio files in various formats";
     homepage    = http://www.68k.org/~michael/audiofile/; 


### PR DESCRIPTION
closes #10678 

This triggers a rebuild of

```
gnuradio-osmosdr performous linuxstopmotion kde5.kde-l10n-ro mediatomb eduke32
acoustidFingerprinter zandronum guvcview extremetuxracer kde5.kwalletmanager blackshades love 
3dfsb mjpegtools kde5.kde-l10n-da kde5.sweeper directfb kde5.ktp-contact-runner gltron xpra 
pypyPackages.youtube-dl prboom rili kde5.kalzium eaglemode darktable blink simplescreenrecorder 
openspades clementine kde4.kopete dfhack xineLib wesnoth kde5.cervisia kino SDL_ttf 
linuxPackages.virtualbox python34Packages.youtube-dl kde5.konquest kde5.ktp-approver esdl grafx2 
kde4.baloo_widgets linuxPackages_4_3.virtualboxHardened e19.enlightenment scummvm kodi pingus 
gl117 kde5.kmag python35Packages.pyacoustid kde5.kspaceduel xen_xenServer 
kde5.mplayerthumbs kde5.kde-l10n-nb vice ffms telepathy_qt5 kde4.telepathy.common_internals 
python27Packages.sipsimple SDL2_image ekiga globulation2 goldendict kde4.eventlist wxcam 
kde4.telepathy.send_file kde4.rsibreak plasma54.plasma-desktop linuxPackages_3_12.virtualbox 
kde5.libksane linuxPackages_3_18.virtualboxHardened gource python35Packages.mps-youtube 
castle_combat python34Packages.infoqscraper warmux dhewm3 keyfinder-cli libretro.nestopia 
jack_oscrolloscope kde5.kfilemetadata kde5.kgoldrunner winswitch cfdg smpeg gsb wxmupen64plus 
mediastreamer-openh264 midoriWrapper kde5.gwenview python34Packages.pythonefl_1_15 remmina 
opal kde5.ktp-common-internals linuxPackages_3_14.virtualboxHardened kde4.kget 
kde4.dolphin_plugins kde5.kde-l10n-ug kde5.kcachegrind quirc beret worldofgoo sound-juicer 
kde4.okular libretro.vba-m kde4.telepathy.kded_integration_module gnunet superTux logstalgia 
kde4.kdetoys kde4.kdepimlibs hatari xfce.parole libretro.vba-next cantata spandsp frescobaldi spek 
kde5.powerdevil kde4.basket gemrb openttd kodiPlain kde4.telepathy.contact_runner renpy kde5.kde-
l10n-lv kde4.print_manager kde5.kde-baseapps kde5.kde-l10n-fi mediastreamer 
linuxPackages_testing.virtualboxHardened kde4.kuser kde5.audiocd-kio minidlna tiny8086 
kde4.kdemultimedia kde5.kde-l10n-uk devede mednafen kde5.kdesdk-strigi-analyzers zeroad 
mhwaveedit kde5.plasma-workspace kdeApps_15_08.dolphin-plugins vbam ocamlPackages.ocamlsdl 
kde5.kde-l10n-fa kde5.libkgeomap plasma54.plasma-mediacenter xpilot-ng kde4.kde_baseapps 
vimprobable2Wrapper bzflag python27Packages.youtube-dl gzdoom farstream kde4.kscreensaver 
chocolateDoom telepathy_qt kde5.kdepimlibs kde4.zanshin kde5.kde-l10n-mr sdlmame 
kde4.kdepim_runtime kde4.nepomuk_core chromaprint openarena kde5.kdenetwork-filesharing 
megaglest jamp ultrastardx kde5.kde-l10n-cs python35Packages.youtube-dl libretro.fba 
kde4.telepathy.text_ui gst_all_1.gst-libav residualvm coriander kde5.palapeli mlt-qt5 
pypyPackages.infoqscraper plasma54.khotkeys kde5.kaccessible kde5.kmahjongg retroarch kde5.ktp-
contact-list pypyPackages.pafy SDL_net kde5.kde-l10n-zh_CN meterbridge cinelerra e19.elementary 
kdeApps_15_08.ffmpegthumbs kde5.kdesdk-kioslaves lincity_ng kde5.kde-l10n-it kde4.kwooty 
kde4.gwenview higan libretro.gambatte kde4.kdeutils atari800 quantumminigolf kde5.plasma-desktop 
airstrike sdl-jstest warsow milkytracker kde5.svgpart navit gmu libretro.snes9x libretro.fceumm 
kde5.juk mgba phonon_backend_vlc kde4.telepathy.call_ui libextractor kde4.kdegraphics_mobipocket 
kde5.kde-l10n-wa exult tpm agg kdeApps_15_08.kgpg schismtracker kde5.ksystemlog kde4.kdevelop 
libav xineUI kde5.kde-l10n-sl openlierox kde5.kde-l10n-es aegisub kde5.kremotecontrol moc 
kde5.kgamma openscenegraph python27Packages.pythonefl_1_15 bomi emulationstation 
kde5.ffmpegthumbs kdeApps_15_08.gwenview empathy kde5.ksaneplugin kde5.ksudoku zandronum-
server sage kde5.kdegraphics-strigi-analyzer kde5.kde-base-artwork kde5.kde-l10n-pt kde4.qtcurve 
kde4.ark love_0_9 sauerbraten kde4.kajongg kde5.knavalbattle uqm kde4.kde_workspace 
speed_dreams SDL2_mixer trigger kde5.kdenlive python34Packages.pafy ataripp ffmpeg_0 
linuxPackages_4_3.virtualbox libretro.mupen64plus kde5.libkexiv2 rekonqWrapper 
linuxPackages_3_10.virtualbox miro kde4.konversation oraclejdk8 qtox urbanterror makemkv 
kde5.ktux kde5.kdesdk-thumbnailers vessel kde5.kde-l10n-bs libretro.genesis-plus-gx freerdpUnstable 
scorched3d libretro.snes9x-next kde5.khotkeys kde5.kde-l10n-sk freerdp zandronum-bin libgroove 
plasma54.plasma-workspace xen bochs kde5.kde-l10n-ja kde5.libkipi hawkthorne quake3game 
libretro.mednafen-pce-fast kde4.choqok kde5.ksirk kde5.kfloppy firefox-esr-wrapper kde5.kde-l10n-hr 
kde5.kdeartwork gnunet_svn flightgear gnuradio kde5.pairs gqrx SDL2_net kde5.krdc kde5.kde-l10n-gl 
libav_0_8 kde5.kdegraphics-thumbnailers kde4.krfb kde5.kscd kde5.libkcompactdisc xen_4_5_0 
kde5.kde-l10n-de uae kde4.ktux d1x_rebirth kde5.kgpg desmume picard kde5.ktp-kded-module 
kde4.kwin_styles asc kde5.kde-l10n-bg kde5.kde-l10n-hu kde5.kde-l10n-el libretro.quicknes 
kde5.kcolorchooser pommed vectoroids vdrift gjay libretro._4do spaceFM pygame zsnes 
ballAndPaddle kde4.baloo spring cataclysm-dda freewheeling kde5.kolourpaint kde4.krusader mpd 
kde5.dragon ffmpeg_2_6 kde5.kget doodle kde4.kdegames simutrans_binaries egoboo kde5.baloo 
bloodspilot-client kde4.pykde4 kdeApps_15_08.baloo-widgets oraclejre7psu kde4.kdenetwork 
synfigstudio gravit crrcsim nexuiz keyfinder gav kde5.kqtquickcharts kde5.kuser avxsynth trackballs 
ffmpeg_2_2 qmmp linuxPackages_latest_xen_dom0.virtualbox kde5.jovie freeciv kde5.libkdcraw 
openra liquidwar kde4.telepathy.desktop_applets audacity kde5.kde-wallpapers SDL gst_ffmpeg 
kde5.kdepim bs1770gain kde4.kdeartwork fceux linuxPackages.virtualboxHardened blackshadeselite 
andyetitmoves kde5.ksnakeduel kde5.kapptemplate groovebasin kde5.kde-l10n-ar kde5.zeroconf-
ioslave python34Packages.mps-youtube kde4.kde_runtime onscripter-en SDL_mixer ffmpeg_1 
python27Packages.pafy kde4.partitionManager kde5.kde-l10n-ca_valencia pypyPackages.pyacoustid 
kde5.kde-l10n-pt_BR plib handbrake pitivi springLobby kde5.kde-l10n-id kid3 
linuxPackages_testing.virtualbox simgear njam kde5.kde-l10n-ko libretro.scummvm retroarchBare 
kde4.kfilemetadata vimbWrapper kde5.kde-l10n-he mupen64plus1_5 libretro.stella kde4.digikam 
kde4.kdegraphics dwarf-therapist tome4 eternity SDL_gfx libretro.picodrive e19.efl kde4.konsole cuyo 
baresip odamex crack_attack kde5.kde-l10n-ca audiofile kde5.kde-l10n-eu weston kde5.kde-l10n-nds 
kde5.kppp crawlTiles kdeApps_15_08.dolphin beets oraclejdk7 unvanquished stella simutrans fsuae 
conkerorWrapper quake3demo SDL2_ttf kde5.kmenuedit bitsnbots wings torcs ffmpegthumbnailer 
kde5.ksnapshot kde4.telepathy.contact_list openmw libav_9 kde4.skrooge kde5.kde-l10n-hi 
kde4.ktorrent kde4.amarok soundOfSorting oraclejre7 qutebrowser linuxConsoleTools sipcmd xmoto 
kde5.lskat kde4.applications opentyrian mess SDL_sound kde5.kamera kde5.kde-l10n-nn unpaper 
linuxPackages_3_12.virtualboxHardened snes9x-gtk libretro.bsnes-mercury kde5.kde-l10n-kk 
dolphinEmuMaster dosbox openxcom SDL2 avidemux kde4.kdepim superTuxKart ultimatestunts lush2 
SDL_stretch liquidsoap stuntrally kde5.kde-l10n-ia linuxPackages_3_14.virtualbox dwarf_fortress 
teetertorture hedgewars linuxPackages_4_2.virtualboxHardened fish-fillets-ng vlc kde5.kde-runtime 
e19.rage kde4.kdeplasma_addons btanks kde5.kde-l10n-sv d2x_rebirth kde5.libkcddb tvheadend 
kde4.klinkstatus kde5.kmouth kde5.kdelibs plasma54.powerdevil clipgrab movit armagetronad tennix 
mlt-qt4 pianobar libretro.ppsspp kde5.kde-l10n-ru kde4.kdenlive gajim kde5.umbrello e19.terminology 
kde4.kate kde5.kde-l10n-ga kde4.kdebindings neverball SDL2_gfx blender kde4.kdewebdev 
kde5.kubrick kde4.telepathy.filetransfer_handler instead kde4.calligra dvd-slideshow 
kde5.kdegraphics-mobipocket brasero obs-studio kde5.kmousetool worldofgoo_demo kde5.kde-l10n-
et linuxPackages_3_10.virtualboxHardened hexen impressive love_luajit oraclejre8 kde5.ktp-auth-
handler kde5.ktuberling kde5.ktp-accounts-kcm guile-sdl gnu-smalltalk kde5.marble ffmpeg 
kde4.kmymoney gnuradio-with-packages kde5.okular kde5.kiriki kde5.kde-l10n-eo kde5.kde-l10n-tr 
lmms kde5.plasma-mediacenter directvnc kde4.telepathy.accounts_kcm kde4.telepathy.approver 
libretro.prboom kde5.superkaramba tomahawk linuxPackages_4_2.virtualbox kde5.kde-l10n-km 
linphone kde4.bangarang kde5.klickety kde5.amor libretro.desmume openmodelica teeworlds 
linuxPackages_3_18.virtualbox kde4.yakuake kde5.ktp-filetransfer-handler 
python27Packages.infoqscraper kde5.krfb kf514.kfilemetadata minitube kde5.kde-l10n-en_GB 
kde4.k3b python34Packages.pyacoustid kde5.kde-l10n-fr kde4.krdc msilbc get_iplayer kde5.kdepim-
runtime e19.evas stardust kde4.kgpg kde4.kactivities kvm nestopia naev kde5.picmi kde5.libkdeedu 
blobby the-powder-toy kde5.libkface telepathy_farstream kde5.kde-workspace e19.emotion kde5.kde-
l10n-lt kde5.ark kde5.kde-l10n-zh_TW kde5.kigo astromenace kde5.kolf kde5.kde-l10n-is kf514.baloo 
widelands e19.econnman kde5.kde-l10n-pa PPSSPP zod audacious mpv SDL_image kde5.dolphin-
plugins kde4.telepathy.auth_handler kde4.kdesdk qemu firefox-wrapper kde5.kopete oraclejdk7psu 
ptlib kde4.kdeadmin kde5.kreversi freedink kde5.poxml mupen64plus 
linuxPackages_latest_xen_dom0.virtualboxHardened ffmpeg-full kde4.nepomuk_widgets kobodeluxe 
kde5.cantor gensgs python35Packages.pafy kde5.kajongg keen4 kde5.ktp-text-ui kde5.ktp-send-file 
kde5.ktouch zdoom kde5.kdf vlc_qt5 xonotic python35Packages.pythonefl_1_15 kde4.ffmpegthumbs 
ufoai kde5.kdenetwork-strigi-analyzers xpraGtk3 antimicro cmus kde5.kde-l10n-nl kde5.kde-l10n-pl 
python27Packages.pyacoustid libguestfs
```
