### PR TITLE
htop: fix build on darwin

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -1,4 +1,5 @@
-{ fetchurl, stdenv, ncurses }:
+{ lib, fetchurl, stdenv, ncurses,
+IOKit }:
 
 stdenv.mkDerivation rec {
   name = "htop-${version}";
@@ -9,7 +10,9 @@ stdenv.mkDerivation rec {
     url = "http://hisham.hm/htop/releases/${version}/${name}.tar.gz";
   };
 
-  buildInputs = [ ncurses ];
+  buildInputs =
+    [ ncurses ] ++
+    lib.optionals stdenv.isDarwin [ IOKit ];
 
   meta = with stdenv.lib; {
     description = "An interactive process viewer for Linux";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10309,7 +10309,9 @@ let
 
   hostapd = callPackage ../os-specific/linux/hostapd { };
 
-  htop = callPackage ../tools/system/htop { };
+  htop = callPackage ../tools/system/htop {
+    inherit (darwin) IOKit;
+  };
 
   # GNU/Hurd core packages.
   gnu = recurseIntoAttrs (callPackage ../os-specific/gnu {


### PR DESCRIPTION
Allow htop to build on OS X, was missing IOKit dependency so added that to build inputs. Shouldn't impact any NixOS/Linux builds but didn't technically test that.

Existing master fails with this message without these changes:

```
/nix/store/j1c9nla822s2cn9h4r5hizyijix8n3rm-CF-osx-10.9.5/Library/Frameworks/CoreFoundation.framework/Headers/CFXMLParser.h:262:116: warning: must specify at least one argument for '...' parameter of variadic macro [-Wgnu-zero-variadic-macro-arguments]
CFDataRef CFXMLTreeCreateXMLData(CFAllocatorRef allocator, CFXMLTreeRef xmlTree) CF_DEPRECATED(10_0, 10_8, 2_0, 6_0);
                                                                                                                   ^
/Nix/store/j1c9nla822s2cn9h4r5hizyijix8n3rm-CF-osx-10.9.5/Library/Frameworks/CoreFoundation.framework/Headers/CFAvailability.h:121:9: note: macro 'CF_DEPRECATED' defined here
#define CF_DEPRECATED(_macIntro, _macDep, _iosIntro, _iosDep, ...) __attribute__((availability(macosx,__NSi_##_macIntro __NSd_##_macDep,message="" __VA_ARGS__)))
        ^
darwin/Battery.c:6:10: fatal error: 'IOKit/ps/IOPowerSources.h' file not found
#include <IOKit/ps/IOPowerSources.h>
         ^
41 warnings and 1 error generated.
Makefile:1517: recipe for target 'darwin/htop-Battery.o' failed
make[1]: *** [darwin/htop-Battery.o] Error 1
make[1]: Leaving directory '/private/var/folders/2y/9y9d_x9s5wd6_9822sj3x3zh000c8w/T/nix-build-htop-2.0.1.drv-0/htop-2.0.1'
Makefile:522: recipe for target 'all' failed
make: *** [all] Error 2
builder for ‘/nix/store/lglvpirjr3p4bn150ciardaxvlnzff0h-htop-2.0.1.drv’ failed with exit code 2
error: build of ‘/nix/store/lglvpirjr3p4bn150ciardaxvlnzff0h-htop-2.0.1.drv’ failed
```
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)

Does this even apply to OS X? I can't build most things on OS X in a chroot and didn't get far:

```
$ nix-build --option build-use-chroot true 
error: assertion failed at /Users/mitch/src/github.com/NixOS/nixpkgs/pkgs/games/adom/default.nix:4:1
```
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
