### PR TITLE
pkgs.boost: 1.59 -> 1.60

### DIFF
--- a/pkgs/development/libraries/boost/1.60.nix
+++ b/pkgs/development/libraries/boost/1.60.nix
@@ -1,0 +1,11 @@
+{ stdenv, callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.60.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/boost/boost_1_60_0.tar.bz2";
+    sha256 = "0fzx6dwqbrkd4bcd8pjv0fpapwmrxxwr8yx9g67lihlsk3zzysk8";
+  };
+
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1057,7 +1057,7 @@ let
   cdrkit = callPackage ../tools/cd-dvd/cdrkit { };
 
   libceph = ceph.lib;
-  ceph = callPackage ../tools/filesystems/ceph { };
+  ceph = callPackage ../tools/filesystems/ceph { boost = boost159; };
   ceph-dev = ceph;
   #ceph-dev = lowPrio (callPackage ../tools/filesystems/ceph/dev.nix { });
 
@@ -4935,7 +4935,7 @@ let
   scala_2_11 = callPackage ../development/compilers/scala { };
   scala = scala_2_11;
 
-  sdcc = callPackage ../development/compilers/sdcc { };
+  sdcc = callPackage ../development/compilers/sdcc { boost = boost159; };
 
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
   smlnj = if stdenv.isDarwin
@@ -6179,7 +6179,8 @@ let
 
   boost155 = callPackage ../development/libraries/boost/1.55.nix { };
   boost159 = callPackage ../development/libraries/boost/1.59.nix { };
-  boost = boost159;
+  boost160 = callPackage ../development/libraries/boost/1.60.nix { };
+  boost = boost160;
 
   boost_process = callPackage ../development/libraries/boost-process { };
 
@@ -9398,6 +9399,7 @@ let
   mariadb = callPackage ../servers/sql/mariadb {
     inherit (darwin) cctools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
+    boost = boost159;
   };
 
   mongodb = callPackage ../servers/nosql/mongodb {
@@ -12973,7 +12975,7 @@ let
     demo = false;
   };
 
-  rapcad = qt5.callPackage ../applications/graphics/rapcad {};
+  rapcad = qt5.callPackage ../applications/graphics/rapcad { boost = boost159; };
 
   rapidsvn = callPackage ../applications/version-management/rapidsvn { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8196,7 +8196,7 @@ in modules // {
 
   # py3k disabled, see https://travis-ci.org/NixOS/nixpkgs/builds/48759067
   graph-tool = if isPy3k then throw "graph-tool in Nix doesn't support py3k yet"
-    else callPackage ../development/python-modules/graph-tool/2.x.x.nix { };
+    else callPackage ../development/python-modules/graph-tool/2.x.x.nix { boost = pkgs.boost159; };
 
   grappelli_safe = buildPythonPackage rec {
     version = "0.3.13";


### PR DESCRIPTION
See http://www.boost.org/users/history/version_1_60_0.html

I maintained the 1.59 version since it has specific patches for cygwin I cannot test. I do not have this platform available, so I did not test it.

From the list of patches applied to the 1.59 cygwin version, the following cannot apply to the 1.60 tree:
- cygwin-fedora-boost-1.54.0-locale-unused_typedef.patch
- cygwin-fedora-boost-1.54.0-python-unused_typedef.patch
- cygwin-fedora-boost-1.57.0-pool-test_linking.patch
- cygwin-fedora-boost-1.57.0-signals2-weak_ptr.patch
- cygwin-fedora-boost-1.57.0-uuid-comparison.patch
- cygwin-fedora-boost-1.57.0-move-is_class.patch
- cygwin-1.57.0-asio-cygwin.patch
- cygwin-1.57.0-context-cygwin.patch
- cygwin-1.57.0-filesystem-cygwin.patch

cc maintainers: @peti @wkennington 
