### PR TITLE
sauce-connect: 4.3.6 -> 4.3.13

### DIFF
--- a/pkgs/development/tools/sauce-connect/default.nix
+++ b/pkgs/development/tools/sauce-connect/default.nix
@@ -1,20 +1,26 @@
-{ stdenv, lib, fetchurl, zlib }:
+{ stdenv, lib, fetchurl, zlib, unzip }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   name = "sauce-connect-${version}";
-  version = "4.3.6";
+  version = "4.3.13";
 
   src = fetchurl (
     if stdenv.system == "x86_64-linux" then {
       url = "https://saucelabs.com/downloads/sc-${version}-linux.tar.gz";
       sha1 = "0d7d2dc12766ac137e62a3e4dad3025b590f9782";
-    } else {
+    } else if stdenv.system == "i686-linux" then {
       url = "https://saucelabs.com/downloads/sc-${version}-linux32.tar.gz";
       sha1 = "ee2c3002eae3b29df801a2ac1db77bb5f1c97bcc";
+    } else {
+      url = "https://saucelabs.com/downloads/sc-${version}-osx.zip";
+      sha1 = "ihr4ynnyi464pafgqyl5xkhfi13yi76j";
     }
   );
+
+  buildInputs = [ unzip ];
+  phases = "unpackPhase installPhase" + (if stdenv.system == "x86_64-darwin" then "" else "patchPhase");
 
   patchPhase = ''
     patchelf \
@@ -35,6 +41,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     homepage = https://docs.saucelabs.com/reference/sauce-connect/;
     maintainers = with maintainers; [offline];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
This updates to the latest version (4.3.13) and also adds osx support.
- [X] Built on: darwin
- [X] Tested execution of binary products.
