### PR TITLE
xdo: from 0.3 -> 0.5

### DIFF
--- a/pkgs/tools/misc/xdo/default.nix
+++ b/pkgs/tools/misc/xdo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libxcb, xcbutilwm }:
 
 stdenv.mkDerivation rec {
-   name = "xdo-0.3";
+   name = "xdo-0.5";
 
    src = fetchurl {
-     url = "https://github.com/baskerville/xdo/archive/0.3.tar.gz";
-     sha256 = "128flaydag9ixsai87p85r84arg2pn1j9h3zgdjwlmbcpb8d4ia8";
+     url = "https://github.com/baskerville/xdo/archive/0.5.tar.gz";
+     sha256 = "0sjnjs12i0gp1dg1m5jid4a3bg9am4qkf0qafyp6yn176yzcz1i6";
    };
 
    prePatch = ''sed -i "s@/usr/local@$out@" Makefile'';


### PR DESCRIPTION
###### Tests done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX / Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### Changes made
1. Updated xdo to the most recent major release.
   This incorporates a number of bugfixes, as well as adding the
   `below` and `above` actions.
2. Moved source fetching from `fetchurl` to `fetchFromGitHub`.

cc @meisternu
