### PR TITLE
cool-retro-term: add missing dependencies and fix qmltermwidget, fixes #12027

### DIFF
--- a/pkgs/applications/misc/cool-retro-term/default.nix
+++ b/pkgs/applications/misc/cool-retro-term/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchgit, makeQtWrapper, qtbase, qtquick1, qmltermwidget }:
+{ stdenv, fetchgit, makeQtWrapper, qtbase, qtquick1, qmltermwidget,
+qtquickcontrols, qtgraphicaleffects }:
 
 stdenv.mkDerivation rec {
   version = "1.0.0";
@@ -15,7 +16,7 @@ stdenv.mkDerivation rec {
     sed -i -e '/qmltermwidget/d' cool-retro-term.pro
   '';
 
-  buildInputs = [ qtbase qtquick1 qmltermwidget ];
+  buildInputs = [ qtbase qtquick1 qmltermwidget qtquickcontrols qtgraphicaleffects ];
   nativeBuildInputs = [ makeQtWrapper ];
 
   configurePhase = "qmake PREFIX=$out";

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace qmltermwidget.pro \
-      --replace '$$[QT_INSTALL_QML]' "/lib/qml/"
+      --replace '$$[QT_INSTALL_QML]' "/lib/qt5/qml/"
   '';
 
   configurePhase = "qmake PREFIX=$out";


### PR DESCRIPTION
This fixes #12027 at least for me. @ttuegel, @kragniz, let me know if it also works for you.

Best,
Sven
