### PR TITLE
omake: Fix broken download URL

### DIFF
--- a/pkgs/development/tools/ocaml/omake/default.nix
+++ b/pkgs/development/tools/ocaml/omake/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "${webpage}/downloads/${pname}-${version}.tar.gz";
+    url = "mirror://debian/pool/main/o/omake/omake_${version}.orig.tar.gz";
     sha256 = "1bfxbsimfivq0ar2g5fkzvr5ql97n5dg562pfyd29y4zyh4mwrsv";
   };
   patchFlags = "-p0";


### PR DESCRIPTION
All the download links on http://omake.metaprl.org/ seem to be dead.
