### PR TITLE
spotify: fix icons

### DIFF
--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -87,7 +87,14 @@ stdenv.mkDerivation {
       # Desktop file
       mkdir -p "$out/share/applications/"
       cp "$out/share/spotify/spotify.desktop" "$out/share/applications/"
-      sed -i "s|Icon=.*|Icon=$out/share/spotify/Icons/spotify-linux-512.png|" "$out/share/applications/spotify.desktop"
+
+      # Icons
+      for i in 16 22 24 32 48 64 128 256 512; do
+        ixi="$i"x"$i"
+        mkdir -p "$out/share/icons/hicolor/$ixi/apps"
+        ln -s "$out/share/spotify/icons/spotify-linux-$i.png" \
+          "$out/share/icons/hicolor/$ixi/apps/spotify-client.png"
+      done
     '';
 
   dontStrip = true;


### PR DESCRIPTION
The icon was not shown (Gnome Shell / preview of `spotify.desktop` in a filebrowser) because of a wrong absolute path in the `spotify.desktop` file. This fixes this and should also allow for custom themes to set the icon correctly.

Tested: working icon.
Not tested: custom themes.

cc @edolstra @ftrvxmtrx
