### PR TITLE
slack: 2.0.1 -> 2.0.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "2.0.1";
+  version = "2.0.3";
 
   rpath = stdenv.lib.makeSearchPath "lib" [
     alsaLib
@@ -41,7 +41,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "12d84e61ba366cc5bac105b3f9930f2dfdd64c1e5fabbb08a6877e1c98bfb9c7";
+        sha256 = "0pp8n1w9kmh3pph5kc6akdswl3z2lqwryjg9d267wgj62mslr3cg";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
