### PR TITLE
slock: 1.2 -> 1.3

### DIFF
--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, xproto, libX11, libXext }:
+{ stdenv, fetchurl, xproto, libX11, libXext, libXrandr }:
 stdenv.mkDerivation rec {
-  name = "slock-1.2";
+  name = "slock-1.3";
   src = fetchurl {
     url = "http://dl.suckless.org/tools/${name}.tar.gz";
-    sha256 = "1crkyr4vblhciy6vnbjwwjnlkm9yg2hzq16v6hzxm20ai67na0il";
+    sha256 = "065xa9hl7zn0lv2f7yjxphqsa35rg6dn9hv10gys0sh4ljpa7d5s";
   };
-  buildInputs = [ xproto libX11 libXext	];
+  buildInputs = [ xproto libX11 libXext libXrandr ];
   installFlags = "DESTDIR=\${out} PREFIX=";
   meta = {
     homepage = http://tools.suckless.org/slock;


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

cc @astsmtl 
