### PR TITLE
udev: sane: fix udev error

### DIFF
--- a/pkgs/applications/graphics/sane/backends/generic.nix
+++ b/pkgs/applications/graphics/sane/backends/generic.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation {
     mkdir -p $out/etc/udev/rules.d/
     ./tools/sane-desc -m udev > $out/etc/udev/rules.d/49-libsane.rules || \
     cp tools/udev/libsane.rules $out/etc/udev/rules.d/49-libsane.rules
+    # the created 49-libsane references /bin/sh
+    substituteInPlace $out/etc/udev/rules.d/49-libsane.rules \
+      -- replace "RUN+=\"/bin/sh" "RUN+=\"${stdenv.shell}"
 
     substituteInPlace $out/lib/libsane.la \
       --replace "-ljpeg" "-L${libjpeg}/lib -ljpeg"


### PR DESCRIPTION
The new udev checks that no script references any absolute /bin/sh
paths, so this patches that out.
