### PR TITLE
pythonPackages.imread: add webp support

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6000,6 +6000,7 @@ in modules // {
       pkgs.libpng
       pkgs.libtiff
       pkgs.libwebp
+      pkgs.pkgconfig
     ];
     propagatedBuildInputs = with self; [ numpy ];
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`: none do
- [x] Tested execution of all binary files (usually in `./result/bin/`): tested python packages
- [x] Fits [CONTRIBUTING.md]
###### More

pkg-config needs to be present at build time for webp support to be
auto-detected by the build script.
