### PR TITLE
certificate-transparency: 2015-11-27 -> 2016-01-14

### DIFF
--- a/pkgs/servers/certificate-transparency/default.nix
+++ b/pkgs/servers/certificate-transparency/default.nix
@@ -3,8 +3,8 @@
 stdenv.mkDerivation rec {
   name = "certificate-transparency-${version}";
 
-  version = "2015-11-27";
-  rev = "dc5a51e55af989ff5871a6647166d00d0de478ab";
+  version = "2016-01-14";
+  rev = "250672b5aef3666edbdfc9a75b95a09e7a57ed08";
 
   meta = with stdenv.lib; {
     homepage = https://www.certificate-transparency.org/;
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "google";
     repo  = "certificate-transparency";
     rev   = rev;
-    sha256 = "14sgc2kcjjsnrykwcjin21h1f3v4kg83w6jqiq9qdm1ha165yhvx";
+    sha256 = "1gn0bqzkf09jvc2aq3da8fwhl65y7q57msqsh6iczvd6fdmrpfdj";
   };
 
   # need to disable regex support in evhtp or building will fail


### PR DESCRIPTION
Bump to latest master.  Among other things, this pulls in
google/certificate-transparency#1088 which fixes a problem with running
xjson-server in clustering mode.
