### PR TITLE
openssh: allow building without linking openssl

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -4,6 +4,7 @@
 , withKerberos ? false
 , withGssapiPatches ? withKerberos
 , kerberos
+, linkOpenssl? true
 }:
 
 assert withKerberos -> kerberos != null;
@@ -54,7 +55,8 @@ stdenv.mkDerivation rec {
     (if pam != null then "--with-pam" else "--without-pam")
   ] ++ optional (etcDir != null) "--sysconfdir=${etcDir}"
     ++ optional withKerberos "--with-kerberos5=${kerberos}"
-    ++ optional stdenv.isDarwin "--disable-libutil";
+    ++ optional stdenv.isDarwin "--disable-libutil"
+    ++ optional (!linkOpenssl) "--without-openssl";
 
   preConfigure = ''
     configureFlagsArray+=("--with-privsep-path=$out/empty")


### PR DESCRIPTION
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): Nix on Arch Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

http://undeadly.org/cgi?action=article&sid=20140430045723 has the
original announcement of this option. Note, openssl headers are still
required at build time, see this comment:
http://www.gossamer-threads.com/lists/openssh/dev/61125#61125
