### PR TITLE
avidemux: 2.5.6 -> 2.6.12

### DIFF
--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -1,46 +1,115 @@
-{stdenv, fetchurl, cmake, pkgconfig, libxml2, qt4, gtk, gettext, SDL,
-libXv, pixman, libpthreadstubs, libXau, libXdmcp, libxslt, x264,
-alsaLib, lame, faad2, libvorbis, yasm, libvpx, xvidcore, libva,
-faac ? null, faacSupport ? false }:
+{ stdenv, lib, fetchurl, cmake, pkgconfig, lndir
+, zlib, gettext, libvdpau, libva, libXv, sqlite, x265
+, yasm, fribidi, gtk3, qt4
+, withX264 ? true, x264
+, withLAME ? true, lame
+, withFAAC ? true, faac
+, withVorbis ? true, libvorbis
+, withPulse ? true, libpulseaudio
+, withFAAD ? true, faad2
+, withOpus ? true, libopus
+, withVPX ? true, libvpx
+}:
 
-assert stdenv ? glibc;
-assert faacSupport -> faac != null;
-
-stdenv.mkDerivation {
-  name = "avidemux-2.5.6";
+stdenv.mkDerivation rec {
+  name = "avidemux-${version}";
+  version = "2.6.12";
 
   src = fetchurl {
-    url = mirror://sourceforge/avidemux/avidemux_2.5.6.tar.gz;
-    sha256 = "12wvxz0n2g85f079d8mdkkp2zm279d34m9v7qgcqndh48cn7znnn";
+    url = "mirror://sourceforge/avidemux/avidemux/${version}/avidemux_${version}.tar.gz";
+    sha256 = "0nz52yih8sff53inndkh2dba759xjzsh4b8xjww419lcpk0qp6kn";
   };
 
-  buildInputs = [ cmake pkgconfig libxml2 qt4 gtk gettext SDL libXv
-    pixman libpthreadstubs libXau libXdmcp libxslt x264 alsaLib
-    lame faad2 libvorbis yasm libvpx xvidcore libva
-  ] ++ stdenv.lib.optional faacSupport faac;
+  nativeBuildInputs = [ cmake pkgconfig yasm lndir ];
+  buildInputs = [ zlib gettext libvdpau libva libXv sqlite x265 fribidi gtk3 qt4 ]
+             ++ lib.optional withX264 x264
+             ++ lib.optional withLAME lame
+             ++ lib.optional withFAAC faac
+             ++ lib.optional withVorbis libvorbis
+             ++ lib.optional withPulse libpulseaudio
+             ++ lib.optional withFAAD faad2
+             ++ lib.optional withOpus libopus
+             ++ lib.optional withVPX libvpx
+             ;
 
-  cmakeFlags = "-DPTHREAD_INCLUDE_DIR=${stdenv.glibc}/include" +
-    " -DGETTEXT_INCLUDE_DIR=${gettext}/include" +
-    " -DSDL_INCLUDE_DIR=${SDL}/include/SDL";
+  enableParallelBuilding = false;
 
-  NIX_LDFLAGS="-lpthread";
+  outputs = [ "out" "cli" "gtk" "qt4" ];
 
-  postInstall = ''
-    cd $NIX_BUILD_TOP/$sourceRoot
-    mkdir build_plugins
-    cd build_plugins
-    cmake $cmakeFlags -DAVIDEMUX_INSTALL_PREFIX=$out \
-      -DAVIDEMUX_SOURCE_DIR=$NIX_BUILD_TOP/$sourceRoot \
-      -DAVIDEMUX_CORECONFIG_DIR=$NIX_BUILD_TOP/$sourceRoot/build/config ../plugins
+  patches = [ ./dynamic_install_dir.patch ];
 
-    make
-    make install
+  buildCommand = ''
+    unpackPhase
+    cd "$sourceRoot"
+    patchPhase
+
+    export cmakeFlags="$cmakeFlags -DAVIDEMUX_SOURCE_DIR=$(pwd)"
+
+    function buildOutput() {
+      ( plugin_ui="$1"
+        output_dir="$2"
+        shift 2
+        export cmakeFlags="$cmakeFlags -DPLUGIN_UI=$plugin_ui -DCMAKE_INSTALL_PREFIX=$output_dir"
+        for i in "$@" avidemux_plugins; do
+          ( cd "$i"
+            cmakeConfigurePhase
+            buildPhase
+            installPhase
+          )
+        done
+        rm -rf avidemux_plugins/build
+      )
+    }
+
+    function buildUi() {
+      plugin_ui="$1"
+      output_dir="$2"
+      shift 2
+
+      # Hack to split builds properly
+      mkdir -p $output_dir
+      lndir $out $output_dir
+      buildOutput $plugin_ui $output_dir "$@"
+    }
+
+    function fixupUi() {
+      output_dir="$1"
+      shift
+
+      find $output_dir -lname $out\* -delete
+      find $output_dir -type f | while read -r f; do
+        rpath="$(patchelf --print-rpath $f 2>/dev/null)" || continue
+        new_rpath=""
+        IFS=':' read -ra old_rpath <<< "$rpath"
+        for p in "''${old_rpath[@]}"; do
+          new_rpath="$new_rpath:$p"
+          if [[ $p = $output_dir* ]]; then
+            new_rpath="$new_rpath:$out/''${p#$output_dir}"
+          fi
+        done
+        patchelf --set-rpath "$new_rpath" $f
+        patchelf --shrink-rpath $f
+      done
+    }
+
+    buildOutput COMMON $out avidemux_core
+    buildOutput SETTINGS $out
+    buildUi CLI $cli avidemux/cli
+    buildUi GTK $gtk avidemux/gtk
+    buildUi QT4 $qt4 avidemux/qt4
+
+    fixupPhase
+
+    fixupUi $cli
+    fixupUi $gtk
+    fixupUi $qt4
   '';
 
   meta = {
     homepage = http://fixounet.free.fr/avidemux/;
     description = "Free video editor designed for simple video editing tasks";
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric abbradar ];
     platforms = with stdenv.lib.platforms; linux;
+    license = stdenv.lib.licenses.gpl2;
   };
 }

