### PR TITLE
Crashplan 46 r2

### DIFF
--- a/nixos/modules/services/backup/crashplan.nix
+++ b/nixos/modules/services/backup/crashplan.nix
@@ -50,7 +50,7 @@ with lib;
         ensureDir ${crashplan.vardir}/log 777
         cp -avn ${crashplan}/conf.template/* ${crashplan.vardir}/conf
         for x in app.asar bin EULA.txt install.vars lang lib libjniwrap64.so libjniwrap.so libjtux64.so libjtux.so libmd564.so libmd5.so share skin upgrade; do
-          if [ -e $x ]; then
+          if [ -e ${crashplan.vardir}/$x ]; then
             true;
           else
             ln -s ${crashplan}/$x ${crashplan.vardir}/$x;

--- a/pkgs/applications/backup/crashplan/default.nix
+++ b/pkgs/applications/backup/crashplan/default.nix
@@ -1,13 +1,15 @@
 { stdenv, fetchurl, makeWrapper, jre, cpio, gawk, gnugrep, gnused, procps, swt, gtk2, glib, libXtst }:
 
-let version = "4.6.0";
+let
+  version = "4.6.0";
+  rev = "2"; #tracks unversioned changes that occur on download.code42.com from time to time
 
 in stdenv.mkDerivation rec {
-  name = "crashplan-${version}";
+  name = "crashplan-${version}-r${rev}";
 
   crashPlanArchive = fetchurl {
     url = "https://download.code42.com/installs/linux/install/CrashPlan/CrashPlan_${version}_Linux.tgz";
-    sha256 = "0h9zk6i1pdvl101c8l4v4x6i7q4wkmkqp2dkm0lq7ha96lrvac47";
+    sha256 = "13rmmdj048r8k4v7ig4i6pnvwyzc1vasfgksf070bx6ksklgbq47";
   };
 
   srcs = [ crashPlanArchive ];


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes checksum mismatch and runtime error reported in https://github.com/NixOS/nixpkgs/pull/14066

cc @domenkozar @sztupi @Baughn @pSub
