### PR TITLE
mpd: set clientSupport to true by default

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -21,7 +21,7 @@
 , jackSupport ? true, libjack2
 , gmeSupport ? true, game-music-emu
 , icuSupport ? true, icu
-, clientSupport ? false, mpd_clientlib
+, clientSupport ? true, mpd_clientlib
 , opusSupport ? true, libopus
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9248,7 +9248,7 @@ let
 
   mpd = callPackage ../servers/mpd {
     aacSupport    = config.mpd.aacSupport or true;
-    clientSupport = config.mpd.clientSupport or false;
+    clientSupport = config.mpd.clientSupport or true;
     ffmpegSupport = config.mpd.ffmpegSupport or true;
     opusSupport   = config.mpd.opusSupport or true;
 


### PR DESCRIPTION
Standard "satellite" configuration from the docs will not work without this.
