### PR TITLE
use File::Spec to remove double backslashes from grub conf file

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -7,6 +7,7 @@ use File::Path;
 use File::stat;
 use File::Copy;
 use File::Slurp;
+use File::Spec;
 use File::Temp;
 require List::Compare;
 use POSIX;
@@ -228,7 +229,7 @@ if ($grubVersion == 1) {
     ";
     if ($splashImage) {
         copy $splashImage, "$bootPath/background.xpm.gz" or die "cannot copy $splashImage to $bootPath\n";
-        $conf .= "splashimage " . $grubBoot->path . "/background.xpm.gz\n";
+        $conf .= "splashimage " . File::Spec->canonpath($grubBoot->path . "/background.xpm.gz") . "\n";
     }
 }
 
@@ -327,9 +328,9 @@ sub addEntry {
     my ($name, $path) = @_;
     return unless -e "$path/kernel" && -e "$path/initrd";
 
-    my $kernel = copyToKernelsDir(Cwd::abs_path("$path/kernel"));
-    my $initrd = copyToKernelsDir(Cwd::abs_path("$path/initrd"));
-    my $xen = -e "$path/xen.gz" ? copyToKernelsDir(Cwd::abs_path("$path/xen.gz")) : undef;
+    my $kernel = File::Spec->canonpath(copyToKernelsDir(Cwd::abs_path("$path/kernel")));
+    my $initrd = File::Spec->canonpath(copyToKernelsDir(Cwd::abs_path("$path/initrd")));
+    my $xen = -e "$path/xen.gz" ? File::Spec->canonpath(copyToKernelsDir(Cwd::abs_path("$path/xen.gz"))) : undef;
 
     # FIXME: $confName
 


### PR DESCRIPTION
This pull request fixes the double backslash issue without turning relative paths into absolute ones. My previous pull request used Cwd::abs_path() which mangled relative paths in the boot.cfg file.

Here is some example usage of File::Spec from the command line to give some intuition about how it works:

```
$ perl -MFile::Spec -le 'print File::Spec->canonpath("//")' 
/
$ perl -MFile::Spec -le 'print File::Spec->canonpath("./test")' 
test
$ perl -MFile::Spec -le 'print File::Spec->canonpath("a/b/c")' 
a/b/c
$ perl -MFile::Spec -le 'print File::Spec->canonpath("//test")'
/test
```

Thanks!
