### PR TITLE
pcl: visualization components in darwin

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qt4
-, libusb1, libpcap, libXt, libpng
+, libusb1, libpcap, libXt, libpng, Cocoa, AGL, cf-private
 }:
 
 stdenv.mkDerivation rec {
@@ -14,13 +14,22 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildInputs = [ cmake qhull flann boost eigen pkgconfig libusb1 libpcap
-                  libpng vtk qt4 libXt ];
+                  libpng vtk qt4 libXt ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa AGL cf-private ];
+  cmakeFlags = stdenv.lib.optionals stdenv.isDarwin [
+    "-DCMAKE_OSX_SYSROOT=" "-DCMAKE_OSX_DEPLOYMENT_TARGET=" ];
+
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed "s,[[:space:]]*-F$NIX_STORE/[[:alnum:]]*-CF-osx-[[:digit:].]*/Library/Frameworks,,g")
+    sed -i 's,^\(      target_link_libraries("''${LIB_NAME}" "-framework Cocoa")\),\1\n      target_link_libraries("''${LIB_NAME}" "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"),' visualization/CMakeLists.txt
+    sed -i 's,^\(set(SUBSYS_DEPS common io kdtree geometry search)\),\1\nset(CMAKE_OSX_SYSROOT "")\nset(CMAKE_OSX_DEPLOYMENT_TARGET ""),' visualization/CMakeLists.txt
+  '';
 
   meta = {
     homepage = http://pointclouds.org/;
     description = "Open project for 2D/3D image and point cloud processing";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8414,6 +8414,8 @@ in
 
   pcl = callPackage ../development/libraries/pcl {
     vtk = vtkWithQt4;
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) Cocoa AGL;
   };
 
   pcre = callPackage ../development/libraries/pcre { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux

---

Supplies the necessary frameworks and build system tweaks to build the
vtkWithQt4 components on darwin. This follows on from PRs #14705 and #14749.
