### PR TITLE
parallel: Revert changes that broke go packages

### DIFF
--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -8,13 +8,14 @@ stdenv.mkDerivation rec {
     sha256 = "0phn9dlkqlq3cq468ypxbbn78bsjcin743pyvf8ip4qg6jz662jm";
   };
 
-  nativeBuildInputs = [ makeWrapper perl ];
+  nativeBuildInputs = [ makeWrapper ];
 
   preFixup = ''
-    patchShebangs $out/bin
+    sed -i 's,#![ ]*/usr/bin/env[ ]*perl,#!${perl}/bin/perl,' $out/bin/*
 
     wrapProgram $out/bin/parallel \
-      ${if stdenv.isLinux then ("--prefix PATH \":\" ${procps}/bin") else ""}
+      ${if stdenv.isLinux then ("--prefix PATH \":\" ${procps}/bin") else ""} \
+      --prefix PATH : "${perl}/bin" \
   '';
 
   doCheck = true;


### PR DESCRIPTION
This is a partial revert of ed2b30dc283f2ec326fe80dc5259682d1f0f4fb3, which, in addition to upgrading the version of parallel, made changes to the build that ended up breaking at least go packages, and perhaps all users of parallel.

This really should have gone through better testing.
