### PR TITLE
Fixes  open-vm-tools build and runtime errors

### DIFF
--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -25,6 +25,8 @@ in
         serviceConfig.ExecStart = "${open-vm-tools}/bin/vmtoolsd";
       };
 
+    environment.etc."vmware-tools".source = "${pkgs.open-vm-tools}/etc/vmware-tools/*";
+
     services.xserver = {
       videoDrivers = mkOverride 50 [ "vmware" ];
 

--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -4,23 +4,24 @@
   pkgconfig, glib, gtk, gtkmm }:
 
 let
-  majorVersion = "9.10";
-  minorVersion = "0";
-  patchSet = "2476743";
-  version = "${majorVersion}.${minorVersion}-${patchSet}";
+  majorVersion = "10.0";
+  minorVersion = "7";
+  version = "${majorVersion}.${minorVersion}";
 
 in stdenv.mkDerivation {
   name = "open-vm-tools-${version}";
   src = fetchurl {
-    url = "mirror://sourceforge/project/open-vm-tools/open-vm-tools/stable-${majorVersion}.x/open-vm-tools-${version}.tar.gz";
-    sha256 = "15lwayrz9bpx4z12fj616hsn25m997y72licwwz7kms4sx9ssip1";
+    url = "https://github.com/vmware/open-vm-tools/archive/stable-${version}.tar.gz";
+    sha256 = "1j1fm6sv2rqgg04ifr9s975i93wyr0523iw0mv7xqfgxmz1nvmw7";
   };
+
+  sourceRoot = "open-vm-tools-stable-${version}/open-vm-tools";
 
   buildInputs =
     [ autoreconfHook makeWrapper libmspack openssl pam xercesc icu libdnet procps
       pkgconfig glib gtk gtkmm xlibsWrapper libXinerama libXi libXrender libXrandr libXtst ];
 
-  patchPhase = ''
+  postPatch = ''
      sed -i s,-Werror,,g configure.ac
      sed -i 's,^confdir = ,confdir = ''${prefix},' scripts/Makefile.am
      sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' services/vmtoolsd/Makefile.am

--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, makeWrapper, autoreconfHook,
   libmspack, openssl, pam, xercesc, icu, libdnet, procps,
   xlibsWrapper, libXinerama, libXi, libXrender, libXrandr, libXtst,
-  pkgconfig, glib, gtk, gtkmm }:
+  pkgconfig, glib, gtk, gtkmm, iproute, dbus, systemd }:
 
 let
   majorVersion = "10.0";
