### PR TITLE
antimicro 2.18 -> 2.18.2 (repository gone)

### DIFF
--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, cmake, pkgconfig, SDL2, qtbase, qttools, xorg, fetchzip }:
+{ stdenv, cmake, pkgconfig, SDL2, qtbase, qttools, xorg, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "antimicro-${version}";
-  version = "2.18";
+  version = "2.18.2";
 
-  src = fetchzip {
-    url    = "https://github.com/Ryochan7/antimicro/archive/${version}.tar.gz";
-    sha256 = "0kyl4xl2am50v2xscgy2irpcdj78f7flgfhljyjck4ynf8d40vb7";
+  src = fetchFromGitHub {
+    owner = "7185";
+    repo = "antimicro";
+    rev = "${version}";
+    sha256 = "1mqw5idn57yj6c1w8y0byzh0xafcpbhaa6czgljh206abwfixjmk";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

**I'm not a user of the software and I can not verify the sources.**

The original repo was deleted by it's author. I took the one with
the most recent releases I could find.
See:
https://github.com/Ryochan7/antimicro-packaging/issues/1#issuecomment-205949365
