### PR TITLE
pythonPackages.closure-linter: init at 2.3.19

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3266,6 +3266,30 @@ in modules // {
     };
   });
 
+  /* There is a project called "closure-linter" on PyPI that is the
+     same as this, but it does not appear to be owned by Google.
+     So we're pulling from Google's GitHub repo instead. */
+  closure-linter = buildPythonPackage rec {
+    name = "closure-linter-${version}";
+    version = "2.3.19";
+
+    /* This project has no Python 3 support, as noted by
+       https://github.com/google/closure-linter/issues/81 */
+    disabled = isPy3k;
+
+    propagatedBuildInputs = with self; [ gflags ];
+    src = pkgs.fetchgit {
+      url = "https://github.com/google/closure-linter";
+      rev = "5c27529075bb88bdc45e73008f496dec8438d658";
+      sha256 = "076c7q7pr7akfvq5y8lxr1ab81wwps07gw00igdkcxnc5k9dzxwc";
+    };
+    meta = {
+      description = "Checks JavaScript files against Google's style guide.";
+      homepage = "https://developers.google.com/closure/utilities/";
+      license = with licenses; [ asl20 ];
+    };
+  };
+
   cloudpickle = buildPythonPackage rec {
     name = "cloudpickle-${version}";
     version = "0.1.1";


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
