### PR TITLE
skype: fix rpath broken by closure-size merge

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skype/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skype/default.nix
@@ -38,13 +38,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{libexec/skype/,bin}
     cp -r * $out/libexec/skype/
 
-    fullPath=
-    for i in $nativeBuildInputs; do
-      fullPath=$fullPath''${fullPath:+:}$i/lib
-    done
-
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "$fullPath" $out/libexec/skype/skype
+        --set-rpath "${lib.makeLibraryPath buildInputs}" $out/libexec/skype/skype
 
     cat > $out/bin/skype << EOF
     #!${stdenv.shell}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
