### PR TITLE
[RFC/WIP] multiple-outputs: Change the order of outputs to have binaries in the primary output

### DIFF
--- a/doc/multiple-output.xml
+++ b/doc/multiple-output.xml
@@ -29,15 +29,15 @@
 
 <section><title>Using a split package</title>
   <para>In the Nix language the individual outputs can be reached explicitly as attributes, e.g. <varname>coreutils.info</varname>, but the typical case is just using packages as build inputs.</para>
-  <para>When a multiple-output derivation gets into a build input of another derivation, the first output is added (<varname>.dev</varname> by convention) and also <varname>propagatedBuildOutputs</varname> of that package which by default contain <varname>$outputBin</varname> and <varname>$outputLib</varname>. (See <xref linkend="multiple-output-file-type-groups" />.)</para>
+  <para>When a multiple-output derivation gets into a build input of another derivation, the <varname>dev</varname> output is added if it exists, otherwise the first output is added. In addition to that, <varname>propagatedBuildOutputs</varname> of that package which by default contain <varname>$outputBin</varname> and <varname>$outputLib</varname> are also added. (See <xref linkend="multiple-output-file-type-groups" />.)</para>
 </section>
 
 
 <section><title>Writing a split derivation</title>
   <para>Here you find how to write a derivation that produces multiple outputs.</para>
   <para>In nixpkgs there is a framework supporting multiple-output derivations. It tries to cover most cases by default behavior.  You can find the source separated in &lt;<filename>nixpkgs/pkgs/build-support/setup-hooks/multiple-outputs.sh</filename>&gt;; it's relatively well-readable.  The whole machinery is triggered by defining the <varname>outputs</varname> attribute to contain the list of desired output names (strings).</para>
-  <programlisting>outputs = [ "dev" "out" "bin" "doc" ];</programlisting>
-  <para>Often such a single line is enough.  For each output an equally named environment variable is passed to the builder and contains the path in nix store for that output.  By convention, the first output should usually be <varname>dev</varname>; typically you also want to have the main <varname>out</varname> output, as it catches any files that didn't get elsewhere.</para>
+  <programlisting>outputs = [ "bin" "dev" "out" "doc" ];</programlisting>
+  <para>Often such a single line is enough.  For each output an equally named environment variable is passed to the builder and contains the path in nix store for that output.  By convention, the first output should contain the executable programs provided by the package as that output is used by Nix in string conversions, allowing references to binaries like <literal>${pkgs.perl}/bin/perl</literal> to always work. Typically you also want to have the main <varname>out</varname> output, as it catches any files that didn't get elsewhere.</para>
 
   <note><para>There is a special handling of the <varname>debug</varname> output, described at <xref linkend="stdenv-separateDebugInfo" />.</para></note>
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -454,6 +454,8 @@ rec {
   getLib = getOutput "lib";
   getDev = getOutput "dev";
 
+  /* Pick the outputs of packages to place in buildInputs */
+  chooseDevOutputs = drvs: builtins.map (drv: if drv.outputUnspecified or false then drv.dev or drv else drv) drvs;
 
   /*** deprecated stuff ***/
 

--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -35,6 +35,17 @@ following incompatible changes:</para>
 <itemizedlist>
 
   <listitem>
+    <para>A large number of packages have been converted to use the multiple outputs feature
+      of Nix to greatly reduce the amount of required disk space. This may require changes
+      to any custom packages to make them build again; see the relevant chapter in the
+      Nixpkgs manual for more information. (Additional caveat to packagers: some packaging conventions
+      related to multiple-output packages
+      <link xlink:href="https://github.com/NixOS/nixpkgs/pull/14766">were changed</link>
+      late (August 2016) in the release cycle and differ from the initial introduction of multiple outputs.)
+    </para>
+  </listitem>
+
+  <listitem>
     <para>Shell aliases for systemd sub-commands
     <link xlink:href="https://github.com/NixOS/nixpkgs/pull/15598">were dropped</link>:
     <command>start</command>, <command>stop</command>,

--- a/pkgs/applications/audio/ardour/ardour3.nix
+++ b/pkgs/applications/audio/ardour/ardour3.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = \"${revision}\"; }\n' > libs/ardour/revision.cc
-    sed 's|/usr/include/libintl.h|${glibc}/include/libintl.h|' -i wscript
+    sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
     patchShebangs ./tools/
   '';
 

--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   #doCheck = true; # takes lots of time
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   meta = with stdenv.lib; {
     homepage = http://xiph.org/flac/;

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./imagetragick.patch ] ++ cfg.patches;
 
-  outputs = [ "dev" "out" "doc" ]; # bin/ isn't really big
+  outputs = [ "out" "dev" "doc" ]; # bin/ isn't really big
   outputMan = "out"; # it's tiny
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/djvulibre/default.nix
+++ b/pkgs/applications/misc/djvulibre/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0psh3zl9dj4n4r3lx25390nx34xz0bg0ql48zdskhq354ljni5p6";
   };
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   buildInputs = [ libjpeg libtiff librsvg ] ++ libintlOrEmpty;
 

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=$(out)" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib libX11 libXcursor libXext harfbuzz mesa libXrandr libXinerama freetype libjpeg jbig2dec openjpeg ];
-  outputs = [ "out" "bin" "doc" ];
+  outputs = [ "bin" "out" "doc" ];
 
   preConfigure = ''
     # Don't remove mujs because upstream version is incompatible

--- a/pkgs/applications/misc/pgadmin/default.nix
+++ b/pkgs/applications/misc/pgadmin/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--with-libxml2=${libxml2}"
+    "--with-libxml2=${libxml2.dev}"
     "--with-libxslt=${libxslt.dev}"
   ];
 

--- a/pkgs/applications/misc/taskjuggler/default.nix
+++ b/pkgs/applications/misc/taskjuggler/default.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = "
     --without-arts --disable-docs
-    --x-includes=${libX11}/include
-    --x-libraries=${libX11}/lib
+    --x-includes=${libX11.dev}/include
+    --x-libraries=${libX11.out}/lib
     --with-qt-dir=${qt3}
   ";
 

--- a/pkgs/applications/science/electronics/tkgate/1.x.nix
+++ b/pkgs/applications/science/electronics/tkgate/1.x.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     sed -i config.h \
       -e 's|.*#define.*TKGATE_TCLTK_VERSIONS.*|#define TKGATE_TCLTK_VERSIONS "${tcl.release}"|' \
-      -e 's|.*#define.*TKGATE_INCDIRS.*|#define TKGATE_INCDIRS "${tcl}/include ${tk}/include ${libiconvInc} ${libX11}/include"|' \
-      -e 's|.*#define.*TKGATE_LIBDIRS.*|#define TKGATE_LIBDIRS "${tcl}/lib ${tk}/lib ${libiconvLib} ${libX11}/lib"|' \
+      -e 's|.*#define.*TKGATE_INCDIRS.*|#define TKGATE_INCDIRS "${tcl}/include ${tk}/include ${libiconvInc} ${libX11.dev}/include"|' \
+      -e 's|.*#define.*TKGATE_LIBDIRS.*|#define TKGATE_LIBDIRS "${tcl}/lib ${tk}/lib ${libiconvLib} ${libX11.out}/lib"|' \
       \
       -e '20 i #define TCL_LIBRARY "${tcl}/lib"' \
       -e '20 i #define TK_LIBRARY "${tk}/lib/${tk.libPrefix}"' \

--- a/pkgs/applications/science/math/calc/default.nix
+++ b/pkgs/applications/science/math/calc/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 let
   makeFlags = ''
-    INCDIR=${glibc}/include \
+    INCDIR=${glibc.dev}/include \
     BINDIR=$out/bin LIBDIR=$out/lib CALC_INCDIR=$out/include/calc CALC_SHAREDIR=$out/share/calc MANDIR=$out/share/man/man1 \
     USE_READLINE=-DUSE_READLINE READLINE_LIB=-lreadline READLINE_EXTRAS='-lhistory -lncurses' \
     TERMCONTROL=-DUSE_TERMIOS \

--- a/pkgs/applications/version-management/redmine/default.nix
+++ b/pkgs/applications/version-management/redmine/default.nix
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
     mkdir -p vendor/cache
     ${stdenv.lib.concatStrings (map (gem: "ln -s ${gem} vendor/cache/${gem.name};") gemspec)}
 
-    bundle config build.nokogiri --use-system-libraries --with-iconv-dir="${libiconv}" --with-xslt-dir="${libxslt.dev}" --with-xml2-dir="${libxml2}"
+    bundle config build.nokogiri --use-system-libraries --with-iconv-dir="${libiconv}" --with-xslt-dir="${libxslt.dev}" --with-xml2-dir="${libxml2.dev}"
 
     bundle install --verbose --local --deployment
 

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -27,7 +27,7 @@ let
     };
 
   # Can't do separate $lib and $bin, as libs reference bins
