### PR TITLE
openbox-menu: 0.5.1 -> 0.8.0

### DIFF
--- a/pkgs/applications/misc/openbox-menu/default.nix
+++ b/pkgs/applications/misc/openbox-menu/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, glib, gtk, menu-cache }:
 
 stdenv.mkDerivation rec {
-  name = "openbox-menu-0.5.1";
+  name = "openbox-menu-${version}";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "https://bitbucket.org/fabriceT/openbox-menu/downloads/${name}.tar.bz2";
-    sha256 = "11v3nlhqcnks5vms1a7rrvwvj8swc9axgjkp7z0r97lijsg6d3rj";
+    sha256 = "1hi4b6mq97y6ajq4hhsikbkk23aha7ikaahm92djw48mgj2f1w8l";
   };
 
   buildInputs = [ pkgconfig glib gtk menu-cache ];
@@ -15,8 +16,13 @@ stdenv.mkDerivation rec {
   installPhase = "make install prefix=$out";
 
   meta = {
+    homepage = "http://fabrice.thiroux.free.fr/openbox-menu_en.html";
     description = "Dynamic XDG menu generator for Openbox";
-    homepage = "http://mimasgpc.free.fr/openbox-menu.html";
+    longDescription = ''
+      Openbox-menu is a pipemenu for Openbox window manager. It provides a
+      dynamic menu listing installed applications. Most of the work is done by
+      the LXDE library menu-cache.
+    '';
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.romildo ];
     platforms   = stdenv.lib.platforms.unix;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): Linux
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
