### PR TITLE
containers: hostbridge and IPv6

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -28,14 +28,23 @@ let
 
       # Initialise the container side of the veth pair.
       if [ "$PRIVATE_NETWORK" = 1 ]; then
+
         ip link set host0 name eth0
         ip link set dev eth0 up
+
+        if [ -n "$LOCAL_ADDRESS" ]; then
+          ip addr add $LOCAL_ADDRESS dev eth0
+        fi
+        if [ -n "$LOCAL_ADDRESS6" ]; then
+          ip -6 addr add $LOCAL_ADDRESS6 dev eth0
+        fi
         if [ -n "$HOST_ADDRESS" ]; then
           ip route add $HOST_ADDRESS dev eth0
           ip route add default via $HOST_ADDRESS
         fi
-        if [ -n "$LOCAL_ADDRESS" ]; then
-          ip addr add $LOCAL_ADDRESS dev eth0
+        if [ -n "$HOST_ADDRESS6" ]; then
+          ip -6 route add $HOST_ADDRESS6 dev eth0
+          ip -6 route add default via $HOST_ADDRESS6
         fi
       fi
 
@@ -48,7 +57,7 @@ let
   system = config.nixpkgs.system;
 
   bindMountOpts = { name, config, ... }: {
-  
+
     options = {
       mountPoint = mkOption {
         example = "/mnt/usb";
@@ -68,13 +77,13 @@ let
         description = "Determine whether the mounted path will be accessed in read-only mode.";
       };
     };
-    
+
     config = {
       mountPoint = mkDefault name;
     };
-    
+
   };
-  
+
   mkBindFlag = d:
                let flagPrefix = if d.isReadOnly then " --bind-ro=" else " --bind=";
                    mountstr = if d.hostPath != null then "${d.hostPath}:${d.mountPoint}" else "${d.mountPoint}";
@@ -142,12 +151,33 @@ in
               '';
             };
 
+            hostBridge = mkOption {
+              type = types.nullOr types.string;
+              default = null;
+              example = "br0";
+              description = ''
+                Put the host-side of the veth-pair into the named bridge.
+                Only one of hostAddress* or hostBridge can be given.
+              '';
+            };
+
             hostAddress = mkOption {
               type = types.nullOr types.str;
               default = null;
               example = "10.231.136.1";
               description = ''
                 The IPv4 address assigned to the host interface.
+                (Not used when hostBridge is set.)
+              '';
+            };
+
+            hostAddress6 = mkOption {
+              type = types.nullOr types.string;
+              default = null;
+              example = "fc00::1";
+              description = ''
+                The IPv6 address assigned to the host interface.
+                (Not used when hostBridge is set.)
               '';
             };
 
@@ -157,6 +187,16 @@ in
               example = "10.231.136.2";
               description = ''
                 The IPv4 address assigned to <literal>eth0</literal>
+                in the container.
+              '';
+            };
+
+            localAddress6 = mkOption {
+              type = types.nullOr types.string;
+              default = null;
+              example = "fc00::2";
+              description = ''
+                The IPv6 address assigned to <literal>eth0</literal>
                 in the container.
               '';
             };
@@ -185,7 +225,7 @@ in
               example = { "/home" = { hostPath = "/home/alice";
                                       isReadOnly = false; };
                         };
-                        
+
               description =
                 ''
                   An extra list of directories that is bound to the container.
@@ -257,11 +297,7 @@ in
 
             if [ "$PRIVATE_NETWORK" = 1 ]; then
               ip link del dev "ve-$INSTANCE" 2> /dev/null || true
-            fi
-
-
-            if [ "$PRIVATE_NETWORK" = 1 ]; then
-              ip link del dev "ve-$INSTANCE" 2> /dev/null || true
+              ip link del dev "vb-$INSTANCE" 2> /dev/null || true
             fi
          '';
 
@@ -281,6 +317,9 @@ in
 
             if [ "$PRIVATE_NETWORK" = 1 ]; then
               extraFlags+=" --network-veth"
