### PR TITLE
Kdevelop5 beta 2

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, cmake, pkgconfig, extra-cmake-modules, qtbase }:
+
+let
+  pname = "kdevelop-pg-qt";
+  version = "1.90.92";
+
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  
+  src = fetchurl {
+    url = "mirror://kde/unstable/${pname}/${version}/src/${name}.tar.xz";
+    sha256 = "a522adc9f77727197dcfcf7e68c3602fa0c6447d4d41156a6d954a1e22f8c5b1";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig extra-cmake-modules ];
+  
+  buildInputs = [ qtbase ];
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.ambrop72 ];
+    platforms = platforms.linux;
+    description = "Parser-generator from KDevplatform";
+    longDescription = ''
+      KDevelop-PG-Qt is the parser-generator from KDevplatform.
+      It is used for some KDevelop-languagesupport-plugins (Ruby, PHP, CSS...).
+    '';
+    homepage = https://www.kdevelop.org;
+  };
+}

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
+, qtquick1, qtquickcontrols
+, kconfig, kdeclarative, kdoctools, kiconthemes, ki18n, kitemmodels, kitemviews
+, kjobwidgets, kcmutils, kio, knewstuff, knotifyconfig, kparts, ktexteditor
+, threadweaver, kxmlgui, kwindowsystem
+, plasma-framework, krunner, kdevplatform, kdevelop-pg-qt, shared_mime_info
+, libksysguard, okteta, llvmPackages
+}:
+
+let
+  pname = "kdevelop";
+  version = "4.90.91";
+
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/unstable/${pname}/${version}/src/${name}.tar.xz";
+    sha256 = "eb807fc6425ff5454c2e4c93a46b80394cf38055770aade50593dce22731d749";
+  };
+
+  nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
+
+  buildInputs = [
+    qtquick1 qtquickcontrols
+    kconfig kdeclarative kdoctools kiconthemes ki18n kitemmodels kitemviews
+    kjobwidgets kcmutils kio knewstuff knotifyconfig kparts ktexteditor
+    threadweaver kxmlgui kwindowsystem plasma-framework krunner
+    kdevplatform kdevelop-pg-qt shared_mime_info libksysguard okteta
+    llvmPackages.llvm llvmPackages.clang-unwrapped
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/kdevelop"
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.ambrop72 ];
+    platforms = platforms.linux;
+    description = "KDE official IDE";
+    longDescription =
+      ''
+        A free, opensource IDE (Integrated Development Environment)
+        for MS Windows, Mac OsX, Linux, Solaris and FreeBSD. It is a
+        feature-full, plugin extendable IDE for C/C++ and other
+        programing languages. It is based on KDevPlatform, KDE and Qt
+        libraries and is under development since 1998.
+      '';
+    homepage = https://www.kdevelop.org;
+  };
+}

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
+, boost, subversion, apr, aprutil
+, qtscript, qtwebkit, grantlee, karchive, kconfig, kcoreaddons, kguiaddons, kiconthemes, ki18n
+, kitemmodels, kitemviews, kio, kparts, sonnet, kcmutils, knewstuff, knotifications
+, knotifyconfig, ktexteditor, threadweaver, kdeclarative, libkomparediff2 }:
+
+let
+  pname = "kdevplatform";
+  version = "4.90.91";
+
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  
+  src = fetchurl {
+    url = "mirror://kde/unstable/kdevelop/${version}/src/${name}.tar.xz";
+    sha256 = "6e4014c2073207794e48fe77a051a565da1f3d2337df495cb54ff064d767196f";
+  };
+
+  nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
+
+  propagatedBuildInputs = [  ];
+  buildInputs = [
+    boost subversion apr aprutil
+    qtscript qtwebkit grantlee karchive kconfig kcoreaddons kguiaddons kiconthemes
+    ki18n kitemmodels kitemviews kio kparts sonnet kcmutils knewstuff
+    knotifications knotifyconfig ktexteditor threadweaver kdeclarative
+    libkomparediff2
+  ];
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.ambrop72 ];
+    platforms = platforms.linux;
+    description = "KDE libraries for IDE-like programs";
+    longDescription = ''
+      A free, opensource set of libraries that can be used as a foundation for
+      IDE-like programs. It is programing-language independent, and is planned
+      to be used by programs like: KDevelop, Quanta, Kile, KTechLab ... etc."
+    '';
+    homepage = https://www.kdevelop.org;
+  };
+}

