### PR TITLE
mesa_drivers: build with older LLVM 3.6

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7740,6 +7740,7 @@ let
   mesa_drivers = mesaDarwinOr (
     let mo = mesa_noglu.override {
       grsecEnabled = config.grsecurity or false;
+      llvmPackages = llvmPackages_36;
     };
     in mo.drivers
   );


### PR DESCRIPTION
3e96b763d2458537e994a23478f5ce4257930f31 makes LLVM 3.7 the default Nixpkgs-wide. Since this commit, I have been unable to start X using the `radeon` driver. There is no error message in the `dmesg` output or in `/var/log/X.0.log`; X simply doesn't open a display. This patch builds `mesa_drivers` with the older LLVM 3.6 instead, in which case X does work. It is not necessary to use the older LLVM for any other packages, so this should be a minimal rebuild.

@wkennington @domenkozar
