### PR TITLE
Replace references to all-packages.nix, by references to the top-level

### DIFF
--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -15,7 +15,7 @@ Usage:
   Attention:
 
   let
-    pkgs = (import /etc/nixos/nixpkgs/pkgs/top-level/all-packages.nix) {};
+    pkgs = (import <nixpkgs>) {};
   in let
     inherit (pkgs.stringsWithDeps) fullDepEntry packEntry noDepEntry textClosureMap;
     inherit (pkgs.lib) id;

--- a/pkgs/build-support/vm/windows/cygwin-iso/default.nix
+++ b/pkgs/build-support/vm/windows/cygwin-iso/default.nix
@@ -16,7 +16,7 @@ let
     sha256 = "1slyj4qha7x649ggwdski9spmyrbs04z2d46vgk8krllg0kppnjv";
   };
 
-  cygwinCross = (import ../../../../top-level/all-packages.nix {
+  cygwinCross = (import ../../../../.. {
     inherit (stdenv) system;
     crossSystem = {
       libc = "msvcrt";

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1,5 +1,5 @@
 { system         ? builtins.currentSystem
-, allPackages    ? import ../../top-level/all-packages.nix
+, allPackages    ? import ../../..
 , platform       ? null
 , config         ? {}
 
@@ -22,7 +22,7 @@ let
     (import "${./standard-sandbox.sb}")
   '';
 in rec {
-  allPackages = import ../../top-level/all-packages.nix;
+  allPackages = import ../../..;
 
   commonPreHook = ''
     export NIX_ENFORCE_PURITY=1

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -1,6 +1,6 @@
 { system ? builtins.currentSystem }:
 
-with import ../../top-level/all-packages.nix { inherit system; };
+with import ../../.. { inherit system; };
 
 rec {
   # We want coreutils without ACL support.
@@ -291,7 +291,7 @@ rec {
   # The ultimate test: bootstrap a whole stdenv from the tools specified above and get a package set out of it
   test-pkgs = let
     stdenv = import ./. { inherit system bootstrapFiles; };
-  in import ../../top-level/all-packages.nix {
+  in import ../../.. {
     inherit system;
     bootStdenv = stdenv.stdenvDarwin;
   };

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,11 +1,11 @@
 { system      ? builtins.currentSystem
-, allPackages ? import ../../top-level/all-packages.nix
+, allPackages ? import ../../..
 , platform    ? null
 , config      ? {}
 }:
 
 rec {
-  allPackages = import ../../top-level/all-packages.nix;
+  allPackages = import ../../..;
 
   bootstrapTools = derivation {
     inherit system;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -6,7 +6,7 @@
 
 # The function defaults are for easy testing.
 { system ? builtins.currentSystem
-, allPackages ? import ../../top-level/all-packages.nix
+, allPackages ? import ../../..
 , platform ? null, config ? {}, lib ? (import ../../../lib)
 , customBootstrapFiles ? null }:
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -3,7 +3,7 @@
 let buildFor = toolsArch: (
 
 let
-  pkgsFun = import ../../top-level/all-packages.nix;
+  pkgsFun = import ../../..;
   pkgsNoParams = pkgsFun {};
   
   sheevaplugCrossSystem = {

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -1,6 +1,6 @@
 { system ? builtins.currentSystem }:
 
-with import ../../top-level/all-packages.nix {inherit system;};
+with import ../../.. {inherit system;};
 
 rec {
 

--- a/pkgs/test/mkOption/keep.nix
+++ b/pkgs/test/mkOption/keep.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import ../../top-level/all-packages.nix {};
+  pkgs = import ../../.. {};
   config = import ./declare.nix;
 in
   with (pkgs.lib);

--- a/pkgs/test/mkOption/merge.nix
+++ b/pkgs/test/mkOption/merge.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import ../../top-level/all-packages.nix {};
+  pkgs = import ../../.. {};
   config = import ./declare.nix;
 
   # Define the handler of unbound options.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -164,7 +164,7 @@ let
     in newpkgs;
 
   # Override system. This is useful to build i686 packages on x86_64-linux.
-  forceSystem = system: kernel: (import ./all-packages.nix) {
+  forceSystem = system: kernel: (import ./../..) {
     inherit system;
     platform = platform // { kernelArch = kernel; };
     inherit bootStdenv noSysDirs gccWithCC gccWithProfiling config
@@ -211,7 +211,7 @@ let
 
   allStdenvs = import ../stdenv {
     inherit system platform config lib;
-    allPackages = args: import ./all-packages.nix ({ inherit config system; } // args);
+    allPackages = args: import ./../.. ({ inherit config system; } // args);
   };
 
   defaultStdenv = allStdenvs.stdenv // { inherit platform; };
@@ -228,7 +228,7 @@ let
         in if changer != null then
           changer {
             # We import again all-packages to avoid recursivities.
-            pkgs = import ./all-packages.nix {
+            pkgs = import ./../.. {
               # We remove packageOverrides to avoid recursivities
               config = removeAttrs config [ "replaceStdenv" ];
             };
@@ -3843,7 +3843,7 @@ let
     # load into the Ben Nanonote
     gccCross =
       let
-        pkgsCross = (import ./all-packages.nix) {
+        pkgsCross = (import ./../..) {
           inherit system;
           inherit bootStdenv noSysDirs gccWithCC gccWithProfiling config;
           # Ben Nanonote system

--- a/pkgs/top-level/guile-2-test.nix
+++ b/pkgs/top-level/guile-2-test.nix
@@ -4,7 +4,7 @@
    -- ludo@gnu.org  */
 
 let
-  allPackages = import ./all-packages.nix;
+  allPackages = import ./../..;
 
   pkgsFun = { system ? builtins.currentSystem }:
     allPackages {

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -48,8 +48,8 @@ releaseTools.sourceTarball rec {
     # Make sure that derivation paths do not depend on the Nixpkgs path.
     mkdir $TMPDIR/foo
     ln -s $(readlink -f .) $TMPDIR/foo/bar
-    p1=$(nix-instantiate pkgs/top-level/all-packages.nix --dry-run -A firefox --show-trace)
-    p2=$(nix-instantiate $TMPDIR/foo/bar/pkgs/top-level/all-packages.nix --dry-run -A firefox)
+    p1=$(nix-instantiate ./. --dry-run -A firefox --show-trace)
+    p2=$(nix-instantiate $TMPDIR/foo/bar --dry-run -A firefox)
     if [ "$p1" != "$p2" ]; then
         echo "Nixpkgs evaluation depends on Nixpkgs path ($p1 vs $p2)!"
         exit 1

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,5 +1,5 @@
 { supportedSystems
-, packageSet ? (import ./all-packages.nix)
+, packageSet ? (import ./../..)
 , allowTexliveBuilds ? false
 , scrubJobs ? true
 }:

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -3,7 +3,7 @@
    $ hydra-eval-jobs pkgs/top-level/release-python.nix
 */
 
-{ nixpkgs ? { outPath = (import ./all-packages.nix {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ./../.. {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
 , # The platforms for which we build Nixpkgs.
   supportedSystems ? [ "x86_64-linux" ]

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -1,7 +1,7 @@
 /* A small release file, with few packages to be built.  The aim is to reduce
    the load on Hydra when testing the `stdenv-updates' branch. */
 
-{ nixpkgs ? { outPath = (import ./all-packages.nix {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ./../.. {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" ]
 }:
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -9,7 +9,7 @@
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
 
-{ nixpkgs ? { outPath = (import ./all-packages.nix {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ./../.. {}).lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
 , # The platforms for which we build Nixpkgs.
   supportedSystems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" ]


### PR DESCRIPTION
This change is extracted from the larger pull request #10851 , and was requested as a cleaner approach than was was done in #10307.

This change is useful, as we now have only a single point of entry in `all-packages.nix`, which is the top-level `default.nix` file of nixpkgs.

Having this change, will allow to split `all-packages.nix` file into one which contains the logic, and another one which contains the list of packages.  Thus giving us the ability to re-indent this one correctly.

cc @domenkozar 
