### PR TITLE
xdg-utils: don't clobber words with sed eg passed

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   '' + ''
     for item in $out/bin/*; do
       substituteInPlace $item --replace "cut " "${coreutils}/bin/cut "
-      substituteInPlace $item --replace "sed " "${gnused}/bin/sed "
+      # don't clobber words with "sed " eg "passed ".
+      sed -i "$item" -re "s#([:blank:])sed #\1${gnused}/bin/sed #g"
       substituteInPlace $item --replace "egrep " "${gnugrep}/bin/egrep "
       sed -i $item -re "s#([^e])grep #\1${gnugrep}/bin/grep #g" # Don't replace 'egrep'
       substituteInPlace $item --replace "which " "type -P "


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #13904 

cc @edolstra 

---

_Please note, that points are not mandatory, but rather desired._

See #13904
