### PR TITLE
vimPlugins: youcompleteme FIX #14006 No rule to make target 'ycm_support_libs'

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -883,11 +883,11 @@ rec {
   };
 
   youcompleteme = buildVimPluginFrom2Nix { # created by nix#NixDerivation
-    name = "youcompleteme-2016-03-08";
+    name = "youcompleteme-2016-03-10";
     src = fetchgit {
       url = "git://github.com/valloric/youcompleteme";
-      rev = "381b2132719a959f41e57ec0e6396fc1c3b6daf4";
-      sha256 = "1gski3s1960pmxisyq85awda0a3kb22ji9y76f67k1a4smy5q9xa";
+      rev = "f44435b88ec98156d17869aa67ad15f38cfecbf3";
+      sha256 = "1y50ilyfwj6rvpvg50iq418maxvsfs54i202v7x0lfs5hmvcb4hi";
     };
     dependencies = [];
     buildInputs = [
@@ -904,7 +904,7 @@ rec {
       mkdir build
       pushd build
       cmake -G "Unix Makefiles" . ../third_party/ycmd/cpp -DPYTHON_LIBRARIES:PATH=${python}/lib/libpython2.7.so -DPYTHON_INCLUDE_DIR:PATH=${python}/include/python2.7 -DUSE_CLANG_COMPLETER=ON -DUSE_SYSTEM_LIBCLANG=ON
-      make ycm_support_libs -j''${NIX_BUILD_CORES} -l''${NIX_BUILD_CORES}}
+      make ycm_core -j''${NIX_BUILD_CORES} -l''${NIX_BUILD_CORES}}
       ${python}/bin/python ../third_party/ycmd/build.py --gocode-completer --clang-completer --system-libclang
       popd
     '';

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/youcompleteme
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/youcompleteme
@@ -12,7 +12,7 @@
       mkdir build
       pushd build
       cmake -G "Unix Makefiles" . ../third_party/ycmd/cpp -DPYTHON_LIBRARIES:PATH=${python}/lib/libpython2.7.so -DPYTHON_INCLUDE_DIR:PATH=${python}/include/python2.7 -DUSE_CLANG_COMPLETER=ON -DUSE_SYSTEM_LIBCLANG=ON
-      make ycm_support_libs -j''${NIX_BUILD_CORES} -l''${NIX_BUILD_CORES}}
+      make ycm_core -j''${NIX_BUILD_CORES} -l''${NIX_BUILD_CORES}}
       ${python}/bin/python ../third_party/ycmd/build.py --gocode-completer --clang-completer --system-libclang
       popd
     '';


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14006 

https://github.com/Valloric/ycmd/commit/599de71575d542d4fc5c33344c65b3931e4d7ed2#diff-6725b893dfc969abac4f4ee39a3a317f
