### PR TITLE
steam: enable hardware decoding (for In-Home Streaming)

### DIFF
--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -85,6 +85,7 @@ let
     libpulseaudio
     alsaLib
     openalSoft
+    libva
   ] ++ lib.optional newStdcpp gcc.cc;
 
   ourRuntime = if runtimeOnly then []


### PR DESCRIPTION
Previous to this patch I was getting software decoding when I used In-Home Streaming. I had a look around and according to:

https://bbs.archlinux.org/viewtopic.php?id=187922

> It seems that the libva version Steam comes with, is not compatible anymore to the newer libva 1.4.0.

Substituting in our version of libva gives me hardware decoding!
