### PR TITLE
ghcjs: have Hydra build ghcjs packages

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -242,6 +242,7 @@ let
       };
 
       haskell.compiler = packagePlatforms pkgs.haskell.compiler;
+      haskell.packages.ghcjs = packagePlatforms pkgs.haskell.packages.ghcjs;
       haskellPackages = packagePlatforms pkgs.haskellPackages;
 
       rPackages = packagePlatforms pkgs.rPackages;


### PR DESCRIPTION
I think we should have Hydra build the GHCJS package set.

**I'm not entirely sure how `pkgs/top-level/release.nix` works, so I might not have this incantation quite right; confirmation would be appreciated.**

@peti Does this seem reasonable (and work as intended)?
