### PR TITLE
tortoisehg: 3.7.1 -> 3.7.3, refactor

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -3,6 +3,7 @@
 , ApplicationServices, cf-private }:
 
 let
+  # if you bump version, update pkgs.tortoisehg too or ping maintainer
   version = "3.7.3";
   name = "mercurial-${version}";
 in

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -2,12 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
     name = "tortoisehg-${version}";
-    version = "3.7.1";
-    namePrefix = "";
+    version = "3.7.3";
 
     src = fetchurl {
       url = "https://bitbucket.org/tortoisehg/targz/downloads/${name}.tar.gz";
-      sha256 = "1ycf8knwk1rs99s5caq611sk4c4nzwyzq8g35hw5kwj15b6dl4k6";
+      sha256 = "1vahiavpkf9ib2mx8z5i6f0kh072zycazmbrc4sl94p5pvv5w1dh";
     };
 
     pythonPath = with pythonPackages; [ pyqt4 mercurial qscintilla iniparse ];
@@ -15,14 +14,11 @@ pythonPackages.buildPythonApplication rec {
     propagatedBuildInputs = with pythonPackages; [ qscintilla iniparse ];
 
     doCheck = false;
-
-    postUnpack = ''
-     substituteInPlace $sourceRoot/setup.py \
-       --replace "sharedir = os.path.join(installcmd.install_data[rootlen:], 'share')" "sharedir = '$out/share/'"
-    '';
-
-    postInstall = ''
-     ln -s $out/bin/thg $out/bin/tortoisehg     #convenient alias
+    dontStrip = true;
+    buildPhase = "";
+    installPhase = ''
+      ${pythonPackages.python.executable} setup.py install --prefix=$out
+      ln -s $out/bin/thg $out/bin/tortoisehg     #convenient alias
     '';
 
     meta = {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This updates TortoiseHg to 3.7.3 and adds alternative fix for #13523 and #13507. If upstream fixes [bug with setup.py](https://bitbucket.org/tortoisehg/thg/issues/4483/problems-with-setuppy-on-posix-systems), we can then remove the custom install phase entirely.

Ping @dckc @FRidh @joachifm as potentially interested persons.
