### PR TITLE
Fix boto3 build for Python 3 and 2.

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2282,10 +2282,15 @@ in modules // {
     };
 
     propagatedBuildInputs = [ self.botocore
-                              self.futures_2_2
                               self.jmespath
-                            ];
-    buildInputs = [ self.docutils ];
+                            ] ++ (if isPy3k then [] else [self.futures_2_2]);
+    buildInputs = [ self.docutils self.nose self.mock ];
+
+    # Tests are failing with `botocore.exceptions.NoCredentialsError:
+    # Unable to locate credentials`. There also seems to be some mock
+    # issues (`assert_called_once` doesn't exist in mock but boto
+    # seems to think it is?).
+    doCheck = false;
 
     meta = {
       homepage = https://github.com/boto3/boto;
@@ -12520,7 +12525,7 @@ in modules // {
     # Disable failing test_f2py test.
     # f2py couldn't be found by test,
     # even though it was used successfully to build numpy
-    
+
     # The large file support test is disabled because it takes forever
     # and can cause the machine to run out of disk space when run.
     prePatch = ''


### PR DESCRIPTION
Tested with nox-review:

```
Building in /tmp/nox-review-uag8zscu: python27Packages.boto3 pypyPackages.boto3 python34Packages.boto3 python35Packages.boto3
[...]
lrwxrwxrwx 1 tom tom 65 Feb  1 12:22 result -> /nix/store/lymmibfyirv9ksdyrf5sxjmw5k7kw1d8-python2.7-boto3-1.2.2
lrwxrwxrwx 1 tom tom 63 Feb  1 12:22 result-2 -> /nix/store/4chjsk2v1zrw05l4hczr77iahfhnbn27-pypy4.0-boto3-1.2.2
lrwxrwxrwx 1 tom tom 65 Feb  1 12:22 result-3 -> /nix/store/y80lfh4fdjlyfgwvq8lyxbdbc6vs6g6v-python3.4-boto3-1.2.2
lrwxrwxrwx 1 tom tom 65 Feb  1 12:22 result-4 -> /nix/store/3nzpdp70qrkk0cccdv7rr8iifhbaiphf-python3.5-boto3-1.2.2
```
