### PR TITLE
fail2ban 0.9.1 -> 0.9.3

### DIFF
--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, python, pythonPackages, unzip, systemd, gamin }:
 
-let version = "0.9.1"; in
+let version = "0.9.3"; in
 
 pythonPackages.buildPythonPackage {
   name = "fail2ban-${version}";
@@ -9,7 +9,7 @@ pythonPackages.buildPythonPackage {
   src = fetchzip {
     name   = "fail2ban-${version}-src";
     url    = "https://github.com/fail2ban/fail2ban/archive/${version}.tar.gz";
-    sha256 = "111xvy2gxwn868kn0zy2fmdfa423z6fk57i7wsfrc0l74p1cdvs5";
+    sha256 = "1pwgr56i6l6wh2ap8b5vknxgsscfzjqy2nmd1c3vzdii5kf72j0f";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
With 0.9.1, I was running into this issue: https://github.com/fail2ban/fail2ban/issues/851 The changelog for 0.9.3 can be found: https://github.com/fail2ban/fail2ban/releases
