### PR TITLE
Racket package improvements

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
     for p in $(ls $out/bin/) ; do
       wrapProgram $out/bin/$p --set LD_LIBRARY_PATH "${LD_LIBRARY_PATH}";
     done
+    export PATH="$out/bin:$PATH";
+    raco setup;
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
- Run `raco setup` after installing `racket`, otherwise some later runs of `raco pkg install` can try to build the documentation for some packages which are in the read-only nix-store.
- Added nightlies version of racket.

Concerning the nightlies, what's the best way to keep track of the lastest and greatest? Should I regularly submit a PR which just changes the commit and sha256, or is there a way to somewhat automate that?
