### PR TITLE
pytestdjango: init at 2.9.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4202,7 +4202,7 @@ in modules // {
     version = "2.9.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-django/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-django/${name}.tar.gz";
       sha256 = "1mmc7zsz3dlhs6sx4sppkj1vgshabi362r1a8b8wpj1qfximpqcb";
     };
     

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4196,6 +4196,28 @@ in modules // {
       description = "pytest plugin with mechanisms for caching across test runs";
     };
   };
+  
+  pytestdjango = buildPythonPackage rec {
+    name = "pytest-django-${version}";
+    version = "2.9.1";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/p/pytest-django/${name}.tar.gz";
+      sha256 = "1mmc7zsz3dlhs6sx4sppkj1vgshabi362r1a8b8wpj1qfximpqcb";
+    };
+    
+    # doing this to allow depending packages to find
+    # pytest's binaries
+    pytest = self.pytest;
+
+    propagatedBuildInputs = with self; [ django pytest setuptools_scm_18 ];
+
+    meta = {
+      description = "py.test plugin for testing of Django applications";
+      homepage = http://pytest-django.readthedocs.org/en/latest/;
+      license = licenses.bsd3;
+    };
+  };
 
   pytestflakes = buildPythonPackage rec {
     name = "pytest-flakes-${version}";
@@ -19677,6 +19699,16 @@ in modules // {
       description = "Handles managing your python package versions in scm metadata";
       license = licenses.mit;
       maintainers = with maintainers; [ jgeerds ];
+    };
+  };
+
+  setuptools_scm_18 = self.setuptools_scm.override rec {
+    name = "setuptools_scm-${version}";
+    version = "1.8.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/s/setuptools_scm/${name}.tar.bz2";
+      sha256 = "00p60v2yfqy1r58pjcx9wy6dvqd7wkpfs5z1dzwf7y75c1g3dgyx";
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19705,6 +19705,9 @@ in modules // {
   setuptools_scm_18 = self.setuptools_scm.override rec {
     name = "setuptools_scm-${version}";
     version = "1.8.0";
+    
+    # tests fail: ImportError: cannot import name 'find_files'
+    disabled = isPy35;
 
     src = pkgs.fetchurl {
       url = "https://pypi.python.org/packages/source/s/setuptools_scm/${name}.tar.bz2";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
