### PR TITLE
Rust pkg-config patch script had hard-coded /nix/store

### DIFF
--- a/pkgs/build-support/rust/patch-registry-deps/pkg-config
+++ b/pkgs/build-support/rust/patch-registry-deps/pkg-config
@@ -4,5 +4,5 @@ for dir in pkg-config-*; do
     echo "Patching pkg-config registry dep"
 
     substituteInPlace "$dir/src/lib.rs" \
-        --replace '"/usr"' '"/nix/store/"'
+        --replace '"/usr"' '"'"$NIX_STORE"'/"'
 done


### PR DESCRIPTION
Ran into [an issue](https://github.com/alexcrichton/git2-rs/issues/77#issuecomment-169822580) installing cargo.  Turns out this patch wasn't firing because my store isn't _/nix/store_.
