### PR TITLE
lsyncd: 2.1.5 -> 2.1.6

### DIFF
--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -1,32 +1,27 @@
-{ stdenv, fetchFromGitHub, automake, autoconf, lua, pkgconfig, rsync,
+{ stdenv, fetchFromGitHub, cmake, lua, pkgconfig, rsync,
   asciidoc, libxml2, docbook_xml_dtd_45, docbook_xml_xslt, libxslt }:
 
 stdenv.mkDerivation rec {
   name = "lsyncd-${version}";
-  version = "2.1.5";
+  version = "2.1.6";
 
   src = fetchFromGitHub {
     owner = "axkibe";
     repo = "lsyncd";
     rev = "release-${version}";
-    sha256 = "0jvr2rv34jyjrv7188vdv1z8vgvm4wydqwsp9x5ksfzh9drbq5gn";
+    sha256 = "1cab96h4qfyapk7lb682j1d8k0hpv7h9pl41vdgc0vr4bq4c3ij2";
   };
 
-  patches = [ ./configure-a2x-fix.patch ];
-
-  preConfigurePhase = ''
+  patchPhase = ''
     substituteInPlace default-rsync.lua \
-      --replace "binary        = '/usr/bin/rsync'," "binary        = '${rsync}/bin/rsync',"
+      --replace "/usr/bin/rsync" "${rsync}/bin/rsync"
   '';
 
-  configurePhase = ''
-    ./autogen.sh --prefix=$out
-    ./configure --prefix=$out
-  '';
+  dontUseCmakeBuildDir = true;
 
   buildInputs = [
     rsync
-    automake autoconf lua pkgconfig
+    cmake lua pkgconfig
     asciidoc libxml2 docbook_xml_dtd_45 docbook_xml_xslt libxslt
   ];
 


### PR DESCRIPTION
Built locally on earlier version of nixpkgs.
