### PR TITLE
gnome-shell: add missing python3 deps for gnome-shell-extension-tool

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/gnome-shell/default.nix
@@ -1,9 +1,10 @@
 { fetchurl, stdenv, pkgconfig, gnome3, json_glib, libcroco, intltool, libsecret
-, python3, libsoup, polkit, clutter, networkmanager, docbook_xsl, docbook_xsl_ns, at_spi2_core
-, libstartup_notification, telepathy_glib, telepathy_logger, libXtst, p11_kit, unzip
-, sqlite, libgweather, libcanberra_gtk3
-, libpulseaudio, libical, libtool, nss, gobjectIntrospection, gstreamer, makeWrapper
-, accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet, librsvg }:
+, python3, python3Packages, libsoup, polkit, clutter, networkmanager
+, docbook_xsl , docbook_xsl_ns, at_spi2_core, libstartup_notification
+, telepathy_glib, telepathy_logger, libXtst, p11_kit, unzip, sqlite, libgweather
+, libcanberra_gtk3 , libpulseaudio, libical, libtool, nss, gobjectIntrospection
+, gstreamer, makeWrapper , accountsservice, gdk_pixbuf, gdm, upower, ibus
+, networkmanagerapplet, librsvg }:
 
 # http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/gnome-base/gnome-shell/gnome-shell-3.10.2.1.ebuild?revision=1.3&view=markup
 
@@ -15,7 +16,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = with gnome3;
     [ gsettings_desktop_schemas gnome_keyring gnome-menus glib gcr json_glib accountsservice
-      libcroco intltool libsecret pkgconfig python3 libsoup polkit libcanberra gdk_pixbuf librsvg
+      libcroco intltool libsecret pkgconfig python3 python3Packages.pygobject3
+      libsoup polkit libcanberra gdk_pixbuf librsvg
       clutter networkmanager libstartup_notification telepathy_glib docbook_xsl docbook_xsl_ns
       libXtst p11_kit networkmanagerapplet gjs mutter libpulseaudio caribou evolution_data_server
       libical libtool nss gobjectIntrospection gtk gstreamer makeWrapper gdm
@@ -39,6 +41,9 @@ stdenv.mkDerivation rec {
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix XDG_DATA_DIRS : "${gnome_themes_standard}/share:$out/share:$XDG_ICON_DIRS" \
       --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+
+    wrapProgram "$out/bin/gnome-shell-extension-tool" \
+      --prefix PYTHONPATH : "${python3Packages.pygobject3}/lib/python3.4/site-packages:$PYTHONPATH"
 
     wrapProgram "$out/libexec/gnome-shell-calendar-server" \
       --prefix XDG_DATA_DIRS : "${evolution_data_server}/share:$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This commits adds missing python3 deps for gnome-shell-extension-tool to run.

Fix #14651
