### PR TITLE
CD/DVD writing improvements

### DIFF
--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -26,10 +26,11 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://sourceforge.net/projects/cdrtools/;
     description = "Highly portable CD/DVD/BluRay command line recording software";
-    # Licensing issues: This package contains code licensed under CDDL, GPL2
-    # and LGPL2. There is debate regarding the legality of this licensing.
-    # Marked as unfree to avoid any possible legal issues.
-    license = licenses.unfree;
+    license = with licenses; [ gpl2 lgpl2 cddl ];
     platforms = platforms.linux;
+    # Licensing issues: This package contains code licensed under CDDL, GPL2
+    # and LGPL2. There is a debate regarding the legality of distributing this
+    # package in binary form.
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/applications/misc/k3b/default.nix
+++ b/pkgs/applications/misc/k3b/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, makeWrapper, automoc4, cmake, perl, pkgconfig
 , shared_mime_info, libvorbis, taglib, flac, libsamplerate
 , libdvdread, lame, libsndfile, libmad, gettext , transcode, cdrdao
-, cdrtools, dvdplusrwtools, vcdimager, cdparanoia, kdelibs, libdvdcss, ffmpeg
+, dvdplusrwtools, vcdimager, cdparanoia, kdelibs, libdvdcss, ffmpeg
 , kdemultimedia, phonon, libkcddb ? null
 }:
 
@@ -9,10 +9,11 @@ let
   # at runtime, k3b needs the executables cdrdao, cdrecord, dvd+rw-format,
   # eMovix, growisofs, mkisofs, normalize, readcd, transcode, vcdxbuild,
   # vcdxminfo, and vcdxrip
