### PR TITLE
fish: pick up completion files from other packages

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -101,6 +101,9 @@ in
       end
     '';
 
+    # include programs that bring their own completions
+    environment.pathsToLink = [ "/share/fish/vendor_completions.d" ];
+
     environment.systemPackages = [ pkgs.fish ];
 
     environment.shells = [

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation rec {
   '' + ''
     sed -i "s|/sbin /usr/sbin||" \
            "$out/share/fish/functions/__fish_complete_subcommand_root.fish"
+
+    # make fish pick up completions from nix profile
+    echo "set fish_complete_path (echo \$NIX_PROFILES | tr ' ' '\n')\"/share/fish/vendor_completions.d\" \$fish_complete_path" >> $out/share/fish/config.fish
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   preInstall = ''
     mkdir -p "$out/share/bash-completion/completions"
     mkdir -p "$out/share/zsh/site-functions"
-    mkdir -p "$out/share/fish/completions"
+    mkdir -p "$out/share/fish/vendor_completions.d"
   '';
 
   installFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
Some packages bring their own completions in
/share/fish/vendor_completions.d. Now they are picked up by fish from
every path in NIX_PROFILES.

cc @aszlig 
