### PR TITLE
tint2: 0.12 -> 0.12.7

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,38 +1,37 @@
-{ stdenv, fetchurl, pkgconfig, cmake, pango, cairo, glib, imlib2, libXinerama
+{ stdenv, fetchFromGitLab, pkgconfig, cmake, pango, cairo, glib, imlib2, libXinerama
 , libXrender, libXcomposite, libXdamage, libX11, libXrandr, gtk, libpthreadstubs
-, libXdmcp, librsvg, fetchgit
+, libXdmcp, librsvg, libstartup_notification
 }:
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.12";
+  version = "0.12.7";
 
-  src = fetchgit {
-    url = "https://gitlab.com/o9000/tint2.git";
+  src = fetchFromGitLab {
+    owner = "o9000";
+    repo = "tint2";
     rev = version;
-    sha256 = "0pd84ydpqz2l6gkhj565nqi2xyiph8zfpn4xha60xshqpsg3pqjq";
+    sha256 = "01wb1yy7zfi01fl34yzpn1d30fykcf8ivmdlynnxp5znqrdsqm2r";
   };
-        
+
+  enableParallelBuilding = true;
+
   buildInputs = [ pkgconfig cmake pango cairo glib imlib2 libXinerama
     libXrender libXcomposite libXdamage libX11 libXrandr gtk libpthreadstubs
-    libXdmcp librsvg
+    libXdmcp librsvg libstartup_notification
   ];
 
   preConfigure =
     ''
       substituteInPlace CMakeLists.txt --replace /etc $out/etc
     '';
+
   prePatch =
     ''
       substituteInPlace ./src/tint2conf/properties.c --replace /usr/share/ /run/current-system/sw/share/
       substituteInPlace ./src/launcher/apps-common.c --replace /usr/share/ /run/current-system/sw/share/
       substituteInPlace ./src/launcher/icon-theme-common.c --replace /usr/share/ /run/current-system/sw/share/
     '';
-
-  cmakeFlags = [
-    "-DENABLE_TINT2CONF=0"
-    "-DENABLE_SN=0"
-  ];
 
   meta = {
     homepage = https://gitlab.com/o9000/tint2;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More
- [ ] New home page on gitlab.
- [ ] Two new dependencies: `librsvg`, `libstartup_notification`.
- [ ] Use `fetchFromGitLab`
- [ ] Enabled `tint2conf`

cc @bjornfor 
