### PR TITLE
Rename NixOS option names: 'host' to 'listenAddress'

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -20,6 +20,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "graphite" "web" "host" ] [ "services" "graphite" "web" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "shout" "host" ] [ "services" "shout" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "statsd" "host" ] [ "services" "statsd" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "subsonic" "host" ] [ "services" "subsonic" "listenAddress" ])
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -14,6 +14,8 @@ with lib;
     (mkRenamedOptionModule [ "networking" "enableWLAN" ] [ "networking" "wireless" "enable" ])
     (mkRenamedOptionModule [ "networking" "enableRT73Firmware" ] [ "networking" "enableRalinkFirmware" ])
 
+    (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
+
     # Old Grub-related options.
     (mkRenamedOptionModule [ "boot" "initrd" "extraKernelModules" ] [ "boot" "initrd" "kernelModules" ])
     (mkRenamedOptionModule [ "boot" "extraKernelParams" ] [ "boot" "kernelParams" ])

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -21,6 +21,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "shout" "host" ] [ "services" "shout" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "sslh" "host" ] [ "services" "sslh" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "statsd" "host" ] [ "services" "statsd" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "subsonic" "host" ] [ "services" "subsonic" "listenAddress" ])
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -14,6 +14,7 @@ with lib;
     (mkRenamedOptionModule [ "networking" "enableWLAN" ] [ "networking" "wireless" "enable" ])
     (mkRenamedOptionModule [ "networking" "enableRT73Firmware" ] [ "networking" "enableRalinkFirmware" ])
 
+    (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
 
     # Old Grub-related options.

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -19,6 +19,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "elasticsearch" "host" ] [ "services" "elasticsearch" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "graphite" "api" "host" ] [ "services" "graphite" "api" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "graphite" "web" "host" ] [ "services" "graphite" "web" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "kibana" "host" ] [ "services" "kibana" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "shout" "host" ] [ "services" "shout" "listenAddress" ])

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -14,6 +14,7 @@ with lib;
     (mkRenamedOptionModule [ "networking" "enableWLAN" ] [ "networking" "wireless" "enable" ])
     (mkRenamedOptionModule [ "networking" "enableRT73Firmware" ] [ "networking" "enableRalinkFirmware" ])
 
