### PR TITLE
Add the python maildir-deduplicate package.

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22955,6 +22955,26 @@ in modules // {
     };
   };
 
+  maildir-deduplicate = buildPythonPackage rec {
+    name = "maildir-deduplicate-${version}";
+    version = "1.0.2";
+
+    disabled = !isPy27;
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/m/maildir-deduplicate/${name}.tar.gz";
+      sha256 = "1xy5z756alrjgpl9qx2gdx898rw1mryrqkwmipbh39mgrvkl3fz9";
+    };
+
+    propagatedBuildInputs = with self; [ click ];
+
+    meta = with stdenv.lib; {
+      description = "Command-line tool to deduplicate mails from a set of maildir folders";
+      homepage = "https://github.com/kdeldycke/maildir-deduplicate";
+      license = licenses.gpl2;
+    };
+  };
+
 
   mps-youtube = buildPythonPackage rec {
     name = "mps-youtube-${version}";


### PR DESCRIPTION
This adds the [maildir-deduplicate](https://github.com/kdeldycke/maildir-deduplicate) project, which is a command-line tool to help deduplicate email from a maildir folder.
