### PR TITLE
maim: 3.4.46 -> 3.4.47

### DIFF
--- a/pkgs/tools/graphics/maim/default.nix
+++ b/pkgs/tools/graphics/maim/default.nix
@@ -1,17 +1,15 @@
-{ stdenv, fetchurl, cmake, gengetopt, imlib2, libXrandr, libXfixes
-, cppcheck}:
+{ stdenv, fetchurl, cmake, gengetopt, imlib2, libXrandr, libXfixes }:
 
 stdenv.mkDerivation rec {
   name = "maim-${version}";
-  version = "3.4.46";
+  version = "3.4.47";
 
   src = fetchurl {
     url = "https://github.com/naelstrof/maim/archive/v${version}.tar.gz";
-    sha256 = "04gb858g0rrvdiva2dxwsfd7dmq62r67irnc8cpd0r02hr92dr6n";
+    sha256 = "0kfp7k55bxc5h6h0wv8bwmsc5ny66h9ra2z4dzs4yzszq16544pv";
   };
 
-  buildInputs = [ cmake gengetopt imlib2 libXrandr libXfixes ]
-                ++ stdenv.lib.optional doCheck cppcheck;
+  buildInputs = [ cmake gengetopt imlib2 libXrandr libXfixes ];
 
   doCheck = false;
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Removed `cppcheck` as it does not appear to use that. Should look into porting `unitTests.sh` (https://github.com/naelstrof/maim/blob/master/unitTests.sh) to a proper NixOS test at some point.
