### PR TITLE
Fix broken "khard"

### DIFF
--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -11,14 +11,15 @@ pythonPackages.buildPythonPackage rec {
   };
 
   propagatedBuildInputs = with pythonPackages; [
+    atomicwrites
     configobj
     vobject
     argparse
+    pyyaml
   ];
 
   buildInputs = with pythonPackages; [
     pkgs.vdirsyncer
-    pyyaml
   ];
 
   meta = {


### PR DESCRIPTION
~~This reverts commit 51e0077e79975649df8c0127a39065cf001c599e.~~

---

~~This revert is done due to a runtime error. `khard` does not find the `yaml` module anymore, though dependency have not changed as far as I can see and the `pyyaml` module is in the dependencies.~~

~~Reverting to previous version (I don't know why there was a version hop between 0.6.\* and 0.8.*) until I can find the issue.~~

---

Fixed import failure by re-writing dependencies and adding missing one.
