### PR TITLE
cpio: patch CVE-2016-2037, out of bounds write

### DIFF
--- a/pkgs/tools/archivers/cpio/CVE-2016-2037-out-of-bounds-write.patch
+++ b/pkgs/tools/archivers/cpio/CVE-2016-2037-out-of-bounds-write.patch
@@ -1,0 +1,29 @@
+diff --git a/src/copyin.c b/src/copyin.c
+index cde911e..032d35f 100644
+--- a/src/copyin.c
++++ b/src/copyin.c
+@@ -1385,6 +1385,8 @@ process_copy_in ()
+          break;
+        }
+
++      if (file_hdr.c_namesize <= 1)
++        file_hdr.c_name = xrealloc(file_hdr.c_name, 2);
+       cpio_safer_name_suffix (file_hdr.c_name, false, !no_abs_paths_flag,
+                              false);
+
+diff --git a/src/util.c b/src/util.c
+index 6ff6032..2763ac1 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -1411,7 +1411,10 @@ set_file_times (int fd,
+ }
+
+ /* Do we have to ignore absolute paths, and if so, does the filename
+-   have an absolute path?  */
++   have an absolute path?
++   Before calling this function make sure that the allocated NAME buffer has
++   capacity at least 2 bytes to allow us to store the "." string inside.  */
++
+ void
+ cpio_safer_name_suffix (char *name, bool link_target, bool absolute_names,
+                        bool strip_leading_dots)

--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -19,6 +19,10 @@ in stdenv.mkDerivation {
         + "CVE-2015-1197-cpio-2.12.patch";
       sha256 = "0ph43m4lavwkc4gnl5h9p3da4kb1pnhwk5l2qsky70dqri8pcr8v";
     })
+
+    # Report: http://www.openwall.com/lists/oss-security/2016/01/19/4
+    # Patch from https://lists.gnu.org/archive/html/bug-cpio/2016-01/msg00005.html
+    ./CVE-2016-2037-out-of-bounds-write.patch
   ];
 
   preConfigure = if stdenv.isCygwin then ''


### PR DESCRIPTION
As far as I can tell, it is a 1-byte out of bounds write, so pretty small. Causes an application crash. Not sure if it has far reaching consequences beyond that.

Working on ticking these off:
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux x86 64.
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
