### PR TITLE
libconfig: 1.4.9 -> 1.5

### DIFF
--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libconfig-${version}";
-  version = "1.4.9";
+  version = "1.5";
 
   src = fetchurl {
     url = "http://www.hyperrealm.com/libconfig/${name}.tar.gz";
-    sha256 = "0h9h8xjd36lky2r8jyc6hw085xwpslf0x6wyjvi960g6aa99gj09";
+    sha256 = "e31daa390d8e4461c8830512fe2e13ba1a3d6a02a2305a02429eec61e68703f6";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / ~~OSX~~ / ~~Linux~~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Doesn't fix anything… yet, and probably doesn't break anything else, but I'm going to push expression which requires it.

cc @cillianderoiste 
