### PR TITLE
More strict commit policy for stable branch

### DIFF
--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -278,9 +278,9 @@ Additional information.
 </listitem>
 
 <listitem>
-<para>If you're cherry-picking and/or commit to a stable release branch, add a
-      clear description about the reason this needs to be included in the
-      release branch.
+<para>If you're cherry-picking and/or commit to a stable release branch always
+       use <command>git cherry-pick -x</command> add a clear description about
+       the reason why this needs to be included in the release branch.
 </para>
 <para>An example of a cherry-picked commit would look like this:</para>
 <screen>

--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -288,9 +288,9 @@ nixos: Refactor the world.
 
 The original commit message describing the reason why the world was torn apart.
 
-Cherry-picked-from: abcdef
-Cherry-pick-reason: I just had a gut feeling that this would also be wanted by
-                    people from the stone age.
+(cherry picked from commit abcdef)
+Reason: I just had a gut feeling that this would also be wanted by people from
+        the stone age.
 </screen>
 </listitem>
 

--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -308,9 +308,10 @@ Additional information.
   <itemizedlist>
     <listitem>
       <para>
-        If you're cherry-picking and/or commit to a stable release branch always
-        use <command>git cherry-pick -x</command> add a clear description about
-        the reason why this needs to be included in the release branch.
+        If you're cherry-picking a commit to a stable release branch, always use
+        <command>git cherry-pick -xe</command> and ensure the message contains a
+        clear description about why this needs to be included in the stable
+        branch.
       </para>
       <para>An example of a cherry-picked commit would look like this:</para>
       <screen>

--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -276,6 +276,24 @@ Additional information.
 <listitem>
 <para>When changing the bootloader installation process, extra care must be taken. Grub installations cannot be rolled back, hence changes may break people's installations forever. For any non-trivial change to the bootloader please file a PR asking for review, especially from @edolstra.</para>
 </listitem>
+
+<listitem>
+<para>If you're cherry-picking and/or commit to a stable release branch, add a
+      clear description about the reason this needs to be included in the
+      release branch.
+</para>
+<para>An example of a cherry-picked commit would look like this:</para>
+<screen>
+nixos: Refactor the world.
+
+The original commit message describing the reason why the world was torn apart.
+
+Cherry-picked-from: abcdef
+Cherry-pick-reason: I just had a gut feeling that this would also be wanted by
+                    people from the stone age.
+</screen>
+</listitem>
+
 </itemizedlist>
 
 </section>

--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -262,39 +262,69 @@ Additional information.
 </listitem>
 
 <listitem>
-<para>Master should only see non-breaking commits that do not cause mass rebuilds.</para>
-</listitem>
-
-<listitem>
-<para>Staging should only see non-breaking mass-rebuild commits. That means it's not to be used for testing, and changes must have been well tested already. <link xlink:href="http://comments.gmane.org/gmane.linux.distributions.nixos/13447">Read policy here</link>.</para>
-</listitem>
-
-<listitem>
-<para>If staging is already in a broken state, please refrain from adding extra new breakages. Stabilize it for a few days, merge into master, then resume development on staging. <link xlink:href="http://hydra.nixos.org/jobset/nixpkgs/staging#tabs-evaluations">Keep an eye on the staging evaluations here</link>. If any fixes for staging happen to be already in master, then master can be merged into staging.</para>
-</listitem>
-
-<listitem>
 <para>When changing the bootloader installation process, extra care must be taken. Grub installations cannot be rolled back, hence changes may break people's installations forever. For any non-trivial change to the bootloader please file a PR asking for review, especially from @edolstra.</para>
 </listitem>
+</itemizedlist>
 
-<listitem>
-<para>If you're cherry-picking and/or commit to a stable release branch always
-       use <command>git cherry-pick -x</command> add a clear description about
-       the reason why this needs to be included in the release branch.
-</para>
-<para>An example of a cherry-picked commit would look like this:</para>
-<screen>
+<section>
+  <title>Master branch</title>
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        It should only see non-breaking commits that do not cause mass rebuilds.
+      </para>
+    </listitem>
+  </itemizedlist>
+</section>
+
+<section>
+  <title>Staging branch</title>
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        It's only for non-breaking mass-rebuild commits. That means it's not to
+        be used for testing, and changes must have been well tested already.
+        <link xlink:href="http://comments.gmane.org/gmane.linux.distributions.nixos/13447">Read policy here</link>.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        If the branch is already in a broken state, please refrain from adding
+        extra new breakages. Stabilize it for a few days, merge into master,
+        then resume development on staging.
+        <link xlink:href="http://hydra.nixos.org/jobset/nixpkgs/staging#tabs-evaluations">Keep an eye on the staging evaluations here</link>.
+        If any fixes for staging happen to be already in master, then master can
+        be merged into staging.
+      </para>
+    </listitem>
+  </itemizedlist>
+</section>
+
+<section>
+  <title>Stable release branches</title>
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        If you're cherry-picking and/or commit to a stable release branch always
+        use <command>git cherry-pick -x</command> add a clear description about
+        the reason why this needs to be included in the release branch.
+      </para>
+      <para>An example of a cherry-picked commit would look like this:</para>
+      <screen>
 nixos: Refactor the world.
 
 The original commit message describing the reason why the world was torn apart.
 
 (cherry picked from commit abcdef)
 Reason: I just had a gut feeling that this would also be wanted by people from
-        the stone age.
-</screen>
-</listitem>
-
-</itemizedlist>
+the stone age.
+      </screen>
+    </listitem>
+  </itemizedlist>
+</section>
 
 </section>
 </chapter>


### PR DESCRIPTION
The motivation behind this was a cherry-pick of c204036 to the 15.09 release branch, which broke evaluation. Now I've cherry-picked another commit which was needed by c204036 (58e9440) because otherwise evaluation would fail.

I by myself didn't state a reason at the time where I was cherry-picking the commit but figured that I should have done so after being [noted by @lethalman](https://github.com/NixOS/nixpkgs/commit/fb1377a14aeb06c982098c8b22987708f931743b#commitcomment-14906480) about a related work that removes the changes in the commit I have cherry-picked.

Long story short: If we cherry-pick stuff to any of the release branches, we should explicitly state the reasons _why_ we did so.

Not only because reviewers spend less time wondering about the introduced changes but to give the committer time to rethink about whether it really _is_ necessary to include the change to a supposedly
stable branch.
