### PR TITLE
ant: preserve antRun script

### DIFF
--- a/pkgs/development/tools/build-managers/apache-ant/default.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/default.nix
@@ -23,9 +23,14 @@ stdenv.mkDerivation {
       mv * $out/lib/ant/
 
       # Get rid of the manual (35 MiB).  Maybe we should put this in a
-      # separate output.  Also get rid of the Ant scripts since we
-      # provide our own.
+      # separate output.  Keep the antRun script since it's vanilla sh
+      # and needed for the <exec/> task (but since we set ANT_HOME to
+      # a weird value, we have to move antRun to a weird location).
+      # Get rid of the other Ant scripts since we provide our own.
+      mv $out/lib/ant/bin/antRun $out/bin/
       rm -rf $out/lib/ant/{manual,bin,WHATSNEW}
+      mkdir $out/lib/ant/bin
+      mv $out/bin/antRun $out/lib/ant/bin/
 
       # Install ant-contrib.
       unpackFile $contrib


### PR DESCRIPTION
This is necessary to make the ant `<exec/>` task work.
