### PR TITLE
Neverwinter Nights: add the game

### DIFF
--- a/pkgs/applications/video/binkplayer/default.nix
+++ b/pkgs/applications/video/binkplayer/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, requireFile, p7zip, SDL, openalSoft }:
+
+let
+  deps = stdenv.lib.makeLibraryPath [ SDL openalSoft ];
+
+in stdenv.mkDerivation {
+  name = "BinkPlayer";
+
+  src = requireFile {
+    url = "http://www.radgametools.com/down/Bink/BinkLinuxPlayer.7z";
+    name = "BinkLinuxPlayer.7z";
+    sha256 = "04pa2bad81hw5nx6a5zh6ab0rmcdwfqh3ifh5n7fbly90hm9vfwh";
+  };
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    cd $out/bin
+    7z x $src
+    chmod +x BinkPlayer
+    patchelf \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      --set-rpath ${deps} \
+      BinkPlayer
+  '';
+
+  nativeBuildInputs = [ p7zip ];
+
+  meta = with stdenv.lib; {
+    description = "Play Bink files (or compiled Bink EXE files) from the command line";
+    homepage = "http://www.radgametools.com/bnkmain.htm";
+    license = licenses.unfree;
+    platforms = [ "i686-linux" ];
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/games/nwn/builder.sh
+++ b/pkgs/games/nwn/builder.sh
@@ -1,0 +1,169 @@
+source $stdenv/setup
+
+# Several variables
+export CC32="$CC -m32"
+export CC64="$CC"
+export CC="$CC32"
+
+# Extract gog setup
+ln -s $gogSetup setup.exe
+ln -s $gogData1 setup-1.bin
+ln -s $gogData2 setup-2.bin
+innoextract -e -m setup.exe
+
+# Extract Game Icons
+mkdir icons
+icotool -x -p 0 app/gfw_high.ico -o icons
+
+# Extract Kingmaker Files
+unzip $gogmods
+7z x KingmakerSetup.exe -xr0\!*PLUGINSDIR* -xr\!*.exe -xr\!*.dat -okingmakertmp
+
+# Create destination directory
+mkdir -p $out/nwn
+
+# Compile nw*
+nwcompile() {
+  cp -r ${!1} $1
+  chmod -R +w $1
+  patchShebangs $1
+  pushd $1
+  eval "$2"
+  sed -i \
+    -e "s|^\$machine = .*|\$machine = \"$system\";|" \
+    -e "s|-I/|-I/does-not-exist/|g" \
+    -e "s|-L/|-L/does-not-exist/|g" \
+    ./$1_install.pl
+  find -name \*.so -delete
+  ./$1_install.pl build
+  find -name \*.so -exec strip -s {} \;
+  install -m755 $1/$1.so $out/nwn/$1.so
+  popd
+}
+
+nwcompile nwmovies "
+  sed -i \
+    -e 's|^\$mplayer = .*|\$mplayer = \"\";|' \
+    -e 's|^\$plaympeg = .*|\$plaympeg = \"\";|' \
+    -e 's|^\$binkplayer = .*|\$binkplayer = \"$binkplayer/bin/BinkPlayer\";|' \
+    nwmovies/nwmovies.pl
+"
+nwcompile nwuser
+nwcompile nwmouse "sed -i 's|linux/user.h|sys/user.h|' nwmouse/nwmouse_cookie.c"
+nwcompile nwlogger "sed -i 's|linux/user.h|sys/user.h|' nwlogger/nwlogger_cookie.c"
+
+# Move game files to directory
+cp -r app/* $out/nwn
+
+# Extract Game Clients
+tar -zxvf $clientgold -C $out/nwn
+tar -zxvf $clienthotu -C $out/nwn
+
+# Install Kingmaker Files
+cp -r kingmakertmp/\$0/* $out/nwn
+
+# Extract Latest Patch
+tar -zxvf $clientpatch -C $out/nwn
+
+# Check the Installation
+pushd $out/nwn
+patchShebangs fixinstall
+./fixinstall
+popd
+
+# Remove Unneeded Files & Directories
+rm -r \
+  $out/nwn/SDL-* \
+  $out/nwn/*.dll \
+  $out/nwn/*.exe \
+  $out/nwn/ereg \
+  $out/nwn/utils \
+  $out/nwn/lib \
+  $out/nwn/premium/*.exe \
+  $out/nwn/miles/*.dll \
+  $out/nwn/fixinstall \
+  $out/nwn/nwn \
+  $out/nwn/dmclient
+
+# Install nwmovies Perl script
+install -D -m755 nwmovies/nwmovies.pl $out/nwn/nwmovies.pl
+
+# Install binkplayer binaries
+install -D -m755 nwmovies/nwmovies/binklib.so $out/nwn/nwmovies/binklib.so
+
+# Install libdis binaries for nwmovies
+install -D -m755 nwmovies/nwmovies/libdis/libdisasm.so $out/nwn/nwmovies/libdis/libdisasm.so
+
+# Install 64bit binaries if Arch64
+if [ "$system" = "x86_64-linux" ]; then
+  install -D -m755 nwuser/nwuser/nwuser64.so $out/nwn/nwuser64.so
+fi
+
+# Install libdis binaries for nwmouse
+install -D -m755 nwmouse/nwmouse/libdis/libdisasm.so $out/nwn/nwmouse/libdis/libdisasm.so
+
+# Install libdis binaries for nwlogger
+install -D -m755 nwlogger/nwlogger/libdis/libdisasm.so $out/nwn/nwlogger/libdis/libdisasm.so
+
+# Copy the original license file
+cp app/nwncdkey.ini $out/nwn/nwncdkey.ini
+
+# Install Cursors
+mkdir -p $out/nwn/nwmouse/cursors/
+tar -zxvf nwmouse/nwmouse/cursors.tar.gz -C $out/nwn/nwmouse/cursors/
+
+# Patch ELFs
+if [ "$system" = "x86_64-linux" ]; then
+  LD=$(cat $NIX_CC/nix-support/dynamic-linker-m32)
+else
+  LD=$(cat $NIX_CC/nix-support/dynamic-linker)
+fi
+
+find $out/nwn -name \*.so -exec patchelf \
+  --set-rpath "$deps" \
+  {} \;
+
+for i in $out/nwn/{nwmain,nwserver}; do
+  patchelf \
+    --set-interpreter "$LD" \
+    --set-rpath "$deps" \
+    "$i"
+done
+
+# Install Launcher (Client)
+mkdir -p $out/bin
+
+sed \
+  -e "s|@out@|$out|g" \
+  -e "s|@shell@|$SHELL|" \
+  $launcher > $out/bin/nwn
+chmod +x $out/bin/nwn
+
+cat >$out/bin/nwserver <<EOF
+#!$SHELL
+cd $out/nwn
+exec ./nwserver \"\$@\"
+EOF
+chmod +x $out/bin/nwserver
+
+# Install Desktop File
+mkdir -p $out/share/applications
+cat >$out/share/applications/nwn.desktop <<EOF
+[Desktop Entry]
+Encoding=UTF-8
+Name=Neverwinter Nights Diamond
+GenericName=Neverwinter Nights
+Comment=Play Neverwinter Nights Diamond
+Exec=$out/bin/nwn
+Icon=nwn
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=Qt;KDE;GNOME;Application;Game;
+EOF
+
+# Install Icon Files
+install -D -m644 icons/gfw_high_6_256x256x32.png $out/share/icons/hicolor/256x256/apps/nwn.png
+install -D -m644 icons/gfw_high_7_48x48x32.png $out/share/icons/hicolor/48x48/apps/nwn.png
+install -D -m644 icons/gfw_high_8_32x32x32.png $out/share/icons/hicolor/32x32/apps/nwn.png
+install -D -m644 icons/gfw_high_9_16x16x32.png $out/share/icons/hicolor/16x16/apps/nwn.png

--- a/pkgs/games/nwn/default.nix
+++ b/pkgs/games/nwn/default.nix
@@ -1,0 +1,93 @@
+{ stdenv, fetchurl, fetchgit, requireFile
+, perl, innoextract, unzip, p7zip, icoutils
+, libX11, libXcursor, libelf, SDL, SDL_gfx, mesa_glu
+, binkplayer
+}:
+
+stdenv.mkDerivation rec {
+  name = "nwn-gog-${version}";
+  version = "2.0.0.15";
+
+  inherit binkplayer;
+
+  gogSetup = requireFile {
+    name = "setup_nwn_diamond_${version}.exe";
+    url = "http://www.gog.com/game/neverwinter_nights_diamond_edition";
+    sha256 = "45852cf42a5df5cd214e77519b55bc45e49add9b029fefc58f3f4efc6ae772c1";
+  };
+
+  gogData1 = requireFile {
+    name = "setup_nwn_diamond_${version}-1.bin";
+    url = "http://www.gog.com/game/neverwinter_nights_diamond_edition";
+    sha256 = "4b535281a74fbb26f1f5752527906def370d1cc28ffde396b672fd74259f1c56";
+  };
+
+  gogData2 = requireFile {
+    name = "setup_nwn_diamond_${version}-2.bin";
+    url = "http://www.gog.com/game/neverwinter_nights_diamond_edition";
+    sha256 = "9b9d5ae7af6000ed4e3a6c13b36c6b16096814044dc50845094386a028cb8336";
+  };
+
+  gogmods = requireFile {
+    name = "nvn_KingmakerSetup.zip";
+    url = "http://www.gog.com/game/neverwinter_nights_diamond_edition";
+    sha256 = "a3fe832f4673a298fc29ffdc8957f9122a185321804170370a0d8f6c6a07f1aa";
+  };
+
+  clientgold = fetchurl {
+    url = "http://nwdownloads.bioware.com/neverwinternights/linux/gold/nwclientgold.tar.gz";
+    sha256 = "1wwm6gsjs94pr0g2x838p4qql7a5nf68h8d1yhz77jgnwb777ska";
+  };
+
+  clienthotu = fetchurl {
+    url = "http://nwdownloads.bioware.com/neverwinternights/linux/161/nwclienthotu.tar.gz";
+    sha256 = "1mygvzvqbfs704pgar87b27x53g9bb74kllvs1kb37ynmhdcwjha";
+  };
+
+  clientpatch = fetchurl {
+    url = "http://files.bioware.com/neverwinternights/updates/linux/169/English_linuxclient169_xp2.tar.gz";
+    sha256 = "0gvnk6bcd5qhsr8vm30dac0ybp0y3gndw66j01zyy9f0jlmmww89";
+  };
+
+  nwmouse = fetchgit {
+    url = "https://github.com/nwnlinux/nwmouse";
+    rev = "6df8b96f0dbf34d0c42511c3f0cdc11b71573aa0";
+    sha256 = "30f47cdae98a30260472c56c845d850b59fb608882f3444e3eeaaac2548a4729";
+  };
+
+  nwuser = fetchgit {
+    url = "https://github.com/nwnlinux/nwuser";
+    rev = "3fbbf546a8ba9cc1e35ba5a718018402baaa658d";
+    sha256 = "d1fb4b922d84e14587a80e594797039b3198186899d8a06627726a51d11dc7c2";
+  };
+
+  nwlogger = fetchgit {
+    url = "https://github.com/nwnlinux/nwlogger";
+    rev = "3bfa7aa58621584dc734cf2f856d49c76840dc14";
+    sha256 = "9506a986548e819154bfcd39e7e8aab907000ace2dd10d93c59e3eff8b362668";
+  };
+
+  nwmovies = fetchgit {
+    url = "https://github.com/nwnlinux/nwmovies";
+    rev = "61fb36453b4d99e710d1bd17b3fd68f529596617";
+    sha256 = "d2b892bf09eedaf8a145053d864c7ccf6ccfc1ca5e44a758c0ce1ac6ecaf8aea";
+  };
+
+  nativeBuildInputs = [ perl innoextract icoutils unzip p7zip ];
+
+  buildInputs = [ libX11 libXcursor libelf SDL ];
+
+  deps = stdenv.lib.makeLibraryPath (buildInputs ++ [ mesa_glu SDL_gfx ]);
+
+  launcher = ./launcher.sh;
+
+  builder = ./builder.sh;
+
+  meta = with stdenv.lib; {
+    description = "Neverwinter Nights, RPG from Bioware. GOG version";
+    homepage = "http://www.gog.com/game/neverwinter_nights_diamond_edition";
+    license = licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/games/nwn/launcher.sh
+++ b/pkgs/games/nwn/launcher.sh
@@ -1,0 +1,28 @@
+#!@shell@
+
+# Create user directory if it doesn't exist
+if [ ! -d "$HOME/.nwn/" ]; then
+    mkdir "$HOME/.nwn/"
+fi
+
+cd @out@/nwn
+
+export SDL_MOUSE_RELATIVE=0
+export SDL_VIDEO_X11_DGAMOUSE=0
+
+# Hardware Mouse Cursor
+export XCURSOR_PATH=@out@/nwn
+export XCURSOR_THEME=nwmouse
+
+# Add Miles Sound Codec to Library Path
+export LD_LIBRARY_PATH="./miles:$LD_LIBRARY_PATH"
+
+# Enable video scaling and optimizations
+[ -z "$BINK_SCALE" ] && export BINK_SCALE=1
+[ -z "$BINK_SMOOTH" ] && export BINK_SMOOTH=1
+
+# Per-User Settings Support, Hardware Mouse Cursor Support, Linux Movies Support, Client Side Chat Logging Support
+export LD_PRELOAD="./nwuser.so:./nwuser64.so:./nwmouse.so:./nwmovies.so:./nwlogger.so:$LD_PRELOAD"
+
+# Run Neverwinter Nights
+exec ./nwmain "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11013,6 +11013,8 @@ let
 
   bibletime = callPackage ../applications/misc/bibletime { };
 
+  binkplayer = callPackage_i686 ../applications/video/binkplayer { };
+
   bitlbee = callPackage ../applications/networking/instant-messengers/bitlbee { };
   bitlbee-plugins = callPackage ../applications/networking/instant-messengers/bitlbee/plugins.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13942,6 +13942,12 @@ let
 
   njam = callPackage ../games/njam { };
 
+  nwn = callPackage ../games/nwn {
+    inherit (pkgsi686Linux.xlibs) libX11 libXcursor;
+    inherit (pkgsi686Linux) libelf SDL SDL_gfx mesa_glu;
+    stdenv = stdenv_32bit;
+  };
+
   newtonwars = callPackage ../games/newtonwars { };
 
   odamex = callPackage ../games/odamex { };


### PR DESCRIPTION
This adds a native Linux version of Neverwinter Nights, with data files extracted from the GOG distribution and Linux client taken from official BioWare server. The packaging script was greatly inspired by https://aur.archlinux.org/packages/nwn-gog/ , but changed to patch necessary things for NixOS and also to improve several things.

NWN also requires `binkplayer` which was added too. Unfortunately, RAD Game Tools disallowed redistribution or automated download of the player (via e-mail), so a user needs to download it by himself.

The main concern of this (so this is a PR) is that this package may be too specific for Nixpkgs. On one hand, it's a native Linux (albeit proprietary) application with a very non-trivial building script. On the other, it's an old game which may be needed by only a few people, of not only by myself. What policy do we have to decide whether a particular package is suited for Nixpkgs?

P.S.: The build sequence is indeed very non-trivial, with very few documentation from BioWare on how actually to build a native distribution. Also the work done by the author of `nwmovies`, `nwuser` etc is enormous, he does a lot of binary patching of the game in memory, dynamically searching for key places using a disassembler library (!). Both the authors of those binary patches and of the source `nwn-gog` AUR package deserve credits ^_^.
