### PR TITLE
htop: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/os-specific/linux/htop/default.nix
+++ b/pkgs/os-specific/linux/htop/default.nix
@@ -1,13 +1,12 @@
-{ fetchFromGitHub, stdenv, autoreconfHook, ncurses }:
+{ fetchurl, stdenv, autoreconfHook, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "htop-2.0.0";
+  name = "htop-${version}";
+  version = "2.0.1";
 
-  src = fetchFromGitHub {
-    sha256 = "1z8rzf3ndswk3090qypl0bqzq9f32w0ik2k5x4zd7jg4hkx66k7z";
-    rev = "2.0.0";
-    repo = "htop";
-    owner = "hishamhm";
+  src = fetchurl {
+    url = "http://hisham.hm/htop/releases/${version}/${name}.tar.gz";
+    sha256 = "0rjn9ybqx5sav7z4gn18f1q6k23nmqyb6yydfgghzdznz9nn447l";
   };
 
   buildInputs = [ ncurses ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
