### PR TITLE
doc/meta.xml: don't encourage users to add a meta.version attribute

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -113,11 +113,6 @@ meta-attributes</title>
   </varlistentry>
 
   <varlistentry>
-    <term><varname>version</varname></term>
-    <listitem><para>Package version.</para></listitem>
-  </varlistentry>
-
-  <varlistentry>
     <term><varname>branch</varname></term>
     <listitem><para>Release branch. Used to specify that a package is not
     going to receive updates that are not in this branch; for example, Linux

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -10,10 +10,10 @@
 
 buildPythonPackage rec {
 
-  name = "youtube-dl-${meta.version}";
+  name = "youtube-dl-2016.01.01";
 
   src = fetchurl {
-    url = "http://yt-dl.org/downloads/${meta.version}/${name}.tar.gz";
+    url = "http://yt-dl.org/downloads/${(builtins.parseDrvName name).version}/${name}.tar.gz";
     sha256 = "0b0pk8h2iswdiyf65c0zcwcad9dm2hid67fnfafj7d3ikp4kfbvk";
   };
 
@@ -24,7 +24,6 @@ buildPythonPackage rec {
     ''wrapProgram $out/bin/youtube-dl --prefix PATH : "${ffmpeg}/bin"'';
 
   meta = with stdenv.lib; {
-    version = "2016.01.01";
     homepage = http://rg3.github.io/youtube-dl/;
     repositories.git = https://github.com/rg3/youtube-dl.git;
     description = "Command-line tool to download videos from YouTube.com and other sites";


### PR DESCRIPTION
That attribute is completely redundant since it just duplicates information from "name".

Cc: @7c6f434c who added that section in e39b1f4ec8740e7dd34185c38464db5ac814eed5.
