### PR TITLE
zsh module: add /share/zsh to pathsToLink

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -163,6 +163,8 @@ in
 
     environment.systemPackages = [ pkgs.zsh ];
 
+    environment.pathsToLink = optionals cfg.enableCompletion [ "/share/zsh" ];
+
     #users.defaultUserShell = mkDefault "/run/current-system/sw/bin/zsh";
 
     environment.shells =


### PR DESCRIPTION
Accidentally omitted from #11251. @abbradar @jagajaga 
