### PR TITLE
Remove version update checks in Calibre and Anki

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -15,7 +15,11 @@ stdenv.mkDerivation rec {
 
   inherit python;
 
-  patches = stdenv.lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
+  patches = [
+    # Patch from Debian that switches the version update change from
+    # enabled by default to disabled by default.
+    ./no_updates_dialog.patch
+  ] ++ stdenv.lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 
   prePatch = ''
     sed -i "/pyqt_sip_dir/ s:=.*:= '${pyqt5}/share/sip':"  \

--- a/pkgs/applications/misc/calibre/no_updates_dialog.patch
+++ b/pkgs/applications/misc/calibre/no_updates_dialog.patch
@@ -1,0 +1,16 @@
+# Description: Disable update check by default.
+Index: calibre/src/calibre/gui2/main.py
+===================================================================
+--- calibre.orig/src/calibre/gui2/main.py	2014-02-02 10:41:28.470954623 +0100
++++ calibre/src/calibre/gui2/main.py	2014-02-02 10:41:56.546954247 +0100
+@@ -37,8 +37,8 @@
+                       help=_('Start minimized to system tray.'))
+     parser.add_option('-v', '--verbose', default=0, action='count',
+                       help=_('Ignored, do not use. Present only for legacy reasons'))
+-    parser.add_option('--no-update-check', default=False, action='store_true',
+-            help=_('Do not check for updates'))
++    parser.add_option('--update-check', dest='no_update_check', default=True, action='store_false',
++            help=_('Check for updates'))
+     parser.add_option('--ignore-plugins', default=False, action='store_true',
+             help=_('Ignore custom plugins, useful if you installed a plugin'
+                 ' that is preventing calibre from starting'))

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
     phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
     patches = [
+      # Disable updated version check.
+      ./no-version-check.patch
+
       (substituteAll {
         src = ./fix-paths.patch;
         inherit lame mplayer qt4;

--- a/pkgs/games/anki/no-version-check.patch
+++ b/pkgs/games/anki/no-version-check.patch
@@ -1,0 +1,13 @@
+diff -Nurp anki-2.0.33.orig/aqt/main.py anki-2.0.33/aqt/main.py
+--- anki-2.0.33.orig/aqt/main.py	2016-01-05 21:37:53.904533750 +0100
++++ anki-2.0.33/aqt/main.py	2016-01-05 21:39:11.469175976 +0100
+@@ -820,6 +820,9 @@ title="%s">%s</button>''' % (
+     ##########################################################################
+ 
+     def setupAutoUpdate(self):
++        # Don't check for latest version since the versions are
++        # managed in Nixpkgs.
++        return
+         import aqt.update
+         self.autoUpdate = aqt.update.LatestVersionFinder(self)
+         self.connect(self.autoUpdate, SIGNAL("newVerAvail"), self.newVerAvail)


### PR DESCRIPTION
These update checks cause unnecessary nagging since they kind of assume you run the programs outside the control of a package manager.
