### PR TITLE
fontconfig service: disable when xserver is disabled too

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -11,7 +11,7 @@ with lib;
       fontconfig = {
         enable = mkOption {
           type = types.bool;
-          default = true;
+          default = false;
           description = ''
             If enabled, a Fontconfig configuration file will be built
             pointing to a set of default fonts.  If you don't care about

--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -84,5 +84,7 @@ in {
     '';
 
     hardware.opengl.enable = mkIf cfg.hwRender true;
+
+    fonts.fontconfig.enable = true;
   };
 }

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -651,6 +651,8 @@ in
         ${xrandrMonitorSections}
       '';
 
+    fonts.fontconfig.enable = true;
+
   };
 
 }


### PR DESCRIPTION
Fontconfig by default is not needed on systems where fonts are not actually rendered. This would be a breaking change, but with a more fine-grained approach (enabling `fontconfig` where needed) we can bring down closure sizes nicely. For example, this brings default NixOS closure (nearly empty `config`):

```
let

  config = { config, pkgs, ... }:
    {
      users = {
        mutableUsers = false;
        extraUsers.root.password = "";
      };
    };

  nixos = import <nixpkgs/nixos> {
    configuration = config;
  };

in nixos.vm
```

from 930MB down to 811MB!
