### PR TITLE
Add Kotlin

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -207,6 +207,7 @@
   muflax = "Stefan Dorn <mail@muflax.com>";
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";
+  nequissimus = "Tim Steinbach <tim@nequissimus.com>";
   nico202 = "Nicolò Balzarotti <anothersms@gmail.com>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
   np = "Nicolas Pouillard <np.nix@nicolaspouillard.fr>";

--- a/pkgs/development/compilers/kotlin/default.nix
+++ b/pkgs/development/compilers/kotlin/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, makeWrapper, jre, unzip, which }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.0-beta-3594";
+  name = "kotlin-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/JetBrains/kotlin/releases/download/build-${version}/kotlin-compiler-${version}.zip";
+    sha256 = "a633dc27bc9bc87174835ea47d5be8ec73e0a673bb46c4b9a5a784db95f3c733";
+  };
+
+  propagatedBuildInputs = [ jre which ] ;
+  buildInputs = [ makeWrapper unzip ] ;
+
+  installPhase = ''
+    mkdir -p $out
+    rm "bin/"*.bat
+    mv * $out
+
+    for p in $(ls $out/bin/) ; do
+      wrapProgram $out/bin/$p --prefix PATH ":" ${jre}/bin ;
+    done
+  '';
+
+  meta = {
+    description = "General purpose programming language";
+    longDescription = ''
+      Kotlin is a statically typed language that targets the JVM and JavaScript.
+      It is a general-purpose language intended for industry use.
+      It is developed by a team at JetBrains although it is an OSS language 
+      and has external contributors.
+    '';
+    homepage = http://kotlinlang.org/;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers;
+      [ nequissimus ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4222,6 +4222,8 @@ let
     openblas = openblasCompat;
   };
 
+  kotlin = callPackage ../development/compilers/kotlin { };
+
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {
     fpc = fpc;
   };


### PR DESCRIPTION
This is adding the latest Kotlin release (https://github.com/JetBrains/kotlin/releases/tag/build-1.0.0-beta-3594) as linked from the official website (http://kotlinlang.org/docs/tutorials/command-line.html)

Since this is my first nixpkg, I mostly followed what scala/default.nix was doing.
I verified the installation with `nix-env -f . -iA kotlin` and a subsequent compile and run on sample Kotlin source code.

The longDescription is taken directly from the Kotlin website (see http://kotlinlang.org/docs/reference/faq.html).
Verified the license is correct.

Let me know if I am missing something.
