### PR TITLE
patchage: init at 1.0.1

### DIFF
--- a/pkgs/applications/audio/patchage/default.nix
+++ b/pkgs/applications/audio/patchage/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, alsaLib, boost, dbus_glib, fetchsvn, ganv, glibmm, gtk2
+, gtkmm, libjack2, pkgconfig, python2
+}:
+
+stdenv.mkDerivation rec {
+  name = "patchage-${version}";
+  version = "1.0.1";
+  src = fetchsvn {
+    url = http://svn.drobilla.net/lad/trunk/patchage/;
+    rev = "5821";
+    sha256 = "1ar64l0sg468qzxj7i6ppgfqjpm92awcp5lzskamrf3ln17lrgj7";
+  };
+
+  buildInputs = [
+    alsaLib boost dbus_glib ganv glibmm gtk2 gtkmm libjack2
+    pkgconfig python2
+  ];
+
+  configurePhase = "python waf configure --prefix=$out";
+  buildPhase = "python waf build";
+  installPhase = "python waf install";
+
+  meta = {
+    description = "Modular patch bay for Jack and ALSA systems";
+    homepage = http://non.tuxfamily.org;
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nico202 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2729,6 +2729,8 @@ let
 
   patch = gnupatch;
 
+  patchage = callPackage ../applications/audio/patchage { };
+
   pbzip2 = callPackage ../tools/compression/pbzip2 { };
 
   pciutils = callPackage ../tools/system/pciutils { };


### PR DESCRIPTION
Added [patchage](http://drobilla.net/software/patchage/) to the latest stable svn
Patchage is a modular patch bay for audio and MIDI systems based on Jack and Alsa.
