### PR TITLE
redis: enable Lua scripting support

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, lua }:
 
 stdenv.mkDerivation rec {
   version = "3.0.7";
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "08vzfdr67gp3lvk770qpax2c5g2sx8hn6p64jn3jddrvxb2939xj";
   };
 
+  buildInputs = [ lua ];
   makeFlags = "PREFIX=$(out)";
 
   enableParallelBuilding = true;


### PR DESCRIPTION
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
