### PR TITLE
qutebrowser: fix youtube segfaults and certificate problems

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, python, buildPythonPackage, qtmultimedia, pyqt5
-, jinja2, pygments, pyyaml, pypeg2, gst_plugins_base, gst_plugins_good
-, gst_ffmpeg }:
+, jinja2, pygments, pyyaml, pypeg2, gst-plugins-base, gst-plugins-good
+, gst-plugins-bad, gst-libav, wrapGAppsHook, glib_networking }:
 
 let version = "0.4.1"; in
 
@@ -17,13 +17,15 @@ buildPythonPackage {
   # Needs tox
   doCheck = false;
 
+  buildInputs = [ wrapGAppsHook
+    gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav
+    glib_networking ];
+
   propagatedBuildInputs = [
     python pyyaml pyqt5 jinja2 pygments pypeg2
   ];
 
   makeWrapperArgs = ''
-    --prefix GST_PLUGIN_PATH : "${stdenv.lib.makeSearchPath "lib/gstreamer-0.10"
-       [ gst_plugins_base gst_plugins_good gst_ffmpeg ]}"
     --prefix QT_PLUGIN_PATH : "${qtmultimedia}/lib/qt5/plugins"
   '';
 

--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,17 +1,16 @@
-{ stdenv, fetchgit, python, buildPythonPackage, qtmultimedia, pyqt5
+{ stdenv, fetchurl, python, buildPythonPackage, qtmultimedia, pyqt5
 , jinja2, pygments, pyyaml, pypeg2, gst-plugins-base, gst-plugins-good
 , gst-plugins-bad, gst-libav, wrapGAppsHook, glib_networking }:
 
-let version = "0.4.1"; in
+let version = "0.5.0"; in
 
-buildPythonPackage {
+buildPythonPackage rec {
   name = "qutebrowser-${version}";
   namePrefix = "";
 
-  src = fetchgit {
-    url = "https://github.com/The-Compiler/qutebrowser.git";
-    rev = "8d9e9851f1dcff5deb6363586ad0f1edec040b72";
-    sha256 = "1qsdad10swnk14qw4pfyvb94y6valhkscyvl46zbxxs7ck6llsm2";
+  src = fetchurl {
+    url = "https://github.com/The-Compiler/qutebrowser/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "16cyw0jg6qg9ksr6xwgnkm1a2bwgii2s35nrgk3g705ywfsf02j7";
   };
 
   # Needs tox

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -2,15 +2,15 @@
 , gsettings_desktop_schemas }:
 
 let
-  ver_maj = "2.44";
-  ver_min = "0";
+  ver_maj = "2.46";
+  ver_min = "1";
 in
 stdenv.mkDerivation rec {
   name = "glib-networking-${ver_maj}.${ver_min}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib-networking/${ver_maj}/${name}.tar.xz";
-    sha256 = "8f8a340d3ba99bfdef38b653da929652ea6640e27969d29f7ac51fbbe11a4346";
+    sha256 = "1cchmi08jpjypgmm9i7xzh5qfg2q5k61kry9ns8mhw3z44a440ym";
   };
 
   configureFlags = "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -3,15 +3,15 @@
 , libintlOrEmpty
 , intltool, python }:
 let
-  majorVersion = "2.50";
-  version = "${majorVersion}.0";
+  majorVersion = "2.52";
+  version = "${majorVersion}.2";
 in
 stdenv.mkDerivation {
   name = "libsoup-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/libsoup/${majorVersion}/libsoup-${version}.tar.xz";
-    sha256 = "1e01365ac4af3817187ea847f9d3588c27eee01fc519a5a7cb212bb78b0f667b";
+    sha256 = "1p4k40y2gikr6m8p3hm0vswdzj2pj133dckipd2jk5bxbj5n4mfv";
   };
 
   patchPhase = ''
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   passthru.propagatedUserEnvPackages = [ glib_networking ];
 
   # glib_networking is a runtime dependency, not a compile-time dependency
-  configureFlags = "--disable-tls-check" + stdenv.lib.optionalString (!gnomeSupport) " --without-gnome";
+  configureFlags = "--disable-tls-check --enable-vala=no" + stdenv.lib.optionalString (!gnomeSupport) " --without-gnome";
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12974,8 +12974,9 @@ let
     gst_plugins_bad = null;
   };
 
-  qutebrowser = qt5.callPackage ../applications/networking/browsers/qutebrowser {
+  qutebrowser = qt55.callPackage ../applications/networking/browsers/qutebrowser {
     inherit (python34Packages) buildPythonPackage python pyqt5 jinja2 pygments pyyaml pypeg2;
+    inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav;
   };
 
   rabbitvcs = callPackage ../applications/version-management/rabbitvcs {};


### PR DESCRIPTION
This is PR #12295, now against staging.

Right now in master, qutebrowser segfaults when visiting youtube.  To sum up:
- There was a mismatch in the Qt plugins used (5.5 library vs. 5.4 plugins)
- In addition, there was a mismatch in the GStreamer plugins used (1.0 vs 0.10)
- But then, libsoup/glib-networking did not like the current `/etc/ssl/certs/ca-certificates.crt`, so I had to upgrade them as well (the reason for the mass-rebuild)
