### PR TITLE
nano: build info manual

### DIFF
--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl
 , ncurses
+, texinfo
 , gettext ? null
 , enableNls ? true
 , enableTiny ? false
@@ -16,7 +17,8 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/nano/${name}.tar.gz";
     sha256 = "1vl9bim56k1b4zwc3icxp46w6pn6gb042j1h4jlz1jklxxpkwcpz";
   };
-  buildInputs = [ ncurses ] ++ optional enableNls gettext;
+  buildInputs = [ ncurses texinfo ] ++ optional enableNls gettext;
+  outputs = [ "out" "info" ];
   configureFlags = ''
     --sysconfdir=/etc
     ${optionalString (!enableNls) "--disable-nls"}


### PR DESCRIPTION
###### Things done:
- [ ] Tested via `nix.useChroot`.
- [ ] Built on platform(s): .
- [ ] Tested compilation of all pkgs that depend on this change.
- [ ] Tested execution of binary products.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This patch enables `texinfo` as a `nano` dependency to include the info manual in the Nano packages.

I did this because the info manual is more complete than the man page, and I was tired of `info nano` not working.
