### PR TITLE
jenkins: copy .war to $out, fixes #14137

### DIFF
--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -16,5 +16,5 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.coconnor ];
   };
 
-  buildCommand = "ln -s $src $out";
+  buildCommand = "cp $src $out";
 }


### PR DESCRIPTION
It appears the `ln -s` used previously breaks `nix-shell`, but copying directly resolves the problem. I'm not 100% sure this is the right thing to do, so please let me know.
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14137 
