### PR TITLE
optipng: 0.7.5 -> 0.7.6 (CVE-2016-2191)

### DIFF
--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -5,11 +5,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "optipng-0.7.5";
+  name = "optipng-0.7.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/optipng/${name}.tar.gz";
-    sha256 = "17b197437z5wn29llpwklk7ihgx8bhc913gvjf4zyb81idwlprbl";
+    sha256 = "105yk5qykvhiahzag67gm36s2kplxf6qn5hay02md0nkrcgn6w28";
   };
 
   buildInputs = [ libpng ];


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

0.7.6 contains a fix for CVE-2016-2191:

> An invalid write may occur in optipng before version 0.7.6 while
> processing bitmap images due to `crt_row' being (inc|dec)remented
> without any boundary checking when encountering delta escapes. This
> issue can possibly be used to execute arbitrary code.
