### PR TITLE
hplip: fix evaluation error on staging

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -38,14 +38,14 @@ let
     };
 
   hplipArch = hplipPlatforms."${stdenv.system}"
-    or (abort "HPLIP not supported on ${stdenv.system}");
+    or (throw "HPLIP not supported on ${stdenv.system}");
 
   pluginArches = [ "x86_32" "x86_64" ];
 
 in
 
 assert withPlugin -> builtins.elem hplipArch pluginArches
-  || abort "HPLIP plugin not supported on ${stdenv.system}";
+  || throw "HPLIP plugin not supported on ${stdenv.system}";
 
 stdenv.mkDerivation {
   inherit name src;


### PR DESCRIPTION
Cherry-picked from master (see commit ec980c7b1ec8a788dd25daacdc3d) onto staging. This fixes an evaluation error on hydra's staging-small; see for instance:

https://hydra.nixos.org/build/28465711/log

Locally tested with

```
nix-build nixos/release-small.nix -A nixpkgs.tarball
```

cc @vcunat (author of the patch)
