### PR TITLE
frameworks: GL is undefined

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -48,7 +48,7 @@ with frameworks; with libs; {
   ForceFeedback           = [ CF IOKit ];
   Foundation              = [ CF libobjc Security ApplicationServices SystemConfiguration ];
   GLKit                   = [ CF ];
-  GLUT                    = [ GL OpenGL ];
+  GLUT                    = [ OpenGL ];
   GSS                     = [];
   GameController          = [];
   GameKit                 = [ Foundation ];


### PR DESCRIPTION
The `GLUT` framework is currently a Nix evaluation error as `GL` is undefined.
