### PR TITLE
Add hypothesis 3.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8719,6 +8719,28 @@ in modules // {
     };
   };
 
+  flaky = buildPythonPackage rec {
+    name = "flaky-${version}";
+    version = "3.1.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/f/flaky/${name}.tar.gz";
+      sha256 = "1x9ixika7wqjj52x8wnsh1vk7jadkdqpx01plj7mlh8slwyq4s41";
+    };
+
+    propagatedBuildInputs = with self; [ pytest ];
+    buildInputs = with self; [ mock ];
+
+    # waiting for feedback https://github.com/box/flaky/issues/97
+    doCheck = false;
+
+    meta = {
+      homepage = https://github.com/box/flaky;
+      description = "Plugin for nose or py.test that automatically reruns flaky tests";
+      license = licenses.asl20;
+    };
+  };
+
   flask = buildPythonPackage {
     name = "flask-0.10.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2061,7 +2061,7 @@ in modules // {
       sha256 = "1j4f51dxic39mdwf6alj7gd769wy6mhk916v031wjali51xkh3xb";
     };
 
-    buildInputs = with self; [ hypothesis sqlite3 ];
+    buildInputs = with self; [ hypothesis1 sqlite3 ];
 
     propagatedBuildInputs = with self; [ chardet ];
 
@@ -3577,7 +3577,7 @@ in modules // {
     };
 
     buildInputs = [ pkgs.openssl self.pretend self.cryptography_vectors
-                    self.iso8601 self.pyasn1 self.pytest self.py self.hypothesis ]
+                    self.iso8601 self.pyasn1 self.pytest self.py self.hypothesis1 ]
                ++ optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
     propagatedBuildInputs = with self; [ six idna ipaddress pyasn1 cffi pyasn1-modules modules.sqlite3 ]
      ++ optional (pythonOlder "3.4") self.enum34;
@@ -6456,7 +6456,7 @@ in modules // {
 
     buildInputs = with self;
       [
-        hypothesis
+        hypothesis1
         pytestcov
         pytestflakes
         pytestpep8
@@ -10025,7 +10025,7 @@ in modules // {
     };
   };
 
-  hypothesis = buildPythonPackage rec {
+  hypothesis1 = buildPythonPackage rec {
     name = "hypothesis-1.14.0";
 
     buildInputs = with self; [fake_factory django numpy pytz flake8 pytest ];
@@ -17034,7 +17034,7 @@ in modules // {
       sha256 = "0jgyhkkq36wn36rymn4jiyqh2vdslmradq4a2mjkxfbk2cz6wpi5";
     };
 
-    buildInputs = with self; [ six pytest hypothesis ] ++ optional (!isPy3k) modules.sqlite3;
+    buildInputs = with self; [ six pytest hypothesis1 ] ++ optional (!isPy3k) modules.sqlite3;
 
     checkPhase = ''
       py.test

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10066,6 +10066,35 @@ in modules // {
     };
   };
 
+  hypothesis = buildPythonPackage rec {
+    # http://hypothesis.readthedocs.org/en/latest/packaging.html
+
+    name = "hypothesis-${version}";
+    version = "3.1.0";
+
+    # Upstream prefers github tarballs
+    src = pkgs.fetchFromGitHub {
+      owner = "DRMacIver";
+      repo = "hypothesis";
+      rev = "${version}";
+      sha256 = "1fhdb2vwc4blas5fvcly6pmha8psqm4bhi67jz32ypjryzk09iyf";
+    };
+
+    buildInputs = with self; [ flake8 pytest flaky ];
+    propagatedBuildInputs = with self; ([ pytz fake_factory django numpy ] ++ optionals isPy27 [ enum34 modules.sqlite3 ]);
+
+    # https://github.com/DRMacIver/hypothesis/issues/300
+    checkPhase = ''
+      ${python.interpreter} -m pytest tests/cover
+    '';
+
+    meta = {
+      description = "A Python library for property based testing";
+      homepage = https://github.com/DRMacIver/hypothesis;
+      license = licenses.mpl20;
+    };
+  };
+
   httpretty = buildPythonPackage rec {
     name = "httpretty-${version}";
     version = "0.8.6";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Because updating hypothesis from 1.14.0 to 3.1 is not that easy (see https://github.com/NixOS/nixpkgs/pull/13835), I'm trying a different path here: rename current hypothesis to hypothesis1, change all derivations depending on hypothesis to now depend on `hypothesis1`, add hypothesis 3.1 under the name `hypothesis`.

cc @lancelotsix @domenkozar @FRidh 

---

_Please note, that points are not mandatory, but rather desired._
