### PR TITLE
qgifer: init at 0.2.1

### DIFF
--- a/pkgs/applications/video/qgifer/default.nix
+++ b/pkgs/applications/video/qgifer/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchsvn, cmake, opencv, qt, giflib }:
+
+stdenv.mkDerivation rec {
+  name = "qgifer-${version}";
+  version = "0.2.1";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/qgifer/code/tags/${name}";
+    sha256 = "0fv40n58xjwfr06ix9ga79hs527rrzfaq1sll3n2xxchpgf3wf4f";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace "SET(CMAKE_INSTALL_PREFIX" "#"
+  '';
+
+  buildInputs = [ cmake opencv qt giflib ];
+
+  meta = with stdenv.lib; {
+    description = "Video-based animated GIF creator";
+    homepage = https://sourceforge.net/projects/qgifer/;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.andrewrk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2937,6 +2937,11 @@ in
     qt = qt4;
   };
 
+  qgifer = callPackage ../applications/video/qgifer {
+    giflib = giflib_4_1;
+    qt = qt4;
+  };
+
   qhull = callPackage ../development/libraries/qhull { };
 
   qjoypad = callPackage ../tools/misc/qjoypad { };


### PR DESCRIPTION
Built on NixOS with `nix-build -A qgifer`.
Tested execution of qgifer binary.
