### PR TITLE
tomb: init at version 2.2

### DIFF
--- a/pkgs/os-specific/linux/tomb/default.nix
+++ b/pkgs/os-specific/linux/tomb/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, zsh, pinentry, cryptsetup, gnupg1orig, makeWrapper }:
+
+let
+    version = "2.2";
+in
+
+stdenv.mkDerivation rec {
+  name = "tomb-${version}";
+
+  src = fetchurl {
+    url = "https://files.dyne.org/tomb/tomb-${version}.tar.gz";
+    sha256 = "11msj38fdmymiqcmwq1883kjqi5zr01ybdjj58rfjjrw4zw2w5y0";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  buildPhase = ''
+    # manually patch the interpreter
+    sed -i -e "1s|.*|#!${zsh}/bin/zsh|g" tomb
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+
+    cp tomb $out/bin/tomb
+    cp doc/tomb.1 $out/share/man/man1
+
+    wrapProgram $out/bin/tomb \
+        --prefix PATH : "${pinentry}/bin" \
+        --prefix PATH : "${cryptsetup}/bin" \
+        --prefix PATH : "${gnupg1orig}/bin"
+  '';
+
+  meta = {
+    description = "File encryption on GNU/Linux";
+    homepage = https://www.dyne.org/software/tomb/;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16618,4 +16618,6 @@ in
   discord = callPackage ../applications/networking/instant-messengers/discord { };
 
   golden-cheetah = qt5.callPackage ../applications/misc/golden-cheetah {};
+
+  tomb = callPackage ../os-specific/linux/tomb {};
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
