### PR TITLE
Add the MPTCP linux kernel

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+
+import ./generic.nix (args // rec {
+  mptcpVersion = "0.90";
+  modDirVersion = "3.18.20";
+  version = "${modDirVersion}-mptcp_v${mptcpVersion}";
+
+  extraMeta = {
+    branch = "3.18";
+    maintainer = stdenv.lib.maintainers.layus;
+  };
+
+  src = fetchurl {
+    url = "https://github.com/multipath-tcp/mptcp/archive/v${mptcpVersion}.tar.gz";
+    sha256 = "1wzdvd1j1wqjkysj98g451y6mxr9a5hff5kn9inxwbzm9yg4icj5";
+  };
+
+  extraConfig = ''
+    IPV6 y
+    MPTCP y
+    IP_MULTIPLE_TABLES y
+
+    # Enable advanced path-managers...
+    MPTCP_PM_ADVANCED y
+    MPTCP_FULLMESH y
+    MPTCP_NDIFFPORTS y
+    # ... but use none by default.
+    # The default is safer if source policy routing is not setup.
+    DEFAULT_DUMMY y
+    DEFAULT_MPTCP_PM "default"
+
+    # MPTCP scheduler selection.
+    # Disabled as the only non-default is the useless round-robin.
+    MPTCP_SCHED_ADVANCED n
+    DEFAULT_MPTCP_SCHED "default"
+
+    # Smarter TCP congestion controllers
+    TCP_CONG_LIA m
+    TCP_CONG_OLIA m
+    TCP_CONG_WVEGAS m
+    TCP_CONG_BALIA m
+  '';
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9910,6 +9910,15 @@ let
 
   kernelPatches = callPackage ../os-specific/linux/kernel/patches.nix { };
 
+  linux_mptcp = callPackage ../os-specific/linux/kernel/linux-mptcp.nix {
+    kernelPatches = [ kernelPatches.bridge_stp_helper ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
   linux_rpi = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
     kernelPatches = [ kernelPatches.bridge_stp_helper ];
   };
@@ -10143,6 +10152,7 @@ let
   linux_latest = linuxPackages_latest.kernel;
 
   # Build the kernel modules for the some of the kernels.
+  linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp linuxPackages_mptcp;
   linuxPackages_rpi = linuxPackagesFor pkgs.linux_rpi linuxPackages_rpi;
   linuxPackages_3_10 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_3_10 linuxPackages_3_10);
   linuxPackages_3_10_tuxonice = linuxPackagesFor pkgs.linux_3_10_tuxonice linuxPackages_3_10_tuxonice;


### PR DESCRIPTION
The reference implementation of Multipath TCP for the linux kernel.
