### PR TITLE
slack: init at 2.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,0 +1,85 @@
+{ stdenv, fetchurl, dpkg
+, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, glib, gnome
+, libnotify, nspr, nss, systemd, xorg }:
+
+let
+
+  version = "2.0.1";
+
+  rpath = stdenv.lib.makeSearchPath "lib" [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gnome.GConf
+    gnome.gdk_pixbuf
+    gnome.gtk
+    gnome.pango
+    libnotify
+    nspr
+    nss
+    systemd
+
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+  ] + ":${stdenv.cc.cc}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/slack-desktop-${version}-amd64.deb";
+        sha256 = "12d84e61ba366cc5bac105b3f9930f2dfdd64c1e5fabbb08a6877e1c98bfb9c7";
+      }
+    else
+      throw "Slack is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "slack-${version}";
+
+  inherit src;
+
+  buildInputs = [ dpkg ];
+  unpackPhase = "true";
+  buildCommand = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rmdir $out/usr
+
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/share/slack $file || true
+    done
+
+    # Fix the symlink
+    rm $out/bin/slack
+    ln -s $out/share/slack/slack $out/bin/slack
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/slack.desktop \
+      --replace /usr/share/slack/slack $out/share/slack/slack
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Desktop client for Slack";
+    homepage = "https://slack.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12678,6 +12678,8 @@ let
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 
+  slack = callPackage ../applications/networking/instant-messengers/slack { };
+
   spectrwm = callPackage ../applications/window-managers/spectrwm { };
 
   wlc = callPackage ../development/libraries/wlc { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ X ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
