### PR TITLE
future proof the wireshark source path

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   name = "wireshark-${variant}-${version}";
 
   src = fetchurl {
-    url = "http://www.wireshark.org/download/src/wireshark-${version}.tar.bz2";
+    url = "http://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.bz2";
     sha256 = "0b7rc1l1gvzcz7gfa6g7pcn32zrcfiqjx0rxm6cg3q1cwwa1qjn7";
   };
 


### PR DESCRIPTION
the src/ directory only has the release version, so the ebuild breaks upon every release

the all-versions sub-dir won't have the same problem
