### PR TITLE
Shout: configure with attrs

### DIFF
--- a/nixos/modules/services/networking/shout.nix
+++ b/nixos/modules/services/networking/shout.nix
@@ -6,6 +6,21 @@ let
   cfg = config.services.shout;
   shoutHome = "/var/lib/shout";
 
+  defaultConfig = pkgs.runCommand "config.js" {} ''
+    EDITOR=true ${pkgs.shout}/bin/shout config --home $PWD
+    mv config.js $out
+  '';
+
+  configFile = if (cfg.configFile != null) then cfg.configFile else ''
+    var _ = require('${pkgs.shout}/lib/node_modules/shout/node_modules/lodash')
+
+    module.exports = _.merge(
+      {},
+      require('${defaultConfig}'),
+      ${builtins.toJSON cfg.config}
+    )
+  '';
+
 in {
   options.services.shout = {
     enable = mkEnableOption "Shout web IRC client";
@@ -33,10 +48,33 @@ in {
 
     configFile = mkOption {
       type = types.nullOr types.lines;
-      default = null;
+      default = configFile;
       description = ''
-        Contents of Shout's <filename>config.js</filename> file. If left empty,
-        Shout will generate from its defaults at first startup.
+        Contents of Shout's <filename>config.js</filename> file.
+
+        Used for backward compatibility, recommended way is now to use
+        the <literal>config</literal> option.
+
+        Documentation: http://shout-irc.com/docs/server/configuration.html
+      '';
+    };
+
+    config = mkOption {
+      default = {};
+      type = types.attrs;
+      example = {
+        displayNetwork = false;
+        defaults = {
+          name = "Your Network";
+          host = "localhost";
+          port = 6697;
+        };
+      };
+      description = ''
+        Shout <filename>config.js</filename> contents as attribute set (will be
+        converted to JSON to generate the configuration file).
+
+        The options defined here will be merged to the default configuration file.
 
         Documentation: http://shout-irc.com/docs/server/configuration.html
       '';
@@ -57,11 +95,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      preStart = if isNull cfg.configFile then ""
-                 else ''
-                   ln -sf ${pkgs.writeText "config.js" cfg.configFile} \
-                          ${shoutHome}/config.js
-                 '';
+      preStart = "ln -sf ${pkgs.writeText "config.js" configFile} ${shoutHome}/config.js";
       script = concatStringsSep " " [
         "${pkgs.shout}/bin/shout"
         (if cfg.private then "--private" else "--public")


### PR DESCRIPTION
This PR allows to configure the Shout service by specifying a Nix attribute set in `config` as an alternative to the configuration file content in `configFile`.

Also, when `config` is used, the generated configuration file will merge the attribute set with the default Shout configuration, allowing to set in `config` only the attributes to change from the default configuration (unlike `configFile` that, when present, replaces the default configuration and must contain all the attributes).
