### PR TITLE
pyelftools: init at 0.23

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16265,6 +16265,32 @@ in modules // {
     };
   });
 
+  pyelftools = buildPythonPackage rec {
+    pname = "pyelftools";
+    version = "0.23";
+    name = "${pname}-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/${pname}/${name}.tar.gz";
+      sha256 = "1pi1mdzfffgl5qcz0prsa7hlbriycy7mgagi0fdrp3vf17fslmzw";
+    };
+
+    checkPhase = ''
+      ${python.interpreter} test/all_tests.py
+    '';
+    # Tests cannot pass against system-wide readelf
+    # https://github.com/eliben/pyelftools/issues/65
+    doCheck = false;
+
+    meta = {
+      description = "A library for analyzing ELF files and DWARF debugging information";
+      homepage = https://github.com/eliben/pyelftools;
+      license = licenses.publicDomain;
+      platforms = platforms.all;
+      maintainers = maintainers.igsha;
+    };
+  };
+
   pyenchant = buildPythonPackage rec {
     name = "pyenchant-1.6.6";
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): x86_64.
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Tested locally for python2.7 and python3.4:

``` bash
 ~ $ nix-shell -I nixpkgs=/home/igor/nixpkgs -p python2Packages.pyelftools
[nix-shell:~]$ which python2
/nix/store/m3m0rrj9xjf5960cf04wl8w9xcah4p70-python-2.7.11/bin/python2

[nix-shell:~]$ python2
Python 2.7.11 (default, Dec  5 2015, 19:47:20) 
[GCC 4.9.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import elftools.elf.elffile as ELF
>>> elff = ELF.ELFFile(open('/nix/store/m3m0rrj9xjf5960cf04wl8w9xcah4p70-python-2.7.11/bin/python2', 'rb'))
>>> elff.header
Container({'e_flags': 0, 'e_shoff': 3872, 'e_phoff': 64, 'e_shnum': 29, 'e_entry': 4196528, 'e_version': 'EV_CURRENT', 'e_machine': 'EM_X86_64', 'e_phnum': 9, 'e_shentsize': 64, 'e_ident': Container({'EI_DATA': 'ELFDATA2LSB', 'EI_OSABI': 'ELFOSABI_SYSV', 'EI_VERSION': 'EV_CURRENT', 'EI_CLASS': 'ELFCLASS64', 'EI_ABIVERSION': 0, 'EI_MAG': [127, 69, 76, 70]}), 'e_type': 'ET_EXEC', 'e_phentsize': 56, 'e_shstrndx': 26, 'e_ehsize': 64})
>>> 
```
