### PR TITLE
lightdm module: Extract greeter configuration and add theme options

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -10,8 +10,8 @@ let
 
   inherit (pkgs) stdenv lightdm writeScript writeText;
 
-  theme = pkgs.gnome3.gnome_themes_standard;
-  icons = pkgs.gnome3.defaultIconTheme;
+  theme = cfg.theme.package;
+  icons = cfg.iconTheme.package;
 
   # The default greeter provided with this expression is the GTK greeter.
   # Again, we need a few things in the environment for the greeter to run with
@@ -45,14 +45,15 @@ let
   gtkGreeterConf = writeText "lightdm-gtk-greeter.conf"
     ''
     [greeter]
-    theme-name = Adwaita
-    icon-theme-name = Adwaita
+    theme-name = ${cfg.theme.name}
+    icon-theme-name = ${cfg.iconTheme.name}
     background = ${ldmcfg.background}
     '';
 
 in
 {
   options = {
+
     services.xserver.displayManager.lightdm.greeters.gtk = {
 
       enable = mkOption {
@@ -63,7 +64,48 @@ in
         '';
       };
 
+      theme = {
+
+        package = mkOption {
+          type = types.path;
+          default = pkgs.gnome3.gnome_themes_standard;
+          description = ''
+            The package path that contains the theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Adwaita";
+          description = ''
+            Name of the theme to use for the lightdm-gtk-greeter.
+          '';
+        };
+
+      };
+
+      iconTheme = {
+
+        package = mkOption {
+          type = types.path;
+          default = pkgs.gnome3.defaultIconTheme;
+          description = ''
+            The package path that contains the icon theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Adwaita";
+          description = ''
+            Name of the icon theme to use for the lightdm-gtk-greeter.
+          '';
+        };
+
+      };
+
     };
+
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dmcfg = config.services.xserver.displayManager;
+  ldmcfg = dmcfg.lightdm;
+  cfg = ldmcfg.greeters.gtk;
+
+  inherit (pkgs) stdenv lightdm writeScript writeText;
+
+  theme = pkgs.gnome3.gnome_themes_standard;
+  icons = pkgs.gnome3.defaultIconTheme;
+
+  # The default greeter provided with this expression is the GTK greeter.
+  # Again, we need a few things in the environment for the greeter to run with
+  # fonts/icons.
+  wrappedGtkGreeter = stdenv.mkDerivation {
+    name = "lightdm-gtk-greeter";
+    buildInputs = [ pkgs.makeWrapper ];
+
+    buildCommand = ''
+      # This wrapper ensures that we actually get themes
+      makeWrapper ${pkgs.lightdm_gtk_greeter}/sbin/lightdm-gtk-greeter \
+        $out/greeter \
+        --prefix PATH : "${pkgs.glibc}/bin" \
+        --set GDK_PIXBUF_MODULE_FILE "${pkgs.gdk_pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
+        --set GTK_PATH "${theme}:${pkgs.gtk3}" \
+        --set GTK_EXE_PREFIX "${theme}" \
+        --set GTK_DATA_PREFIX "${theme}" \
+        --set XDG_DATA_DIRS "${theme}/share:${icons}/share" \
+        --set XDG_CONFIG_HOME "${theme}/share"
+
+      cat - > $out/lightdm-gtk-greeter.desktop << EOF
+      [Desktop Entry]
+      Name=LightDM Greeter
+      Comment=This runs the LightDM Greeter
+      Exec=$out/greeter
+      Type=Application
+      EOF
+    '';
+  };
+
+  gtkGreeterConf = writeText "lightdm-gtk-greeter.conf"
+    ''
+    [greeter]
+    theme-name = Adwaita
+    icon-theme-name = Adwaita
+    background = ${ldmcfg.background}
+    '';
+
+in
+{
+  options = {
+    services.xserver.displayManager.lightdm.greeters.gtk = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable lightdm-gtk-greeter as the lightdm greeter.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    services.xserver.displayManager.lightdm.greeter = mkDefault {
+      package = wrappedGtkGreeter;
+      name = "lightdm-gtk-greeter";
+    };
+
+    environment.etc."lightdm/lightdm-gtk-greeter.conf".source = gtkGreeterConf;
+
+  };
+}

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -18,38 +18,6 @@ let
       exec ${dmcfg.xserverBin} ${dmcfg.xserverArgs}
     '';
 
-  theme = pkgs.gnome3.gnome_themes_standard;
-  icons = pkgs.gnome3.defaultIconTheme;
-
-  # The default greeter provided with this expression is the GTK greeter.
-  # Again, we need a few things in the environment for the greeter to run with
-  # fonts/icons.
-  wrappedGtkGreeter = stdenv.mkDerivation {
-    name = "lightdm-gtk-greeter";
-    buildInputs = [ pkgs.makeWrapper ];
-
-    buildCommand = ''
-      # This wrapper ensures that we actually get themes
-      makeWrapper ${pkgs.lightdm_gtk_greeter}/sbin/lightdm-gtk-greeter \
-        $out/greeter \
-        --prefix PATH : "${pkgs.glibc}/bin" \
-        --set GDK_PIXBUF_MODULE_FILE "${pkgs.gdk_pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
-        --set GTK_PATH "${theme}:${pkgs.gtk3}" \
-        --set GTK_EXE_PREFIX "${theme}" \
-        --set GTK_DATA_PREFIX "${theme}" \
-        --set XDG_DATA_DIRS "${theme}/share:${icons}/share" \
-        --set XDG_CONFIG_HOME "${theme}/share"
-
-      cat - > $out/lightdm-gtk-greeter.desktop << EOF
-      [Desktop Entry]
-      Name=LightDM Greeter
-      Comment=This runs the LightDM Greeter
-      Exec=$out/greeter
-      Type=Application
-      EOF
-    '';
-  };
-
   usersConf = writeText "users.conf"
     ''
       [UserList]
@@ -72,34 +40,42 @@ let
       ${cfg.extraSeatDefaults}
     '';
 
-  gtkGreeterConf = writeText "lightdm-gtk-greeter.conf"
-    ''
-    [greeter]
-    theme-name = Adwaita
-    icon-theme-name = Adwaita
-    background = ${cfg.background}
-    '';
-
 in
 {
+  # Note: the order in which lightdm greeter modules are imported
+  # here determines the default: later modules (if enable) are
+  # preferred.
+  imports = [
+    ./lightdm-greeters/gtk.nix
+  ];
+
   options = {
+
     services.xserver.displayManager.lightdm = {
 
       enable = mkOption {
+        type = types.bool;
         default = false;
         description = ''
           Whether to enable lightdm as the display manager.
         '';
       };
 
-      greeter = mkOption {
-        description = ''
-          The LightDM greeter to login via. The package should be a directory
-          containing a .desktop file matching the name in the 'name' option.
-        '';
-        default = {
-          name = "lightdm-gtk-greeter";
-          package = wrappedGtkGreeter;
+      greeter =  {
+        package = mkOption {
+          type = types.path;
+          description = ''
+            The LightDM greeter to login via. The package should be a directory
+            containing a .desktop file matching the name in the 'name' option.
+          '';
+
+        };
+        name = mkOption {
+          type = types.string;
+          description = ''
+            The name of a .desktop file in the directory specified
+            in the 'package' option.
+          '';
         };
       };
 
@@ -135,7 +111,6 @@ in
       '';
     };
 
-    environment.etc."lightdm/lightdm-gtk-greeter.conf".source = gtkGreeterConf;
     environment.etc."lightdm/lightdm.conf".source = lightdmConf;
     environment.etc."lightdm/users.conf".source = usersConf;
 


### PR DESCRIPTION
I've extracted the configuration for the lightdm-gtk-greeter, to potentially allow for future greeters, and making configuring them more structured.

I've also added options to being able to configure the theme of this greeter, without reimplementing the whole greeter wrapper.

This is my first pull request to this repository, so any feedback is welcome.
