### PR TITLE
Usb modeswitch [WIP]

### DIFF
--- a/pkgs/development/tools/misc/usb-modeswitch-data/default.nix
+++ b/pkgs/development/tools/misc/usb-modeswitch-data/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, libusb1, usb-modeswitch }:
+
+let
+   version = "20160112";
+in
+
+stdenv.mkDerivation rec {
+  name = "usb-modeswitch-data-${version}";
+
+  src = fetchurl {
+     url = "http://www.draisberghof.de/usb_modeswitch/${name}.tar.bz2";
+     sha256 = "19yzqv0592b9mwgdi7apzw881q70ajyx5d56zr1z5ldi915a8yfn";
+   };
+
+  # make clean: we always build from source. It should be necessary on x86_64 only
+  prePatch = ''
+    sed -i 's@usb_modeswitch@${usb-modeswitch}/bin/usb_modeswitch@g' 40-usb_modeswitch.rules
+    sed -i "1 i\DESTDIR=$out" Makefile
+  '';
+
+  buildInputs = [ pkgconfig libusb1 usb-modeswitch ];
+
+  meta = {
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.marcweber ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/usb-modeswitch/default.nix
+++ b/pkgs/development/tools/misc/usb-modeswitch/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, libusb1 }:
 
 let
-   version = "2.2.1";
+   version = "2.3.0";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1177,7 +1177,8 @@ let
 
   "unionfs-fuse" = callPackage ../tools/filesystems/unionfs-fuse { };
 
-  usb_modeswitch = callPackage ../development/tools/misc/usb-modeswitch { };
+  usb-modeswitch-data = callPackage ../development/tools/misc/usb-modeswitch-data { };
+  usb-modeswitch = callPackage ../development/tools/misc/usb-modeswitch { };
 
   anthy = callPackage ../tools/inputmethods/anthy { };
 


### PR DESCRIPTION
Hi,

as there is few issues with USB modems in NixOS I'm trying to fix it by adding udev rules (usb-modeswitch-data). 

As you can see I added missing part of usb-modeswitch package which is udev rules from usb-modeswitch-data package.
I'm not sure how to expose those udev rules to the system. After I install the package (as root), udev rules are not in /etc/udev/rules.d nor /lib/udev/rules.d. Do I need to add nixos "service" or "module" to expose that rules from a package?

Also, maybe will be good to add usb-modeswitch and usb-modeswitch-data as modemmanager dependency so people which install modemmanager have their usb-modems enabled by default?
