### PR TITLE
transmission: 2.90 -> 2.92

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "2.90";
+  version = "2.92";
 in
 
 with { inherit (stdenv.lib) optional optionals optionalString; };
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://transmission.cachefly.net/transmission-${version}.tar.xz";
-    sha256 = "1lig7y9fhmv2ajgq1isj9wqgpcgignzlczs3dy95ahb8h6pqrzv9";
+    sha256 = "0pykmhi7pdmzq47glbj8i2im6iarp4wnj4l1pyvsrnba61f0939s";
   };
 
   buildInputs = [ pkgconfig intltool file openssl curl libevent inotify-tools zlib ]


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS (x
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review transmission"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This update is mandatory because the old version has been removed from the download servers.

Old link: https://transmission.cachefly.net/transmission-2.90.tar.xz

cc @astsmtl @vcunat @wizeman
