### PR TITLE
use the sourceforge mirrors everywhere

### DIFF
--- a/pkgs/applications/audio/QmidiNet/default.nix
+++ b/pkgs/applications/audio/QmidiNet/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "qmidinet-${version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/qmidinet/${name}.tar.gz";
+    url = "mirror://sourceforge/qmidinet/${name}.tar.gz";
     sha256 = "1a1pj4w74wj1gcfv4a0vzcglmr5sw0xp0y56w8rk3ig4k11xi8sa";
   };
 

--- a/pkgs/applications/audio/eq10q/default.nix
+++ b/pkgs/applications/audio/eq10q/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
   name = "eq10q-2-${version}";
   version = "beta7.1";
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/eq10q/${name}.tar.gz";
+    url = "mirror://sourceforge/project/eq10q/${name}.tar.gz";
     sha256 = "1jmrcx4jlx8kgsy5n4jcxa6qkjqvx7d8l2p7dsmw4hj20s39lgyi";
   };
 

--- a/pkgs/applications/audio/faust/faust1.nix
+++ b/pkgs/applications/audio/faust/faust1.nix
@@ -12,7 +12,7 @@ let
   version = "0.9.73";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/faudiostream/faust-${version}.tgz";
+    url = "mirror://sourceforge/project/faudiostream/faust-${version}.tgz";
     sha256 = "0x2scxkwvvjx7b7smj5xb8kr269qakf49z3fxpasd9g7025q44k5";
   };
 

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -19,7 +19,7 @@ let
   version = "2.0-a41";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/faudiostream/faust-2.0.a41.tgz";
+    url = "mirror://sourceforge/project/faudiostream/faust-2.0.a41.tgz";
     sha256 = "1cq4x1cax0lswrcqv0limx5mjdi3187zlmh7cj2pndr0xq6b96cm";
   };
 

--- a/pkgs/applications/audio/gjay/default.nix
+++ b/pkgs/applications/audio/gjay/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   name = "gjay-0.3.2";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/gjay/gjay-0.3.2.tar.gz";
+    url = "mirror://sourceforge/project/gjay/gjay-0.3.2.tar.gz";
     sha256 = "1a1vv4r0vnxjdyl0jyv7gga3zfd5azxlwjm1l6hjrf71lb228zn8";
   };
 

--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   name = "kid3-${meta.version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/kid3/kid3/${meta.version}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/kid3/kid3/${meta.version}/${name}.tar.gz";
     sha256 = "12sa54mg1b3wkagmh5yi20ski8km9d199lk0a1yfxy0ffjfld7js";
   };
 

--- a/pkgs/applications/audio/mp3gain/default.nix
+++ b/pkgs/applications/audio/mp3gain/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "mp3gain-1.5.2";
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/mp3gain/mp3gain-1_5_2-src.zip";
+    url = "mirror://sourceforge/mp3gain/mp3gain-1_5_2-src.zip";
     sha256 = "1jkgry59m8cnnfq05b9y1h4x4wpy3iq8j68slb9qffwa3ajcgbfv";
   };
 

--- a/pkgs/applications/audio/pd-plugins/cyclone/default.nix
+++ b/pkgs/applications/audio/pd-plugins/cyclone/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.1-alpha55";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/pure-data/libraries/cyclone/${name}.tar.gz";
+    url = "mirror://sourceforge/project/pure-data/libraries/cyclone/${name}.tar.gz";
     sha256 = "1yys9xrlz09xgnqk2gqdl8vw6xj6l9d7km2lkihidgjql0jx5b5i";
   };
 

--- a/pkgs/applications/audio/pd-plugins/maxlib/default.nix
+++ b/pkgs/applications/audio/pd-plugins/maxlib/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.5.5";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/pure-data/libraries/maxlib/${name}.tar.gz";
+    url = "mirror://sourceforge/project/pure-data/libraries/maxlib/${name}.tar.gz";
     sha256 = "0vxl9s815dnay5r0067rxsfh8f6jbk61f0nxrydzjydfycza7p1w";
   };
 

