### PR TITLE
Several CVEs

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/moodle.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/moodle.nix
@@ -46,16 +46,16 @@ let
     '';
   # Unpack Moodle and put the config file in its root directory.
   moodleRoot = pkgs.stdenv.mkDerivation rec {
-    name= "moodle-2.8.5";
+    name= "moodle-2.8.10";
 
     src = pkgs.fetchurl {
       url = "https://download.moodle.org/stable28/${name}.tgz";
-      sha256 = "1a159a193010cddedce10ee009184502e6f732e4d7c85167d8597fe5dff9e190";
+      sha256 = "0c3r5081ipcwc9s6shakllnrkd589y2ln5z5m1q09l4h6a7cy4z2";
     };
 
     buildPhase =
       ''
-      ''; 
+      '';
 
     installPhase =
       ''
@@ -132,7 +132,7 @@ in
         cleartext in the Nix store!
       '';
     };
-    
+
     dbPrefix = mkOption {
       default = "mdl_";
       example = "my_other_mdl_";
@@ -158,7 +158,7 @@ in
       type = types.path;
       };
 
-    
+
     extraConfig = mkOption {
       default = "";
       example =

--- a/pkgs/applications/graphics/PythonMagick/default.nix
+++ b/pkgs/applications/graphics/PythonMagick/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "0.9.11";
+  version = "0.9.12";
 
 in
 
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   name = "pythonmagick-${version}";
 
   src = fetchurl {
-    url = "http://www.imagemagick.org/download/python/releases/PythonMagick-${version}.tar.gz";
-    sha256 = "01z01mlqkk0lvrh2jsmf84qjw29sq4rpj0653x7nqy7mrszwwp2v";
+    url = "http://www.imagemagick.org/download/python/releases/PythonMagick-${version}.tar.xz";
+    sha256 = "1l1kr3d7l40fkxgs6mrlxj65alv2jizm9hhgg9i9g90a8qj8642b";
   };
 
   buildInputs = [python boost pkgconfig imagemagick];

--- a/pkgs/applications/graphics/xara/default.nix
+++ b/pkgs/applications/graphics/xara/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     url = http://downloads2.xara.com/opensource/XaraLX-0.7r1785.tar.bz2;
     sha256 = "05xbzq1i1vw2mdsv7zjqfpxfv3g1j0g5kks0gq6sh373xd6y8lyh";
   };
-    
+
   nativeBuildInputs = [ automake pkgconfig gettext perl zip ];
   buildInputs = [ wxGTK gtk libxml2 freetype pango ];
 
@@ -17,4 +17,6 @@ stdenv.mkDerivation {
   patches = map fetchurl (import ./debian-patches.nix);
 
   prePatch = "patchShebangs Scripts";
+
+  meta.broken = true;
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -13,7 +13,7 @@
   enableOfficialBranding ? false
 }:
 
-let version = "38.3.0"; in
+let version = "38.6.0"; in
 let verName = "${version}"; in
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "cgit-${version}";
-  version = "0.11.2";
+  version = "0.12";
 
   src = fetchurl {
     url = "http://git.zx2c4.com/cgit/snapshot/${name}.tar.xz";
-    sha256 = "0fryh56kyah7v9a8zzhbhwlyy2j116w87sxmgrn2kmwk0rvnw4if";
+    sha256 = "1dx54hgfyabmg9nm5qp6d01f54nlbqbbdwhwl0llb9imjf237qif";
   };
 
   # cgit is tightly coupled with git and needs a git source tree to build.
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   # NOTE: as of 0.10.1, the git version is compatible from 1.9.0 to
   # 1.9.2 (see the repository history)
   gitSrc = fetchurl {
-    url    = "mirror://kernel/software/scm/git/git-2.3.2.tar.xz";
-    sha256 = "09gqijsjfnxlbsxbxzlvllg37bfs9f4jwa2plqsanmba09i89sqq";
+    url    = "mirror://kernel/software/scm/git/git-2.7.0.tar.xz";
+    sha256 = "03bvb8s5j8i54qbi3yayl42bv0wf2fpgnh1a2lkhbj79zi7b77zs";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./jasper-CVE-2016-1867.diff
     ./jasper-CVE-2014-8137-variant2.diff
     ./jasper-CVE-2014-8137-noabort.diff
     ./jasper-CVE-2014-8138.diff
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libjpeg ];
 
   configureFlags = "--enable-shared";
