### PR TITLE
CopyQ-2.5.0 clipboard manager

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -320,6 +320,7 @@
   vmandela = "Venkateswara Rao Mandela <venkat.mandela@gmail.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";
   wedens = "wedens <kirill.wedens@gmail.com>";
+  willtim = "Tim Philip Williams <tim.williams.public@gmail.com>";
   winden = "Antonio Vargas Gonzalez <windenntw@gmail.com>";
   wizeman = "Ricardo M. Correia <rcorreia@wizy.org>";
   wjlroe = "William Roe <willroe@gmail.com>";

--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, makeWrapper, qt4, libXfixes, libXtst}:
+
+let version = "2.5.0";
+in
+stdenv.mkDerivation rec {
+  name = "CopyQ-${version}";
+  src  = fetchurl {
+    url    = "https://github.com/hluk/CopyQ/archive/v${version}.tar.gz";
+    sha256 = "7726745056e8d82625531defc75b2a740d3c42131ecce1f3181bc0a0bae51fb1";
+  };
+
+  buildInputs = [ cmake makeWrapper qt4 libXfixes libXtst ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://hluk.github.io/CopyQ";
+    description = "Clipboard Manager with Advanced Features";
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ willtim ];
+    # NOTE: CopyQ supports windows and osx, but I cannot test these.
+    # OSX build requires QT5.
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, cmake, makeWrapper, qt4, libXfixes, libXtst}:
+{ stdenv, fetchurl, cmake, qt4, libXfixes, libXtst}:
 
 let version = "2.5.0";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "CopyQ-${version}";
   src  = fetchurl {
     url    = "https://github.com/hluk/CopyQ/archive/v${version}.tar.gz";
     sha256 = "7726745056e8d82625531defc75b2a740d3c42131ecce1f3181bc0a0bae51fb1";
   };
 
-  buildInputs = [ cmake makeWrapper qt4 libXfixes libXtst ];
+  buildInputs = [ cmake qt4 libXfixes libXtst ];
 
   meta = with stdenv.lib; {
     homepage    = "https://hluk.github.io/CopyQ";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11263,6 +11263,8 @@ let
 
   constant-detune-chorus = callPackage ../applications/audio/constant-detune-chorus { };
 
+  copyq = callPackage ../applications/misc/copyq { };
+
   coriander = callPackage ../applications/video/coriander {
     inherit (gnome) libgnomeui GConf;
   };


### PR DESCRIPTION
Please add the CopyQ clipboard manager to nixpkgs.  CopyQ is actively maintained and regarded by many as the best clipboard manager for Linux. Many thanks, Tim.
