### PR TITLE
gosmore: fix hash again and disable svn externals

### DIFF
--- a/pkgs/applications/misc/gosmore/default.nix
+++ b/pkgs/applications/misc/gosmore/default.nix
@@ -5,10 +5,14 @@ let
 in
 stdenv.mkDerivation {
   name = "gosmore-r${version}";
+  # the gosmore svn repository does not lock revision numbers of its externals
+  # so we explicitly disable them to avoid breaking the hash
+  # especially as the externals appear to be unused
   src = fetchsvn {
     url = http://svn.openstreetmap.org/applications/rendering/gosmore;
-    sha256 = "0i6m3ikavsaqhfy18sykzq0cflw978nr4fhg18hawndcmr45v5zj";
+    sha256 = "0qsckpqx7i7f8gkqhkzdamr65250afk1rpnh3nbman35kdv3dsxi";
     rev = "${version}";
+    ignoreExternals = true;
   };
 
   buildInputs = [ libxml2 gtk curl ];


### PR DESCRIPTION
Gosmore breaks its hash upon every commit on its "map-icons" external due to not locking the external revision number in the top-level repository (see #11524). This commit prevents the externals to be checked out at all, thereby ensuring a consistent hash.

Perhaps this looks wrong at first sight, however I compared the build of the project with the external with this one - and surprisingly the results are actually identical (a small difference in the binary but that's due to a non-deterministic build; the sizes of the binaries are the same). So as the external is apparently not even used for building or installing gosmore, it seemed easiest to simply disable them from being checked out at all.

It could be that the external "map-icons" needs some separate steps for installation, but I rather leave that to someone who actually uses the application - with this merge at least the situation is better than what it was before and will prevent future build failures due to hash mismatches.

Tested against master on Fedora (non-nixos), application starts and appears to be functional.

cc @7c6f434c (Michael Raskin)
