### PR TITLE
{lib}mediainfo{-gui}: 0.7.80 -> 0.7.81

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.80";
+  version = "0.7.81";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "12iwiw4vcmyi8l04j540kbqifmr1wnlfw5cway185iqia43s6c10";
+    sha256 = "1aah8y4kqhghqhcfm6ydgf3hj6q05dllfh0m1lbaij0y8yrrwz07";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.80";
+  version = "0.7.81";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "12iwiw4vcmyi8l04j540kbqifmr1wnlfw5cway185iqia43s6c10";
+    sha256 = "1aah8y4kqhghqhcfm6ydgf3hj6q05dllfh0m1lbaij0y8yrrwz07";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.80";
+  version = "0.7.81";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "0v9px37qx0dkx67gqwi1rd9x4m7zm1ml8sdj5fx0isj6qymbd1z5";
+    sha256 = "0hzfrg7n7wlnwq28hmpxczis1k8x73wbwlsmfkshvqcwi7lva0cs";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
Built and run locally.

From the Changelog:

```
Version 0.7.81, 2015-12-31

+ Acquisition Metadata: support of all SMPTE RDD18 elements
+ Matroska: cover presence and content of the cover, thanks to Max Pozdeev
+ #F446, Matroska: Handling of cropping values, thanks to Max Pozdeev
+ Improvement of Python binding: Mac Os X support, Python2 and Python3
  can use same MediaInfoDLL.py
+ #F484, AVI: OpenDML Interlaced / Progressive scan type detection
+ MP4: support of AtomicParsley imdb tag
x #B959, MPEG-TS: MPEG-1 Video appeared as MPEG-2 Video
x #B914, Matroska: Undefined number of chapters in some M4V with Timed
  Text, thanks to Max Pozdeev
x #B962, Matroska: negative timecodes were not correctly handled
x #B964, FLV: was hanging trying to open some FLV files
x JPEG in AVI or MOV: better handling of buggy APP0/AVI1, avoiding some
  false positives about interlacement
x DVCPRO HD: some containers consider DVCPRO HD as with width 1920
  despite the fact it is 1280 or 1440, using 1280 or 1440 in all cases
```
