### PR TITLE
add helper to lib/attrsets: hasAttrByPath

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -23,6 +23,17 @@ rec {
       then attrByPath (tail attrPath) default e.${attr}
       else default;
 
+  /* Return if an attribute from nested attribute set exists.
+     For instance ["x" "y"] applied to some set e returns true, if e.x.y exists. False
+     is returned otherwise. */
+  hasAttrByPath = attrPath: e:
+    let attr = head attrPath;
+    in
+      if attrPath == [] then true
+      else if e ? ${attr}
+      then hasAttrByPath (tail attrPath) e.${attr}
+      else false;
+
 
   /* Return nested attribute set in which an attribute is set.  For instance
      ["x" "y"] applied with some value v returns `x.y = v;' */

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -120,4 +120,14 @@ runTests {
     expected = { success = false; value = false; };
   };
 
+  testHasAttrByPathTrue = {
+    expr = hasAttrByPath ["a" "b"] { a = { b = "yey"; }; };
+    expected = true;
+  };
+
+  testHasAttrByPathFalse = {
+    expr = hasAttrByPath ["a" "b"] { a = { c = "yey"; }; };
+    expected = false;
+  };
+
 }


### PR DESCRIPTION
Make it easy to test if an attrset has an attribute by path.
