### PR TITLE
multimc: fix building under chroot

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -67,6 +67,7 @@
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   chattered = "Phil Scott <me@philscotted.com>";
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
+  cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
   codsl = "codsl <codsl@riseup.net>";
   codyopel = "Cody Opel <codyopel@gmail.com>";

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, qt5Full, jdk7, zlib, file, makeWrapper, xorg, libpulseaudio }:
+{ stdenv, fetchFromGitHub, cmake, qt5Full, jdk7, zlib, file, makeWrapper, xorg, libpulseaudio, qt5 }:
 
 let
   libnbt = fetchFromGitHub {
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
     rmdir $sourceRoot/depends/libnbtplusplus
     cp -r ${libnbt} $sourceRoot/depends/libnbtplusplus
     chmod 755 -R $sourceRoot/depends/libnbtplusplus
+    mkdir -pv $sourceRoot/build/
+    cp -v ${qt5.quazip.src} $sourceRoot/build/quazip-0.7.1.tar.gz
   '';
 
   patches = [ ./multimc.patch ];
@@ -51,5 +53,6 @@ stdenv.mkDerivation {
     '';
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl21Plus;
+    maintainers = stdenv.lib.maintainers.cleverca22;
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
###### More

Fixes issue #13559
