### PR TITLE
pkgs.slurm-llnl-full: Add full variant of slurm-llnl

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchurl, python, munge, perl, pam, openssl, mysql }:
-
-#TODO: add sview support based on gtk2
+{ stdenv, fetchurl, pkgconfig, curl, python, munge, perl, pam, openssl,
+  ncurses, mysql, gtk }:
 
 stdenv.mkDerivation rec {
   name = "slurm-llnl-${version}";
@@ -11,12 +10,12 @@ stdenv.mkDerivation rec {
     sha256 = "05si1cn7zivggan25brsqfdw0ilvrlnhj96pwv16dh6vfkggzjr1";
   };
 
-  buildInputs = [ python munge perl pam openssl mysql.lib ];
+  buildInputs = [ pkgconfig curl python munge perl pam openssl mysql.lib ncurses gtk ];
 
-  configureFlags = ''
-    --with-munge=${munge}
-    --with-ssl=${openssl}
-  '';
+  configureFlags =
+    [ "--with-munge=${munge}"
+      "--with-ssl=${openssl}"
+    ] ++ stdenv.lib.optional (gtk == null)  "--disable-gtktest";
 
   preConfigure = ''
     substituteInPlace ./doc/html/shtml2html.py --replace "/usr/bin/env python" "${python.interpreter}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9556,7 +9556,9 @@ let
 
   storm = callPackage ../servers/computing/storm { };
 
-  slurm-llnl = callPackage ../servers/computing/slurm { };
+  slurm-llnl = callPackage ../servers/computing/slurm { gtk = null; };
+
+  slurm-llnl-full = appendToName "full" (callPackage ../servers/computing/slurm { });
 
   tomcat5 = callPackage ../servers/http/tomcat/5.0.nix { };
 


### PR DESCRIPTION
Add a variant of slurm-llnl that includes sview (based on gtk).
pkgs.slurm-llnl also gains the ncurses-based smap tool.

cc @jagajaga 
