### PR TITLE
openmpi: added infiniband support (ibverbs)

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gfortran, perl
+{stdenv, fetchurl, gfortran, perl, libibverbs
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     sha256 = "14p4px9a3qzjc22lnl6braxrcrmd9rgmy7fh4qpanawn2pgfq6br";
   };
 
-  buildInputs = [ gfortran ];
+  buildInputs = [ gfortran libibverbs ];
 
   nativeBuildInputs = [ perl ];
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @mornfall 

_Please note, that points are not mandatory, but rather desired._

For the efficient use of openmpi on an HPC platform, one needs the infiniband support which is provided by libibverbs.

Tested with:

```
bzizou@killeen:~/nixpkgs$ ompi_info |grep openib
                 MCA btl: openib (MCA v2.0.0, API v2.0.0, Component v1.10.1)
```

Also tested with a ping/pong c++ application and Gromacs (after also patching the libibverbs package to support some drivers, pull request is coming)

---
