### PR TITLE
lastpass-cli: 0.5.1 -> 0.7.0

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "lastpass-cli-${version}";
 
-  version = "0.5.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "lastpass";
     repo = "lastpass-cli";
     rev = "v${version}";
-    sha256 = "0k2dbfizd6gwd4s8badm50qg2djrh22szd932l1a96mn79q8zb70";
+    sha256 = "18dn4sx173666w6aaqhwcya5x2z3q0fmhg8h76lgdmx8adrhzdzc";
   };
 
   buildInputs = [


### PR DESCRIPTION
Updates `lastpass-cli` from 0.5.1 to 0.7.0

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
