### PR TITLE
j4-dmenu-desktop: init at 2.14

### DIFF
--- a/pkgs/applications/misc/j4-dmenu-desktop/default.nix
+++ b/pkgs/applications/misc/j4-dmenu-desktop/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, dmenu }:
+
+stdenv.mkDerivation rec {
+  name    = "j4-dmenu-desktop-${version}";
+  version = "2.14";
+
+  src = fetchFromGitHub {
+    owner  = "enkore";
+    repo   = "j4-dmenu-desktop";
+    rev    = "r${version}";
+    sha256 = "14srrkz4qx8qplgrrjv38ri4pnkxaxaq6jy89j13xhna492bq128";
+  };
+
+  postPatch = ''
+    sed -e 's,dmenu -i,${dmenu}/bin/dmenu -i,g' -i ./src/Main.hh
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  # tests are fetching an external git repository
+  cmakeFlags = [ "-DNO_TESTS:BOOL=ON" ];
+
+  meta = with stdenv.lib; {
+    description = "A wrapper for dmenu that recognize .desktop files";
+    homepage    = "https://github.com/enkore/j4-dmenu-desktop";
+    license     = licenses.gpl3;
+    maintainer  = with maintainers; [ ericsagnes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12827,6 +12827,8 @@ in
 
   bip = callPackage ../applications/networking/irc/bip { };
 
+  j4-dmenu-desktop = callPackage ../applications/misc/j4-dmenu-desktop/default.nix { };
+
   jabref = callPackage ../applications/office/jabref/default.nix { };
 
   jack_capture = callPackage ../applications/audio/jack-capture { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
