### PR TITLE
ag: init at 0.31.0

### DIFF
--- a/pkgs/tools/text/ag/default.nix
+++ b/pkgs/tools/text/ag/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, autoconf, automake, pkgconfig, pcre, xz }:
+
+stdenv.mkDerivation rec {
+  name = "ag-0.31.0";
+
+  src = fetchurl {
+    url = "https://github.com/ggreer/the_silver_searcher/archive/0.31.0.tar.gz";
+    sha256 = "1a3xncsq3x8pci194k484s5mdqij2sirpz6dj6711n2p8mzq5g31";
+  };
+
+  buildInputs = [ autoconf automake pkgconfig pcre xz ];
+
+  buildPhase = "./build.sh --prefix $out";
+
+  meta = with stdenv.lib; {
+    homepage = "http://geoff.greer.fm/ag";
+    description = "A code-searching tool similar to ack, but faster";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -369,6 +369,8 @@ in
 
   afl = callPackage ../tools/security/afl { };
 
+  ag = callPackage ../tools/text/ag { };
+
   aha = callPackage ../tools/text/aha { };
 
   ahcpd = callPackage ../tools/networking/ahcpd { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm used to `ack`/`ag` for searching in code, as they're easier to use than `grep`. NixOS currently has neither, so here's `ag` (which is faster of the two).

I couldn't figure out how to `nix-build --option build-use-chroot true` after already building once [the way described in the manual](https://nixos.org/nixpkgs/manual/#chap-quick-start), so unfortunately I didn't test that.
