### PR TITLE
git-and-tools: alphabetize attributes before it gets too huge

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -10,9 +10,9 @@ let
       asciidoc xmlto docbook2x docbook_xsl docbook_xml_dtd_45 libxslt cpio tcl
       tk makeWrapper subversionClient gzip libiconv;
     texinfo = texinfo5;
-    svnSupport = false;		# for git-svn support
-    guiSupport = false;		# requires tcl/tk
-    sendEmailSupport = false;	# requires plenty of perl libraries
+    svnSupport = false;         # for git-svn support
+    guiSupport = false;         # requires tcl/tk
+    sendEmailSupport = false;   # requires plenty of perl libraries
     perlLibs = [perlPackages.LWP perlPackages.URI perlPackages.TermReadKey];
     smtpPerlLibs = [
       perlPackages.NetSMTP perlPackages.NetSMTPSSL
@@ -24,16 +24,11 @@ let
 
 in
 rec {
+  # Try to keep this generally alphabetized
 
-  # support for bugzilla
-  git-bz = callPackage ./git-bz { };
+  darcsToGit = callPackage ./darcs-to-git { };
 
   git = appendToName "minimal" gitBase;
-
-  # Git with SVN support, but without GUI.
-  gitSVN = lowPrio (appendToName "with-svn" (gitBase.override {
-    svnSupport = true;
-  }));
 
   # The full-featured Git.
   gitFull = gitBase.override {
@@ -42,10 +37,48 @@ rec {
     sendEmailSupport = !stdenv.isDarwin;
   };
 
+  # Git with SVN support, but without GUI.
+  gitSVN = lowPrio (appendToName "with-svn" (gitBase.override {
+    svnSupport = true;
+  }));
+
   git-annex = pkgs.haskellPackages.git-annex-with-assistant;
   gitAnnex = git-annex;
 
   git-annex-remote-b2 = pkgs.goPackages.git-annex-remote-b2;
+
+  # support for bugzilla
+  git-bz = callPackage ./git-bz { };
+
+  git-cola = callPackage ./git-cola { };
+
+  git-crypt = callPackage ./git-crypt { };
+
+  git-extras = callPackage ./git-extras { };
+
+  git-imerge = callPackage ./git-imerge { };
+
+  git-radar = callPackage ./git-radar { };
+
+  git-remote-hg = callPackage ./git-remote-hg { };
+
+  git2cl = import ./git2cl {
+    inherit fetchgit stdenv perl;
+  };
+
+  gitFastExport = import ./fast-export {
+    inherit fetchgit stdenv mercurial coreutils git makeWrapper subversion;
+  };
+
+  gitRemoteGcrypt = callPackage ./git-remote-gcrypt { };
+
+  gitflow = callPackage ./gitflow { };
+
+  hub = import ./hub {
+    inherit go;
+    inherit stdenv fetchgit;
+    inherit (darwin) Security;
+  };
 
   qgit = import ./qgit {
     inherit fetchurl stdenv;
@@ -63,27 +96,7 @@ rec {
     inherit fetchurl stdenv python git;
   };
 
-  topGit = lib.makeOverridable (import ./topgit) {
-    inherit stdenv fetchurl;
-  };
-
-  tig = callPackage ./tig { };
-
-  transcrypt = callPackage ./transcrypt { };
-
-  hub = import ./hub {
-    inherit go;
-    inherit stdenv fetchgit;
-    inherit (darwin) Security;
-  };
-
-  gitFastExport = import ./fast-export {
-    inherit fetchgit stdenv mercurial coreutils git makeWrapper subversion;
-  };
-
-  git2cl = import ./git2cl {
-    inherit fetchgit stdenv perl;
-  };
+  subgit = callPackage ./subgit { };
 
   svn2git = import ./svn2git {
     inherit stdenv fetchurl ruby makeWrapper;
@@ -92,23 +105,11 @@ rec {
 
   svn2git_kde = callPackage ./svn2git-kde { };
 
-  subgit = callPackage ./subgit { };
+  tig = callPackage ./tig { };
 
-  darcsToGit = callPackage ./darcs-to-git { };
+  topGit = lib.makeOverridable (import ./topgit) {
+    inherit stdenv fetchurl;
+  };
 
-  gitflow = callPackage ./gitflow { };
-
-  git-radar = callPackage ./git-radar { };
-
-  git-remote-hg = callPackage ./git-remote-hg { };
-
-  gitRemoteGcrypt = callPackage ./git-remote-gcrypt { };
-
-  git-extras = callPackage ./git-extras { };
-
-  git-cola = callPackage ./git-cola { };
-
-  git-imerge = callPackage ./git-imerge { };
-
-  git-crypt = callPackage ./git-crypt { };
+  transcrypt = callPackage ./transcrypt { };
 }


### PR DESCRIPTION
There should be zero net change to any derivations from this change; it is just alphabetizing the attribute list in this file to keep it manageable as it gets bigger.

To whomever reviews this PR: If you don't think this is a good idea, feel free to decline and close the request, you won't hurt my feelings or anything like that :)
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): .
- [x] Tested compilation of all pkgs that depend on this change.
- [n/a] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
