### PR TITLE
Crashplan: 4.6.0-r2 -> 4.6.0-r3

### DIFF
--- a/nixos/modules/services/backup/crashplan.nix
+++ b/nixos/modules/services/backup/crashplan.nix
@@ -50,11 +50,8 @@ with lib;
         ensureDir ${crashplan.vardir}/log 777
         cp -avn ${crashplan}/conf.template/* ${crashplan.vardir}/conf
         for x in app.asar bin EULA.txt install.vars lang lib libjniwrap64.so libjniwrap.so libjtux64.so libjtux.so libmd564.so libmd5.so share skin upgrade; do
-          if [ -e ${crashplan.vardir}/$x ]; then
-            true;
-          else
-            ln -s ${crashplan}/$x ${crashplan.vardir}/$x;
-          fi;
+          rm -f ${crashplan.vardir}/$x;
+          ln -sf ${crashplan}/$x ${crashplan.vardir}/$x;
         done
       '';
 

--- a/pkgs/applications/backup/crashplan/default.nix
+++ b/pkgs/applications/backup/crashplan/default.nix
@@ -2,14 +2,14 @@
 
 let
   version = "4.6.0";
-  rev = "2"; #tracks unversioned changes that occur on download.code42.com from time to time
+  rev = "3"; #tracks unversioned changes that occur on download.code42.com from time to time
 
 in stdenv.mkDerivation rec {
   name = "crashplan-${version}-r${rev}";
 
   crashPlanArchive = fetchurl {
     url = "https://download.code42.com/installs/linux/install/CrashPlan/CrashPlan_${version}_Linux.tgz";
-    sha256 = "13rmmdj048r8k4v7ig4i6pnvwyzc1vasfgksf070bx6ksklgbq47";
+    sha256 = "0crrx8gy132xcpjfah08qhsl8g2arx14p5mpypcihl9j6mldi6mz";
   };
 
   srcs = [ crashPlanArchive ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
