### PR TITLE
nix-prefetch-git: create parent directories

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -343,7 +343,7 @@ fi
 
 if test -n "$builder"; then
     test -n "$out" -a -n "$url" -a -n "$rev" || usage
-    mkdir $out
+    mkdir -p $out
     clone_user_rev "$out" "$url" "$rev"
 else
     if test -z "$hashType"; then
@@ -368,7 +368,7 @@ else
         trap "rm -rf \"$tmpPath\"" EXIT
 
         tmpFile="$tmpPath/$(url_to_name "$url" "$rev")"
-        mkdir "$tmpFile"
+        mkdir -p "$tmpFile"
 
         # Perform the checkout.
         clone_user_rev "$tmpFile" "$url" "$rev"


### PR DESCRIPTION
Creating nested folders doesn't work with the current `mkdir` command. Adding the `-p` option to create parent directories.
