### PR TITLE
fsharp: 4.0.0.4 -> 4.0.1.1

### DIFF
--- a/pkgs/development/compilers/fsharp/default.nix
+++ b/pkgs/development/compilers/fsharp/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "fsharp-${version}";
-  version = "4.0.0.4";
+  version = "4.0.1.1";
 
   src = fetchurl {
     url = "https://github.com/fsharp/fsharp/archive/${version}.tar.gz";
-    sha256 = "1m9pwr4xjl3ikaf3pzsa4pb3pr533xa0v34y2cy4pjcc6j0f71av";
+    sha256 = "0mvmvwwpl4zq0yvgzdizww8l9azvlrc82xm32nz1fi1nw8x5qfqk";
   };
 
   buildInputs = [ mono pkgconfig dotnetbuildhelpers autoconf automake which ];


### PR DESCRIPTION
/cc @yawnt
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
