### PR TITLE
Package for certificate-transparency

### DIFF
--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, python, findutils }:
+{ stdenv, fetchurl, autoreconfHook, openssl, python, findutils }:
 
 let version = "2.0.22"; in
 stdenv.mkDerivation {
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ python ] ++ stdenv.lib.optional stdenv.isCygwin findutils;
+  buildInputs = [ openssl python ] ++ stdenv.lib.optional stdenv.isCygwin findutils;
 
   patchPhase = ''
     patchShebangs event_rpcgen.py

--- a/pkgs/development/libraries/libevhtp/default.nix
+++ b/pkgs/development/libraries/libevhtp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libevhtp-${version}";
-  version = "1.2.10";
+  version = "1.2.11";
 
   src = fetchFromGitHub {
     owner = "ellzey";
     repo = "libevhtp";
     rev = version;
-    sha256 = "0z5cxa65zp89vkaj286gp6fpmc5fylr8bmd17g3j1rgc42nysm6a";
+    sha256 = "1rlxdp8w4alcy5ryr7pmw5wi6hv7d64885wwbk1zxhvi64s4x4rg";
   };
 
   buildInputs = [ cmake openssl libevent ];

--- a/pkgs/servers/certificate-transparency/default.nix
+++ b/pkgs/servers/certificate-transparency/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, pkgs, ...}:
+
+stdenv.mkDerivation rec {
+  name = "certificate-transparency-${version}-${rev}";
+
+  version = "2015-11-27";
+  rev = "dc5a51e55af989ff5871a6647166d00d0de478ab";
+
+  meta = with stdenv.lib; {
+    homepage = https://www.certificate-transparency.org/;
+    description = "Auditing for TLS certificates.";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ philandstuff ];
+  };
+
+  src = pkgs.fetchFromGitHub {
+    owner = "google";
+    repo  = "certificate-transparency";
+    rev   = rev;
+    sha256 = "14sgc2kcjjsnrykwcjin21h1f3v4kg83w6jqiq9qdm1ha165yhvx";
+  };
+
+  # need to disable regex support in evhtp or building will fail
+  libevhtp_without_regex = stdenv.lib.overrideDerivation pkgs.libevhtp
+    (oldAttrs: {
+      cmakeFlags="-DEVHTP_DISABLE_REGEX:STRING=ON -DCMAKE_C_FLAGS:STRING=-fPIC";
+    });
+
+  buildInputs = with pkgs; [
+    autoconf automake clang_34 pkgconfig
+    glog gmock google-gflags gperftools gtest json_c leveldb
+    libevent libevhtp_without_regex openssl protobuf sqlite
+  ];
+
+  patches = [
+    ./protobuf-include-from-env.patch
+  ];
+
+  doCheck = false;
+
+  preConfigure = ''
+    ./autogen.sh
+    configureFlagsArray=(
+      CC=clang
+      CXX=clang++
+      GMOCK_DIR=${pkgs.gmock}
+      GTEST_DIR=${pkgs.gtest}
+    )
+  '';
+
+  # the default Makefile constructs BUILD_VERSION from `git describe`
+  # which isn't available in the nix build environment
+  makeFlags = "BUILD_VERSION=${version}-${rev}";
+
+  protocFlags = "-I ${pkgs.protobuf}/include";
+}

--- a/pkgs/servers/certificate-transparency/protobuf-include-from-env.patch
+++ b/pkgs/servers/certificate-transparency/protobuf-include-from-env.patch
@@ -1,0 +1,14 @@
+Get protobuf include path from environment
+
+--- a/python/Makefile
++++ b/python/Makefile
+@@ -5,7 +5,7 @@ all: ct/proto/client_pb2.py ct/proto/ct_pb2.py ct/proto/tls_options_pb2.py \
+ 	ct/proto/test_message_pb2.py ct/proto/certificate_pb2.py
+ 
+ ct/proto/%_pb2.py: ct/proto/%.proto
+-	$(PROTOC) $^ -I/usr/include/ -I/usr/local/include -I$(INSTALL_DIR)/include -I. --python_out=.
++	$(PROTOC) $^ $(protocFlags) -I. --python_out=.
+ 
+ ct/proto/ct_pb2.py: ../proto/ct.proto
+ 	$(PROTOC) --python_out=ct/proto -I../proto ../proto/ct.proto
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -759,6 +759,8 @@ let
 
   gcdemu = callPackage ../misc/emulators/cdemu/gui.nix { };
 
+  certificate-transparency = callPackage ../servers/certificate-transparency { };
+
   image-analyzer = callPackage ../misc/emulators/cdemu/analyzer.nix { };
 
   ccnet = callPackage ../tools/networking/ccnet { };


### PR DESCRIPTION
This bumps evhtp's version because 1.2.11 provides pkg-config
information which makes building certificate-transparency easier.

We need an openssl-enabled version of libevent and libevhtp; the default
builds don't include openssl so I used overrides to rebuild with openssl
support.

This has been tested with `doCheck = true;` to verify the tests actually pass :)
