### PR TITLE
playerctl: 0.4.2 -> 0.5.0

### DIFF
--- a/pkgs/tools/audio/playerctl/default.nix
+++ b/pkgs/tools/audio/playerctl/default.nix
@@ -2,14 +2,14 @@
   pkgconfig, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  name = "playerctl";
-  version = "0.4.2";
+  name = "playerctl-${version}";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "acrisci";
     repo = "playerctl";
     rev = "v${version}";
-    sha256 = "0dy6wc7qr00p53hlhpbg9x40w4ag95r2i7r1nsyb4ym3wzrvskzh";
+    sha256 = "0b4pg5pwblgbf6kvvynzh9dshfikxy5c2ks7733n7wza5wkpgmng";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I added the version to the derivation name, but I'm new at this so correct me if it was left off for a reason.
