### PR TITLE
accelio: kernel 4.2 is the most recent supported kernel

### DIFF
--- a/pkgs/development/libraries/accelio/default.nix
+++ b/pkgs/development/libraries/accelio/default.nix
@@ -55,5 +55,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = with platforms; linux ++ freebsd;
     maintainers = with maintainers; [ wkennington ];
+    # kernel 4.2 is the most recent supported kernel
+    broken = kernel != null && builtins.compareVersions kernel.version "4.2" == 1;
   };
 }


### PR DESCRIPTION
All Hydra builds on more recent kernels fail; from reading the accelio documentation, I get the impression that 4.2 is the most recent supported kernel version.

Ref https://github.com/NixOS/nixpkgs/issues/13559
