### PR TITLE
mpv: Set --confloaddir=/etc/mpv

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   ++ optional waylandSupport "--enable-wayland";
 
   configurePhase = ''
-    python ${waf} configure --prefix=$out $configureFlags
+    python ${waf} configure --prefix=$out --confloaddir=/etc/mpv $configureFlags
   '';
 
   nativeBuildInputs = [ docutils makeWrapper perl pkgconfig python which ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Make mpv look for the system default config files (mpv.conf and
input.conf) in /etc/mpv as opposed to its nix-store output dir, allowing for
comfortable overriding of these settings.
