### PR TITLE
udev service: restart on rules change

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -256,6 +256,7 @@ in
 
     systemd.services.systemd-udevd =
       { environment.MODULE_DIR = "/run/booted-system/kernel-modules/lib/modules";
+        restartTriggers = cfg.packages;
       };
 
   };


### PR DESCRIPTION
This is more sledgehammer'y than `udevadm control -R` but I see no other easy way to do this on switch if `services.udev.packages` are changed. cc @edolstra for a potential advice on this.

Fixes #12790, should also benefit #12724. cc @ctheune for testing!
