### PR TITLE
samba: 4.3.1 -> 4.3.6 for CVE-2015-7560 CVE-2016-0771

### DIFF
--- a/pkgs/applications/misc/stardict/stardict.nix
+++ b/pkgs/applications/misc/stardict/stardict.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     description = "An international dictionary supporting fuzzy and glob style matching";
     license = stdenv.lib.licenses.lgpl3;
     maintainers = with stdenv.lib.maintainers; [qknight];
+    broken = true;
   };
 }

--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "g-wrap-1.9.15";
   src = fetchurl {
     url = "mirror://savannah/g-wrap/${name}.tar.gz";
-    sha256 = "140fcvp24pqmfmiibhjxl3s75hj26ln7pkl2wxas84lnchbj9m4d";
+    sha256 = "0ak0bha37dfpj9kmyw1r8fj8nva639aw5xr66wr5gd3l1rqf5xhg";
   };
 
   # Note: Glib support is optional, but it's quite useful (e.g., it's

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -18,11 +18,11 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "samba-4.3.1";
+  name = "samba-4.3.6";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${name}.tar.gz";
-    sha256 = "10ic9pxsk3ml5ycmi0bql8wraxhbr2l4fhzd0qwmiqmrjl6sh24r";
+    sha256 = "0929fpk2pq4v389naai519xvsm9bzpar4jlgjxwlx1cnn6jyql9j";
   };
 
   patches =


### PR DESCRIPTION
Please backport to
- [ ] 16.03
- [ ] 15.09
###### Things done:

in progress
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
