### PR TITLE
facetimehd: Only unload module if it is loaded

### DIFF
--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -31,7 +31,7 @@ in
 
     # unload module during suspend/hibernate as it crashes the whole system
     powerManagement.powerDownCommands = ''
-      ${pkgs.kmod}/bin/rmmod -f facetimehd
+      ${pkgs.kmod}/bin/lsmod | ${pkgs.gnugrep}/bin/grep -q "^facetimehd" && ${pkgs.kmod}/bin/rmmod -f -v facetimehd
     '';
 
     # and load it back on resume


### PR DESCRIPTION
I would like it if this was backported to 16.03, since it resolves some issues around successfully sleeping.
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The pre-sleep service exits if any command fails. Unloading facetimehd
without it being loaded blocks subsequent commands from running.

Secondly, forcing the unload of kernel module isn't advisable and can
cause crashes on its own, so I removed the `-f` flag because it seemed
to be the correct thing to do.
