### PR TITLE
botocore: 1.1.10 -> 1.2.0

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -13,7 +13,7 @@ pythonPackages.buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    pythonPackages.botocore
+    pythonPackages.botocore_1_1_10
     pythonPackages.bcdoc
     pythonPackages.six
     pythonPackages.colorama

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1621,6 +1621,33 @@ let
   };
 
   botocore = buildPythonPackage rec {
+    version = "1.2.0";
+    name = "botocore-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/b/botocore/${name}.tar.gz";
+      sha256 = "0wj98fsiwqzy0i0zh86fx15sgdjkwqi6crxig6b4kvrckl8bkwjr";
+    };
+
+    propagatedBuildInputs =
+      [ self.dateutil
+        self.requests
+        self.jmespath
+      ];
+
+    buildInputs = [ self.docutils ];
+
+    meta = {
+      homepage = https://github.com/boto/botocore;
+
+      license = "bsd";
+
+      description = "A low-level interface to a growing number of Amazon Web Services";
+
+    };
+  };
+
+  botocore_1_1_10 = buildPythonPackage rec {
     version = "1.1.10";
     name = "botocore-${version}";
 


### PR DESCRIPTION
I tend to "upgrade" usages of `fetchurl` to `fetchzip`, but I saw that all packages in `Pythonpackages` use `fetchurl` so I guess there is some reason for that.

If not, let me know and I can change the pull request