--- a/pkgs/applications/editors/bviplus/default.nix
+++ b/pkgs/applications/editors/bviplus/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "bviplus-${version}";
   version = "0.9.4";
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/bviplus/bviplus/${version}/bviplus-${version}.tgz";
+    url = "mirror://sourceforge/project/bviplus/bviplus/${version}/bviplus-${version}.tgz";
     sha256 = "10x6fbn8v6i0y0m40ja30pwpyqksnn8k2vqd290vxxlvlhzah4zb";
   };
   buildInputs = [

--- a/pkgs/applications/editors/heme/default.nix
+++ b/pkgs/applications/editors/heme/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "heme-${version}";
   version = "0.4.2";
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/heme/heme/heme-${version}/heme-${version}.tar.gz";
+    url = "mirror://sourceforge/project/heme/heme/heme-${version}/heme-${version}.tar.gz";
     sha256 = "0wsrnj5mrlazgqs4252k30aw8m86qw0z9dmrsli9zdxl7j4cg99v";
   };
   postPatch = ''

--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/saga-gis/SAGA%20-%202.2/SAGA%202.2.2/saga-2.2.2.tar.gz";
+    url = "mirror://sourceforge/project/saga-gis/SAGA%20-%202.2/SAGA%202.2.2/saga-2.2.2.tar.gz";
     sha256 = "031cd70b7ec248f32f955a9316aefc7f7ab283c5129c49aa4bd748717d20357e";
   };
 

--- a/pkgs/applications/misc/galculator/default.nix
+++ b/pkgs/applications/misc/galculator/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "2.1.3";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/galculator/${name}.tar.gz";
+    url = "mirror://sourceforge/galculator/${name}.tar.gz";
     sha256 = "12m7dldjk10lpkdxk7zpk98n32ci65zmxidghihb7n1m3rhp3q17";
   };
 

--- a/pkgs/applications/misc/lxappearance/default.nix
+++ b/pkgs/applications/misc/lxappearance/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "lxappearance-0.6.1";
   src = fetchurl{
-    url = "http://downloads.sourceforge.net/project/lxde/LXAppearance/${name}.tar.xz";
+    url = "mirror://sourceforge/project/lxde/LXAppearance/${name}.tar.xz";
     sha256 = "1phnv1b2jdj2vlibjyc9z01izcf3k5zxj8glsaf0i3vh77zqmqq9";
   };
   buildInputs = [ intltool libX11 pkgconfig gtk ];

--- a/pkgs/applications/misc/quicksynergy/default.nix
+++ b/pkgs/applications/misc/quicksynergy/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "quicksynergy-${version}";
   version = "0.9.0";
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/quicksynergy/Linux/${version}/quicksynergy-${version}.tar.gz";
+    url = "mirror://sourceforge/project/quicksynergy/Linux/${version}/quicksynergy-${version}.tar.gz";
     sha256 = "1pi8503bg8q1psw50y6d780i33nnvfjqiy9vnr3v52pdcfip8pix";
   };
   buildInputs = [

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   name = "roxterm-${version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/roxterm/${name}.tar.bz2";
+    url = "mirror://sourceforge/roxterm/${name}.tar.bz2";
     sha256 = "0djfiwfmnqqp6930kswzr2rss0mh40vglcdybwpxrijcw4n8j21x";
   };
 

--- a/pkgs/applications/misc/vym/default.nix
+++ b/pkgs/applications/misc/vym/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.2.4";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/vym/${version}/${name}.tar.bz2";
+    url = "mirror://sourceforge/project/vym/${version}/${name}.tar.bz2";
     sha256 = "1x4qp6wpszscbbs4czkfvskm7qjglvxm813nqv281bpy4y1hhvgs";
   };
 

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "4.0.3-20150806";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/gnomesword/Xiphos/4.0.3/${name}.tar.gz";
+    url = "mirror://sourceforge/project/gnomesword/Xiphos/4.0.3/${name}.tar.gz";
     sha256 = "1xkvhpasdlda2rp0874znz158z4rjh1hpynwy13d96kjxq4npiqv";
   };
 

--- a/pkgs/applications/networking/instant-messengers/choqok/default.nix
+++ b/pkgs/applications/networking/instant-messengers/choqok/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   name = "${pn}-${v}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/choqok/Choqok/choqok-1.5.tar.xz";
+    url = "mirror://sourceforge/project/choqok/Choqok/choqok-1.5.tar.xz";
     sha256 = "5cb97ac4cdf9db4699bb7445a9411393073d213fea649ab0713f659f1308efe4";
   };
 

--- a/pkgs/applications/video/wxcam/default.nix
+++ b/pkgs/applications/video/wxcam/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "1.1";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/wxcam/wxcam/${version}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/wxcam/wxcam/${version}/${name}.tar.gz";
     sha256 = "1765bvc65fpzn9ycnnj5hais9xkx9v0sm6a878d35x54bpanr859";
   };
 

