### PR TITLE
lighttpd: fix mod_rewrite appearing twice

### DIFF
--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -44,7 +44,6 @@ let
     "mod_flv_streaming"
     "mod_magnet"
     "mod_mysql_vhost"
-    "mod_rewrite"
     "mod_scgi"
     "mod_setenv"
     "mod_trigger_b4_dl"


### PR DESCRIPTION
mod_rewrite was included twice by the exact mechanism that prevents multiple inclusions.
