### PR TITLE
log4cxx: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/log4cxx/default.nix
+++ b/pkgs/development/libraries/log4cxx/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
     }' src/examples/cpp/console.cpp \
        src/main/cpp/inputstreamreader.cpp \
        src/main/cpp/socketoutputstream.cpp
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  sed -i 's/namespace std { class locale; }/#include <locale>/' src/main/include/log4cxx/helpers/simpledateformat.h
+  sed -i 's/\(#include <cctype>\)/\1\n#include <cstdlib>/' src/main/cpp/stringhelper.cpp
   '';
 
   buildInputs = [autoconf automake libtool libxml2 cppunit boost apr aprutil db expat];


### PR DESCRIPTION
###### Things done:
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
###### More

This patch replicates the patch logic from the brew recipe
https://github.com/Homebrew/homebrew/blob/56b57d583e874e6dfe7a417d329a147e4d4b064f/Library/Formula/log4cxx.rb
which is necessary to build on darwin.
