### PR TITLE
bindfs: Let `mount` find `bindfs` mount helper

### DIFF
--- a/pkgs/tools/filesystems/bindfs/default.nix
+++ b/pkgs/tools/filesystems/bindfs/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   buildInputs = [ fuse pkgconfig ];
+  postFixup = ''
+    ln -s $out/bin/bindfs $out/bin/mount.fuse.bindfs
+  '';
 
   meta = {
     description = "A FUSE filesystem for mounting a directory to another location";


### PR DESCRIPTION
When mount is used with mount-type "fuse.bindfs", it cannot find the mount helper.

If mount can't find `mount.fuse.bindfs`, it executes the `mount.fuse` mount helper and passes `fuse.bindfs` as argument. Then `mount.fuse` tries to execute `bindfs` on its own, but it is not found in the PATH.

By creating a `mount.fuse.bindfs` link to the `bindfs` executable, this problem is avoided because `mount` will just execute the `mount.fuse.bindfs` mount helper without `mount.fuse` in the middle.
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @lovek323, Sorry for the duplicate PR.

---

_Please note, that points are not mandatory, but rather desired._
