### PR TITLE
nodejs-5_x: 5.6.0 -> 5.7.0

### DIFF
--- a/pkgs/development/web/nodejs/v5.nix
+++ b/pkgs/development/web/nodejs/v5.nix
@@ -7,7 +7,7 @@
 assert stdenv.system != "armv5tel-linux";
 
 let
-  version = "5.6.0";
+  version = "5.7.0";
 
   deps = {
     inherit openssl zlib libuv;
@@ -31,7 +31,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "0zy2pq2xpw170lycs0518jjldy1d5vm5y1pjb4zcibvhb5gcrwis";
+    sha256 = "1n6jvvf3jfmv7fjd64c5jajjapsmc8gr6rlw113vgys55xmb8f13";
   };
 
   configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ];


### PR DESCRIPTION
- Update nodejs 5.x to latest version: `5.7.0`
- Built and tested on `darwin`
