### PR TITLE
xerces-c: 3.1.1 -> 3.1.3

### DIFF
--- a/pkgs/development/libraries/xercesc/default.nix
+++ b/pkgs/development/libraries/xercesc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "xerces-c-${version}";
-  version = "3.1.1";
+  version = "3.1.3";
 
   src = fetchurl {
     url = "mirror://apache/xerces/c/3/sources/${name}.tar.gz";
-    sha256 = "0dl7jr26vlh5p3hps86xrwyafq6f21schc9q4zyxb48b3vvqa9x4";
+    sha256 = "0jav1cbwcyq4miy790dd62yrypf7n0j98vdin9ny30f9nwyzgm7k";
   };
 
   meta = {


### PR DESCRIPTION
Xerces has had many bugfixes between 3.1.1 and 3.1.3, including a recent buffer overflow. This update is binary compatible with 3.1.1, and should be backported to 15.09.

http://seclists.org/oss-sec/2016/q1/4392
###### Things done:
- [X] Tested via `nix.useChroot`.
- [X] Built on platform(s): linux x86 64.
- [X] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
