### PR TITLE
Osrm build fixes

### DIFF
--- a/pkgs/servers/osrm-backend/4.5.0-gcc-binutils.patch
+++ b/pkgs/servers/osrm-backend/4.5.0-gcc-binutils.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -127,8 +127,9 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
+     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+         NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "4.9.0" AND NOT MINGW)
+       message(STATUS "Using gcc specific binutils for LTO.")
+-      set(CMAKE_AR     "/usr/bin/gcc-ar")
+-      set(CMAKE_RANLIB "/usr/bin/gcc-ranlib")
++      # Just let PATH do its job
++      set(CMAKE_AR     "gcc-ar")
++      set(CMAKE_RANLIB "gcc-ranlib")
+     endif()
+   endif (HAS_LTO_FLAG)
+ endif()

--- a/pkgs/servers/osrm-backend/default.nix
+++ b/pkgs/servers/osrm-backend/default.nix
@@ -1,11 +1,13 @@
-{stdenv, fetchurl, cmake, luabind, libosmpbf, stxxl, tbb, boost, expat, protobuf, bzip2, zlib, substituteAll}:
+{stdenv, fetchFromGitHub, cmake, luabind, libosmpbf, stxxl, tbb, boost, expat, protobuf, bzip2, zlib, substituteAll}:
 
 stdenv.mkDerivation rec {
   name = "osrm-backend-4.5.0";
 
-  src = fetchurl {
-    url = "https://github.com/Project-OSRM/osrm-backend/archive/v4.5.0.tar.gz";
-    sha256 = "af61e883051f2ecb73520ace6f17cc6da30edc413208ff7cf3d87992eca0756c";
+  src = fetchFromGitHub {
+    rev = "v4.5.0";
+    owner  = "Project-OSRM";
+    repo   = "osrm-backend";
+    sha256 = "19a8d1llvsrysyk1q48dpmh75qcbibfjlszndrysk11yh62hdvsz";
   };
 
   patches = [

--- a/pkgs/servers/osrm-backend/default.nix
+++ b/pkgs/servers/osrm-backend/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./4.5.0-openmp.patch
+    ./4.5.0-gcc-binutils.patch
     (substituteAll {
       src = ./4.5.0-default-profile-path.template.patch;
     })


### PR DESCRIPTION
This doesn't fix the `_luabind` variant - that's still to come, but it fixes the default variant which I'm guessing got broken at the gcc 4.9 switch (when all of a sudden osrm starting trying to build in LTO mode...)
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
