### PR TITLE
make-wrapper.sh: add an --unset argument

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -19,6 +19,12 @@ makeWrapper() {
             echo "export $varName=$value" >> $wrapper
         fi
 
+        if test "$p" = "--unset"; then
+            varName=${params[$((n + 1))]}
+            n=$((n + 1))
+            echo "unset $varName" >> "$wrapper"
+        fi
+
         if test "$p" = "--run"; then
             command=${params[$((n + 1))]}
             n=$((n + 1))


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`--set FOO ""` is not strictly equivalent to `--unset FOO`. In the former case
the environment variable still exists with an empty string as a value.
