### PR TITLE
iodined service: wantedBy ip-up.target

### DIFF
--- a/nixos/modules/services/networking/iodined.nix
+++ b/nixos/modules/services/networking/iodined.nix
@@ -64,8 +64,7 @@ in
 
     systemd.services.iodined = {
       description = "iodine, ip over dns daemon";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = [ "ip-up.target" ];
       serviceConfig.ExecStart = "${pkgs.iodine}/sbin/iodined -f -u ${iodinedUser} ${cfg.extraConfig} ${cfg.ip} ${cfg.domain}";
     };
 


### PR DESCRIPTION
###### The Change:

When iodined tries to start before any interface other than loopback has an ip, iodined fails.
Wait for ip-up.target

The above is because of the following:
in iodined's code: src/common.c line 157
    the flag AI_ADDRCONFIG is passed as a flag to getaddrinfo.
    Iodine uses the function

```
    get_addr(char *host,
        int port,
        int addr_family,
        int flags,
        struct sockaddr_storage *out);

to get address information via getaddrinfo().

Within get_addr, the flag AI_ADDRCONFIG is forced.

What this flag does, is cause getaddrinfo to return
"Name or service not known" as an error explicitly if no ip
has been assigned to the computer.
see getaddrinfo(3)
```

Wait for an ip before starting iodined.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
