### PR TITLE
amd-non-free: init @ 15.12

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -4,116 +4,135 @@
          version="5.0"
          xml:id="sec-x11">
 
-<title>X Window System</title>
+    <title>X Window System</title>
     
-<para>The X Window System (X11) provides the basis of NixOS’ graphical
-user interface.  It can be enabled as follows:
-<programlisting>
-services.xserver.enable = true;
-</programlisting>
-The X server will automatically detect and use the appropriate video
-driver from a set of X.org drivers (such as <literal>vesa</literal>
-and <literal>intel</literal>).  You can also specify a driver
-manually, e.g.
-<programlisting>
-services.xserver.videoDrivers = [ "r128" ];
-</programlisting>
-to enable X.org’s <literal>xf86-video-r128</literal> driver.</para>
+    <para>
+        The X Window System (X11) provides the basis of NixOS’ graphical
+        user interface.  It can be enabled as follows:
+        <programlisting>
+            services.xserver.enable = true;
+        </programlisting>
+        The X server will automatically detect and use the appropriate video
+        driver from a set of X.org drivers (such as <literal>vesa</literal>
+        and <literal>intel</literal>).  You can also specify a driver
+        manually, e.g.
+        <programlisting>
+            services.xserver.videoDrivers = [ "r128" ];
+        </programlisting>
+        to enable X.org’s <literal>xf86-video-r128</literal> driver.
+    </para>
 
-<para>You also need to enable at least one desktop or window manager.
-Otherwise, you can only log into a plain undecorated
-<command>xterm</command> window.  Thus you should pick one or more of
-the following lines:
-<programlisting>
-services.xserver.desktopManager.kde4.enable = true;
-services.xserver.desktopManager.xfce.enable = true;
-services.xserver.windowManager.xmonad.enable = true;
-services.xserver.windowManager.twm.enable = true;
-services.xserver.windowManager.icewm.enable = true;
-</programlisting>
-</para>
+    <para>
+        You also need to enable at least one desktop or window manager.
+        Otherwise, you can only log into a plain undecorated
+        <command>xterm</command> window.  Thus you should pick one or more of
+        the following lines:
+        <programlisting>
+            services.xserver.desktopManager.kde4.enable = true;
+            services.xserver.desktopManager.xfce.enable = true;
+            services.xserver.windowManager.xmonad.enable = true;
+            services.xserver.windowManager.twm.enable = true;
+            services.xserver.windowManager.icewm.enable = true;
+        </programlisting>
+    </para>
 
-<para>NixOS’s default <emphasis>display manager</emphasis> (the
-program that provides a graphical login prompt and manages the X
-server) is SLiM.  You can select KDE’s <command>kdm</command> instead:
-<programlisting>
-services.xserver.displayManager.kdm.enable = true;
-</programlisting>
-</para>
+    <para>
+        NixOS’s default <emphasis>display manager</emphasis> (the
+        program that provides a graphical login prompt and manages the X
+        server) is SLiM.  You can select KDE’s <command>kdm</command> instead:
+        <programlisting>
+            services.xserver.displayManager.kdm.enable = true;
+        </programlisting>
+    </para>
 
-<para>The X server is started automatically at boot time.  If you
-don’t want this to happen, you can set:
-<programlisting>
-services.xserver.autorun = false;
-</programlisting>
-The X server can then be started manually:
-<screen>
-$ systemctl start display-manager.service
-</screen>
-</para>
+    <para>
+        The X server is started automatically at boot time.  If you
+        don’t want this to happen, you can set:
+        <programlisting>
+            services.xserver.autorun = false;
+        </programlisting>
+        The X server can then be started manually:
+        <screen>
+            $ systemctl start display-manager.service
+        </screen>
+    </para>
 
+    <simplesect>
+        <title>NVIDIA Graphics Cards</title>
+        <para>
+            NVIDIA provides a proprietary driver for its graphics cards that
+            has better 3D performance than the X.org drivers.  It is not enabled
+            by default because it’s not free software.  You can enable it as follows:
+            <programlisting>
+                services.xserver.videoDrivers = [ "nvidia" ];
+            </programlisting>
+            Or if you have an older card, you may have to use one of the legacy drivers:
+            <programlisting>
+                services.xserver.videoDrivers = [ "nvidiaLegacy340" ];
+                services.xserver.videoDrivers = [ "nvidiaLegacy304" ];
+                services.xserver.videoDrivers = [ "nvidiaLegacy173" ];
+            </programlisting>
+            You may need to reboot after enabling this driver to prevent a clash
+            with other kernel modules.
+        </para>
+        <para>
+            On 64-bit systems, if you want full acceleration for 32-bit
+            programs such as Wine, you should also set the following:
+            <programlisting>
+                hardware.opengl.driSupport32Bit = true;
+            </programlisting>
+        </para>
 
-<simplesect><title>NVIDIA Graphics Cards</title>
+    </simplesect>
 
-<para>NVIDIA provides a proprietary driver for its graphics cards that
-has better 3D performance than the X.org drivers.  It is not enabled
-by default because it’s not free software.  You can enable it as follows:
-<programlisting>
-services.xserver.videoDrivers = [ "nvidia" ];
-</programlisting>
-Or if you have an older card, you may have to use one of the legacy drivers:
-<programlisting>
-services.xserver.videoDrivers = [ "nvidiaLegacy340" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy304" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy173" ];
-</programlisting>
-You may need to reboot after enabling this driver to prevent a clash
-with other kernel modules.</para>
+    <simplesect>
+        <title>AMD Graphics Cards</title>
+        <para>
+            AMD provides a proprietary driver release for its Radeon™
+            graphics cards which has superior performance  in comparison
+            to the default radeon kernel module and accompanying X.org driver.
+            It is not enabled by default because the software is not free. 
+            If you agree to the terms of the license which can be found linked at:
+            http://support.amd.com/en-us/download/eula you can enable the software
+            if you specify:
+            <programlisting>
+                services.xserver.videoDrivers = [ "ati_unfree" ];
+            </programlisting>
+            For cards newer than Radeon™ HD6000 which are not supported by
+            amdgpu, the:
+            <programlisting>
+                services.xserver.videoDrivers = [ "amd-non-free" ];
+            </programlisting>
+            option offers the opportunity to try AMD's proprietary Linux Radeon™ driver
+            as an alternative to ati_unfree.
+            You will need to reboot after enabling either of these drivers in order
+            to prevent the possibility of a clash with other kernel modules.
+        </para>
+        <para>
+            On 64-bit systems, if you want full acceleration for 32-bit
+            programs such as Wine, you should also set the following:
+            <programlisting>
+                hardware.opengl.driSupport32Bit = true;
+            </programlisting>
+            If you select amd-non-free, you do not need to select this option.
+            It is enabled by default for you.
+        </para>
+    </simplesect>
 
