### PR TITLE
networkmanager: 1.0.6 -> 1.0.12

### DIFF
--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -6,7 +6,9 @@
 let
   pn = "network-manager-applet";
   major = "1.0";
-  version = networkmanager.version;
+  # With version 1.0.12 of NM, we are no longer in sync
+  # version = "${networkmanager.version}.10";
+  version = "${major}.10";
 in
 
 stdenv.mkDerivation rec {
@@ -14,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pn}/${major}/${name}.tar.xz";
-    sha256 = "1yj0m6fb9v12d0di0rfmk3hx1vmygjkiff2c476rf792sbh56kax";
+    sha256 = "1szh5jyijxm6z55irkp5s44pwah0nikss40mx7pvpk38m8zaqidh";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ];

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -6,16 +6,18 @@
 
 stdenv.mkDerivation rec {
   name = "network-manager-${version}";
-  version = "1.0.6";
+  version = "1.0.12";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/1.0/NetworkManager-${version}.tar.xz";
-    sha256 = "38ea002403e3b884ffa9aae25aea431d2a8420f81f4919761c83fb92648254bd";
+    sha256 = "17jan0g5jzp8mrpklyacwdgnnw016m1c5pc4az5im6qhc260yirs";
   };
 
   preConfigure = ''
     substituteInPlace tools/glib-mkenums --replace /usr/bin/perl ${perl}/bin/perl
     substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe /run/current-system/sw/sbin/modprobe
+    substituteInPlace data/84-nm-drivers.rules \
+      --replace /bin/sh ${stdenv.shell}
     substituteInPlace data/85-nm-unmanaged.rules \
       --replace /bin/sh ${stdenv.shell} \
       --replace /usr/sbin/ethtool ${ethtool}/sbin/ethtool \


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also pulls in networkmanager-applet at 1.0.10 as it is no longer in sync with the NM version.

So this is tested on NixOS (where it works just fine), but I haven't been able to interact with it using plasma-nm as the KDE rebuild is taking FOREVER on the hardware I have available for testing. `nmtui` works though.
