### PR TITLE
Add postsrsd daemon and NixOS module for it

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -241,6 +241,7 @@
       nm-openvpn = 217;
       mathics = 218;
       ejabberd = 219;
+      postsrsd = 220;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -459,6 +460,7 @@
       nm-openvpn = 217;
       mathics = 218;
       ejabberd = 219;
+      postsrsd = 220;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -189,6 +189,7 @@
   ./services/mail/mlmmj.nix
   ./services/mail/opensmtpd.nix
   ./services/mail/postfix.nix
+  ./services/mail/postsrsd.nix
   ./services/mail/spamassassin.nix
   ./services/misc/apache-kafka.nix
   ./services/misc/autofs.nix

--- a/nixos/modules/services/mail/postsrsd.nix
+++ b/nixos/modules/services/mail/postsrsd.nix
@@ -1,0 +1,107 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.postsrsd;
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.postsrsd = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the postsrsd SRS server for Postfix.";
+      };
+
+      domain = mkOption {
+        type = types.str;
+        description = "Domain name for rewrite";
+      };
+
+      secretsFile = mkOption {
+        type = types.path;
+        default = "/var/lib/postsrsd/postsrsd.secret";
+        description = "Secret keys used for signing and verification";
+      };
+
+      forwardPort = mkOption {
+        type = types.int;
+        default = 10001;
+        description = "Port for the forward SRS lookup";
+      };
+
+      reversePort = mkOption {
+        type = types.int;
+        default = 10002;
+        description = "Port for the reverse SRS lookup";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "postsrsd";
+        description = "User for the daemon";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "postsrsd";
+        description = "Group for the daemon";
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    services.postsrsd.domain = mkDefault config.networking.hostName;
+
+    users.extraUsers = optionalAttrs (cfg.user == "postsrsd") (singleton
+      { name = "postsrsd";
+        group = cfg.group;
+        uid = config.ids.uids.postsrsd;
+      });
+
+    users.extraGroups = optionalAttrs (cfg.group == "postsrsd") (singleton
+      { name = "postsrsd";
+        gid = config.ids.gids.postsrsd;
+      });
+
+    systemd.services.postsrsd = {
+      description = "PostSRSd SRS rewriting server";
+      after = [ "network.target" ];
+      before = [ "postfix.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ pkgs.coreutils ];
+
+      serviceConfig = {
+        ExecStart = ''${pkgs.postsrsd}/sbin/postsrsd "-s${cfg.secretsFile}" "-d${cfg.domain}" -f${toString cfg.forwardPort} -r${toString cfg.reversePort}'';
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+      };
+
+      preStart = ''
+        if [ ! -e "${cfg.secretsFile}" ]; then
+          echo "WARNING: secrets file not found, autogenerating!"
+          mkdir -p -m750 "$(dirname "${cfg.secretsFile}")"
+          dd if=/dev/random bs=18 count=1 | base64 > "${cfg.secretsFile}"
+          chmod 600 "${cfg.secretsFile}"
+        fi
+        chown "${cfg.user}:${cfg.group}" "${cfg.secretsFile}"
+      '';
+    };
+
+  };
+}

--- a/pkgs/servers/mail/postsrsd/default.nix
+++ b/pkgs/servers/mail/postsrsd/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, help2man }:
+
+let
+  version = "1.3";
+
+in stdenv.mkDerivation {
+  name = "postsrsd-${version}";
+
+  src = fetchFromGitHub {
+    owner = "roehling";
+    repo = "postsrsd";
+    rev = version;
+    sha256 = "1z89qh2bnypgb4i2vs0zdzzpqlf445jixwa1acd955hryww50npv";
+  };
+
+  cmakeFlags = [ "-DGENERATE_SRS_SECRET=OFF" "-DINIT_FLAVOR=systemd" ];
+
+  preConfigure = ''
+    sed -i "s,\"/etc\",\"$out/etc\",g" CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [ cmake help2man ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/roehling/postsrsd";
+    description = "Postfix Sender Rewriting Scheme daemon";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9338,6 +9338,8 @@ let
   postfix30 = callPackage ../servers/mail/postfix/3.0.nix { };
   postfix = postfix30;
 
+  postsrsd = callPackage ../servers/mail/postsrsd { };
+
   pshs = callPackage ../servers/http/pshs { };
 
   libpulseaudio = callPackage ../servers/pulseaudio { libOnly = true; };


### PR DESCRIPTION
postsrsd is an SRS rewriting daemon for `postfix`. It can be plugged into `postfix` easily just as per documentation:

```
sender_canonical_maps = tcp:127.0.0.1:10001
sender_canonical_classes = envelope_sender
recipient_canonical_maps = tcp:127.0.0.1:10002
recipient_canonical_classes= envelope_recipient,header_recipient
```
