### PR TITLE
jq: build with oniguruma for regex support

### DIFF
--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, oniguruma}:
 let
   s = # Generated upstream information
   rec {
@@ -9,6 +9,7 @@ let
     sha256="0g29kyz4ykasdcrb0zmbrp2jqs9kv1wz9swx849i2d1ncknbzln4";
   };
   buildInputs = [
+    oniguruma
   ];
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
I installed `jq` earlier and was playing around with it, but found that some of its included functions make it fail and complain about not being compiled with the required libraries. With that hint and using [the homebrew formula](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/jq.rb) as a loose reference, this fixed the issue for me.

cc @7c6f434c 
