### PR TITLE
Nix daemon: allow setting sshPublicHostKey for buildMachines

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -341,14 +341,20 @@ in
       { enable = cfg.buildMachines != [];
         text =
           concatMapStrings (machine:
+            let
+              machineSupportedFeatures = concatStringsSep "," (machine.mandatoryFeatures or [] ++ machine.supportedFeatures or []);
+              machineMandatoryFeatures = concatStringsSep "," machine.mandatoryFeatures or [];
+            in
             "${if machine ? sshUser then "${machine.sshUser}@" else ""}${machine.hostName} "
             + machine.system or (concatStringsSep "," machine.systems)
             + " ${machine.sshKey or "-"} ${toString machine.maxJobs or 1} "
             + toString (machine.speedFactor or 1)
             + " "
-            + concatStringsSep "," (machine.mandatoryFeatures or [] ++ machine.supportedFeatures or [])
+            + (if machineSupportedFeatures != "" then machineSupportedFeatures else "-")
             + " "
-            + concatStringsSep "," machine.mandatoryFeatures or []
+            + (if machineMandatoryFeatures != "" then machineMandatoryFeatures else "-")
+            + " "
+            + machine.sshPublicHostKey or "-"
             + "\n"
           ) cfg.buildMachines;
       };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @edolstra 
