### PR TITLE
lean: update and add wrapper for linja

### DIFF
--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "lean-${version}";
-  version = "20150821";
+  version = "20160117";
 
   src = fetchFromGitHub {
     owner  = "leanprover";
     repo   = "lean";
-    rev    = "453bd2341dac51e50d9bff07d5ff6c9c3fb3ba0b";
-    sha256 = "1hmga5my123sra873iyqc7drj4skny4hnhsasaxjkmmdhmj1zpka";
+    rev    = "b2554dcb8f45899ccce84f226cd67b6460442930";
+    sha256 = "1gr024bly92kdjky5qvcm96gn86ijakziiyrsz91h643n1iyxhms";
   };
 
   buildInputs = [ gmp mpfr luajit boost cmake python gperftools ninja ];

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, gmp, mpfr, luajit, boost, python
-, gperftools, ninja }:
+, gperftools, ninja, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "lean-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1gr024bly92kdjky5qvcm96gn86ijakziiyrsz91h643n1iyxhms";
   };
 
-  buildInputs = [ gmp mpfr luajit boost cmake python gperftools ninja ];
+  buildInputs = [ gmp mpfr luajit boost cmake python gperftools ninja makeWrapper ];
   enableParallelBuilding = true;
 
   preConfigure = ''
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/linja --prefix PATH : $out/bin:${ninja}/bin
+  '';
 
   meta = {
     description = "Automatic and interactive theorem prover";


### PR DESCRIPTION
At the moment, the `linja` tool fails if the dependency `ninja` is not present in `PATH`.  In this case, `linja` unsuccessfully tries to download a copy of ninja into the nix store directory.
