### PR TITLE
ddclient: add meta.platforms

### DIFF
--- a/pkgs/tools/networking/ddclient/default.nix
+++ b/pkgs/tools/networking/ddclient/default.nix
@@ -32,5 +32,8 @@ buildPerlPackage rec {
     homepage = https://sourceforge.net/p/ddclient/wiki/Home/;
     description = "Client for updating dynamic DNS service entries";
     license = licenses.gpl2Plus;
+
+    # Mostly since `iproute` is Linux only.
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
ddclient is Linux only since iproute is.
