### PR TITLE
bind: Fix patching Makefile.in

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -10,11 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1w4gp4hdkb452nmz91l413d1rx89isl2l6wv8kpbdd2afpc3phws";
   };
 
-  postPatchPhase = ''
-    sed -i 's/^\t.*run/\t/' Makefile.in
-  '';
-
-  patches = [ ./libressl.patch ];
+  patches = [ ./libressl.patch ./remove-mkdir-var.patch ];
 
   buildInputs = [ openssl libtool perl libxml2 ];
 

--- a/pkgs/servers/dns/bind/remove-mkdir-var.patch
+++ b/pkgs/servers/dns/bind/remove-mkdir-var.patch
@@ -1,0 +1,12 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -53,8 +53,7 @@ docclean manclean maintainer-clean::
+ doc man:: ${MANOBJS}
+ 
+ installdirs:
+-	$(SHELL) ${top_srcdir}/mkinstalldirs ${DESTDIR}${bindir} \
+-	${DESTDIR}${localstatedir}/run ${DESTDIR}${sysconfdir}
++	$(SHELL) ${top_srcdir}/mkinstalldirs ${DESTDIR}${bindir} ${DESTDIR}${sysconfdir}
+	$(SHELL) ${top_srcdir}/mkinstalldirs ${DESTDIR}${mandir}/man1
+ 
+ install:: isc-config.sh installdirs


### PR DESCRIPTION
There is no postPatchPhase.

Fixes a bug introduced by the libressl patch, should have either been postPatch or like this which probably is cleaner anyway.
