### PR TITLE
buildPythonApplication: use new function for Python applications

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, mygpoclient, intltool
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages, mygpoclient, intltool
 , ipodSupport ? true, libgpod
 , gnome3
 }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "gpodder-${version}";
   namePrefix = "";
 

--- a/pkgs/applications/audio/gtklick/default.nix
+++ b/pkgs/applications/audio/gtklick/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, gettext, klick}:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "gtklick-${version}";
   namePrefix = "";
   version = "0.6.4";

--- a/pkgs/applications/audio/lastfmsubmitd/default.nix
+++ b/pkgs/applications/audio/lastfmsubmitd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "lastfmsubmitd-${version}";
   namePrefix = ""; 
   version = "1.0.6";

--- a/pkgs/applications/audio/lastwatch/default.nix
+++ b/pkgs/applications/audio/lastwatch/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "lastwatch-${version}";
   namePrefix = "";
   version = "0.4.1";

--- a/pkgs/applications/audio/mimms/default.nix
+++ b/pkgs/applications/audio/mimms/default.nix
@@ -2,7 +2,7 @@
 
 let version = "3.2";
 in
-  pythonPackages.buildPythonPackage {
+  pythonPackages.buildPythonApplication {
     name = "mimms-${version}";
     src = fetchurl {
       url = "http://download.savannah.gnu.org/releases/mimms/mimms-${version}.tar.bz2";

--- a/pkgs/applications/audio/mopidy-gmusic/default.nix
+++ b/pkgs/applications/audio/mopidy-gmusic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-gmusic-${version}";
   version = "1.0.0";
 

--- a/pkgs/applications/audio/mopidy-moped/default.nix
+++ b/pkgs/applications/audio/mopidy-moped/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-moped-${version}";
   version = "0.6.0";
 

--- a/pkgs/applications/audio/mopidy-mopify/default.nix
+++ b/pkgs/applications/audio/mopidy-mopify/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-mopify-${version}";
 
   version = "1.5.8";

--- a/pkgs/applications/audio/mopidy-musicbox-webclient/default.nix
+++ b/pkgs/applications/audio/mopidy-musicbox-webclient/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-musicbox-webclient-${version}";
 
   version = "2.0.0";

--- a/pkgs/applications/audio/mopidy-soundcloud/default.nix
+++ b/pkgs/applications/audio/mopidy-soundcloud/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-soundcloud-${version}";
 
   version = "2.0.2";

--- a/pkgs/applications/audio/mopidy-spotify-tunigo/default.nix
+++ b/pkgs/applications/audio/mopidy-spotify-tunigo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy, mopidy-spotify }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-spotify-tunigo-${version}";
 
   version = "0.2.1";

--- a/pkgs/applications/audio/mopidy-spotify/default.nix
+++ b/pkgs/applications/audio/mopidy-spotify/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-spotify-${version}";
   version = "2.3.1";
 

--- a/pkgs/applications/audio/mopidy-youtube/default.nix
+++ b/pkgs/applications/audio/mopidy-youtube/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-youtube-${version}";
 
   version = "2.0.1";

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -2,7 +2,7 @@
 , glib_networking, gst_plugins_good, gst_plugins_base, gst_plugins_ugly
 }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mopidy-${version}";
 
   version = "1.1.2";

--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, buildPythonPackage, fetchurl, gettext
+{ stdenv, buildPythonApplication, fetchurl, gettext
 , pkgconfig, libofa, ffmpeg, chromaprint
 , pyqt4, mutagen, python-libdiscid
 }:
 
 let version = "1.3.2"; in
-buildPythonPackage {
+buildPythonApplication {
   name = "picard-${version}";
   namePrefix = "";
 

--- a/pkgs/applications/audio/pithos/default.nix
+++ b/pkgs/applications/audio/pithos/default.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, stdenv, pythonPackages, gtk3, gobjectIntrospection, libnotify
 , gst_all_1, wrapGAppsHook }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   pname = "pithos";
   version = "1.1.2";
   name = "${pname}-${version}";

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, buildPythonPackage, mutagen, pygtk, pygobject, intltool
+{ stdenv, fetchurl, python, buildPythonApplication, mutagen, pygtk, pygobject, intltool
 , pythonDBus, gst_python, withGstPlugins ? false, gst_plugins_base ? null
 , gst_plugins_good ? null, gst_plugins_ugly ? null, gst_plugins_bad ? null }:
 
@@ -9,7 +9,7 @@ assert withGstPlugins -> gst_plugins_base != null
 
 let version = "2.6.3"; in
 
-buildPythonPackage {
+buildPythonApplication {
   # call the package quodlibet and just quodlibet
   name = "quodlibet-${version}"
          + stdenv.lib.optionalString withGstPlugins "-with-gst-plugins";

--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -1,11 +1,11 @@
 { pkgs, stdenv, fetchFromGitHub, pkgconfig, intltool, wrapGAppsHook,
-  python, buildPythonPackage, isPy3k,
+  python, buildPythonApplication, isPy3k,
   gnome3, gtk3, gobjectIntrospection,
   dbus, pygobject3, mpd2 }:
 
 with pkgs.lib;
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "sonata-${version}";
   version = "1.7b1";
   namePrefix = "";

--- a/pkgs/applications/editors/leo-editor/default.nix
+++ b/pkgs/applications/editors/leo-editor/default.nix
@@ -1,6 +1,6 @@
 { stdenv, pythonPackages, fetchgit }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "leo-editor-${version}";
   namePrefix = "";
   version = "5.1";

--- a/pkgs/applications/editors/nvpy/default.nix
+++ b/pkgs/applications/editors/nvpy/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, fetchurl, tk, buildPythonPackage, pythonPackages }:
+{ pkgs, fetchurl, tk, buildPythonApplication, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   version = "0.9.2";
   name = "nvpy-${version}";
 

--- a/pkgs/applications/graphics/jbrout/default.nix
+++ b/pkgs/applications/graphics/jbrout/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchsvn, buildPythonPackage, python, pyGtkGlade, makeWrapper, pyexiv2,  pythonPackages, fbida, which }:
+{ stdenv, fetchsvn, buildPythonApplication, python, pyGtkGlade, makeWrapper, pyexiv2,  pythonPackages, fbida, which }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "jbrout-${version}";
   version = "338";
 

--- a/pkgs/applications/graphics/mcomix/default.nix
+++ b/pkgs/applications/graphics/mcomix/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, python27Packages }:
+{ stdenv, fetchurl, buildPythonApplication, python27Packages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
     namePrefix = "";
     name = "mcomix-1.01";
 

--- a/pkgs/applications/graphics/mirage/default.nix
+++ b/pkgs/applications/graphics/mirage/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, python, pygtk, pillow, libX11, gettext }:
+{ stdenv, fetchurl, buildPythonApplication, python, pygtk, pillow, libX11, gettext }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
     namePrefix = "";
     name = "mirage-0.9.5.2";
 

--- a/pkgs/applications/misc/bleachbit/default.nix
+++ b/pkgs/applications/misc/bleachbit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, pythonPackages, fetchurl }:
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "bleachbit-${version}";
   version = "1.8";
 

--- a/pkgs/applications/misc/electrum-dash/default.nix
+++ b/pkgs/applications/misc/electrum-dash/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, slowaes }:
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages, slowaes }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "electrum-dash-${version}";
   version = "2.4.1";
 

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, slowaes }:
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages, slowaes }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "electrum-${version}";
   version = "2.5.4";
 

