### PR TITLE
kodiPlusings.pvr-hts: fix loading of plugin

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -245,7 +245,7 @@ in
     # them. Symlinking .so, as setting LD_LIBRARY_PATH is of no use
     installPhase = ''
       make install
-      ln -s $out/lib/kodi/addons/pvr.hts/pvr.hts.so $out/share/kodi/addons/pvr.hts
+      ln -s $out/lib/kodi/addons/pvr.hts/pvr.hts.so* $out/share/kodi/addons/pvr.hts
     '';
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

The plugin was looking for pvr.hts.so.2.2.13, so as only pvr.hts.so was copied, the plugin would not load. This symlinks all variants of the name to the addons folder.

cc @cpages 

---

_Please note, that points are not mandatory, but rather desired._
