### PR TITLE
geolite-legacy: Switch to mirror with stable URLs.

### DIFF
--- a/pkgs/data/misc/geolite-legacy/default.nix
+++ b/pkgs/data/misc/geolite-legacy/default.nix
@@ -1,36 +1,49 @@
 { stdenv, fetchurl }:
 
 let
-  fetchDB = src: name: sha256: fetchurl {
+  fetchDB = src: product: name: sha256: fetchurl {
     inherit name sha256;
-    url = "https://geolite.maxmind.com/download/geoip/database/${src}";
+    urls = [
+      "https://headcounter.org/hydra/build/${version}/download/${product}"
+      "https://geolite.maxmind.com/download/geoip/database/${src}"
+    ];
   };
 
-  # Annoyingly, these files are updated without a change in URL. This means that
-  # builds will start failing every month or so, until the hashes are updated.
-  version = "2015-11-23";
+  # Annoyingly, these files are updated without a change in URL. In order to
+  # cope with this, I (aszlig) have set up a mirror on my Hydra at:
+  #
+  # https://headcounter.org/hydra/jobset/aszlig/geoip-legacy-database-mirror
+  #
+  # Please make sure that whenever you update this to do the hash checks on the
+  # upstream URL instead of blindly trusting my Hydra.
+  #
+  # The version here is the build ID of the "mirror" jobset and the right
+  # one corresponding to the current date can be found here:
+  #
+  # https://headcounter.org/hydra/job/aszlig/geoip-legacy-database-mirror/mirror
+  version = "810270";
 in
 stdenv.mkDerivation {
   name = "geolite-legacy-${version}";
 
   srcGeoIP = fetchDB
-    "GeoLiteCountry/GeoIP.dat.gz" "GeoIP.dat.gz"
+    "GeoLiteCountry/GeoIP.dat.gz" "1" "GeoIP.dat.gz"
     "18nwbxy6l153zhd7fi4zdyibnmpcb197p3jlb9cjci852asd465l";
   srcGeoIPv6 = fetchDB
-    "GeoIPv6.dat.gz" "GeoIPv6.dat.gz"
+    "GeoIPv6.dat.gz" "4" "GeoIPv6.dat.gz"
     "0dm8qvsx8vpwdv9y4z70jiws9bwmw10vdn5sc8jdms53p4rgr4n4";
   srcGeoLiteCity = fetchDB
-    "GeoLiteCity.dat.xz" "GeoIPCity.dat.xz"
+    "GeoLiteCity.dat.xz" "5" "GeoIPCity.dat.xz"
     "1bq9kg6fsdsjssd3i6phq26n1px9jmljnq60gfsh8yb9s18hymfq";
   srcGeoLiteCityv6 = fetchDB
-    "GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz" "GeoIPCityv6.dat.gz"
+    "GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz" "6" "GeoIPCityv6.dat.gz"
     "0anx3kppql6wzkpmkf7k1322g4ragb5hh96apl71n2lmwb33i148";
   srcGeoIPASNum = fetchDB
-    "asnum/GeoIPASNum.dat.gz" "GeoIPASNum.dat.gz"
-    "0zlc5gb0qy9am2xzpfv41i9wdydasrscmjwy1drccfsspqwrjvs7";
+    "asnum/GeoIPASNum.dat.gz" "2" "GeoIPASNum.dat.gz"
+    "1w8k6a9590nbisajn8m0l6is44vzsf5xghpw7ld8l72brdm76nfi";
   srcGeoIPASNumv6 = fetchDB
-    "asnum/GeoIPASNumv6.dat.gz" "GeoIPASNumv6.dat.gz"
-    "0p9lwngvrk88an3kqx3v2b3kcs0l51mbrr7lwxg3ckkjyl9si1k3";
+    "asnum/GeoIPASNumv6.dat.gz" "3" "GeoIPASNumv6.dat.gz"
+    "0xqhbbilp6h80zpc5dx5ng15fhpsi9wplimbfbd3rs0jx7gjd3jg";
 
   meta = with stdenv.lib; {
     inherit version;


### PR DESCRIPTION
These files seem to change even on a per-minute basis, so we really can't rely on the upstream URLs at all.

I've tried to find another mirror on the net, but haven't found anything than the Fedora one (http://pkgs.fedoraproject.org/repo/pkgs/GeoIP/) and some outdated Git repository. Both unfortunately do not have a recent enough version, so we would essentially have to downgrade.

So I decided to set up a mirror by myself and I've put it in front of the "urls" attribute, because if the upstream URL has a hash mismatch, another URL isn't tried.

The reason why I've still kept the upstream URL is because updating these packages still should be done using the upstream URL, so that if I happen to go nuts (you'll never know) and tamper with the mirror, nobody gets hurt except for getting a hash mismatch.

Also, I've changed the version to reflect the Hydra build number, so we don't need to do bookkeeping on two values.

The new version numbering scheme is also backwards-compatible, because it exceeds the value of the 4-digit year already.
