### PR TITLE
shout: fix preStart

### DIFF
--- a/nixos/modules/services/networking/shout.nix
+++ b/nixos/modules/services/networking/shout.nix
@@ -57,7 +57,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      preStart = if isNull cfg.configFile then null
+      preStart = if isNull cfg.configFile then ""
                  else ''
                    ln -sf ${pkgs.writeText "config.js" cfg.configFile} \
                           ${shoutHome}/config.js


### PR DESCRIPTION
preStart must be a string

```
error: The option value `containers.shout.systemd.services.shout.preStart' in `/nix/store/m2hifyqjvqnyq6p1xfy2yjmr3qfp6xa7-nixos-15.09.760.ba0d05c/nixos/nixpkgs/nixos/modules/services/networking/shout.nix' is not a string.
```
