### PR TITLE
goPackages: rename "date" to "version"

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -12,9 +12,9 @@ let
 
   inherit go buildGoPackage;
 
-  buildFromGitHub = { rev, date ? null, owner, repo, sha256, name ? repo, goPackagePath ? "github.com/${owner}/${repo}", ... }@args: buildGoPackage (args // {
+  buildFromGitHub = { rev, version ? null, owner, repo, sha256, name ? repo, goPackagePath ? "github.com/${owner}/${repo}", ... }@args: buildGoPackage (args // {
     inherit rev goPackagePath;
-    name = "${name}-${if date != null then date else if builtins.stringLength rev != 40 then rev else stdenv.lib.strings.substring 0 7 rev}";
+    name = "${name}-${if version != null then version else if builtins.stringLength rev != 40 then rev else stdenv.lib.strings.substring 0 7 rev}";
     src  = fetchFromGitHub { inherit rev owner repo sha256; };
   });
 
@@ -22,7 +22,7 @@ let
 
   crypto = buildFromGitHub {
     rev      = "575fdbe86e5dd89229707ebec0575ce7d088a4a6";
-    date     = "2015-08-29";
+    version  = "2015-08-29";
     owner    = "golang";
     repo     = "crypto";
     sha256   = "1kgv1mkw9y404pk3lcwbs0vgl133mwyp294i18jg9hp10s5d56xa";
@@ -35,7 +35,7 @@ let
 
   glog = buildFromGitHub {
     rev    = "fca8c8854093a154ff1eb580aae10276ad6b1b5f";
-    date   = "2015-07-31";
+    version = "2015-07-31";
     owner  = "golang";
     repo   = "glog";
     sha256 = "1nr2q0vas0a2f395f4shjxqpas18mjsf8yhgndsav7svngpbbpg8";
@@ -43,7 +43,7 @@ let
 
   codesearch = buildFromGitHub {
     rev    = "a45d81b686e85d01f2838439deaf72126ccd5a96";
-    date   = "2015-06-17";
+    version = "2015-06-17";
     owner  = "google";
     repo   = "codesearch";
     sha256 = "12bv3yz0l3bmsxbasfgv7scm9j719ch6pmlspv4bd4ix7wjpyhny";
@@ -51,7 +51,7 @@ let
 
   image = buildFromGitHub {
     rev = "8ab1ac6834edd43d91cbe24272897a87ce7e835e";
-    date = "2015-08-23";
+    version = "2015-08-23";
     owner = "golang";
     repo = "image";
     sha256 = "1ckr7yh5dx2kbvp9mis7i090ss9qcz46sazrj9f2hw4jj5g3y7dr";
@@ -61,7 +61,7 @@ let
 
   net_go15 = buildFromGitHub {
     rev    = "62ac18b461605b4be188bbc7300e9aa2bc836cd4";
-    date   = "2015-11-04";
+    version = "2015-11-04";
     owner  = "golang";
     repo   = "net";
     sha256 = "0lwwvbbwbf3yshxkfhn6z20gd45dkvnmw2ms36diiy34krgy402p";
@@ -77,7 +77,7 @@ let
 
   net_go14 = buildFromGitHub {
     rev    = "ea47fc708ee3e20177f3ca3716217c4ab75942cb";
-    date   = "2015-08-29";
+    version = "2015-08-29";
     owner  = "golang";
     repo   = "net";
     sha256 = "0x1pmg97n7l62vak9qnjdjrrfl98jydhv6j0w3jkk4dycdlzn30d";
@@ -95,7 +95,7 @@ let
 
   oauth2 = buildFromGitHub {
     rev = "397fe7649477ff2e8ced8fc0b2696f781e53745a";
-    date = "2015-06-23";
+    version = "2015-06-23";
     owner = "golang";
     repo = "oauth2";
     sha256 = "0fza0l7iwh6llkq2yzqn7dxi138vab0da64lnghfj1p71fprjzn8";
@@ -107,7 +107,7 @@ let
 
   protobuf = buildFromGitHub {
     rev = "59b73b37c1e45995477aae817e4a653c89a858db";
-    date = "2015-08-23";
+    version = "2015-08-23";
     owner = "golang";
     repo = "protobuf";
     sha256 = "1dx22jvhvj34ivpr7gw01fncg9yyx35mbpal4mpgnqka7ajmgjsa";
@@ -117,7 +117,7 @@ let
 
   snappy = buildFromGitHub {
     rev    = "723cc1e459b8eea2dea4583200fd60757d40097a";
-    date   = "2015-07-21";
+    version = "2015-07-21";
     owner  = "golang";
     repo   = "snappy";
     sha256 = "0bprq0qb46f5511b5scrdqqzskqqi2z8b4yh3216rv0n1crx536h";
@@ -126,7 +126,7 @@ let
 
   sys = buildFromGitHub {
     rev    = "d9157a9621b69ad1d8d77a1933590c416593f24f";
-    date   = "2015-02-01";
+    version = "2015-02-01";
     owner  = "golang";
     repo   = "sys";
     sha256 = "1asdbp7rj1j1m1aar1a022wpcwbml6zih6cpbxaw7b2m8v8is931";
@@ -138,7 +138,7 @@ let
 
   text = buildFromGitHub {
     rev = "5eb8d4684c4796dd36c74f6452f2c0fa6c79597e";
-    date = "2015-08-27";
+    version = "2015-08-27";
     owner = "golang";
     repo = "text";
     sha256 = "1cjwm2pv42dbfqc6ylr7jmma902zg4gng5aarqrbjf1k2nf2vs14";
@@ -148,7 +148,7 @@ let
 
   tools = buildFromGitHub {
     rev = "b48dc8da98ae78c3d11f220e7d327304c84e623a";
-    date = "2015-08-24";
+    version = "2015-08-24";
     owner = "golang";
     repo = "tools";
     sha256 = "187p3jjxrw2qjnzqwwrq7f9w10zh6vcnwnfl3q7ms8rbiffpjy5c";
@@ -197,7 +197,7 @@ let
 
   adapted = buildFromGitHub {
     rev = "eaea06aaff855227a71b1c58b18bc6de822e3e77";
-    date = "2015-06-03";
+    version = "2015-06-03";
     owner = "michaelmacinnis";
     repo = "adapted";
     sha256 = "0f28sn5mj48087zhjdrph2sjcznff1i1lwnwplx32bc5ax8nx5xm";
@@ -340,7 +340,7 @@ let
 
   bleve = buildFromGitHub {
     rev    = "fc34a97875840b2ae24517e7d746b69bdae9be90";
-    date   = "2016-01-19";
+    version = "2016-01-19";
     owner  = "blevesearch";
     repo   = "bleve";
     sha256 = "0ny7nvilrxmmzcdvpivwyrjkynnhc22c5gdrxzs421jly35jw8jx";
@@ -358,7 +358,7 @@ let
 
   bitset = buildFromGitHub {
     rev    = "bb0da3785c4fe9d26f6029c77c8fce2aa4d0b291";
-    date   = "2016-01-13";
+    version = "2016-01-13";
     owner  = "willf";
     repo   = "bitset";
     sha256 = "1d4z2hjjs9jk6aysi4mf50p8lbbzag4ir4y1f0z4sz8gkwagh7b7";
@@ -541,7 +541,7 @@ let
 
   consul-alerts = buildFromGitHub {
     rev = "6eb4bc556d5f926dbf15d86170664d35d504ae54";
-    date = "2015-08-09";
+    version = "2015-08-09";
     owner = "AcalephStorage";
     repo = "consul-alerts";
     sha256 = "191bmxix3nl4pr26hcdfxa9qpv5dzggjvi86h2slajgyd2rzn23b";
@@ -562,7 +562,7 @@ let
 
   consul-migrate = buildFromGitHub {
     rev    = "678fb10cdeae25ab309e99e655148f0bf65f9710";
-    date   = "2015-05-19";
+    version = "2015-05-19";
     owner  = "hashicorp";
     repo   = "consul-migrate";
     sha256 = "18zqyzbc3pny700fnh4hi45i5mlsramqykikcr7lgyx7id6alf16";
@@ -632,7 +632,7 @@ let
 
   dbus-old-2015-05-19 = buildFromGitHub {
     rev    = "a5942dec6340eb0d57f43f2003c190ce06e43dea";
-    date   = "2015-05-19";
+    version = "2015-05-19";
     owner  = "godbus";
     repo   = "dbus";
     sha256 = "1vk31wal7ncvjwvnb8q1myrkihv1np46f3q8dndi5k0csflbxxdf";
@@ -640,7 +640,7 @@ let
 
   dbus = buildFromGitHub {
     rev    = "230e4b23db2fd81c53eaa0073f76659d4849ce51";
-    date   = "2016-03-02";
+    version = "2016-03-02";
     owner  = "godbus";
     repo   = "dbus";
     sha256 = "1wxv2cbihzcsz2z7iycyzl7f3arhhgagcc5kqln1k1mkm4l85z0q";
@@ -662,7 +662,7 @@ let
 
   dns = buildFromGitHub {
     rev    = "e59f851c912767b1db587dcabee6e6652e495c75";
-    date   = "2015-07-22";
+    version = "2015-07-22";
     owner  = "miekg";
     repo   = "dns";
     sha256 = "1zcj4drmmskwvjy5ld54qd8a34ls9651ysl3q7c2bcambax5r0hp";
@@ -749,7 +749,7 @@ let
 
   du = buildFromGitHub {
     rev    = "3c0690cca16228b97741327b1b6781397afbdb24";
-    date   = "2015-08-05";
+    version = "2015-08-05";
     owner  = "calmh";
     repo   = "du";
     sha256 = "1mv6mkbslfc8giv47kyl97ny0igb3l7jya5hc75sm54xi6g205wa";
@@ -861,7 +861,7 @@ let
 
   gawp = buildFromGitHub {
     rev    = "488705639109de54d38974cc31353d34cc2cd609";
-    date = "2015-08-31";
+    version = "2015-08-31";
     owner  = "martingallagher";
     repo   = "gawp";
     sha256 = "0iqqd63nqdijdskdb9f0jwnm6akkh1p2jw4p2w7r1dbaqz1znyay";
@@ -903,7 +903,7 @@ let
 
   gosexy.gettext = buildFromGitHub {
     rev    = "4a979356fe964fec12e18326a32a89661f93dea7";
-    date   = "2016-02-20";
+    version = "2016-02-20";
     owner  = "gosexy";
     repo   = "gettext";
     sha256 = "07f3dmq4qsdykbn3fkha3v1w61hic6xw82dvdmvzhf0m41jxsgy6";
@@ -939,7 +939,7 @@ let
   };
 
   git-lfs = buildFromGitHub {
-    date = "1.1.1";  # "date" is effectively "version"
+    version = "1.1.1";
     rev = "v1.1.1";
     owner = "github";
     repo = "git-lfs";
@@ -1025,7 +1025,7 @@ let
 
   gocapability = buildFromGitHub {
     rev    = "2c00daeb6c3b45114c80ac44119e7b8801fdd852";
-    date   = "2015-07-16";
+    version = "2015-07-16";
     owner  = "syndtr";
     repo   = "gocapability";
     sha256 = "1x7jdcg2r5pakjf20q7bdiidfmv7vcjiyg682186rkp2wz0yws0l";
@@ -1060,7 +1060,7 @@ let
 
   gocode = buildFromGitHub {
     rev = "680a0fbae5119fb0dbea5dca1d89e02747a80de0";
-    date = "2015-09-03";
+    version = "2015-09-03";
     owner = "nsf";
     repo = "gocode";
     sha256 = "1ay2xakz4bcn8r3ylicbj753gjljvv4cj9l4wfly55cj1vjybjpv";
@@ -1139,7 +1139,7 @@ let
 
   govers = buildFromGitHub {
     rev = "3b5f175f65d601d06f48d78fcbdb0add633565b9";
-    date = "2015-01-09";
+    version = "2015-01-09";
     owner = "rogpeppe";
     repo = "govers";
     sha256 = "0din5a7nff6hpc4wg0yad2nwbgy4q1qaazxl8ni49lkkr4hyp8pc";
@@ -1162,7 +1162,7 @@ let
 
   golang_protobuf_extensions = buildFromGitHub {
     rev    = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a";
-    date   = "2015-04-06";
+    version = "2015-04-06";
     owner  = "matttproud";
     repo   = "golang_protobuf_extensions";
     sha256 = "0ajg41h6402big484drvm72wvid1af2sffw0qkzbmpy04lq68ahj";
@@ -1171,7 +1171,7 @@ let
 
   goleveldb = buildFromGitHub {
     rev = "1a9d62f03ea92815b46fcaab357cfd4df264b1a0";
-    date = "2015-08-19";
+    version = "2015-08-19";
     owner = "syndtr";
     repo = "goleveldb";
     sha256 = "04ywbif36fiah4fw0x2abr5q3p4fdhi6q57d5icc2mz03q889vhb";
@@ -1209,7 +1209,7 @@ let
 
   google-api-go-client = buildFromGitHub {
     rev = "a5c3e2a4792aff40e59840d9ecdff0542a202a80";
-    date = "2015-08-19";
+    version = "2015-08-19";
     owner = "google";
     repo = "google-api-go-client";
     sha256 = "1kigddnbyrl9ddpj5rs8njvf1ck54ipi4q1282k0d6b3am5qfbj8";
@@ -1258,7 +1258,7 @@ let
 
   goproxy = buildFromGitHub {
     rev    = "2624781dc373cecd1136cafdaaaeba6c9bb90e96";
-    date   = "2015-07-26";
+    version = "2015-07-26";
     owner  = "elazarl";
     repo   = "goproxy";
     sha256 = "1zz425y8byjaa9i7mslc9anz9w2jc093fjl0562rmm5hh4rc5x5f";
@@ -1267,7 +1267,7 @@ let
 
   goreq = buildFromGitHub {
     rev    = "72c51a544272e007ab3da4f7d9ac959b7af7af03";
-    date   = "2015-08-18";
+    version = "2015-08-18";
     owner  = "franela";
     repo   = "goreq";
     sha256 = "0dnqbijdzp2dgsf6m934nadixqbv73q0zkqglaa956zzw0pyhcxp";
@@ -1275,7 +1275,7 @@ let
 
   gotags = buildFromGitHub {
     rev    = "be986a34e20634775ac73e11a5b55916085c48e7";
-    date   = "2015-08-03";
+    version = "2015-08-03";
     owner  = "jstemmer";
     repo   = "gotags";
     sha256 = "071wyq90b06xlb3bb0l4qjz1gf4nnci4bcngiddfcxf2l41w1vja";
@@ -1303,7 +1303,7 @@ let
 
   gozim = buildFromGitHub {
     rev    = "ea9b7c39cb1d13bd8bf19ba4dc4e2a16bab52f14";
-    date   = "2016-01-15";
+    version = "2016-01-15";
     owner  = "akhenakh";
     repo   = "gozim";
     sha256 = "1n50fdd56r3s1sgjbpa72nvdh50gfpf6fq55c077w2p3bxn6p8k6";
@@ -1387,8 +1387,7 @@ let
     owner   = "elazarl";
     repo    = "go-bindata-assetfs";
     sha256  = "636ce247ff6f85c14f38a421f46662fa77bdc29762692e1f72b3cd1f9d7a1d17";
-
-    date = "2015-08-13";
+    version = "2015-08-13";
 
     meta = with stdenv.lib; {
       description = "Serves embedded files from jteeuwen/go-bindata with net/http";
@@ -1424,7 +1423,7 @@ let
 
   go-charset = buildFromGitHub {
     rev    = "61cdee49014dc952076b5852ce4707137eb36b64";
-    date   = "2014-07-13";
+    version = "2014-07-13";
     owner  = "paulrosania";
     repo   = "go-charset";
     sha256 = "0jp6rwxlgl66dipk6ssk8ly55jxncvsxs7jc3abgdrhr3rzccab8";
@@ -1480,7 +1479,7 @@ let
 
   go-fuse = buildFromGitHub rec {
     rev = "324ea173d0a4d90e0e97c464a6ad33f80c9587a8";
-    date = "2015-07-27";
+    version = "2015-07-27";
     owner = "hanwen";
     repo = "go-fuse";
     sha256 = "0r5amgnpb4g7b6kpz42vnj01w515by4yhy64s5lqf3snzjygaycf";
@@ -1526,7 +1525,7 @@ let
 
   go-hostpool = buildFromGitHub {
     rev    = "d0e59c22a56e8dadfed24f74f452cea5a52722d2";
-    date   = "2015-03-31";
+    version = "2015-03-31";
     owner  = "bitly";
     repo   = "go-hostpool";
     sha256 = "14ph12krn5zlg00vh9g6g08lkfjxnpw46nzadrfb718yl1hgyk3g";
@@ -1548,7 +1547,7 @@ let
 
   go-incremental = buildFromGitHub {
     rev    = "92fd0ce4a694213e8b3dfd2d39b16e51d26d0fbf";
-    date   = "2015-02-20";
+    version = "2015-02-20";
     owner  = "GeertJohan";
     repo   = "go.incremental";
     sha256 = "160cspmq73bk6cvisa6kq1dwrrp1yqpkrpq8dl69wcnaf91cbnml";
@@ -1563,7 +1562,7 @@ let
 
   go-liblzma = buildFromGitHub {
     rev    = "e74be71c3c60411922b5424e875d7692ea638b78";
-    date   = "2016-01-01";
+    version = "2016-01-01";
     owner  = "remyoudompheng";
     repo   = "go-liblzma";
     sha256 = "12lwjmdcv2l98097rhvjvd2yz8jl741hxcg29i1c18grwmwxa7nf";
@@ -1587,7 +1586,7 @@ let
 
   go-lxc = buildFromGitHub {
     rev    = "d89df0ad9dc13a7ce491eedaa771b076cf32db16";
-    date   = "2016-02-12";
+    version = "2016-02-12";
     owner  = "lxc";
     repo   = "go-lxc";
     sha256 = "051kqvvclfcinqcbi4zch694llvnxa5vvbw6cbdxbkzhr5zxm36q";
@@ -1605,7 +1604,7 @@ let
 
   rcrowley.go-metrics = buildFromGitHub {
     rev = "1ce93efbc8f9c568886b2ef85ce305b2217b3de3";
-    date = "2015-08-22";
+    version = "2015-08-22";
     owner = "rcrowley";
     repo = "go-metrics";
     sha256 = "06gg72krlmd0z3zdq6s716blrga95pyj8dc2f2psfbknbkyrkfqa";
@@ -1662,7 +1661,7 @@ let
 
   go-options = buildFromGitHub {
     rev    = "7c174072188d0cfbe6f01bb457626abb22bdff52";
-    date   = "2014-12-20";
+    version = "2014-12-20";
     owner  = "mreiferson";
     repo   = "go-options";
     sha256 = "0ksyi2cb4k6r2fxamljg42qbz5hdcb9kv5i7y6cx4ajjy0xznwgm";
@@ -1670,7 +1669,7 @@ let
 
   go-porterstemmer = buildFromGitHub {
     rev    = "23a2c8e5cf1f380f27722c6d2ae8896431dc7d0e";
-    date   = "2014-12-30";
+    version = "2014-12-30";
     owner  = "blevesearch";
     repo   = "go-porterstemmer";
     sha256 = "0rcfbrad79xd114h3dhy5d3zs3b5bcgqwm3h5ih1lk69zr9wi91d";
@@ -1704,7 +1703,7 @@ let
 
   mattn.go-runewidth = buildFromGitHub {
     rev    = "d6bea18f789704b5f83375793155289da36a3c7f";
-    date   = "2016-03-15";
+    version = "2016-03-15";
     owner  = "mattn";
     repo   = "go-runewidth";
     sha256 = "1hnigpn7rjbwd1ircxkyx9hvi0xmxr32b2jdy2jzw6b3jmcnz1fs";
@@ -1731,7 +1730,7 @@ let
 
   go-repo-root = buildFromGitHub {
     rev = "90041e5c7dc634651549f96814a452f4e0e680f9";
-    date = "2014-09-11";
+    version = "2014-09-11";
     owner = "cstrahan";
     repo = "go-repo-root";
     sha256 = "1rlzp8kjv0a3dnfhyqcggny0ad648j5csr2x0siq5prahlp48mg4";
@@ -1740,7 +1739,7 @@ let
 
   go-rice = buildFromGitHub {
     rev    = "4f3c5af2322e393f305d9674845bc36cd1dea589";
-    date   = "2016-01-04";
+    version = "2016-01-04";
     owner  = "GeertJohan";
     repo   = "go.rice";
     sha256 = "01q2d5iwibwdl68gn8sg6dm7byc42hax3zmiqgmdw63ir1fsv4ag";
@@ -1757,7 +1756,7 @@ let
 
   go-sct = buildFromGitHub {
     rev = "b82c2f81727357c45a47a43965c50ed5da5a2e74";
-    date = "2016-01-11";
+    version = "2016-01-11";
     owner = "d4l3k";
     repo = "go-sct";
     sha256 = "13hgmpv2c8ll5ap8fn1n480bdv1j21n86jjwcssd36kh2i933anl";
@@ -1772,7 +1771,7 @@ let
 
   go-simplejson = buildFromGitHub {
     rev    = "18db6e68d8fd9cbf2e8ebe4c81a78b96fd9bf05a";
-    date   = "2015-03-31";
+    version = "2015-03-31";
     owner  = "bitly";
     repo   = "go-simplejson";
     sha256 = "0lj9cxyncchlw6p35j0yym5q5waiz0giw6ri41qdwm8y3dghwwiy";
@@ -1780,7 +1779,7 @@ let
 
   go-snappystream = buildFromGitHub {
     rev = "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504";
-    date = "2015-04-16";
+    version = "2015-04-16";
     owner = "mreiferson";
     repo = "go-snappystream";
     sha256 = "0jdd5whp74nvg35d9hzydsi3shnb1vrnd7shi9qz4wxap7gcrid6";
@@ -1788,7 +1787,7 @@ let
 
   go-spew = buildFromGitHub {
     rev    = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d";
-    date   = "2015-11-05";
+    version = "2015-11-05";
     owner  = "davecgh";
     repo   = "go-spew";
     sha256 = "15h9kl73rdbzlfmsdxp13jja5gs7sknvqkpq2qizq3qv3nr1x8dk";
@@ -1796,7 +1795,7 @@ let
 
   go-sqlite3 = buildFromGitHub {
     rev    = "b4142c444a8941d0d92b0b7103a24df9cd815e42";
-    date   = "2015-07-29";
+    version = "2015-07-29";
     owner  = "mattn";
     repo   = "go-sqlite3";
     sha256 = "0xq2y4am8dz9w9aaq24s1npg1sn8pf2gn4nki73ylz2fpjwq9vla";
@@ -1811,7 +1810,7 @@ let
 
   go-systemd = buildFromGitHub {
     rev    = "7b2428fec40033549c68f54e26e89e7ca9a9ce31";
-    date   = "2016-03-10";
+    version = "2016-03-10";
     owner  = "coreos";
     repo   = "go-systemd";
     sha256 = "0kfbxvm9zsjgvgmiq2jl807y4s5z0rya65rm399llr5rr7vz1lxd";
@@ -1830,7 +1829,7 @@ let
 
   go-uuid = buildFromGitHub {
     rev    = "6b8e5b55d20d01ad47ecfe98e5171688397c61e9";
-    date   = "2015-07-22";
+    version = "2015-07-22";
     owner  = "satori";
     repo   = "go.uuid";
     sha256 = "0injxzds41v8nc0brvyrrjl66fk3hycz6im38s5r9ccbwlp68p44";
@@ -1845,7 +1844,7 @@ let
 
   go-zipexe = buildFromGitHub {
     rev    = "a5fe2436ffcb3236e175e5149162b41cd28bd27d";
-    date   = "2015-03-29";
+    version = "2015-03-29";
     owner  = "daaku";
     repo   = "go.zipexe";
     sha256 = "0vi5pskhifb6zw78w2j97qbhs09zmrlk4b48mybgk5b3sswp6510";
@@ -1853,7 +1852,7 @@ let
 
   go-zookeeper = buildFromGitHub {
     rev    = "5bb5cfc093ad18a28148c578f8632cfdb4d802e4";
-    date   = "2015-06-02";
+    version = "2015-06-02";
     owner  = "samuel";
     repo   = "go-zookeeper";
     sha256 = "1kpx1ymh7rds0b2km291idnyqi0zck74nd8hnk72crgz7wmpqv6z";
@@ -1861,7 +1860,7 @@ let
 
   lint = buildFromGitHub {
     rev = "7b7f4364ff76043e6c3610281525fabc0d90f0e4";
-    date = "2015-06-23";
+    version = "2015-06-23";
     owner = "golang";
     repo = "lint";
     sha256 = "1bj7zv534hyh87bp2vsbhp94qijc5nixb06li1dzfz9n0wcmlqw9";
@@ -1894,7 +1893,7 @@ let
 
   grpc = buildFromGitHub {
     rev = "d455e65570c07e6ee7f23275063fbf34660ea616";
-    date = "2015-08-29";
+    version = "2015-08-29";
     owner = "grpc";
     repo = "grpc-go";
     sha256 = "08vra95hc8ihnj353680zhiqrv3ssw5yywkrifzb1zwl0l3cs2hr";
@@ -1906,7 +1905,7 @@ let
 
   gtreap = buildFromGitHub {
     rev = "0abe01ef9be25c4aedc174758ec2d917314d6d70";
-    date = "2015-08-07";
+    version = "2015-08-07";
     owner = "steveyen";
     repo = "gtreap";
     sha256 = "03z5j8myrpmd0jk834l318xnyfm0n4rg15yq0d35y7j1aqx26gvk";
@@ -2006,7 +2005,7 @@ let
 
   httprouter = buildFromGitHub {
     rev    = "6aacfd5ab513e34f7e64ea9627ab9670371b34e7";
-    date   = "2015-07-08";
+    version = "2015-07-08";
     owner  = "julienschmidt";
     repo   = "httprouter";
     sha256 = "00rrjysmq898qcrf2hfwfh9s70vwvmjx2kp5w03nz1krxa4zhrkl";
@@ -2026,7 +2025,7 @@ let
 
   i3cat = buildFromGitHub {
     rev    = "b9ba886a7c769994ccd8d4627978ef4b51fcf576";
-    date   = "2015-03-21";
+    version = "2015-03-21";
     owner  = "vincent-petithory";
     repo   = "i3cat";
     sha256 = "1xlm5c9ajdb71985nq7hcsaraq2z06przbl6r4ykvzi8w2lwgv72";
@@ -2088,7 +2087,7 @@ let
 
   ipfs = buildFromGitHub{
     rev = "7070b4d878baad57dcc8da80080dd293aa46cabd";
-    date   = "2016-01-12";
+    version = "2016-01-12";
     owner  = "ipfs";
     repo   = "go-ipfs";
     sha256 = "1b7aimnbz287fy7p27v3qdxnz514r5142v3jihqxanbk9g384gcd";
@@ -2122,7 +2121,7 @@ let
 
   kagome = buildFromGitHub {
     rev = "1bbdbdd590e13a8c2f4508c67a079113cd7b9f51";
-    date = "2016-01-19";
+    version = "2016-01-19";
     owner = "ikawaha";
     repo = "kagome";
     sha256 = "1isnjdkn9hnrkp5g37p2k5bbsrx0ma32v3icwlmwwyc5mppa4blb";
@@ -2213,7 +2212,7 @@ let
 
   logger = buildFromGitHub {
     rev = "c96f6a1a8c7b6bf2f4860c667867d90174799eb2";
-    date = "2015-05-23";
+    version = "2015-05-23";
     owner = "calmh";
     repo = "logger";
     sha256 = "1f67xbvvf210g5cqa84l12s00ynfbkjinhl8y6m88yrdb025v1vg";
@@ -2236,7 +2235,7 @@ let
 
   luhn = buildFromGitHub {
     rev    = "0c8388ff95fa92d4094011e5a04fc99dea3d1632";
-    date   = "2015-01-13";
+    version = "2015-01-13";
     owner  = "calmh";
     repo   = "luhn";
     sha256 = "1hfj1lx7wdpifn16zqrl4xml6cj5gxbn6hfz1f46g2a6bdf0gcvs";
@@ -2434,7 +2433,7 @@ let
 
   mtpfs = buildFromGitHub {
     rev = "3ef47f91c38cf1da3e965e37debfc81738e9cd94";
-    date = "2015-08-01";
+    version = "2015-08-01";
     owner = "hanwen";
     repo = "go-mtpfs";
     sha256 = "1f7lcialkpkwk01f7yxw77qln291sqjkspb09mh0yacmrhl231g8";
@@ -2444,7 +2443,7 @@ let
 
   mux = buildFromGitHub {
     rev = "5a8a0400500543e28b2886a8c52d21a435815411";
-    date = "2015-08-05";
+    version = "2015-08-05";
     owner = "gorilla";
     repo = "mux";
     sha256 = "15w1bw14vx157r6v98fhy831ilnbzdsm5xzvs23j8hw6gnknzaw1";
@@ -2593,7 +2592,7 @@ let
 
   oh = buildFromGitHub {
     rev = "f54be52450a07398a2f605222eb22e69bb34f565";
-    date = "2016-03-02";
+    version = "2016-03-02";
     owner = "michaelmacinnis";
     repo = "oh";
     sha256 = "0gczqi9aw6sv7vmjdandxmaz1m6pfzchmbkf12qmpmc6dmh2wy6b";
@@ -2631,7 +2630,7 @@ let
 
   opsgenie-go-sdk = buildFromGitHub {
     rev = "c6e1235dfed2126eb9b562c4d776baf55ccd23e3";
-    date = "2015-08-24";
+    version = "2015-08-24";
     owner = "opsgenie";
     repo = "opsgenie-go-sdk";
     sha256 = "1prvnjiqmhnp9cggp9f6882yckix2laqik35fcj32117ry26p4jm";
@@ -2687,7 +2686,7 @@ let
   };
 
   perks = buildFromGitHub rec {
-    date   = "2014-07-16";
+    version = "2014-07-16";
     owner  = "bmizerany";
     repo   = "perks";
     rev    = "d9a9656a3a4b1c2864fdb44db2ef8619772d92aa";
@@ -2695,7 +2694,7 @@ let
   };
 
   beorn7.perks = buildFromGitHub rec {
-    date   = "2015-02-23";
+    version = "2015-02-23";
     owner  = "beorn7";
     repo   = "perks";
     rev    = "b965b613227fddccbfffe13eae360ed3fa822f8d";
@@ -2703,9 +2702,9 @@ let
   };
 
   pflag = buildGoPackage rec {
-    date = "20131112";
+    version = "20131112";
     rev = "94e98a55fb412fcbcfc302555cb990f5e1590627";
-    name = "pflag-${date}-${stdenv.lib.strings.substring 0 7 rev}";
+    name = "pflag-${version}-${stdenv.lib.strings.substring 0 7 rev}";
     goPackagePath = "github.com/spf13/pflag";
     src = fetchgit {
       inherit rev;
@@ -2745,7 +2744,7 @@ let
 
   pongo2 = buildFromGitHub {
     rev    = "5e81b817a0c48c1c57cdf1a9056cf76bdee02ca9";
-    date   = "2014-10-27";
+    version = "2014-10-27";
     owner  = "flosch";
     repo   = "pongo2";
     sha256 = "0fd7d79644zmcirsb1gvhmh0l5vb5nyxmkzkvqpmzzcg6yfczph8";
@@ -2862,7 +2861,7 @@ let
 
   prometheus.client_model = buildFromGitHub {
     rev    = "fa8ad6fec33561be4280a8f0514318c79d7f6cb6";
-    date   = "2015-02-12";
+    version = "2015-02-12";
     owner  = "prometheus";
     repo   = "client_model";
     sha256 = "11a7v1fjzhhwsl128znjcf5v7v6129xjgkdpym2lial4lac1dhm9";
@@ -2901,7 +2900,7 @@ let
 
   prometheus.log = buildFromGitHub {
     rev    = "439e5db48fbb50ebbaf2c816030473a62f505f55";
-    date   = "2015-05-29";
+    version = "2015-05-29";
     owner  = "prometheus";
     repo   = "log";
     sha256 = "1fl23gsw2hn3c1y91qckr661sybqcw2gqnd1gllxn3hp6p2w6hxv";
@@ -2940,7 +2939,7 @@ let
 
   prometheus.nginx-exporter = buildFromGitHub {
     rev = "2cf16441591f6b6e58a8c0439dcaf344057aea2b";
-    date = "2015-06-01";
+    version = "2015-06-01";
     owner = "discordianfish";
     repo = "nginx_exporter";
     sha256 = "0p9j0bbr2lr734980x2p8d67lcify21glwc5k3i3j4ri4vadpxvc";
@@ -2982,7 +2981,7 @@ let
 
   prometheus.procfs = buildFromGitHub {
     rev    = "c91d8eefde16bd047416409eb56353ea84a186e4";
-    date   = "2015-06-16";
+    version = "2015-06-16";
     owner  = "prometheus";
     repo   = "procfs";
     sha256 = "0pj3gzw9b58l72w0rkpn03ayssglmqfmyxghhfad6mh0b49dvj3r";
@@ -3209,7 +3208,7 @@ let
 
   ratelimit = buildFromGitHub {
     rev    = "772f5c38e468398c4511514f4f6aa9a4185bc0a0";
-    date   = "2015-06-19";
+    version = "2015-06-19";
     owner  = "juju";
     repo   = "ratelimit";
     sha256 = "02rs61ay6sq499lxxszjsrxp33m6zklds1xrmnr5fk73vpqfa28p";
@@ -3224,7 +3223,7 @@ let
 
   raven-go = buildFromGitHub {
     rev    = "74c334d7b8aaa4fd1b4fc6aa428c36fed1699e28";
-    date   = "2015-07-21";
+    version = "2015-07-21";
     owner  = "getsentry";
     repo   = "raven-go";
     sha256 = "1356a7h8zp1mcywnr0y83w0h4qdblp65rcf9slbx667n8x2rzda8";
@@ -3273,7 +3272,7 @@ let
 
   restic = buildFromGitHub {
     rev    = "4d7e802c44369b40177cd52938bc5b0930bd2be1";
-    date   = "2016-01-17";
+    version = "2016-01-17";
     owner  = "restic";
     repo   = "restic";
     sha256 = "0lf40539dy2xa5l1xy1kyn1vk3w0fmapa1h65ciksrdhn89ilrxv";
@@ -3297,7 +3296,7 @@ let
 
   rsrc = buildFromGitHub {
     rev    = "ba14da1f827188454a4591717fff29999010887f";
-    date   = "2015-11-03";
+    version = "2015-11-03";
     owner  = "akavel";
     repo   = "rsrc";
     sha256 = "0g9fj10xnxcv034c8hpcgbhswv6as0d8l176c5nfgh1lh6klmmzc";
@@ -3344,7 +3343,7 @@ let
 
   seelog = buildFromGitHub {
     rev = "c510775bb50d98213cfafca75a4bc5e3fddc8d8f";
-    date = "2015-05-26";
+    version = "2015-05-26";
     owner = "cihub";
     repo = "seelog";
     sha256 = "1f0rwgqlffv1a7b05736a4gf4l9dn80wsfyqcnz6qd2skhwnzv29";
@@ -3352,7 +3351,7 @@ let
 
   segment = buildFromGitHub {
     rev    = "db70c57796cc8c310613541dfade3dce627d09c7";
-    date   = "2016-01-05";
+    version = "2016-01-05";
     owner  = "blevesearch";
     repo   = "segment";
     sha256 = "09xfdlcc6bsrr5grxp6fgnw9p4cf6jc0wwa9049fd1l0zmhj2m1g";
@@ -3360,7 +3359,7 @@ let
 
   semver = buildFromGitHub {
     rev = "31b736133b98f26d5e078ec9eb591666edfd091f";
-    date = "2015-07-20";
+    version = "2015-07-20";
     owner = "blang";
     repo = "semver";
     sha256 = "19ifi0na4cj23q3h8xv89mx7p48y0ciymhmlrq9milm0xz80wk10";
@@ -3368,7 +3367,7 @@ let
 
   serf = buildFromGitHub {
     rev = "668982d8f90f5eff4a766583c1286393c1d27f68";
-    date = "2015-05-15";
+    version = "2015-05-15";
     owner  = "hashicorp";
     repo   = "serf";
     sha256 = "1h05h5xhaj27r1mh5zshnykax29lqjhfc0bx4v9swiwb873c24qk";
@@ -3467,7 +3466,7 @@ let
 
   structfield = buildFromGitHub {
     rev    = "01a738558a47fbf16712994d1737fb31c77e7d11";
-    date   = "2014-08-01";
+    version = "2014-08-01";
     owner  = "vincent-petithory";
     repo   = "structfield";
     sha256 = "1kyx71z13mf6hc8ly0j0b9zblgvj5lzzvgnc3fqh61wgxrsw24dw";
@@ -3541,7 +3540,7 @@ let
 
   syncthing-protocol011 = buildFromGitHub {
     rev = "84365882de255d2204d0eeda8dee288082a27f98";
-    date = "2015-08-28";
+    version = "2015-08-28";
     owner = "syncthing";
     repo = "protocol";
     sha256 = "07xjs43lpd51pc339f8x487yhs39riysj3ifbjxsx329kljbflwx";
@@ -3550,7 +3549,7 @@ let
 
   tablewriter = buildFromGitHub {
     rev    = "cca8bbc0798408af109aaaa239cbd2634846b340";
-    date   = "2016-01-15";
+    version = "2016-01-15";
     owner  = "olekukonko";
     repo   = "tablewriter";
     sha256 = "0f9ph3z7lh6p6gihbl1461j9yq5qiaqxr9mzdkp512n18v89ml48";
@@ -3611,7 +3610,7 @@ let
 
   timer_metrics = buildFromGitHub {
     rev = "afad1794bb13e2a094720aeb27c088aa64564895";
-    date = "2015-02-02";
+    version = "2015-02-02";
     owner = "bitly";
     repo = "timer_metrics";
     sha256 = "1b717vkwj63qb5kan4b92kx4rg6253l5mdb3lxpxrspy56a6rl0c";
@@ -3628,7 +3627,7 @@ let
 
   toml = buildFromGitHub {
     rev    = "056c9bc7be7190eaa7715723883caffa5f8fa3e4";
-    date   = "2015-05-01";
+    version = "2015-05-01";
     owner  = "BurntSushi";
     repo   = "toml";
     sha256 = "0gkgkw04ndr5y7hrdy0r4v2drs5srwfcw2bs1gyas066hwl84xyw";
@@ -3658,7 +3657,7 @@ let
 
   usb = buildFromGitHub rec {
     rev = "69aee4530ac705cec7c5344418d982aaf15cf0b1";
-    date = "2014-12-17";
+    version = "2014-12-17";
     owner = "hanwen";
     repo = "usb";
     sha256 = "01k0c2g395j65vm1w37mmrfkg6nm900khjrrizzpmx8f8yf20dky";
@@ -3669,7 +3668,7 @@ let
 
   uuid = buildFromGitHub {
     rev = "cccd189d45f7ac3368a0d127efb7f4d08ae0b655";
-    date = "2015-08-24";
+    version = "2015-08-24";
     owner = "pborman";
     repo = "uuid";
     sha256 = "0hswk9ihv3js5blp9pk2bpig64zkmyp5p1zhmgydfhb0dr2w8iad";
@@ -3739,7 +3738,7 @@ let
 
   xmpp-client = buildFromGitHub {
     rev      = "525bd26cf5f56ec5aee99464714fd1d019c119ff";
-    date     = "2016-01-10";
+    version  = "2016-01-10";
     owner    = "agl";
     repo     = "xmpp-client";
     sha256   = "0a1r08zs723ikcskmn6ylkdi3frcd0i0lkx30i9q39ilf734v253";
@@ -3768,7 +3767,7 @@ let
 
   yaml-v2 = buildFromGitHub {
     rev = "7ad95dd0798a40da1ccdff6dff35fd177b5edf40";
-    date = "2015-06-24";
+    version = "2015-06-24";
     owner = "go-yaml";
     repo = "yaml";
     sha256 = "0d4jh46jq2yjg5dp00l7yl9ilhly7k4mfvi4harafd5ap5k9wnpb";
@@ -3784,7 +3783,7 @@ let
 
   xdr = buildFromGitHub {
     rev    = "e467b5aeb65ca8516fb3925c84991bf1d7cc935e";
-    date   = "2015-04-08";
+    version = "2015-04-08";
     owner  = "calmh";
     repo   = "xdr";
     sha256 = "1bi4b2xkjzcr0vq1wxz14i9943k71sj092dam0gdmr9yvdrg0nra";
@@ -3799,7 +3798,7 @@ let
 
   ninefans = buildFromGitHub {
     rev    = "65b8cf069318223b1e722b4b36e729e5e9bb9eab";
-    date   = "2015-10-24";
+    version = "2015-10-24";
     owner  = "9fans";
     repo   = "go";
     sha256 = "0kzyxhs2xf0339nlnbm9gc365b2svyyjxnr86rphx5m072r32ims";
@@ -3813,7 +3812,7 @@ let
 
   godef = buildFromGitHub {
     rev    = "ea14e800fd7d16918be88dae9f0195f7bd688586";
-    date   = "2015-10-24";
+    version = "2015-10-24";
     owner  = "rogpeppe";
     repo   = "godef";
     sha256 = "1wkvsz8nqwyp36wbm8vcw4449sfs46894nskrfj9qbsrjijvamyc";
@@ -3824,7 +3823,7 @@ let
 
   godep = buildFromGitHub {
     rev    = "5598a9815350896a2cdf9f4f1d0a3003ab9677fb";
-    date   = "2015-10-15";
+    version = "2015-10-15";
     owner  = "tools";
     repo   = "godep";
     sha256 = "0zc1ah5cvaqa3zw0ska89a40x445vwl1ixz8v42xi3zicx16ibwz";
@@ -3939,7 +3938,7 @@ let
 
   godotenv = buildFromGitHub rec {
     rev    = "4ed13390c0acd2ff4e371e64d8b97c8954138243";
-    date   = "2015-09-07";
+    version = "2015-09-07";
     owner  = "joho";
     repo   = "godotenv";
     sha256 = "1wzgws4dnlavi14aw3jzdl3mdr348skgqaq8xx4j8l68irfqyh0p";
@@ -3949,7 +3948,6 @@ let
   goreman = buildFromGitHub rec {
     version = "0.0.8-rc0";
     rev    = "d3e62509ccf23e47a390447886c51b1d89d0934b";
-    date   = "2016-01-30";
     owner  = "mattn";
     repo   = "goreman";
     sha256 = "153hf4dq4jh1yv35pv30idmxhc917qzl590qy5394l48d4rapgb5";
@@ -3964,7 +3962,7 @@ let
   # '';
   upower-notify = buildFromGitHub rec {
     rev    = "14c581e683a7e90ec9fa6d409413c16599a5323c";
-    date   = "2016-03-10";
+    version = "2016-03-10";
     owner  = "omeid";
     repo   = "upower-notify";
     sha256 = "16zlvn53p9m10ph8n9gps51fkkvl6sf4afdzni6azk05j0ng49jw";


### PR DESCRIPTION
There are several goPackages with a `version` argument that is not currently used. And some put their semantic version in `date` to make it part of derivative name.

This PR renames "date" to "version" to make `buildFromGitHub` more consistent.
