### PR TITLE
nixos: introduce system.nixosLabel support

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -16,7 +16,7 @@ with lib;
     ];
 
   # ISO naming.
-  isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixosVersion}-${pkgs.stdenv.system}.iso";
+  isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixosLabel}-${pkgs.stdenv.system}.iso";
 
   isoImage.volumeID = substring 0 11 "NIXOS_ISO";
 

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -39,7 +39,7 @@ let
     DEFAULT boot
 
     LABEL boot
-    MENU LABEL NixOS ${config.system.nixosVersion}${config.isoImage.appendToMenuLabel}
+    MENU LABEL NixOS ${config.system.nixosLabel}${config.isoImage.appendToMenuLabel}
     LINUX /boot/bzImage
     APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
     INITRD /boot/initrd

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -30,6 +30,29 @@ in
       '';
     };
 
+    nixosLabel = mkOption {
+      type = types.str;
+      description = ''
+        NixOS version name to be used in the names of generated
+        outputs and boot labels.
+
+        If you ever wanted to influence the labels in your GRUB menu,
+        this is option is for you.
+
+        Can be set directly or with <envar>NIXOS_LABEL</envar>
+        environment variable for <command>nixos-rebuild</command>,
+        e.g.:
+
+        <screen>
+        #!/bin/sh
+        today=`date +%Y%m%d`
+        branch=`(cd nixpkgs ; git branch 2>/dev/null | sed -n '/^\* / { s|^\* ||; p; }')`
+        revision=`(cd nixpkgs ; git rev-parse HEAD)`
+        export NIXOS_LABEL="$today.$branch-''${revision:0:7}"
+        nixos-rebuild switch</screen>
+      '';
+    };
+
     nixosVersion = mkOption {
       internal = true;
       type = types.str;
@@ -75,8 +98,9 @@ in
   config = {
 
     system = {
-      # This is set here rather than up there so that changing this
-      # env variable will not rebuild the manual
+      # These defaults are set here rather than up there so that
+      # changing them would not rebuild the manual
+      nixosLabel   = mkDefault (maybeEnv "NIXOS_LABEL" cfg.nixosVersion);
       nixosVersion = mkDefault (maybeEnv "NIXOS_VERSION" (cfg.nixosRelease + cfg.nixosVersionSuffix));
 
       # Note: code names must only increase in alphabetical order.

--- a/nixos/modules/services/ttys/agetty.nix
+++ b/nixos/modules/services/ttys/agetty.nix
@@ -2,6 +2,13 @@
 
 with lib;
 
+let
+
+  autologinArg = optionalString (config.services.mingetty.autologinUser != null) "--autologin ${config.services.mingetty.autologinUser}";
+  gettyCmd = extraArgs: "@${pkgs.utillinux}/sbin/agetty agetty --login-program ${pkgs.shadow}/bin/login ${autologinArg} ${extraArgs}";
+
+in
+
 {
 
   ###### interface
@@ -21,9 +28,9 @@ with lib;
 
       greetingLine = mkOption {
         type = types.str;
-        default = ''<<< Welcome to NixOS ${config.system.nixosVersion} (\m) - \l >>>'';
         description = ''
           Welcome line printed by mingetty.
+          The default shows current NixOS version label, machine type and tty.
         '';
       };
 
@@ -55,10 +62,11 @@ with lib;
 
   ###### implementation
 
-  config = let
-    autologinArg = optionalString (config.services.mingetty.autologinUser != null) "--autologin ${config.services.mingetty.autologinUser}";
-    gettyCmd = extraArgs: "@${pkgs.utillinux}/sbin/agetty agetty --login-program ${pkgs.shadow}/bin/login ${autologinArg} ${extraArgs}";
-  in {
+  config = {
+    # Note: this is set here rather than up there so that changing
+    # nixosLabel would not rebuild manual pages
+    services.mingetty.greetingLine = mkDefault ''<<< Welcome to NixOS ${config.system.nixosLabel} (\m) - \l >>>'';
+
     systemd.services."getty@" =
       { serviceConfig.ExecStart = gettyCmd "--noclear --keep-baud %I 115200,38400,9600 $TERM";
         restartIfChanged = false;
@@ -81,7 +89,7 @@ with lib;
       { serviceConfig.ExecStart = gettyCmd "--noclear --keep-baud console 115200,38400,9600 $TERM";
         serviceConfig.Restart = "always";
         restartIfChanged = false;
-	enable = mkDefault config.boot.isContainer;
+        enable = mkDefault config.boot.isContainer;
       };
 
     environment.etc = singleton

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -67,7 +67,7 @@ let
 
       echo -n "$configurationName" > $out/configuration-name
       echo -n "systemd ${toString config.systemd.package.interfaceVersion}" > $out/init-interface-version
-      echo -n "$nixosVersion" > $out/nixos-version
+      echo -n "$nixosLabel" > $out/nixos-version
       echo -n "$system" > $out/system
 
       mkdir $out/fine-tune
@@ -101,7 +101,7 @@ let
     if [] == failed then pkgs.stdenv.mkDerivation {
       name = let hn = config.networking.hostName;
                  nn = if (hn != "") then hn else "unnamed";
-          in "nixos-system-${nn}-${config.system.nixosVersion}";
+          in "nixos-system-${nn}-${config.system.nixosLabel}";
       preferLocalBuild = true;
       allowSubstitutes = false;
       buildCommand = systemBuilder;
@@ -115,7 +115,7 @@ let
         config.system.build.installBootLoader
         or "echo 'Warning: do not know how to make this configuration bootable; please enable a boot loader.' 1>&2; true";
       activationScript = config.system.activationScripts.script;
-      nixosVersion = config.system.nixosVersion;
+      nixosLabel = config.system.nixosLabel;
 
       configurationName = config.boot.loader.grub.configurationName;
 

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -83,7 +83,7 @@ addEntry() {
     timestampEpoch=$(stat -L -c '%Z' $path)
 
     timestamp=$(date "+%Y-%m-%d %H:%M" -d @$timestampEpoch)
-    nixosVersion="$(cat $path/nixos-version)"
+    nixosLabel="$(cat $path/nixos-version)"
     extraParams="$(cat $path/kernel-params)"
 
     echo
@@ -91,7 +91,7 @@ addEntry() {
     if [ "$tag" = "default" ]; then
         echo "  MENU LABEL NixOS - Default"
     else
-        echo "  MENU LABEL NixOS - Configuration $tag ($timestamp - $nixosVersion)"
+        echo "  MENU LABEL NixOS - Configuration $tag ($timestamp - $nixosLabel)"
     fi
     echo "  LINUX ../nixos/$(basename $kernel)"
     echo "  INITRD ../nixos/$(basename $initrd)"

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -26,7 +26,7 @@ in
               ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -O vpc $diskImage $out/disk.vhd
               rm $diskImage
             '';
-          diskImageBase = "nixos-image-${config.system.nixosVersion}-${pkgs.stdenv.system}.raw";
+          diskImageBase = "nixos-image-${config.system.nixosLabel}-${pkgs.stdenv.system}.raw";
           buildInputs = [ pkgs.utillinux pkgs.perl ];
           exportReferencesGraph =
             [ "closure" config.system.build.toplevel ];

--- a/nixos/modules/virtualisation/brightbox-image.nix
+++ b/nixos/modules/virtualisation/brightbox-image.nix
@@ -26,7 +26,7 @@ in
               rm $diskImageBase
               popd
             '';
-          diskImageBase = "nixos-image-${config.system.nixosVersion}-${pkgs.stdenv.system}.raw";
+          diskImageBase = "nixos-image-${config.system.nixosLabel}-${pkgs.stdenv.system}.raw";
           buildInputs = [ pkgs.utillinux pkgs.perl ];
           exportReferencesGraph =
             [ "closure" config.system.build.toplevel ];

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -30,7 +30,7 @@ in
               rm $out/disk.raw
               popd
             '';
-          diskImageBase = "nixos-image-${config.system.nixosVersion}-${pkgs.stdenv.system}.raw";
+          diskImageBase = "nixos-image-${config.system.nixosLabel}-${pkgs.stdenv.system}.raw";
           buildInputs = [ pkgs.utillinux pkgs.perl ];
           exportReferencesGraph =
             [ "closure" config.system.build.toplevel ];

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -44,8 +44,8 @@ in {
 
     system.build.virtualBoxOVA = pkgs.runCommand "virtualbox-ova"
       { buildInputs = [ pkgs.linuxPackages.virtualbox ];
-        vmName = "NixOS ${config.system.nixosVersion} (${pkgs.stdenv.system})";
-        fileName = "nixos-image-${config.system.nixosVersion}-${pkgs.stdenv.system}.ova";
+        vmName = "NixOS ${config.system.nixosLabel} (${pkgs.stdenv.system})";
+        fileName = "nixos-image-${config.system.nixosLabel}-${pkgs.stdenv.system}.ova";
       }
       ''
         echo "creating VirtualBox VM..."


### PR DESCRIPTION
This patch introduces an `nixosLabel` option that does all you'd want from secure and cheap to modify `nixosVersion` option (cf. commit messages).

E.g. it allows this:

``` shell
#!/bin/sh
today=`date +%Y%m%d`
branch=`(cd nixpkgs ; git branch 2>/dev/null | sed -n '/^\* / { s|^\* ||; p; }')`
revision=`(cd nixpkgs ; git rev-parse HEAD)`
export NIXOS_LABEL="$today.$branch-${revision:0:7}"
nixos-rebuild switch
```

which would generate actually useful GRUB menu entries (I'd say this is so useful that this piece of code should be integrated into `nixos-rebuild` even, but I'm not sure how one is to marry this with channels).
