### PR TITLE
lightdm: allow `dm-tool lock` to work properly

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -22,7 +22,7 @@ let
       else additionalArgs="-logfile /var/log/X.$display.log"
       fi
 
-      exec ${dmcfg.xserverBin} ${dmcfg.xserverArgs} $additionalArgs "$@"
+      exec ${dmcfg.xserverBin} $additionalArgs "$@"
     '';
 
   usersConf = writeText "users.conf"
@@ -41,7 +41,7 @@ let
       sessions-directory = ${dmcfg.session.desktops}
 
       [Seat:*]
-      xserver-command = ${xserverWrapper}
+      xserver-command = ${xserverWrapper} ${dmcfg.xserverArgs}
       session-wrapper = ${dmcfg.session.script}
       greeter-session = ${cfg.greeter.name}
       ${cfg.extraSeatDefaults}


### PR DESCRIPTION
Fixes #5038.

The `dm-tool lock` command fails to work for reasons described in #5038:
it tries passing arguments to the xserver command, but the wrapper
throws the arguments away and replaces them with different arguments.

I fixed this by specifying the xserver args in the lightdm.conf file and
having the wrapper pass them through.  This works for lightdm on
startup, and also works for `dm-tool lock` when it later passes a
different set of arguments to start a separate X server on another
display.

Ping @ocharles @wkennington, who are listed as maintainers of the lightdm package.
