### PR TITLE
libpinyin: move to libraries

### DIFF
--- a/pkgs/development/libraries/libpinyin/default.nix
+++ b/pkgs/development/libraries/libpinyin/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Library for intelligent sentence-based Chinese pinyin input method";
-    homepace    = https://sourceforge.net/projects/libpinyin;
+    homepage    = https://sourceforge.net/projects/libpinyin;
     license     = licenses.gpl2;
     platforms   = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1045,7 +1045,7 @@ in
 
   anthy = callPackage ../tools/inputmethods/anthy { };
 
-  libpinyin = callPackage ../tools/inputmethods/libpinyin { };
+  libpinyin = callPackage ../development/libraries/libpinyin { };
 
   ibus-libpinyin = callPackage ../tools/inputmethods/ibus-engines/ibus-libpinyin { };
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
