### PR TITLE
lastpass-cli: 0.7.0 -> 0.9.0

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "lastpass-cli-${version}";
 
-  version = "0.7.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "lastpass";
     repo = "lastpass-cli";
     rev = "v${version}";
-    sha256 = "18dn4sx173666w6aaqhwcya5x2z3q0fmhg8h76lgdmx8adrhzdzc";
+    sha256 = "1iaz36bcyss2kahhlm92l7yh26rxvs12wnkkh1289yarl5wi0yld";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Things done:

Before:

```
% lpass --version
LastPass CLI v0.7.0

% lpass login cheecheeo@gmail.com
Error: Peer certificate cannot be authenticated with given CA certificates.
```

After:

```
% nix-env --file $NIXPKGS -iA lastpass-cli
installing ‘lastpass-cli-0.9.0’

% lpass --version
LastPass CLI v0.9.0

% lpass login cheecheeo@gmail.com
Success: Logged in as cheecheeo@gmail.com.
```
###### More

cc @cstrahan

---

_Please note, that points are not mandatory, but rather desired._
