### PR TITLE
rr: 4.0.3 -> 4.2.0

### DIFF
--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, cmake, libpfm, zlib, python, pkgconfig, pythonPackages, which, procps }:
+{ stdenv, fetchFromGitHub, cmake, libpfm, zlib, python, pkgconfig, pythonPackages, which, procps, gdb }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.3";
+  version = "4.2.0";
   name = "rr-${version}";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "rr";
     rev = version;
-    sha256 = "0k12r1hzkn5286kz5cg4mvii92m0prs58przchr495r9hfjcy276";
+    sha256 = "03fl2wgbc1cilaw8hrhfqjsbpi05cid6k4cr3s2vmv5gx0dnrgy4";
   };
 
   patchPhase = ''
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  buildInputs = [ cmake libpfm zlib python pkgconfig pythonPackages.pexpect which procps ];
+  buildInputs = [ cmake libpfm zlib python pkgconfig pythonPackages.pexpect which procps gdb ];
   cmakeFlags = "-DCMAKE_C_FLAGS_RELEASE:STRING= -DCMAKE_CXX_FLAGS_RELEASE:STRING=";
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @thoughtpolice 

This version add a chaos mode (record -h), which attempt to starve some threads in a similar way as a loaded system will do.
