### PR TITLE
cairo: build cairo-xlib even on Darwin

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -32,8 +32,7 @@ stdenv.mkDerivation rec {
   ]);
 
   propagatedBuildInputs =
-    with xorg; [ libXext fontconfig expat freetype pixman zlib libpng ]
-    ++ optional (!stdenv.isDarwin) libXrender
+    with xorg; [ libXext fontconfig expat freetype pixman zlib libpng libXrender ]
     ++ optionals xcbSupport [ libxcb xcbutil ]
     ++ optional gobjectSupport glib
     ++ optional glSupport mesa_noglu


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This enables to build gtk+ (which currently fails with “Package requirements (cairo-xlib >= 1.6) were not met”).
