### PR TITLE
use official taglib-extras source

### DIFF
--- a/pkgs/development/libraries/taglib-extras/default.nix
+++ b/pkgs/development/libraries/taglib-extras/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "taglib-extras-1.0.1";
   src = fetchurl {
-    url = "http://www.kollide.net/~jefferai/${name}.tar.gz";
+    url = "http://ftp.rz.uni-wuerzburg.de/pub/unix/kde/taglib-extras/1.0.1/src/${name}.tar.gz";
     sha256 = "0cln49ws9svvvals5fzxjxlzqm0fzjfymn7yfp4jfcjz655nnm7y";
   };
   buildInputs = [ taglib ];


### PR DESCRIPTION
The provided source seems to be some kind of private host.
This uses the official svn repo
