### PR TITLE
python34 pillow: add build input lcms2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15374,8 +15374,7 @@ in modules // {
     doCheck = false;
 
     buildInputs = with self; [
-      pkgs.freetype pkgs.libjpeg pkgs.zlib pkgs.libtiff pkgs.libwebp pkgs.tcl nose ]
-      ++ optionals (isPy26 || isPy27 || isPy33 || isPy34 || isPyPy) [ pkgs.lcms2 ]
+      pkgs.freetype pkgs.libjpeg pkgs.zlib pkgs.libtiff pkgs.libwebp pkgs.tcl nose pkgs.lcms2 ]
       ++ optionals (isPyPy) [ pkgs.tk pkgs.xorg.libX11 ];
 
     # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15375,7 +15375,7 @@ in modules // {
 
     buildInputs = with self; [
       pkgs.freetype pkgs.libjpeg pkgs.zlib pkgs.libtiff pkgs.libwebp pkgs.tcl nose ]
-      ++ optionals (isPy26 || isPy27 || isPy33 || isPyPy) [ pkgs.lcms2 ]
+      ++ optionals (isPy26 || isPy27 || isPy33 || isPy34 || isPyPy) [ pkgs.lcms2 ]
       ++ optionals (isPyPy) [ pkgs.tk pkgs.xorg.libX11 ];
 
     # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.


### PR DESCRIPTION
###### Things done:
- Built using nix on ubuntu
- Tested using `nix-shell -I nixpkgs=repo/nixpkgs -p python34Packages.pillow -p python34Packages.scipy --pure --run python3` and using scipy's imsave
- Note that previously the above command would not build: python34Packages.pillow appears to be broken (at least on Ubuntu)

Sorry, I am not using NixOS to test.
