### PR TITLE
undmg: init at 1.0.0

### DIFF
--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, zlib, bzip2 }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.2";
+  name = "undmg-${version}";
+
+  src = fetchFromGitHub {
+    owner = "matthewbauer";
+    repo = "undmg";
+    rev = "refs/tags/v${version}";
+    sha256 = "0w9vwvj9zbpsjkg251bwv9y10wjyjmh54q2piklz74w64rlbqblr";
+    name = "undmg-${version}";
+  };
+
+  buildInputs = [ zlib bzip2 ];
+
+  setupHook = ./setup-hook.sh;
+
+  installFlags = "PREFIX=\${out}";
+
+  meta = {
+    homepage = https://github.com/matthewbauer/undmg;
+    description = "Extract a DMG file";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/archivers/undmg/setup-hook.sh
+++ b/pkgs/tools/archivers/undmg/setup-hook.sh
@@ -1,0 +1,5 @@
+unpackCmdHooks+=(_tryUnpackDmg)
+_tryUnpackDmg() {
+    if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
+    undmg < "$curSrc"
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3728,6 +3728,8 @@ let
 
   unzipNLS = lowPrio (unzip.override { enableNLS = true; });
 
+  undmg = callPackage ../tools/archivers/undmg { };
+
   uptimed = callPackage ../tools/system/uptimed { };
 
   urjtag = callPackage ../tools/misc/urjtag {


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Fix the remaining issues of `undmg`
###### More

Fixes issue #12969
