### PR TITLE
libxml2: 2.9.2 -> 2.9.3

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -4,16 +4,13 @@ assert pythonSupport -> python != null;
 
 #TODO: share most stuff between python and non-python builds, perhaps via multiple-output
 
-let
-  version = "2.9.2";
-in
-
 stdenv.mkDerivation (rec {
   name = "libxml2-${version}";
+  version = "2.9.3";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "1g6mf03xcabmk5ing1lwqmasr803616gb2xhn7pll10x2l5w6y2i";
+    sha256 = "0bd17g6znn2r98gzpjppsqjg33iraky4px923j3k8kdl8qgy7sad";
   };
 
   outputs = [ "out" "doc" ];
@@ -48,4 +45,3 @@ stdenv.mkDerivation (rec {
 } // stdenv.lib.optionalAttrs (!pythonSupport) {
   configureFlags = "--with-python=no"; # otherwise build impurity bites us
 })
-


### PR DESCRIPTION
Fixes a large number of security issues, so it also needs to go into 15.09.
