### PR TITLE
galen: 2.2.3 -> 2.2.4

### DIFF
--- a/pkgs/development/tools/galen/default.nix
+++ b/pkgs/development/tools/galen/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "galen";
-  version = "2.2.3";
+  version = "2.2.4";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/galenframework/galen/releases/download/galen-${version}/galen-bin-${version}.zip";
-    sha256 = "13kvxbw68g82rv8bp9g4fkrrsd7nag1a4bspilqi2wnxc51c8mqq";
+    sha256 = "0qx6pza6aw880ph76wbypcgy983pln8k4ad2indagb5qhiz4zw1d";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Things done:
- Built on platform(s)
  - [x] OS X
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

[Changelog](https://github.com/galenframework/galen/blob/2c265202376f54f02de028a2ea48a09691595072/CHANGELOG.md#2242015-03-31)
