### PR TITLE
s3gof3r: init at 0.5.0

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3182,6 +3182,8 @@ let
 
   s3cmd = callPackage ../tools/networking/s3cmd { };
 
+  s3gof3r = goPackages.s3gof3r.bin // { outputs = [ "bin" ]; };
+
   s6Dns = callPackage ../tools/networking/s6-dns { };
 
   s6LinuxUtils = callPackage ../os-specific/linux/s6-linux-utils { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -3303,6 +3303,16 @@ let
     sha256 = "0g9fj10xnxcv034c8hpcgbhswv6as0d8l176c5nfgh1lh6klmmzc";
   };
 
+  s3gof3r = buildFromGitHub rec {
+    owner    = "rlmcpherson";
+    repo     = "s3gof3r";
+    rev      = "v${version}";
+    version  = "0.5.0";
+    sha256   = "10banc8hnhxpsdmlkf9nc5fjkh1349bgpd9k7lggw3yih1rvmh7k";
+    disabled = isGo14;
+    propagatedBuildInputs = [ go-flags ];
+  };
+
   sandblast = buildGoPackage rec {
     rev = "694d24817b9b7b8bacb6d458b7989b30d7fe3555";
     name = "sandblast-${stdenv.lib.strings.substring 0 7 rev}";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
