### PR TITLE
virtinst: fix reference to /usr/bin/virsh

### DIFF
--- a/pkgs/applications/virtualization/virtinst/default.nix
+++ b/pkgs/applications/virtualization/virtinst/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, intltool, libxml2Python, curl }:
+{ stdenv, fetchurl, pythonPackages, intltool, libxml2Python, curl, libvirt }:
 
 with stdenv.lib;
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       distutils_extra simplejson readline glanceclient cheetah lockfile httplib2
       # !!! should libvirt be a build-time dependency?  Note that
       # libxml2Python is a dependency of libvirt.py.
-      libvirt libxml2Python urlgrabber
+      pythonPackages.libvirt libxml2Python urlgrabber
     ];
 
   buildInputs =
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
   installPhase =
     ''
        python setup.py install --prefix="$out";
+       substituteInPlace "$out/bin/virt-install" \
+          --replace "/usr/bin/virsh" ${libvirt}/bin/virsh \
+          --replace "/usr/bin/virt-viewer" "virt-viewer"
+
        wrapPythonPrograms
     '';
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
## \- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This change also amends virt-install to resolve virt-viewer from $PATH, as this is considered an
optional dependency by upstream (per the error messages). I haven't tested this part, but it can't be any more broken.
