### PR TITLE
Remove all dots at end of descriptions

### DIFF
--- a/pkgs/applications/audio/bitmeter/default.nix
+++ b/pkgs/applications/audio/bitmeter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://devel.tlrmx.org/audio/bitmeter/;
-    description = "Also known as jack bitscope. Useful to detect denormals.";
+    description = "Also known as jack bitscope. Useful to detect denormals";
     license = licenses.gpl2;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/chirp/default.nix
+++ b/pkgs/applications/misc/chirp/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A free, open-source tool for programming your amateur radio.";
+    description = "A free, open-source tool for programming your amateur radio";
     homepage = http://chirp.danplanet.com/;
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/misc/devilspie2/default.nix
+++ b/pkgs/applications/misc/devilspie2/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Devilspie2 is a window matching utility.";
+    description = "Devilspie2 is a window matching utility";
     longDescription = ''
       Devilspie2 is a window matching utility, allowing the user to
       perform scripted actions on windows as they are created. For

--- a/pkgs/applications/misc/direwolf/default.nix
+++ b/pkgs/applications/misc/direwolf/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway.";
+    description = "A Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";
     # On the page: This page will be disappearing on October 8, 2015.
     homepage = https://home.comcast.net/~wb2osz/site/;
     license = licenses.gpl2;

--- a/pkgs/applications/misc/jp2a/default.nix
+++ b/pkgs/applications/misc/jp2a/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://csl.name/jp2a/;
-    description = "A small utility that converts JPG images to ASCII.";
+    description = "A small utility that converts JPG images to ASCII";
     license = licenses.gpl2;
   };
 }

--- a/pkgs/applications/misc/multimon-ng/default.nix
+++ b/pkgs/applications/misc/multimon-ng/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = "Multimon is a digital baseband audio protocol decoder.";
+    description = "Multimon is a digital baseband audio protocol decoder";
     longDescription = ''
       multimon-ng a fork of multimon, a digital baseband audio
       protocol decoder for common signaling modes in commercial and

--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "lp_solve is a Mixed Integer Linear Programming (MILP) solver.";
+    description = "lp_solve is a Mixed Integer Linear Programming (MILP) solver";
     homepage    = "http://lpsolve.sourceforge.net";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];

--- a/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-radar/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/michaeldfallen/git-radar;
     license = licenses.mit;
-    description = "Git-radar is a tool you can add to your prompt to provide at-a-glance information on your git repo.";
+    description = "Git-radar is a tool you can add to your prompt to provide at-a-glance information on your git repo";
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ kamilchm ];
   };

