### PR TITLE
pythonPackages.python_magic: fix hardcode find_library("magic")

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8663,7 +8663,7 @@ let
     propagatedBuildInputs = with self; [ pkgs.file ];
 
     patchPhase = ''
-      substituteInPlace magic.py --replace "ctypes.CDLL(dll)" "ctypes.CDLL('${pkgs.file}/lib/libmagic.so')"
+      substituteInPlace magic.py --replace "ctypes.util.find_library('magic')" "'${pkgs.file}/lib/libmagic.so'"
     '';
 
     doCheck = false;


### PR DESCRIPTION
Under normal circumstances find_library will fail on nixos and therefore inclusion in another package will result in an error when starting.
