### PR TITLE
wine: Disable stripping to avoid breaking fakedlls.

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -41,6 +41,13 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   # elements specified above.
   dontPatchELF = true;
 
+  # Disable stripping to avoid breaking placeholder DLLs/EXEs.
+  # Symptoms of broken placeholders are: when the wineprefix is created
+  # drive_c/windows/system32 will only contain a few files instead of
+  # hundreds, there will be an error about winemenubuilder and MountMgr
+  # on startup of Wine, and the Drives tab in winecfg will show an error.
+  dontStrip = true;
+
   ## FIXME
   # Add capability to ignore known failing tests
   # and enable doCheck


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Wine is currently subtly broken in NixOS because the fake-DLLs are broken by strip. A simple test is to run `winecfg` without a wineprefix so it creates one, than check the Drives tab. It should show a list of drives rather than an error. Also when one runs wine when the wineprefix already exists, these errors will be observed just at the beginning:

```
err:wineboot:ProcessRunKeys Error running cmd L"C:\\windows\\system32\\winemenubuilder.exe -a -r" (2)
fixme:service:scmdatabase_autostart_services Auto-start service L"MountMgr" failed to start: 2
fixme:service:scmdatabase_autostart_services Auto-start service L"PlugPlay" failed to start: 2
```

Fake-DLLs can be checked for breakage as shown below. For a file that has been broken by strip this will output nothing, but for a good file it should output "Wine placeholder DLL".

```
strings <wine>/lib/wine/fakedlls/kernel32.dll |grep placeholder
```

I have tested that this fixes the issue (fake-DLLs are okay according to this test, winecfg shows Drivers, the mentioned error messages are gone). Though one does need to create a new wineprefix to benefit from the fix.
