### PR TITLE
sdlmame: fix broken URLs

### DIFF
--- a/pkgs/games/sdlmame/default.nix
+++ b/pkgs/games/sdlmame/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
 
   src = if stdenv.system == "x86_64-linux"
     then fetchurl {
-      url    = "ftp://ftp.archlinux.org/community/os/x86_64/${name}-x86_64.pkg.tar.xz";
+      url    = "http://seblu.net/a/archive/packages/s/sdlmame/${name}-x86_64.pkg.tar.xz";
       sha256 = "1j9vjxhrhsskrlk5wr7al4wk2hh3983kcva42mqal09bmc8qg3m9";
     }
     else fetchurl {
-      url    = "ftp://ftp.archlinux.org/community/os/i686/${name}-i686.pkg.tar.xz";
+      url    = "http://seblu.net/a/archive/packages/s/sdlmame/${name}-i686.pkg.tar.xz";
       sha256 = "1i38j9ml66pyxzm0zzf1fv4lb40f6w47cdgaw846q91pzakkkqn7";
     };
 
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     license     = "MAME";
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.linux;
-    broken = true; # URL doesn't work anymore
+    broken = false;
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
