### PR TITLE
oh-my-zsh: 2016-03-11 -> 2016-03-19

### DIFF
--- a/pkgs/shells/oh-my-zsh/default.nix
+++ b/pkgs/shells/oh-my-zsh/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   name = "oh-my-zsh-git-${version}";
-  version = "2016-03-11";
+  version = "2016-03-19";
 
   src = fetchgit {
     url = "https://github.com/robbyrussell/oh-my-zsh";
-    rev = "83cf8dc16f51babbb0193c5b97e568739c1f40de";
-    sha256 = "0lxs7c89c7ib7a1rfsdpc30gxi2q35mapcv2q44rlclv26nikkjv";
+    rev = "8ac1859f377b5292597f11f5973bae1ebc8e2dce";
+    sha256 = "1zq3rps1jqw1gmhqsmcz38c0c1mk5d3z3n8m34v8k5zsfh5y4bha";
   };
 
   phases = "installPhase";


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
