### PR TITLE
pythonPackages.geeknote: 2015-03-02 -> 2015-05-11

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25447,15 +25447,15 @@ in modules // {
   };
 
   geeknote = buildPythonPackage rec {
-    version = "2015-03-02";
+    version = "2015-05-11";
     name = "geeknote-${version}";
     disabled = ! isPy27;
 
     src = pkgs.fetchFromGitHub {
       owner = "VitaliyRodnenko";
       repo = "geeknote";
-      rev = "7ea2255bb6";
-      sha256 = "0lw3m8g7r8r7dxhqih08x0i6agd201q2ig35a59rd4vygr3xqw2j";
+      rev = "8489a87d044e164edb321ba9acca8d4631de3dca";
+      sha256 = "0l16v4xnyqnsf84b1pma0jmdyxvmfwcv3sm8slrv3zv7zpmcm3lf";
     };
 
     /* build with tests fails with "Can not create application dirictory :


### PR DESCRIPTION
geeknote on master was broken for me because it was missing [this fix](https://github.com/VitaliyRodnenko/geeknote/pull/271). With the attached PR, I am able to log in.
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
