### PR TITLE
im-engines: use recurseIntoAttrs

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1194,7 +1194,7 @@ let
 
   ibus-qt = callPackage ../tools/inputmethods/ibus/ibus-qt.nix { };
 
-  ibus-engines = {
+  ibus-engines = recurseIntoAttrs {
 
     anthy = callPackage ../tools/inputmethods/ibus-engines/ibus-anthy {
       inherit (python3Packages) pygobject3;
@@ -1557,7 +1557,7 @@ let
 
   fcitx = callPackage ../tools/inputmethods/fcitx { };
 
-  fcitx-engines = {
+  fcitx-engines = recurseIntoAttrs {
 
     anthy = callPackage ../tools/inputmethods/fcitx-engines/fcitx-anthy { };
 


### PR DESCRIPTION
[`ibus-engines`](http://hydra.nixos.org/search?query=ibus-engines) and [`fcitx-engines`](http://hydra.nixos.org/search?query=fcitx-engines) are currently not built on Hydra.

This change should fix this, but I am not really sure that this is a correct use of `recurseIntoAttrs`.

Could someone with better Hydra and `recurseIntoAttrs` understanding review this and confirm that will work as intended?
