### PR TITLE
goPackages.json2csv: init at d82e60e6dc2a7d3bcf15314d1ecbebeffaacf0c6

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1696,6 +1696,13 @@ let
     disabled = isGo14;
   };
 
+  json2csv = buildFromGitHub{
+    rev = "d82e60e6dc2a7d3bcf15314d1ecbebeffaacf0c6";
+    owner  = "jehiah";
+    repo   = "json2csv";
+    sha256 = "1fw0qqaz2wj9d4rj2jkfj7rb25ra106p4znfib69p4d3qibfjcsn";
+  };
+
   ldap = buildGoPackage rec {
     rev = "83e65426fd1c06626e88aa8a085e5bfed0208e29";
     name = "ldap-${stdenv.lib.strings.substring 0 7 rev}";


### PR DESCRIPTION
```
% nix-env --file $NIXPKGS -iA goPackages.json2csv 
installing ‘go1.5-json2csv-d82e60e’

% json2csv --help
Usage of json2csv:
  -d string
        delimiter used for output values (default ",")
  -i string
        /path/to/input.json (optional; default is stdin)
  -k value
        fields to output (default [])
  -o string
        /path/to/output.json (optional; default is stdout)
  -p    prints header to output
  -v    verbose output (to stderr)
  -version
        print version string
```
