### PR TITLE
x3270: init at 3.4ga9

### DIFF
--- a/pkgs/applications/misc/x3270/default.nix
+++ b/pkgs/applications/misc/x3270/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchgit, autoconf, x11, bdftopcf, mkfontdir, ncurses, tcl,
+{ stdenv, fetchurl, autoconf, x11, bdftopcf, mkfontdir, ncurses, tcl,
   libXaw }:
 
 stdenv.mkDerivation {
   name = "x3270-3.4ga9";
-  src = fetchgit {
-    url = git://git.code.sf.net/p/x3270/code;
-    rev = "refs/tags/3.4ga9";
-    sha256 = "a9e0cf49862d9746e7a273e00a66bbd053cf38c3ed816d6ace19af597576743f";
+
+  src = fetchurl {
+    url = mirror://sourceforge/x3270/suite3270-3.4ga9-src.tgz;
+    sha256 = "07iwv4j4d2n7f6iffv2xfi1lyp4vr0m9qw40pidw15h1jczxgps9";
   };
 
   patches = [ ./repair-interpreter.patch ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ autoconf x11 bdftopcf mkfontdir ncurses tcl libXaw];
   
-  preConfigure = "make -f Makefile.aux prepare";
+  preConfigure = "make -f Makefile.aux prepare"; # TODO possibly unneeded with tarball
   configureFlags = "--enable-unix"; # TODO only build part of the tools
   preBuild = "make depend";
   installTargets = "install"; # TODO install.man target fails

--- a/pkgs/applications/misc/x3270/default.nix
+++ b/pkgs/applications/misc/x3270/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, autoconf, x11, bdftopcf, mkfontdir, ncurses, tcl,
+  libXaw }:
+
+stdenv.mkDerivation {
+  name = "x3270-3.4ga9";
+  src = fetchgit {
+    url = git://git.code.sf.net/p/x3270/code;
+    rev = "refs/tags/3.4ga9";
+    sha256 = "a9e0cf49862d9746e7a273e00a66bbd053cf38c3ed816d6ace19af597576743f";
+  };
+
+  patches = [ ./repair-interpreter.patch ];
+  
+  meta = {
+    homepage = http://x3270.bgp.nu/index.html;
+    description = "An IBM 3270 terminal emulator for the X Window System";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+  };
+
+  buildInputs = [ autoconf x11 bdftopcf mkfontdir ncurses tcl libXaw];
+  
+  preConfigure = "make -f Makefile.aux prepare";
+  configureFlags = "--enable-unix"; # TODO only build part of the tools
+  preBuild = "make depend";
+  installTargets = "install"; # TODO install.man target fails
+}
+

--- a/pkgs/applications/misc/x3270/repair-interpreter.patch
+++ b/pkgs/applications/misc/x3270/repair-interpreter.patch
@@ -1,0 +1,22 @@
+From 5c89e4ad7ae080aea69e98c45233b3b2b7627d98 Mon Sep 17 00:00:00 2001
+From: Daniel Jour <Daniel.Oertwig@gmail.com>
+Date: Sat, 14 Nov 2015 19:55:46 +0100
+Subject: [PATCH] Repaired defect interpreter of m4man
+
+---
+ Common/m4man | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Common/m4man b/Common/m4man
+index 4b4e6dd..070d256 100755
+--- a/Common/m4man
++++ b/Common/m4man
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ # generate a man page or html man page from m4 source
+ function usage()
+ {
+-- 
+2.5.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13637,6 +13637,8 @@ let
 
   xterm = callPackage ../applications/misc/xterm { };
 
+  x3270 = callPackage ../applications/misc/x3270 { };
+
   finalterm = callPackage ../applications/misc/finalterm { };
 
   roxterm = callPackage ../applications/misc/roxterm {


### PR DESCRIPTION
I added a nix expression to build the x3270 IBM 3270 terminal emulator, to be found there:

http://x3270.bgp.nu/index.html

I packaged the current stable version (3.4ga9 stable (23. October 2015), according to their downloads page). Though I pull the source code from the git repository instead of the provided tar balls. A small patch to fix the interpreter of an utility bash script was needed.

Actually this package now provides multiple binaries. One could add support to only build a subset of these binaries (and thus removing tcl, x dependencies). Also there are no man pages, because the respective install target fails and I don't have the time to investigate further.

As for testing I'm successfully running the applications on my laptop (NixOS on x86_64), using them to participate in the IBM Master the Mainframe contest. No further testing than this was done, though.

Please let me know if there's something that needs to be changed (this is my first to be contributed package). This is a second pull request, the first #11031 targeted the release branch and I couldn't get it to target the master branch.
