### PR TITLE
tinc-haskell: init at 20160419

### DIFF
--- a/pkgs/development/tools/misc/tinc/default.nix
+++ b/pkgs/development/tools/misc/tinc/default.nix
@@ -1,0 +1,41 @@
+{ mkDerivation, aeson, base, bytestring, Cabal, containers
+, directory, exceptions, filelock, filepath, gitrev, graph-wrapper
+, hpack, hspec, HUnit, language-dot, mockery, parsec, process
+, QuickCheck, safe, stdenv, temporary, time, transformers, unix
+, unix-compat, with-location, yaml, fetchFromGitHub
+, ghc, cabal2nix, cabal-install, makeWrapper
+}:
+mkDerivation {
+  pname = "tinc";
+  version = "20160419";
+  src = fetchFromGitHub {
+    owner = "sol";
+    repo = "tinc";
+    rev = "b9f7cc1076098b1f99f20655052c9fd34598d891";
+    sha256 = "1f0k7a4vxdd2cd2h5qwska9hfw7ig6q2rx87d09fg2xlix96g81r";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson base bytestring Cabal containers directory exceptions
+    filelock filepath gitrev graph-wrapper hpack language-dot parsec
+    process temporary time transformers unix-compat with-location yaml
+  ];
+  testHaskellDepends = [
+    aeson base bytestring Cabal containers directory exceptions
+    filelock filepath gitrev graph-wrapper hpack hspec HUnit
+    language-dot mockery parsec process QuickCheck safe temporary time
+    transformers unix unix-compat with-location yaml
+  ];
+  postInstall = ''
+    source ${makeWrapper}/nix-support/setup-hook
+    wrapProgram $out/bin/tinc \
+      --prefix PATH : '${ghc}/bin' \
+      --prefix PATH : '${cabal2nix}/bin' \
+      --prefix PATH : '${cabal-install}/bin'
+  '';
+  description = "A dependency manager for Haskell";
+  homepage = "https://github.com/sol/tinc#readme";
+  license = stdenv.lib.licenses.mit;
+  maintainers = [ stdenv.lib.maintainers.robbinch ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6302,6 +6302,8 @@ in
 
   texi2html = callPackage ../development/tools/misc/texi2html { };
 
+  tinc-haskell = haskellPackages.callPackage ../development/tools/misc/tinc { };
+
   travis = callPackage ../development/tools/misc/travis { };
 
   tweak = callPackage ../applications/editors/tweak { };


### PR DESCRIPTION
This adds package tinc-haskell, a dependency manager for Haskell.
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nixx.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
