### PR TITLE
docker: allow disabling btrfs and devicemapper

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
 
-  DOCKER_BUILDTAGS = [ "journald" ];
+  DOCKER_BUILDTAGS = [ "journald" ]
+    ++ optional (btrfs-progs == null) "exclude_graphdriver_btrfs"
+    ++ optional (devicemapper == null) "exclude_graphdriver_devicemapper";
 
   buildPhase = ''
     patchShebangs .


### PR DESCRIPTION
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
