### PR TITLE
Updating ZeroMQ to 4.1.4

### DIFF
--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -1,23 +1,15 @@
 { stdenv, fetchurl, libuuid, pkgconfig, libsodium }:
 
 stdenv.mkDerivation rec {
-  name = "zeromq-4.1.3";
+  name = "zeromq-4.1.4";
 
   src = fetchurl {
     url = "http://download.zeromq.org/${name}.tar.gz";
-    sha256 = "04gligbgr0phipjkwc0dyk1vr9306r6s4dbj85z7fxxk1n1ircv1";
+    sha256 = "0y73dxgf4kaysmkvrkxqq9qk5znklxyghh749jw4qbjwwbyl97z9";
   };
-
-  # Fix zeromq-4.1.3 with libsodium-1.0.6
-  postPatch = ''
-    sed -i 's/libzmq_werror="yes"/libzmq_werror="no"/' configure
-  '';
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libuuid libsodium ];
-
-  # https://github.com/zeromq/libzmq/commit/479db2113643e459c11db392e0fefd6400657c9e
-  patches = [ ./sodium_warning.patch ];
 
   meta = with stdenv.lib; {
     branch = "4";


### PR DESCRIPTION
Minor bump to the ZeroMQ version. The patch used previously was merged into the mainline, so is no longer necessary.
