### PR TITLE
gstreamer 1.4 -> 1.6 and pitivi 0.94 -> 0.95

### DIFF
--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, pkgconfig, intltool, itstool, makeWrapper
-, python3Packages, gst, clutter-gtk, hicolor_icon_theme
+, python3Packages, gst, gtk3, hicolor_icon_theme
 , gobjectIntrospection, librsvg, gnome3, libnotify
 }:
 
 let
-  version = "0.94";
+  version = "0.95";
 in stdenv.mkDerivation rec {
   name = "pitivi-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/pitivi/${version}/${name}.tar.xz";
-    sha256 = "1v7s0qsibwykkmknspjhpdrj80s987pvbl01kh34k4aspi1hcapm";
+    sha256 = "04ykw619aikhxk5wj7z44pvwl52053d1kamcxpscw0ixrh5j45az";
   };
 
   meta = with stdenv.lib; {
@@ -29,15 +29,15 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool itstool makeWrapper ];
 
   buildInputs = [
-    gobjectIntrospection clutter-gtk librsvg gnome3.gnome_desktop
+    gobjectIntrospection gtk3 librsvg gnome3.gnome_desktop
     gnome3.defaultIconTheme
     gnome3.gsettings_desktop_schemas libnotify
   ] ++ (with gst; [
     gstreamer gst-editing-services
     gst-plugins-base gst-plugins-good
-    gst-plugins-bad gst-plugins-ugly gst-libav
+    gst-plugins-bad gst-plugins-ugly gst-libav gst-validate
   ]) ++ (with python3Packages; [
-    python pygobject3 gst-python pyxdg numpy pycairo sqlite3
+    python pygobject3 gst-python pyxdg numpy pycairo sqlite3 matplotlib
   ]);
 
   preFixup = ''

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -14,7 +14,7 @@ let
   inherit (stdenv.lib) optional optionalString;
 in
 stdenv.mkDerivation rec {
-  name = "gst-plugins-bad-1.4.5";
+  name = "gst-plugins-bad-1.6.1";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Bad Plugins";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-bad/${name}.tar.xz";
-    sha256 = "0g4q9yqq71z32pz7zj54wigkcf438a2mcv5kvvwp4gb8a1rasbqm";
+    sha256 = "0rjla9zcal9b5ynagq7cscjs53qrd9bafjkjssrp8s2z2apsjxp1";
   };
 
   nativeBuildInputs = [ pkgconfig python ];

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-base-1.4.5";
+  name = "gst-plugins-base-1.6.1";
 
   meta = {
     description = "Base plugins and helper libraries";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-base/${name}.tar.xz";
-    sha256 = "07ampnfa6p41s0lhia62l9h8bdx3c7vxvdz93pbx64m3wycq3gbp";
+    sha256 = "18sbyjcp281zb3bsqji3pglsdsxi0s6ai7rx90sx8cpflkxdqcwm";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gstreamer-1.4.5";
+  name = "gstreamer-1.6.1";
 
   meta = {
     description = "Open source multimedia framework";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer/${name}.tar.xz";
-    sha256 = "1bmhbhak6i5wmmb6w86jyyv8lax4gdq983la4lk4a0krz6kim020";
+    sha256 = "172w1bpnkn6mm1wi37n03apdbb6cdkykhzjf1vfxchcd7hhkyflp";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -20,4 +20,6 @@ rec {
   gst-editing-services = callPackage ./ges { inherit gnonlin; };
 
   gst-vaapi = callPackage ./vaapi { inherit gst-plugins-base gstreamer gst-plugins-bad; };
+
+  gst-validate = callPackage ./validate { inherit gst-plugins-base; };
 }

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -15,6 +15,8 @@ rec {
 
   gnonlin = callPackage ./gnonlin { inherit gst-plugins-base; };
 
+  # TODO: gnonlin is deprecated in gst-editing-services, better switch to nle
+  # (Non Linear Engine).
   gst-editing-services = callPackage ./ges { inherit gnonlin; };
 
   gst-vaapi = callPackage ./vaapi { inherit gst-plugins-base gstreamer gst-plugins-bad; };

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, pkgconfig, python, gobjectIntrospection
-, gnonlin, libxml2
+, gnonlin, libxml2, flex, perl
 }:
 
 stdenv.mkDerivation rec {
-  name = "gstreamer-editing-services-1.4.0";
+  name = "gstreamer-editing-services-1.6.1";
 
   meta = with stdenv.lib; {
     description = "Library for creation of audio/video non-linear editors";
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer-editing-services/${name}.tar.xz";
-    sha256 = "1cwbh244an6zsxsscvg6xjnb34ylci34g9zx59xjbv5wnw7vj86c";
+    sha256 = "1lkvkrsipn35341hwwkhwn44n90y49sjwra1r5pazbjgn1yykxzm";
   };
 
-  nativeBuildInputs = [ pkgconfig python gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig python gobjectIntrospection flex perl ];
 
   propagatedBuildInputs = [ gnonlin libxml2 ];
 }

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -10,7 +10,7 @@ let
   inherit (stdenv.lib) optionals optionalString;
 in
 stdenv.mkDerivation rec {
-  name = "gst-plugins-good-1.4.5";
+  name = "gst-plugins-good-1.6.1";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Good Plugins";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-good/${name}.tar.xz";
-    sha256 = "0hg6qzdpib9nwn3hdxv0d4rvivi1c4bmxsq2a9hqmamwyzrvbcbr";
+    sha256 = "0darc3058kbnql3mnlpizl0sq0hhli7vkm0rpqb7nywz14abim46";
   };
 
   nativeBuildInputs = [ pkgconfig python ];

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -3,10 +3,13 @@
 , withSystemLibav ? true, libav ? null
 }:
 
+# Note that since gst-libav-1.6, libav is actually ffmpeg. See
+# http://gstreamer.freedesktop.org/releases/1.6/ for more info.
+
 assert withSystemLibav -> libav != null;
 
 stdenv.mkDerivation rec {
-  name = "gst-libav-1.4.5";
+  name = "gst-libav-1.6.1";
 
   meta = {
     homepage = "http://gstreamer.freedesktop.org";
@@ -17,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-libav/${name}.tar.xz";
-    sha256 = "1g7vg9amh3cc3nmc415h6g2rqxqi4wgwqi08hxfbpwq48ri64p30";
+    sha256 = "1a9pc7zp5rg0cvpx8gqkr21w73i6p9xa505a34day9f8p3lfim94";
   };
 
   configureFlags = stdenv.lib.optionalString withSystemLibav

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-ugly-1.4.5";
+  name = "gst-plugins-ugly-1.6.1";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Ugly Plugins";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-ugly/${name}.tar.xz";
-    sha256 = "0rwhljn3f8mp2pfchzfcx4pvps1546dndw9mr56lz50qyqffimaw";
+    sha256 = "0mvasl1pwq70w2kmrkcrg77kggl5q7jqybi7fkvy3vr28c7gkhqc";
   };
 
   nativeBuildInputs = [ pkgconfig python ];

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gst-vaapi-${version}";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchurl {
     url = "${meta.homepage}/software/vaapi/releases/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.bz2";
-    sha256 = "1f3ji0h0x49w4wpqc0widraa9kvq0b47idrdxq4znjb8c1bwd97n";
+    sha256 = "1cv7zlz5wj6b3acv0pr5cq5wqzd5vcs1lrrlvyl9wrzcnzz8mz1n";
   };
 
   nativeBuildInputs = with stdenv.lib; [ pkgconfig bzip2 ];

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig, gstreamer, gst-plugins-base
+, python, gobjectIntrospection
+}:
+
+stdenv.mkDerivation rec {
+  name = "gst-validate-1.6.0";
+
+  meta = {
+    description = "Integration testing infrastructure for the GStreamer framework";
+    homepage = "http://gstreamer.freedesktop.org";
+    license = stdenv.lib.licenses.lgpl2Plus;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ iyzsong ];
+  };
+
+  src = fetchurl {
+    url = "${meta.homepage}/src/gst-validate/${name}.tar.xz";
+    sha256 = "1vmg5mh068zrvhgrjsbnb7y4k632akyhm8ql0g196cinnp3zibiv";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig gobjectIntrospection
+  ];
+
+  buildInputs = [
+    python
+  ];
+
+  propagatedBuildInputs = [ gstreamer gst-plugins-base ];
+
+  enableParallelBuilding = true;
+}
+

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python, pkgconfig, glib, gobjectIntrospection, pycairo, cairo }:
 
 stdenv.mkDerivation rec {
-  name = "pygobject-3.12.1";
+  name = "pygobject-3.18.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/pygobject/3.12/${name}.tar.xz";
-    sha256 = "0dfsjsa95ix8bx3h8w4bhnz7rymgl2paclvbn93x6qp8b53y0pys";
+    url = "mirror://gnome/sources/pygobject/3.18/${name}.tar.xz";
+    sha256 = "0prc3ky7g50ixmfxbc7zf43fw6in4hw2q07667hp8swi2wassg1a";
   };
 
   buildInputs = [ python pkgconfig glib gobjectIntrospection ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6518,7 +6518,7 @@ let
   gperftools = callPackage ../development/libraries/gperftools { };
 
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
-    callPackage = pkgs.newScope (pkgs // { inherit (pkgs) libav; });
+    callPackage = pkgs.newScope (pkgs // { libav = pkgs.ffmpeg; });
   });
 
   gst_all = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2619,8 +2619,10 @@ let
   parted = callPackage ../tools/misc/parted { hurd = null; };
 
   pitivi = callPackage ../applications/video/pitivi {
-    gst = gst_all_1;
-    clutter-gtk = clutter_gtk;
+    gst = gst_all_1 //
+      { gst-plugins-bad = gst_all_1.gst-plugins-bad.overrideDerivation
+          (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ [ gtk3 ]; });
+      };
   };
 
   p0f = callPackage ../tools/security/p0f { };


### PR DESCRIPTION
The plan was just to update pitivi, but as it depends on gstreamer >= 1.6.0 I did both in one go. Also gst-validate had to be added, and pygobject3 needed to be updated for pitivi to be happy.

I've tested pitivi pretty well (so I know it doesn't regress), but I haven't tested any other gstreamer packages yet. (GStreamer documentation says 1.x is compatible/stable, but I don't know...)

CC @iyzsong (gstreamer _and_ pitivi maintainer)

DON'T MERGE YET, SEVERE GSTREAMER PERFORMANCE REGRESSION.
