### PR TITLE
pkgs.darktable: 2.0.0 -> 2.0.2

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Virtual lighttable and darkroom for photographers";
-    homepage = http://www.darktable.org;
+    homepage = https://www.darktable.org;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu maintainers.rickynils maintainers.flosse ];

--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -11,12 +11,12 @@
 assert stdenv ? glibc;
 
 stdenv.mkDerivation rec {
-  version = "2.0.0";
+  version = "2.0.2";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "1cbwvzqn3158cy7r499rdwipx7fpb30lrrvh6jy5a4xvpcjzbwnl";
+    sha256 = "0014j73sy956xqdhd4jrxvbamildqqadx8hmagrbiah8xda67skm";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

_Please note, that points are not mandatory, but rather desired._

darktable-2.0.1 and darktable-2.0.2 are two bugfix releases:

http://www.darktable.org/2016/02/darktable-2-0-1-released/
http://www.darktable.org/2016/03/darktable-2-0-2-released/
