### PR TITLE
python-sipsimple: 2.6.0 -> 3.0.0 (with all dependencies)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pythonPackages, pyqt4, cython, libvncserver, zlib, twisted
-, gnutls, libvpx }:
+, gnutls, libvpx, makeDesktopItem }:
 
 pythonPackages.buildPythonApplication rec {
   name = "blink-${version}";
@@ -20,16 +20,30 @@ pythonPackages.buildPythonApplication rec {
 
   buildInputs = [ cython zlib libvncserver libvpx ];
 
+  desktopItem = makeDesktopItem {
+    name = "Blink";
+    exec = "blink";
+    comment = meta.description;
+    desktopName = "Blink";
+    icon = "blink";
+    genericName = "Instant Messaging";
+    categories = "Application;Internet;";
+  };
+
   postInstall = ''
     wrapProgram $out/bin/blink \
       --prefix LD_LIBRARY_PATH ":" ${gnutls}/lib
+    mkdir -p "$out/share/applications"
+    mkdir -p "$out/share/pixmaps"
+    cp "$desktopItem"/share/applications/* "$out/share/applications"
+    cp "$out"/share/blink/icons/blink.* "$out/share/pixmaps"
   '';
 
   meta = with stdenv.lib; {
     homepage = http://icanblink.com/;
-    description = "A state of the art, easy to use SIP client";
+    description = "A state of the art, easy to use SIP client for Voice, Video and IM";
     platforms = platforms.linux;
-    license = licenses.mit;
+    license = licenses.gplv3;
     maintainers = with maintainers; [ pSub ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -3,11 +3,11 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "blink-${version}";
-  version = "1.4.2";
+  version = "2.0.0";
   
   src = fetchurl {
     url = "http://download.ag-projects.com/BlinkQt/${name}.tar.gz";
-    sha256 = "0ia5hgwyg6cm393ik4ggzhcmc957ncswycs07ilwj6vrrzraxfk7";
+    sha256 = "07hvy45pavgkvdlh4wbz3shsxh4fapg96qlqmfymdi1nfhwghb05";
   };
 
   patches = [ ./pythonpath.patch ];

--- a/pkgs/applications/networking/instant-messengers/blink/pythonpath.patch
+++ b/pkgs/applications/networking/instant-messengers/blink/pythonpath.patch
@@ -1,14 +1,44 @@
-diff -rupN a/blink/resources.py b/blink/resources.py
---- a/blink/resources.py	2015-03-17 03:24:06.000000000 -0600
-+++ b/blink/resources.py	2015-04-07 22:52:06.101096413 -0600
-@@ -60,14 +60,7 @@ class Resources(object):
+--- blink-2.0.0/blink/resources.py	2016-03-09 14:39:07.000000000 +0100
++++ blink-2.0.0/blink/resources-patched.py	2016-03-12 21:34:14.965476623 +0100
+@@ -1,7 +1,10 @@
++# Copyright (C) 2010-2013 AG Projects. See LICENSE for details.
++#
+ 
+ """Provide access to Blink's resources"""
+ 
+-import __main__
++__all__ = ['ApplicationData', 'Resources', 'IconManager']
++
+ import imghdr
+ import os
+ import platform
+@@ -19,14 +22,10 @@
+ from blink.util import run_in_gui_thread
+ 
+ 
+-__all__ = ['ApplicationData', 'Resources', 'IconManager']
+-
+-
+ class DirectoryContextManager(unicode):
+     def __enter__(self):
+         self.directory = os.getcwdu()
+         os.chdir(self)
+-
+     def __exit__(self, type, value, traceback):
+         os.chdir(self.directory)
+ 
+@@ -61,18 +60,7 @@
      @classproperty
      def directory(cls):
          if cls._cached_directory is None:
--            if sys.path[0] == '':
--                application_directory = os.path.realpath('') # executed in interactive interpreter
+-            try:
+-                binary_directory = os.path.dirname(os.path.realpath(__main__.__file__))
+-            except AttributeError:
+-                if hasattr(sys, 'frozen'):
+-                    application_directory = os.path.dirname(os.path.realpath(sys.executable))
+-                else:
+-                    application_directory = os.path.realpath('')  # executed in interactive interpreter
 -            else:
--                binary_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
 -                if os.path.basename(binary_directory) == 'bin':
 -                    application_directory = os.path.dirname(binary_directory)
 -                else:
@@ -17,4 +47,3 @@ diff -rupN a/blink/resources.py b/blink/resources.py
              if os.path.exists(os.path.join(application_directory, 'resources', 'blink.ui')):
                  cls._cached_directory = os.path.join(application_directory, 'resources').decode(sys.getfilesystemencoding())
              else:
-Binary files a/blink/.resources.py.swp and b/blink/.resources.py.swp differ

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5695,8 +5695,8 @@ in modules // {
   gnutls = buildPythonPackage rec {
     name = "python-gnutls";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-gnutls/python-gnutls-2.0.1.tar.gz";
-      sha256 = "d8fb368c6a4dd58bc6cd5e61d4a12d119c4506fd344a371b3429b3ac2623b9ac";
+      url = "https://pypi.python.org/packages/source/p/python-gnutls/python-gnutls-3.0.0.tar.gz";
+      sha256 = "1yrdxcj5rzvz8iglircz6icvyggz5fmdcd010n6w3j60yp4p84kc";
     };
 
     propagatedBuildInputs = with self; [ pkgs.gnutls ];
@@ -13288,6 +13288,31 @@ in modules // {
     };
   };
 
+  python-otr = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "python-otr";
+    version = "1.2.0";
+
+    disabled = isPy3k;
+
+    src = pkgs.fetchFromGitHub {
+      owner = "AGProjects";
+      repo = pname;
+      rev = "release-" + version;
+      sha256 = "0p3b1n8jlxwd65gbk2k5007fkhdyjwcvr4982s42hncivxvabzzy";
+    };
+
+    propagatedBuildInputs = with self; [ zope_interface cryptography application gmpy2 ];
+
+    meta = {
+      description = "A pure python implementation of OTR";
+      homepage = https://github.com/AGProjects/otr;
+      license = licenses.lgpl21Plus;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ edwtjo ];
+    };
+  };
+
   ply = buildPythonPackage (rec {
     name = "ply-3.8";
 
@@ -19950,7 +19975,7 @@ in modules // {
       sha256 = "1q35kgz151rr99240jq55rs39y741m8shh9yihl3x95rkjxchji4";
     };
 
-    propagatedBuildInputs = with self; [ cython pkgs.openssl dns dateutil xcaplib msrplib lxml ];
+    propagatedBuildInputs = with self; [ cython pkgs.openssl dns dateutil xcaplib msrplib lxml python-otr ];
     buildInputs = with pkgs; [ alsaLib ffmpeg libv4l pkgconfig sqlite libvpx ];
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5252,16 +5252,18 @@ in modules // {
 
 
   eventlib = buildPythonPackage rec {
-    name = "python-eventlib-${version}";
-    version = "0.2.1";
+    pname = "python-eventlib";
+    name = "${pname}-${version}";
+    version = "0.2.2";
 
     # Judging from SyntaxError
     disabled = isPy3k;
 
-    src = pkgs.fetchurl {
-      url = "http://download.ag-projects.com/SipClient/${name}.tar.gz";
-      sha256 = "25224794420f430946fe46932718b521a6264903fe8c0ed3563dfdb844c623e7";
-    };
+    src = pkgs.fetchdarcs {
+      url = "http://devel.ag-projects.com/repositories/${pname}";
+      rev = "release-${version}";
+      sha256 = "1zxhpq8i4jwsk7wmfncqfm211hqikj3hp38cfv509924bi76wak8";
+    };  
 
     propagatedBuildInputs = with self; [ greenlet ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22213,12 +22213,15 @@ in modules // {
   };
 
   xcaplib = buildPythonPackage rec {
-    name = "python-xcaplib-${version}";
-    version = "1.1.0";
+    pname = "python-xcaplib";
+    name = "${pname}-${version}";
+    version = "1.2.0";
+    disabled = isPy3k;
 
-    src = pkgs.fetchurl {
-      url = "http://download.ag-projects.com/XCAP/${name}.tar.gz";
-      sha256 = "2f8ea6fe7d005104ef1d854aa87bd8ee85ca242a70cde42f409f8e5557f864b3";
+    src = pkgs.fetchdarcs {
+      url = "http://devel.ag-projects.com/repositories/${pname}";
+      rev = "release-${version}";
+      sha256 = "0vna5r4ihv7z1yx6r93954jqskcxky77znzy1m9dg9vna1dgwfdn";
     };
 
     propagatedBuildInputs = with self; [ eventlib application ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19942,12 +19942,12 @@ in modules // {
 
   sipsimple = buildPythonPackage rec {
     name = "sipsimple-${version}";
-    version = "2.6.0";
+    version = "3.0.0";
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
       url = "http://download.ag-projects.com/SipClient/python-${name}.tar.gz";
-      sha256 = "0xcyasas28q1ad1hgw4vd62b72mf1sng7xwfcls6dc05k9p3q8v3";
+      sha256 = "1q35kgz151rr99240jq55rs39y741m8shh9yihl3x95rkjxchji4";
     };
 
     propagatedBuildInputs = with self; [ cython pkgs.openssl dns dateutil xcaplib msrplib lxml ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -773,13 +773,18 @@ in modules // {
   };
 
   application = buildPythonPackage rec {
-    name = "python-application-${version}";
-    version = "1.5.0";
+    pname = "python-application";
+    name = "${pname}-${version}";
+    version = "2.0.2";
+    disabled = isPy3k;
 
-    src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-application/${name}.tar.gz";
-      sha256 = "9bc00c2c639bf633e2c5e08d4bf1bb5d7edaad6ccdd473692f0362df08f8aafc";
-    };
+    src = pkgs.fetchdarcs {
+      url = "http://devel.ag-projects.com/repositories/${pname}";
+      rev = "release-${version}";
+      sha256 = "19dszv44py8qrq0jcjdycxpa7z2p8hi3ijq9gnqdsazbbjzf9svn";
+    };  
+    buildInputs = with self; [ zope_interface ];
+
   };
 
   appnope = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11959,14 +11959,16 @@ in modules // {
   };
 
   msrplib = buildPythonPackage rec {
-    name = "python-msrplib-${version}";
-    version = "0.18.0";
+    pname = "python-msrplib";
+    name = "${pname}-${version}";
+    version = "0.19";
 
-    src = pkgs.fetchurl {
-      url = "http://download.ag-projects.com/MSRP/${name}.tar.gz";
-      sha256 = "0vp9g5p015g3f67rl4vz0qnn6x7hciry6nmvwf82h9h5rx11r43j";
-    };
-
+    src = pkgs.fetchdarcs {
+      url = "http://devel.ag-projects.com/repositories/${pname}";
+      rev = "release-${version}";
+      sha256 = "0jqvvssbwzq7bwqn3wrjfnpj8zb558mynn2visnlrcma6b57yhwd";
+    };  
+    
     propagatedBuildInputs = with self; [ eventlib application gnutls ];
   };
 


### PR DESCRIPTION
Upgraded 5 Python depencies for Blink Qt (now itself broken) to their current versions. Each dependency has a separate commit. 

Also, because upstream deletes tarballs, moved to directly fetching from the respective upstream darcs repository. One exception: sipsimple cannot yet be fetched from original darcs repo because there is a darcs get flag (--set-scripts-executable) that needs to be set according to [1], and fetchdarcs doesn't seem to be able to do that ...

[1] http://sipsimpleclient.org/projects/sipsimpleclient/wiki/SipInstallation
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @pSub : Blink 2.0.0 has been released, these dependencies are required. As old tarball has been removed upstream (as before), I intend to follow the similar recipe of moving to the upstream darcs repo (now building, will commit separately)
