### PR TITLE
bcc: init at git-2016-05-18

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, makeWrapper, cmake, llvmPackages, kernel,
+  flex, bison, elfutils, python, pythonPackages, luajit, netperf, iperf }:
+
+stdenv.mkDerivation rec {
+  version = "git-2016-05-18";
+  name = "bcc-${version}";
+
+  src = fetchFromGitHub {
+    owner = "iovisor";
+    repo = "bcc";
+    rev = "c7f317deb577d59007411e978ac21a2ea376358f";
+    sha256 = "0jv4smy615kp7623pd61s46m52jjp6m47w0fjgr7s22qamra3g98";
+  };
+
+  buildInputs = [ makeWrapper cmake llvmPackages.llvm llvmPackages.clang-unwrapped kernel
+    flex bison elfutils python pythonPackages.netaddr luajit netperf iperf
+  ];
+
+  cmakeFlags="-DBCC_KERNEL_MODULES_DIR=${kernel.dev}/lib/modules -DBCC_KERNEL_HAS_SOURCE_DIR=1";
+    
+  postInstall = ''
+    mkdir -p $out/bin
+    for f in $out/share/bcc/tools\/*; do
+      ln -s $f $out/bin/$(basename $f) 
+      wrapProgram $f \
+        --prefix LD_LIBRARY_PATH : $out/lib \
+        --prefix PYTHONPATH : $out/lib/python2.7/site-packages \
+        --prefix PYTHONPATH : :${pythonPackages.netaddr}/lib/${python.libPrefix}/site-packages
+    done
+  '';  
+
+  meta = with stdenv.lib; {
+    description = "Dynamic Tracing Tools for Linux";
+    homepage = "https://iovisor.github.io/bcc/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ragge ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10467,6 +10467,8 @@ in
 
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
+    bcc = callPackage ../os-specific/linux/bcc { };
+    
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };


### PR DESCRIPTION
**This is a work in progress**

Opening PR to get some feedback/help.

**Status**: 
- compiles
- have contributed patches upstream, ~~waiting on https://github.com/iovisor/bcc/pull/477~~
- need to test all tools

**Todo**:

Test all tools (on kernel 4.4.6):
- [x] argdist
- [ ] bashreadline
  - does not work, assumes bash is in `/bin/bash`
- [x] biolatency
- [x] biosnoop
- [x] biotop
- [x] bitesize
- [ ] btrfsdist
- [ ] btrfsslower
- [x] cachestat
- [x] dcsnoop
- [x] dcstat
- [x] execsnoop
- [ ] ext4dist
- [ ] ext4slower
- [x] filelife
- [x] fileslower
- [x] filetop
- [x] funccount
- [x] funclatency
- [ ] gethostlatency
- [x] hardirqs
- [x] killsnoop
- [ ] mdflush
  - segfaults
- [ ] memleak
  - requires stackmaps, kernel 4.6+
- [ ] offcputime
  - requires stackmaps, kernel 4.6+
- [x] offwaketime
- [x] oomkill
- [x] opensnoop
- [x] pidpersec
- [x] runqlat
- [x] softirqs
- [x] solisten
- [ ] stackcount
  - requires stackmaps, kernel 4.6+
- [ ] stacksnoop
  - requires stackmaps, kernel 4.6+
- [x] statsnoop
- [x] syncsnoop
- [x] tcpaccept
- [x] tcpconnect
- [x] tcpconnlat
- [x] tcpretrans
- [x] tplist
- [ ] trace
  - library detection fails
- [x] vfscount
- [x] vfsstat
- [x] wakeuptime
- [ ] xfsdist
- [ ] xfsslower
- [ ] zfsdist
- [ ] zfsslower

**Questions**:
- ~~builds off unreleased git commit. What should the nixpkg `version` be?~~

---
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
