### PR TITLE
axel: mark as buildable on darwin

### DIFF
--- a/pkgs/tools/networking/axel/default.nix
+++ b/pkgs/tools/networking/axel/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     description = "Console downloading program with some features for parallel connections for faster downloading";
     homepage = http://axel.alioth.debian.org/;
     maintainers = with maintainers; [ pSub ];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
Tested on OSX 10.9.5
