### PR TITLE
alsa : 1.0.29 -> 1.1.0

### DIFF
--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-lib-1.0.29";
+  name = "alsa-lib-1.1.0";
 
   src = fetchurl {
     urls = [
      "ftp://ftp.alsa-project.org/pub/lib/${name}.tar.bz2"
      "http://alsa.cybermirror.org/lib/${name}.tar.bz2"
     ];
-    sha256 = "1l5xzhq7xjy8xap087zbbyi14gr1bhil18pn987vwdlnxcskq13k";
+    sha256 = "dfde65d11e82b68f82e562ab6228c1fb7c78854345d3c57e2c68a9dd3dae1f15";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, lib, pkgconfig, alsaLib, libogg, libpulseaudio ? null, libjack2 ? null }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-plugins-1.0.29";
+  name = "alsa-plugins-1.1.0";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.alsa-project.org/pub/plugins/${name}.tar.bz2"
       "http://alsa.cybermirror.org/plugins/${name}.tar.bz2"
     ];
-    sha256 = "0ck5xa0vnjhn5w23gf87y30h7bcb6hzsx4817sw35xl5qb58ap9j";
+    sha256 = "3b83c329953bef99f5fe25ae04ec4a455fe6514939f3b45a5321966652b2c9ee";
   };
 
   # ToDo: a52, etc.?

--- a/pkgs/os-specific/linux/alsa-tools/default.nix
+++ b/pkgs/os-specific/linux/alsa-tools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "alsa-tools-${version}";
-  version = "1.0.29";
+  version = "1.1.0";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.alsa-project.org/pub/tools/${name}.tar.bz2"
       "http://alsa.cybermirror.org/tools/${name}.tar.bz2"
     ];
-    sha256 = "1lgvyb81md25s9ciswpdsbibmx9s030kvyylf0673w3kbamz1awl";
+    sha256 = "3b1c3135b76e14532d3dd23fb15759ddd7daf9ffbc183f7a9a0a3a86374748f1";
   };
 
   buildInputs = [ alsaLib pkgconfig gtk gtk3 fltk13 ];

--- a/pkgs/os-specific/linux/alsa-utils/default.nix
+++ b/pkgs/os-specific/linux/alsa-utils/default.nix
@@ -1,15 +1,15 @@
-{stdenv, fetchurl, alsaLib, gettext, ncurses, libsamplerate, pciutils}:
+{stdenv, fetchurl, alsaLib, gettext, ncurses, libsamplerate, pciutils, fftw}:
 
 stdenv.mkDerivation rec {
   name = "alsa-utils-${version}";
-  version = "1.0.29";
+  version = "1.1.0";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.alsa-project.org/pub/utils/${name}.tar.bz2"
       "http://alsa.cybermirror.org/utils/${name}.tar.bz2"
     ];
-    sha256 = "16ryhgbapp4pxyvsjc258mcj14wk7x3xs6g9bpnkqj0l7s7haq2i";
+    sha256 = "3b1c3135b76e14532d3dd23fb15759ddd7daf9ffbc183f7a9a0a3a86374748f1";
   };
 
   patchPhase = ''
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       --replace "which" "type -p" \
       --replace "lspci" "${pciutils}/bin/lspci"
   '';
-  buildInputs = [ gettext alsaLib ncurses libsamplerate ];
+  buildInputs = [ gettext alsaLib ncurses libsamplerate fftw ];
 
   configureFlags = "--disable-xmlto --with-udev-rules-dir=$(out)/lib/udev/rules.d";
 


### PR DESCRIPTION
Bump versions for the following packages within alsa :
- alsa-utils
- alsa-tools
- alsa-plugins
- alsa-lib

Please see http://www.alsa-project.org/main/index.php/Changes_v1.0.29_v1.1.0
for the full changelog this update brings.
