### PR TITLE
letsencrypt: 0.1.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/admin/letsencrypt/default.nix
+++ b/pkgs/tools/admin/letsencrypt/default.nix
@@ -1,22 +1,36 @@
-{ stdenv, pythonPackages, fetchurl, dialog }:
+{ stdenv, pythonPackages, fetchFromGitHub, dialog }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "0.1.0";
   name = "letsencrypt-${version}";
+  version = "0.4.0";
 
-  src = fetchurl {
-    url = "https://github.com/letsencrypt/letsencrypt/archive/v${version}.tar.gz";
-    sha256 = "056y5bsmpc4ya5xxals4ypzsm927j6n5kwby3bjc03sy3sscf6hw";
+  src = fetchFromGitHub {
+    owner = "letsencrypt";
+    repo = "letsencrypt";
+    rev = "v${version}";
+    sha256 = "0r2wis48w5nailzp2d5brkh2f40al6sbz816xx0akh3ll0rl1hbv";
   };
 
   propagatedBuildInputs = with pythonPackages; [
-    zope_interface zope_component six requests2 pytz pyopenssl psutil mock acme
-    cryptography configobj pyRFC3339 python2-pythondialog parsedatetime ConfigArgParse
+    ConfigArgParse
+    acme
+    configobj
+    cryptography
+    parsedatetime
+    psutil
+    pyRFC3339
+    pyopenssl
+    python2-pythondialog
+    pytz
+    six
+    zope_component
+    zope_interface
   ];
   buildInputs = with pythonPackages; [ nose dialog ];
 
   patchPhase = ''
     substituteInPlace letsencrypt/notify.py --replace "/usr/sbin/sendmail" "/var/setuid-wrappers/sendmail"
+    substituteInPlace letsencrypt/le_util.py --replace "sw_vers" "/usr/bin/sw_vers"
   '';
 
   postInstall = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -260,7 +260,44 @@ in modules // {
 
     buildInputs = with self; [ nose ];
 
-    sourceRoot = "letsencrypt-${version}/acme";
+    sourceRoot = "letsencrypt-v${version}-src/acme";
+  };
+
+  acme-tiny = buildPythonPackage rec {
+    name = "acme-tiny-${version}";
+    version = "20151229";
+    rev = "f61f72c212cea27f388eb4a26ede0d65035bdb53";
+
+    src = pkgs.fetchgit {
+      inherit rev;
+      url = "https://github.com/diafygi/acme-tiny.git";
+      sha256 = "dde59354e483bdff3dfd06717c094889ae673efb568e40b150b4695b0c539649";
+    };
+
+    # source doesn't have any python "packaging" as such
+    configurePhase = " ";
+    buildPhase = " ";
+    # the tests are... complex
+    doCheck = false;
+
+    patchPhase = ''
+      substituteInPlace acme_tiny.py --replace "openssl" "${pkgs.openssl}/bin/openssl"
+      substituteInPlace letsencrypt/le_util.py --replace '"sw_vers"' '"/usr/bin/sw_vers"'
+    '';
+
+    installPhase = ''
+      mkdir -p $out/${python.sitePackages}/
+      cp acme_tiny.py $out/${python.sitePackages}/
+      mkdir -p $out/bin
+      ln -s $out/${python.sitePackages}/acme_tiny.py $out/bin/acme_tiny
+      chmod +x $out/bin/acme_tiny
+    '';
+
+    meta = {
+      description = "A tiny script to issue and renew TLS certs from Let's Encrypt";
+      homepage = https://github.com/diafygi/acme-tiny;
+      license = licenses.mit;
+    };
   };
 
   acme-tiny = buildPythonPackage rec {


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): NixOS amd64
- [x] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

An updated version of #12123.

When running it tries to access /etc/letsencrypt. Any ideas @benley ?

```
$ letsencrypt 
An unexpected error occurred:
OSError: [Errno 13] Permission denied: '/etc/letsencrypt'
Please see the logfile 'letsencrypt.log' for more details.
```
