### PR TITLE
doxygen: fix on darwin

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     stdenv.lib.optional (qt4 != null) "-Dbuild_wizard=YES";
 
+  NIX_CFLAGS_COMPILE =
+    stdenv.lib.optional stdenv.isDarwin "-mmacosx-version-min=10.9";
+
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
###### More

This avoids an issue where an old OS X SDK is assumed, leading to a
linker error of the form:

Undefined symbols: __Unwind_Resume
