### PR TITLE
mongodb: forget references to build inputs

### DIFF
--- a/pkgs/servers/nosql/mongodb/default.nix
+++ b/pkgs/servers/nosql/mongodb/default.nix
@@ -49,12 +49,18 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ scons ];
   inherit buildInputs;
 
-  # When not building with the system valgrind, the build should use the
-  # vendored header file - regardless of whether or not we're using the system
-  # tcmalloc - so we need to lift the include path manipulation out of the
-  # conditional.
   patches =
-    [ ./valgrind-include.patch
+    [
+      # When not building with the system valgrind, the build should use the
+      # vendored header file - regardless of whether or not we're using the system
+      # tcmalloc - so we need to lift the include path manipulation out of the
+      # conditional.
+      ./valgrind-include.patch
+
+      # MongoDB keeps track of its build parameters, which tricks nix into
+      # keeping dependencies to build inputs in the final output.
+      # We remove the build flags from buildInfo data.
+      ./forget-build-dependencies.patch
       (fetchpatch {
         url = https://projects.archlinux.org/svntogit/community.git/plain/trunk/boost160.patch?h=packages/mongodb;
         name = "boost160.patch";

--- a/pkgs/servers/nosql/mongodb/forget-build-dependencies.patch
+++ b/pkgs/servers/nosql/mongodb/forget-build-dependencies.patch
@@ -1,0 +1,17 @@
+--- a/site_scons/mongo_scons_utils.py
++++ b/site_scons/mongo_scons_utils.py
+@@ -84,14 +84,11 @@
+ def default_buildinfo_environment_data():
+     return (
+         ('distmod', '$MONGO_DISTMOD', True, True,),
+         ('distarch', '$MONGO_DISTARCH', True, True,),
+         ('cc', '$CC_VERSION', True, False,),
+-        ('ccflags', '$CCFLAGS', True, False,),
+         ('cxx', '$CXX_VERSION', True, False,),
+-        ('cxxflags', '$CXXFLAGS', True, False,),
+-        ('linkflags', '$LINKFLAGS', True, False,),
+         ('target_arch', '$TARGET_ARCH', True, True,),
+         ('target_os', '$TARGET_OS', True, False,),
+     )
+ 
+ # If you want buildInfo and --version to be relatively empty, set


### PR DESCRIPTION
MongoDB keeps track of its build parameters, which tricks nix into
keeping dependencies to build inputs in the final output.

This is quite bad in the case of boost-dev, which are quite big (120MiB) and
completely unneeded by the runtime.

To fix this, I removed the build flags from buildInfo data.
