### PR TITLE
idea: fix problems with openjdk8

### DIFF
--- a/pkgs/applications/editors/idea/common.nix
+++ b/pkgs/applications/editors/idea/common.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeDesktopItem, makeWrapper, patchelf, p7zip
-, coreutils, gnugrep, which, git, python, unzip, androidsdk }:
+, coreutils, gnugrep, which, git, python, unzip, jdk }:
 
-{ name, product, version, build, src, meta, jdk } @ attrs:
+{ name, product, version, build, src, meta } @ attrs:
 
 with stdenv.lib;
 

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -1,6 +1,6 @@
 { stdenv, callPackage, fetchurl, makeDesktopItem, makeWrapper, patchelf
 , coreutils, gnugrep, which, git, python, unzip, p7zip
-, androidsdk, jdk, oraclejdk8
+, androidsdk, jdk
 }:
 
 assert stdenv.isLinux;
@@ -8,12 +8,7 @@ assert stdenv.isLinux;
 let
 
   bnumber = with stdenv.lib; build: last (splitString "-" build);
-  mkIdeaProduct' = callPackage ./common.nix { };
-  mkIdeaProduct = attrs: mkIdeaProduct' ({
-      # After IDEA 15 we can no longer use OpenJDK.
-      # https://youtrack.jetbrains.com/issue/IDEA-147272
-      jdk = if (bnumber attrs.build) < "143" then jdk else oraclejdk8;
-  } // attrs);
+  mkIdeaProduct = callPackage ./common.nix { };
 
   buildAndroidStudio = { name, version, build, src, license, description }:
     let drv = (mkIdeaProduct rec {

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -141,6 +141,11 @@ let
       rm -rf $out/lib/openjdk/jre/bina
       ln -s $out/lib/openjdk/bin $out/lib/openjdk/jre/bin
 
+      # Make sure cmm/*.pf are not symlinks:
+      # https://youtrack.jetbrains.com/issue/IDEA-147272
+      rm -rf $out/lib/openjdk/jre/lib/cmm
+      ln -s {$jre,$out}/lib/openjdk/jre/lib/cmm
+
       # Set PaX markings
       exes=$(file $out/lib/openjdk/bin/* $jre/lib/openjdk/jre/bin/* 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//')
       echo "to mark: *$exes*"


### PR DESCRIPTION
As described in #12555, the reason current IntelliJ versions fail to run with our openjdk8 is the following:

The imgscalr library tries to load the `GRAY.pf` ICC profile, which is located in `$out/lib/openjdk/jre/lib/cmm`.  The `java.awt.color.ICC_Profile` class handles this request, and (probably for security reasons) checks that `GRAY.pf` is indeed located in the `lib/cmm` directory.  However, at the moment `GRAY.pf` is a symlink to the corresponding file in the `$jre` output--i.e. not in the aforementioned directory--and hence this check fails:

``` java
return (f.isFile() && isChildOf(f, dir)) ? f : null;
```

This PR fixes the symlinks in the openjdk8 package, and then makes the IntelliJ package use openjdk8 by default again.

I'd really like to make the jdk easily overridable though, however I'm not familiar with the `makeOverridable` infrastructure.  Any pointers/ideas?

cc @edwtjo 
