### PR TITLE
rtorrent: build with fallocate support

### DIFF
--- a/pkgs/tools/networking/p2p/rtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libtorrent ncurses pkgconfig libsigcxx curl zlib openssl xmlrpc_c ];
-  configureFlags = "--with-xmlrpc-c";
+  configureFlags = [ "--with-xmlrpc-c" "--with-posix-fallocate" ];
 
   # postInstall = ''
   #   mkdir -p $out/share/man/man1 $out/share/rtorrent


### PR DESCRIPTION
This doesn't actually turn it on unless you say

```
system.file_allocate.set = yes
```

in the rtorrent config.
