### PR TITLE
grive2: init at 0.5.0

### DIFF
--- a/pkgs/tools/filesystems/grive2/default.nix
+++ b/pkgs/tools/filesystems/grive2/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, pkgconfig, fetchurl, yajl, cmake, libgcrypt, curl, expat, boost, binutils }:
+
+stdenv.mkDerivation rec {
+  version = "0.5.0";
+  name = "grive2-${version}";
+
+  src = fetchFromGitHub {
+    owner = "vitalif";
+    repo = "grive2";
+    rev =  "v${version}";
+    sha256 = "0gyic9228j25l5x8qj9xxxp2cgbw6y4skxqx0xrq6qilhv4lj23c";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ libgcrypt yajl curl expat stdenv boost binutils ];
+
+  meta = with stdenv.lib; {
+    description = "A console Google Drive client";
+    homepage = https://github.com/vitalif/grive2;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1867,6 +1867,8 @@ let
     json_c = json-c-0-11; # won't configure with 0.12; others are vulnerable
   };
 
+  grive2 = callPackage ../tools/filesystems/grive2 { };
+
   groff = callPackage ../tools/text/groff {
     ghostscript = null;
   };


### PR DESCRIPTION
The package `grive` has been deprecated and does not work anymore, this is its successor.

Package built with NixOS 15.09. I tried sandboxing but I'm not sure if I managed, since it was already built once.

The binaries have been tested and work as expected.
