### PR TITLE
kernel: 3.18.28 -> 3.18.29

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-3.18.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "3.18.28";
+  version = "3.18.29";
   extraMeta.branch = "3.18";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v3.x/linux-${version}.tar.xz";
-    sha256 = "1vd7xm5wh082bwh93f69r99727y1yd5l6qjdm68rs0j5lzhamdbl";
+    sha256 = "0g8vlhifl31dyghiamykrpgj6n8h5w6gh6n88ir57z6lj188vaj8";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
