### PR TITLE
r8168: init at 8.041.01

### DIFF
--- a/pkgs/os-specific/linux/r8168/4.5.patch
+++ b/pkgs/os-specific/linux/r8168/4.5.patch
@@ -1,0 +1,13 @@
+diff --git a/src/r8168_n.c b/src/r8168_n.c
+index d197630..b47419d 100755
+--- a/src/r8168_n.c
++++ b/src/r8168_n.c
+@@ -4209,7 +4209,7 @@ static netdev_features_t rtl8168_fix_features(struct net_device *dev,
+         spin_lock_irqsave(&tp->lock, flags);
+         if (dev->mtu > ETH_DATA_LEN) {
+                 features &= ~NETIF_F_ALL_TSO;
+-                features &= ~NETIF_F_ALL_CSUM;
++                features &= ~NETIF_F_CSUM_MASK;
+         }
+         spin_unlock_irqrestore(&tp->lock, flags);
+ 

--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, nukeReferences, kernel ? null }:
+
+
+with stdenv.lib;
+
+
+stdenv.mkDerivation rec {
+  name = "r8168-${version}-${kernel.version}";
+  version = "8.041.01";
+
+  # NOTE: there is an unnofficial github mirror for the source as well
+  src = fetchurl {
+    url = "http://12244.wpc.azureedge.net/8012244/drivers/rtdrivers/cn/nic/0004-r8168-8.041.01.tar.bz2";
+    sha256 = "0qpc72svjcnc7i812px4b8z1jd1xjal3q4v8xa3z60nr3l2d45vh";
+  };
+
+  preBuild = ''
+    ${optionalString (versionAtLeast kernel.version "4.5") "patch -p1 < ${./4.5.patch}"}
+    substituteInPlace src/Makefile \
+      --replace "\$(shell uname -r)" "${kernel.modDirVersion}" \
+      --replace "/lib/modules" "${kernel.dev}/lib/modules" \
+  '';
+
+  makeFlags = [ "clean" "modules" ];
+
+  installPhase = ''
+      mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/"
+      install -v -D -m 644 src/r8168.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/"
+  '';
+
+  dontStrip = true;
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    # Prevent kernel modules from depending on the Linux -dev output.
+    nuke-refs $(find $out -name "*.ko")
+  '';
+
+  meta = {
+    description = "Linux kernel module for Realtek Gigabit Ethernet controllers";
+    longDescription = ''
+        Linux device driver released for RealTek RTL8168B/8111B, RTL8168C/8111C,
+        RTL8168CP/8111CP, RTL8168D/8111D, RTL8168DP/8111DP, and RTL8168E/8111E
+        Gigabit Ethernet controllers with PCI-Express interface.
+      '';
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sheenobu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10658,6 +10658,8 @@ in
                           # callPackage ../os-specific/linux/nvidia-x11/beta.nix { };
     nvidia_x11           = callPackage ../os-specific/linux/nvidia-x11 { };
 
+    r8168 = callPackage ../os-specific/linux/r8168 { };
+
     rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { };
 
     rtl8812au = callPackage ../os-specific/linux/rtl8812au { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._

I get lots of issues with the r8169 on kernel 4.3.x . Decided to try out this driver. It's GPL2 but has some notes about patents within the source.

Would appreciate some feedback.
