### PR TITLE
ghcjs: update comment on generating built-in pkg list

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -15,7 +15,7 @@ self: super: {
 
   # This is the list of packages that are built into a booted ghcjs installation
   # It can be generated with the command:
-  # nix-shell '<nixpkgs>' -A pkgs.haskellPackages_ghcjs.ghc --command "ghcjs-pkg list | sed -n 's/^    \(.*\)-\([0-9.]*\)$/\1_\2/ p' | sed 's/\./_/g' | sed 's/-\(.\)/\U\1/' | sed 's/^\([^_]*\)\(.*\)$/\1 = null;/'"
+  # nix-shell -p haskell.packages.ghcjs.ghc --command "ghcjs-pkg list | sed -n 's/^    \(.*\)-\([0-9.]*\)$/\1_\2/ p' | sed 's/\./_/g' | sed 's/-\(.\)/\U\1/' | sed 's/^\([^_]*\)\(.*\)$/\1 = null;/'"
   Cabal = null;
   aeson = null;
   array = null;


### PR DESCRIPTION
Just changing instructions in comment, doesn't affect code.

Should we do `import (runCommand ...)` to automate this?
