### PR TITLE
kdevelop: 4.7.1 -> 4.7.3

### DIFF
--- a/pkgs/applications/editors/kdevelop/default.nix
+++ b/pkgs/applications/editors/kdevelop/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "4.7.1";
+  version = "4.7.3";
   pname = "kdevelop";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "e3ad5377f53739a67216d37cda3f88c03f8fbb0c96e2a9ef4056df3c124e95c1";
+    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.bz2";
+    sha256 = "9db388d1c8274da7d168c13db612c7e94ece7815757b945b0aa0371620a06b35";
   };
 
   buildInputs = [ kdevplatform kdebase_workspace okteta qjson ];
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig automoc4 shared_mime_info gettext perl ];
 
   propagatedUserEnvPkgs = [ kdevplatform kate konsole kde_runtime oxygen_icons ];
+
+  patches = [ ./gettext.patch ];
 
   NIX_CFLAGS_COMPILE = "-I${okteta}/include/KDE";
 
@@ -31,6 +33,6 @@ stdenv.mkDerivation rec {
         programing languages. It is based on KDevPlatform, KDE and Qt
         libraries and is under development since 1998.
       '';
-    homepage = http://www.kdevelop.org;
+    homepage = https://www.kdevelop.org;
   };
 }

--- a/pkgs/applications/editors/kdevelop/gettext.patch
+++ b/pkgs/applications/editors/kdevelop/gettext.patch
@@ -1,0 +1,8 @@
+diff -urN kdevelop-4.7.3.orig/po/CMakeLists.txt kdevelop-4.7.3/po/CMakeLists.txt
+--- kdevelop-4.7.3.orig/po/CMakeLists.txt	2016-03-04 23:29:09.411886565 +0100
++++ kdevelop-4.7.3/po/CMakeLists.txt	2016-03-04 23:28:35.108451713 +0100
+@@ -1,3 +1,4 @@
++cmake_policy(SET CMP0002 OLD)
+ find_package(Gettext REQUIRED)
+ if (NOT GETTEXT_MSGMERGE_EXECUTABLE)
+ MESSAGE(FATAL_ERROR "Please install msgmerge binary")

--- a/pkgs/development/libraries/kdevplatform/default.nix
+++ b/pkgs/development/libraries/kdevplatform/default.nix
@@ -1,19 +1,15 @@
-{ stdenv, fetchurl, fetchpatch, cmake, kdelibs, subversion, qt4, automoc4, phonon,
+{ stdenv, fetchurl, cmake, kdelibs, subversion, qt4, automoc4, phonon,
   gettext, pkgconfig, apr, aprutil, boost, qjson, grantlee }:
 
 stdenv.mkDerivation rec {
-  name = "kdevplatform-1.7.1";
+  name = "kdevplatform-1.7.3";
 
   src = fetchurl {
-    url = "mirror://kde/stable/kdevelop/4.7.1/src/${name}.tar.xz";
-    sha256 = "dfd8953aec204f04bd949443781aa0f6d9d58c40f73027619a168bb4ffc4b1ac";
+    url = "mirror://kde/stable/kdevelop/4.7.3/src/${name}.tar.bz2";
+    sha256 = "195134bde11672de38838f4b341ed28c58042374ca12beedacca9d30e6ab4a2b";
   };
 
-  patches = [(fetchpatch {
-    name = "svn-1.9.patch";
-    url = "https://git.reviewboard.kde.org/r/124783/diff/raw/";
-    sha256 = "1ixll5pvynb3l4znc65d82a5bj2s3c7c7is585s2wdpfzjgl5ay0";
-  })];
+  patches = [ ./gettext.patch ];
 
   propagatedBuildInputs = [ kdelibs qt4 phonon ];
   buildInputs = [ apr aprutil subversion boost qjson grantlee ];
@@ -31,5 +27,6 @@ stdenv.mkDerivation rec {
       IDE-like programs. It is programing-language independent, and is planned
       to be used by programs like: KDevelop, Quanta, Kile, KTechLab ... etc."
     '';
+    homepage = https://www.kdevelop.org;
   };
 }

--- a/pkgs/development/libraries/kdevplatform/gettext.patch
+++ b/pkgs/development/libraries/kdevplatform/gettext.patch
@@ -1,0 +1,8 @@
+diff -urN kdevplatform-1.7.3.orig/po/CMakeLists.txt kdevplatform-1.7.3/po/CMakeLists.txt
+--- kdevplatform-1.7.3.orig/po/CMakeLists.txt	2016-03-04 23:25:30.102112596 +0100
++++ kdevplatform-1.7.3/po/CMakeLists.txt	2016-03-04 23:26:06.242570024 +0100
+@@ -1,3 +1,4 @@
++cmake_policy(SET CMP0002 OLD)
+ find_package(Gettext REQUIRED)
+ if (NOT GETTEXT_MSGMERGE_EXECUTABLE)
+ MESSAGE(FATAL_ERROR "Please install msgmerge binary")


### PR DESCRIPTION
Tested on channels/nixos-15.09 but not this PR as-is (I have cherry-picked it to master).

The new patches fix some cmake error having something to do with a target name conflict related to gettext.
