### PR TITLE
clamav: 0.98.7 -> 0.99

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, zlib, bzip2, libiconv, libxml2, openssl, ncurses, curl
-, libmilter }:
+, libmilter, pcre }:
 stdenv.mkDerivation rec {
   name = "clamav-${version}";
-  version = "0.98.7";
+  version = "0.99";
 
   src = fetchurl {
     url = "mirror://sourceforge/clamav/clamav-${version}.tar.gz";
-    sha256 = "0wp2ad8km4cqmlndni5ljv7q3lfxm6y4r3giv0yf23bl0yvif918";
+    sha256 = "1abyg349yr31z764jcgx67q5v098jrkrj88bqkzmys6xza62qyfj";
   };
 
-  buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl libiconv libmilter ];
+  buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl libiconv libmilter pcre ];
 
   configureFlags = [
     "--with-zlib=${zlib}"
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     "--with-openssl=${openssl}"
     "--with-libncurses-prefix=${ncurses}"
     "--with-libcurl=${curl}"
+    "--with-pcre=${pcre}"
     "--enable-milter"
     "--disable-clamav"
   ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): 64bit linux/nixos
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory._
