### PR TITLE
ldap-client: don't break on test failures

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -26,6 +26,7 @@ in
     ./windowmaker.nix
     ./wmii.nix
     ./xmonad.nix
+    ./xinitrc.nix
     ./qtile.nix
     ./none.nix ];
 

--- a/nixos/modules/services/x11/window-managers/xinitrc.nix
+++ b/nixos/modules/services/x11/window-managers/xinitrc.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.xinitrc;
+in
+
+{
+  options = {
+    services.xserver.windowManager.xinitrc = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Run the users's .xinitrc";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "xinitrc";
+      start = ''
+        $HOME/.xinitrc &
+        waitPID=$!
+      '';
+    };
+  };
+}


### PR DESCRIPTION
ldap-client's tests are broken, don't break the build because of it
