### PR TITLE
llvm: make libLLVM.so instead of many .so files

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -47,9 +47,11 @@ in stdenv.mkDerivation rec {
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"
-  ] ++ stdenv.lib.optional enableSharedLibraries
-    "-DBUILD_SHARED_LIBS=ON"
-    ++ stdenv.lib.optional (!isDarwin)
+  ] ++ stdenv.lib.optional enableSharedLibraries [
+    "-DBUILD_SHARED_LIBS=OFF" # make libLLVM.so have no dynamic dependencies
+    "-DLLVM_BUILD_LLVM_DYLIB=ON"
+    "-DLLVM_DYLIB_EXPORT_ALL=ON"
+  ] ++ stdenv.lib.optional (!isDarwin)
     "-DLLVM_BINUTILS_INCDIR=${binutils}/include"
     ++ stdenv.lib.optionals ( isDarwin) [
     "-DLLVM_ENABLE_LIBCXX=ON"


### PR DESCRIPTION
Having many LLVM shared libraries makes code that links against
LLVM slow because the libraries needlessly communicate with each other
via extern symbols when the internal linking could have been static.

This change enables a setting which causes all the LLVM libraries to be statically linked together, and then into a final shared library, libLLVM.so. This is the strategy used, for example, in [the arch package](https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/llvm#n108). 

My motivation for this pull request is [my own compiler project](https://github.com/andrewrk/zig/) which is encumbered by the way LLVM is currently linked. Resolving dynamic symbols is currently a performance bottleneck.

However, this also affects other NixOS packages that depend on LLVM, such as rustc. Try running `rustc --help` and you will find it takes almost 100ms. Now compare that to `cat --help` which is almost instant. If you use callgrind to analyze what is taking the time, it's all in resolving the LLVM shared libs.

In fact now that I'm thinking about it, and I just tested it, the same is true about clang itself. The clang compiler spends a lot of time resolving dynamic symbols to LLVM which makes compile times slower.

I have not finished testing this change, but I want to open it up for discussion while doing so.

We have the option of leaving the .a files around for those who wish to link statically against LLVM, and deleting the .a files to force dependant packages to use libLLVM.so. In the former case this patch would slightly reduce disk usage, and in the latter case this patch would increase disk usage of the LLVM package by the binary size of all the .a files, which is about 450MB. My preference and the default option that happens if we take no action is the former - leave the .a files for those who want them. This is status quo for libclang.

Previously, this nixpkg deviated from the default build options by generating .so files instead of .a files. With this patch, the nixpkg will deviate from the default build options only by _additionally_ generating libLLVM.so alongside the .a files.

In short, I expect this change to drastically speed up any program which depends on LLVM. The only challenge will be making sure that packages which depend on LLVM still build correctly.

cc @lovek323 
cc @7c6f434c 
cc @viric 
