### PR TITLE
catfish: init at 1.4.1

### DIFF
--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchurl, file, which, intltool, findutils, xdg_utils, pycairo,
+  gnome3, pythonPackages, wrapGAppsHook }:
+
+pythonPackages.buildPythonApplication rec {
+  majorver = "1.4";
+  minorver = "1";
+  version = "${majorver}.${minorver}";
+  name = "catfish-${version}";
+
+  src = fetchurl {
+    url = "https://launchpad.net/catfish-search/${majorver}/${version}/+download/${name}.tar.bz2";
+    sha256 = "0dc9xq1l1w22xk1hg63mgwr0920jqxrwfzmkhif01yms1m7vfdv8";
+  };
+
+  nativeBuildInputs = [
+    pythonPackages.distutils_extra
+    file
+    which
+    intltool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.gtk
+    gnome3.dconf
+    pythonPackages.pyxdg
+    pythonPackages.ptyprocess
+    pycairo
+  ];
+
+  propagatedBuildInputs = [
+    pythonPackages.pygobject3
+    pythonPackages.pexpect
+    xdg_utils
+    findutils
+  ];
+  
+  preFixup = ''
+    for f in \
+      "$out/${pythonPackages.python.sitePackages}/catfish_lib/catfishconfig.py" \
+      "$out/share/applications/catfish.desktop"
+    do
+      substituteInPlace $f --replace "${pythonPackages.python}" "$out"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A handy file search tool";
+    longDescription = ''
+      Catfish is a handy file searching tool. The interface is
+      intentionally lightweight and simple, using only GTK+3.
+      You can configure it to your needs by using several command line
+      options.
+    '';
+    homepage = https://launchpad.net/catfish-search;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11741,6 +11741,10 @@ let
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
+  catfish = callPackage ../applications/search/catfish {
+    pythonPackages = python3Packages;
+  };
+
   cava = callPackage ../applications/audio/cava { };
 
   cb2bib = callPackage ../applications/office/cb2bib {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7821,16 +7821,18 @@ in modules // {
   });
 
   distutils_extra = buildPythonPackage rec {
-    name = "distutils-extra-2.26";
+    name = "distutils-extra-${version}";
+    version = "2.39";
 
     src = pkgs.fetchurl {
-      url = "http://launchpad.net/python-distutils-extra/trunk/2.26/+download/python-${name}.tar.gz";
-      sha256 = "11a3d16efffb00c2b50f40c48531dadaf553ed7a36c5621fde437a16ca40f7ea";
+      url = "http://launchpad.net/python-distutils-extra/trunk/${version}/+download/python-${name}.tar.gz";
+      sha256 = "1bv3h2p9ffbzyddhi5sccsfwrm3i6yxzn0m06fdxkj2zsvs28gvj";
     };
 
     meta = {
       homepage = https://launchpad.net/python-distutils-extra;
       description = "Enhancements to Python's distutils";
+      license = licenses.gpl2;
     };
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
