### PR TITLE
Upgrade the nightly rust on 15.09

### DIFF
--- a/pkgs/development/compilers/rustc/head.nix
+++ b/pkgs/development/compilers/rustc/head.nix
@@ -1,18 +1,19 @@
+
 { stdenv, callPackage }:
 callPackage ./generic.nix {
-  shortVersion = "2015-08-09";
+  shortVersion = "nightly";
   isRelease = false;
-  # src rev for 2015-08-09's nightly channel
-  srcRev = "a5d33d891";
-  srcSha = "1iivzk9ggjh7y89rbw275apw4rfmzh4jk50kf0milljhvf72660n";
-  snapshotHashLinux686 = "3459275cdf3896f678e225843fa56f0d9fdbabe8";
-  snapshotHashLinux64 = "e451e3bd6e5fcef71e41ae6f3da9fb1cf0e13a0c";
-  snapshotHashDarwin686 = "428944a7984c0988e77909d82ca2ef77d96a1fbd";
-  snapshotHashDarwin64 = "b0515bb7d2892b9a58282fc865fee11a885406d6";
-  snapshotDate = "2015-07-26";
-  snapshotRev = "a5c12f4";
+  srcRev = "98a59cf57e02b6e6a5a3bd74eb47b1422eaacc53";
+  srcSha = "438ffcaed142d8f849106df7083aa590c84a49174f7cd79979d8a8442d6c776a";
+  snapshotHashLinux686 = "a09c4a4036151d0cb28e265101669731600e01f2";
+  snapshotHashLinux64 = "97e2a5eb8904962df8596e95d6e5d9b574d73bf4";
+  snapshotHashDarwin686 = "ca52d2d3ba6497ed007705ee3401cf7efc136ca1";
+  snapshotHashDarwin64 = "3c44ffa18f89567c2b81f8d695e711c86d81ffc7";
+  snapshotDate = "2015-12-18";
+  snapshotRev = "3391630";
   patches = [
     ./patches/head.patch
   ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
 }
+
 

--- a/pkgs/development/compilers/rustc/patches/grsec.patch
+++ b/pkgs/development/compilers/rustc/patches/grsec.patch
@@ -1,16 +1,24 @@
 diff --git a/src/test/run-make/relocation-model/Makefile b/src/test/run-make/relocation-model/Makefile
-index 2fcdd32..2d9ddb0 100644
+index b22f34f..c6489bd 100644
 --- a/src/test/run-make/relocation-model/Makefile
 +++ b/src/test/run-make/relocation-model/Makefile
-@@ -5,9 +5,11 @@ all:
+@@ -2,9 +2,11 @@
+ 
+ all: others
+ 	$(RUSTC) -C relocation-model=dynamic-no-pic foo.rs
++	paxctl -czexm $(TMPDIR)/foo
  	$(call RUN,foo)
  
  	$(RUSTC) -C relocation-model=default foo.rs
 +	paxctl -czexm $(TMPDIR)/foo
  	$(call RUN,foo)
  
+ 	$(RUSTC) -C relocation-model=default --crate-type=dylib foo.rs
+@@ -16,6 +18,7 @@ others:
+ else
+ others:
  	$(RUSTC) -C relocation-model=static foo.rs
 +	paxctl -czexm $(TMPDIR)/foo
  	$(call RUN,foo)
- 
- 	$(RUSTC) -C relocation-model=default --crate-type=dylib foo.rs
+ 	$(RUSTC) -C relocation-model=static --crate-type=dylib foo.rs
+ endif

--- a/pkgs/development/compilers/rustc/patches/head.patch
+++ b/pkgs/development/compilers/rustc/patches/head.patch
@@ -1,18 +1,3 @@
-diff --git a/src/librustc_back/target/mod.rs b/src/librustc_back/target/mod.rs
-index 39e4291..b352bd1 100644
---- a/src/librustc_back/target/mod.rs
-+++ b/src/librustc_back/target/mod.rs
-@@ -179,8 +179,8 @@ impl Default for TargetOptions {
-     fn default() -> TargetOptions {
-         TargetOptions {
-             data_layout: String::new(),
--            linker: "cc".to_string(),
--            ar: "ar".to_string(),
-+            linker: "@ccPath@".to_string(), // ignore-tidy-linelength
-+            ar: "@arPath@".to_string(), // ignore-tidy-linelength
-             pre_link_args: Vec::new(),
-             post_link_args: Vec::new(),
-             cpu: "generic".to_string(),
 diff --git a/src/test/run-pass/issue-20797.rs b/src/test/run-pass/issue-20797.rs
 index 2772fc8..3d37b08 100644
 --- a/src/test/run-pass/issue-20797.rs


### PR DESCRIPTION
- patch prsec for updated tests
- remove the cc / linker patch
###### Things done:
- [X] Tested via `nix.useChroot`.
- [X] Built on platform(s): x86-64.
- [ ] Tested compilation of all pkgs that depend on this change.
- [X] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
