### PR TITLE
bump ghcjs, ghcjs-boot, ghcjs-shims

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -47,8 +47,8 @@ mkDerivation (rec {
   src = fetchFromGitHub {
     owner = "ghcjs";
     repo = "ghcjs";
-    rev = "2ae1276a97c9f32c4b02080d1bb363cf0c2c553c";
-    sha256 = "18m1737w4bfn84cnwcf021gsy69c84dlkwxnyf4r5h97gly6jx7q";
+    rev = "561365ba1667053b5dc5846e2a8edb33eaa3f6dd";
+    sha256 = "1vfa7j0ql3sng29m944iznjw9hcmyl57nfkgxa33dvi2ival8dl2";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/compilers/ghcjs/ghcjs-boot.nix
+++ b/pkgs/development/compilers/ghcjs/ghcjs-boot.nix
@@ -1,7 +1,7 @@
 { fetchgit }:
 fetchgit {
   url = git://github.com/ghcjs/ghcjs-boot.git;
-  rev = "39cd58e12f02fa99f493387ba4c3708819a72294";
-  sha256 = "0s7hvg60piklrg9ypa7r44l4qzvpinrgsaffak6fr7gd3k08wn9d";
+  rev = "3529c6ab61d5f786bdde449fd069520664330b30";
+  sha256 = "0d33nmbwrdn7ai4lsrn3qzcfy71hbini0jl437387cxdh3z6sjqa";
   fetchSubmodules = true;
 }

--- a/pkgs/development/compilers/ghcjs/shims.nix
+++ b/pkgs/development/compilers/ghcjs/shims.nix
@@ -2,6 +2,6 @@
 fetchFromGitHub {
   owner = "ghcjs";
   repo = "shims";
-  rev = "f17d10cf47450fe4e00433e988db0bddddb35cc0";
-  sha256 = "1kgnkkz1khzkmb0dm0ssp8l17iy9d9n9phszcj6vg9vi7v9y7l05";
+  rev = "09e37565df8bbf876d4b7f36fbc19aa2140844a7";
+  sha256 = "000ds78pv56v4drbdx3y7xncx9224l28n7cal9gy3inns1mq6yhj";
 }


### PR DESCRIPTION
This makes it possible to compile the new version of ghcjs-dom, which appears to work again in my tests.
