### PR TITLE
why3: 0.86.3 -> 0.87.0

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "why3-${version}";
-  version = "0.86.3";
+  version = "0.87.0";
 
   src = fetchurl {
-    url    = https://gforge.inria.fr/frs/download.php/file/35537/why3-0.86.3.tar.gz;
-    sha256 = "0sph6i4ga9450bk60wpm5cq3psw3g8xprnac7yjfq64iqz1dyz03";
+    url    = https://gforge.inria.fr/frs/download.php/file/35643/why3-0.87.0.tar.gz;
+    sha256 = "0c3vhcb70ay7iwvmq0m25fqh38y40c5x7mki4r9pxf13vgbs3xb0";
   };
 
   buildInputs = (with ocamlPackages; [


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Release notes: http://lists.gforge.inria.fr/pipermail/why3-club/2016-March/001323.html
