### PR TITLE
OctoPrint and plugins and support for M3D Micro 3D-printer

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -251,6 +251,7 @@
       cfdyndns = 227;
       gammu-smsd = 228;
       pdnsd = 229;
+      octoprint = 230;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -478,6 +479,7 @@
       rmilter = 226;
       cfdyndns = 227;
       pdnsd = 229;
+      octoprint = 230;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -229,6 +229,7 @@
   ./services/misc/nix-gc.nix
   ./services/misc/nixos-manual.nix
   ./services/misc/nix-ssh-serve.nix
+  ./services/misc/octoprint.nix
   ./services/misc/parsoid.nix
   ./services/misc/phd.nix
   ./services/misc/plex.nix

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.octoprint;
+
+  cfgUpdate = pkgs.writeText "octoprint-config.yaml" (builtins.toJSON {
+    plugins.cura.cura_engine = "${pkgs.curaengine}/bin/CuraEngine";
+    server.host = cfg.host;
+    server.port = cfg.port;
+    webcam.ffmpeg = "${pkgs.ffmpeg}/bin/ffmpeg";
+  });
+
+  pluginsEnv = pkgs.python.buildEnv.override {
+    extraLibs = cfg.plugins pkgs.octoprint-plugins;
+  };
+
+in
+{
+  ##### interface
+
+  options = {
+
+    services.octoprint = {
+
+      enable = mkEnableOption "OctoPrint, web interface for 3D printers";
+
+      host = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = ''
+          Host to bind OctoPrint to.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 5000;
+        description = ''
+          Port to bind OctoPrint to.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "octoprint";
+        description = "User for the daemon.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "octoprint";
+        description = "Group for the daemon.";
+      };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/octoprint";
+        description = "State directory of the daemon.";
+      };
+
+      plugins = mkOption {
+        default = plugins: [];
+        example = literalExample "plugins: [ m3d-fio ]";
+        description = "Additional plugins.";
+      };
+
+    };
+
+  };
+
+  ##### implementation
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers = optionalAttrs (cfg.user == "octoprint") (singleton
+      { name = "octoprint";
+        group = cfg.group;
+        uid = config.ids.uids.octoprint;
+      });
+
+    users.extraGroups = optionalAttrs (cfg.group == "octoprint") (singleton
+      { name = "octoprint";
+        gid = config.ids.gids.octoprint;
+      });
+
+    systemd.services.octoprint = {
+      description = "OctoPrint, web interface for 3D printers";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = [ pluginsEnv ];
+      environment.PYTHONPATH = makeSearchPath pkgs.python.sitePackages [ pluginsEnv ];
+
+      preStart = ''
+        mkdir -p "${cfg.stateDir}"
+        if [ -e "${cfg.stateDir}/config.yaml" ]; then
+          ${pkgs.yaml-merge}/bin/yaml-merge "${cfg.stateDir}/config.yaml" "${cfgUpdate}" > "${cfg.stateDir}/config.yaml.tmp"
+          mv "${cfg.stateDir}/config.yaml.tmp" "${cfg.stateDir}/config.yaml"
+        else
+          cp "${cfgUpdate}" "${cfg.stateDir}/config.yaml"
+          chmod 600 "${cfg.stateDir}/config.yaml"
+        fi
+        chown -R ${cfg.user}:${cfg.group} "${cfg.stateDir}"
+      '';
+
+      serviceConfig = {
+        ExecStart = "${pkgs.octoprint}/bin/octoprint -b ${cfg.stateDir}";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+      };
+    };
+
+  };
+
+}

