### PR TITLE
Add new displaymanager: wtftw

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -480,6 +480,7 @@
   ./services/x11/window-managers/twm.nix
   ./services/x11/window-managers/windowlab.nix
   ./services/x11/window-managers/wmii.nix
+  ./services/x11/window-managers/wtftw.nix
   ./services/x11/window-managers/xmonad.nix
   ./services/x11/xfs.nix
   ./services/x11/xserver.nix

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -27,6 +27,7 @@ in
     ./twm.nix
     ./windowmaker.nix
     ./wmii.nix
+    ./wtftw.nix
     ./xmonad.nix
     ./qtile.nix
     ./none.nix ];

--- a/nixos/modules/services/x11/window-managers/wtftw.nix
+++ b/nixos/modules/services/x11/window-managers/wtftw.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.wtftw;
+in
+
+{
+  options = {
+    services.xserver.windowManager.wtftw.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Enable the wtftw window manager";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "wtftw";
+      start = "
+        ${pkgs.wtftw}/bin/wtftw
+      ";
+    };
+    environment.systemPackages = [ pkgs.wtftw ];
+  };
+}

--- a/pkgs/applications/window-managers/wtftw/default.nix
+++ b/pkgs/applications/window-managers/wtftw/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchgit, rustPlatform, cargo, libXinerama, libX11, xlibs, pkgconfig }:
+
+with import <nixpkgs> { }; with rustPlatform; with xlibs; with stdenv;
+#with rustPlatform;
+
+#with rustPlatform;
+
+buildRustPackage rec {
+  name = "wtftw";
+    src = fetchgit {
+    url = https://github.com/Kintaro/wtftw;
+    rev = "b84fdc04c100ed9d58fbcbd6af072ca553e810f4";
+    sha256 = "09vm2jbdlpamnyg62kzrxcym2cnaz0vcqd3awyiabq507sax6l8l";
+  };
+
+  depsSha256 = "0d0mxbinkryg2rfqwq3p4l49xc7jhrp4bkvxmqz4lr413wvhhbmk";
+
+  buildInputs = [ libXinerama libX11 pkgconfig ];
+  libPath = lib.makeLibraryPath [ libXinerama libX11 ];
+
+  preInstall = ''
+    cargo update
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/xsessions
+    cp -p target/release/wtftw $out/bin/
+    echo "[Desktop Entry]
+      Name=wtftw
+      Exec=/bin/wtftw
+      Type=XSession
+      DesktopName=wtftw" > $out/share/xsessions/wtftw.desktop
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tiling window manager in Rust";
+    homepage = https://github.com/Kintaro/wtftw;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16569,6 +16569,8 @@ in
   wmutils-core = callPackage ../tools/X11/wmutils-core { };
 
   wraith = callPackage ../applications/networking/irc/wraith { };
+  
+  wtftw = callPackage ../applications/window-managers/wtftw { };
 
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };
 


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Built from latest commit: b84fdc0  ( https://github.com/Kintaro/wtftw)
While it buils without error, using --check results in the following error 

> error: derivation ‘/nix/store/pkn17n2n3bn8wxqik46h3kz5akk24rdw-wtftw.drv’ may not be deterministic: output ‘/nix/store/x8qscv3snig2c5ma5zf26g4s0mminmv1-wtftw’ differs

I am not sure how to go about fixing this issue
