### PR TITLE
uget: init at 2.0.5

### DIFF
--- a/pkgs/tools/networking/uget/default.nix
+++ b/pkgs/tools/networking/uget/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, pkgconfig, intltool, openssl, curl, libnotify, gstreamer,
+  gst_plugins_base, gst_plugins_good, gnome3, makeWrapper, aria2 ? null }:
+
+stdenv.mkDerivation rec {
+  name = "uget-${version}";
+  version = "2.0.5";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/urlget/${name}.tar.gz";
+    sha256 = "0cqz8cd8dyciam07w6ipgzj52zhf9q0zvg6ag6wz481sxkpdnfh3";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool makeWrapper ];
+  
+  buildInputs = [
+    openssl curl libnotify gstreamer gst_plugins_base gst_plugins_good
+    gnome3.gtk gnome3.dconf
+  ]
+  ++ (stdenv.lib.optional (aria2 != null) aria2);
+
+  enableParallelBuilding = true;
+  
+  preFixup = ''
+    wrapProgram $out/bin/uget-gtk \
+      ${stdenv.lib.optionalString (aria2 != null) ''--suffix PATH : "${aria2}/bin"''} \
+      --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
+      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Download manager using gtk+ and libcurl";
+    longDescription = ''
+      uGet is a VERY Powerful download manager application with a large
+      inventory of features but is still very light-weight and low on
+      resources, so don't let the impressive list of features scare you into
+      thinking that it "might be too powerful" because remember power is good
+      and lightweight power is uGet!
+    '';
+    license = licenses.lgpl21;
+    homepage = http://www.ugetdm.com;
+    maintainers = with maintainers; [ romildo ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3554,6 +3554,8 @@ let
 
   ufraw = callPackage ../applications/graphics/ufraw { };
 
+  uget = callPackage ../tools/networking/uget { };
+
   umlet = callPackage ../tools/misc/umlet { };
 
   unetbootin = callPackage ../tools/cd-dvd/unetbootin { };


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
