### PR TITLE
twkhtmltopdf: 0.12.2.4 -> 0.12.3.2.

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -2,13 +2,13 @@
 , openssl, libX11, libXext, libXrender, overrideDerivation }:
 
 stdenv.mkDerivation rec {
-  version = "0.12.2.4";
+  version = "0.12.3.2";
   name = "wkhtmltopdf-${version}";
 
   src = fetchgit {
     url = "https://github.com/wkhtmltopdf/wkhtmltopdf.git";
     rev = "refs/tags/${version}";
-    sha256 = "0g96vgi3s633j4myjfzakkyiml1zspvdvbc0q1vhw8fp5n1xdknm";
+    sha256 = "1fvql7xcgdgwxm2fw9ksl7p53ckjl153p91k5rprfwz8k5k6gkmd";
     fetchSubmodules = false;
   };
 
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     enableParallelBuilding = true;
     src = fetchgit {
       url = "https://github.com/wkhtmltopdf/qt.git";
-      rev = "48e71c19c7fc67517fb3dca6d42eacb57341c9ba"; # From git submodule spec in wkhtml repo.
-      sha256 = "1ygr7g3k900zjf54ji6kkfppqnxaqwbh8npr53g2krdw3bmny6fx";
+      rev = "fe194f9dac0b515757392a18f7fc9527c91d45ab"; # From git submodule spec in wkhtml repo.
+      sha256 = "1rkkaf9i7si4kd1l00rgy41ljq3j1yvisvj5fllfjsgxhrasign0";
     };
     configureFlags =
       ''


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #<insert id>

cc @jb55

---

_Please note, that points are not mandatory, but rather desired._

Necessary to build against the QT in nix.