--- a/pkgs/applications/virtualization/bochs/default.nix
+++ b/pkgs/applications/virtualization/bochs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   version = "2.6.8";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/bochs/bochs/${version}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/bochs/bochs/${version}/${name}.tar.gz";
     sha256 = "1kl5cmbz6qgg33j5vv9898nzdppp1rqgy24r5pv762aaj7q0ww3r";
   };
 

--- a/pkgs/development/libraries/biblesync/default.nix
+++ b/pkgs/development/libraries/biblesync/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec{
   version = "1.1.2";
 
   src = fetchurl{
-    url = "http://downloads.sourceforge.net/project/gnomesword/BibleSync/1.1.2/${name}.tar.gz";
+    url = "mirror://sourceforge/project/gnomesword/BibleSync/1.1.2/${name}.tar.gz";
     sha256 = "0190q2da0ppif2242lahl8xfz01n9sijy60aq1a0545qcp0ilvl8";
   };
 

--- a/pkgs/development/libraries/cimg/default.nix
+++ b/pkgs/development/libraries/cimg/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "1.5.9";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/cimg/CImg-${version}.zip";
+    url = "mirror://sourceforge/project/cimg/CImg-${version}.zip";
     sha256 = "1xn20643gcbl76kvy9ajhwbyjjb73mg65q32ma8mdkwn1qhn7f7c";
   };
 

--- a/pkgs/development/libraries/cpptest/default.nix
+++ b/pkgs/development/libraries/cpptest/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "cpptest-1.1.2";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/cpptest/cpptest/${name}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/cpptest/cpptest/${name}/${name}.tar.gz";
     sha256 = "09v070a9dv6zq6hgj4v67i31zsis3s96psrnhlq9g4vhdcaxykwy";
   };
 

--- a/pkgs/development/libraries/gtkspellmm/default.nix
+++ b/pkgs/development/libraries/gtkspellmm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   name = "gtkspellmm-${version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/gtkspell/gtkspellmm/" +
+    url = "mirror://sourceforge/project/gtkspell/gtkspellmm/" +
           "${name}.tar.gz";
     sha256 = "f9dcc0991621c08e7a972f33487afd6b37491468f0b654f50c741a7e6d810624";
   };

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "uriparser-0.8.2";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/uriparser/Sources/0.8.2/${name}.tar.bz2";
+    url = "mirror://sourceforge/project/uriparser/Sources/0.8.2/${name}.tar.bz2";
     sha256 = "13sh7slys3y5gfscc40g2r3hkjjywjvxlcqr77ifjrazc6q6cvkd";
   };
 

--- a/pkgs/development/ocaml-modules/ocamlsdl/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlsdl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl { 
-    url = "http://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz";
+    url = "mirror://sourceforge/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz";
     sha256 = "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f";
   };
 

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   name = "ocaml-ssl-${version}";
 
   src = fetchurl {
-  url = "http://downloads.sourceforge.net/project/savonet/ocaml-ssl/0.5.2/ocaml-ssl-0.5.2.tar.gz";
+  url = "mirror://sourceforge/project/savonet/ocaml-ssl/0.5.2/ocaml-ssl-0.5.2.tar.gz";
 
     sha256 = "0341rm8aqrckmhag1lrqfnl17v6n4ci8ibda62ahkkn5cxd58cpp";
   };

--- a/pkgs/development/tools/analysis/coan/default.nix
+++ b/pkgs/development/tools/analysis/coan/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "coan-${version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/coan2/v${version}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/coan2/v${version}/${name}.tar.gz";
     sha256 = "1d041j0nd1hc0562lbj269dydjm4rbzagdgzdnmwdxr98544yw44";
   };
 

--- a/pkgs/development/tools/literate-programming/eweb/default.nix
+++ b/pkgs/development/tools/literate-programming/eweb/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec{
   name = "eweb-${meta.version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/eweb/${name}.tar.bz2";
+    url = "mirror://sourceforge/project/eweb/${name}.tar.bz2";
     sha256 = "1xy7vm2sj5q6s620fm25klmnwnz9xkrxmx4q2f8h6c85ydisayd5";
   };
 

