### PR TITLE
scanmem: 0.15.2 -> 0.15.6

### DIFF
--- a/pkgs/tools/misc/scanmem/default.nix
+++ b/pkgs/tools/misc/scanmem/default.nix
@@ -1,13 +1,13 @@
 { stdenv, autoconf, automake, intltool, libtool, fetchFromGitHub, readline }:
 
 stdenv.mkDerivation rec {
-  version = "0.15.2";
+  version = "0.15.6";
   name = "scanmem-${version}";
   src = fetchFromGitHub {
     owner  = "scanmem";
     repo   = "scanmem";
     rev    = "v${version}";
-    sha256 = "0f93ac5rycf46q60flab5nl7ksadjls13axijg5j5wy1yif0k094";
+    sha256 = "16cw76ji3mp0sj8q0sz5wndavk10n0si1sm6kr5zpiws4sw047ii";
   };
   buildInputs = [ autoconf automake intltool libtool readline ];
   preConfigure = ''
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/scanmem/scanmem";
     description = "Memory scanner for finding and poking addresses in executing processes";
     maintainers = [ stdenv.lib.maintainers.chattered  ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     license = stdenv.lib.licenses.gpl3;
   };
 }


### PR DESCRIPTION
Changelog mentions darwin support, but I am unable to test that.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
