### PR TITLE
python: lxml: 3.3.6 -> 3.4.4

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8689,19 +8689,22 @@ let
   };
 
   lxml = buildPythonPackage ( rec {
-    name = "lxml-3.3.6";
+    name = "lxml-3.4.4";
+    # Warning : as of nov. 9th, 2015, version 3.5.0b1 breaks a lot of things,
+    # more work is needed before upgrading
 
     src = pkgs.fetchurl {
       url = "http://pypi.python.org/packages/source/l/lxml/${name}.tar.gz";
-      md5 = "a804b36864c483fe7abdd7f493a0c379";
+      sha256 = "16a0fa97hym9ysdk3rmqz32xdjqmy4w34ld3rm3jf5viqjx65lxk";
     };
 
     buildInputs = with self; [ pkgs.libxml2 pkgs.libxslt ];
 
     meta = {
       description = "Pythonic binding for the libxml2 and libxslt libraries";
-      homepage = http://codespeak.net/lxml/index.html;
-      license = "BSD";
+      homepage = http://lxml.de;
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ sjourdois ];
     };
   });
 


### PR DESCRIPTION
I added a warning to not upgrade to 3.5.0b1 without checking that all packages depending on lxml still work. My first tests indicate that all are broken by the upgrade.
3.4.4 seems ok and is in debian testing.
