### PR TITLE
hwinfo: 21.12 -> 21.23

### DIFF
--- a/pkgs/tools/system/hwinfo/default.nix
+++ b/pkgs/tools/system/hwinfo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "hwinfo-${version}";
-  version = "21.12";
+  version = "21.23";
 
   src = fetchurl {
     url = "https://github.com/opensuse/hwinfo/archive/${version}.tar.gz";
-    sha256 = "01y5jk2jns0a3mgsgmvmpvi5yyc0df7b3yqsg32hn5r2nv17i47p";
+    sha256 = "1a8815zp3a7n2jx0cn0hcr69rfr6vmw8r8grbn5mv61g90bbcj6p";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
