### PR TITLE
ati-drivers : Fix some paths in ati_unfree

### DIFF
--- a/pkgs/os-specific/linux/ati-drivers/builder.sh
+++ b/pkgs/os-specific/linux/ati-drivers/builder.sh
@@ -226,8 +226,12 @@ fi
   fi
 
   # libstdc++ and gcc are needed by some libs
+  patchelf --remove-needed libX11.so.6 $out/lib/dri/fglrx_dri.so
+  patchelf --remove-needed libX11.so.6 $out/lib/fglrx_dri.so
   patchelf --set-rpath $gcc/$lib_arch $out/lib/libatiadlxx.so
   patchelf --set-rpath $gcc/$lib_arch $out/lib/xorg/modules/glesx.so
+  patchelf --set-rpath $gcc/$lib_arch/ $out/lib/dri/fglrx_dri.so
+  patchelf --set-rpath $gcc/$lib_arch/ $out/lib/libaticaldd.so
 }
 
 if test -z "$libsOnly"; then


### PR DESCRIPTION
This hopefully closes https://github.com/NixOS/nixpkgs/issues/11740
The commit removes two empty paths to libX11.so.6 in two files where it was duplicated
and adds the path to libstdc++ in some others. Each file was checked using ldd
https://github.com/NixOS/nixpkgs/pull/11817 can be rejected if this commit is taken instead.
