### PR TITLE
tasksh: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/tasksh/default.nix
+++ b/pkgs/applications/misc/tasksh/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, libuuid, gnutls }:
+
+stdenv.mkDerivation rec {
+  name = "tasksh-${version}";
+  version = "1.0.0";
+
+  enableParallelBuilding = true;
+
+  src = fetchurl {
+    url = "http://taskwarrior.org/download/tasksh-latest.tar.gz";
+    sha256 = "0ll6pwhw4wsdffacsmpq46fqh084p9mdaa777giqbag3b8gwik4s";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "REPL for taskwarrior";
+    homepage = http://tasktools.org;
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13714,6 +13714,8 @@ let
 
   taskwarrior = callPackage ../applications/misc/taskwarrior { };
 
+  tasksh = callPackage ../applications/misc/tasksh { };
+
   taskserver = callPackage ../servers/misc/taskserver { };
 
   telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli/default.nix { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @marcweber @jgeerds (taskwarrior maintainers)

---

I'm not sure whether it makes sense to make taskwarrior itself a `propagatedBuildInput` here, as this package is senseless without taskwarrior (I did not test running it without taskwarrior in scope, actually).
