### PR TITLE
retrofe: init at 0.6.169

### DIFF
--- a/pkgs/misc/emulators/retrofe/default.nix
+++ b/pkgs/misc/emulators/retrofe/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, fetchhg, cmake, dos2unix, glib, gst_all_1, makeWrapper, pkgconfig
+, python, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, sqlite, zlib
+}:
+
+let
+  gstPlugins = with gst_all_1; [ gst-libav gst-plugins-base gst-plugins-good ];
+  GST_PLUGIN_PATH = stdenv.lib.makeSearchPath "lib/gstreamer-1.0" gstPlugins;
+
+in stdenv.mkDerivation rec {
+  name = "retrofe-${version}";
+  version = "0.6.169";
+
+  src = fetchhg {
+    url = https://bitbucket.org/teamretro/retrofe;
+    rev = "8793e03";
+    sha256 = "0cvsg07ff0fdqh5zgiv2fs7s6c98hn150kpxmpw5fn6jilaszwkm";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig python ];
+
+  buildInputs = [
+    glib gst_all_1.gstreamer SDL2 SDL2_image SDL2_mixer SDL2_ttf sqlite zlib
+  ] ++ gstPlugins;
+
+  patches = [ ./include-paths.patch ];
+
+  configurePhase = ''
+    cmake RetroFE/Source -BRetroFE/Build -DCMAKE_BUILD_TYPE=Release \
+      -DVERSION_MAJOR=0 -DVERSION_MINOR=0 -DVERSION_BUILD=0 \
+      -DGSTREAMER_BASE_INCLUDE_DIRS='${gst_all_1.gst-plugins-base}/include/gstreamer-1.0'
+  '';
+
+  buildPhase = ''
+    cmake --build RetroFE/Build
+    python Scripts/Package.py --os=linux --build=full
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/retrofe
+    cp -r Artifacts/linux/RetroFE $out/share/retrofe/example
+    mv $out/share/retrofe/example/retrofe $out/bin/
+
+    cat > $out/bin/retrofe-init << EOF
+    #!/bin/sh
+
+    echo "This will install retrofe's example files into this directory"
+    echo "Example files location: $out/share/retrofe/example/"
+
+    while true; do
+        read -p "Do you want to proceed? [yn] " yn
+        case \$yn in
+            [Yy]* ) cp -r --no-preserve=all $out/share/retrofe/example/* .; break;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer with yes or no.";;
+        esac
+    done
+    EOF
+
+    chmod +x $out/bin/retrofe-init
+  '';
+
+  # retrofe will look for config files in its install path ($out/bin).
+  # When set it will use $RETROFE_PATH instead. Sadly this behaviour isn't
+  # documented well. To make it behave more like as expected it's set to
+  # $PWD by default here.
+  fixupPhase = ''
+    wrapProgram "$out/bin/retrofe" \
+      --prefix GST_PLUGIN_PATH : '${GST_PLUGIN_PATH}/lib/gstreamer-1.0' \
+      --set    RETROFE_PATH      "\''${RETROFE_PATH:-\$PWD}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A frontend for arcade cabinets and media PCs";
+    license = licenses.gpl3Plus;
+    homepage = http://retrofe.com;
+    maintainers = with maintainers; [ hrdinka ];
+  };
+}

--- a/pkgs/misc/emulators/retrofe/include-paths.patch
+++ b/pkgs/misc/emulators/retrofe/include-paths.patch
@@ -1,0 +1,11 @@
+diff -ur RetroFE.1/RetroFE/Source/CMakeLists.txt RetroFE.2/RetroFE/Source/CMakeLists.txt
+--- RetroFE.1/RetroFE/Source/CMakeLists.txt	2016-02-21 14:52:36.726070602 +0100
++++ RetroFE.2/RetroFE/Source/CMakeLists.txt	2016-02-21 14:38:43.036249029 +0100
+@@ -59,6 +59,7 @@
+ set(RETROFE_INCLUDE_DIRS
+ 	"${GLIB2_INCLUDE_DIRS}"
+ 	"${GSTREAMER_INCLUDE_DIRS}"
++	"${GSTREAMER_BASE_INCLUDE_DIRS}"
+ 	"${SDL2_INCLUDE_DIRS}"
+ 	"${SDL2_IMAGE_INCLUDE_DIRS}"
+ 	"${SDL2_MIXER_INCLUDE_DIRS}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15903,6 +15903,8 @@ let
     retroarch = retroarchBare;
   });
 
+  retrofe = callPackage ../misc/emulators/retrofe { };
+
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
   runit = callPackage ../tools/system/runit { };


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux x86_64
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This adds [retrofe](http://www.retrofe.com/) a frontend for emulators similar to emulationstation. Retrofe is intended to be run from its install/download directory. That's why I have added `bin/retrofe-init` which creates a complete directory/configuration structure within the current directory + a `$PWD` wrapper (documented in the nix expression).
