### PR TITLE
meta: Add sheenobu as maintainer for relevant packages.

### DIFF
--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     homepage = http://freeradius.org/;
     description = "A modular, high performance free RADIUS suite";
     license = stdenv.lib.licenses.gpl2;
+    maintainers = with maintainers; [ sheenobu ];
   };
 
 }

--- a/pkgs/tools/networking/sipsak/default.nix
+++ b/pkgs/tools/networking/sipsak/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/sipwise/sipsak;
     description = "SIP Swiss army knife";
     license = stdenv.lib.licenses.gpl2;
+    maintainers = with maintainers; [ sheenobu ];
   };
 
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._

freeradius: add sheenobu as maintainer

sipsak: add sheenobu as maintainer
