### PR TITLE
systemd: Pass `cryptsetup` to allow usage of `systemd-cryptsetup-generator` for `/etc/crypttab`

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ linuxHeaders pkgconfig intltool gperf libcap kmod xz pam acl
-      /* cryptsetup */ libuuid m4 glib libxslt libgcrypt libgpgerror
+      cryptsetup libuuid m4 glib libxslt libgcrypt libgpgerror
       libmicrohttpd kexectools libseccomp audit lz4 libapparmor
       /* FIXME: we may be able to prevent the following dependencies
          by generating an autoconf'd tarball, but that's probably not

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11025,7 +11025,7 @@ let
     cryptsetup = null; # Infinite recusion
   };
 
-  systemd-with-cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
+  systemd_with_cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
     inherit cryptsetup;
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11022,6 +11022,11 @@ let
 
   systemd = callPackage ../os-specific/linux/systemd {
     linuxHeaders = linuxHeaders_3_18;
+    cryptsetup = null; # Infinite recusion
+  };
+
+  systemd-with-cryptsetup = systemd.override {
+    inherit cryptsetup;
   };
 
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11025,9 +11025,9 @@ let
     cryptsetup = null; # Infinite recusion
   };
 
-  systemd-with-cryptsetup = systemd.override {
+  systemd-with-cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
     inherit cryptsetup;
-  };
+  });
 
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get
   # LVM2 working in systemd.


### PR DESCRIPTION
Systemd comes with quite good /etc/crypttab support. To support it, systemd needs to be built with `cryptsetup`.

My motivation for this PR was auto-mounting of encrypted external USB disks with a keyfile. For this, I can't use `filesystems.*.encrypted` as this is only applied at boot time. 

The usual approach here is using `/etc/crypttab` to specify the keyfile in combination with a `filesystems.<name>` with `device` pointing to `/dev/mapper/something`, where `something` is the name specified in `/etc/crypttab`.

Example: 

`/etc/crypttab`:

```
backup-disk UUID=22610934-e0bc-448f-a981-313a5d9f3fd0 /root/keyfile-backup luks
```

`configuration.nix`

```
fileSystems."/mnt/btr_backup" = {
  options = [
    "nofail"
    "x-systemd.device-timeout=1"];
  neededForBoot = false;
  device = "/dev/mapper/backup-disk";
};
```

This setup will auto-decrypt the USB disk with the above UUID after plugging-in via `cryptsetup`, making it available under `/dev/mapper/backup-disk`. Systemd will then see that the `device` of `/mnt/btr_backup` became available and activate that mount.

In order for systemd to support `/etc/crypttab`, it has to be compiled with `cryptsetup` in `buildInputs`. In our current systemd this was disabled because of a circular dependency between `systemd`, `lvm2`, and `cryptsetup`. 

This PR adds `systemd-with-cryptsetup` to `all-packages.nix`, allowing people to set `systemd.package = pkgs.systemd-with-cryptsetup;`. 

I'm not patching the default systemd as I'm not sure if there aren't any unforeseen consequences. In the future I'd like to enable `cryptsetup` in our systemd by default. It might even be a good idea to do this directly instead of this PR. In that case, I'll be glad to change it. 

Note that this triggers quite a big rebuild, we might want to merge it into staging instead.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._
