### PR TITLE
shinken: init at 2.4.3

### DIFF
--- a/pkgs/servers/monitoring/shinken/default.nix
+++ b/pkgs/servers/monitoring/shinken/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl }:    
+
+{
+  shinken = buildPythonPackage rec {
+    version = "2.4.3";
+    name = "Shinken-${version}";
+    disabled = isPy3k; # Python 3 is not supported
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/S/Shinken/${name}.tar.gz";
+      sha256 = "1hxbnxlk2bacb7p6lim9kqy50581m0d3p3y6b9hw0x800lfk0y6q";
+    };
+
+    dontStrip = true; # no binaries to strip, so the build process generates lots of warnings
+
+    # missing: logging tagging
+
+    propagatedBuildInputs = with self; [
+      arrow bottle cffi cherrypy django paramiko pycurl pymongo pyopenssl
+    ];
+
+    checkPhase = ''
+      cd $out/test
+      ./quick_test.sh
+    '';
+
+    meta = {
+      homepage = http://www.shinken-monitoring.org/;
+      description = "A monitoring framework compatible with Nagios configuration and plugins";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ peterhoeg ];
+    };
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9165,32 +9165,6 @@ in modules // {
     };
   };
 
-  shinken = buildPythonPackage rec {
-    version = "2.4.3";
-    name = "Shinken-${version}";
-    disabled = isPy3k; # Shinken does not yet support python3
-
-    src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/Shinken/${name}.tar.gz";
-      sha256 = "1hxbnxlk2bacb7p6lim9kqy50581m0d3p3y6b9hw0x800lfk0y6q";
-    };
-
-    dontStrip = true; # no binaries to strip, so the build process generates lots of warnings
-
-    # missing: logging tagging
-
-    propagatedBuildInputs = with self; [
-      arrow bottle cffi cherrypy django paramiko pycurl pymongo pyopenssl
-    ];
-
-    meta = {
-      homepage = http://www.shinken-monitoring.org/;
-      description = "A monitoring framework compatible with Nagios configuration and plugins.";
-      license = licenses.agpl3;
-      maintainers = with maintainers; [ peterhoeg ];
-    };
-  };
-
   flexget = buildPythonPackage rec {
     version = "1.2.337";
     name = "FlexGet-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9165,6 +9165,32 @@ in modules // {
     };
   };
 
+  shinken = buildPythonPackage rec {
+    version = "2.4.3";
+    name = "Shinken-${version}";
+    disabled = isPy3k; # Shinken does not yet support python3
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/S/Shinken/${name}.tar.gz";
+      sha256 = "1hxbnxlk2bacb7p6lim9kqy50581m0d3p3y6b9hw0x800lfk0y6q";
+    };
+
+    dontStrip = true; # no binaries to strip, so the build process generates lots of warnings
+
+    # missing: logging tagging
+
+    propagatedBuildInputs = with self; [
+      arrow bottle cffi cherrypy django paramiko pycurl pymongo pyopenssl
+    ];
+
+    meta = {
+      homepage = http://www.shinken-monitoring.org/;
+      description = "A monitoring framework compatible with Nagios configuration and plugins.";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ peterhoeg ];
+    };
+  };
+
   flexget = buildPythonPackage rec {
     version = "1.2.337";
     name = "FlexGet-${version}";


### PR DESCRIPTION
I want to add proper nixos module support for shinken which is going to be a lot of work, but the first step is to add the python module.

Because I don't really have a way to seed configuration data (the nixos module hasn't been written yet), this package is completely untested except for installation.
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
