### PR TITLE
gcl: fix gcc5 build

### DIFF
--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
     url = "http://gnu.spinellicreations.com/gcl/${name}.tar.gz";
   };
 
+  patches = [(fetchurl {
+    url = https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-lisp/gcl/files/gcl-2.6.12-gcc5.patch;
+    sha256 = "00jbsn0qp8ki2w7dx8caha7g2hr9076xa6bg48j3qqqncff93zdh";
+  })];
+
   buildInputs = [
     mpfr m4 binutils emacs gmp
     libX11 xproto inputproto libXi


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Apply patch from Gentoo

I can't build this due to address space randomization, which I can't be bothered to disable just for this.
