### PR TITLE
stdenv preHook: only define $NIX_ENFORCE_PURITY if it hasn't yet been set

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -25,7 +25,7 @@ in rec {
   allPackages = import ../../top-level/all-packages.nix;
 
   commonPreHook = ''
-    export NIX_ENFORCE_PURITY=1
+    export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
     export NIX_IGNORE_LD_THROUGH_GCC=1
     stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
     export MACOSX_DEPLOYMENT_TARGET=10.7

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -25,7 +25,7 @@ rec {
 
   commonPreHook =
     ''
-      export NIX_ENFORCE_PURITY=1
+      export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
       ${if system == "x86_64-linux" then "NIX_LIB64_IN_SELF_RPATH=1" else ""}
       ${if system == "mips64el-linux" then "NIX_LIB32_IN_SELF_RPATH=1" else ""}
     '';

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -5,7 +5,7 @@ import ../generic rec {
 
   preHook =
     ''
-      export NIX_ENFORCE_PURITY=1
+      export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
       export NIX_IGNORE_LD_THROUGH_GCC=1
     '';
 


### PR DESCRIPTION
Note: **mass rebuild** - I'm not sure how such changes usually work, does it get merged into staging in order to coincide with other mass rebuilds?

This came out of #13532 - the obvious mechanism for opting out of `NIX_ENFORCE_PURITY` is to define `NIX_ENFORCE_PURITY = false;` in your derivation, but that doesn't work because it's _always_ set to `1` in the `stdenv` preHook. To override it, you have to override the entire preHook, which also implicitly drops whatever else was in the `preHook` (I hope it wasn't important!).

Unfortunately, I wasn't able to test my changes - I started a build and it got somewhere, but since this is a mass rebuild type change, I had to give up before I saw the built results. I think it should work fine, but would appreciate someone more familiar with the stdenv (particularly the ordering of events between the preHook and other environment variables being set) to conform.
