### PR TITLE
pws: Init at 1.0.6

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -340,6 +340,7 @@
   spwhitt = "Spencer Whitt <sw@swhitt.me>";
   stephenmw = "Stephen Weinberg <stephen@q5comm.com>";
   steveej = "Stefan Junker <mail@stefanjunker.de>";
+  swistak35 = "Rafał Łasocha <me@swistak35.com>";
   szczyp = "Szczyp <qb@szczyp.com>";
   sztupi = "Attila Sztupak <attila.sztupak@gmail.com>";
   taeer = "Taeer Bar-Yam <taeer@necsi.edu>";

--- a/pkgs/tools/misc/pws/Gemfile
+++ b/pkgs/tools/misc/pws/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'pws'

--- a/pkgs/tools/misc/pws/Gemfile.lock
+++ b/pkgs/tools/misc/pws/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    clipboard (1.0.6)
+    paint (1.0.1)
+    pbkdf2-ruby (0.2.1)
+    pws (1.0.6)
+      clipboard (~> 1.0.5)
+      paint (>= 0.8.7)
+      pbkdf2-ruby
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pws
+
+BUNDLED WITH
+   1.11.2

--- a/pkgs/tools/misc/pws/default.nix
+++ b/pkgs/tools/misc/pws/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, bundlerEnv, ruby, xsel, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "pws-1.0.6";
+
+  env = bundlerEnv {
+    name = "${name}-gems";
+
+    inherit ruby;
+
+    gemfile  = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset   = ./gemset.nix;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = ["installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/pws $out/bin/pws \
+      --set PATH '"${xsel}/bin/:$PATH"'
+  '';
+
+  meta = with lib; {
+    description = "Command-line password safe";
+    homepage    = https://github.com/janlelis/pws;
+    license     = licenses.mit;
+    maintainers = maintainers.swistak35;
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/pws/gemset.nix
+++ b/pkgs/tools/misc/pws/gemset.nix
@@ -1,0 +1,34 @@
+{
+  clipboard = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11r5xi1fhll4qxna2sg83vmnphjzqc4pzwdnmc5qwvdps5jbz7cq";
+      type = "gem";
+    };
+    version = "1.0.6";
+  };
+  paint = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z1fqyyc2jiv6yabv467h652cxr2lmxl5gqqg7p14y28kdqf0nhj";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  pbkdf2-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "014vb5k8klvh192idqrda2571dxsp7ai2v72hj265zd2awy0zyg1";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
+  pws = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1brn123mmrw09ji60sa13ylgfjjp7aicz07hm9h0dc3162zlw5wn";
+      type = "gem";
+    };
+    version = "1.0.6";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2930,6 +2930,8 @@ in
 
   proxytunnel = callPackage ../tools/misc/proxytunnel { };
 
+  pws = callPackage ../tools/misc/pws { };
+
   cntlm = callPackage ../tools/networking/cntlm { };
 
   pastebinit = callPackage ../tools/misc/pastebinit { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`pws` is a CLI utility for storing passwords securely. It needs either `xsel` or `xclip` to work.
