### PR TITLE
as31: use yacc to generate parser.c file

### DIFF
--- a/pkgs/development/compilers/as31/default.nix
+++ b/pkgs/development/compilers/as31/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, yacc }:
 
 let
 
@@ -11,8 +11,15 @@ in stdenv.mkDerivation {
     url = "http://wiki.erazor-zone.de/_media/wiki:projects:linux:as31:as31-${version}.tar.gz";
     sha256 = "0mbk6z7z03xb0r0ccyzlgkjdjmdzknck4yxxmgr9k7v8f5c348fd";
   };
+
+  buildInputs = [ yacc ];
+
   preConfigure = ''
     chmod +x ./configure
+  '';
+
+  postConfigure = ''
+    rm as31/parser.c
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): Nix on Arch Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The source includes a generated parser.c file which is out of date and
causes errors on x86_64 in certain cases. Delete this file so that make
will use yacc to generate a correct parser.c file.

Change taken from comments at https://aur.archlinux.org/packages/as31/.

I tested the resulting binary against a variety of 8051 asm code I've written and compared with results from a (correct) windows as31 version.
