### PR TITLE
pixie: init at 0-1333

### DIFF
--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, fetchgit, fetchurl, python, makeWrapper, pkgconfig, gcc,
+  pypy, libffi, libedit, libuv, boost, zlib,
+  variant ? "jit", buildWithPypy ? false }:
+
+let
+  commit-count = "1333";
+  common-flags = "--thread --gcrootfinder=shadowstack --continuation";
+  variants = {
+    jit = { flags = "--opt=jit"; target = "target.py"; };
+    jit-preload = { flags = "--opt=jit"; target = "target_preload.py"; };
+    no-jit = { flags = ""; target = "target.py"; };
+    no-jit-preload = { flags = ""; target = "target_preload.py"; };
+  };
+  pixie-src = fetchgit {
+    url = "https://github.com/pixie-lang/pixie.git";
+    rev = "36ce07e1cd85ca82eedadf366bef3bb57a627a2a";
+    sha256 = "1b3v99c0is33w029r15qvd0mkrc5n1mrvjjmfpcd9yvhvqb2vcjs";
+  };
+  pypy-tag = "81254";
+  pypy-src = fetchurl {
+    name = "pypy-src-${pypy-tag}";
+    url = "https://bitbucket.org/pypy/pypy/get/${pypy-tag}.tar.bz2";
+    sha256 = "1cs9xqs1rmzdcnwxxkbvy064s5cbp6vvzhn2jmyzh5kg4di1r3bn";
+  };
+  libs = [ libffi libedit libuv boost.dev boost.lib zlib ];
+  include-path = stdenv.lib.concatStringsSep ":"
+                   (map (p: "${p}/include") libs);
+  library-path = stdenv.lib.concatStringsSep ":"
+                   (map (p: "${p}/lib") libs);
+  bin-path = stdenv.lib.concatStringsSep ":"
+               (map (p: "${p}/bin") [ gcc ]);
+  build = {flags, target}: stdenv.mkDerivation rec {
+    name = "pixie-${version}";
+    version = "0-r${commit-count}-${variant}";
+    nativeBuildInputs = libs;
+    buildInputs = [ pkgconfig makeWrapper ];
+    PYTHON = if buildWithPypy
+      then "${pypy}/pypy-c/.pypy-c-wrapped"
+      else "${python}/bin/python";
+    unpackPhase = ''
+      cp -R ${pixie-src} pixie-src
+      mkdir pypy-src
+      (cd pypy-src
+       tar --strip-components=1 -xjf ${pypy-src})
+      chmod -R +w pypy-src pixie-src
+    '';
+    patchPhase = ''
+      (cd pixie-src
+       patch -p1 < ${./load_paths.patch}
+       libraryPaths='["${libuv}" "${libedit}" "${libffi}" "${boost.dev}" "${boost.lib}" "${zlib}"]'
+       export libraryPaths
+       substituteAllInPlace ./pixie/ffi-infer.pxi)
+    '';
+    buildPhase = ''(
+      PYTHONPATH="`pwd`/pypy-src:$PYTHONPATH";
+      RPYTHON="`pwd`/pypy-src/rpython/bin/rpython";
+      cd pixie-src
+      $PYTHON $RPYTHON ${common-flags} ${target}
+      export LD_LIBRARY_PATH="${library-path}:$LD_LIBRARY_PATH"
+      find pixie -name "*.pxi" -exec ./pixie-vm -c {} \;
+    )'';
+    installPhase = ''
+      mkdir -p $out/share $out/bin
+      cp pixie-src/pixie-vm $out/share/pixie-vm
+      cp -R pixie-src/pixie $out/share/pixie
+      makeWrapper $out/share/pixie-vm $out/bin/pxi \
+        --prefix LD_LIBRARY_PATH : ${library-path} \
+        --prefix C_INCLUDE_PATH : ${include-path} \
+        --prefix LIBRARY_PATH : ${library-path} \
+        --prefix PATH : ${bin-path}
+    '';
+    meta = {
+      description = "Pixie is a clojure-like lisp, built with the pypy vm toolkit.";
+      homepage = "https://github.com/pixie-lang/pixie";
+      license = stdenv.lib.licenses.lgpl3;
+      platforms = stdenv.lib.platforms.linux;
+    };
+  };
+in build (builtins.getAttr variant variants)

