### PR TITLE
hg-crecord: switch to same revision, but fetched properly using fetchhg

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7942,9 +7942,10 @@ in modules // {
     name = "hg-crecord-${rev}";
     disabled = isPy3k;
 
-    src = pkgs.fetchurl {
-      url = "https://bitbucket.org/edgimar/crecord/get/${builtins.substring 0 12 rev}.tar.gz";
-      sha256 = "02003fa5620ec40a5ad0d7cede2e65c2cb398a7fe4e1ee26bd3396a87d63ad35";
+    src = pkgs.fetchhg {
+      inherit rev;
+      url = "https://bitbucket.org/edgimar/crecord";
+      sha256 = "14x1k5k0jv3fiynpdfyp5zh4qvs4nr6qwy09chv3js3dhs5887ic";
     };
 
     # crecord comes as just a bare directory


### PR DESCRIPTION
I was previously just fetching the bitbucket-generated tarball of this revision, but
this was vulnerable to breakage when bitbucket made micro-changes to the tarball
generation, causing the file hash to change. This should make mercurial-full buildable
again.
