### PR TITLE
Rework dovecot module, add and update plugins, default Dovecot to 2.2

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -178,22 +178,22 @@ in
     security.pam.services.dovecot2 = mkIf cfg.enablePAM {};
 
     users.extraUsers = [
-      { name = cfg.user;
-        uid = config.ids.uids.dovecot2;
-        description = "Dovecot user";
-        group = cfg.group;
-      }
       { name = "dovenull";
         uid = config.ids.uids.dovenull2;
         description = "Dovecot user for untrusted logins";
         group = cfg.group;
       }
-    ];
+    ] ++ optional (cfg.user == "dovecot2")
+         { name = "dovecot2";
+           uid = config.ids.uids.dovecot2;
+           description = "Dovecot user";
+           group = cfg.group;
+         };
 
-    users.extraGroups = singleton {
-      name = cfg.group;
-      gid = config.ids.gids.dovecot2;
-    };
+    users.extraGroups = optional (cfg.group == "dovecot2")
+      { name = "dovecot2";
+        gid = config.ids.gids.dovecot2;
+      };
 
     systemd.services.dovecot2 = {
       description = "Dovecot IMAP/POP3 server";

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -55,7 +55,7 @@ let
   ];
 
   modulesDir = pkgs.symlinkJoin "dovecot-modules"
-    (map (module: "${module}/lib/dovecot") cfg.modules);
+    (map (pkg: "${pkg}/lib/dovecot") ([ dovecotPkg ] ++ map (module: module.override { dovecot = dovecotPkg; }) cfg.modules));
 
 in
 {

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -135,7 +135,7 @@ in
       example = literalExample "[ pkgs.dovecot_pigeonhole ]";
       description = ''
         Symlinks the contents of lib/dovecot of every given package into
-        /var/lib/dovecot/modules. This will make the given modules available
+        /etc/dovecot/modules. This will make the given modules available
         if a dovecot package with the module_dir patch applied (like
         pkgs.dovecot22, the default) is being used.
       '';
@@ -200,17 +200,14 @@ in
         gid = config.ids.gids.dovecot2;
       };
 
+    environment.etc."dovecot/modules".source = modulesDir;
+
     systemd.services.dovecot2 = {
       description = "Dovecot IMAP/POP3 server";
 
       after = [ "keys.target" "network.target" ];
       wants = [ "keys.target" ];
       wantedBy = [ "multi-user.target" ];
-
-      preStart = ''
-        rm -f "${stateDir}/modules"
-        ln -s "${modulesDir}" "${stateDir}/modules"
-      '';
 
       serviceConfig = {
         ExecStart = "${dovecotPkg}/sbin/dovecot -F -c ${cfg.configFile}";

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -162,7 +162,7 @@ in
     enablePAM = mkOption {
       type = types.bool;
       default = true;
-      description = "Wether to create a own Dovecot PAM service and configure PAM user logins.";
+      description = "Whether to create a own Dovecot PAM service and configure PAM user logins.";
     };
 
     showPAMFailure = mkOption {
@@ -211,6 +211,7 @@ in
 
       serviceConfig = {
         ExecStart = "${dovecotPkg}/sbin/dovecot -F -c ${cfg.configFile}";
+        ExecReload = "${dovecotPkg}/sbin/doveadm reload -c ${cfg.configFile}";
         Restart = "on-failure";
         RestartSec = "1s";
         StartLimitInterval = "1min";

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -27,6 +27,8 @@ let
 
     ''
       default_internal_user = ${cfg.user}
+      ${optionalString (cfg.mailUser != null) "mail_uid = ${cfg.mailUser}"}
+      ${optionalString (cfg.mailGroup != null) "mail_gid = ${cfg.mailGroup}"}
 
       mail_location = ${cfg.mailLocation}
 
@@ -133,6 +135,18 @@ in
       description = ''
         Location that dovecot will use for mail folders. Dovecot mail_location option.
       '';
+    };
+
+    mailUser = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Default user to store mail for virtual users.";
+    };
+
+    mailGroup = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Default group to store mail for virtual users.";
     };
 
     modules = mkOption {
@@ -245,7 +259,7 @@ in
           fi
            ${pkgs.dovecot_pigeonhole}/bin/sievec '${stateDir}/sieve/${to}'
         '') cfg.sieveScripts)}
