### PR TITLE
Add ChromiumOS kernels

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -337,6 +337,7 @@
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zef = "Zef Hemel <zef@zef.me>";
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";
+  zohl = "Al Zohali <zohl@fmap.me>";
   zoomulator = "Kim Simmons <zoomulator@gmail.com>";
   Gonzih = "Max Gonzih <gonzih@gmail.com>";
 }

--- a/pkgs/os-specific/linux/firmware/rt5677/default.nix
+++ b/pkgs/os-specific/linux/firmware/rt5677/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "rt5677-firmware";
+
+  src = fetchgit {
+    url = "https://github.com/raphael/linux-samus";
+    rev = "995de6c2093797905fbcd79f1a3625dd3f50be37";
+    sha256 = "6e59f7ce24122eb9474e7863e63729de632e4c7afcb8f08534cb2102007f8381";
+  };
+
+
+  installPhase = ''
+    mkdir -p $out/lib/firmware
+    cp ./firmware/rt5677_elf_vad $out/lib/firmware
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for Realtek rt5677 device";
+    license = licenses.unfreeRedistributableFirmware;
+    maintainers = [ maintainers.zohl ];
+  };
+}

--- a/pkgs/os-specific/linux/kernel/chromiumos-patches/fix-double-Kconfig-entry-3.14.patch
+++ b/pkgs/os-specific/linux/kernel/chromiumos-patches/fix-double-Kconfig-entry-3.14.patch
@@ -1,0 +1,47 @@
+From de6299c1627d80ea6742a0bef15bdb6981e5cfd7 Mon Sep 17 00:00:00 2001
+From: Nikolay Amiantov <ab@fmap.me>
+Date: Fri, 25 Dec 2015 17:11:40 +0300
+Subject: [PATCH 1/2] drivers_base: fix double Kconfig entry
+
+---
+ drivers/base/Kconfig | 24 ------------------------
+ 1 file changed, 24 deletions(-)
+
+diff --git a/drivers/base/Kconfig b/drivers/base/Kconfig
+index 946ced4..fc3405e1 100644
+--- a/drivers/base/Kconfig
++++ b/drivers/base/Kconfig
+@@ -163,30 +163,6 @@ config FW_LOADER_USER_HELPER
+ 	  no longer required unless you have a special firmware file that
+ 	  resides in a non-standard path.
+ 
+-config WANT_DEV_COREDUMP
+-	bool
+-	help
+-	  Drivers should "select" this option if they desire to use the
+-	  device coredump mechanism.
+-
+-config ALLOW_DEV_COREDUMP
+-	bool "Allow device coredump" if EXPERT
+-	default y
+-	help
+-	  This option controls if the device coredump mechanism is available or
+-	  not; if disabled, the mechanism will be omitted even if drivers that
+-	  can use it are enabled.
+-	  Say 'N' for more sensitive systems or systems that don't want
+-	  to ever access the information to not have the code, nor keep any
+-	  data.
+-
+-	  If unsure, say Y.
+-
+-config DEV_COREDUMP
+-	bool
+-	default y if WANT_DEV_COREDUMP
+-	depends on ALLOW_DEV_COREDUMP
+-
+ config DEBUG_DRIVER
+ 	bool "Driver Core verbose debug messages"
+ 	depends on DEBUG_KERNEL
+-- 
+2.6.3
+

--- a/pkgs/os-specific/linux/kernel/chromiumos-patches/fix-double-Kconfig-entry-3.18.patch
+++ b/pkgs/os-specific/linux/kernel/chromiumos-patches/fix-double-Kconfig-entry-3.18.patch
@@ -1,0 +1,48 @@
+diff --git a/drivers/base/Kconfig b/drivers/base/Kconfig
+index 48398b4..0e37f7d 100644
+--- a/drivers/base/Kconfig
++++ b/drivers/base/Kconfig
+@@ -198,30 +198,6 @@ config DEV_COREDUMP
+ 	default y if WANT_DEV_COREDUMP
+ 	depends on ALLOW_DEV_COREDUMP
+ 
+-config WANT_DEV_COREDUMP
+-	bool
+-	help
+-	  Drivers should "select" this option if they desire to use the
+-	  device coredump mechanism.
+-
+-config ALLOW_DEV_COREDUMP
+-	bool "Allow device coredump" if EXPERT
+-	default y
+-	help
+-	  This option controls if the device coredump mechanism is available or
+-	  not; if disabled, the mechanism will be omitted even if drivers that
+-	  can use it are enabled.
+-	  Say 'N' for more sensitive systems or systems that don't want
+-	  to ever access the information to not have the code, nor keep any
+-	  data.
+-
+-	  If unsure, say Y.
+-
+-config DEV_COREDUMP
+-	bool
+-	default y if WANT_DEV_COREDUMP
+-	depends on ALLOW_DEV_COREDUMP
+-
+ config DEBUG_DRIVER
+ 	bool "Driver Core verbose debug messages"
+ 	depends on DEBUG_KERNEL
+diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
+index 58154a9..53a0d73 100644
+--- a/drivers/mfd/Kconfig
++++ b/drivers/mfd/Kconfig
+@@ -81,7 +81,7 @@ config MFD_AXP20X
+ 
+ config MFD_CROS_EC
+ 	tristate "Support ChromeOS Embedded Controller"
+-	depends on MFD_CORE
++	select MFD_CORE
+ 	help
+ 	  If you say Y here you get support for the ChromeOS Embedded
+ 	  Controller (EC) providing keyboard, battery and power services.

