### PR TITLE
Shipping Security Updates

### DIFF
--- a/pkgs/test/security/abifix-noop.nix
+++ b/pkgs/test/security/abifix-noop.nix
@@ -1,0 +1,9 @@
+# Check that evaluating all the packages, with the abi patching mechanism
+# with no fixes is effectively a no-op.
+
+with import ./lib.nix;
+
+assert builtins.trace "Found ${builtins.toString (builtins.length pkgsDrvs)} packages." true;
+assert builtins.length pkgsDrvs == builtins.length abifixDrvs;
+assert lib.all lib.id (zipPkgs pkgsDrvs abifixDrvs);
+true

--- a/pkgs/test/security/check-quickfix.nix
+++ b/pkgs/test/security/check-quickfix.nix
@@ -1,0 +1,201 @@
+let
+  testDrv = stdenv: name: rec {
+      inherit name;
+      buildInputs = [ ];
+      buildCommand = ''
+        mkdir -p $out
+        touch $out/installed
+        echo ${name} >> $out/installed
+        touch $out/dependency
+        echo $out >> $out/dependency
+      '';
+
+      meta = with stdenv.lib; {
+        homepage = https://nixos.org/;
+        description = "Test case";
+        longDescription = "Test case";
+        license = licenses.mit;
+        maintainers = [ maintainers.pierron ];
+        platforms = platforms.all;
+      };
+    };
+
+  testDrvWithDep = stdenv: name: dep:
+    let drv = testDrv stdenv name; in drv // {
+      buildInputs = [ dep ];
+      buildCommand = drv.buildCommand + ''
+        cat ${dep}/installed >> $out/installed
+        cat ${dep}/dependency >> $out/dependency
+      '';
+    };
+
+  testPkg = stdenv: name:
+    stdenv.mkDerivation (testDrv stdenv name);
+
+  testPkgWithDep = stdenv: name: dep:
+    stdenv.mkDerivation (testDrvWithDep stdenv name dep);
+
+  pkgTestDead = { stdenv, name ? "dead-1.0.0" }:
+    testPkg stdenv name;
+  pkgTestBeef = { stdenv, name ? "beef-1.0.0", test-dead }:
+    testPkgWithDep stdenv name test-dead;
+  pkgTestAte = { stdenv, name ? "ate-1.0.0", test-beef }:
+    testPkgWithDep stdenv name test-beef;
+  pkgTestBad = { stdenv, name ? "bad-1.0.0", test-ate }:
+    testPkgWithDep stdenv name test-ate;
+  pkgTestFood = { stdenv, name ? "food-1.0.0", test-bad }:
+    testPkgWithDep stdenv name test-bad;
+
+  originalPackages = {
+    adapters = import ../../../pkgs/stdenv/adapters.nix;
+    builders = import ../../../pkgs/build-support/trivial-builders.nix;
+    stdenv = import ../../../pkgs/top-level/stdenv.nix;
+    all = import ../../../pkgs/top-level/all-packages.nix;
+    aliases = import ../../../pkgs/top-level/aliases.nix;
+  };
+
+  defaultPackages = originalPackages // {
+    all = top: self: pkgs: originalPackages.all top self pkgs // (
+      let callPackage = top.lib.callPackageWith pkgs; in {
+        test-dead = callPackage pkgTestDead { };
+        test-beef = callPackage pkgTestBeef { };
+        test-ate  = callPackage pkgTestAte  { };
+        test-bad  = callPackage pkgTestBad  { };
+        test-food = callPackage pkgTestFood { };
+      });
+  };
+
+  # Only change the foo package which is used explicitly by bar, and
+  # indirectly by baz.
+  quickfixPackages = originalPackages // {
+    all = top: self: pkgs: originalPackages.all top self pkgs // (
+      let callPackage = top.lib.callPackageWith pkgs; in {
+        test-dead = callPackage pkgTestDead { };
+        test-beef = callPackage pkgTestBeef { name = "beef-1.0.2"; };
+        test-ate  = callPackage pkgTestAte  { };
+        test-bad  = callPackage pkgTestBad  { name = "bad-1.0.51"; };
+        test-food = callPackage pkgTestFood { };
+      });
+  };
+
+  withoutFix = import ../../../. {
+    inherit defaultPackages;
+    quickfixPackages = null;
+  };
+
+  withFix = import ../../../. {
+    inherit defaultPackages quickfixPackages;
+  };
+in
+
+  withoutFix.stdenv.mkDerivation {
+    name = "check-quickfix";
+    buildInputs = [];
+    buildCommand = ''
+      length() {
+        local arg="$1";
+        echo ''${#arg};
+      }
+      set -x;
+
+      : Check that fixes are correctly applies.
+      test    ${withoutFix.test-dead} = ${withFix.test-dead}
+      test \! ${withoutFix.test-beef} = ${withFix.test-beef} # recompiled
+      test \! ${withoutFix.test-ate } = ${withFix.test-ate } # patched
+      test \! ${withoutFix.test-bad } = ${withFix.test-bad } # recompiled & patched
+      test \! ${withoutFix.test-food} = ${withFix.test-food} # patched
+
+      : Check output paths have identical length.
+      test $(length ${withoutFix.test-dead}) -eq $(length ${withFix.test-dead})
+      test $(length ${withoutFix.test-beef}) -eq $(length ${withFix.test-beef})
+      test $(length ${withoutFix.test-ate }) -eq $(length ${withFix.test-ate })
+      test $(length ${withoutFix.test-bad }) -eq $(length ${withFix.test-bad }) # renamed
+      test $(length ${withoutFix.test-food}) -eq $(length ${withFix.test-food})
+
+      : Check compiled packages names.
+      grep -q "dead-1.0.0" ${withoutFix.test-dead}/installed
+      grep -q "beef-1.0.0" ${withoutFix.test-beef}/installed
+      grep -q "ate-1.0.0"  ${withoutFix.test-ate }/installed
+      grep -q "bad-1.0.0"  ${withoutFix.test-bad }/installed
+      grep -q "food-1.0.0" ${withoutFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withoutFix.test-beef}/installed
+      grep -q "beef-1.0.0" ${withoutFix.test-ate }/installed
+      grep -q "ate-1.0.0"  ${withoutFix.test-bad }/installed
+      grep -q "bad-1.0.0"  ${withoutFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withoutFix.test-ate }/installed
+      grep -q "beef-1.0.0" ${withoutFix.test-bad }/installed
+      grep -q "ate-1.0.0"  ${withoutFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withoutFix.test-bad }/installed
+      grep -q "beef-1.0.0" ${withoutFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withoutFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withFix.test-dead}/installed
+      grep -q "beef-1.0.2" ${withFix.test-beef}/installed
+      grep -q "ate-1.0.0"  ${withFix.test-ate }/installed
+      grep -q "bad-1.0.51" ${withFix.test-bad }/installed # not renamed
+      grep -q "food-1.0.0" ${withFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withFix.test-beef}/installed
+      grep -q "beef-1.0.0" ${withFix.test-ate }/installed # not updated
+      grep -q "ate-1.0.0"  ${withFix.test-bad }/installed
+      grep -q "bad-1.0.0"  ${withFix.test-food}/installed # not updated
+
+      grep -q "dead-1.0.0" ${withFix.test-ate }/installed
+      grep -q "beef-1.0.0" ${withFix.test-bad }/installed # not updated
+      grep -q "ate-1.0.0"  ${withFix.test-food}/installed
+
+      grep -q "dead-1.0.0" ${withFix.test-bad }/installed
+      grep -q "beef-1.0.0" ${withFix.test-food}/installed # not updated
+
+      grep -q "dead-1.0.0" ${withFix.test-food}/installed
+
+       : Check dependencies hashes.
+      grep -q ${withoutFix.test-dead} ${withoutFix.test-dead}/dependency
+      grep -q ${withoutFix.test-beef} ${withoutFix.test-beef}/dependency
+      grep -q ${withoutFix.test-ate } ${withoutFix.test-ate }/dependency
+      grep -q ${withoutFix.test-bad } ${withoutFix.test-bad }/dependency
+      grep -q ${withoutFix.test-food} ${withoutFix.test-food}/dependency
+
+      grep -q ${withoutFix.test-dead} ${withoutFix.test-beef}/dependency
+      grep -q ${withoutFix.test-beef} ${withoutFix.test-ate }/dependency
+      grep -q ${withoutFix.test-ate } ${withoutFix.test-bad }/dependency
+      grep -q ${withoutFix.test-bad } ${withoutFix.test-food}/dependency
+
+      grep -q ${withoutFix.test-dead} ${withoutFix.test-ate }/dependency
+      grep -q ${withoutFix.test-beef} ${withoutFix.test-bad }/dependency
+      grep -q ${withoutFix.test-ate } ${withoutFix.test-food}/dependency
+
+      grep -q ${withoutFix.test-dead} ${withoutFix.test-bad }/dependency
+      grep -q ${withoutFix.test-beef} ${withoutFix.test-food}/dependency
+
+      grep -q ${withoutFix.test-dead} ${withoutFix.test-food}/dependency
+
+      grep -q ${withFix.test-dead} ${withFix.test-dead}/dependency
+      grep -q ${withFix.test-beef} ${withFix.test-beef}/dependency # recompiled
+      grep -q ${withFix.test-ate } ${withFix.test-ate }/dependency
+      grep -q ${withFix.test-bad } ${withFix.test-bad }/dependency # recompiled
+      grep -q ${withFix.test-food} ${withFix.test-food}/dependency
+
+      grep -q ${withFix.test-dead} ${withFix.test-beef}/dependency
+      grep -q ${withFix.test-beef} ${withFix.test-ate }/dependency # patched
+      grep -q ${withFix.test-ate } ${withFix.test-bad }/dependency
+      grep -q ${withFix.test-bad } ${withFix.test-food}/dependency # patched
+
+      grep -q ${withFix.test-dead} ${withFix.test-ate }/dependency
+      grep -q ${withFix.test-beef} ${withFix.test-bad }/dependency # patched
+      grep -q ${withFix.test-ate } ${withFix.test-food}/dependency
+
+      grep -q ${withFix.test-dead} ${withFix.test-bad }/dependency
+      grep -q ${withFix.test-beef} ${withFix.test-food}/dependency # patched
+
+      grep -q ${withFix.test-dead} ${withFix.test-food}/dependency
+
+      mkdir -p $out
+      echo success > $out/result
+      set +x
+    '';
+  }

--- a/pkgs/test/security/default.nix
+++ b/pkgs/test/security/default.nix
@@ -1,0 +1,36 @@
+{ nixpkgs, pkgs }:
+
+with pkgs;
+
+let
+  nixCommand = name: command:
+    runCommand name { buildInputs = [ nix ]; } ''
+      datadir="${nix}/share"
+      export TEST_ROOT=$(pwd)/test-tmp
+      export NIX_BUILD_HOOK=
+      export NIX_CONF_DIR=$TEST_ROOT/etc
+      export NIX_DB_DIR=$TEST_ROOT/db
+      export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+      export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+      export NIX_MANIFESTS_DIR=$TEST_ROOT/var/nix/manifests
+      export NIX_STATE_DIR=$TEST_ROOT/var/nix
+      export NIX_STORE_DIR=$TEST_ROOT/store
+      export PAGER=cat
+      cacheDir=$TEST_ROOT/binary-cache
+      nix-store --init
+
+      cd ${nixpkgs}/pkgs/test/security
+      ${command}
+      touch $out
+    '';
+in
+
+{
+  check-quickfix = import ./check-quickfix.nix;
+  onefix-noop = nixCommand "onefix-noop" ''
+    nix-instantiate --timeout 60 ./onefix-noop.nix --eval-only
+  '';
+  abifix-noop = nixCommand "abifix-noop" ''
+    nix-instantiate --timeout 60 ./abifix-noop.nix --eval-only
+  '';
+}

--- a/pkgs/test/security/lib.nix
+++ b/pkgs/test/security/lib.nix
@@ -1,0 +1,82 @@
+let
+  lib = import ../../../lib;
+in
+
+with lib;
+
+rec {
+  inherit lib;
+
+  originalPackages = {
+    adapters = import ../../../pkgs/stdenv/adapters.nix;
+    builders = import ../../../pkgs/build-support/trivial-builders.nix;
+    stdenv = import ../../../pkgs/top-level/stdenv.nix;
+    all = import ../../../pkgs/top-level/all-packages.nix;
+    aliases = import ../../../pkgs/top-level/aliases.nix;
+  };
+
+  pkgs = import ../../../. {
+    defaultPackages = originalPackages;
+    quickfixPackages = null;
+    doPatchWithDependencies = false;
+  } // { recurseForDerivations = true; };
+
+  onefix = import ../../../. {
+    defaultPackages = originalPackages;
+    quickfixPackages = originalPackages;
+    doPatchWithDependencies = false;
+  } // { recurseForDerivations = true; };
+
+  abifix = import ../../../. {
+    defaultPackages = originalPackages;
+    quickfixPackages = originalPackages;
+    doPatchWithDependencies = true;
+  } // { recurseForDerivations = true; };
+
+  # This is the same as the `collectWithPath` function of Nixpkgs's library,
+  # except that it uses `tryEval` to ignore invalid evaluations, such as
+  # broken and unfree packages.
+  #
+  # Example:
+  #   maybeCollectWithPath (x: x ? outPath)
+  #      { a = { outPath = "a/"; }; b = { outPath = "b/"; }; }
+  #   => [ { path = ["a"]; value = { outPath = "a/"; }; }
+  #        { path = ["b"]; value = { outPath = "b/"; }; }
+  #      ]
+  #
+  maybeCollectWithPath = pred: attrs: with lib;
+    let
+      collectInternal = path: attrs:
+        # assert __trace (["maybeCollectWithPath::"] ++ path) true;
+        addErrorContext "while collecting derivations under ${concatStringsSep "." path}:" (
+        if pred attrs then
+          [ { path = concatStringsSep "." path; value = attrs; } ]
+        else if isAttrs attrs && attrs.recurseForDerivations or false then
+          concatMap (name: maybeCollectInternal (path ++ [name]) attrs.${name})
+            (attrNames attrs)
+        else
+          []);
+
+       maybeCollectInternal = path: attrs:
+         # Some evaluation of isAttrs might raise an assertion while
+         # evaluating Nixpkgs, tryEval is used to work-around this issue.
+         let res = builtins.tryEval (collectInternal path attrs); in
+         if res.success then res.value
+         else [];
+
+    in
+      maybeCollectInternal [] attrs;
+
+  # Collect all derivations.
+  collectDerivations = with lib; pkgs:
+    maybeCollectWithPath (drv: isDerivation drv && drv.outPath != "") pkgs;
+
+  pkgsDrvs = collectDerivations pkgs;
+  onefixDrvs = collectDerivations onefix;
+  abifixDrvs = collectDerivations abifix;
+
+  # Zip all packages collected so far, and verify that they are equal.
+  zipPkgs =
+    lib.zipListsWith
+      (p: o: p.path == o.path && p.value.outPath == o.value.outPath);
+}

--- a/pkgs/test/security/onefix-noop.nix
+++ b/pkgs/test/security/onefix-noop.nix
@@ -1,0 +1,6 @@
+with import ./lib.nix;
+
+assert builtins.trace "Found ${builtins.toString (builtins.length pkgsDrvs)} packages." true;
+assert builtins.length pkgsDrvs == builtins.length onefixDrvs;
+assert lib.all lib.id (zipPkgs pkgsDrvs onefixDrvs);
+true

--- a/pkgs/test/security/static-analaysis.nix
+++ b/pkgs/test/security/static-analaysis.nix
@@ -1,0 +1,200 @@
+# ABI compatible patches are made based on one assumption, which is that
+# Nixpkgs is a function which provide a set of derivation, where all the
+# dependencies are taken from its argument. This hypothesis has to hold,
+# in order to make it possible to override packages.
+#
+# Unfortunately, they are many ways in which a dependency can be defined,
+# and it could be defined after multiple iterations through the Nixpkgs
+# function, or at the same iteration.
+#
+# This file is made to analyze and report issues in the resolutions of
+# dependencies such that we can generate safe security updates.
+
+let
+  # Load Nixpkgs without any additional wrapping.
+  pkgs = import ../../../. {
+    quickfixPackages = null;
+    doPatchWithDependencies = false;
+  };
+  pkgsFun = pkgs.__unfix__;
+
+  lib = pkgs.lib;
+
+  # These attributes are unrolling the fix-point of Nixpkgs over a few
+  # numbers of iteration, and all derivations of each iteration are annotated
+  # with their generation number.
+  #
+  # Such annotations are useful to analyze the data-flow of the derivations,
+  # and to find issues which are not safe for applying ABI compatible
+  # patches.
+  rangeMax = 10;
+  genPkgs = with lib;
+    let generations = range 0 rangeMax; in
+      fold (gen: pkgs: annotatePkgs gen (pkgsFun pkgs)) pkgs generations;
+
+  # Annotate all derivations with an extra attribute, named `_generation`.
+  # This extra attribute identify all packages coming from this layer of
+  # Nixpkgs. This is used to track attributes which are not handled by the
+  # applyAbiCompatiblePatches function.
+  annotatePkgs = generation: pkgs: with lib;
+    let
+      recursiveAnnotateValue = attrs:
+        mapAttrsRecursiveCond
+          (as: !isDerivation as) (path: maybeAnnotateValue path)
+          attrs;
+
+      # We don't want to patch callPackages, but the override function
+      # returned by it.
+      validFunctionName = path:
+        let funName = elemAt path (length path - 1); in
+          ! elem funName [ "newScope" "callPackage" "callPackages" "callPackage_i686" "mkDerivation" ];
+
+      annotateValue = path: value:
+        if isDerivation value then
+          # assert __trace (strict ["annotatePkgs::" generation] ++ path) true;
+          (mapAttrs (name: maybeAnnotateValue (path ++ [".drv" name])) value)
+          // {
+            _generation =
+              if value ? _generation then value._generation
+              else
+                # assert __trace (strict ["annotatePkgs>>" generation] ++ path) true;
+                generation;
+          }
+        else if isFunction value && validFunctionName path then
+          x: maybeAnnotateValue (path ++ [">"]) (value x)
+        else
+          value;
+
+      maybeAnnotateValue = path: value:
+        let res = builtins.tryEval (annotateValue path value); in
+        if res.success then res.value
+        else value;
+    in
+      recursiveAnnotateValue pkgs;
+
+  # This is a clone of the recursive update function, which is made lazier,
+  # by not evaluating the left-hand-side. Thus, avoid being strict on
+  # derivations.
+  recursiveUpdate = lhs: rhs: with lib;
+    recursiveUpdateUntil (path: lhs: rhs: !isAttrs rhs) lhs rhs;
+
+  # Do not waste time looking for derivations which might cause us trouble,
+  # either by causing infinite loops or simply by taking too much time to
+  # visit.
+  filteredPkgs = recursiveUpdate genPkgs {
+
+    # Prevent infinite recursions within the following attributes:
+    allStdenvs = null;
+    pkgs = null;
+    pkgsi686Linux = null;
+    gnome3.gnome3 = null;
+    lispPackages.pkgs = null;
+
+    # Prevent errors not caught by builtins.tryEval.
+    darwin.CF_new = null;
+    darwin.Libc_new = null;
+    darwin.Libnotify_new = null;
+    darwin.Libsystem_new = null;
+    darwin.cctools_cross = null;
+    darwin.libdispatch_new = null;
+    darwin.libiconv_new = null;
+    darwin.objc4_new = null;
+    darwin.xnu_new = null;
+
+    linuxPackages_3_10_tuxonice = null;
+    nodePackages.by-spec.pure-css = null;
+
+    # Call me lazy...
+    recurseForDerivations = true;
+  };
+
+  # This is the same as the `collectWithPath` function of Nixpkgs's library,
+  # except that it uses `tryEval` to ignore invalid evaluations, such as
+  # broken and unfree packages.
+  #
+  # Example:
+  #   maybeCollectWithPath (x: x ? outPath)
+  #      { a = { outPath = "a/"; }; b = { outPath = "b/"; }; }
+  #   => [ { path = ["a"]; value = { outPath = "a/"; }; }
+  #        { path = ["b"]; value = { outPath = "b/"; }; }
+  #      ]
+  #
+  maybeCollectWithPath = pred: attrs: with lib;
+    let
+      collectInternal = path: attrs:
+        # assert __trace (["maybeCollectWithPath::"] ++ path) true;
+        addErrorContext "while collecting derivations under ${concatStringsSep "." path}:" (
+        if pred attrs then
+          [ { path = concatStringsSep "." path; value = attrs; } ]
+        else if isAttrs attrs && attrs.recurseForDerivations or false then
+          concatMap (name: maybeCollectInternal (path ++ [name]) attrs.${name})
+            (attrNames attrs)
+        else
+          []);
+
+       maybeCollectInternal = path: attrs:
+         # Some evaluation of isAttrs might raise an assertion while
+         # evaluating Nixpkgs, tryEval is used to work-around this issue.
+         let res = builtins.tryEval (collectInternal path attrs); in
+         if res.success then res.value
+         else [];
+
+    in
+      maybeCollectInternal [] attrs;
+
+  # Collect all derivations.
+  collectDerivations = with lib; pkgs:
+    maybeCollectWithPath (drv: isDerivation drv && drv.outPath != "") pkgs;
+
+  # Look at the collected derivations, and annotate each derivation with
+  # some errors/warnings that should be considered. Filter out any
+  # derivation which does not represent a risk for applying security
+  # updates.
+  analyzePackages = with lib;
+    let
+      getGeneration = dft: drv: drv._generation or dft;
+      inputsByGeneration = dft: gen: drv:
+        filter (d: isDerivation d && getGeneration dft d == gen) (drv.nativeBuildInputs or []);
+      inputsOlderThanGeneration = dft: gen: drv:
+        filter (d: isDerivation d && getGeneration dft d > gen) (drv.nativeBuildInputs or []);
+
+      analyze = {path, value}@elem:
+        rec {
+          generation = getGeneration rangeMax value;
+          inputs-by-generations = {
+            gen0 = inputsByGeneration generation 0 value;
+            gen1 = inputsByGeneration generation 1 value;
+            old = inputsOlderThanGeneration generation 1 value;
+          };
+          messages = []
+          ++ optional (generation != 0) "alias-original: generation ${toString generation}"
+          ++ optional (inputs-by-generations.old != []) ''unpatched-inputs: generation ${toString generation}, inputs: ${
+               concatStringsSep ", " (map (d: "(${toString (getGeneration generation d)}, ${d.outPath})") inputs-by-generations.old)
+             }''
+          ++ optional (inputs-by-generations.gen0 != []) ''static-linking: generation ${toString generation}, inputs: ${
+               concatStringsSep ", " (map (d: "(${toString (getGeneration generation d)}, ${d.outPath})") inputs-by-generations.gen0)
+             }'';
+        };
+
+      addMessages = e: e // analyze e;
+    in
+      filter (e: e.messages != []) (
+        map addMessages (collectDerivations filteredPkgs));
+
+  # Debug function which prints the list of known issues which can be
+  # checked statically.
+  displayAnalysis = issues: with lib;
+    let
+      displayMessages = e:
+        map (m: "${e.path}: ${m}") e.messages;
+      allMessages =
+        concatMap displayMessages issues;
+    in
+    assert __trace (''List of ${toString (length allMessages)} potential issues:
+
+    '' + concatStringsSep "\n" allMessages
+    ) true;
+    null;
+
+in
+  displayAnalysis analyzePackages

