### PR TITLE
Fix fallout after splitting `nix` to multiple outputs

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -81,14 +81,14 @@ pkgs.vmTools.runInLinuxVM (
 
       # Register the paths in the Nix database.
       printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-          chroot /mnt ${config.nix.package}/bin/nix-store --load-db --option build-users-group ""
+          chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
 
       # Add missing size/hash fields to the database. FIXME:
       # exportReferencesGraph should provide these directly.
-      chroot /mnt ${config.nix.package}/bin/nix-store --verify --check-contents
+      chroot /mnt ${config.nix.package.out}/bin/nix-store --verify --check-contents
 
       # Create the system profile to allow nixos-rebuild to work.
-      chroot /mnt ${config.nix.package}/bin/nix-env --option build-users-group "" \
+      chroot /mnt ${config.nix.package.out}/bin/nix-env --option build-users-group "" \
           -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel}
 
       # `nixos-rebuild' requires an /etc/NIXOS.

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -34,7 +34,7 @@ in
       if ! [ -e /var/lib/nixos/did-channel-init ]; then
         echo "unpacking the NixOS/Nixpkgs sources..."
         mkdir -p /nix/var/nix/profiles/per-user/root
-        ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/per-user/root/channels \
+        ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/per-user/root/channels \
           -i ${channelSources} --quiet --option build-use-substitutes false
         mkdir -m 0700 -p /root/.nix-defexpr
         ln -s /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -364,12 +364,12 @@ in
       ''
         # After booting, register the contents of the Nix store on the
         # CD in the Nix database in the tmpfs.
-        ${config.nix.package}/bin/nix-store --load-db < /nix/store/nix-path-registration
+        ${config.nix.package.out}/bin/nix-store --load-db < /nix/store/nix-path-registration
 
         # nixos-rebuild also requires a "system" profile and an
         # /etc/NIXOS tag.
         touch /etc/NIXOS
-        ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+        ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
       '';
 
     # Add vfat support to the initrd to enable people to copy the

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -113,11 +113,11 @@ in
         ${pkgs.e2fsprogs}/bin/resize2fs $rootPart
 
         # Register the contents of the initial Nix store
-        ${config.nix.package}/bin/nix-store --load-db < /nix-path-registration
+        ${config.nix.package.out}/bin/nix-store --load-db < /nix-path-registration
 
         # nixos-rebuild also requires a "system" profile and an /etc/NIXOS tag.
         touch /etc/NIXOS
-        ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+        ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
 
         # Prevents this from running on later boots.
         rm -f /nix-path-registration

--- a/nixos/modules/installer/cd-dvd/system-tarball.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball.nix
@@ -78,14 +78,14 @@ in
         # After booting, register the contents of the Nix store on the
         # CD in the Nix database in the tmpfs.
         if [ -f /nix-path-registration ]; then
-          ${config.nix.package}/bin/nix-store --load-db < /nix-path-registration &&
+          ${config.nix.package.out}/bin/nix-store --load-db < /nix-path-registration &&
           rm /nix-path-registration
         fi
 
         # nixos-rebuild also requires a "system" profile and an
         # /etc/NIXOS tag.
         touch /etc/NIXOS
-        ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+        ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
       '';
 
   };

--- a/nixos/modules/installer/tools/auto-upgrade.nix
+++ b/nixos/modules/installer/tools/auto-upgrade.nix
@@ -78,7 +78,7 @@ let cfg = config.system.autoUpgrade; in
           HOME = "/root";
         };
 
-      path = [ pkgs.gnutar pkgs.xz.bin config.nix.package ];
+      path = [ pkgs.gnutar pkgs.xz.bin config.nix.package.out ];
 
       script = ''
         ${config.system.build.nixos-rebuild}/bin/nixos-rebuild switch ${toString cfg.flags}

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -271,7 +271,7 @@ remotePATH=
 if [ -n "$buildNix" ]; then
     echo "building Nix..." >&2
     nixDrv=
-    if ! nixDrv="$(nix-instantiate '<nixpkgs/nixos>' --add-root $tmpDir/nix.drv --indirect -A config.nix.package "${extraBuildFlags[@]}")"; then
+    if ! nixDrv="$(nix-instantiate '<nixpkgs/nixos>' --add-root $tmpDir/nix.drv --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then
         if ! nixDrv="$(nix-instantiate '<nixpkgs/nixos>' --add-root $tmpDir/nix.drv --indirect -A nixFallback "${extraBuildFlags[@]}")"; then
             if ! nixDrv="$(nix-instantiate '<nixpkgs>' --add-root $tmpDir/nix.drv --indirect -A nix "${extraBuildFlags[@]}")"; then
                 nixStorePath="$(prebuiltNix "$(uname -m)")"

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -22,17 +22,17 @@ let
     src = ./nixos-install.sh;
 
     inherit (pkgs) perl pathsFromGraph;
-    nix = config.nix.package;
+    nix = config.nix.package.out;
 
     nixClosure = pkgs.runCommand "closure"
