### PR TITLE
systemd service: enable systemd-remount-fs in containers

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -783,7 +783,6 @@ in
     systemd.services.systemd-binfmt.wants = [ "proc-sys-fs-binfmt_misc.automount" ];
 
     # Don't bother with certain units in containers.
-    systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";
     systemd.services.systemd-random-seed.unitConfig.ConditionVirtualization = "!container";
 
   };


### PR DESCRIPTION
Disabling this service in containers precludes setting custom options for e.g., /proc.  For context, see discussion at https://github.com/NixOS/nixpkgs/pull/14372.

All the service does is remount / and API file systems using options found in /etc/fstab (if any are set), so there shouldn't be any downsides to running this within a container.
