### PR TITLE
awesome: 3.5.6 -> 3.5.7

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "3.5.6";
+  version = "3.5.7";
 in with luaPackages;
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url    = "http://awesome.naquadah.org/download/awesome-${version}.tar.xz";
-    sha256 = "1ms6a3l1i2jdhzrd1zr25cqckznmb44qgz4n635jam42hzhrvx1p";
+    sha256 = "ba7f92b0ab8b729c569b19b098b0a08339d8654e3c040d07ad02cf99641ceecf";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Updated awesome from version 3.5.6 to version 3.5.7.

The package builds successfully on my system.

cc @lovek323 
