### PR TITLE
julia: darwin compatibility

### DIFF
--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -7,6 +7,8 @@
 , curl, fftwSinglePrec, fftw, gmp, libgit2, mpfr, openlibm, openspecfun, pcre2
 # linear algebra
 , openblas, arpack, suitesparse
+# Darwin frameworks
+, CoreServices, ApplicationServices
 }:
 
 with stdenv.lib;
@@ -19,6 +21,9 @@ in
 let
   arpack = arpack_.override { inherit openblas; };
   suitesparse = suitesparse_.override { inherit openblas; };
+  llvmShared = if stdenv.isDarwin
+               then llvm.override { enableSharedLibraries = true; }
+               else llvm;
 in
 
 let
@@ -68,10 +73,11 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    arpack fftw fftwSinglePrec gmp libgit2 libunwind llvm mpfr
+    arpack fftw fftwSinglePrec gmp libgit2 libunwind llvmShared mpfr
     pcre2 openblas openlibm openspecfun readline suitesparse utf8proc
     zlib
-  ];
+  ] ++
+    stdenv.lib.optionals stdenv.isDarwin [CoreServices ApplicationServices] ;
 
   nativeBuildInputs = [ curl gfortran m4 makeWrapper patchelf perl python2 which ];
 
@@ -126,6 +132,8 @@ stdenv.mkDerivation rec {
     arpack fftw fftwSinglePrec gmp libgit2 mpfr openblas openlibm
     openspecfun pcre2 suitesparse
   ];
+
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${llvmShared}/lib";
 
   dontStrip = true;
   dontPatchELF = true;

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, http-parser}:
+{stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, http-parser, libiconv}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   version = "0.23.2";
   name = "libgit2-${version}";
 
@@ -21,4 +21,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; all;
   };
-}
+} // stdenv.lib.optionalAttrs (!stdenv.isLinux) {
+  NIX_LDFLAGS = "-liconv";
+  propagatedBuildInputs = [ libiconv ];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4546,6 +4546,7 @@ let
   julia = callPackage ../development/compilers/julia {
     gmp = gmp6;
     openblas = openblasCompat;
+    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
   };
 
   julia-git = lowPrio (callPackage ../development/compilers/julia/git.nix {
@@ -6850,7 +6851,11 @@ let
 
   gio-sharp = callPackage ../development/libraries/gio-sharp { };
 
-  libgit2 = callPackage ../development/libraries/git2 { };
+  libgit2 = callPackage ../development/libraries/git2 (
+    stdenv.lib.optionalAttrs stdenv.isDarwin {
+      inherit (darwin) libiconv;
+    }
+  );
 
   libgit2_0_21 = callPackage ../development/libraries/git2/0.21.nix { };
 


### PR DESCRIPTION
###### Things done:
- Built on platform: OSX
- Ran the full julia test suite
- Basic usage in a jupyter notebook with the ijulia kernel
###### More

Along with PR #13879, these patches let julia build and run on
darwin. Using an llvm with shared library support is an idea adopted from
a @pikajude comment here https://github.com/NixOS/nixpkgs/issues/10864

The libgit2 change is mechanical to pull in iconv on darwin.

The frameworks are referenced by julia's build system.
