### PR TITLE
gzip: 1.6 -> 1.7

### DIFF
--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, xz }:
 
 stdenv.mkDerivation rec {
-  name = "gzip-1.6";
+  name = "gzip-${version}";
+  version = "1.7";
 
   src = fetchurl {
     url = "mirror://gnu/gzip/${name}.tar.xz";
-    sha256 = "0ivqnbhiwd12q8hp3qw6rpsrpw2jg5y2mymk8cn22lsx90dfvprp";
+    sha256 = "1as1ddq58spflzz5kxm0ni0xfpswrkkrncjpxyb3aw77gizcacgv";
   };
 
   outputs = [ "out" "man" "info" ];
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
   makeFlags = "SHELL=/bin/sh GREP=grep";
 
   meta = {
-    homepage = http://www.gnu.org/software/gzip/;
+    homepage = https://www.gnu.org/software/gzip/;
     description = "GNU zip compression program";
 
     longDescription =


### PR DESCRIPTION
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
