### PR TITLE
Search path fixes

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -438,6 +438,24 @@ rec {
   overrideExisting = old: new:
     old // listToAttrs (map (attr: nameValuePair attr (attrByPath [attr] old.${attr} new)) (attrNames old));
 
+  /* Try given attributes in order. If no attributes are found, return
+     attribute list itself.
+
+     Example:
+       tryAttrs ["a" "b"] { a = 1; b = 2; }
+       => 1
+       tryAttrs ["a" "b"] { c = 3; }
+       => { c = 3; }
+  */
+  tryAttrs = allAttrs: set:
+    let tryAttrs_ = attrs:
+      if attrs == [] then set
+      else
+        (let h = head attrs; in
+         if hasAttr h set then getAttr h set
+         else tryAttrs_ (tail attrs));
+    in tryAttrs_ allAttrs;
+
 
   /*** deprecated stuff ***/
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -132,7 +132,8 @@ rec {
        makePerlPath [ pkgs.perlPackages.NetSMTP ]
        => "/nix/store/n0m1fk9c960d8wlrs62sncnadygqqc6y-perl-Net-SMTP-1.25/lib/perl5/site_perl"
   */
-  makePerlPath = makeSearchPath "lib/perl5/site_perl";
+  makePerlPath = pkgs: makeSearchPath "lib/perl5/site_perl"
+    (map (pkg: pkg.lib or (pkg.out or pkg)) pkgs);
 
   /* Dependening on the boolean `cond', return either the given string
      or the empty string. Useful to contatenate against a bigger string.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -88,6 +88,16 @@ rec {
   makeSearchPath = subDir: packages:
     concatStringsSep ":" (map (path: path + "/" + subDir) packages);
 
+  /* Construct a Unix-style search path, given trying outputs in order.
+     If no output is found, fallback to `.out` and then to the default.
+
+     Example:
+       makeSearchPathOutputs "bin" ["bin"] [ pkgs.openssl pkgs.zlib ]
+       => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-bin/bin:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/bin"
+  */
+  makeSearchPathOutputs = subDir: outputs: pkgs:
+    makeSearchPath subDir (map (lib.tryAttrs (outputs ++ ["out"])) pkgs);
+
   /* Construct a library search path (such as RPATH) containing the
      libraries for a set of packages
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -109,7 +109,8 @@ rec {
        makeBinPath ["/root" "/usr" "/usr/local"]
        => "/root/bin:/usr/bin:/usr/local/bin"
   */
-  makeBinPath = makeSearchPath "bin";
+  makeBinPath = pkgs: makeSearchPath "bin"
+    (map (pkg: pkg.bin or (pkg.out or pkg)) pkgs);
 
 
   /* Construct a perl search path (such as $PERL5LIB)

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -96,7 +96,7 @@ rec {
        => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-bin/bin:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/bin"
   */
   makeSearchPathOutputs = subDir: outputs: pkgs:
-    makeSearchPath subDir (map (lib.tryAttrs (outputs ++ ["out"])) pkgs);
+    makeSearchPath subDir (map (pkg: if pkg.outputUnspecified or false then lib.tryAttrs (outputs ++ ["out"]) pkg else pkg) pkgs);
 
   /* Construct a library search path (such as RPATH) containing the
      libraries for a set of packages
@@ -110,7 +110,7 @@ rec {
   */
   makeLibraryPath = pkgs: makeSearchPath "lib"
     # try to guess the right output of each pkg
-    (map (pkg: pkg.lib or (pkg.out or pkg)) pkgs);
+    (map (pkg: if pkg.outputUnspecified or false then pkg.lib or (pkg.out or pkg) else pkg) pkgs);
 
   /* Construct a binary search path (such as $PATH) containing the
      binaries for a set of packages.
@@ -120,7 +120,7 @@ rec {
        => "/root/bin:/usr/bin:/usr/local/bin"
   */
   makeBinPath = pkgs: makeSearchPath "bin"
-    (map (pkg: pkg.bin or (pkg.out or pkg)) pkgs);
+    (map (pkg: if pkg.outputUnspecified or false then pkg.bin or (pkg.out or pkg) else pkg) pkgs);
 
 
   /* Construct a perl search path (such as $PERL5LIB)
@@ -133,7 +133,7 @@ rec {
        => "/nix/store/n0m1fk9c960d8wlrs62sncnadygqqc6y-perl-Net-SMTP-1.25/lib/perl5/site_perl"
   */
   makePerlPath = pkgs: makeSearchPath "lib/perl5/site_perl"
-    (map (pkg: pkg.lib or (pkg.out or pkg)) pkgs);
+    (map (pkg: if pkg.outputUnspecified or false then pkg.lib or (pkg.out or pkg) else pkg) pkgs);
 
   /* Dependening on the boolean `cond', return either the given string
      or the empty string. Useful to contatenate against a bigger string.

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -102,7 +102,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       path = [ pluginsEnv ];
-      environment.PYTHONPATH = makeSearchPath pkgs.python.sitePackages [ pluginsEnv ];
+      environment.PYTHONPATH = makeSearchPathOutputs pkgs.python.sitePackages ["lib"] [ pluginsEnv ];
 
       preStart = ''
         mkdir -p "${cfg.stateDir}"

--- a/nixos/modules/services/web-servers/apache-httpd/trac.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/trac.nix
@@ -96,7 +96,7 @@ in
   globalEnvVars = singleton
     { name = "PYTHONPATH";
       value =
-        makeSearchPath "lib/${pkgs.python.libPrefix}/site-packages"
+        makeSearchPathOutputs "lib/${pkgs.python.libPrefix}/site-packages" ["lib"]
           [ pkgs.mod_python
             pkgs.pythonPackages.trac
             pkgs.setuptools

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -7,7 +7,7 @@ let
   e = pkgs.enlightenment;
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager.enlightenment;
-  GST_PLUGIN_PATH = lib.makeSearchPath "lib/gstreamer-1.0" [
+  GST_PLUGIN_PATH = lib.makeSearchPathOutputs "lib/gstreamer-1.0" ["lib"] [
     pkgs.gst_all_1.gst-plugins-base
     pkgs.gst_all_1.gst-plugins-good
     pkgs.gst_all_1.gst-plugins-bad

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -55,10 +55,10 @@ let
         version extraConfig extraPerEntryConfig extraEntries
         extraEntriesBeforeNixOS extraPrepareConfig configurationLimit copyKernels timeout
         default fsIdentifier efiSupport gfxmodeEfi gfxmodeBios;
-      path = (makeSearchPath "bin" ([
+      path = (makeBinPath ([
         pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.findutils pkgs.diffutils pkgs.btrfs-progs
         pkgs.utillinux ] ++ (if cfg.efiSupport && (cfg.version == 2) then [pkgs.efibootmgr ] else [])
-      )) + ":" + (makeSearchPath "sbin" [
+      )) + ":" + (makeSearchPathOutputs "sbin" ["bin"] [
         pkgs.mdadm pkgs.utillinux
       ]);
     });

--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -193,7 +193,7 @@ in rec {
 
     path = mkOption {
       default = [];
-      apply = ps: "${makeSearchPath "bin" ps}:${makeSearchPath "sbin" ps}";
+      apply = ps: "${makeBinPath ps}:${makeSearchPathOutputs "sbin" ["bin"] ps}";
       description = ''
         Packages added to the service's <envar>PATH</envar>
         environment variable.  Both the <filename>bin</filename>

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -42,7 +42,7 @@ let
 
       wrapProgram "$out/bin/waagent" \
           --prefix PYTHONPATH : $PYTHONPATH \
-          --prefix PATH : "${makeSearchPath "bin" runtimeDeps}"
+          --prefix PATH : "${makeBinPath runtimeDeps}"
     '';
   };
 

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -66,7 +66,7 @@ in
 
     services.xserver.displayManager.sessionCommands =
       ''
-        PATH=${makeSearchPath "bin" [ pkgs.gnugrep pkgs.which pkgs.xorg.xorgserver.out ]}:$PATH \
+        PATH=${makeBinPath [ pkgs.gnugrep pkgs.which pkgs.xorg.xorgserver.out ]}:$PATH \
           ${kernel.virtualboxGuestAdditions}/bin/VBoxClient-all
       '';
 

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl, buildEnv, makeDesktopItem, makeWrapper, zlib, glib, alsaLib
+{ stdenv, fetchurl, lib, makeDesktopItem, makeWrapper, zlib, glib, alsaLib
 , dbus, gtk, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
 , gvfs, cairo, cups, expat, libgpgerror, nspr, gconf, nss, xorg, libcap, systemd
 }:
 
 let
-  atomEnv = buildEnv {
-    name = "env-atom";
-    paths = [
-      stdenv.cc.cc zlib glib dbus gtk atk pango freetype libgnome_keyring3
-      fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
-      xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
-      xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
-      xorg.libXcursor libcap systemd
-    ];
-  };
+  atomPkgs = [
+    stdenv.cc.cc zlib glib dbus gtk atk pango freetype libgnome_keyring3
+    fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
+    xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
+    xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
+    xorg.libXcursor libcap systemd
+  ];
+  atomLib = lib.makeLibraryPath atomPkgs;
+  atomLib64 = lib.makeSearchPathOutputs "lib64" ["lib"] atomPkgs;
+
 in stdenv.mkDerivation rec {
   name = "atom-${version}";
   version = "1.6.2";
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
     name = "${name}.deb";
   };
 
-  buildInputs = [ atomEnv gvfs makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   phases = [ "installPhase" "fixupPhase" ];
 
@@ -41,10 +41,10 @@ in stdenv.mkDerivation rec {
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       $out/share/atom/resources/app/apm/bin/node
     wrapProgram $out/bin/atom \
-      --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64" \
+      --prefix "LD_LIBRARY_PATH" : "${atomLib}:${atomLib64}" \
       --prefix "PATH" : "${gvfs}/bin"
     wrapProgram $out/bin/apm \
-      --prefix "LD_LIBRARY_PATH" : "${atomEnv}/lib:${atomEnv}/lib64"
+      --prefix "LD_LIBRARY_PATH" : "${atomLib}:${atomLib64}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/guake/default.nix
+++ b/pkgs/applications/misc/guake/default.nix
@@ -16,8 +16,7 @@ gconftool-2 --recursive-unset /apps/guake
 with lib;
 
 let inputs = [ dbus gtk2 gconf python2 libutempter vte keybinder gnome3.gnome_common ];
-    pySubDir = "lib/${python2.libPrefix}/site-packages";
-    pyPath = makeSearchPath pySubDir (attrVals [ "dbus" "notify" "pyGtkGlade" "pyxdg" ] python2Packages ++ [ gnome2.gnome_python ]);
+    pyPath = makeSearchPathOutputs python2.sitePackages ["lib"] (attrVals [ "dbus" "notify" "pyGtkGlade" "pyxdg" ] python2Packages ++ [ gnome2.gnome_python ]);
  in stdenv.mkDerivation rec {
   name = "guake-${version}";
   version = "0.8.3";
@@ -63,7 +62,7 @@ let inputs = [ dbus gtk2 gconf python2 libutempter vte keybinder gnome3.gnome_co
       wrapProgram $bin \
         --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
         --prefix LD_LIBRARY_PATH : ${makeLibraryPath inputs} \
-        --prefix PYTHONPATH : "$out/${pySubDir}:${pyPath}:$PYTHONPATH"
+        --prefix PYTHONPATH : "$out/${python2.sitePackages}:${pyPath}:$PYTHONPATH"
     done
   '';
 

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -26,7 +26,7 @@ assert stdenv.isLinux;
 let
   version = "4.2.9";
 
-  binpath = stdenv.lib.makeSearchPath "bin"
+  binpath = stdenv.lib.makeBinPath
     [ cabextract
       python2Packages.python
       gettext

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
                          "-I${dbus_libs.lib}/lib/dbus-1.0/include" ];
 
   # Fix up python path so the lockfile library is on it.
-  PYTHONPATH = stdenv.lib.makeSearchPath "lib/${pythonFull.libPrefix}/site-packages" [
+  PYTHONPATH = stdenv.lib.makeSearchPathOutputs pythonFull.sitePackages ["lib"] [
     pythonPackages.curses pythonPackages.lockfile
   ];
 

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -30,7 +30,7 @@ rec {
 
     name = "zathura-${zathura_core.version}";
 
-    plugins_path = stdenv.lib.makeSearchPath "lib" [
+    plugins_path = stdenv.lib.makeLibraryPath [
       zathura_djvu
       zathura_ps
       (if useMupdf then zathura_pdf_mupdf else zathura_pdf_poppler)

--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -64,8 +64,8 @@ let
     '';
 
     patchPhase = let
-      rpaths = [ stdenv.cc.cc.lib ];
-      mkrpath = p: "${makeSearchPath "lib64" p}:${makeSearchPath "lib" p}";
+      rpaths = [ stdenv.cc.cc ];
+      mkrpath = p: "${makeSearchPathOutputs "lib64" ["lib"] p}:${makeLibraryPath p}";
     in ''
       for sofile in PepperFlash/libpepflashplayer.so \
                     libwidevinecdm.so libwidevinecdmadapter.so; do

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
       libheimdal
       libpulseaudio
       systemd
-    ] + ":" + stdenv.lib.makeSearchPath "lib64" [
+    ] + ":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] [
       stdenv.cc.cc
     ];
 

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPath "lib64" buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
 
   preFixup =
     ''

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPath "lib64" buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
 
   buildPhase = ''
     echo "Patching Vivaldi binaries"

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -36,7 +36,7 @@ let
   # relative location where the dropbox libraries are stored
   appdir = "opt/dropbox";
 
-  ldpath = stdenv.lib.makeSearchPath "lib"
+  ldpath = stdenv.lib.makeLibraryPath
     [
       dbus_libs gcc.cc glib libdrm libffi libICE libSM libX11 libXmu
       ncurses popt qtbase qtdeclarative qtwebkit zlib

--- a/pkgs/applications/networking/instant-messengers/hipchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/hipchat/default.nix
@@ -6,7 +6,7 @@ let
 
   version = "4.0.1631";
 
-  rpath = stdenv.lib.makeSearchPath "lib" [
+  rpath = stdenv.lib.makeLibraryPath [
     xorg.libXext
     xorg.libSM
     xorg.libICE

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -6,7 +6,7 @@ let
 
   version = "2.0.3";
 
-  rpath = stdenv.lib.makeSearchPath "lib" [
+  rpath = stdenv.lib.makeLibraryPath [
     alsaLib
     atk
     cairo

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
       nspr
       nss
       pango
-    ] + ":" + stdenv.lib.makeSearchPath "lib64" [
+    ] + ":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] [
       stdenv.cc.cc
     ];
 

--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -16,7 +16,7 @@ let
     else if stdenv.system == "i686-linux" then "8c23271291f40aa144bbf38ceb3cc2a05bed00759c87a65bd798cf8bb289d07a"
     else throw "Spideroak client for: ${stdenv.system} not supported!";
 
-  ldpath = stdenv.lib.makeSearchPath "lib" [
+  ldpath = stdenv.lib.makeLibraryPath [
     glib fontconfig libXext libX11 freetype libXrender
   ];
 

--- a/pkgs/applications/science/machine-learning/torch/torch-distro.nix
+++ b/pkgs/applications/science/machine-learning/torch/torch-distro.nix
@@ -73,8 +73,8 @@ let
 
           for p in $out/bin/*; do
             wrapProgram $p \
-              --suffix LD_LIBRARY_PATH ';' "${lib.makeSearchPath "lib" runtimeDeps_}" \
-              --suffix PATH ';' "${lib.makeSearchPath "bin" runtimeDeps_}" \
+              --suffix LD_LIBRARY_PATH ';' "${lib.makeLibraryPath runtimeDeps_}" \
+              --suffix PATH ';' "${lib.makeBinPath runtimeDeps_}" \
               --suffix LUA_PATH ';' "\"$LUA_PATH\"" \
               --suffix LUA_PATH ';' "\"$out/share/lua/${lua.luaversion}/?.lua;$out/share/lua/${lua.luaversion}/?/init.lua\"" \
               --suffix LUA_CPATH ';' "\"$LUA_CPATH\"" \

--- a/pkgs/applications/science/math/mathematica/9.nix
+++ b/pkgs/applications/science/math/mathematica/9.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   ldpath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPath "lib64" buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
 
   phases = "unpackPhase installPhase fixupPhase";
 

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
   ldpath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPath "lib64" buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
 
   phases = "unpackPhase installPhase fixupPhase";
 

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -5,7 +5,7 @@ let
   version = "5.36.1";
 
   searchPath =
-    stdenv.lib.makeSearchPath "bin"
+    stdenv.lib.makeBinPath
       (stdenv.lib.filter (x: x != null) [ sbcl rlwrap tk gnuplot ]);
 in
 stdenv.mkDerivation {

--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -39,7 +39,7 @@ mkDerivation rec {
 
   postInstall =
     let
-      binpath = makeSearchPath "bin" [ out rcs cvs git coreutils rsync ];
+      binpath = makeBinPath [ out rcs cvs git coreutils rsync ];
     in ''
       for prog in cvs-fast-export cvsconvert cvssync; do
         wrapProgram $out/bin/$prog \

--- a/pkgs/applications/version-management/cvs2svn/default.nix
+++ b/pkgs/applications/version-management/cvs2svn/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     python ./setup.py install --prefix=$out
     for i in bzr svn git; do
       wrapProgram $out/bin/cvs2$i \
-          --prefix PATH : "${lib.makeSearchPath "bin" [ cvs ]}" \
+          --prefix PATH : "${lib.makeBinPath [ cvs ]}" \
           --set PYTHONPATH "$(toPythonPath $out):$PYTHONPATH"
     done
   '';

--- a/pkgs/applications/version-management/reposurgeon/default.nix
+++ b/pkgs/applications/version-management/reposurgeon/default.nix
@@ -46,12 +46,12 @@ mkDerivation rec {
 
   postInstall =
     let
-      binpath = makeSearchPath "bin" (
+      binpath = makeBinPath (
         filter (x: x != null)
         [ out git bazaar cvs darcs fossil mercurial
           monotone rcs src subversion cvs_fast_export ]
       );
-      pythonpath = makeSearchPath (python27.sitePackages) (
+      pythonpath = makeSearchPathOutputs python27.sitePackages ["lib"] (
         filter (x: x != null)
         [ python27Packages.readline or null python27Packages.hglib or null ]
       );

--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     pkg_path = "$out/${name}";
     bin_path = "$out/bin";
     install_freedesktop_items = ./install_freedesktop_items.sh;
-    runtime_paths = lib.makeSearchPath "bin" [
+    runtime_paths = lib.makeBinPath [
       jre
       #git mercurial subversion # the paths are requested in configuration
       which

--- a/pkgs/desktops/kde-5/applications-15.12/ark.nix
+++ b/pkgs/desktops/kde-5/applications-15.12/ark.nix
@@ -20,7 +20,7 @@
 , zip
 }:
 
-let PATH = lib.makeSearchPath "bin" [
+let PATH = lib.makeBinPath [
       p7zip unrar unzipNLS zip
     ];
 in

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
         fi
     done
 
-    patchelf --set-rpath ${stdenv.lib.makeSearchPath "lib" [ libusb ]} \
+    patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ libusb ]} \
         "$out/share/arduino/hardware/tools/avrdude"
   '';
 

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -50,7 +50,7 @@ let
               doCheck = false;
               buildTools = drv.buildTools or [] ++ [ makeWrapper ];
               postInstall =
-                let bins = lib.makeSearchPath "bin" [ nodejs self.elm-make ];
+                let bins = lib.makeBinPath [ nodejs self.elm-make ];
                 in ''
                   wrapProgram $out/bin/elm-repl \
                     --prefix PATH ':' ${bins}

--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-fPIC" ];
 
-  LD_LIBRARY_PATH = makeSearchPath "lib" [
+  LD_LIBRARY_PATH = makeLibraryPath [
     arpack fftw fftwSinglePrec gmp libgit2 mpfr openblas openlibm
     openspecfun pcre2 suitesparse
   ];

--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -130,10 +130,10 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-fPIC" ];
 
-  LD_LIBRARY_PATH = makeSearchPath "lib" (concatLists (map (x : x.all) [
+  LD_LIBRARY_PATH = makeLibraryPath [
     arpack fftw fftwSinglePrec gmp libgit2 mpfr openblas openlibm
     openspecfun pcre2 suitesparse
-  ]));
+  ];
 
   dontStrip = true;
   dontPatchELF = true;

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -41,7 +41,7 @@ let
   hasLibraries  = lib.any (x: x.isHaskellLibrary) paths;
   # CLang is needed on Darwin for -fllvm to work:
   # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/code-generators.html
-  llvm          = lib.makeSearchPath "bin"
+  llvm          = lib.makeBinPath
                   ([ llvmPackages.llvm ]
                    ++ lib.optional stdenv.isDarwin llvmPackages.clang);
 in

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     sed_script_2 =
       "'s|^MYNDKDIR=`dirname $0`" +
       "|MYNDKDIR=`dirname $(readlink -f $(which $0))`|'";
-    runtime_paths = (lib.makeSearchPath "bin" [
+    runtime_paths = (lib.makeBinPath [
       coreutils file findutils
       gawk gnugrep gnused
       jdk

--- a/pkgs/development/mobile/androidenv/androidndk_r8e.nix
+++ b/pkgs/development/mobile/androidenv/androidndk_r8e.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     sed_script_2 =
       "'s|^MYNDKDIR=`dirname $0`" +
       "|MYNDKDIR=`dirname $(readlink -f $(which $0))`|'";
-    runtime_paths = (lib.makeSearchPath "bin" [
+    runtime_paths = (lib.makeBinPath [
       coreutils file findutils
       gawk gnugrep gnused
       jdk

--- a/pkgs/development/tools/haskell/lambdabot/default.nix
+++ b/pkgs/development/tools/haskell/lambdabot/default.nix
@@ -14,14 +14,14 @@ let allPkgs = pkgs: mueval.defaultPkgs pkgs ++ [ pkgs.lambdabot-trusted ] ++ pac
       inherit haskellPackages;
       packages = allPkgs;
     };
-    bins = lib.makeSearchPath "bin" ([ mueval'
-                                       (haskellPackages.ghcWithPackages allPkgs)
-                                       haskellPackages.unlambda
-                                       haskellPackages.brainfuck
-                                     ]
-                                     ++ lib.optional withDjinn haskellPackages.djinn
-                                     ++ lib.optional (aspell != null) aspell
-                                    );
+    bins = lib.makeBinPath ([ mueval'
+                              (haskellPackages.ghcWithPackages allPkgs)
+                              haskellPackages.unlambda
+                              haskellPackages.brainfuck
+                            ]
+                            ++ lib.optional withDjinn haskellPackages.djinn
+                            ++ lib.optional (aspell != null) aspell
+                           );
     modulesStr = lib.replaceChars ["\n"] [" "] modules;
     configStr = lib.replaceChars ["\n"] [" "] configuration;
 

--- a/pkgs/development/web/grails/default.nix
+++ b/pkgs/development/web/grails/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  binpath = stdenv.lib.makeSearchPath "bin"
+  binpath = stdenv.lib.makeBinPath
     ([ coreutils ncurses gnused gnugrep ] ++ stdenv.lib.optional (jdk != null) jdk);
 in
 stdenv.mkDerivation rec {

--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -6,7 +6,7 @@ let
 
   inherit (xorg) libXext libX11;
 
-  lpath = "${stdenv.cc.cc}/lib64:" + stdenv.lib.makeSearchPath "lib" [
+  lpath = "${stdenv.cc.cc.lib}/lib64:" + stdenv.lib.makeLibraryPath [
       zlib libmad libpng12 libcaca libXext libX11 mesa alsaLib libpulseaudio];
 
 in

--- a/pkgs/games/ue4demos/default.nix
+++ b/pkgs/games/ue4demos/default.nix
@@ -12,7 +12,7 @@ let
 
       rtdeps = stdenv.lib.makeLibraryPath
         [ xorg.libXxf86vm xorg.libXext openal ]
-        + ":" + stdenv.lib.makeSearchPath "lib64" [ stdenv.cc.cc ];
+        + ":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] [ stdenv.cc.cc ];
 
       buildCommand =
       ''

--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  binPath = stdenv.lib.makeSearchPath "bin" [ coreutils gnused bc gawk gnugrep which ];
+  binPath = stdenv.lib.makeBinPath [ coreutils gnused bc gawk gnugrep which ];
 
 in stdenv.mkDerivation rec {
   name = "cups-filters-${version}";

--- a/pkgs/os-specific/linux/fanctl/default.nix
+++ b/pkgs/os-specific/linux/fanctl/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace fanctl \
       --replace '@PATH@' \
-                '${lib.makeSearchPath "bin" [
+                '${lib.makeBinPath [
                      gnugrep gawk coreutils bridge-utils iproute dnsmasq
                      iptables kmod utillinux gnused
                      glibc # needed for getent

--- a/pkgs/os-specific/linux/pipework/default.nix
+++ b/pkgs/os-specific/linux/pipework/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp pipework $out/bin
     wrapProgram $out/bin/pipework --prefix PATH : \
-      ${lib.makeSearchPath "bin" [ bridge-utils iproute lxc openvswitch docker busybox dhcpcd dhcp ]};
+      ${lib.makeBinPath [ bridge-utils iproute lxc openvswitch docker busybox dhcpcd dhcp ]};
   '';
   meta = with lib; {
     description = "Software-Defined Networking tools for LXC";

--- a/pkgs/os-specific/linux/pm-utils/default.nix
+++ b/pkgs/os-specific/linux/pm-utils/default.nix
@@ -3,10 +3,10 @@
 
 let
 
-  binPath = stdenv.lib.makeSearchPath "bin"
+  binPath = stdenv.lib.makeBinPath
     [ coreutils gnugrep utillinux module_init_tools procps kbd dbus_tools ];
 
-  sbinPath = stdenv.lib.makeSearchPath "sbin"
+  sbinPath = stdenv.lib.makeSearchPathOutputs "sbin" ["bin"]
     [ procps ];
 
 in

--- a/pkgs/servers/mail/dspam/default.nix
+++ b/pkgs/servers/mail/dspam/default.nix
@@ -15,7 +15,7 @@ let
              ++ lib.optional withSQLite "sqlite3_drv"
              ++ lib.optional withDB "libdb4_drv"
             );
-  maintenancePath = lib.makeSearchPath "bin" [ gawk gnused gnugrep coreutils which ];
+  maintenancePath = lib.makeBinPath [ gawk gnused gnugrep coreutils which ];
 
 in stdenv.mkDerivation rec {
   name = "dspam-3.10.2";

--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  ctlpath = lib.makeSearchPath "bin" [ bash gnused gnugrep coreutils utillinux procps ];
+  ctlpath = lib.makeBinPath [ bash gnused gnugrep coreutils utillinux procps ];
 
   fakegit = writeScriptBin "git" ''
     #! ${stdenv.shell} -e

--- a/pkgs/tools/X11/bumblebee/default.nix
+++ b/pkgs/tools/X11/bumblebee/default.nix
@@ -43,7 +43,7 @@ let
 
   nvidiaLibs = lib.makeLibraryPath nvidia_x11s;
 
-  bbdPath = lib.makeSearchPath "bin" [ module_init_tools xorgserver ];
+  bbdPath = lib.makeBinPath [ module_init_tools xorgserver ];
   bbdLibs = lib.makeLibraryPath [ libX11 libXext ];
 
   xmodules = lib.concatStringsSep "," (map (x: "${x}/lib/xorg/modules") ([ xorgserver ] ++ lib.optional (!useNvidia) xf86videonouveau));

--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -5,7 +5,7 @@
 let
   major = "3.12";
   minor = "0";
-  binpath = stdenv.lib.makeSearchPath "bin" [ dvdauthor cdrdao dvdplusrwtools cdrtools ];
+  binpath = stdenv.lib.makeBinPath [ dvdauthor cdrdao dvdplusrwtools cdrtools ];
 
 in stdenv.mkDerivation rec {
   version = "${major}.${minor}";

--- a/pkgs/tools/graphics/fgallery/default.nix
+++ b/pkgs/tools/graphics/fgallery/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram "$out/share/fgallery/fgallery" \
         --set PERL5LIB "$PERL5LIB" \
-        --set PATH "${stdenv.lib.makeSearchPath "bin"
+        --set PATH "${stdenv.lib.makeBinPath
                      [ coreutils zip imagemagick pngcrush lcms2 fbida ]}"
   '';
 

--- a/pkgs/tools/graphics/imgur-screenshot/default.nix
+++ b/pkgs/tools/graphics/imgur-screenshot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, makeWrapper, curl, gnugrep, libnotify, scrot, which, xclip }:
 
-let deps = stdenv.lib.makeSearchPath "bin" [ curl gnugrep libnotify scrot which xclip ];
+let deps = stdenv.lib.makeBinPath [ curl gnugrep libnotify scrot which xclip ];
 in stdenv.mkDerivation rec {
   version = "1.5.4";
   name = "imgur-screenshot-${version}";

--- a/pkgs/tools/graphics/imgurbash2/default.nix
+++ b/pkgs/tools/graphics/imgurbash2/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cat <<EOF >$out/bin/imgurbash2
     #!${bash}/bin/bash
-    PATH=${stdenv.lib.makeSearchPath "bin" [curl xsel]}:\$PATH
+    PATH=${stdenv.lib.makeBinPath [curl xsel]}:\$PATH
     EOF
     cat imgurbash2 >> $out/bin/imgurbash2
     chmod +x $out/bin/imgurbash2

--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [ perl ];
 
-  paths = lib.makeSearchPath "bin"
+  paths = lib.makeBinPath
           ([ iw rfkill hdparm ethtool inetutils systemd module_init_tools pciutils smartmontools
              x86_energy_perf_policy gawk gnugrep coreutils
            ]

--- a/pkgs/tools/misc/xfstests/default.nix
+++ b/pkgs/tools/misc/xfstests/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
       ln -s @out@/lib/xfstests/$f $f
     done
 
-    export PATH=${lib.makeSearchPath "bin" [acl attr bc e2fsprogs fio gawk libcap_progs lvm2 perl procps psmisc su utillinux which xfsprogs]}:$PATH
+    export PATH=${lib.makeBinPath [acl attr bc e2fsprogs fio gawk libcap_progs lvm2 perl procps psmisc su utillinux which xfsprogs]}:$PATH
     exec ./check "$@"
   '';
 

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     '' else ""}
   '';
 
-  wrapperPath = with stdenv.lib; makeSearchPath "bin/" ([
+  wrapperPath = with stdenv.lib; makeBinPath ([
     coreutils
     gnused
     getopt

--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cp -a $src/config.example $out/share/doc/rofi-pass/config.example
   '';
 
-  wrapperPath = with stdenv.lib; makeSearchPath "bin/" [
+  wrapperPath = with stdenv.lib; makeBinPath [
     coreutils
     findutils
     gnugrep

--- a/pkgs/tools/security/pcsctools/default.nix
+++ b/pkgs/tools/security/pcsctools/default.nix
@@ -3,7 +3,7 @@
 , perl, pcscperl, Glib, Gtk2, Pango
 }:
 
-let deps = lib.makeSearchPath "bin" [ wget coreutils ];
+let deps = lib.makeBinPath [ wget coreutils ];
 
 in stdenv.mkDerivation rec {
   name = "pcsc-tools-1.4.25";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This mass-replaces `makeSearchPath` in tree to its multiple-outputs-aware versions. One such new generic version, `makeSearchPathOutputs`, was added. Existing functions were made aware, too.

EDIT: I've incorrectly said that I replaced `makeLibraryPath`

cc @vcunat 
