### PR TITLE
Drop obsolete "haskell-ng" and "haskellngPackages" aliases.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15448,8 +15448,6 @@ aliases = with self; rec {
   exfat-utils = exfat;                  # 2015-09-11
   firefoxWrapper = firefox-wrapper;
   fuse_exfat = exfat;                   # 2015-09-11
-  haskell-ng = haskell;                 # 2015-04-19
-  haskellngPackages = haskellPackages;  # 2015-04-19
   htmlTidy = html-tidy;  # added 2014-12-06
   inherit (haskell.compiler) jhc uhc;   # 2015-05-15
   inotifyTools = inotify-tools;


### PR DESCRIPTION
Haskell NG became the default implementation in Nixpkgs over half a year ago in commit c0c82ea2ebbcf0632260a931cf832cac1c8a014e. This means the "ng" names are obsolete and should no longer be used. They'll continue to function in the release-15.09 branch for the sake of backwards compatibility, but the master branch no longer supports them.
