### PR TITLE
nixos/manpages: enable linebreaking after slashes

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -187,6 +187,7 @@ in rec {
         --param man.output.in.separate.dir 1 \
         --param man.output.base.dir "'$out/share/man/'" \
         --param man.endnotes.are.numbered 0 \
+        --param man.break.after.slash 1 \
         ${docbook5_xsl}/xml/xsl/docbook/manpages/docbook.xsl \
         ./man-pages.xml
     '';


### PR DESCRIPTION
Allow linebreaks after slashes in long URLs. The option used
is documented at

   http://docbook.sourceforge.net/release/xsl/current/doc/manpages/man.break.after.slash.html

This commit fixes #4538.