+    (mkRenamedOptionModule [ "services" "cadvisor" "host" ] [ "services" "cadvisor" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "dockerRegistry" "host" ] [ "services" "dockerRegistry" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -17,6 +17,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "dockerRegistry" "host" ] [ "services" "dockerRegistry" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "subsonic" "host" ] [ "services" "subsonic" "listenAddress" ])
 
     # Old Grub-related options.
     (mkRenamedOptionModule [ "boot" "initrd" "extraKernelModules" ] [ "boot" "initrd" "kernelModules" ])

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -20,6 +20,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "graphite" "web" "host" ] [ "services" "graphite" "web" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "statsd" "host" ] [ "services" "statsd" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "subsonic" "host" ] [ "services" "subsonic" "listenAddress" ])
 
     # Old Grub-related options.

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -16,6 +16,7 @@ with lib;
 
     (mkRenamedOptionModule [ "services" "cadvisor" "host" ] [ "services" "cadvisor" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "dockerRegistry" "host" ] [ "services" "dockerRegistry" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "elasticsearch" "host" ] [ "services" "elasticsearch" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "graphite" "api" "host" ] [ "services" "graphite" "api" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "graphite" "web" "host" ] [ "services" "graphite" "web" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -14,6 +14,7 @@ with lib;
     (mkRenamedOptionModule [ "networking" "enableWLAN" ] [ "networking" "wireless" "enable" ])
     (mkRenamedOptionModule [ "networking" "enableRT73Firmware" ] [ "networking" "enableRalinkFirmware" ])
 
+    (mkRenamedOptionModule [ "services" "dockerRegistry" "host" ] [ "services" "dockerRegistry" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -16,6 +16,8 @@ with lib;
 
     (mkRenamedOptionModule [ "services" "cadvisor" "host" ] [ "services" "cadvisor" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "dockerRegistry" "host" ] [ "services" "dockerRegistry" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "graphite" "api" "host" ] [ "services" "graphite" "api" "listenAddress" ])
+    (mkRenamedOptionModule [ "services" "graphite" "web" "host" ] [ "services" "graphite" "web" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "subsonic" "host" ] [ "services" "subsonic" "listenAddress" ])

--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -18,7 +18,7 @@ let
     user                "${cfg.user}"
     group               "${cfg.group}"
 
-    ${optionalString (cfg.network.host != "any") ''bind_to_address "${cfg.network.host}"''}
+    ${optionalString (cfg.network.listenAddress != "any") ''bind_to_address "${cfg.network.listenAddress}"''}
     ${optionalString (cfg.network.port != 6600)  ''port "${toString cfg.network.port}"''}
 
     ${cfg.extraConfig}
@@ -75,7 +75,7 @@ in {
 
       network = {
 
-        host = mkOption {
+        listenAddress = mkOption {
           default = "any";
           description = ''
             This setting sets the address for the daemon to listen on. Careful attention

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -7,7 +7,7 @@ let
 
   serverConfig = pkgs.writeText "neo4j-server.properties" ''
     org.neo4j.server.database.location=${cfg.dataDir}/data/graph.db
-    org.neo4j.server.webserver.address=${cfg.host}
+    org.neo4j.server.webserver.address=${cfg.listenAddress}
     org.neo4j.server.webserver.port=${toString cfg.port}
     ${optionalString cfg.enableHttps ''
       org.neo4j.server.webserver.https.enabled=true
@@ -52,7 +52,7 @@ in {
       type = types.package;
     };
 
-    host = mkOption {
+    listenAddress = mkOption {
       description = "Neo4j listen address.";
       default = "127.0.0.1";
       type = types.str;

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -15,7 +15,7 @@ in {
       type = types.bool;
     };
 
-    host = mkOption {
+    listenAddress = mkOption {
       description = "Docker registry host or ip to bind to.";
       default = "127.0.0.1";
       type = types.str;
@@ -50,7 +50,7 @@ in {
       after = [ "network.target" ];
 
       environment = {
-        REGISTRY_HOST = cfg.host;
+        REGISTRY_HOST = cfg.listenAddress;
         REGISTRY_PORT = toString cfg.port;
         GUNICORN_OPTS = "[--preload]"; # see https://github.com/docker/docker-registry#sqlalchemy
         STORAGE_PATH = cfg.storagePath;
@@ -65,7 +65,7 @@ in {
       };
 
       postStart = ''
-        until ${pkgs.curl}/bin/curl -s -o /dev/null 'http://${cfg.host}:${toString cfg.port}/'; do
+        until ${pkgs.curl}/bin/curl -s -o /dev/null 'http://${cfg.listenAddress}:${toString cfg.port}/'; do
           sleep 1;
         done
       '';

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -21,7 +21,7 @@ in
         '';
       };
 
-      host = mkOption {
+      listenAddress = mkOption {
         type = types.string;
         default = "0.0.0.0";
         description = ''
@@ -115,7 +115,7 @@ in
         ExecStart = ''
           ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
             -Dsubsonic.home=${cfg.home} \
-            -Dsubsonic.host=${cfg.host} \
+            -Dsubsonic.host=${cfg.listenAddress} \
             -Dsubsonic.port=${toString cfg.port} \
             -Dsubsonic.httpsPort=${toString cfg.httpsPort} \
             -Dsubsonic.contextPath=${cfg.contextPath} \

--- a/nixos/modules/services/monitoring/cadvisor.nix
+++ b/nixos/modules/services/monitoring/cadvisor.nix
@@ -14,7 +14,7 @@ in {
         description = "Whether to enable cadvisor service.";
       };
 
-      host = mkOption {
+      listenAddress = mkOption {
         default = "127.0.0.1";
         type = types.str;
         description = "Cadvisor listening host";
@@ -71,7 +71,7 @@ in {
       after = [ "network.target" "docker.service" "influxdb.service" ];
 
       postStart = mkBefore ''
-        until ${pkgs.curl}/bin/curl -s -o /dev/null 'http://${cfg.host}:${toString cfg.port}/containers/'; do
+        until ${pkgs.curl}/bin/curl -s -o /dev/null 'http://${cfg.listenAddress}:${toString cfg.port}/containers/'; do
           sleep 1;
         done
       '';
@@ -79,7 +79,7 @@ in {
       serviceConfig = {
         ExecStart = ''${pkgs.cadvisor}/bin/cadvisor \
           -logtostderr=true \
-          -listen_ip=${cfg.host} \
+          -listen_ip=${cfg.listenAddress} \
           -port=${toString cfg.port} \
           ${optionalString (cfg.storageDriver != null) ''
             -storage_driver ${cfg.storageDriver} \

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -77,7 +77,7 @@ in {
         type = types.bool;
       };
 
-      host = mkOption {
+      listenAddress = mkOption {
         description = "Graphite web frontend listen address.";
         default = "127.0.0.1";
         type = types.str;
@@ -121,7 +121,7 @@ in {
         type = types.listOf types.str;
       };
 
-      host = mkOption {
+      listenAddress = mkOption {
         description = "Graphite web service listen address.";
         default = "127.0.0.1";
         type = types.str;
@@ -292,7 +292,7 @@ in {
       };
 
       graphiteUrl = mkOption {
-        default = "http://${cfg.web.host}:${toString cfg.web.port}";
+        default = "http://${cfg.web.listenAddress}:${toString cfg.web.port}";
         description = "Host where graphite service runs.";
         type = types.str;
       };
@@ -337,7 +337,7 @@ in {
 
       graphiteUrl = mkOption {
         description = "URL to your graphite service.";
-        default = "http://${cfg.web.host}:${toString cfg.web.port}";
+        default = "http://${cfg.web.listenAddress}:${toString cfg.web.port}";
         type = types.str;
       };
 
@@ -452,7 +452,7 @@ in {
         serviceConfig = {
           ExecStart = ''
             ${pkgs.python27Packages.waitress}/bin/waitress-serve \
-            --host=${cfg.web.host} --port=${toString cfg.web.port} \
+            --host=${cfg.web.listenAddress} --port=${toString cfg.web.port} \
             --call django.core.handlers.wsgi:WSGIHandler'';
           User = "graphite";
           Group = "graphite";
@@ -494,7 +494,7 @@ in {
         serviceConfig = {
           ExecStart = ''
             ${pkgs.python27Packages.waitress}/bin/waitress-serve \
-            --host=${cfg.api.host} --port=${toString cfg.api.port} \
+            --host=${cfg.api.listenAddress} --port=${toString cfg.api.port} \
             graphite_api.app:app
           '';
           User = "graphite";

--- a/nixos/modules/services/monitoring/statsd.nix
+++ b/nixos/modules/services/monitoring/statsd.nix
@@ -11,7 +11,7 @@ let
 
   configFile = pkgs.writeText "statsd.conf" ''
     {
-      address: "${cfg.host}",
+      address: "${cfg.listenAddress}",
       port: "${toString cfg.port}",
       mgmt_address: "${cfg.mgmt_address}",
       mgmt_port: "${toString cfg.mgmt_port}",
@@ -48,7 +48,7 @@ in
       type = types.bool;
     };
 
-    host = mkOption {
+    listenAddress = mkOption {
       description = "Address that statsd listens on over UDP";
       default = "127.0.0.1";
       type = types.str;

--- a/nixos/modules/services/networking/shout.nix
+++ b/nixos/modules/services/networking/shout.nix
@@ -19,7 +19,7 @@ in {
       '';
     };
 
-    host = mkOption {
+    listenAddress = mkOption {
       type = types.string;
       default = "0.0.0.0";
       description = "IP interface to listen on for http connections.";
@@ -66,7 +66,7 @@ in {
         "${pkgs.shout}/bin/shout"
         (if cfg.private then "--private" else "--public")
         "--port" (toString cfg.port)
-        "--host" (toString cfg.host)
+        "--host" (toString cfg.listenAddress)
         "--home" shoutHome
       ];
       serviceConfig = {

--- a/nixos/modules/services/networking/sslh.nix
+++ b/nixos/modules/services/networking/sslh.nix
@@ -16,7 +16,7 @@ let
 
     listen:
     (
-      { host: "${cfg.host}"; port: "${toString cfg.port}"; }
+      { host: "${cfg.listenAddress}"; port: "${toString cfg.port}"; }
     );
 
     ${cfg.appendConfig}
@@ -56,7 +56,7 @@ in
         description = "PID file path for sslh daemon.";
       };
 
-      host = mkOption {
+      listenAddress = mkOption {
         type = types.str;
         default = config.networking.hostName;
         description = "Listening hostname.";

--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.elasticsearch;
 
   esConfig = ''
-    network.host: ${cfg.host}
+    network.host: ${cfg.listenAddress}
     network.port: ${toString cfg.port}
     network.tcp.port: ${toString cfg.tcp_port}
     cluster.name: ${cfg.cluster_name}
@@ -43,7 +43,7 @@ in {
       type = types.package;
     };
 
-    host = mkOption {
+    listenAddress = mkOption {
       description = "Elasticsearch listen address.";
       default = "127.0.0.1";
       type = types.str;
@@ -142,7 +142,7 @@ in {
         ln -s ${esPlugins}/plugins ${cfg.dataDir}/plugins
       '';
       postStart = mkBefore ''
-        until ${pkgs.curl}/bin/curl -s -o /dev/null ${cfg.host}:${toString cfg.port}; do
+        until ${pkgs.curl}/bin/curl -s -o /dev/null ${cfg.listenAddress}:${toString cfg.port}; do
           sleep 1
         done
       '';

--- a/nixos/modules/services/search/kibana.nix
+++ b/nixos/modules/services/search/kibana.nix
@@ -8,7 +8,7 @@ let
   cfgFile = pkgs.writeText "kibana.json" (builtins.toJSON (
     (filterAttrsRecursive (n: v: v != null) ({
       server = {
-        host = cfg.host;
+        host = cfg.listenAddress;
         port = cfg.port;
         ssl = {
           cert = cfg.cert;
@@ -44,7 +44,7 @@ in {
   options.services.kibana = {
     enable = mkEnableOption "enable kibana service";
 
-    host = mkOption {
+    listenAddress = mkOption {
       description = "Kibana listening host";
       default = "127.0.0.1";
       type = types.str;


### PR DESCRIPTION
The idea to do this kind of renaming came from discussion in https://github.com/NixOS/nixpkgs/pull/11897. (Basically, listenAddress is a more descriptive name.)

I initially felt it was a quite good idea, but now I'm not _that_ enthusiastic. Several programs refer to their listen address as "host" anyway (so I do see why our modules often use "host"). I'm not sure if this PR falls into the bikeshed category or not, but the job is done and here it is :-D

WARNING: Only eval checked. I cannot guarantee that I didn't make a typo or forgot to update a dependent module (if such module(s) exist in the set I'm touching).

CC @garbas.
