### PR TITLE
mxu11x0: init at 1.3.11

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -349,6 +349,7 @@
   tv = "Tomislav Viljetić <tv@shackspace.de>";
   tvestelind = "Tomas Vestelind <tomas.vestelind@fripost.org>";
   twey = "James ‘Twey’ Kay <twey@twey.co.uk>";
+  uralbash = "Svintsov Dmitry <root@uralbash.ru>";
   urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>";
   vandenoever = "Jos van den Oever <jos@vandenoever.info>";
   vanzef = "Ivan Solyankin <vanzef@gmail.com>";

--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+# it doesn't compile anymore on 3.14
+assert stdenv.lib.versionAtLeast kernel.version "3.18";
+
+stdenv.mkDerivation {
+  name = "mxu11x0-1.3.11-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "ellysh";
+    repo = "mxu11x0";
+    rev = "de54053d6f297785d77aba9e9c880001519ffddf";
+    sha256 = "1zmqanw22pgaj3b3lnciq33w6svm5ngg6g0k5xxwwijixg8ri3lf";
+  };
+
+  preBuild = ''
+    sed -i -e "s/\$(uname -r).*/${kernel.modDirVersion}/g" driver/mxconf
+    sed -i -e "s/\$(shell uname -r).*/${kernel.modDirVersion}/g" driver/Makefile
+    sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' driver/mxconf
+    sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' driver/Makefile
+  '';
+  installPhase = ''
+    install -v -D -m 644 ./driver/mxu11x0.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/usb/serial/mxu11x0.ko"
+    install -v -D -m 644 ./driver/mxu11x0.ko "$out/lib/modules/${kernel.modDirVersion}/misc/mxu11x0.ko"
+  '';
+
+  dontStrip = true;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "MOXA UPort 11x0 USB to Serial Hub driver";
+    homepage = "https://github.com/ellysh/mxu11x0";
+    license = licenses.gpl1;
+    maintainers = with maintainers; [ uralbash ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10661,6 +10661,8 @@ let
 
     mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
+    mxu11x0 = callPackage ../os-specific/linux/mxu11x0 { };
+
     /* compiles but has to be integrated into the kernel somehow
        Let's have it uncommented and finish it..
     */


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Kernel module for MOXA Uport 11x0 USB to Serial devices (http://www.moxa.com/product/UPort_1150_1150I.htm).
Works on NixOS and Ubuntu when build isoImage. Builds only for kernel>=3.18

cc @uralbash

---

_Please note, that points are not mandatory, but rather desired._
