### PR TITLE
bugseverywhere: init at 1.1.1

### DIFF
--- a/pkgs/applications/version-management/bugseverywhere/default.nix
+++ b/pkgs/applications/version-management/bugseverywhere/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, pythonPackages, fetchurl }:
+
+#
+# Upstream stopped development of this package. If this package does not build
+# anymore, feel free to remove it by reverting the appropriate patch
+# (git log --grep bugseverywhere)
+#
+pythonPackages.buildPythonApplication rec {
+    version = "1.1.1";
+    name = "bugseverywhere-${version}";
+
+    src = fetchurl {
+      url =
+      "https://pypi.python.org/packages/source/b/bugs-everywhere/bugs-everywhere-${version}.tar.gz";
+      sha256 = "1ikm3ckwpimwcvx32vy7gh5gbp7q750j3327m17nvrj99g3daz2d";
+    };
+
+    # There are no tests in the repository.
+    doCheck = false;
+
+    buildInputs = with pythonPackages; [
+        jinja2
+        cherrypy
+    ];
+
+    meta = with stdenv.lib; {
+        description = "Bugtracker supporting distributed revision control";
+        homepage = "http://www.bugseverywhere.org/";
+        license = licenses.gpl2Plus;
+        platforms = platforms.all;
+        maintainers = [ maintainers.matthiasbeyer ];
+    };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -87,6 +87,8 @@ in modules // {
 
   blivet = callPackage ../development/python-modules/blivet { };
 
+  bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
+
   dbus = callPackage ../development/python-modules/dbus {
     dbus = pkgs.dbus;
   };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

**This does build but crashes on startup.** `./result/bin/be help` for example.

I'm not a python guy, can someone help me please?
