### PR TITLE
DSPAM spam filter and new NixOS module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -243,6 +243,7 @@
       ejabberd = 219;
       postsrsd = 220;
       opendkim = 221;
+      dspam = 222;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -463,6 +464,7 @@
       ejabberd = 219;
       postsrsd = 220;
       opendkim = 221;
+      dspam = 222;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -183,6 +183,7 @@
   ./services/logging/syslogd.nix
   ./services/logging/syslog-ng.nix
   ./services/mail/dovecot.nix
+  ./services/mail/dspam.nix
   ./services/mail/exim.nix
   ./services/mail/freepops.nix
   ./services/mail/mail.nix

--- a/nixos/modules/services/mail/dspam.nix
+++ b/nixos/modules/services/mail/dspam.nix
@@ -1,0 +1,147 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.dspam;
+
+  dspam = pkgs.dspam;
+
+  defaultSock = "/run/dspam/dspam.sock";
+
+  cfgfile = pkgs.writeText "dspam.conf" ''
+    Home /var/lib/dspam
+    StorageDriver ${dspam}/lib/dspam/lib${cfg.storageDriver}_drv.so
+
+    Trust root
+    Trust ${cfg.user}
+    SystemLog on
+    UserLog on
+
+    ${optionalString (cfg.domainSocket != null) ''ServerDomainSocketPath "${cfg.domainSocket}"''}
+
+    ${cfg.extraConfig}
+  '';
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.dspam = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the dspam spam filter.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "dspam";
+        description = "User for the dspam daemon.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "dspam";
+        description = "Group for the dspam daemon.";
+      };
+
+      storageDriver = mkOption {
+        type = types.str;
+        default = "hash";
+        description =  "Storage driver backend to use for dspam.";
+      };
+
+      domainSocket = mkOption {
+        type = types.nullOr types.path;
+        default = defaultSock;
+        description = "Path to local domain socket which is used for communication with the daemon. Set to null to disable UNIX socket.";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Additional dspam configuration.";
+      };
+
+      maintenanceInterval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "If set, maintenance script will be run at specified (in systemd.timer format) interval";
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      users.extraUsers = optionalAttrs (cfg.user == "dspam") (singleton
+        { name = "dspam";
+          group = cfg.group;
+          uid = config.ids.uids.dspam;
+        });
+
+      users.extraGroups = optionalAttrs (cfg.group == "dspam") (singleton
+        { name = "dspam";
+          gid = config.ids.gids.dspam;
+        });
+
+      environment.systemPackages = [ dspam ];
+
+      environment.etc."dspam/dspam.conf".source = cfgfile;
+
+      systemd.services.dspam = {
+        description = "dspam spam filtering daemon";
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ cfgfile ];
+
+        serviceConfig = {
+          ExecStart = "${dspam}/bin/dspam --daemon --nofork";
+          User = cfg.user;
+          Group = cfg.group;
+          RuntimeDirectory = optional (cfg.domainSocket == defaultSock) "dspam";
+          PermissionsStartOnly = true;
+        };
+
+        preStart = ''
+          mkdir -m750 -p /var/lib/dspam
+          chown -R "${cfg.user}:${cfg.group}" /var/lib/dspam
+
+          mkdir -m750 -p /var/log/dspam
+          chown -R "${cfg.user}:${cfg.group}" /var/log/dspam
+        '';
+      };
+    }
+
+    (mkIf (cfg.maintenanceInterval != null) {
+      systemd.timers.dspam-maintenance = {
+        description = "Timer for dspam maintenance script";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.maintenanceInterval;
+          Unit = "dspam-maintenance.service";
+        };
+      };
+
+      systemd.services.dspam-maintenance = {
+        description = "dspam maintenance script";
+        restartTriggers = [ cfgfile ];
+
+        serviceConfig = {
+          ExecStart = "${dspam}/bin/dspam_maintenance";
+          Type = "oneshot";
+          User = cfg.user;
+          Group = cfg.group;
+        };
+      };
+    })
+  ]);
+}

