### PR TITLE
dbus-map: init 2015-05-28

### DIFF
--- a/pkgs/tools/misc/dbus-map/default.nix
+++ b/pkgs/tools/misc/dbus-map/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, glib, procps, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "dbus-map-${version}";
+  version = "2015-05-28";
+  src = fetchFromGitHub {
+    owner = "taviso";
+    repo = "dbusmap";
+    rev = "43703fc5e15743309b67131b5ba457b0d6ea7667";
+    sha256 = "1pjqn6w29ci8hfxkn1aynzfc8nvy3pqv3hixbxwr7qx20g4rwvdc";
+  };
+  buildInputs = [
+    pkgconfig glib procps libxml2
+  ];
+  installPhase = ''
+    mkdir -p $out/bin
+    mv dbus-map $out/bin
+  '';
+  meta = with lib; {
+    description = "Simple utility for enumerating D-Bus endpoints, an nmap for D-Bus";
+    homepage = "https://github.com/taviso/dbusmap";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16167,6 +16167,8 @@ in
     enableAllFeatures = true;
   });
 
+  dbus-map = callPackage ../tools/misc/dbus-map { };
+
   dosbox = callPackage ../misc/emulators/dosbox { };
 
   dpkg = callPackage ../tools/package-management/dpkg { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing (`nix-build --option build-use-sandbox true` or [nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
