### PR TITLE
uhc: Use Stackage LTS 4.1 to build UHC

### DIFF
--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -1,3 +1,8 @@
+# Note: The Haskell package set used for building UHC is
+# determined in the file top-level/haskell-packages.nix.
+# We are using Stackage LTS to avoid constant breakage.
+# Bump the Stackage LTS release to the last release if possible
+# when a new UHC version is released.
 { stdenv, coreutils, fetchgit, m4, libtool, clang, ghcWithPackages }:
 
 let wrappedGhc = ghcWithPackages (hpkgs: with hpkgs; [fgl vector syb uulib network binary hashable uhc-util mtl transformers directory containers array process filepath shuffle uuagc] );
@@ -50,8 +55,10 @@ in stdenv.mkDerivation rec {
     # On Darwin, the GNU libtool is used, which does not
     # support the -static flag and thus breaks the build.
     platforms = ["x86_64-linux"];
-
-    broken = true;  # https://github.com/UU-ComputerScience/uhc/issues/69
+    # Hydra currently doesn't build the Stackage LTS package set,
+    # and we don't want to build all our haskell dependencies
+    # from scratch just to build UHC.
+    hydraPlatforms = stdenv.lib.platforms.none;
 
   };
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -60,7 +60,10 @@ rec {
 
     uhc = callPackage ../development/compilers/uhc/default.nix ({
       stdenv = pkgs.clangStdenv;
-      inherit (pkgs.haskellPackages) ghcWithPackages;
+      # UHC 1.1.9.2 is incompatible with hashable 1.2.4.0,
+      # latest LTS with a compatible hashable is LTS 4.1
+      # See also https://github.com/UU-ComputerScience/uhc/issues/69
+      inherit (pkgs.haskell.packages.lts-4_1) ghcWithPackages;
     });
 
   };


### PR DESCRIPTION
UHC release cycle doesn't align nicely with Hackage's constant stream of new package releases. To make maintenance of the Nix UHC package easier, the Stackage LTS package set should be used.

PR tested on Linux Fedora 64bit.

Maybe the UHC build needs to be disabled on Hydra, as it uses Stackage LTS now ?
