### PR TITLE
mopidy-gmusic: init at 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -141,6 +141,7 @@
   jefdaj = "Jeffrey David Johnson <jefdaj@gmail.com>";
   jfb = "James Felix Black <james@yamtime.com>";
   jgeerds = "Jascha Geerds <jg@ekby.de>";
+  jgillich = "Jakob Gillich <jakob@gillich.me>";
   jirkamarsik = "Jirka Marsik <jiri.marsik89@gmail.com>";
   joachifm = "Joachim Fasting <joachifm@fastmail.fm>";
   joamaki = "Jussi Maki <joamaki@gmail.com>";

--- a/pkgs/applications/audio/mopidy-gmusic/default.nix
+++ b/pkgs/applications/audio/mopidy-gmusic/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "mopidy-gmusic-${version}";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/mopidy/mopidy-gmusic/archive/v${version}.tar.gz";
+    sha256 = "0yfilzfamy1bxnmgb1xk56jrk4sz0i7vcnc0a8klrm9sc7agnm9i";
+  };
+
+  propagatedBuildInputs = [ mopidy pythonPackages.requests2 pythonPackages.gmusicapi ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.mopidy.com/;
+    description = "Mopidy extension for playing music from Google Play Music";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jgillich ];
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -5,15 +5,15 @@
 pythonPackages.buildPythonPackage rec {
   name = "mopidy-${version}";
 
-  version = "1.0.5";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "https://github.com/mopidy/mopidy/archive/v${version}.tar.gz";
-    sha256 = "0lhmm2w2djf6mb3acw1yq1k4j74v1lf4kgx24dsdnpkgsycrv5q6";
+    sha256 = "1xfyg8xqgnrb98wx7a4fzr4vlzkffjhkc1s36ka63rwmx86vqhyw";
   };
 
   propagatedBuildInputs = with pythonPackages; [
-    gst_python pygobject pykka tornado gst_plugins_base gst_plugins_good
+    gst_python pygobject pykka tornado requests2 gst_plugins_base gst_plugins_good
   ];
 
   # There are no tests

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12489,6 +12489,8 @@ let
 
   mopidy = callPackage ../applications/audio/mopidy { };
 
+  mopidy-gmusic = callPackage ../applications/audio/mopidy-gmusic { };
+
   mopidy-spotify = callPackage ../applications/audio/mopidy-spotify { };
 
   mopidy-moped = callPackage ../applications/audio/mopidy-moped { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9866,6 +9866,25 @@ in modules // {
     };
   });
 
+  MechanicalSoup = buildPythonPackage rec {
+    name = "MechanicalSoup-${version}";
+    version = "0.4.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/M/MechanicalSoup/${name}.zip";
+      sha256 = "02jkwly4gw1jqm55l4wwn0j0ggnysx55inw9j96bif5l49z5cacd";
+    };
+
+    propagatedBuildInputs = with self; [ requests2 beautifulsoup4 six ];
+
+    meta = {
+      description = "A Python library for automating interaction with websites";
+      homepage = https://github.com/hickford/MechanicalSoup;
+      license = licenses.mit;
+      maintainers = with maintainers; [ jgillich ];
+    };
+  };
+
 
   meld3 = buildPythonPackage rec {
     name = "meld3-1.0.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4848,6 +4848,38 @@ in modules // {
     };
   };
 
+  gpsoauth = buildPythonPackage rec {
+    version = "0.0.4";
+    name = "gpsoauth-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/g/gpsoauth/${name}.tar.gz";
+      sha256 = "1mhd2lkl1f4fmia1cwxwik8gvqr5q16scjip7kfwzadh9a11n9kw";
+    };
+
+    propagatedBuildInputs = with self; [
+      cffi
+      cryptography
+      enum34
+      idna
+      ipaddress
+      ndg-httpsclient
+      pyopenssl
+      pyasn1
+      pycparser
+      pycrypto
+      requests2
+      six
+    ];
+
+    meta = {
+      description = "A python client library for Google Play Services OAuth.";
+      homepage = "https://github.com/simon-weber/gpsoauth";
+      license = licenses.mit;
+      maintainers = with maintainers; [ jgillich ];
+    };
+  };
+
   gst-python = callPackage ../development/libraries/gstreamer/python {
     gst-plugins-base = pkgs.gst_all_1.gst-plugins-base;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4667,11 +4667,11 @@ in modules // {
   };
 
   gmusicapi = with pkgs; buildPythonPackage rec {
-    name = "gmusicapi-4.0.0";
+    name = "gmusicapi-7.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gmusicapi/gmusicapi-4.0.0.tar.gz";
-      md5 = "12ba66607531978b349c7035c9bab311";
+      url = "https://pypi.python.org/packages/source/g/gmusicapi/gmusicapi-7.0.0.tar.gz";
+      sha256 = "1zji4cgylyzz97cz69lywkbsn5nvvzrhk7iaqnpqpfvj9gwdchwn";
     };
 
     propagatedBuildInputs = with self; [
@@ -4680,14 +4680,16 @@ in modules // {
       mutagen
       protobuf
       setuptools
-      requests
+      requests2
       dateutil
       proboscis
       mock
       appdirs
       oauth2client
+      pyopenssl
+      gpsoauth
+      MechanicalSoup
     ];
-    doCheck = false;
 
     meta = {
       description = "An unofficial API for Google Play Music";


### PR DESCRIPTION
This should work in theory, but it seems like mopidy extensions in general aren't working (tested on unstable):

```
mopidy[2776]: INFO     Disabled extension gmusic: Dependency The 'gmusicapi>=6.0' distribution was not found and is required by the application not found
mopidy[2776]: INFO     Disabled extension spotify: Dependency The 'pyspotify<1.999,>=1.9' distribution was not found and is required by the application not found
```

Can anyone look into this? I don't really know where to start.
