### PR TITLE
fail2ban:Enable jails by default

### DIFF
--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -138,6 +138,7 @@ in
         findtime = 600
         maxretry = 3
         backend  = systemd
+        enabled  = true
        '';
 
     # Block SSH if there are too many failing connection attempts.


### PR DESCRIPTION
...solving the mystery of why enabling fail2ban has no immediate effect.

We don't have a vast stable of disabled jails, so it probably makes sense to let people explicitly _disable_ them (that is, it) if they really want to. Principle of least astonishment.
