### PR TITLE
buildPythonApplication: function for building Python applications

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9103,6 +9103,7 @@ let
 
   # python function with default python interpreter
   buildPythonPackage = pythonPackages.buildPythonPackage;
+  buildPythonApplication = pythonPackages.buildPythonApplication;
 
   # `nix-env -i python-nose` installs for 2.7, the default python.
   # Therefore we do not recurse into attributes here, in contrast to

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19,6 +19,8 @@ let
     bootstrapped-pip = callPackage ../development/python-modules/bootstrapped-pip { };
   });
 
+  buildPythonApplication = args: buildPythonPackage ({namePrefix="";} // args );
+
   # Unique python version identifier
   pythonName =
     if isPy26 then "python26" else
@@ -38,7 +40,7 @@ let
 
 in modules // {
 
-  inherit python isPy26 isPy27 isPy33 isPy34 isPy35 isPyPy isPy3k pythonName buildPythonPackage;
+  inherit python isPy26 isPy27 isPy33 isPy34 isPy35 isPyPy isPy3k pythonName buildPythonPackage buildPythonApplication;
 
   # helpers
 


### PR DESCRIPTION
Currently, the only difference is that namePrefix is not set.

All Python applications, which should be everything outside of `python-packages.nix`, should use this function instead of `buildPythonPackage`.

Closes #1468
