### PR TITLE
[WIP] Force no undefined symbols in shared libraries by default

### DIFF
--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -166,6 +166,12 @@ if [ "$NIX_SET_BUILD_ID" = 1 ]; then
 fi
 
 
+# Don't allow undefined symbols in shared libraries.
+if [ "$NIX_ENFORCE_NO_SHLIB_UNDEFINED" = 1 ]; then
+    extra+=(--no-allow-shlib-undefined)
+fi
+
+
 # Optionally print debug info.
 if [ -n "$NIX_DEBUG" ]; then
   echo "original flags to @prog@:" >&2

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -160,6 +160,9 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" "lib" ];
 
+  # Used during building; results seem fine.
+  NIX_ENFORCE_NO_SHLIB_UNDEFINED = false;
+
   crossAttrs = rec {
     buildInputs = [ expat.crossDrv zlib.crossDrv bzip2.crossDrv ];
     # all buildInputs set previously fell into propagatedBuildInputs, as usual, so we have to

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # Used during building; results seem fine.
+  NIX_ENFORCE_NO_SHLIB_UNDEFINED = false;
+
   meta = {
     description = "MIT Kerberos 5";
     homepage = http://web.mit.edu/kerberos/;

--- a/pkgs/development/libraries/wxGTK-2.8/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.8/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gtk, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
-, gstreamer, gst_plugins_base, GConf, libX11, cairo
+, gstreamer, gst_plugins_base, GConf
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l1w4i113csv3bd5r8ybyj0qpxdq83lj6jrc5p7cc10mkwyiagqz";
   };
 
-  buildInputs = [ gtk libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst_plugins_base GConf libX11 cairo ]
+  buildInputs = [ gtk libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst_plugins_base GConf ]
     ++ optional withMesa mesa;
 
   nativeBuildInputs = [ pkgconfig ];
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     + optionalString withMesa "${mesa}/lib ";
 
   # Work around a bug in configure.
-  NIX_CFLAGS_COMPILE = [ "-DHAVE_X11_XLIB_H=1" "-lX11" "-lcairo" ];
+  NIX_CFLAGS_COMPILE = "-DHAVE_X11_XLIB_H=1";
 
   preConfigure = "
     substituteInPlace configure --replace 'SEARCH_INCLUDE=' 'DUMMY_SEARCH_INCLUDE='

--- a/pkgs/stdenv/linux/bootstrap/i686.nix
+++ b/pkgs/stdenv/linux/bootstrap/i686.nix
@@ -1,12 +1,12 @@
 {
   busybox = import <nix/fetchurl.nix> {
-    url = http://tarballs.nixos.org/stdenv-linux/i686/8d66a51a872af1ab58edc68a2ebddcc79958b563/busybox;
-    sha256 = "9278001d11bb0359d0cc1b30bd5c9823f0b9c65db127d6dfcc1f6bbc000d15a0";
+    url = https://abbradar.net/me/pub/shlib-no-undefined/i686/busybox;
+    sha256 = "18fbjl8pdwwzz9ln9i34jdvdc172sbi0mnggakvf8mxfqzk1nk7g";
     executable = true;
   };
 
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = http://tarballs.nixos.org/stdenv-linux/i686/8d66a51a872af1ab58edc68a2ebddcc79958b563/bootstrap-tools.tar.xz;
-    sha256 = "6bc27ce9b08adcca0298f5fe80fe67f5bbb2dffdd1d8666fd44cb76ace198a25";
+    url = https://abbradar.net/me/pub/shlib-no-undefined/i686/bootstrap-tools.tar.xz;
+    sha256 = "1w15ap7c8ld55774kj8sz1rmy1wqr0carr73cfqiny97g6kj1ar8";
   };
 }

--- a/pkgs/stdenv/linux/bootstrap/x86_64.nix
+++ b/pkgs/stdenv/linux/bootstrap/x86_64.nix
@@ -3,7 +3,7 @@
 
 {
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = http://tarballs.nixos.org/stdenv-linux/x86_64/8d66a51a872af1ab58edc68a2ebddcc79958b563/bootstrap-tools.tar.xz;
-    sha256 = "325230b74d3d98f62ddcb595543887d09cd8421745a4eda229d2a87a1f1ed336";
+    url = https://abbradar.net/me/pub/shlib-no-undefined/x86_64/bootstrap-tools.tar.xz;
+    sha256 = "0as6mg2hpy4ck7s8hkncmfh9z01a8y93zwx18n7llzhpmf4l5qj5";
   };
 }

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -24,6 +24,7 @@ rec {
     ''
       export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
       export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
+      export NIX_ENFORCE_NO_SHLIB_UNDEFINED="''${NIX_ENFORCE_NO_SHLIB_UNDEFINED-1}"
       ${if system == "x86_64-linux" then "NIX_LIB64_IN_SELF_RPATH=1" else ""}
       ${if system == "mips64el-linux" then "NIX_LIB32_IN_SELF_RPATH=1" else ""}
     '';

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -17,6 +17,7 @@ rec {
     # libraries outside the Nix store (like the C library).
     export NIX_ENFORCE_PURITY=
     export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
+    export NIX_ENFORCE_NO_SHLIB_UNDEFINED="''${NIX_ENFORCE_NO_SHLIB_UNDEFINED-1}"
   '';
 
   prehookFreeBSD = ''

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -7,6 +7,7 @@ import ../generic rec {
     ''
       export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
       export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
+      export NIX_ENFORCE_NO_SHLIB_UNDEFINED="''${NIX_ENFORCE_NO_SHLIB_UNDEFINED-1}"
       export NIX_IGNORE_LD_THROUGH_GCC=1
     '';
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -68,6 +68,9 @@ let
 
     enableParallelBuilding = true;
 
+    # Builds Perl plugins.
+    NIX_ENFORCE_NO_SHLIB_UNDEFINED = false;
+
     meta = {
       description = "Powerful package manager that makes package management reliable and reproducible";
       longDescription = ''


### PR DESCRIPTION
After a [discussion](https://github.com/NixOS/nixpkgs/commit/5471eed63ce770491a93f5c07543ba4ba818a90e) I've tried to add a pass to cc-wrapper to make `ld` fail if there are any undefined symbols in created shared libraries by default. This should have been able to catch problems like fixed in https://github.com/NixOS/nixpkgs/commit/5471eed63ce770491a93f5c07543ba4ba818a90e -- but surprisingly, it didn't. There were no errors on building wxGTK with the fix reverted and `ldd` still shows that several libraries are not linked properly in the output. Of course, `pgadmin` fails to build. I don't have ideas what the problem is at this point ;_;

cc @vcunat 
