### PR TITLE
plexpass: 0.9.15.4.1679 -> 0.9.15.5.1712

### DIFF
--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -5,9 +5,9 @@
 
 let
   plexpkg = if enablePlexPass then {
-    version = "0.9.15.4.1679";
-    vsnHash = "e4df231";
-    sha256 = "1l6kw5dkqam1fyihp02p4slxq3yy232dqp0m5dcg1vi146s911dh";
+    version = "0.9.15.5.1712";
+    vsnHash = "ba5070a";
+    sha256 = "0nwcjlfbs8dacp6wzmga75hkx16ngyaqrmdhcx8vqvgwm8l31rxs";
   } else {
     version = "0.9.15.3.1674";
     vsnHash = "f46e7e6";


### PR DESCRIPTION
###### Things done:
- [**no**] Tested via `nix.useChroot`.
- [**yes**] Built on platform(s): Linux.
- [**n/a] Tested compilation of all pkgs that depend on this change.
- [**yes**] Tested execution of binary products.
- [**yes**] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

If someone tells me how to do "Tested via `nix.useChroot`" then I will do that here and on future pull requests. Thanks.
