### PR TITLE
bzip2: use autoconf patch and remove in-house patching

### DIFF
--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -1,11 +1,7 @@
-{ stdenv, fetchurl, linkStatic ? false }:
+{ stdenv, fetchurl, libtool, autoconf, automake, pkgconfig, gnum4 }:
 
 let
   version = "1.0.6";
-
-  sharedLibrary = !stdenv.isDarwin && !(stdenv ? isStatic)
-               && stdenv.system != "i686-cygwin" && !linkStatic;
-
 in stdenv.mkDerivation {
   name = "bzip2-${version}";
 
@@ -14,49 +10,29 @@ in stdenv.mkDerivation {
     sha256 = "1kfrc7f0ja9fdn6j1y6yir6li818npy6217hvr3wzmnmzhs8z152";
   };
 
+  patches = [
+    # original upstream for the autoconf patch is here:
+    # http://ftp.suse.com/pub/people/sbrabec/bzip2/for_downstream/bzip2-1.0.6-autoconfiscated.patch
+    # but we get the mingw-builds version of the patch, which fixes
+    # a few more issues
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/niXman/mingw-builds/17ae841dcf6e72badad7941a06d631edaf687436/patches/bzip2/bzip2-1.0.6-autoconfiscated.patch";
+      sha256 = "1flbd3i8vg9kzq0a712qcg9j2c4ymnqvgd0ldyafpzvbqj1iicnp";
+    })
+  ];
+
+  patchFlags = "-p0";
+
+  nativeBuildInputs = [ libtool autoconf automake gnum4 pkgconfig ];
+
+  preConfigure = "sh ./autogen.sh";
+
   crossAttrs = {
-    patchPhase = ''
+    # https://github.com/niXman/mingw-builds/blob/master/patches/bzip2/bzip2-1.0.5-slash.patch
+    postPatch = ''
       sed -i -e '/<sys\\stat\.h>/s|\\|/|' bzip2.c
-      sed -i -e 's/CC=gcc/CC=${stdenv.cross.config}-gcc/' \
-        -e 's/AR=ar/AR=${stdenv.cross.config}-ar/' \
-        -e 's/RANLIB=ranlib/RANLIB=${stdenv.cross.config}-ranlib/' \
-        -e 's/bzip2recover test/bzip2recover/' \
-        Makefile*
     '';
   };
-
-  preBuild = stdenv.lib.optionalString sharedLibrary ''
-    make -f Makefile-libbz2_so
-  '';
-
-  preInstall = stdenv.lib.optionalString sharedLibrary ''
-    mkdir -p $out/lib
-    mv libbz2.so* $out/lib
-    ( cd $out/lib &&
-      ln -s libbz2.so.1.0.? libbz2.so &&
-      ln -s libbz2.so.1.0.? libbz2.so.1
-    )
-  '';
-
-  installFlags = [ "PREFIX=$(out)" ];
-
-  postInstall = ''
-    rm $out/bin/bunzip2* $out/bin/bzcat*
-    ln -s bzip2 $out/bin/bunzip2
-    ln -s bzip2 $out/bin/bzcat
-  '';
-
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace Makefile --replace 'CC=gcc' 'CC=clang'
-  '';
-
-  preConfigure = ''
-    substituteInPlace Makefile --replace '$(PREFIX)/man' '$(PREFIX)/share/man'
-  '';
-
-  makeFlags = stdenv.lib.optional linkStatic "LDFLAGS=-static";
-
-  inherit linkStatic;
 
   meta = {
     homepage = "http://www.bzip.org";


### PR DESCRIPTION
Replaces #10820; alternative to #11126.

In addition to #11126, this patch uses the autoconf infrastructure not only for the cross build, but also for the native build, allowing most of the hacks to be removed and thereby resulting in a simpler nix expression. This will obviously cause a large mass rebuild.

This patch is obviously a lot more risky, as a lot of core tools depend on native bzip2.

cc @aszlig @peti 
