### PR TITLE
totem: Add missing python3 dependencies for plugins

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/libpeas/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/libpeas/default.nix
@@ -1,13 +1,15 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnome3
-, glib, gtk3, gobjectIntrospection, python, pygobject3
+, glib, gtk3, gobjectIntrospection, python3, python3Packages, ncurses
 }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
+  configureFlags = [ "--enable-python3" ];
+
   buildInputs =  [
-   intltool pkgconfig glib gtk3 gobjectIntrospection python pygobject3
-   gnome3.defaultIconTheme
+   intltool pkgconfig glib gtk3 gobjectIntrospection python3 python3Packages.pygobject3
+   gnome3.defaultIconTheme ncurses
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.18/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/totem/default.nix
@@ -1,6 +1,6 @@
 { stdenv, intltool, fetchurl, gst_all_1
-, clutter_gtk, clutter-gst, pygobject3, shared_mime_info
-, pkgconfig, gtk3, glib
+, clutter_gtk, clutter-gst, python3, python3Packages, shared_mime_info
+, pkgconfig, gtk3, glib, gobjectIntrospection
 , bash, makeWrapper, itstool, libxml2, dbus_glib
 , gnome3, librsvg, gdk_pixbuf, file }:
 
@@ -19,13 +19,15 @@ stdenv.mkDerivation rec {
                   clutter_gtk clutter-gst gnome3.totem-pl-parser gnome3.grilo-plugins
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
                   gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly gst_all_1.gst-libav
-                  gnome3.libpeas pygobject3 shared_mime_info dbus_glib
+                  gnome3.libpeas python3Packages.pygobject3 gobjectIntrospection shared_mime_info dbus_glib
                   gdk_pixbuf gnome3.defaultIconTheme librsvg gnome3.gnome_desktop
                   gnome3.gsettings_desktop_schemas makeWrapper file ];
 
   preFixup = ''
     wrapProgram "$out/bin/totem" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix PYTHONPATH : "${python3Packages.pygobject3}/lib/python3.4/site-packages:$PYTHONPATH" \
+      --prefix GI_TYPELIB_PATH : "$out/lib/girepository-1.0:$GI_TYPELIB_PATH" \
       --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
       --prefix GRL_PLUGIN_PATH : "${gnome3.grilo-plugins}/lib/grilo-0.2" \
       --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)

---

Totem could not load its plugins because of missing python3 dependencies, and because libpeas was not built with python3 support.

I double-checked, and AFAICT there's no application using libpeas with python2 plugins.

/cc @lethalman @DamienCassou 
