### PR TITLE
hplip : add openssl as buildInput

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll
 , pkgconfig
 , cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends, dbus, usbutils
-, net_snmp, polkit
+, net_snmp, openssl, polkit
 , bash, coreutils, utillinux
 , qtSupport ? true, qt4, pyqt4
 , withPlugin ? false
@@ -59,6 +59,7 @@ stdenv.mkDerivation {
     sane-backends
     dbus
     net_snmp
+    openssl
   ] ++ stdenv.lib.optionals qtSupport [
     qt4
   ];


### PR DESCRIPTION
###### Things done

hplip requires openssl. This is included by transitivity when built with `qtSupport = true` (the default), but not when `qtSupport = false`.
This pr explicitly adds it as buildInput. 
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
