### PR TITLE
nixos-container: If container name is already unique, don't append "-0"

### DIFF
--- a/nixos/modules/virtualisation/nixos-container.pl
+++ b/nixos/modules/virtualisation/nixos-container.pl
@@ -97,10 +97,10 @@ if ($action eq "create") {
     if ($ensureUniqueName) {
         my $base = $containerName;
         for (my $nr = 0; ; $nr++) {
-            $containerName = "$base-$nr";
             $confFile = "/etc/containers/$containerName.conf";
             $root = "/var/lib/containers/$containerName";
             last unless -e $confFile || -e $root;
+            $containerName = "$base-$nr";
         }
     }
 


### PR DESCRIPTION
When using `--ensure-unique-name`, don't needlessly append `"-0"` if the
container name is already unique.

This is especially helpful with NixOps since when it deploys to a
container it uses `--ensure-unique-name`.  This means that the container
name will never match the deployment host due to the `"-0"`.  Having the
container name and the host name match isn't exactly a requirement, but
it's nice to have and a small change.
