### PR TITLE
libibverbs: added mlx4 and mthca userspace driver plugins

### DIFF
--- a/pkgs/development/libraries/libibverbs/default.nix
+++ b/pkgs/development/libraries/libibverbs/default.nix
@@ -1,17 +1,65 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
-  name = "libibverbs-1.1.8";
+let
 
-  src = fetchurl {
-    url = "https://www.openfabrics.org/downloads/verbs/${name}.tar.gz";
-    sha256 = "13w2j5lrrqxxxvhpxbqb70x7wy0h8g329inzgfrvqv8ykrknwxkw";
+  verbs = rec {
+      version = "1.1.8";
+      name = "libibverbs-${version}";
+      url = "http://downloads.openfabrics.org/verbs/${name}.tar.gz";
+      sha256 = "13w2j5lrrqxxxvhpxbqb70x7wy0h8g329inzgfrvqv8ykrknwxkw";
   };
+
+  drivers = {
+      libmlx4 = rec { 
+          version = "1.0.6";
+          name = "libmlx4-${version}"; 
+          url = "http://downloads.openfabrics.org/mlx4/${name}.tar.gz";
+          sha256 = "f680ecbb60b01ad893490c158b4ce8028a3014bb8194c2754df508d53aa848a8";
+      };
+      libmthca = rec { 
+          version = "1.0.6"; 
+          name = "libmthca-${version}"; 
+          url = "http://downloads.openfabrics.org/mthca/${name}.tar.gz";
+          sha256 = "cc8ea3091135d68233d53004e82b5b510009c821820494a3624e89e0bdfc855c";
+      };
+  };
+
+in stdenv.mkDerivation rec {
+
+  inherit (verbs) name version ;
+
+  srcs = [
+    ( fetchurl { inherit (verbs) url sha256 ; } )
+    ( fetchurl { inherit (drivers.libmlx4) url sha256 ; } )
+    ( fetchurl { inherit (drivers.libmthca) url sha256 ; } )
+  ];
+
+  sourceRoot = name;
+
+  # Install userspace drivers
+  postInstall = ''
+    for dir in ${drivers.libmlx4.name} ${drivers.libmthca.name} ; do
+      cd ../$dir
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I$out/include"
+      export NIX_LDFLAGS="-rpath $out/lib $NIX_LDFLAGS -L$out/lib"
+      ./configure $configureFlags
+      make -j$NIX_BUILD_CORES
+      make install
+    done
+  '';
+
+  # Re-add the libibverbs path into runpath of the library
+  # to enable plugins to be found by dlopen
+  postFixup = ''
+    RPATH=$(patchelf --print-rpath $out/lib/libibverbs.so)
+    patchelf --set-rpath $RPATH:$out/lib $out/lib/libibverbs.so.1.0.0
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://www.openfabrics.org/;
     license = licenses.bsd2;
     platforms = with platforms; linux ++ freebsd;
-    maintainers = with maintainers; [ wkennington ];
+    maintainers = with maintainers; [ wkennington bzizou ];
   };
 }
+


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @wkennington 

_Please note, that points are not mandatory, but rather desired._

---

Tested with 2 openmpi applications (a ping/pong in c++ and GromacsMpi) on an HPC cluster with mlx4 interfaces (BullX host)
It should be possible to add other driver plugins, but I'm only able to test mlx4 and mthca.
