### PR TITLE
dbus nixos module: add units for systemd user session

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -139,6 +139,30 @@ in
 
     systemd.services.dbus.restartTriggers = [ configDir ];
 
+    systemd.user = {
+      services.dbus = {
+        description = "D-Bus User Message Bus";
+        requires = [ "dbus.socket" ];
+        # NixOS doesn't support "Also" so we pull it in manually
+        # As the .service is supposed to come up at the same time as
+        # the .socket, we use basic.target instead of default.target
+        wantedBy = [ "basic.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.dbus_daemon}/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation";
+          ExecReload = "${pkgs.dbus_daemon}/bin/dbus-send --print-reply --session --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig";
+        };
+      };
+
+      sockets.dbus = {
+        description = "D-Bus User Message Bus Socket";
+        socketConfig = {
+          ListenStream = "%t/bus";
+          ExecStartPost = "-${config.systemd.package}/bin/systemctl --user set-environment DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus";
+        };
+        wantedBy = [ "sockets.target" ];
+      };
+    };
+
     environment.pathsToLink = [ "/etc/dbus-1" "/share/dbus-1" ];
 
   };


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This patch makes dbus launch with the user session instead of leaving it up to the desktop environment launch script to run it.

It has been tested with KDE, which simply uses the running daemon instead of launching its own.

This is upstream's recommended way to run dbus.
