### PR TITLE
dispad: init at 0.3.1

### DIFF
--- a/pkgs/tools/X11/dispad/default.nix
+++ b/pkgs/tools/X11/dispad/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, libX11, libXi, confuse }:
+
+stdenv.mkDerivation rec {
+  name = "dispad-${version}";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "BlueDragonX";
+    repo = "dispad";
+    rev = "v${version}";
+    sha256 = "0y0n9mf1hs3s706gkpmg1lh74m6vvkqc9rdbzgc6s2k7vdl2zp1y";
+  };
+
+  buildInputs = [ libX11 libXi confuse ];
+
+  meta = with stdenv.lib; {
+    description = "A small daemon for disabling trackpads while typing";
+    homepage = https://github.com/BlueDragonX/dispad;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ zimbatm ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -298,6 +298,8 @@ let
     inherit helperFunctions;
   };
 
+  dispad = callPackage ../tools/X11/dispad { };
+
   scatterOutputHook = makeSetupHook {} ../build-support/setup-hooks/scatter_output.sh;
 
   vsenv = callPackage ../build-support/vsenv {


### PR DESCRIPTION
like syndaemon but for non-synaptic devices
