### PR TITLE
bundlerEnv: fix wrapping of programs

### DIFF
--- a/pkgs/development/interpreters/ruby/bundler-env/gen-bin-stubs.rb
+++ b/pkgs/development/interpreters/ruby/bundler-env/gen-bin-stubs.rb
@@ -32,10 +32,8 @@ paths.each do |path|
 ENV["BUNDLE_GEMFILE"] = "#{gemfile}"
 ENV["BUNDLE_PATH"] = "#{bundle_path}"
 
-gem_path = ENV["GEM_PATH"]
-ENV["GEM_PATH"] = "\#{gem_path}\#{":" unless gem_path.nil? || gem_path.empty?}#{bundler_gem_path}"
+Gem.use_paths("#{bundler_gem_path}", ENV["GEM_PATH"])
 
-require 'rubygems'
 require 'bundler/setup'
 
 load Gem.bin_path(#{name.inspect}, #{exe.inspect})


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Setting the GEM_PATH after ruby is started is not reliable enough. In
some cases rubygems would have already loaded and ignore these settings.

Fixes #14048
