### PR TITLE
mednaffe: init at 0.8

### DIFF
--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkgconfig, gtk2, mednafen }:
+
+stdenv.mkDerivation rec {
+
+  version = "0.8";
+  name = "mednaffe-${version}";
+
+  src = fetchFromGitHub {
+	repo = "mednaffe";
+	owner = "AmatCoder";
+	rev = "v${version}";
+	sha256 = "1j4py4ih14fa6dv0hka03rs4mq19ir83qkbxsz3695a4phmip0jr";
+  };
+
+  prePatch = ''
+    substituteInPlace src/mednaffe.c --replace "binpath = NULL" "binpath = \"${mednafen}/bin/mednafen\""
+  '';
+
+  buildInputs = [ pkgconfig gtk2 mednafen ];
+
+  meta = with stdenv.lib; {
+    description = "A GTK based frontend for mednafen";
+    homepage = https://github.com/AmatCoder/mednaffe;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.sheenobu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2428,6 +2428,8 @@ let
 
   mednafen-server = callPackage ../misc/emulators/mednafen/server.nix { };
 
+  mednaffe = callPackage ../misc/emulators/mednaffe/default.nix { };
+
   megacli = callPackage ../tools/misc/megacli { };
 
   megatools = callPackage ../tools/networking/megatools { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._
