### PR TITLE
add libpinyin and ibus-libpinyin

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, intltool, pkgconfig, sqlite, libpinyin, db
+, ibus, glib, gtk3, python3, pygobject3
+}:
+
+stdenv.mkDerivation rec {
+  name = "ibus-libpinyin-${version}";
+  version = "1.7.4";
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description  = "IBus interface to the libpinyin input method";
+    homepage     = https://github.com/libpinyin/ibus-libpinyin;
+    license      = licenses.gpl2;
+    platforms    = platforms.linux;
+  };
+
+  #configureFlags = "--with-anthy-zipcode=${anthy}/share/anthy/zipcode.t";
+
+  buildInputs = [
+  ibus glib sqlite libpinyin python3 gtk3 db
+  ];
+
+  nativeBuildInputs = [ intltool pkgconfig ];
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/libpinyin/ibus-libpinyin/ibus-libpinyin-${version}.tar.gz";
+    sha256 = "c2085992f76ca669ebe4b7e7c0170433bbfb61f764f8336b3b17490b9fb1c334";
+  };
+}

--- a/pkgs/tools/inputmethods/libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/libpinyin/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, glib, db, pkgconfig }:
+
+stdenv.mkDerivation {
+  name = "libpinyin-1.3.0";
+
+  meta = with stdenv.lib; {
+    description = "The libpinyin project aims to provide the algorithms core for intelligent sentence-based Chinese pinyin input methods.";
+    homepace    = https://sourceforge.net/projects/libpinyin;
+    license     = licenses.gpl2;
+    platforms   = platforms.linux;
+  };
+
+  buildInputs = [ glib db pkgconfig ];
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/project/libpinyin/libpinyin/libpinyin-1.3.0.tar.gz";
+    sha256 = "e105c443b01cd67b9db2a5236435d5441cf514b997b891215fa65f16030cf1f2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1030,6 +1030,10 @@ in
 
   anthy = callPackage ../tools/inputmethods/anthy { };
 
+  libpinyin = callPackage ../tools/inputmethods/libpinyin { };
+
+  ibus-libpinyin = callPackage ../tools/inputmethods/ibus-engines/ibus-libpinyin { };
+
   m17n_db = callPackage ../tools/inputmethods/m17n-db { };
 
   m17n_lib = callPackage ../tools/inputmethods/m17n-lib { };
@@ -1048,6 +1052,10 @@ in
     };
 
     hangul = callPackage ../tools/inputmethods/ibus-engines/ibus-hangul {
+      inherit (python3Packages) pygobject3;
+    };
+
+    libpinyin = callPackage ../tools/inputmethods/ibus-engines/ibus-libpinyin {
       inherit (python3Packages) pygobject3;
     };
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I'm fairly new to nixos, so somebody better look this over. I also noticed something unrelated to my changes.

ibus-setup will crash if $IBUS_PREFIX is not set at
https://github.com/ibus/ibus/blob/master/setup/main.py#L511
This looks like an upstream bug. How do you handle something like this?

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
