### PR TITLE
kerberos_server: fix evaluation (closes #14928)

### DIFF
--- a/nixos/modules/services/system/kerberos.nix
+++ b/nixos/modules/services/system/kerberos.nix
@@ -4,7 +4,7 @@ let
 
   inherit (lib) mkOption mkIf singleton;
 
-  inherit (pkgs) heimdal;
+  inherit (pkgs) heimdalFull;
 
   stateDir = "/var/heimdal";
 in
@@ -33,7 +33,7 @@ in
 
   config = mkIf config.services.kerberos_server.enable {
 
-    environment.systemPackages = [ heimdal ];
+    environment.systemPackages = [ heimdalFull ];
 
     services.xinetd.enable = true;
     services.xinetd.services = lib.singleton
@@ -42,7 +42,7 @@ in
         protocol = "tcp";
         user = "root";
         server = "${pkgs.tcp_wrappers}/sbin/tcpd";
-        serverArgs = "${pkgs.heimdal}/sbin/kadmind";
+        serverArgs = "${pkgs.heimdalFull}/sbin/kadmind";
       };
 
     systemd.services.kdc = {
@@ -51,13 +51,13 @@ in
       preStart = ''
         mkdir -m 0755 -p ${stateDir}
       '';
-      script = "${heimdal}/sbin/kdc";
+      script = "${heimdalFull}/sbin/kdc";
     };
 
     systemd.services.kpasswdd = {
       description = "Kerberos Password Changing daemon";
       wantedBy = [ "multi-user.target" ];
-      script = "${heimdal}/sbin/kpasswdd";
+      script = "${heimdalFull}/sbin/kpasswdd";
     };
   };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
