### PR TITLE
fish: Use /bin/hostname on darwin. Fixes #11012.

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
         -i "$out/share/fish/functions/seq.fish" \
            "$out/share/fish/functions/math.fish"
     sed -i "s|which |${which}/bin/which |" "$out/share/fish/functions/type.fish"
-    sed -i "s|(hostname\||(${nettools}/bin/hostname\||" "$out/share/fish/functions/fish_prompt.fish"
     sed -i "s|nroff |${groff}/bin/nroff |" "$out/share/fish/functions/__fish_print_help.fish"
     sed -e "s|gettext |${gettext}/bin/gettext |" \
         -e "s|which |${which}/bin/which |" \
@@ -31,6 +30,7 @@ stdenv.mkDerivation rec {
     substituteInPlace "$out/share/fish/functions/fish_default_key_bindings.fish" \
       --replace "clear;" "${ncurses}/bin/clear;"
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    sed -i "s|(hostname\||(${nettools}/bin/hostname\||" "$out/share/fish/functions/fish_prompt.fish"
     sed -i "s|Popen(\['manpath'|Popen(\['${man_db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"
   '' + ''
     sed -i "s|/sbin /usr/sbin||" \


### PR DESCRIPTION
`nettools` are unavailable for Darwin and I don't know of the alternatives. So falling back to using `hostname` from the environment (as it was prior to #10841).

If there's a nix package with `hostname` for Darwin, please let me know, I'll fix this PR to use it instead.
