### PR TITLE
refactor pam-u2f: add keysPath, verbose, fix docs about u2f_keys path

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -286,6 +286,7 @@ in rec {
   tests.nsd = callTest tests/nsd.nix {};
   tests.openssh = callTest tests/openssh.nix {};
   tests.pam-oath-login = callTest tests/pam-oath-login.nix {};
+  tests.pam-u2f = callTest tests/pam-u2f.nix {};
   #tests.panamax = hydraJob (import tests/panamax.nix { system = "x86_64-linux"; });
   tests.peerflix = callTest tests/peerflix.nix {};
   tests.postgresql = callSubTests tests/postgresql.nix {};

--- a/nixos/tests/pam-u2f.nix
+++ b/nixos/tests/pam-u2f.nix
@@ -1,0 +1,25 @@
+import ./make-test.nix ({ pkgs, latestKernel ? false, ... }:
+
+{
+  name = "pam-u2f";
+
+  machine =
+    { config, pkgs, lib, ... }:
+    {
+      security.pam.u2f = {
+        enable = true;
+        interactive=true;
+        control="sufficient";
+        cue=true;
+        debug=true;
+      };
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit('multi-user.target');
+      $machine->succeed('egrep "auth sufficient .*u2f.*" /etc/pam.d/ -R ');
+
+    '';
+
+})


### PR DESCRIPTION
- change enableU2F option to U2F.\* set
- added few pam-u2f options
- fix documentation about default u2f_keys locations
