### PR TITLE
Symlink several lib/*/include paths to dev outputs

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -67,6 +67,7 @@ self =  stdenv.mkDerivation {
     postFixup = ''
       moveToOutput bin/dbus-launch "$lib"
       ln -s "$lib/bin/dbus-launch" "$out/bin/"
+      ln -s "$lib/lib/dbus-1.0" "$dev/lib"
     '';
 
     passthru = {

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation rec {
     moveToOutput "share/glib-2.0" "$dev"
     substituteInPlace "$dev/bin/gdbus-codegen" --replace "$out" "$dev"
     sed -i "$dev/bin/glib-gettextize" -e "s|^gettext_dir=.*|gettext_dir=$dev/share/glib-2.0/gettext|"
+    ln -s "$out/lib/glib-2.0" "$dev/lib"
   '';
 
   inherit doCheck;

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     moveToOutput share/gtk-2.0/demo "$docdev"
+    mkdir "$dev/lib/gtk-2.0"
+    ln -s "$out/lib/gtk-2.0/include" "$dev/lib/gtk-2.0"
   '';
 
   passthru = {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes #14673. Also fixes `dwarf-fortress-unfuck` build (and other packages which use CMake's `FindGTK2`).
