### PR TITLE
Remove dead link

### DIFF
--- a/pkgs/development/web/nodejs/v5.nix
+++ b/pkgs/development/web/nodejs/v5.nix
@@ -3,7 +3,6 @@
 }:
 
 # nodejs 5.0.0 can't be built on armv5tel. Armv6 with FPU, minimum I think.
-# Related post: http://zo0ok.com/techfindings/archives/1820
 assert stdenv.system != "armv5tel-linux";
 
 let


### PR DESCRIPTION
The link being pointed to belongs to a domain that no longer exists. Just a bunch of spam there now.

As it's just removing a comment, I didn't feel the need to actually test this.
