### PR TITLE
linux: patch CVE-2016-0728 [security, local privilege escalation]

### DIFF
--- a/pkgs/os-specific/linux/kernel/cve-2016-0728.patch
+++ b/pkgs/os-specific/linux/kernel/cve-2016-0728.patch
@@ -1,0 +1,78 @@
+From 05fd13592b60c3e9873f56705f80ff934e98b046 Mon Sep 17 00:00:00 2001
+From: David Howells <dhowells@redhat.com>
+Date: Mon, 18 Jan 2016 10:53:31 +0000
+Subject: [PATCH] KEYS: Fix keyring ref leak in join_session_keyring()
+
+This fixes CVE-2016-0728.
+
+If a thread is asked to join as a session keyring the keyring that's already
+set as its session, we leak a keyring reference.
+
+This can be tested with the following program:
+
+	#include <stddef.h>
+	#include <stdio.h>
+	#include <sys/types.h>
+	#include <keyutils.h>
+
+	int main(int argc, const char *argv[])
+	{
+		int i = 0;
+		key_serial_t serial;
+
+		serial = keyctl(KEYCTL_JOIN_SESSION_KEYRING,
+				"leaked-keyring");
+		if (serial < 0) {
+			perror("keyctl");
+			return -1;
+		}
+
+		if (keyctl(KEYCTL_SETPERM, serial,
+			   KEY_POS_ALL | KEY_USR_ALL) < 0) {
+			perror("keyctl");
+			return -1;
+		}
+
+		for (i = 0; i < 100; i++) {
+			serial = keyctl(KEYCTL_JOIN_SESSION_KEYRING,
+					"leaked-keyring");
+			if (serial < 0) {
+				perror("keyctl");
+				return -1;
+			}
+		}
+
+		return 0;
+	}
+
+If, after the program has run, there something like the following line in
+/proc/keys:
+
+3f3d898f I--Q---   100 perm 3f3f0000     0     0 keyring   leaked-keyring: empty
+
+with a usage count of 100 * the number of times the program has been run,
+then the kernel is malfunctioning.  If leaked-keyring has zero usages or
+has been garbage collected, then the problem is fixed.
+
+Reported-by: Yevgeny Pats <yevgeny@perception-point.io>
+Signed-off-by: David Howells <dhowells@redhat.com>
+RH-bugzilla: 1298036
+---
+ security/keys/process_keys.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/security/keys/process_keys.c b/security/keys/process_keys.c
+index 43b4cddbf2b3..7877e5cd4e23 100644
+--- a/security/keys/process_keys.c
++++ b/security/keys/process_keys.c
+@@ -794,6 +794,7 @@ long join_session_keyring(const char *name)
+ 		ret = PTR_ERR(keyring);
+ 		goto error2;
+ 	} else if (keyring == new->session_keyring) {
++		key_put(keyring);
+ 		ret = 0;
+ 		goto error2;
+ 	}
+-- 
+2.5.0
+

--- a/pkgs/os-specific/linux/kernel/linux-3.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.10.nix
@@ -9,6 +9,8 @@ import ./generic.nix (args // rec {
     sha256 = "0z0jdix1mfpnnc8cxw7rzpnhxdayckpnrasvxi1qf0dwhcqgk92d";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.12.nix
@@ -9,6 +9,8 @@ import ./generic.nix (args // rec {
     sha256 = "1bn07wsrcbg4qgqd4v2810c3qc0ifbcza0fyj8s54yd78g9qj4lj";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14.nix
@@ -10,6 +10,8 @@ import ./generic.nix (args // rec {
     sha256 = "0jw1023cpn4bjmi0db86lrxri9xj75cj8p2iqs44jabvh35idl7l";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18.nix
@@ -9,6 +9,8 @@ import ./generic.nix (args // rec {
     sha256 = "14pz8mvk48i2y1ffkhczjcm2icpb2g9xlpzyrvvis42n5178fjf6";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-4.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.1.nix
@@ -9,6 +9,8 @@ import ./generic.nix (args // rec {
     sha256 = "18sr0dl5ax6pcx6nqp9drb4l6a38g07vxihiqpbwb231jv68h8j7";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-4.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.2.nix
@@ -10,6 +10,8 @@ import ./generic.nix (args // rec {
     sha256 = "0p7v6v3v9kn7w5iragi5hx0dylhis0jy6xmk77gka486q1ynpnqp";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-4.3.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.3.nix
@@ -10,6 +10,8 @@ import ./generic.nix (args // rec {
     sha256 = "8cad4ce7d049c2ecc041b0844bd478bf85f0d3071c93e0c885a776d57cbca3cf";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -10,6 +10,8 @@ import ./generic.nix (args // rec {
     sha256 = "401d7c8fef594999a460d10c72c5a94e9c2e1022f16795ec51746b0d165418b2";
   };
 
+  kernelPatches = args.kernelPatches ++ [ { name = "cve-2016-0728"; patch = ./cve-2016-0728.patch; } ];
+
   features.iwlwifi = true;
   features.efiBootStub = true;
   features.needsCifsUtils = true;


### PR DESCRIPTION
The PoC provided successfully escalates privileges from a local user to
root. The vulnerability affects any Linux Kernel version 3.8 and higher.
http://perception-point.io/2016/01/14/analysis-and-exploitation-of-a-linux-kernel-vulnerability-cve-2016-0728/

(Do we have a standard process for security patching at all? I track these fairly closely and patch them on my own systems before they make their way into a nixpkgs PR, but it's hard to test build them all ahead of time.)
