### PR TITLE
wayland: 1.9.0 -> 1.10.0, weston: 1.9.0 -> 1.10.0, wayland-protocols: init at 1.3

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -1,24 +1,24 @@
 { stdenv, fetchurl, pkgconfig, wayland, mesa, libxkbcommon, cairo, libxcb
 , libXcursor, xlibsWrapper, udev, libdrm, mtdev, libjpeg, pam, dbus, libinput
 , pango ? null, libunwind ? null, freerdp ? null, vaapi ? null, libva ? null
-, libwebp ? null, xwayland ? null
+, libwebp ? null, xwayland ? null, wayland-protocols
 # beware of null defaults, as the parameters *are* supplied by callPackage by default
 }:
 
 stdenv.mkDerivation rec {
   name = "weston-${version}";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1ks8mja6glzy2dkayi535hd6w5c5h021bqk7vzgv182g33rh66ww";
+    sha256 = "1hd5593zz5s3s07vb6linp6akbs62wy2ijh3g7gksafq016h1cp0";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     wayland mesa libxkbcommon cairo libxcb libXcursor xlibsWrapper udev libdrm
     mtdev libjpeg pam dbus.libs libinput pango libunwind freerdp vaapi libva
-    libwebp
+    libwebp wayland-protocols
   ];
 
   configureFlags = [

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkgconfig
-, libffi, docbook_xsl, doxygen, graphviz, libxslt, xmlto
+, libffi, docbook_xsl, doxygen, graphviz, libxslt, xmlto, libxml2
 , expat ? null # Build wayland-scanner (currently cannot be disabled as of 1.7.0)
 }:
 
@@ -8,18 +8,18 @@ assert expat != null;
 
 stdenv.mkDerivation rec {
   name = "wayland-${version}";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1yhy62vkbq8j8c9zaa6yzvn75cd99kfa8n2zfdwl80x019r711ww";
+    sha256 = "1p307ly1yyqjnzn9dbv78yffql2qszn84qk74lwanl3gma8fgxjb";
   };
 
   configureFlags = "--with-scanner --disable-documentation";
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ libffi /* docbook_xsl doxygen graphviz libxslt xmlto */ expat ];
+  buildInputs = [ libffi /* docbook_xsl doxygen graphviz libxslt xmlto */ expat libxml2 ];
 
   meta = {
     description = "Reference implementation of the wayland protocol";

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchurl, pkgconfig
+, wayland
+}:
+
+stdenv.mkDerivation rec {
+  name = "wayland-protocols-${version}";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
+    sha256 = "0byqvrsm6bkvylvzqy8wh5wpszwl5ra1z0yjqzqmw8przlrhdkbb";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ wayland ];
+
+  meta = {
+    description = "Wayland protocol extensions";
+    homepage    = http://wayland.freedesktop.org/;
+    license     = lib.licenses.mit;
+    platforms   = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ];
+  };
+
+  passthru.version = version;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8996,6 +8996,8 @@ in
     graphviz = graphviz-nox;
   };
 
+  wayland-protocols = callPackage ../development/libraries/wayland/protocols.nix { };
+
   webkit = webkitgtk;
 
   wcslib = callPackage ../development/libraries/wcslib { };


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

We could probably go without the dependency on libxml2 if we disable DTD validation (see https://cgit.freedesktop.org/wayland/wayland/commit/?id=f66e2d53dd8920451a4d9544b2fd2568a6a75b9b )
