### PR TITLE
linux_3_10: 3.10.96 -> 3.10.97

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.10.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.10.96";
+  version = "3.10.97";
   extraMeta.branch = "3.10";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "0wnlvbyg92q48kz5cn3bznjkkzpsik8z51dqhcxdpddy1k6iqb3k";
+    sha256 = "0z66nbnbhmzjjbvrd7sbg4351x92grk8xja58rxxbb28cj3sy9r9";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
What is the wizardry needed to build 3.10? Neither the previous 3.10.96 nor the new 3.10.97 build for me.

I just get a whole lot of `Error in reading or end of file`

This should be ok, I want to see if Travis has the same errors I am getting.
