### PR TITLE
kicad: 2013 stable -> 4.0.2

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,21 +1,39 @@
-{ stdenv, fetchurl, fetchbzr, cmake, mesa, wxGTK, zlib, libX11, gettext }:
+{ stdenv, fetchurl, fetchbzr, cmake, mesa, wxGTK, zlib, libX11, gettext, glew, cairo, openssl, boost, pkgconfig, doxygen }:
 
 stdenv.mkDerivation rec {
-  name = "kicad-20131025";
+  name = "kicad-${series}";
+  series = "4.0";
+  version = "4.0.2";
 
-  src = fetchbzr {
-    url = "https://code.launchpad.net/kicad/stable";
-    rev = 4024;
-    sha256 = "1sv1l2zpbn6439ccz50p05hvqg6j551aqra551wck9h3929ghly5";
-  };
+  srcs = [
+    (fetchurl {
+      url = "https://code.launchpad.net/kicad/${series}/${version}/+download/kicad-${version}.tar.xz";
+      sha256 = "1fcf91fmxj6ha3mm6gzdb0px50j58m80p8wrncm8ca9shj36kbif";
+    })
 
-  srcLibrary = fetchbzr {
-    url = "http://bazaar.launchpad.net/~kicad-product-committers/kicad/library";
-    rev = 293;
-    sha256 = "1wn9a4nhqyjzzfkq6xm7ag8n5n10xy7gkq6i7yry7wxini7pzv1i";
-  };
+    (fetchurl {
+      url = "http://downloads.kicad-pcb.org/libraries/kicad-library-${version}.tar.gz";
+      sha256 = "1xk9sxxb3d42chdysqmvizrjcbm0467q7nsq5cahq3j1hci49m6l";
+    })
 
-  cmakeFlags = "-DKICAD_STABLE_VERSION=ON";
+    (fetchurl {
+      url = "http://downloads.kicad-pcb.org/libraries/kicad-footprints-${version}.tar.gz";
+      sha256 = "0vrzykgxx423iwgz6186bi8724kmbi5wfl92gfwb3r6mqammgwpg";
+    })
+  ];
+  
+  sourceRoot = "kicad-${version}";
+
+  cmakeFlags = ''
+    -DCMAKE_BUILD_TYPE=Release
+    -DKICAD_SKIP_BOOST=ON
+    -DKICAD_BUILD_VERSION=${version}
+    -DKICAD_REPO_NAME=stable
+  '';
+
+  enableParallelBuilding = true; # often fails on Hydra: fatal error: pcb_plot_params_lexer.h: No such file or directory
+
+  buildInputs = [ cmake mesa wxGTK zlib libX11 gettext glew cairo openssl boost pkgconfig doxygen ];
 
   # They say they only support installs to /usr or /usr/local,
   # so we have to handle this.
@@ -23,16 +41,25 @@ stdenv.mkDerivation rec {
     sed -i -e 's,/usr/local/kicad,'$out,g common/gestfich.cpp
   '';
 
-  #enableParallelBuilding = true; # often fails on Hydra: fatal error: pcb_plot_params_lexer.h: No such file or directory
-
-  buildInputs = [ cmake mesa wxGTK zlib libX11 gettext ];
+  postUnpack = ''
+    pushd $(pwd)
+  '';  
 
   postInstall = ''
-    mkdir library
-    cd library
-    cmake -DCMAKE_INSTALL_PREFIX=$out $srcLibrary
+    popd
+
+    pushd kicad-library-*
+    cmake -DCMAKE_INSTALL_PREFIX=$out
+    make $MAKE_FLAGS
     make install
+    popd
+   
+    pushd kicad-footprints-*
+    mkdir -p $out/share/kicad/modules
+    cp -R *.pretty $out/share/kicad/modules/
+    popd
   '';
+
 
   meta = {
     description = "Free Software EDA Suite";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15730,7 +15730,7 @@ in
   gtkwave = callPackage ../applications/science/electronics/gtkwave { };
 
   kicad = callPackage ../applications/science/electronics/kicad {
-    wxGTK = wxGTK29;
+    wxGTK = wxGTK30;
   };
 
   ngspice = callPackage ../applications/science/electronics/ngspice { };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Upgrade to latest KiCAD stable release.
