### PR TITLE
zsh: fix $out/etc/zprofile #14256

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -21,13 +21,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ncurses coreutils pcre ];
 
-  configureFlags = [
-    "--enable-maildir-support"
-    "--enable-multibyte"
-    "--enable-zprofile=$out/etc/zprofile"
-    "--with-tcsetpgrp"
-    "--enable-pcre"
-  ];
+  preConfigure = ''
+    configureFlags="--enable-maildir-support --enable-multibyte --enable-zprofile=$out/etc/zprofile --with-tcsetpgrp --enable-pcre"
+  '';
 
   # the zsh/zpty module is not available on hydra
   # so skip groups Y Z


### PR DESCRIPTION
- [ x ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ x ] NixOS
  - [ ] OS X
  - [ x ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes issue #14256

cc @fpletz

---

_Please note, that points are not mandatory, but rather desired._