--- a/pkgs/applications/window-managers/i3/blocks.nix
+++ b/pkgs/applications/window-managers/i3/blocks.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   installFlags = "PREFIX=\${out} VERSION=${version}";
 
   meta = with stdenv.lib; {
-    description = "A flexible scheduler for your i3bar blocks.";
+    description = "A flexible scheduler for your i3bar blocks";
     homepage = https://github.com/vivien/i3blocks;
     license = licenses.gpl3;
     maintainers = [ "MindTooth" ];

--- a/pkgs/data/icons/vanilla-dmz/default.nix
+++ b/pkgs/data/icons/vanilla-dmz/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with lib; {
     homepage = "http://jimmac.musichall.cz";
-    description = "A style neutral scalable cursor theme.";
+    description = "A style neutral scalable cursor theme";
     platforms = platforms.all;
     license = licenses.cc-by-nc-sa-30;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
-    description = "Whisker Menu is an alternate application launcher for Xfce.";
+    description = "Whisker Menu is an alternate application launcher for Xfce";
     platforms = platforms.linux;
     maintainers = [ maintainers.pjbarnoy ];
   };

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://dotnet.github.io/core/;
-    description = ".NET is a general purpose development platform.";
+    description = ".NET is a general purpose development platform";
     platforms = [ "x86_64-linux" ];
     maintainers = with stdenv.lib.maintainers; [ obadz ];
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/compilers/elm/packages/elm-compiler.nix
+++ b/pkgs/development/compilers/elm/packages/elm-compiler.nix
@@ -33,6 +33,6 @@ mkDerivation {
   ];
   jailbreak = true;
   homepage = "http://elm-lang.org";
-  description = "Values to help with elm-package, elm-make, and elm-lang.org.";
+  description = "Values to help with elm-package, elm-make, and elm-lang.org";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/pkgs/development/compilers/gcc/gfortran-darwin.nix
+++ b/pkgs/development/compilers/gcc/gfortran-darwin.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   makeFlags = ["CC=clang"];
   passthru.cc = stdenv.cc.cc;
   meta = with stdenv.lib; {
-    description = "GNU Fortran compiler, part of the GNU Compiler Collection.";
+    description = "GNU Fortran compiler, part of the GNU Compiler Collection";
     homepage    = "https://gcc.gnu.org/fortran/";
     license     = licenses.gpl3Plus;
     platforms   = platforms.darwin;

--- a/pkgs/development/erlang-modules/hex-packages.nix
+++ b/pkgs/development/erlang-modules/hex-packages.nix
@@ -388,7 +388,7 @@ let
 	      "4dacd60356177ec8cf93dbff399de17435b613f3318202614d3d5acbccee1474";
 	      
 	    meta = {
-	      description = "Support library for manipulating Web protocols.";
+	      description = "Support library for manipulating Web protocols";
 	      license = stdenv.lib.licenses.isc;
 	      homepage = "https://github.com/ninenines/cowlib";
 	    };
@@ -405,7 +405,7 @@ let
 	      "db622da03aa039e6366ab953e31186cc8190d32905e33788a1acb22744e6abd2";
 	      
 	    meta = {
-	      description = "Support library for manipulating Web protocols.";
+	      description = "Support library for manipulating Web protocols";
 	      license = stdenv.lib.licenses.isc;
 	      homepage = "https://github.com/ninenines/cowlib";
 	    };
@@ -422,7 +422,7 @@ let
 	      "2b1ac020ec92e7a59cb7322779870c2d3adc7c904ecb3b9fa406f04dc9816b73";
 	      
 	    meta = {
-	      description = "Support library for manipulating Web protocols.";
+	      description = "Support library for manipulating Web protocols";
 	      license = stdenv.lib.licenses.isc;
 	      homepage = "https://github.com/ninenines/cowlib";
 	    };
@@ -599,7 +599,7 @@ let
 	      "6d7365a7854cd724e8d1fd005f5faa4444eae6a87eb6df9b789b6e7f6f09110a";
 	      
 	    meta = {
-	      description = "Markdown generated from Edoc.";
+	      description = "Markdown generated from Edoc";
 	      license = stdenv.lib.licenses.free;
 	      homepage = "https://github.com/uwiger/edown";
 	    };
@@ -1500,7 +1500,7 @@ let
 	    compilePorts = true;
 	     
 	    meta = {
-	      description = "JSON Decoder/Encoder.";
+	      description = "JSON Decoder/Encoder";
 	      license = with stdenv.lib.licenses; [ mit bsd3 ];
 	      homepage = "https://github.com/davisp/jiffy";
 	    };
@@ -1792,7 +1792,7 @@ let
 	      "53e70ea9031f7583331a9f9bdbb29da933e591e5c4cce521b4bf85c68e7f3385";
 	      
 	    meta = {
-	      description = "Lasse: Server-Sent Event handler for Cowboy.";
+	      description = "Lasse: Server-Sent Event handler for Cowboy";
 	      license = stdenv.lib.licenses.asl20;
 	      homepage = "https://github.com/inaka/lasse";
 	    };
@@ -2196,7 +2196,7 @@ let
 	    erlangDeps  = [ getopt_0_8_2 ];
 	    
 	    meta = {
-	      description = "Providers provider.";
+	      description = "Providers provider";
 	      license = stdenv.lib.licenses.mit;
 	      homepage = "https://github.com/tsloughter/providers";
 	    };
@@ -2296,7 +2296,7 @@ let
 	      "98ade939e63e6567da5dec5bc5bd93cbdc53d53f8b1aa998adec60dc4057f048";
 	      
 	    meta = {
-	      description = "Socket acceptor pool for TCP protocols.";
+	      description = "Socket acceptor pool for TCP protocols";
 	      license = stdenv.lib.licenses.isc;
 	      homepage = "https://github.com/ninenines/ranch";
 	    };
@@ -2313,7 +2313,7 @@ let
 	      "82bbb48cdad151000f7ad600d7a29afd972df409fde600bbc9b1ed4fdc08c399";
 	      
 	    meta = {
-	      description = "Socket acceptor pool for TCP protocols.";
+	      description = "Socket acceptor pool for TCP protocols";
 	      license = stdenv.lib.licenses.isc;
 	      homepage = "https://github.com/ninenines/ranch";
 	    };
@@ -2933,7 +2933,7 @@ let
 	      "742c45b3c99e207dd0aeccb818edd2ace4af10699c96fbcee0ce2f692dc5fe12";
 	      
 	    meta = {
-	      description = "weber - is Elixir MVC web framework.";
+	      description = "weber - is Elixir MVC web framework";
 	      license = stdenv.lib.licenses.mit;
 	      homepage = "https://github.com/elixir-web/weber";
 	    };

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A simple Lisp with an integrated database.";
+    description = "A simple Lisp with an integrated database";
     homepage = http://picolisp.com/;
     license = licenses.mit;
     platform = platforms.all;

--- a/pkgs/development/libraries/htmlcxx/default.nix
+++ b/pkgs/development/libraries/htmlcxx/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://htmlcxx.sourceforge.net/;
-    description = "htmlcxx is a simple non-validating css1 and html parser for C++.";
+    description = "htmlcxx is a simple non-validating css1 and html parser for C++";
     license = stdenv.lib.licenses.lgpl2;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A small, fast, portable implementation of TLS/SSL for embedded devices.";
+    description = "A small, fast, portable implementation of TLS/SSL for embedded devices";
     homepage    = "https://www.wolfssl.com/";
     platforms   = platforms.all;
     maintainers = with maintainers; [ mcmtroffaes ];

--- a/pkgs/development/mobile/titaniumenv/cli/registry.nix
+++ b/pkgs/development/mobile/titaniumenv/cli/registry.nix
@@ -439,7 +439,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "A javascript text diff implementation.";
+        description = "A javascript text diff implementation";
         homepage = "https://github.com/kpdecker/jsdiff#readme";
         license = "BSD-3-Clause";
       };
@@ -454,7 +454,7 @@ let
         sha1 = "319bb7a56e7cb63f00b5c0cd7851cd4b4ddf1df9";
       };
       meta = {
-        description = "Rigorous implementation of RFC4122 (v1 and v4) UUIDs.";
+        description = "Rigorous implementation of RFC4122 (v1 and v4) UUIDs";
         homepage = https://github.com/broofa/node-uuid;
       };
       production = true;
