### PR TITLE
Improve checking for FHS paths in udev rules

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -116,6 +116,7 @@ let
           )"
           echo "$localFile ($remoteFile) contains references to $refs."
         done
+        ${optionalString (!cfg.allowImpurePaths) "exit 1"}
       fi
 
       ${optionalString config.networking.usePredictableInterfaceNames ''
@@ -228,6 +229,20 @@ in
           Additional <command>hwdb</command> files. They'll be written
           into file <filename>10-local.hwdb</filename>. Thus they are
           read before all other files.
+        '';
+      };
+
+      allowImpurePaths = mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          If this is disabled, the build will fail whenever one of the
+          <command>udev</command> rules contains a reference to
+          <filename>/usr/bin</filename>, <filename>/usr/sbin</filename>,
+          <filename>/bin</filename> or <filename>/sbin</filename>.
+
+          By default only a warning is printed during build.
         '';
       };
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -116,7 +116,7 @@ let
           )"
           echo "$localFile ($remoteFile) contains references to $refs."
         done
-        ${optionalString (!cfg.allowImpurePaths) "exit 1"}
+        exit 1
       fi
 
       ${optionalString config.networking.usePredictableInterfaceNames ''
@@ -229,20 +229,6 @@ in
           Additional <command>hwdb</command> files. They'll be written
           into file <filename>10-local.hwdb</filename>. Thus they are
           read before all other files.
-        '';
-      };
-
-      allowImpurePaths = mkOption {
-        default = true;
-        example = false;
-        type = types.bool;
-        description = ''
-          If this is disabled, the build will fail whenever one of the
-          <command>udev</command> rules contains a reference to
-          <filename>/usr/bin</filename>, <filename>/usr/sbin</filename>,
-          <filename>/bin</filename> or <filename>/sbin</filename>.
-
-          By default only a warning is printed during build.
         '';
       };
 

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -30,8 +30,6 @@ let
 
         hardware.enableAllFirmware = lib.mkForce false;
 
-        services.udev.allowImpurePaths = false;
-
         ${replaceChars ["\n"] ["\n  "] extraConfig}
       }
     '';
@@ -186,8 +184,6 @@ let
               if grubVersion == 1 then "scsi" else "virtio";
 
             hardware.enableAllFirmware = mkForce false;
-
-            services.udev.allowImpurePaths = false;
 
             # The test cannot access the network, so any packages we
             # need must be included in the VM.

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -30,6 +30,8 @@ let
 
         hardware.enableAllFirmware = lib.mkForce false;
 
+        services.udev.allowImpurePaths = false;
+
         ${replaceChars ["\n"] ["\n  "] extraConfig}
       }
     '';
@@ -184,6 +186,8 @@ let
               if grubVersion == 1 then "scsi" else "virtio";
 
             hardware.enableAllFirmware = mkForce false;
+
+            services.udev.allowImpurePaths = false;
 
             # The test cannot access the network, so any packages we
             # need must be included in the VM.


### PR DESCRIPTION
Currently the check against FHS paths in the rule files is only checking against the original paths from in `services.udev.packages`.

However we do fix up some of these paths in the udev rules generator and the warning is against the unfixed rule files and therefore prints a lot of false positives.

This pull request improves the warning and also adds a NixOS option to turn this warning into a failure, so we can use this for VM tests for example and might also be useful for real systems.

Addresses #12722 as well so we can assure that this won't happen again in the future.

Cc: @edolstra
