### PR TITLE
toggle.sg-download: init at 2016-02-08

### DIFF
--- a/pkgs/tools/misc/togglesg-download/default.nix
+++ b/pkgs/tools/misc/togglesg-download/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, buildPythonApplication, makeWrapper, ffmpeg }:
+
+buildPythonApplication rec {
+
+  name = "togglesg-download-git-${version}";
+  version = "2016-02-08";
+
+  src = fetchFromGitHub {
+    owner = "0x776b7364";
+    repo = "toggle.sg-download";
+    rev = "5cac3ec039d67ad29240b2fa850a8db595264e3d";
+    sha256 = "0pqw73aa5b18d5ws4zj6gcmzap6ag526jrylqq80m0yyh9yxw5hs";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  doCheck = false;
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 download_toggle_video2.py $out/bin/download_toggle_video2.py
+  '';
+
+  postInstall = stdenv.lib.optionalString (ffmpeg != null)
+    ''wrapProgram $out/bin/download_toggle_video2.py --prefix PATH : "${ffmpeg}/bin"'';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/0x776b7364/toggle.sg-download";
+    description = "Command-line tool to download videos from toggle.sg written in Python";
+    longDescription = ''
+      toggle.sg requires SilverLight in order to view videos. This tool will
+      allow you to download the video files for viewing in your media player and
+      on your OS of choice.
+    '';
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3279,7 +3279,7 @@ in
   talkfilters = callPackage ../misc/talkfilters {};
 
   znapzend = callPackage ../tools/backup/znapzend { };
-  
+
   tarsnap = callPackage ../tools/backup/tarsnap { };
 
   tcpcrypt = callPackage ../tools/security/tcpcrypt { };
@@ -16339,6 +16339,8 @@ in
   httrack = callPackage ../tools/backup/httrack { };
 
   mg = callPackage ../applications/editors/mg { };
+
+  togglesg-download = callPackage ../tools/misc/togglesg-download { };
 
 }
 


### PR DESCRIPTION
Initial packaging of a basic toggle.sg download script.
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
