### PR TITLE
get_iplayer: fix outputs and add man page

### DIFF
--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -7,6 +7,7 @@ buildPerlPackage {
 
   preConfigure = "touch Makefile.PL";
   doCheck = false;
+  outputs = [ "out" "man" ];
 
   patchPhase = ''
     sed -e 's|^update_script|#update_script|' \
@@ -15,10 +16,11 @@ buildPerlPackage {
   '';
 
   installPhase = '' 
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
     wrapProgram $out/bin/get_iplayer --suffix PATH : ${ffmpeg.bin}/bin:${flvstreamer}/bin:${vlc}/bin:${rtmpdump}/bin --prefix PERL5LIB : $PERL5LIB
-  '';  
+    cp get_iplayer.1 $out/share/man/man1
+  '';
   
   src = fetchurl {
     url = ftp://ftp.infradead.org/pub/get_iplayer/get_iplayer-2.94.tar.gz;


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against master"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Package stopped building after closure-size merge because `buildPerlPackage` has `docdev` in its default outputs.

There is also a decent man page in the source distribution, which I added to the `man` output.
