### PR TITLE
boot: don't use makeWrapper

### DIFF
--- a/pkgs/development/tools/build-managers/boot/builder.sh
+++ b/pkgs/development/tools/build-managers/boot/builder.sh
@@ -8,6 +8,7 @@ chmod -v 755 $boot_bin
 
 patchShebangs $boot_bin
 
-wrapProgram $boot_bin \
-            --set JAVA_HOME "${jdk}" \
-            --prefix PATH ":" "${jdk}/bin"
+sed -i \
+  -e "2iexport JAVA_HOME=${jdk}" \
+  -e "2iexport PATH=${jdk}/bin\${PATH:+:}\$PATH" \
+  $boot_bin

--- a/pkgs/development/tools/build-managers/boot/default.nix
+++ b/pkgs/development/tools/build-managers/boot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, jdk }:
+{ stdenv, fetchurl, jdk }:
 
 stdenv.mkDerivation rec {
   version = "2.4.2";
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
   inherit jdk;
   
   builder = ./builder.sh;
-
-  buildInputs = [ makeWrapper ];
 
   propagatedBuildInputs = [ jdk ];
 


### PR DESCRIPTION
This makes boot work as shebang, which was previously broken.
makeWrapper was kind of unnecessary here anyway, because boot already _is_ a shell script.
My way of adding to the script here is kind of a hack, but it restores full functionality, and I don't have any particularly cleaner ideas.
