### PR TITLE
dhparams module: Generate Diffie-Hellman parameters

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -83,6 +83,7 @@
   ./security/apparmor.nix
   ./security/apparmor-suid.nix
   ./security/ca.nix
+  ./security/dhparams.nix
   ./security/duosec.nix
   ./security/grsecurity.nix
   ./security/pam.nix

--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.security.dhparams;
+
+  idString = "${config.networking.hostName}-${toString config.networking.hostId}";
+
+  inherit (pkgs) openssl;
+
+  dhparamOpts = { ... }: {
+    options = {
+      bits = mkOption {
+        type = types.int;
+        default = 4096;
+        description = "Number of bits for Diffie-Hellman parameters length";
+      };
+    };
+  };
+
+in
+
+{
+
+  options = {
+    security.dhparams = mkOption {
+      default = { };
+      type = types.loaOf types.optionSet;
+      description = ''
+        Attribute set or list of paths relative to /etc to place Diffie-Hellman
+        parameters that should be generated. Defaults to 4096 bits.
+      '';
+      options = [ dhparamOpts ];
+      example = {
+        "nginx/dhparam.pem".bits = 4096;
+        "prosody/dhparam.pem" = {};
+      };
+    };
+  };
+
+  config = {
+    environment.etc = flip mapAttrs' cfg (path: data: nameValuePair
+      (path)
+      ({ source = pkgs.runCommand "dhparam-${idString}-${replaceStrings ["/"] ["-"] path}" {}
+           "${openssl}/bin/openssl dhparam -out $out ${toString data.bits}";
+      })
+    );
+  };
+
+}


### PR DESCRIPTION
This new module generates Diffie-Hellman parameters for TLS-enabled services by leveraging `environment.etc`. The parameters file is stored in the Nix store and is parametrized with both the hostname, hostid and path to prevent using the same set of parameters on all NixOS hosts.
Parameters will still be cached on a host/path basis in the Nix store, so they won't be regenerated on rebuilds.

Example:

``` nix
  security.dhparams = {
    "nginx/dhparam.pem" = { };
    "ssl/dhparam-2048.pem".bits = 2048;
  };
```
