### PR TITLE
Libressl 2.3 patches

### DIFF
--- a/pkgs/applications/networking/browsers/w3m/RAND_egd.libressl.patch
+++ b/pkgs/applications/networking/browsers/w3m/RAND_egd.libressl.patch
@@ -1,0 +1,11 @@
+--- a/url.c  2014-07-14 12:31:30.476563116 +0200
++++ b/url.c   2014-07-14 12:32:16.364918248 +0200
+@@ -268,7 +268,7 @@ init_PRNG()
+     if (RAND_status())
+ 	return;
+     if ((file = RAND_file_name(buffer, sizeof(buffer)))) {
+-#ifdef USE_EGD
++#if defined(USE_EGD) && defined(HAVE_SSL_RAND_EGD)
+ 	if (RAND_egd(file) > 0)
+ 	    return;
+ #endif

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isSunOS "-lsocket -lnsl";
 
-  patches = [ ./glibc214.patch ]
+  patches = [ ./glibc214.patch ./RAND_egd.libressl.patch ]
     # Patch for the newer unstable boehm-gc 7.2alpha. Not all platforms use that
     # alpha. At the time of writing this, boehm-gc-7.1 is the last stable.
     ++ optional (boehmgc.name != "boehm-gc-7.1") [ ./newgc.patch ]

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,7 +1,8 @@
 { patchSet, useRailsExpress, ops, patchLevel }:
 
-let self = rec {
+rec {
   "1.9.3" = [
+    ./ssl_v3.patch
     ./ruby19-parallel-install.patch
     ./bitperfect-rdoc.patch
   ] ++ ops useRailsExpress [
@@ -25,13 +26,17 @@ let self = rec {
     "${patchSet}/patches/ruby/1.9.3/p${patchLevel}/railsexpress/18-fix-missing-c-return-event.patch"
     "${patchSet}/patches/ruby/1.9.3/p${patchLevel}/railsexpress/19-fix-process-daemon-call.patch"
   ];
-  "2.0.0" = ops useRailsExpress [
+  "2.0.0" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/02-railsexpress-gc.patch"
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/03-display-more-detailed-stack-trace.patch"
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
   ];
-  "2.1.0" = ops useRailsExpress [
+  "2.1.0" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.0/railsexpress/01-current-2.1.1-fixes.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/02-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/03-improve-gc-stats.patch"
@@ -45,7 +50,9 @@ let self = rec {
     "${patchSet}/patches/ruby/2.1.0/railsexpress/11-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/12-backport-r44370.patch"
   ];
-  "2.1.1" = ops useRailsExpress [
+  "2.1.1" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.0/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/03-display-more-detailed-stack-trace.patch"
@@ -58,7 +65,9 @@ let self = rec {
     "${patchSet}/patches/ruby/2.1.0/railsexpress/11-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.0/railsexpress/12-backport-r44370.patch"
   ];
-  "2.1.2" = ops useRailsExpress [
+  "2.1.2" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.2/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.2/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.1.2/railsexpress/03-display-more-detailed-stack-trace.patch"
@@ -70,7 +79,9 @@ let self = rec {
     "${patchSet}/patches/ruby/2.1.2/railsexpress/09-aman-opt-aset-aref-str.patch"
     "${patchSet}/patches/ruby/2.1.2/railsexpress/10-funny-falcon-method-cache.patch"
   ];
-  "2.1.3" = ops useRailsExpress [
+  "2.1.3" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.3/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.3/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.1.3/railsexpress/03-display-more-detailed-stack-trace.patch"
@@ -80,7 +91,9 @@ let self = rec {
     "${patchSet}/patches/ruby/2.1.3/railsexpress/07-aman-opt-aset-aref-str.patch"
     "${patchSet}/patches/ruby/2.1.3/railsexpress/08-funny-falcon-method-cache.patch"
   ];
-  "2.1.6" = ops useRailsExpress [
+  "2.1.6" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.6/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.6/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.1.6/railsexpress/03-display-more-detailed-stack-trace.patch"
@@ -91,7 +104,9 @@ let self = rec {
     "${patchSet}/patches/ruby/2.1.6/railsexpress/08-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.6/railsexpress/09-heap-dump-support.patch"
   ];
-  "2.1.7" = ops useRailsExpress [
+  "2.1.7" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.1.7/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.1.7/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.1.7/railsexpress/03-display-more-detailed-stack-trace.patch"
@@ -102,22 +117,28 @@ let self = rec {
     "${patchSet}/patches/ruby/2.1.7/railsexpress/08-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.7/railsexpress/09-heap-dump-support.patch"
   ];
-  "2.2.0" = ops useRailsExpress [
+  "2.2.0" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.2.0/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.2.0/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.2.0/railsexpress/03-display-more-detailed-stack-trace.patch"
     "${patchSet}/patches/ruby/2.2.0/railsexpress/04-backport-401c8bb.patch"
     "${patchSet}/patches/ruby/2.2.0/railsexpress/05-fix-packed-bitfield-compat-warning-for-older-gccs.patch"
   ];
-  "2.2.2" = ops useRailsExpress [
+  "2.2.2" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.2.2/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.2.2/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.2.2/railsexpress/03-display-more-detailed-stack-trace.patch"
     "${patchSet}/patches/ruby/2.2.2/railsexpress/04-backported-bugfixes-222.patch"
   ];
-  "2.2.3" = ops useRailsExpress [
+  "2.2.3" = [
+    ./ssl_v3.patch
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.2.3/railsexpress/01-zero-broken-tests.patch"
     "${patchSet}/patches/ruby/2.2.3/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.2.3/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
-}; in self
+}

--- a/pkgs/development/interpreters/ruby/ssl_v3.patch
+++ b/pkgs/development/interpreters/ruby/ssl_v3.patch
@@ -1,0 +1,16 @@
+--- a/ext/openssl/ossl_ssl.c  2015-11-26 16:41:03.775058140 +0000
++++ b/ext/openssl/ossl_ssl.c  2015-11-26 16:40:56.191907346 +0000
+@@ -138,9 +138,12 @@
+     OSSL_SSL_METHOD_ENTRY(SSLv2_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv2_client),
+ #endif
++#if defined(HAVE_SSLV3_METHOD) && defined(HAVE_SSLV3_SERVER_METHOD) && \
++        defined(HAVE_SSLV3_CLIENT_METHOD)
+     OSSL_SSL_METHOD_ENTRY(SSLv3),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_client),
++#endif
+     OSSL_SSL_METHOD_ENTRY(SSLv23),
+     OSSL_SSL_METHOD_ENTRY(SSLv23_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv23_client),
+

--- a/pkgs/development/libraries/qca2/default.nix
+++ b/pkgs/development/libraries/qca2/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  patches = [ ./libressl.patch ];
+
   meta = with stdenv.lib; {
     description = "Qt Cryptographic Architecture";
     license = "LGPL";

--- a/pkgs/development/libraries/qca2/libressl.patch
+++ b/pkgs/development/libraries/qca2/libressl.patch
@@ -1,0 +1,28 @@
+--- a/plugins/qca-ossl/qca-ossl.cpp	2015-12-02 09:34:25.810682094 +0000
++++ b/plugins/qca-ossl/qca-ossl.cpp	2015-12-02 09:29:51.720392423 +0000
+@@ -5403,11 +5403,13 @@
+ 			ctx = SSL_CTX_new(SSLv2_client_method());
+ 			break;
+ #endif
++#ifndef OPENSSL_NO_SSL3
+ 		case TLS::SSL_v3:
+ 			ctx = SSL_CTX_new(SSLv3_client_method());
+ 			break;
++#endif
+ 		case TLS::TLS_v1:
++			ctx = SSL_CTX_new(SSLv23_client_method());
+-			ctx = SSL_CTX_new(TLSv1_client_method());
+ 			break;
+ 		case TLS::DTLS_v1:
+ 		default:
+@@ -7133,8 +7135,10 @@
+ 			return new opensslInfoContext(this);
+ 		else if ( type == "sha1" )
+ 			return new opensslHashContext( EVP_sha1(), this, type);
++#ifndef OPENSSL_NO_SHA0
+ 		else if ( type == "sha0" )
+ 			return new opensslHashContext( EVP_sha(), this, type);
++#endif
+ 		else if ( type == "ripemd160" )
+ 			return new opensslHashContext( EVP_ripemd160(), this, type);
+ #ifdef HAVE_OPENSSL_MD2

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [ ./glib-2.32.patch
+      ./libressl.patch
       (substituteAll {
         src = ./dlopen-absolute-paths.diff;
         inherit cups icu libXfixes;

--- a/pkgs/development/libraries/qt-4.x/4.8/libressl.patch
+++ b/pkgs/development/libraries/qt-4.x/4.8/libressl.patch
@@ -1,0 +1,64 @@
+$OpenBSD: patch-src_network_ssl_qsslsocket_openssl_symbols_cpp,v 1.3 2015/09/17 12:24:42 dcoppa Exp $
+--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp	Wed Sep 16 13:27:39 2015
++++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp	Wed Sep 16 13:33:06 2015
+@@ -228,13 +228,17 @@ DEFINEFUNC(int, SSL_shutdown, SSL *a, a, return -1, re
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_client_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_client_method, DUMMYARG, DUMMYARG, return 0, return)
+ #ifndef OPENSSL_NO_SSL2
+ DEFINEFUNC(const SSL_METHOD *, SSLv2_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+ DEFINEFUNC(const SSL_METHOD *, SSLv3_server_method, DUMMYARG, DUMMYARG, return 0, return)
++#endif
+ DEFINEFUNC(const SSL_METHOD *, SSLv23_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(const SSL_METHOD *, TLSv1_server_method, DUMMYARG, DUMMYARG, return 0, return)
+ #else
+@@ -822,13 +826,17 @@ bool q_resolveOpenSslSymbols()
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_client_method)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+     RESOLVEFUNC(SSLv3_client_method)
++#endif
+     RESOLVEFUNC(SSLv23_client_method)
+     RESOLVEFUNC(TLSv1_client_method)
+ #ifndef OPENSSL_NO_SSL2
+     RESOLVEFUNC(SSLv2_server_method)
+ #endif
++#ifndef OPENSSL_NO_SSL3
+     RESOLVEFUNC(SSLv3_server_method)
++#endif
+     RESOLVEFUNC(SSLv23_server_method)
+     RESOLVEFUNC(TLSv1_server_method)
+     RESOLVEFUNC(X509_NAME_entry_count)
+--- a/src/network/ssl/qsslsocket_openssl.cpp	Thu May  7 16:14:44 2015
++++ b/src/network/ssl/qsslsocket_openssl.cpp	Wed Sep 16 13:30:03 2015
+@@ -267,15 +267,19 @@ init_context:
+ #endif
+         break;
+     case QSsl::SslV3:
++#ifndef OPENSSL_NO_SSL3
+         ctx = q_SSL_CTX_new(client ? q_SSLv3_client_method() : q_SSLv3_server_method());
++#else
++        ctx = 0; // SSL 3 not supported by the system, but chosen deliberately -> error
++#endif
+         break;
+-    case QSsl::SecureProtocols: // SslV2 will be disabled below
+-    case QSsl::TlsV1SslV3: // SslV2 will be disabled below
+     case QSsl::AnyProtocol:
+-    default:
+         ctx = q_SSL_CTX_new(client ? q_SSLv23_client_method() : q_SSLv23_server_method());
+         break;
+     case QSsl::TlsV1:
++    case QSsl::SecureProtocols:
++    case QSsl::TlsV1SslV3:
++    default:
+         ctx = q_SSL_CTX_new(client ? q_TLSv1_client_method() : q_TLSv1_server_method());
+         break;
+     }

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/libressl.patch
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/libressl.patch
@@ -1,0 +1,36 @@
+From 81494e67eccba04fc3fe554d76a9ca6fe7f2250e Mon Sep 17 00:00:00 2001
+From: hasufell <hasufell@gentoo.org>
+Date: Sat, 10 Oct 2015 01:15:01 +0200
+Subject: [PATCH] Fix compilation with libressl
+
+By additionally checking for defined(SSL_CTRL_SET_CURVES), which
+is defined in openssl, but not in libressl.
+---
+ src/network/ssl/qsslcontext_openssl.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qtbase/src/network/ssl/qsslcontext_openssl.cpp b/qtbase/src/network/ssl/qsslcontext_openssl.cpp
+index b88ab54..cfc4f6d 100644
+--- a/qtbase/src/network/ssl/qsslcontext_openssl.cpp
++++ b/qtbase/src/network/ssl/qsslcontext_openssl.cpp
+@@ -338,7 +338,7 @@ init_context:
+ 
+     const QVector<QSslEllipticCurve> qcurves = sslContext->sslConfiguration.ellipticCurves();
+     if (!qcurves.isEmpty()) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         // Set the curves to be used
+         if (q_SSLeay() >= 0x10002000L) {
+             // SSL_CTX_ctrl wants a non-const pointer as last argument,
+@@ -352,7 +352,7 @@ init_context:
+                 return sslContext;
+             }
+         } else
+-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         {
+             // specific curves requested, but not possible to set -> error
+             sslContext->errorStr = msgErrorSettingEllipticCurves(QSslSocket::tr("OpenSSL version too old, need at least v1.0.2"));
+-- 
+2.6.0
+

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/series
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/series
@@ -6,3 +6,4 @@ dlopen-dbus.patch
 xdg-config-dirs.patch
 nix-profiles-library-paths.patch
 compose-search-path.patch
+libressl.patch

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./build-fix.patch
+    ./libressl.patch
   ];
 
   postInstall = ''

--- a/pkgs/os-specific/linux/wpa_supplicant/libressl.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/libressl.patch
@@ -1,0 +1,69 @@
+$OpenBSD: patch-src_crypto_tls_openssl_c,v 1.3 2015/09/29 11:57:54 dcoppa Exp $
+
+Compatibility fixes for LibreSSL
+
+--- a/src/crypto/tls_openssl.c	Sun Sep 27 21:02:05 2015
++++ b/src/crypto/tls_openssl.c	Mon Sep 28 13:43:46 2015
+@@ -2229,7 +2229,7 @@ static int tls_parse_pkcs12(struct tls_data *data, SSL
+ 	}
+ 
+ 	if (certs) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 		SSL_clear_chain_certs(ssl);
+ 		while ((cert = sk_X509_pop(certs)) != NULL) {
+ 			X509_NAME_oneline(X509_get_subject_name(cert), buf,
+@@ -2247,7 +2247,7 @@ static int tls_parse_pkcs12(struct tls_data *data, SSL
+ 			/* Try to continue anyway */
+ 		}
+ 		sk_X509_free(certs);
+-#ifndef OPENSSL_IS_BORINGSSL
++#if !defined(OPENSSL_IS_BORINGSSL) && !defined(LIBRESSL_VERSION_NUMBER)
+ 		res = SSL_build_cert_chain(ssl,
+ 					   SSL_BUILD_CHAIN_FLAG_CHECK |
+ 					   SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR);
+@@ -2812,7 +2812,7 @@ int tls_connection_get_random(void *ssl_ctx, struct tl
+ 	if (conn == NULL || keys == NULL)
+ 		return -1;
+ 	ssl = conn->ssl;
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	if (ssl == NULL || ssl->s3 == NULL || ssl->session == NULL)
+ 		return -1;
+ 
+@@ -2841,7 +2841,7 @@ int tls_connection_get_random(void *ssl_ctx, struct tl
+ #ifndef CONFIG_FIPS
+ static int openssl_get_keyblock_size(SSL *ssl)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	const EVP_CIPHER *c;
+ 	const EVP_MD *h;
+ 	int md_size;
+@@ -2911,7 +2911,7 @@ static int openssl_tls_prf(struct tls_connection *conn
+ 		   "mode");
+ 	return -1;
+ #else /* CONFIG_FIPS */
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	SSL *ssl;
+ 	u8 *rnd;
+ 	int ret = -1;
+@@ -3394,7 +3394,7 @@ int tls_connection_set_cipher_list(void *tls_ctx, stru
+ 
+ 	wpa_printf(MSG_DEBUG, "OpenSSL: cipher suites: %s", buf + 1);
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ #if defined(EAP_FAST) || defined(EAP_FAST_DYNAMIC) || defined(EAP_SERVER_FAST)
+ 	if (os_strstr(buf, ":ADH-")) {
+ 		/*
+@@ -3977,7 +3977,7 @@ static int tls_sess_sec_cb(SSL *s, void *secret, int *
+ 	struct tls_connection *conn = arg;
+ 	int ret;
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	if (conn == NULL || conn->session_ticket_cb == NULL)
+ 		return 0;
+ 

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -10,9 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1w4gp4hdkb452nmz91l413d1rx89isl2l6wv8kpbdd2afpc3phws";
   };
 
-  patchPhase = ''
+  postPatchPhase = ''
     sed -i 's/^\t.*run/\t/' Makefile.in
   '';
+
+  patches = [ ./libressl.patch ];
 
   buildInputs = [ openssl libtool perl libxml2 ];
 

--- a/pkgs/servers/dns/bind/libressl.patch
+++ b/pkgs/servers/dns/bind/libressl.patch
@@ -1,0 +1,102 @@
+$OpenBSD: patch-lib_dns_openssl_link_c,v 1.1 2015/09/16 15:28:16 sthen Exp $
+--- a/lib/dns/openssl_link.c	Wed Sep 16 14:01:23 2015
++++ b/lib/dns/openssl_link.c	Wed Sep 16 14:01:46 2015
+@@ -88,7 +88,7 @@ entropy_getpseudo(unsigned char *buf, int num) {
+ 	return (result == ISC_R_SUCCESS ? 1 : -1);
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ static void
+ entropy_add(const void *buf, int num, double entropy) {
+ 	/*
+@@ -121,7 +121,7 @@ lock_callback(int mode, int type, const char *file, in
+ 		UNLOCK(&locks[type]);
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ static unsigned long
+ id_callback(void) {
+ 	return ((unsigned long)isc_thread_self());
+@@ -187,7 +187,7 @@ dst__openssl_init(const char *engine) {
+ 	if (result != ISC_R_SUCCESS)
+ 		goto cleanup_mutexalloc;
+ 	CRYPTO_set_locking_callback(lock_callback);
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	CRYPTO_set_id_callback(id_callback);
+ #endif
+ 
+@@ -287,7 +287,7 @@ dst__openssl_destroy(void) {
+ 	CRYPTO_cleanup_all_ex_data();
+ #endif
+ 	ERR_clear_error();
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	ERR_remove_state(0);
+ #endif
+ 	ERR_free_strings();
+--- a/lib/dns/dst_openssl.h	Wed Sep 16 14:00:47 2015
++++ b/lib/dns/dst_openssl.h	Wed Sep 16 14:02:42 2015
+@@ -36,7 +36,7 @@
+ #define USE_ENGINE 1
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ /*
+  * These are new in OpenSSL 1.1.0.  BN_GENCB _cb needs to be declared in
+  * the function like this before the BN_GENCB_new call:
+--- a/lib/dns/openssldh_link.c	Wed Sep 16 14:01:23 2015
++++ b/lib/dns/openssldh_link.c	Wed Sep 16 14:02:06 2015
+@@ -173,7 +173,7 @@ openssldh_generate(dst_key_t *key, int generator, void
+ 	DH *dh = NULL;
+ #if OPENSSL_VERSION_NUMBER > 0x00908000L
+ 	BN_GENCB *cb;
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	BN_GENCB _cb;
+ #endif
+ 	union {
+@@ -210,7 +210,7 @@ openssldh_generate(dst_key_t *key, int generator, void
+ 		if (dh == NULL)
+ 			return (dst__openssl_toresult(ISC_R_NOMEMORY));
+ 		cb = BN_GENCB_new();
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 		if (cb == NULL) {
+ 			DH_free(dh);
+ 			return (dst__openssl_toresult(ISC_R_NOMEMORY));
+--- a/lib/dns/openssldsa_link.c	Wed Sep 16 14:01:23 2015
++++ b/lib/dns/openssldsa_link.c	Wed Sep 16 14:02:22 2015
+@@ -359,7 +359,7 @@ openssldsa_generate(dst_key_t *key, int unused, void (
+ 	isc_result_t result;
+ #if OPENSSL_VERSION_NUMBER > 0x00908000L
+ 	BN_GENCB *cb;
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	BN_GENCB _cb;
+ #endif
+ 	union {
+@@ -383,7 +383,7 @@ openssldsa_generate(dst_key_t *key, int unused, void (
+ 	if (dsa == NULL)
+ 		return (dst__openssl_toresult(DST_R_OPENSSLFAILURE));
+ 	cb = BN_GENCB_new();
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 	if (cb == NULL) {
+ 		DSA_free(dsa);
+ 		return (dst__openssl_toresult(DST_R_OPENSSLFAILURE));
+$OpenBSD: patch-lib_dns_opensslrsa_link_c,v 1.1 2015/09/16 15:28:16 sthen Exp $
+--- a/lib/dns/opensslrsa_link.c	Wed Sep 16 14:01:23 2015
++++ b/lib/dns/opensslrsa_link.c	Wed Sep 16 14:02:31 2015
+@@ -771,7 +771,7 @@ opensslrsa_generate(dst_key_t *key, int exp, void (*ca
+ 	} u;
+ 	RSA *rsa = RSA_new();
+ 	BIGNUM *e = BN_new();
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	BN_GENCB _cb;
+ #endif
+ 	BN_GENCB *cb = BN_GENCB_new();

--- a/pkgs/tools/networking/socat/2.x.nix
+++ b/pkgs/tools/networking/socat/2.x.nix
@@ -12,12 +12,14 @@ stdenv.mkDerivation rec {
 
   configureFlags = stdenv.lib.optionalString stdenv.isDarwin "--disable-ip6";
 
-  meta = {
+  patches = stdenv.lib.singleton ./libressl-fixes.patch ;
+
+  meta = with stdenv.lib; {
     description = "A utility for bidirectional data transfer between two independent data channels";
     homepage = http://www.dest-unreach.org/socat/;
     repositories.git = git://repo.or.cz/socat.git;
-    platforms = stdenv.lib.platforms.unix;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    platforms = platforms.unix;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
-  patches = [ ./enable-ecdhe.patch ];
+  patches = [ ./enable-ecdhe.patch ./libressl-fixes.patch ];
 
   meta = {
     description = "A utility for bidirectional data transfer between two independent data channels";

--- a/pkgs/tools/networking/socat/libressl-fixes.patch
+++ b/pkgs/tools/networking/socat/libressl-fixes.patch
@@ -1,0 +1,173 @@
+Patch from OpenBSD
+--- a/sslcls.c	Sat Jan 24 03:15:22 2015
++++ b/sslcls.c	Sat Jul 18 20:01:59 2015
+@@ -55,6 +55,7 @@ const SSL_METHOD *sycSSLv2_server_method(void) {
+ }
+ #endif
+ 
++#ifdef HAVE_SSLv3_client_method
+ const SSL_METHOD *sycSSLv3_client_method(void) {
+    const SSL_METHOD *result;
+    Debug("SSLv3_client_method()");
+@@ -62,7 +63,9 @@ const SSL_METHOD *sycSSLv3_client_method(void) {
+    Debug1("SSLv3_client_method() -> %p", result);
+    return result;
+ }
++#endif
+ 
++#ifdef HAVE_SSLv3_server_method
+ const SSL_METHOD *sycSSLv3_server_method(void) {
+    const SSL_METHOD *result;
+    Debug("SSLv3_server_method()");
+@@ -70,6 +73,7 @@ const SSL_METHOD *sycSSLv3_server_method(void) {
+    Debug1("SSLv3_server_method() -> %p", result);
+    return result;
+ }
++#endif
+ 
+ const SSL_METHOD *sycSSLv23_client_method(void) {
+    const SSL_METHOD *result;
+@@ -331,14 +335,6 @@ void sycSSL_free(SSL *ssl) {
+    return;
+ }
+ 
+-int sycRAND_egd(const char *path) {
+-   int result;
+-   Debug1("RAND_egd(\"%s\")", path);
+-   result = RAND_egd(path);
+-   Debug1("RAND_egd() -> %d", result);
+-   return result;
+-}
+-
+ DH *sycPEM_read_bio_DHparams(BIO *bp, DH **x, pem_password_cb *cb, void *u) {
+    DH *result;
+    Debug4("PEM_read_bio_DHparams(%p, %p, %p, %p)",
+@@ -375,7 +371,7 @@ int sycFIPS_mode_set(int onoff) {
+ }
+ #endif /* WITH_FIPS */
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
++#if (OPENSSL_VERSION_NUMBER >= 0x00908000L) && !defined(OPENSSL_NO_COMP)
+ const COMP_METHOD *sycSSL_get_current_compression(SSL *ssl) {
+    const COMP_METHOD *result;
+    Debug1("SSL_get_current_compression(%p)", ssl);
+--- a/sslcls.h	Sat Jan 24 11:15:22 2015
++++ b/sslcls.h	Mon Apr 13 15:06:25 2015
+@@ -47,7 +47,6 @@ X509 *sycSSL_get_peer_certificate(SSL *ssl);
+ int sycSSL_shutdown(SSL *ssl);
+ void sycSSL_CTX_free(SSL_CTX *ctx);
+ void sycSSL_free(SSL *ssl);
+-int sycRAND_egd(const char *path);
+ 
+ DH *sycPEM_read_bio_DHparams(BIO *bp, DH **x, pem_password_cb *cb, void *u);
+ 
+@@ -55,7 +54,7 @@ BIO *sycBIO_new_file(const char *filename, const char 
+ 
+ int sycFIPS_mode_set(int onoff);
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
++#if (OPENSSL_VERSION_NUMBER >= 0x00908000L) && !defined(OPENSSL_NO_COMP)
+ const COMP_METHOD *sycSSL_get_current_compression(SSL *ssl);
+ const COMP_METHOD *sycSSL_get_current_expansion(SSL *ssl);
+ const char *sycSSL_COMP_get_name(const COMP_METHOD *comp);
+@@ -98,7 +97,6 @@ const char *sycSSL_COMP_get_name(const COMP_METHOD *co
+ #define sycSSL_shutdown(s) SSL_shutdown(s)
+ #define sycSSL_CTX_free(c) SSL_CTX_free(c)
+ #define sycSSL_free(s) SSL_free(s)
+-#define sycRAND_egd(p) RAND_egd(p)
+ 
+ #define sycPEM_read_bio_DHparams(b,x,p,u) PEM_read_bio_DHparams(b,x,p,u)
+ 
+--- a/xio-openssl.c	Sat Jan 24 15:33:42 2015
++++ b/xio-openssl.c	Mon Apr 13 14:59:12 2015
+@@ -108,7 +108,6 @@ const struct optdesc opt_openssl_key         = { "open
+ const struct optdesc opt_openssl_dhparam     = { "openssl-dhparam",     "dh",    OPT_OPENSSL_DHPARAM,     GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+ const struct optdesc opt_openssl_cafile      = { "openssl-cafile",     "cafile", OPT_OPENSSL_CAFILE,      GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+ const struct optdesc opt_openssl_capath      = { "openssl-capath",     "capath", OPT_OPENSSL_CAPATH,      GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+-const struct optdesc opt_openssl_egd         = { "openssl-egd",        "egd",    OPT_OPENSSL_EGD,         GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+ const struct optdesc opt_openssl_pseudo      = { "openssl-pseudo",     "pseudo", OPT_OPENSSL_PSEUDO,      GROUP_OPENSSL, PH_SPEC, TYPE_BOOL,     OFUNC_SPEC };
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+ const struct optdesc opt_openssl_compress    = { "openssl-compress",   "compress", OPT_OPENSSL_COMPRESS,  GROUP_OPENSSL, PH_SPEC, TYPE_STRING,   OFUNC_SPEC };
+@@ -147,7 +146,7 @@ int xio_reset_fips_mode(void) {
+ static void openssl_conn_loginfo(SSL *ssl) {
+    Notice1("SSL connection using %s", SSL_get_cipher(ssl));
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
++#if (OPENSSL_VERSION_NUMBER >= 0x00908000L) && !defined(OPENSSL_NO_COMP)
+    {
+       const COMP_METHOD *comp, *expansion;
+ 
+@@ -722,7 +721,6 @@ int
+    char *opt_dhparam = NULL;	/* file name of DH params */
+    char *opt_cafile = NULL;	/* certificate authority file */
+    char *opt_capath = NULL;	/* certificate authority directory */
+-   char *opt_egd = NULL;	/* entropy gathering daemon socket path */
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+    char *opt_compress = NULL;	/* compression method */
+ #endif
+@@ -741,7 +739,6 @@ int
+    retropt_string(opts, OPT_OPENSSL_CAPATH, &opt_capath);
+    retropt_string(opts, OPT_OPENSSL_KEY, &opt_key);
+    retropt_string(opts, OPT_OPENSSL_DHPARAM, &opt_dhparam);
+-   retropt_string(opts, OPT_OPENSSL_EGD, &opt_egd);
+    retropt_bool(opts,OPT_OPENSSL_PSEUDO, &opt_pseudo);
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+    retropt_string(opts, OPT_OPENSSL_COMPRESS, &opt_compress);
+@@ -877,10 +874,6 @@ int
+       }
+    }
+ 
+-   if (opt_egd) {
+-      sycRAND_egd(opt_egd);
+-   }
+-
+    if (opt_pseudo) {
+       long int randdata;
+       /* initialize libc random from actual microseconds */
+@@ -1098,7 +1091,7 @@ static int openssl_SSL_ERROR_SSL(int level, const char
+       if (e == ((ERR_LIB_RAND<<24)|
+ 		(RAND_F_SSLEAY_RAND_BYTES<<12)|
+ 		(RAND_R_PRNG_NOT_SEEDED)) /*0x24064064*/) {
+-	 Error("too few entropy; use options \"egd\" or \"pseudo\"");
++	 Error("too few entropy; use option \"pseudo\"");
+ 	 stat = STAT_NORETRY;
+       } else {
+ 	 Msg2(level, "%s(): %s", funcname, ERR_error_string(e, buf));
+--- a/xio-openssl.h	Sun Jun 23 07:16:48 2013
++++ b/xio-openssl.h	Sat Apr 19 15:58:21 2014
+@@ -21,7 +21,6 @@ extern const struct optdesc opt_openssl_key;
+ extern const struct optdesc opt_openssl_dhparam;
+ extern const struct optdesc opt_openssl_cafile;
+ extern const struct optdesc opt_openssl_capath;
+-extern const struct optdesc opt_openssl_egd;
+ extern const struct optdesc opt_openssl_pseudo;
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+ extern const struct optdesc opt_openssl_compress;
+--- a/xioopts.c	Sat Jan 24 11:15:22 2015
++++ b/xioopts.c	Mon Apr 13 15:06:25 2015
+@@ -412,7 +412,6 @@ const struct optname optionnames[] = {
+ #ifdef ECHOPRT
+ 	IF_TERMIOS("echoprt",	&opt_echoprt)
+ #endif
+-	IF_OPENSSL("egd",	&opt_openssl_egd)
+ 	IF_ANY    ("end-close",	&opt_end_close)
+ 	IF_TERMIOS("eof",	&opt_veof)
+ 	IF_TERMIOS("eol",	&opt_veol)
+@@ -1102,7 +1101,6 @@ const struct optname optionnames[] = {
+ 	IF_OPENSSL("openssl-compress",	&opt_openssl_compress)
+ #endif
+ 	IF_OPENSSL("openssl-dhparam",	&opt_openssl_dhparam)
+-	IF_OPENSSL("openssl-egd",	&opt_openssl_egd)
+ #if WITH_FIPS
+ 	IF_OPENSSL("openssl-fips",	&opt_openssl_fips)
+ #endif
+--- a/xioopts.h	Sat Jan 24 11:15:22 2015
++++ b/xioopts.h	Mon Apr 13 15:06:25 2015
+@@ -478,7 +478,6 @@ enum e_optcode {
+    OPT_OPENSSL_COMPRESS,
+ #endif
+    OPT_OPENSSL_DHPARAM,
+-   OPT_OPENSSL_EGD,
+    OPT_OPENSSL_FIPS,
+    OPT_OPENSSL_KEY,
+    OPT_OPENSSL_METHOD,


### PR DESCRIPTION
These patches fix building some software with libressl 2.3 which removed some obsolete features from libssl (SSLv3, sha0, ...):
- ruby
- bind
- qt4
- qt5
- qca2
- wpa_supplicant
- socat
- w3m

All patches don't change anything for users using old openssl versions.

hydra builds using libressl 2.3 at https://hydra.mayflower.de/project/nixos
