### PR TITLE
nixos/tests: implement dnscrypt-proxy test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -240,6 +240,7 @@ in rec {
   tests.containers = callTest tests/containers.nix {};
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
   tests.dockerRegistry = hydraJob (import tests/docker-registry.nix { system = "x86_64-linux"; });
+  tests.dnscrypt-proxy = callTest tests/dnscrypt-proxy.nix { system = "x86_64-linux"; };
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });
   tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
   tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;

--- a/nixos/tests/dnscrypt-proxy.nix
+++ b/nixos/tests/dnscrypt-proxy.nix
@@ -1,0 +1,32 @@
+import ./make-test.nix ({ pkgs, ... }: {
+  name = "dnscrypt-proxy";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ joachifm ];
+  };
+
+  nodes = {
+    # A client running the recommended setup: DNSCrypt proxy as a forwarder
+    # for a caching DNS client.
+    client =
+    { config, pkgs, ... }:
+    let localProxyPort = 43; in
+    {
+      security.apparmor.enable = true;
+
+      services.dnscrypt-proxy.enable = true;
+      services.dnscrypt-proxy.localPort = localProxyPort;
+
+      services.dnsmasq.enable = true;
+      services.dnsmasq.servers = [ "127.0.0.1#${toString localProxyPort}" ];
+    };
+  };
+
+  testScript = ''
+    $client->start;
+    $client->waitForUnit("multi-user.target");
+
+    # The daemon is socket activated; sending a single ping should activate it.
+    $client->execute("${pkgs.iputils}/bin/ping -c1 example.com");
+    $client->succeed("systemctl is-active dnscrypt-proxy.service");
+  '';
+})


### PR DESCRIPTION
My first attempt at writing a test, feedback/critcism very much welcome.

Seeing as there is actually quite a bit that can go wrong with the dnscrypt-proxy module, I thought a test was in order. Although the test is pretty much as dumb as possible, it has already proven useful to me, by uncovering a mistake in the default config & a mistake in the AppArmor profile.
