### PR TITLE
rsyslog: 8.14.0 -> 8.17.0 (incl. dependencies)

### DIFF
--- a/pkgs/development/libraries/fastjson/default.nix
+++ b/pkgs/development/libraries/fastjson/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, libtool, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  version = "v0.99.2";
+  name = "fastjson-${version}";
+  src = fetchFromGitHub {
+    repo = "libfastjson";
+    owner = "rsyslog";
+    rev = "eabae907c9d991143e17da278a239819f2e8ae1c";
+    sha256 = "17fhaqdn0spc4p0848ahcy68swm6l5yd3bx6bdzxmmwj1jdrmvzk";
+  };
+
+  buildInputs = [ autoconf automake libtool ];
+
+  preConfigure = ''
+    sh autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fast json library for C";
+    homepage = "https://github.com/rsyslog/libfastjson";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nequissimus ];
+  };
+}

--- a/pkgs/development/libraries/libksi/default.nix
+++ b/pkgs/development/libraries/libksi/default.nix
@@ -4,12 +4,12 @@ stdenv.mkDerivation rec {
   name = "libksi-2015-07-03";
 
   src = fetchFromGitHub {
-    owner = "rgerhards";
+    owner = "Guardtime";
     repo = "libksi";
-    rev = "b1ac0346395b4f52ec42a050bf33ac223f194443";
-    sha256 = "0gg0fl56flwqmsph7j92lgybaa39i715w0nwgkcr58njm0c02wlw";
+    rev = "b82dd65bd693722db92397cbe0920170e0d2ae1c";
+    sha256 = "1sqd31l55kx6knl0sg26ail1k5rgmamq8760p6aj7bpb4jwb8r1n";
   };
-  
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openssl curl ];
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/rgerhards/libksi";
+    homepage = "https://github.com/GuardTime/libksi";
     description = "Keyless Signature Infrastructure API library";
     license = licenses.asl20;
     platforms = platforms.all;

--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, libestr, json_c, zlib, pythonPackages
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, libestr, json_c, zlib, pythonPackages, fastJson
 , libkrb5 ? null, systemd ? null, jemalloc ? null, libmysql ? null, postgresql ? null
 , libdbi ? null, net_snmp ? null, libuuid ? null, curl ? null, gnutls ? null
 , libgcrypt ? null, liblognorm ? null, openssl ? null, librelp ? null, libksi ? null
@@ -11,18 +11,18 @@ let
   mkFlag = cond: name: if cond then "--enable-${name}" else "--disable-${name}";
 in
 stdenv.mkDerivation rec {
-  name = "rsyslog-8.14.0";
+  name = "rsyslog-8.17.0";
 
   src = fetchurl {
     url = "http://www.rsyslog.com/files/download/rsyslog/${name}.tar.gz";
-    sha256 = "1hp7ga543m6vhijcnjb4z8v26ddjgypk1lh6km1cvxc45cfmnfs4";
+    sha256 = "1fazpbllr3wk8aw41zk7b6iirds4h8j3im080nf8my2cjssij7pc";
   };
 
   #patches = [ ./fix-gnutls-detection.patch ];
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
-    libestr json_c zlib pythonPackages.docutils libkrb5 jemalloc libmysql
+    fastJson libestr json_c zlib pythonPackages.docutils libkrb5 jemalloc libmysql
     postgresql libdbi net_snmp libuuid curl gnutls libgcrypt liblognorm openssl
     librelp libgt libksi liblogging libnet hadoop rdkafka libmongo-client czmq
     rabbitmq-c hiredis

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -755,6 +755,8 @@ in
 
   fasd = callPackage ../tools/misc/fasd { };
 
+  fastJson = callPackage ../development/libraries/fastjson { };
+
   fop = callPackage ../tools/typesetting/fop { };
 
   fzf = goPackages.fzf.bin // { outputs = [ "bin" ]; };
@@ -1590,11 +1592,11 @@ in
     gazebo6-headless = callPackage ../applications/science/robotics/gazebo/6.nix { withHeadless = true;  };
 
     gazebo7 = callPackage ../applications/science/robotics/gazebo { };
-  
+
     gazebo7-headless = callPackage ../applications/science/robotics/gazebo { withHeadless = true; };
 
   };
-  
+
   # at present, Gazebo 7.0.0 does not match Gazebo 6.5.1 for compatibility
   gazebo = gazeboSimulator.gazebo6;
 
@@ -1936,12 +1938,12 @@ in
 
   ifuse = callPackage ../tools/filesystems/ifuse/default.nix { };
 
-  ignition = recurseIntoAttrs { 
+  ignition = recurseIntoAttrs {
 
     math = callPackage ../development/libraries/ignition-math { };
-  
+
     math2 = ignition.math;
-  
+
     transport0 = callPackage ../development/libraries/ignition-transport/0.9.0.nix { };
 
     transport1 = callPackage ../development/libraries/ignition-transport/1.0.1.nix { };


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @wkennington 

In order to update `rsyslog` to 8.17.0, I needed to update `libksi`. The updates `libksi` is now in the `GuardTime` repository, so I had to switch over to that.
Additionally, `rsyslog` now required `libfastjson` from the `rsyslog` project.
