### PR TITLE
jsonnet: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, emscripten }:
 
-let version = "0.8.6"; in
+let version = "0.8.7"; in
 
 stdenv.mkDerivation {
   name = "jsonnet-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     rev = "v${version}";
     owner = "google";
     repo = "jsonnet";
-    sha256 = "1dkvm81gi1j02zs00mqshn9i71bcnqbxsm5hh3wwa2y0sffvgkwh";
+    sha256 = "0adg7ijz10mc4xs5lfrby5g9sx96icf6cg39hvkh4wqjl85c6i9g";
   };
 
   buildInputs = [ emscripten ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [n/a] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
