### PR TITLE
mcrypt: fix several security issues

### DIFF
--- a/pkgs/tools/misc/mcrypt/default.nix
+++ b/pkgs/tools/misc/mcrypt/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchurl, libmcrypt, libmhash }:
- 
+
 stdenv.mkDerivation rec {
   version = "2.6.8";
   name = "mcrypt-${version}";
-  
+
   src = fetchurl {
     url = "mirror://sourceforge/mcrypt/MCrypt/${version}/${name}.tar.gz";
     sha256 = "5145aa844e54cca89ddab6fb7dd9e5952811d8d787c4f4bf27eb261e6c182098";
   };
- 
-  buildInputs = [libmcrypt libmhash];
- 
+
+  patches = [ ./format-string.patch ./overflow.patch ./segv.patch ./sprintf.patch ];
+
+  buildInputs = [ libmcrypt libmhash ];
+
   meta = {
     description = "Replacement for old UNIX crypt(1)";
     longDescription = ''

--- a/pkgs/tools/misc/mcrypt/format-string.patch
+++ b/pkgs/tools/misc/mcrypt/format-string.patch
@@ -1,0 +1,31 @@
+--- mcrypt-2.6.8/src/errors.c
++++ mcrypt-2.6.8/src/errors.c
+@@ -25,24 +25,24 @@
+
+ void err_quit(char *errmsg)
+ {
+-	fprintf(stderr, errmsg);
++	fprintf(stderr, "%s", errmsg);
+ 	exit(-1);
+ }
+
+ void err_warn(char *errmsg)
+ {
+ 	if (quiet <= 1)
+-		fprintf(stderr, errmsg);
++		fprintf(stderr, "%s", errmsg);
+ }
+
+ void err_info(char *errmsg)
+ {
+ 	if (quiet == 0)
+-		fprintf(stderr, errmsg);
++		fprintf(stderr, "%s", errmsg);
+ }
+
+ void err_crit(char *errmsg)
+ {
+ 	if (quiet <= 2)
+-		fprintf(stderr, errmsg);
++		fprintf(stderr, "%s", errmsg);
+ }

--- a/pkgs/tools/misc/mcrypt/overflow.patch
+++ b/pkgs/tools/misc/mcrypt/overflow.patch
@@ -1,0 +1,24 @@
+From 3efb40e17ce4f76717ae17a1ce1e1f747ddf59fd Mon Sep 17 00:00:00 2001
+From: Alon Bar-Lev <alon.barlev@gmail.com>
+Date: Sat, 22 Dec 2012 22:37:06 +0200
+Subject: [PATCH] cleanup: buffer overflow
+
+---
+ mcrypt-2.6.8/src/extra.c |    2 ++
+ 1 files changed, 2 insertions(+), 0 deletions(-)
+
+diff --git a/mcrypt-2.6.8/src/extra.c b/mcrypt-2.6.8/src/extra.c
+index 3082f82..c7a1ac0 100644
+--- a/src/extra.c
++++ b/src/extra.c
+@@ -241,6 +241,8 @@ int check_file_head(FILE * fstream, char *algorithm, char *mode,
+ 		if (m_getbit(6, flags) == 1) { /* if the salt bit is set */
+ 			if (m_getbit(0, sflag) != 0) { /* if the first bit is set */
+ 				*salt_size = m_setbit(0, sflag, 0);
++				if (*salt_size > sizeof(tmp_buf))
++					err_quit(_("Salt is too long\n"));
+ 				if (*salt_size > 0) {
+ 					fread(tmp_buf, 1, *salt_size,
+ 					      fstream);
+--
+1.7.8.6

--- a/pkgs/tools/misc/mcrypt/segv.patch
+++ b/pkgs/tools/misc/mcrypt/segv.patch
@@ -1,0 +1,39 @@
+From 5bee29fae8f0e936ad4c957aef6035d09532a57a Mon Sep 17 00:00:00 2001
+From: Alon Bar-Lev <alon.barlev@gmail.com>
+Date: Sat, 22 Dec 2012 22:04:27 +0200
+Subject: [PATCH] cleanup: fixup segv on buffer access
+
+use exact buffer size instead of guess.
+
+do not copy out of source buffer.
+
+Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>
+---
+ mcrypt-2.6.8/src/rfc2440.c |    5 +++--
+ 1 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/mcrypt-2.6.8/src/rfc2440.c b/mcrypt-2.6.8/src/rfc2440.c
+index 5a1f296..929b9ab 100644
+--- a/src/rfc2440.c
++++ b/src/rfc2440.c
+@@ -497,7 +497,7 @@ plaintext_encode(const USTRING dat)
+     time_t t;
+
+     assert(dat->len > 0);
+-    result = make_ustring( NULL,  2 * dat->len); /* xxx */
++    result = make_ustring( NULL,  dat->len + 12); /* xxx */
+     newdat = (USTRING)dat;
+     result->d[pos++] = (0x80 | 0x40 | PKT_PLAINTEXT);
+
+@@ -810,7 +810,8 @@ encrypted_encode(const USTRING pt, const DEK *dek)
+     _mcrypt_encrypt(dek->hd, rndpref, dek->blocklen + 2, NULL, 0);
+     _mcrypt_sync(dek->hd, rndpref, dek->blocklen);
+
+-    ct = make_ustring( rndpref,   2 * pt->len); /* xxx */
++    ct = make_ustring( NULL, dek->blocklen + 2 + pt->len + 12); /* xxx */
++    memcpy(ct->d, rndpref, dek->blocklen + 2);
+     pos = dek->blocklen + 2;
+
+     _mcrypt_encrypt(dek->hd, ct->d + pos, pt->len, pt->d, pt->len);
+--
+1.7.8.6

--- a/pkgs/tools/misc/mcrypt/sprintf.patch
+++ b/pkgs/tools/misc/mcrypt/sprintf.patch
@@ -1,0 +1,108 @@
+Description: [CVE-2012-4527] Stack-based buffer overflow with long file names
+ .
+ A buffer overflow in mcrypt version 2.6.8 and earlier due to long filenames.
+ If a user were tricked into attempting to encrypt/decrypt specially crafted
+ long filename(s), this flaw would cause a stack-based buffer overflow that
+ could potentially lead to arbitrary code execution.
+ .
+ Note that this is caught by FORTIFY_SOURCE, which makes this a crash-only
+ bug on wheezy.
+Author: Attila Bogar, Jean-Michel Vourgère <jmv_deb@nirgal.com>
+Origin: https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2012-4527
+Bug: CVE-2012-4527
+Bug-Debian: http://bugs.debian.org/690924
+Forwarded: no
+Last-Update: 2012-11-01
+Index: mcrypt-2.6.8/src/mcrypt.c
+===================================================================
+--- mcrypt-2.6.8.orig/src/mcrypt.c
++++ mcrypt-2.6.8/src/mcrypt.c
+@@ -41,4 +41,6 @@
+
++/* Temporary error message can contain one file name and 1k of text */
++#define ERRWIDTH ((PATH_MAX)+1024)
+-char tmperr[128];
++char tmperr[ERRWIDTH];
+ unsigned int stream_flag = FALSE;
+ char *keymode = NULL;
+ char *mode = NULL;
+@@ -482,7 +485,7 @@
+ #ifdef HAVE_STAT
+       if (stream_flag == FALSE) {
+ 	 if (is_normal_file(file[i]) == FALSE) {
+-	    sprintf(tmperr,
++	    snprintf(tmperr, ERRWIDTH,
+ 		    _
+ 		    ("%s: %s is not a regular file. Skipping...\n"),
+ 		    program_name, file[i]);
+@@ -501,7 +504,7 @@
+ 	    dinfile = file[i];
+ 	 if ((isatty(fileno((FILE *) (stdin))) == 1)
+ 	     && (stream_flag == TRUE) && (force == 0)) {	/* not a tty */
+-	    sprintf(tmperr,
++	    snprintf(tmperr, ERRWIDTH,
+ 		    _
+ 		    ("%s: Encrypted data will not be read from a terminal.\n"),
+ 		    program_name);
+@@ -520,7 +523,7 @@
+ 	    einfile = file[i];
+ 	 if ((isatty(fileno((FILE *) (stdout))) == 1)
+ 	     && (stream_flag == TRUE) && (force == 0)) {	/* not a tty */
+-	    sprintf(tmperr,
++	    snprintf(tmperr, ERRWIDTH,
+ 		    _
+ 		    ("%s: Encrypted data will not be written to a terminal.\n"),
+ 		    program_name);
+@@ -544,7 +547,7 @@
+ 	    strcpy(outfile, einfile);
+ 	    /* if file has already the .nc ignore it */
+ 	    if (strstr(outfile, ".nc") != NULL) {
+-	       sprintf(tmperr,
++	       snprintf(tmperr, ERRWIDTH,
+ 		       _
+ 		       ("%s: file %s has the .nc suffix... skipping...\n"),
+ 		       program_name, outfile);
+@@ -590,10 +593,10 @@
+
+ 	 if (x == 0) {
+ 	    if (stream_flag == FALSE) {
+-	       sprintf(tmperr, _("File %s was decrypted.\n"), dinfile);
++	       snprintf(tmperr, ERRWIDTH, _("File %s was decrypted.\n"), dinfile);
+ 	       err_warn(tmperr);
+ 	    } else {
+-	       sprintf(tmperr, _("Stdin was decrypted.\n"));
++	       snprintf(tmperr, ERRWIDTH, _("Stdin was decrypted.\n"));
+ 	       err_warn(tmperr);
+ 	    }
+ #ifdef HAVE_STAT
+@@ -610,7 +613,7 @@
+
+ 	 } else {
+ 	    if (stream_flag == FALSE) {
+-	       sprintf(tmperr,
++	       snprintf(tmperr, ERRWIDTH,
+ 		       _
+ 		       ("File %s was NOT decrypted successfully.\n"),
+ 		       dinfile);
+@@ -636,10 +639,10 @@
+
+ 	 if (x == 0) {
+ 	    if (stream_flag == FALSE) {
+-	       sprintf(tmperr, _("File %s was encrypted.\n"), einfile);
++	       snprintf(tmperr, ERRWIDTH, _("File %s was encrypted.\n"), einfile);
+ 	       err_warn(tmperr);
+ 	    } else {
+-	       sprintf(tmperr, _("Stdin was encrypted.\n"));
++	       snprintf(tmperr, ERRWIDTH, _("Stdin was encrypted.\n"));
+ 	       err_warn(tmperr);
+ 	    }
+ #ifdef HAVE_STAT
+@@ -655,7 +658,7 @@
+
+ 	 } else {
+ 	    if (stream_flag == FALSE) {
+-	       sprintf(tmperr,
++	       snprintf(tmperr, ERRWIDTH,
+ 		       _
+ 		       ("File %s was NOT encrypted successfully.\n"),
+ 		       einfile);


### PR DESCRIPTION
CVE-2012-4409, CVE-2012-4426, CVE-2012-4527

Patches taken from https://gitweb.gentoo.org/repo/gentoo.git/tree/app-crypt/mcrypt/files
