### PR TITLE
salt: init at 2015.8.8

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,0 +1,51 @@
+{
+  stdenv, fetchurl, pythonPackages, openssl,
+
+  # Many Salt modules require various Python modules to be installed,
+  # passing them in this array enables Salt to find them.
+  extraInputs ? []
+}:
+
+pythonPackages.buildPythonApplication rec {
+  name = "salt-${version}";
+  version = "2015.8.8";
+
+  disabled = pythonPackages.isPy3k;
+
+  src = fetchurl {
+    url = "https://pypi.python.org/packages/source/s/salt/${name}.tar.gz";
+    sha256 = "1xcfcs50pyammb60myph4f8bi2r6iwkxwsnnhrjwvkv2ymxwxv5j";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    futures
+    jinja2
+    markupsafe
+    msgpack
+    pycrypto
+    pyyaml
+    pyzmq
+    requests
+    salttesting
+    tornado
+  ] ++ extraInputs;
+
+  patches = [ ./fix-libcrypto-loading.patch ];
+
+  postPatch = ''
+    substituteInPlace "salt/utils/rsax931.py" \
+      --subst-var-by "libcrypto" "${openssl}/lib/libcrypto.so"
+  '';
+
+  # The tests fail due to socket path length limits at the very least;
+  # possibly there are more issues but I didn't leave the test suite running
+  # as is it rather long.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://saltstack.com/;
+    description = "Portable, distributed, remote execution and configuration management system";
+    maintainers = with maintainers; [ aneeshusa ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
+++ b/pkgs/tools/admin/salt/fix-libcrypto-loading.patch
@@ -1,0 +1,11 @@
+diff --git a/salt/utils/rsax931.py b/salt/utils/rsax931.py
+index 9eb1f4a..d764f7a 100644
+--- a/salt/utils/rsax931.py
++++ b/salt/utils/rsax931.py
+@@ -36,7 +36,7 @@ def _load_libcrypto():
+                 'libcrypto.so*'))
+             lib = lib[0] if len(lib) > 0 else None
+         if lib:
+-            return cdll.LoadLibrary(lib)
++            return cdll.LoadLibrary('@libcrypto@')
+         raise OSError('Cannot locate OpenSSL libcrypto')

--- a/pkgs/tools/admin/salt/testing.nix
+++ b/pkgs/tools/admin/salt/testing.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "SaltTesting-${version}";
+  version = "2015.7.10";
+
+  disabled = pythonPackages.isPy3k;
+
+  propagatedBuildInputs = with pythonPackages; [
+    six
+  ];
+
+  src = fetchurl {
+    url = "https://pypi.python.org/packages/source/S/SaltTesting/${name}.tar.gz";
+    sha256 = "0p0y8kb77pis18rcig1kf9dnns4bnfa3mr91q40lq4mw63l1b34h";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/saltstack/salt-testing;
+    description = "Common testing tools used in the Salt Stack projects";
+    maintainers = with maintainers; [ aneeshusa ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20299,6 +20299,10 @@ in modules // {
     };
   };
 
+  salt = callPackage ../tools/admin/salt {};
+
+  salttesting = callPackage ../tools/admin/salt/testing.nix {};
+
   sandboxlib = buildPythonPackage rec {
     name = "sandboxlib-${version}";
     version = "0.31";


### PR DESCRIPTION
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also init salttesting at 2015.7.10 as a build dependency.

I'm planning on adding a NixOS module for the Salt minion soon, but I'm not sure when I'll get to it so I wanted to post this for review separately in the meantime.
