### PR TITLE
pkgs.slurm-llnl: 14-11-5-1 -> 15-08-5-1

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-llnl-${version}";
-  version = "14-11-5-1";
+  version = "15-08-5-1";
 
   src = fetchurl {
     url = "https://github.com/SchedMD/slurm/archive/slurm-${version}.tar.gz";
-    sha256 = "0vn2jkj83zgc4j656vm24lihapg3w3sfnzpsmynlk4r0v9cy2vcw";
+    sha256 = "05si1cn7zivggan25brsqfdw0ilvrlnhj96pwv16dh6vfkggzjr1";
   };
 
   buildInputs = [ python munge perl pam openssl mysql.lib ];


### PR DESCRIPTION
cc @jagajaga 

Currently, on a system that follow https://nixos.org/channels/nixos-15.09 I cannot install `slurm`. Nix cannot download it at `http://www.schedmd.com/download/latest/slurm-14.11.5.tar.bz2` (and I cannot get it at `https://github.com/SchedMD/slurm/archive/slurm-14-11-5-1.tar.bz2` where current version of `nixpkgs` points). What would b the proper procedure to follow to fix the stable channel ? Find a suitable download URL (`https://github.com/SchedMD/slurm/archive/slurm-14-11-5-1.zip` seems to be fine) or update to 15-08-5 ?
