### PR TITLE
Backport new robotics pkgs

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -267,6 +267,7 @@
   psibi = "Sibi <sibi@psibi.in>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";
+  pxc = "Patrick Callahan <patrick.callahan@latitudeengineering.com>";
   qknight = "Joachim Schiele <js@lastlog.de>";
   ragge = "Ragnar Dahlen <r.dahlen@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";

--- a/pkgs/applications/science/robotics/gazebo/6.nix
+++ b/pkgs/applications/science/robotics/gazebo/6.nix
@@ -1,0 +1,8 @@
+{ stdenv, fetchurl, callPackage, ignition, gazeboSimulator, ... } @ args:
+
+callPackage ./default.nix (args // rec {
+  version = "6.5.1";
+  src-sha256 = "96260aa23f1a1f24bc116f8e359d31f3bc65011033977cb7fb2c64d574321908";
+  sdformat = gazeboSimulator.sdformat3;
+})
+

--- a/pkgs/applications/science/robotics/gazebo/default.nix
+++ b/pkgs/applications/science/robotics/gazebo/default.nix
@@ -1,0 +1,81 @@
+{ stdenv, fetchurl, cmake, pkgconfig, boost, protobuf, freeimage
+  , boost-build, boost_process
+  , xorg_sys_opengl, tbb, ogre, tinyxml-2
+  , libtar, glxinfo,  libusb, libxslt, ruby, ignition
+  , pythonPackages, utillinux
+
+  # these deps are hidden; cmake doesn't catch them
+  , gazeboSimulator, sdformat ? gazeboSimulator.sdformat, curl, tinyxml, kde4, x11
+  , withIgnitionTransport ? true
+  , libav, withLibAvSupport ? true
+  , openal, withAudioSupport ? false
+  , withQuickBuild ? false, withHeadless ? false, withLowMemorySupport ? false
+  , doxygen, withDocs ? true
+  , bullet, withBulletEngineSupport ? false
+  , graphviz, withModelEditorSchematicView ? true # graphviz needed for this view
+  , gdal, withDigitalElevationTerrainsSupport ? true
+  , gts, withConstructiveSolidGeometrySupport ? true
+  , hdf5, withHdf5Support ? true
+  , version ? "7.0.0"
+  , src-sha256 ? "127q2g93kvmak2b6vhl13xzg56h09v14s4pki8wv7aqjv0c3whbl"
+  , ...
+}: with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  inherit version;
+  name = "gazebo-${version}";
+
+  src = fetchurl {
+    url = "http://osrf-distributions.s3.amazonaws.com/gazebo/releases/${name}.tar.bz2";
+    sha256 = src-sha256;
+  };
+
+  enableParallelBuilding = true; # gazebo needs this so bad
+  cmakeFlags = []
+    ++ optional withQuickBuild [ "-DENABLE_TESTS_COMPILATION=False" ]
+    ++ optional withLowMemorySupport [ "-DUSE_LOW_MEMORY_TESTS=True" ]
+    ++ optional withHeadless [ "-DENABLE_SCREEN_TESTS=False" ];
+
+  buildInputs = [
+    #cmake pkgconfig boost protobuf
+    freeimage
+    xorg_sys_opengl
+    tbb
+    ogre
+    tinyxml-2
+    libtar
+    glxinfo
+    libusb
+    libxslt
+    ignition.math2
+    sdformat
+    pythonPackages.pyopengl
+
+    # TODO: add these hidden deps to cmake configuration & submit upstream
+    curl
+    tinyxml
+    x11
+    kde4.qt4
+  ] ++ optional stdenv.isLinux utillinux # on Linux needs uuid/uuid.h
+    ++ optional withDocs doxygen
+    ++ optional withLibAvSupport libav  #TODO: package rubygem-ronn and put it here
+    ++ optional withAudioSupport openal
+    ++ optional withBulletEngineSupport bullet
+    ++ optional withIgnitionTransport ignition.transport
+    ++ optional withModelEditorSchematicView graphviz
+    ++ optional withDigitalElevationTerrainsSupport gdal
+    ++ optional withConstructiveSolidGeometrySupport gts
+    ++ optional withHdf5Support hdf5;
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  propagatedNativeBuildInputs = [ boost boost-build boost_process protobuf ];
+
+  meta = with stdenv.lib; {
+    homepage = http://gazebosim.org/;
+    description = "Multi-robot simulator for outdoor environments";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/science/robotics/qgroundcontrol/0001-fix-gcc-cmath-namespace-issues.patch
+++ b/pkgs/applications/science/robotics/qgroundcontrol/0001-fix-gcc-cmath-namespace-issues.patch
@@ -1,0 +1,140 @@
+From fffc383c10c7c194e427d78c83802c3b910fa1c2 Mon Sep 17 00:00:00 2001
+From: Patrick Callahan <pxcallahan@gmail.com>
+Date: Thu, 24 Mar 2016 18:17:57 -0700
+Subject: [PATCH] fix gcc cmath namespace issues
+
+---
+ src/Vehicle/Vehicle.cc        | 6 +++---
+ src/comm/QGCFlightGearLink.cc | 4 ++--
+ src/comm/QGCJSBSimLink.cc     | 4 ++--
+ src/uas/UAS.cc                | 8 ++++----
+ src/ui/QGCDataPlot2D.cc       | 4 ++--
+ 5 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/src/Vehicle/Vehicle.cc b/src/Vehicle/Vehicle.cc
+index a0d3605..205b1de 100644
+--- a/src/Vehicle/Vehicle.cc
++++ b/src/Vehicle/Vehicle.cc
+@@ -638,17 +638,17 @@ void Vehicle::setLongitude(double longitude){
+ 
+ void Vehicle::_updateAttitude(UASInterface*, double roll, double pitch, double yaw, quint64)
+ {
+-    if (isinf(roll)) {
++    if (std::isinf(roll)) {
+         _rollFact.setRawValue(0);
+     } else {
+         _rollFact.setRawValue(roll * (180.0 / M_PI));
+     }
+-    if (isinf(pitch)) {
++    if (std::isinf(pitch)) {
+         _pitchFact.setRawValue(0);
+     } else {
+         _pitchFact.setRawValue(pitch * (180.0 / M_PI));
+     }
+-    if (isinf(yaw)) {
++    if (std::isinf(yaw)) {
+         _headingFact.setRawValue(0);
+     } else {
+         yaw = yaw * (180.0 / M_PI);
+diff --git a/src/comm/QGCFlightGearLink.cc b/src/comm/QGCFlightGearLink.cc
+index 2a520fb..886aecf 100644
+--- a/src/comm/QGCFlightGearLink.cc
++++ b/src/comm/QGCFlightGearLink.cc
+@@ -230,7 +230,7 @@ void QGCFlightGearLink::updateControls(quint64 time, float rollAilerons, float p
+     Q_UNUSED(systemMode);
+     Q_UNUSED(navMode);
+ 
+-    if(!isnan(rollAilerons) && !isnan(pitchElevator) && !isnan(yawRudder) && !isnan(throttle))
++    if(!std::isnan(rollAilerons) && !std::isnan(pitchElevator) && !std::isnan(yawRudder) && !std::isnan(throttle))
+     {
+         QString state("%1\t%2\t%3\t%4\t%5\n");
+         state = state.arg(rollAilerons).arg(pitchElevator).arg(yawRudder).arg(true).arg(throttle);
+@@ -240,7 +240,7 @@ void QGCFlightGearLink::updateControls(quint64 time, float rollAilerons, float p
+     }
+     else
+     {
+-        qDebug() << "HIL: Got NaN values from the hardware: isnan output: roll: " << isnan(rollAilerons) << ", pitch: " << isnan(pitchElevator) << ", yaw: " << isnan(yawRudder) << ", throttle: " << isnan(throttle);
++        qDebug() << "HIL: Got NaN values from the hardware: std::isnan output: roll: " << std::isnan(rollAilerons) << ", pitch: " << std::isnan(pitchElevator) << ", yaw: " << std::isnan(yawRudder) << ", throttle: " << std::isnan(throttle);
+     }
+ }
+ 
+diff --git a/src/comm/QGCJSBSimLink.cc b/src/comm/QGCJSBSimLink.cc
+index 1210621..89db371 100644
+--- a/src/comm/QGCJSBSimLink.cc
++++ b/src/comm/QGCJSBSimLink.cc
+@@ -242,7 +242,7 @@ void QGCJSBSimLink::updateControls(quint64 time, float rollAilerons, float pitch
+     Q_UNUSED(systemMode);
+     Q_UNUSED(navMode);
+ 
+-    if(!isnan(rollAilerons) && !isnan(pitchElevator) && !isnan(yawRudder) && !isnan(throttle))
++    if(!std::isnan(rollAilerons) && !std::isnan(pitchElevator) && !std::isnan(yawRudder) && !std::isnan(throttle))
+     {
+         QString state("%1\t%2\t%3\t%4\t%5\n");
+         state = state.arg(rollAilerons).arg(pitchElevator).arg(yawRudder).arg(true).arg(throttle);
+@@ -250,7 +250,7 @@ void QGCJSBSimLink::updateControls(quint64 time, float rollAilerons, float pitch
+     }
+     else
+     {
+-        qDebug() << "HIL: Got NaN values from the hardware: isnan output: roll: " << isnan(rollAilerons) << ", pitch: " << isnan(pitchElevator) << ", yaw: " << isnan(yawRudder) << ", throttle: " << isnan(throttle);
++        qDebug() << "HIL: Got NaN values from the hardware: isnan output: roll: " << std::isnan(rollAilerons) << ", pitch: " << std::isnan(pitchElevator) << ", yaw: " << std::isnan(yawRudder) << ", throttle: " << std::isnan(throttle);
+     }
+     //qDebug() << "Updated controls" << state;
+ }
+diff --git a/src/uas/UAS.cc b/src/uas/UAS.cc
+index 4d5c1c2..ac88852 100644
+--- a/src/uas/UAS.cc
++++ b/src/uas/UAS.cc
+@@ -558,7 +558,7 @@ void UAS::receiveMessage(mavlink_message_t message)
+ 
+             setAltitudeAMSL(hud.alt);
+             setGroundSpeed(hud.groundspeed);
+-            if (!isnan(hud.airspeed))
++            if (!std::isnan(hud.airspeed))
+                 setAirSpeed(hud.airspeed);
+             speedZ = -hud.climb;
+             emit altitudeChanged(this, altitudeAMSL, altitudeRelative, -speedZ, time);
+@@ -654,7 +654,7 @@ void UAS::receiveMessage(mavlink_message_t message)
+ 
+                     float vel = pos.vel/100.0f;
+                     // Smaller than threshold and not NaN
+-                    if ((vel < 1000000) && !isnan(vel) && !isinf(vel)) {
++                    if ((vel < 1000000) && !std::isnan(vel) && !std::isinf(vel)) {
+                         setGroundSpeed(vel);
+                         emit speedChanged(this, groundSpeed, airSpeed, time);
+                     } else {
+@@ -1439,8 +1439,8 @@ void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float t
+     if (countSinceLastTransmission++ >= 5) {
+         sendCommand = true;
+         countSinceLastTransmission = 0;
+-    } else if ((!isnan(roll) && roll != manualRollAngle) || (!isnan(pitch) && pitch != manualPitchAngle) ||
+-             (!isnan(yaw) && yaw != manualYawAngle) || (!isnan(thrust) && thrust != manualThrust) ||
++    } else if ((!std::isnan(roll) && roll != manualRollAngle) || (!std::isnan(pitch) && pitch != manualPitchAngle) ||
++             (!std::isnan(yaw) && yaw != manualYawAngle) || (!std::isnan(thrust) && thrust != manualThrust) ||
+              buttons != manualButtons) {
+         sendCommand = true;
+ 
+diff --git a/src/ui/QGCDataPlot2D.cc b/src/ui/QGCDataPlot2D.cc
+index 2e530b2..9d5a774 100644
+--- a/src/ui/QGCDataPlot2D.cc
++++ b/src/ui/QGCDataPlot2D.cc
+@@ -535,7 +535,7 @@ void QGCDataPlot2D::loadCsvLog(QString file, QString xAxisName, QString yAxisFil
+                 {
+                     bool okx = true;
+                     x = text.toDouble(&okx);
+-                    if (okx && !isnan(x) && !isinf(x))
++                    if (okx && !std::isnan(x) && !std::isinf(x))
+                     {
+                         headerfound = true;
+                     }
+@@ -561,7 +561,7 @@ void QGCDataPlot2D::loadCsvLog(QString file, QString xAxisName, QString yAxisFil
+                         y = text.toDouble(&oky);
+                         // Only INF is really an issue for the plot
+                         // NaN is fine
+-                        if (oky && !isnan(y) && !isinf(y) && text.length() > 0 && text != " " && text != "\n" && text != "\r" && text != "\t")
++                        if (oky && !std::isnan(y) && !std::isinf(y) && text.length() > 0 && text != " " && text != "\n" && text != "\r" && text != "\t")
+                         {
+                             // Only append definitely valid values
+                             xValues.value(curveName)->append(x);
+-- 
+2.7.4
+

--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -1,0 +1,98 @@
+{ stdenv, fetchgit, git,  espeak, SDL, udev, doxygen, cmake, overrideCC#, gcc48
+  , qtbase, qtlocation, qtserialport, qtdeclarative, qtconnectivity, qtxmlpatterns
+  , qtsvg, qtquick1, qtquickcontrols, qtgraphicaleffects
+  , makeQtWrapper, lndir
+  , gst_all_1, qt_gstreamer1, pkgconfig, glibc
+  , version ? "2.9.4"
+}:
+
+stdenv.mkDerivation rec {
+  name = "qgroundcontrol-${version}";
+  buildInputs = [
+   SDL udev doxygen git
+  ] ++ gstInputs;
+
+  qtInputs = [
+    qtbase qtlocation qtserialport qtdeclarative qtconnectivity qtxmlpatterns qtsvg 
+    qtquick1 qtquickcontrols qtgraphicaleffects
+  ];
+
+  gstInputs = with gst_all_1; [
+    gstreamer gst-plugins-base
+  ];
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [
+    pkgconfig makeQtWrapper
+ ] ++ qtInputs;
+
+  patches = [ ./0001-fix-gcc-cmath-namespace-issues.patch ];
+
+  preConfigure = ''
+    git submodule init
+    git submodule update
+
+  '';
+
+  configurePhase = ''
+    mkdir build
+    pushd build
+
+    qmake ../qgroundcontrol.pro
+
+    popd
+  '';
+
+  preBuild = "pushd build/";
+  postBuild = "popd";
+
+  installPhase = ''
+    mkdir -p $out/share/applications
+    cp -v qgroundcontrol.desktop $out/share/applications
+    
+    mkdir -p $out/bin
+    cp -v build/release/qgroundcontrol "$out/bin/"
+    
+    mkdir -p $out/share/qgroundcontrol
+    cp -rv resources/ $out/share/qgroundcontrol
+    
+    mkdir -p $out/share/pixmaps
+    cp -v resources/icons/qgroundcontrol.png $out/share/pixmaps
+
+    # we need to link to our Qt deps in our own output if we want
+    # this package to work without being installed as a system pkg
+    mkdir -p $out/lib/qt5 $out/etc/xdg
+    for pkg in $qtInputs; do
+      if [[ -d $pkg/lib/qt5 ]]; then
+        for dir in lib/qt5 share etc/xdg; do
+          if [[ -d $pkg/$dir ]]; then
+            ${lndir}/bin/lndir "$pkg/$dir" "$out/$dir"
+          fi
+        done
+      fi
+    done
+  '';
+
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/qgroundcontrol" \
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
+  '';
+  
+
+  # TODO: package mavlink so we can build from a normal source tarball
+  src = fetchgit {
+    url = "https://github.com/mavlink/qgroundcontrol.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "0rwn2ddlar58ydzdykvnab1anr4xzvb9x0sxx5rs037i49f6sqga";
+    fetchSubmodules = true;
+  };
+
+  meta = {
+    description = "provides full ground station support and configuration for the PX4 and APM Flight Stacks";
+    homepage = http://qgroundcontrol.org/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [ pxc ];
+  };
+}

--- a/pkgs/development/libraries/ignition-math/default.nix
+++ b/pkgs/development/libraries/ignition-math/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake }:
+
+let
+  version = "2.3.0";
+in
+stdenv.mkDerivation rec {
+  name = "ign-math2-${version}";
+
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-math/releases/ignition-math2-${version}.tar.bz2";
+    sha256 = "1a2jgq6allcxg62y0r61iv4hgxkfr1whpsxy75hg7k85s7da8dpl";
+  };
+
+  buildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/math;
+    description = "Math library by Ingition Robotics, created for the Gazebo project";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ignition-transport/0.9.0.nix
+++ b/pkgs/development/libraries/ignition-transport/0.9.0.nix
@@ -1,0 +1,9 @@
+{ stdenv, fetchurl, callPackage, ... } @ args :
+
+callPackage ./generic.nix (args // rec {
+  version = "0.9.0";
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport-${version}.tar.bz2";
+    sha256 = "15a8lkxri8q2gc7h0pj1dg2kivhy46v8d3mlxpjy90l77788bw1z";
+  };
+})

--- a/pkgs/development/libraries/ignition-transport/1.0.1.nix
+++ b/pkgs/development/libraries/ignition-transport/1.0.1.nix
@@ -1,0 +1,9 @@
+{ stdenv, fetchurl, callPackage, ... } @ args :
+
+callPackage ./generic.nix (args // rec {
+  version = "1.0.1";
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport-${version}.tar.bz2";
+    sha256 = "08qyd70vlymms1g4smblags9f057zsn62xxrx29rhd4wy8prnjsq";
+  };
+})

--- a/pkgs/development/libraries/ignition-transport/generic.nix
+++ b/pkgs/development/libraries/ignition-transport/generic.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake, pkgconfig, utillinux,
+  protobuf, zeromq, cppzmq,
+  version, src    # parametrize version and src so we can easily have pkgs
+                  # for different versions
+  , ...
+}:
+
+stdenv.mkDerivation rec {
+  name = "ign-transport-${version}";
+  inherit src;
+
+  buildInputs = [ cmake protobuf zeromq pkgconfig
+    utillinux # we need utillinux/e2fsprogs uuid/uuid.h
+  ];
+
+  propagatedBuildInputs = [ cppzmq ];
+
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/math;
+    description = "Math library by Ingition Robotics, created for the Gazebo project";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -8,11 +8,11 @@
 , nvidia_cg_toolkit }:
 
 stdenv.mkDerivation {
-  name = "ogre-1.9.0";
+  name = "ogre-1.9-hg-20160322";
 
   src = fetchurl {
-     url = "https://bitbucket.org/sinbad/ogre/get/v1-9-0.tar.gz";
-     sha256 = "0p8gyn293qn3iyiy1smfmjd9zpnjb8h2zgvff8778fwh0ylbmlpa";
+     url = "https://bitbucket.org/sinbad/ogre/get/v1-9.tar.gz";
+     sha256 = "0w3argjy1biaxwa3c80zxxgll67wjp8czd83p87awlcvwzdk5mz9";
   };
 
   cmakeFlags = [ "-DOGRE_INSTALL_SAMPLES=yes" ]

--- a/pkgs/development/libraries/sdformat/3.nix
+++ b/pkgs/development/libraries/sdformat/3.nix
@@ -1,0 +1,7 @@
+{ stdenv, fetchurl, callPackage, ... } @ args:
+
+callPackage ./default.nix (args // rec {
+  version = "3.7.0";
+  srchash-sha256 = "07kn8bgvj9mwwinsp2cbmz11z7zw2lgnj61mi1gi1pjg7q9in98q";
+})
+

--- a/pkgs/development/libraries/sdformat/default.nix
+++ b/pkgs/development/libraries/sdformat/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, boost, ruby_1_9, ignition, tinyxml
+  , name ? "sdformat-${version}"
+  , version ? "4.0.0" # versions known to work with this expression include 3.7.0
+  , srchash-sha256 ? "b0f94bb40b0d83e35ff250a7916fdfd6df5cdc1e60c47bc53dd2da5e2378163e"
+  , ...
+  }:
+
+let 
+  ruby = ruby_1_9;
+in
+stdenv.mkDerivation rec {
+  src = fetchurl { 
+      url = "http://osrf-distributions.s3.amazonaws.com/sdformat/releases/${name}.tar.bz2";
+      sha256 = srchash-sha256;
+  };
+
+  inherit name;
+
+  enableParallelBuilding = true;
+  buildInputs = [
+    cmake boost ruby ignition.math2 tinyxml
+  ];
+}

--- a/pkgs/development/libraries/tinyxml-2/default.nix
+++ b/pkgs/development/libraries/tinyxml-2/default.nix
@@ -1,0 +1,11 @@
+{ stdenv, fetchurl, cmake }:
+let version = "3.0.0";
+in stdenv.mkDerivation rec {
+  name = "tinyxml-2-${version}";
+  src = fetchurl {
+    url = "https://github.com/leethomason/tinyxml2/archive/${version}.tar.gz";
+    sha256 = "0ispg7ngkry8vhzzawbq42y8gkj53xjipkycw0rkhh487ras32hj";
+  };
+
+  nativeBuildInputs = [ cmake ];
+}

--- a/pkgs/tools/filesystems/genromfs/default.nix
+++ b/pkgs/tools/filesystems/genromfs/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "0.5.2";
+  name = "genromfs-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/romfs/genromfs/${version}/${name}.tar.gz";
+    sha256 = "0q6rpq7cmclmb4ayfyknvzbqysxs4fy8aiahlax1sb2p6k3pzwrh";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "prefix = /usr" "prefix = $out"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://romfs.sourceforge.net/";
+    description = "Tool for creating romfs file system images";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pxc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1693,7 +1693,21 @@ let
     sdformat3 = callPackage ../development/libraries/sdformat/3.nix { };
 
     sdformat4 = callPackage ../development/libraries/sdformat { };
+
+    gazebo6 = callPackage ../applications/science/robotics/gazebo/6.nix { };
+
+    gazebo6-headless = callPackage ../applications/science/robotics/gazebo/6.nix { withHeadless = true;  };
+
+    gazebo7 = callPackage ../applications/science/robotics/gazebo { };
+  
+    gazebo7-headless = callPackage ../applications/science/robotics/gazebo { withHeadless = true; };
+
   };
+  
+  # at present, Gazebo 7.0.0 does not match Gazebo 6.5.1 for compatibility
+  gazebo = gazeboSimulator.gazebo6;
+
+  gazebo-headless = gazeboSimulator.gazebo6-headless;
 
   gbdfed = callPackage ../tools/misc/gbdfed {
     gtk = gtk2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1687,6 +1687,14 @@ let
 
   gawp = goPackages.gawp.bin // { outputs = [ "bin" ]; };
 
+  gazeboSimulator = recurseIntoAttrs {
+    sdformat = gazeboSimulator.sdformat4;
+
+    sdformat3 = callPackage ../development/libraries/sdformat/3.nix { };
+
+    sdformat4 = callPackage ../development/libraries/sdformat { };
+  };
+
   gbdfed = callPackage ../tools/misc/gbdfed {
     gtk = gtk2;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -888,6 +888,8 @@ let
 
   gencfsm = callPackage ../tools/security/gencfsm { };
 
+  genromfs = callPackage ../tools/filesystems/genromfs { };
+
   gist = callPackage ../tools/text/gist { };
 
   gmic = callPackage ../tools/graphics/gmic { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14312,6 +14312,8 @@ let
 
   qgis = callPackage ../applications/gis/qgis {};
 
+  qgroundcontrol = qt55.callPackage ../applications/science/robotics/qgroundcontrol { };
+
   qtbitcointrader = callPackage ../applications/misc/qtbitcointrader {
     qt = qt4;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2021,6 +2021,14 @@ let
 
   ifuse = callPackage ../tools/filesystems/ifuse/default.nix { };
 
+  ignition = recurseIntoAttrs { 
+
+    math = callPackage ../development/libraries/ignition-math { };
+  
+    math2 = ignition.math;
+  
+  };
+
   ihaskell = callPackage ../development/tools/haskell/ihaskell/wrapper.nix {
     inherit (haskellPackages) ihaskell ghcWithPackages;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2035,7 +2035,13 @@ let
   
     math2 = ignition.math;
   
+    transport0 = callPackage ../development/libraries/ignition-transport/0.9.0.nix { };
+
+    transport1 = callPackage ../development/libraries/ignition-transport/1.0.1.nix { };
+
+    transport = ignition.transport0;
   };
+
 
   ihaskell = callPackage ../development/tools/haskell/ihaskell/wrapper.nix {
     inherit (haskellPackages) ihaskell ghcWithPackages;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8809,6 +8809,8 @@ let
 
   tinyxml2 = callPackage ../development/libraries/tinyxml/2.6.2.nix { };
 
+  tinyxml-2 = callPackage ../development/libraries/tinyxml-2 { };
+
   tk = tk-8_6;
 
   tk-8_6 = callPackage ../development/libraries/tk/8.6.nix { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Except for the upgrade to Ogre3D (the current version of which no longer builds in 16.03 anyway), all of these commits add new packages I recently submitted to master. 16.03 is the release I actually use them on.

cc @domenkozar 

---

_Please note, that points are not mandatory, but rather desired._
