### PR TITLE
rofi: 0.15.12 -> 1.0.0

### DIFF
--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,20 +1,30 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig
-, libX11, libXinerama, pango, cairo
+, libX11, libxkbcommon, pango, cairo, glib
+, libxcb, xcbutil, xcbutilwm, which, git
 , libstartup_notification, i3Support ? false, i3
 }:
 
 stdenv.mkDerivation rec {
   name = "rofi-${version}";
-  version = "0.15.12";
+  version = "1.0.0";
 
   src = fetchurl {
-    url = "https://github.com/DaveDavenport/rofi/archive/${version}.tar.gz";
-    sha256 = "112fgx2awsw1xf1983bmy3jvs33qwyi8qj7j59jqc4gx07nv1rp5";
+    url = "https://github.com/DaveDavenport/rofi/releases/download/${version}/${name}.tar.xz";
+    sha256 = "0ard95pjgykafm5ga8lfy7x206f07lrc6kara5s9irlhdgblq2m5";
   };
 
-  buildInputs = [ autoreconfHook pkgconfig libX11 libXinerama pango
-                  cairo libstartup_notification
+  preConfigure = ''
+    patchShebangs "script"
+    # root not present in build /etc/passwd
+    sed -i 's/~root/~nobody/g' test/helper-expand.c
+  '';
+
+  buildInputs = [ autoreconfHook pkgconfig libX11 libxkbcommon pango
+                  cairo libstartup_notification libxcb xcbutil xcbutilwm
+                  which git
                 ] ++ stdenv.lib.optional i3Support i3;
+
+  doCheck = true;
 
   meta = {
       description = "Window switcher, run dialog and dmenu replacement";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Big update. Now also with tests. `which` and `git` are not strictly necessary, but useful if pointing `src` to a git checkout.

Changelog at https://github.com/DaveDavenport/rofi/releases
