### PR TITLE
freeorion: init at 0.4.5

### DIFF
--- a/pkgs/games/freeorion/92455f9.patch
+++ b/pkgs/games/freeorion/92455f9.patch
@@ -1,0 +1,19 @@
+diff -Naur GG/src/Font.cpp
+--- /GG/src/Font.cpp
++++ /GG/src/Font.cpp
+@@ -1586,8 +1586,13 @@
+     using boost::lexical_cast;
+     FT_UInt index = FT_Get_Char_Index(face, ch);
+     if (index) {
+-        if (FT_Load_Glyph(face, index, FT_LOAD_DEFAULT))
+-            ThrowBadGlyph("GG::Font::GetGlyphBitmap : Freetype could not load the glyph for character '%1%'", ch);
++        if (FT_Load_Glyph(face, index, FT_LOAD_DEFAULT)) {
++            // loading of a glpyh failed so we replace it with
++            // the 'Replacement Character' at codepoint 0xFFFD
++            FT_UInt tmp_index = FT_Get_Char_Index(face, 0xFFFD);
++            if (FT_Load_Glyph(face, tmp_index, FT_LOAD_DEFAULT))
++                ThrowBadGlyph("GG::Font::GetGlyphBitmap : Freetype could not load the glyph for character '%1%'", ch);
++        }
+ 
+         FT_GlyphSlot glyph = face->glyph;
+ 

--- a/pkgs/games/freeorion/default.nix
+++ b/pkgs/games/freeorion/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   # cherry pick for acceptable performance https://github.com/freeorion/freeorion/commit/92455f97c28055e296718230d2e3744eccd738ec
   patches = [ ./92455f9.patch ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "A free, open source, turn-based space empire and galactic conquest (4X) computer game";
     homepage = "http://www.freeorion.org";

--- a/pkgs/games/freeorion/default.nix
+++ b/pkgs/games/freeorion/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, cmake, boost, SDL2, python2, freetype, openal, libogg, libvorbis, zlib, libpng, libtiff, libjpeg, mesa, glew, doxygen }:
+{ stdenv, fetchurl, cmake, boost, SDL2, python2, freetype, openal, libogg, libvorbis, zlib, libpng, libtiff, libjpeg, mesa, glew, doxygen
+, libxslt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   version = "0.4.5";
@@ -9,12 +10,27 @@ stdenv.mkDerivation rec {
     sha256 = "3b99b92eeac72bd059566dbabfab54368989ba83f72e769bc94eb8dd4fe414c0";
   };
 
-  buildInputs = [ cmake boost SDL2 python2 freetype openal libogg libvorbis zlib libpng libtiff libjpeg mesa glew doxygen ];
+  buildInputs = [ cmake boost SDL2 python2 freetype openal libogg libvorbis zlib libpng libtiff libjpeg mesa glew doxygen makeWrapper ];
 
   # cherry pick for acceptable performance https://github.com/freeorion/freeorion/commit/92455f97c28055e296718230d2e3744eccd738ec
   patches = [ ./92455f9.patch ];
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    mkdir -p $out/fixpaths
+    # We need final slashes for XSLT replace to work properly
+    substitute ${./fix-paths.xslt} $out/fixpaths/fix-paths.xslt \
+      --subst-var-by nixStore "$NIX_STORE/" \
+      --subst-var-by out "$out/"
+    substitute ${./fix-paths.sh} $out/fixpaths/fix-paths \
+      --subst-var-by libxsltBin ${libxslt.bin} \
+      --subst-var out
+    chmod +x $out/fixpaths/fix-paths
+
+    wrapProgram $out/bin/freeorion \
+      --run $out/fixpaths/fix-paths
+  '';
 
   meta = with stdenv.lib; {
     description = "A free, open source, turn-based space empire and galactic conquest (4X) computer game";

--- a/pkgs/games/freeorion/default.nix
+++ b/pkgs/games/freeorion/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, boost, SDL2, python2, freetype, openal, libogg, libvorbis, zlib, libpng, libtiff, libjpeg, mesa, glew, doxygen }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.5";
+  name = "freeorion-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/freeorion/freeorion/releases/download/v0.4.5/FreeOrion_v0.4.5_2015-09-01.f203162_Source.tar.gz";
+    sha256 = "3b99b92eeac72bd059566dbabfab54368989ba83f72e769bc94eb8dd4fe414c0";
+  };
+
+  buildInputs = [ cmake boost SDL2 python2 freetype openal libogg libvorbis zlib libpng libtiff libjpeg mesa glew doxygen ];
+
+  # cherry pick for acceptable performance https://github.com/freeorion/freeorion/commit/92455f97c28055e296718230d2e3744eccd738ec
+  patches = [ ./92455f9.patch ];
+
+  meta = with stdenv.lib; {
+    description = "A free, open source, turn-based space empire and galactic conquest (4X) computer game";
+    homepage = "http://www.freeorion.org";
+    license = [ licenses.gpl2 licenses.cc-by-sa-30 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/freeorion/fix-paths.sh
+++ b/pkgs/games/freeorion/fix-paths.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -e ~/.freeorion/config.xml ]; then
+  @libxsltBin@/bin/xsltproc -o ~/.freeorion/config.xml @out@/fixpaths/fix-paths.xslt ~/.freeorion/config.xml
+fi
+exit 0

--- a/pkgs/games/freeorion/fix-paths.xslt
+++ b/pkgs/games/freeorion/fix-paths.xslt
@@ -1,0 +1,13 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" omit-xml-declaration="no" indent="yes" />
+
+  <xsl:template match='node() | @*'>
+    <xsl:copy>
+      <xsl:apply-templates select='node() | @*'/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match='//text()[starts-with(., "@nixStore@")]'>
+    <xsl:value-of select='concat("@out@", substring-after(substring-after(., "@nixStore@"), "/"))'/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14686,6 +14686,8 @@ in
 
   freedink = callPackage ../games/freedink { };
 
+  freeorion = callPackage ../games/freeorion { };
+
   fsg = callPackage ../games/fsg {
     wxGTK = wxGTK28.override { unicode = false; };
   };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Using the released 0.4.5 results in a problem (presumably https://github.com/freeorion/freeorion/pull/426 ) that results in a unplayable slow game.

The build script for requires the .git and git itself (it works without it on the released sources archives).

thanks @nico202  and @manveru  for the help!
