### PR TITLE
Added boot.initrd.logCommands and boot.logCommands in order to log the command output from early userspace in stage-1 and stage-2

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -200,8 +200,8 @@ let
 
     inherit (config.boot) resumeDevice devSize runSize;
 
-    inherit (config.boot.initrd) checkJournalingFS
-      preLVMCommands preDeviceCommands postDeviceCommands postMountCommands kernelModules;
+    inherit (config.boot.initrd) checkJournalingFS 
+      logCommands preLVMCommands preDeviceCommands postDeviceCommands postMountCommands kernelModules;
 
     resumeDevices = map (sd: if sd ? device then sd.device else "/dev/disk/by-label/${sd.label}")
                     (filter (sd: (sd ? label || hasPrefix "/dev/" sd.device) && !sd.randomEncryption) config.swapDevices);
@@ -266,6 +266,14 @@ in
         Specify here the device where the file resides.
         You should also use <varname>boot.kernelParams</varname> to specify
         <literal><replaceable>resume_offset</replaceable></literal>.
+      '';
+    };
+
+    boot.initrd.logCommands = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to replicate command output of stage-1 booting to <filename>/dev/kmsg</filename> or <filename>/run/log/stage-1-init.log</filename> if <filename>/dev/kmsg</filename> is not writable.
       '';
     };
 

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -155,6 +155,23 @@ mkdir -m 0755 -p /var/setuid-wrappers
 mount -t tmpfs -o "mode=0755" tmpfs /var/setuid-wrappers
 
 
+# Optionally log the script output to /dev/kmsg or /run/log/stage-2-init.log.
+# Only at this point are all the necessary prerequisites ready for these commands.
+if test -n "@logCommands@"; then
+    exec {logOutFd}>&1 {logErrFd}>&2
+    if test -w /dev/kmsg; then
+        exec > >(tee -i /proc/self/fd/"$logOutFd" | while read line; do
+            if test -n "$line"; then
+                echo "stage-2-init: $line" > /dev/kmsg
+            fi
+        done) 2>&1
+    else
+        mkdir -p /run/log
+        exec > >(tee -i /run/log/stage-2-init.log) 2>&1
+    fi
+fi
+
+
 # Run the script that performs all configuration activation that does
 # not have to be done at boot time.
 echo "running activation script..."
@@ -180,6 +197,13 @@ ln -sfn /run/booted-system /nix/var/nix/gcroots/booted-system
 
 # Run any user-specified commands.
 @shell@ @postBootCommands@
+
+
+# Reset the logging file descriptors
+if test -n "@logCommands@"; then
+    exec 1>&$logOutFd 2>&$logErrFd
+    exec {logOutFd}>&- {logErrFd}>&-
+fi 
 
 
 # Start systemd.

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -17,7 +17,7 @@ let
     src = ./stage-2-init.sh;
     shellDebug = "${pkgs.bashInteractive}/bin/bash";
     isExecutable = true;
-    inherit (config.boot) devShmSize runSize;
+    inherit (config.boot) logCommands devShmSize runSize;
     inherit (config.nix) readOnlyStore;
     inherit (config.networking) useHostResolvConf;
     ttyGid = config.ids.gids.tty;
@@ -39,6 +39,14 @@ in
   options = {
 
     boot = {
+
+      logCommands = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to replicate command output of stage-1 booting to <filename>/dev/kmsg</filename> or <filename>/run/log/stage-2-init.log</filename> if <filename>/dev/kmsg</filename> is not writable.
+        '';
+      };
 
       postBootCommands = mkOption {
         default = "";


### PR DESCRIPTION
By default these options are left as false. No interruption with existing boot even if you switch them on. You still see all userspace messages on the terminal. No extra packages are installed, stage-1 uses the pre-existing busybox tools, and stage-2 uses only coreutils and bash 4.0 features.

Uses the preexisting `/run/log` folder. I judged this folder to be best folder to use (as it is temporary and mounted in RAM). I explored seeing how I can put the logs into journald, but I realised the timing would be off, and there's no way to inject logs at a previous time into journald. At any case, users can do this easily using their own systemd script if necessary.

These 2 options when switched on will log command output to `/run/log/stage-1-init.log` and `/run/log/stage-2-init.log` respectively. They are really useful for debugging issues at early user space unattended, or when you don't have a direct terminal to access early user space, such as when using cloud instances.

The file descriptor 8 and 9 was used in `stage-1-init.sh`, these were chosen somewhat randomly, but they were not occupied file descriptors. The usage of fifo pipe is required in stage 1 because ASH doesn't support process substitution. Also resetting the file descriptors is necessary to prevent kernel panics in stage 1, and for stage 2, just to be consistent.

I tested this and it works on latest 15.09 on bare metal.
