### PR TITLE
claws-mail: add glib_networking for fancy to load HTTPS content (for master)

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,7 +1,8 @@
-{ fetchurl, stdenv
+{ fetchurl, stdenv, wrapGAppsHook
 , curl, dbus, dbus_glib, enchant, gtk, gnutls, gnupg, gpgme, hicolor_icon_theme
 , libarchive, libcanberra, libetpan, libnotify, libsoup, libxml2, networkmanager
 , openldap , perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk2
+, glib_networking, gsettings_desktop_schemas
 
 # Build options
 # TODO: A flag to build the manual.
@@ -55,8 +56,8 @@ stdenv.mkDerivation {
   '';
 
   buildInputs =
-    [ curl dbus dbus_glib gtk gnutls hicolor_icon_theme
-      libetpan perl pkgconfig python
+    [ curl dbus dbus_glib gtk gnutls gsettings_desktop_schemas hicolor_icon_theme
+      libetpan perl pkgconfig python wrapGAppsHook
     ]
     ++ optional enableSpellcheck enchant
     ++ optionals (enablePgp || enablePluginSmime) [ gnupg gpgme ]
@@ -90,6 +91,9 @@ stdenv.mkDerivation {
     ++ optional (!enableSpellcheck) "--disable-enchant";
 
   enableParallelBuilding = true;
+
+  wrapPrefixVariables = [ "GIO_EXTRA_MODULES" ];
+  GIO_EXTRA_MODULES = "${glib_networking}/lib/gio/modules";
 
   postInstall = ''
     mkdir -p $out/share/applications

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11121,6 +11121,7 @@ let
   cinelerra = callPackage ../applications/video/cinelerra { };
 
   clawsMail = callPackage ../applications/networking/mailreaders/claws-mail {
+    inherit (gnome3) gsettings_desktop_schemas;
     enableNetworkManager = config.networking.networkmanager.enable or false;
   };
 


### PR DESCRIPTION
For bug #10421.  Tested locally and works.
