### PR TITLE
boolstuff: fix archive hash to make boolstuff build

### DIFF
--- a/pkgs/development/libraries/boolstuff/default.nix
+++ b/pkgs/development/libraries/boolstuff/default.nix
@@ -3,16 +3,16 @@
 let baseurl = "http://perso.b2b2c.ca/sarrazip/dev"; in
 
 stdenv.mkDerivation rec {
-  name = "boolstuff-0.1.14";
+  name = "boolstuff-0.1.15";
 
   src = fetchurl {
     url = "${baseurl}/${name}.tar.gz";
-    sha256 = "1ccn9v3kxz44pv3mr8q0l2i9769jiigw1gfv47ia50mbspwb87r6";
+    sha256 = "1mzw4368hqw0b6xr01yqcbs9jk9ma3qq9hk3iqxmkiwqqxgirgln";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  meta = { 
+  meta = {
     description = "Library for operations on boolean expression binary trees";
     homepage = "${baseurl}/boolstuff.html";
     license = "GPL";


### PR DESCRIPTION
the build fails because of invalid hashes, this fixes it.
I contacted the owner of the webserver to fix the problem on his side too
