### PR TITLE
texinfo: fix doCheck properly, cleanup

### DIFF
--- a/pkgs/development/tools/misc/texinfo/5.2.nix
+++ b/pkgs/development/tools/misc/texinfo/5.2.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, ncurses, perl, xz, interactive ? false }:
+{ stdenv, fetchurl, ncurses, perl, xz, procps, interactive ? false }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "texinfo-5.2";
@@ -9,7 +11,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ perl xz ]
-    ++ stdenv.lib.optional interactive ncurses;
+    ++ optional interactive ncurses
+    ++ optional doCheck procps; # for tests
 
   preInstall = ''
     installFlags="TEXMF=$out/texmf-dist";
@@ -21,8 +24,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.gnu.org/software/texinfo/";
     description = "The GNU documentation system";
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
 
     longDescription = ''
       Texinfo is the official documentation format of the GNU project.

--- a/pkgs/development/tools/misc/texinfo/6.0.nix
+++ b/pkgs/development/tools/misc/texinfo/6.0.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, ncurses, perl, xz, libiconv, gawk, interactive ? false }:
+{ stdenv, fetchurl, ncurses, perl, xz, libiconv, gawk, procps, interactive ? false }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "texinfo-6.0";
@@ -9,8 +11,9 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ perl xz ]
-    ++ stdenv.lib.optionals stdenv.isSunOS [ libiconv gawk ]
-    ++ stdenv.lib.optional interactive ncurses;
+    ++ optionals stdenv.isSunOS [ libiconv gawk ]
+    ++ optional interactive ncurses
+    ++ optional doCheck procps; # for tests
 
   configureFlags = stdenv.lib.optionalString stdenv.isSunOS "AWK=${gawk}/bin/awk";
 
@@ -19,13 +22,13 @@ stdenv.mkDerivation rec {
     installTargets="install install-tex";
   '';
 
-  doCheck = !stdenv.isDarwin && !interactive && !stdenv.isSunOS/*flaky*/;
+  doCheck = !stdenv.isDarwin && !stdenv.isSunOS/*flaky*/;
 
   meta = {
     homepage = "http://www.gnu.org/software/texinfo/";
     description = "The GNU documentation system";
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
 
     longDescription = ''
       Texinfo is the official documentation format of the GNU project.


### PR DESCRIPTION
Would be nice if SunOS people would check whenever they can now remove that `!stdenv.isSunOS` flakyness.
