### PR TITLE
flvtool2: fix installation

### DIFF
--- a/pkgs/tools/video/flvtool2/default.nix
+++ b/pkgs/tools/video/flvtool2/default.nix
@@ -1,28 +1,15 @@
-{ stdenv, fetchurl, ruby }:
+{ buildRubyGem, lib, ruby_2_2 }:
 
-stdenv.mkDerivation rec {
-  name = "flvtool2-1.0.6";
-  
-  src = fetchurl {
-    url = "http://rubyforge.org/frs/download.php/17497/${name}.tgz";
-    sha256 = "1pbsf0fvqrs6xzfkqal020bplb68dfiz6c5sfcz36k255v7c5w9a";
-  };
-
-  buildInputs = [ ruby ];
-
-  configurePhase =
-    ''
-      substituteInPlace bin/flvtool2 --replace "/usr/bin/env ruby" "ruby -I$out/lib/ruby/site_ruby/1.8"
-      ruby setup.rb config --prefix=$out --siterubyver=$out/lib/ruby/site_ruby/1.8
-    '';
-  
-  installPhase =
-    ''
-      ruby setup.rb install
-    '';
+buildRubyGem rec {
+  ruby = ruby_2_2;
+  name = "${gemName}-${version}";
+  gemName = "flvtool2";
+  version = "1.0.6";
+  sha256 = "0xsla1061pi4ryh3jbvwsbs8qchprchbqjy7652g2g64v37i74qj";
 
   meta = {
-    homepage = http://www.inlet-media.de/flvtool2/;
+    homepage = https://github.com/unnu/flvtool2;
     description = "A tool to manipulate Macromedia Flash Video files";
+    platforms = ruby.meta.platforms;
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The rubygems.org source doesn't exist anymore. It was also depending on ruby
1.8 to work correctly.
