### PR TITLE
picosat: 960 -> 965, add proof support

### DIFF
--- a/pkgs/applications/science/logic/picosat/default.nix
+++ b/pkgs/applications/science/logic/picosat/default.nix
@@ -9,12 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "0m578rpa5rdn08d10kr4lbsdwp4402hpavrz6n7n53xs517rn5hm";
   };
 
-  configurePhase = "./configure.sh --shared";
+  configurePhase = "./configure.sh --shared --trace";
 
   installPhase = ''
    mkdir -p $out/bin $out/lib $out/include/picosat
-   cp picomus "$out"/bin
-   cp picosat "$out"/bin
+   cp picomus picomcs picosat picogcnf "$out"/bin
 
    cp libpicosat.a "$out"/lib
    cp libpicosat.so "$out"/lib

--- a/pkgs/applications/science/logic/picosat/default.nix
+++ b/pkgs/applications/science/logic/picosat/default.nix
@@ -2,15 +2,14 @@
 
 stdenv.mkDerivation rec {
   name    = "picosat-${version}";
-  version = "960";
+  version = "965";
 
   src = fetchurl {
     url = "http://fmv.jku.at/picosat/${name}.tar.gz";
-    sha256 = "05z8cfjk84mkna5ryqlq2jiksjifg3jhlgbijaq36sbn0i51iczd";
+    sha256 = "0m578rpa5rdn08d10kr4lbsdwp4402hpavrz6n7n53xs517rn5hm";
   };
 
-  dontAddPrefix = true;
-  configureFlags = "--shared";
+  configurePhase = "./configure.sh --shared";
 
   installPhase = ''
    mkdir -p $out/bin $out/lib $out/include/picosat


### PR DESCRIPTION
PicoSAT only supports proof output when compiled with the `--trace` flag.

There are quite a few packages that have optional proof/etc. output that is disabled at compile-time (for example CVC4 comes to mind).  If there are no objections, I'm going to go through the logic packages and enable at least some of the optional features.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @roconnor @thoughtpolice 
