### PR TITLE
ruby: only keep the latest tiny per major.minor

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -157,61 +157,6 @@ in {
     };
   };
 
-  ruby_2_1_0 = generic {
-    majorVersion = "2";
-    minorVersion = "1";
-    teenyVersion = "0";
-    patchLevel = "0";
-    sha256 = {
-      src = "17fhfbw8sr13rxfn58wvrhk2f5i88lkna2afn3gdjvprd8gyqf1m";
-      git = "12sn532yvznqfz85378ys0b9ggmj7w8ddhzc1pnnlx7mbyy7r2hx";
-    };
-  };
-
-  ruby_2_1_1 = generic {
-    majorVersion = "2";
-    minorVersion = "1";
-    teenyVersion = "1";
-    patchLevel = "0";
-    sha256 = {
-      src = "0hc9x3mazyvnk94gs19q8mbnanlzk8mv0hii77slkvc8mqqxyhy8";
-      git = "1v2ffvyd0xx1h1qd70431zczhvsdiyyw5kjxih4rszd5avzh5grl";
-    };
-  };
-
-  ruby_2_1_2 = generic {
-    majorVersion = "2";
-    minorVersion = "1";
-    teenyVersion = "2";
-    patchLevel = "353";
-    sha256 = {
-      src = "0db6krc2bd7yha8p96lcqrahjpsz7g7abhni134g708sh53n8apj";
-      git = "14f8w3zwngnxsgigffh6h9z3ng53xq8mk126xmwrsmz9n3ypm6l0";
-    };
-  };
-
-  ruby_2_1_3 = generic {
-    majorVersion = "2";
-    minorVersion = "1";
-    teenyVersion = "3";
-    patchLevel = "0";
-    sha256 = {
-      src = "00bz6jcbxgnllplk4b9lnyc3w8yd3pz5rn11rmca1s8cn6vvw608";
-      git = "1pnam9jry2l2mbji3gvrbb7jyisxl99xjz6l1qrccwnfinxxbmhv";
-    };
-  };
-
-  ruby_2_1_6 = generic {
-    majorVersion = "2";
-    minorVersion = "1";
-    teenyVersion = "6";
-    patchLevel = "0";
-    sha256 = {
-      src = "1r4bs8lfwsypbcf8j2lpv3by40729vp5mh697njizj97fjp644qy";
-      git = "18kbjsbmgv6l3p1qxgmjnhh4jl7xdk3c20ycjpp62vrhq7pyzjsm";
-    };
-  };
-
   ruby_2_1_7 = generic {
     majorVersion = "2";
     minorVersion = "1";
@@ -220,28 +165,6 @@ in {
     sha256 = {
       src = "10fxlqmpbq9407zgsx060q22yj4zq6c3czbf29h7xk1rmjb1b77m";
       git = "1fmbqd943akqjwsfbj9bg394ac46qmpavm8s0kv2w87rflrjcjfb";
-    };
-  };
-
-  ruby_2_2_0 = generic {
-    majorVersion = "2";
-    minorVersion = "2";
-    teenyVersion = "0";
-    patchLevel = "0";
-    sha256 = {
-      src = "1z2092fbpc2qkv1j3yj7jdz7qwvqpxqpmcnkphpjcpgvmfaf6wbn";
-      git = "1w7rr2nq1bbw6aiagddzlrr3rl95kk33x4pv6570nm072g55ybpi";
-    };
-  };
-
-  ruby_2_2_2 = generic {
-    majorVersion = "2";
-    minorVersion = "2";
-    teenyVersion = "2";
-    patchLevel = "0";
-    sha256 = {
-      src = "0i4v7l8pnam0by2cza12zldlhrffqchwb2m9shlnp7j2gqqhzz2z";
-      git = "08mw1ql2ghy483cp8xzzm78q17simn4l6phgm2gah7kjh9y3vbrn";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -34,76 +34,6 @@ rec {
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/03-display-more-detailed-stack-trace.patch"
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
   ];
-  "2.1.0" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/01-current-2.1.1-fixes.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/02-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/03-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/04-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/05-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/06-fix-missing-c-return-event.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/07-backport-006e66b6680f60adfb434ee7397f0dbc77de7873.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/08-funny-falcon-stc-density.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/09-funny-falcon-stc-pool-allocation.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/10-aman-opt-aset-aref-str.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/11-funny-falcon-method-cache.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/12-backport-r44370.patch"
-  ];
-  "2.1.1" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/05-fix-missing-c-return-event.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/07-backport-006e66b6680f60adfb434ee7397f0dbc77de7873.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/08-funny-falcon-stc-density.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/09-funny-falcon-stc-pool-allocation.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/10-aman-opt-aset-aref-str.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/11-funny-falcon-method-cache.patch"
-    "${patchSet}/patches/ruby/2.1.0/railsexpress/12-backport-r44370.patch"
-  ];
-  "2.1.2" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/05-fix-missing-c-return-event.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/06-backport-006e66b6680f60adfb434ee7397f0dbc77de7873.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/07-funny-falcon-stc-density.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/08-funny-falcon-stc-pool-allocation.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/09-aman-opt-aset-aref-str.patch"
-    "${patchSet}/patches/ruby/2.1.2/railsexpress/10-funny-falcon-method-cache.patch"
-  ];
-  "2.1.3" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/05-funny-falcon-stc-density.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/06-funny-falcon-stc-pool-allocation.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/07-aman-opt-aset-aref-str.patch"
-    "${patchSet}/patches/ruby/2.1.3/railsexpress/08-funny-falcon-method-cache.patch"
-  ];
-  "2.1.6" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/05-funny-falcon-stc-density.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/06-funny-falcon-stc-pool-allocation.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/07-aman-opt-aset-aref-str.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/08-funny-falcon-method-cache.patch"
-    "${patchSet}/patches/ruby/2.1.6/railsexpress/09-heap-dump-support.patch"
-  ];
   "2.1.7" = [
     ./ssl_v3.patch
   ] ++ ops useRailsExpress [
@@ -116,23 +46,6 @@ rec {
     "${patchSet}/patches/ruby/2.1.7/railsexpress/07-aman-opt-aset-aref-str.patch"
     "${patchSet}/patches/ruby/2.1.7/railsexpress/08-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.7/railsexpress/09-heap-dump-support.patch"
-  ];
-  "2.2.0" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.2.0/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.2.0/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.2.0/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.2.0/railsexpress/04-backport-401c8bb.patch"
-    "${patchSet}/patches/ruby/2.2.0/railsexpress/05-fix-packed-bitfield-compat-warning-for-older-gccs.patch"
-  ];
-  "2.2.2" = [
-    ./ssl_v3.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.2.2/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.2.2/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.2.2/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.2.2/railsexpress/04-backported-bugfixes-222.patch"
   ];
   "2.2.3" = [
     ./ssl_v3.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -277,7 +277,7 @@ let
 
   chrootFHSEnv = callPackage ../build-support/build-fhs-chrootenv { };
   userFHSEnv = callPackage ../build-support/build-fhs-userenv {
-   ruby = ruby_2_1_3;
+   ruby = ruby_2_1;
   };
 
   buildFHSChrootEnv = args: chrootFHSEnv {
@@ -5540,7 +5540,7 @@ let
   };
 
   bundix = callPackage ../development/interpreters/ruby/bundix {
-    ruby = ruby_2_1_3;
+    ruby = ruby_2_1;
   };
   bundler = callPackage ../development/interpreters/ruby/bundler.nix { };
   bundler_HEAD = bundler;
@@ -5551,8 +5551,8 @@ let
   inherit (callPackage ../development/interpreters/ruby {})
     ruby_1_9_3
     ruby_2_0_0
-    ruby_2_1_0 ruby_2_1_1 ruby_2_1_2 ruby_2_1_3 ruby_2_1_6 ruby_2_1_7
-    ruby_2_2_0 ruby_2_2_2 ruby_2_2_3
+    ruby_2_1_7
+    ruby_2_2_3
     ruby_2_3_0;
 
   # Ruby aliases
@@ -5812,7 +5812,7 @@ let
   cgdb = callPackage ../development/tools/misc/cgdb { };
 
   chefdk = callPackage ../development/tools/chefdk {
-    ruby = ruby_2_0_0;
+    ruby = ruby_2_0;
   };
 
   matter-compiler = callPackage ../development/compilers/matter-compiler {};
@@ -6296,7 +6296,7 @@ let
   uncrustify = callPackage ../development/tools/misc/uncrustify { };
 
   vagrant = callPackage ../development/tools/vagrant {
-    ruby = ruby_2_2_2;
+    ruby = ruby_2_2;
   };
 
   gdb = callPackage ../development/tools/misc/gdb {
@@ -13035,7 +13035,7 @@ let
   smtube = qt5.callPackage ../applications/video/smtube {};
 
   sup = callPackage ../applications/networking/mailreaders/sup {
-    ruby = ruby_1_9_3.override { cursesSupport = true; };
+    ruby = ruby_1_9.override { cursesSupport = true; };
   };
 
   synapse = callPackage ../applications/misc/synapse {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tiny versions are just for bug-fixes and should be upgraded. I think that the
list has grown a bit too much organically and should be trimmed.

/cc @manveru @cstrahan 
