### PR TITLE
networkmanager: fix link-local ip addresses

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -252,6 +252,7 @@
       gammu-smsd = 228;
       pdnsd = 229;
       octoprint = 230;
+      avahi-autoipd = 231;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -228,6 +228,11 @@ in {
     users.extraUsers = [{
       name = "nm-openvpn";
       uid = config.ids.uids.nm-openvpn;
+    }
+    {
+      # to enable link-local connections
+      name = "avahi-autoipd";
+      uid = config.ids.uids.avahi-autoipd;
     }];
 
     systemd.packages = cfg.packages;

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
       --replace /bin/sh ${stdenv.shell} \
       --replace /usr/sbin/ethtool ${ethtool}/sbin/ethtool \
       --replace /bin/sed ${gnused}/bin/sed
+    # to enable link-local connections
+    substituteInPlace src/devices/nm-device.c --replace '("avahi-autoipd", NULL, NULL)' '("avahi-autoipd", &"${avahi}/sbin/avahi-autoipd", NULL)'
     configureFlags="$configureFlags --with-udev-dir=$out/lib/udev"
   '';
 


### PR DESCRIPTION
NetworkManager needs an additional avahi-user to use link-local
IPv4 (and probably IPv6) addresses. avahi-autoipd also needs to be
patched to the right path.

fixes https://github.com/NixOS/nixpkgs/issues/8824#issuecomment-121521907
