### PR TITLE
LXC: make sure configure script does not guess

### DIFF
--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--enable-doc"
     "--disable-api-docs"
+    "--with-init-script=none"
+    "--with-distro=nixos" # just to be sure it is "unknown"
   ] ++ optional (libapparmor != null) "--enable-apparmor"
     ++ optional (libselinux != null) "--enable-selinux"
     ++ optional (libseccomp != null) "--enable-seccomp"


### PR DESCRIPTION
Do not try to install init script.
And do not make any assumptions about the distribution.

The latter is important when Nix store in not a part of NixOS.

Closes #11729.
