### PR TITLE
pythonPackages.setuptoolsTrial: make twisted overridable

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   buildInputs = with pythonPackages; [
-    mock setuptoolsTrial
+    mock (setuptoolsTrial.override { twisted = twisted15; })
   ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18164,7 +18164,7 @@ in modules // {
   };
 
 
-  setuptoolsTrial = buildPythonPackage {
+  setuptoolsTrial = makeOverridable ({ twisted ? self.twisted }: buildPythonPackage {
     name = "setuptools-trial-0.5.12";
 
     src = pkgs.fetchurl {
@@ -18181,7 +18181,7 @@ in modules // {
 
       license = "unspecified"; # !
     };
-  };
+  }) {};
 
   simplegeneric = buildPythonPackage rec {
     version = "0.8.1";


### PR DESCRIPTION
This allows matrix-synapse and tahoelafs to share this package, despite relying on incompatible Twisted versions.
