### PR TITLE
ati-drivers: Restore opengl & direct rendering

### DIFF
--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -1,9 +1,6 @@
-{ stdenv, fetchurl, kernel ? null, which, imake
-, mesa # for fgl_glxgears
-, libXxf86vm, xf86vidmodeproto # for fglrx_gamma
-, xorg, makeWrapper, glibc, patchelf
-, unzip
-, qt4 # for amdcccle
+{ stdenv, fetchurl, kernel ? null, which
+, xorg, makeWrapper, glibc, patchelf, unzip
+, fontconfig, freetype, mesa # for fgl_glxgears
 , # Whether to build the libraries only (i.e. not the kernel module or
   # driver utils). Used to support 32-bit binaries on 64-bit
   # Linux.
@@ -11,6 +8,15 @@
 }:
 
 assert (!libsOnly) -> kernel != null;
+
+with stdenv.lib;
+
+let
+  version = "15.7";
+in
+
+# This derivation requires a maximum of gcc49, Linux kernel 4.1 and xorg.xserver 1.17
+# and will not build or run using versions newer
 
 # If you want to use a different Xorg version probably
 # DIR_DEPENDING_ON_XORG_VERSION in builder.sh has to be adopted (?)
@@ -20,23 +26,37 @@ assert (!libsOnly) -> kernel != null;
 # See http://thread.gmane.org/gmane.linux.distributions.nixos/4145 for a
 # workaround (TODO)
 
-# The gentoo ebuild contains much more magic and is usually a great resource to
-# find patches :)
+# The gentoo ebuild contains much more "magic" and is usually a great resource to
+# find patches XD
 
 # http://wiki.cchtml.com/index.php/Main_Page
 
-# There is one issue left:
+# 
 # /usr/lib/dri/fglrx_dri.so must point to /run/opengl-driver/lib/fglrx_dri.so
-
-with stdenv.lib;
+# This is done in the builder script.
 
 stdenv.mkDerivation {
-  name = "ati-drivers-15.7" + (optionalString (!libsOnly) "-${kernel.version}");
+
+  linuxonly =
+    if stdenv.system == "i686-linux" then
+      true
+    else if stdenv.system == "x86_64-linux" then
+      true
+    else throw "ati-drivers are Linux only. Sorry. The build was stopped.";
+
+  name = "ati-drivers-${version}" + (optionalString (!libsOnly) "-${kernel.version}");
 
   builder = ./builder.sh;
-
-  inherit libXxf86vm xf86vidmodeproto;
   gcc = stdenv.cc.cc;
+  libXinerama = xorg.libXinerama;
+  libXrandr = xorg.libXrandr;
+  libXrender = xorg.libXrender;
+  libXxf86vm = xorg.libXxf86vm;
+  xf86vidmodeproto = xorg.xf86vidmodeproto;
+  libSM = xorg.libSM;
+  libICE = xorg.libICE;
+  libfreetype = freetype;
+  libfontconfig = fontconfig;
 
   src = fetchurl {
     url = "http://www2.ati.com/drivers/linux/amd-driver-installer-15.20.1046-x86.x86_64.zip";
@@ -44,16 +64,19 @@ stdenv.mkDerivation {
     curlOpts = "--referer http://support.amd.com/en-us/download/desktop?os=Linux%20x86_64";
   };
 
-  patchPhase = "patch -p1 < ${./kernel-api-fixes.patch}";
   patchPhaseSamples = "patch -p2 < ${./patch-samples.patch}";
+  patchPhase1 = "patch -p1 < ${./kernel-api-fixes.patch}";
 
   buildInputs =
-    [ xorg.libXext xorg.libX11 xorg.libXinerama
-      xorg.libXrandr which imake makeWrapper
+    [ xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM
+      xorg.libXrandr xorg.libXxf86vm xorg.xf86vidmodeproto xorg.imake xorg.libICE
       patchelf
       unzip
       mesa
-      qt4
+      fontconfig
+      freetype
+      makeWrapper
+      which
     ];
 
   inherit libsOnly;
@@ -63,26 +86,37 @@ stdenv.mkDerivation {
   inherit glibc /* glibc only used for setting interpreter */;
 
   LD_LIBRARY_PATH = stdenv.lib.concatStringsSep ":"
-    [ "${xorg.libXrandr}/lib"
-      "${xorg.libXrender}/lib"
-      "${xorg.libXext}/lib"
-      "${xorg.libX11}/lib"
-      "${xorg.libXinerama}/lib"
+    [ "${xorg.libXrandr}/lib/"
+      "${xorg.libXrender}/lib/"
+      "${xorg.libXext}/lib/"
+      "${xorg.libX11}/lib/"
+      "${xorg.libXinerama}/lib/"
+      "${xorg.libSM}/lib/"
+      "${xorg.libICE}/lib/"
+      "${stdenv.cc.cc}/lib/"
     ];
 
   # without this some applications like blender don't start, but they start
   # with nvidia. This causes them to be symlinked to $out/lib so that they
   # appear in /run/opengl-driver/lib which get's added to LD_LIBRARY_PATH
-  extraDRIlibs = [ xorg.libXext ];
 
-  inherit mesa qt4; # only required to build examples and amdcccle
+  extraDRIlibs = [ xorg.libXrandr xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM xorg.libICE ];
+
+  inherit mesa; # only required to build the examples
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    description = "ATI drivers";
+    description = "ATI Catalyst display drivers";
     homepage = http://support.amd.com/us/gpudownload/Pages/index.aspx;
     license = licenses.unfree;
     maintainers = with maintainers; [ marcweber offline jgeerds ];
     platforms = platforms.linux;
     hydraPlatforms = [];
+    # Copied from the nvidia default.nix to prevent a store collision.
+    priority = 4;
   };
+
+
+
 }


### PR DESCRIPTION
- Removed a collision in the nix store
- Removed dependency on qt
- Fixed opengl and direct rendering by correcting some link paths
- Some code refactored in builder.sh
- Comments added/modified

This pull request fixes #11740,#11817 and I recommend that it be considered
as a hotfix for the stable channel due to the fact that opengl
and direct rendering are broken there too.
