### PR TITLE
rkt: align stage1 information with upstream source

### DIFF
--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -2,11 +2,11 @@
 , fetchurl, fetchFromGitHub }:
 
 let
-  coreosImageRelease = "835.9.0";
-  coreosImageSystemdVersion = "225";
+  coreosImageRelease = "794.1.0";
+  coreosImageSystemdVersion = "222";
 
   # TODO: track https://github.com/coreos/rkt/issues/1758 to allow "host" flavor.
-  stage1Flavours = [ "coreos" ];
+  stage1Flavours = [ "coreos" "fly" ];
 
 in stdenv.mkDerivation rec {
   version = "0.14.0";
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
 
   stage1BaseImage = fetchurl {
     url = "http://stable.release.core-os.net/amd64-usr/${coreosImageRelease}/coreos_production_pxe_image.cpio.gz";
-    sha256 = "51dc10b4269b9c1801c233de49da817d29ca8d858bb0881df94dc90f7e86ce70";
+    sha256 = "05nzl3av6cawr8v203a8c95c443g6h1nfy2n4jmgvn0j4iyy44ym";
   };
 
   buildInputs = [ autoconf automake go file git wget gnupg1 squashfsTools cpio ];


### PR DESCRIPTION
We rely on the upstream tests and hence should not change the
constellation.

See: https://github.com/coreos/rkt/blob/v0.14.0/stage1/usr_from_coreos/coreos-common.mk

Additionally add the "fly" stage1.

/cc @dgonyeo 
