### PR TITLE
git-remote-hg: fix the derivation name

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   rev = "e716a9e1a9e460a45663694ba4e9e8894a8452b2";
-  version = "v0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2";
+  version = "0.2-${rev}";
   name = "git-remote-hg-${version}";
 
   src = fetchgit {


### PR DESCRIPTION
-v0.2 isn't parsed as a version by Nix, and makes it inconvenient to
install git-remote-hg through nix-env.
