### PR TITLE
xmlto: 0.0.26 -> 0.0.28

### DIFF
--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -1,12 +1,12 @@
 { fetchurl, stdenv, flex, libxml2, libxslt
-, docbook_xml_dtd_42, docbook_xsl, w3m
+, docbook_xml_dtd_45, docbook_xsl, w3m
 , bash, getopt, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "xmlto-0.0.26";
+  name = "xmlto-0.0.28";
   src = fetchurl {
     url = "http://fedorahosted.org/releases/x/m/xmlto/${name}.tar.bz2";
-    sha256 = "1v5mahfg5k9lh3anykl482xnrgxn36zlmqsgwahw29xwncprpd7g";
+    sha256 = "0xhj8b2pwp4vhl9y16v3dpxpsakkflfamr191mprzsspg4xdyc0i";
   };
 
   patchPhase = ''
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
 
   # `libxml2' provides `xmllint', needed at build-time and run-time.
   # `libxslt' provides `xsltproc', used by `xmlto' at run-time.
-  buildInputs = [ libxml2 libxslt docbook_xml_dtd_42 docbook_xsl getopt makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ libxml2 libxslt docbook_xml_dtd_45 docbook_xsl getopt ];
 
   postInstall = ''
     wrapProgram "$out/bin/xmlto" \


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
