### PR TITLE
qhull: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/qhull/default.nix
+++ b/pkgs/development/libraries/qhull/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = "-DMAN_INSTALL_DIR=share/man/man1 -DDOC_INSTALL_DIR=share/doc/qhull";
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's/namespace std { struct bidirectional_iterator_tag; struct random_access_iterator_tag; }/#include <iterator>/' ./src/libqhullcpp/QhullIterator.h
+    sed -i 's/namespace std { struct bidirectional_iterator_tag; struct random_access_iterator_tag; }/#include <iterator>/' ./src/libqhullcpp/QhullLinkedList.h
+  '';
+
   meta = {
     homepage = http://www.qhull.org/;
     description = "Computes the convex hull, Delaunay triangulation, Voronoi diagram and more";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

The hand-rolled iterator declaration is incompatible with libc++'s, and
clang > 3.5 is stricter about this.

See
https://lists.freebsd.org/pipermail/freebsd-ports-bugs/2014-December/298242.html
for another reference to this issue.

The errors that occur are of the form:
reference to 'random_access_iterator_tag' is ambiguous
