### PR TITLE
Replace /usr/bin/env with env-friendly

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -131,7 +131,7 @@ in
     system.activationScripts.usrbinenv =
       ''
         mkdir -m 0755 -p /usr/bin
-        ln -sfn ${pkgs.coreutils}/bin/env /usr/bin/.env.tmp
+        ln -sfn ${pkgs.env-friendly}/bin/env /usr/bin/.env.tmp
         mv /usr/bin/.env.tmp /usr/bin/env # atomically replace /usr/bin/env
       '';
 

--- a/pkgs/misc/env-friendly/Makefile
+++ b/pkgs/misc/env-friendly/Makefile
@@ -1,0 +1,3 @@
+all: env
+install: env
+	install -D env $(out)/bin/env

--- a/pkgs/misc/env-friendly/default.nix
+++ b/pkgs/misc/env-friendly/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, musl, ... }:
+stdenv.mkDerivation {
+  name = "env-friendly-1.0.0";
+
+  unpackPhase = ''
+    cp -v ${./Makefile} Makefile
+    cp -v ${./env.c} env.c
+  '';
+
+  CFLAGS = "-isystem ${musl}/include -B${musl}/lib -L${musl}/lib";
+  LDFLAGS = "-static -Wl,--gc-sections";
+
+  meta = with stdenv.lib; {
+    description = "An environmentally friendly replacement for /usr/bin/env";
+    license = licenses.cc0;
+    maintainers = [ "Nathan Zadoks <nathan@nathan7.eu>" ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/misc/env-friendly/env.c
+++ b/pkgs/misc/env-friendly/env.c
@@ -1,0 +1,15 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "%s: no command specified\n", argv[0]);
+    exit(-1);
+  }
+  execvp(argv[1], &argv[1]);
+  char* err = strerror(errno);
+  fprintf(stderr, "%s: %s: %s", argv[0], argv[1], err);
+  exit(127);
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -861,6 +861,8 @@ let
 
   ent = callPackage ../tools/misc/ent { };
 
+  env-friendly = callPackage ../misc/env-friendly {};
+
   facter = callPackage ../tools/system/facter {};
 
   fasd = callPackage ../tools/misc/fasd { };


### PR DESCRIPTION
`/usr/bin/env` never ends up in PATH, and is only used for shebang lines, which permit passing only a single argument (the executable) to env, and definitely don't require full GNU coreutils `env(1)`.
This replaces it with a minimal, small (21K) statically-linked binary.

(I expect this change to be somewhat controversial, but I'd rather have the discussion around a PR with actual working code, so here it is)
