### PR TITLE
Gettext.sh

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -47,6 +47,12 @@ stdenv.mkDerivation (rec {
     sed -i -e "s/\(am_libgettextlib_la_OBJECTS = \)error.lo/\\1/" gettext-tools/gnulib-lib/Makefile.in
   '';
 
+  postInstall = ''
+    substituteInPlace "$out/bin/gettext.sh" \
+      --replace "  gettext " "  $out/bin/gettext " \
+      --replace "  ngettext " "  $out/bin/ngettext "
+  '';
+
   buildInputs = [ xz ] ++ stdenv.lib.optional (!stdenv.isLinux) libiconv;
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, libiconv, xz }:
 
 stdenv.mkDerivation (rec {
-  name = "gettext-0.19.6";
+  name = "gettext-${version}";
+  version = "0.19.7";
 
   src = fetchurl {
     url = "mirror://gnu/gettext/${name}.tar.gz";
-    sha256 = "0pb9vp4ifymvdmc31ks3xxcnfqgzj8shll39czmk8c1splclqjzd";
+    sha256 = "0gy2b2aydj8r0sapadnjw8cmb8j2rynj28d5qs1mfa800njd51jk";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
#13053 exposed even more impurity that this PR fixes.

This fixes issues like:

```
/nix/store/05fbja9p8wcdw36l7754wpvg9biiwm7v-git-2.7.0/libexec/git-core/git-rebase: line 62: gettext: command not found
/nix/store/05fbja9p8wcdw36l7754wpvg9biiwm7v-git-2.7.0/libexec/git-core/git-rebase: line 569: gettext: command not found
```

I also included an upgrade to gettext since it does a mass-rebuild
