### PR TITLE
Add options to use new libstdc++ on Steam

### DIFF
--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -1,11 +1,17 @@
-{ pkgs, newScope }:
+{ pkgs, newScope
+, nativeOnly ? false
+, runtimeOnly ? false
+, newStdcpp ? false
+}:
 
 let
   callPackage = newScope self;
 
   self = rec {
     steam-runtime = callPackage ./runtime.nix { };
-    steam-runtime-wrapped = callPackage ./runtime-wrapped.nix { };
+    steam-runtime-wrapped = callPackage ./runtime-wrapped.nix {
+      inherit nativeOnly runtimeOnly newStdcpp;
+    };
     steam = callPackage ./steam.nix { };
     steam-chrootenv = callPackage ./chrootenv.nix { };
     steam-fonts = callPackage ./fonts.nix { };

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -1,9 +1,11 @@
-{ stdenv, perl, pkgs, steam-runtime
+{ stdenv, lib, perl, pkgs, steam-runtime
 , nativeOnly ? false
 , runtimeOnly ? false
+, newStdcpp ? false
 }:
 
 assert !(nativeOnly && runtimeOnly);
+assert newStdcpp -> !runtimeOnly;
 
 let 
   runtimePkgs = with pkgs; [
@@ -77,19 +79,18 @@ let
     SDL2_mixer
     gstreamer
     gst_plugins_base
-  ];
+  ] ++ lib.optional (!newStdcpp) gcc48.cc;
 
   overridePkgs = with pkgs; [
-    gcc48.cc # libstdc++
     libpulseaudio
     alsaLib
     openalSoft
-  ];
+  ] ++ lib.optional newStdcpp gcc.cc;
 
   ourRuntime = if runtimeOnly then []
                else if nativeOnly then runtimePkgs ++ overridePkgs
                else overridePkgs;
-  steamRuntime = stdenv.lib.optional (!nativeOnly) steam-runtime;
+  steamRuntime = lib.optional (!nativeOnly) steam-runtime;
 
 in stdenv.mkDerivation rec {
   name = "steam-runtime-wrapped";


### PR DESCRIPTION
Thanks @pstn for testing my flurry of possible solutions. This should give somewhat usable Steam to people who need newer `libstdc++` (such as open-source Radeon driver users).

To get it, use `(steamPackages.override { newLibcpp = true; }).steam-chrootenv`.
