### PR TITLE
torbrowser: add missing shebang to wrapper script

### DIFF
--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -46,14 +46,15 @@ in stdenv.mkDerivation rec {
     cp -R * $out/share/tor-browser
 
     cat > "$out/bin/tor-browser" << EOF
-      export HOME="\$HOME/.torbrowser4"
-      if [ ! -d \$HOME ]; then
-        mkdir -p \$HOME && cp -R $out/share/tor-browser/Browser/TorBrowser/Data \$HOME/ && chmod -R +w \$HOME
-        echo "pref(\"extensions.torlauncher.tordatadir_path\", \"\$HOME/Data/Tor/\");" >> \
-          ~/Data/Browser/profile.default/preferences/extension-overrides.js
-      fi
-      export LD_LIBRARY_PATH=${ldLibraryPath}:$out/share/tor-browser/Browser/TorBrowser/Tor
-      $out/share/tor-browser/Browser/firefox -no-remote -profile ~/Data/Browser/profile.default "$@"
+    #!${stdenv.shell}
+    export HOME="\$HOME/.torbrowser4"
+    if [ ! -d \$HOME ]; then
+      mkdir -p \$HOME && cp -R $out/share/tor-browser/Browser/TorBrowser/Data \$HOME/ && chmod -R +w \$HOME
+      echo "pref(\"extensions.torlauncher.tordatadir_path\", \"\$HOME/Data/Tor/\");" >> \
+        ~/Data/Browser/profile.default/preferences/extension-overrides.js
+    fi
+    export LD_LIBRARY_PATH=${ldLibraryPath}:$out/share/tor-browser/Browser/TorBrowser/Tor
+    $out/share/tor-browser/Browser/firefox -no-remote -profile ~/Data/Browser/profile.default "$@"
     EOF
     chmod +x $out/bin/tor-browser
   '';


### PR DESCRIPTION
I wondered why I would get `Exec format error` trying to launch torbrowser from fish..turns out the wrapper was never a valid script.
