### PR TITLE
programs.zsh: allow override of history defaults

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -98,17 +98,17 @@ in
       loginShellInit = cfge.loginShellInit;
 
       interactiveShellInit = ''
-        ${cfge.interactiveShellInit}
-
-        ${cfg.promptInit}
-        ${zshAliases}
-
-        # Some sane history defaults
+        # history defaults
         export SAVEHIST=2000
         export HISTSIZE=2000
         export HISTFILE=$HOME/.zsh_history
 
         setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
+
+        ${cfge.interactiveShellInit}
+
+        ${cfg.promptInit}
+        ${zshAliases}
 
         # Tell zsh how to find installed completions
         for p in ''${(z)NIX_PROFILES}; do


### PR DESCRIPTION
With the current implementation it is not possible for interactiveShellInit to override History defaults. The only way to change these _defaults_ right now is to use an extra  in  `$HOME/.zshrc` 
This pull-request changes the order of execution to support configuration override via `interactiveShellInit` and `promptInit`.
