### PR TITLE
fix the mime database generation

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -128,7 +128,7 @@ in
       # !!! Hacky, should modularise.
       postBuild =
         ''
-          if [ -x $out/bin/update-mime-database -a -w $out/share/mime/packages ]; then
+          if [ -x $out/bin/update-mime-database -a -w $out/share/mime ]; then
               XDG_DATA_DIRS=$out/share $out/bin/update-mime-database -V $out/share/mime > /dev/null
           fi
 


### PR DESCRIPTION
if only one package (for example: shared-mime-info) provides mime data, then $out/share/mime/packages is a symlink into it, which is read-only, causing the mime-database to not generate

this change resolves the issue and fixes a large portion of xfce
