### PR TITLE
thrift: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, boost, zlib, libevent, openssl, python, pkgconfig, bison
-, flex
+, flex, twisted
 }:
 
 stdenv.mkDerivation rec {
   name = "thrift-${version}";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchurl {
     url = "http://archive.apache.org/dist/thrift/${version}/${name}.tar.gz";
-    sha256 = "0w4m6hjmgr1wqac9p5zyfxx2wwqay730qi14fzxba7f46hwhvxff";
+    sha256 = "17lnchan9q3qdg222rgjjai6819j9k755s239phdv6n0183hlx5h";
   };
 
   #enableParallelBuilding = true; problems on hydra
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   pythonPath = [];
 
   buildInputs = [
-    boost zlib libevent openssl python pkgconfig bison flex
+    boost zlib libevent openssl python pkgconfig bison flex twisted
   ];
 
   preConfigure = "export PY_PREFIX=$out";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8527,7 +8527,9 @@ let
     python = python2;
   };
 
-  thrift = callPackage ../development/libraries/thrift { };
+  thrift = callPackage ../development/libraries/thrift {
+    inherit (pythonPackages) twisted;
+  };
 
   tidyp = callPackage ../development/libraries/tidyp { };
 


### PR DESCRIPTION
Add Twisted as build input so that we can continue to have Python
support. (./configure disables Python support unless it finds the
'trial' program, from Twisted.) I don't know whether upstream intended
that, because it seems perfectly fine to run thrift + Python without
Twisted. (Only the TTwisted transport uses Twisted...)

Ah, Thrift use Twisted in its unit tests. Even when we pass
--enable-tests=no to ./configure :-D
