### PR TITLE
nixos/system-path: allow installing multilib glibc

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -19,7 +19,7 @@ let
       pkgs.diffutils
       pkgs.findutils
       pkgs.gawk
-      pkgs.glibc # for ldd, getent
+      (if config.environment.multilibGlibc then pkgs.glibc_multi else pkgs.glibc) # for ldd, getent
       pkgs.gnugrep
       pkgs.gnupatch
       pkgs.gnused
@@ -78,6 +78,12 @@ in
         default = [];
         example = [ "doc" ];
         description = "List of package outputs to be symlinked into <filename>/run/current-system/sw</filename>.";
+      };
+
+      multilibGlibc = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Install multilib version of Glibc into system path";
       };
 
     };


### PR DESCRIPTION
This is primarily to be able to have multilib-capable `ldd` in the system path. Maybe there's a better way to do this? This feels somewhat inelegant.
