### PR TITLE
samtools: init at 1.3

### DIFF
--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, zlib, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "samtools-${version}";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://github.com/samtools/samtools/releases/download/${version}/${name}.tar.bz2";
+    sha256 = "03mnf0mhbfwhqlqfslrhfnw68s3g0fs1as354i9a584mqw1l1smy";
+  };
+
+  buildInputs = [ zlib ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Tools (written in C using htslib) for manipulating next-generation sequencing data";
+    license = licenses.mit;
+    homepage = http://www.htslib.org/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15476,6 +15476,8 @@ in
 
   plink = callPackage ../applications/science/biology/plink/default.nix { };
 
+  samtools = callPackage ../applications/science/biology/samtools/default.nix { };
+
 
   ### SCIENCE/MATH
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
