### PR TITLE
sipsak: fix build by using --std=gnu89, backport to 16.03

### DIFF
--- a/pkgs/tools/networking/sipsak/default.nix
+++ b/pkgs/tools/networking/sipsak/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     c-ares
   ];
 
+  NIX_CFLAGS_COMPILE = "--std=gnu89";
+
   src = fetchurl {
     url = "https://github.com/sipwise/sipsak/archive/mr${version}.tar.gz";
     sha256 = "769fe59966b1962b67aa35aad7beb9a2110ebdface36558072a05c6405fb5374";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
