### PR TITLE
Bump tint2 to 0.12

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,30 +1,41 @@
 { stdenv, fetchurl, pkgconfig, cmake, pango, cairo, glib, imlib2, libXinerama
 , libXrender, libXcomposite, libXdamage, libX11, libXrandr, gtk, libpthreadstubs
-, libXdmcp
+, libXdmcp, librsvg, fetchgit
 }:
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.11";
+  version = "0.12";
 
-  src = fetchurl {
-    url = "http://tint2.googlecode.com/files/${name}.tar.bz2";
-    sha256 = "07a74ag7lhc6706z34zvqj2ikyyl7wnzisfxpld67ljpc1m6w47y";
+  src = fetchgit {
+    url = "https://gitlab.com/o9000/tint2.git";
+    rev = version;
+    sha256 = "0pd84ydpqz2l6gkhj565nqi2xyiph8zfpn4xha60xshqpsg3pqjq";
   };
         
   buildInputs = [ pkgconfig cmake pango cairo glib imlib2 libXinerama
     libXrender libXcomposite libXdamage libX11 libXrandr gtk libpthreadstubs
-    libXdmcp
+    libXdmcp librsvg
   ];
 
-  preConfigure = "substituteInPlace CMakeLists.txt --replace /etc $out/etc";
+  preConfigure =
+    ''
+      substituteInPlace CMakeLists.txt --replace /etc $out/etc
+    '';
+  prePatch =
+    ''
+      substituteInPlace ./src/tint2conf/properties.c --replace /usr/share/ /run/current-system/sw/share/
+      substituteInPlace ./src/launcher/apps-common.c --replace /usr/share/ /run/current-system/sw/share/
+      substituteInPlace ./src/launcher/icon-theme-common.c --replace /usr/share/ /run/current-system/sw/share/
+    '';
 
   cmakeFlags = [
     "-DENABLE_TINT2CONF=0"
+    "-DENABLE_SN=0"
   ];
 
   meta = {
-    homepage = http://code.google.com/p/tint2;
+    homepage = https://gitlab.com/o9000/tint2;
     license = stdenv.lib.licenses.gpl2;
     description = "A simple panel/taskbar unintrusive and light (memory / cpu / aestetic)";
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
This is my first pull request to nixpkgs, so be gentle!

The version of tint2 currently in nixpkgs was 0.11, but 0.12 has been out for a while now. Also, tint2 has moved from Google Code to GitLab, so I changed the home page URL.

I used substituteInPlace to modify the references to /usr/share, because AFAICT, NixOS uses a different set of directories. Not sure if hard coding the NixOS choices is the right thing to do here, but it works.
