### PR TITLE
gcc-arm-embedded: 4.9 -> 5.2

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, bzip2, patchelf, glibc, gcc, fetchurl, version, releaseType, sha256, ncurses }:
+{ stdenv, bzip2, patchelf, glibc, gcc, fetchurl, version, releaseType, sha256, ncurses
+, dirName ? null, subdirName ? null }:
 with stdenv.lib;
 let
   versionParts = splitString "-" version; # 4.7 2013q3 20130916
@@ -8,13 +9,15 @@ let
   yearQuarterParts = splitString "q" yearQuarter; # 2013 3
   year = elemAt yearQuarterParts 0; # 2013
   quarter = elemAt yearQuarterParts 1; # 3
-  subdirName = "${majorVersion}-${year}-q${quarter}-${releaseType}"; # 4.7-2013-q3-update
+  dirName_ = if dirName != null then dirName else majorVersion;
+  subdirName_ = if subdirName != null then subdirName
+    else "${majorVersion}-${year}-q${quarter}-${releaseType}"; # 4.7-2013-q3-update
 in
 stdenv.mkDerivation {
   name = "gcc-arm-embedded-${version}";
 
   src = fetchurl {
-    url = "https://launchpad.net/gcc-arm-embedded/${majorVersion}/${subdirName}/+download/gcc-arm-none-eabi-${underscoreVersion}-linux.tar.bz2";
+    url = "https://launchpad.net/gcc-arm-embedded/${dirName_}/${subdirName_}/+download/gcc-arm-none-eabi-${underscoreVersion}-linux.tar.bz2";
     sha256 = sha256;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4287,6 +4287,13 @@ in
     releaseType = "update";
     sha256 = "c5e0025b065750bbd76b5357b4fc8606d88afbac9ff55b8a82927b4b96178154";
   };
+  gcc-arm-embedded-5_2 = pkgs.callPackage_i686 ../development/compilers/gcc-arm-embedded {
+    dirName = "5.0";
+    subdirName = "5-2015-q4-major";
+    version = "5.2-2015q4-20151219";
+    releaseType = "major";
+    sha256 = "12mbwl9iwbw7h6gwwkvyvfmrsz7vgjz27jh2cz9z006ihzigi50y";
+  };
   gcc-arm-embedded = self.gcc-arm-embedded-4_9;
 
   gforth = callPackage ../development/compilers/gforth {};


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Seems that GCC ARM Embedded have changed convention for file location,
and version 5.2 isn't accessible from the predicted URL. That's why
nix-expression is updated to allow overloading URL parts.
