### PR TITLE
Darwin ffmpeg

### DIFF
--- a/pkgs/os-specific/darwin/cf-private/setup-hook.sh
+++ b/pkgs/os-specific/darwin/cf-private/setup-hook.sh
@@ -1,5 +1,5 @@
 prependSearchPath() {
-  NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks ${NIX_CFLAGS_COMPILE/"-F@out@/Library/Frameworks"/}"
+  NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks ${NIX_CFLAGS_COMPILE}"
 }
 
 linkWithRealCF() {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6705,7 +6705,9 @@ in
     vid-stab = if stdenv.isDarwin then null else vid-stab;
     x265 = if stdenv.isDarwin then null else x265;
     xavs = if stdenv.isDarwin then null else xavs;
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices;
+    inherit (darwin) CF;
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices AVFoundation
+                                          MediaToolbox VideoDecodeAcceleration;
   };
 
   ffmpegthumbnailer = callPackage ../development/libraries/ffmpegthumbnailer { };


### PR DESCRIPTION
###### Things done:
- Built on platform(s)
  - [ ] OS X
###### More

The three commits here are a journey I went through to get camera input working with ffmpeg on darwin.
- ffmpeg's build system does some checking of available include files that revealed the problem with AVFoundation. This is not an issue with the headers on my 10.11 system, so it is a temporary fix.
- I may have misunderstood the `cf-private/setup-hook.sh` as it didn't make sense to me as it was
- The `install_name_tool` idea implemented in `ffmpeg-full/default.nix` is thanks to @pikajude . I spent two days trying alternatives, none of which worked, before catching him on IRC. It's ugly, but I do not know how to avoid it.
