### PR TITLE
xdgmenumaker: init at 0.9

### DIFF
--- a/pkgs/applications/misc/xdgmenumaker/default.nix
+++ b/pkgs/applications/misc/xdgmenumaker/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, txt2tags, python2Packages }:
+
+stdenv.mkDerivation rec {
+  name = "xdgmenumaker-${version}";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    rev = version;
+    owner = "gapan";
+    repo = "xdgmenumaker";
+    sha256 = "1n29syadsgj0vpnkc8nji4k1c8gminr1xdriz5ck2bcygsgxkdrd";
+  };
+
+  nativeBuildInputs = [
+    txt2tags
+    python2Packages.wrapPython
+  ];
+
+  pythonPath = [
+    python2Packages.pyxdg
+    python2Packages.pygtk
+  ];
+
+  installPhase = ''
+    make install PREFIX=$out DESTDIR=
+    wrapProgram "$out/bin/xdgmenumaker" \
+      --prefix XDG_DATA_DIRS : "$out/share"
+    wrapPythonPrograms
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "Command line tool that generates XDG menus for several window managers";
+    homepage = https://github.com/gapan/xdgmenumaker;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14418,6 +14418,8 @@ in
     w3m = w3m-batch;
   };
 
+  xdgmenumaker = callPackage ../applications/misc/xdgmenumaker { };
+
   xdotool = callPackage ../tools/X11/xdotool { };
 
   xen_4_5_0 = callPackage ../applications/virtualization/xen/4.5.0.nix { stdenv = overrideCC stdenv gcc49; };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
