### PR TITLE
oh-my-zsh: 2016-03-31 -> 2016-04-06

### DIFF
--- a/pkgs/shells/oh-my-zsh/default.nix
+++ b/pkgs/shells/oh-my-zsh/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   name = "oh-my-zsh-git-${version}";
-  version = "2016-03-31";
+  version = "2016-04-06";
 
   src = fetchgit {
     url = "https://github.com/robbyrussell/oh-my-zsh";
-    rev = "286c3e5e28b651c3f629e6aaba589a1cf56da4d8";
-    sha256 = "1jgbpfk6plj1gkwrv7xl1nsxjnrhyh7k3rjkindxx5s9lbq52f7z";
+    rev = "d310fac7f65d31f7494532201e02ebf67c9d9555";
+    sha256 = "0kx552b0jf5j8qkk1kixdr1z49ly79cvzhdh27848rj3kwb0z8vq";
   };
 
   phases = "installPhase";


### PR DESCRIPTION
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
