### PR TITLE
ldb: strip non-standard binaries

### DIFF
--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
     "--builtin-libraries=replace"
   ];
 
+  stripDebugList= [ "bin" "lib" "modules" ]; # also strip modules.
+
   meta = with stdenv.lib; {
     description = "a LDAP-like embedded database";
     homepage = http://ldb.samba.org/;


### PR DESCRIPTION
LDB has binaries in /modules, and this pull gcc and other build time dependencies in runtime packages.