@@ -482,7 +482,7 @@ let
         };
       };
       meta = {
-        description = "Light-weight option parsing with an argv hash. No optstrings attached.";
+        description = "Light-weight option parsing with an argv hash. No optstrings attached";
         homepage = https://github.com/substack/node-optimist;
         license = "MIT/X11";
       };
@@ -497,7 +497,7 @@ let
         sha1 = "a3d5da6cd5c0bc0008d37234bbaf1bed63059107";
       };
       meta = {
-        description = "Wrap those words. Show them at what columns to start and stop.";
+        description = "Wrap those words. Show them at what columns to start and stop";
         homepage = "https://github.com/substack/node-wordwrap#readme";
         license = "MIT";
       };
@@ -645,7 +645,7 @@ let
         };
       };
       meta = {
-        description = "Simplified HTTP request client.";
+        description = "Simplified HTTP request client";
         homepage = "https://github.com/request/request#readme";
         license = "Apache-2.0";
       };
@@ -736,7 +736,7 @@ let
         sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
       };
       meta = {
-        description = "The `util.is*` functions introduced in Node v0.12.";
+        description = "The `util.is*` functions introduced in Node v0.12";
         homepage = "https://github.com/isaacs/core-util-is#readme";
         license = "MIT";
       };
@@ -834,7 +834,7 @@ let
         sha1 = "715b96ea9841593cc33067923f5ec60ebda4f7d7";
       };
       meta = {
-        description = "Caseless object set/get/has, very useful when working with HTTP headers.";
+        description = "Caseless object set/get/has, very useful when working with HTTP headers";
         homepage = "https://github.com/mikeal/caseless#readme";
         license = "Apache-2.0";
       };
@@ -868,7 +868,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "HTTP Agent that keeps socket connections alive between keep-alive requests. Formerly part of mikeal/request, now a standalone module.";
+        description = "HTTP Agent that keeps socket connections alive between keep-alive requests. Formerly part of mikeal/request, now a standalone module";
         homepage = https://github.com/mikeal/forever-agent;
         license = "Apache-2.0";
       };
@@ -904,7 +904,7 @@ let
         };
       };
       meta = {
-        description = "A library to create readable \"multipart/form-data\" streams. Can be used to submit forms and file uploads to other web applications.";
+        description = "A library to create readable \"multipart/form-data\" streams. Can be used to submit forms and file uploads to other web applications";
         homepage = "https://github.com/form-data/form-data#readme";
         license = "MIT";
       };
@@ -943,7 +943,7 @@ let
         };
       };
       meta = {
-        description = "A stream that emits multiple other streams one after another.";
+        description = "A stream that emits multiple other streams one after another";
         homepage = https://github.com/felixge/node-combined-stream;
         license = "MIT";
       };
@@ -959,7 +959,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "Buffers events from a stream until you are ready to handle them.";
+        description = "Buffers events from a stream until you are ready to handle them";
         homepage = https://github.com/felixge/node-delayed-stream;
         license = "MIT";
       };
@@ -984,7 +984,7 @@ let
         };
       };
       meta = {
-        description = "The ultimate javascript content-type utility.";
+        description = "The ultimate javascript content-type utility";
         homepage = https://github.com/jshttp/mime-types;
         license = "MIT";
       };
@@ -1017,7 +1017,7 @@ let
         sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
       };
       meta = {
-        description = "Like JSON.stringify, but doesn't blow up on circular refs.";
+        description = "Like JSON.stringify, but doesn't blow up on circular refs";
         homepage = https://github.com/isaacs/json-stringify-safe;
         license = "ISC";
       };
@@ -1035,7 +1035,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "Rigorous implementation of RFC4122 (v1 and v4) UUIDs.";
+        description = "Rigorous implementation of RFC4122 (v1 and v4) UUIDs";
         homepage = https://github.com/broofa/node-uuid;
       };
       production = true;
@@ -1068,7 +1068,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "HTTP proxy tunneling agent. Formerly part of mikeal/request, now a standalone module.";
+        description = "HTTP proxy tunneling agent. Formerly part of mikeal/request, now a standalone module";
         homepage = "https://github.com/mikeal/tunnel-agent#readme";
         license = "Apache-2.0";
       };
@@ -1120,7 +1120,7 @@ let
         };
       };
       meta = {
-        description = "Reference implementation of Joyent's HTTP Signature scheme.";
+        description = "Reference implementation of Joyent's HTTP Signature scheme";
         homepage = https://github.com/joyent/node-http-signature/;
         license = "MIT";
       };
