### PR TITLE
openssh: decouple gssapi patch from kerberos

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -2,12 +2,13 @@
 , etcDir ? null
 , hpnSupport ? false
 , withKerberos ? false
-, withGssapiPatches ? withKerberos
+, withGssapiPatches ? false
 , kerberos
 , linkOpenssl? true
 }:
 
 assert withKerberos -> kerberos != null;
+assert withGssapiPatches -> withKerberos;
 
 let
 
@@ -24,6 +25,8 @@ let
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
+  # Please ensure that openssh_with_kerberos still builds when
+  # bumping the version here!
   name = "openssh-7.2p1";
 
   src = fetchurl {

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -18,8 +18,8 @@ let
   };
 
   gssapiSrc = fetchpatch {
-    url = "http://anonscm.debian.org/cgit/pkg-ssh/openssh.git/plain/debian/patches/gssapi.patch?h=debian/7.1p2-2";
-    sha256 = "05nsch879nlpyyiwm240wlq9rasy71j9d03j1rfi8kp865zhjfbm";
+    url = "https://anonscm.debian.org/cgit/pkg-ssh/openssh.git/plain/debian/patches/gssapi.patch?id=46961f5704f8e86cea3e99253faad55aef4d8f35";
+    sha256 = "01mf2vx1gavypbdx06mcbmcrkm2smff0h3jfmr61k6h6j3xk88y5";
   };
 
 in


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): Nix on Arch Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Apparently openssh_with_kerberos is prone to breakage when updating the openssh version; see #13595 and #13140.

cc @benley for the GSSAPI patch and @jxy since I broke openssh_with_kerberos for you :(

The GSSAPI patch is useful but maintained by Debian, not upstream, and
can be slow to update. To avoid breaking openssh_with_kerberos when
the openssh version is bumped but the GSSAPI patch has not been updated,
don't enable the GSSAPI patch implicitly but require it to be explicitly
enabled.
