### PR TITLE
a few descriptions fixups

### DIFF
--- a/nixos/modules/config/krb5.nix
+++ b/nixos/modules/config/krb5.nix
@@ -32,7 +32,7 @@ in
 
       kdc = mkOption {
         default = "kerberos.mit.edu";
-        description = "Kerberos Domain Controller.";
+        description = "Key Distribution Center";
       };
 
       kerberosAdminServer = mkOption {

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -257,13 +257,11 @@ in
         type = types.bool;
         default = true;
         description = ''
-          If enabled, Nix will only download binaries from binary
-          caches if they are cryptographically signed with any of the
-          keys listed in
-          <option>nix.binaryCachePublicKeys</option>. If disabled (the
-          default), signatures are neither required nor checked, so
-          it's strongly recommended that you use only trustworthy
-          caches and https to prevent man-in-the-middle attacks.
+          If enabled (the default), Nix will only download binaries from binary caches if
+          they are cryptographically signed with any of the keys listed in
+          <option>nix.binaryCachePublicKeys</option>. If disabled, signatures are neither
+          required nor checked, so it's strongly recommended that you use only
+          trustworthy caches and https to prevent man-in-the-middle attacks.
         '';
       };
 

--- a/nixos/modules/services/system/kerberos.nix
+++ b/nixos/modules/services/system/kerberos.nix
@@ -46,7 +46,7 @@ in
       };
 
     systemd.services.kdc = {
-      description = "Kerberos Domain Controller daemon";
+      description = "Key Distribution Center daemon";
       wantedBy = [ "multi-user.target" ];
       preStart = ''
         mkdir -m 0755 -p ${stateDir}
@@ -55,7 +55,7 @@ in
     };
 
     systemd.services.kpasswdd = {
-      description = "Kerberos Domain Controller daemon";
+      description = "Kerberos Password Changing daemon";
       wantedBy = [ "multi-user.target" ];
       script = "${heimdal}/sbin/kpasswdd";
     };


### PR DESCRIPTION
Here are a few small description changes.

KDC in the documentation[1] is referred as "Key Distribution Center" not "Kerberos Domain Controller".
[1] http://web.mit.edu/kerberos/www/krb5-1.2/krb5-1.2.6/doc/install.html
