### PR TITLE
crashplan: 3.6.4 -> 4.6.0

### DIFF
--- a/nixos/modules/services/backup/crashplan.nix
+++ b/nixos/modules/services/backup/crashplan.nix
@@ -48,6 +48,14 @@ with lib;
         ensureDir ${crashplan.vardir}/cache 700
         ensureDir ${crashplan.vardir}/backupArchives 700
         ensureDir ${crashplan.vardir}/log 777
+        cp -avn ${crashplan}/conf.template/* ${crashplan.vardir}/conf
+        for x in app.asar bin EULA.txt install.vars lang lib libjniwrap64.so libjniwrap.so libjtux64.so libjtux.so libmd564.so libmd5.so share skin upgrade; do
+          if [ -e $x ]; then
+            true;
+          else
+            ln -s ${crashplan}/$x ${crashplan.vardir}/$x;
+          fi;
+        done
       '';
 
       serviceConfig = {

--- a/pkgs/applications/backup/crashplan/CrashPlanDesktop.patch
+++ b/pkgs/applications/backup/crashplan/CrashPlanDesktop.patch
@@ -1,8 +1,12 @@
---- ./scripts/CrashPlanDesktop    2014-12-18 09:51:14.050804325 +0100
-+++ ./scripts/CrashPlanDesktop-1  2014-12-18 09:51:32.271009382 +0100
-@@ -9,4 +9,4 @@
- 
+--- ./scripts/CrashPlanDesktop	2016-03-02 21:01:58.000000000 -0500
++++ ./scripts/CrashPlanDesktop-1	2016-03-18 20:52:10.117686266 -0400
+@@ -11,7 +11,7 @@
  cd ${TARGETDIR}
  
--${JAVACOMMON} ${GUI_JAVA_OPTS} -classpath "./lib/com.backup42.desktop.jar:./lang:./skin" com.backup42.desktop.CPDesktop > ${TARGETDIR}/log/ui_output.log 2> ${TARGETDIR}/log/ui_error.log &
-+${JAVACOMMON} ${GUI_JAVA_OPTS} -classpath "./lib/com.backup42.desktop.jar:./lang:./skin" com.backup42.desktop.CPDesktop &
+ if [ "_${VERSION_5_UI}" == "_true" ]; then
+-	${TARGETDIR}/electron/crashplan > ${TARGETDIR}/log/ui_output.log 2> ${TARGETDIR}/log/ui_error.log &
++	${TARGETDIR}/electron/crashplan &
+ else
+-	${JAVACOMMON} ${GUI_JAVA_OPTS} -classpath "./lib/com.backup42.desktop.jar:./lang:./skin" com.backup42.desktop.CPDesktop > ${TARGETDIR}/log/ui_output.log 2> ${TARGETDIR}/log/ui_error.log &
++	${JAVACOMMON} ${GUI_JAVA_OPTS} -classpath "./lib/com.backup42.desktop.jar:./lang:./skin" com.backup42.desktop.CPDesktop &
+ fi

--- a/pkgs/applications/backup/crashplan/default.nix
+++ b/pkgs/applications/backup/crashplan/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, makeWrapper, jre, cpio, gawk, gnugrep, gnused, procps, swt, gtk2, glib, libXtst }:
 
-let version = "3.6.4";
+let version = "4.6.0";
 
 in stdenv.mkDerivation rec {
   name = "crashplan-${version}";
 
   crashPlanArchive = fetchurl {
-    url = "http://download.crashplan.com/installs/linux/install/CrashPlan/CrashPlan_${version}_Linux.tgz";
-    sha256 = "0xmzpxfm8vghk552jy167wg1nky1pp93dqds1p922hn73g0x5cv3";
+    url = "https://download.code42.com/installs/linux/install/CrashPlan/CrashPlan_${version}_Linux.tgz";
+    sha256 = "0h9zk6i1pdvl101c8l4v4x6i7q4wkmkqp2dkm0lq7ha96lrvac47";
   };
 
   srcs = [ crashPlanArchive ];
@@ -16,7 +16,6 @@ in stdenv.mkDerivation rec {
     description = "An online/offline backup solution";
     homepage = "http://www.crashplan.org";
     license = licenses.unfree;
-    broken = true;  # outdated and new client has trouble starting (nullpointer exception)
     maintainers = with maintainers; [ sztupi iElectric ];
   };
 
@@ -38,7 +37,7 @@ in stdenv.mkDerivation rec {
     # Make sure the daemon is running using the same localization as
     # the (installing) user
     echo "" >> run.conf
-    echo "export LC_ALL=en_US.UTF-8" >> run.conf
+    echo "LC_ALL=en_US.UTF-8" >> run.conf
 
     install -d -m 755 unpacked $out
 
@@ -49,15 +48,15 @@ in stdenv.mkDerivation rec {
     install -D -m 644 scripts/CrashPlan.desktop $out/share/applications/CrashPlan.desktop
 
     rm -r $out/log
+    mv -v $out/conf $out/conf.template
     ln -s $vardir/log $out/log
     ln -s $vardir/cache $out/cache
     ln -s $vardir/backupArchives $out/backupArchives
-    ln -s $vardir/conf/service.model $out/conf/service.model
-    ln -s $vardir/conf/my.service.xml $out/conf/my.service.xml
+    ln -s $vardir/conf $out/conf
 
     echo "JAVACOMMON=${jre}/bin/java" > $out/install.vars
     echo "APP_BASENAME=CrashPlan" >> $out/install.vars
-    echo "TARGETDIR=$out" >> $out/install.vars
+    echo "TARGETDIR=${vardir}" >> $out/install.vars
     echo "BINSDIR=$out/bin" >> $out/install.vars
     echo "MANIFESTDIR=${manifestdir}" >> $out/install.vars
     echo "VARDIR=${vardir}" >> $out/install.vars
@@ -77,7 +76,8 @@ in stdenv.mkDerivation rec {
     
     substituteInPlace $out/share/applications/CrashPlan.desktop \
       --replace /usr/local  $out \
-      --replace crashplan/skin skin
+      --replace crashplan/skin skin \
+      --replace bin/CrashPlanDesktop CrashPlanDesktop
 
     wrapProgram $out/bin/CrashPlanDesktop --prefix LD_LIBRARY_PATH ":" "${gtk2}/lib:${glib}/lib:${libXtst}/lib"
   '';


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @domenkozar @sztupi @Baughn 

---
- the major change is to set TARGETDIR=${vardir}, and symlink from
  ${vardir} back to ${out} instead of the other way around.  this
  gives CP more liberty to write to more directories -- in particular
  it seems to want to write some configuration files outside of conf?
- run.conf does not need 'export'
- minor tweaks to CrashPlanDesktop.patch
- CrashPlan.desktop does not launch from KDE 5, but CrashPlanDesktop
  runs fine from the command line.
