### PR TITLE
timewarrior: init at 2016-03-29

### DIFF
--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, cmake, libuuid, gnutls }:
+
+stdenv.mkDerivation rec {
+  name = "timewarrior-${version}";
+  version = "2016-03-29";
+
+  enableParallelBuilding = true;
+
+  src = fetchgit {
+    url = "https://git.tasktools.org/scm/tm/timew.git";
+    rev = "2175849a81ddd03707dca7b4c9d69d8fa11e35f7";
+    sha256 = "1c55a5jsm9n2zcyskklhqiclnlb2pz2h7klbzx481nsn62xd6bbg";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "A command-line time tracker";
+    homepage = http://tasktools.org/projects/timewarrior.html;
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13834,6 +13834,8 @@ in
 
   timbreid = callPackage ../applications/audio/pd-plugins/timbreid { };
 
+  timewarrior = callPackage ../applications/misc/timewarrior { };
+
   timidity = callPackage ../tools/misc/timidity { };
 
   tint2 = callPackage ../applications/misc/tint2 { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

The software is in early development (pre 0.1.0), though some things are already working and I expect it to become as nice as [taskwarrior](http://taskwarrior.org)

---

Pinging taskwarrior maintainers here: @marcweber @jgeerds 
