### PR TITLE
nvpy: 0.9.2 -> 0.9.7

### DIFF
--- a/pkgs/applications/editors/nvpy/default.nix
+++ b/pkgs/applications/editors/nvpy/default.nix
@@ -1,12 +1,12 @@
 { pkgs, fetchurl, tk, buildPythonApplication, pythonPackages }:
 
 buildPythonApplication rec {
-  version = "0.9.2";
+  version = "0.9.7";
   name = "nvpy-${version}";
 
   src = fetchurl {
     url = "https://github.com/cpbotha/nvpy/archive/v${version}.tar.gz";
-    sha256 = "78e41b80fc5549cba8cfd92b52d6530e8dfc8e8f37e96e4b219f30c266af811d";
+    sha256 = "1rd3vlaqkg16iz6qcw6rkbq0jmyvc0843wa3brnvn1nz0kla243f";
   };
 
   buildInputs = [tk];
@@ -14,6 +14,7 @@ buildPythonApplication rec {
   propagatedBuildInputs = [
     pythonPackages.markdown
     pythonPackages.tkinter
+    pythonPackages.docutils
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- The `docutils` dep was added for rendering reStructuredText notes.
