### PR TITLE
fix: ihaskell's and xmonad's dependence on haskell-ng

### DIFF
--- a/nixos/modules/services/misc/ihaskell.nix
+++ b/nixos/modules/services/misc/ihaskell.nix
@@ -22,9 +22,9 @@ in
       };
 
       haskellPackages = mkOption {
-        default = pkgs.haskellngPackages;
-        defaultText = "pkgs.haskellngPackages";
-        example = literalExample "pkgs.haskell-ng.packages.ghc784";
+        default = pkgs.haskellPackages;
+        defaultText = "pkgs.haskellPackages";
+        example = literalExample "pkgs.haskell.packages.ghc784";
         description = ''
           haskellPackages used to build IHaskell and other packages.
           This can be used to change the GHC version used to build

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -20,9 +20,9 @@ in
       };
 
       haskellPackages = mkOption {
-        default = pkgs.haskellngPackages;
-        defaultText = "pkgs.haskellngPackages";
-        example = literalExample "pkgs.haskell-ng.packages.ghc784";
+        default = pkgs.haskellPackages;
+        defaultText = "pkgs.haskellPackages";
+        example = literalExample "pkgs.haskell.packages.ghc784";
         description = ''
           haskellPackages used to build Xmonad and other packages.
           This can be used to change the GHC version used to build


### PR DESCRIPTION
services weren't fixed by 2c296db845eef13a687ea8aae8f349592d56e45e, or at an earlier commit

these were the last remainders, as
`grep -ir haskellng .`
or
`grep -ir haskell-ng .`
didn't return anything else
