### PR TITLE
ffmpeg-full: 2.8.5 -> 3.0

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -235,11 +235,11 @@ assert x11grabExtlib -> libX11 != null && libXv != null;
 
 stdenv.mkDerivation rec {
   name = "ffmpeg-full-${version}";
-  version = "2.8.5";
+  version = "3.0";
 
   src = fetchurl {
     url = "https://www.ffmpeg.org/releases/ffmpeg-${version}.tar.bz2";
-    sha256 = "0nk1j3i7qc1k3dygpq74pxq382vqg9kaf2hxl9jfw8rkad8rjv9v";
+    sha256 = "1h0k05cj6j0nd2i16z7hc5scpwsbg3sfx68lvm0nlwvz5xxgg7zi";
   };
 
   patchPhase = ''patchShebangs .'';
@@ -449,7 +449,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A complete, cross-platform solution to record, convert and stream audio and video";
-    homepage = http://www.ffmpeg.org/;
+    homepage = https://www.ffmpeg.org/;
     longDescription = ''
       FFmpeg is the leading multimedia framework, able to decode, encode, transcode, 
       mux, demux, stream, filter and play pretty much anything that humans and machines 


### PR DESCRIPTION
###### Things done:
- Built on platform(s): OSX
  ###### More

For OS X, I disabled a few more options to keep the build simpler and quicker:

```
    ffmpeg-full = callPackage (<nixpkgs> + /pkgs/development/libraries/ffmpeg-full) {
      libXv = null;
      libXfixes = null;
      openglExtlib = false;
      ffplayProgram = false;
      SDL = null;

      # The following need to be fixed on Darwin
      frei0r = if stdenv.isDarwin then null else frei0r;
      game-music-emu = if stdenv.isDarwin then null else game-music-emu;
      libjack2 = if stdenv.isDarwin then null else libjack2;
      libmodplug = if stdenv.isDarwin then null else libmodplug;
      libvpx = if stdenv.isDarwin then null else libvpx;
      openal = if stdenv.isDarwin then null else openal;
      libpulseaudio = if stdenv.isDarwin then null else libpulseaudio;
      samba = if stdenv.isDarwin then null else samba;
      vid-stab = if stdenv.isDarwin then null else vid-stab;
      x265 = if stdenv.isDarwin then null else x265;
      xavs = if stdenv.isDarwin then null else xavs;
      inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices;
    };
```