@@ -30,6 +30,14 @@ in stdenv.mkDerivation {
   patches = [ ./recognize_nixos.patch ];
 
   configureFlags = "--without-kernel-modules --without-xmlsecurity";
+
+  postInstall = ''
+	sed -i 's,which ,command -v ,' "$out/etc/vmware-tools/scripts/vmware/network"
+	wrapProgram "$out/etc/vmware-tools/scripts/vmware/network" \
+		--prefix PATH ':' "${iproute}/bin" \
+		--prefix PATH ':' "${dbus}/bin" \
+		--prefix PATH ':' "${systemd}/bin"
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/vmware/open-vm-tools";

--- a/pkgs/applications/virtualization/open-vm-tools/recognize_nixos.patch
+++ b/pkgs/applications/virtualization/open-vm-tools/recognize_nixos.patch
@@ -1,18 +1,7 @@
-From d1b753212ee5151db941de0e2b826dcf9722f2f3 Mon Sep 17 00:00:00 2001
-From: Arseniy Seroka <ars.seroka@gmail.com>
-Date: Fri, 21 Aug 2015 20:20:16 +0300
-Subject: [PATCH] [PATCH]: recognize NixOS Linux
-
----
- open-vm-tools/lib/include/guest_os.h   | 1 +
- open-vm-tools/lib/misc/hostinfoPosix.c | 3 +++
- 2 files changed, 4 insertions(+)
-
-diff --git a/open-vm-tools/lib/include/guest_os.h b/open-vm-tools/lib/include/guest_os.h
-index 4fc9ea7..f5104fd 100644
---- a/open-vm-tools/lib/include/guest_os.h
-+++ b/open-vm-tools/lib/include/guest_os.h
-@@ -215,6 +215,7 @@ Bool Gos_InSetArray(uint32 gos, const uint32 *set);
+diff -ruN open-vm-tools.orig/lib/include/guest_os.h open-vm-tools/lib/include/guest_os.h
+--- open-vm-tools.orig/lib/include/guest_os.h	2016-02-12 00:50:33.000000000 +0000
++++ open-vm-tools/lib/include/guest_os.h	2016-04-18 20:07:41.677251511 +0000
+@@ -222,6 +222,7 @@
  #define STR_OS_MANDRAKE_FULL      "Mandrake Linux"
  #define STR_OS_MANDRIVA           "mandriva"
  #define STR_OS_MKLINUX            "MkLinux"
@@ -20,19 +9,30 @@ index 4fc9ea7..f5104fd 100644
  #define STR_OS_NOVELL             "nld9"
  #define STR_OS_NOVELL_FULL        "Novell Linux Desktop 9"
  #define STR_OS_ORACLE             "oraclelinux"
-diff --git a/open-vm-tools/lib/misc/hostinfoPosix.c b/open-vm-tools/lib/misc/hostinfoPosix.c
-index 6c13fe3..5b82983 100644
---- a/open-vm-tools/lib/misc/hostinfoPosix.c
-+++ b/open-vm-tools/lib/misc/hostinfoPosix.c
-@@ -184,6 +184,7 @@ static const DistroInfo distroArray[] = {
+diff -ruN open-vm-tools.orig/lib/include/vmblock.h open-vm-tools/lib/include/vmblock.h
+--- open-vm-tools.orig/lib/include/vmblock.h	2016-02-12 00:50:33.000000000 +0000
++++ open-vm-tools/lib/include/vmblock.h	2016-04-18 21:51:15.651235848 +0000
+@@ -145,7 +145,7 @@
+ # define VMBLOCK_DEVICE_MODE           VMBLOCK_FUSE_DEVICE_MODE
+ # define VMBLOCK_MOUNT_POINT           VMBLOCK_FUSE_MOUNT_POINT
+ 
+-#elif defined(linux)
++#elif defined(__linux__)
+ # define VMBLOCK_ADD_FILEBLOCK         98
+ # define VMBLOCK_DEL_FILEBLOCK         99
+ # ifdef VMX86_DEVEL
+diff -ruN open-vm-tools.orig/lib/misc/hostinfoPosix.c open-vm-tools/lib/misc/hostinfoPosix.c
+--- open-vm-tools.orig/lib/misc/hostinfoPosix.c	2016-02-12 00:50:33.000000000 +0000
++++ open-vm-tools/lib/misc/hostinfoPosix.c	2016-04-18 20:09:45.841668252 +0000
+@@ -195,6 +195,7 @@
     {"Mandrake",           "/etc/mandrake-release"},
     {"Mandriva",           "/etc/mandriva-release"},
-    {"Mandrake",           "/etc/mandrakelinux-release"},
+    {"MkLinux",            "/etc/mklinux-release"},
 +   {"NixOS",              "/etc/os-release"},
-    {"TurboLinux",         "/etc/turbolinux-release"},
-    {"Fedora Core",        "/etc/fedora-release"},
-    {"Gentoo",             "/etc/gentoo-release"},
-@@ -613,6 +614,8 @@ HostinfoGetOSShortName(char *distro,         // IN: full distro name
+    {"Novell",             "/etc/nld-release"},
+    {"OracleLinux",        "/etc/oracle-release"},
+    {"Photon",             "/etc/lsb-release"},
+@@ -619,6 +620,8 @@
        Str_Strcpy(distroShort, STR_OS_MANDRIVA, distroShortSize);
     } else if (strstr(distroLower, "mklinux")) {
        Str_Strcpy(distroShort, STR_OS_MKLINUX, distroShortSize);
@@ -41,6 +41,3 @@ index 6c13fe3..5b82983 100644
     } else if (strstr(distroLower, "pld")) {
        Str_Strcpy(distroShort, STR_OS_PLD, distroShortSize);
     } else if (strstr(distroLower, "slackware")) {
--- 
-2.5.0
-


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes issue #14436 
