### PR TITLE
curl: simplify packaging

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchurl, pkgconfig, perl
-, http2Support ? true, libnghttp2
+, c-aresSupport ? false, c-ares ? null
+, gssSupport ? false, gss ? null
+, http2Support ? false, libnghttp2 ? null
 , idnSupport ? false, libidn ? null
 , ldapSupport ? false, openldap ? null
-, zlibSupport ? false, zlib ? null
-, sslSupport ? false, openssl ? null
 , scpSupport ? false, libssh2 ? null
-, gssSupport ? false, gss ? null
-, c-aresSupport ? false, c-ares ? null
+, sslSupport ? false, openssl ? null
+, zlibSupport ? false, zlib ? null
 }:
 
+assert c-aresSupport -> c-ares != null;
 assert http2Support -> libnghttp2 != null;
 assert idnSupport -> libidn != null;
 assert ldapSupport -> openldap != null;
-assert zlibSupport -> zlib != null;
-assert sslSupport -> openssl != null;
 assert scpSupport -> libssh2 != null;
-assert c-aresSupport -> c-ares != null;
+assert sslSupport -> openssl != null;
+assert zlibSupport -> zlib != null;
 
 stdenv.mkDerivation rec {
   name = "curl-7.47.1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -364,7 +364,8 @@ let
 
   # `fetchurl' downloads a file from the network.
   fetchurl = import ../build-support/fetchurl {
-    inherit curl stdenv;
+    inherit stdenv;
+    curl = curlMinimal;
   };
 
   # fetchurlBoot is used for curl and its dependencies in order to
@@ -1285,18 +1286,20 @@ let
 
   cudatoolkit = cudatoolkit7;
 
-  curlFull = curl.override {
-    idnSupport = true;
-    ldapSupport = true;
-    gssSupport = true;
+  # Used for bootstrap
+  curlMinimal = callPackage ../tools/networking/curl rec {
+    fetchurl = fetchurlBoot;
+    sslSupport = true;
+    zlibSupport = true;
   };
 
-  curl = callPackage ../tools/networking/curl rec {
-    fetchurl = fetchurlBoot;
+  curl = curlMinimal.override rec {
+    c-aresSupport = true;
+    gssSupport = true;
     http2Support = !stdenv.isDarwin;
-    zlibSupport = true;
-    sslSupport = zlibSupport;
-    scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
+    idnSupport = true;
+    ldapSupport = true;
+    scpSupport = !stdenv.isSunOS && !stdenv.isCygwin;
   };
 
   curl3 = callPackage ../tools/networking/curl/7.15.nix rec {
@@ -8244,7 +8247,6 @@ let
   nghttp2 = callPackage ../development/libraries/nghttp2 { };
   libnghttp2 = nghttp2.override {
     prefix = "lib";
-    fetchurl = fetchurlBoot;
   };
 
   nix-plugins = callPackage ../development/libraries/nix-plugins {
@@ -16416,6 +16418,7 @@ aliases = with self; rec {
   conkerorWrapper = conkeror; # added 2015-01
   cool-old-term = cool-retro-term; # added 2015-01-31
   cupsBjnp = cups-bjnp; # added 2016-01-02
+  curlFull = curl; # added 2016-03-11
   cv = progress; # added 2015-09-06
   dwarf_fortress = dwarf-fortress; # added 2016-01-23
   dwbWrapper = dwb; # added 2015-01


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Would something like that make sense ? Previously the curl package was also including scp, which is only available over HTTPS. So if fetchurlBoot didn't have SSL support baked-in it would fail the whole chain.

curlMinimal is for the bootstrap and only includes HTTP(S) and FTP.

curl is now the full experience with all the protocols enabled.
