### PR TITLE
closure-size: Mass replace `pkg}/bin`-style strings to refer to correct outputs

### DIFF
--- a/nixos/modules/programs/xfs_quota.nix
+++ b/nixos/modules/programs/xfs_quota.nix
@@ -89,8 +89,8 @@ in
       nameValuePair "xfs_quota-${name}" {
         description = "Setup xfs_quota for project ${name}";
         script = ''
-          ${pkgs.xfsprogs}/bin/xfs_quota -x -c 'project -s ${name}' ${opts.fileSystem}
-          ${pkgs.xfsprogs}/bin/xfs_quota -x -c 'limit -p ${limitOptions opts} ${name}' ${opts.fileSystem}
+          ${pkgs.xfsprogs.bin}/bin/xfs_quota -x -c 'project -s ${name}' ${opts.fileSystem}
+          ${pkgs.xfsprogs.bin}/bin/xfs_quota -x -c 'limit -p ${limitOptions opts} ${name}' ${opts.fileSystem}
         '';
 
         wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-servers/apache-httpd/owncloud.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/owncloud.nix
@@ -333,7 +333,7 @@ let
 
       'version' => '${config.package.version}',
 
-      'openssl' => '${pkgs.openssl}/bin/openssl'
+      'openssl' => '${pkgs.openssl.bin}/bin/openssl'
 
       );
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -436,7 +436,7 @@ in
       ${optionalString luks.yubikeySupport ''
         copy_bin_and_libs ${pkgs.ykpers}/bin/ykchalresp
         copy_bin_and_libs ${pkgs.ykpers}/bin/ykinfo
-        copy_bin_and_libs ${pkgs.openssl}/bin/openssl
+        copy_bin_and_libs ${pkgs.openssl.bin}/bin/openssl
 
         cc -O3 -I${pkgs.openssl}/include -L${pkgs.openssl.out}/lib ${./pbkdf2-sha512.c} -o pbkdf2-sha512 -lcrypto
         strip -s pbkdf2-sha512

--- a/pkgs/applications/audio/caudec/default.nix
+++ b/pkgs/applications/audio/caudec/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     for executable in $(cd $out/bin && ls); do
 	wrapProgram $out/bin/$executable \
-	  --prefix PATH : "${bc}/bin:${findutils}/bin:${sox}/bin:${procps}/bin:${opusTools}/bin:${lame}/bin:${flac}/bin"
+	  --prefix PATH : "${bc}/bin:${findutils}/bin:${sox}/bin:${procps}/bin:${opusTools}/bin:${lame}/bin:${flac.bin}/bin"
     done
   '';
 

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
     for a in $out/bin/*; do
       wrapProgram $a --prefix PYTHONPATH : $PYTHONPATH \
-                     --prefix PATH : ${poppler_utils}/bin
+                     --prefix PATH : ${poppler_utils.out}/bin
     done
   '';
 

--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram "$out/bin/dunst" \
-      --prefix PATH : '${dbus_daemon}/bin'
+      --prefix PATH : '${dbus_daemon.out}/bin'
   '';
 
   meta = {

--- a/pkgs/applications/misc/udevil/default.nix
+++ b/pkgs/applications/misc/udevil/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
       --with-mount-prog=${utillinux}/bin/mount \
       --with-umount-prog=${utillinux}/bin/umount \
       --with-losetup-prog=${utillinux}/bin/losetup \
-      --with-setfacl-prog=${acl}/bin/setfacl \
+      --with-setfacl-prog=${acl.bin}/bin/setfacl \
       --sysconfdir=$prefix/etc
   '';
   preConfigure = ''

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -21,7 +21,7 @@ pythonPackages.buildPythonPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/mailpile \
-      --prefix PATH ":" "${gnupg1orig}/bin:${openssl}/bin"
+      --prefix PATH ":" "${gnupg1orig}/bin:${openssl.bin}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       substituteInPlace  $f --replace gunzip        ${gzip}/bin/gunzip
       substituteInPlace  $f --replace iconv         ${libiconv.bin}/bin/iconv
       substituteInPlace  $f --replace lyx           ${lyx}/bin/lyx
-      substituteInPlace  $f --replace pdftotext     ${poppler_utils}/bin/pdftotext
+      substituteInPlace  $f --replace pdftotext     ${poppler_utils.out}/bin/pdftotext
       substituteInPlace  $f --replace pstotext      ${ghostscript}/bin/ps2ascii 
       substituteInPlace  $f --replace sed           ${gnused}/bin/sed
       substituteInPlace  $f --replace tar           ${gnutar}/bin/tar

--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -e 's|"gzip"|"${gzip}/bin/gzip"|' \
         -e 's|"bzip2"|"${bzip2.bin}/bin/bzip2"|' \
-        -e 's|"xz"|"${xz}/bin/xz"|' \
+        -e 's|"xz"|"${xz.bin}/bin/xz"|' \
         -i ui-snapshot.c
   '';
 

--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -e 's|"gzip"|"${gzip}/bin/gzip"|' \
-        -e 's|"bzip2"|"${bzip2}/bin/bzip2"|' \
+        -e 's|"bzip2"|"${bzip2.bin}/bin/bzip2"|' \
         -e 's|"xz"|"${xz}/bin/xz"|' \
         -i ui-snapshot.c
   '';

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     install -Dm755 ./bundles/${version}/dynbinary/docker-${version} $out/libexec/docker/docker
     install -Dm755 ./bundles/${version}/dynbinary/dockerinit-${version} $out/libexec/docker/dockerinit
     makeWrapper $out/libexec/docker/docker $out/bin/docker \
-      --prefix PATH : "${iproute}/sbin:sbin:${iptables}/sbin:${e2fsprogs}/sbin:${xz}/bin:${utillinux}/bin:${optionalString enableLxc "${lxc}/bin"}"
+      --prefix PATH : "${iproute}/sbin:sbin:${iptables}/sbin:${e2fsprogs}/sbin:${xz.bin}/bin:${utillinux}/bin:${optionalString enableLxc "${lxc}/bin"}"
 
     # systemd
     install -Dm644 ./contrib/init/systemd/docker.service $out/etc/systemd/system/docker.service

--- a/pkgs/applications/virtualization/openstack/keystone.nix
+++ b/pkgs/applications/virtualization/openstack/keystone.nix
@@ -33,7 +33,7 @@ pythonPackages.buildPythonPackage rec {
     ldap ldappool webtest requests2 oslotest pep8 pymongo which
   ];
 
-  makeWrapperArgs = ["--prefix PATH : '${openssl}/bin:$PATH'"];
+  makeWrapperArgs = ["--prefix PATH : '${openssl.bin}/bin:$PATH'"];
 
   postInstall = ''
     # install .ini files

--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (vaapi != null) "--enabe-vaapi-recorder"
     ++ stdenv.lib.optionals (xwayland != null) [
         "--enable-xwayland"
-        "--with-xserver-path=${xwayland}/bin/Xwayland"
+        "--with-xserver-path=${xwayland.out}/bin/Xwayland"
       ];
 
   meta = with stdenv.lib; {

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -574,7 +574,7 @@ rec {
       buildCommand = ''
         ${createRootFS}
 
-        PATH=$PATH:${dpkg}/bin:${dpkg}/bin:${glibc.bin}/bin:${lzma}/bin
+        PATH=$PATH:${dpkg}/bin:${dpkg}/bin:${glibc.bin}/bin:${lzma.bin}/bin
 
         # Unpack the .debs.  We do this to prevent pre-install scripts
         # (which have lots of circular dependencies) from barfing.

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
        export XDG_RUNTIME_HOME="$TMP"
        export HOME="$TMP"
        export XDG_DATA_DIRS="${desktop_file_utils}/share:${shared_mime_info}/share"
-       export G_TEST_DBUS_DAEMON="${dbus_daemon}/bin/dbus-daemon"
+       export G_TEST_DBUS_DAEMON="${dbus_daemon.out}/bin/dbus-daemon"
 
        substituteInPlace gio/tests/desktop-files/home/applications/epiphany-weather-for-toronto-island-9c6a4e022b17686306243dada811d550d25eb1fb.desktop --replace "Exec=/bin/true" "Exec=${coreutils}/bin/true"
        # Needs machine-id, comment the test

--- a/pkgs/development/libraries/opendkim/default.nix
+++ b/pkgs/development/libraries/opendkim/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/sbin/opendkim-genkey \
-      --prefix PATH : ${openssl}/bin
+      --prefix PATH : ${openssl.bin}/bin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/sslmate/default.nix
+++ b/pkgs/development/tools/sslmate/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
         JSONPP
         TermReadKey
       ]}" \
-      --prefix PATH : "${openssl}/bin"
+      --prefix PATH : "${openssl.bin}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     export PATH_CP=$(type -tp cp)
     export PATH_CHKCONFIG=/no-such-program
-    export BZIP=${bzip2}/bin/bzip2
+    export BZIP=${bzip2.bin}/bin/bzip2
     export SYSTEMCTL=systemctl
   '';
 

--- a/pkgs/servers/http/nix-binary-cache/default.nix
+++ b/pkgs/servers/http/nix-binary-cache/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       --replace @bzip2@ "${bzip2.bin}/bin" \
       --replace @gnused@ "${gnused}/bin" \
       --replace @gnugrep@ "${gnugrep}/bin" \
-      --replace @openssl@ "${openssl}/bin" \
+      --replace @openssl@ "${openssl.bin}/bin" \
       --replace @lighttpd@ "${lighttpd}/sbin" \
       --replace @iproute@ "${iproute}/sbin" \
       --replace "xXxXx" "xXxXx"
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       --replace @bzip2@ "${bzip2.bin}/bin" \
       --replace @gnused@ "${gnused}/bin" \
       --replace @gnugrep@ "${gnugrep}/bin" \
-      --replace @openssl@ "${openssl}/bin" \
+      --replace @openssl@ "${openssl.bin}/bin" \
       --replace @lighttpd@ "${lighttpd}/sbin" \
       --replace @iproute@ "${iproute}/sbin" \
       --replace "xXxXx" "xXxXx"

--- a/pkgs/servers/http/nix-binary-cache/default.nix
+++ b/pkgs/servers/http/nix-binary-cache/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
       --replace @findutils@ "${findutils}/bin" \
       --replace @nix@ "${nix}/bin" \
       --replace @xz@ "${xz}/bin" \
-      --replace @bzip2@ "${bzip2}/bin" \
+      --replace @bzip2@ "${bzip2.bin}/bin" \
       --replace @gnused@ "${gnused}/bin" \
       --replace @gnugrep@ "${gnugrep}/bin" \
       --replace @openssl@ "${openssl}/bin" \
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       --replace @findutils@ "${findutils}/bin" \
       --replace @nix@ "${nix}/bin" \
       --replace @xz@ "${xz}/bin" \
-      --replace @bzip2@ "${bzip2}/bin" \
+      --replace @bzip2@ "${bzip2.bin}/bin" \
       --replace @gnused@ "${gnused}/bin" \
       --replace @gnugrep@ "${gnugrep}/bin" \
       --replace @openssl@ "${openssl}/bin" \

--- a/pkgs/servers/http/nix-binary-cache/default.nix
+++ b/pkgs/servers/http/nix-binary-cache/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
       --replace @coreutils@ "${coreutils}/bin" \
       --replace @findutils@ "${findutils}/bin" \
       --replace @nix@ "${nix}/bin" \
-      --replace @xz@ "${xz}/bin" \
+      --replace @xz@ "${xz.bin}/bin" \
       --replace @bzip2@ "${bzip2.bin}/bin" \
       --replace @gnused@ "${gnused}/bin" \
       --replace @gnugrep@ "${gnugrep}/bin" \
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       --replace @coreutils@ "${coreutils}/bin" \
       --replace @findutils@ "${findutils}/bin" \
       --replace @nix@ "${nix}/bin" \
-      --replace @xz@ "${xz}/bin" \
+      --replace @xz@ "${xz.bin}/bin" \
       --replace @bzip2@ "${bzip2.bin}/bin" \
       --replace @gnused@ "${gnused}/bin" \
       --replace @gnugrep@ "${gnugrep}/bin" \

--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     substituteInPlace ./shellinabox/launcher.c --replace "/usr/games" "${openssh}/bin"
     substituteInPlace ./shellinabox/service.c --replace "/bin/login" "${shadow}/bin/login"
     substituteInPlace ./shellinabox/launcher.c --replace "/bin/login" "${shadow}/bin/login"
-    substituteInPlace ./libhttp/ssl.c --replace "/usr/bin" "${openssl}/bin"
+    substituteInPlace ./libhttp/ssl.c --replace "/usr/bin" "${openssl.bin}/bin"
   '';
 
   postInstall = ''

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -166,7 +166,7 @@ rec {
         cp -d ${gawk}/bin/awk $out/bin
         cp ${gnutar}/bin/tar $out/bin
         cp ${gzip}/bin/gzip $out/bin
-        cp ${bzip2}/bin/bzip2 $out/bin
+        cp ${bzip2.bin}/bin/bzip2 $out/bin
         cp -d ${gnumake}/bin/* $out/bin
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -79,7 +79,7 @@ rec {
         cp -d ${gawk}/bin/awk $out/bin
         cp ${gnutar}/bin/tar $out/bin
         cp ${gzip}/bin/gzip $out/bin
-        cp ${bzip2}/bin/bzip2 $out/bin
+        cp ${bzip2.bin}/bin/bzip2 $out/bin
         cp -d ${gnumake}/bin/* $out/bin
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -121,7 +121,7 @@ in buildPythonPackage rec {
     }' beets/ui/commands.py
   '' + optionalString enableBadfiles ''
     sed -i -e '/self\.run_command(\[/ {
-      s,"flac","${flac}/bin/flac",
+      s,"flac","${flac.bin}/bin/flac",
       s,"mp3val","${mp3val}/bin/mp3val",
     }' beetsplug/badfiles.py
   '' + optionalString enableReplaygain ''

--- a/pkgs/tools/backup/store-backup/default.nix
+++ b/pkgs/tools/backup/store-backup/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     for p in $out/bin/*
       do wrapProgram "$p" \
       --prefix PERL5LIB ":" "${perlPackages.DBFile}/lib/perl5/site_perl" \
-      --prefix PATH ":" "${which}/bin:${bzip2}/bin"
+      --prefix PATH ":" "${which}/bin:${bzip2.bin}/bin"
     done
 
     patchShebangs $out

--- a/pkgs/tools/compression/pxz/default.nix
+++ b/pkgs/tools/compression/pxz/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     gcc -o pxz pxz.c -llzma \
         -fopenmp -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -O2 \
         -DPXZ_BUILD_DATE=\"nixpkgs\" \
-        -DXZ_BINARY=\"${xz}/bin/xz\" \
+        -DXZ_BINARY=\"${xz.bin}/bin/xz\" \
         -DPXZ_VERSION=\"${version}\"
   '';
 

--- a/pkgs/tools/graphics/jhead/default.nix
+++ b/pkgs/tools/graphics/jhead/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
     substituteInPlace jhead.c \
       --replace "\"   Compiled: \"__DATE__" "" \
-      --replace "jpegtran -trim" "${libjpeg}/bin/jpegtran -trim"
+      --replace "jpegtran -trim" "${libjpeg.bin}/bin/jpegtran -trim"
   '';
 
   installPhase = ''

--- a/pkgs/tools/networking/easyrsa/default.nix
+++ b/pkgs/tools/networking/easyrsa/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     install -D -m755 easyrsa3/easyrsa $out/bin/easyrsa
     substituteInPlace $out/bin/easyrsa \
       --subst-var out \
-      --subst-var-by openssl ${openssl}/bin/openssl
+      --subst-var-by openssl ${openssl.bin}/bin/openssl
 
     # Helper utility
     cat > $out/bin/easyrsa-init <<EOF

--- a/pkgs/tools/typesetting/djvu2pdf/default.nix
+++ b/pkgs/tools/typesetting/djvu2pdf/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp -p djvu2pdf $out/bin
-    wrapProgram $out/bin/djvu2pdf --prefix PATH : ${ghostscript}/bin:${djvulibre}/bin:${which}/bin
+    wrapProgram $out/bin/djvu2pdf --prefix PATH : ${ghostscript}/bin:${djvulibre.bin}/bin:${which}/bin
 
     mkdir -p $out/man/man1
     cp -p djvu2pdf.1.gz $out/man/man1

--- a/pkgs/tools/virtualization/ec2-ami-tools/default.nix
+++ b/pkgs/tools/virtualization/ec2-ami-tools/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
       for i in $out/bin/*; do
           wrapProgram $i \
             --set EC2_HOME $out \
-            --prefix PATH : ${ruby}/bin:${openssl}/bin
+            --prefix PATH : ${ruby}/bin:${openssl.bin}/bin
       done
 
       sed -i 's|/bin/bash|${stdenv.shell}|' $out/lib/ec2/platform/base/pipeline.rb

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -279,7 +279,7 @@ in modules // {
     doCheck = false;
 
     patchPhase = ''
-      substituteInPlace acme_tiny.py --replace "openssl" "${pkgs.openssl}/bin/openssl"
+      substituteInPlace acme_tiny.py --replace "openssl" "${pkgs.openssl.bin}/bin/openssl"
     '';
 
     installPhase = ''


### PR DESCRIPTION
Same drill as before - scripted replace of `foo}/bin` to `foo.bar}/bin` in all cases where `${foo}/bin` doesn't exist.

cc @vcunat
