### PR TITLE
Tahoe-LAFS improvements

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -234,6 +234,7 @@
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mog = "Matthew O'Gorman <mog-lists@rldn.net>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
+  MostAwesomeDude = "Corbin Simpson <cds@corbinsimpson.com>";
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -26,6 +26,15 @@ in
               The port on which the introducer will listen.
             '';
           };
+          tub.location = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            description = ''
+              The external location that the introducer should listen on.
+
+              If specified, the port should be included.
+            '';
+          };
           package = mkOption {
             default = pkgs.tahoelafs;
             defaultText = "pkgs.tahoelafs";
@@ -58,6 +67,18 @@ in
 
               This is the correct setting to tweak if you want Tahoe's storage
               system to listen on a different port.
+            '';
+          };
+          tub.location = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            description = ''
+              The external location that the node should listen on.
+
+              This is the setting to tweak if there are multiple interfaces
+              and you want to alter which interface Tahoe is advertising.
+
+              If specified, the port should be included.
             '';
           };
           web.port = mkOption {
@@ -144,6 +165,8 @@ in
                 [node]
                 nickname = ${settings.nickname}
                 tub.port = ${toString settings.tub.port}
+                ${optionalString (settings.tub.location != null)
+                  "tub.location = ${settings.tub.location}"}
               '';
             });
           # Actually require Tahoe, so that we will have it installed.
@@ -209,6 +232,8 @@ in
                 [node]
                 nickname = ${settings.nickname}
                 tub.port = ${toString settings.tub.port}
+                ${optionalString (settings.tub.location != null)
+                  "tub.location = ${settings.tub.location}"}
                 # This is a Twisted endpoint. Twisted Web doesn't work on
                 # non-TCP. ~ C.
                 web.port = tcp:${toString settings.web.port}

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -6,13 +6,13 @@
 # some loss of functionality because of it.
 
 pythonPackages.buildPythonApplication rec {
-  version = "1.10.2";
+  version = "1.11.0";
   name = "tahoe-lafs-${version}";
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://tahoe-lafs.org/source/tahoe-lafs/releases/allmydata-tahoe-${version}.tar.bz2";
-    sha256 = "1rvv0ik5biy7ji8pg56v0qycnggzr3k6dbg88n555nb6r4cxgmgy";
+    url = "https://tahoe-lafs.org/downloads/tahoe-lafs-${version}.tar.bz2";
+    sha256 = "0hrp87rarbmmpnrxk91s83h6irkykds3pl263dagcddbdl5inqdi";
   };
 
   patchPhase = ''
@@ -30,7 +30,6 @@ pythonPackages.buildPythonApplication rec {
     sed -i 's/"pycrypto.*"/"pycrypto"/' src/allmydata/_auto_deps.py
   '';
 
-  # Some tests want this + http://tahoe-lafs.org/source/tahoe-lafs/deps/tahoe-dep-sdists/mock-0.6.0.tar.bz2
   buildInputs = with pythonPackages; [ unzip numpy mock ];
 
   # The `backup' command requires `sqlite3'.
@@ -48,8 +47,8 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   checkPhase = ''
-    # TODO: broken with wheels
-    #${pythonPackages.python.interpreter} setup.py trial
+    # Still broken. ~ C.
+    #   trial allmydata
   '';
 
   meta = {
@@ -60,9 +59,9 @@ pythonPackages.buildPythonApplication rec {
       such a way that it remains available even when some of the peers
       are unavailable, malfunctioning, or malicious.
     '';
-    homepage = http://allmydata.org/;
+    homepage = http://tahoe-lafs.org/;
     license = [ lib.licenses.gpl2Plus /* or */ "TGPPLv1+" ];
-    maintainers = [ lib.maintainers.simons ];
+    maintainers = with lib.maintainers; [ simons MostAwesomeDude ];
     platforms = lib.platforms.gnu;  # arbitrary choice
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've deployed this update to a private grid and it runs fine.
