### PR TITLE
freeradius: init at 3.0.11

### DIFF
--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, autoreconfHook, talloc, openssl ? null }:
+
+## TODO: include ldap optionally
+## TODO: include sqlite optionally
+## TODO: include mysql optionally
+
+stdenv.mkDerivation rec {
+  name = "freeradius-${version}";
+  version = "3.0.11";
+
+  buildInputs = [
+    autoreconfHook
+    talloc
+    openssl
+  ];
+
+  configureFlags = [
+     "--sysconfdir=/etc"
+     "--localstatedir=/var"
+  ];
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+   ];
+
+  src = fetchurl {
+    url = "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-${version}.tar.gz";
+    sha256 = "0naxw9b060rbp4409904j6nr2zwl6wbjrbq1839xrwhmaf8p4yxr";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://freeradius.org/;
+    description = "A modular, high performance free RADIUS suite";
+    license = stdenv.lib.licenses.gpl2;
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9574,6 +9574,8 @@ let
 
   freepops = callPackage ../servers/mail/freepops { };
 
+  freeradius = callPackage ../servers/freeradius { };
+
   freeswitch = callPackage ../servers/sip/freeswitch { };
 
   gatling = callPackage ../servers/http/gatling { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._

Initial package has been created. However, the configuration system is very modular (sites-enabled, sites-available, modules-enabled, etc) so the service configuration seems non-trivial. Would like some input. Have an initial service configuration here: https://gist.github.com/sheenobu/4d8b29895b7a419a4ec5
