### PR TITLE
libretro-mednafen-psx: init at 2016-03-04

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -158,6 +158,18 @@ in
     buildPhase = "make";
   };
 
+  mednafen-psx = (mkLibRetroCore rec {
+    core = "mednafen-psx";
+    src = fetchRetro {
+      repo = "beetle-psx-libretro";
+      rev = "20c9b0eb0062b8768cc40aca0e2b2d626f1002a2";
+      sha256 = "1dhql8zy9wv55m1lgvqv412087cqmlw7zwcsmxkl3r4z199dsh3m";
+    };
+    description = "Port of Mednafen's PSX Engine core to libretro";
+  }).override {
+    buildPhase = "make";
+  };
+
   mupen64plus = (mkLibRetroCore rec {
     core = "mupen64plus";
     src = fetchRetro {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14079,6 +14079,7 @@ let
       ++ optional (cfg.enableGenesisPlusGX or false) genesis-plus-gx
       ++ optional (cfg.enableMAME or false) mame
       ++ optional (cfg.enableMednafenPCEFast or false) mednafen-pce-fast
+      ++ optional (cfg.enableMednafenPSX or false) mednafen-psx
       ++ optional (cfg.enableMupen64Plus or false) mupen64plus
       ++ optional (cfg.enableNestopia or false) nestopia
       ++ optional (cfg.enablePicodrive or false) picodrive


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS x86_64
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This adds psx a playstation 1 emulator to retroarch.

cc @edwtjo @MP2E 
