### PR TITLE
nixos: libinput use mkEnableOption

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -10,12 +10,7 @@ in {
 
     services.xserver.libinput = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Whether to enable libinput support.";
-      };
+      enable = mkEnableOption "libinput";
 
       dev = mkOption {
         type = types.nullOr types.str;


### PR DESCRIPTION
@jagajaga Here you go :-)
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [ ] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github
-  x Crossed fingers and hoped that it is fine
-  x Did nixos-rebuild dry-build

/CONTRIBUTING.md).
###### Extra

Fixes # .

cc @ .

---

_Please note, that points are not mandatory._
