### PR TITLE
Change argument --port to --listen in nix-serve.nix

### DIFF
--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -56,7 +56,7 @@ in
 
       serviceConfig = {
         ExecStart = "${pkgs.nix-serve}/bin/nix-serve " +
-          "--port ${cfg.bindAddress}:${toString cfg.port} ${cfg.extraParams}";
+          "--listen ${cfg.bindAddress}:${toString cfg.port} ${cfg.extraParams}";
         User = "nix-serve";
         Group = "nogroup";
       };


### PR DESCRIPTION
According to nix-serve manual, it is recommended to use --listen instead.
