### PR TITLE
fetchurl: support sha512

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -87,6 +87,7 @@ in
 
 assert builtins.isList urls;
 assert (urls == []) != (url == "");
+assert sha512 != "" -> builtins.compareVersions "1.11" builtins.nixVersion <= 0;
 
 
 let

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -61,6 +61,7 @@ in
 , md5 ? ""
 , sha1 ? ""
 , sha256 ? ""
+, sha512 ? ""
 
 , recursiveHash ? false
 
@@ -91,7 +92,7 @@ assert (urls == []) != (url == "");
 let
 
   hasHash = showURLs || (outputHash != "" && outputHashAlgo != "")
-    || md5 != "" || sha1 != "" || sha256 != "";
+    || md5 != "" || sha1 != "" || sha256 != "" || sha512 != "";
   urls_ = if urls != [] then urls else [url];
 
 in
@@ -114,9 +115,11 @@ if (!hasHash) then throw "Specify hash for fetchurl fixed-output derivation: ${s
 
   # New-style output content requirements.
   outputHashAlgo = if outputHashAlgo != "" then outputHashAlgo else
-      if sha256 != "" then "sha256" else if sha1 != "" then "sha1" else "md5";
+      if sha512 != "" then "sha512" else if sha256 != "" then "sha256"
+      else if sha1 != "" then "sha1" else "md5";
   outputHash = if outputHash != "" then outputHash else
-      if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
+      if sha512 != "" then sha512 else if sha256 != "" then sha256
+      else if sha1 != "" then sha1 else md5;
 
   outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 


### PR DESCRIPTION
Nix 1.11 supports SHA512 hash algorithm.
