### PR TITLE
irssi: 0.8.17 -> 0.8.19

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, ncurses, glib, openssl, perl, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
-  name = "irssi-0.8.17";
+
+  version = "0.8.19";
+  name = "irssi-${version}";
 
   src = fetchurl {
-    urls = [ "https://distfiles.macports.org/irssi/${name}.tar.bz2"
-             "http://irssi.org/files/${name}.tar.bz2"
-           ];
-    sha256 = "01v82q2pfiimx6lh271kdvgp8hl4pahc3srg04fqzxgdsb5015iw";
+    urls = [ "https://github.com/irssi/irssi/releases/download/${version}/${name}.tar.gz" ];
+    sha256 = "0ny8dry1b8siyc5glaxcwzng0d2mxnwxk74v64f8xplqhrvlnkzy";
   };
 
   buildInputs = [ pkgconfig ncurses glib openssl perl libintlOrEmpty ];


### PR DESCRIPTION
irssi: 0.8.17 -> 0.8.19

This enables [SASL authentication](https://wiki.archlinux.org/index.php/Irssi#Authenticating_with_SASL), which was added in 0.8.18.

Tested via `nix-env -f /path/to/nixpkgs -i irssi`, followed by running
`irssi`.
