### PR TITLE
haskellPackages.dnssd: override the dns_sd dependency to point to ava…

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -960,4 +960,10 @@ self: super: {
     hint = self.hint_0_4_3;
   };
 
+  # Looks like Avahi provides the missing library
+  dnssd = super.dnssd.override {
+    dns_sd = pkgs.avahi.override {
+      withLibdnssdCompat = true;
+    };
+  };
 }


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

@chris-martin: here you go
cc @peti
