### PR TITLE
workaround for missing bash patch without stdenv change

### DIFF
--- a/pkgs/shells/bash/bash-4.3-patches.nix
+++ b/pkgs/shells/bash/bash-4.3-patches.nix
@@ -42,5 +42,5 @@ patch: [
 (patch "039" "1v3l3vkc3g2b6fjycqwlakr8xhiw6bmw6q0zd6bi0m0m4bnxr55b")
 (patch "040" "0sypv66vsldmc95gwvf7ylz1k7y37vnvdsjg8ajjr6b2j9mkkfw4")
 (patch "041" "06ic2gdpbi1afik3wqf9d4vh95if4bz8bmhcgr555621dsb35i2f")
-(patch "042" "1bwhssay66n75fy0pxcrwbm032s6fvfg7dblzbrzzn5k38a56nmp")
+# patch 042 is temporarily on different mirror as hash changed - see default.nix (fix is in stating)
 ]

--- a/pkgs/shells/bash/default.nix
+++ b/pkgs/shells/bash/default.nix
@@ -9,6 +9,11 @@ let
   shortName = "bash43";
   baseConfigureFlags = if interactive then "--with-installed-readline" else "--disable-readline";
   sha256 = "1m14s1f61mf6bijfibcjm9y6pkyvz6gibyl8p4hxq90fisi8gimg";
+  patch42 = fetchurl {
+   url = "https://gist.githubusercontent.com/domenkozar/aa502519c9098080a4f8/raw/1ed579e06d21ca3a64fa75f9631261cd295b5f7c/gistfile1.txt";
+   name = "${shortName}-042";
+   sha256 = "1bwhssay66n75fy0pxcrwbm032s6fvfg7dblzbrzzn5k38a56nmp";
+  };
 in
 
 stdenv.mkDerivation rec {
@@ -40,7 +45,7 @@ stdenv.mkDerivation rec {
           inherit sha256;
         };
     in
-      import ./bash-4.3-patches.nix patch) 
+      import ./bash-4.3-patches.nix patch) ++ [patch42]
       ++ stdenv.lib.optional stdenv.isCygwin ./cygwin-bash-4.3.33-1.src.patch;
 
   crossAttrs = {


### PR DESCRIPTION
see #11512
