### PR TITLE
fish: fix hidden dependency on ul(1) on Linux

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ncurses, nettools, python, which, groff, gettext, man_db,
-  bc, libiconv, coreutils, gnused, kbd }:
+  bc, libiconv, coreutils, gnused, kbd, utillinux }:
 
 stdenv.mkDerivation rec {
   name = "fish-${version}";
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
            "$out/share/fish/functions/prompt_pwd.fish"
     substituteInPlace "$out/share/fish/functions/fish_default_key_bindings.fish" \
       --replace "clear;" "${ncurses}/bin/clear;"
+  '' + stdenv.lib.optionalString stdenv.isLinux ''
+    substituteInPlace "$out/share/fish/functions/__fish_print_help.fish" \
+      --replace "| ul" "| ${utillinux}/bin/ul" 
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     sed -i "s|(hostname\||(${nettools}/bin/hostname\||" "$out/share/fish/functions/fish_prompt.fish"
     sed -i "s|Popen(\['manpath'|Popen(\['${man_db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ncurses, nettools, python, which, groff, gettext, man_db,
-  bc, libiconv, coreutils, gnused, kbd, utillinux }:
+  bc, libiconv, coreutils, gnused, kbd, utillinux, glibc }:
 
 stdenv.mkDerivation rec {
   name = "fish-${version}";
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
   '' + stdenv.lib.optionalString stdenv.isLinux ''
     substituteInPlace "$out/share/fish/functions/__fish_print_help.fish" \
       --replace "| ul" "| ${utillinux}/bin/ul" 
+
+    for cur in $out/share/fish/functions/*.fish; do
+      substituteInPlace "$cur" --replace "/usr/bin/getent" "${glibc}/bin/getent" 
+    done
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     sed -i "s|(hostname\||(${nettools}/bin/hostname\||" "$out/share/fish/functions/fish_prompt.fish"
     sed -i "s|Popen(\['manpath'|Popen(\['${man_db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"


### PR DESCRIPTION
This is used in __fish_print_help, which is used for displaying all the
online documentation in fish.