--- a/pkgs/applications/video/avidemux/dynamic_install_dir.patch
+++ b/pkgs/applications/video/avidemux/dynamic_install_dir.patch
@@ -1,0 +1,12 @@
+diff -ru3 avidemux_2.6.12.old/avidemux_core/ADM_core/src/ADM_fileio.cpp avidemux_2.6.12/avidemux_core/ADM_core/src/ADM_fileio.cpp
+--- avidemux_2.6.12.old/avidemux_core/ADM_core/src/ADM_fileio.cpp	2016-03-25 15:26:00.368213627 +0300
++++ avidemux_2.6.12/avidemux_core/ADM_core/src/ADM_fileio.cpp	2016-03-26 02:32:56.163550537 +0300
+@@ -393,7 +393,7 @@
+ 
+ 	return ADM_getRelativePath(buffer, base1, base2, base3);
+ #else
+-	return ADM_getRelativePath(ADM_INSTALL_DIR, base1, base2, base3);
++	return ADM_getRelativePath(getenv("ADM_ROOT_DIR"), base1, base2, base3);
+ #endif
+ }
+ 

--- a/pkgs/applications/video/avidemux/wrapper.nix
+++ b/pkgs/applications/video/avidemux/wrapper.nix
@@ -1,0 +1,29 @@
+{ buildEnv, avidemux, makeWrapper
+# GTK version is broken upstream, see https://bugzilla.redhat.com/show_bug.cgi?id=1244340
+, withUi ? "qt4"
+}:
+
+let
+  ui = builtins.getAttr withUi avidemux;
+
+in buildEnv {
+  name = "avidemux-${withUi}-" + avidemux.version;
+
+  paths = [ avidemux ui ];
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    # TODO: This could be avoided if buildEnv could be forced to create all directories
+    if [ -L $out/bin ]; then
+      rm $out/bin
+      mkdir $out/bin
+      for i in ${ui}/bin/*; do
+        ln -s $i $out/bin
+      done
+    fi
+    for i in $out/bin/*; do
+      wrapProgram $i --set ADM_ROOT_DIR $out
+    done
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11479,7 +11479,11 @@ in
 
   autopanosiftc = callPackage ../applications/graphics/autopanosiftc { };
 
-  avidemux = callPackage ../applications/video/avidemux { };
+  avidemux_unwrapped = callPackage ../applications/video/avidemux { };
+
+  avidemux = callPackage ../applications/video/avidemux/wrapper.nix {
+    avidemux = avidemux_unwrapped;
+  };
 
   avogadro = callPackage ../applications/science/chemistry/avogadro {
     eigen = eigen2;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This is a major update and also a cleanup. We now build avidemux UIs to separate build outputs and use a wrapper to join them together, so one wouldn't pull Qt dependencies if he wants Gtk UI. That said, Gtk UI is broken upstream for now, so this package defaults to Qt4. To try using Gtk, you need to use `avidemux.override { withUI = "gtk"; }`.

cc @viric 
