### PR TITLE
chroot-user: don't create new user namespace if we are root

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -81,6 +81,11 @@ let
       ln -s /host-etc/resolv.conf resolv.conf
       ln -s /host-etc/nsswitch.conf nsswitch.conf
 
+      # symlink sudo and su stuff
+      ln -s /host-etc/login.defs login.defs
+      ln -s /host-etc/sudoers sudoers
+      ln -s /host-etc/sudoers.d sudoers.d
+
       # symlink other core stuff
       ln -s /host-etc/localtime localtime
       ln -s /host-etc/machine-id machine-id

--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -56,7 +56,7 @@ let
     export PS1='${name}-chrootenv:\u@\h:\w\$ '
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
     export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
-    export PATH='/usr/bin:/usr/sbin'
+    export PATH='/var/setuid-wrappers:/usr/bin:/usr/sbin'
     ${profile}
   '';
 


### PR DESCRIPTION
This makes it possible to have full `root` rights within an FHS sandbox (if you are getting into it as `root`), and to drop them later if desired. This somewhat lowers security of the sandbox:
1. Temporary roots are now 0755 instead of 0700.
2. If you are root, user namespace is not created automatically.

That said, privileges drop was never the aim of `chroot-user` -- we try to drop as _small_ as possible. However I want to warn people who might be using it of those changes and leave this for discussion for some time.
