### PR TITLE
fglrx: fix fglrx_dri.so

### DIFF
--- a/pkgs/os-specific/linux/ati-drivers/builder.sh
+++ b/pkgs/os-specific/linux/ati-drivers/builder.sh
@@ -6,15 +6,15 @@ set -x
 
 die(){ echo $@; exit 1; }
 
-# custom unpack:
-mkdir fglrx
+mkdir fglrx # custom unpack:
 cd fglrx
 unzip $src
 cd ..
 run_file=$(echo fglrx/amd-driver-installer-*)
 sh $run_file --extract .
 
-eval "$patchPhase"
+eval "$patchPhase1"
+eval "$patchPhase2"
 
 case "$system" in
   x86_64-linux)
@@ -31,6 +31,7 @@ case "$system" in
 esac
 
 # Handle/Build the kernel module.
+
 if test -z "$libsOnly"; then
 
   kernelVersion=$(cd ${kernel}/lib/modules && ls)
@@ -41,6 +42,7 @@ if test -z "$libsOnly"; then
   # current kbuild infrastructure allows using CONFIG_* defines
   # but ati sources don't use them yet..
   # copy paste from make.sh
+
   setSMP(){
 
     linuxincludes=$kernelBuild/include
@@ -68,7 +70,6 @@ if test -z "$libsOnly"; then
     if [ "$SMP" = 0 ]; then
       echo "assuming default: SMP=$SMP"
     fi
-
     # act on final result
     if [ ! "$SMP" = 0 ]; then
       smp="-SMP"
@@ -147,19 +148,15 @@ if test -z "$libsOnly"; then
 fi
 
 { # install
-
   mkdir -p $out/lib/xorg
-
   cp -r common/usr/include $out
   cp -r common/usr/sbin $out
   cp -r common/usr/share $out
-  cp -r common/usr/X11R6 $out
-
+  mkdir $out/bin/
+  cp -f common/usr/X11R6/bin/* $out/bin/
   # cp -r arch/$arch/lib $out/lib
-
   # what are those files used for?
   cp -r common/etc $out
-
   cp -r $DIR_DEPENDING_ON_XORG_VERSION/usr/X11R6/$lib_arch/* $out/lib/xorg
 
   # install kernel module
@@ -179,30 +176,26 @@ fi
   cp -r $TMP/arch/$arch/usr/X11R6/$lib_arch/modules/dri/* $out/lib
   cp -r $TMP/arch/$arch/usr/X11R6/$lib_arch/*.so* $out/lib
   cp -r $TMP/arch/$arch/usr/X11R6/$lib_arch/fglrx/fglrx-libGL.so.1.2 $out/lib/fglrx-libGL.so.1.2
-
   cp -r $TMP/arch/$arch/usr/$lib_arch/* $out/lib
-
-  # cp -r $TMP/arch/$arch/usr/$lib_arch/* $out/lib
   ln -s libatiuki.so.1.0 $out/lib/libatiuki.so.1
   ln -s fglrx-libGL.so.1.2 $out/lib/libGL.so.1
   ln -s fglrx-libGL.so.1.2 $out/lib/libGL.so
-
-  ln -s libfglrx_gamma.so.1.0 $out/lib/libfglrx_gamma.so.1
+  # FIXME : This file is missing or has changed versions
+  #ln -s libfglrx_gamma.so.1.0 $out/lib/libfglrx_gamma.so.1
   # make xorg use the ati version
   ln -s $out/lib/xorg/modules/extensions/{fglrx/fglrx-libglx.so,libglx.so}
-
   # Correct some paths that are hardcoded into binary libs.
   if [ "$arch" ==  "x86_64" ]; then
     for lib in \
-      lib/xorg/modules/extensions/fglrx/fglrx-libglx.so \
-      lib/xorg/modules/glesx.so \
-      lib/dri/fglrx_dri.so \
-      lib/fglrx_dri.so \
-      lib/fglrx-libGL.so.1.2
+      xorg/modules/extensions/fglrx/fglrx-libglx.so \
+      xorg/modules/glesx.so \
+      dri/fglrx_dri.so \
+      fglrx_dri.so \
+      fglrx-libGL.so.1.2
     do
       oldPaths="/usr/X11R6/lib/modules/dri"
       newPaths="/run/opengl-driver/lib/dri"
-      sed -i -e "s|$oldPaths|$newPaths|" $out/$lib
+      sed -i -e "s|$oldPaths|$newPaths|" $out/lib/$lib
     done
   else
     oldPaths="/usr/X11R6/lib32/modules/dri\x00/usr/lib32/dri"
@@ -211,34 +204,45 @@ fi
       $out/lib/xorg/modules/extensions/fglrx/fglrx-libglx.so
 
     for lib in \
-      lib/dri/fglrx_dri.so \
-      lib/fglrx_dri.so \
-      lib/xorg/modules/glesx.so
+      dri/fglrx_dri.so \
+      fglrx_dri.so \
+      xorg/modules/glesx.so
     do
       oldPaths="/usr/X11R6/lib32/modules/dri/"
       newPaths="/run/opengl-driver-32/lib/dri"
-      sed -i -e "s|$oldPaths|$newPaths|" $out/$lib
+      sed -i -e "s|$oldPaths|$newPaths|" $out/lib/$lib
     done
 
     oldPaths="/usr/X11R6/lib32/modules/dri\x00"
     newPaths="/run/opengl-driver-32/lib/dri"
     sed -i -e "s|$oldPaths|$newPaths|" $out/lib/fglrx-libGL.so.1.2
   fi
-
   # libstdc++ and gcc are needed by some libs
-  patchelf --set-rpath $gcc/$lib_arch $out/lib/libatiadlxx.so
-  patchelf --set-rpath $gcc/$lib_arch $out/lib/xorg/modules/glesx.so
+  for pelib1 in \
+    fglrx_dri.so \
+    dri/fglrx_dri.so
+  do
+    patchelf --remove-needed libX11.so.6 $out/lib/$pelib1
+  done
+
+  for pelib2 in \
+    libatiadlxx.so \
+    xorg/modules/glesx.so \
+    dri/fglrx_dri.so \
+    fglrx_dri.so \
+    libaticaldd.so
+  do
+    patchelf --set-rpath $gcc/$lib_arch/ $out/lib/$pelib2
+  done
 }
 
 if test -z "$libsOnly"; then
 
 { # build samples
   mkdir -p $out/bin
-
   mkdir -p samples
   cd samples
   tar xfz ../common/usr/src/ati/fglrx_sample_source.tgz
-
   eval "$patchPhaseSamples"
 
   ( # build and install fgl_glxgears
@@ -252,27 +256,42 @@ if test -z "$libsOnly"; then
 
   true || ( # build and install
 
+    ###
+    ## FIXME ?
     # doesn't build  undefined reference to `FGLRX_X11SetGamma'
-    # wich should be contained in -lfglrx_gamma
+    # which should be contained in -lfglrx_gamma
+    # This should create $out/lib/libfglrx_gamma.so.1.0 ? because there is
+    # a symlink named libfglrx_gamma.so.1 linking to libfglrx_gamma.so.1.0 in $out/lib/
 
     cd programs/fglrx_gamma
     gcc -fPIC -I${libXxf86vm}/include \
 	    -I${xf86vidmodeproto}/include \
 	    -I$out/X11R6/include \
 	    -L$out/lib \
-	    -Wall -lm -lfglrx_gamma -lX11 -lXext -o fglrx_xgamma fglrx_xgamma.c 
+	    -Wall -lm -lfglrx_gamma -lX11 -lXext -o $out/bin/fglrx_xgamma fglrx_xgamma.c 
   )
 
-  { # copy binaries and wrap them:
+  {
+    # patch and copy statically linked qt libs used by amdcccle
+    patchelf --set-interpreter $(echo $glibc/lib/ld-linux*.so.2) $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtCore.so.4 &&
+    patchelf  --set-rpath $gcc/$lib_arch/ $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtCore.so.4 &&
+    patchelf --set-rpath $gcc/$lib_arch/:$out/share/ati/:$libXrender/lib/:$libSM/lib/:$libICE/lib/:$libfontconfig/lib/:$libfreetype/lib/ $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtGui.so.4 &&
+    mkdir -p $out/share/ati
+    cp -r $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtCore.so.4 $out/share/ati/
+    cp -r $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtGui.so.4 $out/share/ati/
+    # copy binaries and wrap them:
     BIN=$TMP/arch/$arch/usr/X11R6/bin
-    cp $BIN/* $out/bin
+    patchelf --set-rpath $gcc/$lib_arch/:$out/share/ati/:$libXinerama/lib/:$libXrandr/lib/ $TMP/arch/$arch/usr/X11R6/bin/amdcccle
+    patchelf --set-rpath $libXrender/lib/:$libXrandr/lib/ $TMP/arch/$arch/usr/X11R6/bin/aticonfig
+    patchelf --shrink-rpath $BIN/amdcccle
     for prog in $BIN/*; do
-      patchelf --set-interpreter $(echo $glibc/lib/ld-linux*.so.2) $out/bin/$(basename $prog)
-      wrapProgram $out/bin/$(basename $prog) --prefix LD_LIBRARY_PATH : $out/lib:$gcc/lib:$qt4/lib:$LD_LIBRARY_PATH
+      cp -f $prog $out/bin &&
+      patchelf --set-interpreter $(echo $glibc/lib/ld-linux*.so.2) $out/bin/$(basename $prog) &&
+      wrapProgram $out/bin/$(basename $prog) --prefix LD_LIBRARY_PATH : $out/lib/:$gcc/lib/:$out/share/ati/:$libXinerama/lib/:$libXrandr/lib/:$libfontconfig/lib/:$libfreetype/lib/:$LD_LIBRARY_PATH
     done
   }
 
-  rm -fr $out/lib/modules/fglrx # don't think those .a files are needed. They cause failure of the mod
+  rm -f $out/lib/fglrx/switchlibglx && rm -f $out/lib/fglrx/switchlibGL
 
 }
 

--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -1,9 +1,6 @@
-{ stdenv, fetchurl, kernel ? null, which, imake
-, mesa # for fgl_glxgears
-, libXxf86vm, xf86vidmodeproto # for fglrx_gamma
-, xorg, makeWrapper, glibc, patchelf
-, unzip
-, qt4 # for amdcccle
+{ stdenv, fetchurl, kernel ? null, which
+, xorg, makeWrapper, glibc, patchelf, unzip
+, fontconfig, freetype, mesa # for fgl_glxgears
 , # Whether to build the libraries only (i.e. not the kernel module or
   # driver utils). Used to support 32-bit binaries on 64-bit
   # Linux.
@@ -11,6 +8,15 @@
 }:
 
 assert (!libsOnly) -> kernel != null;
+
+with stdenv.lib;
+
+let
+  version = "15.7";
+in
+
+# This derivation requires a maximum of gcc49, Linux kernel 4.1 and xorg.xserver 1.17
+# and will not build or run using versions newer
 
 # If you want to use a different Xorg version probably
 # DIR_DEPENDING_ON_XORG_VERSION in builder.sh has to be adopted (?)
@@ -20,23 +26,37 @@ assert (!libsOnly) -> kernel != null;
 # See http://thread.gmane.org/gmane.linux.distributions.nixos/4145 for a
 # workaround (TODO)
 
-# The gentoo ebuild contains much more magic and is usually a great resource to
-# find patches :)
+# The gentoo ebuild contains much more "magic" and is usually a great resource to
+# find patches XD
 
 # http://wiki.cchtml.com/index.php/Main_Page
 
-# There is one issue left:
+# 
 # /usr/lib/dri/fglrx_dri.so must point to /run/opengl-driver/lib/fglrx_dri.so
-
-with stdenv.lib;
+# This is done in the builder script.
 
 stdenv.mkDerivation {
-  name = "ati-drivers-15.7" + (optionalString (!libsOnly) "-${kernel.version}");
+
+  linuxonly =
+    if stdenv.system == "i686-linux" then
+      true
+    else if stdenv.system == "x86_64-linux" then
+      true
+    else throw "ati-drivers are Linux only. Sorry. The build was stopped.";
+
+  name = "ati-drivers-${version}" + (optionalString (!libsOnly) "-${kernel.version}");
 
   builder = ./builder.sh;
-
-  inherit libXxf86vm xf86vidmodeproto;
   gcc = stdenv.cc.cc;
+  libXinerama = xorg.libXinerama;
+  libXrandr = xorg.libXrandr;
+  libXrender = xorg.libXrender;
+  libXxf86vm = xorg.libXxf86vm;
+  xf86vidmodeproto = xorg.xf86vidmodeproto;
+  libSM = xorg.libSM;
+  libICE = xorg.libICE;
+  libfreetype = freetype;
+  libfontconfig = fontconfig;
 
   src = fetchurl {
     url = "http://www2.ati.com/drivers/linux/amd-driver-installer-15.20.1046-x86.x86_64.zip";
@@ -44,16 +64,20 @@ stdenv.mkDerivation {
     curlOpts = "--referer http://support.amd.com/en-us/download/desktop?os=Linux%20x86_64";
   };
 
-  patchPhase = "patch -p1 < ${./kernel-api-fixes.patch}";
   patchPhaseSamples = "patch -p2 < ${./patch-samples.patch}";
+  patchPhase1 = "patch -p1 < ${./kernel-api-fixes.patch}";
+  patchPhase2 = "patch -p1 < ${./fglrx_gpl_symbol.patch}";
 
   buildInputs =
-    [ xorg.libXext xorg.libX11 xorg.libXinerama
-      xorg.libXrandr which imake makeWrapper
+    [ xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM
+      xorg.libXrandr xorg.libXxf86vm xorg.xf86vidmodeproto xorg.imake xorg.libICE
       patchelf
       unzip
       mesa
-      qt4
+      fontconfig
+      freetype
+      makeWrapper
+      which
     ];
 
   inherit libsOnly;
@@ -63,26 +87,37 @@ stdenv.mkDerivation {
   inherit glibc /* glibc only used for setting interpreter */;
 
   LD_LIBRARY_PATH = stdenv.lib.concatStringsSep ":"
-    [ "${xorg.libXrandr}/lib"
-      "${xorg.libXrender}/lib"
-      "${xorg.libXext}/lib"
-      "${xorg.libX11}/lib"
-      "${xorg.libXinerama}/lib"
+    [ "${xorg.libXrandr}/lib/"
+      "${xorg.libXrender}/lib/"
+      "${xorg.libXext}/lib/"
+      "${xorg.libX11}/lib/"
+      "${xorg.libXinerama}/lib/"
+      "${xorg.libSM}/lib/"
+      "${xorg.libICE}/lib/"
+      "${stdenv.cc.cc}/lib/"
     ];
 
   # without this some applications like blender don't start, but they start
   # with nvidia. This causes them to be symlinked to $out/lib so that they
   # appear in /run/opengl-driver/lib which get's added to LD_LIBRARY_PATH
-  extraDRIlibs = [ xorg.libXext ];
 
-  inherit mesa qt4; # only required to build examples and amdcccle
+  extraDRIlibs = [ xorg.libXrandr xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM xorg.libICE ];
+
+  inherit mesa; # only required to build the examples
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "ATI drivers";
+    description = "ATI Catalyst display drivers";
     homepage = http://support.amd.com/us/gpudownload/Pages/index.aspx;
     license = licenses.unfree;
     maintainers = with maintainers; [ marcweber offline jgeerds ];
     platforms = platforms.linux;
     hydraPlatforms = [];
+    # Copied from the nvidia default.nix to prevent a store collision.
+    priority = 4;
   };
+
+
+
 }

--- a/pkgs/os-specific/linux/ati-drivers/fglrx_gpl_symbol.patch
+++ b/pkgs/os-specific/linux/ati-drivers/fglrx_gpl_symbol.patch
@@ -1,0 +1,11 @@
+--- 13.1/common/lib/modules/fglrx/build_mod/firegl_public.c	2013-01-15 22:33:27.000000000 +0100
++++ 13.1/common/lib/modules/fglrx/build_mod/firegl_public.c	2014-08-18 20:05:44.327520475 +0200
+@@ -250,7 +250,7 @@
+ #endif
+ 
+ #ifdef MODULE_LICENSE
+-MODULE_LICENSE("Proprietary. (C) 2002 - ATI Technologies, Starnberg, GERMANY");
++MODULE_LICENSE("GPL\0Proprietary. (C) 2002 - ATI Technologies, Starnberg, GERMANY");
+ #endif
+ #ifdef MODULE_DEVICE_TABLE
+ MODULE_DEVICE_TABLE(pci, fglrx_pci_table);


### PR DESCRIPTION
Attempting to fix #11740. I am on 15.09 stable. After the changes, I get a setfault upon running glxinfo:

```
# LIBGL_DEBUG=verbose glxinfo
name of display: :0.0
libGL: AtiGetClientDriverName: 15.20.3 fglrx (screen 0)
ukiDynamicMajor: found major device number 247
ukiDynamicMajor: found major device number 247
ukiDynamicMajor: found major device number 247
ukiOpenDevice: node name is /dev/ati/card0
ukiOpenDevice: open result is 4, (OK)
ukiGetBusid returned 'PCI:2:0:0'
ukiOpenDevice: node name is /dev/ati/card1
ukiOpenDevice: open result is 4, (OK)
ukiGetBusid returned 'PCI:3:0:0'
ukiOpenDevice: node name is /dev/ati/card2
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card3
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card4
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card5
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card6
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card7
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card8
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card9
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card10
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card11
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card12
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card13
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card14
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiOpenDevice: node name is /dev/ati/card15
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: open result is -1, (No such device)
ukiOpenDevice: Open failed
ukiDynamicMajor: found major device number 247
ukiOpenByBusid: Searching for BusID PCI:2:0:0
ukiOpenDevice: node name is /dev/ati/card0
ukiOpenDevice: open result is 4, (OK)
ukiOpenByBusid: ukiOpenMinor returns 4
ukiOpenByBusid: ukiGetBusid reports PCI:2:0:0
libGL: AtiGetClientDriverName: 15.20.3 fglrx (screen 1)
ukiDynamicMajor: found major device number 247
ukiDynamicMajor: found major device number 247
ukiOpenByBusid: Searching for BusID PCI:2:0:0
ukiOpenDevice: node name is /dev/ati/card0
ukiOpenDevice: open result is 5, (OK)
ukiOpenByBusid: ukiOpenMinor returns 5
ukiOpenByBusid: ukiGetBusid reports PCI:2:0:0
Segmentation fault
```

But I no longer need the `/usr/X11R6/lib64/modules/dri` -> `/run/opengl-driver/lib/dri symlink`, and `fglrx_dri.so` seems to have everything resolved:

```
$ ldd /run/opengl-driver/lib/dri/fglrx_dri.so
    linux-vdso.so.1 (0x00007ffc8c79f000)
    libstdc++.so.6 => /nix/store/81gmdmvsi9a3iyhk4hnxamm8hg8d82sx-gcc-4.9.3/lib64/libstdc++.so.6 (0x00007fbaa38de000)
    libpthread.so.0 => /nix/store/npfsi1d9ka8zwnxzn3sr08hbwvpapyk7-glibc-2.21/lib/libpthread.so.0 (0x00007fbaa36c1000)
    librt.so.1 => /nix/store/npfsi1d9ka8zwnxzn3sr08hbwvpapyk7-glibc-2.21/lib/librt.so.1 (0x00007fbaa34b9000)
    libdl.so.2 => /nix/store/npfsi1d9ka8zwnxzn3sr08hbwvpapyk7-glibc-2.21/lib/libdl.so.2 (0x00007fbaa32b5000)
    libm.so.6 => /nix/store/npfsi1d9ka8zwnxzn3sr08hbwvpapyk7-glibc-2.21/lib/libm.so.6 (0x00007fbaa2fb2000)
    libgcc_s.so.1 => /nix/store/81gmdmvsi9a3iyhk4hnxamm8hg8d82sx-gcc-4.9.3/lib64/libgcc_s.so.1 (0x00007fbaa2d9c000)
    libXext.so.6 => /run/opengl-driver/lib/libXext.so.6 (0x00007fbaa2b8a000)
    libX11.so.6 => /run/opengl-driver/lib/libX11.so.6 (0x00007fbaa284d000)
    libc.so.6 => /nix/store/npfsi1d9ka8zwnxzn3sr08hbwvpapyk7-glibc-2.21/lib/libc.so.6 (0x00007fbaa24ad000)
    /nix/store/npfsi1d9ka8zwnxzn3sr08hbwvpapyk7-glibc-2.21/lib64/ld-linux-x86-64.so.2 (0x00007fbaa644b000)
    libxcb.so.1 => /nix/store/dfwj9b6vb2g65asg681yw2w8knpmlqq4-libxcb-1.11/lib/libxcb.so.1 (0x00007fbaa228f000)
    libXau.so.6 => /nix/store/p408ns8dn0cfi4z4fzd6f10b9pvlfhss-libXau-1.0.8/lib/libXau.so.6 (0x00007fbaa208c000)
    libXdmcp.so.6 => /nix/store/xm4jqqq9m2nb9mczvv02z1lsyj225kvf-libXdmcp-1.1.2/lib/libXdmcp.so.6 (0x00007fbaa1e87000)
```

Any feedback on the changes, or especially does anyone have an idea of why the segfault is happening?
