### PR TITLE
softhsm: init at 2.0.0

### DIFF
--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, unzip, botan }:
+
+stdenv.mkDerivation rec {
+
+  name = "softhsm-${version}";
+  majorVersion = "2";
+  version = "${majorVersion}.0.0";
+
+  src = fetchurl {
+    url = "https://dist.opendnssec.org/source/${name}.tar.gz";
+    sha256 = "eae8065f6c472af24f4c056d6728edda0fd34306f41a818697f765a6a662338d";
+  };
+
+  configureFlags = [
+    "--with-crypto-backend=botan"
+    "--with-botan=${botan}"
+    "--sysconfdir=$out/etc"
+    "--localstatedir=$out/var"
+    ];
+
+  buildInputs = [ botan];
+
+  meta = {
+    homepage = https://www.opendnssec.org/softhsm/;
+    description = "Cryptographic store accessible through a PKCS #11 interface";
+    license = stdenv.lib.licenses.bsd;
+    maintainers = with stdenv.lib.maintainers; [];
+    platforms = with stdenv.lib.platforms; all; 
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3067,6 +3067,8 @@ let
   };
 
   snort = callPackage ../applications/networking/ids/snort { };
+  
+  softhsm = callPackage ../applications/security/softhsm { };
 
   solr = callPackage ../servers/search/solr { };
 


### PR DESCRIPTION
SoftHSM is an implementation of a cryptographic store accessible through a PKCS #11 interface. You can use it to explore PKCS #11 without having a Hardware Security Module. It is being developed as a part of the OpenDNSSEC project. SoftHSM uses Botan for its cryptographic operations.
