### PR TITLE
dropbox: 3.12.5 -> 3.12.6

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -19,11 +19,11 @@
 
 let
   # NOTE: When updating, please also update in current stable, as older versions stop working
-  version = "3.12.5";
+  version = "3.12.6";
   sha256 =
     {
-      "x86_64-linux" = "1agy20b8vrvdfyzjf7wr2z6vradvvg49wn31vzrl38f0m1l3gb7s";
-      "i686-linux" = "0a68m2i5lyyadf12g82rvzryw9b1v6sfq5szx94jsc4qhyl7mcaj";
+      "x86_64-linux" = "16d0g9bygvaixv4r42p72z6a6wqhkf5qzb058lijih93zjr8zjlj";
+      "i686-linux" = "1pgqz6axzzyaahql01g0l80an39hd9j4dnq0vfavwvb2qkb27dph";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
Update required because outdated versions stop working.

(cherry picked from commit 077a3102cc49b1ab702c8d70de065f5be91725bf)
