### PR TITLE
qtpass: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, git, gnupg, makeQtWrapper, pass, qtbase, qtsvg, qttools, qmakeHook }:
+{ stdenv, fetchzip, git, gnupg, makeQtWrapper, pass, qtbase, qtsvg, qttools, qmakeHook }:
 
 stdenv.mkDerivation rec {
   name = "qtpass-${version}";
-  version = "1.1.0";
+  version = "1.1.1";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/IJHack/qtpass/archive/v${version}.tar.gz";
-    sha256 = "60b458062f54184057e55dbd9c93958a8bf845244ffd70b9cb31bf58697f0dc6";
+    sha256 = "1x1ic9as0a60gz664sf8d1qiq64ji7q60g19x0rlm3bvcp2612c8";
   };
 
-  buildInputs = [ git gnupg makeQtWrapper pass qtbase qtsvg qttools qmakeHook ];
+  buildInputs = [ git gnupg pass qtbase qtsvg qttools ];
+
+  nativeBuildInputs = [ makeQtWrapper qmakeHook ];
 
   preConfigure = ''
     qmakeFlags="$qmakeFlags CONFIG+=release DESTDIR=$out"
@@ -18,9 +20,12 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir $out/bin
     mv $out/qtpass $out/bin
+    install -D {,$out/share/applications/}qtpass.desktop
+    install -D artwork/icon.svg $out/share/icons/hicolor/scalable/apps/qtpass-icon.svg
+    runHook postInstall
   '';
 
-  postFixup = ''
+  postInstall = ''
     wrapQtProgram $out/bin/qtpass \
       --suffix PATH : ${git}/bin \
       --suffix PATH : ${gnupg}/bin \
@@ -29,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A multi-platform GUI for pass, the standard unix password manager";
-    homepage = https://github.com/IJHack/qtpass;
+    homepage = https://qtpass.org;
     license = licenses.gpl3;
     maintainers = [ maintainers.hrdinka ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Updates qtpass and fixes the current installation method. It further installs the desktop file and application icon.
