### PR TITLE
gcc5: add libgccjit language

### DIFF
--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -6,6 +6,7 @@
 , langAda ? false
 , langVhdl ? false
 , langGo ? false
+, langJit ? false
 , profiledCompiler ? false
 , staticCompiler ? false
 , enableShared ? true
@@ -354,6 +355,7 @@ stdenv.mkDerivation ({
         ++ optional langObjC     "objc"
         ++ optional langObjCpp   "obj-c++"
         ++ optionals crossDarwin [ "objc" "obj-c++" ]
+        ++ optional langJit      "jit"
         )
       )
     }
@@ -365,6 +367,7 @@ stdenv.mkDerivation ({
     ${if cross != null then crossConfigureFlags else ""}
     ${if !bootstrap then "--disable-bootstrap" else ""}
     ${if cross == null then platformFlags else ""}
+    ${if langJit then "--enable-host-shared" else ""}
   ";
 
   targetConfig = if cross != null then cross.config else null;


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): `Linux nitox 4.4.2 #1-NixOS SMP Wed Feb 17 20:31:25 UTC 2016 x86_64 GNU/Linux, 16.03-pre-401d590a64736d3c (Emu)`
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Should this flag be enabled by default? It doesn't pull in extra deps, and the additional .so could live in an extra derivation.
