### PR TITLE
mba6x_bl: init at 2016-02-12

### DIFF
--- a/pkgs/os-specific/linux/mba6x_bl/default.nix
+++ b/pkgs/os-specific/linux/mba6x_bl/default.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitHub, kernel, stdenv }:
+
+with stdenv.lib;
+
+let pkgName = "mba6x_bl";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pkgName}-2016-02-12";
+
+  src = fetchFromGitHub {
+    owner = "patjak";
+    repo = pkgName;
+    rev = "9c2de8a24e7d4e8506170a19d32d6f11f380a142";
+    sha256 = "1zaypai8lznqcaszb6an643amsvr5qjnqj6aq6jkr0qk37x0fjff";
+  };
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  meta = {
+    description = "MacBook Air 6,1 and 6,2 (mid 2013) backlight driver";
+    homepage = "https://github.com/patjak/mba6x_bl";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.simonvandel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10531,6 +10531,8 @@ let
 
     jool = callPackage ../os-specific/linux/jool { };
 
+    mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
+
     /* compiles but has to be integrated into the kernel somehow
        Let's have it uncommented and finish it..
     */


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This driver fixes backlight after suspend/resume on Macbook Air 6,1
and 6,2.

Added a workaround for https://github.com/patjak/mba6x_bl/issues/43 in
form of a systemd service.

Has been working great on my machine for at least a month now.
