### PR TITLE
rustPackages: 2016-03-22 -> 2016-04-02

### DIFF
--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,15 +7,15 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-03-22";
-  rev = "f28cdedb698cf76f513fb4514b5ed2892ec89b2f";
+  version = "2016-04-02";
+  rev = "b705d049d78f96bc27c58ccec7902e65d90826bd";
 
   src = fetchFromGitHub {
       inherit rev;
 
       owner = "rust-lang";
       repo = "crates.io-index";
-      sha256 = "05j43pgdlf554y9r781xdc5la55anwiq6k7vml9icak699ywfxqq";
+      sha256 = "1aspn79i1rw9migw7j0m12ghdq9cqhq8n2vzxy6hy1l728j3ykdp";
   };
 
 in


### PR DESCRIPTION
Updates the Cargo registry to the latest version. [My Rust project](https://github.com/trishume/dayder) wouldn’t build because it uses a newer version of the Iron web framework.

I’ve tested that the package I changed builds but I have not tested if everything else works because I’m a n00b and don’t have much time to figure it out today. I also can’t foresee this causing any problems.

It would be neat to have a script that bumped rust-packages every couple days automatically and submitted a PR, same for the other language repositories. I might attempt that later but for now I’m just bumping.

cc @jagajaga @jgillich
