### PR TITLE
command-not-found: add NIX_AUTO_RUN option, to automatically invoke nix-shell

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -16,7 +16,7 @@ let
     isExecutable = true;
     inherit (pkgs) perl;
     perlFlags = concatStrings (map (path: "-I ${path}/lib/perl5/site_perl ")
-      [ pkgs.perlPackages.DBI pkgs.perlPackages.DBDSQLite ]);
+      [ pkgs.perlPackages.DBI pkgs.perlPackages.DBDSQLite pkgs.perlPackages.StringShellQuote ]);
   };
 
 in

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -30,7 +30,7 @@ in
         local p=/run/current-system/sw/bin/command-not-found
         if [ -x $p -a -f /nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite ]; then
           # Run the helper program.
-          $p "$1"
+          $p "$@"
           # Retry the command if we just installed it.
           if [ $? = 126 ]; then
             "$@"
@@ -51,7 +51,7 @@ in
         local p=/run/current-system/sw/bin/command-not-found
         if [ -x $p -a -f /nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite ]; then
           # Run the helper program.
-          $p "$1"
+          $p "$@"
 
           # Retry the command if we just installed it.
           if [ $? = 126 ]; then

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -3,6 +3,7 @@
 use strict;
 use DBI;
 use DBD::SQLite;
+use String::ShellQuote;
 use Config;
 
 my $program = $ARGV[0];
@@ -31,6 +32,8 @@ the package ‘$package’, which I will now install for you.
 EOF
         ;
         exit 126 if system("nix-env", "-iA", "nixos.$package") == 0;
+    } elsif ($ENV{"NIX_AUTO_RUN"} // "") {
+        exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
     } else {
         print STDERR <<EOF;
 The program ‘$program’ is currently not installed. You can install it by typing:

--- a/pkgs/shells/fish/command-not-found.patch
+++ b/pkgs/shells/fish/command-not-found.patch
@@ -1,0 +1,13 @@
+diff --git a/share/functions/__fish_config_interactive.fish b/share/functions/__fish_config_interactive.fish
+index c3864a8..a12ac4d 100644
+--- a/share/functions/__fish_config_interactive.fish
++++ b/share/functions/__fish_config_interactive.fish
+@@ -230,7 +230,7 @@ function __fish_config_interactive -d "Initializations that should be performed
+ 		# Check for NixOS handler
+ 		else if test -f /run/current-system/sw/bin/command-not-found
+ 			function __fish_command_not_found_handler --on-event fish_command_not_found
+-				/run/current-system/sw/bin/command-not-found $argv[1]
++				/run/current-system/sw/bin/command-not-found $argv
+ 			end
+ 		# Ubuntu Feisty places this command in the regular path instead
+ 		else if type -q -p command-not-found

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation rec {
   name = "fish-${version}";
   version = "2.2.0";
 
+  patches = [ ./command-not-found.patch ];
+
   src = fetchurl {
     url = "http://fishshell.com/files/${version}/${name}.tar.gz";
     sha256 = "0ympqz7llmf0hafxwglykplw6j5cz82yhlrw50lw4bnf2kykjqx7";


### PR DESCRIPTION
This also patches up the fish, zsh, and bash command-not-found hooks, to pass the full argv through to command-not-found.
