### PR TITLE
freeradius: optional dependency support, pcap and cap enabled

### DIFF
--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -1,28 +1,69 @@
-{ stdenv, fetchurl, autoreconfHook, talloc, openssl ? null }:
+{ stdenv, fetchurl, autoreconfHook, talloc
+, openssl
+, linkOpenssl? true
+, openldap
+, withLdap ? false
+, sqlite
+, withSqlite ? false
+, libpcap
+, withPcap ? true
+, libcap
+, withCap ? true
+, libmemcached
+, withMemcached ? false
+, hiredis
+, withRedis ? false
+, libmysql
+, withMysql ? false
+, withJson ? false
+, libyubikey
+, withYubikey ? false
+, collectd
+, withCollectd ? false
+}:
 
-## TODO: include ldap optionally
-## TODO: include sqlite optionally
-## TODO: include mysql optionally
+assert withSqlite -> sqlite != null;
+assert withLdap -> openldap != null;
+assert withPcap -> libpcap != null;
+assert withCap -> libcap != null;
+assert withMemcached -> libmemcached != null;
+assert withRedis -> hiredis != null;
+assert withMysql -> libmysql != null;
+assert withYubikey -> libyubikey != null;
+assert withCollectd -> collectd != null;
 
+## TODO: include windbind optionally (via samba?)
+## TODO: include oracle optionally
+## TODO: include ykclient optionally
+
+with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "freeradius-${version}";
   version = "3.0.11";
 
-  buildInputs = [
-    autoreconfHook
-    talloc
-    openssl
-  ];
+  buildInputs = [ autoreconfHook openssl talloc ]
+    ++ optional withLdap [ openldap ]
+    ++ optional withSqlite [ sqlite ]
+    ++ optional withPcap [ libpcap ]
+    ++ optional withCap [ libcap ]
+    ++ optional withMemcached [ libmemcached ]
+    ++ optional withRedis [ hiredis ]
+    ++ optional withMysql [ libmysql ]
+    ++ optional withJson [ pkgs."json-c" ]
+    ++ optional withYubikey [ libyubikey ]
+    ++ optional withCollectd [ collectd ];
+
+  # NOTE: are the --with-{lib}-lib-dir and --with-{lib}-include-dir necessary with buildInputs ?
 
   configureFlags = [
      "--sysconfdir=/etc"
      "--localstatedir=/var"
-  ];
+  ] ++ optional (!linkOpenssl) "--with-openssl=no";
 
   installFlags = [
     "sysconfdir=\${out}/etc"
     "localstatedir=\${TMPDIR}"
-   ];
+  ];
 
   src = fetchurl {
     url = "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-${version}.tar.gz";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._
