### PR TITLE
pythonPackages.geoalchemy2: init at 0.3.0.dev1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18413,6 +18413,24 @@ in modules // {
     };
   };
 
+  geoalchemy2 = buildPythonPackage rec {
+    name = "GeoAlchemy2-${version}";
+    version = "0.3.0.dev1";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/G/GeoAlchemy2/${name}.tar.gz";
+      sha256 = "1j95p860ikpcpcirs5791yjpy8rf18zsz7vvsdy6v3x32hkim0k6";
+    };
+
+    propagatedBuildInputs = with self ; [ sqlalchemy shapely ];
+
+    meta = {
+      homepage =  http://geoalchemy.org/;
+      license = licenses.mit;
+      description = "Toolkit for working with spatial databases";
+    };
+  };
+
   geopy = buildPythonPackage rec {
     name = "geopy-${version}";
     version = "1.11.0";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

---

Builds with all python implementations (if all dependencies are available, which is not the case for `pypy`)
