### PR TITLE
Basic Declaritive Network Configuration in wpa_supplicant Service

### DIFF
--- a/nixos/doc/manual/configuration/wireless.xml
+++ b/nixos/doc/manual/configuration/wireless.xml
@@ -18,8 +18,18 @@ NixOS will start wpa_supplicant for you if you enable this setting:
 networking.wireless.enable = true;
 </programlisting>
 
-NixOS currently does not generate wpa_supplicant's
-configuration file, <literal>/etc/wpa_supplicant.conf</literal>. You should edit this file
+NixOS lets you specify networks for wpa_supplicant declaratively:
+<programlisting>
+networking.wireless.networks = {
+  echelon = {
+    psk = "abcdefgh";
+  };
+  "free.wifi" = {};
+}
+</programlisting>
+
+When no networks are set it will default to using a configuration file at
+<literal>/etc/wpa_supplicant.conf</literal>. You should edit this file
 yourself to define wireless networks, WPA keys and so on (see
 wpa_supplicant.conf(5)).
 </para>

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -4,33 +4,29 @@ with lib;
 
 let
   cfg = config.networking.wireless;
-  configFile = "/etc/wpa_supplicant.conf";
+  configFile = if cfg.networks != {} then pkgs.writeText "wpa_supplicant.conf" ''
+    ${optionalString cfg.userControlled.enable ''
+      ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=${cfg.userControlled.group}
+      update_config=1''}
+    ${concatStringsSep "\n" (mapAttrsToList (ssid: networkConfig: ''
+      network={
+        ssid="${ssid}"
+        ${optionalString (networkConfig.psk != null) ''psk="${networkConfig.psk}"''}
+        ${optionalString (networkConfig.psk == null) ''key_mgmt=NONE''}
+      }
+    '') cfg.networks)}
+  '' else "/etc/wpa_supplicant.conf";
 in {
   options = {
     networking.wireless = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to start <command>wpa_supplicant</command> to scan for
-          and associate with wireless networks.  Note: NixOS currently
-          does not manage <command>wpa_supplicant</command>'s
-          configuration file, <filename>${configFile}</filename>.  You
-          should edit this file yourself to define wireless networks,
-          WPA keys and so on (see
-          <citerefentry><refentrytitle>wpa_supplicant.conf</refentrytitle>
-          <manvolnum>5</manvolnum></citerefentry>), or use
-          networking.wireless.userControlled.* to allow users to add entries
-          through <command>wpa_cli</command> and <command>wpa_gui</command>.
-        '';
-      };
+      enable = mkEnableOption "wpa_supplicant";
 
       interfaces = mkOption {
         type = types.listOf types.str;
         default = [];
         example = [ "wlan0" "wlan1" ];
         description = ''
-          The interfaces <command>wpa_supplicant</command> will use.  If empty, it will
+          The interfaces <command>wpa_supplicant</command> will use. If empty, it will
           automatically use all wireless interfaces.
         '';
       };
@@ -39,6 +35,34 @@ in {
         type = types.str;
         default = "nl80211,wext";
         description = "Force a specific wpa_supplicant driver.";
+      };
+
+      networks = mkOption {
+        type = types.attrsOf (types.submodule {
+          options = {
+            psk = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                The network's pre-shared key in plaintext defaulting
+                to being a network without any authentication.
+              '';
+            };
+          };
+        });
+        description = ''
+          The network definitions to automatically connect to when
+           <command>wpa_supplicant</command> is running. If this
+           parameter is left empty wpa_supplicant will use
+          /etc/wpa_supplicant.conf as the configuration file.
+        '';
+        default = {};
+        example = literalExample ''
+          echelon = {
+            psk = "abcdefgh";
+          };
+          "free.wifi" = {};
+        '';
       };
 
       userControlled = {
@@ -51,10 +75,8 @@ in {
             to depend on a large package such as NetworkManager just to pick nearby
             access points.
 
-            When you want to use this, make sure ${configFile} doesn't exist.
-            It will be created for you.
-
-            Currently it is also necessary to explicitly specify networking.wireless.interfaces.
+            When using a declarative network specification you cannot persist any
+            settings via wpa_gui or wpa_cli.
           '';
         };
 

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -3,14 +3,8 @@
 with lib;
 
 let
-
   cfg = config.networking.wireless;
   configFile = "/etc/wpa_supplicant.conf";
-
-  ifaces =
-    cfg.interfaces ++
-    optional (config.networking.WLANInterface != "") config.networking.WLANInterface;
-
 in
 
 {
@@ -18,12 +12,6 @@ in
   ###### interface
 
   options = {
-
-    networking.WLANInterface = mkOption {
-      default = "";
-      description = "Obsolete. Use <option>networking.wireless.interfaces</option> instead.";
-    };
-
     networking.wireless = {
       enable = mkOption {
         type = types.bool;
@@ -95,8 +83,9 @@ in
     services.dbus.packages = [ pkgs.wpa_supplicant ];
 
     # FIXME: start a separate wpa_supplicant instance per interface.
-    jobs.wpa_supplicant =
-      { description = "WPA Supplicant";
+    jobs.wpa_supplicant = let
+      ifaces = cfg.interfaces;
+    in { description = "WPA Supplicant";
 
         wantedBy = [ "network.target" ];
 

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -106,16 +106,6 @@ in {
 
         path = [ pkgs.wpa_supplicant ];
 
-        preStart = ''
-          touch -a ${configFile}
-          chmod 600 ${configFile}
-        '' + optionalString cfg.userControlled.enable ''
-          if [ ! -s ${configFile} ]; then
-            echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=${cfg.userControlled.group}" >> ${configFile}
-            echo "update_config=1" >> ${configFile}
-          fi
-        '';
-
         script = ''
           ${if ifaces == [] then ''
             for i in $(cd /sys/class/net && echo *); do


### PR DESCRIPTION
- remove obsolete option networking.WLANInterface, it has been obsolete for years (according to `git blame`)
- refactored to `systemd.services`
- removed `preStart` in the service which created `/etc/wpa_supplicant.conf` if it didn't exist and `userControlled` was turned on, the code is added to the declarative `wpa_supplicant.conf` if used, but does not change existing setups.
- added basic declarative networks specification currently only supporting open wifi networks and simple PSK authentication

This is backward compatible to current configuration by defaulting to using `/etc/wpa_supplicant.conf` if `networking.wireless.networks` is empty.
