### PR TITLE
sent: optional `patches` argument

### DIFF
--- a/pkgs/applications/misc/sent/default.nix
+++ b/pkgs/applications/misc/sent/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, libpng, libX11, libXft }:
+{ stdenv, fetchurl, libpng, libX11, libXft
+, patches ? [] }:
 
 stdenv.mkDerivation rec {
   name = "sent-0.2";
@@ -9,6 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libpng libX11 libXft ];
+
+  inherit patches;
 
   installFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
sent (like most suckless tools) is configured by recompiling with some
header changes. This eases the configuration.
