### PR TITLE
goPackages: start restructuring packages

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -113,10 +113,12 @@ rec {
      foldAttrs (n: a: [n] ++ a) [] [{ a = 2; } { a = 3; }]
      => { a = [ 2 3 ]; }
   */
-  foldAttrs = op: nul: list_of_attrs:
+  foldAttrs = op: foldAttrsWithKey (k: op);
+
+  foldAttrsWithKey = op: nul: list_of_attrs:
     fold (n: a:
         fold (name: o:
-          o // (listToAttrs [{inherit name; value = op n.${name} (a.${name} or nul); }])
+          o // (listToAttrs [{inherit name; value = op name n.${name} (a.${name} or nul); }])
         ) a (attrNames n)
     ) {} list_of_attrs;
 


### PR DESCRIPTION
This is a new scheme that I think avoids a lot of repetition resulting from the fact that the vast majority of the go package ecosystem lives on GitHub, and it's fairly common practice for people to depend on forks
with identical names.

This scheme structures a subset of the go package universe after GitHub namespaces, so all packages are scoped by author and then by repo. In the simplest case, all one needs to provide for a given owner/repo case is an attrset containing the revision and a sha256 for it. One can still obviously add more attributes for more complicated builds.

To save users (and other developers) from having to qualify all package names (like `hashicorp.consul` or `spf13.hugo`), I implemented a simple flattening scheme, where if the package name is unambiguous, one can refer to it unqualified. If it ambiguous, I throw an error explaining the ambiguity, telling the user to use a qualified attribute path.

This change doesn't, as far as I can tell, change any hashes.

If people like the proposal, we can start progressively moving things from the less structured attrset to the more structured one.

cc @wkennington (this is the thing we talked about on IRC) @lethalman @benley and other go contributors.
