### PR TITLE
virtualboxGuestAdditions: Add missing library paths to patchelf.

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation {
 
     for i in lib/VBoxOGL*.so
     do
-        patchelf --set-rpath $out/lib:${dbus}/lib $i
+        patchelf --set-rpath $out/lib:${dbus}/lib:${libXcomposite}/lib:${libXdamage}/lib:${libXext}/lib:${libXfixes}/lib $i
     done
 
     # FIXME: Virtualbox 4.3.22 moved VBoxClient-all (required by Guest Additions


### PR DESCRIPTION
If one tries to use the virtualbox DRI driver from non-NixOS (via setting of LIBGL_DRIVERS_PATH), missing rpaths in libOGL.so cause a weird application crash:

```
Inconsistency detected by ld.so: dl-open.c: 680: _dl_open: Assertion `_dl_debug_initialize (0, args.nsid)->r_state == RT_CONSISTENT' failed!
```

This seems like a secondary issue because libXcomposite.so os not found; setting LD_PRELOAD or LD_LIBRARY_PATH appropriately solves it. I have not verified that this particular fix works (only that it builds), but it should.
