### PR TITLE
google-app-engine-python-sdk: init at 1.9.35

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5865,6 +5865,48 @@ in modules // {
     };
   };
 
+  /* This uses mkDerivation instead of buildPythonPackage because the
+     App Engine SDK isn't packaged for `distutils/setuptools` and doesn't
+     have a setup.py file. */
+  google-app-engine-sdk =
+    if !isPy27
+    then throw "google-app-engine-sdk requires Python 2.7; it is not supported for interpreter ${python.executable}"
+    else pkgs.stdenv.mkDerivation rec {
+      name = "google-app-engine-sdk-${version}";
+      version = "1.9.35";
+      buildInputs = [ pkgs.unzip pkgs.makeWrapper ];
+
+      src = pkgs.fetchurl {
+        url = "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_${version}.zip";
+        sha256 = "19qxkxvb7nxs64mdjlxdhzbg16n5qwp8v229lvkpw9w0i8hghpj0";
+      };
+
+      unpackPhase = "unzip $src";
+
+      installPhase = ''
+
+        mkdir -p $out/lib/${python.libPrefix}
+        mv google_appengine $out/lib/${python.libPrefix}/site-packages
+
+        mkdir -p $out/bin
+
+        # Create a wrapper script for each of the python scripts that
+        # the SDK  provides. For example, `dev_appserver.py` becomes
+        # `google-app-engine-python-dev-appserver`.
+        for f in $(find $out/lib/${python.libPrefix}/site-packages -maxdepth 1 -type f -regex ".*/[a-z][^/]*.py"); do
+          makeWrapper $f \
+            $out/bin/google-app-engine-python-$(basename $f | sed s/_/-/ | sed s/\.py//) \
+            --prefix PATH : ${pkgs.python27Full}/bin
+        done
+      '';
+
+      meta = {
+        description = "A sandbox that emulates Google App Engine services";
+        homepage = "https://cloud.google.com/appengine/docs/python/";
+        license = licenses.asl20;
+      };
+    };
+
   googlecl = buildPythonPackage rec {
     version = "0.9.14";
     name    = "googlecl-${version}";


### PR DESCRIPTION
There are two new packages here:
1. `pkgs.python27Packages.google-app-engine-sdk`
2. `pkgs.google-app-engine-python-sdk`

The first package is just unmodified SDK, useful if all you want to do is import the modules from python code. The second package provides commands to run the app-engine tools (for example, `google-app-engine-python-dev-appserver` to run `dev_appserver.py`).

---
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
