### PR TITLE
Fix notmuch for darwin

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -42,10 +42,30 @@ stdenv.mkDerivation rec {
 
   preFixup = if stdenv.isDarwin then
     ''
+      set -e
+
+      die() {
+        >&2 echo "$@"
+        exit 1
+      }
+
       prg="$out/bin/notmuch"
-      target="libnotmuch.3.dylib"
-      echo "$prg: fixing link to $target"
-      install_name_tool -change "$target" "$out/lib/$target" "$prg"
+      lib="$(find "$out/lib" -name 'libnotmuch.?.dylib')"
+
+      [[ -s "$prg" ]] || die "couldn't find notmuch binary"
+      [[ -s "$lib" ]] || die "couldn't find libnotmuch"
+
+      badname="$(otool -L "$prg" | awk '$1 ~ /libtalloc/ { print $1 }')"
+      goodname="$(find "${talloc}/lib" -name 'libtalloc.?.?.?.dylib')"
+
+      [[ -n "$badname" ]]  || die "couldn't find libtalloc reference in binary"
+      [[ -n "$goodname" ]] || die "couldn't find libtalloc in nix store"
+
+      echo "fixing libtalloc link in $lib"
+      install_name_tool -change "$badname" "$goodname" "$lib"
+
+      echo "fixing libtalloc link in $prg"
+      install_name_tool -change "$badname" "$goodname" "$prg"
     ''
   else
     "";
@@ -58,6 +78,6 @@ stdenv.mkDerivation rec {
     description = "Mail indexer";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ chaoflow garbas ];
-    platforms = stdenv.lib.platforms.gnu;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
- The existing `preFixup` hack for darwin doesn't appear to be necessary anymore
- I had to fix the paths for `libtalloc`
- I relaxed the `platforms` restriction to `unix`. It certainly works on darwin with this change, and could likely work on *bsd, though I haven't tested. (or should I just make it gnu+darwin?)

(This is my first time working with nix, please let me know if I've done everything horribly incorrectly :smile:)

@chaoflow @garbas 
