### PR TITLE
pidgin-im-gnome-shell-extension: init at 1.0

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/default.nix
@@ -382,6 +382,8 @@ let
 
   gpaste = callPackage ./misc/gpaste { };
 
+  pidgin-im-gnome-shell-extension = callPackage ./misc/pidgin { };
+  
   gtkhtml = callPackage ./misc/gtkhtml { };
 
   pomodoro = callPackage ./misc/pomodoro { };

--- a/pkgs/desktops/gnome-3/3.18/misc/pidgin/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/misc/pidgin/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  version = "1.0";
+  basename = "pidgin-im-gnome-shell-extension";
+  name = "${basename}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "muffinmad";
+    repo = "${basename}";
+    rev = "v${version}";
+    sha256 = "0vj4w9qqx9gads24w3f6v6mfh5va28bp8rc4w7lz0vhp7njmy1yy";
+  };
+
+  buildInputs = [ glib ];
+
+  configurePhase = "";
+  buildPhase = "";
+  installPhase = ''
+    share_dir="$prefix/share"
+    extensions_dir="$share_dir/gnome-shell/extensions/pidgin@muffinmad"
+    mkdir -p "$extensions_dir"
+    mv *.js metadata.json dbus.xml gnome-shell-extension-pidgin.pot "$extensions_dir"
+
+    schemas_dir="$share_dir/gsettings-schemas/${name}/glib-2.0/schemas"
+    mkdir -p "$schemas_dir"
+    mv schemas/* "$schemas_dir" # fix Emacs syntax highlighting: */
+    ${glib}/bin/glib-compile-schemas "$schemas_dir"
+
+    locale_dir="$share_dir/locale"
+    mkdir -p "$locale_dir"
+    mv locale/* $locale_dir # fix Emacs syntax highlighting: */
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/muffinmad/pidgin-im-gnome-shell-extension;
+    description = "Make Pidgin IM conversations appear in the Gnome Shell message tray";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ DamienCassou ];
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @lethalman @NicolasPetton 
