### PR TITLE
communi: fix .desktop file's `Exec` path

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapQtProgram "$out/bin/communi"
+    substituteInPlace "$out/share/applications/communi.desktop" \
+      --replace "/usr/bin" "$out/bin"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux (NixOS)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Changes `Exec` in `communi.desktop` from `/usr/bin/communi` to `$out/bin/communi`.
