### PR TITLE
scrapy: init at 1.0.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -102,6 +102,7 @@
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   dochang = "Desmond O. Chang <dochang@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";
+  drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26423,4 +26423,64 @@ in modules // {
     };
   };
 
+  w3lib = buildPythonPackage rec {
+    name = "w3lib-${version}";
+    version = "1.14.2";
+
+    buildInputs = with self ; [ six pytest ];
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/w/w3lib/${name}.tar.gz";
+      sha256 = "bd87eae62d208eef70869951abf05e96a8ee559714074a485168de4c5b190004";
+    };
+
+    meta = {
+      description = "A library of web-related functions";
+      homepage = "https://github.com/scrapy/w3lib";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ drewkett ];
+    };
+  };
+
+  queuelib = buildPythonPackage rec {
+    name = "queuelib-${version}";
+    version = "1.4.2";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/q/queuelib/${name}.tar.gz";
+      sha256 = "a6829918157ed433fafa87b0bb1e93e3e63c885270166db5884a02c34c86f914";
+    };
+
+    buildInputs = with self ; [ pytest ];
+
+    meta = {
+      description = "A collection of persistent (disk-based) queues for Python";
+      homepage = "https://github.com/scrapy/queuelib";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ drewkett ];
+    };
+  };
+
+  scrapy = buildPythonPackage rec {
+    name = "Scrapy-${version}";
+    version = "1.0.5";
+
+    disabled = isPy3k;
+
+    buildInputs = with self ; [ pytest ];
+    propagatedBuildInputs = with self ; [ six twisted w3lib lxml cssselect queuelib pyopenssl service-identity ];
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/source/S/Scrapy/${name}.tar.gz";
+      sha256 = "0a51c785a310d65f6e70285a2da56d48ef7d049bd7fd60a08eef05c52328ca96";
+    };
+
+    meta = {
+      description = "A fast high-level web crawling and web scraping framework, used to crawl websites and extract structured data from their pages";
+      homepage = "http://scrapy.org/";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ drewkett ];
+      platforms = platforms.linux;
+    };
+  };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This adds scrapy and a couple of dependent python packages. I couldn't figure out how to build it using the sandbox, since its a part of the python-packages.nix file. 
