### PR TITLE
Jenkins enhancement

### DIFF
--- a/nixos/modules/services/continuous-integration/jenkins/default.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/default.nix
@@ -48,11 +48,33 @@ in {
         '';
       };
 
+      host = mkOption {
+        default = "0.0.0.0";
+        example = "localhost";
+        type = types.str;
+        description = ''
+          Specifies the bind adress on which the jenkins HTTP interface listens.
+          The default is the wildcard adress.
+        '';
+      };
+
       port = mkOption {
         default = 8080;
         type = types.int;
         description = ''
-          Specifies port number on which the jenkins HTTP interface listens. The default is 8080.
+          Specifies port number on which the jenkins HTTP interface listens.
+          The default is 8080.
+        '';
+      };
+
+      prefix = mkOption {
+        default = "";
+        example = "/jenkins";
+        type = types.str;
+        description = ''
+          Specifies a urlPrefix to use with jenkins.
+          If the example /jenkins is given, the jenkins server will be
+          accessible using localhost:8080/jenkins.
         '';
       };
 
@@ -80,7 +102,7 @@ in {
       extraOptions = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = [ "--debug=9" "--httpListenAddress=localhost" ];
+        example = [ "--debug=9" ];
         description = ''
           Additional command line arguments to pass to Jenkins.
         '';
@@ -134,15 +156,18 @@ in {
       '';
 
       script = ''
-        ${pkgs.jdk}/bin/java -jar ${pkgs.jenkins} --httpPort=${toString cfg.port} ${concatStringsSep " " cfg.extraOptions}
+        ${pkgs.jdk}/bin/java -jar ${pkgs.jenkins} --httpListenAddress=${cfg.host} \
+                                                  --httpPort=${toString cfg.port} \
+                                                  --prefix=${cfg.prefix} \
+                                                  ${concatStringsSep " " cfg.extraOptions}
       '';
 
       postStart = ''
-        until ${pkgs.curl}/bin/curl -s -L localhost:${toString cfg.port} ; do
+        until ${pkgs.curl}/bin/curl -s -L ${cfg.host}:${toString cfg.port}${cfg.prefix} ; do
           sleep 10
         done
         while true ; do
-          index=`${pkgs.curl}/bin/curl -s -L localhost:${toString cfg.port}`
+          index=`${pkgs.curl}/bin/curl -s -L ${cfg.host}:${toString cfg.port}${cfg.prefix}`
           if [[ !("$index" =~ 'Please wait while Jenkins is restarting' ||
                   "$index" =~ 'Please wait while Jenkins is getting ready to work') ]]; then
             exit 0

--- a/nixos/modules/services/continuous-integration/jenkins/job-builder.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/job-builder.nix
@@ -144,7 +144,7 @@ in {
             done
 
             echo "Asking Jenkins to reload config"
-            curl --silent -X POST http://localhost:${toString jenkinsCfg.port}/reload
+            curl --silent -X POST http://${jenkinsCfg.host}:${toString jenkinsCfg.port}${jenkinsCfg.prefix}/reload
           '';
       serviceConfig = {
         User = jenkinsCfg.user;


### PR DESCRIPTION
Added jenkins http bind port option and prefix option. Creating options instead of relying on extra arguments allows to use these options in jenkins-job-builder (Using a prefix meant it stopped working.)
Also we could use this to create a reverse proxy service for apache, nginx, and (name any proxy capable server you want).
