### PR TITLE
Update containers.nix

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -412,7 +412,7 @@ in
       }) config.containers;
 
     # Generate /etc/hosts entries for the containers.
-    networking.extraHosts = concatStrings (mapAttrsToList (name: cfg: optionalString (cfg.localAddress != null)
+    networking.extraHosts = concatStrings (mapAttrsToList (name: cfg: optionalString (cfg.hostAddress != null)
       ''
         ${cfg.hostAddress} ${name}.containers
       '') config.containers);

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -414,7 +414,7 @@ in
     # Generate /etc/hosts entries for the containers.
     networking.extraHosts = concatStrings (mapAttrsToList (name: cfg: optionalString (cfg.localAddress != null)
       ''
-        ${cfg.localAddress} ${name}.containers
+        ${cfg.hostAddress} ${name}.containers
       '') config.containers);
 
     networking.dhcpcd.denyInterfaces = [ "ve-*" ];


### PR DESCRIPTION
When we create a new container, we want to record the brief name in /etc/hosts for use.  But this records the container's local address in host's /etc/hosts, this IP we can‘t access from host side, so instead of the container's host address.
