### PR TITLE
mongodb: fix build (use pcre-cpp instead of  pcre)

### DIFF
--- a/pkgs/servers/nosql/mongodb/default.nix
+++ b/pkgs/servers/nosql/mongodb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, scons, boost, gperftools, pcre, snappy
+{ stdenv, fetchurl, fetchpatch, scons, boost, gperftools, pcre-cpp, snappy
 , zlib, libyamlcpp, sasl, openssl, libpcap, wiredtiger
 }:
 
@@ -20,7 +20,7 @@ let version = "3.2.1";
       "yaml"
     ] ++ optionals stdenv.isLinux [ "tcmalloc" ];
     buildInputs = [
-      sasl boost gperftools pcre snappy
+      sasl boost gperftools pcre-cpp snappy
       zlib libyamlcpp sasl openssl libpcap
     ]; # ++ optional stdenv.is64bit wiredtiger;
 


### PR DESCRIPTION
NongoDB was broken by 30845d07d8110c034156407c71d71e22f92d194a as it requires the cxx variant of pcre.
This patch updates the dependencies.

/cc @vcunat, for an example of an application that requires pcre-cpp.
