### PR TITLE
openssl: security update 1.0.2e -> 1.0.2f

### DIFF
--- a/pkgs/development/libraries/openssl/1.0.2.x.nix
+++ b/pkgs/development/libraries/openssl/1.0.2.x.nix
@@ -8,14 +8,14 @@ let
     stdenv.cross;
 in
 stdenv.mkDerivation rec {
-  name = "openssl-1.0.2e";
+  name = "openssl-1.0.2f";
 
   src = fetchurl {
     urls = [
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha256 = "1zqb1rff1wikc62a7vj5qxd1k191m8qif5d05mwdxz2wnzywlg72";
+    sha256 = "171fkdg9v6j29d962nh6kb79kfm8kkhy7n9makw39d7jvvj4wawk";
   };
 
   patches = optional stdenv.isCygwin ./1.0.1-cygwin64.patch;

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -8,14 +8,14 @@ let
     stdenv.cross;
 in
 stdenv.mkDerivation rec {
-  name = "openssl-1.0.1q";
+  name = "openssl-1.0.1r";
 
   src = fetchurl {
     urls = [
       "http://www.openssl.org/source/${name}.tar.gz"
       "http://openssl.linux-mirror.org/source/${name}.tar.gz"
     ];
-    sha256 = "1dvz0hx7fjxag06b51pawy154y6d2xajm5rwxmfnlq7ax628nrdk";
+    sha256 = "0iik7a3b0mrfrxzngdf7ywfscg9inbw77y0jp2ccw0gdap9xhjvq";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
Also update 1.0.1q -> 1.0.1r

Built and tested the 1.0.2 version on my system, built but did not test 1.0.1.

Addresses [this OpenSSL Security Advisory](https://www.openssl.org/news/secadv/20160128.txt) with associated CVEs CVE-2016-0701, CVE-2015-3197, and CVE-2015-4000
