### PR TITLE
quassel: fix sources

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -22,16 +22,12 @@ assert !buildClient -> !withKDE; # KDE is used by the client only
 
 let
   edf = flag: feature: [("-D" + feature + (if flag then "=ON" else "=OFF"))];
+  source = import ./source.nix { inherit fetchurl; };
 
 in with stdenv; mkDerivation rec {
+  inherit (source) src version;
 
-  version = "0.12.3";
   name = "quassel${tag}-${version}";
-
-  src = fetchurl {
-    url = "http://quassel-irc.org/pub/quassel-${version}.tar.bz2";
-    sha256 = "15vqjiw38mifvnc95bhvy0zl23xxldkwg2byx9xqbyw8rfgggmkb";
-  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/irc/quassel/qt-5.nix
+++ b/pkgs/applications/networking/irc/quassel/qt-5.nix
@@ -33,24 +33,12 @@ assert !buildClient -> !withKDE; # KDE is used by the client only
 
 let
   edf = flag: feature: [("-D" + feature + (if flag then "=ON" else "=OFF"))];
+  source = import ./source.nix { inherit fetchurl; };
 
 in with stdenv; mkDerivation rec {
+  inherit (source) src version;
 
-  version = "0.12.3";
   name = "quassel${tag}-${version}";
-
-  src = fetchurl {
-    url = "http://quassel-irc.org/pub/quassel-${version}.tar.bz2";
-    sha256 = "15vqjiw38mifvnc95bhvy0zl23xxldkwg2byx9xqbyw8rfgggmkb";
-  };
-
-  patches = [
-    # fix build with Qt 5.5
-    (fetchurl {
-      url = "https://github.com/quassel/quassel/commit/078477395aaec1edee90922037ebc8a36b072d90.patch";
-      sha256 = "1njwnay7pjjw0g7m0x5cwvck8xcznc7jbdfyhbrd121nc7jgpbc5";
-    })
-  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/irc/quassel/source.nix
+++ b/pkgs/applications/networking/irc/quassel/source.nix
@@ -1,0 +1,9 @@
+{ fetchurl }:
+
+rec {
+  version = "0.12.3";
+  src = fetchurl {
+    url = "http://quassel-irc.org/pub/quassel-${version}.tar.bz2";
+    sha256 = "0d6lwf6qblj1ia5j9mjy112zrmpbbg9mmxgscbgxiqychldyjgjd";
+  };
+}


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes changes after #14080 where the updated hash was missing.

Put the source in a common file so there is only one place to update.
