### PR TITLE
oraclejdk: 8u73, 8u74 -> 8u77

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "73";
+  patchVersion = "77";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1bi3yj2ds9w13p2lzvmxffk5gax8syi3bw52w8pam1jr3fmzgwgl";
-  sha256_x86_64 = "1rp3nbnhkncyr48m0nn3pf5fr4bp3lzm0ki4gca7mn7rzag19a26";
+  sha256_i686 = "14hyniai5l9qpg0pbnxa4rhyhk90qgihszfkn8h3vziqhmvrp27j";
+  sha256_x86_64 = "0hyzvvj4bf0r4jda8fv3k06d9bf37nji37qbq067mcjp5abc0zd4";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "74";
+  patchVersion = "77";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1vc3g89fbrmznb10bhh5gs143hcjg4wsy4j4hwnr1djfj83y8188";
-  sha256_x86_64 = "1pfx7il1h42w3kigscdvm9vfy616lmsp1d2cqvplim3nyxwmvz8b";
+  sha256_i686 = "14hyniai5l9qpg0pbnxa4rhyhk90qgihszfkn8h3vziqhmvrp27j";
+  sha256_x86_64 = "0hyzvvj4bf0r4jda8fv3k06d9bf37nji37qbq067mcjp5abc0zd4";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Security fix for CVE-2016-0636.

http://www.oracle.com/technetwork/java/javase/8u77-relnotes-2944725.html

8u77 is based on 8u74, which is a Patch Set Updates (PSU). There is no Critical Patch Update (CPU) version but Oracle says “All users of earlier JDK 8 releases should update to this release”. So I updated both 8u73 and 8u74 to 8u77.