--- a/pkgs/applications/misc/octoprint/0001-Don-t-use-static-library.patch
+++ b/pkgs/applications/misc/octoprint/0001-Don-t-use-static-library.patch
@@ -1,0 +1,113 @@
+From 73ff28c3ee5b737303871268a5487db0fcffc0f6 Mon Sep 17 00:00:00 2001
+From: Nikolay Amiantov <ab@fmap.me>
+Date: Wed, 17 Feb 2016 14:37:31 +0300
+Subject: [PATCH 1/2] Don't use static library
+
+---
+ octoprint_m3dfio/__init__.py   | 67 +-----------------------------------------
+ shared library source/Makefile |  6 ++--
+ 2 files changed, 5 insertions(+), 68 deletions(-)
+
+diff --git a/octoprint_m3dfio/__init__.py b/octoprint_m3dfio/__init__.py
+index 5e5369b..9f59768 100644
+--- a/octoprint_m3dfio/__init__.py
++++ b/octoprint_m3dfio/__init__.py
+@@ -764,72 +764,7 @@ class M3DFioPlugin(
+ 		# Set file locations
+ 		self.setFileLocations()
+ 		
+-		# Check if running on Linux
+-		if platform.uname()[0].startswith("Linux") :
+-		
+-			# Check if running on a Raspberry Pi
+-			if platform.uname()[4].startswith("armv6l") and self.getCpuHardware() == "BCM2708" :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_arm1176jzf-s.so")
+-			
+-			# Otherwise check if running on a Raspberry Pi 2
+-			elif platform.uname()[4].startswith("armv7l") and self.getCpuHardware() == "BCM2709" :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_arm_cortex-a7.so")
+-			
+-			# Otherwise check if running on an ARM7 device
+-			elif platform.uname()[4].startswith("armv7") :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_arm7.so")
+-			
+-			# Otherwise check if using an i386 or x86-64 device
+-			elif platform.uname()[4].endswith("86") or platform.uname()[4].endswith("64") :
+-		
+-				# Check if Python is running as 32-bit
+-				if platform.architecture()[0].startswith("32") :
+-				
+-					# Set shared library
+-					self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_i386.so")
+-			
+-				# Otherwise check if Python is running as 64-bit
+-				elif platform.architecture()[0].startswith("64") :
+-				
+-					# Set shared library
+-					self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_x86-64.so")
+-		
+-		# Otherwise check if running on Windows and using an i386 or x86-64 device
+-		elif platform.uname()[0].startswith("Windows") and (platform.uname()[4].endswith("86") or platform.uname()[4].endswith("64")) :
+-		
+-			# Check if Python is running as 32-bit
+-			if platform.architecture()[0].startswith("32") :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_i386.dll")
+-		
+-			# Otherwise check if Python is running as 64-bit
+-			elif platform.architecture()[0].startswith("64") :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_x86-64.dll")
+-		
+-		# Otherwise check if running on OS X and using an i386 or x86-64 device
+-		elif platform.uname()[0].startswith("Darwin") and (platform.uname()[4].endswith("86") or platform.uname()[4].endswith("64")) :
+-		
+-			# Check if Python is running as 32-bit
+-			if platform.architecture()[0].startswith("32") :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_i386.dylib")
+-		
+-			# Otherwise check if Python is running as 64-bit
+-			elif platform.architecture()[0].startswith("64") :
+-			
+-				# Set shared library
+-				self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/static/libraries/preprocessor_x86-64.dylib")
+-		
++		self.sharedLibrary = ctypes.cdll.LoadLibrary(self._basefolder.replace('\\', '/') + "/../../../libpreprocessor.so")
+ 		# Check if shared library was set
+ 		if self.sharedLibrary :
+ 		
+diff --git a/shared library source/Makefile b/shared library source/Makefile
+index 4062a91..89dab71 100644
+--- a/shared library source/Makefile	
++++ b/shared library source/Makefile	
+@@ -58,13 +58,15 @@ ifeq ($(TARGET_PLATFORM), OSX64)
+ 	CFLAGS = -fPIC -m64 -stdlib=libc++ -O3 -Wl,-install_name,$(PROG)$(VER)
+ endif
+ 
++PROG = lib$(LIBRARY_NAME).so
++CC = g++
+ SRCS = preprocessor.cpp gcode.cpp vector.cpp
+-CFLAGS += -Wall -std=c++11 -fvisibility=hidden -shared
++CFLAGS = -O3 -fPIC -Wall -std=c++11 -fvisibility=hidden -shared
+ 
+ all: $(PROG)
+ 
+ $(PROG):   $(SRCS)
+-	$(CC) $(CFLAGS) -o ../octoprint_m3dfio/static/libraries/$(PROG) $(SRCS)
++	$(CC) $(CFLAGS) -o $(PROG) $(SRCS)
+ 
+ clean:
+ 	rm -f ../octoprint_m3dfio/static/libraries/$(PROG)
+-- 
+2.7.0
+

--- a/pkgs/applications/misc/octoprint/0002-Try-to-create-connection-several-times-if-printer-is.patch
+++ b/pkgs/applications/misc/octoprint/0002-Try-to-create-connection-several-times-if-printer-is.patch
@@ -1,0 +1,57 @@
+From b99fc3fd012765c5b3d8ac7a3f64762af5121b4a Mon Sep 17 00:00:00 2001
+From: Nikolay Amiantov <ab@fmap.me>
+Date: Wed, 17 Feb 2016 15:47:34 +0300
+Subject: [PATCH 2/2] Try to create connection several times if printer is not
+ yet available
+
+---
+ octoprint_m3dfio/__init__.py | 25 ++++++++++++++++++++++---
+ 1 file changed, 22 insertions(+), 3 deletions(-)
+
+diff --git a/octoprint_m3dfio/__init__.py b/octoprint_m3dfio/__init__.py
+index 9f59768..e7d97eb 100644
+--- a/octoprint_m3dfio/__init__.py
++++ b/octoprint_m3dfio/__init__.py
+@@ -3421,8 +3421,16 @@ class M3DFioPlugin(
+ 						# Set updated port
+ 						currentPort = self.getPort()
+ 					
+-						# Re-connect
+-						connection = serial.Serial(currentPort, currentBaudrate)
++						# Re-connect; wait for the device to be available
++                                                connection = None
++                                                for i in range(1, 5):
++						        try:
++                                                                connection = serial.Serial(currentPort, currentBaudrate)
++                                                                break
++                                                        except OSError:
++                                                                time.sleep(1)
++                                                if connection is None:
++                                                        raise Exception("Couldn't reconnect to the printer")
+ 				
+ 					# Check if getting EEPROM was successful
+ 					if self.getEeprom(connection) :
+@@ -6799,8 +6807,19 @@ class M3DFioPlugin(
+ 		# Set state to connecting
+ 		comm_instance._log("Connecting to: " + str(port))
+ 		
++                # Create a connection
++                connection = None
++                for i in range(1, 5):
++                        try:
++                                connection = serial.Serial(str(port), baudrate)
++                        # If printer has just power-cycled it may not yet be ready
++                        except OSError:
++                                time.sleep(1)
++                if connection is None:
++                        raise Exception("Couldn't reconnect to the printer")
++
+ 		# Return connection
+-		return serial.Serial(str(port), baudrate)
++		return connection
+ 	
+ 	# Disable sleep
+ 	def disableSleep(self) :
+-- 
+2.7.0
+

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "OctoPrint-${version}";
+  version = "1.2.9";
+
+  src = fetchFromGitHub {
+    owner = "foosel";
+    repo = "OctoPrint";
+    rev = version;
+    sha256 = "00hhq52jqwykhk3p57mn9kkcjbjz6g9mcrp96vx8lqzhw42m3a86";
+  };
+
+  # We need old Tornado
+  propagatedBuildInputs = with pythonPackages; [
+    awesome-slugify flask_assets watchdog rsa requests2 pkginfo pylru
+    semantic-version flask_principal sarge tornado_4_0_1 werkzeug netaddr flaskbabel
+    netifaces psutil pyserial flask_login pyyaml sockjs-tornado
+  ];
+
+  postPatch = ''
+    # Jailbreak dependencies
+    sed -i \
+      -e 's,rsa==,rsa>=,g' \
+      -e 's,sockjs-tornado==,sockjs-tornado>=,g' \
+      -e 's,Flask-Principal==,Flask-Principal>=,g' \
+      -e 's,werkzeug==,werkzeug>=,g' \
+      -e 's,netaddr==,netaddr>=,g' \
+      -e 's,requests==,requests>=,g' \
+      -e 's,netifaces==,netifaces>=,g' \
+      -e 's,psutil==,psutil>=,g' \
+      -e 's,PyYAML==,PyYAML>=,g' \
+      setup.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://octoprint.org/;
+    description = "The snappy web interface for your 3D printer";
+    platforms = platforms.all;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -60,4 +60,24 @@ in {
     };
   };
 
+  stlviewer = buildPlugin rec {
+    name = "OctoPrint-STLViewer-${version}";
+    version = "0.3.0";
+
+    src = fetchFromGitHub {
+      owner = "jneilliii";
+      repo = "OctoPrint-STLViewer";
+      rev = "v${version}";
+      sha256 = "1a6sa8pw9ay7x27pfwr3nzb22x3jaw0c9vwyz4mrj76zkiw6svfi";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/jneilliii/Octoprint-STLViewer;
+      description = "A simple stl viewer tab for OctoPrint";
+      platforms = platforms.all;
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
 }

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, octoprint, pythonPackages }:
+
+let
+  buildPlugin = args: pythonPackages.buildPythonPackage (args // {
+    buildInputs = (args.buildInputs or []) ++ [ octoprint ];
+  });
+in {
+
+  m3d-fio = buildPlugin rec {
+    name = "M3D-Fio-${version}";
+    version = "0.26";
+
+    src = fetchFromGitHub {
+      owner = "donovan6000";
+      repo = "M3D-Fio";
+      rev = "V${version}";
+      sha256 = "1dl8m0cxp2vzla2a729r3jrq5ahxkj10pygp7m9bblj5nn2s0rll";
+    };
+
+    patches = [
+      ./0001-Don-t-use-static-library.patch
+      ./0002-Try-to-create-connection-several-times-if-printer-is.patch
+    ];
+
+    postInstall = ''
+    (
+      cd 'shared library source'
+      make
+      install -Dm755 libpreprocessor.so $out/lib/libpreprocessor.so
+    )
+    rm -rf $out/${pythonPackages.python.sitePackages}/octoprint_m3dfio/static/libraries
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/donovan6000/M3D-Fio;
+      description = " OctoPrint plugin for the Micro 3D printer";
+      platforms = platforms.all;
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
+}

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -40,4 +40,24 @@ in {
     };
   };
 
+  titlestatus = buildPlugin rec {
+    name = "OctoPrint-TitleStatus-${version}";
+    version = "0.0.2";
+
+    src = fetchFromGitHub {
+      owner = "MoonshineSG";
+      repo = "OctoPrint-TitleStatus";
+      rev = version;
+      sha256 = "0rfbpxbcmadyihcrynh6bjywy3yqnzsnjn3yiwifisbrjgpm6sfw";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/MoonshineSG/OctoPrint-TitleStatus;
+      description = "Show printers status in window title";
+      platforms = platforms.all;
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
 }

--- a/pkgs/misc/drivers/m3d-linux/default.nix
+++ b/pkgs/misc/drivers/m3d-linux/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "M3D-Linux-2016-01-20";
+
+  src = fetchFromGitHub {
+    owner = "donovan6000";
+    repo = "M3D-Linux";
+    rev = "d0bbb0379c52a88af55740a937edc92af162cdf6";
+    sha256 = "0fwzb9mf04bw5wxabh3js7nir60kfq8iz7kcigw6c233aadwg03i";
+  };
+
+  installPhase = ''
+    install -Dm755 m3d-linux $out/bin/m3d-linux
+    install -Dm755 90-m3d-local.rules $out/lib/udev/rules.d/90-m3d-local.rules
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/donovan6000/M3D-Linux;
+    description = "A Linux program that can communicate with the Micro 3D printer";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/tools/text/yaml-merge/default.nix
+++ b/pkgs/tools/text/yaml-merge/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name= "yaml-merge-2016-02-16";
+
+  src = fetchFromGitHub {
+    owner = "abbradar";
+    repo = "yaml-merge";
+    rev = "4eef7b68632d79dec369b4eff5a8c63f995f81dc";
+    sha256 = "0mwda2shk43i6f22l379fcdchmb07fm7nf4i2ii7fk3ihkhb8dgp";
+  };
+
+  pythonPath = with pythonPackages; [ pyyaml ];
+  nativeBuildInputs = [ pythonPackages.wrapPython ];
+
+  installPhase = ''
+    install -Dm755 yaml-merge.py $out/bin/yaml-merge
+    wrapPythonPrograms
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Merge YAML data files";
+    homepage = https://github.com/abbradar/yaml-merge;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12983,6 +12983,8 @@ let
     pulseaudioSupport = config.pulseaudio or true;
   };
 
+  octoprint = callPackage ../applications/misc/octoprint { };
+
   ocrad = callPackage ../applications/graphics/ocrad { };
 
   offrss = callPackage ../applications/networking/offrss { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12985,6 +12985,8 @@ let
 
   octoprint = callPackage ../applications/misc/octoprint { };
 
+  octoprint-plugins = callPackage ../applications/misc/octoprint/plugins.nix { };
+
   ocrad = callPackage ../applications/graphics/ocrad { };
 
   offrss = callPackage ../applications/networking/offrss { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3801,6 +3801,8 @@ let
 
   yank = callPackage ../tools/misc/yank { };
 
+  yaml-merge = callPackage ../tools/text/yaml-merge { };
+
   # To expose more packages for Yi, override the extraPackages arg.
   yi = callPackage ../applications/editors/yi/wrapper.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15711,6 +15711,8 @@ let
 
   lkproof = callPackage ../tools/typesetting/tex/lkproof { };
 
+  m3d-linux = callPackage ../misc/drivers/m3d-linux { };
+
   mysqlWorkbench = newScope gnome ../applications/misc/mysql-workbench {
     lua = lua5_1;
     libctemplate = libctemplate_2_2;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23572,7 +23572,7 @@ in modules // {
       sha256 = "0k7vk4k54y55ma0nx2k5s0phfqbriwslhy5shh3b0d046q7ibzaa";
     };
 
-    buildInputs = with self; [ flask jinja2 speaklater Babel pytz ];
+    propagatedBuildInputs = with self; [ flask jinja2 speaklater Babel pytz ];
 
     meta = {
       description = "Adds i18n/l10n support to Flask applications";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1167,7 +1167,6 @@ in modules // {
       colorama
       docutils
       rsa
-      pyasn1
       pkgs.groff
       pkgs.less
     ];
@@ -4751,7 +4750,7 @@ in modules // {
     doCheck = false; # requires redis server
     propagatedBuildInputs = with self; [
       setuptools docker_registry_core blinker flask gevent gunicorn pyyaml
-      requests2 rsa sqlalchemy9 setuptools backports_lzma pyasn1 m2crypto
+      requests2 rsa sqlalchemy9 setuptools backports_lzma m2crypto
     ];
 
     patchPhase = "> requirements/main.txt";
@@ -12883,7 +12882,7 @@ in modules // {
       sha256 = "0phfk6s8bgpap5xihdk1xv2lakdk1pb3rg6hp2wsg94hxcxnrakl";
     };
 
-    propagatedBuildInputs = with self; [ six httplib2 pyasn1 pyasn1-modules rsa ];
+    propagatedBuildInputs = with self; [ six httplib2 pyasn1-modules rsa ];
     doCheck = false;
 
     meta = {
@@ -18470,7 +18469,8 @@ in modules // {
       sha256 = "03f3d9bebad06681771016b8752a40b12f615ff32363c7aa19b3798e73ccd615";
     };
 
-    buildInputs = with self; [ pyasn1 unittest2 ];
+    nativeBuildInputs = with self; [ unittest2 ];
+    propagatedBuildInputs = with self; [ pyasn1 ];
 
     checkPhase = ''
       ${python.interpreter} run_tests.py

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1128,6 +1128,26 @@ in modules // {
     };
   }));
 
