### PR TITLE
dockerTools: make tars deterministic

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -151,7 +151,7 @@ EOF
 
       postMount = ''
         echo Packing raw image
-        tar -C mnt -cf $out .
+        tar -C mnt --mtime=0 -cf $out .
       '';
     };
     
@@ -176,7 +176,7 @@ EOF
       
       echo Packing layer
       mkdir $out
-      tar -C layer -cf $out/layer.tar .
+      tar -C layer --mtime=0 -cf $out/layer.tar .
       ts=$(${tarsum} < $out/layer.tar)
       cat ${baseJson} | jshon -s "$ts" -i checksum > $out/json
       echo -n "1.0" > $out/VERSION
@@ -216,7 +216,7 @@ EOF
 
         echo Packing layer
         mkdir $out
-        tar -C layer -cf $out/layer.tar .
+        tar -C layer --mtime=0 -cf $out/layer.tar .
         ts=$(${tarsum} < $out/layer.tar)
         cat ${baseJson} | jshon -s "$ts" -i checksum > $out/json
         echo -n "1.0" > $out/VERSION
@@ -297,7 +297,7 @@ EOF
         tar -tf temp/layer.tar >> baseFiles
         sed 's/^\.//' -i baseFiles
         comm <(sort -n baseFiles|uniq) <(sort -n layerFiles|uniq|grep -v ${layer}) -1 -3 > newFiles
-        tar -rpf temp/layer.tar --no-recursion --files-from newFiles 2>/dev/null || true
+        tar -rpf temp/layer.tar --mtime=0 --no-recursion --files-from newFiles 2>/dev/null || true
 
         echo Adding meta
         
@@ -320,7 +320,7 @@ EOF
         chmod -R a-w image
 
         echo Cooking the image
-        tar -C image -c . | pigz > $out
+        tar -C image --mtime=0 -c . | pigz -nT > $out
       '';
 
     in


### PR DESCRIPTION
There were two sources of non-determinisim coming into the images. The first was tar mtimes, the second was pigz/gzip times.

An example image now passes with the --check flag.

---

Reviewers: do we have existing things which handle tar and gzip non-determinism? Are the dockerTools just not triggering the right fixups?
