### PR TITLE
i3status: 2.9 -> 2.10

### DIFF
--- a/pkgs/applications/window-managers/i3/status.nix
+++ b/pkgs/applications/window-managers/i3/status.nix
@@ -1,18 +1,17 @@
-{ fetchurl, stdenv, confuse, yajl, alsaLib, wirelesstools
+{ fetchurl, stdenv, confuse, yajl, alsaLib, libpulseaudio, libnl, pkgconfig
   }:
 
 stdenv.mkDerivation rec {
-  name = "i3status-2.9";
+  name = "i3status-2.10";
 
   src = fetchurl {
     url = "http://i3wm.org/i3status/${name}.tar.bz2";
-    sha256 = "1qwxbrga2fi5wf742hh9ajwa8b2kpzkjjnhjlz4wlpv21i80kss2";
+    sha256 = "1497dsvb32z9xljmxz95dnyvsbayn188ilm3l4ys8m5h25vd1xfs";
   };
 
-  buildInputs = [ confuse yajl alsaLib wirelesstools ];
+  buildInputs = [ confuse yajl alsaLib libpulseaudio libnl pkgconfig ];
 
-  makeFlags = "all";
-  installFlags = "PREFIX=\${out}";
+  makeFlags = [ "all" "PREFIX=$(out)" ];
 
   meta = {
     description = "A tiling window manager";


### PR DESCRIPTION
Details in i3status [2.10 changelog](https://github.com/i3/i3status/blob/master/CHANGELOG)

> • wireless/Linux: switch from libiw to libnl. This allows you to run i3status
>   on kernels which don’t have the wext compatibility module enabled.
> • volume: add PulseAudio support. This significantly reduces battery
>   consumption on systems that use PulseAudio, which is the default on any
>   modern Linux desktop.

Moving `PREFIX` to `makeFlags` sets the right `SYSCONFDIR` value so the default setting file can be found.

cc maintainer @garbas 
