### PR TITLE
neomutt: init at 20160404

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, which, autoconf, automake, ncurses, perl
+, cyrus_sasl, gdbm, gpgme, kerberos, libidn, notmuch, openssl }:
+
+stdenv.mkDerivation rec {
+  version = "20160404";
+  name = "neomutt-${version}";
+
+  src = fetchFromGitHub {
+    owner = "neomutt";
+    repo = "neomutt";
+    rev = "fba0ecd82522c2eacb1aaa70044cae5a77c93acf";
+    sha256 = "1blyxb5ga0qf1b5qidg12qhf3dfj1vc6xci0g88xy5zkvkjlhmri";
+  };
+
+  buildInputs = with stdenv.lib;
+    [ autoconf automake cyrus_sasl gdbm gpgme kerberos libidn ncurses
+      notmuch which openssl perl ];
+
+  configureFlags = [
+    "--enable-debug"
+    "--enable-gpgme"
+    "--enable-hcache"
+    "--enable-imap"
+    "--enable-notmuch"
+    "--enable-pgp"
+    "--enable-pop"
+    "--enable-sidebar"
+    "--enable-smtp"
+    "--with-homespool=mailbox"
+    "--with-gss"
+    "--with-mailpath="
+    "--with-ssl"
+    "--with-sasl"
+    "--with-curses"
+    "--with-regex"
+    "--with-idn"
+
+    # Look in $PATH at runtime, instead of hardcoding /usr/bin/sendmail
+    "ac_cv_path_SENDMAIL=sendmail"
+  ];
+
+  configureScript = "./prepare";
+
+  meta = with stdenv.lib; {
+    description = "A small but very powerful text-based mail client";
+    homepage = http://www.neomutt.org;
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ hiberno ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13230,6 +13230,8 @@ in
 
   mutt-kz = callPackage ../applications/networking/mailreaders/mutt-kz { };
 
+  neomutt = callPackage ../applications/networking/mailreaders/neomutt { };
+
   notion = callPackage ../applications/window-managers/notion { };
 
   openshift = callPackage ../applications/networking/cluster/openshift { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @the-kenny @magnetophon 
