### PR TITLE
mcomix: 1.01 -> 1.2.1

### DIFF
--- a/pkgs/applications/graphics/mcomix/default.nix
+++ b/pkgs/applications/graphics/mcomix/default.nix
@@ -2,11 +2,12 @@
 
 buildPythonApplication rec {
     namePrefix = "";
-    name = "mcomix-1.01";
+    name = "mcomix-${version}";
+    version = "1.2.1";
 
     src = fetchurl {
       url = "mirror://sourceforge/mcomix/${name}.tar.bz2";
-      sha256 = "0k3pqbvk08kb1nr0qldaj9bc7ca6rvcycgfi2n7gqmsirq5kscys";
+      sha256 = "0fzsf9pklhfs1rzwzj64c0v30b74nk94p93h371rpg45qnfiahvy";
     };
 
     propagatedBuildInputs = with python27Packages; [ pygtk pillow sqlite3 ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
