### PR TITLE
khard: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgs, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  version = "0.8.1";
+  version = "0.9.0";
   name = "khard-${version}";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://github.com/scheibler/khard/archive/v${version}.tar.gz";
-    sha256 = "13axfrs96isirx0c483545xdmjwwfq1k7yy92xpk7l184v71rgi1";
+    sha256 = "1cj6rlvbk05cfjkl1lnyvq12sb847jjwqy5j8906p2b2x4wq72qi";
   };
 
   propagatedBuildInputs = with python2Packages; [


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @matthiasbeyer 
