### PR TITLE
zsh-navigation-tools: include znt-* functions

### DIFF
--- a/pkgs/tools/misc/zsh-navigation-tools/default.nix
+++ b/pkgs/tools/misc/zsh-navigation-tools/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/share/zsh/site-functions/
     cp n-* $out/share/zsh/site-functions/
+    cp znt-* $out/share/zsh/site-functions/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
