### PR TITLE
mousepad: fix the `Using the 'memory' GSettings backend` issue.

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad.nix
+++ b/pkgs/desktops/xfce/applications/mousepad.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, libxfce4util
-, gtk, gtksourceview, dbus, dbus_glib, makeWrapper }:
+, gtk, gtksourceview, dbus, dbus_glib, makeWrapper
+, dconf }:
 
 stdenv.mkDerivation rec {
   p_name  = "mousepad";
@@ -15,11 +16,13 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig intltool libxfce4util
       gtk gtksourceview dbus dbus_glib makeWrapper
+      dconf
     ];
 
   preFixup = ''
     wrapProgram "$out/bin/mousepad" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:${gtksourceview}/share"
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:${gtksourceview}/share" \
+      --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules"
   '';
 
   meta = {

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -6,6 +6,7 @@ callPackage = newScope (deps // xfce_self);
 
 deps = rec { # xfce-global dependency overrides should be here
   inherit (pkgs.gnome) libglade libwnck vte gtksourceview;
+  inherit (pkgs.gnome3) dconf;
   inherit (pkgs.perlPackages) URI;
 };
 


### PR DESCRIPTION
It means that settings couldn't be saved. The issue appeared
since upgrade to nixos 15.09 and fall as part of #4415.

Tested on nixos.
-  No longer has a stderr when running the application.
-  Settings are effectively saved.
