### PR TITLE
shotwell: fix failure to configure

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, m4, glibc, gtk3, libexif, libgphoto2, libsoup, libxml2, vala, sqlite
-, webkitgtk24x, pkgconfig, gnome3, gst_all_1, which, udev, libraw, glib, json_glib
+, webkitgtk24x, pkgconfig, gnome3, gst_all_1, which, udev, libgudev, libraw, glib, json_glib
 , gettext, desktop_file_utils, lcms2, gdk_pixbuf, librsvg, makeWrapper
 , gnome_doc_utils, hicolor_icon_theme }:
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ m4 glibc gtk3 libexif libgphoto2 libsoup libxml2 vala sqlite webkitgtk24x
                   pkgconfig gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee
-                  which udev gnome3.gexiv2 hicolor_icon_theme
+                  which udev libgudev gnome3.gexiv2 hicolor_icon_theme
                   libraw json_glib gettext desktop_file_utils glib lcms2 gdk_pixbuf librsvg
                   makeWrapper gnome_doc_utils gnome3.rest
                   gnome3.defaultIconTheme ];


### PR DESCRIPTION
Without this change, shotwell would fail even to configure, for lack of
gudev; I infer that libgudev was recently split off of udev, since this
was working fine until a couple of weeks ago.

Resolves #11245
