### PR TITLE
file-roller: Enable nautilus extension

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/apps/file-roller/default.nix
@@ -1,17 +1,16 @@
 { stdenv, fetchurl, glib, pkgconfig, gnome3, intltool, itstool, libxml2, libarchive
-, attr, bzip2, acl, wrapGAppsHook, librsvg, gdk_pixbuf }:
+, attr, bzip2, acl, wrapGAppsHook, librsvg, libnotify, gdk_pixbuf }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
-  # TODO: support nautilus
-  # it tries to create {nautilus}/lib/nautilus/extensions-3.0/libnautilus-fileroller.so
-
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ glib gnome3.gtk intltool itstool libxml2 libarchive
+  buildInputs = [ glib gnome3.gtk intltool itstool libxml2 libarchive libnotify
                   gnome3.defaultIconTheme attr bzip2 acl gdk_pixbuf librsvg
                   gnome3.dconf ];
+
+  installFlags = [ "nautilus_extensiondir=$(out)/lib/nautilus/extensions-3.0" ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/FileRoller;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Compile the nautilus extension in $(out)/lib/nautilus/extensions-3.0
- Add libnotify support

/cc @DamienCassou @lethalman 
