### PR TITLE
bats: fixes installation

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "05xpvfm0xky1532i3hd2l3wznxzh99bv2hxgykwdpxh18h6jr6jm";
   };
 
+  patchPhase = "patchShebangs ./install.sh";
+
   installPhase = "./install.sh $out";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The build was failing with:

  /...-stdenv/setup: ./install.sh: /usr/bin/env: bad interpreter: No such file
  or directory

See https://hydra.nixos.org/build/32353411/log
