### PR TITLE
praat: 5417 -> 5.4.17

### DIFF
--- a/pkgs/applications/audio/praat/default.nix
+++ b/pkgs/applications/audio/praat/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, alsaLib, gtk, pkgconfig }:
 
-let version = "5417"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "praat-${version}";
+  version = "5.4.17";
 
   src = fetchurl {
-    url = "http://www.fon.hum.uva.nl/praat/praat${version}_sources.tar.gz";
-    sha256 = "1bspl963pb1s6k3cd9p3g5j518pxg6hkrann945lqsrvbzaa20kl";
+    url = "https://github.com/praat/praat/archive/v${version}.tar.gz";
+    sha256 = "0s2hrksghg686059vc90h3ywhd2702pqcvy99icw27q5mdk6dqsx";
   };
 
   configurePhase = ''


### PR DESCRIPTION
Fix http://hydra.nixos.org/build/28735657/nixlog/5
Building fine on local machine.

Details:
- upstream moved [source to github](http://www.fon.hum.uva.nl/praat/download_sources.html)
- versioning scheme of the archive has changed from `XXXX` to `X.Y.Z`

Side notes:
- Upstream has newer versions up to [6.0.08](https://github.com/praat/praat/releases/tag/v6.0.08) available