-        chown -R '${cfg.user}:${cfg.group}' ${stateDir}/sieve
+        chown -R '${cfg.mailUser}:${cfg.mailGroup}' '${stateDir}/sieve'
       '';
     };
 

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -201,6 +201,7 @@ in
       };
 
     environment.etc."dovecot/modules".source = modulesDir;
+    environment.etc."dovecot/dovecot.conf".source = cfg.configFile;
 
     systemd.services.dovecot2 = {
       description = "Dovecot IMAP/POP3 server";
@@ -208,10 +209,11 @@ in
       after = [ "keys.target" "network.target" ];
       wants = [ "keys.target" ];
       wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ cfg.configFile ];
 
       serviceConfig = {
-        ExecStart = "${dovecotPkg}/sbin/dovecot -F -c ${cfg.configFile}";
-        ExecReload = "${dovecotPkg}/sbin/doveadm reload -c ${cfg.configFile}";
+        ExecStart = "${dovecotPkg}/sbin/dovecot -F";
+        ExecReload = "${dovecotPkg}/sbin/doveadm reload";
         Restart = "on-failure";
         RestartSec = "1s";
         StartLimitInterval = "1min";

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -203,8 +203,6 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        mkdir -p "${baseDir}/login"
-        chown -R ${cfg.user}:${cfg.group} "${baseDir}"
         rm -f "${stateDir}/modules"
         ln -s "${modulesDir}" "${stateDir}/modules"
       '';
@@ -215,6 +213,7 @@ in
         Restart = "on-failure";
         RestartSec = "1s";
         StartLimitInterval = "1min";
+        RuntimeDirectory = [ "dovecot2" ];
       };
     };
 

--- a/pkgs/servers/mail/dovecot/2.2.x-module_dir.patch
+++ b/pkgs/servers/mail/dovecot/2.2.x-module_dir.patch
@@ -6,7 +6,7 @@ diff -ur dovecot-2.2.12-orig/src/auth/main.c dovecot-2.2.12/src/auth/main.c
  	mod_set.filter_callback = auth_module_filter;
  
 -	modules = module_dir_load(AUTH_MODULE_DIR, NULL, &mod_set);
-+	modules = module_dir_load("/var/lib/dovecot/modules/auth", NULL, &mod_set);
++	modules = module_dir_load("/etc/dovecot/modules/auth", NULL, &mod_set);
  	module_dir_init(modules);
  
  	if (!worker)
