### PR TITLE
desktop manager service: fix and improve default error

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -64,7 +64,13 @@ in
           else if any (w: w.name == defaultDM) cfg.session.list then
             defaultDM
           else
-            throw "Default desktop manager ($(defaultDM)) not found.";
+            throw ''
+              Default desktop manager (${defaultDM}) not found.
+              Probably you want to change
+                services.xserver.desktopManager.default = "${defaultDM}";
+              to one of
+                ${concatMapStringsSep "\n  " (w: "services.xserver.desktopManager.default = \"${w.name}\";") cfg.session.list}
+            '';
       };
 
     };


### PR DESCRIPTION
Before the error if the wrong default desktop was chosen would be:

```
/nixpkgs-channels/lib/modules.nix:282:11:
Default desktop manager ($(defaultDM)) not found.
```

which has the string interpolation done incorrectly. Now that is fixed
and it is more user-friendly as:

```
/nixpkgs-channels/lib/modules.nix:282:11:
Default desktop manager (gnome) not found.
Probably you want to change
  services.xserver.desktopManager.default = "gnome";
to one of
  services.xserver.desktopManager.default = "gnome3";
  services.xserver.desktopManager.default = "none";
```
