### PR TITLE
Make gpgkey2ssh use absolute path to gpg2, fixes #11912

### DIFF
--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
     = [ readline zlib libgpgerror libgcrypt libassuan libksba pth
         openldap bzip2 libusb curl libiconv ];
 
-  patchPhase = ''
+  patches = [ ./gpgkey2ssh-20.patch ];
+
+  prePatch = ''
     find tests -type f | xargs sed -e 's@/bin/pwd@${coreutils}&@g' -i
   '' + stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
@@ -34,6 +36,8 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = optional x11Support "--with-pinentry-pgm=${pinentry}/bin/pinentry";
+
+  postConfigure = "substituteAllInPlace tools/gpgkey2ssh.c";
 
   checkPhase="GNUPGHOME=`pwd` ./agent/gpg-agent --daemon make check";
 

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -20,9 +20,13 @@ stdenv.mkDerivation rec {
     sha256 = "1ybcsazjm21i2ys1wh49cz4azmqz7ghx5rb6hm4gm93i2zc5igck";
   };
 
+  patches = [ ./gpgkey2ssh-21.patch ];
+
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(
+
+  postConfigure = "substituteAllInPlace tools/gpgkey2ssh.c";
 
   buildInputs = [
     pkgconfig libgcrypt libassuan libksba libiconv npth

--- a/pkgs/tools/security/gnupg/gpgkey2ssh-20.patch
+++ b/pkgs/tools/security/gnupg/gpgkey2ssh-20.patch
@@ -1,0 +1,14 @@
+diff --git a/tools/gpgkey2ssh.c b/tools/gpgkey2ssh.c
+index 903fb5b..d5611dc 100644
+--- a/tools/gpgkey2ssh.c
++++ b/tools/gpgkey2ssh.c
+@@ -266,7 +266,7 @@ main (int argc, char **argv)
+   keyid = argv[1];
+ 
+   ret = asprintf (&command,
+-		  "gpg --list-keys --with-colons --with-key-data '%s'",
++		  "@out@/bin/gpg2 --list-keys --with-colons --with-key-data '%s'",
+ 		  keyid);
+   assert (ret > 0);
+ 
+

--- a/pkgs/tools/security/gnupg/gpgkey2ssh-21.patch
+++ b/pkgs/tools/security/gnupg/gpgkey2ssh-21.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/gpgkey2ssh.c b/tools/gpgkey2ssh.c
+index f12c5f4..2e3f2ac 100644
+--- a/tools/gpgkey2ssh.c
++++ b/tools/gpgkey2ssh.c
+@@ -281,7 +281,7 @@ main (int argc, char **argv)
+   keyid = argv[1];
+ 
+   asprintf (&command,
+-            "gpg2 --list-keys --with-colons --with-key-data '%s'",
++            "@out@/bin/gpg2 --list-keys --with-colons --with-key-data '%s'",
+             keyid);
+   if (! command)
+     {


### PR DESCRIPTION
This is a fix for #11912 to point the gpgkey2ssh binary to the absolute path of gpg2.

gpgkey2ssh is a bit poorly written and seems kind of written off by upstream, but since there is demand for it, this is a simple fix.
