### PR TITLE
terminal-notifier: Pass arguments in wrapper script

### DIFF
--- a/pkgs/applications/misc/terminal-notifier/default.nix
+++ b/pkgs/applications/misc/terminal-notifier/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     cp -r terminal-notifier.app $out/Applications
     cat >$out/bin/terminal-notifier <<EOF
     cd $out/Applications/terminal-notifier.app
-    exec ./Contents/MacOS/terminal-notifier
+    exec ./Contents/MacOS/terminal-notifier "\$@"
     EOF
     chmod +x $out/bin/terminal-notifier
   '';


### PR DESCRIPTION
Calling terminal-notifier command always prints the help output. Pass the arguments to fix this.
