### PR TITLE
epson-escpr: update the package meta

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -33,6 +33,7 @@
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";
   aristid = "Aristid Breitkreuz <aristidb@gmail.com>";
   arobyn = "Alexei Robyn <shados@shados.net>";
+  artuuge = "Artur E. Ruuge <artuuge@gmail.com>";
   asppsa = "Alastair Pharo <asppsa@gmail.com>";
   astsmtl = "Alexander Tsamutali <astsmtl@yandex.ru>";
   aszlig = "aszlig <aszlig@redmoonstudios.org>";

--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -16,7 +16,7 @@ in
 
     buildInputs = [ cups ];
 
-    meta = {
+    meta = with stdenv.lib; {
       homepage = https://github.com/artuuge/NixOS-files/;
       description = "ESC/P-R Driver (generic driver)";
       longDescription = ''
@@ -30,7 +30,9 @@ in
 	    drivers = [ pkgs.epson-escpr ];
 	  };
       '';
-      license = stdenv.lib.licenses.gpl3Plus;
+      license = licenses.gpl3Plus;
+      maintainers = with maintainers; [ artuuge ];
+      platforms = platforms.linux;
     };
 
   }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>
Set maintainers attribute in the package meta.

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
