### PR TITLE
Fix 64-bit Wine builds

### DIFF
--- a/pkgs/misc/emulators/wine/packages.nix
+++ b/pkgs/misc/emulators/wine/packages.nix
@@ -1,4 +1,5 @@
 { system, stdenv, stdenv_32bit, lib, pkgs, pkgsi686Linux, callPackage, callPackage_i686,
+  overrideCC, wrapCCMulti, gcc49,
   pulseaudioSupport,
   wineRelease ? "stable"
 }:
@@ -16,6 +17,9 @@ in with src; {
   wine64 = callPackage ./base.nix {
     name = "wine64-${version}";
     inherit src version pulseaudioSupport;
+    # FIXME: drop this when GCC is updated to >5.3.
+    # Corresponding bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69140
+    stdenv = overrideCC stdenv gcc49;
     pkgArches = [ pkgs ];
     geckos = [ gecko64 ];
     monos =  [ mono ];
@@ -25,7 +29,8 @@ in with src; {
   wineWow = callPackage ./base.nix {
     name = "wine-wow-${version}";
     inherit src version pulseaudioSupport;
-    stdenv = stdenv_32bit;
+    # FIXME: see above.
+    stdenv = overrideCC stdenv_32bit (wrapCCMulti gcc49);
     pkgArches = [ pkgs pkgsi686Linux ];
     geckos = [ gecko32 gecko64 ];
     monos =  [ mono ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4044,18 +4044,20 @@ in
 
   gcc = gcc5;
 
-  gcc_multi =
+  wrapCCMulti = cc:
     if system == "x86_64-linux" then lowPrio (
       let
         extraBuildCommands = ''
           echo "dontMoveLib64=1" >> $out/nix-support/setup-hook
         '';
-      in wrapCCWith (callPackage ../build-support/cc-wrapper) glibc_multi extraBuildCommands (gcc.cc.override {
-        stdenv = overrideCC stdenv (wrapCCWith (callPackage ../build-support/cc-wrapper) glibc_multi "" gcc.cc);
+      in wrapCCWith (callPackage ../build-support/cc-wrapper) glibc_multi extraBuildCommands (cc.cc.override {
+        stdenv = overrideCC stdenv (wrapCCWith (callPackage ../build-support/cc-wrapper) glibc_multi "" cc.cc);
         profiledCompiler = false;
         enableMultilib = true;
       }))
-    else throw "Multilib gcc not supported on ‘${system}’";
+    else throw "Multilib ${cc.name} not supported on ‘${system}’";
+
+  gcc_multi = wrapCCMulti gcc;
 
   gcc_debug = lowPrio (wrapCC (gcc.cc.override {
     stripped = false;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes #14627. Still building but it seems to progress further already. cc @vcunat 
