### PR TITLE
Add gnome shell extensions

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/impatience.nix
+++ b/pkgs/desktops/gnome-3/extensions/impatience.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-impatience-${version}";
+  version = "6564c21e4caf4a6bc5fe2bf21116d7c15408d494";
+
+  src = fetchFromGitHub {
+    owner = "timbertson";
+    repo = "gnome-shell-impatience";
+    rev = version;
+    sha256 = "10zyj42i07dcvaciv47qgkcs5g5n2bpc8a0m6fsimfi0442iwlcn";
+  };
+
+  buildInputs = [
+    glib
+  ];
+
+  buildPhase = ''
+    make schemas
+  '';
+
+  installPhase = ''
+    cp -r impatience $out
+  '';
+
+  uuid = "impatience@gfxmonk.net";
+
+  meta = with stdenv.lib; {
+    description = "Speed up builtin gnome-shell animations";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aneeshusa timbertson ];
+    homepage = http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/system-monitor.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-system-monitor-${version}";
+  version = "8b31f070e9e59109d729661ced313d6a63e31787";
+
+  src = fetchFromGitHub {
+    owner = "paradoxxxzero";
+    repo = "gnome-shell-system-monitor-applet";
+    rev = version;
+    sha256 = "0fm5zb6qp53jjy2mnkb8ybxygzjwpb314giiq0ywq87hhrpch8m3";
+  };
+
+  buildInputs = [
+    glib
+  ];
+
+  buildPhase = ''
+    ${glib}/bin/glib-compile-schemas --targetdir=${uuid}/schemas ${uuid}/schemas
+  '';
+
+  installPhase = ''
+    cp -r ${uuid} $out
+  '';
+
+  uuid = "system-monitor@paradoxxx.zero.gmail.com";
+
+  meta = with stdenv.lib; {
+    description = "Display system informations in gnome shell status bar";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aneeshusa ];
+    homepage = https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/volume-mixer.nix
+++ b/pkgs/desktops/gnome-3/extensions/volume-mixer.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-volume-mixer-${version}";
+  version = "844ed80ad448855d8f6218847183a80474b523c7";
+
+  src = fetchFromGitHub {
+    owner = "aleho";
+    repo = "gnome-shell-volume-mixer";
+    rev = version;
+    sha256 = "1vcj2spbymhdi1nazvhldvcfgad23r3h7f0ihh4nianbxn7hjs9w";
+  };
+
+  buildInputs = [
+    glib
+  ];
+
+  buildPhase = ''
+    ${glib}/bin/glib-compile-schemas --targetdir=${uuid}/schemas ${uuid}/schemas
+  '';
+
+  installPhase = ''
+    cp -r ${uuid} $out
+  '';
+
+  uuid = "shell-volume-mixer@derhofbauer.at";
+
+  meta = with stdenv.lib; {
+    description = "GNOME Shell Extension allowing separate configuration of PulseAudio devices";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ aneeshusa ];
+    homepage = https://github.com/aleho/gnome-shell-volume-mixer;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/workspace-grid.nix
+++ b/pkgs/desktops/gnome-3/extensions/workspace-grid.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-workspace-grid-${version}";
+  version = "0f3a430e7d04bb5465a17c1225aab0f574426d6b";
+
+  src = fetchFromGitHub {
+    owner = "zakkak";
+    repo = "workspace-grid-gnome-shell-extension";
+    rev = version;
+    sha256 = "0503b7lmydrbblfvf9b56pv5hpmykzgyc6v8y99rckg58h2jhs69";
+  };
+
+  buildInputs = [
+    glib
+  ];
+
+  installPhase = ''
+    cp -r ${uuid} $out
+  '';
+
+  uuid = "workspace-grid@mathematical.coffee.gmail.com";
+
+  meta = with stdenv.lib; {
+    description = "Arranges workspaces in a configurable grid";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aneeshusa ];
+    homepage = https://github.com/zakkak/workspace-grid-gnome-shell-extension;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15175,6 +15175,7 @@ in
   gnome3 = self.gnome3_18 // {
     shellExtensions = {
       impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix {};
+      system-monitor = callPackage ../desktops/gnome-3/extensions/system-monitor.nix {};
       volume-mixer = callPackage ../desktops/gnome-3/extensions/volume-mixer.nix {};
       workspace-grid = callPackage ../desktops/gnome-3/extensions/workspace-grid.nix {};
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15176,6 +15176,7 @@ in
     shellExtensions = {
       impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix {};
       volume-mixer = callPackage ../desktops/gnome-3/extensions/volume-mixer.nix {};
+      workspace-grid = callPackage ../desktops/gnome-3/extensions/workspace-grid.nix {};
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15172,7 +15172,11 @@ in
 
   gnome3_18 = recurseIntoAttrs (callPackage ../desktops/gnome-3/3.18 { });
 
-  gnome3 = self.gnome3_18;
+  gnome3 = self.gnome3_18 // {
+    shellExtensions = {
+      impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix {};
+    };
+  };
 
   gnome = recurseIntoAttrs self.gnome2;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15175,6 +15175,7 @@ in
   gnome3 = self.gnome3_18 // {
     shellExtensions = {
       impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix {};
+      volume-mixer = callPackage ../desktops/gnome-3/extensions/volume-mixer.nix {};
     };
   };
 


### PR DESCRIPTION
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm running Nix on Arch, where Gnome 3.20 has been released, but https://extensions.gnome.org/ is being slow to update these so I wanted to package these extensions via Nix. Right now, I have a shell script that uses nix-build to make links to these in my `~/.local/share/gnome-shell/extensions` folder; in the future, I'm guessing these could be used via nixuser. I wasn't sure about a few things that I want feedback on:
- Is this the right location in the file structure to put these? Most of them work with a bunch of different Gnome3 versions.
-  How should I add these `top-level/all-packages.nix` file? I wasn't sure if they should have a prefix or something.
- @timbertson do you want to be listed as a maintainer for the impatience extension since you wrote it?
