### PR TITLE
Update vdirsyncer and add automated tests

### DIFF
--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,29 +1,32 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, pythonPackages, glibcLocales }:
 
+# Packaging documentation at:
+# https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
 pythonPackages.buildPythonApplication rec {
-  version = "0.9.0";
+  version = "0.9.2";
   name = "vdirsyncer-${version}";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://pypi.python.org/packages/source/v/vdirsyncer/${name}.tar.gz";
-    sha256 = "0s9awjr9v60rr80xcpwmdhkf4v1yqnydahjmxwvxmh64565is465";
+    sha256 = "1g1107cz4sk41d2z6k6pn9n2fzd26m72j8aj33zn483vfvmyrc4q";
   };
 
   propagatedBuildInputs = with pythonPackages; [
     click click-log click-threading
     lxml
-    setuptools
-    setuptools_scm
     requests_toolbelt
     requests2
     atomicwrites
   ];
 
-  # Unfortunately, checking this package seems a bit too complex
-  # https://github.com/NixOS/nixpkgs/pull/13098#issuecomment-185914025
-  # https://github.com/untitaker/vdirsyncer/issues/334#issuecomment-185872854
-  doCheck = false;
+  buildInputs = with pythonPackages; [hypothesis pytest pytest-localserver pytest-subtesthack setuptools_scm ] ++ [ glibcLocales ];
+
+  LC_ALL = "en_US.utf8";
+
+  checkPhase = ''
+    make DETERMINISTIC_TESTS=true test
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/untitaker/vdirsyncer;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4262,6 +4262,27 @@ in modules // {
     };
   };
 
+  pytest-subtesthack = buildPythonPackage rec {
+    name = "pytest-subtesthack-${version}";
+    version = "0.1.1";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/pytest-subtesthack/${name}.tar.gz";
+      sha256 = "15kzcr5pchf3id4ikdvlv752rc0j4d912n589l4rifp8qsj19l1x";
+    };
+
+    propagatedBuildInputs = with self; [ pytest ];
+
+    # no upstream test
+    doCheck = false;
+
+    meta = {
+      description = "Terrible plugin to set up and tear down fixtures within the test function itself";
+      homepage = https://github.com/untitaker/pytest-subtesthack;
+      license = licenses.publicDomain;
+    };
+  };
+
   tinycss = buildPythonPackage rec {
     name = "tinycss-${version}";
     version = "0.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4239,6 +4239,28 @@ in modules // {
     };
   };
 
+  pytest-localserver = buildPythonPackage rec {
+    name = "pytest-localserver-${version}";
+    version = "0.3.5";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/pytest-localserver/${name}.tar.gz";
+      sha256 = "0dvqspjr6va55zwmnnc2mmpqc7mm65kxig9ya44x1z8aadzxpa4p";
+    };
+
+    propagatedBuildInputs = with self; [ werkzeug ];
+    buildInputs = with self; [ pytest six requests2 ];
+
+    checkPhase = ''
+      py.test
+    '';
+
+    meta = {
+      description = "Plugin for the pytest testing framework to test server connections locally";
+      homepage = https://pypi.python.org/pypi/pytest-localserver;
+      license = licenses.mit;
+    };
+  };
 
   tinycss = buildPythonPackage rec {
     name = "tinycss-${version}";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS 
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @matthiasbeyer @jgeerds 

Building on top of `nixos-unstable` went fine. I'm trying on top of master now.
