### PR TITLE
binutils: Add platforms

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -69,17 +69,15 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Tools for manipulating binaries (linker, assembler, etc.)";
-
     longDescription = ''
       The GNU Binutils are a collection of binary tools.  The main
       ones are `ld' (the GNU linker) and `as' (the GNU assembler).
       They also include the BFD (Binary File Descriptor) library,
       `gprof', `nm', `strip', etc.
     '';
-
     homepage = http://www.gnu.org/software/binutils/;
-
     license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.linux;
 
     /* Give binutils a lower priority than gcc-wrapper to prevent a
        collision due to the ld/as wrappers/symlinks in the latter. */


### PR DESCRIPTION
There are some variants of binutils in all-packages.nix that aren't
getting built by Hydra currently.
