### PR TITLE
pass: fixes .wrapped-pass in usage

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
     sha256 = "05bk3lrp5jwg0v338lvylp7glpliydzz4jf5pjr6k3kagrv3jyik";
   };
 
-  patches = if stdenv.isDarwin then [ ./no-darwin-getopt.patch ] else null;
+  patches =
+    [ ./program-name.patch ] ++
+    stdenv.lib.optional stdenv.isDarwin ./no-darwin-getopt.patch;
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/pass/program-name.patch
+++ b/pkgs/tools/security/pass/program-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/password-store.sh b/src/password-store.sh
+index 6313384..6607a98 100755
+--- a/src/password-store.sh
++++ b/src/password-store.sh
+@@ -573,7 +573,7 @@ cmd_git() {
+ # END subcommand functions
+ #
+ 
+-PROGRAM="${0##*/}"
++PROGRAM="pass"
+ COMMAND="$1"
+ 
+ case "$1" in


### PR DESCRIPTION
When using `pass --help` for example the PROGRAM name is ".wrapped-pass"
instead of "pass".
