### PR TITLE
Make local udev rules higher prioritized

### DIFF
--- a/nixos/doc/manual/release-notes/rl-unstable.xml
+++ b/nixos/doc/manual/release-notes/rl-unstable.xml
@@ -172,6 +172,13 @@ fileSystems."/example" = {
     </para>
   </listitem>
 
+  <listitem>
+    <para><literal>services.udev.extraRules</literal> option now writes rules
+    to <filename>99-local.rules</filename> instead of <filename>10-local.rules</filename>.
+    This makes all the user rules apply after others, so their results wouldn't be
+    overriden by anything else.</para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -13,13 +13,13 @@ let
   extraUdevRules = pkgs.writeTextFile {
     name = "extra-udev-rules";
     text = cfg.extraRules;
-    destination = "/etc/udev/rules.d/10-local.rules";
+    destination = "/etc/udev/rules.d/99-local.rules";
   };
 
   extraHwdbFile = pkgs.writeTextFile {
     name = "extra-hwdb-file";
     text = cfg.extraHwdb;
-    destination = "/etc/udev/hwdb.d/10-local.hwdb";
+    destination = "/etc/udev/hwdb.d/99-local.hwdb";
   };
 
   nixosRules = ''
@@ -212,8 +212,8 @@ in
         type = types.lines;
         description = ''
           Additional <command>udev</command> rules. They'll be written
-          into file <filename>10-local.rules</filename>. Thus they are
-          read before all other rules.
+          into file <filename>99-local.rules</filename>. Thus they are
+          read and applied after all other rules.
         '';
       };
 


### PR DESCRIPTION
I've spent some time debugging why wouldn't my udev rule work until I noticed that the rules won't apply because some other ones later override them. I wouldn't expect that user-defined rules would be overridden by anything. This could be changed by naming rules' files `99-local.{rules,hwdb}` which I did and it fixed my issue. I don't have good knowledge of udev so this might not actually be a good idea. cc @edolstra as one who reviewed my udev changes before.

EDIT: added some sense -- I shouldn't make PRs laaate in the night ^^".
