### PR TITLE
yosys, arachne-pnr, icestorm: init

### DIFF
--- a/pkgs/development/compilers/arachne-pnr/default.nix
+++ b/pkgs/development/compilers/arachne-pnr/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, icestorm }:
+
+stdenv.mkDerivation rec {
+  name = "arachne-pnr-${version}";
+  version = "2015.12.29";
+
+  src = fetchFromGitHub {
+    owner = "cseed";
+    repo = "arachne-pnr";
+    rev = "1a4fdf96a7fd08806c032d41a2443c8e17c72c80";
+    sha256 = "1dj7ycffwkmlsh12117fbybkdfnlhxbbxkbfgwfyvcgmg3cacgl1";
+  };
+
+  preBuild = ''
+    makeFlags="DESTDIR=$out $makeFlags"
+  '';
+  makeFlags = "ICEBOX=${icestorm}/share/icebox";
+
+  meta = {
+    description = "Place and route tool for FPGAs";
+    longDescription = ''
+      Arachne-pnr implements the place and route step of
+      the hardware compilation process for FPGAs. It
+      accepts as input a technology-mapped netlist in BLIF
+      format, as output by the Yosys [0] synthesis suite
+      for example. It currently targets the Lattice
+      Semiconductor iCE40 family of FPGAs [1]. Its output
+      is a textual bitstream representation for assembly by
+      the IceStorm [2] icepack command.
+    '';
+    homepage = https://github.com/cseed/arachne-pnr;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.shell ];
+  };
+}

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, fetchFromBitbucket, pkgconfig, tcl, readline, libffi, python3, bison, flex }:
+
+stdenv.mkDerivation rec {
+  name = "yosys-${version}";
+  version = "2015.12.29";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "cliffordwolf";
+      repo = "yosys";
+      rev = "1d62f8710f04fec405ef79b9e9a4a031afcf7d42";
+      sha256 = "0q1dk9in3gmrihb58pjckncx56lj7y4b6y34jgb68f0fh91fdvfx";
+      name = "yosys";
+    })
+    (fetchFromBitbucket {
+      owner = "alanmi";
+      repo = "abc";
+      rev = "c3698e053a7a";
+      sha256 = "05p0fvbr7xvb6w3d7j2r6gynr3ljb6r5q6jvn2zs3ysn2b003qwd";
+      name = "abc";
+    })
+  ];
+  sourceRoot = "yosys";
+
+  buildInputs = [ pkgconfig tcl readline libffi python3 bison flex ];
+  preBuild = ''
+    chmod -R u+w ../abc
+    ln -s ../abc abc
+    make config-gcc
+    echo 'ABCREV := default' >> Makefile.conf
+    makeFlags="PREFIX=$out $makeFlags"
+  '';
+
+  meta = {
+    description = "Framework for RTL synthesis tools";
+    longDescription = ''
+      Yosys is a framework for RTL synthesis tools. It currently has
+      extensive Verilog-2005 support and provides a basic set of
+      synthesis algorithms for various application domains.
+
+      Yosys can be adapted to perform any synthesis job by combining
+      the existing passes (algorithms) using synthesis scripts and
+      adding additional passes as needed by extending the yosys C++
+      code base.
+    '';
+    homepage = http://www.clifford.at/yosys/;
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.shell ];
+  };
+}

--- a/pkgs/development/tools/icestorm/default.nix
+++ b/pkgs/development/tools/icestorm/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python3, libftdi }:
+
+stdenv.mkDerivation rec {
+  name = "icestorm-${version}";
+  version = "2015.12.29";
+
+  src = fetchFromGitHub {
+    owner = "cliffordwolf";
+    repo = "icestorm";
+    rev = "7852514c2cde208da87b62777b2c5e482092f50d";
+    sha256 = "1ya1nk5h28hjdmd8jdrlfiayr2434rnvi133gs1p0ay21qb3iwfz";
+  };
+
+  buildInputs = [ python3 libftdi ];
+  preBuild = ''
+    makeFlags="DESTDIR=$out $makeFlags"
+  '';
+
+  meta = {
+    description = "Documentation and tools for Lattice iCE40 FPGAs";
+    longDescription = ''
+      Project IceStorm aims at reverse engineering and
+      documenting the bitstream format of Lattice iCE40
+      FPGAs and providing simple tools for analyzing and
+      creating bitstream files.
+    '';
+    homepage = http://www.clifford.at/icestorm/;
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.shell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5001,6 +5001,8 @@ let
 
   yasm = callPackage ../development/compilers/yasm { };
 
+  yosys = callPackage ../development/compilers/yosys { };
+
 
   ### DEVELOPMENT / INTERPRETERS
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5755,6 +5755,8 @@ let
 
   hyenae = callPackage ../tools/networking/hyenae { };
 
+  icestorm = callPackage ../development/tools/icestorm { };
+
   icmake = callPackage ../development/tools/build-managers/icmake { };
 
   iconnamingutils = callPackage ../development/tools/misc/icon-naming-utils {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3776,6 +3776,8 @@ let
 
   aliceml = callPackage ../development/compilers/aliceml { };
 
+  arachne-pnr = callPackage ../development/compilers/arachne-pnr { };
+
   aspectj = callPackage ../development/compilers/aspectj { };
 
   ats = callPackage ../development/compilers/ats { };


### PR DESCRIPTION
These packages are used to program Lattice iCE40 FPGAs. I have tested these against a iCE40-HX8k dev board, and they work well.
