### PR TITLE
zfs:Add option for zpool import -d, and set it to /dev/disk/by-id.

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -75,7 +75,7 @@ in
 
       devNodes = mkOption {
         type = types.path;
-        default = "/dev";
+        default = "/dev/disk/by-id";
         example = "/dev/disk/by-id";
         description = ''
           Name of directory from which to import ZFS devices.

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -73,6 +73,21 @@ in
         '';
       };
 
+      devNodes = mkOption {
+        type = types.path;
+        default = "/dev";
+        example = "/dev/disk/by-id";
+        description = ''
+          Name of directory from which to import ZFS devices.
+
+          Usually /dev works. However, ZFS import may fail if a device node is renamed.
+          It should therefore use stable device names, such as from /dev/disk/by-id.
+
+          The default remains /dev for 15.09, due to backwards compatibility concerns.
+          It will change to /dev/disk/by-id in the next NixOS release.
+        '';
+      };
+
       forceImportRoot = mkOption {
         type = types.bool;
         default = true;
@@ -214,7 +229,7 @@ in
             done
             ''] ++ (map (pool: ''
             echo "importing root ZFS pool \"${pool}\"..."
-            zpool import -d /dev/disk/by-id -N $ZFS_FORCE "${pool}"
+            zpool import -d ${cfgZfs.devNodes} -N $ZFS_FORCE "${pool}"
         '') rootPools));
       };
 
@@ -255,7 +270,7 @@ in
             };
             script = ''
               zpool_cmd="${zfsUserPkg}/sbin/zpool"
-              ("$zpool_cmd" list "${pool}" >/dev/null) || "$zpool_cmd" import -d /dev/disk/by-id -N ${optionalString cfgZfs.forceImportAll "-f"} "${pool}"
+              ("$zpool_cmd" list "${pool}" >/dev/null) || "$zpool_cmd" import -d ${cfgZfs.devNodes} -N ${optionalString cfgZfs.forceImportAll "-f"} "${pool}"
             '';
           };
       in listToAttrs (map createImportService dataPools) // {


### PR DESCRIPTION
These two commits, taken together, amount to a no-op on -unstable.

I split them so that commit #9a82dd8 can reasonably be cherry-picked to 15.09, where it on its own should be a no-op.
