### PR TITLE
gnome-maps: Add missing gsettings schemas

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/apps/gnome-maps/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
                   gtk3 geoclue2 gnome3.gjs gnome3.libgee folks gfbgraph
                   gnome3.geocode_glib libchamplain file libsoup
                   gdk_pixbuf librsvg autoreconfHook
+                  gnome3.gsettings_desktop_schemas gnome3.evolution_data_server
                   gnome3.gnome_online_accounts gnome3.defaultIconTheme ];
 
   patches = [ ./soup.patch ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without `gnome3.gsettings_desktop_schemas` and
`gnome3.evolution_data_server` as buildInputs, `gnome-maps` won't start at
all.
