### PR TITLE
qgroundcontrol: init at 2.9.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -278,6 +278,7 @@
   psibi = "Sibi <sibi@psibi.in>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";
+  pxc = "Patrick Callahan <patrick.callahan@latitudeengineering.com>";
   qknight = "Joachim Schiele <js@lastlog.de>";
   ragge = "Ragnar Dahlen <r.dahlen@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";

--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -1,0 +1,95 @@
+{ stdenv, fetchurl, git,  espeak, SDL, udev, doxygen, cmake
+  , qtbase, qtlocation, qtserialport, qtdeclarative, qtconnectivity, qtxmlpatterns
+  , qtsvg, qtquick1, qtquickcontrols, qtgraphicaleffects
+  , makeQtWrapper, lndir
+  , gst_all_1, qt_gstreamer1, pkgconfig, glibc
+  , version ? "2.9.4"
+}:
+
+stdenv.mkDerivation rec {
+  inherit version;
+  name = "qgroundcontrol-${version}";
+  buildInputs = [
+   SDL udev doxygen git glibc
+  ] ++ gstInputs;
+
+  qtInputs = [
+#    qtbase qtlocation qtserialport qtdeclarative 
+    qtbase qtlocation qtserialport qtdeclarative qtconnectivity qtxmlpatterns qtsvg 
+    qtquick1 qtquickcontrols qtgraphicaleffects
+  ];
+
+  gstInputs = with gst_all_1; [
+    gstreamer gst-plugins-base
+  ];
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [
+    pkgconfig makeQtWrapper
+ ] ++ qtInputs;
+
+  preConfigure = ''
+    git submodule init
+    git submodule update
+  '';
+
+  configurePhase = ''
+    mkdir build
+    pushd build
+
+    qmake PREFIX=$out $src/qgroundcontrol.pro
+
+    popd
+  '';
+
+  preBuild = "pushd build/";
+  postBuild = "popd";
+
+#  makefile = "build/Makefile";
+ 
+  installPhase = ''
+    mkdir -p $out/share/applications
+    cp -v qgroundcontrol.desktop $out/share/applications
+    
+    mkdir -p $out/bin
+    cp -v build/release/qgroundcontrol "$out/bin/"
+    
+    mkdir -p $out/share/qgroundcontrol
+    cp -rv resources/ $out/share/qgroundcontrol
+    
+    mkdir -p $out/share/pixmaps
+    cp -v resources/icons/qgroundcontrol.png $out/share/pixmaps
+
+    # we need to link to our Qt deps in our own output if we want
+    # this package to work without being installed as a system pkg
+    mkdir -p $out/lib/qt5 $out/etc/xdg
+    for pkg in $qtInputs; do
+      if [[ -d $pkg/lib/qt5 ]]; then
+        for dir in lib/qt5 share etc/xdg; do
+          if [[ -d $pkg/$dir ]]; then
+            ${lndir}/bin/lndir "$pkg/$dir" "$out/$dir"
+          fi
+        done
+      fi
+    done
+  '';
+
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/qgroundcontrol" \
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
+  '';
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/qgroundcontrol/releases/download/v${version}/qgroundcontrol.tar.bz2";
+    sha256 = "876328e9d15f643c97b9abf88949407a270ecd18365b2c5c495429fb05fc72cc";
+  };
+
+  meta = {
+    description = "provides full ground station support and configuration for the PX4 and APM Flight Stacks";
+    homepage = http://qgroundcontrol.org/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [ pxc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14349,6 +14349,8 @@ in
 
   qgis = callPackage ../applications/gis/qgis {};
 
+  qgroundcontrol = qt55.callPackage ../applications/science/robotics/qgroundcontrol { };
+
   qtbitcointrader = callPackage ../applications/misc/qtbitcointrader {
     qt = qt4;
   };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

---

_Please note, that points are not mandatory, but rather desired._
