### PR TITLE
ordereddict: do not restrict to python2.6

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13659,8 +13659,8 @@ in modules // {
   # });
 
   ordereddict = buildPythonPackage rec {
-    name = "ordereddict-1.1";
-    disabled = !isPy26;
+    name = "ordereddict-${version}";
+    version = "1.1";
 
     src = pkgs.fetchurl {
       url = "http://pypi.python.org/packages/source/o/ordereddict/${name}.tar.gz";


### PR DESCRIPTION
@garbas 

It seems incorrect to restrict ordereddict to python 2.6, as it is meant to provide back-compatibility, so it's depended on by several packages which can be built from other python versions. I tested this with python2.7 and python3.4 and it works.
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
