### PR TITLE
Getting rid of mkOption in NixOS window manager modules

### DIFF
--- a/nixos/modules/services/x11/window-managers/afterstep.nix
+++ b/nixos/modules/services/x11/window-managers/afterstep.nix
@@ -8,10 +8,7 @@ in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.afterstep.enable = mkOption {
-      default = false;
-      description = "Enable the Afterstep window manager.";
-    };
+    services.xserver.windowManager.afterstep.enable = mkEnableOption "afterstep";
   };
 
   ###### implementation

--- a/nixos/modules/services/x11/window-managers/bspwm.nix
+++ b/nixos/modules/services/x11/window-managers/bspwm.nix
@@ -8,12 +8,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.bspwm.enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = "Enable the bspwm window manager.";
-    };
+    services.xserver.windowManager.bspwm.enable = mkEnableOption "bspwm";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/clfswm.nix
+++ b/nixos/modules/services/x11/window-managers/clfswm.nix
@@ -8,14 +8,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.clfswm = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Enable the clfswm tiling window manager.";
-      };
-    };
+    services.xserver.windowManager.clfswm.enable = mkEnableOption "clfswm";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/compiz.nix
+++ b/nixos/modules/services/x11/window-managers/compiz.nix
@@ -15,10 +15,7 @@ in
 
     services.xserver.windowManager.compiz = {
 
-      enable = mkOption {
-        default = false;
-        description = "Enable the Compiz window manager.";
-      };
+      enable = mkEnableOption "compiz";
 
       renderingFlag = mkOption {
         default = "";

--- a/nixos/modules/services/x11/window-managers/fluxbox.nix
+++ b/nixos/modules/services/x11/window-managers/fluxbox.nix
@@ -8,11 +8,7 @@ in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.fluxbox.enable = mkOption {
-      default = false;
-      description = "Enable the Fluxbox window manager.";
-    };
-  };
+    services.xserver.windowManager.fluxbox.enable = mkEnableOption "fluxbox";
 
   ###### implementation
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/herbstluftwm.nix
+++ b/nixos/modules/services/x11/window-managers/herbstluftwm.nix
@@ -8,12 +8,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.herbstluftwm.enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = "Enable the herbstluftwm window manager.";
-    };
+    services.xserver.windowManager.herbstluftwm.enable = mkEnableOption "herbstluftwm";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -9,11 +9,7 @@ in
 {
   options = {
     services.xserver.windowManager.i3 = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable the i3 tiling window manager.";
-      };
+      enable = mkEnableOption "i3";
 
       configFile = mkOption {
         default = null;

--- a/nixos/modules/services/x11/window-managers/icewm.nix
+++ b/nixos/modules/services/x11/window-managers/icewm.nix
@@ -8,7 +8,7 @@ in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.icewm.enable = mkEnableOption "oroborus";
+    services.xserver.windowManager.icewm.enable = mkEnableOption "icewm";
   };
 
   ###### implementation

--- a/nixos/modules/services/x11/window-managers/metacity.nix
+++ b/nixos/modules/services/x11/window-managers/metacity.nix
@@ -12,13 +12,7 @@ in
 
 {
   options = {
-
-    services.xserver.windowManager.metacity.enable = mkOption {
-      default = false;
-      example = true;
-      description = "Enable the metacity window manager.";
-    };
-
+    services.xserver.windowManager.metacity.enable = mkEnableOption "metacity";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/notion.nix
+++ b/nixos/modules/services/x11/window-managers/notion.nix
@@ -8,13 +8,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.notion = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable the notion tiling window manager.";
-      };
-    };
+    services.xserver.windowManager.notion.enable = mkEnableOption "notion";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/openbox.nix
+++ b/nixos/modules/services/x11/window-managers/openbox.nix
@@ -7,14 +7,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.openbox = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable the Openbox window manager.";
-      };
-    };
-  };
+    services.xserver.windowManager.openbox.enable = mkEnableOption "oroborus";
 
   config = mkIf cfg.enable {
     services.xserver.windowManager = {

--- a/nixos/modules/services/x11/window-managers/ratpoison.nix
+++ b/nixos/modules/services/x11/window-managers/ratpoison.nix
@@ -8,10 +8,7 @@ in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.ratpoison.enable = mkOption {
-      default = false;
-      description = "Enable the Ratpoison window manager.";
-    };
+    services.xserver.windowManager.ratpoison.enable = mkEnableOption "ratpoison";
   };
 
   ###### implementation

--- a/nixos/modules/services/x11/window-managers/sawfish.nix
+++ b/nixos/modules/services/x11/window-managers/sawfish.nix
@@ -8,10 +8,7 @@ in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.sawfish.enable = mkOption {
-      default = false;
-      description = "Enable the Sawfish window manager.";
-    };
+    services.xserver.windowManager.sawfish.enable = mkEnableOption "sawfish";
   };
 
   ###### implementation

--- a/nixos/modules/services/x11/window-managers/spectrwm.nix
+++ b/nixos/modules/services/x11/window-managers/spectrwm.nix
@@ -9,13 +9,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.spectrwm = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable the spectrwm window manager.";
-      };
-    };
+    services.xserver.windowManager.spectrwm.enable = mkEnableOption "spectrwm";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/stumpwm.nix
+++ b/nixos/modules/services/x11/window-managers/stumpwm.nix
@@ -8,14 +8,7 @@ in
 
 {
   options = {
-    services.xserver.windowManager.stumpwm = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Enable the stumpwm tiling window manager.";
-      };
-    };
+    services.xserver.windowManager.stumpwm.enable = mkEnableOption "stumpwm";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/twm.nix
+++ b/nixos/modules/services/x11/window-managers/twm.nix
@@ -13,12 +13,7 @@ in
   ###### interface
 
   options = {
-
-    services.xserver.windowManager.twm.enable = mkOption {
-      default = false;
-      description = "Enable the twm window manager.";
-    };
-
+    services.xserver.windowManager.twm.enable = mkEnableOption "twm";
   };
 
 

--- a/nixos/modules/services/x11/window-managers/windowmaker.nix
+++ b/nixos/modules/services/x11/window-managers/windowmaker.nix
@@ -8,10 +8,7 @@ in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.windowmaker.enable = mkOption {
-      default = false;
-      description = "Enable the Windowmaker window manager.";
-    };
+    services.xserver.windowManager.windowmaker.enable = mkEnableOption "windowmaker";
   };
 
   ###### implementation

--- a/nixos/modules/services/x11/window-managers/wmii.nix
+++ b/nixos/modules/services/x11/window-managers/wmii.nix
@@ -7,11 +7,7 @@ let
 in
 {
   options = {
-    services.xserver.windowManager.wmii.enable = mkOption {
-      default = false;
-      example = true;
-      description = "Enable the wmii window manager.";
-    };
+    services.xserver.windowManager.wmii.enable = mkEnableOption "wmii";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -13,12 +13,7 @@ in
 {
   options = {
     services.xserver.windowManager.xmonad = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable the xmonad window manager.";
-      };
-
+      enable = mkEnableOption "xmonad";
       haskellPackages = mkOption {
         default = pkgs.haskellPackages;
         defaultText = "pkgs.haskellPackages";


### PR DESCRIPTION
Now the default way to define NixOS window manager modules is to use
mkEnableOption to describe the module itself.
In this commit, all files on nixos/modules/services/x11/window-managers
are changed.
