### PR TITLE
gnome-boxes: add qemu to PATH

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/apps/gnome-boxes/default.nix
@@ -3,7 +3,7 @@
 , spice_protocol, libuuid, libsoup, libosinfo, systemd, tracker, vala
 , libcap_ng, libcap, yajl, gmp, gdbm, cyrus_sasl, gnome3, librsvg
 , desktop_file_utils, mtools, cdrkit, libcdio, numactl, xen
-, libusb, libarchive, acl, libgudev
+, libusb, libarchive, acl, libgudev, qemu
 }:
 
 # TODO: ovirt (optional)
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
         wrapProgram "$prog" \
             --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
             --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-            --prefix PATH : "${mtools}/bin:${cdrkit}/bin:${libcdio}/bin"
+            --prefix PATH : "${mtools}/bin:${cdrkit}/bin:${libcdio}/bin:${qemu}/bin"
     done
   '';
 


### PR DESCRIPTION
To actually import an ISO, it needs `qemu-img`:

```
(gnome-boxes:19283): Boxes-WARNING **: wizard.vala:463: Failed to create volume: internal error: creation of non-raw images is not supported without qemu-img
```
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

_Please note, that points are not mandatory, but rather desired._
