### PR TITLE
totem: build with gst-libav and gst-plugins-ugly

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/totem/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2 gnome3.grilo
                   clutter_gtk clutter-gst gnome3.totem-pl-parser gnome3.grilo-plugins
-                  gst_all_1.gstreamer gst_all_1.gst-plugins-base
-                  gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
+                  gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
+                  gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly gst_all_1.gst-libav
                   gnome3.libpeas pygobject3 shared_mime_info dbus_glib
                   gdk_pixbuf gnome3.defaultIconTheme librsvg gnome3.gnome_desktop
                   gnome3.gsettings_desktop_schemas makeWrapper file ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Without `gst-libav`, totem is unable to play most video files.
