### PR TITLE
factorio: 0.12.28 -> 0.12.29

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "0.12.28";
+  version = "0.12.29";
 
   fetch = callPackage ./fetch.nix { username = username; password = password; };
   arch = if stdenv.system == "x86_64-linux" then "x64"


### PR DESCRIPTION
No testing done, but the website clearly shows the latest version as 0.12.29 (https://www.factorio.com/download-headless/stable), the link for that version is live, and I can't see any major issues reported for that version to justify not being on the latest.

cc: @Baughn 
