### PR TITLE
Improve slurm service configuration

### DIFF
--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -1,0 +1,80 @@
+import ./make-test.nix ({ pkgs, ... }:
+let mungekey = "mungeverryweakkeybuteasytointegratoinatest";
+    slurmconfig = {
+      client.enable = true;
+      controlMachine = "control";
+      nodeName = ''
+        control
+        NodeName=node[1-3] CPUs=1 State=UNKNOWN
+      '';
+      partitionName = "debug Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP";
+    };
+in {
+  name = "slurm";
+
+  nodes =
+    let
+    computeNode =
+      { config, pkgs, ...}:
+      {
+        # TODO slrumd port and slurmctld port should be configurations and
+        # automatically allowed by the  firewall.
+        networking.firewall.enable = false;
+        services.munge.enable = true;
+        services.slurm = slurmconfig;
+      };
+    in {
+    control =
+      { config, pkgs, ...}:
+      {
+        networking.firewall.enable = false;
+        services.munge.enable = true;
+        services.slurm = {
+          server.enable = true;
+        } // slurmconfig;
+      };
+    node1 = computeNode;
+    node2 = computeNode;
+    node3 = computeNode;
+  };
+
+  testScript =
+  ''
+  startAll;
+
+  # Set up authentification across the cluster
+  foreach my $node (($control,$node1,$node2,$node3))
+  {
+    $node->waitForUnit("default.target");
+
+    $node->succeed("mkdir /etc/munge");
+    $node->succeed("echo '${mungekey}' > /etc/munge/munge.key");
+    $node->succeed("chmod 0400 /etc/munge/munge.key");
+    $node->succeed("systemctl restart munged");
+  }
+
+  # Restart the services since they have probably failed due to the munge init
+  # failure
+
+  subtest "can_start_slurmctld", sub {
+    $control->succeed("systemctl restart slurmctld");
+    $control->waitForUnit("slurmctld.service");
+  };
+
+  subtest "can_start_slurmd", sub {
+    foreach my $node (($control,$node1,$node2,$node3))
+    {
+      $node->succeed("systemctl restart slurmd.service");
+      $node->waitForUnit("slurmd");
+    }
+  };
+
+  # Test that the cluster work and can distribute jobs;
+
+  subtest "run_distributed_command", sub {
+    # Run `hostname` on 3 nodes of the partition (so on all the 3 nodes).
+    # The output must contain the 3 different names
+    $control->succeed("srun -N 3 hostname | sort | uniq | wc -l | xargs test 3 -eq");
+  };
+  '';
+})


### PR DESCRIPTION
In the current way `slurm` is configured, I cannot run user-space commands (such as `sinfo`) without having to specify where the slurm conf file is (it is not enough to specify it for the services).

I see 3 options so solve this:
— Always have slum read its configuration in `/etc/slurm.conf` (and maintain the config file with `environment.etc."slurm.conf"` I guess)
— Have the default environment define `SLURM_CONF` as a system-wide config (the only place I can think of is `/etc/profile` but I do not see a conviniant way to do it since it is produced in a `bash` related derivation)
— Generate in the store a folder containing the configuration and use as `sysconfigdir` when building `slurm` (but a new configuration implies a now folder to store it, and therefore a new derivation instanciation for slurm it-self)

In this PR, I opted for the 3rd option, but it will necessarily induce compilation for all final users when they will try to configure slurm. If another option should be preferred, please let me know.
