### PR TITLE
pkgs.motuclient: move application away from pythonPackages

### DIFF
--- a/pkgs/applications/science/misc/motu-client/default.nix
+++ b/pkgs/applications/science/misc/motu-client/default.nix
@@ -1,0 +1,23 @@
+{ python27Packages, fetchurl, lib } :
+python27Packages.buildPythonApplication rec {
+  name = "motu-client-${version}";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "https://github.com/quiet-oceans/motuclient-setuptools/archive/${name}.tar.gz";
+    sha256 = "1naqmav312agn72iad9kyxwscn2lz4v1cfcqqi1qcgvc82vnwkw2";
+  };
+
+  meta = with lib; {
+    homepage = https://github.com/quiet-oceans/motuclient-setuptools;
+    description = "CLI to query oceanographic data to Motu servers";
+    longDescription = ''
+      Access data from (motu)[http://sourceforge.net/projects/cls-motu/] servers.
+      This is a refactored fork of the original release in order to simplify integration,
+      deployment and packaging. Upstream code can be found at
+      http://sourceforge.net/projects/cls-motu/ .
+    '';
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.lsix ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2458,7 +2458,7 @@ let
     inherit (perlPackages) IOTty;
   };
 
-  motuclient = python27Packages.motuclient;
+  motuclient = callPackage ../applications/science/misc/motu-client { };
 
   mpage = callPackage ../tools/text/mpage { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6397,32 +6397,6 @@ in modules // {
     };
   };
 
-  motuclient = buildPythonPackage rec {
-    name = "motu-client-${version}";
-    version = "1.0.8";
-
-    namePrefix = "";
-    disabled = !isPy27;
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/quiet-oceans/motuclient-setuptools/archive/${name}.tar.gz";
-      sha256 = "1naqmav312agn72iad9kyxwscn2lz4v1cfcqqi1qcgvc82vnwkw2";
-    };
-
-    meta = {
-      homepage = https://github.com/quiet-oceans/motuclient-setuptools;
-      description = "CLI to query oceanographic data to Motu servers";
-      longDescription = ''
-        Access data from (motu)[http://sourceforge.net/projects/cls-motu/] servers.
-        This is a refactored fork of the original release in order to simplify integration,
-        deployment and packaging. Upstream code can be found at
-        http://sourceforge.net/projects/cls-motu/ .
-      '';
-      license = licenses.lgpl3Plus;
-      maintainers = [ maintainers.lsix ];
-    };
-  };
-
   mwlib-ext = buildPythonPackage rec {
     version = "0.13.2";
     name = "mwlib.ext-${version}";


### PR DESCRIPTION
###### Things done:
- [X] Tested via `nix.useChroot`.
- [X] Built on platform(s): x86_64-linux.
- [X] Tested compilation of all pkgs that depend on this change (none).
- [X] Tested execution of binary products.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

---

This moves a regular application away from the `python-packages.nix` file since it should only contain packages.
