### PR TITLE
systemd: make ctrl-alt-del target configurable.

### DIFF
--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -177,6 +177,8 @@ rec {
         # Stupid misc. symlinks.
         ln -s ${cfg.defaultUnit} $out/default.target
 
+        ln -s ${cfg.ctrl-alt-del} $out/ctrl-alt-del.target
+
         ln -s rescue.target $out/kbrequest.target
 
         mkdir -p $out/getty.target.wants/

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -120,7 +120,6 @@ let
       "systemd-poweroff.service"
       "halt.target"
       "systemd-halt.service"
-      "ctrl-alt-del.target"
       "shutdown.target"
       "umount.target"
       "final.target"
@@ -161,7 +160,6 @@ let
       "systemd-localed.service"
       "systemd-hostnamed.service"
     ]
-
     ++ cfg.additionalUpstreamSystemUnits;
 
   upstreamSystemWants =
@@ -475,6 +473,12 @@ in
       default = "multi-user.target";
       type = types.str;
       description = "Default unit started when the system boots.";
+    };
+
+    systemd.ctrl-alt-del = mkOption {
+      default = "reboot.target";
+      type = types.str;
+      description = "Target that should be started when Ctrl-Alt-Delete is pressed.";
     };
 
     systemd.globalEnvironment = mkOption {


### PR DESCRIPTION
We currently only allow upstream's default of "reboot.target" due to the
way the symlinks are initialized. I made this configurable similar to the
default unit.

I developed and tested this originally on 15.09, but the code on master applied cleanly and looks fine. I don't have a master-based environment around at the moment to test this explicitly.
