### PR TITLE
django packaging: remove remaining uses of makeOverridable for django-depending packages

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8278,7 +8278,7 @@ in modules // {
     };
   };
 
-  django_redis = makeOverridable ({ django ? self.django }: buildPythonPackage rec {
+  django_redis = buildPythonPackage rec {
     name = "django-redis-${version}";
     version = "4.2.0";
 
@@ -8289,18 +8289,18 @@ in modules // {
 
     buildInputs = [ self.mock ];
 
-    propagatedBuildInputs = [ django ] ++
-      (with self; [
-        redis
-        msgpack
-      ]);
+    propagatedBuildInputs = with self; [
+      django
+      redis
+      msgpack
+    ];
 
     meta = {
       description = "Full featured redis cache backend for Django";
       homepage = https://github.com/niwibe/django-redis;
       license = licenses.bsd3;
     };
-  }) {};
+  };
 
   django_reversion = buildPythonPackage rec {
     name = "django-reversion-${version}";
@@ -8322,7 +8322,7 @@ in modules // {
     };
   };
 
-  django_silk = makeOverridable ({ django ? self.django }: buildPythonPackage rec {
+  django_silk = buildPythonPackage rec {
     name = "django-silk-${version}";
     version = "0.5.6";
 
@@ -8333,25 +8333,25 @@ in modules // {
 
     buildInputs = [ self.mock ];
 
-    propagatedBuildInputs = [ django ] ++
-      (with self; [
-        pygments
-        simplejson
-        dateutil
-        requests2
-        sqlparse
-        jinja2
-        autopep8
-        pytz
-        pillow
-      ]);
+    propagatedBuildInputs = with self; [
+      django
+      pygments
+      simplejson
+      dateutil
+      requests2
+      sqlparse
+      jinja2
+      autopep8
+      pytz
+      pillow
+    ];
 
     meta = {
       description = "Silky smooth profiling for the Django Framework";
       homepage = https://github.com/mtford90/silk;
       license = licenses.mit;
     };
-  }) {};
+  };
 
   django_taggit = buildPythonPackage rec {
     name = "django-taggit-${version}";


### PR DESCRIPTION
Turns out these are unnecessary - the only reservation in removing these is breakage of peoples external setups that may be depending onthese packages being overridable. But I suspect I was the only person ever using this...?
