### PR TITLE
beignet: init at 1.1.2

### DIFF
--- a/pkgs/development/libraries/beignet/clang_llvm.patch
+++ b/pkgs/development/libraries/beignet/clang_llvm.patch
@@ -1,0 +1,62 @@
+diff --git a/./CMake/FindLLVM.cmake b/../Beignet-1.1.2-Source_new/CMake/FindLLVM.cmake
+index a148321..96cafb8 100644
+--- a/./CMake/FindLLVM.cmake
++++ b/../Beignet-1.1.2-Source_new/CMake/FindLLVM.cmake
+@@ -22,6 +22,7 @@ if (LLVM_CONFIG_EXECUTABLE)
+ else (LLVM_CONFIG_EXECUTABLE)
+   message(FATAL_ERROR "Could NOT find LLVM executable, please add -DLLVM_INSTALL_DIR=/path/to/llvm-config/ in cmake command")
+ endif (LLVM_CONFIG_EXECUTABLE)
++
+ execute_process(
+   COMMAND ${LLVM_CONFIG_EXECUTABLE} --version
+   OUTPUT_VARIABLE LLVM_VERSION
+@@ -44,10 +45,16 @@ if (LLVM_FIND_VERSION_MAJOR AND LLVM_FIND_VERSION_MINOR)
+   endif (LLVM_VERSION_NODOT VERSION_LESS LLVM_FIND_VERSION_NODOT)
+ endif (LLVM_FIND_VERSION_MAJOR AND LLVM_FIND_VERSION_MINOR)
+ 
+-if (LLVM_INSTALL_DIR)
++if (CLANG_INSTALL_DIR)
+   find_program(CLANG_EXECUTABLE
+                NAMES clang-${LLVM_VERSION_NODOT} clang-${LLVM_VERSION_NOPATCH} clang
+-               PATHS ${LLVM_INSTALL_DIR} NO_DEFAULT_PATH)
++               PATHS ${CLANG_INSTALL_DIR} NO_DEFAULT_PATH)
++else (CLANG_INSTALL_DIR)
++  find_program(CLANG_EXECUTABLE
++               NAMES clang-${LLVM_VERSION_NODOT} clang-${LLVM_VERSION_NOPATCH} clang)
++endif (CLANG_INSTALL_DIR)
++
++if (LLVM_INSTALL_DIR)
+   find_program(LLVM_AS_EXECUTABLE
+                NAMES llvm-as-${LLVM_VERSION_NODOT} llvm-as-${LLVM_VERSION_NOPATCH} llvm-as
+                PATHS ${LLVM_INSTALL_DIR} NO_DEFAULT_PATH)
+@@ -55,8 +62,6 @@ if (LLVM_INSTALL_DIR)
+                NAMES llvm-link-${LLVM_VERSION_NODOT} llvm-link-${LLVM_VERSION_NOPATCH} llvm-link
+                PATHS ${LLVM_INSTALL_DIR} NO_DEFAULT_PATH)
+ else (LLVM_INSTALL_DIR)
+-  find_program(CLANG_EXECUTABLE
+-               NAMES clang-${LLVM_VERSION_NODOT} clang-${LLVM_VERSION_NOPATCH} clang)
+   find_program(LLVM_AS_EXECUTABLE
+                NAMES llvm-as-${LLVM_VERSION_NODOT} llvm-as-${LLVM_VERSION_NOPATCH} llvm-as)
+   find_program(LLVM_LINK_EXECUTABLE
+@@ -105,7 +110,7 @@ endif (LLVM_VERSION_NODOT VERSION_GREATER 34)
+ macro(add_one_lib name)
+   FIND_LIBRARY(CLANG_LIB
+     NAMES ${name}
+-    PATHS ${LLVM_LIBRARY_DIR} NO_DEFAULT_PATH)
++    PATHS ${CLANG_LIBRARY_DIR} NO_DEFAULT_PATH)
+   set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_LIB})
+ 	unset(CLANG_LIB CACHE)
+ endmacro()
+diff --git a/./CMakeLists.txt b/../Beignet-1.1.2-Source_new/CMakeLists.txt
+index 88985d7..01bca9e 100644
+--- a/./CMakeLists.txt
++++ b/../Beignet-1.1.2-Source_new/CMakeLists.txt
+@@ -205,7 +205,7 @@ IF(OCLIcd_FOUND)
+     "intel-beignet.icd.in"
+     "${ICD_FILE_NAME}"
+   )
+-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${ICD_FILE_NAME} DESTINATION /etc/OpenCL/vendors)
++  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${ICD_FILE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/etc/OpenCL/vendors)
+ ELSE(OCLIcd_FOUND)
+   MESSAGE(STATUS "Looking for OCL ICD header file - not found")
+ ENDIF(OCLIcd_FOUND)

