### PR TITLE
pythonPackages.sqalchemy: 1.0.10 -> 1.0.12

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20293,11 +20293,11 @@ in modules // {
 
   sqlalchemy = buildPythonPackage rec {
     name = "SQLAlchemy-${version}";
-    version = "1.0.10";
+    version = "1.0.12";
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/S/SQLAlchemy/${name}.tar.gz";
-      sha256 = "963415bf4ea4fa13698893464bc6917d291331e0e8202dddd0ebfed2864ef7e3";
+      sha256 = "1l8qclhd0s90w3pvwhi5mjxdwr5j7gw7cjka2fx6f2vqmq7f4yb6";
     };
 
     buildInputs = with self; [ nose mock ]


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._

1.0.11 and 1.0.12 are bugfixes releases. See

http://www.sqlalchemy.org/blog/2016/02/15/sqlalchemy-1.0.12-released/
http://www.sqlalchemy.org/blog/2015/12/23/sqlalchemy-1.0.11-released/
