### PR TITLE
bzip2: fix cross build on mingw by using autoconf patch

### DIFF
--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, linkStatic ? false }:
+{ stdenv, fetchurl, libtool, autoconf, automake, gnum4, linkStatic ? false }:
 
 let
   version = "1.0.6";
@@ -15,14 +15,26 @@ in stdenv.mkDerivation {
   };
 
   crossAttrs = {
-    patchPhase = ''
+    buildInputs = [ libtool autoconf automake gnum4 ];
+    patches = [
+      # original upstream for the autoconf patch is here:
+      # http://ftp.suse.com/pub/people/sbrabec/bzip2/for_downstream/bzip2-1.0.6-autoconfiscated.patch
+      # but we get the mingw-builds version of the patch, which fixes
+      # a few more issues
+      (fetchurl {
+        url = "https://raw.githubusercontent.com/niXman/mingw-builds/17ae841dcf6e72badad7941a06d631edaf687436/patches/bzip2/bzip2-1.0.6-autoconfiscated.patch";
+        sha256 = "1flbd3i8vg9kzq0a712qcg9j2c4ymnqvgd0ldyafpzvbqj1iicnp";
+      })
+    ];
+    patchFlags = "-p0";
+    postPatch = ''
       sed -i -e '/<sys\\stat\.h>/s|\\|/|' bzip2.c
-      sed -i -e 's/CC=gcc/CC=${stdenv.cross.config}-gcc/' \
-        -e 's/AR=ar/AR=${stdenv.cross.config}-ar/' \
-        -e 's/RANLIB=ranlib/RANLIB=${stdenv.cross.config}-ranlib/' \
-        -e 's/bzip2recover test/bzip2recover/' \
-        Makefile*
     '';
+    preConfigure = "sh ./autogen.sh";
+    # clear native hooks that are not needed with autoconf
+    preBuild = "";
+    preInstall = "";
+    postInstall = "";
   };
 
   preBuild = stdenv.lib.optionalString sharedLibrary ''


### PR DESCRIPTION
Replaces #10820. [I have a second less conservative version of the patch which I'll submit shortly.]

Main changes compared to #10820:
- use fetchurl to get the autoconf patch to avoid checking in a large file
- rebased against staging

Tested against the current nixpkgs-unstable channel (git hash 3087ef37bb35) and then rebased against staging.
- bzip2 byte-for-byte identical output (except for hashes)
- bzip2.crossDrv byte-for-byte identical output (except for hashes) with the following shell.nix script:

```
import <nixpkgs>
{
  crossSystem = {
    config = "i686-w64-mingw32";
    arch = "i686";
    libc = "msvcrt";
    platform = { };
    openssl.system = "mingw";
  };
}
```

Not tested:
- darwin (I have no access to hardware)

cc @aszlig @peti
