### PR TITLE
ansifilter: add @ 1.15

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -12,6 +12,7 @@
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
   aboseley = "Adam Boseley <adam.boseley@gmail.com>";
   adev = "Adrien Devresse <adev@adev.name>";
+  Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   aespinosa = "Allan Espinosa <allan.espinosa@outlook.com>";
   aflatter = "Alexander Flatter <flatter@fastmail.fm>";
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";

--- a/pkgs/tools/text/ansifilter/default.nix
+++ b/pkgs/tools/text/ansifilter/default.nix
@@ -1,0 +1,27 @@
+{ fetchurl, stdenv, pkgconfig, boost, lua }:
+let version = "1.15";
+    pkgsha = "65dc20cc1a03d4feba990f830186404c90462d599e5f4b37610d4d822d67aec4";
+in stdenv.mkDerivation {
+  name = "ansifilter-${version}";
+  buildInputs = [
+    pkgconfig boost lua
+  ];
+  src = fetchurl {
+    url = "http://www.andre-simon.de/zip/ansifilter-${version}.tar.bz2";
+    sha256 = pkgsha;
+  };
+  meta = {
+    description = "Tool to convert ANSI to other formats";
+    longDescription = ''
+    Tool to remove ANSI or convert them to another format 
+    (HTML, TeX, LaTeX, RTF, Pango or BBCode)
+    '';
+
+    license = stdenv.lib.licenses.gpl1;
+    maintainers = [ stdenv.lib.maintainers.Adjective-Object ];
+  };
+
+  makeFlags="PREFIX=$(out) conf_dir=$(out)/etc/ansifilter/";
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -540,6 +540,8 @@ let
 
   analog = callPackage ../tools/admin/analog {};
 
+  ansifilter = callPackage ../tools/text/ansifilter {};
+
   apktool = callPackage ../development/tools/apktool {
     buildTools = androidenv.buildTools;
   };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

added package [ansifilter](http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php) @ 1.15
