### PR TITLE
thin-provisioning-tools: init at 0.6.1

### DIFF
--- a/pkgs/os-specific/linux/thin-provisioning-tools/default.nix
+++ b/pkgs/os-specific/linux/thin-provisioning-tools/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, autoconf, pkgconfig, utillinux, coreutils, expat, libaio, boost}:
+
+let
+  version = "0.6.1";
+in
+
+stdenv.mkDerivation {
+  name = "thin-provisioning-tools-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jthornber";
+    repo = "thin-provisioning-tools";
+    rev = "e46bdfd4cc6cdb13852de8aba4e3019425ab0a89";
+    sha256 = "061rw33nw16g71ij05axl713wimawx54h2ggpqxvzy7iyi6lhdcm";
+  };
+
+  nativeBuildInputs = [ autoconf pkgconfig expat libaio boost ];
+
+  preConfigure =
+    ''
+      autoconf
+    '';
+
+  meta = {
+    homepage = https://github.com/jthornber/thin-provisioning-tools;
+    descriptions = "Tools for manipulating the metadata of the device-mapper targets (dm-thin-pool, dm-cache, dm-era)";
+    platforms = stdenv.lib.platforms.linux;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10509,6 +10509,8 @@ let
 
   lvm2 = callPackage ../os-specific/linux/lvm2 { };
 
+  thin_provisioning_tools = callPackage ../os-specific/linux/thin-provisioning-tools { };
+
   mbpfan = callPackage ../os-specific/linux/mbpfan { };
 
   mdadm = callPackage ../os-specific/linux/mdadm { };


### PR DESCRIPTION
Tools for manipulating the metadata of the device-mapper targets (dm-thin-pool, dm-cache, dm-era). Required for supporting thin pool and cached volumes in LVM.
