### PR TITLE
skrooge: 1.10.0 -> 1.12.5

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -2,11 +2,11 @@
 , libxslt, kdelibs, kdepimlibs, grantlee, qjson, qca2, libofx, sqlite, boost }:
 
 stdenv.mkDerivation rec {
-  name = "skrooge-1.10.0";
+  name = "skrooge-1.12.5";
 
   src = fetchurl {
-    url = "http://download.kde.org/stable/skrooge/${name}.tar.bz2";
-    sha256 = "0rsw2xdgws5bvnf3h4hg16liahigcxgaxls7f8hzr9wipxx5xqda";
+    url = "http://download.kde.org/stable/skrooge/${name}.tar.xz";
+    sha256 = "1mnkm0367knh0a65gifr20p42ql9zndw7d6kmbvfshvpfsmghl40";
   };
 
   buildInputs = [ libxslt kdelibs kdepimlibs grantlee qjson qca2 libofx sqlite boost ];


### PR DESCRIPTION
Tested on NixOS (x86_64): builds and runs fine.
