### PR TITLE
distcc: add libiberty as a buildInput

### DIFF
--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, popt, avahi, pkgconfig, python, gtk, runCommand, gcc, autoconf, automake, which, procps
+{ stdenv, fetchFromGitHub, popt, avahi, pkgconfig, python, gtk, runCommand
+, gcc, autoconf, automake, which, procps, libiberty_static
 , sysconfDir ? ""   # set this parameter to override the default value $out/etc
 , static ? false
 }:
@@ -15,7 +16,7 @@ let
       sha256 = "1vj31wcdas8wy52hy6749mlrca9v6ynycdiigx5ay8pnya9z73c6";
     };
 
-    buildInputs = [popt avahi pkgconfig python gtk autoconf automake pkgconfig which procps];
+    buildInputs = [popt avahi pkgconfig python gtk autoconf automake pkgconfig which procps libiberty_static];
     preConfigure =
     ''
       export CPATH=$(ls -d ${gcc.cc}/lib/gcc/*/${gcc.cc.version}/plugin/include)


### PR DESCRIPTION
###### Things done:
- [x ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes https://hydra.nixos.org/build/33700817

cc @simons

This is intended to fix the build failure. However, I'm not sure how to test - on my system (x86_64 NixOS) the build succeeds both with and without this diff (libiberty headers are already found due to this line `export CPATH=$(ls -d ${gcc.cc}/lib/gcc/*/${gcc.cc.version}/plugin/include)`). Apparently this doesn't work on i686, so hopefully depending on libiberty will.

---

_Please note, that points are not mandatory, but rather desired._