+              if [ -n "$HOST_BRIDGE" ]; then
+                extraFlags+=" --network-bridge=$HOST_BRIDGE"
+              fi
             fi
 
             for iface in $INTERFACES; do
@@ -315,8 +354,11 @@ in
               --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles" \
               --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots" \
               --setenv PRIVATE_NETWORK="$PRIVATE_NETWORK" \
+              --setenv HOST_BRIDGE="$HOST_BRIDGE" \
               --setenv HOST_ADDRESS="$HOST_ADDRESS" \
               --setenv LOCAL_ADDRESS="$LOCAL_ADDRESS" \
+              --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
+              --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
               --setenv PATH="$PATH" \
               ${containerInit} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
           '';
@@ -324,13 +366,21 @@ in
         postStart =
           ''
             if [ "$PRIVATE_NETWORK" = 1 ]; then
-              ifaceHost=ve-$INSTANCE
-              ip link set dev $ifaceHost up
-              if [ -n "$HOST_ADDRESS" ]; then
-                ip addr add $HOST_ADDRESS dev $ifaceHost
-              fi
-              if [ -n "$LOCAL_ADDRESS" ]; then
-                ip route add $LOCAL_ADDRESS dev $ifaceHost
+              if [ -z "$HOST_BRIDGE" ]; then
+                ifaceHost=ve-$INSTANCE
+                ip link set dev $ifaceHost up
+                if [ -n "$HOST_ADDRESS" ]; then
+                  ip addr add $HOST_ADDRESS dev $ifaceHost
+                fi
+                if [ -n "$HOST_ADDRESS6" ]; then
+                  ip -6 addr add $HOST_ADDRESS6 dev $ifaceHost
+                fi
+                if [ -n "$LOCAL_ADDRESS" ]; then
+                  ip route add $LOCAL_ADDRESS dev $ifaceHost
+                fi
+                if [ -n "$LOCAL_ADDRESS6" ]; then
+                  ip -6 route add $LOCAL_ADDRESS6 dev $ifaceHost
+                fi
               fi
             fi
 
@@ -352,6 +402,9 @@ in
 
         restartIfChanged = false;
         #reloadIfChanged = true; # FIXME
