### PR TITLE
w3m: turn off mouseSupport on Darwin

### DIFF
--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -3,7 +3,7 @@
 , sslSupport ? true, openssl ? null
 , graphicsSupport ? true, imlib2 ? null
 , x11Support ? graphicsSupport, libX11 ? null
-, mouseSupport ? true, gpm-ncurses ? null
+, mouseSupport ? !stdenv.isDarwin, gpm-ncurses ? null
 }:
 
 assert sslSupport -> openssl != null;


### PR DESCRIPTION
Fixes an issue reported at https://github.com/NixOS/nixpkgs/pull/11222/files#r46774825
