### PR TITLE
Remove fish's kbd dependency on darwin.

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -22,8 +22,10 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     sed -e "s|expr|${coreutils}/bin/expr|" \
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
         -e "s|if which unicode_start|if true|" \
         -e "s|unicode_start|${kbd}/bin/unicode_start|" \
+  '' + ''
         -i "$out/etc/fish/config.fish"
     sed -e "s|bc|${bc}/bin/bc|" \
         -e "s|/usr/bin/seq|${coreutils}/bin/seq|" \


### PR DESCRIPTION
A friend of mine reported this, but I don't own a darwin machine, so I'm not
able to fully test this. The previous version fails with the following error:

```
> nix-build '<nixpkgs>' -A fish --argstr system x86_64-darwin
error: Package ‘kbd-2.0.3’ in ‘/nix/store/vyy9k62iq5sknszk0xi58pd97p1jngk6-nixpkgs-16.03pre76763.be0abb3/nixpkgs/pkgs/os-specific/linux/kbd/default.nix:58’ is not supported on ‘x86_64-darwin’, refusing to evaluate.
```

Now fish should either work or at least be one step closer on darwin. It is able
to evaluate the package, at least.

cc @ubsan
