### PR TITLE
autorepeat module: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -450,6 +450,7 @@
   ./services/x11/display-managers/sddm.nix
   ./services/x11/display-managers/slim.nix
   ./services/x11/hardware/libinput.nix
+  ./services/x11/hardware/autorepeat.nix
   ./services/x11/hardware/multitouch.nix
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix

--- a/nixos/modules/services/x11/hardware/autorepeat.nix
+++ b/nixos/modules/services/x11/hardware/autorepeat.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.xserver.autorepeat;
+in {
+  options = {
+    services.xserver.autorepeat.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Enable setting keyboard repeat rate";
+    };
+
+    services.xserver.autorepeat.delay = mkOption {
+      description = "Delay before repeating keys";
+      default = 660;
+      type = types.int;
+    };
+
+    services.xserver.autorepeat.rate = mkOption {
+      description = "Repeat rate of keys";
+      default = 25;
+      type = types.int;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.displayManager.xserverArgs = [
+      "-ardelay ${toString cfg.delay}"
+      "-arinterval ${toString cfg.rate}"
+    ];
+  };
+}


### PR DESCRIPTION
Sets xserver keyboard autorepeat options to the specified values.

module by @puffnfresh, implementation by @Profpatsch

fixes https://github.com/NixOS/nixpkgs/issues/9364#issuecomment-188812740

cc @jb55 @dezgeg 
