### PR TITLE
syncthing: 0.12.19 -> 0.12.21 + nixos module user support

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -7,6 +7,21 @@ let
   cfg = config.services.syncthing;
   defaultUser = "syncthing";
 
+  header = {
+    description = "Syncthing service";
+    environment = {
+      STNORESTART = "yes";
+      STNOUPGRADE = "yes";
+      inherit (cfg) all_proxy;
+    } // config.networking.proxy.envVars;
+  };
+
+  service = {
+    Restart = "on-failure";
+    SuccessExitStatus = "2 3 4";
+    RestartForceExitStatus="3 4";
+  };
+
 in
 
 {
@@ -27,12 +42,30 @@ in
         '';
       };
 
+      systemService = mkOption {
+        default = true;
+        description = "Auto launch syncthing as a system service.";
+      };
+
+      useInotify = mkOption {
+        default = false;
+        description = "Watch files using inotify.";
+      };
+
       user = mkOption {
         type = types.string;
         default = defaultUser;
         description = ''
-          Syncthing will be run under this user (user must exist,
-          this can be your user name).
+          Syncthing will be run under this user (user will be created if it doesn't exist.
+          This can be your user name).
+        '';
+      };
+
+      group = mkOption {
+        default = defaultUser;
+        description = ''
+          Syncthing will be run under this group (group will be created if it doesn't exist.
+          This can be your user name).
         '';
       };
 
@@ -58,16 +91,12 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.syncthing;
-        defaultText = "pkgs.syncthing";
         example = literalExample "pkgs.syncthing";
         description = ''
           Syncthing package to use.
         '';
       };
-
-
     };
-
   };
 
 
@@ -88,30 +117,53 @@ in
         config.ids.gids.syncthing;
     };
 
-    systemd.services.syncthing =
-      {
-        description = "Syncthing service";
-        after    = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        environment = {
-          STNORESTART = "yes";  # do not self-restart
-          STNOUPGRADE = "yes";
-          inherit (cfg) all_proxy;
-        } // config.networking.proxy.envVars;
+    environment.systemPackages = [ cfg.package ] ++ lib.optional cfg.useInotify pkgs.syncthing-inotify;
 
-        serviceConfig = {
-          User  = cfg.user;
+    systemd.services = mkIf cfg.systemService {
+      syncthing = header // {
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = service // {
+          User = cfg.user;
           Group = optionalString (cfg.user == defaultUser) defaultUser;
           PermissionsStartOnly = true;
-          Restart = "on-failure";
           ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser -home=${cfg.dataDir}";
-          SuccessExitStatus = "2 3 4";
-          RestartForceExitStatus="3 4";
         };
       };
 
-    environment.systemPackages = [ cfg.package ];
+      syncthing-inotify = mkIf.useInotify header // {
+        description = "Monitor Syncthing using inotify";
+        after = [ "syncthing.service" ];
+        requires = [ "syncthing.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User = cfg.user;
+          Group = optionalString (cfg.user == defaultUser) defaultUser;
+          PermissionsStartOnly = true;
+          ExecStart = "${pkgs.syncthing-inotify}/bin/syncthing -logflags=0";
+          Restart = "on-failure";
+        };
+      };
+    };
 
+    systemd.user.services =  {
+      syncthing = header // {
+        serviceConfig = service // {
+          ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser";
+        };
+      };
+
+      syncthing-inotify = {
+        description = "Monitor Syncthing using inotify";
+        after = [ "syncthing.service" ];
+        requires = [ "syncthing.service" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.syncthing-inotify}/bin/syncthing-inotify -logflags=0";
+          Restart = "on-failure";
+          ProtectSystem = "full";
+          ProtectHome = "read-only";
+        };
+      };
+    };
   };
-
 }

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -131,7 +131,7 @@ in
         };
       };
 
-      syncthing-inotify = mkIf.useInotify header // {
+      syncthing-inotify = mkIf cfg.useInotify header // {
         description = "Monitor Syncthing using inotify";
         after = [ "syncthing.service" ];
         requires = [ "syncthing.service" ];
