### PR TITLE
webfs: init at 1.21

### DIFF
--- a/pkgs/servers/http/webfs/default.nix
+++ b/pkgs/servers/http/webfs/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, openssl, shared_mime_info }:
+stdenv.mkDerivation rec {
+  name = "webfs-${version}";
+  version = "1.21";
+
+  src = fetchurl {
+    url = "https://www.kraxel.org/releases/webfs/${name}.tar.gz";
+    sha256 = "98c1cb93473df08e166e848e549f86402e94a2f727366925b1c54ab31064a62a";
+  };
+
+  patches = [ ./ls.c.patch ];
+
+  buildInputs = [ openssl ];
+
+  makeFlags = [
+    "mimefile=${shared_mime_info}/share/mime/globs"
+    "prefix=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "HTTP server for purely static content";
+    homepage    = http://linux.bytesex.org/misc/webfs.html;
+    license     = licenses.gpl2;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/servers/http/webfs/ls.c.patch
+++ b/pkgs/servers/http/webfs/ls.c.patch
@@ -1,0 +1,13 @@
+# Source: homebrew
+# https://raw.githubusercontent.com/Homebrew/patches/0518a6d1/webfs/patch-ls.c
+--- ./ls.c.orig	Fri Oct 15 14:20:50 2004
++++ ./ls.c	Fri Oct 15 14:21:13 2004
+@@ -160,7 +160,7 @@
+     return buf;
+ }
+ 
+-#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
++#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__APPLE__)
+ static void strmode(mode_t mode, char *dest)
+ {
+     static const char *rwx[] = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15351,6 +15351,8 @@ let
 
   wcalc = callPackage ../applications/misc/wcalc { };
 
+  webfs = callPackage ../servers/http/webfs { };
+
   wine = callPackage ../misc/emulators/wine {
     wineRelease = config.wine.release or "stable";
     wineBuild = config.wine.build or "wine32";


### PR DESCRIPTION
A small web server to serve local static file. Useful when toying with single-page apps (or testing the nixos-homepage rendering)
