### PR TITLE
sqlalchemy: define sqlalchemy_1_0 attribute

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20940,7 +20940,9 @@ in modules // {
     };
   };
 
-  sqlalchemy = buildPythonPackage rec {
+  sqlalchemy = self.sqlalchemy_1_0;
+
+  sqlalchemy_1_0 = buildPythonPackage rec {
     name = "SQLAlchemy-${version}";
     version = "1.0.12";
 


### PR DESCRIPTION
For other packages where we have multiple versions (numpy, scipy, etc), we name the actual `buildPythonPackage` call with the version, and for the "default" version we point it at one of those versions. This applies the same rule to `sqlalchemy`, and also restores a previous interface (as it used to be the case that `pythonPackages.sqlalchemy_1_0` was a valid attribute path)
###### Things done
- [ ] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
