### PR TITLE
flex: disable tests when cross compiling

### DIFF
--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
   '';
 
   crossAttrs = {
+
+    # disable tests which can't run on build machine
+    postPatch = ''
+      substituteInPlace Makefile.in --replace "tests" " ";
+    '';
+
     preConfigure = ''
       export ac_cv_func_malloc_0_nonnull=yes
       export ac_cv_func_realloc_0_nonnull=yes


### PR DESCRIPTION
When cross compiling the test executable probably won't run on the build machine.  I've just removed the 'test' directory from the makefile.in which seems to do the trick.  

Here's the testcase.

```
let
  pkgsNoParams = import <nixpkgs> {};

  system = builtins.currentSystem;

  rasberryPieCross = {
    config = "armv6l-unknown-linux-gnueabi";
    bigEndian = false;
    arch = "arm";
    float = "hard";
    fpu = "vfp";
    withTLS = true;
    libc = "glibc";
    platform = pkgsNoParams.platforms.raspberrypi;
    openssl.system = "linux-generic32";
    gcc = {
      arch = "armv6";
      fpu = "vfp";
      float = "softfp";
      jabi = "aapcs-linux";
    };
  };

  pkgs = import <nixpkgs> {
     inherit system;
     crossSystem = rasberryPieCross;
     config = { 
      allowUnfree = false;
    };
  };
in
  pkgs.flex.crossDrv
```
