### PR TITLE
Add chessx and stockfish (chess engine)

### DIFF
--- a/pkgs/games/chessx/default.nix
+++ b/pkgs/games/chessx/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, pkgconfig, zlib, qtbase, qtsvg, qttools, qtmultimedia, fetchurl }:
+stdenv.mkDerivation rec {
+  name = "chessx-${version}";
+  version = "1.3.2";
+  src = fetchurl {
+    url = "mirror://sourceforge/chessx/chessx-${version}.tgz";
+    sha256 = "b136cf56d37d34867cdb9538176e1703b14f61b3384885b6f100580d0af0a3ff";
+  };
+  preConfigure = ''
+    qmake -spec linux-g++ chessx.pro
+  '';
+  buildInputs = [
+   stdenv
+   pkgconfig
+   qtbase
+   qtsvg
+   qttools
+   qtmultimedia
+   zlib
+  ];
+
+  enableParallelBuilding = true;
+  installPhase = ''
+      mkdir -p "$out/bin"
+      cp -pr release/chessx "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://chessx.sourceforge.net/;
+    description = "ChessX allows you to browse and analyse chess games";
+    license = licenses.gpl2;
+    maintainers = [maintainers.luispedro];
+  };
+}

--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, unzip }:
+stdenv.mkDerivation rec {
+  version = "6";
+  name = "stockfish-${version}";
+  src = fetchurl {
+    url = https://stockfish.s3.amazonaws.com/stockfish-6-src.zip;
+    sha256 = "a69a371d3f84338cefde4575669bd930d186b046a10fa5ab0f8d1aed6cb204c3";
+  };
+  buildPhase = ''
+  cd src
+  make build ARCH=x86-64
+  '';
+  buildInputs = [
+        stdenv
+        unzip
+  ];
+  enableParallelBuilding = true;
+  installPhase = ''
+  mkdir -p $out/bin
+  cp -pr stockfish $out/bin
+  '';
+  meta = with stdenv.lib; {
+    homepage = https://stockfishchess.org/;
+    description = "Strong open source chess engine";
+    longDescription = ''
+      Stockfish is one of the strongest chess engines in the world. It is also
+      much stronger than the best human chess grandmasters.
+      '';
+    maintainers = with maintainers; [ luispedro ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13998,6 +13998,8 @@ let
 
   chessdb = callPackage ../games/chessdb { };
 
+  chessx = qt5.callPackage ../games/chessx { };
+
   chocolateDoom = callPackage ../games/chocolate-doom { };
 
   cockatrice = qt5.callPackage ../games/cockatrice {  };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14294,6 +14294,8 @@ let
 
   stardust = callPackage ../games/stardust {};
 
+  stockfish = callPackage ../games/stockfish { };
+
   steamPackages = callPackage ../games/steam { };
   steam = steamPackages.steam-chrootenv.override {
     # DEPRECATED


### PR DESCRIPTION
These are utilities to analyse chess games (a viewer, chessx; and a chess engine, stockfish).

The chess engine is actually optional for chessx usage, but I it's a very useful add-on and the whole stockfish package takes on 344K on disk, so I chose to just list it as a `propagatedBuildInput` so users get it automatically.
