### PR TITLE
simp_le: external_pem.sh plugin is now called external.sh

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -56,7 +56,7 @@ let
 
       plugins = mkOption {
         type = types.listOf (types.enum [
-          "cert.der" "cert.pem" "chain.pem" "external_pem.sh"
+          "cert.der" "cert.pem" "chain.pem" "external.sh"
           "fullchain.pem" "full.pem" "key.der" "key.pem" "account_key.json"
         ]);
         default = [ "fullchain.pem" "key.pem" "account_key.json" ];


### PR DESCRIPTION
This commit applies the plugin name change to the configuration,
otherwise simp_le fails to start when the old plugin name is used
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): x86_64.
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
