### PR TITLE
notmuch-addrlookup: init at 7

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch-addrlookup/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-addrlookup/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, pkgconfig, glib, notmuch }:
+
+stdenv.mkDerivation rec {
+  name = "notmuch-addrlookup-${version}";
+  version = "7";
+
+  src = fetchFromGitHub {
+    owner = "aperezdc";
+    repo = "notmuch-addrlookup-c";
+    rev ="v${version}";
+    sha256 = "0mz0llf1ggl1k46brgrqj3i8qlg1ycmkc5a3a0kg8fg4s1c1m6xk";
+  };
+
+
+  buildInputs = [ pkgconfig glib notmuch ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp notmuch-addrlookup "$out/bin"
+  '';
+
+
+
+  meta = with stdenv.lib; {
+    description = "Address lookup tool for Notmuch in C";
+    homepage = https://github.com/aperezdc/notmuch-addrlookup-c;
+    maintainers = with maintainers; [ mog ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11593,6 +11593,8 @@ let
 
     notmuch = lowPrio (pkgs.notmuch.override { inherit emacs; });
 
+    notmuch-addrlookup = callPackage ../applications/networking/mailreaders/notmuch-addrlookup { };
+
     ocamlMode = callPackage ../applications/editors/emacs-modes/ocaml { };
 
     offlineimap = callPackage ../applications/editors/emacs-modes/offlineimap {};


### PR DESCRIPTION
adds a small c program that will do address lookups based on your notmuch db.  its used by emacs mutt and other programs to do completion
