### PR TITLE
ppp: Include convenience scripts

### DIFF
--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -22,6 +22,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpcap ];
 
+  installPhase = ''
+    mkdir -p $out/bin
+    make install
+    install -D -m 755 scripts/{pon,poff,plog} $out/bin
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/bin/{pon,poff,plog} --replace "/usr/sbin" "$out/bin"
+  '';
+
   meta = {
     homepage = https://ppp.samba.org/;
     description = "Point-to-point implementation for Linux and Solaris";


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

PPP comes with some convenience scripts that we generally throw away. This brings in `pon`, `poff` and `plog`.
