### PR TITLE
bower2nix 2.1.0 -> 3.0.1

### DIFF
--- a/doc/languages-frameworks/bower.xml
+++ b/doc/languages-frameworks/bower.xml
@@ -1,0 +1,244 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="sec-bower">
+
+<title>Bower</title>
+
+<para>
+  <link xlink:href="http://bower.io">Bower</link> is a package manager
+  for web site front-end components. Bower packages (comprising of
+  build artefacts and sometimes sources) are stored in
+  <command>git</command> repositories, typically on Github. The
+  package registry is run by the Bower team with package metadata
+  coming from the <filename>bower.json</filename> file within each
+  package.
+</para>
+
+<para>
+  The end result of running Bower is a
+  <filename>bower_components</filename> directory which can be included
+  in the web app's build process.
+</para>
+
+<para>
+  Bower can be run interactively, by installing
+  <varname>nodePackages.bower</varname>. More interestingly, the Bower
+  components can be declared in a Nix derivation, with the help of
+  <varname>nodePackages.bower2nix</varname>.
+</para>
+
+<section xml:id="ssec-bower2nix-usage">
+  <title><command>bower2nix</command> usage</title>
+
+<para>
+  Suppose you have a <filename>bower.json</filename> with the following contents:
+
+
+<example xml:id="ex-bowerJson"><title><filename>bower.json</filename></title>
+<programlisting language="json">
+<![CDATA[{
+  "name": "my-web-app",
+  "dependencies": {
+    "angular": "~1.5.0",
+    "bootstrap": "~3.3.6"
+  }
+}]]>
+</programlisting>
+</example>
+</para>
+
+
+<para>
+  Running <command>bower2nix</command> will produce something like the
+  following output:
+
+<programlisting language="nix">
+<![CDATA[{ fetchbower, buildEnv }:
+buildEnv { name = "bower-env"; ignoreCollisions = true; paths = [
+  (fetchbower "angular" "1.5.3" "~1.5.0" "1749xb0firxdra4rzadm4q9x90v6pzkbd7xmcyjk6qfza09ykk9y")
+  (fetchbower "bootstrap" "3.3.6" "~3.3.6" "1vvqlpbfcy0k5pncfjaiskj3y6scwifxygfqnw393sjfxiviwmbv")
+  (fetchbower "jquery" "2.2.2" "1.9.1 - 2" "10sp5h98sqwk90y4k6hbdviwqzvzwqf47r3r51pakch5ii2y7js1")
+]; }]]>
+</programlisting>
+</para>
+
+
+<para>
+  Using the <command>bower2nix</command> command line arguments, the
+  output can be redirected to a file. A name like
+  <filename>bower-packages.nix</filename> would be fine.
+</para>
+
+<para>
+  The resulting derivation is a union of all the downloaded Bower
+  packages (and their dependencies). To use it, they still need to be
+  linked together by Bower, which is where
+  <varname>buildBowerComponents</varname> is useful.
+</para>
+</section>
+
+<section xml:id="ssec-build-bower-components"><title><varname>buildBowerComponents</varname> function</title>
+
+  <para>
+  The function is implemented in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/bower-modules/generic/default.nix">
+  <filename>pkgs/development/bower-modules/generic/default.nix</filename></link>.
+  Example usage:
+
+<example xml:id="ex-buildBowerComponents"><title>buildBowerComponents</title>
+<programlisting language="nix">
+bowerComponents = buildBowerComponents {
+  name = "my-web-app";
+  generated = ./bower-packages.nix; <co xml:id="ex-buildBowerComponents-1" />
+  src = myWebApp; <co xml:id="ex-buildBowerComponents-2" />
+};
+</programlisting>
+</example>
+  </para>
+
+<para>
+In <xref linkend="ex-buildBowerComponents" />, the following arguments
+are of special significance to the function:
+
+<calloutlist>
+  <callout arearefs="ex-buildBowerComponents-1">
+    <para>
+      <varname>generated</varname> specifies the file which was created by <command>bower2nix</command>.
+    </para>
+  </callout>
+
+  <callout arearefs="ex-buildBowerComponents-2">
+    <para>
+      <varname>src</varname> is your project's sources. It needs to
+      contain a <filename>bower.json</filename> file.
+    </para>
+  </callout>
+</calloutlist>
+</para>
+
+<para>
+  <varname>buildBowerComponents</varname> will run Bower to link
+  together the output of <command>bower2nix</command>, resulting in a
+  <filename>bower_components</filename> directory which can be used.
+</para>
+
+<para>
+  Here is an example of a web frontend build process using
+  <command>gulp</command>. You might use <command>grunt</command>, or
+  anything else.
+</para>
+
+<example xml:id="ex-bowerGulpFile"><title>Example build script (<filename>gulpfile.js</filename>)</title>
+<programlisting language="javascript">
+<![CDATA[var gulp = require('gulp');
+
+gulp.task('default', [], function () {
+  gulp.start('build');
+});
+
+gulp.task('build', [], function () {
+  console.log("Just a dummy gulp build");
+  gulp
+    .src(["./bower_components/**/*"])
+    .pipe(gulp.dest("./gulpdist/"));
+});]]>
+</programlisting>
+</example>
+
+<example xml:id="ex-buildBowerComponentsDefaultNix">
+  <title>Full example — <filename>default.nix</filename></title>
+<programlisting language="nix">
+{ myWebApp ? { outPath = ./.; name = "myWebApp"; }
+, pkgs ? import &lt;nixpkgs&gt; {}
+}:
+
+pkgs.stdenv.mkDerivation {
+  name = "my-web-app-frontend";
+  src = myWebApp;
+
+  buildInputs = [ pkgs.nodePackages.gulp ];
+
+  bowerComponents = pkgs.buildBowerComponents { <co xml:id="ex-buildBowerComponentsDefault-1" />
+    name = "my-web-app";
+    generated = ./bower-packages.nix;
+    src = myWebApp;
+  };
+
+  buildPhase = ''
+    cp --reflink=auto --no-preserve=mode -R $bowerComponents/bower_components . <co xml:id="ex-buildBowerComponentsDefault-2" />
+    export HOME=$PWD <co xml:id="ex-buildBowerComponentsDefault-3" />
+    ${pkgs.nodePackages.gulp}/bin/gulp build <co xml:id="ex-buildBowerComponentsDefault-4" />
+  '';
+
+  installPhase = "mv gulpdist $out";
+}
+</programlisting>
+</example>
+
+<para>
+A few notes about <xref linkend="ex-buildBowerComponentsDefaultNix" />:
+
+<calloutlist>
+  <callout arearefs="ex-buildBowerComponentsDefault-1">
+    <para>
+      The result of <varname>buildBowerComponents</varname> is an
+      input to the frontend build.
+    </para>
+  </callout>
+
+  <callout arearefs="ex-buildBowerComponentsDefault-2">
+    <para>
+      Whether to symlink or copy the
+      <filename>bower_components</filename> directory depends on the
+      build tool in use. In this case a copy is used to avoid
+      <command>gulp</command> silliness with permissions.
+    </para>
+  </callout>
+
+  <callout arearefs="ex-buildBowerComponentsDefault-3">
+    <para>
+      <command>gulp</command> requires <varname>HOME</varname> to
+      refer to a writeable directory.
+    </para>
+  </callout>
+
+  <callout arearefs="ex-buildBowerComponentsDefault-4">
+    <para>
+      The actual build command. Other tools could be used.
+    </para>
+  </callout>
+</calloutlist>
+</para>
+</section>
+
+<section xml:id="ssec-bower2nix-troubleshooting">
+  <title>Troubleshooting</title>
+
+<variablelist>
+
+  <varlistentry>
+    <term>
+    <literal>ENOCACHE</literal> errors from
+    <varname>buildBowerComponents</varname>
+    </term>
+    <listitem>
+      <para>
+        This means that Bower was looking for a package version which
+        doesn't exist in the generated
+        <filename>bower-packages.nix</filename>.
+      </para>
+      <para>
+        If <filename>bower.json</filename> has been updated, then run
+        <command>bower2nix</command> again.
+      </para>
+      <para>
+        It could also be a bug in <command>bower2nix</command> or
+        <command>fetchbower</command>. If possible, try reformulating
+        the version specification in <filename>bower.json</filename>.
+      </para>
+    </listitem>
+  </varlistentry>
+</variablelist>
+
+</section>
+
+</section>

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -24,6 +24,24 @@ such as Perl or Haskell.  These are described in this chapter.</para>
 <xi:include href="r.xml" /> <!-- generated from ../../pkgs/development/r-modules/README.md  -->
 <xi:include href="qt.xml" />
 <xi:include href="texlive.xml" />
+<xi:include href="bower.xml" />
+
+
+<!--
+<section><title>Haskell</title>
+
+<para>TODO</para>
+
+</section>
+
+
+<section><title>TeX / LaTeX</title>
+
+<para>* Special support for building TeX documents</para>
+
+</section>
+-->
+>>>>>>> 05113a5... nixpkgs manual: Add documentation for bower2nix
 
 
 </chapter>

--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -1,11 +1,26 @@
-{ stdenv, fetch-bower, git }: name: version: target: outputHash: stdenv.mkDerivation {
-  name = "${name}-${version}";
-  buildCommand = ''
-    out=$PWD/out fetch-bower "${name}" "${version}" "${target}"
-    cp -R out $out
-  '';
-  outputHashMode = "recursive";
-  outputHashAlgo = "sha256";
-  inherit outputHash;
-  buildInputs = [git fetch-bower];
-}
+{ stdenv, lib, bower2nix }:
+let
+  bowerVersion = version:
+    let
+      components = lib.splitString "#" version;
+      hash = lib.last components;
+      ver = if builtins.length components == 1 then version else hash;
+    in ver;
+
+  fetchbower = name: version: target: outputHash: stdenv.mkDerivation {
+    name = "${name}-${bowerVersion version}";
+    buildCommand = ''
+      fetch-bower --quiet --out=$PWD/out "${name}" "${target}" "${version}"
+      # In some cases, the result of fetchBower is different depending
+      # on the output directory (e.g. if the bower package contains
+      # symlinks). So use a local output directory before copying to
+      # $out.
+      cp -R out $out
+    '';
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    inherit outputHash;
+    buildInputs = [ bower2nix ];
+  };
+
+in fetchbower

