### PR TITLE
opensmtpd: compile with support for 'db' tables

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     "--with-queue-user=smtpq"
     "--with-ca-file=/etc/ssl/certs/ca-certificates.crt"
     "--with-libevent-dir=${libevent}"
+    "--enable-table-db"
   ];
 
   installFlags = [


### PR DESCRIPTION
Latest versions of `opensmtp` need to be configured explicitly for support for `db` tables.

cc @rickynils 