--- a/pkgs/test/security/static-analaysis.nix
+++ b/pkgs/test/security/static-analaysis.nix
@@ -43,7 +43,9 @@ let
       # returned by it.
       validFunctionName = path:
         let funName = elemAt path (length path - 1); in
-          ! elem funName [ "newScope" "callPackage" "callPackages" "callPackage_i686" "mkDerivation" ];
+          ! elem funName [ "newScope" "callPackage" "callPackages" "callPackage_i686" "mkDerivation"
+            "forceNativeDrv" "lowPrio"
+          ];
 
       annotateValue = path: value:
         if isDerivation value then

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -45,6 +45,16 @@
   # to apply security fixes to a few packages which would be compiled, and
   # to patch any of their dependencies, to have a fast turn-around.
 , quickfixPackages ? null
+
+  # When a set of quickfix packages is defined, this flag is used to enable
+  # patching packages which are depending on the packages which are updated
+  # in the quickfix packages.
+  #
+  # This flag highly recommend to be `true` on a user/server system, while
+  # it is suggested to set it to `false` on buildfarms, as we do not want to
+  # distribute, and use space for all the variants of the patched packages,
+  # on the buildfarm servers.
+, doPatchWithDependencies ? true
 }:
 
 
@@ -344,7 +354,8 @@ let
           '';
 
     in
