### PR TITLE
rsnapshot service: Avoid package rebuild, create+use /etc/rsnapshot.conf

### DIFF
--- a/pkgs/tools/backup/rsnapshot/default.nix
+++ b/pkgs/tools/backup/rsnapshot/default.nix
@@ -1,20 +1,5 @@
-{ fetchurl, stdenv, writeText, perl, openssh, rsync, logger,
-  configFile ? "/etc/rsnapshot.conf" }:
+{ fetchurl, stdenv, writeText, perl, openssh, rsync, logger }:
 
-let patch = writeText "rsnapshot-config.patch" ''
---- rsnapshot-program.pl	2013-10-05 20:31:08.715991442 +0200
-+++ rsnapshot-program.pl	2013-10-05 20:31:42.496193633 +0200
-@@ -383,7 +383,7 @@
- 	}
- 	
- 	# set global variable
--	$config_file = $default_config_file;
-+	$config_file = '${configFile}';
- }
- 
- # accepts no args
-'';
-in
 stdenv.mkDerivation rec {
   name = "rsnapshot-1.4.1";
 
@@ -25,10 +10,12 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [perl openssh rsync logger];
 
+  configureFlags = [ "--sysconfdir=/etc --prefix=/" ];
+  makeFlags = [ "DESTDIR=$(out)" ];
+
   patchPhase = ''
     substituteInPlace "Makefile.in" --replace \
       "/usr/bin/pod2man" "${perl}/bin/pod2man"
-    patch -p0 <${patch}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Doing things this way seems a lot more sensible to me - it avoids an unnecessary package rebuild, and you can use commands like `rsnapshot configtest` and `rsnapshot du` without having to refer to `/etc/crontab` to determine the correct `rsnapshot` binary to use to do so...
