### PR TITLE
kde5.filelight: init at 15.12

### DIFF
--- a/pkgs/applications/kde-apps-15.12/default.nix
+++ b/pkgs/applications/kde-apps-15.12/default.nix
@@ -35,6 +35,7 @@ let
     dolphin = callPackage ./dolphin.nix {};
     dolphin-plugins = callPackage ./dolphin-plugins.nix {};
     ffmpegthumbs = callPackage ./ffmpegthumbs.nix {};
+    filelight = callPackage ./filelight.nix {};
     gpgmepp = callPackage ./gpgmepp.nix {};
     gwenview = callPackage ./gwenview.nix {};
     kate = callPackage ./kate.nix {};

--- a/pkgs/applications/kde-apps-15.12/filelight.nix
+++ b/pkgs/applications/kde-apps-15.12/filelight.nix
@@ -1,0 +1,35 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, qtscript
+, kio
+, solid
+, kxmlgui
+, kparts
+}:
+
+kdeApp {
+  name = "filelight";
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+  buildInputs = [
+    kio
+    kparts
+    qtscript
+    solid
+    kxmlgui
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/filelight"
+  '';
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): NixOS.
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
