### PR TITLE
brgenml1cupswrapper: fix regression and improvements

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16035,7 +16035,7 @@ in
 
   beep = callPackage ../misc/beep { };
 
-  brgenml1lpr = callPackage ../misc/cups/drivers/brgenml1lpr {};
+  brgenml1lpr = callPackage_i686 ../misc/cups/drivers/brgenml1lpr {};
 
   brgenml1cupswrapper = callPackage ../misc/cups/drivers/brgenml1cupswrapper {};
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  - [x] Tested non-rebased version by printing through it. Worked fine.
  - [x] Built rebased version using `nix-shell -p`. Built fine.

---

`cp`, `grep`, `chmod`, `sed` executables
no longer found when upgrading from nixos
15.09 to 16.03. Fixed by use of wrapper
script that brings these executables into
`PATH`.

Also fix lpd binaries on 64 bits machines
by use of `callPackage_i686`.
