### PR TITLE
udisks2: fix udev rules file

### DIFF
--- a/nixos/modules/services/hardware/udisks2.nix
+++ b/nixos/modules/services/hardware/udisks2.nix
@@ -39,7 +39,7 @@ with lib;
         mkdir -m 0755 -p /var/lib/udisks2
       '';
 
-    #services.udev.packages = [ pkgs.udisks2 ];
+    services.udev.packages = [ pkgs.udisks2 ];
     
     systemd.services.udisks2 = {
       description = "Udisks2 service";

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool
+{ stdenv, fetchurl, pkgconfig, intltool, gnused
 , expat, acl, systemd, glib, libatasmart, polkit
 , libxslt, docbook_xsl, utillinux, mdadm, libgudev
 }:
@@ -21,7 +21,11 @@ stdenv.mkDerivation rec {
     ''
       substituteInPlace src/main.c --replace \
         "@path@" \
-        "${utillinux}/bin:${mdadm}/sbin:/var/run/current-system/sw/bin:/var/run/current-system/sw/bin"
+        "${utillinux}/bin:${mdadm}/bin:/run/current-system/sw/bin"
+      substituteInPlace data/80-udisks2.rules \
+        --replace "/bin/sh" "${stdenv.shell}" \
+        --replace "/sbin/mdadm" "${mdadm}/bin/mdadm" \
+        --replace " sed " " ${gnused}/bin/sed "
     '';
 
   nativeBuildInputs = [ pkgconfig intltool ];


### PR DESCRIPTION
This properly hides system partitions (like EFI or Windows recovery) from UDisks.
