### PR TITLE
fetchgit: output improvements

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -52,6 +52,7 @@ for arg; do
             --hash) argfun=set_hashType;;
             --branch-name) argfun=set_branchName;;
             --deepClone) deepClone=true;;
+            --quiet) QUIET=true;;
             --no-deepClone) deepClone=false;;
             --leave-dotGit) leaveDotGit=true;;
             --fetch-submodules) fetchSubmodules=true;;
@@ -281,9 +282,9 @@ clone_user_rev() {
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
     if test -z "$leaveDotGit"; then
         echo "removing \`.git'..." >&2
-        find $dir -name .git\* | xargs rm -rf
+        find "$dir" -name .git\* -print0 | xargs -0 rm -rf
     else
-        find $dir -name .git | while read gitdir; do
+        find "$dir" -name .git | while read gitdir; do
             make_deterministic_repo "$(readlink -f "$gitdir/..")"
         done
     fi

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -12,6 +12,11 @@ fetchSubmodules=
 builder=
 branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 
+# populated by clone_user_rev()
+fullRev=
+humanReadableRev=
+commitDate=
+
 if test -n "$deepClone"; then
     deepClone=true
 else
@@ -255,7 +260,7 @@ make_deterministic_repo(){
 }
 
 
-clone_user_rev() {
+_clone_user_rev() {
     local dir="$1"
     local url="$2"
     local rev="${3:-HEAD}"
@@ -273,10 +278,9 @@ clone_user_rev() {
             fi;;
     esac
 
-    local full_revision=$(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/$branchName) | tail -n1)
-    echo "git revision is $full_revision"
-    echo "git human-readable version is $(cd $dir && (git describe $full_revision 2> /dev/null || git describe --tags $full_revision 2> /dev/null || echo -- none --))" >&2
-    echo "Commit date is $(cd $dir && git show --no-patch --pretty=%ci $full_revision)"
+    fullRev="$(cd $dir && (git rev-parse $rev 2> /dev/null || git rev-parse refs/heads/$branchName) | tail -n1)"
+    humanReadableRev="$(cd $dir && (git describe $fullRev 2> /dev/null || git describe --tags $fullRev 2> /dev/null || echo -- none --))"
+    commitDate="$(cd $dir && git show --no-patch --pretty=%ci $fullRev)"
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
@@ -287,6 +291,44 @@ clone_user_rev() {
         find "$dir" -name .git | while read gitdir; do
             make_deterministic_repo "$(readlink -f "$gitdir/..")"
         done
+    fi
+}
+
+clone_user_rev() {
+    if ! test -n "$QUIET"; then
+        _clone_user_rev "$@"
+    else
+        errfile="$(mktemp "${TMPDIR:-/tmp}/git-checkout-err-XXXXXXXX")"
+        trap "rm -rf \"$errfile\"" EXIT
+        _clone_user_rev "$@" 2> "$errfile" || (
+            status="$?"
+            cat "$errfile" >&2
+            exit "$status"
+        )
+    fi
+}
+
+
+print_results() {
+    hash="$1"
+    if ! test -n "$QUIET"; then
+        echo "" >&2
+        echo "git revision is $fullRev" >&2
+        if test -n "$finalPath"; then
+            echo "path is $finalPath" >&2
+        fi
+        echo "git human-readable version is $humanReadableRev" >&2
+        echo "Commit date is $commitDate" >&2
+        if test -n "$hash"; then
+            echo "hash is $hash" >&2
+        fi
+    fi
+    if test -n "$hash"; then
+        echo "{"
+        echo "  url = \"$url\";"
+        echo "  rev = \"$fullRev\";"
+        echo "  $hashType = \"$hash\";"
+        echo "}"
     fi
 }
 
@@ -328,20 +370,18 @@ else
 
         # Compute the hash.
         hash=$(nix-hash --type $hashType --base32 $tmpFile)
-        if ! test -n "$QUIET"; then echo "hash is $hash" >&2; fi
 
         # Add the downloaded file to the Nix store.
         finalPath=$(nix-store --add-fixed --recursive "$hashType" "$tmpFile")
 
         if test -n "$expHash" -a "$expHash" != "$hash"; then
-            echo "hash mismatch for URL \`$url'"
+            print_metadata
+            echo "hash mismatch for URL \`$url'" >&2
             exit 1
         fi
     fi
 
-    if ! test -n "$QUIET"; then echo "path is $finalPath" >&2; fi
-
-    echo $hash
+    print_results "$hash"
 
     if test -n "$PRINT_PATH"; then
         echo $finalPath


### PR DESCRIPTION
I use fetchgit a lot, but scrubbing through the output to copy/paste out the revision hash and the digest hash (both long hashes) can be tedious. So I thought perhaps `nix-prefetch-git` should just print out a valid nix expression, like so:

```
$ nix-prefetch-git $PWD --quiet
{
  url = "/home/tim/dev/nix/nixpkgs";
  rev = "d27f16399d9e5459bf7a829b7f18e8a7eee314be";
  sha256 = "453b04608f0ca057e26f9c45cfa65630f09bfb3d5492ae338801bd4b14befd68";
}
```

This is very easy to copy/paste, and you can even redirect the result into a file and then directly import it as e.g. `fetchgit (import ./git-rev.nix)` (obviously you'd need to use a public URL instead of a local path in that case)

This patch also implements the `--qiet` flag. It previously respected an inherited `$QUIET` var, but this wasn't used consistently.

Any scripts relying on the old output will break, but I don't know how common that is likely to be.

I haven't touched any of the other `prefetch` scripts yet, but if this goes ahead I expect I'd like to at least do the same to the `url` fetcher, since that is the other main one I use myself.
