### PR TITLE
orage: init at 4.12.1

### DIFF
--- a/pkgs/desktops/xfce/applications/orage.nix
+++ b/pkgs/desktops/xfce/applications/orage.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, pkgconfig, bison, flex, intltool, gtk, libical, dbus_glib
+, libnotify, popt, xfce
+}:
+
+stdenv.mkDerivation rec {
+  name = "${p_name}-${ver_maj}.${ver_min}";
+  p_name  = "orage";
+  ver_maj = "4.12";
+  ver_min = "1";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/apps/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "0qlhvnl2m33vfxqlbkic2nmfpwyd4mq230jzhs48cg78392amy9w";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool bison flex ];
+  
+  buildInputs = [ gtk libical dbus_glib libnotify popt xfce.libxfce4util
+    xfce.xfce4panel ];
+
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache ";
+
+  meta = {
+    homepage = http://www.xfce.org/projects/;
+    description = "A simple calendar application with reminders";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -51,6 +51,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
 
   gigolo          = callPackage ./applications/gigolo.nix { };
   mousepad        = callPackage ./applications/mousepad.nix { };
+  orage           = callPackage ./applications/orage.nix { };
   parole          = callPackage ./applications/parole.nix { };
   ristretto       = callPackage ./applications/ristretto.nix { };
   terminal        = xfce4terminal; # it has changed its name


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
