### PR TITLE
ccache: create symlinks to gcc lib & include in ccache-links directory

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -49,6 +49,9 @@ stdenv.mkDerivation {
             ln -s ${gcc.cc}/bin/$executable $out/bin/$executable
           fi
         done
+        for file in $(ls ${gcc.cc} | grep -vw bin); do
+          ln -s ${gcc.cc}/$file $out/$file
+        done
       '');
   };
 


### PR DESCRIPTION
This patch fixes compilation errors when using ccache wrapper:

```
cc1: error: /nix/store/19vvbsjs6l6j0r22albzhysxfvr94imf-ccache-links/lib/gcc/*/*/include-fixed: No such file or directory
```