-<para>On 64-bit systems, if you want full acceleration for 32-bit
-programs such as Wine, you should also set the following:
-<programlisting>
-hardware.opengl.driSupport32Bit = true;
-</programlisting>
-</para>
-
-</simplesect>
-
-<simplesect><title>AMD Graphics Cards</title>
-
-<para>AMD provides a proprietary driver for its graphics cards that
-has better 3D performance than the X.org drivers.  It is not enabled
-by default because it’s not free software.  You can enable it as follows:
-<programlisting>
-services.xserver.videoDrivers = [ "ati_unfree" ];
-</programlisting>
-You will need to reboot after enabling this driver to prevent a clash
-with other kernel modules.</para>
-
-<para>On 64-bit systems, if you want full acceleration for 32-bit
-programs such as Wine, you should also set the following:
-<programlisting>
-hardware.opengl.driSupport32Bit = true;
-</programlisting>
-</para>
-
-</simplesect>
-
-<simplesect><title>Touchpads</title>
-
-<para>Support for Synaptics touchpads (found in many laptops such as
-the Dell Latitude series) can be enabled as follows:
-<programlisting>
-services.xserver.synaptics.enable = true;
-</programlisting>
-The driver has many options (see <xref linkend="ch-options"/>).  For
-instance, the following enables two-finger scrolling:
-<programlisting>
-services.xserver.synaptics.twoFingerScroll = true;
-</programlisting>
-</para>
-
-</simplesect>
-
+    <simplesect>
+        <title>Touchpads</title>
+        <para>
+            Support for Synaptics touchpads (found in many laptops such as
+            the Dell Latitude series) can be enabled as follows:
+            <programlisting>
+                services.xserver.synaptics.enable = true;
+            </programlisting>
+            The driver has many options (see <xref linkend="ch-options"/>).  For
+            instance, the following enables two-finger scrolling:
+            <programlisting>
+                services.xserver.synaptics.twoFingerScroll = true;
+            </programlisting>
+        </para>
+    </simplesect>
 
 </chapter>

