### PR TITLE
dumptorrent: init at 1.2

### DIFF
--- a/pkgs/tools/misc/dumptorrent/default.nix
+++ b/pkgs/tools/misc/dumptorrent/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+    name = "dumptorrent-${version}";
+    version = "1.2";
+    
+    src = fetchurl {
+      url = "mirror://sourceforge/dumptorrent/dumptorrent-${version}.tar.gz";
+      sha256 = "073h03bmpfdy15qh37lvppayld2747i4acpyk0pm5nf2raiak0zm";
+    };
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ./dumptorrent $out/bin
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Dump .torrent file information";
+      homepage = https://sourceforge.net/projects/dumptorrent/;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.zohl ];
+      platforms = platforms.all;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1314,6 +1314,8 @@ in
 
   duff = callPackage ../tools/filesystems/duff { };
 
+  dumptorrent = callPackage ../tools/misc/dumptorrent { };
+
   duo-unix = callPackage ../tools/security/duo-unix { };
 
   duplicity = callPackage ../tools/backup/duplicity {


### PR DESCRIPTION
Just a small utility, nothing non-trivial here.
## 
###### Things done:
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
