### PR TITLE
v8: fix build(s)

### DIFF
--- a/pkgs/development/libraries/v8/generic.nix
+++ b/pkgs/development/libraries/v8/generic.nix
@@ -41,12 +41,18 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
   buildInputs = [ readline python icu ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
+
   buildFlags = [
     "LINK=g++"
     "-C out"
     "builddir=$(CURDIR)/Release"
     "BUILDTYPE=Release"
   ];
+
+  postPatch = stdenv.lib.optionalString (!stdenv.cc.isClang) ''
+    sed -i build/standalone.gyp -e 's,-Wno-format-pedantic,,g'
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Ignore errors due to strict-overflow warnings; strip clang-only flag on
non-clang builds. Concerning the latter "fix", it's not entirely clear to me why
the -Wno-format-pedantic flag ends up being passed to gcc, the .gyp file appears
to already condition the inclusion of this flag on whether cc=clang.

As per usual, I don't have enough memory for this ...

Ref: https://github.com/NixOS/nixpkgs/issues/13559
