### PR TITLE
make-initrd: store all files with root as owner

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -39,7 +39,7 @@ mkdir -p $out
 for PREP in $prepend; do
   cat $PREP >> $out/initrd
 done
-(cd root && find * -print0 | cpio -o -H newc --null | perl $cpioClean | $compressor >> $out/initrd)
+(cd root && find * -print0 | cpio -o -H newc -R 0:0 --null | perl $cpioClean | $compressor >> $out/initrd)
 
 if [ -n "$makeUInitrd" ]; then
     mv $out/initrd $out/initrd.gz


### PR DESCRIPTION
This was initially done as a fix to a certain kernel which wouldn't boot the other way. Later it was discovered that the kernel had `fs.protected_hardlinks` and `fs.protected_symlinks` enabled by default (which was reverted), but this fix looks like generally the Right Thing to do (and shouldn't harm).
