### PR TITLE
sudo: Compile with '--with-iologdir' to improve build purity

### DIFF
--- a/pkgs/tools/security/sudo/default.nix
+++ b/pkgs/tools/security/sudo/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     "--with-rundir=/run/sudo"
     "--with-vardir=/var/db/sudo"
     "--with-logpath=/var/log/sudo.log"
+    "--with-iologdir=/var/log/sudo-io"
     "--with-sendmail=${sendmailPath}"
   ] ++ stdenv.lib.optional withInsults [
     "--with-insults"


### PR DESCRIPTION
Otherwise it will try to guess the log directory, and the guess might
not be the same if chroot builds are enabled or not.

The gruesome details from m4/sudo.m4:

```
dnl
dnl Where the I/O log files go, use /var/log/sudo-io if
dnl /var/log exists, else /{var,usr}/adm/sudo-io
dnl
AC_DEFUN([SUDO_IO_LOGDIR], [
    AC_MSG_CHECKING(for I/O log dir location)
    if test "${with_iologdir-yes}" != "yes"; then
        iolog_dir="$with_iologdir"
    elif test -d "/var/log"; then
        iolog_dir="/var/log/sudo-io"
    elif test -d "/var/adm"; then
        iolog_dir="/var/adm/sudo-io"
    else
        iolog_dir="/usr/adm/sudo-io"
    fi
    if test "${with_iologdir}" != "no"; then
        SUDO_DEFINE_UNQUOTED(_PATH_SUDO_IO_LOGDIR, "$iolog_dir")
    fi
    AC_MSG_RESULT($iolog_dir)
])dnl
```
