### PR TITLE
A couple of vulkan utilities

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake, bison }:
+
+stdenv.mkDerivation rec {
+  name = "glslang-${version}";
+  version = "2016-07-27";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "glslang";
+    rev = "8c8505c60454549181d78301933f3f108e2f55e6";
+    sha256 = "1219sq86pz6k8nzg9sqm34b0rdv6kkjirg54y6b2r5ak568r4kwx";
+  };
+
+  patches = [ ./install-headers.patch ];
+
+  buildInputs = [ cmake bison ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Khronos reference front-end for GLSL and ESSL";
+  };
+}

--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "glslang-${version}";
-  version = "2016-07-27";
+  version = "2016-07-16";
 
+  # `vulkan-loader` requires a specific version of `glslang` as specified in
+  # `<vulkan-loader-repo>/glslang_revision`.
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "8c8505c60454549181d78301933f3f108e2f55e6";
-    sha256 = "1219sq86pz6k8nzg9sqm34b0rdv6kkjirg54y6b2r5ak568r4kwx";
+    rev = "e4821e43c86d97bcf65fb07c1f70471b7102978d";
+    sha256 = "0vnfl8r5ssil1sffgk9sf7c7n5l3775pfizxgb1bcyvm84vw0pr3";
   };
 
   patches = [ ./install-headers.patch ];

--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -1,21 +1,22 @@
 { stdenv, fetchFromGitHub, cmake, bison }:
 
 stdenv.mkDerivation rec {
-  name = "glslang-${version}";
-  version = "2016-07-16";
+  name = "glslang-git-${version}";
+  version = "2016-08-26";
 
   # `vulkan-loader` requires a specific version of `glslang` as specified in
   # `<vulkan-loader-repo>/glslang_revision`.
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "e4821e43c86d97bcf65fb07c1f70471b7102978d";
-    sha256 = "0vnfl8r5ssil1sffgk9sf7c7n5l3775pfizxgb1bcyvm84vw0pr3";
+    rev = "81cd764b5ffc475bc73f1fb35f75fd1171bb2343";
+    sha256 = "1vfwl6lzkjh9nh29q32b7zca4q1abf3q4nqkahskijgznw5lr59g";
   };
 
   patches = [ ./install-headers.patch ];
 
   buildInputs = [ cmake bison ];
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/compilers/glslang/install-headers.patch
+++ b/pkgs/development/compilers/glslang/install-headers.patch
@@ -1,0 +1,26 @@
+diff --git a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
+index 50cda68..d4ba381 100755
+--- a/SPIRV/CMakeLists.txt
++++ b/SPIRV/CMakeLists.txt
+@@ -26,3 +26,8 @@ endif(WIN32)
+
+ install(TARGETS SPIRV
+         ARCHIVE DESTINATION lib)
++
++foreach(file ${HEADERS})
++    get_filename_component(dir ${file} DIRECTORY)
++    install(FILES ${file} DESTINATION include/SPIRV/${dir})
++endforeach()
+diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
+index 28f4742..5a25cbb 100644
+--- a/glslang/CMakeLists.txt
++++ b/glslang/CMakeLists.txt
+@@ -87,3 +87,8 @@ endif(WIN32)
+
+ install(TARGETS glslang
+         ARCHIVE DESTINATION lib)
++
++foreach(file ${HEADERS})
++    get_filename_component(dir ${file} DIRECTORY)
++    install(FILES ${file} DESTINATION include/glslang/${dir})
++endforeach()

--- a/pkgs/development/compilers/glslang/install-headers.patch
+++ b/pkgs/development/compilers/glslang/install-headers.patch
@@ -1,23 +1,23 @@
 diff --git a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
-index 50cda68..d4ba381 100755
+index 48a6c46..593d941 100755
 --- a/SPIRV/CMakeLists.txt
 +++ b/SPIRV/CMakeLists.txt
