### PR TITLE
tptp: 6.1.0 -> 6.3.0, and get rid of builderDefsPackage

### DIFF
--- a/pkgs/applications/science/logic/tptp/default.nix
+++ b/pkgs/applications/science/logic/tptp/default.nix
@@ -11,14 +11,14 @@ let
     (builtins.attrNames (builtins.removeAttrs x helperArgNames));
   sourceInfo = rec {
     baseName="TPTP";
-    version="6.1.0";
+    version="6.3.0";
     name="${baseName}-${version}";
     urls=
     [
     "http://www.cs.miami.edu/~tptp/TPTP/Distribution/TPTP-v${version}.tgz"
     "http://www.cs.miami.edu/~tptp/TPTP/Archive/TPTP-v${version}/TPTP-v${version}.tgz"
     ];
-    hash="054p0kx9qh619ixslxpb4qcwvcqr4kan154b3a87b546b78k7kv4";
+    hash="17wl80mnm91jp3npdjzfbb8ds45f2gni250jlfw0d91i1476wcl3";
   };
 in
 rec {

--- a/pkgs/applications/science/logic/tptp/default.nix
+++ b/pkgs/applications/science/logic/tptp/default.nix
@@ -1,90 +1,48 @@
-x@{builderDefsPackage
-  , yap, tcsh, perl, patchelf, pkgsi686Linux
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    ["pkgsi686Linux"];
+{ stdenv, fetchurl, yap, tcsh, perl, patchelf }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    baseName="TPTP";
-    version="6.3.0";
-    name="${baseName}-${version}";
-    urls=
-    [
-    "http://www.cs.miami.edu/~tptp/TPTP/Distribution/TPTP-v${version}.tgz"
-    "http://www.cs.miami.edu/~tptp/TPTP/Archive/TPTP-v${version}/TPTP-v${version}.tgz"
+stdenv.mkDerivation rec {
+  name = "TPTP-${version}";
+  version = "6.3.0";
+
+  src = fetchurl {
+    url = [
+      "http://www.cs.miami.edu/~tptp/TPTP/Distribution/TPTP-v${version}.tgz"
+      "http://www.cs.miami.edu/~tptp/TPTP/Archive/TPTP-v${version}/TPTP-v${version}.tgz"
     ];
-    hash="17wl80mnm91jp3npdjzfbb8ds45f2gni250jlfw0d91i1476wcl3";
-  };
-in
-rec {
-  src = a.fetchurl {
-    urls = sourceInfo.urls;
-    sha256 = sourceInfo.hash;
+    sha256 = "17wl80mnm91jp3npdjzfbb8ds45f2gni250jlfw0d91i1476wcl3";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  buildInputs = [ tcsh yap perl patchelf ];
 
-  /* doConfigure should be removed if not needed */
-  phaseNames = ["goTarget" "doUnpack" "fixPlace" "setVars" "installScripts" 
-    "patchBinaries" "makeLinks"];
+  installPhase = ''
+    sharedir=$out/share/tptp
 
-  goTarget = a.fullDepEntry ''
-    mkdir -p "$out"/share/
-    cd "$out"/share/
-  '' ["defEnsureDir" "minInit"];
+    mkdir -p $sharedir
+    cp -r ./ $sharedir
 
-  fixPlace = a.fullDepEntry ''
-    cd ..
-    mv TPTP-* tptp
-    cd tptp
-  '' ["minInit" "doUnpack"];
+    export TPTP=$sharedir
 
-  setVars = a.noDepEntry ''
-    export TPTP="$PWD"
+    tcsh $sharedir/Scripts/tptp2T_install -default
+
+    substituteInPlace $sharedir/TPTP2X/tptp2X_install --replace /bin/mv mv
+    tcsh $sharedir/TPTP2X/tptp2X_install -default
+
+    patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $sharedir/Scripts/tptp4X
+
+    mkdir -p $out/bin
+    ln -s $sharedir/TPTP2X/tptp2X $out/bin
+    ln -s $sharedir/Scripts/tptp2T $out/bin
+    ln -s $sharedir/Scripts/tptp4X $out/bin
   '';
 
-  installScripts = a.fullDepEntry ''
-    tcsh "$out/share/tptp/Scripts/tptp2T_install" -default
-
-    sed -e 's@^ */bin/@@' -i TPTP2X/*
-
-    tcsh "$out/share/tptp/TPTP2X/tptp2X_install" -default
-  '' ["addInputs"];
-
-  makeLinks = a.fullDepEntry ''
-    mkdir -p "$out/bin"
-    ln -s "../share/tptp/TPTP2X/tptp2X" "$out/bin"
-    ln -s "../share/tptp/Scripts/tptp2T" "$out/bin"
-    ln -s "../share/tptp/Scripts/tptp4X" "$out/bin"
-  '' ["defEnsureDir" "minInit"];
-
-  patchBinaries = a.fullDepEntry ''
-    patchelf --set-interpreter "${pkgsi686Linux.glibc}"/lib/ld-linux.so.* \
-      "Scripts/tptp4X"
-  '' ["addInputs"];
-      
-  meta = {
+  meta = with stdenv.lib; {
     description = "Thousands of problems for theorem provers and tools";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    # A GiB of data. Installation is unpacking and editing a few files.
+    maintainers = with maintainers; [ raskin gebner ];
+    # 6.3 GiB of data. Installation is unpacking and editing a few files.
     # No sense in letting Hydra build it.
     # Also, it is unclear what is covered by "verbatim" - we will edit configs
     hydraPlatforms = [];
-    license = "verbatim-redistribution";
+    platforms = platforms.all;
+    license = licenses.unfreeRedistributable;
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://tptp.org/";
-    };
-  };
-}) x
-
+}


### PR DESCRIPTION
TPTP contains one binary executable for 64-bit linux, but all other scripts (and the gigabytes of problem files) should work fine on other platforms, hence I've set platforms to `platforms.all`.

cc maintainer @7c6f434c 
