### PR TITLE
nsd: check config and zone files before start

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -113,6 +113,28 @@ nginx.override {
     extra X11 options for nvidia and nouveau drivers, respectively.
     </para>
   </listitem>
+
+  <listitem>
+    <para>
+    The option <option>services.nsd.zones.&lt;name&gt;.data</option> no
+    longer interpret the dollar sign ($) as a shell variable, as such it
+    should not be escaped anymore.  Thus the following zone data:
+    </para>
+    <programlisting>
+\$ORIGIN example.com.
+\$TTL 1800
+@       IN      SOA     ns1.vpn.nbp.name.      admin.example.com. (
+    </programlisting>
+    <para>
+    Should modified to look like the actual file expected by nsd:
+    </para>
+    <programlisting>
+$ORIGIN example.com.
+$TTL 1800
+@       IN      SOA     ns1.vpn.nbp.name.      admin.example.com. (
+    </programlisting>
+  </listitem>
+
 </itemizedlist>
 
 </section>

--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -45,6 +45,8 @@ in import ./make-test.nix ({ pkgs, ...} : {
         ns AAAA dead:beef::1
       '';
       services.nsd.zones."deleg.example.com.".data = ''
+        $ORIGIN deleg.example.com.
+        $TTL 3600
         @ SOA ns.example.com noc.example.com 666 7200 3600 1209600 3600
         @ A 9.8.7.6
         @ AAAA fedc::bbaa

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -55,6 +55,23 @@ rec {
       '';
 
 
+  # This is identical to symlinkJoin, except that in some cases program do
+  # not trust symbolic links for security reasons, so we have to copy files.
+  copyJoin = name: paths:
+    runCommand name { inherit paths; }
+      ''
+        set -x
+        mkdir -p $out
+        for i in $paths; do
+          (cd $i; find . -type d) | while read d; do
+            mkdir -p $out/$dir
+          done
+          (cd $i; find . \! -type d) | while read f; do
+            cp $i/$f $out/$f
+          done
+        done
+      '';
+
   # Make a package that just contains a setup hook with the given contents.
   makeSetupHook = { deps ? [], substitutions ? {} }: script:
     runCommand "hook" substitutions


### PR DESCRIPTION
This pull request is a followup and replacement to #9284. If this patch gets merged #9284 can be closed without merging. This patch is not squashed into one commit to preserve authorship.

The commit from #9284 makes the use of escaping in front of variable names unnecessary. This is how it should have been from the beginning, sadly the patch will break every NSD config out there.
The commit uses nsd-checkconf and nsd-checkzone to validate zone and config files before the systemd unit gets started. This will

1) make NSD fail on any errors. Till now it still started when errors where present in some zone files which made it possible to end up with a non working config without noticing it.
2) make deployments via nixops fail on zone errors.
3) fail if the old config style was detected. There is a special check to find out if escaped dollar signs are being used, in this case it shows an extra explanation besides NSDs error message.
4) give you a nice overview of you zone/config files and there check result in the journal.

I have also redone the deletion of old state files. The old way led to errors in some special cases.
All patches are tested and already integrated in my production systems without any problems.

@nbp @aszlig 

Update: The latest commit from https://github.com/NixOS/nixpkgs/pull/9284 which adds documentation of the new config behavior has now been added as well.
