### PR TITLE
ibus: fix dconf dependency

### DIFF
--- a/nixos/modules/programs/ibus.nix
+++ b/nixos/modules/programs/ibus.nix
@@ -27,7 +27,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.ibus ];
+    environment.systemPackages = [ pkgs.ibus pkgs.gnome3.dconf ];
 
     gtkPlugins = [ pkgs.ibus ];
     qtPlugins = [ pkgs.ibus-qt ];


### PR DESCRIPTION
Fixes problem of ibus settings that are not saved on an environment where `dconf` is not installed, by automatically installing `gnome3.dconf` if `programs.ibus.enable` is set to `true`.

Details:

Running `ibus-setup` on an environment where `gnome3.dconf` is not explicitly installed (like xmonad) give the following error and settings are not saved:

```
dconf-WARNING **: failed to commit changes to dconf: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name ca.desrt.dconf was not provided by any .service files
```

cc ibus maintainer @gebner 
