### PR TITLE
Add shell env to buildHex packages.

### DIFF
--- a/pkgs/development/erlang-modules/build-erlang.nix
+++ b/pkgs/development/erlang-modules/build-erlang.nix
@@ -1,3 +1,6 @@
+# This file is not used not tested at this time, build-hex.nix is the currently
+# main vehicle of bringing Erlang packages in.
+
 { stdenv, erlang, rebar, openssl, libyaml }:
 
 { name, version

--- a/pkgs/development/erlang-modules/build-hex.nix
+++ b/pkgs/development/erlang-modules/build-hex.nix
@@ -1,5 +1,5 @@
 { stdenv, erlang, rebar3, openssl, libyaml, fetchHex, fetchFromGitHub,
-  rebar3-pc }:
+  rebar3-pc, buildEnv }:
 
 { name, version, sha256
 , hexPkg ? name
@@ -11,79 +11,99 @@
 
 with stdenv.lib;
 
-stdenv.mkDerivation (attrs // {
-  name = "${name}-${version}";
+let
+  plugins = pluginDeps ++ (if compilePorts then [rebar3-pc] else []);
+  getDeps = drv: [drv] ++ (map getDeps drv.erlangDeps);
+  recursiveDeps = unique (flatten (map getDeps erlangDeps));
+  recursivePluginsDeps = unique (flatten (map getDeps plugins));
 
-  buildInputs = buildInputs ++ [ erlang rebar3 openssl libyaml ];
-
-  src = fetchHex {
-    pkg = hexPkg;
-    inherit version;
-    inherit sha256;
+  erlEnv = drv: buildEnv {
+    name = "erlang-env-${drv.name}";
+    paths = [ drv ] ++ recursiveDeps;
+    ignoreCollisions = false;
+    meta = drv.meta;
   };
 
-  postPatch = ''
-    rm -f rebar rebar3
-    if [ -e "src/${name}.app.src" ]; then
-      sed -i -e 's/{ *vsn *,[^}]*}/{vsn, "${version}"}/' "src/${name}.app.src"
-    fi
-
-    ${if compilePorts then ''
-    echo "{plugins, [pc]}." >> rebar.config
-    '' else ''''}
-
-    ${rebar3.setupRegistry}
-
-    ${postPatch}
-  '';
-
-  configurePhase = let
-    plugins = pluginDeps ++ (if compilePorts then [rebar3-pc] else []);
-    getDeps = drv: [drv] ++ (map getDeps drv.erlangDeps);
-    recursiveDeps = unique (flatten (map getDeps erlangDeps));
-    recursivePluginsDeps = unique (flatten (map getDeps plugins));
-  in ''
-    runHook preConfigure
-    ${concatMapStrings (dep: ''
-      header "linking erlang dependency ${dep}"
-      ln -s "${dep}" "_build/default/lib/${dep.packageName}"
-      stopNest
-    '') recursiveDeps}
-    ${concatMapStrings (dep: ''
-      header "linking rebar3 plugins ${dep}"
-      ln -s "${dep}" "_build/default/plugins/${dep.packageName}"
-      stopNest
-    '') recursivePluginsDeps}
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-    HOME=. rebar3 compile
-    ${if compilePorts then ''
-    HOME=. rebar3 pc compile
-    '' else ''''}
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir "$out"
-    for reldir in src ebin priv include; do
-      fd="_build/default/lib/${name}/$reldir"
-      [ -d "$fd" ] || continue
-      cp -Hrt "$out" "$fd"
-      success=1
-    done
-    runHook postInstall
-  '';
-
-  meta = {
-    inherit (erlang.meta) platforms;
-  } // meta;
-
-  passthru = {
-    packageName = name;
-    inherit erlangDeps;
+  shell = drv: let
+    drvEnv = erlEnv drv;
+  in stdenv.mkDerivation {
+    name = "interactive-shell-${drv.name}";
+    nativeBuildInputs = [ erlang drvEnv ];
+    shellHook = ''
+      export ERL_LIBS="${drvEnv}";
+    '';
   };
-})
+  pkg = self: stdenv.mkDerivation (attrs // {
+    name = "${name}-${version}";
+
+    buildInputs = buildInputs ++ [ erlang rebar3 openssl libyaml ];
+
+    src = fetchHex {
+      pkg = hexPkg;
+      inherit version;
+      inherit sha256;
+    };
+
+    postPatch = ''
+      rm -f rebar rebar3
+      if [ -e "src/${name}.app.src" ]; then
+        sed -i -e 's/{ *vsn *,[^}]*}/{vsn, "${version}"}/' "src/${name}.app.src"
+      fi
+
+      ${if compilePorts then ''
+        echo "{plugins, [pc]}." >> rebar.config
+      '' else ''''}
+
+      ${rebar3.setupRegistry}
+
+      ${postPatch}
+    '';
+
+    configurePhase = ''
+      runHook preConfigure
+      ${concatMapStrings (dep: ''
+        header "linking erlang dependency ${dep}"
+        ln -s "${dep}/${dep.name}" "_build/default/lib/${dep.name}"
+        stopNest
+      '') recursiveDeps}
+      ${concatMapStrings (dep: ''
+        header "linking rebar3 plugins ${dep}"
+        ln -s "${dep}/${dep.name}" "_build/default/plugins/${dep.name}"
+        stopNest
+      '') recursivePluginsDeps}
+      runHook postConfigure
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      HOME=. rebar3 compile
+      ${if compilePorts then ''
+        HOME=. rebar3 pc compile
+      '' else ''''}
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/${name}"
+      for reldir in src ebin priv include; do
+        fd="_build/default/lib/${name}/$reldir"
+        [ -d "$fd" ] || continue
+        cp -Hrt "$out/${name}" "$fd"
+        success=1
+      done
+      runHook postInstall
+    '';
+
+    meta = {
+      inherit (erlang.meta) platforms;
+    } // meta;
+
+    passthru = {
+      packageName = name;
+      env = shell self;
+      inherit erlangDeps;
+    };
+  });
+in
+  fix pkg


### PR DESCRIPTION
This adds erlangPackages.${name}.env, which is usable to launch a shell
with the package and it's dependencies like this:

```
nix-shell -A erlangPackages.lager.env
```

This required:

1) refactoring buildHex to become a fixed-point function,
2) moves output of a package into $out/${name},
3) introduces erlEnv (buildEnv, which links in package and it's deps
   into one directory - a super-simple plagiarization of
   haskellPackages.compiler.ghcWithPackages) and
4) shell function producing a un-buildable derivation to be used by
   nix-shell
