### PR TITLE
aucdtect: init at 0.8.2

### DIFF
--- a/pkgs/tools/audio/aucdtect/default.nix
+++ b/pkgs/tools/audio/aucdtect/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, lib, rpmextract }:
+
+assert stdenv.isLinux;
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "aucdtext-${version}";
+  version = "0.8-2";
+
+  src = fetchurl {
+    url = "http://www.true-audio.com/ftp/aucdtect-${version}.i586.rpm";
+    sha256 = "1lp5f0rq5b5n5il0c64m00gcfskarvgqslpryms9443d200y6mmd";
+  };
+
+  unpackCmd = "${rpmextract}/bin/rpmextract $src";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 local/bin/auCDtect $out/bin/aucdtect
+  '';
+
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    description = "Verify authenticity of lossless audio files";
+    homepage = http://tausoft.org;
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16599,6 +16599,8 @@ in
 
   mg = callPackage ../applications/editors/mg { };
 
+  aucdtect = callPackage ../tools/audio/aucdtect { };
+
   togglesg-download = callPackage ../tools/misc/togglesg-download { };
 
   discord = callPackage ../applications/networking/instant-messengers/discord { };


### PR DESCRIPTION
A binary distribution of the TA Analyzer that verifies if audio files are in fact lossless.
- Sources  are not available, but the binaries are released as "Freeware". As there are no free sources available, the user must `{ allowUnfree = true; }`.
- There is only a 32 bit version available, but it is statically linked and thus works on 64 bit.
- There is also a Windows binary available, but I have no machines to test that on, hence the `assert stdenv.isLinux;`
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
