### PR TITLE
mysql_jdbc: 5.1.32 -> 5.1.38

### DIFF
--- a/pkgs/servers/sql/mysql/jdbc/default.nix
+++ b/pkgs/servers/sql/mysql/jdbc/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, ant, unzip}:
 
 stdenv.mkDerivation {
-  name = "mysql-connector-java-5.1.32";
+  name = "mysql-connector-java-5.1.38";
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.32.zip;
-    sha256 = "11vjwws1pa8fdwn86rrmqdwsq3ld3sh2r0pp4lpr2gxw0w18ykc7";
+    url = http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.zip;
+    sha256 = "0b1j2dylnpk6b17gn3168qdrrwq8kdil57nxrd08n1lnkirdsx33";
   };
 
   buildInputs = [ unzip ant ];


### PR DESCRIPTION
To be honest, this is just a goal to get monitor.nixos.org to stop saying this has 69 CVEs. I haven't tested the product.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
