### PR TITLE
boto3: enable unit tests, correct version of botocore

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2483,8 +2483,8 @@ in modules // {
       name = "botocore-${version}";
       version = "1.3.30";
       src = pkgs.fetchurl {
-        url = "https://pypi.python.org/packages/6c/79/5d3abfb9fffe4a8cb0a113f088c1012743cf40db805aaac625b2e3cf2111/botocore-1.3.30.tar.gz";
-        md5 = "0bbccf3385a0e509e5a674ddb2d27752";
+        url = "https://pypi.python.org/packages/source/b/botocore/${name}.tar.gz";
+        sha256 = "12c6xjvlvgaz6rlzfy6x1k7xan8lhxgw3c5bgh5dlpfhz7kf5m2v";
       };
     };
   in buildPythonPackage rec {


### PR DESCRIPTION
This allows boto3 to work (with unit tests) with python2.7 and python3.4.
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
