### PR TITLE
higan: 096 -> 098

### DIFF
--- a/pkgs/misc/emulators/higan/0001-change-flags.diff
+++ b/pkgs/misc/emulators/higan/0001-change-flags.diff
@@ -1,26 +1,23 @@
-diff -rupN higan_v095-source.orig/GNUmakefile higan_v095-source/GNUmakefile
---- higan_v095-source.orig/GNUmakefile	2015-11-04 10:28:26.173428178 +0100
-+++ higan_v095-source/GNUmakefile	2015-11-04 10:28:31.752231593 +0100
-@@ -12,7 +12,8 @@ target := tomoko
- # console := true
- 
- # compiler
--flags += -I. -O3
-+flags += -I. $(CXXFLAGS)
-+link += $(LDFLAGS)
- objects := libco
- 
- # profile-guided optimization mode
-diff -rupN higan_v095-source.orig/icarus/GNUmakefile higan_v095-source/icarus/GNUmakefile
---- higan_v095-source.orig/icarus/GNUmakefile	2015-11-04 10:28:26.186486119 +0100
-+++ higan_v095-source/icarus/GNUmakefile	2015-11-04 10:28:48.755059317 +0100
-@@ -1,8 +1,8 @@
- include ../nall/GNUmakefile
- include ../hiro/GNUmakefile
- 
--flags += -I.. -O3
--link +=
-+flags += -I.. $(CXXFLAGS)
-+link += $(LDFLAGS)
- objects := obj/hiro.o obj/icarus.o
- objects += $(if $(call streq,$(platform),windows),obj/resource.o)
+diff -rupN higan_v097-source.old/higan/GNUmakefile higan_v097-source/higan/GNUmakefile
+--- higan_v097-source.old/higan/GNUmakefile	2016-01-24 09:21:45.822940200 +0100
++++ higan_v097-source/higan/GNUmakefile	2016-01-24 09:24:03.028722500 +0100
+@@ -36,7 +36,7 @@ ifeq ($(platform),windows)
+ else ifeq ($(platform),macosx)
+   flags += -march=native
+ else ifneq ($(filter $(platform),linux bsd),)
+-  flags += -march=native -fopenmp
++  flags += -fopenmp
+   link += -fopenmp
+   link += -Wl,-export-dynamic
+   link += -lX11 -lXext
+diff -rupN higan_v097-source.old/nall/GNUmakefile higan_v097-source/nall/GNUmakefile
+--- higan_v097-source.old/nall/GNUmakefile	2016-01-24 09:21:46.021749600 +0100
++++ higan_v097-source/nall/GNUmakefile	2016-01-24 09:25:06.347100800 +0100
+@@ -40,8 +40,8 @@ cflags := -x c -std=c99
+ objcflags := -x objective-c -std=c99
+ cppflags := -x c++ -std=c++14
+ objcppflags := -x objective-c++ -std=c++14
+-flags :=
+-link :=
++flags := $(CXXFLAGS)
++link := $(LDFLAGS)

--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -5,18 +5,18 @@
 , mesa, SDL
 , libao, openal, libpulseaudio
 , gtk, gtksourceview
-, profile ? "balanced" # Options: accuracy, balanced, performance
 }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "higan-${meta.version}";
-  sourceName = "higan_v${meta.version}-source";
+  name = "higan-${version}";
+  version = "098";
+  sourceName = "higan_v${version}-source";
 
   src = fetchurl {
     urls = [ "http://download.byuu.org/${sourceName}.7z" ];
-    sha256 = "0yc5gwg6dq9iwi2qk3g66wn8j2l55nhdb0311jzmdsh86zcrpvqh";
+    sha256 = "0qphvjfv17dbmzgb4pny2q6ln0lsgzyhalq6qyqxc3qwm4fzdjv1";
     curlOpts = "--user-agent 'Mozilla/5.0'"; # the good old user-agent trick...
   };
 
@@ -31,18 +31,17 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    make compiler=c++ profile=${profile} -C icarus
-    make compiler=c++ profile=${profile}
+    make compiler=c++ -C icarus
+    make compiler=c++ -C higan
   '';
 
   installPhase = ''
     install -dm 755 $out/bin $out/share/applications $out/share/higan $out/share/pixmaps
-    install -m 755 icarus/icarus $out/bin/
-    install -m 755 out/tomoko $out/bin/
-    (cd $out/bin; ln -Ts tomoko higan) #backwards compatibility
-    install -m 644 data/higan.desktop $out/share/applications/
-    install -m 644 data/higan.png $out/share/pixmaps/
-    cp -dr --no-preserve='ownership' profile/* data/cheats.bml $out/share/higan/
+    install -m 755 icarus/out/icarus $out/bin/
+    install -m 755 higan/out/higan $out/bin/
+    install -m 644 higan/data/higan.desktop $out/share/applications/
+    install -m 644 higan/data/higan.png $out/share/pixmaps/
+    cp --recursive --no-dereference --preserve='links' --no-preserve='ownership' higan/data/cheats.bml higan/profile/* $out/share/higan/
   '';
 
   fixupPhase = ''
@@ -54,21 +53,22 @@ stdenv.mkDerivation rec {
     cat <<EOF > $out/bin/higan-init.sh
     #!${stdenv.shell}
 
-    cp --update --recursive $out/share/higan \$HOME/.config
-    chmod --recursive u+w \$HOME/.config/higan
+    cp --update $out/share/higan/cheats.bml \$HOME/.config/
+    cp --recursive --update $out/share/higan/*.sys \$HOME/.local/share/higan/
+
     EOF
 
     chmod +x $out/bin/higan-init.sh
   '';
 
   meta = {
-    version = "096";
     description = "An open-source, cycle-accurate Nintendo multi-system emulator";
     longDescription = ''
       Higan (formerly bsnes) is a Nintendo multi-system emulator.
       It currently supports the following systems:
         Famicom; Super Famicom;
         Game Boy; Game Boy Color; Game Boy Advance
+        WonderSwan; WonderSwan Color
       higan also supports the following subsystems:
         Super Game Boy; BS-X Satellaview; Sufami Turbo
     '';
@@ -82,5 +82,4 @@ stdenv.mkDerivation rec {
 #
 # TODO:
 #   - fix the BML and BIOS paths - maybe submitting
-#     a custom patch to Higan project would not be a bad idea...
-#   - Qt support
+#     a custom patch to upstream would not be a bad idea...

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16550,7 +16550,6 @@ in
 
   higan = callPackage ../misc/emulators/higan {
     inherit (gnome) gtksourceview;
-    profile = config.higan.profile or "balanced";
   };
 
   misc = callPackage ../misc/misc.nix { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Now without some options, reflecting upstream development.
In special, no GTK building (as it was obsoleted on 096)
and no profile selecion, because it will be obsoleted
on next release.