+
+        wants = [ "netwprk.target" ];
+        after = [ "network.target" ];
 
         serviceConfig = {
           ExecReload = pkgs.writeScript "reload-container"
@@ -396,11 +449,20 @@ in
             SYSTEM_PATH=${cfg.path}
             ${optionalString cfg.privateNetwork ''
               PRIVATE_NETWORK=1
+              ${optionalString (cfg.hostBridge != null) ''
+                HOST_BRIDGE=${cfg.hostBridge}
+              ''}
               ${optionalString (cfg.hostAddress != null) ''
                 HOST_ADDRESS=${cfg.hostAddress}
               ''}
+              ${optionalString (cfg.hostAddress6 != null) ''
+                HOST_ADDRESS6=${cfg.hostAddress6}
+              ''}
               ${optionalString (cfg.localAddress != null) ''
                 LOCAL_ADDRESS=${cfg.localAddress}
+              ''}
+              ${optionalString (cfg.localAddress6 != null) ''
+                LOCAL_ADDRESS6=${cfg.localAddress6}
               ''}
             ''}
              INTERFACES="${toString cfg.interfaces}"

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -199,9 +199,10 @@ in rec {
   tests.cadvisor = hydraJob (import tests/cadvisor.nix { system = "x86_64-linux"; });
   tests.chromium = callSubTests tests/chromium.nix {};
   tests.cjdns = callTest tests/cjdns.nix {};
-  tests.containers = callTest tests/containers.nix {};
+  tests.containers-ipv4 = callTest tests/containers-ipv4.nix {};
   tests.containers-ipv6 = callTest tests/containers-ipv6.nix {};
   tests.containers-bridge = callTest tests/containers-bridge.nix {};
+  tests.containers-imperative = callTest tests/containers-imperative.nix {};
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
   tests.dockerRegistry = hydraJob (import tests/docker-registry.nix { system = "x86_64-linux"; });
   tests.dnscrypt-proxy = callTest tests/dnscrypt-proxy.nix { system = "x86_64-linux"; };

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -200,6 +200,8 @@ in rec {
   tests.chromium = callSubTests tests/chromium.nix {};
   tests.cjdns = callTest tests/cjdns.nix {};
   tests.containers = callTest tests/containers.nix {};
+  tests.containers-ipv6 = callTest tests/containers-ipv6.nix {};
+  tests.containers-bridge = callTest tests/containers-bridge.nix {};
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
   tests.dockerRegistry = hydraJob (import tests/docker-registry.nix { system = "x86_64-linux"; });
   tests.dnscrypt-proxy = callTest tests/dnscrypt-proxy.nix { system = "x86_64-linux"; };

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -1,0 +1,81 @@
+# Test for NixOS' container support.
+
+let
+  hostIp = "192.168.0.1";
+  containerIp = "192.168.0.100/24";
+  hostIp6 = "fc00::1";
+  containerIp6 = "fc00::2/7";
+in
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-bridge";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aristid aszlig eelco chaoflow ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      networking.bridges = {
+        br0 = {
+          interfaces = [];
+        };
+      };
+      networking.interfaces = {
+        br0 = {
+          ip4 = [{ address = hostIp; prefixLength = 24; }];
+          ip6 = [{ address = hostIp6; prefixLength = 7; }];
+        };
+      };
+
+      containers.webserver =
+        {
+          autoStart = true;
+          privateNetwork = true;
+          hostBridge = "br0";
+          localAddress = containerIp;
+          localAddress6 = containerIp6;
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+              networking.firewall.allowPing = true;
+            };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("default.target");
+      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+      # Start the webserver container.
+      $machine->succeed("nixos-container status webserver") =~ /up/ or die;
+
+      "${containerIp}" =~ /([^\/]+)\/([0-9+])/;
+      my $ip = $1;
+      chomp $ip;
+      $machine->succeed("ping -n -c 1 $ip");
+      $machine->succeed("curl --fail http://$ip/ > /dev/null");
+
+      "${containerIp6}" =~ /([^\/]+)\/([0-9+])/;
+      my $ip6 = $1;
+      chomp $ip6;
+      $machine->succeed("ping6 -n -c 1 $ip6");
+      $machine->succeed("curl --fail http://[$ip6]/ > /dev/null");
+
+      # Stop the container.
+      $machine->succeed("nixos-container stop webserver");
+      $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
+      $machine->fail("curl --fail --connect-timeout 2 http://[$ip6]/ > /dev/null");
+
+      # Destroying a declarative container should fail.
+      $machine->fail("nixos-container destroy webserver");
+    '';
+
+})

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -1,7 +1,7 @@
 # Test for NixOS' container support.
 
 import ./make-test.nix ({ pkgs, ...} : {
-  name = "containers";
+  name = "containers-imperative";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco chaoflow ];
   };
