### PR TITLE
bedup: update 20140413 -> 0.10

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1768,17 +1768,20 @@ in modules // {
   };
 
   bedup = buildPythonPackage rec {
-    name = "bedup-20140413";
+    version = "0.10";
+    name = "bedup-${version}";
 
     src = pkgs.fetchgit {
       url = "https://github.com/g2p/bedup.git";
-      rev = "5189e166145b8954ac41883f81ef3c3b50dc96ab";
-      sha256 = "e61768fa19934bd176799f90bda3ea9f49a5def21fa2523a8e47df8a48e730e9";
+      rev = "598fd4b";
+      sha256 = "0s11dpf4k26n8qxrx6wcsr78vp98rx3yibzkh6ifmsyaqcmpm7wy";
     };
 
     buildInputs = with self; [ pkgs.btrfs-progs ];
     propagatedBuildInputs = with self; [ contextlib2 pyxdg pycparser alembic ]
       ++ optionals (!isPyPy) [ cffi ];
+
+    disabled = pythonOlder "3.3";
 
     # No proper test suite. Included tests cannot be run because of relative import
     doCheck = false;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
