### PR TITLE
Rust Updates

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -294,6 +294,7 @@
   refnil = "Martin Lavoie <broemartino@gmail.com>";
   relrod = "Ricky Elrod <ricky@elrod.me>";
   renzo = "Renzo Carbonara <renzocarbonara@gmail.com>";
+  retrry = "Tadas Barzdžius <retrry@gmail.com>";
   rick68 = "Wei-Ming Yang <rick68@gmail.com>";
   rickynils = "Rickard Nilsson <rickynils@gmail.com>";
   rnhmjoj = "Michele Guerini Rocco <micheleguerinirocco@me.com>";

--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchdarcs, rustUnstable, openssl, libssh }:
+{ stdenv, fetchdarcs, rustPlatform, openssl, libssh }:
 
-with rustUnstable;
+with rustPlatform;
 
 buildRustPackage rec {
   name = "pijul-${version}";

--- a/pkgs/development/compilers/rustc/default.nix
+++ b/pkgs/development/compilers/rustc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, callPackage }:
 
 callPackage ./generic.nix {
-  shortVersion = "1.7.0";
+  shortVersion = "1.8.0";
   isRelease = true;
   forceBundledLLVM = false;
   configureFlags = [ "--release-channel=stable" ];
-  srcSha = "05f4v6sfmvkwsv6a7jp9sxsm84s0gdvqyf2wwdi1ilg9k8nxzgd4";
+  srcSha = "1s03aymmhhrndq29sv9cs8s4p1sg8qvq8ds6lyp6s4ny8nyvdpzy";
 
   /* Rust is bootstrapped from an earlier built version. We need
   to fetch these earlier versions, which vary per platform.
@@ -15,12 +15,12 @@ callPackage ./generic.nix {
   for the tagged release and not a snapshot in the current HEAD.
   */
 
-  snapshotHashLinux686 = "a09c4a4036151d0cb28e265101669731600e01f2";
-  snapshotHashLinux64 = "97e2a5eb8904962df8596e95d6e5d9b574d73bf4";
-  snapshotHashDarwin686 = "ca52d2d3ba6497ed007705ee3401cf7efc136ca1";
-  snapshotHashDarwin64 = "3c44ffa18f89567c2b81f8d695e711c86d81ffc7";
-  snapshotDate = "2015-12-18";
-  snapshotRev = "3391630";
+  snapshotHashLinux686 = "5f194aa7628c0703f0fd48adc4ec7f3cc64b98c7";
+  snapshotHashLinux64 = "d29b7607d13d64078b6324aec82926fb493f59ba";
+  snapshotHashDarwin686 = "4c8e42dd649e247f3576bf9dfa273327b4907f9c";
+  snapshotHashDarwin64 = "411a41363f922d1d93fa62ff2fedf5c35e9cccb2";
+  snapshotDate = "2016-02-17";
+  snapshotRev = "4d3eebf";
 
   patches = [ ./patches/remove-uneeded-git.patch ]
     ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;

--- a/pkgs/development/compilers/rustc/generic.nix
+++ b/pkgs/development/compilers/rustc/generic.nix
@@ -62,7 +62,7 @@ let version = if isRelease then
     meta = with stdenv.lib; {
       homepage = http://www.rust-lang.org/;
       description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington ];
+      maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
       license = [ licenses.mit licenses.asl20 ];
       platforms = platforms.linux ++ platforms.darwin;
     };
