### PR TITLE
[wip] Eval darwin

### DIFF
--- a/pkgs/applications/audio/baudline/default.nix
+++ b/pkgs/applications/audio/baudline/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libXmu, libXt, libX11, libXext, libXxf86vm, jack
-, makeWrapper
+, makeWrapper, glibc
 }:
 
 let
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
     cp -r . "$out/libexec/baudline/"
 
-    interpreter="$(echo ${stdenv.glibc}/lib/ld-linux*)"
+    interpreter="$(echo ${glibc}/lib/ld-linux*)"
     for prog in "$out"/libexec/baudline/baudline*; do
         patchelf --interpreter "$interpreter" "$prog"
         ln -sr "$prog" "$out/bin/"

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -4,9 +4,8 @@ let
   version = "11.0.53191";
 
   ld32 =
-    if stdenv.system == "i686-linux" then "${stdenv.cc}/nix-support/dynamic-linker"
-    else if stdenv.system == "x86_64-linux" then "${stdenv.cc}/nix-support/dynamic-linker-m32"
-    else abort "Unsupported architecture";
+    if stdenv.system == "x86_64-linux" then "${stdenv.cc}/nix-support/dynamic-linker-m32"
+    else "${stdenv.cc}/nix-support/dynamic-linker";
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
 
   mkLdPath = ps: lib.makeLibraryPath (with ps; [ qt4 dbus alsaLib ]);

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -72,8 +72,7 @@ stdenv.mkDerivation rec {
   ]);
 
   ldpath = stdenv.lib.makeLibraryPath buildInputs
-    + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPath "lib64" buildInputs);
+    + stdenv.lib.optionalString (stdenv.system == "x86_64-linux") (":" + stdenv.lib.makeSearchPath "lib64" buildInputs);
 
   phases = "unpackPhase installPhase fixupPhase";
 

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -11,8 +11,7 @@ let
 
   fetch = callPackage ./fetch.nix { username = username; password = password; };
   arch = if stdenv.system == "x86_64-linux" then "x64"
-         else if stdenv.system == "i686-linux" then "x32"
-         else abort "Unsupported platform";
+         else "x32";
 
   variants = {
     x64 = {

--- a/pkgs/misc/cups/drivers/samsung/default.nix
+++ b/pkgs/misc/cups/drivers/samsung/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, patchelf, cups, libusb, libxml2 }:
+{ stdenv, fetchurl, patchelf, cups, libusb, libxml2, glibc }:
 
 let
 
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
     my_patchelf \
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      --set-rpath ${cups}/lib:$(cat $NIX_CC/nix-support/orig-cc)/lib:${stdenv.glibc}/lib \
+      --set-rpath ${cups}/lib:$(cat $NIX_CC/nix-support/orig-cc)/lib:${glibc}/lib \
       - ${arch}/{pstosecps,rastertospl,smfpnetdiscovery}
 
     mkdir -p $out/etc/sane.d/dll.d/
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/lib
     my_patchelf \
-      --set-rpath $(cat $NIX_CC/nix-support/orig-cc)/lib:${stdenv.glibc}/lib \
+      --set-rpath $(cat $NIX_CC/nix-support/orig-cc)/lib:${glibc}/lib \
       - ${arch}/libscmssc.so*
     install -m755 ${arch}/libscmssc.so* $out/lib
 
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/lib/sane
     my_patchelf \
-      --set-rpath $(cat $NIX_CC/nix-support/orig-cc)/lib:${stdenv.glibc}/lib:${libusb}/lib:${libxml2}/lib \
+      --set-rpath $(cat $NIX_CC/nix-support/orig-cc)/lib:${glibc}/lib:${libusb}/lib:${libxml2}/lib \
       - ${arch}/libsane-smfp.so*
     install -m755 ${arch}/libsane-smfp.so* $out/lib/sane
     ln -s libsane-smfp.so.1.0.1 $out/lib/sane/libsane-smfp.so.1


### PR DESCRIPTION
There are a few instances of "stdenv.glibc" in top-level that will cause 

``` sh
nix-env -qaP \* --drv-path --out-path
```

to fail. I'm trying to get those to work on darwin or else you get lots of

```
error: attribute ‘glibc’ missing, at /Users/matthew/Projects/nixpkgs/pkgs/applications/audio/baudline/default.nix:39:27
(use ‘--show-trace’ to show detailed location information)
```
