### PR TITLE
unbound: 1.5.7 -> 1.5.8

### DIFF
--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -113,7 +113,7 @@ in
       '';
 
       serviceConfig = {
-        ExecStart = "${pkgs.unbound}/sbin/unbound -d -c ${stateDir}/unbound.conf";
+        ExecStart = "${pkgs.unbound}/bin/unbound -d -c ${stateDir}/unbound.conf";
         ExecStopPost="${pkgs.utillinux}/bin/umount ${stateDir}/dev/random";
       };
     };

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     "--with-libevent=${libevent}"
     "--localstatedir=/var"
     "--sysconfdir=/etc"
+    "--sbindir=\${out}/bin"
     "--enable-pie"
     "--enable-relro-now"
   ];

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unbound-${version}";
-  version = "1.5.7";
+  version = "1.5.8";
 
   src = fetchurl {
     url = "http://unbound.net/downloads/${name}.tar.gz";
-    sha256 = "1a0wfgp6wqpf7cxlcbprqhnjx6z9ywf0rhrpcf7x98l1mbjqh82b";
+    sha256 = "33567a20f73e288f8daa4ec021fbb30fe1824b346b34f12677ad77899ecd09be";
   };
 
   buildInputs = [ openssl expat libevent ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Edit: also dropped sbin as per #11939
