### PR TITLE
msmtp: Enable on OS X with Keychain integration.

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, pkgconfig, gnutls, gsasl, libidn }:
+{ stdenv, fetchurl, openssl, pkgconfig, gnutls, gsasl, libidn, Security }:
 
 stdenv.mkDerivation rec {
   version = "1.6.2";
@@ -9,7 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "12c7ljahb06pgn8yvvw526xvr11vnr6d4nr0apylixddpxycsvig";
   };
 
-  buildInputs = [ openssl pkgconfig gnutls gsasl libidn ];
+  buildInputs = [ openssl pkgconfig gnutls gsasl libidn ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+  configureFlags =
+    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
 
   postInstall = ''
     cp scripts/msmtpq/msmtp-queue scripts/msmtpq/msmtpq $prefix/bin/
@@ -21,6 +25,6 @@ stdenv.mkDerivation rec {
       homepage = "http://msmtp.sourceforge.net/";
       license = stdenv.lib.licenses.gpl3;
       maintainers = [ stdenv.lib.maintainers.garbas ];
-      platforms = stdenv.lib.platforms.linux;
+      platforms = stdenv.lib.platforms.unix;
     };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12468,7 +12468,9 @@ let
 
   sxhkd = callPackage ../applications/window-managers/sxhkd { };
 
-  msmtp = callPackage ../applications/networking/msmtp { };
+  msmtp = callPackage ../applications/networking/msmtp {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   imapfilter = callPackage ../applications/networking/mailreaders/imapfilter.nix {
     lua = lua5;


### PR DESCRIPTION
This pull request enables msmtp on OS X and adds the Security framework to make msmtp's Keychain integration work.
