### PR TITLE
tidy-html5: fix missing dependency

### DIFF
--- a/pkgs/tools/text/tidy-html5/default.nix
+++ b/pkgs/tools/text/tidy-html5/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cmake, fetchFromGitHub, ... }:
+{ stdenv, lib, cmake, fetchFromGitHub, libxslt, ... }:
 
 stdenv.mkDerivation rec {
 
@@ -12,12 +12,13 @@ stdenv.mkDerivation rec {
     sha256 = "0hd4c23352r5lnh23mx137wb4mkxcjdrl1dy8kgghszik5fprs3s";
   };
 
-  buildInputs = [ cmake ];
+  buildInputs = [ cmake libxslt ];
 
   meta = with stdenv.lib; {
     description = "The granddaddy of HTML tools, with support for modern standards";
     homepage = "http://www.html-tidy.org/";
     license = licenses.w3c;
+    platforms = platforms.all;
     maintainers = with maintainers; [ edwtjo ];
   };
 


### PR DESCRIPTION
xsltproc is used during the build
