### PR TITLE
kde5.kdepim

### DIFF
--- a/pkgs/desktops/kde-5/applications-16.04/akonadi-calendar.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/akonadi-calendar.nix
@@ -1,0 +1,30 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, kio
+, kwallet
+}:
+
+kdeApp {
+  name = "akonadi-calendar";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  buildInputs = [
+    kio
+    kwallet
+
+  ];
+
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/akonadi-calendar.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/akonadi-calendar.nix
@@ -16,7 +16,7 @@ kdeApp {
     makeQtWrapper
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     kio
     kwallet
 

--- a/pkgs/desktops/kde-5/applications-16.04/akonadi.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/akonadi.nix
@@ -1,0 +1,36 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, shared_mime_info
+}:
+
+kdeApp {
+  name = "akonadi";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  buildInputs = [
+    shared_mime_info
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/akonadi_agent_launcher"
+    wrapQtProgram "$out/bin/akonadi_agent_server"
+    wrapQtProgram "$out/bin/akonadi_control"
+    wrapQtProgram "$out/bin/akonadi_rds"
+    wrapQtProgram "$out/bin/akonadictl"
+    wrapQtProgram "$out/bin/akonadiserver"
+    wrapQtProgram "$out/bin/asapcat"
+  '';
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/akonadi.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/akonadi.nix
@@ -4,6 +4,7 @@
 , kdoctools
 , makeQtWrapper
 , shared_mime_info
+, kitemviews
 }:
 
 kdeApp {
@@ -15,7 +16,8 @@ kdeApp {
     makeQtWrapper
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
+    kitemviews
     shared_mime_info
   ];
 

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -30,6 +30,7 @@ let
 
     kdelibs = callPackage ./kdelibs { inherit (pkgs) attica phonon; };
 
+    akonadi = callPackage ./akonadi.nix {};
     ark = callPackage ./ark.nix {};
     baloo-widgets = callPackage ./baloo-widgets.nix {};
     dolphin = callPackage ./dolphin.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -53,6 +53,7 @@ let
     kldap = callPackage ./kldap.nix {};
     kmime = callPackage ./kmime.nix {};
     konsole = callPackage ./konsole.nix {};
+    kpimtextedit = callPackage ./kpimtextedit.nix {};
     libkdcraw = callPackage ./libkdcraw.nix {};
     libkexiv2 = callPackage ./libkexiv2.nix {};
     libkipi = callPackage ./libkipi.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -43,6 +43,7 @@ let
     kcalc = callPackage ./kcalc.nix {};
     kcalcore = callPackage ./kcalcore.nix {};
     kcolorchooser = callPackage ./kcolorchooser.nix {};
+    kcontacts = callPackage ./kcontacts.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -47,6 +47,7 @@ let
     kcontacts = callPackage ./kcontacts.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
+    kdepim = callPackage ./kdepim.nix {};
     kdepimlibs = callPackage ./kdepimlibs.nix {};
     kmailtransport = callPackage ./kmailtransport.nix {};
     kmbox = callPackage ./kmbox.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -46,6 +46,7 @@ let
     kcontacts = callPackage ./kcontacts.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
+    kmailtransport = callPackage ./kmailtransport.nix {};
     kmbox = callPackage ./kmbox.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };
     kio-extras = callPackage ./kio-extras.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -46,6 +46,7 @@ let
     kcontacts = callPackage ./kcontacts.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
+    kmbox = callPackage ./kmbox.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };
     kio-extras = callPackage ./kio-extras.nix {};
     kldap = callPackage ./kldap.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -50,6 +50,7 @@ let
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };
     kio-extras = callPackage ./kio-extras.nix {};
     kldap = callPackage ./kldap.nix {};
+    kmime = callPackage ./kmime.nix {};
     konsole = callPackage ./konsole.nix {};
     libkdcraw = callPackage ./libkdcraw.nix {};
     libkexiv2 = callPackage ./libkexiv2.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -49,6 +49,7 @@ let
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
     kdepim = callPackage ./kdepim.nix {};
     kdepimlibs = callPackage ./kdepimlibs.nix {};
+    kdepim-runtime = callPackage ./kdepim-runtime.nix {};
     kmailtransport = callPackage ./kmailtransport.nix {};
     kmbox = callPackage ./kmbox.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -48,6 +48,7 @@ let
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };
     kio-extras = callPackage ./kio-extras.nix {};
