### PR TITLE
slack: fixes

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -23,6 +23,7 @@ let
     libnotify
     nspr
     nss
+    stdenv.cc.cc
     systemd
 
     xorg.libX11
@@ -57,7 +58,7 @@ in stdenv.mkDerivation {
     mkdir -p $out
     dpkg -x $src $out
     cp -av $out/usr/* $out
-    rm -rf $out/usr
+    rm -rf $out/usr $out/share/lintian
 
     # Otherwise it looks "suspicious"
     chmod -R g-w $out
@@ -73,7 +74,8 @@ in stdenv.mkDerivation {
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/slack.desktop \
-      --replace /usr/lib/slack/slack $out/lib/slack/slack
+      --replace /usr/bin/ $out/bin/ \
+      --replace /usr/share/ $out/share/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Fixes rpath to use the right derivation after closure-size changes
- Removes unused share/lintian
- Fixes slack.desktop paths
