### PR TITLE
yakuake: 2.9.8 -> 2.9.9

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -3,23 +3,21 @@
 
 let
   pname = "yakuake";
-  version = "2.9.8";
+  version = "2.9.9";
 in
 stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.bz2";
-    sha256 = "0a9x3nmala8nl4xl3h7rcd76f5j7b7r74jc5cfbayc6jgkjdynd3";
+    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
+    sha256 = "0e0e4994c568f8091c9424e4aab35645436a9ff341c00b1cd1eab0ada0bf61ce";
   };
 
   buildInputs = [ kdelibs ];
 
   nativeBuildInputs = [ automoc4 cmake gettext perl pkgconfig ];
 
-  patchPhase = ''
-    substituteInPlace app/terminal.cpp --replace \"konsolepart\" "\"${konsole}/lib/kde4/libkonsolepart.so\""
-  '';
+  propagatedUserEnvPkgs = [ konsole ];
 
   meta = {
     homepage = http://yakuake.kde.org;


### PR DESCRIPTION
Update yakuake to the latest version. 

I'm not sure why this wasn't done before: `2.9.9` is several years old.  

I don't know how to specify runtime dependency on `konsole-4`, it is no more loaded with a path to `.so`: https://github.com/Gnurou/yakuake/blob/master/app/terminal.cpp#L63
