### PR TITLE
kanif: init at 1.2.2

### DIFF
--- a/pkgs/applications/networking/cluster/kanif/default.nix
+++ b/pkgs/applications/networking/cluster/kanif/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, perl , taktuk}:
+
+stdenv.mkDerivation rec {
+  version = "1.2.2";
+  name = "kanif-${version}";
+
+  propagateBuildInputs = [ perl taktuk ];
+
+  src = fetchurl {
+    url = "http://gforge.inria.fr/frs/download.php/26773/${name}.tar.gz";
+    sha256 = "3f0c549428dfe88457c1db293cfac2a22b203f872904c3abf372651ac12e5879";
+  };
+
+  preBuild = ''
+      substituteInPlace ./kanif --replace "/usr/bin/perl" "${perl}/bin/perl"
+      substituteInPlace ./kanif --replace '$taktuk_command = "taktuk";' '$taktuk_command = "${taktuk}/bin/taktuk";'
+  '';
+
+  meta = {
+    description = "Cluster management and administration swiss army knife";
+    longDescription = ''
+      Kanif is a tool for high performance computing clusters management and
+      administration. It combines the main functionalities of well-known cluster
+      management tools such as c3, pdsh and dsh, and mimics their syntax. It
+      provides three tools to run the same command on several nodes ("parallel
+      ssh", using the 'kash' command), to broadcast the copy of files or
+      directories to several nodes ('kaput' command), and to gather several
+      remote files or directories locally ('kaget' command). It relies on TakTuk
+      for efficiency and scalability.'';
+    homepage = http://taktuk.gforge.inria.fr/kanif;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5338,6 +5338,8 @@ let
 
   davmail = callPackage ../applications/networking/davmail {};
 
+  kanif = callPackage ../applications/networking/cluster/kanif { };
+
   lxappearance = callPackage ../applications/misc/lxappearance {};
 
   kona = callPackage ../development/interpreters/kona {};


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
