### PR TITLE
haskellPackages.haste-compiler: fix build issue in #14581

### DIFF
--- a/pkgs/development/tools/haskell/haste/haste-compiler.nix
+++ b/pkgs/development/tools/haskell/haste/haste-compiler.nix
@@ -1,4 +1,5 @@
-{ overrideCabal
+{ mkDerivation
+, overrideCabal
 , super-haste-compiler
 }:
 


### PR DESCRIPTION
Attempts to fix build issue in https://github.com/NixOS/nixpkgs/pull/14581#issuecomment-208403431
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
