### PR TITLE
closure-size: move ncurses utilities to $out

### DIFF
--- a/pkgs/applications/editors/emacs-24/macport-24.5.nix
+++ b/pkgs/applications/editors/emacs-24/macport-24.5.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "LDFLAGS=-L${ncurses.lib}/lib"
+    "LDFLAGS=-L${ncurses.out}/lib"
     "--with-xml2=yes"
     "--with-gnutls=yes"
     "--with-mac"
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   ];
 
   CFLAGS = "-O3";
-  LDFLAGS = "-O3 -L${ncurses.lib}/lib";
+  LDFLAGS = "-O3 -L${ncurses.out}/lib";
 
   postInstall = ''
     mkdir -p $out/share/emacs/site-lisp/

--- a/pkgs/applications/editors/heme/default.nix
+++ b/pkgs/applications/editors/heme/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile \
       --replace "/usr/local" "$out" \
       --replace "CFLAGS = " "CFLAGS = -I${ncurses.dev}/include " \
-      --replace "LDFLAGS = " "LDFLAGS = -L${ncurses.lib}/lib " \
+      --replace "LDFLAGS = " "LDFLAGS = -L${ncurses.out}/lib " \
       --replace "-lcurses" "-lncurses"
   '';
   buildInputs = [ ncurses ];

--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig gtk gettext ];
 
   makeFlags = [ "PREFIX=$(out)" ]
-    ++ optional withBuildColors "TPUT=${ncurses.dev}/bin/tput"
+    ++ optional withBuildColors "TPUT=${ncurses.out}/bin/tput"
     ++ optional (!withBuildColors) "TPUT_AVAILABLE=0"
     ;
 

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "RSTTOMAN=${docutils}/bin/rst2man.py"
     "VERBOSE=1"
-    "TPUT=${ncurses.dev}/bin/tput"
+    "TPUT=${ncurses.out}/bin/tput"
   ];
 
   postInstall = ''

--- a/pkgs/applications/science/logic/saw-tools/default.nix
+++ b/pkgs/applications/science/logic/saw-tools/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     mv doc $out/share
 
     # Hack around lack of libtinfo in NixOS
-    ln -s ${ncurses.lib}/lib/libncursesw.so.5       $out/lib/libtinfo.so.5
+    ln -s ${ncurses.out}/lib/libncursesw.so.5       $out/lib/libtinfo.so.5
     ln -s ${stdenv.cc.libc}/lib/libpthread.so.0 $out/lib/libpthread.so.0
 
     # Add a clang symlink for easy building with a suitable compiler.

--- a/pkgs/desktops/gnome-3/3.18/core/vte/2.90.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/vte/2.90.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
-    substituteInPlace $out/lib/libvte2_90.la --replace "-lncurses" "-L${ncurses.lib}/lib -lncurses"
+    substituteInPlace $out/lib/libvte2_90.la --replace "-lncurses" "-L${ncurses.out}/lib -lncurses"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.18/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/vte/default.nix
@@ -20,7 +20,7 @@ let baseAttrs = rec {
   enableParallelBuilding = true;
 
   postInstall = ''
-    substituteInPlace $out/lib/libvte2_90.la --replace "-lncurses" "-L${ncurses.lib}/lib -lncurses"
+    substituteInPlace $out/lib/libvte2_90.la --replace "-lncurses" "-L${ncurses.out}/lib -lncurses"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     for f in $(find $out); do
       if [ -f "$f" ] && patchelf "$f" 2> /dev/null; then
         patchelf --set-interpreter ${glibc.out}/lib/ld-linux.so.2 \
-                 --set-rpath $out/lib:${gcc.lib or gcc}/lib:${ncurses.lib}/lib \
+                 --set-rpath $out/lib:${gcc.lib or gcc}/lib:${ncurses.out}/lib \
                  "$f" || true
       fi
     done

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     (if stdenv.isLinux then ''
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${libedit}/lib:${ncurses.lib}/lib:${gmp.out}/lib" {} \;
+          --set-rpath "${libedit}/lib:${ncurses.out}/lib:${gmp.out}/lib" {} \;
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
       done

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
   '';
 
   preConfigure = ''

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optionalString stdenv.isLinux ''
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${ncurses.lib}/lib:${gmp.out}/lib" {} \;
+          --set-rpath "${ncurses.out}/lib:${gmp.out}/lib" {} \;
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       for prog in ld ar gcc strip ranlib; do

--- a/pkgs/development/compilers/ghc/7.0.4.nix
+++ b/pkgs/development/compilers/ghc/7.0.4.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"

--- a/pkgs/development/compilers/ghc/7.10.2.nix
+++ b/pkgs/development/compilers/ghc/7.10.2.nix
@@ -9,7 +9,7 @@ let
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.lib}/lib"
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ];

