### PR TITLE
texlive-new: fix updmap in combine function

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/combine.nix
@@ -76,7 +76,7 @@ in buildEnv {
       rm ./texmf.cnf
       cat "$cnfOrig" | sed 's/texmf-dist/texmf/g' > ./texmf.cnf
 
-      rm updmap.cfg
+      #rm updmap.cfg
     )
   '' +
     # updmap.cfg seems like not needing changes
@@ -158,7 +158,8 @@ in buildEnv {
     texlinks.sh "$out/bin" && wrapBin
     perl `type -P fmtutil.pl` --sys --refresh | grep '^fmtutil' # too verbose
     #texlinks.sh "$out/bin" && wrapBin # do we need to regenerate format links?
-    perl `type -P updmap.pl` --sys --syncwithtrees --force
+    echo "y" | perl `type -P updmap.pl` --sys --syncwithtrees --force
+    perl `type -P updmap.pl` --sys --force
     perl `type -P mktexlsr.pl` ./share/texmf-* # to make sure
   '' +
     # install (wrappers for) scripts, based on a list from upstream texlive


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14157 
cc @vcunat 
