### PR TITLE
VDPAU and VA-API fixes, Mesa update

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -174,6 +174,12 @@ nginx.override {
     of adding <literal>gutenprint</literal> to the <literal>drivers</literal> list.
     </para>
   </listitem>
+
+  <listitem>
+    <para><literal>services.xserver.vaapiDrivers</literal> has been removed. Use
+    <literal>services.hardware.opengl.extraPackages{,32}</literal> instead. You can
+    also specify VDPAU drivers there.</para>
+  </listitem>
 </itemizedlist>
 
 

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -10,13 +10,23 @@ let
 
   videoDrivers = config.services.xserver.videoDrivers;
 
-  makePackage = p: p.buildEnv {
+  makePackage = p: pkgs.buildEnv {
     name = "mesa-drivers+txc-${p.mesa_drivers.version}";
     paths =
       [ p.mesa_drivers
         p.mesa_noglu # mainly for libGL
         (if cfg.s3tcSupport then p.libtxc_dxtn else p.libtxc_dxtn_s2tc)
       ];
+  };
+
+  package = pkgs.buildEnv {
+    name = "opengl-drivers";
+    paths = [ cfg.package ] ++ cfg.extraPackages;
+  };
+
+  package32 = pkgs.buildEnv {
+    name = "opengl-drivers-32bit";
+    paths = [ cfg.package32 ] ++ cfg.extraPackages32;
   };
 
 in
@@ -75,7 +85,25 @@ in
       internal = true;
       description = ''
         The package that provides the 32-bit OpenGL implementation on
-        64-bit systems.  Used when <option>driSupport32Bit</option> is
+        64-bit systems. Used when <option>driSupport32Bit</option> is
+        set.
+      '';
+    };
+
+    hardware.opengl.extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = ''
+        Additional packages to add to OpenGL drivers.
+      '';
+    };
+
+    hardware.opengl.extraPackages32 = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = ''
+        Additional packages to add to 32-bit OpenGL drivers on
+        64-bit systems. Used when <option>driSupport32Bit</option> is
         set.
       '';
     };
@@ -91,11 +119,11 @@ in
 
     system.activationScripts.setup-opengl =
       ''
-        ln -sfn ${cfg.package} /run/opengl-driver
+        ln -sfn ${package} /run/opengl-driver
         ${if pkgs.stdenv.isi686 then ''
           ln -sfn opengl-driver /run/opengl-driver-32
         '' else if cfg.driSupport32Bit then ''
-          ln -sfn ${cfg.package32} /run/opengl-driver-32
+          ln -sfn ${package32} /run/opengl-driver-32
         '' else ''
           rm -f /run/opengl-driver-32
         ''}

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -93,18 +93,21 @@ in
     hardware.opengl.extraPackages = mkOption {
       type = types.listOf types.package;
       default = [];
+      example = literalExample "with pkgs; [ vaapiIntel libvdpau-va-gl vaapiVdpau ]";
       description = ''
-        Additional packages to add to OpenGL drivers.
+        Additional packages to add to OpenGL drivers. This can be used
+        to add additional VA-API/VDPAU drivers.
       '';
     };
 
     hardware.opengl.extraPackages32 = mkOption {
       type = types.listOf types.package;
       default = [];
+      example = literalExample "with pkgs; [ vaapiIntel libvdpau-va-gl vaapiVdpau ]";
       description = ''
         Additional packages to add to 32-bit OpenGL drivers on
         64-bit systems. Used when <option>driSupport32Bit</option> is
-        set.
+        set. This can be used to add additional VA-API/VDPAU drivers.
       '';
     };
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -77,6 +77,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "xserver" "driSupport32Bit" ] [ "hardware" "opengl" "driSupport32Bit" ])
     (mkRenamedOptionModule [ "services" "xserver" "s3tcSupport" ] [ "hardware" "opengl" "s3tcSupport" ])
     (mkRenamedOptionModule [ "hardware" "opengl" "videoDrivers" ] [ "services" "xserver" "videoDrivers" ])
+    (mkRenamedOptionModule [ "services" "xserver" "vaapiDrivers" ] [ "hardware" "opengl" "extraPackages" ])
 
     (mkRenamedOptionModule [ "services" "mysql55" ] [ "services" "mysql" ])
 

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -16,13 +16,6 @@ let
   cfg = config.services.xserver;
   xorg = pkgs.xorg;
 
