### PR TITLE
Respect umask settings in Transmission config

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -21,7 +21,7 @@ let
     else toString ''"${x}"'';
 
   # for users in group "transmission" to have access to torrents
-  fullSettings = { download-dir = downloadDir; incomplete-dir = incompleteDir; } // cfg.settings // { umask = 2; };
+  fullSettings = { umask = 2; download-dir = downloadDir; incomplete-dir = incompleteDir; } // cfg.settings;
 in
 {
   options = {


### PR DESCRIPTION
Accidentally closed old pull request #10050 when trying to rebase it. Here is a new one.

In NixOS/nixpkgs@da6bc44 @thoughtpolice
made the Transmission NixOS module override the umask setting in the
Transmission config. This commit removes that override.

I want a different umask setting and I guess it is possible that other
people might want it to. Thus I think it is a good idea to respect the
umask settings in the Transmission config.
