### PR TITLE
fix a fetchgit problem

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -264,7 +264,7 @@ clone_user_rev() {
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
     if test -z "$leaveDotGit"; then
         echo "removing \`.git'..." >&2
-        find $dir -name .git\* | xargs rm -rf
+        find $dir -name .git | xargs rm -rf
     else
         find $dir -name .git | while read gitdir; do
             make_deterministic_repo "$(readlink -f "$gitdir/..")"


### PR DESCRIPTION
`fetchgit` does not only remove `.git` directory, but also `.gitignore` file
