### PR TITLE
WIP: python setuptools: 19.4 -> 20.0, use setuptools shim

### DIFF
--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -6,8 +6,8 @@ let
     sha256 = "ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd";
   };
   setuptools_source = fetchurl {
-    url = "https://pypi.python.org/packages/3.5/s/setuptools/setuptools-19.4-py2.py3-none-any.whl";
-    sha256 = "0801e6d862ca4ce24d918420d62f07ee2fe736dc016e3afa99d2103e7a02e9a6";
+    url = "https://pypi.python.org/packages/3.5/s/setuptools/setuptools-20.0-py2.py3-none-any.whl";
+    sha256 = "4c15b00b76fbb296d7fdee314f21e339fc5f9b913264ce07a9ab2445a3d594a7";
   };
 in stdenv.mkDerivation rec {
   name = "python-${python.version}-bootstrapped-pip-${version}";

--- a/pkgs/development/python-modules/generic/run_setup.py
+++ b/pkgs/development/python-modules/generic/run_setup.py
@@ -1,6 +1,0 @@
-import setuptools
-import tokenize
-
-__file__='setup.py';
-
-exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   shortName = "setuptools-${version}";
   name = "${python.executable}-${shortName}";
 
-  version = "19.4";  # 18.4 and up breaks python34Packages.characteristic and many others
+  version = "20.0";
 
   src = fetchurl {
     url = "http://pypi.python.org/packages/source/s/setuptools/${shortName}.tar.gz";
-    sha256 = "214bf29933f47cf25e6faa569f710731728a07a19cae91ea64f826051f68a8cf";
+    sha256 = "a6f7b295f399fed3de918c4bea9e2053a5fbd9e3a55a6fef7aafe9d1f474866d";
   };
 
   buildInputs = [ python wrapPython ];


### PR DESCRIPTION
- Update setuptools to latest version.
- Use upstream shim, remove our own.

cc @domenkozar 

Progress: https://headcounter.org/hydra/eval/309112

New failing tests:
- funcsigs 2.7 and PyPy: https://headcounter.org/hydra/build/924504 . This one causes basically all other failures. [Issue at setuptools](https://bitbucket.org/pypa/setuptools/issues/493/setuptools-upgrade-breaks-funcsigs-test)
- zope_schema: https://headcounter.org/hydra/build/923948/nixlog/1/raw
- zconfig: https://headcounter.org/hydra/build/924642/nixlog/1/raw
- vobject: https://headcounter.org/hydra/build/927087/nixlog/1/raw