@@ -1180,7 +1180,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "OAuth 1 signing. Formerly a vendor lib in mikeal/request, now a standalone module.";
+        description = "OAuth 1 signing. Formerly a vendor lib in mikeal/request, now a standalone module";
         homepage = "https://github.com/mikeal/oauth-sign#readme";
         license = "Apache-2.0";
       };
@@ -1327,7 +1327,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "AWS signing. Originally pulled from LearnBoost/knox, maintained as vendor in request, now a standalone module.";
+        description = "AWS signing. Originally pulled from LearnBoost/knox, maintained as vendor in request, now a standalone module";
       };
       production = true;
       linkDependencies = false;
@@ -1463,7 +1463,7 @@ let
         };
       };
       meta = {
-        description = "Terminal string styling done right. Much color.";
+        description = "Terminal string styling done right. Much color";
         homepage = "https://github.com/chalk/chalk#readme";
         license = "MIT";
       };
@@ -1729,7 +1729,7 @@ let
         sha1 = "3af1dd20fe85463910d469a385e33017d2a030d9";
       };
       meta = {
-        description = "Simple JSON Addressing.";
+        description = "Simple JSON Addressing";
         homepage = "https://github.com/janl/node-jsonpointer#readme";
         license = "MIT";
       };
@@ -1763,7 +1763,7 @@ let
         sha1 = "9fb3f4004f900d83c47968fe42f7583e05832cc9";
       };
       meta = {
-        description = "The semantic version parser used by npm.";
+        description = "The semantic version parser used by npm";
         homepage = "https://github.com/npm/node-semver#readme";
         license = "ISC";
       };
@@ -1843,7 +1843,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "Recursive filesystem (and other) operations that Node *should* have.";
+        description = "Recursive filesystem (and other) operations that Node *should* have";
         homepage = https://github.com/ryanmcgrath/wrench-js;
       };
       production = true;
@@ -1935,7 +1935,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "A transform to make UglifyJS work in browserify.";
+        description = "A transform to make UglifyJS work in browserify";
         homepage = https://github.com/ForbesLindesay/uglify-to-browserify;
         license = "MIT";
       };
@@ -1977,7 +1977,7 @@ let
         };
       };
       meta = {
-        description = "Light-weight option parsing with an argv hash. No optstrings attached.";
+        description = "Light-weight option parsing with an argv hash. No optstrings attached";
         homepage = https://github.com/bcoe/yargs;
         license = "MIT/X11";
       };
@@ -2033,7 +2033,7 @@ let
         sha1 = "5438cd2ea93b202efa3a19fe8887aee7c94f9c9d";
       };
       meta = {
-        description = "Reliable way to to get the height and width of the terminal/console in a node.js environment.";
+        description = "Reliable way to to get the height and width of the terminal/console in a node.js environment";
         homepage = https://github.com/jonschlinkert/window-size;
       };
       production = true;
@@ -2048,7 +2048,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "Wrap those words. Show them at what columns to start and stop.";
+        description = "Wrap those words. Show them at what columns to start and stop";
         license = "MIT/X11";
       };
       production = true;
@@ -2064,7 +2064,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "A W3C Standard XML DOM(Level2 CORE) implementation and parser(DOMParser/XMLSerializer).";
+        description = "A W3C Standard XML DOM(Level2 CORE) implementation and parser(DOMParser/XMLSerializer)";
         homepage = https://github.com/jindw/xmldom;
       };
       production = true;
@@ -2194,7 +2194,7 @@ let
         };
       };
       meta = {
-        description = "Simplified HTTP request client.";
+        description = "Simplified HTTP request client";
         homepage = "https://github.com/request/request#readme";
         license = "Apache-2.0";
       };
@@ -2226,7 +2226,7 @@ let
         sha1 = "77466de589cd5d3c95f138aa78bc569a3cb5d27a";
       };
       meta = {
-        description = "The semantic version parser used by npm.";
+        description = "The semantic version parser used by npm";
         homepage = "https://github.com/npm/node-semver#readme";
         license = "ISC";
       };
@@ -2379,7 +2379,7 @@ let
       };
       dependencies = {};
       meta = {
-        description = "Get v8 stack traces as an array of CallSite objects.";
+        description = "Get v8 stack traces as an array of CallSite objects";
         homepage = https://github.com/felixge/node-stack-trace;
       };
       production = true;

--- a/pkgs/development/ocaml-modules/bitstring/2.0.4.nix
+++ b/pkgs/development/ocaml-modules/bitstring/2.0.4.nix
@@ -17,7 +17,7 @@ buildOcaml rec {
   hasSharedObjects = true;
 
   meta = with stdenv.lib; {
-    description = "This library adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml.";
+    description = "This library adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml";
     homepage = http://code.google.com/p/bitstring/;
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.maurer ];

--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://piqi.org;
-    description = "Universal schema language and a collection of tools built around it. These are the ocaml bindings.";
+    description = "Universal schema language and a collection of tools built around it. These are the ocaml bindings";
     license = licenses.asl20;
     maintainers = [ maintainers.maurer ];
   };

