### PR TITLE
mercurial: 3.5.1 -> 3.7.1

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -3,7 +3,7 @@
 , ApplicationServices, cf-private }:
 
 let
-  version = "3.5.1";
+  version = "3.7.1";
   name = "mercurial-${version}";
 in
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://mercurial.selenic.com/release/${name}.tar.gz";
-    sha256 = "1795ia6ghbqwfp4d6bz0qwlvzymh76zdgk2viikrkqq3ldfs8zcr";
+    sha256 = "1vfgqlb8z2k1vcx2nvcianxmml79cqqqncchw6aj40sa8hgpvlwn";
   };
 
   inherit python; # pass it so that the same version can be used in hg2git


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

cc @edolstra 
