### PR TITLE
lxmenu-data: init at 0.1.5

### DIFF
--- a/pkgs/desktops/lxde/core/lxmenu-data.nix
+++ b/pkgs/desktops/lxde/core/lxmenu-data.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, intltool }:
+
+stdenv.mkDerivation rec {
+  name = "lxmenu-data-${version}";
+  version = "0.1.5";
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/lxde/${name}.tar.xz";
+    sha256 = "9fe3218d2ef50b91190162f4f923d6524c364849f87bcda8b4ed8eb59b80bab8";
+  };
+
+  buildInputs = [ intltool ];
+
+  meta = {
+    homepage = "http://lxde.org/";
+    license = stdenv.lib.licenses.gpl2;
+    description = "Freedesktop.org desktop menus for LXDE";
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5308,6 +5308,8 @@ in
 
   lxappearance = callPackage ../applications/misc/lxappearance {};
 
+  lxmenu-data = callPackage ../desktops/lxde/core/lxmenu-data.nix { };
+
   kona = callPackage ../development/interpreters/kona {};
 
   lolcode = callPackage ../development/interpreters/lolcode { };


### PR DESCRIPTION
Provides menus for LXDE, or for e.g. PCManFM if no desktop environment is installed. On Arch, PCManFM depends on this package, so we can consider doing the same here. I did not yet do this, however. CC @ttuegel, maintainer of PCManFM

I put it in pkgs/desktops/lxde/core, because I did not know where else to put it. This directory did not exists before this PR, so please tell me if it's not right. At the moment LXDE is not yet packaged in nixpkgs, so maybe this can be misleading.

**Edit:** Maybe pkgs/data/misc?
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

---

_Please note, that points are not mandatory, but rather desired._
