### PR TITLE
wrapPython: drop python suffixes

### DIFF
--- a/pkgs/development/python-modules/generic/wrap.sh
+++ b/pkgs/development/python-modules/generic/wrap.sh
@@ -28,8 +28,10 @@ wrapPythonProgramsIn() {
     # Find all regular files in the output directory that are executable.
     for f in $(find "$dir" -type f -perm -0100); do
         # Rewrite "#! .../env python" to "#! /nix/store/.../python".
+        # Strip suffix, like "3" or "2.7m" -- we don't have any choice on which
+        # Python to use besides one in $python anyway.
         if head -n1 "$f" | grep -q '#!.*/env.*\(python\|pypy\)'; then
-            sed -i "$f" -e "1 s^.*/env[ ]*\(python\|pypy\)^#! $python^"
+            sed -i "$f" -e "1 s^.*/env[ ]*\(python\|pypy\)[^ ]*^#! $python^"
         fi
 
         # catch /python and /.python-wrapped


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes situations when the shebang is `#!/usr/bin/env python3` (notice the `3` suffix). If it's the case, it would be incorrectly replaced to `#!/nix/store/...../bin/python3.4m3` (for example). I'm not sure that's the best fix, however -- maybe this regexp breaks some valid cases.

cc @domenkozar
