### PR TITLE
vim-plugins: add airline-themes

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1451,6 +1451,16 @@ rec {
 
   };
 
+  vim-airline-themes = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-airline-themes-2016-02-24";
+    src = fetchgit {
+      url = "git://github.com/vim-airline/vim-airline-themes";
+      rev = "13bad30d4ee3892cae755c83433ee85fbc96d028";
+      sha256 = "0w36ani4r2v58pd0fcqv12j0hjd97g2q78zici1a72njvwp9qhgj";
+    };
+    dependencies = [ "vim-airline" ];
+  };
+
   vim-coffee-script = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-coffee-script-2015-04-20";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -112,6 +112,7 @@
 "vim-addon-toggle-buffer"
 "vim-addon-xdebug"
 "vim-airline"
+"vim-airline-themes"
 "vim-coffee-script"
 "vim-easy-align"
 "vim-gista"


### PR DESCRIPTION
[vim-airline](https://github.com/vim-airline/vim-airline) now requires themes to live in [vim-airline-themes](https://github.com/vim-airline/vim-airline-themes).

This is my first PR here, let me know if I'm doing anything wrong.
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jagajaga 
