### PR TITLE
grilo: 0.2.12 -> 0.2.14, grilo-plugins: 0.2.13 -> 0.2.16

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/grilo-plugins/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/grilo-plugins/default.nix
@@ -3,11 +3,11 @@
 , gmime, json_glib, avahi, tracker, itstool }:
 
 stdenv.mkDerivation rec {
-  name = "grilo-plugins-0.2.13";
+  name = "grilo-plugins-0.2.16";
 
   src = fetchurl {
     url = "mirror://gnome/sources/grilo-plugins/0.2/${name}.tar.xz";
-    sha256 = "008jwm5ydl0k25p3d2fkcail40fj9y3qknihxb5fg941p8qlhm55";
+    sha256 = "00sjmkzxc8w4qn4lp5yj65c4y83mwhp0zlvk11ghvpxnklgmgd40";
   };
 
   installFlags = [ "GRL_PLUGINS_DIR=$(out)/lib/grilo-0.2" ];

--- a/pkgs/desktops/gnome-3/3.18/core/grilo/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/grilo/default.nix
@@ -2,11 +2,11 @@
 , libxml2, gnome3, gobjectIntrospection, libsoup }:
 
 stdenv.mkDerivation rec {
-  name = "grilo-0.2.12";
+  name = "grilo-0.2.14";
 
   src = fetchurl {
     url = "mirror://gnome/sources/grilo/0.2/${name}.tar.xz";
-    sha256 = "11bvc7rsrjjwz8hp67p3fn8zmywrpawrcbi3vgw8b0dwa0sndd2m";
+    sha256 = "1k8wj8f7xfaw5hxypnmwd34li3fq8h76dacach547rvsfjhjxj3r";
   };
 
   setupHook = ./setup-hook.sh;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fix #14717

GNOME Music 3.18 requires a more recent version of the 0.2.x series of
Grilo and its plugins to work.
