### PR TITLE
colord color management daemon

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -439,6 +439,7 @@
   ./services/web-servers/varnish/default.nix
   ./services/web-servers/winstone.nix
   ./services/web-servers/zope2.nix
+  ./services/x11/colord.nix
   ./services/x11/unclutter.nix
   ./services/x11/desktop-managers/default.nix
   ./services/x11/display-managers/auto.nix

--- a/nixos/modules/services/x11/colord.nix
+++ b/nixos/modules/services/x11/colord.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.colord;
+
+in {
+
+  options = {
+
+    services.colord = {
+      enable = mkEnableOption "colord, the color management daemon";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    services.dbus.packages = [ pkgs.colord ];
+
+    services.udev.packages = [ pkgs.colord ];
+
+    environment.systemPackages = [ pkgs.colord ];
+
+    systemd.services.colord = {
+      description = "Manage, Install and Generate Color Profiles";
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.freedesktop.ColorManager";
+        ExecStart = "${pkgs.colord}/libexec/colord";
+        PrivateTmp = true;
+      };
+    };
+
+  };
+
+}

--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -2,7 +2,7 @@
 , libXrender, libXext, libtiff, libjpeg, libpng, libXScrnSaver, writeText
 , libXdmcp, libXau, lib, openssl, zlib }:
 let
-  version = "1.8.2";
+  version = "1.8.3";
  in
 stdenv.mkDerivation rec {
   name = "argyllcms-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     # Kind of flacky URL, it was reaturning 406 and inconsistent binaries for a
     # while on me. It might be good to find a mirror
     url = "http://www.argyllcms.com/Argyll_V${version}_src.zip";
-    sha256 = "0hnsciwak5chy4a421l8fz7amxzg8kbmy57a07dn460gdg6r63cy";
+    sha256 = "00ggh47qzb3xyl8rnppwxa6j113lr38aiwvsfyxwgs51aqmvq7bd";
 
     # The argyllcms web server doesn't like curl ...
     curlOpts = "--user-agent 'Mozilla/5.0'";

--- a/pkgs/tools/misc/colord-kde/default.nix
+++ b/pkgs/tools/misc/colord-kde/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ colord libX11 libXrandr lcms2 kdelibs ];
 
+  patches = [ ./fix_check_include_files.patch ];
+  patchFlags = [ "-p0" ];
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/tools/misc/colord-kde/fix_check_include_files.patch
+++ b/pkgs/tools/misc/colord-kde/fix_check_include_files.patch
@@ -1,0 +1,9 @@
+--- CMakeLists.txt.orig	2013-05-01 05:04:34.000000000 +1000
++++ CMakeLists.txt	2015-12-10 20:43:51.351800988 +1100
+@@ -9,6 +9,7 @@
+ include(FindPkgConfig)
+ include(KDE4Defaults)
++include(CheckIncludeFiles)
+ include(ConfigureChecks.cmake)
+ 
+ message(STATUS "X randr is required, found: " ${XRANDR_1_3_FOUND})

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip, fetchgit, bashCompletion
 , glib, polkit, pkgconfig, intltool, gusb, libusb1, lcms2, sqlite, systemd, dbus
 , automake, autoconf, libtool, gtk_doc, which, gobjectIntrospection, argyllcms
-, libgudev }:
+, libgudev, sane-backends }:
 
 stdenv.mkDerivation rec {
   name = "colord-1.2.12";
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--with-udevrulesdir=$out/lib/udev/rules.d"
+    "--enable-sane"
+    "--with-udevrulesdir=$(out)/lib/udev/rules.d"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--localstatedir=/var"
     "--disable-bash-completion"
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ glib polkit pkgconfig intltool gusb libusb1 lcms2 sqlite systemd dbus gobjectIntrospection
-                  bashCompletion argyllcms automake autoconf libgudev ];
+                  bashCompletion argyllcms automake autoconf libgudev sane-backends ];
 
   postInstall = ''
     mkdir -p $out/etc/bash_completion.d

--- a/pkgs/tools/misc/xiccd/default.nix
+++ b/pkgs/tools/misc/xiccd/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libX11, libXrandr, glib, colord }:
+
+stdenv.mkDerivation rec {
+  name = "xiccd-${version}";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "agalakhov";
+    repo = "xiccd";
+    rev = "v${version}";
+    sha256 = "17p3vngmmjk52r5p8y41s19nwp7w25bgff68ffd50zdlicd33rsy";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libX11 libXrandr glib colord ];
+
+  meta = with stdenv.lib; {
+    description = "X color profile daemon";
+    homepage = https://github.com/agalakhov/xiccd;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3871,6 +3871,8 @@ let
 
   xmpppy = pythonPackages.xmpppy;
 
+  xiccd = callPackage ../tools/misc/xiccd { };
+
   xorriso = callPackage ../tools/cd-dvd/xorriso { };
 
   xpf = callPackage ../tools/text/xml/xpf {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This should bring color management support to NixOS. We might want to enable it by default in GNOME3 and KDE{4,5} -- they have (supposedly) good integration with it and allow users to control it via their control panels. This would benefit even people who don't know anything about color management because it can load color profiles from monitors via EDID. I haven't however tested it in GNOME3/KDE -- instead I use XFCE + xiccd (a helper daemon for DEs without color management support).

Testing procedure:

a) Setup (in DEs this can be done via control panels):
1. Build with this enabled, log in into DE with color management support (or run xiccd)
2. `colormgr import-profile ${colord}/share/color/icc/colord/SwappedRedAndGreen.icc`;
3. `colormgr get-devices`;
4. `colormgr device-add-profile your_device_path imported_profile_path`;
5. `colormgr device-make-profile-default your_device_path imported_profile_path`.

b) Actual test:
1. Open GIMP and some image;
2. Preferences -> Color management;
3. Tick and untick "Attempt to use system color profile", verify that color distorts.

c) Teardown:
1. `colormgr delete-profile imported_profile_path`.

cc @lethalman (GNOME)
cc @ttuegel (KDE, notice that `colord-kde` for KDE4 is broken now)
