### PR TITLE
pipelight: Add support for 32 bit linux via #9000

### DIFF
--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchurl, fetchgit, autoconf, automake, wineStaging, perl, xorg
-  , gnupg, gcc_multi, mesa, curl, bash, cacert, cabextract, utillinux, attr
-  }:
+{ stdenv, fetchurl, bash, cabextract, curl, gnupg, libX11, mesa, perl, wineStaging
+ }:
 
 let
   wine_custom = wineStaging;
@@ -19,13 +18,14 @@ in stdenv.mkDerivation rec {
     sha256 = "1i440rf22fmd2w86dlm1mpi3nb7410rfczc0yldnhgsvp5p3sm5f";
   };
 
-  buildInputs = [ wine_custom xorg.libX11 gcc_multi mesa curl ];
+  buildInputs = [ wine_custom libX11 mesa curl ];
+
   propagatedbuildInputs = [ curl cabextract ];
 
   patches = [ ./pipelight.patch ];
 
   configurePhase = ''
-    patchShebangs . 
+    patchShebangs .
     ./configure \
       --prefix=$out \
       --moz-plugin-path=$out/${mozillaPluginPath} \
@@ -56,7 +56,7 @@ in stdenv.mkDerivation rec {
     homepage = "http://pipelight.net/";
     license = with stdenv.lib.licenses; [ mpl11 gpl2 lgpl21 ];
     description = "A wrapper for using Windows plugins in Linux browsers";
-    maintainers = with stdenv.lib.maintainers; [skeidel];
+    maintainers = with stdenv.lib.maintainers; [ skeidel ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit, autoconf, automake, wineStaging, perl, xlibs
-  , gnupg, gcc_multi, mesa, curl, bash, cacert, cabextract, utillinux, attr
+  , gnupg, stdenv_32bit, mesa, curl, bash, cacert, cabextract, utillinux, attr
   }:
 
 let
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1i440rf22fmd2w86dlm1mpi3nb7410rfczc0yldnhgsvp5p3sm5f";
   };
 
-  buildInputs = [ wine_custom xlibs.libX11 gcc_multi mesa curl ];
+  buildInputs = [ wine_custom xlibs.libX11 stdenv_32bit.cc mesa curl ];
   propagatedbuildInputs = [ curl cabextract ];
 
   patches = [ ./pipelight.patch ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7970,6 +7970,7 @@ let
   physfs = callPackage ../development/libraries/physfs { };
 
   pipelight = callPackage ../tools/misc/pipelight {
+    stdenv = stdenv_32bit;
     wineStaging = pkgsi686Linux.wineStaging;
   };
 


### PR DESCRIPTION
This is an update to #9000 (sorry for the extra PR, I don't know if there's a cleaner way to suggest changes via github). I've removed some inputs which don't seem to be used, passed in stdenv_32bit via all-packages.nix and tried to test it a bit. It seems to do something (a window pops up when I start firefox after enabling e.g. widevine). But examples I found didn't seem to work:
- http://www.iis.net/media/experiencesmoothstreaming1080p
- http://pipelight.net/cms/plugin-widevine.html

The patch also seems to be outdated e.g. 

```
$ pipelight-plugin --system-check
/home/goibhniu/.nix-profile/bin/pipelight-plugin: line 424: /usr/bin/id: No such file or directory
```

any ideas @jraygauthier, @nathanielbaxter?
