### PR TITLE
apt-cacher-ng: 0.8.6 -> 0.8.9

### DIFF
--- a/pkgs/servers/http/apt-cacher-ng/default.nix
+++ b/pkgs/servers/http/apt-cacher-ng/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "apt-cacher-ng-${version}";
-  version = "0.8.6";
+  version = "0.8.9";
 
   src = fetchurl {
     url = "http://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_${version}.orig.tar.xz";
-    sha256 = "0044dfks8djl11fs28jj8894i4rq424xix3d3fkvzz2i6lnp8nr5";
+    sha256 = "15zkacy8n6fiklqpdk139pa7qssynrr9akv5h54ky1l53n0k70m6";
   };
 
   NIX_LDFLAGS = "-lpthread";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): OSX 
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
