### PR TITLE
KeePass: add plugin support; include keefox

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keefox/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keefox/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildEnv, fetchurl, mono, unzip }:
+
+let
+  version = "1.5.4";
+  drv = stdenv.mkDerivation {
+    name = "keefox-${version}";
+    src = fetchurl {
+      url    = "https://github.com/luckyrat/KeeFox/releases/download/v${version}/${version}.xpi";
+      sha256 = "c7c30770beb0ea32cbdee5311d03a9910fb7772695af3aa655e4ae64cd4d8335";
+    };
+
+    meta = {
+      description = "Keepass plugin for keefox Firefox add-on";
+      homepage    = http://keefox.org;
+      platforms   = with stdenv.lib.platforms; linux;
+      license     = stdenv.lib.licenses.gpl2;
+    };
+
+    buildInputs = [ unzip ];
+
+    pluginFilename = "KeePassRPC.plgx";
+
+    unpackCmd = "unzip $src deps/$pluginFilename ";
+    sourceRoot = "deps";
+
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $pluginFilename $out/lib/dotnet/keepass/$pluginFilename
+    '';
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/applications/misc/keepass/keepass-plugins-load.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins-load.patch
@@ -1,0 +1,1 @@
++				m_pluginManager.LoadAllPlugins("$PATH$/lib/dotnet/keepass");

--- a/pkgs/applications/misc/keepass/keepass-plugins.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins.patch
@@ -1,0 +1,14 @@
+--- old/KeePass/Forms/MainForm.cs
++++ new/KeePass/Forms/MainForm.cs
+@@ -384,9 +384,$OUTPUT_LC$ @@ namespace KeePass.Forms
+ 			m_pluginManager.Initialize(m_pluginDefaultHost);
+ 
+ 			m_pluginManager.UnloadAllPlugins();
+-			if(AppPolicy.Current.Plugins)
+-				m_pluginManager.LoadAllPlugins(UrlUtil.GetFileDirectory(
+-					WinUtil.GetExecutable(), false, true));
++			if(AppPolicy.Current.Plugins) {
+$DO_LOADS$+			}
+ 
+ 			// Delete old files *after* loading plugins (when timestamps
+ 			// of loaded plugins have been updated already)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11706,6 +11706,8 @@ let
 
   keepass = callPackage ../applications/misc/keepass { };
 
+  keepass-keefox = callPackage ../applications/misc/keepass-plugins/keefox { };
+
   exrdisplay = callPackage ../applications/graphics/exrdisplay {
     fltk = fltk20;
   };


### PR DESCRIPTION
Hi, I started playing with NixOS recently and I've tried to add keefox (http://keefox.org/) to nixpkgs. After multiple attempts I still worry if my approach is acceptable, and after reading contributing notes in the manual I still worry whether I'm requesting a pull correctly, but hopefully I won't cause too much trouble :)
#### Why this is so complicated:

Keefox has two parts: a browser add-on and a KeePass plugin.

KeePass looks for plugins in directory containing KeePass.exe; AFAIU, on NixOS it meant effectively no plugin support. The first approach I had working was to modify keepass derivation to copy plugin to that directory if configuration flag was enabled - this worked, but coupled app to plugin tightly in repository.

I discovered buildEnv, but KeePass.exe would need to copied to the resulting environment rather than linked for the correct directory to be searched. Additionally, compiler is required at runtime for the plugin to be compiled during loading. Most probably this could have been overcome with more complex layering and specific copying. I wanted to avoid patching keepass (would addition of environmental variable for search path be a potential security issue?), but in the end, that's what is done - paths to plugins are hardcoded into the nix store. I hope the result is cleaner.

The patch is inline and makes whitespace significant. I could not work out how to move patch to files and not get errors :(
#### Merging

I use 15.09 stable nixos channel, and I **have tested** my changes by building keepass with and without keefox using nix-env, on user account, without mono in path. The pull request is against master, as stated in manual; I **haven't** tested nixpkgs master. I wonder if I should do a pull against release/15.09 instead?
