### PR TITLE
bzip2: Fix cross-compilation

### DIFF
--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -58,7 +58,7 @@ in stdenv.mkDerivation {
     ln -s bzip2 $out/bin/bzcat
   '';
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile --replace CC=gcc CC=cc
     substituteInPlace Makefile-libbz2_so --replace CC=gcc CC=cc
   '';


### PR DESCRIPTION
The cross-compiling the "patchPhase" from the parent attribute set was
preventing application of patches specified in the crossDrv. Fix by
turning patchPhase into postPatch.
