### PR TITLE
guake: init at 0.8.3

### DIFF
--- a/pkgs/applications/misc/guake/default.nix
+++ b/pkgs/applications/misc/guake/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchurl, lib
+, pkgconfig, libtool, intltool, makeWrapper
+, dbus, gtk2, gconf, python2, python2Packages, libutempter, vte, keybinder, gnome2, gnome3 }:
+
+with lib;
+
+let inputs = [ dbus gtk2 gconf python2 libutempter vte keybinder gnome3.gnome_common ];
+    pySubDir = "lib/${python2.libPrefix}/site-packages";
+    pyPath = makeSearchPath pySubDir (attrVals [ "dbus" "notify" "pyGtkGlade" "pyxdg" ] python2Packages ++ [ gnome2.gnome_python ]);
+ in stdenv.mkDerivation rec {
+  name = "guake-${version}";
+  version = "0.8.3";
+
+  src = fetchurl {
+    url = "https://github.com/Guake/guake/archive/${version}.tar.gz";
+    sha256 = "1lbmdz3i9a97840h8239s360hd37nmhy3hs6kancxbzl1512ak1y";
+  };
+
+  nativeBuildInputs = [ pkgconfig libtool intltool makeWrapper ];
+
+  buildInputs = inputs ++ (with python2Packages; [ pyGtkGlade pyxdg ]);
+
+  patchPhase = ''
+    patchShebangs .
+  '';
+
+  configureScript = "./autogen.sh";
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--disable-schemas-install"
+  ];
+
+  installFlags = [
+    # Configuring the installation to not install gconf schemas is not always supported,
+    # therefore gconftool-2 has this variable, which will make gconftool-2 not update any of the databases.
+    "GCONF_DISABLE_MAKEFILE_SCHEMA_INSTALL=1"
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/gconf/schemas
+    cp data/guake.schemas $out/share/gconf/schemas
+  '';
+
+  postFixup = ''
+    for bin in $out/bin/{guake,guake-prefs}; do
+      substituteInPlace $bin \
+        --replace '/usr/bin/env python2' ${python2}/bin/python2
+      wrapProgram $bin \
+        --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+        --prefix LD_LIBRARY_PATH : ${makeLibraryPath inputs} \
+        --prefix PYTHONPATH : "$out/${pySubDir}:${pyPath}:$PYTHONPATH"
+    done
+  '';
+
+  meta = {
+    description = "Drop-down terminal for GNOME";
+    homepage = http://guake-project.org;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/development/libraries/libutempter/default.nix
+++ b/pkgs/development/libraries/libutempter/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, lib, glib }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "libutempter-${version}";
+  version = "1.1.6";
+
+  src = fetchurl {
+    url = "http://archive.ubuntu.com/ubuntu/pool/main/libu/libutempter/libutempter_${version}.orig.tar.bz2";
+    sha256 = "15y3xbgznjxnfmix4xg3bwmqdvghdw7slbhazb0ybmyf65gmd65q";
+  };
+
+  buildInputs = [ glib ];
+
+  installFlags = [
+    "libdir=\${out}/lib"
+    "libexecdir=\${out}/lib"
+    "includedir=\${out}/include"
+    "mandir=\${out}/share/man"
+  ];
+
+  meta = {
+    description = "Interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7503,6 +7503,8 @@ let
 
   libusbmuxd = callPackage ../development/libraries/libusbmuxd { };
 
+  libutempter = callPackage ../development/libraries/libutempter { };
+
   libunwind = if stdenv.isDarwin
     then darwin.libunwind
     else callPackage ../development/libraries/libunwind { };
@@ -11834,6 +11836,11 @@ let
 
   gtk2fontsel = callPackage ../applications/misc/gtk2fontsel {
     inherit (gnome2) gtk;
+  };
+
+  guake = callPackage ../applications/misc/guake {
+    gconf = gnome.GConf;
+    vte = gnome.vte.override { pythonSupport = true; };
   };
 
   guitone = callPackage ../applications/version-management/guitone {


### PR DESCRIPTION
After starting Guake it will give the error message "Guake can not init! Gconf Error. Have you installed guake.schemas properly?", which will have to be resolved manually, because I have not found a way to automate this, without being impure.

If you have Guake installed, you can use `nix-build -A gnome3.guake` to get the path to the build directory in the nix store, which then can be used in the following command to install the schemas file of Guake:
gconftool-2 --install-schema-file /path/returned/by/nix-build/share/gconf/schemas/guake.schemas

It can be removed again by the following command:
gconftool-2 --recursive-unset /apps/guake
