### PR TITLE
Refactor to use autoreconfHook where possible

### DIFF
--- a/pkgs/applications/audio/freewheeling/default.nix
+++ b/pkgs/applications/audio/freewheeling/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, pkgconfig, autoconf, automake, gnutls33, freetype
+{ stdenv, fetchsvn, pkgconfig, autoreconfHook, gnutls33, freetype
 , SDL, SDL_gfx, SDL_ttf, liblo, libxml2, alsaLib, libjack2, libvorbis
 , libsndfile, libogg
 }:
@@ -13,11 +13,9 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    pkgconfig autoconf automake gnutls33 freetype SDL SDL_gfx SDL_ttf
+    pkgconfig autoreconfHook gnutls33 freetype SDL SDL_gfx SDL_ttf
     liblo libxml2 libjack2 alsaLib libvorbis libsndfile libogg
   ];
-
-  preConfigure = "autoreconf -vfi";
 
   patches = [ ./am_path_sdl.patch ./xml.patch ];
 

--- a/pkgs/applications/audio/ladspa-plugins/git.nix
+++ b/pkgs/applications/audio/ladspa-plugins/git.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchgit, automake, autoreconfHook, fftw, gettext, ladspaH, libxml2, pkgconfig, perl, perlPackages }:
+{ stdenv, fetchgit, autoreconfHook, automake, fftw, ladspaH, libxml2, pkgconfig
+, perl, perlPackages }:
 
 stdenv.mkDerivation {
   name = "swh-plugins-git-2015-03-04";
@@ -9,17 +10,12 @@ stdenv.mkDerivation {
     sha256 = "7d9aa13a064903b330bd52e35c1f810f1c8a253ea5eb4e5a3a69a051af03150e";
   };
 
-  buildInputs = [ automake autoreconfHook fftw gettext ladspaH libxml2 pkgconfig perl perlPackages.XMLParser ];
+  buildInputs = [ autoreconfHook fftw ladspaH libxml2 pkgconfig perl perlPackages.XMLParser ];
 
   patchPhase = ''
     patchShebangs .
     patchShebangs ./metadata/
     cp ${automake}/share/automake-*/mkinstalldirs .
-  '';
-
-  configurePhase = ''
-    autoreconf -i
-    ./configure --prefix=$out
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/editors/emacs-modes/emacs-w3m/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs-w3m/default.nix
@@ -1,4 +1,4 @@
-{ fetchcvs, stdenv, emacs, w3m, imagemagick, texinfo, autoconf }:
+{ fetchcvs, stdenv, emacs, w3m, imagemagick, texinfo, autoreconfHook }:
 
 let date = "2013-03-21"; in
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lmcj8rf83w13q8q68hh7sa1abc2m6j2zmfska92xdp7hslhdgc5";
   };
 
-  buildInputs = [ emacs w3m texinfo autoconf ];
+  buildInputs = [ emacs w3m texinfo autoreconfHook ];
 
   # XXX: Should we do the same for xpdf/evince, gv, gs, etc.?
   patchPhase = ''
