### PR TITLE
sipsak: build with gcc 4.8

### DIFF
--- a/pkgs/tools/networking/sipsak/default.nix
+++ b/pkgs/tools/networking/sipsak/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchurl, autoreconfHook, c-ares, openssl ? null }:
+{ stdenv, fetchurl, gcc48, autoreconfHook, c-ares, openssl ? null }:
 
 stdenv.mkDerivation rec {
   name = "sipsak-${version}";
   version = "4.1.2.1";
 
   buildInputs = [
+    gcc48
     autoreconfHook
     openssl
     c-ares


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
