### PR TITLE
beancount: init at 2016-04-08

### DIFF
--- a/pkgs/applications/office/beancount/default.nix
+++ b/pkgs/applications/office/beancount/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchhg, pkgs, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  version = "2016-04-10-b5721f1c6f01bd168a5781652e5e3167f7f8ceb3";
+  name = "beancount-${version}";
+  namePrefix = "";
+
+  src = fetchhg {
+    url = "https://bitbucket.org/blais/beancount";
+    rev = "b5721f1c6f01bd168a5781652e5e3167f7f8ceb3";
+    sha256 = "10nv3p9cix7yp23a9hnq5163rpl8cfs3hv75h90ld57dc24nxzn2";
+  };
+
+  buildInputs = with pythonPackages; [ nose ];
+
+  checkPhase = ''
+    nosetests $out
+  '';
+
+  propagatedBuildInputs = with pythonPackages; [
+    beautifulsoup4
+    bottle
+    chardet
+    dateutil
+    google_api_python_client
+    lxml
+    ply
+    python_magic
+  ];
+
+  meta = {
+    homepage = http://furius.ca/beancount/;
+    description = "double-entry bookkeeping computer language";
+    longDescription = ''
+        A double-entry bookkeeping computer language that lets you define
+        financial transaction records in a text file, read them in memory,
+        generate a variety of reports from them, and provides a web interface.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14585,6 +14585,10 @@ in
 
   bastet = callPackage ../games/bastet {};
 
+  beancount = callPackage ../applications/office/beancount {
+      pythonPackages = python3Packages;
+  };
+
   beret = callPackage ../games/beret { };
 
   bitsnbots = callPackage ../games/bitsnbots {


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I'm having issues building this. It complains `hashlib` is not present, but there is no package `hashlib` in nixpkgs though doing `python3.3` and then `import hashlib` works fine...
