### PR TITLE
librsync needs --std=gnu89 due to use of inline

### DIFF
--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "librsync-${version}";
   version = "1.0.0";
-  
+
   src = fetchFromGitHub {
     owner = "librsync";
     repo = "librsync";
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ autoreconfHook perl zlib bzip2 popt ];
 
   configureFlags = if stdenv.isCygwin then "--enable-static" else "--enable-shared";
+
+  CFLAGS = "-std=gnu89";
 
   crossAttrs = {
     dontStrip = true;


### PR DESCRIPTION
Without this, if compiled with clang, all static functions do not end
up in the resultant shared library due to clang defaulting to c99.

The simple fix is to adjust CFLAGS, otherwise one needs to patch
a lot of inline's away needlessly.
