### PR TITLE
gazebo: init at 6.5.1 and 7.0.0

### DIFF
--- a/pkgs/applications/science/robotics/gazebo/6.nix
+++ b/pkgs/applications/science/robotics/gazebo/6.nix
@@ -1,0 +1,8 @@
+{ stdenv, fetchurl, callPackage, ignition, gazeboSimulator, ... } @ args:
+
+callPackage ./default.nix (args // rec {
+  version = "6.5.1";
+  src-sha256 = "96260aa23f1a1f24bc116f8e359d31f3bc65011033977cb7fb2c64d574321908";
+  sdformat = gazeboSimulator.sdformat3;
+})
+

--- a/pkgs/applications/science/robotics/gazebo/default.nix
+++ b/pkgs/applications/science/robotics/gazebo/default.nix
@@ -1,0 +1,81 @@
+{ stdenv, fetchurl, cmake, pkgconfig, boost, protobuf, freeimage
+  , boost-build, boost_process
+  , xorg_sys_opengl, tbb, ogre, tinyxml-2
+  , libtar, glxinfo,  libusb, libxslt, ruby, ignition
+  , pythonPackages, utillinux
+
+  # these deps are hidden; cmake doesn't catch them
+  , gazeboSimulator, sdformat ? gazeboSimulator.sdformat, curl, tinyxml, kde4, x11
+  , withIgnitionTransport ? true
+  , libav, withLibAvSupport ? true
+  , openal, withAudioSupport ? false
+  , withQuickBuild ? false, withHeadless ? false, withLowMemorySupport ? false
+  , doxygen, withDocs ? true
+  , bullet, withBulletEngineSupport ? false
+  , graphviz, withModelEditorSchematicView ? true # graphviz needed for this view
+  , gdal, withDigitalElevationTerrainsSupport ? true
+  , gts, withConstructiveSolidGeometrySupport ? true
+  , hdf5, withHdf5Support ? true
+  , version ? "7.0.0"
+  , src-sha256 ? "127q2g93kvmak2b6vhl13xzg56h09v14s4pki8wv7aqjv0c3whbl"
+  , ...
+}: with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  inherit version;
+  name = "gazebo-${version}";
+
+  src = fetchurl {
+    url = "http://osrf-distributions.s3.amazonaws.com/gazebo/releases/${name}.tar.bz2";
+    sha256 = src-sha256;
+  };
+
+  enableParallelBuilding = true; # gazebo needs this so bad
+  cmakeFlags = []
+    ++ optional withQuickBuild [ "-DENABLE_TESTS_COMPILATION=False" ]
+    ++ optional withLowMemorySupport [ "-DUSE_LOW_MEMORY_TESTS=True" ]
+    ++ optional withHeadless [ "-DENABLE_SCREEN_TESTS=False" ];
+
+  buildInputs = [
+    #cmake pkgconfig boost protobuf
+    freeimage
+    xorg_sys_opengl
+    tbb
+    ogre
+    tinyxml-2
+    libtar
+    glxinfo
+    libusb
+    libxslt
+    ignition.math2
+    sdformat
+    pythonPackages.pyopengl
+
+    # TODO: add these hidden deps to cmake configuration & submit upstream
+    curl
+    tinyxml
+    x11
+    kde4.qt4
+  ] ++ optional stdenv.isLinux utillinux # on Linux needs uuid/uuid.h
+    ++ optional withDocs doxygen
+    ++ optional withLibAvSupport libav  #TODO: package rubygem-ronn and put it here
+    ++ optional withAudioSupport openal
+    ++ optional withBulletEngineSupport bullet
+    ++ optional withIgnitionTransport ignition.transport
+    ++ optional withModelEditorSchematicView graphviz
+    ++ optional withDigitalElevationTerrainsSupport gdal
+    ++ optional withConstructiveSolidGeometrySupport gts
+    ++ optional withHdf5Support hdf5;
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  propagatedNativeBuildInputs = [ boost boost-build boost_process protobuf ];
+
+  meta = with stdenv.lib; {
+    homepage = http://gazebosim.org/;
+    description = "Multi-robot simulator for outdoor environments";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ignition-math/default.nix
+++ b/pkgs/development/libraries/ignition-math/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake }:
+
+let
+  version = "2.3.0";
+in
+stdenv.mkDerivation rec {
+  name = "ign-math2-${version}";
+
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-math/releases/ignition-math2-${version}.tar.bz2";
+    sha256 = "1a2jgq6allcxg62y0r61iv4hgxkfr1whpsxy75hg7k85s7da8dpl";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/math;
+    description = "Math library by Ingition Robotics, created for the Gazebo project";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ignition-transport/0.9.0.nix
+++ b/pkgs/development/libraries/ignition-transport/0.9.0.nix
@@ -1,0 +1,9 @@
+{ stdenv, fetchurl, callPackage, ... } @ args :
+
+callPackage ./generic.nix (args // rec {
+  version = "0.9.0";
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport-${version}.tar.bz2";
+    sha256 = "15a8lkxri8q2gc7h0pj1dg2kivhy46v8d3mlxpjy90l77788bw1z";
+  };
+})