+    kldap = callPackage ./kldap.nix {};
     konsole = callPackage ./konsole.nix {};
     libkdcraw = callPackage ./libkdcraw.nix {};
     libkexiv2 = callPackage ./libkexiv2.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -47,6 +47,7 @@ let
     kcontacts = callPackage ./kcontacts.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
+    kdepimlibs = callPackage ./kdepimlibs.nix {};
     kmailtransport = callPackage ./kmailtransport.nix {};
     kmbox = callPackage ./kmbox.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -41,6 +41,7 @@ let
     gwenview = callPackage ./gwenview.nix {};
     kate = callPackage ./kate.nix {};
     kcalc = callPackage ./kcalc.nix {};
+    kcalcore = callPackage ./kcalcore.nix {};
     kcolorchooser = callPackage ./kcolorchooser.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -31,6 +31,7 @@ let
     kdelibs = callPackage ./kdelibs { inherit (pkgs) attica phonon; };
 
     akonadi = callPackage ./akonadi.nix {};
+    akonadi-calendar = callPackage ./akonadi-calendar.nix {};
     ark = callPackage ./ark.nix {};
     baloo-widgets = callPackage ./baloo-widgets.nix {};
     dolphin = callPackage ./dolphin.nix {};

--- a/pkgs/desktops/kde-5/applications-16.04/kcalcore.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kcalcore.nix
@@ -1,0 +1,26 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, kdelibs4support
+, libical
+}:
+
+kdeApp {
+  name = "kcalcore";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    kdelibs4support
+    libical
+  ];
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kcalcore.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kcalcore.nix
@@ -14,7 +14,7 @@ kdeApp {
     kdoctools
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     kdelibs4support
     libical
   ];

