### PR TITLE
cc-wrapper: add C++-specific paths if `-x cpp` is passed

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -15,29 +15,37 @@ fi
 source @out@/nix-support/utils.sh
 
 
-# Figure out if linker flags should be passed.  GCC prints annoying
-# warnings when they are not needed.
+# Parse command line options and set several variables.
+# For instance, figure out if linker flags should be passed.
+# GCC prints annoying warnings when they are not needed.
 dontLink=0
 getVersion=0
 nonFlagArgs=0
+[[ "@prog@" = *++ ]] && isCpp=1 || isCpp=0
 
-for i in "$@"; do
-    if [ "$i" = -c ]; then
+params=("$@")
+n=0
+while [ $n -lt ${#params[*]} ]; do
+    p=${params[n]}
+    p2=${params[$((n+1))]}
+    if [ "$p" = -c ]; then
         dontLink=1
-    elif [ "$i" = -S ]; then
+    elif [ "$p" = -S ]; then
         dontLink=1
-    elif [ "$i" = -E ]; then
+    elif [ "$p" = -E ]; then
         dontLink=1
-    elif [ "$i" = -E ]; then
+    elif [ "$p" = -E ]; then
         dontLink=1
-    elif [ "$i" = -M ]; then
+    elif [ "$p" = -M ]; then
         dontLink=1
-    elif [ "$i" = -MM ]; then
+    elif [ "$p" = -MM ]; then
         dontLink=1
-    elif [ "$i" = -x ]; then
-        # At least for the cases c-header or c++-header we should set dontLink.
-        # I expect no one use -x other than making precompiled headers.
+    elif [[ "$p" = -x && "$p2" = *-header ]]; then
         dontLink=1
+    elif [[ "$p" = -x && "$p2" = c++* && "$isCpp" = 0 ]]; then
+        isCpp=1
+    elif [ "$p" = -nostdlib ]; then
+        isCpp=-1
     elif [ "${i:0:1}" != - ]; then
         nonFlagArgs=1
     elif [ "$i" = -m32 ]; then
@@ -45,6 +53,7 @@ for i in "$@"; do
             NIX_LDFLAGS="$NIX_LDFLAGS -dynamic-linker $(cat @out@/nix-support/dynamic-linker-m32)"
         fi
     fi
+    n=$((n + 1))
 done
 
 # If we pass a flag like -Wl, then gcc will call the linker unless it
@@ -58,7 +67,6 @@ fi
 
 
 # Optionally filter out paths not refering to the store.
-params=("$@")
 if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" ]; then
     rest=()
     n=0
@@ -83,11 +91,9 @@ if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" ]; then
     params=("${rest[@]}")
 fi
 
-if [[ "@prog@" = *++ ]]; then
-    if  echo "$@" | grep -qv -- -nostdlib; then
-        NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
-        NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK $NIX_CXXSTDLIB_LINK"
-    fi
+if [[ "$isCpp" = 1 ]]; then
+    NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
+    NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK $NIX_CXXSTDLIB_LINK"
 fi
 
 # Add the flags for the C compiler proper.


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I've encountered an issue with Emacs's company-mode failing to find standard C++ libraries, like `iostream`. Turned out it's so because company-mode calls `clang -x c++` (notice, not `clang++`). Our wrapper, on the other hand, adds necessary paths for C++ libraries only if binary ends with `++`. This seems like a valid use case (at least supported by both `clang` and `gcc`) -- in case of `clang` it can be used for auto-completion.

Notice that the issue is very minor, so I don't expect this to be pulled on its own (it's a mass rebuild, after all) -- only coupled with some other mass-rebuildy PR.

Tested by building `clang` itself (so wrapped `gcc` is tested by building `llvm`, `clang` and friends) and checking that the problem is gone.
