### PR TITLE
gradle: 2.8 -> 2.9

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -34,12 +34,12 @@ rec {
     };
   };
 
-  gradle28 = gradleGen rec {
-    name = "gradle-2.8";
+  gradleLatest = gradleGen rec {
+    name = "gradle-2.9";
 
     src = fetchurl {
       url = "http://services.gradle.org/distributions/${name}-bin.zip";
-      sha256 = "1jq3m6ihvcxyp37mwsg3i8li9hd6rpv8ri8ih2mgvph4y71bk3d8";
+      sha256 = "c9159ec4362284c0a38d73237e224deae6139cbde0db4f0f44e1c7691dd3de2f";
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1809,7 +1809,7 @@ let
   pgf_graphics = callPackage ../tools/graphics/pgf { };
 
   pigz = callPackage ../tools/compression/pigz { };
-  
+
   pixz = callPackage ../tools/compression/pixz { };
 
   pxz = callPackage ../tools/compression/pxz { };
@@ -2985,7 +2985,7 @@ let
 
   samplicator = callPackage ../tools/networking/samplicator { };
 
-  screen = callPackage ../tools/misc/screen { 
+  screen = callPackage ../tools/misc/screen {
     inherit (darwin.apple_sdk.libs) utmp;
   };
 
@@ -5717,7 +5717,7 @@ let
   gotty = goPackages.gotty.bin // { outputs = [ "bin" ]; };
 
   gradleGen = callPackage ../development/tools/build-managers/gradle { };
-  gradle = self.gradleGen.gradle28;
+  gradle = self.gradleGen.gradleLatest;
   gradle25 = self.gradleGen.gradle25;
 
   gperf = callPackage ../development/tools/misc/gperf { };
@@ -10300,7 +10300,7 @@ let
 
   gocode = goPackages.gocode.bin // { outputs = [ "bin" ]; };
 
-  kgocode = callPackage ../applications/misc/kgocode { 
+  kgocode = callPackage ../applications/misc/kgocode {
     inherit (pkgs.kde4) kdelibs;
   };
 


### PR DESCRIPTION
- Built with `nix-build -A gradle`
- Installed with `nix-env -f . -i gradle`
- `gradle --version` outputs version 2.9 (confirming the installation works)

I kept 2.8 around because there are breaking changes between 2.8 and 2.9.

Pinging @jagajaga @bendlas @volhovM since you guys were just working on Gradle a few days ago.
