### PR TITLE
maven: 3.3.3 -> 3.3.9

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/default.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/default.nix
@@ -2,7 +2,7 @@
 
 assert jdk != null;
 
-let version = "3.3.3"; in
+let version = "3.3.9"; in
 stdenv.mkDerivation rec {
   name = "apache-maven-${version}";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/maven/maven-3/${version}/binaries/${name}-bin.tar.gz";
-    sha256 = "0ya71kxx0isvdnxz3n0rcynlgjah06mvp5r039x61wxr5ahw939s";
+    sha256 = "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
- Built with `nix-build -A maven`
- Installed with `nix-env -f . -i apache-maven`
- `mvn --version` output:

```
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T11:41:47-05:00)
Maven home: /nix/store/cnhs5s8i5x89kkxq2bmpzrzg3km7cw5h-apache-maven-3.3.9/maven
Java version: 1.7.0-u60-unofficial, vendor: Oracle Corporation
Java home: /nix/store/b2bzzfqcvkdz332nvvrh7xd6y8zs1f4g-openjdk-7u60b30/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.11.2", arch: "x86_64", family: "mac"
```

Tested against an actual Java/Maven project, everything looks good
