### PR TITLE
WIP: pythonPackages.setuptools: 19.4 -> 19.6

### DIFF
--- a/pkgs/development/python-modules/generic/run_setup.py
+++ b/pkgs/development/python-modules/generic/run_setup.py
@@ -1,6 +1,0 @@
-import setuptools
-import tokenize
-
-__file__='setup.py';
-
-exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   shortName = "setuptools-${version}";
   name = "${python.executable}-${shortName}";
 
-  version = "19.4";  # 18.4 and up breaks python34Packages.characteristic and many others
+  version = "19.6";
 
   src = fetchurl {
     url = "http://pypi.python.org/packages/source/s/setuptools/${shortName}.tar.gz";
-    sha256 = "214bf29933f47cf25e6faa569f710731728a07a19cae91ea64f826051f68a8cf";
+    sha256 = "1s8jd6lgaqjk5vbc3h5grvabzbzsvsk67f1651mcr3hs7isqvm7c";
   };
 
   buildInputs = [ python wrapPython ];


### PR DESCRIPTION
This updates setuptools to the latest version, 19.6.
There are some problems with this version, see https://bitbucket.org/pypa/setuptools/issues/490/upgrading-194-196-breaks-pyramid_mako 
and #12552, and therefore we won't upgrade yet.
