### PR TITLE
daemontools: init at 0.76

### DIFF
--- a/pkgs/tools/admin/daemontools/default.nix
+++ b/pkgs/tools/admin/daemontools/default.nix
@@ -1,0 +1,42 @@
+{ fetchurl, bash, glibc, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "daemontools-0.76";
+  
+  src = fetchurl {
+    url = "https://cr.yp.to/daemontools/${name}.tar.gz";
+    sha256 = "07scvw88faxkscxi91031pjkpccql6wspk4yrlnsbrrb5c0kamd5";
+  };
+  
+  configurePhase = ''
+    cd ${name}
+    
+    sed -ie '1 s_$_ -include ${glibc}/include/errno.h_' src/conf-cc
+    
+    substituteInPlace src/Makefile \
+      --replace '/bin/sh' '${bash}/bin/bash -oxtrace'
+    
+    sed -ie "s_^PATH=.*_PATH=$src/${name}/compile:''${PATH}_" src/rts.tests
+    
+    cat ${glibc}/include/errno.h
+  '';
+  
+  buildPhase = ''
+    package/compile
+  '';
+  
+  installPhase = ''
+    for cmd in $(cat package/commands); do
+      install -Dm755 "command/$cmd" "$out/bin/$cmd"
+    done
+  '';
+  
+  meta = {
+    license = stdenv.lib.licenses.publicDomain;
+    homepage = https://cr.yp.to/daemontools.html;
+    description = "A collection of tools for managing UNIX services.";
+    
+    maintainers = with stdenv.lib.maintainers; [ kevincox ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -696,6 +696,8 @@ in
   cpulimit = callPackage ../tools/misc/cpulimit { };
 
   contacts = callPackage ../tools/misc/contacts { };
+  
+  daemontools = callPackage ../tools/admin/daemontools { };
 
   datamash = callPackage ../tools/misc/datamash { };
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
