### PR TITLE
xcftools: init at 1.0.7

### DIFF
--- a/pkgs/tools/graphics/xcftools/default.nix
+++ b/pkgs/tools/graphics/xcftools/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl, libpng, perl, gettext }:
+
+stdenv.mkDerivation {
+  name = "xcftools-1.0.7";
+
+  src = fetchurl {
+    url = "http://henning.makholm.net/xcftools/xcftools-1.0.7.tar.gz";
+    sha256 = "19i0x7yhlw6hd2gp013884zchg63yzjdj4hpany011il0n26vgqy";
+  };
+
+  buildInputs = [ libpng perl gettext ];
+
+  patchPhase = ''
+    # Required if building with libpng-1.6, innocuous otherwise
+    substituteInPlace xcf2png.c         \
+      --replace png_voidp_NULL NULL     \
+      --replace png_error_ptr_NULL NULL
+
+    # xcfview needs mailcap and isn't that useful anyway
+    sed -i -e '/BINARIES/s/xcfview//' Makefile.in
+  '';
+
+  meta = {
+    homepage = http://henning.makholm.net/software;
+    description = "Command-line tools for converting Gimp XCF files";
+    longDescription = ''
+      A set of fast command-line tools for extracting information from
+      the Gimp's native file format XCF.
+
+      The tools are designed to allow efficient use of layered XCF
+      files as sources in a build system that use 'make' and similar
+      tools to manage automatic processing of the graphics.
+
+      These tools work independently of the Gimp engine and do not
+      require the Gimp to even be installed.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15759,6 +15759,8 @@ let
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };
 
+  xcftools = callPackage ../tools/graphics/xcftools { };
+
   xhyve = callPackage ../applications/virtualization/xhyve { };
 
   xinput_calibrator = callPackage ../tools/X11/xinput_calibrator {};


### PR DESCRIPTION
xcftools contains programs to convert Gimp XCF format into PNG or PNM. It exists in Debian but is missing from NixOS. I have tested the derivation and it succeeds in its task.

Cheers
