### PR TITLE
djvu2pdf: make work in nix-shell

### DIFF
--- a/pkgs/tools/typesetting/djvu2pdf/default.nix
+++ b/pkgs/tools/typesetting/djvu2pdf/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, djvulibre, ghostscript }:
+{ stdenv, makeWrapper, fetchurl, djvulibre, ghostscript, which }:
 
 stdenv.mkDerivation rec {
   version = "0.9.2";
@@ -9,12 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0v2ax30m7j1yi4m02nzn9rc4sn4vzqh5vywdh96r64j4pwvn5s5g";
   };
 
-  buildInputs = [ pkgconfig ];
-  propagatedUserEnvPkgs = [ djvulibre ghostscript ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp -p djvu2pdf $out/bin
+    wrapProgram $out/bin/djvu2pdf --prefix PATH : ${ghostscript}/bin:${djvulibre}/bin:${which}/bin
+
     mkdir -p $out/man/man1
     cp -p djvu2pdf.1.gz $out/man/man1
   '';
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
     description = "Creates djvu files from PDF files";
     homepage = http://0x2a.at/s/projects/djvu2pdf;
     license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.all;
     inherit version;
   };
 }


### PR DESCRIPTION
Currently when run with `nix-shell -p djvu2pdf`, the command `djvu2pdf` fails:

```
[gebner:~] $ nix-shell -p djvu2pdf
[nix-shell] [gebner:~] $ djvu2pdf
Error: /nix/store/rj1ki2fdfvkbhrwww83dml1a5dckjn75-djvu2pdf-0.9.2/bin/djvu2pdf: ddjvu not found. Install djvulibre.
```

This PR adds a wrapper that adds the necessary dependencies to PATH.
