### PR TITLE
yoshimi: 1.3.7.1 -> 1.3.8.2

### DIFF
--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchurl, alsaLib, boost, cairo, cmake, fftwSinglePrec, fltk
-, libjack2, libsndfile, readline, lv2, mesa, minixml, pkgconfig, zlib, xorg
+, libjack2, libsndfile, libXdmcp, readline, lv2, mesa, minixml, pkgconfig, zlib, xorg
 }:
 
 assert stdenv ? glibc;
 
 stdenv.mkDerivation  rec {
   name = "yoshimi-${version}";
-  version = "1.3.7.1";
+  version = "1.3.8.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/yoshimi/${name}.tar.bz2";
-    sha256 = "13xc1x8jrr2rn26jx4dini692ww3771d5j5xf7f56ixqr7mmdhvz";
+    sha256 = "0wl4ln6v1nkkx56kfah23chyrhga2vi93i82g0s200c4s4184xr8";
   };
 
   buildInputs = [
-    alsaLib boost cairo fftwSinglePrec fltk libjack2 libsndfile readline lv2 mesa
+    alsaLib boost cairo fftwSinglePrec fltk libjack2 libsndfile libXdmcp readline lv2 mesa
     minixml zlib xorg.libpthreadstubs
   ];
 


### PR DESCRIPTION
###### Things done:
- [x ] Tested via `nix.useChroot`.
- [ x] Built on platform(s): .
- [ x] Tested compilation of all pkgs that depend on this change.
- [ x] Tested execution of binary products.
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
