### PR TITLE
innoextract: 1.5 -> 1.6

### DIFF
--- a/pkgs/tools/archivers/innoextract/default.nix
+++ b/pkgs/tools/archivers/innoextract/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, cmake, python, doxygen, lzma, boost}:
 
 stdenv.mkDerivation rec {
-  name = "innoextract-1.5";
+  name = "innoextract-1.6";
 
   src = fetchurl {
     url = "http://constexpr.org/innoextract/files/${name}.tar.gz";
-    sha256 = "1ks8z8glak63xvqlv7dnmlzkjrwsn81lhybmai2mja6g5jclwngj";
+    sha256 = "0gh3q643l8qlwla030cmf3qdcdr85ixjygkb7j4dbm7zbwa3yik6";
   };
 
   buildInputs = [ python doxygen lzma boost ];


### PR DESCRIPTION
Get it while it's hot: https://github.com/dscharrer/innoextract/releases
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
