### PR TITLE
tinyxml: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/tinyxml/2.6.2-cxx.patch
+++ b/pkgs/development/libraries/tinyxml/2.6.2-cxx.patch
@@ -1,0 +1,17 @@
+diff -u a/Makefile b/Makefile
+--- a/Makefile	2011-05-14 22:24:57.000000000 -0400
++++ b/Makefile	2016-04-01 14:53:05.000000000 -0400
+@@ -19,9 +19,9 @@
+ 
+ #****************************************************************************
+ 
+-CC     := gcc
+-CXX    := g++
+-LD     := g++
++CC     ?= gcc
++CXX    ?= g++
++LD     ?= g++
+ AR     := ar rc
+ RANLIB := ranlib
+ 
+Common subdirectories: a/docs and b/docs


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More
- Relax the baked-in assumption that g++ is used to build and link
- Use the appropriate shared library extension on darwin
