### PR TITLE
botanUnstable: 1.11.28 -> 1.11.29 (security)

### DIFF
--- a/pkgs/development/libraries/botan/unstable.nix
+++ b/pkgs/development/libraries/botan/unstable.nix
@@ -2,7 +2,7 @@
 
 callPackage ./generic.nix (args // {
   baseVersion = "1.11";
-  revision = "28";
-  sha256 = "0cjr3zkara8js1fbm8ddcbd5mkizxh1wm6fja13psw5j8mpwj554";
+  revision = "29";
+  sha256 = "157bp8716h17agrxyj7xpsj2i5sqhafj1nfx4gpzccx7y2kyq176";
   openssl = null;
 })


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This release contains fixes for
- CVE-2016-2849
- CVE-2016-2850
