### PR TITLE
exim: 4.86 -> 4.86.2

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -1,11 +1,11 @@
 { coreutils, fetchurl, db, openssl, pcre, perl, pkgconfig, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "exim-4.86";
+  name = "exim-4.86.2";
 
   src = fetchurl {
     url = "http://mirror.switch.ch/ftp/mirror/exim/exim/exim4/${name}.tar.bz2";
-    sha256 = "0mn4bxih9slrmll5262ayhf41ji43pjf1rv0y6xpy6x55v7g5k7i";
+    sha256 = "1cvfcc1hi60lydv8h3a2rxlfc0v2nflwpvzjj7h7cdsqs2pxwmkp";
   };
 
   buildInputs = [ coreutils db openssl pcre perl pkgconfig ];


### PR DESCRIPTION
I've tested the patch against 40c586b7ce2c559374df435f46d673baf711c543 (nixos-unstable) and it's currently running on all my machines, receiving and sending mail.

This patch fixes [CVE-2016-1531](http://www.exim.org/static/doc/CVE-2016-1531.txt).
