### PR TITLE
NAnt

### DIFF
--- a/pkgs/development/compilers/mono/default.nix
+++ b/pkgs/development/compilers/mono/default.nix
@@ -63,6 +63,11 @@ stdenv.mkDerivation rec {
   postInstall = ''
     echo "Updating Mono key store"
     $out/bin/cert-sync ${cacert}/etc/ssl/certs/ca-bundle.crt
+  ''
+  # According to [1], gmcs is just mcs
+  # [1] https://github.com/mono/mono/blob/master/scripts/gmcs.in
+  + ''
+    ln -s $out/bin/mcs $out/bin/gmcs
   '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/nant/default.nix
+++ b/pkgs/development/tools/build-managers/nant/default.nix
@@ -1,0 +1,69 @@
+{ fetchurl, stdenv, fetchFromGitHub, pkgconfig, mono, makeWrapper
+, targetVersion ? "4.5" }:
+
+let
+   version = "2015-11-15";
+
+  src = fetchFromGitHub {
+    owner = "nant";
+    repo = "nant";
+    rev = "19bec6eca205af145e3c176669bbd57e1712be2a";
+    sha256 = "11l5y76csn686p8i3kww9s0sxy659ny9l64krlqg3y2nxaz0fk6l";
+  };
+
+  nant-bootstrapped = stdenv.mkDerivation {
+    name = "nant-bootstrapped-${version}";
+    inherit src;
+
+    buildInputs = [ pkgconfig mono makeWrapper ];
+
+    buildFlags = "bootstrap";
+
+    dontStrip = true;
+
+    installPhase = ''
+      mkdir -p $out/lib/nant-bootstrap
+      cp -r bootstrap/* $out/lib/nant-bootstrap
+
+      mkdir -p $out/bin
+      makeWrapper "${mono}/bin/mono" $out/bin/nant \
+        --add-flags "$out/lib/nant-bootstrap/NAnt.exe"
+    '';
+  };
+
+in stdenv.mkDerivation {
+  name = "nant-${version}";
+  inherit src;
+
+  buildInputs = [ pkgconfig mono makeWrapper nant-bootstrapped ];
+
+  dontStrip = true;
+
+  buildPhase = ''
+    nant -t:mono-${targetVersion}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/nant
+    cp -r build/mono-${targetVersion}.unix/nant-debug/bin/* $out/lib/nant/
+
+    mkdir -p $out/bin
+    makeWrapper "${mono}/bin/mono" $out/bin/nant \
+      --add-flags "$out/lib/nant/NAnt.exe"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://nant.sourceforge.net;
+    description = "NAnt is a free .NET build tool";
+
+    longDescription = ''
+      NAnt is a free .NET build tool. In theory it is kind of like make without
+      make's wrinkles. In practice it's a lot like Ant.
+    '';
+
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ zohl ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5858,6 +5858,8 @@ let
     };
   };
 
+  nant = callPackage ../development/tools/build-managers/nant { };
+
   ninja = callPackage ../development/tools/build-managers/ninja { };
 
   nixbang = callPackage ../development/tools/misc/nixbang {


### PR DESCRIPTION
This patch adds NAnt, a builder for dotnet projects.

There is two-step building process:
1) build NAnt with make (nant-bootstrapped)
2) build NAnt with NAnt

While the first step is ok, the second one throws errors.

One of the problem, `gmcs not found`, can be fixed by symlinking `mcs`. There is another way (e.g. see library Hyena), but this will require to patch every project which uses `gmcs`.

Another one is where I stumped. NAnt failed with message:
`
[resgen] Cannot open assembly '/nix/store/...-mono-4.0.4.1/lib/mono/2.0/resgen.exe': No such file or directory.
`
As far as I understand it can be fixed by providing MONO_GAC_PREFIX. But, indeed, there is no such file.
I compiled NAnt in a clean debian with no problem. There is `mono-complete` package that provides this executable image. Could it be a missing file in nix's `mono` package?

Seeking for advice, as I' not familiar with dotnet things.
