### PR TITLE
gtk: search immodules.cache in $NIX_PROFILE

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -102,6 +102,8 @@ in
     environment.pathsToLink =
       [ "/bin"
         "/etc/xdg"
+        "/etc/gtk-2.0"
+        "/etc/gtk-3.0"
         "/info"
         "/lib" # FIXME: remove and update debug-info.nix
         "/sbin"

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -1,10 +1,32 @@
 { config, pkgs, lib, ... }:
 
 with lib;
-
+let
+  cfg = config.i18n.inputMethod;
+  gtk2_cache = pkgs.stdenv.mkDerivation {
+    preferLocalBuild = true; 
+    allowSubstitutes = false;
+    name = "gtk2-immodule.cache";
+    buildInputs = [ pkgs.gtk cfg.package ];
+    buildCommand = ''
+      mkdir -p $out/etc/gtk-2.0/
+      GTK_PATH=${cfg.package}/lib/gtk-2.0/ gtk-query-immodules-2.0 > $out/etc/gtk-2.0/immodules.cache
+    '';
+  };
+  gtk3_cache = pkgs.stdenv.mkDerivation {
+    preferLocalBuild = true; 
+    allowSubstitutes = false;
+    name = "gtk3-immodule.cache";
+    buildInputs = [ pkgs.gtk3 cfg.package ];
+    buildCommand = ''
+      mkdir -p $out/etc/gtk-3.0/
+      GTK_PATH=${cfg.package}/lib/gtk-3.0/ gtk-query-immodules-3.0 > $out/etc/gtk-3.0/immodules.cache
+    '';
+  };
+in
 {
-  options = {
-    i18n.inputMethod = {
+  options.i18n = {
+    inputMethod = {
       enabled = mkOption {
         type    = types.nullOr (types.enum [ "ibus" "fcitx" "nabi" "uim" ]);
         default = null;
@@ -24,6 +46,20 @@ with lib;
           </itemizedlist>
         '';
       };
+
+      package = mkOption {
+        internal = true;
+        type     = types.path;
+        default  = null;
+        description = ''
+          The input method method package.
+        '';
+      };
     };
   };
+
+  config = mkIf (cfg.enabled != null) {
+    environment.systemPackages = [ cfg.package gtk2_cache gtk3_cache ];
+  };
+
 }

--- a/nixos/modules/i18n/input-method/fcitx.nix
+++ b/nixos/modules/i18n/input-method/fcitx.nix
@@ -32,7 +32,7 @@ in
   };
 
   config = mkIf (config.i18n.inputMethod.enabled == "fcitx") {
-    environment.systemPackages = [ fcitxPackage ];
+    i18n.inputMethod.package = fcitxPackage;
 
     environment.variables = {
       GTK_IM_MODULE = "fcitx";

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -41,9 +41,11 @@ in
   };
 
   config = mkIf (config.i18n.inputMethod.enabled == "ibus") {
+    i18n.inputMethod.package = ibusPackage;
+
     # Without dconf enabled it is impossible to use IBus
     environment.systemPackages = with pkgs; [
-      ibusPackage ibus-qt gnome3.dconf ibusAutostart
+      ibus-qt gnome3.dconf ibusAutostart
     ];
 
     environment.variables = {

--- a/nixos/modules/i18n/input-method/nabi.nix
+++ b/nixos/modules/i18n/input-method/nabi.nix
@@ -3,7 +3,7 @@
 with lib;
 {
   config = mkIf (config.i18n.inputMethod.enabled == "nabi") {
-    environment.systemPackages = [ pkgs.nabi ];
+    i18n.inputMethod.package = pkgs.nabi;
 
     environment.variables = {
       GTK_IM_MODULE = "nabi";

--- a/nixos/modules/i18n/input-method/uim.nix
+++ b/nixos/modules/i18n/input-method/uim.nix
@@ -22,7 +22,7 @@ in
   };
 
   config = mkIf (config.i18n.inputMethod.enabled == "uim") {
-    environment.systemPackages = [ pkgs.uim ];
+    i18n.inputMethod.package = pkgs.uim;
 
     environment.variables = {
       GTK_IM_MODULE = "uim";

--- a/pkgs/development/libraries/gtk+/2.0-immodules.cache.patch
+++ b/pkgs/development/libraries/gtk+/2.0-immodules.cache.patch
@@ -1,0 +1,27 @@
+--- a/gtk/gtkrc.c	2014-09-30 05:02:17.000000000 +0900
++++ b/gtk/gtkrc.c	2016-04-09 17:39:51.363288355 +0900
+@@ -445,5 +445,23 @@
+   if (var)
+     result = g_strdup (var);
+ 
++  // check NIX_PROFILES paths.
++  const gchar *nixProfilesEnv = g_getenv ("NIX_PROFILES");
++  gchar *cachePath;
++  guint i;
++
++  if(nixProfilesEnv && !result){
++    gchar **paths = g_strsplit(nixProfilesEnv, " ", -1);
++    for (i = 0; paths[i] != NULL; i++){
++      cachePath = g_build_filename(paths[i], "etc", "gtk-2.0", "immodules.cache", NULL);
++      if( g_file_test( cachePath, G_FILE_TEST_EXISTS) ){
++        if(result) g_free(result);
++        result = g_strdup(cachePath);
++      }
++      g_free(cachePath);
++    }
++    g_strfreev(paths);
++  }
++
+   if (!result)
+     {
+

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ setupHook perl pkgconfig gettext ];
 
+  patches = [ ./2.0-immodules.cache.patch ];
+
   propagatedBuildInputs = with xorg; with stdenv.lib;
     [ glib cairo pango gdk_pixbuf atk ]
     ++ optionals (stdenv.isLinux || stdenv.isDarwin) [

--- a/pkgs/development/libraries/gtk+/3.0-immodules.cache.patch
+++ b/pkgs/development/libraries/gtk+/3.0-immodules.cache.patch
@@ -1,0 +1,27 @@
+--- a/gtk/deprecated/gtkrc.c	2016-04-02 18:43:08.401663112 +0900
++++ b/gtk/deprecated/gtkrc.c	2016-04-02 18:29:19.927608592 +0900
+@@ -774,5 +774,23 @@
+   if (var)
+     result = g_strdup (var);
+ 
++  // check NIX_PROFILES paths.
++  const gchar *nixProfilesEnv = g_getenv ("NIX_PROFILES");
++  gchar *cachePath;
++  guint i;
++
++  if(nixProfilesEnv && !result){
++    gchar **paths = g_strsplit(nixProfilesEnv, " ", -1);
++    for (i = 0; paths[i] != NULL; i++){
++      cachePath = g_build_filename(paths[i], "etc", "gtk-3.0", "immodules.cache", NULL);
++      if( g_file_test( cachePath, G_FILE_TEST_EXISTS) ){
++        if(result) g_free(result);
++        result = g_strdup(cachePath);
++      }
++      g_free(cachePath);
++    }
++    g_strfreev(paths);
++  }
++
+   if (!result)
+     {
+ 

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection perl ];
 
+  patches = [ ./3.0-immodules.cache.patch ];
+
   buildInputs = [ libxkbcommon epoxy json_glib ];
   propagatedBuildInputs = with xorg; with stdenv.lib;
     [ expat glib cairo pango gdk_pixbuf atk at_spi2_atk
@@ -57,13 +59,6 @@ stdenv.mkDerivation rec {
     substituteInPlace "$out/lib/gtk-3.0/3.0.0/printbackends/libprintbackend-cups.la" \
       --replace '-L${gmp.dev}/lib' '-L${gmp.out}/lib'
   '';
-
-  passthru = {
-    gtkExeEnvPostBuild = ''
-      rm $out/lib/gtk-3.0/3.0.0/immodules.cache
-      $out/bin/gtk-query-immodules-3.0 $out/lib/gtk-3.0/3.0.0/immodules/*.so > $out/lib/gtk-3.0/3.0.0/immodules.cache
-    ''; # workaround for bug of nix-mode for Emacs */ '';
-  };
 
   meta = with stdenv.lib; {
     description = "A multi-platform toolkit for creating graphical user interfaces";


### PR DESCRIPTION
This a fix for #14019 with a different approach than #14417.
See #14417 comments for details.

**This PR triggers the rebuild of gtk+3 and gtk+2 and all the packages that depends on them.**
# Description
## GTK im module cache

GTK application need to know the input method on the system to be able to use them.
For that purpose, gtk uses a cache file (`immodule.cache`) that list all the paths to the input method library of the **matching gtk version** (this will be important later).

The cache has to be updated everytime a new input method is installed or removed on the system by running the command `gtk-query-immodules-*`.

The default cache path of gtk is in the gtk package `lib/` folder, making it incompatible with nix immutable packages.

There are a few ways to override the default `immodules.cache` file,
the default logic is (before the patch):

For gtk2
1. Look at `GTK_IM_MODULE_FILE`, if present use it
2. Look at `gtkrc` file `im_module_file` setting, if present use it
3. Use the default cache file that is inside gtk2 package `lib/gtk-2.0/2.10.0/immodules.cache`

For gtk3 (all the logic is deprecated and just for backward compatibility)
1. Look at `GTK_IM_MODULE_FILE`, if present use it
2. Look at `gtkrc` file `im_module_file` setting, if present use it
3. Use the default cache file that is inside gtk3 package `lib/gtk-3.0/3.0.0/immodules.cache`
## Problems with Nix

So the problems that we are facing with Nix are:
- default cache file location is in an immutable package -> we cannot update it, so we cannot use it
- using `GTK_IM_MODULE_FILE` to specify a ad-hoc cache file is fine, but the problem is gtk2 and gtk3 will use the same file, and every entry must point the input method library matching the gtk version
  -> we cannot make gtk2 and gtk3 work at the same time
## Solutions

The first approach (#14417) was to patch gtk3 to make it look for `GTK3_IM_MODULE_FILE` and use it if present, that allowed to have 2 different cache files, `GTK3_IM_MODULE_FILE` for gtk3 and `GTK_IM_MODULE_FILE` for gtk2.

There was a problem though, that is if a package installed via `nix-env` and not updated after a `nixos-rebuild` will still read `GTK_IM_MODULE_FILE` that point to an input method gtk2 library, that would result in the application crashing.

From there, @ttuegel suggested that we could use `NIX_PROFILES` as it was done for Qt.

That lead us to the current implementation based on `NIX_PROFILES`.

So the new logic is (after the patch):

For gtk2
1. Look at `GTK_IM_MODULE_FILE`, if present use it
2. **New**: Look at `NIX_PROFILES`, and for each entry, check if `etc/gtk-2.0/immodules.cache` exists, use if present (the last entry having the file will have priority) [1]
3. Look at the `im_module_file` setting in the `gtkrc` file, if present use it 
4. Use the default cache file that is inside gtk2 package `lib/gtk-2.0/2.10.0/immodules.cache`

For gtk3 (all the logic is deprecated and just for backward compatibility)
1. Look at `GTK_IM_MODULE_FILE`, if present use it
2. **New**: Look at `NIX_PROFILES`, and for each entry, check if `etc/gtk-3.0/immodules.cache` exists, use if present (the last entry having the file will have priority) [1]
3. Look at the `im_module_file` setting in the `gtkrc` file, if present use it (the code is here, but I am not even sure that gtk3 is looking for a gtkrc file in the first place)
4. Use the default cache file that is inside gtk3 package `lib/gtk-3.0/3.0.0/immodules.cache`

[1] Regarding `NIX_PROFILES`

The NIX_PROFILES variable is defined by reversing the list of entries in the `environment.profiles`.
If not changed, the order is `/run/current-system/sw` `/nix/var/nix/profiles/default` `$HOME/.nix-profile`, from generic to specific.

The order seems arbitrary (in the meaning that there is no mention about it in the option description) and can be changed. 
But we can consider that few users are changing it, and if they do we can just hope that they respect the specific -> generic order (`NIX_PROFILES` use the reversed list of `environment.profiles`).

Anyway, in a normal use case there shouldn't be a cache file anywhere else than `/run/current-system/sw` as it is generated by the module system.
If there is a cache in more that one location of the $NIX_PROFILE, the user did it on purpose and in my opinion, we can consider that he knows what he is doing. 
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ttuegel @taku0 @astsmtl  @abbradar 

---
- 2014-04-16: rebased on master to fix trivial conflicts in  `pkgs/development/libraries/gtk+/3.x.nix`.
