### PR TITLE
kernel: 3.10.99 -> 3.10.101

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.10.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.10.99";
+  version = "3.10.101";
   extraMeta.branch = "3.10";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "1hq90yn2ry36y317px7f0wy55j70ip3wlxa4qsdl9pzlndadcp24";
+    sha256 = "1g8jx6vla8bjhy3xn0s7r6awinxpfr1w8zqfzjsx88pkqbf8qd9n";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._
