### PR TITLE
[closure-size] Fix evaluation errors on Darwin

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       substituteInPlace  $f --replace egrep         ${gnugrep}/bin/egrep
       substituteInPlace  $f --replace groff         ${groff}/bin/groff
       substituteInPlace  $f --replace gunzip        ${gzip}/bin/gunzip
-      substituteInPlace  $f --replace iconv         ${libiconv.bin}/bin/iconv
+      substituteInPlace  $f --replace iconv         ${libiconv.bin or libiconv}/bin/iconv
       substituteInPlace  $f --replace lyx           ${lyx}/bin/lyx
       substituteInPlace  $f --replace pdftotext     ${poppler_utils.out}/bin/pdftotext
       substituteInPlace  $f --replace pstotext      ${ghostscript}/bin/ps2ascii 

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
      '' else "");
 
   configurePhase = ''
-    ./configure --prefix=$out --with-gmp-libraries=${gmp.out}/lib --with-gmp-includes=${gmp.dev}/include
+    ./configure --prefix=$out --with-gmp-libraries=${gmp.out}/lib --with-gmp-includes=${gmp.dev or gmp}/include
   '';
 
   # Stripping combined with patchelf breaks the executables (they die

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       ./libressl.patch
       (substituteAll {
         src = ./dlopen-absolute-paths.diff;
-        cups = cups.out;
+        cups = if cups != null then cups.out else null;
         icu = icu.out;
         libXfixes = libXfixes.out;
         glibc = stdenv.cc.libc.out;

--- a/pkgs/os-specific/linux/module-init-tools/default.nix
+++ b/pkgs/os-specific/linux/module-init-tools/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, docbook2x, docbook_sgml_dtd_41 }:
 
+assert (stdenv.lib.elem stdenv.system stdenv.lib.platforms.linux);
+
 stdenv.mkDerivation {
   name = "module-init-tools-3.16";
 
@@ -31,5 +33,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://www.kernel.org/pub/linux/utils/kernel/module-init-tools/;
     description = "Tools for loading and managing Linux kernel modules";
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -62,7 +62,7 @@ rec {
       cp -d ${openssl.out}/lib/*.dylib $out/lib
 
       cp -d ${gnugrep.pcre.out}/lib/libpcre*.dylib $out/lib
-      cp -d ${libiconv.lib}/lib/lib*.dylib $out/lib
+      cp -d ${libiconv.lib or libiconv}/lib/lib*.dylib $out/lib
       cp -d ${gettext}/lib/libintl*.dylib $out/lib
       chmod +x $out/lib/libintl*.dylib
       cp -d ${ncurses.lib}/lib/libncurses*.dylib $out/lib

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     [ ( substituteAll {
         src = ./nix-purity.patch;
         inherit libpcap;
-        glibc = stdenv.cc.libc.dev;
+        glibc = stdenv.cc.libc.dev or stdenv.cc.libc;
       })
       # Without nonpriv.patch, pppd --version doesn't work when not run as
       # root.


### PR DESCRIPTION
@vcunat This fixes all the Darwin evaluation errors on closure-size. Could you take a quick look to see if this is correct? There is a change in `stdenv`. I don't believe it's a mass-rebuild because it shouldn't change the hash, but I thought you should take a look first.
