### PR TITLE
zkfuse: init

### DIFF
--- a/pkgs/tools/filesystems/zkfuse/default.nix
+++ b/pkgs/tools/filesystems/zkfuse/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, zookeeper, zookeeper_mt, fuse, pkgconfig, autoreconfHook, log4cxx, boost, tree }:
+
+stdenv.mkDerivation rec {
+  name = "zkfuse";
+
+  src = zookeeper.src;
+  patches = [
+    # see: https://issues.apache.org/jira/browse/ZOOKEEPER-1929
+    ./zookeeper-1929.patch
+  ];
+
+  setSourceRoot = "export sourceRoot=${zookeeper.name}/src/contrib/zkfuse";
+
+  buildInputs = [ autoreconfHook zookeeper_mt log4cxx boost fuse ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v src/zkfuse $out/bin
+  '';
+
+  meta = with lib; {
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/tools/filesystems/zkfuse/zookeeper-1929.patch
+++ b/pkgs/tools/filesystems/zkfuse/zookeeper-1929.patch
@@ -1,0 +1,15 @@
+diff --git a/src/contrib/zkfuse/src/zkadapter.cc b/src/contrib/zkfuse/src/zkadapter.cc
+index 886051d..93dbef5 100644
+--- a/src/zkadapter.cc
++++ b/src/zkadapter.cc
+@@ -845,7 +845,10 @@ ZooKeeperAdapter::getNodeData(const string &path,
+             string("Unable to get data of node ") + path, rc 
+         );
+     } else {
+-        return string( buffer, buffer + len );
++        if (len == -1) {
++            len = 0;
++        };
++        return string( buffer, len );
+     }
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3652,6 +3652,8 @@ let
 
   zip = callPackage ../tools/archivers/zip { };
 
+  zkfuse = callPackage ../tools/filesystems/zkfuse { };
+
   zpaq = callPackage ../tools/archivers/zpaq { };
   zpaqd = callPackage ../tools/archivers/zpaq/zpaqd.nix { };
 


### PR DESCRIPTION
This packages `zkfuse`, which allows for mounting a Zookeeper instance as a file-system.