--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -1,0 +1,27 @@
+{ stdenv, pixie, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "dust-0-91";
+  src = fetchgit {
+    url = "https://github.com/pixie-lang/dust.git";
+    rev = "efe469661e749a71e86858fd006f61464810575a";
+    sha256 = "0krh7ynald3gqv9f17a4kfx7sx8i31l6j1fhd5k8b6m8cid7f9c1";
+  };
+  buildInputs = [ pixie ];
+  patches = [ ./make-paths-configurable.patch ];
+  configurePhase = ''
+    pixiePath="${pixie}/bin/pxi" \
+    basePath="$out/share/dust" \
+      substituteAll dust.in dust
+    chmod +x dust
+  '';
+# FIXME: AOT for dust
+#  buildPhase = ''
+#    find . -name "*.pxi" -exec pixie-vm -c {} \;
+#  '';
+  installPhase = ''
+    mkdir -p $out/bin $out/share/dust
+    cp -a src/ run.pxi $out/share/dust
+    mv dust $out/bin/dust
+  '';
+}

--- a/pkgs/development/interpreters/pixie/load_paths.patch
+++ b/pkgs/development/interpreters/pixie/load_paths.patch
@@ -1,0 +1,25 @@
+diff --git a/pixie/ffi-infer.pxi b/pixie/ffi-infer.pxi
+index 9f13ac7..74301c2 100644
+--- a/pixie/ffi-infer.pxi
++++ b/pixie/ffi-infer.pxi
+@@ -1,15 +1,12 @@
+ (ns pixie.ffi-infer
+   (:require [pixie.io-blocking :as io]))
+ 
++(defn -add-library-path [p]
++  (swap! load-paths conj (str p "/include"))
++  (swap! load-paths conj (str p "/lib")))
+ 
+-(defn -add-rel-path [rel]
+-  (swap! load-paths conj (str (first @load-paths) "/" rel)))
+-
+-(-add-rel-path "lib")
+-(-add-rel-path "include")
+-(-add-rel-path "../lib")
+-(-add-rel-path "../include")
+-
++(doseq [lp @libraryPaths@]
++  (-add-library-path lp))
+ 
+ (def *config* nil)
+ (set-dynamic! (var *config*))

