### PR TITLE
tbb: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -1,5 +1,8 @@
 { stdenv, fetchurl }:
 
+let
+  SHLIB_EXT = if stdenv.isDarwin then "dylib" else "so";
+in
 stdenv.mkDerivation {
   name = "tbb-4.4-u2";
 
@@ -13,7 +16,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/{lib,share/doc}
-    cp "build/"*release*"/"*so* $out/lib/
+    cp "build/"*release*"/"*${SHLIB_EXT}* $out/lib/
     mv include $out/
     rm $out/include/index.html
     mv doc/html $out/share/doc/tbb
@@ -33,7 +36,7 @@ stdenv.mkDerivation {
       represents a higher-level, task-based parallelism that abstracts platform
       details and threading mechanisms for scalability and performance.
     '';
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = with stdenv.lib.maintainers; [ simons thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Reflects the different extension of shared library files, and uses a
`cp` that supports the `installPhase` usage.
