### PR TITLE
git: 2.7.0 -> 2.7.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "2.7.0";
+  version = "2.7.1";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "03bvb8s5j8i54qbi3yayl42bv0wf2fpgnh1a2lkhbj79zi7b77zs";
+    sha256 = "1zkbdmh5gvxalr8l1cwnirqq5raijmp2d0s36s6qabrlvqvq2yj7";
   };
 
   patches = [


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

cc @peti @the-kenny @wmertens 
