### PR TITLE
namecoin: fix sha256 using fetchzip

### DIFF
--- a/pkgs/applications/altcoins/namecoind.nix
+++ b/pkgs/applications/altcoins/namecoind.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, db4, boost, openssl, miniupnpc, unzip }:
+{ stdenv, fetchzip, db4, boost, openssl, miniupnpc, unzip }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   version = "0.3.80";
   name = "namecoind-${version}";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/namecoin/namecoin/archive/nc${version}.tar.gz";
-    sha256 = "1755mqxpg91wg9hf0ibpj59sdzfmhh73yrpi7hfi2ipabkwmlpiz";
+    sha256 = "0mbkhj7y3f4vbqp5q3zk27bzqlk2kq71rcgivvj06w29fzd64mw6";
   };
 
   buildInputs = [ db4 boost openssl unzip miniupnpc ];


### PR DESCRIPTION
Another one; see https://hydra.nixos.org/build/28567680

Build tested locally against the nixpkgs-unstable channel, then rebased onto master.

cc @domenkozar
