### PR TITLE
librecad: 2.0.8 -> 2.0.9

### DIFF
--- a/pkgs/applications/misc/librecad/default.nix
+++ b/pkgs/applications/misc/librecad/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, qt4, muparser, which, boost, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.8";
+  version = "2.0.9";
   name = "librecad-${version}";
 
   src = fetchurl {
     url = "https://github.com/LibreCAD/LibreCAD/tarball/${version}";
     name = name + ".tar.gz";
-    sha256 = "110vn1rvzidg8k6ifz1zws2wsn4cd05xl5ha0hbff2ln7izy84zc";
+    sha256 = "0npr2nxwmx1qil7lqhkh6yvkw7dwym0nfashxjglxspjallqjya7";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Updated LibreCAD from 2.0.8 to 2.0.9.
