### PR TITLE
raspberrypifw: Patch the ELF binaries to set the correct dynamic link…

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -17,6 +17,11 @@ in stdenv.mkDerivation {
     cp -R boot/* $out/share/raspberrypi/boot
     cp -R hardfp/opt/vc/* $out
     cp opt/vc/LICENCE $out/share/raspberrypi
+
+    for f in $out/bin/*; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f"
+      patchelf --set-rpath "$out/lib" "$f"
+    done
   '';
 
   meta = {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This fixes the precompiled executables in raspberrypifw to have the correct dynamic linker and RPATH to work on NixOS.
