### PR TITLE
mpi4py: 1.3.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,56 +1,33 @@
-{ stdenv, fetchurl, python, buildPythonPackage, mpi, openssh, isPy3k, isPyPy }:
+{ stdenv, fetchurl, python, buildPythonPackage,
+  cython, mpi, openssh }:
 
 buildPythonPackage rec {
-  name = "mpi4py-1.3.1";
+  name = "mpi4py-2.0.0";
 
   src = fetchurl {
     url = "https://bitbucket.org/mpi4py/mpi4py/downloads/${name}.tar.gz";
-    sha256 = "e7bd2044aaac5a6ea87a87b2ecc73b310bb6efe5026031e33067ea3c2efc3507";
+    sha256 = "10fb01595rg17ycz08a23v24akm25d13srsy2rnixam7a5ca0hv5";
   };
 
   passthru = {
     inherit mpi;
   };
 
-  # The tests in the `test_spawn` module fail in the chroot build environment.
-  # However, they do pass in a pure, or non-pure nix-shell. Hence, we
-  # deactivate these particular tests.
-  # Unfortunately, the command-line arguments to `./setup.py test` are not
-  # correctly passed to the test-runner. Hence, these arguments are patched
-  # directly into `setup.py`.
-  patchPhase = ''
-    sed 's/err = main(cmd.args or \[\])/err = main(cmd.args or ["-v", "-e", "test_spawn"])/' -i setup.py
-  '';
+  # mpi4py 2.0.0 patch NOT needed in future releases
+  # https://bitbucket.org/mpi4py/mpi4py/issues/28/test_dltestdl-test-failure
+  patches = [ ./test-libm.patch ];
 
-  configurePhase = "";
+  preBuild = "export MPICC=${mpi}/bin/mpicc";
 
-  installPhase = ''
-    mkdir -p "$out/lib/${python.libPrefix}/site-packages"
-    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
-
-    ${python}/bin/${python.executable} setup.py install \
-      --install-lib=$out/lib/${python.libPrefix}/site-packages \
-      --prefix="$out"
-
-    # --install-lib:
-    # sometimes packages specify where files should be installed outside the usual
-    # python lib prefix, we override that back so all infrastructure (setup hooks)
-    # work as expected
-  '';
-
-  setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
-
-  buildInputs = [ mpi ];
+  buildInputs = [ mpi cython ];
   # Requires openssh for tests. Tests of dependent packages will also fail,
   # if openssh is not present. E.g. h5py with mpi support.
   propagatedBuildInputs = [ openssh ];
 
-  disabled = isPy3k || isPyPy;
-
   meta = {
     description =
       "Python bindings for the Message Passing Interface standard";
-    homepage = "http://code.google.com/p/mpi4py/";
+    homepage = "https://bitbucket.org/mpi4py/mpi4py";
     license = stdenv.lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/mpi4py/test-libm.patch
+++ b/pkgs/development/python-modules/mpi4py/test-libm.patch
@@ -1,0 +1,13 @@
+diff --git a/test/test_dl.py b/test/test_dl.py
+index a3211a3..53b9f36 100644
+--- a/test/test_dl.py
++++ b/test/test_dl.py
+@@ -15,6 +15,9 @@ class TestDL(unittest.TestCase):
+             libm = 'libm.so'
+
+         handle = dl.dlopen(libm, dl.RTLD_LOCAL|dl.RTLD_LAZY)
++        if handle == 0 and sys.platform.startswith('linux'):
++            self.assertTrue(dl.dlerror() is not None)
++            handle = dl.dlopen('libm.so.6', dl.RTLD_LOCAL|dl.RTLD_LAZY)
+         self.assertTrue(handle != 0)
+         self.assertTrue(dl.dlerror() is None)


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Install formula was significantly simplified. There is a bug in the unitests
that is addressed at https://bitbucket.org/mpi4py/mpi4py/issues/28/test_dltestdl-test-failure
Now all tests are run and pass (previously some tests were omitted). Patch will _not_ be necissary in next release > 2.0.0.

_This commit depends on pull request 14445_ https://github.com/NixOS/nixpkgs/pull/14445 I will update when this pull request has been accepted
