### PR TITLE
ncmpcpp: 0.7 -> 0.7.2

### DIFF
--- a/pkgs/applications/audio/ncmpcpp/default.nix
+++ b/pkgs/applications/audio/ncmpcpp/default.nix
@@ -15,11 +15,11 @@ assert taglibSupport -> (taglib != null);
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "ncmpcpp-${version}";
-  version = "0.7";
+  version = "0.7.2";
 
   src = fetchurl {
     url = "http://ncmpcpp.rybczak.net/stable/${name}.tar.bz2";
-    sha256 = "0xzz0g9whqjcjaaqmsw5ph1zvpi2j5v3i5k73g7916rca3q4z4jh";
+    sha256 = "0fq9nk796cp7gs0gwrabb6wp7f5h7pph10hrkrik1wf4k3mzb4k3";
   };
 
   configureFlags = [ "BOOST_LIB_SUFFIX=" ]


### PR DESCRIPTION
Tested on nixos x86_64 with default options: builds and runs.
