### PR TITLE
buildRubyGem: use Gem.use_paths to load gems

### DIFF
--- a/pkgs/development/interpreters/ruby/build-ruby-gem/gem-post-build.rb
+++ b/pkgs/development/interpreters/ruby/build-ruby-gem/gem-post-build.rb
@@ -64,8 +64,7 @@ spec.executables.each do |exe|
 # this file is here to facilitate running it.
 #
 
-gem_path = ENV["GEM_PATH"]
-ENV["GEM_PATH"] = "\#{gem_path}\#{":" unless gem_path.nil? || gem_path.empty?}#{(gem_path+[gem_home]).join(":")}"
+Gem.use_paths "#{gem_home}", #{gem_path.to_s}
 
 require 'rubygems'
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @cstrahan 

---

After ruby initializes, rubygems no longer reads the GEM_PATH. Before,
we have the following scenario:

```
Gem.path # => ["a"]
ENV['GEM_PATH'] = ["b"]
Gem.path # => ["a"] # Still returns the same
```

Gem.use_paths is the documented way to create isolated environments as
documented in [1].

[1] http://www.rubydoc.info/github/rubygems/rubygems/Gem.use_paths