+  awesome-slugify = buildPythonPackage rec {
+    name = "awesome-slugify-${version}";
+    version = "1.6.5";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/a/awesome-slugify/${name}.tar.gz";
+      sha256 = "0wgxrhr8s5vk2xmcz9s1z1aml4ppawmhkbggl9rp94c747xc7pmv";
+    };
+
+    propagatedBuildInputs = with self; [ unidecode regex ];
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/dimka665/awesome-slugify;
+      description = "Python flexible slugify function";
+      license = licenses.gpl3;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   awscli = buildPythonPackage rec {
     name = "awscli-${version}";
     version = "1.10.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3651,7 +3651,6 @@ in modules // {
     };
   };
 
-
   openstackclient = buildPythonPackage rec {
     name = "openstackclient-${version}";
     version = "1.7.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8770,6 +8770,27 @@ in modules // {
     };
   };
 
+  flask_script = buildPythonPackage rec {
+    name = "Flask-Script-${version}";
+    version = "2.0.5";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/F/Flask-Script/${name}.tar.gz";
+      sha256 = "0zqh2yq8zk7m9b4xw1ryqmrljkdigfb3hk5155a3b5hkfnn6xxyf";
+    };
+
+    nativeBuildInputs = with self; [ pytest ];
+    propagatedBuildInputs = with self; [ flask ];
+
+    meta = {
+      homepage = http://github.com/smurfix/flask-script;
+      description = "Scripting support for Flask";
+      license = licenses.bsd3;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   wtforms = buildPythonPackage rec {
     version = "2.0.2";
     name = "wtforms-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10693,6 +10693,24 @@ in modules // {
     };
   };
 
