### PR TITLE
services.bepasty: buildEnv for creating PYTHONPATH

### DIFF
--- a/nixos/modules/services/misc/bepasty.nix
+++ b/nixos/modules/services/misc/bepasty.nix
@@ -103,9 +103,13 @@ in
           after = [ "network.target" ];
           restartIfChanged = true;
 
-          environment = {
+          environment = let
+            penv = python.buildEnv.override {
+              extraLibs = [ bepasty gevent ];
+            };
+          in {
             BEPASTY_CONFIG = "${server.workDir}/bepasty-${name}.conf";
-            PYTHONPATH= "${bepasty}/lib/${python.libPrefix}/site-packages:${gevent}/lib/${python.libPrefix}/site-packages";
+            PYTHONPATH= "${penv}/${python.sitePackages}/";
           };
 
           serviceConfig = {


### PR DESCRIPTION
Some time in the past 6 months the behavior of gunicorn changed - only adding the explicit dependencies to the PYTHONPATH is not enough anymore. 

Changes only in `nixos/modules/` not `pkgs/`
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): linux
- [ ] Tested compilation of all pkgs that depend on this change. (not applicable)
- [x] Tested execution of binary products and deployment of service
     tested by deploying simple config:

```
services.bepasty = {
  enable = true;
  servers.internal.secretKey = true;
}
```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes _"You need gevent installed to use this worker"_ when trying to start up gunicorn with gevent. This is due to an implicit missing dependency (greenlet). This commit prepares a python environment with the two explicit dependencies and then runs gunicorn with this PYTHONPATH.

Without this fix bepasty will not successfully be served by gunicorn

cc @domenkozar 
