### PR TITLE
Add tcl dependency to newt.

### DIFF
--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, slang, popt }:
+{ fetchurl, stdenv, slang, popt, tcl }:
 
 stdenv.mkDerivation rec {
   name = "newt-0.52.15";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sed -i -e s,/usr/bin/install,install, -e s,-I/usr/include/slang,, Makefile.in po/Makefile
   '';
 
-  buildInputs = [ slang popt ];
+  buildInputs = [ slang popt tcl ];
 
   crossAttrs = {
     makeFlags = "CROSS_COMPILE=${stdenv.cross.config}-";


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux.
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
