### PR TITLE
Feature: gimp with plugins

### DIFF
--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -6,6 +6,12 @@
 stdenv.mkDerivation rec {
   name = "gimp-2.8.16";
 
+  # This declarations for `gimp-with-plugins` wrapper,
+  # (used for determining $out/lib/gimp/${majorVersion}/ paths)
+  majorVersion = "2.0";
+  targetPluginDir = "$out/lib/gimp/${majorVersion}/plug-ins";
+  targetScriptDir = "$out/lib/gimp/${majorVersion}/scripts";
+
   src = fetchurl {
     url = "http://download.gimp.org/pub/gimp/v2.8/${name}.tar.bz2";
     sha256 = "1dsgazia9hmab8cw3iis7s69dvqyfj5wga7ds7w2q5mms1xqbqwm";

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -52,7 +52,7 @@ rec {
     name = "gap-2.6.0";
     buildInputs = [ gimp pkgconfig glib pkgs.intltool gimp.gtk ] ++ gimp.nativeBuildInputs;
     src = fetchurl {
-      url = ftp://ftp.gimp.org/pub/gimp/plug-ins/v2.6/gap/gimp-gap-2.6.0.tar.bz2;
+      url = http://ftp.gimp.org/pub/gimp/plug-ins/v2.6/gap/gimp-gap-2.6.0.tar.bz2;
       sha256 = "1jic7ixcmsn4kx2cn32nc5087rk6g8xsrz022xy11yfmgvhzb0ql";
     };
     patchPhase = ''

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -6,9 +6,7 @@
 { pkgs, gimp }:
 let
   inherit (pkgs) stdenv fetchurl pkgconfig glib;
-  targetPluginDir = "$out/${gimp.name}-plugins";
-  targetScriptDir = "$out/${gimp.name}-scripts";
-  prefix = "plugin-gimp-";
+  inherit (gimp) targetPluginDir targetScriptDir;
 
   pluginDerivation = a: stdenv.mkDerivation ({
     prePhases = "extraLib";

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, buildEnv, gimp, makeWrapper, gimpPlugins, plugins ? null}:
+
+let
+allPlugins = lib.filter (pkg: builtins.isAttrs pkg && pkg.type == "derivation") (lib.attrValues gimpPlugins);
+selectedPlugins = if plugins == null then allPlugins else plugins;
+extraArgs = map (x: x.wrapArgs or "") selectedPlugins;
+
+drv = buildEnv {
+  name = "gimp-with-plugins-" + (builtins.parseDrvName gimp.name).version;
+
+  paths = [ gimp ] ++ selectedPlugins;
+
+  postBuild = ''
+    # TODO: This could be avoided if buildEnv could be forced to create all directories
+    if [ -L $out/bin ]; then
+      rm $out/bin
+      mkdir $out/bin
+      for i in ${gimp}/bin/*; do
+        ln -s $i $out/bin
+      done
+    fi
+    for each in gimp-2.8 gimp-console-2.8; do
+      wrapProgram $out/bin/$each \
+        --set GIMP2_PLUGINDIR "$out/lib/gimp/2.0" \
+        ${toString extraArgs}
+    done
+    set +x
+    for each in gimp gimp-console; do
+      ln -sf "$each-2.8" $out/bin/$each
+    done
+  '';
+  };
+in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12225,6 +12225,11 @@ let
 
   gimp = gimp_2_8;
 
+  gimp-with-plugins = callPackage ../applications/graphics/gimp/wrapper.nix {
+    gimp = gimp_2_8;
+    plugins = null; # All packaged plugins enabled, if not explicit plugin list supplied
+  };
+
   gimpPlugins = recurseIntoAttrs (callPackage ../applications/graphics/gimp/plugins {});
 
   gitAndTools = recurseIntoAttrs (callPackage ../applications/version-management/git-and-tools {});


### PR DESCRIPTION
###### Things done:
- [ x ] Tested via `nix.useChroot`.
- [ x ] Built on platform(s): linux.
- [ x ] Tested compilation of all pkgs that depend on this change.
- [ x ] Tested execution of binary products.
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Rework gimp stuff, adding gimp-with-plugin derivation  with all packaged plugins enabled.

Actually only ufraw plugin really tested, others only checked for proper placement.
