### PR TITLE
vtk: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,8 +1,10 @@
 { stdenv, fetchurl, fetchpatch, cmake, mesa, libX11, xproto, libXt
-, qtLib ? null }:
+, qtLib ? null
+# Darwin support
+, Cocoa, CoreServices, DiskArbitration, IOKit, CFNetwork, Security, GLUT
+, ApplicationServices, CoreText, IOSurface, cf-private, ImageIO, xpc, libobjc }:
 
 with stdenv.lib;
-
 let
   os = stdenv.lib.optionalString;
   majorVersion = "5.10";
@@ -20,8 +22,13 @@ stdenv.mkDerivation rec {
   # https://bugzilla.redhat.com/show_bug.cgi?id=1138466
   postPatch = "sed '/^#define GL_GLEXT_LEGACY/d' -i ./Rendering/vtkOpenGL.h";
 
-  buildInputs = [ cmake mesa libX11 xproto libXt ]
-    ++ optional (qtLib != null) qtLib;
+  buildInputs =
+    if !stdenv.isDarwin
+    then [ cmake mesa libX11 xproto libXt ] ++ optional (qtLib != null) qtLib
+    else [ cmake qtLib xpc CoreServices DiskArbitration IOKit
+           CFNetwork Security ApplicationServices CoreText IOSurface ImageIO
+           GLUT ];
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ Cocoa libobjc ];
 
   # Shared libraries don't work, because of rpath troubles with the current
   # nixpkgs camke approach. It wants to call a binary at build time, just
@@ -29,7 +36,15 @@ stdenv.mkDerivation rec {
   # At least, we use -fPIC for other packages to be able to use this in shared
   # objects.
   cmakeFlags = [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ]
-    ++ optional (qtLib != null) [ "-DVTK_USE_QT:BOOL=ON" ];
+    ++ optional (qtLib != null) [ "-DVTK_USE_QT:BOOL=ON" ]
+    ++ optional stdenv.isDarwin [ "-DBUILD_TESTING:BOOL=OFF" ];
+
+  postConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's, -F/Applications/Xcode.app/.*\.sdk/System/Library/Frameworks,,' Rendering/CMakeFiles/vtkRendering.dir/flags.make
+    sed -i 's/#define inline//' ../Utilities/vtktiff/tif_config.h.in
+  '';
+
+  doCheck = !stdenv.isDarwin;
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9509,7 +9509,13 @@ in
 
   vrpn = callPackage ../development/libraries/vrpn { };
 
-  vtk = callPackage ../development/libraries/vtk { };
+  vtk = callPackage ../development/libraries/vtk {
+    inherit (darwin) cf-private libobjc;
+    inherit (darwin.apple_sdk.libs) xpc;
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
+                                          IOKit CFNetwork Security ApplicationServices
+                                          CoreText IOSurface ImageIO GLUT;
+  };
 
   vtkWithQt4 = vtk.override { qtLib = qt4; };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  ## \- [ ] Linux

Along with PR #14705, this gets vtkWithQt4 working on darwin.

It is mostly a matter of supplying the necessary frameworks, and
plumbing the system's CoreFoundation framework into cmake.
