### PR TITLE
dnscrypt-proxy: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/networking/dnscrypt-proxy/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dnscrypt-proxy-${version}";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchurl {
     url = "http://download.dnscrypt.org/dnscrypt-proxy/${name}.tar.bz2";
-    sha256 = "0zfw9vi9qbsc55awncyigqfqp25v5adqk6jpg1jdfkmbqqfykk70";
+    sha256 = "16lif3qhyfjpgg54vjlwpslxk90akmbhlpnn1szxm628bmpw6nl9";
   };
 
   configureFlags = ''


### PR DESCRIPTION
Stable update per request by @joachifm.  Details in #13613.