-@@ -26,3 +26,8 @@ endif(WIN32)
-
- install(TARGETS SPIRV
+@@ -42,3 +42,8 @@ endif(WIN32)
+ 
+ install(TARGETS SPIRV SPVRemapper
          ARCHIVE DESTINATION lib)
 +
-+foreach(file ${HEADERS})
++foreach(file ${HEADERS} ${SPVREMAP_HEADERS})
 +    get_filename_component(dir ${file} DIRECTORY)
 +    install(FILES ${file} DESTINATION include/SPIRV/${dir})
 +endforeach()
 diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
-index 28f4742..5a25cbb 100644
+index ff91135..4318279 100644
 --- a/glslang/CMakeLists.txt
 +++ b/glslang/CMakeLists.txt
-@@ -87,3 +87,8 @@ endif(WIN32)
-
- install(TARGETS glslang
+@@ -90,3 +90,8 @@ endif(WIN32)
+ 
+ install(TARGETS glslang 
          ARCHIVE DESTINATION lib)
 +
 +foreach(file ${HEADERS})

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, glslang, spirv-tools, python }:
+
+stdenv.mkDerivation rec {
+  name = "shaderc-git-${version}";
+  version = "2016-09-08";
+
+  # `vulkan-loader` requires a specific version of `glslang` as specified in
+  # `<vulkan-loader-repo>/glslang_revision`.
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "shaderc";
+    rev = "e17bb8ba3b8b0b9142b788d988612a40541c54ce";
+    sha256 = "17qfjqkz6j355qi130kixaz51svl09k9b5sfikksgnbmzglzcwki";
+  };
+
+  patchPhase = ''
+    cp -r ${spirv-tools.src} third_party/spirv-tools
+    chmod -R +w third_party/spirv-tools
+    ln -s ${spirv-tools.headers} third_party/spirv-tools/external/spirv-headers
+  '';
+
+  buildInputs = [ cmake glslang python ];
+  enableParallelBuilding = true;
+
+  cmakeFlags = [ "-DSHADERC_SKIP_TESTS=ON" "-DSHADERC_GLSLANG_DIR=${glslang.src}" ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "A collection of tools, libraries and tests for shader compilation.";
+  };
+}

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, fetchFromGitHub, cmake, git, python3, libxcb
+, python3Packages, glslang, pkgconfig, x11 }:
+
+assert stdenv.system == "x86_64-linux";
+
+stdenv.mkDerivation rec {
+  name = "vulkan-loader-${version}";
+  version = "1.0.21.0";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "Vulkan-LoaderAndValidationLayers";
+    rev = "97e3b677d9681aa8d420c314edae96c4bf72246d";
+    sha256 = "1y42rlffmr80rd4m0xfv2mfwd9qvd680i18vr0xs109narb6fm4f";
+  };
+
+  buildInputs = [ cmake git python3 libxcb python3Packages.lxml glslang
+                  pkgconfig x11
+                ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/bin
+    cp loader/libvulkan.so* $out/lib
+    cp demos/vulkaninfo $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "LunarG Vulkan loader";
+    homepage    = http://www.lunarg.com;
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, fetchFromGitHub, cmake, pkgconfig, git, python3,
-  python3Packages, glslang, spirv-tools, x11, libxcb}:
+  python3Packages, glslang, spirv-tools, x11, libxcb, wayland }:
 
 assert stdenv.system == "x86_64-linux";
 
@@ -15,8 +15,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ cmake pkgconfig git python3 python3Packages.lxml
-                  glslang spirv-tools x11 libxcb
+                  glslang spirv-tools x11 libxcb wayland
                 ];
+
+  cmakeFlags = [
+    "-DBUILD_WSI_WAYLAND_SUPPORT=ON" # XLIB/XCB supported by default
+  ];
 
   installPhase = ''
     mkdir -p $out/lib

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchgit, fetchFromGitHub, cmake, git, python3, libxcb
-, python3Packages, glslang, pkgconfig, x11 }:
+{ stdenv, fetchgit, fetchFromGitHub, cmake, pkgconfig, git, python3,
+  python3Packages, glslang, spirv-tools, x11, libxcb}:
 
 assert stdenv.system == "x86_64-linux";
 
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1y42rlffmr80rd4m0xfv2mfwd9qvd680i18vr0xs109narb6fm4f";
   };
 
