### PR TITLE
zfs: Update devNodes description

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -80,11 +80,8 @@ in
         description = ''
           Name of directory from which to import ZFS devices.
 
-          Usually /dev works. However, ZFS import may fail if a device node is renamed.
-          It should therefore use stable device names, such as from /dev/disk/by-id.
-
-          The default remains /dev for 15.09, due to backwards compatibility concerns.
-          It will change to /dev/disk/by-id in the next NixOS release.
+          This should be a path under /dev containing stable names for all devices needed, as
+          import may fail if device nodes are renamed concurrently with a device failing.
         '';
       };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
