### PR TITLE
i2c-tools: Fetch source from debian

### DIFF
--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.1.1";
 
   src = fetchurl {
-    url = "http://dl.lm-sensors.org/i2c-tools/releases/${name}.tar.bz2";
+    url = "http://http.debian.net/debian/pool/main/i/i2c-tools/i2c-tools_${version}.orig.tar.bz2";
     sha256 = "000pvg995qy1b15ks59gd0klri55hb33kqpg5czy84hw1pbdgm0l";
   };
 


### PR DESCRIPTION
lm-sensors.org has been down for a while now.
