### PR TITLE
libcollectdclient: make client derive from collectd package

### DIFF
--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -1,14 +1,9 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, collectd }:
+with stdenv.lib;
 
-stdenv.mkDerivation rec {
-  version = "5.5.0";
-  name = "libcollectdclient-${version}";
-  tarname = "collectd-${version}";
-
-  src = fetchurl {
-    url = "http://collectd.org/files/${tarname}.tar.bz2";
-    sha256 = "847684cf5c10de1dc34145078af3fcf6e0d168ba98c14f1343b1062a4b569e88";
-  };
+overrideDerivation collectd (oldAttrs: {
+  name = "libcollectdclient-${collectd.version}";
+  buildInputs = [ ];
 
   configureFlags = [
     "--without-daemon"
@@ -18,8 +13,7 @@ stdenv.mkDerivation rec {
     "-C src/libcollectdclient/"
   ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
-
+}) // {
   meta = with stdenv.lib; {
     description = "C Library for collectd, a daemon which collects system performance statistics periodically";
     homepage = http://collectd.org;

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -30,9 +30,9 @@
 , varnish ? null
 , yajl ? null
 }:
-
 stdenv.mkDerivation rec {
-  name = "collectd-5.5.0";
+  version = "5.5.0";
+  name = "collectd-${version}";
 
   src = fetchurl {
     url = "http://collectd.org/files/${name}.tar.bz2";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._

collectd: split version and name

libcollectdclient: make client derive from collectd package
