### PR TITLE
rtl8723bs: improved build and split off firmware

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -22,7 +22,11 @@ with lib;
   ###### implementation
 
   config = mkIf config.hardware.enableAllFirmware {
-    hardware.firmware = [ pkgs.firmwareLinuxNonfree pkgs.intel2200BGFirmware ];
+    hardware.firmware = with pkgs; [
+      firmwareLinuxNonfree
+      intel2200BGFirmware
+      rtl8723bs-firmware
+    ];
   };
 
 }

--- a/pkgs/os-specific/linux/firmware/rtl8723bs-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8723bs-firmware/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, linuxPackages }:
+with stdenv.lib;
+stdenv.mkDerivation {
+  name = "rtl8723bs-firmware-${linuxPackages.rtl8723bs.rev}";
+  inherit (linuxPackages.rtl8723bs) src;
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p                "$out/lib/firmware/rtlwifi"
+    cp rtl8723bs_nic.bin    "$out/lib/firmware/rtlwifi"
+    cp rtl8723bs_wowlan.bin "$out/lib/firmware/rtlwifi"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for RealTek 8723bs";
+    homepage = https://github.com/hadess/rtl8723bs;
+    license = licenses.unfreeRedistributableFirmware;
+    maintainers = with maintainers; [ elitak ];
+  };
+}

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -1,36 +1,43 @@
-{ stdenv, fetchFromGitHub, kernel }:
-
-let
-  ver = "c517f2b";
-in
+{ stdenv, fetchFromGitHub, nukeReferences, kernel }:
+with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "rtl8723bs-${kernel.version}-c517f2b";
-  
+  name = "rtl8723bs-${kernel.version}-${rev}";
+  rev = "c517f2bf8bcc3d57311252ea7cd49ae81466eead";
+
   src = fetchFromGitHub {
     owner = "hadess";
     repo = "rtl8723bs";
-    rev = "c517f2bf8bcc3d57311252ea7cd49ae81466eead";
+    inherit rev;
     sha256 = "0phzrhq85g52pi2b74a9sr9l2x6dzlz714k3pix486w2x5axw4xb";
   };
-  
-  patchPhase = ''
-    substituteInPlace ./Makefile --replace /lib/modules/ "${kernel.dev}/lib/modules/"
-    substituteInPlace ./Makefile --replace '$(shell uname -r)' "${kernel.modDirVersion}"
-    substituteInPlace ./Makefile --replace /sbin/depmod #
-    substituteInPlace ./Makefile --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
-    substituteInPlace ./Makefile --replace '/lib/firmware' "$out/lib/firmware"
+
+  buildInputs = [ nukeReferences ];
+
+  makeFlags = concatStringsSep " " [
+    "ARCH=${stdenv.platform.kernelArch}" # Normally not needed, but the Makefile sets ARCH in a broken way.
+    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" # Makefile uses $(uname -r); breaks us.
+  ];
+
+  enableParallelBuilding = true;
+
+  # The Makefile doesn't use env-vars well, so install manually:
+  installPhase = ''
+    mkdir -p      $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless
+    cp r8723bs.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless
+
+    mkdir -p                "$out/lib/firmware/rtlwifi"
+    cp rtl8723bs_nic.bin    "$out/lib/firmware/rtlwifi"
+    cp rtl8723bs_wowlan.bin "$out/lib/firmware/rtlwifi"
+
+    nuke-refs $(find $out -name "*.ko")
   '';
-  
-  preInstall = ''
-    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
-    mkdir -p "$out/lib/firmware/rtlwifi"
-  '';
-   
+
   meta = {
     description = "Realtek SDIO Wi-Fi driver";
     homepage = "https://github.com/hadess/rtl8723bs";
     license = stdenv.lib.licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
-    broken = !stdenv.lib.versionAtLeast kernel.version "3.19";
+    platforms = [ "x86_64-linux" "i686-linux" "armv7l-linux" ];
+    broken = ! versionAtLeast kernel.version "3.19";
+    maintainers = with maintainers; [ elitak ];
   };
 }

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -25,10 +25,6 @@ stdenv.mkDerivation rec {
     mkdir -p      $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless
     cp r8723bs.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless
 
-    mkdir -p                "$out/lib/firmware/rtlwifi"
-    cp rtl8723bs_nic.bin    "$out/lib/firmware/rtlwifi"
-    cp rtl8723bs_wowlan.bin "$out/lib/firmware/rtlwifi"
-
     nuke-refs $(find $out -name "*.ko")
   '';
 

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -2,13 +2,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "rtl8723bs-${kernel.version}-${rev}";
-  rev = "c517f2bf8bcc3d57311252ea7cd49ae81466eead";
+  rev = "6918e9b2ff297b1cc7fde193e72452c33c10e1c8";
 
   src = fetchFromGitHub {
     owner = "hadess";
     repo = "rtl8723bs";
     inherit rev;
-    sha256 = "0phzrhq85g52pi2b74a9sr9l2x6dzlz714k3pix486w2x5axw4xb";
+    sha256 = "07srd457wnz29nvvq02wz66s387bhjbydnmbs3qr7ljprabhsgmi";
   };
 
   buildInputs = [ nukeReferences ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11015,6 +11015,8 @@ in
 
   rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };
 
+  rtl8723bs-firmware = callPackage ../os-specific/linux/firmware/rtl8723bs-firmware { };
+
   s3ql = callPackage ../tools/backup/s3ql { };
 
   sassc = callPackage ../development/tools/sassc { };


### PR DESCRIPTION
Tested on NextThingCo CHIP (armv7l) and Intel ComputeStick (x86_64).

I split the firmware into its own package because, as I understand it, binary firmware can not be GPLed, as the rest of the code is.

I added this firmware to the list enabled by "all" in nixos; I don't know if that's appropriate.

To enable in configuration.nix for testing:

```
hardware.firmware = [ pkgs.rtl8723bs-firmware ];
boot.extraModulePackages = [ config.boot.kernelPackages.rtl8723bs ];
```

I believe this is how it should be done; please correct me if I'm wrong.
