### PR TITLE
wkhtmltopdf: 0.12.2.4 -> 0.12.3.2, fix broken build on 16.03

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -1,72 +1,114 @@
-{ stdenv, fetchgit, qt4, fontconfig, freetype, libpng, zlib, libjpeg
+{ stdenv, fetchFromGitHub, qt4, fontconfig, freetype, libpng, zlib, libjpeg
 , openssl, libX11, libXext, libXrender, overrideDerivation }:
 
 stdenv.mkDerivation rec {
-  version = "0.12.2.4";
+  version = "0.12.3.2";
   name = "wkhtmltopdf-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/wkhtmltopdf/wkhtmltopdf.git";
-    rev = "refs/tags/${version}";
-    sha256 = "0g96vgi3s633j4myjfzakkyiml1zspvdvbc0q1vhw8fp5n1xdknm";
-    fetchSubmodules = false;
+  src = fetchFromGitHub {
+    owner  = "wkhtmltopdf";
+    repo   = "wkhtmltopdf";
+    rev    = "${version}";
+    sha256 = "1yyqjhxv4dvpkad79scs7xdx4iz8jpyidr9ya86k3zpfyvh4gq3s";
   };
 
   wkQt = overrideDerivation qt4 (deriv: {
-    name = "qt-mod-4.8.6";
+    name = "qt-mod-4.8.7";
     enableParallelBuilding = true;
-    src = fetchgit {
-      url = "https://github.com/wkhtmltopdf/qt.git";
-      rev = "48e71c19c7fc67517fb3dca6d42eacb57341c9ba"; # From git submodule spec in wkhtml repo.
-      sha256 = "1ygr7g3k900zjf54ji6kkfppqnxaqwbh8npr53g2krdw3bmny6fx";
+    src = fetchFromGitHub {
+      owner  = "wkhtmltopdf";
+      repo   = "qt";
+      rev    = "fe194f9dac0b515757392a18f7fc9527c91d45ab"; # From git submodule spec in wkhtml repo.
+      sha256 = "1j2ld2bfacnn3vm2l1870v55sj82bq4y8zkawmlx2y5j63d8vr23";
     };
     configureFlags =
       ''
-        -v -no-separate-debug-info -release -confirm-license -opensource
-        -qdbus -glib -dbus-linked -openssl-linked
+        -dbus-linked
+        -glib
+        -no-separate-debug-info
+        -openssl-linked
+        -qdbus
+        -v
       ''
       + # This is taken from the wkhtml build script that we don't run
       ''
-        -fast
-        -static
+        -confirm-license
         -exceptions
-        -xmlpatterns
-        -webkit
-        -system-zlib
-        -system-libpng
-        -system-libjpeg
+        -fast
+        -graphicssystem raster
+        -iconv
+        -largefile
+        -no-3dnow
+        -no-accessibility
+        -no-audio-backend
+        -no-avx
+        -no-cups
+        -no-dbus
+        -no-declarative
+        -no-glib
+        -no-gstreamer
+        -no-gtkstyle
+        -no-icu
+        -no-javascript-jit
         -no-libmng
         -no-libtiff
-        -no-accessibility
-        -no-stl
-        -no-qt3support
+        -nomake demos
+        -nomake docs
+        -nomake examples
+        -nomake tests
+        -nomake tools
+        -nomake translations
+        -no-mitshm
+        -no-mmx
+        -no-multimedia
+        -no-nas-sound
+        -no-neon
+        -no-nis
+        -no-opengl
+        -no-openvg
+        -no-pch
         -no-phonon
         -no-phonon-backend
-        -no-opengl
-        -no-declarative
+        -no-qt3support
+        -no-rpath
+        -no-scripttools
+        -no-sm
         -no-sql-ibase
         -no-sql-mysql
         -no-sql-odbc
         -no-sql-psql
         -no-sql-sqlite
         -no-sql-sqlite2
-        -no-mmx
-        -no-3dnow
         -no-sse
         -no-sse2
-        -no-multimedia
-        -nomake demos
-        -nomake docs
-        -nomake examples
-        -nomake tools
-        -nomake tests
-        -nomake translations
+        -no-sse3
+        -no-sse4.1
+        -no-sse4.2
+        -no-ssse3
+        -no-stl
+        -no-xcursor
+        -no-xfixes
+        -no-xinerama
+        -no-xinput
+        -no-xkb
+        -no-xrandr
+        -no-xshape
+        -no-xsync
+        -opensource
+        -openssl
+        -release
+        -static
+        -system-libjpeg
+        -system-libpng
+        -system-zlib
+        -webkit
+        -xmlpatterns
       '';
   });
 
   buildInputs = [ wkQt fontconfig freetype libpng zlib libjpeg openssl
-    libX11 libXext libXrender
-    ];
+                  libX11 libXext libXrender
+                ];
 
   configurePhase = "qmake wkhtmltopdf.pro INSTALLBASE=$out";
 


### PR DESCRIPTION
Fix wkhtmltopdf on 16.03
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Fixes issue #14422
