### PR TITLE
linux_3_12: 3.12.53 -> 3.12.54

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.12.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.12.53";
+  version = "3.12.54";
   extraMeta.branch = "3.12";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "1f2h4z8lk1s0h5lw7n3yb47dhpbr7gzma7ifsslwhyjg7s44cb27";
+    sha256 = "0a6wv72257nasc1qrw966ajd60z24cjpc83hnbblsjkfl0b3zrrn";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): Linux/NixOS.
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
