### PR TITLE
mdk: new package

### DIFF
--- a/pkgs/development/tools/mdk/default.nix
+++ b/pkgs/development/tools/mdk/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, intltool, pkgconfig, glib }:
+
+stdenv.mkDerivation {
+  name = "gnu-mdk-1.2.9";
+  src = fetchurl {
+    url = http://ftp.gnu.org/gnu/mdk/v1.2.9/mdk-1.2.9.tar.gz;
+    md5 = "08c96baa4b99dd9d25190dd15fe415a5";
+  };
+  buildInputs = [ intltool pkgconfig glib ];
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp/
+    cp -v ./misc/*.el $out/share/emacs/site-lisp
+  '';
+
+  meta = {
+    description = "GNU MIX Development Kit (MDK)";
+    homepage = https://www.gnu.org/software/mdk/;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2344,6 +2344,8 @@ let
     inherit (gnome) scrollkeeper;
   };
 
+  mdk = callPackage ../development/tools/mdk { };
+
   mdp = callPackage ../applications/misc/mdp { };
 
   mednafen = callPackage ../misc/emulators/mednafen { };


### PR DESCRIPTION
this adds GNU's [MDK](http://www.gnu.org/software/mdk/mdk.html) suite.

a few notes:
- I have declared `stdenv.lib.platforms.all` but have only tested on darwin 10.9 (and it builds and runs fine). I can test on linux tomorrow if you are interested.
- I think many more dependencies may be added (guile, gtk, etc). This adds `mixasm`, `mixvm` binaries, and a few things to `share` (such as an emacs module).

thanks. also, this is my first pull request, apologies if this isn't how it is done.
