### PR TITLE
apt-cacher-ng: disable on OSX

### DIFF
--- a/pkgs/servers/http/apt-cacher-ng/default.nix
+++ b/pkgs/servers/http/apt-cacher-ng/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     description = "A caching proxy specialized for linux distribution files";
     homepage = https://www.unix-ag.uni-kl.de/~bloch/acng/;
     license = licenses.gpl2;
+    platforms = platforms.linux;
     maintainers = [ maintainers.makefu ];
   };
 }


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

fmemopen() doesn't exist on OSX. This causes the builds to fail.
