### PR TITLE
evince: add shared_mime_info dir to XDG_DATA_DIRS env variable

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/evince/default.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
       sed -i 's/\(if (++n_items == \)5\(.*\)/\1${builtins.toString recentListSize}\2/' shell/ev-window.c
     '';
 
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared_mime_info}/share")
+  '';
+
   doCheck = false; # would need pythonPackages.dogTail, which is missing
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue reported by @DamienCassou at PR #14121 

`wrapGAppsHook` does not automatically add `${shared_mime_info}/share` to `XDG_DATA_DIRS` environment variable. This PR does it explicitly.

cc @DamienCassou 
cc @lethalman 
