### PR TITLE
lib.trivial: add a new importJSON function

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -75,4 +75,25 @@ rec {
   min = x: y: if x < y then x else y;
   max = x: y: if x > y then x else y;
 
+  /* Reads a JSON file. It is useful to import pure data into other nix
+     expressions.
+
+     Example:
+
+       mkDerivation {
+         src = fetchgit (importJSON ./repo.json)
+         #...
+       }
+
+       where repo.json contains:
+
+       {
+         "url": "git://some-domain/some/repo",
+         "rev": "265de7283488964f44f0257a8b4a055ad8af984d",
+         "sha256": "0sb3h3067pzf3a7mlxn1hikpcjrsvycjcnj9hl9b1c3ykcgvps7h"
+       }
+
+  */
+  importJSON = path:
+    builtins.fromJSON (builtins.readFile path);
 }

--- a/pkgs/build-support/build-maven.nix
+++ b/pkgs/build-support/build-maven.nix
@@ -11,7 +11,7 @@
  *        the project.
  */
 infoFile: let
-  info = builtins.fromJSON (builtins.readFile infoFile);
+  info = lib.importJSON infoFile;
 
   script = writeText "build-maven-repository.sh" ''
     ${lib.concatStrings (map (dep: let


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is meant to be used by packages who often re-generate their outputs.

Producing valid JSON is easier than nix, and also garantees it's purity.
