### PR TITLE
plex: plexpass: 0.9.16.2.1827 -> 0.9.16.3.1840

### DIFF
--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -5,9 +5,9 @@
 
 let
   plexpkg = if enablePlexPass then {
-    version = "0.9.16.0.1754";
-    vsnHash = "23623fb";
-    sha256 = "0yn5bqpgz28ig6y3qw3zxzm8gfvwaw7nh5krmav8h1ryws98cc6g";
+    version = "0.9.16.3.1840";
+    vsnHash = "cece46d";
+    sha256 = "0p1rnia18a67h05f7l7smkpry1ldkpdkyvs9fgrqpay3w0jfk9gd";
   } else {
     version = "0.9.15.6.1714";
     vsnHash = "7be11e1";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
