### PR TITLE
postgresql service: initialScript fixup

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -242,7 +242,7 @@ in
 
             if test -e "${cfg.dataDir}/.first_startup"; then
               ${optionalString (cfg.initialScript != null) ''
-                cat "${cfg.initialScript}" | psql --port=${toString cfg.port} postgres
+                psql -f "${cfg.initialScript}" --port=${toString cfg.port} postgres
               ''}
               rm -f "${cfg.dataDir}/.first_startup"
             fi


### PR DESCRIPTION
Passing the script via `cat` loses information on the script's directory. This leads to incorrect behavior of `\include_relative` command.

Note that the output of the script can slightly differ (e.g. psql will supply errors with line numbers), which may affect automated testing.
