### PR TITLE
nix-daemon: change default to `useChroot = true`

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -100,7 +100,7 @@ in
 
       useChroot = mkOption {
         type = types.bool;
-        default = false;
+        default = true;
         description = "
           If set, Nix will perform builds in a chroot-environment that it
           will set up automatically for each build.  This prevents


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Is there any reasons that we don't enable sandboxed builds by default ?

I suppose that when they were first introduced, a lot of work was needed to cleanup all the packages.
Now that hydra has been building packages with sandboxing by default a lot of the issues have been caught and fixed.

What do you think ?
