### PR TITLE
pkgs.darktable: 1.6.9 -> 2.0.0

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -1,46 +1,35 @@
 { stdenv, fetchurl, libsoup, graphicsmagick, SDL, json_glib
 , GConf, atk, cairo, cmake, curl, dbus_glib, exiv2, glib
-, libgnome_keyring, gtk, ilmbase, intltool, lcms, lcms2
+, libgnome_keyring, gtk3, ilmbase, intltool, lcms, lcms2
 , lensfun, libXau, libXdmcp, libexif, libglade, libgphoto2, libjpeg
-, libpng, libpthreadstubs, libraw1394, librsvg, libtiff, libxcb
+, libpng, libpthreadstubs, librsvg, libtiff, libxcb
 , openexr, pixman, pkgconfig, sqlite, bash, libxslt, openjpeg
-, mesa }:
+, mesa, lua, pugixml, colord, colord-gtk, libxshmfence, libxkbcommon
+, epoxy, at_spi2_core, libwebp, libsecret
+}:
 
 assert stdenv ? glibc;
 
 stdenv.mkDerivation rec {
-  version = "1.6.9";
+  version = "2.0.0";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "0wri89ygjpv7npiz58mnydhgldywp6arqp9jq3v0g54a56fiwwhg";
+    sha256 = "1cbwvzqn3158cy7r499rdwipx7fpb30lrrvh6jy5a4xvpcjzbwnl";
   };
 
   buildInputs =
-    [ GConf atk cairo cmake curl dbus_glib exiv2 glib libgnome_keyring gtk
+    [ GConf atk cairo cmake curl dbus_glib exiv2 glib libgnome_keyring gtk3
       ilmbase intltool lcms lcms2 lensfun libXau libXdmcp libexif
-      libglade libgphoto2 libjpeg libpng libpthreadstubs libraw1394
+      libglade libgphoto2 libjpeg libpng libpthreadstubs
       librsvg libtiff libxcb openexr pixman pkgconfig sqlite libxslt
-      libsoup graphicsmagick SDL json_glib openjpeg mesa
+      libsoup graphicsmagick SDL json_glib openjpeg mesa lua pugixml
+      colord colord-gtk libxshmfence libxkbcommon epoxy at_spi2_core
+      libwebp libsecret
     ];
 
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk}/include/gtk-2.0"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk}/lib/gtk-2.0/include"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${cairo}/include/cairo"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${atk}/include/atk-1.0"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${ilmbase}/include/OpenEXR"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${openexr}/include/OpenEXR"
-  '';
-
   cmakeFlags = [
-    "-DPTHREAD_INCLUDE_DIR=${stdenv.glibc}/include"
-    "-DPTHREAD_LIBRARY=${stdenv.glibc}/lib/libpthread.so"
-    "-DCMAKE_BUILD_TYPE=Release"
-    "-DBINARY_PACKAGE_BUILD=1"
-    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib}/lib/glib-2.0/include"
-    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk}/lib/gtk-2.0/include"
     "-DBUILD_USERMANUAL=False"
   ];
 

--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake }:
+{ stdenv, fetchurl, cmake, shared ? false }:
 
 stdenv.mkDerivation rec {
   name = "pugixml-${version}";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   sourceRoot = "${name}/scripts";
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if shared then "ON" else "OFF"}" ];
 
   preConfigure = ''
     # Enable long long support (required for filezilla)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11468,6 +11468,7 @@ let
 
   darktable = callPackage ../applications/graphics/darktable {
     inherit (gnome) GConf libglade;
+    pugixml = pugixml.override { shared = true; };
   };
 
   das_watchdog = callPackage ../tools/system/das_watchdog { };


### PR DESCRIPTION
See http://www.darktable.org/2015/12/darktable-2-0-released/

Nixpkgs already have PR #11982 about this subject.

In a discussion, @ikervagyok (the author of the related PR) suggested to take this variant over his: https://github.com/lancelotsix/nixpkgs/commit/5354617c9096ae22aa4221782007b2539c369344#commitcomment-15354657 

Considering the absence of activity on PR #11982, I propose this one as drop-in replacement. One of the two PR should be closed.

cc @nckx @rickynils @flosse 
