### PR TITLE
[release-16.03] KDE 5 fixes

### DIFF
--- a/pkgs/desktops/kde-5/applications-15.12/l10n.nix
+++ b/pkgs/desktops/kde-5/applications-15.12/l10n.nix
@@ -193,9 +193,19 @@ lib.mapAttrs (name: attr: pkgs.recurseIntoAttrs attr) {
     qt5 = callPackage (kdeLocale5 "sl" {}) {};
   };
   sr = {
-    qt4 = callPackage (kdeLocale4 "sr" {}) {};
+    qt4 = callPackage (kdeLocale4 "sr" {
+      preConfigure = ''
+        patchShebangs \
+            4/sr/sr@latin/scripts/ts-pmap-compile.py \
+            4/sr/scripts/ts-pmap-compile.py \
+            4/sr/data/resolve-sr-hybrid \
+            4/sr/sr@ijekavian/scripts/ts-pmap-compile.py \
+            4/sr/sr@ijekavianlatin/scripts/ts-pmap-compile.py
+        '';
+    }) {};
     qt5 = callPackage (kdeLocale5 "sr" {
       preConfigure = ''
+        patchShebangs 5/sr/data/resolve-sr-hybrid
         sed -e 's/add_subdirectory(kdesdk)//' -i 5/sr/data/CMakeLists.txt
       '';
     }) {};

--- a/pkgs/desktops/kde-5/applications-15.12/l10n.nix
+++ b/pkgs/desktops/kde-5/applications-15.12/l10n.nix
@@ -152,13 +152,10 @@ lib.mapAttrs (name: attr: pkgs.recurseIntoAttrs attr) {
     qt4 = callPackage (kdeLocale4 "nds" {}) {};
     qt5 = callPackage (kdeLocale5 "nds" {}) {};
   };
-  # TODO: build broken in 15.11.80; re-enable in next release
-  /*
   nl = {
     qt4 = callPackage (kdeLocale4 "nl" {}) {};
     qt5 = callPackage (kdeLocale5 "nl" {}) {};
   };
-  */
   nn = {
     qt4 = callPackage (kdeLocale4 "nn" {}) {};
     qt5 = callPackage (kdeLocale5 "nn" {}) {};

--- a/pkgs/desktops/kde-5/plasma-5.5/kwin/default.nix
+++ b/pkgs/desktops/kde-5/plasma-5.5/kwin/default.nix
@@ -26,6 +26,7 @@ plasmaPackage {
     kwindowsystem plasma-framework qtdeclarative qtmultimedia qtx11extras
   ];
   patches = [ ./0001-qdiriterator-follow-symlinks.patch ];
+  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
   postInstall = ''
     wrapQtProgram "$out/bin/kwin_x11"
     wrapQtProgram "$out/bin/kwin_wayland"

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ tstrobel ];
     platforms = platforms.linux;
+    broken = true;
   };
 }


### PR DESCRIPTION
@domenkozar This takes care of the last Hydra failures on release-16.03 related to KDE 5.
