### PR TITLE
zfs:Always import from /dev/disk/by-id

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -214,7 +214,7 @@ in
             done
             ''] ++ (map (pool: ''
             echo "importing root ZFS pool \"${pool}\"..."
-            zpool import -N $ZFS_FORCE "${pool}"
+            zpool import -d /dev/disk/by-id -N $ZFS_FORCE "${pool}"
         '') rootPools));
       };
 
@@ -255,7 +255,7 @@ in
             };
             script = ''
               zpool_cmd="${zfsUserPkg}/sbin/zpool"
-              ("$zpool_cmd" list "${pool}" >/dev/null) || "$zpool_cmd" import -N ${optionalString cfgZfs.forceImportAll "-f"} "${pool}"
+              ("$zpool_cmd" list "${pool}" >/dev/null) || "$zpool_cmd" import -d /dev/disk/by-id -N ${optionalString cfgZfs.forceImportAll "-f"} "${pool}"
             '';
           };
       in listToAttrs (map createImportService dataPools) // {


### PR DESCRIPTION
By default, ZFS looks in /dev for the device nodes for its pools.

This easily breaks. There are a couple of failure modes, at least one of them disastrous: If you lose a disk from the pool, and the device nodes are renamed, then ZFS will claim that all data is corrupt and refuse to import the pool until you can change the names back, something which may or may not be possible. It's also very difficult for users to guess that this is the problem.

The canonical solution is to use the device nodes in /dev/disk/by-id instead, which is what this patch should do.

Unfortunately, I don't know how to test it. Any guidance? My system is running 15.09-small, which isn't going to change, but I'd like to pull it there anyway.
