### PR TITLE
httpretty: working build for python3

### DIFF
--- a/pkgs/development/python-modules/httpretty/setup.py.patch
+++ b/pkgs/development/python-modules/httpretty/setup.py.patch
@@ -1,0 +1,11 @@
+--- setup.py    2016-04-18 10:44:27.915536022 -0500
++++ setup-new.py           2016-04-18 10:44:13.515537377 -0500
+@@ -75,7 +75,7 @@
+
+
+ local_file = lambda *f: \
+-    open(os.path.join(os.path.dirname(__file__), *f)).read()
++    open(os.path.join(os.path.dirname(__file__), *f), encoding="utf-8").read()
+
+
+ install_requires, dependency_links = \

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10420,7 +10420,6 @@ in modules // {
   httpretty = buildPythonPackage rec {
     name = "httpretty-${version}";
     version = "0.8.6";
-    disabled = isPy3k;
     doCheck = false;
 
     src = pkgs.fetchurl {
@@ -10442,6 +10441,9 @@ in modules // {
       --- 566 ----
       !                 'content-length': str(len(self.body))
       DIFF
+
+      # Explicit encoding flag is required with python3, unless locale is set.
+      patch -p0 -i ${../development/python-modules/httpretty/setup.py.patch}
     '';
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10443,7 +10443,8 @@ in modules // {
       DIFF
 
       # Explicit encoding flag is required with python3, unless locale is set.
-      patch -p0 -i ${../development/python-modules/httpretty/setup.py.patch}
+      ${if !self.isPy3k then "" else
+        "patch -p0 -i ${../development/python-modules/httpretty/setup.py.patch}"}
     '';
 
     meta = {


### PR DESCRIPTION
This patch allows `httpretty` to be built with python3. Among other things, it allows boto to be built with python3.
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
