### PR TITLE
Plex: update plex, plexpass; fix plex module to restart

### DIFF
--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -128,6 +128,7 @@ in
         Group = cfg.group;
         PermissionsStartOnly = "true";
         ExecStart = "/bin/sh -c '${cfg.package}/usr/lib/plexmediaserver/Plex\\ Media\\ Server'";
+        Restart = "on-failure";
       };
       environment = {
         PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR=cfg.dataDir;

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -5,9 +5,9 @@
 
 let
   plexpkg = if enablePlexPass then {
-    version = "0.9.16.3.1840";
-    vsnHash = "cece46d";
-    sha256 = "0p1rnia18a67h05f7l7smkpry1ldkpdkyvs9fgrqpay3w0jfk9gd";
+    version = "0.9.16.4.1911";
+    vsnHash = "ee6e505";
+    sha256 = "0lq0lcynmc09d0whynb0x2zgd39dp7z7k86ndgm2clay3zbzqpfd";
   } else {
     version = "0.9.16.4.1911";
     vsnHash = "ee6e505";

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -9,9 +9,9 @@ let
     vsnHash = "cece46d";
     sha256 = "0p1rnia18a67h05f7l7smkpry1ldkpdkyvs9fgrqpay3w0jfk9gd";
   } else {
-    version = "0.9.15.6.1714";
-    vsnHash = "7be11e1";
-    sha256 = "1kyk41qnbm8w5bvnisp3d99cf0r72wvlggfi9h4np7sq4p8ksa0g";
+    version = "0.9.16.4.1911";
+    vsnHash = "ee6e505";
+    sha256 = "0lq0lcynmc09d0whynb0x2zgd39dp7z7k86ndgm2clay3zbzqpfd";
   };
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
Tested on my machines. Builds both plex and plexpass. Server works as usual. Every once in a while plex will fail to start on boot. Restarting on-failure should help.
