### PR TITLE
Simplify fetchurl assertion logic.

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -85,7 +85,7 @@ in
 }:
 
 assert builtins.isList urls;
-assert urls == [] || url == "";
+assert (urls == []) != (url == "");
 
 
 let

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -85,8 +85,7 @@ in
 }:
 
 assert builtins.isList urls;
-assert urls != [] -> url == "";
-assert url != "" -> urls == [];
+assert urls == [] || url == "";
 
 
 let


### PR DESCRIPTION
The two lines I removed technically assert the exact same thing, since `!a -> b`
is equivalent to `a || b`. So, I replaced the two lines with the more symmetric
form to make it clearer.
