### PR TITLE
rustUnstable.rustc: 2015-08-09 -> 2016-02-22

### DIFF
--- a/pkgs/development/compilers/rustc/head.nix
+++ b/pkgs/development/compilers/rustc/head.nix
@@ -2,11 +2,11 @@
 { stdenv, callPackage }:
 
 callPackage ./generic.nix {
-  shortVersion = "2016-02-01";
+  shortVersion = "2016-02-22";
   isRelease = false;
   forceBundledLLVM = true;
-  srcRev = "094c5b0d6";
-  srcSha = "0908xzxb4q8vqwmzi5c2vzrhfsrw7d18r4n7mq3ir5671y9cqpvz";
+  srcRev = "d1f422ec280b881b8236c5d173103bc799e1590e";
+  srcSha = "b0753045ae438c0869d37f429fe84451dcacc4b2ab9413d34bf29fde94fde462";
 
   /* Rust is bootstrapped from an earlier built version. We need
   to fetch these earlier versions, which vary per platform.


### PR DESCRIPTION
Continuation from https://github.com/NixOS/nixpkgs/pull/13371

@wizeman despite still building and testing these changes locally (I'll tick the "done" boxes as they finish, rust takes a long time ...) how does this look? How do we go about backporting this to 15.09, which is my ultimate goal? I'd like to do as much of that backporting work as possible for this ticket so I can do it in the future too.
###### Things done:
- [x] Tested via `nix.useChroot`.
- [X] Built on platform(s): linux x86-64.
- [ ] Tested compilation of all pkgs that depend on this change.
- [X] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
