### PR TITLE
mpv: add script infrastructure & convert script

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -22,6 +22,8 @@
 , cacaSupport ? true, libcaca ? null
 , vaapiSupport ? false, libva ? null
 , waylandSupport ? false, wayland ? null, libxkbcommon ? null
+# scripts you want to be loaded by default
+, scripts ? []
 }:
 
 assert x11Support -> (libX11 != null && libXext != null && mesa != null && libXxf86vm != null);
@@ -45,7 +47,7 @@ assert cacaSupport -> libcaca != null;
 assert waylandSupport -> (wayland != null && libxkbcommon != null);
 
 let
-  inherit (stdenv.lib) optional optionals optionalString;
+  inherit (stdenv.lib) optional optionals optionalString concatStringsSep;
 
   # Purity: Waf is normally downloaded by bootstrap.py, but
   # for purity reasons this behavior should be avoided.
@@ -125,7 +127,9 @@ stdenv.mkDerivation rec {
     ln -s ${freefont_ttf}/share/fonts/truetype/FreeSans.ttf $out/share/mpv/subfont.ttf
   '' + optionalString youtubeSupport ''
     # Ensure youtube-dl is available in $PATH for MPV
-    wrapProgram $out/bin/mpv --prefix PATH : "${youtube-dl}/bin"
+    wrapProgram $out/bin/mpv \
+      --prefix PATH : "${youtube-dl}/bin" \
+      --add-flags "--script=${concatStringsSep "," scripts}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, lib
+, yad, mkvtoolnix, libnotify }:
+
+stdenv.mkDerivation {
+  name = "mpv-convert-script-2016-03-18.lua";
+  src = fetchgit {
+    url = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
+    rev = "f95cee43e390e843a47e8ec9d1711a12a8cd343d";
+    sha256 = "13m7l4sy2r8jv2sfrb3vvqvnim4a9ilnv28q5drlg09v298z3mck";
+  };
+
+  patches = [ ./convert.patch ];
+
+  postPatch =
+    let
+      t = k: v: '' 'local ${k} = "${v}"' '';
+      subs = var: orig: repl: "--replace " + t var orig + t var repl;
+    in ''
+      substituteInPlace convert_script.lua \
+        ${subs "NOTIFY_CMD" "notify-send" "${libnotify}/bin/notify-send"} \
+        ${subs "YAD_CMD" "yad" "${yad}/bin/yad"} \
+        ${subs "MKVMERGE_CMD" "mkvmerge" "${mkvtoolnix}/bin/mkvmerge"}
+  '';
+
+  dontBuild = true;
+  installPhase = ''
+    cp convert_script.lua $out
+  '';
+
+  meta = {
+    description = "Convert parts of a video while you are watching it in mpv";
+    homepage = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
+    maintainers = lib.maintainers.profpatsch;
+    longDescription = ''
+      When this script is loaded into mpd, you can hit Alt+W to mark the beginning
+      and Alt+W again to mark the end of the clip. Then a settings window opens.
+    '';
+  };
+}
+

