### PR TITLE
bomi: fix missing build dependency

### DIFF
--- a/pkgs/applications/video/bomi/default.nix
+++ b/pkgs/applications/video/bomi/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
                   libvdpau
                   libva
                   libbluray
+                  qtquickcontrols
                 ]
                 ++ optional jackSupport jack
                 ++ optional portaudioSupport portaudio


### PR DESCRIPTION
The build fails without specifying qtquickcontrols as a build input.

Failing trunk build: https://hydra.nixos.org/build/29218219
