### PR TITLE
Shout: fix infinite loop in service configuration

### DIFF
--- a/nixos/modules/services/networking/shout.nix
+++ b/nixos/modules/services/networking/shout.nix
@@ -11,7 +11,7 @@ let
     mv config.js $out
   '';
 
-  configFile = if (cfg.configFile != null) then cfg.configFile else ''
+  finalConfigFile = if (cfg.configFile != null) then cfg.configFile else ''
     var _ = require('${pkgs.shout}/lib/node_modules/shout/node_modules/lodash')
 
     module.exports = _.merge(
@@ -48,7 +48,7 @@ in {
 
     configFile = mkOption {
       type = types.nullOr types.lines;
-      default = configFile;
+      default = null;
       description = ''
         Contents of Shout's <filename>config.js</filename> file.
 
@@ -95,7 +95,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      preStart = "ln -sf ${pkgs.writeText "config.js" configFile} ${shoutHome}/config.js";
+      preStart = "ln -sf ${pkgs.writeText "config.js" finalConfigFile} ${shoutHome}/config.js";
       script = concatStringsSep " " [
         "${pkgs.shout}/bin/shout"
         (if cfg.private then "--private" else "--public")


### PR DESCRIPTION
#14564 broke Shout service as described in #14594. This PR fixes the infinite loop bug introduced by the former PR.

Sorry for introducing this bug, I made a mistake while editing the PR... thought the `configFile.default` was a more elegant way to achieve this but didn't test it. My bad.

cc @joachifm, I use your [original suggestion](https://github.com/NixOS/nixpkgs/pull/14564#issuecomment-207994877) in this PR.
