### PR TITLE
ssh-agent module: run in foreground as upstream recommends

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -204,11 +204,11 @@ in
         serviceConfig =
           { ExecStartPre = "${pkgs.coreutils}/bin/rm -f %t/ssh-agent";
             ExecStart =
-                "${cfg.package}/bin/ssh-agent " +
+                "${cfg.package}/bin/ssh-agent -D " +
                 optionalString (cfg.agentTimeout != null) ("-t ${cfg.agentTimeout} ") +
                 "-a %t/ssh-agent";
             StandardOutput = "null";
-            Type = "forking";
+            Type = "simple";
             Restart = "on-failure";
             SuccessExitStatus = "0 2";
           };

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -207,6 +207,7 @@ in
                 "${cfg.package}/bin/ssh-agent -D " +
                 optionalString (cfg.agentTimeout != null) ("-t ${cfg.agentTimeout} ") +
                 "-a %t/ssh-agent";
+            ExecStartPost = "/bin/sh -c 'set -eu ; while [ ! -f $SSH_AUCK_SOCK ]; do sleep 1; done'";
             StandardOutput = "null";
             Type = "simple";
             Restart = "on-failure";

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -207,7 +207,7 @@ in
                 "${cfg.package}/bin/ssh-agent -D " +
                 optionalString (cfg.agentTimeout != null) ("-t ${cfg.agentTimeout} ") +
                 "-a %t/ssh-agent";
-            ExecStartPost = "/bin/sh -c 'set -eu ; while [ ! -f $SSH_AUCK_SOCK ]; do sleep 1; done'";
+            ExecStartPost = "/bin/sh -c 'set -eu ; while [ ! -S $SSH_AUCK_SOCK ]; do sleep 1; done'";
             StandardOutput = "null";
             Type = "simple";
             Restart = "on-failure";


### PR DESCRIPTION
I'm using it here and it works perfectly fine.

Systemd's official recommendation is that everything should run in the foreground.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
