### PR TITLE
gibo: init at 1.0.4

### DIFF
--- a/pkgs/tools/misc/gibo/default.nix
+++ b/pkgs/tools/misc/gibo/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, coreutils, findutils, git }:
+
+stdenv.mkDerivation rec {
+  name = "gibo-${version}";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "simonwhitaker";
+    repo = "gibo";
+    rev = version;
+    sha256 = "1vzchggxv660c1cj5v0hlmln7yda48wjy2cv0qwi619cmr5hwbgh";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/etc/bash_completion.d
+    cp gibo $out/bin
+    cp gibo-completion.bash $out/etc/bash_completion.d
+
+    sed -e 's|\<git |${git}/bin/git |g' \
+        -e 's|\<basename |${coreutils}/bin/basename |g' \
+        -i "$out/bin/gibo"
+    sed -e 's|\<find |${findutils}/bin/find |g' \
+        -i "$out/etc/bash_completion.d/gibo-completion.bash"
+  '';
+
+  meta = {
+    homepage = https://github.com/simonwhitaker/gibo;
+    license = stdenv.lib.licenses.publicDomain;
+    description = "A shell script for easily accessing gitignore boilerplates";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1602,6 +1602,8 @@ let
 
   ggobi = callPackage ../tools/graphics/ggobi { };
 
+  gibo = callPackage ../tools/misc/gibo { };
+
   gifsicle = callPackage ../tools/graphics/gifsicle { };
 
   git-hub = callPackage ../applications/version-management/git-and-tools/git-hub { };


### PR DESCRIPTION
Checked on Darwin and NixOS, builds, seems to work fine.

There's also a mandatory initialization step (`gibo -u`) which performs a `git clone` into `$HOME/.gitignore-boilerplates`. I'm not sure if I should've done it here myself (if so, at which phase?) and so left it on the user.
