### PR TITLE
emby: init at 3.0.5930

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -263,6 +263,7 @@
       caddy = 239;
       taskd = 240;
       factorio = 241;
+      emby = 242;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -497,6 +498,7 @@
       caddy = 239;
       taskd = 240;
       factorio = 241;
+      emby = 242;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -216,6 +216,7 @@
   ./services/misc/dictd.nix
   ./services/misc/disnix.nix
   ./services/misc/docker-registry.nix
+  ./services/misc/emby.nix
   ./services/misc/etcd.nix
   ./services/misc/felix.nix
   ./services/misc/folding-at-home.nix

--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -1,0 +1,64 @@
+{ config, pkgs, lib, mono, ... }:
+
+with lib;
+
+let
+  cfg = config.services.emby;
+  emby = pkgs.emby;
+in
+{
+  options = {
+    services.emby = {
+      enable = mkEnableOption "Emby Media Server";
+
+      user = mkOption {
+        type = types.str;
+        default = "emby";
+        description = "User account under which Emby runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "emby";
+        description = "Group under which emby runs.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.emby = {
+      description = "Emby Media Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        test -d /var/lib/emby/ProgramData-Server || {
+          echo "Creating initial Emby data directory in /var/lib/emby/ProgramData-Server"
+          mkdir -p /var/lib/emby/ProgramData-Server
+          chown -R ${cfg.user}:${cfg.group} /var/lib/emby/ProgramData-Server
+          }
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = "true";
+        ExecStart = "${pkgs.mono}/bin/mono ${pkgs.emby}/bin/MediaBrowser.Server.Mono.exe";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers = mkIf (cfg.user == "emby") {
+      emby = {
+        group = cfg.group;
+        uid = config.ids.uids.emby;
+      };
+    };
+
+    users.extraGroups = mkIf (cfg.group == "emby") {
+      emby = {
+        gid = config.ids.gids.emby;
+      };
+    };
+  };
+}

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, unzip, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "emby-${version}";
+  version = "3.0.5930";
+
+  src = fetchurl {
+    url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
+    sha256 = "0498v7wng13c9n8sjfaq0b8p933vn7hk5icsranm39bkh3jqgdwf";
+  };
+
+  buildInputs = [ unzip ];
+  propagatedBuildInputs = [ sqlite ];
+
+  # Need to set sourceRoot as unpacker will complain about multiple directory output
+  sourceRoot = ".";
+
+  patchPhase = ''
+    substituteInPlace System.Data.SQLite.dll.config --replace libsqlite3.so ${sqlite.out}/lib/libsqlite3.so
+    substituteInPlace MediaBrowser.Server.Mono.exe.config --replace ProgramData-Server "/var/lib/emby/ProgramData-Server"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out/bin
+  '';
+
+  meta = {
+    description = "MediaBrowser - Bring together your videos, music, photos, and live television";
+    homepage = http://emby.media/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.fadenb ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -754,6 +754,8 @@ in
 
   elementary-icon-theme = callPackage ../data/icons/elementary-icon-theme { };
 
+  emby = callPackage ../servers/emby { };
+
   enca = callPackage ../tools/text/enca { };
 
   ent = callPackage ../tools/misc/ent { };


### PR DESCRIPTION
This PR contains a new package for emby as well as a basic emby service (based on plex service)

This package and service has been running for some hours on multiple hosts and all basic functionality is working fine.
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
