### PR TITLE
fish: don't use manpath(1) from PATH in functions/man.fish

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     sed -i "s|(hostname\||(${nettools}/bin/hostname\||" "$out/share/fish/functions/fish_prompt.fish"
     sed -i "s|Popen(\['manpath'|Popen(\['${man_db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"
+    sed -i "s|command manpath|command ${man_db}/bin/manpath|" "$out/share/fish/functions/man.fish"
   '' + ''
     sed -i "s|/sbin /usr/sbin||" \
            "$out/share/fish/functions/__fish_complete_subcommand_root.fish"


### PR DESCRIPTION
Previously, this'd invoke my command-not-found handler (and if you have `NIX_AUTO_RUN` enabled, it'd work, but occasionally download manpath afresh when you just wanted a manpage).
This doesn't really fix `manpath(1)` erroring out on NixOS (`can't open the manpath configuration file /etc/man_db.conf`), but that's a pre-existing issue.
