### PR TITLE
wtforms: Update to 2.1, make work on python3, disable tests for now.

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8935,15 +8935,19 @@ in modules // {
   };
 
   wtforms = buildPythonPackage rec {
-    version = "2.0.2";
+    version = "2.1";
     name = "wtforms-${version}";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/W/WTForms/WTForms-${version}.zip";
-      md5 = "613cf723ab40537705bec02733c78d95";
+      sha256 = "0vyl26y9cg409cfyj8rhqxazsdnd0jipgjw06civhrd53yyi1pzz";
     };
 
-    propagatedBuildInputs = with self; [ ordereddict Babel ];
+    # Django tests are broken "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet."
+    # This is fixed in master I believe but not yet in 2.1;
+    doCheck = false;
+
+    propagatedBuildInputs = with self; ([ Babel ] ++ (optionals isPy26 [ ordereddict ]));
 
     meta = {
       homepage = https://github.com/wtforms/wtforms;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
