### PR TITLE
elixir: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "elixir-${version}";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchurl {
     url = "https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz";
-    sha256 = "09s8469830s4070i0m04fxdhqimkdyc5k9jylm5vpfz9l3z4wvl8";
+    sha256 = "16759ff84d08b480b7e5499716e663b2fffd26e20cf2863de5613bc7bb05c817";
   };
 
   buildInputs = [ erlang rebar makeWrapper ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @the-kenny, @havvy, @couchemar
