### PR TITLE
oraclejdk: 8u65, 8u66 -> 8u71, 8u72

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "65";
+  patchVersion = "71";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1shri8mw648piivyparbpzskiq4i0z6kain9kr7ylav5mv7h66fg";
-  sha256_x86_64 = "1rr6g2sb0f1vyf3l9nvj49ah28bsid92z0lj9pfjlb12vjn2mnw8";
+  sha256_i686 = "11wcizv4gvlffzn2wj34ffwrq21xwh4ikg2vjv63avdfp2hazjqv";
+  sha256_x86_64 = "18jqdrlbv4sdds2hlmp437waq7r9b33f7hdp8kb6l7pkrizr9nwv";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "66";
+  patchVersion = "72";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "18l4r89na4z92djcdgyinjlhl6fmgz4x1sm40lwrsiwzg26nl0i1";
-  sha256_x86_64 = "02nwcgplq14vj1vkz99r5x20lg86hscrxb5aaifwcny7l5gsv5by";
+  sha256_i686 = "023rnlm5v7d9w4d7bgcac8j0r1vqkbv6fl20k8354pzpdjg6liaq";
+  sha256_x86_64 = "167ca39a6y0n8l87kdm5nv2hrp0wf6g4mw1rbychjc04f5igkrs6";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
8u71 is Critical Patch Update (CPU), contains security vulnerability fixes.
8u72 is Patch Set Update (PSU), contains security vulnerability fixes and other bug fixes.

8u71 release notes: http://www.oracle.com/technetwork/java/javase/8u71-relnotes-2773756.html
8u72 release notes: http://www.oracle.com/technetwork/java/javase/8u72-relnotes-2775802.html

Both tested on x86_64.