-  
+
   meta = {
     homepage = https://www.ece.uvic.ca/~frodo/jasper/;
     description = "JPEG2000 Library";

--- a/pkgs/development/libraries/jasper/jasper-CVE-2016-1867.diff
+++ b/pkgs/development/libraries/jasper/jasper-CVE-2016-1867.diff
@@ -1,0 +1,11 @@
+--- jasper-1.900.1/src/libjasper/jpc/jpc_t2cod.c	2007-01-19 22:43:07.000000000 +0100
++++ jasper-1.900.1/src/libjasper/jpc/jpc_t2cod.c	2016-01-14 14:22:24.569056412 +0100
+@@ -429,7 +429,7 @@
+ 	}
+
+ 	for (pi->compno = pchg->compnostart, pi->picomp =
+-	  &pi->picomps[pi->compno]; pi->compno < JAS_CAST(int, pchg->compnoend); ++pi->compno,
++	  &pi->picomps[pi->compno]; pi->compno < JAS_CAST(int, pchg->compnoend) && pi->compno < pi->numcomps; ++pi->compno,
+ 	  ++pi->picomp) {
+ 		pirlvl = pi->picomp->pirlvls;
+ 		pi->xstep = pi->picomp->hsamp * (1 << (pirlvl->prcwidthexpn +

--- a/pkgs/development/libraries/libbsd/default.nix
+++ b/pkgs/development/libraries/libbsd/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
-let name = "libbsd-0.7.0";
+let name = "libbsd-0.8.2";
 in stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
     url = "http://libbsd.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1fqhbi0vd6xjxazf633x388cc8qyn58l78704s0h6k63wlbhwfqg";
+    sha256 = "02i5brb2007sxq3mn862mr7yxxm0g6nj172417hjyvjax7549xmj";
   };
 
   patchPhase = ''
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
       --replace "{exec_prefix}" "{prefix}"
   '';
 
-  meta = { 
+  meta = {
     description = "Common functions found on BSD systems";
     homepage = http://libbsd.freedesktop.org/;
     license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  name = "mbedtls-1.3.14";
+  name = "mbedtls-1.3.16";
 
   src = fetchurl {
     url = "https://polarssl.org/download/${name}-gpl.tgz";
-    sha256 = "1y3gr3kfai3d13j08r4pv42sh47nbfm4nqi9jq8c9d06qidr2xmy";
+    sha256 = "f413146c177c52d4ad8f48015e2fb21dd3a029ca30a2ea000cbc4f9bd092c933";
   };
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "mysql-${version}";
-  version = "5.5.45";
+  version = "5.5.48";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.5/${name}.tar.gz";
-    sha256 = "0clkr3r44j8nsgmjzv6r09pb0vjangn5hpyjxgg5ynr674ygskkl";
+    sha256 = "10fpzvf6hxvqgaq8paiz8fvhcbbs4qnzqw0svq40bvlyhx2qfgyc";
   };
 
   patches = if stdenv.isCygwin then [


### PR DESCRIPTION
# Please review.

nox-review is running on my build server. It isn't a small set of changes.
###### Things done:
- [X] Tested via `nix.useChroot`.
- [ ] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
## Not Updated...

There are some CVEs I'm not updating for, because I'm going for low-hanging fruit to get as many as possible.
- https://lwn.net/Vulnerabilities/674843/ rails-html-sanitizer, used it gitlab
- https://lwn.net/Vulnerabilities/674609/ qemu, which they don't seem to have an updated release to patch?
- https://lwn.net/Vulnerabilities/674707/ webkitgtk4 which I'm not sure we use or not
- https://lwn.net/Vulnerabilities/672314/ ffmpeg, 3.0.0 is out, 2.8.6 is vulnerable, there may be a patch, and 1.x is way old. The ffmpeg nix expressions seem pretty complicated, and needlessly tied together into a "generic" expression. I'm going to leave this one be, too.
- https://lwn.net/Vulnerabilities/674075/ xen, but I think we're patched. Should we have a 4.6.1 though? 
- https://lwn.net/Vulnerabilities/668127/ firefox / thunderbird / seamonkey, the generate_sources doesn't seem to run: `./generate_sources.rb:25:in`<main>': undefined method `match' for nil:NilClass (NoMethodError)`
- https://lwn.net/Vulnerabilities/671915/ libtiff, since the patch may not fix the issue, and upstream has not released a fix.
