### PR TITLE
displayManager module: Add assertion to have at least one session

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -324,6 +324,12 @@ in
 
     services.xserver.displayManager.xserverBin = "${xorg.xorgserver}/bin/X";
 
+
+    assertions = mkIf cfg.enable (singleton { 
+      assertion = cfg.displayManager.session.names != [];
+      message = "Please enable at least one desktop manager or window manager";
+    });
+
   };
 
 }


### PR DESCRIPTION
Implementation for #11064

Adds an assertion to check if at least one desktopManager or windowManager is enabled.

@vcunat @nbp 
