### PR TITLE
[WIP, RFC] networking: add veth pairs via nix config

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -335,7 +335,13 @@ in
           ({
             description = "Veth Pair ${n}";
             wantedBy = [ "network.target" (subsystemDevice n) ];
-            after = [ "network-pre.target" ];
+            after = [ "network-pre.target" ] ++ mapAttrsToList (name: container:
+              "container@${name}.service"
+            ) (
+              filterAttrs (name: container:
+                any (i: i == n) container.interfaces
+              ) config.containers
+            );
             before = [ "network-interfaces.target" (subsystemDevice n) ];
             serviceConfig.type = "oneshot";
             serviceConfig.RemainAfterExit = true;

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -770,7 +770,7 @@ in
       { description = "Link configuration of ${i.name}";
         wantedBy = [ "network-interfaces.target" ];
         before = [ "network-interfaces.target" ];
-        bindsTo = [ (subsystemDevice i.name) ];
+        bindsTo = if config.boot.isContainer then [] else [ (subsystemDevice i.name) ];
         after = [ (subsystemDevice i.name) "network-pre.target" ];
         path = [ pkgs.iproute ];
         serviceConfig = {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -265,9 +265,9 @@ in
         generate a random 32-bit ID using the following commands:
 
         <literal>cksum /etc/machine-id | while read c rest; do printf "%x" $c; done</literal>
-        
+
         (this derives it from the machine-id that systemd generates) or
-        
+
         <literal>head -c4 /dev/urandom | od -A none -t x4</literal>
       '';
     };
@@ -609,6 +609,31 @@ in
           description = "The interface the vlan will transmit packets through.";
         };
 
+      };
+    };
+
+    networking.veths = mkOption {
+      default = { };
+      example = {
+        veth0 = {
+          peername = "veth0-peer";
+        };
+        container0 = {
+          peername = "container0-inside";
+        };
+      };
+      description = ''
+        This option allows you to define veth-pairs which are virtual network interfaces that are pair-wise connected. One side can be placed in a network namespace like a container.
+      '';
+
+      type = types.attrsOf types.optionSet;
+
+      options = {
+        peername = mkOption {
+          example = "veth0-peer";
+          type = types.string;
+          description = "Name of the other end of the veth pair.";
+        };
       };
     };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -266,6 +266,7 @@ in rec {
   tests.networking.networkd.macvlan = callTest tests/networking.nix { networkd = true; test = "macvlan"; };
   tests.networking.networkd.sit = callTest tests/networking.nix { networkd = true; test = "sit"; };
   tests.networking.networkd.vlan = callTest tests/networking.nix { networkd = true; test = "vlan"; };
+  #tests.networking.networkd.veth = callTest tests/networking.nix { networkd = true; test = "veth"; };
   tests.networking.scripted.static = callTest tests/networking.nix { networkd = false; test = "static"; };
   tests.networking.scripted.dhcpSimple = callTest tests/networking.nix { networkd = false; test = "dhcpSimple"; };
   tests.networking.scripted.dhcpOneIf = callTest tests/networking.nix { networkd = false; test = "dhcpOneIf"; };
@@ -274,6 +275,7 @@ in rec {
   tests.networking.scripted.macvlan = callTest tests/networking.nix { networkd = false; test = "macvlan"; };
   tests.networking.scripted.sit = callTest tests/networking.nix { networkd = false; test = "sit"; };
   tests.networking.scripted.vlan = callTest tests/networking.nix { networkd = false; test = "vlan"; };
+  tests.networking.scripted.veth = callTest tests/networking.nix { networkd = false; test = "veth"; };
   # TODO: put in networking.nix after the test becomes more complete
   tests.networkingProxy = callTest tests/networking-proxy.nix {};
   tests.nfs3 = callTest tests/nfs.nix { version = 3; };

--- a/nixos/tests/containers.nix
+++ b/nixos/tests/containers.nix
@@ -29,91 +29,97 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
-      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+      $machine->waitForUnit("network.target");
 
-      # Start the webserver container.
-      $machine->succeed("nixos-container start webserver");
+      subtest "container webserver", sub {
+        $machine->succeed("nixos-container list") =~ /webserver/ or die;
 
-      # Since "start" returns after the container has reached
-      # multi-user.target, we should now be able to access it.
-      my $ip = $machine->succeed("nixos-container show-ip webserver");
-      chomp $ip;
-      #$machine->succeed("ping -c1 $ip"); # FIXME
-      $machine->succeed("curl --fail http://$ip/ > /dev/null");
+        # Start the webserver container.
+        $machine->succeed("nixos-container start webserver");
 
-      # Stop the container.
-      $machine->succeed("nixos-container stop webserver");
-      $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
+        # Since "start" returns after the container has reached
+        # multi-user.target, we should now be able to access it.
+        my $ip = $machine->succeed("nixos-container show-ip webserver");
+        chomp $ip;
+        #$machine->succeed("ping -c1 $ip"); # FIXME
+        $machine->succeed("curl --fail http://$ip/ > /dev/null");
 
-      # Make sure we have a NixOS tree (required by ‘nixos-container create’).
-      $machine->succeed("PAGER=cat nix-env -qa -A nixos.hello >&2");
+        # Stop the container.
+        $machine->succeed("nixos-container stop webserver");
+        $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
 
-      # Create some containers imperatively.
-      my $id1 = $machine->succeed("nixos-container create foo --ensure-unique-name");
-      chomp $id1;
-      $machine->log("created container $id1");
+        # Destroying a declarative container should fail.
+        $machine->fail("nixos-container destroy webserver");
+      };
 
-      my $id2 = $machine->succeed("nixos-container create foo --ensure-unique-name");
-      chomp $id2;
-      $machine->log("created container $id2");
+      subtest "imperative containers", sub {
+        # Make sure we have a NixOS tree (required by ‘nixos-container create’).
+        $machine->succeed("PAGER=cat nix-env -qa -A nixos.hello >&2");
 
-      die if $id1 eq $id2;
+        # Create some containers imperatively.
+        my $id1 = $machine->succeed("nixos-container create foo --ensure-unique-name");
+        chomp $id1;
+        $machine->log("created container $id1");
 
-      # Put the root of $id2 into a bind mount.
-      $machine->succeed(
-        "mv /var/lib/containers/$id2 /id2-bindmount",
-        "mount --bind /id2-bindmount /var/lib/containers/$id1"
-      );
+        my $id2 = $machine->succeed("nixos-container create foo --ensure-unique-name");
+        chomp $id2;
+        $machine->log("created container $id2");
 
-      my $ip1 = $machine->succeed("nixos-container show-ip $id1");
-      chomp $ip1;
-      my $ip2 = $machine->succeed("nixos-container show-ip $id2");
-      chomp $ip2;
-      die if $ip1 eq $ip2;
+        die if $id1 eq $id2;
 
-      # Create a directory and a file we can later check if it still exists
-      # after destruction of the container.
-      $machine->succeed(
-        "mkdir /nested-bindmount",
-        "echo important data > /nested-bindmount/dummy",
-      );
-
-      # Create a directory with a dummy file and bind-mount it into both
-      # containers.
-      foreach ($id1, $id2) {
-        my $importantPath = "/var/lib/containers/$_/very/important/data";
+        # Put the root of $id2 into a bind mount.
         $machine->succeed(
-          "mkdir -p $importantPath",
-          "mount --bind /nested-bindmount $importantPath"
+          "mv /var/lib/containers/$id2 /id2-bindmount",
+          "mount --bind /id2-bindmount /var/lib/containers/$id1"
         );
-      }
 
-      # Start one of them.
-      $machine->succeed("nixos-container start $id1");
+        my $ip1 = $machine->succeed("nixos-container show-ip $id1");
+        chomp $ip1;
+        my $ip2 = $machine->succeed("nixos-container show-ip $id2");
+        chomp $ip2;
+        die if $ip1 eq $ip2;
 
-      # Execute commands via the root shell.
-      $machine->succeed("nixos-container run $id1 -- uname") =~ /Linux/ or die;
+        # Create a directory and a file we can later check if it still exists
+        # after destruction of the container.
+        $machine->succeed(
+          "mkdir /nested-bindmount",
+          "echo important data > /nested-bindmount/dummy",
+        );
 
-      # Stop and start (regression test for #4989)
-      $machine->succeed("nixos-container stop $id1");
-      $machine->succeed("nixos-container start $id1");
+        # Create a directory with a dummy file and bind-mount it into both
+        # containers.
+        foreach ($id1, $id2) {
+          my $importantPath = "/var/lib/containers/$_/very/important/data";
+          $machine->succeed(
+            "mkdir -p $importantPath",
+            "mount --bind /nested-bindmount $importantPath"
+          );
+        }
 
-      # Execute commands via the root shell.
-      $machine->succeed("nixos-container run $id1 -- uname") =~ /Linux/ or die;
+        # Start one of them.
+        $machine->succeed("nixos-container start $id1");
 
-      # Destroy the containers.
-      $machine->succeed("nixos-container destroy $id1");
-      $machine->succeed("nixos-container destroy $id2");
+        # Execute commands via the root shell.
+        $machine->succeed("nixos-container run $id1 -- uname") =~ /Linux/ or die;
 
-      $machine->succeed(
-        # Check whether destruction of any container has killed important data
-        "grep -qF 'important data' /nested-bindmount/dummy",
-        # Ensure that the container path is gone
-        "test ! -e /var/lib/containers/$id1"
-      );
+        # Stop and start (regression test for #4989)
+        $machine->succeed("nixos-container stop $id1");
+        $machine->succeed("nixos-container start $id1");
 
-      # Destroying a declarative container should fail.
-      $machine->fail("nixos-container destroy webserver");
+        # Execute commands via the root shell.
+        $machine->succeed("nixos-container run $id1 -- uname") =~ /Linux/ or die;
+
+        # Destroy the containers.
+        $machine->succeed("nixos-container destroy $id1");
+        $machine->succeed("nixos-container destroy $id2");
+
+        $machine->succeed(
+          # Check whether destruction of any container has killed important data
+          "grep -qF 'important data' /nested-bindmount/dummy",
+          # Ensure that the container path is gone
+          "test ! -e /var/lib/containers/$id1"
+        );
+      };
     '';
 
 })


### PR DESCRIPTION
This allows to define veth pairs and use them in other network components or
with containers and network namespaces.

One issue I didn't yet manage to solve: When releasing veths from network
namespaces, the devices are gone. But the systemd-unit doesn't recognize this.
It only detects the -netdev job as failed when the stop fails (which fails as
the device is already gone).

Because of this it is not possible to use these veth pairs with containers
without manual intervention. Or maybe it works with a clever definition of
unit-dependencies?

Also the networkd-way of doing this is missing completely…
