### PR TITLE
nixos timezone: set /etc/timezone which is needed by python

### DIFF
--- a/nixos/modules/config/timezone.nix
+++ b/nixos/modules/config/timezone.nix
@@ -44,6 +44,8 @@ in
         mode = "direct-symlink";
       };
 
+    environment.etc.timezone.text = config.time.timeZone;
+
     environment.etc.zoneinfo.source = "${pkgs.tzdata}/share/zoneinfo";
 
   };


### PR DESCRIPTION
Turns out python programs will try to read `/etc/timezone` or TZ. If neither is set, they will fall back to UTC.

`/etc/timezone` is no longer mentioned in the FHS though so I am honestly not sure if this is the right way forward.
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
