### PR TITLE
logkeys: 5ef6b0dcb9e3 -> 2015-11-10

### DIFF
--- a/pkgs/tools/security/logkeys/default.nix
+++ b/pkgs/tools/security/logkeys/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "logkeys-${version}";
-  version = "5ef6b0dcb9e3";
+  version = "2015-11-10";
 
   src = fetchgit {
     url = https://github.com/kernc/logkeys;
-    rev = "5ef6b0dcb9e38e6137ad1579d624ec12107c56c3";
-    sha256 = "02p0l92l0fq069g31ks6xbqavzxa9njj9460vw2jsa7livcn2z9d";
+    rev = "78321c6e70f61c1e7e672fa82daa664017c9e69d";
+    sha256 = "1b1fa1rblyfsg6avqyls03y0rq0favipn5fha770rsirzg4r637q";
   };
 
   buildInputs = [ which procps kbd ];


### PR DESCRIPTION
This fix http://hydra.nixos.org/build/28536888#tabs-buildsteps
Building fine on local machine with current master.

Details
The rev of the derivation was not available in the [upstream repo](https://github.com/kernc/logkeys/commits/master), I updated to what seemed the new and stable one.

@offline can you check if this new `logkeys` version work as intended?
