### PR TITLE
emacsPackages: remove outdated helm

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -963,22 +963,6 @@ let
     };
   };
 
-  helm = melpaBuild rec {
-    pname   = "helm";
-    version = "20150105";
-    src = fetchFromGitHub {
-      owner  = "emacs-helm";
-      repo   = pname;
-      rev    = "e5608ad86e7ca72446a4b1aa0faf604200ffe895";
-      sha256 = "0n2kr6pyzcsi8pq6faxz2y8kicz1gmvj98fzzlq3a107dqqp25ay";
-    };
-    packageRequires = [ async ];
-    meta = {
-      description = "An incremental completion and selection narrowing framework for Emacs";
-      license = gpl3Plus;
-    };
-  };
-
   helm-bibtex = melpaBuild rec {
     pname = "helm-bibtex";
     version = "20151125";


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true -A emacsPackagesNg.helm`)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of some pkgs that depend on this change using `emacsWithPackages (epkgs: [ epkgs.helm epkgs.helm-projectile ])`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

`helm-20150105` was added in https://github.com/NixOS/nixpkgs/pull/6250, which looks like an abandoned path since we now have automatically generated melpa packages.

Meanwhile, `helm-projectile` (probably among other packages) requires a newer `helm` (one that has `helm-types.el` i.e. 1.7.7 onwards). `helm-1.9.2` is already in `melpa-stable-generated.nix`. This removal makes that work (and hopefully others).

Question: is there any plan for `emacs-packages.nix`? IIUC it's just there for overrides (e.g. when some auto generated melpa packages are broken). If there are melpa generated packages that aren't broken, they should be removed from `emacs-packages.nix`, is that correct?

---

_Please note, that points are not mandatory, but rather desired._
