### PR TITLE
plex: plexpass: 0.9.15.6.1714 -> 0.9.16.0.1754

### DIFF
--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -5,9 +5,9 @@
 
 let
   plexpkg = if enablePlexPass then {
-    version = "0.9.15.6.1714";
-    vsnHash = "7be11e1";
-    sha256 = "1kyk41qnbm8w5bvnisp3d99cf0r72wvlggfi9h4np7sq4p8ksa0g";
+    version = "0.9.16.0.1754";
+    vsnHash = "23623fb";
+    sha256 = "0yn5bqpgz28ig6y3qw3zxzm8gfvwaw7nh5krmav8h1ryws98cc6g";
   } else {
     version = "0.9.15.6.1714";
     vsnHash = "7be11e1";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS) **no**
- [x] Built on platform(s): NixOS / OSX / Linux **NixOS (aka Linux)**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` **n/a**
- [x] Tested execution of all binary files (usually in `./result/bin/`) **yes**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). **yes**
###### More

(It already uses HTTPS as well)
