### PR TITLE
khard: force Python2

### DIFF
--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgs, pythonPackages }:
+{ stdenv, fetchurl, pkgs, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "0.8.1";
   name = "khard-${version}";
   namePrefix = "";
@@ -10,16 +10,12 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "13axfrs96isirx0c483545xdmjwwfq1k7yy92xpk7l184v71rgi1";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     atomicwrites
     configobj
     vobject
     argparse
     pyyaml
-  ];
-
-  buildInputs = with pythonPackages; [
-    pkgs.vdirsyncer
   ];
 
   meta = {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @matthiasbeyer @domenkozar 

---

setup.py says that khard is only compatible with Python 2.