--- a/pkgs/development/libraries/ignition-transport/1.0.1.nix
+++ b/pkgs/development/libraries/ignition-transport/1.0.1.nix
@@ -1,0 +1,9 @@
+{ stdenv, fetchurl, callPackage, ... } @ args :
+
+callPackage ./generic.nix (args // rec {
+  version = "1.0.1";
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport-${version}.tar.bz2";
+    sha256 = "08qyd70vlymms1g4smblags9f057zsn62xxrx29rhd4wy8prnjsq";
+  };
+})

--- a/pkgs/development/libraries/ignition-transport/generic.nix
+++ b/pkgs/development/libraries/ignition-transport/generic.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake, pkgconfig, utillinux,
+  protobuf, zeromq, cppzmq,
+  version, src    # parametrize version and src so we can easily have pkgs
+                  # for different versions
+  , ...
+}:
+
+stdenv.mkDerivation rec {
+  name = "ign-transport-${version}";
+  inherit src;
+
+  buildInputs = [ cmake protobuf zeromq pkgconfig
+    utillinux # we need utillinux/e2fsprogs uuid/uuid.h
+  ];
+
+  propagatedBuildInputs = [ cppzmq ];
+
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/math;
+    description = "Math library by Ingition Robotics, created for the Gazebo project";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -8,11 +8,11 @@
 , nvidia_cg_toolkit }:
 
 stdenv.mkDerivation {
-  name = "ogre-1.9.0";
+  name = "ogre-1.9-hg-20160322";
 
   src = fetchurl {
-     url = "https://bitbucket.org/sinbad/ogre/get/v1-9-0.tar.gz";
-     sha256 = "0p8gyn293qn3iyiy1smfmjd9zpnjb8h2zgvff8778fwh0ylbmlpa";
+     url = "https://bitbucket.org/sinbad/ogre/get/v1-9.tar.gz";
+     sha256 = "0w3argjy1biaxwa3c80zxxgll67wjp8czd83p87awlcvwzdk5mz9";
   };
 
   cmakeFlags = [ "-DOGRE_INSTALL_SAMPLES=yes" ]

--- a/pkgs/development/libraries/sdformat/3.nix
+++ b/pkgs/development/libraries/sdformat/3.nix
@@ -1,0 +1,7 @@
+{ stdenv, fetchurl, callPackage, ... } @ args:
+
+callPackage ./default.nix (args // rec {
+  version = "3.7.0";
+  srchash-sha256 = "07kn8bgvj9mwwinsp2cbmz11z7zw2lgnj61mi1gi1pjg7q9in98q";
+})
+

--- a/pkgs/development/libraries/sdformat/default.nix
+++ b/pkgs/development/libraries/sdformat/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, boost, ruby_1_9, ignition, tinyxml
+  , name ? "sdformat-${version}"
+  , version ? "4.0.0" # versions known to work with this expression include 3.7.0
+  , srchash-sha256 ? "b0f94bb40b0d83e35ff250a7916fdfd6df5cdc1e60c47bc53dd2da5e2378163e"
+  , ...
+  }:
+
+let 
+  ruby = ruby_1_9;
+in
+stdenv.mkDerivation rec {
+  src = fetchurl { 
+      url = "http://osrf-distributions.s3.amazonaws.com/sdformat/releases/${name}.tar.bz2";
+      sha256 = srchash-sha256;
+  };
+
+  inherit name;
+
+  enableParallelBuilding = true;
+  buildInputs = [
+    cmake boost ruby ignition.math2 tinyxml
+  ];
+}

