### PR TITLE
dhparams service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -102,6 +102,7 @@
   ./security/audit.nix
   ./security/ca.nix
   ./security/chromium-suid-sandbox.nix
+  ./security/dhparams.nix
   ./security/duosec.nix
   ./security/grsecurity.nix
   ./security/hidepid.nix

--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -1,0 +1,107 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.security.dhparams;
+
+  dhOptions = { ... }: {
+    options = {
+      service = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Name of the systemd service (without .service suffix) which uses these DH
+          parameters. If not set, parameters name would be used.
+        '';
+      };
+
+      length = mkOption {
+        type = types.int;
+        default = 2048;
+        description = "Length of generated DH parameters.";
+      };
+
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Owner of generated parameters. If not set, parameters name would be used.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "root";
+        description = "Owner group of generated parameters.";
+      };
+
+      allowKeysForGroup = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Give read permissions to the specified group to read DH parameters.";
+      };
+    };
+  };
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+    security.dhparams = {
+      directory = mkOption {
+        default = "/var/lib/dhparams";
+        type = types.str;
+        description = ''
+          Directory where generated DH parameters will be stored.
+        '';
+      };
+
+      params = mkOption {
+        default = { };
+        type = types.attrsOf (types.submodule dhOptions);
+        description = ''
+          Attribute set of DH parameters to be generated.
+        '';
+        example = {
+          nginx = { };
+          dovecot2 = {
+            user = "mail";
+            length = 1024;
+          };
+        };
+      };
+    };
+  };
+
+  ###### implementation
+  config = {
+    systemd.services =
+      let
+        svc = name: opts: nameValuePair "dhparams-${name}" {
+          description = "Generate Diffie-Hellman parameters for ${name} if they don't exist";
+          before = [ "${opts.service}.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig.Type = "oneshot";
+          path = [ pkgs.openssl ];
+          script = ''
+            mkdir -p "${cfg.directory}"
+            mkdir -pm${if opts.allowKeysForGroup then "750" else "700"} "${cfg.directory}/${name}"
+            if [ ! -e "${cfg.directory}/${name}/dh.pem" ]; then
+              openssl dhparam -out "${cfg.directory}/${name}/dh.pem" "${toString opts.length}"
+            fi
+            chown -R ${opts.user}:${opts.group} "${cfg.directory}/${name}"
+          '';
+        };
+
+        in mapAttrs' (name: val: svc name (val // {
+          service = if val.service == null then name else val.service;
+          user = if val.user == null then name else val.user;
+        })) cfg.params;
+
+    meta.maintainers = with lib.maintainers; [ abbradar ];
+  };
+
+}


### PR DESCRIPTION
This adds a service which generates Diffie-Hellman parameters for daemons that need them. Parameters are stored in `/var/lib/dhparams` by default. I've added some documentation describing their purpose and example settings for nginx (analogous to our acme module).

I've found out about #11505 post-factum. The main difference between our solutions is that I don't store generated parameters in the Nix store, avoiding non-determinism. Personally I like that solution more (a thought of purposely non-deterministic Nix outputs contradicts my views on Nix ~_^), but I understand some advantages of doing it as an output and am open for discussion.

cc @fpletz 