@@ -26,11 +26,10 @@ stdenv.mkDerivation rec {
             s|(w3m-which-command "identify")|"${imagemagick}/bin/identify"|g'
   '';
 
-  configurePhase = ''
-    autoreconf -vfi && \
-    ./configure --prefix="$out" --with-lispdir="$out/share/emacs/site-lisp" \
-                --with-icondir="$out/share/emacs/site-lisp/images/w3m"
-  '';
+  configureFlags = [
+    "--with-lispdir=$out/share/emacs/site-lisp"
+    "--with-icondir=$out/share/emacs/site-lisp/images/w3m"
+  ];
 
   postInstall = ''
     cd "$out/share/emacs/site-lisp"

--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchgit,autoconf, automake, gcc, fltk13
-, libjpeg, libpng, libtool, mesa, pkgconfig }:
+{ stdenv, fetchgit, autoreconfHook, fltk13
+, libjpeg, libpng, mesa, pkgconfig }:
 
 stdenv.mkDerivation {
   name = "solvespace-2.0";
@@ -14,26 +14,14 @@ stdenv.mkDerivation {
   dontBuild = true;
   enableParallelBuilding = false;
 
-  buildInputs = [        
-    autoconf
-    automake
-    gcc
+  buildInputs = [
+    autoreconfHook
     fltk13
     libjpeg
     libpng
-    libtool
     mesa
     pkgconfig
-    stdenv
   ];
-
-  preConfigure = ''
-    aclocal
-    libtoolize
-    
-    autoreconf -i
-    automake --add-missing
-  '';
 
   meta = {
     description = "A parametric 3d CAD program";

--- a/pkgs/applications/misc/evtest/default.nix
+++ b/pkgs/applications/misc/evtest/default.nix
@@ -1,11 +1,9 @@
-{ stdenv, fetchgit, autoconf, automake, pkgconfig, libxml2 }:
+{ stdenv, fetchgit, autoreconfHook, automake, pkgconfig, libxml2 }:
 
 stdenv.mkDerivation rec {
   name = "evtest-1.32";
 
-  preConfigure = "autoreconf -iv";
-
-  buildInputs = [ autoconf automake pkgconfig libxml2 ];
+  buildInputs = [ autoreconfHook pkgconfig libxml2 ];
 
   src = fetchgit {
     url = "git://anongit.freedesktop.org/evtest";

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, makeWrapper, autoconf, automake, boost, file, gettext
+{ stdenv, fetchurl, makeWrapper, autoreconfHook, boost, file
 , glib, glibc, libgnome_keyring, gnome_keyring, gtk, gtkmm, intltool
 , libctemplate, libglade
 , libiodbc
-, libgnome, libsigcxx, libtool, libuuid, libxml2, libzip, lua, mesa, mysql
+, libgnome, libsigcxx, libuuid, libxml2, libzip, lua, mesa, mysql
 , pango, paramiko, pcre, pexpect, pkgconfig, pycrypto, python, sqlite, sudo
 }:
 
@@ -16,16 +16,12 @@ stdenv.mkDerivation rec {
     sha256 = "1343fn3msdxqfpxw0kgm0mdx5r7g9ra1cpc8p2xhl7kz2pmqp4p6";
   };
 
-  buildInputs = [ autoconf automake boost file gettext glib glibc libgnome_keyring gtk gtkmm intltool
-    libctemplate libglade libgnome libiodbc libsigcxx libtool libuuid libxml2 libzip lua makeWrapper mesa
+  buildInputs = [ autoreconfHook boost file glib glibc libgnome_keyring gtk gtkmm intltool
+    libctemplate libglade libgnome libiodbc libsigcxx libuuid libxml2 libzip lua makeWrapper mesa
     mysql.lib paramiko pcre pexpect pkgconfig pycrypto python sqlite ];
 
   preConfigure = ''
     substituteInPlace $(pwd)/frontend/linux/workbench/mysql-workbench.in --replace "catchsegv" "${glibc}/bin/catchsegv"
-  '';
-
-  postConfigure = ''
-    autoreconf -fi
   '';
 
   postInstall = ''

--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, pkgconfig
+{ stdenv, fetchurl, autoreconfHook, pkgconfig
 , libX11, libXinerama, pango, cairo
 , libstartup_notification, i3Support ? false, i3
 }:
@@ -12,13 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "112fgx2awsw1xf1983bmy3jvs33qwyi8qj7j59jqc4gx07nv1rp5";
   };
 
-  buildInputs = [ autoconf automake pkgconfig libX11 libXinerama pango
+  buildInputs = [ autoreconfHook pkgconfig libX11 libXinerama pango
                   cairo libstartup_notification
                 ] ++ stdenv.lib.optional i3Support i3;
-
-  preConfigure = ''
-    autoreconf -vif
-  '';
 
   meta = {
       description = "Window switcher, run dialog and dmenu replacement";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, libtoxcore, pidgin, autoconf, automake, libtool
-, libsodium } :
+{ stdenv, fetchFromGitHub, libtoxcore, pidgin, autoreconfHook, libsodium }:
 
 let
   version = "dd181722ea";
@@ -17,11 +16,9 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = "-lssp -lsodium";
 
-  preConfigure = "autoreconf -vfi";
-
   postInstall = "mv $out/lib/purple-2 $out/lib/pidgin";
 
-  buildInputs = [ libtoxcore pidgin autoconf automake libtool libsodium ];
+  buildInputs = [ libtoxcore pidgin autoreconfHook libsodium ];
 
   meta = {
     homepage = http://tox.dhs.org/;

--- a/pkgs/applications/science/astronomy/celestia/default.nix
+++ b/pkgs/applications/science/astronomy/celestia/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, freeglut, gtk2, gtkglext, libjpeg_turbo, libtheora, libXmu
-, lua, mesa, pkgconfig, perl, automake, autoconf, libtool, gettext, glib, cairo
+, lua, mesa, pkgconfig, perl, autoreconfHook, glib, cairo
 , pango, gdk_pixbuf, atk
 }:
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ freeglut gtk2 gtkglext libjpeg_turbo libtheora libXmu mesa pkgconfig lua
-    perl automake autoconf libtool gettext ];
+    perl autoreconfHook ];
 
   patchPhase = ''
     patch -Np0 -i "${gcc46Patch}"
@@ -53,17 +53,14 @@ stdenv.mkDerivation {
     patch -Np2 -i "${libpng16Patch}"
     patch -Np1 -i "${linkingPatch}"
     patch -Np1 -i "${gcc47Patch}"
-    autoreconf
-    configureFlagsArray=(
-      --with-gtk
-      --with-lua=${lua}
-      CPPFLAGS="-DNDEBUG"
-      CFLAGS="-O2 -fsigned-char"
-      CXXFLAGS="-O2 -fsigned-char"
-      GTK_CFLAGS="-I${gtk2}/include/gtk-2.0 -I${gtk2}/lib/gtk-2.0/include -I${glib}/include/glib-2.0 -I${glib}/lib/glib-2.0/include -I${cairo}/include/cairo -I${pango}/include/pango-1.0 -I${gdk_pixbuf}/include/gdk-pixbuf-2.0 -I${atk}/include/atk-1.0 -I${gtkglext}/include/gtkglext-1.0 -I${gtkglext}/lib/gtkglext-1.0/include"
-      GTK_LIBS="-lgtk-x11-2.0 -lgtkglext-x11-1.0 -lcairo -lgdk_pixbuf-2.0 -lpango-1.0 -lgobject-2.0"
-    )
   '';
+
+  configureFlags = "--with-gtk --with-lua=${lua}";
+  CPPFLAGS = "-DNDEBUG";
+  CFLAGS = "-O2 -fsigned-char";
+  CXXFLAGS = "-O2 -fsigned-char";
+  GTK_CFLAGS = "-I${gtk2}/include/gtk-2.0 -I${gtk2}/lib/gtk-2.0/include -I${glib}/include/glib-2.0 -I${glib}/lib/glib-2.0/include -I${cairo}/include/cairo -I${pango}/include/pango-1.0 -I${gdk_pixbuf}/include/gdk-pixbuf-2.0 -I${atk}/include/atk-1.0 -I${gtkglext}/include/gtkglext-1.0 -I${gtkglext}/lib/gtkglext-1.0/include";
+  GTK_LIBS = "-lgtk-x11-2.0 -lgtkglext-x11-1.0 -lcairo -lgdk_pixbuf-2.0 -lpango-1.0 -lgobject-2.0";
 
   installPhase = ''make MKDIR_P="mkdir -p" install'';
 

--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchurl, makeWrapper, autoconf, automake,
-  libmspack, openssl, pam, xercesc, icu, libdnet, procps, 
+{ stdenv, lib, fetchurl, makeWrapper, autoreconfHook,
+  libmspack, openssl, pam, xercesc, icu, libdnet, procps,
   xlibsWrapper, libXinerama, libXi, libXrender, libXrandr, libXtst,
   pkgconfig, glib, gtk, gtkmm }:
 
@@ -16,8 +16,8 @@ in stdenv.mkDerivation {
     sha256 = "15lwayrz9bpx4z12fj616hsn25m997y72licwwz7kms4sx9ssip1";
   };
 
-  buildInputs = 
-    [ autoconf automake makeWrapper libmspack openssl pam xercesc icu libdnet procps
+  buildInputs =
+    [ autoreconfHook makeWrapper libmspack openssl pam xercesc icu libdnet procps
       pkgconfig glib gtk gtkmm xlibsWrapper libXinerama libXi libXrender libXrandr libXtst ];
 
   patchPhase = ''
@@ -28,7 +28,6 @@ in stdenv.mkDerivation {
 
   patches = [ ./recognize_nixos.patch ];
 
-  preConfigure = "autoreconf";
   configureFlags = "--without-kernel-modules --without-xmlsecurity";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/cloog-ppl/default.nix
+++ b/pkgs/development/libraries/cloog-ppl/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, ppl, autoconf, automake, libtool }:
+{ fetchurl, stdenv, ppl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "cloog-ppl-0.15.11";
@@ -10,19 +10,14 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ ppl ];
 
-  nativeBuildInputs = [ automake autoconf libtool ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   patches = [ ./fix-ppl-version.patch ];
 
   configureFlags = "--with-ppl=${ppl}";
 
-  preConfigure = ''
+  preAutoreconf = ''
     touch NEWS ChangeLog AUTHORS
-    ${libtool}/bin/libtoolize -c --force
-    ${automake}/bin/aclocal
-    ${automake}/bin/automake --add-missing
-    ${automake}/bin/automake -a -c --foreign
-    ${autoconf}/bin/autoreconf
   '';
 
   crossAttrs = {

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoconf, automake, libtool
+{ stdenv, fetchurl, pkgconfig, autoreconfHook
 , expat, systemd, glib, dbus_glib, python
 , libX11 ? null, libICE ? null, libSM ? null, x11Support ? (stdenv.isLinux || stdenv.isDarwin) }:
 
@@ -46,14 +46,15 @@ let
           done
         '';
 
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkgconfig autoreconfHook ];
     propagatedBuildInputs = [ expat ];
-    buildInputs = [ autoconf automake libtool ]; # ToDo: optional selinux?
+
+    preAutoreconf = ''
+      substituteInPlace tools/Makefile.am --replace 'install-localstatelibDATA:' 'disabled:'
+    '';
 
     preConfigure = ''
       patchShebangs .
-      substituteInPlace tools/Makefile.am --replace 'install-localstatelibDATA:' 'disabled:'
-      autoreconf -fi
     '';
 
     configureFlags = [

--- a/pkgs/development/libraries/dotconf/default.nix
+++ b/pkgs/development/libraries/dotconf/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, autoconf, automake, libtool }:
+{ fetchFromGitHub, stdenv, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "dotconf-" + version;
@@ -11,9 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sc95hw5k2xagpafny0v35filmcn05k1ds5ghkldfpf6xw4hakp7";
   };
 
-  buildInputs = [ autoconf automake libtool ];
-
-  preConfigure = "autoreconf --install";
+  buildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
     description = "A configuration parser library";

--- a/pkgs/development/libraries/funambol/default.nix
+++ b/pkgs/development/libraries/funambol/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, curl, automake, libtool, autoconf, unzip }:
+{ stdenv, fetchurl, zlib, curl, autoreconfHook, unzip }:
 
 stdenv.mkDerivation rec {
   name = "funambol-client-cpp-9.0.0";
@@ -10,17 +10,9 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''sourceRoot+="/sdk/cpp/build/autotools"'';
 
-  # Upstream guys forgotten to run autoreconf...
-  preConfigure=''
-    libtoolize -c -f
-    aclocal
-    autoheader
-    automake -a -c -f --add-missing
-    autoconf -f'';
-
   propagatedBuildInputs = [ zlib curl ];
 
-  nativeBuildInputs = [ automake libtool autoconf unzip ];
+  nativeBuildInputs = [ autoreconfHook unzip ];
 
   meta = {
     description = "SyncML client sdk by Funambol project";

--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, automake, autoconf, libtool, makeWrapper
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, makeWrapper
 , perl, libxml2, IOStringy }:
 
 stdenv.mkDerivation rec {
@@ -13,13 +13,9 @@ stdenv.mkDerivation rec {
   patches = [ ./hivex-syms.patch ];
 
   buildInputs = [
-    pkgconfig automake autoconf libtool makeWrapper
+    pkgconfig autoreconfHook makeWrapper
     perl libxml2 IOStringy
   ];
-
-  preConfigure = ''
-    AUTOPOINT=true autoreconf --verbose --install 
-  '';
 
   postInstall = ''
     for bin in $out/bin/*; do

--- a/pkgs/development/libraries/libgksu/default.nix
+++ b/pkgs/development/libraries/libgksu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, makeWrapper, gtk, gnome, gnome3,
-  libstartup_notification, libgtop, perl, perlXMLParser, autoconf,
-  automake, libtool, intltool, gtk_doc, docbook_xsl, xauth, sudo
+  libstartup_notification, libgtop, perl, perlXMLParser,
+  autoreconfHook, intltool, gtk_doc, docbook_xsl, xauth, sudo
 }:
 
 stdenv.mkDerivation rec {
@@ -52,13 +52,12 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     intltoolize --force --copy --automake
-    autoreconf -vfi
   '';
 
   buildInputs = [
     pkgconfig makeWrapper gtk gnome.GConf libstartup_notification
     gnome3.libgnome_keyring libgtop gnome.libglade perl perlXMLParser
-    autoconf automake libtool intltool gtk_doc docbook_xsl
+    autoreconfHook intltool gtk_doc docbook_xsl
   ];
 
   preFixup = ''

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoconf, automake, libtool, makeWrapper
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, makeWrapper
 , ncurses, cpio, gperf, perl, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex
 , gmp, readline, file, libintlperl, GetoptLong, SysVirt, numactl, xen }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    makeWrapper pkgconfig autoconf automake libtool ncurses cpio gperf perl
+    makeWrapper pkgconfig autoreconfHook ncurses cpio gperf perl
     cdrkit flex bison qemu pcre augeas libxml2 acl libcap libcap_ng libconfig
     systemd fuse yajl libvirt gmp readline file hivex libintlperl GetoptLong
     SysVirt numactl xen
@@ -27,10 +27,6 @@ stdenv.mkDerivation rec {
   configureFlags = "--disable-appliance --disable-daemon";
   patches = [ ./libguestfs-syms.patch ];
   NIX_CFLAGS_COMPILE="-I${libxml2}/include/libxml2/";
-
-  preConfigure = ''
-    AUTOPOINT=true LIBTOOLIZE=true autoreconf --verbose --install
-  '';
 
   postInstall = ''
     for bin in $out/bin/*; do

--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, file, protobufc }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, file, protobufc }:
 
 stdenv.mkDerivation rec {
   name = "libivykis-${version}";
@@ -10,9 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "11d7sjbhcll932rlvx9sf3vk60b5bazmjf4vlr4qd9cz0cashizz";
   };
 
-  buildInputs = [ autoconf automake libtool pkgconfig file protobufc ];
-
-  preConfigure = "autoreconf -i";
+  buildInputs = [ autoreconfHook pkgconfig file protobufc ];
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/development/libraries/libpst/default.nix
+++ b/pkgs/development/libraries/libpst/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, libtool, boost, python, libgsf,
+{ stdenv, fetchurl, autoreconfHook, boost, python, libgsf,
   pkgconfig, bzip2, xmlto, gettext, imagemagick, doxygen }:
 
 stdenv.mkDerivation rec {
@@ -9,12 +9,8 @@ stdenv.mkDerivation rec {
       sha256 = "0qih919zk40japs4mpiaw5vyr2bvwz60sjf23gixd5vvzc32cljz";
     };
 
-  buildInputs = [ autoconf automake libtool boost python libgsf pkgconfig bzip2
+  buildInputs = [ autoreconfHook boost python libgsf pkgconfig bzip2
 		  xmlto gettext imagemagick doxygen ];
-
-  preConfigure = ''
-    autoreconf -v -f -i
-  '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/librdf/default.nix
+++ b/pkgs/development/libraries/librdf/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, libtool, automake, autoconf
-, librdf_raptor, librdf_raptor2, ladspaH, openssl, zlib #, swh_lv2
+{ stdenv, fetchurl, pkgconfig, autoreconfHook
+, librdf_raptor2, ladspaH, openssl, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -11,18 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "18p2flb2sv2hq6w2qkd29z9c7knnwqr3f12i2srshlzx6vwkm05s";
   };
 
+  preAutoreconf = "rm m4/*";
   postPatch = "sed -i -e 's:usr/local:usr:' examples/{instances,remove}_test.c";
 
-  preConfigure = "rm m4/* && autoreconf -if";
-
-  buildInputs = [
-    pkgconfig libtool automake autoconf ladspaH openssl zlib /*swh_lv2*/
-    #librdf_raptor 
-  ];
+  buildInputs = [ pkgconfig autoreconfHook ladspaH openssl zlib ];
 
   propagatedBuildInputs = [ librdf_raptor2 ];
-
-  #doCheck = true; # would need swh_lv2 and some path patching
 
   meta = {
     description = "Lightweight RDF library with special support for LADSPA plugins";

--- a/pkgs/development/libraries/libtoxcore/new-api/default.nix
+++ b/pkgs/development/libraries/libtoxcore/new-api/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, libtool, automake, libsodium, ncurses, libopus
+{ stdenv, fetchFromGitHub, autoreconfHook, libsodium, ncurses, libopus
 , libvpx, check, libconfig, pkgconfig }:
 
 stdenv.mkDerivation rec {
@@ -22,10 +22,6 @@ stdenv.mkDerivation rec {
       auto_tests/tox_test.c
   '';
 
-  preConfigure = ''
-    autoreconf -i
-  '';
-
   configureFlags = [
     "--with-libsodium-headers=${libsodium}/include"
     "--with-libsodium-libs=${libsodium}/lib"
@@ -34,8 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    autoconf libtool automake libsodium ncurses
-    check libconfig pkgconfig
+    autoreconfHook libsodium ncurses check libconfig pkgconfig
   ] ++ stdenv.lib.optionals (!stdenv.isArm) [
     libopus
   ];

--- a/pkgs/development/libraries/libtoxcore/old-api/default.nix
+++ b/pkgs/development/libraries/libtoxcore/old-api/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, libtool, automake, libsodium, ncurses, libopus
+{ stdenv, fetchFromGitHub, autoreconfHook, libsodium, ncurses, libopus
 , libvpx, check, libconfig, pkgconfig }:
 
 let
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
       auto_tests/tox_test.c
   '';
 
-  preConfigure = ''
-    autoreconf -i
-  '';
-
   configureFlags = [
     "--with-libsodium-headers=${libsodium}/include"
     "--with-libsodium-libs=${libsodium}/lib"
@@ -38,7 +34,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    autoconf libtool automake libsodium ncurses
+    autoreconfHook libsodium ncurses
     check libconfig pkgconfig
   ] ++ stdenv.lib.optionals (!stdenv.isArm) [
     libopus

--- a/pkgs/development/libraries/minizip/default.nix
+++ b/pkgs/development/libraries/minizip/default.nix
@@ -1,14 +1,11 @@
-{ stdenv, zlib, autoconf, automake, libtool }:
+{ stdenv, zlib, autoreconfHook }:
 
 stdenv.mkDerivation {
   name = "minizip-${zlib.version}";
   inherit (zlib) src;
 
-  nativeBuildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ zlib ];
 
-  preConfigure = ''
-    cd contrib/minizip
-    autoreconf -vfi
-  '';
+  sourceRoot = "zlib-${zlib.version}/contrib/minizip";
 }

--- a/pkgs/development/libraries/pkcs11helper/default.nix
+++ b/pkgs/development/libraries/pkcs11helper/default.nix
@@ -1,20 +1,18 @@
-{ stdenv, fetchurl, pkgconfig, openssl, autoconf, automake, libtool }:
+{ stdenv, fetchurl, pkgconfig, openssl, autoreconfHook }:
 
 let
   rev = "5d412bad60";
 in
 stdenv.mkDerivation rec {
   name = "pkcs11-helper-20121123-${rev}";
-  
+
   src = fetchurl {
     url = "https://github.com/alonbl/pkcs11-helper/tarball/${rev}";
     name = "${name}.tar.gz";
     sha256 = "1mih6mha39yr5s5m18lg4854qc105asgnwmjw7f95kgmzni62kxp";
   };
 
-  preConfigure = "autoreconf -vfi";
-  
-  buildInputs = [ pkgconfig openssl autoconf automake libtool ];
+  buildInputs = [ pkgconfig openssl autoreconfHook ];
 
   meta = with stdenv.lib; {
     homepage = https://www.opensc-project.org/opensc/wiki/pkcs11-helper;

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, gtk, spice_protocol, intltool, celt_0_5_1
 , openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
-, cyrus_sasl, python, pygtk, autoconf, automake, libtool, usbredir, libsoup
+, cyrus_sasl, python, pygtk, autoreconfHook, usbredir, libsoup
 , gtk3, enableGTK3 ? false }:
 
 with stdenv.lib;
@@ -18,14 +18,16 @@ stdenv.mkDerivation rec {
     libjpeg_turbo zlib cyrus_sasl python pygtk usbredir
   ] ++ (if enableGTK3 then [ gtk3 ] else [ gtk ]);
 
-  nativeBuildInputs = [ pkgconfig intltool libtool libsoup autoconf automake ];
+  nativeBuildInputs = [ pkgconfig intltool libsoup autoreconfHook ];
 
   NIX_CFLAGS_COMPILE = "-fno-stack-protector";
 
-  preConfigure = ''
+  preAutoreconf = ''
     substituteInPlace src/Makefile.am \
-      --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0'
-    autoreconf -v --force --install
+          --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0'
+  '';
+
+  preConfigure = ''
     intltoolize -f
   '';
 

--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchsvn, autoconf, automake, libtool, pkgconfig, libogg }:
+{ stdenv, fetchsvn, autoreconfHook, pkgconfig, libogg }:
 
 stdenv.mkDerivation rec {
   name = "tremor-svn-${src.rev}";
-  
+
   src = fetchsvn {
     url = http://svn.xiph.org/trunk/Tremor;
     rev = "17866";
     sha256 = "161411cbefa1527da7a8fc087e78d8e21d19143d3a6eb42fb281e5026aad7568";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
   propagatedBuildInputs = [ libogg ];
 
   preConfigure = ''
-    autoreconf -vfi
     sed -i /XIPH_PATH_OGG/d configure
   '';
 

--- a/pkgs/games/rili/default.nix
+++ b/pkgs/games/rili/default.nix
@@ -1,8 +1,8 @@
-{stdenv, fetchurl, SDL_mixer, SDL, autoconf, automake}:
+{ stdenv, fetchurl, SDL_mixer, SDL, autoreconfHook }:
 
 stdenv.mkDerivation {
-  name = "ri_li-2.0.1"; 
-  
+  name = "ri_li-2.0.1";
+
   src = fetchurl {
     url = mirror://sourceforge/ri-li/Ri-li-2.0.1.tar.bz2;
     sha256 = "f71ccc20c37c601358d963e087ac0d524de8c68e96df09c3aac1ae65edd38dbd";
@@ -10,13 +10,10 @@ stdenv.mkDerivation {
 
   patches = [ ./moderinze_cpp.patch ];
 
-  preConfigure = ''
-    export CPPFLAGS="-I${SDL}/include -I${SDL}/include/SDL -I${SDL_mixer}/include"
-    autoreconf -i
-  '';
-  
-  buildInputs = [SDL SDL_mixer autoconf automake];
-  
+  CPPFLAGS = "-I${SDL}/include -I${SDL}/include/SDL -I${SDL_mixer}/include";
+
+  buildInputs = [ SDL SDL_mixer autoreconfHook ];
+
   meta = {
     homepage = http://ri-li.sourceforge.net;
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/misc/emulators/vice/default.nix
+++ b/pkgs/misc/emulators/vice/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchurl, perl, gettext, libpng, giflib, libjpeg, alsaLib, readline, mesa, libX11
-, pkgconfig, gtk, SDL, autoconf, automake, makeDesktopItem
+{ stdenv, fetchurl, perl, libpng, giflib, libjpeg, alsaLib, readline, mesa, libX11
+, pkgconfig, gtk, SDL, autoreconfHook, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
   name = "vice-2.2";
+
   src = fetchurl {
     url = http://www.zimmers.net/anonftp/pub/cbm/crossplatform/emulators/VICE/vice-2.2.tar.gz;
     sha256 = "0l8mp9ybx494fdqgr1ps4x3c3qzms4yyg4hzcn3ihzy92zw1nn2x";
   };
-  buildInputs = [ perl gettext libpng giflib libjpeg alsaLib readline mesa
-                  pkgconfig gtk SDL autoconf automake ];
+
+  buildInputs = [ perl libpng giflib libjpeg alsaLib readline mesa
+                  pkgconfig gtk SDL autoreconfHook ];
   configureFlags = "--with-sdl --enable-fullscreen --enable-gnomeui";
-  
+
   desktopItem = makeDesktopItem {
     name = "vice";
     exec = "x64";
@@ -23,18 +25,16 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     # Disable font-cache update
-    
     sed -i -e "s|install: install-data-am|install-no: install-data-am|" data/fonts/Makefile.am
-    autoreconf -f -i
   '';
-  
+
   NIX_LDFLAGS = "-lX11 -L${libX11}/lib";
-  
+
   postInstall = ''
     mkdir -p $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications
   '';
-  
+
   meta = {
     description = "Commodore 64, 128 and other emulators";
     homepage = http://www.viceteam.org;

--- a/pkgs/misc/screensavers/alock/default.nix
+++ b/pkgs/misc/screensavers/alock/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, autoconf, automake
+{ stdenv, fetchgit, pkgconfig, autoreconfHook
 , libX11, pam, libgcrypt, libXrender, imlib2 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "c1f00bf90c966b2b76e00061cc4b54a3c0bc6547e788731ab694b43f55a216ab";
   };
 
-  preConfigure = "autoreconf -fvi";
   configureFlags = [
     "--enable-pam"
     "--enable-hash"
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
     "--enable-imlib2"
   ];
   buildInputs = [
-    pkgconfig autoconf automake libX11
+    pkgconfig autoreconfHook libX11
     pam libgcrypt libXrender imlib2
   ];
 

--- a/pkgs/os-specific/linux/xf86-input-mtrack/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-mtrack/default.nix
@@ -1,34 +1,28 @@
 {
   stdenv
 , fetchurl
-, autoconf
-, automake
 , utilmacros
 , pkgconfig
-, libtool
 , mtdev
 , xorgserver
 , xproto
 , inputproto
 , pixman
+, autoreconfHook
 }:
 
 stdenv.mkDerivation {
   name = "xf86-input-mtrack-0.3.0";
 
-  preConfigure = "autoreconf -vfi";
-
   buildInputs = [
-    autoconf
-    automake
     utilmacros
     pkgconfig
-    libtool
     mtdev
     xorgserver
     xproto
     inputproto
     pixman
+    autoreconfHook
   ];
 
   CFLAGS = "-I${pixman}/include/pixman-1";

--- a/pkgs/os-specific/linux/xf86-video-nested/default.nix
+++ b/pkgs/os-specific/linux/xf86-video-nested/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchgit, autoconf, automake, fontsproto, libX11, libXext
-, libtool, pixman, pkgconfig, renderproto, utilmacros, xorgserver
+{ stdenv, fetchgit, autoreconfHook, fontsproto, libX11, libXext
+, pixman, pkgconfig, renderproto, utilmacros, xorgserver
 }:
 
 stdenv.mkDerivation {
@@ -12,13 +12,12 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ autoconf automake fontsproto libX11 libXext libtool pixman
+    [ autoreconfHook fontsproto libX11 libXext pixman
       pkgconfig renderproto utilmacros xorgserver
     ];
 
 
   configurePhase = ''
-    autoreconf -fvi
     ./configure --prefix=$out CFLAGS="-I${pixman}/include/pixman-1"
   '';
 

--- a/pkgs/servers/nosql/hyperdex/busybee.nix
+++ b/pkgs/servers/nosql/hyperdex/busybee.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchurl, unzip, autoconf, automake, libtool,
-  libpo6, libe, pkgconfig }:
+{ stdenv, fetchurl, unzip, autoreconfHook, libpo6, libe, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "busybee-${version}";
@@ -9,16 +8,14 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rescrv/busybee/archive/releases/${version}.zip";
     sha256 = "0b51h1kmkf0s3d9y7wjqgp1pk1rk9i7n8bcgyj01kflzdgafbl0b";
   };
+
   buildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     libe
     libpo6
-    libtool
     pkgconfig
     unzip
   ];
-  preConfigure = "autoreconf -i";
 
   meta = with stdenv.lib; {
     description = "A high-performance messaging layer";

--- a/pkgs/servers/nosql/hyperdex/default.nix
+++ b/pkgs/servers/nosql/hyperdex/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, makeWrapper, unzip, autoconf, automake, libtool,
-  python, libsodium, pkgconfig, popt, glog, xz, json_c, gperf, yacc,
-  flex, pandoc, help2man, autoconf-archive, callPackage }:
+{ stdenv, fetchurl, makeWrapper, unzip, autoreconfHook, autoconf-archive
+, python, libsodium, pkgconfig, popt, glog, xz, json_c, gperf, yacc
+, flex, pandoc, help2man, callPackage }:
 
 assert stdenv.isLinux;
 
@@ -25,9 +25,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    autoconf
+    autoreconfHook
     autoconf-archive
-    automake
     busybee
     glog
     hyperleveldb
@@ -35,7 +34,6 @@ stdenv.mkDerivation rec {
     libe
     libmacaroons
     libpo6
-    libtool
     pkgconfig
     popt
     python
@@ -47,7 +45,6 @@ stdenv.mkDerivation rec {
     help2man
     pandoc
   ];
-  preConfigure = "autoreconf -fi";
 
   meta = with stdenv.lib; {
     description = "A scalable, searchable key-value store";

--- a/pkgs/servers/nosql/hyperdex/hyperleveldb.nix
+++ b/pkgs/servers/nosql/hyperdex/hyperleveldb.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, autoconf, automake, libtool }:
+{ stdenv, fetchurl, unzip, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "hyperleveldb-${version}";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rescrv/HyperLevelDB/archive/releases/${version}.zip";
     sha256 = "0m5fwl9sc7c6m2zm3zjlxxg7f602gnaryikxgflahhdccdvvr56y";
   };
-  buildInputs = [ unzip autoconf automake libtool ];
-  preConfigure = "autoreconf -i";
+
+  buildInputs = [ unzip autoreconfHook ];
 
   meta = with stdenv.lib; {
     description = ''A fork of LevelDB intended to meet the needs of

--- a/pkgs/servers/nosql/hyperdex/libe.nix
+++ b/pkgs/servers/nosql/hyperdex/libe.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, autoconf, automake, libtool, libpo6, pkgconfig }:
+{ stdenv, fetchurl, unzip, autoreconfHook, libpo6, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "libe-${version}";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rescrv/e/archive/releases/${version}.zip";
     sha256 = "18xm0hcnqdf0ipfn19jrgzqsxij5xjbbnihhzc57n4v7yfdca1w3";
   };
-  buildInputs = [ unzip autoconf automake libtool libpo6 pkgconfig ];
-  preConfigure = "autoreconf -i";
+
+  buildInputs = [ unzip autoreconfHook libpo6 pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "Library containing high-performance datastructures and utilities for C++";

--- a/pkgs/servers/nosql/hyperdex/libmacaroons.nix
+++ b/pkgs/servers/nosql/hyperdex/libmacaroons.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, unzip, autoconf, automake, libtool, 
-  pkgconfig, libsodium, python }:
+{ stdenv, fetchurl, unzip, autoreconfHook, pkgconfig, libsodium, python }:
+
 stdenv.mkDerivation rec {
   name = "libmacaroons-${version}";
   version = "0.3.0";
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rescrv/libmacaroons/archive/releases/${version}.zip";
     sha256 = "18c44424jri0p5la6jgrnlz5p937hk7ws2mldhzjwisqyf5qld43";
   };
-  buildInputs = [ unzip autoconf automake libtool python libsodium pkgconfig ];
-  preConfigure = "autoreconf -i";
-  
+
+  buildInputs = [ unzip autoreconfHook python libsodium pkgconfig ];
+
   meta = with stdenv.lib; {
     description = ''Macaroons are flexible authorization credentials that
         support decentralized delegation, attenuation, and verification.'';

--- a/pkgs/servers/nosql/hyperdex/libpo6.nix
+++ b/pkgs/servers/nosql/hyperdex/libpo6.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, autoconf, automake, libtool }:
+{ stdenv, fetchurl, unzip, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "libpo6-${version}";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rescrv/po6/archive/releases/${version}.zip";
     sha256 = "17grzkh6aw1f68qvkhivbb6vwbm6jd41ysbfn88pypf5lczxrxly";
   };
-  buildInputs = [ unzip autoconf automake libtool ];
-  preConfigure = "autoreconf -i";
+
+  buildInputs = [ unzip autoreconfHook ];
 
   meta = with stdenv.lib; {
     description = "POSIX wrappers for C++";

--- a/pkgs/servers/nosql/hyperdex/replicant.nix
+++ b/pkgs/servers/nosql/hyperdex/replicant.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, autoconf, automake, libtool, glog,
+{ stdenv, fetchurl, unzip, autoreconfHook, glog,
   hyperleveldb, libe, pkgconfig, popt, libpo6, busybee }:
 
 stdenv.mkDerivation rec {
@@ -9,21 +9,19 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rescrv/Replicant/archive/releases/${version}.zip";
     sha256 = "1q3pdq2ndpj70yd1578bn4grlrp77gl8hv2fz34jpx34qmlalda4";
   };
+
   buildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     busybee
     glog
     hyperleveldb
     libe
     libpo6
-    libtool
     pkgconfig
     popt
     unzip
   ];
-  preConfigure = "autoreconf -i";
-  
+
   meta = with stdenv.lib; {
     description = "A system for maintaining replicated state machines";
     homepage = https://github.com/rescrv/Replicant;

--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pam, openssl, openssh, shadow, makeWrapper }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pam, openssl, openssh, shadow, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "2.19";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./shellinabox-minus.patch ];
 
-  buildInputs = [ autoconf automake libtool pam openssl openssh makeWrapper];
+  buildInputs = [ autoreconfHook pam openssl openssh makeWrapper ];
 
   # Disable GSSAPIAuthentication errors. Also, paths in certain source files are
   # hardcoded. Replace the hardcoded paths with correct paths.
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
     substituteInPlace ./shellinabox/service.c --replace "/bin/login" "${shadow}/bin/login"
     substituteInPlace ./shellinabox/launcher.c --replace "/bin/login" "${shadow}/bin/login"
     substituteInPlace ./libhttp/ssl.c --replace "/usr/bin" "${openssl}/bin"
-    autoreconf -vfi
   '';
 
   postInstall = ''

--- a/pkgs/tools/archivers/runzip/default.nix
+++ b/pkgs/tools/archivers/runzip/default.nix
@@ -1,21 +1,20 @@
-{stdenv, fetchFromGitHub, libzip, autoconf, automake, libtool, m4}:
+{ stdenv, fetchFromGitHub, libzip, autoreconfHook }:
+
 stdenv.mkDerivation rec {
-  baseName = "runzip";
   version = "1.4";
-  name = "${baseName}-${version}";
-  buildInputs = [libzip autoconf automake libtool m4];
+  name = "runzip-${version}";
+
+  buildInputs = [ libzip autoreconfHook ];
+
   src = fetchFromGitHub {
     owner = "vlm";
     repo = "zip-fix-filename-encoding";
     rev = "v${version}";
     sha256 = "0l5zbb5hswxczigvyal877j0aiq3fc01j3gv88bvy7ikyvw3lc07";
   };
-  preConfigure = ''
-    autoreconf -iv
-  '';
+
   meta = {
-    inherit version;
-    description = ''A tool to convert filename encoding inside a ZIP archive'';
+    description = "A tool to convert filename encoding inside a ZIP archive";
     license = stdenv.lib.licenses.bsd2 ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, autoconf, automake, texinfo, buggyBiosCDSupport ? true}:
+{stdenv, fetchurl, autoreconfHook, texinfo, buggyBiosCDSupport ? true}:
 
 stdenv.mkDerivation {
   name = "grub-0.97-patch-1.12";
@@ -33,8 +33,8 @@ stdenv.mkDerivation {
 
   ] ++ (stdenv.lib.optional buggyBiosCDSupport ./buggybios.patch);
 
-  # Autoconf/automake required for the splashimage patch.
-  buildInputs = [autoconf automake texinfo];
+  # autoreconfHook required for the splashimage patch.
+  buildInputs = [ autoreconfHook texinfo ];
 
   prePatch = ''
     unpackFile $gentooPatches
@@ -43,11 +43,6 @@ stdenv.mkDerivation {
       echo "applying patch $i"
       patch -p1 < $i || patch -p0 < $i
     done
-  '';
-
-  preConfigure = ''
-    autoreconf
-    automake --add-missing
   '';
 
   passthru.grubTarget = "";

--- a/pkgs/tools/misc/mdbtools/git.nix
+++ b/pkgs/tools/misc/mdbtools/git.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchurl, fetchgit, glib, readline, bison, flex, pkgconfig,
-  libiconv, autoconf, automake, libtool, which, txt2man, gnome_doc_utils,
-  scrollkeeper}:
+{ stdenv, fetchgit, glib, readline, bison, flex, pkgconfig,
+  libiconv, autoreconfHook, which, txt2man, gnome_doc_utils, scrollkeeper }:
 
 stdenv.mkDerivation {
   name = "mdbtools-git-2014-07-25";
@@ -12,16 +11,18 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    glib readline bison flex pkgconfig autoconf automake
-    libtool which txt2man gnome_doc_utils scrollkeeper libiconv
+    glib readline bison flex autoreconfHook pkgconfig which txt2man
+    gnome_doc_utils scrollkeeper libiconv
   ];
+
+  preAutoreconf = ''
+    sed -e '/ENABLE_GTK_DOC/aAM_CONDITIONAL(HAVE_GNOME_DOC_UTILS, test x$enable_gtk_doc = xyes)' \
+        -e  '/ENABLE_GTK_DOC/aAM_CONDITIONAL(ENABLE_SK, test x$enable_scrollkeeper = xyes)' \
+        -i configure.ac
+  '';
 
   preConfigure = ''
     sed -e 's@static \(GHashTable [*]mdb_backends;\)@\1@' -i src/libmdb/backend.c
-    sed -e '/ENABLE_GTK_DOC/aAM_CONDITIONAL(HAVE_GNOME_DOC_UTILS, test x$enable_gtk_doc = xyes)' \
-    -e  '/ENABLE_GTK_DOC/aAM_CONDITIONAL(ENABLE_SK, test x$enable_scrollkeeper = xyes)'          \
-    -i configure.ac
-    autoreconf -i -f
   '';
 
   meta = {

--- a/pkgs/tools/misc/riemann-c-client/default.nix
+++ b/pkgs/tools/misc/riemann-c-client/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, file
-, protobufc }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, file , protobufc }:
 
 stdenv.mkDerivation rec {
   name = "riemann-c-client-${version}";
@@ -13,9 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jc2bbw7sp2gr4cswx78srs0p1kp81prcarq4ivqpfw4bmzg6xg4";
   };
 
-  buildInputs = [ autoconf automake libtool pkgconfig file protobufc ];
-
-  preConfigure = "autoreconf -i";
+  buildInputs = [ autoreconfHook pkgconfig file protobufc ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/algernon/riemann-c-client;

--- a/pkgs/tools/misc/xclip/default.nix
+++ b/pkgs/tools/misc/xclip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, xlibsWrapper, libXmu, autoconf, automake, libtool }:
+{ stdenv, fetchsvn, xlibsWrapper, libXmu, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   # The last release from 2012, 0.12, lacks '-targets'
@@ -9,11 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0d6r38xas5l79l700sdm14l41vvjqhah613367ha8kcvx54zkddz";
   };
 
-  preConfigure = "autoreconf -vfi";
+  buildInputs = [ xlibsWrapper libXmu autoreconfHook ];
 
-  buildInputs = [ xlibsWrapper libXmu autoconf automake libtool ];
-
-  meta = { 
+  meta = {
     description = "Tool to access the X clipboard from a console application";
     homepage = http://sourceforge.net/projects/xclip/;
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/tools/networking/biosdevname/default.nix
+++ b/pkgs/tools/networking/biosdevname/default.nix
@@ -1,10 +1,9 @@
-{stdenv, fetchgit, automake, autoconf, zlib, pciutils}:
-let
-  version = "0.6.1";
-in
-stdenv.mkDerivation {
+{ stdenv, fetchgit, autoreconfHook, zlib, pciutils }:
+
+stdenv.mkDerivation rec {
   name = "biosdevname-${version}";
-  
+  version = "0.6.1";
+
   src = fetchgit {
     url = git://linux.dell.com/biosdevname.git;
     rev = "refs/tags/v${version}";
@@ -12,15 +11,10 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    automake
-    autoconf
+    autoreconfHook
     zlib
     pciutils
   ];
-
-  preConfigure = ''
-    autoreconf -i
-  '';
 
   # Don't install /lib/udev/rules.d/*-biosdevname.rules
   patches = [ ./makefile.patch ];

--- a/pkgs/tools/networking/driftnet/default.nix
+++ b/pkgs/tools/networking/driftnet/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, autoconf, automake, libpcap, libjpeg, libungif, libpng, giflib, glib, gtk2, cairo, pango, gdk_pixbuf, atk, pkgconfig }:
+{ stdenv, lib, fetchFromGitHub, libpcap, libjpeg , libungif, libpng
+, giflib, glib, gtk2, cairo, pango, gdk_pixbuf, atk
+, pkgconfig, autoreconfHook }:
 
 with lib;
 
@@ -6,9 +8,10 @@ stdenv.mkDerivation rec {
   name = "driftnet-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "8d47fd563a06122d4a6f9b9b9d27ba3d635148c0";
 
-  buildInputs = [ autoconf automake pkgconfig libpcap libjpeg libungif libpng giflib glib gtk2 glib cairo pango gdk_pixbuf atk ];
-
-  preConfigure = "autoreconf -fi";
+  buildInputs = [
+    pkgconfig libpcap libjpeg libungif libpng giflib
+    glib gtk2 glib cairo pango gdk_pixbuf atk autoreconfHook
+  ];
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, sqlite, pkgconfig, autoconf, automake
+{ fetchurl, stdenv, sqlite, pkgconfig, autoreconfHook
 , xapian, glib, gmime, texinfo , emacs, guile
 , gtk3, webkit, libsoup, icu, withMug ? false /* doesn't build with current gtk3 */ }:
 
@@ -11,14 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0wj33pma8xgjvn2akk7khzbycwn4c9sshxvzdph9dnpy7gyqxj51";
   };
 
-  buildInputs =
-    [ sqlite pkgconfig autoconf automake xapian
-      glib gmime texinfo emacs guile libsoup icu ]
-    ++ stdenv.lib.optionals withMug [ gtk3 webkit ];
-
-  preConfigure = ''
-    autoreconf -i
-  '';
+  buildInputs = [
+    sqlite pkgconfig xapian glib gmime texinfo emacs guile libsoup icu
+    autoreconfHook
+  ] ++ stdenv.lib.optionals withMug [ gtk3 webkit ];
 
   preBuild = ''
     # Fix mu4e-builddir (set it to $out)

--- a/pkgs/tools/networking/par2cmdline/default.nix
+++ b/pkgs/tools/networking/par2cmdline/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip, autoconf, automake}:
+{ stdenv, fetchzip, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name    = "par2cmdline-${version}";
@@ -9,9 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0maywssv468ia7rf8jyq4axwahgli3nfykl7x3zip503psywjj8a";
   };
 
-  buildInputs = [ autoconf automake ];
-
-  preConfigure = "autoreconf";
+  buildInputs = [ autoreconfHook ];
 
   meta = {
     homepage = https://github.com/BlackIkeEagle/par2cmdline;

--- a/pkgs/tools/text/recode/default.nix
+++ b/pkgs/tools/text/recode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python, perl, autoconf, automake, libtool, intltool, flex,
+{ stdenv, fetchFromGitHub, python, perl, intltool, flex, autoreconfHook,
 texinfo, libiconv }:
 
 stdenv.mkDerivation rec {
@@ -11,17 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "06vyjqaraamcc5vka66mlvxj27ihccqc74aymv2wn8nphr2rhh03";
   };
 
-  nativeBuildInputs = [ python perl autoconf automake libtool intltool flex texinfo
-  libiconv ];
+  nativeBuildInputs = [ python perl intltool flex texinfo autoreconfHook libiconv ];
 
-  preConfigure = ''
+  preAutoreconf = ''
     # fix build with new automake, https://bugs.gentoo.org/show_bug.cgi?id=419455
-    #rm acinclude.m4
     substituteInPlace Makefile.am --replace "ACLOCAL = ./aclocal.sh @ACLOCAL@" ""
     sed -i '/^AM_C_PROTOTYPES/d' configure.ac
     substituteInPlace src/Makefile.am --replace "ansi2knr" ""
-
-    autoreconf -fi
   ''
   + stdenv.lib.optionalString stdenv.isDarwin ''
     export LDFLAGS=-lintl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1754,7 +1754,6 @@ let
 
   grub = callPackage_i686 ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
-    automake = automake112x; # fails with 13 and 14
   };
 
   trustedGrub = callPackage_i686 ../tools/misc/grub/trusted.nix { };
@@ -2639,9 +2638,7 @@ let
 
   paper-gtk-theme = callPackage ../misc/themes/gtk3/paper-gtk-theme { };
 
-  par2cmdline = callPackage ../tools/networking/par2cmdline {
-    automake = automake112x; # fails with 14
-  };
+  par2cmdline = callPackage ../tools/networking/par2cmdline { };
 
   parallel = callPackage ../tools/misc/parallel { };
 
@@ -13022,9 +13019,7 @@ let
 
   rkt = callPackage ../applications/virtualization/rkt { };
 
-  rofi = callPackage ../applications/misc/rofi {
-    automake = automake114x;
-  };
+  rofi = callPackage ../applications/misc/rofi { };
 
   rofi-pass = callPackage ../tools/security/pass/rofi-pass.nix { };
 


### PR DESCRIPTION
This refactors most occurrences of `autoreconf` or similar to use the autoreconfHook which is specifically designed for these use cases.

(targeted at staging because of a major rebuild, technically not a mass-rebuild, but quite a lot)
