### PR TITLE
partimage: correct the patch SHA256

### DIFF
--- a/pkgs/tools/backup/partimage/default.nix
+++ b/pkgs/tools/backup/partimage/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
       name = "no-SSLv2.patch";
       url = "https://projects.archlinux.org/svntogit/community.git/plain/trunk"
         + "/use-SSLv3-by-default.patch?h=packages/partimage&id=7e95d1c6614e";
-      sha256 = "1zfixa6g1nb1hqfzn2wvyvxsr38gm7908zfml2iaqnwy6iz6jd8v";
+      sha256 = "17dfqwvwnkinz8vs0l3bjjbmfx3a7y8nv3wn67gjsqpmggcpdnd6";
     })
   ];
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It was using a hash for the file itself, instead of the one for a sanitized patch - which probably worked for the author because he has prefetched / fetchurl'ed the patch earlier.
