### PR TITLE
epson-escpr: 1.6.3 -> 1.6.4

### DIFF
--- a/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
+++ b/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure_new
-index c3e7199..ccbf290 100755
+index 3d6f68c..c2b10ff 100755
 --- a/configure
 +++ b/configure_new
 @@ -11585,55 +11585,8 @@ else

--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, cups }:
 
 let
-  version = "1.6.3";
+  version = "1.6.4";
 in
   stdenv.mkDerivation {
 
     name = "epson-escpr-${version}";
   
     src = fetchurl {
-      url = "https://download3.ebz.epson.net/dsc/f/03/00/04/33/53/0177a44361d3dfeacf7f15ff4a347cef373688da/epson-inkjet-printer-escpr-1.6.3-1lsb3.2.tar.gz";
-      sha256 = "4988479ce7dd5513bfa1cce4a83f82348572d8d69d6aa3b2c6e154a58a04ad86"; 
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/04/37/97/88177bc0dc7025905eae4a0da1e841408f82e33c/epson-inkjet-printer-escpr-1.6.4-1lsb3.2.tar.gz"; 
+      sha256 = "76c66461a30be82b9cc37d663147a72f488fe060ef54578120602bb87a3f7754"; 
     }; 
 
     patches = [ ./cups-filter-ppd-dirs.patch ]; 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>
The URL link corresponding to epson-escpr driver version 1.6.3 is not available anymore. 
There is a new link corresponding to version 1.6.4.

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
