### PR TITLE
Backport Slack to 16.03

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,0 +1,85 @@
+{ stdenv, fetchurl, dpkg
+, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, glib, gnome
+, libnotify, nspr, nss, systemd, xorg }:
+
+let
+
+  version = "2.0.1";
+
+  rpath = stdenv.lib.makeSearchPath "lib" [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gnome.GConf
+    gnome.gdk_pixbuf
+    gnome.gtk
+    gnome.pango
+    libnotify
+    nspr
+    nss
+    systemd
+
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+  ] + ":${stdenv.cc.cc}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/slack-desktop-${version}-amd64.deb";
+        sha256 = "12d84e61ba366cc5bac105b3f9930f2dfdd64c1e5fabbb08a6877e1c98bfb9c7";
+      }
+    else
+      throw "Slack is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "slack-${version}";
+
+  inherit src;
+
+  buildInputs = [ dpkg ];
+  unpackPhase = "true";
+  buildCommand = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm -rf $out/usr
+
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/share/slack $file || true
+    done
+
+    # Fix the symlink
+    rm $out/bin/slack
+    ln -s $out/share/slack/slack $out/bin/slack
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/slack.desktop \
+      --replace /usr/share/slack/slack $out/share/slack/slack
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Desktop client for Slack";
+    homepage = "https://slack.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -64,16 +64,16 @@ in stdenv.mkDerivation {
 
     for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
-      patchelf --set-rpath ${rpath}:$out/share/slack $file || true
+      patchelf --set-rpath ${rpath}:$out/lib/slack $file || true
     done
 
     # Fix the symlink
     rm $out/bin/slack
-    ln -s $out/share/slack/slack $out/bin/slack
+    ln -s $out/lib/slack/slack $out/bin/slack
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/slack.desktop \
-      --replace /usr/share/slack/slack $out/share/slack/slack
+      --replace /usr/lib/slack/slack $out/lib/slack/slack
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "2.0.1";
+  version = "2.0.3";
 
   rpath = stdenv.lib.makeSearchPath "lib" [
     alsaLib
@@ -41,7 +41,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "12d84e61ba366cc5bac105b3f9930f2dfdd64c1e5fabbb08a6877e1c98bfb9c7";
+        sha256 = "0pp8n1w9kmh3pph5kc6akdswl3z2lqwryjg9d267wgj62mslr3cg";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12572,6 +12572,8 @@ let
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 
+  slack = callPackage ../applications/networking/instant-messengers/slack { };
+
   spectrwm = callPackage ../applications/window-managers/spectrwm { };
 
   wlc = callPackage ../development/libraries/wlc { };


### PR DESCRIPTION
See: https://github.com/NixOS/nixpkgs/pull/14630#issuecomment-209143767
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
