### PR TITLE
openiscsi: fix download url, add platforms

### DIFF
--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -2,13 +2,16 @@
 let
   pname = "open-iscsi-2.0-873";
 in stdenv.mkDerivation {
-  name = "${pname}";
+  name = pname;
   outputs = [ "out" "iscsistart" ];
 
   buildInputs = [ nukeReferences ];
   
   src = fetchurl {
-    url = "http://www.open-iscsi.org/bits/${pname}.tar.gz";
+    urls = [
+      "http://www.open-iscsi.org/bits/${pname}.tar.gz"
+      "http://pkgs.fedoraproject.org/repo/pkgs/iscsi-initiator-utils/${pname}.tar.gz/8b8316d7c9469149a6cc6234478347f7/${pname}.tar.gz"
+    ];
     sha256 = "1nbwmj48xzy45h52917jbvyqpsfg9zm49nm8941mc5x4gpwz5nbx";
   };
   
@@ -24,9 +27,10 @@ in stdenv.mkDerivation {
     nuke-refs $iscsistart/bin/iscsistart
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A high performance, transport independent, multi-platform implementation of RFC3720";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = http://www.open-iscsi.org;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Built on platform(s): NixOS / Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
