### PR TITLE
libcollectdclient: init at 5.5.0

### DIFF
--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "5.5.0";
+  name = "libcollectdclient-${version}";
+  tarname = "collectd-${version}";
+
+  src = fetchurl {
+    url = "http://collectd.org/files/${tarname}.tar.bz2";
+    sha256 = "847684cf5c10de1dc34145078af3fcf6e0d168ba98c14f1343b1062a4b569e88";
+  };
+
+  configureFlags = [
+    "--without-daemon"
+  ];
+
+  makeFlags = [
+    "-C src/libcollectdclient/"
+  ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
+
+  meta = with stdenv.lib; {
+    description = "C Library for collectd, a daemon which collects system performance statistics periodically";
+    homepage = http://collectd.org;
+    license = licenses.gpl2;
+    platforms = platforms.linux; # TODO: collectd may be linux but the C client may be more portable?
+    maintainers = [ maintainers.sheenobu maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7407,6 +7407,8 @@ let
 
   libcangjie = callPackage ../development/libraries/libcangjie { };
 
+  libcollectdclient = callPackage ../development/libraries/libcollectdclient { };
+
   libcredis = callPackage ../development/libraries/libcredis { };
 
   libctemplate = callPackage ../development/libraries/libctemplate { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) - no binaries
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #13953

cc @bjornfor - added you as maintainer as you are listed in the collectd package.
cc @sheenobu

---

_Please note, that points are not mandatory, but rather desired._
