### PR TITLE
bzip2: avoid https url in native build

### DIFF
--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -1,7 +1,11 @@
-{ stdenv, fetchurl, libtool, autoconf, automake, pkgconfig, gnum4 }:
+{ stdenv, fetchurl, linkStatic ? false }:
 
 let
   version = "1.0.6";
+
+  sharedLibrary = !stdenv.isDarwin && !(stdenv ? isStatic)
+               && stdenv.system != "i686-cygwin" && !linkStatic;
+
 in stdenv.mkDerivation {
   name = "bzip2-${version}";
 
@@ -10,29 +14,49 @@ in stdenv.mkDerivation {
     sha256 = "1kfrc7f0ja9fdn6j1y6yir6li818npy6217hvr3wzmnmzhs8z152";
   };
 
-  patches = [
-    # original upstream for the autoconf patch is here:
-    # http://ftp.suse.com/pub/people/sbrabec/bzip2/for_downstream/bzip2-1.0.6-autoconfiscated.patch
-    # but we get the mingw-builds version of the patch, which fixes
-    # a few more issues
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/niXman/mingw-builds/17ae841dcf6e72badad7941a06d631edaf687436/patches/bzip2/bzip2-1.0.6-autoconfiscated.patch";
-      sha256 = "1flbd3i8vg9kzq0a712qcg9j2c4ymnqvgd0ldyafpzvbqj1iicnp";
-    })
-  ];
-
-  patchFlags = "-p0";
-
-  nativeBuildInputs = [ libtool autoconf automake gnum4 pkgconfig ];
-
-  preConfigure = "sh ./autogen.sh";
-
   crossAttrs = {
-    # https://github.com/niXman/mingw-builds/blob/master/patches/bzip2/bzip2-1.0.5-slash.patch
-    postPatch = ''
+    patchPhase = ''
       sed -i -e '/<sys\\stat\.h>/s|\\|/|' bzip2.c
+      sed -i -e 's/CC=gcc/CC=${stdenv.cross.config}-gcc/' \
+        -e 's/AR=ar/AR=${stdenv.cross.config}-ar/' \
+        -e 's/RANLIB=ranlib/RANLIB=${stdenv.cross.config}-ranlib/' \
+        -e 's/bzip2recover test/bzip2recover/' \
+        Makefile*
     '';
   };
+
+  preBuild = stdenv.lib.optionalString sharedLibrary ''
+    make -f Makefile-libbz2_so
+  '';
+
+  preInstall = stdenv.lib.optionalString sharedLibrary ''
+    mkdir -p $out/lib
+    mv libbz2.so* $out/lib
+    ( cd $out/lib &&
+      ln -s libbz2.so.1.0.? libbz2.so &&
+      ln -s libbz2.so.1.0.? libbz2.so.1
+    )
+  '';
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    rm $out/bin/bunzip2* $out/bin/bzcat*
+    ln -s bzip2 $out/bin/bunzip2
+    ln -s bzip2 $out/bin/bzcat
+  '';
+
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile --replace 'CC=gcc' 'CC=clang'
+  '';
+
+  preConfigure = ''
+    substituteInPlace Makefile --replace '$(PREFIX)/man' '$(PREFIX)/share/man'
+  '';
+
+  makeFlags = stdenv.lib.optional linkStatic "LDFLAGS=-static";
+
+  inherit linkStatic;
 
   meta = {
     homepage = "http://www.bzip.org";

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, linkStatic ? false }:
+{ stdenv, fetchurl, libtool, autoconf, automake, gnum4, linkStatic ? false }:
 
 let
   version = "1.0.6";
@@ -15,14 +15,26 @@ in stdenv.mkDerivation {
   };
 
   crossAttrs = {
-    patchPhase = ''
+    buildInputs = [ libtool autoconf automake gnum4 ];
+    patches = [
+      # original upstream for the autoconf patch is here:
+      # http://ftp.suse.com/pub/people/sbrabec/bzip2/for_downstream/bzip2-1.0.6-autoconfiscated.patch
+      # but we get the mingw-builds version of the patch, which fixes
+      # a few more issues
+      (fetchurl {
+        url = "https://raw.githubusercontent.com/niXman/mingw-builds/17ae841dcf6e72badad7941a06d631edaf687436/patches/bzip2/bzip2-1.0.6-autoconfiscated.patch";
+        sha256 = "1flbd3i8vg9kzq0a712qcg9j2c4ymnqvgd0ldyafpzvbqj1iicnp";
+      })
+    ];
+    patchFlags = "-p0";
+    postPatch = ''
       sed -i -e '/<sys\\stat\.h>/s|\\|/|' bzip2.c
-      sed -i -e 's/CC=gcc/CC=${stdenv.cross.config}-gcc/' \
-        -e 's/AR=ar/AR=${stdenv.cross.config}-ar/' \
-        -e 's/RANLIB=ranlib/RANLIB=${stdenv.cross.config}-ranlib/' \
-        -e 's/bzip2recover test/bzip2recover/' \
-        Makefile*
     '';
+    preConfigure = "sh ./autogen.sh";
+    # clear native hooks that are not needed with autoconf
+    preBuild = "";
+    preInstall = "";
+    postInstall = "";
   };
 
   preBuild = stdenv.lib.optionalString sharedLibrary ''


### PR DESCRIPTION
This reverts https://github.com/NixOS/nixpkgs/pull/11127 and instead merges https://github.com/NixOS/nixpkgs/pull/11126 as we cannot have https urls in staging-small (for bootstrapping). See discussion at https://github.com/NixOS/hydra/issues/257 for more details.