-  buildInputs = [ cmake git python3 libxcb python3Packages.lxml glslang
-                  pkgconfig x11
+  buildInputs = [ cmake pkgconfig git python3 python3Packages.lxml
+                  glslang spirv-tools x11 libxcb
                 ];
 
   installPhase = ''

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,20 +3,29 @@
 
 assert stdenv.system == "x86_64-linux";
 
-stdenv.mkDerivation rec {
-  name = "vulkan-loader-${version}";
-  version = "1.0.21.0";
-
+let
+  version = "1.0.26.0";
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-LoaderAndValidationLayers";
-    rev = "97e3b677d9681aa8d420c314edae96c4bf72246d";
-    sha256 = "1y42rlffmr80rd4m0xfv2mfwd9qvd680i18vr0xs109narb6fm4f";
+    rev = "sdk-${version}";
+    sha256 = "157m746hc76xrxd3qq0f44f5dy7pjbz8cx74ykqrlbc7rmpjpk58";
   };
+  getRev = name: builtins.substring 0 40 (builtins.readFile "${src}/${name}_revision");
+in
+
+assert getRev "spirv-tools" == spirv-tools.src.rev;
+assert getRev "spirv-headers" == spirv-tools.headers.rev;
+assert getRev "glslang" == glslang.src.rev;
+
+stdenv.mkDerivation rec {
+  name = "vulkan-loader-${version}";
+  inherit version src;
 
   buildInputs = [ cmake pkgconfig git python3 python3Packages.lxml
                   glslang spirv-tools x11 libxcb wayland
                 ];
+  enableParallelBuilding = true;
 
   cmakeFlags = [
     "-DBUILD_WSI_WAYLAND_SUPPORT=ON" # XLIB/XCB supported by default

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, python }:
+
+let
+
+spirv_sources = {
+  # `vulkan-loader` requires a specific version of `spirv-tools` as specified
+  # in `<vulkan-loader-repo>/spirv-tools_revision`.
+  tools = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-Tools";
+    rev = "1a9385bbd0e6eae188c14302cf37c415ecc8b698";
+    sha256 = "12a2wyxhsnms966s12x9bkz2kh478qf9ygglzkxkd83j5fvmvzwm";
+  };
+  headers = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-Headers";
+    rev = "3814effb879ab5a98a7b9288a4b4c7849d2bc8ac";
+    sha256 = "1wfszfsx318i0gavwk0w1klg4wiav8g4q4qpraqgm69arasfb9gh";
+  };
+};
+
+in
+
+stdenv.mkDerivation rec {
+  name = "spirv-tools-${version}";
+  version = "2016-07-18";
+
+  src = spirv_sources.tools;
+  patchPhase = ''ln -sv ${spirv_sources.headers} external/spirv-headers'';
+
+  buildInputs = [ cmake python ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "The SPIR-V Tools project provides an API and commands for processing SPIR-V modules.";
+  };
+}

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -3,19 +3,19 @@
 let
 
 spirv_sources = {
-  # `vulkan-loader` requires a specific version of `spirv-tools` as specified
-  # in `<vulkan-loader-repo>/spirv-tools_revision`.
+  # `vulkan-loader` requires a specific version of `spirv-tools` and `spirv-headers` as specified in
+  # `<vulkan-loader-repo>/spirv-tools_revision`.
   tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "1a9385bbd0e6eae188c14302cf37c415ecc8b698";
-    sha256 = "12a2wyxhsnms966s12x9bkz2kh478qf9ygglzkxkd83j5fvmvzwm";
+    rev = "923a4596b44831a07060df45caacb522613730c9";
+    sha256 = "0hmgng2sv34amfsag3ya09prnv1w535djwlzfn8h2vh430vgawxa";
   };
   headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "3814effb879ab5a98a7b9288a4b4c7849d2bc8ac";
-    sha256 = "1wfszfsx318i0gavwk0w1klg4wiav8g4q4qpraqgm69arasfb9gh";
+    rev = "33d41376d378761ed3a4c791fc4b647761897f26";
+    sha256 = "1s103bpi3g6hhq453qa4jbabfkyxxpf9vn213j8k4vm26lsi8hs2";
   };
 };
 
@@ -27,8 +27,13 @@ stdenv.mkDerivation rec {
 
   src = spirv_sources.tools;
   patchPhase = ''ln -sv ${spirv_sources.headers} external/spirv-headers'';
+  enableParallelBuilding = true;
 
   buildInputs = [ cmake python ];
+
+  passthru = {
+    headers = spirv_sources.headers;
+  };
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9346,6 +9346,8 @@ in
                                           CoreText IOSurface ImageIO OpenGL GLUT;
   };
 
+  vulkan-loader = callPackage ../development/libraries/vulkan-loader { };
+
   vtkWithQt4 = vtk.override { qtLib = qt4; };
 
   vxl = callPackage ../development/libraries/vxl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6344,6 +6344,8 @@ in
 
   spin = callPackage ../development/tools/analysis/spin { };
 
+  spirv-tools = callPackage ../development/tools/spirv-tools { };
+
   splint = callPackage ../development/tools/analysis/splint {
     flex = flex_2_5_35;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11775,6 +11775,8 @@ in
 
   sampradaya = callPackage ../data/fonts/sampradaya { };
 
+  shaderc = callPackage ../development/compilers/shaderc { };
+
   shared_mime_info = callPackage ../data/misc/shared-mime-info { };
 
   shared_desktop_ontologies = callPackage ../data/misc/shared-desktop-ontologies { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4844,6 +4844,8 @@ in
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
+  glslang = callPackage ../development/compilers/glslang { };
+
   go_bootstrap = callPackage ../development/compilers/go/1.4.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] ~~OS X~~ (Not applicable)
  - [x] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`). See below
###### Notes

I don't think that this is quite ready to be merged as it's not easy to use the resultant binary or library.

In order to run `vulkaninfo` on Ubuntu it's necessary to do this at the moment: `LD_LIBRARY_PATH=/usr/lib/nvidia-355/:/usr/lib/x86_64-linux-gnu ~/.nix-profile/bin/vulkaninfo` 

I think that adding `/usr/lib/nvidia-355/` to `LD_LIBRARY_PATH` is unavoidable on Ubuntu due to #9415. Having to add `/usr/lib/x86_64-linux-gnu` is totally gross, and I'd rather avoid it if possible. This seems to be necessary to link with `libX11.so` and `libxcb-dri3.so`. Perhaps there should be some fancy library path patching in the mix.

I'd be grateful if someone on NixOS with a suitable driver installed could give `nix-shell -p vulkan-loader --command vulkaninfo` a spin and let me know what happens.
