### PR TITLE
pharo-vm: stop trying to build on darwin

### DIFF
--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -88,6 +88,10 @@ stdenv.mkDerivation rec {
     homepage = http://pharo.org;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.DamienCassou ];
-    platforms = stdenv.lib.platforms.mesaPlatforms;
+    # Pharo VM sources are packaged separately for darwin (OS X)
+    platforms = with stdenv.lib;
+                  intersectLists
+                    platforms.mesaPlatforms
+                    (subtractLists platforms.darwin platforms.unix);
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Building these pharo-vm sources on darwin may be possible but doesn't
make much sense because native darwin sources exist.
