### PR TITLE
libclc: 2015-03-27 -> 0.2.0

### DIFF
--- a/pkgs/development/libraries/libclc/default.nix
+++ b/pkgs/development/libraries/libclc/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, python, llvm, clang }:
 
 stdenv.mkDerivation {
-  name = "libclc-2015-03-27";
+  name = "libclc-2015-08-07";
 
   src = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "libclc";
-    rev = "0a2d1619921545b52303be5608b64dc46f381e97";
-    sha256 = "0hgm013c0vlfqfbbf4cdajl01hhk1mhsfk4h4bfza1san97l0vcc";
+    rev = "f97d9db40718f2e68b3f0b44200760d8e0d50532";
+    sha256 = "10n9qk1dild9yjkjjkzpmp9zid3ysdgvqrad554azcf755frch7g";
   };
 
   buildInputs = [ python llvm clang ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @wkennington 

Disclaimer: I have no clue about libclc, I just picked the next stable release with almost only contains the llvm bugfix. If this looks good please cherry-pick into `release-16.03` as well.
