### PR TITLE
gnuplot: Improve startup performance

### DIFF
--- a/pkgs/tools/graphics/gnuplot/set-gdfontpath-from-fontconfig.sh
+++ b/pkgs/tools/graphics/gnuplot/set-gdfontpath-from-fontconfig.sh
@@ -1,4 +1,4 @@
-p=( $(for n in $(fc-list | sed -r -e 's|^([^:]+):.*$|\1|'); do echo $(dirname "$n"); done | sort | uniq) )
+p=( $(fc-list : file | sed "s@/[^/]*: @@" | sort -u) )
 IFS=:
 export GDFONTPATH="${GDFONTPATH}${GDFONTPATH:+:}${p[*]}"
 unset IFS p


### PR DESCRIPTION
Before executing the gnuplot executable the environment variable `GDFONTPATH`
is populated with a list of font directories, which is obtained from `fc-list`.
In that process we iterated over each line and called `dirname` on it, which
introduces a performance hit for loading and executing the external executable
`dirname` every time.

The new version combines formatting options of `fc-list` and `bash` builtin
substring removal in order to avoid any calls to external programs within the
loop.

The author of this patch measured a 21 fold performance improvement:

old version:

```
$ time ./gnuplot_old/bin/gnuplot -e ''
real    0m3.932s
user    0m0.439s
sys     0m0.454s
```

new version:

```
$ time ./gnuplot_new/bin/gnuplot -e ''
real    0m0.184s
user    0m0.166s
sys     0m0.033s
```

The correctness of the value of `GDFONTPATH` was confirmed with the following
command and comparing its output between versions:

```
$ gnuplot -e 'print system("echo $GDFONTPATH")'
```
