### PR TITLE
Expose arguments provided by callPackage on the derivation.

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -60,11 +60,13 @@ rec {
         { override = newArgs: makeOverridable f (overrideWith newArgs);
           overrideDerivation = fdrv:
             makeOverridable (args: overrideDerivation (f args) fdrv) origArgs;
+          originalArgs = origArgs;
         })
       else if builtins.isFunction ff then
         { override = newArgs: makeOverridable f (overrideWith newArgs);
           __functor = self: ff;
           overrideDerivation = throw "overrideDerivation not yet supported for functors";
+          originalArgs = origArgs;
         }
       else ff;
 
@@ -108,6 +110,7 @@ rec {
       pkgs = f finalArgs;
       mkAttrOverridable = name: pkg: pkg // {
         override = newArgs: mkAttrOverridable name (f (finalArgs // newArgs)).${name};
+        originalArgs = finalArgs;
       };
     in lib.mapAttrs mkAttrOverridable pkgs;
 


### PR DESCRIPTION
This modification is needed by #10851 for introspecting the dependencies of all packages which are using `callPackage` or equivalent functions, which correspond to a large portion of nixpkgs.

Please refer to the `patchUpdatedDependencies` function inside #10851 to see how it is used.

cc @edolstra 
