### PR TITLE
nixos avahi-daemon: add new option declarations

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -247,6 +247,8 @@ in
 
         wantedBy = [ "multi-user.target" ];
         wants = [ "cups.service" "avahi-daemon.service" ];
+        bindsTo = [ "cups.service" "avahi-daemon.service" ];
+        partOf = [ "cups.service" "avahi-daemon.service" ];
         after = [ "cups.service" "avahi-daemon.service" ];
 
         path = [ cups ];


### PR DESCRIPTION
Add new option declarations to control what information is published
by the avahi-daemon. The default values are chosen to respect the
privacy of the user over the connectivity of the system.

Link cups browsed daemon to reload or exit with the avahi-daemon.
