### PR TITLE
units: add readline dependency

### DIFF
--- a/pkgs/tools/misc/units/default.nix
+++ b/pkgs/tools/misc/units/default.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchurl, readline }:
+
 stdenv.mkDerivation rec {
   name = "units-${version}";
   version = "2.12";
@@ -8,8 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "1jxvjknz2jhq773jrwx9gc1df3gfy73yqmkjkygqxzpi318yls3q";
   };
 
-  meta = {
+  buildInputs = [ readline ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
     description = "Unit conversion tool";
-    platforms = stdenv.lib.platforms.linux;
+    homepage = https://www.gnu.org/software/units/;
+    license = [ licenses.gpl3Plus ];
+    platforms = stdenv.lib.platforms.all;
   };
 }


### PR DESCRIPTION
The dependency on readline is for tab-completion support. This commit also enables tests and adds meta information.
