### PR TITLE
yarp (+ libace): init at 2.3.64

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -155,6 +155,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Common Public License 1.0";
   };
 
+  doc = spdx {
+    spdxId = "DOC";
+    fullName = "DOC License";
+  };
+
   efl10 = spdx {
     spdxId = "EFL-1.0";
     fullName = "Eiffel Forum License v1.0";

--- a/pkgs/applications/science/misc/yarp/default.nix
+++ b/pkgs/applications/science/misc/yarp/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, ace
+}:
+
+stdenv.mkDerivation rec {
+  name = "yarp-${version}";
+  version = "2.3.64";
+  src = fetchFromGitHub {
+    owner = "robotology";
+    repo = "yarp";
+    rev = "v2.3.64";
+    sha256 = "0x9sdc8d6rppzf1kx53w0yjlnmz7h75qv62yd3ls09w3cy7nb5x7";
+  };
+
+  buildInputs = [ cmake ace ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Yet Another Robot Platform";
+    homepage = http://yarp.it;
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nico202 ];
+  };
+}
+

--- a/pkgs/development/libraries/ace/default.nix
+++ b/pkgs/development/libraries/ace/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig, libtool, perl
+}:
+
+stdenv.mkDerivation rec {
+  name = "ace-${version}";
+  version = "6.3.3";
+  src = fetchurl {
+    url=http://download.dre.vanderbilt.edu/previous_versions/ACE-6.3.3.tar.bz2;
+    sha256 = "124qk205v8rx8p7rfigsargrpxjx3mh4nr99nlyk9csdc9gy8qpk";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ pkgconfig libtool perl ];
+
+  patchPhase = ''substituteInPlace ./MPC/prj_install.pl \
+    --replace /usr/bin/perl "${perl}/bin/perl"'';
+  
+  preConfigure = ''
+    export INSTALL_PREFIX=$out
+    export ACE_ROOT=$(pwd)
+    export LD_LIBRARY_PATH="$ACE_ROOT/ace:$ACE_ROOT/lib"
+    echo '#include "ace/config-linux.h"' > ace/config.h
+    echo 'include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU'\
+    > include/makeinclude/platform_macros.GNU
+  '';
+
+meta = {
+    description = "ADAPTIVE Communication Environment";
+    homepage = http://www.dre.vanderbilt.edu/~schmidt/ACE.html;
+    license = stdenv.lib.licenses.doc;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nico202 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6889,6 +6889,8 @@ let
 
   glib_networking = callPackage ../development/libraries/glib-networking {};
 
+  ace = callPackage ../development/libraries/ace { };
+
   atk = callPackage ../development/libraries/atk { };
   atkmm = callPackage ../development/libraries/atkmm { };
 
@@ -14137,6 +14139,8 @@ let
   };
 
   pahole = callPackage ../development/tools/misc/pahole {};
+
+  yarp = callPackage ../applications/science/misc/yarp {};
 
   yed = callPackage ../applications/graphics/yed {};
 


### PR DESCRIPTION
Adds YARP, its dependency (ace), add ace licence to licences.nix (http://spdx.org/licenses/DOC.html).
Various optional dependency are not used (ie. It would be useful to add the option to enable python API but I'm not succeeding, if someone wants to help, else I'll update the request when I'll get it working
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux x86-64.
- [x] Tested execution of binary products.
### Extra:

cc @therealpxc 
