### PR TITLE
Fix emacs-24.5 build on OS X

### DIFF
--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -62,6 +62,12 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (stdenv.isDarwin && withX)
     "-I${cairo}/include/cairo";
 
+  # Occasionally, the Emacs "unexec" method of producing an executable
+  # on OS X will fail if there is not enough room for data segments.
+  # See:
+  #   http://web.mit.edu/Emacs/source/emacs-23.1/src/unexmacosx.c
+  #   https://lists.gnu.org/archive/html/emacs-devel/2013-05/msg00453.html
+  # Increasing the headerpad size fixes this issue.
   NIX_CFLAGS_LINK = stdenv.lib.optionalString stdenv.isDarwin
     "-headerpad_max_install_names";
 

--- a/pkgs/applications/editors/emacs-24/default.nix
+++ b/pkgs/applications/editors/emacs-24/default.nix
@@ -62,6 +62,9 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (stdenv.isDarwin && withX)
     "-I${cairo}/include/cairo";
 
+  NIX_CFLAGS_LINK = stdenv.lib.optionalString stdenv.isDarwin
+    "-headerpad_max_install_names";
+
   postInstall = ''
     mkdir -p $out/share/emacs/site-lisp/
     cp ${./site-start.el} $out/share/emacs/site-lisp/site-start.el


### PR DESCRIPTION
Fixes #12863.

(This might strictly only be necessary for the macports build as that's the one I use.)
