### PR TITLE
facetimehd: PCIe webcam support for Macbooks

### DIFF
--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.hardware.facetimehd;
+
+  kernelPackages = config.boot.kernelPackages;
+
+in
+
+{
+
+  options.hardware.facetimehd.enable = mkEnableOption "facetimehd kernel module";
+
+  config = mkIf cfg.enable {
+
+    assertions = singleton {
+      assertion = versionAtLeast kernelPackages.kernel.version "3.19";
+      message = "facetimehd is not supported for kernels older than 3.19";
+    };
+
+    boot.kernelModules = [ "facetimehd" ];
+
+    boot.extraModulePackages = [ kernelPackages.facetimehd ];
+
+    hardware.firmware = [ pkgs.facetimehd-firmware ];
+
+    # unload module during suspend/hibernate as it crashes the whole system
+    powerManagement.powerDownCommands = ''
+      ${pkgs.module_init_tools}/bin/rmmod -f facetimehd
+    '';
+
+    # and load it back on resume
+    powerManagement.resumeCommands = ''
+      export MODULE_DIR=/run/current-system/kernel-modules/lib/modules
+      ${pkgs.module_init_tools}/bin/modprobe -v facetimehd
+    '';
+
+  };
+
+}

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -23,6 +23,8 @@ in
 
     boot.kernelModules = [ "facetimehd" ];
 
+    boot.blacklistedKernelModules = [ "bdc_pci" ];
+
     boot.extraModulePackages = [ kernelPackages.facetimehd ];
 
     hardware.firmware = [ pkgs.facetimehd-firmware ];

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -42,6 +42,7 @@
   ./hardware/video/bumblebee.nix
   ./hardware/video/nvidia.nix
   ./hardware/video/ati.nix
+  ./hardware/video/webcam/facetimehd.nix
   ./installer/tools/auto-upgrade.nix
   ./installer/tools/nixos-checkout.nix
   ./installer/tools/tools.nix

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+# facetimehd is not supported for kernels older than 3.19";
+assert stdenv.lib.versionAtLeast kernel.version "3.19";
+
+stdenv.mkDerivation rec {
+
+  name = "facetimehd-${version}-${kernel.version}";
+  version = "git-20160127";
+
+  src = fetchFromGitHub {
+    owner = "patjak";
+    repo = "bcwc_pcie";
+    rev = "186e9f9101ed9bbd7cc8d470f840d4a74c585ca7";
+    sha256 = "1frsf6z6v94cz9fww9rbnk926jzl36fp3w2d1aw6djhzwm80a5gs";
+  };
+
+  preConfigure = ''
+    export INSTALL_MOD_PATH="$out"
+  '';
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/patjak/bcwc_pcie;
+    description = "Linux driver for the Facetime HD (Broadcom 1570) PCIe webcam";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, cpio, xz, pkgs }:
+
+let
+
+  version = "1.43";
+
+  dmgRange = "420107885-421933300"; # the whole download is 1.3GB, this cuts it down to 2MB
+
+  firmwareIn = "./System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface";
+  firmwareOut = "firmware.bin";
+  firmwareOffset = "81920";
+  firmwareSize = "603715";
+
+  # separated this here as the script will fail without the 'exit 0'
+  unpack = pkgs.writeScriptBin "unpack" ''
+    xzcat -Q $src | cpio --format odc -i -d ${firmwareIn}
+    exit 0
+  '';
+
+in
+
+stdenv.mkDerivation {
+
+  name = "facetimehd-firmware-${version}";
+
+  src = fetchurl {
+    url = "https://support.apple.com/downloads/DL1849/en_US/osxupd10.11.2.dmg";
+    sha256 = "1jw6sy9vj27amfak83cs2c7q856y4mk1wix3rl4q10yvd9bl4k9x";
+    curlOpts = "-r ${dmgRange}";
+  };
+
+  phases = [ "buildPhase" ];
+
+  buildInputs = [ cpio xz ];
+
+  buildPhase = ''
+    ${unpack}/bin/unpack
+    dd bs=1 skip=${firmwareOffset} count=${firmwareSize} if=${firmwareIn} of=${firmwareOut}.gz &> /dev/null
+    mkdir -p $out/lib/firmware/facetimehd
+    gunzip -c ${firmwareOut}.gz > $out/lib/firmware/facetimehd/${firmwareOut}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "facetimehd firmware";
+    homepage = https://support.apple.com/downloads/DL1849;
+    license = licenses.unfree;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10263,6 +10263,8 @@ let
 
     openafsClient = callPackage ../servers/openafs-client { };
 
+    facetimehd = callPackage ../os-specific/linux/facetimehd { };
+
     kernelHeaders = callPackage ../os-specific/linux/kernel-headers { };
 
     klibc = callPackage ../os-specific/linux/klibc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9938,6 +9938,8 @@ let
 
   eject = utillinux;
 
+  facetimehd-firmware = callPackage ../os-specific/linux/firmware/facetimehd-firmware { };
+
   fanctl = callPackage ../os-specific/linux/fanctl {
     iproute = iproute.override { enableFan = true; };
   };


### PR DESCRIPTION
It's still early days for this driver and users will have to perform the occasional rmmod/modprobe dance.

That being said, it still beats restarting to OSX everytime for video meetings (Hangouts on Firefox and Chromium works).

This seems to behave reasonably on my MacBookPro11,3 running kernels 4.1, 4.2 and 4.3.
