### PR TITLE
gnome-terminal: refactor wrapping variables in binaries

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/gnome-terminal/default.nix
@@ -1,27 +1,22 @@
 { stdenv, fetchurl, pkgconfig, cairo, libxml2, gnome3, pango
 , gnome_doc_utils, intltool, libX11, which, libuuid, vala
-, desktop_file_utils, itstool, makeWrapper, appdata-tools }:
+, desktop_file_utils, itstool, wrapGAppsHook, appdata-tools }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   buildInputs = [ gnome3.gtk gnome3.gsettings_desktop_schemas gnome3.vte appdata-tools
-                  gnome3.dconf itstool makeWrapper gnome3.nautilus vala ];
+                  gnome3.dconf itstool gnome3.nautilus vala ];
 
-  nativeBuildInputs = [ pkgconfig intltool gnome_doc_utils which libuuid libxml2 desktop_file_utils ];
+  nativeBuildInputs = [ pkgconfig intltool gnome_doc_utils which libuuid libxml2
+                        desktop_file_utils wrapGAppsHook ];
 
   # FIXME: enable for gnome3
   configureFlags = [ "--disable-search-provider" "--disable-migration" ];
 
-  preFixup = ''
-    for f in "$out/libexec/gnome-terminal-server"; do
-      wrapProgram "$f" \
-        --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
-        --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
-    done
-  '';
-
   meta = with stdenv.lib; {
+    description = "The GNOME Terminal Emulator";
+    homepage = https://wiki.gnome.org/Apps/Terminal/;
     platforms = platforms.linux;
     maintainers = gnome3.maintainers;
   };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Currently running `gnome-terminal` with a specific profile outside of the GNOME desktop fails because not all relevant environment variables are not wrapped in binaries.

```
$ gnome-terminal --window-with-profile=mutt
(gnome-terminal:6019): GLib-GIO-ERROR **: No GSettings schemas are installed on the system
Trace/breakpoint trap
```

This PR fixes that by automating variable wrapping with `wrapGAppsHook` instead of explicitly using `wrapProgram`.
