### PR TITLE
Fix build of gpsbabel on i686

### DIFF
--- a/pkgs/applications/misc/gpsbabel/default.nix
+++ b/pkgs/applications/misc/gpsbabel/default.nix
@@ -20,7 +20,10 @@ stdenv.mkDerivation rec {
     But FOP isn't packaged yet.  */
 
   preConfigure = "cd gpsbabel";
-  configureFlags = [ "--with-zlib=system" ];
+  configureFlags = [ "--with-zlib=system" ]
+    # Floating point behavior on i686 causes test failures. Preventing
+    # extended precision fixes this problem.
+    ++ stdenv.lib.optional stdenv.isi686 "CXXFLAGS=-ffloat-store";
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/applications/misc/gpsbabel/default.nix
+++ b/pkgs/applications/misc/gpsbabel/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     # extended precision fixes this problem.
     ++ stdenv.lib.optional stdenv.isi686 "CXXFLAGS=-ffloat-store";
 
+  enableParallelBuilding = true;
+
   doCheck = true;
   preCheck = ''
     patchShebangs testo


### PR DESCRIPTION
The 1.5.2 version of gpsbabel turns out to produce test errors on the i686 platform. This fixes the build by changing the floating point precision, this solution is inspired by the solution used by Debian.

Also enable parallel building.
