### PR TITLE
zotero: patch firefox xpi loading

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bash, firefox, perl, unzipNLS, xorg }:
+{ stdenv, fetchurl, fetchpatch, bash, firefox, perl, unzipNLS, xorg }:
 
 let
 
@@ -6,6 +6,14 @@ let
     url = "https://download.zotero.org/extension/zotero-${version}.xpi";
     sha256 = "02h2ja08v8as4fawj683rh5rmxsjf5d0qmvqa77i176nm20y5s7s";
   };
+
+  firefox' = stdenv.lib.overrideDerivation (firefox) (attrs: {
+    patches = [ (fetchpatch {
+      url = "https://hg.mozilla.org/releases/mozilla-beta/raw-rev/0558da46f20c";
+      sha256 = "08ibp7hny78x8ywfvrh56z90kf8fjpf04mibdlrwkw4f1vgm3fc3";
+      name = "fix-external-xpi-loader";
+    }) ];
+  });
 
   version = "4.0.28";
 
@@ -21,7 +29,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ perl unzipNLS ];
 
-  inherit bash firefox;
+  inherit bash;
+
+  firefox = firefox';
 
   phases = "unpackPhase installPhase fixupPhase";
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue with plugin loading in Zotero

cc @ttuegel 

---

_Please note, that points are not mandatory, but rather desired._

Not sure this actually needs merging since this is merged in FF45, due in about 7 days or something. But it is still a nice thing to be able to use plugins in zotero standalone, if this is merged then after the the FF45 update this can be reverted.
