### PR TITLE
aspell: improve the doc string

### DIFF
--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Note: Users should define the `ASPELL_CONF' environment variable to
-  # `dict-dir $HOME/.nix-profile/lib/aspell/' so that they can access
+  # `data-dir $HOME/.nix-profile/lib/aspell/' so that they can access
   # dictionaries installed in their profile.
   #
   # We can't use `$out/etc/aspell.conf' for that purpose since Aspell


### PR DESCRIPTION
It is better to specify data-dir in the environmental variable since
then both the language description files and the dictionaries will be
found. Since dict-dir defaults to data-dir only the latter needs to be
set. See for example https://github.com/NixOS/nixpkgs/issues/1000
