### PR TITLE
Systemd: Allow specifying external generators

### DIFF
--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -11,11 +11,15 @@ stdenv.lib.overrideDerivation systemd (p: {
 
   buildPhase = ''
     make $makeFlags built-sources
+    make $makeFlags systemd-cryptsetup
     make $makeFlags systemd-cryptsetup-generator
   '';
 
   installPhase = ''
     mkdir -p $out/lib/systemd/system-generators/
     cp systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
+
+    mkdir -p $out/lib/systemd/
+    cp systemd-cryptsetup $out/lib/systemd/systemd-cryptsetup
   '';
 })

--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -1,0 +1,21 @@
+{ stdenv, systemd, cryptsetup }:
+
+assert stdenv.isLinux;
+
+stdenv.lib.overrideDerivation systemd (p: {
+  version = p.version;
+  name = "systemd-cryptsetup-generator";
+
+  nativeBuildInputs = p.nativeBuildInputs ++ [ cryptsetup ];
+  outputs = [ "out" ];
+
+  buildPhase = ''
+    make $makeFlags built-sources
+    make $makeFlags systemd-cryptsetup-generator
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/systemd/system-generators/
+    cp systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
+  '';
+})

--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -16,10 +16,10 @@ stdenv.lib.overrideDerivation systemd (p: {
   '';
 
   installPhase = ''
-    mkdir -p $out/lib/systemd/system-generators/
-    cp systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
-
     mkdir -p $out/lib/systemd/
     cp systemd-cryptsetup $out/lib/systemd/systemd-cryptsetup
+
+    mkdir -p $out/lib/systemd/system-generators/
+    cp systemd-cryptsetup-generator $out/lib/systemd/system-generators/systemd-cryptsetup-generator
   '';
 })

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ linuxHeaders pkgconfig intltool gperf libcap kmod xz pam acl
-      /* cryptsetup */ libuuid m4 glib libxslt libgcrypt libgpgerror
+      cryptsetup libuuid m4 glib libxslt libgcrypt libgpgerror
       libmicrohttpd kexectools libseccomp audit lz4 libapparmor
       /* FIXME: we may be able to prevent the following dependencies
          by generating an autoconf'd tarball, but that's probably not

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ linuxHeaders pkgconfig intltool gperf libcap kmod xz pam acl
-      cryptsetup libuuid m4 glib libxslt libgcrypt libgpgerror
+      /* cryptsetup */ libuuid m4 glib libxslt libgcrypt libgpgerror
       libmicrohttpd kexectools libseccomp audit lz4 libapparmor
       /* FIXME: we may be able to prevent the following dependencies
          by generating an autoconf'd tarball, but that's probably not

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10990,14 +10990,9 @@ in
 
   systemd = callPackage ../os-specific/linux/systemd {
     linuxHeaders = linuxHeaders_3_18;
-    cryptsetup = null; # Infinite recusion
   };
 
-  systemd_with_cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
-    inherit cryptsetup;
-  });
-
-  # The standalone cryptsetup generator for systemd
+  # standalone cryptsetup generator for systemd
   systemd-cryptsetup-generator = callPackage ../os-specific/linux/systemd/cryptsetup-generator.nix { };
 
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10993,7 +10993,7 @@ in
     cryptsetup = null; # Infinite recusion
   };
 
-  systemd-with-cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
+  systemd_with_cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
     inherit cryptsetup;
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10997,6 +10997,9 @@ in
     inherit cryptsetup;
   });
 
+  # The standalone cryptsetup generator for systemd
+  systemd-cryptsetup-generator = callPackage ../os-specific/linux/systemd/cryptsetup-generator.nix { };
+
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get
   # LVM2 working in systemd.
   systemd_with_lvm2 = pkgs.lib.overrideDerivation pkgs.systemd (p: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10993,9 +10993,9 @@ in
     cryptsetup = null; # Infinite recusion
   };
 
-  systemd-with-cryptsetup = systemd.override {
+  systemd-with-cryptsetup = appendToName "-with-cryptsetup" (systemd.override {
     inherit cryptsetup;
-  };
+  });
 
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get
   # LVM2 working in systemd.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10990,6 +10990,11 @@ in
 
   systemd = callPackage ../os-specific/linux/systemd {
     linuxHeaders = linuxHeaders_3_18;
+    cryptsetup = null; # Infinite recusion
+  };
+
+  systemd-with-cryptsetup = systemd.override {
+    inherit cryptsetup;
   };
 
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get


### PR DESCRIPTION
This PR is a replacement for #14074. Please take a look at it for my motivation.

My goal was to enable `cryptsetup`-support in our systemd. This wasn't as easy as hoped because of a circular dependency between `systemd`, `lvm2`, and `cryptsetup`.

This PR implements a new approach: It adds support for external generator packages, allowing users to enable support for `cryptsetup` (and therefore `/etc/crypttab`) via:

```
systemd.generator-packages = [ 
  pkgs.systemd-cryptsetup-generator
];
```

This has the benefit over #14074 that we don't have to rebuild `systemd` anymore. Nor pulls it two instances of systemd into the system closure.

One thing to note is that it's possible to replicate the same behavior via:

```
systemd.generators = { 
  "systemd-cryptsetup-generator" = "${pkgs.systemd-cryptsetup-generator}/lib/systemd/system-generators/systemd-cryptsetup-generator";
};
```

Which I dislike quite a bit because you have to know about the internal directory structure of the generator package in order to use this. My implementation of `systemd.generator-packages` generates the paths automatically.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
