### PR TITLE
slack: Fix 2.0.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -64,16 +64,16 @@ in stdenv.mkDerivation {
 
     for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-      patchelf --set-rpath ${rpath}:$out/share/slack $file || true
+      patchelf --set-rpath ${rpath}:$out/lib/slack $file || true
     done
 
     # Fix the symlink
     rm $out/bin/slack
-    ln -s $out/share/slack/slack $out/bin/slack
+    ln -s $out/lib/slack/slack $out/bin/slack
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/slack.desktop \
-      --replace /usr/share/slack/slack $out/share/slack/slack
+      --replace /usr/lib/slack/slack $out/lib/slack/slack
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There was an issue with paths. I am unsure how I was ever able to run 2.0.3 before (#14601), but these paths changed recently and needed to be updated.
