### PR TITLE
sane: *really* fix udev error

### DIFF
--- a/pkgs/applications/graphics/sane/backends/generic.nix
+++ b/pkgs/applications/graphics/sane/backends/generic.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     cp tools/udev/libsane.rules $out/etc/udev/rules.d/49-libsane.rules
     # the created 49-libsane references /bin/sh
     substituteInPlace $out/etc/udev/rules.d/49-libsane.rules \
-      -- replace "RUN+=\"/bin/sh" "RUN+=\"${stdenv.shell}"
+      --replace "RUN+=\"/bin/sh" "RUN+=\"${stdenv.shell}"
 
     substituteInPlace $out/lib/libsane.la \
       --replace "-ljpeg" "-L${libjpeg}/lib -ljpeg"


### PR DESCRIPTION
#12874 tried to patch out the literal /bin/sh, but an additional space

sneaked in.

cc @aszlig 
