### PR TITLE
hovercraft 2.0b1 -> 2.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5777,11 +5777,11 @@ in modules // {
   hovercraft = buildPythonPackage rec {
     disabled = ! isPy3k;
     name = "hovercraft-${version}";
-    version = "2.0b1";
+    version = "2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/hovercraft/${name}.zip";
-      sha256 = "1l88xp563miwwkahil1sxn4kz9khjcx6z85j8d6mq8gjc8rxz3j6";
+      url = "https://pypi.python.org/packages/source/h/hovercraft/${name}.tar.gz";
+      sha256 = "0lqxr816lymgnywln8bbv9nrmkyahjjcjkm9kjyny9bflayz4f1g";
     };
 
     propagatedBuildInputs = with self; [ docutils lxml manuel pygments svg-path watchdog ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): darwin ok
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Fixes # .

cc @ .

---

_Please note, that points are not mandatory._
