### PR TITLE
haproxy: 1.5.14 -> 1.6.4

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,13 +1,13 @@
 { stdenv, pkgs, fetchurl, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-  majorVersion = "1.5";
-  version = "${majorVersion}.14";
+  majorVersion = "1.6";
+  version = "${majorVersion}.4";
   name = "haproxy-${version}";
 
   src = fetchurl {
     url = "http://haproxy.1wt.eu/download/${majorVersion}/src/${name}.tar.gz";
-    sha256 = "16cg1jmy2d8mq2ypwifsvhbyp4pyrj0zm0r818sx0r4hchwdsrcm";
+    sha256 = "0c6j1j30xw08zdlk149s9ghvwphhbiqadkacjyvfrs8z9xh3ryp5";
   };
 
   buildInputs = [ openssl zlib ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @garbas 

---

_Please note, that points are not mandatory, but rather desired._
