### PR TITLE
grml-zsh-config: init at 0.12.4

### DIFF
--- a/pkgs/shells/grml-zsh-config/default.nix
+++ b/pkgs/shells/grml-zsh-config/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, lib
+, zsh, coreutils, inetutils, procps, txt2tags }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "grml-zsh-config-${version}";
+  version = "0.12.4";
+
+  src = fetchurl {
+    url = "http://deb.grml.org/pool/main/g/grml-etc-core/grml-etc-core_${version}.tar.gz";
+    sha256 = "1cbedc41e32787c37c2ed546355a26376dacf2ae1fab9551c9ace3e46d236b72";
+  };
+
+  buildInputs = [ zsh coreutils inetutils procps txt2tags ];
+
+  buildPhase = ''
+    cd doc
+    make
+    cd ..
+  '';
+
+  installPhase = ''
+    install -D -m644 etc/zsh/keephack $out/etc/zsh/keephack
+    install -D -m644 etc/zsh/zshrc $out/etc/zsh/zshrc
+
+    install -D -m644 doc/grmlzshrc.5 $out/share/man/man5/grmlzshrc.5
+    ln -s grmlzshrc.5.gz $out/share/man/man5/grml-zsh-config.5.gz
+  '';
+
+  meta = with stdenv.lib; {
+    description = "grml's zsh setup";
+    homepage = http://grml.org/zsh/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.msteen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3741,6 +3741,8 @@ let
 
   nix-zsh-completions = callPackage ../shells/nix-zsh-completions { };
 
+  grml-zsh-config = callPackage ../shells/grml-zsh-config { };
+
 
   ### DEVELOPMENT / COMPILERS
 


### PR DESCRIPTION
The Zsh configuration I was used to while using Arch Linux: https://wiki.archlinux.org/index.php/Zsh#Sample_.zshrc_files
