### PR TITLE
buildRubyGem: ensure gem versions don't get misparsed

### DIFF
--- a/pkgs/development/interpreters/ruby/build-ruby-gem/default.nix
+++ b/pkgs/development/interpreters/ruby/build-ruby-gem/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (attrs // {
     ++ lib.optional stdenv.isDarwin darwin.libobjc
     ++ buildInputs;
 
-  name = attrs.name or (namePrefix + gemName);
+  name = attrs.name or "${namePrefix}${gemName}-${version}";
 
   inherit src;
 

--- a/pkgs/development/interpreters/ruby/build-ruby-gem/default.nix
+++ b/pkgs/development/interpreters/ruby/build-ruby-gem/default.nix
@@ -32,7 +32,9 @@ lib.makeOverridable (
 , platform ? "ruby"
 , ruby ? defs.ruby
 , stdenv ? ruby.stdenv
-, namePrefix ? "${ruby.name}" + "-"
+, namePrefix ? (let
+    rubyName = builtins.parseDrvName ruby.name;
+  in "${rubyName.name}${rubyName.version}-")
 , buildInputs ? []
 , doCheck ? false
 , meta ? {}


### PR DESCRIPTION
Without this, every nix-env --upgrade replaces ruby with an arbitrary gem, which makes Ruby unusuable from user environments.
