### PR TITLE
bootstrap-tools-linux: Qualify packages with multiple outputs

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -10,6 +10,8 @@ rec {
     aclSupport = false;
   });
 
+  tarMinimal = gnutar.override { acl = null; };
+
   busyboxMinimal = busybox.override {
     useMusl = true;
     enableStatic = true;
@@ -79,7 +81,7 @@ rec {
         cp -d ${gnugrep.out}/bin/grep $out/bin
         cp ${gawk.out}/bin/gawk $out/bin
         cp -d ${gawk.out}/bin/awk $out/bin
-        cp ${gnutar.out}/bin/tar $out/bin
+        cp ${tarMinimal.out}/bin/tar $out/bin
         cp ${gzip.out}/bin/gzip $out/bin
         cp ${bzip2.bin}/bin/bzip2 $out/bin
         cp -d ${gnumake.out}/bin/* $out/bin

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -56,9 +56,9 @@ rec {
         # glibc can contain linker scripts: find them, copy their deps,
         # and get rid of absolute paths (nuke-refs would make them useless)
         local lScripts=$(grep --files-with-matches --max-count=1 'GNU ld script' -R "$out/lib")
-        cp -d -t "$out/lib/" $(cat $lScripts | tr " " "\n" | grep -F '${glibc}' | sort -u)
+        cp -d -t "$out/lib/" $(cat $lScripts | tr " " "\n" | grep -F '${glibc.out}' | sort -u)
         for f in $lScripts; do
-          substituteInPlace "$f" --replace '${glibc}/lib/' ""
+          substituteInPlace "$f" --replace '${glibc.out}/lib/' ""
         done
 
         # Hopefully we won't need these.
@@ -68,33 +68,33 @@ rec {
         mv $out/include $out/include-glibc
 
         # Copy coreutils, bash, etc.
-        cp ${coreutilsMinimal}/bin/* $out/bin
+        cp ${coreutilsMinimal.out}/bin/* $out/bin
         (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
 
-        cp ${bash}/bin/bash $out/bin
-        cp ${findutils}/bin/find $out/bin
-        cp ${findutils}/bin/xargs $out/bin
-        cp -d ${diffutils}/bin/* $out/bin
-        cp -d ${gnused}/bin/* $out/bin
-        cp -d ${gnugrep}/bin/grep $out/bin
-        cp ${gawk}/bin/gawk $out/bin
-        cp -d ${gawk}/bin/awk $out/bin
-        cp ${gnutar}/bin/tar $out/bin
-        cp ${gzip}/bin/gzip $out/bin
+        cp ${bash.out}/bin/bash $out/bin
+        cp ${findutils.out}/bin/find $out/bin
+        cp ${findutils.out}/bin/xargs $out/bin
+        cp -d ${diffutils.out}/bin/* $out/bin
+        cp -d ${gnused.out}/bin/* $out/bin
+        cp -d ${gnugrep.out}/bin/grep $out/bin
+        cp ${gawk.out}/bin/gawk $out/bin
+        cp -d ${gawk.out}/bin/awk $out/bin
+        cp ${gnutar.out}/bin/tar $out/bin
+        cp ${gzip.out}/bin/gzip $out/bin
         cp ${bzip2.bin}/bin/bzip2 $out/bin
-        cp -d ${gnumake}/bin/* $out/bin
+        cp -d ${gnumake.out}/bin/* $out/bin
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin
 
         cp -d ${gnugrep.pcre.out}/lib/libpcre*.so* $out/lib # needed by grep
 
         # Copy what we need of GCC.
-        cp -d ${gcc.cc}/bin/gcc $out/bin
-        cp -d ${gcc.cc}/bin/cpp $out/bin
-        cp -d ${gcc.cc}/bin/g++ $out/bin
-        cp -d ${gcc.cc}/lib*/libgcc_s.so* $out/lib
-        cp -d ${gcc.cc}/lib*/libstdc++.so* $out/lib
-        cp -rd ${gcc.cc}/lib/gcc $out/lib
+        cp -d ${gcc.cc.out}/bin/gcc $out/bin
+        cp -d ${gcc.cc.out}/bin/cpp $out/bin
+        cp -d ${gcc.cc.out}/bin/g++ $out/bin
+        cp -d ${gcc.cc.lib}/lib*/libgcc_s.so* $out/lib
+        cp -d ${gcc.cc.lib}/lib*/libstdc++.so* $out/lib
+        cp -rd ${gcc.cc.out}/lib/gcc $out/lib
         chmod -R u+w $out/lib
         rm -f $out/lib/gcc/*/*/include*/linux
         rm -f $out/lib/gcc/*/*/include*/sound
@@ -102,16 +102,16 @@ rec {
         rm -f $out/lib/gcc/*/*/include-fixed/asm
         rm -rf $out/lib/gcc/*/*/plugin
         #rm -f $out/lib/gcc/*/*/*.a
-        cp -rd ${gcc.cc}/libexec/* $out/libexec
+        cp -rd ${gcc.cc.out}/libexec/* $out/libexec
         chmod -R u+w $out/libexec
         rm -rf $out/libexec/gcc/*/*/plugin
         mkdir $out/include
-        cp -rd ${gcc.cc}/include/c++ $out/include
+        cp -rd ${gcc.cc.out}/include/c++ $out/include
         chmod -R u+w $out/include
         rm -rf $out/include/c++/*/ext/pb_ds
         rm -rf $out/include/c++/*/ext/parallel
 
-        cp -d ${gmpxx}/lib/libgmp*.so* $out/lib
+        cp -d ${gmpxx.out}/lib/libgmp*.so* $out/lib
         cp -d ${mpfr.out}/lib/libmpfr*.so* $out/lib
         cp -d ${libmpc}/lib/libmpc*.so* $out/lib
         cp -d ${zlib.out}/lib/libz.so* $out/lib
@@ -119,7 +119,7 @@ rec {
 
         # Copy binutils.
         for i in as ld ar ranlib nm strip readelf objdump; do
-          cp ${binutils}/bin/$i $out/bin
+          cp ${binutils.out}/bin/$i $out/bin
         done
         cp -d ${binutils.out}/lib/lib*.so* $out/lib
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) **(only tests)**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Builds using `nix-build . -A stdenvBootstrapTools.x86_64-linux`

---

Fails currently on [Hydra](http://hydra.nixos.org/build/34463800).
I added the output selector for every package with multiple outputs, not only for gcc/glib where it was missing.

The tests kept failing because of tar being built with acl and neither libacl nor libattr is copied. So I added a minimal tar version without acl.
