### PR TITLE
discord: init at 0.0.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -186,6 +186,7 @@
   ktosiek = "Tomasz Kontusz <tomasz.kontusz@gmail.com>";
   lassulus = "Lassulus <lassulus@gmail.com>";
   layus = "Guillaume Maudoux <layus.on@gmail.com>";
+  ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";
   lebastr = "Alexander Lebedev <lebastr@gmail.com>";
   leenaars = "Michiel Leenaars <ml.software@leenaa.rs>";
   leonardoce = "Leonardo Cecchi <leonardo.cecchi@gmail.com>";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl
+, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf
+, glib, gnome, gtk, libnotify, libX11, libXcomposite, libXcursor, libXdamage
+, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, pango
+, udev }:
+
+let version = "0.0.1"; in
+
+stdenv.mkDerivation {
+
+    name = "discord-${version}";
+
+    src = fetchurl {
+        url = "https://storage.googleapis.com/discord-developer/test/discord-canary-${version}.tar.gz";
+        sha256 = "1skmwc84s4xqyc167qrplhy5ah06kwfa3d3rxiwi4c8rc55vdd0g";
+    };
+
+    libPath = stdenv.lib.makeLibraryPath [
+        stdenv.cc.cc alsaLib atk cairo cups dbus expat fontconfig freetype
+        gdk_pixbuf glib gnome.GConf gtk libnotify libX11 libXcomposite
+        libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+        libXtst nspr nss pango udev
+     ];
+
+    installPhase = ''
+        mkdir -p $out/bin
+        mv * $out
+
+        # Copying how adobe-reader does it,
+        # see pkgs/applications/misc/adobe-reader/builder.sh
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+                 --set-rpath "$out:$libPath"                                   \
+                 $out/DiscordCanary
+
+        ln -s $out/DiscordCanary $out/bin/
+
+        # Putting udev in the path won't work :(
+        ln -s ${udev}/lib/libudev.so.1 $out
+        '';
+
+    meta = with stdenv.lib; {
+        description = "All-in-one voice and text chat for gamers that’s free, secure, and works on both your desktop and phone";
+        homepage = "https://discordapp.com/";
+        license = licenses.unfree;
+        maintainers = [ maintainers.ldesgoui ];
+        platforms = [ "x86_64-linux" ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16471,4 +16471,5 @@ in
 
   togglesg-download = callPackage ../tools/misc/togglesg-download { };
 
+  discord = callPackage ../applications/networking/instant-messengers/discord { };
 }


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (No dependencies, this is a new package)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @<maintainer>

---

Canary build reddit thread: https://www.reddit.com/r/discordapp/comments/4bu7lm/discord_linux_very_experimental_canary_release/

Voice might play around with your input settings, I recommend disabling Automatic Gain Control in Settings -> Voice -> Advanced

Their post-crash upload-log routine assumes /usr/bin/wget is present, this has been reported.
