### PR TITLE
Set `link_power_policy_management` default to "max_performance"

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -71,7 +71,6 @@ in
 
     # FIXME: Implement powersave governor for sandy bridge or later Intel CPUs
     powerManagement.cpuFreqGovernor = mkDefault "ondemand";
-    powerManagement.scsiLinkPolicy = mkDefault "max_performance";
 
     systemd.targets.post-resume = {
       description = "Post-Resume Actions";

--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -71,7 +71,7 @@ in
 
     # FIXME: Implement powersave governor for sandy bridge or later Intel CPUs
     powerManagement.cpuFreqGovernor = mkDefault "ondemand";
-    powerManagement.scsiLinkPolicy = mkDefault "min_power";
+    powerManagement.scsiLinkPolicy = mkDefault "max_performance";
 
     systemd.targets.post-resume = {
       description = "Post-Resume Actions";


### PR DESCRIPTION
The kernel default for `link_power_management_policy` is `"max_performance"`. This commit: https://github.com/NixOS/nixpkgs/commit/f169f60575bec7c61626af180cae364d321b4bec set the NixOS default to `"min_power"`.

This issue (https://github.com/NixOS/nixpkgs/issues/11276) details my long journey to discover that, after several file system failures incorrectly attributed to `TRIM` and `NCQ` settings, the origin of my (and others') issues were around the `"min_power"` default setting. Setting it back to `"max_performance"` as per the kernel default resolved my issues.

I think we should use the kernel default of `"max_performance"` to assure the best experience for new users with SSDs and to conform to the defaults of the kernel and other distros.
