### PR TITLE
perf: fix build

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   # Note: we don't add elfutils to buildInputs, since it provides a
   # bad `ld' and other stuff.
-  NIX_CFLAGS_COMPILE = "-I${elfutils}/include -Wno-error=cpp";
+  NIX_CFLAGS_COMPILE = "-I${elfutils}/include -Wno-error=cpp -Wno-error=bool-compare";
   NIX_CFLAGS_LINK = "-L${elfutils}/lib";
 
   installFlags = "install install-man ASCIIDOC8=1";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More:

Ref: https://github.com/NixOS/nixpkgs/issues/13559
