### PR TITLE
gitAndTools.darcsToGit: 0.2git -> 2015-06-04

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "darcs-to-git-${version}";
-  version = "0.2git";
+  version = "2015-06-04";
 
   src = fetchgit {
     url = "git://github.com/purcell/darcs-to-git.git";
-    rev = "58a55936899c7e391df5ae1326c307fbd4617a25";
-    sha256 = "366aa691920991e21cfeebd4cbd53a6c42d80e2bc46ff398af482d1d15bac4c3";
+    rev = "e5fee32495908fe0f7d700644c7b37347b7a0a5b";
+    sha256 = "0ycp7pzv9g9pgj25asiby3p3m5vg5czqf4rpy2mavjqhiblxlcv5";
   };
 
   patchPhase = let


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes error where ruby 2.0+ doesn't have iconv anymore.

```
`require': cannot load such file -- iconv (LoadError)
```
