### PR TITLE
ipfs: Disable building with Go 1.4

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1686,6 +1686,7 @@ let
     owner  = "ipfs";
     repo   = "go-ipfs";
     sha256 = "0g80b65ysj995dj3mkh3lp4v616fzjl7bx2wf14mkxfri4gr5icb";
+    disabled = isGo14;
   };
 
   ldap = buildGoPackage rec {


### PR DESCRIPTION
As @domenkozar pointed out, `ipfs` will not build with `Go 1.4`.
However, building with `Go 1.5` works just fine. Thanks again for the
hints Domen!
