### PR TITLE
pax-utils: 1.1.1 -> 1.1.6

### DIFF
--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -2,15 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "pax-utils-${version}";
-  version = "1.1.1";
+  version = "1.1.6";
 
   src = fetchurl {
     url = "http://dev.gentoo.org/~vapier/dist/${name}.tar.xz";
-    sha256 = "0gldvyr96jgbcahq7rl3k4krzyhvlz95ckiqh3yhink56s5z58cy";
+    sha256 = "04hvsizzspfzfq6hhfif7ya9nwsc0cs6z6n2bq1zfh7agd8nqhzm";
   };
 
   makeFlags = [
-    "DESTDIR=$(out)"
     "PREFIX=$(out)"
   ];
 

--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.1.6";
 
   src = fetchurl {
-    url = "http://dev.gentoo.org/~vapier/dist/${name}.tar.xz";
+    url = "https://dev.gentoo.org/~vapier/dist/${name}.tar.xz";
     sha256 = "04hvsizzspfzfq6hhfif7ya9nwsc0cs6z6n2bq1zfh7agd8nqhzm";
   };
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A suite of tools for PaX/grsecurity";
-    homepage    = "http://dev.gentoo.org/~vapier/dist/";
+    homepage    = "https://dev.gentoo.org/~vapier/dist/";
     license     = licenses.gpl2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Also fixes install path, used to end up in $out/$out/bin thus was not available in $PATH

cc @thoughtpolice
