### PR TITLE
mercurial: 3.7.1 -> 3.7.3 for multiple CVEs

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -3,7 +3,7 @@
 , ApplicationServices, cf-private }:
 
 let
-  version = "3.7.1";
+  version = "3.7.3";
   name = "mercurial-${version}";
 in
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://mercurial.selenic.com/release/${name}.tar.gz";
-    sha256 = "1vfgqlb8z2k1vcx2nvcianxmml79cqqqncchw6aj40sa8hgpvlwn";
+    sha256 = "0c2vkad9piqkggyk8y310rf619qgdfcwswnk3nv21mg2fhnw96f0";
   };
 
   inherit python; # pass it so that the same version can be used in hg2git


### PR DESCRIPTION
Please backport to 16.03
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CVE-2016-3068

```
Blake Burkhart discovered that Mercurial allows URLs for Git
subrepositories that could result in arbitrary code execution on
clone.
```

CVE-2016-3069

```
Blake Burkhart discovered that Mercurial allows arbitrary code
execution when converting Git repositories with specially
crafted names.
```

CVE-2016-3630

```
It was discovered that Mercurial does not properly perform bounds-
checking in its binary delta decoder, which may be exploitable for
remote code execution via clone, push or pull.
```
