### PR TITLE
Redundant DHCP support in initrd

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -63,9 +63,9 @@ in
       copy_bin_and_libs ${pkgs.mkinitcpio-nfs-utils}/bin/ipconfig
     '';
 
-    boot.initrd.preLVMCommands =
+    boot.initrd.preLVMCommands = mkBefore (
       # Search for interface definitions in command line.
-      mkBefore ''
+      ''
         for o in $(cat /proc/cmdline); do
           case $o in
             ip=*)
@@ -87,11 +87,16 @@ in
 
           # Acquire a DHCP lease.
           echo "acquiring IP address via DHCP..."
-          udhcpc --quit --now --script ${udhcpcScript}
+          udhcpc --quit --now --script ${udhcpcScript} && hasNetwork=1
         fi
       ''
 
-      + cfg.postCommands;
+      + ''
+        if [ -n "$hasNetwork" ]; then
+          echo "networking is up!"
+          ${cfg.postCommands}
+        fi
+      '');
 
   };
 


### PR DESCRIPTION
This is the followup to https://github.com/NixOS/nixpkgs/commit/cc925d0506ab2a049d5ee55c1173950073ed307f#commitcomment-15838365. It's more for discussion than for merge now! There may be some problems of old DHCP support via `ip=dhcp`, so this needs a comment from @edolstra. Notice that I haven't tested changes for `amazon-image.nix`!

One more thing that @edolstra pointed out is that `ipconfig` from `mkinitcpio-net-utils` seems redundant there when we have BusyBox. It's there only because it is tedious to parse `ip=` string by ourselves, but we may want to do this is future. On the other hand, `ipconfig` is only 28K in size and is there only if initrd networking is enabled, so this maybe is not so relevant.
