### PR TITLE
vscode: switch to unfree, binary package

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,90 +1,50 @@
-{ callPackage, stdenv, fetchurl, makeWrapper
-, jq, xlibs, gtk, python, nodejs
+{ stdenv, callPackage, fetchurl, unzip
 , ...
 } @ args:
 
 let
-  electron = callPackage ../../../development/tools/electron/default.nix (args // rec {
-    version = "0.35.6";
-    sha256 = "1bwn14769nby04zkza9jphsya2p6fjnkm1k2y4h5y2l4gnqdvmx0";
-  });
+  atomEnv = callPackage ../../../development/tools/electron/env-atom.nix (args);
+
+  version = "0.10.10";
+  rev = "5b5f4db87c10345b9d5c8d0bed745bcad4533135";
+  sha256 = if stdenv.system == "i686-linux"    then "1mmgq4fxi2h4hvz7yxgzzyvlznkb42qwr8i1g2b1akdlgnrvvpby"
+      else if stdenv.system == "x86_64-linux"  then "1zjb6mys5qs9mb21rpgpnbgq4gpnw6gsgfn5imf7ca7myk1bxnvk"
+      else if stdenv.system == "x86_64-darwin" then "0y1as2s6nhicyvdfszphhqp76iv9wcygglrl2f0jamm98g9qp66p"
+      else throw "Unsupported system: ${stdenv.system}";
+
+  urlMod = if stdenv.system == "i686-linux" then "linux-ia32"
+      else if stdenv.system == "x86_64-linux" then "linux-x64"
+      else if stdenv.system == "x86_64-darwin" then "darwin"
+      else throw "Unsupported system: ${stdenv.system}";
+
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
-    version = "0.10.10";
+    inherit version;
 
     src = fetchurl {
-      url = "https://github.com/Microsoft/vscode/archive/${version}.tar.gz";
-      sha256 = "1mzkip6621111xwwksqjad1kgpbhna4dhpkf6cnj2r18dkk2jmcw";
+      url = "https://az764295.vo.msecnd.net/stable/${rev}/VSCode-${urlMod}-stable.zip";
+      inherit sha256;
     };
 
-    buildInputs = [ makeWrapper jq xlibs.libX11 xlibs.xproto gtk python nodejs electron ];
-
-    extensionGalleryJSON = ''
-      {
-        \"extensionsGallery\": {
-          \"serviceUrl\": \"https://marketplace.visualstudio.com/_apis/public/gallery\",
-          \"cacheUrl\": \"https://vscode.blob.core.windows.net/gallery/index\",
-          \"itemUrl\": \"https://marketplace.visualstudio.com/items\"
-        }
-      }
-    '';
-
-    configurePhase = ''
-      # PATCH SCRIPT SHEBANGS
-      echo "PATCH SCRIPT SHEBANGS"
-      patchShebangs ./scripts
-
-      # ADD EXTENSION GALLERY URLS TO APPLICATION CONFIGURATION
-      echo "AUGMENT APPLICATION CONFIGURATION"
-      echo "$(cat ./product.json) ${extensionGalleryJSON}" | jq -s add  > tmpFile && \
-        mv tmpFile ./product.json
-    '';
-
-    buildPhase  = ''
-      # BUILD COMPILE- & RUN-TIME DEPENDENCIES
-      echo "BUILD COMPILE- & RUN-TIME DEPENDENCIES"
-      mkdir -p ./tmp
-      HOME=./tmp ./scripts/npm.sh install
-
-      # COMPILE SOURCES
-      echo "COMPILE SOURCES"
-      ./node_modules/.bin/gulp
-    '';
-
-    doCheck = true;
-    checkPhase = ''
-      # CHECK APPLICATION
-      echo "CHECK APPLICATION"
-      ATOM_SHELL_INTERNAL_RUN_AS_NODE=1 ${electron}/bin/electron ./node_modules/.bin/_mocha
-    '';
+    buildInputs = [ unzip ];
 
     installPhase = ''
