### PR TITLE
ocamlPackages.cryptokit: 1.9 -> 1.10

### DIFF
--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -7,11 +7,11 @@ in
 assert stdenv.lib.versionAtLeast ocaml_version "3.12";
 
 stdenv.mkDerivation {
-  name = "cryptokit-1.9";
+  name = "cryptokit-1.10";
 
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/1166/cryptokit-1.9.tar.gz;
-    sha256 = "1jh0jqiwkjy9qplnfcm5r25zdgyk36sxb0c87ks3rjj7khrw1a2n";
+    url = http://forge.ocamlcore.org/frs/download.php/1493/cryptokit-1.10.tar.gz;
+    sha256 = "1k2f2ixm7jcsgrzn9lz1hm9qqgq71lk9lxy3v3cwsd8xdrj3jrnv";
   };
 
   buildInputs = [zlib ocaml findlib ncurses];


### PR DESCRIPTION
###### Things done:
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
