### PR TITLE
php: add a dev ouptut & strip all the binaries

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -337,7 +337,7 @@ let
         allModules =
           concatMap (svc: svc.extraModulesPre) allSubservices
           ++ map (name: {inherit name; path = "${httpd}/modules/mod_${name}.so";}) apacheModules
-          ++ optional enablePHP { name = "php5"; path = "${php}/modules/libphp5.so"; }
+          ++ optional enablePHP { name = "php5"; path = "${php.out}/modules/libphp5.so"; }
           ++ concatMap (svc: svc.extraModules) allSubservices
           ++ extraForeignModules;
       in concatMapStrings load allModules
@@ -406,7 +406,7 @@ let
         ([ mainCfg.phpOptions ] ++ (map (svc: svc.phpOptions) allSubservices));
     }
     ''
-      cat ${php}/etc/php-recommended.ini > $out
+      cat ${php.out}/etc/php-recommended.ini > $out
       echo "$options" >> $out
     '';
 

--- a/nixos/modules/services/web-servers/phpfpm.nix
+++ b/nixos/modules/services/web-servers/phpfpm.nix
@@ -37,8 +37,8 @@ in {
 
       phpPackage = mkOption {
         type = types.package;
-        default = pkgs.php;
-        defaultText = "pkgs.php";
+        default = pkgs.php.out;
+        defaultText = "pkgs.php.out";
         description = ''
           The PHP package to use for running the FPM service.
         '';

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -275,6 +275,9 @@ let
         cp php.ini-production $iniFile
       '';
 
+      # Also strip libphp5.so which resides in /modules
+      stripDebugList= [ "lib" "modules" "bin" "sbin" ];
+
       src = fetchurl {
         url = "http://www.php.net/distributions/php-${version}.tar.bz2";
         inherit sha256;

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -255,6 +255,8 @@ let
         calendarSupport = config.php.calendar or true;
       };
 
+      outputs = [ "dev" "out" ];
+
       configurePhase = ''
         # Don't record the configure flags since this causes unnecessary
         # runtime dependencies.


### PR DESCRIPTION
These commits introduce stripping to all the binaries, and create a dev output to separate php's generated include files which contain references to build inputs.

Also update nixos to pick the right output.
