### PR TITLE
w3m: fetch source from actively maintained debian repo

### DIFF
--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, fetchpatch
+{ stdenv, fetchgit, fetchpatch
 , ncurses, boehmgc, gettext, zlib
 , sslSupport ? true, openssl ? null
 , graphicsSupport ? true, imlib2 ? null
 , x11Support ? graphicsSupport, libX11 ? null
 , mouseSupport ? !stdenv.isDarwin, gpm-ncurses ? null
-, perl, man
+, perl, man, pkgconfig
 }:
 
 assert sslSupport -> openssl != null;
@@ -17,9 +17,10 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "w3m-0.5.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/w3m/${name}.tar.gz";
-    sha256 = "1qx9f0kprf92r1wxl3sacykla0g04qsi0idypzz24b7xy9ix5579";
+  src = fetchgit {
+    url = "git://anonscm.debian.org/collab-maint/w3m.git";
+    rev = "e0b6e022810271bd0efcd655006389ee3879e94d";
+    sha256 = "1vahm3719hb0m20nc8k88165z35f8b15qasa0whhk78r12bls1q6";
   };
 
   NIX_LDFLAGS = optionalString stdenv.isSunOS "-lsocket -lnsl";
@@ -29,44 +30,17 @@ stdenv.mkDerivation rec {
   PERL = "${perl}/bin/perl";
   MAN = "${man}/bin/man";
 
-  # the Arch patches were pulled from:
-  # https://aur.archlinux.org/cgit/aur.git/?h=w3m-mouse
   patches = [
     ./RAND_egd.libressl.patch
-    (fetchpatch {
-      name = "file_handle.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/file_handle.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
-      sha256 = "0kkqm68ig9d658kf1iwa1dwcf651f6dy2j98gplcks1mn3bdlak4";
-    })
-    (fetchpatch {
-      name = "form_unknown.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/form_unknown.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
-      sha256 = "1mbfclid3bihb1xv7sxcahprn3slzd6ga8rjzlq4rbq80bl053fw";
-    })
-    (fetchpatch {
-      name = "gc72.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/gc72.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
-      sha256 = "1n6anaw17by0s6rn25bwkgj2mck7ffspizpwbijvx1ynk451459a";
-    })
     (fetchpatch {
       name = "https.patch";
       url = "https://aur.archlinux.org/cgit/aur.git/plain/https.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
       sha256 = "08skvaha1hjyapsh8zw5dgfy433mw2hk7qy9yy9avn8rjqj7kjxk";
     })
-    (fetchpatch {
-      name = "perl.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/perl.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
-      sha256 = "15cq7cwh0d2v64i8by44rgxw48156sgh872921hxrqdakr95p3gy";
-    })
-    (fetchpatch {
-      name = "w3m_rgba.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/w3m_rgba.patch?h=w3m-mouse&id=5b5f0fbb59f674575e87dd368fed834641c35f03";
-      sha256 = "1dhp1p6z621ayyl9zip9w35x2cxyhhj72jv5dvf0zp4rk6cjm781";
-    })
   ] ++ optional (graphicsSupport && !x11Support) [ ./no-x11.patch ]
     ++ optional stdenv.isCygwin ./cygwin.patch;
 
-  buildInputs = [ncurses boehmgc gettext zlib]
+  buildInputs = [ pkgconfig ncurses boehmgc gettext zlib ]
     ++ optional sslSupport openssl
     ++ optional mouseSupport gpm-ncurses
     ++ optional graphicsSupport imlib2


### PR DESCRIPTION
The official repository has last been updated in 2013, meanwhile there are a lot of issues like non-existant certificate verification. The debian repository is actively maintained and already includes most of our custom patches, so we use it instead.

closes #12257

Can someone verify that the graphicsSupport/x11Support options work? Initially I was getting some build failures due to imlib not being found, so I looked into the configure script and it now seems to autoconfigure these with pkg-config. I'm not entirely sure tho and don't know how to test that properly.
