### PR TITLE
bitcoin: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchurl, pkgconfig, autoreconfHook, openssl, db48, boost
-, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode
+, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
 , withGui }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-" + version;
-  core_version = "0.11.0";
+  core_version = "0.12.0";
   version = core_version;
 
   src = fetchurl {
     urls = [ "https://bitcoin.org/bin/bitcoin-core-${core_version}/bitcoin-${version}.tar.gz"
              "mirror://sourceforge/bitcoin/Bitcoin/bitcoin-${core_version}/bitcoin-${version}.tar.gz"
            ];
-    sha256 = "51ba1756addfa71567559e3f22331c1d908a63571891287689fff7113035d09f";
+    sha256 = "0f1cda66c841a548a07cc37e80b0727354b1236d9f374c7d44362acdb85eb3e1";
   };
 
   buildInputs = [ pkgconfig autoreconfHook openssl db48 boost zlib
-                  miniupnpc protobuf ]
+                  miniupnpc protobuf libevent]
                   ++ optionals stdenv.isLinux [ utillinux ]
                   ++ optionals withGui [ qt4 qrencode ];
 


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): Linux x64
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Fixes # .

cc @roconnor @AndersonTorres .

---

_Please note, that points are not mandatory._
