### PR TITLE
rethinkdb: 2.1.3 -> 2.2.4

### DIFF
--- a/pkgs/servers/nosql/rethinkdb/default.nix
+++ b/pkgs/servers/nosql/rethinkdb/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "rethinkdb-${version}";
-  version = "2.1.3";
+  version = "2.2.4";
 
   src = fetchurl {
     url = "http://download.rethinkdb.com/dist/${name}.tgz";
-    sha256 = "03w9fq3wcvwy04b3x6zb3hvwar7b9jfbpq77rmxdlgh5w64vvgwd";
+    sha256 = "0zs07g7arrrvm85mqbkffyzgd255qawn64r6iqdws25lj1kq2qim";
   };
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
Tested locally with a few tables and inserts/deletes.

```
[nix-shell:~/git/nixpkgs]$ rethinkdb --version
rethinkdb 2.2.4 (GCC 4.9.3)

[nix-shell:~/git/nixpkgs]$ rethinkdb 
Recursively removing directory /home/kragniz/git/nixpkgs/rethinkdb_data/tmp
Initializing directory /home/kragniz/git/nixpkgs/rethinkdb_data
Running rethinkdb 2.2.4 (GCC 4.9.3)...
Running on Linux 4.4.0 x86_64
Loading data from directory /home/kragniz/git/nixpkgs/rethinkdb_data
Listening for intracluster connections on port 29015
Listening for client driver connections on port 28015
Listening for administrative HTTP connections on port 8080
Listening on addresses: 127.0.0.1, ::1
To fully expose RethinkDB on the network, bind to all addresses by running rethinkdb with the `--bind all` command line option.
Server ready, "lambda_lol_v2w" e02951d7-7c7c-4d78-9ded-92a4e14d2159
warn: Problem when checking for new versions of RethinkDB: HTTP request to update.rethinkdb.com failed.
^CServer got SIGINT from pid 0, uid 0; shutting down...
Shutting down client connections...
All client connections closed.
Shutting down storage engine... (This may take a while if you had a lot of unflushed data in the writeback cache.)
Storage engine shut down.

[nix-shell:~/git/nixpkgs]$
```
