### PR TITLE
python buildPythonPackage: check and run correct test command

### DIFF
--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -109,11 +109,11 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled" "doCheck"] //
     runHook preCheck
 
     if which py.test; then
-        py.test
+      py.test
     elif which nosetests; then
-        nosetests
+      nosetests
     else
-        ${python.interpreter} nix_run_setup.py test
+      ${python.interpreter} nix_run_setup.py test
     fi
 
     runHook postCheck
@@ -131,11 +131,11 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled" "doCheck"] //
   shellHook = attrs.shellHook or ''
     ${preShellHook}
     if test -e setup.py; then
-       tmp_path=$(mktemp -d)
-       export PATH="$tmp_path/bin:$PATH"
-       export PYTHONPATH="$tmp_path/${python.sitePackages}:$PYTHONPATH"
-       mkdir -p $tmp_path/${python.sitePackages}
-       ${bootstrapped-pip}/bin/pip install -e . --prefix $tmp_path
+      tmp_path=$(mktemp -d)
+      export PATH="$tmp_path/bin:$PATH"
+      export PYTHONPATH="$tmp_path/${python.sitePackages}:$PYTHONPATH"
+      mkdir -p $tmp_path/${python.sitePackages}
+      ${bootstrapped-pip}/bin/pip install -e . --prefix $tmp_path
     fi
     ${postShellHook}
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4696,10 +4696,6 @@ in modules // {
     buildInputs = with self; [ nose ];
     propagatedBuildInputs = with self; [ smmap ];
 
-    checkPhase = ''
-      nosetests
-    '';
-
     doCheck = false; # Bunch of tests fail because they need an actual git repo
 
     meta = {
@@ -7696,10 +7692,6 @@ in modules // {
       substituteInPlace jsonschema/tests/test_jsonschema_test_suite.py --replace "python" "${python}/bin/${python.executable}"
     '';
 
-    checkPhase = ''
-      nosetests
-    '';
-
     meta = {
       homepage = https://github.com/Julian/jsonschema;
       description = "An implementation of JSON Schema validation for Python";
@@ -8456,8 +8448,6 @@ in modules // {
     propagatedBuildInputs = with self; [
       six
     ] ++ optionals isPy26 [ ordereddict ];
-
-    checkPhase = "nosetests";
 
     meta = {
       homepage = https://github.com/html5lib/html5lib-python;
@@ -10383,10 +10373,6 @@ in modules // {
     };
 
     buildInputs = with self; [ nose minimock ];
-
-    checkPhase = ''
-      nosetests
-    '';
 
     disabled = isPy3k;
 
@@ -13591,10 +13577,6 @@ in modules // {
     # nosetests needs to be run explicitly.
     # Note that the distributed archive does not actually contain any tests.
     # https://github.com/matze/pkgconfig/issues/9
-    checkPhase = ''
-      nosetests
-    '';
-
   };
 
   plumbum = buildPythonPackage rec {
@@ -14327,9 +14309,8 @@ in modules // {
 
     # Run tests using nosetests but first need to install the binaries
     # to the root source directory where they can be found.
-    checkPhase = ''
+    preCheck = ''
       ./setup.py install_lib -d .
-      nosetests
     '';
 
     meta = {
@@ -15875,8 +15856,6 @@ in modules // {
 
     buildInputs = with self; [ nose ];
     propagatedBuildInputs = with self; [ modules.sqlite3 six ];
-
-    checkPhase = "nosetests";
 
     disabled = isPy3k;
 
@@ -17446,9 +17425,8 @@ in modules // {
       sha256 = "1nqham81ihffc9xmw85dz3rg3v90rw7h0dp3dy0bh3qkp4n499q6";
     };
 
-    checkPhase = ''
+    preCheck = ''
       export LANG="en_US.UTF-8"
-      py.test
     '';
 
     buildInputs = with self; [ pytest py mock pkgs.glibcLocales ];
@@ -18196,10 +18174,6 @@ in modules // {
     };
 
     buildInputs = with self; [ pytest pretend freezegun ];
-
-    checkPhase = ''
-      py.test
-    '';
 
     meta = {
       description = "Painless structural logging";
@@ -21011,8 +20985,6 @@ in modules // {
       sha256 = "41b90d5f35e99a020a6b1b77938690652521d1841b3165574fcfcee807ce4e6a";
     };
 
-    checkPhase = "nosetests";
-
     propagatedBuildInputs = with self; [
       flask
       flask_cache
@@ -21097,7 +21069,6 @@ in modules // {
     ];
 
     patchPhase = "> requirements.txt";
-    checkPhase = "nosetests";
 
     meta = {
       description = "A simple alerting application for Graphite metrics";


### PR DESCRIPTION
The default command for running tests is `python setup.py test`.  Many
packages use a test runner that needs to be invoked, e.g. `nosetests` or
`py.test`. It would be nice if `buildPythonPackage` automatically
determines which command to run.

We can check in the `buildInputs` whether `nose` or `pytest` is
included, and if so, do either 1) or 2)
1. Run the appropriate command, `nosetests` or `py.test`.
2. Apply a patch to enable `python setup.py test`. For
   [py.test](http://pytest.org/latest/goodpractises.html#integrating-with-
   setuptools-python-setup-py-test-pytest-runner) and
   [nose](http://nose.readthedocs.org/en/latest/api/commands.html)

Option 2) could get complicated/messy and therefore I'm in favor of
option 1).

This commit implements option 1.

---

Reference to #1819 

---

Furthermore, comments in buildPythonPackage are moved out of the arguments, and explicit calls to the test runners that are not necessary anymore are removed.
