### PR TITLE
opendungeons: init at 0.6.0

### DIFF
--- a/pkgs/development/libraries/cegui/default.nix
+++ b/pkgs/development/libraries/cegui/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, cmake, ogre, freetype, boost, expat }:
+
+stdenv.mkDerivation rec {
+  name = "cegui-${version}";
+  version = "0.8.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/crayzedsgui/${name}.tar.bz2";
+    sha256 = "1253aywv610rbs96hwqiw2z7xrrv24l3jhfsqj95w143idabvz5m";
+  };
+
+
+  buildInputs = [ cmake ogre freetype boost expat ];
+
+  meta = with stdenv.lib; {
+    homepage = http://cegui.org.uk/;
+    description = "C++ Library for creating GUIs";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/opendungeons/cmakepaths.patch
+++ b/pkgs/games/opendungeons/cmakepaths.patch
@@ -1,0 +1,17 @@
+--- ../CMakeLists.txt	
++++ ../CMakeLists.txt	
+@@ -31,12 +31,12 @@
+     set(OD_PLUGINS_CFG_PATH ".")
+ else()
+     # Set binary and data install locations if we want to use the installer
+-    set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX}/games CACHE PATH "Absolute path to the game binary directory")
++    set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX}/bin CACHE PATH "Absolute path to the game binary directory")
+     set(OD_DATA_PATH ${CMAKE_INSTALL_PREFIX}/share/games/${PROJECT_NAME} CACHE PATH "Absolute path to the game data directory")
+     set(OD_SHARE_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE PATH "Absolute path to the shared data directory (desktop file, icons, etc.)")
+     # Set the plugins.cfg file path to a common but architecture-dependent location.
+     # Because the plugins.cfg Ogre plugins path path may vary depending on the architecture used.
+-    set(OD_PLUGINS_CFG_PATH /etc/${PROJECT_NAME} CACHE PATH "Absolute path to the Ogre plugins.cfg file")
++    set(OD_PLUGINS_CFG_PATH ${CMAKE_INSTALL_PREFIX}/etc/${PROJECT_NAME} CACHE PATH "Absolute path to the Ogre plugins.cfg file")
+ endif()
+ 
+ if(NOT MSVC)

--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, ogre, cegui, boost, sfml, openal, cmake, ois }:
+
+stdenv.mkDerivation rec {
+  name = "opendungeons-${version}";
+  version = "0.6.0";
+
+  src = fetchurl {
+    url = "ftp://download.tuxfamily.org/opendungeons/${version}/${name}.tar.xz";
+    sha256 = "1g0sjh732794h26cbkr0p96i3c0avm0mx9ip5zbvb2y3sbpjcbib";
+  };
+
+  patches = [ ./cmakepaths.patch ];
+
+  buildInputs = [ cmake ogre cegui boost sfml openal ois ];
+
+  meta = with stdenv.lib; {
+    description = "An open source, real time strategy game sharing game elements with the Dungeon Keeper series and Evil Genius.";
+    homepage = "https://opendungeons.github.io";
+    license = [ licenses.gpl3Plus licenses.zlib licenses.mit licenses.cc-by-sa-30 licenses.cc0 licenses.ofl licenses.cc-by-30 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6492,6 +6492,8 @@ in
   celt_0_7 = callPackage ../development/libraries/celt/0.7.nix {};
   celt_0_5_1 = callPackage ../development/libraries/celt/0.5.1.nix {};
 
+  cegui = callPackage ../development/libraries/cegui {};
+
   cgal = callPackage ../development/libraries/CGAL {};
 
   cgui = callPackage ../development/libraries/cgui {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14904,6 +14904,8 @@ in
 
   openarena = callPackage ../games/openarena { };
 
+  opendungeons = callPackage ../games/opendungeons { };
+
   openlierox = callPackage ../games/openlierox { };
 
   openmw = callPackage ../games/openmw { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
