### PR TITLE
ums 5.4.0 -> 6.2.2

### DIFF
--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "ums-${version}";
-  version = "5.4.0";
+  version = "6.2.2";
   
   src = fetchurl {
     url = "mirror://sourceforge/project/unimediaserver/Official%20Releases/Linux/" + stdenv.lib.toUpper "${name}" + "-Java8.tgz";
-    sha256 = "0ryp26h7pyqing8pyg0xjrp1wm77wwgya4a7d00wczh885pk16kq";
+    sha256 = "1qa999la9hixy0pdj9phjvr6lwqycgdvm94nc1606vz0ivf95b15";
     name = "${name}.tgz";
   };
 


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
