### PR TITLE
icon-conv-tools: init at 0.0.0

### DIFF
--- a/pkgs/build-support/icon-conv-tools/bin/extractWinRscIconsToStdFreeDesktopDir.sh
+++ b/pkgs/build-support/icon-conv-tools/bin/extractWinRscIconsToStdFreeDesktopDir.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+# The file from which to extract *.ico files or a particular *.ico file.
+# (e.g.: './KeePass.exe', './myLibrary.dll', './my/path/to/app.ico'). 
+# As you notived, the utility can extract icons from a windows executable or
+# dll.
+rscFile=$1
+
+# A regexp that can extract the image size from the file name. Because we
+# use 'icotool', this value should usually be set to something like
+# '[^\.]+\.exe_[0-9]+_[0-9]+_[0-9]+_[0-9]+_([0-9]+x[0-9]+)x[0-9]+\.png'.
+# A reg expression may be written at some point that relegate this to
+# an implementation detail.
+sizeRegex=$2
+
+# A regexp replace expression that will be used with 'sizeRegex' to create
+# a proper size directory (e.g.: '48x48'). Usually this is left to '\1'.
+sizeReplaceExp=$3
+
+# A regexp that can extract the name of the target image from the file name
+# of the image (usually png) extracted from the *.ico file(s). A good
+# default is '([^\.]+).+' which gets the basename without extension.
+nameRegex=$4
+
+# A regexp replace expression that will be used alongside 'nameRegex' to create
+# a icon file name. Note that you usually put directly you icon name here
+# without any extension (e.g.: 'my-app'). But in case you've got something
+# fancy, it will usually be '\1'.
+nameReplaceExp=$5
+
+# The 
+# out=./myOut
+out=$6
+
+# An optional temp dir.
+if [ "" != "$7" ]; then
+  tmp=$7
+  isOwnerOfTmpDir=false
+else
+  tmp=`mktemp -d`
+  isOwnerOfTmpDir=true
+fi
+
+rm -rf $tmp/png $tmp/ico
+mkdir -p $tmp/png $tmp/ico
+
+# Extract the ressource file's extension.
+rscFileExt=`echo "$rscFile" | sed -re 's/.+\.(.+)$/\1/'`
+
+if [ "ico" = "$rscFileExt" ]; then
+  cp -p $rscFile $tmp/ico
+else
+  wrestool -x --output=$tmp/ico -t14 $rscFile
+fi
+    
+icotool --icon -x --palette-size=0 -o $tmp/png $tmp/ico/*.ico
+
+mkdir -p $out
+
+for i in $tmp/png/*.png; do
+  fn=`basename "$i"`
+  size=$(echo $fn | sed -re 's/'${sizeRegex}'/'${sizeReplaceExp}'/')
+  name=$(echo $fn | sed -re 's/'${nameRegex}'/'${nameReplaceExp}'/')
+  targetDir=$out/share/icons/hicolor/$size/apps
+  targetFile=$targetDir/$name.png
+  mkdir -p $targetDir
+  mv $i $targetFile
+done
+
+rm -rf "$tmp/png" "$tmp/ico"
+
+if $isOwnerOfTmpDir; then
+  rm -rf "$tmp"
+fi

--- a/pkgs/build-support/icon-conv-tools/bin/icoFileToHiColorTheme
+++ b/pkgs/build-support/icon-conv-tools/bin/icoFileToHiColorTheme
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+SCRIPT_DIR=`cd "$(dirname $0)" && pwd`
+
+# The '*.ico' file that needs to be converted (e.g.: "./my/path/to/file.ico").
+icoFile="$1"
+
+# The desired name of created icon files without extension. (e.g.: "my-app").
+targetIconName="$2"
+
+# The output directory where the free desktop hierarchy will be created.
+# (e.g.: "./path/to/my/out" or usually in nix "$out"). Note that the
+# whole directory hierarchy to the icon will be created in the specified
+# output directory (e.g.: "$out/share/icons/hicolor/48x48/apps/my-app.png").
+out="$3"
+
+# An optional temp directory location (e.g.: ./tmp). If not specified
+# a random '/tmp' directory will be created.
+tmp="$4"
+
+$SCRIPT_DIR/extractWinRscIconsToStdFreeDesktopDir.sh \
+  "$icoFile" \
+  '[^\.]+_[0-9]+_([0-9]+x[0-9]+)x[0-9]+\.png' \
+  '\1' \
+  '([^\.]+).+' \
+  "$targetIconName" \
+  "$out" \
+  "$tmp"

--- a/pkgs/build-support/icon-conv-tools/default.nix
+++ b/pkgs/build-support/icon-conv-tools/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, icoutils }:
+
+stdenv.mkDerivation {
+  name = "icon-conv-tools-0.0.0";
+
+  src = ./.;
+
+  buildInputs = [ icoutils ];
+
+  patchPhase = ''
+    substituteInPlace "./bin/extractWinRscIconsToStdFreeDesktopDir.sh" \
+      --replace "icotool" "${icoutils}/bin/icotool" \
+      --replace "wrestool" "${icoutils}/bin/wrestool"
+  '';
+
+  buildPhase = ''
+    mkdir -p "$out/bin"
+    cp -p "./bin/"* "$out/bin"
+  '';
+
+  installPhase = "true";
+  
+  dontPatchELF = true;
+  dontStrip = true;
+
+  meta = {
+    description = "Tools for icon conversion specific to nix package manager";
+    maintainers = with stdenv.lib.maintainers; [ jraygauthier ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -328,6 +328,8 @@ in
 
   useOldCXXAbi = makeSetupHook { } ../build-support/setup-hooks/use-old-cxx-abi.sh;
 
+  iconConvTools = callPackage ../build-support/icon-conv-tools {};
+
 
   ### TOOLS
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using `nix-shell --pure` sandboxing
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

A nix specific set of tools for converting icon files
that are not in a freedesktop ready format.

I plan on using these tools for both `keepass` and
`retroarch` packages. It may benifit many other packages.
