### PR TITLE
ipxe: fix gcc5 build

### DIFF
--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation {
 
   preConfigure = "cd src";
 
+  NIX_CFLAGS_COMPILE = "-Wno-error";
+
   makeFlags =
     [ "ECHO_E_BIN_ECHO=echo" "ECHO_E_BIN_ECHO_E=echo" # No /bin/echo here.
       "ISOLINUX_BIN_LIST=${syslinux}/share/syslinux/isolinux.bin"


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

gcc5 enables additional warnings, causing the build to fail with
-Werror.  The build could be fixed by specifically disabling errors
for `discarded-array-qualifiers` and `logical-not-parentheses` warnings,
but simply passing -Wno-error is more future proof.

See https://hydra.nixos.org/build/33274006/nixlog/1/raw
