### PR TITLE
stage2 - replace tmp.mount with tmpfs handling on bootup/activation

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -158,8 +158,11 @@ in
         ${pkgs.utillinux}/bin/mount -o "remount,size=${config.boot.devSize}" none /dev
         ${pkgs.utillinux}/bin/mount -o "remount,size=${config.boot.devShmSize}" none /dev/shm
         ${pkgs.utillinux}/bin/mount -o "remount,size=${config.boot.runSize}" none /run
+      '' + optionalString config.boot.tmpOnTmpfs ''
+        if [ mountpoint -q /tmp ]; then
+          ${pkgs.utillinux}/bin/mount -o "remount,size=${config.boot.tmpFsSize}" none /tmp
+        fi
       '';
-
   };
 
 }

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -91,6 +91,12 @@ if ! mountpoint -q /dev/shm; then
 fi
 mkdir -m 0755 -p /dev/pts
 [ -e /proc/bus/usb ] && mount -t usbfs usbfs /proc/bus/usb # UML doesn't have USB by default
+
+# Clean tmp directory, if requested
+if [ -n "@cleanTmpDir@" ]; then
+    rm -rf /tmp
+fi
+
 mkdir -m 01777 -p /tmp
 mkdir -m 0755 -p /var /var/log /var/lib /var/db
 mkdir -m 0755 -p /nix/var
@@ -109,6 +115,10 @@ rm -f /etc/{group,passwd,shadow}.lock
 # Also get rid of temporary GC roots.
 rm -rf /nix/var/nix/gcroots/tmp /nix/var/nix/temproots
 
+# Create a tmpfs on /tmp, if tmpOnTmpfs is enabled
+if [ -n "@tmpOnTmpfs@" ]; then
+    mount -t tmpfs -o "mode=1777,strictatime,size=@tmpFsSize@" tmpfs /tmp
+fi
 
 # Create a tmpfs on /run to hold runtime state for programs such as
 # udev (if stage 1 hasn't already done so).

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -20,6 +20,7 @@ let
     src = ./stage-2-init.sh;
     shellDebug = "${pkgs.bashInteractive}/bin/bash";
     isExecutable = true;
+    inherit (config.boot) cleanTmpDir tmpOnTmpfs tmpFsSize;
     inherit (config.boot) devShmSize runSize;
     inherit (config.nix) readOnlyStore;
     inherit (config.networking) useHostResolvConf;

--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -24,16 +24,15 @@ with lib;
       '';
     };
 
-  };
-
-  ###### implementation
-
-  config = {
-
-    systemd.additionalUpstreamSystemUnits = optional config.boot.tmpOnTmpfs "tmp.mount";
-
-    systemd.tmpfiles.rules = optional config.boot.cleanTmpDir "D! /tmp 1777 root root";
-
+    boot.tmpFsSize = mkOption {
+        default = "90%";
+        example = "256m";
+        type = types.str;
+        description = ''
+          Size limit for the <filename>/tmp</filename> tmpfs. Look at mount(8), tmpfs size option,
+          for the accepted syntax.
+        '';
+    };
   };
 
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #14777 and #10670

~~Haven't tested yet. would love some help on how to do that =)~~

Built an ova. testing now~
