### PR TITLE
ntfy: init at 1.2.0

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2631,6 +2631,8 @@ let
   # ntfsprogs are merged into ntfs-3g
   ntfsprogs = pkgs.ntfs3g;
 
+  ntfy = pythonPackages.ntfy;
+
   ntopng = callPackage ../tools/networking/ntopng { };
 
   ntp = callPackage ../tools/networking/ntp {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12816,6 +12816,26 @@ in modules // {
     };
   };
 
+  ntfy = buildPythonPackage rec {
+    version = "1.2.0";
+    name = "ntfy-${version}";
+    src = pkgs.fetchFromGitHub {
+      owner = "dschep";
+      repo = "ntfy";
+      rev = "v${version}";
+      sha256 = "0yjxwisxpxy3vpnqk9nw5k3db3xx6wyf6sk1px9m94s30glcq2cc";
+    };
+
+    propagatedBuildInputs = with self; [ appdirs pyyaml requests dbus ];
+
+    meta = {
+      description = "A utility for sending notifications, on demand and when commands finish";
+      homepage = http://ntfy.rtfd.org/;
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ kamilchm ];
+    };
+  };
+
   ntplib = buildPythonPackage rec {
     name = "ntplib-0.3.2";
     src = pkgs.fetchurl {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
