### PR TITLE
nix-prefetch-scripts: Split into multiple derivations

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -1,5 +1,5 @@
 {stdenv, vim, vimPlugins, vim_configurable, buildEnv, writeText, writeScriptBin
-, nix-prefetch-scripts }:
+, nix-prefetch-hg, nix-prefetch-git }:
 
 /*
 
@@ -310,8 +310,8 @@ rec {
         echom repeat("=", 80)
       endif
       let opts = {}
-      let opts.nix_prefetch_git = "${nix-prefetch-scripts}/bin/nix-prefetch-git"
-      let opts.nix_prefetch_hg  = "${nix-prefetch-scripts}/bin/nix-prefetch-hg"
+      let opts.nix_prefetch_git = "${nix-prefetch-git}/bin/nix-prefetch-git"
+      let opts.nix_prefetch_hg  = "${nix-prefetch-hg}/bin/nix-prefetch-hg"
       let opts.cache_file = g:vim_addon_manager.plugin_root_dir.'/cache'
       let opts.plugin_dictionaries = []
       ${lib.concatMapStrings (file: "let opts.plugin_dictionaries += map(readfile(\"${file}\"), 'eval(v:val)')\n") namefiles }

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,40 +1,52 @@
-{ stdenv, makeWrapper,
+{ stdenv, makeWrapper, buildEnv,
   git, subversion, mercurial, bazaar, cvs, unzip, curl, gnused, coreutils
 }:
-stdenv.mkDerivation {
-  name = "nix-prefetch-scripts";
 
-  buildInputs = [ makeWrapper ];
+let mkPrefetchScript = tool: src: deps:
+  stdenv.mkDerivation {
+    name = "nix-prefetch-${tool}";
 
-  phases = [ "installPhase" "fixupPhase" ];
-  installPhase = ''
-    mkdir -p $out/bin
-    function copyScript {
-      local name=nix-prefetch-$1;
-      local src=$2;
+    buildInputs = [ makeWrapper ];
+
+    phases = [ "installPhase" "fixupPhase" ];
+    installPhase = ''
+      mkdir -p $out/bin
+
       local wrapArgs=""
-      cp $src $out/bin/$name;
-      for dep in ''${@:3}; do
+      cp ${src} $out/bin/$name;
+      for dep in ${stdenv.lib.concatStringsSep " " deps}; do
         wrapArgs="$wrapArgs --prefix PATH : $dep/bin"
       done
       wrapArgs="$wrapArgs --prefix PATH : ${gnused}/bin"
       wrapArgs="$wrapArgs --set HOME : /homeless-shelter"
       wrapProgram $out/bin/$name $wrapArgs
-    }
+    '';
 
-    copyScript "hg" ${../../../build-support/fetchhg/nix-prefetch-hg} ${mercurial}
-    copyScript "git" ${../../../build-support/fetchgit/nix-prefetch-git} ${git} ${coreutils}
-    copyScript "svn" ${../../../build-support/fetchsvn/nix-prefetch-svn} ${subversion}
-    copyScript "bzr" ${../../../build-support/fetchbzr/nix-prefetch-bzr} ${bazaar}
-    copyScript "cvs" ${../../../build-support/fetchcvs/nix-prefetch-cvs} ${cvs}
-    copyScript "zip" ${../../../build-support/fetchzip/nix-prefetch-zip} ${unzip} ${curl}
-  '';
+    preferLocalBuild = true;
 
-  meta = with stdenv.lib; {
-    description = "Collection of all the nix-prefetch-* scripts which may be used to obtain source hashes";
-    maintainers = with maintainers; [ bennofs ];
-    platforms = with stdenv.lib.platforms; unix;
-    # Quicker to build than to download, I hope
-    hydraPlatforms = [];
+    meta = with stdenv.lib; {
+      description = "Script used to obtain source hashes for fetch${tool}";
+      maintainers = with maintainers; [ bennofs ];
+      platforms = stdenv.lib.platforms.unix;
+    };
+  };
+in rec {
+  nix-prefetch-bzr = mkPrefetchScript "bzr" ../../../build-support/fetchbzr/nix-prefetch-bzr [bazaar];
+  nix-prefetch-cvs = mkPrefetchScript "cvs" ../../../build-support/fetchcvs/nix-prefetch-cvs [cvs];
+  nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [git coreutils];
+  nix-prefetch-hg  = mkPrefetchScript "hg"  ../../../build-support/fetchhg/nix-prefetch-hg   [mercurial];
+  nix-prefetch-svn = mkPrefetchScript "svn" ../../../build-support/fetchsvn/nix-prefetch-svn [subversion];
+  nix-prefetch-zip = mkPrefetchScript "zip" ../../../build-support/fetchzip/nix-prefetch-zip [unzip curl];
+
+  nix-prefetch-scripts = buildEnv {
+    name = "nix-prefetch-scripts";
+
+    paths = [ nix-prefetch-bzr nix-prefetch-cvs nix-prefetch-git nix-prefetch-hg nix-prefetch-svn nix-prefetch-zip ];
+
+    meta = with stdenv.lib; {
+      description = "Collection of all the nix-prefetch-* scripts which may be used to obtain source hashes";
+      maintainers = with maintainers; [ bennofs ];
+      platforms = stdenv.lib.platforms.unix;
+    };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15240,7 +15240,14 @@ let
 
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
-  nix-prefetch-scripts = callPackage ../tools/package-management/nix-prefetch-scripts { };
+  inherit (callPackages ../tools/package-management/nix-prefetch-scripts { })
+    nix-prefetch-bzr
+    nix-prefetch-cvs
+    nix-prefetch-git
+    nix-prefetch-hg
+    nix-prefetch-svn
+    nix-prefetch-zip
+    nix-prefetch-scripts;
 
   nix-template-rpm = callPackage ../build-support/templaterpm { inherit (pythonPackages) python toposort; };
 


### PR DESCRIPTION
This makes it possible to e.g. only install nix-prefetch-git and not the
others.

Closes #7399.
