### PR TITLE
php security updates (5.5.32 -> 5.5.33, 5.6.18 -> 5.6.19) (15.09 backport)

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -295,8 +295,8 @@ in {
   };
 
   php56 = generic {
-    version = "5.6.18";
-    sha256 = "1vgl2zjq6ws5cjjb3llhwpfwg9gasq3q84ibdv9hj8snm4llmkf3";
+    version = "5.6.19";
+    sha256 = "0s61fncsdgr1mqgh8jma6pi6xxz4gl350467lk00ls3i97wa691a";
   };
 
   php70 = lib.lowPrio (generic {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -290,8 +290,8 @@ in {
   };
 
   php55 = generic {
-    version = "5.5.32";
-    sha256 = "1vljdvyqsq0vas4yhvpqycqyxl2gfndbmak6cfgxn1cfvc4c3wmh";
+    version = "5.5.33";
+    sha256 = "1a8ac1zcq68irvdffh08cpi4aaaira4hsqwgns7b95pm9pnv3464";
   };
 
   php56 = generic {


### PR DESCRIPTION
Please note this _fails_ a local `nox-review` build, but the existing 15.09 head fails on the same package for me anyway, so I'm assuming this doesn't introduce any new breakage.

FYI existing failure is

```
configure: error: '/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/bin/php-config --includes' reports '-I/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/include/php -I/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/include/php/main -I/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/include/php/TSRM -I/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/include/php/Zend -I/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/include/php/ext -I/nix/store/x39gn9mvi69d8xkbrhz0vwvnbk8zhfqp-php-5.6.18/include/php/ext/date/lib' but zend.h can't be included from there
builder for ‘/nix/store/sjjazkxjbslr1x93dfd42cfcssawg56l-xapian-bindings-1.0.23.drv’ failed with exit code 1
error: build of ‘/nix/store/sjjazkxjbslr1x93dfd42cfcssawg56l-xapian-bindings-1.0.23.drv’ failed
```
