### PR TITLE
ranger: fix, added file as a runtime dependency

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, python, w3m }:
+{ stdenv, fetchurl, buildPythonPackage, python, w3m, file }:
 
 buildPythonPackage rec {
   name = "ranger-1.7.1";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "11nznx2lqv884q9d2if63101prgnjlnan8pcwy550hji2qsn3c7q";
   };
 
-  propagatedBuildInputs = with python.modules; [ curses ];
+  propagatedBuildInputs = [ python.modules.curses file ];
 
   preConfigure = ''
     substituteInPlace ranger/ext/img_display.py \


### PR DESCRIPTION
I added `file` to propagatedBuildInputs:

ranger invokes `file` to check MIME types, so if file is not in $PATH, ranger will fail with `[errno 2]: no such file or directory` when a file with no extension was opened.

I tested this fix and now ranger works out of the box.
