### PR TITLE
rake: init at 11.1.1

### DIFF
--- a/pkgs/development/tools/build-managers/rake/Gemfile
+++ b/pkgs/development/tools/build-managers/rake/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'rake'

--- a/pkgs/development/tools/build-managers/rake/Gemfile.lock
+++ b/pkgs/development/tools/build-managers/rake/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (11.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+
+BUNDLED WITH
+   1.10.5

--- a/pkgs/development/tools/build-managers/rake/default.nix
+++ b/pkgs/development/tools/build-managers/rake/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  name = "rake-11.1.1";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+  
+  meta = with lib; {
+    description = "A software task management and build automation tool";
+    homepage = https://github.com/ruby/rake;
+    license  = with licenses; mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/build-managers/rake/gemset.nix
+++ b/pkgs/development/tools/build-managers/rake/gemset.nix
@@ -1,0 +1,9 @@
+{
+  "rake" = {
+    version = "11.1.1";
+    source = {
+      type = "gem";
+      sha256 = "0h8wcic2xh3lv7yvs05pqnfqb80jyl488f7136lgxmajb0s1rqhg";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9302,6 +9302,8 @@ let
 
   radius = callPackage ../servers/radius { };
 
+  rake = callPackage ../development/tools/build-managers/rake { };
+  
   redis = callPackage ../servers/nosql/redis { };
 
   redstore = callPackage ../servers/http/redstore { };


### PR DESCRIPTION
Add package "rake", which is a ruby-based build tool.
Obviously, no other packages depend on rake, so the addition should not break anything.
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (... no dependencies)
- [X] Tested execution of all binary files (usually in `./result/bin/`) (... no binary files)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
