### PR TITLE
Remove which -> type -P bash alias.

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -17,6 +17,7 @@
     pkgs.ddrescue
     pkgs.ccrypt
     pkgs.cryptsetup # needed for dm-crypt volumes
+    pkgs.which # 88K size
 
     # Some networking tools.
     pkgs.fuse

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -56,7 +56,7 @@ in
       */
 
       shellAliases = mkOption {
-        default = config.environment.shellAliases // { which = "type -P"; };
+        default = config.environment.shellAliases;
         description = ''
           Set of aliases for bash shell. See <option>environment.shellAliases</option>
           for an option format description.


### PR DESCRIPTION
Aliases are not the same as programs. They won't work in subshells.
It's better to just use `which` binary as it's only 88K.

cc @edolstra 
