### PR TITLE
nco: init at 4.5.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -58,6 +58,7 @@
   bosu = "Boris Sukholitko <boriss@gmail.com>";
   bramd = "Bram Duvigneau <bram@bramd.nl>";
   bstrik = "Berno Strik <dutchman55@gmx.com>";
+  bzizou = "Bruno Bzeznik <Bruno@bzizou.net>";
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";

--- a/pkgs/development/libraries/nco/default.nix
+++ b/pkgs/development/libraries/nco/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, netcdf, netcdfcxx4, gsl, udunits, antlr, which, curl }:
+
+stdenv.mkDerivation rec {
+  version = "4.5.5";
+  name = "nco";
+
+  buildInputs = [ netcdf netcdfcxx4 gsl udunits antlr which curl ];
+
+  src = fetchurl {
+    url = "https://github.com/nco/nco/archive/${version}.tar.gz";
+    sha256 = "bc6f5b976fdfbdec51f2ebefa158fa54672442c2fd5f042ba884f9f32c2ad666";
+  };
+
+  meta = { 
+    description = "The NCO (netCDF Operator) toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5";
+    homepage = http://nco.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2426,6 +2426,8 @@ let
 
   netcdfcxx4 = callPackage ../development/libraries/netcdf-cxx4 { };
 
+  nco = callPackage ../development/libraries/nco { };
+
   nc6 = callPackage ../tools/networking/nc6 { };
 
   ncat = callPackage ../tools/networking/ncat { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [X] Built on platform(s): x86_64-linux.
- [ ] Tested compilation of all pkgs that depend on this change.
- [X] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Fixes # .

cc @ .

---

_Please note, that points are not mandatory._