--- a/pkgs/applications/video/mpv/scripts/convert.patch
+++ b/pkgs/applications/video/mpv/scripts/convert.patch
@@ -1,0 +1,52 @@
+--- convert/convert_script.lua	2016-03-18 19:30:49.675401969 +0100
++++ convert_script.lua	2016-03-19 01:18:00.801897043 +0100
+@@ -3,6 +3,10 @@
+ local opt = require 'mp.options'
+ local utils = require 'mp.utils'
+ 
++local NOTIFY_CMD = "notify-send"
++local YAD_CMD = "yad"
++local MKVMERGE_CMD = "mkvmerge"
++
+ -- default options, convert_script.conf is read
+ local options = {
+     bitrate_multiplier = 0.975,			-- to make sure the file won’t go over the target file size, set it to 1 if you don’t care
+@@ -354,9 +358,9 @@
+     if ovc == "gif" then
+         full_command = full_command .. ' --vf-add=lavfi=graph=\\"framestep=' .. framestep .. '\\" && convert ' 
+         .. tmpfolder .. '/*.png -set delay ' .. delay .. ' -loop 0 -fuzz ' .. fuzz .. '% ' .. dither .. ' -layers optimize '
+-        .. full_output_path .. ' && rm -rf ' .. tmpfolder .. ' && notify-send "Gif done") & disown'
++        .. full_output_path .. ' && rm -rf ' .. tmpfolder .. ' && ' .. NOTIFY_CMD .. ' "Gif done") & disown'
+     else
+-        full_command = full_command .. ' && notify-send "Encoding done"; mkvpropedit '
++        full_command = full_command .. ' && ' .. NOTIFY_CMD .. ' "Encoding done"; mkvpropedit '
+         .. full_output_path .. ' -s title="' .. metadata_title .. '") & disown'
+     end
+     
+@@ -409,7 +413,7 @@
+     sep = ",+"
+     
+     if enc then
+-        local command = "mkvmerge '" .. video .. "' " .. mkvmerge_parts .. " -o " .. full_output_path
++        local command = MKVMERGE_CMD .. " '" .. video .. "' " .. mkvmerge_parts .. " -o " .. full_output_path
+         msg.info(command)
+         os.execute(command)
+         clear()
+@@ -508,7 +512,7 @@
+     end
+     
+     
+-    local yad_command = [[LC_NUMERIC=C yad --title="Convert Script" --center --form --fixed --always-print-result \
++    local yad_command = [[LC_NUMERIC=C ]] .. YAD_CMD .. [[ --title="Convert Script" --center --form --fixed --always-print-result \
+     --name "convert script" --class "Convert Script" --field="Resize to height:NUM" "]] .. scale_sav		--yad_table 1
+     .. [[" --field="Resize to width instead:CHK" ]] .. resize_to_width_instead .. " "				--yad_table 2
+     if options.legacy_yad then
+@@ -543,7 +547,7 @@
+     yad_command = yad_command .. [[ --button="Crop:1" --button="gtk-cancel:2" --button="gtk-ok:0"; ret=$? && echo $ret]]
+     
+     if gif_dialog then
+-        yad_command = [[echo $(LC_NUMERIC=C yad --title="Gif settings" --name "convert script" --class "Convert Script" \
++        yad_command = [[echo $(LC_NUMERIC=C ]] .. YAD_CMD .. [[ --title="Gif settings" --name "convert script" --class "Convert Script" \
+         --center --form --always-print-result --separator="…" \
+         --field="Fuzz Factor:NUM" '1!0..100!0.5!1' \
+         --field="Framestep:NUM" '3!1..3!1' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13153,6 +13153,10 @@ let
     vaapiSupport = config.mpv.vaapiSupport or false;
   };
 
+  mpvScripts = {
+    convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
+  };
+
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };
 
   mrxvt = callPackage ../applications/misc/mrxvt { };


### PR DESCRIPTION
mpv’s functionality can be modified with lua scripts, by specifying them
on the command line.
`scripts` is a list of lua files that are appended to the default mpv
invocation. We also provide a `mpvScripts` attrset with the available
scripts in the top namespace.

`convert` is one such script, that extends mpv with a simple but very
convenient on-the-fly cropping and converting feature.

Tested `nix-build -E 'with import ./. {}; mpv.override { scripts=[mpvScripts.convert]; }'`.

One discussion point before this is accepted is how the plugins should look like. This implementation makes `scripts` just a list of lua files, and `convert` is (by chance?!) such a file. The disadvantage of this approach is that plugins can only ever be one file.
Maybe it is advisable to have one more layer of indirection, so that `mpvScripts` still consists of direct “pluggable“ paths to the lua files, by appending the correct filename. But that shouldn’t be done in `all-packages.nix` …
There is also the mpv bug that `--script` only accepts files which end in `.lua` and silently (!) ignores anything else. Also silently ignored are: non-existing files, syntactically non-valid lua files, and probably also scripts exiting with an error. phew.

Another question is how to document these plugins. I’ve used `longDescription` for `convert` to give a very basic how-to. Once there are more plugins, we should look for a discoverable way of documenting them.
