### PR TITLE
jekyll: added rouge for highlighting.

### DIFF
--- a/pkgs/applications/misc/jekyll/Gemfile
+++ b/pkgs/applications/misc/jekyll/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem 'jekyll'
 gem 'rdiscount'
 gem 'RedCloth'
+gem 'rouge'

--- a/pkgs/applications/misc/jekyll/Gemfile.lock
+++ b/pkgs/applications/misc/jekyll/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    rouge (1.10.1)
     RedCloth (4.2.9)
     blankslate (2.1.2.4)
     celluloid (0.16.0)
@@ -71,6 +72,7 @@ PLATFORMS
 DEPENDENCIES
   RedCloth
   jekyll
+  rouge
   rdiscount
 
 BUNDLED WITH

--- a/pkgs/applications/misc/jekyll/gemset.nix
+++ b/pkgs/applications/misc/jekyll/gemset.nix
@@ -6,6 +6,13 @@
       sha256 = "06pahxyrckhgb7alsxwhhlx1ib2xsx33793finj01jk8i054bkxl";
     };
   };
+  "rouge" = {
+    version = "1.10.1";
+    source = {
+      type = "gem";
+      sha256 = "0wp8as9ypdy18kdj9h70kny1rdfq71mr8cj2bpahr9vxjjvjasqz";
+    };
+  };
   "blankslate" = {
     version = "2.1.2.4";
     source = {
@@ -95,6 +102,7 @@
     dependencies = [
       "classifier-reborn"
       "colorator"
+      "rogue"
       "jekyll-coffeescript"
       "jekyll-gist"
       "jekyll-paginate"


### PR DESCRIPTION
This is to address #12224  issue I was having.  Instead of using the pygments highlighter that is broken it allows for the use of a rub implemented one called rouge.  Unfortunately you still have to configure jekyll to manually use this highlighter but at least its an option.  In future versions of jekyll it is the new default.
