### PR TITLE
cargo: add libiconv to buildInputs to fix darwin build

### DIFF
--- a/pkgs/development/tools/build-managers/cargo/default.nix
+++ b/pkgs/development/tools/build-managers/cargo/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, cacert, fetchgit, rustPlatform, file, curl, python, pkgconfig, openssl
-, cmake, zlib, makeWrapper }:
+{ stdenv, lib, cacert, fetchgit, rustPlatform, file, curl, python, pkgconfig, openssl
+, cmake, zlib, makeWrapper
+# Darwin dependencies
+, libiconv }:
 
 with rustPlatform;
 
@@ -20,7 +22,8 @@ buildRustPackage rec {
 
   depsSha256 = "1x2m7ww2z8nl5ic2nds85p7ma8x0zp654jg7ay905ia95daiabzg";
 
-  buildInputs = [ file curl pkgconfig python openssl cmake zlib makeWrapper ];
+  buildInputs = [ file curl pkgconfig python openssl cmake zlib makeWrapper ]
+    ++ lib.optional stdenv.isDarwin libiconv;
 
   configurePhase = ''
     ./configure --enable-optimize --prefix=$out --local-cargo=${cargo}/bin/cargo


### PR DESCRIPTION
###### Things done

Fix build failure on Darwin (https://hydra.nixos.org/build/34850183/nixlog/1). I somehow missed this in my last pull-request, where I enabled cargo Darwin compatibility.
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
