### PR TITLE
colordiff: add archive URL

### DIFF
--- a/pkgs/tools/text/colordiff/default.nix
+++ b/pkgs/tools/text/colordiff/default.nix
@@ -4,7 +4,10 @@ stdenv.mkDerivation rec {
   name = "colordiff-1.0.16";
 
   src = fetchurl {
-    url = "http://www.colordiff.org/${name}.tar.gz";
+    urls = [
+      "http://www.colordiff.org/${name}.tar.gz"
+      "http://www.colordiff.org/archive/${name}.tar.gz"
+    ];
     sha256 = "12qkkw13261dra8pg7mzx4r8p9pb0ajb090bib9j1s6hgphwzwga";
   };
 


### PR DESCRIPTION
When a new version of colordiff is released the old tarball is moved to the archive directory. This breaks builds until the derivation is updated to the new version. This commit lets fetchurl know about the archive URL.
