### PR TITLE
faust2: fix build

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15895,7 +15895,9 @@ let
 
   faust1 = callPackage ../applications/audio/faust/faust1.nix { };
 
-  faust2 = callPackage ../applications/audio/faust/faust2.nix { };
+  faust2 = callPackage ../applications/audio/faust/faust2.nix {
+    llvm = llvm_37;
+  };
 
   faust2alqt = callPackage ../applications/audio/faust/faust2alqt.nix { };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/12749

The build failure was caused by brittle detection of the
llvm version. See the code for (excessive) details. This fix
is a quick hack, a proper fix would be to parse the version
of the input llvm derivation and use that to derive a proper
value. Here we just pin the version & set a known good value.

Also move build-time deps to `nativeBuildInputs`.

Ref: https://github.com/NixOS/nixpkgs/issues/13559
