### PR TITLE
khal: add setuptools_scm to dependencies

### DIFF
--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -24,6 +24,7 @@ python3Packages.buildPythonApplication rec {
     urwid
     pkginfo
   ];
+  buildInputs = with python3Packages; [ setuptools_scm ];
 
   meta = with stdenv.lib; {
     homepage = http://lostpackets.de/khal/;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @matthiasbeyer @jgeerds 
