### PR TITLE
pythonPackages.acme_0_1: init at 0.1.0

### DIFF
--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -10,7 +10,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0l4qs0y4cbih76zrpbkn77xj17iwsm5fi83zc3p048x4hj163805";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ acme ];
+  propagatedBuildInputs = with pythonPackages; [ acme_0_1 ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -263,6 +263,29 @@ in modules // {
     sourceRoot = "letsencrypt-v${version}-src/acme";
   };
 
+  # Maintained for simp_le compatibility
+  acme_0_1 = buildPythonPackage rec {
+    version = "0.1.0";
+
+    name = "acme-${version}";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "letsencrypt";
+      repo = "letsencrypt";
+      rev = "v${version}";
+      sha256 = "1f7406nnybsdbwxf7r9qjf6hzkfd7cg6qp8l9l7hrzwscsq5hicj";
+    };
+
+    propagatedBuildInputs = with self; [
+      cryptography pyasn1 pyopenssl pyRFC3339 pytz requests2 six werkzeug mock
+      ndg-httpsclient
+    ];
+
+    buildInputs = with self; [ nose ];
+
+    sourceRoot = "letsencrypt-v${version}-src/acme";
+  };
+
   acme-tiny = buildPythonPackage rec {
     name = "acme-tiny-${version}";
     version = "20151229";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`acme_0_1` is introduced because `simp_le` strictly depends on version 0.1.0
of the library (which is now at 0.4.0).

This fixes a regression I introduced when upgrading letsencrypt (in https://github.com/NixOS/nixpkgs/pull/13467)