+  pylru = buildPythonPackage rec {
+    name = "pylru-${version}";
+    version = "1.0.9";
+
+    src = pkgs.fetchurl {
+      url = "http://pypi.python.org/packages/source/p/pylru/${name}.tar.gz";
+      sha256 = "0b0pq0l7xv83dfsajsc49jcxzc99kb9jfx1a1dlx22hzcy962dvi";
+    };
+
+    meta = {
+      homepage = https://github.com/jlhutch/pylru;
+      description = "A least recently used (LRU) cache implementation";
+      license = licenses.gpl2;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   lazy-object-proxy = buildPythonPackage rec {
     name = "lazy-object-proxy-${version}";
     version = "1.2.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7440,6 +7440,23 @@ in modules // {
     };
   };
 
+  regex = buildPythonPackage rec {
+    name = "regex-${version}";
+    version = "2016.01.10";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/regex/${name}.tar.gz";
+      sha256 = "1q3rbmnijjzn7y3cm3qy49b5lqw1fq38zv974xma387lwc37d9q2";
+    };
+
+    meta = {
+      description = "Alternative regular expression module, to replace re";
+      homepage = https://bitbucket.org/mrabarnett/mrab-regex;
+      license = licenses.psfl;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
 
   repoze_lru = buildPythonPackage rec {
     name = "repoze.lru-0.6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8709,6 +8709,29 @@ in modules // {
     };
   };
 
+  flask_login = buildPythonPackage rec {
+    name = "Flask-Login-${version}";
+    version = "0.2.2";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/F/Flask-Login/${name}.tar.gz";
+      sha256 = "09ygn0r3i3jz065a5psng6bhlsqm78msnly4z6x39bs48r5ww17p";
+    };
+
+    propagatedBuildInputs = with self; [ flask ];
+
+    # FIXME
+    doCheck = false;
+
+    meta = {
+      homepage = http://github.com/miracle2k/flask-assets;
+      description = "User session management for Flask";
+      license = licenses.mit;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   flask-pymongo = buildPythonPackage rec {
     name = "Flask-PyMongo-${version}";
     version = "0.3.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22629,6 +22629,18 @@ in modules // {
     };
   };
 
+  tornado_4_0_1 = buildPythonPackage rec {
+    name = "tornado-${version}";
+    version = "4.0.1";
+
+    propagatedBuildInputs = with self; [ backports_ssl_match_hostname_3_4_0_2 certifi ];
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/t/tornado/${name}.tar.gz";
+      sha256 = "00crp5vnasxg7qyjv89qgssb69vd7qr13jfghdryrcbnn9l8c1df";
+    };
+  };
+
   tokenlib = buildPythonPackage rec {
     name = "tokenlib-${version}";
     version = "0.3.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8653,6 +8653,26 @@ in modules // {
     };
   };
 
