### PR TITLE
WIP: cc-wrapper: Fix a typo in param parsing

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -46,9 +46,9 @@ while [ $n -lt ${#params[*]} ]; do
         isCpp=1
     elif [ "$p" = -nostdlib ]; then
         isCpp=-1
-    elif [ "${i:0:1}" != - ]; then
+    elif [ "${p:0:1}" != - ]; then
         nonFlagArgs=1
-    elif [ "$i" = -m32 ]; then
+    elif [ "$p" = -m32 ]; then
         if [ -e @out@/nix-support/dynamic-linker-m32 ]; then
             NIX_LDFLAGS="$NIX_LDFLAGS -dynamic-linker $(cat @out@/nix-support/dynamic-linker-m32)"
         fi


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes adding the 32bit linker when gcc is run with -m32. So far I've only tested building VirtualBox with this wrapper used only for the virtualbox's stdenv, I'll try building the whole thing properly overnight.

I did it while trying to fix VirtualBox, but I'm now getting `./result/bin/VirtualBox: relocation error: /nix/store/n2wxp513rr00f6hr2dy0waqahns49dch-glibc-2.21/lib/libpthread.so.0: symbol h_errno, version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference` (which I assume is an unrelated error).
