### PR TITLE
libsamplerate, libdvdcss: fix darwin build

### DIFF
--- a/pkgs/development/libraries/libdvdcss/default.nix
+++ b/pkgs/development/libraries/libdvdcss/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchurl }:
+{stdenv, fetchurl, IOKit}:
 
 stdenv.mkDerivation rec {
   name = "libdvdcss-${version}";
   version = "1.4.0";
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin IOKit;
 
   src = fetchurl {
     url = "http://get.videolan.org/libdvdcss/${version}/${name}.tar.bz2";
@@ -13,6 +15,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.videolan.org/developers/libdvdcss.html;
     description = "A library for decrypting DVDs";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7545,7 +7545,9 @@ in
 
   libdwg = callPackage ../development/libraries/libdwg { };
 
-  libdvdcss = callPackage ../development/libraries/libdvdcss { };
+  libdvdcss = callPackage ../development/libraries/libdvdcss {
+    inherit (darwin) IOKit;
+  };
 
   libdvdnav = callPackage ../development/libraries/libdvdnav { };
   libdvdnav_4_2_1 = callPackage ../development/libraries/libdvdnav/4.2.1.nix {


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

I started with intent to get Handbrake building on darwin, but that turned our more difficult than anticipated. It seems to pretty heavily depend on Xcode.

I did manage to fix these two in the process, though. They build for me locally just fine. The nox-review fails for me while building doxygen, which seems pretty unrelated.
