### PR TITLE
haxor-news: init at 0.3.1

### DIFF
--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  version = "0.3.1";
+  name = "haxor-news-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/donnemartin/haxor-news/archive/0.3.1.tar.gz";
+    sha256 = "0jglx8fy38sjyszvvg7mvmyk66l53kyq4i09hmgdz7hb1hrm9m2m";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    click
+    colorama
+    requests2
+    pygments
+    prompt_toolkit_52
+    six
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/donnemartin/haxor-news";
+    description = "Browse Hacker News like a haxor";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7128,6 +7128,8 @@ in
 
   hawknl = callPackage ../development/libraries/hawknl { };
 
+  haxor-news = callPackage ../applications/misc/haxor-news { };
+
   herqq = callPackage ../development/libraries/herqq { };
 
   heyefi = self.haskellPackages.heyefi;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
