### PR TITLE
Adopt OpenDKIM and add NixOS module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -242,6 +242,7 @@
       mathics = 218;
       ejabberd = 219;
       postsrsd = 220;
+      opendkim = 221;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -461,6 +462,7 @@
       mathics = 218;
       ejabberd = 219;
       postsrsd = 220;
+      opendkim = 221;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -187,6 +187,7 @@
   ./services/mail/freepops.nix
   ./services/mail/mail.nix
   ./services/mail/mlmmj.nix
+  ./services/mail/opendkim.nix
   ./services/mail/opensmtpd.nix
   ./services/mail/postfix.nix
   ./services/mail/postsrsd.nix

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -1,0 +1,109 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.opendkim;
+
+  defaultSock = "local:/run/opendkim/opendkim.sock";
+
+  args = [ "-f" "-l"
+           "-p" cfg.socket
+           "-d" cfg.domains
+           "-k" cfg.keyFile
+           "-s" cfg.selector
+         ] ++ optionals (cfg.configFile != null) [ "-x" cfg.configFile ];
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.opendkim = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the OpenDKIM sender authentication system.";
+      };
+
+      socket = mkOption {
+        type = types.str;
+        default = defaultSock;
+        description = "Socket which is used for communication with OpenDKIM.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "opendkim";
+        description = "User for the daemon.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "opendkim";
+        description = "Group for the daemon.";
+      };
+
+      domains = mkOption {
+        type = types.str;
+        description = "Local domains set; messages from them are signed, not verified.";
+      };
+
+      keyFile = mkOption {
+        type = types.path;
+        description = "Secret key file used for signing messages.";
+      };
+
+      selector = mkOption {
+        type = types.str;
+        description = "Selector to use when signing.";
+      };
+
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Additional opendkim configuration.";
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    services.opendkim.domains = mkDefault "csl:${config.networking.hostName}";
+
+    users.extraUsers = optionalAttrs (cfg.user == "opendkim") (singleton
+      { name = "opendkim";
+        group = cfg.group;
+        uid = config.ids.uids.opendkim;
+      });
+
+    users.extraGroups = optionalAttrs (cfg.group == "opendkim") (singleton
+      { name = "opendkim";
+        gid = config.ids.gids.opendkim;
+      });
+
+    environment.systemPackages = [ pkgs.opendkim ];
+
+    systemd.services.opendkim = {
+      description = "OpenDKIM signing and verification daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.opendkim}/bin/opendkim ${concatMapStringsSep " " escapeShellArg args}";
+        User = cfg.user;
+        Group = cfg.group;
+        RuntimeDirectory = optional (cfg.socket == defaultSock) "opendkim";
+      };
+    };
+
+  };
+}

--- a/pkgs/development/libraries/opendkim/default.nix
+++ b/pkgs/development/libraries/opendkim/default.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchurl, openssl, libmilter, libbsd}:
+{ stdenv, fetchurl, pkgconfig, libbsd, openssl, libmilter
+, perl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "opendkim-2.10.3";
@@ -7,15 +8,22 @@ stdenv.mkDerivation rec {
     sha256 = "06v8bqhh604sz9rh5bvw278issrwjgc4h1wx2pz9a84lpxbvm823";
   };
 
-  configureFlags="--with-openssl=${openssl} --with-milter=${libmilter}";
+  configureFlags= [ "--with-milter=${libmilter}" ];
 
-  buildInputs = [openssl libmilter libbsd];
-  
-  meta = {
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+
+  buildInputs = [ libbsd openssl libmilter perl ];
+
+  postInstall = ''
+    wrapProgram $out/sbin/opendkim-genkey \
+      --prefix PATH : ${openssl}/bin
+  '';
+
+  meta = with stdenv.lib; {
     description = "C library for producing DKIM-aware applications and an open source milter for providing DKIM service";
-    homepage = http://opendkim.org/;
-    maintainers = [ ];
-    platforms = with stdenv.lib.platforms; all;
+    homepage = http://www.opendkim.org/;
+    maintainers = with maintainers; [ abbradar ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
   };
-
 }


### PR DESCRIPTION
This adopts and fixes `opendkim` package and adds NixOS module which makes use of it. OpenDKIM can be used as a mail signing/verification daemon. It supports standard `milter` protocol, so it's easily pluggable into your MTA of choice.
