### PR TITLE
webkitgtk: init at 2.12

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.12.nix
+++ b/pkgs/development/libraries/webkitgtk/2.12.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, perl, python, ruby, bison, gperf, cmake
+, pkgconfig, gettext, gobjectIntrospection, libnotify
+, gtk2, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at_spi2_core
+, libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs
+, enableGeoLocation ? true, geoclue2, sqlite
+, gst-plugins-base
+}:
+
+assert enableGeoLocation -> geoclue2 != null;
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "webkitgtk-${version}";
+  version = "2.12.0";
+
+  meta = {
+    description = "Web content rendering engine, GTK+ port";
+    homepage = "http://webkitgtk.org/";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    hydraPlatforms = [];
+    maintainers = with maintainers; [ iyzsong koral ];
+  };
+
+  preConfigure = "patchShebangs Tools";
+
+  src = fetchurl {
+    url = "http://webkitgtk.org/releases/${name}.tar.xz";
+    sha256 = "19jyvyw8ss4bacq3f7ybdb0r16r84q12j2bpciyj9jqvzpw091m6";
+  };
+
+  patches = [ ./finding-harfbuzz-icu.patch ];
+
+  cmakeFlags = [ "-DPORT=GTK" "-DUSE_LIBHYPHEN=0" ];
+
+  # XXX: WebKit2 missing include path for gst-plugins-base.
+  # Filled: https://bugs.webkit.org/show_bug.cgi?id=148894
+  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base}/include/gstreamer-1.0";
+
+  nativeBuildInputs = [
+    cmake perl python ruby bison gperf sqlite
+    pkgconfig gettext gobjectIntrospection
+  ] ++ (with xlibs; [ libXdmcp ]);
+
+  buildInputs = [
+    gtk2 wayland libwebp enchant libnotify
+    libxml2 libsecret libxslt harfbuzz libpthreadstubs
+    gst-plugins-base libxkbcommon epoxy at_spi2_core
+  ] ++ optional enableGeoLocation geoclue2;
+
+  propagatedBuildInputs = [
+    libsoup gtk3
+  ];
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8930,6 +8930,11 @@ let
     gst-plugins-base = gst_all_1.gst-plugins-base;
   };
 
+  webkitgtk212x = callPackage ../development/libraries/webkitgtk/2.12.nix {
+    harfbuzz = harfbuzz-icu;
+    gst-plugins-base = gst_all_1.gst-plugins-base;
+  };
+
   webkitgtk2 = webkitgtk24x.override {
     withGtk2 = true;
     enableIntrospection = false;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - `nox-review` crashed: https://gist.github.com/bendlas/fcad69ead1c044a291bc probably not related to the change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

a preview of the 2.12 release, with the b3 jit activated
`hydraPlatforms` is set to `[]` as per 8726c6d50638fea25808e99192ed546657200d87

cc @iyzsong @k0ral 
