### PR TITLE
khard: remove dependency to vdirsyncer

### DIFF
--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -18,10 +18,6 @@ pythonPackages.buildPythonApplication rec {
     pyyaml
   ];
 
-  buildInputs = with pythonPackages; [
-    pkgs.vdirsyncer
-  ];
-
   meta = {
     homepage = https://github.com/scheibler/khard;
     description = "Console carddav client";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @matthiasbeyer @domenkozar 

---

khard and vdirsyncer can be used together, but there are no real dependency between them.
