### PR TITLE
diction: init at 1.11

### DIFF
--- a/pkgs/tools/text/diction/default.nix
+++ b/pkgs/tools/text/diction/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "diction-1.11";
+
+  src = fetchurl {
+    url = "mirror://gnu/diction/${name}.tar.gz";
+    sha256 = "1xi4l1x1vvzmzmbhpx0ghmfnwwrhabjwizrpyylmy3fzinzz3him";
+  };
+
+  meta = {
+    description = "GNU style and diction utilities";
+    longDescription = ''
+      Diction and style are two old standard Unix commands. Diction identifies
+      wordy and commonly misused phrases. Style analyses surface
+      characteristics of a document, including sentence length and other
+      readability measures.
+    '';
+    license = stdenv.lib.licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1384,6 +1384,8 @@ let
 
   di = callPackage ../tools/system/di { };
 
+  diction = callPackage ../tools/text/diction { };
+
   diffoscope = callPackage ../tools/misc/diffoscope {
     jdk = jdk7;
     pythonPackages = python3Packages;


### PR DESCRIPTION
GNU utilities for finding misused phrases in documents (`diction`) and analysing documents to find their readability grades, sentence lengths and so on (`style`).

Tested on NixOS. Diction has no dependencies and no dependents.
