### PR TITLE
types: added someOf

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -126,6 +126,20 @@ rec {
       substSubModules = m: listOf (elemType.substSubModules m);
     };
 
+    # a listOf type with a restriction on valid values
+    # example: types.someOf types.package [ pkgs.vim pkgs.emacs ]
+    someOf = elemType: validValues:
+      let checkValues = validValues: values:
+        let invalidValues = subtractLists validValues values; 
+            showList = xs: "[${concatStringsSep " " (map toString xs)}]";
+        in
+        if (invalidValues == []) then true
+        else builtins.trace (''
+          Invalid value(s) ${showList invalidValues}.
+          Should be some of ${showList validValues}.
+        '') false;
+      in addCheck (listOf elemType) (checkValues validValues);
+
     attrsOf = elemType: mkOptionType {
       name = "attribute set of ${elemType.name}s";
       check = isAttrs;

--- a/nixos/doc/manual/development/option-declarations.xml
+++ b/nixos/doc/manual/development/option-declarations.xml
@@ -125,6 +125,15 @@ options = {
   </varlistentry>
 
   <varlistentry>
+    <term><varname>types.someOf</varname> <replaceable>t</replaceable> <replaceable>[v]</replaceable></term>
+    <listitem>
+      <para>A list of elements of type <replaceable>t</replaceable> with a list of valid values of [v]
+      (e.g., <literal>types.someOf types.str ["a" "b"]</literal> is a list of
+      strings where ["a"], ["b"] or ["a" "b"] are the only valid values).</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
     <term><varname>types.attrsOf</varname> <replaceable>t</replaceable></term>
     <listitem>
       <para>A set of elements of type <replaceable>t</replaceable>


### PR DESCRIPTION
please review this PR in detail before merging as it add functionality to lib/types.

---
# Detail

Adds a `someOf` type that work like a `listOf` but with a restriction on valid values.

example: `types.someOf types.str ["a" "b"]` will throw an error if the list passed is not `["a"]` or `["b"]` or `["a" "b"]`.
# Motivation

When implementing  a plugin system in a Nix module like:

``` nix
i18n.inputMethod.fcitx = {
      engines = mkOption {
        type    = with types; listOf package;
        default = [];
        example = literalExample "with pkgs.fcitx-engines; [ fcitx-mozc fcitx-hangul ]";
        description = ''
          Enabled Fcitx engines.
          Available engines can be found by running `nix-env "&lt;nixpkgs&gt;" . -qaP -A fcitx-engines`.
        '';
      };
};
```

The user can set `i18n.inputMethod.fcitx.plugins = [ pkgs.firefox ]` without triggering an error.

Instead, if the module is defined with `types.someOf`:

``` nix
i18n.inputMethod.fcitx = {
      engines = mkOption {
        type    = types.someOf types.package  (with pkgs.fcitx-engines; [ mozc hangul ]);
        default = [];
        example = literalExample "with pkgs.fcitx-engines; [ fcitx-mozc fcitx-hangul ]";
        description = ''
          Enabled Fcitx engines.
          Available engines can be found by running `nix-env "&lt;nixpkgs&gt;" . -qaP -A fcitx-engines`.
        '';
      };
};
```

And if the user set `i18n.inputMethod.fcitx.plugins = [ pkgs.firefox ]`, `nixos-rebuild` will trigger an error:

```
$ nixos-rebuild switch
building Nix...
building the system configuration...
trace: Invalid value(s) [/nix/store/npx2a5c2iqyffypq4k97dyqw7gbnjgs5-firefox-43.0.4].
Should be some of [/nix/store/1kvv18insxwhbfkasdywj42hl9km6pc0-fcitx-mozc-2.17.2313.102 /nix/store/a643p1qixdf96n7s2872n381j8x31jqr-fcitx-hangul-0.3.0].

error: The option value `i18n.inputMethod.fcitx.engines' in `/etc/nixos/software.nix' is not a list of derivations.
```
# Possible improvements
- In case of `types.package` the error message get a little cryptic as the attribute names are converted to a store path, this should be improved if possible.
- the `someOf` restriction could be automatically used in the example
- The last line of the error "error: The option value `i18n.inputMethod.fcitx.engines' in`/etc/nixos/software.nix' is not a list of derivations." is misleading and should be changed as "error: The option value `i18n.inputMethod.fcitx.engines' in`/etc/nixos/software.nix' is not a list of **valid** derivations." if possible.
