### PR TITLE
nixos/grafana: unbreak and update to 2.6.0 (by cherry-picking from master)

### DIFF
--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -7,150 +7,37 @@ let
 
   b2s = val: if val then "true" else "false";
 
-  cfgFile = pkgs.writeText "grafana.ini" ''
-    app_name = grafana
-    app_mode = production
+  envOptions = {
+    PATHS_DATA = cfg.dataDir;
+    PATHS_LOGS = "${cfg.dataDir}/log";
 
-    [server]
-    ; protocol (http or https)
-    protocol = ${cfg.protocol}
-    ; the ip address to bind to, empty will bind to all interfaces
-    http_addr = ${cfg.addr}
-    ; the http port  to use
-    http_port = ${toString cfg.port}
-    ; The public facing domain name used to access grafana from a browser
-    domain = ${cfg.domain}
-    ; the full public facing url
-    root_url = ${cfg.rootUrl}
-    router_logging = false
-    ; the path relative to the binary where the static (html/js/css) files are placed
-    static_root_path = ${cfg.staticRootPath}
-    ; enable gzip
-    enable_gzip = false
-    ; https certs & key file
-    cert_file = ${cfg.certFile}
-    cert_key = ${cfg.certKey}
+    SERVER_PROTOCOL = cfg.protocol;
+    SERVER_HTTP_ADDR = cfg.addr;
+    SERVER_HTTP_PORT = cfg.port;
+    SERVER_DOMAIN = cfg.domain;
+    SERVER_ROOT_URL = cfg.rootUrl;
+    SERVER_STATIC_ROOT_PATH = cfg.staticRootPath;
+    SERVER_CERT_FILE = cfg.certFile;
+    SERVER_CERT_KEY = cfg.certKey;
 
-    [analytics]
-    # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
-    # No ip addresses are being tracked, only simple counters to track
-    # running instances, dashboard and error counts. It is very helpful to us.
-    # Change this option to false to disable reporting.
-    reporting_enabled = true
-    ; Google Analytics universal tracking code, only enabled if you specify an id here
-    google_analytics_ua_id =
+    DATABASE_TYPE = cfg.database.type;
+    DATABASE_HOST = cfg.database.host;
+    DATABASE_NAME = cfg.database.name;
+    DATABASE_USER = cfg.database.user;
+    DATABASE_PASSWORD = cfg.database.password;
+    DATABASE_PATH = cfg.database.path;
 
-    [database]
-    ; Either "mysql", "postgres" or "sqlite3", it's your choice
-    type = ${cfg.database.type}
-    host = ${cfg.database.host}
-    name = ${cfg.database.name}
-    user = ${cfg.database.user}
-    password = ${cfg.database.password}
-    ; For "postgres" only, either "disable", "require" or "verify-full"
-    ssl_mode = disable
-    ; For "sqlite3" only
-    path = ${cfg.database.path}
+    SECURITY_ADMIN_USER = cfg.security.adminUser;
+    SECURITY_ADMIN_PASSWORD = cfg.security.adminPassword;
+    SECURITY_SECRET_KEY = cfg.security.secretKey;
 
-    [session]
-    ; Either "memory", "file", "redis", "mysql", default is "memory"
-    provider = file
-    ; Provider config options
-    ; memory: not have any config yet
-    ; file: session file path, e.g. `data/sessions`
-    ; redis: config like redis server addr, poolSize, password, e.g. `127.0.0.1:6379,100,grafana`
-    ; mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1)/database_name`
-    provider_config = data/sessions
-    ; Session cookie name
-    cookie_name = grafana_sess
-    ; If you use session in https only, default is false
-    cookie_secure = false
-    ; Session life time, default is 86400
-    session_life_time = 86400
-    ; session id hash func, Either "sha1", "sha256" or "md5" default is sha1
-    session_id_hashfunc = sha1
-    ; Session hash key, default is use random string
-    session_id_hashkey =
+    USERS_ALLOW_SIGN_UP = b2s cfg.users.allowSignUp;
+    USERS_ALLOW_ORG_CREATE = b2s cfg.users.allowOrgCreate;
+    USERS_AUTO_ASSIGN_ORG = b2s cfg.users.autoAssignOrg;
+    USERS_AUTO_ASSIGN_ORG_ROLE = cfg.users.autoAssignOrgRole;
 
-    [security]
-    ; default admin user, created on startup
-    admin_user = ${cfg.security.adminUser}
-    ; default admin password, can be changed before first start of grafana,  or in profile settings
-    admin_password = ${cfg.security.adminPassword}
-    ; used for signing
-    secret_key = ${cfg.security.secretKey}
-    ; Auto-login remember days
-    login_remember_days = 7
-    cookie_username = grafana_user
-    cookie_remember_name = grafana_remember
-
-    [users]
-    ; disable user signup / registration
-    allow_sign_up = ${b2s cfg.users.allowSignUp}
-    ; Allow non admin users to create organizations
-    allow_org_create = ${b2s cfg.users.allowOrgCreate}
-    # Set to true to automatically assign new users to the default organization (id 1)
-    auto_assign_org = ${b2s cfg.users.autoAssignOrg}
-    ; Default role new users will be automatically assigned (if disabled above is set to true)
-    auto_assign_org_role = ${cfg.users.autoAssignOrgRole}
-
-    [auth.anonymous]
-    ; enable anonymous access
-    enabled = ${b2s cfg.auth.anonymous.enable}
-    ; specify organization name that should be used for unauthenticated users
-    org_name = Main Org.
-    ; specify role for unauthenticated users
-    org_role = Viewer
-
-    [auth.github]
-    enabled = false
-    client_id = some_id
-    client_secret = some_secret
-    scopes = user:email
-    auth_url = https://github.com/login/oauth/authorize
-    token_url = https://github.com/login/oauth/access_token
-
-    [auth.google]
-    enabled = false
-    client_id = some_client_id
-    client_secret = some_client_secret
-    scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
-    auth_url = https://accounts.google.com/o/oauth2/auth
-    token_url = https://accounts.google.com/o/oauth2/token
-
-    [log]
-    root_path = data/log
-    ; Either "console", "file", default is "console"
-    ; Use comma to separate multiple modes, e.g. "console, file"
-    mode = console
-    ; Buffer length of channel, keep it as it is if you don't know what it is.
-    buffer_len = 10000
-    ; Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
-    level = Info
-
-    ; For "console" mode only
-    [log.console]
-    level =
-
-    ; For "file" mode only
-    [log.file]
-    level =
-    ; This enables automated log rotate(switch of following options), default is true
-    log_rotate = true
-    ; Max line number of single file, default is 1000000
-    max_lines = 1000000
-    ; Max size shift of single file, default is 28 means 1 << 28, 256MB
-    max_lines_shift = 28
-    ; Segment log daily, default is true
-    daily_rotate = true
-    ; Expired days of log file(delete after max days), default is 7
-    max_days = 7
-
-    [event_publisher]
-    enabled = false
-    rabbitmq_url = amqp://localhost/
-    exchange = grafana_events
-  '';
+    AUTH_ANONYMOUS_ENABLE = b2s cfg.auth.anonymous.enable;
+  } // cfg.extraOptions;
 
 in {
   options.services.grafana = {
@@ -306,6 +193,16 @@ in {
         type = types.bool;
       };
     };
+
+    extraOptions = mkOption {
+      description = ''
+        Extra configuration options passed as env variables as specified in
+        <link xlink:href="http://docs.grafana.org/installation/configuration/">documentation</link>,
+        but without GF_ prefix
+      '';
+      default = {};
+      type = types.attrsOf types.str;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -317,11 +214,15 @@ in {
       description = "Grafana Service Daemon";
       wantedBy = ["multi-user.target"];
       after = ["networking.target"];
+      environment = mapAttrs' (n: v: nameValuePair "GF_${n}" (toString v)) envOptions;
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/grafana --config ${cfgFile} web";
+        ExecStart = "${cfg.package}/bin/grafana -homepath ${cfg.dataDir}";
         WorkingDirectory = cfg.dataDir;
         User = "grafana";
       };
+      preStart = ''
+        ln -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}
+      '';
     };
 
     users.extraUsers.grafana = {
@@ -331,7 +232,7 @@ in {
       createHome = true;
     };
 
-    services.grafana.staticRootPath = mkDefault "${cfg.package.out}/share/go/src/github.com/grafana/grafana/public";
+    services.grafana.staticRootPath = mkDefault "${cfg.package}/share/grafana/public";
 
   };
 }

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -205,7 +205,7 @@ in {
 
     package = mkOption {
       description = "Package to use.";
-      default = pkgs.goPackages.grafana;
+      default = pkgs.grafana;
       type = types.package;
     };
 

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,0 +1,35 @@
+{ lib, goPackages, fetchurl, fetchFromGitHub }:
+
+goPackages.buildGoPackage rec {
+  version = "2.5.0";
+  name = "grafana-v${version}";
+  goPackagePath = "github.com/grafana/grafana";
+  subPackages = [ "./" ];
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "grafana";
+    sha256 = "11m6jvls3gm9z8g27vxmfx84f22vyjff8bllz5lvpdizydry6zar";
+  };
+
+  srcStatic = fetchurl {
+    url = "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}.linux-x64.tar.gz";
+    sha256 = "1zih0nzlx1sszgc4b5gll4jvsq43ikx782vv991fgy79bb2a5snk";
+  };
+
+  preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";
+  postInstall = ''
+    tar -xvf $srcStatic
+    mkdir -p $bin/share/grafana
+    mv grafana-*/{public,conf} $bin/share/grafana/
+  '';
+
+  meta = with lib; {
+    description = "Gorgeous metric viz, dashboards & editors for Graphite, InfluxDB & OpenTSDB";
+    license = licenses.asl20;
+    homepage = http://grafana.org/;
+    maintainers = with maintainers; [ offline ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,7 @@
 { lib, goPackages, fetchurl, fetchFromGitHub }:
 
 goPackages.buildGoPackage rec {
-  version = "2.5.0";
+  version = "2.6.0";
   name = "grafana-v${version}";
   goPackagePath = "github.com/grafana/grafana";
   subPackages = [ "./" ];
@@ -10,12 +10,12 @@ goPackages.buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "11m6jvls3gm9z8g27vxmfx84f22vyjff8bllz5lvpdizydry6zar";
+    sha256 = "160jarvmfvrzpk8agbl44761qz4rw273d59jg6kzd0ghls03wipr";
   };
 
   srcStatic = fetchurl {
     url = "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}.linux-x64.tar.gz";
-    sha256 = "1zih0nzlx1sszgc4b5gll4jvsq43ikx782vv991fgy79bb2a5snk";
+    sha256 = "1i4aw5jvamgqfaanxlh3l83sn8xx10wpihciihvf7s3846s623ab";
   };
 
   preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1720,8 +1720,8 @@ let
 
   gptfdisk = callPackage ../tools/system/gptfdisk { };
 
-  grafana-frontend = callPackage ../development/tools/misc/grafana { };
-  grafana-backend = goPackages.grafana.bin // { outputs = [ "bin" ]; };
+  grafana-old = callPackage ../development/tools/misc/grafana { };
+  grafana = pkgs.goPackages.grafana.bin // { outputs = [ "bin" ]; };
 
   grafx2 = callPackage ../applications/graphics/grafx2 {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1721,7 +1721,6 @@ let
   gptfdisk = callPackage ../tools/system/gptfdisk { };
 
   grafana-old = callPackage ../development/tools/misc/grafana { };
-  grafana = pkgs.goPackages.grafana.bin // { outputs = [ "bin" ]; };
 
   grafx2 = callPackage ../applications/graphics/grafx2 {};
 
@@ -9054,6 +9053,8 @@ let
   freeswitch = callPackage ../servers/sip/freeswitch { };
 
   ghostOne = callPackage ../servers/games/ghost-one { };
+
+  grafana = (callPackage ../servers/monitoring/grafana { }).bin // { outputs = ["bin"]; };
 
   groovebasin = callPackage ../applications/audio/groovebasin { };
 

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1399,20 +1399,6 @@ let
     };
   };
 
-  grafana = buildGoPackage rec {
-    version = "2.0.0-beta1";
-    name = "grafana-v${version}";
-    goPackagePath = "github.com/grafana/grafana";
-    preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";
-    src = fetchFromGitHub {
-      rev = "v${version}";
-      owner = "grafana";
-      repo = "grafana";
-      sha256 = "1b263qj7n72xc5qn0hhrlivqrd0zc8746c9ic11kdxyf81nx4lza";
-    };
-    subPackages = [ "./" ];
-  };
-
   groupcache = buildFromGitHub {
     rev    = "604ed5785183e59ae2789449d89e73f3a2a77987";
     owner  = "golang";


### PR DESCRIPTION
This unbreaks the grafana service and updates grafana from 2.0.0-beta1 to 2.6.0 (on NixOS 15.09).

The unbreaking part can be made with a single line, but I figure we'd want to run latest stable by default. (Also, nobody seems to be running grafana on NixOS 15.09 except me, as it has been broken for a while. Since september last year?) I had a small dashboard defined with 2.0.0-beta1 that survived the upgrade. Grafana release notes mention several breaking changes between releases in the 2.x series though:

https://github.com/grafana/grafana/blob/master/CHANGELOG.md

Fixes https://github.com/NixOS/nixpkgs/issues/12970

CC @offlinehacker.
