### PR TITLE
rubygems: 2.4.8 -> 2.5.2

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems.nix
+++ b/pkgs/development/interpreters/ruby/rubygems.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "rubygems-${version}";
-  version = "2.4.8";
+  version = "2.5.2";
   src = fetchurl {
     url = "http://production.cf.rubygems.org/rubygems/${name}.tgz";
-    sha256 = "0pl4civyf0vhqsqbqaivvxrb3fsg8sid9a8jv5vfnk4hypz3ahss";
+    sha256 = "1jpcmvjfpj2m0jh23371ghfj95gh4jliihzrj5ln0x2cl1pwwwai";
   };
 
   patches = [ ./gem_hook.patch ];


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes #11950
