### PR TITLE
Allow spaces in variables set through makeWrapperArgs

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -16,7 +16,7 @@ makeWrapper() {
             varName=${params[$((n + 1))]}
             value=${params[$((n + 2))]}
             n=$((n + 2))
-            echo "export $varName=$value" >> $wrapper
+            echo "export $varName='$value'" >> $wrapper
         fi
 
         if test "$p" = "--unset"; then

--- a/pkgs/development/python-modules/generic/wrap.sh
+++ b/pkgs/development/python-modules/generic/wrap.sh
@@ -46,16 +46,15 @@ wrapPythonProgramsIn() {
                 # wrapProgram creates the executable shell script described
                 # above. The script will set PYTHONPATH and PATH variables.!
                 # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
-                local wrap_args="$f \
-                                 --prefix PYTHONPATH ':' $program_PYTHONPATH \
-                                 --prefix PATH ':' $program_PATH:$dir/bin"
+                local -a wrap_args=("$f"
+                                 --prefix PYTHONPATH ':' "$program_PYTHONPATH"
+                                 --prefix PATH ':' "$program_PATH:$dir/bin")
 
                 # Add any additional arguments provided by makeWrapperArgs
                 # argument to buildPythonPackage.
-                for arg in $makeWrapperArgs; do
-                    wrap_args="$wrap_args $arg"
-                done
-                wrapProgram $wrap_args
+                local -a user_args="($makeWrapperArgs)"
+                local -a wrapProgramArgs=("${wrap_args[@]}" "${user_args[@]}")
+                wrapProgram "${wrapProgramArgs[@]}"
             fi
         fi
     done


### PR DESCRIPTION
### The issue

If a user tries to set a variable containing spaces with `makeWrapperArgs`, it will be broken up on said spaces by `wrapPythonPrograms` into separate `wrapProgram` arguments, resulting in a broken wrapper script.

E.g. if you do `makeWrapperArgs = ["--set LD_PRELOAD 'lib1 lib2'"]`, the resulting wrapper line will look as such: `export LD_PRELOAD='lib1`, which obviously isn't what we want.
### The fix

Bash supports declaring an array from a string while preserving quoted elements with the following syntax: `declare -a arrName="($varWithQuotedStrings)"`. I've modified `wrapPythonPrograms` to use that rather than naively looping through `makeWrapperArgs` (which is passed from Nix as a single string and has to be broken up one way or another).

I also had to add quotes around the exported variables from `wrapProgram` to cater for this new functionality. Otherwise the above example would end up as `export LD_PRELOAD=lib1 lib2` which naturally also breaks the parser.
### The merge

This triggers a rather hefty rebuild as everything that uses `makeWrapper` is affected. The `makeWrapper` change will cause breakage if there are cases where it's already quoted, and there is a chance that the new `wrapPythonPrograms` behaviour might break some uses. It may be wise to merge the `make-wrapper.sh` fix first to reduce noise.
