### PR TITLE
Haka: new package

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -313,6 +313,7 @@
   tstrobel = "Thomas Strobel <ts468@cam.ac.uk>";
   ttuegel = "Thomas Tuegel <ttuegel@gmail.com>";
   tv = "Tomislav Viljetić <tv@shackspace.de>";
+  tvestelind = "Tomas Vestelind <tomas.vestelind@fripost.org>";
   twey = "James ‘Twey’ Kay <twey@twey.co.uk>";
   urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>";
   vandenoever = "Jos van den Oever <jos@vandenoever.info>";

--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -42,6 +42,7 @@ nixos.path = ./nixpkgs-unstable-2015-12-06/nixos;
   <itemizedlist>
     <listitem><para><literal>services/monitoring/longview.nix</literal></para></listitem>
     <listitem><para><literal>services/web-apps/pump.io.nix</literal></para></listitem>
+    <listitem><para><literal>services/security/haka.nix</literal></para></listitem>
   </itemizedlist>
 </para>
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -395,6 +395,7 @@
   ./services/security/fprintd.nix
   ./services/security/fprot.nix
   ./services/security/frandom.nix
+  ./services/security/haka.nix
   ./services/security/haveged.nix
   ./services/security/hologram.nix
   ./services/security/munge.nix

--- a/nixos/modules/services/security/haka.nix
+++ b/nixos/modules/services/security/haka.nix
@@ -1,0 +1,156 @@
+# This module defines global configuration for Haka.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.haka;
+
+  haka = cfg.package;
+
+  hakaConf = pkgs.writeText "haka.conf"
+  ''
+    [general]
+    configuration = ${if lib.strings.hasPrefix "/" cfg.configFile
+      then "${cfg.configFile}"
+      else "${haka}/share/haka/sample/${cfg.configFile}"}
+    ${optionalString (builtins.lessThan 0 cfg.threads) "thread = ${cfg.threads}"}
+
+    [packet]
+    ${optionalString cfg.pcap ''module = "packet/pcap"''}
+    ${optionalString cfg.nfqueue ''module = "packet/nqueue"''}
+    ${optionalString cfg.dump.enable ''dump = "yes"''}
+    ${optionalString cfg.dump.enable ''dump_input = "${cfg.dump.input}"''}
+    ${optionalString cfg.dump.enable ''dump_output = "${cfg.dump.output}"''}
+
+    interfaces = "${lib.strings.concatStringsSep "," cfg.interfaces}"
+
+    [log]
+    # Select the log module
+    module = "log/syslog"
+
+    # Set the default logging level
+    #level = "info,packet=debug"
+
+    [alert]
+    # Select the alert module
+    module = "alert/syslog"
+
+    # Disable alert on standard output
+    #alert_on_stdout = no
+
+    # alert/file module option
+    #file = "/dev/null"
+  '';
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.haka = {
+
+      enable = mkEnableOption "Haka";
+
+      package = mkOption {
+        default = pkgs.haka;
+        type = types.package;
+        description = "
+          Which Haka derivation to use.
+        ";
+      };
+
+      configFile = mkOption {
+        default = "empty.lua";
+        example = "/srv/haka/myfilter.lua";
+        type = types.string;
+        description = ''
+          Specify which configuration file Haka uses.
+          It can be absolute path or a path relative to the sample directory of
+          the haka git repo.
+        '';
+      };
+
+      interfaces = mkOption {
+        default = [ "eth0" ];
+        example = [ "any" ];
+        type = with types; listOf string;
+        description = ''
+          Specify which interface(s) Haka listens to.
+          Use 'any' to listen to all interfaces.
+        '';
+      };
+
+      threads = mkOption {
+        default = 0;
+        example = 4;
+        type = types.int;
+        description = ''
+          The number of threads that will be used.
+          All system threads are used by default.
+        '';
+      };
+
+      pcap = mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = "Whether to enable pcap";
+      };
+
+      nfqueue = mkEnableOption "nfqueue";
+
+      dump.enable = mkEnableOption "dump";
+      dump.input  = mkOption {
+        default = "/tmp/input.pcap";
+        example = "/path/to/file.pcap";
+        type = types.path;
+        description = "Path to file where incoming packets are dumped";
+      };
+
+      dump.output  = mkOption {
+        default = "/tmp/output.pcap";
+        example = "/path/to/file.pcap";
+        type = types.path;
+        description = "Path to file where outgoing packets are dumped";
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = cfg.pcap != cfg.nfqueue;
+        message = "either pcap or nfqueue can be enabled, not both.";
+      }
+      { assertion = cfg.nfqueue -> !dump.enable;
+        message = "dump can only be used with nfqueue.";
+      }
+      { assertion = cfg.interfaces != [];
+        message = "at least one interface must be specified.";
+      }];
+
+
+    environment.systemPackages = [ haka ];
+
+    systemd.services.haka = {
+      description = "Haka";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = "${haka}/bin/haka -c ${hakaConf}";
+        ExecStop = "${haka}/bin/hakactl stop";
+        User = "root";
+        Type = "forking";
+      };
+    };
+  };
+}

