### PR TITLE
nix-prefetch-scripts: make nix-prefetch-git report fetchSubmodules in its JSON output

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -327,7 +327,12 @@ print_results() {
         echo "{"
         echo "  \"url\": \"$url\","
         echo "  \"rev\": \"$fullRev\","
-        echo "  \"$hashType\": \"$hash\""
+        echo -n "  \"$hashType\": \"$hash\""
+        if test -n "$fetchSubmodules"; then
+            echo ","
+            echo -n "  \"fetchSubmodules\": true"
+        fi
+        echo ""
         echo "}"
     fi
 }


### PR DESCRIPTION
Previously, nix-prefetch-git would report the same JSON whether submodules were being fetched or not; with this change, the --fetch-submodules option will cause the JSON output to include "fetchSubmodules": true, so that fetchgit (builtins.fromJSON (builtins.readFile ./path/to/output.json)) will work.