--- a/pkgs/os-specific/linux/kernel/chromiumos-patches/mfd-fix-dependency.patch
+++ b/pkgs/os-specific/linux/kernel/chromiumos-patches/mfd-fix-dependency.patch
@@ -1,0 +1,25 @@
+From 65c5b603489d230b1f1775b01ba1529843cfeba6 Mon Sep 17 00:00:00 2001
+From: Nikolay Amiantov <ab@fmap.me>
+Date: Fri, 25 Dec 2015 17:11:56 +0300
+Subject: [PATCH 2/2] mfd: fix dependency for MFD_CROS_EC
+
+---
+ drivers/mfd/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
+index f425dce..a62a285 100644
+--- a/drivers/mfd/Kconfig
++++ b/drivers/mfd/Kconfig
+@@ -61,7 +61,7 @@ config MFD_AAT2870_CORE
+ 
+ config MFD_CROS_EC
+ 	tristate "Support ChromeOS Embedded Controller"
+-	depends on MFD_CORE
++	select MFD_CORE
+ 	help
+ 	  If you say Y here you get support for the ChromeOS Embedded
+ 	  Controller (EC) providing keyboard, battery and power services.
+-- 
+2.6.3
+

--- a/pkgs/os-specific/linux/kernel/chromiumos-patches/no-link-restrictions.patch
+++ b/pkgs/os-specific/linux/kernel/chromiumos-patches/no-link-restrictions.patch
@@ -1,0 +1,15 @@
+diff --git a/fs/namei.c b/fs/namei.c
+index d999a86..eb6e530 100644
+--- a/fs/namei.c
++++ b/fs/namei.c
+@@ -703,8 +703,8 @@ static inline void put_link(struct nameidata *nd, struct path *link, void *cooki
+ 	path_put(link);
+ }
+ 
+-int sysctl_protected_symlinks __read_mostly = 1;
+-int sysctl_protected_hardlinks __read_mostly = 1;
++int sysctl_protected_symlinks __read_mostly = 0;
++int sysctl_protected_hardlinks __read_mostly = 0;
+ 
+ /**
+  * may_follow_link - Check symlink following for unsafe situations

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -147,7 +147,7 @@ with stdenv.lib;
 
   # Video configuration.
   # Enable KMS for devices whose X.org driver supports it.
-  ${optionalString (versionOlder version "4.3") ''
+  ${optionalString (versionOlder version "4.3" && !(features.chromiumos or false)) ''
     DRM_I915_KMS y
   ''}
   # Allow specifying custom EDID on the kernel command line
@@ -502,6 +502,67 @@ with stdenv.lib;
 
   # Disable the firmware helper fallback, udev doesn't implement it any more
   FW_LOADER_USER_HELPER_FALLBACK? n
+
+  # ChromiumOS support
+  ${optionalString (features.chromiumos or false) ''
+    CHROME_PLATFORMS y
+    VGA_SWITCHEROO n
+    MMC_SDHCI_PXAV2 n
+    NET_IPVTI n
+    IPV6_VTI n
+    REGULATOR_FIXED_VOLTAGE n
+    TPS6105X n
+    CPU_FREQ_STAT y
+    IPV6 y
+    MFD_CROS_EC y
+    MFD_CROS_EC_LPC y
+    MFD_CROS_EC_DEV y
+    CHARGER_CROS_USB_PD y
+    I2C y
+    MEDIA_SUBDRV_AUTOSELECT n
+    VIDEO_IR_I2C n
+    BLK_DEV_DM y
+    ANDROID_PARANOID_NETWORK n
+    DM_VERITY n
+    DRM_VGEM n
+    CPU_FREQ_GOV_INTERACTIVE n
+    INPUT_KEYRESET n
+    DM_BOOTCACHE n
+    UID_CPUTIME n
+
+    ${optionalString (versionAtLeast version "3.18") ''
+      CPUFREQ_DT n
+      EXTCON_CROS_EC n
+      DRM_POWERVR_ROGUE n
+      CHROMEOS_OF_FIRMWARE y
+      TEST_RHASHTABLE n
+      BCMDHD n
+      TRUSTY n
+    ''}
+
+    ${optionalString (versionOlder version "3.18") ''
+      MALI_MIDGARD n
+      DVB_USB_DIB0700 n
+      DVB_USB_DW2102 n
+      DVB_USB_PCTV452E n
+      DVB_USB_TTUSB2 n
+      DVB_USB_AF9015 n
+      DVB_USB_AF9035 n
+      DVB_USB_ANYSEE n
+      DVB_USB_AZ6007 n
+      DVB_USB_IT913X n
+      DVB_USB_LME2510 n
+      DVB_USB_RTL28XXU n
+      USB_S2255 n
+      VIDEO_EM28XX n
+      VIDEO_TM6000 n
+      USB_DWC2 n
+      USB_GSPCA n
+      SPEAKUP n
+      XO15_EBOOK n
+      USB_GADGET n
+    ''}
+  ''}
 
   ${kernelPlatform.kernelExtraConfig or ""}
   ${extraConfig}

--- a/pkgs/os-specific/linux/kernel/genksyms-fix-segfault.patch
+++ b/pkgs/os-specific/linux/kernel/genksyms-fix-segfault.patch
@@ -1,0 +1,19 @@
+diff --git a/scripts/genksyms/genksyms.c b/scripts/genksyms/genksyms.c
+index 88632df..ba6cfa9 100644
+--- a/scripts/genksyms/genksyms.c
++++ b/scripts/genksyms/genksyms.c
+@@ -233,11 +233,11 @@ static struct symbol *__add_symbol(const char *name, enum symbol_type type,
+ 		free_list(last_enum_expr, NULL);
+ 		last_enum_expr = NULL;
+ 		enum_counter = 0;
+-		if (!name)
+-			/* Anonymous enum definition, nothing more to do */
+-			return NULL;
+ 	}
+ 
++	if (!name)
++		return NULL;
++
+ 	h = crc32(name) % HASH_BUCKETS;
+ 	for (sym = symtab[h]; sym; sym = sym->hash_next) {
+ 		if (map_to_ns(sym->type) == map_to_ns(type) &&

--- a/pkgs/os-specific/linux/kernel/linux-chromiumos-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-chromiumos-3.14.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchgit, perl, buildLinux, ncurses, openssh, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "3.14.0";
+  extraMeta.branch = "3.14";
+
+  src = fetchgit {
+    url = "https://chromium.googlesource.com/chromiumos/third_party/kernel";
+    rev = "63a768b40c91c6f3518ea1f20d0cb664ed4e6a57";
+    sha256 = "613527a032699be32c18d3f5d8d4c215d7718279a1c372c9f371d4e6c0b9cc34";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+  features.chromiumos = true;
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-chromiumos-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-chromiumos-3.18.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchgit, perl, buildLinux, ncurses, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "3.18.0";
+  extraMeta.branch = "3.18";
+
+  src = fetchgit {
+    url = "https://chromium.googlesource.com/chromiumos/third_party/kernel";
+    rev = "3179ec7e3f07fcc3ca35817174c5fc6584030ab3";
+    sha256 = "0hfa97fs216x8q20fsmw02kvf6mw6c6zczfjk2bpym6v7zxdzj28";
+  };
+
+  features.iwlwifi = true;
+  features.efiBootStub = true;
+  features.needsCifsUtils = true;
+  features.canDisableNetfilterConntrackHelpers = true;
+  features.netfilterRPFilter = true;
+  features.chromiumos = true;
+  
+  extraMeta.hydraPlatforms = [];
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -103,4 +103,19 @@ rec {
       patch = ./crc-regression.patch;
     };
 
+  genksyms_fix_segfault =
+    { name = "genksyms-fix-segfault";
+      patch = ./genksyms-fix-segfault.patch;
+    };
+
+
+  chromiumos_Kconfig_fix_entries_3_18 =
+    { name = "Kconfig_fix_entries_3_18";
+      patch = ./chromiumos-patches/fix-double-Kconfig-entry-3.18.patch;
+    };
+
+  chromiumos_no_link_restrictions =
+    { name = "chromium-no-link-restrictions";
+      patch = ./chromiumos-patches/no-link-restrictions.patch;
+    };
 }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -109,6 +109,11 @@ rec {
     };
 
 
+  chromiumos_Kconfig_fix_entries_3_14 =
+    { name = "Kconfig_fix_entries_3_14";
+      patch = ./chromiumos-patches/fix-double-Kconfig-entry-3.14.patch;
+    };
+
   chromiumos_Kconfig_fix_entries_3_18 =
     { name = "Kconfig_fix_entries_3_18";
       patch = ./chromiumos-patches/fix-double-Kconfig-entry-3.18.patch;
@@ -117,5 +122,10 @@ rec {
   chromiumos_no_link_restrictions =
     { name = "chromium-no-link-restrictions";
       patch = ./chromiumos-patches/no-link-restrictions.patch;
+    };
+
+  chromiumos_mfd_fix_dependency =
+    { name = "mfd_fix_dependency";
+      patch = ./chromiumos-patches/mfd-fix-dependency.patch;
     };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10456,6 +10456,8 @@ let
 
   rtkit = callPackage ../os-specific/linux/rtkit { };
 
+  rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };
+
   s3ql = callPackage ../tools/backup/s3ql { };
 
   sassc = callPackage ../development/tools/sassc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10057,6 +10057,14 @@ let
       ];
   };
 
+  linux_chromiumos_3_14 = callPackage ../os-specific/linux/kernel/linux-chromiumos-3.14.nix {
+    kernelPatches = [ kernelPatches.chromiumos_Kconfig_fix_entries_3_14
+                      kernelPatches.chromiumos_mfd_fix_dependency
+                      kernelPatches.chromiumos_no_link_restrictions
+                      kernelPatches.genksyms_fix_segfault
+                    ];
+  };
+
   linux_chromiumos_3_18 = callPackage ../os-specific/linux/kernel/linux-chromiumos-3.18.nix {
     kernelPatches = [ kernelPatches.chromiumos_Kconfig_fix_entries_3_18
                       kernelPatches.chromiumos_no_link_restrictions
@@ -10254,6 +10262,7 @@ let
   linuxPackages_grsec_testing_server_xen = grPackage grFlavors.linux_grsec_testing_server_xen;
 
   # ChromiumOS kernels
+  linuxPackages_chromiumos_3_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_chromiumos_3_14 linuxPackages_chromiumos_3_14);
   linuxPackages_chromiumos_3_18 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_chromiumos_3_18 linuxPackages_chromiumos_3_18);
   linuxPackages_chromiumos_latest = recurseIntoAttrs (linuxPackagesFor pkgs.linux_chromiumos_latest linuxPackages_chromiumos_latest);
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10057,6 +10057,15 @@ let
       ];
   };
 
