### PR TITLE
 Libxml2 pkgconfig

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation (rec {
 
   enableParallelBuilding = true;
 
+  postInstall = ''
+    ln -s $out/lib/pkgconfig/libxml-2.0.pc $out/lib/pkgconfig/libxml2.pc
+  '';
+
   meta = {
     homepage = http://xmlsoft.org/;
     description = "An XML parsing library for C";


### PR DESCRIPTION
Some packages try to check pkg-config for libxml2 explicitly which currently breaks.

(fixes nokogiri finding libxml with bundler or gem)

Base is staging as I reckon this will be a rather major rebuild.
