### PR TITLE
python: CommonMark and recommonmark packages

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2344,6 +2344,23 @@ let
   };
 
 
+  CommonMark = buildPythonPackage rec {
+    name = "CommonMark-${version}";
+    version = "0.5.4";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/C/CommonMark/${name}.tar.gz";
+      sha256 = "34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5";
+    };
+
+    meta = {
+      description = "Python parser for the CommonMark Markdown spec";
+      homepage = https://github.com/rolandshoemaker/CommonMark-py;
+      license = licenses.bsd3;
+    };
+  };
+
+
   coilmq = buildPythonPackage (rec {
     name = "coilmq-0.6.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15442,6 +15442,27 @@ let
     };
   };
 
+  recommonmark = buildPythonPackage rec {
+    name = "recommonmark-${version}";
+    version = "0.2.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/recommonmark/${name}.tar.gz";
+      sha256 = "28c0babc79c487280fc5bf5daf1f3f1d734e9e4293ba929a7617524ff6911fd7";
+    };
+
+    buildInputs = with self; [ pytest sphinx ];
+    propagatedBuildInputs = with self; [ CommonMark docutils ];
+
+    meta = {
+      description = "A docutils-compatibility bridge to CommonMark";
+      homepage = https://github.com/rtfd/recommonmark;
+      license = licenses.mit;
+      maintainer = with maintainers; [ fridh ];
+    };
+
+  };
+
   redis = buildPythonPackage rec {
     name = "redis-2.10.3";
 


### PR DESCRIPTION
Two new packages. One is a commonmark parser, the other a Sphinx plugin for commonmark.
@domenkozar 
