### PR TITLE
makemkv 1.9.7 -> 1.9.9

### DIFF
--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -4,17 +4,17 @@
 
 stdenv.mkDerivation rec {
   name = "makemkv-${ver}";
-  ver = "1.9.7";
+  ver = "1.9.9";
   builder = ./builder.sh;
 
   src_bin = fetchurl {
     url = "http://www.makemkv.com/download/makemkv-bin-${ver}.tar.gz";
-    sha256 = "1b1kdfs89ms2vyi4406ydw01py0mvvij01rx9anblgy10bc0yvfy";
+    sha256 = "1rsmsfyxjh18bdj93gy7whm4j6k1098zfak8napxsqfli7dyijb6";
   };
 
   src_oss = fetchurl {
     url = "http://www.makemkv.com/download/makemkv-oss-${ver}.tar.gz";
-    sha256 = "169fl1v3i133ihldyfq3akj3x30qsxndw7q52vv90gmn5r52bzb9";
+    sha256 = "070x8l88nv70abd9gy8jchs09mh09x6psjc0zs4vplk61cbqk3b0";
   };
 
   buildInputs = [openssl qt4 mesa zlib pkgconfig libav];


### PR DESCRIPTION
Unfortunately, the 1.9.7 sources/binaries are not available anymore
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @titanous

---

_Please note, that points are not mandatory, but rather desired._
