### PR TITLE
pulseaudio nixos module: run as systemd user service instead

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -150,6 +150,29 @@ in {
         target = "pulse/default.pa";
         source = cfg.configFile;
       };
+
+      systemd.user = {
+        services.pulseaudio = {
+          description = "PulseAudio Server";
+          # NixOS doesn't support "Also" so we bring it in manually
+          wantedBy = [ "default.target" ];
+          serviceConfig = {
+            Type = "notify";
+            ExecStart = "${cfg.package}/bin/pulseaudio --daemonize=no";
+            Restart = "on-failure";
+          };
+        };
+
+        sockets.pulseaudio = {
+          description = "PulseAudio Socket";
+          wantedBy = [ "sockets.target" ];
+          socketConfig = {
+            Priority = 6;
+            Backlog = 5;
+            ListenStream = "%t/pulse/native";
+          };
+        };
+      };
     })
 
     (mkIf systemWide {
@@ -171,8 +194,9 @@ in {
         before = [ "sound.target" ];
         environment.PULSE_RUNTIME_PATH = stateDir;
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/pulseaudio -D --log-level=${cfg.daemon.logLevel} --system --use-pid-file -n --file=${cfg.configFile}";
-          PIDFile = "${stateDir}/pid";
+          Type = "notify";
+          ExecStart = "${cfg.package}/bin/pulseaudio --daemonize=no --log-level=${cfg.daemon.logLevel} --system -n --file=${cfg.configFile}";
+          Restart = "on-failure";
         };
       };
     })


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Most of the desktop environments will spawn pulseaudio, but we can instead simply run it as a systemd service instead.

This patch also makes the system wide service run in foreground as recommended by upstream and allows it to use sd_notify to signal ready instead of reading a pid written to a file.

The user version has been tested with KDE and works fine there.

The system-wide version runs, but I haven't actually used it. Upstream does not recommend running in this mode.