-  outputs = [ "dev" "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
     buildInputs = [ zlib apr aprutil sqlite ]
       ++ stdenv.lib.optional httpSupport serf

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -160,8 +160,7 @@ _multioutDevs() {
     done
 }
 
-# Make the first output (typically "dev") propagate other outputs needed for development.
-# Take the first, because that's what one gets when putting the package into buildInputs.
+# Make the "dev" propagate other outputs needed for development.
 # Note: with current cross-building setup, all packages are "native" if not cross-building;
 # however, if cross-building, the outputs are non-native. We have to choose the right file.
 _multioutPropagateDev() {
@@ -171,13 +170,17 @@ _multioutPropagateDev() {
     for outputFirst in $outputs; do
         break
     done
+    local propagaterOutput="$outputDev"
+    if [ -z "$propagaterOutput" ]; then
+        propagaterOutput="$outputFirst"
+    fi
 
     # Default value: propagate binaries, includes and libraries
     if [ -z "${propagatedBuildOutputs+1}" ]; then
         local po_dirty="$outputBin $outputInclude $outputLib"
         set +o pipefail
         propagatedBuildOutputs=`echo "$po_dirty" \
-            | tr -s ' ' '\n' | grep -v -F "$outputFirst" \
+            | tr -s ' ' '\n' | grep -v -F "$propagaterOutput" \
             | sort -u | tr '\n' ' ' `
         set -o pipefail
     fi
@@ -187,7 +190,6 @@ _multioutPropagateDev() {
         return
     fi
 
-    mkdir -p "${!outputFirst}"/nix-support
     local propagatedBuildInputsFile
     if [ -z "$crossConfig" ]; then
         propagatedBuildInputsFile=propagated-native-build-inputs
@@ -195,8 +197,9 @@ _multioutPropagateDev() {
         propagatedBuildInputsFile=propagated-build-inputs
     fi
 
+    mkdir -p "${!propagaterOutput}"/nix-support
     for output in $propagatedBuildOutputs; do
-        echo -n " ${!output}" >> "${!outputFirst}"/nix-support/$propagatedBuildInputsFile
+        echo -n " ${!output}" >> "${!propagaterOutput}"/nix-support/$propagatedBuildInputsFile
     done
 }
 

--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "09ch709cb9fniwc4221xgkq0jf0x0lxs814sqig8p2dcll0llvzk";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   buildInputs = [ ORBit2 dbus_libs dbus_glib libxml2 ]
     # polkit requires pam, which requires shadow.h, which is not available on

--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib libIDL ] ++ libintlOrEmpty;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   preBuild = ''
     sed 's/-DG_DISABLE_DEPRECATED//' -i linc2/src/Makefile

--- a/pkgs/desktops/gnome-2/platform/gnome-vfs/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gnome-vfs/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ajg8jb8k3snxc7rrgczlh8daxkjidmcv3zr9w809sq4p2sn9pk2";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs =
     [ pkgconfig libxml2 bzip2 openssl samba dbus_glib fam cdparanoia

--- a/pkgs/desktops/gnome-2/platform/libbonobo/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libbonobo/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0swp4kk6x7hy1rvd1f9jba31lvfc6qvafkvbpg9h0r34fzrd8q4i";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   preConfigure = # still using stuff deprecated in new glib versions
     "sed 's/-DG_DISABLE_DEPRECATED//g' -i configure activation-server/Makefile.in";

--- a/pkgs/desktops/gnome-2/platform/libglade/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libglade/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1v2x2s04jry4gpabws92i0wq2ghd47yr5n9nhgnkd7c38xv1wdk4";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ pkgconfig gtk python gettext ];
 

--- a/pkgs/desktops/gnome-2/platform/libgnome/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libgnome/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "197pnq8y0knqjhm2fg4j6hbqqm3qfzfnd0irhwxpk1b4hqb3kimj";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   patches = [ ./new-glib.patch ];
 

--- a/pkgs/desktops/gnome-2/platform/libgnomecanvas/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libgnomecanvas/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h6xvswbqspdifnyh5pm2pqq55yp3kn6yrswq7ay9z49hkh7i6w5";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ libglade ];
   nativeBuildInputs = [ pkgconfig intltool ];

--- a/pkgs/desktops/gnome-3/3.20/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/apps/evolution/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
   configureFlags = [ "--disable-spamassassin" "--disable-pst-import" "--disable-autoar"
                      "--disable-libcryptui" ];
 
-  NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss}/include/nss -I${glib.dev}/include/gio-unix-2.0";
+  NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss.dev}/include/nss -I${glib.dev}/include/gio-unix-2.0";
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/3.20/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/epiphany/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
                   gdk_pixbuf gnome3.defaultIconTheme librsvg which gnome_common
                   gcr avahi gnome3.gsettings_desktop_schemas gnome3.dconf ];
 
-  NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss}/include/nss -I${glib.dev}/include/gio-unix-2.0";
+  NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss.dev}/include/nss -I${glib.dev}/include/gio-unix-2.0";
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/3.20/core/folks/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/folks/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--disable-fatal-warnings";
 
-  NIX_CFLAGS_COMPILE = ["-I${nspr.dev}/include/nspr" "-I${nss}/include/nss"
+  NIX_CFLAGS_COMPILE = ["-I${nspr.dev}/include/nspr" "-I${nss.dev}/include/nss"
                         "-I${dbus_glib.dev}/include/dbus-1.0" "-I${dbus_libs.dev}/include/dbus-1.0"];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/3.20/core/libcroco/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/libcroco/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mm0wldbi40am5qn0nv7psisbg01k42rwzjxl3gv11l5jj554aqk";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   configureFlags = stdenv.lib.optional stdenv.isDarwin "--disable-Bsymbolic";

--- a/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
@@ -36,6 +36,6 @@ plasmaPackage rec {
   NIX_CFLAGS_COMPILE = [ "-I${xorgserver.dev}/include/xorg" ];
   cmakeFlags = [
     "-DEvdev_INCLUDE_DIRS=${xf86inputevdev.dev}/include/xorg"
-    "-DSynaptics_INCLUDE_DIRS=${xf86inputsynaptics}/include/xorg"
+    "-DSynaptics_INCLUDE_DIRS=${xf86inputsynaptics.dev}/include/xorg"
   ];
 }

--- a/pkgs/desktops/xfce/core/exo.nix
+++ b/pkgs/desktops/xfce/core/exo.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
     # lib/xfce4/exo-1/exo-compose-mail-1 is a perl script :-/
 
   nativeBuildInputs = [ pkgconfig intltool ];

--- a/pkgs/desktops/xfce/core/garcon.nix
+++ b/pkgs/desktops/xfce/core/garcon.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wm9pjbwq53s3n3nwvsyf0q8lbmhiy2ln3bn5ncihr9vf5cwhzbq";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ pkgconfig intltool glib libxfce4util gtk libxfce4ui ];
 

--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "3d619811bfbe7478bb984c16543d980cadd08586365a7bc25e59e3ca6384ff43";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/desktops/xfce/core/libxfce4util.nix
+++ b/pkgs/desktops/xfce/core/libxfce4util.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "07c8r3xwx5is298zk77m3r784gmr5y4mh8bbca5zdjqk5vxdwsw7";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   buildInputs = [ pkgconfig glib intltool ];
 

--- a/pkgs/desktops/xfce/core/libxfcegui4.nix
+++ b/pkgs/desktops/xfce/core/libxfcegui4.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cs5im0ib0cmr1lhr5765yliqjfyxvk4kwy8h1l8bn3mj6bzk0ib";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   #TODO: gladeui
   # By default, libxfcegui4 tries to install into libglade's prefix.

--- a/pkgs/desktops/xfce/core/tumbler.nix
+++ b/pkgs/desktops/xfce/core/tumbler.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wvip28gm2w061hn84zp2q4dv947ihylrppahn4cjspzff935zfh";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   buildInputs = [
     pkgconfig intltool dbus_glib gdk_pixbuf curl freetype

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [ ./xfce4-panel-datadir.patch ];
   patchFlags = "-p1";
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   buildInputs =
     [ pkgconfig intltool gtk libxfce4util exo libwnck

--- a/pkgs/desktops/xfce/core/xfconf.nix
+++ b/pkgs/desktops/xfce/core/xfconf.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mmi0g30aln3x98y5p507g17pipq0dj0bwypshan8cq5hkmfl44r";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   #TODO: no perl bingings yet (ExtUtils::Depends, ExtUtils::PkgConfig, Glib)
   buildInputs = [ pkgconfig intltool glib libxfce4util ];

--- a/pkgs/development/compilers/orc/default.nix
+++ b/pkgs/development/compilers/orc/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lak3hyvvb0w9avzmf0a8vayb7vqhj4m709q1czlhvgjb15dbcf1";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev"; # compilation tools
 
   postInstall = ''

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "1c2i9ih331304bh31c5gh94fx0qa49rsn70pvczvdfhi8pmcms6g";
   };
 
-  outputs = [ "dev" "out" "bin" "static" ];
+  outputs = [ "bin" "dev" "out" "static" ];
 
   postPatch = ''
     substituteInPlace Makefile --replace \

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   nativeBuildInputs = [ perl texinfo ];
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -824,10 +824,10 @@ self: super: {
   # https://github.com/ivanperez-keera/hcwiid/pull/4
   hcwiid = overrideCabal super.hcwiid (drv: {
     configureFlags = (drv.configureFlags or []) ++ [
-      "--extra-lib-dirs=${pkgs.bluez}/lib"
+      "--extra-lib-dirs=${pkgs.bluez.out}/lib"
       "--extra-lib-dirs=${pkgs.cwiid}/lib"
       "--extra-include-dirs=${pkgs.cwiid}/include"
-      "--extra-include-dirs=${pkgs.bluez}/include"
+      "--extra-include-dirs=${pkgs.bluez.dev}/include"
     ];
     prePatch = '' sed -i -e "/Extra-Lib-Dirs/d" -e "/Include-Dirs/d" "hcwiid.cabal" '';
   });

--- a/pkgs/development/interpreters/erlang/R14.nix
+++ b/pkgs/development/interpreters/erlang/R14.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     sed -e s@/bin/pwd@pwd@g -i otp_build
   '';
 
-  configureFlags = "--with-ssl=${openssl}";
+  configureFlags = "--with-ssl=${openssl.dev}";
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -108,12 +108,12 @@ let
 
         mysql = {
           configureFlags = ["--with-mysql"];
-          buildInputs = [ mysql.lib ];
+          buildInputs = [ mysql.lib.dev ];
         };
 
         mysqli = {
-          configureFlags = ["--with-mysqli=${mysql.lib}/bin/mysql_config"];
-          buildInputs = [ mysql.lib ];
+          configureFlags = ["--with-mysqli=${mysql.lib.dev}/bin/mysql_config"];
+          buildInputs = [ mysql.lib.dev ];
         };
 
         mysqli_embedded = {
@@ -123,8 +123,8 @@ let
         };
 
         pdo_mysql = {
-          configureFlags = ["--with-pdo-mysql=${mysql.lib}"];
-          buildInputs = [ mysql.lib ];
+          configureFlags = ["--with-pdo-mysql=${mysql.lib.dev}"];
+          buildInputs = [ mysql.lib.dev ];
         };
 
         bcmath = {

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation {
        export MACOSX_DEPLOYMENT_TARGET=10.6
      ''}
 
-    substituteInPlace ./Lib/plat-generic/regen --replace "/usr/include" ${glibc}/include
+    substituteInPlace ./Lib/plat-generic/regen --replace "/usr/include" ${glibc.dev}/include
 
     configureFlagsArray=( --enable-shared --with-threads
                           CPPFLAGS="${concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs)}"

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -156,7 +156,7 @@ let
           baseRuby = baseruby;
           libPath = "lib/${rubyEngine}/${versionNoPatch}";
           gemPath = "lib/${rubyEngine}/gems/${versionNoPatch}";
-          dev = import ./dev.nix {
+          devEnv = import ./dev.nix {
             inherit buildEnv bundler bundix;
             ruby = self;
           };

--- a/pkgs/development/interpreters/spidermonkey/17.0.nix
+++ b/pkgs/development/interpreters/spidermonkey/17.0.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fig2wf4f10v43mqx67y68z6h77sy900d1w0pz9qarrqx57rc7ij";
   };
 
-  outputs = [ "dev" "out" "lib" ];
+  outputs = [ "out" "dev" "lib" ];
 
   propagatedBuildInputs = [ nspr ];
 

--- a/pkgs/development/interpreters/spidermonkey/24.2.nix
+++ b/pkgs/development/interpreters/spidermonkey/24.2.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1n1phk8r3l8icqrrap4czplnylawa0ddc2cc4cgdz46x3lrkybz6";
   };
 
-  outputs = [ "dev" "out" "lib" ];
+  outputs = [ "out" "dev" "lib" ];
 
   propagatedBuildInputs = [ nspr ];
 

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "005d993xcac8236fpvd1iawkz4wqjybkpn8dbwaliqz5jfkidlyn";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev"; # sdl-config
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/aalib/default.nix
+++ b/pkgs/development/libraries/aalib/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1vkh19gb76agvh4h87ysbrgy82hrw88lnsvhynjf4vng629dmpgv";
   };
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
   setOutputFlags = false; # Doesn't support all the flags
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin.patch ];

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "08qd9s3wfhv0ajswsylnfwr5h0d7j9d4rgip855nrh400nxp940p";
   };
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   nativeBuildInputs = [ gettext ];
   buildInputs = [ attr ];

