### PR TITLE
Make /var/lib/postfix world-readable

### DIFF
--- a/pkgs/servers/mail/postfix/3.0.nix
+++ b/pkgs/servers/mail/postfix/3.0.nix
@@ -35,10 +35,14 @@ in stdenv.mkDerivation rec {
                 ++ lib.optional withMySQL libmysql
                 ++ lib.optional withSQLite sqlite;
 
-  patches = [ ./postfix-script-shell.patch ./postfix-3.0-no-warnings.patch ];
+  patches = [ ./postfix-script-shell.patch ./postfix-3.0-no-warnings.patch ./post-install-script.patch ];
 
   preBuild = ''
     sed -e '/^PATH=/d' -i postfix-install
+    sed -e "s|@PACKAGE@|$out|" -i conf/post-install
+
+    # post-install need skip permissions check/set on all symlinks following to /nix/store
+    sed -e "s|@NIX_STORE@|$NIX_STORE|" -i conf/post-install
 
     export command_directory=$out/sbin
     export config_directory=/etc/postfix

--- a/pkgs/servers/mail/postfix/post-install-script.patch
+++ b/pkgs/servers/mail/postfix/post-install-script.patch
@@ -1,0 +1,28 @@
+--- a/conf/post-install	1970-01-01 03:00:01.000000000 +0300
++++ b/conf/post-install	2016-01-20 13:25:18.382233172 +0200
+@@ -254,6 +254,8 @@
+ }
+ 
+ # Bootstrapping problem.
++meta_directory="@PACKAGE@/etc/postfix"
++command_directory="@PACKAGE@/bin"
+ 
+ if [ -n "$command_directory" ]
+ then
+@@ -528,7 +530,16 @@
+ 	    # Skip uninstalled files.
+ 	    case $path in
+ 	    no|no/*) continue;;
++        # Skip immutable files from package, correct permissions provided by Nix.
++        @PACKAGE@/*) continue;
+ 	    esac
++        # Also skip symlinks following to /nix/store
++        if test -L $path; then
++            case "$(readlink $path)" in
++                @NIX_STORE@/*) continue;
++            esac
++        fi
++
+ 	    # Pick up the flags.
+ 	    case $flags in *u*) upgrade_flag=1;; *) upgrade_flag=;; esac
+ 	    case $flags in *c*) create_flag=1;; *) create_flag=;; esac


### PR DESCRIPTION
It not affect queue stuff in /var/lib/postix/queue, but allow
`sendmail` wrapper to read /var/lib/postix/conf, fixing
`sendmail: fatal: open /etc/postfix/main.cf: Permission denied`
(/etc/postfix is symlink to /var/lib/postix/conf)
