### PR TITLE
sonic-pi: 2.8.0 -> 2.9.0

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -11,25 +11,25 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.8.0";
+  version = "2.9.0";
   name = "sonic-pi-${version}";
 
   src = fetchFromGitHub {
     owner = "samaaron";
     repo = "sonic-pi";
     rev = "v${version}";
-    sha256 = "1yyavgazb6ar7xnmjx460s9p8nh70klaja2yb20nci15k8vngq9h";
+    sha256 = "19db5dxrf6h1v2w3frds5g90nb6izd9ppp7cs2xi6i0m67l6jrwb";
   };
 
   buildInputs = [
-    qscintilla
-    supercollider
-    ruby
-    qt48Full
-    cmake
-    pkgconfig
     bash
+    cmake
     makeWrapper
+    pkgconfig
+    qscintilla
+    qt48Full
+    ruby
+    supercollider
   ];
 
   meta = {
@@ -42,13 +42,22 @@ stdenv.mkDerivation rec {
 
   dontUseCmakeConfigure = true;
 
+  patches = [ ./fixed-prefixes.patch ];
+
+  preConfigure = ''
+    patchShebangs .
+    substituteInPlace app/gui/qt/mainwindow.cpp \
+      --subst-var-by ruby "${ruby}/bin/ruby" \
+      --subst-var out
+  '';
+
   buildPhase = ''
     pushd app/server/bin
-    ${ruby}/bin/ruby compile-extensions.rb
+      ./compile-extensions.rb
     popd
 
     pushd app/gui/qt
-    ${bash}/bin/bash rp-build-app
+      ./rp-build-app
     popd
   '';
 

--- a/pkgs/applications/audio/sonic-pi/fixed-prefixes.patch
+++ b/pkgs/applications/audio/sonic-pi/fixed-prefixes.patch
@@ -1,0 +1,36 @@
+diff --git a/app/gui/qt/mainwindow.cpp b/app/gui/qt/mainwindow.cpp
+index 0af6cf7..97c17ad 100644
+--- a/app/gui/qt/mainwindow.cpp
++++ b/app/gui/qt/mainwindow.cpp
+@@ -677,28 +677,9 @@ void MainWindow::startServer(){
+ 
+     serverProcess = new QProcess();
+ 
+-    QString root = rootPath();
+-
+-  #if defined(Q_OS_WIN)
+-    QString prg_path = root + "/app/server/native/windows/ruby/bin/ruby.exe";
+-    QString prg_arg = root + "/app/server/bin/sonic-pi-server.rb";
+-    sample_path = root + "/etc/samples";
+-  #elif defined(Q_OS_MAC)
+-    QString prg_path = root + "/server/native/osx/ruby/bin/ruby";
+-    QString prg_arg = root + "/server/bin/sonic-pi-server.rb";
+-    sample_path = root + "/etc/samples";
+-  #else
+-    //assuming Raspberry Pi
+-    QString prg_path = root + "/app/server/native/raspberry/ruby/bin/ruby";
+-    QFile file(prg_path);
+-    if(!file.exists()) {
+-      // use system ruby if bundled ruby doesn't exist
+-      prg_path = "/usr/bin/ruby";
+-    }
+-
+-    QString prg_arg = root + "/app/server/bin/sonic-pi-server.rb";
+-    sample_path = root + "/etc/samples";
+-  #endif
++    QString prg_path = "@ruby@";
++    QString prg_arg = "@out@/app/server/bin/sonic-pi-server.rb";
++    sample_path = "@out@/etc/samples";
+ 
+     prg_path = QDir::toNativeSeparators(prg_path);
+     prg_arg = QDir::toNativeSeparators(prg_arg);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13513,7 +13513,9 @@ let
 
   viber = callPackage ../applications/networking/instant-messengers/viber { };
 
-  sonic-pi = callPackage ../applications/audio/sonic-pi { };
+  sonic-pi = callPackage ../applications/audio/sonic-pi {
+    ruby = ruby_2_2;
+  };
 
   st = callPackage ../applications/misc/st {
     conf = config.st.conf or null;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm mainly submitting this because it was failing to compile on an unrelated change. Now it compiles but segfaults during execution.

If nobody is interested to finish the work I think that we should remove the package as it's also installing a whole lot of things under the root of the derivation and probably never actually worked seeing how it was packaged.
