### PR TITLE
lsb-release: init at 1.4

### DIFF
--- a/pkgs/os-specific/linux/lsb-release/default.nix
+++ b/pkgs/os-specific/linux/lsb-release/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, perl, getopt }:
+
+stdenv.mkDerivation rec {
+  version = "1.4";
+  name = "lsb-release-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/lsb/${name}.tar.gz";
+    sha256 = "0wkiy7ymfi3fh2an2g30raw6yxh6rzf6nz2v90fplbnnz2414clr";
+  };
+
+  preConfigure = ''
+    substituteInPlace help2man \
+      --replace /usr/bin/perl ${perl}/bin/perl
+  '';
+
+  installFlags = [ "prefix=$(out)" ];
+
+  buildInputs = [ perl getopt ];
+
+  meta = {
+    description = "Prints certain LSB (Linux Standard Base) and Distribution information";
+    homepage = http://www.linuxfoundation.org/collaborate/workgroups/lsb;
+    license = [ stdenv.lib.licenses.gpl2Plus stdenv.lib.licenses.gpl3Plus ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2249,6 +2249,8 @@ in
 
   lrzip = callPackage ../tools/compression/lrzip { };
 
+  lsb-release = callPackage ../os-specific/linux/lsb-release { };
+
   # lsh installs `bin/nettle-lfib-stream' and so does Nettle.  Give the
   # former a lower priority than Nettle.
   lsh = lowPrio (callPackage ../tools/networking/lsh { });


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is the lsb_release executable from https://sourceforge.net/projects/lsb/. Should probably be tested from someone on other linux distro.

Even if nixos is deliberately not LSB-compliant, it seems interesting to include this tool .
Making it useful on nixos requires including a /etc/lsb-release and possibly /etc/nixos-release on nixos.

some potentially relevant discussion and info: 

http://www.gossamer-threads.com/lists/gentoo/user/110551

http://linux.die.net/man/1/lsb_release

cc @grahamc 
