### PR TITLE
wolfssl: 3.7.0 -> 3.8.0

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, autoconf, automake, libtool }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.7.0";
+  version = "3.8.0";
 
-  src = fetchurl {
-    url    = "https://github.com/wolfSSL/wolfssl/archive/v${version}.tar.gz";
-    sha256 = "1r1awivral4xjjvnna9lrfz2rh84rcbp04834rymbsz0kbyykgb6";
+  src = fetchFromGitHub {
+    owner = "wolfSSL";
+    repo = "wolfssl";
+    rev = "v${version}";
+    sha256 = "0vc2120a9gfxg3rv018ch1g84ia2cpplcqbpy8v6vpfb79rn1nf5";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];


### PR DESCRIPTION
###### Things done:
- [ ] Not built on nixos (I do not have it installed).
- [x] Built on platform(s): Linux (Fedora 22)
- [x] No packages in nixpkgs currently depend on wolfssl. However, curl successfully compiles against wolfssl with the nix shell script below.
- [x] Tested execution of curl built against wolfssl: `/nix/store/gc8hdffrc8k6p577rca69g8gxqy012y7-curl-7.47.1/bin/curl https://github.com/wolfSSL/wolfssl/`; works as expected.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Whilst at it, also changed fetchurl -> fetchFromGitHub.
###### Nix shell script used for testing

``` nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags = oldAttrs.configureFlags ++ [
      "--with-cyassl=${wolfssl}"
    ];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```
