### PR TITLE
linux config: enable the Yama LSM

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -277,6 +277,7 @@ with stdenv.lib;
   RANDOMIZE_BASE? y
   STRICT_DEVMEM y # Filter access to /dev/mem
   SECURITY_SELINUX_BOOTPARAM_VALUE 0 # Disable SELinux by default
+  SECURITY_YAMA y # Prevent processes from ptracing non-children processes
   DEVKMEM n # Disable /dev/kmem
   ${if versionOlder version "3.14" then ''
     CC_STACKPROTECTOR? y # Detect buffer overflows on the stack


### PR DESCRIPTION
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The Yama Linux Security Module restricts the use of ptrace so that
processes cannot ptrace processes that are not their children. This
prevents attackers from compromising one user-level processes and
snooping on the memory and runtime state of other processes owned
by the same user.

I think this was listed as a potential improvement on a Security page on the wiki.

I've been running with this enabled for about 2 weeks and haven't seen any problems. The `common-config.nix` file says to test all kernels with the config change - how can I do that?
