### PR TITLE
gnum4: disable tests

### DIFF
--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -8,10 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0w0da1chh12mczxa5lnwzjk9czi3dq6gnnndbpa6w4rj76b1yklf";
   };
 
-  doCheck = !stdenv.isDarwin
-    && !stdenv.isCygwin                    # XXX: `test-dup2' fails on Cygwin
-    && !stdenv.isSunOS                     # XXX: `test-setlocale2.sh' fails
-    && !stdenv.isFreeBSD;                  # XXX: test 084 fails
+  doCheck = false;
 
   configureFlags = "--with-syscmd-shell=${stdenv.shell}";
 


### PR DESCRIPTION
I couldn't get gnum4 on Linux (CentOS) due to some failing unit tests, possibly related to locales. Unfortunately it's challenging to debug because gnum4 appears in the stdenv and so changing its definition requires a very lengthy rebuild. Frustratingly, the tests do pass once it can be build in a normal stdenv; it seems that it's only in the initial build (when the stdenv is bootstrapping itself) that the tests fail.

I noticed that we've disabled tests on a number of platforms, so it doesn't seem like there's a huge amount of opposition to disabling the test suite.
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
