### PR TITLE
libressl: enable multiple outputs

### DIFF
--- a/pkgs/development/libraries/libressl/2.2.nix
+++ b/pkgs/development/libraries/libressl/2.2.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  outputs = [ "dev" "out" "man" "bin" ];
+
   meta = with stdenv.lib; {
     description = "Free TLS/SSL implementation";
     homepage    = "http://www.libressl.org";

--- a/pkgs/development/libraries/libressl/2.3.nix
+++ b/pkgs/development/libraries/libressl/2.3.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  outputs = [ "dev" "out" "man" "bin" ];
+
   meta = with stdenv.lib; {
     description = "Free TLS/SSL implementation";
     homepage    = "http://www.libressl.org";


### PR DESCRIPTION
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I set `openssl = pkgs.libressl_2_3` in my `packageOverrides`, and this broke after `closure-size` was merged in. However, thanks to great work by @vcunat, the fix (providing multiple outputs to match openssl) is super simple :)
