### PR TITLE
mosh: fix segfaulting issue

### DIFF
--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, zlib, boost, protobuf, ncurses, pkgconfig, IOTty
-, makeWrapper, perl, openssl }:
+, makeWrapper, perl, openssl, autoreconfHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "mosh-1.2.5";
@@ -9,7 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "1qsb0y882yfgwnpy6f98pi5xqm6kykdsrxzvaal37hs7szjhky0s";
   };
 
-  buildInputs = [ boost protobuf ncurses zlib pkgconfig IOTty makeWrapper perl openssl ];
+  buildInputs = [ autoreconfHook boost protobuf ncurses zlib pkgconfig IOTty makeWrapper perl openssl ];
+
+  patches = [
+    # remove automake detection macro patch on next release as it is already on mosh master
+    (fetchpatch {
+      name = "fix_automake_detection_macro.patch";
+      url = "https://github.com/mobile-shell/mosh/commit/a47917b97606a03f6bbf0cafd1fcd495b0229790.patch";
+      sha256 = "0ib200ffvbnns125xd58947fyxdx31m06rmnzqmxpxcnjza7k404";
+    })
+  ];
 
   postInstall = ''
       wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB


### PR DESCRIPTION
Fixes mosh-server segfaulting. Background on the issue causing this can be found at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=817929
###### Things done:
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @viric 

---
