### PR TITLE
oidentd: Set C dialect to gnu89 (broken by GCC 5)

### DIFF
--- a/pkgs/servers/identd/oidentd/default.nix
+++ b/pkgs/servers/identd/oidentd/default.nix
@@ -3,6 +3,8 @@
 stdenv.mkDerivation rec {
   name = "oidentd-2.0.8";
 
+  CFLAGS = [ "--std=gnu89" ];
+
   src = fetchurl {
     url = "mirror://sourceforge/ojnk/${name}.tar.gz";
     sha256 = "0vzv2086rrxcaavrm3js7aqvyc0grgaqy78x61d8s7r8hz8vwk55";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

---

_Please note, that points are not mandatory, but rather desired._
