### PR TITLE
owncloud 7.0.11 -> 7.0.12

### DIFF
--- a/pkgs/servers/owncloud/default.nix
+++ b/pkgs/servers/owncloud/default.nix
@@ -37,23 +37,23 @@ in {
   };
 
   owncloud70 = common {
-    versiona = "7.0.11";
-    sha256 = "21dd75de4ed832f16f577eb6763d04c663ef13251153ba2e8847e3f5799d2ad2";
+    versiona = "7.0.12";
+    sha256 = "d1a0f73f5094ec1149b50e2409b5fea0a9bebb16d663789d4b8f98fed341aa91";
   };
 
   owncloud80 = common {
-    versiona = "8.0.9";
-    sha256 = "0c1f915f4123dbe07d564cf0172930568690ab5257d2fca4fec4ec515858bef1";
+    versiona = "8.0.10";
+    sha256 = "3054b997f258178b57efc526e14384829ac8ab94757191f2d03c13fcb0a3cd93";
   };
 
   owncloud81 = common {
-    versiona = "8.1.4";
-    sha256 = "e0f4bf0c85821fc1b6e7f6268080ad3ca3e98c41baa68a9d616809d74a77312d";
+    versiona = "8.1.5";
+    sha256 = "6d8687e40af32c5ca5adfea3fee556ed987b77ad15a1ead5d40cc87a8b76f4b4";
   };
 
   owncloud82 = common {
-    versiona = "8.2.1";
-    sha256 = "5390b2172562a5bf97a46e9a621d1dd92f9b74efaccbb77978c39eb90d6988d4";
+    versiona = "8.2.2";
+    sha256 = "d5b935f904744b8b40b310f19679702387c852498d0dc7aaeda4555a3db9ad5b";
   };
 
 }


### PR DESCRIPTION
The name says it all, updates all flavours of owncloud to the
latest version. As before, only the 7.0 branch of owncloud works
without issues on nixos.
