### PR TITLE
openssl -> openssl_1_0_1

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8025,7 +8025,8 @@ let
 
   wolfssl = callPackage ../development/libraries/wolfssl { };
 
-  openssl = callPackage ../development/libraries/openssl {
+  openssl = openssl_1_0_1;
+  openssl_1_0_1 = callPackage ../development/libraries/openssl {
     fetchurl = fetchurlBoot;
     cryptodevHeaders = linuxPackages.cryptodev.override {
       fetchurl = fetchurlBoot;


### PR DESCRIPTION
This renames the current openssl to openssl_1_0_1 and defaults
openssl back to openssl_1_0_1 essentially changing nothing currently,
but allowing people to explicitly select openssl_1_0_1 for some software
which needs ABI compatibility to a specific libssl implementation like
binaries (spotify amongst others) and at the same time overriding
openssl to another implementation like libressl.
