### PR TITLE
musl: pass the correct syslibdir

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  preConfigure = ''
+    configureFlagsArray+=("--syslibdir=$out/lib")
+  '';
+
   configureFlags = [
     "--enable-shared"
     "--enable-static"


### PR DESCRIPTION
This fixes dynamic linking (the specfile contains the correct path, and
the dynamic loader is symlinked in place)
Fixes #8543
