### PR TITLE
liquibase: init at 3.4.2

### DIFF
--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "liquibase";
+  version = "3.4.2";
+
+  src = fetchurl {
+    url = "https://github.com/liquibase/liquibase/releases/download/${pname}-parent-${version}/${name}-bin.tar.gz";
+    sha256 = "1kvxqjz8jmqpmb1clhp2asxmgfk6ynqjir8fldc321v9a5wnqby5";
+  };
+
+  buildInputs = [ jre makeWrapper ];
+
+  unpackPhase = ''
+    tar xfz ${src}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib,sdk}
+    mv ./* $out/
+    wrapProgram $out/liquibase --prefix PATH ":" ${jre}/bin --set LIQUIBASE_HOME $out;
+    ln -s $out/liquibase $out/bin/liquibase
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Version Control for your database";
+    homepage = "http://www.liquibase.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nequissimus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4464,6 +4464,8 @@ in
 
   lessc = callPackage ../development/compilers/lessc { };
 
+  liquibase = callPackage ../development/tools/database/liquibase { };
+
   llvm = llvmPackages.llvm;
 
   llvm_38 = llvmPackages_38.llvm;


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
