### PR TITLE
logstash: fix bin path

### DIFF
--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -16,9 +16,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
-    cp -r {Gemfile*,vendor,lib} $out
-    cp bin/logstash $out/logstash
-    cp bin/plugin $out/logstash-plugin
+    cp -r {Gemfile*,vendor,lib,bin} $out
+    mv $out/bin/plugin $out/bin/logstash-plugin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
with the last commit for logstash plugin the bin path was not being used and the executables
were written directly in the root directory
this results in the failure of the logstash service configuration.
additionally the logstash tool itself does not start because it cannot source shell libraries relative
to the current location
