### PR TITLE
qtpass: 1.0.6 -> 1.1.0

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, git, gnupg, makeWrapper, pass, qtbase, qttools }:
+{ stdenv, fetchurl, git, gnupg, makeQtWrapper, pass, qtbase, qtsvg, qttools }:
 
 stdenv.mkDerivation rec {
   name = "qtpass-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "60b458062f54184057e55dbd9c93958a8bf845244ffd70b9cb31bf58697f0dc6";
   };
 
-  buildInputs = [ git gnupg makeWrapper pass qtbase qttools ];
+  buildInputs = [ git gnupg makeQtWrapper pass qtbase qtsvg qttools ];
 
   configurePhase = "qmake CONFIG+=release PREFIX=$out DESTDIR=$out";
 
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
     mv $out/qtpass $out/bin
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/qtpass \
-        --suffix PATH : ${git}/bin \
-        --suffix PATH : ${gnupg}/bin \
-        --suffix PATH : ${pass}/bin
+  postFixup = ''
+    wrapQtProgram $out/bin/qtpass \
+      --suffix PATH : ${git}/bin \
+      --suffix PATH : ${gnupg}/bin \
+      --suffix PATH : ${pass}/bin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "qtpass-${version}";
-  version = "1.0.6";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "https://github.com/IJHack/qtpass/archive/v${version}.tar.gz";
-    sha256 = "ccad9a06e3efa23278fa3e958185bf24fb3800874d8165be4ae6649706a2ab1c";
+    sha256 = "60b458062f54184057e55dbd9c93958a8bf845244ffd70b9cb31bf58697f0dc6";
   };
 
   buildInputs = [ git gnupg makeWrapper pass qtbase qttools ];


### PR DESCRIPTION
This updates qtpass to 1.1.0 (by @annejan) and uses `wrapQtProgram` instead of `wrapProgam` which sets QT's runtime variables correctly and therefore makes icons visible.

Built and tested locally.
