### PR TITLE
gsimplecal: init at 2.1

### DIFF
--- a/pkgs/applications/misc/gsimplecal/default.nix
+++ b/pkgs/applications/misc/gsimplecal/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, automake, autoconf, pkgconfig, gtk3 }:
+
+stdenv.mkDerivation rec {
+  name = "gsimplecal-${version}";
+  version = "2.1";
+
+  src = fetchurl {
+    url = "https://github.com/dmedvinsky/gsimplecal/archive/v${version}.tar.gz";
+    sha256 = "1sa05ifjp41xipfspk5n6l3wzpzmp3i45q88l01p4l6k6drsq336";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ pkgconfig automake autoconf gtk3 ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = {
+    homepage = http://dmedvinsky.github.io/gsimplecal/;
+    description = "Lightweight calendar application written in C++ using GTK";
+    longDescription = ''
+      gsimplecal was intentionally made for use with tint2 panel in the
+      openbox environment to be launched upon clock click, but of course it
+      will work without it. In fact, binding the gsimplecal to some hotkey in
+      you window manager will probably make you happy. The thing is that when
+      it is started it first shows up, when you run it again it closes the
+      running instance. In that way it is very easy to integrate anywhere. No
+      need to write some wrapper scripts or whatever.
+
+      Also, you can configure it to not only show the calendar, but also
+      display multiple clocks for different world time zones.
+    '';
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12150,6 +12150,8 @@ let
     inherit (gnome) libgnome libgnomeui vte;
   };
 
+  gsimplecal = callPackage ../applications/misc/gsimplecal { };
+
   gtimelog = pythonPackages.gtimelog;
 
   inherit (gnome3) gucharmap;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): Linux
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
