### PR TITLE
scim: 0.1.9 -> 0.2.1 (sc-im)

### DIFF
--- a/pkgs/applications/misc/sc-im/default.nix
+++ b/pkgs/applications/misc/sc-im/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, yacc, ncurses, libxml2 }:
 
 let
-  version = "0.1.9";
+  version = "0.2.1";
 in
 stdenv.mkDerivation rec {
 
-  name = "scim-${version}";
+  name = "sc-im-${version}";
 
   src = fetchurl {
     url = "https://github.com/andmarti1424/sc-im/archive/v${version}.tar.gz";
-    sha256 = "00rjz344acw0bxv78x1w9jz8snl9lb9qhr9z22phxinidnd3vaaz";
+    sha256 = "08yks8grj5w434r81dy2knzbdhdnkc23r0d9v848mcl706xnjl6j";
   };
 
   buildInputs = [ yacc ncurses libxml2 ];
@@ -29,12 +29,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://github.com/andmarti1424/scim";
-    description = "SCIM - Spreadsheet Calculator Improvised - SC fork";
-    license = {
-      fullName = "SCIM License";
-      url = "https://github.com/andmarti1424/scim/raw/master/LICENSE";
-    };
+    homepage = "https://github.com/andmarti1424/sc-im";
+    description = "SC-IM - Spreadsheet Calculator Improvised - SC fork";
+    license = stdenv.lib.licenses.bsdOriginal;
     maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux; # Cannot test others
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13150,7 +13150,7 @@ let
     boost = boost155;
   };
 
-  sc-im = callPackage ../applications/misc/scim { };
+  sc-im = callPackage ../applications/misc/sc-im { };
 
   scite = callPackage ../applications/editors/scite { };
 


### PR DESCRIPTION
Move derivation definition to "sc-im", as project was renamed.
Also change the license to BSD, which is what what-license.com
detechted.
