### PR TITLE
Fix typo in service.syncthing.dataDir description.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1603.xml
+++ b/nixos/doc/manual/release-notes/rl-1603.xml
@@ -348,7 +348,7 @@ $TTL 1800
     <para>
     <literal>service.syncthing.dataDir</literal> options now has to point
     to exact folder where syncthing is writing to. Example configuration should
-    loook something like:
+    look something like:
     </para>
     <programlisting>
 services.syncthing = {


### PR DESCRIPTION
This should be cherry-picked to 16.03 branch.

cc @garbas 
