### PR TITLE
cmus: add gcc build dep for darwin

### DIFF
--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ncurses, pkgconfig
+{ stdenv, fetchFromGitHub, ncurses, pkgconfig, gcc
 
 , alsaSupport ? stdenv.isLinux, alsaLib ? null
 # simple fallback for everyone else
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
     "CONFIG_WAV=y"
   ] ++ concatMap (a: a.flags) opts);
 
-  buildInputs = [ ncurses pkgconfig ] ++ concatMap (a: a.deps) opts;
+  buildInputs = [ ncurses pkgconfig gcc ] ++ concatMap (a: a.deps) opts;
 
   meta = {
     description = "Small, fast and powerful console music player for Linux and *BSD";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @oxij

---

_Please note, that points are not mandatory, but rather desired._