--- a/nixos/modules/hardware/video/amd.nix
+++ b/nixos/modules/hardware/video/amd.nix
@@ -1,0 +1,46 @@
+# This module provides the proprietary AMD Radeon™ X11 / OpenGL drivers.
+
+{ config, lib, pkgs, pkgs_i686, ... }:
+
+with lib;
+
+let
+
+  drivers = config.services.xserver.videoDrivers;
+  enabled = elem "amd-non-free" drivers;
+  amd-fglrx = config.boot.kernelPackages.amd-non-free;
+  amd-fglrx-libs = config.boot.kernelPackages.amd-non-free-libs;
+
+  atieventsdUnit = {
+    description = "Catalyst event Daemon.";
+    serviceConfig = {
+      requires="acpid.service";
+      ExecStart="${amd-fglrx}/bin/atieventsd --acpidsocket=/run/acpid.socket --socket=/run/atieventsd.socket --nosyslog --xauthscript=${amd-fglrx}/etc/ati/authatieventsd.sh";
+    };
+    wantedBy = [ "graphical.target" ];
+    after = [ "local-fs.target" "multi-user.target" "graphical.target" ];
+  };
+
+in
+
+{
+
+  config = mkIf enabled {
+
+    environment.systemPackages = [ amd-fglrx ];
+
+    services.xserver.drivers = singleton
+      { name = "fglrx"; modules = [ amd-fglrx-libs ]; libPath = [ "${amd-fglrx-libs}/lib" ]; };
+
+    hardware.opengl.driSupport32Bit = if pkgs.stdenv.isx86_64 then true else false;
+    hardware.opengl.package = amd-fglrx-libs;
+    hardware.opengl.package32 = pkgs_i686.linuxPackages.amd-non-free-libs;
+    boot.extraModulePackages = [ amd-fglrx ];
+    boot.blacklistedKernelModules = [ "radeon" "amdgpu" "radeonfb" ];
+    boot.kernelParams = [ "nomodeset" ];
+    environment.etc."ati".source = "${amd-fglrx}/etc/ati";
+    systemd.services."atieventsd" = if config.services.acpid.enable then atieventsdUnit else false;
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -40,6 +40,7 @@
   ./hardware/pcmcia.nix
   ./hardware/video/bumblebee.nix
   ./hardware/video/nvidia.nix
+  ./hardware/video/amd.nix
   ./hardware/video/ati.nix
   ./hardware/video/webcam/facetimehd.nix
   ./i18n/inputMethod/default.nix

--- a/pkgs/os-specific/linux/amd-non-free/4.3-gentoo-mtrr.patch
+++ b/pkgs/os-specific/linux/amd-non-free/4.3-gentoo-mtrr.patch
@@ -1,0 +1,27 @@
+--- 15.9/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-09 00:57:14.000000000 +0200
++++ 15.9/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-11-03 19:00:09.121884973 +0100
+@@ -3412,7 +3412,11 @@
+ int ATI_API_CALL KCL_MEM_MTRR_AddRegionWc(unsigned long base, unsigned long size)
+ {
+ #ifdef CONFIG_MTRR
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
++    return arch_phys_wc_add(base, size);
++#else
+     return mtrr_add(base, size, MTRR_TYPE_WRCOMB, 1);
++#endif
+ #else /* !CONFIG_MTRR */
+     return -EPERM;
+ #endif /* !CONFIG_MTRR */
+@@ -3421,7 +3425,12 @@
+ int ATI_API_CALL KCL_MEM_MTRR_DeleteRegion(int reg, unsigned long base, unsigned long size)
+ {
+ #ifdef CONFIG_MTRR
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
++    arch_phys_wc_del(reg);
++    return reg;
++#else
+     return mtrr_del(reg, base, size);
++#endif
+ #else /* !CONFIG_MTRR */
+     return -EPERM;
+ #endif /* !CONFIG_MTRR */

--- a/pkgs/os-specific/linux/amd-non-free/4.3-kolasa-seq_printf.patch
+++ b/pkgs/os-specific/linux/amd-non-free/4.3-kolasa-seq_printf.patch
@@ -1,0 +1,16 @@
+--- 15.9/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-09-09 00:57:14.000000000 +0200
++++ 15.9b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-11-02 21:02:06.124639919 +0100
+@@ -623,8 +623,13 @@
+ 
+     len = snprintf(buf, request, "%d\n", major);
+ #else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
++    seq_printf(m, "%d\n", major);
++    len = 0;
++#else
+     len = seq_printf(m, "%d\n", major);
+ #endif
++#endif
+ 
+     KCL_DEBUG1(FN_FIREGL_PROC, "return len=%i\n",len);
+ 

--- a/pkgs/os-specific/linux/amd-non-free/4.4-manjaro-xstate.patch
+++ b/pkgs/os-specific/linux/amd-non-free/4.4-manjaro-xstate.patch
@@ -1,0 +1,22 @@
+--- 15.12/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-12-18 19:47:41.000000000 +0100
++++ 15.12b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-12-19 20:48:13.223261632 +0100
+@@ -6450,12 +6450,15 @@
+    struct fpu *fpu = &tsk->thread.fpu;
+ 
+    if(static_cpu_has(X86_FEATURE_XSAVE)) {
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
+-      fpu_xsave(fpu);
+-      if (!(fpu->state->xsave.xsave_hdr.xstate_bv & XSTATE_FP))
+-#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
++	  copy_xregs_to_kernel(&fpu->state.xsave);
++      if (!(fpu->state.xsave.header.xfeatures & XFEATURE_MASK_FP))
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
+ 	  copy_xregs_to_kernel(&fpu->state.xsave);
+       if (!(fpu->state.xsave.header.xfeatures & XSTATE_FP))
++#else
++      fpu_xsave(fpu);
++      if (!(fpu->state->xsave.xsave_hdr.xstate_bv & XSTATE_FP))
+ #endif
+          return 1;
+    } else if (static_cpu_has(X86_FEATURE_FXSR)) {

--- a/pkgs/os-specific/linux/amd-non-free/amd-non-free-libs.nix
+++ b/pkgs/os-specific/linux/amd-non-free/amd-non-free-libs.nix
@@ -1,0 +1,160 @@
+{
+stdenv, fetchurl, xorg, patchelf, unzip, fontconfig, freetype, glibc
+}:
+
+with stdenv.lib;
+
+let
+  version = "15.12";
+in
+
+# /usr/lib/dri/fglrx_dri.so must point to /run/opengl-driver/lib/fglrx_dri.so
+
+stdenv.mkDerivation {
+
+  name = "amd-non-free-${version}-libs";
+
+  src = fetchurl {
+    url = "http://www2.ati.com/drivers/linux/radeon-crimson-${version}-15.302-151217a-297685e.zip";
+    curlOpts = "--referer http://support.amd.com/en-us/download/desktop?os=Linux%20x86_64";
+    sha256 = "704f2dfc14681f76dae3b4120c87b1ded33cf43d5a1d800b6de5ca292bb61e58";
+  };
+
+  inherit glibc /* glibc only used for setting interpreter */;
+  dontStrip = true;
+  dontPatchELF = true;
+  preferLocalBuild = true;
+  enableParallelBuilding = true;
+  gcc = stdenv.cc.cc;
+  arch =
+    if stdenv.system == "i686-linux" then
+      "x86"
+    else if stdenv.system == "x86_64-linux" then
+      "x86_64"
+    else throw "amd-non-free is Linux only. Sorry. The build was stopped.";
+  lib_arch =
+    if stdenv.system == "i686-linux" then
+      "lib"
+    else if stdenv.system == "x86_64-linux" then
+      "lib64"
+    else false;
+  DIR_DEPENDING_ON_XORG_VERSION =
+    if stdenv.system == "i686-linux" then
+      "xpic"
+    else if stdenv.system == "x86_64-linux" then
+      "xpic_64a"
+    else false;
+
+  buildInputs = [
+    xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM xorg.libXrandr xorg.libXxf86vm
+    xorg.xf86vidmodeproto xorg.imake xorg.libICE patchelf unzip fontconfig freetype
+  ];
+
+  LD_LIBRARY_PATH = stdenv.lib.concatStringsSep ":" [
+    "${xorg.libXrandr}/lib/"
+    "${xorg.libXrender}/lib/"
+    "${xorg.libXext}/lib/"
+    "${xorg.libX11}/lib/"
+    "${xorg.libXinerama}/lib/"
+    "${xorg.libSM}/lib/"
+    "${xorg.libICE}/lib/"
+    "${stdenv.cc.cc}/lib/"
+  ];
+
+  # This adds the following libraries as symlinks in $out/lib so that they
+  # appear in /run/opengl-driver/lib which is added to the LD_LIBRARY_PATH.
+  extraDRIlibs = [ xorg.libXrandr xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM xorg.libICE ];
+
+  phases = [ "unpackPhase" "patchPhase" "buildPhase" "fixupPhase" ];
+ 
+  preUnpack = "die(){ echo $@; exit 1; }";
+  postUnpack = "sh fglrx*/amd-driver-installer-* --extract .";
+  prePatch = ''cd ..'';
+
+  buildPhase = ''
+    mkdir -p $out/lib/xorg
+    for d1 in \
+      $TMP/arch/$arch/usr/X11R6/$lib_arch/modules/dri \
+      $TMP/arch/$arch/usr/X11R6/$lib_arch/modules/dri/* \
+      $TMP/arch/$arch/usr/X11R6/$lib_arch/*.so* \
+      $TMP/arch/$arch/usr/$lib_arch/*
+    do
+      cp -r $d1 $out/lib
+    done
+    cp -r $TMP/$DIR_DEPENDING_ON_XORG_VERSION/usr/X11R6/$lib_arch/modules $out/lib/xorg
+    cp -r $TMP/arch/$arch/usr/X11R6/$lib_arch/fglrx/fglrx-libGL.so.1.2 $out/lib/fglrx-libGL.so.1.2
+    ln -s libatiuki.so.1.0 $out/lib/libatiuki.so.1
+    ln -s fglrx-libGL.so.1.2 $out/lib/libGL.so.1
+    ln -s fglrx-libGL.so.1.2 $out/lib/libGL.so
+    # make xorg use the ati version
+    ln -s $out/lib/xorg/modules/extensions/{fglrx/fglrx-libglx.so,libglx.so}
+    # Correct some paths that are hardcoded into binary libs.
+    if [ "$arch" ==  "x86_64" ]; then
+      for lib2 in \
+        xorg/modules/extensions/fglrx/fglrx-libglx.so \
+        xorg/modules/glesx.so \
+        dri/fglrx_dri.so \
+        fglrx_dri.so \
+        fglrx-libGL.so.1.2
+      do
+        oldPaths="/usr/X11R6/lib/modules/dri"
+        newPaths="/run/opengl-driver/lib/dri"
+        sed -i -e "s|$oldPaths|$newPaths|" $out/lib/$lib2
+      done
+      for pelib1 in \
+        fglrx_dri.so \
+        dri/fglrx_dri.so
+      do
+        patchelf --remove-needed libX11.so.6 $out/lib/$pelib1
+      done
+
+    else
+
+      oldPaths="/usr/X11R6/lib32/modules/dri\x00/usr/lib32/dri"
+      newPaths="/run/opengl-driver-32/lib/dri\x00/dev/null/dri"
+      sed -i -e "s|$oldPaths|$newPaths|" \
+        $out/lib/xorg/modules/extensions/fglrx/fglrx-libglx.so
+
+      for lib3 in \
+        dri/fglrx_dri.so \
+        fglrx_dri.so \
+        xorg/modules/glesx.so
+      do
+        oldPaths="/usr/X11R6/lib32/modules/dri/"
+        newPaths="/run/opengl-driver-32/lib/dri"
+        sed -i -e "s|$oldPaths|$newPaths|" $out/lib/$lib3
+      done
+
+      oldPaths="/usr/X11R6/lib32/modules/dri\x00"
+      newPaths="/run/opengl-driver-32/lib/dri"
+      sed -i -e "s|$oldPaths|$newPaths|" $out/lib/fglrx-libGL.so.1.2
+
+    fi
+
+    for pelib2 in \
+      libatiadlxx.so \
+      xorg/modules/glesx.so \
+      dri/fglrx_dri.so \
+      fglrx_dri.so \
+      libaticaldd.so
+    do
+      patchelf --set-rpath $gcc/$lib_arch/ $out/lib/$pelib2
+    done
+
+    for p in $extraDRIlibs; do
+      for lib in $p/lib/*.so*; do
+        ln -s $lib $out/lib/
+      done
+    done
+
+    rm -f $out/lib/fglrx/switchlibglx && rm -f $out/lib/fglrx/switchlibGL'';
+
+  meta = {
+    description = "ATI Radeon™ display driver shared libraries.";
+    homepage = http://support.amd.com/us/gpudownload/Pages/index.aspx;
+    license = licenses.amd;
+    platforms = platforms.linux;
+    priority = 4;
+  };
+
+}

--- a/pkgs/os-specific/linux/amd-non-free/crimson_i686_xg.patch
+++ b/pkgs/os-specific/linux/amd-non-free/crimson_i686_xg.patch
@@ -1,0 +1,12 @@
+--- 15.11/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-11-21 00:35:38.000000000 +0100
++++ 15.11b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-11-24 22:28:02.113843493 +0100
+@@ -1714,6 +1714,9 @@
+ 
+ #if defined(__i386__) 
+ #ifndef __HAVE_ARCH_CMPXCHG
++#ifndef __xg
++#define __xg(x) ((volatile long *)(x))
++#endif
+ static inline 
+ unsigned long __fgl_cmpxchg(volatile void *ptr, unsigned long old,            
+                         unsigned long new, int size)                      

--- a/pkgs/os-specific/linux/amd-non-free/default.nix
+++ b/pkgs/os-specific/linux/amd-non-free/default.nix
@@ -1,0 +1,156 @@
+{
+stdenv, fetchurl, which, xorg, makeWrapper, glibc
+, patchelf, unzip, fontconfig, freetype, kernel ? null
+,procps ,amd-non-free-libs
+# Enable lock debugging ?
+,developer ? false
+}:
+
+assert kernel != null;
+with stdenv.lib;
+
+# This driver supports Radeon™ R9 200, R7 200, HD 7000, HD 6000, and HD 5000 Series cards.
+# You will require amdgpu instead if you have a newer card.
+# This derivation requires a maximum of gcc5, Linux kernel 4.4 and xorg.xserver 1.17
+# and will not build or run using versions newer.
+# This driver does not support an i686-linux NixOS system. However the 32bit libs
+# (for running 32 binaries in 64 bit user space are provided.)
+# use nixpkgs.config.amd-non-free.developer = true; to enable lock debugging.
+
+let
+  version = "15.12";
+in
+
+# /usr/lib/dri/fglrx_dri.so must point to /run/opengl-driver/lib/fglrx_dri.so
+
+stdenv.mkDerivation {
+
+  name = "amd-non-free-${version}-${kernel.version}";
+
+  src = fetchurl {
+    url = "http://www2.ati.com/drivers/linux/radeon-crimson-${version}-15.302-151217a-297685e.zip";
+    curlOpts = "--referer http://support.amd.com/en-us/download/desktop?os=Linux%20x86_64";
+    sha256 = "704f2dfc14681f76dae3b4120c87b1ded33cf43d5a1d800b6de5ca292bb61e58";
+  };
+
+  inherit glibc /* glibc only used for setting interpreter */;
+  dontStrip = true;
+  whichBin = which;
+  pidofBin = procps;
+  dontPatchELF = true;
+  preferLocalBuild = true;
+  enableParallelBuilding = true;
+  # Variables for the module build script etc.
+  gcc = stdenv.cc.cc;
+  xauth = xorg.xauth;
+  libSM = xorg.libSM;
+  libICE = xorg.libICE;
+  libfreetype = freetype;
+  libfontconfig = fontconfig;
+  libXrandr = xorg.libXrandr;
+  libXrender = xorg.libXrender;
+  libXxf86vm = xorg.libXxf86vm;
+  libXinerama = xorg.libXinerama;
+  kernel = kernel.dev;
+  xf86vidmodeproto = xorg.xf86vidmodeproto;
+  arch =
+    if stdenv.system == "i686-linux" then
+      "x86"
+    else if stdenv.system == "x86_64-linux" then
+      "x86_64"
+    else throw "amd-non-free is Linux only. Sorry. The build was stopped.";
+  lib_arch =
+    if stdenv.system == "i686-linux" then
+      "lib"
+    else if stdenv.system == "x86_64-linux" then
+      "lib64"
+    else false;
+  DIR_DEPENDING_ON_XORG_VERSION =
+    if stdenv.system == "i686-linux" then
+      "xpic"
+    else if stdenv.system == "x86_64-linux" then
+      "xpic_64a"
+    else false;
+
+  buildInputs = [
+    xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM xorg.libXrandr xorg.libXxf86vm
+    xorg.xf86vidmodeproto xorg.imake xorg.libICE patchelf unzip fontconfig freetype makeWrapper
+    which procps
+  ];
+
+  LD_LIBRARY_PATH = stdenv.lib.concatStringsSep ":" [
+    "${xorg.libXrandr}/lib/"
+    "${xorg.libXrender}/lib/"
+    "${xorg.libXext}/lib/"
+    "${xorg.libX11}/lib/"
+    "${xorg.libXinerama}/lib/"
+    "${xorg.libSM}/lib/"
+    "${xorg.libICE}/lib/"
+    "${stdenv.cc.cc}/lib/"
+  ];
+
+  phases = [  "unpackPhase" "patchPhase" "preBuild" "buildPhase" "fixupPhase" ];
+ 
+  preUnpack = "die(){ echo $@; exit 1; }";
+  postUnpack = "sh fglrx*/amd-driver-installer-* --extract .";
+  prePatch = ''cd ..'';
+
+  patches = [
+    ./4.4-manjaro-xstate.patch  ./grsec_arch.patch ./makefile_compat.patch ./lano1106_kcl_agp_13_4.patch
+    ./lano1106_fglrx_intel_iommu.patch ./crimson_i686_xg.patch ./4.3-kolasa-seq_printf.patch
+    ./4.3-gentoo-mtrr.patch ./display-managers.patch
+  ];
+
+  preBuild = if (developer) then ''
+    substituteInPlace $TMP/common/lib/modules/fglrx/build_mod/firegl_public.c --replace "Proprietary." "GPL\0Proprietary."
+    echo "Lock debugging enabled." ''
+  else ''echo "Lock debugging disabled." '';
+
+  buildPhase = ''
+    source ${./module.sh}
+    substituteInPlace $TMP/common/etc/ati/authatieventsd.sh --replace "/usr/bin:/usr/X11R6/bin" "$xauth/bin/"
+    for d1 in \
+      $out/bin \
+      $out/share/ati
+    do
+      mkdir -p $d1
+    done
+    for d2 in \
+      $TMP/common/etc \
+      $TMP/common/usr/share
+    do
+      cp -r $d2 $out
+    done
+    BIN=$TMP/arch/$arch/usr/X11R6/bin
+    # patch and copy statically linked qt libs used by amdcccle
+    patchelf --set-interpreter $(echo $glibc/lib/ld-linux-x86-64.so.2) $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtCore.so.4 &&
+    patchelf --set-rpath $gcc/$lib_arch/ $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtCore.so.4 &&
+    patchelf --set-rpath $gcc/$lib_arch/:$out/share/ati/:$libXrender/lib/:$libSM/lib/:$libICE/lib/:$libfontconfig/lib/:$libfreetype/lib/ $TMP/arch/$arch/usr/share/ati/$lib_arch/libQtGui.so.4 &&
+    patchelf --set-rpath $gcc/$lib_arch/:$out/share/ati/:$libXinerama/lib/:$libXrandr/lib/ $TMP/arch/$arch/usr/X11R6/bin/amdcccle &&
+    patchelf --set-rpath $libXrender/lib/:$libXrandr/lib/ $TMP/arch/$arch/usr/X11R6/bin/aticonfig &&
+    patchelf --shrink-rpath $BIN/amdcccle
+    # copy binaries and wrap them:
+    for prog in $BIN/*; do
+      cp -f $prog $out/bin &&
+      patchelf --set-interpreter $(echo $glibc/lib/ld-linux-x86-64.so.2) $out/bin/$(basename $prog) &&
+      wrapProgram $out/bin/$(basename $prog) --prefix LD_LIBRARY_PATH : $out/lib/:$gcc/lib/:$out/share/ati/:$libfontconfig/lib/:$libfreetype/lib/:$LD_LIBRARY_PATH
+    done
+    for d3 in \
+      $TMP/common/usr/X11R6/bin/* \
+      $TMP/arch/$arch/usr/sbin/atieventsd
+    do
+      cp -f $d3 $out/bin/
+    done
+    patchelf --set-interpreter $(echo $glibc/lib/ld-linux-x86-64.so.2) $out/bin/atieventsd &&
+    wrapProgram $out/bin/atieventsd --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib/:$out/lib/:$gcc/lib/:$out/share/ati/:$libfontconfig/lib/:$libfreetype/lib/:$LD_LIBRARY_PATH \
+      --prefix PATH : $whichBin/bin:$pidofBin/bin:$xauth/bin
+    cp -r $TMP/arch/$arch/usr/share/ati/$lib_arch/* $out/share/ati/ '';
+
+  meta = {
+    description = "ATI Radeon™ display driver kernel module and apps.";
+    homepage = http://support.amd.com/us/gpudownload/Pages/index.aspx;
+    license = licenses.amd;
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/os-specific/linux/amd-non-free/display-managers.patch
+++ b/pkgs/os-specific/linux/amd-non-free/display-managers.patch
@@ -1,0 +1,55 @@
+--- fglrx-15.302/common/etc/ati/authatieventsd.sh	2016-02-20 17:01:02.182983079 +0000
++++ fglrx-15.302b/common/etc/ati/authatieventsd.sh	2016-02-20 17:01:16.000000000 +0000
+@@ -32,7 +32,7 @@
+     # vary depending upon whether X was started via xdm/kdm, gdm or startx, so
+     # check each one in turn.
+ 
+-    # Check xdm/kdm
++    # Check xdm
+ 
+     XDM_AUTH_MASK=/var/lib/xdm/authdir/authfiles/A$1*
+     XDM_AUTH_FILE=`ls -t $XDM_AUTH_MASK 2>/dev/null | head -n 1`   # Choose the newest file
+@@ -51,6 +51,43 @@
+         return 0
+     fi
+ 
++    # Check kdm
++
++    KDM_AUTH_MASK=/var/run/xauth/A$1*
++    KDM_AUTH_FILE=`ls -t $KDM_AUTH_MASK 2>/dev/null | head -n 1`   # Choose the newest file
++    if [ -n "$KDM_AUTH_FILE" ]; then
++        SERVER_AUTH_FILE=$KDM_AUTH_FILE
++        DISP_SEARCH_STRING="#ffff#"
++        return 0
++    fi
++
++    # Check for gdm 3
++
++    GDM3_AUTH_FILE=/var/run/gdm/auth-for-gdm-*/database
++    if [ -e $GDM3_AUTH_FILE ]; then
++        SERVER_AUTH_FILE=$GDM3_AUTH_FILE
++        DISP_SEARCH_STRING="unix$1"
++        return 0
++    fi
++
++    # Check for lightdm
++	LIGHTDM_AUTH_FILE=/var/run/lightdm/root/$1
++	if [ -e $LIGHTDM_AUTH_FILE ]; then
++		SERVER_AUTH_FILE=$LIGHTDM_AUTH_FILE
++		# Not sure if this is correct
++		DISP_SEARCH_STRING="unix$1"
++		return 0
++	fi
++
++    # Check for sddm
++	SDDM_AUTH_FILE=/var/run/sddm/$1
++	if [ -e $SDDM_AUTH_FILE ]; then
++		SERVER_AUTH_FILE=$SDDM_AUTH_FILE
++		# Not sure if this is correct
++		DISP_SEARCH_STRING="unix$1"
++		return 0
++	fi
++
+     # Finally, check for startx
+ 
+     for XPID in `pidof X`; do

--- a/pkgs/os-specific/linux/amd-non-free/grsec_arch.patch
+++ b/pkgs/os-specific/linux/amd-non-free/grsec_arch.patch
@@ -1,0 +1,77 @@
+diff -uNr 15.12/common/lib/modules/fglrx/build_mod/firegl_public.c 15.12b/common/lib/modules/fglrx/build_mod/firegl_public.c
+--- 15.12/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-12-19 21:14:13.251002548 +0100
++++ 15.12b/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-12-19 21:36:27.703783498 +0100
+@@ -6465,11 +6465,21 @@
+ 
+    if(static_cpu_has(X86_FEATURE_XSAVE)) {
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
++#ifdef CONFIG_GRKERNSEC
++        copy_xregs_to_kernel(&fpu->state->xsave);
++        if (!(fpu->state->xsave.header.xfeatures & XFEATURE_MASK_FP))
++#else
+ 	  copy_xregs_to_kernel(&fpu->state.xsave);
+       if (!(fpu->state.xsave.header.xfeatures & XFEATURE_MASK_FP))
++#endif
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
++#ifdef CONFIG_GRKERNSEC
++        copy_xregs_to_kernel(&fpu->state->xsave);
++        if (!(fpu->state->xsave.header.xfeatures & XSTATE_FP))
++#else
+ 	  copy_xregs_to_kernel(&fpu->state.xsave);
+       if (!(fpu->state.xsave.header.xfeatures & XSTATE_FP))
++#endif
+ #else
+       fpu_xsave(fpu);
+       if (!(fpu->state->xsave.xsave_hdr.xstate_bv & XSTATE_FP))
+@@ -6486,8 +6496,12 @@
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
+                   : [fx] "=m" (fpu->state->fsave));
+ #else
++#ifdef CONFIG_GRKERNSEC
++                  : [fx] "=m" (fpu->state->fsave));
++#else
+                   : [fx] "=m" (fpu->state.fsave));
+ #endif
++#endif
+         return 0;
+    }
+ 
+diff -uNr 15.12/common/lib/modules/fglrx/build_mod/kcl_acpi.c 15.12b/common/lib/modules/fglrx/build_mod/kcl_acpi.c
+--- 15.12/common/lib/modules/fglrx/build_mod/kcl_acpi.c	2015-12-19 21:14:13.247669219 +0100
++++ 15.12b/common/lib/modules/fglrx/build_mod/kcl_acpi.c	2015-12-19 21:10:27.224899708 +0100
+@@ -145,7 +145,11 @@
+     return NOTIFY_OK;
+ }
+ 
++#ifdef CONFIG_GRKERNSEC
++static notifier_block_no_const firegl_acpi_lid_notifier = {
++#else
+ static struct notifier_block firegl_acpi_lid_notifier = {
++#endif
+         .notifier_call = firegl_acpi_lid_event,
+ };
+ #endif
+@@ -400,7 +404,11 @@
+             KCL_DEBUG_ERROR ("Could not allocate enough memory for video notifier_block\n");
+             return -ENOMEM;
+         }
++#ifdef CONFIG_GRKERNSEC
++        ((notifier_block_no_const*)(*nb))->notifier_call = firegl_acpi_video_event;
++#else
+         ((struct notifier_block*)(*nb))->notifier_call = firegl_acpi_video_event;
++#endif
+         return register_acpi_notifier((struct notifier_block*)(*nb));
+     }
+ 
+@@ -413,7 +421,11 @@
+             KCL_DEBUG_ERROR ("Could not allocate enough memory for ac notifier_block\n");
+             return -ENOMEM;
+         }
++#ifdef CONFIG_GRKERNSEC
++        ((notifier_block_no_const*)(*nb))->notifier_call = firegl_acpi_ac_event;
++#else
+         ((struct notifier_block*)(*nb))->notifier_call = firegl_acpi_ac_event;
++#endif
+         return register_acpi_notifier((struct notifier_block*)(*nb));
+     }
+ 

