### PR TITLE
epson-escpr: init at version 1.6.3

### DIFF
--- a/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
+++ b/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
@@ -1,0 +1,62 @@
+diff --git a/configure b/configure_new
+index c3e7199..ccbf290 100755
+--- a/configure
++++ b/configure_new
+@@ -11585,55 +11585,8 @@ else
+ $as_echo "no" >&6; }
+ fi
+ 
+-
+-
+-if test "xNONE" != "x${prefix}" ; then
+-   cups_default_prefix="${prefix}"
+-else
+-   cups_default_prefix="${ac_default_prefix}"
+-fi
+-
+-
+-# Check whether --with-cupsfilterdir was given.
+-if test "${with_cupsfilterdir+set}" = set; then :
+-  withval=$with_cupsfilterdir;
+-else
+-  with_cupsfilterdir=no
+-fi
+-
+-if test "xno" = "x${with_cupsfilterdir}"; then
+-   if test "xyes" = "x$have_cups_config" ; then
+-            CUPS_FILTER_DIR="${cups_default_prefix}`cups-config --serverbin | sed -e 's,^/[^/][^/]*,,'`/filter"
+-   else
+-      CUPS_FILTER_DIR="${cups_default_prefix}/lib/cups/filter"
+-   fi
+-else
+-   CUPS_FILTER_DIR="${with_cupsfilterdir}"
+-fi
+-
+-
+-# Check whether --with-cupsppddir was given.
+-if test "${with_cupsppddir+set}" = set; then :
+-  withval=$with_cupsppddir;
+-else
+-  with_cupsppddir=no
+-fi
+-
+-if test "xno" = "x${with_cupsppddir}"; then
+-   if test -d "${cups_default_prefix}/share/ppd" ; then
+-      CUPS_PPD_DIR="${cups_default_prefix}/share/ppd"
+-   elif test "xyes" = "x$have_cups_config" ; then
+-            CUPS_PPD_DIR="${cups_default_prefix}/`cups-config --datadir | sed -e 's,^/[^/][^/]*,,'`/model"
+-   else
+-      CUPS_PPD_DIR="${cups_default_prefix}/share/cups/model"
+-   fi
+-else
+-   CUPS_PPD_DIR="${with_cupsppddir}"
+-fi
+-
+-
+-
+-
++CUPS_FILTER_DIR="${prefix}/lib/cups/filter"
++CUPS_PPD_DIR="${prefix}/share/cups/model"
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
+ $as_echo_n "checking for ANSI C header files... " >&6; }

--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, cups }:
+
+let
+  version = "1.6.3";
+in
+  stdenv.mkDerivation {
+
+    name = "epson-escpr-${version}";
+  
+    src = fetchurl {
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/04/33/53/0177a44361d3dfeacf7f15ff4a347cef373688da/epson-inkjet-printer-escpr-1.6.3-1lsb3.2.tar.gz";
+      sha256 = "4988479ce7dd5513bfa1cce4a83f82348572d8d69d6aa3b2c6e154a58a04ad86"; 
+    }; 
+
+    patches = [ ./cups-filter-ppd-dirs.patch ]; 
+
+    buildInputs = [ cups ];
+
+    meta = {
+      homepage = https://github.com/artuuge/NixOS-files/;
+      description = "ESC/P-R Driver (generic driver)";
+      longDescription = ''
+        Epson Inkjet Printer Driver (ESC/P-R) for Linux and the
+	corresponding PPD files. The list of supported printers
+	can be found at http://www.openprinting.org/driver/epson-escpr/ .
+
+	To use the driver adjust your configuration.nix file:
+	  services.printing = {
+	    enable = true;
+	    drivers = [ pkgs.epson-escpr ];
+	  };
+      '';
+      license = stdenv.lib.licenses.gpl3Plus;
+    };
+
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15435,6 +15435,8 @@ let
 
   crashplan = callPackage ../applications/backup/crashplan { };
 
+  epson-escpr = callPackage ../misc/drivers/epson-escpr { };
+
   gutenprint = callPackage ../misc/drivers/gutenprint { };
 
   gutenprintBin = callPackage ../misc/drivers/gutenprint/bin.nix { };


### PR DESCRIPTION
This package implements a support for a series of Epson inkjet printers listed at http://www.openprinting.org/driver/epson-escpr/ . 
It makes use of ESC/P-R Driver (generic driver) and the patch adjusts a couple of environment variables in the original Debian oriented configure script to make it compatible with NixOS:

```
CUPS_FILTER_DIR="${prefix}/lib/cups/filter"
CUPS_PPD_DIR="${prefix}/share/cups/model"
```

The corresponding explanation can be found at [NixOS-files](https://github.com/artuuge/NixOS-files). One can configure printing in `/etc/nixos/configuration.nix` as follows: 

``` nix
{
  services.printing = {
    enable = true;
    drivers = [ pkgs.epson-escpr ];
  };
}
```

After rebuilding the system one should be able to find a list of Epson printers via the CUPS page in a browser.

The package has been tested with Epson WorkForce WF-3620 printer:
- Open `http://localhost:631` in Firefox.
- Add a printer selecting a connection: `socket://ip-address-of-the-printer:9100`
- Find a driver in the list of Epson models:
  `EPSON WF-3620 Series , Epson Inkjet Printer Driver (ESC/P-R) for Linux (color, 2-sided printing)`
- Print a two-sided colored test page on A4. 
