### PR TITLE
bigloo: 4.1a-2 -> 4.2c

### DIFF
--- a/pkgs/development/compilers/bigloo/default.nix
+++ b/pkgs/development/compilers/bigloo/default.nix
@@ -1,13 +1,15 @@
-{ fetchurl, stdenv, gmp }:
+{ stdenv, fetchurl, autoconf, automake, libtool, gmp }:
 
 stdenv.mkDerivation rec {
   name = "bigloo-${version}";
-  version = "4.1a-2";
+  version = "4.2c";
 
   src = fetchurl {
     url = "ftp://ftp-sop.inria.fr/indes/fp/Bigloo/bigloo${version}.tar.gz";
-    sha256 = "09yrz8r0jpj7bda39fdxzrrdyhi851nlfajsyf0b6jxanz6ygcjx";
+    sha256 = "02yi1g0xgs8priwk4hmj6b4l8icq05lri36xa1nv69j38yzldchg";
   };
+
+  nativeBuildInputs = [ autoconf automake libtool ];
 
   propagatedBuildInputs = [ gmp ];
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer @thoughtpolice 
