### PR TITLE
gobject-introspection: Use absolute shared library paths

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -1,5 +1,55 @@
+diff --git a/giscanner/scannermain.py b/giscanner/scannermain.py
+index 89ec193..8ee92c3 100755
+--- a/giscanner/scannermain.py
++++ b/giscanner/scannermain.py
+@@ -94,6 +94,34 @@ def get_windows_option_group(parser):
+     return group
+ 
+ 
++def _get_default_fallback_libpath():
++    outputs = os.environ.get("outputs", "out").split()
++    if "lib" in outputs:
++        # For multiple output derivations let's try whether there is a $lib
++        # environment variable and use that as the base store path.
++        store_path = os.environ.get("lib")
++    elif "out" in outputs:
++        # Otherwise we have a single output derivation, so the libraries most
++        # certainly will end up in "$out/lib".
++        store_path = os.environ.get("out")
++
++    if store_path is not None:
++        # Even if we have a $lib as output, there still should be a $lib/lib
++        # directory.
++        return os.path.join(store_path, 'lib')
++    else:
++        # If we haven't found a possible scenario, let's return an empty string
++        # so that the shared library won't be prepended with a path.
++        #
++        # Note that this doesn't mean that all hope is lost, because after all
++        # we can still use --fallback-library-path to set one.
++        #
++        # Also, we're not returning None, because that would make it very
++        # difficult to disable adding fallback paths altogether using something
++        # like: --fallback-library-path=""
++        return ""
++
++
+ def _get_option_parser():
+     parser = optparse.OptionParser('%prog [options] sources')
+     parser.add_option('', "--quiet",
+@@ -200,6 +228,10 @@ match the namespace prefix.""")
+     parser.add_option("", "--filelist",
+                       action="store", dest="filelist", default=[],
+                       help="file containing headers and sources to be scanned")
++    parser.add_option("", "--fallback-library-path",
++                      action="store", dest="fallback_libpath",
++                      default=_get_default_fallback_libpath(),
++                      help="Path to prepend to unknown shared libraries")
+ 
+     group = get_preprocessor_option_group(parser)
+     parser.add_option_group(group)
 diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
-index 838d343..9dbdc0f 100644
+index 838d343..35b6dab 100644
 --- a/giscanner/shlibs.py
 +++ b/giscanner/shlibs.py
 @@ -53,10 +53,24 @@ def _resolve_libtool(options, binary, libraries):
@@ -30,6 +80,19 @@ index 838d343..9dbdc0f 100644
  
  
  # This is a what we do for non-la files. We assume that we are on an
+@@ -115,7 +129,11 @@ def _resolve_non_libtool(options, binary, libraries):
+                 m = pattern.search(line)
+                 if m:
+                     del patterns[library]
+-                    shlibs.append(m.group(1))
++                    match = m.group(1)
++                    if not match.startswith('/') \
++                       and len(options.fallback_libpath) > 0:
++                        match = os.path.join(options.fallback_libpath, match)
++                    shlibs.append(match)
+                     break
+ 
+         if len(patterns) > 0:
 diff --git a/giscanner/utils.py b/giscanner/utils.py
 index 660081e..c9c767a 100644
 --- a/giscanner/utils.py

--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -1,6 +1,40 @@
---- ./giscanner/utils.py.orig	2014-08-14 22:05:05.055334080 +0200
-+++ ./giscanner/utils.py	2014-08-14 22:05:24.687497334 +0200
-@@ -110,17 +110,11 @@
+diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
+index 838d343..9dbdc0f 100644
+--- a/giscanner/shlibs.py
++++ b/giscanner/shlibs.py
+@@ -53,10 +53,24 @@ def _resolve_libtool(options, binary, libraries):
+ # Match absolute paths on OS X to conform to how libraries are usually
+ # referenced on OS X systems.
+ def _ldd_library_pattern(library_name):
++    nix_store_dir = re.escape('@nixStoreDir@'.rstrip('/'))
+     pattern = "(?<![A-Za-z0-9_-])(lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
+-    if platform.system() == 'Darwin':
+-        pattern = "([^\s]*lib*%s[^A-Za-z0-9_-][^\s\(\)]*)"
+-    return re.compile(pattern % re.escape(library_name))
++    pattern = r'''
++        (
++          (?:
++            # First match Nix store paths because they need to be absolute.
++            (?:%s(?:/[^/]*)+)
++            # Everything else not a store path remains relative, because we
++            # would end up having absolute build paths in the resulting GIR
++            # file.
++            | (?<=/)
++          )
++          # And finally the library itself:
++          (?:lib%s[^A-Za-z0-9_-][^\s\(\)]*)
++        )
++    '''
++    return re.compile(pattern % (nix_store_dir, re.escape(library_name)),
++                      re.VERBOSE)
+ 
+ 
+ # This is a what we do for non-la files. We assume that we are on an
+diff --git a/giscanner/utils.py b/giscanner/utils.py
+index 660081e..c9c767a 100644
+--- a/giscanner/utils.py
++++ b/giscanner/utils.py
+@@ -109,17 +109,11 @@ def extract_libtool_shlib(la_file):
      if dlname is None:
          return None
  

--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -1,21 +1,26 @@
 diff --git a/giscanner/scannermain.py b/giscanner/scannermain.py
-index 89ec193..8ee92c3 100755
+index 89ec193..54f1d2e 100755
 --- a/giscanner/scannermain.py
 +++ b/giscanner/scannermain.py
-@@ -94,6 +94,34 @@ def get_windows_option_group(parser):
+@@ -94,6 +94,39 @@ def get_windows_option_group(parser):
      return group
  
  
 +def _get_default_fallback_libpath():
-+    outputs = os.environ.get("outputs", "out").split()
-+    if "lib" in outputs:
-+        # For multiple output derivations let's try whether there is a $lib
-+        # environment variable and use that as the base store path.
-+        store_path = os.environ.get("lib")
-+    elif "out" in outputs:
-+        # Otherwise we have a single output derivation, so the libraries most
-+        # certainly will end up in "$out/lib".
-+        store_path = os.environ.get("out")
++    # Newer multiple-output-optimized stdenv has an environment variable
++    # $outputLib which in turn specifies another variable which then is used as
++    # the destination for the library contents (${!outputLib}/lib).
++    store_path = os.environ.get(os.environ.get("outputLib"))
++    if store_path is None:
++        outputs = os.environ.get("outputs", "out").split()
++        if "lib" in outputs:
++            # For multiple output derivations let's try whether there is a $lib
++            # environment variable and use that as the base store path.
++            store_path = os.environ.get("lib")
++        elif "out" in outputs:
++            # Otherwise we have a single output derivation, so the libraries
++            # most certainly will end up in "$out/lib".
++            store_path = os.environ.get("out")
 +
 +    if store_path is not None:
 +        # Even if we have a $lib as output, there still should be a $lib/lib
@@ -37,7 +42,7 @@ index 89ec193..8ee92c3 100755
  def _get_option_parser():
      parser = optparse.OptionParser('%prog [options] sources')
      parser.add_option('', "--quiet",
-@@ -200,6 +228,10 @@ match the namespace prefix.""")
+@@ -200,6 +233,10 @@ match the namespace prefix.""")
      parser.add_option("", "--filelist",
                        action="store", dest="filelist", default=[],
                        help="file containing headers and sources to be scanned")

--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -49,7 +49,7 @@ index 89ec193..8ee92c3 100755
      group = get_preprocessor_option_group(parser)
      parser.add_option_group(group)
 diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
-index 838d343..35b6dab 100644
+index 838d343..ca7fc0d 100644
 --- a/giscanner/shlibs.py
 +++ b/giscanner/shlibs.py
 @@ -53,10 +53,24 @@ def _resolve_libtool(options, binary, libraries):
@@ -67,8 +67,8 @@ index 838d343..35b6dab 100644
 +            # First match Nix store paths because they need to be absolute.
 +            (?:%s(?:/[^/]*)+)
 +            # Everything else not a store path remains relative, because we
-+            # would end up having absolute build paths in the resulting GIR
-+            # file.
++            # would end up with temporary paths that are only valid during
++            # build time in the resulting GIR file.
 +            | (?<=/)
 +          )
 +          # And finally the library itself:

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, glib, flex, bison, pkgconfig, libffi, python
 , libintlOrEmpty, autoconf, automake, otool
-, substituteAll, nixStoreDir ? "/nix/store"
+, substituteAll, nixStoreDir ? builtins.storeDir
 }:
 # now that gobjectIntrospection creates large .gir files (eg gtk3 case)
 # it may be worth thinking about using multiple derivation outputs

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, glib, flex, bison, pkgconfig, libffi, python
-, libintlOrEmpty, autoconf, automake, otool }:
+, libintlOrEmpty, autoconf, automake, otool
+, substituteAll, nixStoreDir ? "/nix/store"
+}:
 # now that gobjectIntrospection creates large .gir files (eg gtk3 case)
 # it may be worth thinking about using multiple derivation outputs
 # In that case its about 6MB which could be separated
@@ -33,7 +35,10 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  patches = [ ./absolute_shlib_path.patch ];
+  patches = stdenv.lib.singleton (substituteAll {
+    src = ./absolute_shlib_path.patch;
+    inherit nixStoreDir;
+  });
 
   meta = with stdenv.lib; {
     description = "A middleware layer between C libraries and language bindings";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6639,7 +6639,9 @@ let
   #GMP ex-satellite, so better keep it near gmp
   mpfr = callPackage ../development/libraries/mpfr/default.nix { };
 
-  gobjectIntrospection = callPackage ../development/libraries/gobject-introspection { };
+  gobjectIntrospection = callPackage ../development/libraries/gobject-introspection {
+    nixStoreDir = config.nix.storeDir or "/nix/store";
+  };
 
   goocanvas = callPackage ../development/libraries/goocanvas { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6640,7 +6640,7 @@ let
   mpfr = callPackage ../development/libraries/mpfr/default.nix { };
 
   gobjectIntrospection = callPackage ../development/libraries/gobject-introspection {
-    nixStoreDir = config.nix.storeDir or "/nix/store";
+    nixStoreDir = config.nix.storeDir or builtins.storeDir;
   };
 
   goocanvas = callPackage ../development/libraries/goocanvas { };


### PR DESCRIPTION
So far only `.la` files get correctly converted to absolute paths in the GIR file. However if there are `.so` files which depend on a particular library using GI, they still get only the basename of the `.so` file.

This improves on the existing `absolute_shlib_path.patch` not only figuring out the absolute path of `.so` files but also falling back on the absolute path of `$out/lib` (or `$lib/lib` with multiple outputs) of the current build.

With this, we should no longer need to resort to setting `LD_LIBRARY_PATH` for all programs that use GI libraries.

I have only done very limited testing and I'm not using Gnome, nor do I use OS X, so I don't know whether this will cause problems on any of these environments.

Cc: @lethalman and anyone who can test on Darwin :-)
