### PR TITLE
dosage: Init at 2016.03.17

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -874,6 +874,8 @@ let
 
   dlx = callPackage ../misc/emulators/dlx { };
 
+  dosage = pythonPackages.dosage;
+
   dpic = callPackage ../tools/graphics/dpic { };
 
   dragon-drop = callPackage ../tools/X11/dragon-drop {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1966,6 +1966,28 @@ in modules // {
     };
   };
 
+  dosage = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "dosage";
+    version = "2016.03.17";
+    PBR_VERSION = version;
+    src = pkgs.fetchFromGitHub {
+      owner = "webcomics";
+      repo = "dosage";
+      rev = "1af022895e5f86bc43da95754c4c4ed305790f5b";
+      sha256 = "1bkqhlzigy656pam0znp2ddp1y5sqzyhw3c4fyy58spcafldq4j6";
+    };
+    buildInputs = with self; [ pytest ];
+    propagatedBuildInputs = with self; [ requests2 lxml pbr ];
+    # prompt_toolkit doesn't work on 3.5 on OSX.
+    doCheck = !isPy35;
+
+    meta = {
+      description = "A comic strip downloader and archiver";
+      homepage = http://dosage.rocks/;
+    };
+  };
+
   dugong = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "dugong";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._
