### PR TITLE
python pykafka: init at 2.0.3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5253,6 +5253,39 @@ let
     };
   };
 
+  pykafka = buildPythonPackage rec {
+    name = "pykafka-${version}";
+    version = "2.0.3";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/pykafka/${name}.tar.gz";
+      sha256 = "6c7b475d86a9c4867a88c1e5c3b0ea3af46b55b3ba2408378d161cb9b9ac73ea";
+    };
+
+    buildInputs = with self; [
+      mock
+      python-snappy
+      tabulate
+      unittest2
+      coverage
+      pytest
+      pytestcov
+    ];
+
+    propagatedBuildInputs = with self; [
+      kazoo
+    ];
+
+    meta = {
+      description = "Full-Featured Pure-Python Kafka Client";
+      homepage = "https://github.com/Parsely/pykafka";
+      license = licenses.asl20;
+    };
+
+    doCheck = false;
+  };
+
+
   pyramid = buildPythonPackage rec {
     name = "pyramid-1.5.7";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5442,6 +5442,27 @@ let
     propagatedBuildInputs = with self; [ pyramid hawkauthlib tokenlib webtest ];
   };
 
+  python-snappy = buildPythonPackage rec {
+    name = "python-snappy-${version}";
+    version = "0.5";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/python-snappy/${name}.tar.gz";
+      sha256 = "c7fe37679ebfc73840c7cc83657a76bc1ac978efa286b8ac3569fd0630d2b80d";
+    };
+
+    buildInputs = with self; [
+      pkgs.snappy
+      pytestcov
+    ];
+
+    meta = {
+      description = "Python library for the snappy compression library from Google";
+      homepage = "http://code.google.com/p/snappy";
+      license = licenses.bsd3;
+    };
+  };
+
   radicale = buildPythonPackage rec {
     name = "radicale-${version}";
     namePrefix = "";


### PR DESCRIPTION
I had to disable the tests as 5 failed (30 pass) with the following error:

```
==================================== ERRORS ====================================
___________ ERROR collecting tests/pykafka/test_balancedconsumer.py ____________
tests/pykafka/test_balancedconsumer.py:11: in <module>
    from pykafka.test.utils import get_cluster, stop_cluster
pykafka/test/utils.py:3: in <module>
    from pykafka.test.kafka_instance import KafkaInstance, KafkaConnection
pykafka/test/kafka_instance.py:30: in <module>
    from testinstances import utils
E   ImportError: No module named testinstances

```

I did a manual testing it by starting a client and receiving messages in a python interpreter.
