### PR TITLE
Ncftp manpage /usr/local workaround

### DIFF
--- a/pkgs/tools/networking/ncftp/default.nix
+++ b/pkgs/tools/networking/ncftp/default.nix
@@ -23,10 +23,12 @@ stdenv.mkDerivation {
     sed 's@/bin/rm@${coreutils}/bin/rm@g' -i configure
   '';
 
+  configureFlags = [ "--mandir=$out/share/man/" ];
+
   meta = with stdenv.lib; {
     description = "Command line FTP (File Transfer Protocol) client";
     homepage = http://www.ncftp.com/ncftp/;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
ncftp appears to not properly honor PREFIX in its manpage target and
tries to install them to /usr/local

Work around this by adding --mandir to its configure flags.
