### PR TITLE
acbuild: 0.1.1 -> 0.2.2 and moved to own default.nix

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -81,6 +81,7 @@
   devhell = "devhell <\"^\"@regexmail.net>";
   dezgeg = "Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>";
   dfoxfranke = "Daniel Fox Franke <dfoxfranke@gmail.com>";
+  dgonyeo = "Derek Gonyeo <derek@gonyeo.com>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   dochang = "Desmond O. Chang <dochang@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";

--- a/pkgs/applications/misc/acbuild/default.nix
+++ b/pkgs/applications/misc/acbuild/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, go, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "acbuild-${version}";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "appc";
+    repo = "acbuild";
+    rev = "v${version}";
+    sha256 = "0sajmjg655irwy5fywk88cmwhc1q186dg5w8589pab2jhwpavdx4";
+  };
+
+  buildInputs = [ go ];
+
+  patchPhase = ''
+    sed -i -e 's|\$(git describe --dirty)|"${version}"|' build
+  '';
+
+  buildPhase = ''
+    patchShebangs build
+    ./build
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    mv bin $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A build tool for ACIs";
+    homepage = https://github.com/appc/acbuild;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dgonyeo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -482,6 +482,8 @@ let
 
   abduco = callPackage ../tools/misc/abduco { };
 
+  acbuild = callPackage ../applications/misc/acbuild { };
+
   acct = callPackage ../tools/system/acct { };
 
   acoustidFingerprinter = callPackage ../tools/audio/acoustid-fingerprinter {

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -3218,26 +3218,6 @@ let
     sha256 = "0zc1ah5cvaqa3zw0ska89a40x445vwl1ixz8v42xi3zicx16ibwz";
   };
 
-  acbuild = stdenv.mkDerivation rec {
-    version = "0.1.1";
-    name = "acbuild-${version}";
-    src = fetchFromGitHub {
-      rev    = "beae3971de6b2c35807a98ef1d0fa3167cc3a4a8";
-      owner  = "appc";
-      repo   = "acbuild";
-      sha256 = "1mjmg2xj190dypp2yqslrx8xhwcyrrz38xxp0rig4fr60i2qy41j";
-    };
-    buildInputs = [ go ];
-    patchPhase = ''
-      sed -i -e 's|\$(git describe --dirty)|"${version}"|' build
-      sed -i -e 's|\$GOBIN/acbuild|$out/bin/acbuild|' build
-    '';
-    installPhase = ''
-      mkdir -p $out/bin
-      ./build
-    '';
-  };
-
   color = buildFromGitHub {
     rev      = "9aae6aaa22315390f03959adca2c4d395b02fcef";
     owner    = "fatih";


### PR DESCRIPTION
Moved acbuild into its own directory and default.nix, bumped the version to 0.2.2, and listed myself as the maintainer (I did write it after all).

Wasn't certain what directory would be best to put acbuild under. It's currently under `pkgs/applications/misc`, but perhaps something more specific like `pkgs/applications/virtualization` would make more sense.

cc @garbas, since it looks like you were the one who put acbuild into nix in the first place.
