### PR TITLE
azure: package qemu 2.2.0 to fix VHD creation

### DIFF
--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -16,14 +16,14 @@ in
               cyl=$(((${diskSize}*1024*1024)/(512*63*255)))
               size=$(($cyl*255*63*512))              
               roundedsize=$((($size/(1024*1024)+1)*(1024*1024)))
-              ${pkgs.vmTools.qemu}/bin/qemu-img create -f raw $diskImage $roundedsize
+              ${pkgs.vmTools.qemu-220}/bin/qemu-img create -f raw $diskImage $roundedsize
               mv closure xchg/
             '';
 
           postVM =
             ''
               mkdir -p $out
-              ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -O vpc -o subformat=fixed $diskImage $out/disk.vhd
+              ${pkgs.vmTools.qemu-220}/bin/qemu-img convert -f raw -O vpc -o subformat=fixed $diskImage $out/disk.vhd
               rm $diskImage
             '';
           diskImageBase = "nixos-image-${config.system.nixosLabel}-${pkgs.stdenv.system}.raw";

--- a/nixos/modules/virtualisation/azure-qemu-220-no-etc-install.patch
+++ b/nixos/modules/virtualisation/azure-qemu-220-no-etc-install.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index d6b9dc1..ce7c493 100644
+--- a/Makefile
++++ b/Makefile
+@@ -384,8 +384,7 @@ install-confdir:
+ install-sysconfig: install-datadir install-confdir
+ 	$(INSTALL_DATA) $(SRC_PATH)/sysconfigs/target/target-x86_64.conf "$(DESTDIR)$(qemu_confdir)"
+ 
+-install: all $(if $(BUILD_DOCS),install-doc) install-sysconfig \
+-install-datadir install-localstatedir
++install: all $(if $(BUILD_DOCS),install-doc) install-datadir
+ ifneq ($(TOOLS),)
+ 	$(call install-prog,$(TOOLS),$(DESTDIR)$(bindir))
+ endif

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -11,6 +11,15 @@ rec {
 
   qemu = pkgs.qemu_kvm;
 
+  qemu-220 = lib.overrideDerivation pkgs.qemu_kvm (attrs: rec {
+    version = "2.2.0";
+    src = fetchurl {
+      url = "http://wiki.qemu.org/download/qemu-${version}.tar.bz2";
+      sha256 = "1703c3scl5n07gmpilg7g2xzyxnr7jczxgx6nn4m8kv9gin9p35n";
+    };
+    patches = [ ../../../nixos/modules/virtualisation/azure-qemu-220-no-etc-install.patch ];
+  });
+
   qemuProg = "${qemu}/bin/qemu-kvm";
 
 


### PR DESCRIPTION
This is related to: [(issue) NixOS Azure image](https://github.com/NixOS/nixpkgs/issues/3986):
1. (Re-)package `qemu-2.2.0` temporarily. Due to a [bug in qemu](https://bugs.launchpad.net/qemu/+bug/1490611), Azure images need to be built with an older version of qemu. I was hoping that this could be fixed and we could get a new bugfix release of `qemu`, but it seems this has been discussed in one form or another for ~2 months already.
2. Use `fixed` subformat for VHDs. This is required for VHDs to be usable in Azure.

The goal is to enable building Azure-compatible VHDs from `master` (and hopefully soon `nixos-unstable`) without needing a separate fork.

Not sure whether:
1. ... this sort of a change is acceptable, in general. It's a somewhat service-specific fix, but the fix also _only impacts_ scenarios which require the fix.
2. ... the location of the `qemu-2.2.0` patch is okay. (If not, where is a more appropriate place in the file tree?)

cc: @Phreedom 
