### PR TITLE
make mkDerivation lazier

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -111,30 +111,41 @@ let
           builtins.unsafeGetAttrPos "name" attrs;
       pos'' = if pos' != null then "‘" + pos'.file + ":" + toString pos'.line + "’" else "«unknown-file»";
 
-      throwEvalHelp = unfreeOrBroken: whatIsWrong:
-        assert builtins.elem unfreeOrBroken ["Unfree" "Broken" "blacklisted"];
+      throwEvalHelp = { reason, errormsg }:
+        # uppercase the first character of string s
+        let up = s: with lib;
+          let cs = lib.stringToCharacters s;
+          in concatStrings (singleton (toUpper (head cs)) ++ tail cs);
+        in
+        assert builtins.elem reason ["unfree" "broken" "blacklisted"];
 
-        throw ("Package ‘${attrs.name or "«name-missing»"}’ in ${pos''} ${whatIsWrong}, refusing to evaluate."
-        + (lib.strings.optionalString (unfreeOrBroken != "blacklisted") ''
+        throw ("Package ‘${attrs.name or "«name-missing»"}’ in ${pos''} ${errormsg}, refusing to evaluate."
+        + (lib.strings.optionalString (reason != "blacklisted") ''
 
           For `nixos-rebuild` you can set
-            { nixpkgs.config.allow${unfreeOrBroken} = true; }
+            { nixpkgs.config.allow${up reason} = true; }
           in configuration.nix to override this.
           For `nix-env` you can add
-            { allow${unfreeOrBroken} = true; }
+            { allow${up reason} = true; }
           to ~/.nixpkgs/config.nix.
         ''));
 
-      licenseAllowed = attrs:
+      # Check if a derivation is valid, that is whether it passes checks for
+      # e.g brokenness or license.
+      #
+      # Return { valid: Bool } and additionally
+      # { reason: String; errormsg: String } if it is not valid, where
+      # reason is one of "unfree", "blacklisted" or "broken".
+      checkValidity = attrs:
         if hasDeniedUnfreeLicense attrs && !(hasWhitelistedLicense attrs) then
-          throwEvalHelp "Unfree" "has an unfree license (‘${showLicense attrs.meta.license}’)"
+          { valid = false; reason = "unfree"; errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)"; }
         else if hasBlacklistedLicense attrs then
-          throwEvalHelp "blacklisted" "has a blacklisted license (‘${showLicense attrs.meta.license}’)"
+          { valid = false; reason = "blacklisted"; errormsg = "has a blacklisted license (‘${showLicense attrs.meta.license}’)"; }
         else if !allowBroken && attrs.meta.broken or false then
-          throwEvalHelp "Broken" "is marked as broken"
+          { valid = false; reason = "broken"; errormsg = "is marked as broken"; }
         else if !allowBroken && attrs.meta.platforms or null != null && !lib.lists.elem result.system attrs.meta.platforms then
-          throwEvalHelp "Broken" "is not supported on ‘${result.system}’"
-        else true;
+          { valid = false; reason = "broken"; errormsg = "is not supported on ‘${result.system}’"; }
+        else { valid = true; };
 
       outputs' =
         outputs ++
@@ -144,7 +155,6 @@ let
         (if separateDebugInfo then [ ../../build-support/setup-hooks/separate-debug-info.sh ] else []);
 
     in
-      assert licenseAllowed attrs;
 
       lib.addPassthru (derivation (
         (removeAttrs attrs
@@ -158,7 +168,12 @@ let
             lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (propagatedBuildInputs ++ propagatedNativeBuildInputs));
         in
         {
-          builder = attrs.realBuilder or shell;
+          builder =
+            # Throw an error if trying to evaluate an non-valid derivation
+            let v = checkValidity attrs;
+            in if v.valid
+               then attrs.realBuilder or shell
+               else throwEvalHelp (removeAttrs v ["valid"]);
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
           stdenv = result;
           system = result.system;


### PR DESCRIPTION
Up until now, it was not possible to access metadata of a package that
was marked as broken (or didn’t pass the license check).
So use cases like creating a list mapping derivation names to derivation
types (which e.g. haskellPackages would need) were not possible and
would simply throw an error, even though there should be no reason to
do so.

This commit draws the brokenness assertion from the toplevel of
mkDerivation into a strict field of the actual derivation call itself.
It also renames `licenseAllowed` to `checkValidity` and makes it a
true function.

That function should probably exposed in `lib/`, along with a function
to recursively filter out reverse dependencies for a broken package.
### Test file

I created [a gist](https://gist.github.com/Profpatsch/a9ade8e229953d31cdfd) to test a trivial usage of mkDerivation. It needs to be put into the `nixpkgs` root folder.
### Implications for nixpkgs
- `nix-env -qa` will not filter out invalid packages anymore (thanks to @vcunat)
- according to @peti, hydra finds out whether a package is marked as broken my accessing the derivation type and checking if that throws an assertion. It needs to be changed to use the actual value of the `meta.broken` attribute.
- ~~nixpkgs will do a complete rebuild~~

cc @vcunat @edolstra @peti