-      { exportReferencesGraph = ["refs" config.nix.package]; }
+      { exportReferencesGraph = ["refs" config.nix.package.out]; }
       "cp refs $out";
   };
 
   nixos-rebuild = makeProg {
     name = "nixos-rebuild";
     src = ./nixos-rebuild.sh;
-    nix = config.nix.package;
+    nix = config.nix.package.out;
   };
 
   nixos-generate-config = makeProg {

--- a/nixos/modules/profiles/docker-container.nix
+++ b/nixos/modules/profiles/docker-container.nix
@@ -37,12 +37,12 @@ in {
       # After booting, register the contents of the Nix store in the Nix
       # database.
       if [ -f /nix-path-registration ]; then
-        ${config.nix.package}/bin/nix-store --load-db < /nix-path-registration &&
+        ${config.nix.package.out}/bin/nix-store --load-db < /nix-path-registration &&
         rm /nix-path-registration
       fi
 
       # nixos-rebuild also requires a "system" profile
-      ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+      ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
     '';
 
   # Install new init script

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.nix;
 
-  nix = cfg.package;
+  nix = cfg.package.out;
 
   makeNixBuildUser = nr:
     { name = "nixbld${toString nr}";

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -65,8 +65,8 @@ in
 
       package = mkOption {
         type = types.package;
-        default = pkgs.nix.out;
-        defaultText = "pkgs.nix.out";
+        default = pkgs.nix;
+        defaultText = "pkgs.nix";
         description = ''
           This option specifies the Nix package instance to use throughout the system.
         '';

--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -52,7 +52,7 @@ in
 
     systemd.services.nix-gc =
       { description = "Nix Garbage Collector";
-        script = "exec ${config.nix.package}/bin/nix-collect-garbage ${cfg.options}";
+        script = "exec ${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
         startAt = optionalString cfg.automatic cfg.dates;
       };
 

--- a/nixos/modules/services/misc/nix-ssh-serve.nix
+++ b/nixos/modules/services/misc/nix-ssh-serve.nix
@@ -41,7 +41,7 @@ with lib;
         PermitTTY no
         PermitTunnel no
         X11Forwarding no
-        ForceCommand ${config.nix.package}/bin/nix-store --serve
+        ForceCommand ${config.nix.package.out}/bin/nix-store --serve
       Match All
     '';
 

--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -50,7 +50,7 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      path = [ config.nix.package pkgs.bzip2.bin ];
+      path = [ config.nix.package.out pkgs.bzip2.bin ];
       environment.NIX_REMOTE = "daemon";
       environment.NIX_SECRET_KEY_FILE = cfg.secretKeyFile;
 

--- a/nixos/modules/system/boot/loader/gummiboot/gummiboot.nix
+++ b/nixos/modules/system/boot/loader/gummiboot/gummiboot.nix
@@ -14,7 +14,7 @@ let
 
     inherit (pkgs) python gummiboot;
 
-    nix = config.nix.package;
+    nix = config.nix.package.out;
 
     timeout = if cfg.timeout != null then cfg.timeout else "";
 

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -8,7 +8,7 @@ let
 
     echo "attempting to fetch configuration from EC2 user data..."
 
-    export PATH=${config.nix.package}/bin:${pkgs.systemd}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${config.system.build.nixos-rebuild}/bin:$PATH
+    export PATH=${pkgs.lib.makeBinPath [ config.nix.package pkgs.systemd pkgs.gnugrep pkgs.gnused config.system.build.nixos-rebuild]}:$PATH
     export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
 
     userData=/etc/ec2-metadata/user-data

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -62,10 +62,10 @@ in
 
           echo Register the paths in the Nix database.
           printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-              chroot /mnt ${config.nix.package}/bin/nix-store --load-db --option build-users-group ""
+              chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
 
           echo Create the system profile to allow nixos-rebuild to work.
-          chroot /mnt ${config.nix.package}/bin/nix-env \
+          chroot /mnt ${config.nix.package.out}/bin/nix-env \
               -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel} --option build-users-group ""
 
           echo nixos-rebuild requires an /etc/NIXOS.

--- a/nixos/modules/virtualisation/brightbox-image.nix
+++ b/nixos/modules/virtualisation/brightbox-image.nix
@@ -62,10 +62,10 @@ in
 
           # Register the paths in the Nix database.
           printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-              chroot /mnt ${config.nix.package}/bin/nix-store --load-db --option build-users-group ""
+              chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
 
           # Create the system profile to allow nixos-rebuild to work.
-          chroot /mnt ${config.nix.package}/bin/nix-env \
+          chroot /mnt ${config.nix.package.out}/bin/nix-env \
               -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel} \
               --option build-users-group ""
 

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -66,10 +66,10 @@ in
 
           # Register the paths in the Nix database.
           printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-              chroot /mnt ${config.nix.package}/bin/nix-store --load-db --option build-users-group ""
+              chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
 
           # Create the system profile to allow nixos-rebuild to work.
-          chroot /mnt ${config.nix.package}/bin/nix-env \
+          chroot /mnt ${config.nix.package.out}/bin/nix-env \
               -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel} \
               --option build-users-group ""
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -403,7 +403,7 @@ in
     boot.postBootCommands =
       ''
         if [[ "$(cat /proc/cmdline)" =~ regInfo=([^ ]*) ]]; then
-          ${config.nix.package}/bin/nix-store --load-db < ''${BASH_REMATCH[1]}
+          ${config.nix.package.out}/bin/nix-store --load-db < ''${BASH_REMATCH[1]}
         fi
       '';
 


### PR DESCRIPTION
Fixes #14902 where the Gummiboot boot generator (and presumably lots of other things) failed if `nix.package` was specified by the user.

It is worth mentioning that those `treewide` mass-replace commits would not be needed with #14766 applied.

cc @edolstra 
