### PR TITLE
gentium-book-basic: init at 1.102

### DIFF
--- a/pkgs/data/fonts/gentium-book-basic/default.nix
+++ b/pkgs/data/fonts/gentium-book-basic/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "gentium-book-basic-${version}";
+  major = "1";
+  minor = "102";
+  version = "${major}.${minor}";
+
+  src = fetchzip {
+    name = "${name}.zip";
+    url = "http://software.sil.org/downloads/gentium/GentiumBasic_${major}${minor}.zip";
+    sha256 = "109yiqwdfb1bn7d6bjp8d50k1h3z3kz86p3faz11f9acvsbsjad0";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.ttf $out/share/fonts/truetype/
+    cp -v FONTLOG.txt GENTIUM-FAQ.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://software.sil.org/gentium/";
+    description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
+    maintainers = with maintainers; [ DamienCassou ];
+    license = licenses.ofl;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11112,6 +11112,8 @@ let
 
   gentium = callPackage ../data/fonts/gentium {};
 
+  gentium-book-basic = callPackage ../data/fonts/gentium-book-basic {};
+
   geolite-legacy = callPackage ../data/misc/geolite-legacy { };
 
   gohufont = callPackage ../data/fonts/gohufont { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
