### PR TITLE
add a wrapper to gdb which adds gcc (or other paths) as safe path

### DIFF
--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -1,3 +1,4 @@
+
 { stdenv, fetchurl, noSysDirs
 , langC ? true, langCC ? true, langFortran ? false
 , langObjC ? stdenv.isDarwin

--- a/pkgs/development/tools/misc/gdb/wrapper.nix
+++ b/pkgs/development/tools/misc/gdb/wrapper.nix
@@ -1,0 +1,18 @@
+{ stdenv, lib, makeWrapper, buildEnv, gdbWithoutWrapper, safePaths}:
+
+let gdb = gdbWithoutWrapper; in
+stdenv.mkDerivation {
+  name = gdb.name;
+  buildInputs = [makeWrapper];
+  propagatedBuildInputs = [gdb];
+  propagatedUserEnvPkgs = [gdb];
+  phases = "installPhase fixupPhase";
+  installPhase = ''
+    mkdir -p $out/share/gdb/system-gdbinit
+    echo add-auto-load-safe-path ${lib.concatStringsSep ":" safePaths} > $out/share/gdb/system-gdbinit/safePaths.py
+    makeWrapper "${gdb}/bin/gdb" \
+      "$out/bin/gdb" \
+      --add-flags -x $out/share/gdb/system/gdbinit/safePaths.py
+    '';
+  meta = gdb.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5897,13 +5897,15 @@ let
     ruby = ruby_2_0_0;
   };
 
-  gdb = callPackage ../development/tools/misc/gdb {
+  gdbWithoutWrapper = callPackage ../development/tools/misc/gdb {
     guile = null;
     hurd = gnu.hurdCross;
     inherit (gnu) mig;
   };
 
-  gdbGuile = lowPrio (gdb.override { inherit guile; });
+  gdb = callPackage ../development/tools/misc/gdb/wrapper.nix { safePaths = [ gcc ]; };
+
+  gdbGuile = lowPrio (gdb.override { gdbWithoutWrapper = gdbWithoutWrapper.override { inherit guile; }; });
 
   gdbCross = lowPrio (callPackage ../development/tools/misc/gdb {
     target = crossSystem;


### PR DESCRIPTION
This fixes #10427. Though I'm not sure if defaulting to adding gcc is the right way to do it.
