### PR TITLE
[WIP] PINE64: Kernel init

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-pine64.nix
+++ b/pkgs/os-specific/linux/kernel/linux-pine64.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub, perl, buildLinux, ... } @ args:
+
+let
+  rev = "4";
+in import ./generic.nix (args // rec {
+  version = "3.10.65-${rev}-pine64";
+
+  modDirVersion = "3.10.65-v7";
+
+  src = fetchFromGitHub {
+      owner = "longsleep";
+      repo = "linux-pine64";
+      rev = "${version}";
+      sha256 = "1mxxpvfwvs51ank94kbhrqa20fh66qlrpv3mg9vf4jif0cj9ns7c";
+  };
+
+  features.iwlwifi = true;
+
+  extraMeta.hydraPlatforms = [];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10383,6 +10383,10 @@ in
     kernelPatches = [ kernelPatches.bridge_stp_helper ];
   };
 
+  linux_pine64 = callPackage ../os-specific/linux/kernel/linux-pine64.nix {
+    kernelPatches = [ kernelPatches.bridge_stp_helper ];
+  };
+
   linux_3_10 = callPackage ../os-specific/linux/kernel/linux-3.10.nix {
     kernelPatches = with kernelPatches; [ bridge_stp_helper link_lguest link_apm ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")


### PR DESCRIPTION
I am giving this a shot.
The PINE is a relatively new SoC.

I am thinking this should work similarly to the Raspberry Pi support.

A 3.10 kernel that works on the PINE can be found here:
http://forum.pine64.org/showthread.php?tid=343

The kernel needs to be built on an ARM system from what I can tell. Will use my existing Raspberry Pi to do so and then see if the kernel works on the PINE.

If anybody would like to contribute, you are more than welcome.
