### PR TITLE
mfi: init at 2.1.11

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -258,6 +258,7 @@
       hydra-queue-runner = 235;
       hydra-www = 236;
       syncthing = 237;
+      mfi = 238;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -487,6 +488,7 @@
       octoprint = 230;
       radicale = 234;
       syncthing = 237;
+      #mfi = 238; # unused
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -333,6 +333,7 @@
   ./services/networking/lambdabot.nix
   ./services/networking/libreswan.nix
   ./services/networking/mailpile.nix
+  ./services/networking/mfi.nix
   ./services/networking/mjpg-streamer.nix
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix

--- a/nixos/modules/services/networking/mfi.nix
+++ b/nixos/modules/services/networking/mfi.nix
@@ -1,0 +1,90 @@
+{ config, lib, pkgs, utils, ... }:
+with lib;
+let
+  name = "Ubiquiti mFi Controller";
+  cfg = config.services.mfi;
+  stateDir = "/var/lib/mfi";
+  # XXX 2 runtime exceptions using jre8: JSPException on GET / ; can't initialize ./data/keystore on first run.
+  cmd = "@${pkgs.jre7}/bin/java java -jar ${stateDir}/lib/ace.jar";
+  mountPoints = [
+    { what = "${pkgs.mfi}/dl"; where = "${stateDir}/dl"; }
+    { what = "${pkgs.mfi}/lib"; where = "${stateDir}/lib"; }
+    { what = "${pkgs.mongodb248}/bin"; where = "${stateDir}/bin"; }
+  ];
+  systemdMountPoints = map (m: "${utils.escapeSystemdPath m.where}.mount") mountPoints;
+  ports = [ 6080 6880 6443 6843 ];
+in
+{
+  options = {
+    services.mfi = {
+      enable = mkEnableOption name;
+      openPorts = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to open TCP ports ${concatMapStrings (a: "${toString a} ") ports}for the services.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    networking.firewall.allowedTCPPorts = mkIf config.services.mfi.openPorts ports;
+
+    users.users.mfi = {
+      uid = config.ids.uids.mfi;
+      description = "mFi controller daemon user";
+      home = "${stateDir}";
+    };
+
+    # We must create the binary directories as bind mounts instead of symlinks
+    # This is because the controller resolves all symlinks to absolute paths
+    # to be used as the working directory.
+    systemd.mounts = map ({ what, where }: {
+        bindsTo = [ "mfi.service" ];
+        partOf = [ "mfi.service" ];
+        unitConfig.RequiresMountsFor = stateDir;
+        options = "bind";
+        what = what;
+        where = where;
+      }) mountPoints;
+
+    systemd.services.mfi = {
+      description = "mFi controller daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ] ++ systemdMountPoints;
+      partOf = systemdMountPoints;
+      bindsTo = systemdMountPoints;
+      unitConfig.RequiresMountsFor = stateDir;
+
+      preStart = ''
+        # Clear ./webapps each run.
+        rm -rf                               "${stateDir}/webapps"
+        mkdir -p                             "${stateDir}/webapps"
+        ln -s "${pkgs.mfi}/webapps/ROOT.war" "${stateDir}/webapps"
+
+        # Copy initial config only once.
+        test -e "${stateDir}/conf" || cp -ar "${pkgs.mfi}/conf" "${stateDir}/conf"
+        test -e "${stateDir}/data" || cp -ar "${pkgs.mfi}/data" "${stateDir}/data"
+
+        # Fix Permissions.
+        # (Bind-mounts cause errors; ignore exit codes)
+        chown -fR mfi:      "${stateDir}" || true
+        chmod -fR u=rwX,go= "${stateDir}" || true
+      '';
+
+      postStop = ''
+        rm -rf "${stateDir}/webapps"
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cmd} start";
+        ExecStop = "${cmd} stop";
+        User = "mfi";
+        PermissionsStartOnly = true;
+        UMask = "0077";
+        WorkingDirectory = "${stateDir}";
+      };
+    };
+  };
+}

--- a/pkgs/development/libraries/v8/3.14.nix
+++ b/pkgs/development/libraries/v8/3.14.nix
@@ -1,0 +1,28 @@
+{ stdenv, callPackage, fetchFromGitHub, python, ... } @ args:
+with stdenv.lib;
+let
+  version = "3.14.5.10";
+  sha256 = "08vhl84166x13b3cbx8y0g99yqx772zd33gawsa1nxqkyrykql6k";
+in
+(callPackage ./generic.nix (args // {
+  inherit version sha256;
+})).overrideDerivation (oldAttrs:{
+  patchPhase = [
+    oldAttrs.patchPhase
+    "sed -i 's,#!/usr/bin/python,#!${python}/bin/python,' build/gyp_v8"
+  ];
+
+  # http://code.google.com/p/v8/issues/detail?id=2149
+  NIX_CFLAGS_COMPILE = concatStringsSep " " [
+    oldAttrs.NIX_CFLAGS_COMPILE
+    "-Wno-unused-local-typedefs"
+    "-Wno-aggressive-loop-optimizations"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "v8";
+    repo = "v8";
+    rev = "${version}";
+    inherit sha256;
+  };
+})

