### PR TITLE
cc-wrapper: add option to skip flags for native optimizations

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -91,6 +91,20 @@ if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" ]; then
     params=("${rest[@]}")
 fi
 
+
+# Clear march/mtune=native -- they bring impurity.
+if [ "$NIX_ENFORCE_NO_NATIVE" = 1 ]; then
+    rest=()
+    for i in "${params[@]}"; do
+        if [[ "$i" = -m*=native ]]; then
+            skip $i
+        else
+            rest=("${rest[@]}" "$i")
+        fi
+    done
+    params=("${rest[@]}")
+fi
+
 if [[ "$isCpp" = 1 ]]; then
     NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
     NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK $NIX_CXXSTDLIB_LINK"

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -70,6 +70,20 @@ if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" ]; then
 fi
 
 
+# Clear march/mtune=native -- they bring impurity.
+if [ "$NIX_ENFORCE_NO_NATIVE" = 1 ]; then
+    rest=()
+    for i in "${params[@]}"; do
+        if [[ "$i" = -m*=native ]]; then
+            skip $i
+        else
+            rest=("${rest[@]}" "$i")
+        fi
+    done
+    params=("${rest[@]}")
+fi
+
+
 # Add the flags for the GNAT compiler proper.
 extraAfter=($NIX_GNATFLAGS_COMPILE)
 extraBefore=()

--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
     ''
       sed -i GNUmakefile \
         -e 's|-march=native|${marchflags} -fPIC|g' \
-        -e 's|-mtune=native||g' \
         -e '/^CXXFLAGS =/s|-g ||'
     '';
 

--- a/pkgs/misc/emulators/higan/0001-change-flags.diff
+++ b/pkgs/misc/emulators/higan/0001-change-flags.diff
@@ -11,15 +11,6 @@ diff -rupN higan_v095-source.orig/GNUmakefile higan_v095-source/GNUmakefile
  objects := libco
  
  # profile-guided optimization mode
-@@ -43,7 +44,7 @@ ifeq ($(platform),windows)
- else ifeq ($(platform),macosx)
-   flags += -march=native
- else ifeq ($(platform),linux)
--  flags += -march=native -fopenmp
-+  flags += -fopenmp
-   link += -fopenmp
-   link += -Wl,-export-dynamic
-   link += -lX11 -lXext -ldl
 diff -rupN higan_v095-source.orig/icarus/GNUmakefile higan_v095-source/icarus/GNUmakefile
 --- higan_v095-source.orig/icarus/GNUmakefile	2015-11-04 10:28:26.186486119 +0100
 +++ higan_v095-source/icarus/GNUmakefile	2015-11-04 10:28:48.755059317 +0100

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -26,6 +26,7 @@ in rec {
 
   commonPreHook = ''
     export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
+    export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
     export NIX_IGNORE_LD_THROUGH_GCC=1
     stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
     export MACOSX_DEPLOYMENT_TARGET=10.7

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -23,6 +23,7 @@ rec {
   commonPreHook =
     ''
       export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
+      export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
       ${if system == "x86_64-linux" then "NIX_LIB64_IN_SELF_RPATH=1" else ""}
       ${if system == "mips64el-linux" then "NIX_LIB32_IN_SELF_RPATH=1" else ""}
     '';

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -16,6 +16,7 @@ rec {
     # Disable purity tests; it's allowed (even needed) to link to
     # libraries outside the Nix store (like the C library).
     export NIX_ENFORCE_PURITY=
+    export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
   '';
 
   prehookFreeBSD = ''

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -6,6 +6,7 @@ import ../generic rec {
   preHook =
     ''
       export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
+      export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
       export NIX_IGNORE_LD_THROUGH_GCC=1
     '';
 

--- a/pkgs/tools/networking/pingtcp/default.nix
+++ b/pkgs/tools/networking/pingtcp/default.nix
@@ -13,11 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  postPatch = ''
-    substituteInPlace {.,pfcquirks}/CMakeLists.txt \
-      --replace "-march=native" ""
-  '';
-
   enableParallelBuilding = true;
 
   doCheck = false;

--- a/pkgs/tools/security/crackxls/default.nix
+++ b/pkgs/tools/security/crackxls/default.nix
@@ -13,12 +13,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig autoconf automake openssl libgsf gmp ];
 
-  patchPhase = ''
-    substituteInPlace Makefile.in \
-      --replace '-march=native' "" \
-      --replace '-mtune=native' ""
-  '';
-
   installPhase =
   ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This adds filtering of `-mwhatever=native` compiler options in NixOS. Previously it was done ad-hoc by package maintainers. Tested together with #13907 by building and running `higan` (a random package with broad enough dependencies and `-march=native`). Also removed all previous custom fixes for this across the tree.

Fixes issue #13662.
