### PR TITLE
gnome-music: add missing requests2 dependency

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/apps/gnome-music/default.nix
@@ -10,10 +10,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig gtk3 glib intltool itstool gnome3.libmediaart
                   gdk_pixbuf gnome3.defaultIconTheme librsvg python3
-                  gnome3.grilo gnome3.grilo-plugins libxml2 python3Packages.pygobject3 libnotify
-                  python3Packages.pycairo python3Packages.dbus gnome3.totem-pl-parser
-                  gst_all_1.gstreamer gst_all_1.gst-plugins-base wrapGAppsHook
-                  gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
+                  gnome3.grilo gnome3.grilo-plugins gnome3.totem-pl-parser libxml2 libnotify
+                  python3Packages.pycairo python3Packages.dbus python3Packages.requests2
+                  python3Packages.pygobject3 gst_all_1.gstreamer gst_all_1.gst-plugins-base
+                  gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad wrapGAppsHook
                   gnome3.gsettings_desktop_schemas makeWrapper tracker ];
 
   wrapPrefixVariables = [ "PYTHONPATH" ];


### PR DESCRIPTION
Fixes:

```
$ gnome-music 
Traceback (most recent call last):
  File "/nix/store/yvnk7vckbzdfdxhm70dcgfd8vdp2ck8n-gnome-music-3.18.0/bin/.gnome-music-wrapped", line 82, in <module>
    from gnomemusic.application import Application
  File "/nix/store/yvnk7vckbzdfdxhm70dcgfd8vdp2ck8n-gnome-music-3.18.0/lib/python3.4/site-packages/gnomemusic/application.py", line 37, in <module>
    from gnomemusic.window import Window
  File "/nix/store/yvnk7vckbzdfdxhm70dcgfd8vdp2ck8n-gnome-music-3.18.0/lib/python3.4/site-packages/gnomemusic/window.py", line 39, in <module>
    from gnomemusic.player import Player, SelectionToolbar
  File "/nix/store/yvnk7vckbzdfdxhm70dcgfd8vdp2ck8n-gnome-music-3.18.0/lib/python3.4/site-packages/gnomemusic/player.py", line 50, in <module>
    import requests
ImportError: No module named 'requests'
```
