### PR TITLE
kernel: 4.5.1 -> 4.5.2

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.5.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.5.1";
+  version = "4.5.2";
   extraMeta.branch = "4.5";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0q6qkp7w5hy1ai13zgvj2982kjk81rfzd8ff7ixp3slq8bmsz07i";
+    sha256 = "17r063zx880ka3ayv9cf1yjfilvxlifhja1rhw5z3w35hgdkj8z3";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
