### PR TITLE
workrave: add missing dependencies

### DIFF
--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoconf, automake, gettext, intltool, libtool, pkgconfig,
-  libXtst, cheetah, libXScrnSaver,
+  libXtst, cheetah, libXScrnSaver, xorg,
   glib, glibmm,
   gtk, gtkmm,
   atk,
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     libXScrnSaver
 
     glib glibmm gtk gtkmm atk pango pangomm cairo cairomm
-    dbus dbus_glib GConf gconfmm gdome2 gstreamer libsigcxx
+    dbus dbus_glib GConf gconfmm gdome2 gstreamer libsigcxx xorg.libICE xorg.libSM
   ];
 
   preConfigure = "./autogen.sh";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @prikhi