--- a/pkgs/development/libraries/agg/default.nix
+++ b/pkgs/development/libraries/agg/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sh autogen.sh
   '';
 
-  configureFlags = "--x-includes=${libX11}/include --x-libraries=${libX11}/lib";
+  configureFlags = "--x-includes=${libX11.dev}/include --x-libraries=${libX11.out}/lib";
 
   meta = {
     description = "High quality rendering engine for C++";

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   patches = optional stdenv.isFreeBSD ./include-static-dependencies.patch;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   buildInputs = optional stdenv.isFreeBSD autoreconfHook;

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./is-this-a-compiler-bug.patch ];
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   preConfigure =

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "88a4de9d43139f13cca531b47b901bc1b56e0ab06ba899126644abd4ac16a143";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [
     python pkgconfig popt  intltool dbus_glib

--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = libintlOrEmpty;
 

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nd8y0m6awc9ahv0ciiwf8gy54c8d3j51pw9xg7f7cn579jjyxr5";
   };
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   nativeBuildInputs = [ gettext ];
 

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
   patches = if stdenv.isCygwin then [ ./cygwin.patch ] else null;
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   configureFlags =
     [ "--enable-cplusplus" ]

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -162,7 +162,7 @@ stdenv.mkDerivation {
 
   postFixup = fixup;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   setOutputFlags = false;
 
   crossAttrs = rec {

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     patches="$patches $(echo $infinality/*_cairo-iu/*.patch)"
   '';
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev"; # very small
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1hvvbcsg21nlncbgs0cgn3iwlnb3vannzwsp6rwvnn9ba4v53g4g";
   };
 
-  outputs = [ "dev" "bin" "out" "man" "docdev" ];
+  outputs = [ "bin" "dev" "out" "man" "docdev" ];
 
   buildInputs =
     [ openssl db gettext kerberos ]

--- a/pkgs/development/libraries/dbus-glib/default.nix
+++ b/pkgs/development/libraries/dbus-glib/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0in0i6v68ixcy0ip28i84hdczf10ykq9x682qgcvls6gdmq552dk";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   nativeBuildInputs = [ pkgconfig gettext ];

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -32,7 +32,7 @@ self =  stdenv.mkDerivation {
         --replace 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
     '';
 
-    outputs = [ "dev" "out" "lib" "doc" ];
+    outputs = [ "out" "dev" "lib" "doc" ];
 
     nativeBuildInputs = [ pkgconfig ];
     propagatedBuildInputs = [ expat ];

--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dfkd4xbp7v5gwsf6qwaraz54yzizf3lj5ymyc0msjn0adq3j5yl";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig utilmacros python ];
   buildInputs = [ mesa libX11 ];

--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
   postPatch = "patchShebangs ./src/svn_version.sh";
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ gettext ];
   propagatedBuildInputs = [ zlib expat ];

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1zq4lnwjlw8s9mmachwfvfjf2x3lk24jm41746ykhdcvs7r0zrfr";
   };
 
-  outputs = [ "dev" "out" ]; # TODO: fix referrers
+  outputs = [ "out" "dev" ]; # TODO: fix referrers
   outputBin = "dev";
 
   configureFlags = stdenv.lib.optional stdenv.isFreeBSD "--with-pic";

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   postPatch = ''patchShebangs .'';
   inherit patches;
 
-  outputs = [ "dev" "out" "bin" ]
+  outputs = [ "bin" "dev" "out" ]
     ++ optional (reqMin "1.0") "doc" ; # just dev-doc
   setOutputFlags = false; # doesn't accept all and stores configureFlags in libs!
 

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1kwbx92ps0r7s2mqy7lxbxanslxdzj7dp7r7gmdkzv1j8yqf3kwf";
   };
 
-  outputs = [ "dev" "out" "doc" ]; # it's dev-doc only
+  outputs = [ "out" "dev" "doc" ]; # it's dev-doc only
   outputBin = "dev"; # fftw-wisdom
 
   configureFlags =

--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
       }
     ;
 
-  outputs = [ "dev" "lib" "bin" "out" ]; # $out contains all the config
+  outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
 
   propagatedBuildInputs = [ freetype ];
   buildInputs = [ pkgconfig expat ];

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "dev" "lib" "bin" "out" ]; # $out contains all the config
+  outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
 
   propagatedBuildInputs = [ freetype ];
   buildInputs = [ pkgconfig expat ];

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     patches="$patches $(ls ${infinality}/*_freetype2-iu/*-infinality-*.patch)"
   '';
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ zlib bzip2 libpng ]; # needed when linking against freetype
   # dependence on harfbuzz is looser than the reverse dependence

--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ zlib fontconfig freetype ];
   propagatedBuildInputs = [ libpng libjpeg libwebp libtiff libXpm ];
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   postFixup = ''moveToOutput "bin/gdlib-config" $dev'';
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0yc8indbl3hf18z6x6kjg59xp9sngm1d8vmz4c7bs6g27qw5npnm";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1cchmi08jpjypgmm9i7xzh5qfg2q5k61kry9ns8mhw3z44a440ym";
   };
 
