### PR TITLE
libreoffice: 5.1.0.3 -> 5.1.2.2

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -21,8 +21,8 @@ let
   langsSpaces = stdenv.lib.concatStringsSep " " langs;
   major = "5";
   minor = "1";
-  patch = "0";
-  tweak = "3";
+  patch = "2";
+  tweak = "2";
   subdir = "${major}.${minor}.${patch}";
   version = "${subdir}${if tweak == "" then "" else "."}${tweak}";
 
@@ -48,14 +48,14 @@ let
 
     translations = fetchSrc {
       name = "translations";
-      sha256 = "1qqffq7646yh7rskzd1wvy0zgkdnkpdbyhvsny424lxqjglyw3px";
+      sha256 = "1w2m4hfrxb706p8bjfgklqv0j5hnivbvif3vav7sbngp5ms0vgvz";
     };
 
     # TODO: dictionaries
 
     help = fetchSrc {
       name = "help";
-      sha256 = "0ixlq6yzn6z8hsih24l934sa05vvz2vk3p03nalpqqrhm7vdzsf2";
+      sha256 = "0lr90z5fdg157lcid5w4p0zxi72c4xziiw51kh38kbbqrbb9ykfw";
     };
 
   };
@@ -64,7 +64,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1csphxpbpc7bxrwnl5i9nvm3bh3p0j7r3h9ivsdl7cys13q066xl";
+    sha256 = "108p8jg22lg3g9wypqv5d71j4vkcpmg2x2w9l2v4z9h10agdrv2l";
   };
 
   # Openoffice will open libcups dynamically, so we link it directly


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
