### PR TITLE
jython: 2.7-rc3 -> 2.7.0

### DIFF
--- a/pkgs/development/interpreters/jython/default.nix
+++ b/pkgs/development/interpreters/jython/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "jython-${version}";
 
-  version = "2.7-rc3";
+  version = "2.7.0";
 
   src = fetchurl {
     url = "http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/${version}/jython-standalone-${version}.jar";
-    sha256 = "89fcaf53f1bda6124f836065c1e318e2e853d5a9a1fbf0e96a387c6d38828c78";
+    sha256 = "0sk4myh9v7ma7nmzb8khg41na77xfi2zck7876bs7kq18n8nc1nx";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
