### PR TITLE
buildStackPackage: Fix path to generic-stack-builder.nix.

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -81,7 +81,7 @@ rec {
 
   buildStrictly = pkg: buildFromSdist (appendConfigureFlag pkg "--ghc-option=-Wall --ghc-option=-Werror");
 
-  buildStackProject = pkgs.callPackage ../development/haskell-modules/generic-stack-builder.nix { };
+  buildStackProject = pkgs.callPackage ./generic-stack-builder.nix { };
 
   triggerRebuild = drv: i: overrideCabal drv (drv: { postUnpack = ": trigger rebuild ${toString i}"; });
 


### PR DESCRIPTION
Before:

```
error: getting status of
‘/home/user/nixpkgs/pkgs/development/development/haskell-modules/generic-stack-builder.nix’:
No such file or directory
```

This error slipped in following a last minute change of location of
this function.
