### PR TITLE
WIP: nixos: mkEnableOption on steroids for discoverable `man configuration.nix`

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -15,6 +15,7 @@ rec {
     , defaultText ? null # Textual representation of the default, for in the manual.
     , example ? null # Example value used in the manual.
     , description ? null # String describing the option.
+    , packages ? [] # Related packages to be specified with `literalPackages*' functions
     , type ? null # Option type, providing type-checking and value merging.
     , apply ? null # Function that converts the option value to something else.
     , internal ? null # Whether the option is for NixOS developers only.
@@ -77,6 +78,16 @@ rec {
   getValues = map (x: x.value);
   getFiles = map (x: x.file);
 
+  # Generate DocBook documentation for a list of packages
+  packageListToDocString = packages:
+    let
+      describePkg = n: p:
+          "<listitem>"
+        + "<para><option>${n}</option> (${p.name}): ${p.meta.description or "???"}.</para>"
+        # Lots of `longDescription's break DocBook, so we just wrap them into <programlisting>
+        + optionalString (p.meta ? longDescription) "\n<programlisting>${p.meta.longDescription}</programlisting>"
+        + "</listitem>";
+    in "<itemizedlist>${concatStringsSep "\n" (map ({name, value}: describePkg name value) packages)}</itemizedlist>";
 
   # Generate documentation template from the list of option declaration like
   # the set generated with filterOptionSets.
@@ -87,16 +98,17 @@ rec {
       let
         docOption = rec {
           name = showOption opt.loc;
-          description = opt.description or (throw "Option `${name}' has no description.");
+          description = (opt.description or (throw "Option `${name}' has no description."))
+                      + optionalString (opt ? packages && opt.packages != []) "\n\n${packageListToDocString opt.packages}";
           declarations = filter (x: x != unknownModule) opt.declarations;
           internal = opt.internal or false;
           visible = opt.visible or true;
           readOnly = opt.readOnly or false;
           type = opt.type.name or null;
         }
-        // (if opt ? example then { example = scrubOptionValue opt.example; } else {})
-        // (if opt ? default then { default = scrubOptionValue opt.default; } else {})
-        // (if opt ? defaultText then { default = opt.defaultText; } else {});
+        // (optionalAttrs (opt ? example)     { example = scrubOptionValue opt.example; })
+        // (optionalAttrs (opt ? default)     { default = scrubOptionValue opt.default; })
+        // (optionalAttrs (opt ? defaultText) { default = opt.defaultText; });
 
         subOptions =
           let ss = opt.type.getSubOptions opt.loc;
@@ -124,6 +136,14 @@ rec {
      functions. */
   literalExample = text: { _type = "literalExample"; inherit text; };
 
+  /* For use in the ‘packages’ option attribute. */
+  literalPackage' = pkgs: n: p: nameValuePair "${optionalString (n != "") (n + ".")}${p}" (getAttrFromPath (splitString "." p) pkgs);
+
+  literalPackages' = pkgs: n: l: map (literalPackage' pkgs n) l;
+
+  literalPackage = pkgs: n: literalPackage' { inherit pkgs; } "" n;
+
+  literalPackages = pkgs: l: literalPackages' { inherit pkgs; } "" l;
 
   /* Helper functions. */
   showOption = concatStringsSep ".";

--- a/nixos/modules/hardware/ksm.nix
+++ b/nixos/modules/hardware/ksm.nix
@@ -1,7 +1,9 @@
 { config, lib, ... }:
 
 {
-  options.hardware.enableKSM = lib.mkEnableOption "Kernel Same-Page Merging";
+  options.hardware.enableKSM = lib.mkEnableOption' {
+    name = "Kernel Same-Page Merging";
+  };
 
   config = lib.mkIf config.hardware.enableKSM {
     systemd.services.enable-ksm = {

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -12,7 +12,10 @@ in
 
 {
 
-  options.hardware.facetimehd.enable = mkEnableOption "facetimehd kernel module";
+  options.hardware.facetimehd.enable = mkEnableOption' {
+    name = "facetimehd kernel module";
+    package = literalPackage' kernelPackages "kernelPackages" "facetimehd";
+  };
 
   config = mkIf cfg.enable {
 

--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -14,6 +14,11 @@ in
 
     programs.atop = {
 
+      enable = mkWheneverToPkgOption {
+        what = "globally configure atop";
+        package = literalPackage pkgs "pkgs.atop";
+      };
+
       settings = mkOption {
         type = types.attrs;
         default = {};
@@ -29,7 +34,7 @@ in
     };
   };
 
-  config = mkIf (cfg.settings != {}) {
+  config = mkIf cfg.enable {
     environment.etc."atoprc".text =
       concatStrings (mapAttrsToList (n: v: "${n} ${toString v}\n") cfg.settings);
   };

--- a/nixos/modules/programs/blcr.nix
+++ b/nixos/modules/programs/blcr.nix
@@ -1,19 +1,19 @@
 { config, lib, ... }:
 
+with lib;
+
 let
-  inherit (lib) mkOption mkIf;
   cfg = config.environment.blcr;
-  blcrPkg = config.boot.kernelPackages.blcr;
+  kp = config.boot.kernelPackages;
 in
 
 {
   ###### interface
 
   options = {
-    environment.blcr.enable = mkOption {
-      default = false;
-      description =
-        "Whether to enable support for the BLCR checkpointing tool.";
+    environment.blcr.enable = mkEnableOption' {
+      name = "support for the BLCR checkpointing tool";
+      #asserts #package = literalPackage' kp "kernelPackages" "blcr";
     };
   };
 
@@ -21,7 +21,7 @@ in
 
   config = mkIf cfg.enable {
     boot.kernelModules = [ "blcr" "blcr_imports" ];
-    boot.extraModulePackages = [ blcrPkg ];
-    environment.systemPackages = [ blcrPkg ];
+    boot.extraModulePackages = [ kp.blcr ];
+    environment.systemPackages = [ kp.blcr ];
   };
 }

--- a/nixos/modules/programs/cdemu.nix
+++ b/nixos/modules/programs/cdemu.nix
@@ -7,13 +7,12 @@ in {
 
   options = {
     programs.cdemu = {
-      enable = mkOption {
-        default = false;
-        description = ''
-          <command>cdemu</command> for members of
-          <option>programs.cdemu.group</option>.
-        '';
+
+      enable = mkWheneverToPkgOption {
+        what = "globally configure cdemu";
+        package = literalPackage pkgs "pkgs.cdemu-daemon";
       };
+
       group = mkOption {
         default = "cdrom";
         description = ''

--- a/nixos/modules/programs/kbdlight.nix
+++ b/nixos/modules/programs/kbdlight.nix
@@ -7,7 +7,10 @@ let
 
 in
 {
-  options.programs.kbdlight.enable = mkEnableOption "kbdlight";
+  options.programs.kbdlight.enable = mkEnableOption' {
+    name = "kbdlight";
+    package = literalPackage pkgs "pkgs.kbdlight";
+  };
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.kbdlight ];

--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -1,7 +1,8 @@
 { config, pkgs, lib, ... }:
 
+with lib;
+
 let
-  inherit (lib) mkOption mkEnableOption mkIf mkMerge types;
 
   cfg = config.programs.tmux;
 
@@ -12,7 +13,10 @@ in
   options = {
     programs.tmux = {
 
-      enable = mkEnableOption "<command>tmux</command> - a <command>screen</command> replacement.";
+      enable = mkWheneverToPkgOption {
+        what = "globally configure tmux";
+        package = literalPackage pkgs "pkgs.tmux";
+      };
 
       tmuxconf = mkOption {
         default = "";

--- a/nixos/modules/services/audio/icecast.nix
+++ b/nixos/modules/services/audio/icecast.nix
@@ -44,7 +44,10 @@ in {
 
     services.icecast = {
 
-      enable = mkEnableOption "Icecast server";
+      enable = mkEnableOption' {
+        name = "Icecast server";
+        package = literalPackage pkgs "pkgs.icecast";
+      };
 
       hostname = mkOption {
         type = types.str;

--- a/nixos/modules/services/backup/rsnapshot.nix
+++ b/nixos/modules/services/backup/rsnapshot.nix
@@ -7,7 +7,11 @@ in
 {
   options = {
     services.rsnapshot = {
-      enable = mkEnableOption "rsnapshot backups";
+
+      enable = mkWheneverToPkgOption {
+        what = "enable backups with rsnapshot";
+        package = literalPackage pkgs "pkgs.rsnapshot";
+      };
 
       extraConfig = mkOption {
         default = "";

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -8,7 +8,12 @@ in
 {
   options = {
     services.znapzend = {
-      enable = mkEnableOption "ZnapZend daemon";
+
+      enable = mkWheneverToPkgOption {
+        what = "enable backups with ZsnapZend";
+        package = literalPackage pkgs "pkgs.znapzend";
+      };
+
     };
   };
 

--- a/nixos/modules/services/databases/riak.nix
+++ b/nixos/modules/services/databases/riak.nix
@@ -16,7 +16,11 @@ in
 
     services.riak = {
 
-      enable = mkEnableOption "riak";
+      enable = mkEnableOption' {
+        name = "riak";
+        broken = true;
+        package = literalPackage pkgs "pkgs.riak";
+      };
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/hardware/irqbalance.nix
+++ b/nixos/modules/services/hardware/irqbalance.nix
@@ -9,7 +9,10 @@ let
 
 in
 {
-  options.services.irqbalance.enable = mkEnableOption "irqbalance daemon";
+  options.services.irqbalance.enable = mkEnableOption' {
+    name = "irqbalance daemon";
+    package = literalPackage pkgs "pkgs.irqbalance";
+  };
 
   config = mkIf cfg.enable {
 

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -70,7 +70,10 @@ in
 {
 
   options.services.dovecot2 = {
-    enable = mkEnableOption "Dovecot 2.x POP3/IMAP server";
+    enable = mkEnableOption' {
+      name = "Dovecot POP3/IMAP server";
+      package = literalPackage pkgs "pkgs.dovecot";
+    };
 
     enablePop3 = mkOption {
       type = types.bool;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -191,10 +191,9 @@ in
 
     services.postfix = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to run the Postfix mail server.";
+      enable = mkEnableOption' {
+        name = "Postfix mail server";
+        package = literalPackage pkgs "pkgs.postfix";
       };
 
       enableSmtp = mkOption {

--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -16,7 +16,10 @@ in
 
     services.calibre-server = {
 
-      enable = mkEnableOption "calibre-server";
+      enable = mkEnableOption' {
+        name = "calibre-server";
+        package = literalPackage pkgs "pkgs.calibre";
+      };
 
       libraryDir = mkOption {
         description = ''

--- a/nixos/modules/services/misc/confd.nix
+++ b/nixos/modules/services/misc/confd.nix
@@ -17,7 +17,10 @@ let
 
 in {
   options.services.confd = {
-    enable = mkEnableOption "confd service";
+    enable = mkEnableOption' {
+      name = "confd service";
+      package = literalPackage pkgs "pkgs.confd";
+    };
 
     backend = mkOption {
       description = "Confd config storage backend to use.";

--- a/nixos/modules/services/misc/gammu-smsd.nix
+++ b/nixos/modules/services/misc/gammu-smsd.nix
@@ -53,7 +53,10 @@ in {
   options = {
     services.gammu-smsd = {
 
-      enable = mkEnableOption "gammu-smsd daemon";
+      enable = mkEnableOption' {
+        name = "gammu-smsd daemon";
+        package = literalPackage pkgs "pkgs.gammu";
+      };
 
       user = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -57,7 +57,11 @@ ${cfg.extraConfig}
 in {
   options = {
     services.matrix-synapse = {
-      enable = mkEnableOption "matrix.org synapse";
+      enable = mkEnableOption' {
+        name = "matrix.org synapse";
+        package = literalPackage pkgs "pkgs.matrix-synapse";
+      };
+
       package = mkOption {
         type = types.package;
         default = pkgs.matrix-synapse;

--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -9,7 +9,10 @@ in
 {
   options = {
     services.plex = {
-      enable = mkEnableOption "Plex Media Server";
+      enable = mkEnableOption' {
+        name = "Plex Media Server";
+        #unfree #package = literalPackage pkgs "pkgs.plex";
+      };
 
       # FIXME: In order for this config option to work, symlinks in the Plex
       # package in the Nix store have to be changed to point to this directory.

--- a/nixos/modules/services/misc/ripple-data-api.nix
+++ b/nixos/modules/services/misc/ripple-data-api.nix
@@ -35,7 +35,11 @@ let
 in {
   options = {
     services.rippleDataApi = {
-      enable = mkEnableOption "ripple data api";
+      enable = mkEnableOption' {
+        name = "ripple data api";
+        broken = true; # does not exists
+        package = literalPackage pkgs "pkgs.ripple-data-api";
+      };
 
       port = mkOption {
         description = "Ripple data api port";

--- a/nixos/modules/services/misc/rippled.nix
+++ b/nixos/modules/services/misc/rippled.nix
@@ -202,7 +202,10 @@ in
 
   options = {
     services.rippled = {
-      enable = mkEnableOption "rippled";
+      enable = mkEnableOption' {
+        name = "rippled";
+        #unfree #package = literalPackage pkgs "pkgs.rippled";
+      };
 
       package = mkOption {
 	description = "Which rippled package to use.";
@@ -374,7 +377,10 @@ in
       };
 
       statsd = {
-        enable = mkEnableOption "statsd monitoring for rippled";
+        enable = mkEnableOption' {
+          name = "statsd monitoring for rippled";
+          #unfree #package = literalPackage pkgs "pkgs.rippled";
+        };
 
         address = mkOption {
           description = "The UDP address and port of the listening StatsD server.";

--- a/nixos/modules/services/monitoring/uptime.nix
+++ b/nixos/modules/services/monitoring/uptime.nix
@@ -1,7 +1,8 @@
 { config, pkgs, lib, ... }:
-let
-  inherit (lib) mkOption mkEnableOption mkIf mkMerge types optionalAttrs optional;
 
+with lib;
+
+let
   cfg = config.services.uptime;
 
   configDir = pkgs.runCommand "config" {} (if cfg.configFile != null then ''
@@ -49,9 +50,15 @@ in {
       type = types.bool;
     };
 
-    enableWebService = mkEnableOption "the uptime monitoring program web service";
+    enableWebService = mkEnableOption' {
+      name = "the uptime monitoring program web service";
+      package = literalPackage pkgs "pkgs.nodePackages.node-uptime";
+    };
 
-    enableSeparateMonitoringService = mkEnableOption "the uptime monitoring service" // { default = cfg.enableWebService; };
+    enableSeparateMonitoringService = mkEnableOption' {
+      name = "the uptime monitoring service";
+      default = cfg.enableWebService;
+    };
 
     nodeEnv = mkOption {
       description = "The node environment to run in (development, production, etc.)";

--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -330,7 +330,10 @@ in
   # options are ordered alphanumerically
   options.services.nsd = {
 
-    enable = mkEnableOption "NSD authoritative DNS server";
+    enable = mkEnableOption' {
+      name = "NSD authoritative DNS server";
+      package = literalPackage pkgs "pkgs.nsd";
+    };
 
     bind8Stats = mkEnableOption "BIND8 like statistics";
 

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -23,7 +23,10 @@ let
 in {
   options = {
     networking.wireless = {
-      enable = mkEnableOption "wpa_supplicant";
+      enable = mkEnableOption' {
+        name = "wpa_supplicant";
+        package = literalPackage pkgs "pkgs.wpa_supplicant";
+      };
 
       interfaces = mkOption {
         type = types.listOf types.str;


### PR DESCRIPTION
This is a WIP on #9306. I wanted to implement this for a while now, and now it even kinda works, and generates pretty awesome man page if I may say so myself.

How to test this:
- Merge with your local branch.
- Do
  
  ```
  nix-build ./nixpkgs/nixos/release.nix -A manpages
  ```
  
  (you might need to set your `NIX_PATH`)
- Run `man result/share/man/man5/configuration.nix.5`.
- Lo and behold.
- Search, e.g. `/tmux`.
- Lo and behold again.

![screenshot](http://i.imgur.com/VrAxxsI.png)

Current problems:
- Needs a ton of refactoring in `nixos/modules`, I rewrote a bunch of pieces just for testing purposes, but `grep` shows that there's a lot of work there. Hopefully (but not likely), I will work that out till the end of this week.
- Ideally, this code needs to access `meta`s of all the packages, but broken derivations, derivations with unfree licenses, and derivations with assertions evaluate to exceptions. That's even more crazy: they fail differently:
  - Broken and unfree packages fail on `p.meta` access (in `stdenv.mkDerivation`).
  - Packages with assertions fail on `callPackage`, that is, access to `p`, that is, even before `mkDerivation`. Which makes sense, but that's too strict for both pretty and complete solution I had in mind.
  
  For now I just commented unfree (because I didn't want to mark them as "broken") and assert-failing packages out.
  
  The former case can probably be fixed by some kind of `stdenv` hack that pushes `meta` out as early as possible.
  The latter needs `nix` support for catching exceptions (and assertions) or a new style of derivation definitions a-la "nixos modules with assertions".
  If this got to be implemented somehow I would totally start generating and then searching a separate man page with descriptions of all the available packages instead of `nix-env -q`.
- As it turns out, quite a lot of nixos modules are nonfunctional simply because they refer to nonexistent packages. Rewriting them using this mechanisms highlights all of those previously invisible problems (which is good, but annoying).
- Names of the new functions are ugly, better ideas are very much welcome.

Questionable design decisions:
- The very first patch in the sequence. I think it's awesome, but your OCD towards lexicographical ordering might vary.
- `packages` in `mkOption`. At first I did a separate `mkOption`-variant for this, but then all the functions using it got really ugly. So I decided that emulating TeX bibliography is okay (the idea is that the last paragraph in the description says "what are those packages listed here for").
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
