### PR TITLE
buku: init at 1.8

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, pythonPackages, fetchFromGitHub,
+  encryptionSupport ? false
+}:
+
+pythonPackages.buildPythonApplication rec {
+  version = "1.8";
+  name = "buku-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = "buku";
+    rev = "53d48ee56a3abfb53b94ed25fb620ee759141c96";
+    sha256 = "185d3gndw20c3l6f3mf0iq4qapm8g30bl0hn0wsqpp36vl0bpq28";
+  };
+
+  buildInputs = stdenv.lib.optional encryptionSupport pythonPackages.pycrypto;
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    make install PREFIX=$out
+  '';
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Private cmdline bookmark manager";
+    homepage = https://github.com/jarun/Buku;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -915,6 +915,10 @@ in
 
   burp = callPackage ../tools/backup/burp { };
 
+  buku = callPackage ../applications/misc/buku {
+    pythonPackages = python3Packages;
+  };
+
   byzanz = callPackage ../applications/video/byzanz {};
 
   ori = callPackage ../tools/backup/ori { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I tested this by running `./result/bin/buku -h` in a `nix-shell -p python3` as I do not have python3 installed.

I hope this is alright?
