### PR TITLE
nanoflann: init at 1.1.9

### DIFF
--- a/pkgs/development/libraries/nanoflann/default.nix
+++ b/pkgs/development/libraries/nanoflann/default.nix
@@ -1,0 +1,25 @@
+{stdenv, fetchFromGitHub, cmake}:
+
+stdenv.mkDerivation rec {
+  version = "1.1.9";
+  name = "nanoflann-${version}";
+  
+  src = fetchFromGitHub {
+    owner = "jlblancoc";
+    repo = "nanoflann";
+    rev = "v${version}";
+    sha256 = "1q588cf2aark45bp4ciqjiz3dkdv8dcijkhm1ybzs8qjdzz9fimn";
+  };
+
+  buildInputs = [ cmake ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = {
+    homepage = https://github.com/jlblancoc/nanoflann;
+    license = stdenv.lib.licenses.bsd3;
+    description = "Header only C++ library for approximate nearest neighbor search";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8256,6 +8256,8 @@ in
 
   mythes = callPackage ../development/libraries/mythes { };
 
+  nanoflann = callPackage ../development/libraries/nanoflann { };
+
   nanomsg = callPackage ../development/libraries/nanomsg { };
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
