### PR TITLE
WIP: darktable: add version 2.0.0

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -4,26 +4,28 @@
 , lensfun, libXau, libXdmcp, libexif, libglade, libgphoto2, libjpeg
 , libpng, libpthreadstubs, libraw1394, librsvg, libtiff, libxcb
 , openexr, pixman, pkgconfig, sqlite, bash, libxslt, openjpeg
-, mesa }:
+, mesa, majorVersion ? 1, gtk3, lua5_2, pugixml }:
 
 assert stdenv ? glibc;
 
 stdenv.mkDerivation rec {
-  version = "1.6.9";
+  version = if majorVersion == 1 then "1.6.9" else "2.0.0";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "0wri89ygjpv7npiz58mnydhgldywp6arqp9jq3v0g54a56fiwwhg";
+    sha256 = if majorVersion == 1 then "0wri89ygjpv7npiz58mnydhgldywp6arqp9jq3v0g54a56fiwwhg" else "1cbwvzqn3158cy7r499rdwipx7fpb30lrrvh6jy5a4xvpcjzbwnl";
   };
 
   buildInputs =
-    [ GConf atk cairo cmake curl dbus_glib exiv2 glib libgnome_keyring gtk
+    [ GConf atk cairo cmake curl dbus_glib exiv2 glib libgnome_keyring (if  majorVersion == 1 then gtk else gtk3)
       ilmbase intltool lcms lcms2 lensfun libXau libXdmcp libexif
-      libglade libgphoto2 libjpeg libpng libpthreadstubs libraw1394
+      libglade libgphoto2 libjpeg libpng libpthreadstubs
       librsvg libtiff libxcb openexr pixman pkgconfig sqlite libxslt
       libsoup graphicsmagick SDL json_glib openjpeg mesa
-    ];
+    ]
+++ stdenv.lib.optional (majorVersion == 1) libraw1394
+++ stdenv.lib.optional (majorVersion == 2) [ lua5_2 (pugixml.override {pic = true;}) ];
 
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk}/include/gtk-2.0"

--- a/pkgs/applications/misc/osm-gps-map/default.nix
+++ b/pkgs/applications/misc/osm-gps-map/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, gtkdoc, libtool, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.0";
+  name = "osm-gps-map-${version}";
+
+  src = fetchFromGitHub {
+    owner = "nzjrs";
+    repo = "osm-gps-map";
+    rev = "${version}";
+    sha256 = "0hx6s67cnf37b8z4kcm6dsmnyrp2qlhvr3zhk3g3lq8ra5wrmn1v";
+  };
+
+ nativeBuildInputs = [ autoreconfHook autoconf automake libtool gtkdoc];
+
+  buildInputs = [ ];
+
+  meta = with stdenv.lib; {
+    description = "Gtk+ Widget for Displaying OpenStreetMap tiles";
+    homepage = http://nzjrs.github.io/osm-gps-map;
+    maintainers = [ maintainers.ikervagyok ];
+  };
+}

--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake }:
+{ stdenv, fetchurl, cmake, pic ? false }:
 
 stdenv.mkDerivation rec {
   name = "pugixml-${version}";
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     # Enable long long support (required for filezilla)
     sed -ire '/PUGIXML_HAS_LONG_LONG/ s/^\/\///' ../src/pugiconfig.hpp
   '';
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional pic "-fpic";
 
   meta = with stdenv.lib; {
     description = "Light-weight, simple and fast XML parser for C++ with XPath support";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11363,6 +11363,7 @@ let
   darktable = callPackage ../applications/graphics/darktable {
     inherit (gnome) GConf libglade;
   };
+  darktable2 = darktable.override {majorVersion = 2;};
 
   das_watchdog = callPackage ../tools/system/das_watchdog { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11365,6 +11365,11 @@ let
   };
   darktable2 = darktable.override {majorVersion = 2;};
 
+  osm-gps-map = callPackage ../applications/misc/osm-gps-map {
+    inherit (gnome) gtkdoc;
+  };
+
+
   das_watchdog = callPackage ../tools/system/das_watchdog { };
 
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};


### PR DESCRIPTION
also make it optional, as once darktable is updated, there's problems going back to version 1.6

see: `http://www.darktable.org/2015/12/darktable-2-0-released/`
`when updating from the currently stable 1.6.x series, please bear in mind that your edits will be preserved during this process, but it will not be possible to downgrade from 2.0 to 1.6.x any more.`
