### PR TITLE
xsession: Update DBus activation environment

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -165,6 +165,8 @@ in {
         '';
       };
 
+    services.xserver.updateDbusEnvironment = true;
+
     environment.variables.GIO_EXTRA_MODULES = [ "${gnome3.dconf}/lib/gio/modules"
                                                 "${gnome3.glib_networking.out}/lib/gio/modules"
                                                 "${gnome3.gvfs}/lib/gio/modules" ];

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -42,9 +42,12 @@ in
             # Set GTK_DATA_PREFIX so that GTK+ can find the Xfce themes.
             export GTK_DATA_PREFIX=${config.system.path}
 
-            exec ${pkgs.stdenv.shell} ${pkgs.xfce.xinitrc}
+            ${pkgs.stdenv.shell} ${pkgs.xfce.xinitrc} &
+            waitPID=$!
           '';
       };
+
+    services.xserver.updateDbusEnvironment = true;
 
     environment.systemPackages =
       [ pkgs.gtk # To get GTK+'s themes.

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -126,6 +126,14 @@ let
         (*) echo "$0: Desktop manager '$desktopManager' not found.";;
       esac
 
+      ${optionalString cfg.startDbusSession ''
+        ${pkgs.glib}/bin/gdbus call --session \
+          --dest org.freedesktop.DBus --object-path /org/freedesktop/DBus \
+          --method org.freedesktop.DBus.UpdateActivationEnvironment \
+          "{$(env | ${pkgs.gnused}/bin/sed "s/'/\\\\'/g; s/\([^=]*\)=\(.*\)/'\1':'\2'/" \
+                  | ${pkgs.coreutils}/bin/paste -sd,)}"
+      ''}
+
       test -n "$waitPID" && wait "$waitPID"
       exit 0
     '';

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -126,7 +126,7 @@ let
         (*) echo "$0: Desktop manager '$desktopManager' not found.";;
       esac
 
-      ${optionalString cfg.startDbusSession ''
+      ${optionalString (cfg.startDbusSession && cfg.updateDbusEnvironment) ''
         ${pkgs.glib}/bin/gdbus call --session \
           --dest org.freedesktop.DBus --object-path /org/freedesktop/DBus \
           --method org.freedesktop.DBus.UpdateActivationEnvironment \

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -233,6 +233,15 @@ in
         '';
       };
 
+      updateDbusEnvironment = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to update the DBus activation environment after launching the
+          desktop manager.
+        '';
+      };
+
       layout = mkOption {
         type = types.str;
         default = "us";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a slightly hackish way of solving #10577 as described in my comment there and in the commit message. While the bug only directly affects Gnome, the broader issue of an incomplete environment for DBus activation may also affect other cases, so I thought it would be a good choice to update the environment generally. The downside of the way I did this are the ad-hoc escaping and the dependency on glib for `gdbus` (I couldn't get the escaping right with `dbus-send`).