--- a/nixos/tests/haka.nix
+++ b/nixos/tests/haka.nix
@@ -1,0 +1,24 @@
+# This test runs haka and probes it with hakactl
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "haka";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ tvestelind ];
+  };
+
+  nodes = {
+    haka =
+      { config, pkgs, ... }:
+        {
+          services.haka.enable = true;
+        };
+    };
+
+  testScript = ''
+    startAll;
+
+    $haka->waitForUnit("haka.service");
+    $haka->succeed("hakactl status");
+    $haka->succeed("hakactl stop");
+  '';
+})

--- a/pkgs/tools/security/haka/default.nix
+++ b/pkgs/tools/security/haka/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     name = "haka_${version}_source.tar.gz";
-    url = "https://github.com/haka-security/haka/releases/download/v${version}";
+    url = "https://github.com/haka-security/haka/releases/download/v${version}/haka_${version}_source.tar.gz";
 
     # https://github.com/haka-security/haka/releases/download/v${version}/haka_${version}_source.tar.gz.sha1.txt
     sha1 = "87625ed32841cc0b3aa92aa49397ce71ce434bc2";

--- a/pkgs/tools/security/haka/default.nix
+++ b/pkgs/tools/security/haka/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, cmake, swig, wireshark, check, rsync, libpcap, gawk, libedit, pcre }:
+
+let version = "0.3.0"; in
+
+stdenv.mkDerivation rec {
+  name = "haka-${version}";
+
+  src = fetchurl {
+    name = "haka_${version}_source.tar.gz";
+    url = "https://github.com/haka-security/haka/releases/download/v${version}";
+
+    # https://github.com/haka-security/haka/releases/download/v${version}/haka_${version}_source.tar.gz.sha1.txt
+    sha1 = "87625ed32841cc0b3aa92aa49397ce71ce434bc2";
+  };
+
+  preConfigure = ''
+    sed -i 's,/etc,'$out'/etc,' src/haka/haka.c
+    sed -i 's,/etc,'$out'/etc,' src/haka/CMakeLists.txt
+    sed -i 's,/opt/haka/etc,$out/opt/haka/etc,' src/haka/haka.1
+    sed -i 's,/etc,'$out'/etc,' doc/user/tool_suite_haka.rst
+  '';
+
+  buildInputs = [ cmake swig wireshark check rsync libpcap gawk libedit pcre ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    dscription = "A collection of tools that allows capturing TCP/IP packets and filtering them based on Lua policy files";
+    homepage = http://www.haka-security.org/;
+    license = stdenv.lib.licenses.mpl20;
+    maintaineres = [ stdenv.lib.maintainers.tvestelind ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9285,6 +9285,8 @@ let
 
   groovebasin = callPackage ../applications/audio/groovebasin { };
 
+  haka = callPackage ../tools/security/haka { };
+
   heapster = (callPackage ../servers/monitoring/heapster { }).bin // { outputs = ["bin"]; };
 
   hbase = callPackage ../servers/hbase {};


### PR DESCRIPTION
I have made a package for Haka, a tool for capturing and filtering TCP/IP traffic. Their repository can be found here: https://github.com/haka-security/haka/
I also added options and a systemd service for NixOS.
Most of the testing have been manual but I also added a very basic test to nixos/tests/haka.nix.
