### PR TITLE
go: strip binaries in /share

### DIFF
--- a/pkgs/development/compilers/go/1.1.nix
+++ b/pkgs/development/compilers/go/1.1.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation {
     cp ./misc/emacs/* $out/share/emacs/site-lisp/
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   meta = {
     branch = "1.1";
     homepage = http://golang.org/;

--- a/pkgs/development/compilers/go/1.2.nix
+++ b/pkgs/development/compilers/go/1.2.nix
@@ -80,6 +80,8 @@ stdenv.mkDerivation {
     cp ./misc/emacs/* $out/share/emacs/site-lisp/
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   meta = {
     branch = "1.2";
     homepage = http://golang.org/;

--- a/pkgs/development/compilers/go/1.3.nix
+++ b/pkgs/development/compilers/go/1.3.nix
@@ -100,6 +100,8 @@ stdenv.mkDerivation {
     cp ./misc/emacs/* $out/share/emacs/site-lisp/
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   setupHook = ./setup-hook.sh;
 
   meta = {

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -113,6 +113,8 @@ stdenv.mkDerivation rec {
     ./all.bash
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   setupHook = ./setup-hook.sh;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/go/1.5.nix
+++ b/pkgs/development/compilers/go/1.5.nix
@@ -124,6 +124,8 @@ stdenv.mkDerivation rec {
     rm -r $out/share/go/pkg/bootstrap
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   setupHook = ./setup-hook.sh;
 
   disallowedReferences = [ go_1_4 ];

--- a/pkgs/development/compilers/go/1.6.nix
+++ b/pkgs/development/compilers/go/1.6.nix
@@ -136,6 +136,8 @@ stdenv.mkDerivation rec {
     rm -r $out/share/go/pkg/bootstrap
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   setupHook = ./setup-hook.sh;
 
   disallowedReferences = [ go_1_4 ];

--- a/pkgs/development/compilers/go/default.nix
+++ b/pkgs/development/compilers/go/default.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation {
     cp ./misc/emacs/* $out/share/emacs/site-lisp/
   '';
 
+  stripDebugList = [ "bin" "share" ];
+
   meta = {
     branch = "1.0";
     homepage = http://golang.org/;


### PR DESCRIPTION
I have only tested this with go 1.5.
Reviews welcome for other versions of go.
