### PR TITLE
libsndfile: 1.0.25 -> 1.0.26 (security)

### DIFF
--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "libsndfile-1.0.25";
+  name = "libsndfile-1.0.26";
 
   src = fetchurl {
     url = "http://www.mega-nerd.com/libsndfile/files/${name}.tar.gz";
-    sha256 = "10j8mbb65xkyl0kfy0hpzpmrp0jkr12c7mfycqipxgka6ayns0ar";
+    sha256 = "14jhla289cj45946h0hq2an0a9g4wkwb3v4571bla6ixfvn20rfd";
   };
 
   buildInputs = [ pkgconfig flac libogg libvorbis ]


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

This release contains fixes for
- CVE-2014-9496
- CVE-2014-9756
- CVE-2015-7805

This triggers a large rebuild so I've targeted staging.
