### PR TITLE
quagga: 0.99.24.1 -> 1.0.20160315

### DIFF
--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "quagga-${version}";
-  version = "0.99.24.1";
+  version = "1.0.20160315";
 
   src = fetchurl {
     url = "mirror://savannah/quagga/${name}.tar.gz";
-    sha256 = "0kvmc810m7ssrvgb3213271rpywyxb646v5bzjl1jl88vx3imbl4";
+    sha256 = "0qrjhp6l1hw35jrvcwyl0df4zjx1kqhrsafx307i6pzgs2xbgzr1";
   };
 
   buildInputs =
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       It is more than a routed replacement, it can be used as a Route Server and
       a Route Reflector.
     '';
-    homepage = http://www.quagga.net/;
+    homepage = http://www.nongnu.org/quagga/;
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ tavyc ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Security update, fixes [CVE-2016-2342](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2342)
Please cherry-pick to release-16.03.

Tested on master (61fc93b) and release-16.03 (18fd4c1).
