### PR TITLE
factorio: add explict dependency on cacert for chroot build

### DIFF
--- a/pkgs/games/factorio/fetch.nix
+++ b/pkgs/games/factorio/fetch.nix
@@ -1,4 +1,4 @@
-{ stdenv, curl
+{ stdenv, curl, cacert
 # Begin download parameters
 , username ? ""
 , password ? ""
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ curl ];
 
-  inherit url loginUrl username password;
+  inherit url loginUrl username password cacert;
 
   builder = ./fetch.sh;
 

--- a/pkgs/games/factorio/fetch.sh
+++ b/pkgs/games/factorio/fetch.sh
@@ -8,7 +8,7 @@ source $stdenv/setup
 curl="curl \
  --max-redirs 20 \
  --retry 3 \
- --cacert /etc/ssl/certs/ca-bundle.crt \
+ --cacert $cacert/etc/ssl/certs/ca-bundle.crt \
  $curlOpts \
  $NIX_CURL_FLAGS"
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
