### PR TITLE
murmur: sslCa and extraConfig options.

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -39,6 +39,9 @@ let
     certrequired=${if cfg.clientCertRequired then "true" else "false"}
     ${if cfg.sslCert == "" then "" else "sslCert="+cfg.sslCert}
     ${if cfg.sslKey  == "" then "" else "sslKey="+cfg.sslKey}
+    ${if cfg.sslCa   == "" then "" else "sslCA="+cfg.sslCa}
+    
+    ${cfg.extraConfig}
   '';
 in
 {
@@ -218,6 +221,18 @@ in
         type = types.str;
         default = "";
         description = "Path to your SSL key.";
+      };
+
+      sslCa = mkOption {
+        type = types.str;
+        default = "";
+        description = "Path to your SSL CA certificate.";
+      };
+
+      extraConfig = mkOption {
+        type = types.str;
+        default = "";
+        description = "Extra configuration to put into mumur.ini.";
       };
     };
   };


### PR DESCRIPTION
This adds the `sslCa` option which is essential for users who's certificate isn't in their root store as well as the `extraConfig` option which allows users to add arbitrary options to their config file.
