### PR TITLE
Pre-generate fontconfig caches

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -129,6 +129,14 @@ with lib;
 
         };
 
+        cache32Bit = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            Generate system fonts cache for 32-bit applications.
+          '';
+        };
+
       };
 
     };
@@ -231,12 +239,19 @@ with lib;
         "${pkgs.fontconfig}/etc/fonts/fonts.conf";
 
       environment.etc."fonts/${pkgs.fontconfig.configVersion}/conf.d/00-nixos.conf".text =
-        ''
+        let
+          cache = fontconfig: pkgs.makeFontsCache { inherit fontconfig; fontDirectories = config.fonts.fonts; };
+        in ''
           <?xml version='1.0'?>
           <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
           <fontconfig>
             <!-- Font directories -->
             ${concatStringsSep "\n" (map (font: "<dir>${font}</dir>") config.fonts.fonts)}
+            <!-- Pre-generated font caches -->
+            <cachedir>${cache pkgs.fontconfig}</cachedir>
+            ${optionalString (pkgs.stdenv.isx86_64 && config.fonts.fontconfig.cache32Bit) ''
+              <cachedir>${cache pkgs.pkgsi686Linux.fontconfig}</cachedir>
+            ''}
           </fontconfig>
         '';
 

--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -1,0 +1,27 @@
+{ runCommand, lib, writeText, fontconfig, fontbhttf, fontDirectories }:
+
+runCommand "fc-cache"
+  rec {
+    buildInputs = [ fontconfig ];
+    passAsFile = [ "fontDirs" ];
+    fontDirs = ''
+      <!-- Font directories -->
+      ${lib.concatStringsSep "\n" (map (font: "<dir>${font}</dir>") fontDirectories)}
+    '';
+  }
+  ''
+    export FONTCONFIG_FILE=$(pwd)/fonts.conf
+
+    cat > fonts.conf << EOF
+    <?xml version='1.0'?>
+    <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+    <fontconfig>
+      <include>${fontconfig}/etc/fonts/fonts.conf</include>
+      <cachedir>$out</cachedir>
+    EOF
+    cat "$fontDirsPath" >> fonts.conf
+    echo "</fontconfig>" >> fonts.conf
+
+    mkdir -p $out
+    fc-cache -sv
+  ''

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -23,15 +23,15 @@
     <fontconfig>
       <xsl:apply-templates select="child::node()[name() != 'dir' and name() != 'cachedir' and name() != 'include']" />
 
-      <!-- fontconfig distribution conf.d -->
-      <include><xsl:value-of select="$fontconfig" />/etc/fonts/conf.d</include>
-      <!-- versioned system-wide config -->
-      <include ignore_missing="yes">/etc/fonts/<xsl:value-of select="$fontconfigConfigVersion" />/conf.d</include>
-
       <!-- the first cachedir will be used to store the cache -->
       <cachedir prefix="xdg">fontconfig</cachedir>
       <!-- /var/cache/fontconfig is useful for non-nixos systems -->
       <cachedir>/var/cache/fontconfig</cachedir>
+
+      <!-- fontconfig distribution conf.d -->
+      <include><xsl:value-of select="$fontconfig" />/etc/fonts/conf.d</include>
+      <!-- versioned system-wide config -->
+      <include ignore_missing="yes">/etc/fonts/<xsl:value-of select="$fontconfigConfigVersion" />/conf.d</include>
 
       <dir prefix="xdg">fonts</dir>
       <xsl:for-each select="str:tokenize($fontDirectories)">

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6503,6 +6503,11 @@ let
       inherit fontconfig fontDirectories;
     };
 
+  makeFontsCache = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
+    callPackage ../development/libraries/fontconfig/make-fonts-cache.nix {
+      inherit fontconfig fontDirectories;
+    };
+
   freealut = callPackage ../development/libraries/freealut { };
 
   freeglut = callPackage ../development/libraries/freeglut { };


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/12648. Also should generally improve startup times, I think. Note that when using fonts like `noto-fonts-cjk` the build time would be somewhat long -- that's expected (better than having all applications rebuild this in memory on every start!).
