### PR TITLE
Workaround Skype segfault

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skype/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skype/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     cat > $out/bin/skype << EOF
     #!${stdenv.shell}
     export PULSE_LATENCY_MSEC=60  # workaround for pulseaudio glitches
-    $out/libexec/skype/skype --resources=$out/libexec/skype "\$@"
+    exec $out/libexec/skype/skype --resources=$out/libexec/skype "\$@"
     EOF
 
     chmod +x $out/bin/skype
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
     description = "A proprietary voice-over-IP (VoIP) client";
     homepage = http://www.skype.com/;
     license = stdenv.lib.licenses.unfree;
+    platforms = [ "i686-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13505,7 +13505,13 @@ let
 
   siproxd = callPackage ../applications/networking/siproxd { };
 
-  skype = callPackage_i686 ../applications/networking/instant-messengers/skype { };
+  # Needed for skype
+  qt4-clang = qt4.override {
+    stdenv = clangStdenv;
+  };
+  skype = callPackage_i686 ../applications/networking/instant-messengers/skype {
+    qt4 = qt4-clang;
+  };
 
   skype4pidgin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/skype4pidgin { };
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -184,6 +184,7 @@ let
       pythonFull = linux;
       sbcl = linux;
       qt3 = linux;
+      qt4-clang = [ "i686-linux" ];
       quake3demo = linux;
       reiserfsprogs = linux;
       rubber = allBut cygwin;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This is one possible solution to the problem. I'm not sure if I've done everything correctly to force Hydra to build `qt4-clang` only on i686.

Fixes issue #14234

cc @rycee @domenkozar 
