### PR TITLE
go1.5: Fix Darwin build by disabling a broken test

### DIFF
--- a/pkgs/development/compilers/go/1.5.nix
+++ b/pkgs/development/compilers/go/1.5.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation rec {
     sed -i '/TestCgoLookupIP/areturn' src/net/cgo_unix_test.go
     sed -i '/TestChdirAndGetwd/areturn' src/os/os_test.go
     sed -i '/TestRead0/areturn' src/os/os_test.go
+    sed -i '/TestNohup/areturn' src/os/signal/signal_test.go
     sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
 
     sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go


### PR DESCRIPTION
TestNohup appears to work on Darwin if the test suite is running
attached to a terminal, but not when Nix runs it.
