### PR TITLE
slurm-llnl: 14.11.5 -> 14-11-5-1

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-llnl-${version}";
-  version = "14.11.5";
+  version = "14-11-5-1";
 
   src = fetchurl {
-    url = "http://www.schedmd.com/download/latest/slurm-${version}.tar.bz2";
-    sha256 = "0xx1q9ximsyyipl0xbj8r7ajsz4xrxik8xmhcb1z9nv0aza1rff2";
+    url = "https://github.com/SchedMD/slurm/archive/slurm-${version}.tar.gz";
+    sha256 = "0vn2jkj83zgc4j656vm24lihapg3w3sfnzpsmynlk4r0v9cy2vcw";
   };
 
   buildInputs = [ python munge perl pam openssl mysql.lib ];


### PR DESCRIPTION
This fix http://hydra.nixos.org/build/28880801/nixlog/10.

Details:
Upstream moved `src` to [github](http://www.schedmd.com/#repos).
This is not an update, just a `src` fix but as upstream version scheme has changed from `X.Y.Z` to `X-Y-Z-A` the version label changed.
The archives page is [here](https://github.com/SchedMD/slurm/releases) and newer versions are available.

cc maintainer @jagajaga 
