### PR TITLE
arangodb: fix gcc5 build

### DIFF
--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     openssl zlib python gyp go readline
   ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
+
   configureFlagsArray = [ "--with-openssl-lib=${openssl}/lib" ];
 
   patchPhase = ''


### PR DESCRIPTION
https://hydra.nixos.org/build/33263863/nixlog/1/raw

I don't have enough memory to build this, appearantly ...