--- a/pkgs/development/bower-modules/generic/default.nix
+++ b/pkgs/development/bower-modules/generic/default.nix
@@ -1,0 +1,49 @@
+{ pkgs }:
+
+{ buildInputs ? [], generated, ... } @ attrs:
+
+let
+  # Fetches the bower packages. `generated` should be the result of a
+  # `bower2nix` command.
+  bowerPackages = import generated {
+    inherit (pkgs) buildEnv fetchbower;
+  };
+
+in pkgs.stdenv.mkDerivation (
+  attrs
+  //
+  {
+    name = "bower_components-" + attrs.name;
+
+    inherit bowerPackages;
+
+    builder = builtins.toFile "builder.sh" ''
+      source $stdenv/setup
+
+      # The project's bower.json is required
+      cp $src/bower.json .
+
+      # Dereference symlinks -- bower doesn't like them
+      cp  --recursive --reflink=auto       \
+          --dereference --no-preserve=mode \
+          $bowerPackages bc
+
+      # Bower install in offline mode -- links together the fetched
+      # bower packages.
+      HOME=$PWD bower \
+          --config.storage.packages=bc/packages \
+          --config.storage.registry=bc/registry \
+          --offline install
+
+      # Sets up a single bower_components directory within
+      # the output derivation.
+      mkdir -p $out
+      mv bower_components $out
+    '';
+
+    buildInputs = buildInputs ++ [
+      pkgs.git
+      pkgs.nodePackages.bower
+    ];
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9150,6 +9150,10 @@ in
 
   yuicompressor = callPackage ../development/tools/yuicompressor { };
 
+  ### DEVELOPMENT / BOWER MODULES (JAVASCRIPT)
+
+  buildBowerComponents = callPackage ../development/bower-modules/generic { };
+
   ### DEVELOPMENT / GO MODULES
 
   go14Packages = callPackage ./go-packages.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -171,7 +171,7 @@ in
   };
 
   fetchbower = callPackage ../build-support/fetchbower {
-    inherit (nodePackages) fetch-bower;
+    inherit (nodePackages) bower2nix;
   };
 
   fetchbzr = callPackage ../build-support/fetchbzr { };

--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -42014,8 +42014,6 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."typescript"."*" =
-    self.by-version."typescript"."1.5.0-alpha";
   by-version."typescript"."1.5.0-alpha" = self.buildNodePackage {
     name = "typescript-1.5.0-alpha";
     version = "1.5.0-alpha";
@@ -42033,7 +42031,28 @@
     os = [ ];
     cpu = [ ];
   };
-  "typescript" = self.by-version."typescript"."1.5.0-alpha";
+  by-version."typescript"."1.8.9" = self.buildNodePackage {
+    name = "typescript-1.8.9";
+    version = "1.8.9";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/typescript/-/typescript-1.8.9.tgz";
+      name = "typescript-1.8.9.tgz";
+      sha1 = "b3b3a74059fd31cbd3ecad95d62465939e7ed5fa";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."typescript"."*" =
+    self.by-version."typescript"."1.8.9";
+  by-spec."typescript"."~1.8.9" =
+    self.by-version."typescript"."1.8.9";
+  "typescript" = self.by-version."typescript"."1.8.9";
   by-spec."typewiselite"."~1.0.0" =
     self.by-version."typewiselite"."1.0.0";
   by-version."typewiselite"."1.0.0" = self.buildNodePackage {

--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -4650,35 +4650,30 @@
     cpu = [ ];
   };
   by-spec."bower2nix"."*" =
-    self.by-version."bower2nix"."2.1.0";
-  by-version."bower2nix"."2.1.0" = self.buildNodePackage {
-    name = "bower2nix-2.1.0";
-    version = "2.1.0";
-    bin = true;
+    self.by-version."bower2nix"."3.0.1";
+  by-version."bower2nix"."3.0.1" = self.buildNodePackage {
+    name = "bower2nix-3.0.1";
+    version = "3.0.1";
     src = fetchurl {
-      url = "http://registry.npmjs.org/bower2nix/-/bower2nix-2.1.0.tgz";
-      name = "bower2nix-2.1.0.tgz";
-      sha1 = "213f507a729b20a1c3cb48f995a034f9c05f53e6";
+      url = "http://registry.npmjs.org/bower2nix/-/bower2nix-3.0.1.tgz";
+      name = "bower2nix-3.0.1.tgz";
+      sha256 = "0jfrz2mvnx3fp2p76dcnw18c1vajladbqcrzapf93jh8h6715msi";
     };
     deps = {
-      "temp-0.6.0" = self.by-version."temp"."0.6.0";
-      "fs.extra-1.3.2" = self.by-version."fs.extra"."1.3.2";
-      "bower-json-0.4.0" = self.by-version."bower-json"."0.4.0";
+      "argparse-1.0.4" = self.by-version."argparse"."1.0.4";
+      "bower-1.7.7" = self.by-version."bower"."1.7.7";
       "bower-endpoint-parser-0.2.1" = self.by-version."bower-endpoint-parser"."0.2.1";
+      "bower-json-0.6.0" = self.by-version."bower-json"."0.6.0";
       "bower-logger-0.2.1" = self.by-version."bower-logger"."0.2.1";
-      "bower-1.4.1" = self.by-version."bower"."1.4.1";
-      "argparse-0.1.15" = self.by-version."argparse"."0.1.15";
-      "clone-0.1.11" = self.by-version."clone"."0.1.11";
-      "semver-2.3.2" = self.by-version."semver"."2.3.2";
-      "fetch-bower-2.0.0" = self.by-version."fetch-bower"."2.0.0";
+      "fs-extra-0.26.7" = self.by-version."fs-extra"."0.26.7";
+      "lodash-4.2.1" = self.by-version."lodash"."4.2.1";
+      "promised-temp-0.1.0" = self.by-version."promised-temp"."0.1.0";
+      "semver-5.1.0" = self.by-version."semver"."5.1.0";
+      "temp-0.8.3" = self.by-version."temp"."0.8.3";
+      "glob-6.0.4" = self.by-version."glob"."6.0.4";
     };
-    optionalDependencies = {
-    };
-    peerDependencies = [];
-    os = [ ];
-    cpu = [ ];
   };
-  "bower2nix" = self.by-version."bower2nix"."2.1.0";
+  "bower2nix" = self.by-version."bower2nix"."3.0.1";
   by-spec."bplist-parser"."0.0.6" =
     self.by-version."bplist-parser"."0.0.6";
   by-version."bplist-parser"."0.0.6" = self.buildNodePackage {
@@ -14812,32 +14807,6 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."fetch-bower"."*" =
-    self.by-version."fetch-bower"."2.0.0";
-  by-version."fetch-bower"."2.0.0" = self.buildNodePackage {
-    name = "fetch-bower-2.0.0";
-    version = "2.0.0";
-    bin = true;
-    src = fetchurl {
-      url = "http://registry.npmjs.org/fetch-bower/-/fetch-bower-2.0.0.tgz";
-      name = "fetch-bower-2.0.0.tgz";
-      sha1 = "c027feb75a512001d1287bbfb3ffaafba67eb92f";
-    };
-    deps = {
-      "bower-endpoint-parser-0.2.1" = self.by-version."bower-endpoint-parser"."0.2.1";
-      "bower-logger-0.2.1" = self.by-version."bower-logger"."0.2.1";
-      "bower-1.4.1" = self.by-version."bower"."1.4.1";
-      "glob-3.2.11" = self.by-version."glob"."3.2.11";
-    };
-    optionalDependencies = {
-    };
-    peerDependencies = [];
-    os = [ ];
-    cpu = [ ];
-  };
-  "fetch-bower" = self.by-version."fetch-bower"."2.0.0";
-  by-spec."fetch-bower".">=2 <3" =
-    self.by-version."fetch-bower"."2.0.0";
   by-spec."fields"."~0.1.22" =
     self.by-version."fields"."0.1.23";
   by-version."fields"."0.1.23" = self.buildNodePackage {
@@ -45546,6 +45515,3919 @@
     };
     deps = {
       "tape-0.2.2" = self.by-version."tape"."0.2.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ansi-regex"."^2.0.0" =
+    self.by-version."ansi-regex"."2.0.0";
+  by-version."ansi-regex"."2.0.0" = self.buildNodePackage {
+    name = "ansi-regex-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz";
+      name = "ansi-regex-2.0.0.tgz";
+      sha1 = "c5061b6e0ef8a81775e50f5d66151bf6bf371107";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ansi-styles"."^2.1.0" =
+    self.by-version."ansi-styles"."2.2.0";
+  by-version."ansi-styles"."2.2.0" = self.buildNodePackage {
+    name = "ansi-styles-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz";
+      name = "ansi-styles-2.2.0.tgz";
+      sha1 = "c59191936e6ed1c1315a4b6b6b97f3acfbfa68b0";
+    };
+    deps = {
+      "color-convert-1.0.0" = self.by-version."color-convert"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."argparse"."1.0.4" =
+    self.by-version."argparse"."1.0.4";
+  by-version."argparse"."1.0.4" = self.buildNodePackage {
+    name = "argparse-1.0.4";
+    version = "1.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz";
+      name = "argparse-1.0.4.tgz";
+      sha1 = "2b12247b933001971addcbfe4e67d20fd395bbf4";
+    };
+    deps = {
+      "lodash-4.6.1" = self.by-version."lodash"."4.6.1";
+      "sprintf-js-1.0.3" = self.by-version."sprintf-js"."1.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "argparse" = self.by-version."argparse"."1.0.4";
+  by-spec."argparse"."^1.0.2" =
+    self.by-version."argparse"."1.0.7";
+  by-version."argparse"."1.0.7" = self.buildNodePackage {
+    name = "argparse-1.0.7";
+    version = "1.0.7";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz";
+      name = "argparse-1.0.7.tgz";
+      sha1 = "c289506480557810f14a8bc62d7a06f63ed7f951";
+    };
+    deps = {
+      "sprintf-js-1.0.3" = self.by-version."sprintf-js"."1.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."array-find-index"."^1.0.0" =
+    self.by-version."array-find-index"."1.0.1";
+  by-version."array-find-index"."1.0.1" = self.buildNodePackage {
+    name = "array-find-index-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz";
+      name = "array-find-index-1.0.1.tgz";
+      sha1 = "0bc25ddac941ec8a496ae258fd4ac188003ef3af";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."asn1".">=0.2.3 <0.3.0" =
+    self.by-version."asn1"."0.2.3";
+  by-version."asn1"."0.2.3" = self.buildNodePackage {
+    name = "asn1-0.2.3";
+    version = "0.2.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz";
+      name = "asn1-0.2.3.tgz";
+      sha1 = "dac8787713c9966849fc8180777ebe9c1ddf3b86";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."assert-plus".">=0.2.0 <0.3.0" =
+    self.by-version."assert-plus"."0.2.0";
+  by-version."assert-plus"."0.2.0" = self.buildNodePackage {
+    name = "assert-plus-0.2.0";
+    version = "0.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz";
+      name = "assert-plus-0.2.0.tgz";
+      sha1 = "d74e1b87e7affc0db8aadb7021f3fe48101ab234";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."assert-plus"."^0.2.0" =
+    self.by-version."assert-plus"."0.2.0";
+  by-spec."assert-plus"."^1.0.0" =
+    self.by-version."assert-plus"."1.0.0";
+  by-version."assert-plus"."1.0.0" = self.buildNodePackage {
+    name = "assert-plus-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
+      name = "assert-plus-1.0.0.tgz";
+      sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."assertion-error"."^1.0.0" =
+    self.by-version."assertion-error"."1.0.1";
+  by-version."assertion-error"."1.0.1" = self.buildNodePackage {
+    name = "assertion-error-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz";
+      name = "assertion-error-1.0.1.tgz";
+      sha1 = "35aaeec33097f11f42399ecadf33faccd27f5c4c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."async"."^1.5.2" =
+    self.by-version."async"."1.5.2";
+  by-version."async"."1.5.2" = self.buildNodePackage {
+    name = "async-1.5.2";
+    version = "1.5.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/async/-/async-1.5.2.tgz";
+      name = "async-1.5.2.tgz";
+      sha1 = "ec6a61ae56480c0c3cb241c95618e20892f9672a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."aws-sign2"."~0.6.0" =
+    self.by-version."aws-sign2"."0.6.0";
+  by-version."aws-sign2"."0.6.0" = self.buildNodePackage {
+    name = "aws-sign2-0.6.0";
+    version = "0.6.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz";
+      name = "aws-sign2-0.6.0.tgz";
+      sha1 = "14342dd38dbcc94d0e5b87d763cd63612c0e794f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."aws4"."^1.2.1" =
+    self.by-version."aws4"."1.3.2";
+  by-version."aws4"."1.3.2" = self.buildNodePackage {
+    name = "aws4-1.3.2";
+    version = "1.3.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz";
+      name = "aws4-1.3.2.tgz";
+      sha1 = "d39e0bee412ced0e8ed94a23e314f313a95b9fd1";
+    };
+    deps = {
+      "lru-cache-4.0.1" = self.by-version."lru-cache"."4.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."balanced-match"."^0.3.0" =
+    self.by-version."balanced-match"."0.3.0";
+  by-version."balanced-match"."0.3.0" = self.buildNodePackage {
+    name = "balanced-match-0.3.0";
+    version = "0.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz";
+      name = "balanced-match-0.3.0.tgz";
+      sha1 = "a91cdd1ebef1a86659e70ff4def01625fc2d6756";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."bl"."^0.9.3" =
+    self.by-version."bl"."0.9.5";
+  by-version."bl"."0.9.5" = self.buildNodePackage {
+    name = "bl-0.9.5";
+    version = "0.9.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/bl/-/bl-0.9.5.tgz";
+      name = "bl-0.9.5.tgz";
+      sha1 = "c06b797af085ea00bc527afc8efcf11de2232054";
+    };
+    deps = {
+      "readable-stream-1.0.33" = self.by-version."readable-stream"."1.0.33";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."bl"."~1.0.0" =
+    self.by-version."bl"."1.0.3";
+  by-version."bl"."1.0.3" = self.buildNodePackage {
+    name = "bl-1.0.3";
+    version = "1.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/bl/-/bl-1.0.3.tgz";
+      name = "bl-1.0.3.tgz";
+      sha1 = "fc5421a28fd4226036c3b3891a66a25bc64d226e";
+    };
+    deps = {
+      "readable-stream-2.0.6" = self.by-version."readable-stream"."2.0.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."bluebird"."~1.2.4" =
+    self.by-version."bluebird"."1.2.4";
+  by-version."bluebird"."1.2.4" = self.buildNodePackage {
+    name = "bluebird-1.2.4";
+    version = "1.2.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz";
+      name = "bluebird-1.2.4.tgz";
+      sha1 = "5985ec23cb6ff1a5834cc6447b3c5ef010fd321a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."boom"."2.10.1" = self.buildNodePackage {
+    name = "boom-2.10.1";
+    version = "2.10.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz";
+      name = "boom-2.10.1.tgz";
+      sha1 = "39c8918ceff5799f83f9492a848f625add0c766f";
+    };
+    deps = {
+      "hoek-2.16.3" = self.by-version."hoek"."2.16.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "bower-endpoint-parser" = self.by-version."bower-endpoint-parser"."0.2.1";
+  by-spec."bower-json"."0.6.0" =
+    self.by-version."bower-json"."0.6.0";
+  by-version."bower-json"."0.6.0" = self.buildNodePackage {
+    name = "bower-json-0.6.0";
+    version = "0.6.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/bower-json/-/bower-json-0.6.0.tgz";
+      name = "bower-json-0.6.0.tgz";
+      sha1 = "326579b23c33e4ea828e4763c55cd81fd7650329";
+    };
+    deps = {
+      "deep-extend-0.4.1" = self.by-version."deep-extend"."0.4.1";
+      "ext-name-3.0.0" = self.by-version."ext-name"."3.0.0";
+      "graceful-fs-3.0.8" = self.by-version."graceful-fs"."3.0.8";
+      "intersect-1.0.1" = self.by-version."intersect"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "bower-json" = self.by-version."bower-json"."0.6.0";
+  "bower-logger" = self.by-version."bower-logger"."0.2.1";
+  by-version."brace-expansion"."1.1.3" = self.buildNodePackage {
+    name = "brace-expansion-1.1.3";
+    version = "1.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz";
+      name = "brace-expansion-1.1.3.tgz";
+      sha1 = "46bff50115d47fc9ab89854abb87d98078a10991";
+    };
+    deps = {
+      "balanced-match-0.3.0" = self.by-version."balanced-match"."0.3.0";
+      "concat-map-0.0.1" = self.by-version."concat-map"."0.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."builtin-modules"."^1.0.0" =
+    self.by-version."builtin-modules"."1.1.1";
+  by-version."builtin-modules"."1.1.1" = self.buildNodePackage {
+    name = "builtin-modules-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz";
+      name = "builtin-modules-1.1.1.tgz";
+      sha1 = "270f076c5a72c02f5b65a47df94c5fe3a278892f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."camelcase"."^2.0.0" =
+    self.by-version."camelcase"."2.1.1";
+  by-version."camelcase"."2.1.1" = self.buildNodePackage {
+    name = "camelcase-2.1.1";
+    version = "2.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz";
+      name = "camelcase-2.1.1.tgz";
+      sha1 = "7c1d16d679a1bbe59ca02cacecfb011e201f5a1f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."camelcase-keys"."^2.0.0" =
+    self.by-version."camelcase-keys"."2.1.0";
+  by-version."camelcase-keys"."2.1.0" = self.buildNodePackage {
+    name = "camelcase-keys-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz";
+      name = "camelcase-keys-2.1.0.tgz";
+      sha1 = "308beeaffdf28119051efa1d932213c91b8f92e7";
+    };
+    deps = {
+      "camelcase-2.1.1" = self.by-version."camelcase"."2.1.1";
+      "map-obj-1.0.1" = self.by-version."map-obj"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."caseless"."~0.11.0" =
+    self.by-version."caseless"."0.11.0";
+  by-version."caseless"."0.11.0" = self.buildNodePackage {
+    name = "caseless-0.11.0";
+    version = "0.11.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz";
+      name = "caseless-0.11.0.tgz";
+      sha1 = "715b96ea9841593cc33067923f5ec60ebda4f7d7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."chalk"."1.1.1" = self.buildNodePackage {
+    name = "chalk-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz";
+      name = "chalk-1.1.1.tgz";
+      sha1 = "509afb67066e7499f7eb3535c77445772ae2d019";
+    };
+    deps = {
+      "ansi-styles-2.2.0" = self.by-version."ansi-styles"."2.2.0";
+      "escape-string-regexp-1.0.5" = self.by-version."escape-string-regexp"."1.0.5";
+      "has-ansi-2.0.0" = self.by-version."has-ansi"."2.0.0";
+      "strip-ansi-3.0.1" = self.by-version."strip-ansi"."3.0.1";
+      "supports-color-2.0.0" = self.by-version."supports-color"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."chalk"."^1.1.1" =
+    self.by-version."chalk"."1.1.1";
+  by-spec."color-convert"."^1.0.0" =
+    self.by-version."color-convert"."1.0.0";
+  by-version."color-convert"."1.0.0" = self.buildNodePackage {
+    name = "color-convert-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz";
+      name = "color-convert-1.0.0.tgz";
+      sha1 = "3c26fcd885d272d45beacf6e41baba75c89a8579";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."colors"."^1.1.0" =
+    self.by-version."colors"."1.1.2";
+  by-version."colors"."1.1.2" = self.buildNodePackage {
+    name = "colors-1.1.2";
+    version = "1.1.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz";
+      name = "colors-1.1.2.tgz";
+      sha1 = "168a4701756b6a7f51a12ce0c97bfa28c084ed63";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."combined-stream"."^1.0.5" =
+    self.by-version."combined-stream"."1.0.5";
+  by-version."combined-stream"."1.0.5" = self.buildNodePackage {
+    name = "combined-stream-1.0.5";
+    version = "1.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz";
+      name = "combined-stream-1.0.5.tgz";
+      sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
+    };
+    deps = {
+      "delayed-stream-1.0.0" = self.by-version."delayed-stream"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."combined-stream"."~1.0.5" =
+    self.by-version."combined-stream"."1.0.5";
+  by-spec."commander"."^2.9.0" =
+    self.by-version."commander"."2.9.0";
+  by-version."commander"."2.9.0" = self.buildNodePackage {
+    name = "commander-2.9.0";
+    version = "2.9.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
+      name = "commander-2.9.0.tgz";
+      sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
+    };
+    deps = {
+      "graceful-readlink-1.0.1" = self.by-version."graceful-readlink"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."core-util-is"."1.0.2" = self.buildNodePackage {
+    name = "core-util-is-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz";
+      name = "core-util-is-1.0.2.tgz";
+      sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."cryptiles"."2.0.5" = self.buildNodePackage {
+    name = "cryptiles-2.0.5";
+    version = "2.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz";
+      name = "cryptiles-2.0.5.tgz";
+      sha1 = "3bdfecdc608147c1c67202fa291e7dca59eaa3b8";
+    };
+    deps = {
+      "boom-2.10.1" = self.by-version."boom"."2.10.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."dashdash".">=1.10.1 <2.0.0" =
+    self.by-version."dashdash"."1.13.0";
+  by-version."dashdash"."1.13.0" = self.buildNodePackage {
+    name = "dashdash-1.13.0";
+    version = "1.13.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz";
+      name = "dashdash-1.13.0.tgz";
+      sha1 = "a5aae6fd9d8e156624eb0dd9259eb12ba245385a";
+    };
+    deps = {
+      "assert-plus-1.0.0" = self.by-version."assert-plus"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."debug"."2.2.0" = self.buildNodePackage {
+    name = "debug-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz";
+      name = "debug-2.2.0.tgz";
+      sha1 = "f87057e995b1a1f6ae6a4960664137bc56f039da";
+    };
+    deps = {
+      "ms-0.7.1" = self.by-version."ms"."0.7.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."decamelize"."^1.1.2" =
+    self.by-version."decamelize"."1.2.0";
+  by-version."decamelize"."1.2.0" = self.buildNodePackage {
+    name = "decamelize-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz";
+      name = "decamelize-1.2.0.tgz";
+      sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."deep-extend"."^0.4.0" =
+    self.by-version."deep-extend"."0.4.1";
+  by-version."deep-extend"."0.4.1" = self.buildNodePackage {
+    name = "deep-extend-0.4.1";
+    version = "0.4.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz";
+      name = "deep-extend-0.4.1.tgz";
+      sha1 = "efe4113d08085f4e6f9687759810f807469e2253";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."deep-extend"."~0.4.0" =
+    self.by-version."deep-extend"."0.4.1";
+  by-spec."deep-freeze"."0.0.1" =
+    self.by-version."deep-freeze"."0.0.1";
+  by-version."deep-freeze"."0.0.1" = self.buildNodePackage {
+    name = "deep-freeze-0.0.1";
+    version = "0.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz";
+      name = "deep-freeze-0.0.1.tgz";
+      sha1 = "3a0b0005de18672819dfd38cd31f91179c893e84";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."definition-header"."~0.1.0" =
+    self.by-version."definition-header"."0.1.0";
+  by-version."definition-header"."0.1.0" = self.buildNodePackage {
+    name = "definition-header-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/definition-header/-/definition-header-0.1.0.tgz";
+      name = "definition-header-0.1.0.tgz";
+      sha1 = "01445ff4ca663114cbf2c5a1131f13bb544eb5dd";
+    };
+    deps = {
+      "joi-4.9.0" = self.by-version."joi"."4.9.0";
+      "joi-assert-0.0.3" = self.by-version."joi-assert"."0.0.3";
+      "parsimmon-0.5.1" = self.by-version."parsimmon"."0.5.1";
+      "xregexp-2.0.0" = self.by-version."xregexp"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."delayed-stream"."~1.0.0" =
+    self.by-version."delayed-stream"."1.0.0";
+  by-version."delayed-stream"."1.0.0" = self.buildNodePackage {
+    name = "delayed-stream-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
+      name = "delayed-stream-1.0.0.tgz";
+      sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."detect-indent"."^0.2.0" =
+    self.by-version."detect-indent"."0.2.0";
+  by-version."detect-indent"."0.2.0" = self.buildNodePackage {
+    name = "detect-indent-0.2.0";
+    version = "0.2.0";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz";
+      name = "detect-indent-0.2.0.tgz";
+      sha1 = "042914498979ac2d9f3c73e4ff3e6877d3bc92b6";
+    };
+    deps = {
+      "get-stdin-0.1.0" = self.by-version."get-stdin"."0.1.0";
+      "minimist-0.1.0" = self.by-version."minimist"."0.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."diff"."^1.4.0" =
+    self.by-version."diff"."1.4.0";
+  by-version."diff"."1.4.0" = self.buildNodePackage {
+    name = "diff-1.4.0";
+    version = "1.4.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/diff/-/diff-1.4.0.tgz";
+      name = "diff-1.4.0.tgz";
+      sha1 = "7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."duplexify"."3.4.3" = self.buildNodePackage {
+    name = "duplexify-3.4.3";
+    version = "3.4.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz";
+      name = "duplexify-3.4.3.tgz";
+      sha1 = "af6a7b10d928b095f8ad854d072bb90998db850d";
+    };
+    deps = {
+      "end-of-stream-1.0.0" = self.by-version."end-of-stream"."1.0.0";
+      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+      "readable-stream-2.0.6" = self.by-version."readable-stream"."2.0.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ecc-jsbn".">=0.0.1 <1.0.0" =
+    self.by-version."ecc-jsbn"."0.1.1";
+  by-version."ecc-jsbn"."0.1.1" = self.buildNodePackage {
+    name = "ecc-jsbn-0.1.1";
+    version = "0.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz";
+      name = "ecc-jsbn-0.1.1.tgz";
+      sha1 = "0fc73a9ed5f0d53c38193398523ef7e543777505";
+    };
+    deps = {
+      "jsbn-0.1.0" = self.by-version."jsbn"."0.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ends-with"."^0.2.0" =
+    self.by-version."ends-with"."0.2.0";
+  by-version."ends-with"."0.2.0" = self.buildNodePackage {
+    name = "ends-with-0.2.0";
+    version = "0.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz";
+      name = "ends-with-0.2.0.tgz";
+      sha1 = "2f9da98d57a50cfda4571ce4339000500f4e6b8a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."error-ex"."^1.2.0" =
+    self.by-version."error-ex"."1.3.0";
+  by-version."error-ex"."1.3.0" = self.buildNodePackage {
+    name = "error-ex-1.3.0";
+    version = "1.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz";
+      name = "error-ex-1.3.0.tgz";
+      sha1 = "e67b43f3e82c96ea3a584ffee0b9fc3325d802d9";
+    };
+    deps = {
+      "is-arrayish-0.2.1" = self.by-version."is-arrayish"."0.2.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."escape-string-regexp"."1.0.5" = self.buildNodePackage {
+    name = "escape-string-regexp-1.0.5";
+    version = "1.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+      name = "escape-string-regexp-1.0.5.tgz";
+      sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."esprima"."^2.6.0" =
+    self.by-version."esprima"."2.7.2";
+  by-version."esprima"."2.7.2" = self.buildNodePackage {
+    name = "esprima-2.7.2";
+    version = "2.7.2";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz";
+      name = "esprima-2.7.2.tgz";
+      sha1 = "f43be543609984eae44c933ac63352a6af35f339";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."event-stream"."~3.1.5" =
+    self.by-version."event-stream"."3.1.7";
+  by-version."event-stream"."3.1.7" = self.buildNodePackage {
+    name = "event-stream-3.1.7";
+    version = "3.1.7";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz";
+      name = "event-stream-3.1.7.tgz";
+      sha1 = "b4c540012d0fe1498420f3d8946008db6393c37a";
+    };
+    deps = {
+      "through-2.3.8" = self.by-version."through"."2.3.8";
+      "duplexer-0.1.1" = self.by-version."duplexer"."0.1.1";
+      "from-0.1.3" = self.by-version."from"."0.1.3";
+      "map-stream-0.1.0" = self.by-version."map-stream"."0.1.0";
+      "pause-stream-0.0.11" = self.by-version."pause-stream"."0.0.11";
+      "split-0.2.10" = self.by-version."split"."0.2.10";
+      "stream-combiner-0.0.4" = self.by-version."stream-combiner"."0.0.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ext-list"."^2.0.0" =
+    self.by-version."ext-list"."2.2.0";
+  by-version."ext-list"."2.2.0" = self.buildNodePackage {
+    name = "ext-list-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ext-list/-/ext-list-2.2.0.tgz";
+      name = "ext-list-2.2.0.tgz";
+      sha1 = "a3e6fdeab978bca7a320c7e786f537083fc30055";
+    };
+    deps = {
+      "got-2.9.2" = self.by-version."got"."2.9.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ext-name"."^3.0.0" =
+    self.by-version."ext-name"."3.0.0";
+  by-version."ext-name"."3.0.0" = self.buildNodePackage {
+    name = "ext-name-3.0.0";
+    version = "3.0.0";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ext-name/-/ext-name-3.0.0.tgz";
+      name = "ext-name-3.0.0.tgz";
+      sha1 = "07e4418737cb1f513c32c6ea48d8b8c8e0471abb";
+    };
+    deps = {
+      "ends-with-0.2.0" = self.by-version."ends-with"."0.2.0";
+      "ext-list-2.2.0" = self.by-version."ext-list"."2.2.0";
+      "meow-3.7.0" = self.by-version."meow"."3.7.0";
+      "sort-keys-length-1.0.1" = self.by-version."sort-keys-length"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."extend"."~3.0.0" =
+    self.by-version."extend"."3.0.0";
+  by-version."extend"."3.0.0" = self.buildNodePackage {
+    name = "extend-3.0.0";
+    version = "3.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
+      name = "extend-3.0.0.tgz";
+      sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."extsprintf"."1.0.3" =
+    self.by-version."extsprintf"."1.0.3";
+  by-version."extsprintf"."1.0.3" = self.buildNodePackage {
+    name = "extsprintf-1.0.3";
+    version = "1.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.3.tgz";
+      name = "extsprintf-1.0.3.tgz";
+      sha1 = "3310ca8ced5205e5234766b0b2744ea5b2788d67";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."find-up"."^1.0.0" =
+    self.by-version."find-up"."1.1.2";
+  by-version."find-up"."1.1.2" = self.buildNodePackage {
+    name = "find-up-1.1.2";
+    version = "1.1.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz";
+      name = "find-up-1.1.2.tgz";
+      sha1 = "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f";
+    };
+    deps = {
+      "path-exists-2.1.0" = self.by-version."path-exists"."2.1.0";
+      "pinkie-promise-2.0.0" = self.by-version."pinkie-promise"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."foreach"."^2.0.4" =
+    self.by-version."foreach"."2.0.5";
+  by-version."foreach"."2.0.5" = self.buildNodePackage {
+    name = "foreach-2.0.5";
+    version = "2.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz";
+      name = "foreach-2.0.5.tgz";
+      sha1 = "0bee005018aeb260d0a3af3ae658dd0136ec1b99";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."form-data"."~1.0.0-rc3" =
+    self.by-version."form-data"."1.0.0-rc4";
+  by-version."form-data"."1.0.0-rc4" = self.buildNodePackage {
+    name = "form-data-1.0.0-rc4";
+    version = "1.0.0-rc4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz";
+      name = "form-data-1.0.0-rc4.tgz";
+      sha1 = "05ac6bc22227b43e4461f488161554699d4f8b5e";
+    };
+    deps = {
+      "async-1.5.2" = self.by-version."async"."1.5.2";
+      "combined-stream-1.0.5" = self.by-version."combined-stream"."1.0.5";
+      "mime-types-2.1.10" = self.by-version."mime-types"."2.1.10";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."from"."~0" =
+    self.by-version."from"."0.1.3";
+  by-version."from"."0.1.3" = self.buildNodePackage {
+    name = "from-0.1.3";
+    version = "0.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/from/-/from-0.1.3.tgz";
+      name = "from-0.1.3.tgz";
+      sha1 = "ef63ac2062ac32acf7862e0d40b44b896f22f3bc";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."fs-extra"."~0.26.5" =
+    self.by-version."fs-extra"."0.26.7";
+  by-version."fs-extra"."0.26.7" = self.buildNodePackage {
+    name = "fs-extra-0.26.7";
+    version = "0.26.7";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz";
+      name = "fs-extra-0.26.7.tgz";
+      sha1 = "9ae1fdd94897798edab76d0918cf42d0c3184fa9";
+    };
+    deps = {
+      "graceful-fs-4.1.3" = self.by-version."graceful-fs"."4.1.3";
+      "jsonfile-2.2.3" = self.by-version."jsonfile"."2.2.3";
+      "klaw-1.1.3" = self.by-version."klaw"."1.1.3";
+      "path-is-absolute-1.0.0" = self.by-version."path-is-absolute"."1.0.0";
+      "rimraf-2.5.2" = self.by-version."rimraf"."2.5.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "fs-extra" = self.by-version."fs-extra"."0.26.7";
+  by-version."generate-object-property"."1.2.0" = self.buildNodePackage {
+    name = "generate-object-property-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz";
+      name = "generate-object-property-1.2.0.tgz";
+      sha1 = "9c0e1c40308ce804f4783618b937fa88f99d50d0";
+    };
+    deps = {
+      "is-property-1.0.2" = self.by-version."is-property"."1.0.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."get-stdin"."^0.1.0" =
+    self.by-version."get-stdin"."0.1.0";
+  by-version."get-stdin"."0.1.0" = self.buildNodePackage {
+    name = "get-stdin-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz";
+      name = "get-stdin-0.1.0.tgz";
+      sha1 = "5998af24aafc802d15c82c685657eeb8b10d4a91";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."glob"."6.0.4" =
+    self.by-version."glob"."6.0.4";
+  by-version."glob"."6.0.4" = self.buildNodePackage {
+    name = "glob-6.0.4";
+    version = "6.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/glob/-/glob-6.0.4.tgz";
+      name = "glob-6.0.4.tgz";
+      sha1 = "0f08860f6a155127b2fadd4f9ce24b1aab6e4d22";
+    };
+    deps = {
+      "inflight-1.0.4" = self.by-version."inflight"."1.0.4";
+      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+      "minimatch-3.0.0" = self.by-version."minimatch"."3.0.0";
+      "once-1.3.3" = self.by-version."once"."1.3.3";
+      "path-is-absolute-1.0.0" = self.by-version."path-is-absolute"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "glob" = self.by-version."glob"."6.0.4";
+  by-spec."glob"."^4.0.6" =
+    self.by-version."glob"."4.5.3";
+  by-spec."glob"."^7.0.0" =
+    self.by-version."glob"."7.0.3";
+  by-version."glob"."7.0.3" = self.buildNodePackage {
+    name = "glob-7.0.3";
+    version = "7.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/glob/-/glob-7.0.3.tgz";
+      name = "glob-7.0.3.tgz";
+      sha1 = "0aa235931a4a96ac13d60ffac2fb877bd6ed4f58";
+    };
+    deps = {
+      "inflight-1.0.4" = self.by-version."inflight"."1.0.4";
+      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+      "minimatch-3.0.0" = self.by-version."minimatch"."3.0.0";
+      "once-1.3.3" = self.by-version."once"."1.3.3";
+      "path-is-absolute-1.0.0" = self.by-version."path-is-absolute"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."got"."^2.7.2" =
+    self.by-version."got"."2.9.2";
+  by-version."got"."2.9.2" = self.buildNodePackage {
+    name = "got-2.9.2";
+    version = "2.9.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/got/-/got-2.9.2.tgz";
+      name = "got-2.9.2.tgz";
+      sha1 = "2e1ee58ea1e8d201e25ae580b96e63c15fefd4ee";
+    };
+    deps = {
+      "duplexify-3.4.3" = self.by-version."duplexify"."3.4.3";
+      "infinity-agent-2.0.3" = self.by-version."infinity-agent"."2.0.3";
+      "is-stream-1.0.1" = self.by-version."is-stream"."1.0.1";
+      "lowercase-keys-1.0.0" = self.by-version."lowercase-keys"."1.0.0";
+      "nested-error-stacks-1.0.2" = self.by-version."nested-error-stacks"."1.0.2";
+      "object-assign-2.1.1" = self.by-version."object-assign"."2.1.1";
+      "prepend-http-1.0.3" = self.by-version."prepend-http"."1.0.3";
+      "read-all-stream-2.2.0" = self.by-version."read-all-stream"."2.2.0";
+      "statuses-1.2.1" = self.by-version."statuses"."1.2.1";
+      "timed-out-2.0.0" = self.by-version."timed-out"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."got"."^3.2.0" =
+    self.by-version."got"."3.3.1";
+  by-version."got"."3.3.1" = self.buildNodePackage {
+    name = "got-3.3.1";
+    version = "3.3.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/got/-/got-3.3.1.tgz";
+      name = "got-3.3.1.tgz";
+      sha1 = "e5d0ed4af55fc3eef4d56007769d98192bcb2eca";
+    };
+    deps = {
+      "duplexify-3.4.3" = self.by-version."duplexify"."3.4.3";
+      "infinity-agent-2.0.3" = self.by-version."infinity-agent"."2.0.3";
+      "is-redirect-1.0.0" = self.by-version."is-redirect"."1.0.0";
+      "is-stream-1.0.1" = self.by-version."is-stream"."1.0.1";
+      "lowercase-keys-1.0.0" = self.by-version."lowercase-keys"."1.0.0";
+      "nested-error-stacks-1.0.2" = self.by-version."nested-error-stacks"."1.0.2";
+      "object-assign-3.0.0" = self.by-version."object-assign"."3.0.0";
+      "prepend-http-1.0.3" = self.by-version."prepend-http"."1.0.3";
+      "read-all-stream-3.1.0" = self.by-version."read-all-stream"."3.1.0";
+      "timed-out-2.0.0" = self.by-version."timed-out"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."graceful-fs"."3.0.8" = self.buildNodePackage {
+    name = "graceful-fs-3.0.8";
+    version = "3.0.8";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz";
+      name = "graceful-fs-3.0.8.tgz";
+      sha1 = "ce813e725fa82f7e6147d51c9a5ca68270551c22";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."graceful-fs"."^4.1.2" =
+    self.by-version."graceful-fs"."4.1.3";
+  by-version."graceful-fs"."4.1.3" = self.buildNodePackage {
+    name = "graceful-fs-4.1.3";
+    version = "4.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz";
+      name = "graceful-fs-4.1.3.tgz";
+      sha1 = "92033ce11113c41e2628d61fdfa40bc10dc0155c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."har-validator"."~2.0.6" =
+    self.by-version."har-validator"."2.0.6";
+  by-version."har-validator"."2.0.6" = self.buildNodePackage {
+    name = "har-validator-2.0.6";
+    version = "2.0.6";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz";
+      name = "har-validator-2.0.6.tgz";
+      sha1 = "cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d";
+    };
+    deps = {
+      "chalk-1.1.1" = self.by-version."chalk"."1.1.1";
+      "commander-2.9.0" = self.by-version."commander"."2.9.0";
+      "is-my-json-valid-2.13.1" = self.by-version."is-my-json-valid"."2.13.1";
+      "pinkie-promise-2.0.0" = self.by-version."pinkie-promise"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."has-ansi"."^2.0.0" =
+    self.by-version."has-ansi"."2.0.0";
+  by-version."has-ansi"."2.0.0" = self.buildNodePackage {
+    name = "has-ansi-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
+      name = "has-ansi-2.0.0.tgz";
+      sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
+    };
+    deps = {
+      "ansi-regex-2.0.0" = self.by-version."ansi-regex"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."hawk"."~3.1.0" =
+    self.by-version."hawk"."3.1.3";
+  by-version."hawk"."3.1.3" = self.buildNodePackage {
+    name = "hawk-3.1.3";
+    version = "3.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz";
+      name = "hawk-3.1.3.tgz";
+      sha1 = "078444bd7c1640b0fe540d2c9b73d59678e8e1c4";
+    };
+    deps = {
+      "hoek-2.16.3" = self.by-version."hoek"."2.16.3";
+      "boom-2.10.1" = self.by-version."boom"."2.10.1";
+      "cryptiles-2.0.5" = self.by-version."cryptiles"."2.0.5";
+      "sntp-1.0.9" = self.by-version."sntp"."1.0.9";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."hoek"."2.16.3" = self.buildNodePackage {
+    name = "hoek-2.16.3";
+    version = "2.16.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz";
+      name = "hoek-2.16.3.tgz";
+      sha1 = "20bb7403d3cea398e91dc4710a8ff1b8274a25ed";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."hoek"."^2.2.x" =
+    self.by-version."hoek"."2.16.3";
+  by-spec."hosted-git-info"."^2.1.4" =
+    self.by-version."hosted-git-info"."2.1.4";
+  by-version."hosted-git-info"."2.1.4" = self.buildNodePackage {
+    name = "hosted-git-info-2.1.4";
+    version = "2.1.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz";
+      name = "hosted-git-info-2.1.4.tgz";
+      sha1 = "d9e953b26988be88096c46e926494d9604c300f8";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."http-signature"."~1.1.0" =
+    self.by-version."http-signature"."1.1.1";
+  by-version."http-signature"."1.1.1" = self.buildNodePackage {
+    name = "http-signature-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz";
+      name = "http-signature-1.1.1.tgz";
+      sha1 = "df72e267066cd0ac67fb76adf8e134a8fbcf91bf";
+    };
+    deps = {
+      "assert-plus-0.2.0" = self.by-version."assert-plus"."0.2.0";
+      "jsprim-1.2.2" = self.by-version."jsprim"."1.2.2";
+      "sshpk-1.7.4" = self.by-version."sshpk"."1.7.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."indent-string"."^2.1.0" =
+    self.by-version."indent-string"."2.1.0";
+  by-version."indent-string"."2.1.0" = self.buildNodePackage {
+    name = "indent-string-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz";
+      name = "indent-string-2.1.0.tgz";
+      sha1 = "8e2d48348742121b4a8218b7a137e9a52049dc80";
+    };
+    deps = {
+      "repeating-2.0.0" = self.by-version."repeating"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."infinity-agent"."^2.0.0" =
+    self.by-version."infinity-agent"."2.0.3";
+  by-version."infinity-agent"."2.0.3" = self.buildNodePackage {
+    name = "infinity-agent-2.0.3";
+    version = "2.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz";
+      name = "infinity-agent-2.0.3.tgz";
+      sha1 = "45e0e2ff7a9eb030b27d62b74b3744b7a7ac4216";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."ini"."1.3.4" = self.buildNodePackage {
+    name = "ini-1.3.4";
+    version = "1.3.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ini/-/ini-1.3.4.tgz";
+      name = "ini-1.3.4.tgz";
+      sha1 = "0537cb79daf59b59a1a517dff706c86ec039162e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."intersect"."^1.0.1" =
+    self.by-version."intersect"."1.0.1";
+  by-version."intersect"."1.0.1" = self.buildNodePackage {
+    name = "intersect-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/intersect/-/intersect-1.0.1.tgz";
+      name = "intersect-1.0.1.tgz";
+      sha1 = "332650e10854d8c0ac58c192bdc27a8bf7e7a30c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-arrayish"."^0.2.1" =
+    self.by-version."is-arrayish"."0.2.1";
+  by-version."is-arrayish"."0.2.1" = self.buildNodePackage {
+    name = "is-arrayish-0.2.1";
+    version = "0.2.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz";
+      name = "is-arrayish-0.2.1.tgz";
+      sha1 = "77c99840527aa8ecb1a8ba697b80645a7a926a9d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-builtin-module"."^1.0.0" =
+    self.by-version."is-builtin-module"."1.0.0";
+  by-version."is-builtin-module"."1.0.0" = self.buildNodePackage {
+    name = "is-builtin-module-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz";
+      name = "is-builtin-module-1.0.0.tgz";
+      sha1 = "540572d34f7ac3119f8f76c30cbc1b1e037affbe";
+    };
+    deps = {
+      "builtin-modules-1.1.1" = self.by-version."builtin-modules"."1.1.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."is-finite"."1.0.1" = self.buildNodePackage {
+    name = "is-finite-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz";
+      name = "is-finite-1.0.1.tgz";
+      sha1 = "6438603eaebe2793948ff4a4262ec8db3d62597b";
+    };
+    deps = {
+      "number-is-nan-1.0.0" = self.by-version."number-is-nan"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-my-json-valid"."^2.12.4" =
+    self.by-version."is-my-json-valid"."2.13.1";
+  by-version."is-my-json-valid"."2.13.1" = self.buildNodePackage {
+    name = "is-my-json-valid-2.13.1";
+    version = "2.13.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz";
+      name = "is-my-json-valid-2.13.1.tgz";
+      sha1 = "d55778a82feb6b0963ff4be111d5d1684e890707";
+    };
+    deps = {
+      "generate-function-2.0.0" = self.by-version."generate-function"."2.0.0";
+      "generate-object-property-1.2.0" = self.by-version."generate-object-property"."1.2.0";
+      "jsonpointer-2.0.0" = self.by-version."jsonpointer"."2.0.0";
+      "xtend-4.0.1" = self.by-version."xtend"."4.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-plain-obj"."^1.0.0" =
+    self.by-version."is-plain-obj"."1.1.0";
+  by-version."is-plain-obj"."1.1.0" = self.buildNodePackage {
+    name = "is-plain-obj-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz";
+      name = "is-plain-obj-1.1.0.tgz";
+      sha1 = "71a50c8429dfca773c92a390a4a03b39fcd51d3e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-redirect"."^1.0.0" =
+    self.by-version."is-redirect"."1.0.0";
+  by-version."is-redirect"."1.0.0" = self.buildNodePackage {
+    name = "is-redirect-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz";
+      name = "is-redirect-1.0.0.tgz";
+      sha1 = "1d03dded53bd8db0f30c26e4f95d36fc7c87dc24";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-typedarray"."~1.0.0" =
+    self.by-version."is-typedarray"."1.0.0";
+  by-version."is-typedarray"."1.0.0" = self.buildNodePackage {
+    name = "is-typedarray-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz";
+      name = "is-typedarray-1.0.0.tgz";
+      sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."is-utf8"."0.2.1" = self.buildNodePackage {
+    name = "is-utf8-0.2.1";
+    version = "0.2.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz";
+      name = "is-utf8-0.2.1.tgz";
+      sha1 = "4b0da1442104d1b336340e80797e865cf39f7d72";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."isarray"."~1.0.0" =
+    self.by-version."isarray"."1.0.0";
+  by-version."isarray"."1.0.0" = self.buildNodePackage {
+    name = "isarray-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
+      name = "isarray-1.0.0.tgz";
+      sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."isemail"."1.x.x" =
+    self.by-version."isemail"."1.2.0";
+  by-version."isemail"."1.2.0" = self.buildNodePackage {
+    name = "isemail-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz";
+      name = "isemail-1.2.0.tgz";
+      sha1 = "be03df8cc3e29de4d2c5df6501263f1fa4595e9a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."isstream"."~0.1.2" =
+    self.by-version."isstream"."0.1.2";
+  by-spec."jodid25519".">=1.0.0 <2.0.0" =
+    self.by-version."jodid25519"."1.0.2";
+  by-version."jodid25519"."1.0.2" = self.buildNodePackage {
+    name = "jodid25519-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz";
+      name = "jodid25519-1.0.2.tgz";
+      sha1 = "06d4912255093419477d425633606e0e90782967";
+    };
+    deps = {
+      "jsbn-0.1.0" = self.by-version."jsbn"."0.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."joi"."^4.0.0" =
+    self.by-version."joi"."4.9.0";
+  by-version."joi"."4.9.0" = self.buildNodePackage {
+    name = "joi-4.9.0";
+    version = "4.9.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/joi/-/joi-4.9.0.tgz";
+      name = "joi-4.9.0.tgz";
+      sha1 = "2355023363089ca01bc1fd079e72949f977baada";
+    };
+    deps = {
+      "hoek-2.16.3" = self.by-version."hoek"."2.16.3";
+      "topo-1.1.0" = self.by-version."topo"."1.1.0";
+      "isemail-1.2.0" = self.by-version."isemail"."1.2.0";
+      "moment-2.12.0" = self.by-version."moment"."2.12.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."joi"."^4.7.0" =
+    self.by-version."joi"."4.9.0";
+  by-spec."joi-assert"."0.0.3" =
+    self.by-version."joi-assert"."0.0.3";
+  by-version."joi-assert"."0.0.3" = self.buildNodePackage {
+    name = "joi-assert-0.0.3";
+    version = "0.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/joi-assert/-/joi-assert-0.0.3.tgz";
+      name = "joi-assert-0.0.3.tgz";
+      sha1 = "77291376ac3f0b124f433f98db74b4f20f686fd6";
+    };
+    deps = {
+      "assertion-error-1.0.1" = self.by-version."assertion-error"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."js-yaml"."3.5.5" = self.buildNodePackage {
+    name = "js-yaml-3.5.5";
+    version = "3.5.5";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz";
+      name = "js-yaml-3.5.5.tgz";
+      sha1 = "0377c38017cabc7322b0d1fbcd25a491641f2fbe";
+    };
+    deps = {
+      "argparse-1.0.7" = self.by-version."argparse"."1.0.7";
+      "esprima-2.7.2" = self.by-version."esprima"."2.7.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."jsbn".">=0.1.0 <0.2.0" =
+    self.by-version."jsbn"."0.1.0";
+  by-version."jsbn"."0.1.0" = self.buildNodePackage {
+    name = "jsbn-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz";
+      name = "jsbn-0.1.0.tgz";
+      sha1 = "650987da0dd74f4ebf5a11377a2aa2d273e97dfd";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."jsbn"."~0.1.0" =
+    self.by-version."jsbn"."0.1.0";
+  by-spec."jsesc"."^0.5.0" =
+    self.by-version."jsesc"."0.5.0";
+  by-version."jsesc"."0.5.0" = self.buildNodePackage {
+    name = "jsesc-0.5.0";
+    version = "0.5.0";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz";
+      name = "jsesc-0.5.0.tgz";
+      sha1 = "e7dee66e35d6fc16f710fe91d5cf69f70f08911d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."json-pointer"."^0.2.2" =
+    self.by-version."json-pointer"."0.2.2";
+  by-version."json-pointer"."0.2.2" = self.buildNodePackage {
+    name = "json-pointer-0.2.2";
+    version = "0.2.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/json-pointer/-/json-pointer-0.2.2.tgz";
+      name = "json-pointer-0.2.2.tgz";
+      sha1 = "1a78285d4650c50b10475f7f59919a99db8a164b";
+    };
+    deps = {
+      "foreach-2.0.5" = self.by-version."foreach"."2.0.5";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."json-stringify-safe"."~5.0.1" =
+    self.by-version."json-stringify-safe"."5.0.1";
+  by-version."json-stringify-safe"."5.0.1" = self.buildNodePackage {
+    name = "json-stringify-safe-5.0.1";
+    version = "5.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
+      name = "json-stringify-safe-5.0.1.tgz";
+      sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."jsonfile"."^2.1.0" =
+    self.by-version."jsonfile"."2.2.3";
+  by-version."jsonfile"."2.2.3" = self.buildNodePackage {
+    name = "jsonfile-2.2.3";
+    version = "2.2.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz";
+      name = "jsonfile-2.2.3.tgz";
+      sha1 = "e252b99a6af901d3ec41f332589c90509a7bc605";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."jsonpointer"."2.0.0" =
+    self.by-version."jsonpointer"."2.0.0";
+  by-version."jsonpointer"."2.0.0" = self.buildNodePackage {
+    name = "jsonpointer-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz";
+      name = "jsonpointer-2.0.0.tgz";
+      sha1 = "3af1dd20fe85463910d469a385e33017d2a030d9";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."jsprim"."^1.2.2" =
+    self.by-version."jsprim"."1.2.2";
+  by-version."jsprim"."1.2.2" = self.buildNodePackage {
+    name = "jsprim-1.2.2";
+    version = "1.2.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz";
+      name = "jsprim-1.2.2.tgz";
+      sha1 = "f20c906ac92abd58e3b79ac8bc70a48832512da1";
+    };
+    deps = {
+      "extsprintf-1.0.2" = self.by-version."extsprintf"."1.0.2";
+      "json-schema-0.2.2" = self.by-version."json-schema"."0.2.2";
+      "verror-1.3.6" = self.by-version."verror"."1.3.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."klaw"."^1.0.0" =
+    self.by-version."klaw"."1.1.3";
+  by-version."klaw"."1.1.3" = self.buildNodePackage {
+    name = "klaw-1.1.3";
+    version = "1.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz";
+      name = "klaw-1.1.3.tgz";
+      sha1 = "7da33c6b42f9b3dc9cec00d17f13af017fcc2721";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."latest-version"."1.0.1" = self.buildNodePackage {
+    name = "latest-version-1.0.1";
+    version = "1.0.1";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz";
+      name = "latest-version-1.0.1.tgz";
+      sha1 = "72cfc46e3e8d1be651e1ebb54ea9f6ea96f374bb";
+    };
+    deps = {
+      "package-json-1.2.0" = self.by-version."package-json"."1.2.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."lazy.js"."~0.3.2" =
+    self.by-version."lazy.js"."0.3.2";
+  by-version."lazy.js"."0.3.2" = self.buildNodePackage {
+    name = "lazy.js-0.3.2";
+    version = "0.3.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/lazy.js/-/lazy.js-0.3.2.tgz";
+      name = "lazy.js-0.3.2.tgz";
+      sha1 = "7cc1107e5f809ae70498f511dd180e1f80b4efa9";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."load-json-file"."^1.0.0" =
+    self.by-version."load-json-file"."1.1.0";
+  by-version."load-json-file"."1.1.0" = self.buildNodePackage {
+    name = "load-json-file-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz";
+      name = "load-json-file-1.1.0.tgz";
+      sha1 = "956905708d58b4bab4c2261b04f59f31c99374c0";
+    };
+    deps = {
+      "graceful-fs-4.1.3" = self.by-version."graceful-fs"."4.1.3";
+      "parse-json-2.2.0" = self.by-version."parse-json"."2.2.0";
+      "pify-2.3.0" = self.by-version."pify"."2.3.0";
+      "pinkie-promise-2.0.0" = self.by-version."pinkie-promise"."2.0.0";
+      "strip-bom-2.0.0" = self.by-version."strip-bom"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."lodash".">= 4.0.0 < 5.0.0" =
+    self.by-version."lodash"."4.6.1";
+  by-version."lodash"."4.6.1" = self.buildNodePackage {
+    name = "lodash-4.6.1";
+    version = "4.6.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz";
+      name = "lodash-4.6.1.tgz";
+      sha1 = "df00c1164ad236b183cfc3887a5e8d38cc63cbbc";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."lodash"."~4.2.1" =
+    self.by-version."lodash"."4.2.1";
+  by-version."lodash"."4.2.1" = self.buildNodePackage {
+    name = "lodash-4.2.1";
+    version = "4.2.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz";
+      name = "lodash-4.2.1.tgz";
+      sha1 = "171fdcfbbc30d689c544cd18c0529f56de6c1aa9";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "lodash" = self.by-version."lodash"."4.2.1";
+  by-spec."loud-rejection"."^1.0.0" =
+    self.by-version."loud-rejection"."1.3.0";
+  by-version."loud-rejection"."1.3.0" = self.buildNodePackage {
+    name = "loud-rejection-1.3.0";
+    version = "1.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz";
+      name = "loud-rejection-1.3.0.tgz";
+      sha1 = "f289a392f17d2baacf194d0a673004394433b115";
+    };
+    deps = {
+      "array-find-index-1.0.1" = self.by-version."array-find-index"."1.0.1";
+      "signal-exit-2.1.2" = self.by-version."signal-exit"."2.1.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."lru-cache"."2.7.3" = self.buildNodePackage {
+    name = "lru-cache-2.7.3";
+    version = "2.7.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz";
+      name = "lru-cache-2.7.3.tgz";
+      sha1 = "6d4524e8b955f95d4f5b58851ce21dd72fb4e952";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."lru-cache"."^4.0.0" =
+    self.by-version."lru-cache"."4.0.1";
+  by-version."lru-cache"."4.0.1" = self.buildNodePackage {
+    name = "lru-cache-4.0.1";
+    version = "4.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz";
+      name = "lru-cache-4.0.1.tgz";
+      sha1 = "1343955edaf2e37d9b9e7ee7241e27c4b9fb72be";
+    };
+    deps = {
+      "pseudomap-1.0.2" = self.by-version."pseudomap"."1.0.2";
+      "yallist-2.0.0" = self.by-version."yallist"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."map-obj"."1.0.1" = self.buildNodePackage {
+    name = "map-obj-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz";
+      name = "map-obj-1.0.1.tgz";
+      sha1 = "d933ceb9205d82bdcf4886f6742bdc2b4dea146d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."map-obj"."^1.0.1" =
+    self.by-version."map-obj"."1.0.1";
+  by-spec."map-stream"."~0.1.0" =
+    self.by-version."map-stream"."0.1.0";
+  by-version."map-stream"."0.1.0" = self.buildNodePackage {
+    name = "map-stream-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz";
+      name = "map-stream-0.1.0.tgz";
+      sha1 = "e56aa94c4c8055a16404a0674b78f215f7c8e194";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."meow"."3.7.0" = self.buildNodePackage {
+    name = "meow-3.7.0";
+    version = "3.7.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz";
+      name = "meow-3.7.0.tgz";
+      sha1 = "72cb668b425228290abbfa856892587308a801fb";
+    };
+    deps = {
+      "camelcase-keys-2.1.0" = self.by-version."camelcase-keys"."2.1.0";
+      "decamelize-1.2.0" = self.by-version."decamelize"."1.2.0";
+      "loud-rejection-1.3.0" = self.by-version."loud-rejection"."1.3.0";
+      "map-obj-1.0.1" = self.by-version."map-obj"."1.0.1";
+      "minimist-1.2.0" = self.by-version."minimist"."1.2.0";
+      "normalize-package-data-2.3.5" = self.by-version."normalize-package-data"."2.3.5";
+      "object-assign-4.0.1" = self.by-version."object-assign"."4.0.1";
+      "read-pkg-up-1.0.1" = self.by-version."read-pkg-up"."1.0.1";
+      "redent-1.0.0" = self.by-version."redent"."1.0.0";
+      "trim-newlines-1.0.0" = self.by-version."trim-newlines"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mime-db"."~1.22.0" =
+    self.by-version."mime-db"."1.22.0";
+  by-version."mime-db"."1.22.0" = self.buildNodePackage {
+    name = "mime-db-1.22.0";
+    version = "1.22.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz";
+      name = "mime-db-1.22.0.tgz";
+      sha1 = "ab23a6372dc9d86d3dc9121bd0ebd38105a1904a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mime-types"."^2.1.10" =
+    self.by-version."mime-types"."2.1.10";
+  by-version."mime-types"."2.1.10" = self.buildNodePackage {
+    name = "mime-types-2.1.10";
+    version = "2.1.10";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz";
+      name = "mime-types-2.1.10.tgz";
+      sha1 = "b93c7cb4362e16d41072a7e54538fb4d43070837";
+    };
+    deps = {
+      "mime-db-1.22.0" = self.by-version."mime-db"."1.22.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mime-types"."~2.1.7" =
+    self.by-version."mime-types"."2.1.10";
+  by-spec."minichain"."~0.0.1" =
+    self.by-version."minichain"."0.0.1";
+  by-version."minichain"."0.0.1" = self.buildNodePackage {
+    name = "minichain-0.0.1";
+    version = "0.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/minichain/-/minichain-0.0.1.tgz";
+      name = "minichain-0.0.1.tgz";
+      sha1 = "0bae49774170d8931401c271bb6ed6d3992a9f52";
+    };
+    deps = {
+      "ministyle-0.1.4" = self.by-version."ministyle"."0.1.4";
+      "miniwrite-0.1.4" = self.by-version."miniwrite"."0.1.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."minimatch"."2 || 3" =
+    self.by-version."minimatch"."3.0.0";
+  by-version."minimatch"."3.0.0" = self.buildNodePackage {
+    name = "minimatch-3.0.0";
+    version = "3.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz";
+      name = "minimatch-3.0.0.tgz";
+      sha1 = "5236157a51e4f004c177fb3c527ff7dd78f0ef83";
+    };
+    deps = {
+      "brace-expansion-1.1.3" = self.by-version."brace-expansion"."1.1.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."minimatch"."2.0.10" = self.buildNodePackage {
+    name = "minimatch-2.0.10";
+    version = "2.0.10";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz";
+      name = "minimatch-2.0.10.tgz";
+      sha1 = "8d087c39c6b38c001b97fca7ce6d0e1e80afbac7";
+    };
+    deps = {
+      "brace-expansion-1.1.3" = self.by-version."brace-expansion"."1.1.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."minimist"."^0.1.0" =
+    self.by-version."minimist"."0.1.0";
+  by-version."minimist"."0.1.0" = self.buildNodePackage {
+    name = "minimist-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz";
+      name = "minimist-0.1.0.tgz";
+      sha1 = "99df657a52574c21c9057497df742790b2b4c0de";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."minimist"."1.2.0" = self.buildNodePackage {
+    name = "minimist-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz";
+      name = "minimist-1.2.0.tgz";
+      sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."minimist"."^1.1.3" =
+    self.by-version."minimist"."1.2.0";
+  by-spec."minimist"."^1.2.0" =
+    self.by-version."minimist"."1.2.0";
+  by-spec."ministyle".">=0.1.2 >=0.1.3 <0.2.0" =
+    self.by-version."ministyle"."0.1.4";
+  by-spec."ministyle"."~0.1.2" =
+    self.by-version."ministyle"."0.1.4";
+  by-spec."minitable"."0.0.4" =
+    self.by-version."minitable"."0.0.4";
+  by-version."minitable"."0.0.4" = self.buildNodePackage {
+    name = "minitable-0.0.4";
+    version = "0.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/minitable/-/minitable-0.0.4.tgz";
+      name = "minitable-0.0.4.tgz";
+      sha1 = "8d61cb78fae6f371d8051ce77e8a7831ce3d5396";
+    };
+    deps = {
+      "miniwrite-0.1.4" = self.by-version."miniwrite"."0.1.4";
+      "minichain-0.0.1" = self.by-version."minichain"."0.0.1";
+      "ministyle-0.1.4" = self.by-version."ministyle"."0.1.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."miniwrite"."~0.1.2" =
+    self.by-version."miniwrite"."0.1.4";
+  by-version."mkdirp"."0.5.1" = self.buildNodePackage {
+    name = "mkdirp-0.5.1";
+    version = "0.5.1";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz";
+      name = "mkdirp-0.5.1.tgz";
+      sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
+    };
+    deps = {
+      "minimist-0.0.8" = self.by-version."minimist"."0.0.8";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."moment"."2.x.x" =
+    self.by-version."moment"."2.12.0";
+  by-version."moment"."2.12.0" = self.buildNodePackage {
+    name = "moment-2.12.0";
+    version = "2.12.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/moment/-/moment-2.12.0.tgz";
+      name = "moment-2.12.0.tgz";
+      sha1 = "dc2560d19838d6c0731b1a6afa04675264d360d6";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ms"."0.7.1" =
+    self.by-version."ms"."0.7.1";
+  by-version."ms"."0.7.1" = self.buildNodePackage {
+    name = "ms-0.7.1";
+    version = "0.7.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz";
+      name = "ms-0.7.1.tgz";
+      sha1 = "9cd13c03adbff25b65effde7ce864ee952017098";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."nested-error-stacks"."1.0.2" = self.buildNodePackage {
+    name = "nested-error-stacks-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz";
+      name = "nested-error-stacks-1.0.2.tgz";
+      sha1 = "19f619591519f096769a5ba9a86e6eeec823c3cf";
+    };
+    deps = {
+      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."node-uuid"."1.x" =
+    self.by-version."node-uuid"."1.4.7";
+  by-version."node-uuid"."1.4.7" = self.buildNodePackage {
+    name = "node-uuid-1.4.7";
+    version = "1.4.7";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz";
+      name = "node-uuid-1.4.7.tgz";
+      sha1 = "6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."node-uuid"."~1.4.7" =
+    self.by-version."node-uuid"."1.4.7";
+  by-spec."normalize-package-data"."^2.3.2" =
+    self.by-version."normalize-package-data"."2.3.5";
+  by-version."normalize-package-data"."2.3.5" = self.buildNodePackage {
+    name = "normalize-package-data-2.3.5";
+    version = "2.3.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz";
+      name = "normalize-package-data-2.3.5.tgz";
+      sha1 = "8d924f142960e1777e7ffe170543631cc7cb02df";
+    };
+    deps = {
+      "hosted-git-info-2.1.4" = self.by-version."hosted-git-info"."2.1.4";
+      "is-builtin-module-1.0.0" = self.by-version."is-builtin-module"."1.0.0";
+      "semver-5.1.0" = self.by-version."semver"."5.1.0";
+      "validate-npm-package-license-3.0.1" = self.by-version."validate-npm-package-license"."3.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."normalize-package-data"."^2.3.4" =
+    self.by-version."normalize-package-data"."2.3.5";
+  by-spec."number-is-nan"."^1.0.0" =
+    self.by-version."number-is-nan"."1.0.0";
+  by-version."number-is-nan"."1.0.0" = self.buildNodePackage {
+    name = "number-is-nan-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz";
+      name = "number-is-nan-1.0.0.tgz";
+      sha1 = "c020f529c5282adfdd233d91d4b181c3d686dc4b";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."oauth-sign"."~0.8.0" =
+    self.by-version."oauth-sign"."0.8.1";
+  by-version."oauth-sign"."0.8.1" = self.buildNodePackage {
+    name = "oauth-sign-0.8.1";
+    version = "0.8.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz";
+      name = "oauth-sign-0.8.1.tgz";
+      sha1 = "182439bdb91378bf7460e75c64ea43e6448def06";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."object-assign"."2.1.1" = self.buildNodePackage {
+    name = "object-assign-2.1.1";
+    version = "2.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz";
+      name = "object-assign-2.1.1.tgz";
+      sha1 = "43c36e5d569ff8e4816c4efa8be02d26967c18aa";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."object-assign"."^3.0.0" =
+    self.by-version."object-assign"."3.0.0";
+  by-version."object-assign"."3.0.0" = self.buildNodePackage {
+    name = "object-assign-3.0.0";
+    version = "3.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz";
+      name = "object-assign-3.0.0.tgz";
+      sha1 = "9bedd5ca0897949bca47e7ff408062d549f587f2";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."object-assign"."^4.0.1" =
+    self.by-version."object-assign"."4.0.1";
+  by-version."object-assign"."4.0.1" = self.buildNodePackage {
+    name = "object-assign-4.0.1";
+    version = "4.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz";
+      name = "object-assign-4.0.1.tgz";
+      sha1 = "99504456c3598b5cad4fc59c26e8a9bb107fe0bd";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."once"."1.3.3" = self.buildNodePackage {
+    name = "once-1.3.3";
+    version = "1.3.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/once/-/once-1.3.3.tgz";
+      name = "once-1.3.3.tgz";
+      sha1 = "b2e261557ce4c314ec8304f3fa82663e4297ca20";
+    };
+    deps = {
+      "wrappy-1.0.1" = self.by-version."wrappy"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."os-homedir"."^1.0.0" =
+    self.by-version."os-homedir"."1.0.1";
+  by-version."os-homedir"."1.0.1" = self.buildNodePackage {
+    name = "os-homedir-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz";
+      name = "os-homedir-1.0.1.tgz";
+      sha1 = "0d62bdf44b916fd3bbdcf2cab191948fb094f007";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."os-tmpdir"."^1.0.0" =
+    self.by-version."os-tmpdir"."1.0.1";
+  by-version."os-tmpdir"."1.0.1" = self.buildNodePackage {
+    name = "os-tmpdir-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz";
+      name = "os-tmpdir-1.0.1.tgz";
+      sha1 = "e9b423a1edaf479882562e92ed71d7743a071b6e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."osenv"."0.1.3" = self.buildNodePackage {
+    name = "osenv-0.1.3";
+    version = "0.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz";
+      name = "osenv-0.1.3.tgz";
+      sha1 = "83cf05c6d6458fc4d5ac6362ea325d92f2754217";
+    };
+    deps = {
+      "os-homedir-1.0.1" = self.by-version."os-homedir"."1.0.1";
+      "os-tmpdir-1.0.1" = self.by-version."os-tmpdir"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."package-json"."1.2.0" = self.buildNodePackage {
+    name = "package-json-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz";
+      name = "package-json-1.2.0.tgz";
+      sha1 = "c8ecac094227cdf76a316874ed05e27cc939a0e0";
+    };
+    deps = {
+      "got-3.3.1" = self.by-version."got"."3.3.1";
+      "registry-url-3.0.3" = self.by-version."registry-url"."3.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."parse-json"."^2.2.0" =
+    self.by-version."parse-json"."2.2.0";
+  by-version."parse-json"."2.2.0" = self.buildNodePackage {
+    name = "parse-json-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz";
+      name = "parse-json-2.2.0.tgz";
+      sha1 = "f480f40434ef80741f8469099f8dea18f55a4dc9";
+    };
+    deps = {
+      "error-ex-1.3.0" = self.by-version."error-ex"."1.3.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."parsimmon"."^0.5.0" =
+    self.by-version."parsimmon"."0.5.1";
+  by-version."parsimmon"."0.5.1" = self.buildNodePackage {
+    name = "parsimmon-0.5.1";
+    version = "0.5.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/parsimmon/-/parsimmon-0.5.1.tgz";
+      name = "parsimmon-0.5.1.tgz";
+      sha1 = "247c970d7d5e99a51115b16a106de96f0eb9303b";
+    };
+    deps = {
+      "pjs-5.1.1" = self.by-version."pjs"."5.1.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."path-exists"."^2.0.0" =
+    self.by-version."path-exists"."2.1.0";
+  by-version."path-exists"."2.1.0" = self.buildNodePackage {
+    name = "path-exists-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz";
+      name = "path-exists-2.1.0.tgz";
+      sha1 = "0feb6c64f0fc518d9a754dd5efb62c7022761f4b";
+    };
+    deps = {
+      "pinkie-promise-2.0.0" = self.by-version."pinkie-promise"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."path-type"."^1.0.0" =
+    self.by-version."path-type"."1.1.0";
+  by-version."path-type"."1.1.0" = self.buildNodePackage {
+    name = "path-type-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz";
+      name = "path-type-1.1.0.tgz";
+      sha1 = "59c44f7ee491da704da415da5a4070ba4f8fe441";
+    };
+    deps = {
+      "graceful-fs-4.1.3" = self.by-version."graceful-fs"."4.1.3";
+      "pify-2.3.0" = self.by-version."pify"."2.3.0";
+      "pinkie-promise-2.0.0" = self.by-version."pinkie-promise"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."pause-stream"."0.0.11" =
+    self.by-version."pause-stream"."0.0.11";
+  by-version."pause-stream"."0.0.11" = self.buildNodePackage {
+    name = "pause-stream-0.0.11";
+    version = "0.0.11";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz";
+      name = "pause-stream-0.0.11.tgz";
+      sha1 = "fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445";
+    };
+    deps = {
+      "through-2.3.8" = self.by-version."through"."2.3.8";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."pify"."^2.0.0" =
+    self.by-version."pify"."2.3.0";
+  by-version."pify"."2.3.0" = self.buildNodePackage {
+    name = "pify-2.3.0";
+    version = "2.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz";
+      name = "pify-2.3.0.tgz";
+      sha1 = "ed141a6ac043a849ea588498e7dca8b15330e90c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."pinkie"."^2.0.0" =
+    self.by-version."pinkie"."2.0.4";
+  by-version."pinkie"."2.0.4" = self.buildNodePackage {
+    name = "pinkie-2.0.4";
+    version = "2.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz";
+      name = "pinkie-2.0.4.tgz";
+      sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."pinkie-promise"."^2.0.0" =
+    self.by-version."pinkie-promise"."2.0.0";
+  by-version."pinkie-promise"."2.0.0" = self.buildNodePackage {
+    name = "pinkie-promise-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz";
+      name = "pinkie-promise-2.0.0.tgz";
+      sha1 = "4c83538de1f6e660c29e0a13446844f7a7e88259";
+    };
+    deps = {
+      "pinkie-2.0.4" = self.by-version."pinkie"."2.0.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."pjs"."5.x" =
+    self.by-version."pjs"."5.1.1";
+  by-version."pjs"."5.1.1" = self.buildNodePackage {
+    name = "pjs-5.1.1";
+    version = "5.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/pjs/-/pjs-5.1.1.tgz";
+      name = "pjs-5.1.1.tgz";
+      sha1 = "9dfc4673bb01deffd6915fb1dec75827aba42abf";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."prepend-http"."1.0.3" = self.buildNodePackage {
+    name = "prepend-http-1.0.3";
+    version = "1.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz";
+      name = "prepend-http-1.0.3.tgz";
+      sha1 = "4d0d2b6f9efcf1190c23931325b4f3a9dba84869";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."process-nextick-args"."~1.0.6" =
+    self.by-version."process-nextick-args"."1.0.6";
+  by-version."process-nextick-args"."1.0.6" = self.buildNodePackage {
+    name = "process-nextick-args-1.0.6";
+    version = "1.0.6";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz";
+      name = "process-nextick-args-1.0.6.tgz";
+      sha1 = "0f96b001cea90b12592ce566edb97ec11e69bd05";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."promised-temp"."^0.1.0" =
+    self.by-version."promised-temp"."0.1.0";
+  by-version."promised-temp"."0.1.0" = self.buildNodePackage {
+    name = "promised-temp-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/promised-temp/-/promised-temp-0.1.0.tgz";
+      name = "promised-temp-0.1.0.tgz";
+      sha1 = "5f8a704ccdf5f2ac23996fcafe2b301bc2a8d0eb";
+    };
+    deps = {
+      "temp-0.8.3" = self.by-version."temp"."0.8.3";
+      "q-1.4.1" = self.by-version."q"."1.4.1";
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "mkdirp-0.5.1" = self.by-version."mkdirp"."0.5.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "promised-temp" = self.by-version."promised-temp"."0.1.0";
+  by-spec."pseudomap"."^1.0.1" =
+    self.by-version."pseudomap"."1.0.2";
+  by-version."pseudomap"."1.0.2" = self.buildNodePackage {
+    name = "pseudomap-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz";
+      name = "pseudomap-1.0.2.tgz";
+      sha1 = "f052a28da70e618917ef0a8ac34c1ae5a68286b3";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."q"."1.4.1" = self.buildNodePackage {
+    name = "q-1.4.1";
+    version = "1.4.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/q/-/q-1.4.1.tgz";
+      name = "q-1.4.1.tgz";
+      sha1 = "55705bcd93c5f3673530c2c2cbc0c2b3addc286e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."qs"."~6.0.2" =
+    self.by-version."qs"."6.0.2";
+  by-version."qs"."6.0.2" = self.buildNodePackage {
+    name = "qs-6.0.2";
+    version = "6.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/qs/-/qs-6.0.2.tgz";
+      name = "qs-6.0.2.tgz";
+      sha1 = "88c68d590e8ed56c76c79f352c17b982466abfcd";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."rc"."1.1.6" = self.buildNodePackage {
+    name = "rc-1.1.6";
+    version = "1.1.6";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/rc/-/rc-1.1.6.tgz";
+      name = "rc-1.1.6.tgz";
+      sha1 = "43651b76b6ae53b5c802f1151fa3fc3b059969c9";
+    };
+    deps = {
+      "deep-extend-0.4.1" = self.by-version."deep-extend"."0.4.1";
+      "ini-1.3.4" = self.by-version."ini"."1.3.4";
+      "minimist-1.2.0" = self.by-version."minimist"."1.2.0";
+      "strip-json-comments-1.0.4" = self.by-version."strip-json-comments"."1.0.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."read-all-stream"."2.2.0" = self.buildNodePackage {
+    name = "read-all-stream-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz";
+      name = "read-all-stream-2.2.0.tgz";
+      sha1 = "6b83370546c55ab6ade2bf75e83c66e45989bbf0";
+    };
+    deps = {
+      "readable-stream-2.0.6" = self.by-version."readable-stream"."2.0.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."read-all-stream"."^3.0.0" =
+    self.by-version."read-all-stream"."3.1.0";
+  by-version."read-all-stream"."3.1.0" = self.buildNodePackage {
+    name = "read-all-stream-3.1.0";
+    version = "3.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz";
+      name = "read-all-stream-3.1.0.tgz";
+      sha1 = "35c3e177f2078ef789ee4bfafa4373074eaef4fa";
+    };
+    deps = {
+      "pinkie-promise-2.0.0" = self.by-version."pinkie-promise"."2.0.0";
+      "readable-stream-2.0.6" = self.by-version."readable-stream"."2.0.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."read-pkg"."^1.0.0" =
+    self.by-version."read-pkg"."1.1.0";
+  by-version."read-pkg"."1.1.0" = self.buildNodePackage {
+    name = "read-pkg-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz";
+      name = "read-pkg-1.1.0.tgz";
+      sha1 = "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28";
+    };
+    deps = {
+      "load-json-file-1.1.0" = self.by-version."load-json-file"."1.1.0";
+      "normalize-package-data-2.3.5" = self.by-version."normalize-package-data"."2.3.5";
+      "path-type-1.1.0" = self.by-version."path-type"."1.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."read-pkg-up"."^1.0.1" =
+    self.by-version."read-pkg-up"."1.0.1";
+  by-version."read-pkg-up"."1.0.1" = self.buildNodePackage {
+    name = "read-pkg-up-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz";
+      name = "read-pkg-up-1.0.1.tgz";
+      sha1 = "9d63c13276c065918d57f002a57f40a1b643fb02";
+    };
+    deps = {
+      "find-up-1.1.2" = self.by-version."find-up"."1.1.2";
+      "read-pkg-1.1.0" = self.by-version."read-pkg"."1.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."readable-stream"."^2.0.0" =
+    self.by-version."readable-stream"."2.0.6";
+  by-version."readable-stream"."2.0.6" = self.buildNodePackage {
+    name = "readable-stream-2.0.6";
+    version = "2.0.6";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz";
+      name = "readable-stream-2.0.6.tgz";
+      sha1 = "8f90341e68a53ccc928788dacfcd11b36eb9b78e";
+    };
+    deps = {
+      "core-util-is-1.0.2" = self.by-version."core-util-is"."1.0.2";
+      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+      "isarray-1.0.0" = self.by-version."isarray"."1.0.0";
+      "process-nextick-args-1.0.6" = self.by-version."process-nextick-args"."1.0.6";
+      "string_decoder-0.10.31" = self.by-version."string_decoder"."0.10.31";
+      "util-deprecate-1.0.2" = self.by-version."util-deprecate"."1.0.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."readable-stream"."~2.0.5" =
+    self.by-version."readable-stream"."2.0.6";
+  by-spec."redent"."^1.0.0" =
+    self.by-version."redent"."1.0.0";
+  by-version."redent"."1.0.0" = self.buildNodePackage {
+    name = "redent-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/redent/-/redent-1.0.0.tgz";
+      name = "redent-1.0.0.tgz";
+      sha1 = "cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde";
+    };
+    deps = {
+      "indent-string-2.1.0" = self.by-version."indent-string"."2.1.0";
+      "strip-indent-1.0.1" = self.by-version."strip-indent"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."repeating"."^2.0.0" =
+    self.by-version."repeating"."2.0.0";
+  by-version."repeating"."2.0.0" = self.buildNodePackage {
+    name = "repeating-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz";
+      name = "repeating-2.0.0.tgz";
+      sha1 = "fd27d6d264d18fbebfaa56553dd7b82535a5034e";
+    };
+    deps = {
+      "is-finite-1.0.1" = self.by-version."is-finite"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."request"."2.69.0" = self.buildNodePackage {
+    name = "request-2.69.0";
+    version = "2.69.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/request/-/request-2.69.0.tgz";
+      name = "request-2.69.0.tgz";
+      sha1 = "cf91d2e000752b1217155c005241911991a2346a";
+    };
+    deps = {
+      "aws-sign2-0.6.0" = self.by-version."aws-sign2"."0.6.0";
+      "aws4-1.3.2" = self.by-version."aws4"."1.3.2";
+      "bl-1.0.3" = self.by-version."bl"."1.0.3";
+      "caseless-0.11.0" = self.by-version."caseless"."0.11.0";
+      "combined-stream-1.0.5" = self.by-version."combined-stream"."1.0.5";
+      "extend-3.0.0" = self.by-version."extend"."3.0.0";
+      "forever-agent-0.6.1" = self.by-version."forever-agent"."0.6.1";
+      "form-data-1.0.0-rc4" = self.by-version."form-data"."1.0.0-rc4";
+      "har-validator-2.0.6" = self.by-version."har-validator"."2.0.6";
+      "hawk-3.1.3" = self.by-version."hawk"."3.1.3";
+      "http-signature-1.1.1" = self.by-version."http-signature"."1.1.1";
+      "is-typedarray-1.0.0" = self.by-version."is-typedarray"."1.0.0";
+      "isstream-0.1.2" = self.by-version."isstream"."0.1.2";
+      "json-stringify-safe-5.0.1" = self.by-version."json-stringify-safe"."5.0.1";
+      "mime-types-2.1.10" = self.by-version."mime-types"."2.1.10";
+      "node-uuid-1.4.7" = self.by-version."node-uuid"."1.4.7";
+      "oauth-sign-0.8.1" = self.by-version."oauth-sign"."0.8.1";
+      "qs-6.0.2" = self.by-version."qs"."6.0.2";
+      "stringstream-0.0.5" = self.by-version."stringstream"."0.0.5";
+      "tough-cookie-2.2.2" = self.by-version."tough-cookie"."2.2.2";
+      "tunnel-agent-0.4.2" = self.by-version."tunnel-agent"."0.4.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."request"."^2.45.0" =
+    self.by-version."request"."2.69.0";
+  by-version."rimraf"."2.5.2" = self.buildNodePackage {
+    name = "rimraf-2.5.2";
+    version = "2.5.2";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz";
+      name = "rimraf-2.5.2.tgz";
+      sha1 = "62ba947fa4c0b4363839aefecd4f0fbad6059726";
+    };
+    deps = {
+      "glob-7.0.3" = self.by-version."glob"."7.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."semver"."2 || 3 || 4 || 5" =
+    self.by-version."semver"."5.1.0";
+  by-version."semver"."5.1.0" = self.buildNodePackage {
+    name = "semver-5.1.0";
+    version = "5.1.0";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/semver/-/semver-5.1.0.tgz";
+      name = "semver-5.1.0.tgz";
+      sha1 = "85f2cf8550465c4df000cf7d86f6b054106ab9e5";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."semver".">=5.1.0 <6" =
+    self.by-version."semver"."5.1.0";
+  by-version."semver"."4.3.6" = self.buildNodePackage {
+    name = "semver-4.3.6";
+    version = "4.3.6";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/semver/-/semver-4.3.6.tgz";
+      name = "semver-4.3.6.tgz";
+      sha1 = "300bc6e0e86374f7ba61068b5b1ecd57fc6532da";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."semver"."^5.0.3" =
+    self.by-version."semver"."5.1.0";
+  by-version."semver-diff"."2.1.0" = self.buildNodePackage {
+    name = "semver-diff-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz";
+      name = "semver-diff-2.1.0.tgz";
+      sha1 = "4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36";
+    };
+    deps = {
+      "semver-5.1.0" = self.by-version."semver"."5.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."sigmund"."1.0.1" = self.buildNodePackage {
+    name = "sigmund-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz";
+      name = "sigmund-1.0.1.tgz";
+      sha1 = "3ff21f198cad2175f9f3b781853fd94d0d19b590";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."signal-exit"."^2.1.2" =
+    self.by-version."signal-exit"."2.1.2";
+  by-version."signal-exit"."2.1.2" = self.buildNodePackage {
+    name = "signal-exit-2.1.2";
+    version = "2.1.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz";
+      name = "signal-exit-2.1.2.tgz";
+      sha1 = "375879b1f92ebc3b334480d038dc546a6d558564";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."sort-keys"."^1.0.0" =
+    self.by-version."sort-keys"."1.1.1";
+  by-version."sort-keys"."1.1.1" = self.buildNodePackage {
+    name = "sort-keys-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz";
+      name = "sort-keys-1.1.1.tgz";
+      sha1 = "a791c26071df66c356bf5dcad9cfb57a7b2f826e";
+    };
+    deps = {
+      "is-plain-obj-1.1.0" = self.by-version."is-plain-obj"."1.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."sort-keys-length"."^1.0.0" =
+    self.by-version."sort-keys-length"."1.0.1";
+  by-version."sort-keys-length"."1.0.1" = self.buildNodePackage {
+    name = "sort-keys-length-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz";
+      name = "sort-keys-length-1.0.1.tgz";
+      sha1 = "9cb6f4f4e9e48155a6aa0671edd336ff1479a188";
+    };
+    deps = {
+      "sort-keys-1.1.1" = self.by-version."sort-keys"."1.1.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."spdx-correct"."~1.0.0" =
+    self.by-version."spdx-correct"."1.0.2";
+  by-version."spdx-correct"."1.0.2" = self.buildNodePackage {
+    name = "spdx-correct-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz";
+      name = "spdx-correct-1.0.2.tgz";
+      sha1 = "4b3073d933ff51f3912f03ac5519498a4150db40";
+    };
+    deps = {
+      "spdx-license-ids-1.2.0" = self.by-version."spdx-license-ids"."1.2.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."spdx-exceptions"."^1.0.4" =
+    self.by-version."spdx-exceptions"."1.0.4";
+  by-version."spdx-exceptions"."1.0.4" = self.buildNodePackage {
+    name = "spdx-exceptions-1.0.4";
+    version = "1.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz";
+      name = "spdx-exceptions-1.0.4.tgz";
+      sha1 = "220b84239119ae9045a892db81a83f4ce16f80fd";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."spdx-expression-parse"."~1.0.0" =
+    self.by-version."spdx-expression-parse"."1.0.2";
+  by-version."spdx-expression-parse"."1.0.2" = self.buildNodePackage {
+    name = "spdx-expression-parse-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz";
+      name = "spdx-expression-parse-1.0.2.tgz";
+      sha1 = "d52b14b5e9670771440af225bcb563122ac452f6";
+    };
+    deps = {
+      "spdx-exceptions-1.0.4" = self.by-version."spdx-exceptions"."1.0.4";
+      "spdx-license-ids-1.2.0" = self.by-version."spdx-license-ids"."1.2.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."spdx-license-ids"."^1.0.0" =
+    self.by-version."spdx-license-ids"."1.2.0";
+  by-version."spdx-license-ids"."1.2.0" = self.buildNodePackage {
+    name = "spdx-license-ids-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz";
+      name = "spdx-license-ids-1.2.0.tgz";
+      sha1 = "b549dd0f63dcb745a17e2ea3a07402e0e332d1e2";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."spdx-license-ids"."^1.0.2" =
+    self.by-version."spdx-license-ids"."1.2.0";
+  by-spec."split"."0.2" =
+    self.by-version."split"."0.2.10";
+  by-version."split"."0.2.10" = self.buildNodePackage {
+    name = "split-0.2.10";
+    version = "0.2.10";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/split/-/split-0.2.10.tgz";
+      name = "split-0.2.10.tgz";
+      sha1 = "67097c601d697ce1368f418f06cd201cf0521a57";
+    };
+    deps = {
+      "through-2.3.8" = self.by-version."through"."2.3.8";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."sprintf-js"."1.0.3" = self.buildNodePackage {
+    name = "sprintf-js-1.0.3";
+    version = "1.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz";
+      name = "sprintf-js-1.0.3.tgz";
+      sha1 = "04e6926f662895354f3dd015203633b857297e2c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."sshpk"."^1.7.0" =
+    self.by-version."sshpk"."1.7.4";
+  by-version."sshpk"."1.7.4" = self.buildNodePackage {
+    name = "sshpk-1.7.4";
+    version = "1.7.4";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz";
+      name = "sshpk-1.7.4.tgz";
+      sha1 = "ad7b47defca61c8415d964243b62b0ce60fbca38";
+    };
+    deps = {
+      "asn1-0.2.3" = self.by-version."asn1"."0.2.3";
+      "assert-plus-0.2.0" = self.by-version."assert-plus"."0.2.0";
+      "dashdash-1.13.0" = self.by-version."dashdash"."1.13.0";
+    };
+    optionalDependencies = {
+      "jsbn-0.1.0" = self.by-version."jsbn"."0.1.0";
+      "tweetnacl-0.14.1" = self.by-version."tweetnacl"."0.14.1";
+      "jodid25519-1.0.2" = self.by-version."jodid25519"."1.0.2";
+      "ecc-jsbn-0.1.1" = self.by-version."ecc-jsbn"."0.1.1";
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."stringstream"."0.0.5" = self.buildNodePackage {
+    name = "stringstream-0.0.5";
+    version = "0.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz";
+      name = "stringstream-0.0.5.tgz";
+      sha1 = "4e484cd4de5a0bbbee18e46307710a8a81621878";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."strip-ansi"."^3.0.0" =
+    self.by-version."strip-ansi"."3.0.1";
+  by-version."strip-ansi"."3.0.1" = self.buildNodePackage {
+    name = "strip-ansi-3.0.1";
+    version = "3.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
+      name = "strip-ansi-3.0.1.tgz";
+      sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
+    };
+    deps = {
+      "ansi-regex-2.0.0" = self.by-version."ansi-regex"."2.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."strip-bom"."^2.0.0" =
+    self.by-version."strip-bom"."2.0.0";
+  by-version."strip-bom"."2.0.0" = self.buildNodePackage {
+    name = "strip-bom-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz";
+      name = "strip-bom-2.0.0.tgz";
+      sha1 = "6219a85616520491f35788bdbf1447a99c7e6b0e";
+    };
+    deps = {
+      "is-utf8-0.2.1" = self.by-version."is-utf8"."0.2.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."strip-indent"."^1.0.1" =
+    self.by-version."strip-indent"."1.0.1";
+  by-version."strip-indent"."1.0.1" = self.buildNodePackage {
+    name = "strip-indent-1.0.1";
+    version = "1.0.1";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz";
+      name = "strip-indent-1.0.1.tgz";
+      sha1 = "0c7962a6adefa7bbd4ac366460a638552ae1a0a2";
+    };
+    deps = {
+      "get-stdin-4.0.1" = self.by-version."get-stdin"."4.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."strip-json-comments"."~1.0.4" =
+    self.by-version."strip-json-comments"."1.0.4";
+  by-version."strip-json-comments"."1.0.4" = self.buildNodePackage {
+    name = "strip-json-comments-1.0.4";
+    version = "1.0.4";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz";
+      name = "strip-json-comments-1.0.4.tgz";
+      sha1 = "1e15fbcac97d3ee99bf2d73b4c656b082bbafb91";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."supports-color"."^2.0.0" =
+    self.by-version."supports-color"."2.0.0";
+  by-version."supports-color"."2.0.0" = self.buildNodePackage {
+    name = "supports-color-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
+      name = "supports-color-2.0.0.tgz";
+      sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."temp"."0.8.3" =
+    self.by-version."temp"."0.8.3";
+  by-version."temp"."0.8.3" = self.buildNodePackage {
+    name = "temp-0.8.3";
+    version = "0.8.3";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/temp/-/temp-0.8.3.tgz";
+      name = "temp-0.8.3.tgz";
+      sha1 = "e0c6bc4d26b903124410e4fed81103014dfc1f59";
+    };
+    deps = {
+      "os-tmpdir-1.0.1" = self.by-version."os-tmpdir"."1.0.1";
+      "rimraf-2.2.8" = self.by-version."rimraf"."2.2.8";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."temp"."^0.8.1" =
+    self.by-version."temp"."0.8.3";
+  by-spec."through"."2" =
+    self.by-version."through"."2.3.8";
+  by-version."through"."2.3.8" = self.buildNodePackage {
+    name = "through-2.3.8";
+    version = "2.3.8";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/through/-/through-2.3.8.tgz";
+      name = "through-2.3.8.tgz";
+      sha1 = "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."through"."~2.3" =
+    self.by-version."through"."2.3.8";
+  by-spec."through"."~2.3.1" =
+    self.by-version."through"."2.3.8";
+  by-spec."topo"."1.x.x" =
+    self.by-version."topo"."1.1.0";
+  by-version."topo"."1.1.0" = self.buildNodePackage {
+    name = "topo-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/topo/-/topo-1.1.0.tgz";
+      name = "topo-1.1.0.tgz";
+      sha1 = "e9d751615d1bb87dc865db182fa1ca0a5ef536d5";
+    };
+    deps = {
+      "hoek-2.16.3" = self.by-version."hoek"."2.16.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."tough-cookie"."~2.2.0" =
+    self.by-version."tough-cookie"."2.2.2";
+  by-version."tough-cookie"."2.2.2" = self.buildNodePackage {
+    name = "tough-cookie-2.2.2";
+    version = "2.2.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz";
+      name = "tough-cookie-2.2.2.tgz";
+      sha1 = "c83a1830f4e5ef0b93ef2a3488e724f8de016ac7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."trim-newlines"."^1.0.0" =
+    self.by-version."trim-newlines"."1.0.0";
+  by-version."trim-newlines"."1.0.0" = self.buildNodePackage {
+    name = "trim-newlines-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz";
+      name = "trim-newlines-1.0.0.tgz";
+      sha1 = "5887966bb582a4503a41eb524f7d35011815a613";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."tsd"."~0.6.5" =
+    self.by-version."tsd"."0.6.5";
+  by-version."tsd"."0.6.5" = self.buildNodePackage {
+    name = "tsd-0.6.5";
+    version = "0.6.5";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/tsd/-/tsd-0.6.5.tgz";
+      name = "tsd-0.6.5.tgz";
+      sha1 = "34a0b64c1db6a70b3860fe4f5571d9d1357421ad";
+    };
+    deps = {
+      "assertion-error-1.0.0" = self.by-version."assertion-error"."1.0.0";
+      "bl-0.9.5" = self.by-version."bl"."0.9.5";
+      "bluebird-1.2.4" = self.by-version."bluebird"."1.2.4";
+      "chalk-1.1.1" = self.by-version."chalk"."1.1.1";
+      "colors-1.1.2" = self.by-version."colors"."1.1.2";
+      "deep-freeze-0.0.1" = self.by-version."deep-freeze"."0.0.1";
+      "definition-header-0.1.0" = self.by-version."definition-header"."0.1.0";
+      "detect-indent-0.2.0" = self.by-version."detect-indent"."0.2.0";
+      "diff-1.4.0" = self.by-version."diff"."1.4.0";
+      "event-stream-3.1.7" = self.by-version."event-stream"."3.1.7";
+      "exit-0.1.2" = self.by-version."exit"."0.1.2";
+      "glob-4.5.3" = self.by-version."glob"."4.5.3";
+      "joi-4.9.0" = self.by-version."joi"."4.9.0";
+      "joi-assert-0.0.3" = self.by-version."joi-assert"."0.0.3";
+      "jsesc-0.5.0" = self.by-version."jsesc"."0.5.0";
+      "json-pointer-0.2.2" = self.by-version."json-pointer"."0.2.2";
+      "lazy.js-0.3.2" = self.by-version."lazy.js"."0.3.2";
+      "lru-cache-2.5.2" = self.by-version."lru-cache"."2.5.2";
+      "minimatch-1.0.0" = self.by-version."minimatch"."1.0.0";
+      "minimist-1.2.0" = self.by-version."minimist"."1.2.0";
+      "ministyle-0.1.4" = self.by-version."ministyle"."0.1.4";
+      "minitable-0.0.4" = self.by-version."minitable"."0.0.4";
+      "miniwrite-0.1.4" = self.by-version."miniwrite"."0.1.4";
+      "mkdirp-0.5.1" = self.by-version."mkdirp"."0.5.1";
+      "open-0.0.5" = self.by-version."open"."0.0.5";
+      "request-2.69.0" = self.by-version."request"."2.69.0";
+      "rimraf-2.2.8" = self.by-version."rimraf"."2.2.8";
+      "semver-4.3.6" = self.by-version."semver"."4.3.6";
+      "type-detect-0.1.2" = self.by-version."type-detect"."0.1.2";
+      "universal-analytics-0.3.11" = self.by-version."universal-analytics"."0.3.11";
+      "update-notifier-0.2.2" = self.by-version."update-notifier"."0.2.2";
+      "uri-templates-0.1.9" = self.by-version."uri-templates"."0.1.9";
+      "uuid-2.0.1" = self.by-version."uuid"."2.0.1";
+      "verror-1.4.0" = self.by-version."verror"."1.4.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "tsd" = self.by-version."tsd"."0.6.5";
+  by-spec."tunnel-agent"."~0.4.1" =
+    self.by-version."tunnel-agent"."0.4.2";
+  by-version."tunnel-agent"."0.4.2" = self.buildNodePackage {
+    name = "tunnel-agent-0.4.2";
+    version = "0.4.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz";
+      name = "tunnel-agent-0.4.2.tgz";
+      sha1 = "1104e3f36ac87125c287270067d582d18133bfee";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."tweetnacl".">=0.13.0 <1.0.0" =
+    self.by-version."tweetnacl"."0.14.1";
+  by-version."tweetnacl"."0.14.1" = self.buildNodePackage {
+    name = "tweetnacl-0.14.1";
+    version = "0.14.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.1.tgz";
+      name = "tweetnacl-0.14.1.tgz";
+      sha1 = "37c6a1fb5cd4b63b7acee450d8419d9c0024cc03";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."type-detect"."~0.1.2" =
+    self.by-version."type-detect"."0.1.2";
+  by-version."type-detect"."0.1.2" = self.buildNodePackage {
+    name = "type-detect-0.1.2";
+    version = "0.1.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/type-detect/-/type-detect-0.1.2.tgz";
+      name = "type-detect-0.1.2.tgz";
+      sha1 = "c88e853e54e5abd88f1bf3194b477c853c94f854";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."universal-analytics"."~0.3.4" =
+    self.by-version."universal-analytics"."0.3.11";
+  by-version."universal-analytics"."0.3.11" = self.buildNodePackage {
+    name = "universal-analytics-0.3.11";
+    version = "0.3.11";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.11.tgz";
+      name = "universal-analytics-0.3.11.tgz";
+      sha1 = "512879193a12a66dcbd9185121389bab913cd4b6";
+    };
+    deps = {
+      "request-2.69.0" = self.by-version."request"."2.69.0";
+      "underscore-1.8.3" = self.by-version."underscore"."1.8.3";
+      "node-uuid-1.4.7" = self.by-version."node-uuid"."1.4.7";
+      "async-0.2.10" = self.by-version."async"."0.2.10";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."update-notifier"."^0.2.2" =
+    self.by-version."update-notifier"."0.2.2";
+  by-version."update-notifier"."0.2.2" = self.buildNodePackage {
+    name = "update-notifier-0.2.2";
+    version = "0.2.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/update-notifier/-/update-notifier-0.2.2.tgz";
+      name = "update-notifier-0.2.2.tgz";
+      sha1 = "e69b3a784b4e686a2acd98f5e66944591996e187";
+    };
+    deps = {
+      "chalk-0.5.1" = self.by-version."chalk"."0.5.1";
+      "configstore-0.3.2" = self.by-version."configstore"."0.3.2";
+      "is-npm-1.0.0" = self.by-version."is-npm"."1.0.0";
+      "latest-version-1.0.1" = self.by-version."latest-version"."1.0.1";
+      "semver-diff-2.1.0" = self.by-version."semver-diff"."2.1.0";
+      "string-length-1.0.1" = self.by-version."string-length"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."uri-templates"."~0.1.5" =
+    self.by-version."uri-templates"."0.1.9";
+  by-version."uri-templates"."0.1.9" = self.buildNodePackage {
+    name = "uri-templates-0.1.9";
+    version = "0.1.9";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/uri-templates/-/uri-templates-0.1.9.tgz";
+      name = "uri-templates-0.1.9.tgz";
+      sha1 = "c56f7a5731b3a310226695f6e5639180fd1aa249";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."util-deprecate"."~1.0.1" =
+    self.by-version."util-deprecate"."1.0.2";
+  by-version."util-deprecate"."1.0.2" = self.buildNodePackage {
+    name = "util-deprecate-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
+      name = "util-deprecate-1.0.2.tgz";
+      sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."validate-npm-package-license"."^3.0.1" =
+    self.by-version."validate-npm-package-license"."3.0.1";
+  by-version."validate-npm-package-license"."3.0.1" = self.buildNodePackage {
+    name = "validate-npm-package-license-3.0.1";
+    version = "3.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz";
+      name = "validate-npm-package-license-3.0.1.tgz";
+      sha1 = "2804babe712ad3379459acfbe24746ab2c303fbc";
+    };
+    deps = {
+      "spdx-correct-1.0.2" = self.by-version."spdx-correct"."1.0.2";
+      "spdx-expression-parse-1.0.2" = self.by-version."spdx-expression-parse"."1.0.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."verror"."~1.4.0" =
+    self.by-version."verror"."1.4.0";
+  by-version."verror"."1.4.0" = self.buildNodePackage {
+    name = "verror-1.4.0";
+    version = "1.4.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/verror/-/verror-1.4.0.tgz";
+      name = "verror-1.4.0.tgz";
+      sha1 = "5d8fdf5875141c3183b7c6bc23a0aa3e3e6ca4e2";
+    };
+    deps = {
+      "extsprintf-1.0.3" = self.by-version."extsprintf"."1.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."xtend"."4.0.1" = self.buildNodePackage {
+    name = "xtend-4.0.1";
+    version = "4.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz";
+      name = "xtend-4.0.1.tgz";
+      sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."yallist"."^2.0.0" =
+    self.by-version."yallist"."2.0.0";
+  by-version."yallist"."2.0.0" = self.buildNodePackage {
+    name = "yallist-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz";
+      name = "yallist-2.0.0.tgz";
+      sha1 = "306c543835f09ee1a4cb23b7bce9ab341c91cdd4";
+    };
+    deps = {
     };
     optionalDependencies = {
     };

--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -4477,7 +4477,24 @@
     os = [ ];
     cpu = [ ];
   };
-  "bower" = self.by-version."bower"."1.4.1";
+  by-version."bower"."1.7.7" = self.buildNodePackage {
+    name = "bower-1.7.7";
+    version = "1.7.7";
+    bin = true;
+    src = fetchurl {
+      url = "http://registry.npmjs.org/bower/-/bower-1.7.7.tgz";
+      name = "bower-1.7.7.tgz";
+      sha1 = "2fd7ff3ebdcba5a8ffcd84c397c8fdfe9f825f92";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "bower" = self.by-version."bower"."1.7.7";
   by-spec."bower".">=1.2.8 <2" =
     self.by-version."bower"."1.4.1";
   by-spec."bower-config"."^0.6.1" =

--- a/pkgs/top-level/node-packages.json
+++ b/pkgs/top-level/node-packages.json
@@ -122,7 +122,6 @@
 , "git-run"
 , "bower"
 , "bower2nix"
-, "fetch-bower"
 , "npm-check-updates"
 , "node-stringprep"
 , "ltx"

--- a/pkgs/top-level/node-packages.nix
+++ b/pkgs/top-level/node-packages.nix
@@ -63,6 +63,12 @@ in rec {
         sha1 = "26220f7e43ee3c0d714860db61c4d0ecc9bb3d89";
       }} ../webdrvr/chromedriver_linux64.zip
     '';
+    bower2nix.buildInputs = [ pkgs.makeWrapper ];
+    bower2nix.postInstall = ''
+      for prog in bower2nix fetch-bower; do
+        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+      done
+    '';
   } // args.overrides or {};
 
   # Apply overrides and back compatiblity transformations


### PR DESCRIPTION
This updates `bower2nix` and `fetch-bower` to fix some bugs ([release notes](https://github.com/rvl/bower2nix/releases/tag/v3.0.1)).

There is a new `buildBowerComponents` function which wraps `fetchBower` and makes it easier to use in a project.

I have also written some documentation.

cc @shlevy @rbvermaa @svanderburg 
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [X] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against master"`.
  :question: Have run this, with a `Result in /run/user/1000/nox-review-5mnpj70p`. What is the expected output of `nox-review`?
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
