### PR TITLE
wireshark: 1.12.7 -> 2.0.0

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -10,7 +10,7 @@ assert withQt -> !withGtk && qt4 != null;
 with stdenv.lib;
 
 let
-  version = "1.12.7";
+  version = "2.0.0";
   variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
 in
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.bz2";
-    sha256 = "0b7rc1l1gvzcz7gfa6g7pcn32zrcfiqjx0rxm6cg3q1cwwa1qjn7";
+    sha256 = "1pci4vj23wamycfj4lxxmpxps96yq6jfmqn7hdvisw4539v6q0lh";
   };
 
   buildInputs = [
@@ -70,6 +70,6 @@ stdenv.mkDerivation {
     '';
 
     platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ simons bjornfor ];
+    maintainers = with stdenv.lib.maintainers; [ simons bjornfor fpletz ];
   };
 }

--- a/pkgs/applications/networking/sniffers/wireshark/wireshark-lookup-dumpcap-in-path.patch
+++ b/pkgs/applications/networking/sniffers/wireshark/wireshark-lookup-dumpcap-in-path.patch
@@ -1,6 +1,6 @@
-From 188e8858243b2278239261aaaaea7ad07476d561 Mon Sep 17 00:00:00 2001
+From 5bef9deeff8a2e4401de0f45c9701cd6f98f29d8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B8rn=20Forsman?= <bjorn.forsman@gmail.com>
-Date: Sun, 13 Apr 2014 15:17:24 +0200
+Date: Thu, 26 Nov 2015 21:03:35 +0100
 Subject: [PATCH] Lookup dumpcap in PATH
 
 NixOS patch: Look for dumpcap in PATH first, because there may be a
@@ -10,20 +10,21 @@ non-setuid dumpcap binary.
 Also change execv() to execvp() because we've set argv[0] to "dumpcap"
 and have to enable PATH lookup. Wireshark is not a setuid program, so
 looking in PATH is not a security issue.
----
- capture_sync.c | 18 ++++++++++++++----
- 1 file changed, 14 insertions(+), 4 deletions(-)
 
-diff --git a/capture_sync.c b/capture_sync.c
-index eb05fae..efb5675 100644
---- a/capture_sync.c
-+++ b/capture_sync.c
-@@ -326,8 +326,18 @@ init_pipe_args(int *argc) {
-     argv = (char **)g_malloc(sizeof (char *));
-     *argv = NULL;
- 
--    /* take Wireshark's absolute program path and replace "Wireshark" with "dumpcap" */
--    exename = g_strdup_printf("%s" G_DIR_SEPARATOR_S "dumpcap", progfile_dir);
+Signed-off-by: Franz Pletz <fpletz@fnordicwalking.de>
+---
+ capchild/capture_sync.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/capchild/capture_sync.c b/capchild/capture_sync.c
+index 970688e..49914d5 100644
+--- a/capchild/capture_sync.c
++++ b/capchild/capture_sync.c
+@@ -332,7 +332,18 @@ init_pipe_args(int *argc) {
+ #ifdef _WIN32
+     exename = g_strdup_printf("%s\\dumpcap.exe", progfile_dir);
+ #else
+-    exename = g_strdup_printf("%s/dumpcap", progfile_dir);
 +    /*
 +     * NixOS patch: Look for dumpcap in PATH first, because there may be a
 +     * dumpcap setuid-wrapper that we want to use instead of the default
@@ -34,12 +35,12 @@ index eb05fae..efb5675 100644
 +        exename = g_strdup_printf("dumpcap");
 +    } else {
 +        /* take Wireshark's absolute program path and replace "Wireshark" with "dumpcap" */
-+        exename = g_strdup_printf("%s" G_DIR_SEPARATOR_S "dumpcap", progfile_dir);
++        exename = g_strdup_printf("%s/dumpcap", progfile_dir);
 +    }
+ #endif
  
      /* Make that the first argument in the argument list (argv[0]). */
-     argv = sync_pipe_add_arg(argv, argc, exename);
-@@ -649,7 +659,7 @@ sync_pipe_start(capture_options *capture_opts, capture_session *cap_session, voi
+@@ -729,7 +740,7 @@ sync_pipe_start(capture_options *capture_opts, capture_session *cap_session, voi
           */
          dup2(sync_pipe[PIPE_WRITE], 2);
          ws_close(sync_pipe[PIPE_READ]);
@@ -48,7 +49,7 @@ index eb05fae..efb5675 100644
          g_snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
                     argv[0], g_strerror(errno));
          sync_pipe_errmsg_to_parent(2, errmsg, "");
-@@ -879,7 +889,7 @@ sync_pipe_open_command(char** argv, int *data_read_fd,
+@@ -997,7 +1008,7 @@ sync_pipe_open_command(char** argv, int *data_read_fd,
          dup2(sync_pipe[PIPE_WRITE], 2);
          ws_close(sync_pipe[PIPE_READ]);
          ws_close(sync_pipe[PIPE_WRITE]);
@@ -58,5 +59,5 @@ index eb05fae..efb5675 100644
                     argv[0], g_strerror(errno));
          sync_pipe_errmsg_to_parent(2, errmsg, "");
 -- 
-1.9.0
+2.6.3
 


### PR DESCRIPTION
Updates wireshark to the next major stable version. Also updated and tested the patch to search for dumpcap in PATH by @bjornfor.

cc @peti
