### PR TITLE
nvidia_x11_legacy304: fix evaluation on 16.03

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
@@ -8,25 +8,23 @@
 
 with stdenv.lib;
 
-let versionNumber = "304.125"; in
+let versionNumber = "304.131"; in
 
 stdenv.mkDerivation {
   name = "nvidia-x11-${versionNumber}${optionalString (!libsOnly) "-${kernel.version}"}";
 
   builder = ./builder-legacy304.sh;
 
-  patches = [ ./nvidia-340.76-kernel-4.0.patch ];
-
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "1xy4g3yc73mb932cfr25as648k12sxpyymppb8nia3lijakv7idf";
+        sha256 = "1a1d0fsahgijcvs2p59vwhs0dpp7pp2wmvgcs1i7fzl6yyv4nmfj";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "08p6hikn7pbfg0apnsbaqyyh2s9m5r0ckqzgjvxirn5qcyll0g5a";
+        sha256 = "0gpqzb5gvhrcgrp3kph1p0yjkndx9wfzgh5j88ysrlflkv3q4vig";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 


### PR DESCRIPTION
## Fixed by upgrading, original description:

---

See also: https://github.com/NixOS/nixpkgs/commit/a90196d4cda5fac99bf60c5a254e5bc02b58e71e

nvidia-340.76-kernel-4.0.patch was removed from nvidia_x11_legacy340
54d342add8ab512c5650e1b2da25708622dd327d but is still needed for 304.

I think. CC @vcunat.

(cherry picked from commit a90196d4cda5fac99bf60c5a254e5bc02b58e71e)
