### PR TITLE
Use wrapGAppsHook where possible

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, boost, cmake, gettext, gstreamer, gst_plugins_base
 , liblastfm, qt4, taglib, fftw, glew, qjson, sqlite, libgpod, libplist
 , usbmuxd, libmtp, gvfs, libcdio, libspotify, protobuf, qca2, pkgconfig
-, sparsehash, config, makeWrapper, runCommand, gst_plugins }:
+, sparsehash, config, runCommand, gst_plugins, wrapGAppsHook }:
 
 let
   withSpotify = config.clementine.spotify or false;
@@ -71,7 +71,7 @@ let
     '';
     postInstall = ''
       mkdir -p $out/libexec/clementine
-      mv $out/bin/clementine-spotifyblob $out/libexec/clementine
+      mv $out/bin/clementine-spotifyblob $out/libexec/clementine/
       rmdir $out/bin
     '';
     enableParallelBuilding = true;
@@ -92,7 +92,8 @@ with stdenv.lib;
 runCommand "clementine-${version}"
 {
   inherit blob free;
-  buildInputs = [ makeWrapper ] ++ gst_plugins; # for the setup-hooks
+  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = gst_plugins;
   dontPatchELF = true;
   dontStrip = true;
   meta = {
@@ -109,9 +110,13 @@ runCommand "clementine-${version}"
 }
 ''
   mkdir -p $out/bin
-  makeWrapper "$free/bin/${exeName}" "$out/bin/${exeName}" \
-      ${optionalString withSpotify "--set CLEMENTINE_SPOTIFYBLOB \"$blob/libexec/clementine\""} \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
+  ln -s "$free/bin/${exeName}" "$out/bin/${exeName}"
+
+  ${optionalString withSpotify ''
+    gappsWrapperArgs+=(--set CLEMENTINE_SPOTIFYBLOB "$blob/libexec/clementine")
+  ''}
+
+  wrapGAppsHook
 
   mkdir -p $out/share
   for dir in applications icons kde4; do

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -23,10 +23,6 @@ pythonPackages.buildPythonPackage rec {
   # There are no tests
   doCheck = false;
 
-  preFixup = ''
-    gappsWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH")
-  '';
-
   meta = with stdenv.lib; {
     homepage = http://www.mopidy.com/;
     description = ''

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchgit, python, pythonPackages, cdparanoia, cdrdao
 , pygobject, gst_python, gst_plugins_base, gst_plugins_good
-, setuptools, utillinux, makeWrapper, substituteAll, autoreconfHook }:
+, setuptools, utillinux, substituteAll, autoreconfHook
+, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "morituri-${version}";
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
-    python cdparanoia cdrdao utillinux makeWrapper
+    python cdparanoia cdrdao utillinux wrapGAppsHook
     gst_plugins_base gst_plugins_good
   ] ++ pythonPath;
 
@@ -37,11 +38,7 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
   dontStrip = true;
 
-  postInstall = ''
-    wrapProgram "$out/bin/rip" \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
-  '';
+  wrapPrefixVariables = "PYTHONPATH";
 
   meta = with stdenv.lib; {
     homepage = http://thomas.apestaart.org/morituri/trac/;

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, python, buildPythonPackage, mutagen, pygtk, pygobject, intltool
-, pythonDBus, gst_python, withGstPlugins ? false, gst_plugins_base ? null
-, gst_plugins_good ? null, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
+, pythonDBus, gst_python, wrapGAppsHook
+, withGstPlugins ? true, gst_plugins_base ? null, gst_plugins_good ? null
+, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
 
 assert withGstPlugins -> gst_plugins_base != null
                          || gst_plugins_good != null
@@ -46,17 +47,11 @@ buildPythonPackage {
 
   buildInputs = stdenv.lib.optionals withGstPlugins [
     gst_plugins_base gst_plugins_good gst_plugins_ugly gst_plugins_bad
-  ];
+  ] ++ stdenv.lib.optionals withGstPlugins [ wrapGAppsHook ];
 
   propagatedBuildInputs = [
     mutagen pygtk pygobject pythonDBus gst_python intltool
   ];
-
-  postInstall = stdenv.lib.optionalString withGstPlugins ''
-    # Wrap quodlibet so it finds the GStreamer plug-ins
-    wrapProgram "$out/bin/quodlibet" --prefix \
-      GST_PLUGIN_SYSTEM_PATH ":" "$GST_PLUGIN_SYSTEM_PATH"                                                     \
-  '';
 
   meta = {
     description = "GTK+-based audio player written in Python, using the Mutagen tagging library";

--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchurl, gettext, gtk3, pythonPackages
-, gdk_pixbuf, libnotify, gst_all_1
+, gdk_pixbuf, libnotify, gst_all_1, wrapGAppsHook
 , libgnome_keyring3 ? null, networkmanager ? null
 }:
 
@@ -17,18 +17,10 @@ buildPythonPackage rec {
     pythonPackages.pyxdg gdk_pixbuf libnotify gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad libgnome_keyring3 networkmanager
+    wrapGAppsHook
   ];
 
-  preFixup = ''
-    for script in mailnag mailnag-config; do
-      wrapProgram $out/bin/$script \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share" \
-        --prefix PYTHONPATH : "$PYTHONPATH"
-    done
-  '';
+  wrapPrefixVariables = [ "PYTHONPATH" ];
 
   meta = with stdenv.lib; {
     description = "An extensible mail notification daemon";

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, intltool, file, makeWrapper
+{ stdenv, fetchurl, pkgconfig, intltool, file, wrapGAppsHook
 , openssl, curl, libevent, inotify-tools, systemd, zlib
-, enableGTK3 ? false, gtk3
+, enableGTK3 ? false, gtk3, hicolor_icon_theme
 }:
 
 let
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ pkgconfig intltool file openssl curl libevent inotify-tools zlib ]
-    ++ optionals enableGTK3 [ gtk3 makeWrapper ]
+    ++ optionals enableGTK3 [ gtk3 wrapGAppsHook hicolor_icon_theme ]
     ++ optional stdenv.isLinux systemd;
 
   preConfigure = ''
@@ -28,11 +28,9 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-systemd-daemon" ]
     ++ optional enableGTK3 "--with-gtk";
 
-  preFixup = optionalString enableGTK3 /* gsettings schemas for file dialogues */ ''
-    rm "$out/share/icons/hicolor/icon-theme.cache"
-    wrapProgram "$out/bin/transmission-gtk" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-  '';
+#  preFixup = optionalString enableGTK3 /* gsettings schemas for file dialogues */ ''
+#    rm "$out/share/icons/hicolor/icon-theme.cache"
+#  '';
 
   meta = with stdenv.lib; {
     description = "A fast, easy and free BitTorrent client";

--- a/pkgs/applications/video/gnash/default.nix
+++ b/pkgs/applications/video/gnash/default.nix
@@ -5,7 +5,7 @@
 , boost, freetype, agg, dbus, curl, pkgconfig, gettext
 , glib, gtk, gtkglext, pangox_compat, xlibsWrapper, ming, dejagnu, python, perl
 , freefont_ttf, haxe, swftools
-, lib, makeWrapper
+, lib, wrapGAppsHook
 , xulrunner }:
 
 assert stdenv ? glibc;
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     libogg libxml2 libjpeg mesa libpng libungif boost freetype agg
     dbus curl pkgconfig glib gtk gtkglext pangox_compat
     xulrunner
-    makeWrapper
+    wrapGAppsHook
   ]
 
   ++ (stdenv.lib.optionals doCheck [
@@ -91,13 +91,6 @@ stdenv.mkDerivation rec {
   preInstall = ''mkdir -p $out/plugins'';
   postInstall = ''
     make install-plugins
-
-    # Wrap programs so the find the GStreamer plug-ins they need
-    # (e.g., gst-ffmpeg is needed to watch movies such as YouTube's).
-    for prog in "$out/bin/"*
-    do
-      wrapProgram "$prog" --prefix GST_PLUGIN_SYSTEM_PATH ":" "$GST_PLUGIN_SYSTEM_PATH"
-    done
   '';
 
   meta = {

--- a/pkgs/applications/video/kazam/default.nix
+++ b/pkgs/applications/video/kazam/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3Packages, gst_all_1, makeWrapper, gobjectIntrospection
+{ stdenv, fetchurl, python3Packages, gst_all_1, wrapGAppsHook, gobjectIntrospection
 , gtk3, libwnck3, keybinder, intltool, libcanberra }:
 
 
@@ -16,7 +16,7 @@ python3Packages.buildPythonPackage rec {
   buildInputs = with python3Packages;
     [ pygobject3 pyxdg pycairo gst_all_1.gstreamer gst_all_1.gst-plugins-base
       gst_all_1.gst-plugins-good gobjectIntrospection gtk3 libwnck3 distutils_extra
-      intltool dbus ];
+      intltool dbus wrapGAppsHook ];
 
   # TODO: figure out why PYTHONPATH is not passed automatically for those programs
   pythonPath = with python3Packages;
@@ -32,12 +32,11 @@ python3Packages.buildPythonPackage rec {
   doCheck = false;
 
   preFixup = ''
-    wrapProgram $out/bin/kazam \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix LD_LIBRARY_PATH ":" "${gtk3}/lib:${gst_all_1.gstreamer}/lib:${keybinder}/lib" \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share" \
-      --set GST_REGISTRY "/tmp/kazam.gstreamer.registry";
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH ":" "${gtk3}/lib:${gst_all_1.gstreamer}/lib:${keybinder}/lib"
+      --prefix XDG_DATA_DIRS : "${gtk3}/share"
+      --set GST_REGISTRY "/tmp/kazam.gstreamer.registry"
+    )
   '';
 
 

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -2,7 +2,7 @@
 , pyrex096, ffmpeg, boost, glib, pygobject, gtk2, webkitgtk2, libsoup, pygtk
 , taglib, sqlite, pycurl, mutagen, pycairo, pythonDBus, pywebkitgtk
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
-, gst_python, gst_plugins_base, gst_plugins_good, gst_ffmpeg
+, gst_python, gst_plugins_base, gst_plugins_good, gst_ffmpeg, wrapGAppsHook
 , enableBonjour ? false, avahi ? null
 }:
 
@@ -62,15 +62,11 @@ buildPythonPackage rec {
 
   postInstall = ''
     mv "$out/bin/miro.real" "$out/bin/miro"
-    wrapProgram "$out/bin/miro" \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
-      --prefix GIO_EXTRA_MODULES : "${glib_networking}/lib/gio/modules" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share"
   '';
 
   buildInputs = [
     pkgconfig pyrex096 ffmpeg boost glib pygobject gtk2 webkitgtk2 libsoup
-    pygtk taglib gsettings_desktop_schemas sqlite
+    pygtk taglib gsettings_desktop_schemas sqlite glib_networking wrapGAppsHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, makeWrapper
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, wrapGAppsHook
 , python3Packages, gst, gtk3, hicolor_icon_theme
 , gobjectIntrospection, librsvg, gnome3, libnotify
 }:
@@ -26,11 +26,11 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ iyzsong ];
   };
 
-  nativeBuildInputs = [ pkgconfig intltool itstool makeWrapper ];
+  nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
 
   buildInputs = [
     gobjectIntrospection gtk3 librsvg gnome3.gnome_desktop
-    gnome3.defaultIconTheme
+    gnome3.defaultIconTheme gnome3.dconf
     gnome3.gsettings_desktop_schemas libnotify
   ] ++ (with gst; [
     gstreamer gst-editing-services
@@ -40,11 +40,11 @@ in stdenv.mkDerivation rec {
     python pygobject3 gst-python pyxdg numpy pycairo sqlite3 matplotlib
   ]);
 
-  preFixup = ''
-    wrapProgram "$out/bin/pitivi" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$out/share:$GSETTINGS_SCHEMAS_PATH"
-  '';
+#  preFixup = ''
+#    wrapProgram "$out/bin/pitivi" \
+#      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+#      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+#      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+#      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$out/share:$GSETTINGS_SCHEMAS_PATH"
+#  '';
 }

--- a/pkgs/applications/video/subtitleeditor/default.nix
+++ b/pkgs/applications/video/subtitleeditor/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, desktop_file_utils, enchant, gnome, gstreamer, gstreamermm,
   gst_plugins_base, gst_plugins_good, intltool, hicolor_icon_theme,
-  libsigcxx, libxmlxx, makeWrapper, xdg_utils, pkgconfig } :
+  libsigcxx, libxmlxx, wrapGAppsHook, xdg_utils, pkgconfig } :
 
 let
   ver_maj = "0.41";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs =  [
     desktop_file_utils enchant gnome.gtk gnome.gtkmm gstreamer gstreamermm
     gst_plugins_base gst_plugins_good intltool hicolor_icon_theme libsigcxx libxmlxx
-    makeWrapper xdg_utils pkgconfig
+    wrapGAppsHook xdg_utils pkgconfig
   ];
 
   src = fetchurl {
@@ -22,12 +22,6 @@ stdenv.mkDerivation rec {
   };
 
   doCheck = true;
-
-  postInstall = ''
-    wrapProgram "$out/bin/subtitleeditor" --prefix \
-      GST_PLUGIN_SYSTEM_PATH ":" "$GST_PLUGIN_SYSTEM_PATH"                                                     \
-  '';
-
 
   meta = {
     description = "GTK+2 application to edit video subtitles";

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -30,7 +30,7 @@ wrapGAppsHook() {
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "$prefix/share")
   fi
 
-  for v in $wrapPrefixVariables GST_PLUGIN_SYSTEM_PATH_1_0 GI_TYPELIB_PATH GRL_PLUGIN_PATH; do
+  for v in $wrapPrefixVariables GST_PLUGIN_SYSTEM_PATH GST_PLUGIN_SYSTEM_PATH_1_0 GI_TYPELIB_PATH GRL_PLUGIN_PATH; do
     eval local dummy="\$$v"
     gappsWrapperArgs+=(--prefix $v : "$dummy")
   done

--- a/pkgs/desktops/gnome-3/3.16/core/sushi/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/sushi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, file, intltool, gobjectIntrospection, glib
 , clutter_gtk, clutter-gst, gnome3, gtksourceview, libmusicbrainz
-, webkitgtk, libmusicbrainz5, icu, makeWrapper, gst_all_1
+, webkitgtk, libmusicbrainz5, icu, wrapGAppsHook, gst_all_1
 , gdk_pixbuf, librsvg, gtk3 }:
 
 stdenv.mkDerivation rec {
@@ -13,20 +13,13 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good ];
 
-  buildInputs = [ pkgconfig file intltool gobjectIntrospection glib gtk3
-                  clutter_gtk clutter-gst gnome3.gjs gtksourceview gdk_pixbuf
-                  librsvg gnome3.defaultIconTheme libmusicbrainz5 webkitgtk
-                  gnome3.evince icu makeWrapper ];
+  nativeBuildInputs = [ pkgconfig file intltool wrapGAppsHook ];
+
+  buildInputs = [ gobjectIntrospection glib gtk3 clutter_gtk clutter-gst gnome3.gjs
+                  gtksourceview gdk_pixbuf librsvg gnome3.defaultIconTheme
+                  libmusicbrainz5 webkitgtk gnome3.evince icu ];
 
   enableParallelBuilding = true;
-
-  preFixup = ''
-    wrapProgram $out/libexec/sushi-start \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
 
   meta = with stdenv.lib; {
     homepage = "http://en.wikipedia.org/wiki/Sushi_(software)";

--- a/pkgs/desktops/gnome-3/3.16/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/3.16/core/totem/default.nix
@@ -1,7 +1,7 @@
 { stdenv, intltool, fetchurl, gst_all_1
 , clutter_gtk, clutter-gst, pygobject3, shared_mime_info
 , pkgconfig, gtk3, glib
-, bash, makeWrapper, itstool, libxml2, dbus_glib
+, bash, wrapGAppsHook, itstool, libxml2, dbus_glib
 , gnome3, librsvg, gdk_pixbuf, file }:
 
 stdenv.mkDerivation rec {
@@ -20,22 +20,24 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
-  buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2 gnome3.grilo
+  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook file ];
+
+  buildInputs = [ gtk3 glib itstool libxml2 gnome3.grilo
                   clutter_gtk clutter-gst gnome3.totem-pl-parser gnome3.grilo-plugins
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base
-                  gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
+                  gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly
                   gnome3.libpeas pygobject3 shared_mime_info dbus_glib
                   gdk_pixbuf gnome3.defaultIconTheme librsvg gnome3.gnome_desktop
-                  gnome3.gsettings_desktop_schemas makeWrapper file ];
+                  gnome3.gsettings_desktop_schemas ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/totem" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-      --prefix GRL_PLUGIN_PATH : "${gnome3.grilo-plugins}/lib/grilo-0.2" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-
-  '';
+#  preFixup = ''
+#    wrapProgram "$out/bin/totem" \
+#      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+#      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+#      --prefix GRL_PLUGIN_PATH : "${gnome3.grilo-plugins}/lib/grilo-0.2" \
+#      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+#
+#  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Videos;

--- a/pkgs/desktops/xfce/applications/parole.nix
+++ b/pkgs/desktops/xfce/applications/parole.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, intltool, gst_all_1
+{ stdenv, fetchurl, wrapGAppsHook, pkgconfig, intltool, gst_all_1
 , gtk, dbus_glib, libxfce4ui, libxfce4util, xfconf
 , taglib, libnotify
 , withGstPlugins ? true
@@ -15,20 +15,18 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook ];
 
   buildInputs = [
-    makeWrapper 
     gtk dbus_glib libxfce4ui libxfce4util xfconf
     taglib libnotify
-  ] ++ (with gst_all_1; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav]);
+  ] ++ (stdenv.lib.optionals withGstPlugins
+    (with gst_all_1; [
+      gst-plugins-base gst-plugins-good gst-plugins-bad
+      gst-plugins-ugly gst-libav
+    ]));
 
   configureFlags = [ "--with-gstreamer=1.0" ];
-
-  postInstall = stdenv.lib.optionalString withGstPlugins ''
-    wrapProgram "$out/bin/parole" --prefix \
-      GST_PLUGIN_SYSTEM_PATH_1_0 ":" "$GST_PLUGIN_SYSTEM_PATH_1_0"
-  '';
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/applications/${p_name}";

--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, intltool, makeWrapper
-, glib, gstreamer, gst_plugins_base, gtk
+{ stdenv, fetchurl, pkgconfig, intltool, wrapGAppsHook
+, glib, gstreamer, gst_plugins_base, gtk, hicolor_icon_theme
 , libxfce4util, libxfce4ui, xfce4panel, xfconf, libunique ? null
 , pulseaudioSupport ? false, gst_plugins_good
 }:
@@ -28,16 +28,12 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  buildInputs =
-    [ pkgconfig intltool glib gstreamer gtk
-      libxfce4util libxfce4ui xfce4panel xfconf libunique makeWrapper
-    ] ++ gst_plugins;
+  nativeBuildInputs =
+    [ pkgconfig intltool wrapGAppsHook hicolor_icon_theme ];
 
-  postInstall =
-    ''
-      wrapProgram "$out/bin/xfce4-mixer" \
-        --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
-    '';
+  buildInputs =
+    [ glib gstreamer gtk libxfce4util libxfce4ui xfce4panel xfconf libunique
+    ] ++ gst_plugins;
 
   passthru = { inherit gst_plugins; };
 

--- a/pkgs/desktops/xfce/applications/xfce4-volumed.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, makeWrapper
+{ stdenv, fetchurl, pkgconfig, wrapGAppsHook
 , gstreamer, gtk2, gst_plugins_base, libnotify
 , keybinder, xfconf
 }:
@@ -28,13 +28,7 @@ stdenv.mkDerivation rec {
       keybinder xfconf libnotify
     ];
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
-
-  postInstall =
-    ''
-      wrapProgram "$out/bin/xfce4-volumed" \
-        --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
-    '';
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
   meta = with stdenv.lib; {
     homepage = http://www.xfce.org/projects/xfce4-volumed; # referenced but inactive

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, libxfce4ui
 , libxfce4ui_gtk3, libwnck, exo, garcon, xfconf, libstartup_notification
-, makeWrapper, xfce4mixer
+, wrapGAppsHook, xfce4mixer
 , withGtk3 ? false, gtk3
 }:
 
@@ -22,18 +22,14 @@ stdenv.mkDerivation rec {
 
   configureFlags = optional withGtk3 "--enable-gtk3";
 
+  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook ];
+
   buildInputs =
-    [ pkgconfig intltool gtk libxfce4util exo libwnck
-      garcon xfconf libstartup_notification makeWrapper
+    [ gtk libxfce4util exo libwnck garcon xfconf libstartup_notification
     ] ++ xfce4mixer.gst_plugins
       ++ optional withGtk3 gtk3;
 
   propagatedBuildInputs = [ (if withGtk3 then libxfce4ui_gtk3 else libxfce4ui) ];
-
-  postInstall = ''
-    wrapProgram "$out/bin/xfce4-panel" \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
-  '';
 
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 


### PR DESCRIPTION
This PR adds wrapping `GST_PLUGIN_SYSTEM_PATH` to `wrapGAppsHook` and cleans up a lot of packages to use `wrapGAppsHook` instead of creating the wrapper and specifying the environment variables manually.

This fixes missing icons in some applications. One application even failed to run previously.

Currently, this is still a work in progress because I haven't tested all applications yet.
