### PR TITLE
byobu: 5.87 -> 5.98

### DIFF
--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchurl, ncurses, python, perl }:
+{ stdenv, fetchurl, ncurses, python, perl, textual-window-manager }:
 
 stdenv.mkDerivation rec {
-  name = "byobu-5.87";
+  version = "5.98";
+  name = "byobu-" + version;
 
   src = fetchurl {
-    url = "https://launchpad.net/byobu/trunk/5.87/+download/byobu_5.87.orig.tar.gz";
-    sha256 = "08v9y5hxb92caf5zp83fiq0jfwi167vw1ylf42s65x1ng8rvryqh";
+    url = "https://launchpad.net/byobu/trunk/${version}/+download/byobu_${version}.orig.tar.gz";
+    sha256 = "1s8nh4wbds1nh52i0d1hy1b308jjf4siwpq92lna1zh9ll4x71j5";
   };
 
   doCheck = true;
 
   buildInputs = [ python perl ];
+  propagatedBuildInputs = [ textual-window-manager ];
 
   meta = {
     homepage = https://launchpad.net/byobu/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -732,7 +732,10 @@ let
 
   bwm_ng = callPackage ../tools/networking/bwm-ng { };
 
-  byobu = callPackage ../tools/misc/byobu { };
+  byobu = callPackage ../tools/misc/byobu {
+    # Choices: [ tmux screen ];
+    textual-window-manager = tmux;
+  };
 
   bsh = fetchurl {
     url = http://www.beanshell.org/bsh-2.0b5.jar;


### PR DESCRIPTION
Make byobu depend on either tmux or screen. tmux is default, you can
use screen by changing textual-window-manager to screen.
