### PR TITLE
vis: init vis at 0.2x (nightly)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -372,6 +372,7 @@
   vlstill = "Vladimír Štill <xstill@fi.muni.cz>";
   vmandela = "Venkateswara Rao Mandela <venkat.mandela@gmail.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";
+  vrthra = "Rahul Gopinath <rahul@gopinath.org>";
   wedens = "wedens <kirill.wedens@gmail.com>";
   willtim = "Tim Philip Williams <tim.williams.public@gmail.com>";
   winden = "Antonio Vargas Gonzalez <windenntw@gmail.com>";

--- a/pkgs/applications/editors/vis/default.nix
+++ b/pkgs/applications/editors/vis/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, unzip, pkgconfig, makeWrapper, ncurses, libtermkey, lpeg, lua }:
+
+stdenv.mkDerivation rec {
+  name = "vis-nightly-${version}";
+  version = "2016-04-15";
+
+  src = fetchFromGitHub {
+    sha256 = "0a4gpwniy5r9dpfq51fxjxxnxavdjv8x76w9bbjnbnh8n63p3sj7";
+    rev = "472c559a273d3c7b0f5ee92260c5544bc3d74576";
+    repo = "vis";
+    owner = "martanne";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+     unzip
+     pkgconfig
+     ncurses
+     libtermkey
+     lua
+     lpeg
+  ];
+
+  LUA_CPATH="${lpeg}/lib/lua/${lua.luaversion}/?.so;";
+  LUA_PATH="${lpeg}/share/lua/${lua.luaversion}/?.lua";
+
+  postInstall = ''
+    echo wrapping $out/bin/vis with runtime environment
+    wrapProgram $out/bin/vis \
+      --prefix LUA_CPATH : "${lpeg}/lib/lua/${lua.luaversion}/?.so" \
+      --prefix LUA_PATH : "${lpeg}/share/lua/${lua.luaversion}/?.lua" \
+      --prefix VIS_PATH : "$out/share/vis"
+  '';
+
+  meta = {
+    description = "A vim like editor";
+    homepage = http://github.com/martanne/vis;
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.vrthra ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14154,6 +14154,10 @@ in
 
   neovim-pygui = pythonPackages.neovim_gui;
 
+  vis = callPackage ../applications/editors/vis {
+    inherit (lua52Packages) lpeg;
+  };
+
   virt-viewer = callPackage ../applications/virtualization/virt-viewer {
     gtkvnc = gtkvnc.override { enableGTK3 = true; };
     spice_gtk = spice_gtk.override { enableGTK3 = true; };


### PR DESCRIPTION
I am not quite sure how to manage (1). If I get a link on details, I will do that.

This is a current repo checkout of `vis editor` since the last release (v0.2) does not seem to compile correctly on Nix. If there is an alternative mechanism for such packages, I would be happy to update.
###### Things done
- [ ](1) Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Vis editor is a vim like editor.
