### PR TITLE
Use wrapGAppsHook to wrap environment variables in some gnome3 applications 

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/apps/file-roller/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, pkgconfig, gnome3, intltool, itstool, libxml2, libarchive
-, attr, bzip2, acl, makeWrapper, librsvg, gdk_pixbuf }:
+, attr, bzip2, acl, wrapGAppsHook, librsvg, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -7,14 +7,11 @@ stdenv.mkDerivation rec {
   # TODO: support nautilus
   # it tries to create {nautilus}/lib/nautilus/extensions-3.0/libnautilus-fileroller.so
 
-  buildInputs = [ glib pkgconfig gnome3.gtk intltool itstool libxml2 libarchive
-                  gnome3.defaultIconTheme attr bzip2 acl gdk_pixbuf librsvg
-                  makeWrapper ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/file-roller" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:$out/share"
-  '';
+  buildInputs = [ glib gnome3.gtk intltool itstool libxml2 libarchive
+                  gnome3.defaultIconTheme attr bzip2 acl gdk_pixbuf librsvg
+                  gnome3.dconf ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/FileRoller;

--- a/pkgs/desktops/gnome-3/3.18/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/apps/gedit/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl, enchant, isocodes
 , pkgconfig, gtk3, glib
-, bash, makeWrapper, itstool, libsoup, libxml2
+, bash, wrapGAppsHook, itstool, libsoup, libxml2
 , gnome3, librsvg, gdk_pixbuf, file }:
 
 stdenv.mkDerivation rec {
@@ -8,19 +8,17 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
-  buildInputs = [ pkgconfig gtk3 glib intltool itstool enchant isocodes
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  buildInputs = [ gtk3 glib intltool itstool enchant isocodes
                   gdk_pixbuf gnome3.defaultIconTheme librsvg libsoup
                   gnome3.libpeas gnome3.gtksourceview libxml2
-                  gnome3.gsettings_desktop_schemas makeWrapper file ];
+                  gnome3.gsettings_desktop_schemas gnome3.dconf file ];
 
   enableParallelBuilding = true;
 
   preFixup = ''
-    wrapProgram "$out/bin/gedit" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix LD_LIBRARY_PATH : "${gnome3.libpeas}/lib:${gnome3.gtksourceview}/lib" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${gnome3.libpeas}/lib:${gnome3.gtksourceview}/lib")
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.18/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/dconf-editor/default.nix
@@ -1,16 +1,13 @@
 { stdenv, fetchurl, vala, libxslt, pkgconfig, glib, dbus_glib, gnome3
-, libxml2, intltool, docbook_xsl_ns, docbook_xsl, makeWrapper }:
+, libxml2, intltool, docbook_xsl_ns, docbook_xsl, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  buildInputs = [ vala libxslt pkgconfig glib dbus_glib gnome3.gtk libxml2 gnome3.defaultIconTheme
-                  intltool docbook_xsl docbook_xsl_ns makeWrapper gnome3.dconf ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/dconf-editor" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
+  buildInputs = [ vala libxslt glib dbus_glib gnome3.gtk libxml2 gnome3.defaultIconTheme
+                  intltool docbook_xsl docbook_xsl_ns gnome3.dconf ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/3.18/core/eog/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/eog/default.nix
@@ -1,20 +1,15 @@
 { fetchurl, stdenv, intltool, pkgconfig, itstool, libxml2, libjpeg, gnome3
-, shared_mime_info, makeWrapper, librsvg, libexif }:
+, shared_mime_info, wrapGAppsHook, librsvg, libexif }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
   buildInputs = with gnome3;
-    [ intltool pkgconfig itstool libxml2 libjpeg gtk glib libpeas makeWrapper librsvg
-      gsettings_desktop_schemas shared_mime_info adwaita-icon-theme gnome_desktop libexif ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/eog" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${shared_mime_info}/share:${gnome3.adwaita-icon-theme}/share:${gnome3.gtk}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
-
-  '';
+    [ intltool itstool libxml2 libjpeg gtk glib libpeas librsvg
+      gsettings_desktop_schemas shared_mime_info adwaita-icon-theme
+      gnome_desktop libexif dconf ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/EyeOfGnome; 

--- a/pkgs/desktops/gnome-3/3.18/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/epiphany/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, pkgconfig, gtk3, glib, nspr, icu
-, bash, makeWrapper, gnome3, libwnck3, libxml2, libxslt, libtool
+, bash, wrapGAppsHook, gnome3, libwnck3, libxml2, libxslt, libtool
 , webkitgtk, libsoup, glib_networking, libsecret, gnome_desktop, libnotify, p11_kit
 , sqlite, gcr, avahi, nss, isocodes, itstool, file, which
 , gdk_pixbuf, librsvg, gnome_common }:
@@ -12,26 +12,17 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
-  nativeBuildInputs = [ pkgconfig file ];
+  nativeBuildInputs = [ pkgconfig file wrapGAppsHook ];
 
   buildInputs = [ gtk3 glib intltool libwnck3 libxml2 libxslt pkgconfig file 
                   webkitgtk libsoup libsecret gnome_desktop libnotify libtool
                   sqlite isocodes nss itstool p11_kit nspr icu gnome3.yelp_tools
                   gdk_pixbuf gnome3.defaultIconTheme librsvg which gnome_common
-                  gcr avahi gnome3.gsettings_desktop_schemas makeWrapper ];
+                  gcr avahi gnome3.gsettings_desktop_schemas gnome3.dconf ];
 
   NIX_CFLAGS_COMPILE = "-I${nspr}/include/nspr -I${nss}/include/nss -I${glib}/include/gio-unix-2.0";
 
   enableParallelBuilding = true;
-
-  preFixup = ''
-    for f in $out/bin/* $out/libexec/*; do
-      wrapProgram "$f" \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix GIO_EXTRA_MODULES : "${glib_networking}/lib/gio/modules" \
-        --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-    done
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Epiphany;

--- a/pkgs/desktops/gnome-3/3.18/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/evince/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, pkgconfig, intltool, perl, perlXMLParser, libxml2
 , glib, gtk3, pango, atk, gdk_pixbuf, shared_mime_info, itstool, gnome3
-, poppler, ghostscriptX, djvulibre, libspectre, libsecret , makeWrapper
+, poppler, ghostscriptX, djvulibre, libspectre, libsecret , wrapGAppsHook
 , librsvg, gobjectIntrospection
 , recentListSize ? null # 5 is not enough, allow passing a different number
 , supportXPS ? false    # Open XML Paper Specification via libgxps
@@ -9,13 +9,15 @@
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
   buildInputs = [
-    pkgconfig intltool perl perlXMLParser libxml2
+    intltool perl perlXMLParser libxml2
     glib gtk3 pango atk gdk_pixbuf gobjectIntrospection
     itstool gnome3.adwaita-icon-theme
     gnome3.libgnome_keyring gnome3.gsettings_desktop_schemas
     poppler ghostscriptX djvulibre libspectre
-    makeWrapper libsecret librsvg gnome3.adwaita-icon-theme
+    libsecret librsvg gnome3.adwaita-icon-theme gnome3.dconf
   ] ++ stdenv.lib.optional supportXPS gnome3.libgxps;
 
   configureFlags = [
@@ -36,15 +38,6 @@ stdenv.mkDerivation rec {
       sed -i 's/\(gtk_recent_chooser_set_limit .*\)5)/\1${builtins.toString recentListSize})/' shell/ev-open-recent-action.c
       sed -i 's/\(if (++n_items == \)5\(.*\)/\1${builtins.toString recentListSize}\2/' shell/ev-window.c
     '';
-
-  preFixup = ''
-    # Tell Glib/GIO about the MIME info directory, which is used
-    # by `g_file_info_get_content_type ()'.
-    wrapProgram "$out/bin/evince" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3}/share:${shared_mime_info}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
-
-  '';
 
   doCheck = false; # would need pythonPackages.dogTail, which is missing
 

--- a/pkgs/desktops/gnome-3/3.18/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/gnome-calculator/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, pkgconfig, libxml2
-, bash, gtk3, glib, makeWrapper
+, bash, gtk3, glib, wrapGAppsHook
 , itstool, gnome3, librsvg, gdk_pixbuf, mpfr, gmp }:
 
 stdenv.mkDerivation rec {
@@ -9,16 +9,12 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
-  buildInputs = [ bash pkgconfig gtk3 glib intltool itstool
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  buildInputs = [ bash gtk3 glib intltool itstool
                   libxml2 gnome3.gtksourceview mpfr gmp
                   gdk_pixbuf gnome3.defaultIconTheme librsvg
-                  gnome3.gsettings_desktop_schemas makeWrapper ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/gnome-calculator" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-  '';
+                  gnome3.gsettings_desktop_schemas gnome3.dconf ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/action/show/Apps/Calculator;

--- a/pkgs/desktops/gnome-3/3.18/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/nautilus/default.nix
@@ -1,21 +1,15 @@
 { stdenv, fetchurl, pkgconfig, libxml2, dbus_glib, shared_mime_info, libexif
 , gtk, gnome3, libunique, intltool, gobjectIntrospection
-, libnotify, makeWrapper, exempi, librsvg, tracker }:
+, libnotify, wrapGAppsHook, exempi, librsvg, tracker }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  buildInputs = [ pkgconfig libxml2 dbus_glib shared_mime_info libexif gtk libunique intltool exempi librsvg
-                  gnome3.gnome_desktop gnome3.adwaita-icon-theme
-                  gnome3.gsettings_desktop_schemas libnotify makeWrapper tracker ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/nautilus" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$out/share" \
-      --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-  '';
+  buildInputs = [ libxml2 dbus_glib shared_mime_info libexif gtk libunique intltool exempi librsvg
+                  gnome3.gnome_desktop gnome3.adwaita-icon-theme
+                  gnome3.gsettings_desktop_schemas gnome3.dconf libnotify tracker ];
 
   patches = [ ./extension_dir.patch ];
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Partially fixes issue #14120 

cc @lethalman 
