### PR TITLE
xserver: make xkbdir configurable

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -280,6 +280,14 @@ in
         '';
       };
 
+      xkbDir = mkOption {
+        type = types.str;
+        default = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+        description = ''
+        Path used for -xkbdir xserver parameter.
+        '';
+      };
+
       config = mkOption {
         type = types.lines;
         description = ''
@@ -462,7 +470,7 @@ in
             target = "X11/xorg.conf";
           }
           # -xkbdir command line option does not seems to be passed to xkbcomp.
-          { source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+          { source = "${cfg.xkbDir}";
             target = "X11/xkb";
           }
         ]);
@@ -528,7 +536,7 @@ in
       [ "-ac"
         "-terminate"
         "-config ${configFile}"
-        "-xkbdir" "${pkgs.xkeyboard_config}/etc/X11/xkb"
+        "-xkbdir" "${cfg.xkbDir}"
       ] ++ optional (cfg.display != null) ":${toString cfg.display}"
         ++ optional (cfg.tty     != null) "vt${toString cfg.tty}"
         ++ optionals (cfg.display != null) [ "-logfile" "/var/log/X.${toString cfg.display}.log" ]


### PR DESCRIPTION
I need to add custom xkb keyboard layouts, making the search path configurable seems to be the easiest way to to it without resorting to patching files in xkeyboard_config.
