### PR TITLE
fix ftp.mozilla.org URLs

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/default.nix
+++ b/pkgs/development/interpreters/spidermonkey/default.nix
@@ -2,9 +2,9 @@
 
 stdenv.mkDerivation rec {
   name = "spidermonkey-1.7";
-  
+
   src = fetchurl {
-    url = ftp://ftp.mozilla.org/pub/mozilla.org/js/js-1.7.0.tar.gz;
+    url = https://ftp.mozilla.org/pub/js/js-1.7.0.tar.gz;
     sha256 = "12v6v2ccw1y6ng3kny3xw0lfs58d1klylqq707k0x04m707kydj4";
   };
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   makefileExtra = ./Makefile.extra;
   makefile = "Makefile.ref";
-  
+
   patchPhase =
     ''
       cat ${makefileExtra} >> ${makefile}

--- a/pkgs/development/libraries/java/rhino/default.nix
+++ b/pkgs/development/libraries/java/rhino/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   name = "rhino-${version}";
 
   src = fetchurl {
-    url = "ftp://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R2.zip";
+    url = "https://ftp.mozilla.org/pub/js/rhino1_7R2.zip";
     sha256 = "1p32hkghi6bkc3cf2dcqyaw5cjj7403mykcp0fy8f5bsnv0pszv7";
   };
 

--- a/pkgs/development/libraries/svrcore/default.nix
+++ b/pkgs/development/libraries/svrcore/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "4.0.4";
 
   src = fetchurl {
-    url = "ftp://ftp.mozilla.org/pub/mozilla.org/directory/svrcore/releases/${version}/src/${name}.tar.bz2";
+    url = "https://ftp.mozilla.org/pub/directory/svrcore/releases/${version}/src/${name}.tar.bz2";
     sha256 = "0n3alg6bxml8952fb6h0bi0l29farvq21q6k20gy2ba90m3znwj7";
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8047,17 +8047,18 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
-  MozillaLdap = buildPerlPackage {
-    name = "Mozilla-Ldap-1.5.3";
-    USE_OPENLDAP=1;
-    LDAPSDKDIR=pkgs.openldap;
+  MozillaLdap = buildPerlPackage rec {
+    name = "Mozilla-Ldap-${version}";
+    version = "1.5.3";
+    USE_OPENLDAP = 1;
+    LDAPSDKDIR = pkgs.openldap;
     src = fetchurl {
-      url = "ftp://ftp.mozilla.org/pub/mozilla.org/directory/perldap/releases/1.5.3/src/perl-mozldap-1.5.3.tar.gz";
+      url = "https://ftp.mozilla.org/pub/directory/perldap/releases/${version}/src/perl-mozldap-${version}.tar.gz";
       sha256 = "0s0albdw0zvg3w37s7is7gddr4mqwicjxxsy400n1p96l7ipnw4x";
     };
     meta = {
       description = "Mozilla's ldap client library";
-      license = "unknown";
+      license = with stdenv.lib.licenses; [ mpl20 lgpl21Plus gpl2Plus ];
     };
   };
 


### PR DESCRIPTION
The old URLs time out.
