### PR TITLE
gnucash: enable dbi

### DIFF
--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, libxml2, libxslt, perl, perlPackages, gconf, guile
 , intltool, glib, gtk, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
 , webkit, glibcLocales, gsettings_desktop_schemas, makeWrapper, dconf, file
-, gettext, swig, slibGuile, enchant, bzip2, isocodes
+, gettext, swig, slibGuile, enchant, bzip2, isocodes, libdbi, libdbiDrivers
 }:
 
 /*
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
     perl perlPackages.FinanceQuote perlPackages.DateManip
     # guile
     guile slibGuile
+    # database backends
+    libdbi libdbiDrivers
     # build
     makeWrapper
   ];
@@ -41,8 +43,14 @@ stdenv.mkDerivation rec {
   patchShebangs ./src
   '';
 
-  configureFlags = "CFLAGS=-O3 CXXFLAGS=-O3 --disable-dbi --enable-ofx --enable-aqbanking";
-
+  configureFlags = [
+    "CFLAGS=-O3"
+    "CXXFLAGS=-O3"
+    "--enable-dbi"
+    "--with-dbi-dbd-dir=${libdbiDrivers}/lib/dbd/"
+    "--enable-ofx"
+    "--enable-aqbanking"
+  ];
 
   postInstall = ''
     # Auto-updaters don't make sense in Nix.


### PR DESCRIPTION
My accounts are stored in the DBI backend (SQLite, specifically).
Before the present change, GnuCash would be compiled without DBI
 support (`--disable-dbi` flag), so I could only use the XML backend.
Now I can use either backend.

I made the change only for 2.6. It looks like 2.4 works the same way,
so maybe I'll enable DBI for that one later.

Making nix packages is delightful! It might replace my accounting hobby!
