### PR TITLE
mutt: 1.5.24 -> 1.6.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -17,14 +17,14 @@ assert saslSupport -> cyrus_sasl != null;
 assert gpgmeSupport -> gpgme != null;
 
 let
-  version = "1.5.24";
+  version = "1.6.0";
 in
 stdenv.mkDerivation rec {
   name = "mutt${stdenv.lib.optionalString withSidebar "-with-sidebar"}-${version}";
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/mutt-${version}.tar.gz";
-    sha256 = "0012njrgxf1barjksqkx7ccid2l0xyikhna9mjs9vcfpbrvcm4m2";
+    sha256 = "06bc2drbgalkk68rzg7hq2v5m5qgjxff5357wg0419dpi8ivdbr9";
   };
 
   buildInputs = with stdenv.lib;

--- a/pkgs/applications/networking/mailreaders/mutt/sidebar.patch
+++ b/pkgs/applications/networking/mailreaders/mutt/sidebar.patch
@@ -78,7 +78,7 @@ index 5dfeff6..cf1ac98 100644
  	score.c send.c sendlib.c signal.c sort.c \
  	status.c system.c thread.c charset.c history.c lib.c \
 +	sidebar.c \
- 	muttlib.c editmsg.c mbyte.c \
+ 	muttlib.c editmsg.c mbyte.c mutt_idna.c \
  	url.c ascii.c crypt-mod.c crypt-mod.h safe_asprintf.c
  
 diff --git a/OPS b/OPS


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Release notes: http://www.mutt.org/changes.html