-  binPath = lib.makeBinPath [ cdrdao dvdplusrwtools transcode vcdimager cdrtools ];
+  binPath = lib.makeBinPath [ cdrdao dvdplusrwtools transcode vcdimager ];
 
 in stdenv.mkDerivation rec {
-  name = "k3b-2.0.3a";
+  name = "k3b-${version}";
+  version = "2.0.3a";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/k3b/${name}.tar.xz";

--- a/pkgs/applications/misc/k3b/wrapper.nix
+++ b/pkgs/applications/misc/k3b/wrapper.nix
@@ -1,0 +1,23 @@
+{ lib, buildEnv, k3b-original, cdrtools, makeWrapper }:
+
+let
+  binPath = lib.makeBinPath [ cdrtools ];
+in buildEnv {
+  name = "k3b-${k3b-original.version}";
+
+  paths = [ k3b-original ];
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    # TODO: This could be avoided if buildEnv could be forced to create all directories
+    if [ -L $out/bin ]; then
+      rm $out/bin
+      mkdir $out/bin
+      for i in ${k3b-original}/bin/*; do
+        ln -s $i $out/bin
+      done
+    fi
+    wrapProgram $out/bin/k3b \
+      --prefix PATH ':' ${binPath}
+  '';
+}

--- a/pkgs/development/libraries/libburn/default.nix
+++ b/pkgs/development/libraries/libburn/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libburn-${version}";
+  version = "1.4.2.pl01";
+
+  src = fetchurl {
+    url = "http://files.libburnia-project.org/releases/${name}.tar.gz";
+    sha256 = "1nqfm24dm2csdnhsmpgw9cwcnkwvqlvfzsm9bhr6yg7bbmzwvkrk";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://libburnia-project.org/;
+    description = "A library by which preformatted data get onto optical media: CD, DVD, BD (Blu-Ray)";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/libisofs/default.nix
+++ b/pkgs/development/libraries/libisofs/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, acl, attr, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "libisofs-${version}";
+  version = "1.4.2";
+
+  src = fetchurl {
+    url = "http://files.libburnia-project.org/releases/${name}.tar.gz";
+    sha256 = "1axk1ykv8ibrlrd2f3allidviimi4ya6k7wpvr6r4y1sc7mg7rym";
+  };
+
+  buildInputs = [ attr zlib ];
+  propagatedBuildInputs = [ acl ];
+
+  meta = with stdenv.lib; {
+    homepage = http://libburnia-project.org/;
+    description = "A library to create an ISO-9660 filesystem with extensions like RockRidge or Joliet";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, fetchurl, pkgconfig, gtk3, itstool, gst_all_1, libxml2, libnotify
-, libcanberra_gtk3, intltool, makeWrapper, dvdauthor, cdrdao
-, dvdplusrwtools, cdrtools, vcdimager, wrapGAppsHook }:
+, libcanberra_gtk3, intltool, makeWrapper, dvdauthor, libburn, libisofs
+, vcdimager, wrapGAppsHook }:
 
 # libdvdcss is "too old" (in fast "too new"), see https://bugs.launchpad.net/ubuntu/+source/brasero/+bug/611590
 
 let
   major = "3.12";
   minor = "1";
-  binpath = lib.makeBinPath [ dvdauthor cdrdao dvdplusrwtools vcdimager cdrtools ];
+  binpath = lib.makeBinPath [ dvdauthor vcdimager ];
 
 in stdenv.mkDerivation rec {
   version = "${major}.${minor}";
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook ];
 
-  buildInputs = [ gtk3 libxml2 libnotify libcanberra_gtk3
+  buildInputs = [ gtk3 libxml2 libnotify libcanberra_gtk3 libburn libisofs
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base
                   gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
                   gst_all_1.gst-plugins-ugly gst_all_1.gst-libav ];

--- a/pkgs/tools/cd-dvd/brasero/wrapper.nix
+++ b/pkgs/tools/cd-dvd/brasero/wrapper.nix
@@ -1,0 +1,23 @@
+{ lib, buildEnv, brasero-original, cdrtools, makeWrapper }:
+
+let
+  binPath = lib.makeBinPath [ cdrtools ];
+in buildEnv {
+  name = "brasero-${brasero-original.version}";
+
+  paths = [ brasero-original ];
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    # TODO: This could be avoided if buildEnv could be forced to create all directories
+    if [ -L $out/bin ]; then
+      rm $out/bin
+      mkdir $out/bin
+      for i in ${brasero-original}/bin/*; do
+        ln -s $i $out/bin
+      done
+    fi
+    wrapProgram $out/bin/brasero \
+      --prefix PATH ':' ${binPath}
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7338,6 +7338,8 @@ in
 
   libbson = callPackage ../development/libraries/libbson { };
 
+  libburn = callPackage ../development/libraries/libburn { };
+
   libcaca = callPackage ../development/libraries/libcaca { };
 
   libcanberra = callPackage ../development/libraries/libcanberra { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15292,9 +15292,9 @@ in
 
           eventlist = callPackage ../applications/office/eventlist {};
 
-          k3b = callPackage ../applications/misc/k3b {
-            cdrtools = cdrkit;
-          };
+          k3b-original = lowPrio (callPackage ../applications/misc/k3b { });
+
+          k3b = callPackage ../applications/misc/k3b/wrapper.nix { };
 
           kadu = callPackage ../applications/networking/instant-messengers/kadu { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -609,7 +609,9 @@ in
 
   boxfs = callPackage ../tools/filesystems/boxfs { };
 
-  brasero = callPackage ../tools/cd-dvd/brasero { };
+  brasero-original = lowPrio (callPackage ../tools/cd-dvd/brasero { });
+
+  brasero = callPackage ../tools/cd-dvd/brasero/wrapper.nix { };
 
   brltty = callPackage ../tools/misc/brltty {
     alsaSupport = (!stdenv.isDarwin);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7735,6 +7735,8 @@ in
     graphviz = graphviz-nox;
   };
 
+  libisofs = callPackage ../development/libraries/libisofs { };
+
   libiptcdata = callPackage ../development/libraries/libiptcdata { };
 
   libjpeg_original = callPackage ../development/libraries/libjpeg { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Right now we have several packages depend on cdrtools and others depend on cdrkit. Both have their advantages and disadvantages: cdrtools are newer and maintained but have [possible licensing problems](https://en.wikipedia.org/wiki/Cdrtools#License_compatibility_controversy), so they and all packages using them are not built on Hydra. Meanwhile cdrkit is not maintained for 5 years but free fork of cdrtools -- it can be freely built but has bugs and problems that are not fixed.

Because all software using them have support for both packages and search for them in `PATH` I propose to defer choice to the user instead. This way Brasero and dvd-slideshow are built on Hydra and K3B doesn't force to use cdrkit. Notice that this is a breaking change: user is expected to add either cdrtools or cdrkit to his `environmentPackages`. I've noted that in the release notes.
