### PR TITLE
fhs-env: symlink /usr/lib to libs for the main architecture

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -54,8 +54,8 @@ let
 
   etcProfile = nixpkgs.writeText "profile" ''
     export PS1='${name}-chrootenv:\u@\h:\w\$ '
-    export LOCALE_ARCHIVE='/usr/lib${if isMultiBuild then "64" else ""}/locale/locale-archive'
-    export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:/lib:/lib64
+    export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
+    export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
     export PATH='/usr/bin:/usr/sbin'
     ${profile}
   '';
@@ -129,7 +129,7 @@ let
   setupLibDirs_multi = ''
     mkdir -m0755 lib32
     mkdir -m0755 lib64
-    ln -s lib32 lib
+    ln -s lib64 lib
 
     # copy glibc stuff
     cp -rsHf ${staticUsrProfileTarget}/lib/32/* lib32/ && chmod u+w -R lib32/
@@ -149,6 +149,9 @@ let
     # copy gcc libs
     cp -rsHf ${chosenGcc.cc}/lib/*   lib32/
     cp -rsHf ${chosenGcc.cc}/lib64/* lib64/
+
+    # symlink 32-bit ld-linux.so
+    ln -s ${staticUsrProfileTarget}/lib/32/ld-linux.so.2 lib/
   '';
 
   setupLibDirs = if isTargetBuild then setupLibDirs_target

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -40,12 +40,10 @@ buildFHSUserEnv {
     ];
 
   extraBuildCommands = ''
-    [ -d lib64 ] && mv lib64/steam lib
-
     mkdir -p steamrt
 
     ln -s ../lib64/steam-runtime steamrt/amd64
-    ln -s ../lib/steam-runtime steamrt/i386
+    ln -s ../lib32/steam-runtime steamrt/i386
   '';
 
   profile = ''


### PR DESCRIPTION
This makes `/usr/lib` a symlink to `/usr/lib64` in multiarch environments. Additional care is required to place 32-bit `ld.so` into `/usr/lib`. Also did several cleanups w.r.t. the change.

Closes https://github.com/NixOS/nixpkgs/issues/10944

/cc @bjornfor 
