### PR TITLE
pythonPackages.keyring: 3.3 -> 8.4.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10431,15 +10431,19 @@ in modules // {
 
 
   keyring = buildPythonPackage rec {
-    name = "keyring-3.3";
+    name = "keyring-8.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/keyring/${name}.zip";
-      md5 = "81291e0c7337affb71442e6c7671e77f";
+      url = "https://pypi.python.org/packages/source/k/keyring/${name}.tar.gz";
+      sha256 = "1286sh5g53168qxbl4g5bmns9ci0ld0jl3h44b7h8is5nw1421ar";
     };
 
     buildInputs = with self;
-      [ fs gdata python_keyczar mock pyasn1 pycrypto pytest six ];
+      [ fs gdata python_keyczar mock pyasn1 pycrypto pytest_28 six setuptools_scm pytestrunner ];
+
+    checkPhase = ''
+      py.test $out
+    '';
 
     meta = {
       description = "Store and access your passwords safely";


### PR DESCRIPTION
This won't build, but I don't understand why. Can somebody please help me? Error message is:

```
[...]
============================= test session starts ==============================
platform linux -- Python 3.4.4, pytest-2.8.6, py-1.4.31, pluggy-0.3.1
rootdir: /tmp/nix-build-python3.4-keyring-8.4.1.drv-6/keyring-8.4.1, inifile: pytest.ini
collected 40 items / 1 errors

keyring/core.py .
keyring/py33compat.py .
keyring/backends/fail.py .
keyring/tests/backends/test_OS_X.py ssssssss.
keyring/tests/backends/test_SecretService.py ssssssss.
keyring/tests/backends/test_Windows.py ssssssss
keyring/tests/backends/test_kwallet.py ssssssss
keyring/util/__init__.py .
keyring/util/properties.py ..

==================================== ERRORS ====================================
______________________ ERROR collecting nix_run_setup.py _______________________
/nix/store/7gwsaqlkznlss7krpka08d1mf2w8zinb-python3.4-py-1.4.31/lib/python3.4/site-packages/py/_path/local.py:668: in pyimport
    raise self.ImportMismatchError(modname, modfile, self)
E   py._path.local.ImportMismatchError: ('nix_run_setup', 'setup.py', local('/tmp/nix-build-python3.4-keyring-8.4.1.drv-6/keyring-8.4.1/nix_run_setup.py'))
================ 8 passed, 32 skipped, 1 error in 0.22 seconds =================
note: keeping build directory ‘/tmp/nix-build-python3.4-keyring-8.4.1.drv-6’
builder for ‘/nix/store/kipch2wpsz4rks3xy6r1xi4b19xvrl1w-python3.4-keyring-8.4.1.drv’ failed with exit code 1
error: build of ‘/nix/store/kipch2wpsz4rks3xy6r1xi4b19xvrl1w-python3.4-keyring-8.4.1.drv’ failed
```
