### PR TITLE
ghostscript: fix dynamic library path, fixes #11165

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -93,6 +93,10 @@ stdenv.mkDerivation rec {
     ln -s "${fonts}" "$out/share/ghostscript/fonts"
   '';
 
+  preFixup = stdenv.lib.strings.optionalString stdenv.isDarwin ''
+    install_name_tool -change libgs.dylib.${version} $out/lib/libgs.dylib.${version} $out/bin/gs
+  '';
+
   meta = {
     homepage = "http://www.ghostscript.com/";
     description = "PostScript interpreter (mainline version)";


### PR DESCRIPTION
On Darwin, ghostscript cannot find its dynamically linked library (see #11165). A simple call to `install_name_tool` fixes the issue. @viric, please review.
