### PR TITLE
libzen: 0.4.32 -> 0.4.33

### DIFF
--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -1,26 +1,25 @@
-{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig }:
+{ stdenv, fetchurl, autoreconfHook }:
 
-let version = "0.4.32"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  version = "0.4.33";
   name = "libzen-${version}";
   src = fetchurl {
-    url = "http://mediaarea.net/download/source/libzen/${version}/libzen_${version}.tar.bz2";
-    sha256 = "0rhbiaywij6jj8d7vkc4v7y21ic1kv9fbn9lk82mm12yjwzlhhyd";
+    url = "https://mediaarea.net/download/source/libzen/${version}/libzen_${version}.tar.bz2";
+    sha256 = "0py5iagajz6m5zh26svkjyy85k1dmyhi6cdbmc3cb56a4ix1k2d2";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook ];
   configureFlags = [ "--enable-shared" ];
 
   sourceRoot = "./ZenLib/Project/GNU/Library/";
 
   preConfigure = "sh autogen.sh";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Shared library for libmediainfo and mediainfo";
-    homepage = http://mediaarea.net/;
-    license = stdenv.lib.licenses.bsd2;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    homepage = https://mediaarea.net/;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.devhell ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested locally.

From the changelog:

```
Version 0.4.33, 2016-02-29

x File::Open(): using now FILE_APPEND_DATA on windows when append mode
  is requested
x File::Open(): accept file names with * and ? characters on non-Windows
  platforms
x Better MinGW and CygWin compatibility
x autogen.sh: Adding missing shebang
x Dir/Create: create the parents directory if not existing
```