@@ -140,7 +140,7 @@ in
           User = cfg.user;
           Group = optionalString (cfg.user == defaultUser) defaultUser;
           PermissionsStartOnly = true;
-          ExecStart = "${pkgs.syncthing-inotify}/bin/syncthing -logflags=0";
+          ExecStart = "${pkgs.syncthing-inotify}/bin/syncthing-inotify -logflags=0";
           Restart = "on-failure";
         };
       };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13848,6 +13848,8 @@ in
 
   syncthing = go15Packages.syncthing.bin // { outputs = [ "bin" ]; };
   syncthing011 = go15Packages.syncthing011.bin // { outputs = [ "bin" ]; };
+  syncthing012 = go15Packages.syncthing012.bin // { outputs = [ "bin" ]; };
+  syncthing-inotify = go15Packages.syncthing-inotify.bin // { outputs = [ "bin" ]; };
 
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -338,6 +338,13 @@ let
     ];
   };
 
+  backoff = buildFromGitHub {
+    rev    = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc";
+    owner  = "cenkalti";
+    repo   = "backoff";
+    sha256 = "08b475bzg4q14bx0v83vxyb86ndy1s4mz5f05hd0j7av0awwam43";
+  };
+
   bleve = buildFromGitHub {
     rev    = "fc34a97875840b2ae24517e7d746b69bdae9be90";
     version = "2016-01-19";
@@ -2504,6 +2511,14 @@ let
     buildFlags = [ "-tags release" ];
   };
 
+  notify = buildFromGitHub {
+    rev    = "921f2bc094bff902bf6089603902a84ac988d351";
+    owner  = "zillode";
+    repo   = "notify";
+    sha256 = "057lpzqc99hrafpdhfxm4cx4zak64fqfi6i8ix8mih46y0lbrisk";
+  };
+
+
   nitro = buildFromGitHub {
     rev    = "24d7ef30a12da0bdc5e2eb370a79c659ddccf0e8";
     owner  = "spf13";
@@ -3499,11 +3514,11 @@ let
   };
 
   syncthing = buildFromGitHub rec {
-    version = "0.12.19";
+    version = "0.12.21";
     rev = "v${version}";
     owner = "syncthing";
     repo = "syncthing";
-    sha256 = "11ij8whaqrrzriavxa08jpsmbd1zkc2qxsni1nbgszw2hymmv38g";
+    sha256 = "18bq8677nnnwkns0diy3hmzdlhyq6c3faqddiwz4ysbl3vjyr847";
     buildFlags = [ "-tags noupgrade,release" ];
     disabled = isGo14;
     buildInputs = [
@@ -3530,6 +3545,18 @@ let
       # Mostly a cosmetic change
       sed -i 's,unknown-dev,${version},g' cmd/syncthing/main.go
     '';
+  };
+
+  syncthing012 = syncthing;
+
+  syncthing-inotify = buildFromGitHub rec {
+    version = "0.6.8";
+    rev = "v${version}";
+    owner = "syncthing";
+    repo = "syncthing-inotify";
+    sha256 = "0ppnrxxybqa97rvain3g41cpk8bda55y0lyd5bhmbca7q002z29q";
+    # disabled = isGo14;
+    buildInputs = [ backoff notify ];
   };
 
   syncthing-lib = buildFromGitHub {


### PR DESCRIPTION
# Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
# More

This patch only applies against master due to changes merged recently.

We are basically doing a few things in this, which I can of course break up in case people feel that makes sense:
1. Upgrade to 0.12.21
2. Add syncthing-inotify (init at 0.6.8)
3. Changes to the NixOS module to allow specifying:
   1. If syncthing should run as a system service, and
   2. If we should be using inotify
4. A stub package for syncthing 0.12 as the upcoming 0.13 will again change the protocol.
5. User services for both syncthing and syncthing-inotify so they will run for normal users on a multi-user machine.

Defaults have been set, so that behaviour is the same as before, so there should be no surprises.

Cherrypicking along with `7c8c578` makes it run against `nixos-unstable`.
