### PR TITLE
nvidia_x11_legacy304: 304.125 -> 304.131

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
@@ -8,25 +8,23 @@
 
 with stdenv.lib;
 
-let versionNumber = "304.125"; in
+let versionNumber = "304.131"; in
 
 stdenv.mkDerivation {
   name = "nvidia-x11-${versionNumber}${optionalString (!libsOnly) "-${kernel.version}"}";
 
   builder = ./builder-legacy304.sh;
 
-  patches = [ ./nvidia-340.76-kernel-4.0.patch ];
-
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "1xy4g3yc73mb932cfr25as648k12sxpyymppb8nia3lijakv7idf";
+        sha256 = "1a1d0fsahgijcvs2p59vwhs0dpp7pp2wmvgcs1i7fzl6yyv4nmfj";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://us.download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "08p6hikn7pbfg0apnsbaqyyh2s9m5r0ckqzgjvxirn5qcyll0g5a";
+        sha256 = "0gpqzb5gvhrcgrp3kph1p0yjkndx9wfzgh5j88ysrlflkv3q4vig";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Thanks to the great commit message in 6257425dabe7ad9190d7e5d5fab3d0bc5dad366e
(thank you edwtjo) I was able to go back and find out the patch which
was causing build failures is no longer necessary after upgrading
this legacy driver.
