### PR TITLE
ogre: don't build with nvigia-cg and samples by default, add flags

### DIFF
--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -1,11 +1,12 @@
-{ fetchurl, stdenv
+{ fetchurl, stdenv, lib
 , cmake, mesa
 , freetype, freeimage, zziplib, randrproto, libXrandr
 , libXaw, freeglut, libXt, libpng, boost, ois
 , xproto, libX11, libXmu, libSM, pkgconfig
 , libXxf86vm, xf86vidmodeproto, libICE
 , renderproto, libXrender
-, nvidia_cg_toolkit }:
+, withNvidiaCg ? false, nvidia_cg_toolkit
+, withSamples ? false }:
 
 stdenv.mkDerivation {
   name = "ogre-1.9-hg-20160322";
@@ -15,10 +16,10 @@ stdenv.mkDerivation {
      sha256 = "0w3argjy1biaxwa3c80zxxgll67wjp8czd83p87awlcvwzdk5mz9";
   };
 
-  cmakeFlags = [ "-DOGRE_INSTALL_SAMPLES=yes" ]
-    ++ (map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
-            [ "BSP" "CG" "OCTREE" "PCZ" "PFX" ])
-    ++ (map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ]);
+  cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
+    ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
+           ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
+    ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
 
   enableParallelBuilding = true;
 
@@ -29,8 +30,7 @@ stdenv.mkDerivation {
      xproto libX11 libXmu libSM pkgconfig
      libXxf86vm xf86vidmodeproto libICE
      renderproto libXrender
-     nvidia_cg_toolkit
-   ];
+   ] ++ lib.optional withNvidiaCg nvidia_cg_toolkit;
 
   meta = {
     description = "A 3D engine";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should make `ogre` free by default, allowing us to build it and all dependent packages on Hydra. I've run `nox-review` and even built `gazebo` (but haven't run) -- haven't noticed any breakage.

cc @7c6f434c 
