### PR TITLE
dosbox: Replace patch from bugzilla with local analog

### DIFF
--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -9,11 +9,8 @@ stdenv.mkDerivation rec {
   };
 
   patches =
-    [ # Fix building with GCC 4.6.
-      (fetchurl {
-        url = "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/games-emulation/dosbox/files/dosbox-0.74-gcc46.patch?revision=1.1";
-        sha256 = "03iv1ph7fccfw327ngnhvzwyiix7fsbdb5mmpxivzkidhlrssxq9";
-      })
+    [ # Fix building with GCC 4.6+.
+      ./gcc46+.patch
     ];
 
   patchFlags = "-p0";

--- a/pkgs/misc/emulators/dosbox/gcc46+.patch
+++ b/pkgs/misc/emulators/dosbox/gcc46+.patch
@@ -1,0 +1,11 @@
+--- include/dos_inc.h.old   2011-04-28 08:46:04.505011354 +0200
++++ include/dos_inc.h   2011-04-28 08:46:27.104408178 +0200
+@@ -21,6 +21,7 @@
+ #ifndef DOSBOX_DOS_INC_H
+ #define DOSBOX_DOS_INC_H
+ 
++#include <cstddef>
+ #ifndef DOSBOX_DOS_SYSTEM_H
+ #include "dos_system.h"
+ #endif
+


### PR DESCRIPTION
I am not sure it it exactly same one, due patch link to bugzilla
are dead. I take this one from gentoo.
