### PR TITLE
virtualgl: fix libturbojpeg library path

### DIFF
--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mnpljmx8nxnmpbx4ja430b3y535wkz185qknsxmk27yz4dbmm8l";
   };
 
-  cmakeFlags = [ "-DVGL_SYSTEMFLTK=1" "-DTJPEG_LIBRARY=${libjpeg_turbo}/lib/libturbojpeg.so" ];
+  cmakeFlags = [ "-DVGL_SYSTEMFLTK=1" "-DTJPEG_LIBRARY=${libjpeg_turbo.out}/lib/libturbojpeg.so" ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
Without this, it tries to link to the dev output of libjpeg_turbo, which
breaks the build.
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
