### PR TITLE
buildFHSEnv: add standard paths for compilers

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -57,6 +57,11 @@ let
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
     export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
     export PATH='/var/setuid-wrappers:/usr/bin:/usr/sbin'
+
+    # Force compilers to look in default search paths
+    export NIX_CFLAGS_COMPILE='-idirafter /usr/include'
+    export NIX_LDFLAGS_BEFORE='-L/usr/lib -L/usr/lib32'
+
     ${profile}
   '';
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX / Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Our compilers do not search in FHS locations for include files and libraries to enforce purity. This is contrary to what we want in FHS environments -- this patch achieves approximation of it via NIX_\* flags.

Fixes issue #13933

cc @tokudan
