### PR TITLE
Fix CMake w. multiple outputs

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake libsndfile flex bison alsaLib libpulseaudio tcltk ];
 
-  NIX_LDFLAGS="-L${stdenv.cc.libc.out}/lib";
-
   meta = {
     description = "sound design, audio synthesis, and signal processing system, providing facilities for music composition and performance on all major operating systems and platforms";
     homepage = http://www.csounds.com/;

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = "-DBUILD_SHARED_LIBS=ON";
-  NIX_LDFLAGS= "-lpthread -L${stdenv.cc.libc.out}/lib";
 
   meta = with stdenv.lib; { 
     description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";

--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -58,11 +58,14 @@ stdenv.mkDerivation rec {
 
   dontUseCmakeConfigure = true;
 
-  preConfigure = optionalString (stdenv ? glibc)
+  preConfigure = with stdenv; optionalString (stdenv ? glibc)
     ''
       source $setupHook
       fixCmakeFiles .
-      substituteInPlace Modules/Platform/UnixPaths.cmake --subst-var-by glibc ${stdenv.glibc}
+      substituteInPlace Modules/Platform/UnixPaths.cmake \
+        --subst-var-by glibc_bin ${glibc.bin or glibc} \
+        --subst-var-by glibc_dev ${glibc.dev or glibc} \
+        --subst-var-by glibc_lib ${glibc.out or glibc}
     '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/cmake/search-path-3.2.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path-3.2.patch
@@ -1,31 +1,20 @@
-diff --git a/Modules/Platform/UnixPaths.cmake b/Modules/Platform/UnixPaths.cmake
-index 20ee1d1..39834e6 100644
---- a/Modules/Platform/UnixPaths.cmake
-+++ b/Modules/Platform/UnixPaths.cmake
-@@ -33,64 +33,18 @@ get_filename_component(_CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" PATH)
+diff -ru3 cmake-3.4.3/Modules/Platform/UnixPaths.cmake cmake-3.4.3-new/Modules/Platform/UnixPaths.cmake
+--- cmake-3.4.3/Modules/Platform/UnixPaths.cmake	2016-01-25 19:57:19.000000000 +0300
++++ cmake-3.4.3-new/Modules/Platform/UnixPaths.cmake	2016-04-14 00:20:08.963492213 +0300
+@@ -32,9 +32,6 @@
+ # List common installation prefixes.  These will be used for all
  # search types.
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
-   # Standard
+-  # Standard
 -  /usr/local /usr /
 -
--  # CMake install location
--  "${_CMAKE_INSTALL_DIR}"
--  )
--if (NOT CMAKE_FIND_NO_INSTALL_PREFIX)
--  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
--    # Project install destination.
--    "${CMAKE_INSTALL_PREFIX}"
--  )
--  if(CMAKE_STAGING_PREFIX)
--    list(APPEND CMAKE_SYSTEM_PREFIX_PATH
--      # User-supplied staging prefix.
--      "${CMAKE_STAGING_PREFIX}"
--    )
--  endif()
--endif()
--
--# List common include file locations not under the common prefixes.
--list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
+   # CMake install location
+   "${_CMAKE_INSTALL_DIR}"
+   )
+@@ -53,44 +50,25 @@
+ 
+ # List common include file locations not under the common prefixes.
+ list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
 -  # Windows API on Cygwin
 -  /usr/include/w32api
 -
@@ -36,9 +25,10 @@ index 20ee1d1..39834e6 100644
 -  /usr/pkg/include
 -  /opt/csw/include /opt/include
 -  /usr/openwin/include
--  )
++  @glibc_dev@/include
+   )
 -
--list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
+ list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
 -  # Windows API on Cygwin
 -  /usr/lib/w32api
 -
@@ -49,26 +39,26 @@ index 20ee1d1..39834e6 100644
 -  /usr/pkg/lib
 -  /opt/csw/lib /opt/lib
 -  /usr/openwin/lib
--  )
--
--list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
++  @glibc_lib@/lib
+   )
+ 
+ list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
 -  /usr/pkg/bin
-+  "@glibc_bin@"
++  @glibc_bin@/bin
    )
  
  list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 -  /lib /lib32 /lib64 /usr/lib /usr/lib32 /usr/lib64
-+  "@glibc_lib@/lib"
++  @glibc_lib@/lib
    )
  
  list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  "@glibc_dev@/include"
++  @glibc_dev@/include
    )
  list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  "@glibc_dev@/include"
++  @glibc_dev@/include
    )
  
  # Enable use of lib64 search path variants by default.
-

--- a/pkgs/development/tools/build-managers/cmake/search-path.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path.patch
@@ -1,8 +1,7 @@
-diff --git a/Modules/Platform/Linux.cmake b/Modules/Platform/Linux.cmake
-index fe8e003..378512c 100644
---- a/Modules/Platform/Linux.cmake
-+++ b/Modules/Platform/Linux.cmake
-@@ -36,13 +36,13 @@ else()
+diff -ru3 cmake-2.8.12.2/Modules/Platform/Linux.cmake cmake-2.8.12.2-new/Modules/Platform/Linux.cmake
+--- cmake-2.8.12.2/Modules/Platform/Linux.cmake	2014-01-16 21:15:08.000000000 +0400
++++ cmake-2.8.12.2-new/Modules/Platform/Linux.cmake	2016-04-13 22:00:32.928575740 +0300
+@@ -36,22 +36,11 @@
    # checking the platform every time.  This option is advanced enough
    # that only package maintainers should need to adjust it.  They are
    # capable of providing a setting on the command line.
