### PR TITLE
weechat: make language plugins optional

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,7 +1,23 @@
-{ stdenv, fetchurl, ncurses, openssl, perl, python, aspell, gnutls
-, zlib, curl , pkgconfig, libgcrypt, ruby, lua5, tcl, guile
-, pythonPackages, cmake, makeWrapper, libobjc, libiconv
+{ stdenv, fetchurl, ncurses, openssl, aspell, gnutls
+, zlib, curl , pkgconfig, libgcrypt
+, cmake, makeWrapper, libobjc, libiconv
+, guileSupport ? true, guile
+, luaSupport ? true, lua5
+, perlSupport ? true, perl
+, pythonPackages
+, rubySupport ? true, ruby
+, tclSupport ? true, tcl
 , extraBuildInputs ? [] }:
+
+assert guileSupport -> guile != null;
+assert luaSupport -> lua5 != null;
+assert perlSupport -> perl != null;
+assert rubySupport -> ruby != null;
+assert tclSupport -> tcl != null;
+
+let
+  inherit (pythonPackages) python pycrypto pync;
+in
 
 stdenv.mkDerivation rec {
   version = "1.4";
@@ -12,14 +28,26 @@ stdenv.mkDerivation rec {
     sha256 = "1m6xq6izcac5186xvvmm8znfjzrg9hq42p69jabdvv7cri4rjvg0";
   };
 
-  cmakeFlags = stdenv.lib.optional stdenv.isDarwin
-    "-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib";
+  cmakeFlags = with stdenv.lib; []
+    ++ optional stdenv.isDarwin "-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib"
+    ++ optional (!guileSupport) "-DENABLE_GUILE=OFF"
+    ++ optional (!luaSupport)   "-DENABLE_LUA=OFF"
+    ++ optional (!perlSupport)  "-DENABLE_PERL=OFF"
+    ++ optional (!rubySupport)  "-DENABLE_RUBY=OFF"
+    ++ optional (!tclSupport)   "-DENABLE_TCL=OFF"
+    ;
 
-  buildInputs = 
-    [ ncurses perl python openssl aspell gnutls zlib curl pkgconfig
-      libgcrypt ruby lua5 tcl guile pythonPackages.pycrypto makeWrapper
-      cmake ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ pythonPackages.pync libobjc ]
+  buildInputs = with stdenv.lib; [
+      ncurses python openssl aspell gnutls zlib curl pkgconfig
+      libgcrypt pycrypto makeWrapper
+      cmake
+    ]
+    ++ optionals stdenv.isDarwin [ pync libobjc ]
+    ++ optional  guileSupport    guile
+    ++ optional  luaSupport      lua5
+    ++ optional  perlSupport     perl
+    ++ optional  rubySupport     ruby
+    ++ optional  tclSupport      tcl
     ++ extraBuildInputs;
 
   NIX_CFLAGS_COMPILE = "-I${python}/include/${python.libPrefix} -DCA_FILE=/etc/ssl/certs/ca-certificates.crt";


### PR DESCRIPTION
They're still enabled by default, but now can be disabled.

Python has not been made optional due to the additional complexity of:
- python2 vs python3
- pync support on Darwin
  Making Python support optional should be revisited at another time.

I've tested this locally, disabling guile, lua, perl and tcl, but keeping ruby enabled, with Nix on Arch.
