### PR TITLE
go-1.6: remove the cacert 1.5 patch

### DIFF
--- a/pkgs/development/compilers/go/1.6.nix
+++ b/pkgs/development/compilers/go/1.6.nix
@@ -90,7 +90,6 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    ./cacert-1.5.patch
     ./remove-tools-1.5.patch
   ]
   # -ldflags=-s is required to compile on Darwin, see


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): x86 64.
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @zimbatm 

The patch was removed in https://github.com/NixOS/nixpkgs/commit/58dbaf69b7abd7a3483d47bd4eede02d68fcdc78
