### PR TITLE
Gateone: fix cacerts dependency

### DIFF
--- a/nixos/modules/services/networking/gateone.nix
+++ b/nixos/modules/services/networking/gateone.nix
@@ -21,7 +21,7 @@ options = {
 };
 config = mkIf cfg.enable {
   environment.systemPackages = with pkgs.pythonPackages; [
-    gateone pkgs.openssh pkgs.procps pkgs.coreutils ];
+    gateone pkgs.openssh pkgs.procps pkgs.coreutils pkgs.cacert];
 
   users.extraUsers.gateone = {
     description = "GateOne privilege separation user";
@@ -49,8 +49,6 @@ config = mkIf cfg.enable {
       User = "gateone";
       Group = "gateone";
       WorkingDirectory = cfg.settingsDir;
-      PermissionsStartOnly = true;
-
     };
 
     wantedBy = [ "multi-user.target" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5065,18 +5065,21 @@ in modules // {
     name = "gateone-1.2-0d57c3";
     disabled = ! isPy27;
     src = pkgs.fetchFromGitHub {
-      rev = "11ed97c663b3e8c1b8eba473b5cf8362b10d57c3";
+      rev = "1d0e8037fbfb7c270f3710ce24154e24b7031bea";
       owner= "liftoff";
       repo = "GateOne";
-      sha256 ="0zp9vfs6sqbx4d0g45kkjinfmsl9zqwa6bhp3xd81wx3ph9yr1hq";
+      sha256 = "1ghrawlqwv7wnck6alqpbwy9mpv0y21cw2jirrvsxaracmvgk6vv";
     };
-    propagatedBuildInputs = with self; [tornado futures html5lib readline pkgs.openssl];
+    propagatedBuildInputs = with self; [tornado futures html5lib readline pkgs.openssl pkgs.cacert pkgs.openssh];
     meta = {
       homepage = https://liftoffsoftware.com/;
       description = "GateOne is a web-based terminal emulator and SSH client";
       maintainers = with maintainers; [ tomberek ];
 
     };
+    postInstall=''
+    cp -R $out/gateone/* $out/lib/python2.7/site-packages/gateone
+    '';
   };
 
   gcutil = buildPythonPackage rec {


### PR DESCRIPTION
Update to latest version and give gateone access to cacerts (required for some authentication schemes).

postInstall will ensure assets are available where they are expected to be.
