### PR TITLE
lammps: init at 2016-02-16 with serial and mpi builds

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, writeText, fetchurl,
+  libpng, fftw,
+  mpiSupport ? false, mpi ? null
+}:
+
+assert mpiSupport -> mpi != null;
+
+stdenv.mkDerivation rec {
+  # LAMMPS has weird versioning converted to ISO 8601 format
+  version = "2016-02-16";
+  name = "lammps-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/lammps/lammps-16Feb16.tar.gz";
+    sha256 = "1yzfbkxma3xa1288rnn66h4w0smbmjkwq1fx1y60pjiw0prmk105";
+  };
+
+  passthru = {
+    inherit mpi;
+  };
+
+  buildInputs = [ fftw libpng ]
+  ++ (stdenv.lib.optionals mpiSupport [ mpi ]);
+
+  # Must do manual build due to LAMMPS requiring a seperate build for
+  # the libraries and executable
+  builder = writeText "builder.sh" ''
+    source $stdenv/setup
+
+    tar xzf $src
+    cd lammps-*/src
+    make mode=exe ${if mpiSupport then "mpi" else "serial"} SHELL=$SHELL LMP_INC="-DLAMMPS_GZIP -DLAMMPS_PNG" FFT_PATH=-DFFT_FFTW3 FFT_LIB=-lfftw3 JPG_LIB=-lpng
+    make mode=shlib ${if mpiSupport then "mpi" else "serial"} SHELL=$SHELL LMP_INC="-DLAMMPS_GZIP -DLAMMPS_PNG" FFT_PATH=-DFFT_FFTW3 FFT_LIB=-lfftw3 JPG_LIB=-lpng
+
+    mkdir -p $out/bin
+    cp -v lmp_* $out/bin/lammps
+
+    mkdir -p $out/lib
+    cp -v liblammps* $out/lib/
+  '';
+
+  meta = {
+    description = "Classical Molecular Dynamics simulation code";
+    longDescription = ''
+      LAMMPS is a classical molecular dynamics simulation code designed to
+      run efficiently on parallel computers. It was developed at Sandia
+      National Laboratories, a US Department of Energy facility, with
+      funding from the DOE. It is an open-source code, distributed freely
+      under the terms of the GNU Public License (GPL).
+      '';
+    homepage = "http://lammps.sandia.gov";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15524,6 +15524,15 @@ in
 
   ### SCIENCE/MOLECULAR-DYNAMICS
 
+  lammps = callPackage ../applications/science/molecular-dynamics/lammps {
+    fftw = fftw;
+  };
+
+  lammps-mpi = appendToName "mpi" (lammps.override {
+    mpiSupport = true;
+    mpi = openmpi;
+  });
+
   gromacs = callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = true;
     mpiEnabled = false;


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Lammps is a scientific package for molecular dynamics. The package is added with serial and mpi support. I have tested to see that is does run the simulations correctly.

This is my first open source contribution so please be extra critical on my commit so I know I am doing it correctly!
