### PR TITLE
git: add openssh as a runtime dependency

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -8,7 +8,7 @@ let
   gitBase = lib.makeOverridable (import ./git) {
     inherit fetchurl stdenv curl openssl zlib expat perl python gettext gnugrep
       asciidoc xmlto docbook2x docbook_xsl docbook_xml_dtd_45 libxslt cpio tcl
-      tk makeWrapper subversionClient gzip libiconv;
+      tk makeWrapper subversionClient gzip openssh libiconv;
     texinfo = texinfo5;
     svnSupport = false;         # for git-svn support
     guiSupport = false;         # requires tcl/tk

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -1,4 +1,5 @@
-{ fetchurl, stdenv, curl, openssl, zlib, expat, perl, python, gettext, cpio, gnugrep, gzip
+{ fetchurl, stdenv, curl, openssl, zlib, expat, perl, python, gettext, cpio
+, gnugrep, gzip, openssh
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
 , libxslt, tcl, tk, makeWrapper, libiconv
 , svnSupport, subversionClient, perlLibs, smtpPerlLibs
@@ -25,7 +26,15 @@ stdenv.mkDerivation {
     ./docbook2texi.patch
     ./symlinks-in-bin.patch
     ./git-sh-i18n.patch
+    ./ssh-path.patch
   ];
+
+  postPatch = ''
+    for x in connect.c git-gui/lib/remote_add.tcl ; do
+      substituteInPlace "$x" \
+        --subst-var-by ssh "${openssh}/bin/ssh"
+    done
+  '';
 
   buildInputs = [curl openssl zlib expat gettext cpio makeWrapper libiconv]
     ++ stdenv.lib.optionals withManual [ asciidoc texinfo xmlto docbook2x

--- a/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
@@ -1,0 +1,26 @@
+diff --git a/connect.c b/connect.c
+index fd7ffe1..20cd992 100644
+--- a/connect.c
++++ b/connect.c
+@@ -768,7 +768,7 @@ struct child_process *git_connect(int fd[2], const char *url,
+ 
+ 				ssh = getenv("GIT_SSH");
+ 				if (!ssh)
+-					ssh = "ssh";
++					ssh = "@ssh@";
+ 
+ 				ssh_dup = xstrdup(ssh);
+ 				base = basename(ssh_dup);
+diff --git a/git-gui/lib/remote_add.tcl b/git-gui/lib/remote_add.tcl
+index 50029d0..17b9594 100644
+--- a/git-gui/lib/remote_add.tcl
++++ b/git-gui/lib/remote_add.tcl
+@@ -139,7 +139,7 @@ method _add {} {
+ 		# Parse the location
+ 		if { [regexp {(?:git\+)?ssh://([^/]+)(/.+)} $location xx host path]
+ 		     || [regexp {([^:][^:]+):(.+)} $location xx host path]} {
+-			set ssh ssh
++			set ssh @ssh@
+ 			if {[info exists env(GIT_SSH)]} {
+ 				set ssh $env(GIT_SSH)
+ 			}


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #1923
