### PR TITLE
sway: mark as broken

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.mit;
     platforms   = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ];
+    broken      = true;
   };
 }


### PR DESCRIPTION
Fails building and has no maintainer:

```
a2x: WARNING: --destination-dir option is only applicable to HTML based
outputs
a2x: ERROR: "xsltproc"  --stringparam callout.graphics 0 --stringparam
navig.graphics 0 --stringparam admon.textlabel 1 --stringparam
admon.graphics 0
"/nix/store/d9hjgj3yas4kfvazz5x2winrgcgmz8v4-asciidoc-8.6.9/etc/asciidoc/docbook-xsl/manpage.xsl"
"/tmp/nix-build-sway-git-2016-02-08.drv-0/sway-16e904634c65128610537bed7fcb16ac3bb45165/build/bin/sway.1.xml"
returned non-zero exit status 5
CMakeFiles/man.dir/build.make:61: recipe for target 'bin/sway.1' failed
```
