### PR TITLE
softhsm: init -> 2.1.0

### DIFF
--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, unzip, botan }:
+
+stdenv.mkDerivation rec {
+
+  name = "softhsm-${version}";
+  majorVersion = "2";
+  version = "${majorVersion}.1.0";
+
+  src = fetchurl {
+    url = "https://dist.opendnssec.org/source/${name}.tar.gz";
+    sha256 = "0399b06f196fbfaebe73b4aeff2e2d65d0dc1901161513d0d6a94f031dcd827e";
+  };
+
+  configureFlags = [
+    "--with-crypto-backend=botan"
+    "--with-botan=${botan}"
+    "--sysconfdir=$out/etc"
+    "--localstatedir=$out/var"
+    ];
+
+  buildInputs = [ botan];
+
+  postInstall = "rm -rf $out/var";
+
+  meta = {
+    homepage = https://www.opendnssec.org/softhsm;
+    description = "Cryptographic store accessible through a PKCS #11 interface";
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = stdenv.lib.maintainers.leenaars;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3230,6 +3230,8 @@ in
 
   snort = callPackage ../applications/networking/ids/snort { };
 
+  softhsm = callPackage ../tools/security/softhsm { };
+
   solr = callPackage ../servers/search/solr { };
 
   solvespace = callPackage ../applications/graphics/solvespace { };


### PR DESCRIPTION
SoftHSM is an implementation of a cryptographic store accessible through a PKCS #11 interface. You can use it to explore PKCS #11 without having a Hardware Security Module. It is being developed as a part of the OpenDNSSEC project. SoftHSM uses Botan for its cryptographic operations.
