### PR TITLE
update nsd to 4.1.7 + update service module

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -55,6 +55,7 @@ let
       port:                ${toString cfg.port}
       verbosity:           ${toString cfg.verbosity}
       hide-version:        ${yesOrNo  cfg.hideVersion}
+      ${maybeString "version: " cfg.version}
       identity:            "${cfg.identity}"
       ${maybeString "nsid: " cfg.nsid}
       tcp-count:           ${toString cfg.tcpCount}
@@ -373,6 +374,16 @@ in
         default     = true;
         description = ''
           Wheter NSD should answer VERSION.BIND and VERSION.SERVER CHAOS class queries.
+        '';
+      };
+
+      version = mkOption {
+        type        = types.nullOr types.str;
+        default     = null;
+        description = ''
+          The version string replied for CH TXT version.server and version.bind
+          queries. Will use the compiled package version on null.
+          See hideVersion for enabling/disabling this responses.
         '';
       };
 

--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -13,11 +13,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "nsd-4.1.6";
+  name = "nsd-4.1.7";
 
   src = fetchurl {
     url = "http://www.nlnetlabs.nl/downloads/nsd/${name}.tar.gz";
-    sha256 = "0pvpsxhil60m21h3pqlzs0l5m8qd3l6j8fkjyfg8plwmbh2j5xl8";
+    sha256 = "12hskfgfbkvcgpa1xxkqd8lnc6xvln1amn97x6avfnj9kfrbxa3v";
   };
 
   buildInputs = [ libevent openssl ];
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.nlnetlabs.nl;
     description = "Authoritative only, high performance, simple and open source name server";
     license = licenses.bsd3;
-
     platforms = platforms.unix;
     maintainers = [ maintainers.hrdinka ];
   };


### PR DESCRIPTION
This updates NSD to 4.1.7 (first commit) and adds the `version` option to it's service module (new in 4.1.7). I do have this running in production without any problems.

@ whoever merges this: please have a look at https://github.com/NixOS/nixpkgs/pull/10991 as well. It's a great improvement that I would love to see in the next stable release and a merge would simplify maintenance and testing for me a lot.
