### PR TITLE
aws-mturk-clt: update sha256 hash

### DIFF
--- a/pkgs/tools/misc/aws-mturk-clt/default.nix
+++ b/pkgs/tools/misc/aws-mturk-clt/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://mturk.s3.amazonaws.com/CLTSource/${name}.tar.gz";
-    sha256 = "06p0cbb5afmqjjlibbw9gb08jp270c7j57lhnf9ld50sm1z021ln";
+    sha256 = "00yyc7k3iygg83cknv9i2dsaxwpwzdkc8a2l9j56lg999hw3mqm3";
   };
 
   installPhase =


### PR DESCRIPTION
Stable tarballs are so 2015.
