### PR TITLE
activation-script module: add environment.usrbinenv option

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -94,6 +94,18 @@ in
 
     };
 
+    environment.usrbinenv = mkOption {
+      default = "${pkgs.coreutils}/bin/env";
+      example = literalExample ''
+        "''${pkgs.busybox}/bin/env"
+      '';
+      type = types.nullOr types.path;
+      visible = false;
+      description = ''
+        The env(1) executable that is linked system-wide to
+        <literal>/usr/bin/env</literal>.
+      '';
+    };
   };
 
 
@@ -128,11 +140,15 @@ in
         mkdir -m 0555 -p /var/empty
       '';
 
-    system.activationScripts.usrbinenv =
-      ''
+    system.activationScripts.usrbinenv = if config.environment.usrbinenv != null
+      then ''
         mkdir -m 0755 -p /usr/bin
-        ln -sfn ${pkgs.coreutils}/bin/env /usr/bin/.env.tmp
+        ln -sfn ${config.environment.usrbinenv} /usr/bin/.env.tmp
         mv /usr/bin/.env.tmp /usr/bin/env # atomically replace /usr/bin/env
+      ''
+      else ''
+        rm -f /usr/bin/env
+        rmdir --ignore-fail-on-non-empty /usr/bin /usr
       '';
 
     system.activationScripts.tmpfs =


### PR DESCRIPTION
Step 1 of https://github.com/NixOS/nixpkgs/pull/12474#issuecomment-172913145.
I based this on [`environment.binsh`](https://github.com/NixOS/nixpkgs/blob/e67717bc8d545c593f974163a8a496f5f898b73d/nixos/modules/config/shells-environment.nix#L120-L134)
Bikesheds before we merge this:
- Is this a reasonable option name?
- Should it be `visible = false`? (I copied that from `binsh`)
- Should it carry a warning too, like `binsh`?
