### PR TITLE
oraclejdk: 8u71, 8u72 -> 8u73, 8u74

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "71";
+  patchVersion = "73";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "11wcizv4gvlffzn2wj34ffwrq21xwh4ikg2vjv63avdfp2hazjqv";
-  sha256_x86_64 = "18jqdrlbv4sdds2hlmp437waq7r9b33f7hdp8kb6l7pkrizr9nwv";
+  sha256_i686 = "1bi3yj2ds9w13p2lzvmxffk5gax8syi3bw52w8pam1jr3fmzgwgl";
+  sha256_x86_64 = "1rp3nbnhkncyr48m0nn3pf5fr4bp3lzm0ki4gca7mn7rzag19a26";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "72";
+  patchVersion = "74";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "023rnlm5v7d9w4d7bgcac8j0r1vqkbv6fl20k8354pzpdjg6liaq";
-  sha256_x86_64 = "167ca39a6y0n8l87kdm5nv2hrp0wf6g4mw1rbychjc04f5igkrs6";
+  sha256_i686 = "1vc3g89fbrmznb10bhh5gs143hcjg4wsy4j4hwnr1djfj83y8188";
+  sha256_x86_64 = "1pfx7il1h42w3kigscdvm9vfy616lmsp1d2cqvplim3nyxwmvz8b";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
This version fixes security vulnerabilities for Windows platform. Just sha256 updates for Linux.

http://www.oracle.com/technetwork/java/javase/8u73-relnotes-2874654.html
http://www.oracle.com/technetwork/java/javase/8u74-relnotes-2879024.html
