### PR TITLE
gist: 4.3.0 -> 4.4.2

### DIFF
--- a/pkgs/tools/text/gist/Gemfile.lock
+++ b/pkgs/tools/text/gist/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    gist (4.3.0)
+    gist (4.4.2)
 
 PLATFORMS
   ruby

--- a/pkgs/tools/text/gist/default.nix
+++ b/pkgs/tools/text/gist/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, bundlerEnv }:
 
-let version = "4.3.0";
+let version = "4.4.2";
 in bundlerEnv {
   name = "gist-${version}";
   gemfile = ./Gemfile;

--- a/pkgs/tools/text/gist/gemset.nix
+++ b/pkgs/tools/text/gist/gemset.nix
@@ -1,9 +1,9 @@
 {
   "gist" = {
-    version = "4.3.0";
+    version = "4.4.2";
     source = {
       type = "gem";
-      sha256 = "0az6l8nq433sszailr7kglh21l3gkcb11k7ag6668nyxxplm9rp0";
+      sha256 = "0lr4rywpm549llk0ypdpb3sjdpqw9snzwzqc3dggg8qn5wj69k81";
     };
   };
 }


### PR DESCRIPTION
One issue with bundlerEnv packages is that the Gemfile is installed in the root of the environment and conflicts with other bundlerEnv packages (bundix)  
