### PR TITLE
you-get: init at 0.4.293

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22221,6 +22221,26 @@ in modules // {
     pandoc = null;
   };
 
+  you-get=buildPythonPackage rec {
+    name="you-get-${version}";
+    version="0.4.293";
+    src = pkgs.fetchFromGitHub {
+      owner = "soimort";
+      repo = "you-get";
+      rev = "v${version}";
+      sha256 = "16g1lfjhjaai1k2vfa7fw577bvar20nz8zw75nsz3qy6knla3mzn";
+    };
+    meta={
+      licenses="MIT";
+      description="A tiny command-line utility to download media contents (videos, audios, images) from the Web.";
+      homepage="https://you-get.org/";
+    };
+    disabled=!isPy3k;
+    #namePrefix="";
+    propagateBuildInputs= [pkgs.ffmpeg];
+    doCheck=false;#checks require working sites
+  };
+  
   zbase32 = buildPythonPackage (rec {
     name = "zbase32-1.1.2";
 


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux_x64.
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
