### PR TITLE
nixos: networking cleanup

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -6,17 +6,8 @@ with lib;
 let
 
   cfg = config.networking;
-  interfaces = attrValues cfg.interfaces;
 
-  interfaceIps = i:
-    i.ip4 ++ optionals cfg.enableIPv6 i.ip6
-    ++ optional (i.ipAddress != null) {
-      address = i.ipAddress;
-      prefixLength = i.prefixLength;
-    } ++ optional (cfg.enableIPv6 && i.ipv6Address != null) {
-      address = i.ipv6Address;
-      prefixLength = i.ipv6PrefixLength;
-    };
+  interfaces = attrValues cfg.interfaces;
 
   dhcpStr = useDHCP: if useDHCP == true || useDHCP == null then "both" else "none";
 
@@ -92,8 +83,8 @@ in
         networks."40-${i.name}" = mkMerge [ (genericNetwork mkDefault) {
           name = mkDefault i.name;
           DHCP = mkForce (dhcpStr
-            (if i.useDHCP != null then i.useDHCP else cfg.useDHCP && interfaceIps i == [ ]));
-          address = flip map (interfaceIps i)
+            (if i.useDHCP != null then i.useDHCP else cfg.useDHCP && i.ips == [ ]));
+          address = flip map i.ips
             (ip: "${ip.address}/${toString ip.prefixLength}");
         } ];
       })))


### PR DESCRIPTION
NixOS networking module is a mess. I've been trying to do something about it for a while, and I think I did simplify it somewhat with this patch set, but it has one problem: deprecating/renaming options in submodules doesn't work.

`mkRemovedOptionModule` and `mkRenamedOptionModule` generate a warning inside a submodule, but this warning never get's out to the top-level warnings.

I tried to implement something that could possibly work, but historically all my attempts had failed. NixOS recently introduced `mkRemovedOptionModule` and friends, and I tried to use it, but it did not suffice too.

I want users that define `subnetMask` to get errors, and to implement that behavior without top-level asserts, but all my attempts are either completely ignored in the process of evaluation because these errors don't get computed/propagated to top-level or `subnetMask` asserts produce errors even when it's not defined.

Same problem with `*address` and `*prefixLength` options.

I actually have a continuation of this patch set that then breaks networking into a series of independent modules and adds new useful assertions, but I didn't merge it with the current master yet, and don't want to do it until this gets to work properly.