@@ -164,7 +164,8 @@ with stdenv.lib; stdenv.mkDerivation {
   buildInputs = [ ncurses ]
     ++ optional (!forceBundledLLVM) llvmShared;
 
-  enableParallelBuilding = false; # missing files during linking, occasionally
+  # https://github.com/rust-lang/rust/issues/30181
+  # enableParallelBuilding = false; # missing files during linking, occasionally
 
   outputs = [ "out" "doc" ];
   setOutputFlags = false;

--- a/pkgs/development/tools/build-managers/cargo/common.nix
+++ b/pkgs/development/tools/build-managers/cargo/common.nix
@@ -31,8 +31,8 @@
   meta = with stdenv.lib; {
     homepage = http://crates.io;
     description = "Downloads your Rust project's dependencies and builds your project";
-    maintainers = with maintainers; [ wizeman ];
+    maintainers = with maintainers; [ wizeman retrry ];
     license = [ licenses.mit licenses.asl20 ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/tools/build-managers/cargo/default.nix
+++ b/pkgs/development/tools/build-managers/cargo/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchgit, rustPlatform, file, curl, python, pkgconfig, openssl
+{ stdenv, cacert, fetchgit, rustPlatform, file, curl, python, pkgconfig, openssl
 , cmake, zlib, makeWrapper }:
 
 with rustPlatform;
 
 with ((import ./common.nix) {
   inherit stdenv rustc;
-  version = "0.8.0";
+  version = "0.9.0";
 });
 
 buildRustPackage rec {
@@ -15,10 +15,10 @@ buildRustPackage rec {
   src = fetchgit {
     url = "git://github.com/rust-lang/cargo";
     rev = "refs/tags/${version}";
-    sha256 = "02z0b6hpygjjfbskg22ggrhdv2nasrgf8x1fd8y0qzg4krx2czlh";
+    sha256 = "0d3n2jdhaz06yhilvmw3m2avxv501da1hdhljc9mwkz3l5bkv2jv";
   };
 
-  depsSha256 = "1gwc5ygs3h8jxs506xmbj1xzaqpb3kmg3pkxg9j9yqy616jw6rcn";
+  depsSha256 = "1x2m7ww2z8nl5ic2nds85p7ma8x0zp654jg7ay905ia95daiabzg";
 
   buildInputs = [ file curl pkgconfig python openssl cmake zlib makeWrapper ];
 
@@ -28,8 +28,15 @@ buildRustPackage rec {
 
   buildPhase = "make";
 
-  # Disable check phase as there are lots of failures (some probably due to
-  # trying to access the network).
+  checkPhase = ''
+    # Export SSL_CERT_FILE as without it one test fails with SSL verification error
+    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+    # Disable cross compilation tests
+    export CFG_DISABLE_CROSS_TESTS=1
+    cargo test
+  '';
+
+  # Disable check phase as there are failures (author_prefers_cargo test fails)
   doCheck = false;
 
   installPhase = ''

--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "2016-03-22";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustfmt";
-    rev = "ca757183fedf8e89286372b91ca074c11d99c4f4";
-    sha256 = "0ngg5m002hwwmsqy9wr50dj3l3zgwk39701wzszm3nrhz6x13dmj";
+    rev = "19768da5c97c108a05e6f545b73ba4b76d1b1788";
+    sha256 = "0f2m0gvlqlybcjl2xqwxlp5hjkhd30kx25dq56k5x0r3808ijksg";
   };
 
-  depsSha256 = "0mg4z197iiwjlgqs5izacld25cr11qi3bcrqq204f0jzrnj3y8ag";
+  depsSha256 = "1lbcpvp7xhyl96w7jfd18w6py60nwllr93jna5j33zvnip61cpf5";
 
   meta = with stdenv.lib; {
     description = "A tool for formatting Rust code according to style guidelines";

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -4,15 +4,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "exa-${version}";
-  version = "2016-04-11";
+  version = "2016-04-20";
 
   depsSha256 = "1rpynsni2r3gim10xc1qkj51wpbzafwsr99y61zh41v4vh047g1k";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = "exa";
-    rev = "9b87ef1da2231acef985bb08f7bd4a557167b652";
-    sha256 = "1f71bqkpc6bf9jg1zxy21rzbyhzghwfmgbyyyb81ggxcri0kajwi";
+    rev = "110a1c716bfc4a7f74f74b3c4f0a881c773fcd06";
+    sha256 = "136yxi85m50vwmqinr1wnd0h29n5yjykqqqk9ibbcmmhx8sqhjzf";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -4,17 +4,17 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "heatseeker-${version}";
-  version = "1.3.0";
+  version = "1.4.0";
 
-  depsSha256 = "03jap7myf85xgx9270sws8x57nl04a1wx8szrk9qx24s9vnnjcnh";
+  depsSha256 = "1acimdkl6ra9jlyiydzzd6ccdygr5is2xf9gw8i45xzh0xnsq226";
 
   src = fetchFromGitHub {
     owner = "rschmitt";
     repo = "heatseeker";
     rev = "v${version}";
-    sha256 = "1xdvwgmh9lwv82hv1qg82bjv2iplnvva6lzbg7dyhbszhv7rhkbl";
+    sha256 = "1v2p6l4bdmvn9jggb12p0j5ajjvnbcdjsiavlcqiijz2w8wcdgs8";
   };
-  
+
   # some tests require a tty, this variable turns them off for Travis CI,
   # which we can also make use of
   TRAVIS= "true";


### PR DESCRIPTION
###### Various Rust and Cargo updates.

rustc updated to 1.8.0
cargo updated to 0.9.0 (we can't update to 0.10.0, as it breaks our buildRustPackage function https://github.com/NixOS/nixpkgs/issues/11144#issuecomment-212079455) and enabled Darwin compatibility.
rustfmt updated to 0.4.0
heatseeker updated to 1.4.0
exa updated to 2016-04-20 to fix compilation with rustc 1.8.0
pijul now using stable rustPlatform
Added myself as maintainer for rustc and cargo.

Should fix: https://github.com/NixOS/nixpkgs/issues/10864

@vcunat I enabled parallel building for rustc, which you disabled here: https://github.com/NixOS/nixpkgs/commit/d7e87db0c7f8d0ed759261cdfbdd2c71a7933bf0. If those errors return - we could disable it again, but it builds okay on my NixOS and Darwin machines.

Rust head fails test suite on Mac OS X due net errors. I will investigate this later as rust stable compiles and runs okay.
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
