### PR TITLE
capybara-webkit: gem needs qt5Full

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -21,7 +21,7 @@
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, gecode_3, curl
-, libmsgpack
+, libmsgpack, qt5Full
 }:
 
 let
@@ -29,9 +29,13 @@ let
 in
 
 {
-  charlock_holmes = attrs: {
-    buildInputs = [ which icu zlib ];
-  };
+   capybara-webkit = attrs: {
+     buildInputs = [ qt5Full ];
+   };
+
+   capybara-webkit = attrs: {
+     buildInputs = [ qt5Full ];
+   };
 
   dep-selector-libgecode = attrs: {
     USE_SYSTEM_GECODE = true;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @cstrahan @zimbatm 
