### PR TITLE
sweethome3d: Improvements

### DIFF
--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -1,20 +1,33 @@
-{ stdenv, fetchurl, fetchcvs, makeWrapper, makeDesktopItem, jdk, jre, ant
+{ lib, stdenv, fetchurl, fetchcvs, makeWrapper, makeDesktopItem, jdk, jre, ant
 , gtk3, gsettings_desktop_schemas, p7zip }:
 
 let
 
+  getDesktopFileName = drvName: (builtins.parseDrvName drvName).name;
+
+  # TODO: Should we move this to `lib`? Seems like its would be useful in many cases.
+  extensionOf = filePath: 
+    lib.concatStringsSep "." (lib.tail (lib.splitString "." 
+      (builtins.baseNameOf filePath)));
+
+  installIcons = iconName: icons: lib.concatStringsSep "\n" (lib.mapAttrsToList (size: iconFile: ''
+    mkdir -p "$out/share/icons/hicolor/${size}/apps"
+    ln -s -T "${iconFile}" "$out/share/icons/hicolor/${size}/apps/${iconName}.${extensionOf iconFile}"
+  '') icons);
+
   mkSweetHome3D =
-  { name, module, version, src, license, description, icon }:
+  { name, module, version, src, license, description, desktopName, icons }:
 
   stdenv.mkDerivation rec {
-    inherit name version src description icon;
+    inherit name version src description;
     exec = stdenv.lib.toLower module;
     sweethome3dItem = makeDesktopItem {
-      inherit name exec icon;
+      inherit exec desktopName;
+      name = getDesktopFileName name;
+      icon = getDesktopFileName name;
       comment =  description;
-      desktopName = name;
       genericName = "Computer Aided (Interior) Design";
-      categories = "Application;CAD;";
+      categories = "Application;Graphics;2DGraphics;3DGraphics;";
     };
 
     buildInputs = [ ant jdk jre makeWrapper p7zip gtk3 gsettings_desktop_schemas ];
@@ -29,7 +42,11 @@ let
     installPhase = ''
       mkdir -p $out/bin
       cp install/${module}-${version}.jar $out/share/java/.
+
+      ${installIcons (getDesktopFileName name) icons}
+
       cp "${sweethome3dItem}/share/applications/"* $out/share/applications
+
       makeWrapper ${jre}/bin/java $out/bin/$exec \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3}/share:${gsettings_desktop_schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-jar $out/share/java/${module}-${version}.jar -cp $out/share/java/Furniture.jar:$out/share/java/Textures.jar:$out/share/java/Help.jar ${if stdenv.system == "x86_64-linux" then "-d64" else "-d32"}"
@@ -62,9 +79,16 @@ in rec {
       module = module;
       tag = "V_" + d2u version;
     };
-    icon = fetchurl {
-      url = "http://sweethome3d.cvs.sourceforge.net/viewvc/sweethome3d/SweetHome3D/src/com/eteks/sweethome3d/viewcontroller/resources/help/images/sweethome3d.png";
-      sha256 = "0lnv2sz2d3m8jx25hz92gzardf0iblykhy5q0q2cyb7mw2qb2p92";
+    desktopName = "Sweet Home 3D";
+    icons = {
+      "32x32" = fetchurl {
+        url = "http://sweethome3d.cvs.sourceforge.net/viewvc/sweethome3d/SweetHome3D/deploy/SweetHome3DIcon32x32.png";
+        sha256 = "1r2fhfg27mx00nfv0qj66rhf719s2g1vhdis7bdc9mqk9x0mb0ir";
+      };
+      "48x48" = fetchurl {
+        url = "http://sweethome3d.cvs.sourceforge.net/viewvc/sweethome3d/SweetHome3D/deploy/SweetHome3DIcon48x48.png";
+        sha256 = "1ap6d75dyqqvx21wddvn8vw2apq3v803vmbxdriwd0dw9rq3zn4g";
+      };
     };
   };
 

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -9,19 +9,21 @@ let
     + "-editor";
   sweetName = m: v: sweetExec m + "-" + v;
 
+  getDesktopFileName = drvName: (builtins.parseDrvName drvName).name;
+
   mkEditorProject =
-  { name, module, version, src, license, description }:
+  { name, module, version, src, license, description, desktopName }:
 
   stdenv.mkDerivation rec {
     application = sweethome3dApp;
     inherit name module version src description;
     exec = sweetExec module;
     editorItem = makeDesktopItem {
-      inherit name exec;
+      inherit exec desktopName;
+      name = getDesktopFileName name;
       comment =  description;
-      desktopName = name;
       genericName = "Computer Aided (Interior) Design";
-      categories = "Application;CAD;";
+      categories = "Application;Graphics;2DGraphics;3DGraphics;";
     };
 
     buildInputs = [ ant jre jdk makeWrapper gtk3 gsettings_desktop_schemas ];
@@ -72,6 +74,7 @@ in {
       module = module;
       tag = "V_" + d2u version;
     };
+    desktopName = "Sweet Home 3D - Textures Library Editor";
   };
 
   furniture-editor = mkEditorProject rec {
@@ -86,6 +89,7 @@ in {
       module = module;
       tag = "V_" + d2u version;
     };
+    desktopName = "Sweet Home 3D - Furniture Library Editor";
   };
 
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More
-  Replace non freedesktop `CAD` desktop category
  by categories taken from debian's desktop item.
  
  This make the desktop items appear under the
  `Graphic` category in DE menus instead of `Others`.
-  Moved to new package icons as specified by
  upstream release notes.
-  Moved to icon name instead of full path to
  a single icon as specified by freedesktop
  specification.
-  Human readable desktop item names.

cc @edwtjo

---

_Please note, that points are not mandatory, but rather desired._
-  Replace non freedesktop `CAD` desktop category
  by categories taken from debian's desktop item.
  
  This make the desktop items appear under the
  `Graphic` category in DE menus instead of `Others`.
-  Moved to new package icons as specified by
  upstream release notes.
-  Moved to icon name instead of full path to
  a single icon as specified by freedesktop
  specification.
-  Human readable desktop item names.
