### PR TITLE
ffmpeg 2.8: init at 2.8.1

### DIFF
--- a/pkgs/development/libraries/ffmpeg/2.8.nix
+++ b/pkgs/development/libraries/ffmpeg/2.8.nix
@@ -1,0 +1,7 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "${branch}.1";
+  branch = "2.8";
+  sha256 = "1qk6g2h993i0wgs9d2p3ahdc5bqr03mp74bk6r1zj6pfinr5mvg2";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6229,10 +6229,13 @@ let
   ffmpeg_2_7 = callPackage ../development/libraries/ffmpeg/2.7.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
+  ffmpeg_2_8 = callPackage ../development/libraries/ffmpeg/2.8.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
   # Aliases
   ffmpeg_0 = ffmpeg_0_10;
   ffmpeg_1 = ffmpeg_1_2;
-  ffmpeg_2 = ffmpeg_2_7;
+  ffmpeg_2 = ffmpeg_2_8;
   ffmpeg = ffmpeg_2;
 
   ffmpeg-full = callPackage ../development/libraries/ffmpeg-full {


### PR DESCRIPTION
Built and run locally.

This commit adds a `ffmpeg 2.8` branch with the init version being
`2.8.1`. `ffmpeg` points to `ffmpeg 2.8`.

The changelog can be found here:
https://github.com/FFmpeg/FFmpeg/blob/master/Changelog
