### PR TITLE
curl3: fix build against recent openssl

### DIFF
--- a/pkgs/tools/networking/curl/7.15.nix
+++ b/pkgs/tools/networking/curl/7.15.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "061bgjm6rv0l9804vmm4jvr023l52qvmy9qq4zjv4lgqhlljvhz3";
   };
 
-  patches = [ ./disable-ca-install.patch ];
+  patches = [ ./disable-ca-install.patch ./no-sslv2.patch ];
 
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains
   # "-lz -lssl", which aren't necessary direct build inputs of

--- a/pkgs/tools/networking/curl/no-sslv2.patch
+++ b/pkgs/tools/networking/curl/no-sslv2.patch
@@ -1,0 +1,20 @@
+diff -ruN a/lib/ssluse.c b/lib/ssluse.c
+--- a/lib/ssluse.c	2005-08-11 00:57:27.000000000 +0200
++++ b/lib/ssluse.c	2016-03-25 13:10:55.637094954 +0100
+@@ -1139,13 +1139,14 @@
+   default:
+   case CURL_SSLVERSION_DEFAULT:
+     /* we try to figure out version */
+-    req_method = SSLv23_client_method();
++    req_method = TLSv1_client_method();
+     break;
+   case CURL_SSLVERSION_TLSv1:
+     req_method = TLSv1_client_method();
+     break;
+   case CURL_SSLVERSION_SSLv2:
+-    req_method = SSLv2_client_method();
++    failf(data, "OpenSSL was built without SSLv2 support");
++    return CURLE_SSL_CONNECT_ERROR;
+     break;
+   case CURL_SSLVERSION_SSLv3:
+     req_method = SSLv3_client_method();


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

The ancient curl3 does not support building against an
OpenSSL without SSLv2 support.  This "fixes" this problem
by 1) making TLSv1 the default; 2) causing selection of SSLv2 to
error out.

This patch was derived from
https://github.com/curl/curl/commit/c66b0b32fba175d5f096c944d8ec8f9f06299f4a

Although this PR is against staging, I actually tested the build on the release branch.

cc @domenkozar 
