### PR TITLE
get_iplayer fixes

### DIFF
--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -8,10 +8,15 @@ buildPerlPackage {
   preConfigure = "touch Makefile.PL";
   doCheck = false;
 
+  patchPhase = ''
+    sed -e 's|^update_script|#update_script|' \
+        -e '/WARNING.*updater/d' \
+        -i get_iplayer
+  '';
+
   installPhase = '' 
     mkdir -p $out/bin
     cp get_iplayer $out/bin
-    sed -i 's|^update_script|#update_script|' $out/bin/get_iplayer
     wrapProgram $out/bin/get_iplayer --suffix PATH : ${ffmpeg}/bin:${flvstreamer}/bin:${vlc}/bin:${rtmpdump}/bin --prefix PERL5LIB : $PERL5LIB
   '';  
   

--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -1,9 +1,9 @@
 {stdenv, fetchurl, flvstreamer, ffmpeg, makeWrapper, perl, buildPerlPackage, perlPackages, vlc, rtmpdump}:
 buildPerlPackage {
-  name = "get_iplayer-2.86";
+  name = "get_iplayer-2.94";
 
   buildInputs = [makeWrapper perl];
-  propagatedBuildInputs = with perlPackages; [HTMLParser HTTPCookies LWP];
+  propagatedBuildInputs = with perlPackages; [HTMLParser HTTPCookies LWP XMLSimple];
 
   preConfigure = "touch Makefile.PL";
   doCheck = false;
@@ -21,8 +21,8 @@ buildPerlPackage {
   '';  
   
   src = fetchurl {
-    url = ftp://ftp.infradead.org/pub/get_iplayer/get_iplayer-2.86.tar.gz;
-    sha256 = "0zhcw0ikxrrz1jayx7jjgxmdf7gzk4pmzfvpraxmv64xwzgc1sc1";
+    url = ftp://ftp.infradead.org/pub/get_iplayer/get_iplayer-2.94.tar.gz;
+    sha256 = "16p0bw879fl8cs6rp37g1hgrcai771z6rcqk2nvm49kk39dx1zi4";
   };
   
 }


### PR DESCRIPTION
Version 2.94 is required to watch War and Peace drama series on BBC iPlayer.

I also quashed a warning about the "auto-update" code which is already patched out.
