### PR TITLE
bash-completion: remove collision

### DIFF
--- a/pkgs/shells/bash-completion/default.nix
+++ b/pkgs/shells/bash-completion/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  # nmcli is included in the network-manager package
+  postInstall = ''
+    rm $out/share/bash-completion/completions/nmcli
+  '';
+
   meta = {
     homepage = "http://bash-completion.alioth.debian.org/";
     description = "Programmable completion for the bash shell";


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._

nmcli is already provided by network-manager
