### PR TITLE
libretro-mame: init at git-2016-02-10

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchgit, pkgconfig, makeWrapper, python27, retroarch
-, fluidsynth, mesa, SDL, ffmpeg, libpng, libjpeg, libvorbis, zlib }:
+, alsaLib, fluidsynth, mesa, portaudio, SDL, ffmpeg, libpng, libjpeg
+, libvorbis, zlib }:
 
 let
 
@@ -33,7 +34,7 @@ let
       inherit description;
       homepage = "http://www.libretro.com/";
       license = licenses.gpl3Plus;
-      maintainers = with maintainers; [ edwtjo MP2E ];
+      maintainers = with maintainers; [ edwtjo hrdinka MP2E ];
       platforms = platforms.linux;
     };
   } // a);
@@ -131,6 +132,18 @@ in
       sha256 = "16jm97h66bb2sqlimjlks31sapb23x4q8sr16wdqn1xgi670xw3c";
     };
     description = "Enhanced Genesis Plus libretro port";
+  };
+
+  mame = mkLibRetroCore {
+    core = "mame";
+    src = fetchRetro {
+      repo = "mame";
+      rev = "8da2303292bb8530f9f4ffad8bf1df95ee4cab74";
+      sha256 = "0rzy5klp8vf9vc8fylbdnp2qcvl1nkgw5a55ljqc5vich4as5alq";
+    };
+    description = "Port of MAME to libretro";
+
+    extraBuildInputs = [ alsaLib portaudio python27 ];
   };
 
   mednafen-pce-fast = (mkLibRetroCore rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14013,6 +14013,7 @@ let
       ++ optional (cfg.enableFceumm or false) fceumm
       ++ optional (cfg.enableGambatte or false) gambatte
       ++ optional (cfg.enableGenesisPlusGX or false) genesis-plus-gx
+      ++ optional (cfg.enableMAME or false) mame
       ++ optional (cfg.enableMednafenPCEFast or false) mednafen-pce-fast
       ++ optional (cfg.enableMupen64Plus or false) mupen64plus
       ++ optional (cfg.enableNestopia or false) nestopia


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux x86_64
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This adds mame as libretro core.

cc @edwtjo @MP2E.
