### PR TITLE
phpPackages: init php56Packages and php70Packages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5201,10 +5201,18 @@ let
 
   php = php56;
 
-  phpPackages = recurseIntoAttrs (callPackage ./php-packages.nix {});
+  phpPackages = php56Packages;
 
   php55Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
     php = php55;
+  });
+
+  php56Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php56;
+  });
+
+  php70Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php70;
   });
 
   inherit (callPackages ../development/interpreters/php { })

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,25 +1,46 @@
-{ pkgs, php }:
+{ pkgs, fetchgit, php }:
 
-let self = with self; {
-  buildPecl = import ../build-support/build-pecl.nix {
-    inherit php;
-    inherit (pkgs) stdenv autoreconfHook fetchurl;
-  };
+let
+  self = with self; {
+    buildPecl = import ../build-support/build-pecl.nix {
+      inherit php;
+      inherit (pkgs) stdenv autoreconfHook fetchurl;
+    };
+  isPhpOlder55 = pkgs.lib.versionOlder php.version "5.5";
+  isPhp7 = pkgs.lib.versionAtLeast php.version "7.0";
 
-  apcu = buildPecl {
+  apcu = if isPhp7 then apcu51 else apcu40;
+
+  apcu40 = assert !isPhp7; buildPecl {
     name = "apcu-4.0.7";
 
     sha256 = "1mhbz56mbnq7dryf2d64l84lj3fpr5ilmg2424glans3wcg772hp";
   };
 
-  imagick = buildPecl {
+  apcu51 = assert isPhp7; buildPecl {
+    name = "apcu-5.1.2";
+
+    sha256 = "0r5pfbjbmdj46h20jm3iqmy969qd27ajyf0phjhgykv6j0cqjlgd";
+  };
+
+  imagick = if isPhp7 then imagick34 else imagick31;
+
+  imagick31 = assert !isPhp7; buildPecl {
     name = "imagick-3.1.2";
     sha256 = "14vclf2pqcgf3w8nzqbdw0b9v30q898344c84jdbw2sa62n6k1sj";
     configureFlags = "--with-imagick=${pkgs.imagemagick}";
     buildInputs = [ pkgs.pkgconfig ];
   };
 
-  memcache = buildPecl {
+  imagick34 = buildPecl {
+    name = "imagick-3.4.0RC4";
+    sha256 = "0fdkzdv3r8sm6y1x11kp3rxsimq6zf15xvi0mhn57svmnan4zh0i";
+    configureFlags = "--with-imagick=${pkgs.imagemagick}";
+    buildInputs = [ pkgs.pkgconfig ];
+  };
+
+  # No support for PHP 7 yet
+  memcache = assert !isPhp7; buildPecl {
     name = "memcache-3.0.8";
 
     sha256 = "04c35rj0cvq5ygn2jgmyvqcb0k8d03v4k642b6i37zgv7x15pbic";
@@ -27,7 +48,9 @@ let self = with self; {
     configureFlags = "--with-zlib-dir=${pkgs.zlib}";
   };
 
-  memcached = buildPecl {
+  memcached = if isPhp7 then memcachedPhp7 else memcached22;
+
+  memcached22 = assert !isPhp7; buildPecl {
     name = "memcached-2.2.0";
 
     sha256 = "0n4z2mp4rvrbmxq079zdsrhjxjkmhz6mzi7mlcipz02cdl7n1f8p";
@@ -40,7 +63,27 @@ let self = with self; {
     buildInputs = with pkgs; [ pkgconfig cyrus_sasl ];
   };
 
-  xdebug = buildPecl {
+  # Not released yet
+  memcachedPhp7 = assert isPhp7; buildPecl rec {
+    name = "memcached-php7";
+
+    src = fetchgit {
+      url = "https://github.com/php-memcached-dev/php-memcached";
+      rev = "e573a6e8fc815f12153d2afd561fc84f74811e2f";
+      sha256 = "f7acfdae04ef2ef9ece67b6d009aaf6604db64735fc7619f7169929aabb9c58f";
+    };
+
+    configureFlags = [
+      "--with-zlib-dir=${pkgs.zlib}"
+      "--with-libmemcached-dir=${pkgs.libmemcached}"
+    ];
+
+    buildInputs = with pkgs; [ pkgconfig cyrus_sasl ];
+  };
+
+  xdebug = if isPhp7 then xdebug24 else xdebug23;
+
+  xdebug23 = assert !isPhp7; buildPecl {
     name = "xdebug-2.3.1";
 
     sha256 = "0k567i6w7cw14m13s7ip0946pvy5ii16cjwjcinnviw9c24na0xm";
@@ -49,13 +92,25 @@ let self = with self; {
     checkTarget = "test";
   };
 
-  zendopcache = buildPecl {
+  xdebug24 = buildPecl {
+    name = "xdebug-2.4.0RC3";
+
+    sha256 = "06ppsihw4cl8kxmywvic6wsm4ps9pvsns2vbab9ivrfyp8b6h5dy";
+
+    doCheck = true;
+    checkTarget = "test";
+  };
+
+  # Since PHP 5.5 OPcache is integrated in the core and has to be enabled via --enable-opcache during compilation.
+  zendopcache = assert isPhpOlder55; buildPecl {
     name = "zendopcache-7.0.3";
 
     sha256 = "0qpfbkfy4wlnsfq4vc4q5wvaia83l89ky33s08gqrcfp3p1adn88";
   };
 
-  zmq = buildPecl {
+  zmq = if isPhp7 then zmqPhp7 else zmq11;
+
+  zmq11 = assert !isPhp7; buildPecl {
     name = "zmq-1.1.2";
 
     sha256 = "0ccz73p8pkda3y9p9qbr3m19m0yrf7k2bvqgbaly3ibgh9bazc69";
@@ -67,7 +122,25 @@ let self = with self; {
     buildInputs = [ pkgs.pkgconfig ];
   };
 
-  xcache = buildPecl rec {
+  # Not released yet
+  zmqPhp7 = assert isPhp7; buildPecl rec {
+    name = "zmq-php7";
+
+    src = fetchgit {
+      url = "https://github.com/mkoppanen/php-zmq";
+      rev = "94d2b87d195f870775b153b42c29f30da049f4db";
+      sha256 = "51a25b1029800d8abe03c5c08c50d6aee941c95c741dc22d2f853052511f4296";
+    };
+
+    configureFlags = [
+      "--with-zmq=${pkgs.zeromq2}"
+    ];
+
+    buildInputs = [ pkgs.pkgconfig ];
+  };
+
+  # No support for PHP 7 and probably never will be
+  xcache = assert !isPhp7; buildPecl rec {
     name = "xcache-${version}";
 
     version = "3.2.0";
@@ -92,14 +165,22 @@ let self = with self; {
     buildInputs = [ pkgs.m4 ];
   };
 
-  pthreads = assert pkgs.config.php.zts or false; buildPecl {
-    #pthreads requires a build of PHP with ZTS (Zend Thread Safety) enabled
-    #--enable-maintainer-zts or --enable-zts on Windows
+  #pthreads requires a build of PHP with ZTS (Zend Thread Safety) enabled
+  #--enable-maintainer-zts or --enable-zts on Windows
+  pthreads = if isPhp7 then pthreads31 else pthreads20;
+
+  pthreads20 = assert (pkgs.config.php.zts or false) && (!isPhp7); buildPecl {
     name = "pthreads-2.0.10";
     sha256 = "1xlcb1b1g10jd0xhm3c01a06yqpb5qln47pd1k522138324qvpwb";
   };
 
-  geoip = buildPecl {
+  pthreads31 = assert (pkgs.config.php.zts or false) && isPhp7; buildPecl {
+    name = "pthreads-3.1.5";
+    sha256 = "1ziap0py3zrc7qj9lw4nzq6wx1viyj8v9y1babchizzan014x6p5";
+  };
+
+  # No support for PHP 7 yet
+  geoip = assert !isPhp7; buildPecl {
     name = "geoip-1.1.0";
     sha256 = "1fcqpsvwba84gqqmwyb5x5xhkazprwkpsnn4sv2gfbsd4svxxil2";
 
@@ -108,9 +189,22 @@ let self = with self; {
     buildInputs = [ pkgs.geoip ];
   };
 
-  redis = buildPecl {
+  redis = if isPhp7 then redisPhp7 else redis22;
+
+  redis22 = buildPecl {
     name = "redis-2.2.7";
     sha256 = "00n9dpk9ak0bl35sbcd3msr78sijrxdlb727nhg7f2g7swf37rcm";
+  };
+
+  # Not released yet
+  redisPhp7 = assert isPhp7; buildPecl rec {
+    name = "redis-php7";
+
+    src = fetchgit {
+      url = "https://github.com/phpredis/phpredis";
+      rev = "4a37e47d0256581ce2f7a3b15b5bb932add09f36";
+      sha256 = "ac5894d168e22ae4a770ce252cfbd07d0f9f1a5b48b084c0559b67fe4d3e51cb";
+    };
   };
 
   composer = pkgs.stdenv.mkDerivation rec {


### PR DESCRIPTION
Since PHP7 package was added quite some time ago, the PHP packages should also reflect this new version. Added `php56Packages` for `php56` and `php70Packages` for `php70`.
