### PR TITLE
ibus-table-with-plugins: init at 1.9.11

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table/wrapper.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildEnv, ibus-table }:
+
+# Intended usage:
+# Add something like the following in /etc/nixos/configuration.nix:
+# i18n.inputMethod = {
+#   enabled = "ibus";
+#   ibus.engines = with pkgs.ibus-engines; [
+#     (table-with-plugins [ table-others ])
+#   ];
+# };
+
+plugins:
+
+stdenv.lib.overrideDerivation ibus-table (self: {
+  name = "ibus-table-with-plugins-" + self.version;
+
+  paths = plugins;
+
+  postInstall = ''
+    for plugin in $paths
+    do
+      for t in $plugin/share/ibus-table/tables/*
+      do
+        ln -s "$t" "$out/share/ibus-table/tables"
+      done
+
+      for i in $plugin/share/ibus-table/icons/*
+      do
+        ln -s "$i" "$out/share/ibus-table/icons"
+      done
+    done
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1078,6 +1078,10 @@ in
       inherit (gnome3) dconf;
     };
 
+    table-with-plugins = callPackage ../tools/inputmethods/ibus-engines/ibus-table/wrapper.nix {
+      ibus-table = ibus-engines.table;
+    };
+
     table-others = callPackage ../tools/inputmethods/ibus-engines/ibus-table-others {
       ibus-table = ibus-engines.table;
     };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is the long-promised plugin system for `ibus-table`. The idea is that `ibus-table-others`, for example, is a plugin to `ibus-table`, and the whole thing is a plugin to `ibus`. Plugins to `ibus-table` have already been compiled using a clean `ibus-table`, and all we have to do is copy the results over.
