### PR TITLE
unifi, mfi: closure-size fix, relocatable data dir

### DIFF
--- a/nixos/modules/services/networking/mfi.nix
+++ b/nixos/modules/services/networking/mfi.nix
@@ -10,6 +10,7 @@ let
     { what = "${pkgs.mfi}/dl"; where = "${stateDir}/dl"; }
     { what = "${pkgs.mfi}/lib"; where = "${stateDir}/lib"; }
     { what = "${pkgs.mongodb248}/bin"; where = "${stateDir}/bin"; }
+    { what = "${cfg.dataDir}"; where = "${stateDir}/data"; }
   ];
   systemdMountPoints = map (m: "${utils.escapeSystemdPath m.where}.mount") mountPoints;
   ports = [ 6080 6880 6443 6843 ];
@@ -22,6 +23,15 @@ in
         type = types.bool;
         default = true;
         description = "Whether to open TCP ports ${concatMapStrings (a: "${toString a} ") ports}for the services.";
+      };
+      dataDir = mkOption {
+        type = types.str;
+        default = "${stateDir}/data";
+        description = ''
+          Where to store the database and other data.
+
+          This directory will be bind-mounted to ${stateDir}/data as part of the service startup.
+        '';
       };
     };
   };

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -62,7 +62,7 @@ in
       bindsTo = systemdMountPoints;
       unitConfig.RequiresMountsFor = stateDir;
       # This a HACK to fix missing dependencies of dynamic libs extracted from jars
-      environment.LD_LIBRARY_PATH = with pkgs.stdenv; "${cc.cc}/lib";
+      environment.LD_LIBRARY_PATH = with pkgs.stdenv; "${cc.cc.lib}/lib";
 
       preStart = ''
         # Ensure privacy of state

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -17,6 +17,10 @@ let
       what = "${pkgs.mongodb}/bin";
       where = "${stateDir}/bin";
     }
+    {
+      what = "${cfg.dataDir}";
+      where = "${stateDir}/data";
+    }
   ];
   systemdMountPoints = map (m: "${utils.escapeSystemdPath m.where}.mount") mountPoints;
 in
@@ -29,6 +33,16 @@ in
       default = false;
       description = ''
         Whether or not to enable the unifi controller service.
+      '';
+    };
+
+    services.unifi.dataDir = mkOption {
+      type = types.str;
+      default = "${stateDir}/data";
+      description = ''
+        Where to store the database and other data.
+
+        This directory will be bind-mounted to ${stateDir}/data as part of the service startup.
       '';
     };
 


### PR DESCRIPTION
Tested on x86_64.

By default, the data dir bind-mounts to itself. Should I change this to types.nullOr? I felt this way was better because the default value is more meaningful.
