### PR TITLE
bdf2psf: 1.134 -> 1.137

### DIFF
--- a/pkgs/tools/misc/bdf2psf/default.nix
+++ b/pkgs/tools/misc/bdf2psf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "bdf2psf-${version}";
-  version = "1.134";
+  version = "1.137";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/c/console-setup/bdf2psf_${version}_all.deb";
-    sha256 = "1am5ka5qrbh60jjihzqac03ii3ydprvqm3w54dc55a0zwl61njsz";
+    sha256 = "08pgpwg0ccf0j4r8dbaadh1yr4h4fnvkfb5ym49kwvm2p2vxdq32";
   };
 
   buildInputs = [ dpkg ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [x] Built on platform(s): only on GNU/Linux.
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
