### PR TITLE
bird module: run as user/group `bird`, not `ircd`

### DIFF
--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -30,7 +30,7 @@ in
 
       user = mkOption {
         type = types.string;
-        default = "ircd";
+        default = "bird";
         description = ''
           BIRD Internet Routing Daemon user.
         '';
@@ -38,7 +38,7 @@ in
 
       group = mkOption {
         type = types.string;
-        default = "ircd";
+        default = "bird";
         description = ''
           BIRD Internet Routing Daemon group.
         '';


### PR DESCRIPTION
I have no idea why this was the case, but it's probably sensible to fix it.
AFAICT, bird doesn't have any persistent state, so I think this should be safe to backport
