### PR TITLE
linux-testing: 4.6-rc3 -> 4.6-rc4

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.6-rc3";
-  modDirVersion = "4.6.0-rc3";
+  version = "4.6-rc4";
+  modDirVersion = "4.6.0-rc4";
   extraMeta.branch = "4.6";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/testing/linux-${version}.tar.xz";
-    sha256 = "1vhvhbldk5pvwxhdndyzvyqy5mscpnlz09sfyh2c9rk6wc1hc8xv";
+    sha256 = "1c6y6ry8nll8mab0xwwkmpwzp2k4rbp7jl3f4ihi7g2kv2678cbp";
   };
 
   features.iwlwifi = true;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
