### PR TITLE
Search path fixes, v2

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -438,6 +438,18 @@ rec {
   overrideExisting = old: new:
     old // listToAttrs (map (attr: nameValuePair attr (attrByPath [attr] old.${attr} new)) (attrNames old));
 
+  /* Get a package output.
+     If no output is found, fallback to `.out` and then to the default.
+
+     Example:
+       getOutput "dev" pkgs.openssl
+       => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-dev"
+  */
+  getOutput = output: pkg:
+    if pkg.outputUnspecified or false
+      then pkg.${output} or pkg.out or pkg
+      else pkg;
+
 
   /*** deprecated stuff ***/
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -450,6 +450,10 @@ rec {
       then pkg.${output} or pkg.out or pkg
       else pkg;
 
+  getBin = getOutput "bin";
+  getLib = getOutput "lib";
+  getDev = getOutput "dev";
+
 
   /*** deprecated stuff ***/
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -438,24 +438,6 @@ rec {
   overrideExisting = old: new:
     old // listToAttrs (map (attr: nameValuePair attr (attrByPath [attr] old.${attr} new)) (attrNames old));
 
-  /* Try given attributes in order. If no attributes are found, return
-     attribute list itself.
-
-     Example:
-       tryAttrs ["a" "b"] { a = 1; b = 2; }
-       => 1
-       tryAttrs ["a" "b"] { c = 3; }
-       => { c = 3; }
-  */
-  tryAttrs = allAttrs: set:
-    let tryAttrs_ = attrs:
-      if attrs == [] then set
-      else
-        (let h = head attrs; in
-         if hasAttr h set then getAttr h set
-         else tryAttrs_ (tail attrs));
-    in tryAttrs_ allAttrs;
-
 
   /*** deprecated stuff ***/
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -107,9 +107,7 @@ rec {
        makeLibraryPath [ pkgs.openssl pkgs.zlib ]
        => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r/lib:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/lib"
   */
-  makeLibraryPath = pkgs: makeSearchPath "lib"
-    # try to guess the right output of each pkg
-    (map (pkg: if pkg.outputUnspecified or false then pkg.lib or (pkg.out or pkg) else pkg) pkgs);
+  makeLibraryPath = makeSearchPathOutput "lib" "lib";
 
   /* Construct a binary search path (such as $PATH) containing the
      binaries for a set of packages.
@@ -118,8 +116,7 @@ rec {
        makeBinPath ["/root" "/usr" "/usr/local"]
        => "/root/bin:/usr/bin:/usr/local/bin"
   */
-  makeBinPath = pkgs: makeSearchPath "bin"
-    (map (pkg: if pkg.outputUnspecified or false then pkg.bin or (pkg.out or pkg) else pkg) pkgs);
+  makeBinPath = makeSearchPathOutput "bin" "bin";
 
 
   /* Construct a perl search path (such as $PERL5LIB)
@@ -131,8 +128,7 @@ rec {
        makePerlPath [ pkgs.perlPackages.NetSMTP ]
        => "/nix/store/n0m1fk9c960d8wlrs62sncnadygqqc6y-perl-Net-SMTP-1.25/lib/perl5/site_perl"
   */
-  makePerlPath = pkgs: makeSearchPath "lib/perl5/site_perl"
-    (map (pkg: if pkg.outputUnspecified or false then pkg.lib or (pkg.out or pkg) else pkg) pkgs);
+  makePerlPath = makeSearchPathOutput "lib" "lib/perl5/site_perl";
 
   /* Dependening on the boolean `cond', return either the given string
      or the empty string. Useful to contatenate against a bigger string.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -88,15 +88,14 @@ rec {
   makeSearchPath = subDir: packages:
     concatStringsSep ":" (map (path: path + "/" + subDir) packages);
 
-  /* Construct a Unix-style search path, given trying outputs in order.
+  /* Construct a Unix-style search path, using given package output.
      If no output is found, fallback to `.out` and then to the default.
 
      Example:
-       makeSearchPathOutputs "bin" ["bin"] [ pkgs.openssl pkgs.zlib ]
-       => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-bin/bin:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/bin"
+       makeSearchPathOutput "dev" "bin" [ pkgs.openssl pkgs.zlib ]
+       => "/nix/store/9rz8gxhzf8sw4kf2j2f1grr49w8zx5vj-openssl-1.0.1r-dev/bin:/nix/store/wwh7mhwh269sfjkm6k5665b5kgp7jrk2-zlib-1.2.8/bin"
   */
-  makeSearchPathOutputs = subDir: outputs: pkgs:
-    makeSearchPath subDir (map (pkg: if pkg.outputUnspecified or false then lib.tryAttrs (outputs ++ ["out"]) pkg else pkg) pkgs);
+  makeSearchPathOutput = output: subDir: pkgs: makeSearchPath subDir (map (lib.getOutput output) pkgs);
 
   /* Construct a library search path (such as RPATH) containing the
      libraries for a set of packages

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -102,7 +102,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       path = [ pluginsEnv ];
-      environment.PYTHONPATH = makeSearchPathOutputs pkgs.python.sitePackages ["lib"] [ pluginsEnv ];
+      environment.PYTHONPATH = makeSearchPathOutput "lib" pkgs.python.sitePackages [ pluginsEnv ];
 
       preStart = ''
         mkdir -p "${cfg.stateDir}"

--- a/nixos/modules/services/web-servers/apache-httpd/trac.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/trac.nix
@@ -96,7 +96,7 @@ in
   globalEnvVars = singleton
     { name = "PYTHONPATH";
       value =
-        makeSearchPathOutputs "lib/${pkgs.python.libPrefix}/site-packages" ["lib"]
+        makeSearchPathOutput "lib" "lib/${pkgs.python.libPrefix}/site-packages"
           [ pkgs.mod_python
             pkgs.pythonPackages.trac
             pkgs.setuptools

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -7,7 +7,7 @@ let
   e = pkgs.enlightenment;
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager.enlightenment;
-  GST_PLUGIN_PATH = lib.makeSearchPathOutputs "lib/gstreamer-1.0" ["lib"] [
+  GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
     pkgs.gst_all_1.gst-plugins-base
     pkgs.gst_all_1.gst-plugins-good
     pkgs.gst_all_1.gst-plugins-bad

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -12,8 +12,7 @@ let
     '';
   });
 
-  path = map # outputs TODO?
-    (pkg: (pkg.bin or (pkg.out or pkg)))
+  path = map getBin
     [ pkgs.coreutils pkgs.gnugrep pkgs.findutils
       pkgs.glibc # needed for getent
       pkgs.shadow

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -58,7 +58,7 @@ let
       path = (makeBinPath ([
         pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.findutils pkgs.diffutils pkgs.btrfs-progs
         pkgs.utillinux ] ++ (if cfg.efiSupport && (cfg.version == 2) then [pkgs.efibootmgr ] else [])
-      )) + ":" + (makeSearchPathOutputs "sbin" ["bin"] [
+      )) + ":" + (makeSearchPathOutput "bin" "sbin" [
         pkgs.mdadm pkgs.utillinux
       ]);
     });

--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -193,7 +193,7 @@ in rec {
 
     path = mkOption {
       default = [];
-      apply = ps: "${makeBinPath ps}:${makeSearchPathOutputs "sbin" ["bin"] ps}";
+      apply = ps: "${makeBinPath ps}:${makeSearchPathOutput "bin" "sbin" ps}";
       description = ''
         Packages added to the service's <envar>PATH</envar>
         environment variable.  Both the <filename>bin</filename>

--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -13,7 +13,7 @@ let
   ];
 
   libPathNative = lib.makeLibraryPath packages;
-  libPath64 = lib.makeSearchPathOutputs "lib64" ["lib"] packages;
+  libPath64 = lib.makeSearchPathOutput "lib" "lib64" packages;
   libPath = "${libPathNative}:${libPath64}";
 
 in { inherit packages libPath; }

--- a/pkgs/applications/misc/guake/default.nix
+++ b/pkgs/applications/misc/guake/default.nix
@@ -16,7 +16,7 @@ gconftool-2 --recursive-unset /apps/guake
 with lib;
 
 let inputs = [ dbus gtk2 gconf python2 libutempter vte keybinder gnome3.gnome_common ];
-    pyPath = makeSearchPathOutputs python2.sitePackages ["lib"] (attrVals [ "dbus" "notify" "pyGtkGlade" "pyxdg" ] python2Packages ++ [ gnome2.gnome_python ]);
+    pyPath = makeSearchPathOutput "lib" python2.sitePackages (attrVals [ "dbus" "notify" "pyGtkGlade" "pyxdg" ] python2Packages ++ [ gnome2.gnome_python ]);
  in stdenv.mkDerivation rec {
   name = "guake-${version}";
   version = "0.8.3";

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
                          "-I${dbus_libs.lib}/lib/dbus-1.0/include" ];
 
   # Fix up python path so the lockfile library is on it.
-  PYTHONPATH = stdenv.lib.makeSearchPathOutputs pythonFull.sitePackages ["lib"] [
+  PYTHONPATH = stdenv.lib.makeSearchPathOutput "lib" pythonFull.sitePackages [
     pythonPackages.curses pythonPackages.lockfile
   ];
 

--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -65,7 +65,7 @@ let
 
     patchPhase = let
       rpaths = [ stdenv.cc.cc ];
-      mkrpath = p: "${makeSearchPathOutputs "lib64" ["lib"] p}:${makeLibraryPath p}";
+      mkrpath = p: "${makeSearchPathOutput "lib" "lib64" p}:${makeLibraryPath p}";
     in ''
       for sofile in PepperFlash/libpepflashplayer.so \
                     libwidevinecdm.so libwidevinecdmadapter.so; do

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
       libheimdal
       libpulseaudio
       systemd
-    ] + ":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] [
+    ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc
     ];
 

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -65,7 +65,7 @@ in stdenv.mkDerivation rec {
     tar xf data.tar.xz
   '';
 
-  rpath = makeLibraryPath deps + ":" + makeSearchPathOutputs "lib64" ["lib"] deps;
+  rpath = makeLibraryPath deps + ":" + makeSearchPathOutput "lib" "lib64" deps;
   binpath = makeBinPath deps;
 
   installPhase = ''

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
   preFixup =
     ''

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   libPath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
   buildPhase = ''
     echo "Patching Vivaldi binaries"

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
       nspr
       nss
       pango
-    ] + ":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] [
+    ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc
     ];
 

--- a/pkgs/applications/science/math/mathematica/9.nix
+++ b/pkgs/applications/science/math/mathematica/9.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   ldpath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
   phases = "unpackPhase installPhase fixupPhase";
 

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
   ldpath = stdenv.lib.makeLibraryPath buildInputs
     + stdenv.lib.optionalString (stdenv.system == "x86_64-linux")
-      (":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] buildInputs);
+      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs);
 
   phases = "unpackPhase installPhase fixupPhase";
 

--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bison
+{ stdenv, fetchurl, lib, bison
 , qt4, xapian, file, python, perl
 , djvulibre, groff, libxslt, unzip, poppler_utils, antiword, catdoc, lyx
 , libwpd, unrtf, untex
@@ -26,27 +26,27 @@ stdenv.mkDerivation rec {
   # the absolute path to the filtering command. 
   postInstall = ''
     for f in $out/share/recoll/filters/* ; do
-      substituteInPlace  $f --replace antiword      ${antiword}/bin/antiword
-      substituteInPlace  $f --replace awk           ${gawk}/bin/awk
-      substituteInPlace  $f --replace catppt        ${catdoc}/bin/catppt
-      substituteInPlace  $f --replace djvused       ${djvulibre.bin}/bin/djvused
-      substituteInPlace  $f --replace djvutxt       ${djvulibre.bin}/bin/djvutxt
-      substituteInPlace  $f --replace egrep         ${gnugrep}/bin/egrep
-      substituteInPlace  $f --replace groff         ${groff}/bin/groff
-      substituteInPlace  $f --replace gunzip        ${gzip}/bin/gunzip
-      substituteInPlace  $f --replace iconv         ${libiconv.bin or libiconv}/bin/iconv
-      substituteInPlace  $f --replace lyx           ${lyx}/bin/lyx
-      substituteInPlace  $f --replace pdftotext     ${poppler_utils.out}/bin/pdftotext
-      substituteInPlace  $f --replace pstotext      ${ghostscript}/bin/ps2ascii 
-      substituteInPlace  $f --replace sed           ${gnused}/bin/sed
-      substituteInPlace  $f --replace tar           ${gnutar}/bin/tar
-      substituteInPlace  $f --replace unzip         ${unzip}/bin/unzip
-      substituteInPlace  $f --replace xls2csv       ${catdoc}/bin/xls2csv
-      substituteInPlace  $f --replace xsltproc      ${libxslt.bin}/bin/xsltproc
-      substituteInPlace  $f --replace unrtf         ${unrtf}/bin/unrtf
-      substituteInPlace  $f --replace untex         ${untex}/bin/untex
-      substituteInPlace  $f --replace wpd2html      ${libwpd}/bin/wpd2html
-      substituteInPlace  $f --replace /usr/bin/perl ${perl}/bin/perl
+      substituteInPlace  $f --replace antiword      ${lib.getBin antiword}/bin/antiword
+      substituteInPlace  $f --replace awk           ${lib.getBin gawk}/bin/awk
+      substituteInPlace  $f --replace catppt        ${lib.getBin catdoc}/bin/catppt
+      substituteInPlace  $f --replace djvused       ${lib.getBin djvulibre}/bin/djvused
+      substituteInPlace  $f --replace djvutxt       ${lib.getBin djvulibre}/bin/djvutxt
+      substituteInPlace  $f --replace egrep         ${lib.getBin gnugrep}/bin/egrep
+      substituteInPlace  $f --replace groff         ${lib.getBin groff}/bin/groff
+      substituteInPlace  $f --replace gunzip        ${lib.getBin gzip}/bin/gunzip
+      substituteInPlace  $f --replace iconv         ${lib.getBin libiconv}/bin/iconv
+      substituteInPlace  $f --replace lyx           ${lib.getBin lyx}/bin/lyx
+      substituteInPlace  $f --replace pdftotext     ${lib.getBin poppler_utils}/bin/pdftotext
+      substituteInPlace  $f --replace pstotext      ${lib.getBin ghostscript}/bin/ps2ascii
+      substituteInPlace  $f --replace sed           ${lib.getBin gnused}/bin/sed
+      substituteInPlace  $f --replace tar           ${lib.getBin gnutar}/bin/tar
+      substituteInPlace  $f --replace unzip         ${lib.getBin unzip}/bin/unzip
+      substituteInPlace  $f --replace xls2csv       ${lib.getBin catdoc}/bin/xls2csv
+      substituteInPlace  $f --replace xsltproc      ${lib.getBin libxslt}/bin/xsltproc
+      substituteInPlace  $f --replace unrtf         ${lib.getBin unrtf}/bin/unrtf
+      substituteInPlace  $f --replace untex         ${lib.getBin untex}/bin/untex
+      substituteInPlace  $f --replace wpd2html      ${lib.getBin libwpd}/bin/wpd2html
+      substituteInPlace  $f --replace /usr/bin/perl ${lib.getBin perl}/bin/perl
     done
   '';
 

--- a/pkgs/applications/version-management/reposurgeon/default.nix
+++ b/pkgs/applications/version-management/reposurgeon/default.nix
@@ -51,7 +51,7 @@ mkDerivation rec {
         [ out git bazaar cvs darcs fossil mercurial
           monotone rcs src subversion cvs_fast_export ]
       );
-      pythonpath = makeSearchPathOutputs python27.sitePackages ["lib"] (
+      pythonpath = makeSearchPathOutput "lib" python27.sitePackages (
         filter (x: x != null)
         [ python27Packages.readline or null python27Packages.hglib or null ]
       );

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -27,13 +27,13 @@ let
   ccVersion = (builtins.parseDrvName cc.name).version;
   ccName = (builtins.parseDrvName cc.name).name;
 
-  libc_bin = if nativeLibc then null else libc.bin or libc;
-  libc_dev = if nativeLibc then null else libc.dev or libc;
-  libc_lib = if nativeLibc then null else libc.out or libc;
-  cc_solib = cc.lib or cc;
-  binutils_bin = if nativeTools then "" else binutils.bin or binutils;
+  libc_bin = if nativeLibc then null else getBin libc;
+  libc_dev = if nativeLibc then null else getDev libc;
+  libc_lib = if nativeLibc then null else getLib libc;
+  cc_solib = getLib cc;
+  binutils_bin = if nativeTools then "" else getBin binutils;
   # The wrapper scripts use 'cat' and 'grep', so we may need coreutils.
-  coreutils_bin = if nativeTools then "" else coreutils.bin or coreutils;
+  coreutils_bin = if nativeTools then "" else getBin coreutils;
 in
 
 stdenv.mkDerivation {

--- a/pkgs/build-support/gcc-wrapper-old/default.nix
+++ b/pkgs/build-support/gcc-wrapper-old/default.nix
@@ -5,7 +5,7 @@
 # stdenv.mkDerivation provides a wrapper that sets up the right environment
 # variables so that the compiler and the linker just "work".
 
-{ name ? "", stdenv, nativeTools, nativeLibc, nativePrefix ? ""
+{ name ? "", stdenv, lib, nativeTools, nativeLibc, nativePrefix ? ""
 , gcc ? null, libc ? null, binutils ? null, coreutils ? null, shell ? ""
 , zlib ? null
 }:
@@ -41,10 +41,10 @@ stdenv.mkDerivation {
   addFlags = ./add-flags;
 
   inherit nativeTools nativeLibc nativePrefix gcc;
-  gcc_lib = gcc.lib or gcc;
+  gcc_lib = lib.getLib gcc;
   libc = if nativeLibc then null else libc;
-  libc_dev = if nativeLibc then null else libc.dev or libc;
-  libc_bin = if nativeLibc then null else libc.bin or libc;
+  libc_dev = if nativeLibc then null else lib.getDev libc;
+  libc_bin = if nativeLibc then null else lib.getBin libc;
   binutils = if nativeTools then null else binutils;
   # The wrapper scripts use 'cat', so we may need coreutils
   coreutils = if nativeTools then null else coreutils;

--- a/pkgs/build-support/gcc-wrapper-old/default.nix
+++ b/pkgs/build-support/gcc-wrapper-old/default.nix
@@ -45,9 +45,9 @@ stdenv.mkDerivation {
   libc = if nativeLibc then null else libc;
   libc_dev = if nativeLibc then null else lib.getDev libc;
   libc_bin = if nativeLibc then null else lib.getBin libc;
-  binutils = if nativeTools then null else binutils;
+  binutils = if nativeTools then null else lib.getBin binutils;
   # The wrapper scripts use 'cat', so we may need coreutils
-  coreutils = if nativeTools then null else coreutils;
+  coreutils = if nativeTools then null else lib.getBin coreutils;
 
   langC = if nativeTools then true else gcc.langC;
   langCC = if nativeTools then true else gcc.langCC;

--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation {
 
     for f in $(find $out); do
       if [ -f "$f" ] && patchelf "$f" 2> /dev/null; then
-        patchelf --set-interpreter ${glibc.out}/lib/ld-linux.so.2 \
-                 --set-rpath $out/lib:${gcc.lib or gcc}/lib:${ncurses.out}/lib \
+        patchelf --set-interpreter ${getLib glibc}/lib/ld-linux.so.2 \
+                 --set-rpath $out/lib:${getLib gcc}/lib:${ncurses.out}/lib \
                  "$f" || true
       fi
     done

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl, libedit, ncurses, gmp}:
+{stdenv, lib, fetchurl, perl, libedit, ncurses, gmp}:
 
 stdenv.mkDerivation rec {
   version = "6.10.2";
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
      '' else "");
 
   configurePhase = ''
-    ./configure --prefix=$out --with-gmp-libraries=${gmp.out}/lib --with-gmp-includes=${gmp.dev or gmp}/include
+    ./configure --prefix=$out --with-gmp-libraries=${lib.getLib gmp}/lib --with-gmp-includes=${lib.getDev gmp}/include
   '';
 
   # Stripping combined with patchelf breaks the executables (they die

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
 
     # Find the loader dynamically
-    LOADER="$(find ${libc.out or libc}/lib -name ld-linux\* | head -n 1)"
+    LOADER="$(find ${lib.getLib libc}/lib -name ld-linux\* | head -n 1)"
 
     # Replace references to the loader
     find src/cmd -name asm.c -exec sed -i "s,/lib/ld-linux.*\.so\.[0-9],$LOADER," {} \;

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -17,8 +17,8 @@ assert enableThreading -> (stdenv ? glibc);
 let
 
   libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
-  libcInc = libc.dev or libc;
-  libcLib = libc.out or libc;
+  libcInc = lib.getDev libc;
+  libcLib = lib.getLib libc;
   common = { version, sha256 }: stdenv.mkDerivation rec {
     name = "perl-${version}";
 

--- a/pkgs/development/interpreters/pypy/default.nix
+++ b/pkgs/development/interpreters/pypy/default.nix
@@ -25,10 +25,9 @@ let
       ++ stdenv.lib.optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc
       ++ stdenv.lib.optional zlibSupport zlib;
 
-    C_INCLUDE_PATH = stdenv.lib.concatStringsSep ":" (map (p: "${p.dev or p}/include") buildInputs);
-    LIBRARY_PATH = stdenv.lib.concatStringsSep ":" (map (p: "${p.lib or p.out or p}/lib") buildInputs);
-    LD_LIBRARY_PATH = stdenv.lib.concatStringsSep ":" (map (p: "${p.lib or p.out or p}/lib")
-      (stdenv.lib.filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs));
+    C_INCLUDE_PATH = stdenv.lib.makeSearchPathOutput "dev" "include" buildInputs;
+    LIBRARY_PATH = stdenv.lib.makeLibraryPath buildInputs;
+    LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath (stdenv.lib.filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs);
 
     preConfigure = ''
       # hint pypy to find nix ncurses

--- a/pkgs/development/interpreters/python/2.6/default.nix
+++ b/pkgs/development/interpreters/python/2.6/default.nix
@@ -53,8 +53,8 @@ let
     ++ optional zlibSupport zlib;
 
   mkPaths = paths: {
-    C_INCLUDE_PATH = concatStringsSep ":" (map (p: "${p.dev or p}/include") paths);
-    LIBRARY_PATH = concatStringsSep ":" (map (p: "${p.lib or (p.out or p)}/lib") paths);
+    C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" paths;
+    LIBRARY_PATH = makeLibraryPath paths;
   };
 
   # Build the basic Python interpreter without modules that have

--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -102,8 +102,8 @@ let
   propagatedBuildInputs = optional stdenv.isDarwin configd;
 
   mkPaths = paths: {
-    C_INCLUDE_PATH = concatStringsSep ":" (map (p: "${p.dev or p}/include") paths);
-    LIBRARY_PATH = concatStringsSep ":" (map (p: "${p.lib or (p.out or p)}/lib") paths);
+    C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" paths;
+    LIBRARY_PATH = makeLibraryPath paths;
   };
 
   # Build the basic Python interpreter without modules that have

--- a/pkgs/development/interpreters/python/3.2/default.nix
+++ b/pkgs/development/interpreters/python/3.2/default.nix
@@ -44,8 +44,8 @@ stdenv.mkDerivation {
     ${optionalString stdenv.isDarwin ''export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"''}
 
     configureFlagsArray=( --enable-shared --with-threads --with-wide-unicode
-                          CPPFLAGS="${concatStringsSep " " (map (p: "-I${p.dev or p}/include") buildInputs)}"
-                          LDFLAGS="${concatStringsSep " " (map (p: "-L${p.lib or (p.out or p)}/lib") buildInputs)}"
+                          CPPFLAGS="${makeSearchPathOutput "dev" "include" buildInputs}"
+                          LDFLAGS="${makeLibraryPath buildInputs}"
                           LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';

--- a/pkgs/development/interpreters/python/3.3/default.nix
+++ b/pkgs/development/interpreters/python/3.3/default.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation {
     ${optionalString stdenv.isDarwin ''export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"''}
 
     configureFlagsArray=( --enable-shared --with-threads
-                          CPPFLAGS="${concatStringsSep " " (map (p: "-I${p.dev or p}/include") buildInputs)}"
-                          LDFLAGS="${concatStringsSep " " (map (p: "-L${p.lib or (p.out or p)}/lib") buildInputs)}"
+                          CPPFLAGS="${makeSearchPathOutput "dev" "include" buildInputs}"
+                          LDFLAGS="${makeLibraryPath buildInputs}"
                           LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';

--- a/pkgs/development/interpreters/python/3.4/default.nix
+++ b/pkgs/development/interpreters/python/3.4/default.nix
@@ -58,8 +58,8 @@ stdenv.mkDerivation {
      ''}
 
     configureFlagsArray=( --enable-shared --with-threads
-                          CPPFLAGS="${concatStringsSep " " (map (p: "-I${p.dev or p}/include") buildInputs)}"
-                          LDFLAGS="${concatStringsSep " " (map (p: "-L${p.lib or (p.out or p)}/lib") buildInputs)}"
+                          CPPFLAGS="${makeSearchPathOutput "dev" "include" buildInputs}"
+                          LDFLAGS="${makeLibraryPath buildInputs}"
                           LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';

--- a/pkgs/development/interpreters/python/3.5/default.nix
+++ b/pkgs/development/interpreters/python/3.5/default.nix
@@ -58,8 +58,8 @@ stdenv.mkDerivation {
      ''}
 
     configureFlagsArray=( --enable-shared --with-threads
-                          CPPFLAGS="${concatStringsSep " " (map (p: "-I${p.dev or p}/include") buildInputs)}"
-                          LDFLAGS="${concatStringsSep " " (map (p: "-L${p.lib or (p.out or p)}/lib") buildInputs)}"
+                          CPPFLAGS="${makeSearchPathOutput "dev" "include" buildInputs}"
+                          LDFLAGS="${makeLibraryPath buildInputs}"
                           LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
                         )
   '';

--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = optional wantPS ps;
 
-  CMAKE_PREFIX_PATH = stdenv.lib.concatStringsSep ":"
+  CMAKE_PREFIX_PATH = concatStringsSep ":"
     (concatMap (p: [ p p.out ]) buildInputs);
 
   configureFlags =
@@ -63,9 +63,9 @@ stdenv.mkDerivation rec {
       source $setupHook
       fixCmakeFiles .
       substituteInPlace Modules/Platform/UnixPaths.cmake \
-        --subst-var-by glibc_bin ${glibc.bin or glibc} \
-        --subst-var-by glibc_dev ${glibc.dev or glibc} \
-        --subst-var-by glibc_lib ${glibc.out or glibc}
+        --subst-var-by glibc_bin ${getBin glibc} \
+        --subst-var-by glibc_dev ${getDev glibc} \
+        --subst-var-by glibc_lib ${getLib glibc}
     '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -47,9 +47,9 @@ stdenv.mkDerivation rec {
     ''
       fixCmakeFiles .
       substituteInPlace Modules/Platform/UnixPaths.cmake \
-        --subst-var-by glibc_bin ${glibc.bin or glibc} \
-        --subst-var-by glibc_dev ${glibc.dev or glibc} \
-        --subst-var-by glibc_lib ${glibc.out or glibc}
+        --subst-var-by glibc_bin ${getBin glibc} \
+        --subst-var-by glibc_dev ${getDev glibc} \
+        --subst-var-by glibc_lib ${getLib glibc}
     '';
   configureFlags =
     [ "--docdir=/share/doc/${name}"

--- a/pkgs/games/ue4demos/default.nix
+++ b/pkgs/games/ue4demos/default.nix
@@ -12,7 +12,7 @@ let
 
       rtdeps = stdenv.lib.makeLibraryPath
         [ xorg.libXxf86vm xorg.libXext openal ]
-        + ":" + stdenv.lib.makeSearchPathOutputs "lib64" ["lib"] [ stdenv.cc.cc ];
+        + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [ stdenv.cc.cc ];
 
       buildCommand =
       ''

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -32,9 +32,10 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   # them to the RPATH so that the user doesn't have to set them in
   # LD_LIBRARY_PATH.
   NIX_LDFLAGS = map (path: "-rpath " + path) (
-      map (x: "${x}/lib") ([ stdenv.cc.cc ] ++ (map (x: x.lib or x.out) buildInputs))
+      map (x: "${lib.getLib x}/lib") ([ stdenv.cc.cc ] ++ buildInputs)
       # libpulsecommon.so is linked but not found otherwise
-      ++ lib.optionals pulseaudioSupport (map (x: "${x}/lib/pulseaudio") (toBuildInputs pkgArches (pkgs: [ pkgs.libpulseaudio ])))
+      ++ lib.optionals pulseaudioSupport (map (x: "${lib.getLib x}/lib/pulseaudio")
+          (toBuildInputs pkgArches (pkgs: [ pkgs.libpulseaudio ])))
     );
 
   # Don't shrink the ELF RPATHs in order to keep the extra RPATH

--- a/pkgs/os-specific/linux/pm-utils/default.nix
+++ b/pkgs/os-specific/linux/pm-utils/default.nix
@@ -6,7 +6,7 @@ let
   binPath = stdenv.lib.makeBinPath
     [ coreutils gnugrep utillinux kmod procps kbd dbus_tools ];
 
-  sbinPath = stdenv.lib.makeSearchPathOutputs "sbin" ["bin"]
+  sbinPath = stdenv.lib.makeSearchPathOutput "bin" "sbin"
     [ procps ];
 
 in

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -62,7 +62,7 @@ rec {
       cp -d ${openssl.out}/lib/*.dylib $out/lib
 
       cp -d ${gnugrep.pcre.out}/lib/libpcre*.dylib $out/lib
-      cp -d ${libiconv.lib or libiconv}/lib/lib*.dylib $out/lib
+      cp -d ${lib.getLib libiconv}/lib/lib*.dylib $out/lib
       cp -d ${gettext}/lib/libintl*.dylib $out/lib
       chmod +x $out/lib/libintl*.dylib
       cp -d ${ncurses.out}/lib/libncurses*.dylib $out/lib

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -223,7 +223,7 @@ let
         # include it in the result, it *is* available to nix-env for queries.
         meta = { }
             # If the packager hasn't specified `outputsToInstall`, choose a default,
-            # namely `p.bin or p.out or p`;
+            # namely `lib.getBin p`;
             # if he has specified it, it will be overridden below in `// meta`.
             #   Note: This default probably shouldn't be globally configurable.
             #   Services and users should specify outputs explicitly,

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -223,7 +223,7 @@ let
         # include it in the result, it *is* available to nix-env for queries.
         meta = { }
             # If the packager hasn't specified `outputsToInstall`, choose a default,
-            # namely `lib.getBin p`;
+            # which is the name of `p.bin or p.out or p`;
             # if he has specified it, it will be overridden below in `// meta`.
             #   Note: This default probably shouldn't be globally configurable.
             #   Services and users should specify outputs explicitly,


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is continuation of my attempts at having outputs correctly used tree-wise. We now have a more specific function `makeSearchPathOutput`, defined via `getOutput` -- a new function for getting output from a package with necessary checks and fallbacks. This function is very useful on its own, so I've run a few regexps tree-wise to use it instead of ad-hoc `a.needed or a.out or a`. What I _don't_ like is that as of now ideally this function should be used anywhere to abstract from splitted/unsplitted packages, and that would be a slowdown and also clunky-looking. However it's better than ad-hoc fixes anyway and this is a price for multiple outputs -- a little one for its benefits ~_^.

cc @vcunat @edolstra 
