### PR TITLE
Add coreutils-prefixed to install coreutils as gls, ggrep, etc.

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -2,6 +2,7 @@
 , aclSupport ? false, acl ? null
 , selinuxSupport? false, libselinux ? null, libsepol ? null
 , autoconf, automake114x, texinfo
+, withPrefix ? false
 }:
 
 assert aclSupport -> acl != null;
@@ -82,6 +83,15 @@ let
     NIX_LDFLAGS = optionalString selinuxSupport "-lsepol";
 
     makeFlags = optionalString stdenv.isDarwin "CFLAGS=-D_FORTIFY_SOURCE=0";
+
+    # e.g. ls -> gls; grep -> ggrep
+    postFixup = stdenv.lib.optionalString withPrefix
+      ''
+        (
+          cd "$out/bin"
+          find * -type f -executable -exec mv {} g{} \;
+        )
+      '';
 
     meta = {
       homepage = http://www.gnu.org/software/coreutils/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1151,6 +1151,8 @@ let
     aclSupport = stdenv.isLinux;
   };
 
+  coreutils-prefixed = coreutils.override { withPrefix = true; };
+
   cpio = callPackage ../tools/archivers/cpio { };
 
   crackxls = callPackage ../tools/security/crackxls { };


### PR DESCRIPTION
This is the way `coreutils` works from homebrew. It's useful to have the GNU coreutils available, but not replace the BSD coreutils.
