### PR TITLE
build-fhs-chrootenv: set PKG_CONFIG_PATH

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -57,6 +57,7 @@ let
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
     export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
     export PATH='/var/setuid-wrappers:/usr/bin:/usr/sbin'
+    export PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
     # Force compilers to look in default search paths
     export NIX_CFLAGS_COMPILE='-idirafter /usr/include'


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Currently `PKG_CONFIG_PATH` isn't set in FHS chroots rendering `pkg-config`
unusable. This patch sets it to `/usr/lib/pkgconfig`.