@@ -15,7 +15,7 @@ diff -ur dovecot-2.2.12-orig/src/auth/main.c dovecot-2.2.12/src/auth/main.c
  	mod_set.ignore_missing = TRUE;
  
 -	modules = module_dir_load_missing(modules, AUTH_MODULE_DIR, names,
-+	modules = module_dir_load_missing(modules, "/var/lib/dovecot/modules/auth", names,
++	modules = module_dir_load_missing(modules, "/etc/dovecot/modules/auth", names,
  					  &mod_set);
  	module_dir_init(modules);
  }
@@ -27,7 +27,7 @@ diff -ur dovecot-2.2.12-orig/src/config/all-settings.c dovecot-2.2.12/src/config
  
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
-+	.mail_plugin_dir = "/var/lib/dovecot/modules",
++	.mail_plugin_dir = "/etc/dovecot/modules",
  
  	.mail_log_prefix = "%s(%u): ",
  
@@ -36,7 +36,7 @@ diff -ur dovecot-2.2.12-orig/src/config/all-settings.c dovecot-2.2.12/src/config
  	.libexec_dir = PKG_LIBEXECDIR,
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
-+	.mail_plugin_dir = "/var/lib/dovecot/modules",
++	.mail_plugin_dir = "/etc/dovecot/modules",
  	.auth_socket_path = "auth-userdb",
  	.doveadm_socket_path = "doveadm-server",
  	.doveadm_worker_count = 0,
@@ -49,7 +49,7 @@ diff -ur dovecot-2.2.12-orig/src/config/config-parser.c dovecot-2.2.12/src/confi
  	memset(&mod_set, 0, sizeof(mod_set));
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
 -	modules = module_dir_load(CONFIG_MODULE_DIR, NULL, &mod_set);
-+	modules = module_dir_load("/var/lib/dovecot/modules/settings", NULL, &mod_set);
++	modules = module_dir_load("/etc/dovecot/modules/settings", NULL, &mod_set);
  	module_dir_init(modules);
  
  	i_array_init(&new_roots, 64);
@@ -61,7 +61,7 @@ diff -ur dovecot-2.2.12-orig/src/dict/main.c dovecot-2.2.12/src/dict/main.c
  	mod_set.require_init_funcs = TRUE;
  
 -	modules = module_dir_load(DICT_MODULE_DIR, NULL, &mod_set);
-+	modules = module_dir_load("/var/lib/dovecot/modules/dict", NULL, &mod_set);
++	modules = module_dir_load("/etc/dovecot/modules/dict", NULL, &mod_set);
  	module_dir_init(modules);
  
  	/* Register only after loading modules. They may contain SQL drivers,
@@ -73,7 +73,7 @@ diff -ur dovecot-2.2.12-orig/src/doveadm/doveadm-settings.c dovecot-2.2.12/src/d
  	.libexec_dir = PKG_LIBEXECDIR,
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
-+	.mail_plugin_dir = "/var/lib/dovecot/modules",
++	.mail_plugin_dir = "/etc/dovecot/modules",
  	.auth_socket_path = "auth-userdb",
  	.doveadm_socket_path = "doveadm-server",
  	.doveadm_worker_count = 0,
@@ -86,7 +86,7 @@ diff -ur dovecot-2.2.12-orig/src/lib-fs/fs-api.c dovecot-2.2.12/src/lib-fs/fs-ap
  	mod_set.ignore_missing = TRUE;
  
 -	fs_modules = module_dir_load_missing(fs_modules, MODULE_DIR,
-+	fs_modules = module_dir_load_missing(fs_modules, "/var/lib/dovecot/modules",
++	fs_modules = module_dir_load_missing(fs_modules, "/etc/dovecot/modules",
  					     module_name, &mod_set);
  	module_dir_init(fs_modules);
  
@@ -99,7 +99,7 @@ diff -ur dovecot-2.2.12-orig/src/lib-ssl-iostream/iostream-ssl.c dovecot-2.2.12/
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
  	mod_set.setting_name = "<built-in lib-ssl-iostream lookup>";
 -	ssl_module = module_dir_load(MODULE_DIR, plugin_name, &mod_set);
-+	ssl_module = module_dir_load("/var/lib/dovecot/modules", plugin_name, &mod_set);
++	ssl_module = module_dir_load("/etc/dovecot/modules", plugin_name, &mod_set);
  
  	ssl_vfuncs = module_get_symbol(ssl_module, "ssl_vfuncs");
  	if (ssl_vfuncs == NULL) {
@@ -112,7 +112,7 @@ diff -ur dovecot-2.2.12-orig/src/lib-storage/mail-storage-settings.c dovecot-2.2
  
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
-+	.mail_plugin_dir = "/var/lib/dovecot/modules",
++	.mail_plugin_dir = "/etc/dovecot/modules",
  
  	.mail_log_prefix = "%s(%u): ",
  

--- a/pkgs/servers/mail/dovecot/2.2.x.nix
+++ b/pkgs/servers/mail/dovecot/2.2.x.nix
@@ -2,14 +2,14 @@
 , inotify-tools, clucene_core_2, sqlite }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.2.19";
+  name = "dovecot-2.2.21";
 
   buildInputs = [ perl openssl bzip2 zlib openldap clucene_core_2 sqlite ]
     ++ stdenv.lib.optionals (stdenv.isLinux) [ systemd pam inotify-tools ];
 
   src = fetchurl {
     url = "http://dovecot.org/releases/2.2/${name}.tar.gz";
-    sha256 = "17sf5aancad4pg1vx1606k99389wg76blpqzmnmxlz4hklzix7km";
+    sha256 = "080bil83gr2dski4gk2bxykg2g497kqm2hn2z4xkbw71b6g17dvs";
   };
 
   preConfigure = ''

--- a/pkgs/servers/mail/dovecot/2.2.x.nix
+++ b/pkgs/servers/mail/dovecot/2.2.x.nix
@@ -1,11 +1,21 @@
-{ stdenv, fetchurl, perl, systemd, openssl, pam, bzip2, zlib, openldap
-, inotify-tools, clucene_core_2, sqlite }:
+{ stdenv, lib, fetchurl, perl, pkgconfig, systemd, openssl
+, bzip2, zlib, inotify-tools, pam, libcap
+, clucene_core_2, icu, openldap
+# Auth modules
+, withMySQL ? false, libmysql
+, withPgSQL ? false, postgresql
+, withSQLite ? true, sqlite
+}:
 
 stdenv.mkDerivation rec {
   name = "dovecot-2.2.21";
 
-  buildInputs = [ perl openssl bzip2 zlib openldap clucene_core_2 sqlite ]
-    ++ stdenv.lib.optionals (stdenv.isLinux) [ systemd pam inotify-tools ];
+  nativeBuildInputs = [ perl pkgconfig ];
+  buildInputs = [ openssl bzip2 zlib clucene_core_2 icu openldap ]
+    ++ lib.optionals (stdenv.isLinux) [ systemd pam libcap inotify-tools ]
+    ++ lib.optional withMySQL libmysql
+    ++ lib.optional withPgSQL postgresql
+    ++ lib.optional withSQLite sqlite;
 
   src = fetchurl {
     url = "http://dovecot.org/releases/2.2/${name}.tar.gz";
@@ -13,11 +23,10 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    substituteInPlace src/config/settings-get.pl --replace \
-      "/usr/bin/env perl" "${perl}/bin/perl"
+    patchShebangs src/config/settings-get.pl
   '';
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libclucene-shared.1.dylib \
         ${clucene_core_2}/lib/libclucene-shared.1.dylib \
         $out/lib/dovecot/lib21_fts_lucene_plugin.so
@@ -28,9 +37,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Make dovecot look for plugins in /etc/dovecot/modules
-    # so we can symlink plugins from several packages there
-    # The symlinking needs to be done in NixOS, as part of the
-    # dovecot service start-up
+    # so we can symlink plugins from several packages there.
+    # The symlinking needs to be done in NixOS.
     ./2.2.x-module_dir.patch
   ];
 
@@ -39,14 +47,16 @@ stdenv.mkDerivation rec {
     # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=626211
     "--localstatedir=/var"
     "--with-ldap"
-    "--with-lucene"
     "--with-ssl=openssl"
-    "--with-sqlite"
     "--with-zlib"
     "--with-bzlib"
-  ] ++ stdenv.lib.optionals (stdenv.isLinux) [
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-  ];
+    "--with-ldap"
+    "--with-lucene"
+    "--with-icu"
+  ] ++ lib.optional (stdenv.isLinux) "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+    ++ lib.optional withMySQL "--with-mysql"
+    ++ lib.optional withPgSQL "--with-pgsql"
+    ++ lib.optional withSQLite "--with-sqlite";
 
   meta = {
     homepage = "http://dovecot.org/";

--- a/pkgs/servers/mail/dovecot/2.2.x.nix
+++ b/pkgs/servers/mail/dovecot/2.2.x.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    # Make dovecot look for plugins in /var/lib/dovecot/modules
+    # Make dovecot look for plugins in /etc/dovecot/modules
     # so we can symlink plugins from several packages there
     # The symlinking needs to be done in NixOS, as part of the
     # dovecot service start-up

--- a/pkgs/servers/mail/dovecot/plugins/antispam/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/antispam/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchhg, autoconf, automake, dovecot, openssl }:
+
+stdenv.mkDerivation {
+  name = "dovecot-antispam-20130429";
+
+  src = fetchhg {
+    url = "http://hg.dovecot.org/dovecot-antispam-plugin/";
+    rev = "5ebc6aae4d7c";
+    sha256 = "181i79c9sf3a80mgmycfq1f77z7fpn3j2s0qiddrj16h3yklf4gv";
+  };
+
+  buildInputs = [ dovecot openssl ];
+  nativeBuildInputs = [ autoconf automake ];
+
+  preConfigure = ''
+    ./autogen.sh
+    # Ugly hack; any ideas?
+    sed "s,^dovecot_moduledir=.*,dovecot_moduledir=$out/lib/dovecot," ${dovecot}/lib/dovecot/dovecot-config > dovecot-config
+  '';
+
+  configureFlags = [
+    "--with-dovecot=."
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://wiki2.dovecot.org/Plugins/Antispam;
+    description = "An antispam plugin for the Dovecot IMAP server";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -1,15 +1,15 @@
-{stdenv, fetchurl, dovecot22, openssl}:
+{ stdenv, fetchurl, dovecot, openssl }:
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.4.3";
+  version = "0.4.10";
 
   src = fetchurl {
     url = "http://pigeonhole.dovecot.org/releases/2.2/dovecot-2.2-pigeonhole-${version}.tar.gz";
-    sha256 = "0mypnkc980s3kd1bmy4f93dliwg6n8jfsac8r51jrpvv0ymz94nn";
-  };  
+    sha256 = "0vvjj1yjr189rn8f41z5rj8gfvk24a8j33q6spb6bd6k1wbfgpz9";
+  };
 
-  buildInputs = [ dovecot22 openssl ];
+  buildInputs = [ dovecot openssl ];
 
   preConfigure = ''
     substituteInPlace src/managesieve/managesieve-settings.c --replace \
@@ -18,18 +18,21 @@ stdenv.mkDerivation rec {
     substituteInPlace src/managesieve-login/managesieve-login-settings.c --replace \
       ".executable = \"managesieve-login\"" \
       ".executable = \"$out/libexec/dovecot/managesieve-login\""
-  ''; 
+  '';
 
-  configureFlags = [ 
-    "--with-dovecot=${dovecot22}/lib/dovecot"
+  configureFlags = [
+    "--with-dovecot=${dovecot}/lib/dovecot"
     "--without-dovecot-install-dirs"
     "--with-moduledir=$(out)/lib/dovecot"
-  ];  
+  ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = http://pigeonhole.dovecot.org/;
     description = "A sieve plugin for the Dovecot IMAP server";
     license = licenses.lgpl21;
     maintainers = [ maintainers.rickynils ];
-  };  
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9234,7 +9234,9 @@ let
 
   dovecot22 = callPackage ../servers/mail/dovecot/2.2.x.nix { };
 
-  dovecot_pigeonhole = callPackage ../servers/mail/dovecot-pigeonhole { };
+  dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole {
+    dovecot = dovecot22;
+  };
 
   dspam = callPackage ../servers/mail/dspam {
     inherit (perlPackages) NetSMTP;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9228,7 +9228,7 @@ let
 
   dnschain = callPackage ../servers/dnschain { };
 
-  dovecot = dovecot21;
+  dovecot = dovecot22;
 
   dovecot21 = callPackage ../servers/mail/dovecot { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9238,6 +9238,8 @@ let
     dovecot = dovecot22;
   };
 
+  dovecot_antispam = callPackage ../servers/mail/dovecot/plugins/antispam { };
+
   dspam = callPackage ../servers/mail/dspam {
     inherit (perlPackages) NetSMTP;
   };


### PR DESCRIPTION
This makes quite a few changes into our Dovecot packages and modules:
- `dovecot` now defaults to `dovecot22`. `dovecot_pigeonhole` doesn't even build with the old version, and we support it better via our patches.
- `dovecot_pigeonhole` is updated, and `dovecot_antispam` is added as new Dovecot plugins.
- Our modules directory patch now changes modules dir into `/etc/dovecot/modules`. This gives us cleaner NixOS module (`environment.etc` instead of `preStart` script).
- `ExecReload` command is added.
- Dovecot users and groups now added only if their names haven't changed (as per our convention in other modules).
- We now create `/run/dovecot2` via systemd.
- New `protocols` option is introduced. My own use case is `sieve` protocol, I imagine it can be used for other protocols added by plugins.
- `sieveScripts` option is added, which allows us to specify system-wide Sieve scripts which will be compiled automatically.
- `mailUser` and `mailGroup` options added -- primarily because `pigeonhole` uses daemon with `mail_uid` user to access system-wide sieve scripts (and to store cache files).
