### PR TITLE
codeblocks: add libX11 build dependency to fix 16.03 hydra build

### DIFF
--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, file, zip, wxGTK, gtk
-, contribPlugins ? false, hunspell, gamin, boost
+, contribPlugins ? false, hunspell, gamin, boost, libX11
 }:
 
 with { inherit (stdenv.lib) optionalString optional optionals; };
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "044njhps4cm1ijfdyr5f9wjyd0vblhrz9b4603ma52wcdq25093p";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig file zip wxGTK gtk ]
+  buildInputs = [ automake autoconf libtool pkgconfig file zip wxGTK gtk libX11 ]
     ++ optionals contribPlugins [ hunspell gamin boost ];
   enableParallelBuilding = true;
   patches = [ ./writable-projects.patch ];


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

http://hydra.nixos.org/build/33296816/nixlog/1
