### PR TITLE
Most alternative gem servers actually use /gems/<gem>-<version>.gem

### DIFF
--- a/pkgs/applications/version-management/redmine/generate_nix_requirements.rb
+++ b/pkgs/applications/version-management/redmine/generate_nix_requirements.rb
@@ -31,7 +31,7 @@ lockfile.specs.each do |s|
   Dir.chdir TMP_DIR do
     filename = `gem fetch #{s.name} -v #{s.version.to_s}`.split()[1]
     hash = `sha256sum #{filename}.gem`
-    url = "#{GEMSERVER}/downloads/#{filename}.gem"
+    url = "#{GEMSERVER}/gems/#{filename}.gem"
     puts url
     requirements[s.name] = { :version => s.version.to_s, 
                              :hash => hash.split().first,

--- a/pkgs/development/interpreters/ruby/bundler-env/default.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default.nix
@@ -25,7 +25,7 @@ let
 
   fetchers.path = attrs: attrs.source.path;
   fetchers.gem = attrs: fetchurl {
-    url = "${attrs.source.source or "https://rubygems.org"}/downloads/${gemName attrs}";
+    url = "${attrs.source.source or "https://rubygems.org"}/gems/${gemName attrs}";
     inherit (attrs.source) sha256;
   };
   fetchers.git = attrs: fetchgit {


### PR DESCRIPTION
Servers like https://rails-assets.org use /gems URIs, instead of /downloads URIs.
/downloads may gives 404 errors in servers that aren't https://rubygems.org

At the same time, https://rubygems.org also accepts the /gems URI.
