### PR TITLE
sw-raid: make mdmon start from initrd

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -58,6 +58,7 @@ let
 
       # Add RAID mdadm tool.
       copy_bin_and_libs ${pkgs.mdadm}/sbin/mdadm
+      copy_bin_and_libs ${pkgs.mdadm}/sbin/mdmon
 
       # Copy udev.
       copy_bin_and_libs ${udev}/lib/systemd/systemd-udevd

--- a/nixos/modules/tasks/swraid.nix
+++ b/nixos/modules/tasks/swraid.nix
@@ -12,4 +12,45 @@
     cp -v ${pkgs.mdadm}/lib/udev/rules.d/*.rules $out/
   '';
 
+  systemd.services.mdadmShutdown = {
+    wantedBy = [ "final.target"];
+    after = [ "umount.target" ];
+
+    unitConfig = {
+      DefaultDependencies = false;
+    };
+
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = ''${pkgs.mdadm}/bin/mdadm --wait-clean --scan'';
+    };
+  };
+
+  systemd.services."mdmon@" = {
+    description = "MD Metadata Monitor on /dev/%I";
+
+    unitConfig.DefaultDependencies = false;
+
+    serviceConfig = {
+      Type = "forking";
+      Environment = "IMSM_NO_PLATFORM=1";
+      ExecStart = ''${pkgs.mdadm}/bin/mdmon --offroot --takeover %I'';
+      KillMode = "none";
+    };
+  };
+
+  systemd.services."mdadm-grow-continue@" = {
+    description = "Manage MD Reshape on /dev/%I";
+
+    unitConfig.DefaultDependencies = false;
+
+    serviceConfig = {
+      ExecStart = ''${pkgs.mdadm}/bin/mdadm --grow --continue /dev/%I'';
+      StandardInput = "null";
+      StandardOutput = "null";
+      StandardError = "null";
+      KillMode = "none";
+    };
+  };
+ 
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): NixOS amd64
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Fixes #13058 

After investigating my problem #13058 I found out partitions couldn't be mounted as non read-only because mdmon wasn't started in initrd because the binary wasn't included, so I added it.

The other problem was raids syncing after every boot. This happens because arrays aren't clean on shutdown. I fixed this by adding systemd services for starting/stopping mdmon to ensure proper shutdown. The mdmon@.service is actullay called for by udev rules in https://github.com/nixos/nixpkgs/blob/0e32206a8610bf76bf5e82af4f6dd510a83a3d1d/nixos/modules/tasks/swraid.nix#L12 but is missing.

Referencing this:
https://git.centos.org/blob/rpms!mdadm.git/8c89314bd54c3fdc59cad75f6cc4505a30a8e8fb/SOURCES!mdadm-3.2.6-systemd-various-fixes-for-boot-with-container-arrays.patch
https://github.com/neilbrown/mdadm/blob/master/systemd/mdmon@.service
https://github.com/neilbrown/mdadm/blob/master/systemd/mdadm.shutdown
