### PR TITLE
liberal-crime-squad: init at 2016-03-03

### DIFF
--- a/pkgs/games/liberal-crime-squad/default.nix
+++ b/pkgs/games/liberal-crime-squad/default.nix
@@ -1,0 +1,28 @@
+{ fetchFromGitHub, stdenv, ncurses, autoconf, automake , SDL2, SDL2_mixer }:
+
+stdenv.mkDerivation rec {
+  version = "2016-03-03";
+  name = "liberal-crime-squad-${version}";
+  src = fetchFromGitHub {
+    owner = "Kamal-Sadek";
+    repo = "Liberal-Crime-Squad";
+    rev = "39c5f167e902e33cb37b152215d67f71b9ae8269";
+    sha256 = "18s2w2570fd79y9rb7ikxls1qw29l1lbwk9n2dxxqjslbzrbvv31";
+  };
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  buildInputs = [ ncurses autoconf automake SDL2 SDL2_mixer ];
+
+  meta = with stdenv.lib; {
+    description = "A humorous politically themed ncurses game";
+    longDescription = ''
+      Welcome to Liberal Crime Squad! The Conservatives have taken the Executive, Legislative, and Judicial branches of government. Over time, the Liberal laws of this nation will erode and turn the country into a BACKWOODS YET CORPORATE NIGHTMARE. To prevent this from happening, the Liberal Crime Squad was established. The mood of the country is shifting, and we need to turn things around. Go out on the streets and indoctrinate Conservative automatons. That is, let them see their True Liberal Nature. Then arm them and send them forth to Stop Evil.
+    '';
+    homepage = https://github.com/Kamal-Sadek/Liberal-Crime-Squad;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14758,6 +14758,8 @@ in
 
   lgogdownloader = callPackage ../games/lgogdownloader { };
 
+  liberal-crime-squad = callPackage ../games/liberal-crime-squad { };
+
   lincity = callPackage ../games/lincity {};
 
   lincity_ng = callPackage ../games/lincity/ng.nix {};


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
