### PR TITLE
U-Boot: 2015.10 -> 2016.01, refactor & support some new boards

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -23,7 +23,7 @@ in
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.kernelPackages = pkgs.linuxPackages_latest;
-  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
+  boot.kernelParams = ["console=ttyS0,115200n8" "console=ttymxc0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
   # FIXME: this probably should be in installation-device.nix
   users.extraUsers.root.initialHashedPassword = "";

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -30,7 +30,7 @@ in
 
     bootSize = mkOption {
       type = types.int;
-      default = 128;
+      default = 120;
       description = ''
         Size of the /boot partition, in megabytes.
       '';
@@ -66,10 +66,10 @@ in
       buildInputs = with pkgs; [ dosfstools e2fsprogs mtools libfaketime utillinux ];
 
       buildCommand = ''
-        # Create the image file sized to fit /boot and /, plus 4M of slack
+        # Create the image file sized to fit /boot and /, plus 20M of slack
         rootSizeBlocks=$(du -B 512 --apparent-size ${rootfsImage} | awk '{ print $1 }')
         bootSizeBlocks=$((${toString config.sdImage.bootSize} * 1024 * 1024 / 512))
-        imageSize=$((rootSizeBlocks * 512 + bootSizeBlocks * 512 + 4096 * 1024))
+        imageSize=$((rootSizeBlocks * 512 + bootSizeBlocks * 512 + 20 * 1024 * 1024))
         truncate -s $imageSize $out
 
         # type=b is 'W95 FAT32', type=83 is 'Linux'.
@@ -77,8 +77,8 @@ in
             label: dos
             label-id: 0x2178694e
 
-            start=1M, size=$bootSizeBlocks, type=b, bootable
-            type=83
+            start=8M, size=$bootSizeBlocks, type=b, bootable
+            start=${toString (8 + config.sdImage.bootSize)}M, type=83
         EOF
 
         # Copy the rootfs into the SD image

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -61,6 +61,12 @@ in rec {
     filesToInstall = ["tools/dumpimage" "tools/mkenvimage" "tools/mkimage"];
   };
 
+  ubootBananaPi = buildUBoot rec {
+    defconfig = "Bananapi_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
   ubootJetsonTK1 = buildUBoot rec {
     defconfig = "jetson-tk1_defconfig";
     targetPlatforms = ["armv7l-linux"];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,62 +1,89 @@
-{ stdenv, fetchurl, bc, dtc
-, toolsOnly ? false
-, defconfig ? "allnoconfig"
-, targetPlatforms
-, filesToInstall
-}:
+{ stdenv, fetchurl, bc, dtc }:
 
 let
-  platform = stdenv.platform;
-  crossPlatform = stdenv.cross.platform;
-  makeTarget = if toolsOnly then "tools NO_SDL=1" else "all";
-  installDir = if toolsOnly then "$out/bin" else "$out";
-  buildFun = kernelArch:
-    ''
-      if test -z "$crossConfig"; then
-          make ${makeTarget}
-      else
-          make ${makeTarget} ARCH=${kernelArch} CROSS_COMPILE=$crossConfig-
-      fi
+  buildUBoot = { targetPlatforms
+            , filesToInstall
+            , installDir ? "$out"
+            , defconfig
+            , extraMeta ? {}
+            , ... } @ args:
+           stdenv.mkDerivation (rec {
+
+    name = "uboot-${defconfig}-${version}";
+    version = "2015.10";
+
+    nativeBuildInputs = [ bc dtc ];
+
+    src = fetchurl {
+      url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
+      sha256 = "0m8r08izci0lzzjn5c5g5manp2rc7yc5swww0lxr7bamjigqvimx";
+    };
+
+    configurePhase = ''
+      make ${defconfig}
     '';
-in
 
-stdenv.mkDerivation rec {
-  name = "uboot-${defconfig}-${version}";
-  version = "2015.10";
+    installPhase = ''
+      runHook preInstall
 
-  src = fetchurl {
-    url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-    sha256 = "0m8r08izci0lzzjn5c5g5manp2rc7yc5swww0lxr7bamjigqvimx";
+      mkdir -p ${installDir}
+      cp ${stdenv.lib.concatStringsSep " " filesToInstall} ${installDir}
+
+      runHook postInstall
+    '';
+
+    dontStrip = true;
+
+    crossAttrs = {
+      makeFlags = [
+        "ARCH=${stdenv.cross.platform.kernelArch}"
+        "CROSS_COMPILE=${stdenv.cross.config}-"
+      ];
+    };
+
+    meta = with stdenv.lib; {
+      homepage = "http://www.denx.de/wiki/U-Boot/";
+      description = "Boot loader for embedded systems";
+      license = licenses.gpl2;
+      maintainers = [ maintainers.dezgeg ];
+      platforms = targetPlatforms;
+    } // extraMeta;
+  } // args);
+
+in rec {
+  inherit buildUBoot;
+
+  ubootTools = buildUBoot rec {
+    installDir = "$out/bin";
+    buildFlags = "tools NO_SDL=1";
+    dontStrip = false;
+    targetPlatforms = stdenv.lib.platforms.linux;
+    filesToInstall = ["tools/dumpimage" "tools/mkenvimage" "tools/mkimage"];
   };
 
-  patches = [ ./vexpress-Use-config_distro_bootcmd.patch ];
-
-  nativeBuildInputs = [ bc dtc ];
-
-  configurePhase = ''
-    make ${defconfig}
-  '';
-
-  buildPhase = assert (platform ? kernelArch);
-    buildFun platform.kernelArch;
-
-  installPhase = ''
-    mkdir -p ${installDir}
-    cp ${stdenv.lib.concatStringsSep " " filesToInstall} ${installDir}
-  '';
-
-  dontStrip = !toolsOnly;
-
-  crossAttrs = {
-    buildPhase = assert (crossPlatform ? kernelArch);
-      buildFun crossPlatform.kernelArch;
+  ubootJetsonTK1 = buildUBoot rec {
+    defconfig = "jetson-tk1_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot" "u-boot.dtb" "u-boot-dtb-tegra.bin" "u-boot-nodtb-tegra.bin"];
   };
 
-  meta = with stdenv.lib; {
-    homepage = "http://www.denx.de/wiki/U-Boot/";
-    description = "Boot loader for embedded systems";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.dezgeg ];
-    platforms = targetPlatforms;
+  ubootPcduino3Nano = buildUBoot rec {
+    defconfig = "Linksprite_pcDuino3_Nano_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
+  ubootRaspberryPi = buildUBoot rec {
+    defconfig = "rpi_defconfig";
+    targetPlatforms = ["armv6l-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
+  # Intended only for QEMU's vexpress-a9 emulation target!
+  ubootVersatileExpressCA9 = buildUBoot rec {
+    defconfig = "vexpress_ca9x4_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot"];
+    patches = [ ./vexpress-Use-config_distro_bootcmd.patch ];
   };
 }

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -10,13 +10,13 @@ let
            stdenv.mkDerivation (rec {
 
     name = "uboot-${defconfig}-${version}";
-    version = "2015.10";
+    version = "2016.01";
 
     nativeBuildInputs = [ bc dtc ];
 
     src = fetchurl {
       url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "0m8r08izci0lzzjn5c5g5manp2rc7yc5swww0lxr7bamjigqvimx";
+      sha256 = "1md5jpq5n9jh08s7sdkjrvg2q7kpzwa7yrpgl9581ncrjfx2yyg5";
     };
 
     configurePhase = ''

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -92,4 +92,10 @@ in rec {
     filesToInstall = ["u-boot"];
     patches = [ ./vexpress-Use-config_distro_bootcmd.patch ];
   };
+
+  ubootWandboard = buildUBoot rec {
+    defconfig = "wandboard_defconfig";
+    targetPlatforms = ["armv7l-linux"];
+    filesToInstall = ["u-boot.img" "SPL"];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10574,36 +10574,13 @@ let
   ubootChooser = name: ubootTools;
 
   # Upstream U-Boots:
-  ubootTools = callPackage ../misc/uboot {
-    toolsOnly = true;
-    targetPlatforms = lib.platforms.linux;
-    filesToInstall = ["tools/dumpimage" "tools/mkenvimage" "tools/mkimage"];
-  };
-
-  ubootJetsonTK1 = callPackage ../misc/uboot {
-    defconfig = "jetson-tk1_defconfig";
-    targetPlatforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot" "u-boot.dtb" "u-boot-dtb-tegra.bin" "u-boot-nodtb-tegra.bin"];
-  };
-
-  ubootPcduino3Nano = callPackage ../misc/uboot {
-    defconfig = "Linksprite_pcDuino3_Nano_defconfig";
-    targetPlatforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
-  };
-
-  ubootRaspberryPi = callPackage ../misc/uboot {
-    defconfig = "rpi_defconfig";
-    targetPlatforms = ["armv6l-linux"];
-    filesToInstall = ["u-boot.bin"];
-  };
-
-  # Intended only for QEMU's vexpress-a9 emulation target!
-  ubootVersatileExpressCA9 = callPackage ../misc/uboot {
-    defconfig = "vexpress_ca9x4_defconfig";
-    targetPlatforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot"];
-  };
+  inherit (callPackage ../misc/uboot {})
+    buildUBoot
+    ubootJetsonTK1
+    ubootPcduino3Nano
+    ubootRaspberryPi
+    ubootVersatileExpressCA9
+    ;
 
   # Non-upstream U-Boots:
   ubootSheevaplug = callPackage ../misc/uboot/sheevaplug.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10576,6 +10576,7 @@ let
   # Upstream U-Boots:
   inherit (callPackage ../misc/uboot {})
     buildUBoot
+    ubootBananaPi
     ubootJetsonTK1
     ubootPcduino3Nano
     ubootRaspberryPi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10581,6 +10581,7 @@ let
     ubootPcduino3Nano
     ubootRaspberryPi
     ubootVersatileExpressCA9
+    ubootWandboard
     ;
 
   # Non-upstream U-Boots:


### PR DESCRIPTION
The new derivation style (using `callPackages`) has the benefit of removing stuff from `all-packages.nix` and making the actual definitions of the U-Boot builds more localized to the common build function. This also allows things like easily applying patches only to certain boards (Versatile, in this case) and making the tools build less hardcoded.
