### PR TITLE
sddm: add numlock switch

### DIFF
--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -31,6 +31,9 @@ let
     [General]
     HaltCommand=${pkgs.systemd}/bin/systemctl poweroff
     RebootCommand=${pkgs.systemd}/bin/systemctl reboot
+    ${optionalString cfg.autoNumlock ''
+    Numlock=on
+    ''}
 
     [Theme]
     Current=${cfg.theme}
@@ -107,6 +110,14 @@ in
         default = [];
         description = ''
           Extra packages providing themes.
+        '';
+      };
+
+      autoNumlock = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable numlock at login.
         '';
       };
 


### PR DESCRIPTION
- added numlock on boot switch
- simply add :
  services.xserver.displayManager.sddm.autoNumlock = true;
  to configuration.nix and sddm will start
  with numlock enabled.
