### PR TITLE
OpenSSL: Security Updates for 15.09

### DIFF
--- a/pkgs/development/libraries/openssl/1.0.2.x.nix
+++ b/pkgs/development/libraries/openssl/1.0.2.x.nix
@@ -8,14 +8,14 @@ let
     stdenv.cross;
 in
 stdenv.mkDerivation rec {
-  name = "openssl-1.0.2d";
+  name = "openssl-1.0.2e";
 
   src = fetchurl {
     urls = [
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha1 = "d01d17b44663e8ffa6a33a5a30053779d9593c3d";
+    sha256 = "1zqb1rff1wikc62a7vj5qxd1k191m8qif5d05mwdxz2wnzywlg72";
   };
 
   patches = optional stdenv.isCygwin ./1.0.1-cygwin64.patch;

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -8,14 +8,14 @@ let
     stdenv.cross;
 in
 stdenv.mkDerivation rec {
-  name = "openssl-1.0.1p";
+  name = "openssl-1.0.1q";
 
   src = fetchurl {
     urls = [
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha1 = "9d1977cc89242cd11471269ece2ed4650947c046";
+    sha256 = "1dvz0hx7fjxag06b51pawy154y6d2xajm5rwxmfnlq7ax628nrdk";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
Cherry-picked version of #11469 for the 15.09 release.
