### PR TITLE
pythonPackages.fs: fix to make it work on Python3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8958,9 +8958,6 @@ in modules // {
       ${python.interpreter} -m unittest discover
     '';
 
-    # Judging from SyntaxError
-    disabled = isPy3k;
-
     # Lots of errors. Likely due to being in a chroot
     doCheck = false;
 


### PR DESCRIPTION
pyfilesystem is supposed to work on Python3 https://github.com/PyFilesystem/pyfilesystem/issues/246
