### PR TITLE
Cherry-pick fix for #10367 to release-15.09.

### DIFF
--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -17,7 +17,9 @@ let
       mkdir -p $out
       cp -prd ${pkgs.path} $out/nixos
       chmod -R u+w $out/nixos
-      ln -s . $out/nixos/nixpkgs
+      if [ ! -e $out/nixos/nixpkgs ]; then
+        ln -s . $out/nixos/nixpkgs
+      fi
       rm -rf $out/nixos/.git
       echo -n ${config.system.nixosVersionSuffix} > $out/nixos/.version-suffix
     '';


### PR DESCRIPTION
Building config.system.build.isoImage would fail with the following
error using the channel:

  ln: failed to create symbolic link
'/nix/store/zz0hzi5imrg4927v6f8mv281qs6v6pbq-nixos-16.03pre69762.e916273/nixos/nixpkgs/.': File exists

The fix skips symlink as it already exists if the channel
nixpkgs copy is used.

Fixes #10367

(cherry picked from commit 75284b09e16f3168abc5273a9ed28d1fb4b33adf by
falsifian)
