### PR TITLE
nix-prefetch-git: add a --dry-run flag

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -41,6 +41,7 @@ Options:
       --no-deepClone  Make a shallow clone of just the required ref.
       --leave-dotGit  Keep the .git directories.
       --fetch-submodules Fetch submodules.
+      --dry-run       Do not actually store the repository.
       --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
 "
     exit 1
@@ -61,6 +62,7 @@ for arg; do
             --no-deepClone) deepClone=false;;
             --leave-dotGit) leaveDotGit=true;;
             --fetch-submodules) fetchSubmodules=true;;
+            --dry-run) dryRun=true;;
             --builder) builder=true;;
             --help) usage; exit;;
             *)
@@ -371,8 +373,10 @@ else
         # Compute the hash.
         hash=$(nix-hash --type $hashType --base32 $tmpFile)
 
-        # Add the downloaded file to the Nix store.
-        finalPath=$(nix-store --add-fixed --recursive "$hashType" "$tmpFile")
+        if test -z "$dryRun"; then
+            # Add the downloaded file to the Nix store.
+            finalPath=$(nix-store --add-fixed --recursive "$hashType" "$tmpFile")
+        fi
 
         if test -n "$expHash" -a "$expHash" != "$hash"; then
             print_metadata


### PR DESCRIPTION
This allows running nix-prefetch-git without touching the Nix database.

Without this, running nix-prefetch-git in a nix-shell --pure or in a nix-build phase would result in the following error, caused by the nix-store call:

```
Nix database directory ‘/nix/var/nix/db’ is not writable: Permission denied
```
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
