### PR TITLE
emacs25pre: 25.0.92 -> 25.0.93

### DIFF
--- a/pkgs/applications/editors/emacs-25/default.nix
+++ b/pkgs/applications/editors/emacs-25/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = "ftp://alpha.gnu.org/gnu/emacs/pretest/emacs-25.0.92.tar.xz";
-    sha256 = "13jnj1js2l90k4yk219r3z67fff90r6mniprsp0sgip2kaak75y2";
+    url = "ftp://alpha.gnu.org/gnu/emacs/pretest/emacs-25.0.93.tar.xz";
+    sha256 = "1wbr2n723ycg16rlg81v9x17w9ciy7qyckxplnwghlyfj6j9k4dk";
   };
 
   patches = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
