### PR TITLE
subsonic: 5.2.1 -> 5.3

### DIFF
--- a/pkgs/servers/misc/subsonic/default.nix
+++ b/pkgs/servers/misc/subsonic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, jre }:
 
-let version = "5.2.1"; in
+let version = "5.3"; in
 
 stdenv.mkDerivation rec {
   name = "subsonic-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/subsonic/subsonic-${version}-standalone.tar.gz";
-    sha256 = "523fa8357c961c1ae742a15f0ceaabdd41fcba9137c29d244957922af90ee791";
+    sha256 = "11ylg89r9dbxyas7jcyij6fpm84dixskdkahb3hdi4ig0wqwswfw";
   };
 
   inherit jre;


### PR DESCRIPTION
Update Subsonic from 5.2.1 to 5.3. Tested by building and running server -- I've already upgraded to it on my machine without incident.
