### PR TITLE
openmw: 0.36.1 -> 0.38.0

### DIFF
--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,34 +1,23 @@
-{ stdenv, fetchFromGitHub, qt4, ogre, mygui, bullet, ffmpeg, boost, cmake, SDL2, unshield, openal, pkgconfig }:
+{ stdenv, fetchFromGitHub, qt4, openscenegraph, mygui, bullet, ffmpeg, boost, cmake, SDL2, unshield, openal, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "0.36.1";
+  version = "0.38.0";
   name = "openmw-${version}";
-
-  mygui_ = mygui.overrideDerivation (oldAttrs: {
-    name = "mygui-3.2.1";
-    version = "3.2.1";
-
-    src = fetchFromGitHub {
-      owner = "MyGUI";
-      repo = "mygui";
-      rev = "MyGUI3.2.1";
-      sha256 = "1ic4xwyh2akfpqirrbyvicc56yy2r268rzgcgx16yqb4nrldy2p0";
-    };
-  });
 
   src = fetchFromGitHub {
     owner = "OpenMW";
     repo = "openmw";
     rev = name;
-    sha256 = "0yfiilad6izmingc0nhvkvn6dpybps04xwj4k1h13ymip6awm80x";
+    sha256 = "1ssz1pa59a34v5vxiccqyvij5s38kl662p7xbc59y90y668f78y6";
   };
 
-  buildInputs = [ cmake boost ffmpeg qt4 bullet mygui_ ogre SDL2 unshield openal pkgconfig ];
+  enableParallelBuilding = true;
+
+  buildInputs = [ cmake boost ffmpeg qt4 bullet mygui openscenegraph SDL2 unshield openal pkgconfig ];
 
   meta = {
     description = "An unofficial open source engine reimplementation of the game Morrowind";
     homepage = "http://openmw.org";
     license = stdenv.lib.licenses.gpl3;
   };
-  
 }


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] openmw
  - [x] openmw-launcher
  - [x] openmw-wizard
  - [x] openmw-cs
  - [ ] openmw-essimporter (only help message tested)
  - [ ] openmw-iniimporter (only help message tested)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- I don't know why the package had a overrideDerivation for MyGUI.
- Upstream suggests using their fork of OpenSceneGraph https://github.com/OpenMW/osg. This wasn't done (yet?).
- The overrideDerivation for MyGUI is now used to remove MyGUI's dependency on Ogre, as suggested by upstream. This so the game can depend on only OSG instead of both Ogre and OSG, as there was a move from Ogre to OSG in the previous versions.
- The game requires hardware.opengl.s3tcSupport to be true. I don't know how to do that.

Upstream source for the above: https://wiki.openmw.org/index.php?title=Development_Environment_Setup#General_notes_on_dependencies
