### PR TITLE
i3pystatus: 3.33 -> 3.34

### DIFF
--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, libpulseaudio, python3Packages, extraLibs ? [] }:
+
+python3Packages.buildPythonApplication rec {
+  name = "${pname}-${version}";
+  version = "3.34";
+  pname = "i3pystatus";
+  disabled = !python3Packages.isPy3k;
+
+  src = fetchurl {
+    url = "https://pypi.python.org/packages/source/i/${pname}/${name}.tar.gz";
+    sha256 = "1bpkkf9q4zqq7fh65zynbv26nq24rfznmw71jjvda7g8kjrwjdk5";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ keyring colour netifaces praw psutil basiciw ] ++
+    [ libpulseaudio ] ++ extraLibs;
+
+  ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${libpulseaudio}/lib\"";
+  makeWrapperArgs = [ ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
+
+  postInstall = ''
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/${pname}-python-interpreter \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      ${ldWrapperSuffix}
+  '';
+
+  # no tests in tarball
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/enkore/i3pystatus;
+    description = "A complete replacement for i3status";
+    longDescription = ''
+      i3pystatus is a growing collection of python scripts for status output compatible
+      to i3status / i3bar of the i3 window manager.
+    '';
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.igsha ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12467,6 +12467,8 @@ let
 
   i3minator = callPackage ../tools/misc/i3minator { };
 
+  i3pystatus = callPackage ../applications/window-managers/i3/pystatus.nix { };
+
   i3status = callPackage ../applications/window-managers/i3/status.nix { };
 
   i810switch = callPackage ../os-specific/linux/i810switch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5973,41 +5973,6 @@ in modules // {
     };
   };
 
-  i3pystatus = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    version = "3.33";
-    pname = "i3pystatus";
-    namePrefix = "";
-    disabled = !isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/${pname}/${name}.tar.gz";
-      sha256 = "1fs2nlzm9in8bwg8cm3567ayiha0v7k8pn793pm5fb7lywaalasy";
-    };
-
-    propagatedBuildInputs = with self; [ keyring colour netifaces praw psutil
-      basiciw pkgs.libpulseaudio ];
-    ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${pkgs.libpulseaudio}/lib\"";
-    makeWrapperArgs = [ ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
-
-    postInstall = ''
-      makeWrapper ${python.interpreter} $out/bin/${pname}-python-interpreter \
-        --prefix PYTHONPATH : "$PYTHONPATH" \
-        ${ldWrapperSuffix}
-    '';
-
-    meta = {
-      homepage = https://github.com/enkore/i3pystatus;
-      description = "A complete replacement for i3status";
-      longDescription = ''
-        i3pystatus is a growing collection of python scripts for status output compatible
-        to i3status / i3bar of the i3 window manager.
-      '';
-      license = licenses.mit;
-      platforms = platforms.linux;
-    };
-  };
-
   jdcal = buildPythonPackage rec {
     version = "1.0";
     name = "jdcal-${version}";


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): x86_64 linux.
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

``` bash
[23:02] igor@igor-pc nixpkgs (i3pystatus) $ nix-shell --pure -I nixpkgs=/home/igor/nixpkgs/ -p python3Packages.i3pystatus

[nix-shell:~/nixpkgs]$ i3pystatus
{"version": 1, "click_events": true}
[
[{"urgent": false, "name": "i3pystatus.clock.Clock", "instance": "139924714783296", "full_text": "Wed 24 Feb 23:04:15", "markup": "none"}]
,[{"urgent": false, "name": "i3pystatus.clock.Clock", "instance": "139924714783296", "full_text": "Wed 24 Feb 23:04:16", "markup": "none"}]
,[{"urgent": false, "name": "i3pystatus.clock.Clock", "instance": "139924714783296", "full_text": "Wed 24 Feb 23:04:17", "markup": "none"}]
,[{"urgent": false, "name": "i3pystatus.clock.Clock", "instance": "139924714783296", "full_text": "Wed 24 Feb 23:04:18", "markup": "none"}]
^C
[nix-shell:~/nixpkgs]$
```
