### PR TITLE
qt4: add a toplevel entry for the version skype uses

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -11,6 +11,7 @@
 , docs ? false
 , examples ? false
 , demos ? false
+, xmlpatterns ? true
 }:
 
 with stdenv.lib;
@@ -105,7 +106,7 @@ stdenv.mkDerivation rec {
 
       ${if mysql != null then "-plugin" else "-no"}-sql-mysql -system-sqlite
 
-      -exceptions -xmlpatterns
+      ${if xmlpatterns then "-exceptions -xmlpatterns" else "-no-exceptions"}
 
       -make libs -make tools -make translations
       -${if demos then "" else "no"}make demos

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13730,7 +13730,7 @@ in
   siproxd = callPackage ../applications/networking/siproxd { };
 
   skype = callPackage_i686 ../applications/networking/instant-messengers/skype {
-    qt4 = pkgsi686Linux.qt4_clang;
+    qt4 = pkgsi686Linux.qt4.override { xmlpatterns = false; };
   };
 
   skype4pidgin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/skype4pidgin { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8516,6 +8516,8 @@ in
 
   qt4 = self.kde4.qt4;
 
+  qt4_clang = lowPrio (qt4.override { stdenv = clangStdenv; });
+
   qt48 = callPackage ../development/libraries/qt-4.x/4.8 {
     # GNOME dependencies are not used unless gtkStyle == true
     mesa = mesa_noglu;
@@ -13728,9 +13730,7 @@ in
   siproxd = callPackage ../applications/networking/siproxd { };
 
   skype = callPackage_i686 ../applications/networking/instant-messengers/skype {
-    qt4 = pkgsi686Linux.qt4.override {
-      stdenv = pkgsi686Linux.clangStdenv;
-    };
+    qt4 = pkgsi686Linux.qt4_clang;
   };
 
   skype4pidgin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/skype4pidgin { };

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -183,6 +183,7 @@ let
       pythonFull = linux;
       sbcl = linux;
       qt3 = linux;
+      qt4_clang = ["i686-linux"];
       quake3demo = linux;
       reiserfsprogs = linux;
       rubber = allBut cygwin;


### PR DESCRIPTION
Correct me if I'm wrong, but I think without this, the clang/i686 version of qt4 won't get built by the cache, and installing skype will require building it locally, which takes hours?
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Otherwise, it won't get built by hydra
