### PR TITLE
archiveopteryx: init at 3.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -201,6 +201,7 @@
   phausmann = "Philipp Hausmann <nix@314.ch>";
   philandstuff = "Philip Potter <philip.g.potter@gmail.com>";
   phreedom = "Evgeny Egorochkin <phreedom@yandex.ru>";
+  phunehehe = "Hoang Xuan Phu <phunehehe@gmail.com>";
   pierron = "Nicolas B. Pierron <nixos@nbp.name>";
   piotr = "Piotr Pietraszkiewicz <ppietrasa@gmail.com>";
   pjones = "Peter Jones <pjones@devalot.com>";

--- a/pkgs/servers/mail/archiveopteryx/default.nix
+++ b/pkgs/servers/mail/archiveopteryx/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, openssl, perl, zlib }:
+stdenv.mkDerivation rec {
+  version = "3.2.0";
+  name = "archiveopteryx-${version}";
+  src = fetchurl {
+    url = "http://archiveopteryx.org/download/${name}.tar.bz2";
+    sha256 = "0i0zg8di8nbh96qnyyr156ikwcsq1w9b2291bazm5whb351flmqx";
+  };
+  buildInputs = [ openssl perl zlib ];
+  installPhase = ''
+    INSTALLROOT=$out make install
+    mkdir $out/bin
+    ln --symbolic $out/usr/local/archiveopteryx/sbin/* $out/bin/
+    ln --symbolic $out/usr/local/archiveopteryx/bin/* $out/bin/
+  '';
+  meta = with stdenv.lib; {
+    homepage = http://archiveopteryx.org/;
+    description = "An advanced PostgreSQL-based IMAP/POP server";
+    license = licenses.postgresql;
+    maintainers = [ maintainers.phunehehe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8923,6 +8923,8 @@ let
   apacheHttpdPackages_2_2 = apacheHttpdPackagesFor pkgs.apacheHttpd_2_2 pkgs.apacheHttpdPackages_2_2;
   apacheHttpdPackages_2_4 = apacheHttpdPackagesFor pkgs.apacheHttpd_2_4 pkgs.apacheHttpdPackages_2_4;
 
+  archiveopteryx = callPackage ../servers/mail/archiveopteryx/default.nix { };
+
   cadvisor = callPackage ../servers/monitoring/cadvisor { };
 
   cassandra_1_2 = callPackage ../servers/nosql/cassandra/1.2.nix { };


### PR DESCRIPTION
From https://github.com/NixOS/nixpkgs/pull/11841

> If this works out OK, is there a reason not to include it in 15.09? I think it might be fine because it can't break anything existing.
