### PR TITLE
pkgs.freeipmi: 1.4.9 -> 1.5.1

### DIFF
--- a/pkgs/tools/system/freeipmi/default.nix
+++ b/pkgs/tools/system/freeipmi/default.nix
@@ -1,12 +1,12 @@
 { fetchurl, stdenv, libgcrypt, readline }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.9";
+  version = "1.5.1";
   name = "freeipmi-${version}";
 
   src = fetchurl {
     url = "mirror://gnu/freeipmi/${name}.tar.gz";
-    sha256 = "0v2xfwik2mv6z8066raiypc4xymjvr8pb0mv3mc3g4ym4km132qp";
+    sha256 = "0lhjxlha4j5rx11d81y1rgp9j18rlpxsjc0flsmj6bm60awmm627";
   };
 
   buildInputs = [ libgcrypt readline ];


### PR DESCRIPTION
See https://lists.gnu.org/archive/html/info-gnu/2015-12/msg00000.html
