### PR TITLE
Nghttp2 1.8.0

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -34,12 +34,12 @@ let
 in
 stdenv.mkDerivation rec {
   name = "${prefix}nghttp2-${version}";
-  version = "1.7.1";
+  version = "1.8.0";
 
   # Don't use fetchFromGitHub since this needs a bootstrap curl
   src = fetchurl {
     url = "http://http.debian.net/debian/pool/main/n/nghttp2/nghttp2_${version}.orig.tar.bz2";
-    sha256 = "0nbrww5gyjn4il33wz5b4sql5nifi12y2jbkmfbvxwlxlywm48kf";
+    sha256 = "10xz3s624w208pr9xgm4ammc8bc5mi17vy4357hjfd5vmmp5m8b0";
   };
 
   # Configure script searches for a symbol which does not exist in jemalloc on Darwin


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

nghttp2 is a dependency of curl so I expect a mass rebuild
