### PR TITLE
Allow kpcli to work with xclip

### DIFF
--- a/pkgs/tools/security/kpcli/default.nix
+++ b/pkgs/tools/security/kpcli/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/kpcli --set PERL5LIB \
       "${with perlPackages; stdenv.lib.makePerlPath [
-         Clone CryptRijndael SortNaturally TermReadKey TermShellUI FileKeePass TermReadLineGnu XMLParser
+         CaptureTiny Clipboard Clone CryptRijndael SortNaturally TermReadKey TermShellUI FileKeePass TermReadLineGnu XMLParser
       ]}"
   '';
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1898,6 +1898,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  Clipboard = buildPerlPackage {
+    name = "Clipboard-0.13";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/K/KI/KING/Clipboard-0.13.tar.gz;
+      sha256 = "eebf1c9cb2484be850abdae017147967cf47f8ccd99293771517674b0046ec8a";
+    };
+    meta = {
+      description = "Clipboard - Copy and Paste with any OS";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+
   Clone = buildPerlPackage rec {
     name = "Clone-0.38";
     src = fetchurl {


### PR DESCRIPTION
I'm a kpcli user and rely on it to copy my passwords to the x clipboard. Adding a two perl packages to the wrapper, one of which I also needed to add to nixpkgs did the trick.

I did not include a dependency upon xclip itself since this would pull in the X libs and that is a bit heavy for my taste. I think the most practical path here is to just let the user install xclip if they wish to.
