### PR TITLE
eduke32: 20150420-5160 moved to the old releases directory

### DIFF
--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -2,6 +2,7 @@
 , pkgconfig, SDL2, SDL2_mixer }:
 
 let
+  year = "2015";
   date = "20150420";
   rev = "5160";
 in stdenv.mkDerivation rec {
@@ -9,7 +10,7 @@ in stdenv.mkDerivation rec {
   version = "${date}-${rev}";
 
   src = fetchurl {
-    url = "http://dukeworld.duke4.net/eduke32/synthesis/${version}/eduke32_src_${version}.tar.xz";
+    url = "http://dukeworld.duke4.net/eduke32/synthesis/old/${year}/${version}/eduke32_src_${version}.tar.xz";
     sha256 = "1nlq5jbglg00c1z1vsyl627fh0mqfxvk5qyxav5vzla2b4svik2v";
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes build issues in https://github.com/NixOS/nixpkgs/pull/13918
