### PR TITLE
linux_4_3: 4.3.5 -> 4.3.6

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.3.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.3.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.3.5";
+  version = "4.3.6";
 
   extraMeta.branch = "4.3";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0g656q51nzb61n0kb2k8br9shvz51yh8kyrsblbjmhi4dbcpizr8";
+    sha256 = "0wdd8z4ykjz1rkizlv9dm70vjd87fly4km4bs7av4p5w5xfp98z0";
   };
 
   features.iwlwifi = true;


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): Linux/NixOS.
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Considering 4.3 is EOL'd, what do we usually do with kernels like this?
Keep them around for a bit?
