### PR TITLE
Fixes default pager environment

### DIFF
--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -19,7 +19,8 @@ in
     environment.variables =
       { LOCATE_PATH = "/var/cache/locatedb";
         NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-        PAGER = mkDefault "less -R";
+        PAGER = mkDefault "less";
+        LESS = mkDefault "-R";
         EDITOR = mkDefault "nano";
       };
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [ ] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Splits PAGER="less -R" to PAGER="less" and LESS="-R"

Fixes #13436
