### PR TITLE
mini-httpd: add -ansi to CFLAGS

### DIFF
--- a/pkgs/servers/http/mini-httpd/default.nix
+++ b/pkgs/servers/http/mini-httpd/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1x4b6x40ymbaamqqq9p97lc0mnah4q7bza04fjs35c8agpm19zir";
   };
 
+  configureFlagsArray = [ "CFLAGS=-ansi" ];
+
   buildInputs = [ boost ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes  building mini-httpd. I've tested starting it and fetching a small file.

cc @peti 
