### PR TITLE
ghcjs: bump version number to 0.2.0

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -40,7 +40,7 @@
 , ghcjsBoot ? import ./ghcjs-boot.nix { inherit fetchgit; }
 , shims ? import ./shims.nix { inherit fetchFromGitHub; }
 }:
-let version = "0.1.0"; in
+let version = "0.2.0"; in
 mkDerivation (rec {
   pname = "ghcjs";
   inherit version;


### PR DESCRIPTION
Actually should have been this for a while.

cc @luigy
