### PR TITLE
linux_3_14: 3.14.60 -> 3.14.61

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.14.60";
+  version = "3.14.61";
   extraMeta.branch = "3.14";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "1zwq0j4slqg33z4yyk5s35hdzrq0g7jk1bd2kvgvkyqn1dkkvh0j";
+    sha256 = "06lrz2z3lskajk87kq1qi8q6rbdczhsz6sbp5cba4i0nw7sg1nbg";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): Linux/NixOS.
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
