### PR TITLE
linux-testing: 4.4-rc8 -> 4.5-rc2

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.4-rc8";
-  modDirVersion = "4.4.0-rc8";
-  extraMeta.branch = "4.4";
+  version = "4.5-rc2";
+  modDirVersion = "4.5.0-rc2";
+  extraMeta.branch = "4.5";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/testing/linux-${version}.tar.xz";
-    sha256 = "0cwf80lryzhdajd3r97b33ym5njjpf5rbcbjzz7lja0w9xs1dvwj";
+    sha256 = "1nq61nimgvl7m7rrimr95ixwkc5sd473m5kvaf5qdyhfnh7m4br3";
   };
 
   features.iwlwifi = true;


### PR DESCRIPTION
Built with `$ nix-build -A linux_testing`
