### PR TITLE
jool: mark broken for kernel versions > 4.3

### DIFF
--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -26,5 +26,7 @@ stdenv.mkDerivation {
     description = "Fairly compliant SIIT and Stateful NAT64 for Linux - kernel modules";
     platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz ];
+    # kernel version 4.3 is the most recent supported version
+    broken = builtins.compareVersions kernel.version "4.3" == 1;
   };
 }


### PR DESCRIPTION
All hydra builds for kernel version >4.3 fail; the build failure indicates changes to the kernel API used by the package.

Ref https://github.com/NixOS/nixpkgs/issues/13559
