### PR TITLE
teamspeak client: bump 3.0.18.1 -> 3.0.18.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -30,23 +30,22 @@ in
 stdenv.mkDerivation rec {
   name = "teamspeak-client-${version}";
 
-  version = "3.0.18.1";
+  version = "3.0.18.2";
 
   src = fetchurl {
     urls = [
       "http://dl.4players.de/ts/releases/${version}/TeamSpeak3-Client-linux_${arch}-${version}.run"
       "http://teamspeak.gameserver.gamed.de/ts3/releases/${version}/TeamSpeak3-Client-linux_${arch}-${version}.run"
-      "http://files.teamspeak-services.com/releases/${version}/TeamSpeak3-Client-linux_${arch}-${version}.run"
     ];
     sha256 = if stdenv.is64bit
-                then "1bc9m2niagqmijmzlki8jmp48vhns041xdjlji9fyqay6l5mx5fw"
-                else "156dirxjys7pbximw19qs7j52my36p4kp98df3kgrsiiv8mz6v68";
+                then "1r0l0jlng1fz0cyvnfa4hqwlszfraj5kcs2lg9qnqvp03x8sqn6h"
+                else "1pgpsv1r216l76fx0grlqmldd9gha3sj84gnm44km8y98b3hj525";
   };
 
   # grab the plugin sdk for the desktop icon
   pluginsdk = fetchurl {
-    url = "http://dl.4players.de/ts/client/pluginsdk/pluginsdk_3.0.16.zip";
-    sha256 = "1qpqpj3r21wff3ly9ail4l6b57pcqycsh2hca926j14sdlvpv7kl";
+    url = "http://dl.4players.de/ts/client/pluginsdk/pluginsdk_3.0.18.1.zip";
+    sha256 = "108y52mfg44cnnhhipnmrr0cxh7ram5c2hnchxjkwvf5766vbaq4";
   };
 
   buildInputs = [ makeWrapper less which unzip ];


### PR DESCRIPTION
Update for teamspeak client. Also removed a mirror that no longer works.

Note: I am the maintainer for this package.
