### PR TITLE
elm: update to latest revs

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-compiler.nix
+++ b/pkgs/development/compilers/elm/packages/elm-compiler.nix
@@ -10,8 +10,8 @@ mkDerivation {
   version = "0.16";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-compiler";
-    sha256 = "696413b69fa5e66f878ed189094be5f74dfaced42121c82ac88bbab1c2bb9861";
-    rev = "cb1bad3b6ebaa02d5af47e9b98eab7d475a3a48d";
+    sha256 = "b3bcdca469716f3a4195469549a9e9bc53a6030aff132ec620b9c93958a5ffe6";
+    rev = "df86c1c9b3cf06de3ccb78f26b4d2fac0129ce5a";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-make.nix
+++ b/pkgs/development/compilers/elm/packages/elm-make.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.16";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-make";
-    sha256 = "bae1206c8066fb4e191345a3da79b89a5ec488929370b210203c8b4dcb35cebc";
-    rev = "e3bfc3e3d04c9b47e18fac289c796caec88d4fef";
+    sha256 = "fc0a6ed08b236dfab43e9af73f8e83a3b88a155695a9671a2b291dc596a75116";
+    rev = "54e0b33fea0cd72400ac6a3dec7643bf1b900741";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-reactor.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.16";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-reactor";
-    sha256 = "dbf881808ff00772d464675f1dd88a40273569ab0e9298805133a3b8f3ed4f26";
-    rev = "ff4ad13ea6b55c63b2d2099b738fd1d5ec2d29b4";
+    sha256 = "55605b8443dad20c78e297ce35a603cb107b0c1e57bf1c4710faaebc60396de0";
+    rev = "b03166296d11e240fa04cdb748e1f3c4af7afc83";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/update-elm.rb
+++ b/pkgs/development/compilers/elm/update-elm.rb
@@ -14,6 +14,7 @@ for pkg, ver in $elm_packages
 end
 
 File.open("release.nix", 'w') do |file|
+  file.puts "{ callPackage }:"
   file.puts "{"
   file.puts "  version = \"#{$elm_version}\";"
   file.puts "  packages = {"


### PR DESCRIPTION
Some tags were updated with bug fixes. Also fixed update-elm.rb to
include the callPackage argument for release.nix.
