### PR TITLE
Add hydraPlatform to all ocaml modules and ocaml versions.

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -50,7 +50,8 @@ stdenv.mkDerivation {
     homepage = "http://www.loria.fr/equipes/calligramme/acg";
     description = "A toolkit for developing ACG signatures and lexicon";
     license = licenses.cecill20;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -11,7 +11,8 @@
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
   defaultMeta = {
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 in
   assert minimumSupportedOcamlVersion != null ->

--- a/pkgs/development/compilers/mezzo/default.nix
+++ b/pkgs/development/compilers/mezzo/default.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation {
     homepage = http://protz.github.io/mezzo/;
     description = "A programming language in the ML tradition, which places strong emphasis on the control of aliasing and access to mutable memory";
     license = licenses.gpl2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }
 

--- a/pkgs/development/compilers/ocaml/3.08.0.nix
+++ b/pkgs/development/compilers/ocaml/3.08.0.nix
@@ -12,4 +12,12 @@ stdenv.mkDerivation {
   configureFlags = ["-no-tk" "-x11lib" xlibsWrapper];
   buildFlags = ["world" "bootstrap" "opt"];
   checkTarget = ["opt.opt"];
+
+  meta = {
+    homepage = http://caml.inria.fr/ocaml;
+    license = with stdenv.lib.licenses; [ qpl lgpl2 ];
+    description = "Most popular variant of the Caml language";
+    platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
+  };
 }

--- a/pkgs/development/compilers/ocaml/3.10.0.nix
+++ b/pkgs/development/compilers/ocaml/3.10.0.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation (rec {
     homepage = http://caml.inria.fr/ocaml;
     license = with stdenv.lib.licenses; [ qpl lgpl2 ];
     description = "Most popular variant of the Caml language";
+    platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
   };
 
 })

--- a/pkgs/development/compilers/ocaml/3.11.2.nix
+++ b/pkgs/development/compilers/ocaml/3.11.2.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation rec {
        '';
 
     platforms = with platforms; linux ++ darwin;
+    hydraPlatforms = with platforms; linux ++ darwin;
   };
 
 }

--- a/pkgs/development/compilers/ocaml/3.12.1.nix
+++ b/pkgs/development/compilers/ocaml/3.12.1.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
       '';
 
     platforms = with platforms; linux ++ darwin;
+    hydraPlatforms = with platforms; linux ++ darwin;
   };
 
 }

--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation rec {
       '';
 
     platforms = with platforms; linux ++ darwin;
+    hydraPlatforms = with platforms; linux ++ darwin;
   };
 
 }

--- a/pkgs/development/compilers/ocaml/4.01.0.nix
+++ b/pkgs/development/compilers/ocaml/4.01.0.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation rec {
       '';
 
     platforms = with platforms; linux ++ darwin;
+    hydraPlatforms = with platforms; linux ++ darwin;
   };
 
 }

--- a/pkgs/development/compilers/ocaml/4.02.nix
+++ b/pkgs/development/compilers/ocaml/4.02.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
       '';
 
     platforms = with platforms; linux ++ darwin;
+    hydraPlatforms = with platforms; linux ++ darwin;
   };
 
 }

