### PR TITLE
platforms.nix: Use bcm2835_defconfig for RPi kernelHeadersBaseConfig

### DIFF
--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -134,7 +134,7 @@ rec {
   raspberrypi = {
     name = "raspberrypi";
     kernelMajor = "2.6";
-    kernelHeadersBaseConfig = "kirkwood_defconfig";
+    kernelHeadersBaseConfig = "bcm2835_defconfig";
     kernelBaseConfig = "bcmrpi_defconfig";
     kernelArch = "arm";
     kernelAutoModules = false;


### PR DESCRIPTION
kirkwood_defconfig was removed in the 3.17 kernel release, so
kernelHeadersBaseConfig needs to be changed in order to build
any Raspberry Pi stuff against linuxHeaders_3_18 (which has been the
default since the systemd 227 merge).
