### PR TITLE
openssh: Compile with '--with-pid-dir' to improve build purity

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   # properly when cross building.
   configureFlags = [
     "--localstatedir=/var"
+    "--with-pid-dir=/run"
     "--with-mantype=man"
     "--with-libedit=yes"
     "--disable-strip"
@@ -61,6 +62,7 @@ stdenv.mkDerivation rec {
     cp contrib/ssh-copy-id.1 $out/share/man/man1/
   '';
 
+  installTargets = [ "install-nokeys" ];
   installFlags = [
     "sysconfdir=\${out}/etc/ssh"
   ];


### PR DESCRIPTION
The configure script tries to probe whether /var/run exists when
determining the location for the pid file, which is not very nice when
doing chroot builds. Just set it explicitly to avoid the problem.

For reference, the culprit in configure.ac:

```
piddir=/var/run
if test ! -d $piddir ; then
        piddir=`eval echo ${sysconfdir}`
        case $piddir in
                NONE/*) piddir=`echo $piddir | sed "s~NONE~$ac_default_prefix~"` ;;
        esac
fi

AC_ARG_WITH([pid-dir],
        [  --with-pid-dir=PATH     Specify location of ssh.pid file],
...

```

Also, use the `install-nokeys` target in installPhase so we avoid
installing useless host keys into $out/etc/ssh and improve built purity
as well.
