### PR TITLE
haskell-modules: fix conduit runtime dependency

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.8.x.nix
@@ -136,6 +136,7 @@ self: super: {
 
   # Needs void on pre 7.10.x compilers.
   conduit = addBuildDepend super.conduit self.void;
+  conduit_1_2_5 = addBuildDepend super.conduit_1_2_5 self.void;
 
   # Needs nats on pre 7.10.x compilers.
   semigroups = addBuildDepend super.semigroups self.nats;


### PR DESCRIPTION
This fixes an issue regarding Haskell modules set LTS-2.21. The `Void` dependency of `Conduit` package was set on expression `conduit`, while in fact, `condui_1_2_5` is used for this set.
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s): NixOS / OSX / Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
