### PR TITLE
wireshark: 2.0.0 -> 2.0.2 for multiple CVEs:…

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -11,7 +11,7 @@ assert withQt -> !withGtk && qt4 != null;
 with stdenv.lib;
 
 let
-  version = "2.0.0";
+  version = "2.0.2";
   variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
 in
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.bz2";
-    sha256 = "1pci4vj23wamycfj4lxxmpxps96yq6jfmqn7hdvisw4539v6q0lh";
+    sha256 = "1hdrnsllkfbvfwsvlqvvky0z91q63mbbnjcri56nb9c5403zn8g9";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS x86 64
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  
  CVE-2016-2521 CVE-2016-2522 CVE-2016-2523 CVE-2016-2524 CVE-2016-2525 CVE-2016-2526 CVE-2016-2527 CVE-2016-2528 CVE-2016-2529 CVE-2016-2531 CVE-2016-2532
