### PR TITLE
zerotierone: hardcoded path fix

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       substituteInPlace ./make-linux.mk \
           --replace 'CXX=$(shell which clang++ g++ c++ 2>/dev/null | head -n 1)' "CC=${gcc}/bin/g++";
       substituteInPlace ./osdep/LinuxEthernetTap.cpp \
-          --replace '/sbin/ip' "${iproute}/bin/ip"
+          --replace 'execlp("ip",' 'execlp("${iproute}/bin/ip",'
   '';
 
   buildInputs = [ openssl lzo zlib gcc iproute ];


### PR DESCRIPTION
New code in zerotier 1.1.4 broke the previous substitution where we refer to the correct path for "ip".

This should allow zerotier to correctly set the interface IP address when connecting to a network.

cc @sjmackenzie @zimbatm @jagajaga
