### PR TITLE
opencpn: init at 4.2.0

### DIFF
--- a/pkgs/applications/misc/opencpn/default.nix
+++ b/pkgs/applications/misc/opencpn/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, gtk2, wxGTK30, libpulseaudio, curl,
+  gettext, glib, portaudio }:
+
+stdenv.mkDerivation rec {
+  name = "opencpn-${version}";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenCPN";
+    repo = "OpenCPN";
+    rev = "v${version}";
+    sha256 = "1m6fp9lf9ki9444h0dq6bj0vr7d0pcxkbjv3j2v76p0ksk2l8kw3";
+  };
+
+  buildInputs = [ pkgconfig cmake gtk2 wxGTK30 libpulseaudio curl gettext
+                  glib portaudio ];
+
+  cmakeFlags = [
+    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2}/lib/gtk-2.0/include"
+    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib}/lib/glib-2.0/include"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A concise ChartPlotter/Navigator";
+    maintainers = [ stdenv.lib.maintainers.kragniz ];
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.gpl2;
+    homepage = "http://opencpn.org/";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13001,6 +13001,8 @@ let
 
   openbrf = callPackage ../applications/misc/openbrf { };
 
+  opencpn = callPackage ../applications/misc/opencpn { };
+
   openimageio = callPackage ../applications/graphics/openimageio { };
 
   openjump = callPackage ../applications/misc/openjump { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
