### PR TITLE
anki: major refactor

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchurl, lame, mplayer, libpulseaudio, portaudio
-, python, pyqt4, pythonPackages
+{ stdenv, lib, fetchurl, substituteAll, lame, mplayer
+, libpulseaudio, python, pyqt4, qt4, pythonPackages
 # This little flag adds a huge number of dependencies, but we assume that
 # everyone wants Anki to draw plots with statistics by default.
 , plotsSupport ? true }:
@@ -18,37 +18,59 @@ stdenv.mkDerivation rec {
       sha256 = "1d5rf5gcw98m38wam6wh3hyh7qd78ws7zipm67xg744flqsjrzmr";
     };
 
-    pythonPath = [ pyqt4 py.pysqlite py.sqlalchemy9 py.pyaudio ]
+    pythonPath = [ pyqt4 py.pysqlite py.sqlalchemy9 py.pyaudio py.beautifulsoup py.httplib2 ]
               ++ lib.optional plotsSupport py.matplotlib;
 
     buildInputs = [ python py.wrapPython lame mplayer libpulseaudio ];
 
-    patchPhase = ''
-      substituteInPlace anki/sound.py --replace '["mplayer"]' '["${mplayer}/bin/mplayer"]'
+    phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+
+    patches = [
+      (substituteAll {
+        src = ./fix-paths.patch;
+        inherit lame mplayer qt4;
+        qt4name = qt4.name;
+      })
+    ];
+
+    postPatch = ''
+      substituteInPlace oldanki/lang.py --subst-var-by anki $out
+      substituteInPlace anki/lang.py --subst-var-by anki $out
+
+      # Remove unused starter. We'll create our own, minimalistic,
+      # starter.
+      rm anki/anki
+
+      # Remove QT translation files. We'll use the standard QT ones.
+      rm "locale/"*.qm
     '';
 
-    preConfigure = ''
-      substituteInPlace anki/anki \
-        --replace /usr/share/ $out/share/
+    installPhase = ''
+      pp=$out/lib/${python.libPrefix}/site-packages
 
-      substituteInPlace Makefile \
-        --replace PREFIX=/usr PREFIX=$out \
-        --replace /local/bin/ /bin/
-
-      sed -i '/xdg-mime/ d' Makefile
-    '';
-
-    preInstall = ''
       mkdir -p $out/bin
-      mkdir -p $out/share/pixmaps
       mkdir -p $out/share/applications
+      mkdir -p $out/share/doc/anki
       mkdir -p $out/share/man/man1
-    '';
+      mkdir -p $out/share/mime/packages
+      mkdir -p $out/share/pixmaps
+      mkdir -p $pp
 
-    postInstall = ''
-      mkdir -p "$out/lib/${python.libPrefix}/site-packages"
-      ln -s "$out/share/anki/"* $out/lib/${python.libPrefix}/site-packages/
-      export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+      cat > $out/bin/anki <<EOF
+      #!${python}/bin/python
+      import aqt
+      aqt.run()
+      EOF
+      chmod 755 $out/bin/anki
+
+      cp -v anki.desktop $out/share/applications/
+      cp -v README* LICENSE* $out/share/doc/anki/
+      cp -v anki.1 $out/share/man/man1/
+      cp -v anki.xml $out/share/mime/packages/
+      cp -v anki.{png,xpm} $out/share/pixmaps/
+      cp -rv locale $out/share/
+      cp -rv anki aqt thirdparty/send2trash $pp/
+
       wrapPythonPrograms
     '';
 

