### PR TITLE
Add a new nixpkg vmmlib. A vector and matrix C++ library

### DIFF
--- a/pkgs/development/libraries/vmmlib/default.nix
+++ b/pkgs/development/libraries/vmmlib/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, blas }:
+
+stdenv.mkDerivation rec {
+  version = "1.6.2";
+  name = "vmmlib-${version}";
+  buildInputs = [ stdenv pkgconfig cmake boost blas ];
+
+  src = fetchFromGitHub {
+    owner = "VMML";
+    repo = "vmmlib";
+    rev = "release-${version}";
+    sha256 = "0sn6jl1r5k6ka0vkjsdnn14hb95dqq8158dapby6jk72wqj9kdml";
+  };
+
+  patches = [ 
+		./disable-cpack.patch   #disable the need of cpack/rpm
+	    ];
+  
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    description = "A vector and matrix math library implemented using C++ templates";
+
+    longDescription = ''vmmlib is a vector and matrix math library implemented 
+            using C++ templates. Its basic functionality includes a vector 
+            and a matrix class, with additional functionality for the 
+            often-used 3d and 4d vectors and 3x3 and 4x4 matrices.
+            More advanced functionality include solvers, frustum 
+            computations and frustum culling classes, and spatial data structures'';
+
+    license     = licenses.bsd2;
+    homepage    = http://github.com/VMML/vmmlib/;
+    maintainers = [ maintainers.adev ];
+    platforms   = platforms.all;
+  };  
+}
+

--- a/pkgs/development/libraries/vmmlib/disable-cpack.patch
+++ b/pkgs/development/libraries/vmmlib/disable-cpack.patch
@@ -1,0 +1,11 @@
+diff -ur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	1970-01-01 00:00:01.000000000 +0000
++++ b/CMakeLists.txt	2016-02-19 08:49:30.053759000 +0000
+@@ -178,6 +178,5 @@
+ install(FILES ${DOCS} DESTINATION share/vmmlib COMPONENT dev)
+ 
+ include(DoxygenRule) # must be after all targets
+-include(CPackConfig)
+ include(CTest)
+-include(PackageConfig)
++

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6508,6 +6508,8 @@ let
   eigen = callPackage ../development/libraries/eigen {};
 
   eigen2 = callPackage ../development/libraries/eigen/2.0.nix {};
+  
+  vmmlib = callPackage ../development/libraries/vmmlib {};  
 
   enchant = callPackage ../development/libraries/enchant { };
 


### PR DESCRIPTION
Request to include vmmlib in NixOS. vmmlib is a matrix and vector C++ template and header-based library oriented for 3D and geometry.

It is already packaged in the major linux distributions ( Debian, RedHat ), this is in order to include it in NixOS.
