### PR TITLE
etcd: 2.1.2 -> 2.3.0

### DIFF
--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -114,6 +114,7 @@ in {
       }) // (mapAttrs' (n: v: nameValuePair "ETCD_${n}" v) cfg.extraConf);
 
       serviceConfig = {
+        Type = "notify";
         ExecStart = "${pkgs.etcd}/bin/etcd";
         User = "etcd";
         PermissionsStartOnly = true;

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -789,10 +789,11 @@ let
   };
 
   etcd = buildFromGitHub {
-    rev    = "v2.1.2";
+    rev    = "v2.3.0";
     owner  = "coreos";
     repo   = "etcd";
-    sha256 = "1d3wl9rqbhkkdhfkjfrzjfcwz8hx315zbjbmij3pf62bc1p5nh60";
+    sha256 = "1cchlhsdbbqal145cvdiq7rzqqi131iq7z0r2hmzwx414k04wyn7";
+    buildInputs = [ pkgs.libpcap tablewriter ];
   };
 
   fsnotify.v0 = buildGoPackage rec {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
