### PR TITLE
swap service: don't restart mkswap.service on switches

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -128,6 +128,7 @@ in
             wantedBy = [ "${realDevice'}.swap" ];
             before = [ "${realDevice'}.swap" ];
             path = [ pkgs.utillinux ] ++ optional sw.randomEncryption pkgs.cryptsetup;
+
             script =
               ''
                 ${optionalString (sw.size != null) ''
@@ -145,11 +146,13 @@ in
                   mkswap ${sw.realDevice}
                 ''}
               '';
+
             unitConfig.RequiresMountsFor = [ "${dirOf sw.device}" ];
             unitConfig.DefaultDependencies = false; # needed to prevent a cycle
             serviceConfig.Type = "oneshot";
             serviceConfig.RemainAfterExit = sw.randomEncryption;
             serviceConfig.ExecStop = optionalString sw.randomEncryption "${pkgs.cryptsetup}/bin/cryptsetup luksClose ${sw.deviceName}";
+            restartIfChanged = false;
           };
 
       in listToAttrs (map createSwapDevice (filter (sw: sw.size != null || sw.randomEncryption) config.swapDevices));


### PR DESCRIPTION
Sadly, we can't instruct systemd to properly restart device-name.swap when this service restarts (or I haven't found the way to do so). As of now blindly restarting it would only get you a bunch of errors about device already used -- let's avoid it.

EDIT: a bunch of errors would only be visible if you have an encrypted swap, otherwise it'll start properly, but only because we haven't implemented changing sizes of existing swap files yet ~_^.
