### PR TITLE
audiofile: update to work on osx

### DIFF
--- a/pkgs/development/libraries/audiofile/default.nix
+++ b/pkgs/development/libraries/audiofile/default.nix
@@ -1,9 +1,12 @@
-{ stdenv, fetchurl, alsaLib }:
+{ stdenv, fetchurl, alsaLib,
+Cocoa, CoreServices, CoreAudio, AudioUnit }:
 
 stdenv.mkDerivation rec {
   name = "audiofile-0.3.6";
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.isLinux alsaLib;
+  nativeBuildInputs = [] ++
+    stdenv.lib.optional stdenv.isLinux [alsaLib] ++
+    stdenv.lib.optional stdenv.isDarwin [Cocoa CoreServices CoreAudio AudioUnit];
 
   src = fetchurl {
     url = "http://audiofile.68k.org/${name}.tar.gz";
@@ -14,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library for reading and writing audio files in various formats";
-    homepage    = http://www.68k.org/~michael/audiofile/; 
+    homepage    = http://www.68k.org/~michael/audiofile/;
     license     = licenses.lgpl21Plus;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6044,7 +6044,9 @@ let
 
   aubio = callPackage ../development/libraries/aubio { };
 
-  audiofile = callPackage ../development/libraries/audiofile { };
+  audiofile = callPackage ../development/libraries/audiofile {
+    inherit (darwin.apple_sdk.frameworks) CoreAudio CoreServices AudioUnit Cocoa;
+  };
 
   babl = callPackage ../development/libraries/babl { };
 


### PR DESCRIPTION
Add missing OSX frameworks for audiofile so it can build.

Dependency of youtube-dl as an example.
