### PR TITLE
Use BlueZ 5 by default, update blueman

### DIFF
--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -73,6 +73,8 @@ stdenv.mkDerivation rec {
     ln -s ../libexec/bluetooth/obexd $out/sbin/obexd
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = http://www.bluez.org/;
     repositories.git = https://git.kernel.org/pub/scm/bluetooth/bluez.git;

--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -1,43 +1,49 @@
-{ stdenv, fetchurl, pkgconfig, intltool, python, pyrex, pygobject, pygtk
-, notify, pythonDBus, bluez, glib, gtk, libstartup_notification
-, makeWrapper, xdg_utils, obex_data_server
-, libpulseaudio
-}:
-   
-stdenv.mkDerivation rec {
-  name = "blueman-1.23";
+{ stdenv, lib, fetchurl, intltool, pkgconfig, pythonPackages, bluez, polkit, gtk3
+, obex_data_server, xdg_utils, libnotify, dconf
+, withPulseAudio ? true, libpulseaudio }:
+
+let
+  binPath = lib.makeBinPath [ xdg_utils ];
+
+in stdenv.mkDerivation rec {
+  name = "blueman-${version}";
+  version = "2.0.3";
    
   src = fetchurl {
-    url = "http://download.tuxfamily.org/blueman/${name}.tar.gz";
-    sha256 = "04ghlh4h5bwp9mqr5jxcmjm01595l5fq5561qxvf369fvjy63cjh";
+    url = "https://github.com/blueman-project/blueman/releases/download/${version}/${name}.tar.xz";
+    sha256 = "09aqlk4c2qzqpmyf7b40sic7d45c1l8fyrb9f3s22b8w83j0adi4";
   };
 
-  configureFlags = "--disable-polkit";
+  nativeBuildInputs = [ intltool pkgconfig pythonPackages.wrapPython pythonPackages.cython ];
 
-  buildInputs =
-    [ pkgconfig intltool python pyrex pygobject pygtk notify pythonDBus
-      bluez glib gtk libstartup_notification makeWrapper
-    ];
+  buildInputs = [ bluez gtk3 pythonPackages.python libnotify dconf ]
+                ++ pythonPath
+                ++ lib.optional withPulseAudio libpulseaudio;
 
-  # !!! Ugly.
-  PYTHONPATH = "${pygobject}/lib/${python.libPrefix}/site-packages/gtk-2.0:${pygtk}/lib/${python.libPrefix}/site-packages/gtk-2.0:${notify}/lib/${python.libPrefix}/site-packages/gtk-2.0";
+  postPatch = lib.optionalString withPulseAudio ''
+    sed -i 's,CDLL(",CDLL("${libpulseaudio}/lib/,g' blueman/main/PulseAudioUtils.py
+  '';
 
-  postInstall =
-    ''
-      # Create wrappers that set the environment correctly.
-      for i in $out/bin/* $out/libexec/*; do
-          wrapProgram $i \
-              --set PYTHONPATH "$(toPythonPath $out):$PYTHONPATH" \
-              --set LD_LIBRARY_PATH "${libpulseaudio}/lib:" \
-              --prefix PATH : ${xdg_utils}/bin
-      done
+  pythonPath = with pythonPackages; [ dbus pygobject3 ];
 
-      mkdir -p $out/nix-support
-      echo ${obex_data_server} > $out/nix-support/propagated-user-env-packages
-    ''; # */
+  propagatedUserEnvPkgs = [ obex_data_server ];
 
-  meta = {
-    homepage = http://blueman-project.org/;
+  configureFlags = [ (lib.enableFeature withPulseAudio "pulseaudio") ];
+
+  postFixup = ''
+    makeWrapperArgs="\
+      --prefix PATH ':' ${binPath} \
+      --prefix GI_TYPELIB_PATH : $GI_TYPELIB_PATH \
+      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
+      --prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
+    wrapPythonPrograms
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/blueman-project;
     description = "GTK+-based Bluetooth Manager";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/tools/bluetooth/obexfs/default.nix
+++ b/pkgs/tools/bluetooth/obexfs/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, fuse, obexftp}:
+{ stdenv, fetchurl, pkgconfig, fuse, obexftp }:
    
 stdenv.mkDerivation rec {
   name = "obexfs-0.12";
@@ -8,12 +8,13 @@ stdenv.mkDerivation rec {
     sha256 = "1g3krpygk6swa47vbmp9j9s8ahqqcl9ra8r25ybgzv2d9pmjm9kj";
   };
 
-  buildInputs = [pkgconfig fuse obexftp];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ fuse obexftp ];
 
-  NIX_LDFLAGS = "-lobexftp";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://dev.zuckschwerdt.org/openobex/wiki/ObexFs;
     description = "A tool to mount OBEX-based devices (such as Bluetooth phones)";
+    platforms = platforms.linux;
+    license = licenses.lgpl2Plus;
   };
 }

--- a/pkgs/tools/bluetooth/obexftp/default.nix
+++ b/pkgs/tools/bluetooth/obexftp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, openobex, bluez, cmake}:
+{ stdenv, fetchurl, pkgconfig, openobex, bluez, cmake }:
    
 stdenv.mkDerivation rec {
   name = "obexftp-0.24";
@@ -8,13 +8,21 @@ stdenv.mkDerivation rec {
     sha256 = "0szy7p3y75bd5h4af0j5kf0fpzx2w560fpy4kg3603mz11b9c1xr";
   };
 
-  buildInputs = [pkgconfig bluez cmake];
+  nativeBuildInputs = [ pkgconfig cmake ];
 
-  propagatedBuildInputs = [openobex];
+  buildInputs = [ bluez ];
 
-  meta = {
+  propagatedBuildInputs = [ openobex ];
+
+  # There's no such thing like "bluetooth" library; possibly they meant "bluez" but it links correctly without this.
+  postFixup = ''
+    sed -i 's,^Requires: bluetooth,Requires:,' $out/lib/pkgconfig/obexftp.pc
+  '';
+
+  meta = with stdenv.lib; {
     homepage = http://dev.zuckschwerdt.org/openobex/wiki/ObexFtp;
     description = "A library and tool to access files on OBEX-based devices (such as Bluetooth phones)";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.lgpl2Plus;
   };
 }

--- a/pkgs/tools/bluetooth/openobex/default.nix
+++ b/pkgs/tools/bluetooth/openobex/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, bluez, libusb, cmake}:
+{ stdenv, fetchurl, pkgconfig, bluez, libusb, cmake }:
    
 stdenv.mkDerivation rec {
   name = "openobex-1.7.1";
@@ -8,18 +8,20 @@ stdenv.mkDerivation rec {
     sha256 = "0mza0mrdrbcw4yix6qvl31kqy7bdkgxjycr0yx7yl089v5jlc9iv";
   };
 
-  buildInputs = [pkgconfig bluez libusb cmake];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ bluez libusb ];
 