@@ -10,46 +9,40 @@ index fe8e003..378512c 100644
 -    set(CMAKE_INSTALL_SO_NO_EXE 1 CACHE INTERNAL
 -      "Install .so files without execute permission.")
 -  else()
-+  # if(EXISTS "/etc/debian_version")
-+  #   set(CMAKE_INSTALL_SO_NO_EXE 1 CACHE INTERNAL
-+  #     "Install .so files without execute permission.")
-+  # else()
-     set(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL
-       "Install .so files without execute permission.")
+-    set(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL
+-      "Install .so files without execute permission.")
 -  endif()
-+  # endif()
++  set(CMAKE_INSTALL_SO_NO_EXE 0 CACHE INTERNAL
++    "Install .so files without execute permission.")
  endif()
  
  # Match multiarch library directory names.
-@@ -52,6 +52,6 @@ include(Platform/UnixPaths)
+ set(CMAKE_LIBRARY_ARCHITECTURE_REGEX "[a-z0-9_]+(-[a-z0-9_]+)?-linux-gnu[a-z0-9_]*")
  
- # Debian has lib64 paths only for compatibility so they should not be
- # searched.
+ include(Platform/UnixPaths)
+-
+-# Debian has lib64 paths only for compatibility so they should not be
+-# searched.
 -if(EXISTS "/etc/debian_version")
 -  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
 -endif()
-+# if(EXISTS "/etc/debian_version")
-+#  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
-+#endif()
-diff --git a/Modules/Platform/UnixPaths.cmake b/Modules/Platform/UnixPaths.cmake
-index ccb2663..39834e6 100644
---- a/Modules/Platform/UnixPaths.cmake
-+++ b/Modules/Platform/UnixPaths.cmake
-@@ -33,55 +33,18 @@ get_filename_component(_CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" PATH)
+diff -ru3 cmake-2.8.12.2/Modules/Platform/UnixPaths.cmake cmake-2.8.12.2-new/Modules/Platform/UnixPaths.cmake
+--- cmake-2.8.12.2/Modules/Platform/UnixPaths.cmake	2014-01-16 21:15:08.000000000 +0400
++++ cmake-2.8.12.2-new/Modules/Platform/UnixPaths.cmake	2016-04-14 00:09:10.106362636 +0300
+@@ -32,9 +32,6 @@
+ # List common installation prefixes.  These will be used for all
  # search types.
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
-   # Standard
+-  # Standard
 -  /usr/local /usr /
 -
--  # CMake install location
--  "${_CMAKE_INSTALL_DIR}"
--
--  # Project install destination.
--  "${CMAKE_INSTALL_PREFIX}"
--  )
--
--# List common include file locations not under the common prefixes.
--list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
+   # CMake install location
+   "${_CMAKE_INSTALL_DIR}"
+ 
+@@ -44,44 +41,26 @@
+ 
+ # List common include file locations not under the common prefixes.
+ list(APPEND CMAKE_SYSTEM_INCLUDE_PATH
 -  # Windows API on Cygwin
 -  /usr/include/w32api
 -
@@ -60,9 +53,10 @@ index ccb2663..39834e6 100644
 -  /usr/pkg/include
 -  /opt/csw/include /opt/include
 -  /usr/openwin/include
--  )
--
--list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
++  @glibc_dev@/include
+   )
+ 
+ list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
 -  # Windows API on Cygwin
 -  /usr/lib/w32api
 -
@@ -73,25 +67,26 @@ index ccb2663..39834e6 100644
 -  /usr/pkg/lib
 -  /opt/csw/lib /opt/lib
 -  /usr/openwin/lib
--  )
--
--list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
++  @glibc_lib@/lib
+   )
+ 
+ list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
 -  /usr/pkg/bin
-+  "@glibc@"
++  @glibc_bin@/bin
    )
  
  list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 -  /lib /usr/lib /usr/lib32 /usr/lib64
-+  "@glibc@/lib"
++  @glibc_lib@/lib
    )
  
  list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  "@glibc@/include"
++  @glibc_dev@/include
    )
  list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  "@glibc@/include"
++  @glibc_dev@/include
    )
  
  # Enable use of lib64 search path variants by default.


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Previously we have not used several CMake variables for system header, library and program prefixes. Instead we set system prefix as glibc and filled several other variables. This breaks several CMake functions, for example `find_path`, when used to find glibc header. This:

```
PROJECT(TEST)
FIND_PATH(PTHREAD_INCLUDE_DIR pthread.h)
MESSAGE(STATUS "TEST: ${PTHREAD_INCLUDE_DIR}")
```

Would not work without this patch. This also breaks `avidemux` now.

Also this updates CMake 2.8 to actually be compatible with multiple outputs, and cleanups patch a bit.
