### PR TITLE
mjpg-streamer: update and add NixOS service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -254,6 +254,7 @@
       octoprint = 230;
       avahi-autoipd = 231;
       nntp-proxy = 232;
+      mjpg-streamer = 233;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -331,6 +331,7 @@
   ./services/networking/lambdabot.nix
   ./services/networking/libreswan.nix
   ./services/networking/mailpile.nix
+  ./services/networking/mjpg-streamer.nix
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix
   ./services/networking/mstpd.nix

--- a/pkgs/applications/video/mjpg-streamer/default.nix
+++ b/pkgs/applications/video/mjpg-streamer/default.nix
@@ -1,34 +1,31 @@
-{stdenv, fetchsvn, pkgconfig, libjpeg, imagemagick, libv4l}:
+{ stdenv, fetchFromGitHub, cmake, libjpeg }:
 
 stdenv.mkDerivation rec {
-  rev = "182";
-  name = "mjpg-streamer-${rev}";
+  name = "mjpg-streamer-${version}";
+  version = "2016-03-08";
 
-  src = fetchsvn {
-    url = https://mjpg-streamer.svn.sourceforge.net/svnroot/mjpg-streamer/mjpg-streamer;
-    inherit rev;
-    sha256 = "008k2wk6xagprbiwk8fvzbz4dd6i8kzrr9n62gj5i1zdv7zcb16q";
+  src = fetchFromGitHub {
+    owner = "jacksonliam";
+    repo = "mjpg-streamer";
+    rev = "4060cb64e3557037fd404d10e1c1d076b672e9e8";
+    sha256 = "0g7y832jsz4ylmq9qp2l4fq6bm8l6dhsbi60fr5jfqpx4l0pia8m";
   };
 
-  patchPhase = ''
-    substituteInPlace Makefile "make -C plugins\/input_gspcav1" "# make -C plugins\/input_gspcav1"
-    substituteInPlace Makefile "cp plugins\/input_gspcav1\/input_gspcav1.so" "# cp plugins\/input_gspcav1\/input_gspcav1.so"
+  prePatch = ''
+    cd mjpg-streamer-experimental
   '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libjpeg ];
 
   postFixup = ''
-    patchelf --set-rpath "$(patchelf --print-rpath $out/bin/mjpg_streamer):$out/lib:$out/lib/plugins" $out/bin/mjpg_streamer
+    patchelf --set-rpath "$(patchelf --print-rpath $out/bin/mjpg_streamer):$out/lib/mjpg-streamer" $out/bin/mjpg_streamer
   '';
 
-  makeFlags = "DESTDIR=$(out)";
-
-  preInstall = ''
-    mkdir -p $out/{bin,lib}
-  '';
-
-  buildInputs = [ pkgconfig libjpeg imagemagick libv4l ];
-  
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://sourceforge.net/projects/mjpg-streamer/;
     description = "MJPG-streamer takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software";
+    platforms = platforms.linux;
+    licenses = licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
