### PR TITLE
gradle: Fix gradle on Linux to find libstdc++.so.6 reference.

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -14,6 +14,7 @@ rec {
       test -f $gradle_launcher_jar
       makeWrapper ${jdk}/bin/java $out/bin/gradle \
         --set JAVA_HOME ${jdk} \
+        --set LD_LIBRARY_PATH ${stdenv.cc.cc}/lib \
         --add-flags "-classpath $gradle_launcher_jar org.gradle.launcher.GradleMain"
     '';
 


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #11915

(Unlike the previous fix, this allows gradle to be used from the command line.)

cc @NeQuissimus 

---

_Please note, that points are not mandatory, but rather desired._
