### PR TITLE
display-managers: fix pam_env.so usage

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -162,7 +162,7 @@ in
 
       gdm.text = ''
         auth     requisite      pam_nologin.so
-        auth     required       pam_env.so
+        auth     required       pam_env.so envfile=${config.system.build.pamEnvironment}
 
         auth     required       pam_succeed_if.so uid >= 1000 quiet
         auth     optional       ${gnome3.gnome_keyring}/lib/security/pam_gnome_keyring.so

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -150,7 +150,7 @@ in
       allowNullPassword = true;
       startSession = true;
       text = ''
-        auth     required pam_env.so
+        auth     required pam_env.so envfile=${config.system.build.pamEnvironment}
         auth     required pam_permit.so
 
         account  required pam_permit.so


### PR DESCRIPTION
 Fixed usage of pam_env.so PAM module in lightDM and GDM.
