### PR TITLE
requests2: 2.8.1 -> 2.9.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17562,11 +17562,11 @@ in modules // {
 
   requests2 = buildPythonPackage rec {
     name = "requests-${version}";
-    version = "2.8.1";
+    version = "2.9.1";
 
     src = pkgs.fetchurl {
       url = "http://pypi.python.org/packages/source/r/requests/${name}.tar.gz";
-      sha256 = "0ny2nr1sqr4hcn3903ghmh7w2yni8shlfv240a8c9p6wyidqvzl4";
+      sha256 = "0zsqrzlybf25xscgi7ja4s48y2abf9wvjkn47wh984qgs1fq2xy5";
     };
 
     buildInputs = [ self.pytest ];


### PR DESCRIPTION
Tested manually locally. Sanity checked with:

```
~/g/nixpkgs (requests2-2.9.1) $ nix-shell -I nixpkgs=/home/kragniz/git/nixpkgs/ -p python27Packages.requests2 --pure --run "python -c 'import requests; print requests.__version__'"
2.9.1
```
