### PR TITLE
quassel: 0.12.2 -> 0.12.3

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -25,7 +25,7 @@ let
 
 in with stdenv; mkDerivation rec {
 
-  version = "0.12.2";
+  version = "0.12.3";
   name = "quassel${tag}-${version}";
 
   src = fetchurl {

--- a/pkgs/applications/networking/irc/quassel/qt-5.nix
+++ b/pkgs/applications/networking/irc/quassel/qt-5.nix
@@ -36,7 +36,7 @@ let
 
 in with stdenv; mkDerivation rec {
 
-  version = "0.12.2";
+  version = "0.12.3";
   name = "quassel${tag}-${version}";
 
   src = fetchurl {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Needs testing
