### PR TITLE
nixos: add option to restrict process information to process owners

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -47,6 +47,7 @@
       #floppy = 18; # unused
       #uucp = 19; # unused
       #lp = 20; # unused
+      #proc = 21; # unused
       pulseaudio = 22; # must match `pulseaudio' GID
       gpsd = 23;
       #cdrom = 24; # unused
@@ -288,6 +289,7 @@
       floppy = 18;
       uucp = 19;
       lp = 20;
+      proc = 21;
       pulseaudio = 22; # must match `pulseaudio' UID
       gpsd = 23;
       cdrom = 24;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -90,6 +90,7 @@
   ./security/ca.nix
   ./security/duosec.nix
   ./security/grsecurity.nix
+  ./security/hidepid.nix
   ./security/oath.nix
   ./security/pam.nix
   ./security/pam_usb.nix

--- a/nixos/modules/security/hidepid.nix
+++ b/nixos/modules/security/hidepid.nix
@@ -1,0 +1,42 @@
+{ config, pkgs, lib, ... }:
+with lib;
+
+{
+  options = {
+    security.hideProcessInformation = mkEnableOption "" // { description = ''
+      Restrict access to process information to the owning user.  Enabling
+      this option implies, among other things, that command-line arguments
+      remain private.  This option is recommended for most systems, unless
+      there's a legitimate reason for allowing unprivileged users to inspect
+      the process information of other users.
+
+      Members of the group "proc" are exempt from process information hiding.
+      To allow a service to run without process information hiding, add "proc"
+      to its supplementary groups via
+      <option>systemd.services.&lt;name?&gt;.serviceConfig.SupplementaryGroups</option>.
+    ''; };
+  };
+
+  config = mkIf config.security.hideProcessInformation {
+    users.groups.proc.gid = config.ids.gids.proc;
+
+    systemd.services.hidepid = {
+      wantedBy = [ "local-fs.target" ];
+      after = [ "systemd-remount-fs.service" ];
+      before = [ "local-fs-pre.target" "local-fs.target" "shutdown.target" ];
+      wants = [ "local-fs-pre.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = ''${pkgs.utillinux}/bin/mount -o remount,hidepid=2,gid=${toString config.ids.gids.proc} /proc'';
+        ExecStop = ''${pkgs.utillinux}/bin/mount -o remount,hidepid=0,gid=0 /proc'';
+      };
+
+      unitConfig = {
+        DefaultDependencies = false;
+        Conflicts = "shutdown.target";
+      };
+    };
+  };
+}

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -25,6 +25,8 @@ import ./make-test.nix ({ pkgs, ...} : {
         };
       users.users.sybil = { isNormalUser = true; group = "wheel"; };
       security.sudo = { enable = true; wheelNeedsPassword = false; };
+      security.hideProcessInformation = true;
+      users.users.alice = { isNormalUser = true; extraGroups = [ "proc" ]; };
     };
 
   testScript =
@@ -116,6 +118,13 @@ import ./make-test.nix ({ pkgs, ...} : {
       # Test sudo
       subtest "sudo", sub {
           $machine->succeed("su - sybil -c 'sudo true'");
+      };
+
+      # Test hidepid
+      subtest "hidepid", sub {
+          $machine->succeed("grep -Fq hidepid=2 /etc/mtab");
+          $machine->succeed("[ `su - sybil -c 'pgrep -c -u root'` = 0 ]");
+          $machine->succeed("[ `su - alice -c 'pgrep -c -u root'` != 0 ]");
       };
     '';
 })


### PR DESCRIPTION
This is intended as a conversation starter. This may be either too trivial (the code:boilerplate ratio is ridiculous) or cause too much potential breakage, but I find it to be a nifty option nonetheless, making it more discoverable would be a good thing, IMO.

I have used process information hiding on my desktop for years without problems; I believe it is safe to enable it for typical desktop installations, but have left it disabled by default, as I'm sure it breaks _SOME_ workflow out there (that's the only reason for even making this a module instead of just setting it unconditionally in the stage-2 init).

If the general idea is accepted, I would also add an option to specify a gid that is exempt from the hidepid restriction. This module would then provide a more user-friendly alternative to the severe /proc hardening offered by grsecurity.

Note that this implementation is only a rough draft, I would have to test it properly before it'd be considerd ready.

Thoughts?
