### PR TITLE
selenium-server-standalone: 2.45.0 -> 2.53.0

### DIFF
--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -10,29 +10,16 @@ let
 
 in stdenv.mkDerivation rec {
   name = "selenium-server-standalone-${version}";
-  version = "2.45.0";
+  version = "2.53.0";
 
   src = fetchurl {
-    url = "http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar";
-    sha256 = "0yvmmngqff3k5si1js8v87nx3whlsx7q4p78v6ybqhsbv6idywhi";
+    url = "http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-${version}.jar";
+    sha256 = "0dp0n5chl1frjy9pcyjvpcdgv1f4dkslh2bpydpxwc5isfzqrf37";
   };
 
   unpackPhase = "true";
 
   buildInputs = [ jre makeWrapper ];
-
-  # Patch launcher binaries for opera
-  patchPhase = optionalString (arch!="") ''
-    cp $src $TMPDIR/${name}.jar
-    export src=$TMPDIR/${name}.jar
-
-    ${jdk}/bin/jar xf $src launchers/launcher-linux-amd64
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${gcc.cc}/lib/:${gcc.cc}/lib64:${xorg.libX11.out}/lib" \
-      launchers/launcher-linux-${arch}
-    ${jdk}/bin/jar uf $src launchers/launcher-linux-${arch}
-  '';
 
   installPhase = ''
     mkdir -p $out/share/lib/${name}


### PR DESCRIPTION
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @offlinehacker , I removed the patchPhase you added for Opera support, since the relevant file does not exist anymore. But I'm not sure Opera works with this patch, can you check it?
