### PR TITLE
swig: Incorrect detection of system-wide TCL

### DIFF
--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ pcre ];
 
+  configureFlags = "--without-tcl";
+
   postPatch = ''
     # Disable ccache documentation as it need yodl
     sed -i '/man1/d' CCache/Makefile.in


### PR DESCRIPTION
On Ubuntu 14.04.3 LTS with tcl8.6-dev:amd64 package installed the
current swig build will find the system-wide
/usr/lib/tcl8.6/tclConfig.sh and then fail to correctly configure
