### PR TITLE
Add communi IRC client

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -1,0 +1,30 @@
+{ fetchgit, libcommuni, qt5, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  name = "communi-${version}";
+  version = "2016-01-03";
+
+  src = fetchgit {
+    url = "https://github.com/communi/communi-desktop.git";
+    rev = "ad1b9a30ed6c51940c0d2714b126a32b5d68c876";
+    sha256 = "0gk6gck09zb44qfsal7bs4ln2vl9s9x3vfxh7jvfc7mmf7l3sspd";
+  };
+
+  buildInputs = [ libcommuni qt5.qtbase ];
+
+  enableParallelBuild = true;
+
+  configurePhase = ''
+    export QMAKEFEATURES=${libcommuni}/features
+    qmake -r COMMUNI_INSTALL_PREFIX=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple and elegant cross-platform IRC client";
+    homepage = https://github.com/communi/communi-desktop;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hrdinka ];
+  };
+}

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -1,0 +1,30 @@
+{ fetchgit, qt5, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  name = "libcommuni-${version}";
+  version = "2016-01-02";
+
+  src = fetchgit {
+    url = "https://github.com/communi/libcommuni.git";
+    rev = "779b0c774428669235d44d2db8e762558e2f4b79";
+    sha256 = "15sb7vinaaz1v5nclxpnp5p9a0kmfmlgiqibkipnyydizclidpfx";
+  };
+
+  buildInputs = [ qt5.qtbase ];
+
+  enableParallelBuild = true;
+
+  configurePhase = ''
+    sed -i -e 's|/bin/pwd|pwd|g' configure
+    ./configure -config release -prefix $out -qmake ${qt5.qtbase}/bin/qmake
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform IRC framework written with Qt";
+    homepage = https://communi.github.io;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hrdinka ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11288,6 +11288,8 @@ let
     pulseaudioSupport = config.pulseaudio or false;
   };
 
+  communi = callPackage ../applications/networking/irc/communi { };
+
   CompBus = callPackage ../applications/audio/CompBus { };
 
   compiz = callPackage ../applications/window-managers/compiz {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7040,6 +7040,8 @@ let
 
   libcm = callPackage ../development/libraries/libcm { };
 
+  libcommuni = callPackage ../development/libraries/libcommuni { };
+
   inherit (gnome3) libcroco;
 
   libcangjie = callPackage ../development/libraries/libcangjie { };


### PR DESCRIPTION
This adds libcommuni as well as the communi desktop IRC client. The configure script might look a bit curious but that is how it is actually supposed to be done:

https://github.com/communi/communi-desktop/wiki/How-to-build-communi-in-its-own-directory

I have decided to use the latest git commits as versions instead of stable releases. The official guide does only show how to install communi from its master branch. I guess that is because there isn't much release management going on—there have only been 4 release since 2008.