@@ -11,43 +11,11 @@ import ./make-test.nix ({ pkgs, ...} : {
     { imports = [ ../modules/installer/cd-dvd/channel.nix ];
       virtualisation.writableStore = true;
       virtualisation.memorySize = 768;
-
-      containers.webserver =
-        { privateNetwork = true;
-          hostAddress = "10.231.136.1";
-          localAddress = "10.231.136.2";
-          config =
-            { services.httpd.enable = true;
-              services.httpd.adminAddr = "foo@example.org";
-              networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.firewall.allowPing = true;
-            };
-        };
-
       virtualisation.pathsInNixDB = [ pkgs.stdenv ];
     };
 
   testScript =
     ''
-      $machine->succeed("nixos-container list") =~ /webserver/ or die;
-
-      # Start the webserver container.
-      $machine->succeed("nixos-container start webserver");
-
-      # wait two seconds for the container to start and the network to be up
-      sleep 2;
-
-      # Since "start" returns after the container has reached
-      # multi-user.target, we should now be able to access it.
-      my $ip = $machine->succeed("nixos-container show-ip webserver");
-      chomp $ip;
-      $machine->succeed("ping -n -c1 $ip");
-      $machine->succeed("curl --fail http://$ip/ > /dev/null");
-
-      # Stop the container.
-      $machine->succeed("nixos-container stop webserver");
-      $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
-
       # Make sure we have a NixOS tree (required by ‘nixos-container create’).
       $machine->succeed("PAGER=cat nix-env -qa -A nixos.hello >&2");
 
@@ -114,9 +82,6 @@ import ./make-test.nix ({ pkgs, ...} : {
         # Ensure that the container path is gone
         "test ! -e /var/lib/containers/$id1"
       );
-
-      # Destroying a declarative container should fail.
-      $machine->fail("nixos-container destroy webserver");
     '';
 
 })

--- a/nixos/tests/containers-ipv4.nix
+++ b/nixos/tests/containers-ipv4.nix
@@ -1,0 +1,55 @@
+# Test for NixOS' container support.
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-ipv4";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aristid aszlig eelco chaoflow ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      containers.webserver =
+        { privateNetwork = true;
+          hostAddress = "10.231.136.1";
+          localAddress = "10.231.136.2";
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+              networking.firewall.allowPing = true;
+            };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+      # Start the webserver container.
+      $machine->succeed("nixos-container start webserver");
+
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
+      # Since "start" returns after the container has reached
+      # multi-user.target, we should now be able to access it.
+      my $ip = $machine->succeed("nixos-container show-ip webserver");
+      chomp $ip;
+      $machine->succeed("ping -n -c1 $ip");
+      $machine->succeed("curl --fail http://$ip/ > /dev/null");
+
+      # Stop the container.
+      $machine->succeed("nixos-container stop webserver");
+      $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
+
+      # Destroying a declarative container should fail.
+      $machine->fail("nixos-container destroy webserver");
+    '';
+
+})

--- a/nixos/tests/containers-ipv6.nix
+++ b/nixos/tests/containers-ipv6.nix
@@ -1,0 +1,61 @@
+# Test for NixOS' container support.
+
+let
+  hostIp = "fc00::2";
+  localIp = "fc00::1";
+in
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-ipv6";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aristid aszlig eelco chaoflow ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      containers.webserver =
+        { privateNetwork = true;
+          hostAddress6 = hostIp;
+          localAddress6 = localIp;
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+              networking.firewall.allowPing = true;
+            };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("default.target");
+      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+      # Start the webserver container.
+      $machine->succeed("nixos-container start webserver");
+
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
+      # Since "start" returns after the container has reached
+      # multi-user.target, we should now be able to access it.
+      my $ip = "${localIp}";
+      chomp $ip;
+      $machine->succeed("ping6 -n -c 1 $ip");
+      $machine->succeed("curl --fail http://[$ip]/ > /dev/null");
+
+      # Stop the container.
+      $machine->succeed("nixos-container stop webserver");
+      $machine->fail("curl --fail --connect-timeout 2 http://[$ip]/ > /dev/null");
+
+      # Destroying a declarative container should fail.
+      $machine->fail("nixos-container destroy webserver");
+    '';
+
+})

--- a/nixos/tests/containers.nix
+++ b/nixos/tests/containers.nix
@@ -34,11 +34,14 @@ import ./make-test.nix ({ pkgs, ...} : {
       # Start the webserver container.
       $machine->succeed("nixos-container start webserver");
 
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
       # Since "start" returns after the container has reached
       # multi-user.target, we should now be able to access it.
       my $ip = $machine->succeed("nixos-container show-ip webserver");
       chomp $ip;
-      #$machine->succeed("ping -c1 $ip"); # FIXME
+      $machine->succeed("ping -n -c1 $ip");
       $machine->succeed("curl --fail http://$ip/ > /dev/null");
 
       # Stop the container.


### PR DESCRIPTION
This patches achieve two things that extend containers to make them more usable (at least for me):
- Add IPv6 addresses for containers
  With this the containers can get one IPv6 address in addition to the ipv4 address. Or only an ipv6 address;-)
- Put the host-side of the veth-pair into an existing bridge
  Its also now possible to define the host-side bridge the containers interface should be placed in. Then only the container-side of the addresses is needed.
###### More

superseedes #12736 

cc @fpletz 
