### PR TITLE
chromium/plugins: Fix widevine substitution

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -80,7 +80,7 @@ let
       wvName = "Widevine Content Decryption Module";
       wvDescription = "Playback of encrypted HTML audio/video content";
       wvMimeTypes = "application/x-ppapi-widevine-cdm";
-      wvModule = "$widevine/lib/libwidevinecdmadapter.so";
+      wvModule = "@widevine@/lib/libwidevinecdmadapter.so";
       wvInfo = "#${wvName}#${wvDescription};${wvMimeTypes}";
     in ''
       flashVersion="$(


### PR DESCRIPTION
Fixes: #12840
Related to: 61042a5b6ac89166180b9257fa72c478439d3753

61042a5 changes the replaced token from `$something` to `@something@`. This commit repeats that change in one additional location used by the WideVine plugin

cc: @aszlig 
