### PR TITLE
diffoscope: 29 -> 44 

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -5,33 +5,30 @@
 
 pythonPackages.buildPythonPackage rec {
   name = "diffoscope-${version}";
-  version = "29";
+  version = "44";
 
   namePrefix = "";
 
   src = fetchgit {
     url = "git://anonscm.debian.org/reproducible/diffoscope.git";
     rev = "refs/tags/${version}";
-    sha256 = "0q7hx2wm9gvzl1f7iilr9pjwpv8i2anscqan7cgk80v90s2pakrf";
+    sha256 = "1sisdmh1bl62b16yfjy9mxxdfzhskrabp0l3pl1kxn7db0c4vpac";
   };
 
   postPatch = ''
-    # Different pkg name in debian
-    sed -i setup.py -e "s@'magic'@'Magic-file-extensions'@"
-
     # Upstream doesn't provide a PKG-INFO file
-    sed -i setup.py -e "/'rpm',/d"
+    sed -i setup.py -e "/'rpm-python',/d"
   '';
 
-  # Still missing these tools: ghc javap showttf sng
-  propagatedBuildInputs = (with pythonPackages; [ debian libarchive-c magic ssdeep ]) ++
+  # Still missing these tools: enjarify ghc img2txt javap otool(maybe OS X only) ppudump showttf sng
+  # Also these libraries: python3-guestfs
+  propagatedBuildInputs = (with pythonPackages; [ debian libarchive-c python_magic tlsh ]) ++
     [ acl binutils bzip2 cdrkit cpio diffutils e2fsprogs file gettext gnupg
       gzip pdftk poppler_utils rpm sqlite squashfsTools unzip vim xz ];
 
   doCheck = false; # Calls 'mknod' in squashfs tests, which needs root
 
   postInstall = ''
-    mv $out/bin/diffoscope.py $out/bin/diffoscope
     mkdir -p $out/share/man/man1
     ${docutils}/bin/rst2man.py debian/diffoscope.1.rst $out/share/man/man1/diffoscope.1
   '';

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, pythonPackages, docutils
-, acl, binutils, bzip2, cdrkit, cpio, diffutils, e2fsprogs, file, gettext
-, gnupg, gzip, pdftk, poppler_utils, rpm, sqlite, squashfsTools, unzip, vim, xz
+, acl, binutils, bzip2, cbfstool, cdrkit, cpio, diffutils, e2fsprogs, file, fpc, gettext, ghc, gnupg1
+, gzip, jdk, libcaca, mono, pdftk, poppler_utils, rpm, sng, sqlite, squashfsTools, unzip, vim, xz
 }:
 
 pythonPackages.buildPythonPackage rec {
@@ -20,11 +20,11 @@ pythonPackages.buildPythonPackage rec {
     sed -i setup.py -e "/'rpm-python',/d"
   '';
 
-  # Still missing these tools: enjarify ghc img2txt javap otool(maybe OS X only) ppudump showttf sng
+  # Still missing these tools: enjarify otool(maybe OS X only) showttf
   # Also these libraries: python3-guestfs
   propagatedBuildInputs = (with pythonPackages; [ debian libarchive-c python_magic tlsh ]) ++
-    [ acl binutils bzip2 cdrkit cpio diffutils e2fsprogs file gettext gnupg
-      gzip pdftk poppler_utils rpm sqlite squashfsTools unzip vim xz ];
+    [ acl binutils bzip2 cbfstool cdrkit cpio diffutils e2fsprogs file fpc gettext ghc gnupg1
+      gzip jdk libcaca mono pdftk poppler_utils rpm sng sqlite squashfsTools unzip vim xz ];
 
   doCheck = false; # Calls 'mknod' in squashfs tests, which needs root
 

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_LINK = "-L${elfutils}/lib";
 
+  postPatch = ''
+    # For Python3, the original expression evaluates as 'python3.4' but we want 'python3.4m' here
+    substituteInPlace configure --replace 'python''${PYTHON_VERSION}' ${python.executable}
+  '';
+
   configureFlags = "--with-external-db --without-lua --enable-python";
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1285,7 +1285,10 @@ let
 
   di = callPackage ../tools/system/di { };
 
-  diffoscope = callPackage ../tools/misc/diffoscope { };
+  diffoscope = callPackage ../tools/misc/diffoscope {
+    pythonPackages = python3Packages;
+    rpm = rpm.override { python = python3; };
+  };
 
   diffstat = callPackage ../tools/text/diffstat { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1286,6 +1286,7 @@ let
   di = callPackage ../tools/system/di { };
 
   diffoscope = callPackage ../tools/misc/diffoscope {
+    jdk = jdk7;
     pythonPackages = python3Packages;
     rpm = rpm.override { python = python3; };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21111,6 +21111,29 @@ in modules // {
     };
   };
 
+  tlsh = buildPythonPackage rec {
+    name = "tlsh-3.4.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "trendmicro";
+      repo = "tlsh";
+      rev = "b319aed6a270cc765347296b442820c495018833";
+      sha256 = "08ysniihvidcyvh9zip64wwvj7mvxvsqs60ci8cxj28f1ip0n8wg";
+    };
+    buildInputs = with pkgs; [ cmake ];
+    preConfigure = ''
+      mkdir build
+      cd build
+      cmake ..
+      cd ../py_ext
+    '';
+    meta = with stdenv.lib; {
+      description = "Trend Micro Locality Sensitive Hash";
+      homepage = https://github.com/trendmicro/tlsh;
+      license = licenses.asl20;
+      platforms = platforms.linux;
+    };
+  };
+
   toposort = buildPythonPackage rec {
     name = "toposort-${version}";
     version = "1.1";


### PR DESCRIPTION
Relevant changes:
- Python version switched to Python 3
- ssdeep library got replaced with tlsh
- the 'magic' Python package got replaced with a different one
- Minor build system improvements == less work for us

In total the changes are fairly large and I'm not terribly familiar with Python packaging, so maybe @domenkozar could have a quick look?
