### PR TITLE
RFC: Style and shellchecks

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -21,6 +21,12 @@ makeWrapper() {
             echo "export $varName=$value" >> "$wrapper"
             ;;
 
+          --unset)
+            varName=${params[$((n + 1))]}
+            n=$((n + 1))
+            echo "unset $varName" >> "$wrapper"
+            ;;
+
           --run)
             command=${params[$((n + 1))]}
             n=$((n + 1))

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -1,12 +1,13 @@
+#!bash
 makeWrapper() {
     local original=$1
     local wrapper=$2
     local params varName value command separator n fileNames
     local argv0 flagsBefore flags
 
-    mkdir -p "$(dirname $wrapper)"
+    mkdir -p "$(dirname "$wrapper")"
 
-    echo "#! $SHELL -e" > $wrapper
+    echo "#! $SHELL -e" > "$wrapper"
 
     params=("$@")
     for ((n = 2; n < ${#params[*]}; n += 1)); do
@@ -16,13 +17,13 @@ makeWrapper() {
             varName=${params[$((n + 1))]}
             value=${params[$((n + 2))]}
             n=$((n + 2))
-            echo "export $varName=$value" >> $wrapper
+            echo "export $varName=$value" >> "$wrapper"
         fi
 
         if test "$p" = "--run"; then
             command=${params[$((n + 1))]}
             n=$((n + 1))
-            echo "$command" >> $wrapper
+            echo "$command" >> "$wrapper"
         fi
 
         if test "$p" = "--suffix" -o "$p" = "--prefix"; then
@@ -32,9 +33,9 @@ makeWrapper() {
             n=$((n + 3))
             if test -n "$value"; then
                 if test "$p" = "--suffix"; then
-                    echo "export $varName=\$$varName\${$varName:+$separator}$value" >> $wrapper
+                    echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
                 else
-                    echo "export $varName=$value\${$varName:+$separator}\$$varName" >> $wrapper
+                    echo "export $varName=$value\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             fi
         fi
@@ -45,7 +46,7 @@ makeWrapper() {
             values=${params[$((n + 3))]}
             n=$((n + 3))
             for value in $values; do
-                echo "export $varName=\$$varName\${$varName:+$separator}$value" >> $wrapper
+                echo "export $varName=\$$varName\${$varName:+$separator}$value" >> "$wrapper"
             done
         fi
 
@@ -56,9 +57,9 @@ makeWrapper() {
             n=$((n + 3))
             for fileName in $fileNames; do
                 if test "$p" = "--suffix-contents"; then
-                    echo "export $varName=\$$varName\${$varName:+$separator}$(cat $fileName)" >> $wrapper
+                    echo "export $varName=\$$varName\${$varName:+$separator}$(< "$fileName")" >> "$wrapper"
                 else
-                    echo "export $varName=$(cat $fileName)\${$varName:+$separator}\$$varName" >> $wrapper
+                    echo "export $varName=$(< "$fileName")\${$varName:+$separator}\$$varName" >> "$wrapper"
                 fi
             done
         fi
@@ -78,9 +79,9 @@ makeWrapper() {
     # Note: extraFlagsArray is an array containing additional flags
     # that may be set by --run actions.
     echo exec ${argv0:+-a $argv0} "$original" \
-         $flagsBefore '"${extraFlagsArray[@]}"' '"$@"' >> $wrapper
+         "$flagsBefore" '"${extraFlagsArray[@]}"' '"$@"' >> "$wrapper"
 
-    chmod +x $wrapper
+    chmod +x "$wrapper"
 }
 
 addSuffix() {
@@ -103,6 +104,6 @@ filterExisting() {
 wrapProgram() {
     local prog="$1"
     local hidden="$(dirname "$prog")/.$(basename "$prog")"-wrapped
-    mv $prog $hidden
-    makeWrapper $hidden $prog --argv0 '"$0"' "$@"
+    mv "$prog" "$hidden"
+    makeWrapper "$hidden" "$prog" --argv0 '"$0"' "$@"
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Using ShellCheck to make sure all of our bash is escaped properly. Is this something desirable ?

There are a couple of things I see as controversial in these changes:

Use `#!bash` is a hack that lets vim and shellcheck know that we are dealing with a bash dialect. The file itself is not executable because a shebang needs an absolute path (thus /usr/bin/env's existance).

Use `[[ ]]` over the POSIX `[ ]` or `test` syntax. Mainly because it's smarter in regards to escaping and less likely to mis-use.

A new `--unset` option that I bundle with these changes because of the mass-rebuild. 

---

This is not done yet, just seeking for confirmation if this is a good idea or not. Also trying to see if we can agree on a bash style.

/cc @edolstra @domenkozar 
