### PR TITLE
cegui: init at 0.8.4

### DIFF
--- a/pkgs/development/libraries/cegui/default.nix
+++ b/pkgs/development/libraries/cegui/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, cmake, ogre, freetype, boost, expat }:
+
+stdenv.mkDerivation rec {
+  name = "cegui-${version}";
+  version = "0.8.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/crayzedsgui/${name}.tar.bz2";
+    sha256 = "1253aywv610rbs96hwqiw2z7xrrv24l3jhfsqj95w143idabvz5m";
+  };
+
+
+  buildInputs = [ cmake ogre freetype boost expat ];
+
+  meta = with stdenv.lib; {
+    homepage = http://cegui.org.uk/;
+    description = "C++ Library for creating GUIs";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6492,6 +6492,8 @@ in
   celt_0_7 = callPackage ../development/libraries/celt/0.7.nix {};
   celt_0_5_1 = callPackage ../development/libraries/celt/0.5.1.nix {};
 
+  cegui = callPackage ../development/libraries/cegui {};
+
   cgal = callPackage ../development/libraries/CGAL {};
 
   cgui = callPackage ../development/libraries/cgui {};


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

0.8.4 instead of 0.8.5 because of http://cegui.org.uk/forum/viewtopic.php?t=7111 and https://bitbucket.org/cegui/cegui/issues/1120/bug-regarding-auto-window-children-element

Right now, the dependencies are fixed at specifically what is needed for opendungeons (will submit later). Should probably add all the withFoo flags for options, but we need to know what to set as default. [Here's the CMakeLists.txt](https://bitbucket.org/cegui/cegui/src/c89f9d44a5a5e65046c72626b7fab473b37db7d8/CMakeLists.txt) to get an idea of all the dependencies.
