### PR TITLE
cmdtest: init at version 0.18

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19123,6 +19123,27 @@ let
     };
   };
 
+  cmdtest = buildPythonPackage rec {
+    name = "cmdtest-${version}";
+    version = "0.18";
+    disabled = isPy3k || isPyPy;
+
+    propagatedBuildInputs = with self; [ cliapp ttystatus markdown ];
+
+    # TODO: cmdtest tests must be run before the buildPhase
+    doCheck = false;
+
+    src = pkgs.fetchurl {
+      url = "http://code.liw.fi/debian/pool/main/c/cmdtest/cmdtest_0.18.orig.tar.xz";
+      sha256 = "068f24k8ad520hcf8g3gj7wvq1wspyd46ay0k9xa360jlb4dv2mn";
+    };
+
+    meta = {
+      homepage = http://liw.fi/cmdtest/;
+      description = "black box tests Unix command line tools";
+    };
+  };
+
   tornado = buildPythonPackage rec {
     name = "tornado-${version}";
     version = "4.2.1";


### PR DESCRIPTION
Hi,

This adds the cmdtest python package which provides utils for black box and behaviour driven testing.

Thanks,
Richard Ipsum
