### PR TITLE
chromium/plugins: use jq for extracting the Flash version

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -1,4 +1,5 @@
 { stdenv
+, jshon
 , enablePepperFlash ? false
 , enableWideVine ? false
 
@@ -83,9 +84,7 @@ let
       wvModule = "@widevine@/lib/libwidevinecdmadapter.so";
       wvInfo = "#${wvName}#${wvDescription};${wvMimeTypes}";
     in ''
-      flashVersion="$(
-        sed -n -r 's/.*"version": "([^"]+)",.*/\1/p' PepperFlash/manifest.json
-      )"
+      flashVersion="$(${jshon}/bin/jshon -F PepperFlash/manifest.json -e version -u)"
 
       install -vD PepperFlash/libpepflashplayer.so \
         "$flash/lib/libpepflashplayer.so"


### PR DESCRIPTION
Doing this with a sed expression is significantly more fragile, fragile enough that this actually ended up setting the Flash version to a Nix store path, instead of the actual version.
This breaks a bunch of websites that detect the Flash version through `navigator.plugins`, including Dropbox.
