### PR TITLE
Rust updates

### DIFF
--- a/pkgs/development/compilers/rustc/head.nix
+++ b/pkgs/development/compilers/rustc/head.nix
@@ -2,11 +2,11 @@
 { stdenv, callPackage }:
 
 callPackage ./generic.nix {
-  shortVersion = "2016-02-22";
+  shortVersion = "2016-03-22";
   isRelease = false;
   forceBundledLLVM = true;
-  srcRev = "d1f422ec280b881b8236c5d173103bc799e1590e";
-  srcSha = "b0753045ae438c0869d37f429fe84451dcacc4b2ab9413d34bf29fde94fde462";
+  srcRev = "6cc502c986d42da407e26a49d4f09f21d3072fcb";
+  srcSha = "096lsc8irh9a7w494yaji28kzy9frs2myqrfyj0fzbxkvs3yfhzz";
 
   /* Rust is bootstrapped from an earlier built version. We need
   to fetch these earlier versions, which vary per platform.
@@ -15,14 +15,13 @@ callPackage ./generic.nix {
   with the set you want at the top.
   */
 
-  snapshotHashLinux686 = "a09c4a4036151d0cb28e265101669731600e01f2";
-  snapshotHashLinux64 = "97e2a5eb8904962df8596e95d6e5d9b574d73bf4";
-  snapshotHashDarwin686 = "ca52d2d3ba6497ed007705ee3401cf7efc136ca1";
-  snapshotHashDarwin64 = "3c44ffa18f89567c2b81f8d695e711c86d81ffc7";
-  snapshotDate = "2015-12-18";
-  snapshotRev = "3391630";
+  snapshotHashLinux686 = "0e0e4448b80d0a12b75485795244bb3857a0a7ef";
+  snapshotHashLinux64 = "1273b6b6aed421c9e40c59f366d0df6092ec0397";
+  snapshotHashDarwin686 = "9f9c0b4a2db09acbce54b792fb8839a735585565";
+  snapshotHashDarwin64 = "52570f6fd915b0210a9be98cfc933148e16a75f8";
+  snapshotDate = "2016-03-18";
+  snapshotRev = "235d774";
 
   patches = [ ./patches/remove-uneeded-git.patch ]
     ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
 }
-

