### PR TITLE
setup.sh: substitute uses only valid bash names

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1169,7 +1169,15 @@ PATH=/nix/store/68afga4khv0w...-coreutils-6.12/bin
 echo @foo@
 </programlisting>
 
-    That is, no substitution is performed for undefined variables.</para></listitem>
+    That is, no substitution is performed for undefined variables.</para>
+
+    <para>Environment variables that start with an uppercase letter are filtered out,
+    to prevent global variables (like <literal>HOME</literal>) from accidentally
+    getting substituted.
+    The variables also have to be valid bash “names”, as
+    defined in the bash manpage (alphanumeric or <literal>_</literal>, must not
+    start with a number).</para>
+  </listitem>
   </varlistentry>
 
 

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -2,6 +2,7 @@
 
 args:
 
+# see the substituteAll in the nixpkgs documentation for usage and constaints
 stdenv.mkDerivation ({
   name = if args ? name then args.name else baseNameOf (toString args.src);
   builder = ./substitute-all.sh;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -408,6 +408,11 @@ substitute() {
 
         if [ "$p" = --subst-var ]; then
             varName="${params[$((n + 1))]}"
+            # check if the used nix attribute name is a valid bash name
+            if ! [[ "$varName" =~ ^[a-zA-Z_]+[a-zA-Z0-9_]*$ ]]; then
+                echo "substitution variables must be valid bash names, \"$varName\" isn't."
+                exit 1;
+            fi
             pattern="@$varName@"
             replacement="${!varName}"
             n=$((n + 1))
@@ -439,6 +444,7 @@ substituteAll() {
     local output="$2"
 
     # Select all environment variables that start with a lowercase character.
+    # Will not work with nix attribute names (and thus env variables) containing '\n'.
     for envVar in $(env | sed -e $'s/^\([a-z][^=]*\)=.*/\\1/; t \n d'); do
         if [ "$NIX_DEBUG" = "1" ]; then
             echo "$envVar -> ${!envVar}"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -445,7 +445,7 @@ substituteAll() {
 
     # Select all environment variables that start with a lowercase character.
     # Will not work with nix attribute names (and thus env variables) containing '\n'.
-    for envVar in $(env | sed -e $'s/^\([a-z][^=]*\)=.*/\\1/; t \n d'); do
+    for envVar in $(set | sed -e $'s/^\([a-z][^=]*\)=.*/\\1/; t \n d'); do
         if [ "$NIX_DEBUG" = "1" ]; then
             echo "$envVar -> ${!envVar}"
         fi


### PR DESCRIPTION
bash variable names may only contain alphanumeric ASCII-symbols and _,
and must not start with a number. Nix expression attribute names however
might contain nearly every character (in particular spaces and dashes).

Previously, a substitution that was not a valid bash name would be
expanded to an empty string. This commit introduce a check that throws
a (hopefully) helpful error when a wrong name is used in a substitution.
That was discovered by chexxor when it happened to me in a substitution.

Additionally, substituteAll previously filtered out all environment
variables starting with an uppercase letter. That increased the number
of silently(!) ignored envvars (and nix attributes) even further.
Because it was quite arbitrary, it is removed.

This will trigger a mass rebuild.
