### PR TITLE
uhc: 1.1.9.2 -> 1.1.9.3

### DIFF
--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -1,23 +1,17 @@
 # Note: The Haskell package set used for building UHC is
 # determined in the file top-level/haskell-packages.nix.
-# We are using Stackage LTS to avoid constant breakage.
-# Bump the Stackage LTS release to the last release if possible
-# when a new UHC version is released.
-{ stdenv, coreutils, fetchgit, m4, libtool, clang, ghcWithPackages }:
+{ stdenv, coreutils, m4, libtool, clang, ghcWithPackages, fetchFromGitHub }:
 
 let wrappedGhc = ghcWithPackages (hpkgs: with hpkgs; [fgl vector syb uulib network binary hashable uhc-util mtl transformers directory containers array process filepath shuffle uuagc] );
 in stdenv.mkDerivation rec {
-  # Important:
-  # The commits "Fixate/tag v..." are the released versions.
-  # Ignore the "bumped version to ...." commits, they do not
-  # correspond to releases.
-  version = "1.1.9.2";
+  version = "1.1.9.3";
   name = "uhc-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/UU-ComputerScience/uhc.git";
-    rev = "292d259113b98c32154a5be336875751caa5edbc";
-    sha256 = "1f462xq9ilkp9mnxm8hxhh1cdwps5d0hxysyibxryk32l7hh53cz";
+  src = fetchFromGitHub {
+    owner = "UU-ComputerScience";
+    repo = "uhc";
+    rev = "v${version}";
+    sha256 = "1r3mja77dqj2ncgp1d9nnc7dhp3gzrb1b1qvml3rq2321mn3m2ad";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/EHC";
@@ -55,10 +49,5 @@ in stdenv.mkDerivation rec {
     # On Darwin, the GNU libtool is used, which does not
     # support the -static flag and thus breaks the build.
     platforms = ["x86_64-linux"];
-    # Hydra currently doesn't build the Stackage LTS package set,
-    # and we don't want to build all our haskell dependencies
-    # from scratch just to build UHC.
-    hydraPlatforms = stdenv.lib.platforms.none;
-
   };
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -65,10 +65,7 @@ rec {
 
     uhc = callPackage ../development/compilers/uhc/default.nix ({
       stdenv = pkgs.clangStdenv;
-      # UHC 1.1.9.2 is incompatible with hashable 1.2.4.0,
-      # latest LTS with a compatible hashable is LTS 4.1
-      # See also https://github.com/UU-ComputerScience/uhc/issues/69
-      inherit (pkgs.haskell.packages.lts-4_1) ghcWithPackages;
+      inherit (pkgs.haskellPackages) ghcWithPackages;
     });
 
   };


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): Fedora 23 amd64
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Uses hackage again instead of stackage, as this makes hydra builds possible again.

cc @peti 
