### PR TITLE
{lib}mediainfo{-gui}: 0.7.82 -> 0.7.83

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -1,28 +1,29 @@
-{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, wxGTK, desktop_file_utils, libSM, imagemagick }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, wxGTK
+, desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.82";
+  version = "0.7.83";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0ivvmxx93aldfbms6wg46x9npghg304j2zxl5i70m710gybjr232";
+    sha256 = "0d8mph9lbg2lw0ccg1la0kqhbisra8q9rzn195lncch5cia5zyg7";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo wxGTK desktop_file_utils libSM imagemagick ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libzen libmediainfo wxGTK desktop_file_utils libSM
+                  imagemagick ];
 
   sourceRoot = "./MediaInfo/Project/GNU/GUI/";
 
-  preConfigure = "sh autogen.sh";
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "Supplies technical and tag information about a video or audio file (GUI version)";
     longDescription = ''
       MediaInfo is a convenient unified display of the most relevant technical
       and tag data for video and audio files.
     '';
     homepage = http://mediaarea.net/;
-    license = stdenv.lib.licenses.bsd2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.devhell ];
   };
 }

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, libmediainfo, zlib }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.82";
+  version = "0.7.83";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0ivvmxx93aldfbms6wg46x9npghg304j2zxl5i70m710gybjr232";
+    sha256 = "0d8mph9lbg2lw0ccg1la0kqhbisra8q9rzn195lncch5cia5zyg7";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig libzen libmediainfo zlib ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libzen libmediainfo zlib ];
 
   sourceRoot = "./MediaInfo/Project/GNU/CLI/";
 
   configureFlags = [ "--with-libmediainfo=${libmediainfo}" ];
-  preConfigure = "sh autogen.sh";
 
   meta = with stdenv.lib; {
     description = "Supplies technical and tag information about a video or audio file";

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,29 +1,29 @@
-{ stdenv, fetchurl, automake, autoconf, libtool, pkgconfig, libzen, zlib }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.82";
+  version = "0.7.83";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "1mqmk1q2phwqwrak54jc9hfwjllhhr4nqyigisrh9rcvd6wx6r86";
+    sha256 = "0kl5x07j3jp5mnmhpjvdq0a2nnlgvqnhwar0xalvg3b3msdf8417";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig libzen zlib ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libzen zlib ];
 
   sourceRoot = "./MediaInfoLib/Project/GNU/Library/";
 
   configureFlags = [ "--enable-shared" ];
-  preConfigure = "sh autogen.sh";
 
   postInstall = ''
     install -vD -m 644 libmediainfo.pc "$out/lib/pkgconfig/libmediainfo.pc"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Shared library for mediainfo";
     homepage = http://mediaarea.net/;
-    license = stdenv.lib.licenses.bsd2;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.devhell ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built and tested locally.

From the changelog:

``````
Version 0.7.83, 2016-02-29

  + HEVC: Maximum Content Light Level (MaxCLL) and Maximum Frame-Average
     Light Level (MaxFALL), metadata mandated by CEA-861.3 for HDR support
  + HEVC: Mastering display color primaries and luminance (based on SMPTE
    ST 2084), metadata mandated by CEA-861.3 for HDR support
  + HEVC: SMPTE ST 2048 and SMPTE ST 428-1 transfer characteristics
  + HEVC: Chroma subsampling location (indication of the location type
    described in the HEVC spec)
  + MPEG-TS: ATSC Modulation Mode (Analog, SCTE_mode_1 aka 64-QAM,
    SCTE_mode_2 aka 256-QAM, 8-VSB, 16-VSB)
  + #B981, MP4: support of buggy file having "hint" SubType
  x HLS: better handling of media playlists having EXT-X-BYTERANGE
    ```
``````
