### PR TITLE
morituri fails because of missing CDDB dependency

### DIFF
--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   pythonPath = [
     pygobject gst_python pythonPackages.musicbrainzngs
     pythonPackages.pycdio pythonPackages.pyxdg setuptools
+    pythonPackages.CDDB
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, python, pythonPackages, cdparanoia, cdrdao
+{ stdenv, fetchgit, python, pythonPackages, cdparanoia, cdrdao
 , pygobject, gst_python, gst_plugins_base, gst_plugins_good
-, setuptools, utillinux, makeWrapper, substituteAll }:
+, setuptools, utillinux, makeWrapper, substituteAll, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "morituri-${version}";
-  version = "0.2.3";
+  version = "0.2.3.20151109";
   namePrefix = "";
 
-  src = fetchurl {
-    url = "http://thomas.apestaart.org/download/morituri/${name}.tar.bz2";
-    sha256 = "1b30bs1y8azl04izsrl01gw9ys0lhzkn5afxi4p8qbiri2h4v210";
+  src = fetchgit {
+    url = "https://github.com/thomasvs/morituri.git";
+    fetchSubmodules = true;
+    rev = "135b2f7bf27721177e3aeb1d26403f1b29116599";
+    sha256 = "1ccxq1spny6xgd7nqwn13n9nqa00ay0nhflg3vbdkvbirh8fgxwq";
   };
 
   pythonPath = [
@@ -18,6 +20,7 @@ stdenv.mkDerivation rec {
     pythonPackages.CDDB
   ];
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
     python cdparanoia cdrdao utillinux makeWrapper
     gst_plugins_base gst_plugins_good

--- a/pkgs/applications/audio/morituri/paths.patch
+++ b/pkgs/applications/audio/morituri/paths.patch
@@ -1,8 +1,9 @@
-diff -Nurp morituri-0.2.3-orig/doc/Makefile.in morituri-0.2.3/doc/Makefile.in
---- morituri-0.2.3-orig/doc/Makefile.in	2014-12-23 12:44:46.222410092 +0100
-+++ morituri-0.2.3/doc/Makefile.in	2014-12-23 12:46:49.619756940 +0100
-@@ -486,7 +486,7 @@ morituri.ics: $(top_srcdir)/morituri.doa
- 	-moap doap -f $(top_srcdir)/morituri.doap ical > morituri.ics
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index c115c2c..78c883e 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -24,7 +24,7 @@ morituri.ics: $(top_srcdir)/morituri.doap
+ man_MANS = rip.1
  
  rip.1: $(top_srcdir)/morituri/extern/python-command/scripts/help2man $(top_srcdir)/morituri
 -	PYTHONPATH=$(top_srcdir) $(PYTHON) $(top_srcdir)/morituri/extern/python-command/scripts/help2man morituri.rip.main.Rip rip > rip.1
@@ -10,9 +11,10 @@ diff -Nurp morituri-0.2.3-orig/doc/Makefile.in morituri-0.2.3/doc/Makefile.in
  
  clean-local:
  	@rm -rf reference
-diff -Nurp morituri-0.2.3-orig/morituri/common/program.py morituri-0.2.3/morituri/common/program.py
---- morituri-0.2.3-orig/morituri/common/program.py	2014-12-23 12:44:46.218410048 +0100
-+++ morituri-0.2.3/morituri/common/program.py	2014-12-23 12:46:49.647757245 +0100
+diff --git a/morituri/common/program.py b/morituri/common/program.py
+index d340fdd..15cb751 100644
+--- a/morituri/common/program.py
++++ b/morituri/common/program.py
 @@ -92,13 +92,13 @@ class Program(log.Loggable):
          """
          Load the given device.
@@ -38,19 +40,12 @@ diff -Nurp morituri-0.2.3-orig/morituri/common/program.py morituri-0.2.3/moritur
  
      def getFastToc(self, runner, toc_pickle, device):
          """
-diff -Nurp morituri-0.2.3-orig/morituri/extern/python-command/scripts/help2man morituri-0.2.3/morituri/extern/python-command/scripts/help2man
---- morituri-0.2.3-orig/morituri/extern/python-command/scripts/help2man	2014-12-23 12:44:46.206409916 +0100
-+++ morituri-0.2.3/morituri/extern/python-command/scripts/help2man	2014-12-23 12:46:49.631757074 +0100
-@@ -1,4 +1,4 @@
--#!/usr/bin/python
-+#!@python@/bin/python
- 
- # -*- Mode: Python -*-
- # vi:si:et:sw=4:sts=4:ts=4
-diff -Nurp morituri-0.2.3-orig/morituri/program/cdparanoia.py morituri-0.2.3/morituri/program/cdparanoia.py
---- morituri-0.2.3-orig/morituri/program/cdparanoia.py	2014-12-23 12:44:46.202409873 +0100
-+++ morituri-0.2.3/morituri/program/cdparanoia.py	2014-12-23 12:46:49.659757376 +0100
-@@ -278,7 +278,7 @@ class ReadTrackTask(log.Loggable, task.T
+Submodule morituri/extern/python-command contains modified content
+diff --git a/morituri/program/cdparanoia.py b/morituri/program/cdparanoia.py
+index 46176d5..fce14a5 100644
+--- a/morituri/program/cdparanoia.py
++++ b/morituri/program/cdparanoia.py
+@@ -278,7 +278,7 @@ class ReadTrackTask(log.Loggable, task.Task):
              stopTrack, stopOffset)
  
          bufsize = 1024
@@ -68,9 +63,10 @@ diff -Nurp morituri-0.2.3-orig/morituri/program/cdparanoia.py morituri-0.2.3/mor
          _VERSION_RE,
          "%(version)s %(release)s")
  
-diff -Nurp morituri-0.2.3-orig/morituri/program/cdrdao.py morituri-0.2.3/morituri/program/cdrdao.py
---- morituri-0.2.3-orig/morituri/program/cdrdao.py	2014-12-23 12:44:46.202409873 +0100
-+++ morituri-0.2.3/morituri/program/cdrdao.py	2014-12-23 12:46:49.667757463 +0100
+diff --git a/morituri/program/cdrdao.py b/morituri/program/cdrdao.py
+index c6fba64..c4d0306 100644
+--- a/morituri/program/cdrdao.py
++++ b/morituri/program/cdrdao.py
 @@ -257,7 +257,7 @@ class CDRDAOTask(ctask.PopenTask):
  
      def start(self, runner):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1953,6 +1953,23 @@ let
     };
   };
 
