### PR TITLE
linux_chromiumos: require 64bit build host

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-chromiumos-3.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-chromiumos-3.14.nix
@@ -1,5 +1,8 @@
 { stdenv, fetchgit, perl, buildLinux, ncurses, openssh, ... } @ args:
 
+# ChromiumOS requires a 64bit build host
+assert stdenv.is64bit;
+
 import ./generic.nix (args // rec {
   version = "3.14.0";
   extraMeta.branch = "3.14";

--- a/pkgs/os-specific/linux/kernel/linux-chromiumos-3.18.nix
+++ b/pkgs/os-specific/linux/kernel/linux-chromiumos-3.18.nix
@@ -1,5 +1,8 @@
 { stdenv, fetchgit, perl, buildLinux, ncurses, ... } @ args:
 
+# ChromiumOS requires a 64bit build host
+assert stdenv.is64bit;
+
 import ./generic.nix (args // rec {
   version = "3.18.0";
   extraMeta.branch = "3.18";


### PR DESCRIPTION
I noticed that most all the Hydra build failures were on i686. Sure enough, upstream says that you need an x86_64 machine to build the kernel.

Ref: https://github.com/NixOS/nixpkgs/issues/13559
