### PR TITLE
Fix OMake source URL

### DIFF
--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "${webpage}/downloads/${pname}-${version}.tar.gz";
+    url = "http://pkgs.fedoraproject.org/repo/pkgs/ocaml-omake/${pname}-${version}.tar.gz/fe39a476ef4e33b7ba2ca77a6bcaded2/${pname}-${version}.tar.gz";
     sha256 = "1sas02pbj56m7wi5vf3vqrrpr4ynxymw2a8ybvfj2dkjf7q9ii13";
   };
   patchFlags = "-p0";


### PR DESCRIPTION
Current source is 404, moving to pkgs.fedoraproject.org mirror.

Should fix current aborted jobs on Hydra: http://hydra.nixos.org/eval/1237311#tabs-aborted
