### PR TITLE
pythonPackages.gateone: Fix python packages reference

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4181,7 +4181,7 @@ in modules // {
       repo = "GateOne";
       sha256 ="0zp9vfs6sqbx4d0g45kkjinfmsl9zqwa6bhp3xd81wx3ph9yr1hq";
     };
-    propagatedBuildInputs = with pkgs.self; [tornado futures html5lib readline pkgs.openssl];
+    propagatedBuildInputs = with self; [tornado futures html5lib readline pkgs.openssl];
     meta = {
       homepage = https://liftoffsoftware.com/;
       description = "GateOne is a web-based terminal emulator and SSH client";


### PR DESCRIPTION
This fixes an error that was introduced with https://github.com/NixOS/nixpkgs/commit/d2519c1f160e7cb63a845a5a2f57b340ea8d05aa#diff-2afbba83e1b14f9e0c304c769831a0e2L4168.

See Travis fails like this one: https://travis-ci.org/NixOS/nixpkgs/builds/93419025#L173

cc @garbas 
