### PR TITLE
inkscape: add numpy to runtime path

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, perl, perlXMLParser, gtk, libXft
 , libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm
 , glibmm, libsigcxx, lcms, boost, gettext, makeWrapper, intltool
-, gsl, python, pyxml, lxml, poppler, imagemagick, libwpg, librevenge
+, gsl, python, numpy, pyxml, lxml, poppler, imagemagick, libwpg, librevenge
 , libvisio, libcdr, libexif, unzip
 , boxMakerPlugin ? false # boxmaker plugin
 }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     # Python is used at run-time to execute scripts, e.g., those from
     # the "Effects" menu.
-    python pyxml lxml
+    python pyxml numpy lxml
   ];
 
   buildInputs = [
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     for i in "$out/bin/"*
     do
       wrapProgram "$i" --prefix PYTHONPATH :      \
-       "$(toPythonPath ${pyxml}):$(toPythonPath ${lxml})"  \
+       "$(toPythonPath ${pyxml}):$(toPythonPath ${lxml}):$(toPythonPath ${numpy})"  \
        --prefix PATH : ${python}/bin ||  \
         exit 2
     done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12420,7 +12420,7 @@ let
   inferno = callPackage_i686 ../applications/inferno { };
 
   inkscape = callPackage ../applications/graphics/inkscape {
-    inherit (pythonPackages) lxml;
+    inherit (pythonPackages) python pyxml lxml numpy;
     lcms = lcms2;
   };
 


### PR DESCRIPTION
This is fixes at least one plugin, depending on numpy. Also, pyxml is instantiated with the same python interpreter as the one used in inkscape.
