### PR TITLE
idea.idea15-ultimate: init at 15.0.5

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -195,6 +195,18 @@ in
     };
   };
 
+  idea15-ultimate = buildIdea rec {
+    name = "idea-ultimate-${version}";
+    version = "15.0.5";
+    build = "IU-143.2332.3";
+    description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
+    license = stdenv.lib.licenses.unfree;
+    src = fetchurl {
+      url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
+      sha256 = "1hvc5cmbfpp0qad0236ffh3g7zwfk64rh5bkkb750h3387jz7nr2";
+    };
+  };
+
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
     version = "2016.1";


### PR DESCRIPTION
This adds back idea-ultimate version 15, which 5bb0aa3 upgraded away from.

Personally, I can't upgrade past 15 right now, because it's the latest version I have a license key for. Due to JetBrains' recent changes to their license terms, I suspect there are others in this situation as well.