--- a/pkgs/games/anki/fix-paths.patch
+++ b/pkgs/games/anki/fix-paths.patch
@@ -1,0 +1,98 @@
+diff -Nurp anki-2.0.33.orig/anki/lang.py anki-2.0.33/anki/lang.py
+--- anki-2.0.33.orig/anki/lang.py	2015-12-27 11:23:02.334908723 +0100
++++ anki-2.0.33/anki/lang.py	2015-12-27 14:06:00.688003103 +0100
+@@ -71,13 +71,7 @@ def ngettext(single, plural, n):
+     return localTranslation().ungettext(single, plural, n)
+ 
+ def langDir():
+-    dir = os.path.join(os.path.dirname(
+-        os.path.abspath(__file__)), "locale")
+-    if not os.path.isdir(dir):
+-        dir = os.path.join(os.path.dirname(sys.argv[0]), "locale")
+-    if not os.path.isdir(dir):
+-        dir = "/usr/share/anki/locale"
+-    return dir
++    return "@anki@/share/locale"
+ 
+ def setLang(lang, local=True):
+     trans = gettext.translation(
+diff -Nurp anki-2.0.33.orig/anki/sound.py anki-2.0.33/anki/sound.py
+--- anki-2.0.33.orig/anki/sound.py	2015-12-27 11:23:02.334908723 +0100
++++ anki-2.0.33/anki/sound.py	2015-12-27 11:34:11.863147265 +0100
+@@ -29,8 +29,9 @@ processingDst = u"rec.mp3"
+ processingChain = []
+ recFiles = []
+ 
++lameCmd = "@lame@/bin/lame"
+ processingChain = [
+-    ["lame", "rec.wav", processingDst, "--noreplaygain", "--quiet"],
++    [lameCmd, "rec.wav", processingDst, "--noreplaygain", "--quiet"],
+     ]
+ 
+ # don't show box on windows
+@@ -44,13 +45,6 @@ if isWin:
+ else:
+     si = None
+ 
+-if isMac:
+-    # make sure lame, which is installed in /usr/local/bin, is in the path
+-    os.environ['PATH'] += ":" + "/usr/local/bin"
+-    dir = os.path.dirname(os.path.abspath(__file__))
+-    dir = os.path.abspath(dir + "/../../../..")
+-    os.environ['PATH'] += ":" + dir + "/audio"
+-
+ def retryWait(proc):
+     # osx throws interrupted system call errors frequently
+     while 1:
+@@ -62,13 +56,7 @@ def retryWait(proc):
+ # Mplayer settings
+ ##########################################################################
+ 
+-if isWin:
+-    mplayerCmd = ["mplayer.exe", "-ao", "win32"]
+-    dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+-    os.environ['PATH'] += ";" + dir
+-    os.environ['PATH'] += ";" + dir + "\\..\\win\\top" # for testing
+-else:
+-    mplayerCmd = ["mplayer"]
++mplayerCmd = ["@mplayer@/bin/mplayer"]
+ mplayerCmd += ["-really-quiet", "-noautosub"]
+ 
+ # Mplayer in slave mode
+@@ -220,7 +208,7 @@ class _Recorder(object):
+         self.encode = encode
+         for c in processingChain:
+             #print c
+-            if not self.encode and c[0] == 'lame':
++            if not self.encode and c[0] == lameCmd:
+                 continue
+             try:
+                 ret = retryWait(subprocess.Popen(c, startupinfo=si))
+diff -Nurp anki-2.0.33.orig/aqt/__init__.py anki-2.0.33/aqt/__init__.py
+--- anki-2.0.33.orig/aqt/__init__.py	2015-12-27 11:23:02.338908782 +0100
++++ anki-2.0.33/aqt/__init__.py	2015-12-27 12:35:03.405565214 +0100
+@@ -107,7 +107,7 @@ def setupLang(pm, app, force=None):
+         app.setLayoutDirection(Qt.LeftToRight)
+     # qt
+     _qtrans = QTranslator()
+-    if _qtrans.load("qt_" + lang, dir):
++    if _qtrans.load("qt_" + lang, "@qt4@/share/@qt4name@/translations"):
+         app.installTranslator(_qtrans)
+ 
+ # App initialisation
+diff -Nurp anki-2.0.33.orig/oldanki/lang.py anki-2.0.33/oldanki/lang.py
+--- anki-2.0.33.orig/oldanki/lang.py	2015-12-27 11:23:02.390909551 +0100
++++ anki-2.0.33/oldanki/lang.py	2015-12-27 14:05:51.663920453 +0100
+@@ -32,11 +32,7 @@ def ngettext(single, plural, n):
+     return localTranslation().ungettext(single, plural, n)
+ 
+ def setLang(lang, local=True):
+-    base = os.path.dirname(os.path.abspath(__file__))
+-    localeDir = os.path.join(base, "locale")
+-    if not os.path.exists(localeDir):
+-        localeDir = os.path.join(
+-            os.path.dirname(sys.argv[0]), "locale")
++    localeDir = "@anki@/share/locale"
+     trans = gettext.translation('libanki', localeDir,
+                                 languages=[lang],
+                                 fallback=True)


### PR DESCRIPTION
This refactoring changes a number of things:
- use system copies of Python libraries BeautifulSoup, and HTTPLIB2,
- custom install to avoid installation of unnecessary files and poor directory structure, and
- add patch for sorting out file paths, in particular this fixes localization and error during execution of `lame`.

The patch twiddling above also makes Anki seem to run fine on non-NixOS.

Note, I was thinking about using the system jquery and jquery-ui packages but didn't bother. Might be worth revisiting if there is interest.
