### PR TITLE
[RFC] hostbridge and IPv6 for containers

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -260,6 +260,9 @@ in
 
             if [ "$PRIVATE_NETWORK" = 1 ]; then
               extraFlags+=" --network-veth"
+              if [ -n "$HOST_BRIDGE" ]; then
+                extraFlags+=" --network-bridge=$HOST_BRIDGE"
+              fi
             fi
 
             for iface in $INTERFACES; do
@@ -303,11 +306,9 @@ in
         postStart =
           ''
             if [ "$PRIVATE_NETWORK" = 1 ]; then
-              ifaceHost=ve-$INSTANCE
-              ip link set dev $ifaceHost up
-              if [ -n "$HOST_BRIDGE" ]; then
-                ip link set dev $ifaceHost master $HOST_BRIDGE
-              else
+              if [ -z "$HOST_BRIDGE" ]; then
+                ifaceHost=ve-$INSTANCE
+                ip link set dev $ifaceHost up
                 if [ -n "$HOST_ADDRESS" ]; then
                   ip addr add $HOST_ADDRESS dev $ifaceHost
                 fi

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -119,6 +119,7 @@ in
                 Only one of hostAddress* or hostBridge can be given.
               '';
             };
+
             hostAddress = mkOption {
               type = types.nullOr types.string;
               default = null;
@@ -138,7 +139,6 @@ in
                 (Not used when hostBridge is set.)
               '';
             };
-
 
             localAddress = mkOption {
               type = types.nullOr types.string;
@@ -241,6 +241,7 @@ in
 
             if [ "$PRIVATE_NETWORK" = 1 ]; then
               ip link del dev "ve-$INSTANCE" 2> /dev/null || true
+              ip link del dev "vb-$INSTANCE" 2> /dev/null || true
             fi
          '';
 

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -110,6 +110,17 @@ in
               '';
             };
 
