### PR TITLE
cc-wrapper: fix on darwin

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -1,4 +1,8 @@
 #! @shell@ -e
+path_backup=$PATH
+if [ -n "@coreutils@" ]; then
+  PATH="@coreutils@/bin:@gnugrep@/bin"
+fi
 
 if [ -n "$NIX_CC_WRAPPER_START_HOOK" ]; then
     source "$NIX_CC_WRAPPER_START_HOOK"
@@ -141,4 +145,5 @@ if [ -n "$NIX_CC_WRAPPER_EXEC_HOOK" ]; then
     source "$NIX_CC_WRAPPER_EXEC_HOOK"
 fi
 
+PATH=$path_backup
 exec @prog@ ${extraBefore[@]} "${params[@]}" "${extraAfter[@]}"

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -9,13 +9,14 @@
 , cc ? null, libc ? null, binutils ? null, coreutils ? null, shell ? stdenv.shell
 , zlib ? null, extraPackages ? [], extraBuildCommands ? ""
 , dyld ? null # TODO: should this be a setup-hook on dyld?
-, isGNU ? false, isClang ? cc.isClang or false
+, isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
 }:
 
 with stdenv.lib;
 
 assert nativeTools -> nativePrefix != "";
-assert !nativeTools -> cc != null && binutils != null && coreutils != null;
+assert !nativeTools ->
+  cc != null && binutils != null && coreutils != null && gnugrep != null;
 assert !nativeLibc -> libc != null;
 
 # For ghdl (the vhdl language provider to gcc) we need zlib in the wrapper.
@@ -37,9 +38,11 @@ stdenv.mkDerivation {
 
   inherit cc shell;
   libc = if nativeLibc then null else libc;
-  binutils = if nativeTools then null else binutils;
-  # The wrapper scripts use 'cat', so we may need coreutils.
-  coreutils = if nativeTools then null else coreutils;
+  binutils = if nativeTools then "" else binutils;
+  # The wrapper scripts use 'cat' and 'grep', so we may need coreutils
+  # and gnugrep.
+  coreutils = if nativeTools then "" else coreutils;
+  gnugrep = if nativeTools then "" else gnugrep;
 
   passthru = { inherit nativeTools nativeLibc nativePrefix isGNU isClang; };
 

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -1,4 +1,8 @@
 #! @shell@ -e
+path_backup=$PATH
+if [ -n "@coreutils@" ]; then
+  PATH="@coreutils@/bin"
+fi
 
 if [ -n "$NIX_GNAT_WRAPPER_START_HOOK" ]; then
     source "$NIX_GNAT_WRAPPER_START_HOOK"
@@ -100,4 +104,5 @@ if [ -n "$NIX_GNAT_WRAPPER_EXEC_HOOK" ]; then
     source "$NIX_GNAT_WRAPPER_EXEC_HOOK"
 fi
 
+PATH=$path_backup
 exec @prog@ ${extraBefore[@]} "${params[@]}" ${extraAfter[@]}

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -1,4 +1,8 @@
 #! @shell@ -e
+path_backup=$PATH
+if [ -n "@coreutils@" ]; then
+  PATH="@coreutils@/bin"
+fi
 
 if [ -n "$NIX_LD_WRAPPER_START_HOOK" ]; then
     source "$NIX_LD_WRAPPER_START_HOOK"
@@ -163,4 +167,5 @@ if [ -n "$NIX_LD_WRAPPER_EXEC_HOOK" ]; then
     source "$NIX_LD_WRAPPER_EXEC_HOOK"
 fi
 
+PATH=$path_backup
 exec @prog@ ${extraBefore[@]} "${params[@]}" ${extra[@]}

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -278,7 +278,7 @@ in rec {
       inherit stdenv shell;
       nativeTools = false;
       nativeLibc  = false;
-      inherit (pkgs) coreutils binutils;
+      inherit (pkgs) coreutils binutils gnugrep;
       inherit (pkgs.darwin) dyld;
       cc   = pkgs.llvmPackages.clang-unwrapped;
       libc = pkgs.darwin.Libsystem;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -64,7 +64,7 @@ rec {
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun =
-    {gccPlain, glibc, binutils, coreutils, name, overrides ? (pkgs: {}), extraBuildInputs ? []}:
+    {gccPlain, glibc, binutils, coreutils, gnugrep, name, overrides ? (pkgs: {}), extraBuildInputs ? []}:
 
     let
 
@@ -93,7 +93,7 @@ rec {
           cc = gccPlain;
           isGNU = true;
           libc = glibc;
-          inherit binutils coreutils;
+          inherit binutils coreutils gnugrep;
           name = name;
           stdenv = stage0.stdenv;
         };
@@ -125,6 +125,7 @@ rec {
     glibc = null;
     binutils = null;
     coreutils = null;
+    gnugrep = null;
     name = null;
 
     overrides = pkgs: {
@@ -160,6 +161,7 @@ rec {
     inherit (stage0.pkgs) glibc;
     binutils = bootstrapTools;
     coreutils = bootstrapTools;
+    gnugrep = bootstrapTools;
     name = "bootstrap-gcc-wrapper";
 
     # Rebuild binutils to use from stage2 onwards.
@@ -184,6 +186,7 @@ rec {
     inherit (stage1.pkgs) glibc;
     binutils = stage1.pkgs.binutils;
     coreutils = bootstrapTools;
+    gnugrep = bootstrapTools;
     name = "bootstrap-gcc-wrapper";
 
     overrides = pkgs: {
@@ -200,6 +203,7 @@ rec {
     gccPlain = bootstrapTools;
     inherit (stage2.pkgs) glibc binutils;
     coreutils = bootstrapTools;
+    gnugrep = bootstrapTools;
     name = "bootstrap-gcc-wrapper";
 
     overrides = pkgs: rec {
@@ -227,7 +231,7 @@ rec {
   # Construct a fourth stdenv that uses the new GCC.  But coreutils is
   # still from the bootstrap tools.
   stage4 = stageFun {
-    inherit (stage3.pkgs) gccPlain glibc binutils;
+    inherit (stage3.pkgs) gccPlain glibc binutils gnugrep;
     coreutils = bootstrapTools;
     name = "";
 
@@ -244,7 +248,7 @@ rec {
         isGNU = true;
         cc = stage4.stdenv.cc.cc;
         libc = stage4.pkgs.glibc;
-        inherit (stage4.pkgs) binutils coreutils;
+        inherit (stage4.pkgs) binutils coreutils gnugrep;
         name = "";
         stdenv = stage4.stdenv;
         shell = stage4.pkgs.bash + "/bin/bash";


### PR DESCRIPTION
The ld-wrapper.sh script calls `readlink` in some circumstances. We need
to ensure that this is the `readlink` from the `coreutils` package so
that flag support is as expected.

Without doing this, the following happens with a trivial `main.c`:

```
nix-env -f "<nixpkgs>" -iA pkgs.clang
$ clang main.c -L /nix/../nix/store/2ankvagznq062x1gifpxwkk7fp3xwy63-xnu-2422.115.4/Library -o a.out
readlink: illegal option -- f
usage: readlink [-n] [file ...]
```

The key element is the `..` in the path supplied to the linker via a
`-L` flag. With this patch, the above invocation works correctly on
darwin, whose native `/usr/bin/readlink` does not support the `-f` flag.

Fixes #6447
