### PR TITLE
emacsPackagesNg: remove compatibility cl-lib

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-packages.nix
@@ -35,11 +35,11 @@ self:
     };
 
     overrides = {
-      # These packages require emacs-25
-      el-search = markBroken super.el-search;
-      iterators = markBroken super.iterators;
-      midi-kbd = markBroken super.midi-kbd;
-      stream = markBroken super.stream;
+      el-search = markBroken super.el-search; # requires emacs-25
+      iterators = markBroken super.iterators; # requires emacs-25
+      midi-kbd = markBroken super.midi-kbd; # requires emacs-25
+      stream = markBroken super.stream; # requires emacs-25
+      cl-lib = null; # builtin
     };
 
     elpaPackages = super // overrides;


### PR DESCRIPTION
ELPA has the compatibility library cl-lib-0.5 which interferes with the
builtin cl-lib-1.0.

(cherry picked from commit 6c05554b8560c9992afb5996c7d0e1a1f590f50c)
