### PR TITLE
stdenv: don't complain about configure script not existing

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -649,14 +649,14 @@ configurePhase() {
 
     # Add --disable-dependency-tracking to speed up some builds.
     if [ -z "$dontAddDisableDepTrack" ]; then
-        if grep -q dependency-tracking "$configureScript"; then
+        if [ -f "$configureScript" ] && grep -q dependency-tracking "$configureScript"; then
             configureFlags="--disable-dependency-tracking $configureFlags"
         fi
     fi
 
     # By default, disable static builds.
     if [ -z "$dontDisableStatic" ]; then
-        if grep -q enable-static "$configureScript"; then
+        if [ -f "$configureScript" ] && grep -q enable-static "$configureScript"; then
             configureFlags="--disable-static $configureFlags"
         fi
     fi


### PR DESCRIPTION
IIUC, since 89036ef76ab09a, when a package doesn't include a configure script, the build complains with:

```
grep: : No such file or directory
grep: : No such file or directory
```

I believe this change should fix that, though I'd like fore someone to confirm.
