### PR TITLE
Minor upgrades

### DIFF
--- a/pkgs/applications/misc/spacefm/default.nix
+++ b/pkgs/applications/misc/spacefm/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "spacefm-${version}";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "IgnorantGuru";
     repo = "spacefm";
     rev = "${version}";
-    sha256 = "1jywsb5yjrq4w9m94m4mbww36npd1jk6s0b59liz6965hv3xp2sy";
+    sha256 = "06askkrwls09d1x382zjrmnvcm0ghfgz4cms2qbhdkazfyy0ff65";
   };
 
   configureFlags = [

--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, zlib }:
+{ stdenv, fetchurl, ocamlPackages, zlib }:
 
 stdenv.mkDerivation rec {
   name = "google-drive-ocamlfuse-${version}";
-  version = "0.5.18";
+  version = "0.5.22";
 
-  src = fetchFromGitHub {
-    owner  = "astrada";
-    repo   = "google-drive-ocamlfuse";
-    rev    = "v${version}";
-    sha256 = "0a545zalsqw3jndrvkc0bsn4aab74cf8lwnsw09b5gjm8pm79b9r";
+  src = fetchurl {
+    url = "https://forge.ocamlcore.org/frs/download.php/1587/${name}.tar.gz";
+    sha256 = "1hjm6hyva9sl6lddb0372wsy7f76105iaxh976yyzfn3b4ran6ab";
   };
 
   buildInputs = [ zlib ] ++ (with ocamlPackages; [ocaml ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl]);

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, ocaml, findlib, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
 
 stdenv.mkDerivation rec {
-  name = "gapi-ocaml-0.2.6";
+  name = "gapi-ocaml-0.2.10";
   src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/1468/${name}.tar.gz";
-    sha256 = "1sqsir07xxk9xy723l206r7d10sp6rfid9dvi0g34vbkvshm50y2";
+    url = "https://forge.ocamlcore.org/frs/download.php/1601/${name}.tar.gz";
+    sha256 = "0kg4j7dhr7jynpy8x53bflqjf78jyl14j414l6px34xz7c9qx5fl";
   };
   buildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib yojson ocamlnet xmlm ];


### PR DESCRIPTION
- spacefm: 1.0.4 -> 1.0.5
- google-drive-ocamlfuse: 0.5.18 -> 0.5.22
- gapi-ocaml: 0.2.6 -> 0.2.10
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
