### PR TITLE
docker: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -10,13 +10,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "docker-${version}";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "docker";
     rev = "v${version}";
-    sha256 = "1a1ss210i712fs9mp5hcljb8bdx93lss91sxj9zay0vrmdb84zn2";
+    sha256 = "1mhi4y820h2wxz6hqmr95c7yvklyw578dd9c83jr463w7rq0rgr6";
   };
 
   buildInputs = [
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     patchShebangs .
     export AUTO_GOPATH=1
-    export DOCKER_GITCOMMIT="76d6bc9a"
+    export DOCKER_GITCOMMIT="a34a1d59"
     ./hack/make.sh dynbinary
   '';
 


### PR DESCRIPTION
Docker 1.9.1 has been out for a while now, and contains a bunch of fixes for minor bugs in 1.9.0.
