### PR TITLE
syncthing: 0.11 -> 0.12

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -21,7 +21,7 @@ in
         description = ''
           Whether to enable the Syncthing, self-hosted open-source alternative
           to Dropbox and BittorrentSync. Initial interface will be
-          available on http://127.0.0.1:8080/.
+          available on http://127.0.0.1:8384/.
         '';
       };
 
@@ -39,6 +39,17 @@ in
           Path where the settings and keys will exist.
         '';
       };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.syncthing;
+        example = literalExample "pkgs.syncthing";
+        description = ''
+          Syncthing package to use.
+        '';
+      };
+
+
 
     };
 
@@ -66,7 +77,7 @@ in
         };
       };
 
-    environment.systemPackages = [ pkgs.syncthing ];
+    environment.systemPackages = [ cfg.package ];
 
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4864,7 +4864,7 @@ let
   tinycc = callPackage ../development/compilers/tinycc { };
 
   trv = callPackage ../development/tools/misc/trv {
-   inherit (ocamlPackages_4_02) findlib camlp4 core async async_unix 
+   inherit (ocamlPackages_4_02) findlib camlp4 core async async_unix
      async_extra sexplib async_shell core_extended async_find cohttp uri;
     ocaml = ocaml_4_02;
   };
@@ -13102,8 +13102,8 @@ let
 
   symlinks = callPackage ../tools/system/symlinks { };
 
-  # syncthing is pinned to go1.4 until https://github.com/golang/go/issues/12301 is resolved
-  syncthing = go14Packages.syncthing.bin // { outputs = [ "bin" ]; };
+  syncthing = go15Packages.syncthing.bin // { outputs = [ "bin" ]; };
+  syncthing011 = go15Packages.syncthing011.bin // { outputs = [ "bin" ]; };
 
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -19,11 +19,11 @@ let
   ## OFFICIAL GO PACKAGES
 
   crypto = buildFromGitHub {
-    rev      = "d5c5f1769f2fcd2377be6f29863081f59a4fc80f";
+    rev      = "575fdbe86e5dd89229707ebec0575ce7d088a4a6";
     date     = "2015-08-29";
     owner    = "golang";
     repo     = "crypto";
-    sha256   = "0rkcvl3q8akkar4rmj052z23y61hbav9514ky6grb4gvxfx4ydbn";
+    sha256   = "1kgv1mkw9y404pk3lcwbs0vgl133mwyp294i18jg9hp10s5d56xa";
     goPackagePath = "golang.org/x/crypto";
     goPackageAliases = [
       "code.google.com/p/go.crypto"
@@ -58,18 +58,18 @@ let
   };
 
   net = buildFromGitHub {
-    rev    = "ea47fc708ee3e20177f3ca3716217c4ab75942cb";
+    rev    = "62ac18b461605b4be188bbc7300e9aa2bc836cd4";
     date   = "2015-08-29";
     owner  = "golang";
     repo   = "net";
-    sha256 = "0x1pmg97n7l62vak9qnjdjrrfl98jydhv6j0w3jkk4dycdlzn30d";
+    sha256 = "0lwwvbbwbf3yshxkfhn6z20gd45dkvnmw2ms36diiy34krgy402p";
     goPackagePath = "golang.org/x/net";
     goPackageAliases = [
       "code.google.com/p/go.net"
       "github.com/hashicorp/go.net"
       "github.com/golang/net"
     ];
-    propagatedBuildInputs = [ text ];
+    propagatedBuildInputs = [ text crypto ];
   };
 
   oauth2 = buildFromGitHub {
@@ -95,11 +95,11 @@ let
   };
 
   snappy = buildFromGitHub {
-    rev    = "0c7f8a7704bfec561913f4df52c832f094ef56f0";
+    rev    = "723cc1e459b8eea2dea4583200fd60757d40097a";
     date   = "2015-07-21";
     owner  = "golang";
     repo   = "snappy";
-    sha256 = "17j421ra8jm2da8gc0sk71g3n1nizqsfx1mapn255nvs887lqm0y";
+    sha256 = "0bprq0qb46f5511b5scrdqqzskqqi2z8b4yh3216rv0n1crx536h";
     goPackageAliases = [ "code.google.com/p/snappy-go/snappy" ];
   };
 
@@ -116,11 +116,11 @@ let
   };
 
   text = buildFromGitHub {
-    rev = "505f8b49cc14d790314b7535959a10b87b9161c7";
+    rev = "5eb8d4684c4796dd36c74f6452f2c0fa6c79597e";
     date = "2015-08-27";
     owner = "golang";
     repo = "text";
-    sha256 = "0h31hyb1ijs7zcsmpwa713x41k1wkh0igv7i4chwvwyjyl7zligy";
+    sha256 = "1cjwm2pv42dbfqc6ylr7jmma902zg4gng5aarqrbjf1k2nf2vs14";
     goPackagePath = "golang.org/x/text";
     goPackageAliases = [ "github.com/golang/text" ];
   };
@@ -963,11 +963,11 @@ let
   };
 
   goleveldb = buildFromGitHub {
-    rev = "183614d6b32571e867df4cf086f5480ceefbdfac";
-    date = "2015-06-17";
+    rev = "1a9d62f03ea92815b46fcaab357cfd4df264b1a0";
+    date = "2015-08-19";
     owner = "syndtr";
     repo = "goleveldb";
-    sha256 = "0crslwglkh8b3204l4zvav712a7yd2ykjnbrnny6yrq94mlvba8r";
+    sha256 = "04ywbif36fiah4fw0x2abr5q3p4fdhi6q57d5icc2mz03q889vhb";
     propagatedBuildInputs = [ ginkgo gomega snappy ];
   };
 
