### PR TITLE
autoUpgrade: pulling 'dates' option through to master

### DIFF
--- a/nixos/modules/installer/tools/auto-upgrade.nix
+++ b/nixos/modules/installer/tools/auto-upgrade.nix
@@ -42,6 +42,17 @@ let cfg = config.system.autoUpgrade; in
         '';
       };
 
+      dates = mkOption {
+        default = "04:40";
+        type = types.str;
+        description = ''
+          Specification (in the format described by
+          <citerefentry><refentrytitle>systemd.time</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry>) of the time at
+          which the update will occur.
+        '';
+      };
+
     };
 
   };
@@ -73,7 +84,7 @@ let cfg = config.system.autoUpgrade; in
         ${config.system.build.nixos-rebuild}/bin/nixos-rebuild switch ${toString cfg.flags}
       '';
 
-      startAt = mkIf cfg.enable "04:40";
+      startAt = optionalString cfg.enable cfg.dates;
     };
 
   };


### PR DESCRIPTION
Same change as my [Pull Request from yesterday](https://github.com/NixOS/nixpkgs/pull/11808), except this time it's going through to Master, instead of just release 15.09.
