### PR TITLE
warzone2100: 3.1.1 -> 3.1.5

### DIFF
--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -1,25 +1,29 @@
 { stdenv, fetchurl, bison, flex, gettext, pkgconfig, libpng
 , libtheora, openal, physfs, mesa, fribidi, fontconfig
 , freetype, qt4, glew, libogg, libvorbis, zlib, libX11
-, libXrandr, zip, unzip, which
+, libXrandr, zip, unzip, which, perl
 , withVideos ? false
 }:
-stdenv.mkDerivation rec {
+
+let
   pname = "warzone2100";
-  version = "3.1.1";
-  name = "${pname}-${version}";
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/releases/${version}/${name}.tar.xz";
-    sha256 = "c937a2e2c7afdad00b00767636234bbec4d8b18efb008073445439d32edb76cf";
-  };
   sequences_src = fetchurl {
     url = "mirror://sourceforge/${pname}/warzone2100/Videos/high-quality-en/sequences.wz";
     sha256 = "90ff552ca4a70e2537e027e22c5098ea4ed1bc11bb7fc94138c6c941a73d29fa";
   };
+in
+
+stdenv.mkDerivation rec {
+  version = "3.1.5";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/releases/${version}/${name}.tar.xz";
+    sha256 = "0hm49i2knvvg3wlnryv7h4m84s3qa7jfyym5yy6365sx8wzcrai1";
+  };
   buildInputs = [ bison flex gettext pkgconfig libpng libtheora openal
                   physfs mesa fribidi fontconfig freetype qt4
                   glew libogg libvorbis zlib libX11 libXrandr zip
-                  unzip
+                  unzip perl
                 ];
   patchPhase = ''
     substituteInPlace lib/exceptionhandler/dumpinfo.cpp \
@@ -31,8 +35,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-fpermissive"; # GL header minor incompatibility
 
-  postInstall = []
-    ++ stdenv.lib.optional withVideos "cp ${sequences_src} $out/share/warzone2100/sequences.wz";
+  postInstall = stdenv.lib.optionalString withVideos "cp ${sequences_src} $out/share/warzone2100/sequences.wz";
 
   meta = with stdenv.lib; {
     description = "A free RTS game, originally developed by Pumpkin Studios";
@@ -45,7 +48,7 @@ stdenv.mkDerivation rec {
       missiles. The game offers campaign, multi-player, and single-player
       skirmish modes. An extensive tech tree with over 400 different
       technologies, combined with the unit design system, allows for a wide
-      variety of possible units and tactics. 
+      variety of possible units and tactics.
     '';
     homepage = http://wz2100.net;
     license = licenses.gpl2Plus;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Added the optional dependency on perl which is needed for autogeneration of some sources

When I tried building without setting withVideos, it downloaded the videos anyways, so I added optionalString to sequences_src. Not sure if correct.

I didn't test withVideos yet.

maintainer cc @astsmtl 
