### PR TITLE
Remove Python packages from `all-packages.nix`

### DIFF
--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, python3, python3Packages, at_spi2_core }:
+{ stdenv, fetchurl, pkgconfig, at_spi2_core, pythonPackages }:
 
 stdenv.mkDerivation rec {
   version = "2.18.0";
@@ -9,8 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0imbyk2v6c11da7pkwz91313pkkldxs8zfg81zb2ql6h0nnh6vzq";
   };
 
+  broken = true;
+
   buildInputs = [
-    pkgconfig python3 python3Packages.pygobject3 at_spi2_core
+    at_spi2_core
+    pkgconfig
+    pythonPackages.python
+    pythonPackages.pygobject3
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2987,7 +2987,7 @@ let
 
   pwnat = callPackage ../tools/networking/pwnat { };
 
-  pyatspi = callPackage ../development/python-modules/pyatspi { };
+  pyatspi = python3Packages.pyatspi;
 
   pycangjie = pythonPackages.pycangjie;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9347,7 +9347,7 @@ let
 
   pycups = pythonPackages.pycups;
 
-  pyexiv2 = callPackage ../development/python-modules/pyexiv2 { };
+  pyexiv2 = pythonPackages.pyexiv2;
 
   pygame = pythonPackages.pygame;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9365,7 +9365,7 @@ let
 
   pyopenssl = pythonPackages.pyopenssl;
 
-  rhpl = callPackage ../development/python-modules/rhpl { };
+  rhpl = pythonPackages.rhpl;
 
   pyqt4 = pythonPackages.pyqt4;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1034,7 +1034,9 @@ let
     inherit (strategoPackages016) strategoxt sdf;
   };
 
-  bittornado = callPackage ../tools/networking/p2p/bit-tornado { };
+  bittornado = callPackage ../tools/networking/p2p/bit-tornado {
+    inherit (pythonPackages) wxPython;
+  };
 
   blueman = callPackage ../tools/bluetooth/blueman {
     inherit (gnome3) dconf gsettings_desktop_schemas;
@@ -9335,65 +9337,6 @@ let
     self = pypyPackages;
   };
 
-  bsddb3 = pythonPackages.bsddb3;
-
-  ecdsa = pythonPackages.ecdsa;
-
-  pycairo = pythonPackages.pycairo;
-
-  pycapnp = pythonPackages.pycapnp;
-
-  pycrypto = pythonPackages.pycrypto;
-
-  pycups = pythonPackages.pycups;
-
-  pyexiv2 = pythonPackages.pyexiv2;
-
-  pygame = pythonPackages.pygame;
-
-  pygobject = pythonPackages.pygobject;
-
-  pygobject3 = pythonPackages.pygobject3;
-
-  pygtk = pythonPackages.pygtk;
-
-  pygtksourceview = pythonPackages.pygtksourceview;
-
-  pyGtkGlade = pythonPackages.pyGtkGlade;
-
-  pylint = pythonPackages.pylint;
-
-  pyopenssl = pythonPackages.pyopenssl;
-
-  rhpl = pythonPackages.rhpl;
-
-  pyqt4 = pythonPackages.pyqt4;
-
-  pysideApiextractor = pythonPackages.pysideApiextractor;
-
-  pysideGeneratorrunner = pythonPackages.pysideGeneratorrunner;
-
-  pyside = pythonPackages.pyside;
-
-  pysideTools = pythonPackages.pysideTools;
-
-  pysideShiboken = pythonPackages.pysideShiboken;
-
-  pyxml = pythonPackages.pyxml;
-
-  rbtools = pythonPackages.rbtools;
-
-  setuptools = pythonPackages.setuptools;
-
-  slowaes = pythonPackages.slowaes;
-
-  wxPython = pythonPackages.wxPython;
-  wxPython28 = pythonPackages.wxPython28;
-
-  twisted = pythonPackages.twisted;
-
-  ZopeInterface = pythonPackages.zope_interface;
-
   ### DEVELOPMENT / R MODULES
 
   R = callPackage ../applications/science/math/R {
@@ -11510,7 +11453,9 @@ let
 
   batik = callPackage ../applications/graphics/batik { };
 
-  batti = callPackage ../applications/misc/batti { };
+  batti = callPackage ../applications/misc/batti {
+    inherit (pythonPackages) pygtk;
+  };
 
   baudline = callPackage ../applications/audio/baudline {
     jack = jack1;
@@ -14382,7 +14327,9 @@ let
 
   andyetitmoves = if stdenv.isLinux then callPackage ../games/andyetitmoves {} else null;
 
-  anki = callPackage ../games/anki { };
+  anki = callPackage ../games/anki {
+    inherit (pythonPackages) pyqt4;
+  };
 
   armagetronad = callPackage ../games/armagetronad { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -185,6 +185,8 @@ in modules // {
 
   pyxml = if !isPy3k then callPackage ../development/python-modules/pyxml{ } else throw "pyxml not supported for interpreter ${python.executable}";
 
+  rhpl = if !isPy3k then callPackage ../development/python-modules/rhpl {} else throw "rhpl not supported for interpreter ${python.executable}";
+
   sip = callPackage ../development/python-modules/sip { };
 
   sip_4_16 = callPackage ../development/python-modules/sip/4.16.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -146,6 +146,8 @@ in modules // {
 
   pycrypto = callPackage ../development/python-modules/pycrypto { };
 
+  pyexiv2 = if (!isPy3k) then callPackage ../development/python-modules/pyexiv2 {} else throw "pyexiv2 not supported for interpreter ${python.executable}";
+
   pygame = callPackage ../development/python-modules/pygame { };
 
   pygobject = callPackage ../development/python-modules/pygobject { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -137,6 +137,8 @@ in modules // {
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  pyatspi = if isPy3k then callPackage ../development/python-modules/pyatspi { } else throw "pyatspi not supported for interpreter ${python.executable}";
+
   pycairo = callPackage ../development/python-modules/pycairo {
   };
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
## Goal

Too often people use Python packages that are in `all-packages.nix` causing all sorts of trouble. Earlier, we moved `callPackage` calls into `python-packages.nix` solving issues like accidentally having packages with different interpreter versions inside a single expression. 

Now I would like to finish that job by removing all Python packages from `all-packages.nix`. Why? For exactly the same reason. Python packages in `all-packages.nix` are using CPython 2.7, and it still happens that these packages are mixed with `python3Packages`.
