### PR TITLE
Revert change from cp -v to cp -r in fira-code.

### DIFF
--- a/pkgs/data/fonts/fira-code/default.nix
+++ b/pkgs/data/fonts/fira-code/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/fonts/opentype
-    cp -r *.otf $out/share/fonts/opentype
+    cp -v *.otf $out/share/fonts/opentype
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Mistakenly used `-r` in #11842.
