### PR TITLE
samba: reduce closure size

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -5,7 +5,6 @@
 , gnutls, libgcrypt, libgpgerror
 , ncurses, libunwind, libibverbs, librdmacm, systemd
 
-, enableKerberos ? false
 , enableInfiniband ? false
 , enableLDAP ? false
 , enablePrinting ? false
@@ -34,10 +33,9 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ python pkgconfig perl libxslt docbook_xsl docbook_xml_dtd_42 /*
       docbook_xml_dtd_45 */ readline talloc ntdb tdb tevent ldb popt iniparser
-      libbsd libarchive zlib acl fam libiconv gettext libunwind
+      libbsd libarchive zlib acl fam libiconv gettext libunwind kerberos
     ]
     ++ optionals stdenv.isLinux [ libaio pam systemd ]
-    ++ optional enableKerberos kerberos
     ++ optionals (enableInfiniband && stdenv.isLinux) [ libibverbs librdmacm ]
     ++ optional enableLDAP openldap
     ++ optional (enablePrinting && stdenv.isLinux) cups
@@ -58,23 +56,22 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--with-static-modules=NONE"
       "--with-shared-modules=ALL"
+      "--with-system-mitkrb5"
       "--enable-fhs"
       "--sysconfdir=/etc"
       "--localstatedir=/var"
-      "--bundled-libraries=${if enableKerberos && kerberos != null &&
-        kerberos.implementation == "heimdal" then "NONE" else "com_err"}"
+      "--bundled-libraries=NONE"
       "--private-libraries=NONE"
-      "--builtin-libraries=replace"
+      "--builtin-libraries=NONE"
     ]
-    ++ optional (enableKerberos && kerberos != null &&
-      kerberos.implementation == "krb5") "--with-system-mitkrb5"
     ++ optional (!enableDomainController) "--without-ad-dc"
     ++ optionals (!enableLDAP) [ "--without-ldap" "--without-ads" ];
 
   enableParallelBuilding = true;
 
-  stripAllList = [ "bin" "sbin" ];
-
+  # Some libraries don't have /lib/samba in RPATH but need it.
+  # Use find -type f -executable -exec echo {} \; -exec sh -c 'ldd {} | grep "not found"' \;
+  # Looks like a bug in installer scripts.
   postFixup = ''
     export SAMBA_LIBS="$(find $out -type f -name \*.so -exec dirname {} \; | sort | uniq)"
     read -r -d "" SCRIPT << EOF || true
@@ -85,7 +82,7 @@ stdenv.mkDerivation rec {
     patchelf --set-rpath "\$ALL_LIBS" "\$BIN" 2>/dev/null || exit $?;
     patchelf --shrink-rpath "\$BIN";
     EOF
-    find $out -type f -exec $SHELL -c "$SCRIPT" \;
+    find $out -type f -name \*.so -exec $SHELL -c "$SCRIPT" \;
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9819,7 +9819,6 @@ let
 
   samba4 = callPackage ../servers/samba/4.x.nix {
     python = python2;
-    kerberos = null;  # Bundle kerberos because samba uses internal, non-stable functions
     # enableLDAP
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): NixOS, x86_64-linux.
- [x] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

This brings Samba 4 closure from 132M down to 56M. One issue is that I don't understand what `postFixup` does. Also I have only tested client side of things -- this definitely needs further testing!
