### PR TITLE
nix-prefetch-git: change the default output to JSON

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -325,9 +325,9 @@ print_results() {
     fi
     if test -n "$hash"; then
         echo "{"
-        echo "  url = \"$url\";"
-        echo "  rev = \"$fullRev\";"
-        echo "  $hashType = \"$hash\";"
+        echo "  \"url\": \"$url\","
+        echo "  \"rev\": \"$fullRev\","
+        echo "  \"$hashType\": \"$hash\""
         echo "}"
     fi
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

As discussed on the mailing list. The nix output was short-lived so it's
probably okay to change it.

/cc @edolstra 
