### PR TITLE
libssh2: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurlBoot, openssl, zlib, windows}:
 
 stdenv.mkDerivation rec {
-  name = "libssh2-1.6.0";
+  name = "libssh2-1.7.0";
 
   src = fetchurlBoot {
     url = "${meta.homepage}/download/${name}.tar.gz";
-    sha256 = "05c2is69c50lyikkh29nk6zhghjk4i7hjx0zqfhq47aald1jj82s";
+    sha256 = "116mh112w48vv9k3f15ggp5kxw5sj4b88dzb5j69llsh7ba1ymp4";
   };
 
   buildInputs = [ openssl zlib ];


### PR DESCRIPTION
I'm not sure if 1.7.0 should be ported back to 15.09, or if the patch option should be taken. I'd be happy to open a PR either way.

Release notes for this update, includes a CVE about inadequate handshakes:

```
This release includes the following changes:
  o libssh2_session_set_last_error: Add function
  o mac: Add support for HMAC-SHA-256 and HMAC-SHA-512
  o WinCNG: support for SHA256/512 HMAC
  o kex: Added diffie-hellman-group-exchange-sha256 support
  o OS/400 crypto library QC3 support
This release includes the following security advisory:
  o diffie_hellman_sha256: convert bytes to bits
    CVE-2016-0787: http://www.libssh2.org/adv_20160223.html
This release includes the following bugfixes:
  o SFTP: Increase speed and datasize in SFTP read
  o openssl: make libssh2_sha1 return error code
  o openssl: fix memleak in _libssh2_dsa_sha1_verify()
  o cmake: include CMake files in the release tarballs
  o Fix builds with Visual Studio 2015
  o hostkey.c: Fix compiling error when OPENSSL_NO_MD5 is defined
  o GNUmakefile: add support for LIBSSH2_LDFLAG_EXTRAS
  o GNUmakefile: add -m64 CFLAGS when targeting mingw64
  o kex: free server host key before allocating it (again)
  o SCP: add libssh2_scp_recv2 to support large (> 2GB) files on windows
  o channel: Detect bad usage of libssh2_channel_process_startup
  o userauth: Fix off by one error when reading public key file
  o kex: removed dupe entry from libssh2_kex_methods
  o _libssh2_error: Support allocating the error message
  o hostkey: fix invalid memory access if libssh2_dsa_new fails
  o hostkey: align code path of ssh_rsa_init to ssh_dss_init
  o libssh2.pc.in: fix the output of pkg-config --libs
  o wincng: fixed possible memory leak in _libssh2_wincng_hash
  o wincng: fixed _libssh2_wincng_hash_final return value
  o add OpenSSL 1.1.0-pre2 compatibility
  o agent_disconnect_unix: unset the agent fd after closing it
  o sftp: stop reading when buffer is full
  o sftp: Send at least one read request before reading
  o sftp: Don't return EAGAIN if data was written to buffer
  o sftp: Check read packet file offset
  o configure: build "silent" if possible
  o openssl: add OpenSSL 1.1.0-pre3-dev compatibility
  o GNUmakefile: list system libs after user libs
```
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [ ] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
