### PR TITLE
eclipse: modularized buildEclipse

### DIFF
--- a/pkgs/applications/editors/eclipse/buildEclipse.nix
+++ b/pkgs/applications/editors/eclipse/buildEclipse.nix
@@ -1,0 +1,54 @@
+{ stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender, zlib, jre, glib, gtk, libXtst, webkitgtk2, makeWrapper, ... }:
+
+{ name, src ? builtins.getAttr stdenv.system sources, sources ? null, description }:
+
+stdenv.mkDerivation rec {
+  inherit name src;
+
+  desktopItem = makeDesktopItem {
+    name = "Eclipse";
+    exec = "eclipse";
+    icon = "eclipse";
+    comment = "Integrated Development Environment";
+    desktopName = "Eclipse IDE";
+    genericName = "Integrated Development Environment";
+    categories = "Application;Development;";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    # Unpack tarball.
+    mkdir -p $out
+    tar xfvz $src -C $out
+
+    # Patch binaries.
+    interpreter=$(echo ${stdenv.glibc}/lib/ld-linux*.so.2)
+    libCairo=$out/eclipse/libcairo-swt.so
+    patchelf --set-interpreter $interpreter $out/eclipse/eclipse
+    [ -f $libCairo ] && patchelf --set-rpath ${freetype}/lib:${fontconfig}/lib:${libX11}/lib:${libXrender}/lib:${zlib}/lib $libCairo
+
+    # Create wrapper script.  Pass -configuration to store
+    # settings in ~/.eclipse/org.eclipse.platform_<version> rather
+    # than ~/.eclipse/org.eclipse.platform_<version>_<number>.
+    productId=$(sed 's/id=//; t; d' $out/eclipse/.eclipseproduct)
+    productVersion=$(sed 's/version=//; t; d' $out/eclipse/.eclipseproduct)
+
+    makeWrapper $out/eclipse/eclipse $out/bin/eclipse \
+      --prefix PATH : ${jre}/bin \
+      --prefix LD_LIBRARY_PATH : ${glib}/lib:${gtk}/lib:${libXtst}/lib${stdenv.lib.optionalString (webkitgtk2 != null) ":${webkitgtk2}/lib"} \
+      --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"
+
+    # Create desktop item.
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+    mkdir -p $out/share/pixmaps
+    ln -s $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
+  ''; # */
+
+  meta = {
+    homepage = http://www.eclipse.org/;
+    inherit description;
+  };
+
+}

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -260,7 +260,6 @@ in {
       "x86_64-linux" = fetchurl {
           url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk-x86_64.tar.gz;
           sha256 = "0g00alsixfaakmn4khr0m9fxvkrbhbg6qqfa27xr6a9np6gzg98l";
-
         };
       "i686-linux" = fetchurl {
           url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk.tar.gz;
@@ -276,7 +275,6 @@ in {
       "x86_64-linux" = fetchurl {
           url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk-x86_64.tar.gz;
           sha256 = "0vfql4gh263ms8bg7sgn05gnjajplx304cn3nr03jlacgr3pkarf";
-
         };
       "i686-linux" = fetchurl {
           url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk.tar.gz;
@@ -305,12 +303,11 @@ in {
     description = "Eclipse platform";
     sources = {
       "x86_64-linux" = fetchurl {
-          url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk-x86_64.tar.gz";
+          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk-x86_64.tar.gz;
           sha256 = "1510j41yr86pbzwf48kjjdd46nkpkh8zwn0hna0cqvsw1gk2vqcg";
-
         };
       "i686-linux" = fetchurl {
-          url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk.tar.gz";
+          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk.tar.gz;
           sha256 = "1f97jd3qbi3830y3djk8bhwzd9whsq8gzfdk996chxc55prn0qbd";
         };
     };

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -285,6 +285,21 @@ in {
     };
   };
 
+  eclipse_sdk_451 = buildEclipse {
+    name = "eclipse-sdk-4.5.1";
+    description = "Eclipse Mars Classic";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk-x86_64.tar.gz;
+          sha256 = "b56503ab4b86f54e1cdc93084ef8c32fb1eaabc6f6dad9ef636153b14c928e02";
+        };
+      "i686-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk.tar.gz;
+          sha256 = "f2e41da52e138276f8f121fd4d57c3f98839817836b56f8424e99b63c9b1b025";
+        };
+    };
+  };
+
   eclipse-platform = buildEclipse {
     name = "eclipse-platform-4.5";
     description = "Eclipse platform";

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -4,66 +4,14 @@
 , webkitgtk2 ? null  # for internal web browser
 , buildEnv, writeText, runCommand
 , callPackage
-}:
+} @ args:
 
 assert stdenv ? glibc;
 
 let
 
-  buildEclipse =
-    { name, src ? builtins.getAttr stdenv.system sources, sources ? null, description }:
+  buildEclipse = import ./buildEclipse.nix args;
 
-    stdenv.mkDerivation rec {
-      inherit name src;
-
-      desktopItem = makeDesktopItem {
-        name = "Eclipse";
-        exec = "eclipse";
-        icon = "eclipse";
-        comment = "Integrated Development Environment";
-        desktopName = "Eclipse IDE";
-        genericName = "Integrated Development Environment";
-        categories = "Application;Development;";
-      };
-
-      buildInputs = [ makeWrapper ];
-
-      buildCommand = ''
-        # Unpack tarball.
-        mkdir -p $out
-        tar xfvz $src -C $out
-
-        # Patch binaries.
-        interpreter=$(echo ${stdenv.glibc}/lib/ld-linux*.so.2)
-        libCairo=$out/eclipse/libcairo-swt.so
-        patchelf --set-interpreter $interpreter $out/eclipse/eclipse
-        [ -f $libCairo ] && patchelf --set-rpath ${freetype}/lib:${fontconfig}/lib:${libX11}/lib:${libXrender}/lib:${zlib}/lib $libCairo
-
-        # Create wrapper script.  Pass -configuration to store
-        # settings in ~/.eclipse/org.eclipse.platform_<version> rather
-        # than ~/.eclipse/org.eclipse.platform_<version>_<number>.
-        productId=$(sed 's/id=//; t; d' $out/eclipse/.eclipseproduct)
-        productVersion=$(sed 's/version=//; t; d' $out/eclipse/.eclipseproduct)
-        
-        makeWrapper $out/eclipse/eclipse $out/bin/eclipse \
-          --prefix PATH : ${jre}/bin \
-          --prefix LD_LIBRARY_PATH : ${glib}/lib:${gtk}/lib:${libXtst}/lib${stdenv.lib.optionalString (webkitgtk2 != null) ":${webkitgtk2}/lib"} \
-          --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"
-
-        # Create desktop item.
-        mkdir -p $out/share/applications
-        cp ${desktopItem}/share/applications/* $out/share/applications
-        mkdir -p $out/share/pixmaps
-        ln -s $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
-      ''; # */
-
-      meta = {
-        homepage = http://www.eclipse.org/;
-        inherit description;
-      };
-
-    };
-    
 in {
 
   eclipse_sdk_35 = buildEclipse {


### PR DESCRIPTION
I modularized the Eclipse packages so that custom versions can easily be defined in, say, _~/.nixpkgs/config.nix_. I also added the latest version of the SDK (4.5.1) since that was my original requirement anyway.

I tried to do this in the most obviously equivalent way I could think of.

I **did not** change the _eclipse-platform_ version or even add the 4.5.1 platform release. Perhaps we should provide different versions like we do for the SDK. Something like:
-  rename _eclipse-platform_ to _eclipse_platform_45_
- add  _eclipse_platform_451_

But, I am unsure of the proper protocol and etiquette for renaming derivations, and I suspect that may be too much for this pull request.
