### PR TITLE
rebar3-nix-bootstrap: correct homepage URL

### DIFF
--- a/pkgs/development/tools/erlang/rebar3-nix-bootstrap/default.nix
+++ b/pkgs/development/tools/erlang/rebar3-nix-bootstrap/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     meta = {
       description = "Shim command to help bootstrap a rebar3 project on Nix";
       license = stdenv.lib.licenses.asl20;
-      homepage = "https://github.com/erl-nix/rebar3-nix-bootstrap";
+      homepage = "https://github.com/erlang-nix/rebar3-nix-bootstrap";
       maintainers = with stdenv.lib.maintainers; [ ericbmerritt ];
     };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @ericbmerritt

---

_Please note, that points are not mandatory, but rather desired._

Correct `homepage` URL: `s/erl-nix/erlang-nix/`
