### PR TITLE
sqlitebrowser: 3.7.0 -> 3.8.0

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchzip, qt4, sqlite, cmake }:
+{ stdenv, fetchFromGitHub, qt4, sqlite, cmake }:
 
 stdenv.mkDerivation rec {
-  version = "3.7.0";
+  version = "3.8.0";
   name = "sqlitebrowser-${version}";
 
-  src = fetchzip {
-    name = "${name}-src";
-    url = "https://github.com/sqlitebrowser/sqlitebrowser/archive/v${version}.tar.gz";
-    sha256 = "1zsgylnxk4lyg7p6k6pv8d3mh1k0wkfcplh5c5da3x3i9a3qs78j";
+  src = fetchFromGitHub {
+    repo   = "sqlitebrowser";
+    owner  = "sqlitebrowser";
+    rev    = "v${version}";
+    sha256 = "009yaamf6f654dl796f1gmj3rb34d55w87snsfgk33gpy6x19ccp";
   };
 
   buildInputs = [ qt4 sqlite cmake ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @matthiasbeyer 
