### PR TITLE
Make php and phpPackages extension directory consistent

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -21,6 +21,8 @@ let
 
       buildInputs = [ flex bison pkgconfig ];
 
+      configureFlags = ["EXTENSION_DIR=$(out)/lib/php/extensions"];
+
       flags = {
 
         # much left to do here...


### PR DESCRIPTION
Fixes issue #11618 .

Extension directory in profile before:

```
root@a4a1c46b4e9a:/# ls -ali /nix/var/nix/profiles/zosch/lib/php/extensions/                      
total 24
13778796 dr-xr-xr-x 2 root nixbld 4096 Jan  1  1970 .
13778778 dr-xr-xr-x 3 root nixbld 4096 Jan  1  1970 ..
13778797 lrwxrwxrwx 1 root nixbld   85 Jan  1  1970 apcu.so -> /nix/store/xwiamby7pbnx8zmwpa68rqbmgwal7v97-php-apcu-4.0.7/lib/php/extensions/apcu.so
13778798 lrwxrwxrwx 1 root nixbld   95 Jan  1  1970 no-debug-zts-20131226 -> /nix/store/5bv024pmkg4p6kx49b5g3mqycbsfyz6w-php-5.6.15/lib/php/extensions/no-debug-zts-20131226
13778799 lrwxrwxrwx 1 root nixbld   94 Jan  1  1970 pthreads.so -> /nix/store/mmi3rlnqwrjn283rcq4w79jgbvnzs0lm-php-pthreads-2.0.10/lib/php/extensions/pthreads.so
13778800 lrwxrwxrwx 1 root nixbld   89 Jan  1  1970 xdebug.so -> /nix/store/dwbp7avnlcask7dd3a9ywhgis4y3hm2g-php-xdebug-2.3.1/lib/php/extensions/xdebug.so

root@a4a1c46b4e9a:/# ls -ali /nix/var/nix/profiles/zosch/lib/php/extensions/no-debug-zts-20131226/
total 444
13774978 dr-xr-xr-x 2 root nixbld   4096 Jan  1  1970 .
13774899 dr-xr-xr-x 3 root nixbld   4096 Jan  1  1970 ..
13778726 -r-xr-xr-x 1 root nixbld 268300 Jan  1  1970 opcache.a
13775037 -r-xr-xr-x 1 root nixbld 175298 Jan  1  1970 opcache.so
```

Extension directory in profile after:

```
root@a4a1c46b4e9a:/# ls -ali /nix/var/nix/profiles/zosch/lib/php/extensions/
total 28
13805981 dr-xr-xr-x 2 root nixbld 4096 Jan  1  1970 .
13805963 dr-xr-xr-x 3 root nixbld 4096 Jan  1  1970 ..
13805982 lrwxrwxrwx 1 root nixbld   85 Jan  1  1970 apcu.so -> /nix/store/9wxz0lj65sad1910wbhx6ds8csl0d88q-php-apcu-4.0.7/lib/php/extensions/apcu.so
13805983 lrwxrwxrwx 1 root nixbld   83 Jan  1  1970 opcache.a -> /nix/store/1i8r6km3n747mjbbqn0npq805za87l8q-php-5.6.15/lib/php/extensions/opcache.a
13805984 lrwxrwxrwx 1 root nixbld   84 Jan  1  1970 opcache.so -> /nix/store/1i8r6km3n747mjbbqn0npq805za87l8q-php-5.6.15/lib/php/extensions/opcache.so
13805985 lrwxrwxrwx 1 root nixbld   94 Jan  1  1970 pthreads.so -> /nix/store/kpnz1zd5gfk3ffbiw9sh1l2mj4gb5f3f-php-pthreads-2.0.10/lib/php/extensions/pthreads.so
13805986 lrwxrwxrwx 1 root nixbld   89 Jan  1  1970 xdebug.so -> /nix/store/w7p1wxmsk5lv84dicy73h1ivw57q2r1j-php-xdebug-2.3.1/lib/php/extensions/xdebug.so
```

This makes it a lot easier to configure PHP extensions from PHP build and PECL installations.
