### PR TITLE
ds4drv: init at 0.5.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5053,6 +5053,27 @@ in modules // {
     };
   };
 
+
+  ds4drv = buildPythonPackage rec {
+    name = "ds4drv-${version}";
+    version = "0.5.0";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/d/ds4drv/${name}.tar.gz";
+      sha256 = "0dq2z1z09zxa6rn3v94vwqaaz29jwiydkss8hbjglixf20krmw3b";
+    };
+
+    propagatedBuildInputs = with self; [ evdev pyudev ];
+
+    buildInputs = [ pkgs.bluez ];
+
+    meta = {
+      description = "Userspace driver for the DualShock 4 controller";
+      homepage = "https://github.com/chrippa/ds4drv";
+      license = licenses.mit;
+    };
+
+  };
+
   dyn = buildPythonPackage rec {
     version = "1.5.0";
     name = "dyn-${version}";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change (none ☺) using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
