### PR TITLE
racket: 6.2.1 -> 6.3, add parameter to enable building docs

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -32,11 +32,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "racket-${version}";
-  version = "6.2.1";
+  version = "6.3";
 
   src = fetchurl {
     url = "http://mirror.racket-lang.org/installers/${version}/${name}-src.tgz";
-    sha256 = "0555j63k7fs10iv0icmivlxpzgp6s7gwcbfddmbwxlf2rk80qhq0";
+    sha256 = "0f21vnads6wsrzimfja969gf3pkl60s0rdfrjf9s70lcy9x0jz4i";
   };
 
   FONTCONFIG_FILE = fontsConf;

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -3,6 +3,7 @@
 , glib, gmp, gtk, libffi, libjpeg, libpng
 , libtool, mpfr, openssl, pango, poppler
 , readline, sqlite
+, disableDocs ? true
 }:
 
 let
@@ -50,7 +51,8 @@ stdenv.mkDerivation rec {
     cd src/build
   '';
 
-  configureFlags = [ "--enable-shared" "--enable-lt=${libtool}/bin/libtool" "--disable-docs"];
+  configureFlags = [ "--enable-shared" "--enable-lt=${libtool}/bin/libtool" ]
+                   ++ stdenv.lib.optional disableDocs [ "--disable-docs" ];
 
   configureScript = "../configure";
 


### PR DESCRIPTION
- 6fc61a1 adds a `disableDocs` parameter to the Racket expression, with a default argument of `true`.  This default remains consistent with changes introduced in 89cec0c, which disabled building Racket's documentation to reduce Hydra build failures.  The new parameter allows users to locally build Racket w/documentation by means of `packageOverrides`.  It was named to maintain consistency with upstream configuration options. 
- 00f394e updates Racket to version 6.3.

Both changes have been tested locally against `master`.
