### PR TITLE
ipmitool: Fix build on darwin

### DIFF
--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation {
     sha256 = "0y6g8xg9p854n7xm3kds8m3d53jrsllnknp8lcr3jscf99j4x5ph";
   };
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/plugins/ipmi_intf.c --replace "s6_addr16" "s6_addr"
+  '';
+
   buildInputs = [ openssl ];
 
   preConfigure = ''


### PR DESCRIPTION
s6_addr16 is not available on Mac OS X.
