### PR TITLE
skype: Use a larger icon for the .desktop file

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skype/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skype/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
     # Fixup desktop file
     substituteInPlace skype.desktop --replace \
-      "Icon=skype.png" "Icon=$out/libexec/skype/icons/SkypeBlue_48x48.png"
+      "Icon=skype.png" "Icon=$out/libexec/skype/icons/SkypeBlue_128x128.png"
     substituteInPlace skype.desktop --replace \
       "Terminal=0" "Terminal=false"
     mkdir -p $out/share/applications


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The current skype icon used in the .desktop file looks blurry, as it quite small (48x48px). Using a larger one (128x128) looks much better (see attached screenshot).

![screenshot from 2016-04-11 14-10-29](https://cloud.githubusercontent.com/assets/123539/14426549/0663f834-fff0-11e5-9762-f41e74179d82.png)
