### PR TITLE
matplotlib: declare missing runtime packages

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, buildPythonPackage, pycairo
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado
-, freetype, libpng, pkgconfig, mock, pytz, pygobject3
+, freetype, libpng, pkgconfig, mock, pytz, pygobject3, six
 , enableGhostscript ? false, ghostscript ? null, gtk3
 , enableGtk2 ? false, pygtk ? null, gobjectIntrospection
 , enableGtk3 ? false, cairo
@@ -34,6 +34,11 @@ buildPythonPackage rec {
     ]
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ];
+
+  propagatedUserEnvPkgs =
+    [ pyparsing cycler dateutil
+    ]
+    ++ stdenv.lib.optional python.isPy3k six;
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv.patch ];
 


### PR DESCRIPTION
###### Things done:
- [ x ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
