### PR TITLE
buildGoPackage: do not remove Go references if allowGoReferences is true

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -30,7 +30,7 @@ if disabled then throw "${name} not supported for go ${go.meta.branch}" else
 let
   args = lib.filterAttrs (name: _: name != "extraSrcs") args';
 
-  removeReferences = [ go ];
+  removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
 
   removeExpr = refs: lib.flip lib.concatMapStrings refs (ref: ''
     | sed "s,${ref},$(echo "${ref}" | sed "s,$NIX_STORE/[^-]*,$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,"),g" \


### PR DESCRIPTION
`allowGoReference` was only checked for `disallowedReferences` definition, but the fixup of all output binaries removing references to the compiler did not take this setting into account, resulting in a not so allowed Go reference.
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): Darwin.
- [x] Tested compilation of all pkgs that depend on this change (`goPackages.tools`, the only package using this attribute).
- [x] Tested execution of binary products (tested on [go2nix](https://github.com/kamilchm/go2nix)).
