### PR TITLE
nix-prefetch-scripts: explicitly depend on Nix

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,5 +1,5 @@
 { stdenv, makeWrapper, buildEnv,
-  git, subversion, mercurial, bazaar, cvs, unzip, curl, gnused, coreutils
+  git, subversion, mercurial, bazaar, cvs, unzip, curl, gnused, coreutils, nix
 }:
 
 let mkPrefetchScript = tool: src: deps:
@@ -18,6 +18,7 @@ let mkPrefetchScript = tool: src: deps:
         wrapArgs="$wrapArgs --prefix PATH : $dep/bin"
       done
       wrapArgs="$wrapArgs --prefix PATH : ${gnused}/bin"
+      wrapArgs="$wrapArgs --prefix PATH : ${nix}/bin" # For nix-hash
       wrapArgs="$wrapArgs --set HOME : /homeless-shelter"
       wrapProgram $out/bin/$name $wrapArgs
     '';


### PR DESCRIPTION
Otherwise, a call to, for example, nix-prefetch-git, in a nix-shell --pure or nix-build phase would result in an error such as:

```
Switched to a new branch 'fetchgit'
removing `.git'...
/nix/store/7qvjji7kbd033nsyxlpiiiam61a44yz9-nix-prefetch-git/bin/.nix-prefetch-git-wrapped: line 374: nix-hash: command not found
```
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
