### PR TITLE
fix: solaar 0.9.2

### DIFF
--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,19 +1,14 @@
-{fetchurl, stdenv, makeWrapper, gtk3, python3Packages}:
-let
-  version = "0.9.2";
-in
-stdenv.mkDerivation {
+{fetchurl, stdenv, python34, gtk3, python34Packages, gobjectIntrospection}:
+python34Packages.buildPythonPackage rec {
   name = "solaar-${version}";
+  version = "0.9.2";
+  namePrefix = "";
   src = fetchurl {
     sha256 = "0954grz2adggfzcj4df4mpr4d7qyl7w8rb4j2s0f9ymawl92i05j";
     url = "https://github.com/pwr/Solaar/archive/${version}.tar.gz";
   };
 
-  buildInputs = [gtk3 python3Packages.pygobject3 python3Packages.pyudev];
-  enableParallelBuilding = true;
-  installPhase = ''
-    mkdir -p "$out";
-  '';
+  propagatedBuildInputs = [python34Packages.pygobject3 python34Packages.pyudev gobjectIntrospection gtk3];
   postInstall = ''
     wrapProgram "$out/bin/solaar" \
       --prefix PYTHONPATH : "$PYTHONPATH" \
@@ -22,6 +17,8 @@ stdenv.mkDerivation {
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
   '';
+
+  enableParallelBuilding = true;
   meta = with stdenv.lib; {
     description = "Linux devices manager for the Logitech Unifying Receiver";
     longDescription = ''


### PR DESCRIPTION
This is (partial) fix for https://github.com/NixOS/nixpkgs/pull/12221 which was completely broken as @vcunat noticed.

There are two applications inside, solaar-cli (works fine), solaar (gtk3 gui) which does not work because of error:

```
Solaar: missing required package 'gir1.2-gtk-3.0'
```

I'm not sure what is missing, I used gobjectIntrospection, gtk3 and pygobject3 but still looks like gir files are missing. Anybody knows what could help here?

@vcunat : Thank you for checking this package. The mistake was because firstly I created a package using buildPythonPackage and installed it as root, then I was experimenting with other version of nix expression but still old version was usable even if this nix expression produced empty directory! Such a mistake :-) 
Sorry for pushing broken stuff to the repo.
