### PR TITLE
taskserver: integrate pki scripts

### DIFF
--- a/pkgs/servers/misc/taskserver/default.nix
+++ b/pkgs/servers/misc/taskserver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, libuuid, gnutls }:
+{ stdenv, fetchurl, cmake, libuuid, gnutls, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "taskserver-${version}";
@@ -11,6 +11,26 @@ stdenv.mkDerivation rec {
     sha256 = "1d110q9vw8g5syzihxymik7hd27z1592wkpz55kya6lphzk8i13v";
   };
 
+  patchPhase = ''
+    pkipath=$out/share/taskd/pki
+    mkdir -p $pkipath
+    cp -r pki/* $pkipath
+    echo "patching paths in pki/generate"
+    sed -i "s#^\.#$pkipath#" $pkipath/generate
+    for f in $pkipath/generate* ;do
+      i=$(basename $f)
+      echo patching $i
+      sed -i \
+          -e 's/which/type -p/g' \
+          -e 's#^\. ./vars#if test -e ./vars;then . ./vars; else echo "cannot find ./vars - copy the template from '$pkipath'/vars into the working directory";exit 1; fi#' $f
+
+      echo wrapping $i
+      makeWrapper  $pkipath/$i $out/bin/taskd-pki-$i \
+        --prefix PATH : ${gnutls}/bin/
+    done
+  '';
+
+  buildInputs = [ makeWrapper ];
   nativeBuildInputs = [ cmake libuuid gnutls ];
 
   meta = {
@@ -18,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = http://taskwarrior.org;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer makefu ];
   };
 }


### PR DESCRIPTION
This PR integrates the `pki` convenience scripts into the taskserver package.

In the patchPhase all scripts related to generating a CA for taskwarrior are written into share/taskd and patched to actually work within nixos environment.
###### Things done:
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I saw there is an open PR #14476 for integrating the whole taskserver into nixpks - still i think providing the original scripts as described in the official documentation.

cc @matthiasbeyer 
