### PR TITLE
Add miniball package and fix haskell-miniball by adding the miniball package as dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -840,6 +840,9 @@ self: super: {
   configurator = dontCheck super.configurator;
 
   # The cabal files for these libraries do not list the required system dependencies.
+  miniball = overrideCabal super.miniball (drv: {
+    librarySystemDepends = [ pkgs.miniball ];
+  });
   SDL-image = overrideCabal super.SDL-image (drv: {
     librarySystemDepends = [ pkgs.SDL pkgs.SDL_image ] ++ drv.librarySystemDepends or [];
   });

--- a/pkgs/development/libraries/miniball/default.nix
+++ b/pkgs/development/libraries/miniball/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "miniball-${version}";
+  version = "3.0";
+
+  src = fetchurl {
+    url = "https://www.inf.ethz.ch/personal/gaertner/miniball/Miniball.hpp";
+    sha256 = "1piap5v8wqq0aachrq6j50qkr01gzpyndl6vf661vyykrfq0nnd2";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/include
+    cp $src $out/include/miniball.hpp
+  '';
+
+  meta = {
+    description = "Smallest Enclosing Balls of Points";
+    homepage = https://www.inf.ethz.ch/personal/gaertner/miniball.html;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.erikryb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2321,6 +2321,8 @@ let
 
   miniupnpd = callPackage ../tools/networking/miniupnpd { };
 
+  miniball = callPackage ../development/libraries/miniball { }; 
+ 
   minixml = callPackage ../development/libraries/minixml { };
 
   mjpegtools = callPackage ../tools/video/mjpegtools { };


### PR DESCRIPTION
I have added the miniball package, a C++ library for calculating the smallest enclosing ball of a set of points. I then fixed the haskell-miniball package, a haskell binding, by adding this package as a dependency.

I have tested this, and it works on my machine.
