### PR TITLE
net-snmp: fix mnttab path when built under chroot

### DIFF
--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       "--with-logfile=/var/log/net-snmpd.log"
       "--with-persistent-directory=/var/lib/net-snmp"
       "--with-openssl=${openssl}"
-    ];
+    ] ++ stdenv.lib.optional stdenv.isLinux [ "--with-mnttab=/proc/mounts" ];
 
   buildInputs = [ autoreconfHook file perl unzip openssl ];
 


### PR DESCRIPTION
the configure script checks for the presense of /etc/mtab to decide which one to use at run-time, the chroot lacks one and its just a symlink under modern linux installs