-      abifix;
+      if doPatchWithDependencies then abifix
+      else onefix;
 
 in
   maybeApplyAbiCompatiblePatches pkgs

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -105,7 +105,10 @@ let
   # (un-overridden) set of packages, allowing packageOverrides
   # attributes to refer to the original attributes (e.g. "foo =
   # ... pkgs.foo ...").
-  pkgs = pkgsWithOverridesWithPackages (self: config.packageOverrides or (super: {})) defaultPackages;
+  pkgs = pkgsWithPackages defaultPackages;
+
+  pkgsWithPackages =
+    pkgsWithOverridesWithPackages (self: config.packageOverrides or (super: {}));
 
   # Return the complete set of packages, after applying the overrides
   # returned by the `overrider' function (see above).  Warning: this

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -40,6 +40,11 @@
     all = import ./all-packages.nix;
     aliases = import ./aliases.nix;
   }
+
+  # Additional list of packages, similar to defaultPackages, which is used
+  # to apply security fixes to a few packages which would be compiled, and
+  # to patch any of their dependencies, to have a fast turn-around.
+, quickfixPackages ? null
 }:
 
 
@@ -159,5 +164,21 @@ let
                 lib.extends trivialBuilders (
                   lib.extends stdenvAdapters (
                     self: {})))))));
