### PR TITLE
i2p: 0.9.24 -> 0.9.25

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,10 +1,10 @@
 { stdenv, procps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
 
 stdenv.mkDerivation rec {
-  name = "i2p-0.9.24";
+  name = "i2p-0.9.25";
   src = fetchurl {
     url = "https://github.com/i2p/i2p.i2p/archive/${name}.tar.gz";
-    sha256 = "0hk28cigil6ia707zb6p8n7959xg7v816bacxxlln780cc1wi830";
+    sha256 = "1lj4khln0k0b4f55hjighwn5j3cyal8flmapjmadjyj6cd5py0v8";
   };
   buildInputs = [ jdk ant gettext which ];
   patches = [ ./i2p.patch ];


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