--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = http://piqi.org;
-    description = "Universal schema language and a collection of tools built around it.";
+    description = "Universal schema language and a collection of tools built around it";
     license = licenses.asl20;
     maintainers = [ maintainers.maurer ];
   };

--- a/pkgs/development/ocaml-modules/uuidm/default.nix
+++ b/pkgs/development/ocaml-modules/uuidm/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
 
   meta = with stdenv.lib; {
-    description = "An OCaml module implementing 128 bits universally unique identifiers version 3, 5 (name based with MD5, SHA-1 hashing) and 4 (random based) according to RFC 4122.";
+    description = "An OCaml module implementing 128 bits universally unique identifiers version 3, 5 (name based with MD5, SHA-1 hashing) and 4 (random based) according to RFC 4122";
     homepage = http://erratique.ch/software/uuidm;
     license = licenses.bsd3;
     platforms = ocaml.meta.platforms;

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Command-line tool for accessing the Backblaze B2 storage service.";
+    description = "Command-line tool for accessing the Backblaze B2 storage service";
     homepage    = https://github.com/Backblaze/B2_Command_Line_Tool;
     license     = licenses.mit;
     maintainers = with maintainers; [ kevincox ];

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "https://github.com/rebar/rebar3";
-    description = "rebar 3.0 is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases.";
+    description = "rebar 3.0 is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases";
 
     longDescription = ''
       rebar is a self-contained Erlang script, so it's easy to distribute or

--- a/pkgs/development/tools/compass/default.nix
+++ b/pkgs/development/tools/compass/default.nix
@@ -9,7 +9,7 @@ bundlerEnv {
   gemset = ./gemset.nix;
 
   meta = with lib; {
-    description = "Stylesheet Authoring Environment that makes your website design simpler to implement and easier to maintain.";
+    description = "Stylesheet Authoring Environment that makes your website design simpler to implement and easier to maintain";
     homepage    = https://github.com/Compass/compass;
     license     = with licenses; mit;
     maintainers = with maintainers; [ offline ];

--- a/pkgs/development/tools/dcadec/default.nix
+++ b/pkgs/development/tools/dcadec/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   installPhase = "make PREFIX=/ DESTDIR=$out install";
 
   meta = with stdenv.lib; {
-    description = "DTS Coherent Acoustics decoder with support for HD extensions.";
+    description = "DTS Coherent Acoustics decoder with support for HD extensions";
     maintainers = with maintainers; [ edwtjo ];
     homepage = http://github.com/foo86/dcadec;
     license = licenses.lgpl21;

--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ python ];
 
   meta = with stdenv.lib; {
-    description = "omniORB is a robust high performance CORBA ORB for C++ and Python. It is freely available under the terms of the GNU Lesser General Public License (for the libraries), and GNU General Public License (for the tools). omniORB is largely CORBA 2.6 compliant.";
+    description = "omniORB is a robust high performance CORBA ORB for C++ and Python. It is freely available under the terms of the GNU Lesser General Public License (for the libraries), and GNU General Public License (for the tools). omniORB is largely CORBA 2.6 compliant";
     homepage    = "http://omniorb.sourceforge.net/";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -79,7 +79,7 @@ EOF
   '';
 
   meta = {
-    description = "A game in which you build and maintain factories.";
+    description = "A game in which you build and maintain factories";
     longDescription = ''
       Factorio is a game in which you build and maintain factories.
 

--- a/pkgs/games/lgogdownloader/default.nix
+++ b/pkgs/games/lgogdownloader/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://github.com/Sude-/lgogdownloader;
-    description = "Unofficial downloader to GOG.com for Linux users. It uses the same API as the official GOGDownloader.";
+    description = "Unofficial downloader to GOG.com for Linux users. It uses the same API as the official GOGDownloader";
     license = stdenv.lib.licenses.wtfpl;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/games/pioneer/default.nix
+++ b/pkgs/games/pioneer/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Pioneer is a space adventure game set in the Milky Way galaxy at the turn of the 31st century.";
+    description = "Pioneer is a space adventure game set in the Milky Way galaxy at the turn of the 31st century";
     homepage = "http://pioneerspacesim.net";
     license = with licenses; [
         gpl3 cc-by-sa-30

--- a/pkgs/games/zandronum/bin.nix
+++ b/pkgs/games/zandronum/bin.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://zandronum.com/;
-    description = "multiplayer oriented port, based off Skulltag, for Doom and Doom II by id Software. Binary version for online play.";
+    description = "multiplayer oriented port, based off Skulltag, for Doom and Doom II by id Software. Binary version for online play";
     maintainers = [ stdenv.lib.maintainers.lassulus ];
     # Binary version has different version string than source code version.
     license = stdenv.lib.licenses.unfreeRedistributable;

--- a/pkgs/games/zandronum/default.nix
+++ b/pkgs/games/zandronum/default.nix
@@ -53,7 +53,7 @@ in stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = http://zandronum.com/;
-    description = "Multiplayer oriented port, based off Skulltag, for Doom and Doom II by id Software.";
+    description = "Multiplayer oriented port, based off Skulltag, for Doom and Doom II by id Software";
     maintainers = with maintainers; [ lassulus ];
     platforms = platforms.linux;
     license = licenses.bsdOriginal;

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
    
   meta = {
-    description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod.";
+    description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
     homepage = "https://github.com/csssuf/rtl8812au";
     license = stdenv.lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/servers/certificate-transparency/default.nix
+++ b/pkgs/servers/certificate-transparency/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://www.certificate-transparency.org/;
-    description = "Auditing for TLS certificates.";
+    description = "Auditing for TLS certificates";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ philandstuff ];

--- a/pkgs/servers/monitoring/longview/default.nix
+++ b/pkgs/servers/monitoring/longview/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://www.linode.com/longview;
-    description = "Longview collects all of your system-level metrics and sends them to Linode.";
+    description = "Longview collects all of your system-level metrics and sends them to Linode";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.rvl ];
     inherit version;

--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-      description = "Universal Media Server: a DLNA-compliant UPnP Media Server.";
+      description = "Universal Media Server: a DLNA-compliant UPnP Media Server";
       license = stdenv.lib.licenses.gpl2;
       platforms = stdenv.lib.platforms.linux;
       maintainers = [ stdenv.lib.maintainers.thall ];

--- a/pkgs/tools/graphics/imgur-screenshot/default.nix
+++ b/pkgs/tools/graphics/imgur-screenshot/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A tool for easy screencapping and uploading to imgur.";
+    description = "A tool for easy screencapping and uploading to imgur";
     homepage = "https://https://github.com/jomo/imgur-screenshot/";
     platforms = platforms.linux;
     license = licenses.mit;

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-hangul/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-hangul/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     isIbusEngine = true;
-    description  = "Ibus Hangul engine.";
+    description  = "Ibus Hangul engine";
     homepage     = https://github.com/choehwanjin/ibus-hangul;
     license      = licenses.gpl2;
     platforms    = platforms.linux;

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     isIbusEngine = true;
-    description  = "m17n engine for ibus.";
+    description  = "m17n engine for ibus";
     homepage     = https://github.com.com/ibus/ibus-m17n;
     license      = licenses.gpl2;
     platforms    = platforms.linux;

--- a/pkgs/tools/misc/entr/default.nix
+++ b/pkgs/tools/misc/entr/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://entrproject.org/;
-    description = "Run arbitrary commands when files change.";
+    description = "Run arbitrary commands when files change";
 
     license = stdenv.lib.licenses.isc;
 

--- a/pkgs/tools/misc/homesick/default.nix
+++ b/pkgs/tools/misc/homesick/default.nix
@@ -13,7 +13,7 @@ bundlerEnv {
   '';
 
   meta = with lib; {
-    description = "Your home directory is your castle. Don't leave your dotfiles behind.";
+    description = "Your home directory is your castle. Don't leave your dotfiles behind";
     long_description =
       ''
         Homesick is sorta like rip, but for dotfiles. It uses git to clone a repository containing

--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Logstash is a data pipeline that helps you process logs and other event data from a variety of systems.";
+    description = "Logstash is a data pipeline that helps you process logs and other event data from a variety of systems";
     homepage    = https://www.elastic.co/products/logstash;
     license     = licenses.asl20;
     platforms   = platforms.unix;

--- a/pkgs/tools/networking/driftnet/default.nix
+++ b/pkgs/tools/networking/driftnet/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "Driftnet watches network traffic, and picks out and displays JPEG and GIF images for display.";
+    description = "Driftnet watches network traffic, and picks out and displays JPEG and GIF images for display";
     homepage = https://github.com/deiv/driftnet;
     maintainers = with maintainers; [ offline ];
     platforms = platforms.linux;

--- a/pkgs/tools/security/pamtester/default.nix
+++ b/pkgs/tools/security/pamtester/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pam ];
 
   meta = with stdenv.lib; {
-    description = "Utility program to test the PAM facility.";
+    description = "Utility program to test the PAM facility";
     homepage = http://pamtester.sourceforge.net/;
     license = licenses.bsd3;
     platforms = platforms.linux;

--- a/pkgs/tools/text/popfile/default.nix
+++ b/pkgs/tools/text/popfile/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "An email classification system that automatically sorts messages and fights spam.";
+    description = "An email classification system that automatically sorts messages and fights spam";
     homepage = http://getpopfile.org;
     license = stdenv.lib.licenses.gpl2;
 

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -395,7 +395,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
   #   outputFiles = [ "build/*" ];
   #
   #   meta = {
-  #     description = "FSharpx.Extras is a collection of libraries and tools for use with F#.";
+  #     description = "FSharpx.Extras is a collection of libraries and tools for use with F#";
   #     homepage = "http://fsprojects.github.io/FSharpx.Extras/";
   #     license = stdenv.lib.licenses.asl20;
   #     maintainers = with stdenv.lib.maintainers; [ obadz ];
@@ -419,7 +419,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "out/lib/Net40/*" "src/FSharp/MathNet.Numerics.fsx" "src/FSharp/MathNet.Numerics.IfSharp.fsx" ];
 
     meta = {
-      description = "Math.NET Numerics is an opensource numerical library for .Net, Silverlight and Mono.";
+      description = "Math.NET Numerics is an opensource numerical library for .Net, Silverlight and Mono";
       homepage = http://numerics.mathdotnet.com/;
       license = stdenv.lib.licenses.mit;
       maintainers = with stdenv.lib.maintainers; [ obadz ];

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -408,7 +408,7 @@ let
     packageRequires = [ dash ];
     files = [ "dash-functional.el" ];
     meta = {
-      description = "Collection of useful combinators for Emacs Lisp.";
+      description = "Collection of useful combinators for Emacs Lisp";
       license = gpl3Plus;
     };
   };
@@ -1525,7 +1525,7 @@ let
     };
     packageRequires = [ dash ];
     meta = {
-      description = "Hiding and/or highlighting the list of minor modes in the Emacs mode-line.";
+      description = "Hiding and/or highlighting the list of minor modes in the Emacs mode-line";
       license = gpl3Plus;
     };
   };
@@ -1541,7 +1541,7 @@ let
       sha256 = "1wvjisi26lb4g5rjq80kq9jmf1r2m3isy47nwrnahfzxk886qfbq";
       };
     meta = {
-      description = "A major mode for editing rust code.";
+      description = "A major mode for editing rust code";
       license = asl20;
     };
   };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -818,7 +818,7 @@ let
 
     meta = with stdenv.lib; {
       homepage    = "https://github.com/martingallagher/gawp";
-      description = "A simple, configurable, file watching, job execution tool implemented in Go.";
+      description = "A simple, configurable, file watching, job execution tool implemented in Go";
       maintainers = with maintainers; [ kamilchm ];
       license     = licenses.asl20 ;
       platforms   = platforms.all;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6900,7 +6900,7 @@ let self = _self // overrides; _self = with self; {
     };
     propagatedBuildInputs = [ IOLockedFile ];
     meta = {
-      description = "Helps us create simple logs for our application.";
+      description = "Helps us create simple logs for our application";
       license = "perl";
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1213,7 +1213,7 @@ in modules // {
 
     meta = {
       homepage = https://github.com/awslabs/aws-shell;
-      description = "An integrated shell for working with the AWS CLI.";
+      description = "An integrated shell for working with the AWS CLI";
       license = licenses.asl20;
       maintainers = [ ];
     };
@@ -3838,7 +3838,7 @@ in modules // {
     meta = {
       homepage = https://pypi.python.org/pypi/pkginfo;
       license = licenses.mit;
-      description = "Query metadatdata from sdists / bdists / installed packages.";
+      description = "Query metadatdata from sdists / bdists / installed packages";
 
       longDescription = ''
         This package provides an API for querying the distutils metadata
@@ -3970,7 +3970,7 @@ in modules // {
     propagatedBuildInputs = with self; [ pyparsing decorator six ];
 
     meta = {
-      description = "Allows to declare constraints on function parameters and return values.";
+      description = "Allows to declare constraints on function parameters and return values";
       homepage = https://pypi.python.org/pypi/PyContracts;
       license = licenses.lgpl2;
     };
@@ -5520,7 +5520,7 @@ in modules // {
     '';
 
     meta = {
-      description = "Command-line tool for interacting with Google Compute Engine.";
+      description = "Command-line tool for interacting with Google Compute Engine";
       homepage = "https://cloud.google.com/compute/docs/gcutil/";
       license = licenses.asl20;
       maintainers = with maintainers; [ phreedom ];
@@ -5784,7 +5784,7 @@ in modules // {
     ];
 
     meta = {
-      description = "A python client library for Google Play Services OAuth.";
+      description = "A python client library for Google Play Services OAuth";
       homepage = "https://github.com/simon-weber/gpsoauth";
       license = licenses.mit;
       maintainers = with maintainers; [ jgillich ];
@@ -6891,7 +6891,7 @@ in modules // {
 
     meta = {
       homepage = https://launchpad.net/pypolicyd-spf/;
-      description = "Postfix policy engine for Sender Policy Framework (SPF) checking.";
+      description = "Postfix policy engine for Sender Policy Framework (SPF) checking";
       maintainers = with maintainers; [ abbradar ];
       license = licenses.asl20;
       platform = platforms.all;
@@ -8241,7 +8241,7 @@ in modules // {
     propagatedBuildInputs = with self; [ django_1_6 futures ];
 
     meta = with stdenv.lib; {
-      description = "Pipeline is an asset packaging library for Django.";
+      description = "Pipeline is an asset packaging library for Django";
       homepage = https://github.com/cyberdelia/django-pipeline;
       license = stdenv.lib.licenses.mit;
     };
@@ -8305,7 +8305,7 @@ in modules // {
     doCheck = false;
 
     meta = with stdenv.lib; {
-      description = "An HTTP handler for `urllib2` that supports HTTP 1.1 and keepalive.";
+      description = "An HTTP handler for `urllib2` that supports HTTP 1.1 and keepalive";
       homepage = "https://github.com/wikier/keepalive";
     };
   };
@@ -8330,7 +8330,7 @@ in modules // {
     ];
 
     meta = with stdenv.lib; {
-      description = "This is a wrapper around a SPARQL service. It helps in creating the query URI and, possibly, convert the result into a more manageable format.";
+      description = "This is a wrapper around a SPARQL service. It helps in creating the query URI and, possibly, convert the result into a more manageable format";
       homepage = "http://rdflib.github.io/sparqlwrapper";
     };
   };
@@ -10223,7 +10223,7 @@ in modules // {
     };
 
     meta = {
-      description = "An intelligent grader that allows secured and automated testing of code made by students.";
+      description = "An intelligent grader that allows secured and automated testing of code made by students";
       homepage = "https://github.com/UCL-INGI/INGInious";
       license = licenses.agpl3;
       maintainers = with maintainers; [ layus ];
@@ -13241,7 +13241,7 @@ in modules // {
     };
 
     meta = {
-      description = "A drop-in substitute for Py2.7's new collections.OrderedDict that works in Python 2.4-2.6.";
+      description = "A drop-in substitute for Py2.7's new collections.OrderedDict that works in Python 2.4-2.6";
       license = licenses.bsd3;
       maintainers = with maintainers; [ garbas ];
     };
@@ -13715,7 +13715,7 @@ in modules // {
     ];
 
     meta = with stdenv.lib; {
-      description = "Enhancements for standard library's cmd module.";
+      description = "Enhancements for standard library's cmd module";
       homepage = "http://packages.python.org/cmd2/";
     };
   };
