### PR TITLE
mapnik: init at 3.0.9

### DIFF
--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl
+, boost, cairo, freetype, gdal, harfbuzz, icu, libjpeg, libpng, libtiff
+, libwebp, libxml2, proj, python, scons, sqlite, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "mapnik-${version}";
+  version = "3.0.9";
+
+  src = fetchurl {
+    url = "https://mapnik.s3.amazonaws.com/dist/v${version}/mapnik-v${version}.tar.bz2";
+    sha256 = "1nnkamwq4vcg4q2lbqn7cn8sannxszzjxcxsllksby055d9nfgrs";
+  };
+
+  nativeBuildInputs = [ python scons ];
+
+  buildInputs =
+    [ boost cairo freetype gdal harfbuzz icu libjpeg libpng libtiff
+      libwebp libxml2 proj python sqlite zlib
+    ];
+
+  configurePhase = ''
+    scons configure PREFIX="$out"
+  '';
+
+  buildPhase = false;
+
+  installPhase = ''
+    mkdir -p "$out"
+    scons install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open source toolkit for developing mapping applications";
+    homepage = http://mapnik.org;
+    maintainers = with maintainers; [ hrdinka ];
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7711,6 +7711,8 @@ let
 
   lzo = callPackage ../development/libraries/lzo { };
 
+  mapnik = callPackage ../development/libraries/mapnik { };
+
   matio = callPackage ../development/libraries/matio { };
 
   mbedtls = callPackage ../development/libraries/mbedtls { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5075,6 +5075,27 @@ in modules // {
     };
   };
 
+  python-mapnik = buildPythonPackage {
+    name = "python-mapnik-fae6388";
+
+    src = pkgs.fetchgit {
+      url = https://github.com/mapnik/python-mapnik.git;
+      rev = "fae63881ed0945829e73f711d52740240b740936";
+      sha256 = "13i9zsy0dk9pa947vfq26a3nrn1ddknqliyb0ljcmi5w5x0z758k";
+    };
+
+    disabled = isPyPy;
+    doCheck = false; # doesn't find needed test data files
+    buildInputs = with pkgs; [ boost harfbuzz icu mapnik ];
+    propagatedBuildInputs = with self; [ pillow pycairo ];
+
+    meta = with stdenv.lib; {
+      description = "Python bindings for Mapnik";
+      homepage = http://mapnik.org;
+      license  = licenses.lgpl21;
+    };
+  };
+
   mwlib = buildPythonPackage rec {
     version = "0.15.15";
     name = "mwlib-${version}";


### PR DESCRIPTION
This adds mapnik version 3.0.9 as well as its most recent python bindings. There hasn't been a stable release of the bindings since they have seperated them from the main repo in 3.*. That is why it downloads the latest git rev. Tested and working.
