### PR TITLE
virtualbox service: fix use of deprecated option names

### DIFF
--- a/nixos/modules/programs/virtualbox.nix
+++ b/nixos/modules/programs/virtualbox.nix
@@ -1,8 +1,8 @@
 let
   msg = "Importing <nixpkgs/nixos/modules/programs/virtualbox.nix> is "
-      + "deprecated, please use `services.virtualboxHost.enable = true' "
+      + "deprecated, please use `virtualisation.virtualbox.host.enable = true' "
       + "instead.";
 in {
   config.warnings = [ msg ];
-  config.services.virtualboxHost.enable = true;
+  config.virtualisation.virtualbox.host.enable = true;
 }


### PR DESCRIPTION
VirtualBox has moved under the virtualisation namespace.
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
