### PR TITLE
gnome-terminal: enable GNOME Shell search provider

### DIFF
--- a/pkgs/desktops/gnome-3/3.16/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/gnome-terminal/default.nix
@@ -19,8 +19,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool gnome_doc_utils which libuuid libxml2 desktop_file_utils ];
 
+  # Silly ./configure, it looks for dbus file from gnome-shell in the
+  # installation tree of the package it is configuring.
+  preConfigure = ''
+    mkdir -p "$out/share/dbus-1/interfaces"
+    cp "${gnome3.gnome_shell}/share/dbus-1/interfaces/org.gnome.ShellSearchProvider2.xml" "$out/share/dbus-1/interfaces"
+  '';
+
   # FIXME: enable for gnome3
-  configureFlags = [ "--disable-search-provider" "--disable-migration" ];
+  configureFlags = [ "--disable-migration" ];
 
   preFixup = ''
     for f in "$out/libexec/gnome-terminal-server"; do


### PR DESCRIPTION
Silly ./configure, it looks for dbus file from gnome-shell in the
installation tree of the package it is configuring. Fix by copying the
needed file from gnome-shell before ./configure is run.

This change makes gnome-shell a build time dependency (not runtime).
