### PR TITLE
dmd: Adding gcc runtime dependency

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -256,6 +256,7 @@
   thammers = "Tobias Hammerschmidt <jawr@gmx.de>";
   the-kenny = "Moritz Ulrich <moritz@tarn-vedra.de>";
   theuni = "Christian Theune <ct@flyingcircus.io>";
+  thomad = "Thomas Mader <thomas.mader@gmail.com>";
   thoughtpolice = "Austin Seipp <aseipp@pobox.com>";
   titanous = "Jonathan Rudenberg <jonathan@titanous.com>";
   tomberek = "Thomas Bereknyei <tomberek@gmail.com>";

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, curl }:
+{ stdenv, fetchurl, unzip, curl, makeWrapper, gcc }:
 
 stdenv.mkDerivation {
   name = "dmd-2.067.1";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "0ny99vfllvvgcl79pwisxcdnb3732i827k9zg8c0j4s0n79k5z94";
   };
 
-  buildInputs = [ unzip curl ];
+  buildInputs = [ unzip curl makeWrapper ];
 
   # Allow to use "clang++", commented in Makefile
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -46,6 +46,8 @@ stdenv.mkDerivation {
 
       cp -r std $out/include/d2
       cp -r etc $out/include/d2
+
+      wrapProgram $out/bin/dmd --prefix PATH ":" "${gcc}/bin/"
 
       cd $out/bin
       tee dmd.conf << EOF

--- a/pkgs/development/compilers/dmd/dmd.2.067.1.nix
+++ b/pkgs/development/compilers/dmd/dmd.2.067.1.nix
@@ -1,19 +1,15 @@
-{ stdenv, callPackage, fetchurl, unzip, which, makeWrapper, gcc }:
-
-let
-  bootstrap = callPackage ./dmd.2.067.1.nix { };
-in
+{ stdenv, fetchurl, unzip, makeWrapper, gcc }:
 
 stdenv.mkDerivation rec {
-  version = "2.069.1";
+  version = "2.067.1";
   name = "dmd-${version}";
 
   src = fetchurl {
     url = "http://downloads.dlang.org/releases/2015/dmd.${version}.zip";
-    sha256 = "1g1sff6zp8cnzrlffwjfh0ff2y2ijhd558nz5fhbwwffrjgz4wwc";
+    sha256 = "0ny99vfllvvgcl79pwisxcdnb3732i827k9zg8c0j4s0n79k5z94";
   };
 
-  buildInputs = [ unzip which makeWrapper ];
+  buildInputs = [ unzip makeWrapper ];
 
   # Allow to use "clang++", commented in Makefile
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -22,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
       cd src/dmd
-      make -f posix.mak INSTALL_DIR=$out HOST_DC=${bootstrap}/bin/dmd
+      make -f posix.mak INSTALL_DIR=$out
       export DMD=$PWD/dmd
       cd ../druntime
       make -f posix.mak INSTALL_DIR=$out DMD=$DMD


### PR DESCRIPTION
Adding gcc runtime dependency because dmd uses the linker of gcc on linux.
If no gcc-wrapper is installed in the current profile and one tries to compile a simple Hello World Program via 'dmd hello.d' the compilation succeeds but the linking fails with:

gcc: No such file or directory
--- errorlevel 255

This is because dmd uses the gcc linker.
I tested using 'nix-env -f . -iA dmd' on my branch based on release-15.09. I am not sure how to best push changes to master. My installed system version is release-15.09 and I don't want to build additional packages.
