### PR TITLE
pythonPackages.tqdm: disable tests due to transient failures

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19383,14 +19383,11 @@ in modules // {
     buildInputs = with self; [ nose coverage pkgs.glibcLocales flake8 ];
     propagatedBuildInputs = with self; [ matplotlib pandas ];
 
-    # Performance test fails
-    prePatch = ''
-      rm tqdm/tests/tests_perf.py
-    '';
-
     preBuild = ''
       export LC_ALL="en_US.UTF-8"
     '';
+
+    doCheck = false; # Many transient failures in performance tests and due to use of sleep
 
     meta = {
       description = "A Fast, Extensible Progress Meter";


### PR DESCRIPTION
Many transient failures in performance tests and due to use of sleep.
