### PR TITLE
nvidia:Bump to 358.16

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -21,14 +21,6 @@ buildPhase() {
         unset src # used by the nv makefile
         make SYSSRC=$sysSrc SYSOUT=$sysOut module
 
-        # nvidia no longer provides uvm kernel module for 32-bit archs
-        # http://www.nvidia.com/download/driverResults.aspx/79722/en-us
-        if [[ "$system" = "x86_64-linux" ]]; then
-            cd uvm
-            make SYSSRC=$sysSrc SYSOUT=$sysOut module
-            cd ..
-        fi
-
         cd ..
     fi
 }
@@ -73,8 +65,12 @@ installPhase() {
           ln -srnf "$libname" "$libname_short.2"
       fi
 
-      ln -srnf "$libname" "$libname_short"
-      ln -srnf "$libname" "$libname_short.1"
+      if [[ "$libname" != "$libname_short" ]]; then
+        ln -srnf "$libname" "$libname_short"
+      fi
+      if [[ "$libname" != "$libname_short.1" ]]; then
+        ln -srnf "$libname" "$libname_short.1"
+      fi
     done
 
     #patchelf --set-rpath $out/lib:$glPath $out/lib/libGL.so.*.*

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "352.63";
+  versionNumber = "358.16";
 
   # Policy: use the highest stable version as the default (on our master).
   inherit (stdenv.lib) makeLibraryPath;
@@ -27,17 +27,17 @@ stdenv.mkDerivation {
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
-        url = "http://us.download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "0vxrx2hmycvhyp32mapf1vv01ddlghliwsvkhsg29hv3a7fl4i28";
+        url = "http://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
+        sha256 = "1cc0zsri92nz2mznabfd6pqckm9mlbszmysqqqh3w5mipwn898nk";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "http://us.download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "11dgvsygavdsgbgq87d3d2sj3dc85f2yarr71qczkgiqa030yb1k";
+        url = "http://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
+        sha256 = "1xr16faam2zsx8ajwm9g9302m6qjzyjh1zd56g8jhc8jxg8h43sg";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 
-  patches = [ ./nvidia-4.2.patch ];
+  #patches = [ ./nvidia-4.2.patch ];
 
   inherit versionNumber libsOnly;
   inherit (stdenv) system;


### PR DESCRIPTION
As far as I can tell, explicitly compiling UVM is no longer necessary. Some of the library versions changed to ~.1, thus the other build-script change.

I changed the download server because we don't all live in the US; I don't think the non-us-prefixed server is actually a different one, but it might be if nVidia ever fixes their distribution infrastructure. It'd also be nice if they'd support SSL; I downloaded the package from two locations in hopes of discovering any MITM. Of course there wasn't any.

I have no idea what that patch was supposed to do. Things seem to work without it. Let me know if that makes sense, and I'll remove it instead of just commenting it out.
