### PR TITLE
Bring in krb5 for darwin builds seeing as we use

### DIFF
--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gss, libidn }:
+{ fetchurl, stdenv, gss, libidn, krb5Full }:
 
 stdenv.mkDerivation rec {
   name = "gsasl-1.8.0";
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libidn ]
-    ++ stdenv.lib.optional (!stdenv.isDarwin) gss;
+    ++ stdenv.lib.optional (!stdenv.isDarwin) gss
+    ++ stdenv.lib.optional stdenv.isDarwin krb5Full;
 
   configureFlags = stdenv.lib.optionalString stdenv.isDarwin "--with-gssapi-impl=mit";
 


### PR DESCRIPTION
gsasl did not have GSSAPI mechanism in Darwin because no Kerberos was available.
