### PR TITLE
fix set-source-date-epoch-to-latest

### DIFF
--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -27,5 +27,9 @@ updateSourceDateEpoch() {
 postUnpackHooks+=(_updateSourceDateEpochFromSourceRoot)
 
 _updateSourceDateEpochFromSourceRoot() {
-    updateSourceDateEpoch "$sourceRoot"
+    if [ -z "$sourceRoot" ]; then
+      echo "warning: \$sourceRoot missing in the derivation"
+    else
+      updateSourceDateEpoch "$sourceRoot"
+    fi
 }


### PR DESCRIPTION
In some cases the $sourceRoot is missing (eg: some ruby packages). Explain the error explicitly instead
of showing the following cryptic error:

```
find: cannot search `': No such file or directory
/nix/store/0p1afvl8jcpi6dvsq2n58i90w9c59vz1-set-source-date-epoch-to-latest.sh: line 12: [: : integer expression expected
```
