### PR TITLE
cups-kyocera: init at 1.1203

### DIFF
--- a/pkgs/misc/cups/drivers/kyocera/default.nix
+++ b/pkgs/misc/cups/drivers/kyocera/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchzip, cups }:
+
+let
+  platform =
+    if stdenv.system == "x86_64-linux" then "64bit"
+    else if stdenv.system == "i686-linux" then "32bit"
+         else abort "Unsupported platform";
+
+  libPath = lib.makeLibraryPath [ cups ];
+in
+
+stdenv.mkDerivation rec {
+  name = "cups-kyocera-${version}";
+  version = "1.1203";
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  src = fetchzip {
+    url = "http://cdn.kyostatics.net/dlc/ru/driver/all/linuxdrv_1_1203_fs-1x2xmfp.-downloadcenteritem-Single-File.downloadcenteritem.tmp/LinuxDrv_1.1203_FS-1x2xMFP.zip";
+    sha256 = "0z1pbgidkibv4j21z0ys8cq1lafc6687syqa07qij2qd8zp15wiz";
+  };
+
+  installPhase = ''
+    tar -xvf ${platform}/Global/English.tar.gz
+    install -Dm755 English/rastertokpsl $out/lib/cups/filter/rastertokpsl
+    patchelf \
+      --set-rpath ${libPath} \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/lib/cups/filter/rastertokpsl
+
+    mkdir -p $out/share/cups/model/Kyocera
+    cd English
+    for i in *.ppd; do
+      sed -i $i -e \
+        "s,/usr/lib/cups/filter/rastertokpsl,$out/lib/cups/filter/rastertokpsl,g"
+      cp $i $out/share/cups/model/Kyocera
+    done;
+  '';
+
+  meta = with lib; {
+    description = "CUPS drivers for several Kyocera FS-{1020,1025,1040,1060,1120,1125} printers";
+    homepage = "https://www.kyoceradocumentsolutions.ru/index/service_support/download_center.false.driver.FS1040._.EN.html#";
+    license = licenses.unfree;
+    maintainers = [ maintainers.vanzef ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15929,6 +15929,8 @@ let
 
   cups-pk-helper = callPackage ../misc/cups/cups-pk-helper.nix { };
 
+  cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};
+
   crashplan = callPackage ../applications/backup/crashplan { };
 
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @abbradar 
