### PR TITLE
wine(tricks): update packages

### DIFF
--- a/pkgs/misc/emulators/wine/versions.nix
+++ b/pkgs/misc/emulators/wine/versions.nix
@@ -1,11 +1,11 @@
 {
   unstable = {
-    wineVersion = "1.7.55";
-    wineSha256  = "06b1sgjxycbr1qsy33z5w22ykz12kkdsfq2yl7qmx9s5rg4zcj51";
-    geckoVersion = "2.36";
-    geckoSha256 = "12hjks32yz9jq4w3xhk3y1dy2g3iakqxd7aldrdj51cqiz75g95g";
-    gecko64Version = "2.36";
-    gecko64Sha256 = "0i7dchrzsda4nqbkhp3rrchk74rc2whn2af1wzda517m9c0886vh";
+    wineVersion = "1.8-rc2";
+    wineSha256  = "0g7pk69mp9kjyd9hw64difqm5df12aqy8hiipxjrmwg044csqqvh";
+    geckoVersion = "2.40";
+    geckoSha256 = "00nkaxhb9dwvf53ij0q75fb9fh7pf43hmwx6rripcax56msd2a8s";
+    gecko64Version = "2.40";
+    gecko64Sha256 = "0c4jikfzb4g7fyzp0jcz9fk2rpdl1v8nkif4dxcj28nrwy48kqn3";
     monoVersion = "4.5.6";
     monoSha256 = "09dwfccvfdp3walxzp6qvnyxdj2bbyw9wlh6cxw2sx43gxriys5c";
   };
@@ -20,11 +20,11 @@
     monoSha256 = "09dwfccvfdp3walxzp6qvnyxdj2bbyw9wlh6cxw2sx43gxriys5c";
   };
   staging = {
-    version = "1.7.55";
-    sha256 = "16hs1q2ff7frja36pnriprxrpvk22bacjbigbscayshhlj958a8m";
+    version = "1.8-rc2";
+    sha256 = "1h2yq33nnylcmbnbwq54kxcdq9yzz8cbljkg8jz2skhi39vlcplp";
   };
   winetricks = {
-    version = "20151110";
-    sha256 = "1aq8rkqq8mdksb5c4gc3k9plh3zc28gffi7y29v9vyk4f25j64sz";
+    version = "20151116";
+    sha256 = "1iih2b85s7f4if1mn36infc43hd4pdp8bl84q0nml3gh3fh8zqpr";
   };
 }


### PR DESCRIPTION
wine 1.7.55 -> 1.8-rc2
winetricks 20151110 -> 20151116

release candidate of new wine unstable, let's help the wine team out with some testing:
@abbradar @jagajaga 
