### PR TITLE
{lib}mediainfo{-gui}: 0.7.83 -> 0.7.84

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -2,11 +2,11 @@
 , desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.83";
+  version = "0.7.84";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0d8mph9lbg2lw0ccg1la0kqhbisra8q9rzn195lncch5cia5zyg7";
+    sha256 = "0w3hm34amfy5bq3n1jihbwqvwqn0f8kvvq3lfc8nfwf8v7mjn7q9";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.83";
+  version = "0.7.84";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0d8mph9lbg2lw0ccg1la0kqhbisra8q9rzn195lncch5cia5zyg7";
+    sha256 = "0w3hm34amfy5bq3n1jihbwqvwqn0f8kvvq3lfc8nfwf8v7mjn7q9";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.83";
+  version = "0.7.84";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "0kl5x07j3jp5mnmhpjvdq0a2nnlgvqnhwar0xalvg3b3msdf8417";
+    sha256 = "0k657ynfxcw6lvakc8plz0pzfixlqbsiih2idimk9k1dd4xzhq3d";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

---

Built and tested locally.

From the changelog:

```
Version 0.7.84, 2016-03-31
x #I122, MPEG-4/MOV: Crash if mdhd timescale is 0
x MPEG-4/MOV: Infinite loop if malformed stsc / stsz (detected by
  fuzzing)
x MPEG-TS: some DVB Subtitles were not detected
x HLS: better handling of media playlists having EXT-X-BYTERANGE
```
