### PR TITLE
atom: 1.4.0 -> 1.4.3

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -16,11 +16,11 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "atom-${version}";
-  version = "1.4.0";
+  version = "1.4.3";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "0dipww58p0sm99jn1ariisha9wsnhl7rnd8achpxqkf4b3vwi5iz";
+    sha256 = "15ix5ww3ny5ylgmmxpkc32li6af2vc4a2p6aymx9c472fra0c41x";
     name = "${name}.deb";
   };
 


### PR DESCRIPTION
Not super fond of using the .deb to make the package but it was easier to just bump the version
