### PR TITLE
gosmore: r30811 -> r31801, fix sha256

### DIFF
--- a/pkgs/applications/misc/gosmore/default.nix
+++ b/pkgs/applications/misc/gosmore/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchsvn, libxml2, gtk, curl, pkgconfig } :
 
 let
-  version = "30811";
+  version = "31801";
 in
 stdenv.mkDerivation {
   name = "gosmore-r${version}";
   src = fetchsvn {
     url = http://svn.openstreetmap.org/applications/rendering/gosmore;
-    sha256 = "0d8ddfa0nhz51ambwj9y5jjbizl9y9w44sviisk3ysqvn8q0phds";
+    sha256 = "0i6m3ikavsaqhfy18sykzq0cflw978nr4fhg18hawndcmr45v5zj";
     rev = "${version}";
   };
 


### PR DESCRIPTION
Fixing another broken build (see https://hydra.nixos.org/build/28630074). I've also updated the svn revision. Successfully built and tested on nixpkgs-unstable and rebased onto master.

I have only very briefly tested the application itself, however the last revision to the core source code is r30327 so this update doesn't affect any of the code. The only difference for this project is in the "map-icons" external (currently at revision 31801), which as far as I can tell only contains data, so this should mostly keep working.

A wider issue is that svn does not lock externals at a specific revision if not properly set up - this being a limitation of subversion itself of course - so this project will keep breaking its hash on every commit to the external...

cc @7c6f434c (Michael Raskin) @domenkozar 
