### PR TITLE
ocamlPackages.containers: 0.15 -> 0.16

### DIFF
--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -1,6 +1,14 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, cppo, gen, sequence, qtest, ounit }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, cppo, gen, sequence, qtest, ounit, ocaml_oasis, result }:
 
-let version = "0.15"; in
+let
+
+  mkpath = p:
+    let v = stdenv.lib.getVersion ocaml; in
+      "${p}/lib/ocaml/${v}/site-lib";
+
+  version = "0.16";
+
+in
 
 stdenv.mkDerivation {
   name = "ocaml-containers-${version}";
@@ -9,10 +17,24 @@ stdenv.mkDerivation {
     owner = "c-cube";
     repo = "ocaml-containers";
     rev = "${version}";
-    sha256 = "13mdl8jp4ymg1wip7lqmh4224x4jnji3frm1ik55vvm3ac8caqng";
+    sha256 = "1mc33b4nvn9k3r4k56amxr804bg5ndhxv92cmjzg5pf4qh220c2h";
   };
 
-  buildInputs = [ ocaml findlib cppo gen sequence qtest ounit ];
+  buildInputs = [ ocaml findlib cppo gen sequence qtest ounit ocaml_oasis ];
+
+  propagatedBuildInputs = [ result ];
+
+  preConfigure = ''
+    # The following is done so that the '#use "topfind"' directive works in the ocaml top-level
+    export HOME="$(mktemp -d)"
+    export OCAML_TOPLEVEL_PATH="${mkpath findlib}"
+    cat <<EOF > $HOME/.ocamlinit
+let () =
+  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ()
+;;
+EOF
+  '';
 
   configureFlags = [
     "--enable-unix"


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This update was trickier than usual because the build system changed.
It tries to load `findlib` in the ocaml top-level via `#use "topfind"`, which was failing because the ocaml top-level doesn't know where the `topfind` file is.

Furthermore, apparently there is no environment variable that you can set to add a directory to the include/search paths of the ocaml top-level. This was worked-around by creating an ad-hoc `~/.ocamlinit` file.

cc @vbgl 
