### PR TITLE
grsecurity: 4.4.4 -> 4.4.5

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-grsecurity-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-grsecurity-4.4.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.4.4";
+  version = "4.4.5";
   extraMeta.branch = "4.4";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0b4190mwmxf329n16yl32my7dfi02pi7qf39a8v61sl9b2gxffad";
+    sha256 = "1daavrj2msl85aijh1izfm1cwf14c7mi75hldzidr1h2v629l89h";
   };
 
   kernelPatches = args.kernelPatches;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -102,9 +102,9 @@ rec {
   grsecurity_4_4 = grsecPatch
     { kernel    = pkgs.grsecurity_base_linux_4_4;
       patches   = [ grsecurity_fix_path_4_4 ];
-      kversion  = "4.4.4";
-      revision  = "201603032158";
-      sha256    = "18b8dmwn4qwrd7i838d9dlfk9fn7m4bjab5583p3980yayxqpa3k";
+      kversion  = "4.4.5";
+      revision  = "201603131305";
+      sha256    = "04k4nhshl6r5n41ha5620s7cd70dmmmvyf9mnn5359jr1720kxpf";
     };
 
   grsecurity_latest = grsecurity_4_4;


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [X] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._
