### PR TITLE
taglib-extras: make taglib-extras work with taglib > 1.9

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     libmtp liblastfm libgpod qjson ffmpeg libofa nepomuk_core
   ];
 
+  preConfigure = ''
+    sed -i -e 's/STRLESS/VERSION_LESS/g' cmake/modules/FindTaglib.cmake
+  '';
+
   cmakeFlags = "-DKDE4_BUILD_TESTS=OFF";
 
   propagatedUserEnvPkgs = [ qtscriptgenerator ];

--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     libmtp liblastfm libgpod qjson ffmpeg libofa nepomuk_core
   ];
 
+  # This is already fixed upstream, will be release in 2.9
   preConfigure = ''
     sed -i -e 's/STRLESS/VERSION_LESS/g' cmake/modules/FindTaglib.cmake
   '';

--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -93,6 +93,10 @@ stdenv.mkDerivation rec {
     "-DENABLE_UDISKS2=ON"
   ];
 
+  preConfigure = ''
+    sed -i -e 's/STRLESS/VERSION_LESS/g' cmake/FindTaglib.cmake
+  '';
+
   postInstall = stdenv.lib.optionalString withQt5 ''
     wrapQtProgram "$out/bin/cantata"
   '';

--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -93,6 +93,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_UDISKS2=ON"
   ];
 
+  # This is already fixed upstream but not released yet. Maybe in version 2.
   preConfigure = ''
     sed -i -e 's/STRLESS/VERSION_LESS/g' cmake/FindTaglib.cmake
   '';

--- a/pkgs/development/libraries/taglib-extras/default.nix
+++ b/pkgs/development/libraries/taglib-extras/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
   };
   buildInputs = [ taglib ];
   nativeBuildInputs = [ cmake ];
+
+  # Workaround for upstream bug https://bugs.kde.org/show_bug.cgi?id=357181
   preConfigure = ''
     sed -i -e 's/STRLESS/VERSION_LESS/g' cmake/modules/FindTaglib.cmake
   '';

--- a/pkgs/development/libraries/taglib-extras/default.nix
+++ b/pkgs/development/libraries/taglib-extras/default.nix
@@ -8,4 +8,7 @@ stdenv.mkDerivation rec {
   };
   buildInputs = [ taglib ];
   nativeBuildInputs = [ cmake ];
+  preConfigure = ''
+    sed -i -e 's/STRLESS/VERSION_LESS/g' cmake/modules/FindTaglib.cmake
+  '';
 }


### PR DESCRIPTION
the current taglib_extras code uses STRLESS to compare versions, this fails because the current version 1.10 is STRLESS then the minimum version 1.6.
I replace the comparison with VERSION_LESS which works as intended.
