### PR TITLE
libssh2: fix shared library build under mingw

### DIFF
--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurlBoot, openssl, zlib}:
+{stdenv, fetchurlBoot, openssl, zlib, windows}:
 
 stdenv.mkDerivation rec {
   name = "libssh2-1.6.0";
@@ -9,6 +9,21 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ openssl zlib ];
+
+  crossAttrs = {
+    # link against cross-built libraries
+    configureFlags = [
+      "--with-openssl"
+      "--with-libssl-prefix=${openssl.crossDrv}"
+      "--with-libz"
+      "--with-libz-prefix=${zlib.crossDrv}"
+    ];
+  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+    # mingw needs import library of ws2_32 to build the shared library
+    preConfigure = ''
+      export LDFLAGS="-L${windows.mingw_w64}/lib $LDFLAGS"
+    '';
+  };
 
   meta = {
     description = "A client-side C library implementing the SSH2 protocol";


### PR DESCRIPTION
This patch fixes the mingw cross build (and possibly also other cross builds) of libssh2. The `windows.mingw_w64` libs are really necessary on the mingw target: without them, libtool silently builds a static library instead of a shared one because it cannot identify the dll import library for one of the built-in dlls on windows.

Tested with:

```
with import <nixpkgs> {
  crossSystem = {
    config = "i686-w64-mingw32";
    arch = "i686";
    libc = "msvcrt";
    platform = { };
    openssl.system = "mingw";
  };
};
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [ libssh2.crossDrv ];
  };
}
```