@@ -14211,7 +14211,7 @@ in modules // {
     '';
 
     meta = with stdenv.lib; {
-      description = "FormEncode validates and converts nested structures.";
+      description = "FormEncode validates and converts nested structures";
       homepage = "http://formencode.org";
     };
   };
@@ -16303,7 +16303,7 @@ in modules // {
     buildInputs = with self; [ nose mock ];
 
     meta = {
-      description = "A clean, future-proof, high-scale API to elasticsearch.";
+      description = "A clean, future-proof, high-scale API to elasticsearch";
       homepage = https://pyelasticsearch.readthedocs.org;
       license = licenses.bsd3;
     };
@@ -17268,7 +17268,7 @@ in modules // {
       sha256 = "1r50lm6n59jzdwpp53n0c0hp3aj1jxn304bk5gh830226gsaf2hn";
     };
     meta = {
-      description = "Test classes and test cases using decorators, execute test cases by command line, and get clear reports.";
+      description = "Test classes and test cases using decorators, execute test cases by command line, and get clear reports";
       homepage = https://pypi.python.org/pypi/ptest;
       license = licenses.asl20;
     };
@@ -19257,7 +19257,7 @@ in modules // {
     buildInputs = with self; [pep8];
 
     meta = {
-      description = "A generator library for concise, unambiguous and URL-safe UUIDs.";
+      description = "A generator library for concise, unambiguous and URL-safe UUIDs";
       homepage = https://github.com/stochastic-technologies/shortuuid/;
       license = licenses.bsd3;
       maintainers = with maintainers; [ zagy ];
@@ -20527,7 +20527,7 @@ in modules // {
     propagatedBuildInputs = with self; [ pyparsing ];
 
     meta = {
-      description = "A Python library to create SVG drawings.";
+      description = "A Python library to create SVG drawings";
       homepage = http://bitbucket.org/mozman/svgwrite;
       license = licenses.mit;
     };
@@ -21511,7 +21511,7 @@ in modules // {
     doCheck = false;
 
     meta = {
-      description = "A backport of traceback to older supported Pythons.";
+      description = "A backport of traceback to older supported Pythons";
       homepage = https://pypi.python.org/pypi/traceback2/;
     };
   };
