### PR TITLE
qbittorrent: 3.2.3 -> 3.3.1

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, which
-, boost, libtorrentRasterbar, qt4
+, boost, libtorrentRasterbar, qt5
 , debugSupport ? false # Debugging
 , guiSupport ? true, dbus_libs ? null # GUI (disable to run headless)
 , webuiSupport ? true # WebUI
@@ -10,16 +10,16 @@ assert guiSupport -> (dbus_libs != null);
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "qbittorrent-${version}";
-  version = "3.2.3";
+  version = "3.3.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/qbittorrent/${name}.tar.xz";
-    sha256 = "05590ak4nnqkah8dy71cxf7mqv6phw0ih1719dm761mxf8vrz9w6";
+    sha256 = "1li9law732n4vc7sn6i92pwxn8li7ypqaxcmfpm17kk978immlfs";
   };
 
   nativeBuildInputs = [ pkgconfig which ];
 
-  buildInputs = [ boost libtorrentRasterbar qt4 ]
+  buildInputs = [ boost libtorrentRasterbar qt5.qtbase qt5.qttools ]
     ++ optional guiSupport dbus_libs;
 
   configureFlags = [
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
     (if guiSupport then "" else "--disable-gui")
     (if webuiSupport then "" else "--disable-webui")
   ] ++ optional debugSupport "--enable-debug";
+
+  # The lrelease binary is named lrelease instead of lrelease-qt4
+  patches = [ ./fix-lrelease.patch];
 
   # https://github.com/qbittorrent/qBittorrent/issues/1992 
   enableParallelBuilding = false;

--- a/pkgs/applications/networking/p2p/qbittorrent/fix-lrelease.patch
+++ b/pkgs/applications/networking/p2p/qbittorrent/fix-lrelease.patch
@@ -1,0 +1,13 @@
+diff --git a/qm_gen.pri b/qm_gen.pri
+index ed29b76..2d5990c 100644
+--- a/qm_gen.pri
++++ b/qm_gen.pri
+@@ -5,7 +5,7 @@ isEmpty(QMAKE_LRELEASE) {
+     win32|os2:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
+     else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+     unix {
+-        !exists($$QMAKE_LRELEASE) { QMAKE_LRELEASE = lrelease-qt4 }
++        !exists($$QMAKE_LRELEASE) { QMAKE_LRELEASE = lrelease }
+     } else {
+         !exists($$QMAKE_LRELEASE) { QMAKE_LRELEASE = lrelease }
+     }


### PR DESCRIPTION
- upstream has switched to qt5 as default, so also done here
- Adds a patch to use the qt lrelease tool correct
