### PR TITLE
libao: add dependencies for Darwin frameworks

### DIFF
--- a/pkgs/development/libraries/libao/default.nix
+++ b/pkgs/development/libraries/libao/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl, pkgconfig, libpulseaudio, alsaLib, libcap
+, CoreAudio, CoreServices, AudioUnit
 , usePulseAudio }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +13,8 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig ] ++
     lib.optional stdenv.isLinux (if usePulseAudio then libpulseaudio else alsaLib) ++
-    lib.optional stdenv.isLinux libcap;
+    lib.optional stdenv.isLinux libcap ++
+    lib.optionals stdenv.isDarwin [ CoreAudio CoreServices AudioUnit ];
 
   meta = {
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7074,6 +7074,7 @@ let
 
   libao = callPackage ../development/libraries/libao {
     usePulseAudio = config.pulseaudio or true;
+    inherit (darwin.apple_sdk.frameworks) CoreAudio CoreServices AudioUnit;
   };
 
   libabw = callPackage ../development/libraries/libabw { };


### PR DESCRIPTION
Adds CoreAudio, CoreServices, and AudioUnit as dependencies on Darwin platform. This fixes compile errors.

Tested on OS X 10.11.3.
