### PR TITLE
networkd: add IPForward IPMasquerade options,  DHCPServer section

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -131,6 +131,16 @@ let
     (assertValueOneOf "RequestBroadcast" boolValues)
   ];
 
+  checkDhcpServer = checkUnitConfig "DHCPServer" [
+    (assertOnlyFields [
+      "PoolOffset" "PoolSize" "DefaultLeaseTimeSec" "MaxLeaseTimeSec"
+      "EmitDNS" "DNS" "EmitNTP" "NTP" "EmitTimezone" "Timezone"
+    ])
+    (assertValueOneOf "EmitDNS" boolValues)
+    (assertValueOneOf "EmitNTP" boolValues)
+    (assertValueOneOf "EmitTimezone" boolValues)
+  ];
+
   commonNetworkOptions = {
 
     enable = mkOption {
@@ -338,6 +348,18 @@ let
       description = ''
         Each attribute in this set specifies an option in the
         <literal>[DHCP]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.network</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
+    dhcpServerConfig = mkOption {
+      default = {};
+      example = { PoolOffset = 50; EmitDNS = false; };
+      type = types.addCheck (types.attrsOf unitOption) checkDhcpServer;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[DHCPServer]</literal> section of the unit.  See
         <citerefentry><refentrytitle>systemd.network</refentrytitle>
         <manvolnum>5</manvolnum></citerefentry> for details.
       '';
@@ -566,6 +588,11 @@ let
           ${optionalString (def.dhcpConfig != { }) ''
             [DHCP]
             ${attrsToSection def.dhcpConfig}
+
+          ''}
+          ${optionalString (def.dhcpServerConfig != { }) ''
+            [DHCPServer]
+            ${attrsToSection def.dhcpServerConfig}
 
           ''}
           ${flip concatMapStrings def.addresses (x: ''

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -93,11 +93,13 @@ let
 
   checkNetwork = checkUnitConfig "Network" [
     (assertOnlyFields [
-      "Description" "DHCP" "DHCPServer" "IPv4LL" "IPv4LLRoute"
+      "Description" "DHCP" "DHCPServer" "IPForward" "IPMasquerade" "IPv4LL" "IPv4LLRoute"
       "LLMNR" "Domains" "Bridge" "Bond"
     ])
     (assertValueOneOf "DHCP" ["both" "none" "v4" "v6"])
     (assertValueOneOf "DHCPServer" boolValues)
+    (assertValueOneOf "IPForward" ["yes" "no" "ipv4" "ipv6"])
+    (assertValueOneOf "IPMasquerade" boolValues)
     (assertValueOneOf "IPv4LL" boolValues)
     (assertValueOneOf "IPv4LLRoute" boolValues)
     (assertValueOneOf "LLMNR" boolValues)


### PR DESCRIPTION
This enables to configure options thet were lately introduced into systemd-networkd.

[Network]
  IPForward v219
  IPMasquerade v219

[DHCPServer] v226

for details see man systemd.network

I use them already in my present [configuration.nix](https://gist.github.com/calbrecht/055bf83943afbeb9bcbe#file-configuration-nix-L439) to serve a vagrant-lxc development box.
