### PR TITLE
{lib}mediainfo{-gui}: 0.7.81 -> 0.7.82

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.81";
+  version = "0.7.82";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1aah8y4kqhghqhcfm6ydgf3hj6q05dllfh0m1lbaij0y8yrrwz07";
+    sha256 = "0ivvmxx93aldfbms6wg46x9npghg304j2zxl5i70m710gybjr232";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.81";
+  version = "0.7.82";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1aah8y4kqhghqhcfm6ydgf3hj6q05dllfh0m1lbaij0y8yrrwz07";
+    sha256 = "0ivvmxx93aldfbms6wg46x9npghg304j2zxl5i70m710gybjr232";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.81";
+  version = "0.7.82";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "0hzfrg7n7wlnwq28hmpxczis1k8x73wbwlsmfkshvqcwi7lva0cs";
+    sha256 = "1mqmk1q2phwqwrak54jc9hfwjllhhr4nqyigisrh9rcvd6wx6r86";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];


### PR DESCRIPTION
Built and tested locally.

From the changelog:

```
Version 0.7.82, 2016-01-27
+ Matroska: CRC-32 validation
+ Matroska: support of padding/junk at the start of a segment
+ Matroska: trace is activated for all elements (but report is still
  based on the first element met)
+ Matroska: add an intermediate level in the trace for the raw stream
  parser
x FLV: potential infinite loop fixed
x #B966, DTS: DTS-HD HR 3840 not detected anymore
x AC-3: wrong sample rate with 32 kHz streams
x #B948, EBUCore 1.6: invalid output due to position of
  containerEncoding element
x #B957, MPEG-7 output: No XML encoded value output
```
