### PR TITLE
riak: fix leveldb hash

### DIFF
--- a/pkgs/servers/nosql/riak/1.3.1.nix
+++ b/pkgs/servers/nosql/riak/1.3.1.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, unzip, erlangR15}:
+{ stdenv, fetchurl, fetchFromGitHub, unzip, erlangR15}:
 
 let
   srcs = {
-     riak = fetchurl {
+    riak = fetchurl {
       url = "http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.1/riak-1.3.1.tar.gz";
       sha256 = "a69093fc5df1b79f58645048b9571c755e00c3ca14dfd27f9f1cae2c6e628f01";
     };
-     leveldb = fetchurl {
-      url = "https://github.com/basho/leveldb/archive/1.3.1.zip";
-      sha256 = "dc48ba2b44fca11888ea90695d385c494e1a3abd84a6b266b07fdc160ab2ef64";
+    leveldb = fetchFromGitHub {
+      owner  = "basho";
+      repo   = "leveldb";
+      rev    = "1.3.1";
+      sha256 = "1jvv260ic38657y4lwwcvzmhah8xai594xy19r28gkzlpra1lnbb";
     };
   };
 in
@@ -22,11 +24,10 @@ stdenv.mkDerivation rec {
   patches = [ ./riak-1.3.1.patch ./riak-admin-1.3.1.patch ];
 
   postUnpack = ''
-    ln -sv ${srcs.leveldb} $sourceRoot/deps/eleveldb/c_src/leveldb.zip
-    pushd $sourceRoot/deps/eleveldb/c_src/
-    unzip leveldb.zip
-    mv leveldb-* leveldb
-    cd ../../
+    mkdir -p $sourceRoot/deps/eleveldb/c_src/leveldb
+    cp -r ${srcs.leveldb}/* $sourceRoot/deps/eleveldb/c_src/leveldb
+    chmod 755 -R $sourceRoot/deps/eleveldb/c_src/leveldb
+    pushd $sourceRoot/deps/
     mkdir riaknostic/deps
     cp -R lager riaknostic/deps
     cp -R getopt riaknostic/deps


### PR DESCRIPTION
fix wrong `leveldb` hash for riak.

Details:

```
nix-prefetch-url https://github.com/basho/leveldb/archive/1.3.1.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   117    0   117    0     0     92      0 --:--:--  0:00:01 --:--:--    92
100  318k  100  318k    0     0  89859      0  0:00:03  0:00:03 --:--:--  149k
path is ‘/nix/store/q8nykd3sxqb6jqywgxj8wzl5i5fwzhhf-1.3.1.zip’
1269wg9r8rwjj3ipnxsqyavkgk6v34yzc5kq4i814i5w2j6gc8cp
```
