### PR TITLE
nix-zsh-completions package and module support 

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -25,7 +25,7 @@ in
       enable = mkOption {
         default = false;
         description = ''
-          Whenever to configure Zsh as an interactive shell.
+          Whether to configure zsh as an interactive shell.
         '';
         type = types.bool;
       };
@@ -73,6 +73,14 @@ in
         type = types.lines;
       };
 
+      enableCompletion = mkOption {
+        default = true;
+        description = ''
+          Enable zsh completion for all interactive zsh shells.
+        '';
+        type = types.bool;
+      };
+
     };
 
   };
@@ -101,6 +109,13 @@ in
         export HISTFILE=$HOME/.zsh_history
 
         setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
+
+        # Tell zsh how to find installed completions
+        for p in ''${(z)NIX_PROFILES}; do
+          fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions)
+        done
+
+        ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}
       '';
 
     };
@@ -161,7 +176,8 @@ in
 
     environment.etc."zinputrc".source = ./zinputrc;
 
-    environment.systemPackages = [ pkgs.zsh ];
+    environment.systemPackages = [ pkgs.zsh ]
+      ++ optional cfg.enableCompletion pkgs.nix-zsh-completions;
 
     #users.defaultUserShell = mkDefault "/run/current-system/sw/bin/zsh";
 

--- a/pkgs/shells/nix-zsh-completions/default.nix
+++ b/pkgs/shells/nix-zsh-completions/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nix-zsh-completions";
+
+  src = fetchFromGitHub {
+    owner = "spwhitt";
+    repo = "nix-zsh-completions";
+    rev = "0.2";
+    sha256 = "0wimjdxnkw1lzhjn28zm4pgbij86ym0z17ayivpzz27g0sacimga";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/zsh/site-functions
+    cp _* $out/share/zsh/site-functions
+  '';
+
+  meta = {
+    homepage = "http://github.com/spwhitt/nix-zsh-completions";
+    description = "ZSH completions for Nix, NixOS, and NixOps";
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.spwhitt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3708,6 +3708,8 @@ let
 
   zsh = callPackage ../shells/zsh { };
 
+  nix-zsh-completions = callPackage ../shells/nix-zsh-completions { };
+
 
   ### DEVELOPMENT / COMPILERS
 


### PR DESCRIPTION
1. Adds a package for nix-zsh-completions
2. Configures zsh's fpath to include completions installed through Nix packages
3. Adds an enableCompletion option ZSH module

I set up the enableCompletion option to also pull in the nix-zsh-completions package, under the assumption that anyone using completions on NixOS is probably interested in completions for the Nix utilities as well. If anyone doesn't like this, feel free to let me know and I'll remove that line, and people will have to add nix-zsh-completions to their `systemPackages` manually.

@jagajaga @offlinehacker @garbas 
