### PR TITLE
partclone: fix sha256 and buildInputs

### DIFF
--- a/pkgs/tools/backup/partclone/default.nix
+++ b/pkgs/tools/backup/partclone/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchFromGitHub
 , pkgconfig, libuuid
-, e2fsprogs
+, e2fsprogs, automake, autoconf
 }:
 stdenv.mkDerivation {
   name = "partclone-stable";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     sha256 = "0q3brjmnldpr89nhbiajxg3gncz0nagc34n7q2723lpz7bn28w3z";
   };
 
-  buildInputs = [e2fsprogs pkgconfig libuuid];
+  buildInputs = [e2fsprogs pkgconfig libuuid automake autoconf];
 
   installPhase = ''make INSTPREFIX=$out install'';
 

--- a/pkgs/tools/backup/partclone/default.nix
+++ b/pkgs/tools/backup/partclone/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl
+{stdenv, fetchFromGitHub
 , pkgconfig, libuuid
 , e2fsprogs
 }:
@@ -6,10 +6,11 @@ stdenv.mkDerivation {
   name = "partclone-stable";
   enableParallelBuilding = true;
 
-  src = fetchurl {
-    url = https://codeload.github.com/Thomas-Tsai/partclone/legacy.tar.gz/stable;
-    sha256 = "12bnhljc4n4951p5c05gc7z5qwdsjpx867ad1npmgsm8d9w941sn";
-    name = "Thomas-Tsai-partclone-stable-20150722.tar.gz";
+  src = fetchFromGitHub {
+    owner = "Thomas-Tsai";
+    repo = "partclone";
+    rev = "stable";
+    sha256 = "0q3brjmnldpr89nhbiajxg3gncz0nagc34n7q2723lpz7bn28w3z";
   };
 
   buildInputs = [e2fsprogs pkgconfig libuuid];


### PR DESCRIPTION
Locally built against nixpkgs-unstable and then rebased onto master. I've also double checked that the contents of the old and new archives is identical. The project didn't build without automake and autoconf so I added those in as well.

This should fix https://hydra.nixos.org/build/28627511

cc @MarcWeber @domenkozar
