### PR TITLE
numpy/scipy/sqlalchemy: allow defaultversions to be configured

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -12,6 +12,7 @@
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
   aboseley = "Adam Boseley <adam.boseley@gmail.com>";
   adev = "Adrien Devresse <adev@adev.name>";
+  adnelson = "Allen Nelson <anelson@narrativescience.com>";
   Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   aespinosa = "Allan Espinosa <allan.espinosa@outlook.com>";
   aflatter = "Alexander Flatter <flatter@fastmail.fm>";

--- a/pkgs/development/python-modules/numpy.nix
+++ b/pkgs/development/python-modules/numpy.nix
@@ -46,6 +46,6 @@ in buildPythonPackage (args // rec {
   meta = {
     description = "Scientific tools for Python";
     homepage = "http://numpy.scipy.org/";
-    maintainers = with lib.maintainers; [ fridh ];
+    maintainers = with lib.maintainers; [ fridh adnelson ];
   } // (args.meta or {});
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5477,22 +5477,6 @@ in
   python2Packages = python27Packages;
   python3Packages = python34Packages;
 
-  # Some arguments that pythonPackages uses; these can be overridden in your
-  # nixpkgs config. For example, to have python packages use numpy verison 1.9
-  # by default, you can specify the following in your config:
-  #
-  #   packageOverrides = self: {
-  #     defaultNumpyVersion = "1.9";
-  #   };
-  #
-
-  # Default version of numpy
-  defaultNumpyVersion = "1.10";
-  # Default version of scipy
-  defaultScipyVersion = "0.16";
-  # Default version of sqlalchemy
-  defaultSqlalchemyVersion = "1.0";
-
   python26 = callPackage ../development/interpreters/python/2.6 {
     db = db47;
     self = python26;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5477,6 +5477,22 @@ in
   python2Packages = python27Packages;
   python3Packages = python34Packages;
 
+  # Some arguments that pythonPackages uses; these can be overridden in your
+  # nixpkgs config. For example, to have python packages use numpy verison 1.9
+  # by default, you can specify the following in your config:
+  #
+  #   packageOverrides = self: {
+  #     defaultNumpyVersion = "1.9";
+  #   };
+  #
+
+  # Default version of numpy
+  defaultNumpyVersion = "1.10";
+  # Default version of scipy
+  defaultScipyVersion = "0.16";
+  # Default version of sqlalchemy
+  defaultSqlalchemyVersion = "1.0";
+
   python26 = callPackage ../development/interpreters/python/2.6 {
     db = db47;
     self = python26;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1,14 +1,4 @@
-{ pkgs, stdenv, python, self,
-  # Set the default version of numpy, which will be used for packages that
-  # don't depend on a specific version of numpy.
-  defaultNumpyVersion ? "1.10",
-  # Set the default version of scipy, which will be used for packages that
-  # don't depend on a specific version of scipy.
-  defaultScipyVersion ? "0.16",
-  # Set the default version of sqlalchemy, which will be used for packages
-  # that don't depend on a specific version of sqlalchemy.
-  defaultSqlalchemyVersion ? "1.0"
-}:
+{ pkgs, stdenv, python, self }:
 
 with pkgs.lib;
 
@@ -13286,10 +13276,7 @@ in modules // {
     blas = pkgs.openblasCompat;
   };
 
-  numpy = if defaultNumpyVersion == "1.11" then self.numpy_1_11
-          else if defaultNumpyVersion == "1.10" then self.numpy_1_10
-          else if defaultNumpyVersion == "1.9" then self.numpy_1_9
-          else throw "Unsupported numpy version: ${defaultNumpyVersion}";
+  numpy = self.numpy_1_10;
 
   numpy_1_9 = self.buildNumpyPackage rec {
     version = "1.9.2";
@@ -19540,9 +19527,7 @@ in modules // {
     gfortran = pkgs.gfortran;
   };
 
-  scipy = if defaultScipyVersion == "0.17" then self.scipy_0_17
-          else if defaultScipyVersion == "0.16" then self.scipy_0_16
-          else throw "Unsupported scipy version: ${defaultScipyVersion}";
+  scipy = self.scipy_0_17;
 
   scipy_0_16 = self.buildScipyPackage rec {
     version = "0.16.1";
@@ -20755,12 +20740,7 @@ in modules // {
     rope = if isPy3k then null else self.rope;
   };
 
-  sqlalchemy =
-    if defaultSqlalchemyVersion == "0.7" then self.sqlalchemy7
-    else if defaultSqlalchemyVersion == "0.8" then self.sqlalchemy8
-    else if defaultSqlalchemyVersion == "0.9" then self.sqlalchemy9
-    else if defaultSqlalchemyVersion == "1.0" then self.sqlalchemy_1_0
-    else throw "Unsupported sqlalchemy version: ${defaultSqlalchemyVersion}";
+  sqlalchemy = self.sqlalchemy_1_0;
 
   sqlalchemy7 = buildPythonPackage rec {
     name = "SQLAlchemy-0.7.10";
@@ -20813,32 +20793,6 @@ in modules // {
     buildInputs = with self; [ nose mock ]
       ++ stdenv.lib.optional doCheck pysqlite;
     propagatedBuildInputs = with self; [ modules.sqlite3 ];
-
-    checkPhase = ''
-      ${python.executable} sqla_nose.py
-    '';
-
-    meta = {
-      homepage = http://www.sqlalchemy.org/;
-      description = "A Python SQL toolkit and Object Relational Mapper";
-    };
-  };
-
-  sqlalchemy9 = buildPythonPackage rec {
-    name = "SQLAlchemy-0.9.9";
-
-    src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/SQLAlchemy/${name}.tar.gz";
-      sha256 = "14az6hhrz4bgnicz4q373z119zmaf7j5zxl1jfbfl5lix5m1z9bj";
-    };
-
-    buildInputs = with self; [ nose mock ]
-      ++ stdenv.lib.optional doCheck pysqlite;
-    propagatedBuildInputs = with self; [ modules.sqlite3 ];
-
-    # Test-only dependency pysqlite doesn't build on Python 3. This isn't an
-    # acceptable reason to make all dependents unavailable on Python 3 as well
-    doCheck = !(isPyPy || isPy3k);
 
     checkPhase = ''
       ${python.executable} sqla_nose.py


### PR DESCRIPTION
This allows a user to configure at top-level the default versions of numpy, scipy and sqlalchemy. All three are commonly-used libraries, and a package that uses them might also depend on other packages which also use these libraries, in which case the versions must match. This change preserves the existing default versions, while allowing users to configure their own defaults if they need to.

I also added (back) in versions 1.9 of numpy and 0.9 of sqlalchemy.
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
