### PR TITLE
gupnp-tools: add required icons, rename from gupnptools

### DIFF
--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -1,4 +1,4 @@
-{fetchurl, stdenv, gupnp, gssdp, pkgconfig, gtk3, libuuid, intltool, gupnp_av, gnome3, makeWrapper}:
+{fetchurl, stdenv, gupnp, gssdp, pkgconfig, gtk3, libuuid, intltool, gupnp_av, gnome3, gnome2, makeWrapper}:
 
 stdenv.mkDerivation rec {
   name = "gupnp-tools-${version}";
@@ -9,11 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "160dgh9pmlb85qfavwqz46lqawpshs8514bx2b57f9rbiny8kbij";
   };
 
-  buildInputs = [gupnp libuuid gssdp pkgconfig gtk3 intltool gupnp_av 
-                 gnome3.defaultIconTheme gnome3.gnome_themes_standard makeWrapper];
+  buildInputs = [gupnp libuuid gssdp pkgconfig gtk3 intltool gupnp_av
+                 gnome2.gnome_icon_theme makeWrapper];
 
   postInstall = ''
-    wrapProgram "$out/bin/gupnp-av-cp" --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome3.defaultIconTheme}/share:$out/share"
-    wrapProgram "$out/bin/gupnp-universal-cp" --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome3.defaultIconTheme}/share:$out/share"
+    for program in gupnp-av-cp gupnp-universal-cp; do
+      wrapProgram "$out/bin/$program" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share:${gnome3.gnome_themes_standard}/share:${gnome2.gnome_icon_theme}/share:$out/share"
+    done
   '';
+
+  meta = {
+    platforms = stdenv.lib.platforms.linux;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1805,7 +1805,7 @@ let
 
   gupnp_igd = callPackage ../development/libraries/gupnp-igd {};
 
-  gupnptools = callPackage ../tools/networking/gupnp-tools {};
+  gupnp-tools = callPackage ../tools/networking/gupnp-tools {};
 
   gvpe = callPackage ../tools/networking/gvpe { };
 
@@ -15856,6 +15856,7 @@ aliases = with self; rec {
   firefoxWrapper = firefox-wrapper;
   fuse_exfat = exfat;                   # 2015-09-11
   grantlee5 = qt5.grantlee;  # added 2015-12-19
+  gupnptools = gupnp-tools;  # added 2015-12-19
   htmlTidy = html-tidy;  # added 2014-12-06
   inherit (haskell.compiler) jhc uhc;   # 2015-05-15
   inotifyTools = inotify-tools;


### PR DESCRIPTION
This fixes #11690. I was able to run gupnp-universal-cp and find a minidlna instance with it.
