### PR TITLE
clisp: fix i686 build

### DIFF
--- a/pkgs/development/interpreters/clisp/2.44.1.nix
+++ b/pkgs/development/interpreters/clisp/2.44.1.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     cd builddir
   '';
 
-  NIX_CFLAGS_COMPILE="-O0";
+  NIX_CFLAGS_COMPILE = "-O0 ${stdenv.lib.optionalString (!stdenv.is64bit) "-falign-functions=4"}";
 
   # TODO : make mod-check fails
   doCheck = false;

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
         clx/new-clx bindings/glibc pcre rawsock wildcard zlib
   '';
 
-  NIX_CFLAGS_COMPILE="-O0";
+  NIX_CFLAGS_COMPILE = "-O0 ${stdenv.lib.optionalString (!stdenv.is64bit) "-falign-functions=4"}";
 
   # TODO : make mod-check fails
   doCheck = false;


### PR DESCRIPTION
Requires -falign-functions=4

See https://hydra.nixos.org/build/33256640/nixlog/1/raw
