### PR TITLE
google-cloud-sdk: Add various modules to python path

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -1,5 +1,7 @@
 {stdenv, fetchurl, python27, python27Packages, makeWrapper}:
 
+with python27Packages;
+
 stdenv.mkDerivation rec {
   version = "0.9.82";
   name = "google-cloud-sdk-${version}";
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
         wrapper="$out/bin/$program"
         makeWrapper "$programPath" "$wrapper" \
             --set CLOUDSDK_PYTHON "${python27}/bin/python" \
-            --prefix PYTHONPATH : "$(toPythonPath ${python27Packages.crcmod})"
+            --prefix PYTHONPATH : "$(toPythonPath ${cffi}):$(toPythonPath ${cryptography}):$(toPythonPath ${pyopenssl}):$(toPythonPath ${crcmod})"
     done
 
     # install man pages


### PR DESCRIPTION
This fixes a sequence of missing-module errors seen when calling `gcloud auth activate-service-account`.

cc @stephenmw