+  linux_chromiumos_3_18 = callPackage ../os-specific/linux/kernel/linux-chromiumos-3.18.nix {
+    kernelPatches = [ kernelPatches.chromiumos_Kconfig_fix_entries_3_18
+                      kernelPatches.chromiumos_no_link_restrictions
+                      kernelPatches.genksyms_fix_segfault
+                    ];
+  };
+
+  linux_chromiumos_latest = linux_chromiumos_3_18;
+
   /* grsec configuration
 
      We build several flavors of 'default' grsec kernels. These are
@@ -10243,6 +10252,10 @@ let
   linuxPackages_grsec_testing_desktop = grPackage grFlavors.linux_grsec_testing_desktop;
   linuxPackages_grsec_testing_server  = grPackage grFlavors.linux_grsec_testing_server;
   linuxPackages_grsec_testing_server_xen = grPackage grFlavors.linux_grsec_testing_server_xen;
+
+  # ChromiumOS kernels
+  linuxPackages_chromiumos_3_18 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_chromiumos_3_18 linuxPackages_chromiumos_3_18);
+  linuxPackages_chromiumos_latest = recurseIntoAttrs (linuxPackagesFor pkgs.linux_chromiumos_latest linuxPackages_chromiumos_latest);
 
   # A function to build a manually-configured kernel
   linuxManualConfig = pkgs.buildLinux;


### PR DESCRIPTION
This set of commits provides ChromiumOS kernels, that have better support for chromebooks hardware than the mainline kernel.
The kernels were tested on chromebook pixel 2015 (samus), so additional efforts may be required in order to make it work on another devices.

The pull request contains:
- kernel 3.14 (full hardware support)
- kernel 3.18 (full hardware support except audio)
- firmware blob for Realtek rt5677 device

To enable sound there are required additional steps that are described in [2].

The kernels are taken from chromiumos project's repository [1], the firmware is taken from Raphael's repository [2].
Many thanks to @abbradar for assistance and sharing knowledge.

[1] https://chromium.googlesource.com/
[2] https://github.com/raphael/linux-samus