-      # PRUNE COMPILE-TIME DEPENDENCIES
-      echo "PRUNE COMPILE-TIME DEPENDENCIES"
-      npm prune --production
+      mkdir -p $out/bin
+      cp -r ./* $out/bin
 
-      # COPY FILES NEEDED FOR RUNNING APPLICATION TO OUT DIRECTORY
-      echo "COPY FILES NEEDED FOR RUNNING APPLICATION TO OUT DIRECTORY"
-      mkdir -p "$out"
-      cp -R ./.vscode "$out"/.vscode
-      cp -R ./extensions "$out"/extensions
-      cp -R ./out "$out"/out
-      cp -R ./node_modules "$out"/node_modules
-      cp ./package.json "$out"/package.json
-      cp ./product.json "$out"/product.json
-      cp ./tslint.json "$out"/tslint.json
-      # COPY LEGAL STUFF
-      cp ./LICENSE.txt "$out"/LICENSE.txt
-      cp ./OSSREADME.json "$out"/OSSREADME.json
-      cp ./ThirdPartyNotices.txt "$out"/ThirdPartyNotices.txt
+      ${if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux") then ''
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        $out/bin/code
+      '' else ""}
+    '';
 
-      # CREATE RUNNER SCRIPT
-      echo "CREATE RUNNER SCRIPT"
-      mkdir -p "$out"/bin
-      makeWrapper "${electron}/bin/electron" "$out/bin/vscode" \
-      --set VSCODE_DEV 1 \
-      --add-flags "$out"
+    postFixup = ''
+      ${if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux") then ''
+        patchelf \
+        --set-rpath "${atomEnv}/lib:${atomEnv}/lib64:$out/bin:$(patchelf --print-rpath $out/bin/code)" \
+        $out/bin/code
+      '' else ""}
     '';
 
     meta = with stdenv.lib; {
@@ -95,7 +55,8 @@ in
         It is also customizable, so users can change the editor's theme, keyboard shortcuts, and preferences.
       '';
       homepage = http://code.visualstudio.com/;
-      license = licenses.mit;
-      platforms = [ "x86_64-linux" ];
+      downloadPage = https://code.visualstudio.com/Updates;
+      license = licenses.unfree;
+      platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
     };
   }

--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,27 +1,16 @@
-{ stdenv, fetchurl, buildEnv, zlib, glib, alsaLib
-, dbus, gtk, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
-, cairo, cups, expat, libgpgerror, nspr, gconf, nss, xorg, libcap, unzip
-, systemd, libnotify
-, version ? "0.36.2", sha256 ? "01d78j8dfrdygm1r141681b3bfz1f1xqg9vddz7j52z1mlfv9f1d", ...
-}:
+{ stdenv, callPackage, fetchurl, unzip
+, ...
+} @ args:
+
 let
-  atomEnv = buildEnv {
-    name = "env-atom";
-    paths = [
-      stdenv.cc.cc zlib glib dbus gtk atk pango freetype libgnome_keyring3
-      fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
-      xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
-      xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
-      xorg.libXcursor libcap systemd libnotify
-    ];
-  };
+  atomEnv = callPackage ./env-atom.nix (args);
 in stdenv.mkDerivation rec {
   name = "electron-${version}";
-  inherit version;
+  version = "0.36.2";
 
   src = fetchurl {
     url = "https://github.com/atom/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-    inherit sha256;
+    sha256 = "01d78j8dfrdygm1r141681b3bfz1f1xqg9vddz7j52z1mlfv9f1d";
     name = "${name}.zip";
   };
 

--- a/pkgs/development/tools/electron/env-atom.nix
+++ b/pkgs/development/tools/electron/env-atom.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildEnv, zlib, glib, alsaLib
+, dbus, gtk, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
+, cairo, cups, expat, libgpgerror, nspr, gconf, nss, xorg, libcap
+, systemd, libnotify
+, ...
+}:
+
+buildEnv {
+  name = "env-atom";
+  paths = [
+    stdenv.cc.cc zlib glib dbus gtk atk pango freetype libgnome_keyring3
+    fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
+    xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
+    xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
+    xorg.libXcursor libcap systemd libnotify
+  ];
+}


### PR DESCRIPTION
###### Motivation:

As described in [#14354](https://github.com/NixOS/nixpkgs/issues/14354#issuecomment-205269346), the current `vscode` derivation fails to build on hydra, due to the expression depending on `npm install`.
There are a lot `nodePackage` dependencies that are missing in the `nixpkgs` collection (some of them must be natively build). I guess that would take quite some effort to get `vscode` to successfully build from source.
Hence, this PR switches the drv to use the unfree, pre-built binary and patchElf it accordingly. That could be changed in future of course.
###### Questions:

I don't have a Mac to test this, how does the binary find the shared libraries on a darwin architecture? AFAIU, patchELF only works on linux platforms. Should I remove `darwin` as a build target for this derivation?
###### Things done:
- [x] Tested using buildtime sandboxing (`nix-build . --option build-use-chroot true -A vscode`)
- [x] Tested using runtime sandboxing (`nix-shell -I nixpkgs=. --pure -p vscode`)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` from root of nixpkgs fork
  - [x] dependent pkg `vscode` compiles & runs
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14354 
