### PR TITLE
japa: init at 0.8.4

### DIFF
--- a/pkgs/applications/audio/japa/default.nix
+++ b/pkgs/applications/audio/japa/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl,   alsaLib, libjack2, fftwFloat, libclthreads, libclxclient, libX11,  libXft, zita-alsa-pcmi, }:
+
+stdenv.mkDerivation rec {
+  version = "0.8.4";
+  name = "japa-${version}";
+
+  src = fetchurl {
+    url = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${name}.tar.bz2";
+    sha256 = "1jhj7s4vqk5c4lchdall0kslvj5sh91902hhfjvs6r3a5nrhwcp0";
+  };
+
+  buildInputs = [ alsaLib libjack2 fftwFloat libclthreads libclxclient libX11 libXft zita-alsa-pcmi ];
+
+  preConfigure = ''
+    cd ./source/
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "SUFFIX=''"
+  ];
+
+  meta = {
+    description = "A 'perceptual' or 'psychoacoustic' audio spectrum analyser for JACK and ALSA";
+    homepage = http://kokkinizita.linuxaudio.org/linuxaudio/index.html;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12772,6 +12772,8 @@ in
 
   jamin = callPackage ../applications/audio/jamin { };
 
+  japa = callPackage ../applications/audio/japa { };
+
   jedit = callPackage ../applications/editors/jedit { };
 
   jigdo = callPackage ../applications/misc/jigdo { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
