### PR TITLE
qt4.8: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -11,6 +11,8 @@
 , docs ? false
 , examples ? false
 , demos ? false
+# darwin support
+, cf-private, libobjc, ApplicationServices, OpenGL, Cocoa, AGL, libcxx
 }:
 
 with stdenv.lib;
@@ -114,7 +116,7 @@ stdenv.mkDerivation rec {
 
       -no-phonon ${if buildWebkit then "" else "-no"}-webkit ${if buildMultimedia then "" else "-no"}-multimedia -audio-backend
       ${if developerBuild then "-developer-build" else ""}
-    '';
+    '' + optionalString stdenv.isDarwin "-platform unsupported/macx-clang-libc++";
 
   propagatedBuildInputs =
     [ libXrender libXrandr libXinerama libXcursor libXext libXfixes libXv libXi
@@ -129,14 +131,16 @@ stdenv.mkDerivation rec {
     [ cups # Qt dlopen's libcups instead of linking to it
       postgresql sqlite libjpeg libmng libtiff icu ]
     ++ optionals (mysql != null) [ mysql.lib ]
-    ++ optionals gtkStyle [ gtk gdk_pixbuf ];
+    ++ optionals gtkStyle [ gtk gdk_pixbuf ]
+    ++ optionals stdenv.isDarwin [ cf-private ApplicationServices OpenGL Cocoa AGL libcxx libobjc ];
 
   nativeBuildInputs = [ perl pkgconfig which ];
 
   enableParallelBuilding = false;
 
   NIX_CFLAGS_COMPILE = optionalString (stdenv.isFreeBSD || stdenv.isDarwin)
-    "-I${glib.dev}/include/glib-2.0 -I${glib.out}/lib/glib-2.0/include";
+    "-I${glib.dev}/include/glib-2.0 -I${glib.out}/lib/glib-2.0/include"
+    + optionalString stdenv.isDarwin " -I${libcxx}/include/c++/v1";
 
   NIX_LDFLAGS = optionalString (stdenv.isFreeBSD || stdenv.isDarwin)
     "-lglib-2.0";
@@ -145,6 +149,8 @@ stdenv.mkDerivation rec {
     # resolve "extra qualification on member" error
     sed -i 's/struct ::TabletProximityRec;/struct TabletProximityRec;/' \
       src/gui/kernel/qt_cocoa_helpers_mac_p.h
+    find . -name "Makefile*" | xargs sed -i 's/^\(LINK[[:space:]]* = clang++\)/\1 ${NIX_LDFLAGS}/'
+    sed -i 's/^\(LIBS[[:space:]]*=.*$\)/\1 -lobjc/' ./src/corelib/Makefile.Release
   '';
 
   crossAttrs = let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8522,6 +8522,9 @@ in
 
     # XXX: mariadb doesn't built on fbsd as of nov 2015
     mysql = if (!stdenv.isFreeBSD) then mysql else null;
+
+    inherit (pkgs.darwin) cf-private libobjc;
+    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL Cocoa AGL;
   };
 
   qt48Full = appendToName "full" (qt48.override {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Supplies the necessary system frameworks.
- Specifies the mac clang platform
- Adds `NIX_LDFLAGS` to linker flags