-  vaapiDrivers = pkgs.buildEnv {
-    name = "vaapi-drivers";
-    paths = cfg.vaapiDrivers;
-    # We only want /lib/dri, but with a single input path, we need "/" for it to work
-    pathsToLink = [ "/" ];
-  };
-
   fontconfig = config.fonts.fontconfig;
   xresourcesXft = pkgs.writeText "Xresources-Xft" ''
     ${optionalString (fontconfig.dpi != 0) ''Xft.dpi: ${toString fontconfig.dpi}''}
@@ -106,8 +99,6 @@ let
       elif test -e ~/.Xdefaults; then
           ${xorg.xrdb}/bin/xrdb -merge ~/.Xdefaults
       fi
-
-      export LIBVA_DRIVERS_PATH=${vaapiDrivers}/lib/dri
 
       # Speed up application start by 50-150ms according to
       # http://kdemonkey.blogspot.nl/2008/04/magic-trick.html

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -216,15 +216,6 @@ in
         '';
       };
 
-      vaapiDrivers = mkOption {
-        type = types.listOf types.path;
-        default = [ ];
-        example = literalExample "[ pkgs.vaapiIntel pkgs.vaapiVdpau ]";
-        description = ''
-          Packages providing libva acceleration drivers.
-        '';
-      };
-
       startGnuPGAgent = mkOption {
         type = types.bool;
         default = false;

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "libva-1.6.1";
+  name = "libva-1.6.2";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/vaapi/releases/libva/${name}.tar.bz2";
-    sha256 = "0bjfb5s8dk3lql843l91ffxzlq47isqks5sj19cxh7j3nhzw58kz";
+    sha256 = "1l4bij21shqbfllbxicmqgmay4v509v9hpxyyia9wm7gvsfg05y4";
   };
 
   buildInputs = [ libX11 libXext pkgconfig libdrm libXfixes wayland libffi mesa_noglu ];

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libX11, pkgconfig, libXext, libdrm, libXfixes, wayland, libffi
-, mesa ? null
+, mesa_noglu ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -10,9 +10,20 @@ stdenv.mkDerivation rec {
     sha256 = "0bjfb5s8dk3lql843l91ffxzlq47isqks5sj19cxh7j3nhzw58kz";
   };
 
-  buildInputs = [ libX11 libXext pkgconfig libdrm libXfixes wayland libffi mesa ];
+  buildInputs = [ libX11 libXext pkgconfig libdrm libXfixes wayland libffi mesa_noglu ];
 
-  configureFlags = stdenv.lib.optional (mesa != null) "--enable-glx";
+  configureFlags = stdenv.lib.optionals (mesa_noglu != null) [
+    "--with-drivers-path=${mesa_noglu.driverLink}/lib/dri"
+    "--enable-glx"
+  ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    cp -r $out/${mesa_noglu.driverLink}/* $out
+    cp -r $out/$out/* $out
+    rm -rf $out/run $out/$(echo "$out" | cut -d "/" -f2)
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/vaapi;

--- a/pkgs/development/libraries/libvdpau-va-gl/default.nix
+++ b/pkgs/development/libraries/libvdpau-va-gl/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libX11, libpthreadstubs, libvdpau, glib
+, libva, ffmpeg, mesa_glu }:
+
+let
+  version = "0.3.4";
+
+in stdenv.mkDerivation rec {
+  name = "libvdpau-va-gl-${version}";
+
+  src = fetchFromGitHub {
+    owner = "i-rinat";
+    repo = "libvdpau-va-gl";
+    rev = "v${version}";
+    sha256 = "1909f3srm2iy2hv4m6jxg1nxrh9xgsnjs07wfzw3ais1fww0i2nn";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libX11 libpthreadstubs libvdpau glib libva ffmpeg mesa_glu ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/i-rinat/libvdpau-va-gl;
+    description = "VDPAU driver with OpenGL/VAAPI backend";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, xorg }:
+{ stdenv, fetchurl, pkgconfig, xorg, mesa_noglu }:
 
 stdenv.mkDerivation rec {
   name = "libvdpau-1.1.1";
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
   buildInputs = with xorg; [ pkgconfig dri2proto libXext ];
 
   propagatedBuildInputs = [ xorg.libX11 ];
+
+  configureFlags = [ "--with-module-dir=${mesa_noglu.driverLink}/lib/vdpau" ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    cp -r $out/${mesa_noglu.driverLink}/* $out
+    cp -r $out/$out/* $out
+    rm -rf $out/run $out/$(echo "$out" | cut -d "/" -f2)
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://people.freedesktop.org/~aplattner/vdpau/;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -22,7 +22,7 @@ else
 */
 
 let
-  version = "11.0.8";
+  version = "11.1.1";
   # this is the default search path for DRI drivers
   driverLink = "/run/opengl-driver" + stdenv.lib.optionalString stdenv.isi686 "-32";
 in
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
         + head (splitString "." version) + ''.x/${version}/mesa-${version}.tar.xz'')
       "https://launchpad.net/mesa/trunk/${version}/+download/mesa-${version}.tar.xz"
     ];
