### PR TITLE
udevil: added patch

### DIFF
--- a/pkgs/applications/misc/udevil/default.nix
+++ b/pkgs/applications/misc/udevil/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
     cat src/Makefile.am
     exit 2
   '';
+  patches = [ ./device-info-sys-stat.patch ];
   meta = {
     description = "A command line Linux program which mounts and unmounts removable devices without a password, shows device info, and monitors device changes";
     homepage = https://ignorantguru.github.io/udevil/;

--- a/pkgs/applications/misc/udevil/device-info-sys-stat.patch
+++ b/pkgs/applications/misc/udevil/device-info-sys-stat.patch
@@ -1,0 +1,14 @@
+diff --git a/src/device-info.h b/src/device-info.h
+index 6cb3683..ddac24c 100644
+--- a/src/device-info.h
++++ b/src/device-info.h
+@@ -18,7 +18,8 @@
+ // intltool
+ #include <glib/gi18n.h>
+ 
+-
++// stat
++#include <sys/stat.h>
+ 
+ typedef struct device_t  {
+     struct udev_device *udevice;


### PR DESCRIPTION
Added [upstream patch](https://github.com/IgnorantGuru/udevil/issues/59 fixes) to fix udevil build error on current nixos-unstable:

```
`device-info.c
device-info.c: In function 'info_mount_points':
device-info.c:943:33: error: implicit declaration of function 'stat' [-Werror=implicit-function-declaration]
                                 stat( mount_source, &statbuf ) == 0 &&
                                 ^
device-info.c:944:33: error: implicit declaration of function 'S_ISBLK' [-Werror=implicit-function-declaration]
                                 S_ISBLK( statbuf.st_mode ) )
                                 ^
cc1: some warnings being treated as errors
Makefile:495: recipe for target 'udevil-device-info.o' failed
make[2]: *** [udevil-device-info.o] Error 1
make[2]: Leaving directory '/tmp/nix-build-udevil-0.4.4.drv-0/udevil-0.4.4/src'
Makefile:428: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/tmp/nix-build-udevil-0.4.4.drv-0/udevil-0.4.4'
Makefile:359: recipe for target 'all' failed
make: *** [all] Error 2
builder for ‘/nix/store/gzmrcfnncw4l30ywcnz2gfcjwii4sw3n-udevil-0.4.4.drv’ failed with exit code 2
error: build of ‘/nix/store/gzmrcfnncw4l30ywcnz2gfcjwii4sw3n-udevil-0.4.4.drv’ failed
/run/current-system/sw/bin/nix-shell: failed to build all dependencies
```