--- a/pkgs/development/libraries/beignet/default.nix
+++ b/pkgs/development/libraries/beignet/default.nix
@@ -1,0 +1,123 @@
+{ stdenv
+, fetchurl
+, cmake
+, pkgconfig
+, clang-unwrapped
+, llvm
+, libdrm
+, libX11
+, libXfixes
+, libpthreadstubs
+, libXdmcp
+, libXdamage
+, libXxf86vm
+, python
+, gl
+, ocl-icd
+}: 
+
+stdenv.mkDerivation rec {
+  name = "beignet-${version}";
+  version = "1.1.2"; 
+
+  src = fetchurl {
+    url = "https://01.org/sites/default/files/${name}-source.tar.gz"; 
+    sha256 = "6a8d875afbb5e3c4fc57da1ea80f79abadd9136bfd87ab1f83c02784659f1d96"; 
+  };  
+
+  patches = [ ./clang_llvm.patch ]; 
+
+  postPatch = ''
+    patchShebangs src/git_sha1.sh; 
+
+    for f in $(find utests -type f)
+    do
+      sed -e "s@isnan(@std::isnan(@g" -i $f
+      sed -e "s@_std::isnan@_isnan@g" -i $f
+
+      sed -e "s@isinf(@std::isinf(@g" -i $f
+      sed -e "s@_std::isinf@_isinf@g" -i $f
+    done
+  ''; 
+
+  configurePhase = ''
+    cmake . -DCMAKE_INSTALL_PREFIX=$out \
+            -DCLANG_LIBRARY_DIR="${clang-unwrapped}/lib" \
+            -DLLVM_INSTALL_DIR="${llvm}/bin" \
+            -DCLANG_INSTALL_DIR="${clang-unwrapped}/bin"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/utests/kernels
+    mkdir -p $out/utests/lib
+
+    cp -r kernels $out/utests
+    cp src/libcl.so $out/utests/lib
+
+    cat > $out/utests/setenv.sh << EOF
+#!/bin/sh
+export OCL_BITCODE_LIB_PATH=$out/lib/beignet/beignet.bc
+export OCL_HEADER_FILE_DIR=$out/lib/beignet/include
+export OCL_PCH_PATH=$out/lib/beignet/beignet.pch
+export OCL_GBE_PATH=$out/lib/beignet/libgbe.so
+export OCL_INTERP_PATH=$out/lib/beignet/libgbeinterp.so
+export OCL_KERNEL_PATH=$out/utests/kernels
+export OCL_IGNORE_SELF_TEST=1
+EOF
+
+    function fixRunPath {
+      p0=$(patchelf --print-rpath $1)
+      p1=$(echo $p0 | sed -e "s@$(pwd)/src@$out/utests/lib@g" -)
+      p2=$(echo $p1 | sed -e "s@$(pwd)/utests@$out/utests@g" -)
+      patchelf --set-rpath $p2 $1 
+    }
+    
+    fixRunPath utests/utest_run
+    fixRunPath utests/libutests.so
+
+    cp utests/utest_run $out/utests
+    cp utests/libutests.so $out/utests
+
+    mkdir -p $out/bin
+    ln -s $out/utests/setenv.sh $out/bin/beignet_setenv.sh
+    ln -s $out/utests/utest_run $out/bin/beignet_utest_run
+  ''; 
+
+  # To run the unit tests, the user must be in "video" group. 
+  # The nix builders are members of only "nixbld" group, so 
+  # they are able to compile the tests, but not to run them. 
+  # To verify the installation, add yourself to "video" group, 
+  # switch to a working directory which has both read and write 
+  # permissions, run: nix-shell -p pkgs.beignet, and execute:
+  # . beignet_setenv.sh && beignet_utest_run
+  doCheck = false; 
+
+  buildInputs = [ 
+    llvm 
+    clang-unwrapped
+    cmake 
+    libX11 
+    pkgconfig 
+    libdrm 
+    gl 
+    libXfixes 
+    libpthreadstubs
+    libXdmcp
+    libXdamage
+    libXxf86vm
+    python
+    ocl-icd
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://cgit.freedesktop.org/beignet/;
+    description = "OpenCL Library for Intel Ivy Bridge and newer GPUs";
+    longDescription = ''
+      The package provides an open source implementation of the OpenCL specification for Intel GPUs. 
+      It supports the Intel OpenCL runtime library and compiler. 
+    '';
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ artuuge ];
+    platforms = platforms.linux;
+  }; 
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6449,6 +6449,14 @@ in
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
+  beignet = callPackage ../development/libraries/beignet {
+    inherit (llvmPackages) clang-unwrapped; 
+    inherit (xlibs) libX11; 
+    inherit (xorg) libXfixes libpthreadstubs libXdmcp libXdamage libXxf86vm; 
+    inherit (python3Packages) python; 
+    inherit (purePackages) gl; 
+  }; 
+  
   belle-sip = callPackage ../development/libraries/belle-sip { };
 
   bobcat = callPackage ../development/libraries/bobcat { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The unit tests are disabled in the installation script since they require a user to be in "video" group. These tests can be executed afterwards from a `nix-shell -p pkgs.beignet`, see the comments in `default.nix`. The patch fixes a problem with files stemming from `clang` and `llvm` packages. The assumption in the original `CMakeLists.txt` is that the files from `clang` end up in the same directory as the files from `llvm`, what is not the case on NixOS. This motivates a new variable `CLANG_INSTALL_DIR` which is similar to `LLVM_INSTALL_DIR`. The corresponding paths are passed to `cmake` via -D arguments at configure phase. The file `intel-beignet.icd` is installed in a local directory `${beignet}/etc/OpenCL/vendors`.

The package has been tested by running all unit tests included in the source distribution on a machine with Intel Corporation 3rd Gen Core processor Graphics Controller [8086:0156].    
