### PR TITLE
release.nix: remove reference to pthreadmanpages

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -160,7 +160,6 @@ let
       pmccabe = linux;
       ppl = all;
       procps = linux;
-      pthreadmanpages = linux;
       pygtk = linux;
       python = allBut cygwin;
       pythonFull = linux;


### PR DESCRIPTION
Commit 9aa1cb6c59f7afc93d72037ab4477d5c259a3ff8 broke the nixpkgs.tarball job on hydra (see https://hydra.nixos.org/build/28466812). The commit removes the last reference to pthreadmanpages.
