### PR TITLE
wine && mumble -- Fixes for post multiple-output issues

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -40,7 +40,9 @@ let
       ++ (overrides.configureFlags or [ ]);
 
     configurePhase = ''
+      runHook preConfigure
       qmake $configureFlags DEFINES+="PLUGIN_PATH=$out/lib"
+      runHook postConfigure
     '';
 
     makeFlags = [ "release" ];

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   # them to the RPATH so that the user doesn't have to set them in
   # LD_LIBRARY_PATH.
   NIX_LDFLAGS = map (path: "-rpath " + path) (
-      map (x: "${x}/lib") ([ stdenv.cc.cc ] ++ buildInputs)
+      map (x: "${x}/lib") ([ stdenv.cc.cc ] ++ (map (x: x.lib or x.out) buildInputs))
       # libpulsecommon.so is linked but not found otherwise
       ++ lib.optionals pulseaudioSupport (map (x: "${x}/lib/pulseaudio") (toBuildInputs pkgArches (pkgs: [ pkgs.libpulseaudio ])))
     );


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