-    sha256 = "5696e4730518b6805d2ed5def393c4293f425a2c2c01bd5ed4bdd7ad62f7ad75";
+    sha256 = "087xlxl8dzmhzjilpsdiy19dn106spq120c9ndgnn4qlqm7hgnv4";
   };
 
   prePatch = "patchShebangs .";

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -154,8 +154,6 @@ stdenv.mkDerivation {
     done
   '' + /* set the default search path for DRI drivers; used e.g. by X server */ ''
     substituteInPlace "$out/lib/pkgconfig/dri.pc" --replace '$(drivers)' "${driverLink}"
-  '' + /* move vdpau drivers to $drivers/lib, so they are found */ ''
-    mv "$drivers"/lib/vdpau/* "$drivers"/lib/ && rmdir "$drivers"/lib/vdpau
   '';
   #ToDo: @vcunat isn't sure if drirc will be found when in $out/etc/, but it doesn't seem important ATM
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder-legacy304.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder-legacy304.sh
@@ -93,6 +93,10 @@ installPhase() {
         substituteInPlace $out/share/applications/nvidia-settings.desktop \
             --replace '__UTILS_PATH__' $out/bin \
             --replace '__PIXMAP_PATH__' $out/share/pixmaps
+
+        # Move VDPAU libraries to their place
+        mkdir "$out"/lib/vdpau
+        mv "$out"/lib/libvdpau* "$out"/lib/vdpau
     fi
 }
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder-legacy340.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder-legacy340.sh
@@ -108,8 +108,12 @@ installPhase() {
     #patchelf --set-rpath $cudaPath $out/lib/libcuda.so.*.*
     #patchelf --set-rpath $openclPath $out/lib/libnvidia-opencl.so.*.*
 
-    # we distribute these separately in `libvdpau`
+    # We distribute these separately in `libvdpau`
     rm "$out"/lib/libvdpau{.*,_trace.*}
+
+    # Move VDPAU libraries to their place
+    mkdir "$out"/lib/vdpau
+    mv "$out"/lib/libvdpau* "$out"/lib/vdpau
 }
 
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -119,8 +119,12 @@ installPhase() {
     # For simplicity and dependency reduction, don't support the gtk3 interface.
     rm $out/lib/libnvidia-gtk3.*
 
-    # we distribute these separately in `libvdpau`
+    # We distribute these separately in `libvdpau`
     rm "$out"/lib/libvdpau{.*,_trace.*}
+
+    # Move VDPAU libraries to their place
+    mkdir "$out"/lib/vdpau
+    mv "$out"/lib/libvdpau* "$out"/lib/vdpau
 }
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7726,6 +7726,8 @@ let
 
   libvdpau = callPackage ../development/libraries/libvdpau { };
 
+  libvdpau-va-gl = callPackage ../development/libraries/libvdpau-va-gl { };
+
   libvirt = callPackage ../development/libraries/libvirt { };
 
   libvirt-glib = callPackage ../development/libraries/libvirt-glib { };


### PR DESCRIPTION
This makes several changes in packages:
1. Both VA-API and VDPAU libraries now expect drivers in our `/run/opengl-driver{,-32}` directories.
2. VDPAU drivers now reside in their proper place of `/lib/vdpau` (that touches `mesa`, so that's a mass rebuild).

On the NixOS side, we now have `hardware.opengl.extraPackages{,32}` for adding extra packages to the drivers' directories. Old `services.xserver.vaapiDrivers` option is now removed in favor of them (marked as renamed, because types and expected inputs are identical).

Aside from cleanup that (2) gives us (less libraries in `LD_LIBRARY_PATH`), this allows user now to use `libvdpau-va-gl` (it isn't possible without `extraPackages`) and as a bonus, to add 32-bit VDPAU/VA-API libraries. As a probably unremarkable improvement, VA-API also should now work for SUID binaries.

As an example, this configuration:

```
hardware.opengl.extraPackages = with pkgs; [ vaapiIntel libvdpau-va-gl ];
hardware.opengl.extraPackages32 = with pkgs.pkgsi686Linux; [ vaapiIntel libvdpau-va-gl ];
```

Gives me working VA-API and VDPAU (via VA-API bridge) for Intel card for both 64-bit and 32-bit applications.
