### PR TITLE
nixos/xserver: Changed xrandrHeads to support corresponding monitor s…

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -32,12 +32,30 @@ let
 
 
   # Just enumerate all heads without discarding XRandR output information.
-  xrandrHeads = let
-    mkHead = num: output: {
-      name = "multihead${toString num}";
-      inherit output;
-    };
-  in imap mkHead cfg.xrandrHeads;
+  xrandrHeads = (
+    fold
+      (nextHead: { index, alreadyPrimary, processedHeads }:
+        let
+          processedHead = { name = "multihead${toString index}"; } // 
+            (if isAttrs nextHead then
+              {
+                output = nextHead.output;
+                primary = if alreadyPrimary then false else nextHead.primary || index == 0;
+                monitorConfig = nextHead.monitorConfig;
+              }
+            else
+              {
+                output = nextHead;
+                primary = if alreadyPrimary then false else index == 0;
+                monitorConfig = "";
+              }
+            );
+          primariness = if alreadyPrimary then true else processedHead.primary;
+        in
+          { index = index - 1; alreadyPrimary = primariness; processedHeads = ([ processedHead ] ++ processedHeads); })
+      { index = (length cfg.xrandrHeads) - 1; alreadyPrimary = false; processedHeads = []; }
+      cfg.xrandrHeads
+  ).processedHeads;
 
   xrandrDeviceSection = let
     monitors = flip map xrandrHeads (h: ''
@@ -61,9 +79,13 @@ let
       value = ''
         Section "Monitor"
           Identifier "${current.name}"
+          ${optionalString (current.primary) ''
+          Option "Primary" "true"
+          ''}
           ${optionalString (previous != []) ''
           Option "RightOf" "${(head previous).name}"
           ''}
+          ${current.monitorConfig}
         EndSection
       '';
     } ++ previous;
@@ -317,12 +339,27 @@ in
 
       xrandrHeads = mkOption {
         default = [];
-        example = [ "HDMI-0" "DVI-0" ];
-        type = with types; listOf string;
+        example = [ "HDMI-0" { output = "DVI-0"; primary = true; monitorConfig = ""; } ];
+        type = with types; listOf (either
+          str
+          (submodule {
+            options.output = str;
+            options.primary = bool;
+            options.monitorConfig = lines;
+          })
+        );
         description = ''
           Simple multiple monitor configuration, just specify a list of XRandR
-          outputs which will be mapped from left to right in the order of the
-          list.
+          outputs as the values of the list. The monitors will be mapped from
+          left to right in the order of the list.
+
+          By default, the first monitor will be set as the primary monitor.
+          However instead of a list, you can give an attribute set. That set
+          can contain a primary monitor specification and a custom monitor
+          configuration section.
+
+          Only one monitor is allowed to be primary. If multiple monitors are
+          specified as primary, only the last monitor will be primary.
 
           Be careful using this option with multiple graphic adapters or with
           drivers that have poor support for XRandR, unexpected things might

--- a/pkgs/development/tools/analysis/garcosim/tracefilegen/builder.sh
+++ b/pkgs/development/tools/analysis/garcosim/tracefilegen/builder.sh
@@ -1,0 +1,17 @@
+source "$stdenv"/setup
+
+cp --recursive "$src" ./
+
+chmod --recursive u=rwx ./"$(basename "$src")"
+
+cd ./"$(basename "$src")"
+
+cmake ./ 
+
+make
+
+mkdir --parents "$out"/bin
+cp ./TraceFileGen "$out"/bin
+
+mkdir --parents "$out"/share/doc/"$name"/html
+cp --recursive ./Documentation/html/* "$out/share/doc/$name/html/"

--- a/pkgs/development/tools/analysis/garcosim/tracefilegen/default.nix
+++ b/pkgs/development/tools/analysis/garcosim/tracefilegen/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, cmake }:
+
+stdenv.mkDerivation rec {
+
+  name = "tracefilegen";
+
+  src = fetchgit {
+    url = "https://github.com/GarCoSim/TraceFileGen.git";
+    rev = "4acf75b142683cc475c6b1c841a221db0753b404";
+    sha256 = "69b056298cf570debd3718b2e2cb7e63ad9465919c8190cf38043791ce61d0d6";
+  };
+
+  buildInputs = [ cmake ];
+
+  builder = ./builder.sh;
+  
+  meta = with stdenv.lib; {
+    description = "Automatically generate all types of basic memory management operations and write into trace files";
+    homepage = "https://github.com/GarCoSim";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/development/tools/analysis/garcosim/tracefilesim/default.nix
+++ b/pkgs/development/tools/analysis/garcosim/tracefilesim/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+
+  name = "tracefilesim";
+  
+  src = fetchgit {
+    url = "https://github.com/GarCoSim/TraceFileSim.git";
+    rev = "368aa6b1d6560e7ecbd16fca47000c8f528f3da2";
+    sha256 = "22dfb60d1680ce6c98d60d12c0d0950073f02359605fcdef625e3049bca07809";
+  };
+  
+  installPhase = ''
+    mkdir --parents "$out/bin"
+    cp ./traceFileSim "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ease the analysis of existing memory management techniques, as well as the prototyping of new memory management techniques.";
+    homepage = "https://github.com/GarCoSim";
+    licenses = licenses.gpl2;
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3521,6 +3521,10 @@ in
 
   tracebox = callPackage ../tools/networking/tracebox { };
 
+  tracefilegen = callPackage ../development/tools/analysis/garcosim/tracefilegen { };
+
+  tracefilesim = callPackage ../development/tools/analysis/garcosim/tracefilesim { };
+
   trash-cli = callPackage ../tools/misc/trash-cli { };
 
   trickle = callPackage ../tools/networking/trickle {};


### PR DESCRIPTION
This is a breaking change (actually it is no longer breaking) to `services.xserver.xrandrHeads`, however it is a necessary change. This allows xrandrHeads to support per-monitor section configuation in Xorg.conf. There's currently no other way to set the primary monitor or per monitor section configuration when using the `xrandrHeads` option.

Requested by: https://github.com/NixOS/nixpkgs/issues/7463

What it fixes:

When you multiple monitors setup. By default, the first monitor detected by `xrandr` is set to the primary monitor. However this may not be the monitor you need to be set as primary. In fact this monitor set to primary may in fact be disconnected. Which is exactly what happened to me. This has affected 3 programs for me:
1. XMonad  - gets confused with `Super + {w,e,r}`
2. SDDM - puts the login screen on the wrong monitor, and does not currently duplicate the login screen on all monitors
3. XMobar - puts the xmobar on the wrong monitor, as it only puts the taskbar on the primary monitor

This PR fixes all of the above 3 problems (Xmonad is no longer confused, SDDM puts the login screen on my primary monitor (laptop), Xmobar is working. It is simple to use. And simple to change. Previously you would do something like:

```
services.xserver.xrandrHeads = [ "DP-0" "HDMI-0" ];
```

Now you can do:

```
services.xserver.xrandrHeads = {
    DP-0 =  ''
        Option "Primary" "true"
    '';
    HDMI-0 = "";
};
```

The reason why I did this, is to allow other per-monitor configuration options when using xrandrHeads (such as per-monitor DPI in the future). Note that the `services.xserver.monitorSection` setting does not work in conjunction with `xrandrHeads`.

I have tested this in current 15.09-small and it works.
