### PR TITLE
fixup! rkt: align stage1 information with upstream source

### DIFF
--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -2,11 +2,11 @@
 , fetchurl, fetchFromGitHub }:
 
 let
-  coreosImageRelease = "835.9.0";
-  coreosImageSystemdVersion = "225";
+  coreosImageRelease = "794.1.0";
+  coreosImageSystemdVersion = "222";
 
   # TODO: track https://github.com/coreos/rkt/issues/1758 to allow "host" flavor.
-  stage1Flavours = [ "coreos" ];
+  stage1Flavours = [ "coreos" "fly" ];
 
 in stdenv.mkDerivation rec {
   version = "0.14.0";
@@ -21,8 +21,8 @@ in stdenv.mkDerivation rec {
   };
 
   stage1BaseImage = fetchurl {
-    url = "http://stable.release.core-os.net/amd64-usr/${coreosImageRelease}/coreos_production_pxe_image.cpio.gz";
-    sha256 = "51dc10b4269b9c1801c233de49da817d29ca8d858bb0881df94dc90f7e86ce70";
+    url = "http://alpha.release.core-os.net/amd64-usr/${coreosImageRelease}/coreos_production_pxe_image.cpio.gz";
+    sha256 = "05nzl3av6cawr8v203a8c95c443g6h1nfy2n4jmgvn0j4iyy44ym";
   };
 
   buildInputs = [ autoconf automake go file git wget gnupg1 squashfsTools cpio ];


### PR DESCRIPTION
Same as #11946 with the correct mirror for the CoreOS PXE image.
