### PR TITLE
389-ds-base: fix compilation

### DIFF
--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    "--with-openldap=${openldap}"
+    "--with-openldap"
     "--with-db=${db}"
     "--with-sasl=${cyrus_sasl}"
     "--with-netsnmp=${net_snmp}"


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Multiple outputs in openldap made this package confused. Remove the explicit reference to the openldap library and let configure sort it out. Note, I did not confirm functionality merely that the package built OK and verified that it links to the expected openldap libraries using `ldd`.

CC maintainer: @wkennington 
