### PR TITLE
cmdstan: init at 2.9.0

### DIFF
--- a/pkgs/development/compilers/cmdstan/default.nix
+++ b/pkgs/development/compilers/cmdstan/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "cmdstan-2.9.0";
+
+  src = fetchurl {
+    url = "https://github.com/stan-dev/cmdstan/releases/download/v2.9.0/cmdstan-2.9.0.tar.gz";
+    sha256 = "08bim6nxgam989152hm0ga1rfb33mr71pwsym1nmfmavma68bwm9";
+  };
+
+  buildFlags = "build";
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  checkPhase = "./runCmdStanTests.py src/test/interface";
+
+  installPhase = ''
+    mkdir -p $out/opt $out/bin
+    cp -r . $out/opt/cmdstan
+    ln -s $out/opt/cmdstan/bin/stanc $out/bin/stanc
+    ln -s $out/opt/cmdstan/bin/stansummary $out/bin/stansummary
+    cat > $out/bin/stan <<EOF
+    #!/bin/sh
+    make -C $out/opt/cmdstan "\$(realpath "\$1")"
+    EOF
+    chmod a+x $out/bin/stan
+  '';
+
+  meta = {
+    description = "Command-line interface to Stan";
+    longDescription = ''
+      Stan is a probabilistic programming language implementing full Bayesian
+      statistical inference with MCMC sampling (NUTS, HMC), approximate Bayesian
+      inference with Variational inference (ADVI) and penalized maximum
+      likelihood estimation with Optimization (L-BFGS).
+    '';
+    homepage = http://mc-stan.org/interfaces/cmdstan.html;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3818,6 +3818,8 @@ let
 
   closurecompiler = callPackage ../development/compilers/closure { };
 
+  cmdstan = callPackage ../development/compilers/cmdstan { };
+
   cmucl_binary = callPackage_i686 ../development/compilers/cmucl/binary.nix { };
 
   compcert = callPackage ../development/compilers/compcert (


### PR DESCRIPTION
[CmdStan](http://mc-stan.org/interfaces/cmdstan.html) is the command-line interface to the compiler for the probabilistic programming language [Stan](http://mc-stan.org/).

This is my first nixpkg, so I hope I did it properly :)
