### PR TITLE
genromfs: init at 0.5.2

### DIFF
--- a/pkgs/tools/filesystems/genromfs/default.nix
+++ b/pkgs/tools/filesystems/genromfs/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "0.5.2";
+  name = "genromfs-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/romfs/genromfs/${version}/${name}.tar.gz";
+    sha256 = "0q6rpq7cmclmb4ayfyknvzbqysxs4fy8aiahlax1sb2p6k3pzwrh";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "prefix = /usr" "prefix = $out"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://romfs.sourceforge.net/";
+    description = "Tool for creating romfs file system images";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -757,6 +757,8 @@ in
 
   gencfsm = callPackage ../tools/security/gencfsm { };
 
+  genromfs = callPackage ../tools/filesystems/genromfs { };
+
   gist = callPackage ../tools/text/gist { };
 
   gmic = callPackage ../tools/graphics/gmic { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Genromfs is used by PX4, an open-source autopilot stack. I need genromfs for the development environment I use with it, which I also hope to eventually turn into a package.

---

_Please note, that points are not mandatory, but rather desired._