+
+  # Apply ABI compatible fixes:
+  #  1. This will cause the recompilation of packages which have a different
+  #     derivation in quickfix, than what they have in the default packages.
+  #  2. This will patch any of the dependencies to substitute the hash of
+  #     the default packages by the corresponding hash of the quickfix
+  #     packages which got recompiled.
+  #
+  # If there is no quickfix to apply, or if we are bootstrapping the
+  # compilation environment, then there is no need for making any patches.
+  maybeApplyAbiCompatiblePatches = pkgs:
+    if bootStdenv == null && quickfixPackages != null then
+      throw "NYI"
+    else
+      pkgs;
+
 in
-  pkgs
+  maybeApplyAbiCompatiblePatches pkgs

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -29,6 +29,7 @@ let
 
       manual = import ../../doc;
       lib-tests = import ../../lib/tests/release.nix { inherit nixpkgs; };
+      tests.security = import ../../pkgs/test/security { inherit nixpkgs pkgs; };
 
       unstable = pkgs.releaseTools.aggregate
         { name = "nixpkgs-${jobs.tarball.version}";
@@ -38,6 +39,9 @@ let
               jobs.metrics
               jobs.manual
               jobs.lib-tests
+              jobs.tests.security.check-quickfix
+              jobs.tests.security.onefix-noop
+              jobs.tests.security.abifix-noop
               jobs.stdenv.x86_64-linux
               jobs.stdenv.i686-linux
               jobs.stdenv.x86_64-darwin


### PR DESCRIPTION
## Motivations

The way of handling security updates today involves a lot of humans efforts, going from reading the mailing list, to adding lines to the configuration files.

More over, this implies having control over the top-level derivation, which is not always possible with `nix-env`, and `nix-shell`.  This has to be patched inside the current pipeline, as what got made for NixOS.

Also, as the current method for applying security updates is complex, we are only restricting them to a few packages, such as `glibc`, `bash` and `openssl` which are used a lot, but we do not such mechanism for all other packages which have minor security / usability updates such as `firefox`.

As a work-around, today, we offer the option of having a small channel, to get updates from, but this is not a good solution for end-users, as the small channel basically involves recompiling any large project.

More over the current mechanism cannot safely be composed as explained in #4336.
## Goals

This work aims at making it **transparent**, such as security updates are cannot be distinguished from any other updates by the end user.

This work aims at making it **easy**, such that packagers only have to cherry-pick a commit made on master into a security/master branch to let the buildfarm compile and distribute the package against the latest stable branch.

This work aims at making it **fast**, such that the buildfarm in charge of producing pre-compiled versions of the packages will only recompile the packages which are being fixed, against the latest stable branch.  When a user updates, Nix will download from the latest stable channel, with the addition of the recompiled packages, and Nix will patch all the packages depending on the fixed packages.

This new approach is **sane**, as it constructs the patches which have to be apply, without any knowledge of the runtime dependency.  Thus, all the packages patches can be build up-front without having to realize any of the derivations.  This is a big plus to guarantee reproducible builds of the patching mechanism.
## Approach
### Nixpkgs as a pure function

This approach aims at constructing patches based on the Nix expressions of the packages. Thus we have to change the way we evaluate Nixpkgs to reflect the patching mechanism.

This approach is based on the recent modification of #14000 (#9400), which make Nixpkgs behave as a single function with no external inputs.  As the Nix language is pure, the following property holds for Nixpkgs.

```
    fix f == f (fix f)
```

This property means that we can call `f` one extra time on the result of the fix-point without changing the result of the fix-point.  As a consequence, all the packages will keep the same hashes.
### Recompile only fixed packages

This patching mechanism relies on one hypothesis.  This hypothesis is that all packages derivations are expressed in the last evaluation of Nixpkgs, and that dependencies are taken from the previous evaluation of Nixpkgs.

This hypothesis does not hold, as of today, but with the help of a static analysis, we can identify how many times we jump through the Nixpkgs argument before we settle on a derivation, and before we settle on its inputs.

Once this hypothesis is guaranteed, we can change the above expression to

```
    g (fix f)
```

Where `g` is a slightly different version of `f`.  With the above hypothesis, this means that all derivations of packages are taken from `g`, but the dependencies of `g` are taken from `f`.

If `f` is the stable version of Nixpkgs, and `g` is a stable version of Nixpkgs with extra patches.  This implies we will recompile any patched packages of `g`, while keeping the same hashes as `f` for non-patched packages.

At this stage, we have what we expect to let Hydra compile.  Still, this stage does not apply any patches to any of the packages.
### Building patches

To be able to apply patches to the dependencies, we need the equivalent of a fix-point, to evaluate the dependencies, and the dependencies of the dependencies, and so on … In addition to a fix-point, we want to iterate from the maybe-recompiled packages of `g (fix f)`, and iterate over `g` to settle on the patched version of the packages.  We would name this patched version of packages `h`.

To construct patches, we need to know the dependencies of the packages, and which one got updated.

To list the dependencies of a package, we have to rely on some form of introspection, encoded as part of the derivations.  As a first approach I relied on `callPackage`, which would give us a super set of the dependencies, but this has a lot of issues, and left-over packages.  As a second approach, I now rely on the `buildInputs` which are exposed by the derivation, but this has the issue of being a sub-set of the dependencies.  Still, I am confident that we can instrument the default builder to ensure that buildInputs are a super set of the runtime dependencies.

To check for updates, we can compare the `outPath` of 2 derivations.  If the derivations have a different `outPath`, this means that the derivations has a different inputs.  (Note: hash collisions are unlikely, but if this happens we can easily add a dummy environment variable to get a different hash)

Patches are composed of the hashes of the old versions, and the hashes of the new versions.  Making a patch for one derivation, is being able to list the old hashes and associate them with the new hashes.  The hashes are the hashes of the dependencies.

Based on the last hypothesis, looking for the dependencies of `g (fix f)`, will gives us hashes of derivations from `fix f`.  These are our old hashes.

Looking for the new hashes, implies that we have to build packages based on patched versions of the packages, i-e `h`.  Thus if we look for the dependencies of `g h`, we would have our new hashes.

Therefore `h` definition should look like:

```
  h = patch (g (fix f)) (g h);
```

Where `patch` is a function which on a derivation, will take the value of `g (fix f)`, and apply a patch for any of its dependencies which got updated, by substituting the dependencies from `fix f` by dependencies from `h`.

In practice, we also need to feed `fix f` to this `patch` function, as we have to make sure that patches can be applied safely, by ensuring that the `outPath` of the derivation still have the same length.
## Status
- [x] Implement this approach on top of Nixpkgs
- [x] Add test case to ensure that, when the one-application hypothesis holds, we can only recompile fixed packages, and apply patches on the rest of the packages.
- [x] Make a static analysis which reports all violations of the one-application hypothesis.
- [x] `nix-env -f ./. -qaP --drv-path` works when `quickfixPackages` is equal to `defaultPackages`, and does not cause recompilation of existing packages. (Note: nox-review fails to see that we have no recompilation because of violation of the one-application hypothesis)
- [x] Add a test case to verify that `nix-env -f ./. -qaP --drv-path` always works, when `quickfixPackages` is equal to `defaultPackages`.
- [x] Hook the test cases as release blockers of Nixpkgs.

This mechanism is disabled by default, as no `quickfixPackages` are provided yet.  Also, when disabled, this work has no impact.

To avoid to bloat and delay these changes, I would recommend that we merge them as soon as possible, even if the one-application hypothesis does not hold yet, and address any issues reported by the static analysis as follow-up issues.
#### References

NixCon slides: http://nbp.github.io/slides/NixCon/2015.ShippingSecurityUpdates/
NixCon video: https://www.youtube.com/watch?v=RhcKXS00zEE
