### PR TITLE
curl: fixes installation of 7.15

### DIFF
--- a/pkgs/tools/networking/curl/7.15.nix
+++ b/pkgs/tools/networking/curl/7.15.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "061bgjm6rv0l9804vmm4jvr023l52qvmy9qq4zjv4lgqhlljvhz3";
   };
 
+  patches = [ ./disable-ca-install.patch ];
+
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains
   # "-lz -lssl", which aren't necessary direct build inputs of
   # applications that use Curl.

--- a/pkgs/tools/networking/curl/disable-ca-install.patch
+++ b/pkgs/tools/networking/curl/disable-ca-install.patch
@@ -1,0 +1,14 @@
+--- a/lib/Makefile.in
++++ b/lib/Makefile.in
+@@ -106,10 +106,7 @@ else
+ endif
+ 
+ install-data-hook:
+-	@if test -n "@CURL_CA_BUNDLE@"; then \
+-	  $(mkinstalldirs) `dirname $(DESTDIR)@CURL_CA_BUNDLE@`; \
+-	  @INSTALL_DATA@ $(srcdir)/ca-bundle.crt $(DESTDIR)@CURL_CA_BUNDLE@; \
+-        fi
++	echo "install-data-hook disabled"
+ 
+ # this hook is mainly for non-unix systems to build even if configure
+ # isn't run


### PR DESCRIPTION
It was trying to install /etc/ssl/cert/ca-certificates.pem

See https://hydra.nixos.org/build/32167398/nixlog/1