@@ -2136,10 +2136,10 @@ let
   };
 
   osext = buildFromGitHub {
-    rev = "6e7f843663477789fac7c02def0d0909e969b4e5";
+    rev = "10da29423eb9a6269092eebdc2be32209612d9d2";
     owner = "kardianos";
     repo = "osext";
-    sha256 = "1sn1kk60azqbll687fndiskkfvp0ppca8rmakv8wgsn7a64sm39f";
+    sha256 = "1mawalaz84i16njkz6f9fd5jxhcbxkbsjnav3cmqq2dncv2hyv8a";
     goPackageAliases = [
       "github.com/bugsnag/osext"
       "bitbucket.org/kardianos/osext"
@@ -2710,12 +2710,12 @@ let
     sha256 = "1m7nc1gvv5yqnq8ii75f33485il6y6prf8gxl97dimsw94qccc5v";
   };
 
-  relaysrv = buildFromGitHub {
+  relaysrv = buildFromGitHub rec {
     rev    = "7fe1fdd8c751df165ea825bc8d3e895f118bb236";
     owner  = "syncthing";
     repo   = "relaysrv";
     sha256 = "0qy14pa0z2dq5mix5ylv2raabwxqwj31g5kkz905wzki6d4j5lnp";
-    buildInputs = [ xdr syncthing-protocol ratelimit syncthing-lib ];
+    buildInputs = [ xdr syncthing-protocol011 ratelimit syncthing-lib ];
   };
 
   reflectwalk = buildFromGitHub {
@@ -2903,26 +2903,43 @@ let
     sha256 = "0pyrc7svc826g37al3db19n5l4r2m9h1mlhjh3hz2r41xfaqia50";
   };
 
-  suture = buildFromGitHub {
-    rev    = "fc7aaeabdc43fe41c5328efa1479ffea0b820978";
+  suture = buildFromGitHub rec {
+    version = "1.0.1";
+    rev    = "v${version}";
     owner  = "thejerf";
     repo   = "suture";
-    sha256 = "1l7nw00pazp317n5nprrxwhcq56kdblc774lsznxmbb30xcp8nmf";
+    sha256 = "094ksr2nlxhvxr58nbnzzk0prjskb21r86jmxqjr3rwg4rkwn6d4";
   };
 
   syncthing = buildFromGitHub rec {
-    version = "0.11.25";
+    version = "0.12.4";
     rev = "v${version}";
     owner = "syncthing";
     repo = "syncthing";
-    sha256 = "17phkj0dxzc1j755ddpf15rq34yp52pw2lx9kpg7gyc9qp0pzacl";
-    doCheck = false; # Tests are currently broken for 32-bit but they are benign
+    sha256 = "0sri86hsjpf4xlhi45zkafi1jncamzplxnvriza0xsah1bc31g65";
+    # buildFlags = [ "-tags noupgrade,release" ];
     buildInputs = [
-      go-lz4 du luhn xdr snappy ratelimit osext syncthing-protocol relaysrv
+      go-lz4 du luhn xdr snappy ratelimit osext
+      goleveldb suture qart crypto net text rcrowley.go-metrics
+    ];
+    postPatch = ''
+      # Mostly a cosmetic change
+      sed -i 's,unknown-dev,${version},g' cmd/syncthing/main.go
+    '';
+  };
+
+  syncthing011 = buildFromGitHub rec {
+    version = "0.11.26";
+    rev = "v${version}";
+    owner = "syncthing";
+    repo = "syncthing";
+    sha256 = "0c0dcvxrvjc84dvrsv90790aawkmavsj9bwp8c6cd6wrwj3cp9lq";
+    buildInputs = [
+      go-lz4 du luhn xdr snappy ratelimit osext syncthing-protocol011
       goleveldb suture qart crypto net text
     ];
     postPatch = ''
-      # Mostly a costmetic change
+      # Mostly a cosmetic change
       sed -i 's,unknown-dev,${version},g' cmd/syncthing/main.go
     '';
   };
@@ -2930,10 +2947,21 @@ let
   syncthing-lib = buildFromGitHub {
     inherit (syncthing) rev owner repo sha256;
     subPackages = [ "lib/sync" ];
-    buildInputs = [ logger ];
+    propagatedBuildInputs = syncthing.buildInputs;
   };
 
   syncthing-protocol = buildFromGitHub {
+    inherit (syncthing) rev owner repo sha256;
+    subPackages = [ "lib/protocol" ];
+    propagatedBuildInputs = [
+      go-lz4
+      logger
+      luhn
+      xdr
+      text ];
+  };
+
+  syncthing-protocol011 = buildFromGitHub {
     rev = "84365882de255d2204d0eeda8dee288082a27f98";
     date = "2015-08-28";
     owner = "syncthing";
@@ -3116,11 +3144,11 @@ let
   };
 
   xdr = buildFromGitHub {
-    rev    = "5f7208e86762911861c94f1849eddbfc0a60cbf0";
+    rev    = "e467b5aeb65ca8516fb3925c84991bf1d7cc935e";
     date   = "2015-04-08";
     owner  = "calmh";
     repo   = "xdr";
-    sha256 = "18m8ms2kg4apj5772r317i3axklgci8x1pq3pgicsv3acmpclh47";
+    sha256 = "1bi4b2xkjzcr0vq1wxz14i9943k71sj092dam0gdmr9yvdrg0nra";
   };
 
   xon = buildFromGitHub {


### PR DESCRIPTION
Also, keep 0.11 around (in an updated version) and make the
pkg an option to the service module.

This also updates dependencies to at least the version required by 0.12. 0.11 seems to work fine with those, too.

I didn't update relaysrv as something is weird with the build, which I think is due to my missing knowledge about go building infrastructure. Maybe @wkennington might help? However, this at least gets us 0.12 with correct dependencies and the option for people to have 0.11 around, too.
