### PR TITLE
add go-upower-notify

### DIFF
--- a/pkgs/tools/system/yeshup/default.nix
+++ b/pkgs/tools/system/yeshup/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "yeshup-${builtins.substring 0 7 rev}";
+  rev = "5461a8f957c686ccd0240be3f0fd8124d7381b08";
+
+  src = fetchFromGitHub {
+    owner = "RhysU";
+    repo  = "yeshup";
+    inherit rev;
+    sha256 = "1wwbc158y46jsmdi1lp0m3dlbr9kvzvwxfvzj6646cpy9d6h21v9";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v yeshup $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/RhysU/yeshup;
+    platforms = platforms.all;
+    license = licenses.cc-by-sa-30; # From Stackoverflow answer
+    maintainers = with maintainers; [ obadz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1805,6 +1805,8 @@ let
 
   go-pup = goPackages.pup.bin // { outputs = [ "bin" ]; };
 
+  go-upower-notify = goPackages.upower-notify.bin // { outputs = [ "bin" ]; };
+
   googleAuthenticator = callPackage ../os-specific/linux/google-authenticator { };
 
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3893,6 +3893,8 @@ let
 
   yaml-merge = callPackage ../tools/text/yaml-merge { };
 
+  yeshup = callPackage ../tools/system/yeshup { };
+
   # To expose more packages for Yi, override the extraPackages arg.
   yi = callPackage ../applications/editors/yi/wrapper.nix { };
 

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -3791,4 +3791,19 @@ let
     sha256 = "153hf4dq4jh1yv35pv30idmxhc917qzl590qy5394l48d4rapgb5";
     buildInputs = [ go-colortext yaml-v2 godotenv ];
   };
+
+  # To use upower-notify, the maintainer suggests adding something like this to your configuration.nix:
+  #
+  # service.xserver.displayManager.sessionCommands = ''
+  #   ${pkgs.dunst}/bin/dunst -shrink -geometry 0x0-50-50 -key space & # ...if don't already have a dbus notification display app
+  #   (sleep 3; exec ${pkgs.yeshup}/bin/yeshup ${pkgs.go-upower-notify}/bin/upower-notify) &
+  # '';
+  upower-notify = buildFromGitHub rec {
+    rev    = "14c581e683a7e90ec9fa6d409413c16599a5323c";
+    date   = "2016-03-10";
+    owner  = "omeid";
+    repo   = "upower-notify";
+    sha256 = "16zlvn53p9m10ph8n9gps51fkkvl6sf4afdzni6azk05j0ng49jw";
+    propagatedBuildInputs = [ dbus ];
+  };
 }; in self

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -596,17 +596,20 @@ let
     sha256 = "09sdijfx5d05z4cd5k6lhl7k3kbpdf2amzlngv15h5v0fff9qw4s";
   };
 
-  dbus = buildGoPackage rec {
-    rev = "a5942dec6340eb0d57f43f2003c190ce06e43dea";
-    name = "dbus-${stdenv.lib.strings.substring 0 7 rev}";
-    goPackagePath = "github.com/godbus/dbus";
+  dbus-old-2015-05-19 = buildFromGitHub {
+    rev    = "a5942dec6340eb0d57f43f2003c190ce06e43dea";
+    date   = "2015-05-19";
+    owner  = "godbus";
+    repo   = "dbus";
+    sha256 = "1vk31wal7ncvjwvnb8q1myrkihv1np46f3q8dndi5k0csflbxxdf";
+  };
 
-    src = fetchFromGitHub {
-      inherit rev;
-      owner = "godbus";
-      repo = "dbus";
-      sha256 = "1vk31wal7ncvjwvnb8q1myrkihv1np46f3q8dndi5k0csflbxxdf";
-    };
+  dbus = buildFromGitHub {
+    rev    = "230e4b23db2fd81c53eaa0073f76659d4849ce51";
+    date   = "2016-03-02";
+    owner  = "godbus";
+    repo   = "dbus";
+    sha256 = "1wxv2cbihzcsz2z7iycyzl7f3arhhgagcc5kqln1k1mkm4l85z0q";
   };
 
   deis = buildFromGitHub {
@@ -1705,7 +1708,7 @@ let
     owner = "stgraber";
     repo = "lxd-go-systemd";
     sha256 = "006dhy3j8ld0kycm8hrjxvakd7xdn1b6z2dsjp1l4sqrxdmm188w";
-    buildInputs = [ dbus ];
+    buildInputs = [ dbus-old-2015-05-19 ];
   };
 
   go-update-v0 = buildFromGitHub {

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1687,18 +1687,13 @@ let
     sha256 = "1j53m2wjyczm9m55znfycdvm4c8vfniqgk93dvzwy8vpj5gm6sb3";
   };
 
-  go-systemd = buildGoPackage rec {
-    rev = "2688e91251d9d8e404e86dd8f096e23b2f086958";
-    name = "go-systemd-${stdenv.lib.strings.substring 0 7 rev}";
-    goPackagePath = "github.com/coreos/go-systemd";
-
-    src = fetchFromGitHub {
-      inherit rev;
-      owner = "coreos";
-      repo = "go-systemd";
-      sha256 = "0c1k3y5msc1xplhx0ksa7g08yqjaavns8s5zrfg4ig8az30gwlpa";
-    };
-
+  go-systemd = buildFromGitHub {
+    rev    = "7b2428fec40033549c68f54e26e89e7ca9a9ce31";
+    date   = "2016-03-10";
+    owner  = "coreos";
+    repo   = "go-systemd";
+    sha256 = "0kfbxvm9zsjgvgmiq2jl807y4s5z0rya65rm399llr5rr7vz1lxd";
+    nativeBuildInputs = [ pkgs.pkgconfig pkgs.systemd ];
     buildInputs = [ dbus ];
   };
 


### PR DESCRIPTION
Adding go-upower-notify
Upgrading go-dbus was a prereq.
Also adding yeshup which is very useful to launch upower-notify.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / ~~OSX~~ / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

---

_Please note, that points are not mandatory, but rather desired._
