### PR TITLE
openssh: fix CVE-2015-8325

### DIFF
--- a/pkgs/tools/networking/openssh/CVE-2015-8325.patch
+++ b/pkgs/tools/networking/openssh/CVE-2015-8325.patch
@@ -1,0 +1,28 @@
+From 85bdcd7c92fe7ff133bbc4e10a65c91810f88755 Mon Sep 17 00:00:00 2001
+From: Damien Miller <djm@mindrot.org>
+Date: Wed, 13 Apr 2016 10:39:57 +1000
+Subject: [PATCH] ignore PAM environment vars when UseLogin=yes
+
+If PAM is configured to read user-specified environment variables
+and UseLogin=yes in sshd_config, then a hostile local user may
+attack /bin/login via LD_PRELOAD or similar environment variables
+set via PAM.
+
+CVE-2015-8325, found by Shayan Sadigh, via Colin Watson
+---
+ session.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/session.c b/session.c
+index 4859245..4653b09 100644
+--- a/session.c
++++ b/session.c
+@@ -1322,7 +1322,7 @@ do_setup_env(Session *s, const char *shell)
+ 	 * Pull in any environment variables that may have
+ 	 * been set by PAM.
+ 	 */
+-	if (options.use_pam) {
++	if (options.use_pam && !options.use_login) {
+ 		char **p;
+ 
+ 		p = fetch_pam_child_environment();

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -41,8 +41,10 @@ stdenv.mkDerivation rec {
     '';
 
   patches =
-    [ ./locale_archive.patch
+    [
+      ./locale_archive.patch
       ./fix-host-key-algorithms-plus.patch
+      ./CVE-2015-8325.patch
     ]
     ++ optional withGssapiPatches gssapiSrc;
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Debian Security Advisory: https://www.debian.org/security/2016/dsa-3550
Upstream commit: https://anongit.mindrot.org/openssh.git/commit/?id=85bdcd7c92fe7ff133bbc4e10a65c91810f88755