--- a/pkgs/development/tools/literate-programming/nuweb/default.nix
+++ b/pkgs/development/tools/literate-programming/nuweb/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec{
   version = "1.58";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/nuweb/${name}.tar.gz";
+    url = "mirror://sourceforge/project/nuweb/${name}.tar.gz";
     sha256 = "0q51i3miy15fv4njjp82yws01qfjxvqx5ly3g3vh8z3h7iq9p47y";
   };
 

--- a/pkgs/development/tools/misc/premake/3.nix
+++ b/pkgs/development/tools/misc/premake/3.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   name = "${baseName}-${version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/sourceforge/premake/${baseName}-src-${version}.zip";
+    url = "mirror://sourceforge/sourceforge/premake/${baseName}-src-${version}.zip";
     sha256 = "b59841a519e75d5b6566848a2c5be2f91455bf0cc6ae4d688fcbd4c40db934d5";
   };
 

--- a/pkgs/games/instead/default.nix
+++ b/pkgs/games/instead/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   name = "instead-" + version;
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/instead/instead/${version}/instead_${version}.tar.gz";
+    url = "mirror://sourceforge/project/instead/instead/${version}/instead_${version}.tar.gz";
     sha256 = "1ldisjkmmcpnmv4vsd25dc1sfiwbr9fcn3hxhl78i4jwlyqgrms8";
   };
 

--- a/pkgs/games/odamex/default.nix
+++ b/pkgs/games/odamex/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "odamex-0.7.0";
   src = fetchurl {
-    url = http://downloads.sourceforge.net/odamex/odamex-src-0.7.0.tar.bz2;
+    url = mirror://sourceforge/odamex/odamex-src-0.7.0.tar.bz2;
     sha256 = "0cb6p58yv55kdyfj7s9n9xcwpvxrj8nyc6brw9jvwlc5n4y3cd5a";
   };
 

--- a/pkgs/games/vassal/default.nix
+++ b/pkgs/games/vassal/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "VASSAL-3.2.15";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/vassalengine/${name}-linux.tar.bz2";
+    url = "mirror://sourceforge/vassalengine/${name}-linux.tar.bz2";
     sha256 = "10ng571nxr5zc2nlviyrk5bci8my67kq3qvhfn9bifzkxmjlqmk9";
   };
 

--- a/pkgs/misc/emulators/cdemu/base.nix
+++ b/pkgs/misc/emulators/cdemu/base.nix
@@ -4,7 +4,7 @@ let name = "${pkgName}-${version}";
 in stdenv.mkDerivation ({
   inherit name buildInputs;
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/cdemu/${name}.tar.bz2";
+    url = "mirror://sourceforge/cdemu/${name}.tar.bz2";
     sha256 = pkgSha256;
   };
   nativeBuildInputs = [ pkgconfig cmake ];

--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -3,7 +3,7 @@ let version = "20140928";
 in stdenv.mkDerivation {
   name = "vhba-${version}";
   src  = fetchurl {
-    url = "http://downloads.sourceforge.net/cdemu/vhba-module-${version}.tar.bz2";
+    url = "mirror://sourceforge/cdemu/vhba-module-${version}.tar.bz2";
     sha256 = "18jmpg2kpx87f32b8aprr1pxla9dlhf901rkj1sp3ammf94nxxa5";
   };
   preBuild = ''

--- a/pkgs/misc/emulators/desmume/default.nix
+++ b/pkgs/misc/emulators/desmume/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "0.9.11";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/desmume/desmume/${version}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/desmume/desmume/${version}/${name}.tar.gz";
     sha256 = "15l8wdw3q61fniy3h93d84dnm6s4pyadvh95a0j6d580rjk4pcrs";
   };
 

--- a/pkgs/misc/emulators/stella/default.nix
+++ b/pkgs/misc/emulators/stella/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "4.6.1";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/stella/stella/${version}/${name}-src.tar.gz";
+    url = "mirror://sourceforge/project/stella/stella/${version}/${name}-src.tar.gz";
     sha256 = "126jph21b70jlxapzmll8pq36i53lb304hbsiap25160vdqid4n1";
   };
 

