### PR TITLE
rubyripper: fix installation

### DIFF
--- a/pkgs/applications/audio/rubyripper/default.nix
+++ b/pkgs/applications/audio/rubyripper/default.nix
@@ -6,6 +6,9 @@ stdenv.mkDerivation rec {
     url = "https://rubyripper.googlecode.com/files/rubyripper-${version}.tar.bz2";
     sha256 = "1fwyk3y0f45l2vi3a481qd7drsy82ccqdb8g2flakv58m45q0yl1";
   };
+
+  preConfigure = "patchShebangs .";
+
   configureFlags = [ "--enable-cli" ];
   buildInputs = [ ruby cdparanoia makeWrapper ];
   postInstall = ''


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
