### PR TITLE
shellinabox: 2.16 -> 2.19

### DIFF
--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, pam, openssl, openssh, shadow, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "2.16";
+  version = "2.19";
   name = "shellinabox-${version}";
 
   src = fetchFromGitHub {
     owner = "shellinabox";
     repo = "shellinabox";
-    rev = "8ac3a4efcf20f7b66d3f1eb1d4f3054aef6e196b";
-    sha256 = "1pp6nk0279d2q7l1cvx8jc73skfjv0s42wxb2m00x0bg9i1fvs5j";
+    rev = "1a8010f2c94a62e7398c4fa130dfe9e099dc55cd";
+    sha256 = "16cr7gbnh6vzsxlhg9j9avqrxbhbkqhsbvh197b0ccdwbb04ysan";
   };
 
   patches = [ ./shellinabox-minus.patch ];


### PR DESCRIPTION
Version 2.19 contains a fix for [CVE-2015-8400](https://github.com/shellinabox/shellinabox/issues/355).
Tested and works with the shellinabox NixOS module.

cc @tomberek
