### PR TITLE
udev service: generate hwdb database from all udev packages

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -8,6 +8,8 @@
 
 assert stdenv.isLinux;
 
+# FIXME: When updating, please remove makeFlags -- `hwdb_bin` flag is not supported anymore.
+
 stdenv.mkDerivation rec {
   version = "228";
   name = "systemd-${version}";


### PR DESCRIPTION
With this a proper hwdb database should be generated from `services.udev.packages`. Because many `hwdb` files are contained in `udev` package itself, it was added to `services.udev.packages` (why wasn't it there, anyway?). Also we now don't dynamically regenerate `hwdb.bin` in activatiion script, which is a Good Thing IMO.
