### PR TITLE
shotwell: 0.20.2 -> 0.22.0

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -6,12 +6,12 @@
 # for dependencies see http://www.yorba.org/projects/shotwell/install/
 
 stdenv.mkDerivation rec {
-  version = "0.20.2";
+  version = "0.22.0";
   name = "shotwell-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/shotwell/0.20/${name}.tar.xz";
-    sha256 = "0h5pdczsrkplvlvq54zk3am4kjmfpd6pn2sz0ky8lfq1fngwiqip";
+    url = "mirror://gnome/sources/shotwell/0.22/${name}.tar.xz";
+    sha256 = "0cgqaaikrb10plhf6zxbgqy32zqpiwyi9dpx3g8yr261q72r5c81";
   };
 
   NIX_CFLAGS_COMPILE = "-I${glib}/include/glib-2.0 -I${glib}/lib/glib-2.0/include";
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Popular photo organizer for the GNOME desktop";
-    homepage = http://www.yorba.org/projects/shotwell/;
+    homepage = https://wiki.gnome.org/Apps/Shotwell;
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [iElectric];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3032,7 +3032,9 @@ let
 
   sharutils = callPackage ../tools/archivers/sharutils { };
 
-  shotwell = callPackage ../applications/graphics/shotwell { };
+  shotwell = callPackage ../applications/graphics/shotwell {
+    vala = vala_0_28;
+  };
 
   shout = callPackage ../applications/networking/irc/shout { };
 


### PR DESCRIPTION
This release has actually been out for nine months, and the existing
release completely failed to be able to import photos in my setup.
