### PR TITLE
A whole bunch of python packages necessary to install ROS

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19271,6 +19271,27 @@ in modules // {
     };
   };
 
+  rosinstall = buildPythonPackage rec {
+    version = "0.7.7";
+    name = "rosinstall-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/rosinstall/rosinstall-${version}.tar.gz";
+      sha256 = "1b91bcsrdv5vydbpibmddm835v5g7m3hn886fzraj6bpqqipkym0";
+    };
+
+    propagatedBuildInputs = with self; [ catkin_pkg rosdistro vcstools wstool ];
+
+    # No test suite
+    doCheck = false;
+
+    meta = {
+      description = "The installer for ROS";
+      homepage = http://wiki.ros.org/rosinstall;
+      license = licenses.bsd3;
+    };
+  };
+
   rosinstall_generator = buildPythonPackage rec {
     version = "0.1.11";
     name = "rosinstall_generator-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19271,6 +19271,27 @@ in modules // {
     };
   };
 
+  rosinstall_generator = buildPythonPackage rec {
+    version = "0.1.11";
+    name = "rosinstall_generator-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/rosinstall_generator/rosinstall_generator-${version}.tar.gz";
+      sha256 = "0qgigpy7r81rfcwg7qb2fkwxxkijcclrzjhfwc84dw1x8p589dz6";
+    };
+
+    propagatedBuildInputs = with self; [ argparse catkin_pkg distribute rosdistro rospkg ];
+
+    # No test suite
+    doCheck = false;
+
+    meta = {
+      description = "A tool to generator rosinstall files";
+      homepage = http://wiki.ros.org/rosinstall_generator;
+      license = licenses.bsd3;
+    };
+  };
+
   rospkg = buildPythonPackage rec {
     version = "1.0.38";
     name = "rospkg-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22760,6 +22760,27 @@ in modules // {
     };
   };
 
+  wstool = buildPythonPackage rec {
+    name = "wstool-${version}";
+    version = "0.1.12";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/w/wstool/wstool-${version}.tar.gz";
+      sha256 = "0vrf3sfkadmzb3kz2p8nvq7sa2bbwwczldprfm1x5hifv93w21r5";
+    };
+
+    propagatedBuildInputs = with self; [ vcstools ];
+
+    # No test suite.
+    doCheck = false;
+
+    meta = {
+      description = "workspace multi-SCM commands";
+      homepage = http://wiki.ros.org/wstool;
+      license = licenses.bsd3;
+    };
+  };
+
   wxPython = self.wxPython28;
 
   wxPython28 = import ../development/python-modules/wxPython/2.8.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19227,6 +19227,29 @@ in modules // {
      };
   };
 
+  rosdep = buildPythonPackage rec {
+    version = "0.11.4";
+    name = "rosdep-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/rosdep/rosdep-${version}.tar.gz";
+      sha256 = "1f4br1sq9shg5lh2s7vvzgchi8vf8l8s25pvqldqnya5096ivwz4";
+    };
+
+    buildInputs = with self; [ mock ];
+
+    propagatedBuildInputs = with self; [ rosdistro ];
+
+    # Some tests require network access
+    doCheck = false;
+
+    meta = {
+      description = "rosdep package manager abstrction tool for ROS";
+      homepage = http://wiki.ros.org/rosdep;
+      license = licenses.bsd3;
+    };
+  };
+
   rosdistro = buildPythonPackage rec {
     version = "0.4.7";
     name = "rosdistro-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22296,6 +22296,27 @@ in modules // {
     };
   };
 
+  vcstools = buildPythonPackage rec {
+    name = "vcstools-${version}";
+    version = "0.1.38";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/v/vcstools/vcstools-${version}.tar.gz";
+      sha256 = "0wmgnrbb0kw3dm1xa0rqlxh5c6lg09s6qqwk3rg97iscx8vvz0lw";
+    };
+
+    propagatedBuildInputs = with self; [ dateutil pyyaml ];
+
+    # No test suite.
+    doCheck = false;
+
+    meta = {
+      description = "VCS/SCM source control library for svn, git, hg, and bzr";
+      homepage = "http://wiki.ros.org/vcstools";
+      license = licenses.bsd3;
+    };
+  };
+
   virtual-display = buildPythonPackage rec {
     name = "PyVirtualDisplay-0.1.5";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19227,7 +19227,26 @@ in modules // {
      };
   };
 
+  rospkg = buildPythonPackage rec {
+    version = "1.0.38";
+    name = "rospkg-${version}";
 
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/rospkg/rospkg-${version}.tar.gz";
+      sha256 = "0clc7c8y0l8kjn1006pg72w9iy2sg2pj1ha07mrlkzmjny7lfjvp";
+    };
+
+    propagatedBuildInputs = with self; [ pyyaml ];
+
+    # No test suite
+    doCheck = false;
+
+    meta = {
+      description = "ROS package library";
+      homepage = http://wiki.ros.org/rospkg;
+      license = licenses.bsd3;
+    };
+  };
 
   routes = buildPythonPackage rec {
     name = "routes-1.12.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2936,6 +2936,27 @@ in modules // {
     };
   };
 
+  catkin_pkg = buildPythonPackage rec {
+    name = "catkin_pkg-${version}";
+    version = "0.2.8";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/c/catkin_pkg/catkin_pkg-${version}.tar.gz";
+      sha256 = "034kbkmiicg82mzhp684v2vr64z7w758ddf84z308ndiz20x7ljg";
+    };
+
+    propagatedBuildInputs = with self; [ argparse dateutil docutils ];
+
+    # There are no tests
+    doCheck = false;
+
+    meta = {
+      homepage = http://wiki.ros.org/catkin_pkg;
+      description = "Library for retrieving information about catkin packages.";
+      license = licenses.bsd3;
+    };
+  };
+
   CDDB = buildPythonPackage rec {
     name = "CDDB-1.4";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7977,6 +7977,23 @@ in modules // {
     };
   });
 
+  distribute = buildPythonPackage rec {
+    version = "0.7.3";
+    name = "distribute-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/d/distribute/distribute-${version}.zip";
+      sha256 = "0plc2dkmfd6p8lsqqvl1rryz03pf4i5198igml72zxywb78aiirx";
+    };
+
+    propagatedBuildInputs = with self; [ ];
+
+    meta = {
+      description = "distribute legacy wrapper";
+      homepage = http://packages.python.org/distribute;
+    };
+  };
+
   distutils_extra = buildPythonPackage rec {
     name = "distutils-extra-${version}";
     version = "2.39";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19227,6 +19227,27 @@ in modules // {
      };
   };
 
+  rosdistro = buildPythonPackage rec {
+    version = "0.4.7";
+    name = "rosdistro-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/r/rosdistro/rosdistro-${version}.tar.gz";
+      sha256 = "1i7d3qv3bgfqc2pdcf2jzvmrxq64wx404mvddyghir6fdcrmfizl";
+    };
+
+    propagatedBuildInputs = with self; [ catkin_pkg rospkg ];
+
+    # No test suite
+    doCheck = false;
+
+    meta = {
+      description = "A tool to work with rosdistro files";
+      homepage = http://wiki.ros.org/rosdistro;
+      license = licenses.bsd3;
+    };
+  };
+
   rospkg = buildPythonPackage rec {
     version = "1.0.38";
     name = "rospkg-${version}";


### PR DESCRIPTION
Note that I had to disable the tests for `rosdep` as they depended on network access.
Someone interested in Python may want to take a look to see if these individual tests can be disabled or fixed.
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
