### PR TITLE
gromacs: 4.6.5 -> 4.6.7 + MPI support

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -1,22 +1,30 @@
 
 { stdenv, fetchurl, cmake,
   singlePrec ? true,
-  fftw
+  mpiEnabled ? false,
+  fftw,
+  openmpi
 }:
 
 
 stdenv.mkDerivation {
-  name = "gromacs-4.6.5";
+  name = "gromacs-4.6.7";
 
   src = fetchurl {
-    url = "ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.5.tar.gz";
-    sha256 = "02ggrplh8fppqib86y3rfk4qm08yddlrb1yjgzl138b3b4qjy957";
+    url = "ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.7.tar.gz";
+    sha256 = "6afb1837e363192043de34b188ca3cf83db6bd189601f2001a1fc5b0b2a214d9";
   };
 
-  buildInputs = [cmake fftw];
+  buildInputs = [cmake fftw]
+  ++ (stdenv.lib.optionals mpiEnabled [ openmpi ]);
 
   cmakeFlags = ''
     ${if singlePrec then "-DGMX_DOUBLE=OFF" else "-DGMX_DOUBLE=ON -DGMX_DEFAULT_SUFFIX=OFF"}
+    ${if mpiEnabled then "-DGMX_MPI:BOOL=TRUE 
+                          -DGMX_CPU_ACCELERATION:STRING=SSE4.1 
+                          -DGMX_OPENMP:BOOL=TRUE
+                          -DGMX_THREAD_MPI:BOOL=FALSE"
+                     else "-DGMX_MPI:BOOL=FALSE" }
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15085,12 +15085,28 @@ let
 
   gromacs = callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = true;
+    mpiEnabled = false;
     fftw = fftwSinglePrec;
     cmake = cmakeCurses;
   };
 
+  gromacsMpi = lowPrio (callPackage ../applications/science/molecular-dynamics/gromacs {
+    singlePrec = true;
+    mpiEnabled = true;
+    fftw = fftwSinglePrec;
+    cmake = cmakeCurses;
+  });
+
   gromacsDouble = lowPrio (callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = false;
+    mpiEnabled = false;
+    fftw = fftw;
+    cmake = cmakeCurses;
+  });
+
+  gromacsDoubleMpi = lowPrio (callPackage ../applications/science/molecular-dynamics/gromacs {
+    singlePrec = false;
+    mpiEnabled = true;
     fftw = fftw;
     cmake = cmakeCurses;
   });


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>
## The MPI version needs to be launched with openmpi (mpirun command) so it's in a specific package.

_Please note, that points are not mandatory, but rather desired._