+            hostBridge = mkOption {
+              type = types.nullOr types.string;
+              default = null;
+              example = "br0";
+              description = ''
+                Put the host-side of the veth-pair into the named bridge.
+                CAUTION: only one of hostAddress or hostBridge can be given.
+                         hostAddress currently takes precedence
+              '';
+            };
+
             localAddress = mkOption {
               type = types.nullOr types.string;
               default = null;
@@ -269,6 +280,10 @@ in
               ip link set dev $ifaceHost up
               if [ -n "$HOST_ADDRESS" ]; then
                 ip addr add $HOST_ADDRESS dev $ifaceHost
+              else
+                if [ -n "$HOST_BRIDGE" ]; then
+                  ip link set dev $ifaceHost master $HOST_BRIDGE
+                fi
               fi
               if [ -n "$LOCAL_ADDRESS" ]; then
                 ip route add $LOCAL_ADDRESS dev $ifaceHost
@@ -339,6 +354,9 @@ in
               PRIVATE_NETWORK=1
               ${optionalString (cfg.hostAddress != null) ''
                 HOST_ADDRESS=${cfg.hostAddress}
+              ''}
+              ${optionalString (cfg.hostBridge != null) ''
+                HOST_BRIDGE=${cfg.hostBridge}
               ''}
               ${optionalString (cfg.localAddress != null) ''
                 LOCAL_ADDRESS=${cfg.localAddress}

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -22,14 +22,23 @@ let
 
       # Initialise the container side of the veth pair.
       if [ "$PRIVATE_NETWORK" = 1 ]; then
+
         ip link set host0 name eth0
         ip link set dev eth0 up
+
+        if [ -n "$LOCAL_ADDRESS" ]; then
+          ip addr add $LOCAL_ADDRESS dev eth0
+        fi
+        if [ -n "$LOCAL_ADDRESS6" ]; then
+          ip -6 addr add $LOCAL_ADDRESS6 dev eth0
+        fi
         if [ -n "$HOST_ADDRESS" ]; then
           ip route add $HOST_ADDRESS dev eth0
           ip route add default via $HOST_ADDRESS
         fi
-        if [ -n "$LOCAL_ADDRESS" ]; then
-          ip addr add $LOCAL_ADDRESS dev eth0
+        if [ -n "$HOST_ADDRESS6" ]; then
+          ip -6 route add $HOST_ADDRESS6 dev eth0
+          ip -6 route add default via $HOST_ADDRESS6
         fi
       fi
 

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -285,7 +285,7 @@ in
                   ip link set dev $ifaceHost master $HOST_BRIDGE
                 fi
               fi
-              if [ -n "$LOCAL_ADDRESS" ]; then
+              if [ -n "$LOCAL_ADDRESS" -a -z "$HOST_BRIDGE" ]; then
                 ip route add $LOCAL_ADDRESS dev $ifaceHost
               fi
             fi

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -219,6 +219,8 @@ in rec {
   tests.chromium = callTest tests/chromium.nix {};
   tests.cjdns = callTest tests/cjdns.nix {};
   tests.containers = callTest tests/containers.nix {};
+  tests.containers-ipv6 = callTest tests/containers-ipv6.nix {};
+  tests.containers-bridge = callTest tests/containers-bridge.nix {};
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
   tests.dockerRegistry = hydraJob (import tests/docker-registry.nix { system = "x86_64-linux"; });
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -1,0 +1,84 @@
+# Test for NixOS' container support.
+
+let
+  hostIp = "192.168.0.1";
+  containerIp = "192.168.0.100/24";
+  hostIp6 = "fc00::1";
+  containerIp6 = "fc00::2/7";
+in
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aristid aszlig eelco chaoflow ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      networking.bridges = {
+        br0 = {
+          interfaces = [];
+        };
+      };
+      networking.interfaces = {
+        br0 = {
+          ip4 = [{ address = hostIp; prefixLength = 24; }];
+          ip6 = [{ address = hostIp6; prefixLength = 7; }];
+        };
+      };
+
+      containers.webserver =
+        { privateNetwork = true;
+          hostBridge = "br0";
+          localAddress = containerIp;
+          localAddress6 = containerIp6;
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+              networking.firewall.allowPing = true;
+            };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("default.target");
+      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+      # Start the webserver container.
+      $machine->succeed("nixos-container start webserver");
+
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
+      # Since "start" returns after the container has reached
+      # multi-user.target, we should now be able to access it.
+      "${containerIp}" =~ /([^\/]+)\/([0-9+])/;
+      my $ip = $1;
+      chomp $ip;
+      $machine->succeed("ping -n -c 1 $ip");
+      $machine->succeed("curl --fail http://$ip/ > /dev/null");
+
+      "${containerIp6}" =~ /([^\/]+)\/([0-9+])/;
+      my $ip6 = $1;
+      chomp $ip6;
+      $machine->succeed("ping6 -n -c 1 $ip6");
+      $machine->succeed("curl --fail http://[$ip6]/ > /dev/null");
+
+      # Stop the container.
+      $machine->succeed("nixos-container stop webserver");
+      $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
+      $machine->fail("curl --fail --connect-timeout 2 http://[$ip6]/ > /dev/null");
+
+      # Destroying a declarative container should fail.
+      $machine->fail("nixos-container destroy webserver");
+    '';
+
+})

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -8,7 +8,7 @@ let
 in
 
 import ./make-test.nix ({ pkgs, ...} : {
-  name = "containers";
+  name = "containers-bridge";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco chaoflow ];
   };

--- a/nixos/tests/containers-ipv6.nix
+++ b/nixos/tests/containers-ipv6.nix
@@ -1,0 +1,61 @@
+# Test for NixOS' container support.
+
+let
+  hostIp = "fc00::2";
+  localIp = "fc00::1";
+in
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aristid aszlig eelco chaoflow ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      containers.webserver =
+        { privateNetwork = true;
+          hostAddress6 = hostIp;
+          localAddress6 = localIp;
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+              networking.firewall.allowPing = true;
+            };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("default.target");
+      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+      # Start the webserver container.
+      $machine->succeed("nixos-container start webserver");
+
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
+      # Since "start" returns after the container has reached
+      # multi-user.target, we should now be able to access it.
+      my $ip = "${localIp}";
+      chomp $ip;
+      $machine->succeed("ping6 -n -c 1 $ip");
+      $machine->succeed("curl --fail http://[$ip]/ > /dev/null");
+
+      # Stop the container.
+      $machine->succeed("nixos-container stop webserver");
+      $machine->fail("curl --fail --connect-timeout 2 http://[$ip]/ > /dev/null");
+
+      # Destroying a declarative container should fail.
+      $machine->fail("nixos-container destroy webserver");
+    '';
+
+})

--- a/nixos/tests/containers-ipv6.nix
+++ b/nixos/tests/containers-ipv6.nix
@@ -6,7 +6,7 @@ let
 in
 
 import ./make-test.nix ({ pkgs, ...} : {
-  name = "containers";
+  name = "containers-ipv6";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco chaoflow ];
   };

--- a/nixos/tests/containers.nix
+++ b/nixos/tests/containers.nix
@@ -34,11 +34,14 @@ import ./make-test.nix ({ pkgs, ...} : {
       # Start the webserver container.
       $machine->succeed("nixos-container start webserver");
 
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
       # Since "start" returns after the container has reached
       # multi-user.target, we should now be able to access it.
       my $ip = $machine->succeed("nixos-container show-ip webserver");
       chomp $ip;
-      #$machine->succeed("ping -c1 $ip"); # FIXME
+      $machine->succeed("ping -n -c1 $ip");
       $machine->succeed("curl --fail http://$ip/ > /dev/null");
 
       # Stop the container.


### PR DESCRIPTION
Hi all,

scratching my own itch I had some ideas on how to a) give nixos containers IPv6 and b) allow declarative containers to join an existing bridge for connectivity.

What I mostly do not like yet: It should be possible to define the network-settings inside the container with `networking.interfaces.eth0.*` instead of defining it from the outside.

So please comment on this, maybe I can rework this into something usable to get IPv6 and bridging to declarative containers.