--- a/pkgs/development/tools/build-managers/cargo/head.nix
+++ b/pkgs/development/tools/build-managers/cargo/head.nix
@@ -5,7 +5,7 @@ with rustPlatform;
 
 with ((import ./common.nix) {
   inherit stdenv rustc;
-  version = "2016-02-25";
+  version = "2016-03-20";
 });
 
 buildRustPackage rec {
@@ -14,11 +14,11 @@ buildRustPackage rec {
   # Needs to use fetchgit instead of fetchFromGitHub to fetch submodules
   src = fetchgit {
     url = "git://github.com/rust-lang/cargo";
-    rev = "e7212896dc1b182493a0252a2a126db8be067153";
-    sha256 = "1qbic7gp7cpihi40kfv3kagja8zsngica8sq9jcm9czb6ba44dsa";
+    rev = "132b82d75f607dcb1116b8d44fe60f202f1eb110";
+    sha256 = "0kx2m0p45zr0ils2ax19sr32cibjppgwj8xvsgrfvzvlnc540xpl";
   };
 
-  depsSha256 = "1xfpj1233p4314j6jmip0jjl5m3kj2wbac1ll3yvh7383zb83i1s";
+  depsSha256 = "19d2fl5p92108a0yjpix0qxdc23jy122xc87k69hk0pwwxa92l3a";
 
   buildInputs = [ file curl pkgconfig python openssl cmake zlib makeWrapper ];
 

--- a/pkgs/development/tools/build-managers/cargo/snapshot.nix
+++ b/pkgs/development/tools/build-managers/cargo/snapshot.nix
@@ -2,7 +2,7 @@
 
 /* Cargo binary snapshot */
 
-let snapshotDate = "2015-06-17";
+let snapshotDate = "2016-01-31";
 in
 
 with ((import ./common.nix) {
@@ -11,13 +11,13 @@ with ((import ./common.nix) {
 });
 
 let snapshotHash = if stdenv.system == "i686-linux"
-      then "g2h9l35123r72hqdwayd9h79kspfb4y9"
+      then "7e2f9c82e1af5aa43ef3ee2692b985a5f2398f0a"
       else if stdenv.system == "x86_64-linux"
-      then "fnx2rf1j8zvrplcc7xzf89czn0hf3397"
+      then "4c03a3fd2474133c7ad6d8bb5f6af9915ca5292a"
       else if stdenv.system == "i686-darwin"
-      then "3viz3fi2jx18qjwrc90nfhm9cik59my6"
+      then "4d84d31449a5926f9e7ceb344540d6e5ea530b88"
       else if stdenv.system == "x86_64-darwin"
-      then "h2bf3db4vwz5cjjkn98lxayivdc6dflp"
+      then "f8baef5b0b3e6f9825be1f1709594695ac0f0abc"
       else throw "no snapshot for platform ${stdenv.system}";
     snapshotName = "cargo-nightly-${platform}.tar.gz";
 in

--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -3,15 +3,17 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "rustfmt-git-2016-02-15";
+  name = "rustfmt-${version}";
+  version = "2016-03-22";
+
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustfmt";
-    rev = "65bc5c242de86f0651b34fd913ca338a880696e8";
-    sha256 = "02rdim0y5zg1r2zkfy6kj53idlbdybf3ckardbjsvdna5idc1hpz";
+    rev = "ca757183fedf8e89286372b91ca074c11d99c4f4";
+    sha256 = "0ngg5m002hwwmsqy9wr50dj3l3zgwk39701wzszm3nrhz6x13dmj";
   };
 
-  depsSha256 = "1297vy5sgiq4xqdm27pa8f99qiwrl15hb2r1dydzgk7n4iqyir6c";
+  depsSha256 = "0mg4z197iiwjlgqs5izacld25cr11qi3bcrqq204f0jzrnj3y8ag";
 
   meta = with stdenv.lib; {
     description = "A tool for formatting Rust code according to style guidelines";

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -4,15 +4,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "exa-${version}";
-  version = "2016-02-15";
+  version = "2016-03-22";
 
-  depsSha256 = "1925nhpfph82wn755zf2nmad24f1hzbxq60gpva9sic6rnap4c1x";
+  depsSha256 = "18anwh235kzziq6z7md8f3rl2xl4l9d4ivsqw9grkb7yivd5j0jk";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = "exa";
-    rev = "252eba484476369bb966fb1af7f739732b968fc0";
-    sha256 = "1smyy32z44zgmhyhlbjaxcgfnlbcwz7am9225yppqfdsiqqgdybf";
+    rev = "8805ce9e3bcd4b56f8811a686dd56c47202cdbab";
+    sha256 = "0dkvk0rsf068as6zcd01p7959rdjzm26mlkpid6z0j168gp4kh4q";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,15 +7,15 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-03-10";
-  rev = "5e78a14c1b82522e019586687f7dbfd36ce67fa5";
+  version = "2016-03-22";
+  rev = "f28cdedb698cf76f513fb4514b5ed2892ec89b2f";
 
   src = fetchFromGitHub {
       inherit rev;
 
       owner = "rust-lang";
       repo = "crates.io-index";
-      sha256 = "0hzhfhlv8qbqb5nm9id36dlzvhalhlrh2k82ks67ap4mdcs3c650";
+      sha256 = "05j43pgdlf554y9r781xdc5la55anwiq6k7vml9icak699ywfxqq";
   };
 
 in


### PR DESCRIPTION
Currently fails to build cargo:

```
 Downloading regex v0.1.58 (registry file:///nix/store/xj4i6hmks3wv5mdnanncrn8kwwjzip0z-rustRegistry-2016-03-20-a8f5a24)
unable to get packages from source

Caused by:
  failed to parse manifest at `/nix/store/gqidn6a0k6sz7psxi0imnwfkhjij9lf3-cargo-2016-03-20-fetch/registry/src/-ce71226a1be9ab73/regex-0.1.58/Cargo.toml`

Caused by:
  expected a value of type `string` for the key `lib.name`
builder for ‘/nix/store/am9p1970s3a45hpq7f56nkcik22bzfj1-cargo-2016-03-20-fetch.drv’ failed with exit code 101
cannot build derivation ‘/nix/store/fx7lrj7kvbmypysx6i4cdrm7yrslzwrn-cargo-2016-03-20.drv’: 1 dependencies couldn't be built
```

Maybe someone knows what's going on here?
