### PR TITLE
consul service: add package option

### DIFF
--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.consul;
 
   configOptions = { data_dir = dataDir; } //
-    (if cfg.webUi then { ui_dir = "${pkgs.consul.ui}"; } else { }) //
+    (if cfg.webUi then { ui_dir = "${cfg.package.ui}"; } else { }) //
     cfg.extraConfig;
 
   configFiles = [ "/etc/consul.json" "/etc/consul-addrs.json" ]
@@ -29,6 +29,15 @@ in
           Enables the consul daemon.
         '';
       };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.consul;
+        description = ''
+          The package used for the Consul agent and CLI.
+        '';
+      };
+
 
       webUi = mkOption {
         type = types.bool;
@@ -155,7 +164,7 @@ in
         etc."consul.json".text = builtins.toJSON configOptions;
         # We need consul.d to exist for consul to start
         etc."consul.d/dummy.json".text = "{ }";
-        systemPackages = with pkgs; [ consul ];
+        systemPackages = [ cfg.package ];
       };
 
       systemd.services.consul = {
@@ -167,14 +176,14 @@ in
             (filterAttrs (n: _: hasPrefix "consul.d/" n) config.environment.etc);
 
         serviceConfig = {
-          ExecStart = "@${pkgs.consul}/bin/consul consul agent -config-dir /etc/consul.d"
+          ExecStart = "@${cfg.package}/bin/consul consul agent -config-dir /etc/consul.d"
             + concatMapStrings (n: " -config-file ${n}") configFiles;
-          ExecReload = "${pkgs.consul}/bin/consul reload";
+          ExecReload = "${cfg.package}/bin/consul reload";
           PermissionsStartOnly = true;
           User = if cfg.dropPrivileges then "consul" else null;
           TimeoutStartSec = "0";
         } // (optionalAttrs (cfg.leaveOnStop) {
-          ExecStop = "${pkgs.consul}/bin/consul leave";
+          ExecStop = "${cfg.package}/bin/consul leave";
         });
 
         path = with pkgs; [ iproute gnugrep gawk consul ];
@@ -221,7 +230,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "consul.service" ];
 
-        path = [ pkgs.consul ];
+        path = [ cfg.package ];
 
         serviceConfig = {
           ExecStart = ''


### PR DESCRIPTION
Many service packages already seem to have options like this, and I happened to need this one in particular.
Its sister service consul-alerts already had one.
