### PR TITLE
unixODBCDrivers: fix broken module invocation

### DIFF
--- a/nixos/modules/config/unix-odbc-drivers.nix
+++ b/nixos/modules/config/unix-odbc-drivers.nix
@@ -12,7 +12,7 @@ with lib;
     environment.unixODBCDrivers = mkOption {
       type = types.listOf types.package;
       default = [];
-      example = literalExample "with pkgs.unixODBCDrivers; [ mysql psql psqlng ]";
+      example = literalExample "with pkgs.unixODBCDrivers; [ mysql psql ]";
       description = ''
         Specifies Unix ODBC drivers to be registered in
         <filename>/etc/odbcinst.ini</filename>.  You may also want to

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,36 +1,18 @@
-{fetchurl, stdenv, unixODBC, glibc, libtool, openssl, zlib, postgresql, mysql, sqlite}:
+{fetchurl, stdenv, unixODBC, glibc, libtool, openssl, zlib, postgresql, mysql, sqlite, unixODBCDrivers}:
 # each attr contains the name deriv referencing the derivation and ini which
 # evaluates to a string which can be appended to the global unix odbc ini file
 # to register the driver
 # I haven't done any parameter tweaking.. So the defaults provided here might be bad
+
+let
+
+  this = unixODBCDrivers;
+
+in
 {
-# new postgres connector library (doesn't work yet)
-  psqlng = rec {
-    deriv = stdenv.mkDerivation {
-      name = "unix-odbc-pg-odbcng-0.90.101";
-      buildInputs = [ unixODBC glibc libtool postgresql ];
-      # added -ltdl to resolve missing references `dlsym' `dlerror' `dlopen' `dlclose'
-      preConfigure="
-        export CPPFLAGS=-I${unixODBC}/include
-        export LDFLAGS='-L${unixODBC}/lib -lltdl'
-      ";
-      src = fetchurl {
-        # using my mirror because original url is https
-        # https://projects.commandprompt.com/public/odbcng/attachment/wiki/Downloads/odbcng-0.90.101.tar.gz";
-        url = http://mawercer.de/~publicrepos/odbcng-0.90.101.tar.gz;
-        sha256 = "13z3sify4z2jcil379704w0knkpflg6di4jh6zx1x2gdgzydxa1y";
-      };
-      meta = {
-          description = "unix odbc driver for postgresql";
-          homepage = https://projects.commandprompt.com/public/odbcng;
-          license = stdenv.lib.licenses.gpl2;
-      };
-    };
-    ini = "";
-  };
-# official postgres connector
- psql = rec {
-   deriv = stdenv.mkDerivation rec {
+
+  # official postgres connector
+  psql = stdenv.mkDerivation rec {
     name = "psqlodbc-09.03.0100";
     buildInputs = [ unixODBC libtool postgresql openssl ];
     preConfigure="
@@ -47,69 +29,72 @@
         homepage =  http://pgfoundry.org/projects/psqlodbc/;
         license = "LGPL";
     };
+
+    passthru.ini =
+      "[PostgreSQL]\n" +
+      "Description     = official PostgreSQL driver for Linux & Win32\n" +
+      "Driver          = ${this.psql}/lib/psqlodbcw.so\n" +
+      "Threading       = 2\n";
   };
-  ini =
-    "[PostgreSQL]\n" +
-    "Description     = official PostgreSQL driver for Linux & Win32\n" +
-    "Driver          = ${deriv}/lib/psqlodbcw.so\n" +
-    "Threading       = 2\n";
- };
-# mysql connector
- mysql = rec {
-    libraries = ["lib/libmyodbc3-3.51.12.so"];
-    deriv = stdenv.mkDerivation {
-      name = "mysql-connector-odbc-3.51.12";
-      src = fetchurl {
-        url = http://ftp.snt.utwente.nl/pub/software/mysql/Downloads/MyODBC3/mysql-connector-odbc-3.51.12.tar.gz;
-        md5 = "a484f590464fb823a8f821b2f1fd7fef";
-      };
-      configureFlags = "--disable-gui"
-         +  " --with-mysql-path=${mysql.lib} --with-unixODBC=${unixODBC}";
-      buildInputs = [ libtool zlib ];
-      inherit mysql unixODBC;
+
+  # mysql connector
+  mysql = stdenv.mkDerivation {
+    name = "mysql-connector-odbc-3.51.12";
+    src = fetchurl {
+      url = http://ftp.snt.utwente.nl/pub/software/mysql/Downloads/MyODBC3/mysql-connector-odbc-3.51.12.tar.gz;
+      md5 = "a484f590464fb823a8f821b2f1fd7fef";
     };
-    ini =
-      "[MYSQL]\n" +
-      "Description     = MySQL driver\n" +
-      "Driver          = ${deriv}/lib/libmyodbc3-3.51.12.so\n" +
-      "CPTimeout       = \n" +
-      "CPReuse         = \n" +
-      "FileUsage       = 3\n ";
- };
- sqlite = rec {
-    deriv = let version = "0.995"; in
-    stdenv.mkDerivation {
-      name = "sqlite-connector-odbc-${version}";
+    configureFlags = "--disable-gui"
+       +  " --with-mysql-path=${mysql.lib} --with-unixODBC=${unixODBC}";
+    buildInputs = [ libtool zlib ];
+    inherit mysql unixODBC;
 
-      src = fetchurl {
-        url = "http://www.ch-werner.de/sqliteodbc/sqliteodbc-${version}.tar.gz";
-        sha256 = "1r97fw6xy5w2f8c0ii7blfqfi6salvd3k8wnxpx9wqc1gxk8jnyy";
-      };
+   meta = {
+     broken = true;
+   };
 
-      buildInputs = [ sqlite ];
+   passthru.ini =
+     "[MYSQL]\n" +
+     "Description     = MySQL driver\n" +
+     "Driver          = ${this.mysql}/lib/libmyodbc3-3.51.12.so\n" +
+     "CPTimeout       = \n" +
+     "CPReuse         = \n" +
+     "FileUsage       = 3\n ";
+  };
 
-      configureFlags = "--with-sqlite3=${sqlite} --with-odbc=${unixODBC}";
+  sqlite = let version = "0.995"; in stdenv.mkDerivation {
+    name = "sqlite-connector-odbc-${version}";
 
-      # move libraries to $out/lib where they're expected to be
-      postInstall = ''
-        mkdir -p "$out/lib"
-        mv "$out"/*.so "$out/lib"
-        mv "$out"/*.la "$out/lib"
-      '';
-
-      meta = {
-        description = "ODBC driver for SQLite";
-        homepage = http://www.ch-werner.de/sqliteodbc;
-        license = stdenv.lib.licenses.bsd2;
-        platforms = stdenv.lib.platforms.linux;
-        maintainers = with stdenv.lib.maintainers; [ vlstill ];
-      };
+    src = fetchurl {
+      url = "http://www.ch-werner.de/sqliteodbc/sqliteodbc-${version}.tar.gz";
+      sha256 = "1r97fw6xy5w2f8c0ii7blfqfi6salvd3k8wnxpx9wqc1gxk8jnyy";
     };
-    ini =
+
+    buildInputs = [ sqlite ];
+
+    configureFlags = "--with-sqlite3=${sqlite} --with-odbc=${unixODBC}";
+
+    # move libraries to $out/lib where they're expected to be
+    postInstall = ''
+      mkdir -p "$out/lib"
+      mv "$out"/*.so "$out/lib"
+      mv "$out"/*.la "$out/lib"
+    '';
+
+    meta = {
+      description = "ODBC driver for SQLite";
+      homepage = http://www.ch-werner.de/sqliteodbc;
+      license = stdenv.lib.licenses.bsd2;
+      platforms = stdenv.lib.platforms.linux;
+      maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    };
+
+    passthru.ini =
       "[SQLite]\n" +
       "Description     = SQLite ODBC Driver\n" +
-      "Driver          = ${deriv}/lib/libsqlite3odbc.so\n" +
-      "Setup           = ${deriv}/lib/libsqlite3odbc.so\n" +
+      "Driver          = ${this.sqlite}/lib/libsqlite3odbc.so\n" +
+      "Setup           = ${this.sqlite}/lib/libsqlite3odbc.so\n" +
       "Threading       = 2\n";
- };
+    };
+
 }


### PR DESCRIPTION
environment.unixODBCDrivers was broken, because the type was `package`,
but the drivers were attrsets that looked like this:

```
{ ini = "…"; deriv = <derivation>; }
```

Keep the module type, but move the .inis into `passthru`.

Remove `psqlng`, which has been broken since 2008 and was
never finished.

unixODBCDrivers.mysql is broken.

Tested by inserting all available packages in `unixODBCDrivers` and
rebuilding.
