### PR TITLE
Oracle Java Mission Control: fix startup

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -11,6 +11,7 @@
 { swingSupport ? true
 , stdenv
 , requireFile
+, makeWrapper
 , unzip
 , file
 , xorg ? null
@@ -82,6 +83,8 @@ let result = stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ file ]
     ++ stdenv.lib.optional installjce unzip;
+
+  buildInputs = [ makeWrapper ];
 
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
@@ -159,6 +162,10 @@ let result = stdenv.mkDerivation rec {
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
     EOF
+
+    # Oracle Java Mission Control needs to know where libgtk-x11 and related is
+    wrapProgram "$out/bin/jmc" \
+        --suffix-each LD_LIBRARY_PATH ':' "${rpath}" \
   '';
 
   inherit installjdk pluginSupport;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The jmc binary needed some runtime dependencies. JMC can now be run.
