### PR TITLE
lightdm-gtk-greeter module: Fix error when lightdm disabled

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -108,7 +108,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (ldmcfg.enable && cfg.enable) {
 
     services.xserver.displayManager.lightdm.greeter = mkDefault {
       package = wrappedGtkGreeter;


### PR DESCRIPTION
Fix for error introduced by #11336 
