### PR TITLE
sway: fix build

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,21 +1,23 @@
-{ lib, stdenv, fetchurl, makeWrapper, cmake, pkgconfig
-, wayland, wlc, libxkbcommon, pixman, fontconfig, pcre, json_c, asciidoc, libxslt, dbus_libs
+{ stdenv, fetchFromGitHub
+, makeWrapper, cmake, pkgconfig, asciidoc, libxslt, docbook_xsl
+, wayland, wlc, libxkbcommon, pixman, fontconfig, pcre, json_c, dbus_libs
 }:
 
 stdenv.mkDerivation rec {
   name = "sway-${version}";
   version = "git-2016-02-08";
-  repo = "https://github.com/SirCmpwn/sway";
-  rev = "16e904634c65128610537bed7fcb16ac3bb45165";
 
-  src = fetchurl {
-    url = "${repo}/archive/${rev}.tar.gz";
-    sha256 = "52d6c4b49fea69e2a2c1b44b858908b7736301bdb9ed483c294bc54bb40e872e";
+  src = fetchFromGitHub {
+    owner = "Sircmpwn";
+    repo = "sway";
+
+    rev = "16e904634c65128610537bed7fcb16ac3bb45165";
+    sha256 = "04qvdjaarglq3qsjbb9crjkad3y1v7s51bk82sl8w26c71jbhklg";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];
 
-  buildInputs = [ makeWrapper wayland wlc libxkbcommon pixman fontconfig pcre json_c asciidoc libxslt dbus_libs ];
+  buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs ];
 
   patchPhase = ''
     sed -i s@/etc/sway@$out/etc/sway@g CMakeLists.txt;
@@ -24,17 +26,17 @@ stdenv.mkDerivation rec {
   makeFlags = "PREFIX=$(out)";
   installPhase = "PREFIX=$out make install";
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [ wlc dbus_libs ];
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ wlc dbus_libs ];
   preFixup = ''
     wrapProgram $out/bin/sway \
       --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}";
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "i3-compatible window manager for Wayland";
     homepage    = "http://swaywm.org";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ];
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): Linux
###### More

Building the manual requires docbook_xsl; in sandboxed environments,
the build would fail due to being unable to download missing docbook
resources.

Also include some minor improvements to the build recipe:
- use fetchFromGitHub
- move build-time dependencies to nativeBuildInputs

xref: https://github.com/NixOS/nixpkgs/pull/13900

I tried updating this as well, but that ended up with more build errors & stuff I don't care to deal with.

If nobody objects, I'll merge & pick to release.
