### PR TITLE
python spyder: 2.3.7 -> 2.3.8

### DIFF
--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   name = "spyder-${version}";
-  version = "2.3.7";
+  version = "2.3.8";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://pypi.python.org/packages/source/s/spyder/${name}.zip";
-    sha256 = "0ywgvgcp9s64ys25nfscd2648f7di8544a21b5lb59d4f48z028h";
+    sha256 = "99fdae2cea325c0f2842c77bd67dd22db19fef3d9c0dde1545b1a2650eae517e";
   };
 
   # NOTE: sphinx makes the build fail with: ValueError: ZIP does not support timestamps before 1980


### PR DESCRIPTION
Note that this update doesn't fix the failing Python 3 builds.

cc @bjornfor @domenkozar 
