### PR TITLE
cuter: init at 0.1

### DIFF
--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -1,0 +1,43 @@
+{stdenv, autoconf, which, writeText, makeWrapper, fetchFromGitHub, erlang,
+  erlangPackages, z3, python27 }:
+
+stdenv.mkDerivation rec {
+    name = "cuter";
+    version = "0.1";
+
+    src = fetchFromGitHub {
+        owner = "aggelgian";
+        repo = "cuter";
+        rev = "v${version}";
+        sha256 = "1ax1pj6ji4w2mg3p0nh2lzmg3n9mgfxk4cf07pll51yrcfpfrnfv";
+    };
+
+    setupHook = writeText "setupHook.sh" ''
+       addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+    '';
+    buildInputs = with erlangPackages; [ autoconf erlang z3 python27 makeWrapper which ];
+
+    buildFlags = "PWD=$(out)/lib/erlang/lib/cuter-${version} cuter_target";
+    configurePhase = ''
+      autoconf
+      ./configure --prefix $out
+    '';
+
+    installPhase = ''
+      mkdir -p "$out/lib/erlang/lib/cuter-${version}"
+      mkdir -p "$out/bin"
+      cp -r * "$out/lib/erlang/lib/cuter-${version}"
+      cp cuter "$out/bin/cuter"
+      wrapProgram $out/bin/cuter \
+       --prefix PATH : "${python27}/bin" \
+       --suffix PYTHONPATH : "${z3}/lib/python2.7/site-packages" \
+       --suffix ERL_LIBS : "$out/lib/erlang/lib"
+    '';
+
+    meta = {
+      description = "A concolic testing tool for the Erlang functional programming language";
+      license = stdenv.lib.licenses.gpl3;
+      homepage = "https://github.com/aggelgian/cuter";
+      maintainers = with stdenv.lib.maintainers; [ ericbmerritt ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5355,6 +5355,7 @@ let
   fetchHex = callPackage ../development/tools/build-managers/rebar3/fetch-hex.nix { };
 
   erlangPackages = callPackage ../development/erlang-modules { };
+  cuter = erlangPackages.callPackage ../development/tools/erlang/cuter { };
   hex2nix = erlangPackages.callPackage ../development/tools/erlang/hex2nix { };
 
   elixir = callPackage ../development/interpreters/elixir { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
