### PR TITLE
skype: build qt4 with the 32bits clangStdenv

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13612,7 +13612,7 @@ in
 
   skype = callPackage_i686 ../applications/networking/instant-messengers/skype {
     qt4 = pkgsi686Linux.qt4.override {
-      stdenv = clangStdenv;
+      stdenv = pkgsi686Linux.clangStdenv;
     };
   };
 


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This allows to build qt4 without errors like this:
clang++ -Wl,-O1 -o libmng libmng.o     -lmng
/nix/store/1d2abmmqvindckyq51nq9kd1yisiv54j-binutils-2.26/bin/ld: skipping incompatible /nix/store/72nklasrjg774iwxxnpyxwkzxz2j37v5-libmng-2.0.2/lib/libmng.so when searching for -lmng
/nix/store/1d2abmmqvindckyq51nq9kd1yisiv54j-binutils-2.26/bin/ld: cannot find -lmng
/nix/store/1d2abmmqvindckyq51nq9kd1yisiv54j-binutils-2.26/bin/ld: skipping incompatible /nix/store/n0y8pv4kaff7vnq7rmzwrd654gqaj0ki-glibc-2.23/lib/libm.so when searching for -lm
/nix/store/1d2abmmqvindckyq51nq9kd1yisiv54j-binutils-2.26/bin/ld: skipping incompatible /nix/store/n0y8pv4kaff7vnq7rmzwrd654gqaj0ki-glibc-2.23/lib/libm.a when searching for -lm
clang-3.7: error: linker command failed with exit code 1 (use -v to see invocation)
