### PR TITLE
popfile: init at 1.1.3

### DIFF
--- a/pkgs/tools/text/popfile/default.nix
+++ b/pkgs/tools/text/popfile/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchzip, makeWrapper, perlPackages,
+... }:
+
+stdenv.mkDerivation rec {
+  appname = "popfile";
+  version = "1.1.3";
+  name = "${appname}-${version}";
+
+  src = fetchzip {
+    url = "http://getpopfile.org/downloads/${appname}-${version}.zip";
+    sha256 = "0gcib9j7zxk8r2vb5dbdz836djnyfza36vi8215nxcdfx1xc7l63";
+    stripRoot = false;
+  };
+
+  buildInputs = [ makeWrapper ] ++ (with perlPackages; [
+    ## These are all taken from the popfile documentation as applicable to Linux
+    ## http://getpopfile.org/docs/howtos:allplatformsrequireperl
+    perl
+    DBI
+    DBDSQLite
+    Digest
+    DigestMD5
+    HTMLTagset
+    MIMEBase64 # == MIMEQuotedPrint
+    TimeDate # == DateParse
+    HTMLTemplate
+    # IO::Socket::Socks is not in nixpkgs
+    # IOSocketSocks 
+    IOSocketSSL
+    NetSSLeay
+    SOAPLite
+  ]);
+
+
+  phases = [ "unpackPhase" "installPhase" "patchPhase" "postInstall" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    # I user `cd` rather than `cp $out/* ...` b/c the * breaks syntax
+    # highlighting in emacs for me.
+    cd $src
+    cp -r * $out/bin
+    cd $out/bin
+    chmod +x *.pl
+  '';
+
+  patchPhase = "patchShebangs $out";
+
+  postInstall = ''
+    find $out -name '*.pl' -executable | while read path; do
+      wrapProgram "$path" \
+        --prefix PERL5LIB : $PERL5LIB:$out/bin \
+        --set POPFILE_ROOT $out/bin \
+        --set POPFILE_USER \$\{POPFILE_USER:-\$HOME/.popfile\} \
+        --run "test -d \$POPFILE_USER || mkdir -m 0700 -p \$POPFILE_USER"
+    done
+  '';
+
+  meta = {
+    description = "An email classification system that automatically sorts messages and fights spam.";
+    homepage = http://getpopfile.org;
+    license = stdenv.lib.licenses.gpl2;
+
+    # Should work on OS X, but havent tested it.
+    # Windows support is more complicated.
+    # http://getpopfile.org/docs/faq:systemrequirements
+    platforms = stdenv.lib.platforms.linux;
+  };
+
+}
+  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2824,6 +2824,8 @@ let
 
   ponysay = callPackage ../tools/misc/ponysay { };
 
+  popfile = callPackage ../tools/text/popfile { };
+
   povray = callPackage ../tools/graphics/povray {
     automake = automake113x; # fails with 14
   };


### PR DESCRIPTION
I've tested popfile with imap on 64 bit linux NixOS 15.09.

Some important notes: default popfile configuration assumes 
1. the ability to modify the contents of its installation directory 
2. it is being run from its installation directory

To get around this,  specify `POPFILE_USER` and `POPFILE_ROOT` before calling `popfile.pl`.
For instance, while testing, I ran it like so:

```
POPFILE_ROOT=$(readlink -f result/bin) POPFILE_USER=/tmp/popfile-test ./result/bin/popfile.pl
```

The details on what these variables do is provided in the [popfile documentation](http://getpopfile.org/docs/howtos:multiusers).
