### PR TITLE
xserver.displayManager: lightdm as default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -154,6 +154,12 @@ nginx.override {
     rights, new <literal>aliasFiles</literal> and <literal>mapFiles</literal>
     options and more.</para>
   </listitem>
+
+  <listitem>
+    <para>The default display manager is now LightDM.
+    To use SLiM set <literal>services.xserver.displayManager.slim.enable</literal>
+    to <literal>true</literal>.
+  </listitem>
 </itemizedlist>
 
 

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -80,8 +80,6 @@ in
       }
     ];
 
-    services.xserver.displayManager.slim.enable = false;
-
     users.extraUsers.gdm =
       { name = "gdm";
         uid = config.ids.uids.gdm;

--- a/nixos/modules/services/x11/display-managers/kdm.nix
+++ b/nixos/modules/services/x11/display-managers/kdm.nix
@@ -131,8 +131,6 @@ in
 
   config = mkIf cfg.enable {
 
-    services.xserver.displayManager.slim.enable = false;
-
     services.xserver.displayManager.job =
       { execCmd =
           ''

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -105,7 +105,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    services.xserver.displayManager.slim.enable = false;
 
     services.xserver.displayManager.job = {
       logsXsession = true;

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -199,8 +199,6 @@ in
       }
     ];
 
-    services.xserver.displayManager.slim.enable = false;
-
     services.xserver.displayManager.job = {
       logsXsession = true;
 

--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -49,7 +49,7 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = config.services.xserver.enable;
+        default = false;
         description = ''
           Whether to enable SLiM as the display manager.
         '';

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -435,6 +435,15 @@ in
 
   config = mkIf cfg.enable {
 
+    services.xserver.displayManager.lightdm.enable =
+      let dmconf = cfg.displayManager;
+          default = !( dmconf.auto.enable
+                    || dmconf.gdm.enable
+                    || dmconf.kdm.enable
+                    || dmconf.sddm.enable
+                    || dmconf.slim.enable );
+      in mkIf (default) true;
+
     hardware.opengl.enable = mkDefault true;
 
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];


### PR DESCRIPTION
Implementation of #12516
# Description

Make lightdm the default display manager (instead of slim).
# Details

slim is an suboptimal choice as default display manager for a few reasons:
- make nix configuration more complex(#4300)
- is not documented (documentation site is dead)
- is abandonned since 2013
- is not fully compatible with systemd ([source](https://wiki.archlinux.org/index.php/SLiM))
- make the NixOS manual configuration examples not working out of the box (see #12516 for details)

Slim is a very good and light display manager and should be available.
But as it is more likely an advanced user choice and it involves some extra setting to play well with the rest, its usage should be explicit by setting `services.xserver.displayManager.slim.enable` to `true`.

As no mention of the default display manager was made in the documentation, no change or addition was made.
I can add documentation if necessary.

---

As it is changing a default behavior, it would be nice to have some message on upgrade or an announcement on the ML upon merging.
