### PR TITLE
dropbox-cli: minor refactoring to play nice with dropbox

### DIFF
--- a/pkgs/applications/networking/dropbox-cli/default.nix
+++ b/pkgs/applications/networking/dropbox-cli/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation {
   phases = "unpackPhase installPhase";
 
   installPhase = ''
-    mkdir -p "$out/bin/" "$out/share/applications"
-    cp data/dropbox.desktop "$out/share/applications"
+    mkdir -p "$out/bin/"
     substitute "dropbox.in" "$out/bin/dropbox" \
       --replace '@PACKAGE_VERSION@' ${version} \
       --replace '@DESKTOP_FILE_DIR@' "$out/share/applications" \
@@ -25,6 +24,7 @@ stdenv.mkDerivation {
       --replace '@IMAGEDATA64@' '"too-lazy-to-fix"'
     sed -i 's:db_path = .*:db_path = "${dropboxd}":' $out/bin/dropbox
     chmod +x "$out/bin/"*
+    mv $out/bin/dropbox $out/bin/dropbox-cli
     patchShebangs "$out/bin"
   '';
 


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._

We were previously getting collissions for the following
2 files with files from the dropbox package:
- bin/dropbox
- share/applications/dropbox.desktop

As a consequence the binary has been renamed to dropbox-cli and
the .desktop removed as it is redundant.
