### PR TITLE
Create utillinuxMinimal and utillinux (full).

### DIFF
--- a/pkgs/desktops/e19/efl.nix
+++ b/pkgs/desktops/e19/efl.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, openssl, libjpeg, zlib, freetype, fontconfig, fribidi, SDL2, SDL, mesa, giflib, libpng, libtiff, glib, gst_all_1, libpulseaudio, libsndfile, xorg, libdrm, libxkbcommon, udev, utillinuxCurses, dbus, bullet, luajit, python27Packages, openjpeg, doxygen, expat, harfbuzz, jbig2dec, librsvg, dbus_libs, alsaLib, poppler, libraw, libspectre, xineLib, libwebp, curl, libinput }:
+{ stdenv, fetchurl, pkgconfig, openssl, libjpeg, zlib, freetype, fontconfig, fribidi, SDL2, SDL, mesa, giflib, libpng, libtiff, glib, gst_all_1, libpulseaudio, libsndfile, xorg, libdrm, libxkbcommon, udev, utillinux, dbus, bullet, luajit, python27Packages, openjpeg, doxygen, expat, harfbuzz, jbig2dec, librsvg, dbus_libs, alsaLib, poppler, libraw, libspectre, xineLib, libwebp, curl, libinput }:
 
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig openssl zlib freetype fontconfig fribidi SDL2 SDL mesa
     giflib libpng libtiff glib gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-libav libpulseaudio libsndfile xorg.libXcursor xorg.printproto
-    xorg.libX11 udev utillinuxCurses ];
+    xorg.libX11 udev utillinux ];
 
   propagatedBuildInputs = [ libxkbcommon python27Packages.dbus dbus libjpeg xorg.libXcomposite
     xorg.libXdamage xorg.libXinerama xorg.libXp xorg.libXtst xorg.libXi xorg.libXext

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, intltool, gperf, libcap, dbus, kmod
-, xz, pam, acl, cryptsetup, libuuid, m4, utillinux
+, xz, pam, acl, cryptsetup, libuuid, m4, utillinuxMinimal
 , glib, kbd, libxslt, coreutils, libgcrypt, libgpgerror, libapparmor, audit, lz4
 , kexectools, libmicrohttpd, linuxHeaders, libseccomp
 , autoreconfHook, gettext, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
@@ -75,13 +75,13 @@ stdenv.mkDerivation rec {
         test -e $i
         substituteInPlace $i \
           --replace /usr/bin/getent ${stdenv.glibc}/bin/getent \
-          --replace /bin/mount ${utillinux}/bin/mount \
-          --replace /bin/umount ${utillinux}/bin/umount \
-          --replace /sbin/swapon ${utillinux}/sbin/swapon \
-          --replace /sbin/swapoff ${utillinux}/sbin/swapoff \
+          --replace /bin/mount ${utillinuxMinimal}/bin/mount \
+          --replace /bin/umount ${utillinuxMinimal}/bin/umount \
+          --replace /sbin/swapon ${utillinuxMinimal}/sbin/swapon \
+          --replace /sbin/swapoff ${utillinuxMinimal}/sbin/swapoff \
           --replace /bin/echo ${coreutils}/bin/echo \
           --replace /bin/cat ${coreutils}/bin/cat \
-          --replace /sbin/sulogin ${utillinux}/sbin/sulogin \
+          --replace /sbin/sulogin ${utillinuxMinimal}/sbin/sulogin \
           --replace /usr/lib/systemd/systemd-fsck $out/lib/systemd/systemd-fsck
       done
 

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, zlib, ncurses ? null, perl ? null, pam }:
+{ stdenv, fetchurl, zlib, ncurses ? null, perl ? null, pam, systemd ? null
+, pkgconfig
+}:
 
 stdenv.mkDerivation rec {
   name = "util-linux-2.27.1";
@@ -38,11 +40,16 @@ stdenv.mkDerivation rec {
     --disable-use-tty-group
     --enable-fs-paths-default=/var/setuid-wrappers:/var/run/current-system/sw/bin:/sbin
     ${if ncurses == null then "--without-ncurses" else ""}
+    ${if systemd == null then "" else ''
+      --with-systemd
+      --with-systemdsystemunitdir=$out/lib/systemd/system/
+    ''}
   '';
 
   buildInputs =
     [ zlib pam ]
     ++ stdenv.lib.optional (ncurses != null) ncurses
+    ++ stdenv.lib.optional (systemd != null) [ systemd pkgconfig ]
     ++ stdenv.lib.optional (perl != null) perl;
 
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9979,8 +9979,8 @@ let
 
   libuuid =
     if crossSystem != null && crossSystem.config == "i586-pc-gnu"
-    then (utillinux // {
-      crossDrv = lib.overrideDerivation utillinux.crossDrv (args: {
+    then (utillinuxMinimal // {
+      crossDrv = lib.overrideDerivation utillinuxMinimal.crossDrv (args: {
         # `libblkid' fails to build on GNU/Hurd.
         configureFlags = args.configureFlags
           + " --disable-libblkid --disable-mount --disable-libmount"
@@ -9993,7 +9993,7 @@ let
       });
     })
     else if stdenv.isLinux
-    then utillinux
+    then utillinuxMinimal
     else null;
 
   light = callPackage ../os-specific/linux/light { };
@@ -10784,13 +10784,12 @@ let
 
   usermount = callPackage ../os-specific/linux/usermount { };
 
-  utillinux = callPackage ../os-specific/linux/util-linux {
+  utillinux = callPackage ../os-specific/linux/util-linux { };
+
+  utillinuxMinimal = appendToName "minimal" (utillinux.override {
     ncurses = null;
     perl = null;
-  };
-
-  utillinuxCurses = appendToName "curses" (utillinux.override {
-    inherit ncurses perl;
+    systemd = null;
   });
 
   v4l_utils = callPackage ../os-specific/linux/v4l-utils {

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -169,7 +169,7 @@ with import ./release-lib.nix { inherit supportedSystems; };
   upstart = linux;
   usbutils = linux;
   utillinux = linux;
-  utillinuxCurses = linux;
+  utillinuxMinimal = linux;
   w3m = all;
   webkit = linux;
   wget = all;


### PR DESCRIPTION
This is the start of the change to fix #11637. Currently I am having problems with circular dependencies as it appears that system is still pulling in a utillinux with a non-null `systemd` argument even though I have told it to use `utillinuxMinimal`.
