### PR TITLE
transmission: build transmission-cli

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [ "--with-systemd-daemon" ]
+    ++ [ "--enable-cli" ]
     ++ optional enableGTK3 "--with-gtk";
 
   preFixup = optionalString enableGTK3 /* gsettings schemas for file dialogues */ ''


### PR DESCRIPTION
As of version 2.92, transmission-cli is no longer built by default (it
is deprecated).  This breaks the bittorrent vmtest.  For now, explicitly
enable the cli.
