### PR TITLE
autoUpgrade: added a 'dates' option, to allow you to switch when the …

### DIFF
--- a/nixos/modules/installer/tools/auto-upgrade.nix
+++ b/nixos/modules/installer/tools/auto-upgrade.nix
@@ -42,6 +42,17 @@ let cfg = config.system.autoUpgrade; in
         '';
       };
 
+      dates = mkOption {
+        default = "04:40";
+        type = types.str;
+        description = ''
+          Specification (in the format described by
+          <citerefentry><refentrytitle>systemd.time</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry>) of the time at
+          which the update will occur.
+        '';
+      };
+
     };
 
   };
@@ -73,7 +84,7 @@ let cfg = config.system.autoUpgrade; in
         ${config.system.build.nixos-rebuild}/bin/nixos-rebuild switch ${toString cfg.flags}
       '';
 
-      startAt = mkIf cfg.enable "04:40";
+      startAt = optionalString cfg.enable cfg.dates;
     };
 
   };


### PR DESCRIPTION
…upgrade happens.

It uses the same default time as autoUpgrade did previously, so configurations that already use _'autoUpgrade.enable'_ should be fine.

(Note: most of the code here just comes from [nix-gc](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/misc/nix-gc.nix)).

I've only tested this on my machine, so if more tests need to be done, let me know.
