### PR TITLE
strongswan service: use config.system.sbin.modprobe instead of kmod

### DIFF
--- a/nixos/modules/services/networking/strongswan.nix
+++ b/nixos/modules/services/networking/strongswan.nix
@@ -118,7 +118,7 @@ in
     systemd.services.strongswan = {
       description = "strongSwan IPSec Service";
       wantedBy = [ "multi-user.target" ];
-      path = with pkgs; [ kmod iproute iptables utillinux ]; # XXX Linux
+      path = with pkgs; [ config.system.sbin.modprobe iproute iptables utillinux ]; # XXX Linux
       wants = [ "keys.target" ];
       after = [ "network.target" "keys.target" ];
       environment = {


### PR DESCRIPTION
Fixes: #8343
