### PR TITLE
dropbox: 3.12.6 -> 3.14.7

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -20,11 +20,11 @@
 
 let
   # NOTE: When updating, please also update in current stable, as older versions stop working
-  version = "3.14.5";
+  version = "3.14.7";
   sha256 =
     {
-      "x86_64-linux" = "02yjc910j3m61yd19akfv5yxh0a06cqwx2rxb2xhdbf1cb6c2wdg";
-      "i686-linux" = "0aqni6gsnbmshczxwn10qbp43qqnprxr18spx7dc9cz9cq27rgrv";
+      "x86_64-linux" = "1pwmghpr0kyca2biysyk90kk9k6ffv4i95vs5rq96vc0zbckws6n";
+      "i686-linux" = "08yqrxh09cfd80kbiq1f2sirx9s85acij4khpklvvwrnf2x1i1zm";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -20,11 +20,11 @@
 
 let
   # NOTE: When updating, please also update in current stable, as older versions stop working
-  version = "3.12.6";
+  version = "3.14.5";
   sha256 =
     {
-      "x86_64-linux" = "16d0g9bygvaixv4r42p72z6a6wqhkf5qzb058lijih93zjr8zjlj";
-      "i686-linux" = "1pgqz6axzzyaahql01g0l80an39hd9j4dnq0vfavwvb2qkb27dph";
+      "x86_64-linux" = "02yjc910j3m61yd19akfv5yxh0a06cqwx2rxb2xhdbf1cb6c2wdg";
+      "i686-linux" = "0aqni6gsnbmshczxwn10qbp43qqnprxr18spx7dc9cz9cq27rgrv";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13380,7 +13380,7 @@ let
 
   copy-com = callPackage ../applications/networking/copy-com { };
 
-  dropbox = qt5.callPackage ../applications/networking/dropbox { };
+  dropbox = qt55.callPackage ../applications/networking/dropbox { };
 
   dropbox-cli = callPackage ../applications/networking/dropbox-cli { };
 


### PR DESCRIPTION
Also updates qt5 dependency to qt55, as per release notes: https://www.dropboxforum.com/hc/en-us/community/posts/205672126-Release-Candidate-3-14-5
