### PR TITLE
gradle: Fix gradle-2.12 on Linux to find libstdc++.so.6 reference.

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -4,6 +4,8 @@ rec {
   gradleGen = {name, src} : stdenv.mkDerivation rec {
     inherit name src;
 
+    buildPhase = ":";
+
     installPhase = ''
       mkdir -pv $out/lib/gradle/
       cp -rv lib/ $out/lib/gradle/
@@ -15,7 +17,21 @@ rec {
         --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain"
     '';
 
-    phases = "unpackPhase installPhase";
+    fixupPhase = if (!stdenv.isLinux) then ":" else
+      let arch = if stdenv.is64bit then "amd64" else "i386"; in ''
+        mkdir patching
+        pushd patching
+        jar xf $out/lib/gradle/lib/native-platform-linux-${arch}-0.10.jar
+        patchelf --set-rpath "${stdenv.cc.cc}/lib:${stdenv.cc.cc}/lib64" net/rubygrapefruit/platform/linux-${arch}/libnative-platform.so
+        jar cf native-platform-linux-${arch}-0.10.jar .
+        mv native-platform-linux-${arch}-0.10.jar $out/lib/gradle/lib/
+        popd
+
+        # The scanner doesn't pick up the runtime dependency in the jar.
+        # Manually add a reference where it will be found.
+        mkdir $out/nix-support
+        echo ${stdenv.cc.cc} > $out/nix-support/manual-runtime-dependencies
+      '';
 
     buildInputs = [ unzip jdk makeWrapper ];
 


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Supersedes https://github.com/NixOS/nixpkgs/pull/11915

Unfortunately, gradle-2.12 on OS X continues to have to a dynamic library dependency on /usr/lib/libstdc++.6.dylib. I don't know how to fix that.

This is my first contribution to nixpkgs and I'm new to nix{,os,pkgs} --- please educate on whitespace, formatting, shell script idioms, etc.

cc @NeQuissimus @vcunat @copumpkin as interested parties on #11915.
