### PR TITLE
texlive.combine: also patch `texmfcnf.lua`

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/combine.nix
@@ -60,21 +60,24 @@ in buildEnv {
     +
   ''
     export PATH="$out/bin:$out/share/texmf/scripts/texlive:${perl}/bin:$PATH"
-    export TEXMFCNF="$out/share/texmf/web2c"
-    export TEXMFDIST="$out/share/texmf"
-    export TEXMFSYSCONFIG="$out/share/texmf-config"
-    export TEXMFSYSVAR="$out/share/texmf-var"
     export PERL5LIB="$out/share/texmf/scripts/texlive"
   '' +
-    # patch texmf-dist -> texmf to be sure
-    # TODO: cleanup the search paths incl. SELFAUTOLOC, and perhaps do lua actions?
+    # patch texmf-{dist,local} -> texmf to be sure
+    # TODO: perhaps do lua actions?
     # tried inspiration from install-tl, sub do_texmf_cnf
   ''
     (
       cd ./share/texmf/web2c/
       local cnfOrig="$(realpath ./texmf.cnf)"
       rm ./texmf.cnf
-      cat "$cnfOrig" | sed 's/texmf-dist/texmf/g' > ./texmf.cnf
+      sed \
+        -e 's,texmf-dist,texmf,g' \
+        -e 's,texmf-local,texmf,g' \
+        -e "s,\$SELFAUTOLOC,$out,g" \
+        -e "s,\$SELFAUTODIR,$out/share,g" \
+        -e "s,\$SELFAUTOPARENT,$out/share,g" \
+        -e "s,\$SELFAUTOGRANDPARENT,$out/share,g" \
+        "$cnfOrig" > ./texmf.cnf
 
       rm updmap.cfg
     )
@@ -112,10 +115,6 @@ in buildEnv {
       rm "$link"
       makeWrapper "$target" "$link" \
         --prefix PATH : "$out/bin:${perl}/bin" \
-        --set TEXMFCNF "$out/share/texmf/web2c" \
-        --set TEXMFDIST "$out/share/texmf" \
-        --set TEXMFSYSCONFIG "$out/share/texmf-config" \
-        --set TEXMFSYSVAR "$out/share/texmf-var" \
         --prefix PERL5LIB : "$out/share/texmf/scripts/texlive"
 
       # avoid using non-nix shebang in $target by calling interpreter

--- a/pkgs/tools/typesetting/tex/texlive-new/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/combine.nix
@@ -79,6 +79,19 @@ in buildEnv {
         -e "s,\$SELFAUTOGRANDPARENT,$out/share,g" \
         "$cnfOrig" > ./texmf.cnf
 
+      local cnfLuaOrig="$(realpath ./texmfcnf.lua)"
+      rm ./texmfcnf.lua
+      sed \
+        -e 's,texmf-dist,texmf,g' \
+        -e 's,texmf-local,texmf,g' \
+        -e "s,\(TEXMFLOCAL[ ]*=[ ]*\)[^\,]*,\1\"$out/share/texmf\",g" \
+        -e "s,\$SELFAUTOLOC,$out,g" \
+        -e "s,selfautodir:/,$out/share/,g" \
+        -e "s,selfautodir:,$out/share/,g" \
+        -e "s,selfautoparent:/,$out/share/,g" \
+        -e "s,selfautoparent:,$out/share/,g" \
+        "$cnfLuaOrig" > ./texmfcnf.lua
+
       rm updmap.cfg
     )
   '' +


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #14463.

Based on @abbradar "texlive.combine: patch paths into texmf.cnf" yet unmerged
patch.

Tested with #14463 test case using environment:

```
 nix-shell --pure -E 'with import <nixpkgs> { }; stdenv.mkDerivation {name = "otf"; buildInputs = [pandoc (texlive.combine { inherit (texlive) scheme-context; })];}'
```

context now runs properly.