-  outputs = [ "dev" "out" ]; # to deal with propagatedBuildInputs
+  outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs
 
   configureFlags = "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";
 

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch ++ optional doCheck ./skip-timer-test.patch;
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation ({
 
   installFlags = [ "sysconfdir=$(out)/etc" ];
 
-  outputs = [ "bin" "dev" "out" "static" ];
+  outputs = [ "out" "bin" "dev" "static" ];
 
   buildInputs = lib.optionals (cross != null) [ gccCross ]
     ++ lib.optionals withGd [ gd libpng ];

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation ({
 
   installFlags = [ "sysconfdir=$(out)/etc" ];
 
-  outputs = [ "dev" "out" "bin" "static" ];
+  outputs = [ "bin" "dev" "out" "static" ];
 
   buildInputs = lib.optionals (cross != null) [ gccCross ]
     ++ lib.optionals withGd [ gd libpng ];

--- a/pkgs/development/libraries/glibc/multi.nix
+++ b/pkgs/development/libraries/glibc/multi.nix
@@ -6,7 +6,7 @@ let
   glibc64 = glibc;
 in
 runCommand "${nameVersion.name}-multi-${nameVersion.version}"
-  { outputs = [ "dev" "out" "bin" ]; } # TODO: no static version here (yet)
+  { outputs = [ "bin" "dev" "out"]; } # TODO: no static version here (yet)
   ''
     mkdir -p "$out/lib"
     ln -s '${glibc64.out}'/lib/* "$out/lib"

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1pvw2mrm03p51p03179rb6fk9p42iykkwj1jcdv7jr265xymy8nw";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig gnum4 ];
   propagatedBuildInputs = [ glib libsigcxx ];

--- a/pkgs/development/libraries/gmime/default.nix
+++ b/pkgs/development/libraries/gmime/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0rfzbgsh8ira5p76kdghygl5i3fvmmx4wbw5rp7f8ajc4vxp18g0";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib zlib libgpgerror ];

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -1,12 +1,18 @@
 { stdenv, fetchurl, m4, cxx ? true }:
 
-stdenv.mkDerivation rec {
+let self = stdenv.mkDerivation rec {
   name = "gmp-4.3.2";
 
   src = fetchurl {
     url = "mirror://gnu/gmp/${name}.tar.bz2";
     sha256 = "0x8prpqi9amfcmi7r4zrza609ai9529pjaq0h4aw51i867064qck";
   };
+
+  #outputs TODO: split $cxx due to libstdc++ dependency
+  # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
+  # - see #5855 for related discussion
+  outputs = [ "out" "dev" "info" ];
+  passthru.static = self.out;
 
   nativeBuildInputs = [ m4 ];
 
@@ -60,4 +66,5 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
   };
-}
+};
+  in self

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -2,7 +2,7 @@
 
 with { inherit (stdenv.lib) optional optionalString; };
 
-stdenv.mkDerivation rec {
+let self = stdenv.mkDerivation rec {
   name = "gmp-5.1.3";
 
   src = fetchurl { # we need to use bz2, others aren't in bootstrapping stdenv
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "0q5i39pxrasgn9qdxzpfbwhh11ph80p57x6hf48m74261d97j83m";
   };
 
-  outputs = [ "out" "info" ];
+  #outputs TODO: split $cxx due to libstdc++ dependency
+  # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
+  # - see #5855 for related discussion
+  outputs = [ "out" "dev" "info" ];
+  passthru.static = self.out;
 
   nativeBuildInputs = [ m4 ];
 
@@ -76,4 +80,5 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = [ maintainers.peti ];
   };
-}
+};
+  in self

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -13,7 +13,7 @@ let self = stdenv.mkDerivation rec {
   #outputs TODO: split $cxx due to libstdc++ dependency; maybe port to gmp5;
   # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
   # - see #5855 for related discussion
-  outputs = [ "dev" "out" "info" ];
+  outputs = [ "out" "dev" "info" ];
   passthru.static = self.out;
 
   nativeBuildInputs = [ m4 ];

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -10,7 +10,7 @@ let self = stdenv.mkDerivation rec {
     sha256 = "1mpzprdzkgfpdc1v2lf4dxlxps4x8bvmzvd8n1ri6gw9y9jrh458";
   };
 
-  #outputs TODO: split $cxx due to libstdc++ dependency; maybe port to gmp5;
+  #outputs TODO: split $cxx due to libstdc++ dependency
   # maybe let ghc use a version with *.so shared with rest of nixpkgs and *.a added
   # - see #5855 for related discussion
   outputs = [ "out" "dev" "info" ];

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   inherit src patches;
 
-  outputs = [ "dev" "out" "bin" "man" "docdev" ];
+  outputs = [ "bin" "dev" "out" "man" "docdev" ];
   outputInfo = "docdev";
 
   postPatch = lib.optionalString (lib.versionAtLeast version "3.4") ''

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0xsqwxhfqzr79av89mg766kxpb2i41bd0vwspk01xjdzrnn5l9zs";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
   outputMan = "dev"; # tiny pages
 

--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "17892sclz3yg45wbyqqrzzpq3l0icbnfl28f101b3062g8cy97dh";
   };
 
-  outputs = [ "dev" "out" "info" ];
+  outputs = [ "out" "dev" "info" ];
   outputBin = "dev"; # gpgme-config; not so sure about gpgme-tool
 
   propagatedBuildInputs = [ libgpgerror glib libassuan pth ];

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     sha256 = "d7995317530c8773ec088f94d9320909d41da61996b801ebacce9a56af493f97";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig python ];
 

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "9d7109c8fb0a5dec8edb17b0053c59a46aba7ddf48dc48ea822ebbbd4339d38d";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
     pkgconfig python gobjectIntrospection

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = "9dbebe079c2ab2004ef7f2649fa317cabea1feb4fb5605c24d40744b90918341";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "a1d57ff9461407cca1f6e7a9f31a5bdb73f73f33c488a3e3318b27e10a4332ae";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig python gobjectIntrospection flex perl ];
 

--- a/pkgs/development/libraries/gstreamer/gnonlin/default.nix
+++ b/pkgs/development/libraries/gstreamer/gnonlin/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zv60rq2h736a6fivd3a3wp59dj1jar7b2vwzykahvl168b7wrid";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     sha256 = "8d7549118a3b7a009ece6bb38a05b66709c551d32d2adfd89eded4d1d7a23944";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig python ];
 

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0bj6and9b26d32bq90l8nx5wqh2ikkh8dm7qwxyxfdvmrzhixhgi";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig file ];
 

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "b5f3c7a27b39b5f5c2f0bfd546b0c655020faf6b38d27b64b346c43e5ebf687a";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   configureFlags = stdenv.lib.optionalString withSystemLibav
     "--with-system-libav";

--- a/pkgs/development/libraries/gstreamer/python/default.nix
+++ b/pkgs/development/libraries/gstreamer/python/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./different-path-with-pygobject.patch ];
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig python ];
 

--- a/pkgs/development/libraries/gstreamer/qt-gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/qt-gstreamer/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ gst_all_1.gstreamer gst_all_1.gst-plugins-base glib qt4 ];
   propagatedBuildInputs = [ boost ];

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     sha256 = "9c5b33a2a98fc1d6d6c99a1b536b1fb2de45f53cc8bf8ab85a8b8141fed1a8ac";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig python ];
 

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "14jal2g5mf8r59w8420ixl3kg50vcmy56446ncwd0xrizd6yms5b";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = with stdenv.lib; [ pkgconfig bzip2 ];
 

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "33c5b585c5ca1659fe6c09fdf02e45d8132c0d386b405bf527b14ab481a0bafe";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
     pkgconfig gobjectIntrospection

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "0d15cec3b6d55c60eac205b1f3ba81a1ed4eadd9d0f8e7c508bc7065d0c4ca50";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "05xcwvy68p7f4hdhi4bgdm3aycvqqr4pr5kkkr8ba91l5yx0k9l3";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection perl ];

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     sha256 = "09lh8x6qj0cd950whgaqqi3c4pqbl6z7aw9ddm73i14bw056185v";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   configureFlags = [

--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0v14ff9s37vkh45diaddndcrj0hmn67arh8xh8k79q9c1vgc1cm7";
   };
 
-  outputs = [ "dev" "out" "bin" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   buildInputs = [ ncurses readline ];
   configureFlags = [ "--with-ui" "--with-readline" ];

--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation ({
     sha256 = "10cmkqigxh9f73y7q3p991q6j8pph0mrydgj11w1x6wlcp5ng37z";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   makeFlags = stdenv.lib.optionalString stdenv.isDarwin

--- a/pkgs/development/libraries/imlib/default.nix
+++ b/pkgs/development/libraries/imlib/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation {
 
   configureFlags = "
     --disable-shm
-    --x-includes=${libX11}/include
-    --x-libraries=${libX11}/lib";
+    --x-includes=${libX11.dev}/include
+    --x-libraries=${libX11.out}/lib";
 
   buildInputs = [libjpeg libXext libX11 xextproto libtiff libungif libpng];
 

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--enable-shared";
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jdk, pkgconfig, gtk
+{ stdenv, lib, fetchurl, unzip, jdk, pkgconfig, gtk
 , libXtst, libXi, mesa, webkit, libsoup, xorg
 , pango, gdk_pixbuf, glib
 }:
@@ -37,10 +37,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ unzip jdk pkgconfig gtk libXtst libXi mesa webkit libsoup ];
 
-  NIX_LFLAGS = [ "-lX11" "-I${xorg.libX11}/lib"
-    "-lpango-1.0" "-I${pango}/lib"
-    "-lgdk_pixbuf-2.0" "-I${gdk_pixbuf}/lib"
-    "-lglib-2.0" "-I${glib}/lib"];
+  NIX_LFLAGS = (map (x: "-L${lib.getLib x}/lib") [ xorg.libX11 pango gdk_pixbuf glib ]) ++
+    [ "-lX11" "-lpango-1.0" "-lgdk_pixbuf-2.0" "-lglib-2.0" ];
 
   buildPhase = ''
     unzip src.zip -d src

--- a/pkgs/development/libraries/json-c/default.nix
+++ b/pkgs/development/libraries/json-c/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./unused-variable.patch ];
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ autoreconfHook ]; # won't configure without it, no idea why
 

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -24,7 +24,7 @@ let
       let
       in stdenv.mkDerivation (args // {
 
-        outputs = args.outputs or [ "dev" "out" ];
+        outputs = args.outputs or [ "out" "dev" ];
 
         propagatedUserEnvPkgs =
           builtins.map lib.getBin (args.propagatedBuildInputs or []);

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -70,7 +70,7 @@ let
     ecm =
       let drv = { cmake, ecmNoHooks, pkgconfig, qtbase, qttools }:
             makeSetupHook
-            { deps = [ cmake ecmNoHooks pkgconfig qtbase qttools ]; }
+            { deps = lib.chooseDevOutputs [ cmake ecmNoHooks pkgconfig qtbase qttools ]; }
             ./setup-hook.sh;
       in callPackage drv {};
     ecmNoHooks = callPackage ./extra-cmake-modules {

--- a/pkgs/development/libraries/lcms/default.nix
+++ b/pkgs/development/libraries/lcms/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1abkf8iphwyfs3z305z3qczm3z1i9idc1lz4gvfg92jnkz5k5bl0";
   };
 
-  outputs = [ "dev" "out" "bin" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   meta = {
     description = "Color management engine";

--- a/pkgs/development/libraries/lcms2/default.nix
+++ b/pkgs/development/libraries/lcms2/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0lvaglcjsvnyglgj3cb3pjc22nq8fml1vlx5dmmmw66ywx526925";
   };
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   propagatedBuildInputs = [ libtiff libjpeg zlib ];
 

--- a/pkgs/development/libraries/libao/default.nix
+++ b/pkgs/development/libraries/libao/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1bwwv1g9lchaq6qmhvj1pp3hnyqr64ydd4j38x94pmprs4d27b83";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   buildInputs =
     [ pkgconfig ] ++

--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0w9bmasln4z8mn16s1is55a06w3nv8jbyal496z5jvr5vcxkm112";
   };
 
-  outputs = [ "dev" "out" "info" ];
+  outputs = [ "out" "dev" "info" ];
   outputBin = "dev"; # libassuan-config
 
   buildInputs = [ libgpgerror pth ];

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -85,7 +85,7 @@ let
 
     enableParallelBuilding = true;
 
-    outputs = [ "dev" "out" "bin" ];
+    outputs = [ "bin" "dev" "out" ];
     setOutputFlags = false;
 
     # alltools to build smaller tools, incl. aviocat, ismindex, qt-faststart, etc.

--- a/pkgs/development/libraries/libcaca/default.nix
+++ b/pkgs/development/libraries/libcaca/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1x3j6yfyxl52adgnabycr0n38j9hx2j74la0hz0n8cnh9ry4d2qj";
   };
 
-  outputs = [ "dev" "bin" "out" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   configureFlags = "--disable-x11 --disable-imlib2 --disable-doc";
 

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "b17d4b39ed97ca0e4cffa0db06ff609e617bac94646ec38e8e0579d530540e7b";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libpthreadstubs libpciaccess ]

--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake ];
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputDoc = "dev";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
   postPatch = "patchShebangs event_rpcgen.py";
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.optional stdenv.isCygwin ./3.2.1-cygwin.patch;
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   buildInputs = stdenv.lib.optional doCheck dejagnu;
 

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wbh6fq5zi9wg2xcfvfpwh7dv52jihivx1vm4h91c2kx0w8n3b6x";
   };
 
-  outputs = [ "dev" "out" "info" ];
+  outputs = [ "out" "dev" "info" ];
   outputBin = "dev";
 
   buildInputs =

--- a/pkgs/development/libraries/libgnome-keyring/default.nix
+++ b/pkgs/development/libraries/libgnome-keyring/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "030gka96kzqg1r19b4xrmac89hf1xj1kr5p461yvbzfxh46qqf2n";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ glib dbus_libs libgcrypt ];
   nativeBuildInputs = [ pkgconfig intltool ];

--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   postPatch = "sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure";
 
-  outputs = [ "dev" "out" "info" ];
+  outputs = [ "out" "dev" "info" ];
   outputBin = "dev"; # deps want just the lib, most likely
 
   # If architecture-dependent MO files aren't available, they're generated

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "068fjg2arlppjqqpzd714n1lf6gxkpac9v5yyvp1qwmv6nvam9s4";
   };
 
-  outputs = [ "dev" "out" "bin" "info" "docdev" ];
+  outputs = [ "bin" "dev" "out" "info" "docdev" ];
 
   doCheck = ! stdenv.isDarwin;
 

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = "1kmiv1mcrxniigdcs65w23897mczsx0hasxc6p13hjk58zzfvj1h";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   configureFlags = [
     (mkFlag documentationSupport "documentation")

--- a/pkgs/development/libraries/libjpeg-drop/default.nix
+++ b/pkgs/development/libraries/libjpeg-drop/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   configureFlags = []
     ++ optional static [ "--enable-static" "--disable-shared" ];
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   meta = {
     homepage = http://jpegclub.org/jpegtran/;

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional (stdenv.cross.libc or null == "msvcrt")
       ./mingw-boolean.patch;
 
-  outputs = [ "dev" "out" "doc" "bin" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   nativeBuildInputs = [ nasm ];
 

--- a/pkgs/development/libraries/libjpeg/default.nix
+++ b/pkgs/development/libraries/libjpeg/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   configureFlags = optional static "--enable-static --disable-shared";
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   meta = {
     homepage = http://www.ijg.org/;

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0abv0h9c3kbw4bq1b9270sg189jcjj3x3wa91bj836ynwg9m34wl";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   preConfigure = ''
     patchShebangs .

--- a/pkgs/development/libraries/libmicrohttpd/default.nix
+++ b/pkgs/development/libraries/libmicrohttpd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mzbqr6sqisppz88mh73bbh5sw57g8l87qvhcjdx5pmbd183idni";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   buildInputs = [ libgcrypt curl gnutls pkgconfig ];
 
   preCheck = ''

--- a/pkgs/development/libraries/libmng/default.nix
+++ b/pkgs/development/libraries/libmng/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0l5wa3b9rr4zl49zbbjpapqyccqjwzkzw1ph3p4pk9p5h73h9317";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputMan= "docdev";
 
   propagatedBuildInputs = [ zlib libpng libjpeg lcms2 ];

--- a/pkgs/development/libraries/libmp3splt/default.nix
+++ b/pkgs/development/libraries/libmp3splt/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1p1mn2hsmj5cp40fnc8g1yfvk72p8pjxi866gjdkgjsqrr7xdvih";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   nativeBuildInputs = [ libtool ];
   buildInputs = [ libmad libid3tag ];
 

--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sc768q2cixwanlwrz95mp389iaadl4s95486caavxx4g7znvn8m";
   };
 
-  outputs = [ "dev" "bin" "out" ];
+  outputs = [ "bin" "dev" "out" ];
 
   propagatedBuildInputs = [ libusb1 ];
   buildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libogg/default.nix
+++ b/pkgs/development/libraries/libogg/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "16z74q422jmprhyvy7c9x909li8cqzmvzyr8cgbm52xcsp6pqs1z";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   meta = with stdenv.lib; {
     homepage = http://xiph.org/ogg/;

--- a/pkgs/development/libraries/liboil/default.nix
+++ b/pkgs/development/libraries/liboil/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./x86_64-cpuid.patch ];
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev"; # oil-bugreport
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1z87x5c5x951lhnm70iqr2gqn15wns5cqsw8nnkvl48jwdw00a8f";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   configureFlags = stdenv.lib.optional fixedPoint "--enable-fixed-point"
                 ++ stdenv.lib.optional withCustomModes "--enable-custom-modes";

--- a/pkgs/development/libraries/libpng/12.nix
+++ b/pkgs/development/libraries/libpng/12.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ghd03p353x0vi4dk83n1nlldg11w7vqdk3f99rkgfb82ic59ki4";
   };
 
-  outputs = [ "dev" "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
 
   propagatedBuildInputs = [ zlib ];
 

--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   };
   postPatch = whenPatched "gunzip < ${patch_src} | patch -Np1";
 
-  outputs = [ "dev" "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
   outputBin = "dev";
 
   propagatedBuildInputs = [ zlib ];

--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jw6454gxjykmbnbh544axi8hzz9gmm4jz1y5gw1hdqnakg36gyw";
   };
 
-  outputs = [ "dev" "out" ]; # to deal with propagatedBuildInputs
+  outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs
 
   nativeBuildInputs = [ pkgconfig cmake ];
   propagatedBuildInputs = [ zlib ]

--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "101ppan2q1h4pyp2zbn9b8sdwy2c7fk9rp91yykxz3afrvzbymq8";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   preBuild = ''
     patchShebangs .

--- a/pkgs/development/libraries/libressl/2.3.nix
+++ b/pkgs/development/libraries/libressl/2.3.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   meta = with stdenv.lib; {
     description = "Free TLS/SSL implementation";

--- a/pkgs/development/libraries/libressl/2.4.nix
+++ b/pkgs/development/libraries/libressl/2.4.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   meta = with stdenv.lib; {
     description = "Free TLS/SSL implementation";

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ libxml2 libgsf bzip2 libcroco pango libintlOrEmpty ]
     ++ stdenv.lib.optional enableIntrospection [ gobjectIntrospection ];

--- a/pkgs/development/libraries/libsamplerate/default.nix
+++ b/pkgs/development/libraries/libsamplerate/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   #--disable-fftw          disable usage of FFTW
   #--disable-cpu-clip      disable tricky cpu specific clipper
 
-  outputs = [ "dev" "bin" "out" ];
+  outputs = [ "bin" "dev" "out" ];
 
   postConfigure = optionalString stdenv.isDarwin ''
     # need headers from the Carbon.framework in /System/Library/Frameworks to

--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   # need headers from the Carbon.framework in /System/Library/Frameworks to
   # compile this on darwin -- not sure how to handle

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1gn45g956lyz8l6iq187yc6l627vyivyp8qc5dkr6dnhdnlqddvi";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
      substituteInPlace libsoup/Makefile.in --replace "\$(DESTDIR)\$(vapidir)" "\$(DESTDIR)\$(girdir)/../vala/vapi"
   '';
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = libintlOrEmpty ++ [ intltool python sqlite ]
     ++ stdenv.lib.optionals valaSupport [ vala_0_23 ];

--- a/pkgs/development/libraries/libssh/default.nix
+++ b/pkgs/development/libraries/libssh/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sed -i 's,nacl/,sodium/,g' ./include/libssh/curve25519.h src/curve25519.c
   '';
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ zlib openssl libsodium ];
 

--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "116mh112w48vv9k3f15ggp5kxw5sj4b88dzb5j69llsh7ba1ymp4";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   buildInputs = [ openssl zlib ];
 

--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "04y5m29pqmvkfdbppmsdifyx89v8xclxzklpfc7a1fkr9p4jz07s";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   buildInputs = [ perl texinfo ];

--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0swiaj8987n995rc7hw0asvpwhhzpjiws8kr3s6r44bqqib2k5a0";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputDoc = "docdev";
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "136nf1rj9dp5jgv1p7z4dk0xy3wki1w0vfjbk82f645m0w4samsd";
   };
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sed -i -e '/LIBLZMA/s:-lzma:-llzma:' configure
   '';
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ xz ];
 

--- a/pkgs/development/libraries/libusb/default.nix
+++ b/pkgs/development/libraries/libusb/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libusb-compat-0.1.5";
 
-  outputs = [ "dev" "out" ]; # get rid of propagating systemd closure
+  outputs = [ "out" "dev" ]; # get rid of propagating systemd closure
   outputBin = "dev";
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h38p9rxfpg9vkrbyb120i1diq57qcln82h5fr7hvy82c20jql3c";
   };
 
-  outputs = [ "dev" "out" ]; # get rid of propagating systemd closure
+  outputs = [ "out" "dev" ]; # get rid of propagating systemd closure
 
   buildInputs = [ pkgconfig ];
   propagatedBuildInputs =

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0py9igf4kicj7ji22bjawkpd6my013qpg0s4ir2np9l1rk5vr2d6";
   };
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = with xorg; [ pkgconfig dri2proto libXext ];
 

--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lg1n3a6r41492r7in0fpvzc7909mc5ir9z0gd3qh2pz4yalmyal";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''patchShebangs .'';
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   setOutputFlags = false;
 
   configureFlags = [

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''patchShebangs .'';
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   setOutputFlags = false;
 
   configureFlags = [

--- a/pkgs/development/libraries/libwnck/3.x.nix
+++ b/pkgs/development/libraries/libwnck/3.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "d48ac9c7f50c0d563097f63d07bcc83744c7d92a1b4ef65e5faeab32b5ccb723";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   patches = [ ./install_introspection_to_prefix.patch ];

--- a/pkgs/development/libraries/libwnck/default.nix
+++ b/pkgs/development/libraries/libwnck/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "17isfjvrzgj5znld2a7zsk9vd39q9wnsysnw5jr8iz410z935xw3";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   buildInputs = [ pkgconfig gtk intltool xorg.libX11 xorg.libXres ];

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0q47xa1szlxwgvwmhv4b7xwawnykz1hnc431d84nj8dlh2q8f22v";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ pkgconfig yacc flex xkeyboard_config libxcb ];
 

--- a/pkgs/development/libraries/libxklavier/default.nix
+++ b/pkgs/development/libraries/libxklavier/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "016lpdv35z0qsw1cprdc2k5qzkdi5waj6qmr0a2q6ljn9g2kpv7b";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   # TODO: enable xmodmap support, needs xmodmap DB
   propagatedBuildInputs = with xorg; [ libX11 libXi xkeyboard_config libxml2 libICE glib libxkbfile isocodes ];

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0i7a0nhxwkxx6dkm8917qn0bsfn1av6ghg2f4dxanxi4bn4b1jjn";
   };
 
-  outputs = [ "dev" "out" "bin" "doc" ]
+  outputs = [ "bin" "dev" "out" "doc" ]
     ++ lib.optional supportPython "py";
   propagatedBuildOutputs = "out bin" + lib.optionalString supportPython " py";
 

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       })
     ];
 
-  outputs = [ "dev" "out" "bin" "doc" ];
+  outputs = [ "bin" "dev" "out" "doc" ];
 
   buildInputs = [ libxml2 ];
 

--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "08b26qbfxq6z5xf36y1d8insm5valv83dhj933iag6man04prb2r";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ perl ];
   propagatedBuildInputs = [ zlib ];

--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0fda6syrfb81930sf7rgw1qmpnik8k1ngrjkh43ywd3s37nbqh1n";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ python scons ];
 

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
       --replace _EGL_DRIVER_SEARCH_DIR '"${driverLink}"'
   '';
 
-  outputs = [ "dev" "out" "drivers" "osmesa" ];
+  outputs = [ "out" "dev" "drivers" "osmesa" ];
 
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   configureFlags = [

--- a/pkgs/development/libraries/ming/default.nix
+++ b/pkgs/development/libraries/ming/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   # We don't currently build the Python, Perl, PHP, etc. bindings.
   # Perl is needed for the test suite, though.
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   nativeBuildInputs = [ autoreconfHook flex bison perl ];
   buildInputs = [ freetype zlib libpng giflib ];
 

--- a/pkgs/development/libraries/mpfr/default.nix
+++ b/pkgs/development/libraries/mpfr/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./upstream.patch ];
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   # mpfr.h requires gmp.h
   propagatedBuildInputs = [ gmp ];

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./clang.patch ] ++ lib.optional (abiVersion == "5" && stdenv.cc.isGNU) ./gcc-5.patch;
 
-  outputs = [ "dev" "out" "man" ];
+  outputs = [ "out" "dev" "man" ];
   setOutputFlags = false; # some aren't supported
 
   configureFlags = [

--- a/pkgs/development/libraries/nettle/generic.nix
+++ b/pkgs/development/libraries/nettle/generic.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (rec {
 
   inherit src;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   buildInputs = [ gnum4 ];

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace "malloc_stats_print" "je_malloc_stats_print"
   '' else null;
 
-  outputs = [ "dev" "out" "lib" ];
+  outputs = [ "out" "dev" "lib" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl libev zlib ];

--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1pk98bmc5xzbl62q5wf2d6mryf0v95z6rsmxz27nclwiaqg0mcg0";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   outputBin = "dev";
 
   preConfigure = ''

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     INSTALL_TARGET
   '';
 
-  outputs = [ "dev" "out" "tools" ];
+  outputs = [ "out" "dev" "tools" ];
 
   preConfigure = "cd nss";
 

--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_NAME_DIR=\${CMAKE_INSTALL_PREFIX}/lib"

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   # TODO: separate "out" and "bin"
-  outputs = [ "dev" "out" "man" "docdev" ];
+  outputs = [ "out" "dev" "man" "docdev" ];
 
   buildInputs = [ openssl cyrus_sasl db groff ];
 

--- a/pkgs/development/libraries/openssl/chacha.nix
+++ b/pkgs/development/libraries/openssl/chacha.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1030rs4bdaysxbq0mmck1dn6g5adspzkwsrnhvv16b4ig0r4ncgj";
   };
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
   setOutputFlags = false;
 
   nativeBuildInputs = [ perl zlib ];

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -24,7 +24,7 @@ let
            (versionOlder version "1.0.2" && (stdenv.isDarwin || (stdenv ? cross && stdenv.cross.libc == "libSystem")))
            ./darwin-arch.patch;
 
-  outputs = [ "dev" "out" "man" "bin" ];
+  outputs = [ "bin" "dev" "out" "man" ];
   setOutputFlags = false;
 
     nativeBuildInputs = [ perl ];

--- a/pkgs/development/libraries/osm-gps-map/default.nix
+++ b/pkgs/development/libraries/osm-gps-map/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0fal3mqcf3yypir4f7njz0dm5wr7lqwpimjx28wz9imh48cqx9n9";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1w7szm190phlkg7qx05ychlj2dbvkgkhx9gw6dx4d5rw62l6wwms";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
   outputBin = "dev";
 
   buildInputs = [ pkgconfig libffi libtasn1 libiconv ];

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40";
   };
 
-  outputs = [ "dev" "out" "bin" "docdev" ];
+  outputs = [ "bin" "dev" "out" "docdev" ];
 
   buildInputs = [ gobjectIntrospection ];
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
     ./CVE-2016-1283.patch
   ];
 
-  outputs = [ "dev" "out" "bin" "doc" "man" ];
+  outputs = [ "bin" "dev" "out" "doc" "man" ];
 
   configureFlags = [
     "--enable-jit"

--- a/pkgs/development/libraries/polkit-qt-1/qt-5.nix
+++ b/pkgs/development/libraries/polkit-qt-1/qt-5.nix
@@ -5,7 +5,7 @@ with stdenv.lib;
 stdenv.mkDerivation {
   name = "polkit-qt-1-qt5-0.112.0";
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://kde/stable/apps/KDE4.x/admin/polkit-qt-1-0.112.0.tar.bz2";

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "109w86kfqrgz83g9ivggplmgc77rz8kx8646izvm2jb57h4rbh71";
   };
 
-  outputs = [ "dev" "out" "bin" ]; # small man pages in $bin
+  outputs = [ "bin" "dev" "out" ]; # small man pages in $bin
 
   buildInputs =
     [ pkgconfig glib expat pam intltool spidermonkey gobjectIntrospection ]

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [ libiconv ] ++ libintlOrEmpty ++ lib.optional withData poppler_data;
 

--- a/pkgs/development/libraries/qt-5/5.5/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/default.nix
@@ -46,7 +46,7 @@ let
 
       NIX_QT_SUBMODULE = args.NIX_QT_SUBMODULE or true;
 
-      outputs = args.outputs or [ "dev" "out" ];
+      outputs = args.outputs or [ "out" "dev" ];
       setOutputFlags = args.setOutputFlags or false;
 
       setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
   sourceRoot = "qt-everywhere-opensource-src-${version}";
 
-  outputs = [ "dev" "out" "gtk" ];
+  outputs = [ "out" "dev" "gtk" ];
 
   postUnpack = ''
     mv qtbase-opensource-src-${version} ./qt-everywhere-opensource-src-${version}/qtbase

--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -47,7 +47,7 @@ let
 
       NIX_QT_SUBMODULE = args.NIX_QT_SUBMODULE or true;
 
-      outputs = args.outputs or [ "dev" "out" ];
+      outputs = args.outputs or [ "out" "dev" ];
       setOutputFlags = args.setOutputFlags or false;
 
       setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   name = "qtbase-${srcs.qtbase.version}";
   inherit (srcs.qtbase) src version;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   patches =
     copyPathsToStore (lib.readPathsFromFile ./. ./series)

--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -47,7 +47,7 @@ let
 
       NIX_QT_SUBMODULE = args.NIX_QT_SUBMODULE or true;
 
-      outputs = args.outputs or [ "dev" "out" ];
+      outputs = args.outputs or [ "out" "dev" ];
       setOutputFlags = args.setOutputFlags or false;
 
       setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.7/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtbase/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   name = "qtbase-${version}";
   inherit src version;
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   patches =
     copyPathsToStore (lib.readPathsFromFile ./. ./series)

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hzxr9jxqqx5sxsv9vmlxdnvlr9vi4ih1avjb869hbs6p5qn1fjn";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   propagatedBuildInputs = [ncurses];
 

--- a/pkgs/development/libraries/schroedinger/default.nix
+++ b/pkgs/development/libraries/schroedinger/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "04prr667l4sn4zx256v1z36a0nnkxfdqyln48rbwlamr6l3jlmqy";
   };
 
-  outputs = [ "dev" "out" "docdev" ];
+  outputs = [ "out" "dev" "docdev" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ orc ];

--- a/pkgs/development/libraries/slang/default.nix
+++ b/pkgs/development/libraries/slang/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "0aqd2cjabj6nhd4r3dc4vhqif2bf3dmqnrn2gj0xm4gqyfd177jy";
   };
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   # Fix some wrong hardcoded paths
   preConfigure = ''

--- a/pkgs/development/libraries/speex/default.nix
+++ b/pkgs/development/libraries/speex/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sed -i '/AC_CONFIG_MACRO_DIR/i PKG_PROG_PKG_CONFIG' configure.ac
   '';
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ fftw speexdsp ];

--- a/pkgs/development/libraries/speexdsp/default.nix
+++ b/pkgs/development/libraries/speexdsp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   patches = [ ./build-fix.patch ];
   postPatch = "sed '3i#include <stdint.h>' -i ./include/speex/speexdsp_config_types.h.in";
 
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ fftw ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "19j73j44akqgc6m82wm98yvnmm3mfzmfqr8mp3n7n080d53q4wdw";
   };
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   buildInputs = lib.optionals interactive [ readline ncurses ];
 

--- a/pkgs/development/libraries/webkitgtk/2.10.nix
+++ b/pkgs/development/libraries/webkitgtk/2.10.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   # XXX: WebKit2 missing include path for gst-plugins-base.
   # Filled: https://bugs.webkit.org/show_bug.cgi?id=148894
-  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base}/include/gstreamer-1.0";
+  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base.dev}/include/gstreamer-1.0";
 
   nativeBuildInputs = [
     cmake perl python ruby bison gperf sqlite

--- a/pkgs/development/libraries/webkitgtk/2.12.nix
+++ b/pkgs/development/libraries/webkitgtk/2.12.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   # XXX: WebKit2 missing include path for gst-plugins-base.
   # Filled: https://bugs.webkit.org/show_bug.cgi?id=148894
-  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base}/include/gstreamer-1.0";
+  NIX_CFLAGS_COMPILE = "-I${gst-plugins-base.dev}/include/gstreamer-1.0";
 
   nativeBuildInputs = [
     cmake perl python ruby bison gperf sqlite

--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b1a9rmzpzjblj0gsrzas2aljivd0gfimcsj8gjl80ng25zgmaxr";
   };
 
-  outputs = [ "dev" "out" "doc" "lib" ];
+  outputs = [ "out" "dev" "doc" "lib" ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
+++ b/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     platforms   = platforms.linux ++ platforms.darwin;
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   buildInputs = [
     autoconf

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
   '';
 
-  outputs = [ "dev" "out" "static" ];
+  outputs = [ "out" "dev" "static" ];
   setOutputFlags = false;
   outputDoc = "dev"; # single tiny man3 page
 

--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = optional wantPS ps;
 
   CMAKE_PREFIX_PATH = concatStringsSep ":"
-    (concatMap (p: [ p p.out ]) buildInputs);
+    (concatMap (p: [ (p.dev or p) (p.out or p) ]) buildInputs);
 
   configureFlags =
     "--docdir=/share/doc/${name} --mandir=/share/man --system-libs"

--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "01d4m8ckww12sy50vgyxlnz83z9dxqpyqp153cscncc9w6jq19d7";
   };
 
-  outputs = [ "dev" "bin" "lib" "out" "man" "info" ];
+  outputs = [ "bin" "dev" "lib" "out" "man" "info" ];
 
   nativeBuildInputs = [ which pkgconfig perl ];
   buildInputs = [ guile libxml2 ];

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     ./pt-pax-flags.patch
   ];
 
-  outputs = (optional (cross == null) "dev") ++ [ "out" "info" ];
+  outputs = [ "out" "info" ] ++ (optional (cross == null) "dev");
 
   nativeBuildInputs = [ bison ];
   buildInputs = [ zlib ];

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   # FIXME: the cups libraries contains some $out/share strings so can't be split.
-  outputs = [ "dev" "out" "man" ]; # TODO: above
+  outputs = [ "out" "dev" "man" ]; # TODO: above
 
   buildInputs = [ pkgconfig zlib libjpeg libpng libtiff libusb gnutls libpaper ]
     ++ optionals stdenv.isLinux [ avahi pam dbus systemd acl ]

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out/bin $out/include
 
-    ln -s ${binutils-raw}/bin/c++filt $out/bin/c++filt
+    ln -s ${binutils-raw.out}/bin/c++filt $out/bin/c++filt
 
     # We specifically need:
     # - ld: binutils doesn't provide it on darwin
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     done
 
     # FIXME: this will give us incorrect man pages for bits of cctools
-    ln -s ${binutils-raw}/share $out/share
+    ln -s ${binutils-raw.out}/share $out/share
     ln -s ${binutils-raw.out}/lib $out/lib
 
     ln -s ${cctools}/libexec $out/libexec

--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's/u_int\([0-9]*\)_t/uint\1_t/g' include/pcm.h
   '';
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   crossAttrs = {
     patchPhase = ''

--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       # gstreamer gst_plugins_base
     ];
 
-  outputs = [ "dev" "out" "test" ];
+  outputs = [ "out" "dev" "test" ];
 
   patches = [ ./bluez-5.37-obexd_without_systemd-1.patch ];
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -74,7 +74,7 @@ let
 
       installsFirmware = (config.isEnabled "FW_LOADER") &&
         (isModular || (config.isDisabled "FIRMWARE_IN_KERNEL"));
-    in (optionalAttrs isModular { outputs = [ "out" "dev" ]; propagatedBuildOutputs = ""; }) // {
+    in (optionalAttrs isModular { outputs = [ "out" "dev" ]; }) // {
       passthru = {
         inherit version modDirVersion config kernelPatches configfile;
       };

--- a/pkgs/os-specific/linux/libcap/default.nix
+++ b/pkgs/os-specific/linux/libcap/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qjiqc5pknaal57453nxcbz3mn1r4hkyywam41wfcglq3v2qlg39";
   };
 
-  outputs = [ "dev" "lib" "doc" "out" ]
+  outputs = [ "out" "dev" "lib" "doc" ]
     ++ stdenv.lib.optional (pam != null) "pam";
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     owner = "thom311";
   };
 
-  outputs = [ "dev" "bin" "out" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   nativeBuildInputs = [ autoreconfHook bison flex pkgconfig ];
 

--- a/pkgs/os-specific/linux/systemd/libudev.nix
+++ b/pkgs/os-specific/linux/systemd/libudev.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "libudev-${systemd.version}";
 
   unpackPhase = ":";
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   installPhase = ''
     mkdir -p "$out/lib" "$dev/lib/pkgconfig" "$dev/include"
     cp -P "${systemd}"/lib/libudev.* "$out/lib/"

--- a/pkgs/os-specific/linux/v4l-utils/default.nix
+++ b/pkgs/os-specific/linux/v4l-utils/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = "1h1nhg5cmmzlbipak526nk4bm6d0yb217mll75f3rpg7kz1cqiv1";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   configureFlags = [
     "--enable-libv4l"

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "05si1cn7zivggan25brsqfdw0ilvrlnhj96pwv16dh6vfkggzjr1";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mmhzi4483mkak47wj255a36g3v0yilxwfwlbckr1hssinri5m7q";
   };
 
-  outputs = [ "dev" "bin" "out" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   patches = [ ./dont-keep-configure-flags.patch ./remove-mkdir-var.patch ] ++
     stdenv.lib.optional stdenv.isDarwin ./darwin-openssl-linking-fix.patch;

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--localstatedir=/var"
     "--with-libtool"
-    "--with-libxml2=${libxml2}"
+    "--with-libxml2=${libxml2.dev}"
     "--with-openssl=${openssl.dev}"
     "--without-atf"
     "--without-dlopen"

--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   # FIXME: -dev depends on -doc
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
   setOutputFlags = false; # it would move $out/modules, etc.
 
   propagatedBuildInputs = [ apr ]; # otherwise mod_* fail to find includes often

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   # FIXME: -dev depends on -doc
-  outputs = [ "dev" "out" "doc" ];
+  outputs = [ "out" "dev" "doc" ];
   setOutputFlags = false; # it would move $out/modules, etc.
 
   buildInputs = [perl] ++

--- a/pkgs/servers/monitoring/longview/default.nix
+++ b/pkgs/servers/monitoring/longview/default.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation rec {
     mv Linode $out
     ln -s ../Linode/Longview.pl $out/bin/longview
     for h in syscall.h sys/syscall.h asm/unistd.h asm/unistd_32.h asm/unistd_64.h bits/wordsize.h bits/syscall.h; do
-        ${perl}/bin/h2ph -d $out ${glibc}/include/$h
+        ${perl}/bin/h2ph -d $out ${glibc.dev}/include/$h
         mkdir -p $out/usr/include/$(dirname $h)
-        mv $out${glibc}/include/''${h%.h}.ph $out/usr/include/$(dirname $h)
+        mv $out${glibc.dev}/include/''${h%.h}.ph $out/usr/include/$(dirname $h)
     done
     wrapProgram $out/Linode/Longview.pl --prefix PATH : ${perl}/bin:$out/bin \
      --suffix PERL5LIB : $out/Linode --suffix PERL5LIB : $PERL5LIB \

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./caps-fix.patch ];
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig intltool autoreconfHook ];
 

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -87,7 +87,7 @@ common = rec { # attributes common to both builds
 client = stdenv.mkDerivation (common // {
   name = "mariadb-client-${common.version}";
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
 
   propagatedBuildInputs = [ openssl zlib ]; # required from mariadb.pc
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -328,7 +328,7 @@ in
   };
 
   xf86videoati = attrs: attrs // {
-    NIX_CFLAGS_COMPILE = "-I${xorg.xorgserver}/include/xorg";
+    NIX_CFLAGS_COMPILE = "-I${xorg.xorgserver.dev or xorg.xorgserver}/include/xorg";
   };
 
   xf86videonv = attrs: attrs // {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -73,7 +73,7 @@ in
   libxcb = attrs : attrs // {
     nativeBuildInputs = [ args.python ];
     configureFlags = "--enable-xkb --enable-xinput";
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
   };
 
   xcbproto = attrs : attrs // {
@@ -81,7 +81,7 @@ in
   };
 
   libX11 = attrs: attrs // {
-    outputs = [ "dev" "out" "man" ];
+    outputs = [ "out" "dev" "man" ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling + ''
       sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure
     '';
@@ -101,15 +101,15 @@ in
   };
 
   libXau = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
   };
 
   libXdmcp = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
   };
 
   libXfont = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
     propagatedBuildInputs = [ args.freetype ]; # propagate link reqs. like bzip2
     # prevents "misaligned_stack_error_entering_dyld_stub_binder"
     configureFlags = lib.optionals isDarwin [
@@ -118,7 +118,7 @@ in
   };
 
   libXxf86vm = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
   };
 
@@ -131,7 +131,7 @@ in
     '';
     propagatedBuildInputs = [ xorg.libSM ];
     CPP = stdenv.lib.optionalString stdenv.isDarwin "clang -E -";
-    outputs = [ "dev" "out" "docdev" ];
+    outputs = [ "out" "dev" "docdev" ];
   };
 
   # See https://bugs.freedesktop.org/show_bug.cgi?id=47792
@@ -145,29 +145,29 @@ in
   };
 
   libICE = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
   };
 
   libXcomposite = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
     propagatedBuildInputs = [ xorg.libXfixes ];
   };
 
   libXaw = attrs: attrs // {
-    outputs = [ "dev" "out" "docdev" ];
+    outputs = [ "out" "dev" "docdev" ];
     propagatedBuildInputs = [ xorg.libXmu ];
   };
 
   libXcursor = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
   };
 
   libXdamage = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
   };
 
   libXft = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
     propagatedBuildInputs = [ xorg.libXrender args.freetype args.fontconfig ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
     # the include files need ft2build.h, and Requires.private isn't enough for us
@@ -177,59 +177,59 @@ in
   };
 
   libXext = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
     propagatedBuildInputs = [ xorg.xproto xorg.libXau ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
   };
 
   libXfixes = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
   };
 
   libXi = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
   };
 
   libXinerama = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
   };
 
   libXmu = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
     buildFlags = ''BITMAP_DEFINES=-DBITMAPDIR=\"/no-such-path\"'';
   };
 
   libXrandr = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
     propagatedBuildInputs = [xorg.libXrender];
   };
 
   libSM = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
     propagatedBuildInputs = [ xorg.libICE ];
   };
 
   libXrender = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
     preConfigure = setMalloc0ReturnsNullCrossCompiling;
   };
 
   libXres = attrs: attrs // {
-    outputs = [ "dev" "out" "docdev" ];
+    outputs = [ "out" "dev" "docdev" ];
   };
 
   libXv = attrs: attrs // {
-    outputs = [ "dev" "out" "docdev" ];
+    outputs = [ "out" "dev" "docdev" ];
   };
 
   libXvMC = attrs: attrs // {
-    outputs = [ "dev" "out" "doc" ];
+    outputs = [ "out" "dev" "doc" ];
     buildInputs = attrs.buildInputs ++ [xorg.renderproto];
   };
 
   libXpm = attrs: attrs // {
-    outputs = [ "dev" "out" "bin" ]; # tiny man in $bin
+    outputs = [ "bin" "dev" "out" ]; # tiny man in $bin
     patchPhase = "sed -i '/USE_GETTEXT_TRUE/d' sxpm/Makefile.in cxpm/Makefile.in";
   };
 
@@ -237,11 +237,11 @@ in
     // { buildInputs = with xorg; attrs.buildInputs ++ [ libXext libXfixes libXrandr ]; };
 
   libxkbfile = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # mainly to avoid propagation
+    outputs = [ "out" "dev" ]; # mainly to avoid propagation
   };
 
   libxshmfence = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # mainly to avoid propagation
+    outputs = [ "out" "dev" ]; # mainly to avoid propagation
   };
 
   libpciaccess = attrs: attrs // {
@@ -265,32 +265,32 @@ in
   };
 
   xcbutil = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
   };
 
   xcbutilcursor = attrs: attrs // {
-    outputs = [ "dev" "out" ];
+    outputs = [ "out" "dev" ];
     meta = attrs.meta // { maintainers = [ stdenv.lib.maintainers.lovek323 ]; };
   };
 
   xcbutilimage = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # mainly to get rid of propagating others
+    outputs = [ "out" "dev" ]; # mainly to get rid of propagating others
   };
 
   xcbutilkeysyms = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # mainly to get rid of propagating others
+    outputs = [ "out" "dev" ]; # mainly to get rid of propagating others
   };
 
   xcbutilrenderutil = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # mainly to get rid of propagating others
+    outputs = [ "out" "dev" ]; # mainly to get rid of propagating others
   };
 
   xcbutilwm = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # mainly to get rid of propagating others
+    outputs = [ "out" "dev" ]; # mainly to get rid of propagating others
   };
 
   xf86inputevdev = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # to get rid of xorgserver.dev; man is tiny
+    outputs = [ "out" "dev" ]; # to get rid of xorgserver.dev; man is tiny
     preBuild = "sed -e '/motion_history_proc/d; /history_size/d;' -i src/*.c";
     installFlags = "sdkdir=\${out}/include/xorg";
     buildInputs = attrs.buildInputs ++ [ args.mtdev args.libevdev ];
@@ -310,7 +310,7 @@ in
   };
 
   xf86inputsynaptics = attrs: attrs // {
-    outputs = [ "dev" "out" ]; # *.pc pulls xorgserver.dev
+    outputs = [ "out" "dev" ]; # *.pc pulls xorgserver.dev
     buildInputs = attrs.buildInputs ++ [args.mtdev args.libevdev];
     installFlags = "sdkdir=\${out}/include/xorg configdir=\${out}/share/X11/xorg.conf.d";
   };
@@ -420,7 +420,7 @@ in
     in
       if (!isDarwin)
       then {
-        outputs = [ "dev" "out" ];
+        outputs = [ "out" "dev" ];
         buildInputs = [ makeWrapper ] ++ commonBuildInputs;
         propagatedBuildInputs = [ libpciaccess args.epoxy ] ++ commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [
           args.udev

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -158,8 +158,12 @@ let
         outputs ++
         (if separateDebugInfo then assert result.isLinux; [ "debug" ] else []);
 
-      buildInputs' = buildInputs ++
+      buildInputs' = lib.chooseDevOutputs buildInputs ++
         (if separateDebugInfo then [ ../../build-support/setup-hooks/separate-debug-info.sh ] else []);
+
+      nativeBuildInputs' = lib.chooseDevOutputs nativeBuildInputs;
+      propagatedBuildInputs' = lib.chooseDevOutputs propagatedBuildInputs;
+      propagatedNativeBuildInputs' = lib.chooseDevOutputs propagatedNativeBuildInputs;
 
     in
 
@@ -176,13 +180,13 @@ let
            "sandboxProfile" "propagatedSandboxProfile"])
         // (let
           computedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (extraBuildInputs ++ buildInputs ++ nativeBuildInputs);
+            lib.concatMap (input: input.__propagatedSandboxProfile or []) (extraBuildInputs ++ buildInputs' ++ nativeBuildInputs');
           computedPropagatedSandboxProfile =
-            lib.concatMap (input: input.__propagatedSandboxProfile or []) (propagatedBuildInputs ++ propagatedNativeBuildInputs);
+            lib.concatMap (input: input.__propagatedSandboxProfile or []) (propagatedBuildInputs' ++ propagatedNativeBuildInputs');
           computedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (extraBuildInputs ++ buildInputs ++ nativeBuildInputs));
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (extraBuildInputs ++ buildInputs' ++ nativeBuildInputs'));
           computedPropagatedImpureHostDeps =
-            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (propagatedBuildInputs ++ propagatedNativeBuildInputs));
+            lib.unique (lib.concatMap (input: input.__propagatedImpureHostDeps or []) (propagatedBuildInputs' ++ propagatedNativeBuildInputs'));
         in
         {
           builder = attrs.realBuilder or shell;
@@ -194,17 +198,17 @@ let
 
           # Inputs built by the cross compiler.
           buildInputs = if crossConfig != null then buildInputs' else [];
-          propagatedBuildInputs = if crossConfig != null then propagatedBuildInputs else [];
+          propagatedBuildInputs = if crossConfig != null then propagatedBuildInputs' else [];
           # Inputs built by the usual native compiler.
-          nativeBuildInputs = nativeBuildInputs
+          nativeBuildInputs = nativeBuildInputs'
             ++ lib.optionals (crossConfig == null) buildInputs'
             ++ lib.optional
                 (result.isCygwin
                   || (crossConfig != null && lib.hasSuffix "mingw32" crossConfig))
                 ../../build-support/setup-hooks/win-dll-link.sh
             ;
-          propagatedNativeBuildInputs = propagatedNativeBuildInputs ++
-            (if crossConfig == null then propagatedBuildInputs else []);
+          propagatedNativeBuildInputs = propagatedNativeBuildInputs' ++
+            (if crossConfig == null then propagatedBuildInputs' else []);
         } // ifDarwin {
           # TODO: remove lib.unique once nix has a list canonicalization primitive
           __sandboxProfile =

--- a/pkgs/tools/admin/daemontools/default.nix
+++ b/pkgs/tools/admin/daemontools/default.nix
@@ -11,14 +11,14 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     cd ${name}
     
-    sed -ie '1 s_$_ -include ${glibc}/include/errno.h_' src/conf-cc
+    sed -ie '1 s_$_ -include ${glibc.dev}/include/errno.h_' src/conf-cc
     
     substituteInPlace src/Makefile \
       --replace '/bin/sh' '${bash}/bin/bash -oxtrace'
     
     sed -ie "s_^PATH=.*_PATH=$src/${name}/compile:''${PATH}_" src/rts.tests
     
-    cat ${glibc}/include/errno.h
+    cat ${glibc.dev}/include/errno.h
   '';
   
   buildPhase = ''

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sed -i -e '/<sys\\stat\.h>/s|\\|/|' bzip2.c
   '';
 
-  outputs = [ "dev" "bin" "out" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   configureFlags =
     stdenv.lib.optionals linkStatic [ "--enable-static" "--disable-shared" ];

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1da071wyx921pyx3zkxlnbpp14p6km98pnp66mg1arwi9dxgbxbg";
   };
 
-  outputs = [ "dev" "out" "bin" "man" "doc" ];
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   doCheck = true;
 

--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libuuid ];
   buildInputs = [ gettext readline ];
 
-  outputs = [ "dev" "out" "bin" ]; # TODO: review xfs
+  outputs = [ "bin" "dev" "out" ]; # TODO: review xfs
 
   preConfigure = ''
     NIX_LDFLAGS="$(echo $NIX_LDFLAGS | sed "s,$out,$lib,g")"

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fyc2c7jzr7k797c2dqyyvapzc3szxwcp48r382yxz2yq558xgd9";
   };
 
-  outputs = [ "dev" "out" "doc"];
+  outputs = [ "out" "dev" "doc"];
 
   cmakeFlags = ''
     -DWITH_MATLAB=false 

--- a/pkgs/tools/graphics/pstoedit/default.nix
+++ b/pkgs/tools/graphics/pstoedit/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "130kz0ghsrggdn70kygrmsy3n533hwd948q69vyvqz44yw9n3f06";
   };
 
-  outputs = [ "dev" "out" ];
+  outputs = [ "out" "dev" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib ghostscript imagemagick plotutils gd libjpeg libwebp ];
 

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
           -i src/modules/locale/timezonewidget/localeconst.h \
           -i src/modules/locale/SetTimezoneJob.cpp
 
-      sed -e 's,/usr/share/i18n/locales,${glibc}/share/i18n/locales,' \
+      sed -e 's,/usr/share/i18n/locales,${glibc.out}/share/i18n/locales,' \
           -i src/modules/locale/timezonewidget/localeconst.h
 
       sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \

--- a/pkgs/tools/misc/snapper/default.nix
+++ b/pkgs/tools/misc/snapper/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   NIX_CFLAGS_COMPILE = [
-    "-I${libxml2}/include/libxml2"
+    "-I${libxml2.dev}/include/libxml2"
   ];
 
   postInstall = ''

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mjidq4q0hikhis2d35kzkhx6xfcgl875mk5ph5d98fa9kswa4iw";
   };
 
-  outputs = [ "dev" "out" "bin" "man" "docdev" ];
+  outputs = [ "bin" "dev" "out" "man" "docdev" ];
 
   nativeBuildInputs = [ pkgconfig perl ];
 

--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -22,8 +22,8 @@ in stdenv.mkDerivation rec {
   preConfigure = ''
     sed -i 's|/usr/bin/||' doc/Makefile
     sed -i 's|/usr/include/libaio.h|${libaio}/include/libaio.h|' usr/Makefile
-    sed -i 's|/usr/include/sys/|${stdenv.glibc}/include/sys/|' usr/Makefile
-    sed -i 's|/usr/include/linux/|${stdenv.glibc}/include/linux/|' usr/Makefile
+    sed -i 's|/usr/include/sys/|${stdenv.glibc.dev}/include/sys/|' usr/Makefile
+    sed -i 's|/usr/include/linux/|${stdenv.glibc.dev}/include/linux/|' usr/Makefile
   '';
 
   postInstall = ''

--- a/pkgs/tools/package-management/nix-repl/default.nix
+++ b/pkgs/tools/package-management/nix-repl/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     $CXX -O3 -Wall -std=c++0x \
       -o $out/bin/nix-repl nix-repl.cc \
-      -I${nix}/include/nix \
+      -I${nix.dev}/include/nix \
       -lnixformat -lnixutil -lnixstore -lnixexpr -lnixmain -lreadline -lgc \
       -DNIX_VERSION=\"${(builtins.parseDrvName nix.name).version}\"
   '';

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -9,7 +9,7 @@ let
   common = { name, src }: stdenv.mkDerivation rec {
     inherit name src;
 
-    outputs = [ "dev" "out" "man" "doc" ];
+    outputs = [ "out" "dev" "man" "doc" ];
 
     nativeBuildInputs = [ perl pkgconfig ];
 

--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     "--with-zlib=${zlib.dev}"
     "--with-libbz2-prefix=${bzip2.dev}"
     "--with-iconv-dir=${libiconv}"
-    "--with-xml=${libxml2}"
+    "--with-xml=${libxml2.dev}"
     "--with-openssl=${openssl.dev}"
     "--with-libncurses-prefix=${ncurses.dev}"
     "--with-libcurl=${curl.dev}"

--- a/pkgs/tools/security/modsecurity/default.nix
+++ b/pkgs/tools/security/modsecurity/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     "--with-pcre=${pcre.dev}"
     "--with-apr=${apr.dev}"
     "--with-apu=${aprutil.dev}/bin/apu-1-config"
-    "--with-libxml=${libxml2}"
+    "--with-libxml=${libxml2.dev}"
   ];
 
   outputs = ["out" "nginx"];

--- a/pkgs/tools/security/tcpcrypt/default.nix
+++ b/pkgs/tools/security/tcpcrypt/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''mkdir -vp $sourceRoot/m4'';
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "bin" "dev" "out" ];
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openssl ]
     ++ optionals stdenv.isLinux [ libcap libpcap libnfnetlink libnetfilter_conntrack libnetfilter_queue ];

--- a/pkgs/tools/system/awstats/default.nix
+++ b/pkgs/tools/system/awstats/default.nix
@@ -14,7 +14,7 @@ perlPackages.buildPerlPackage rec {
       --replace /usr/share/awstats/ "$out/wwwroot/cgi-bin/"
   '';
 
-  outputs = [ "out" "bin" "doc" ]; # bin just links the user-run executable
+  outputs = [ "bin" "out" "doc" ]; # bin just links the user-run executable
   propagatedBuildOutputs = [ ]; # otherwise out propagates bin -> cycle
 
   buildInputs = with perlPackages; [ ]; # plugins will need some

--- a/pkgs/tools/text/xml/xmlstarlet/default.nix
+++ b/pkgs/tools/text/xml/xmlstarlet/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   preConfigure =
     ''
       export LIBXSLT_PREFIX=${libxslt.dev}
-      export LIBXML_PREFIX=${libxml2}
+      export LIBXML_PREFIX=${libxml2.dev}
       export LIBXSLT_LIBS=$(pkg-config --libs libxslt libexslt)
       export LIBXML_LIBS=$(pkg-config --libs libxml-2.0)
     '';

--- a/pkgs/tools/video/mjpegtools/default.nix
+++ b/pkgs/tools/video/mjpegtools/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libdv libjpeg libpng pkgconfig ]
               ++ lib.optional (!withMinimal) [ gtk libX11 SDL SDL_gfx ];
 
-  NIX_CFLAGS_COMPILE = lib.optional (!withMinimal) "-I${SDL}/include/SDL";
+  NIX_CFLAGS_COMPILE = lib.optional (!withMinimal) "-I${SDL.dev}/include/SDL";
 
   postPatch = ''
     sed -i -e '/ARCHFLAGS=/s:=.*:=:' configure

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -280,7 +280,7 @@ let
       onigVariable = "ONIG_DIR=${oniguruma}";
       gnuVariable = "GNU_INCDIR=${gnulib}/lib";
       treVariable = "TRE_DIR=${tre}";
-      posixVariable = "POSIX_DIR=${glibc}";
+      posixVariable = "POSIX_DIR=${glibc.dev}";
     in ''
       sed -e 's@$(LUAROCKS) $(LUAROCKS_COMMAND) $$i;@$(LUAROCKS) $(LUAROCKS_COMMAND) $$i ${pcreVariable} ${onigVariable} ${gnuVariable} ${treVariable} ${posixVariable};@' \
           -i Makefile


### PR DESCRIPTION
This series reorders the outputs of each multiple-output splitted package in nixpkgs to have the output that is installed into the user environment be the first one (though I made a single exception: `glibc` has its libraries first to keep usages like `${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2` working). Previously the `dev` output was typically the primary one, although there were some exceptions like the kernel package. To accommodate this, `mkDerivation` was changed to use the `dev` output by default in packages passed to `buildInputs` and friends.

The rationale for doing this is to avoid breakage to users' scripts and systemd services that reference binaries like `${pkgs.perl}/bin/perl` (e.g. https://github.com/NixOS/nixos-org-configurations/blob/master/delft/common.nix#L62). Currently, those usages will just silently produce a nonsensical path, which IMHO is a significant regression to the pre-multiple-outputs state. 

Also this should fix some of our in-tree systemd units which suffer from the same issue and avoid the need for changes like https://github.com/NixOS/nixpkgs/pull/14150/commits/3e38a712dae34d53c823556bd26e8d2d896b1ff6

As a part of doing this, I manually eyeballed all usages of `${pkgs.multiout-package}` . I collected this list of packages where the implicit `dev` is currently incorrectly used in place of the correct output: https://github.com/dezgeg/nixpkgs/commits/bad-multiout-refs. So this PR fixes some of them as a side-effect (though not all, there are other things wrong as well).

Note: I'm still compiling most of this (at least `stdenv` builds...). It's certainly possible that `chooseDevOutputs` needs to be used in more places...

cc @edolstra @vcunat @ttuegel @joachifm @lethalman 
