### PR TITLE
Remove double-backslashes from grub conf file

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -228,7 +228,7 @@ if ($grubVersion == 1) {
     ";
     if ($splashImage) {
         copy $splashImage, "$bootPath/background.xpm.gz" or die "cannot copy $splashImage to $bootPath\n";
-        $conf .= "splashimage " . $grubBoot->path . "/background.xpm.gz\n";
+        $conf .= "splashimage " . Cwd::abs_path($grubBoot->path . "/background.xpm.gz") . "\n";
     }
 }
 
@@ -327,9 +327,9 @@ sub addEntry {
     my ($name, $path) = @_;
     return unless -e "$path/kernel" && -e "$path/initrd";
 
-    my $kernel = copyToKernelsDir(Cwd::abs_path("$path/kernel"));
-    my $initrd = copyToKernelsDir(Cwd::abs_path("$path/initrd"));
-    my $xen = -e "$path/xen.gz" ? copyToKernelsDir(Cwd::abs_path("$path/xen.gz")) : undef;
+    my $kernel = Cwd::abs_path(copyToKernelsDir(Cwd::abs_path("$path/kernel")));
+    my $initrd = Cwd::abs_path(copyToKernelsDir(Cwd::abs_path("$path/initrd")));
+    my $xen = -e "$path/xen.gz" ? Cwd::abs_path(copyToKernelsDir(Cwd::abs_path("$path/xen.gz"))) : undef;
 
     # FIXME: $confName
 


### PR DESCRIPTION
The double-backspashes in the splashimage, kernel, and initrd sections serve no purpose and confuse pygrub
