### PR TITLE
bash-4.3: Patch 42 changed its hash

### DIFF
--- a/pkgs/shells/bash/bash-4.3-patches.nix
+++ b/pkgs/shells/bash/bash-4.3-patches.nix
@@ -42,5 +42,5 @@ patch: [
 (patch "039" "1v3l3vkc3g2b6fjycqwlakr8xhiw6bmw6q0zd6bi0m0m4bnxr55b")
 (patch "040" "0sypv66vsldmc95gwvf7ylz1k7y37vnvdsjg8ajjr6b2j9mkkfw4")
 (patch "041" "06ic2gdpbi1afik3wqf9d4vh95if4bz8bmhcgr555621dsb35i2f")
-(patch "042" "1bwhssay66n75fy0pxcrwbm032s6fvfg7dblzbrzzn5k38a56nmp")
+(patch "042" "06a90k0p6bqc4wk2dsmapna69124an76xvlnlj3xm497vci968dc")
 ]


### PR DESCRIPTION
Building bash failed with the following error message:

```
trying http://ftpmirror.gnu.org/bash/bash-4.3-patches/bash43-042
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   332  100   332    0     0   1889      0 --:--:-- --:--:-- --:--:--  1908
100  1535  100  1535    0     0   7789      0 --:--:-- --:--:-- --:--:--  7789
output path ‘/nix/store/pdwz581jbf27cm2lvmngrhnrbyd5bv7a-bash43-042’ should have sha256 hash ‘1bwhssay66n75fy0pxcrwbm032s6fvfg7dblzbrzzn5k38a56nmp’, instead has ‘06a90k0p6bqc4wk2dsmapna69124an76xvlnlj3xm497vci968dc’
cannot build derivation ‘/nix/store/nkn2j7v1ws8yq17b4kdkxyqd2dbdwjcg-bash-4.3-p42.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/nkn2j7v1ws8yq17b4kdkxyqd2dbdwjcg-bash-4.3-p42.drv’ failed
```

I ran `update-patch-set.sh` and noticed that it produced a different hash for patch 42. This PR reflects that change.
