### PR TITLE
network-manager: use ping/ping6 from the nix store

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -2,7 +2,7 @@
 , udev, libgudev, libnl, libuuid, polkit, gnutls, ppp, dhcp, dhcpcd, iptables
 , libgcrypt, dnsmasq, avahi, bind, perl, bluez5, substituteAll, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
-, ethtool, gnused }:
+, ethtool, gnused, coreutils, file, inetutils }:
 
 stdenv.mkDerivation rec {
   name = "network-manager-${version}";
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    substituteInPlace tools/glib-mkenums --replace /usr/bin/perl ${perl}/bin/perl
+    substituteInPlace configure --replace /usr/bin/uname ${coreutils}/bin/uname
+    substituteInPlace configure --replace /usr/bin/file ${file}/bin/file
+    substituteInPlace src/devices/nm-device.c --replace /usr/bin/ping ${inetutils}/bin/ping
     substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe /run/current-system/sw/sbin/modprobe
     substituteInPlace data/85-nm-unmanaged.rules \
       --replace /bin/sh ${stdenv.shell} \


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14103 and #14155 

NM upstream has a hardcoded path to /usr/bin/ping. One alternative is to replace that with a link to the suid wrapper for ping/ping6, but that breaks !NixOS. @abbradar excellent suggestion was to use the unwrapped version from the nix store as networkmanager runs as root anyway.

This patch changes:
- ping/ping6 are now used from the nix store
- we no longer try to make substitutions on a missing file
- we use file from the nix store instead of /usr/bin/file in the configure script
