### PR TITLE
darwin: IOKit: add impure /usr/lib/libenergytrace.dylib

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/impure-deps.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/impure-deps.nix
@@ -12,6 +12,7 @@ rec {
   ];
   IOKit = [
     "/System/Library/Frameworks/IOKit.framework"
+    "/usr/lib/libenergytrace.dylib"
   ];
   JavaScriptCore = [
     "/System/Library/Frameworks/JavaScriptCore.framework"


### PR DESCRIPTION
This is required at least to nix-build '< nixpkgs >' -p go (which doesn't build for other reasons)
