### PR TITLE
alot: Create top-level binding

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11216,6 +11216,8 @@ let
 
   alock = callPackage ../misc/screensavers/alock { };
 
+  inherit (python2Packages) alot;
+
   alpine = callPackage ../applications/networking/mailreaders/alpine {
     tcl = tcl-8_5;
   };


### PR DESCRIPTION
Since it’s an executable.

cc @dezgeg 
