### PR TITLE
nixpkgs manual: fix link to go2nix

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -119,6 +119,6 @@ done
 </screen>
 </para>
 
-  <para>To extract dependency information from a Go package in automated way use <link xlink:href="https://github.com/cstrahan/go2nix">go2nix</link>.</para>
+  <para>To extract dependency information from a Go package in automated way use <link xlink:href="https://github.com/kamilchm/go2nix">go2nix</link>.</para>
 </section>
 


### PR DESCRIPTION
The GitHub link in the documentation didn't match the package that's in nixpkgs.
