### PR TITLE
avro-c++: Init at 1.7.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -289,6 +289,7 @@
   pxc = "Patrick Callahan <patrick.callahan@latitudeengineering.com>";
   qknight = "Joachim Schiele <js@lastlog.de>";
   ragge = "Ragnar Dahlen <r.dahlen@gmail.com>";
+  rasendubi = "Alexey Shmalko <rasen.dubi@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";
   refnil = "Martin Lavoie <broemartino@gmail.com>";

--- a/pkgs/development/libraries/avro-c++/default.nix
+++ b/pkgs/development/libraries/avro-c++/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, boost155, pythonPackages
+}:
+
+let version = "1.7.5"; in
+
+stdenv.mkDerivation {
+  name = "avro-c++-${version}";
+
+  src = fetchurl {
+    url = "mirror://apache/avro/avro-${version}/cpp/avro-cpp-${version}.tar.gz";
+    sha256 = "064ssbbgrc3hyalzj8rn119bsrnyk1vlpkhl8gghv96jgqbpdyb3";
+  };
+
+  buildInputs = [
+    cmake
+    boost155
+    pythonPackages.python
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A C++ library which implements parts of the Avro Specification";
+    homepage = https://avro.apache.org/;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ rasendubi ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -523,6 +523,8 @@ in
     qt4Support = config.avahi.qt4Support or false;
   };
 
+  avro-cpp = callPackage ../development/libraries/avro-c++ { };
+
   aws = callPackage ../tools/virtualization/aws { };
 
   aws_mturk_clt = callPackage ../tools/misc/aws-mturk-clt { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
