### PR TITLE
apache: strip extra dirs.

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   # FIXME: -dev depends on -doc
   outputs = [ "dev" "out" "doc" ];
   setOutputFlags = false; # it would move $out/modules, etc.
+  stripDebugList= [ "bin" "lib" "modules" ]; # also strip modules.
 
   propagatedBuildInputs = [ apr ]; # otherwise mod_* fail to find includes often
   buildInputs = [ pkgconfig perl aprutil pcre zlib ] ++
@@ -55,8 +56,6 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
-
-  stripDebugList = "lib modules bin";
 
   postInstall = ''
     mkdir -p $doc/share/doc/httpd

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   # FIXME: -dev depends on -doc
   outputs = [ "dev" "out" "doc" ];
   setOutputFlags = false; # it would move $out/modules, etc.
+  stripDebugList= [ "bin" "lib" "modules" ]; # also strip modules.
 
   buildInputs = [perl] ++
     optional sslSupport openssl ++


### PR DESCRIPTION
Apache keeps reference to build-time paths in /include files.
I bet these files could be simply removed, but creating a dev output works just as well.
