### PR TITLE
haskell-hs-blake2: fix dependency on libb2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -46,6 +46,9 @@ self: super: {
   # The package doesn't compile with ruby 1.9, which is our default at the moment.
   hruby = super.hruby.override { ruby = pkgs.ruby_2_1; };
 
+  # help blake finding its native library
+  hs-blake2 = super.hs-blake2.override { b2 = pkgs.libb2; };
+
   # Use the default version of mysql to build this package (which is actually mariadb).
   mysql = super.mysql.override { mysql = pkgs.mysql.lib; };
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

`hs-blake2` currently wrongly depends on `pkgs.b2` which is an application for backblazes storage service. This patch overrides it to link against its correct native library `pkgs.libb2`.

I've not found out how to regenerate all Haskell packages. `nix-build pkgs/development/haskell-modules/generate-hackage-package-set.nix` complains about missing `bootsrap` attribute. That's why this patch is untested. I hope I got everything right though.

cc @peti.
