### PR TITLE
dropbox: 3.14.7 -> 3.18.1

### DIFF
--- a/pkgs/applications/networking/dropbox-cli/default.nix
+++ b/pkgs/applications/networking/dropbox-cli/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
   phases = "unpackPhase installPhase";
 
   installPhase = ''
-    mkdir -p "$out/bin/"
+    mkdir -p "$out/bin/" "$out/share/applications"
+    cp data/dropbox.desktop "$out/share/applications"
     substitute "dropbox.in" "$out/bin/dropbox" \
       --replace '@PACKAGE_VERSION@' ${version} \
       --replace '@DESKTOP_FILE_DIR@' "$out/share/applications" \
@@ -24,7 +25,6 @@ stdenv.mkDerivation {
       --replace '@IMAGEDATA64@' '"too-lazy-to-fix"'
     sed -i 's:db_path = .*:db_path = "${dropboxd}":' $out/bin/dropbox
     chmod +x "$out/bin/"*
-    mv $out/bin/dropbox $out/bin/dropbox-cli
     patchShebangs "$out/bin"
   '';
 

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -20,11 +20,11 @@
 
 let
   # NOTE: When updating, please also update in current stable, as older versions stop working
-  version = "3.14.7";
+  version = "3.18.1";
   sha256 =
     {
-      "x86_64-linux" = "1pwmghpr0kyca2biysyk90kk9k6ffv4i95vs5rq96vc0zbckws6n";
-      "i686-linux" = "08yqrxh09cfd80kbiq1f2sirx9s85acij4khpklvvwrnf2x1i1zm";
+      "x86_64-linux" = "1qdahr8xzk3zrrv89335l3aa2gfgjn1ymfixj9zgipv34grkjghm";
+      "i686-linux" = "015bjkr2dwyac410i398qm1v60rqln539wcj5f25q776haycbcji";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
###### Things done

Reverted #14077 due to reasons detailed there and on the revert commit.
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jagajaga @peterhoeg @joachifm 
