### PR TITLE
tint2: 0.12.7 -> 0.12.9

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,37 +1,41 @@
-{ stdenv, fetchFromGitLab, pkgconfig, cmake, pango, cairo, glib, imlib2, libXinerama
-, libXrender, libXcomposite, libXdamage, libX11, libXrandr, gtk, libpthreadstubs
-, libXdmcp, librsvg, libstartup_notification
+{ stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, pango, cairo, glib
+, pcre , imlib2, libXinerama , libXrender, libXcomposite, libXdamage, libX11
+, libXrandr, gtk, libpthreadstubs , libXdmcp, librsvg
+, libstartup_notification, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.12.7";
+  version = "0.12.9";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "01wb1yy7zfi01fl34yzpn1d30fykcf8ivmdlynnxp5znqrdsqm2r";
+    sha256 = "17n3yssqiwxqrwsxypzw8skwzxm2540ikbyx7kfxv2gqlbjx5y6q";
   };
 
   enableParallelBuilding = true;
 
-  buildInputs = [ pkgconfig cmake pango cairo glib imlib2 libXinerama
-    libXrender libXcomposite libXdamage libX11 libXrandr gtk libpthreadstubs
-    libXdmcp librsvg libstartup_notification
-  ];
+  nativeBuildInputs = [ pkgconfig cmake gettext wrapGAppsHook ];
 
-  preConfigure =
-    ''
-      substituteInPlace CMakeLists.txt --replace /etc $out/etc
-    '';
+  buildInputs = [ pango cairo glib pcre imlib2 libXinerama libXrender
+    libXcomposite libXdamage libX11 libXrandr gtk libpthreadstubs libXdmcp
+    librsvg libstartup_notification ];
 
-  prePatch =
-    ''
-      substituteInPlace ./src/tint2conf/properties.c --replace /usr/share/ /run/current-system/sw/share/
-      substituteInPlace ./src/launcher/apps-common.c --replace /usr/share/ /run/current-system/sw/share/
-      substituteInPlace ./src/launcher/icon-theme-common.c --replace /usr/share/ /run/current-system/sw/share/
-    '';
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace /etc $out/etc
+  '';
+
+  prePatch = ''
+    for f in ./src/tint2conf/properties.c \
+             ./src/launcher/apps-common.c \
+             ./src/launcher/icon-theme-common.c \
+             ./themes/*tint2rc
+    do
+      substituteInPlace $f --replace /usr/share/ /run/current-system/sw/share/
+    done
+  '';
 
   meta = {
     homepage = https://gitlab.com/o9000/tint2;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