--- a/pkgs/development/compilers/ghc/7.2.2.nix
+++ b/pkgs/development/compilers/ghc/7.2.2.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     stdenv.lib.optionalString stdenv.isLinux ''
       mkdir -p "$out/lib"
-      ln -sv "${ncurses.lib}/lib/libncurses.so" "$out/lib/libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5"
+      ln -sv "${ncurses.out}/lib/libncurses.so" "$out/lib/libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5"
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "$out/lib:${gmp.out}/lib" {} \;

--- a/pkgs/development/compilers/ghc/7.4.2.nix
+++ b/pkgs/development/compilers/ghc/7.4.2.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"

--- a/pkgs/development/compilers/ghc/7.6.3.nix
+++ b/pkgs/development/compilers/ghc/7.6.3.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-libraries="${libiconv}/lib"

--- a/pkgs/development/compilers/ghc/7.8.3.nix
+++ b/pkgs/development/compilers/ghc/7.8.3.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     DYNAMIC_BY_DEFAULT = NO
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"

--- a/pkgs/development/compilers/ghc/7.8.4.nix
+++ b/pkgs/development/compilers/ghc/7.8.4.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (rec {
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     DYNAMIC_BY_DEFAULT = NO
     ${stdenv.lib.optionalString stdenv.isDarwin ''
       libraries/base_CONFIGURE_OPTS += --configure-option=--with-iconv-includes="${libiconv}/include"

--- a/pkgs/development/compilers/ghc/8.0.1.nix
+++ b/pkgs/development/compilers/ghc/8.0.1.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"
     "--with-gmp-includes=${gmp}/include" "--with-gmp-libraries=${gmp.out}/lib"
-    "--with-curses-includes=${ncurses}/include" "--with-curses-libraries=${ncurses.lib}/lib"
+    "--with-curses-includes=${ncurses}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ];

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gcc=${stdenv.cc}/bin/cc"
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
-    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.lib}/lib"
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
   ] ++ stdenv.lib.optional stdenv.isDarwin [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
   ];

--- a/pkgs/development/compilers/ghc/nokinds.nix
+++ b/pkgs/development/compilers/ghc/nokinds.nix
@@ -7,7 +7,7 @@ let
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries="${gmp.out}/lib"
     libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes="${gmp.dev}/include"
     libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-includes="${ncurses.dev}/include"
-    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.lib}/lib"
+    libraries/terminfo_CONFIGURE_OPTS += --configure-option=--with-curses-libraries="${ncurses.out}/lib"
     DYNAMIC_BY_DEFAULT = NO
     SRC_HC_OPTS        = -H64m -O -fasm
     GhcLibHcOpts       = -O -dcore-lint

--- a/pkgs/development/compilers/mentor/default.nix
+++ b/pkgs/development/compilers/mentor/default.nix
@@ -34,7 +34,7 @@ let
 
             # GDB needs ncurses
             case "$file" in
-              *gdb) patchelf --set-rpath "${ncurses.lib}/lib" "$file";;
+              *gdb) patchelf --set-rpath "${ncurses.out}/lib" "$file";;
             esac
         done
 

--- a/pkgs/development/interpreters/ruby/gemconfig/default.nix
+++ b/pkgs/development/interpreters/ruby/gemconfig/default.nix
@@ -73,7 +73,7 @@ in
     buildInputs = [ ncurses ];
     buildFlags = [
       "--with-cflags=-I${ncurses.dev}/include"
-      "--with-ldflags=-L${ncurses.lib}/lib"
+      "--with-ldflags=-L${ncurses.out}/lib"
     ];
   };
 

--- a/pkgs/development/libraries/aalib/default.nix
+++ b/pkgs/development/libraries/aalib/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   postInstall = ''
     mkdir -p $dev/bin
     mv $bin/bin/aalib-config $dev/bin/aalib-config
