### PR TITLE
nscd service: run in foreground so we can avoid the ugly postStart hack

### DIFF
--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -64,9 +64,7 @@ in
         restartTriggers = [ config.environment.etc.hosts.source config.environment.etc."nsswitch.conf".source ];
 
         serviceConfig =
-          { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd -f ${cfgFile}";
-            Type = "forking";
-            PIDFile = "/run/nscd/nscd.pid";
+          { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd -F -f ${cfgFile}";
             Restart = "always";
             ExecReload =
               [ "${pkgs.glibc.bin}/sbin/nscd --invalidate passwd"
@@ -74,16 +72,6 @@ in
                 "${pkgs.glibc.bin}/sbin/nscd --invalidate hosts"
               ];
           };
-
-        # Urgggggh... Nscd forks before opening its socket and writing
-        # its pid. So wait until it's ready.
-        postStart =
-          ''
-            while ! ${pkgs.glibc.bin}/sbin/nscd -g -f ${cfgFile} > /dev/null; do
-              sleep 0.2
-            done
-          '';
       };
-
   };
 }


### PR DESCRIPTION
The systemd project recommends that all services run in the foreground instead of forking. This also means we can get rid of the postStart hack.
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
