### PR TITLE
R: add a new `enableStrictBarrier` package option.

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -3,6 +3,7 @@
 , less, texinfo, graphviz, icu, pkgconfig, bison, imake, which, jdk, openblas
 , curl, Cocoa, Foundation, cf-private, libobjc, tzdata
 , withRecommendedPackages ? true
+, enableStrictBarrier ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
       --with-system-pcre
       --with-system-xz
       --with-ICU
+      ${stdenv.lib.optionalString enableStrictBarrier "--enable-strict-barrier"}
       --enable-R-shlib
       AR=$(type -p ar)
       AWK=$(type -p gawk)


### PR DESCRIPTION
This option compiles R with --enable-strict-barrier. Doing so is
enables extra memory diagnostics in R that very useful for debugging
memory leak or memory protections issues in extensions to R written in
C, or for any apps embedding R (e.g. Haskell aps embedding R via
HaskellR).
