### PR TITLE
Do not relocate /nix and /tmp to small disks on AWS

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -68,7 +68,11 @@ let cfg = config.ec2; in
                 diskNr=$((diskNr + 1))
                 echo "mounting $device on $mp..."
                 if mountFS "$device" "$mp" "" ext3; then
-                    if [ -z "$diskForUnionfs" ]; then diskForUnionfs="$mp"; fi
+                    if [ -z "$diskForUnionfs" -a \
+                         $(lsblk -bno size $device) -gt $(lsblk -bno size /dev/xvda1)
+                       ]; then
+                       diskForUnionfs="$mp";
+                    fi
                 fi
             else
                 echo "skipping unknown device type $device"


### PR DESCRIPTION
The default behavior with an m3.medium instance is to relocate
/nix and /tmp to /disk0 because an assumption is made that any
ephemeral disk is larger than the root volume.  Rather than make
that assumption, add a check to see if the disk is larger, and
only then relocate /nix and /tmp.

This addresses https://github.com/NixOS/nixpkgs/issues/12613
