### PR TITLE
seafile-*: 4.4.2 -> 5.0.7

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec
 {
-  version = "4.4.2";
+  version = "5.0.7";
   name = "seafile-client-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/seafile-client/archive/v${version}.tar.gz";
-    sha256 = "0aj39xiayibxp3vcrwi58pn51h9vcsy2z04q8jm17qadmk9dzyw6";
+    sha256 = "ae6975bc1adf45d09cf9f6332ceac7cf285f8191f6cf50c6291ed45f8cf4ffa5";
   };
 
   buildInputs = [ pkgconfig cmake qt4 seafile-shared makeWrapper ];

--- a/pkgs/development/libraries/libsearpc/default.nix
+++ b/pkgs/development/libraries/libsearpc/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec
 {
-  version = "1.2.2";
-  seafileVersion = "3.0-latest";
+  version = "3.0.7";
+  seafileVersion = "5.0.7";
   name = "libsearpc-${version}";
 
   src = fetchurl
   {
-    url = "https://github.com/haiwen/libsearpc/archive/v${seafileVersion}.tar.gz";
-    sha256 = "1kdq6chn3qhvr616sw91gf9kjfgbv9snl2srqisw0zddw1qkfcan";
+    url = "https://github.com/haiwen/libsearpc/archive/v${version}.tar.gz";
+    sha256 = "0fdrgksdwd4qxp7qvh75y39dy52h2f5wfjbqr00h3rwkbx4npvpg";
   };
 
   patches = [ ./libsearpc.pc.patch ];

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec
 {
-  version = "4.4.2";
+  version = "5.0.7";
   name = "seafile-shared-${version}";
 
   src = fetchurl
   {
     url = "https://github.com/haiwen/seafile/archive/v${version}.tar.gz";
-    sha256 = "00sflvyap3nw38qblpagp2japgp83sqc5s4r336mi6475grgmnyi";
+    sha256 = "ec166c86a41e7ab3b1ae97a56326ab4a2b1ec38686486b956c3d153b8023c670";
   };
 
   buildInputs = [ which automake autoconf pkgconfig libtool vala python intltool fuse ];

--- a/pkgs/tools/networking/ccnet/default.nix
+++ b/pkgs/tools/networking/ccnet/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec
 {
-  version = "1.4.2";
-  seafileVersion = "4.0.6";
+  version = "5.0.7";
+  seafileVersion = "5.0.7";
   name = "ccnet-${version}";
 
   src = fetchurl
   {
-    url = "https://github.com/haiwen/ccnet/archive/v${seafileVersion}.tar.gz";
-    sha256 = "06srvyphrfx7g18vk899850q0aw8cxx34cj96mjzc3sqm0bkzqsh";
+    url = "https://github.com/haiwen/ccnet/archive/v${version}.tar.gz";
+    sha256 = "1e1c670a85619b174328a15925a050c7a8b323fecd13434992332f5c15e05de1";
   };
 
   buildInputs = [ which automake autoconf pkgconfig libtool vala  python ];


### PR DESCRIPTION
###### Things done (see comment below)
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Comment on sandboxing: could not get that to work with chroot, was getting a chroot permission error. I don't think that is package related. But this is my first nix package, so I might well be wrong.

Also updated dependencies:
ccnet: 1.4.2 -> 5.0.7
libsearpc: 1.2.2 -> 3.0.7