--- a/pkgs/development/libraries/tinyxml-2/default.nix
+++ b/pkgs/development/libraries/tinyxml-2/default.nix
@@ -1,0 +1,11 @@
+{ stdenv, fetchurl, cmake }:
+let version = "3.0.0";
+in stdenv.mkDerivation rec {
+  name = "tinyxml-2-${version}";
+  src = fetchurl {
+    url = "https://github.com/leethomason/tinyxml2/archive/${version}.tar.gz";
+    sha256 = "0ispg7ngkry8vhzzawbq42y8gkj53xjipkycw0rkhh487ras32hj";
+  };
+
+  nativeBuildInputs = [ cmake ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1906,6 +1906,14 @@ in
 
   ifuse = callPackage ../tools/filesystems/ifuse/default.nix { };
 
+  ignition = recurseIntoAttrs { 
+
+    math = callPackage ../development/libraries/ignition-math { };
+  
+    math2 = ignition.math;
+  
+  };
+
   ihaskell = callPackage ../development/tools/haskell/ihaskell/wrapper.nix {
     inherit (haskellPackages) ihaskell ghcWithPackages;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8788,6 +8788,8 @@ in
 
   tinyxml2 = callPackage ../development/libraries/tinyxml/2.6.2.nix { };
 
+  tinyxml-2 = callPackage ../development/libraries/tinyxml-2 { };
+
   tk = tk-8_6;
 
   tk-8_6 = callPackage ../development/libraries/tk/8.6.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1920,7 +1920,13 @@ in
   
     math2 = ignition.math;
   
+    transport0 = callPackage ../development/libraries/ignition-transport/0.9.0.nix { };
+
+    transport1 = callPackage ../development/libraries/ignition-transport/1.0.1.nix { };
+
+    transport = ignition.transport0;
   };
+
 
   ihaskell = callPackage ../development/tools/haskell/ihaskell/wrapper.nix {
     inherit (haskellPackages) ihaskell ghcWithPackages;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1578,7 +1578,21 @@ in
     sdformat3 = callPackage ../development/libraries/sdformat/3.nix { };
 
     sdformat4 = callPackage ../development/libraries/sdformat { };
+
+    gazebo6 = callPackage ../applications/science/robotics/gazebo/6.nix { };
+
+    gazebo6-headless = callPackage ../applications/science/robotics/gazebo/6.nix { withHeadless = true;  };
+
+    gazebo7 = callPackage ../applications/science/robotics/gazebo { };
+  
+    gazebo7-headless = callPackage ../applications/science/robotics/gazebo { withHeadless = true; };
+
   };
+  
+  # at present, Gazebo 7.0.0 does not match Gazebo 6.5.1 for compatibility
+  gazebo = gazeboSimulator.gazebo6;
+
+  gazebo-headless = gazeboSimulator.gazebo6-headless;
 
   gbdfed = callPackage ../tools/misc/gbdfed {
     gtk = gtk2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1572,6 +1572,14 @@ in
 
   gawp = goPackages.gawp.bin // { outputs = [ "bin" ]; };
 
+  gazeboSimulator = recurseIntoAttrs {
+    sdformat = gazeboSimulator.sdformat4;
+
+    sdformat3 = callPackage ../development/libraries/sdformat/3.nix { };
+
+    sdformat4 = callPackage ../development/libraries/sdformat { };
+  };
+
   gbdfed = callPackage ../tools/misc/gbdfed {
     gtk = gtk2;
   };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I've cleaned a few things up and made a second pull request from this repo so I can rep my employer a little bit. Most of my work on these packages has been on their time, and all of said work has been driven by our use cases as a robotics company. :-)

Every package introduced in this commit but Gazebo itself is a dependency of Gazebo.

cc @nico202 

---

_Please note, that points are not mandatory, but rather desired._
