### PR TITLE
[WIP] pidgin: fix gstreamer plugin path

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, gtk, gtkspell, aspell
-, gstreamer, gst_plugins_base, startupnotification, gettext
+{ stdenv, fetchurl, makeWrapper, pkgconfig, gtk, gtkspell, aspell
+, gstreamer, gst_plugins_base, gst_plugins_good, startupnotification, gettext
 , perl, perlXMLParser, libxml2, nss, nspr, farsight2
 , libXScrnSaver, ncurses, avahi, dbus, dbus_glib, intltool, libidn
 , lib, python, libICE, libXext, libSM
@@ -22,9 +22,11 @@ stdenv.mkDerivation rec {
 
   inherit nss ncurses;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [
     gtkspell aspell
-    gstreamer gst_plugins_base startupnotification
+    gstreamer gst_plugins_base gst_plugins_good startupnotification
     libxml2 nss nspr farsight2
     libXScrnSaver ncurses python
     avahi dbus dbus_glib intltool libidn
@@ -53,6 +55,11 @@ stdenv.mkDerivation rec {
   ++ (lib.optionals (gnutls != null) ["--enable-gnutls=yes" "--enable-nss=no"]);
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/pidgin \
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
+  '';
 
   meta = with stdenv.lib; {
     description = "Multi-protocol instant messaging client";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS (x86_64)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This fixes #13719 by adding a wrapper around pidgin. I've also added `gst_plugins_good` to `buildInputs` this should fix #10556 but I haven't confirmed this yet.

cc @vcunat, @ben0x539, @fuzzy-id.