@@ -21530,7 +21530,7 @@ in modules // {
     doCheck = false;
 
     meta = with stdenv.lib; {
-      description = "A backport of linecache to older supported Pythons.";
+      description = "A backport of linecache to older supported Pythons";
       homepage = "https://github.com/testing-cabal/linecache2";
     };
   };
@@ -25006,7 +25006,7 @@ in modules // {
     LC_ALL="en_US.UTF-8";
 
     meta = {
-      description = "Copy your docs directly to the gh-pages branch.";
+      description = "Copy your docs directly to the gh-pages branch";
       homepage = "http://github.com/davisp/ghp-import";
       license = "Tumbolia Public License";
       maintainers = with maintainers; [ garbas ];
@@ -25096,7 +25096,7 @@ in modules // {
     ];
 
     meta = {
-      description = "Jenkins Job Builder is a system for configuring Jenkins jobs using simple YAML files stored in Git.";
+      description = "Jenkins Job Builder is a system for configuring Jenkins jobs using simple YAML files stored in Git";
       homepage = "http://docs.openstack.org/infra/system-config/jjb.html";
       license = licenses.asl20;
       maintainers = with maintainers; [ garbas ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [ ] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Is this something that we want to do ? It might make it harder for some of the long-running branches to rebase. Although they usually touch the code and not the descriptions.

Specially crafted for @JagaJaga

```
find -name "*.nix" -exec sed -e 's|\(description.*\)\.";|\1";|g' -i {} \;
```
