### PR TITLE
gradle: fix attribute name for gcc libs path.

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -22,7 +22,7 @@ rec {
         mkdir patching
         pushd patching
         jar xf $out/lib/gradle/lib/native-platform-linux-${arch}-0.10.jar
-        patchelf --set-rpath "${stdenv.cc.cc}/lib:${stdenv.cc.cc}/lib64" net/rubygrapefruit/platform/linux-${arch}/libnative-platform.so
+        patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64" net/rubygrapefruit/platform/linux-${arch}/libnative-platform.so
         jar cf native-platform-linux-${arch}-0.10.jar .
         mv native-platform-linux-${arch}-0.10.jar $out/lib/gradle/lib/
         popd


### PR DESCRIPTION
PR #14326 fixed gradle so that its native code library could find
libstdc++.so.6, but this fix is inoperative now, because this library
is in `"${stdenv.cc.cc.lib}/lib"` now, rather than
`"${stdenv.cc.cc}/lib"`.
