### PR TITLE
stdenv: set SSL_CERT_FILE only if it isn't already

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -384,7 +384,9 @@ paxmark() { true; }
 
 # Prevent OpenSSL-based applications from using certificates in
 # /etc/ssl.
-export SSL_CERT_FILE=/no-cert-file.crt
+if [ -z "$SSL_CERT_FILE" ]; then
+  export SSL_CERT_FILE=/no-cert-file.crt
+fi
 
 
 ######################################################################


### PR DESCRIPTION
This would fix `fetchcargo` breakage caused by it setting `SSL_CERT_FILE` in the derivation, which would later be overridden by stdenv. This is very low-priority because workaround is available (testing in progress), but sounds nice to fix.
##### Things done:
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

(Other points are removed because they are not applicable there IMHO)
