### PR TITLE
freenet: rewrite wrapper to not depend on PATH

### DIFF
--- a/pkgs/applications/networking/p2p/freenet/freenetWrapper
+++ b/pkgs/applications/networking/p2p/freenet/freenetWrapper
@@ -1,4 +1,6 @@
-#! /usr/bin/env bash
+#! @bash@/bin/bash
+
+PATH=@coreutils@/bin:$PATH
 
 export FREENET_HOME="$HOME/.local/share/freenet"
 if [ -n "$XDG_DATA_HOME" ]
@@ -9,8 +11,8 @@ if [ ! -d $FREENET_HOME ]; then
   mkdir -p $FREENET_HOME
 fi
 
-cp -u $FREENET_SEEDNODES $FREENET_HOME/seednodes.fref
+cp -u @seednodes@ $FREENET_HOME/seednodes.fref
 chmod u+rw $FREENET_HOME/seednodes.fref
 
 cd $FREENET_HOME
-exec $FREENET_ROOT/bin/freenet.wrapped "$@"
+@jre@/bin/java -cp @freenet@/share/freenet/bcprov-jdk15on-152.jar:@freenet@/share/freenet/freenet-ext.jar:@freenet@/share/freenet/freenet.jar -Xmx1024M freenet.node.NodeStarter


### PR DESCRIPTION
Rewrite wrapper depended on `$PATH` containing bash and coreutils, so I've merged the wrapper and run script together and ensured that they don't. Can @spacekitteh test this, I've so far only tested that it starts.