--- a/pkgs/servers/mail/dspam/default.nix
+++ b/pkgs/servers/mail/dspam/default.nix
@@ -1,0 +1,106 @@
+{ stdenv, lib, fetchurl, makeWrapper
+, gawk, gnused, gnugrep, coreutils
+, perl, NetSMTP
+, withMySQL ? false, zlib, libmysql
+, withPgSQL ? false, postgresql
+, withSQLite ? false, sqlite
+, withDB ? false, db
+}:
+
+let
+  drivers = lib.concatStringsSep ","
+            ([ "hash_drv" ]
+             ++ lib.optional withMySQL "mysql_drv"
+             ++ lib.optional withPgSQL "pgsql_drv"
+             ++ lib.optional withSQLite "sqlite3_drv"
+             ++ lib.optional withDB "libdb4_drv"
+            );
+  maintenancePath = lib.makeSearchPath "bin" [ gawk gnused gnugrep coreutils ];
+
+in stdenv.mkDerivation rec {
+  name = "dspam-3.10.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dspam/dspam/${name}/${name}.tar.gz";
+    sha256 = "1acklnxn1wvc7abn31l3qdj8q6k13s51k5gv86vka7q20jb5cxmf";
+  };
+
+  buildInputs = [ perl ]
+                ++ lib.optionals withMySQL [ zlib libmysql ]
+                ++ lib.optional withPgSQL postgresql
+                ++ lib.optional withSQLite sqlite
+                ++ lib.optional withDB db;
+  nativeBuildInputs = [ makeWrapper ];
+
+  configureFlags = [
+    "--with-storage-driver=${drivers}"
+    "--sysconfdir=/etc/dspam"
+    "--localstatedir=/var"
+    "--with-dspam-home=/var/lib/dspam"
+    "--with-logdir=/var/log/dspam"
+    "--with-logfile=/var/log/dspam/dspam.log"
+
+    "--enable-daemon"
+    "--enable-clamav"
+    "--enable-syslog"
+    "--enable-large-scale"
+    "--enable-virtual-users"
+    "--enable-split-configuration"
+    "--enable-preferences-extension"
+    "--enable-long-usernames"
+    "--enable-external-lookup"
+  ] ++ lib.optional withMySQL "--with-mysql-includes=${libmysql}/include/mysql";
+
+  # Lots of things are hardwired to paths like sysconfdir. That's why we install with both "prefix" and "DESTDIR"
+  # and fix directory structure manually after that.
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    cp -r $out/$out/* $out
+    rm -rf $out/$(echo "$out" | cut -d "/" -f2)
+    rm -rf $out/var
+
+    wrapProgram $out/bin/dspam_notify \
+      --set PERL5LIB "${lib.makePerlPath [ NetSMTP ]}"
+
+    # Install SQL scripts
+    mkdir -p $out/share/dspam/sql
+    # MySQL
+    cp src/tools.mysql_drv/mysql_*.sql $out/share/dspam/sql
+    for i in src/tools.mysql_drv/{purge*.sql,virtual*.sql}; do
+      cp "$i" $out/share/dspam/sql/mysql_$(basename "$i")
+    done
+    # PostgreSQL
+    cp src/tools.pgsql_drv/pgsql_*.sql $out/share/dspam/sql
+    for i in src/tools.pgsql_drv/{purge*.sql,virtual*.sql}; do
+      cp "$i" $out/share/dspam/sql/pgsql_$(basename "$i")
+    done
+    # SQLite
+    for i in src/tools.sqlite_drv/purge*.sql; do
+      cp "$i" $out/share/dspam/sql/sqlite_$(basename "$i")
+    done
+
+    # Install maintenance script
+    install -Dm755 contrib/dspam_maintenance/dspam_maintenance.sh $out/bin/dspam_maintenance
+    sed -i \
+      -e '2iexport PATH=${maintenancePath}:$PATH' \
+      -e 's,/usr/[a-z0-9/]*,,g' \
+      -e 's,^DSPAM_CONFIGDIR=.*,DSPAM_CONFIGDIR=/etc/dspam,' \
+      -e "s,^DSPAM_HOMEDIR=.*,DSPAM_HOMEDIR=/var/lib/dspam," \
+      -e "s,^DSPAM_PURGE_SCRIPT_DIR=.*,DSPAM_PURGE_SCRIPT_DIR=$out/share/dspam/sql," \
+      -e "s,^DSPAM_BIN_DIR=.*,DSPAM_BIN_DIR=$out/bin," \
+      -e "s,^MYSQL_BIN_DIR=.*,MYSQL_BIN_DIR=/run/current-system/sw/bin," \
+      -e "s,^PGSQL_BIN_DIR=.*,PGSQL_BIN_DIR=/run/current-system/sw/bin," \
+      -e "s,^SQLITE_BIN_DIR=.*,SQLITE_BIN_DIR=/run/current-system/sw/bin," \
+      -e "s,^SQLITE3_BIN_DIR=.*,SQLITE3_BIN_DIR=/run/current-system/sw/bin," \
+      $out/bin/dspam_maintenance
+  '';
+
+  meta = with lib; {
+    homepage = http://dspam.nuclearelephant.com/;
+    description = "Community Driven Antispam Filter";
+    license = licenses.agpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9189,6 +9189,10 @@ let
 
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot-pigeonhole { };
 
+  dspam = callPackage ../servers/mail/dspam {
+    inherit (perlPackages) NetSMTP;
+  };
+
   etcd = goPackages.etcd.bin // { outputs = [ "bin" ]; };
 
   ejabberd = callPackage ../servers/xmpp/ejabberd { };


### PR DESCRIPTION
This adds DSPAM spam filter, along with a corresponding NixOS module. DSPAM is a spam filter, with both command-line pipe and socket (LMTP) interface. It is very configurable and (anecdotally) has the best error ratios around. It can be plugged into your favorite MTA in a multitude of ways, and resend analyzed messages for further processing via LMTP or other means.
