### PR TITLE
pcre: patch CVE-2016-1283

### DIFF
--- a/pkgs/development/libraries/pcre/CVE-2016-1283.patch
+++ b/pkgs/development/libraries/pcre/CVE-2016-1283.patch
@@ -1,0 +1,18 @@
+Index: pcre_compile.c
+===================================================================
+--- a/pcre_compile.c	(revision 1635)
++++ b/pcre_compile.c	(revision 1636)
+@@ -7311,7 +7311,12 @@
+           so far in order to get the number. If the name is not found, leave
+           the value of recno as 0 for a forward reference. */
+ 
+-          else
++          /* This patch (removing "else") fixes a problem when a reference is
++          to multiple identically named nested groups from within the nest.
++          Once again, it is not the "proper" fix, and it results in an
++          over-allocation of memory. */
++
++          /* else */
+             {
+             ng = cd->named_groups;
+             for (i = 0; i < cd->names_found; i++, ng++)

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -22,8 +22,9 @@ in stdenv.mkDerivation rec {
     sha256 = "1pvra19ljkr5ky35y2iywjnsckrs9ch2anrf5b0dc91hw8v2vq5r";
   };
 
-  patches =
-    [ ];
+  patches = [
+    ./CVE-2016-1283.patch
+  ];
 
   outputs = [ "out" "doc" "man" ];
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

> The pcre_compile2 function in pcre_compile.c in PCRE 8.38 mishandles the `/((?:F?+(?:^(?(R)a+\"){99}-))(?J)(?'R'(?'R'<((?'RR'(?'R'\){97)?J)?J)(?'R'(?'R'\){99|(:(?|(?'R')(\k'R')|((?'R')))H'R'R)(H'R))))))/` pattern and related patterns with named subgroups, which allows remote attackers to cause a denial of service (heap-based buffer overflow) or possibly have unspecified other impact via a crafted regular expression, as demonstrated by a JavaScript RegExp object encountered by Konqueror.
- We are vulnerable to this, you can try compiling the above pattern with any number of things in nixpkgs that use pcre, e.g. in zsh `zmodload zsh/pcre; pcre_compile "/((?:F?+(?:^(?(R)a+\"){99}-))(?J)(?'R'(?'R'<((?'RR'(?'R'\){97)?J)?J)(?'R'(?'R'\){99|(:(?|(?'R')(\k'R')|((?'R')))H'R'R)(H'R))))))/"` core dumps.
- As demonstrated this seems to "only" be a DOS vector, but the [Arch Security Advisory](https://lists.archlinux.org/pipermail/arch-security/2016-March/000583.html) suggests the possibility of crafting a pattern to trigger arbitrary code execution.

> Exploits with advanced Heap Fengshui techniques may allow
> an attacker to execute arbitrary code in the context of the user running
> the affected application.
- This triggers a large rebuild.
