### PR TITLE
config.security.oath: new module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -93,6 +93,7 @@
   ./security/ca.nix
   ./security/duosec.nix
   ./security/grsecurity.nix
+  ./security/oath.nix
   ./security/pam.nix
   ./security/pam_usb.nix
   ./security/pam_mount.nix

--- a/nixos/modules/security/oath.nix
+++ b/nixos/modules/security/oath.nix
@@ -1,0 +1,50 @@
+# This module provides configuration for the OATH PAM modules.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options = {
+
+    security.pam.oath = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the OATH (one-time password) PAM module.
+        '';
+      };
+
+      digits = mkOption {
+        type = types.enum [ 6 7 8 ];
+        default = 6;
+        description = ''
+          Specify the length of the one-time password in number of
+          digits.
+        '';
+      };
+
+      window = mkOption {
+        type = types.int;
+        default = 5;
+        description = ''
+          Specify the number of one-time passwords to check in order
+          to accommodate for situations where the system and the
+          client are slightly out of sync (iteration for HOTP or time
+          steps for TOTP).
+        '';
+      };
+
+      usersFile = mkOption {
+        type = types.path;
+        default = "/etc/users.oath";
+        description = ''
+          Set the path to file where the user's credentials are
+          stored. This file must not be world readable!
+        '';
+      };
+    };
+
+  };
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested.
- [x] Built on platform(s): x86_64_linux.
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Add a module to make options to pam_oath module configurable.
These are:
-  window - number of OTPs to check
- digits - length of the OTP (adds support for two-factor auth)
- usersfile - filename to store OATH credentials in

The OATH line in the PAM session section is not needed by OATH. I therefore dropped it.
