### PR TITLE
nodejs: 5.8.0 -> 5.9.0

### DIFF
--- a/pkgs/development/web/nodejs/v5.nix
+++ b/pkgs/development/web/nodejs/v5.nix
@@ -7,7 +7,7 @@
 assert stdenv.system != "armv5tel-linux";
 
 let
-  version = "5.8.0";
+  version = "5.9.0";
 
   deps = {
     inherit openssl zlib libuv;
@@ -31,7 +31,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "165q4bbq1fjrr82ciiczbgyz37fl8sg3nqspccz0aqhwxh65ikg8";
+    sha256 = "0ghgfqs64794g6ggrvsdcqwz2lnhck0yiy2fyyg3in8z91k5l5z5";
   };
 
   configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ];


### PR DESCRIPTION
###### Things done:
- Built on platform(s)
  - [X] OS X
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
