### PR TITLE
Add focus_password if defaultUser is set

### DIFF
--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -18,6 +18,7 @@ let
       halt_cmd ${config.systemd.package}/sbin/shutdown -h now
       reboot_cmd ${config.systemd.package}/sbin/shutdown -r now
       ${optionalString (cfg.defaultUser != null) ("default_user " + cfg.defaultUser)}
+      ${optionalString (cfg.defaultUser != null) ("focus_password yes")}
       ${optionalString cfg.autoLogin "auto_login yes"}
       ${cfg.extraConfig}
     '';


### PR DESCRIPTION
Add 'focus_password yes' if defaultUser is set, to reflect the description of defaultUser.
