### PR TITLE
ahoviewer: init at 1.4.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -307,6 +307,7 @@
   sjmackenzie = "Stewart Mackenzie <setori88@gmail.com>";
   sjourdois = "Stéphane ‘kwisatz’ Jourdois <sjourdois@gmail.com>";
   skeidel = "Sven Keidel <svenkeidel@gmail.com>";
+  skrzyp = "Jakub Skrzypnik <jot.skrzyp@gmail.com>";
   sleexyz = "Sean Lee <freshdried@gmail.com>";
   smironov = "Sergey Mironov <ierton@gmail.com>";
   spacefrogg = "Michael Raitza <spacefrogg-nixos@meterriblecrew.net>";

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, pkgs, fetchurl, fetchFromGitHub, pkgconfig, libconfig, 
+  gtkmm, glibmm, libxml2, libsecret, curl, unrar, libzip, 
+  librsvg, gst_all_1, autoreconfHook, makeWrapper }:
+stdenv.mkDerivation {
+  name = "ahoviewer-1.4.6";
+  src = fetchFromGitHub {
+    owner = "ahodesuka";
+    repo = "ahoviewer";
+    rev = "414cb91d66d96fab4b48593a7ef4d9ad461306aa";
+    sha256 = "081jgfmbwf2av0cn229cf4qyv6ha80ridymsgwq45124b78y2bmb";
+  };
+  enableParallelBuilding = true; 
+  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
+  buildInputs = [ glibmm libconfig gtkmm glibmm libxml2 
+                  libsecret curl unrar libzip librsvg 
+                  gst_all_1.gstreamer
+                  gst_all_1.gst-plugins-good 
+                  gst_all_1.gst-plugins-bad 
+                  gst_all_1.gst-libav
+                  gst_all_1.gst-plugins-base ];
+  postPatch = ''patchShebangs version.sh'';
+  postInstall = ''
+    wrapProgram $out/bin/ahoviewer \
+    --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+    --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+  '';
+  meta = {
+    homepage = "https://github.com/ahodesuka/ahoviewer";
+    description = "A GTK2 image viewer, manga reader, and booru browser";
+    maintainers = [ stdenv.lib.maintainers.skrzyp ];
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.allBut [ "darwin" "cygwin" ];
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11389,6 +11389,8 @@ let
     gtk = gtk2;
   };
 
+  ahoviewer = callPackage ../applications/graphics/ahoviewer { };
+
   alchemy = callPackage ../applications/graphics/alchemy { };
 
   alock = callPackage ../misc/screensavers/alock { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / ~~OSX~~ / ~~Linux~~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] ~~Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).~~ _(I'm not sure…)_
###### More

My first standalone Nixpkgs expression, please review it completely, because I'm unsure if I've done everything properly.
