### PR TITLE
bspwm: 0.9 -> 0.9.1

### DIFF
--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, libxcb, libXinerama, sxhkd, xcbutil, xcbutilkeysyms, xcbutilwm }:
 
 stdenv.mkDerivation rec {
-  name = "bspwm-0.9";
-  
+  name = "bspwm-${version}";
+  version = "0.9.1";
+
 
   src = fetchurl {
-    url = "https://github.com/baskerville/bspwm/archive/0.9.tar.gz";
-    sha256 = "1efb2db7b8a251bcc006d66a050cf66e9d311761c94890bebf91a32905042fde";
+    url = "https://github.com/baskerville/bspwm/archive/${version}.tar.gz";
+    sha256 = "11dvfcvr8bc116yb3pvl0k1h2gfm9rv652jbxd1c5pmc0yimifq2";
   };
 
   buildInputs = [ libxcb libXinerama xcbutil xcbutilkeysyms xcbutilwm ];
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     make PREFIX=$out
   '';
- 
+
   installPhase = ''
     make PREFIX=$out install
   '';


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is more than just a bugfix release. Make sure to read
https://github.com/baskerville/bspwm/wiki/Upcoming-Changes-in-0.9.1.
