### PR TITLE
.github/ISSUE_TEMPLATE.md - get more information

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Basic info
+
+To make sure that we are on the same page:
+
+* Kernel: (run `uname -a`)
+* System: (NixOS: `nixos-version`, Ubuntu/Fedora: `lsb_release -a`, ...)
+* Nix version: (run `nix-env --version`)
+* Channel: (run `nix-instantiate --eval '<nixpkgs>' -A lib.nixpkgsVersion`)
+
+## Describe your issue here
+
+### Expected result
+
+### Actual result
+
+### Steps to reproduce
+


### PR DESCRIPTION
The goal is to get all the necessary information from the reporter upfront.
Too many times the issues submits and we need to do a round of asking before
we can get close to a solution.

In the future we could even add a `nix-bug` or `nix-report` that fetches all that information.
