### PR TITLE
haskell-packages: properly set postPatch

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -52,7 +52,7 @@ mkDerivation (rec {
   };
   isLibrary = true;
   isExecutable = true;
-  jailbreak = false; # manually jailbreak, until postPatch in mkDerivation is fixed
+  jailbreak = true;
   doHaddock = false;
   doCheck = false;
   buildDepends = [
@@ -72,9 +72,6 @@ mkDerivation (rec {
   ];
   patches = [ ./ghcjs.patch ];
   postPatch = ''
-    echo "Run jailbreak-cabal to lift version restrictions on build inputs."
-    ${jailbreak-cabal}/bin/jailbreak-cabal ${pname}.cabal
-
     substituteInPlace Setup.hs \
       --replace "/usr/bin/env" "${coreutils}/bin/env"
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -299,7 +299,6 @@ stdenv.mkDerivation ({
 // optionalAttrs (configureFlags != []) { inherit configureFlags; }
 // optionalAttrs (patches != [])        { inherit patches; }
 // optionalAttrs (patchPhase != "")     { inherit patchPhase; }
-// optionalAttrs (postPatch != "")      { inherit postPatch; }
 // optionalAttrs (preConfigure != "")   { inherit preConfigure; }
 // optionalAttrs (postConfigure != "")  { inherit postConfigure; }
 // optionalAttrs (preBuild != "")       { inherit preBuild; }


### PR DESCRIPTION
The existing code overrode the postPatch, instead of combining the
jailbreak commands with the user supplied postPatch.

/cc @peti 
