### PR TITLE
rmilter: remove invalid debug option

### DIFF
--- a/nixos/modules/services/mail/rmilter.nix
+++ b/nixos/modules/services/mail/rmilter.nix
@@ -47,11 +47,6 @@ in
         description = "Whether to run the rmilter daemon.";
       };
 
-      debug = mkOption {
-        default = false;
-        description = "Whether to run the rmilter daemon in debug mode.";
-      };
-
       user = mkOption {
         type = types.string;
         default = "rmilter";
@@ -168,7 +163,7 @@ milter_default_action = accept
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.rmilter}/bin/rmilter ${optionalString cfg.debug "-d"} -n -c ${rmilterConfigFile}";
+        ExecStart = "${pkgs.rmilter}/bin/rmilter -n -c ${rmilterConfigFile}";
         User = cfg.user;
         Group = cfg.group;
         PermissionsStartOnly = true;


### PR DESCRIPTION
There's no debug option available, setting it causes the daemon fail to start.

```
# rmilter -d
rmilter: invalid option -- 'd'
Rapid Milter Version 1.6.7
Usage: rmilter [-h] [-d] -c <config_file>
-n - do not daemonize on startup
-h - this help message
-c - path to config file
```
