### PR TITLE
steam-run: add derivation

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -1,5 +1,5 @@
 { runCommand, lib, writeText, writeScriptBin, stdenv, ruby } :
-{ env, runScript ? "bash", extraBindMounts ? [], extraInstallCommands ? "", importMeta ? {} } :
+{ env, runScript ? "bash", extraBindMounts ? [], extraInstallCommands ? "", meta ? {}, passthru ? {} } :
 
 let
   name = env.pname;
@@ -27,9 +27,9 @@ let
   '';
 
 in runCommand name {
-  meta = importMeta;
-  passthru.env =
-    runCommand "${name}-shell-env" {
+  inherit meta;
+  passthru = passthru // {
+    env = runCommand "${name}-shell-env" {
       shellHook = ''
         export CHROOTENV_EXTRA_BINDS="${lib.concatStringsSep ":" extraBindMounts}:$CHROOTENV_EXTRA_BINDS"
         exec ${chroot-user}/bin/chroot-user ${env} bash -l ${init "bash"} "$(pwd)"
@@ -40,6 +40,7 @@ in runCommand name {
       echo >&2 ""
       exit 1
     '';
+  };
 } ''
   mkdir -p $out/bin
   cat <<EOF >$out/bin/${name}

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,4 +1,5 @@
-{ lib, buildFHSUserEnv, steam
+{ stdenv, lib, writeScript, buildFHSUserEnv, steam
+, steam-runtime, steam-runtime-i686 ? null
 , withJava ? false
 , withPrimus ? false
 , nativeOnly ? false
@@ -6,10 +7,11 @@
 , newStdcpp ? false
 }:
 
-buildFHSUserEnv {
-  name = "steam";
+let
+  self = {
+    name = "steam";
 
-  targetPkgs = pkgs: with pkgs; [
+    targetPkgs = pkgs: with pkgs; [
       steamPackages.steam
       steamPackages.steam-fonts
       # License agreement
@@ -22,15 +24,13 @@ buildFHSUserEnv {
       which
       # Needed by gdialog, including in the steam-runtime
       perl
-    ]
-    ++ lib.optional withJava jdk
-    ++ lib.optional withPrimus (primus.override {
-      stdenv = overrideInStdenv stdenv [ useOldCXXAbi ];
-      stdenv_i686 = overrideInStdenv pkgsi686Linux.stdenv [ useOldCXXAbi ];
-    })
-    ;
+    ] ++ lib.optional withJava jdk
+      ++ lib.optional withPrimus (primus.override {
+           stdenv = overrideInStdenv stdenv [ useOldCXXAbi ];
+           stdenv_i686 = overrideInStdenv pkgsi686Linux.stdenv [ useOldCXXAbi ];
+         });
 
-  multiPkgs = pkgs: with pkgs; [
+    multiPkgs = pkgs: with pkgs; [
       # These are required by steam with proper errors
       xlibs.libXcomposite
       xlibs.libXtst
@@ -49,23 +49,47 @@ buildFHSUserEnv {
       })
     ];
 
-  extraBuildCommands = ''
-    mkdir -p steamrt
+    extraBuildCommands = ''
+      mkdir -p steamrt
+      ln -s ../lib/steam-runtime steamrt/${steam-runtime.arch}
+      ${lib.optionalString (steam-runtime-i686 != null) ''
+        ln -s ../lib32/steam-runtime steamrt/${steam-runtime-i686.arch}
+      ''}
+    '';
 
-    ln -s ../lib64/steam-runtime steamrt/amd64
-    ln -s ../lib32/steam-runtime steamrt/i386
-  '';
+    extraInstallCommands = ''
+      mkdir -p $out/share/applications
+      ln -s ${steam}/share/icons $out/share
+      ln -s ${steam}/share/pixmaps $out/share
+      sed "s,/usr/bin/steam,$out/bin/steam,g" ${steam}/share/applications/steam.desktop > $out/share/applications/steam.desktop
+    '';
 
-  extraInstallCommands = ''
-    mkdir -p $out/share/applications
-    ln -s ${steam}/share/icons $out/share
-    ln -s ${steam}/share/pixmaps $out/share
-    sed "s,/usr/bin/steam,$out/bin/steam,g" ${steam}/share/applications/steam.desktop > $out/share/applications/steam.desktop
-  '';
+    profile = ''
+      export STEAM_RUNTIME=/steamrt
+    '';
 
-  profile = ''
-    export STEAM_RUNTIME=/steamrt
-  '';
+    runScript = "steam";
 
-  runScript = "steam";
-}
+    passthru.run = buildFHSUserEnv (self // {
+      name = "steam-run";
+
+      runScript =
+        let ldPath = map (x: "/steamrt/${steam-runtime.arch}/" + x) steam-runtime.libs
+                   ++ lib.optionals (steam-runtime-i686 != null) (map (x: "/steamrt/${steam-runtime-i686.arch}/" + x) steam-runtime-i686.libs);
+        in writeScript "steam-run" ''
+          #!${stdenv.shell}
+          run="$1"
+          if [ "$run" = "" ]; then
+            echo "Usage: steam-run command-to-run args..." >&2
+            exit 1
+          fi
+          shift
+          export LD_LIBRARY_PATH=${lib.concatStringsSep ":" ldPath}:$LD_LIBRARY_PATH
+          exec "$run" "$@"
+        '';
+
+      passthru = {};
+    });
+  };
+
+in buildFHSUserEnv self

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -7,8 +7,13 @@ let
     steam-runtime = callPackage ./runtime.nix { };
     steam-runtime-wrapped = callPackage ./runtime-wrapped.nix { };
     steam = callPackage ./steam.nix { };
-    steam-chrootenv = callPackage ./chrootenv.nix { };
     steam-fonts = callPackage ./fonts.nix { };
+    steam-chrootenv = callPackage ./chrootenv.nix {
+      steam-runtime-i686 =
+        if pkgs.system == "x86_64-linux"
+        then pkgs.pkgsi686Linux.steamPackages.steam-runtime
+        else null;
+    };
   };
 
 in self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -134,11 +134,12 @@ in
   };
 
   buildFHSUserEnv = args: userFHSEnv {
-    env = buildFHSEnv (removeAttrs args [ "runScript" "extraBindMounts" "extraInstallCommands" "meta" ]);
+    env = buildFHSEnv (removeAttrs args [ "runScript" "extraBindMounts" "extraInstallCommands" "meta" "passthru" ]);
     runScript = args.runScript or "bash";
     extraBindMounts = args.extraBindMounts or [];
     extraInstallCommands = args.extraInstallCommands or "";
-    importMeta = args.meta or {};
+    meta = args.meta or {};
+    passthru = args.passthru or {};
   };
 
   buildMaven = callPackage ../build-support/build-maven.nix {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14896,11 +14896,14 @@ in
   stockfish = callPackage ../games/stockfish { };
 
   steamPackages = callPackage ../games/steam { };
+
   steam = steamPackages.steam-chrootenv.override {
     # DEPRECATED
     withJava = config.steam.java or false;
     withPrimus = config.steam.primus or false;
   };
+
+  steam-run = steam.run;
 
   stepmania = callPackage ../games/stepmania { };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This adds a new `steam-run` script, which gives one ability to run something with our assembled Steam Runtime in environment. This should come very handy for all kinds of games downloaded from various places (GOG, for example). Steam Runtime is the _de facto_ expected Linux userspace for commercial games, so this should make running them much more easy.

Example:

```
> steam-run ./run-game.sh
```

This also makes hopefully small but incompatible change to `userFHSEnv`, renaming `importMeta` argument to `meta` (a more standard name). `userFHSEnv` is mostly an internal function used by `buildFHSUserEnv`, so this should not be a problem.

Merging this in few days unless there are any remarks.
