### PR TITLE
Disable networking.firewall by default

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -528,6 +528,8 @@ $bootLoaderConfig
   # networking.hostName = "nixos"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  networking.firewall.enable = true;
+
   # Select internationalisation properties.
   # i18n = {
   #   consoleFont = "Lat2-Terminus16";

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -232,7 +232,7 @@ in
 
     networking.firewall.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = versionOlder config.system.stateVersion "16.03";
       description =
         ''
           Whether to enable the firewall.  This is a simple stateful


### PR DESCRIPTION
This got a bit off-topic in #12927 by [my comment](https://github.com/NixOS/nixpkgs/issues/12927#issuecomment-183372799) against having it enabled by default, so let's continue here instead.

As stated in the comment, we _really_ should focus on not opening ports that are not needed to world instead of putting additional netfilter/conntrack modules in front that will increase the attack vector.

After all, if you _want_ a service to be available to the world, the netfilter can't help you either and if you don't want it to be available, why enable the service (or listening to `::`) in the first place? Everything that we might want to block or disable _can_ be disabled without relying on netfilter, except a few very specific corner cases (like for example port knocking) which where people can still enable it.

The pull request still lacks documentation in the release notes and is primarily there for discussion, in addition to that I'd like to add a few tests (and module fixes) here to ensure that we don't listen to ports that are unnecessary.
