### PR TITLE
torbrowser: 5.5.3 -> 5.5.4

### DIFF
--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -16,13 +16,13 @@ let
 
 in stdenv.mkDerivation rec {
   name = "tor-browser-${version}";
-  version = "5.5.3";
+  version = "5.5.4";
 
   src = fetchurl {
     url = "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux${if stdenv.is64bit then "64" else "32"}-${version}_en-US.tar.xz";
     sha256 = if stdenv.is64bit then
-      "04na0xp2fqq72shj88wayx23cwhbhcdsl0vi0wfhh4k6ajr7yg7c" else
-      "06xmbrpyazvss89dwd08rdza7s2p4i326izjdrdhxrjkz83jkf2m";
+      "0sjx2r7z7s3x1ygs9xak1phng13jcf4d5pcfyfrfsrd8kb1yn8xa" else
+      "0w9wk9hk57hyhhx7l4sr2x64ki9882fr6py2can1slr7kbb4mhpb";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
