### PR TITLE
kodiPlugins.pvr-hts: init at 2.1.18

### DIFF
--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   buildInputs = [ makeWrapper ];
 
   buildCommand = ''
-    mkdir -p $out/share/kodi/addons/packages
+    mkdir -p $out/share/kodi/addons
     ${stdenv.lib.concatMapStrings
         (plugin: "ln -s ${plugin.out
                             + plugin.kodiPlugin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13568,6 +13568,7 @@ let
       ++ optional (config.kodi.enableGenesis or false) genesis
       ++ optional (config.kodi.enableSVTPlay or false) svtplay
       ++ optional (config.kodi.enableSteamLauncher or false) steam-launcher
+      ++ optional (config.kodi.enablePVRHTS or false) pvr-hts
       );
   };
 


### PR DESCRIPTION
WIP: Add Tvheadend HTSP PVR client addon for Kodi.

cc @edwtjo @domenkozar (as kodi maintainers):  this is working but I'm using that symlink trick as it searches for the addon .so in the lib dir from the original non-wrapped kodi. Any suggestion how to workaround this more cleanly?
