### PR TITLE
radicale service: run with dedicated user

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -255,6 +255,7 @@
       avahi-autoipd = 231;
       nntp-proxy = 232;
       mjpg-streamer = 233;
+      radicale = 234;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -483,6 +484,7 @@
       cfdyndns = 227;
       pdnsd = 229;
       octoprint = 230;
+      radicale = 234;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -35,12 +35,27 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.pythonPackages.radicale ];
 
+    users.extraUsers = singleton
+      { name = "radicale";
+        uid = config.ids.uids.radicale;
+        description = "radicale user";
+        home = "/var/lib/radicale";
+        createHome = true;
+      };
+
+    users.extraGroups = singleton
+      { name = "radicale";
+        gid = config.ids.gids.radicale;
+      };
+
     systemd.services.radicale = {
       description = "A Simple Calendar and Contact Server";
       after = [ "network-interfaces.target" ];
       wantedBy = [ "multi-user.target" ];
       script = "${pkgs.pythonPackages.radicale}/bin/radicale -C ${confFile} -d";
       serviceConfig.Type = "forking";
+      serviceConfig.User = "radicale";
+      serviceConfig.Group = "radicale";
     };
   };
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This is done in the context of #11908.
