### PR TITLE
sxhkd: 0.5.5 -> 0.5.6

### DIFF
--- a/pkgs/applications/window-managers/sxhkd/default.nix
+++ b/pkgs/applications/window-managers/sxhkd/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sxhkd-${version}";
-  version = "0.5.5";
+  version = "0.5.6";
 
   src = fetchurl {
     url = "https://github.com/baskerville/sxhkd/archive/${version}.tar.gz";
-    sha256 = "04s3y2bq9502gw72jj3y2zsh96yj3qg2av3zsa8ahd2farvrysg6";
+    sha256 = "15grmzpxz5fqlbfg2slj7gb7r6nzkvjmflmbkqx7mlby9pm6wdkj";
   };
 
   buildInputs = [ asciidoc libxcb xcbutil xcbutilkeysyms xcbutilwm ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
