### PR TITLE
syncthing service: support running from systemd --user instance

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -7,6 +7,21 @@ let
   cfg = config.services.syncthing;
   defaultUser = "syncthing";
 
+  header = {
+    description = "Syncthing service";
+    environment = {
+      STNORESTART = "yes";
+      STNOUPGRADE = "yes";
+      inherit (cfg) all_proxy;
+    } // config.networking.proxy.envVars;
+  };
+
+  service = {
+    Restart = "on-failure";
+    SuccessExitStatus = "2 3 4";
+    RestartForceExitStatus="3 4";
+  };
+
 in
 
 {
@@ -17,22 +32,35 @@ in
 
     services.syncthing = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
+      enable = mkEnableOption {
         description = ''
-          Whether to enable the Syncthing, self-hosted open-source alternative
-          to Dropbox and BittorrentSync. Initial interface will be
+          Whether to enable Syncthing - the self-hosted open-source alternative
+          to Dropbox and Bittorrent Sync. Initial interface will be
           available on http://127.0.0.1:8384/.
         '';
+      };
+
+      systemService = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Auto launch Syncthing as a system service.";
       };
 
       user = mkOption {
         type = types.string;
         default = defaultUser;
         description = ''
-          Syncthing will be run under this user (user must exist,
-          this can be your user name).
+          Syncthing will be run under this user (user will be created if it doesn't exist.
+          This can be your user name).
+        '';
+      };
+
+      group = mkOption {
+        type = types.string;
+        default = "nogroup";
+        description = ''
+          Syncthing will be run under this group (group will not be created if it doesn't exist.
+          This can be your user name).
         '';
       };
 
@@ -64,10 +92,7 @@ in
           Syncthing package to use.
         '';
       };
-
-
     };
-
   };
 
 
@@ -77,7 +102,7 @@ in
 
     users = mkIf (cfg.user == defaultUser) {
       extraUsers."${defaultUser}" =
-        { group = defaultUser;
+        { group = cfg.group;
           home  = cfg.dataDir;
           createHome = true;
           uid = config.ids.uids.syncthing;
@@ -101,17 +126,30 @@ in
 
         serviceConfig = {
           User  = cfg.user;
-          Group = optionalString (cfg.user == defaultUser) defaultUser;
-          PermissionsStartOnly = true;
-          Restart = "on-failure";
-          ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser -home=${cfg.dataDir}";
-          SuccessExitStatus = "2 3 4";
-          RestartForceExitStatus="3 4";
-        };
-      };
+          Group = cfg.group;
+    };
 
     environment.systemPackages = [ cfg.package ];
 
-  };
+    systemd.services = mkIf cfg.systemService {
+      syncthing = header // {
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = service // {
+          User = cfg.user;
+          Group = cfg.group;
+          PermissionsStartOnly = true;
+          ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser -home=${cfg.dataDir}";
+        };
+      };
+    };
 
+    systemd.user.services =  {
+      syncthing = header // {
+        serviceConfig = service // {
+          ExecStart = "${pkgs.syncthing}/bin/syncthing -no-browser";
+        };
+      };
+    };
+  };
 }


### PR DESCRIPTION
This PR only covers the systemd --user instance changes from #14489.
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @rnhmjoj, @peti
