### PR TITLE
davmail: 4.7.1 -> 4.7.2

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, jre, glib, libXtst, gtk, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "davmail-4.7.1";
+  name = "davmail-4.7.2";
   src = fetchurl {
-    url = "mirror://sourceforge/davmail/4.7.1/davmail-linux-x86_64-4.7.1-2416.tgz";
-    sha256 = "c3bf1a3a94f35586a3a8d2d28cdaf8c9514a8cf904a51fd74961e93909c9d2a4";
+    url = "mirror://sourceforge/davmail/4.7.2/davmail-linux-x86_64-4.7.2-2427.tgz";
+    sha256 = "0hanv90klhbsxcizz8xddd4zn1j59bs43j4qllg04r2b1cbpkgh2";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
