### PR TITLE
kde5.kcalc: init at 15.12

### DIFF
--- a/pkgs/applications/kde-apps-15.12/default.nix
+++ b/pkgs/applications/kde-apps-15.12/default.nix
@@ -38,6 +38,7 @@ let
     gpgmepp = callPackage ./gpgmepp.nix {};
     gwenview = callPackage ./gwenview.nix {};
     kate = callPackage ./kate.nix {};
+    kcalc = callPackage ./kcalc.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };

--- a/pkgs/applications/kde-apps-15.12/kcalc.nix
+++ b/pkgs/applications/kde-apps-15.12/kcalc.nix
@@ -1,0 +1,38 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, kconfig
+, kconfigwidgets
+, kguiaddons
+, kinit
+, knotifications
+
+}:
+
+kdeApp {
+  name = "kcalc";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    kconfig
+    kconfigwidgets
+    kguiaddons
+    kinit
+    knotifications
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/kcalc"
+  '';
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): .
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