+  CDDB = buildPythonPackage rec {
+    name = "CDDB-1.4";
+
+    disabled = !isPy27;
+
+    src = pkgs.fetchurl {
+      url = "http://cddb-py.sourceforge.net/${name}.tar.gz";
+      sha256 = "098xhd575ibvdx7i3dny3lwi851yxhjg2hn5jbbgrwj833rg5l5w";
+    };
+
+    meta = {
+      homepage = http://cddb-py.sourceforge.net/;
+      description = "CDDB and FreeDB audio CD track info access";
+      license = licenses.gpl2Plus;
+    };
+  };
+
 
   celery = buildPythonPackage rec {
     name = "celery-${version}";


### PR DESCRIPTION
When trying to rip a CD with morituri (at least one that is not on MusicBrainz), morituri fails with the following message:

```
$ rip cd rip -U
WARNING: using default offset 0.
Install pycdio and run 'rip offset find' to detect your drive's offset.
Checking device /dev/sr0
eject: CD-ROM tray close command failed: Input/output error
CDDB disc id: 830a170a
MusicBrainz disc id Sk_yjKnzHChyKzedESUFC_oj1x0-
MusicBrainz lookup URL http://mm.musicbrainz.org/bare/cdlookup.html?toc=1+10+193942+150+15006+39353+53871+74629+87758+110028+125772+147799+166402&tracks=10&id=Sk_yjKnzHChyKzedESUFC_oj1x0-
Disc duration: 00:43:03.893, 10 audio tracks
Error: NotFoundException(ResponseError(),)
Continuing without metadata
Submit this disc to MusicBrainz at the above URL.

Could not import python module 'CDDB'
This module is part of python-CDDB.
See http://cddb-py.sourceforge.net/ for more information.

Traceback (most recent call last):
  File "/nix/store/yzrrrp1krv3x504n208js7hrlakc2czh-morituri-0.2.3/bin/.rip-wrapped", line 41, in <module>
    sys.exit(main.main(sys.argv[1:]))
  File "/nix/store/yzrrrp1krv3x504n208js7hrlakc2czh-morituri-0.2.3/lib/python2.7/site-packages/morituri/rip/main.py", line 50, in main   
    h.handleImportError(e)
  File "/nix/store/yzrrrp1krv3x504n208js7hrlakc2czh-morituri-0.2.3/lib/python2.7/site-packages/morituri/extern/deps/deps.py", line 128, in handleImportError
    self.handleMissingDependency(dep)
  File "/nix/store/yzrrrp1krv3x504n208js7hrlakc2czh-morituri-0.2.3/lib/python2.7/site-packages/morituri/extern/deps/deps.py", line 148, in handleMissingDependency
    d = distro.getDistroFromRelease()
  File "/nix/store/yzrrrp1krv3x504n208js7hrlakc2czh-morituri-0.2.3/lib/python2.7/site-packages/morituri/extern/deps/distro.py", line 74, in getDistroFromRelease
    raise DistroException('lsb_release binary not found')
morituri.extern.deps.distro.DistroException: lsb_release binary not found
```

This PR adds the missing CDDB dependency.  Unfortunately this is not enough, there is a bug in `rip cd rip -U` which has been [fixed since the latest release](https://github.com/thomasvs/morituri/commit/01f07c5ad90563dc258eba4134a2544d192d0a49), so I have updated morituri to the latest git revision as well.
