### PR TITLE
openxpki: fix build

### DIFF
--- a/pkgs/servers/openxpki/default.nix
+++ b/pkgs/servers/openxpki/default.nix
@@ -50,7 +50,10 @@ buildPerlPackage {
       lib libapreq2 libnet podlators threads threadsshared version ];
 
   preConfigure = ''
-    export OPENSSL_PREFIX=${openssl}
+    substituteInPlace core/server/Makefile.PL \
+      --replace "my \$openssl_inc_dir = ''';" "my \$openssl_inc_dir = '${openssl}/include';" \
+      --replace "my \$openssl_lib_dir = ''';" "my \$openssl_lib_dir = '${openssl.out}/lib';" \
+      --replace "my \$openssl_binary  = ''';" "my \$openssl_binary  = '${openssl.bin}/bin/openssl';"
     substituteInPlace tools/vergen --replace "#!/usr/bin/perl" "#!${perl}/bin/perl"
     cp ${./vergen_revision_state} .vergen_revision_state
     cd core/server


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The openxpki build is not liking the multiple outputs of openssl. This commit fixes the build, unfortunately not in the prettiest of ways. Note, I did not confirm functionality merely that the package built OK and verified that it links to the expected openssl libraries using `ldd`.

CC maintainer: @ts468
