### PR TITLE
virt-{manager,inst}: Fix glance dependency

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   propagatedBuildInputs =
     [ eventlet greenlet gflags netaddr carrot routes
       PasteDeploy m2crypto ipy twisted sqlalchemy_migrate_0_7
-      distutils_extra simplejson readline glance cheetah lockfile httplib2
+      distutils_extra simplejson readline glanceclient cheetah lockfile httplib2
       urlgrabber virtinst pyGtkGlade pythonDBus gnome_python pygobject3
       libvirt libxml2Python ipaddr vte libosinfo gobjectIntrospection gtk3 mox
       gtkvnc libvirt-glib glib gsettings_desktop_schemas gnome3.defaultIconTheme

--- a/pkgs/applications/virtualization/virtinst/default.nix
+++ b/pkgs/applications/virtualization/virtinst/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   pythonPath = with pythonPackages;
     [ setuptools eventlet greenlet gflags netaddr sqlalchemy carrot routes
       PasteDeploy m2crypto ipy twisted sqlalchemy_migrate
-      distutils_extra simplejson readline glance cheetah lockfile httplib2
+      distutils_extra simplejson readline glanceclient cheetah lockfile httplib2
       # !!! should libvirt be a build-time dependency?  Note that
       # libxml2Python is a dependency of libvirt.py.
       libvirt libxml2Python urlgrabber


### PR DESCRIPTION
Since 710b350b8e012554a5fa0494571c0835223aca98 `glance` has been
replaced in favor of `glanceclient`. This commit fixes the resulting
eval error.

Built and tested locally.
