### PR TITLE
docbook-xsl: 1.78.1 -> 1.79.1

### DIFF
--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -3,7 +3,7 @@
 let
 
   common = { pname, sha256 }: stdenv.mkDerivation rec {
-    name = "${pname}-1.78.1";
+    name = "${pname}-1.79.1";
 
     src = fetchurl {
       url = "mirror://sourceforge/docbook/${name}.tar.bz2";
@@ -36,12 +36,12 @@ in {
 
   docbook_xsl = common {
     pname = "docbook-xsl";
-    sha256 = "0rxl013ncmz1n6ymk2idvx3hix9pdabk8xn01cpcv32wmfb753y9";
+    sha256 = "0s59lihif2fr7rznckxr2kfyrvkirv76r1zvidp9b5mj28p4apvj";
   };
 
   docbook_xsl_ns = common {
     pname = "docbook-xsl-ns";
-    sha256 = "1x3sc0axk9z3i6n0jhlsmzlmb723a4sjgslm9g12by6phirdx3ng";
+    sha256 = "170ggf5dgjar65kkn5n33kvjr3pdinpj66nnxfx8b2avw0k91jin";
   };
 
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
