### PR TITLE
tmux nixos module: add nixos program module for tmux

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -77,6 +77,7 @@
   ./programs/shell.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
+  ./programs/tmux.nix
   ./programs/venus.nix
   ./programs/wvdial.nix
   ./programs/xfs_quota.nix

--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, lib, ... }:
+
+let
+  inherit (lib) mkOption mkEnableOption mkIf mkMerge types;
+
+  cfg = config.programs.tmux;
+
+in
+{
+  ###### interface
+
+  options = {
+    programs.tmux = {
+
+      enable = mkEnableOption "<command>tmux</command> - a <command>screen</command> replacement.";
+
+      tmuxconf = mkOption {
+        default = "";
+        description = ''
+          The contents of /etc/tmux.conf
+        '';
+        type = types.lines;
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ pkgs.tmux ];
+      etc."tmux.conf".text = cfg.tmuxconf;
+    };
+  };
+}


### PR DESCRIPTION
An extremely simple program module that allows specifying tmux configuration as it comes with some rather annoying defaults.

I'm not sure what the policy is on setting defaults for programs, but for now we don't touch them.
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
