### PR TITLE
librest 0.7.92 -> 0.7.93

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/rest/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/rest/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, libsoup, gobjectIntrospection, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "rest-0.7.92";
+  name = "rest-0.7.93";
 
   src = fetchurl {
     url = "mirror://gnome/sources/rest/0.7/${name}.tar.xz";
-    sha256 = "07548c8785a3e743daf54a82b952ff5f32af94fee68997df4c83b00d52f9c0ec";
+    sha256 = "05mj10hhiik23ai8w4wkk5vhsp7hcv24bih5q3fl82ilam268467";
   };
 
   buildInputs = [ pkgconfig glib libsoup gobjectIntrospection];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
