### PR TITLE
s3cmd: 1.5.2 -> 1.6.1

### DIFF
--- a/pkgs/tools/networking/s3cmd/default.nix
+++ b/pkgs/tools/networking/s3cmd/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchFromGitHub, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "s3cmd-1.5.2";
+  name = "s3cmd-${version}";
+  version = "1.6.1";
   
-  src = fetchurl {
-    url = "mirror://sourceforge/s3tools/${name}.tar.gz";
-    sha256 = "0bdl2wvh4nri4n6hpaa8s9lk98xy4a1b0l9ym54fvmxxx1j6g2pz";
+  src = fetchFromGitHub {
+    owner  = "s3tools";
+    repo   = "s3cmd";
+    rev    = "v${version}";
+    sha256 = "0aan6v1qj0pdkddhhkbaky44d54irm1pa8mkn52i2j86nb2rkcf9";
   };
 
   propagatedBuildInputs = with pythonPackages; [ python_magic dateutil ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
