### PR TITLE
activemq: 5.8.0 -> 5.13.2

### DIFF
--- a/pkgs/development/libraries/apache-activemq/5.12.nix
+++ b/pkgs/development/libraries/apache-activemq/5.12.nix
@@ -1,6 +1,0 @@
-import ./recent.nix
-  rec {
-    version = "5.12.1";
-    sha256 = "1hn6pls12dzc2fngz6lji7kmz7blvd3z1dq4via8gd4fjflmw5c9";
-    mkUrl = name: "mirror://apache/activemq/${version}/${name}-bin.tar.gz";
-  }

--- a/pkgs/development/libraries/apache-activemq/5.8.nix
+++ b/pkgs/development/libraries/apache-activemq/5.8.nix
@@ -1,6 +1,0 @@
-import ./recent.nix
-  rec {
-    version = "5.8.0";
-    sha256 = "12a1lmmqapviqdgw307jm07vw1z5q53r56pkbp85w9wnqwspjrbk";
-    mkUrl = name: "mirror://apache/activemq/apache-activemq/${version}/${name}-bin.tar.gz";
-  }

--- a/pkgs/development/libraries/apache-activemq/default.nix
+++ b/pkgs/development/libraries/apache-activemq/default.nix
@@ -1,13 +1,12 @@
-{ version, sha256, mkUrl }:
-# use a function to make the source url, because the url schemes differ between 5.8.0 and greater
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "apache-activemq-${version}";
+  version = "5.13.2";
 
   src = fetchurl {
-    url = mkUrl name;
-    inherit sha256;
+    sha256 = "0vrgny8fw973xvr3w4wc1s44z50b0c2hgcqa91s8fbx2yjmqn5xy";
+    url = "mirror://apache/activemq/${version}/${name}-bin.tar.gz";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6406,9 +6406,7 @@ let
 
   acl = callPackage ../development/libraries/acl { };
 
-  activemq = callPackage ../development/libraries/apache-activemq/5.8.nix { };
-
-  activemq512 = callPackage ../development/libraries/apache-activemq/5.12.nix { };
+  activemq = callPackage ../development/libraries/apache-activemq { };
 
   adns = callPackage ../development/libraries/adns { };
 


### PR DESCRIPTION
It seems Activemq was "split" in to 5.8.0 and 5.12.1 only to keep from
trampling someone on 5.8.0. This is to the point of not upgrading the
default, but making a new activemq attribute specific for 5.12.1.

As far as I can tell, there is no good reason to stay providing 5.8.0,
so this is the (opinionated) proposal to delete it.

Note: There are over 1,000 fixes between 5.9.0 to 5.13.2,
and 5.8 is not receiving new development.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
