### PR TITLE
darwin: add libobjc to buildInputs of pkgs.bundlerEnv

### DIFF
--- a/pkgs/development/interpreters/ruby/bundler-env/default-gem-config.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default-gem-config.nix
@@ -70,7 +70,6 @@ in
       "--with-exslt-lib=${libxslt}/lib"
       "--with-exslt-include=${libxslt}/include"
     ] ++ lib.optional stdenv.isDarwin "--with-iconv-dir=${libiconv}";
-    buildInputs = lib.optional stdenv.isDarwin darwin.libobjc;
   };
 
   pg = attrs: {
@@ -122,10 +121,6 @@ in
       substituteInPlace lib/tzinfo/zoneinfo_data_source.rb \
         --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
     '';
-  };
-
-  unf_ext = attrs: {
-    buildInputs = lib.optional stdenv.isDarwin darwin.libobjc;
   };
 
   xapian-ruby = attrs: {

--- a/pkgs/development/interpreters/ruby/bundler-env/default.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default.nix
@@ -1,6 +1,6 @@
 { stdenv, runCommand, writeText, writeScript, writeScriptBin, ruby, lib
 , callPackage, defaultGemConfig, fetchurl, fetchgit, buildRubyGem , bundler_HEAD
-, git
+, git, darwin
 }@defs:
 
 # This is a work-in-progress.
@@ -38,10 +38,15 @@ let
       src = (fetchers."${attrs.source.type}" attrs);
     };
 
-  applyGemConfigs = attrs:
-    if gemConfig ? "${attrs.name}"
-    then attrs // gemConfig."${attrs.name}" attrs
-    else attrs;
+  applyGemConfigs = oldAttrs:
+    let
+      attrs = {
+        buildInputs = lib.optional stdenv.isDarwin darwin.libobjc;
+      } // oldAttrs;
+    in
+      if gemConfig ? "${attrs.name}"
+      then attrs // gemConfig."${attrs.name}" attrs
+      else attrs;
 
   needsPatch = attrs:
     (attrs ? patches) || (attrs ? prePatch) || (attrs ? postPatch);


### PR DESCRIPTION
rubygems with c extensions should now work on darwin unless they need specific buildFlags
