### PR TITLE
lsof: stop configure script from searching /usr paths

### DIFF
--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -16,13 +16,15 @@ stdenv.mkDerivation rec {
   };
 
   unpackPhase = "tar xvjf $src; cd lsof_*; tar xvf lsof_*.tar; sourceRoot=$( echo lsof_*/); ";
-  
+
   preBuild = "sed -i Makefile -e 's/^CFGF=/&	-DHASIPv6=1/;';";
-  
-  configurePhase = if stdenv.isDarwin
-    then "./Configure -n darwin;"
-    else "./Configure -n linux;";
-  
+
+  configurePhase = ''
+    # Stop build scripts from searching global include paths
+    export LSOF_INCLUDE=/$(md5sum <(echo $name) | awk '{print $1}')
+    ./Configure -n ${if stdenv.isDarwin then "darwin" else "linux"}
+  '';
+
   installPhase = ''
     mkdir -p $out/bin $out/man/man8
     cp lsof.8 $out/man/man8/


### PR DESCRIPTION
@mornfall 

LSOF was failing to build on CentOS because it discovered `selinux` headers in `/usr/include` or some other system directories. I'm setting `LSOF_INCLUDE` to point to a non-existent path to remove this behavior. Tested on NixOS and CentOS.
###### Things done
- [X] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
