### PR TITLE
calibre: make unrar support optional, and bump to latest version

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, pyqt5, sip_4_16, poppler_utils, pkgconfig, libpng
 , imagemagick, libjpeg, fontconfig, podofo, qtbase, icu, sqlite
-, makeWrapper, unrar, chmlib, pythonPackages, xz, libusb1, libmtp
+, makeWrapper, unrarSupport ? false, chmlib, pythonPackages, xz, libusb1, libmtp
 , xdg_utils
 }:
 
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
 
   inherit python;
 
-  patchPhase = ''
+  patches = stdenv.lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
+
+  prePatch = ''
     sed -i "/pyqt_sip_dir/ s:=.*:= '${pyqt5}/share/sip':"  \
       setup/build_environment.py
   '';
@@ -53,7 +55,6 @@ stdenv.mkDerivation rec {
 
     for a in $out/bin/*; do
       wrapProgram $a --prefix PYTHONPATH : $PYTHONPATH \
-                     --prefix LD_LIBRARY_PATH : ${unrar}/lib \
                      --prefix PATH : ${poppler_utils}/bin
     done
   '';
@@ -61,7 +62,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Comprehensive e-book software";
     homepage = http://calibre-ebook.com;
-    license = licenses.gpl3;
+    license = with licenses; if unrarSupport then unfreeRedistributable else gpl3;
     maintainers = with maintainers; [ viric iElectric pSub AndersonTorres ];
     platforms = platforms.linux;
     inherit version;

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.46.0";
+  version = "2.48.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "http://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "0ig1pb62w57l6nhwg391mkjhw9dyicix6xigpdyw0320jdw9nlkb";
+    sha256 = "0bjzw806czqxkhq9qqkhff8bhfc428pijkidb1h6gr47jqdp4hpg";
   };
 
   inherit python;

--- a/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
+++ b/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
@@ -1,0 +1,47 @@
+Author: Dmitry Shachnev <mitya57@gmail.com>
+Description: do not build unrar extension as we strip unrar from the tarball
+Forwarded: not-needed
+Last-Update: 2013-04-04
+
+Index: calibre/setup/extensions.py
+===================================================================
+--- calibre.orig/setup/extensions.py	2014-02-02 10:42:14.510954007 +0100
++++ calibre/setup/extensions.py	2014-02-02 10:42:14.502954007 +0100
+@@ -209,24 +209,6 @@
+                 sip_files=['calibre/ebooks/pdf/render/qt_hack.sip']
+                 ),
+ 
+-    Extension('unrar',
+-              ['unrar/%s.cpp'%(x.partition('.')[0]) for x in '''
+-               rar.o strlist.o strfn.o pathfn.o savepos.o smallfn.o global.o file.o
+-               filefn.o filcreat.o archive.o arcread.o unicode.o system.o
+-               isnt.o crypt.o crc.o rawread.o encname.o resource.o match.o
+-               timefn.o rdwrfn.o consio.o options.o ulinks.o errhnd.o rarvm.o
+-               secpassword.o rijndael.o getbits.o sha1.o extinfo.o extract.o
+-               volume.o list.o find.o unpack.o cmddata.o filestr.o scantree.o
+-               '''.split()] + ['calibre/utils/unrar.cpp'],
+-              inc_dirs=['unrar'],
+-              cflags=[('/' if iswindows else '-') + x for x in (
+-                  'DSILENT', 'DRARDLL', 'DUNRAR')] + (
+-                  [] if iswindows else ['-D_FILE_OFFSET_BITS=64',
+-                                        '-D_LARGEFILE_SOURCE']),
+-              optimize_level=2,
+-              libraries=['User32', 'Advapi32', 'kernel32', 'Shell32'] if iswindows else []
+-              ),
+-
+     ]
+ 
+ 
+Index: calibre/src/calibre/ebooks/metadata/archive.py
+===================================================================
+--- calibre.orig/src/calibre/ebooks/metadata/archive.py	2014-02-02 10:42:14.510954007 +0100
++++ calibre/src/calibre/ebooks/metadata/archive.py	2014-02-02 10:42:14.502954007 +0100
+@@ -42,7 +42,7 @@
+     description = _('Extract common e-book formats from archives '
+         '(zip/rar) files. Also try to autodetect if they are actually '
+         'cbz/cbr files.')
+-    file_types = set(['zip', 'rar'])
++    file_types = set(['zip'])
+     supported_platforms = ['windows', 'osx', 'linux']
+     on_import = True
+ 


### PR DESCRIPTION
As discussed  in #12091, even though the calibre derivation says it is GPLv3, the calibre package contains and builds its own copy of the non-free unrar library.

This PR makes the unrar feature optional.
- If unrarSupport is false (the default), then unrar support is removed [with the same patch that Debian applies](http://sources.debian.net/patches/patch/calibre/2.45.0%2Bdfsg-1/dont_build_unrar_plugin.patch/).  In this case calibre's license is set to gpl3.
- If unrarSupport is true, then calibre is built normally, but the license attribute is set to unfreeRedistributable.

cc @nckx and maintainers @viric @domenkozar @pSub @AndersonTorres 
