### PR TITLE
glib: fix compilation on SmartOS/Illumos

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -68,11 +68,16 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     optional stdenv.isDarwin "--disable-compile-warnings"
-    ++ optional stdenv.isFreeBSD "--with-libiconv=gnu"
-    ++ optional stdenv.isSunOS ["--disable-modular-tests" "--with-libiconv"];
+    ++ optional (stdenv.isFreeBSD || stdenv.isSunOS) "--with-libiconv=gnu"
+    ++ optional stdenv.isSunOS "--disable-dtrace";
 
   NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin " -lintl"
     + optionalString stdenv.isSunOS " -DBSD_COMP";
+
+  preConfigure = optionalString stdenv.isSunOS
+    ''
+      sed -i -e 's|inotify.h|foobar-inotify.h|g' configure
+    '';
 
   preBuild = optionalString stdenv.isDarwin
     ''


### PR DESCRIPTION
Recent illumos includes a linux-incompatible `inotify.h` header, which configure detects: compilation fails.
Also, a newer `dtrace` on SmartOS fails creating the probes ELF linkable object (with `dtrace -G`). Disable for now.

Remove old configure option `--disable-modular-tests`.
