### PR TITLE
gnupg20: 2.0.29 -> 2.0.30

### DIFF
--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -12,11 +12,11 @@ with stdenv.lib;
 assert x11Support -> pinentry != null;
 
 stdenv.mkDerivation rec {
-  name = "gnupg-2.0.29";
+  name = "gnupg-2.0.30";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";
-    sha256 = "1jaakn0mi6pi2b3g3imxj3qzxw2zg0ifxs30baq2b157dcw6pvb8";
+    sha256 = "0wax4cy14hh0h7kg9hj0hjn9424b71z8lrrc5kbsasrn9xd7hag3";
   };
 
   buildInputs

--- a/pkgs/tools/security/gnupg/gpgkey2ssh-20.patch
+++ b/pkgs/tools/security/gnupg/gpgkey2ssh-20.patch
@@ -2,7 +2,7 @@ diff --git a/tools/gpgkey2ssh.c b/tools/gpgkey2ssh.c
 index 903fb5b..d5611dc 100644
 --- a/tools/gpgkey2ssh.c
 +++ b/tools/gpgkey2ssh.c
-@@ -266,7 +266,7 @@ main (int argc, char **argv)
+@@ -268,7 +268,7 @@ main (int argc, char **argv)
    keyid = argv[1];
  
    ret = asprintf (&command,


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @roconnor 

---

See https://lists.gnupg.org/pipermail/gnupg-announce/2016q1/000385.html
