### PR TITLE
kernel: 3.14.63 -> 3.14.65

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.14.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.14.63";
+  version = "3.14.65";
   extraMeta.branch = "3.14";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "0q3qcgcaxjc298dgjpfn6g17lvki2p87f0zkaxs0h0g13jhykwbz";
+    sha256 = "0pqfgzinwgllvyx0cfv0vnllgvzrrpbr2yi21zgppdd1iw6nipsd";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
