### PR TITLE
unifi: LD_LIBRARY_PATH hack for embedded libsnappyjava.so, fixes #12897

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -61,6 +61,8 @@ in
       partOf = systemdMountPoints;
       bindsTo = systemdMountPoints;
       unitConfig.RequiresMountsFor = stateDir;
+      # This a HACK to fix missing dependencies of dynamic libs extracted from jars
+      environment.LD_LIBRARY_PATH = with pkgs.stdenv; "${cc.cc}/lib";
 
       preStart = ''
         # Ensure privacy of state


### PR DESCRIPTION
The unifi package is not FOSS and installed from a zip of binaries. Within that zip are many jars; within one (and possibly others) are .so files dynamically linked for traditional LHS filesystems. One particular jar/so combination (snappy-java-1.0.5.jar: org/xerial/snappy/native/Linux/amd64/libsnappyjava.so) causes adoption of gateway-type devices, because the backend relies on extracting to /tmp and using this .so file.

This fix addresses the issue by simply adding an appropriate LD_LIBRARY_PATH value to the service's environment. I've reproduced issue #12897 and tested that this fixes it.

For consideration: Should LD_LIBRARY_PATH be set to "${cc.cc}/lib:${cc.libc}/lib" or is "${cc.cc}/lib" enough? In the case of libsnappyjava.so, the libc deps seem to get resolved just fine on their own:

```
$ ldd /tmp/snappy-1.0.5-libsnappyjava.so
        linux-vdso.so.1 (0x00007ffff83f4000)
        libstdc++.so.6 => not found
        libm.so.6 => /nix/store/n2wxp513rr00f6hr2dy0waqahns49dch-glibc-2.21/lib/libm.so.6 (0x00007f96cd841000)
        libc.so.6 => /nix/store/n2wxp513rr00f6hr2dy0waqahns49dch-glibc-2.21/lib/libc.so.6 (0x00007f96cd4a1000)
        /nix/store/n2wxp513rr00f6hr2dy0waqahns49dch-glibc-2.21/lib64/ld-linux-x86-64.so.2 (0x00005636691f7000)
```
