### PR TITLE
cups: refer systemd service to correct outputs

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -34,9 +34,10 @@ let
   bindir = pkgs.buildEnv {
     name = "cups-progs";
     paths =
-      [ cups additionalBackends cups_filters pkgs.ghostscript ]
-      ++ optional cfg.gutenprint gutenprint
-      ++ cfg.drivers;
+      map (drv: drv.bin or drv.out or drv)
+        ([ cups additionalBackends cups_filters pkgs.ghostscript ]
+         ++ optional cfg.gutenprint gutenprint
+         ++ cfg.drivers);
     pathsToLink = [ "/lib/cups" "/share/cups" "/bin" ];
     postBuild = cfg.bindirCmds;
     ignoreCollisions = true;
@@ -269,21 +270,21 @@ in
     environment.systemPackages = [ cups ] ++ optional polkitEnabled cups-pk-helper;
     environment.etc."cups".source = "/var/lib/cups";
 
-    services.dbus.packages = [ cups ] ++ optional polkitEnabled cups-pk-helper;
+    services.dbus.packages = [ cups.out ] ++ optional polkitEnabled cups-pk-helper;
 
     # Cups uses libusb to talk to printers, and does not use the
     # linux kernel driver. If the driver is not in a black list, it
     # gets loaded, and then cups cannot access the printers.
     boot.blacklistedKernelModules = [ "usblp" ];
 
-    systemd.packages = [ cups ];
+    systemd.packages = [ cups.out ];
 
     systemd.services.cups =
       { wantedBy = [ "multi-user.target" ];
         wants = [ "network.target" ];
         after = [ "network.target" ];
 
-        path = [ cups ];
+        path = [ cups.out ];
 
         preStart =
           ''
@@ -324,7 +325,7 @@ in
         partOf = [ "cups.service" "avahi-daemon.service" ];
         after = [ "cups.service" "avahi-daemon.service" ];
 
-        path = [ cups ];
+        path = [ cups.out ];
 
         serviceConfig.ExecStart = "${cups_filters}/bin/cups-browsed";
 


### PR DESCRIPTION
This is still WIP. With these changes, CUPS will start, but it shutsdown immediately with no error message.
