### PR TITLE
add Paket2Nix-1.0.2.0 

### DIFF
--- a/pkgs/development/tools/dotnet/paket2nix/Argu/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Argu/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "argu-1.1.2";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/argu.1.1.2.nupkg";
+    sha256 = "97688111dc7aa95e63f40b79e033bd12f4c1987eaf3455ec6395c1e62de8fd7e";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/argu-1.1.2/Argu";
+    unzip -x "$src" -d "$out/lib/mono/packages/argu-1.1.2/Argu";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/FAKE/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/FAKE/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "fake-4.9.1";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/fake.4.9.1.nupkg";
+    sha256 = "1b616c4dd98a9adad02ba72aa1c45358e84eda844eb7b759d60cc78555d8b9cc";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/fake-4.9.1/FAKE";
+    unzip -x "$src" -d "$out/lib/mono/packages/fake-4.9.1/FAKE";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/FSharp.Compiler.Service/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/FSharp.Compiler.Service/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "fsharp.compiler.service-1.4.0.6";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/fsharp.compiler.service.1.4.0.6.nupkg";
+    sha256 = "83dc0f5c56f65f2a9501e4ba011b9c46c5952fde90785ca4b5a0e7aceb7cd0ab";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/fsharp.compiler.service-1.4.0.6/FSharp.Compiler.Service";
+    unzip -x "$src" -d "$out/lib/mono/packages/fsharp.compiler.service-1.4.0.6/FSharp.Compiler.Service";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/FSharp.Core/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/FSharp.Core/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "fsharp.core-4.0.0.1";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/fsharp.core.4.0.0.1.nupkg";
+    sha256 = "f67929917b5d91f03019718ea5eec5aefcd38b7f15feb677c981a2df3a93d006";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/fsharp.core-4.0.0.1/FSharp.Core";
+    unzip -x "$src" -d "$out/lib/mono/packages/fsharp.core-4.0.0.1/FSharp.Core";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/FSharp.Formatting/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/FSharp.Formatting/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "fsharp.formatting-2.12.0";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/fsharp.formatting.2.12.0.nupkg";
+    sha256 = "0aef25d948870a429dcdda64c520b4dc20820cb0ac415e0a77af9698ae420b67";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/fsharp.formatting-2.12.0/FSharp.Formatting";
+    unzip -x "$src" -d "$out/lib/mono/packages/fsharp.formatting-2.12.0/FSharp.Formatting";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/FSharpVSPowerTools.Core/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/FSharpVSPowerTools.Core/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "fsharpvspowertools.core-2.1.0";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/fsharpvspowertools.core.2.1.0.nupkg";
+    sha256 = "2645fd6f2c67a2203b138c320278a1f88e829b279ea115170e49c70ee4ad5f3d";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/fsharpvspowertools.core-2.1.0/FSharpVSPowerTools.Core";
+    unzip -x "$src" -d "$out/lib/mono/packages/fsharpvspowertools.core-2.1.0/FSharpVSPowerTools.Core";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Microsoft.Bcl.Build/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Microsoft.Bcl.Build/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "microsoft.bcl.build-1.0.21";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/microsoft.bcl.build.1.0.21.nupkg";
+    sha256 = "c1f43aeb79b44680a8bf06d28c4d7dd2f89542ed22fd89c41f7bfc832e6a0870";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/microsoft.bcl.build-1.0.21/Microsoft.Bcl.Build";
+    unzip -x "$src" -d "$out/lib/mono/packages/microsoft.bcl.build-1.0.21/Microsoft.Bcl.Build";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Microsoft.Bcl/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Microsoft.Bcl/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "microsoft.bcl-1.1.10";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/microsoft.bcl.1.1.10.nupkg";
+    sha256 = "220680f4f1cc4e3db38ebf971ee8ad8bc5fe8ac213a3098443e38c6fcd8912a5";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/microsoft.bcl-1.1.10/Microsoft.Bcl";
+    unzip -x "$src" -d "$out/lib/mono/packages/microsoft.bcl-1.1.10/Microsoft.Bcl";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Microsoft.Net.Http/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Microsoft.Net.Http/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "microsoft.net.http-2.2.29";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/microsoft.net.http.2.2.29.nupkg";
+    sha256 = "300545178dde5bc98acbb0c432254155ede1af4a3d3921fd3bed57acf981381d";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/microsoft.net.http-2.2.29/Microsoft.Net.Http";
+    unzip -x "$src" -d "$out/lib/mono/packages/microsoft.net.http-2.2.29/Microsoft.Net.Http";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/NUnit.Runners/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/NUnit.Runners/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "nunit.runners-2.6.4";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/nunit.runners.2.6.4.nupkg";
+    sha256 = "44877aeb399ffb14b30ecca1c073813aab71dcf9a92986d16f31d919f789d586";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/nunit.runners-2.6.4/NUnit.Runners";
+    unzip -x "$src" -d "$out/lib/mono/packages/nunit.runners-2.6.4/NUnit.Runners";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/NUnit/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/NUnit/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "nunit-2.6.4";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/nunit.2.6.4.nupkg";
+    sha256 = "be8cde6e9754474d5d4f553addb6331cf442c2182a0eb4dc87618d744fd59ca9";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/nunit-2.6.4/NUnit";
+    unzip -x "$src" -d "$out/lib/mono/packages/nunit-2.6.4/NUnit";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Newtonsoft.Json/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Newtonsoft.Json/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "newtonsoft.json-7.0.1";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/newtonsoft.json.7.0.1.nupkg";
+    sha256 = "ff2a9942325b22cccfe3e505ac8abdf46b071bcc60ef44da464df929c60fc846";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/newtonsoft.json-7.0.1/Newtonsoft.Json";
+    unzip -x "$src" -d "$out/lib/mono/packages/newtonsoft.json-7.0.1/Newtonsoft.Json";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Octokit/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Octokit/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "octokit-0.16.0";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/octokit.0.16.0.nupkg";
+    sha256 = "146cfdb851b9a9fd62e1b1718e45b206d01a60e9b0772c5a6bc8372461843cc8";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/octokit-0.16.0/Octokit";
+    unzip -x "$src" -d "$out/lib/mono/packages/octokit-0.16.0/Octokit";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Paket.Core/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Paket.Core/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "paket.core-2.25.1";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/paket.core.2.25.1.nupkg";
+    sha256 = "429c1578d99d87b0d8458df47afa2ab1ee2bc72763372cdd98ed67c653d61a73";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/paket.core-2.25.1/Paket.Core";
+    unzip -x "$src" -d "$out/lib/mono/packages/paket.core-2.25.1/Paket.Core";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/Paket2Nix/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/Paket2Nix/default.nix
@@ -1,0 +1,64 @@
+
+{ stdenv, fetchgit, fetchurl, fsharp, mono , Argu, FAKE, FSharpCompilerService, FSharpCore, FSharpFormatting, FSharpVSPowerToolsCore, MicrosoftBcl, MicrosoftBclBuild, MicrosoftNetHttp, NewtonsoftJson, NUnit, NUnitRunners, Octokit, PaketCore, SourceLinkFake }:
+
+stdenv.mkDerivation {
+  name = "paket2nix-1.0.2.0";
+
+  src = fetchurl {
+    url    = "http://github.com/krgn/Paket2Nix/archive/1.0.2.0.tar.gz";
+    sha256 = "17znv5w2is4iyqh10djyqpchk9sbvw66q7cx73bixdkzm217kgj4";
+  };
+
+  meta = {
+    homepage = "http://github.com/krgn/Paket2Nix";
+    description = "Helper to turn nuget/paket packages into nix packages.";
+    maintainers = [  "Karsten Gebbert" ];
+  };
+
+  phases = [ "unpackPhase" "patchPhase" "buildPhase" "installPhase" ];
+
+  buildInputs = [ fsharp mono  Argu FAKE FSharpCompilerService FSharpCore FSharpFormatting FSharpVSPowerToolsCore MicrosoftBcl MicrosoftBclBuild MicrosoftNetHttp NewtonsoftJson NUnit NUnitRunners Octokit PaketCore SourceLinkFake ];
+
+  patchPhase = ''
+    mkdir -p packages
+
+    find . -type f -iname '*.fsproj' -exec sed -i '/paket.targets/'d '{}'  \;
+    find . -type f -iname '*.csproj' -exec sed -i '/paket.targets/'d '{}'  \;
+    find . -type f -iname '*.vbproj' -exec sed -i '/paket.targets/'d '{}'  \;
+
+    ln -s "${Argu}/lib/mono/packages/argu-1.1.2/Argu" "packages/Argu"
+    ln -s "${FAKE}/lib/mono/packages/fake-4.9.1/FAKE" "packages/FAKE"
+    ln -s "${FSharpCompilerService}/lib/mono/packages/fsharp.compiler.service-1.4.0.6/FSharp.Compiler.Service" "packages/FSharp.Compiler.Service"
+    ln -s "${FSharpCore}/lib/mono/packages/fsharp.core-4.0.0.1/FSharp.Core" "packages/FSharp.Core"
+    ln -s "${FSharpFormatting}/lib/mono/packages/fsharp.formatting-2.12.0/FSharp.Formatting" "packages/FSharp.Formatting"
+    ln -s "${FSharpVSPowerToolsCore}/lib/mono/packages/fsharpvspowertools.core-2.1.0/FSharpVSPowerTools.Core" "packages/FSharpVSPowerTools.Core"
+    ln -s "${MicrosoftBcl}/lib/mono/packages/microsoft.bcl-1.1.10/Microsoft.Bcl" "packages/Microsoft.Bcl"
+    ln -s "${MicrosoftBclBuild}/lib/mono/packages/microsoft.bcl.build-1.0.21/Microsoft.Bcl.Build" "packages/Microsoft.Bcl.Build"
+    ln -s "${MicrosoftNetHttp}/lib/mono/packages/microsoft.net.http-2.2.29/Microsoft.Net.Http" "packages/Microsoft.Net.Http"
+    ln -s "${NewtonsoftJson}/lib/mono/packages/newtonsoft.json-7.0.1/Newtonsoft.Json" "packages/Newtonsoft.Json"
+    ln -s "${NUnit}/lib/mono/packages/nunit-2.6.4/NUnit" "packages/NUnit"
+    ln -s "${NUnitRunners}/lib/mono/packages/nunit.runners-2.6.4/NUnit.Runners" "packages/NUnit.Runners"
+    ln -s "${Octokit}/lib/mono/packages/octokit-0.16.0/Octokit" "packages/Octokit"
+    ln -s "${PaketCore}/lib/mono/packages/paket.core-2.25.1/Paket.Core" "packages/Paket.Core"
+    ln -s "${SourceLinkFake}/lib/mono/packages/sourcelink.fake-1.1.0/SourceLink.Fake" "packages/SourceLink.Fake"
+
+  '';
+
+  buildPhase = ''
+    export FSharpTargetsPath=${fsharp}/lib/mono/4.5/Microsoft.FSharp.Targets
+    export TargetFSharpCorePath=${fsharp}/lib/mono/4.5/FSharp.Core.dll
+    xbuild /nologo /verbosity:minimal /p:Configuration="Release" Paket2Nix.sln
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib/mono/packages/paket2nix-1.0.2.0";
+    cp -rv src/Paket2Nix/bin/Release "$out/lib/mono/packages/paket2nix-1.0.2.0/Paket2Nix"
+    
+    mkdir -p "$out/bin";
+    cat > "$out/bin/paket2nix" <<-WRAPPER
+    #!/bin/sh
+    ${mono}/bin/mono $out/lib/mono/packages/paket2nix-1.0.2.0/Paket2Nix/Paket2Nix.exe "\$@"
+    WRAPPER
+    chmod a+x "$out/bin/paket2nix" 
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/SourceLink.Fake/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/SourceLink.Fake/default.nix
@@ -1,0 +1,20 @@
+
+{ stdenv, fetchgit, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "sourcelink.fake-1.1.0";
+
+  src = fetchurl {
+    url    = "https://api.nuget.org/packages/sourcelink.fake.1.1.0.nupkg";
+    sha256 = "b7f098b574c1cfc62a64a46efc0449f9cef467d233c9d1a3d78a43bd52e31fa5";
+  };
+
+  phases = [ "unpackPhase" ];
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    mkdir -p "$out/lib/mono/packages/sourcelink.fake-1.1.0/SourceLink.Fake";
+    unzip -x "$src" -d "$out/lib/mono/packages/sourcelink.fake-1.1.0/SourceLink.Fake";
+  '';
+}

--- a/pkgs/development/tools/dotnet/paket2nix/default.nix
+++ b/pkgs/development/tools/dotnet/paket2nix/default.nix
@@ -1,0 +1,22 @@
+
+with import <nixpkgs> {};
+{
+   Paket2Nix = callPackage ./Paket2Nix {
+ 
+    Argu = callPackage ./Argu {};
+    FAKE = callPackage ./FAKE {};
+    FSharpCompilerService = callPackage ./FSharp.Compiler.Service {};
+    FSharpCore = callPackage ./FSharp.Core {};
+    FSharpFormatting = callPackage ./FSharp.Formatting {};
+    FSharpVSPowerToolsCore = callPackage ./FSharpVSPowerTools.Core {};
+    MicrosoftBcl = callPackage ./Microsoft.Bcl {};
+    MicrosoftBclBuild = callPackage ./Microsoft.Bcl.Build {};
+    MicrosoftNetHttp = callPackage ./Microsoft.Net.Http {};
+    NewtonsoftJson = callPackage ./Newtonsoft.Json {};
+    NUnit = callPackage ./NUnit {};
+    NUnitRunners = callPackage ./NUnit.Runners {};
+    Octokit = callPackage ./Octokit {};
+    PaketCore = callPackage ./Paket.Core {};
+    SourceLinkFake = callPackage ./SourceLink.Fake {}; 
+};
+}

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -813,4 +813,6 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     };
   };
 
+  Paket2Nix = import ../development/tools/dotnet/paket2nix/default.nix; 
+
 }; in self


### PR DESCRIPTION
Adds a command to create `nix` expressions for `.NET` packages managed with `Paket`. See the project page here: 

https://github.com/krgn/Paket2Nix
