### PR TITLE
fetchurl: support executables

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -45,6 +45,11 @@ tryDownload() {
 
 finish() {
     set +o noglob
+
+    if [[ $executable == "1" ]]; then
+      chmod +x $downloadedFile
+    fi
+
     runHook postFetch
     stopNest
     exit 0

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -73,6 +73,9 @@ in
   # is communicated to postFetch via $downloadedFile.
   downloadToTemp ? false
 
+, # If true, set executable bit on downloaded file
+  executable ? false
+
 , # If set, don't download the file, but write a list of all possible
   # URLs (resulting from resolving mirror:// URLs) to $out.
   showURLs ? false
@@ -116,9 +119,9 @@ if (!hasHash) then throw "Specify hash for fetchurl fixed-output derivation: ${s
   outputHash = if outputHash != "" then outputHash else
       if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
 
-  outputHashMode = if recursiveHash then "recursive" else "flat";
+  outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 
-  inherit curlOpts showURLs mirrorsFile impureEnvVars postFetch downloadToTemp;
+  inherit curlOpts showURLs mirrorsFile impureEnvVars postFetch downloadToTemp executable;
 
   # Doing the download on a remote machine just duplicates network
   # traffic, so don't do that.


### PR DESCRIPTION
Example:

```
pkgs.fetchurl {
   url = "https://raw.githubusercontent.com/SnabbCo/snabbswitch/681129bb42de87eba957d947f6ee7a1d387f6a6d/src/scripts/snabb_bot.sh";
   sha256 = "0jhzqdmqdcmi9kk3vp6lx48d8pm8ai3g95a255lhdlnw7n3886nz";
   executable = true;
}
```
