### PR TITLE
pyqt5: 5.4.2 -> 5.5.1

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -2,7 +2,7 @@
 , lndir, makeWrapper }:
 
 let
-  version = "5.4.2";
+  version = "5.5.1";
 in stdenv.mkDerivation {
   name = "${python.libPrefix}-PyQt-${version}";
 
@@ -16,7 +16,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/PyQt5/PyQt-${version}/PyQt-gpl-${version}.tar.gz";
-    sha256 = "1402n5kwzd973b65avxk1j9js96wzfm0yw4rshjfy8l7an00bnac";
+    sha256 = "11l3pm0wkwkxzw4n3022iid3yyia5ap4l0ny1m5ngkzzzfafyw0a";
   };
 
   buildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -166,7 +166,7 @@ in modules // {
   pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix {
     sip = self.sip_4_16;
     pythonDBus = self.dbus;
-    inherit (pkgs.qt5) qtbase qtsvg qtwebkit;
+    inherit (pkgs.qt55) qtbase qtsvg qtwebkit;
   };
 
   pyside = callPackage ../development/python-modules/pyside { };


### PR DESCRIPTION
This fixes an annoying bug in qutebrowser: [displaying large diffs in github is really slow with Qt 5.4, but that is fixed in Qt 5.5](https://github.com/The-Compiler/qutebrowser/issues/1179#issuecomment-163569447). 

I have tested the upgrade with both packages that depend on pyqt5: qutebrowser and calibre.
