### PR TITLE
gsl: 1.16 -> 2.1

### DIFF
--- a/pkgs/development/libraries/gsl/gsl-1_16.nix
+++ b/pkgs/development/libraries/gsl/gsl-1_16.nix
@@ -1,16 +1,21 @@
 { fetchurl, fetchpatch, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "gsl-2.1";
+  name = "gsl-1.16";
 
   src = fetchurl {
     url = "mirror://gnu/gsl/${name}.tar.gz";
-    sha256 = "0rhcia9jhr3p1f1wybwyllwqfs9bggz99i3mi5lpyqcpff1hdbar";
+    sha256 = "0lrgipi0z6559jqh82yx8n4xgnxkhzj46v96dl77hahdp58jzg3k";
   };
 
   patches = [
     # ToDo: there might be more impurities than FMA support check
     ./disable-fma.patch # http://lists.gnu.org/archive/html/bug-gsl/2011-11/msg00019.html
+    (fetchpatch {
+      name = "bug-39055.patch";
+      url = "http://git.savannah.gnu.org/cgit/gsl.git/patch/?id=9cc12d";
+      sha256 = "1bmrmihi28cly9g9pq54kkix2jy59y7cd7h5fw4v1c7h5rc2qvs8";
+    })
   ];
 
   doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -563,6 +563,7 @@ let
 
   asymptote = callPackage ../tools/graphics/asymptote {
     texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super; };
+    gsl = gsl_1;
   };
 
   atomicparsley = callPackage ../tools/video/atomicparsley { };
@@ -1995,7 +1996,7 @@ let
 
   kpcli = callPackage ../tools/security/kpcli { };
 
-  kst = callPackage ../tools/graphics/kst { };
+  kst = callPackage ../tools/graphics/kst { gsl = gsl_1; };
 
   leocad = callPackage ../applications/graphics/leocad { };
 
@@ -6570,6 +6571,8 @@ let
   gsasl = callPackage ../development/libraries/gsasl { };
 
   gsl = callPackage ../development/libraries/gsl { };
+
+  gsl_1 = callPackage ../development/libraries/gsl/gsl-1_16.nix { };
 
   gsm = callPackage ../development/libraries/gsm {};
 
@@ -12608,7 +12611,7 @@ let
 
   opusTools = callPackage ../applications/audio/opus-tools { };
 
-  orpie = callPackage ../applications/misc/orpie { };
+  orpie = callPackage ../applications/misc/orpie { gsl = gsl_1; };
 
   osmo = callPackage ../applications/office/osmo { };
 


### PR DESCRIPTION
Release notes :
— gsl-2.0: https://savannah.gnu.org/forum/forum.php?forum_id=8392
— gsl-2.1: https://savannah.gnu.org/forum/forum.php?forum_id=8408

The bug-39055.patch is removed since it seems to be integrated in the
2.1 release.

Neither release notes seems to mention API breaks, so it seems ok to
go from the 1.x branch to the 2.x branch.
