### PR TITLE
chessx: install chessx.desktop file

### DIFF
--- a/pkgs/games/chessx/default.nix
+++ b/pkgs/games/chessx/default.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   installPhase = ''
       mkdir -p "$out/bin"
+      mkdir -p "$out/share/applications"
       cp -pr release/chessx "$out/bin"
+      cp -pr unix/chessx.desktop "$out/share/applications"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` : none do
- [x ] Tested execution of all binary files (usually in `./result/bin/`): yes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

_Please note, that points are not mandatory, but rather desired._

This installs the chessx.desktop file associating `chessx` with .pgn files.
