### PR TITLE
dynamic-colors: init at 2013-12-28

### DIFF
--- a/pkgs/tools/misc/dynamic-colors/default.nix
+++ b/pkgs/tools/misc/dynamic-colors/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, makeWrapper, tmux, vim }:
+
+stdenv.mkDerivation rec {
+  name = "dynamic-colors-git-${version}";
+  version = "2013-12-28";
+
+  src = fetchFromGitHub {
+    owner = "sos4nt";
+    repo = "dynamic-colors";
+    rev = "35325f43620c5ee11a56db776b8f828bc5ae1ddd";
+    sha256 = "1xsjanqyvjlcj1fb8x4qafskxp7aa9b43ba9gyjgzr7yz8hkl4iz";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  patches = [ ./separate-config-and-dynamic-root-path.patch ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/etc/bash_completion.d $out/share/dynamic-colors
+    cp bin/dynamic-colors $out/bin/
+    cp completions/dynamic-colors.bash $out/etc/bash_completion.d/
+    cp -r colorschemes $out/share/dynamic-colors/
+
+    sed -e 's|\<tmux\>|${tmux}/bin/tmux|g' \
+        -e 's|/usr/bin/vim|${vim}/bin/vim|g' \
+        -i "$out/bin/dynamic-colors"
+
+    wrapProgram $out/bin/dynamic-colors --set DYNAMIC_COLORS_ROOT "$out/share/dynamic-colors"
+  '';
+
+  meta = {
+    homepage = https://github.com/sos4nt/dynamic-colors;
+    license = stdenv.lib.licenses.mit;
+    description = "Change terminal colors on the fly";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/dynamic-colors/separate-config-and-dynamic-root-path.patch
+++ b/pkgs/tools/misc/dynamic-colors/separate-config-and-dynamic-root-path.patch
@@ -1,0 +1,58 @@
+From ee44b859003972275d8e469ab41b9900420295e0 Mon Sep 17 00:00:00 2001
+From: Malte Rohde <malte.rohde@flavoursys.com>
+Date: Fri, 9 Jan 2015 13:10:41 +0100
+Subject: [PATCH] Store user configuration in appropriate config location.
+
+So that the dynamic-colors source can live somewhere else
+(e.g., /usr/local/dynamic-colors) and multiple users
+can use the same script.
+---
+ bin/dynamic-colors | 21 ++++++++++++++++-----
+ 1 file changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/bin/dynamic-colors b/bin/dynamic-colors
+index a669221..5d6bce7 100755
+--- a/bin/dynamic-colors
++++ b/bin/dynamic-colors
+@@ -84,16 +84,27 @@ else
+ fi
+ COLORSCHEMES="${DYNAMIC_COLORS_ROOT}/colorschemes"
+ 
++if [ -z "${DYNAMIC_COLORS_HOME}" ]; then
++  if [ -d "${HOME}/.dynamic-colors" ] || [ -z "${XDG_CONFIG_HOME}" ]; then
++    DYNAMIC_COLORS_HOME="${HOME}/.dynamic-colors"
++  else
++    DYNAMIC_COLORS_HOME="${XDG_CONFIG_HOME}/dynamic-colors"
++  fi
++else
++  DYNAMIC_COLORS_HOME="${DYNAMIC_COLORS_HOME%/}"
++fi
++
+ write_colorscheme_name () {
+-  echo "$1" > "${DYNAMIC_COLORS_ROOT}/colorscheme"
++  [ ! -d "${DYNAMIC_COLORS_HOME}" ] && mkdir -p "${DYNAMIC_COLORS_HOME}"
++  echo "$1" > "${DYNAMIC_COLORS_HOME}/colorscheme"
+ }
+ 
+ load_colorscheme_name () {
+-  head -1 "${DYNAMIC_COLORS_ROOT}/colorscheme"
++  head -1 "${DYNAMIC_COLORS_HOME}/colorscheme"
+ }
+ 
+ init () {
+-  [ ! -f "${DYNAMIC_COLORS_ROOT}/colorscheme" ] && return
++  [ ! -f "${DYNAMIC_COLORS_HOME}/colorscheme" ] && return
+   colorscheme_name=$(load_colorscheme_name)
+   load_colorscheme "$colorscheme_name"
+   set_colors
+@@ -142,8 +153,8 @@ audit () {
+ }
+ 
+ cycle() {
+-    if [ -f "${DYNAMIC_COLORS_ROOT}/colorscheme" ]; then
+-        current=`head -1 "${DYNAMIC_COLORS_ROOT}/colorscheme"`
++    if [ -f "${DYNAMIC_COLORS_HOME}/colorscheme" ]; then
++        current=$(load_colorscheme_name)
+         found=false
+         cd "$COLORSCHEMES"
+         for file in *.sh; do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -839,6 +839,8 @@ let
     linuxHeaders = linuxHeaders_3_18;
   };
 
+  dynamic-colors = callPackage ../tools/misc/dynamic-colors { };
+
   edac-utils = callPackage ../os-specific/linux/edac-utils { };
 
   eggdrop = callPackage ../tools/networking/eggdrop { };


### PR DESCRIPTION
Checked on NixOS.

This includes second patch from https://github.com/sos4nt/dynamic-colors/pull/8 to separate user config (i.e. the chosen colorscheme) from resources (i.e. colorschemes themselves).
