### PR TITLE
emacs-pdf-tools: Move packages to packageRequires

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -103,9 +103,10 @@ let
       rev = "v${version}";
       sha256 = "19sy49r3ijh36m7hl4vspw5c4i8pnfqdn4ldm2sqchxigkw56ayl";
     };
-    buildInputs = with external; [ autoconf automake libpng zlib poppler pkgconfig ] ++ [ tablist let-alist ];
+    buildInputs = with external; [ autoconf automake libpng zlib poppler pkgconfig ];
     preBuild = "make server/epdfinfo";
     fileSpecs = [ "lisp/pdf-*.el" "server/epdfinfo" ];
+    packageRequires = [ tablist let-alist ];
     meta = {
       description = "Emacs support library for PDF files";
       license = gpl3;


### PR DESCRIPTION
Move the Emacs packages to packageRequires so that they get installed.

Before:

$ ls ~/.nix-profile/share/emacs/site-lisp/elpa
pdf-tools-0.70

After:

$ ls ~/.nix-profile/share/emacs/site-lisp/elpa
let-alist-1.0.4  pdf-tools-0.70  tablist-0.70
