### PR TITLE
pcsx2: init at 1.4.0

### DIFF
--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -1,0 +1,71 @@
+{ alsaLib, cmake, fetchFromGitHub, glib, gtk2, gettext, libaio, libpng
+, makeWrapper, perl, pkgconfig, portaudio, SDL2, soundtouch, stdenv
+, wxGTK30, zlib }:
+
+assert stdenv.isi686;
+
+stdenv.mkDerivation rec {
+  name = "pcsx2-${version}";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "PCSX2";
+    repo = "pcsx2";
+    rev = "v${version}";
+    sha256 = "0s7mxq2cgzwjfsq0vhpz6ljk7wr725nxg48128iyirf85585l691";
+  };
+
+  configurePhase = ''
+    mkdir -p build
+    cd build
+
+    cmake \
+      -DBIN_DIR="$out/bin" \
+      -DCMAKE_BUILD_PO=TRUE \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX="$out" \
+      -DDISABLE_PCSX2_WRAPPER=TRUE \
+      -DDOC_DIR="$out/share/doc/pcsx2" \
+      -DGAMEINDEX_DIR="$out/share/pcsx2" \
+      -DGLSL_SHADER_DIR="$out/share/pcsx2" \
+      -DGTK2_GLIBCONFIG_INCLUDE_DIR='${glib}/lib/glib-2.0/include' \
+      -DGTK2_GDKCONFIG_INCLUDE_DIR='${gtk2}/lib/gtk-2.0/include' \
+      -DGTK2_INCLUDE_DIRS='${gtk2}/include/gtk-2.0' \
+      -DPACKAGE_MODE=TRUE \
+      -DPLUGIN_DIR="$out/lib/pcsx2" \
+      -DREBUILD_SHADER=TRUE \
+      ..
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/PCSX2 \
+      --set __GL_THREADED_OPTIMIZATIONS 1
+  '';
+
+  nativeBuildInputs = [ cmake perl pkgconfig ];
+
+  buildInputs = [
+    alsaLib glib gettext gtk2 libaio libpng makeWrapper portaudio SDL2
+    soundtouch wxGTK30 zlib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Playstation 2 emulator";
+    longDescription= ''
+      PCSX2 is an open-source PlayStation 2 (AKA PS2) emulator. Its purpose
+      is to emulate the PS2 hardware, using a combination of MIPS CPU
+      Interpreters, Recompilers and a Virtual Machine which manages hardware
+      states and PS2 system memory. This allows you to play PS2 games on your
+      PC, with many additional features and benefits.
+    '';
+    homepage = http://pcsx2.net;
+    maintainers = with maintainers; [ hrdinka ];
+
+    # PCSX2's source code is released under LGPLv3+. It However ships
+    # additional data files and code that are licensed differently.
+    # This might be solved in future, for now we should stick with
+    # license.free
+    license = licenses.free;
+    platforms = platforms.i686;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13154,6 +13154,8 @@ let
 
   paraview = callPackage ../applications/graphics/paraview { };
 
+  pcsx2 = callPackage_i686 ../misc/emulators/pcsx2 { };
+
   pencil = callPackage ../applications/graphics/pencil { };
 
   perseus = callPackage ../applications/science/math/perseus {};


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): built on linux x86_64 via callPackage_i686 (pcsx2 is 32bit only)
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products - yes :)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This adds pcsx2 a Playstation 2 emulator. Please note that while its source is licensed under LGPLv3+ some of its content might not. This expression does not use any of the 3rd party libraries, however the state of some additional community contributed files (cheats, performance/widescreen fixes) is not clear, see https://github.com/PCSX2/pcsx2/issues/950. That's why I have chosen `license.free` once the issue is resolved I will change it regardingly.
