### PR TITLE
exa: init at git 2016-02-15

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -95,6 +95,7 @@
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";
   edwtjo = "Edward Tjörnhammar <ed@cflags.cc>";
   eelco = "Eelco Dolstra <eelco.dolstra@logicblox.com>";
+  ehegnes = "Eric Hegnes <eric.hegnes@gmail.com>";
   ehmry = "Emery Hemingway <emery@vfemail.net>";
   eikek = "Eike Kettner <eike.kettner@posteo.de>";
   elasticdog = "Aaron Bull Schaefer <aaron@elasticdog.com>";

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, rustPlatform, openssl, cmake, zlib }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "exa-${version}";
+  version = "2016-02-15";
+
+  depsSha256 = "1925nhpfph82wn755zf2nmad24f1hzbxq60gpva9sic6rnap4c1x";
+
+  src = fetchFromGitHub {
+    owner = "ogham";
+    repo = "exa";
+    rev = "252eba484476369bb966fb1af7f739732b968fc0";
+    sha256 = "1smyy32z44zgmhyhlbjaxcgfnlbcwz7am9225yppqfdsiqqgdybf";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl zlib ];
+
+  # Some tests fail, but Travis ensures a proper build
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Replacement for 'ls' written in Rust";
+    longDescription = ''
+      exa is a modern replacement for ls. It uses colours for information by
+      default, helping you distinguish between many types of files, such as
+      whether you are the owner, or in the owning group. It also has extra
+      features not present in the original ls, such as viewing the Git status
+      for a directory, or recursing into directories with a tree view. exa is
+      written in Rust, so it’s small, fast, and portable.
+    '';
+    homepage = http://bsago.me/exa;
+    license = licenses.mit;
+    maintainer = [ maintainers.ehegnes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1472,6 +1472,8 @@ let
 
   evtest = callPackage ../applications/misc/evtest { };
 
+  exa = callPackage ../tools/misc/exa { };
+
   exempi = callPackage ../development/libraries/exempi { };
 
   execline = callPackage ../tools/misc/execline { };

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,15 +7,15 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-02-02";
-  rev = "9312acc30def6bb16739ab6c4560fb9880b25c5a";
+  version = "2016-02-15";
+  rev = "af2c6a768083a66a898a07f5f3b7ec62871dbc3c";
 
   src = fetchFromGitHub {
       inherit rev;
 
       owner = "rust-lang";
       repo = "crates.io-index";
-      sha256 = "0mrfcipc7sv0kzryjs649x3j4djr8jgbl58jd21hrcihc61qa38n";
+      sha256 = "f2da91b1a11146eed04c4b4ad7599f1bd3dc2bca4e011b3377ba16365b3124aa";
   };
 
 in


### PR DESCRIPTION
This is my first work with the Nix package manager (with which I am not very familiar, since I don't use NixOS). Please let me know if the placement of my package in the Nix tree is proper or not.

I'm using a git revision due to some changes since the latest tagged release of [`exa`](https://github.com/ogham/exa) that make compilation possible without a beta or nightly Rust.

I have also added myself as a maintainer, as I'd like to continue to maintain future releases of this package.

The `exa` issue regarding the addition of this package may be seen at https://github.com/ogham/exa/issues/98.
