### PR TITLE
intel2200BGFirmware: init at 3.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -184,6 +184,7 @@
   lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";
   lsix = "Lancelot SIX <lsix@lancelotsix.com>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
+  lukasepple = "Lukas Epple <post@lukasepple.de>";
   lukego = "Luke Gorrie <luke@snabb.co>";
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -22,7 +22,7 @@ with lib;
   ###### implementation
 
   config = mkIf config.hardware.enableAllFirmware {
-    hardware.firmware = [ pkgs.firmwareLinuxNonfree ];
+    hardware.firmware = [ pkgs.firmwareLinuxNonfree pkgs.intel2200BGFirmware ];
   };
 
 }

--- a/nixos/modules/hardware/network/intel-2200bg.nix
+++ b/nixos/modules/hardware/network/intel-2200bg.nix
@@ -23,7 +23,7 @@
 
   config = lib.mkIf config.networking.enableIntel2200BGFirmware {
 
-    hardware.enableAllFirmware = true;
+    hardware.firmware = [ pkgs.intel2200BGFirmware ];
 
   };
 

--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl }:
+
+let version = "3.1"; in
+
+stdenv.mkDerivation {
+  name = "intel2200BGFirmware-${version}";
+
+  src = fetchurl {
+    url = "http://pkgs.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
+    sha256 = "c6818c11c18cc030d55ff83f64b2bad8feef485e7742f84f94a61d811a6258bd";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/lib/firmware
+    for fw in \
+      ipw2200-bss.fw \
+      ipw2200-ibss.fw \
+      ipw2200-sniffer.fw
+    do
+      cp -f $fw $out/lib/firmware/$fw
+    done
+    mkdir -p $out/share/doc/intel2200BGFirmware
+    cp -f LICENSE.ipw2200-fw $out/share/doc/intel2200BGFirmware/LICENSE
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for Intel 2200BG cards";
+    homepage = http://ipw2200.sourceforge.net/firmware.php;
+    license = stdenv.lib.licenses.unfreeRedistributableFirmware;
+    maintainers = with maintainers; [ lukasepple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10073,6 +10073,8 @@ let
 
   ima-evm-utils = callPackage ../os-specific/linux/ima-evm-utils { };
 
+  intel2200BGFirmware = callPackage ../os-specific/linux/firmware/intel2200BGFirmware { };
+
   iomelt = callPackage ../os-specific/linux/iomelt { };
 
   iotop = callPackage ../os-specific/linux/iotop { };


### PR DESCRIPTION
This commit adds the firmware for the Intel 2200BG wireless card.
