### PR TITLE
vsftpd: Add possibility to specify path to RSA key file

### DIFF
--- a/nixos/modules/services/networking/vsftpd.nix
+++ b/nixos/modules/services/networking/vsftpd.nix
@@ -85,6 +85,9 @@ let
         ssl_enable=YES
         rsa_cert_file=${cfg.rsaCertFile}
       ''}
+      ${optionalString (cfg.rsaKeyFile != null) ''
+        rsa_private_key_file=${cfg.rsaKeyFile}
+      ''}
       ${optionalString (cfg.userlistFile != null) ''
         userlist_file=${cfg.userlistFile}
       ''}
@@ -145,6 +148,12 @@ in
         type = types.nullOr types.path;
         default = null;
         description = "RSA certificate file.";
+      };
+
+      rsaKeyFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "RSA private key file.";
       };
 
       anonymousUmask = mkOption {


### PR DESCRIPTION
This is just a tiny change to allow specifying the path to a private key file, which can be used when `pkgs.vsftpd.sslEnable` is true.  I found that I couldn't start the service with only the certificate file, (even if the certificate and key were concatenated) and that option `rsa_private_key_file` was required.

Not sure who the maintainer of this is, sorry!
