### PR TITLE
redis: 3.0.6 -> 3.0.7

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "3.0.6";
+  version = "3.0.7";
   name = "redis-${version}";
 
   src = fetchurl {
     url = "http://download.redis.io/releases/${name}.tar.gz";
-    sha256 = "092nnxjyaf7h9mnwac5rwjl0ikyyqa44vn426w64hn2534iia7kg";
+    sha256 = "08vzfdr67gp3lvk770qpax2c5g2sx8hn6p64jn3jddrvxb2939xj";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
Tested locally.
