### PR TITLE
{lib-}mediainfo{-gui}: 0.7.79 -> 0.7.80

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.79";
+  version = "0.7.80";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0qwb3msw9gfzdymlirpvzah0lcszc2p67jg8k5ca2camymnfcvx3";
+    sha256 = "12iwiw4vcmyi8l04j540kbqifmr1wnlfw5cway185iqia43s6c10";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.79";
+  version = "0.7.80";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0qwb3msw9gfzdymlirpvzah0lcszc2p67jg8k5ca2camymnfcvx3";
+    sha256 = "12iwiw4vcmyi8l04j540kbqifmr1wnlfw5cway185iqia43s6c10";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.79";
+  version = "0.7.80";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "0lanhx1zg7s36wgi9ndv4zz7dbhkqz4dc99mva6x9rcj2p5p8c6d";
+    sha256 = "0v9px37qx0dkx67gqwi1rd9x4m7zm1ml8sdj5fx0isj6qymbd1z5";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
From the changelog:

```
Version 0.7.80, 2015-11-30

+ Matroska: support of MKVMerge statistics tags (duration frame count,
  stream size, bit rate) per track, thanks to ndjamena
+ FLAC: Channel positions, thanks to ndjamena
+ FLAC: difference between detected bit depth and stored bit depth
+ MPEG-TS: if DTVCC transport stream is present and no DTVCC service
  descriptor, scan also in the middle of the file in order to detect
  more caption services
+ Subtitle frame rate computing if frame count and duration are
  available (hidden by default)
+ Subtitles in Matroska: count of elements
+ Matroska, MXF and MP4/MOV: detection of truncated files
+ DTS: difference between ES Matrix and ES Discrete
+ DTS: display ES Matrix or ES Discrete even if HRA or MA is present
+ DTS: difference between DTS-HRA with 96k option and pure DTS-96/24
+ DTS: detection of DTS:X
+ Samples per frame info
+ AC-3: detection of Atmos inside TrueHD
+ Video frame rate: showing precision of 1/1.001 frame rates (e.g.
  "23.976 (24000/1001) fps" and "23.976 (23976/1000) fps")
+ MPEG-4/MOV: showing the complete list of compatible brands in the
  CodecID field
+ MPEG-4/MOV: Alternate groups
+ MPEG-4/MOV: "Disabled" tag
+ MPEG-4/MOV: "Forced" tag
+ MPEG-4/MOV: showing links between tracks (chapters for, subtitles for,
  fallback for)
+ MXF: handling of more acquisition metadata items
+ MXF: Package name
+ AVC: Store method of interlaced content (Interleaved Fields or
  Separated Fields)
+ EBUCore: acquisition metadata (Proof of concept, for feedback only)
x Matroska: frame rate detection algorithm revisited, less wrong numbers
  are expected
x SDP/Teletext: some pages were sometimes (when present in 2 different
  SDP lines) displayed several times
x MPEG-4/MOV: some hint tracks were not displayed
+ Hongkongese language added
+ Option "Full parsing"
```
