### PR TITLE
buildkite-agent: init at 2.1.8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -268,6 +268,7 @@
   pakhfn = "Fedor Pakhomov <pakhfn@gmail.com>";
   palo = "Ingolf Wanger <palipalo9@googlemail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
+  pawelpacana = "Paweł Pacana <pawel.pacana@gmail.com>";
   pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
   peterhoeg = "Peter Hoeg <peter@hoeg.com>";
   philandstuff = "Philip Potter <philip.g.potter@gmail.com>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -126,6 +126,7 @@
   ./services/continuous-integration/jenkins/default.nix
   ./services/continuous-integration/jenkins/slave.nix
   ./services/continuous-integration/jenkins/job-builder.nix
+  ./services/continuous-integration/buildkite-agent.nix
   ./services/databases/4store-endpoint.nix
   ./services/databases/4store.nix
   ./services/databases/couchdb.nix

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -1,0 +1,100 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.buildkite-agent;
+  configFile = pkgs.writeText "buildkite-agent.cfg"
+    ''
+      token="${cfg.token}"
+      name="${cfg.name}"
+      meta-data="${cfg.meta-data}"
+      hooks-path="${pkgs.buildkite-agent}/share/hooks"
+      build-path="/var/lib/buildkite-agent/builds"
+      bootstrap-script="${pkgs.buildkite-agent}/share/bootstrap.sh"
+    '';
+in
+
+{
+  options = {
+    services.buildkite-agent = {
+      enable = mkEnableOption "buildkite-agent";
+
+      token = mkOption {
+        type = types.str;
+        description = ''
+          The token from your Buildkite "Agents" page.
+        '';
+      };
+
+      name = mkOption {
+        type = types.str;
+        description = ''
+          The name of the agent.
+        '';
+      };
+
+      meta-data = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Meta data for the agent.
+        '';
+      };
+
+      openssh =
+        { privateKey = mkOption {
+            type = types.str;
+            description = ''
+              Private agent key.
+            '';
+          };
+          publicKey = mkOption {
+            type = types.str;
+            description = ''
+              Public agent key.
+            '';
+          };
+        };
+    };
+  };
+
+  config = mkIf config.services.buildkite-agent.enable {
+    users.extraUsers.buildkite-agent =
+      { name = "buildkite-agent";
+        home = "/var/lib/buildkite-agent";
+        createHome = true;
+        description = "Buildkite agent user";
+      };
+
+    environment.systemPackages = [ pkgs.buildkite-agent ];
+
+    systemd.services.buildkite-agent =
+      { description = "Buildkite Agent";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        environment.HOME = "/var/lib/buildkite-agent";
+        preStart = ''
+            ${pkgs.coreutils}/bin/mkdir -m 0700 -p /var/lib/buildkite-agent/.ssh
+
+            if ! [ -f /var/lib/buildkite-agent/.ssh/id_rsa ]; then
+              echo "${cfg.openssh.privateKey}" > /var/lib/buildkite-agent/.ssh/id_rsa
+              ${pkgs.coreutils}/bin/chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa
+            fi
+
+            if ! [ -f /var/lib/buildkite-agent/.ssh/id_rsa.pub ]; then
+              echo "${cfg.openssh.publicKey}" > /var/lib/buildkite-agent/.ssh/id_rsa.pub
+              ${pkgs.coreutils}/bin/chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa.pub
+            fi
+          '';
+
+        serviceConfig =
+          { ExecStart = "${pkgs.buildkite-agent}/bin/buildkite-agent start --config ${configFile}";
+            User = "buildkite-agent";
+            RestartSec = 5;
+            Restart = "on-failure";
+            TimeoutSec = 10;
+          };
+      };
+  };
+}

--- a/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-agent/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, makeWrapper, coreutils, git, openssh, bash, gnused, gnugrep }:
+
+stdenv.mkDerivation rec {
+  version = "2.1.8";
+  name = "buildkite-agent-${version}";
+  dontBuild = true;
+
+  src = fetchurl {
+    url = "https://github.com/buildkite/agent/releases/download/v${version}/buildkite-agent-linux-386-${version}.tar.gz";
+    sha256 = "f54ca7da4379180700f5038779a7cbb1cef31d49f4a06c42702d68c34387c242";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  sourceRoot = ".";
+  installPhase = ''
+    install -Dt "$out/bin/" buildkite-agent
+
+    mkdir -p $out/share
+    mv hooks bootstrap.sh $out/share/
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/bootstrap.sh \
+      --replace "#!/bin/bash" "#!$(type -P bash)"
+    wrapProgram $out/bin/buildkite-agent \
+      --set PATH '"${openssh}/bin/:${git}/bin:${coreutils}/bin:${gnused}/bin:${gnugrep}/bin:$PATH"'
+  '';
+
+  meta = {
+    description = "Build runner for buildkite.com";
+    longDescription = ''
+      The buildkite-agent is a small, reliable, and cross-platform build runner
+      that makes it easy to run automated builds on your own infrastructure.
+      It’s main responsibilities are polling buildkite.com for work, running
+      build jobs, reporting back the status code and output log of the job,
+      and uploading the job's artifacts.
+    '';
+    homepage = https://buildkite.com/docs/agent;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.pawelpacana ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5780,6 +5780,8 @@ in
     inherit (pythonPackages) twisted;
   };
 
+  buildkite-agent = callPackage ../development/tools/continuous-integration/buildkite-agent { };
+
   byacc = callPackage ../development/tools/parsing/byacc { };
 
   cargo = callPackage ../development/tools/build-managers/cargo {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The buildkite agent is a build runner for buildkite.com service
