### PR TITLE
Update gup and rename gfxmonk -> timbertson

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -139,7 +139,6 @@
   garrison = "Jim Garrison <jim@garrison.cc>";
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
-  gfxmonk = "Tim Cuthbertson <tim@gfxmonk.net>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   gleber = "Gleb Peregud <gleber.p@gmail.com>";
   globin = "Robin Gloster <mail@glob.in>";
@@ -345,6 +344,7 @@
   the-kenny = "Moritz Ulrich <moritz@tarn-vedra.de>";
   theuni = "Christian Theune <ct@flyingcircus.io>";
   thoughtpolice = "Austin Seipp <aseipp@pobox.com>";
+  timbertson = "Tim Cuthbertson <tim@gfxmonk.net>";
   titanous = "Jonathan Rudenberg <jonathan@titanous.com>";
   tohl = "Tomas Hlavaty <tom@logand.com>";
   tokudan = "Daniel Frank <git@danielfrank.net>";

--- a/pkgs/development/tools/build-managers/gup/build.nix
+++ b/pkgs/development/tools/build-managers/gup/build.nix
@@ -1,5 +1,5 @@
 # NOTE: this file is copied from the upstream repository for this package.
-# Please submit any changes you make here to https://github.com/gfxmonk/gup/
+# Please submit any changes you make here to https://github.com/timbertson/gup/
 
 { stdenv, lib, python, which, pychecker ? null }:
 { src, version, meta ? {} }:

--- a/pkgs/development/tools/build-managers/gup/default.nix
+++ b/pkgs/development/tools/build-managers/gup/default.nix
@@ -5,17 +5,17 @@ let
     sha256 = "12yv0j333z6jkaaal8my3jx3k4ml9hq8ldis5zfvr8179d4xah7q";
     rev = "version-${version}";
     repo = "gup";
-    owner = "gfxmonk";
+    owner = "timbertson";
   };
 in
 import ./build.nix
   { inherit stdenv lib python which; }
   { inherit src version;
     meta = {
+      inherit (src.meta) homepage;
       description = "A better make, inspired by djb's redo";
-      homepage = https://github.com/gfxmonk/gup;
       license = stdenv.lib.licenses.lgpl2Plus;
-      maintainers = [ stdenv.lib.maintainers.gfxmonk ];
+      maintainers = [ stdenv.lib.maintainers.timbertson ];
       platforms = stdenv.lib.platforms.all;
     };
   }

--- a/pkgs/development/tools/build-managers/gup/default.nix
+++ b/pkgs/development/tools/build-managers/gup/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchgit, lib, python, which }:
+{ stdenv, fetchFromGitHub, lib, python, which }:
 let
-  version = "0.5.4";
-  src = fetchgit {
-    url = "https://github.com/gfxmonk/gup.git";
-    rev = "b3980e529c860167b48e31634d2b479fc4d10274";
-    sha256 = "bb02ba0a7f1680ed5b9a8e8c9cc42aa07016329840f397d914b94744f9ed7c85";
+  version = "0.5.5";
+  src = fetchFromGitHub {
+    sha256 = "12yv0j333z6jkaaal8my3jx3k4ml9hq8ldis5zfvr8179d4xah7q";
+    rev = "version-${version}";
+    repo = "gup";
+    owner = "gfxmonk";
   };
 in
 import ./build.nix

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15585,7 +15585,7 @@ in modules // {
     meta = {
       description = "Bringing the power of python to stream editing";
       homepage = https://github.com/timbertson/piep;
-      maintainers = with maintainers; [ gfxmonk ];
+      maintainers = with maintainers; [ timbertson ];
       license = licenses.gpl3;
     };
   };


### PR DESCRIPTION
I switched from `fetchgit` to `fetchFromGitHub`, since all gup releases seem to be properly (and consistently) tagged and it removes the need to match hashes to version numbers.

@timbertson: what do you think?
