### PR TITLE
claws-mail: Fix fancy plugin

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [ curl dbus dbus_glib gtk gnutls gsettings_desktop_schemas hicolor_icon_theme
-      libetpan perl pkgconfig python wrapGAppsHook
+      libetpan perl pkgconfig python wrapGAppsHook glib_networking
     ]
     ++ optional enableSpellcheck enchant
     ++ optionals (enablePgp || enablePluginSmime) [ gnupg gpgme ]
@@ -91,9 +91,6 @@ stdenv.mkDerivation {
     ++ optional (!enableSpellcheck) "--disable-enchant";
 
   enableParallelBuilding = true;
-
-  wrapPrefixVariables = [ "GIO_EXTRA_MODULES" ];
-  GIO_EXTRA_MODULES = "${glib_networking}/lib/gio/modules";
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared_mime_info}/share")

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -95,6 +95,10 @@ stdenv.mkDerivation {
   wrapPrefixVariables = [ "GIO_EXTRA_MODULES" ];
   GIO_EXTRA_MODULES = "${glib_networking}/lib/gio/modules";
 
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared_mime_info}/share")
+  '';
+
   postInstall = ''
     mkdir -p $out/share/applications
     cp claws-mail.desktop $out/share/applications


### PR DESCRIPTION
This fixes the fancy plugin displaying HTML mails as text as suggested by @wedens.

This fixes #10421.
