### PR TITLE
libdap: init at 3.15.1

### DIFF
--- a/pkgs/development/libraries/libdap/default.nix
+++ b/pkgs/development/libraries/libdap/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, bison, libuuid, curl, libxml2, flex }:
+
+stdenv.mkDerivation rec {
+  version = "3.15.1";
+  name = "libdap";
+
+  buildInputs = [ bison libuuid curl libxml2 flex ];
+
+  src = fetchurl {
+    url = "http://www.opendap.org/pub/source/${name}-${version}.tar.gz";
+    sha256 = "6ee13cc69ae0b5e7552ddfd17013ebb385859bba66f42a2cfba3b3be7aa4ef0f";
+  };
+
+  meta = { 
+    description = "A C++ SDK which contains an implementation of DAP";
+    homepage = http://www.opendap.org/download/libdap;
+    license = stdenv.lib.licenses.lgpl2;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7308,6 +7308,8 @@ let
 
   libdaemon = callPackage ../development/libraries/libdaemon { };
 
+  libdap = callPackage ../development/libraries/libdap { };
+
   libdbi = callPackage ../development/libraries/libdbi { };
 
   libdbiDriversBase = callPackage ../development/libraries/libdbi-drivers {


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [X] Built on platform(s): x86_64-linux.
- [ ] Tested compilation of all pkgs that depend on this change.
- [X] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Fixes # .

cc @ .

---

_Please note, that points are not mandatory._
