### PR TITLE
fetchurl: use kernel.org cdn by default

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -61,6 +61,7 @@ rec {
 
   # kernel.org's /pub (/pub/{linux,software}) tree.
   kernel = [
+    http://cdn.kernel.org/pub/
     http://www.all.kernel.org/pub/
     http://ramses.wh2.tu-dresden.de/pub/mirrors/kernel.org/
     http://linux-kernel.uio.no/pub/


### PR DESCRIPTION
- use http://cdn.kernel.org/pub/ as the default mirror
  for kernel source requests.
  Discovered by browsing :
  https://www.kernel.org/introducing-fastly-cdn.html

The cdn actually has a valid ssl cert compared to http://www.all.kernel.org/pub/ which does not.
