### PR TITLE
keepass-keefox: 1.5.4 -> 1.6.0b1

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keefox/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keefox/default.nix
@@ -1,12 +1,12 @@
 { stdenv, buildEnv, fetchurl, mono, unzip }:
 
 let
-  version = "1.5.4";
+  version = "1.6.0b1";
   drv = stdenv.mkDerivation {
     name = "keefox-${version}";
     src = fetchurl {
       url    = "https://github.com/luckyrat/KeeFox/releases/download/v${version}/${version}.xpi";
-      sha256 = "c7c30770beb0ea32cbdee5311d03a9910fb7772695af3aa655e4ae64cd4d8335";
+      sha256 = "c640fbc266b867cae4bd1758d3bf6a411208e72730f3b5eee6bcb7b5115b65ba";
     };
 
     meta = {


### PR DESCRIPTION
Bump plugin version to 1.6.0b1
