### PR TITLE
yamdi: change src url to sourceforge mirror

### DIFF
--- a/pkgs/tools/video/yamdi/default.nix
+++ b/pkgs/tools/video/yamdi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   # Source repo is also available here:
   # https://github.com/ioppermann/yamdi
   src = fetchurl {
-    url = "https://downloads.sourceforge.net/project/yamdi/yamdi/${version}/yamdi-${version}.tar.gz";
+    url = "mirror://sourceforge/yamdi/yamdi-${version}.tar.gz";
     sha256 = "4a6630f27f6c22bcd95982bf3357747d19f40bd98297a569e9c77468b756f715";
   };
 


### PR DESCRIPTION
The PR introducing the yamdi package ( #13962 ) was merged before a final comment could be addressed. This fixes the sourforge src URL to use our sourceforge mirror instead of sourceforge directly.

cc @hrdinka 
