### PR TITLE
pygmentex: init at 0.8

### DIFF
--- a/pkgs/tools/typesetting/pygmentex/default.nix
+++ b/pkgs/tools/typesetting/pygmentex/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchzip, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  name = "pygmentex-${version}";
+  version = "0.8";
+
+  src = fetchzip {
+      url = "http://mirrors.ctan.org/macros/latex/contrib/pygmentex.zip";
+      sha256 = "1nm19pvhlv51mv2sdankndhw64ys9r7ch6szzd6i4jz8zr86kn9v";
+  };
+
+  pythonPath = [ python2Packages.pygments python2Packages.chardet ];
+
+  buildPhase = ":";
+  
+  doCheck = false;
+  
+  installPhase = ''
+  
+    mkdir -p $out/bin
+    cp -a pygmentex.py $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.ctan.org/pkg/pygmentex;
+    description = "Auxiliary tool for typesetting code listings in LaTeX documents using Pygments";
+    longDescription = ''
+      PygmenTeX is a Python-based LaTeX package that can be used for
+      typesetting code listings in a LaTeX document using Pygments.
+
+      Pygments is a generic syntax highlighter for general use in all kinds of
+      software such as forum systems, wikis or other applications that need to
+      prettify source code.
+
+      This package installs just the script needed to process code listings
+      snippets extracted from the a LaTeX document by the pygmentex LaTeX
+      package. In order to use it effectivelly the texlive package pygmentex
+      also has to be installed. This can be done by adding pygmentex to
+      texlive.combine.
+    '';
+    license = licenses.lppl13c;
+    maintainers = with maintainers; [ romildo ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3002,6 +3002,8 @@ let
 
   pydb = callPackage ../development/tools/pydb { };
 
+  pygmentex = callPackage ../tools/typesetting/pygmentex { };
+
   pystringtemplate = callPackage ../development/python-modules/stringtemplate { };
 
   pythonDBus = dbus_python;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #10885 

cc @vcunat 
