### PR TITLE
Fvwm: add gestures and create libstroke package

### DIFF
--- a/pkgs/applications/window-managers/fvwm/default.nix
+++ b/pkgs/applications/window-managers/fvwm/default.nix
@@ -1,7 +1,11 @@
-{ stdenv, fetchurl, pkgconfig
+{ gestures ? false
+, stdenv, fetchurl, pkgconfig
 , cairo, fontconfig, freetype, libXft, libXcursor, libXinerama
 , libXpm, librsvg, libpng, fribidi, perl
+, libstroke ? null
 }:
+
+assert gestures -> libstroke != null;
 
 stdenv.mkDerivation rec {
   name = "fvwm-2.6.5";
@@ -15,7 +19,7 @@ stdenv.mkDerivation rec {
     pkgconfig cairo fontconfig freetype
     libXft libXcursor libXinerama libXpm
     librsvg libpng fribidi perl
-  ];
+  ] ++ stdenv.lib.optional gestures libstroke;
 
   meta = {
     homepage = "http://fvwm.org";

--- a/pkgs/development/libraries/libstroke/default.nix
+++ b/pkgs/development/libraries/libstroke/default.nix
@@ -1,0 +1,33 @@
+{stdenv, fetchurl, automake, autoconf, x11}:
+
+stdenv.mkDerivation {
+  name = "libstroke-0.5.1";
+
+  src = fetchurl {
+    url = http://etla.net/libstroke/libstroke-0.5.1.tar.gz;
+    sha256 = "0da9f5fde66feaf6697ba069baced8fb3772c3ddc609f39861f92788f5c7772d";
+  };
+
+  buildInputs = [ automake autoconf x11 ];
+
+  # libstroke ships with an ancient config.sub that doesn't know about x86_64, so regenerate it.
+  # Also, modern automake doesn't like things and returns error code 63.  But it generates the file.
+  preConfigure = ''
+      rm config.sub
+      autoconf
+      automake -a || true
+    '';
+
+  meta = {
+    description = "libstroke, a library for simple gesture recognition";
+    homepage = http://etla.net/libstroke/;
+    license = stdenv.lib.licenses.gpl2;
+
+    longDescription =
+      '' libstroke, last updated in 2001, still successfully provides a basic
+        gesture recognition engine based around a 3x3 grid.  It's simple and
+        easy to work with, and notably used by FVWM.
+      '';
+
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7438,6 +7438,8 @@ let
 
   libstartup_notification = callPackage ../development/libraries/startup-notification { };
 
+  libstroke = callPackage ../development/libraries/libstroke { };
+
   libstrophe = callPackage ../development/libraries/libstrophe { };
 
   libspatialindex = callPackage ../development/libraries/libspatialindex { };


### PR DESCRIPTION
This adds libstroke so that fvwm can be compiled with gesture support, as well as a flag to enable it in fvwm.

This is my first non-trivial contribution, so is largely pattern-matched from existing packages.  Feedback is welcome.
