### PR TITLE
mygui: add withOgre argument

### DIFF
--- a/pkgs/development/libraries/mygui/default.nix
+++ b/pkgs/development/libraries/mygui/default.nix
@@ -1,9 +1,10 @@
-{stdenv, fetchFromGitHub, libX11, unzip, ogre, cmake, ois, freetype, libuuid, boost, pkgconfig}:
+{  stdenv, fetchFromGitHub, libX11, unzip, cmake, ois, freetype, libuuid,
+   boost, pkgconfig, lib, withOgre ? true, ogre ? null } :
 
 stdenv.mkDerivation rec {
   name = "mygui-${version}";
   version = "3.2.2";
-  
+
   src = fetchFromGitHub {
     owner = "MyGUI";
     repo = "mygui";
@@ -13,7 +14,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ libX11 unzip ogre cmake ois freetype libuuid boost pkgconfig ];
+
+  buildInputs = [ libX11 unzip cmake ois freetype libuuid boost pkgconfig ]
+                ++ lib.optional withOgre [ ogre ];
+
+  cmakeFlags = lib.optional (! withOgre) ["-DMYGUI_RENDERSYSTEM=1" "-DMYGUI_BUILD_DEMOS=OFF" "-DMYGUI_BUILD_TOOLS=OFF" "-DMYGUI_BUILD_PLUGINS=OFF"];
 
   meta = {
     homepage = http://mygui.info/;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [n/a] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Added a withOgre argument according to #14587 so it doesn't depend on Ogre (and indirectly on nvidia-cg-toolkit, which is nonfree)

Compiling openmw with {withOgre = false} worked (it didn't recompile, just repeated the result from the previous commit which used overrideDerivation). Building with withOgre = true (the default) wasn't done yet, but this one is supposed to be exactly the same as before.
