### PR TITLE
gnome3_*.libgdata: add `nss` dependency

### DIFF
--- a/pkgs/development/libraries/liboauth/default.nix
+++ b/pkgs/development/libraries/liboauth/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-nss" ];
 
+  postInstall = ''
+    substituteInPlace $out/lib/liboauth.la \
+      --replace "-lnss3" "-L${nss}/lib -lnss3"
+  '';
+
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     description = "C library implementing the OAuth secure authentication protocol";


### PR DESCRIPTION
Fixes the following build error:

```
  CCLD     gdata/libgdata.la
/nix/store/5kdjp8200hazaydx0dmwn5qghqkyi3py-binutils-2.23.1/bin/ld: cannot find -lssl3
/nix/store/5kdjp8200hazaydx0dmwn5qghqkyi3py-binutils-2.23.1/bin/ld: cannot find -lsmime3
/nix/store/5kdjp8200hazaydx0dmwn5qghqkyi3py-binutils-2.23.1/bin/ld: cannot find -lnss3
/nix/store/5kdjp8200hazaydx0dmwn5qghqkyi3py-binutils-2.23.1/bin/ld: cannot find -lnssutil3
collect2: error: ld returned 1 exit status
```

cc @lethalman.
