### PR TITLE
kde5.yakuake: init at 3.0.2

### DIFF
--- a/pkgs/applications/misc/yakuake/3.0.nix
+++ b/pkgs/applications/misc/yakuake/3.0.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, lib
+, fetchurl
+, cmake
+, extra-cmake-modules
+, karchive
+, kcrash
+, kdbusaddons
+, ki18n
+, kiconthemes
+, knewstuff
+, knotifications
+, knotifyconfig
+, konsole
+, kparts
+, kwindowsystem
+, makeQtWrapper
+
+}:
+
+let
+  pname = "yakuake";
+  version = "3.0.2";
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://download.kde.org/stable/${pname}/${version}/src/${name}.tar.xz";
+    sha256 = "0vcdji1k8d3pz7k6lkw8ighkj94zff2l2cf9v1avf83f4hjyfhg5";
+  };
+
+  buildInputs = [
+    cmake
+    extra-cmake-modules
+    karchive
+    kcrash
+    kdbusaddons
+    ki18n
+    kiconthemes
+    knewstuff
+    knotifications
+    knotifyconfig
+    kparts
+    kwindowsystem
+  ];
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    makeQtWrapper
+  ];
+
+  propagatedUserEnvPkgs = [
+    konsole
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/yakuake"
+  '';
+
+  meta = {
+    homepage = https://yakuake.kde.org;
+    description = "Quad-style terminal emulator for KDE";
+    maintainers = with lib.maintainers; [ fridh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15272,6 +15272,8 @@ in
       themes = [];  # extra themes, etc.
     };
 
+    yakuake = callPackage ../applications/misc/yakuake/3.0.nix {};
+
   };
 
   kde5 =


### PR DESCRIPTION
This adds a KDE5 port of Yakuake. While there hasn't been a release yet
of this port it is already in a workable state.
