### PR TITLE
vacuum: port to mkDerivation, add zlib for hydra failure

### DIFF
--- a/pkgs/applications/networking/instant-messengers/vacuum/default.nix
+++ b/pkgs/applications/networking/instant-messengers/vacuum/default.nix
@@ -1,56 +1,30 @@
-x@{builderDefsPackage
+{ stdenv, lib, fetchurl
   , qt4, openssl
   , xproto, libX11, libXScrnSaver, scrnsaverproto
-  , xz
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+  , xz, zlib
+}:
+stdenv.mkDerivation rec {
+  name = "vacuum-im-${version}";
+  version = "1.2.4";
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    version="1.2.4";
-    baseName="vacuum-im";
-    name="${baseName}-${version}";
-    url="https://googledrive.com/host/0B7A5K_290X8-d1hjQmJaSGZmTTA/vacuum-1.2.4.tar.gz";
-    sha256="10qxpfbbaagqcalhk0nagvi5irbbz5hk31w19lba8hxf6pfylrhf";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.sha256;
+  src = fetchurl {
+    url = "https://googledrive.com/host/0B7A5K_290X8-d1hjQmJaSGZmTTA/vacuum-${version}.tar.gz";
+    sha256 = "10qxpfbbaagqcalhk0nagvi5irbbz5hk31w19lba8hxf6pfylrhf";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
+  buildInputs = [
+    qt4 openssl xproto libX11 libXScrnSaver scrnsaverproto xz zlib
+  ];
 
-  /* doConfigure should be removed if not needed */
-  phaseNames = ["addInputs" "doQMake" "doMakeInstall"];
-
-  doQMake = a.fullDepEntry (''
+  configurePhase = ''
     qmake INSTALL_PREFIX=$out -recursive vacuum.pro
-  '') ["doUnpack" "addInputs"];
-      
-  meta = {
+  '';
+
+  meta = with stdenv.lib; {
     description = "An XMPP client fully composed of plugins";
-    maintainers = with a.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = with a.lib.platforms;
-      linux;
-    license = with a.lib.licenses;
-      gpl3;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
     homepage = "http://code.google.com/p/vacuum-im/";
   };
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://code.google.com/p/vacuum-im/downloads/list?can=2&q=&colspec=Filename";
-    };
-  };
-}) x
-
+}


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
