### PR TITLE
kde5 bluedevil plasmoid : enable bluez5 bluetooth functionality

### DIFF
--- a/pkgs/desktops/plasma-5.5/bluedevil.nix
+++ b/pkgs/desktops/plasma-5.5/bluedevil.nix
@@ -20,5 +20,7 @@ plasmaPackage {
   postInstall = ''
     wrapQtProgram "$out/bin/bluedevil-wizard"
     wrapQtProgram "$out/bin/bluedevil-sendfile"
+    # Fix the location of logic.js for the plasmoid
+    ln -s $out/share/plasma/plasmoids/org.kde.plasma.bluetooth/contents/code/logic.js $out/share/plasma/plasmoids/org.kde.plasma.bluetooth/contents/ui/logic.js
   '';
 }

--- a/pkgs/os-specific/linux/bluez/bluez-5.37-obexd_without_systemd-1.patch
+++ b/pkgs/os-specific/linux/bluez/bluez-5.37-obexd_without_systemd-1.patch
@@ -1,0 +1,61 @@
+Submitted By:            Armin K. <krejzi at email dot com>
+Date:                    2013-04-29
+Initial Package Version: 5.17
+Upstream Status:         unknown
+Origin:                  Arch Linux (Giovanni Campagna)
+Description:             Allow using obexd without systemd in the user session
+
+Not all sessions run systemd --user (actually, the majority
+doesn't), so the dbus daemon must be able to spawn obexd
+directly, and to do so it needs the full path of the daemon.
+---
+ Makefile.obexd                      | 4 ++--
+ obexd/src/org.bluez.obex.service    | 4 ----
+ obexd/src/org.bluez.obex.service.in | 4 ++++
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+ delete mode 100644 obexd/src/org.bluez.obex.service
+ create mode 100644 obexd/src/org.bluez.obex.service.in
+
+diff --git a/Makefile.obexd b/Makefile.obexd
+index 3760867..142e7c3 100644
+--- a/Makefile.obexd
++++ b/Makefile.obexd
+@@ -2,12 +2,12 @@
+ if SYSTEMD
+ systemduserunitdir = @SYSTEMD_USERUNITDIR@
+ systemduserunit_DATA = obexd/src/obex.service
++endif
+ 
+ dbussessionbusdir = @DBUS_SESSIONBUSDIR@
+ dbussessionbus_DATA = obexd/src/org.bluez.obex.service
+-endif
+ 
+-EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service
++EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service.in
+ 
+ obex_plugindir = $(libdir)/obex/plugins
+ 
+diff --git a/obexd/src/org.bluez.obex.service b/obexd/src/org.bluez.obex.service
+deleted file mode 100644
+index a538088..0000000
+--- a/obexd/src/org.bluez.obex.service
++++ /dev/null
+@@ -1,4 +0,0 @@
+-[D-BUS Service]
+-Name=org.bluez.obex
+-Exec=/bin/false
+-SystemdService=dbus-org.bluez.obex.service
+diff --git a/obexd/src/org.bluez.obex.service.in b/obexd/src/org.bluez.obex.service.in
+new file mode 100644
+index 0000000..9c815f2
+--- /dev/null
++++ b/obexd/src/org.bluez.obex.service.in
+@@ -0,0 +1,4 @@
++[D-BUS Service]
++Name=org.bluez.obex
++Exec=@libexecdir@/obexd
++SystemdService=dbus-org.bluez.obex.service
+-- 
+1.8.3.1
+
+

--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
       # gstreamer gst_plugins_base 
     ];
 
+  patches = [ ./bluez-5.37-obexd_without_systemd-1.patch ];
+    
   preConfigure = ''
       substituteInPlace tools/hid2hci.rules --replace /sbin/udevadm ${systemd}/bin/udevadm
       substituteInPlace tools/hid2hci.rules --replace "hid2hci " "$out/lib/udev/hid2hci "
@@ -68,6 +70,7 @@ stdenv.mkDerivation rec {
     # for bluez4 compatibility for NixOS
     mkdir $out/sbin
     ln -s ../libexec/bluetooth/bluetoothd $out/sbin/bluetoothd
+    ln -s ../libexec/bluetooth/obexd $out/sbin/obexd
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/bluez/bluez5_28.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5_28.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
     # for bluez4 compatibility for NixOS
     mkdir $out/sbin
     ln -s ../libexec/bluetooth/bluetoothd $out/sbin/bluetoothd
+    ln -s ../libexec/bluetooth/obexd $out/sbin/obexd
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
```
- Fixed a bug in bluedevil (link to a .js file)
- Made bluez5 the default bluetooth service except for kde4
- created org.bluez.obex systemd dbus service
- Patched bluez5 using bluez-5.37-obexd_without_systemd-1.patch
in order to enable obex when using either the bluedevil plasmoid
or dolpin file manager within plasma workspaces 5.

The functionality was tested using a Sony Xperia Z, the machine
and the handset paired  and two different files were sent in both
directions successfully.
```
