### PR TITLE
i3 service: added i3status and dmenu dependency

### DIFF
--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -34,6 +34,6 @@ in
         '';
       }];
     };
-    environment.systemPackages = [ pkgs.i3 ];
+    environment.systemPackages = with pkgs; [ i3 i3status dmenu ];
   };
 }


### PR DESCRIPTION
Improve default i3 experience by adding system packages:
- `i3status` to prevent `Error: status_command not found or is missing a library dependency (exit 127)` to be displayed in i3bar.
- `dmenu` as it is a default shortcut (`Mod1+d`)
