### PR TITLE
Change the preset networking.hostId to use `mkDefault` so it can be easily changed by the user later.

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -1,7 +1,7 @@
 # This module defines the software packages included in the "minimal"
 # installation CD.  It might be useful elsewhere.
 
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   # Include some utilities that are useful for installing or repairing
@@ -50,5 +50,5 @@
   boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "zfs" "ntfs" "cifs" ];
 
   # Configure host id for ZFS to work
-  networking.hostId = "8425e349";
+  networking.hostId = lib.mkDefault "8425e349";
 }


### PR DESCRIPTION
I'm not sure, but I get the feeling that the `lib` argument can just be added and everything will work?
