### PR TITLE
dvdbackup: init at 0.4.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -60,6 +60,7 @@
   bodil = "Bodil Stokke <nix@bodil.org>";
   boothead = "Ben Ford <ben@perurbis.com>";
   bosu = "Boris Sukholitko <boriss@gmail.com>";
+  bradediger = "Brad Ediger <brad@bradediger.com>";
   bramd = "Bram Duvigneau <bram@bramd.nl>";
   bstrik = "Berno Strik <dutchman55@gmx.com>";
   bzizou = "Bruno Bzeznik <Bruno@bzizou.net>";

--- a/pkgs/applications/video/dvdbackup/default.nix
+++ b/pkgs/applications/video/dvdbackup/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, libdvdread, libdvdcss, dvdauthor }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.2";
+  name = "dvdbackup-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dvdbackup/${name}.tar.xz";
+    sha256 = "1rl3h7waqja8blmbpmwy01q9fgr5r0c32b8dy3pbf59bp3xmd37g";
+  };
+
+  buildInputs = [ libdvdread libdvdcss dvdauthor ];
+
+  meta = {
+    description = "A tool to rip video DVDs from the command line";
+    homepage = http://dvdbackup.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.bradediger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11818,6 +11818,8 @@ in
 
   dvdauthor = callPackage ../applications/video/dvdauthor { };
 
+  dvdbackup = callPackage ../applications/video/dvdbackup { };
+
   dvd-slideshow = callPackage ../applications/video/dvd-slideshow { };
 
   dwb-unwrapped = callPackage ../applications/networking/browsers/dwb { dconf = gnome3.dconf; };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
