### PR TITLE
i18n: Fix vconsole colorscheme generation

### DIFF
--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -4,14 +4,14 @@ with lib;
 
 let
 
-  makeColor = n: value: "COLOR_${toString n}=${value}";
+  makeColor = n: value: "COLOR_${toString n}=${value}";  
+  colors = concatImapStringsSep "\n" makeColor config.i18n.consoleColors;
 
-  vconsoleConf = pkgs.writeText "vconsole.conf"
-    ''
-      KEYMAP=${config.i18n.consoleKeyMap}
-      FONT=${config.i18n.consoleFont}
-    '' + concatImapStringsSep "\n" makeColor config.i18n.consoleColors;
-
+  vconsoleConf = pkgs.writeText "vconsole.conf" ''
+    KEYMAP=${config.i18n.consoleKeyMap}
+    FONT=${config.i18n.consoleFont}
+    ${colors}
+  '';
 in
 
 {


### PR DESCRIPTION
It seems I have forgot about left associativity
