### PR TITLE
Clean-up abc package expressions.

### DIFF
--- a/pkgs/development/compilers/abc/default.nix
+++ b/pkgs/development/compilers/abc/default.nix
@@ -1,23 +1,6 @@
-{stdenv, fetchurl, javaCup, jre, apacheAnt, patches} :
+{stdenv, fetchurl, javaCup, jre, apacheAnt}:
 
-let { 
-  body =
-    stdenv.mkDerivation {
-      name = "abc-1.2.0";
-      builder = ./builder.sh;
-
-      src = fetchurl {
-        url = http://abc.comlab.ox.ac.uk/dists/1.2.0/files/abc-1.2.0-src.tar.gz;
-        md5 = "aef9e8eac860f904f2a841e18770dc47";
-      };
-
-      inherit apacheAnt polyglot soot javaCup xact jasmin jre javabdd paddle jedd patches;
-
-      meta = {
-        description = "The AspectBench Compiler for AspectJ";
-      };
-    };
-
+let
   soot =
     import ./soot {
       inherit stdenv fetchurl apacheAnt polyglot jasmin;
@@ -76,4 +59,21 @@ let {
         md5 = "9810ad8762101ea691a895f0a6b7a5c3";
       };
     };
+in
+
+stdenv.mkDerivation {
+  name = "abc-1.2.0";
+  builder = ./builder.sh;
+
+  src = fetchurl {
+    url = http://abc.comlab.ox.ac.uk/dists/1.2.0/files/abc-1.2.0-src.tar.gz;
+    md5 = "aef9e8eac860f904f2a841e18770dc47";
+  };
+
+  inherit apacheAnt polyglot soot javaCup xact jasmin jre javabdd paddle jedd;
+  patches = [];
+
+  meta = {
+    description = "The AspectBench Compiler for AspectJ";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3924,14 +3924,7 @@ in
 
   ### DEVELOPMENT / COMPILERS
 
-  abc =
-    abcPatchable [];
-
-  abcPatchable = patches :
-    callPackage ../development/compilers/abc/default.nix {
-      inherit patches;
-      javaCup = callPackage ../development/libraries/java/cup { };
-    };
+  abc = callPackage ../development/compilers/abc/default.nix { };
 
   aldor = callPackage ../development/compilers/aldor { };
 


### PR DESCRIPTION
This change fix an aliased-package security issue (#10851).
- [x] Tested same hashes using `nix-shell -p nox --run "nox-review wip"`
