### PR TITLE
wine: add initial pulseaudio support

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, pkgArches,
   name, version, src, monos, geckos, platforms,
+  pulseaudioSupport,
   buildScript ? null, configureFlags ? ""
 }:
 
@@ -19,7 +20,9 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
 
   nativeBuildInputs = toBuildInputs pkgArches (pkgs: (with pkgs; [
     freetype fontconfig mesa mesa_noglu.osmesa libdrm libpng libjpeg openssl gnutls cups ncurses
-  ]) ++ (with pkgs.xorg; [
+  ])
+  ++ lib.optional pulseaudioSupport pkgs.libpulseaudio
+  ++ (with pkgs.xorg; [
     xlibsWrapper libXi libXcursor libXinerama libXrandr libXrender libXxf86vm libXcomposite
   ]));
 

--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -9,11 +9,13 @@
 { lib, pkgs, system, callPackage,
   wineRelease ? "stable",
   wineBuild ? (if system == "x86_64-linux" then "wineWow" else "wine32"),
+  pulseaudioSupport ? false,
   libtxc_dxtn_Name ? "libtxc_dxtn_s2tc" }:
 
 let wine-build = build: release:
       lib.getAttr build (callPackage ./packages.nix {
         wineRelease = release;
+        inherit pulseaudioSupport;
       });
 
 in if wineRelease == "staging" then

--- a/pkgs/misc/emulators/wine/packages.nix
+++ b/pkgs/misc/emulators/wine/packages.nix
@@ -1,4 +1,5 @@
 { system, stdenv, stdenv_32bit, lib, pkgs, pkgsi686Linux, fetchurl,
+  pulseaudioSupport,
   wineRelease ? "stable"
 }:
 
@@ -30,6 +31,7 @@ in {
     name = "wine-${version}";
     inherit (sources) version src;
     inherit (pkgsi686Linux) lib stdenv;
+    inherit pulseaudioSupport;
     pkgArches = [ pkgsi686Linux ];
     geckos = with sources; [ wineGecko32 ];
     monos = with sources; [ wineMono ];
@@ -39,6 +41,7 @@ in {
     name = "wine64-${version}";
     inherit (sources) version src;
     inherit lib stdenv;
+    inherit pulseaudioSupport;
     pkgArches = [ pkgs ];
     geckos = with sources; [ wineGecko64 ];
     monos = with sources; [ wineMono ];
@@ -50,6 +53,7 @@ in {
     inherit (sources) version src;
     inherit lib;
     stdenv = stdenv_32bit;
+    inherit pulseaudioSupport;
     pkgArches = [ pkgs pkgsi686Linux ];
     geckos = with sources; [ wineGecko32 wineGecko64 ];
     monos = with sources; [ wineMono ];

--- a/pkgs/misc/emulators/wine/staging.nix
+++ b/pkgs/misc/emulators/wine/staging.nix
@@ -15,7 +15,7 @@ let v = (import ./versions.nix).staging;
 in assert (builtins.parseDrvName wineUnstable.name).version == version;
 
 stdenv.lib.overrideDerivation wineUnstable (self: {
-  nativeBuildInputs = build-inputs [ "libpulseaudio" libtxc_dxtn_Name ] self.nativeBuildInputs; 
+  nativeBuildInputs = build-inputs [ libtxc_dxtn_Name ] self.nativeBuildInputs; 
   buildInputs = build-inputs [ "perl" "utillinux" "autoconf" ] self.buildInputs;
 
   name = "${self.name}-staging";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15691,6 +15691,9 @@ let
   wine = callPackage ../misc/emulators/wine {
     wineRelease = config.wine.release or "stable";
     wineBuild = config.wine.build or "wine32";
+    pulseaudioSupport = if (config ? pulseaudio)
+                        then config.pulseaudio
+                        else stdenv.isLinux;
   };
   wineStable = wine.override { wineRelease = "stable"; };
   wineUnstable = lowPrio (wine.override { wineRelease = "unstable"; });


### PR DESCRIPTION
tested it on my machine - don't really know, if/how i should/could test for pulseaudio on the system...
but wine here seems to be only for linux, so it's probably fine (assert in base.nix)

merry gaming season, wine-gamers on nixos,
ikervagyok
