### PR TITLE
platformio: 2.7 -> 2.7.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14059,13 +14059,13 @@ in modules // {
 
   platformio =  buildPythonPackage rec {
     name = "platformio-${version}";
-    version="2.7.0";
+    version="2.7.1";
 
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/p/platformio/platformio-${version}.tar.gz";
-      sha256 = "0bjp8gapd8v5az0xvsgh44zyma5kazhhbq266fk092i2q348zbv6";
+      sha256 = "1xrjzgwdw7526vfimqjyr9115qzcs17dbyf7023x13anc8b2s9pq";
      };
 
      propagatedBuildInputs = with self; [ click_5 requests2 bottle pyserial lockfile colorama];


### PR DESCRIPTION
```
Initial support for Arduino Zero board (issue #356)
Added support for completions to Atom text editor using .clang_complete
Generate default targets for supported IDE (CLion, Eclipse IDE, Emacs, Sublime Text, VIM): Build, Clean, Upload, Upload SPIFFS image, Upload using Programmer, Update installed platforms and libraries (issue #427)
Updated Teensy Arduino Framework to 1.27 (issue #434)
Fixed uploading of EEPROM data using uploadeep target for Atmel AVR development platform
Fixed project generator for CLion IDE (issue #422)
Fixed package shasum validation on Mac OS X 10.11.2 (issue #429)
Fixed CMakeLists.txt add_executable has only one source file (issue #421)
```
