### PR TITLE
pythonPackages.cefpython3: init at 31.2

### DIFF
--- a/pkgs/development/python-modules/cefpython3/no-post-install.patch
+++ b/pkgs/development/python-modules/cefpython3/no-post-install.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 2f7a36b..a6f7541 100644
+--- a/setup.py
++++ b/setup.py
+@@ -69,7 +69,6 @@ def post_install():
+ class install(_install):
+     def run(self):
+         _install.run(self)
+-        post_install()
+         
+ class BinaryDistribution(Distribution):
+     def is_pure(self):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2872,6 +2872,58 @@ in modules // {
     };
   };
 
+  cefpython3 = buildPythonPackage rec {
+    name = "cefpython3-${version}";
+    version = "31.2";
+
+    disabled = !isPy27;
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/cztomczak/cefpython/releases/download/v${version}/cefpython3-${version}-linux64-setup.zip";
+      sha256 = "0275va62wyml2624wfd7yv0pcrsmdsmynpk78zzny408bx9fask1";
+    };
+
+    patches = [ ../development/python-modules/cefpython3/no-post-install.patch ];
+
+    postInstall = with pkgs; ''
+      cd $out
+      patchelf --set-rpath \
+${alsaLib}/lib:\
+${atk}/lib:\
+${cairo}/lib:\
+${cups}/lib:\
+${dbus}/lib:\
+${expat}/lib:\
+${fontconfig}/lib:\
+${freetype}/lib:\
+${gdk_pixbuf}/lib:\
+${glib}/lib:\
+${gnome.GConf}/lib:\
+${gnome.gtk}/lib:\
+${gnome.pango}/lib:\
+${libgcrypt_1_5}/lib:\
+${nspr}/lib:\
+${nss}/lib:\
+${stdenv.cc.cc}/lib:\
+${udev182}/lib:\
+${xorg.libX11}/lib:\
+${xorg.libXcomposite}/lib:\
+${xorg.libXdamage}/lib:\
+${xorg.libXext}/lib:\
+${xorg.libXfixes}/lib:\
+${xorg.libXi}/lib:\
+${xorg.libXrender}/lib:\
+${xorg.libXtst}/lib \
+        lib/python2.7/site-packages/cefpython3/libcef.so
+      cd -
+    '';
+
+    meta = {
+      homepage = "https://github.com/cztomczak/cefpython";
+      description = "Python bindings for the Chromium Embedded Framework";
+      license = licenses.bsd3;
+    };
+  };
 
   celery = buildPythonPackage rec {
     name = "celery-${version}";


### PR DESCRIPTION
The package itself builds without a problem (after applying the included patch).

When it comes to `import cefpython3` there are some problems regarding loading some shared objects.

`import cefpython3` fails because it's unable to find `libX11.so.6`. I'm adding that file's location to `LD_LIBRARY_PATH` in the derivation and removing the line in `__init__.py` which sets `LD_LIBRARY_PATH` but the call to `ctypes.CDLL` is still unable to find `libX11.so.6`.

If I start the python REPL with `LD_LIBARAY_PATH=/nix/store/...libX11../lib python` then it succeeds in loading `libX11` (and goes on to fail on another X library, but I'm pretty sure that's solvable in the same way as the missing `libX11.so.6`)

This isn't ready to be merged as is.
