### PR TITLE
lttng-modules: mark as broken on kernel version <3.18

### DIFF
--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl21 gpl2 mit ];
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
-    broken = (kernel.features.grsecurity or false);
+    broken =
+      (builtins.compareVersions kernel.version "3.18" == -1) ||
+      (kernel.features.grsecurity or false);
   };
 
 }


### PR DESCRIPTION
Ref: https://github.com/NixOS/nixpkgs/issues/13559
