### PR TITLE
goaccess: added geoip db

### DIFF
--- a/pkgs/tools/misc/goaccess/default.nix
+++ b/pkgs/tools/misc/goaccess/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, geoip, ncurses, glib }:
+{ stdenv, fetchurl, pkgconfig, geoipWithDatabase, ncurses, glib }:
 
 let
   version = "0.9.4";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig
-    geoip
+    geoipWithDatabase
     ncurses
     glib
   ];


### PR DESCRIPTION
fixes the following error:

```
Error Opening file /nix/store/l45z6kjxncrc40rhgkbpgqhi4xvfcjjj-geoip-1.6.2/share/GeoIP/GeoIP.dat
```
