### PR TITLE
Handle submodules for type "either"

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -246,7 +246,25 @@ rec {
     either = t1: t2: mkOptionType {
       name = "${t1.name} or ${t2.name}";
       check = x: t1.check x || t2.check x;
-      merge = mergeOneOption;
+      merge = loc: defs:
+             if all t1.check (getValues defs) then t1.merge loc defs
+        else if all t2.check (getValues defs) then t2.merge loc defs
+        else throw ( "The option `${showOption loc}' has conflicting"
+                   + " definitions for type either, in"
+                   + " ${showFiles (getFiles defs)}.");
+
+      getSubOptions = prefix: t1.getSubOptions prefix
+                           // t2.getSubOptions prefix;
+
+      getSubModules = concatLists (remove null [
+        t1.getSubModules
+        t2.getSubModules
+      ]);
+
+      substSubModules = m: let
+        maybeDef = def: r: if r == null then def else r;
+      in either (maybeDef t1 (t1.substSubModules m))
+                (maybeDef t2 (t2.substSubModules m));
     };
 
     # Obsolete alternative to configOf.  It takes its option


### PR DESCRIPTION
So far the `either` type only handled "flat" types, so you couldn't do something like:

``` nix
{
  type = either int (submodule {
    options = ...;
  });
}
```

Not only caused this the submodule's options not being checked but also
not show up in the documentation.

This was something we stumbled on with #13916.

Cc: @edolstra, @nbp
