### PR TITLE
nixos: remove redundant services.dovecot2.package option

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -124,6 +124,7 @@ with lib;
     (mkRemovedOptionModule [ "services" "printing" "cupsdConf" ])
     (mkRemovedOptionModule [ "services" "xserver" "startGnuPGAgent" ])
     (mkRemovedOptionModule [ "services" "phpfpm" "phpIni" ])
+    (mkRemovedOptionModule [ "services" "dovecot2" "package" ])
 
   ];
 }

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.services.dovecot2;
-  dovecotPkg = cfg.package;
+  dovecotPkg = pkgs.dovecot;
 
   baseDir = "/run/dovecot2";
   stateDir = "/var/lib/dovecot";
@@ -98,13 +98,6 @@ in
       description = "Additional listeners to start when Dovecot is enabled.";
     };
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.dovecot;
-      defaultText = "pkgs.dovecot";
-      description = "Dovecot package to use.";
-    };
-
     user = mkOption {
       type = types.str;
       default = "dovecot2";
@@ -159,8 +152,7 @@ in
       description = ''
         Symlinks the contents of lib/dovecot of every given package into
         /etc/dovecot/modules. This will make the given modules available
-        if a dovecot package with the module_dir patch applied (like
-        pkgs.dovecot22, the default) is being used.
+        if a dovecot package with the module_dir patch applied is being used.
       '';
     };
 


### PR DESCRIPTION
Instead of using this option, please modify the dovecot package by means of an override. For example:

```
  nixpkgs.config.packageOverrides = super: {
    dovecot = super.dovecot.override { withPgSQL = true; };
  };
```

Closes https://github.com/NixOS/nixpkgs/issues/14097.
