### PR TITLE
pcsx2: disable advance SIMD instructions

### DIFF
--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
       -DCMAKE_BUILD_PO=TRUE \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX="$out" \
+      -DDISABLE_ADVANCE_SIMD=TRUE \
       -DDISABLE_PCSX2_WRAPPER=TRUE \
       -DDOC_DIR="$out/share/doc/pcsx2" \
       -DGAMEINDEX_DIR="$out/share/pcsx2" \


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

By setting `-DDISABLE_ADVANCE_SIMD=TRUE` pcsx2 will be compiled with predefined
SIMD flags instead of `-march=native`. This makes the resulting binary more
portable. Further this seems to be needed to make pcsx2 compile with gcc5.
