### PR TITLE
pygobject: fix some warnings

### DIFF
--- a/pkgs/development/python-modules/pygobject/default.nix
+++ b/pkgs/development/python-modules/pygobject/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "docdev" ];
 
+  patches = [
+    # Fix warning spam
+    ./pygobject-2.28.6-set_qdata.patch
+    ./pygobject-2.28.6-gio-types-2.32.patch
+  ];
+
   configureFlags = "--disable-introspection";
 
   buildInputs = [ python pkgconfig glib ];

--- a/pkgs/development/python-modules/pygobject/pygobject-2.28.6-gio-types-2.32.patch
+++ b/pkgs/development/python-modules/pygobject/pygobject-2.28.6-gio-types-2.32.patch
@@ -1,0 +1,50 @@
+From 42d01f060c5d764baa881d13c103d68897163a49 Mon Sep 17 00:00:00 2001
+From: Ryan Lortie <desrt@desrt.ca>
+Date: Mon, 12 Mar 2012 16:44:14 -0400
+Subject: [PATCH] gio-types.defs: change some enums to flags
+
+These flags types were originally incorrectly handled in glib as being
+enums.  That bug was fixed, but they're still enums here, leading to
+warnings about the mismatch.
+
+Change them to flags.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=668522
+---
+ gio/gio-types.defs |    6 +++---
+ 1 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gio/gio-types.defs b/gio/gio-types.defs
+index 331e0bc..7eee5c8 100644
+--- a/gio/gio-types.defs
++++ b/gio/gio-types.defs
+@@ -526,7 +526,7 @@
+   )
+ )
+ 
+-(define-enum MountMountFlags
++(define-flags MountMountFlags
+   (in-module "gio")
+   (c-name "GMountMountFlags")
+   (gtype-id "G_TYPE_MOUNT_MOUNT_FLAGS")
+@@ -545,7 +545,7 @@
+   )
+ )
+ 
+-(define-enum DriveStartFlags
++(define-flags DriveStartFlags
+   (in-module "gio")
+   (c-name "GDriveStartFlags")
+   (gtype-id "G_TYPE_DRIVE_START_FLAGS")
+@@ -770,7 +770,7 @@
+   )
+ )
+ 
+-(define-enum SocketMsgFlags
++(define-flags SocketMsgFlags
+   (in-module "gio")
+   (c-name "GSocketMsgFlags")
+   (gtype-id "G_TYPE_SOCKET_MSG_FLAGS")
+-- 
+1.7.8.5
+

--- a/pkgs/development/python-modules/pygobject/pygobject-2.28.6-set_qdata.patch
+++ b/pkgs/development/python-modules/pygobject/pygobject-2.28.6-set_qdata.patch
@@ -1,0 +1,28 @@
+From 42d871eb0b08ee6d55e95cc7e4b90844919555b9 Mon Sep 17 00:00:00 2001
+From: Ivan Stankovic <ivan.stankovic@avl.com>
+Date: Tue, 21 Feb 2012 12:24:58 +0100
+Subject: [PATCH] Fix set_qdata warning on accessing NULL gobject property
+
+https://bugzilla.gnome.org/show_bug.cgi?id=661155
+---
+ gobject/pygobject.c |    4 +++-
+ 1 files changed, 3 insertions(+), 1 deletions(-)
+
+diff --git a/gobject/pygobject.c b/gobject/pygobject.c
+index 6c2f06c..70dc89a 100644
+--- a/gobject/pygobject.c
++++ b/gobject/pygobject.c
+@@ -991,7 +991,9 @@ pygobject_new(GObject *obj)
+ PyObject *
+ pygobject_new_sunk(GObject *obj)
+ {
+-    g_object_set_qdata (obj, pygobject_ref_sunk_key, GINT_TO_POINTER (1));
++    if (obj)
++       g_object_set_qdata (obj, pygobject_ref_sunk_key, GINT_TO_POINTER (1));
++       
+     return pygobject_new_full(obj, TRUE, NULL);
+ }
+ 
+-- 
+1.7.8.5
+


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

When running applications dependent on `pygobject` some warnings regarding `gtype` may be shown:

```
$ xdgmenumaker --help

** (process:2207): WARNING **: Trying to register gtype 'GMountMountFlags' as enum when in fact it is of type 'GFlags'

** (process:2207): WARNING **: Trying to register gtype 'GDriveStartFlags' as enum when in fact it is of type 'GFlags'

** (process:2207): WARNING **: Trying to register gtype 'GSocketMsgFlags' as enum when in fact it is of type 'GFlags'
[...]
```

The fixes have been taken from [Gentoo Linux](https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-python/pygobject).
