### PR TITLE
git: respect $SSL_CERT_FILE

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
     ./symlinks-in-bin.patch
     ./git-sh-i18n.patch
     ./ssh-path.patch
+    ./ssl-cert-file.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/version-management/git-and-tools/git/ssl-cert-file.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssl-cert-file.patch
@@ -1,0 +1,11 @@
+diff -ru git-2.7.4-orig/http.c git-2.7.4/http.c
+--- git-2.7.4-orig/http.c	2016-03-17 21:47:59.000000000 +0100
++++ git-2.7.4/http.c	2016-04-12 11:38:33.187070848 +0200
+@@ -544,6 +544,7 @@
+ #if LIBCURL_VERSION_NUM >= 0x070908
+ 	set_from_env(&ssl_capath, "GIT_SSL_CAPATH");
+ #endif
++	set_from_env(&ssl_cainfo, "SSL_CERT_FILE");
+ 	set_from_env(&ssl_cainfo, "GIT_SSL_CAINFO");
+ 
+ 	set_from_env(&user_agent, "GIT_HTTP_USER_AGENT");


### PR DESCRIPTION
This allows git to work on systems without
`/etc/ssl/certs/ca-certificates.crt`, such as OS X, instead of failing
with "error setting certificate verify locations".
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
