### PR TITLE
ocamlPackages: add tsdl and result

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-result/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-result/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib }:
+
+let version = "1.1"; in
+
+stdenv.mkDerivation {
+  name = "ocaml-result-${version}";
+
+  src = fetchFromGitHub {
+    owner = "janestreet";
+    repo = "result";
+    rev = "${version}";
+    sha256 = "05y07rxdbkaxsc8cy458y00gq05i8gp35hhwg1b757mam21ccxxz";
+  };
+
+  buildInputs = [ ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = https://github.com/janestreet/result;
+    description = "Compatibility Result module";
+    longDescription = ''
+      Projects that want to use the new result type defined in OCaml >= 4.03
+      while staying compatible with older version of OCaml should use the
+      Result module defined in this library.
+    '';
+    license = stdenv.lib.licenses.bsd3;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, ocaml, findlib, ctypes, result, SDL2, pkgconfig, opam }:
+
+let
+  inherit (stdenv.lib) getVersion;
+
+  pname = "tsdl";
+  version = "0.9.0";
+  webpage = "http://erratique.ch/software/${pname}";
+
+in
+
+stdenv.mkDerivation {
+  name = "ocaml-${pname}-${version}";
+
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    sha256 = "02x0wsy5nxagxrh07yb2h4yqqy1bxryp2gwrylds0j6ybqsv4shm";
+  };
+
+  buildInputs = [ ocaml findlib result pkgconfig opam ];
+  propagatedBuildInputs = [ SDL2 ctypes ];
+
+  createFindlibDestdir = true;
+
+  unpackCmd = "tar xjf $src";
+
+  buildPhase = ''
+    # The following is done to avoid an additional dependency (ncurses)
+    # due to linking in the custom bytecode runtime. Instead, just
+    # compile directly into a native binary, even if it's just a
+    # temporary build product.
+    substituteInPlace myocamlbuild.ml \
+      --replace ".byte" ".native"
+
+    ocaml pkg/build.ml native=true native-dynlink=true
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ${pname}.install | sh
+    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "${webpage}";
+    description = "Thin bindings to the cross-platform SDL library";
+    license = licenses.bsd3;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5001,6 +5001,8 @@ let
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 
+    tsdl = callPackage ../development/ocaml-modules/tsdl { };
+
     twt = callPackage ../development/ocaml-modules/twt { };
 
     typerep = callPackage ../development/ocaml-modules/typerep { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4920,6 +4920,8 @@ let
 
     re2 = callPackage ../development/ocaml-modules/re2 { };
 
+    result = callPackage ../development/ocaml-modules/ocaml-result { };
+
     sequence = callPackage ../development/ocaml-modules/sequence { };
 
     tuntap = callPackage ../development/ocaml-modules/tuntap { };


### PR DESCRIPTION
###### Things done:
- [X] Tested via `nix.useChroot`.
- [X] Built on platform(s): Linux x86-64.
- [X] Tested compilation of all pkgs that depend on this change.
- [X] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Adds 2 new OCaml packages: `tsdl` (SDL2 bindings) and `result` (compatibility module)
