### PR TITLE
rxvt: 2.6.4 -> 2.7.10

### DIFF
--- a/pkgs/applications/misc/rxvt/default.nix
+++ b/pkgs/applications/misc/rxvt/default.nix
@@ -1,18 +1,36 @@
-{ stdenv, fetchurl, libX11, libXt }:
+{ stdenv, fetchurl
+, pkgconfig, libtool
+, libX11, libXt, libXpm }:
 
-stdenv.mkDerivation {
-  name = "rxvt-2.6.4";
+stdenv.mkDerivation rec {
+  name = "rxvt-${version}";
+  version = "2.7.10";
 
   src = fetchurl {
-    url = mirror://sourceforge/rxvt/rxvt-2.6.4.tar.gz;
-    sha256 = "0hi29whjv8v11nkjbq1i6ms411v6csykghmlpkmayfjn9nxr02xg";
+    url = "mirror://sourceforge/rxvt/${name}.tar.gz";
+    sha256 = "0jfl71gz3k7zh3kxdb8lxi06kajjnx7bq1rxjgk680l209jxask1";
   };
 
-  buildInputs = [ libX11 libXt ];
+  buildInputs = [ pkgconfig libtool libX11 libXt libXpm ];
 
-  meta = { 
+  configureFlags = [ "--enable-everything" "--enable-smart-resize" "--enable-256-color" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://rxvt.sourceforge.net/;
     description = "Colour vt102 terminal emulator with less features and lower memory consumption";
-    homepage = http://www.rxvt.org/;
-    license = "GPL";
+    longDescription = ''
+      rxvt (acronym for our extended virtual terminal) is a terminal
+      emulator for the X Window System, originally written by Rob Nation
+      as an extended version of the older xvt terminal by John Bovey of
+      University of Kent. Mark Olesen extensively modified it later and
+      took over maintenance for several years.
+    
+      rxvt is intended to be a slimmed-down alternate for xterm,
+      omitting some of its little-used features, like Tektronix 4014
+      emulation and toolkit-style configurability.
+    '';
+    maintainers = with maintainers; [ AndersonTorres ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_Please note, that points are not mandatory, but rather desired._

A strange bug appears here: the local libtool barfs with the message:
`libtool: not configured to build any kind of library`
and fails to compile rxvt - but builds and installs rclock.

In fact it is even reported on monitor build log:

http://monitor.nixos.org/buildlog?outpath=%2Fnix%2Fstore%2Fv62bp6fdvfny4np2irwm70szc4kxasqk-rxvt-2.7.10
