### PR TITLE
pcl: buildable without GUI components

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qt4
-, libusb1, libpcap, libXt
+, libusb1, libpcap, libXt, libpng
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake qhull flann boost vtk eigen pkgconfig qt4 libusb1 libpcap libXt ];
+  buildInputs = [ cmake qhull flann boost eigen pkgconfig libusb1 libpcap
+                  libpng vtk qt4 libXt ];
 
   meta = {
     homepage = http://pointclouds.org/;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

One can build pcl with vtk, qt4, and libXt set to null iff libpng is
explicitly listed as a dependency.

pcl's build system is happy to proceed without those GUI-related
packages as long as libpng is available.