--- a/pkgs/development/interpreters/eff/default.nix
+++ b/pkgs/development/interpreters/eff/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation {
       backtracking, multi-threading, and much more...
     '';
     license = licenses.bsd2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/development/ocaml-modules/ansiterminal/default.nix
+++ b/pkgs/development/ocaml-modules/ansiterminal/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation {
       this part is currently work in progress).
     '';
     license = licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/mirleft/ocaml-asn1-combinators;
     description = "Combinators for expressing ASN.1 grammars in OCaml";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
     broken = stdenv.isi686; # https://github.com/mirleft/ocaml-asn1-combinators/issues/13

--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = https://github.com/mirage/ocaml-base64;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "Base64 encoding and decoding in OCaml";
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation {
       language.
     '';
     license = stdenv.lib.licenses.lgpl21Plus;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "${webpage}";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -48,7 +48,8 @@ EOF
       modeled after the famous log4j logging framework for Java.
     '';
     license = licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/development/ocaml-modules/calendar/default.nix
+++ b/pkgs/development/ocaml-modules/calendar/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
     homepage = https://forge.ocamlcore.org/projects/calendar/;
     description = "An Objective Caml library managing dates and times";
     license = "LGPL";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.gal_bolle
     ];

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -40,7 +40,8 @@ stdenv.mkDerivation {
       for reading from and writing to compressed files in these formats.
     '';
     license = "LGPL+linking exceptions";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/camomile/0.8.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.2.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation {
     description = "A comprehensive Unicode library for OCaml";
     license = stdenv.lib.licenses.lgpl21;
     branch = "0.8.2";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation {
     homepage = https://github.com/yoriyuki/Camomile/tree/master/Camomile;
     description = "A comprehensive Unicode library for OCaml";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/cil/default.nix
+++ b/pkgs/development/ocaml-modules/cil/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
     description = "A front-end for the C programming language that facilitates program analysis and transformation";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
     description = "An OCaml module for the declarative definition of command line interfaces";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/config-file/default.nix
+++ b/pkgs/development/ocaml-modules/config-file/default.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://config-file.forge.ocamlcore.org/;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "An OCaml library used to manage the configuration file(s) of an application";
     license = stdenv.lib.licenses.lgpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation {
       helpers for unix and threads.
     '';
     license = stdenv.lib.licenses.bsd2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = http://www.coherentpdf.com/;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "PDF Command Line Tools";
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation {
       itself.
     '';
     license = stdenv.lib.licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://pauillac.inria.fr/~xleroy/software.html";
     description = "A library of cryptographic primitives for OCaml";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
     description = "Map OCaml arrays onto C-like structs";
     license = stdenv.lib.licenses.isc;
     maintainers = [ maintainers.vbgl maintainers.ericbmerritt ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/csv/default.nix
+++ b/pkgs/development/ocaml-modules/csv/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/Chris00/ocaml-csv;
     license = licenses.lgpl21;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/dolog/default.nix
+++ b/pkgs/development/ocaml-modules/dolog/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/UnixJunkie/dolog;
     description = "Minimalistic lazy logger in OCaml";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation {
     homepage = http://dypgen.free.fr;
     description = "Dypgen GLR self extensible parser generator";
     license = stdenv.lib.licenses.cecill-b;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -51,7 +51,8 @@ stdenv.mkDerivation rec
 
     license = stdenv.lib.licenses.lgpl21;
 
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
 
     maintainers = [ stdenv.lib.maintainers.gal_bolle ];
   };

--- a/pkgs/development/ocaml-modules/enumerate/default.nix
+++ b/pkgs/development/ocaml-modules/enumerate/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation {
     homepage = https://ocaml.janestreet.com/;
     description = "Quotation expanders for enumerating finite types";
     license = stdenv.lib.licenses.asl20;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/ermine/xml;
     description = "XML Parser for discrete data";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/ermine/xmpp;
     description = "OCaml based XMPP implementation";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
     homepage = http://code.google.com/p/ocaml-extlib/;
     description = "Enhancements to the OCaml Standard Library modules";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/mirage/ezjsonm;
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/fieldslib/default.nix
+++ b/pkgs/development/ocaml-modules/fieldslib/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
     description = "OCaml syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values";
     license = licenses.asl20;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/fileutils/default.nix
+++ b/pkgs/development/ocaml-modules/fileutils/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = https://forge.ocamlcore.org/projects/ocaml-fileutils/;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "Library to provide pure OCaml functions to manipulate real file (POSIX like) and filename";
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/fix/default.nix
+++ b/pkgs/development/ocaml-modules/fix/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
     description = "A simple OCaml module for computing the least solution of a system of monotone equations";
     license = licenses.cecill-c;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/fontconfig/default.nix
+++ b/pkgs/development/ocaml-modules/fontconfig/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
   meta = {
     description = "Fontconfig bindings for OCaml";
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
     description = "A distributed computing library for Objective Caml which facilitates distributed execution of parallelizable computations in a seamless fashion";
     license = licenses.lgpl21;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     homepage = http://gapi-ocaml.forge.ocamlcore.org;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ bennofs ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/c-cube/gen;
     description = "Simple, efficient iterators for OCaml";
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -41,7 +41,8 @@ stdenv.mkDerivation rec {
       raster data.
     '';
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];
   };

--- a/pkgs/development/ocaml-modules/gtktop/default.nix
+++ b/pkgs/development/ocaml-modules/gtktop/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
     description = "A small OCaml library to ease the creation of graphical toplevels";
     license = stdenv.lib.licenses.lgpl3;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/mirage/ocaml-hex;
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/http/default.nix
+++ b/pkgs/development/ocaml-modules/http/default.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = http://ocaml-http.forge.ocamlcore.org/;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "do it yourself (OCaml) HTTP daemon";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ roconnor vbgl ];

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = https://github.com/mirage/io-page;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "IO memory page library for Mirage backends";
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/iso8601/default.nix
+++ b/pkgs/development/ocaml-modules/iso8601/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
     homepage = http://sagotch.github.io/ISO8601.ml/;
     description = "ISO 8601 and RFC 3999 date parsing for OCaml";
     license = stdenv.lib.licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "${webpage}";
     license = licenses.lgpl3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     homepage = http://erratique.ch/software/jsonm;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation {
   createFindlibDestdir = true;
 
   meta = {
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
     homepage = http://gtk-extras.forge.ocamlcore.org/;
     description = "A collection of libraries and modules useful when developing OCaml/LablGtk2 applications";

--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
   createFindlibDestdir = true;
 
   meta = {
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
     homepage = http://gtk-extras.forge.ocamlcore.org/;
     description = "A collection of libraries and modules useful when developing OCaml/LablGtk2 applications";

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation (rec {
 
   meta = {
     branch = "2.14";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
       stdenv.lib.maintainers.roconnor

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       z77z roconnor vbgl
     ];

--- a/pkgs/development/ocaml-modules/lambda-term/1.6.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/1.6.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation rec {
 
     homepage = https://github.com/diml/lambda-term;
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     branch = "1.6";
     maintainers = [
       stdenv.lib.maintainers.gal_bolle

--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
 
     homepage = https://github.com/diml/lambda-term;
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.gal_bolle
     ];

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation {
 
   meta = {
     inherit (llvm.meta) license homepage;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "OCaml bindings distributed with LLVM";
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation {
     homepage = http://ocsigen.org/lwt;
     description = "Lightweight thread library for Objective Caml";
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       z77z vbgl gal_bolle
     ];

--- a/pkgs/development/ocaml-modules/macaque/default.nix
+++ b/pkgs/development/ocaml-modules/macaque/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
     description = "Macros for Caml Queries";
     homepage = https://github.com/ocsigen/macaque;
     license = licenses.lgpl2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/magic-mime/default.nix
+++ b/pkgs/development/ocaml-modules/magic-mime/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/mirage/ocaml-magic-mime;
     description = "Convert file extensions to MIME types";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/menhir/generic.nix
+++ b/pkgs/development/ocaml-modules/menhir/generic.nix
@@ -41,7 +41,8 @@ stdenv.mkDerivation {
       qpl /* generator */
       lgpl2 /* library */
     ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ z77z ];
   };
 }

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/mirleft/ocaml-nocrypto;
     description = "Simplest possible crypto to support TLS";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
     homepage = http://cairographics.org/cairo-ocaml;
     description = "ocaml bindings for cairo library";
     license = stdenv.lib.licenses.gpl2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo2/default.nix
@@ -47,7 +47,8 @@ stdenv.mkDerivation {
       and SVG file output.
     '';
     license = licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-result/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-result/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
       Result module defined in this library.
     '';
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-text/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-text/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation {
     homepage = "http://ocaml-text.forge.ocamlcore.org/";
     description = "A library for convenient text manipulation";
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -38,7 +38,8 @@ stdenv.mkDerivation {
     homepage = http://ocamlgraph.lri.fr/;
     description = "Graph library for Objective Caml";
     license = stdenv.lib.licenses.gpl2Oss;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.kkallio
     ];

--- a/pkgs/development/ocaml-modules/ocamlnat/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnat/default.nix
@@ -32,7 +32,8 @@ stdenv.mkDerivation {
       x86 or x86-64 processors. Support for additional architectures and
       operating systems is planned, but not yet available.
     '';
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -42,7 +42,8 @@ stdenv.mkDerivation {
     homepage = http://projects.camlcity.org/projects/ocamlnet.html;
     description = "A library implementing Internet protocols (http, cgi, email, etc.) for OCaml";
     license = "Most Ocamlnet modules are released under the zlib/png license. The HTTP server module Nethttpd is, however, under the GPL.";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/ocplib-endian/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-endian/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation {
     description = "Optimised functions to read and write int16/32/64";
     homepage = https://github.com/OCamlPro/ocplib-endian;
     license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
     homepage = https://github.com/ocsigen/deriving;
     description = "Extension to OCaml for deriving functions from type declarations";
     license = stdenv.lib.licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [
       gal_bolle vbgl
     ];

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -42,7 +42,8 @@ stdenv.mkDerivation {
       A full featured Web server. It implements most features of the HTTP protocol, and has a very powerful extension mechanism that make very easy to plug your own OCaml modules for generating pages.
       '';
     license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ stdenv.lib.maintainers.gal_bolle ];
   };
 

--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd3;
     homepage = http://ocurl.forge.ocamlcore.org/;
     maintainers = with stdenv.lib.maintainers; [ bennofs ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation {
     description = "Store data using OCaml notation";
     homepage = https://forge.ocamlcore.org/projects/odn/;
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       vbgl z77z
     ];

--- a/pkgs/development/ocaml-modules/ojquery/default.nix
+++ b/pkgs/development/ocaml-modules/ojquery/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
     description = "jQuery Binding for Eliom";
     homepage = http://ocsigen.org/ojquery/;
     license = stdenv.lib.licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/optcomp/default.nix
+++ b/pkgs/development/ocaml-modules/optcomp/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
     homepage = https://github.com/diml/optcomp;
     description = "Optional compilation for OCaml with cpp-like directives";
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.gal_bolle
     ];

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -42,7 +42,8 @@ stdenv.mkDerivation rec {
       of them.
     '';
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];
   };

--- a/pkgs/development/ocaml-modules/ounit/default.nix
+++ b/pkgs/development/ocaml-modules/ounit/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
     homepage = http://ounit.forge.ocamlcore.org/;
     description = "Unit test framework for OCaml";
     license = stdenv.lib.licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -22,7 +22,8 @@ buildOcaml {
     homepage = "https://bitbucket.org/mmottl/pcre-ocaml";
     description = "An efficient C-library for pattern matching with Perl-style regular expressions in OCaml";
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ z77z vbmithr ];
   };
 }

--- a/pkgs/development/ocaml-modules/pgocaml/default.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
     description = "An interface to PostgreSQL databases for OCaml applications";
     homepage = http://pgocaml.forge.ocamlcore.org/;
     license = licenses.lgpl2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/pprint/default.nix
+++ b/pkgs/development/ocaml-modules/pprint/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
     description = "An OCaml adaptation of Wadler’s and Leijen’s prettier printer";
     license = licenses.cecill-c;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
     description = "Tools for authors of ppx rewriters";
     homepage = http://www.lexifi.com/ppx_tools;
     license = licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/pycaml/default.nix
+++ b/pkgs/development/ocaml-modules/pycaml/default.nix
@@ -46,6 +46,7 @@ in stdenv.mkDerivation {
     homepage = "http://github.com/chemoelectric/pycaml";
     description = "Bindings for python and ocaml";
     license = "LGPL";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/c-cube/qcheck/;
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/qtest/default.nix
+++ b/pkgs/development/ocaml-modules/qtest/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation {
   meta = {
     description = "Inline (Unit) Tests for OCaml (formerly “qtest”)";
     homepage = https://github.com/vincent-hugot/iTeML;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/re/default.nix
+++ b/pkgs/development/ocaml-modules/re/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://github.com/ocaml/ocaml-re;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "Pure OCaml regular expressions, with support for Perl and POSIX-style strings";
     license = stdenv.lib.licenses.lgpl2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation {
     homepage = http://erratique.ch/software/react;
     description = "Applicative events and signals for OCaml";
     license = licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ z77z vbmithr gal_bolle];
   };
 }

--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation {
     description = "An OCaml module for functional reactive programming (FRP) based on React";
     homepage = https://github.com/hhugo/reactiveData;
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/safepass/default.nix
+++ b/pkgs/development/ocaml-modules/safepass/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
     homepage = http://ocaml-safepass.forge.ocamlcore.org/;
     description = "An OCaml library offering facilities for the safe storage of user passwords";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "${webpage}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/sequence/default.nix
+++ b/pkgs/development/ocaml-modules/sequence/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
       sequence is iterated/folded on.
     '';
     license = stdenv.lib.licenses.bsd2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/sexplib/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/sexplib/108.08.00.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     description = "Library for serializing OCaml values to and from S-expressions";
     license = licenses.asl20;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/sexplib/111.25.00.nix
+++ b/pkgs/development/ocaml-modules/sexplib/111.25.00.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
     description = "Library for serializing OCaml values to and from S-expressions";
     license = licenses.asl20;
     maintainers = [ maintainers.vbgl maintainers.ericbmerritt ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/sqlite3/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
     homepage = http://mmottl.github.io/sqlite3-ocaml/;
     description = "OCaml bindings to the SQLite 3 database access library";
     license = licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       z77z vbgl
     ];

--- a/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
     description = "A thin wrapper for sqlite3-ocaml with a simplified interface";
     license = licenses.mit;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
     homepage = http://savonet.rastageeks.org/;
     description = "OCaml bindings for libssl ";
     license = "LGPL+link exception";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = https://github.com/rgrinberg/stringext;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "Extra string functions for OCaml";
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
     homepage = "${webpage}";
     description = "Thin bindings to the cross-platform SDL library";
     license = licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/twt/default.nix
+++ b/pkgs/development/ocaml-modules/twt/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     description = "“The Whitespace Thing” for OCaml";
     license = licenses.mit;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation {
     description = "Support library for OCaml preprocessor type conversions";
     license = licenses.asl20;
     branch = "108";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ z77z ];
   };
 }

--- a/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation {
     homepage = "http://forge.ocamlcore.org/projects/type-conv/";
     description = "Support library for OCaml preprocessor type conversions";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ z77z ];
   };
 }

--- a/pkgs/development/ocaml-modules/tyxml/default.nix
+++ b/pkgs/development/ocaml-modules/tyxml/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation {
     homepage = http://ocsigen.org/tyxml/;
     description = "A library that makes it almost impossible for your OCaml programs to generate wrong XML output, using static typing";
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       gal_bolle vbgl
       ];

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
     homepage = http://www.cduce.org/download.html;
     description = "A lexer generator for Unicode and OCaml";
     license = stdenv.lib.licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ stdenv.lib.maintainers.roconnor ];
   };
 }

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = https://github.com/mirage/ocaml-uri;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "RFC3986 URI parsing library for OCaml";
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/uucd/default.nix
+++ b/pkgs/development/ocaml-modules/uucd/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An OCaml module to decode the data of the Unicode character database from its XML representation";
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;
   };

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "An OCaml library providing efficient access to a selection of character properties of the Unicode character database";
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
   };

--- a/pkgs/development/ocaml-modules/uuidm/default.nix
+++ b/pkgs/development/ocaml-modules/uuidm/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     description = "An OCaml module implementing 128 bits universally unique identifiers version 3, 5 (name based with MD5, SHA-1 hashing) and 4 (random based) according to RFC 4122";
     homepage = http://erratique.ch/software/uuidm;
     license = licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.maurer ];
   };
 }

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An OCaml module for normalizing Unicode text";
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
   };

--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -40,7 +40,8 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "An OCaml library for segmenting Unicode text";
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
   };

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Non-blocking streaming Unicode codec for OCaml";
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
   };

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
     module. An API allows to implement new renderers.
     '';
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];
   };

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/mirleft/ocaml-x509;
     description = "X509 (RFC5280) handling in OCaml";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
     homepage = "http://tech.motion-twin.com/xmllight.html";
     license = stdenv.lib.licenses.lgpl21;
     maintainers = [ stdenv.lib.maintainers.romildo ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An OCaml streaming codec to decode and encode the XML data format";
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;
   };

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
     homepage = "http://mjambon.com/${pname}.html";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -30,7 +30,8 @@ stdenv.mkDerivation rec {
     description = "fast, arbitrary precision OCaml integers";
     homepage    = "http://forge.ocamlcore.org/projects/zarith";
     license     = licenses.lgpl2;
-    platforms   = ocaml.meta.platforms or [];
+    platforms   = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [ thoughtpolice vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/zed/default.nix
+++ b/pkgs/development/ocaml-modules/zed/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/diml/zed;
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.gal_bolle
     ];

--- a/pkgs/development/tools/misc/trv/default.nix
+++ b/pkgs/development/tools/misc/trv/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     description = "Shim for vrt to enable bootstrapping";
     license = licenses.asl20;
     maintainers = [ maintainers.ericbmerritt ];
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "A software system for writing extensible parsers for programming languages";
     homepage = https://github.com/ocaml/camlp4;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/tools/ocaml/camlp5/5.15.nix
+++ b/pkgs/development/tools/ocaml/camlp5/5.15.nix
@@ -39,7 +39,8 @@ stdenv.mkDerivation {
     homepage = "${webpage}";
     license = stdenv.lib.licenses.bsd3;
     branch = "5";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
     ];

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation {
     '';
     homepage = http://pauillac.inria.fr/~ddr/camlp5/;
     license = licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       z77z vbgl
     ];

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -51,7 +51,8 @@ stdenv.mkDerivation rec {
     homepage = http://projects.camlcity.org/projects/findlib.html;
     description = "O'Caml library manager";
     license = stdenv.lib.licenses.mit;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.z77z
       stdenv.lib.maintainers.vbmithr

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
     homepage = http://ocsigen.org/js_of_ocaml/;
     description = "Compiler of OCaml bytecode to Javascript. It makes it possible to run Ocaml programs in a Web browser";
     license = licenses.lgpl2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       maintainers.gal_bolle
     ];

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
     homepage = http://oasis.forge.ocamlcore.org/;
     description = "Configure, build and install system for OCaml projects";
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with maintainers; [
       vbgl z77z
     ];

--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation {
     homepage = http://www.typerex.org/ocaml-top.html;
     license = stdenv.lib.licenses.gpl3;
     description = "A simple cross-platform OCaml code editor built for top-level evaluation";
-    platforms = ocamlPackages.ocaml.meta.platforms or [];
+    platforms = ocamlPackages.ocaml.meta.platforms;
+    hydraPlatforms = ocamlPackages.ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocamlify/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlify/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://forge.ocamlcore.org/projects/ocamlmod/ocamlmod;
     description = "Generate OCaml modules from source files";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     license = stdenv.lib.licenses.lgpl21;
     maintainers = with stdenv.lib.maintainers; [
       z77z

--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://forge.ocamlcore.org/projects/ocamlmod/ocamlmod;
     description = "Generate OCaml modules from source files";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [
       z77z
     ];

--- a/pkgs/development/tools/ocaml/ocamlscript/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlscript/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = http://martin.jambon.free.fr/ocamlscript.html;
     license = licenses.boost;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     description = "Natively-compiled OCaml scripts";
     maintainers = [ maintainers.vbgl ];
   };

--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation {
       between source files.
     '';
     license = licenses.gpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocp-indent/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-indent/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation {
     homepage = "http://typerex.ocamlpro.com/ocp-indent.html";
     description = "A customizable tool to indent OCaml code";
     license = licenses.gpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -38,7 +38,8 @@ stdenv.mkDerivation {
     homepage = http://typerex.ocamlpro.com/ocp-index.html;
     description = "A simple and light-weight documentation extractor for OCaml";
     license = stdenv.lib.licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
     description = "Omake build system";
     homepage = "${webpage}";
     license = "GPL";
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -43,7 +43,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/diml/utop;
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
     maintainers = [
       stdenv.lib.maintainers.gal_bolle
     ];

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
     homepage = http://liquidsoap.fm/;
     maintainers = with maintainers; [ ehmry ];
     license = licenses.gpl2;
-    platforms = ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms;
+    hydraPlatforms = ocaml.meta.hydraPlatforms;
   };
 }


### PR DESCRIPTION
This is a followup to https://github.com/NixOS/nixpkgs/pull/13897#issuecomment-196785199
Which adds the `hydraPlatforms` attribute to all ocaml modules, and to all ocaml derivations too.

cc @zimbatm, @vbgl and @globin 
