### PR TITLE
Refactor uWSGI

### DIFF
--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -113,21 +113,24 @@ in {
             vassals = {
               moin = {
                 type = "normal";
-                python2Packages = self: with self; [ moinmoin ];
+                pythonPackages = self: with self; [ moinmoin ];
                 socket = "${config.services.uwsgi.runDir}/uwsgi.sock";
               };
             };
           }
         '';
         description = ''
-          uWSGI configuration. This awaits either a path to file or a set which will be made into one.
-          If given a set, it awaits an attribute <literal>type</literal> which can be either <literal>normal</literal>
-          or <literal>emperor</literal>.
+          uWSGI configuration. It awaits an attribute <literal>type</literal> inside which can be either
+          <literal>normal</literal> or <literal>emperor</literal>.
 
-          For <literal>normal</literal> mode you can specify <literal>python2Packages</literal> and
-          <literal>python3Packages</literal> as functions from libraries set into lists of libraries.
+          For <literal>normal</literal> mode you can specify <literal>pythonPackages</literal> as a function
+          from libraries set into a list of libraries. <literal>pythonpath</literal> will be set accordingly.
+
           For <literal>emperor</literal> mode, you should use <literal>vassals</literal> attribute
           which should be either a set of names and configurations or a path to a directory.
+
+          Other attributes will be used in configuration file as-is. Notice that you can redefine
+          <literal>plugins</literal> setting here.
         '';
       };
 

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -1,28 +1,35 @@
 { stdenv, lib, fetchurl, pkgconfig, jansson
-# plugins: list of strings, eg. [python2, python3]
+# plugins: list of strings, eg. [ "python2" "python3" ]
 , plugins
-, pam, withPAM ? stdenv.isLinux
-, systemd, withSystemd ? stdenv.isLinux
+, pam, withPAM ? false
+, systemd, withSystemd ? false
 , python2, python3, ncurses
 }:
 
-let pythonPlugin = pkg : { name = "python${if pkg ? isPy2 then "2" else "3"}";
-                           interpreter = pkg;
+let pythonPlugin = pkg : lib.nameValuePair "python${if pkg ? isPy2 then "2" else "3"}" {
+                           interpreter = pkg.interpreter;
                            path = "plugins/python";
-                           deps = [ pkg ncurses ];
+                           inputs = [ pkg ncurses ];
                            install = ''
                              install -Dm644 uwsgidecorators.py $out/${pkg.sitePackages}/uwsgidecorators.py
                              ${pkg.executable} -m compileall $out/${pkg.sitePackages}/
                              ${pkg.executable} -O -m compileall $out/${pkg.sitePackages}/
                            '';
                          };
-    available = [ (pythonPlugin python2)
+
+    available = lib.listToAttrs [
+                  (pythonPlugin python2)
                   (pythonPlugin python3)
                 ];
-     needed = builtins.filter (x: lib.any (y: x.name == y) plugins) available;
-in
 
-assert builtins.filter (x: lib.all (y: y.name != x) available) plugins == [];
+    getPlugin = name:
+      let all = lib.concatStringsSep ", " (lib.attrNames available);
+      in if lib.hasAttr name available
+         then lib.getAttr name available // { inherit name; }
+         else throw "Unknown UWSGI plugin ${name}, available : ${all}";
+
+    needed = builtins.map getPlugin plugins;
+in
 
 stdenv.mkDerivation rec {
   name = "uwsgi-2.0.11.2";
@@ -34,17 +41,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python3 pkgconfig ];
 
-  buildInputs =  with stdenv.lib;
-                 [ jansson ]
-              ++ optional withPAM pam
-              ++ optional withSystemd systemd
-              ++ lib.concatMap (x: x.deps) needed
+  buildInputs =  [ jansson ]
+              ++ lib.optional withPAM pam
+              ++ lib.optional withSystemd systemd
+              ++ lib.concatMap (x: x.inputs) needed
               ;
 
-  basePlugins =  with stdenv.lib;
-                 concatStringsSep ","
-                 (  optional withPAM "pam"
-                 ++ optional withSystemd "systemd_logger"
+  basePlugins =  lib.concatStringsSep ","
+                 (  lib.optional withPAM "pam"
+                 ++ lib.optional withSystemd "systemd_logger"
                  );
 
   passthru = {
@@ -59,12 +64,11 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     mkdir -p $pluginDir
     python3 uwsgiconfig.py --build nixos
-    ${lib.concatMapStringsSep ";" (x: "${x.interpreter.interpreter} uwsgiconfig.py --plugin ${x.path} nixos ${x.name}") needed}
+    ${lib.concatMapStringsSep ";" (x: "${x.interpreter} uwsgiconfig.py --plugin ${x.path} nixos ${x.name}") needed}
   '';
 
   installPhase = ''
     install -Dm755 uwsgi $out/bin/uwsgi
-    #cp *_plugin.so $pluginDir || true
     ${lib.concatMapStringsSep "\n" (x: x.install) needed}
   '';
 

--- a/pkgs/servers/uwsgi/nixos.ini
+++ b/pkgs/servers/uwsgi/nixos.ini
@@ -2,4 +2,5 @@
 plugin_dir = @pluginDir@
 main_plugin = @basePlugins@
 json = true
+yaml = false
 inherit = base

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3477,6 +3477,8 @@ let
 
   uwsgi = callPackage ../servers/uwsgi {
     plugins = [];
+    withPAM = stdenv.isLinux;
+    withSystemd = stdenv.isLinux;
   };
 
   vacuum = callPackage ../applications/networking/instant-messengers/vacuum {};


### PR DESCRIPTION
This should address most problems expressed in #13060. cc @makefu for testing. One thing to notice is that I haven't resolved this problem:

> the current documentation for uwsgi is extremely slim - e.g. plugins is empty by default which results in `-- unavailable modifier requested: 0 --`.

because I don't see a way to fix that in NixOS.

This is a breaking change -- instead of `python2Packages` and `python3Packages` we now have just `pythonPackages` which gets a package set corresponding to activated uWSGI plugin (`python2` or `python3`) -- the former behavior was invalid, mixing up packages from both worlds.
