### PR TITLE
pharo vm: Add cairo as runtime dependency

### DIFF
--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ bash unzip cmake glibc openssl gcc mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share ];
+  propagatedBuildInputs = [ cairo ];
 
   meta = {
     description = "Clean and innovative Smalltalk-inspired environment";


### PR DESCRIPTION
This is a work in progress attempt to make Cairo (libcairo) available in Pharo.

The specific problem I see is that when I run the [Moose 6.0 image](https://ci.inria.fr/moose/job/moose-6.0/lastSuccessfulBuild/artifact/moose-6.0.zip) then Roassal does not work. Can reproduce by opening Roassal Examples from the World menu and clicking to open one. The problem is that Pharo tries to dynamically load libcairo from a few hard-coded locations (none of which are suitable with nix).

Here is the local hack that I am using right now to make this actually work:
![pharoscreenshot 1](https://cloud.githubusercontent.com/assets/13791/14230269/1c3d8c16-f950-11e5-9218-0a1cd645ba7c.png)

Any tips on how to do this properly @DamienCassou?
