### PR TITLE
syncthing: run daemon with dedicated user as default

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -257,6 +257,7 @@
       radicale = 234;
       hydra-queue-runner = 235;
       hydra-www = 236;
+      syncthing = 237;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -485,6 +486,7 @@
       pdnsd = 229;
       octoprint = 230;
       radicale = 234;
+      syncthing = 237;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal


### PR DESCRIPTION
###### Things done:
- [x] Tested in a NixOS vm
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14304

This PR creates a user and a group (defaults to "syncthing") to run syncthing when none is given. This way the service works just by setting `services.syncthing.enable = true;`

I also tried setting the permissions of `dataDir` to allow user access just by adding "syncthing" to `<username>.extraGroups` however it seems these changes are overwritten by syncthing when it starts: I tried with `postStart` and `facl -R -m` but it won't work. If no one can figure this out I'll just remove it.
