### PR TITLE
zip: fixed build phase (i.e. unicode support)

### DIFF
--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -13,11 +13,9 @@ stdenv.mkDerivation {
     sha256 = "0sb3h3067pzf3a7mlxn1hikpcjrsvycjcnj9hl9b1c3ykcgvps7h";
   };
 
-  # should be makeFlags on all archs, not changed yet to prevent rebuild
-  buildFlags="-f unix/Makefile generic";
-  makeFlags = if stdenv.isCygwin then "-f unix/Makefile ${if stdenv.isCygwin then "cygwin" else "generic"}" else null;
-
-  installFlags="-f unix/Makefile prefix=$(out) INSTALL=cp";
+  makefile = "unix/Makefile";
+  buildFlags = if stdenv.isCygwin then "cygwin" else "generic";
+  installFlags = "prefix=$(out) INSTALL=cp";
 
   patches = if (enableNLS && !stdenv.isCygwin) then [ ./natspec-gentoo.patch.bz2 ] else [];
 


### PR DESCRIPTION
 The build did not use the current build infrastructure correctly. As a
 consequence zip lacked support for unicode and 64bit files.
