### PR TITLE
pythonPackages.sqlalchemy: follows upstream, use "sqlalchemy7" for lecagy

### DIFF
--- a/pkgs/applications/virtualization/openstack/glance.nix
+++ b/pkgs/applications/virtualization/openstack/glance.nix
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
 
   # https://github.com/openstack/glance/blob/stable/liberty/requirements.txt
   propagatedBuildInputs = with pythonPackages; [
-     pbr sqlalchemy_1_0 anyjson eventlet PasteDeploy routes webob sqlalchemy_migrate
+     pbr sqlalchemy anyjson eventlet PasteDeploy routes webob sqlalchemy_migrate
      httplib2 pycrypto iso8601 stevedore futurist keystonemiddleware paste
      jsonschema keystoneclient pyopenssl six retrying semantic-version qpid-python
      WSME osprofiler glance_store castellan taskflow cryptography xattr pysendfile

--- a/pkgs/applications/virtualization/openstack/keystone.nix
+++ b/pkgs/applications/virtualization/openstack/keystone.nix
@@ -18,7 +18,7 @@ pythonPackages.buildPythonApplication rec {
   # https://github.com/openstack/keystone/blob/stable/liberty/requirements.txt
   propagatedBuildInputs = with pythonPackages; [
     pbr webob eventlet greenlet PasteDeploy paste routes cryptography six
-    sqlalchemy_1_0 sqlalchemy_migrate stevedore passlib keystoneclient memcached
+    sqlalchemy sqlalchemy_migrate stevedore passlib keystoneclient memcached
     keystonemiddleware oauthlib pysaml2 dogpile_cache jsonschema pycadf msgpack
     xmlsec MySQL_python
 

--- a/pkgs/applications/virtualization/openstack/neutron.nix
+++ b/pkgs/applications/virtualization/openstack/neutron.nix
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
   # https://github.com/openstack/neutron/blob/stable/liberty/requirements.txt
   propagatedBuildInputs = with pythonPackages; [
    pbr paste PasteDeploy routes debtcollector eventlet greenlet httplib2 requests2
-   jinja2 keystonemiddleware netaddr retrying sqlalchemy_1_0 webob alembic six
+   jinja2 keystonemiddleware netaddr retrying sqlalchemy webob alembic six
    stevedore pecan ryu networking-hyperv MySQL_python
 
    # clients

--- a/pkgs/applications/virtualization/openstack/nova.nix
+++ b/pkgs/applications/virtualization/openstack/nova.nix
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication rec {
 
   # https://github.com/openstack/nova/blob/stable/liberty/requirements.txt
   propagatedBuildInputs = with pythonPackages; [
-    pbr sqlalchemy_1_0 boto decorator eventlet jinja2 lxml routes cryptography
+    pbr sqlalchemy boto decorator eventlet jinja2 lxml routes cryptography
     webob greenlet PasteDeploy paste prettytable sqlalchemy_migrate netaddr
     netifaces paramiko Babel iso8601 jsonschema keystoneclient requests2 six
     stevedore websockify rfc3986 os-brick psutil_1 alembic psycopg2 pymysql

--- a/pkgs/applications/virtualization/virtinst/default.nix
+++ b/pkgs/applications/virtualization/virtinst/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   pythonPath = with pythonPackages;
-    [ setuptools eventlet greenlet gflags netaddr sqlalchemy carrot routes
+    [ setuptools eventlet greenlet gflags netaddr sqlalchemy7 carrot routes
       PasteDeploy m2crypto ipy twisted sqlalchemy_migrate
       distutils_extra simplejson readline glanceclient cheetah lockfile httplib2
       # !!! should libvirt be a build-time dependency?  Note that

--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonApplication, fetchurl, twisted, dateutil, jinja2
-, sqlalchemy , sqlalchemy_migrate_0_7
+, sqlalchemy_migrate_0_7
 , enableDebugClient ? false, pygobject ? null, pyGtkGlade ? null
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5724,7 +5724,7 @@ let
   };
 
   buildbot = callPackage ../development/tools/build-managers/buildbot {
-    inherit (pythonPackages) twisted jinja2 sqlalchemy sqlalchemy_migrate_0_7;
+    inherit (pythonPackages) twisted jinja2 sqlalchemy_migrate_0_7;
     dateutil = pythonPackages.dateutil_1_5;
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): x86_64-linux.
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

I still miss a rebuild of all the derivations that depend on `sqlalchemy`, which could make sense before merging that.

Feedbacks welcome to validate that it is preferable to call `sqlalchemy` the most up to date branch and keep legacy releases with distinct names for those who need it.

---

_Please note, that points are not mandatory._

This makes pythonPackages.sqlalchemy the most up to date revision (it
was called sqlalchemy_1_0 before), and maintains the various “legacy”
versions available as pythonPackages.sqlalchemyX for X in {7,8,9}.

All derivations that required `sqlalchemy_1_0` now require `sqlalchemy`
while those that required `sqlalchemy` now require `sqlalchemy7`.

The derivations are not changed, only the attribute names they are
bound to.
