### PR TITLE
zotero: 4.0.28 -> 4.0.29

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -4,10 +4,10 @@ let
 
   xpi = fetchurl {
     url = "https://download.zotero.org/extension/zotero-${version}.xpi";
-    sha256 = "02h2ja08v8as4fawj683rh5rmxsjf5d0qmvqa77i176nm20y5s7s";
+    sha256 = "1dyf578yfj3xr9kkhmsvbkvraw2arghmh67ksi5c8qlxczx5i1xy";
   };
 
-  version = "4.0.28";
+  version = "4.0.29";
 
 in
 stdenv.mkDerivation {
@@ -15,8 +15,8 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://github.com/zotero/zotero-standalone-build/archive/4.0.28.8.tar.gz";
-    sha256 = "ab1fd5dde9bd2a6b6d31cc9a53183a04de3698f1273a943ef31ecc4c42808a68";
+    url = "https://github.com/zotero/zotero-standalone-build/archive/4.0.29.2.tar.gz";
+    sha256 = "0pfip6s5dawp7wp8r5czvzlnxvvdwjja64g71h9dxyxrh49v2mxa";
   };
 
   nativeBuildInputs = [ perl unzipNLS ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @ttuegel 

---

Built and tested locally.

From the changelog:

```
Firefox 45/46 compatibility
  * [Zotero Standalone] Save PDFs directly from browsers via the Save to
    Zotero button
  * Requires Chrome connector version 4.0.29; updated Safari connector
    coming soon
  * To convert a standalone PDF attachment to a full item, right-click
    the item and choose “Retrieve Metadata for PDF” or “Create Parent
    Item”.
  * [Zotero for Firefox] Don't show Firefox open/save dialog when
    showing style installation prompt
  * Retry additional file sync failures automatically
  * Fixed potential crash when dragging in files on some systems
  * Fixed potential crash when dragging collections to another library
  * Miscellaneous bibliographic output and word processor integration
    fixes
  * Updated citeproc-js to version 1.1.71
  * Fixed spacing of toolbar icons on Windows/Linux in Firefox 43+
  * Use larger text field for Book Title
  * Make highlight color of selected items list rows on Linux more
    distinct when items pane doesn't have focus
  * [Zotero for Firefox] Improved error message on Firefox login manager
    failure
  * Improved error message when trying to use a later database version
```
