### PR TITLE
adv_cmds: fix typo in file name

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
@@ -19,7 +19,7 @@ in appleDerivation {
   buildInputs = [ bsdmake perl yacc flex ];
 
   patchPhase = ''
-    substituteInPlace BSDMakefile \
+    substituteInPlace BSDmakefile \
       --replace chgrp true \
       --replace /Developer/Makefiles/bin/compress-man-pages.pl true \
       --replace "ps.tproj" "" --replace "gencat.tproj" "" --replace "md.tproj" "" \


### PR DESCRIPTION
adv_cmds archive actually contains BSDmakefile, not BSDMakefile. While
that probably doesn't matter in default installations, it does matter
for case-sensitive filesystems.
