### PR TITLE
patchelf: fix syntax error during bootstrap

### DIFF
--- a/pkgs/development/tools/misc/patchelf/setup-hook.sh
+++ b/pkgs/development/tools/misc/patchelf/setup-hook.sh
@@ -5,15 +5,16 @@
 fixupOutputHooks+=('if [ -z "$dontPatchELF" ]; then patchELF "$prefix"; fi')
 
 patchELF() {
-    header "shrinking RPATHs of ELF executables and libraries in $prefix"
-
+    local dir=$1
     local i
-    while IFS= read -r -d $'\0' i; do
+    header "shrinking RPATHs of ELF executables and libraries in $dir"
+
+    find "$dir" -type f -print0 | while IFS= read -r -d $'\0' i; do
         if [[ "$i" =~ .build-id ]]; then continue; fi
         if ! isELF "$i"; then continue; fi
         echo "shrinking $i"
         patchelf --shrink-rpath "$i" || true
-    done < <(find "$prefix" -type f -print0)
+    done
 
     stopNest
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested via `nix.useChroot`.
- [ ] Built on platform(s): nixos, linux-x86_64
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes regression after d71a4851e8a2ef52f6d806d65822290cdbae8804 on staging

To explain better: early in the bootstrap, the script is evaluated with `sh` instead of bash, and it fails evaluating the script on the `< <(find)` syntax. I don't believe that the script is actually used at that stage so we can keep all the bashism. This change just tries to make the `sh` parser happy.

/cc @edolstra 