--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -39,23 +39,23 @@ rec {
 		sha256 = "1vhw81pphb64fzsjvpzsnnyr34ka2fxizfwilnxyjcmpn9360h07";
 	}) "nld-eng" "nl_NL";
 	eng2nld =  makeDictdDBFreedict (fetchurl {
-		url = http://downloads.sourceforge.net/freedict/eng-nld.tar.gz;
+		url = mirror://sourceforge/freedict/eng-nld.tar.gz;
 		sha256 = "0rcg28ldykv0w2mpxc6g4rqmfs33q7pbvf68ssy1q9gpf6mz7vcl";
 	}) "eng-nld" "en_UK";
 	eng2rus = makeDictdDBFreedict (fetchurl {
-		url = http://downloads.sourceforge.net/freedict/eng-rus.tar.gz;
+		url = mirror://sourceforge/freedict/eng-rus.tar.gz;
 		sha256 = "15409ivhww1wsfjr05083pv6mg10bak8v5pg1wkiqybk7ck61rry";
 	}) "eng-rus" "en_UK";
 	fra2eng = makeDictdDBFreedict (fetchurl {
-		url = http://downloads.sourceforge.net/freedict/fra-eng.tar.gz;
+		url = mirror://sourceforge/freedict/fra-eng.tar.gz;
 		sha256 = "0sdd88s2zs5whiwdf3hd0s4pzzv75sdsccsrm1wxc87l3hjm85z3";
 	}) "fra-eng" "fr_FR";
 	eng2fra = makeDictdDBFreedict (fetchurl {
-		url = http://downloads.sourceforge.net/freedict/eng-fra.tar.gz;
+		url = mirror://sourceforge/freedict/eng-fra.tar.gz;
 		sha256 = "0fi6rrnbqnhc6lq8d0nmn30zdqkibrah0mxfg27hsn9z7alwbj3m";
 	}) "eng-fra" "en_UK";
 	mueller_eng2rus_pkg = makeDictdDB (fetchurl {
-		url = http://downloads.sourceforge.net/mueller-dict/mueller-dict-3.1.tar.gz;
+		url = mirror://sourceforge/mueller-dict/mueller-dict-3.1.tar.gz;
 		sha256 = "04r5xxznvmcb8hkxqbjgfh2gxvbdd87jnhqn5gmgvxxw53zpwfmq";
 	}) "mueller-eng-rus" "mueller-dict-*/dict" "en_UK";
 	mueller_enru_abbr = {

--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "5.4.0";
   
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/unimediaserver/Official%20Releases/Linux/" + stdenv.lib.toUpper "${name}" + "-Java8.tgz";
+    url = "mirror://sourceforge/project/unimediaserver/Official%20Releases/Linux/" + stdenv.lib.toUpper "${name}" + "-Java8.tgz";
     sha256 = "0ryp26h7pyqing8pyg0xjrp1wm77wwgya4a7d00wczh885pk16kq";
     name = "${name}.tgz";
   };

--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   srcName = "refind-src-${meta.version}";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/refind/${meta.version}/${srcName}.zip";
+    url = "mirror://sourceforge/project/refind/${meta.version}/${srcName}.zip";
     sha256 = "0ai150rzx20sfl92j6y1p6qnyy0wbmazrlp2fg19acs98qyxl8lh";
   };
 

--- a/pkgs/tools/networking/traceroute/default.nix
+++ b/pkgs/tools/networking/traceroute/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.0.21";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/traceroute/${name}.tar.gz";
+    url = "mirror://sourceforge/traceroute/${name}.tar.gz";
     sha256 = "1q4n9s42nfcc4fmnwmrsiabvqrcaagiagmmqj9r5hfmi63pr7b7p";
   };
 

--- a/pkgs/tools/typesetting/pdfgrep/default.nix
+++ b/pkgs/tools/typesetting/pdfgrep/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.1";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/pdfgrep/${version}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/pdfgrep/${version}/${name}.tar.gz";
     sha256 = "6e8bcaf8b219e1ad733c97257a97286a94124694958c27506b2ea7fc8e532437";
   };
 

--- a/pkgs/tools/typesetting/tex/pgf/3.x.nix
+++ b/pkgs/tools/typesetting/tex/pgf/3.x.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "pgf-3.00";
 
   src = fetchurl {
-    url = http://downloads.sourceforge.net/project/pgf/pgf/version%203.0.0/pgf_3.0.0.tds.zip;
+    url = mirror://sourceforge/project/pgf/pgf/version%203.0.0/pgf_3.0.0.tds.zip;
     sha256 = "0kj769hyp4z2zmdv3f8xv443wcfqn5nkkbzxzqgfxjizlz81aav7";
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @jagajaga 

```
find pkgs -name "*.nix" -exec sed -r \
"s|https?://downloads.sourceforge.net/|mirror://sourceforge/|g" -i {} \;
```
