### PR TITLE
Revert "iptables: 1.4.21 -> 1.6.0"

### DIFF
--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,21 +1,13 @@
-{stdenv, fetchurl, bison, flex, libnetfilter_conntrack, libnftnl, libmnl}:
+{stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
   name = "iptables-${version}";
-  version = "1.6.0";
+  version = "1.4.21";
 
   src = fetchurl {
     url = "http://www.netfilter.org/projects/iptables/files/${name}.tar.bz2";
-    sha256 = "0q0w1x4aijid8wj7dg1ny9fqwll483f1sqw7kvkskd8q1c52mdsb";
+    sha256 = "1q6kg7sf0pgpq0qhab6sywl23cngxxfzc9zdzscsba8x09l4q02j";
   };
-
-  nativeBuildInputs = [bison flex];
-
-  buildInputs = [libnetfilter_conntrack libnftnl libmnl];
-
-  preConfigure = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lmnl -lnftnl"
-  '';
 
   configureFlags = ''
     --enable-devel


### PR DESCRIPTION
This reverts commit b2ac241e958c767c4d817e65c37802014499d7a4, which
upgraded iptables, because it causes connmand to segfault on my machine:

```
Jan 05 22:02:06 aching connmand[7866]: Connection Manager version 1.30
Jan 05 22:02:06 aching audit: NETFILTER_CFG table=filter family=2 entries=27
Jan 05 22:02:06 aching audit[7866]: SYSCALL arch=c000003e syscall=54 success=yes exit=0 a0=a a1=0 a2=40 a3=103a5b0 items=0 ppid=1 pid=7866 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="connmand" exe="/nix/store/x7lyis4srvd68lflgnqqmg2bc1fm2whb-connman-1.30/bin/connmand" key=(null)
Jan 05 22:02:06 aching audit: PROCTITLE proctitle=2F6E69782F73746F72652F78376C796973347372766436386C666C676E71716D6732626331666D327768622D636F6E6E6D616E2D312E33302F7362696E2F636F6E6E6D616E64002D2D636F6E6669673D2F6E69782F73746F72652F37383078797137726367376766306271706A3130306C666238336B69367938762D636F6E6E
Jan 05 22:02:06 aching audit: NETFILTER_CFG table=mangle family=2 entries=6
Jan 05 22:02:06 aching audit[7866]: SYSCALL arch=c000003e syscall=54 success=yes exit=0 a0=a a1=0 a2=40 a3=1038c00 items=0 ppid=1 pid=7866 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="connmand" exe="/nix/store/x7lyis4srvd68lflgnqqmg2bc1fm2whb-connman-1.30/bin/connmand" key=(null)
Jan 05 22:02:06 aching audit: PROCTITLE proctitle=2F6E69782F73746F72652F78376C796973347372766436386C666C676E71716D6732626331666D327768622D636F6E6E6D616E2D312E33302F7362696E2F636F6E6E6D616E64002D2D636F6E6669673D2F6E69782F73746F72652F37383078797137726367376766306271706A3130306C666238336B69367938762D636F6E6E
Jan 05 22:02:06 aching audit: NETFILTER_CFG table=nat family=2 entries=5
Jan 05 22:02:06 aching audit[7866]: SYSCALL arch=c000003e syscall=54 success=yes exit=0 a0=a a1=0 a2=40 a3=1037800 items=0 ppid=1 pid=7866 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="connmand" exe="/nix/store/x7lyis4srvd68lflgnqqmg2bc1fm2whb-connman-1.30/bin/connmand" key=(null)
Jan 05 22:02:06 aching audit: PROCTITLE proctitle=2F6E69782F73746F72652F78376C796973347372766436386C666C676E71716D6732626331666D327768622D636F6E6E6D616E2D312E33302F7362696E2F636F6E6E6D616E64002D2D636F6E6669673D2F6E69782F73746F72652F37383078797137726367376766306271706A3130306C666238336B69367938762D636F6E6E
Jan 05 22:02:06 aching connmand[7866]: Aborting (signal 11) [/nix/store/x7lyis4srvd68lflgnqqmg2bc1fm2whb-connman-1.30/sbin/connmand]
Jan 05 22:02:06 aching connmand[7866]: ++++++++ backtrace ++++++++
Jan 05 22:02:06 aching connmand[7866]: +++++++++++++++++++++++++++
Jan 05 22:02:06 aching systemd[1]: connman.service: Main process exited, code=exited, status=1/FAILURE
Jan 05 22:02:06 aching systemd[1]: connman.service: Unit entered failed state.
Jan 05 22:02:06 aching systemd[1]: connman.service: Failed with result 'exit-code'.
Jan 05 22:02:06 aching systemd[1]: connman.service: Service hold-off time over, scheduling restart.
Jan 05 22:02:06 aching systemd[1]: Stopped Connection service.
```

Arrived at through bisection, verified using this commit.
