### PR TITLE
nvidia: Bump beta driver to 361.18

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -14,6 +14,8 @@ let
   nvidiaForKernel = kernelPackages:
     if elem "nvidia" drivers then
         kernelPackages.nvidia_x11
+    else if elem "nvidiaBeta" drivers then
+        kernelPackages.nvidia_x11_beta
     else if elem "nvidiaLegacy173" drivers then
       kernelPackages.nvidia_x11_legacy173
     else if elem "nvidiaLegacy304" drivers then

--- a/pkgs/os-specific/linux/nvidia-x11/beta.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/beta.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "349.12";
+  versionNumber = "361.18";
 
   # Policy: use the highest stable version as the default (on our master).
   inherit (stdenv.lib) makeLibraryPath;
@@ -27,13 +27,13 @@ stdenv.mkDerivation {
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
-        url = "http://us.download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "0x9zfw66nxv98zpkdkymlyqzspksk850bhfmza7g7pba4yba085h";
+        url = "http://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
+        sha256 = "1n6nrz59r3dgcpkcpr4yw997fygkpsdbv1x45c30w781w0j1q5s5";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "http://us.download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "19mfkigzffxsik3h4bsjsl481q410h804fz3rdc7chs86q4bg9h3";
+        url = "http://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
+        sha256 = "12fi7vb697h38qh0f2j40q76yx9fqk6vwx20zfxhac3fvdhw2sj0";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -19,7 +19,7 @@ buildPhase() {
         sysSrc=$(echo $kernel/lib/modules/$kernelVersion/source)
         sysOut=$(echo $kernel/lib/modules/$kernelVersion/build)
         unset src # used by the nv makefile
-        make SYSSRC=$sysSrc SYSOUT=$sysOut module
+        make SYSSRC=$sysSrc SYSOUT=$sysOut module -j8 -l8
 
         cd ..
     fi
@@ -33,6 +33,14 @@ installPhase() {
 
     cp -prd *.so.* tls "$out/lib/"
     rm "$out"/lib/lib{glx,nvidia-wfb}.so.* # handled separately
+
+    # According to nvidia, we're supposed to use GLVND.
+    # But so far I've failed to make any applications run using that stack.
+    #
+    # If you want to try it, swap the two lines below.
+
+    #rm "$out"/lib/libGL.so.${versionNumber} # Non-GLVND
+    rm $out/lib/libGL.so.1.* # GLVND
 
     if test -z "$libsOnly"; then
         # Install the X drivers.
@@ -119,15 +127,9 @@ installPhase() {
     # For simplicity and dependency reduction, don't support the gtk3 interface.
     rm $out/lib/libnvidia-gtk3.*
 
-    # We distribute these separately in `libvdpau`
-    rm "$out"/lib/libvdpau{.*,_trace.*}
-
     # Move VDPAU libraries to their place
     mkdir "$out"/lib/vdpau
     mv "$out"/lib/libvdpau* "$out"/lib/vdpau
-
-    # # nvidia no longer distributes them in 361.18 and up, so eventually remove this.
-    # rm -f "$out"/lib/libvdpau{.*,_trace.*}
 }
 
 

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -61,7 +61,7 @@ installPhase() {
       libname_short=`echo -n "$libname" | sed 's/so\..*/so/'`
 
       # nvidia's EGL stack seems to expect libGLESv2.so.2 to be available
-      if [ $(basename "$libname_short") == "libGLESv2.so" ]; then
+      if [ $(basename "$libname_short") == "libGLESv2.so" -a "$libname" != "$libname_short.2" ]; then
           ln -srnf "$libname" "$libname_short.2"
       fi
 
@@ -125,6 +125,9 @@ installPhase() {
     # Move VDPAU libraries to their place
     mkdir "$out"/lib/vdpau
     mv "$out"/lib/libvdpau* "$out"/lib/vdpau
+
+    # # nvidia no longer distributes them in 361.18 and up, so eventually remove this.
+    # rm -f "$out"/lib/libvdpau{.*,_trace.*}
 }
 
 

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "358.16";
+  versionNumber = "361.28";
 
   # Policy: use the highest stable version as the default (on our master).
   inherit (stdenv.lib) makeLibraryPath;
@@ -28,12 +28,12 @@ stdenv.mkDerivation {
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "1cc0zsri92nz2mznabfd6pqckm9mlbszmysqqqh3w5mipwn898nk";
+        sha256 = "013l9hfjc7gyk5g2v2h71lwjmx4dqlkczsb17cz833fnadcrn4hs";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "1xr16faam2zsx8ajwm9g9302m6qjzyjh1zd56g8jhc8jxg8h43sg";
+        sha256 = "1kq335mdmwlgp0lp9z8wrwyh48p2xv2nwdlgfj7b83vsh6ib17a4";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 


### PR DESCRIPTION
Including some more build fixes for that. These will presumably be useful for the default version, eventually.
