### PR TITLE
openblas: 0.2.15 -> 0.2.17

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -22,13 +22,13 @@ let local = config.openblas.preferLocalBuild or false;
       optionals (hasAttr "target" config.openblas) [ "TARGET=${config.openblas.target}" ];
     blas64 = if blas64_ != null then blas64_ else hasPrefix "x86_64" stdenv.system;
 
-    version = "0.2.15";
+    version = "0.2.17";
 in
 stdenv.mkDerivation {
   name = "openblas-${version}";
   src = fetchurl {
     url = "https://github.com/xianyi/OpenBLAS/archive/v${version}.tar.gz";
-    sha256 = "0i4hrjx622vw5ff35wm6cnga3ic8hcfa88p1wlj24a3qb770mi3k";
+    sha256 = "1gqdrxgc7qmr3xqq4wqcysjhv7ix4ar7ymn3vk5g97r1xvgkds0g";
     name = "openblas-${version}.tar.gz";
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ttuegel 
