### PR TITLE
pdf2svg: add autoreconf hook

### DIFF
--- a/pkgs/tools/graphics/pdf2svg/default.nix
+++ b/pkgs/tools/graphics/pdf2svg/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cairo, gtk, poppler }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, cairo, gtk, poppler }:
 
 stdenv.mkDerivation rec {
   name = "pdf2svg-${version}";
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "14ffdm4y26imq99wjhkrhy9lp33165xci1l5ndwfia8hz53bl02k";
   };
 
-  buildInputs = [ cairo pkgconfig poppler gtk ];
+  buildInputs = [ autoreconfHook cairo pkgconfig poppler gtk ];
 
   meta = with stdenv.lib; {
     description = "PDF converter to SVG format";


### PR DESCRIPTION
This fixes builds that may fail due to all files in the archive having the same timestamp. As shown in the [i686 build](https://hydra.nixos.org/build/29214063/nixlog/1/raw) that @vcunat brought to my attention. Forcing a regeneration of the autotool files resolves the issue.
