### PR TITLE
aj-snapshot: init 0.9.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -215,6 +215,7 @@
   page = "Carles Pagès <page@cubata.homelinux.net>";
   paholg = "Paho Lurie-Gregg <paho@paholg.com>";
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
+  palo = "Ingolf Wanger <palipalo9@googlemail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
   phausmann = "Philipp Hausmann <nix@314.ch>";

--- a/pkgs/applications/audio/aj-snapshot/default.nix
+++ b/pkgs/applications/audio/aj-snapshot/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, alsaLib, jack2Full, minixml, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name =  packageName + "-" + version ;
+  packageName = "aj-snapshot" ;
+  version = "0.9.6" ;
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${packageName}/${name}.tar.bz2";
+    sha256 = "12n2h3609fbvsnnwrwma4m55iyv6lcv1v3q5pznz2w6f12wf0c9z";
+  };
+
+  doCheck = false;
+
+  buildInputs = [ alsaLib minixml jack2Full pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "Tool for storing/restoring JACK and/or ALSA connections to/from cml files";
+    longDescription = ''
+    Aj-snapshot is a small program that can be used to make snapshots of the connections made between JACK and/or ALSA clients. 
+    Because JACK can provide both audio and MIDI support to programs, aj-snapshot can store both types of connections for JACK. 
+    ALSA, on the other hand, only provides routing facilities for MIDI clients. 
+    You can also run aj-snapshot in daemon mode if you want to have your connections continually restored.
+    '';
+
+    homepage = http://aj-snapshot.sourceforge.net/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.palo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -522,6 +522,8 @@ let
 
   airfield = callPackage ../tools/networking/airfield { };
 
+  aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
+
   analog = callPackage ../tools/admin/analog {};
 
   apktool = callPackage ../development/tools/apktool {


### PR DESCRIPTION
It's a tool to save the jack connections.

I tested it with `nix-build -A aj-snapshot`

It's my first pull-request to the nixpkgs repository, so I'm very open for improvements.
@magnetophon @henrytill maybe you as musnix can approve or merge the pull-request.

Thanks
