### PR TITLE
bundix: 2.0.6 -> 2.0.8

### DIFF
--- a/pkgs/development/interpreters/ruby/bundix/default.nix
+++ b/pkgs/development/interpreters/ruby/bundix/default.nix
@@ -5,9 +5,9 @@ buildRubyGem rec {
 
   name = "${gemName}-${version}";
   gemName = "bundix";
-  version = "2.0.6";
+  version = "2.0.8";
 
-  sha256 = "0yd960awd427mg29r2yzhccd0vjimn1ljr8d8hncj6m6wg84nvh5";
+  sha256 = "0ikpf2g01izadjpdnc4k2rb9v4g11f1jk2y5alxc7n7rxjkwdc66";
 
   buildInputs = [bundler];
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue with changed nix-prefetch-git output.

cc @zimbatm 
