### PR TITLE
Make fail2ban work again

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -3,13 +3,10 @@
 , glib, kbd, libxslt, coreutils, libgcrypt
 , kexectools, libmicrohttpd, linuxHeaders, libseccomp
 , autoreconfHook, gettext, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
-, pythonPackages ? null, pythonSupport ? false
 , enableKDbus ? false
 }:
 
 assert stdenv.isLinux;
-
-assert pythonSupport -> pythonPackages != null;
 
 stdenv.mkDerivation rec {
   version = "228";
@@ -32,7 +29,7 @@ stdenv.mkDerivation rec {
          by generating an autoconf'd tarball, but that's probably not
          worth it. */
       autoreconfHook gettext docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_45
-    ] ++ stdenv.lib.optionals pythonSupport [pythonPackages.python pythonPackages.lxml];
+    ];
 
   configureFlags =
     [ "--localstatedir=/var"

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -18,14 +18,6 @@ pythonPackages.buildPythonPackage {
     ++ [ python.modules.sqlite3 gamin ];
 
   preConfigure = ''
-    substituteInPlace setup.cfg \
-      --replace /usr $out
-
-    substituteInPlace setup.py \
-      --replace /usr $out \
-      --replace /etc $out/etc \
-      --replace /var $TMPDIR/var \
-
     for i in fail2ban-client fail2ban-regex fail2ban-server; do
       substituteInPlace $i \
         --replace /usr/share/fail2ban $out/share/fail2ban
@@ -39,6 +31,18 @@ pythonPackages.buildPythonPackage {
   '';
 
   doCheck = false;
+
+  preInstall = ''
+    # see https://github.com/NixOS/nixpkgs/issues/4968
+    ${python}/bin/${python.executable} setup.py install_data --install-dir=$out --root=$out
+  '';
+
+  postInstall = let
+    sitePackages = "$out/lib/${python.libPrefix}/site-packages";
+  in ''
+    # see https://github.com/NixOS/nixpkgs/issues/4968
+    rm -rf ${sitePackages}/etc ${sitePackages}/usr ${sitePackages}/var;
+  '';
 
   meta = with stdenv.lib; {
     homepage    = http://www.fail2ban.org/;

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, python, pythonPackages, unzip, systemd, gamin }:
+{ stdenv, fetchzip, python, pythonPackages, unzip, gamin }:
 
 let version = "0.9.1"; in
 
@@ -14,8 +14,8 @@ pythonPackages.buildPythonPackage {
 
   buildInputs = [ unzip ];
 
-  pythonPath = (stdenv.lib.optional stdenv.isLinux systemd)
-    ++ [ python.modules.sqlite3 gamin ];
+  propagatedBuildInputs = [ python.modules.sqlite3 gamin ]
+    ++ (stdenv.lib.optional stdenv.isLinux pythonPackages.systemd);
 
   preConfigure = ''
     for i in fail2ban-client fail2ban-regex fail2ban-server; do

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, python, pythonPackages, unzip, gamin }:
 
-let version = "0.9.1"; in
+let version = "0.9.3"; in
 
 pythonPackages.buildPythonPackage {
   name = "fail2ban-${version}";
@@ -9,7 +9,7 @@ pythonPackages.buildPythonPackage {
   src = fetchzip {
     name   = "fail2ban-${version}-src";
     url    = "https://github.com/fail2ban/fail2ban/archive/${version}.tar.gz";
-    sha256 = "111xvy2gxwn868kn0zy2fmdfa423z6fk57i7wsfrc0l74p1cdvs5";
+    sha256 = "1pwgr56i6l6wh2ap8b5vknxgsscfzjqy2nmd1c3vzdii5kf72j0f";
   };
 
   buildInputs = [ unzip ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1432,11 +1432,7 @@ let
 
   fabric = pythonPackages.fabric;
 
-  fail2ban = callPackage ../tools/security/fail2ban {
-    systemd = systemd.override {
-      pythonSupport = true;
-    };
-  };
+  fail2ban = callPackage ../tools/security/fail2ban { };
 
   fakeroot = callPackage ../tools/system/fakeroot { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18554,7 +18554,6 @@ in modules // {
     };
   };
 
-
   structlog = buildPythonPackage rec {
     name = "structlog-15.3.0";
 
@@ -18596,21 +18595,59 @@ in modules // {
     };
   };
 
+  syncthing-gtk = buildPythonPackage rec {
+    version = "0.6.3";
+    name = "syncthing-gtk-${version}";
+    src = pkgs.fetchFromGitHub {
+      owner = "syncthing";
+      repo = "syncthing-gtk";
+      rev = "v${version}";
+      sha256 = "1qa5bw2qizjiqvkms8i31wsjf8cw9p0ciamxgfgq6n37wcalv6ms";
+    };
 
-  # XXX: ValueError: ZIP does not support timestamps before 1980
-  # svneverever =  buildPythonPackage rec {
-  #   name = "svneverever-778489a8";
-  #
-  #   src = pkgs.fetchgit {
-  #     url = git://git.goodpoint.de/svneverever.git;
-  #     rev = "778489a8c6f07825fb18c9da3892a781c3d659ac";
-  #     sha256 = "41c9da1dab2be7b60bff87e618befdf5da37c0a56287385cb0cbd3f91e452bb6";
-  #   };
-  #
-  #   propagatedBuildInputs = with self; [ pysvn argparse ];
-  #
-  #   doCheck = false;
-  # };
+    disabled = isPy3k;
+
+    propagatedBuildInputs = with self; [ pkgs.syncthing dateutil pyinotify pkgs.libnotify pkgs.psmisc
+      pygobject3 pkgs.gtk3 ];
+
+    patchPhase = ''
+      substituteInPlace "scripts/syncthing-gtk" \
+              --replace "/usr/share" "$out/share"
+      substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
+    '';
+
+    meta = {
+      description = " GTK3 & python based GUI for Syncthing ";
+      maintainers = with maintainers; [ DamienCassou ];
+      platforms = pkgs.syncthing.meta.platforms;
+      homepage = "https://github.com/syncthing/syncthing-gtk";
+      license = licenses.gpl2;
+    };
+  };
+
+  systemd = buildPythonPackage rec {
+    version = "231";
+    name = "python-systemd-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/systemd/python-systemd/archive/v${version}.tar.gz";
+      sha256 = "1sifq7mdg0y5ngab8vjy8995nz9c0hxny35dxs5qjx0k0hyzb71c";
+    };
+
+    buildInputs = with pkgs; [ systemd pkgconfig ];
+
+    patchPhase = ''
+      substituteInPlace setup.py \
+          --replace "/usr/include" "${pkgs.systemd}/include"
+      echo '#include <time.h>' >> systemd/pyutil.h
+    '';
+
+    meta = {
+      description = "Python module for native access to the systemd facilities";
+      homepage = http://www.freedesktop.org/software/systemd/python-systemd/;
+      license = licenses.lgpl21;
+    };
+  };
 
   tabulate = buildPythonPackage rec {
     version = "0.7.5";
@@ -18653,36 +18690,6 @@ in modules // {
       description = "A command shell for managing the Linux LIO kernel target";
       homepage = "https://github.com/agrover/targetcli-fb";
       platforms = platforms.linux;
-    };
-  };
-
-  syncthing-gtk = buildPythonPackage rec {
-    version = "0.6.3";
-    name = "syncthing-gtk-${version}";
-    src = pkgs.fetchFromGitHub {
-      owner = "syncthing";
-      repo = "syncthing-gtk";
-      rev = "v${version}";
-      sha256 = "1qa5bw2qizjiqvkms8i31wsjf8cw9p0ciamxgfgq6n37wcalv6ms";
-    };
-
-    disabled = isPy3k;
-
-    propagatedBuildInputs = with self; [ pkgs.syncthing dateutil pyinotify pkgs.libnotify pkgs.psmisc
-      pygobject3 pkgs.gtk3 ];
-
-    patchPhase = ''
-      substituteInPlace "scripts/syncthing-gtk" \
-              --replace "/usr/share" "$out/share"
-      substituteInPlace setup.py --replace "version = get_version()" "version = '${version}'"
-    '';
-
-    meta = {
-      description = " GTK3 & python based GUI for Syncthing ";
-      maintainers = with maintainers; [ DamienCassou ];
-      platforms = pkgs.syncthing.meta.platforms;
-      homepage = "https://github.com/syncthing/syncthing-gtk";
-      license = licenses.gpl2;
     };
   };
 


### PR DESCRIPTION
1. fail2ban depends on the systemd python module which has changed location.
2. There was some problem with the location of installed files (issue #11534).
3. Update to the latest release (0.9.3 2015/08/01 - lets-all-stay-friends) for good measure.
