### PR TITLE
Fix unrecognized "--with-curlwrappers" configure flag on PHP >= 5.5

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -9,7 +9,9 @@ let
   generic =
     { version, sha256 }:
 
-    let php7 = lib.versionAtLeast version "7.0"; in
+    let
+      php54 = lib.versionOlder version "5.5";
+      php7 = lib.versionAtLeast version "7.0"; in
 
     composableDerivation.composableDerivation {} (fixed: {
 
@@ -223,7 +225,7 @@ let
         bcmathSupport = config.php.bcmath or true;
         socketsSupport = config.php.sockets or true;
         curlSupport = config.php.curl or true;
-        curlWrappersSupport = (!php7) && (config.php.curlWrappers or true);
+        curlWrappersSupport = (php54) && (config.php.curlWrappers or true);
         gettextSupport = config.php.gettext or true;
         pcntlSupport = config.php.pcntl or true;
         postgresqlSupport = config.php.postgresql or true;


### PR DESCRIPTION
The configure flag `--with-curlwrappers` is not available anymore in PHP core >= 5.5. [The feature has been moved to PECL](http://php.net/manual/en/curl.installation.php).
To avoid having `configure: WARNING: unrecognized options: --with-curlwrappers` during compilation of PHP >= 5.5, this PR restricts its evaluation to PHP 5.4.
