### PR TITLE
nix-prefetch-git: output base32 hash so output matches nix-build errors

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -326,7 +326,7 @@ else
         clone_user_rev "$tmpFile" "$url" "$rev"
 
         # Compute the hash.
-        hash=$(nix-hash --type $hashType $hashFormat $tmpFile)
+        hash=$(nix-hash --type $hashType --base32 $tmpFile)
         if ! test -n "$QUIET"; then echo "hash is $hash" >&2; fi
 
         # Add the downloaded file to the Nix store.


### PR DESCRIPTION
It turns out hashFormat has never been set.
