### PR TITLE
srtp: 1.5.2 -> 1.5.4 for CVE-2015-6360

### DIFF
--- a/pkgs/development/libraries/srtp/default.nix
+++ b/pkgs/development/libraries/srtp/default.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libsrtp-${version}";
-  version = "1.5.2";
+  version = "1.5.4";
 
   src = fetchFromGitHub {
     owner = "cisco";
     repo = "libsrtp";
     rev = "v${version}";
-    sha256 = "0iy1il72gnjcwbi16wf4kzdqs1xx8is9qvs6m49pg37218s26gdw";
+    sha256 = "0s029m4iw0nsvnsm2hlz8yajrasdvf315iv2dw8mfm7nhbshwsqa";
   };
 
   buildInputs = [ pkgconfig ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   ] ++ optional (openssl != null) "--enable-openssl";
 
   postInstall = ''
-    rmdir $out/bin
+    rm -rf $out/bin
   '';
 
   meta = {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Prevent potential DoS attack due to lack of bounds
checking on RTP header CSRC count and extension header
length. Credit goes to Randell Jesup and the Firefox team
for reporting this issue.

https://www.rapid7.com/db/vulnerabilities/freebsd-vid-6171eb07-d8a9-11e5-b2bd-002590263bf5
