### PR TITLE
graphite2: 1.2.4 -> 1.3.6 for multiple CVEs

### DIFF
--- a/pkgs/applications/misc/d4x/default.nix
+++ b/pkgs/applications/misc/d4x/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   inherit boost;
 
   src = fetchurl {
-    url =  http://d4x.krasu.ru/files/d4x-2.5.7.1.tar.bz2;
+    url = http://pkgs.fedoraproject.org/repo/pkgs/d4x/d4x-2.5.7.1.tar.bz2/68d6336c3749a7caabb0f5a5f84f4102/d4x-2.5.7.1.tar.bz2;
     sha256 = "1i1jj02bxynisqapv31481sz9jpfp3f023ky47spz1v1wlwbs13m";
   };
 

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, freetype, cmake }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.4";
+  version = "1.3.6";
   name = "graphite2-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/silgraphite/graphite2/${name}.tgz";
-    sha256 = "00xhv1mp640fr3wmdzwn4yz0g56jd4r9fb7b02mc1g19h0bdbhsb";
+    sha256 = "0xdg6bc02bl8yz39l5i2skczfg17q4lif0qqan0dhvk0mibpcpj7";
   };
 
   buildInputs = [ pkgconfig freetype cmake ];


### PR DESCRIPTION
Please backport to:
- [ ] 16.03
- [ ] 15.09
###### Things done:

(in progress)
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CVE-2016-1977 CVE-2016-2790 CVE-2016-2791 CVE-2016-2792 CVE-2016-2793 CVE-2016-2794 CVE-2016-2795 CVE-2016-2796 CVE-2016-2797 CVE-2016-2798 CVE-2016-2799 CVE-2016-2800 CVE-2016-2801 CVE-2016-2802
