### PR TITLE
steam: use libstdc++ from host, not steam runtime

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -57,6 +57,7 @@ buildFHSUserEnv {
 
   profile = ''
     export STEAM_RUNTIME=/steamrt
+    export LD_PRELOAD='/lib32/libstdc++.so.6'
   '';
 
   runScript = "steam";


### PR DESCRIPTION
this fixes https://github.com/NixOS/nixpkgs/issues/10950 for me. I have an intel card, not radeon, but saw the same errors.
