### PR TITLE
git: fixes references to gettext properly

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
   patches = [
     ./docbook2texi.patch
     ./symlinks-in-bin.patch
+    ./git-sh-i18n.patch
   ];
 
   buildInputs = [curl openssl zlib expat gettext cpio makeWrapper libiconv]
@@ -85,7 +86,7 @@ stdenv.mkDerivation {
 
       # Fix references to gettext.
       substituteInPlace $out/libexec/git-core/git-sh-i18n \
-          --replace 'gettext.sh' '${gettext}/bin/gettext.sh'
+          --subst-var-by gettext ${gettext}
 
       # gzip (and optionally bzip2, xz, zip) are runtime dependencies for
       # gitweb.cgi, need to patch so that it's found

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -1,0 +1,78 @@
+diff --git a/git-sh-i18n.sh b/git-sh-i18n.sh
+index e6c3116..4e34a2c 100644
+--- a/git-sh-i18n.sh
++++ b/git-sh-i18n.sh
+@@ -15,69 +15,11 @@ else
+ fi
+ export TEXTDOMAINDIR
+ 
+-# First decide what scheme to use...
+-GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
+-if test -n "@@USE_GETTEXT_SCHEME@@"
+-then
+-	GIT_INTERNAL_GETTEXT_SH_SCHEME="@@USE_GETTEXT_SCHEME@@"
+-elif test -n "$GIT_INTERNAL_GETTEXT_TEST_FALLBACKS"
+-then
+-	: no probing necessary
+-elif test -n "$GIT_GETTEXT_POISON"
+-then
+-	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
+-elif type gettext.sh >/dev/null 2>&1
+-then
+-	# GNU libintl's gettext.sh
+-	GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
+-elif test "$(gettext -h 2>&1)" = "-h"
+-then
+-	# gettext binary exists but no gettext.sh. likely to be a gettext
+-	# binary on a Solaris or something that is not GNU libintl and
+-	# lack eval_gettext.
+-	GIT_INTERNAL_GETTEXT_SH_SCHEME=gettext_without_eval_gettext
+-fi
+-export GIT_INTERNAL_GETTEXT_SH_SCHEME
+-
+-# ... and then follow that decision.
+-case "$GIT_INTERNAL_GETTEXT_SH_SCHEME" in
+-gnu)
+-	# Use libintl's gettext.sh, or fall back to English if we can't.
+-	. gettext.sh
+-	;;
+-gettext_without_eval_gettext)
+-	# Solaris has a gettext(1) but no eval_gettext(1)
+-	eval_gettext () {
+-		gettext "$1" | (
+-			export PATH $(git sh-i18n--envsubst --variables "$1");
+-			git sh-i18n--envsubst "$1"
+-		)
+-	}
+-	;;
+-poison)
+-	# Emit garbage so that tests that incorrectly rely on translatable
+-	# strings will fail.
+-	gettext () {
+-		printf "%s" "# GETTEXT POISON #"
+-	}
+-
+-	eval_gettext () {
+-		printf "%s" "# GETTEXT POISON #"
+-	}
+-	;;
+-*)
+-	gettext () {
+-		printf "%s" "$1"
+-	}
++# GNU gettext
++export GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
++export PATH=@gettext@/bin:$PATH
+ 
+-	eval_gettext () {
+-		printf "%s" "$1" | (
+-			export PATH $(git sh-i18n--envsubst --variables "$1");
+-			git sh-i18n--envsubst "$1"
+-		)
+-	}
+-	;;
+-esac
++. @gettext@/bin/gettext.sh
+ 
+ # Git-specific wrapper functions
+ gettextln () {


### PR DESCRIPTION
A better implementation of 5273dbf530a1149076cfd22c676b09c5f2627524

Fixes https://github.com/NixOS/nixpkgs/issues/13150

The attached patch removes a whole swath of unnecessary runtime gettext
detection. It also adds gettext on the PATH so that git-rebase can find it.

Built and tested on NixOS. I double-checked the content of git-sh-i18n and ran a `git-rebase` without having gettext available on the PATH.
