### PR TITLE
i3: move dependencies to runtime

### DIFF
--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -34,6 +34,6 @@ in
         '';
       }];
     };
-    environment.systemPackages = with pkgs; [ i3 i3status dmenu ];
+    environment.systemPackages = with pkgs; [ i3 ];
   };
 }

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, which, pkgconfig, makeWrapper, libxcb, xcbutilkeysyms
 , xcbutil, xcbutilwm, libstartup_notification, libX11, pcre, libev, yajl
 , xcb-util-cursor, coreutils, perl, pango, perlPackages, libxkbcommon
-, xorgserver, xvfb_run }:
+, xorgserver, xvfb_run, dmenu, i3status }:
 
 stdenv.mkDerivation rec {
   name = "i3-${version}";
@@ -22,6 +22,13 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs .
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/etc/i3/config --replace dmenu_run ${dmenu}/bin/dmenu_run
+    substituteInPlace $out/etc/i3/config --replace "status_command i3status" "status_command ${i3status}/bin/i3status"
+    substituteInPlace $out/etc/i3/config.keycodes --replace dmenu_run ${dmenu}/bin/dmenu_run
+    substituteInPlace $out/etc/i3/config.keycodes --replace "status_command i3status" "status_command ${i3status}/bin/i3status"
   '';
 
   # Tests have been failing (at least for some people in some cases)


### PR DESCRIPTION
This cleanup the environment by moving dependencies to runtime.
see https://github.com/NixOS/nixpkgs/pull/12463 comments for details:

> I'd sed -i the default i3 config file with the full store paths of dmenu and others (such as xterm or whatnot).

related to #12575
