### PR TITLE
love: fix broken 0.8.2 + added version 0.72

### DIFF
--- a/pkgs/development/interpreters/love/0.7.nix
+++ b/pkgs/development/interpreters/love/0.7.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, pkgconfig
+, SDL, mesa, openal, lua
+, libdevil, freetype, physfs
+, libmodplug, mpg123, libvorbis, libogg
+}:
+
+stdenv.mkDerivation rec {
+  name = "love-0.7.2";
+  src = fetchurl {
+    url = "https://bitbucket.org/rude/love/downloads/${name}-linux-src.tar.gz";
+    sha256 = "0s7jywkvydlshlgy11ilzngrnybmq5xlgzp2v2dhlffwrfqdqym5";
+  };
+
+  buildInputs = [
+    pkgconfig SDL mesa openal lua
+    libdevil freetype physfs libmodplug mpg123 libvorbis libogg
+  ];
+
+  preConfigure = ''
+    luaoptions="${"''"} lua luajit "
+    for i in lua luajit-; do
+      for j in 5 5.0 5.1 5.2 5.3 5.4; do
+        luaoptions="$luaoptions $i$j "
+      done
+    done
+    luaso="$(echo "${lua}/lib/"lib*.so.*)"
+    luaso="''${luaso##*/lib}"
+    luaso="''${luaso%%.so*}"
+    luaoptions="$luaoptions $luaso"
+    sed -e "s/${"''"} lua lua.*;/$luaoptions;/" -i configure
+
+    luaincdir="$(echo "${lua}/include"/*/ )"
+    test -d "$luaincdir" && {
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I$luaincdir"
+    } || true
+  '';
+
+  NIX_CFLAGS_COMPILE = ''
+    -I${SDL}/include/SDL
+    -I${freetype}include/freetype2
+  '';
+
+  meta = {
+    homepage = "http://love2d.org";
+    description = "A Lua-based 2D game engine/scripting language";
+    license = stdenv.lib.licenses.zlib;
+
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.raskin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5318,7 +5318,8 @@ let
 
   lolcode = callPackage ../development/interpreters/lolcode { };
 
-  love_0_8 = callPackage ../development/interpreters/love/0.8.nix { };
+  love_0_7 = callPackage ../development/interpreters/love/0.7.nix { lua=lua5_1; };
+  love_0_8 = callPackage ../development/interpreters/love/0.8.nix { lua=lua5_1; };
   love_0_9 = callPackage ../development/interpreters/love/0.9.nix { };
   love_0_10 = callPackage ../development/interpreters/love/0.10.nix { };
   love = love_0_10;


### PR DESCRIPTION
Quite a few API breakages across different version of the engine mean that games are specific to older versions. Fixed broken 0.8 and added 0.72.
