### PR TITLE
opencsg: Fix build related to missing libX11 linking the example.

### DIFF
--- a/pkgs/development/libraries/opencsg/default.nix
+++ b/pkgs/development/libraries/opencsg/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
+  preConfigure = ''
+    sed -i 's/^\(LIBS *=.*\)$/\1 -lX11/' example/Makefile
+  '';
+
   installPhase = ''
     mkdir -pv "$out/"{bin,share/doc/opencsg}
 


### PR DESCRIPTION
See https://hydra.nixos.org/build/32684629 (when Hydra starts working again).

I have only seen this happening on release-16.03 not on master. So please merge at least to release-16.03 (yes this PR is against master). I don't completely understand the error but it looks like some logic for the linking might have changed, or dependencies of libraries have changed to cause this.