--- a/pkgs/os-specific/linux/amd-non-free/lano1106_fglrx_intel_iommu.patch
+++ b/pkgs/os-specific/linux/amd-non-free/lano1106_fglrx_intel_iommu.patch
@@ -1,0 +1,11 @@
+--- 13.4/common/lib/modules/fglrx/build_mod/firegl_public.c	2013-04-16 23:29:55.000000000 +0200
++++ 13.4/common/lib/modules/fglrx/build_mod/firegl_public.c	2013-05-21 17:05:34.726681102 +0200
+@@ -93,7 +93,7 @@
+    and they use different config options. These options can only be enabled
+    on x86_64 with newer 2.6 kernels (2.6.23 for intel, 2.6.26 for amd).
+ */
+-#if defined(CONFIG_AMD_IOMMU) || defined(CONFIG_DMAR)
++#if defined(CONFIG_AMD_IOMMU) || defined(CONFIG_INTEL_IOMMU)
+     #define FIREGL_DMA_REMAPPING
+ #endif
+

--- a/pkgs/os-specific/linux/amd-non-free/lano1106_kcl_agp_13_4.patch
+++ b/pkgs/os-specific/linux/amd-non-free/lano1106_kcl_agp_13_4.patch
@@ -1,0 +1,90 @@
+--- 13.4/common/lib/modules/fglrx/build_mod/kcl_agp.c	2013-05-24 16:45:52.236740084 -0400
++++ 13.4/common/lib/modules/fglrx/build_mod/kcl_agp.c	2013-05-24 16:49:29.283579408 -0400
+@@ -56,6 +56,43 @@ unsigned int KCL_AGP_IsInUse(void)
+     return kcl_agp_is_in_use;
+ }
+
++/** \brief Find AGP caps registers in PCI config space
++ ** \param dev PCI device handle
++ ** \return Positive register index on success, negative errno on error
++ */
++int ATI_API_CALL KCL_AGP_FindCapsRegisters(KCL_PCI_DevHandle dev)
++{
++    u8 capndx;
++    u32 cap_id;
++
++    if (!dev)
++    {
++        return -ENODEV;
++    }
++
++    pci_read_config_byte((struct pci_dev*)dev, 0x34, &capndx);
++
++    if (capndx == 0x00)
++    {
++        return -ENODATA;
++    }
++
++    do
++    { // search capability list for AGP caps
++        pci_read_config_dword((struct pci_dev*)dev, capndx, &cap_id);
++
++        if ((cap_id & 0xff) == 0x02)
++        {
++            return capndx;
++        }
++
++        capndx = (cap_id >> 8) & 0xff;
++    }
++    while (capndx != 0x00);
++
++    return -ENODATA;
++}
++
+ #if defined(CONFIG_AGP) || defined(CONFIG_AGP_MODULE)
+
+ typedef struct {
+@@ -272,43 +309,6 @@ int ATI_API_CALL KCL_AGP_Enable(unsigned
+     }
+ }
+
+-/** \brief Find AGP caps registers in PCI config space
+- ** \param dev PCI device handle
+- ** \return Positive register index on success, negative errno on error
+- */
+-int ATI_API_CALL KCL_AGP_FindCapsRegisters(KCL_PCI_DevHandle dev)
+-{
+-    u8 capndx;
+-    u32 cap_id;
+-
+-    if (!dev)
+-    {
+-        return -ENODEV;
+-    }
+-
+-    pci_read_config_byte((struct pci_dev*)dev, 0x34, &capndx);
+-
+-    if (capndx == 0x00)
+-    {
+-        return -ENODATA;
+-    }
+-
+-    do
+-    { // search capability list for AGP caps
+-        pci_read_config_dword((struct pci_dev*)dev, capndx, &cap_id);
+-
+-        if ((cap_id & 0xff) == 0x02)
+-        {
+-            return capndx;
+-        }
+-
+-        capndx = (cap_id >> 8) & 0xff;
+-    }
+-    while (capndx != 0x00);
+-
+-    return -ENODATA;
+-}
+-
+ /** \brief Get AGP caps
+  ** \param dev PCI device handle
+  ** \param caps pointer to caps vector

--- a/pkgs/os-specific/linux/amd-non-free/makefile_compat.patch
+++ b/pkgs/os-specific/linux/amd-non-free/makefile_compat.patch
@@ -1,0 +1,10 @@
+--- 10.10/common/lib/modules/fglrx/build_mod/2.6.x/Makefile	2010-09-22 09:15:33.000000000 +0200
++++ 10.10/common/lib/modules/fglrx/build_mod/2.6.x/Makefile	2010-10-01 17:57:21.057820899 +0200
+@@ -66,6 +66,7 @@
+                 -DFGL_GART_RESERVED_SLOT \
+                 -DFGL_LINUX253P1_VMA_API \
+                 -DPAGE_ATTR_FIX=$(PAGE_ATTR_FIX) \
++                -DCOMPAT_ALLOC_USER_SPACE=$(COMPAT_ALLOC_USER_SPACE) \
+ 
+ ifeq ($(KERNELRELEASE),)
+ # on first call from remote location we get into this path

--- a/pkgs/os-specific/linux/amd-non-free/module.sh
+++ b/pkgs/os-specific/linux/amd-non-free/module.sh
@@ -1,0 +1,93 @@
+# Build an fglrx kernel module
+source $stdenv/setup
+set -x
+# Handle/Build the kernel module.
+cp -r $TMP/common/usr/include $out
+kernelVersion=$(cd ${kernel}/lib/modules && ls)
+kernelBuild=$(echo ${kernel}/lib/modules/$kernelVersion/build)
+linuxsources=$(echo ${kernel}/lib/modules/$kernelVersion/source)
+# note: maybe the .config file should be used to determine this ?
+# current kbuild infrastructure allows using CONFIG_* defines
+# but ati sources don't use them yet..
+# copy paste from make.sh
+setSMP(){
+
+  linuxincludes=$kernelBuild/include
+  src_file=$linuxincludes/generated/autoconf.h
+
+  [ -e $src_file ] || die "$src_file not found"
+
+  if [ `cat $src_file | grep "#undef" | grep "CONFIG_SMP" -c` = 0 ]; then
+    SMP=`cat $src_file | grep CONFIG_SMP | cut -d' ' -f3`
+    echo "file $src_file says: SMP=$SMP"
+  fi
+
+  if [ "$SMP" = 0 ]; then
+    echo "assuming default: SMP=$SMP"
+  fi
+  # act on final result
+  if [ ! "$SMP" = 0 ]; then
+    smp="-SMP"
+    def_smp=-D__SMP__
+  fi
+
+}
+
+setModVersions(){
+  ! grep CONFIG_MODVERSIONS=y $kernelBuild/.config ||
+  def_modversions="-DMODVERSIONS"
+  # make.sh contains much more code to determine this whether its enabled
+}
+
+for src_file in \
+  $kernelBuild/arch/x86/include/asm/compat.h \
+  $linuxsources/arch/x86/include/asm/compat.h \
+  $kernelBuild/include/asm-x86_64/compat.h \
+  $linuxsources/include/asm-x86_64/compat.h \
+  $kernelBuild/include/asm/compat.h;
+  do
+    if [ -e $src_file ];
+      then
+        break
+    fi
+done
+
+if [ ! -e $src_file ]; then
+    echo "Warning: x86 compat.h not found in kernel headers"
+    echo "neither arch/x86/include/asm/compat.h nor include/asm-x86_64/compat.h"
+    echo "could be found in $kernelBuild or $linuxsources"
+    echo ""
+  else
+    if [ `cat $src_file | grep -c arch_compat_alloc_user_space` -gt 0 ]
+       then
+         COMPAT_ALLOC_USER_SPACE=arch_compat_alloc_user_space
+    fi
+    echo "file $src_file says: COMPAT_ALLOC_USER_SPACE=$COMPAT_ALLOC_USER_SPACE"
+fi
+# make.sh contains some code figuring out whether to use these or not..
+PAGE_ATTR_FIX=0
+setSMP
+setModVersions
+CC=gcc
+MODULE=fglrx
+LIBIP_PREFIX=$TMP/arch/$arch/lib/modules/fglrx/build_mod
+[ -d $LIBIP_PREFIX ]
+GCC_MAJOR="`gcc --version | grep -o -e ") ." | head -1 | cut -d " " -f 2`"
+ # build .ko module
+cd ./common/lib/modules/fglrx/build_mod/2.6.x
+echo .lib${MODULE}_ip.a.GCC${GCC_MAJOR}.cmd
+echo 'This is a dummy file created to suppress this warning: could not find /lib/modules/fglrx/build_mod/2.6.x/.libfglrx_ip.a.GCC4.cmd for /lib/modules/fglrx/build_mod/2.6.x/libfglrx_ip.a.GCC4' > lib${MODULE}_ip.a.GCC${GCC_MAJOR}.cmd
+sed -i -e "s@COMPAT_ALLOC_USER_SPACE@$COMPAT_ALLOC_USER_SPACE@" ../kcl_ioctl.c
+make CC=${CC} \
+  LIBIP_PREFIX=$(echo "$LIBIP_PREFIX" | sed -e 's|^\([^/]\)|../\1|') \
+  MODFLAGS="-DMODULE -DATI -DFGL -DPAGE_ATTR_FIX=$PAGE_ATTR_FIX -DCOMPAT_ALLOC_USER_SPACE=$COMPAT_ALLOC_USER_SPACE $def_smp $def_modversions" \
+  KVER=$kernelVersion \
+  KDIR=$kernelBuild \
+  PAGE_ATTR_FIX=$PAGE_ATTR_FIX \
+  -j4
+
+cd $TMP
+  # Install the kernel module
+fglrxmod_dir=$out/lib/modules/${kernelVersion}/kernel/drivers/misc
+mkdir -p $fglrxmod_dir
+cp $TMP/common/lib/modules/fglrx/build_mod/2.6.x/fglrx.ko $fglrxmod_dir

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10456,6 +10456,10 @@ let
 
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };
 
+    amd-non-free-libs = callPackage ../os-specific/linux/amd-non-free/amd-non-free-libs.nix { };
+
+    amd-non-free = callPackage ../os-specific/linux/amd-non-free { developer = config.amd-non-free.developer or false; };
+
     blcr = callPackage ../os-specific/linux/blcr { };
 
     cryptodev = callPackage ../os-specific/linux/cryptodev { };


### PR DESCRIPTION
- Created new package for AMD proprietary graphics
- Re-used some old code from ati_unfree
- Added patches to enable compilation using gcc5, linux 4.4, etc.
- Added atieventsd service to enable laptop lid support
- Fixed some 32bit lib paths
- Separated the libs, module and applications into individual parts
- Corrected interpreter to ld-linux-x86-64.so.2 for some files
- Removed many unrequired software dependencies
- Added a 'developer' switch to enable lock debugging
- Reduced the amount of files required to be symlinked inside of /run

Please note that this is a proposal and feedback which is constructive and useful will be greatly appreciated.

Fixes: https://github.com/NixOS/nixpkgs/pull/13535
as https://github.com/NixOS/nixpkgs/pull/13535 won't work because some people still need to be able to use the old version of fglrx because this new version does not work for them and they are experiencing bugs with this new fglrx version.

Please note that this driver still does not support xserver 1.18. We are waiting for AMD to patch in support for 1.18 in their next release.

I have spent around three months working on this proposal due to the terrible state at which ati_unfree was in. It is tested and working for me.
