### PR TITLE
mopidy-spotify: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/applications/audio/mopidy-spotify/default.nix
+++ b/pkgs/applications/audio/mopidy-spotify/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonPackage rec {
   name = "mopidy-spotify-${version}";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchurl {
     url = "https://github.com/mopidy/mopidy-spotify/archive/v${version}.tar.gz";
-    sha256 = "0wrrkkrin92ad9k1rwgjbyv2whwrb5b66nmmykxxp6bqcdgdyl5i";
+    sha256 = "0g105kb27q1p8ssrbxkxcjgx9jkqnd9kk5smw8sjcx6f3b23wrwx";
   };
 
   propagatedBuildInputs = [ mopidy pythonPackages.pyspotify ];


### PR DESCRIPTION
## v2.3.1 (2016-02-14)

Bug fix release.
- Require Mopidy < 2 as Mopidy 2.0 breaks the audio API with the upgrade to
  GStreamer 1.
- Use the new Spotify Web API for search. Searching through libspotify has been
  discontinued and is not working anymore. (Fixes: #89)
- Note that search through the Spotify Web API doesn't return artists or date
  for albums. This also means that `library.get_distinct()` when given type
  `albumartist` or `date` and a query only returns an empty set.
- Emit a warning if config value `spotify/search_album_count`,
  `spotify/search_artist_count`, or `spotify/search_track_count` is greater
  than 50, and use 50 instead. 50 is the maximum value that the Spotify Web API
  allows. The maximum in the config schema is not changed to not break existing
  configs.
## v2.3.0 (2016-02-06)

Feature release.
- Ignore all audio data deliveries from libspotify when when a seek is in
  progress. This ensures that we don't deliver audio data from before the seek
  with timestamps from after the seek.
- Ignore duplicate end of track callbacks.
- Don't increase the audio buffer timestamp if the buffer is rejected by
  Mopidy. This caused audio buffers delivered after one or more rejected audio
  buffers to have too high timestamps.
- When changing tracks, block until Mopidy completes the appsrc URI change.
  Not blocking here might break gapless playback.
- Lookup of a playlist you're not subscribed to will now properly load all of
  the playlist's tracks. (Fixes: #81, PR: #82)
- Workaround teardown race outputing lots of short stack traces on Mopidy
  shutdown. (See #73 for details)
