### PR TITLE
corkscrew: fix darwin build

### DIFF
--- a/pkgs/tools/networking/corkscrew/default.nix
+++ b/pkgs/tools/networking/corkscrew/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, automake }:
 
 stdenv.mkDerivation rec {
   name = "corkscrew-2.0";
@@ -7,6 +7,11 @@ stdenv.mkDerivation rec {
     url = "http://agroman.net/corkscrew/${name}.tar.gz";
     sha256 = "0d0fcbb41cba4a81c4ab494459472086f377f9edb78a2e2238ed19b58956b0be";
   };
+
+  preConfigure = ''
+    ln -sf ${automake}/share/automake-*/config.sub config.sub
+    ln -sf ${automake}/share/automake-*/config.guess config.guess
+  '';
 
   meta = with stdenv.lib; {
     homepage    = http://agroman.net/corkscrew/;


### PR DESCRIPTION
corkscrew ships outdated versions of config.{sub,guess}. Point to
automake version instead.
