### PR TITLE
gradle: Require libstdc++.so.6

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -12,7 +12,8 @@ rec {
       test -f $gradle_launcher_jar
       makeWrapper ${jdk}/bin/java $out/bin/gradle \
         --set JAVA_HOME ${jdk} \
-        --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain"
+        --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain" \
+        --suffix LD_LIBRARY_PATH : ${stdenv.cc.cc}/lib
     '';
 
     phases = "unpackPhase installPhase";


### PR DESCRIPTION
At runtime, gradle required access to libstdc++.so.6.
The only way I could see to put this in scope is adding an LD_LIBRARY_PATH prefix/suffix in the makeWrapper command.

It is curious that this change did not seem necessary on my old laptop.
The fresh NixOS installation requires this change for all gradle versions.

If somebody has a better alternative, you are more than welcome to contribute. I simply need gradle and this is fixing the issue for me.
