### PR TITLE
vscode: shrink derivation size

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -42,8 +42,8 @@ in
     '';
 
     buildPhase  = ''
-      # INSTALL COMPILE- & RUN-TIME DEPENDENCIES
-      echo "INSTALL COMPILE- & RUN-TIME DEPENDENCIES"
+      # BUILD COMPILE- & RUN-TIME DEPENDENCIES
+      echo "BUILD COMPILE- & RUN-TIME DEPENDENCIES"
       mkdir -p ./tmp
       HOME=./tmp ./scripts/npm.sh install
 
@@ -60,6 +60,10 @@ in
     '';
 
     installPhase = ''
+      # PRUNE COMPILE-TIME DEPENDENCIES
+      echo "PRUNE COMPILE-TIME DEPENDENCIES"
+      npm prune --production
+
       # COPY FILES NEEDED FOR RUNNING APPLICATION TO OUT DIRECTORY
       echo "COPY FILES NEEDED FOR RUNNING APPLICATION TO OUT DIRECTORY"
       mkdir -p "$out"


### PR DESCRIPTION
Follow-up of #14418: This PR shrinks derivation size from ~337MB to ~121MB, which is around the same size as the downloadable, pre-built binary.
###### Things done:
- [x] Tested using buildtime sandboxing (`nix-build . --option build-use-chroot true -A vscode`)
- [x] Tested using runtime sandboxing (`nix-shell -I nixpkgs=. --pure -p vscode`)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested pkgs depending on change (`nix-shell -p nox --run "nox-review wip --against HEAD~1"`)
  - [x] dependent pkg `vscode` compiles & runs
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
