### PR TITLE
mgba: 0.3.1 -> git 20160325

### DIFF
--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -1,11 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, cmake, ffmpeg, imagemagick, libzip, SDL2
+{ stdenv, fetchgit
+, pkgconfig, cmake, ffmpeg, imagemagick, libzip, SDL2
 , qtbase, qtmultimedia }:
 
 stdenv.mkDerivation rec {
-  name = "mgba-${meta.version}";
-  src = fetchurl {
-    url = "https://github.com/mgba-emu/mgba/archive/${meta.version}.tar.gz";
-    sha256 = "0z52w4dkgjjviwi6w13gls082zclljgx1sa8nlyb1xcnnrn6980l";
+  name = "mgba-git-${version}";
+  version = "20160325";
+
+  src = fetchgit {
+    url = "https://github.com/mgba-emu/mgba.git";
+    rev = "be2641c77b4a438e0db487bc82b43bc27a26e0c2";
+    sha256 = "0ygsmmp24w14x5fm2qz2v68p59bs2ravn22axrg2ipn5skkgrvxz";
   };
 
   buildInputs = [
@@ -13,10 +17,7 @@ stdenv.mkDerivation rec {
     qtbase qtmultimedia
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
-    version = "0.3.1";
     homepage = https://mgba.io;
     description = "A modern GBA emulator with a focus on accuracy";
     longDescription = ''


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux - NixOS x86_64
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @MP2E 
###### More

I have made it on git because the 0.4.0 release doesn't compile (gcc
complains with an error in Window.cpp: "isnan is not defined on this
scope"). The error automagically disappears on mgba's git HEAD.
