### PR TITLE
galen: 2.2.1 -> 2.2.3

### DIFF
--- a/pkgs/development/tools/galen/default.nix
+++ b/pkgs/development/tools/galen/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "galen";
-  version = "2.2.1";
+  version = "2.2.3";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
-    url = "https://github.com/galenframework/galen/releases/download/galen-2.2.1/galen-bin-${version}.zip";
-    sha256 = "0zwrh3bxcgkwip6z9lvy3hn53kfr99cdij64c57ff8d95xilclhb";
+    url = "https://github.com/galenframework/galen/releases/download/galen-${version}/galen-bin-${version}.zip";
+    sha256 = "13kvxbw68g82rv8bp9g4fkrrsd7nag1a4bspilqi2wnxc51c8mqq";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Things done:
- [x] Built on platform(s): OSX
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

[Galen Changelog](https://github.com/galenframework/galen/blob/fbee286063f331505dbd04dad302cfe94a45010c/CHANGELOG.md)

cc @gilligan
