### PR TITLE
hostapd: rename extraCfg -> extraConfig, added asserts

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -75,6 +75,8 @@ with lib;
     # DNSCrypt-proxy
     (mkRenamedOptionModule [ "services" "dnscrypt-proxy" "port" ] [ "services" "dnscrypt-proxy" "localPort" ])
 
+    (mkRenamedOptionModule [ "services" "hostapd" "extraCfg" ] [ "services" "hostapd" "extraConfig" ])
+
     # Options that are obsolete and have no replacement.
     (mkRemovedOptionModule [ "boot" "initrd" "luks" "enable" ])
     (mkRemovedOptionModule [ "programs" "bash" "enable" ])


### PR DESCRIPTION
hostapd is the only module that uses `extraCfg` instead of `extraConfig`. I also changed the hwMode default to `g`, which should be fine because nobody has `b` hardware anymore, right?
