### PR TITLE
nixos-ssh: set SSH_ASKPASS globally and not just on interactive shells

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -221,10 +221,7 @@ in
         fi
       '';
 
-    environment.interactiveShellInit = optionalString config.services.xserver.enable
-      ''
-        export SSH_ASKPASS=${askPassword}
-      '';
+    environment.variables.SSH_ASKPASS = optionalString config.services.xserver.enable askPassword;
 
     programs.ssh.askPassword = mkDefault "${pkgs.x11_ssh_askpass}/libexec/x11-ssh-askpass";
 


### PR DESCRIPTION
If we limit SSH_ASKPASS to interactive shells, users are unable to trigger
the ssh-passphrase dialog from their desktop environment autostart scripts.
Usecase: I call ssh-add during my desktop environment autostart and want to have
the passphrase dialog immediately after startup.
For this to work, SSH_ASKPASS needs to be propagated properly on
non-interactive shells.
