### PR TITLE
rakudo-star: 2015.11 -> 2016.01

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchurl, perl, jdk, icu, zlib, gmp, readline }:
+{ stdenv, fetchurl, perl, icu, zlib, gmp, readline }:
 
 stdenv.mkDerivation rec {
   name = "rakudo-star-${version}";
-  version = "2015.11";
+  version = "2016.01";
 
   src = fetchurl {
     url    = "http://rakudo.org/downloads/star/${name}.tar.gz";
-    sha256 = "1rzabg8daxf2g4l1njhdv3gfav91mp3y9my0mpz2xw06cxqfsjki";
+    sha256 = "feb385c5d05166061f413882e442d3a0ec53884918768940d3f00bb63bc85497";
   };
 
-  buildInputs = [ icu zlib gmp readline jdk perl ];
+  buildInputs = [ icu zlib gmp readline perl ];
   configureScript = "perl ./Configure.pl";
   configureFlags =
-    [ "--backends=moar,jvm"
+    [ "--backends=moar"
       "--gen-moar"
       "--gen-nqp"
     ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

The first rakudo-star release since the Perl 6 spec was stabilized! I removed JVM support because it's not considered functional yet and upstream recommends using MoarVM only.
