### PR TITLE
rtl8723bs: only works with kernel 3.19 and later

### DIFF
--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hadess/rtl8723bs";
     license = stdenv.lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
+    broken = !stdenv.lib.versionAtLeast kernel.version "3.19";
   };
 }


### PR DESCRIPTION
See e.g., https://hydra.nixos.org/build/33512583/nixlog/1/raw

Ref Ref https://github.com/NixOS/nixpkgs/issues/13559
