### PR TITLE
wolfssl: 3.8.0 -> 3.9.0

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.8.0";
+  version = "3.9.0";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}";
-    sha256 = "0vc2120a9gfxg3rv018ch1g84ia2cpplcqbpy8v6vpfb79rn1nf5";
+    sha256 = "0j4la9936jcy2fam1x5wplbslqa4zjnrk4wyipkbwz9m8cxg0n6v";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [ ] Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux (Fedora 22)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

No packages depend on wolfssl; therefore additionally I tested the new library with the following nix script, which builds a version of curl that uses wolfssl rather than openssl:

``` nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags = oldAttrs.configureFlags ++ [
      "--with-cyassl=${wolfssl}"
    ];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```

For the actual test, I ran

``` bash
/nix/store/q7xhmkmnq665hly3xyzajd96wrrzkkiq-curl-7.47.1/bin/curl https://github.com/wolfSSL/wolfssl/
```

and confirmed that this works as expected.
