### PR TITLE
Updated imgur-screenshot to current version since the old one stopped working due to some imgur mojo

### DIFF
--- a/pkgs/tools/graphics/imgur-screenshot/default.nix
+++ b/pkgs/tools/graphics/imgur-screenshot/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchFromGitHub, makeWrapper, curl, gnugrep, libnotify, scrot, which, xclip }:
 
-let deps = stdenv.lib.makeSearchPath "bin" [ curl gnugrep libnotify scrot which xclip ];
+let deps = stdenv.lib.makeBinPath [ curl gnugrep libnotify scrot which xclip ];
 in stdenv.mkDerivation rec {
-  version = "1.5.4";
+  version = "1.7.1";
   name = "imgur-screenshot-${version}";
 
   src = fetchFromGitHub {
     owner = "jomo";
     repo = "imgur-screenshot";
     rev = "v${version}";
-    sha256 = "1ff88mvrd0b7nmrkjljs3rnprk5ih0iif92dn39s3vnag3fp9f10";
+    sha256 = "01wiqrc7xxvk7kzgw756jahwa0szb200l8030iwfcgxb679k3v0j";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
