### PR TITLE
xfsprogs: Extend patch to make xfs_mdrestore and xfs_quota work

### DIFF
--- a/pkgs/tools/filesystems/xfsprogs/4.2.0-sharedlibs.patch
+++ b/pkgs/tools/filesystems/xfsprogs/4.2.0-sharedlibs.patch
@@ -78,3 +78,23 @@
  
  
  ifeq ($(HAVE_BUILDDEFS), yes)
+--- xfsprogs-4.2.0/quota/Makefile
++++ xfsprogs-4.2.0/quota/Makefile
+@@ -16,7 +16,6 @@ LSRCFILES = $(shell echo $(PCFILES) | sed -e "s/$(PKG_PLATFORM).c//g")
+ 
+ LLDLIBS = $(LIBXCMD)
+ LTDEPENDENCIES = $(LIBXCMD)
+-LLDFLAGS = -static
+ 
+ ifeq ($(ENABLE_READLINE),yes)
+ LLDLIBS += $(LIBREADLINE) $(LIBTERMCAP)
+--- xfsprogs-4.2.0/mdrestore/Makefile
++++ xfsprogs-4.2.0/mdrestore/Makefile
+@@ -10,7 +10,6 @@ CFILES = xfs_mdrestore.c
+ 
+ LLDLIBS = $(LIBXFS) $(LIBRT) $(LIBPTHREAD) $(LIBUUID)
+ LTDEPENDENCIES = $(LIBXFS)
+-LLDFLAGS = -static
+ 
+ default: depend $(LTCOMMAND)
+ 


### PR DESCRIPTION
Previously these tools were failing to start with:

```
xfs_mdrestore: error while loading shared libraries: libxfs.so.0: \
        cannot open shared object file: No such file or directory
xfs_quota: error while loading shared libraries: libxcmd.so.0: \
        cannot open shared object file: No such file or directory
```

Extend the `4.2.0-sharedlibs.patch` to make those programs work as well.
