### PR TITLE
iSpike: init at 2.1

### DIFF
--- a/pkgs/development/libraries/science/robotics/ispike/default.nix
+++ b/pkgs/development/libraries/science/robotics/ispike/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, boost
+}:
+
+stdenv.mkDerivation rec {
+  name = "ispike-${version}";
+  version = "2.1.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/ispike/${name}.tar.gz";
+    sha256 = "0khrxp43bi5kisr8j4lp9fl4r5marzf7b4inys62ac108sfb28lp";
+  };
+
+  buildInputs = [ cmake boost ];
+
+  meta = {
+    description = "Spiking neural interface between iCub and a spiking neural simulator";
+    homepage = https://sourceforge.net/projects/ispike/;
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nico202 ];
+  };
+
+  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2017,6 +2017,8 @@ in
   isl_0_14 = callPackage ../development/libraries/isl/0.14.1.nix { };
   isl_0_15 = callPackage ../development/libraries/isl/0.15.0.nix { };
 
+  ispike = callPackage ../development/libraries/science/robotics/ispike { };
+
   isync = callPackage ../tools/networking/isync { };
   isyncUnstable = callPackage ../tools/networking/isync/unstable.nix { };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
