### PR TITLE
plex, plexpass: update to 0.9.15.6.1714

### DIFF
--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -9,9 +9,9 @@ let
     vsnHash = "7be11e1";
     sha256 = "1kyk41qnbm8w5bvnisp3d99cf0r72wvlggfi9h4np7sq4p8ksa0g";
   } else {
-    version = "0.9.15.3.1674";
-    vsnHash = "f46e7e6";
-    sha256 = "086njnjcmknmbn90mmvf60ls7q73g2m955yk621jjdngs4ybvm19";
+    version = "0.9.15.6.1714";
+    vsnHash = "7be11e1";
+    sha256 = "1kyk41qnbm8w5bvnisp3d99cf0r72wvlggfi9h4np7sq4p8ksa0g";
   };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -5,9 +5,9 @@
 
 let
   plexpkg = if enablePlexPass then {
-    version = "0.9.15.5.1712";
-    vsnHash = "ba5070a";
-    sha256 = "0nwcjlfbs8dacp6wzmga75hkx16ngyaqrmdhcx8vqvgwm8l31rxs";
+    version = "0.9.15.6.1714";
+    vsnHash = "7be11e1";
+    sha256 = "1kyk41qnbm8w5bvnisp3d99cf0r72wvlggfi9h4np7sq4p8ksa0g";
   } else {
     version = "0.9.15.3.1674";
     vsnHash = "f46e7e6";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): ~~NixOS / OSX~~ / **Linux**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This is unusual for plex and plexpass to be on the same revision. I feel it's appropriate to leave both sources in there, since we would just redo it as soon as plexpass gets a newer version.
