### PR TITLE
flashplayer: 11.2.202.577 -> 11.2.202.616

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -49,7 +49,7 @@ let
   suffix =
     if      stdenv.system == "x86_64-linux" then
       if    debug then throw "no x86_64 debugging version available"
-      else             "-release.x86_64"
+      else             "_linux.x86_64"
     else if stdenv.system == "i686-linux"   then
       if    debug then "_linux_debug.i386"
       else             "_linux.i386"
@@ -59,28 +59,30 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "11.2.202.577";
+  version = "11.2.202.616";
 
   src = fetchurl {
     url = "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_${version}_archive.zip";
-    sha256 = "1k02d6c9y8z9lxyqyq04zsc5735cvm30mkwli71mh87fr1va2q4j";
+    sha256 = "0y4bjkla6ils4crmx61pi31s4gscy8rgiv7xccx1z0g6hba9j73l";
   };
 
   buildInputs = [ unzip ];
 
   postUnpack = ''
     pushd $sourceRoot
-    tar -xvzf *${arch}/*${suffix}.tar.gz
+    tar -xvzf *${suffix}.tar.gz
 
     ${ lib.optionalString is-i686 ''
-       tar -xvzf */*_sa.*.tar.gz
-       tar -xvzf */*_sa_debug.*.tar.gz
+       tar -xvzf *_sa.*.tar.gz
+       tar -xvzf *_sa_debug.*.tar.gz
     ''}
 
     popd
   '';
 
-  sourceRoot = "fp_${version}_archive";
+  setSourceRoot = ''
+    sourceRoot=$(ls -d *${arch})
+  '';
 
   dontStrip = true;
   dontPatchELF = true;


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

Security fix for [APSB16-10](https://helpx.adobe.com/security/products/flash-player/apsb16-10.html).

Tested on x86_64 NixOS with Firefox.
