### PR TITLE
Add Telegram Desktop

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,0 +1,164 @@
+{ stdenv, lib, fetchFromGitHub, fetchgit, qtbase, qtimageformats
+, breakpad, ffmpeg, openalSoft, openssl, zlib, libexif, lzma, libopus
+, gtk2, glib, cairo, pango, gdk_pixbuf, atk, libappindicator-gtk2
+, libunity, dee, libdbusmenu-glib, libva
+
+, pkgconfig, libxcb, xcbutilwm, xcbutilimage, xcbutilkeysyms
+, libxkbcommon, libpng, libjpeg, freetype, harfbuzz, pcre16
+, xproto, libX11, inputproto, sqlite, dbus
+}:
+
+let
+  system-x86_64 = lib.elem stdenv.system lib.platforms.x86_64;
+in stdenv.mkDerivation rec {
+  name = "telegram-desktop-${version}";
+  version = "0.9.33";
+  qtVersion = lib.replaceStrings ["."] ["_"] qtbase.version;
+
+  src = fetchFromGitHub {
+    owner = "telegramdesktop";
+    repo = "tdesktop";
+    rev = "v${version}";
+    sha256 = "020vwm7h22951v9zh457d82qy5ifp746vwishkvb16h1vwr1qx4s";
+  };
+
+  tgaur = fetchgit {
+    url = "https://aur.archlinux.org/telegram-desktop.git";
+    rev = "df47a864282959b103a08b65844e9088e012fdb3";
+    sha256 = "1v1dbi8yiaf2hgghniykm5qbnda456xj3zfjnbqysn41f5cn40h4";
+  };
+
+  buildInputs = [
+    breakpad ffmpeg openalSoft openssl zlib libexif lzma libopus
+    gtk2 glib libappindicator-gtk2 libunity cairo pango gdk_pixbuf atk
+    dee libdbusmenu-glib libva
+    # Qt dependencies
+    libxcb xcbutilwm xcbutilimage xcbutilkeysyms libxkbcommon
+    libpng libjpeg freetype harfbuzz pcre16 xproto libX11
+    inputproto sqlite dbus
+  ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  qmakeFlags = [
+    "CONFIG+=release"
+    "DEFINES+=TDESKTOP_DISABLE_AUTOUPDATE"
+    "DEFINES+=TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME"
+    "INCLUDEPATH+=${gtk2}/include/gtk-2.0"
+    "INCLUDEPATH+=${glib}/include/glib-2.0"
+    "INCLUDEPATH+=${glib}/lib/glib-2.0/include"
+    "INCLUDEPATH+=${cairo}/include/cairo"
+    "INCLUDEPATH+=${pango}/include/pango-1.0"
+    "INCLUDEPATH+=${gtk2}/lib/gtk-2.0/include"
+    "INCLUDEPATH+=${gdk_pixbuf}/include/gdk-pixbuf-2.0"
+    "INCLUDEPATH+=${atk}/include/atk-1.0"
+    "INCLUDEPATH+=${libappindicator-gtk2}/include/libappindicator-0.1"
+    "INCLUDEPATH+=${libunity}/include/unity"
+    "INCLUDEPATH+=${dee}/include/dee-1.0"
+    "INCLUDEPATH+=${libdbusmenu-glib}/include/libdbusmenu-glib-0.4"
+    "INCLUDEPATH+=${breakpad}/include/breakpad"
+    "LIBS+=-lcrypto"
+    "LIBS+=-lssl"
+    "LIBS+=-lz"
+    "LIBS+=-lgobject-2.0"
+    "LIBS+=-lxkbcommon"
+    "LIBS+=-lX11"
+    "LIBS+=${breakpad}/lib/libbreakpad_client.a"
+    "LIBS+=./../../../Libraries/QtStatic/qtbase/plugins/platforms/libqxcb.a"
+    "LIBS+=./../../../Libraries/QtStatic/qtimageformats/plugins/imageformats/libqwebp.a"
+  ];
+
+  qtSrcs = qtbase.srcs ++ [ qtimageformats.src ];
+  qtPatches = qtbase.patches;
+
+  buildCommand = ''
+    # We don't use nativeBuildInputs to avoid adding system Qt 5 libraries to various paths.
+    export PATH="${qtbase}/bin:$PATH"
+
+    unpackPhase
+    cd "$sourceRoot"
+    patchPhase
+    sed -i 'Telegram/Telegram.pro' \
+      -e 's/CUSTOM_API_ID//g' \
+      -e 's,/usr,/does-not-exist,g' \
+      -e '/LIBS += .*libxkbcommon.a/d' \
+      -e '/LIBS += .*libz.a/d' \
+      -e '/LIBS += .*libbreakpad_client.a/d' \
+      -e 's,-flto ,,g'
+    echo "Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)" >> Telegram/SourceFiles/stdafx.cpp
+
+    ( mkdir -p ../Libraries
+      cd ../Libraries
+      for i in $qtSrcs; do
+        tar -xaf $i
+      done
+      mv qt-everywhere-opensource-src-* QtStatic
+      mv qtbase-opensource-src-* ./QtStatic/qtbase
+      mv qtimageformats-opensource-src-* ./QtStatic/qtimageformats
+      cd QtStatic/qtbase
+      patch -p1 < ../../../$sourceRoot/Telegram/_qtbase_${qtVersion}_patch.diff
+      cd ..
+      for i in $qtPatches; do
+        patch -p1 < $i
+      done
+      ${qtbase.postPatch}
+
+      export configureFlags="-prefix "../../qt" -release -opensource -confirm-license -system-zlib \
+        -system-libpng -system-libjpeg -system-freetype -system-harfbuzz -system-pcre -system-xcb \
+        -system-xkbcommon-x11 -no-opengl -static -nomake examples -nomake tests \
+        -openssl-linked -dbus-linked -system-sqlite -verbose \
+        ${lib.optionalString (!system-x86_64) "-no-sse2"} -no-sse3 -no-ssse3 \
+        -no-sse4.1 -no-sse4.2 -no-avx -no-avx2 -no-mips_dsp -no-mips_dspr2"
+      export dontAddPrefix=1
+      export buildFlags="module-qtbase module-qtimageformats"
+      export installFlags="module-qtbase-install_subtargets module-qtimageformats-install_subtargets"
+
+      ( export MAKEFLAGS=-j$NIX_BUILD_CORES
+        configurePhase
+      )
+      buildPhase
+      installPhase
+    )
+
+    ( mkdir -p Linux/DebugIntermediateStyle
+      cd Linux/DebugIntermediateStyle
+      qmake CONFIG+=debug ../../Telegram/MetaStyle.pro
+      buildPhase
+    )
+    ( mkdir -p Linux/DebugIntermediateLang
+      cd Linux/DebugIntermediateLang
+      qmake CONFIG+=debug ../../Telegram/MetaLang.pro
+      buildPhase
+    )
+
+    ( mkdir -p Linux/ReleaseIntermediate
+      cd Linux/ReleaseIntermediate
+      qmake $qmakeFlags ../../Telegram/Telegram.pro
+      pattern="^PRE_TARGETDEPS +="
+      grep "$pattern" "../../Telegram/Telegram.pro" | sed "s/$pattern//g" | xargs make
+
+      qmake $qmakeFlags ../../Telegram/Telegram.pro
+      buildPhase
+    )
+
+    install -Dm755 Linux/Release/Telegram $out/bin/telegram-desktop
+    mkdir -p $out/share/applications $out/share/kde4/services
+    sed "s,/usr/bin,$out/bin,g" $tgaur/telegramdesktop.desktop > $out/share/applications/telegramdesktop.desktop
+    sed "s,/usr/bin,$out/bin,g" $tgaur/tg.protocol > $out/share/kde4/services/tg.protocol
+    for icon_size in 16 32 48 64 128 256 512; do
+      install -Dm644 "Telegram/SourceFiles/art/icon''${icon_size}.png" "$out/share/icons/hicolor/''${icon_size}x''${icon_size}/apps/telegram-desktop.png"
+    done
+
+    fixupPhase
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Telegram Desktop messaging app";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    homepage = "https://desktop.telegram.org/";
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/breakpad/default.nix
+++ b/pkgs/development/libraries/breakpad/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  name = "breakpad-2016-03-28";
+  
+  src = fetchgit {
+    url = "https://chromium.googlesource.com/breakpad/breakpad";
+    rev = "512cac3a1b69721ab727f3079f4d29e4580467b1";
+    sha256 = "0v7k7racdl2f16mbi3r0vkbkagh0gf6ksnpf3ri28b9pjfngkl5s";
+  };
+
+  breakpad_lss = fetchgit {
+    url = "https://chromium.googlesource.com/linux-syscall-support";
+    rev = "08056836f2b4a5747daff75435d10d649bed22f6";
+    sha256 = "1ryshs2nyxwa0kn3rlbnd5b3fhna9vqm560yviddcfgdm2jyg0hz";
+  };
+
+  enableParallelBuilding = true;
+
+  prePatch = ''
+    cp -r $breakpad_lss src/third_party/lss
+    chmod +w -R src/third_party/lss
+  '';
+}

--- a/pkgs/development/libraries/dee/default.nix
+++ b/pkgs/development/libraries/dee/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, python, pkgconfig
+, glib, icu, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "dee-${version}";
+  version = "1.2.7";
+
+  src = fetchurl {
+    url = "https://launchpad.net/dee/1.0/${version}/+download/${name}.tar.gz";
+    sha256 = "12mzffk0lyd566y46x57jlvb9af152b4dqpasr40zal4wrn37w0v";
+  };
+
+  buildInputs = [ glib gobjectIntrospection icu ];
+  nativeBuildInputs = [ python pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A library that uses DBus to provide objects allowing you to create Model-View-Controller type programs across DBus";
+    homepage = "https://launchpad.net/dee";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/libgee/0.6.nix
+++ b/pkgs/development/libraries/libgee/0.6.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, glib }:
+
+let
+  ver_maj = "0.6";
+  ver_min = "8";
+in
+stdenv.mkDerivation rec {
+  name = "libgee-${ver_maj}.${ver_min}";
+
+  src = fetchurl {
+    url = "https://download.gnome.org/sources/libgee/${ver_maj}/${name}.tar.xz";
+    sha256 = "1lzmxgz1bcs14ghfp8qqzarhn7s64ayx8c508ihizm3kc5wqs7x6";
+  };
+
+  buildInputs = [ glib ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Utility library providing GObject-based interfaces and classes for commonly used data structures";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    homepage = "http://live.gnome.org/Libgee";
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/libunity/default.nix
+++ b/pkgs/development/libraries/libunity/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, vala, python, intltool, pkgconfig
+, glib, libgee_0_6, gtk3, dee, libdbusmenu-glib
+}:
+
+stdenv.mkDerivation rec {
+  name = "libunity-${version}";
+  version = "6.12.0";
+
+  src = fetchurl {
+    url = "https://launchpad.net/libunity/6.0/${version}/+download/${name}.tar.gz";
+    sha256 = "1nadapl3390x98q1wv2yarh60hzi7ck0d1s8zz9xsiq3zz6msbjd";
+  };
+
+  buildInputs = [ glib libgee_0_6 gtk3 ];
+  propagatedBuildInputs = [ dee libdbusmenu-glib ];
+  nativeBuildInputs = [ vala python intltool pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A library for instrumenting- and integrating with all aspects of the Unity shell";
+    homepage = "https://launchpad.net/libunity";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7424,6 +7424,8 @@ in
 
   libgdata = gnome3.libgdata;
 
+  libgee_0_6 = callPackage ../development/libraries/libgee/0.6.nix { };
+
   libgig = callPackage ../development/libraries/libgig { };
 
   libgnome_keyring = callPackage ../development/libraries/libgnome-keyring { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6549,6 +6549,8 @@ in
   dbus_libs = pkgs.dbus.libs;
   dbus_daemon = pkgs.dbus.daemon;
 
+  dee = callPackage ../development/libraries/dee { };
+
   dhex = callPackage ../applications/editors/dhex { };
 
   double_conversion = callPackage ../development/libraries/double-conversion { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7906,6 +7906,8 @@ in
 
   libu2f-server = callPackage ../development/libraries/libu2f-server { };
 
+  libunity = callPackage ../development/libraries/libunity { };
+
   libunistring = callPackage ../development/libraries/libunistring { };
 
   libupnp = callPackage ../development/libraries/pupnp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13852,7 +13852,9 @@ in
 
   taskserver = callPackage ../servers/misc/taskserver { };
 
-  telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli/default.nix { };
+  tdesktop = qt55.callPackage ../applications/networking/instant-messengers/telegram/tdesktop { };
+
+  telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli { };
 
   telepathy_gabble = callPackage ../applications/networking/instant-messengers/telepathy/gabble { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8345,6 +8345,14 @@ in
   pcre = callPackage ../development/libraries/pcre {
     unicodeSupport = config.pcre.unicode or true;
   };
+  pcre16 = pcre.override {
+    cplusplusSupport = false;
+    withCharSize = 16;
+  };
+  pcre32 = pcre.override {
+    cplusplusSupport = false;
+    withCharSize = 32;
+  };
 
   pcre2 = callPackage ../development/libraries/pcre2 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6389,6 +6389,8 @@ in
   box2d = callPackage ../development/libraries/box2d { };
   box2d_2_0_1 = callPackage ../development/libraries/box2d/2.0.1.nix { };
 
+  breakpad = callPackage ../development/libraries/breakpad { };
+
   buddy = callPackage ../development/libraries/buddy { };
 
   bwidget = callPackage ../development/libraries/bwidget { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Adds Telegram Desktop and required packages.

P.S.: In my personal rating of packages with completely crazy, "because f*ck you that's why" build sequences this would make a top, and for a long time I feel. The most funny thing is that, modulo several improvements for using more system libraries and more `INCLUDEPATH`s than expected (Because why use pkg-config? Let's just hardcode FHS paths for all packages we use and their dependencies by hand!), this is _an official building procedure_ (see [1](https://github.com/telegramdesktop/tdesktop/blob/master/doc/building-qmake.md)). _Yes_, with a statically built Qt with custom patches "because our font rendering engine uses internal Qt calls". _Yes_, with sed-patches and manual adding of `LIBS` to link to. _Yes_, with this `grep ... | sed ... | xargs make` -- because why spend time to figure out how to properly list dependencies in QMake? And even -- _yes_, with Arch AUR package as an official source for .desktop files.

Not a nice package, certainly. If you spot any profanity in the code, please excuse me -- I was forced.
