### PR TITLE
postfix: use relative symlinks for mailq and newaliases

### DIFF
--- a/pkgs/servers/mail/postfix/3.0.nix
+++ b/pkgs/servers/mail/postfix/3.0.nix
@@ -35,7 +35,12 @@ in stdenv.mkDerivation rec {
                 ++ lib.optional withMySQL libmysql
                 ++ lib.optional withSQLite sqlite;
 
-  patches = [ ./postfix-script-shell.patch ./postfix-3.0-no-warnings.patch ./post-install-script.patch ];
+  patches = [
+    ./postfix-script-shell.patch
+    ./postfix-3.0-no-warnings.patch
+    ./post-install-script.patch
+    ./relative-symlinks.patch
+  ];
 
   preBuild = ''
     sed -e '/^PATH=/d' -i postfix-install

--- a/pkgs/servers/mail/postfix/relative-symlinks.patch
+++ b/pkgs/servers/mail/postfix/relative-symlinks.patch
@@ -1,0 +1,13 @@
+diff --git a/postfix-install b/postfix/postfix-install
+index 1662c3d..0f20ec0 100644
+--- a/postfix-install
++++ b/postfix-install
+@@ -336,7 +336,7 @@ compare_or_symlink() {
+ 	# 2) we cannot use mv to replace a symlink-to-directory;
+ 	# 3) "ln -n" is not in POSIX, therefore it's not portable.
+ 	# rm+ln is less atomic but this affects compatibility symlinks only.
+-	rm -f $2 && ln -sf $link $2 || exit 1
++	rm -f $2 && ln -rsf $link $2 || exit 1
+     }
+ }
+ 


### PR DESCRIPTION
###### Things done:
- [x] Tested via `nix.useChroot`.
- [x] Built on platform(s): x86_64-linux.
- [ ] Tested compilation of all pkgs that depend on this change.
- [x] Tested execution of binary products.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Extra

Fixes #12017.
Replaces #12033.

cc @gebner @peti @wmertens.

(Woa templates)
