### PR TITLE
icdiff: init at 1.7.3

### DIFF
--- a/pkgs/tools/text/icdiff/default.nix
+++ b/pkgs/tools/text/icdiff/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub, buildPythonApplication }:
+
+buildPythonApplication rec {
+  name = "icdiff-${version}";
+  version = "1.7.3";
+
+  src = fetchFromGitHub {
+    owner = "jeffkaufman";
+    repo = "icdiff";
+    rev = "release-${version}";
+    sha256 = "1k7dlf2i40flsrvkma1k1vii9hsjwdmwryx65q0n0yj4frv7ky6k";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://www.jefftk.com/icdiff;
+    description = "Side-by-side highlighted command line diffs";
+    maintainers = with maintainers; [ aneeshusa ];
+    license = licenses.psfl;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10302,6 +10302,8 @@ in modules // {
     };
   };
 
+  icdiff = callPackage ../tools/text/icdiff {};
+
   importlib = buildPythonPackage rec {
     name = "importlib-1.0.2";
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm not 100% sure the license is correct - see https://github.com/jeffkaufman/icdiff#license.
