### PR TITLE
click-log: 0.1.1 -> 0.1.3

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3005,12 +3005,12 @@ in modules // {
   };
 
   click-log = buildPythonPackage rec {
-    version = "0.1.1";
+    version = "0.1.3";
     name = "click-log-${version}";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/c/click-log/${name}.tar.gz";
-      sha256 = "1z3jdwjmwax159zrnyx830xa968rfqrpkm04ad5xqyh0269ydiqb";
+      sha256 = "0kdd1vminxpcfczxl2kkf285n0dr1gxh2cdbx1p6vkj7b7bci3gx";
     };
 
     propagatedBuildInputs = with self; [ click ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS 
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of 1 dependency's binary file (vdirsyncer)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
