### PR TITLE
replace /usr/bin/python in ansible modules

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -592,10 +592,14 @@ in modules // {
       sed -i "s,/usr/,$out," lib/ansible/constants.py
     '';
 
+    postInstall = ''
+      find $out/${python.sitePackages}/ansible -type f -name '*.py' -print0 \
+        | xargs -0 sed -i "s|/usr/bin/python|/usr/bin/env python|"
+    '';
+
     doCheck = false;
     dontStrip = true;
     dontPatchELF = true;
-    dontPatchShebangs = true;
     windowsSupport = true;
 
     propagatedBuildInputs = with self; [
@@ -622,6 +626,11 @@ in modules // {
 
     prePatch = ''
       sed -i "s,/usr/,$out," lib/ansible/constants.py
+    '';
+
+    postInstall = ''
+      find $out/${python.sitePackages}/ansible -type f -name '*.py' -print0 \
+        | xargs -0 sed -i "s|/usr/bin/python|/usr/bin/env python|"
     '';
 
     doCheck = false;


### PR DESCRIPTION
@copumpkin There are a bunch of python scripts in the ansible modules folder which reference `/usr/bin/python`. This won't work on nixos. Unfortunately just replacing it with a hard-coded path like `/nix/store/...` won't work if the file is copied to a machine and executed remotely, but `/usr/bin/env python` should. 
