### PR TITLE
firefox-bin: wrap firefox-bin

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -60,7 +60,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "firefox-bin-${version}";
+  name = "firefox-bin-unwrapped-${version}";
 
   src = fetchurl {
     url = "http://download-installer.cdn.mozilla.net/pub/firefox/releases/${version}/${source.arch}/${source.locale}/firefox-${version}.tar.bz2";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11852,9 +11852,16 @@ let
   firefox = wrapFirefox firefox-unwrapped { };
   firefox-esr = wrapFirefox firefox-esr-unwrapped { };
 
-  firefox-bin = callPackage ../applications/networking/browsers/firefox-bin {
+  firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
     gconf = pkgs.gnome.GConf;
     inherit (pkgs.gnome) libgnome libgnomeui;
+  };
+
+  firefox-bin = wrapFirefox firefox-bin-unwrapped {
+    browserName = "firefox";
+    name = "firefox-bin-" +
+      (builtins.parseDrvName firefox-bin-unwrapped.name).version;
+    desktopName = "Firefox";
   };
 
   firestr = qt5.callPackage ../applications/networking/p2p/firestr


### PR DESCRIPTION
Replaces `firefox-bin` with Wrapped version.

See also #12299.
