### PR TITLE
mongodb: fix build against boost-1.60

### DIFF
--- a/pkgs/servers/nosql/mongodb/default.nix
+++ b/pkgs/servers/nosql/mongodb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, scons, boost, gperftools, pcre, snappy
+{ stdenv, fetchurl, fetchpatch, scons, boost, gperftools, pcre, snappy
 , zlib, libyamlcpp, sasl, openssl, libpcap, wiredtiger
 }:
 
@@ -53,7 +53,14 @@ in stdenv.mkDerivation rec {
   # vendored header file - regardless of whether or not we're using the system
   # tcmalloc - so we need to lift the include path manipulation out of the
   # conditional.
-  patches = [ ./valgrind-include.patch ];
+  patches =
+    [ ./valgrind-include.patch
+      (fetchpatch {
+        url = https://projects.archlinux.org/svntogit/community.git/plain/trunk/boost160.patch?h=packages/mongodb;
+        name = "boost160.patch";
+        sha256 = "0bvsf3499zj55pzamwjmsssr6x63w434944w76273fr5rxwzcmh8";
+      })
+    ];
 
   postPatch = ''
     # fix environment variable reading


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Apply patch from Arch Linux. Suggested by @wkennington.
