### PR TITLE
x11 service: bspwm limit sxhkd freqency

### DIFF
--- a/nixos/modules/services/x11/window-managers/bspwm.nix
+++ b/nixos/modules/services/x11/window-managers/bspwm.nix
@@ -15,7 +15,7 @@ in
     services.xserver.windowManager.session = singleton {
       name = "bspwm";
       start = "
-        ${pkgs.sxhkd}/bin/sxhkd &
+        SXHKD_SHELL=/bin/sh ${pkgs.sxhkd}/bin/sxhkd -f 100 &
         ${pkgs.bspwm}/bin/bspwm
       ";
     };


### PR DESCRIPTION
allow sxhkd to behave well in more situations (w/ bspwm as WindowManager)

add '-f 100' as an argument to sxhkd to keep it from flooding bspwm

add SXHKD_SHELL=/bin/sh to help default to a faster shell than what may
be set in $SHELL (example: with zsh)

Things done:
- [x] Tested via nix.useChroot. 
- [x] Built on platform(s): NixOS x86_64
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits CONTRIBUTING.md.
