### PR TITLE
Mark clfswm as broken

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -10,7 +10,6 @@ in
   imports = [
     ./afterstep.nix
     ./bspwm.nix
-    ./clfswm.nix
     ./compiz.nix
     ./dwm.nix
     ./exwm.nix

--- a/pkgs/applications/window-managers/clfswm/default.nix
+++ b/pkgs/applications/window-managers/clfswm/default.nix
@@ -46,5 +46,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl3;
     maintainers = with maintainers; [ robgssp ];
     platforms   = platforms.linux;
+    broken      = true;
   };
 }


### PR DESCRIPTION
This package has been broken for a long time. I failed to fix it, but I'm not that motivated to try, as I don't use this package myself. Unless someone steps up to fix it, I'll merge this & pick into the next release.

See https://hydra.nixos.org/build/33498133/nixlog/2/raw

cc maintainer @robgssp