--- a/pkgs/desktops/kde-5/applications-15.12/default.nix
+++ b/pkgs/desktops/kde-5/applications-15.12/default.nix
@@ -48,6 +48,8 @@ let
     libkdcraw = callPackage ./libkdcraw.nix {};
     libkexiv2 = callPackage ./libkexiv2.nix {};
     libkipi = callPackage ./libkipi.nix {};
+    libkomparediff2 = callPackage ./libkomparediff2.nix {};
+    okteta = callPackage ./okteta.nix {};
     okular = callPackage ./okular.nix {};
     print-manager = callPackage ./print-manager.nix {};
     spectacle = callPackage ./spectacle.nix {};

--- a/pkgs/desktops/kde-5/applications-15.12/libkomparediff2.nix
+++ b/pkgs/desktops/kde-5/applications-15.12/libkomparediff2.nix
@@ -1,0 +1,25 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kconfig
+, ki18n
+, kxmlgui
+, kparts
+, kcoreaddons
+, kcodecs
+, kio
+}:
+
+kdeApp {
+  name = "libkomparediff2";
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+  buildInputs = [
+    kconfig ki18n kxmlgui kparts kcoreaddons kcodecs kio
+  ];
+  meta = {
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = [ lib.maintainers.ambrop72 ];
+  };
+}

--- a/pkgs/desktops/kde-5/applications-15.12/okteta.nix
+++ b/pkgs/desktops/kde-5/applications-15.12/okteta.nix
@@ -1,0 +1,60 @@
+{ kdeApp
+, lib
+, extra-cmake-modules
+, kdoctools
+, makeQtWrapper
+, qtscript
+, kconfig
+, kconfigwidgets
+, kbookmarks
+, kcodecs
+, kcompletion
+, kdbusaddons
+, kiconthemes
+, ki18n
+, kcmutils
+, kio
+, knewstuff
+, kparts
+, kxmlgui
+, shared_mime_info
+, qca-qt5
+}:
+
+kdeApp {
+  name = "okteta";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    makeQtWrapper
+  ];
+
+  buildInputs = [
+    qtscript
+    kconfig
+    kconfigwidgets
+    kbookmarks
+    kcodecs
+    kcompletion
+    kdbusaddons
+    kiconthemes
+    ki18n
+    kcmutils
+    kio
+    knewstuff
+    kparts
+    kxmlgui
+    shared_mime_info
+    qca-qt5
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/okteta"
+  '';
+
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.ambrop72 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15389,6 +15389,14 @@ in
 
     kdeconnect = callPackage ../applications/misc/kdeconnect { };
 
+    kdevplatform = callPackage ../applications/editors/kdevelop5/kdevplatform.nix {};
+    
+    kdevelop-pg-qt = callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix {};
+    
+    kdevelop = callPackage ../applications/editors/kdevelop5/kdevelop.nix {
+        llvmPackages = llvmPackages_38;
+    };
+    
     kile = callPackage ../applications/editors/kile/frameworks.nix { };
 
     konversation = callPackage ../applications/networking/irc/konversation/1.6.nix {


### PR DESCRIPTION
Tested this on 16.03 - starts up all right, sometimes freezes but that seems like an upstream bug. I assume it works all right within Plasma5 but since I'm using it from Xfce, I had to do some system configuration (like in the kde5 desktop-manager service) to get KDE5 apps to run in general, and also [this hack](https://github.com/NixOS/nixpkgs/issues/13715#issuecomment-209089191) to get icons to show up.
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
