### PR TITLE
qt55: fix qtmultimedia gstreamer support

### DIFF
--- a/pkgs/development/libraries/qt-5/5.5/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtmultimedia.nix
@@ -1,4 +1,4 @@
-{ qtSubmodule, qtbase, qtdeclarative
+{ qtSubmodule, qtbase, qtdeclarative, pkgconfig
 , alsaLib, gstreamer, gst-plugins-base, libpulseaudio
 }:
 
@@ -6,6 +6,7 @@ qtSubmodule {
   name = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
   buildInputs = [
-    alsaLib gstreamer gst-plugins-base libpulseaudio
+    pkgconfig alsaLib gstreamer gst-plugins-base libpulseaudio
   ];
+  configureFlags = "GST_VERSION=1.0";
 }


### PR DESCRIPTION
Without this, configure will say:

  Checking for openal... no
  /tmp/nix-build-qtmultimedia-5.5.0.drv-0/qtmultimedia-opensource-src-5.5.0/qtmultimedia.pro:28:
  Variable GST_VERSION is not defined.
  Checking for resourcepolicy... no

And there may be application runtime errors like

  defaultServiceProvider::requestService(): no service found for - "org.qt-project.qt.camera"

After this fix, configure will say:

  Checking for openal... no
  Checking for gstreamer... yes
  Checking for gstreamer_photography... no
  Checking for gstreamer_encodingprofiles... yes
  Checking for gstreamer_appsrc... yes
  Checking for linux_v4l... yes
  Checking for resourcepolicy... no

And the above runtime error will not appear.

This fix is similar to 449b6028 ("qt5.multimedia: fix gstreamer
support."), except with Qt 5.5 we also need to set GST_VERSION.
