### PR TITLE
tigervnc: prevent nix store collision

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -1,96 +1,86 @@
-{ stdenv, fetchFromGitHub, libX11, libXext, gettext, libICE, libXtst, libXi, libSM, xorgserver
-, autoconf, automake, cvs, libtool, nasm, utilmacros, pixman, xkbcomp, xkeyboard_config
-, fontDirectories, fontutil, libgcrypt, gnutls, pam, flex, bison
-, fixesproto, damageproto, xcmiscproto, bigreqsproto, randrproto, renderproto
-, fontsproto, videoproto, compositeproto, scrnsaverproto, resourceproto
-, libxkbfile, libXfont, libpciaccess, cmake, libjpeg_turbo, libXft, fltk, libXinerama
-, xineramaproto, libXcursor
+{ stdenv, fetchgit, xorg
+, autoconf, automake, cvs, libtool, nasm, pixman, xkeyboard_config
+, fontDirectories, libgcrypt, gnutls, pam, flex, bison, gettext
+, cmake, libjpeg_turbo, fltk
 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "tigervnc-${version}";
   version = "1.6.0";
+  name = "tigervnc-${version}";
 
-  src = fetchFromGitHub {
-    owner = "TigerVNC";
-    repo = "tigervnc";
-    rev = "v${version}";
+  src = fetchgit {
+    url = "https://github.com/TigerVNC/tigervnc/";
     sha256 = "1plljv1cxsax88kv52g02n8c1hzwgp6j1p8z1aqhskw36shg4pij";
+    rev = "5a727f25990d05c9a1f85457b45d6aed66409cb3";
   };
 
   inherit fontDirectories;
 
   patchPhase = ''
     sed -i -e 's,$(includedir)/pixman-1,${if stdenv ? cross then pixman.crossDrv else pixman}/include/pixman-1,' unix/xserver/hw/vnc/Makefile.am
-    sed -i -e '/^$pidFile/a$ENV{XKB_BINDIR}="${if stdenv ? cross then xkbcomp.crossDrv else xkbcomp}/bin";' unix/vncserver
+    sed -i -e '/^$pidFile/a$ENV{XKB_BINDIR}="${if stdenv ? cross then xorg.xkbcomp.crossDrv else xorg.xkbcomp}/bin";' unix/vncserver
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${if stdenv ? cross then xkeyboard_config.crossDrv else xkeyboard_config}/etc/X11/xkb";' unix/vncserver
-
     fontPath=
     for i in $fontDirectories; do
       for j in $(find $i -name fonts.dir); do
         addToSearchPathWithCustomDelimiter "," fontPath $(dirname $j)
       done
     done
-
     sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -fp '"$fontPath"'";' unix/vncserver
   '';
 
-  # I don't know why I can't use in the script
-  # this:  ${concatStringsSep " " (map (f: "${f}") xorgserver.patches)}
-  xorgPatches = xorgserver.patches;
-
-  dontUseCmakeBuildDir = "yes";
+  dontUseCmakeBuildDir = true;
 
   postBuild = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -fpermissive -Wno-error=int-to-pointer-cast"
-
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error=int-to-pointer-cast"
+    export CXXFLAGS="$CXXFLAGS -fpermissive"
     # Build Xvnc
-    tar xf ${xorgserver.src}
+    tar xf ${xorg.xorgserver.src}
     cp -R xorg*/* unix/xserver
     pushd unix/xserver
-    for a in $xorgPatches ../xserver116.patch
-    do
-      patch -p1 < $a
-    done
     autoreconf -vfi
-    ./configure $configureFlags --disable-xinerama --disable-xvfb --disable-xnest \
+    ./configure $configureFlags --disable-devel-docs --disable-docs --disable-xinerama --disable-xvfb --disable-xnest \
         --disable-xorg --disable-dmx --disable-dri --disable-dri2 --disable-glx \
         --prefix="$out" --disable-unit-tests \
         --with-xkb-path=${xkeyboard_config}/share/X11/xkb \
-        --with-xkb-bin-directory=${xkbcomp}/bin \
+        --with-xkb-bin-directory=${xorg.xkbcomp}/bin \
         --with-xkb-output=$out/share/X11/xkb/compiled
     make TIGERVNC_SRCDIR=`pwd`/../..
     popd
   '';
-
+  
   postInstall = ''
     pushd unix/xserver
     make TIGERVNC_SRCDIR=`pwd`/../.. install
+    popd
+    rm -f $out/lib/xorg/protocol.txt
   '';
 
   crossAttrs = {
     buildInputs = (map (x : x.crossDrv) (buildInputs ++ [
-      fixesproto damageproto xcmiscproto bigreqsproto randrproto renderproto
-      fontsproto videoproto compositeproto scrnsaverproto resourceproto
-      libxkbfile libXfont libpciaccess xineramaproto
+      xorg.fixesproto xorg.damageproto xorg.xcmiscproto xorg.bigreqsproto xorg.randrproto xorg.renderproto
+      xorg.fontsproto xorg.videoproto xorg.compositeproto xorg.scrnsaverproto xorg.resourceproto
+      xorg.libxkbfile xorg.libXfont xorg.libpciaccess xorg.xineramaproto
     ]));
   };
 
   buildInputs =
-    [ libX11 libXext gettext libICE libXtst libXi libSM libXft
-      nasm libgcrypt gnutls pam pixman libjpeg_turbo fltk xineramaproto
-      libXinerama libXcursor
+    [ xorg.libX11 xorg.libXext gettext xorg.libICE xorg.libXtst xorg.libXi xorg.libSM xorg.libXft
+      nasm libgcrypt gnutls pam pixman libjpeg_turbo fltk xorg.xineramaproto
+      xorg.libXinerama xorg.libXcursor
     ];
 
   nativeBuildInputs =
-    [ autoconf automake cvs utilmacros fontutil libtool flex bison
+    [ autoconf automake cvs xorg.utilmacros xorg.fontutil libtool flex bison
       cmake
     ]
-      ++ xorgserver.nativeBuildInputs;
+      ++ xorg.xorgserver.nativeBuildInputs;
 
-  propagatedNativeBuildInputs = xorgserver.propagatedNativeBuildInputs;
+  propagatedNativeBuildInputs = xorg.xorgserver.propagatedNativeBuildInputs;
+
+  enableParallelBuilding = true;
 
   meta = {
     homepage = http://www.tigervnc.org/;
@@ -98,5 +88,7 @@ stdenv.mkDerivation rec {
     description = "Fork of tightVNC, made in cooperation with VirtualGL";
     maintainers = with stdenv.lib.maintainers; [viric];
     platforms = with stdenv.lib.platforms; linux;
+    # Prevent a store collision.
+    priority = 4;
   };
 }


### PR DESCRIPTION
- Prevent store collision with the xserver for two files
- Stop gcc from complaining at build time about C and CXX flags
- Enable parallel building for this expression
- Move to the new way of calling Xorg and it's dependencies