--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, gtk3, pythonPackages, python, pycairo, pygobject3, intltool,
   pango, gsettings_desktop_schemas }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "4.1.1";
   name = "gramps-${version}";
   namePrefix = "";
@@ -18,7 +18,7 @@ pythonPackages.buildPythonPackage rec {
 
   pythonPath = [ pygobject3 pango pycairo pythonPackages.bsddb ];
 
-  # Same installPhase as in buildPythonPackage but without --old-and-unmanageble
+  # Same installPhase as in buildPythonApplication but without --old-and-unmanageble
   # install flag.
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/misc/hamster-time-tracker/default.nix
+++ b/pkgs/applications/misc/hamster-time-tracker/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, buildPythonPackage, docbook2x, libxslt, gnome_doc_utils
+{ stdenv, fetchzip, buildPythonApplication, docbook2x, libxslt, gnome_doc_utils
 , intltool, dbus_glib, pygobject, pygtk, pyxdg, gnome_python, dbus, sqlite3
 , hicolor_icon_theme
 }:
@@ -8,7 +8,7 @@
 #
 #   WARNING:root:Could not import wnck - workspace tracking will be disabled
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "hamster-time-tracker-1.04";
   namePrefix = "";
 

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgs, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "0.7.0";
   name = "khal-${version}";
 

--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgs, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "0.8.1";
   name = "khard-${version}";
   namePrefix = "";

--- a/pkgs/applications/misc/loxodo/default.nix
+++ b/pkgs/applications/misc/loxodo/default.nix
@@ -3,7 +3,7 @@ let
   py = python27Packages;
   python = py.python;
 in
-py.buildPythonPackage rec {
+py.buildPythonApplication rec {
   name = "loxodo-0.20150124";
 
   src = fetchgit {

--- a/pkgs/applications/misc/ocropus/default.nix
+++ b/pkgs/applications/misc/ocropus/default.nix
@@ -17,7 +17,7 @@ let
   ];
 
 in
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "ocropus-${version}";
   version = "20150316";
 

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "OctoPrint-${version}";
   version = "1.2.9";
 

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, octoprint, pythonPackages }:
 
 let
-  buildPlugin = args: pythonPackages.buildPythonPackage (args // {
+  buildPlugin = args: pythonPackages.buildPythonApplication (args // {
     buildInputs = (args.buildInputs or []) ++ [ octoprint ];
   });
 in {

--- a/pkgs/applications/misc/pdfdiff/default.nix
+++ b/pkgs/applications/misc/pdfdiff/default.nix
@@ -2,7 +2,7 @@
 let
   py = pythonPackages;
 in
-py.buildPythonPackage rec {
+py.buildPythonApplication rec {
   name = "pdfdiff-${version}";
   version = "0.92";
 

--- a/pkgs/applications/misc/pitz/default.nix
+++ b/pkgs/applications/misc/pitz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, tempita, jinja2, pyyaml, clepy, mock
+{ stdenv, fetchurl, buildPythonApplication, tempita, jinja2, pyyaml, clepy, mock
 , nose, decorator, docutils
 }:
 
@@ -11,7 +11,7 @@
 # pitz-shell is not the primary interface, so it is not critical to have it
 # working. Concider fixing pitz upstream.
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "pitz-1.2.4";
   namePrefix = "";
 

--- a/pkgs/applications/misc/printrun/default.nix
+++ b/pkgs/applications/misc/printrun/default.nix
@@ -1,6 +1,6 @@
 { stdenv, python27Packages, fetchFromGitHub }:
 
-python27Packages.buildPythonPackage rec {
+python27Packages.buildPythonApplication rec {
   name = "printrun-20150310";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/misc/pytrainer/default.nix
+++ b/pkgs/applications/misc/pytrainer/default.nix
@@ -11,7 +11,7 @@ let
 
 in
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "pytrainer-${version}";
   version = "1.10.0";
 

--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, python, w3m, file }:
+{ stdenv, fetchurl, buildPythonApplication, python, w3m, file }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "ranger-1.7.2";
 
   meta = {

--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pkgs, lib, python, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "1.8.0";
   name = "rtv-${version}";
 

--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,5 +1,5 @@
 {fetchurl, stdenv, gtk3, python34Packages, gobjectIntrospection}:
-python34Packages.buildPythonPackage rec {
+python34Packages.buildPythonApplication rec {
   name = "solaar-${version}";
   version = "0.9.2";
   namePrefix = "";

--- a/pkgs/applications/misc/zscroll/default.nix
+++ b/pkgs/applications/misc/zscroll/default.nix
@@ -2,7 +2,7 @@
 
 let version = "1.0"; in
 
-python3Packages.buildPythonPackage {
+python3Packages.buildPythonApplication {
   name = "zscroll-${version}";
   # don't prefix with python version
   namePrefix = "";

--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, python, buildPythonPackage, qtmultimedia, pyqt5
+{ stdenv, fetchurl, python, buildPythonApplication, qtmultimedia, pyqt5
 , jinja2, pygments, pyyaml, pypeg2, gst-plugins-base, gst-plugins-good
 , gst-plugins-bad, gst-libav, wrapGAppsHook, glib_networking }:
 
 let version = "0.5.1"; in
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "qutebrowser-${version}";
   namePrefix = "";
 

--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, python34Packages, readline, ncurses, canto-daemon }:
 
-python34Packages.buildPythonPackage rec {
+python34Packages.buildPythonApplication rec {
   version = "0.9.6";
   name = "canto-curses-${version}";
 

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, python34Packages, }:
 
-python34Packages.buildPythonPackage rec {
+python34Packages.buildPythonApplication rec {
   version = "0.9.5";
   name = "canto-daemon-${version}";
   namePrefix = "";

--- a/pkgs/applications/networking/feedreaders/rawdog/default.nix
+++ b/pkgs/applications/networking/feedreaders/rawdog/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "rawdog-${version}";
   version = "2.21";
 

--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pythonPackages, pyqt4, cython, libvncserver, zlib, twisted
 , gnutls, libvpx }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "blink-${version}";
   version = "1.4.2";
   

--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildPythonPackage, fetchurl, gettext, gtk3, pythonPackages
+{ stdenv, buildPythonApplication, fetchurl, gettext, gtk3, pythonPackages
 , gdk_pixbuf, libnotify, gst_all_1
 , libgnome_keyring3 ? null, networkmanager ? null
 }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "mailnag-${version}";
   version = "1.1.0";
 

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, pythonPackages, gnupg1orig, makeWrapper, openssl }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "mailpile-${version}";
   version = "0.4.1";
 

--- a/pkgs/applications/office/keepnote/default.nix
+++ b/pkgs/applications/office/keepnote/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, pygtk }:
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages, pygtk }:
 
-buildPythonPackage {
+buildPythonApplication {
   name = "keepnote-0.7.8";
   namePrefix = "";
 

--- a/pkgs/applications/office/zim/default.nix
+++ b/pkgs/applications/office/zim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildPythonPackage, pythonPackages, pygtk, pygobject, python }:
+{ stdenv, lib, fetchurl, buildPythonApplication, pythonPackages, pygtk, pygobject, python }:
 
 #
 # TODO: Declare configuration options for the following optional dependencies:
@@ -7,7 +7,7 @@
 #  -  pyxdg: Need to make it work first (see setupPyInstallFlags).
 #
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "zim-${version}";
   version = "0.63";
   namePrefix = "";

--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, buildPythonPackage, makeDesktopItem
+{ stdenv, fetchurl, unzip, buildPythonApplication, makeDesktopItem
 # mandatory
 , pyside
 # recommended
@@ -7,7 +7,7 @@
 , ipython ? null, pylint ? null, pep8 ? null
 }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "spyder-${version}";
   version = "2.3.8";
   namePrefix = "";

--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, pythonPackages, makeWrapper, gettext }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "git-cola-${version}";
   version = "2.2.1";
 

--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, python} :
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "git-review-${version}";
   version = "1.25.0";
 

--- a/pkgs/applications/version-management/gitinspector/default.nix
+++ b/pkgs/applications/version-management/gitinspector/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip, buildPythonPackage }:
+{ stdenv, fetchzip, buildPythonApplication }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "gitinspector-${version}";
   version = "0.4.1";
   namePrefix = "";

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, itstool, buildPythonPackage, python27, intltool, makeWrapper
+{ stdenv, fetchurl, itstool, buildPythonApplication, python27, intltool, makeWrapper
 , libxml2, pygobject3, gobjectIntrospection, gtk3, gnome3, pycairo, cairo
 }:
 
@@ -8,7 +8,7 @@ let
   version = "${minor}.0";
 in
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "meld-${version}";
   namePrefix = "";
 

--- a/pkgs/applications/version-management/peru/default.nix
+++ b/pkgs/applications/version-management/peru/default.nix
@@ -4,7 +4,7 @@ let
   version = "0.2.3"; 
 in
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   
   # Do not prefix name with python specific version identifier.
   namePrefix = "";

--- a/pkgs/applications/version-management/rabbitvcs/default.nix
+++ b/pkgs/applications/version-management/rabbitvcs/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, lib, python2Packages, meld, subversion, gvfs, xdg_utils }:
-python2Packages.buildPythonPackage rec {
+python2Packages.buildPythonApplication rec {
   name = "rabbitvcs-${version}";
   version = "0.16";
   namePrefix = "";

--- a/pkgs/applications/version-management/tailor/default.nix
+++ b/pkgs/applications/version-management/tailor/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "tailor-${version}";
   version = "0.9.35";
 

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, mercurial, pyPackages ? pkgs.python27Packages }:
 
-pkgs.buildPythonPackage rec {
+pkgs.buildPythonApplication rec {
     name = "tortoisehg-${version}";
     version = "3.6";
     namePrefix = "";

--- a/pkgs/applications/video/devede/default.nix
+++ b/pkgs/applications/video/devede/default.nix
@@ -1,9 +1,9 @@
-{ pkgs, stdenv, fetchurl, pythonPackages, buildPythonPackage, pygtk, ffmpeg, mplayer, vcdimager, cdrkit, dvdauthor }:
+{ pkgs, stdenv, fetchurl, pythonPackages, buildPythonApplication, pygtk, ffmpeg, mplayer, vcdimager, cdrkit, dvdauthor }:
 
 let
   inherit (pythonPackages) dbus;
 
-in buildPythonPackage rec {
+in buildPythonApplication rec {
   name = "devede-3.23.0";
   namePrefix = "";
 

--- a/pkgs/applications/video/kazam/default.nix
+++ b/pkgs/applications/video/kazam/default.nix
@@ -2,7 +2,7 @@
 , gtk3, libwnck3, keybinder, intltool, libcanberra }:
 
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   name = "kazam-${version}";
   version = "1.4.3";
   namePrefix = "";

--- a/pkgs/applications/video/key-mon/default.nix
+++ b/pkgs/applications/video/key-mon/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, gnome, librsvg, pygtk, pythonPackages }:
+{ stdenv, fetchurl, buildPythonApplication, gnome, librsvg, pygtk, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "key-mon-${version}";
   version = "1.17";
   namePrefix = "";

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, buildPythonPackage, pythonPackages, pkgconfig
+{ stdenv, fetchurl, python, buildPythonApplication, pythonPackages, pkgconfig
 , pyrex096, ffmpeg, boost, glib, pygobject, gtk2, webkitgtk2, libsoup, pygtk
 , taglib, sqlite, pycurl, mutagen, pycairo, pythonDBus, pywebkitgtk
 , libtorrentRasterbar, glib_networking, gsettings_desktop_schemas
@@ -10,7 +10,7 @@ assert enableBonjour -> avahi != null;
 
 with stdenv.lib;
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "miro-${version}";
   namePrefix = "";
   version = "6.0";

--- a/pkgs/applications/virtualization/openstack/glance.nix
+++ b/pkgs/applications/virtualization/openstack/glance.nix
@@ -1,7 +1,7 @@
 
 { stdenv, fetchurl, pythonPackages, sqlite, which, strace }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "glance-${version}";
   version = "11.0.0";
   namePrefix = "";

--- a/pkgs/applications/virtualization/openstack/keystone.nix
+++ b/pkgs/applications/virtualization/openstack/keystone.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, xmlsec, which, openssl }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "keystone-${version}";
   version = "8.0.0";
   namePrefix = "";

--- a/pkgs/applications/virtualization/openstack/neutron.nix
+++ b/pkgs/applications/virtualization/openstack/neutron.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, xmlsec, which, dnsmasq }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "neutron-${version}";
   version = "7.0.0";
   namePrefix = "";

--- a/pkgs/applications/virtualization/openstack/nova.nix
+++ b/pkgs/applications/virtualization/openstack/nova.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, openssl, openssh }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "nova-${version}";
   version = "12.0.0";
   namePrefix = "";

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -7,7 +7,7 @@
 with stdenv.lib;
 with pythonPackages;
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "virt-manager-${version}";
   version = "1.3.1";
   namePrefix = "";

--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, buildPythonPackage, python27Packages, pkgs }:
+{ stdenv, fetchFromGitHub, buildPythonApplication, python27Packages, pkgs }:
 
 let cairocffi-xcffib = python27Packages.cairocffi.override {
     pythonPath = [ python27Packages.xcffib ];
   };
 in
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "qtile-${version}";
   version = "0.10.4";
 

--- a/pkgs/development/arduino/ino/default.nix
+++ b/pkgs/development/arduino/ino/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, picocom
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages, picocom
 , avrdude, arduino-core, avrgcclibc }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "ino-0.3.6";
   namePrefix = "";
 

--- a/pkgs/development/tools/build-managers/buildbot-slave/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot-slave/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildPythonPackage, fetchurl, coreutils, twisted }:
+{ stdenv, buildPythonApplication, fetchurl, coreutils, twisted }:
 
-buildPythonPackage (rec {
+buildPythonApplication (rec {
   name = "buildbot-slave-0.8.10";
   namePrefix = "";
 

--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchurl, twisted, dateutil, jinja2
+{ stdenv, buildPythonApplication, fetchurl, twisted, dateutil, jinja2
 , sqlalchemy , sqlalchemy_migrate_0_7
 , enableDebugClient ? false, pygobject ? null, pyGtkGlade ? null
 }:
@@ -8,7 +8,7 @@
 
 assert enableDebugClient -> pygobject != null && pyGtkGlade != null;
 
-buildPythonPackage (rec {
+buildPythonApplication (rec {
   name = "buildbot-0.8.12";
   namePrefix = "";
 

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, python} :
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "devpi-client-${version}";
   version = "2.3.2";
 

--- a/pkgs/development/tools/grabserial/default.nix
+++ b/pkgs/development/tools/grabserial/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, buildPythonPackage, pythonPackages }:
+{ stdenv, fetchgit, buildPythonApplication, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
 
   name = "grabserial-20141120";
   namePrefix = "";

--- a/pkgs/development/tools/misc/nixbang/default.nix
+++ b/pkgs/development/tools/misc/nixbang/default.nix
@@ -1,7 +1,7 @@
 { lib, pythonPackages, fetchFromGitHub }:
 
 let version = "0.1.2"; in
-pythonPackages.buildPythonPackage {
+pythonPackages.buildPythonApplication {
   name = "nixbang-${version}";
   namePrefix = "";
 

--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, python, llvmPackages, boost, pythonPackages, buildPythonPackage, makeWrapper
+{ stdenv, fetchgit, cmake, python, llvmPackages, boost, pythonPackages, buildPythonApplication, makeWrapper
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/tools/profiling/gprof2dot/default.nix
+++ b/pkgs/development/tools/profiling/gprof2dot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages }:
 
-pythonPackages.buildPythonPackage {
+pythonPackages.buildPythonApplication {
   name = "gprof2dot-2015-04-27";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/winpdb/default.nix
+++ b/pkgs/development/tools/winpdb/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, wxPython, makeDesktopItem }:
+{ stdenv, fetchurl, buildPythonApplication, wxPython, makeDesktopItem }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "winpdb-1.4.8";
   namePrefix = "";
 

--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -1,12 +1,12 @@
 { stdenv
 , fetchurl
-, buildPythonPackage
+, buildPythonApplication
 , pyqt4
 , pythonPackages
 }:
 let
   version = "2.3.2";
-in buildPythonPackage rec {
+in buildPythonApplication rec {
   name = "mnemosyne-${version}";
   src = fetchurl {
     url    = "http://sourceforge.net/projects/mnemosyne-proj/files/mnemosyne/${name}/Mnemosyne-${version}.tar.gz";

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, lilypond, pyqt4, pygame }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "frescobaldi-${version}";
   version = "2.0.16";
 

--- a/pkgs/os-specific/linux/iotop/default.nix
+++ b/pkgs/os-specific/linux/iotop/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages }:
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "iotop-0.6";
   namePrefix = "";
 

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, stdenv, buildPythonPackage, pythonPackages, fetchurl, fetchFromGitHub }:
+{ pkgs, stdenv, buildPythonApplication, pythonPackages, fetchurl, fetchFromGitHub }:
 let
-  matrix-angular-sdk = buildPythonPackage rec {
+  matrix-angular-sdk = buildPythonApplication rec {
     name = "matrix-angular-sdk-${version}";
     version = "0.6.6";
 
@@ -10,7 +10,7 @@ let
     };
   };
 in
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "matrix-synapse-${version}";
   version = "0.12.0";
 

--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchFromGitHub, python3Packages}:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   name = "xonsh-${version}";
   version = "0.1.3";
 

--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, xrandr, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "arandr-0.1.8";
 
   src = fetchurl {

--- a/pkgs/tools/X11/winswitch/default.nix
+++ b/pkgs/tools/X11/winswitch/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages
 , which, xpra, xmodmap }:
 
 let
-  base = buildPythonPackage rec {
+  base = buildPythonApplication rec {
     name = "winswitch-${version}";
     namePrefix = "";
     version = "0.12.16";

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages
 , python, cython, pkgconfig
 , xorg, gtk, glib, pango, cairo, gdk_pixbuf, atk, pycairo
 , makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf, xkeyboard_config
 , ffmpeg, x264, libvpx, libwebp
 , libfakeXinerama }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "xpra-0.15.3";
   namePrefix = "";
 

--- a/pkgs/tools/X11/xpra/gtk3.nix
+++ b/pkgs/tools/X11/xpra/gtk3.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, buildPythonPackage
+{ stdenv, fetchurl, buildPythonApplication
 , python, cython, pkgconfig
 , xorg, gtk3, glib, pango, cairo, gdk_pixbuf, atk, pygobject3, pycairo, gobjectIntrospection
 , makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf, xkeyboard_config
 , ffmpeg, x264, libvpx, libwebp
 , libfakeXinerama }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "xpra-0.14.19";
   namePrefix = "";
 

--- a/pkgs/tools/admin/cli53/default.nix
+++ b/pkgs/tools/admin/cli53/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildPythonPackage, pythonPackages, fetchurl }:
+{ lib, buildPythonApplication, pythonPackages, fetchurl }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "cli53-${version}";
   namePrefix = "";  # Suppress "python27-" name prefix
   version = "0.4.4";

--- a/pkgs/tools/admin/letsencrypt/default.nix
+++ b/pkgs/tools/admin/letsencrypt/default.nix
@@ -1,6 +1,6 @@
 { stdenv, pythonPackages, fetchurl, dialog }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "0.1.0";
   name = "letsencrypt-${version}";
 

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "simp_le-2016-01-09";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/audio/beets/alternatives-plugin.nix
+++ b/pkgs/tools/audio/beets/alternatives-plugin.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pythonPackages }:
+{ stdenv, buildPythonApplication, fetchFromGitHub, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "beets-alternatives-${version}";
   version = "0.8.2";
 

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, writeScript, glibcLocales
-, buildPythonPackage, pythonPackages, python, imagemagick
+, buildPythonApplication, pythonPackages, python, imagemagick
 
 , enableAcousticbrainz ? true
 , enableAcoustid       ? true
@@ -68,7 +68,7 @@ let
   testShell = "${bashInteractive}/bin/bash --norc";
   completion = "${bashCompletion}/share/bash-completion/bash_completion";
 
-in buildPythonPackage rec {
+in buildPythonApplication rec {
   name = "beets-${version}";
   version = "1.3.17";
   namePrefix = "";
@@ -103,7 +103,7 @@ in buildPythonPackage rec {
     ++ optional enableThumbnails   pythonPackages.pyxdg
     ++ optional enableWeb          pythonPackages.flask
     ++ optional enableAlternatives (import ./alternatives-plugin.nix {
-      inherit stdenv buildPythonPackage pythonPackages fetchFromGitHub;
+      inherit stdenv buildPythonApplication pythonPackages fetchFromGitHub;
     });
 
   buildInputs = with pythonPackages; [

--- a/pkgs/tools/backup/attic/default.nix
+++ b/pkgs/tools/backup/attic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, python3Packages, openssl, acl }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   name = "attic-${version}";
   version = "0.16";
   namePrefix = "";

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python3Packages, acl, lz4, openssl }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   name = "borgbackup-${version}";
   version = "0.30.0";
   namePrefix = "";

--- a/pkgs/tools/backup/obnam/default.nix
+++ b/pkgs/tools/backup/obnam/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, pythonPackages, pycrypto, attr }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "obnam-${version}";
   version = "1.19.1";
 

--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python3Packages, sqlite  }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "s3ql";
   version = "2.13";

--- a/pkgs/tools/backup/wal-e/default.nix
+++ b/pkgs/tools/backup/wal-e/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages, lzop, postgresql, pv }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "wal-e-${version}";
   version = "0.6.10";
 

--- a/pkgs/tools/compression/dtrx/default.nix
+++ b/pkgs/tools/compression/dtrx/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, pythonPackages}:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "dtrx-${version}";
   version = "7.1";
 

--- a/pkgs/tools/filesystems/gitfs/default.nix
+++ b/pkgs/tools/filesystems/gitfs/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, python, buildPythonPackage, pythonPackages }:
+{ stdenv, fetchFromGitHub, python, buildPythonApplication, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "gitfs-0.2.5";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, buildPythonPackage, pykickstart, pyparted, pyblock
+{ stdenv, fetchurl, buildPythonApplication, pykickstart, pyparted, pyblock
 , libselinux, cryptsetup, multipath_tools, lsof, utillinux
 , useNixUdev ? true, udev ? null
 }:
 
 assert useNixUdev -> udev != null;
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "blivet-${version}";
   version = "0.17-1";
 

--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, buildPythonPackage
+{ stdenv, fetchurl, python, buildPythonApplication
 # Propagated to blivet
 , useNixUdev ? true
 # No longer needed, but kept for backwards-compatibility with older NixOps.
@@ -9,7 +9,7 @@
 
 let
   blivet = import ./blivet.nix {
-    inherit stdenv fetchurl buildPythonPackage;
+    inherit stdenv fetchurl buildPythonApplication;
     inherit pykickstart pyparted pyblock cryptsetup multipath_tools;
     inherit useNixUdev;
     inherit (pkgs) lsof utillinux udev;
@@ -48,15 +48,15 @@ let
   };
 
   pykickstart = import ./pykickstart.nix {
-    inherit stdenv fetchurl python buildPythonPackage urlgrabber;
+    inherit stdenv fetchurl python buildPythonApplication urlgrabber;
   };
 
   pyparted = import ./pyparted.nix {
-    inherit stdenv fetchurl python buildPythonPackage parted;
+    inherit stdenv fetchurl python buildPythonApplication parted;
     inherit (pkgs) pkgconfig e2fsprogs;
   };
 
-in buildPythonPackage rec {
+in buildPythonApplication rec {
   name = "nixpart-${version}";
   version = "0.4.1";
 

--- a/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
@@ -1,6 +1,6 @@
-{ stdenv, python, buildPythonPackage, fetchurl, urlgrabber }:
+{ stdenv, python, buildPythonApplication, fetchurl, urlgrabber }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "pykickstart-${version}";
   version = "1.99.39";
 

--- a/pkgs/tools/filesystems/nixpart/0.4/pyparted.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyparted.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, python, buildPythonPackage, parted, e2fsprogs }:
+{ stdenv, fetchurl, pkgconfig, python, buildPythonApplication, parted, e2fsprogs }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "pyparted-${version}";
   version = "3.10";
 

--- a/pkgs/tools/filesystems/nixpart/default.nix
+++ b/pkgs/tools/filesystems/nixpart/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, blivet }:
+{ stdenv, fetchurl, buildPythonApplication, blivet }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "nixpart-${version}";
   version = "1.0.0";
 

--- a/pkgs/tools/misc/apt-offline/default.nix
+++ b/pkgs/tools/misc/apt-offline/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, bash, buildPythonPackage }:
+{ stdenv, fetchurl, bash, buildPythonApplication }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   version = "1.3";
   name = "apt-offline-${version}";
 

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -4,7 +4,7 @@
 , enableBloat ? false
 }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "diffoscope-${version}";
   version = "45";
 

--- a/pkgs/tools/misc/i3minator/default.nix
+++ b/pkgs/tools/misc/i3minator/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, pythonPackages, python }:
+{ stdenv, fetchurl, buildPythonApplication, pythonPackages, python }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   name = "i3minator-${version}";
   version = "0.0.4";
 

--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.isLinux;
 
-python2Packages.buildPythonPackage rec {
+python2Packages.buildPythonApplication rec {
   name = "trash-cli-${version}";
   version = "0.12.9.14";
   namePrefix = "";

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "0.9.0";
   name = "vdirsyncer-${version}";
   namePrefix = "";

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, makeWrapper, ffmpeg, zip
+{ stdenv, fetchurl, buildPythonApplication, makeWrapper, ffmpeg, zip
 , pandoc ? null
 }:
 
@@ -9,7 +9,7 @@
 # case someone wants to use this derivation to build a Git version of
 # the tool that doesn't have the formatted man page included.
 
-buildPythonPackage rec {
+buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
   version = "2016.01.01";

--- a/pkgs/tools/networking/getmail/default.nix
+++ b/pkgs/tools/networking/getmail/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage }:
+{ stdenv, fetchurl, buildPythonApplication }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   version = "4.49.0";
   name = "getmail-${version}";
   namePrefix = "";

--- a/pkgs/tools/networking/gmvault/default.nix
+++ b/pkgs/tools/networking/gmvault/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, fetchurl, buildPythonPackage, pythonPackages }:
+{ pkgs, fetchurl, buildPythonApplication, pythonPackages }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   version = "1.8.1-beta";
   name = "gmvault-${version}";
 

--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "httpie-0.9.2";
   namePrefix = "";
 

--- a/pkgs/tools/networking/offlineimap/default.nix
+++ b/pkgs/tools/networking/offlineimap/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, buildPythonPackage, sqlite3 }:
+{ stdenv, fetchFromGitHub, buildPythonApplication, sqlite3 }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   version = "6.6.1";
   name = "offlineimap-${version}";
   namePrefix = "";

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -5,7 +5,7 @@
 # store path. The problem appears to be non-fatal, but there's probably
 # some loss of functionality because of it.
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   version = "1.10.2";
   name = "tahoe-lafs-${version}";
   namePrefix = "";

--- a/pkgs/tools/networking/s3cmd/default.nix
+++ b/pkgs/tools/networking/s3cmd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "s3cmd-1.5.2";
   
   src = fetchurl {

--- a/pkgs/tools/networking/speedtest-cli/default.nix
+++ b/pkgs/tools/networking/speedtest-cli/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "speedtest-cli-${version}";
   version = "0.3.1";
   namePrefix = "";

--- a/pkgs/tools/networking/urlwatch/default.nix
+++ b/pkgs/tools/networking/urlwatch/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python3Packages }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   name = "urlwatch-2.0";
 
   src = fetchurl {

--- a/pkgs/tools/package-management/nixops/generic.nix
+++ b/pkgs/tools/package-management/nixops/generic.nix
@@ -3,7 +3,7 @@
 , src, version
 }:
 
-pythonPackages.buildPythonPackage {
+pythonPackages.buildPythonApplication {
   name = "nixops-${version}";
   namePrefix = "";
 

--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -1,6 +1,6 @@
 { lib, pythonPackages, fetchurl }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "nox-${version}";
   version = "0.0.2";
   namePrefix = "";

--- a/pkgs/tools/package-management/python2nix/default.nix
+++ b/pkgs/tools/package-management/python2nix/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "python2nix-20140927";
  
   src = fetchFromGitHub {

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -2,7 +2,7 @@
 
 let version = "0.9.3"; in
 
-pythonPackages.buildPythonPackage {
+pythonPackages.buildPythonApplication {
   name = "fail2ban-${version}";
   namePrefix = "";
 

--- a/pkgs/tools/security/knockknock/default.nix
+++ b/pkgs/tools/security/knockknock/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, buildPythonPackage, python, pycrypto, hping }:
+{ stdenv, fetchFromGitHub, buildPythonApplication, python, pycrypto, hping }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   rev  = "bf14bbff";
   name = "knockknock-r${rev}";
 

--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pythonPackages, fetchurl, makeWrapper, pandoc
 , coreutils, iptables, nettools, openssh, procps }:
   
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "sshuttle-${version}";
   version = "0.76";
 

--- a/pkgs/tools/security/volatility/default.nix
+++ b/pkgs/tools/security/volatility/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, buildPythonPackage, pycrypto }:
+{ stdenv, fetchurl, buildPythonApplication, pycrypto }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   namePrefix = "";
   name = "volatility-2.4";
 

--- a/pkgs/tools/system/honcho/default.nix
+++ b/pkgs/tools/system/honcho/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip, pythonPackages, buildPythonPackage }:
+{ stdenv, fetchzip, pythonPackages, buildPythonApplication }:
 
-let honcho = buildPythonPackage rec {
+let honcho = buildPythonApplication rec {
   name = "honcho-${version}";
   version = "0.6.6";
   namePrefix = "";

--- a/pkgs/tools/text/grin/default.nix
+++ b/pkgs/tools/text/grin/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "grin-1.2.1";
   namePrefix = "";
 

--- a/pkgs/tools/typesetting/odpdown/default.nix
+++ b/pkgs/tools/typesetting/odpdown/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, buildPythonPackage, libreoffice, lpod, lxml, mistune, pillow
+{ stdenv, fetchurl, buildPythonApplication, libreoffice, lpod, lxml, mistune, pillow
 , pygments
 }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
 
   name = "odpdown-${version}";
   version = "0.4.1";

--- a/pkgs/tools/video/vnc2flv/default.nix
+++ b/pkgs/tools/video/vnc2flv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "vnc2flv-20100207";
   namePrefix = "";
 

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -2,7 +2,7 @@
 
 let version = "0.7.6";
 
-in pythonPackages.buildPythonPackage rec {
+in pythonPackages.buildPythonApplication rec {
   name = "cloud-init-${version}";
   namePrefix = "";
 

--- a/pkgs/tools/virtualization/euca2ools/default.nix
+++ b/pkgs/tools/virtualization/euca2ools/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, which, pythonPackages }:
 
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonApplication rec {
   name = "euca2ools-2.1.4";
   namePrefix = "";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3197,7 +3197,7 @@ let
   solvespace = callPackage ../applications/graphics/solvespace { };
 
   sonata = callPackage ../applications/audio/sonata {
-    inherit (python3Packages) buildPythonPackage python isPy3k dbus pygobject3 mpd2;
+    inherit (python3Packages) buildPythonApplication python isPy3k dbus pygobject3 mpd2;
   };
 
   sparsehash = callPackage ../development/libraries/sparsehash { };
@@ -13216,7 +13216,7 @@ let
   };
 
   qutebrowser = qt55.callPackage ../applications/networking/browsers/qutebrowser {
-    inherit (python34Packages) buildPythonPackage python pyqt5 jinja2 pygments pyyaml pypeg2;
+    inherit (python34Packages) buildPythonApplication python pyqt5 jinja2 pygments pyyaml pypeg2;
     inherit (gst_all_1) gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav;
   };
 
@@ -14090,7 +14090,7 @@ let
   xpra = callPackage ../tools/X11/xpra { inherit (texFunctions) fontsConf; };
   libfakeXinerama = callPackage ../tools/X11/xpra/libfakeXinerama.nix { };
   #TODO: 'pil' is not available for python3, yet
-  xpraGtk3 = callPackage ../tools/X11/xpra/gtk3.nix { inherit (texFunctions) fontsConf; inherit (python3Packages) buildPythonPackage python cython pygobject3 pycairo; };
+  xpraGtk3 = callPackage ../tools/X11/xpra/gtk3.nix { inherit (texFunctions) fontsConf; inherit (python3Packages) buildPythonApplication python cython pygobject3 pycairo; };
 
   xrestop = callPackage ../tools/X11/xrestop { };
 


### PR DESCRIPTION
In 49c68939db5ae9634f1400cfc7c78253939ff6df buildPythonApplication was introduced.
This commit converts (almost) all occurrences of buildPythonPackage with buildPythonApplication except those in
- pkgs/top-level/python-packages.nix
- pkgs/development/python-modules/
