### PR TITLE
helvetica-neue-lt-std: init at 2013.06.07

### DIFF
--- a/pkgs/data/fonts/helvetica-neue-lt-std/default.nix
+++ b/pkgs/data/fonts/helvetica-neue-lt-std/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "helvetica-neue-lt-std-${version}";
+  version = "2013.06.07"; # date of most recent file in distribution
+
+  src = fetchurl {
+    url = "http://www.ephifonts.com/downloads/helvetica-neue-lt-std.zip";
+    sha256 = "0nrjdj2a11dr6d3aihvjxzrkdi0wq6f2bvaiimi5iwmpyz80n0h6";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  sourceRoot = "Helvetica Neue LT Std";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    cp -v *.otf $out/share/fonts/opentype
+  '';
+
+  meta = {
+    homepage = http://www.ephifonts.com/free-helvetica-font-helvetica-neue-lt-std.html;
+    description = "Helvetica Neue LT Std font";
+    longDescription = ''
+      Helvetica Neue Lt Std is one of the most highly rated and complete
+      fonts of all time. Developed in early 1983, this font has well
+      camouflaged heights and weights. The structure of the word is uniform
+      throughout all the characters.
+
+      The legibility with Helvetica Neue LT Std is said to have improved as
+      opposed to other fonts. The tail of it is much longer in this
+      font. The numbers are well spaced and defined with high accuracy. The
+      punctuation marks are heavily detailed as well.
+    '';
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11334,6 +11334,8 @@ in
 
   hack-font = callPackage ../data/fonts/hack { };
 
+  helvetica-neue-lt-std = callPackage ../data/fonts/helvetica-neue-lt-std { };
+
   hicolor_icon_theme = callPackage ../data/icons/hicolor-icon-theme { };
 
   hanazono = callPackage ../data/fonts/hanazono { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
