### PR TITLE
redmine: fix compilation with ruby 2.3

### DIFF
--- a/pkgs/applications/version-management/redmine/Gemfile.lock
+++ b/pkgs/applications/version-management/redmine/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     jquery-rails (2.0.3)
       railties (>= 3.1.0, < 5.0)
       thor (~> 0.14)
-    json (1.8.1)
+    json (1.8.3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)

--- a/pkgs/applications/version-management/redmine/Gemfile.nix
+++ b/pkgs/applications/version-management/redmine/Gemfile.nix
@@ -115,9 +115,9 @@ version = "2.0.3";
 }
 {
 name = "json";
-hash = "961bfbbfa9fda1e857e9c791e964e6664e0d43bf687b19669dfbc7cdbc5e0200";
-url = "http://rubygems.org/downloads/json-1.8.1.gem";
-version = "1.8.1";
+hash = "1nsby6ry8l9xg3yw4adlhk2pnc7i0h0rznvcss4vk3v74qg0k8lc";
+url = "http://rubygems.org/downloads/json-1.8.3.gem";
+version = "1.8.3";
 }
 {
 name = "mail";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Just bumped the JSON dependency manually to the one bundled with ruby 2.3

The json gem compilation was failing with: 

```
Installing json 1.8.1 with native extensions
Building native extensions.  This could take a while...

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /nix/store/sg1nw9j3w53qrgdv532fwynga3dhv6nm-redmine-2.5.2/share/redmine/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
/nix/store/p1smzl194057x5ixk5aymkal6cwmjq3j-ruby-2.3.0-p0/bin/ruby -r ./siteconf20160229-387-m13w3c.rb extconf.rb
creating Makefile

current directory: /nix/store/sg1nw9j3w53qrgdv532fwynga3dhv6nm-redmine-2.5.2/share/redmine/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /nix/store/sg1nw9j3w53qrgdv532fwynga3dhv6nm-redmine-2.5.2/share/redmine/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function 'fbuffer_to_s':
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
Makefile:238: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2
```
