### PR TITLE
pijul: 0.2-6ab9ba

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,21 +1,31 @@
-{ stdenv, fetchdarcs, ocaml, findlib, cryptokit, yojson, lmdb, zlib }:
+{ stdenv, fetchdarcs, rustUnstable, openssl, libssh }:
 
-stdenv.mkDerivation rec {
+with rustUnstable;
+
+buildRustPackage rec {
   name = "pijul-${version}";
-  version = "0.1";
+  version = "0.2-6ab9ba";
 
   src = fetchdarcs {
     url = "http://pijul.org/";
-    rev = version;
-    sha256 = "0r189xx900w4smq6nyy1wnrjf9sgqrqw5as0l7k6gq0ra36szzff";
+    context = ./pijul.org.context;
+    sha256 = "1cgkcr5wdkwj7s0rda90bfchbwmchgi60w5d637894w20hkplsr4";
   };
 
-  buildInputs = [ ocaml findlib cryptokit yojson lmdb zlib ];
+  sourceRoot = "fetchdarcs/pijul";
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp pijul $out/bin/
+  depsSha256 = "110bj2lava1xs75z6k34aip7zb7rcmnxk5hmiyi32i9hs0ddsdrz";
+
+  cargoUpdateHook = ''
+    cp -r ../libpijul src/
   '';
+
+  setSourceRoot = ''
+    chmod -R u+w "$sourceRoot"
+    cp -r "$sourceRoot"/../libpijul "$sourceRoot"/src/
+  '';
+
+  buildInputs = [ openssl libssh ];
 
   meta = with stdenv.lib; {
     homepage = https://pijul.org/;

--- a/pkgs/applications/version-management/pijul/pijul.org.context
+++ b/pkgs/applications/version-management/pijul/pijul.org.context
@@ -1,0 +1,92 @@
+
+Context:
+
+[+libpijul/Cargo.lock
+pe@pijul.org**20160212063509
+ Ignore-this: e5a696b13850b36668a41aedb7bd1b74
+] 
+
+[+pijul/Cargo.lock
+pe@pijul.org**20160212063451
+ Ignore-this: a621a502d1701cb63e6b5c8fd0afbde8
+] 
+
+[Error detection, gnupg messages
+pe@pijul.org**20160210101417
+ Ignore-this: 3c517e122c1eca1df9520aed8fd3b0ea
+] 
+
+[Login command
+pe@pijul.org**20160210055826
+ Ignore-this: 7be5618dc418554a82c5f8a68cc8f515
+] 
+
+[Extra functions for the nest
+pe@pijul.org**20160208205519
+ Ignore-this: 39c8cbed5517b31bc846493e6ffefc76
+] 
+
+[Timestamp in RFC3339
+pe@pijul.org**20160208145551
+ Ignore-this: dd114fe418052570572d73e443683d85
+] 
+
+[Combined external_hash and contents in libpijul (makes it easier to print patches)
+pe@pijul.org**20160208145450
+ Ignore-this: 69f588e1bab551bffd719fa05ad7080a
+] 
+
+[disentangle output in libpijul
+florent.becker@ens-lyon.org**20160208094544
+ Ignore-this: 2dc35255cf48d77eb0c4ba2dde6d4f98
+] 
+
+[Disentangle libpijul::Repository::local_diff
+florent.becker@ens-lyon.org**20160207104631
+ Ignore-this: 65b119358afa95eb013e84c0d7a250d9
+] 
+
+[remove redundant import
+florent.becker@ens-lyon.org**20160207104613
+ Ignore-this: e3f7873ec678f62f4129be61238c2c0d
+] 
+
+[Disentangle add_lines and delete_lines in diff
+florent.becker@ens-lyon.org**20160207102456
+ Ignore-this: 5e89908adf7a519bbe2b2ab399cf0a2
+] 
+
+[Disentangle libpijul::rec_delete
+florent.becker@ens-lyon.org**20160206214730
+ Ignore-this: fb6a70c298a38724665c3d6452577649
+] 
+
+[Make InternalKey type be an array rather than a reference
+florent.becker@ens-lyon.org**20160205195638
+ Ignore-this: f9b5d15049358b2d8e93322d25a50e58
+] 
+
+[Ask ssh known_hosts, and new file format
+pe@pijul.org**20160207120834
+ Ignore-this: f7a7f2ae672a3f6f40a2ac85139d6e10
+] 
+
+[Handling HTTP errors (when cloning from HTTP)
+pe@pijul.org**20160204182444
+ Ignore-this: 1805ae8d3b8a4ca49da06e18dd37b151
+] 
+
+[Small debugging assertions
+pe@pijul.org**20160203143007
+ Ignore-this: e3d3dddc72511166d606e1751b19411b
+] 
+
+[Two unused functions back (used in the nest)
+pe@pijul.org**20160202075743
+ Ignore-this: 8c6904b122c8a78bfa0b9cc5416c943
+] 
+
+[TAG 0.2
+pe@pijul.org**20160202073939
+ Ignore-this: 1e9d04d5ffe231ffaccaf9c4ccb684d3
+] 

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -75,7 +75,7 @@ in stdenv.mkDerivation (args // {
     (
         set -euo pipefail
 
-        cd ../deps/registry/src/*
+        cd $NIX_BUILD_TOP/deps/registry/src/*
 
         for script in $patchRegistryDeps/*; do
           # Run in a subshell so that directory changes and shell options don't

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12862,9 +12862,7 @@ let
 
   pig = callPackage ../applications/networking/cluster/pig { };
 
-  pijul = callPackage ../applications/version-management/pijul {
-    inherit (ocamlPackages) findlib cryptokit yojson;
-  };
+  pijul = callPackage ../applications/version-management/pijul { };
 
   playonlinux = callPackage ../applications/misc/playonlinux {
      stdenv = stdenv_32bit;


### PR DESCRIPTION
pijul 0.1 broke due to the repo disappearing and reappearing for a rewrite in Rust.

See #12924 for details. 6ab9ba was given by the Pijul maintainer to use.

This was not a straightforward upgrade. I had to fix `buildRustPackage` not working with a nested `sourceRoot`. Sadly I think this is going to cause a rebuild for all the Rust things!
