### PR TITLE
kernel: Let the kernel build system strip modules

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -129,6 +129,9 @@ let
         mkdir -p $out/dtbs
         cp $buildRoot/arch/$karch/boot/dts/*.dtb $out/dtbs
       '' else "") + (if isModular then ''
+        if [ -z "$dontStrip" ]; then
+          installFlagsArray+=("INSTALL_MOD_STRIP=1")
+        fi
         make modules_install $makeFlags "''${makeFlagsArray[@]}" \
           $installFlags "''${installFlagsArray[@]}"
         unlink $out/lib/modules/${modDirVersion}/build
@@ -190,9 +193,6 @@ let
       # !!! This leaves references to gcc in $dev
       # that we might be able to avoid
       postFixup = if isModular then ''
-        if [ -z "$dontStrip" ]; then
-            find $out -name "*.ko" -print0 | xargs -0 -r ''${crossConfig+$crossConfig-}strip -S
-        fi
         # !!! Should this be part of stdenv? Also patchELF should take an argument...
         prefix=$dev
         patchELF


### PR DESCRIPTION
Since commit 48f51f118506 we let the kernel build system compress the
modules, which makes the original strip expression not work. Let the
kernel build system strip them as well so they get stripped.

cc @edolstra. Also something should be done wrt. `module_init_tools`.
