### PR TITLE
zathura: 0.3.5 -> 0.3.6, girara: 0.2.5 -> 0.2.6

### DIFF
--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -5,11 +5,11 @@ assert withBuildColors -> ncurses != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "girara-${version}";
-  version = "0.2.5";
+  version = "0.2.6";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/girara/download/${name}.tar.gz";
-    sha256 = "14m8mfbck49ldwi1w2i47bbg5c9daglcmvz9v2g1hnrq8k8g5x2w";
+    sha256 = "03wsxj27hvcbs3x96nah7j3paclifwlfag8kdph4kldl48srp9pb";
   };
 
   preConfigure = ''

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, gtk, girara, ncurses, gettext, docutils, file, makeWrapper, zathura_icon, sqlite, glib }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.5";
+  version = "0.3.6";
   name = "zathura-core-${version}";
 
   src = fetchurl {
     url = "http://pwmt.org/projects/zathura/download/zathura-${version}.tar.gz";
-    sha256 = "031kdr10065q14nixc4p58c4rgvrqcmn9x39b19h2357kzabaw9a";
+    sha256 = "0fyb5hak0knqvg90rmdavwcmilhnrwgg1s5ykx9wd3skbpi8nsh8";
   };
 
   buildInputs = [ pkgconfig file gtk girara gettext makeWrapper sqlite glib ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
## 

The zathura plugins haven't released new versions but all remain compatible.
