### PR TITLE
windows improvements, mainly cross: linux -> mingw

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig, libtool
+{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, libtool
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg
 , lcms2, openexr, libpng, librsvg, libtiff, libxml2
 }:
@@ -9,11 +9,28 @@ let
     else if stdenv.system == "x86_64-linux" || stdenv.system == "x86_64-darwin" then "x86-64"
     else if stdenv.system == "armv7l-linux" then "armv7l"
     else throw "ImageMagick is not supported on this platform.";
+
+  cfg = {
+    version = "6.9.3-8";
+    sha256 = "129s4cwp6cbhgsr3xr8186q5j02zpbk6kqfk4j7ayb563zsrdb4h";
+    patches = [];
+  }
+    # Freeze version on mingw so we don't need to port the patch too often.
+    // lib.optionalAttrs (stdenv.cross.libc or null == "msvcrt") {
+        version = "6.9.2-0";
+        sha256 = "17ir8bw1j7g7srqmsz3rx780sgnc21zfn0kwyj78iazrywldx8h7";
+        patches = (fetchpatch {
+          name = "mingw-build.patch";
+          url = "https://raw.githubusercontent.com/Alexpux/MINGW-packages/"
+            + "01ca03b2a4ef/mingw-w64-imagemagick/002-build-fixes.patch";
+          sha256 = "1pypszlcx2sf7wfi4p37w1y58ck2r8cd5b2wrrwr9rh87p7fy1c0";
+        });
+      };
 in
 
 stdenv.mkDerivation rec {
   name = "imagemagick-${version}";
-  version = "6.9.3-8";
+  inherit (cfg) version;
 
   src = fetchurl {
     urls = [
@@ -21,8 +38,9 @@ stdenv.mkDerivation rec {
       # the original source above removes tarballs quickly
       "http://distfiles.macports.org/ImageMagick/ImageMagick-${version}.tar.xz"
     ];
-    sha256 = "129s4cwp6cbhgsr3xr8186q5j02zpbk6kqfk4j7ayb563zsrdb4h";
+    inherit (cfg) sha256;
   };
+  inherit (cfg) patches;
 
   outputs = [ "out" "doc" ];
 
@@ -35,15 +53,26 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (ghostscript != null)
       [ "--with-gs-font-dir=${ghostscript}/share/ghostscript/fonts"
         "--with-gslib"
-      ];
+      ]
+    ++ lib.optionals (stdenv.cross.libc or null == "msvcrt")
+      [ "--enable-static" "--disable-shared" ] # due to libxml2 being without DLLs ATM
+    ;
+
+  nativeBuildInputs = [ pkgconfig libtool ];
 
   buildInputs =
-    [ pkgconfig libtool zlib fontconfig freetype ghostscript libjpeg
-      openexr libpng librsvg libtiff libxml2
-    ];
+    [ zlib fontconfig freetype ghostscript
+      libpng libtiff libxml2
+    ]
+    ++ lib.optionals (stdenv.cross.libc or null != "msvcrt")
+      [ openexr librsvg ]
+    ;
 
   propagatedBuildInputs =
-    [ bzip2 freetype libjpeg libX11 libXext libXt lcms2 ];
+    [ bzip2 freetype libjpeg lcms2 ]
+    ++ lib.optionals (stdenv.cross.libc or null != "msvcrt")
+      [ libX11 libXext libXt ]
+    ;
 
   postInstall = ''
     (cd "$out/include" && ln -s ImageMagick* ImageMagick)

--- a/pkgs/build-support/setup-hooks/win-dll-link.sh
+++ b/pkgs/build-support/setup-hooks/win-dll-link.sh
@@ -1,0 +1,45 @@
+
+fixupOutputHooks+=(_linkDLLs)
+
+# For every *.{exe,dll} in $output/bin/ we try to find all (potential)
+# transitive dependencies and symlink those DLLs into $output/bin
+# so they are found on invocation.
+# (DLLs are first searched in the directory of the running exe file.)
+# The links are relative, so relocating whole /nix/store won't break them.
+_linkDLLs() {
+(
+    if [ ! -d "$prefix/bin" ]; then exit; fi
+    cd "$prefix/bin"
+
+    # Compose path list where DLLs should be located:
+    #   prefix $PATH by currently-built outputs
+    local DLLPATH=""
+    local outName
+    for outName in $outputs; do
+        addToSearchPath DLLPATH "${!outName}/bin"
+    done
+    DLLPATH="$DLLPATH:$PATH"
+
+    echo DLLPATH="'$DLLPATH'"
+
+    linkCount=0
+    # Iterate over any DLL that we depend on.
+    local dll
+    for dll in $(objdump -p *.{exe,dll} | sed -n 's/.*DLL Name: \(.*\)/\1/p' | sort -u); do
+        if [ -e "./$dll" ]; then continue; fi
+        # Locate the DLL - it should be an *executable* file on $DLLPATH.
+        local dllPath="$(PATH="$DLLPATH" type -P "$dll")"
+        if [ -z "$dllPath" ]; then continue; fi
+        # That DLL might have its own (transitive) dependencies,
+        # so add also all DLLs from its directory to be sure.
+        local dllPath2
+        for dllPath2 in "$dllPath" "$(dirname "$dllPath")"/*.dll; do
+            if [ -e ./"$(basename "$dllPath2")" ]; then continue; fi
+            ln -sr "$dllPath2" .
+            linkCount=$(($linkCount+1))
+        done
+    done
+    echo "Created $linkCount DLL link(s) in $prefix/bin"
+)
+}
+

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -76,6 +76,9 @@ let
     "--user-config=user-config.jam"
     "toolset=gcc-cross"
     "--without-python"
+  ] ++ optionals stdenv.isCrossWin [
+    "target-os=windows"
+    "threadapi=win32"
   ];
   crossB2Args = concatStringsSep " " (genericB2Flags ++ crossB2Flags);
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -77,7 +77,7 @@ let
     "toolset=gcc-cross"
     "--without-python"
   ];
-  crossB2Args = concatMapStringsSep " " (genericB2Flags ++ crossB2Flags);
+  crossB2Args = concatStringsSep " " (genericB2Flags ++ crossB2Flags);
 
   builder = b2Args: ''
     ./b2 ${b2Args}

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, icu, expat, zlib, bzip2, python, fixDarwinDylibNames
+{ stdenv, fetchurl, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
 , toolset ? if stdenv.cc.isClang then "clang" else null
 , enableRelease ? true
 , enableDebug ? false
@@ -151,7 +151,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ expat zlib bzip2 ]
+  buildInputs = [ expat zlib bzip2 libiconv ]
     ++ stdenv.lib.optionals (! stdenv ? cross) [ python icu ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -173,7 +173,6 @@ stdenv.mkDerivation {
     # usual --build and --host added on cross building.
     preConfigure = ''
       export configureFlags="--without-icu ${concatStringsSep " " commonConfigureFlags}"
-      set -x
       cat << EOF > user-config.jam
       using gcc : cross : $crossConfig-g++ ;
       EOF

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -54,13 +54,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  crossAttrs = {
-    buildInputs = lib.optional (stdenv ? ccCross && stdenv.ccCross.libc ? libiconv)
-      stdenv.ccCross.libc.libiconv.crossDrv;
-    # Gettext fails to guess the cross compiler
-    configureFlags = "CXX=${stdenv.cross.config}-g++";
-  };
-
   meta = {
     description = "Well integrated set of translation tools and documentation";
 

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, lib }:
 
-assert (!stdenv.isLinux);
+assert !stdenv.isLinux || stdenv ? cross; # TODO: improve on cross
 
 stdenv.mkDerivation rec {
   name = "libiconv-1.14";
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
     ./libiconv-1.14-reloc.patch
     ./libiconv-1.14-wchar.patch
   ];
+
+  postPatch =
+    lib.optionalString (stdenv.cross.libc or null == "msvcrt")
+      ''
+        sed '/^_GL_WARN_ON_USE (gets/d' -i srclib/stdio.in.h
+      '';
 
   configureFlags =
   # On Cygwin, Libtool produces a `.dll.a', which is not a "real" DLL

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -8,6 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "0gi349hp1x7mb98s4mf66sb2xay2kjjxj9ihrriw0yiy0k9va6sj";
   };
 
+  patches =
+    stdenv.lib.optional (stdenv.cross.libc or null == "msvcrt")
+      ./mingw-boolean.patch;
+
   outputs = [ "dev" "out" "doc" "bin" ];
 
   nativeBuildInputs = [ nasm ];

--- a/pkgs/development/libraries/libjpeg-turbo/mingw-boolean.patch
+++ b/pkgs/development/libraries/libjpeg-turbo/mingw-boolean.patch
@@ -1,0 +1,19 @@
+Ported to updated libjpeg-turbo from
+https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libjpeg-turbo/jpeg-typedefs.patch
+--- a/jmorecfg.h	2012-02-10 06:47:55 +0300
++++ b/jmorecfg.h	2012-05-03 10:29:13 +0400
+@@ -224,7 +224,13 @@
+  * Defining HAVE_BOOLEAN before including jpeglib.h should make it work.
+  */
+ 
+-#ifndef HAVE_BOOLEAN
++#if defined(_WIN32) && !defined(HAVE_BOOLEAN)
++#ifndef __RPCNDR_H__
++typedef unsigned char boolean;
++#endif
++#define HAVE_BOOLEAN
++#endif
++#if !defined(HAVE_BOOLEAN) && !defined(__RPCNDR_H__)
+ typedef int boolean;
+ #endif
+ #ifndef FALSE			/* in case these macros already exist */

--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -26,7 +26,9 @@ in stdenv.mkDerivation rec {
 
   preConfigure = "export bin=$dev";
 
-  doCheck = true;
+  # it's hard to cross-run tests and some check programs didn't compile anyway
+  makeFlags = stdenv.lib.optional (!doCheck) "check_PROGRAMS=";
+  doCheck = ! stdenv ? cross;
 
   postInstall = ''mv "$out/bin" "$dev/bin"'';
 

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, zlib, xz, python, findXMLCatalogs }:
+{ stdenv, lib, fetchurl, zlib, xz, python, findXMLCatalogs, libiconv
+, supportPython ? (! stdenv ? cross) }:
 
 stdenv.mkDerivation rec {
   name = "libxml2-${version}";
@@ -9,23 +10,35 @@ stdenv.mkDerivation rec {
     sha256 = "0bd17g6znn2r98gzpjppsqjg33iraky4px923j3k8kdl8qgy7sad";
   };
 
-  outputs = [ "dev" "out" "bin" "doc" "py" ];
-  propagatedBuildOutputs = "out bin py";
+  outputs = [ "dev" "out" "bin" "doc" ]
+    ++ lib.optional supportPython "py";
+  propagatedBuildOutputs = "out bin" + lib.optionalString supportPython " py";
 
-  buildInputs = [ python ]
+  buildInputs = lib.optional supportPython python
     # Libxml2 has an optional dependency on liblzma.  However, on impure
     # platforms, it may end up using that from /usr/lib, and thus lack a
     # RUNPATH for that, leading to undefined references for its users.
-    ++ stdenv.lib.optional stdenv.isFreeBSD xz;
+    ++ lib.optional stdenv.isFreeBSD xz;
 
   propagatedBuildInputs = [ zlib findXMLCatalogs ];
 
-  configureFlags = "--with-python=${python}";
+  configureFlags = lib.optional supportPython "--with-python=${python}";
 
   enableParallelBuilding = true;
 
-  preInstall = ''substituteInPlace python/libxml2mod.la --replace "${python}" "$py"'';
-  installFlags = ''pythondir="$(py)/lib/${python.libPrefix}/site-packages"'';
+  crossAttrs = lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+    # creating the DLL is broken ATM
+    dontDisableStatic = true;
+    configureFlags = configureFlags ++ [ "--disable-shared" ];
+
+    # libiconv is a header dependency - propagating is enough
+    propagatedBuildInputs =  [ findXMLCatalogs libiconv ];
+  };
+
+  preInstall = lib.optionalString supportPython
+    ''substituteInPlace python/libxml2mod.la --replace "${python}" "$py"'';
+  installFlags = lib.optionalString supportPython
+    ''pythondir="$(py)/lib/${python.libPrefix}/site-packages"'';
 
   postFixup = ''
     moveToOutput bin/xml2-config "$dev"
@@ -33,13 +46,13 @@ stdenv.mkDerivation rec {
     moveToOutput share/man/man1 "$bin"
   '';
 
-  passthru = { inherit version; pythonSupport = true; };
+  passthru = { inherit version; pythonSupport = supportPython; };
 
   meta = {
     homepage = http://xmlsoft.org/;
     description = "An XML parsing library for C";
     license = "bsd";
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.eelco ];
   };
 }

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
   };
 
   patches = stdenv.lib.optional stdenv.isSunOS ./patch-ah.patch
+    ++ stdenv.lib.optional (stdenv.cross.libc or null == "msvcrt")
+        (fetchpatch {
+          name = "mingw.patch";
+          url = "http://git.gnome.org/browse/libxslt/patch/?id=ab5810bf27cd63";
+          sha256 = "0kkqq3fv2k3q86al38vp6zwxazpvp5kslcjnmrq4ax5cm2zvsjk3";
+        })
     ++ [
       (fetchpatch {
         name = "CVE-2015-7995.patch";

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -43,6 +43,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  crossAttrs.postPatch =
+    # there are tests using `strXXX_s` functions that are missing apparently
+    stdenv.lib.optionalString (stdenv.cross.libc or null == "msvcrt")
+      "sed '/^SUBDIRS =/s/ test / /' -i Makefile.in";
+
   meta = with lib; {
     homepage = http://poppler.freedesktop.org/;
     description = "A PDF rendering library";

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
 
   # TODO: reduce propagation to necessary libs
   propagatedBuildInputs = with lib;
-    [ zlib freetype fontconfig libjpeg lcms curl openjpeg ]
-    ++ optional (!minimal) cairo
+    [ zlib freetype fontconfig libjpeg ]
+    ++ optionals (!minimal) [ cairo lcms curl openjpeg ]
     ++ optional qt4Support qt4
     ++ optional qt5Support qtbase;
 
@@ -35,8 +35,11 @@ stdenv.mkDerivation rec {
       "--enable-libcurl"
       "--enable-zlib"
     ]
-    ++ optionals minimal [ "--disable-poppler-glib" "--disable-poppler-cpp" ]
-    ++ optional (!utils) "--disable-utils";
+    ++ optionals minimal [
+      "--disable-poppler-glib" "--disable-poppler-cpp"
+      "--disable-libopenjpeg" "--disable-libcurl"
+    ]
+    ++ optional (!utils) "--disable-utils" ;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -52,14 +52,21 @@ stdenv.mkDerivation rec {
 
   crossAttrs = {
     dontStrip = static;
+    dontSetConfigureCross = true;
   } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
-    configurePhase=''
-      installFlags="BINARY_PATH=$out/bin INCLUDE_PATH=$out/include LIBRARY_PATH=$out/lib"
-    '';
+    installFlags = [
+      "BINARY_PATH=$(out)/bin"
+      "INCLUDE_PATH=$(dev)/include"
+      "LIBRARY_PATH=$(out)/lib"
+    ];
     makeFlags = [
       "-f" "win32/Makefile.gcc"
       "PREFIX=${stdenv.cross.config}-"
-    ] ++ (if static then [] else [ "SHARED_MODE=1" ]);
+    ] ++ stdenv.lib.optional (!static) "SHARED_MODE=1";
+
+    # Non-typical naming confuses libtool which then refuses to use zlib's DLL
+    # in some cases, e.g. when compiling libpng.
+    postInstall = postInstall + "ln -s zlib1.dll $out/bin/libz.dll";
   } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "libSystem") {
     makeFlags = [ "RANLIB=${stdenv.cross.config}-ranlib" ];
   };

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -4,14 +4,15 @@
 }:
 
 let
-  name = "mingw-w64-3.1.0";
+  version = "4.0.6";
+  name = "mingw-w64-${version}";
 in
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation ({
   inherit name;
 
   src = fetchurl {
-    url = "mirror://sourceforge/mingw-w64/mingw-w64-v3.1.0.tar.bz2";
-    sha256 = "1lhpw381gc59w8b1r9zzdwa9cdi2wx6qx7s6rvajapmbw7ksgrzc";
+    url = "mirror://sourceforge/mingw-w64/mingw-w64-v${version}.tar.bz2";
+    sha256 = "0p01vm5kx1ixc08402z94g1alip4vx66gjpvyi9maqyqn2a76h0c";
   };
 } //
 (if onlyHeaders then {

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -96,8 +96,12 @@ rec {
                     name = name + "-" + cross.config;
                     nativeBuildInputs = nativeBuildInputsDrvs
                       ++ nativeInputsFromBuildInputs
-                      ++ [ gccCross binutilsCross ] ++
-                      stdenv.lib.optional selfNativeBuildInput nativeDrv;
+                      ++ [ gccCross binutilsCross ]
+                      ++ stdenv.lib.optional selfNativeBuildInput nativeDrv
+                        # without proper `file` command, libtool sometimes fails
+                        # to recognize 64-bit DLLs
+                      ++ stdenv.lib.optional (cross.config  == "x86_64-w64-mingw32") pkgs.file
+                      ;
 
                     # Cross-linking dynamic libraries, every buildInput should
                     # be propagated because ld needs the -rpath-link to find

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -196,7 +196,13 @@ let
           buildInputs = if crossConfig != null then buildInputs' else [];
           propagatedBuildInputs = if crossConfig != null then propagatedBuildInputs else [];
           # Inputs built by the usual native compiler.
-          nativeBuildInputs = nativeBuildInputs ++ (if crossConfig == null then buildInputs' else []);
+          nativeBuildInputs = nativeBuildInputs
+            ++ lib.optionals (crossConfig == null) buildInputs'
+            ++ lib.optional
+                (result.isCygwin
+                  || (crossConfig != null && lib.hasSuffix "mingw32" crossConfig))
+                ../../build-support/setup-hooks/win-dll-link.sh
+            ;
           propagatedNativeBuildInputs = propagatedNativeBuildInputs ++
             (if crossConfig == null then propagatedBuildInputs else []);
         } // ifDarwin {

--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ];
 
+  cmakeFlags = stdenv.lib.optional
+    (stdenv.cross.libc or null == "msvcrt") "-DCMAKE_SYSTEM_NAME=Windows";
+
   # ATM bin/tidy is statically linked, as upstream provides no other option yet.
   # https://github.com/htacg/tidy-html5/issues/326#issuecomment-160322107
 


### PR DESCRIPTION
The main point point of this is to make some particular packages cross-compile to mingw. I'll merge in a few days if there's noone interested.

A specific change that may be of interest is a kindof-replacement for RPATH on Windows: https://github.com/NixOS/nixpkgs/commit/6e7787e666c50558b5aa10ffcca8e6c0c9bc1ba3. It allows me to just `wine ./result-bin/bin/foo` on dynamically linked binaries. I activated that hook for cygwin as well, although I have only tested it on cross: linux -> mingw.

The linux non-cross stdenv is unchanged, but this PR is probably still a non-cross mass rebuild.

---
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of **most** binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md), hopefully.
