### PR TITLE
Add SSL support to slrn

### DIFF
--- a/pkgs/applications/networking/newsreaders/slrn/default.nix
+++ b/pkgs/applications/networking/newsreaders/slrn/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, slang, ncurses }:
+, slang, ncurses, openssl }:
 
 let version = "1.0.2"; in
 
@@ -18,9 +18,9 @@ stdenv.mkDerivation {
       -e "s|/bin/rm|rm|"
   '';
 
-  configureFlags = "--with-slang=${slang}";
+  configureFlags = "--with-slang=${slang} --with-ssl=${openssl}";
 
-  buildInputs = [ slang ncurses ];
+  buildInputs = [ slang ncurses openssl ];
 
   meta = with stdenv.lib; {
     description = "The slrn (S-Lang read news) newsreader";


### PR DESCRIPTION
slrn in NixOS should absolutely support SSL. To do so, we follow http://slrn.sourceforge.net/docs/README.SSL which, unfortunately, is hosted on sourceforge. For those whose browsers prevent them from reading from SF, I'll supply the useful bits.

``` text
Compiling SLRN with SSL support
-------------------------------

To build slrn with SSL support, you must first obtain and install the
OpenSSL library from http://www.openssl.org.  Beware that some
countries may have import/export regulations concerning such software.
If you get arrested, do not call me!  Just as important, do not
contact me if you have trouble compiling OpenSSL --- I have nothing to
do with the development of OpenSSL.

After installing OpenSSL, configure slrn for SSL support, e.g.,

   ./configure --with-ssl

By default, OpenSSL will install itself in /usr/local/ssl.  If you
install it elsewhere, e.g., $HOME/ssl, then use:

   ./configure --with-ssl=$HOME/ssl

After compiling it, `slrn --version' should indicate SSL support.
```
