### PR TITLE
rsync: Add rrsync as individual app

### DIFF
--- a/pkgs/applications/networking/sync/rsync/base.nix
+++ b/pkgs/applications/networking/sync/rsync/base.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "3.2.1";
+in
+{
+  version = version;
+  src = fetchurl {
+    # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
+    url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
+    sha256 = "1hm1q04hz15509f0p9bflw4d6jzfvpm1d36dxjwihk1wzakn5ypc";
+  };
+  patches = fetchurl {
+    # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
+    url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
+    sha256 = "09i3dcl37p22dp75vlnsvx7bm05ggafnrf1zwhf2kbij4ngvxvpd";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://rsync.samba.org/;
+    #description = "A helper to run rsync-only environments from ssh-logins.";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ simons ehmry kampfschlaefer ];
+  };
+}

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -5,17 +5,15 @@
 
 assert enableACLs -> acl != null;
 
+let
+  base = import ./base.nix { inherit stdenv fetchurl; };
+in
 stdenv.mkDerivation rec {
-  name = "rsync-${version}";
-  version = "3.1.2";
+  name = "rsync-${base.version}";
 
-  mainSrc = import ./src.nix { inherit fetchurl version; };
+  mainSrc = base.src;
 
-  patchesSrc = fetchurl {
-    # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
-    url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
-    sha256 = "09i3dcl37p22dp75vlnsvx7bm05ggafnrf1zwhf2kbij4ngvxvpd";
-  };
+  patchesSrc = base.patches;
 
   srcs = [mainSrc] ++ stdenv.lib.optional enableCopyDevicesPatch patchesSrc;
   patches = stdenv.lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff";
@@ -25,11 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--with-nobody-group=nogroup";
 
-  meta = with stdenv.lib; {
-    homepage = http://rsync.samba.org/;
+  meta = base.meta // {
     description = "A fast incremental file transfer utility";
-    license = licenses.gpl3Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ simons ehmry ];
   };
 }

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -9,11 +9,7 @@ stdenv.mkDerivation rec {
   name = "rsync-${version}";
   version = "3.1.2";
 
-  mainSrc = fetchurl {
-    # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
-    url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
-    sha256 = "1hm1q04hz15509f0p9bflw4d6jzfvpm1d36dxjwihk1wzakn5ypc";
-  };
+  mainSrc = import ./src.nix { inherit fetchurl version; };
 
   patchesSrc = fetchurl {
     # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, perl, rsync }:
+
+stdenv.mkDerivation rec {
+  name = "rrsync-${version}";
+  version = "3.1.2";
+
+  src = import ./src.nix { inherit fetchurl version; };
+
+  buildInputs = [ rsync ];
+  nativeBuildInputs = [perl];
+
+  # Skip configure and build phases.
+  # We just want something from the support directory
+  configurePhase = "true";
+  dontBuild = true;
+
+  postPatch = ''
+    sed -i 's#/usr/bin/rsync#${rsync}/bin/rsync#' support/rrsync
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp support/rrsync $out/bin
+    chmod a+x $out/bin/rrsync
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://rsync.samba.org/;
+    description = "A helper to run rsync-only environments from ssh-logins.";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ simons ehmry ];
+  };
+}

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, perl, rsync }:
 
+let
+  base = import ./base.nix { inherit stdenv fetchurl; };
+in
 stdenv.mkDerivation rec {
-  name = "rrsync-${version}";
-  version = "3.1.2";
+  name = "rrsync-${base.version}";
 
-  src = import ./src.nix { inherit fetchurl version; };
+  src = base.src;
 
   buildInputs = [ rsync ];
   nativeBuildInputs = [perl];
@@ -15,7 +17,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   postPatch = ''
-    sed -i 's#/usr/bin/rsync#${rsync}/bin/rsync#' support/rrsync
+    substituteInPlace support/rrsync --replace /usr/bin/rsync ${rsync}/bin/rsync
   '';
 
   installPhase = ''
@@ -24,11 +26,7 @@ stdenv.mkDerivation rec {
     chmod a+x $out/bin/rrsync
   '';
 
-  meta = with stdenv.lib; {
-    homepage = http://rsync.samba.org/;
-    description = "A helper to run rsync-only environments from ssh-logins.";
-    license = licenses.gpl3Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ simons ehmry ];
+  meta = base.meta // {
+    description = "A helper to run rsync-only environments from ssh-logins";
   };
 }

--- a/pkgs/applications/networking/sync/rsync/src.nix
+++ b/pkgs/applications/networking/sync/rsync/src.nix
@@ -1,0 +1,7 @@
+{ version, fetchurl }:
+
+fetchurl {
+  # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
+  url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
+  sha256 = "1hm1q04hz15509f0p9bflw4d6jzfvpm1d36dxjwihk1wzakn5ypc";
+}

--- a/pkgs/applications/networking/sync/rsync/src.nix
+++ b/pkgs/applications/networking/sync/rsync/src.nix
@@ -1,7 +1,0 @@
-{ version, fetchurl }:
-
-fetchurl {
-  # signed with key 0048 C8B0 26D4 C96F 0E58  9C2F 6C85 9FB1 4B96 A8C5
-  url = "mirror://samba/rsync/src/rsync-${version}.tar.gz";
-  sha256 = "1hm1q04hz15509f0p9bflw4d6jzfvpm1d36dxjwihk1wzakn5ypc";
-}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13225,6 +13225,7 @@ let
     enableACLs = !(stdenv.isDarwin || stdenv.isSunOS || stdenv.isFreeBSD);
     enableCopyDevicesPatch = (config.rsync.enableCopyDevicesPatch or false);
   };
+  rrsync = callPackage ../applications/networking/sync/rsync/rrsync.nix {};
 
   rtl-sdr = callPackage ../applications/misc/rtl-sdr { };
 


### PR DESCRIPTION
Extract the rsync source fetching into its own expression and use that
expression to fetch the same source for rsync and rrsync.

rrsync is just copied from the support folder of rsync, no configure or build
needed. Also none of the rsync patches are needed. Only the path to rsync needs
to be patched into rrsync.
