### PR TITLE
Update awscli Package to 1.9.6

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -2,14 +2,14 @@
 
 pythonPackages.buildPythonPackage rec {
   name = "awscli-${version}";
-  version = "1.7.47";
+  version = "1.9.6";
   namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     rev = version;
-    sha256 = "1955y1ar2mqzqgfngpwp8pc78wphh1qdgwwy0gs6i352jaqzkvwi";
+    sha256 = "08qclasxf8zdxwmngvynq9n5vv4nwdy68ma7wn7ji40bxmls37g2";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1621,12 +1621,12 @@ let
   };
 
   botocore = buildPythonPackage rec {
-    version = "1.1.10";
+    version = "1.3.6";
     name = "botocore-${version}";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/b/botocore/${name}.tar.gz";
-      sha256 = "0syj0m0l7k4wa0n9h7h8ywayjv9fgpn5wyzpdriws0j417y1zlyc";
+      sha256 = "260058fe4b8bc6512de930c0ef7869fad48f9a3995ca6a823ca73b63368c4015";
     };
 
     propagatedBuildInputs =


### PR DESCRIPTION
- Needed for apigateway interaction
- Requires botocore 1.3.6