--- a/pkgs/desktops/kde-5/applications-16.04/kcontacts.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kcontacts.nix
@@ -17,7 +17,7 @@ kdeApp {
     makeQtWrapper
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     kcodecs
     kcoreaddons
     kconfig

--- a/pkgs/desktops/kde-5/applications-16.04/kcontacts.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kcontacts.nix
@@ -1,0 +1,30 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, kcoreaddons
+, kconfig
+, kcodecs
+}:
+
+kdeApp {
+  name = "kcontacts";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  buildInputs = [
+    kcodecs
+    kcoreaddons
+    kconfig
+  ];
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kdepim-runtime.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kdepim-runtime.nix
@@ -1,0 +1,42 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, akonadi
+, shared_mime_info
+, qtxmlpatterns
+, qtwebkit
+, kdelibs4support
+, knotifyconfig
+, kross
+}:
+
+kdeApp {
+  name = "kdepim-runtime";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    akonadi
+    shared_mime_info
+    qtxmlpatterns
+    qtwebkit
+    kdelibs4support
+    knotifyconfig
+    kross
+  ];
+
+  postInstall = ''
+    ls -l $out/bin
+    wrapQtProgram "$out/bin/kcalc"
+  '';
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kdepim-runtime.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kdepim-runtime.nix
@@ -20,7 +20,7 @@ kdeApp {
     kdoctools
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     akonadi
     shared_mime_info
     qtxmlpatterns

--- a/pkgs/desktops/kde-5/applications-16.04/kdepim.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kdepim.nix
@@ -29,7 +29,7 @@ kdeApp {
     kdoctools
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     akonadi
     grantlee
     qtwebkit

--- a/pkgs/desktops/kde-5/applications-16.04/kdepim.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kdepim.nix
@@ -1,0 +1,60 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, akonadi
+, qtwebkit
+, qtx11extras
+, grantlee
+, gpgme
+, kdelibs4support
+, kwallet
+, knewstuff
+, kcmutils
+, kdewebkit
+, knotifyconfig
+, khtml
+, phonon
+, kdnssd
+, ktexteditor
+, kpimtextedit
+}:
+
+kdeApp {
+  name = "kdepim";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    akonadi
+    grantlee
+    qtwebkit
+    qtx11extras
+    gpgme
+    kdelibs4support
+    kwallet
+    knewstuff
+    kcmutils
+    kdewebkit
+    knotifyconfig
+    khtml
+    phonon
+    kdnssd
+    ktexteditor
+    kpimtextedit
+  ];
+
+  postInstall = ''
+    ls -l $out/bin
+    wrapQtProgram "$out/bin/kcalc"
+  '';
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kdepimlibs.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kdepimlibs.nix
@@ -34,7 +34,7 @@ kdeApp {
     makeQtWrapper
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     akonadi
     kcontacts
     kitemviews

--- a/pkgs/desktops/kde-5/applications-16.04/kdepimlibs.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kdepimlibs.nix
@@ -1,0 +1,69 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, kitemviews
+, kio
+, kdesignerplugin
+, kdbusaddons
+, kitemmodels
+, kguiaddons
+, kiconthemes
+, akonadi
+, kmime
+, shared_mime_info
+, phonon
+, kcontacts
+, kcalcore
+, kdelibs4support
+, libical
+, kldap
+, openldap
+, cyrus_sasl
+, kmbox
+, boost
+}:
+
+kdeApp {
+  name = "kdepimlibs";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  buildInputs = [
+    akonadi
+    kcontacts
+    kitemviews
+    kio
+    kdesignerplugin
+    kdbusaddons
+    kitemmodels
+    kguiaddons
+    kiconthemes
+    kmime
+    shared_mime_info
+    phonon
+    kcalcore
+    kdelibs4support
+    libical
+    kldap
+    openldap
+    cyrus_sasl
+    kmbox
+    boost
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/akonadi2xml"
+    wrapQtProgram "$out/bin/akonadiselftest"
+  '';
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kgpg.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kgpg.nix
@@ -21,7 +21,7 @@ kdeApp {
     perl
     pkgconfig
   ];
-  buildInputs = [
+  propagatedbuildInputs = [
     boost
     gpgme
     kdelibs

--- a/pkgs/desktops/kde-5/applications-16.04/kldap.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kldap.nix
@@ -1,0 +1,34 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, kcompletion
+, kwidgetsaddons
+, openldap
+, cyrus_sasl
+}:
+
+kdeApp {
+  name = "kldap";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    kcompletion
+    kwidgetsaddons
+    openldap
+    cyrus_sasl
+  ];
+
+  propagatedBuildInputs = [
+    cyrus_sasl
+  ];
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kmailtransport.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kmailtransport.nix
@@ -1,0 +1,33 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, kcmutils
+, kwallet
+, kmime
+, akonadi
+}:
+
+kdeApp {
+  name = "kmailtransport";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  buildInputs = [
+    kcmutils
+    kmime
+    kwallet
+    akonadi
+
+  ];
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kmailtransport.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kmailtransport.nix
@@ -18,7 +18,7 @@ kdeApp {
     makeQtWrapper
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     kcmutils
     kmime
     kwallet

--- a/pkgs/desktops/kde-5/applications-16.04/kmbox.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kmbox.nix
@@ -13,7 +13,7 @@ kdeApp {
     kdoctools
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     kmime
   ];
 

--- a/pkgs/desktops/kde-5/applications-16.04/kmbox.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kmbox.nix
@@ -1,0 +1,24 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, kmime
+}:
+
+kdeApp {
+  name = "kmbox";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    kmime
+  ];
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kmime.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kmime.nix
@@ -1,0 +1,24 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, kcodecs
+}:
+
+kdeApp {
+  name = "kmime";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    kcodecs
+  ];
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-16.04/kmime.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kmime.nix
@@ -13,7 +13,7 @@ kdeApp {
     kdoctools
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     kcodecs
   ];
 

--- a/pkgs/desktops/kde-5/applications-16.04/kpimtextedit.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kpimtextedit.nix
@@ -20,7 +20,7 @@ kdeApp {
     kdoctools
   ];
 
-  buildInputs = [
+  propagatedbuildInputs = [
     grantlee
     kcoreaddons
     kemoticons

--- a/pkgs/desktops/kde-5/applications-16.04/kpimtextedit.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/kpimtextedit.nix
@@ -1,0 +1,39 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, grantlee
+, kcoreaddons
+, kemoticons
+, sonnet
+, ktextwidgets
+, kwidgetsaddons
+, kio
+, kiconthemes
+}:
+
+kdeApp {
+  name = "kpimtextedit";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    grantlee
+    kcoreaddons
+    kemoticons
+    sonnet
+    ktextwidgets
+    kwidgetsaddons
+    kio
+    kiconthemes
+  ];
+
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.fridh ];
+  };
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): NixOS .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

All dependencies of kdepim build. It seems as if akonadi is missing AkonadiConfig cmake file causing build of kdepim to fail.
