### PR TITLE
signing-party: 2.0 -> 2.1

### DIFF
--- a/pkgs/tools/security/signing-party/default.nix
+++ b/pkgs/tools/security/signing-party/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, gnupg, perl, automake111x, autoconf}:
 
 stdenv.mkDerivation rec {
-  version = "2.0";
+  version = "2.1";
   basename = "signing-party";
   name = "${basename}-${version}";
   src = fetchurl {
     url = "mirror://debian/pool/main/s/${basename}/${basename}_${version}.orig.tar.gz";
-    sha256 = "0vn15sb2yyzd57xdblw48p5hi6fnpvgy83mqyz5ygph65y5y88yc";
+    sha256 = "0pcni3mf92503bqknwlsvv1f5gz23dmzwas2j8g2fk7afjd891ya";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Fixes source not found error when building.

PS: upstream seems to keep only the [most recent version archive file](http://debian.lagis.at/debian/pool/main/s/signing-party/), so this package should be updated as soon as possible when upstream release a new version to avoid this issue to happen again in the future.
