### PR TITLE
nixos: tarsnap - allow and document concurrent backups

### DIFF
--- a/nixos/modules/services/backup/tarsnap.nix
+++ b/nixos/modules/services/backup/tarsnap.nix
@@ -5,8 +5,8 @@ with lib;
 let
   cfg = config.services.tarsnap;
 
-  configFile = cfg: ''
-    cachedir ${config.services.tarsnap.cachedir}
+  configFile = name: cfg: ''
+    cachedir ${config.services.tarsnap.cachedir}/${name}
     keyfile  ${config.services.tarsnap.keyfile}
     ${optionalString cfg.nodump "nodump"}
     ${optionalString cfg.printStats "print-stats"}
@@ -56,6 +56,12 @@ in
           Should the cache become desynchronized or corrupted, tarsnap
           will refuse to run until you manually rebuild the cache with
           <command>tarsnap --fsck</command>.
+
+          Note that each individual archive (specified below) has its own cache
+          directory specified under <literal>cachedir</literal>; this is because
+          tarsnap locks the cache during backups, meaning multiple services
+          archives cannot be backed up concurrently or overlap with a shared
+          cache.
 
           Set to <literal>null</literal> to disable caching.
         '';
@@ -258,6 +264,7 @@ in
         mkdir -p -m 0700 ${cfg.cachedir}
         chown root:root ${cfg.cachedir}
         chmod 0700 ${cfg.cachedir}
+        mkdir -p -m 0700 ${cfg.cachedir}/$1
         DIRS=`cat /etc/tarsnap/$1.dirs`
         exec tarsnap --configfile /etc/tarsnap/$1.conf -c -f $1-$(date +"%Y%m%d%H%M%S") $DIRS
       '';
@@ -280,7 +287,7 @@ in
 
     environment.etc =
       (mapAttrs' (name: cfg: nameValuePair "tarsnap/${name}.conf"
-        { text = configFile cfg;
+        { text = configFile name cfg;
         }) cfg.archives) //
       (mapAttrs' (name: cfg: nameValuePair "tarsnap/${name}.dirs"
         { text = concatStringsSep " " cfg.directories;

--- a/nixos/modules/services/backup/tarsnap.nix
+++ b/nixos/modules/services/backup/tarsnap.nix
@@ -7,7 +7,7 @@ let
 
   configFile = name: cfg: ''
     cachedir ${config.services.tarsnap.cachedir}/${name}
-    keyfile  ${config.services.tarsnap.keyfile}
+    keyfile  ${cfg.keyfile}
     ${optionalString cfg.nodump "nodump"}
     ${optionalString cfg.printStats "print-stats"}
     ${optionalString cfg.printStats "humanize-numbers"}
@@ -41,6 +41,20 @@ in
           account.
           Create the keyfile with <command>tarsnap-keygen</command>.
 
+          Note that each individual archive (specified below) may also have its
+          own individual keyfile specified. Tarsnap does not allow multiple
+          concurrent backups with the same cache directory and key (starting a
+          new backup will cause another one to fail). If you have multiple
+          archives specified, you should either spread out your backups to be
+          far apart, or specify a separate key for each archive. By default
+          every archive defaults to using
+          <literal>"/root/tarsnap.key"</literal>.
+
+          It's recommended for backups that you generate a key for every archive
+          using <literal>tarsnap-keygen(1)</literal>, and then generate a
+          write-only tarsnap key using <literal>tarsnap-keymgmt(1)</literal>,
+          and keep your master key(s) for a particular machine off-site.
+
           The keyfile name should be given as a string and not a path, to
           avoid the key being copied into the Nix store.
         '';
@@ -71,6 +85,28 @@ in
         type = types.attrsOf (types.submodule (
           {
             options = {
+              keyfile = mkOption {
+                type = types.str;
+                default = config.services.tarsnap.keyfile;
+                description = ''
+                  Set a specific keyfile for this archive. This defaults to
+                  <literal>"/root/tarsnap.key"</literal> if left unspecified.
+
+                  Use this option if you want to run multiple backups
+                  concurrently - each archive must have a unique key. You can
+                  generate a write-only key derived from your master key (which
+                  is recommended) using <literal>tarsnap-keymgmt(1)</literal>.
+
+                  Note: every archive must have an individual master key. You
+                  must generate multiple keys with
+                  <literal>tarsnap-keygen(1)</literal>, and then generate write
+                  only keys from those.
+
+                  The keyfile name should be given as a string and not a path, to
+                  avoid the key being copied into the Nix store.
+                '';
+              };
+
               nodump = mkOption {
                 type = types.bool;
                 default = true;


### PR DESCRIPTION
I have multiple separate archives I want to backup concurrently. Needless to say, I can't right now.

Tarsnap locks the cachedir during backup, meaning if you specify
multiple backups with a shared cache that might overlap (for example,
one backup may take an hour), secondary backups will fail. This isn't
very nice behavior for the obvious reasons.

This splits the cache dirs for each archive appropriately. Note that
this will require a rebuild of your archive caches (although if you were
only using one archive for your whole system, you can just move the
directory).

However, you also must use a separate key (generated via `tarsnap-keygen`) for each archive. So this also extends each archive to have support for specifying individual keys.
