### PR TITLE
oraclejdk: 8u77 -> 8u91, 8u92

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -119,12 +119,6 @@ let result = stdenv.mkDerivation rec {
       done
     fi
 
-    # construct the rpath
-    rpath=
-    for i in $libraries; do
-        rpath=$rpath''${rpath:+:}$i/lib:$i/lib64
-    done
-
     if test -z "$installjdk"; then
       jrePath=$out
     else
@@ -175,6 +169,8 @@ let result = stdenv.mkDerivation rec {
   libraries =
     [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf atk] ++
     (if swingSupport then [xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt xorg.libXrender stdenv.cc.cc] else []);
+
+  rpath = stdenv.lib.strings.makeLibraryPath libraries;
 
   passthru.mozillaPlugin = if installjdk then "/jre/lib/${architecture}/plugins" else "/lib/${architecture}/plugins";
 

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "77";
+  patchVersion = "91";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "14hyniai5l9qpg0pbnxa4rhyhk90qgihszfkn8h3vziqhmvrp27j";
-  sha256_x86_64 = "0hyzvvj4bf0r4jda8fv3k06d9bf37nji37qbq067mcjp5abc0zd4";
+  sha256_i686 = "0lndni81vfpz2l6zb8zsshaavk0483q5jc8yzj4fdjv6wnshbkay";
+  sha256_x86_64 = "0lkm3fz1vdi69f34sysavvh3abx603j1frc9hxvr08pwvmm536vg";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "77";
+  patchVersion = "92";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "14hyniai5l9qpg0pbnxa4rhyhk90qgihszfkn8h3vziqhmvrp27j";
-  sha256_x86_64 = "0hyzvvj4bf0r4jda8fv3k06d9bf37nji37qbq067mcjp5abc0zd4";
+  sha256_i686 = "095j2hh2xas05jajy4qdj9hxq3k460x4m12rcaxkaxw754imj0vj";
+  sha256_x86_64 = "11wrqd3qbkhimbw9n4g9i0635pjhhnijwxyid7lvjv26kdgg58vr";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

8u91 is Critical Patch Update (CPU), contains security vulnerability fixes.
8u92 is Patch Set Update (PSU), contains security vulnerability fixes and other bug fixes.

8u91 release notes: http://www.oracle.com/technetwork/java/javase/8u91-relnotes-2949462.html
8u92 release notes: http://www.oracle.com/technetwork/java/javase/8u92-relnotes-2949471.html

Both tested on x86_64.

This PR also contains fix for `closure-size` disaster.
