### PR TITLE
gnome3: removed duplicate line

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -140,9 +140,6 @@ in {
           # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
           ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update
 
-          # Find the mouse
-          export XCURSOR_PATH=~/.icons:${config.system.path}/share/icons
-
           ${gnome3.gnome_session}/bin/gnome-session&
           waitPID=$!
         '';


### PR DESCRIPTION
XCURSOR_PATH is set twice by accident (just randomly stumbled over this)
