### PR TITLE
Fix "nix" stdenv

### DIFF
--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -18,10 +18,9 @@ import ../generic rec {
     nativePrefix = stdenv.lib.optionalString stdenv.isSunOS "/usr";
     nativeLibc = true;
     inherit stdenv;
-    binutils = pkgs.binutils;
+    inherit (pkgs) binutils coreutils gnugrep;
     cc = pkgs.gcc.cc;
     isGNU = true;
-    coreutils = pkgs.coreutils;
     shell = pkgs.bash + "/bin/sh";
   };
 


### PR DESCRIPTION
This adds the missing `gnugrep`, causing "assertion failed" for all platforms using "nix" stdenv.

Broken by changes introduced in d96893647de5c519c458c1254f043f2d67d9b29c
