### PR TITLE
murmur_git: fix failing build because of changed ice file paths

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -95,7 +95,7 @@ let
     type = "murmur";
 
     postPatch = optional iceSupport ''
-      sed -i 's,/usr/share/Ice/,${zeroc_ice}/,g' src/murmur/murmur.pro
+      grep -Rl '/usr/share/Ice' . | xargs sed -i 's,/usr/share/Ice/,${zeroc_ice}/,g'
     '';
 
     configureFlags = [


### PR DESCRIPTION
build currently fails: https://hydra.nixos.org/build/29216753

This fixes it because upstream moved the path to the ice files.
