### PR TITLE
go: 1.5.1 -> 1.5.3 (backport to 15.09) [urgent, security]

### DIFF
--- a/pkgs/development/compilers/go/1.5.nix
+++ b/pkgs/development/compilers/go/1.5.nix
@@ -15,11 +15,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.5.1";
+  version = "1.5.3";
 
   src = fetchurl {
     url = "https://github.com/golang/go/archive/go${version}.tar.gz";
-    sha256 = "1xd1nd1li7pdl72vq8zkh6m7ms3ajgyqz9a5d61gagm0cgj8zilz";
+    sha256 = "1n2niq0147pqflqh8j1s5wv8aq3vlh58ni3bp9add261z5q1g50k";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
This addresses CVE-2015-8618 (a vulnerability in math/big)
This issue can affect RSA computations in crypto/rsa, which is used by
crypto/tls. TLS servers on 32-bit systems could plausibly leak their RSA
private key due to this issue. Other protocol implementations that
create many RSA signatures could also be impacted in the same way.
https://groups.google.com/forum/#!topic/golang-dev/MEATuOi_ei4

Backported to 15.09 from 174221b744358438fd108f19dfab81a2844be538

/cc @edolstra