-    substituteInPlace $out/lib/libaa.la --replace "${ncurses.dev}/lib" "${ncurses.lib}/lib"
+    substituteInPlace $out/lib/libaa.la --replace "${ncurses.dev}/lib" "${ncurses.out}/lib"
   '';
 
   meta = {

--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-good/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/lib/gstreamer-0.10/libgstaasink.la \
-      --replace "${ncurses.dev}/lib" "${ncurses.lib}/lib"
+      --replace "${ncurses.dev}/lib" "${ncurses.out}/lib"
   '';
 
   meta = {

--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     find $out/lib -type f | grep '\.\(la\|pc\)''$' | xargs sed -i \
-      -e 's,-lncurses[a-z]*,-L${ncurses.lib}/lib -lncursesw,g'
+      -e 's,-lncurses[a-z]*,-L${ncurses.out}/lib -lncursesw,g'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   # gcc-5.patch should be removed after 5.9
   patches = [ ./clang.patch ./gcc-5.patch ];
 
-  outputs = [ "dev" "lib" "out" "man" ];
+  outputs = [ "dev" "out" "man" ];
   setOutputFlags = false; # some aren't supported
 
   configureFlags = [
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     export PKG_CONFIG_LIBDIR="$dev/lib/pkgconfig"
     mkdir -p "$PKG_CONFIG_LIBDIR"
     configureFlagsArray+=(
-      "--libdir=$lib/lib"
+      "--libdir=$out/lib"
       "--includedir=$dev/include"
       "--bindir=$dev/bin"
       "--mandir=$man/share/man"
@@ -85,14 +85,14 @@ stdenv.mkDerivation rec {
 
       for library in $libs; do
         for dylibtype in so dll dylib; do
-          if [ -e "$lib/lib/lib''${library}$suffix.$dylibtype" ]; then
-            ln -svf lib''${library}$suffix.$dylibtype $lib/lib/lib$library$newsuffix.$dylibtype
-            ln -svf lib''${library}$suffix.$dylibtype.${abiVersion} $lib/lib/lib$library$newsuffix.$dylibtype.${abiVersion}
+          if [ -e "$out/lib/lib''${library}$suffix.$dylibtype" ]; then
+            ln -svf lib''${library}$suffix.$dylibtype $out/lib/lib$library$newsuffix.$dylibtype
+            ln -svf lib''${library}$suffix.$dylibtype.${abiVersion} $out/lib/lib$library$newsuffix.$dylibtype.${abiVersion}
           fi
         done
         for statictype in a dll.a la; do
-          if [ -e "$lib/lib/lib''${library}$suffix.$statictype" ]; then
-            ln -svf lib''${library}$suffix.$statictype $lib/lib/lib$library$newsuffix.$statictype
+          if [ -e "$out/lib/lib''${library}$suffix.$statictype" ]; then
+            ln -svf lib''${library}$suffix.$statictype $out/lib/lib$library$newsuffix.$statictype
           fi
         done
         ln -svf ''${library}$suffix.pc $dev/lib/pkgconfig/$library$newsuffix.pc
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    rm "$lib"/lib/*.a
+    rm "$out"/lib/*.a
   '';
 
   meta = {

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -98,6 +98,14 @@ stdenv.mkDerivation rec {
         ln -svf ''${library}$suffix.pc $dev/lib/pkgconfig/$library$newsuffix.pc
       done
     done
+
+    # move some utilities to $bin
+    # these programs are used at runtime and don't really belong in $dev
+    moveToOutput "bin/clear" "$out"
+    moveToOutput "bin/reset" "$out"
+    moveToOutput "bin/tabs" "$out"
+    moveToOutput "bin/tput" "$out"
+    moveToOutput "bin/tset" "$out"
   '';
 
   preFixup = ''

--- a/pkgs/development/mobile/androidenv/androidndk_r8e.nix
+++ b/pkgs/development/mobile/androidenv/androidndk_r8e.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
         \( -type f -a -name "*.so*" \) -o \
         \( -type f -a -perm -0100 \) \
         \) -exec patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-*so.? \
-                          --set-rpath ${zlib.out}/lib:${ncurses.lib}/lib {} \;
+                          --set-rpath ${zlib.out}/lib:${ncurses.out}/lib {} \;
     # fix ineffective PROGDIR / MYNDKDIR determination
     for i in ndk-build ndk-gdb ndk-gdb-py
     do

--- a/pkgs/development/tools/misc/drush/default.nix
+++ b/pkgs/development/tools/misc/drush/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out"
     cp -r . "$out/src"
     mkdir "$out/bin"
-    wrapProgram "$out/src/drush" --prefix PATH : "${which}/bin:${php}/bin:${bash}/bin:${coreutils}/bin:${ncurses.dev}/bin"
+    wrapProgram "$out/src/drush" --prefix PATH : "${which}/bin:${php}/bin:${bash}/bin:${coreutils}/bin:${ncurses.out}/bin"
     ln -s "$out/src/drush" "$out/bin/drush"
   '';
 }

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     "-DWITHOUT_OQGRAPH_STORAGE_ENGINE=1"
     "-DWITHOUT_TOKUDB=1"
-    "-DCURSES_LIBRARY=${ncurses.lib}/lib/libncurses.dylib"
+    "-DCURSES_LIBRARY=${ncurses.out}/lib/libncurses.dylib"
   ];
 
   # fails to find lex_token.h sometimes

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
         -i "$out/share/fish/functions/alias.fish" \
            "$out/share/fish/functions/prompt_pwd.fish"
     substituteInPlace "$out/share/fish/functions/fish_default_key_bindings.fish" \
-      --replace "clear;" "${ncurses}/bin/clear;"
+      --replace "clear;" "${ncurses.out}/bin/clear;"
   '' + stdenv.lib.optionalString stdenv.isLinux ''
     substituteInPlace "$out/share/fish/functions/__fish_print_help.fish" \
       --replace "| ul" "| ${utillinux}/bin/ul" 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -296,7 +296,7 @@ in rec {
     allowedRequisites = (with pkgs; [
       xz.out xz.bin libcxx libcxxabi icu.out gmp.out gnumake findutils bzip2.out
       bzip2.bin llvm zlib.out zlib.dev libffi.out coreutils ed diffutils gnutar
-      gzip ncurses.out ncurses.dev ncurses.lib ncurses.man gnused bash gawk
+      gzip ncurses.out ncurses.dev ncurses.man gnused bash gawk
       gnugrep llvmPackages.clang-unwrapped patch pcre.out binutils-raw.out
       binutils-raw.dev binutils gettext
     ]) ++ (with pkgs.darwin; [

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -65,7 +65,7 @@ rec {
       cp -d ${libiconv.lib}/lib/lib*.dylib $out/lib
       cp -d ${gettext}/lib/libintl*.dylib $out/lib
       chmod +x $out/lib/libintl*.dylib
-      cp -d ${ncurses.lib}/lib/libncurses*.dylib $out/lib
+      cp -d ${ncurses.out}/lib/libncurses*.dylib $out/lib
 
       # Copy what we need of clang
       cp -d ${llvmPackages.clang-unwrapped}/bin/clang $out/bin

--- a/pkgs/tools/misc/entr/default.nix
+++ b/pkgs/tools/misc/entr/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace Makefile.bsd --replace /bin/echo echo
     substituteInPlace entr.c --replace /bin/cat ${coreutils}/bin/cat
-    substituteInPlace entr.c --replace /usr/bin/clear ${ncurses.dev}/bin/clear
+    substituteInPlace entr.c --replace /usr/bin/clear ${ncurses.out}/bin/clear
     substituteInPlace entr.1 --replace /bin/cat cat
     substituteInPlace entr.1 --replace /usr/bin/clear clear
   '';

--- a/pkgs/tools/system/gptfdisk/default.nix
+++ b/pkgs/tools/system/gptfdisk/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile.mac --replace \
       " -I/opt/local/include -I /usr/local/include -I/opt/local/include" ""
     substituteInPlace Makefile.mac --replace \
-      "/opt/local/lib/libncurses.a" "${ncurses.lib}/lib/libncurses.dylib"
+      "/opt/local/lib/libncurses.a" "${ncurses.out}/lib/libncurses.dylib"
   '';
 
   buildPhase = stdenv.lib.optionalString stdenv.isDarwin "make -f Makefile.mac";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11220,7 +11220,7 @@ let self = _self // overrides; _self = with self; {
     preConfigure =
       ''
         substituteInPlace Makefile.PL --replace '$Config{libpth}' \
-          "'${pkgs.ncurses.lib}/lib'"
+          "'${pkgs.ncurses.out}/lib'"
       '';
 
     # Tests don't work because they require /dev/tty.


### PR DESCRIPTION
All the programs provided by ncurses were being installed to the $dev
output, but several of them are intended for runtime use, e.g. to
operate on the running terminal. These user-facing programs are moved to
the $bin output.

/cc @vcunat 
