### PR TITLE
nix-serve user added to nix-daemon allowed users

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -390,11 +390,12 @@ rec {
   */
   filterOverrides = defs:
     let
+      defs' = filter (def: def.value._type or "" != "user-defined") defs;
       defaultPrio = 100;
       getPrio = def: if def.value._type or "" == "override" then def.value.priority else defaultPrio;
-      highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
-      strip = def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
-    in concatMap (def: if getPrio def == highestPrio then [(strip def)] else []) defs;
+      highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs';
+      strip = def: if def.value._type or "" == "override" || def.value._type or "" == "user-defined" then def // { value = def.value.content; } else def;
+    in concatMap (def: if getPrio def == highestPrio then [(strip def)] else []) (if highestPrio < 1000 then defs else defs');
 
   /* Sort a list of properties.  The sort priority of a property is
      1000 by default, but can be overriden by wrapping the property
@@ -435,6 +436,11 @@ rec {
   mkIf = condition: content:
     { _type = "if";
       inherit condition content;
+    };
+
+  mkIfUserDefined = content:
+    { _type = "user-defined";
+      inherit content;
     };
 
   mkAssert = assertion: message: content:

--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -66,5 +66,7 @@ in
       description = "Nix-serve user";
       uid = config.ids.uids.nix-serve;
     };
+
+    nix.allowedUsers = mkIfUserDefined [ "nix-serve" ];
   };
 }


### PR DESCRIPTION
Without the nix-serve user in the allowed users of the Nix daemon,
it will not have access to the Nix store, which will result in internal server errors.
