### PR TITLE
Erlang: Pass buildPlugins to rebar3-nix-bootstrap from buildRebar3

### DIFF
--- a/pkgs/development/erlang-modules/build-rebar3.nix
+++ b/pkgs/development/erlang-modules/build-rebar3.nix
@@ -4,7 +4,7 @@
 { name, version
 , src
 , setupHook ? null
-, buildInputs ? [], erlangDeps ? [], pluginDeps ? []
+, buildInputs ? [], erlangDeps ? [], buildPlugins ? []
 , postPatch ? ""
 , compilePorts ? false
 , installPhase ? null
@@ -14,8 +14,7 @@
 with stdenv.lib;
 
 let
-  plugins = pluginDeps ++ (if compilePorts then [pc] else []);
-
+  ownPlugins = buildPlugins ++ (if compilePorts then [pc] else []);
 
   shell = drv: stdenv.mkDerivation {
           name = "interactive-shell-${drv.name}";
@@ -28,7 +27,11 @@ let
     inherit version;
 
     buildInputs = buildInputs ++ [ erlang rebar3 openssl libyaml ];
-    propagatedBuildInputs = erlangDeps ++ plugins;
+    propagatedBuildInputs = unique (erlangDeps ++ ownPlugins);
+
+    # The following are used by rebar3-nix-bootstrap
+    inherit compilePorts;
+    buildPlugins = ownPlugins;
 
     inherit src;
 

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -81,8 +81,7 @@ stdenv.mkDerivation {
   patches = [ ./hermetic-bootstrap.patch ];
 
   buildInputs = [ erlang tree  ];
-  propagatedBuildInputs = [ registrySnapshot  rebar3-nix-bootstrap ];
-
+  propagatedBuildInputs = [ registrySnapshot rebar3-nix-bootstrap ];
 
   postPatch = ''
     echo postPatch


### PR DESCRIPTION
To successfully build rebar packages, it needs to be provided with
rebar3 plugins used to build it. This change passes them to env
variable. From there rebar3-nix-bootstrap takes them and symlinks into
_build/default/plugins.

This goes together with https://github.com/erlang-nix/rebar3-nix-bootstrap/pull/2
