### PR TITLE
Hunspell: add wrapper to include dictionaries

### DIFF
--- a/pkgs/development/libraries/hunspell/wrapper.nix
+++ b/pkgs/development/libraries/hunspell/wrapper.nix
@@ -1,0 +1,13 @@
+{ stdenv, lib, hunspell, makeWrapper, dicts ? [] }:
+with lib;
+let
+  searchPath = makeSearchPath "share/hunspell" dicts;
+in
+stdenv.mkDerivation {
+  name = (appendToName "with-dicts" hunspell).name;
+  buildInputs = [ makeWrapper ];
+  buildCommand = ''
+    makeWrapper ${hunspell}/bin/hunspell $out/bin/hunspell --prefix DICPATH : ${searchPath}
+  '';
+  inherit (hunspell) meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6856,6 +6856,8 @@ let
 
   hunspellDicts = recurseIntoAttrs (callPackages ../development/libraries/hunspell/dictionaries.nix {});
 
+  hunspellWithDicts = dicts: callPackage ../development/libraries/hunspell/wrapper.nix { inherit dicts; };
+
   hwloc = callPackage ../development/libraries/hwloc {};
 
   hydraAntLogger = callPackage ../development/libraries/java/hydra-ant-logger { };


### PR DESCRIPTION
Hunspell could not find dictionaries, so this wrapper adds a way for Hunspell to find them.
Use like this:

``` nix
(hunspellWithDicts (with hunspellDicts; [en-us en-gb-ise]))
```

This does not affect the `hunspell` attribute which some packages (e.g firefox) depend on. This means (I think) that Hunspell can not find any system dictionaries in those packages.

One way would be to patch Hunspell to look at some place in the nix profile or `/run/current-system/sw/`, but that seems somewhat static as the dictionaries have to be in the system path. 

Any ideas how this can be solved? 
