### PR TITLE
libtorrentRasterbar: 1.0.6 -> 1.0.9

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "1.0.6";
-  sha256 = "1qypc5lx82vlqm9016knxx8khxpc9dy78a0q2x5jmxjk8v6g994r";
+  version = "1.0.9";
+  sha256 = "1kfydlvmx4pgi5lpbhqr4p3jr78p3f61ic32046mkp4yfyydrspl";
 })


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
###### More

Fixes issue https://bbs.archlinux.org/viewtopic.php?id=206627 present in nixos deluge right now

cc @Phreedom 
