### PR TITLE
tinc-haskell: Rename package name to avoid conflict

### DIFF
--- a/pkgs/development/tools/misc/tinc-haskell/default.nix
+++ b/pkgs/development/tools/misc/tinc-haskell/default.nix
@@ -6,7 +6,7 @@
 , ghc, cabal2nix, cabal-install, makeWrapper
 }:
 mkDerivation {
-  pname = "tinc";
+  pname = "tinc-haskell";
   version = "20160419";
   src = fetchFromGitHub {
     owner = "sol";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6302,7 +6302,7 @@ in
 
   texi2html = callPackage ../development/tools/misc/texi2html { };
 
-  tinc-haskell = haskellPackages.callPackage ../development/tools/misc/tinc { };
+  tinc-haskell = haskellPackages.callPackage ../development/tools/misc/tinc-haskell { };
 
   travis = callPackage ../development/tools/misc/travis { };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
