### PR TITLE
fcitx-qt5: fix build

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   preInstall = ''
     substituteInPlace platforminputcontext/cmake_install.cmake \
-      --replace ${qtbase} $out
+      --replace ${qtbase.out} $out
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without this change, the install phase fails with the following message:

```
CMake Error at platforminputcontext/cmake_install.cmake:50 (file):
  file INSTALL cannot copy file
  "/tmp/nix-build-fcitx-qt5-1.0.5.drv-0/fcitx-qt5-1.0.5/build/platforminputcontext/libfcitxplatforminputcontextplugin.so"
  to
  "/nix/store/5ixiz6661qki5a3crlv4q74hc6l8za7g-qtbase-5.5.1/lib/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so".
Call Stack (most recent call first):
  cmake_install.cmake:39 (include)
```

@ttuegel I am not yet familiar with multiple outputs, is this the right way to address this problem?
