### PR TITLE
znc:Update version 1.6.1 -> 1.6.2

### DIFF
--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -7,11 +7,11 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "znc-1.6.1";
+  name = "znc-1.6.2";
 
   src = fetchurl {
     url = "http://znc.in/releases/${name}.tar.gz";
-    sha256 = "0h61nv5kx9k8prmhsffxhlprf7gjcq8vqhjjmqr6v3glcirkjjds";
+    sha256 = "14q5dyr5zg99hm6j6g1gilcn1zf7dskhxfpz3bnkyhy6q0kpgwgf";
   };
 
   buildInputs = [ openssl pkgconfig ]


### PR DESCRIPTION
The 1.6.1 version no longer exists on the upstream site.

(It would be good to not have external dependencies in nixpkgs.)