--- a/pkgs/development/interpreters/pixie/make-paths-configurable.patch
+++ b/pkgs/development/interpreters/pixie/make-paths-configurable.patch
@@ -1,0 +1,122 @@
+From 0cbb82e606610d36e52c70d888995fbbf9b0d7c8 Mon Sep 17 00:00:00 2001
+From: Herwig Hochleitner <herwig@bendlas.net>
+Date: Sun, 28 Feb 2016 16:34:14 +0100
+Subject: [PATCH] make paths configurable
+
+---
+ dust    | 52 ----------------------------------------------------
+ dust.in | 43 +++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 43 insertions(+), 52 deletions(-)
+ delete mode 100755 dust
+ create mode 100755 dust.in
+
+diff --git a/dust b/dust
+deleted file mode 100755
+index ffced9b..0000000
+--- a/dust
++++ /dev/null
+@@ -1,52 +0,0 @@
+-#!/usr/bin/env bash
+-
+-base_path=$0
+-if [ -L "$base_path" ]; then
+-    base_path=`readlink $base_path`
+-fi
+-base_path=`dirname $base_path`
+-
+-pixie_path=`which pixie-vm`
+-if [ -z "$pixie_path" ]; then
+-    echo "Error: 'pixie-vm' must be on your PATH"
+-    exit 1
+-fi
+-
+-function set_load_path() {
+-    load_path=""
+-    if ([ -f "project.edn" ] || [ -f "project.pxi" ]) && [ -f ".load-path" ]; then
+-        load_path="`cat .load-path`"
+-    fi
+-}
+-
+-if [ ! -f "project.edn" ] && [ -f "project.pxi" ]; then
+-	echo "Warning: 'project.pxi' is deprecated, please use 'project.edn'."
+-	echo "To start you can run the following command:"
+-	echo "  pixie-vm -l $base_path/src -e '(require dust.project :as p) (p/load-project!) (prn (dissoc @p/*project* :path))'"
+-	echo
+-fi
+-
+-set_load_path
+-run_dust="$pixie_path -l $base_path/src $load_path $base_path/run.pxi"
+-
+-case $1 in
+-    ""|"repl")
+-        rlwrap_cmd=""
+-        if [ -n "`which rlwrap`" ]; then
+-            rlwrap_cmd="rlwrap -aignored -n"
+-        fi
+-        $rlwrap_cmd $pixie_path $load_path
+-        ;;
+-    "run")
+-        shift
+-        file=$1
+-        shift
+-        $pixie_path $load_path $file $@
+-        ;;
+-    -h|--help)
+-        $run_dust help
+-        ;;
+-    *)
+-        $run_dust $@
+-        ;;
+-esac
+diff --git a/dust.in b/dust.in
+new file mode 100755
+index 0000000..44a7fbd
+--- /dev/null
++++ b/dust.in
+@@ -0,0 +1,43 @@
++#!/usr/bin/env bash
++
++base_path=@basePath@
++pixie_path=@pixiePath@
++
++function set_load_path() {
++    load_path=""
++    if ([ -f "project.edn" ] || [ -f "project.pxi" ]) && [ -f ".load-path" ]; then
++        load_path="`cat .load-path`"
++    fi
++}
++
++if [ ! -f "project.edn" ] && [ -f "project.pxi" ]; then
++	echo "Warning: 'project.pxi' is deprecated, please use 'project.edn'."
++	echo "To start you can run the following command:"
++	echo "  pixie-vm -l $base_path/src -e '(require dust.project :as p) (p/load-project!) (prn (dissoc @p/*project* :path))'"
++	echo
++fi
++
++set_load_path
++run_dust="$pixie_path -l $base_path/src $load_path $base_path/run.pxi"
++
++case $1 in
++    ""|"repl")
++        rlwrap_cmd=""
++        if [ -n "`which rlwrap`" ]; then
++            rlwrap_cmd="rlwrap -aignored -n"
++        fi
++        $rlwrap_cmd $pixie_path $load_path
++        ;;
++    "run")
++        shift
++        file=$1
++        shift
++        $pixie_path $load_path $file $@
++        ;;
++    -h|--help)
++        $run_dust help
++        ;;
++    *)
++        $run_dust $@
++        ;;
++esac
+-- 
+2.7.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5508,6 +5508,7 @@ let
   };
 
   pixie = callPackage ../development/interpreters/pixie { };
+  dust = callPackage ../development/interpreters/pixie/dust.nix { };
 
   bundix = callPackage ../development/interpreters/ruby/bundix {
     ruby = ruby_2_1_3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5507,6 +5507,8 @@ let
     wrapPython = pythonPackages.wrapPython;
   };
 
+  pixie = callPackage ../development/interpreters/pixie { };
+
   bundix = callPackage ../development/interpreters/ruby/bundix {
     ruby = ruby_2_1_3;
   };


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): `Linux nitox 4.4.2 #1-NixOS SMP Wed Feb 17 20:31:25 UTC 2016 x86_64 GNU/Linux, 16.03-pre-401d590a64736d3c (Emu)`
- [x] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This is the pixie language, a clojure-like lisp, utilizing the pypy vm toolkit for JIT, GC and C bindings.
see https://github.com/pixie-lang/pixie

**EDIT**
Regarding closure size: The package weighs in at around 6MB, and only depends on `libffi`, `libuv`, `boost`, `zlib` and `gcc`
