### PR TITLE
Apache HTTP/2

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, perl, zlib, apr, aprutil, pcre, libiconv
 , proxySupport ? true
 , sslSupport ? true, openssl
+, http2Support ? true, libnghttp2
 , ldapSupport ? true, openldap
 , libxml2Support ? true, libxml2
 , luaSupport ? false, lua5
@@ -12,6 +13,7 @@ in
 
 assert sslSupport -> aprutil.sslSupport && openssl != null;
 assert ldapSupport -> aprutil.ldapSupport && openldap != null;
+assert http2Support -> libnghttp2 != null;
 
 stdenv.mkDerivation rec {
   version = "2.4.18";
@@ -25,6 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [perl] ++
     optional ldapSupport openldap ++    # there is no --with-ldap flag
     optional libxml2Support libxml2 ++
+    optional http2Support libnghttp2 ++
     optional stdenv.isDarwin libiconv;
 
   # Required for ‘pthread_cancel’.
@@ -44,6 +47,7 @@ stdenv.mkDerivation rec {
     --enable-cgi
     ${optionalString proxySupport "--enable-proxy"}
     ${optionalString sslSupport "--enable-ssl --with-ssl=${openssl}"}
+    ${optionalString http2Support "--enable-http2 --with-nghttp2=${libnghttp2}"}
     ${optionalString luaSupport "--enable-lua --with-lua=${lua5}"}
     ${optionalString libxml2Support "--with-libxml2=${libxml2}/include/libxml2"}
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9461,7 +9461,8 @@ let
   };
 
   apacheHttpd_2_4 = lowPrio (callPackage ../servers/http/apache-httpd/2.4.nix {
-    sslSupport = true;
+    # 1.0.2+ for ALPN support
+    openssl = openssl_1_0_2;
   });
 
   apacheHttpdPackagesFor = apacheHttpd: self: let callPackage = newScope self; in {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`). https://zimbatm.com now supports http/2
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

In NixOS you can enable HTTP/2 like this:

```
services.httpd.extraModules = [ "http2" ];
services.httpd.extraConfig = ''
  Protocols h2 http/1.1
'';
```

And configure SSL.
