### PR TITLE
services.xserver: Disable Ctrl+Alt+Backspace by default

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -409,6 +409,16 @@ in
           if possible.
         '';
       };
+
+      enableCtrlAltBackspace = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the DontZap option, which binds Ctrl+Alt+Backspace
+          to forcefully kill X. This can lead to data loss and is disabled
+          by default.
+        '';
+      };
     };
 
   };
@@ -533,6 +543,7 @@ in
       ''
         Section "ServerFlags"
           Option "AllowMouseOpenFail" "on"
+          Option "DontZap" "${if cfg.enableCtrlAltBackspace then "off" else "on"}"
           ${cfg.serverFlagsSection}
         EndSection
 


### PR DESCRIPTION
Ctrl+Alt+Backspace is usually enabled by default under X, and is a
keyboard shortcut that forcefully kills the current X server. This can
lead to data loss by users if accidentally pressed. This commit
introduces a new option, services.xserver.enableCtrlAltBackspace, that
is _disabled_ by default. If set to true, the previous behavior can be
restored.

A similar decision was made by the Ubuntu team, and is documented here:
https://wiki.ubuntu.com/XorgCtrlAltBackspace
