### PR TITLE
IHaskell: remove un-needed inherit

### DIFF
--- a/nixos/modules/services/misc/ihaskell.nix
+++ b/nixos/modules/services/misc/ihaskell.nix
@@ -6,7 +6,6 @@ let
 
   cfg = config.services.ihaskell;
   ihaskell = pkgs.ihaskell.override {
-    inherit (cfg.haskellPackages) ihaskell ghcWithPackages;
     packages = self: cfg.extraPackages self;
   };
 


### PR DESCRIPTION
Inherit statement not required and in fact breaks the service. Tested on NixOS: `16.03.git.148396cM (Emu)`
