### PR TITLE
bundlerEnv: add wrapper

### DIFF
--- a/doc/languages-frameworks/ruby.xml
+++ b/doc/languages-frameworks/ruby.xml
@@ -42,5 +42,37 @@ and scalable.";
 <para>Please check in the <filename>Gemfile</filename>, <filename>Gemfile.lock</filename> and the <filename>gemset.nix</filename> so future updates can be run easily.
 </para>
 
+<para>Resulting derivations also have two helpful items, <literal>env</literal> and <literal>wrapper</literal>. The first one allows one to quickly drop into
+<command>nix-shell</command> with the specified environment present. E.g. <command>nix-shell -A sensu.env</command> would give you an environment with Ruby preset
+so it has all the libraries necessary for <literal>sensu</literal> in its paths. The second one can be used to make derivations from custom Ruby scripts which have
+<filename>Gemfile</filename>s with their dependencies specified. It is a derivation with <command>ruby</command> wrapped so it can find all the needed dependencies.
+For example, to make a derivation <literal>my-script</literal> for a <filename>my-script.rb</filename> (which should be placed in <filename>bin</filename>) you should
+run <command>bundix</command> as specified above and then use <literal>bundlerEnv</literal> lile this:</para>
+
+<programlisting>
+<![CDATA[let env = bundlerEnv {
+  name = "my-script-env";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+};
+
+in stdenv.mkDerivation {
+  name = "my-script";
+
+  buildInputs = [ env.wrapper ];
+
+  script = ./my-script.rb;
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    install -D -m755 $script $out/bin/my-script
+    patchShebangs $out/bin/my-script
+  '';
+}]]>
+</programlisting>
+
 </section>
 

--- a/pkgs/development/interpreters/ruby/bundler-env/default.nix
+++ b/pkgs/development/interpreters/ruby/bundler-env/default.nix
@@ -65,8 +65,24 @@ let
         "${bundler}/${ruby.gemPath}" \
         ${shellEscape (toString envPaths)}
     '' + lib.optionalString (postBuild != null) postBuild;
-    passthru = {
+    passthru = rec {
       inherit ruby bundler meta gems;
+
+      wrapper = stdenv.mkDerivation {
+        name = "wrapper-${name}";
+        nativeBuildInputs = [ makeWrapper ];
+        buildCommand = ''
+          mkdir -p $out/bin
+          for i in ${ruby}/bin/*; do
+            makeWrapper "$i" $out/bin/$(basename "$i") \
+              --set BUNDLE_GEMFILE ${confFiles}/Gemfile \
+              --set BUNDLE_PATH ${bundlerEnv}/${ruby.gemPath} \
+              --set GEM_HOME ${bundlerEnv}/${ruby.gemPath} \
+              --set GEM_PATH ${bundlerEnv}/${ruby.gemPath}
+          done
+        '';
+      };
+
       env = let
         irbrc = builtins.toFile "irbrc" ''
           if !(ENV["OLD_IRBRC"].nil? || ENV["OLD_IRBRC"].empty?)
@@ -77,12 +93,8 @@ let
         '';
         in stdenv.mkDerivation {
           name = "interactive-${name}-environment";
-          nativeBuildInputs = [ ruby bundlerEnv ];
+          nativeBuildInputs = [ wrapper bundlerEnv ];
           shellHook = ''
-            export BUNDLE_GEMFILE=${confFiles}/Gemfile
-            export BUNDLE_PATH=${bundlerEnv}/${ruby.gemPath}
-            export GEM_HOME=${bundlerEnv}/${ruby.gemPath}
-            export GEM_PATH=${bundlerEnv}/${ruby.gemPath}
             export OLD_IRBRC="$IRBRC"
             export IRBRC=${irbrc}
           '';


### PR DESCRIPTION
This adds a `.wrapper` attribute to the `bundlerEnv` derivation. Its main purpose is to enable easy packaging of simple Ruby scripts with Gemfiles. For example:

```
let env = bundlerEnv {
  name = "my-script-env";

  inherit ruby;
  gemfile = ./Gemfile;
  lockfile = ./Gemfile.lock;
  gemset = ./gemset.nix;
};

in stdenv.mkDerivation {
  name = "my-script";

  buildInputs = [ env.wrapper ];

  script = ./my-script.rb;

  buildCommand = ''
    mkdir -p $out/bin
    install -D -m755 $script $out/bin/my-script
    patchShebangs $out/bin/my-script
  '';
}
```

cc @cstrahan 
