### PR TITLE
add nginxModules.brotli

### DIFF
--- a/pkgs/development/libraries/libbrotli/default.nix
+++ b/pkgs/development/libraries/libbrotli/default.nix
@@ -1,0 +1,36 @@
+{stdenv, fetchFromGitHub, autoconf, automake, libtool, brotliUnstable}:
+
+stdenv.mkDerivation rec {
+  name = "libbrotli-20160120";
+  version = "53d53e8";
+
+  src = fetchFromGitHub {
+    owner = "bagder";
+    repo = "libbrotli";
+    rev = "53d53e8d9c0d37398d37bac2e7a7aa20b0025e9e";
+    sha256 = "10r4nx6n1r54f5cjck5mmmsj7bkasnmmz7m84imhil45q73kzd4m";
+  };
+
+  buildInputs = [autoconf automake libtool];
+  preConfigure = ''
+    cp -r ${brotliUnstable.src}/* brotli/
+    chmod -R +700 brotli
+    mkdir m4
+    autoreconf --install --force --symlink
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Meta project to build libraries from the brotli source code";
+    longDescription = ''
+      Wrapper scripts and code around the brotli code base.
+      Builds libraries out of the brotli decode and encode sources. Uses autotools.
+      'brotlidec' is the library for decoding, decompression
+      'brotlienc' is the library for encoding, compression
+    '';
+
+    homepage = https://github.com/bagder/libbrotli;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [];
+  };
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -1,6 +1,16 @@
 { fetchFromGitHub, pkgs }:
 
 {
+  brotli = {
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = "ngx_brotli";
+      rev = "788615eab7c5e0a984278113c55248305620df14";
+      sha256 = "02514bbjdhm9m38vljdh626d3c1783jxsxawv5c6bzblwmb8xgvf";
+    };
+    inputs = [ pkgs.libbrotli ];
+  };
+
   rtmp = {
     src = fetchFromGitHub {
       owner = "arut";

--- a/pkgs/tools/compression/brotli/unstable.nix
+++ b/pkgs/tools/compression/brotli/unstable.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub }:
+
+# ?TODO: there's also python lib in there
+
+stdenv.mkDerivation rec {
+  name = "brotli-20160112";
+  version = "bed93862";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "brotli";
+    rev = "bed93862608d4d232ebe6d229f04e48399775e8b";
+    sha256 = "0g94kqh984qkbqbj4fpkkyji9wnbrb9cs32r9d6niw1sqfnfkd6f";
+  };
+
+  preConfigure = "cd tools";
+
+  # Debian installs "brotli" instead of "bro" but let's keep upstream choice for now.
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv ./bro "$out/bin/"
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+
+    description = "A generic-purpose lossless compression algorithm and tool";
+
+    longDescription =
+      ''  Brotli is a generic-purpose lossless compression algorithm that
+          compresses data using a combination of a modern variant of the LZ77
+          algorithm, Huffman coding and 2nd order context modeling, with a
+          compression ratio comparable to the best currently available
+          general-purpose compression methods. It is similar in speed with
+          deflate but offers more dense compression.
+
+          The specification of the Brotli Compressed Data Format is defined
+          in the following internet draft:
+          http://www.ietf.org/id/draft-alakuijala-brotli
+      '';
+
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1146,6 +1146,8 @@ let
 
   brotliUnstable = callPackage ../tools/compression/brotli/unstable.nix { };
 
+  libbrotli = callPackage ../development/libraries/libbrotli { };
+
   biosdevname = callPackage ../tools/networking/biosdevname { };
 
   checkbashism = callPackage ../development/tools/misc/checkbashisms { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1144,6 +1144,8 @@ let
 
   brotli = callPackage ../tools/compression/brotli { };
 
+  brotliUnstable = callPackage ../tools/compression/brotli/unstable.nix { };
+
   biosdevname = callPackage ../tools/networking/biosdevname { };
 
   checkbashism = callPackage ../development/tools/misc/checkbashisms { };


### PR DESCRIPTION
This adds the nginx module for static and on the fly brotli compression. It needs libbrotli which needs a newer version of brotli. Because of that, brotliUnstable is included.
On my side of the internet, all packages (including nginx with the module) compile fine.
