### PR TITLE
Install less so `aws help` outputs help docs

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, pythonPackages, groff }:
+{ stdenv, fetchzip, pythonPackages, groff, less }:
 
 pythonPackages.buildPythonPackage rec {
   name = "awscli-${version}";
@@ -19,6 +19,7 @@ pythonPackages.buildPythonPackage rec {
     pythonPackages.rsa
     pythonPackages.pyasn1
     groff
+    less
   ];
 
   postInstall = ''


### PR DESCRIPTION
Without less, we get:

```
2016-01-22 10:31:59,098 - MainThread - awscli.help - DEBUG - Running command: ['groff', '-man', '-T', 'ascii']
2016-01-22 10:31:59,109 - MainThread - awscli.help - DEBUG - Running command: ['less', '-R']
2016-01-22 10:31:59,111 - MainThread - awscli.clidriver - DEBUG - Exception caught in main()
Traceback (most recent call last):
  File "/nix/store/jmgflkyf1yfz6an82pvhq084mp1j0bjn-awscli-1.7.41/lib/python2.7/site-packages/awscli/clidriver.py", line 183, in main
    return command_table[parsed_args.command](remaining, parsed_args)
  File "/nix/store/jmgflkyf1yfz6an82pvhq084mp1j0bjn-awscli-1.7.41/lib/python2.7/site-packages/awscli/help.py", line 245, in __call__
    self.renderer.render(self.doc.getvalue())
  File "/nix/store/jmgflkyf1yfz6an82pvhq084mp1j0bjn-awscli-1.7.41/lib/python2.7/site-packages/awscli/help.py", line 81, in render
    self._send_output_to_pager(converted_content)
  File "/nix/store/jmgflkyf1yfz6an82pvhq084mp1j0bjn-awscli-1.7.41/lib/python2.7/site-packages/awscli/help.py", line 86, in _send_output_to_pager
    p = self._popen(cmdline, stdin=PIPE)
  File "/nix/store/jmgflkyf1yfz6an82pvhq084mp1j0bjn-awscli-1.7.41/lib/python2.7/site-packages/awscli/help.py", line 90, in _popen
    return Popen(*args, **kwargs)
  File "/nix/store/6a1x9r9wywa27v9gvp0yqgq0mmkfa3ww-python-2.7.11/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/nix/store/6a1x9r9wywa27v9gvp0yqgq0mmkfa3ww-python-2.7.11/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
2016-01-22 10:31:59,112 - MainThread - awscli.clidriver - DEBUG - Exiting with rc 255

[Errno 2] No such file or directory
```
