### PR TITLE
grub: fix typo in variable name (trivial)

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -470,7 +470,7 @@ in
       ] ++ flip concatMap cfg.mirroredBoots (args: [
         {
           assertion = args.devices != [ ];
-          message = "A boot path cannot have an empty devices string in ${arg.path}";
+          message = "A boot path cannot have an empty devices string in ${args.path}";
         }
         {
           assertion = hasPrefix "/" args.path;


### PR DESCRIPTION
Fix a typo in error message for assertion
