### PR TITLE
elm: Update elm-lang/core hash.

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
@@ -13,6 +13,6 @@
   };
   "elm-lang/core" = {
     version = "3.0.0";
-    sha256 = "1bc4wibcmv6sxf3wq83avhzwj137wac1gf3zx52rfwnb5jm3lipm";
+    sha256 = "18pdsnz05pjhdv575l3bqzrjd7780zgpcklg4c6lvwwcanpg42pk";
   };
 }


### PR DESCRIPTION
elm-lang/core tag 3.0.0 was moved. 
See: https://groups.google.com/d/msg/elm-dev/K5eu8S5to-c/Bl4-Z_0QBQAJ
