### PR TITLE
emacsPackagesNg.evil-mc: Fix license typo

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -605,7 +605,7 @@ let
     packageRequires = [ evil ];
     meta = {
       description = "Multiple cursors implementation for evil-mode";
-      license = gpl3plus;
+      license = gpl3Plus;
     };
   };
 


### PR DESCRIPTION
The license attribute `gpl3plus` is wrong and should be `gpl3Plus` instead. This fixes all recent travis errors.

The typo was introduced in d3de3db07769c5a6c6d57db7e86b128a494e645e.
