### PR TITLE
git-stree: init at 0.4.5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -62,6 +62,8 @@ rec {
 
   git-remote-hg = callPackage ./git-remote-hg { };
 
+  git-stree = callPackage ./git-stree { };
+
   git2cl = import ./git2cl {
     inherit fetchgit stdenv perl;
   };

--- a/pkgs/applications/version-management/git-and-tools/git-stree/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-stree/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, ... }:
+
+stdenv.mkDerivation rec {
+  name = "git-stree-${version}";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "tdd";
+    repo = "git-stree";
+    rev = "0.4.5";
+    sha256 = "0y5h44n38w6rhy9m591dvibxpfggj3q950ll7y4h49bhpks4m0l9";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin $out/etc/bash_completion.d
+    install -m 0755 git-stree $out/bin/
+    install -m 0644 git-stree-completion.bash $out/etc/bash_completion.d/
+  '';
+
+  meta = with lib; {
+    description = "A better Git subtree helper command";
+    homepage = http://deliciousinsights.github.io/git-stree;
+    license = licenses.mit;
+    maintainers = [ maintainers.benley ];
+  };
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): Darwin, Linux amd64
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
