### PR TITLE
haskellPackages.haste-compiler: fix so that it now builds and runs

### DIFF
--- a/doc/haskell-users-guide.md
+++ b/doc/haskell-users-guide.md
@@ -647,6 +647,30 @@ command, i.e. by running:
     rm /nix/var/nix/manifests/*
     rm /nix/var/nix/channel-cache/*
 
+### How to use the Haste Haskell-to-Javascript transpiler
+
+Open a shell with `haste-compiler` and `haste-cabal-install` (you don't actually need
+`node`, but it can be useful to test stuff):
+
+    $ nix-shell -p "haskellPackages.ghcWithPackages (self: with self; [haste-cabal-install haste-compiler])" -p nodejs
+
+You may not need the following step but if `haste-boot` fails to compile all the
+packages it needs, this might do the trick
+
+    $ haste-cabal update
+
+`haste-boot` builds a set of core libraries so that they can be used from Javascript
+transpiled programs:
+
+    $ haste-boot
+
+Transpile and run a "Hello world" program:
+
+    $ echo 'module Main where main = putStrLn "Hello world"' > hello-world.hs
+    $ hastec --onexec hello-world.hs
+    $ node hello-world.js
+    Hello world
+
 ### Builds on Darwin fail with `math.h` not found
 
 Users of GHC on Darwin have occasionally reported that builds fail, because the

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -154,7 +154,6 @@ self: super: {
   gl = dontHaddock super.gl;
   groupoids = dontHaddock super.groupoids;
   hamlet = dontHaddock super.hamlet;
-  haste-compiler = dontHaddock super.haste-compiler;
   HaXml = dontHaddock super.HaXml;
   HDBC-odbc = dontHaddock super.HDBC-odbc;
   hoodle-core = dontHaddock super.hoodle-core;
@@ -964,4 +963,8 @@ self: super: {
   # https://github.com/danidiaz/pipes-transduce/issues/2
   pipes-transduce = super.pipes-transduce.override { foldl = self.foldl_1_1_6; };
 
+  # Haste stuff
+  haste-Cabal         = self.callPackage ../tools/haskell/haste/haste-Cabal.nix {};
+  haste-cabal-install = self.callPackage ../tools/haskell/haste/haste-cabal-install.nix { Cabal = self.haste-Cabal; HTTP = self.HTTP_4000_2_23; };
+  haste-compiler      = self.callPackage ../tools/haskell/haste/haste-compiler.nix { inherit overrideCabal; super-haste-compiler = super.haste-compiler; };
 }

--- a/pkgs/development/tools/haskell/haste/haste-Cabal.nix
+++ b/pkgs/development/tools/haskell/haste/haste-Cabal.nix
@@ -1,0 +1,35 @@
+# Haste requires its own patched up version of Cabal that's not on hackage
+{ mkDerivation, array, base, binary, bytestring, containers
+, deepseq, directory, extensible-exceptions, filepath, old-time
+, pretty, process, QuickCheck, regex-posix, stdenv, tasty
+, tasty-hunit, tasty-quickcheck, time, unix
+, fetchFromGitHub
+}:
+
+mkDerivation {
+  pname = "Cabal";
+  version = "1.23.0.0";
+  src = fetchFromGitHub {
+    owner = "valderman";
+    repo = "cabal";
+    rev = "a1962987ba32d5e20090830f50c6afdc78dae005";
+    sha256 = "1gjmscfsikcvgkv6zricpfxvj23wxahndm784lg9cpxrc3pn5hvh";
+  };
+  libraryHaskellDepends = [
+    array base binary bytestring containers deepseq directory filepath
+      pretty process time unix
+  ];
+  testHaskellDepends = [
+    base bytestring containers directory extensible-exceptions filepath
+      old-time pretty process QuickCheck regex-posix tasty tasty-hunit
+      tasty-quickcheck unix
+  ];
+  prePatch = ''
+    rm -rf cabal-install
+    cd Cabal
+    '';
+  doCheck = false;
+  homepage = "http://www.haskell.org/cabal/";
+  description = "A framework for packaging Haskell software";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/tools/haskell/haste/haste-cabal-install.nix
+++ b/pkgs/development/tools/haskell/haste/haste-cabal-install.nix
@@ -1,0 +1,46 @@
+# Haste requires its own patched up version of cabal-install that's not on hackage
+{ mkDerivation, array, base, bytestring, Cabal, containers
+, directory, extensible-exceptions, filepath, HTTP, mtl, network
+, network-uri, pretty, process, QuickCheck, random, regex-posix
+, stdenv, stm, tagged, tasty, tasty-hunit, tasty-quickcheck, time
+, unix, zlib
+, fetchFromGitHub
+}:
+
+mkDerivation {
+  pname = "cabal-install";
+  version = "1.23.0.0";
+  src = fetchFromGitHub {
+    owner = "valderman";
+    repo = "cabal";
+    rev = "a1962987ba32d5e20090830f50c6afdc78dae005";
+    sha256 = "1gjmscfsikcvgkv6zricpfxvj23wxahndm784lg9cpxrc3pn5hvh";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    array base bytestring Cabal containers directory filepath HTTP mtl
+    network network-uri pretty process random stm time unix zlib
+  ];
+  testHaskellDepends = [
+    array base bytestring Cabal containers directory
+    extensible-exceptions filepath HTTP mtl network network-uri pretty
+    process QuickCheck random regex-posix stm tagged tasty tasty-hunit
+    tasty-quickcheck time unix zlib
+  ];
+  prePatch = ''
+    rm -rf Cabal
+    cd cabal-install
+  '';
+  postInstall = ''
+    mkdir $out/etc
+    mv bash-completion $out/etc/bash_completion.d
+
+    # Manually added by Nix maintainer
+    mv -v $out/etc/bash_completion.d/cabal $out/etc/bash_completion.d/haste-cabal
+  '';
+  doCheck = false;
+  homepage = "http://www.haskell.org/cabal/";
+  description = "The command-line interface for Cabal and Hackage";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/tools/haskell/haste/haste-compiler.nix
+++ b/pkgs/development/tools/haskell/haste/haste-compiler.nix
@@ -1,0 +1,32 @@
+{ overrideCabal
+, super-haste-compiler
+}:
+
+overrideCabal super-haste-compiler (drv: {
+  configureFlags = [ "-f-portable" ];
+  prePatch = ''
+    # Get ghc libdir by invoking ghc and point to haste-cabal binary
+    substituteInPlace src/Haste/Environment.hs \
+      --replace \
+        'hasteGhcLibDir = hasteSysDir' \
+        'hasteGhcLibDir = head $ lines $ either (error . show) id $ unsafePerformIO $ shell $ run "ghc" ["--print-libdir"] ""' \
+      --replace \
+        'hasteCabalBinary = hasteBinDir </> "haste-cabal" ++ binaryExt' \
+        'hasteCabalBinary = "haste-cabal" ++ binaryExt'
+
+    # Don't try to download/install haste-cabal in haste-boot:
+    patch src/haste-boot.hs << EOF
+    @@ -178,10 +178,6 @@
+                             pkgSysLibDir, jsmodSysDir, pkgSysDir]
+
+           mkdir True (hasteCabalRootDir portableHaste)
+    -      case getHasteCabal cfg of
+    -        Download    -> installHasteCabal portableHaste tmpdir
+    -        Prebuilt fp -> copyHasteCabal portableHaste fp
+    -        Source mdir -> buildHasteCabal portableHaste (maybe "../cabal" id mdir)
+
+           -- Spawn off closure download in the background.
+           dir <- pwd -- use absolute path for closure to avoid dir changing race
+    EOF
+  '';
+})


### PR DESCRIPTION
cc @peti, @bennofs, @cstrahan, @ocharles
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Required adding:
haskellPackages.haste-Cabal, and
haskellPackages.haste-cabal-install
