### PR TITLE
add Terraria dedicated server for Linux x86_64

### DIFF
--- a/pkgs/games/terraria-server/default.nix
+++ b/pkgs/games/terraria-server/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, file, fetchurl }:
+assert stdenv.system == "x86_64-linux";
+
+stdenv.mkDerivation rec {
+  name    = "terraria-server-${version}";
+  version = "1308";
+
+  src = fetchurl {
+    url = http://terraria.org/server/terraria-server-linux-1308.tar.gz;
+    sha256 = "0cx3nx7wmzcw9l0nz9zm4amccl8nrd09hlb3jc1yrqcaswbyxc8a";
+  };
+
+  buildInputs = [ file ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out/
+    ln -s $out/terraria-server-linux-${version}/TerrariaServer.bin.x86_64 $out/bin/TerrariaServer
+
+    # Fix "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
+    echo "running patchelf on prebuilt binaries:"
+    find "$out" | while read filepath; do
+      if file "$filepath" | grep -q "ELF.*executable"; then
+        echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
+        patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath"
+        test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
+      fi
+    done
+  '';
+
+  meta = with lib; {
+    homepage = http://terraria.org;
+    description = "Dedicated server for the main game";
+    platforms = platforms.linux;
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14266,6 +14266,8 @@ let
 
   tennix = callPackage ../games/tennix { };
 
+  terraria-server = callPackage ../games/terraria-server/default.nix { };
+
   tibia = callPackage_i686 ../games/tibia { };
 
   tintin = callPackage ../games/tintin { };


### PR DESCRIPTION
After a long time being stuck with Windows (because of a game) I'm back on NixOS.

This is a small contribution to the gaming section of `nixpkgs`.

I couldn't get the x86 server version running and honestly I don't really care. I have set `platforms = [ "x86_64-linux" ];`

Tell me if there are any problems with this PR.
