### PR TITLE
nixos-install: don't check that /mnt is a mount point

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -73,11 +73,6 @@ if ! test -e "$mountPoint"; then
     exit 1
 fi
 
-if ! grep -F -q " $mountPoint " /proc/mounts; then
-    echo "$mountPoint doesn't appear to be a mount point"
-    exit 1
-fi
-
 
 # Mount some stuff in the target root directory.
 mkdir -m 0755 -p $mountPoint/dev $mountPoint/proc $mountPoint/sys $mountPoint/etc $mountPoint/run $mountPoint/home


### PR DESCRIPTION
This check is not really needed for some configurations, for example, I built a NixOS root tree with this patch and deployed it to an OpenVZ container.
