### PR TITLE
Postfix configuration options

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -108,10 +108,14 @@ let
     flush     unix  n       -       n       1000?   0       flush
     proxymap  unix  -       -       n       -       -       proxymap
     proxywrite unix -       -       n       -       1       proxymap
+  ''
+  + optionalString cfg.enableSmtp ''
     smtp      unix  -       -       n       -       -       smtp
     relay     unix  -       -       n       -       -       smtp
     	      -o smtp_fallback_relay=
     #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+  ''
+  + ''
     showq     unix  n       -       n       -       -       showq
     error     unix  -       -       n       -       -       error
     retry     unix  -       -       n       -       -       error
@@ -152,6 +156,11 @@ in
       enable = mkOption {
         default = false;
         description = "Whether to run the Postfix mail server.";
+      };
+
+      enableSmtp = mkOption {
+        default = true;
+        description = "Whether to enable smtp in master.cf.";
       };
 
       setSendmail = mkOption {

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -83,6 +83,9 @@ let
     + optionalString (cfg.virtual != "") ''
       virtual_alias_maps = hash:/etc/postfix/virtual
     ''
+    + optionalString (cfg.transport != "") ''
+      transport_maps = hash:/etc/postfix/transport
+    ''
     + cfg.extraConfig;
 
   masterCf = ''
@@ -142,6 +145,7 @@ let
   virtualFile = pkgs.writeText "postfix-virtual" cfg.virtual;
   mainCfFile = pkgs.writeText "postfix-main.cf" mainCf;
   masterCfFile = pkgs.writeText "postfix-master.cf" masterCf;
+  transportFile = pkgs.writeText "postfix-transport" cfg.transport;
 
 in
 
@@ -314,6 +318,13 @@ in
         ";
       };
 
+      transport = mkOption {
+        default = "";
+        description = "
+          Entries for the transport map, cf. man-page transport(8).
+        ";
+      };
+
       extraMasterConf = mkOption {
         default = "";
         example = "submission inet n - n - - smtpd";
@@ -392,6 +403,7 @@ in
           ln -sf ${virtualFile} /var/postfix/conf/virtual
           ln -sf ${mainCfFile} /var/postfix/conf/main.cf
           ln -sf ${masterCfFile} /var/postfix/conf/master.cf
+          ln -sf ${transportFile} /var/postfix/conf/transport
 
           ${pkgs.postfix}/sbin/postalias -c /var/postfix/conf /var/postfix/conf/aliases
           ${pkgs.postfix}/sbin/postmap -c /var/postfix/conf /var/postfix/conf/virtual


### PR DESCRIPTION
This patch adds two configuration options to the postfix service:
- enableSmtp allows users to disable SMTP in master.cf (This is actually useful for my local setup)
- transport allows users to add transport maps

I am actively using this setup for my e-mail, so it is reasonably well tested.
