### PR TITLE
ilbc: extract-cfile.awk has fallen off the internet

### DIFF
--- a/pkgs/development/libraries/ilbc/default.nix
+++ b/pkgs/development/libraries/ilbc/default.nix
@@ -3,11 +3,7 @@
 stdenv.mkDerivation rec {
   name = "ilbc-rfc3951";
 
-  script = fetchurl {
-    url = http://ilbcfreeware.org/documentation/extract-cfile.txt;
-    name = "extract-cfile.awk";
-    sha256 = "0md76qlszaras9grrxaq7xfxn1yikmz4qqgnjj6y50jg31yr5wyd";
-  };
+  script = ./extract-cfile.awk;
 
   rfc3951 = fetchurl {
     url = http://www.ietf.org/rfc/rfc3951.txt;

--- a/pkgs/development/libraries/ilbc/extract-cfile.awk
+++ b/pkgs/development/libraries/ilbc/extract-cfile.awk
@@ -1,0 +1,24 @@
+BEGIN { srcname = "nothing"; }
+{ if (/^A\.[0-9][0-9]*\.* *[a-zA-Z][a-zA-Z_0-9]*\.[ch]/) {
+    if (srcname != "nothing")
+      close(srcname);
+    srcname = $2;
+    printf("creating source file %s\n", srcname);
+  }else if (srcname != "nothing") {
+    if (/Andersen,* *et* *al\./) 
+      printf("skipping %s\n", $0);
+    else if (//)
+      printf("skipping2 %s\n", $0);
+    else if (/Internet Low Bit Rate Codec *December 2004/)
+      printf("skipping3 %s\n", $0);
+    else if (/Authors' *Addresses/){
+      close(srcname);
+      exit;}
+    else
+      print $0 >> srcname;
+  }
+}
+END {
+  printf("ending file %s\n", srcname);
+  close(srcname);
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes build issues with https://github.com/NixOS/nixpkgs/pull/13918
