### PR TITLE
linux: kernel config for extended BPF support

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -118,6 +118,10 @@ with stdenv.lib;
   ${optionalString (stdenv.system == "x86_64-linux") ''
     BPF_JIT y
   ''}
+  ${optionalString (versionAtLeast version "4.4") ''
+    NET_CLS_BPF m
+    NET_ACT_BPF m
+  ''}
 
   # Wireless networking.
   CFG80211_WEXT? y # Without it, ipw2200 drivers don't build
@@ -397,6 +401,10 @@ with stdenv.lib;
   STACK_TRACER y
   ${optionalString (versionAtLeast version "3.10") ''
     UPROBE_EVENT y
+  ''}
+  ${optionalString (versionAtLeast version "4.4") ''
+    BPF_SYSCALL y
+    BPF_EVENTS y
   ''}
   FUNCTION_PROFILER y
   RING_BUFFER_BENCHMARK n


### PR DESCRIPTION
- Enable BPF_SYSCALL and BPF_EVENTS
- Build modules for NET_CLS_BPF and NET_ACT_BPF

With these config options we can leverage the full potential of BPF for tracing and instrumenting Linux systems, for example using libraries/tools like those provided by the [bcc](https://iovisor.github.io/bcc/) project.

Notes:
- These options should actually be OK from 4.2, but since default is now 4.4 I chose to start there
- This PR will make usage of bcc as implemented in https://github.com/NixOS/nixpkgs/pull/14479 simpler as users won't need to compile a custom kernel

cc @shlevy @edolstra @nathan7 
