### PR TITLE
dockerTools: remove "tarballs" attribute

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, callPackage, runCommand, writeReferencesToFile, writeText, vmTools, writeScript
-, docker, shadow, utillinux, coreutils, jshon, e2fsprogs, goPackages }:
+, docker, shadow, utillinux, coreutils, jshon, e2fsprogs, goPackages, pigz }:
 
 # WARNING: this API is unstable and may be subject to backwards-incompatible changes in the future.
   
@@ -249,7 +249,7 @@ EOF
                then mkPureLayer { inherit baseJson contents extraCommands; }
                else mkRootLayer { inherit baseJson fromImage fromImageName fromImageTag contents runAsRoot diskSize extraCommands; });
       result = runCommand "${baseName}.tar.gz" {
-        buildInputs = [ jshon ];
+        buildInputs = [ jshon pigz ];
 
         imageName = name;
         imageTag = tag;
@@ -317,7 +317,7 @@ EOF
         chmod -R a-w image
 
         echo Cooking the image
-        tar -C image -czf $out .
+        tar -C image -c . | pigz > $out
       '';
 
     in


### PR DESCRIPTION
```
    dockerTools: remove tarballs functionality

    I think the intention of this functionality was to provide a simple
    alternative to the "runAsRoot" and "contents" attributes.

    The implementation caused very slow builds of Docker images. Almost all
    of the build time was spent in IO for tar, due to tarballs being
    created, immediately extracted, then recreated. I had 30 minute builds
    on some of my images which are now down to less than 2 minutes. A couple
    of other users on #nix IRC have observed similar improvements.

    The implementation also mutated the produced Docker layers without
    changing their hashes. Using non-empty tarballs would produce images
    which got cached incorrectly in Docker.

    I have a commit which just fixes the performance problem but I opted to
    completely remove the tarball feature after I found out that it didn't
    correctly implement the Docker Image Specification due to the broken
    hashing.
```

```
    dockerTools: use pigz for final image tar

    Saves a few seconds on large images.
```

These commits came from trying to use the Docker build-support at work. My team members were annoyed at the build times, which they observed spent on IO and almost entirely in tar.

@manveru can confirm the huge improvements to build speed.

@lethalman let me know if these commits make sense. I think we can support the tarballs feature in the future but it needs to be implemented carefully due to the performance and caching impact.
