### PR TITLE
devpi-client: add missing python libraries

### DIFF
--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -9,12 +9,15 @@ pythonPackages.buildPythonApplication rec {
     md5= "bfc8cd768f983fd0585c347bca00c8bb";
   };
 
-  buildInputs = [ pythonPackages.tox pythonPackages.check-manifest pythonPackages.devpi-common pythonPackages.pkginfo ];
+  buildInputs = [ pythonPackages.tox pythonPackages.check-manifest pythonPackages.pkginfo ];
+
+  propagatedBuildInputs = [ pythonPackages.py pythonPackages.devpi-common ];
+
   meta = {
     homepage = http://doc.devpi.net;
     description = "Github-style pypi index server and packaging meta tool";
     license = stdenv.lib.licenses.mit;
-    maintainers = [stdenv.lib.maintainers.lewo];
+    maintainers = with stdenv.lib.maintainers; [ lewo makefu ];
 
   };
 }


### PR DESCRIPTION
devpi-client does not work due to two missing dependencies:
1. **py**
2. **devpi-common** (which is currently only a build dep, not being propagated)

adding these deps to propagatedBuildInputs makes the executable buildable again.
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` - devpi-client does not have dependencies
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
