### PR TITLE
openmpi: patch for legitimate zero size messages

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -20,6 +20,12 @@ in stdenv.mkDerivation rec {
     sha256 = "14p4px9a3qzjc22lnl6braxrcrmd9rgmy7fh4qpanawn2pgfq6br";
   };
 
+  # Bug in openmpi implementation for zero sized messages
+  # Patch required to make mpi4py pass. Will NOT
+  # be required when openmpi >= 2.0.0
+  # https://www.open-mpi.org/community/lists/users/2015/11/28030.php
+  patches = [ ./nbc_copy.patch ];
+
   buildInputs = [ gfortran libibverbs ];
 
   nativeBuildInputs = [ perl ];
@@ -42,4 +48,3 @@ in stdenv.mkDerivation rec {
     maintainers = [ stdenv.lib.maintainers.mornfall ];
   };
 }
-

--- a/pkgs/development/libraries/openmpi/nbc_copy.patch
+++ b/pkgs/development/libraries/openmpi/nbc_copy.patch
@@ -1,0 +1,30 @@
+commit 4ee20ba31dd64b8f899447cdad78ec2379acfce7
+Author: Gilles Gouaillardet <gilles@rist.or.jp>
+Date:   Tue Nov 10 08:59:03 2015 +0900
+
+    fix NBC_Copy for legitimate zero size messages
+    
+    (back ported from commit open-mpi/ompi@0bd765eddd33e3d4ac18ec644c60a5c160cb48dc)
+    (back ported from commit open-mpi/ompi@9a70765f27fdf17e70e1a115754fef7e5f16132a)
+
+diff --git a/ompi/mca/coll/libnbc/nbc_internal.h b/ompi/mca/coll/libnbc/nbc_internal.h
+index bf2f1cb..81be8cc 100644
+--- a/ompi/mca/coll/libnbc/nbc_internal.h
++++ b/ompi/mca/coll/libnbc/nbc_internal.h
+@@ -501,7 +501,14 @@ static inline int NBC_Copy(void *src, int srccount, MPI_Datatype srctype, void *
+   } else {
+     /* we have to pack and unpack */
+     res = MPI_Pack_size(srccount, srctype, comm, &size);
+-    if (MPI_SUCCESS != res || 0 == size) { printf("MPI Error in MPI_Pack_size() (%i:%i)\n", res, size); return (MPI_SUCCESS == res) ? MPI_ERR_SIZE : res;}
++    if (MPI_SUCCESS != res) {
++      printf ("MPI Error in MPI_Pack_size() (%i:%i)", res, size);
++      return res;
++    }
++
++    if (0 == size) {
++        return OMPI_SUCCESS;
++    }
+     packbuf = malloc(size);
+     if (NULL == packbuf) { printf("Error in malloc()\n"); return res; }
+     pos=0;
+


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This patch is required in order to make python-mpi4py tests pass.
It is also a bug in the openmpi implementation to see full discussion
see https://www.open-mpi.org/community/lists/users/2015/11/28030.php

I will be releasing an python-mpi4py change that depends on this patch. 

Please note that this patch will NOT be required when openmpi upgrades to 2.0.0.
