### PR TITLE
quasselDaemon: option for static linking

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -5,6 +5,7 @@
 , tag ? "" # tag added to the package name
 , withKDE ? stdenv.isLinux # enable KDE integration
 , kdelibs ? null
+, static ? false # link statically
 
 , stdenv, fetchurl, cmake, makeWrapper, qt, automoc4, phonon, dconf, qca2 }:
 
@@ -42,8 +43,8 @@ in with stdenv; mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-fPIC";
 
   cmakeFlags = [
-    "-DEMBED_DATA=OFF"
-    "-DSTATIC=OFF" ]
+    "-DEMBED_DATA=OFF" ]
+    ++ edf static "STATIC"
     ++ edf monolithic "WANT_MONO"
     ++ edf daemon "WANT_CORE"
     ++ edf client "WANT_QTCLIENT"

--- a/pkgs/applications/networking/irc/quassel/qt-5.nix
+++ b/pkgs/applications/networking/irc/quassel/qt-5.nix
@@ -3,6 +3,7 @@
 , client ? false # build Quassel client
 , previews ? false # enable webpage previews on hovering over URLs
 , tag ? "" # tag added to the package name
+, static ? false # link statically
 
 , stdenv, fetchurl, cmake, makeWrapper, dconf
 , qtbase, qtscript, qtwebkit
@@ -66,9 +67,9 @@ in with stdenv; mkDerivation rec {
 
   cmakeFlags = [
     "-DEMBED_DATA=OFF"
-    "-DSTATIC=OFF"
     "-DUSE_QT5=ON"
   ]
+    ++ edf static "STATIC"
     ++ edf monolithic "WANT_MONO"
     ++ edf daemon "WANT_CORE"
     ++ edf client "WANT_QTCLIENT"


### PR DESCRIPTION
In order to be able to drag & drop to a server without working package manager.
