### PR TITLE
retroarch: improvements

### DIFF
--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -1,6 +1,20 @@
-{ stdenv, fetchgit, pkgconfig, ffmpeg, mesa, nvidia_cg_toolkit
+{ stdenv, fetchgit, makeDesktopItem, pkgconfig, ffmpeg, mesa, nvidia_cg_toolkit
 , freetype, libxml2, libv4l, coreutils, python34, which, udev, alsaLib
 , libX11, libXext, libXxf86vm, libXdmcp, SDL, libpulseaudio ? null }:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "retroarch";
+    exec = "retroarch";
+    icon = "retroarch";
+    comment = "Multi-Engine Platform";
+    desktopName = "RetroArch";
+    genericName = "Libretro Frontend";    
+    categories = "Game;Emulator;";
+    #keywords = "multi;engine;emulator;xmb;";
+  };
+  
+in
 
 stdenv.mkDerivation rec {
   name = "retroarch-bare-${version}";
@@ -18,6 +32,14 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     export GLOBAL_CONFIG_DIR=$out/etc
     sed -e 's#/bin/true#${coreutils}/bin/true#' -i qb/qb.libs.sh
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp -p -T ./media/retroarch.svg $out/share/icons/hicolor/scalable/apps/retroarch.svg
+
+    mkdir -p "$out/share/applications"
+    cp ${desktopItem}/share/applications/* $out/share/applications
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/misc/emulators/retroarch/wrapper.nix
+++ b/pkgs/misc/emulators/retroarch/wrapper.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation {
     do
       $(ln -s $coreDir/*.so $out/lib/.)
     done)
+
+    ln -s -t $out ${retroarch}/share
+
     makeWrapper ${retroarch}/bin/retroarch $out/bin/retroarch \
       --suffix-each LD_LIBRARY_PATH ':' "$cores" \
       --add-flags "-L $out/lib/ --menu" \


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS stable and unstable and latest
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): 
  yes on stable. On both latest and unstable, the executable segfault and it has nothing to
  do with this change.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More
-  Added missing freedesktop items (`*.desktop` and icon).
  
  Note that for the moment, only added an `*.svg`
  icon as was the only available. It does not give
  us the best results (at least in xfce). We may decide
  later on to extract the content of the `*.ico` instead
  which is a bit more involved.
