### PR TITLE
libreswan: add package and service to nixos

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -15,6 +15,7 @@
   aespinosa = "Allan Espinosa <allan.espinosa@outlook.com>";
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";
   aflatter = "Alexander Flatter <flatter@fastmail.fm>";
+  afranchuk = "Alex Franchuk <alex.franchuk@gmail.com>";
   aherrmann = "Andreas Herrmann <andreash87@gmx.ch>";
   ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -328,6 +328,7 @@
   ./services/networking/ircd-hybrid/default.nix
   ./services/networking/kippo.nix
   ./services/networking/lambdabot.nix
+  ./services/networking/libreswan.nix
   ./services/networking/mailpile.nix
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix

--- a/nixos/modules/services/networking/libreswan.nix
+++ b/nixos/modules/services/networking/libreswan.nix
@@ -1,0 +1,126 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.libreswan;
+
+  libexec = "${pkgs.libreswan}/libexec/ipsec";
+  ipsec = "${pkgs.libreswan}/sbin/ipsec";
+
+  trim = chars: str: let
+      nonchars = filter (x : !(elem x.value chars))
+                  (imap (i: v: {ind = (sub i 1); value = v;}) (stringToCharacters str));
+    in
+      if length nonchars == 0 then ""
+      else substring (head nonchars).ind (add 1 (sub (last nonchars).ind (head nonchars).ind)) str;
+  indent = str: concatStrings (concatMap (s: ["  " (trim [" " "\t"] s) "\n"]) (splitString "\n" str));
+  configText = indent (toString cfg.configSetup);
+  connectionText = concatStrings (mapAttrsToList (n: v: 
+    ''
+      conn ${n}
+      ${indent v}
+
+    '') cfg.connections);
+  configFile = pkgs.writeText "ipsec.conf"
+    ''
+      config setup
+      ${configText}
+      
+      ${connectionText}
+    '';
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.libreswan = {
+
+      enable = mkEnableOption "libreswan ipsec service";
+
+      configSetup = mkOption {
+        type = types.lines;
+        default = ''
+            protostack=netkey
+            nat_traversal=yes
+            virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v4:100.64.0.0/10,%v6:fd00::/8,%v6:fe80::/10
+        '';
+        example = ''
+            secretsfile=/root/ipsec.secrets
+            protostack=netkey
+            nat_traversal=yes
+            virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v4:100.64.0.0/10,%v6:fd00::/8,%v6:fe80::/10
+        '';
+        description = "Options to go in the 'config setup' section of the libreswan ipsec configuration";
+      };
+
+      connections = mkOption {
+        type = types.attrsOf types.lines;
+        default = {};
+        example = {
+          myconnection = ''
+            auto=add
+            left=%defaultroute
+            leftid=@user
+
+            right=my.vpn.com
+
+            ikev2=no
+            ikelifetime=8h
+          '';
+        };
+        description = "A set of connections to define for the libreswan ipsec service";
+      };
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.libreswan pkgs.iproute ];
+
+    systemd.services.ipsec = {
+      description = "Internet Key Exchange (IKE) Protocol Daemon for IPsec";
+      path = [
+        "${pkgs.libreswan}"
+        "${pkgs.iproute}"
+        "${pkgs.procps}"
+      ];
+
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        EnvironmentFile = "${pkgs.libreswan}/etc/sysconfig/pluto";
+        ExecStartPre = [
+          "${libexec}/addconn --config ${configFile} --checkconfig"
+          "${libexec}/_stackmanager start"
+          "${ipsec} --checknss"
+          "${ipsec} --checknflog"
+        ];
+        ExecStart = "${libexec}/pluto --config ${configFile} --nofork \$PLUTO_OPTIONS";
+        ExecStop = "${libexec}/whack --shutdown";
+        ExecStopPost = [
+          "${pkgs.iproute}/bin/ip xfrm policy flush"
+          "${pkgs.iproute}/bin/ip xfrm state flush"
+          "${ipsec} --stopnflog"
+        ];
+        ExecReload = "${libexec}/whack --listen";
+      };
+
+    };
+
+  };
+
+}

--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, fetchurl, makeWrapper,
+  pkgconfig, systemd, gmp, unbound, bison, flex, pam, libevent, libcap_ng, curl, nspr,
+  bash, iproute, iptables, procps, coreutils, gnused, gawk, nssTools, which, python,
+  docs ? false, xmlto
+  }:
+
+let
+  optional = stdenv.lib.optional;
+  version = "3.16";
+  name = "libreswan-${version}";
+  binPath = stdenv.lib.makeBinPath [
+    bash iproute iptables procps coreutils gnused gawk nssTools which python
+  ];
+in
+
+assert docs -> xmlto != null;
+
+stdenv.mkDerivation {
+  inherit name;
+  inherit version;
+
+  src = fetchurl {
+    url = "https://download.libreswan.org/${name}.tar.gz";
+    sha256 = "15qv4101p1jw591l04gsfscb3farzd278mgi8yph015vmifyjxrd";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pkgconfig bash iproute iptables systemd coreutils gnused gawk gmp unbound bison flex pam libevent
+                  libcap_ng curl nspr nssTools python ]
+                ++ optional docs xmlto;
+
+  prePatch = ''
+    # Correct bash path
+    sed -i -e 's|/bin/bash|/usr/bin/env bash|' mk/config.mk
+
+    # Fix systemd unit directory, and prevent the makefile from trying to reload the systemd daemon
+    sed -i -e 's|UNITDIR=.*$|UNITDIR=$\{out}/etc/systemd/system/|' -e 's|systemctl --system daemon-reload|true|' initsystems/systemd/Makefile
+
+    # Fix the ipsec program from crushing the PATH
+    sed -i -e 's|\(PATH=".*"\):.*$|\1:$PATH|' programs/ipsec/ipsec.in
+
+    # Fix python script to use the correct python
+    sed -i -e 's|#!/usr/bin/python|#!/usr/bin/env python|' -e 's/^\(\W*\)installstartcheck()/\1sscmd = "ss"\n\0/' programs/verify/verify.in
+  '';
+  
+  # Set appropriate paths for build
+  preBuild = "export INC_USRLOCAL=\${out}";
+
+  makeFlags = [ 
+    "INITSYSTEM=systemd"
+    (if docs then "all" else "base")
+  ];
+
+  installTargets = [ (if docs then "install" else "install-base") ];
+  # Hack to make install work
+  installFlags = [
+    "FINALVARDIR=\${out}/var"
+    "FINALSYSCONFDIR=\${out}/etc"
+  ];
+
+  postInstall = ''
+    for i in $out/bin/* $out/libexec/ipsec/*; do
+      wrapProgram "$i" --prefix PATH ':' "$out/bin:${binPath}"
+    done
+  '';
+
+  meta = {
+    homepage = "https://libreswan.org";
+    description = "A free software implementation of the VPN protocol based on IPSec and the Internet Key Exchange";
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin ++ stdenv.lib.platforms.freebsd;
+    maintainers = [ stdenv.lib.maintainers.afranchuk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2279,6 +2279,8 @@ let
 
   librdmacm = callPackage ../development/libraries/librdmacm { };
 
+  libreswan = callPackage ../tools/networking/libreswan { };
+
   libwebsockets = callPackage ../development/libraries/libwebsockets { };
 
   limesurvey = callPackage ../servers/limesurvey { };


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux.
- [x] Tested compilation of all pkgs that depend on this change. (none)
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have tested the resulting binaries/services and have been able to use the package to successfully connect to a rather temperamental VPN (to which strongswan couldn't connect).
