### PR TITLE
This fixes bug #10825 for hexchat.  Hexchat loads enchant library at …

### DIFF
--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation rec {
     desktop_file_utils hicolor_icon_theme
   ];
 
+ #hexchat and heachat-text loads enchant spell checking library at run time and so it needs to have route to the path
+  patchPhase = ''
+    sed -i "s,libenchant.so.1,${enchant}/lib/libenchant.so.1,g" src/fe-gtk/sexy-spell-entry.c
+  '';
+
   configureFlags = [ "--enable-shm" "--enable-textfe" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/irc/xchat/default.nix
+++ b/pkgs/applications/networking/irc/xchat/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, tcl, gtk}:
+{stdenv, fetchurl, pkgconfig, tcl, gtk, gtkspell }:
 
 stdenv.mkDerivation {
   name = "xchat-2.8.8";
@@ -6,8 +6,8 @@ stdenv.mkDerivation {
     url = http://www.xchat.org/files/source/2.8/xchat-2.8.8.tar.bz2;
     sha256 = "0d6d69437b5e1e45f3e66270fe369344943de8a1190e498fafa5296315a27db0";
   };
-  buildInputs = [pkgconfig tcl gtk];
-  configureFlags = "--disable-nls";
+  buildInputs = [pkgconfig tcl gtk gtkspell];
+  configureFlags = "--disable-nls --enable-spell=gtkspell";
 
   patches = [ ./glib-top-level-header.patch ];
 


### PR DESCRIPTION
resolves this bug for hexchat and xchat #10825 

hexchat and xchat try to load the enchant library at runtime
https://github.com/hexchat/hexchat/blob/master/src/fe-gtk/sexy-spell-entry.c#L157-L205

this patch creates a wrapper so they can actually find and use it for spell checking 
