### PR TITLE
Remove 7f

### DIFF
--- a/pkgs/top-level/node-packages.json
+++ b/pkgs/top-level/node-packages.json
@@ -133,7 +133,6 @@
 , "node-xmpp-server"
 , "node-xmpp-serviceadmin"
 , "node-xmpp-joap"
-, "7f"
 , "jfs"
 , "cordova"
 , "sloc"


### PR DESCRIPTION
The 7f package caused nodejs to upgrade to nodejs-7f (the version checker thinks it is a version of nodejs).
