### PR TITLE
linux_chromiumos_3_14: kernel option fix

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -478,7 +478,9 @@ with stdenv.lib;
   ''}
   ${optionalString (versionAtLeast version "3.7") ''
     MEDIA_USB_SUPPORT y
-    MEDIA_PCI_SUPPORT y
+    ${optionalString (!(features.chromiumos or false)) ''
+      MEDIA_PCI_SUPPORT y
+    ''}
   ''}
 
   # Our initrd init uses shebang scripts, so can't be modular.


### PR DESCRIPTION
Looks like ChromiumOS kernel doesn't support this option, so I set it explicitly off. The other kernels should not be affected by this commit.
