### PR TITLE
atomicwrites: 0.1.0 -> 0.1.9

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -950,12 +950,12 @@ in modules // {
   };
 
   atomicwrites = buildPythonPackage rec {
-    version = "0.1.0";
+    version = "0.1.9";
     name = "atomicwrites-${version}";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/a/atomicwrites/atomicwrites-${version}.tar.gz";
-      sha256 = "1lxz0xhnzihqlvl1h6j2nfxjqqgr4s08196z5phnlcz2s7d5z0mg";
+      sha256 = "08s05h211r07vs66r4din3swrbzb344vli041fihpg34q3lcxpvw";
     };
 
     meta = {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
