### PR TITLE
Add simp_le, a simple non-interactive ACME client, with a NixOS service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -410,6 +410,7 @@
   ./services/web-servers/lighttpd/gitweb.nix
   ./services/web-servers/nginx/default.nix
   ./services/web-servers/phpfpm.nix
+  ./services/web-servers/simp_le.nix
   ./services/web-servers/shellinabox.nix
   ./services/web-servers/tomcat.nix
   ./services/web-servers/uwsgi.nix

--- a/nixos/modules/services/web-servers/simp_le.nix
+++ b/nixos/modules/services/web-servers/simp_le.nix
@@ -1,0 +1,133 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.simp_le;
+
+  cmdline = toString (
+    optionals (cfg.email != null) [ "--email" (escapeShellArg cfg.email) ]
+    ++ concatMap (x: [ "-f" x ]) cfg.plugins
+    ++ concatLists (mapAttrsToList (name: root: [ "-d" "${name}:${escapeShellArg root}" ]) cfg.domains)
+  );
+
+in {
+
+  options = {
+    services.simp_le = {
+      email = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Email address of domains administrator; used by CA to send
+          warning emails.
+        '';
+      };
+
+      plugins = mkOption {
+        type = types.listOf types.str;
+        default = [ "account_key.json" "key.pem" "fullchain.pem" ];
+        description = ''
+          Input/output plugins for simp_le. With default settings simp_le will
+          store public certificate bundle in <filename>fullchain.pem</filename>
+          and private key in <filename>key.pem</filename> in its state directory.
+        '';
+      };
+
+      domains = mkOption {
+        type = types.attrsOf types.str;
+        example = {
+          "example.org" = "/srv/http/nginx";
+          "mydomain.org" = "/srv/http/mydomain.org/nginx";
+        };
+        description = ''
+          Domain names for which certificates are to be issued, with their
+          server roots. <filename>.well-known/acme-challenge/</filename> directories
+          will be created automatically in those roots if they don't exist.
+          <literal>http://example.org/.well-known/acme-challenge/</literal> must also
+          be available (notice unencrypted HTTP).
+        '';
+      };
+
+      postRun = mkOption {
+        type = types.lines;
+        default = "";
+        example = "systemctl reload nginx.service";
+        description = ''
+          Commands to run after certificates are re-issued. Typically
+          the web server and other servers using certificates need to
+          be reloaded.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          User under which simp_le would run.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          Group under which simp_le would run.
+        '';
+      };
+
+      period = mkOption {
+        type = types.str;
+        default = "weekly";
+        description = ''
+          Interval at which simp_le is runned.
+        '';
+      };
+
+      stateDir = mkOption {
+        type = types.str;
+        default = "/var/lib/simp_le";
+        description = ''
+          simp_le state directory, including certificate storage.
+          It is readable only by the simp_le user by default.
+
+          Issued certificates will be stored in this directory in format
+          depending on plugins.
+        '';
+        apply = escapeShellArg;
+      };
+    };
+  };
+
+  config = mkIf (builtins.length (builtins.attrNames cfg.domains) > 0) {
+
+    systemd.services."simp_le" = {
+      description = "simp_le ACME client";
+      requires    = [ "network.target" ];
+      serviceConfig.Type = "oneshot";
+
+      path = [ pkgs.pythonPackages.simp_le pkgs.sudo ];
+      script = ''
+        if [ ! -d ${cfg.stateDir} ]; then
+          mkdir -p -m 0700 ${cfg.stateDir}
+          chown ${cfg.user}:${cfg.group} ${cfg.stateDir}
+        fi
+
+        cd ${cfg.stateDir}
+        set +e
+        sudo -u ${cfg.user} simp_le ${cmdline}
+        ERRORCODE=$?
+        [ "$ERRORCODE" == "1" ] && exit 0
+        [ "$ERRORCODE" == "2" ] && exit 1
+        set -e
+        ${cfg.postRun}
+      '';
+    };
+
+    systemd.timers."simp_le" = {
+      timerConfig.OnCalendar = cfg.period;
+      wantedBy = [ "timers.target" ];
+    };
+
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16780,6 +16780,25 @@ in modules // {
     };
   };
 
+  simp_le = buildPythonPackage rec {
+    version = "20151207";
+    name = "simplegeneric-${version}";
+
+    src = pkgs.fetchgit {
+      url = "https://github.com/kuba/simp_le";
+      rev = "ac836bc0af988cb14dc0a83dc2039e7fa541b677";
+      sha256 = "6c471b57e1964f68ee99558fcd57196061dfe50cebd66856a239a5511f0d558f";
+    };
+
+    propagatedBuildInputs = with self; [ acme ];
+
+    meta = {
+      description = "Simple Let's Encrypt Client";
+      homepage = https://github.com/kuba/simp_le;
+      license = licenses.gpl3;
+    };
+  };
+
   simplegeneric = buildPythonPackage rec {
     version = "0.8.1";
     name = "simplegeneric-${version}";


### PR DESCRIPTION
See https://github.com/kuba/simp_le. The service supports running the client on timer with given parameters. It is much simpler than the official client, and very script-friendly.

cc @domenkozar 
