### PR TITLE
pkgs.gcc5: 5.2.0 -> 5.3.0

### DIFF
--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -57,7 +57,7 @@ assert langGo -> langCC;
 with stdenv.lib;
 with builtins;
 
-let version = "5.2.0";
+let version = "5.3.0";
 
     # Whether building a cross-compiler for GNU/Hurd.
     crossGNU = cross != null && cross.config == "i586-pc-gnu";
@@ -212,7 +212,7 @@ stdenv.mkDerivation ({
 
   src = fetchurl {
     url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
-    sha256 = "1bccp8a106xwz3wkixn65ngxif112vn90qf95m6lzpgpnl25p0sz";
+    sha256 = "1ny4smkp5bzs3cp8ss7pl6lk8yss0d9m4av1mvdp72r1x695akxq";
   };
 
   inherit patches;


### PR DESCRIPTION
gcc-5.3.0 is a bug-fix release from the GCC 5 branch.

See https://lists.gnu.org/archive/html/info-gnu/2015-12/msg00002.html

cc maintainers: @peti @viric 