+  flask_assets = buildPythonPackage rec {
+    name = "Flask-Assets-${version}";
+    version = "0.10";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/F/Flask-Assets/${name}.tar.gz";
+      sha256 = "1v6ika3ias21xzhg7kglki99nwfx1i33rdhnw9kdqbwxkpwbwkyl";
+    };
+
+    propagatedBuildInputs = with self; [ flask webassets flask_script nose ];
+
+    meta = {
+      homepage = http://github.com/miracle2k/flask-assets;
+      description = "Asset management for Flask, to compress and merge CSS and Javascript files";
+      license = licenses.bsd2;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   flask_cache = buildPythonPackage rec {
     name = "Flask-Cache-0.13.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7125,6 +7125,24 @@ in modules // {
     doCheck = false;
   };
 
+  sarge = buildPythonPackage rec {
+    name = "sarge-${version}";
+    version = "0.1.4";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/s/sarge/${name}.tar.gz";
+      sha256 = "08s8896973bz1gg0pkr592w6g4p6v47bkfvws5i91p9xf8b35yar";
+    };
+
+    meta = {
+      homepage = http://sarge.readthedocs.org/;
+      description = "A wrapper for subprocess which provides command pipeline functionality";
+      license = licenses.bsd3;
+      platform = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   hyp = buildPythonPackage rec {
     name = "hyp-server-${version}";
     version = "1.2.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21487,6 +21487,25 @@ in modules // {
     };
   };
 
+  webassets = buildPythonPackage rec {
+    name = "webassets-${version}";
+    version = "0.11.1";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/w/webassets/${name}.tar.gz";
+      sha256 = "0p1qypcbq9b88ipcylxh3bbnby5n6dr421wb4bwmrlcrgvj4r5lz";
+    };
+
+    propagatedBuildInputs = with self; [ pyyaml ];
+
+    meta = {
+      description = "Media asset management for Python, with glue code for various web frameworks";
+      homepage = http://github.com/miracle2k/webassets/;
+      license = licenses.bsd2;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
 
   webcolors = buildPythonPackage rec {
     name = "webcolors-1.4";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8732,6 +8732,26 @@ in modules // {
     };
   };
 
+  flask_principal = buildPythonPackage rec {
+    name = "Flask-Principal-${version}";
+    version = "0.4.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/F/Flask-Principal/${name}.tar.gz";
+      sha256 = "0lwlr5smz8vfm5h9a9i7da3q1c24xqc6vm9jdywdpgxfbi5i7mpm";
+    };
+
+    propagatedBuildInputs = with self; [ flask blinker nose ];
+
+    meta = {
+      homepage = http://packages.python.org/Flask-Principal/;
+      description = "Identity management for flask";
+      license = licenses.bsd2;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   flask-pymongo = buildPythonPackage rec {
     name = "Flask-PyMongo-${version}";
     version = "0.3.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19149,6 +19149,27 @@ in modules // {
     };
   };
 
+  sockjs-tornado = buildPythonPackage rec {
+    name = "sockjs-tornado-${version}";
+    version = "1.0.2";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/s/sockjs-tornado/${name}.tar.gz";
+      sha256 = "15lcy40h2cm0l8aknbrk48p2sni5wzybsqjx1hxwpk9lfa1xryyv";
+    };
+
+    # This is needed for compatibility with OctoPrint
+    propagatedBuildInputs = with self; [ tornado_4_0_1 ];
+
+    meta = {
+      description = "SockJS python server implementation on top of Tornado framework";
+      homepage = http://github.com/mrjoes/sockjs-tornado/;
+      license = licenses.mit;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abbradar ];
+    };
+  };
+
   sopel = buildPythonPackage rec {
     name = "sopel-6.3.0";
 


### PR DESCRIPTION
This adds OctoPrint 3D-printing spooler with several plugins, namely M3D-Fio to support M3D Micro printer.Configurations for various other printers will differ, but usually you will need to add an udev rule and maybe package another plugin.

My udev rule for M3D Micro:

```
ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2404",  MODE="0660", GROUP="octoprint", ENV{ID_MM_DEVICE_IGNORE}="1"
```
