### PR TITLE
cide: add missing git runtime dependency

### DIFF
--- a/pkgs/development/tools/continuous-integration/cide/default.nix
+++ b/pkgs/development/tools/continuous-integration/cide/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, bundlerEnv, makeWrapper, docker }:
+{ stdenv, lib, bundlerEnv, makeWrapper, docker, git }:
 
 stdenv.mkDerivation rec {
   name = "cide-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     makeWrapper ${env}/bin/cide $out/bin/cide \
-      --set PATH ${docker}/bin
+      --set PATH ${docker}/bin:${git}/bin
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): NixOS amd64
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`git` is being used during `cide package`