-  configureFlags = "--enable-apps";
+  configureFlags = [ "--enable-apps" ];
 
   patchPhase = ''
     sed -i "s!/lib/udev!$out/lib/udev!" udev/CMakeLists.txt
     sed -i "/if ( PKGCONFIG_UDEV_FOUND )/,/endif ( PKGCONFIG_UDEV_FOUND )/d" udev/CMakeLists.txt
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://dev.zuckschwerdt.org/openobex/;
     description = "An open source implementation of the Object Exchange (OBEX) protocol";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.lgpl2Plus;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1012,7 +1012,8 @@ let
   bittornado = callPackage ../tools/networking/p2p/bit-tornado { };
 
   blueman = callPackage ../tools/bluetooth/blueman {
-    inherit (pythonPackages) notify;
+    inherit (gnome3) dconf;
+    withPulseAudio = config.pulseaudio or true;
   };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9858,16 +9858,16 @@ let
 
   batctl = callPackage ../os-specific/linux/batman-adv/batctl.nix { };
 
-  bluez4 = callPackage ../os-specific/linux/bluez {
+  bluez4 = lowPrio (callPackage ../os-specific/linux/bluez {
     pygobject = pygobject3;
-  };
+  });
 
-  bluez5 = lowPrio (callPackage ../os-specific/linux/bluez/bluez5.nix { });
+  bluez5 = callPackage ../os-specific/linux/bluez/bluez5.nix { };
 
   # Needed for LibreOffice
   bluez5_28 = lowPrio (callPackage ../os-specific/linux/bluez/bluez5_28.nix { });
 
-  bluez = bluez4;
+  bluez = bluez5;
 
   inherit (pythonPackages) bedup;
 


### PR DESCRIPTION
Now that we have https://github.com/NixOS/nixpkgs/pull/12683 merged, we should start building with BlueZ 5 by default. I've also updated blueman (the new version supports BlueZ 5) and fixed ObexFS. Tested with `nox-review wip`.
