### PR TITLE
subtitleeditor: 0.41.0 -> 0.52.1

### DIFF
--- a/pkgs/applications/video/subtitleeditor/default.nix
+++ b/pkgs/applications/video/subtitleeditor/default.nix
@@ -1,44 +1,65 @@
-{ stdenv, fetchurl, desktop_file_utils, enchant, gnome, gstreamer, gstreamermm,
-  gst_plugins_base, gst_plugins_good, intltool, hicolor_icon_theme,
-  libsigcxx, libxmlxx, makeWrapper, xdg_utils, pkgconfig } :
+{ stdenv, fetchurl, pkgconfig, autoconf, automake114x, intltool,
+  desktop_file_utils, enchant, gnome3, gst_all_1, hicolor_icon_theme,
+  libsigcxx, libxmlxx, xdg_utils, isocodes, wrapGAppsHook } :
 
 let
-  ver_maj = "0.41";
-  ver_min = "0";
+  ver_maj = "0.52";
+  ver_min = "1";
 in
 
 stdenv.mkDerivation rec {
   name = "subtitle-editor-${ver_maj}.${ver_min}";
 
-  buildInputs =  [
-    desktop_file_utils enchant gnome.gtk gnome.gtkmm gstreamer gstreamermm
-    gst_plugins_base gst_plugins_good intltool hicolor_icon_theme libsigcxx libxmlxx
-    makeWrapper xdg_utils pkgconfig
-  ];
-
   src = fetchurl {
     url = "http://download.gna.org/subtitleeditor/${ver_maj}/subtitleeditor-${ver_maj}.${ver_min}.tar.gz";
-    md5 = "3c21ccd8296001dcb1a02c62396db1b6";
+    sha256 = "1m8j2i27kjaycvp09b0knp9in61jd2dj852hrx5hvkrby70mygjv";
   };
+
+  nativeBuildInputs =  [
+    autoconf automake114x pkgconfig intltool wrapGAppsHook
+  ];
+
+  buildInputs =  [
+    desktop_file_utils
+    enchant
+    gnome3.gtk
+    gnome3.gtkmm
+    gst_all_1.gstreamer
+    gst_all_1.gstreamermm
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    hicolor_icon_theme
+    libsigcxx
+    libxmlxx
+    xdg_utils
+    isocodes
+  ];
+
+  NIX_CFLAGS_COMPILE = "-std=c++11 -DDEBUG";
+
+  enableParallelBuilding = true;
 
   doCheck = true;
 
-  postInstall = ''
-    wrapProgram "$out/bin/subtitleeditor" --prefix \
-      GST_PLUGIN_SYSTEM_PATH ":" "$GST_PLUGIN_SYSTEM_PATH"                                                     \
+  patches = [ ./subtitleeditor-0.52.1-build-fix.patch ];
+
+  preConfigure = ''
+    # ansi overrides -std, see src_configure
+    sed 's/\(CXXFLAGS\) -ansi/\1/' -i configure.ac configure
   '';
 
+  configureFlags = [ "--disable-debug" ];
 
   meta = {
-    description = "GTK+2 application to edit video subtitles";
+    description = "GTK+3 application to edit video subtitles";
     longDescription = ''
-      Subtitle Editor is a GTK+2 tool to edit subtitles for GNU/Linux/*BSD. It can be
-      used for new subtitles or as a tool to transform, edit, correct and refine
-      existing subtitle. This program also shows sound waves, which makes it easier
-      to synchronise subtitles to voices.
+      Subtitle Editor is a GTK+3 tool to edit subtitles for GNU/Linux/*BSD. It
+      can be used for new subtitles or as a tool to transform, edit, correct
+      and refine existing subtitle. This program also shows sound waves, which
+      makes it easier to synchronise subtitles to voices.
       '';
     homepage = http://home.gna.org/subtitleeditor;
-    license = stdenv.lib.licenses.gpl3;
+    license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [ stdenv.lib.maintainers.plcplc ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/applications/video/subtitleeditor/subtitleeditor-0.52.1-build-fix.patch
+++ b/pkgs/applications/video/subtitleeditor/subtitleeditor-0.52.1-build-fix.patch
@@ -1,0 +1,55 @@
+Fix build errors with gcc-4.9.3 -std=c++11 (after disabling -ansi)
+
+https://gna.org/bugs/?23714
+
+https://bugs.gentoo.org/show_bug.cgi?id=550764
+https://bugs.gentoo.org/show_bug.cgi?id=566328
+
+--- a/src/subtitleview.cc	2015-12-24 01:52:29.322622155 +0100
++++ b/src/subtitleview.cc	2015-12-24 01:52:44.210491213 +0100
+@@ -1363,7 +1363,7 @@
+ 	{
+ 		int num;
+ 		std::istringstream ss(event->string);
+-		bool is_num = ss >> num != 0; 
++		bool is_num = static_cast<bool>(ss >> num) != 0; 
+ 		// Update only if it's different
+ 		if(is_num != get_enable_search())
+ 			set_enable_search(is_num);
+--- a/src/utility.h	2015-12-24 01:49:42.205104858 +0100
++++ b/src/utility.h	2015-12-24 01:50:23.387737071 +0100
+@@ -91,7 +91,7 @@
+ 	std::istringstream s(src);
+ 	// return s >> dest != 0;
+ 
+-	bool state = s >> dest != 0;
++	bool state = static_cast<bool>(s >> dest) != 0;
+ 
+ 	if(!state)
+ 		se_debug_message(SE_DEBUG_UTILITY, "string:'%s'failed.", src.c_str());
+--- a/plugins/actions/dialoguize/dialoguize.cc	2015-12-24 01:06:24.125428454 +0100
++++ b/plugins/actions/dialoguize/dialoguize.cc	2015-12-24 01:06:42.630277006 +0100
+@@ -23,7 +23,7 @@
+  *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+  
+-#include <auto_ptr.h>
++#include <memory>
+ #include "extension/action.h"
+ #include "i18n.h"
+ #include "debug.h"
+--- a/plugins/actions/documentmanagement/documentmanagement.old	2015-12-24 01:17:13.914730337 +0100
++++ b/plugins/actions/documentmanagement/documentmanagement.cc	2015-12-24 01:17:23.339640430 +0100
+@@ -178,9 +178,9 @@
+ 
+ 		ui_id = ui->new_merge_id();
+ 
+-		#define ADD_UI(name) ui->add_ui(ui_id, "/menubar/menu-file/"name, name, name);
+-		#define ADD_OPEN_UI(name) ui->add_ui(ui_id, "/menubar/menu-file/menu-open/"name, name, name);
+-		#define ADD_SAVE_UI(name) ui->add_ui(ui_id, "/menubar/menu-file/menu-save/"name, name, name);
++		#define ADD_UI(name) ui->add_ui(ui_id, "/menubar/menu-file/" name, name, name);
++		#define ADD_OPEN_UI(name) ui->add_ui(ui_id, "/menubar/menu-file/menu-open/" name, name, name);
++		#define ADD_SAVE_UI(name) ui->add_ui(ui_id, "/menubar/menu-file/menu-save/" name, name, name);
+ 
+ 		ADD_UI("new-document");
+ 		ADD_OPEN_UI("open-document");

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -3,6 +3,8 @@
 rec {
   gstreamer = callPackage ./core { };
 
+  gstreamermm = callPackage ./gstreamermm { };
+
   gst-plugins-base = callPackage ./base { inherit gstreamer; };
 
   gst-plugins-good = callPackage ./good { inherit gst-plugins-base; };

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, file, glibmm, gst_all_1 }:
+
+let
+  ver_maj = "1.4";
+  ver_min = "3";
+in
+stdenv.mkDerivation rec {
+  name = "gstreamermm-${ver_maj}.${ver_min}";
+
+  src = fetchurl {
+    url    = "mirror://gnome/sources/gstreamermm/${ver_maj}/${name}.tar.xz";
+    sha256 = "0bj6and9b26d32bq90l8nx5wqh2ikkh8dm7qwxyxfdvmrzhixhgi";
+  };
+ 
+  nativeBuildInputs = [ pkgconfig file ];
+
+  propagatedBuildInputs = [ glibmm gst_all_1.gst-plugins-base ];
+
+  enableParallelBuilding = true;
+ 
+  meta = with stdenv.lib; {
+    description = "C++ interface for GStreamer";
+    homepage = http://gstreamer.freedesktop.org/bindings/cplusplus.html;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ romildo ];
+    platforms = platforms.unix;
+  };
+
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Also added `gstreamermm-1.4.3`, a dependency to `subtitleeditor-0.52.1`.
