### PR TITLE
Simplify contributing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,4 +12,18 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
 
 ## Submitting changes
 
-See the nixpkgs manual for details on how to [Submit changes to nixpkgs](http://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download-by-type/doc/manual#chap-submitting-changes).
+* Format the commits in the following way:
+
+  `(pkg-name | service-name): (from -> to | init at version | refactor | etc)`
+
+  Examples:
+
+  * nginx: init at 2.0.1
+  * firefox: 3.0 -> 3.1.1
+  * hydra service: add bazBaz option
+  * nginx service: refactor config generation
+
+* Don't put dots at the end of package descriptions.
+
+See the nixpkgs manual for more details on how to [Submit changes to nixpkgs](http://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download-by-type/doc/manual#chap-submitting-changes).
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,10 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
   * hydra service: add bazBaz option
   * nginx service: refactor config generation
 
-* Don't put dots at the end of package descriptions.
+* `meta.description` should:
+  * Be capitalized
+  * Not start with the package name
+  * Not have a dot at the end
 
 See the nixpkgs manual for more details on how to [Submit changes to nixpkgs](http://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download-by-type/doc/manual#chap-submitting-changes).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-###### Things done:
+###### Things done
 
 - [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
 - Built on platform(s)
@@ -9,13 +9,5 @@
 - [ ] Tested execution of all binary files (usually in `./result/bin/`)
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 
-###### More
-
-Fixes issue #<insert id>
-
-cc @<maintainer>
-
-
 ---
 
-_Please note, that points are not mandatory, but rather desired._


### PR DESCRIPTION
- Highlight the top mistakes directly in CONTRIBUTING.md
- Remove unecessary cruft from the PR template (which I always have to delete anyways)
