### PR TITLE
clementineFree: fix gcc5 build

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -50,6 +50,12 @@ let
     name = "clementine-free-${version}";
     inherit patches src buildInputs;
     enableParallelBuilding = true;
+    postPatch = ''
+      sed -i src/CMakeLists.txt \
+        -e 's,-Werror,,g' \
+        -e 's,-Wno-unknown-warning-option,,g' \
+        -e 's,-Wno-unused-private-field,,g'
+    '';
     meta = with stdenv.lib; {
       homepage = "http://www.clementine-player.org";
       description = "A multiplatform music player";


### PR DESCRIPTION
See https://hydra.nixos.org/build/33277865/nixlog/1/raw
