### PR TITLE
scribus: 1.4.5 -> 1.4.6

### DIFF
--- a/pkgs/applications/office/scribus/default.nix
+++ b/pkgs/applications/office/scribus/default.nix
@@ -3,11 +3,11 @@
 , zlib, libpng, xorg, cairo, podofo, aspell, boost, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "scribus-1.4.5";
+  name = "scribus-1.4.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/scribus/scribus/${name}.tar.bz2";
-    sha256 = "1644ym79q7a1m5xf3xl1wf4kdk870np911jmpqdv2syjc42nyw4z";
+    url = "mirror://sourceforge/scribus/scribus/${name}.tar.xz";
+    sha256 = "16m1g38dig37ag0zxjx3wk1rxx9xxzjqfc7prj89rp4y1m83dqr1";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
