### PR TITLE
raspberrypi-firmware: 20150506 -> 1.20160315

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -2,14 +2,14 @@
 
 let
 
-  rev = "b7bbd3d1683e9f3bb11ef86b952adee71e83862f";
+  rev = "1.20160315";
 
 in stdenv.mkDerivation {
   name = "raspberrypi-firmware-${rev}";
 
   src = fetchurl {
     url = "https://github.com/raspberrypi/firmware/archive/${rev}.tar.gz";
-    sha256 = "16wpwa1y3imd3la477b3rfbfypssvlh0zjdag3hgkm33aysizijp";
+    sha256 = "0a7ycv01s0kk84szsh51hy2mjjil1dzdk0g7k83h50d5nya090fl";
   };
 
   installPhase = ''
@@ -24,9 +24,11 @@ in stdenv.mkDerivation {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Firmware for the Raspberry Pi board";
     homepage = https://github.com/raspberrypi;
-    license = stdenv.lib.licenses.unfree;
+    license = licenses.unfree;
+    platforms = [ "armv6l-linux" "armv7l-linux" ];
+    maintainers = with maintainers; [ viric tavyc ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Tested on release-16.03 on a Raspberry Pi 2b.

cc @viric 
