### PR TITLE
vim_configurable: add configuration option for XIM support

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -154,6 +154,7 @@ composableDerivation {
     multibyteSupport = config.vim.multibyte or false;
     cscopeSupport    = config.vim.cscope or true;
     netbeansSupport  = config.netbeans or true; # eg envim is using it
+    ximSupport       = config.vim.xim or false;
 
     # by default, compile with darwin support if we're compiling on darwin, but
     # allow this to be disabled by setting config.vim.darwin to false


### PR DESCRIPTION
Even if you install vimHugeX, support for the X Input Method is disabled. Consequently, gvim does not support "compose" or "dead" key sequences, making it more difficult to enter foreign and special characters. A quick search of the IRC channel reveals that a few people have encountered this issue but were unable to resolve it ([e.g.](https://botbot.me/freenode/nixos/2015-11-15/?msg=54184745&page=5)).

With this patch, adding the following to your config.nix will result in vim_configurable being built with XIM support:

```
{
   vim.xim = true;
}
```
