### PR TITLE
dwarf-fortress-unfuck: 2016-02-11 -> 2016-04-22 and zlib dependency

### DIFF
--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, cmake
 , mesa, SDL, SDL_image, SDL_ttf, glew, openalSoft
-, ncurses, glib, gtk2, libsndfile
+, ncurses, glib, gtk2, libsndfile, zlib
 }:
 
 stdenv.mkDerivation {
-  name = "dwarf_fortress_unfuck-2016-02-11";
+  name = "dwarf_fortress_unfuck-2016-04-22";
 
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = "dwarf_fortress_unfuck";
-    rev = "2ba59c87bb63bea598825a73bdc896b0e041e2d5";
-    sha256 = "0q2rhigvaabdknmb2c84gg71qz7xncmx04npzx4bki9avyxsrpcl";
+    rev = "dde40a2c619eac119b6db1bcd0c8d8612472f866";
+    sha256 = "12bqh3k4wsk1c0bz2zly8h0ilbsdmsbwr9cdjc6i7liwg9906g7i";
   };
 
   cmakeFlags = [
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     mesa SDL SDL_image SDL_ttf glew openalSoft
-    ncurses gtk2 libsndfile
+    ncurses gtk2 libsndfile zlib
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fix libz.so.1 not being found (both here and upstream)

maintainer @abbradar 
