### PR TITLE
linuxPackages_grsec.kernelHeaders: fix build

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, kernel, perl }:
+{ stdenv, kernel, perl, gmp, libmpc, mpfr, bc }:
 
 let
   baseBuildFlags = [ "INSTALL_HDR_PATH=$(out)" "headers_install" ];
@@ -7,7 +7,13 @@ in stdenv.mkDerivation {
 
   inherit (kernel) src patches;
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl ]
+    ++ stdenv.lib.optionals (kernel.features.grsecurity or false) [ gmp libmpc mpfr bc ];
+
+  preConfigure = stdenv.lib.optionals (kernel.features.grsecurity or false) ''
+    cp ${kernel.configfile} .config
+    make prepare
+  '';
 
   buildFlags = [ "ARCH=${stdenv.platform.kernelArch}" ] ++ baseBuildFlags;
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Adds gmp, libmpc, mpfr, and bc for gcc plugin support.  Running 'make
prepare' before building turns out to be necessary.

I think the `preConfigure` step could be made unconditional, but I've made it conditional just to minimize the impact of this patch.

cc @domenkozar 
