### PR TITLE
putty: 0.66 -> 0.67

### DIFF
--- a/pkgs/applications/networking/remote/putty/default.nix
+++ b/pkgs/applications/networking/remote/putty/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ncurses, gtk, pkgconfig, autoconf, automake, perl, halibut, libtool }:
 
 stdenv.mkDerivation rec {
-  version = "0.66";
+  version = "0.67";
   name = "putty-${version}";
 
   src = fetchurl {
     url = "http://the.earth.li/~sgtatham/putty/latest/${name}.tar.gz";
-    sha256 = "14r9yfqjs61l82q09m8zifgcxrzvs6dvgx32ndl5i1jldkv14wzy";
+    sha256 = "0isak6dy5vmfzf9ckcq6jvhgrn3xfmfcmziaa7g2jqm4x1c286c0";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING

Note that the URL for 0.66 now returns 404, so version 0.66 won't build at all.
