### PR TITLE
Renamed subdirectories in Android SKD's build-tools

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -219,7 +219,7 @@ stdenv.mkDerivation rec {
         fi
     done
 
-    for i in $out/libexec/android-sdk-*/build-tools/android-*/*
+    for i in $out/libexec/android-sdk-*/build-tools/*/*
     do
         if [ ! -d $i ] && [ -x $i ]
         then

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -18,10 +18,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/build-tools
     cd $out/build-tools
     unzip $src
+    mv android-* ${version}
     
     ${stdenv.lib.optionalString (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
       ''
-        cd android-*
+        cd ${version}
         
         # Patch the interpreter
         for i in aapt aidl bcc_compat dexdump llvm-rs-cc


### PR DESCRIPTION
Nix unzips the different components of the Android SDK one by one.
It followed the directory structure of complete packages released for
mainstream OS but the names of the directories in build-tools doesn't
match those.
As a result, some programs assuming the usual directory structure and
naming conventions broke (in my case it is a gradle plugin).
This is a fix. It may introduce a regression if some programs rely on
the current behavior.
