### PR TITLE
google-cloud-sdk: 0.9.82 -> 106.0.0

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, python27, python27Packages, makeWrapper}:
 
 stdenv.mkDerivation rec {
-  version = "0.9.82";
+  version = "106.0.0";
   name = "google-cloud-sdk-${version}";
 
   src = fetchurl {
-    url = "https://dl.google.com/dl/cloudsdk/release/packages/google-cloud-sdk-coretools-linux-static-20151008123015.tar.gz";
-    sha256 = "11gnhgjj4y4dzi3wfdpnz918m7xraz1k3ady1d6y446hmc5q2512";
+    url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-106.0.0-linux-x86_64.tar.gz";
+    sha256 = "00jhpx32sfxcgl404plmb8122bs0ijl2rv25h17mnjn067nhz7nn";
   };
 
   buildInputs = [python27 makeWrapper];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
