### PR TITLE
xdg_utils: fix replacement of which with type -P

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/xdg-mime \
       --replace "/usr/bin/file" "${file}/bin/file"
 
-    sed 's# which # type -P #g' -i "$out"/bin/*
+    sed 's#which # type -P #g' -i "$out"/bin/*
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Before, the postInstall in xdg_utils failed to properly replace all instances of `which` with `type -P` due to some errant spaces in the sed command. This fixes the problem (hopefully).

I'm lazy and I don't have a local copy of the nixpkgs repo at the moment, so I haven't really tested this yet, but I have tested a similar fix using `overrideDerivation`, so it'll probably work. ;)
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
