### PR TITLE
hardlink: Fix Mac build error

### DIFF
--- a/pkgs/tools/system/hardlink/default.nix
+++ b/pkgs/tools/system/hardlink/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
-    gcc -O2 hardlink.c -o $out/bin/hardlink
+    $CC -O2 hardlink.c -o $out/bin/hardlink
     mv hardlink.1 $out/share/man/man1/hardlink.1
   '';
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes build failure on OS X

cc @peti 

---

_Please note, that points are not mandatory, but rather desired._

Use $CC instead of hardcoded gcc which isn't used on Mac

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/14082)

<!-- Reviewable:end -->
