### PR TITLE
bspwm: add startThroughSession & sessionScript option

### DIFF
--- a/nixos/modules/services/x11/window-managers/bspwm.nix
+++ b/nixos/modules/services/x11/window-managers/bspwm.nix
@@ -8,16 +8,39 @@ in
 
 {
   options = {
-    services.xserver.windowManager.bspwm.enable = mkEnableOption "bspwm";
+    services.xserver.windowManager.bspwm = {
+        enable = mkEnableOption "bspwm";
+        startThroughSession = mkOption {
+            type = with types; bool;
+            default = false;
+            description = "
+                Start the window manager through the script defined in 
+                sessionScript. Defaults to the the bspwm-session script
+                provided by bspwm
+            ";
+        };
+        sessionScript = mkOption {
+            default = "${pkgs.bspwm}/bin/bspwm-session";
+            defaultText = "(pkgs.bspwm)/bin/bspwm-session";
+            description = "
+                The start-session script to use. Defaults to the
+                provided bspwm-session script from the bspwm package.
+
+                Does nothing unless `bspwm.startThroughSession` is enabled
+            ";
+        };
+    };
   };
 
   config = mkIf cfg.enable {
     services.xserver.windowManager.session = singleton {
       name = "bspwm";
-      start = "
-        SXHKD_SHELL=/bin/sh ${pkgs.sxhkd}/bin/sxhkd -f 100 &
-        ${pkgs.bspwm}/bin/bspwm
-      ";
+      start = if cfg.startThroughSession
+        then cfg.sessionScript
+        else ''
+            SXHKD_SHELL=/bin/sh ${pkgs.sxhkd}/bin/sxhkd -f 100 &
+            ${pkgs.bspwm}/bin/bspwm
+        '';
     };
     environment.systemPackages = [ pkgs.bspwm ];
   };


### PR DESCRIPTION
First pull request to nixpkgs, I did my best to follow the [manual on submitting changes](http://hydra.nixos.org/build/31168087/download/1/nixpkgs/manual.html#chap-submitting-changes).

cc @meisternu
## Changes

Added the ability to do a more traditional bspwm startup from the login screen (using either the `bspwm-session` script provided by nixpkgs.bspwm or a custom script) as an alternative to directly runnning sxhkd & bspwm.
## Rationale

The current bspwm start process, only gives script hooks in `~/.xprofile`, `~/.xsession` and `$XDG_CONFIG_HOME/bspwm/bspwmrc`. 

If the user wants to run bswpm-specific startup logic, they have to either break separation of concerns by putting it in their bspwmrc or building a table in their xsession script to detect the sessionType, which creates a dependency on the user's environment in order to be a decently functioning desktop experience. It also eases migrating from a different distro with a bspwm setup to nixos because it means that any session startup scripts can be reused.
