### PR TITLE
amarok: add necessary dependencies to fix failing build

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -2,6 +2,7 @@
 , qtscriptgenerator, gettext, curl , libxml2, mysql, taglib
 , taglib_extras, loudmouth , kdelibs , qca2, libmtp, liblastfm, libgpod
 , phonon , strigi, soprano, qjson, ffmpeg, libofa, nepomuk_core ? null
+, lz4, lzo, snappy, libaio
 }:
 
 stdenv.mkDerivation rec {
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
     qtscriptgenerator stdenv.cc.libc gettext curl libxml2 mysql.lib
     taglib taglib_extras loudmouth kdelibs phonon strigi soprano qca2
     libmtp liblastfm libgpod qjson ffmpeg libofa nepomuk_core
+    lz4 lzo snappy libaio
   ];
 
   # This is already fixed upstream, will be release in 2.9


### PR DESCRIPTION
The amarok build has been failing for some time, this makes it build again.

Attention: Amarok will build with this, but the build in itself is still quite broken and music playback does not work because of other issues.
I will try to fix the remaining issues in follow-up pull requests.
