### PR TITLE
kde5.konversation: init at 1.6

### DIFF
--- a/pkgs/applications/networking/irc/konversation/1.6.nix
+++ b/pkgs/applications/networking/irc/konversation/1.6.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, lib
+, fetchurl
+, cmake
+, extra-cmake-modules
+, kbookmarks
+, karchive
+, kconfig
+, kconfigwidgets
+, kcoreaddons
+, kdbusaddons
+, kdoctools
+, kemoticons
+, kglobalaccel
+, ki18n
+, kiconthemes
+, kidletime
+, kitemviews
+, knotifications
+, knotifyconfig
+, kio
+, kparts
+, kwallet
+, makeQtWrapper
+, solid
+, sonnet
+, phonon}:
+
+let
+  pn = "konversation";
+  v = "1.6";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pn}-${v}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pn}/${v}/src/${name}.tar.xz";
+    sha256 = "789fd75644bf54606778971310433dbe2bc01ac0917b34bc4e8cac88e204d5b6";
+  };
+
+  buildInputs = [
+    cmake
+    extra-cmake-modules
+    kbookmarks
+    karchive
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kdbusaddons
+    kdoctools
+    kemoticons
+    kglobalaccel
+    ki18n
+    kiconthemes
+    kidletime
+    kitemviews
+    knotifications
+    knotifyconfig
+    kio
+    kparts
+    kwallet
+    solid
+    sonnet
+    phonon
+  ];
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/konversation"
+  '';
+
+  meta = {
+    description = "Integrated IRC client for KDE";
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ fridh ];
+    homepage = https://konversation.kde.org;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14739,6 +14739,9 @@ let
 
     k9copy = callPackage ../applications/video/k9copy {};
 
+    konversation = callPackage ../applications/networking/irc/konversation/1.6.nix {
+    };
+
     quassel = callPackage ../applications/networking/irc/quassel/qt-5.nix {
       monolithic = true;
       daemon = false;


### PR DESCRIPTION
Currently we have `pkgs.kde4.konversation` which is version 1.5 of
Konversation.
This adds `pkgs.konversation_1_6` which is version 1.6 and builds
against the latest KDE Frameworks.
