### PR TITLE
htop: fix platforms attribute

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     description = "An interactive process viewer for Linux";
     homepage = https://hisham.hm/htop/;
     license = licenses.gpl2Plus;
-    platforms = with platforms; [ linux freebsd openbsd darwin ];
+    platforms = with platforms; linux ++ freebsd ++ openbsd ++ darwin;
     maintainers = with maintainers; [ rob simons relrod nckx ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

See comments at https://github.com/NixOS/nixpkgs/commit/57dd725e853b54c578e3b73f520756be3ff2359c.

These values are already lists and need to be concatenated together
instead of placed in another list.
