### PR TITLE
emacs25pre: call autogen.sh before configuring

### DIFF
--- a/pkgs/applications/editors/emacs-25/builder.sh
+++ b/pkgs/applications/editors/emacs-25/builder.sh
@@ -5,6 +5,8 @@ source $stdenv/setup
 # *our* versions, not the ones found in the system, as it would do by default.
 # On other platforms, this appears to be unnecessary.
 preConfigure() {
+    ./autogen.sh
+
     for i in Makefile.in ./src/Makefile.in ./lib-src/Makefile.in ./leim/Makefile.in; do
         substituteInPlace $i --replace /bin/pwd pwd
     done


### PR DESCRIPTION
Trivial patch to call `autogen.sh` prior to configuring. Otherwise, the `configure` script is missing and the builder calls `make` directly, which then uses the `GNUmakefile` from the source tree. That file in turn calls `autogen.sh` without `--prefix`, so the install phase fails.

It's still necessary to override the derivation with `doCheck = false` due to #13573.
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @chaoflow @lovek323 @peti @the-kenny
