### PR TITLE
mpv: added optional wayland support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -21,6 +21,7 @@
 , youtubeSupport ? true, youtube-dl ? null
 , cacaSupport ? true, libcaca ? null
 , vaapiSupport ? false, libva ? null
+, waylandSupport ? false, wayland ? null, libxkbcommon ? null
 }:
 
 assert x11Support -> (libX11 != null && libXext != null && mesa != null && libXxf86vm != null);
@@ -41,6 +42,7 @@ assert bs2bSupport -> libbs2b != null;
 assert libpngSupport -> libpng != null;
 assert youtubeSupport -> youtube-dl != null;
 assert cacaSupport -> libcaca != null;
+assert waylandSupport -> (wayland != null && libxkbcommon != null);
 
 let
   inherit (stdenv.lib) optional optionals optionalString;
@@ -77,7 +79,8 @@ stdenv.mkDerivation rec {
     "--enable-manpage-build"
     "--disable-build-date" # Purity
     "--enable-zsh-comp"
-  ] ++ optional vaapiSupport "--enable-vaapi";
+  ] ++ optional vaapiSupport "--enable-vaapi"
+  ++ optional waylandSupport "--enable-wayland";
 
   configurePhase = ''
     python ${waf} configure --prefix=$out $configureFlags
@@ -105,7 +108,8 @@ stdenv.mkDerivation rec {
     ++ optional youtubeSupport youtube-dl
     ++ optional sdl2Support SDL2
     ++ optional cacaSupport libcaca
-    ++ optional vaapiSupport libva;
+    ++ optional vaapiSupport libva
+    ++ optionals waylandSupport [ wayland libxkbcommon ];
 
   enableParallelBuilding = true;
 
@@ -139,6 +143,5 @@ stdenv.mkDerivation rec {
     '';
   };
 }
-# TODO: Wayland support
 # TODO: investigate caca support
 # TODO: investigate lua5_sockets bug


### PR DESCRIPTION
This PR adds an optional wayland support to the mpv video player.

Tested on a NixOS installation, builds and runs without problem
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` :
  
  The command gets me an error about the dwarfFortress package wich seems totally unrelated, but a grep on the nixpkgs repo shows that the only package depending on mpv is pythonPackages.mpv which builds fine.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
