### PR TITLE
manual: use a better relaxng validation tool #4966

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -67,9 +67,9 @@ stdenv.mkDerivation {
   + ''
     echo ${nixpkgsVersion} > .version
 
-    xmllint --noout --nonet --xinclude --noxincludenode \
-      --relaxng ${docbook5}/xml/rng/docbook/docbook.rng \
-      manual.xml
+    # validate against relaxng schema
+    xmllint --nonet --xinclude --noxincludenode manual.xml --output manual-full.xml
+    ${jing}/bin/jing ${docbook5}/xml/rng/docbook/docbook.rng manual-full.xml
 
     dst=$out/share/doc/nixpkgs
     mkdir -p $dst


### PR DESCRIPTION
Before:

```
$ nix-build -A manual pkgs/top-level/release.nix -K                                                                                                                                                                                                          
these derivations will be built:
  /nix/store/jp7f8q3ifqfnrgajh1kjx5xa6v88hgpv-nixpkgs-manual.drv
building path(s) ‘/nix/store/mfkp2wdn53vj79gv51nb43bij05ck1wk-nixpkgs-manual’
manual.xml:7: element para: Relax-NG validity error : Did not expect element para there
manual.xml:11: element section: Relax-NG validity error : Did not expect element section there
manual.xml:11: element section: Relax-NG validity error : Element chapter has extra content: section
manual.xml:4: element info: Relax-NG validity error : Element book has extra content: info
manual.xml fails to validate
builder for ‘/nix/store/i0ccwsn8yxicsggv8rysvi3cg1x3nw16-nixpkgs-manual.drv’ failed with exit code 3
error: build of ‘/nix/store/i0ccwsn8yxicsggv8rysvi3cg1x3nw16-nixpkgs-manual.drv’ failed
```

After:

```
$ nix-build -A manual pkgs/top-level/release.nix -K                                                                                                                                                                                                          
these derivations will be built:
  /nix/store/jp7f8q3ifqfnrgajh1kjx5xa6v88hgpv-nixpkgs-manual.drv
building path(s) ‘/nix/store/k73kv3c6bf5vcbhl61g7djnifrbkbibn-nixpkgs-manual’
/tmp/nix-build-nixpkgs-manual.drv-0/manual-full.xml:1754:97: error: element "para" not allowed here; expected the element end-tag, text or element "abbrev", "accel", "acronym", "address", "alt", "anchor", "annotation", "application", "author", "biblioli
st", "biblioref", "blockquote", "bridgehead", "calloutlist", "caution", "citation", "citebiblioid", "citerefentry", "citetitle", "classname", "classsynopsis", "cmdsynopsis", "code", "command", "computeroutput", "constant", "constraintdef", "constructors
ynopsis", "coref", "database", "date", "destructorsynopsis", "editor", "email", "emphasis", "envar", "epigraph", "equation", "errorcode", "errorname", "errortext", "errortype", "example", "exceptionname", "fieldsynopsis", "figure", "filename", "firstter
m", "footnote", "footnoteref", "foreignphrase", "funcsynopsis", "function", "glosslist", "glossterm", "guibutton", "guiicon", "guilabel", "guimenu", "guimenuitem", "guisubmenu", "hardware", "important", "indexterm", "informalequation", "informalexample"
, "informalfigure", "informaltable", "initializer", "inlineequation", "inlinemediaobject", "interfacename", "itemizedlist", "jobtitle", "keycap", "keycode", "keycombo", "keysym", "link", "literal", "literallayout", "markup", "mediaobject", "menuchoice",
 "methodname", "methodsynopsis", "modifier", "mousebutton", "msgset", "nonterminal", "note", "olink", "ooclass", "ooexception", "oointerface", "option", "optional", "orderedlist", "org", "orgname", "package", "parameter", "person", "personname", "phrase
", "procedure", "productionset", "productname", "productnumber", "programlisting", "programlistingco", "prompt", "property", "qandaset", "quote", "remark", "replaceable", "returnvalue", "revhistory", "screen", "screenco", "screenshot", "segmentedlist", 
"shortcut", "sidebar", "simplelist", "subscript", "superscript", "symbol", "synopsis", "systemitem", "table", "tag", "task", "termdef", "tip", "token", "trademark", "type", "uri", "userinput", "variablelist", "varname", "warning", "wordasword" or "xref"
note: keeping build directory ‘/tmp/nix-build-nixpkgs-manual.drv-3’
builder for ‘/nix/store/jp7f8q3ifqfnrgajh1kjx5xa6v88hgpv-nixpkgs-manual.drv’ failed with exit code 1
error: build of ‘/nix/store/jp7f8q3ifqfnrgajh1kjx5xa6v88hgpv-nixpkgs-manual.drv’ failed
```

One has to use `-K` to open `manual-full.xml`, but this is way better than it was.

Fixes #4966
