### PR TITLE
installation-cd-graphical: Enable the 'synaptics' touchpad driver

### DIFF
--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -8,6 +8,7 @@
     enable = true;
     displayManager.kdm.enable = true;
     desktopManager.kde4.enable = true;
+    synaptics.enable = true; # for touchpad support on many laptops
   };
 
   environment.systemPackages = [ pkgs.glxinfo ];


### PR DESCRIPTION
This is needed to get touchpad working in the installer on several
laptops. Tested on a Thinkpad X250.
