### PR TITLE
[WIP] systemd: enable timedated, hostnamed, localed.

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -148,6 +148,12 @@ let
 
       # Misc.
       "systemd-sysctl.service"
+      "dbus-org.freedesktop.timedate1.service"
+      "dbus-org.freedesktop.locale1.service"
+      "dbus-org.freedesktop.hostname1.service"
+      "systemd-timedated.service"
+      "systemd-localed.service"
+      "systemd-hostnamed.service"
     ]
 
     ++ cfg.additionalUpstreamSystemUnits;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -48,13 +48,13 @@ stdenv.mkDerivation rec {
       "--enable-compat-libs" # get rid of this eventually
       "--disable-tests"
 
-      "--disable-hostnamed"
+      "--enable-hostnamed"
       "--enable-networkd"
       "--disable-sysusers"
-      "--disable-timedated"
+      "--enable-timedated"
       "--enable-timesyncd"
       "--disable-firstboot"
-      "--disable-localed"
+      "--enable-localed"
       "--enable-resolved"
       "--disable-split-usr"
       "--disable-libcurl"


### PR DESCRIPTION
WIP because this depends on a patch to our systemd fork: nixos/systemd#2

Right now, we disable the timedated, hostnamed, and localed services because they can modify the system configuration.  But this also disables the useful timedatectl, hostnamectl, and localectl utilities.

The systemd patch disables the problematic dbus methods in these services and makes them return error messages instead.  This PR then enables the services.

With this PR, timedatectl, hostnamectl, and localectl work fine if you use them read-only; as soon as you try to change the system configuration you get a useful error message:

```
# timedatectl set-ntp true
Failed to set ntp: Changing system settings via systemd is not supported on NixOS.
```

Fixes nixos/nixos#82
