### PR TITLE
kdbg: init at 2.5.5

### DIFF
--- a/pkgs/development/tools/misc/kdbg/default.nix
+++ b/pkgs/development/tools/misc/kdbg/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, cmake, kdelibs, automoc4, gdb, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "kdbg-${version}";
+  version = "2.5.5";
+  src = fetchurl {
+    url = "mirror://sourceforge/kdbg/${version}/${name}.tar.gz";
+    sha256 = "0yc8hy8ip6din2jjq4r8cd8jnda0kry2abcy8i12yxcd4n4lqglq";
+  };
+
+  buildInputs = [ cmake kdelibs automoc4 gdb makeWrapper ];
+
+  patchPhase = ''
+    sed '6 a \
+    include(CheckIncludeFiles)' -i kdbg/CMakeLists.txt
+  '';
+
+  fixupPhase = ''
+    wrapProgram $out/bin/kdbg --prefix PATH : "${gdb}/bin"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.kdbg.org/;
+    description = ''
+      A graphical user interface to gdb, the GNU debugger. It provides an
+      intuitive interface for setting breakpoints, inspecting variables, and
+      stepping through code.
+    '';
+    platform = unix;
+    license = license.gpl2;
+    maintainer = [ maintainers.eduarrrd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2069,6 +2069,10 @@ let
     lua = lua5_2_compat;
   };
 
+  kdbg = callPackage ../development/tools/misc/kdbg {
+    inherit (pkgs.kde4) kdelibs;
+  };
+
   kippo = callPackage ../servers/kippo { };
 
   kzipmix = callPackage_i686 ../tools/compression/kzipmix { };


### PR DESCRIPTION
It works in terms of functionality. However, I don't think I'm wrapping the right things since icons are missing and the open dialog pops modal dialogs about missing mimetypes. Probably a ksycoca issue? I tried looking into wrapKDEProgram but that is defined only in the docs and does not appear in the repository from what I can tell.

@ttuegel Could you take a look at this and point at what wrappers I'm missing?
