### PR TITLE
WIP: Refactor fixpoints and overriding in all-packages

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -1,6 +1,6 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
-	 xmlns:xlink="http://www.w3.org/1999/xlink"
-	 xml:id="chap-functions">
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="chap-functions">
 
 <title>Functions reference</title>
 
@@ -31,13 +31,32 @@ in ...</programlisting>
   </para>
 
   <para>
+    It can be used multiple times in succession to "chain" overrides:
+
+    <programlisting>let
+  pkgs0 = import &lt;nixpkgs&gt; {};
+  pkgs1 = pkgs0.overridePackages (self: super: {
+    foo = null;
+  };
+  pkgs2 = pkgs1.overridePackages (self: super: {
+    foo = 1;
+    bar = super.foo;
+    baz = self.bar;
+  };
+  pkgs3 = pkgs2.overridePackages (self: super: {
+    bar = super.foo;
+  };
+in assert foo == 1; assert bar == 1; assert baz = 1; ...</programlisting>
+  </para>
+
+  <para>
     The resulting <varname>newpkgs</varname> will have the new <varname>foo</varname>
     expression, and all other expressions depending on <varname>foo</varname> will also
     use the new <varname>foo</varname> expression.
   </para>
 
   <para>
-    The behavior of this function is similar to <link 
+    The behavior of this function is similar to <link
     linkend="sec-modify-via-packageOverrides">config.packageOverrides</link>.
   </para>
 
@@ -49,7 +68,7 @@ in ...</programlisting>
 
   <para>
     The <varname>super</varname> parameter refers to the old package set.
-    It's equivalent to <varname>pkgs</varname> in the above example.
+    It's equivalent to <varname>pkgs</varname> in the first example.
   </para>
 
 </section>
@@ -91,7 +110,7 @@ in ...</programlisting>
   <para>
     The function <varname>overrideDerivation</varname> is usually available for all the
     derivations in the nixpkgs expression (<varname>pkgs</varname>).
-  </para> 
+  </para>
   <para>
     It is used to create a new derivation by overriding the attributes of
     the original derivation according to the given function.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -124,7 +124,6 @@ let
 
   # The package compositions.  Yes, this isn't properly indented.
   pkgsFun = pkgs: overrides:
-    with helperFunctions;
     let defaultScope = pkgs // pkgs.xorg; self = self_ // overrides;
     self_ = with self; helperFunctions // {
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -115,17 +115,67 @@ let
       overrides = mkOverrides pkgsOrig (overrider pkgsOrig);
 
       # The un-overriden packages, passed to `overrider'.
-      pkgsOrig = pkgsFun pkgs {};
+      pkgsOrig = pkgsFun pkgs pkgsOrig;
 
       # The overriden, final packages.
-      pkgs = pkgsFun pkgs overrides;
+      pkgs = pkgsFun pkgs pkgs // overrides;
     in pkgs;
 
 
   # The package compositions.  Yes, this isn't properly indented.
-  pkgsFun = pkgs: overrides:
-    let defaultScope = pkgs // pkgs.xorg; self = self_ // overrides;
-    self_ = with self; helperFunctions // {
+  pkgsFun = pkgs: self: let
+    defaultScope = pkgs // pkgs.xorg;
+
+    rawAliases = with self; rec {
+      adobeReader = adobe-reader;
+      arduino_core = arduino-core; # added 2015-02-04
+      asciidocFull = asciidoc-full; # added 2014-06-22
+      bridge_utils = bridge-utils; # added 2015-02-20
+      buildbotSlave = buildbot-slave; # added 2014-12-09
+      cheetahTemplate = pythonPackages.cheetah; # 2015-06-15
+      clangAnalyzer = clang-analyzer; # added 2015-02-20
+      cool-old-term = cool-retro-term; # added 2015-01-31
+      cv = progress; # added 2015-09-06
+      enblendenfuse = enblend-enfuse;	# 2015-09-30
+      exfat-utils = exfat; # 2015-09-11
+      firefoxWrapper = firefox-wrapper;
+      fuse_exfat = exfat; # 2015-09-11
+      haskell-ng = haskell; # 2015-04-19
+      haskellngPackages = haskellPackages; # 2015-04-19
+      htmlTidy = html-tidy; # added 2014-12-06
+      inherit (haskell.compiler) jhc uhc; # 2015-05-15
+      inotifyTools = inotify-tools;
+      jquery_ui = jquery-ui; # added 2014-09-07
+      libtidy = html-tidy; # added 2014-12-21
+      lttngTools = lttng-tools; # added 2014-07-31
+      lttngUst = lttng-ust; # added 2014-07-31
+      nfsUtils = nfs-utils; # added 2014-12-06
+      quassel_qt5 = kf5Packages.quassel_qt5; # added 2015-09-30
+      quasselClient_qt5 = kf5Packages.quasselClient_qt5; # added 2015-09-30
+      quasselDaemon_qt5 = kf5Packages.quasselDaemon; # added 2015-09-30
+      quassel_kf5 = kf5Packages.quassel; # added 2015-09-30
+      quasselClient_kf5 = kf5Packages.quasselClient; # added 2015-09-30
+      rdiff_backup = rdiff-backup; # added 2014-11-23
+      rssglx = rss-glx; #added 2015-03-25
+      rxvt_unicode_with-plugins = rxvt_unicode-with-plugins; # added 2015-04-02
+      speedtest_cli = speedtest-cli; # added 2015-02-17
+      sqliteInteractive = sqlite-interactive; # added 2014-12-06
+      x11 = xlibsWrapper; # added 2015-09
+      xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
+      xlibs = xorg; # added 2015-09
+      youtube-dl = pythonPackages.youtube-dl; # added 2015-06-07
+      youtubeDL = youtube-dl; # added 2014-10-26
+      pidginlatexSF = pidginlatex; # added 2014-11-02
+    };
+
+    tweakAlias = _n: alias: with lib;
+      if alias.recurseForDerivations or false
+      then removeAttrs alias ["recurseForDerivations"]
+      else alias;
+
+    aliases = lib.mapAttrs tweakAlias rawAliases;
+
+  in with self; helperFunctions // aliases // {
 
   # Make some arguments passed to all-packages.nix available
   inherit system platform;
@@ -157,7 +207,7 @@ let
   # will use the new version.
   overridePackages = f:
     let
-      newpkgs = pkgsFun newpkgs overrides;
+      newpkgs = pkgsFun newpkgs newpkgs // overrides;
       overrides = mkOverrides pkgs (f newpkgs pkgs);
     in newpkgs;
 
@@ -15349,56 +15399,5 @@ let
 
   mg = callPackage ../applications/editors/mg { };
 
-}; # self_ =
-
-
-  ### Deprecated aliases - for backward compatibility
-
-aliases = with self; rec {
-  adobeReader = adobe-reader;
-  arduino_core = arduino-core;  # added 2015-02-04
-  asciidocFull = asciidoc-full;  # added 2014-06-22
-  bridge_utils = bridge-utils;  # added 2015-02-20
-  buildbotSlave = buildbot-slave;  # added 2014-12-09
-  cheetahTemplate = pythonPackages.cheetah; # 2015-06-15
-  clangAnalyzer = clang-analyzer;  # added 2015-02-20
-  cool-old-term = cool-retro-term; # added 2015-01-31
-  cv = progress; # added 2015-09-06
-  enblendenfuse = enblend-enfuse;	# 2015-09-30
-  exfat-utils = exfat;                  # 2015-09-11
-  firefoxWrapper = firefox-wrapper;
-  fuse_exfat = exfat;                   # 2015-09-11
-  haskell-ng = haskell;                 # 2015-04-19
-  haskellngPackages = haskellPackages;  # 2015-04-19
-  htmlTidy = html-tidy;  # added 2014-12-06
-  inherit (haskell.compiler) jhc uhc;   # 2015-05-15
-  inotifyTools = inotify-tools;
-  jquery_ui = jquery-ui;  # added 2014-09-07
-  libtidy = html-tidy;  # added 2014-12-21
-  lttngTools = lttng-tools;  # added 2014-07-31
-  lttngUst = lttng-ust;  # added 2014-07-31
-  nfsUtils = nfs-utils;  # added 2014-12-06
-  quassel_qt5 = kf5Packages.quassel_qt5; # added 2015-09-30
-  quasselClient_qt5 = kf5Packages.quasselClient_qt5; # added 2015-09-30
-  quasselDaemon_qt5 = kf5Packages.quasselDaemon; # added 2015-09-30
-  quassel_kf5 = kf5Packages.quassel; # added 2015-09-30
-  quasselClient_kf5 = kf5Packages.quasselClient; # added 2015-09-30
-  rdiff_backup = rdiff-backup;  # added 2014-11-23
-  rssglx = rss-glx; #added 2015-03-25
-  rxvt_unicode_with-plugins = rxvt_unicode-with-plugins; # added 2015-04-02
-  speedtest_cli = speedtest-cli;  # added 2015-02-17
-  sqliteInteractive = sqlite-interactive;  # added 2014-12-06
-  x11 = xlibsWrapper; # added 2015-09
-  xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
-  xlibs = xorg; # added 2015-09
-  youtube-dl = pythonPackages.youtube-dl; # added 2015-06-07
-  youtubeDL = youtube-dl;  # added 2014-10-26
-  pidginlatexSF = pidginlatex; # added 2014-11-02
 };
-
-tweakAlias = _n: alias: with lib;
-  if alias.recurseForDerivations or false then
-    removeAttrs alias ["recurseForDerivations"]
-  else alias;
-
-in lib.mapAttrs tweakAlias aliases // self; in pkgs
+in pkgs


### PR DESCRIPTION
Whatever was there before I found...confusing. I'm not sure this is better, but at least I find it much clearer: `pkgsFun` no longer ties any knots, `overridePackages` on the other hand does _all_ the knot tying, even if the user doesn't use have any overrides.

Potential highlights, if I understand things correctly:
- This brings `overridePackages` more in line with our other functions following the `self: super: ...` pattern. `Super` is now only shallowly un-overridden, by which I mean this:

``` nix
let super = defaults self; self = super // overrides self super; in self
```

vs 

``` nix
let super = defaults super; self = super // overrides self super; in self
```
- `self` bound in `pkgFun` and `with`'d, and `pkgs` bound in the outermost let and returned, were not obviously the same thing, yet used seemingly interchangeably in the body of `pkgFun`. `self` has been renamed to `pkgs` to shadow the other, and remove this potential source of inconsistency.
- `applyGlobalOverrides` and `overridePackages` were awkwardly similar, but the former is now removed.

My biggest concern is I accidentally introduced a new level of stdenv bootstrapping, if pkg overrides effect the stdenv. But if so, I am confused why this wasn't already necessary and suspect it only appeared that way due to bugs in the old code.

If this is accepted, I propose trying to make `all-packages.nix` just contain `pkgFun` (anonymous, of course), and move the rest to a new `top-level/default.nix` 

I _highly_ recommend going looking at the diff commit by commit first.

CC @Lethalman this is an outgrowth of the concerns I voiced on IRC.
