### PR TITLE
rustc: 1.6.0 -> 1.7.0. Enable Darwin platform.

### DIFF
--- a/pkgs/development/compilers/rustc/default.nix
+++ b/pkgs/development/compilers/rustc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, callPackage }:
 
 callPackage ./generic.nix {
-  shortVersion = "1.6.0";
+  shortVersion = "1.7.0";
   isRelease = true;
   forceBundledLLVM = false;
   configureFlags = [ "--release-channel=stable" ];
-  srcSha = "1dvpiswl0apknizsz9bcrjnc4c43ys191a1b9gm3569xdlmxr36w";
+  srcSha = "05f4v6sfmvkwsv6a7jp9sxsm84s0gdvqyf2wwdi1ilg9k8nxzgd4";
 
   /* Rust is bootstrapped from an earlier built version. We need
   to fetch these earlier versions, which vary per platform.
@@ -15,12 +15,12 @@ callPackage ./generic.nix {
   for the tagged release and not a snapshot in the current HEAD.
   */
 
-  snapshotHashLinux686 = "e2553bf399cd134a08ef3511a0a6ab0d7a667216";
-  snapshotHashLinux64 = "7df8ba9dec63ec77b857066109d4b6250f3d222f";
-  snapshotHashDarwin686 = "29750870c82a0347f8b8b735a4e2e0da26f5098d";
-  snapshotHashDarwin64 = "c9f2c588238b4c6998190c3abeb33fd6164099a2";
-  snapshotDate = "2015-08-11";
-  snapshotRev = "1af31d4";
+  snapshotHashLinux686 = "a09c4a4036151d0cb28e265101669731600e01f2";
+  snapshotHashLinux64 = "97e2a5eb8904962df8596e95d6e5d9b574d73bf4";
+  snapshotHashDarwin686 = "ca52d2d3ba6497ed007705ee3401cf7efc136ca1";
+  snapshotHashDarwin64 = "3c44ffa18f89567c2b81f8d695e711c86d81ffc7";
+  snapshotDate = "2015-12-18";
+  snapshotRev = "3391630";
 
   patches = [ ./patches/remove-uneeded-git.patch ]
     ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;

--- a/pkgs/development/compilers/rustc/generic.nix
+++ b/pkgs/development/compilers/rustc/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit, fetchzip, file, python2, tzdata, procps
-, llvmPackages_37, jemalloc, ncurses, darwin, binutils
+, llvm, jemalloc, ncurses, darwin, binutils
 
 , shortVersion, isRelease
 , forceBundledLLVM ? false
@@ -11,8 +11,6 @@
 
 , patches
 } @ args:
-
-assert !stdenv.isFreeBSD;
 
 /* Rust's build process has a few quirks :
 
@@ -39,7 +37,7 @@ let version = if isRelease then
 
     procps = if stdenv.isDarwin then darwin.ps else args.procps;
 
-    llvmShared = llvmPackages_37.llvm.override { enableSharedLibraries = true; };
+    llvmShared = llvm.override { enableSharedLibraries = true; };
 
     platform = if stdenv.system == "i686-linux"
       then "linux-i386"
@@ -66,7 +64,7 @@ let version = if isRelease then
       description = "A safe, concurrent, practical language";
       maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington ];
       license = [ licenses.mit licenses.asl20 ];
-      platforms = platforms.linux;
+      platforms = platforms.linux ++ platforms.darwin;
     };
 
     snapshotHash = if stdenv.system == "i686-linux"

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -4,15 +4,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "exa-${version}";
-  version = "2016-03-22";
+  version = "2016-04-11";
 
-  depsSha256 = "18anwh235kzziq6z7md8f3rl2xl4l9d4ivsqw9grkb7yivd5j0jk";
+  depsSha256 = "1rpynsni2r3gim10xc1qkj51wpbzafwsr99y61zh41v4vh047g1k";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = "exa";
-    rev = "8805ce9e3bcd4b56f8811a686dd56c47202cdbab";
-    sha256 = "0dkvk0rsf068as6zcd01p7959rdjzm26mlkpid6z0j168gp4kh4q";
+    rev = "9b87ef1da2231acef985bb08f7bd4a557167b652";
+    sha256 = "1f71bqkpc6bf9jg1zxy21rzbyhzghwfmgbyyyb81ggxcri0kajwi";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Updated to Rust 1.7.0. Now rust network tests pass and do not fail on Darwin.

@copumpkin @pikajude nix-build option with sandbox enabled fails for me. Could you help debug me those as I don't have enough expertise in Darwin things.

```
$ nix-build --option build-use-chroot relaxed -A rustc
these derivations will be built:
  /nix/store/pids5n5s8hvixms06fcsj4sfz1rrhazg-rustc-1.7.0.drv
building path(s) ‘/nix/store/hp4v5c5xlkb4gvpnrd5dcpanixsgf4mz-rustc-1.7.0-doc’, ‘/nix/store/nq046bklqhgjm7zp01smbdxvcb2kzzbz-rustc-1.7.0’
killing process 7334
killing process 7334: Operation not permitted
error: while setting up the build environment: changing into ‘/private/var/folders/j7/4_0kh_7n6574vdxv_q0b4_1h0000gn/T/nix-build-rustc-1.7.0.drv-0’: No such file or directory
```

---

_Please note, that points are not mandatory, but rather desired._
