### PR TITLE
nvidia-x11: 358.16 -> 361.42

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "358.16";
+  versionNumber = "361.42";
 
   # Policy: use the highest stable version as the default (on our master).
   inherit (stdenv.lib) makeLibraryPath;
@@ -28,12 +28,12 @@ stdenv.mkDerivation {
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "1cc0zsri92nz2mznabfd6pqckm9mlbszmysqqqh3w5mipwn898nk";
+        sha256 = "10jfdrmjcddgp7kg9l3dwxjh4b7sdrg86nwaf6zalfnsc9zh8bg3";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "1xr16faam2zsx8ajwm9g9302m6qjzyjh1zd56g8jhc8jxg8h43sg";
+        sha256 = "04yyrzk4xzq1i386mdxfwg4dqiclvj1fm195qsqy0r79zmpc3kq4";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 


### PR DESCRIPTION
Cherry-picked from master.

See: https://github.com/NixOS/nixpkgs/pull/14404https://github.com/NixOS/nixpkgs/pull/14404

Building locally just in case.
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @domenkozar 

---

This fixes the segfault reported in #13942 caused by missing
libEGL.so.0 and libEGL_nvidia.so.0 symlinks.