--- a/pkgs/development/libraries/v8/fix-GetLocalizedMessage-usage.patch
+++ b/pkgs/development/libraries/v8/fix-GetLocalizedMessage-usage.patch
@@ -1,0 +1,27 @@
+From dbe142c4eda0f15fad9fa85743dd11b81292fa8f Mon Sep 17 00:00:00 2001
+From: Timothy J Fontaine <tjfontaine@gmail.com>
+Date: Thu, 23 May 2013 13:57:59 -0700
+Subject: [PATCH] v8: fix GetLocalizedMessage usage
+
+As is the backport of the abort on uncaught exception wouldn't compile
+because we it was passing in `this` when it was unnecessary.
+---
+ deps/v8/src/isolate.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/isolate.cc b/src/isolate.cc
+index 04a438b..5a5293e 100644
+--- a/src/isolate.cc
++++ b/src/isolate.cc
+@@ -1161,7 +1161,7 @@ void Isolate::DoThrow(Object* exception, MessageLocation* location) {
+           (report_exception || can_be_caught_externally)) {
+         fatal_exception_depth++;
+         fprintf(stderr, "%s\n\nFROM\n",
+-          *MessageHandler::GetLocalizedMessage(this, message_obj));
++          *MessageHandler::GetLocalizedMessage(message_obj));
+         PrintCurrentStackTrace(stderr);
+         OS::Abort();
+       }
+-- 
+1.8.1.6
+

--- a/pkgs/servers/mfi/default.nix
+++ b/pkgs/servers/mfi/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "mfi-controller-${version}";
+  version = "2.1.11";
+
+  src = fetchurl {
+    url = "https://dl.ubnt.com/mfi/${version}/mFi.unix.zip";
+    sha256 = "0b9q6025zf9zjzq8dcmcyai8rslx67g52j41gacxsk9i5dspmw90";
+  };
+
+  buildInputs = [ unzip ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -ar conf data dl lib webapps $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.ubnt.com/;
+    description = "Controller for Ubiquiti mFi devices";
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ elitak ];
+  };
+}

--- a/pkgs/servers/nosql/mongodb/2.4.8.nix
+++ b/pkgs/servers/nosql/mongodb/2.4.8.nix
@@ -1,0 +1,45 @@
+# This derivation was resurrected from 4c8ec5e12e187347fd97b1a1a9a43eb19e009ed0
+# by elitak for use with the Ubiquiti mFi Controller package, which breaks at
+# runtime on mongodb3+ and jre8+. We will need to pull in sufficiently old
+# versions of boost and v8 to build this, as well.
+{ stdenv, fetchurl, scons, boost155, v8_3_14, gperftools, pcre, snappy }:
+with stdenv.lib;
+let
+  version = "2.4.8";
+in
+stdenv.mkDerivation rec {
+  name = "mongodb-${version}";
+
+  src = fetchurl {
+    url = "http://downloads.mongodb.org/src/mongodb-src-r${version}.tar.gz";
+    sha256 = "1p6gnharypglfp39halp72fig96fqjhakyy7m76a1prxwpjkqw7x";
+  };
+
+  nativeBuildInputs = [ scons boost155 v8_3_14 gperftools pcre snappy ];
+
+  postPatch = ''
+    substituteInPlace SConstruct \
+        --replace "Environment( BUILD_DIR" "Environment( ENV = os.environ, BUILD_DIR" \
+        --replace 'CCFLAGS=["-Werror", "-pipe"]' 'CCFLAGS=["-pipe"]'
+  '';
+
+  NIX_CFLAGS_COMPILE = "-Wno-unused-local-typedefs";
+
+  buildPhase = ''
+    export SCONSFLAGS="-j$NIX_BUILD_CORES"
+    scons all --use-system-all
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    scons install --use-system-all --full --prefix=$out
+  '';
+
+  meta = {
+    description = "A scalable, high-performance, open source NoSQL database";
+    homepage = http://www.mongodb.org;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ bluescreen303 elitak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8907,6 +8907,10 @@ in
     gnutls = gnutls;
   });
 
+  v8_3_14 = callPackage ../development/libraries/v8/3.14.nix {
+    inherit (pythonPackages) gyp;
+  };
+
   v8_3_16_14 = callPackage ../development/libraries/v8/3.16.14.nix {
     inherit (pythonPackages) gyp;
     # The build succeeds using gcc5 but it fails to build pkgs.consul-ui
@@ -9624,6 +9628,8 @@ in
 
   meteor = callPackage ../servers/meteor/default.nix { };
 
+  mfi = callPackage ../servers/mfi { };
+
   # Backwards compatibility.
   mod_dnssd = pkgs.apacheHttpdPackages.mod_dnssd;
   mod_evasive = pkgs.apacheHttpdPackages.mod_evasive;
@@ -9740,6 +9746,8 @@ in
   mongodb = callPackage ../servers/nosql/mongodb {
     sasl = cyrus_sasl;
   };
+
+  mongodb248 = callPackage ../servers/nosql/mongodb/2.4.8.nix { };
 
   riak = callPackage ../servers/nosql/riak/2.1.1.nix { };
 


### PR DESCRIPTION
Ubiquiti mFi Controller daemon. I had to resurrect old versions of mongodb and v8 to get this to run. The newer ones break the services in this package. I've reported the issues upstream.

Potential issues:
- The nixos module was based heavily off of the unifi one. Would it be wise to reuse some of that config?
- Should this service share the unifi uid?
- Changes to resurrected files are untracked because there was no rename from default.nix . Help me do this better in git. If there is a way, I don't know it.
