### PR TITLE
Python: use PyPI mirror

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -108,7 +108,7 @@ toolz = buildPythonPackage rec{
   version = "0.7.4";
 
   src = pkgs.fetchurl{
-    url = "https://pypi.python.org/packages/source/t/toolz/toolz-${version}.tar.gz";
+    url = "mirror://pypi/t/toolz/toolz-${version}.tar.gz";
     sha256 = "43c2c9e5e7a16b6c88ba3088a9bfc82f7db8e13378be7c78d6c14a5f8ed05afd";
   };
 
@@ -146,7 +146,7 @@ pkgs.python35Packages.buildPythonPackage rec {
   version = "0.7.4";
 
   src = pkgs.fetchurl{
-    url = "https://pypi.python.org/packages/source/t/toolz/toolz-${version}.tar.gz";
+    url = "mirror://pypi/t/toolz/toolz-${version}.tar.gz";
     sha256 = "43c2c9e5e7a16b6c88ba3088a9bfc82f7db8e13378be7c78d6c14a5f8ed05afd";
   };
 
@@ -175,7 +175,7 @@ with import <nixpkgs> {};
       version = "0.7.4";
 
       src = pkgs.fetchurl{
-        url = "https://pypi.python.org/packages/source/t/toolz/toolz-${version}.tar.gz";
+        url = "mirror://pypi/t/toolz/toolz-${version}.tar.gz";
         sha256 = "43c2c9e5e7a16b6c88ba3088a9bfc82f7db8e13378be7c78d6c14a5f8ed05afd";
       };
 
@@ -220,7 +220,7 @@ datashape = buildPythonPackage rec {
   version = "0.4.7";
 
   src = pkgs.fetchurl {
-    url = "https://pypi.python.org/packages/source/D/DataShape/${name}.tar.gz";
+    url = "mirror://pypi/D/DataShape/${name}.tar.gz";
     sha256 = "14b2ef766d4c9652ab813182e866f493475e65e558bed0822e38bf07bba1a278";
   };
 
@@ -251,7 +251,7 @@ lxml = buildPythonPackage rec {
   name = "lxml-3.4.4";
 
   src = pkgs.fetchurl {
-    url = "http://pypi.python.org/packages/source/l/lxml/${name}.tar.gz";
+    url = "mirror://pypi/l/lxml/${name}.tar.gz";
     sha256 = "16a0fa97hym9ysdk3rmqz32xdjqmy4w34ld3rm3jf5viqjx65lxk";
   };
 
@@ -282,7 +282,7 @@ pyfftw = buildPythonPackage rec {
   version = "0.9.2";
 
   src = pkgs.fetchurl {
-    url = "https://pypi.python.org/packages/source/p/pyFFTW/pyFFTW-${version}.tar.gz";
+    url = "mirror://pypi/p/pyFFTW/pyFFTW-${version}.tar.gz";
     sha256 = "f6bbb6afa93085409ab24885a1a3cdb8909f095a142f4d49e346f2bd1b789074";
   };
 
@@ -373,7 +373,7 @@ buildPythonPackage rec {
   version = "0.7.4";
 
   src = pkgs.fetchurl{
-    url = "https://pypi.python.org/packages/source/t/toolz/toolz-${version}.tar.gz";
+    url = "mirror://pypi/t/toolz/toolz-${version}.tar.gz";
     sha256 = "43c2c9e5e7a16b6c88ba3088a9bfc82f7db8e13378be7c78d6c14a5f8ed05afd";
   };
 

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -5,7 +5,7 @@ let
     version = "0.1.7";
     name = "jsonrpclib-${version}";
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jsonrpclib/${name}.tar.gz";
+      url = "mirror://pypi/j/jsonrpclib/${name}.tar.gz";
       sha256 = "02vgirw2bcgvpcxhv5hf3yvvb4h5wzd1lpjx8na5psdmaffj6l3z";
     };
     propagatedBuildInputs = [ pythonPackages.cjson ];

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -5,7 +5,7 @@ python3Packages.buildPythonApplication rec {
   name = "khal-${version}";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/k/khal/khal-${version}.tar.gz";
+    url = "mirror://pypi/k/khal/khal-${version}.tar.gz";
     sha256 = "00llxj7cv31mjsx0j6zxmyi9s1q20yvfkn025xcy8cv1ylfwic66";
   };
 

--- a/pkgs/applications/misc/pitz/default.nix
+++ b/pkgs/applications/misc/pitz/default.nix
@@ -16,7 +16,7 @@ buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://pypi.python.org/packages/source/p/pitz/${name}.tar.gz";
+    url = "mirror://pypi/p/pitz/${name}.tar.gz";
     sha256 = "1k7f3h4acllzqy3mjqnjd4w5jskp03s79b7dx3c85vlmd7824smr";
   };
 

--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -13,7 +13,7 @@ buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/s/spyder/${name}.zip";
+    url = "mirror://pypi/s/spyder/${name}.zip";
     sha256 = "99fdae2cea325c0f2842c77bd67dd22db19fef3d9c0dde1545b1a2650eae517e";
   };
 

--- a/pkgs/applications/version-management/bugseverywhere/default.nix
+++ b/pkgs/applications/version-management/bugseverywhere/default.nix
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
 
     src = fetchurl {
       url =
-      "https://pypi.python.org/packages/source/b/bugs-everywhere/bugs-everywhere-${version}.tar.gz";
+      "mirror://pypi/b/bugs-everywhere/bugs-everywhere-${version}.tar.gz";
       sha256 = "1ikm3ckwpimwcvx32vy7gh5gbp7q750j3327m17nvrj99g3daz2d";
     };
 

--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -7,7 +7,7 @@ python3Packages.buildPythonApplication rec {
   disabled = !python3Packages.isPy3k;
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/i/${pname}/${name}.tar.gz";
+    url = "mirror://pypi/i/${pname}/${name}.tar.gz";
     sha256 = "1bpkkf9q4zqq7fh65zynbv26nq24rfznmw71jjvda7g8kjrwjdk5";
   };
 

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -340,4 +340,9 @@ rec {
     http://repo.steampowered.com/steamrt/
     https://abbradar.net/steamrt/
   ];
+
+  # Python PyPI mirrors
+  pypi = [
+    https://pypi.io/packages/source/
+  ];
 }

--- a/pkgs/development/arduino/ino/default.nix
+++ b/pkgs/development/arduino/ino/default.nix
@@ -6,7 +6,7 @@ buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://pypi.python.org/packages/source/i/ino/${name}.tar.gz";
+    url = "mirror://pypi/i/ino/${name}.tar.gz";
     sha256 = "0k6lzfcn55favbj0w4afrvnmwyskf7bgzg9javv2ycvskp35srwv";
   };
 

--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -42,7 +42,7 @@ let
   
   virtualenvVersion = "1.11.6";
   virtualenv = fetchurl {
-    url = "https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${virtualenvVersion}.tar.gz";
+    url = "mirror://pypi/v/virtualenv/virtualenv-${virtualenvVersion}.tar.gz";
     sha256 = "1xq4prmg25n9cz5zcvbqx68lmc3kl39by582vd8pzs9f3qalqyiy";
   };
 in

--- a/pkgs/development/python-modules/buildout-nix/default.nix
+++ b/pkgs/development/python-modules/buildout-nix/default.nix
@@ -4,7 +4,7 @@ buildPythonPackage {
   name = "zc.buildout-nix-2.5.0";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/z/zc.buildout/zc.buildout-2.5.0.tar.gz";
+    url = "mirror://pypi/z/zc.buildout/zc.buildout-2.5.0.tar.gz";
     sha256 = "721bd2231a9f01f2d5c14f3adccb3385f85b093ee05b18d15d0ff2b9f1f1bd02";
   };
 

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   version = "2.5.0";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/h/h5py/${name}.tar.gz";
+    url = "mirror://pypi/h/h5py/${name}.tar.gz";
     sha256 = "9833df8a679e108b561670b245bcf9f3a827b10ccb3a5fa1341523852cfac2f6";
   };
 

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   version = "1.5.1";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/m/matplotlib/${name}.tar.gz";
+    url = "mirror://pypi/m/matplotlib/${name}.tar.gz";
     sha256 = "3ab8d968eac602145642d0db63dd8d67c85e9a5444ce0e2ecb2a8fedc7224d40";
   };
 

--- a/pkgs/development/python-modules/pycrypto/default.nix
+++ b/pkgs/development/python-modules/pycrypto/default.nix
@@ -5,7 +5,7 @@ buildPythonPackage rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://pypi.python.org/packages/source/p/pycrypto/${name}.tar.gz";
+    url = "mirror://pypi/p/pycrypto/${name}.tar.gz";
     sha256 = "0g0ayql5b9mkjam8hym6zyg6bv77lbh66rv1fyvgqb17kfc1xkpj";
   };
 

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "19.4";  # 18.4 and up breaks python34Packages.characteristic and many others
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/s/setuptools/${shortName}.tar.gz";
+    url = "mirror://pypi/s/setuptools/${shortName}.tar.gz";
     sha256 = "214bf29933f47cf25e6faa569f710731728a07a19cae91ea64f826051f68a8cf";
   };
 

--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -6,7 +6,7 @@ buildPythonPackage rec {
   name = "tables-${version}";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/t/tables/${name}.tar.gz";
+    url = "mirror://pypi/t/tables/${name}.tar.gz";
     sha256 = "3564b351a71ec1737b503b001eb7ceae1f65d5d6e3ffe1ea75aafba10f37fa84";
   };
 

--- a/pkgs/development/python-modules/yolk/default.nix
+++ b/pkgs/development/python-modules/yolk/default.nix
@@ -7,7 +7,7 @@ buildPythonApplication rec {
   version = "0.4.3";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/y/yolk/yolk-${version}.tar.gz";
+    url = "mirror://pypi/y/yolk/yolk-${version}.tar.gz";
     sha256 = "1f6xwx210jnl5nq0m3agh2p1cxmaizawaf3fwq43q4yw050fn1qw";
   };
 

--- a/pkgs/development/tools/build-managers/buildbot-slave/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot-slave/default.nix
@@ -5,7 +5,7 @@ buildPythonApplication (rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/b/buildbot-slave/${name}.tar.gz";
+    url = "mirror://pypi/b/buildbot-slave/${name}.tar.gz";
     sha256 = "09pncw44c7vqrl7zyn1nvfismiqi9s51axk9cqxn9gq7jhj38mpg";
   };
 

--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -13,7 +13,7 @@ buildPythonApplication (rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/b/buildbot/${name}.tar.gz";
+    url = "mirror://pypi/b/buildbot/${name}.tar.gz";
     sha256 = "1mn4h04sp6smr3ahqfflys15cpn13q9mfkapcs2jc4ppvxv6kdn6";
   };
 

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -5,7 +5,7 @@ pythonPackages.buildPythonApplication rec {
   version = "2.3.2";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/d/devpi-client/devpi-client-${version}.tar.gz";
+    url = "mirror://pypi/d/devpi-client/devpi-client-${version}.tar.gz";
     md5= "bfc8cd768f983fd0585c347bca00c8bb";
   };
 

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -5,7 +5,7 @@ let
     version = "0.6.8";
 
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/m/matrix-angular-sdk/matrix-angular-sdk-${version}.tar.gz";
+      url = "mirror://pypi/m/matrix-angular-sdk/matrix-angular-sdk-${version}.tar.gz";
       sha256 = "0gmx4y5kqqphnq3m7xk2vpzb0w2a4palicw7wfdr1q2schl9fhz2";
     };
   };

--- a/pkgs/tools/admin/cli53/default.nix
+++ b/pkgs/tools/admin/cli53/default.nix
@@ -6,7 +6,7 @@ buildPythonApplication rec {
   version = "0.4.4";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/c/cli53/${name}.tar.gz";
+    url = "mirror://pypi/c/cli53/${name}.tar.gz";
     sha256 = "0s9jzigq6a16m2c3qklssx2lz16cf13g5zh80vh24kxazaxqzbig";
   };
 

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
   disabled = pythonPackages.isPy3k;
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/s/salt/${name}.tar.gz";
+    url = "mirror://pypi/s/salt/${name}.tar.gz";
     sha256 = "1xcfcs50pyammb60myph4f8bi2r6iwkxwsnnhrjwvkv2ymxwxv5j";
   };
 

--- a/pkgs/tools/admin/salt/testing.nix
+++ b/pkgs/tools/admin/salt/testing.nix
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/S/SaltTesting/${name}.tar.gz";
+    url = "mirror://pypi/S/SaltTesting/${name}.tar.gz";
     sha256 = "0p0y8kb77pis18rcig1kf9dnns4bnfa3mr91q40lq4mw63l1b34h";
   };
 

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -6,7 +6,7 @@ python3Packages.buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/b/borgbackup/borgbackup-${version}.tar.gz";
+    url = "mirror://pypi/b/borgbackup/borgbackup-${version}.tar.gz";
     sha256 = "1myz10pwxnac9z59gw1w3xjhz6ghx03vngpl97ca527pj0r39shi";
   };
 

--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -5,7 +5,7 @@ pythonPackages.buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://pypi.python.org/packages/source/h/httpie/${name}.tar.gz";
+    url = "mirror://pypi/h/httpie/${name}.tar.gz";
     sha256 = "0s0dsj1iimn17h0xyziwk4kz4ga9s0vy9rhzixh8dna32za84fdg";
   };
 

--- a/pkgs/tools/networking/speedtest-cli/default.nix
+++ b/pkgs/tools/networking/speedtest-cli/default.nix
@@ -5,7 +5,7 @@ pythonPackages.buildPythonApplication rec {
   version = "0.3.4";
   
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/s/speedtest-cli/speedtest-cli-${version}.tar.gz";
+    url = "mirror://pypi/s/speedtest-cli/speedtest-cli-${version}.tar.gz";
     sha256 = "19i671cd815fcv0x7h2m0a493slzwkzn7r926g8myx1srkss0q6d";
   };
 

--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -6,7 +6,7 @@ pythonPackages.buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/n/nix-nox/nix-nox-${version}.tar.gz";
+    url = "mirror://pypi/n/nix-nox/nix-nox-${version}.tar.gz";
     sha256 = "1wpxh5fhj8nx4yx4cvmc087cnf4iqwxf7zd7rdh2ln3pgxrjfral";
   };
 

--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -7,7 +7,7 @@ pythonPackages.buildPythonApplication rec {
 
   src = fetchurl {
     sha256 = "18hrwi2gyri1n2rq0nghvv7hfhbhh5h67am89524vc1yyx40vn3b";
-    url = "https://pypi.python.org/packages/source/s/sshuttle/${name}.tar.gz";
+    url = "mirror://pypi/s/sshuttle/${name}.tar.gz";
   };
 
   patches = [ ./sudo.patch ];

--- a/pkgs/tools/text/grin/default.nix
+++ b/pkgs/tools/text/grin/default.nix
@@ -5,7 +5,7 @@ pythonPackages.buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/source/g/grin/${name}.tar.gz";
+    url = "mirror://pypi/g/grin/${name}.tar.gz";
     sha256 = "1swzwb17wibam8jszdv98h557hlx44pg6psv6rjz7i33qlxk0fdz";
   };
 

--- a/pkgs/tools/video/vnc2flv/default.nix
+++ b/pkgs/tools/video/vnc2flv/default.nix
@@ -5,7 +5,7 @@ pythonPackages.buildPythonApplication rec {
   namePrefix = "";
 
   src = fetchurl {
-    url = "http://pypi.python.org/packages/source/v/vnc2flv/${name}.tar.gz";
+    url = "mirror://pypi/v/vnc2flv/${name}.tar.gz";
     sha256 = "14d4nm8yim0bm0nd3wyj7z4zdsg5zk3d9bhhvwdc36x03r8d0sbq";
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -106,7 +106,7 @@ in modules // {
     };
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/discid/${name}.tar.gz";
+      url = "mirror://pypi/d/discid/${name}.tar.gz";
       sha256 = "b39d443051b26d0230be7a6c616243daae93337a8711dd5d4119bb6a0e516fa8";
     };
 
@@ -203,7 +203,7 @@ in modules // {
     name = "aafigure-0.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/aafigure/${name}.tar.gz";
+      url = "mirror://pypi/a/aafigure/${name}.tar.gz";
       sha256 = "090c88beb091d28a233f854e239713aa15d8d1906ea16211855345c912e8a091";
     };
 
@@ -335,7 +335,7 @@ in modules // {
     name = "actdiag-0.5.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/actdiag/${name}.tar.gz";
+      url = "mirror://pypi/a/actdiag/${name}.tar.gz";
       sha256 = "1vr4hnkr0gcvvpaycd8q3vcx029b2f5yv8swhdr8kwspaqb0dvfa";
     };
 
@@ -361,7 +361,7 @@ in modules // {
     name = "adal-${version}";
 
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/adal/adal-0.1.0.tar.gz;
+      url = mirror://pypi/a/adal/adal-0.1.0.tar.gz;
       sha256 = "1f32k18ck54adqlgvh6fjhy4yavcyrwy813prjyqppqqq4bn1a09";
     };
 
@@ -415,7 +415,7 @@ in modules // {
     version = "1.0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/aiodns/${name}.tar.gz";
+      url = "mirror://pypi/a/aiodns/${name}.tar.gz";
       sha256 = "595b78b8d54115d937cf60d778c02dad76b6f789fd527dab308f99e5601e7f3d";
     };
 
@@ -440,7 +440,7 @@ in modules // {
     version = "0.21.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/aiohttp/${name}.tar.gz";
+      url = "mirror://pypi/a/aiohttp/${name}.tar.gz";
       sha256 = "0n8517wc8b6yc925f7zhgl4wqf4ay1w2fzar0pj1h20yfa1wiids";
     };
 
@@ -462,7 +462,7 @@ in modules // {
     name = "alabaster-0.7.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/alabaster/${name}.tar.gz";
+      url = "mirror://pypi/a/alabaster/${name}.tar.gz";
       sha256 = "f416a84e0d0ddbc288f6b8f2c276d10b40ca1238562cd9ed5a751292ec647b71";
     };
 
@@ -483,7 +483,7 @@ in modules // {
     name = "alembic-0.8.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/alembic/${name}.tar.gz";
+      url = "mirror://pypi/a/alembic/${name}.tar.gz";
       sha256 = "1sgwvwylzd5h14130mwr0cbyy0fil0a1bq0d0ki97wqvkic3db7f";
     };
 
@@ -502,7 +502,7 @@ in modules // {
     version = "0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-editor/${name}.tar.gz";
+      url = "mirror://pypi/p/python-editor/${name}.tar.gz";
       sha256 = "1gykxn16anmsbcrwhx3rrhwjif95mmwvq9gjcrr9bbzkdc8sf8a4";
     };
 
@@ -517,7 +517,7 @@ in modules // {
     version = "0.3.8";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/p/python-gnupg/${name}.tar.gz";
+      url    = "mirror://pypi/p/python-gnupg/${name}.tar.gz";
       sha256 = "0nkbs9c8f30lra7ca39kg91x8cyxn0jb61vih4qky839gpbwwwiq";
     };
 
@@ -540,7 +540,7 @@ in modules // {
     name = "almir-0.1.8";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/a/almir/${name}.zip";
+      url = "mirror://pypi/a/almir/${name}.zip";
       sha256 = "5dc0b8a5071f3ff46cd2d92608f567ba446e4c733c063b17d89703caeb9868fe";
     };
 
@@ -634,7 +634,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/a/anyjson/${name}.tar.gz";
+      url = "mirror://pypi/a/anyjson/${name}.tar.gz";
       sha256 = "37812d863c9ad3e35c0734c42e0bf0320ce8c3bed82cd20ad54cb34d158157ba";
     };
 
@@ -653,7 +653,7 @@ in modules // {
     disabled = pythonOlder "2.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/amqp/${name}.tar.gz";
+      url = "mirror://pypi/a/amqp/${name}.tar.gz";
       sha256 = "06n6q0kxhjnbfz3vn8x9yz09lwmn1xi9d6wxp31h5jbks0b4vsid";
     };
 
@@ -752,7 +752,7 @@ in modules // {
     name = "apipkg-1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/apipkg/${name}.tar.gz";
+      url = "mirror://pypi/a/apipkg/${name}.tar.gz";
       sha256 = "2e38399dbe842891fe85392601aab8f40a8f4cc5a9053c326de35a1cc0297ac6";
     };
 
@@ -769,7 +769,7 @@ in modules // {
     name = "appdirs-1.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/appdirs/appdirs-1.4.0.tar.gz";
+      url = "mirror://pypi/a/appdirs/appdirs-1.4.0.tar.gz";
       sha256 = "8fc245efb4387a4e3e0ac8ebcc704582df7d72ff6a42a53f5600bbb18fdaadc5";
     };
 
@@ -800,7 +800,7 @@ in modules // {
     name = "appnope-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/appnope/${name}.tar.gz";
+      url = "mirror://pypi/a/appnope/${name}.tar.gz";
       sha256 = "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71";
     };
 
@@ -838,7 +838,7 @@ in modules // {
 
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/asyncio/${name}.tar.gz";
+      url = "mirror://pypi/a/asyncio/${name}.tar.gz";
       sha256 = "0hfbqwk9y0bbfgxzg93s2wyk6gcjsdxlr5jwy97hx64ppkw0ydl3";
     };
 
@@ -853,7 +853,7 @@ in modules // {
     name = "funcsigs-0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/funcsigs/${name}.tar.gz";
+      url = "mirror://pypi/f/funcsigs/${name}.tar.gz";
       sha256 = "d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033";
     };
 
@@ -874,7 +874,7 @@ in modules // {
     disabled = !isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/A/APScheduler/${name}.tar.gz";
+      url = "mirror://pypi/A/APScheduler/${name}.tar.gz";
       sha256 = "1ljjhn6cv8b1pccsi3mgc887ypi2vim317r9p0zh0amd0bhkk6wb";
     };
 
@@ -907,7 +907,7 @@ in modules // {
     name = "args-0.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/args/${name}.tar.gz";
+      url = "mirror://pypi/a/args/${name}.tar.gz";
       sha256 = "a785b8d837625e9b61c39108532d95b85274acd679693b71ebb5156848fcf814";
     };
 
@@ -921,7 +921,7 @@ in modules // {
     name = "Area53-0.94";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/A/Area53/${name}.tar.gz";
+      url = "mirror://pypi/A/Area53/${name}.tar.gz";
       sha256 = "0v9b7f8b6v21y410anx5sr52k2ac8jrzdf19q6m6p0zsdsf9vr42";
     };
 
@@ -937,7 +937,7 @@ in modules // {
     version = "1.1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/chai/${name}.tar.gz";
+      url = "mirror://pypi/c/chai/${name}.tar.gz";
       sha256 = "016kf3irrclpkpvcm7q0gmkfibq7jgy30a9v73pp42bq9h9a32bl";
     };
 
@@ -951,7 +951,7 @@ in modules // {
     version = "0.7.0";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/a/arrow/${name}.tar.gz";
+      url    = "mirror://pypi/a/arrow/${name}.tar.gz";
       sha256 = "0yx10dz3hp825fcq9w15zbp26v622npcjscb91da05zig8036lra";
     };
 
@@ -978,7 +978,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/async/${name}.tar.gz";
+      url = "mirror://pypi/a/async/${name}.tar.gz";
       sha256 = "1lfmjm8apy9qpnpbq8g641fd01qxh9jlya5g2d6z60vf8p04rla1";
     };
   };
@@ -988,7 +988,7 @@ in modules // {
     name = "atomiclong-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/atomiclong/atomiclong-${version}.tar.gz";
+      url = "mirror://pypi/a/atomiclong/atomiclong-${version}.tar.gz";
       sha256 = "1gjbc9lvpkgg8vj7dspif1gz9aq4flkhxia16qj6yvb7rp27h4yb";
     };
     buildInputs = with self; [ pytest ];
@@ -1008,7 +1008,7 @@ in modules // {
     name = "atomicwrites-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/atomicwrites/atomicwrites-${version}.tar.gz";
+      url = "mirror://pypi/a/atomicwrites/atomicwrites-${version}.tar.gz";
       sha256 = "08s05h211r07vs66r4din3swrbzb344vli041fihpg34q3lcxpvw";
     };
 
@@ -1024,7 +1024,7 @@ in modules // {
     name = "argparse-1.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/argparse/${name}.tar.gz";
+      url = "mirror://pypi/a/argparse/${name}.tar.gz";
       sha256 = "1r6nznp64j68ih1k537wms7h57nvppq0szmwsaf99n71bfjqkc32";
     };
 
@@ -1057,7 +1057,7 @@ in modules // {
     propagatedBuildInputs = with self; [ logilab_common six lazy-object-proxy wrapt ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/astroid/${name}.tar.gz";
+      url = "mirror://pypi/a/astroid/${name}.tar.gz";
       sha256 = "7f7e5512efe515098e77cbd3a60e87c8db8954097b0e025d8d6f72f2e8ddc298";
     };
 
@@ -1079,7 +1079,7 @@ in modules // {
     name = "attrdict-2.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/attrdict/${name}.tar.gz";
+      url = "mirror://pypi/a/attrdict/${name}.tar.gz";
       sha256 = "86aeb6d3809e0344409f8148d7cac9eabce5f0b577c160b5e90d10df3f8d2ad3";
     };
 
@@ -1097,7 +1097,7 @@ in modules // {
     version = "2.1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/audioread/${name}.tar.gz";
+      url = "mirror://pypi/a/audioread/${name}.tar.gz";
       sha256 = "ffb601de7a9e40850d4ec3256a3a6bbe8fa40466dafb5c65f41b08e4bb963f1e";
     };
 
@@ -1131,7 +1131,7 @@ in modules // {
     name = "autopep8-1.0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/autopep8/${name}.tar.gz";
+      url = "mirror://pypi/a/autopep8/${name}.tar.gz";
       sha256 = "17lydqm8y9a5qadp6iifxrb5mb0g9fr1vxn5qy1fjpyhazxaw8n1";
     };
 
@@ -1155,7 +1155,7 @@ in modules // {
     version = "0.2.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/av/${name}.tar.gz";
+      url = "mirror://pypi/a/av/${name}.tar.gz";
       sha256 = "bdc7e2e213cb9041d9c5c0497e6f8c47e84f89f1f2673a46d891cca0fb0d19a0";
     };
 
@@ -1179,7 +1179,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/avro/${name}.tar.gz";
+      url = "mirror://pypi/a/avro/${name}.tar.gz";
       sha256 = "edf14143cabb2891f05a73d60a57a9fc5a9ebd305c2188abb3f5db777c707ad5";
     };
 
@@ -1195,7 +1195,7 @@ in modules // {
     disabled = (!isPy3k);
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/avro3k/${name}.tar.gz";
+      url = "mirror://pypi/a/avro3k/${name}.tar.gz";
       sha256 = "15ahl0irwwj558s964abdxg4vp6iwlabri7klsm2am6q5r0ngsky";
     };
 
@@ -1212,7 +1212,7 @@ in modules // {
     version = "1.6.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/awesome-slugify/${name}.tar.gz";
+      url = "mirror://pypi/a/awesome-slugify/${name}.tar.gz";
       sha256 = "0wgxrhr8s5vk2xmcz9s1z1aml4ppawmhkbggl9rp94c747xc7pmv";
     };
 
@@ -1232,7 +1232,7 @@ in modules // {
     version = "1.10.18";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/awscli/${name}.tar.gz";
+      url = "mirror://pypi/a/awscli/${name}.tar.gz";
       sha256 = "0vdj7p4cwsbzhanhp5f2c0b0qr2gh76dyanji73avvj4jvdb5d4g";
     };
 
@@ -1272,7 +1272,7 @@ in modules // {
     version = "0.1.0";
     src = pkgs.fetchurl {
         sha256 = "05isyrqbk16dg1bc3mnc4ynxr3nchslvia5wr1sdmxvc3v2y729d";
-        url = "https://pypi.python.org/packages/source/a/aws-shell/aws-shell-0.1.0.tar.gz";
+        url = "mirror://pypi/a/aws-shell/aws-shell-0.1.0.tar.gz";
       };
     propagatedBuildInputs = with self; [
       configobj prompt_toolkit_52 awscli boto3 pygments sqlite3 mock pytest
@@ -1303,7 +1303,7 @@ in modules // {
     disabled = pythonOlder "2.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/azure/${name}.zip";
+      url = "mirror://pypi/a/azure/${name}.zip";
       sha256 = "89c20b2efaaed3c6f56345d55c32a8d4e7d2a16c032d0acb92f8f490c508fe24";
     };
 
@@ -1321,7 +1321,7 @@ in modules // {
     version = "1.0.0";
     name = "azure-nspkg-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-nspkg/azure-nspkg-1.0.0.zip;
+      url = mirror://pypi/a/azure-nspkg/azure-nspkg-1.0.0.zip;
       sha256 = "1xqvc8by1lbd7j9dxyly03jz3rgbmnsiqnqgydhkf4pa2mn2hgr9";
     };
     meta = {
@@ -1337,7 +1337,7 @@ in modules // {
     name = "azure-common-${version}";
     disabled = isPyPy;
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-common/azure-common-1.0.0.zip;
+      url = mirror://pypi/a/azure-common/azure-common-1.0.0.zip;
       sha256 = "074rwwy8zzs7zw3nww5q2wg5lxgdc4rmypp2gfc9mwsz0gb70491";
     };
     propagatedBuildInputs = with self; [ azure-nspkg ];
@@ -1356,7 +1356,7 @@ in modules // {
     version = "0.20.0";
     name = "azure-mgmt-common-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-mgmt-common/azure-mgmt-common-0.20.0.zip;
+      url = mirror://pypi/a/azure-mgmt-common/azure-mgmt-common-0.20.0.zip;
       sha256 = "1rmzpz3733wv31rsnqpdy4bbafvk5dhbqx7q0xf62dlz7p0i4f66";
     };
     propagatedBuildInputs = with self; [ azure-common azure-mgmt-nspkg requests2 ];
@@ -1376,7 +1376,7 @@ in modules // {
     version = "0.20.0";
     name = "azure-mgmt-compute-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-mgmt-compute/azure-mgmt-compute-0.20.0.zip;
+      url = mirror://pypi/a/azure-mgmt-compute/azure-mgmt-compute-0.20.0.zip;
       sha256 = "12hr5vxdg2sk2fzr608a37f4i8nbchca7dgdmly2w5fc7x88jx2v";
     };
     postInstall = ''
@@ -1396,7 +1396,7 @@ in modules // {
     version = "0.20.1";
     name = "azure-mgmt-network-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-mgmt-network/azure-mgmt-network-0.20.1.zip;
+      url = mirror://pypi/a/azure-mgmt-network/azure-mgmt-network-0.20.1.zip;
       sha256 = "10vj22h6nxpw0qpvib5x2g6qs5j8z31142icvh4qk8k40fcrs9hx";
     };
     postInstall = ''
@@ -1416,7 +1416,7 @@ in modules // {
     version = "1.0.0";
     name = "azure-mgmt-nspkg-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-mgmt-nspkg/azure-mgmt-nspkg-1.0.0.zip;
+      url = mirror://pypi/a/azure-mgmt-nspkg/azure-mgmt-nspkg-1.0.0.zip;
       sha256 = "1rq92fj3kvnqkk18596dybw0kvhgscvc6cd8hp1dhy3wrkqnhwmq";
     };
     propagatedBuildInputs = with self; [ azure-nspkg ];
@@ -1432,7 +1432,7 @@ in modules // {
     version = "0.20.1";
     name = "azure-mgmt-resource-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-mgmt-resource/azure-mgmt-resource-0.20.1.zip;
+      url = mirror://pypi/a/azure-mgmt-resource/azure-mgmt-resource-0.20.1.zip;
       sha256 = "0slh9qfm5nfacrdm3lid0sr8kwqzgxvrwf27laf9v38kylkfqvml";
     };
     postInstall = ''
@@ -1452,7 +1452,7 @@ in modules // {
     version = "0.20.0";
     name = "azure-mgmt-storage-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-mgmt-storage/azure-mgmt-storage-0.20.0.zip;
+      url = mirror://pypi/a/azure-mgmt-storage/azure-mgmt-storage-0.20.0.zip;
       sha256 = "16iw7hqhq97vlzfwixarfnirc60l5mz951p57brpcwyylphl3yim";
     };
     postInstall = ''
@@ -1472,7 +1472,7 @@ in modules // {
     version = "0.20.3";
     name = "azure-storage-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-storage/azure-storage-0.20.3.zip;
+      url = mirror://pypi/a/azure-storage/azure-storage-0.20.3.zip;
       sha256 = "06bmw6k2000kln5jwk5r9bgcalqbyvqirmdh9gq4s6nb4fv3c0jb";
     };
     propagatedBuildInputs = with self; [ azure-common futures dateutil requests2 ];
@@ -1491,7 +1491,7 @@ in modules // {
     version = "0.20.1";
     name = "azure-servicemanagement-legacy-${version}";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/azure-servicemanagement-legacy/azure-servicemanagement-legacy-0.20.1.zip;
+      url = mirror://pypi/a/azure-servicemanagement-legacy/azure-servicemanagement-legacy-0.20.1.zip;
       sha256 = "17dwrp99sx5x9cm4vldkaxhki9gbd6dlafa0lpr2n92xhh2838zs";
     };
     propagatedBuildInputs = with self; [ azure-common requests2 ];
@@ -1510,7 +1510,7 @@ in modules // {
     name = "backports.ssl_match_hostname-3.4.0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz";
+      url = "mirror://pypi/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz";
       sha256 = "07410e7fb09aab7bdaf5e618de66c3dac84e2e3d628352814dc4c37de321d6ae";
     };
 
@@ -1525,7 +1525,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/backports.lzma/${name}.tar.gz";
+      url = "mirror://pypi/b/backports.lzma/${name}.tar.gz";
       sha256 = "bac58aec8d39ac3d22250840fb24830d0e4a0ef05ad8f3f09172dc0cc80cdbca";
     };
 
@@ -1544,7 +1544,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/babelfish/${name}.tar.gz";
+      url = "mirror://pypi/b/babelfish/${name}.tar.gz";
       sha256 = "0wrw21dyq7v6lbffwvi1ik43d7dhmcv8xvgrrihhiv7ys1rd3gag";
     };
 
@@ -1562,7 +1562,7 @@ in modules // {
     disabled = isPy26 || isPy27 || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/b/${pname}/${name}.tar.gz";
       sha256 = "1ajmflvvlkflrcmqmkrx0zaira84z8kv4ssb2jprfwvjh8vfkysb";
     };
 
@@ -1582,7 +1582,7 @@ in modules // {
     name = "batinfo-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/batinfo/${name}.tar.gz";
+      url = "mirror://pypi/b/batinfo/${name}.tar.gz";
       sha256 = "0gyzkxzvj5l6qrw706bnm3cckqzzzbrjr7jkxc087d7775a73499";
     };
 
@@ -1602,7 +1602,7 @@ in modules // {
     name = "bcdoc-0.14.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bcdoc/${name}.tar.gz";
+      url = "mirror://pypi/b/bcdoc/${name}.tar.gz";
       sha256 = "1s2kdqs1n2mj7wq3w0pq30zs7vxq0l3abik2clqnc4hm2j7crbk8";
     };
 
@@ -1638,7 +1638,7 @@ in modules // {
     name = "beautifulsoup4-4.4.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/b/beautifulsoup4/${name}.tar.gz";
+      url = "mirror://pypi/b/beautifulsoup4/${name}.tar.gz";
       sha256 = "1d36lc4pfkvl74fmzdib2nqnvknm0jddgf2n9yd7im150qyh3m47";
     };
 
@@ -1660,7 +1660,7 @@ in modules // {
     name = "beautifulsoup4-4.1.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/b/beautifulsoup4/${name}.tar.gz";
+      url = "mirror://pypi/b/beautifulsoup4/${name}.tar.gz";
       sha256 = "0cbcml88bkx9gf1wznxa0kqz1wpyakfbyh9gmxw0wljhda1q0zk1";
     };
 
@@ -1711,7 +1711,7 @@ in modules // {
     name = "betamax-0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/betamax/${name}.tar.gz";
+      url = "mirror://pypi/b/betamax/${name}.tar.gz";
       sha256 = "0vw4d53jbbb2kdl7l891h8iyxklqcd6ldvgcyhw9hl40ljdhv1wz";
     };
 
@@ -1730,7 +1730,7 @@ in modules // {
     version = "0.3.0";
 
     src = pkgs.fetchurl {
-       url = "https://pypi.python.org/packages/source/b/betamax-matchers/${name}.tar.gz";
+       url = "mirror://pypi/b/betamax-matchers/${name}.tar.gz";
       sha256 = "039kvqsdcvvlfxjc3n1x2xvjg6qkqbql0p7rc4z7bnxm9kcm88la";
     };
 
@@ -1812,7 +1812,7 @@ in modules // {
 
     src = pkgs.fetchurl {
       sha256 = "1azd0g0p9qk9wp344jmvqp4wk5f3wpsz3lb750xvnmd7qzf6v377";
-      url = "https://pypi.python.org/packages/source/b/buttersink/${name}.tar.gz";
+      url = "mirror://pypi/b/buttersink/${name}.tar.gz";
     };
 
     meta = {
@@ -1838,7 +1838,7 @@ in modules // {
     name = "cached-property-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cached-property/${name}.tar.gz";
+      url = "mirror://pypi/c/cached-property/${name}.tar.gz";
       sha256 = "10dwi3s6f154ag9dvqy5jiwp31fs57lbxjcjgn4cwvi8qyqpi3j5";
     };
 
@@ -1880,7 +1880,7 @@ in modules // {
     name = "circus-0.11.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/circus/${name}.tar.gz";
+      url = "mirror://pypi/c/circus/${name}.tar.gz";
       sha256 = "3757344aa5073ea29e6e2607b3de8ba1652502c61964316116931884293fe846";
     };
 
@@ -1894,7 +1894,7 @@ in modules // {
     version = "2.6.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/colorlog/${name}.tar.gz";
+      url = "mirror://pypi/c/colorlog/${name}.tar.gz";
       sha256 = "0djv6ky1yk28s1l093w8plg19kp88q4nyrm1vfxyq0s9j4pix29l";
     };
 
@@ -1914,7 +1914,7 @@ in modules // {
     version = "0.1.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/c/${pname}/${name}.tar.gz";
       sha256 = "0w1j43l76zw10dvs2kk7jz7kqj2ss7gfgfdxyls27pckwin89gxb";
     };
 
@@ -1947,7 +1947,7 @@ in modules // {
     version = "1.1.7";
     disabled = isPyPy;
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/c/${pname}/${name}.tar.gz";
       sha256 = "f856ea2e9e2947abc1a6557625cc6b0e45228984f397a90c420b2f468dc4cb97";
     };
     doCheck = false;
@@ -1970,7 +1970,7 @@ in modules // {
     version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/C/Cycler/${name}.tar.gz";
+      url = "mirror://pypi/C/Cycler/${name}.tar.gz";
       sha256 = "cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8";
     };
 
@@ -1998,7 +1998,7 @@ in modules // {
     pname = "datadog";
     version = "0.10.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/d/${pname}/${name}.tar.gz";
       sha256 = "0y2if4jj43n5jis20imragvhhyhr840w4m1g7j7fxh9bn7h273zp";
     };
 
@@ -2017,7 +2017,7 @@ in modules // {
     pname = "python-debian";
     version = "0.1.23";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
       sha256 = "193faznwnjc3n5991wyzim6h9gyq1zxifmfrnpm3avgkh7ahyynh";
     };
     propagatedBuildInputs = with self; [ chardet six ];
@@ -2028,7 +2028,7 @@ in modules // {
     pname = "defusedxml";
     version = "0.4.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/d/${pname}/${name}.tar.gz";
       sha256 = "0y147zy3jqmk6ly7fbhqmzn1hf41xcb53f2vcc3m8x4ba5d1smfd";
     };
   };
@@ -2060,7 +2060,7 @@ in modules // {
     pname = "dugong";
     version = "3.5";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/${pname}/${name}.tar.bz2";
+      url = "mirror://pypi/d/${pname}/${name}.tar.bz2";
       sha256 = "0y0rdxbiwm03zv6vpvapqilrird3h8ijz7xmb0j7ds5j4p6q3g24";
     };
 
@@ -2071,7 +2071,7 @@ in modules // {
     name = "iowait-0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/iowait/${name}.tar.gz";
+      url = "mirror://pypi/i/iowait/${name}.tar.gz";
       sha256 = "ab1bc2eb84c22ccf61f17a0024f9fb6df781b39f1852764a66a7769d5adfb299";
     };
 
@@ -2085,7 +2085,7 @@ in modules // {
     name = "responses-0.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/responses/${name}.tar.gz";
+      url = "mirror://pypi/r/responses/${name}.tar.gz";
       sha256 = "0fs7a4cf4f12mjhcjd5vfh0f3ixcy2nawzxpgsfr3ahf0rg7ppx5";
     };
 
@@ -2099,7 +2099,7 @@ in modules // {
     name = "rarfile-2.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rarfile/rarfile-2.6.tar.gz";
+      url = "mirror://pypi/r/rarfile/rarfile-2.6.tar.gz";
       sha256 = "326700c5450cfb367f612e918866ea27551bac02f4656f340003c88873fa1a56";
     };
 
@@ -2113,7 +2113,7 @@ in modules // {
     name = "proboscis-1.2.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/proboscis/proboscis-1.2.6.0.tar.gz";
+      url = "mirror://pypi/p/proboscis/proboscis-1.2.6.0.tar.gz";
       sha256 = "b822b243a7c82030fce0de97bdc432345941306d2c24ef227ca561dd019cd238";
     };
 
@@ -2131,7 +2131,7 @@ in modules // {
     name = "pyechonest-8.0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyechonest/pyechonest-8.0.2.tar.gz";
+      url = "mirror://pypi/p/pyechonest/pyechonest-8.0.2.tar.gz";
       sha256 = "496265f4b7d33483ec153b9e1b8333fe959b115f7e781510089c8313b7d86560";
     };
 
@@ -2149,7 +2149,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/billiard/${name}.tar.gz";
+      url = "mirror://pypi/b/billiard/${name}.tar.gz";
       sha256 = "02wxsc6bhqvzh8j6w758kvgqbnj14l796mvmrcms8fgfamd2lak9";
     };
 
@@ -2168,7 +2168,7 @@ in modules // {
     version = "0.4.0";
 
     src = pkgs.fetchurl {
-      url ="https://pypi.python.org/packages/source/b/binaryornot/${name}.tar.gz";
+      url ="mirror://pypi/b/binaryornot/${name}.tar.gz";
       sha256 = "1j4f51dxic39mdwf6alj7gd769wy6mhk916v031wjali51xkh3xb";
     };
 
@@ -2188,7 +2188,7 @@ in modules // {
     name = "bitbucket-api-0.4.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/b/bitbucket-api/${name}.tar.gz";
+      url = "mirror://pypi/b/bitbucket-api/${name}.tar.gz";
       sha256 = "e890bc3893d59a6f203c1eb2bae60e78ac4d3869da7ea4fb104dca588aea85b2";
     };
 
@@ -2206,7 +2206,7 @@ in modules // {
   bitbucket-cli = buildPythonPackage rec {
     name = "bitbucket-cli-0.4.1";
     src = pkgs.fetchurl {
-       url = "https://pypi.python.org/packages/source/b/bitbucket-cli/${name}.tar.gz";
+       url = "mirror://pypi/b/bitbucket-cli/${name}.tar.gz";
        sha256 = "d8909627ae7a46519379c6343698d49f9ffd5de839ff44796974828d843a9419";
     };
 
@@ -2245,7 +2245,7 @@ in modules // {
     version = "0.9.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/blaze/${name}.tar.gz";
+      url = "mirror://pypi/b/blaze/${name}.tar.gz";
       sha256 = "fde4fd5733d8574345521581078a4fd89bb51ad3814eda88f1f467faa3a9784a";
     };
 
@@ -2320,7 +2320,7 @@ in modules // {
     version = "1.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/blinker/${name}.tar.gz";
+      url = "mirror://pypi/b/blinker/${name}.tar.gz";
       sha256 = "6811010809262261e41ab7b92f3f6d23f35cf816fbec2bc05077992eebec6e2f";
     };
 
@@ -2383,7 +2383,7 @@ in modules // {
     version = "6.1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bsddb3/${name}.tar.gz";
+      url = "mirror://pypi/b/bsddb3/${name}.tar.gz";
       sha256 = "6f21b0252125c07798d784c164ef135ad153d226c01b290258ee1c5b9e7c4dd3";
     };
 
@@ -2412,7 +2412,7 @@ in modules // {
     version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bokeh/${name}.tar.gz";
+      url = "mirror://pypi/b/bokeh/${name}.tar.gz";
       sha256 = "2d8bd8c98e2f62b2a28328d3cc95bfbe257742fa7efc9c382b4c8ae4a141df14";
     };
 
@@ -2519,7 +2519,7 @@ in modules // {
     name = "botocore-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/botocore/${name}.tar.gz";
+      url = "mirror://pypi/b/botocore/${name}.tar.gz";
       sha256 = "07rp24lnpjlk0c889g0d8y2ykc711gi04w715nkm9mv734ndsman";
     };
 
@@ -2550,7 +2550,7 @@ in modules // {
     name = "bottle-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bottle/${name}.tar.gz";
+      url = "mirror://pypi/b/bottle/${name}.tar.gz";
       sha256 = "1b2hq0l4nwh75s2w6wgiqlkj4q1qvyx6a94axl2k4lsym1aifpfd";
     };
 
@@ -2571,7 +2571,7 @@ in modules // {
     disabled = (!isPy27);
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/B/Box2D/Box2D-2.3b0.zip";
+      url = "mirror://pypi/B/Box2D/Box2D-2.3b0.zip";
       sha256 = "4519842c650b0153550eb0c9864da46b5a4ec8555c68b70f5cd2952a21c788b0";
     };
 
@@ -2596,7 +2596,7 @@ in modules // {
     version = "1.0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bugwarrior/${name}.tar.gz";
+      url = "mirror://pypi/b/bugwarrior/${name}.tar.gz";
       sha256 = "efe41756c152789f39006f157add9bedfa2b85d2cac15c067e635e37c70cb8f8";
     };
 
@@ -2641,7 +2641,7 @@ in modules // {
     version = "1.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-bugzilla/python-${name}.tar.gz";
+      url = "mirror://pypi/p/python-bugzilla/python-${name}.tar.gz";
       sha256 = "11361635a4f1613803a0b9b93ba9126f7fd36180653f953e2590b1536d107d46";
     };
 
@@ -2672,7 +2672,7 @@ in modules // {
     version = "0.30";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/check-manifest/check-manifest-${version}.tar.gz";
+      url = "mirror://pypi/c/check-manifest/check-manifest-${version}.tar.gz";
       sha256 = "b19fd0d8b9286532ba3dc0282484fd76d11200cf24b340dc3d08f293c7dd0500";
     };
 
@@ -2691,7 +2691,7 @@ in modules // {
     version = "2.0.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/devpi-common/devpi-common-${version}.tar.gz";
+      url = "mirror://pypi/d/devpi-common/devpi-common-${version}.tar.gz";
       sha256 = "a059c4099002d4af8f3ccfc8a9f4bf133b20ea404049b21a31fc1003e1d79452";
     };
 
@@ -2715,7 +2715,7 @@ in modules // {
     name = "zc.buildout-2.2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zc.buildout/${name}.tar.gz";
+      url = "mirror://pypi/z/zc.buildout/${name}.tar.gz";
       sha256 = "a6122ea5c06c6c044a9efce4a3df452c8573e1aebfda7b24262655daac894ef5";
     };
 
@@ -2733,7 +2733,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zc.buildout/${name}.tar.gz";
+      url = "mirror://pypi/z/zc.buildout/${name}.tar.gz";
       sha256 = "a5c2fafa4d073ad3dabec267c44a996cbc624700a9a49467cd6b1ef63d35e029";
     };
 
@@ -2751,7 +2751,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zc.buildout/${name}.tar.gz";
+      url = "mirror://pypi/z/zc.buildout/${name}.tar.gz";
       sha256 = "0ac5a325d3ffbc5a988fb3ba87f4159d4769cc73e3331cb5234edc8839b6506b";
     };
 
@@ -2778,7 +2778,7 @@ in modules // {
 
     src = pkgs.fetchurl {
       inherit sha256;
-      url = "https://pypi.python.org/packages/source/z/zc.recipe.egg/zc.recipe.egg-${version}.tar.gz";
+      url = "mirror://pypi/z/zc.recipe.egg/zc.recipe.egg-${version}.tar.gz";
     };
     meta.broken = true;  # https://bitbucket.org/pypa/setuptools/issues/462/pkg_resourcesfind_on_path-thinks-the
   };
@@ -2798,7 +2798,7 @@ in modules // {
     meta.maintainers = with maintainers; [ mornfall ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bunch/${name}.tar.gz";
+      url = "mirror://pypi/b/bunch/${name}.tar.gz";
       sha256 = "1akalx2pd1fjlvrq69plvcx783ppslvikqdm93z2sdybq07pmish";
     };
     doCheck = false;
@@ -2809,7 +2809,7 @@ in modules // {
     name = "cairocffi-0.7.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cairocffi/${name}.tar.gz";
+      url = "mirror://pypi/c/cairocffi/${name}.tar.gz";
       sha256 = "e42b4256d27bd960cbf3b91a6c55d602defcdbc2a73f7317849c80279feeb975";
     };
 
@@ -2862,7 +2862,7 @@ in modules // {
     name = "cairosvg-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/C/CairoSVG/CairoSVG-${version}.tar.gz";
+      url = "mirror://pypi/C/CairoSVG/CairoSVG-${version}.tar.gz";
       sha256 = "01lpm38qp7xlnv8jv7qg48j44p5088dwfsrcllgs5fz355lrfds1";
     };
 
@@ -2880,7 +2880,7 @@ in modules // {
     name = "carrot-0.10.7";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/carrot/${name}.tar.gz";
+      url = "mirror://pypi/c/carrot/${name}.tar.gz";
       sha256 = "cb46374f3c883c580d142a79d2609883713a867cc86e0514163adce784ce2468";
     };
 
@@ -2923,7 +2923,7 @@ in modules // {
     name = "cassandra-driver-2.6.0c2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/cassandra-driver/${name}.tar.gz";
+      url = "mirror://pypi/c/cassandra-driver/${name}.tar.gz";
       sha256 = "00cc2rkvkxaxn7sf2qzy29s6h394fla73rbdh9krxbswp5nvp27r";
     };
 
@@ -2967,7 +2967,7 @@ in modules // {
     disabled = pythonOlder "2.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/celery/${name}.tar.gz";
+      url = "mirror://pypi/c/celery/${name}.tar.gz";
       sha256 = "0614ppp18vmiwdk0rxvz0wn62d7svanwdnx7jgqxpy9pb20rqd8s";
     };
 
@@ -2990,7 +2990,7 @@ in modules // {
     version = "0.9.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/C/Cerberus/${name}.tar.gz";
+      url = "mirror://pypi/C/Cerberus/${name}.tar.gz";
       sha256 = "1km7hvns1snrmcwz58bssi4wv3gwd34zm1z1hwjylmpqrfrcf8mi";
     };
 
@@ -3006,7 +3006,7 @@ in modules // {
     version = "2015.9.6.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/certifi/${name}.tar.gz";
+      url = "mirror://pypi/c/certifi/${name}.tar.gz";
       sha256 = "19mfly763c6bzya9dwm6qgc48z4x3gk6ldl6fprdncqhklnjnfnw";
     };
 
@@ -3021,7 +3021,7 @@ in modules // {
   characteristic = buildPythonPackage rec {
     name = "characteristic-14.1.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/characteristic/${name}.tar.gz";
+      url = "mirror://pypi/c/characteristic/${name}.tar.gz";
       sha256 = "91e254948180678dd69e6143202b4686f2fa47cce136936079bb4d9a3b82419d";
     };
 
@@ -3067,7 +3067,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/C/Cheetah/Cheetah-${version}.tar.gz";
+      url = "mirror://pypi/C/Cheetah/Cheetah-${version}.tar.gz";
       sha256 = "be308229f0c1e5e5af4f27d7ee06d90bb19e6af3059794e5fd536a6f29a9b550";
     };
 
@@ -3105,7 +3105,7 @@ in modules // {
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-cjson/${name}.tar.gz";
+      url = "mirror://pypi/p/python-cjson/${name}.tar.gz";
       sha256 = "a01fabb7593728c3d851e1cd9a3efbd18f72650a31a5aa8a74018640da3de8b3";
     };
 
@@ -3122,7 +3122,7 @@ in modules // {
     version = "0.5.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/clf/${name}.tar.gz";
+      url = "mirror://pypi/c/clf/${name}.tar.gz";
       sha256 = "04lqd2i4fjs606b0q075yi9xksk567m0sfph6v6j80za0hvzqyy5";
     };
 
@@ -3148,7 +3148,7 @@ in modules // {
     name = "click-6.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/click/${name}.tar.gz";
+      url = "mirror://pypi/c/click/${name}.tar.gz";
       sha256 = "1sggipyz52crrybwbr9xvwxd4aqigvplf53k9w3ygxmzivd1jsnc";
     };
 
@@ -3177,7 +3177,7 @@ in modules // {
     name = "click-5.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/click/${name}.tar.gz";
+      url = "mirror://pypi/c/click/${name}.tar.gz";
       sha256 = "0njsm0wn31l21bi118g5825ma5sa3rwn7v2x4wjd7yiiahkri337";
     };
 
@@ -3198,7 +3198,7 @@ in modules // {
     name = "click-log-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/click-log/${name}.tar.gz";
+      url = "mirror://pypi/c/click-log/${name}.tar.gz";
       sha256 = "0kdd1vminxpcfczxl2kkf285n0dr1gxh2cdbx1p6vkj7b7bci3gx";
     };
 
@@ -3217,7 +3217,7 @@ in modules // {
     name = "click-threading-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/click-threading/${name}.tar.gz";
+      url = "mirror://pypi/c/click-threading/${name}.tar.gz";
       sha256 = "0jmrv4334lfxa2ss53c06dafdwqbk1pb3ihd26izn5igw1bm8145";
     };
 
@@ -3235,7 +3235,7 @@ in modules // {
     name = "clepy-0.3.20";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/clepy/${name}.tar.gz";
+      url = "mirror://pypi/c/clepy/${name}.tar.gz";
       sha256 = "16vibfxms5z4ld8gbkra6dkhqm2cc3jnn0fwp7mw70nlwxnmm51c";
     };
 
@@ -3253,7 +3253,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/C/ClientForm/ClientForm-0.2.10.tar.gz";
+      url = "mirror://pypi/C/ClientForm/ClientForm-0.2.10.tar.gz";
       sha256 = "0dydh3i1sx7rrj6d0gj375wkjpiivm7jjlsimw6hmwv4ck7yf1wm";
     };
 
@@ -3295,7 +3295,7 @@ in modules // {
     version = "0.1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cloudpickle/${name}.tar.gz";
+      url = "mirror://pypi/c/cloudpickle/${name}.tar.gz";
       sha256 = "3418303f44c6c4daa184f1dc36c8c0b7ff8261c56d1f922ffd8d09e79caa4b74";
     };
 
@@ -3321,7 +3321,7 @@ in modules // {
     name    = "cogapp-${version}";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/c/cogapp/${name}.tar.gz";
+      url    = "mirror://pypi/c/cogapp/${name}.tar.gz";
       sha256 = "0gzmzbsk54r1qa6wd0yg4zzdxvn2f19ciprr2acldxaknzrpllnn";
     };
 
@@ -3343,7 +3343,7 @@ in modules // {
     version = "0.3.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/colorama/${name}.tar.gz";
+      url = "mirror://pypi/c/colorama/${name}.tar.gz";
       sha256 = "eb21f2ba718fbf357afdfdf6f641ab393901c7ca8d9f37edd0bee4806ffa269c";
     };
 
@@ -3360,7 +3360,7 @@ in modules // {
     version = "0.6.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/C/CommonMark/${name}.tar.gz";
+      url = "mirror://pypi/C/CommonMark/${name}.tar.gz";
       sha256 = "ee5a88f23678794592efe3fc11033f17fc77b3296a85f5e1d5b715f8e110a773";
     };
 
@@ -3381,7 +3381,7 @@ in modules // {
   CommonMark_54 = self.CommonMark.override rec {
     name = "CommonMark-0.5.4";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/C/CommonMark/${name}.tar.gz";
+      url = "mirror://pypi/C/CommonMark/${name}.tar.gz";
       sha256 = "34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5";
     };
   };
@@ -3392,7 +3392,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/C/CoilMQ/${name}.tar.gz";
+      url = "mirror://pypi/C/CoilMQ/${name}.tar.gz";
       sha256 = "0wwa6fsqw1mxsryvgp0yrdjil8axyj0kslzi7lr45cnhgp5ab375";
     };
 
@@ -3415,7 +3415,7 @@ in modules // {
     name = "colander-1.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/colander/${name}.tar.gz";
+      url = "mirror://pypi/c/colander/${name}.tar.gz";
       sha256 = "7389413266b9e680c9529c16d56284edf87e0d5de557948e75f41d65683c23b3";
     };
 
@@ -3437,7 +3437,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/configparser/${name}.tar.gz";
+      url = "mirror://pypi/c/configparser/${name}.tar.gz";
       sha256 = "6a2318590dfc4013fc5bf53c2bec14a8cb455a232295eb282a13f94786c4b0b2";
     };
 
@@ -3453,7 +3453,7 @@ in modules // {
     version = "0.3.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/C/ColanderAlchemy/${name}.tar.gz";
+      url = "mirror://pypi/C/ColanderAlchemy/${name}.tar.gz";
       sha256 = "11wcni2xmfmy001rj62q2pwf305vvngkrfm5c4zlwvgbvlsrvnnw";
     };
 
@@ -3472,7 +3472,7 @@ in modules // {
     name = "configobj-5.0.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/configobj/${name}.tar.gz";
+      url = "mirror://pypi/c/configobj/${name}.tar.gz";
       sha256 = "a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902";
     };
 
@@ -3517,7 +3517,7 @@ in modules // {
     name = "construct-2.5.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/construct/${name}.tar.gz";
+      url = "mirror://pypi/c/construct/${name}.tar.gz";
       sha256 = "084h02p0m8lhmlywlwjdg0kd0hd6sz481c96qwcm5wddxrqn4nv6";
     };
 
@@ -3537,7 +3537,7 @@ in modules // {
     name = "python-consul-0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-consul/${name}.tar.gz";
+      url = "mirror://pypi/p/python-consul/${name}.tar.gz";
       sha256 = "0vfyr499sbc4nnhhijp2lznyj507nnak95bvv9w8y78ngxggskbh";
     };
 
@@ -3556,7 +3556,7 @@ in modules // {
     name = "contextlib2-0.4.0";
 
     src = pkgs.fetchurl rec {
-      url = "https://pypi.python.org/packages/source/c/contextlib2/${name}.tar.gz";
+      url = "mirror://pypi/c/contextlib2/${name}.tar.gz";
       sha256 = "55a5dc78f7a742a0e756645134ffb39bbe11da0fea2bc0f7070d40dac208b732";
     };
   };
@@ -3589,7 +3589,7 @@ in modules // {
     name = "cookies-2.2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cookies/${name}.tar.gz";
+      url = "mirror://pypi/c/cookies/${name}.tar.gz";
       sha256 = "13pfndz8vbk4p2a44cfbjsypjarkrall71pgc97glk5fiiw9idnn";
     };
 
@@ -3606,7 +3606,7 @@ in modules // {
     name = "coverage-4.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/coverage/${name}.tar.gz";
+      url = "mirror://pypi/c/coverage/${name}.tar.gz";
       sha256 = "0nrd817pzjw1haaz6gambgwf4jdjnh9kyxkgj6l8qgl6hdxga45w";
     };
 
@@ -3624,7 +3624,7 @@ in modules // {
   covCore = buildPythonPackage rec {
     name = "cov-core-1.15.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/cov-core/${name}.tar.gz";
+      url = "mirror://pypi/c/cov-core/${name}.tar.gz";
       sha256 = "4a14c67d520fda9d42b0da6134638578caae1d374b9bb462d8de00587dba764c";
     };
     meta = {
@@ -3636,7 +3636,7 @@ in modules // {
   crcmod = buildPythonPackage rec {
     name = "crcmod-1.7";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/c/crcmod/crcmod-1.7.tar.gz;
+      url = mirror://pypi/c/crcmod/crcmod-1.7.tar.gz;
       sha256 = "07k0hgr42vw2j92cln3klxka81f33knd7459cn3d8aszvfh52w6w";
     };
     meta = {
@@ -3677,7 +3677,7 @@ in modules // {
     version = "0.7.4";
 
     src = pkgs.fetchurl{
-      url = "https://pypi.python.org/packages/source/c/cytoolz/cytoolz-${version}.tar.gz";
+      url = "mirror://pypi/c/cytoolz/cytoolz-${version}.tar.gz";
       sha256 = "9c2e3dda8232b6cd5b84b8c8df6c8155c2adeb8734eb7ec38e189affc0f2eba5";
     };
 
@@ -3709,7 +3709,7 @@ in modules // {
     propagatedBuildInputs = with self; [ pbkdf2 modules.crypt ];
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/cryptacular/${name}.tar.gz";
+      url = "mirror://pypi/c/cryptacular/${name}.tar.gz";
       sha256 = "273f03d03f9b316671ae4f1c1c6b8d3c883da19a5706873e8f3d6543e13dd4a1";
     };
 
@@ -3726,7 +3726,7 @@ in modules // {
     name = "cryptography-1.2.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cryptography/${name}.tar.gz";
+      url = "mirror://pypi/c/cryptography/${name}.tar.gz";
       sha256 = "0kj511z4g21fhcr649pyzpl0zzkkc7hsgxxjys6z8wwfvmvirccf";
     };
 
@@ -3746,7 +3746,7 @@ in modules // {
     name = "cryptography_vectors-1.2.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cryptography-vectors/${name}.tar.gz";
+      url = "mirror://pypi/c/cryptography-vectors/${name}.tar.gz";
       sha256 = "0shawgpax79gvjrj0a313sll9gaqys7q1hxngn6j4k24lmz7bwki";
     };
   };
@@ -3756,7 +3756,7 @@ in modules // {
     version = "1.22.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.vmware/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.vmware/${name}.tar.gz";
       sha256 = "1119q3x2y3hjz3p784byr13aqay75pbj4cb8v43gjq5piqlpp16x";
     };
 
@@ -3775,7 +3775,7 @@ in modules // {
     version = "3.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-barbicanclient/python-barbicanclient-${version}.tar.gz";
+      url = "mirror://pypi/p/python-barbicanclient/python-barbicanclient-${version}.tar.gz";
       sha256 = "1kxnxiijvkkc8ahlfbkslpzxcbah7y5pi86hvkyac62xzda87inm";
     };
 
@@ -3798,7 +3798,7 @@ in modules // {
     version = "0.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-ironicclient/python-ironicclient-${version}.tar.gz";
+      url = "mirror://pypi/p/python-ironicclient/python-ironicclient-${version}.tar.gz";
       sha256 = "16kaixrmnx6a32mfv281w22h8lavjh0k9yiqikmwc986ydh85s4d";
     };
 
@@ -3855,7 +3855,7 @@ in modules // {
     version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tablib/tablib-${version}.tar.gz";
+      url = "mirror://pypi/t/tablib/tablib-${version}.tar.gz";
       sha256 = "14wc8bmz60g35r6gsyhdzfvgfqpd3gw9lfkq49z5bxciykbxmhj1";
     };
 
@@ -3873,7 +3873,7 @@ in modules // {
     version = "1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cliff-tablib/cliff-tablib-${version}.tar.gz";
+      url = "mirror://pypi/c/cliff-tablib/cliff-tablib-${version}.tar.gz";
       sha256 = "0fa1qw41lwda5ac3z822qhzbilp51y6p1wlp0h76vrvqcqgxi3ja";
     };
 
@@ -3894,7 +3894,7 @@ in modules // {
     version = "1.7.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-openstackclient/python-openstackclient-${version}.tar.gz";
+      url = "mirror://pypi/p/python-openstackclient/python-openstackclient-${version}.tar.gz";
       sha256 = "0h1jkrwx06l32k50zq5gs9iba132q2x2jjb3z5gkxxlcd3apk8y9";
     };
 
@@ -3921,7 +3921,7 @@ in modules // {
     name = "idna-2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/idna/${name}.tar.gz";
+      url = "mirror://pypi/i/idna/${name}.tar.gz";
       sha256 = "0frxgmgi234lr9hylg62j69j4ik5zhg0wz05w5dhyacbjfnrl68n";
     };
 
@@ -4006,7 +4006,7 @@ in modules // {
     name = "pkginfo-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pkginfo/${name}.tar.gz";
+      url = "mirror://pypi/p/pkginfo/${name}.tar.gz";
       sha256 = "0g0g6avplfqw1adzqybbrh1a2z0kfjl8qn3annkrc7w3ibz6sgxd";
     };
 
@@ -4032,7 +4032,7 @@ in modules // {
     name = "pretend-1.0.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pretend/pretend-1.0.8.tar.gz";
+      url = "mirror://pypi/p/pretend/pretend-1.0.8.tar.gz";
       sha256 = "0r5r7ygz9m6d2bklflbl84cqhjkc2q12xgis8268ygjh30g2q3wk";
     };
 
@@ -4049,7 +4049,7 @@ in modules // {
     propagatedBuildInputs = with self; [ tox py eventlet ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/detox/detox-0.9.3.tar.gz";
+      url = "mirror://pypi/d/detox/detox-0.9.3.tar.gz";
       sha256 = "39d48b6758c43ba579f694507d54da96931195eb1b72ad79b46f50af9520b2f3";
     };
 
@@ -4064,7 +4064,7 @@ in modules // {
     name = "pbkdf2-1.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pbkdf2/${name}.tar.gz";
+      url = "mirror://pypi/p/pbkdf2/${name}.tar.gz";
       sha256 = "ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979";
     };
 
@@ -4080,7 +4080,7 @@ in modules // {
     name = "bcrypt-2.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/b/bcrypt/${name}.tar.gz";
+      url = "mirror://pypi/b/bcrypt/${name}.tar.gz";
       sha256 = "8b2d197ef220d10eb74625dde7af3b10daa973ae9a1eadd6366f763fad4387fa";
     };
 
@@ -4098,7 +4098,7 @@ in modules // {
     name = "cffi-1.5.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cffi/${name}.tar.gz";
+      url = "mirror://pypi/c/cffi/${name}.tar.gz";
       sha256 = "1p91p1n8n46y0k3q7ddgxxjnfh08rjqsjh7zbjxzfiifhycxx6ys";
     };
 
@@ -4121,7 +4121,7 @@ in modules // {
     name = "pycollada-0.4.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pycollada/${name}.tar.gz";
+      url = "mirror://pypi/p/pycollada/${name}.tar.gz";
       sha256 = "0i50lh98550pwr95zgzrgiqzsspm09wl52xlv83y5nrsz4mblylv";
     };
 
@@ -4145,7 +4145,7 @@ in modules // {
     name = "PyContracts-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyContracts/${name}.tar.gz";
+      url = "mirror://pypi/P/PyContracts/${name}.tar.gz";
       sha256 = "0rdc9pz08885vqkazjc3lyrrghmf3jzxnlsgpn8akl808x1qrfqf";
     };
 
@@ -4165,7 +4165,7 @@ in modules // {
     version = "2.14";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pycparser/${name}.tar.gz";
+      url = "mirror://pypi/p/pycparser/${name}.tar.gz";
       sha256 = "7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73";
     };
 
@@ -4184,7 +4184,7 @@ in modules // {
     name = "pytest-2.7.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pytest/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest/${name}.tar.gz";
       sha256 = "1z4yi986f9n0p8qmzmn21m21m8j1x78hk3505f89baqm6pdw7afm";
     };
 
@@ -4209,7 +4209,7 @@ in modules // {
     name = "pytest-2.8.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pytest/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest/${name}.tar.gz";
       sha256 = "ed38a3725b8e4478555dfdb549a4219ca3ba57955751141a1aaa45b706d84194";
     };
   };
@@ -4217,7 +4217,7 @@ in modules // {
   pytestcache = buildPythonPackage rec {
     name = "pytest-cache-1.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-cache/pytest-cache-1.0.tar.gz";
+      url = "mirror://pypi/p/pytest-cache/pytest-cache-1.0.tar.gz";
       sha256 = "1a873fihw4rhshc722j4h6j7g3nj7xpgsna9hhg3zn6ksknnhx5y";
     };
 
@@ -4235,7 +4235,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-flakes/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-flakes/${name}.tar.gz";
       sha256 = "0vvfprga6k4v2zq1qsr3yq1bjl22vygfsnvyn3hh80cc2386dk6h";
     };
 
@@ -4251,7 +4251,7 @@ in modules // {
   pytestpep8 = buildPythonPackage rec {
     name = "pytest-pep8";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pytest-pep8/pytest-pep8-1.0.6.tar.gz";
+      url = "mirror://pypi/p/pytest-pep8/pytest-pep8-1.0.6.tar.gz";
       sha256 = "06032agzhw1i9d9qlhfblnl3dw5hcyxhagn7b120zhrszbjzfbh3";
     };
 
@@ -4269,7 +4269,7 @@ in modules // {
      version = "0.0.1";
 
      src = pkgs.fetchurl {
-       url = "https://pypi.python.org/packages/source/p/pytest-pep257/${name}.tar.gz";
+       url = "mirror://pypi/p/pytest-pep257/${name}.tar.gz";
        sha256 = "003vdkxpx37n0kjqpwgj3314hwk2jfz3nz58db7xh68bf8xy75lk";
      };
 
@@ -4287,7 +4287,7 @@ in modules // {
     version = "2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-raisesregexp/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-raisesregexp/${name}.tar.gz";
       sha256 = "0fde8aac1a54f9b56e5f9c61fda76727542ed24968c27c6e3688c6f1885f1e61";
     };
 
@@ -4311,7 +4311,7 @@ in modules // {
     name = "pytest-runner-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-runner/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-runner/${name}.tar.gz";
       sha256 = "e775a40ee4a3a1d45018b199c44cc20bbe7f3df2dc8882f61465bb4141c78cdb";
     };
 
@@ -4331,7 +4331,7 @@ in modules // {
     name = "pytest-quickcheck-0.8.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-quickcheck/pytest-quickcheck-0.8.2.tar.gz";
+      url = "mirror://pypi/p/pytest-quickcheck/pytest-quickcheck-0.8.2.tar.gz";
       sha256 = "047w4zwdsnlzmsc5f3rapzbzd2frlvz9nnp8v4b48fjmqmxassh3";
     };
 
@@ -4348,7 +4348,7 @@ in modules // {
     name = "pytest-cov-2.2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-cov/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-cov/${name}.tar.gz";
       sha256 = "1lf9jsmhqk5nc4w3kzwglmdzjvmi7ajvrsnwv826j3bn0wzx8c92";
     };
 
@@ -4365,7 +4365,7 @@ in modules // {
     name = "pytest-xdist-1.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-xdist/pytest-xdist-1.8.zip";
+      url = "mirror://pypi/p/pytest-xdist/pytest-xdist-1.8.zip";
       sha256 = "b02135db7080c0978b7ce5d8f43a5879231441c2062a4791bc42b6f98c94fa69";
     };
 
@@ -4383,7 +4383,7 @@ in modules // {
     version = "0.3.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-localserver/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-localserver/${name}.tar.gz";
       sha256 = "0dvqspjr6va55zwmnnc2mmpqc7mm65kxig9ya44x1z8aadzxpa4p";
     };
 
@@ -4406,7 +4406,7 @@ in modules // {
     version = "0.1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest-subtesthack/${name}.tar.gz";
+      url = "mirror://pypi/p/pytest-subtesthack/${name}.tar.gz";
       sha256 = "15kzcr5pchf3id4ikdvlv752rc0j4d912n589l4rifp8qsj19l1x";
     };
 
@@ -4427,7 +4427,7 @@ in modules // {
     version = "0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/tinycss/${name}.tar.gz";
+      url = "mirror://pypi/t/tinycss/${name}.tar.gz";
       sha256 = "1pichqra4wk86142hqgvy9s5x6c5k5zhy8l9qxr0620pqk8spbd4";
     };
 
@@ -4454,7 +4454,7 @@ in modules // {
     name = "cssselect-${version}";
     version = "0.9.1";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/cssselect/${name}.tar.gz";
+      url = "mirror://pypi/c/cssselect/${name}.tar.gz";
       sha256 = "10h623qnp6dp1191jri7lvgmnd4yfkl36k9smqklp1qlf3iafd85";
     };
     # AttributeError: 'module' object has no attribute 'tests'
@@ -4465,7 +4465,7 @@ in modules // {
     name = "cssutils-0.9.9";
 
     src = pkgs.fetchurl {
-      url = http://pypi.python.org/packages/source/c/cssutils/cssutils-0.9.9.zip;
+      url = mirror://pypi/c/cssutils/cssutils-0.9.9.zip;
       sha256 = "139yfm9yz9k33kgqw4khsljs10rkhhxyywbq9i82bh2r31cil1pp";
     };
 
@@ -4488,7 +4488,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/darcsver/${name}.tar.gz";
+      url = "mirror://pypi/d/darcsver/${name}.tar.gz";
       sha256 = "1yb1c3jxqvy4r3qiwvnb86qi5plw6018h15r3yk5ji3nk54qdcb6";
     };
 
@@ -4516,7 +4516,7 @@ in modules // {
     version = "0.7.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dask/${name}.tar.gz";
+      url = "mirror://pypi/d/dask/${name}.tar.gz";
       sha256 = "ff27419e059715907afefe6cbcc1f8c748855c7a93be25be211dabcb689cee3b";
     };
 
@@ -4543,7 +4543,7 @@ in modules // {
     version = "0.5.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/D/DataShape/${name}.tar.gz";
+      url = "mirror://pypi/D/DataShape/${name}.tar.gz";
       sha256 = "21c424f11604873da9a36d4c55ef1d15cc3960cd208d7828b82315c494bff96a";
     };
 
@@ -4568,7 +4568,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/requests-cache/${name}.tar.gz";
+      url = "mirror://pypi/r/requests-cache/${name}.tar.gz";
       sha256 = "671969d00719fa3e80476b128dc9232025926884d0110d4d235abdd9c3508fc0";
     };
 
@@ -4588,7 +4588,7 @@ in modules // {
     version = "1.1.7";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/h/howdoi/${name}.tar.gz";
+      url = "mirror://pypi/h/howdoi/${name}.tar.gz";
       sha256 = "df4e49a219872324875d588e7699a1a82174a267e8487505e86bfcb180aea9b7";
     };
 
@@ -4606,7 +4606,7 @@ in modules // {
     version = "0.5.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nose-parameterized/${name}.tar.gz";
+      url = "mirror://pypi/n/nose-parameterized/${name}.tar.gz";
       sha256 = "a11c41b0cf8218e7cdc19ab7a1bdf5c141d161cd2350daee819473cc63cd0685";
     };
 
@@ -4633,7 +4633,7 @@ in modules // {
     version = "0.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/N/NeuroTools/${name}.tar.gz";
+      url = "mirror://pypi/N/NeuroTools/${name}.tar.gz";
       sha256 = "0ly6qa87l3afhksab06vp1iimlbm1kdnsw98mxcnpzz9q07l4nd4";
     };
 
@@ -4667,7 +4667,7 @@ in modules // {
     version = "1.7.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/j/jdatetime/${name}.tar.gz";
+      url = "mirror://pypi/j/jdatetime/${name}.tar.gz";
       sha256 = "c08ba5791c2350b26e87ddf478bf223108146e241b6c949538221b54afd633ac";
     };
 
@@ -4712,7 +4712,7 @@ in modules // {
     version = "2.4.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/python-dateutil/python-${name}.tar.gz";
+      url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
       sha256 = "3e95445c1db500a344079a47b171c45ef18f57d188dffdb0e4165c71bea8eb3d";
     };
 
@@ -4732,7 +4732,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/python-dateutil/python-${name}.tar.gz";
+      url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
       sha256 = "02dhw57jf5kjcp7ng1if7vdrbnlpb9yjmz7wygwwvf3gni4766bg";
     };
 
@@ -4750,7 +4750,7 @@ in modules // {
     name = "dateutil-2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/python-dateutil/python-${name}.tar.gz";
+      url = "mirror://pypi/p/python-dateutil/python-${name}.tar.gz";
       sha256 = "1vlx0lpsxjxz64pz87csx800cwfqznjyr2y7nk3vhmzhkwzyqi2c";
     };
 
@@ -4793,7 +4793,7 @@ in modules // {
     version = "4.0.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/decorator/${name}.tar.gz";
+      url = "mirror://pypi/d/decorator/${name}.tar.gz";
       sha256 = "1c6254597777fd003da2e8fb503c3dbf3d9e8f8d55f054709c0e65be3467209c";
     };
 
@@ -4808,7 +4808,7 @@ in modules // {
     name = "deform-2.0a2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/deform/${name}.tar.gz";
+      url = "mirror://pypi/d/deform/${name}.tar.gz";
       sha256 = "3fa4d287c8da77a83556e4a5686de006ddd69da359272120b915dc8f5a70cabd";
     };
 
@@ -4835,7 +4835,7 @@ in modules // {
     name = "deform-2.0a2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/deform/${name}.tar.gz";
+      url = "mirror://pypi/d/deform/${name}.tar.gz";
       sha256 = "1gfaf1d8zp0mp4h229srlffxdp86w1nni9g4aqsshxysr23x591z";
     };
 
@@ -4863,7 +4863,7 @@ in modules // {
     name = "deform_bootstrap-0.2.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/deform_bootstrap/${name}.tar.gz";
+      url = "mirror://pypi/d/deform_bootstrap/${name}.tar.gz";
       sha256 = "1hgq3vqsfqdmlyahnlc40w13viawhpzqf4jzigsggdb41x545fda";
     };
 
@@ -4886,7 +4886,7 @@ in modules // {
     name = "demjson-1.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/demjson/${name}.tar.gz";
+      url = "mirror://pypi/d/demjson/${name}.tar.gz";
       sha256 = "0abf7wqqq7rk1sycy47ayn5p93yy7gjq50cb2z69wmik1qqrr60x";
     };
 
@@ -4912,7 +4912,7 @@ in modules // {
     propagatedBuildInputs = with self; [ six ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/derpconf/${name}.tar.gz";
+      url = "mirror://pypi/d/derpconf/${name}.tar.gz";
       sha256 = "9129419e3a6477fe6366c339d2df8c614bdde82a639f33f2f40d4de9a1ed236a";
     };
 
@@ -4962,7 +4962,7 @@ in modules // {
     version = "0.2.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dill/${name}.tgz";
+      url = "mirror://pypi/d/dill/${name}.tgz";
       sha256 = "deca57da33ad2121ab1b9c4493bf8eb2b3a72b6426d4b9a3a853a073c68b97ca";
     };
 
@@ -4982,7 +4982,7 @@ in modules // {
     name = "discogs-client-2.0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/discogs-client/${name}.tar.gz";
+      url = "mirror://pypi/d/discogs-client/${name}.tar.gz";
       sha256 = "0a3616a818dd9fa61a61c3d9731d176e9123130d1b1b97a6beee63b4c72306b7";
     };
 
@@ -5000,10 +5000,10 @@ in modules // {
     version = "1.12.0";
 
     src = if isPy3k then pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dnspython3/dnspython3-${version}.zip";
+      url = "mirror://pypi/d/dnspython3/dnspython3-${version}.zip";
       sha256 = "138wxj702vx6zni9g2y8dbgbpin95v6hk23rh2kwfr3q4130jqz9";
     } else pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dnspython/${name}.tar.gz";
+      url = "mirror://pypi/d/dnspython/${name}.tar.gz";
       sha256 = "0kvjlkp96qzh3j31szpjlzqbp02brixh4j4clnpw80b0hspq5yq3";
     };
 
@@ -5024,7 +5024,7 @@ in modules // {
     version = "1.7.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/docker-py/${name}.tar.gz";
+      url = "mirror://pypi/d/docker-py/${name}.tar.gz";
       sha256 = "0k6hm3vmqh1d3wr9rryyif5n4rzvcffdlb1k4jvzp7g4996d3ccm";
     };
 
@@ -5044,7 +5044,7 @@ in modules // {
     name = "dockerpty-0.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dockerpty/${name}.tar.gz";
+      url = "mirror://pypi/d/dockerpty/${name}.tar.gz";
       sha256 = "1kjn64wx23jmr8dcc6g7bwlmrhfmxr77gh6iphqsl39sayfxdab9";
     };
 
@@ -5062,7 +5062,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/docker-registry-core/${name}.tar.gz";
+      url = "mirror://pypi/d/docker-registry-core/${name}.tar.gz";
       sha256 = "347e804f1f35b28dbe27bf8d7a0b630fca29d684032139bf26e3940572360360";
     };
 
@@ -5087,7 +5087,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/docker-registry/${name}.tar.gz";
+      url = "mirror://pypi/d/docker-registry/${name}.tar.gz";
       sha256 = "1svm1h59sg4bwj5cy10m016gj0xpiin15nrz5z66h47sbkndvlw3";
     };
 
@@ -5117,7 +5117,7 @@ in modules // {
     name = "docopt-0.6.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/docopt/${name}.tar.gz";
+      url = "mirror://pypi/d/docopt/${name}.tar.gz";
       sha256 = "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491";
     };
 
@@ -5133,7 +5133,7 @@ in modules // {
     version = "0.1.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/doctest-ignore-unicode/${name}.tar.gz";
+      url = "mirror://pypi/d/doctest-ignore-unicode/${name}.tar.gz";
       sha256= "fc90b2d0846477285c6b67fc4cb4d6f39fcf76d8752f4df0a241486f31512ad5";
     };
 
@@ -5152,7 +5152,7 @@ in modules // {
     propagatedBuildInputs = with self; [ dogpile_core ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dogpile.cache/dogpile.cache-0.5.4.tar.gz";
+      url = "mirror://pypi/d/dogpile.cache/dogpile.cache-0.5.4.tar.gz";
       sha256 = "9eab7a5dc05ad1b6573144c4a2717226b5c38811f9ec29b514e774535a91ea24";
     };
 
@@ -5169,7 +5169,7 @@ in modules // {
     name = "dogpile.core-0.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dogpile.core/dogpile.core-0.4.1.tar.gz";
+      url = "mirror://pypi/d/dogpile.core/dogpile.core-0.4.1.tar.gz";
       sha256 = "be652fb11a8eaf66f7e5c94d418d2eaa60a2fe81dae500f3743a863cc9dbed76";
     };
 
@@ -5186,7 +5186,7 @@ in modules // {
     name = "dotfiles-0.6.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dotfiles/${name}.tar.gz";
+      url = "mirror://pypi/d/dotfiles/${name}.tar.gz";
       sha256 = "45ecfd7f2ed9d0f2a7ac632c9bd0ebdca758d8bbc2b6f11562579d525f0467b8";
     };
 
@@ -5246,7 +5246,7 @@ in modules // {
     name = "urllib3-1.12";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/urllib3/${name}.tar.gz";
+      url = "mirror://pypi/u/urllib3/${name}.tar.gz";
       sha256 = "1ikj72kd4cdcq7pmmcd5p6s9dvp7wi0zw01635v4xzkid5vi598f";
     };
 
@@ -5283,7 +5283,7 @@ in modules // {
     #doCheck = false; # python 2.7.9 does verify ssl certificates
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dropbox/${name}.tar.gz";
+      url = "mirror://pypi/d/dropbox/${name}.tar.gz";
       sha256 = "f65c12bd97f09e29a951bc7cb30a74e005fc4b2f8bb48778796be3f73866b173";
     };
 
@@ -5301,7 +5301,7 @@ in modules // {
     name = "ds4drv-${version}";
     version = "0.5.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/ds4drv/${name}.tar.gz";
+      url = "mirror://pypi/d/ds4drv/${name}.tar.gz";
       sha256 = "0dq2z1z09zxa6rn3v94vwqaaz29jwiydkss8hbjglixf20krmw3b";
     };
 
@@ -5322,7 +5322,7 @@ in modules // {
     name = "dyn-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dyn/${name}.tar.gz";
+      url = "mirror://pypi/d/dyn/${name}.tar.gz";
       sha256 = "dc4b4b2a5d9d26f683230fd822641b39494df5fcbfa716281d126ea6425dd4c3";
     };
 
@@ -5349,7 +5349,7 @@ in modules // {
     name = "EasyProcess-0.1.9";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/E/EasyProcess/${name}.tar.gz";
+      url = "mirror://pypi/E/EasyProcess/${name}.tar.gz";
       sha256 = "c9980c0b0eeab97969305d8829bed966a3e28a77284e4f45a9b38fb23ce83633";
     };
 
@@ -5365,7 +5365,7 @@ in modules // {
     name = "elasticsearch-1.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/elasticsearch/${name}.tar.gz";
+      url = "mirror://pypi/e/elasticsearch/${name}.tar.gz";
       sha256 = "091s60ziwhyl9kjfm833i86rcpjx46v9h16jkgjgkk5441dln3gb";
     };
 
@@ -5388,7 +5388,7 @@ in modules // {
     name = "elasticsearch-dsl-0.0.9";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/elasticsearch-dsl/${name}.tar.gz";
+      url = "mirror://pypi/e/elasticsearch-dsl/${name}.tar.gz";
       sha256 = "1gdcdshk881vy18p0czcmbb3i4s5hl8llnfg6961b6x7jkvhihbj";
     };
 
@@ -5413,7 +5413,7 @@ in modules // {
     disabled = isPy34;  # see http://bugs.python.org/issue21121
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/evdev/${name}.tar.gz";
+      url = "mirror://pypi/e/evdev/${name}.tar.gz";
       sha256 = "1mz8cfncpxc1wbk2nj7apl0ssqc0vfndysxchq3wabd9vzx5p71k";
     };
 
@@ -5437,7 +5437,7 @@ in modules // {
     name = "Eve-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/E/Eve/${name}.tar.gz";
+      url = "mirror://pypi/E/Eve/${name}.tar.gz";
       sha256 = "0wf1x8qixkld6liz5syqi8i9nrfrhq4lpmh0p9cy3jbkhk34km69";
     };
 
@@ -5495,7 +5495,7 @@ in modules // {
     version = "0.2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/E/Events/${name}.tar.gz";
+      url = "mirror://pypi/E/Events/${name}.tar.gz";
       sha256 = "0rymyfvarjdi2fdhfz2iqmp4wgd2n2sm0p2mx44c3spm7ylnqzqa";
     };
 
@@ -5547,7 +5547,7 @@ in modules // {
     name = "execnet-1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/execnet/${name}.zip";
+      url = "mirror://pypi/e/execnet/${name}.zip";
       sha256 = "fa1d8bd6b6d2282ff4df474b8ac687e1775bff4fc6462b219a5f89d5e9e6908c";
     };
 
@@ -5565,7 +5565,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/facebook-sdk/facebook-sdk-0.4.0.tar.gz";
+      url = "mirror://pypi/f/facebook-sdk/facebook-sdk-0.4.0.tar.gz";
       sha256 = "5a96c54d06213039dff1fe1fabc51972e394666cd6d83ea70f7c2e67472d9b72";
     };
 
@@ -5580,7 +5580,7 @@ in modules // {
     name = "faker-0.0.4";
     disabled = isPy3k;
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/F/Faker/Faker-0.0.4.tar.gz;
+      url = mirror://pypi/F/Faker/Faker-0.0.4.tar.gz;
       sha256 = "09q5jna3j8di0gw5yjx0dvlndkrk2x9vvqzwyfsvg3nlp8h38js1";
     };
     buildInputs = with self; [ nose ];
@@ -5596,7 +5596,7 @@ in modules // {
   fake_factory = buildPythonPackage rec {
     name = "fake-factory-0.2";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/f/fake-factory/fake-factory-0.2.tar.gz;
+      url = mirror://pypi/f/fake-factory/fake-factory-0.2.tar.gz;
       sha256 = "0qdmk8p4anrj9mf95dh9v7bkhv1pz69hvhlw380kj4iz7b44b6zn";
     };
     meta = {
@@ -5612,7 +5612,7 @@ in modules // {
     name = "Fabric-${version}";
     version = "1.10.2";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Fabric/${name}.tar.gz";
+      url = "mirror://pypi/F/Fabric/${name}.tar.gz";
       sha256 = "0nikc05iz1fx2c9pvxrhrs819cpmg566azm99450yq2m8qmp1cpd";
     };
     disabled = isPy3k;
@@ -5654,7 +5654,7 @@ in modules // {
     name = "frozendict-0.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/frozendict/${name}.tar.gz";
+      url = "mirror://pypi/f/frozendict/${name}.tar.gz";
       sha256 = "0m4kg6hbadvf99if78nx01q7qnbyhdw3x4znl5dasgciyi54432n";
     };
 
@@ -5670,7 +5670,7 @@ in modules // {
     name = "ftputil-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/ftputil/${name}.tar.gz";
+      url = "mirror://pypi/f/ftputil/${name}.tar.gz";
       sha256 = "1714w0v6icw2xjx5m54yv2qgkq49qwxwllq4gdb7wkz25iiapr8b";
     };
 
@@ -5687,7 +5687,7 @@ in modules // {
   fudge = buildPythonPackage rec {
     name = "fudge-1.1.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/fudge/${name}.tar.gz";
+      url = "mirror://pypi/f/fudge/${name}.tar.gz";
       sha256 = "eba59a926fa1df1ab6dddd69a7a8af21865b16cad800cb4d1af75070b0f52afb";
     };
     buildInputs = with self; [ nose nosejs ];
@@ -5703,7 +5703,7 @@ in modules // {
   fudge_9 = self.fudge.override rec {
     name = "fudge-0.9.6";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/fudge/${name}.tar.gz";
+      url = "mirror://pypi/f/fudge/${name}.tar.gz";
       sha256 = "34690c4692e8717f4d6a2ab7d841070c93c8d0ea0d2615b47064e291f750b1a0";
     };
   };
@@ -5713,7 +5713,7 @@ in modules // {
     name = "funcparserlib-0.3.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/funcparserlib/${name}.tar.gz";
+      url = "mirror://pypi/f/funcparserlib/${name}.tar.gz";
       sha256 = "b7992eac1a3eb97b3d91faa342bfda0729e990bd8a43774c1592c091e563c91d";
     };
 
@@ -5738,7 +5738,7 @@ in modules // {
     propagatedBuildInputs = with self; [ six ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/singledispatch/${name}.tar.gz";
+      url = "mirror://pypi/s/singledispatch/${name}.tar.gz";
       sha256 = "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c";
     };
 
@@ -5752,7 +5752,7 @@ in modules // {
     version = "3.2.3-2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/functools32/functools32-${version}.tar.gz";
+      url = "mirror://pypi/f/functools32/functools32-${version}.tar.gz";
       sha256 = "0v8ya0b58x47wp216n1zamimv4iw57cxz3xxhzix52jkw3xks9gn";
     };
 
@@ -5840,7 +5840,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gmpy/${name}.zip";
+      url = "mirror://pypi/g/gmpy/${name}.zip";
       sha256 = "1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14";
     };
 
@@ -5860,7 +5860,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gmpy2/${name}.zip";
+      url = "mirror://pypi/g/gmpy2/${name}.zip";
       sha256 = "5041d0ae24407c24487106099f5bcc4abb1a5f58d90e6712cc95321975eddbd4";
     };
 
@@ -5882,7 +5882,7 @@ in modules // {
     name = "gmusicapi-7.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gmusicapi/gmusicapi-7.0.0.tar.gz";
+      url = "mirror://pypi/g/gmusicapi/gmusicapi-7.0.0.tar.gz";
       sha256 = "1zji4cgylyzz97cz69lywkbsn5nvvzrhk7iaqnpqpfvj9gwdchwn";
     };
 
@@ -5916,7 +5916,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gnureadline/${name}.tar.gz";
+      url = "mirror://pypi/g/gnureadline/${name}.tar.gz";
       sha256 = "1ghck2zz4xbqa3wz73brgjhrqj55p9hc1fq6c9zb09dnyhwb0nd2";
     };
 
@@ -5929,7 +5929,7 @@ in modules // {
   gnutls = buildPythonPackage rec {
     name = "python-gnutls";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-gnutls/python-gnutls-3.0.0.tar.gz";
+      url = "mirror://pypi/p/python-gnutls/python-gnutls-3.0.0.tar.gz";
       sha256 = "1yrdxcj5rzvz8iglircz6icvyggz5fmdcd010n6w3j60yp4p84kc";
     };
 
@@ -5940,7 +5940,7 @@ in modules // {
     name = "gitdb-0.6.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gitdb/${name}.tar.gz";
+      url = "mirror://pypi/g/gitdb/${name}.tar.gz";
       sha256 = "0n4n2c7rxph9vs2l6xlafyda5x1mdr8xy16r9s3jwnh3pqkvrsx3";
     };
 
@@ -5967,7 +5967,7 @@ in modules // {
     name = "GitPython-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/G/GitPython/GitPython-${version}.tar.gz";
+      url = "mirror://pypi/G/GitPython/GitPython-${version}.tar.gz";
       sha256 = "0q7plxnbbkp5dd0k73736l7gf932a89yy920yrgl8amfpixw324w";
     };
 
@@ -6072,7 +6072,7 @@ in modules // {
     name = "gpsoauth-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gpsoauth/${name}.tar.gz";
+      url = "mirror://pypi/g/gpsoauth/${name}.tar.gz";
       sha256 = "1mhd2lkl1f4fmia1cwxwik8gvqr5q16scjip7kfwzadh9a11n9kw";
     };
 
@@ -6147,7 +6147,7 @@ in modules // {
     name = "hglib-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-hglib/python-hglib-${version}.tar.gz";
+      url = "mirror://pypi/p/python-hglib/python-hglib-${version}.tar.gz";
       sha256 = "0dc087d15b774cda82d3c8096fb0e514caeb2ddb60eed38e9056b16e279ba3c5";
     };
 
@@ -6165,7 +6165,7 @@ in modules // {
     name = "humanize-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/humanize/${name}.tar.gz";
+      url = "mirror://pypi/h/humanize/${name}.tar.gz";
       sha256 = "a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19";
     };
 
@@ -6189,7 +6189,7 @@ in modules // {
     version = "2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/hovercraft/${name}.tar.gz";
+      url = "mirror://pypi/h/hovercraft/${name}.tar.gz";
       sha256 = "0lqxr816lymgnywln8bbv9nrmkyahjjcjkm9kjyny9bflayz4f1g";
     };
 
@@ -6212,7 +6212,7 @@ in modules // {
     name = "httpauth-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/httpauth/${name}.tar.gz";
+      url = "mirror://pypi/h/httpauth/${name}.tar.gz";
       sha256 = "294029b5dfed27bca5746a31e3ffb5ed99268761536705e8bbd44231b7ca15ec";
     };
 
@@ -6231,7 +6231,7 @@ in modules // {
     version = "0.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/imagesize/${name}.tar.gz";
+      url = "mirror://pypi/i/imagesize/${name}.tar.gz";
       sha256 = "0msgz4ncp2nb5nbsxnf8kvxsl6nhwvc3b46ik097fvznl3y10gdv";
     };
 
@@ -6275,7 +6275,7 @@ in modules // {
     name = "itsdangerous-0.24";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/itsdangerous/${name}.tar.gz";
+      url = "mirror://pypi/i/itsdangerous/${name}.tar.gz";
       sha256 = "06856q6x675ly542ig0plbqcyab6ksfzijlyf1hzhgg3sgwgrcyb";
     };
 
@@ -6291,7 +6291,7 @@ in modules // {
     version = "0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/iniparse/iniparse-${version}.tar.gz";
+      url = "mirror://pypi/i/iniparse/iniparse-${version}.tar.gz";
       sha256 = "0m60k46vr03x68jckachzsipav0bwhhnqb8715hm1cngs89fxhdb";
     };
 
@@ -6314,7 +6314,7 @@ in modules // {
     name = "i3-py-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/i3-py/i3-py-${version}.tar.gz";
+      url = "mirror://pypi/i/i3-py/i3-py-${version}.tar.gz";
       sha256 = "1sgl438jrb4cdyl7hbc3ymwsf7y3zy09g1gh7ynilxpllp37jc8y";
     };
 
@@ -6375,7 +6375,7 @@ in modules // {
     name = "jsonpatch-1.11";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jsonpatch/${name}.tar.gz";
+      url = "mirror://pypi/j/jsonpatch/${name}.tar.gz";
       sha256 = "22d0bc0f5522a4a03dd9fb4c4cdf7c1f03256546c88be4c61e5ceabd22280e47";
     };
 
@@ -6392,7 +6392,7 @@ in modules // {
     name = "jsonpointer-1.9";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jsonpointer/${name}.tar.gz";
+      url = "mirror://pypi/j/jsonpointer/${name}.tar.gz";
       sha256 = "39403b47a71aa782de6d80db3b78f8a5f68ad8dfc9e674ca3bb5b32c15ec7308";
     };
 
@@ -6435,7 +6435,7 @@ in modules // {
     name = "ledger-autosync-${version}";
     version = "0.2.3";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/ledger-autosync/ledger-autosync-${version}.tar.gz";
+      url = "mirror://pypi/l/ledger-autosync/ledger-autosync-${version}.tar.gz";
       sha256 = "f19fa66e656309825887171d84a462e64676b1cc36b62e4dd8679ff63926a469";
     };
 
@@ -6466,7 +6466,7 @@ in modules // {
     version = "1.2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/libthumbor/${name}.tar.gz";
+      url = "mirror://pypi/l/libthumbor/${name}.tar.gz";
       sha256 = "09bbaf08124ee33ea4ef99881625bd20450b0b43ab90fd678479beba8c03f86e";
     };
 
@@ -6484,7 +6484,7 @@ in modules // {
     name = "lightning-python-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/lightning-python/${name}.tar.gz";
+      url = "mirror://pypi/l/lightning-python/${name}.tar.gz";
       sha256 = "3987d7d4a634bdb6db9bcf212cf4d2f72bab5bc039f4f6cbc02c9d01c4ade792";
     };
 
@@ -6510,7 +6510,7 @@ in modules // {
     name = "jupyter-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jupyter/${name}.tar.gz";
+      url = "mirror://pypi/j/jupyter/${name}.tar.gz";
       sha256 = "d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f";
     };
 
@@ -6536,7 +6536,7 @@ in modules // {
     name = "jupyter_console-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jupyter_console/${name}.tar.gz";
+      url = "mirror://pypi/j/jupyter_console/${name}.tar.gz";
       sha256 = "1qsa9h7db8qzd4hg9l5mfl8299y4i7jkd6p3vpksk3r5ip8wym6p";
     };
 
@@ -6566,7 +6566,7 @@ in modules // {
     ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyLTI/${name}.tar.gz";
+      url = "mirror://pypi/P/PyLTI/${name}.tar.gz";
       sha256 = "1lkk6qx8yfx1h0rhi4abnd44x0wakggi6zs0nvi572lajf6ydmdh";
     };
 
@@ -6616,7 +6616,7 @@ in modules // {
     name = "mailchimp-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mailchimp/mailchimp-${version}.tar.gz";
+      url = "mirror://pypi/m/mailchimp/mailchimp-${version}.tar.gz";
       sha256 = "0351ai0jqv3dzx0xxm1138sa7mb42si6xfygl5ak8wnfc95ff770";
     };
 
@@ -6732,7 +6732,7 @@ in modules // {
     name = "natsort-4.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/natsort/${name}.tar.gz";
+      url = "mirror://pypi/n/natsort/${name}.tar.gz";
       sha256 = "a0d4239bd609eae5cd5163db6f9794378ce0e3f43ae16c10c35472d866ae20cd";
     };
 
@@ -6792,7 +6792,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/netCDF4/${name}.tar.gz";
+      url = "mirror://pypi/n/netCDF4/${name}.tar.gz";
       sha256 = "0wzg73zyjjhns4209vrcvh71gs392d16ynz76x3pl1xg2by723iy";
     };
 
@@ -6824,7 +6824,7 @@ in modules // {
     name = "odfpy-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/odfpy/${name}.tar.gz";
+      url = "mirror://pypi/o/odfpy/${name}.tar.gz";
       sha256 = "e458f969f1ccd7ed77d70a45fe69ad656ac61b39e36e4d32c42d4e3216030891";
     };
 
@@ -6844,7 +6844,7 @@ in modules // {
     version = "0.1.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pathtools/${name}.tar.gz";
+      url = "mirror://pypi/p/pathtools/${name}.tar.gz";
       sha256 = "1h7iam33vwxk8bvslfj4qlsdprdnwf8bvzhqh3jq5frr391cadbw";
     };
 
@@ -6861,7 +6861,7 @@ in modules // {
     name    = "Paver-${version}";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/P/Paver/Paver-${version}.tar.gz";
+      url    = "mirror://pypi/P/Paver/Paver-${version}.tar.gz";
       sha256 = "0lix9d33ndb3yk56sm1zlj80fbmxp0w60yk0d9pr2xqxiwi88sqy";
     };
 
@@ -6885,7 +6885,7 @@ in modules // {
     name    = "passlib-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/passlib/passlib-${version}.tar.gz";
+      url = "mirror://pypi/p/passlib/passlib-${version}.tar.gz";
       sha256 = "e987f6000d16272f75314c7147eb015727e8532a3b747b1a8fb58e154c68392d";
     };
 
@@ -6904,7 +6904,7 @@ in modules // {
     disabled = ! isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pdfminer/pdfminer-${version}.tar.gz";
+      url = "mirror://pypi/p/pdfminer/pdfminer-${version}.tar.gz";
       sha256 = "0qpjv4b776dwvpf5a7v19g41qsz97bv0qqsyvm7a31k50n9pn65s";
     };
 
@@ -6922,7 +6922,7 @@ in modules // {
     name = "peppercorn-0.5";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/peppercorn/${name}.tar.gz";
+      url = "mirror://pypi/p/peppercorn/${name}.tar.gz";
       sha256 = "921cba5d51fa211e6da0fbd2120b9a98d663422a80f5bb669ad81ffb0909774b";
     };
 
@@ -6939,7 +6939,7 @@ in modules // {
     disabled = pythonOlder "3.4"; # old versions require backported libraries
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pew/${name}.tar.gz";
+      url = "mirror://pypi/p/pew/${name}.tar.gz";
       sha256 = "0p188ah80l0rzbib2srahj2sswz8rcpqwbrbajyv2r5c1m5k6r4b";
     };
 
@@ -6957,7 +6957,7 @@ in modules // {
     name = "pies-2.6.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pies/${name}.tar.gz";
+      url = "mirror://pypi/p/pies/${name}.tar.gz";
       sha256 = "d8d6ae4faa0a7da5d634ad8c6ca4bb22b70ad53bb7ecd91af23d490fcd2a88e8";
     };
 
@@ -6979,7 +6979,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pies2overrides/${name}.tar.gz";
+      url = "mirror://pypi/p/pies2overrides/${name}.tar.gz";
       sha256 = "2a91445afc7f692bdbabfbf00d3defb1d47ad7825eb568a6464359758ab35763";
     };
 
@@ -7000,7 +7000,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pirate-get/${name}.tar.gz";
+      url = "mirror://pypi/p/pirate-get/${name}.tar.gz";
       sha256 = "033dwv0w9fx3dwrna3fzvmynsfhb2qjhx6f2i9sfv82ijvkm8ynz";
     };
 
@@ -7020,7 +7020,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/plotly/${name}.tar.gz";
+      url = "mirror://pypi/p/plotly/${name}.tar.gz";
       sha256 = "628679e880caab22e2a46273e85e1d1ce1382b631e1c7bbfe539f804c5269b21";
     };
 
@@ -7040,7 +7040,7 @@ in modules // {
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-poppler-qt4/" +
+      url = "mirror://pypi/p/python-poppler-qt4/" +
             "python-poppler-qt4-${version}.tar.gz";
       sha256 = "00e3f89f4e23a844844d082918a89c2cbb1e8231ecb011b81d592e7e3c33a74c";
     };
@@ -7068,7 +7068,7 @@ in modules // {
     name = "pudb-2013.3.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pudb/${name}.tar.gz";
+      url = "mirror://pypi/p/pudb/${name}.tar.gz";
       sha256 = "81b20a995803c4be513e6d36c8ec9a531d3ccb24670b2416abc20f3933ddb8be";
     };
 
@@ -7086,7 +7086,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pycares/${name}.tar.gz";
+      url = "mirror://pypi/p/pycares/${name}.tar.gz";
       sha256 = "a18341ea030e2cc0743acdf4aa72302bdf6b820938b36ce4bd76e43faa2276a3";
     };
 
@@ -7107,7 +7107,7 @@ in modules // {
     version = "0.1.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-axolotl/${name}.tar.gz";
+      url = "mirror://pypi/p/python-axolotl/${name}.tar.gz";
       sha256 = "1i3id1mjl67n4sca31s5zwq96kswgsi6lga6np83ayb45rxggvhx";
     };
 
@@ -7127,7 +7127,7 @@ in modules // {
     version = "0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-axolotl-curve25519/${name}.tar.gz";
+      url = "mirror://pypi/p/python-axolotl-curve25519/${name}.tar.gz";
       sha256 = "1h1rsdr7m8lvgxwrwng7qv0xxmyc9k0q7g9nbcr6ks2ipyjzcnf5";
     };
 
@@ -7169,7 +7169,7 @@ in modules // {
     name = "pyramid-1.5.7";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid/${name}.tar.gz";
       sha256 = "1d29fj86724z68zcj9ximl2nrn34pflrlr6v9mwyhcv8rdf2sc61";
     };
 
@@ -7213,7 +7213,7 @@ in modules // {
     name = "pyramid_beaker-0.8";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_beaker/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_beaker/${name}.tar.gz";
       sha256 = "0hflx3qkcdml1mwpq53sz46s7jickpfn0zy0ns2c7j445j66bp3p";
     };
 
@@ -7231,7 +7231,7 @@ in modules // {
     name = "pyramid_chameleon-0.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyramid_chameleon/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_chameleon/${name}.tar.gz";
       sha256 = "d176792a50eb015d7865b44bd9b24a7bd0489fa9a5cebbd17b9e05048cef9017";
     };
 
@@ -7253,7 +7253,7 @@ in modules // {
     version = "2.5";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_jinja2/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_jinja2/${name}.tar.gz";
       sha256 = "93c86e3103b454301f4d66640191aba047f2ab85ba75647aa18667b7448396bd";
     };
 
@@ -7271,7 +7271,7 @@ in modules // {
     name = "pyramid_debugtoolbar-1.0.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_debugtoolbar/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_debugtoolbar/${name}.tar.gz";
       sha256 = "1vnzg1qnnyisv7znxg7pasayfyr3nz7rrs5nqr4fmdgwj9q2pyv0";
     };
 
@@ -7284,7 +7284,7 @@ in modules // {
     name = "pyramid_mako-0.3.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_mako/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_mako/${name}.tar.gz";
       sha256 = "00811djmsc4rz20kpy2paam05fbx6dmrv2i5jf90f6xp6zw4isy6";
     };
 
@@ -7297,7 +7297,7 @@ in modules // {
     name = "pyramid_exclog-0.7";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_exclog/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_exclog/${name}.tar.gz";
       sha256 = "a58c82866c3e1a350684e6b83b440d5dc5e92ca5d23794b56d53aac06fb65a2c";
     };
 
@@ -7314,7 +7314,7 @@ in modules // {
     name = "pyramid_tm-0.10";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_tm/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_tm/${name}.tar.gz";
       sha256 = "99528c54accf2bd5860d10634fe8972e8375b2d0f50ee08f208ed0484ffafc1d";
     };
 
@@ -7331,7 +7331,7 @@ in modules // {
     version = "0.3.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyramid_multiauth/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_multiauth/${name}.tar.gz";
       sha256 = "c33f357e0a216cd6ef7d143d40d4679c9fb0796a1eabaf1249aeef63ed000828";
     };
 
@@ -7379,7 +7379,7 @@ in modules // {
     version = "1.1.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/R/Radicale/Radicale-${version}.tar.gz";
+      url = "mirror://pypi/R/Radicale/Radicale-${version}.tar.gz";
       sha256 = "1c5lv8qca21mndkx350wxv34qypqh6gb4rhzms4anr642clq3jg2";
     };
 
@@ -7410,7 +7410,7 @@ in modules // {
     name = "raven-3.4.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/raven/${name}.tar.gz";
+      url = "mirror://pypi/r/raven/${name}.tar.gz";
       sha256 = "c27e40ab3ccf37f30a9f77acb4917370d9341e25abda8e94b9bd48c7127f7d48";
     };
 
@@ -7428,7 +7428,7 @@ in modules // {
     name = "roman-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/roman/${name}.zip";
+      url = "mirror://pypi/r/roman/${name}.zip";
       sha256 = "90e83b512b44dd7fc83d67eb45aa5eb707df623e6fc6e66e7f273abd4b2613ae";
     };
 
@@ -7449,7 +7449,7 @@ in modules // {
     name = "librosa-${version}";
     version = "0.4.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/librosa/librosa-0.4.0.tar.gz";
+      url = "mirror://pypi/l/librosa/librosa-0.4.0.tar.gz";
       sha256 = "cc11dcc41f51c08e442292e8a2fc7d7ee77e0d47ff771259eb63f57fcee6f6e7";
     };
 
@@ -7461,7 +7461,7 @@ in modules // {
     name = "joblib-${version}";
     version = "0.9.4";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/joblib/${name}.tar.gz";
+      url = "mirror://pypi/j/joblib/${name}.tar.gz";
       sha256 = "e5faacf0da7b3035dbca9d56210962b86564aafca71a25f4ea376a405455cd60";
     };
 
@@ -7498,7 +7498,7 @@ in modules // {
     version = "0.1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sarge/${name}.tar.gz";
+      url = "mirror://pypi/s/sarge/${name}.tar.gz";
       sha256 = "08s8896973bz1gg0pkr592w6g4p6v47bkfvws5i91p9xf8b35yar";
     };
 
@@ -7517,7 +7517,7 @@ in modules // {
     disabled = !isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/hyp-server/${name}.tar.gz";
+      url = "mirror://pypi/h/hyp-server/${name}.tar.gz";
       sha256 = "1lafjdcn9nnq6xc3hhyizfwh6l69lc7rixn6dx65aq71c913jc15";
     };
 
@@ -7534,7 +7534,7 @@ in modules // {
     name = "hypatia-0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/h/hypatia/${name}.tar.gz";
+      url = "mirror://pypi/h/hypatia/${name}.tar.gz";
       sha256 = "fb4d394eeac4b06ff2259cada6174aebbe77edd243ffd1deda320cb327f98bd9";
     };
 
@@ -7550,7 +7550,7 @@ in modules // {
     name = "zope.copy-4.0.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.copy/${name}.zip";
+      url = "mirror://pypi/z/zope.copy/${name}.zip";
       sha256 = "eb2a95866df1377741876a3ee62d8600e80089e6246e1a235e86791b29534457";
     };
 
@@ -7566,7 +7566,7 @@ in modules // {
     name = "ssdeep-3.1.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/ssdeep/${name}.tar.gz";
+      url = "mirror://pypi/s/ssdeep/${name}.tar.gz";
       sha256 = "1p9dpykmnfb73cszdiic5wbz5bmbbmkiih08pb4dah5mwq4n7im6";
     };
 
@@ -7580,7 +7580,7 @@ in modules // {
     version = "3.2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/statsd/${name}.tar.gz";
+      url = "mirror://pypi/s/statsd/${name}.tar.gz";
       sha256 = "3fa92bf0192af926f7a0d9be031fe3fd0fbaa1992d42cf2f07e68f76ac18288e";
     };
 
@@ -7605,7 +7605,7 @@ in modules // {
   py3status = buildPythonPackage rec {
     name = "py3status-2.8";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/py3status/${name}.tar.gz";
+      url = "mirror://pypi/p/py3status/${name}.tar.gz";
       sha256 = "1aq4l1lj6j54a8mh9y3yscbxv41bbhz89fiwnydj2gx0md5sq5v5";
     };
     propagatedBuildInputs = with self; [ requests2 ];
@@ -7622,7 +7622,7 @@ in modules // {
     version = "2.0.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/multi_key_dict/multi_key_dict-${version}.tar.gz";
+      url = "mirror://pypi/m/multi_key_dict/multi_key_dict-${version}.tar.gz";
       sha256 = "17lkx4rf4waglwbhc31aak0f28c63zl3gx5k5i1iq2m3gb0xxsyy";
     };
 
@@ -7636,7 +7636,7 @@ in modules // {
     name = "pyramid_zodbconn-0.7";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_zodbconn/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_zodbconn/${name}.tar.gz";
       sha256 = "56cfdb6b13dc87b1c51c7abc1557c63960d6b858e14a2d4c9693c3f7877f5f63";
     };
 
@@ -7656,7 +7656,7 @@ in modules // {
     name = "pyramid_mailer-0.13";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyramid_mailer/${name}.tar.gz";
+      url = "mirror://pypi/p/pyramid_mailer/${name}.tar.gz";
       sha256 = "4debfad05ee65a05ba6f43e2af913e6e30db75ba42254e4aa0291500c4caa1fc";
     };
 
@@ -7672,7 +7672,7 @@ in modules // {
     name = "pyrtlsdr-0.2.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyrtlsdr/${name}.zip";
+      url = "mirror://pypi/p/pyrtlsdr/${name}.zip";
       sha256 = "cbb9086efe4320858c48f4856d09f7face191c4156510b1459ef4e5588935b6a";
     };
 
@@ -7694,7 +7694,7 @@ in modules // {
     name = "repoze.sendmail-4.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/repoze.sendmail/${name}.tar.gz";
+      url = "mirror://pypi/r/repoze.sendmail/${name}.tar.gz";
       sha256 = "51813730adc24728d5ce2609038f7bb81aa1632539d7a79045ef4aa6942eaba2";
     };
 
@@ -7710,7 +7710,7 @@ in modules // {
     name = "zodburi-2.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zodburi/${name}.tar.gz";
+      url = "mirror://pypi/z/zodburi/${name}.tar.gz";
       sha256 = "c04b9beca032bb7b968a3464417596ba4607a927c5e65929860962ddba1cccc0";
     };
 
@@ -7727,7 +7727,7 @@ in modules // {
     propagatedBuildInputs = with self; [ random2 zodb six transaction persistent zc_lockfile zconfig zdaemon zope_interface ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/Z/ZEO/${name}.tar.gz";
+      url = "mirror://pypi/Z/ZEO/${name}.tar.gz";
       sha256 = "63555b6d2b5f98d215c4b5fdce004fb0475daa6efc8b70f39c77d646c12d7e51";
     };
 
@@ -7742,7 +7742,7 @@ in modules // {
     doCheck = !isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/random2/${name}.zip";
+      url = "mirror://pypi/r/random2/${name}.zip";
       sha256 = "34ad30aac341039872401595df9ab2c9dc36d0b7c077db1cea9ade430ed1c007";
     };
   };
@@ -7796,7 +7796,7 @@ in modules // {
     version = "2.0b1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/svg.path/${name}.zip";
+      url = "mirror://pypi/s/svg.path/${name}.zip";
       sha256 = "038x4wqkbvcs71x6n6kzr4kn99csyv8v4gqzssr8pqylqpxi56bm";
     };
 
@@ -7813,7 +7813,7 @@ in modules // {
     version = "2016.01.10";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/regex/${name}.tar.gz";
+      url = "mirror://pypi/r/regex/${name}.tar.gz";
       sha256 = "1q3rbmnijjzn7y3cm3qy49b5lqw1fq38zv974xma387lwc37d9q2";
     };
 
@@ -7830,7 +7830,7 @@ in modules // {
     name = "repoze.lru-0.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/repoze.lru/${name}.tar.gz";
+      url = "mirror://pypi/r/repoze.lru/${name}.tar.gz";
       sha256 = "0f7a323bf716d3cb6cb3910cd4fccbee0b3d3793322738566ecce163b01bbd31";
     };
 
@@ -7846,7 +7846,7 @@ in modules // {
     name = "repoze.sphinx.autointerface-0.7.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/repoze.sphinx.autointerface/${name}.tar.gz";
+      url = "mirror://pypi/r/repoze.sphinx.autointerface/${name}.tar.gz";
       sha256 = "97ef5fac0ab0a96f1578017f04aea448651fa9f063fc43393a8253bff8d8d504";
     };
 
@@ -7888,7 +7888,7 @@ in modules // {
     version = "1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/setuptools-git/${name}.tar.gz";
+      url = "mirror://pypi/s/setuptools-git/${name}.tar.gz";
       sha256 = "047d7595546635edebef226bc566579d422ccc48a8a91c7d32d8bd174f68f831";
     };
 
@@ -7915,7 +7915,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/watchdog/${name}.tar.gz";
+      url = "mirror://pypi/w/watchdog/${name}.tar.gz";
       sha256 = "0qj1vqszxwfx6d1s66s96jmfmy2j94bywxiqdydh6ikpvcm8hrby";
     };
 
@@ -7931,7 +7931,7 @@ in modules // {
     name = "pywatchman-${version}";
     version = "1.3.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pywatchman/pywatchman-${version}.tar.gz";
+      url = "mirror://pypi/p/pywatchman/pywatchman-${version}.tar.gz";
       sha256 = "c3d5be183b5b04f6ad575fc71b06dd196185dea1558d9f4d0598ba9beaab8245";
     };
     postPatch = ''
@@ -7946,7 +7946,7 @@ in modules // {
     propagatedBuildInputs = with self; [ zope_interface six zope_testrunner ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/z/zope.tales/${name}.zip";
+      url = "mirror://pypi/z/zope.tales/${name}.zip";
       sha256 = "c0485f09c3f23c7a0ceddabcb02d4a40ebecf8f8f36c87fa9a02c415f96c969e";
     };
   };
@@ -7956,7 +7956,7 @@ in modules // {
     name = "zope.deprecation-4.1.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.deprecation/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.deprecation/${name}.tar.gz";
       sha256 = "fed622b51ffc600c13cc5a5b6916b8514c115f34f7ea2730409f30c061eb0b78";
     };
 
@@ -7972,7 +7972,7 @@ in modules // {
     name = "validictory-1.0.0a2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/v/validictory/validictory-1.0.0a2.tar.gz";
+      url = "mirror://pypi/v/validictory/validictory-1.0.0a2.tar.gz";
       sha256 = "c02388a70f5b854e71e2e09bd6d762a2d8c2a017557562e866d8ffafb0934b07";
     };
 
@@ -7989,7 +7989,7 @@ in modules // {
     name = "venusian-1.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/v/venusian/${name}.tar.gz";
+      url = "mirror://pypi/v/venusian/${name}.tar.gz";
       sha256 = "1720cff2ca9c369c840c1d685a7c7a21da1afa687bfe62edd93cae4bf429ca5a";
     };
 
@@ -8007,7 +8007,7 @@ in modules // {
     name = "Chameleon-2.15";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/C/Chameleon/${name}.tar.gz";
+      url = "mirror://pypi/C/Chameleon/${name}.tar.gz";
       sha256 = "bd1dfc96742c2a5b0b2adcab823bdd848e70c45a994dc4e51dd2cc31e2bae3be";
     };
 
@@ -8026,7 +8026,7 @@ in modules // {
     name = "ddt-1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/ddt/${name}.tar.gz";
+      url = "mirror://pypi/d/ddt/${name}.tar.gz";
       sha256 = "e24ecb7e2cf0bf43fa9d4255d3ae2bd0b7ce30b1d1b89ace7aa68aca1152f37a";
     };
 
@@ -8089,7 +8089,7 @@ in modules // {
     name = "pyxdg-0.25";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyxdg/${name}.tar.gz";
+      url = "mirror://pypi/p/pyxdg/${name}.tar.gz";
       sha256 = "81e883e0b9517d624e8b0499eb267b82a815c0b7146d5269f364988ae031279d";
     };
 
@@ -8108,7 +8108,7 @@ in modules // {
     name = "chardet-2.3.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/chardet/${name}.tar.gz";
+      url = "mirror://pypi/c/chardet/${name}.tar.gz";
       sha256 = "e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa";
     };
 
@@ -8256,7 +8256,7 @@ in modules // {
     version = "1.0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-appconf/django-appconf-${version}.tar.gz";
+      url = "mirror://pypi/d/django-appconf/django-appconf-${version}.tar.gz";
       sha256 = "0q3fg17qi4vwpipbj075zn4wk58p6a946kah8wayks1423xpa4xs";
     };
 
@@ -8275,7 +8275,7 @@ in modules // {
     version = "1.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django_compressor/django_compressor-${version}.tar.gz";
+      url = "mirror://pypi/d/django_compressor/django_compressor-${version}.tar.gz";
       sha256 = "0bp2acagc6b1mmcajlmjf5vvp6zj429bq7p2wks05n47pwfzv281";
     };
 
@@ -8297,7 +8297,7 @@ in modules // {
     disabled = isPy35;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-compat/${name}.tar.gz";
+      url = "mirror://pypi/d/django-compat/${name}.tar.gz";
       sha256 = "195dgr55vzpw1fbjvbw2h35k9bfhvm5zchh2p7nzbq57xmwb3sra";
     };
 
@@ -8316,7 +8316,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django_evolution/${name}.tar.gz";
+      url = "mirror://pypi/d/django_evolution/${name}.tar.gz";
       sha256 = "1qbcx54hq8iy3n2n6cki3bka1m9rp39np4hqddrm9knc954fb7nv";
     };
 
@@ -8333,7 +8333,7 @@ in modules // {
     name = "django-tagging-0.3.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/django-tagging/${name}.tar.gz";
+      url = "mirror://pypi/d/django-tagging/${name}.tar.gz";
       sha256 = "e5fbeb7ca6e0c22a9a96239095dff508040ec95171e51c69e6f8ada72ea4bce2";
     };
 
@@ -8354,7 +8354,7 @@ in modules // {
     version = "0.6.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/django-classy-tags/${name}.tar.gz";
+      url = "mirror://pypi/d/django-classy-tags/${name}.tar.gz";
       sha256 = "0wxvpmjdzk0aajk33y4himn3wqjx7k0aqlka9j8ay3yfav78bdq0";
     };
 
@@ -8375,7 +8375,7 @@ in modules // {
     version = "2.0.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-hijack/${name}.tar.gz";
+      url = "mirror://pypi/d/django-hijack/${name}.tar.gz";
       sha256 = "0rpi1bkfx74xfbb2nk874kfdra1jcqp2vzky1r3z7zidlc9kah04";
     };
 
@@ -8393,7 +8393,7 @@ in modules // {
     version = "1.4.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-nose/${name}.tar.gz";
+      url = "mirror://pypi/d/django-nose/${name}.tar.gz";
       sha256 = "0rl9ipa98smprlw56xqlhzhps28p84wg0640qlyn0rjyrpsdmf0r";
     };
 
@@ -8414,7 +8414,7 @@ in modules // {
     version = "0.6.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-modelcluster/django-modelcluster-${version}.tar.gz";
+      url = "mirror://pypi/d/django-modelcluster/django-modelcluster-${version}.tar.gz";
       sha256 = "1plsdi44dvsj2sfx79lsrccjfg0ymajcsf5n0mln4cwd4qi5mwpx";
     };
 
@@ -8433,7 +8433,7 @@ in modules // {
     version = "3.2.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/djangorestframework/${name}.tar.gz";
+      url = "mirror://pypi/d/djangorestframework/${name}.tar.gz";
       sha256 = "06kp4hg3y4bqy2ixlb1q6bw81gwgsb86l4lanbav7bp1grrbbnj1";
     };
 
@@ -8452,7 +8452,7 @@ in modules // {
     version = "4.2.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/django-redis/${name}.tar.gz";
+      url = "mirror://pypi/d/django-redis/${name}.tar.gz";
       sha256 = "9ad6b299458f7e6bfaefa8905f52560017369d82fb8fb0ed4b41adc048dbf11c";
     };
 
@@ -8476,7 +8476,7 @@ in modules // {
     version = "1.10.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-reversion/${name}.tar.gz";
+      url = "mirror://pypi/d/django-reversion/${name}.tar.gz";
       sha256 = "01iv8w6lmmq98qjhxmnp8ddjxifmhxcmp612ijd91wc8nv8lk12w";
     };
 
@@ -8495,7 +8495,7 @@ in modules // {
     version = "0.5.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-silk/${name}.tar.gz";
+      url = "mirror://pypi/d/django-silk/${name}.tar.gz";
       sha256 = "845abc688738858ce06e993c4b7dbbcfcecf33029e828f143463ff96f9a78947";
     };
 
@@ -8527,7 +8527,7 @@ in modules // {
     disabled = pythonOlder "2.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-taggit/django-taggit-${version}.tar.gz";
+      url = "mirror://pypi/d/django-taggit/django-taggit-${version}.tar.gz";
       sha256 = "1xy4mm1y6z6bpakw907859wz7fiw7jfm586dj89w0ggdqlb0767b";
     };
 
@@ -8544,7 +8544,7 @@ in modules // {
     version = "3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-treebeard/${name}.tar.gz";
+      url = "mirror://pypi/d/django-treebeard/${name}.tar.gz";
       sha256 = "10p9rb2m1zccszg7590fjd0in6rabzsh86f5m7qm369mapc3b6dc";
     };
 
@@ -8563,7 +8563,7 @@ in modules // {
     version = "1.5.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/django-pipeline/${name}.tar.gz";
+      url = "mirror://pypi/d/django-pipeline/${name}.tar.gz";
       sha256 = "1y49fa8jj7x9qjj5wzhns3zxwj0s73sggvkrv660cqw5qb7d8hha";
     };
 
@@ -8579,7 +8579,7 @@ in modules // {
   django_pipeline_1_3 = self.django_pipeline.overrideDerivation (super: rec {
     name = "django-pipeline-1.3.27";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/django-pipeline/${name}.tar.gz";
+      url = "mirror://pypi/d/django-pipeline/${name}.tar.gz";
       sha256 = "0iva3cmnh5jw54c7w83nx9nqv523hjvkbjchzd2pb6vzilxf557k";
     };
   });
@@ -8607,7 +8607,7 @@ in modules // {
     version = "0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pillowfight/pillowfight-${version}.tar.gz";
+      url = "mirror://pypi/p/pillowfight/pillowfight-${version}.tar.gz";
       sha256 = "1mh1nhcjjgv7x134sv0krri59ng8bp2w6cwsxc698rixba9f3g0m";
     };
 
@@ -8626,7 +8626,7 @@ in modules // {
     version = "0.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/keepalive/keepalive-${version}.tar.gz";
+      url = "mirror://pypi/k/keepalive/keepalive-${version}.tar.gz";
       sha256 = "3c6b96f9062a5a76022f0c9d41e9ef5552d80b1cadd4fccc1bf8f183ba1d1ec1";
     };
 
@@ -8645,7 +8645,7 @@ in modules // {
     version = "1.7.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-${version}.tar.gz";
+      url = "mirror://pypi/S/SPARQLWrapper/SPARQLWrapper-${version}.tar.gz";
       sha256 = "1dpwwlcdk4m8wr3d9lb24g1xcvs202c0ir4q3jcijy88is3bvgmp";
     };
 
@@ -8670,7 +8670,7 @@ in modules // {
     version = "0.10.1a";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dulwich/${name}.tar.gz";
+      url = "mirror://pypi/d/dulwich/${name}.tar.gz";
       sha256 = "02rknqarwy7p50693cqswbibqwgxzrfzdq4yhwqxbdmhbsmh0rk6";
     };
 
@@ -8691,7 +8691,7 @@ in modules // {
     version = "0.8.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/h/hg-git/${name}.tar.gz";
+      url = "mirror://pypi/h/hg-git/${name}.tar.gz";
       sha256 = "0hz0i6qgcn3ic292sny86mdl1psj1bnczcai1b1kzvwcla6z99py";
     };
 
@@ -8744,7 +8744,7 @@ in modules // {
     name = "dtopt-0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/d/dtopt/${name}.tar.gz";
+      url = "mirror://pypi/d/dtopt/${name}.tar.gz";
       sha256 = "06ae07a12294a7ba708abaa63f838017d1a2faf6147a1e7a14ca4fa28f86da7f";
     };
 
@@ -8762,7 +8762,7 @@ in modules // {
     version = "0.13";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/ecdsa/${name}.tar.gz";
+      url = "mirror://pypi/e/ecdsa/${name}.tar.gz";
       sha256 = "1yj31j0asmrx4an9xvsaj2icdmzy6pw0glfpqrrkrphwdpi1xkv4";
     };
 
@@ -8782,7 +8782,7 @@ in modules // {
     name = "elpy-${version}";
     version = "1.9.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/elpy/${name}.tar.gz";
+      url = "mirror://pypi/e/elpy/${name}.tar.gz";
       sha256 = "419f7b05b19182bc1aedde1ae80812c1534e59a0493476aa01ea819e76ba26f0";
     };
     python2Deps = if isPy3k then [ ] else [ self.rope ];
@@ -8802,7 +8802,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/enum/${name}.tar.gz";
+      url = "mirror://pypi/e/enum/${name}.tar.gz";
       sha256 = "9bdfacf543baf2350df7613eb37f598a802f346985ca0dc1548be6494140fdff";
     };
 
@@ -8823,7 +8823,7 @@ in modules // {
     version = "1.0.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/enum34/${name}.tar.gz";
+      url = "mirror://pypi/e/enum34/${name}.tar.gz";
       sha256 = "0iz4jjdvdgvfllnpmd92qxj5fnfxqpgmjpvpik0jjim3lqk9zhfk";
     };
 
@@ -8839,7 +8839,7 @@ in modules // {
   epc = buildPythonPackage rec {
     name = "epc-0.0.3";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/epc/${name}.tar.gz";
+      url = "mirror://pypi/e/epc/${name}.tar.gz";
       sha256 = "30b594bd4a4acbd5bda0d3fa3d25b4e8117f2ff8f24d2d1e3e36c90374f3c55e";
     };
 
@@ -8857,7 +8857,7 @@ in modules // {
     name = "et_xmlfile-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/et_xmlfile/${name}.tar.gz";
+      url = "mirror://pypi/e/et_xmlfile/${name}.tar.gz";
       sha256="0nrkhcb6jdrlb6pwkvd4rycw34y3s931hjf409ij9xkjsli9fkb1";
     };
 
@@ -8888,7 +8888,7 @@ in modules // {
     name = "eventlet-0.17.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/eventlet/${name}.tar.gz";
+      url = "mirror://pypi/e/eventlet/${name}.tar.gz";
       sha256 = "0vam0qfm8p5jkpp2cv12r5bnpnv902ld7q074h7x5y5g9rqyj8c7";
     };
 
@@ -8912,7 +8912,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/fastimport/${name}.tar.gz";
+      url = "mirror://pypi/f/fastimport/${name}.tar.gz";
       sha256 = "0k8x7552ypx9rc14vbsvg2lc6z0r8pv9laah28pdwyynbq10825d";
     };
 
@@ -8932,7 +8932,7 @@ in modules // {
     name = "feedgenerator-1.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/feedgenerator/${name}.tar.gz";
+      url = "mirror://pypi/f/feedgenerator/${name}.tar.gz";
       sha256 = "5d6b0b10134ac392be0c0c3a39c0e1d7e9c17cc7894590f75981e3f497a4a60f";
     };
 
@@ -8953,7 +8953,7 @@ in modules // {
     name = "feedparser-5.2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/f/feedparser/${name}.tar.gz";
+      url = "mirror://pypi/f/feedparser/${name}.tar.gz";
       sha256 = "1ycva69bqssalhqg45rbrfipz3l6hmycszy26k0351fhq990c0xx";
     };
 
@@ -8974,7 +8974,7 @@ in modules // {
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyfribidi/${name}.zip";
+      url = "mirror://pypi/p/pyfribidi/${name}.zip";
       sha256 = "6f7d83c09eae0cb98a40b85ba3dedc31af4dbff8fc4425f244c1e9f44392fded";
     };
 
@@ -8991,7 +8991,7 @@ in modules // {
     namePrefix = "";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/docker-compose/${name}.tar.gz";
+      url = "mirror://pypi/d/docker-compose/${name}.tar.gz";
       sha256 = "10i4032d99hm5nj1p74pcad9i3gz1h5x3096byklncgssfyjqki6";
     };
 
@@ -9019,7 +9019,7 @@ in modules // {
     name = "filebrowser_safe-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/f/filebrowser_safe/${name}.tar.gz";
+      url = "mirror://pypi/f/filebrowser_safe/${name}.tar.gz";
       sha256 = "02bn60fdslvng2ckn65fms3hjbzgsa8qa5161a8lr720wbx8gpj2";
     };
 
@@ -9050,7 +9050,7 @@ in modules // {
     version = "2.5.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/f/flake8/${name}.tar.gz";
+      url = "mirror://pypi/f/flake8/${name}.tar.gz";
       sha256 = "0bs9cz4fr99r2rwig1b8jwaadl1nan7kgpdzqwj0bwbckwbmh7nc";
     };
 
@@ -9070,7 +9070,7 @@ in modules // {
     version = "3.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/flaky/${name}.tar.gz";
+      url = "mirror://pypi/f/flaky/${name}.tar.gz";
       sha256 = "1x9ixika7wqjj52x8wnsh1vk7jadkdqpx01plj7mlh8slwyq4s41";
     };
 
@@ -9091,7 +9091,7 @@ in modules // {
     name = "flask-0.10.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/F/Flask/Flask-0.10.1.tar.gz";
+      url = "mirror://pypi/F/Flask/Flask-0.10.1.tar.gz";
       sha256 = "4c83829ff83d408b5e1d4995472265411d2c414112298f2eb4b359d9e4563373";
     };
 
@@ -9109,7 +9109,7 @@ in modules // {
     version = "0.10";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Assets/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Assets/${name}.tar.gz";
       sha256 = "1v6ika3ias21xzhg7kglki99nwfx1i33rdhnw9kdqbwxkpwbwkyl";
     };
 
@@ -9128,7 +9128,7 @@ in modules // {
     name = "Flask-Cache-0.13.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Cache/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Cache/${name}.tar.gz";
       sha256 = "90126ca9bc063854ef8ee276e95d38b2b4ec8e45fd77d5751d37971ee27c7ef4";
     };
 
@@ -9146,7 +9146,7 @@ in modules // {
     version = "2.1.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Cors/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Cors/${name}.tar.gz";
       sha256 = "0fd618a4f88ykqx4x55viz47cm9rl214q1b45a0b4mz5vhxffqpj";
     };
 
@@ -9165,7 +9165,7 @@ in modules // {
     version = "0.2.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Login/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Login/${name}.tar.gz";
       sha256 = "09ygn0r3i3jz065a5psng6bhlsqm78msnly4z6x39bs48r5ww17p";
     };
 
@@ -9188,7 +9188,7 @@ in modules // {
     version = "1.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Migrate/Flask-Migrate-1.7.0.tar.gz";
+      url = "mirror://pypi/F/Flask-Migrate/Flask-Migrate-1.7.0.tar.gz";
       sha256 = "16d7vnaj9xmxvb3qbcmhahm3ldfdhzzi6y221h62x4v1v1jayx7v";
     };
 
@@ -9213,7 +9213,7 @@ in modules // {
     version = "0.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Principal/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Principal/${name}.tar.gz";
       sha256 = "0lwlr5smz8vfm5h9a9i7da3q1c24xqc6vm9jdywdpgxfbi5i7mpm";
     };
 
@@ -9233,7 +9233,7 @@ in modules // {
     version = "0.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-PyMongo/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-PyMongo/${name}.tar.gz";
       sha256 = "0305qngvjrjyyabf8gxqgqvd9ffh00gr5yfrjf4nncr2my9svbyd";
     };
 
@@ -9251,7 +9251,7 @@ in modules // {
     version = "2.0.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-Script/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Script/${name}.tar.gz";
       sha256 = "0zqh2yq8zk7m9b4xw1ryqmrljkdigfb3hk5155a3b5hkfnn6xxyf";
     };
 
@@ -9272,7 +9272,7 @@ in modules // {
     version = "2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/Flask-SQLAlchemy/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-SQLAlchemy/${name}.tar.gz";
       sha256 = "1i9ps5d5snih9xlqhrvmi3qfiygkmqzxh92n25kj4pf89kj4s965";
     };
 
@@ -9290,7 +9290,7 @@ in modules // {
     name = "wtforms-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/W/WTForms/WTForms-${version}.zip";
+      url = "mirror://pypi/W/WTForms/WTForms-${version}.zip";
       sha256 = "0vyl26y9cg409cfyj8rhqxazsdnd0jipgjw06civhrd53yyi1pzz";
     };
 
@@ -9313,7 +9313,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/FlexGet/${name}.tar.gz";
+      url = "mirror://pypi/F/FlexGet/${name}.tar.gz";
       sha256 = "0f7aaf0bf37860f0c5adfb0ba59ca228aa3f5c582131445623a4c3bc82d45346";
     };
 
@@ -9347,7 +9347,7 @@ in modules // {
     name = "grappelli_safe-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/grappelli_safe/${name}.tar.gz";
+      url = "mirror://pypi/g/grappelli_safe/${name}.tar.gz";
       sha256 = "8b21b4724bce449cc4f22dc74ed0be9b3e841d968f3271850bf4836864304eb6";
     };
 
@@ -9375,7 +9375,7 @@ in modules // {
     name = "tvrage-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-tvrage/python-tvrage-${version}.tar.gz";
+      url = "mirror://pypi/p/python-tvrage/python-tvrage-${version}.tar.gz";
       sha256 = "f8a530376c5cf1bc573d1945a8504c3394b228c731a3eff5100c705997a72063";
     };
 
@@ -9397,7 +9397,7 @@ in modules // {
     disabled = !isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python2-pythondialog/python2-pythondialog-${version}.tar.gz";
+      url = "mirror://pypi/p/python2-pythondialog/python2-pythondialog-${version}.tar.gz";
       sha256 = "1yhkagsh99bfi592ymczf8rnw8rk6n9hdqy3dd98m3yrx8zmjvry";
     };
 
@@ -9415,7 +9415,7 @@ in modules // {
     version = "0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyRFC3339/pyRFC3339-${version}.tar.gz";
+      url = "mirror://pypi/p/pyRFC3339/pyRFC3339-${version}.tar.gz";
       sha256 = "1pp648xsjaw9h1xq2mgwzda5wis2ypjmzxlksc1a8grnrdmzy155";
     };
 
@@ -9428,7 +9428,7 @@ in modules // {
     version = "0.9.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/C/ConfigArgParse/ConfigArgParse-${version}.tar.gz";
+      url = "mirror://pypi/C/ConfigArgParse/ConfigArgParse-${version}.tar.gz";
       sha256 = "0a984pvv7370yz7zbkl6s6i7yyl9myahx0m9jkjvg3hz5q8mf70l";
     };
 
@@ -9451,7 +9451,7 @@ in modules // {
     name = "jsonschema-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jsonschema/jsonschema-${version}.tar.gz";
+      url = "mirror://pypi/j/jsonschema/jsonschema-${version}.tar.gz";
       sha256 = "0hddbqjm4jq63y8jf44nswina1crjs16l9snb6m3vvgyg31klrrn";
     };
 
@@ -9479,7 +9479,7 @@ in modules // {
     version = "2.14.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/v/vcversioner/vcversioner-${version}.tar.gz";
+      url = "mirror://pypi/v/vcversioner/vcversioner-${version}.tar.gz";
       sha256 = "11ivq1bm7v0yb4nsfbv9m7g7lyjn112gbvpjnjz8nv1fx633dm5c";
     };
 
@@ -9492,7 +9492,7 @@ in modules // {
     name = "falcon-0.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/falcon/${name}.tar.gz";
+      url = "mirror://pypi/f/falcon/${name}.tar.gz";
       sha256 = "10ivzk88m8nn3bqbg6xgv6yfy2dgp6yzbcvr645y93pzlash4xpj";
     };
 
@@ -9538,7 +9538,7 @@ in modules // {
     name = "fonttools-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/FontTools/fonttools-${version}.tar.gz";
+      url = "mirror://pypi/F/FontTools/fonttools-${version}.tar.gz";
       sha256 = "0f4iblpbf3y3ghajiccvdwk2f46cim6dsj6fq1kkrbqfv05dr4nz";
     };
 
@@ -9586,7 +9586,7 @@ in modules // {
     name = "forbiddenfruit-${version}";
 
     src = pkgs.fetchurl {
-      url= "https://pypi.python.org/packages/source/f/forbiddenfruit/${name}.tar.gz";
+      url= "mirror://pypi/f/forbiddenfruit/${name}.tar.gz";
       sha256 = "0xra2kw6m8ag29ifwmhi5zqksh4cr0yy1waqd488rm59kcr3zl79";
     };
 
@@ -9601,7 +9601,7 @@ in modules // {
     name = "fs-0.5.4";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/f/fs/${name}.tar.gz";
+      url    = "mirror://pypi/f/fs/${name}.tar.gz";
       sha256 = "ba2cca8773435a7c86059d57cb4b8ea30fda40f8610941f7822d1ce3ffd36197";
     };
 
@@ -9652,7 +9652,7 @@ in modules // {
     name = "fusepy-2.0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/fusepy/${name}.tar.gz";
+      url = "mirror://pypi/f/fusepy/${name}.tar.gz";
       sha256 = "0v5grm4zyf58hsplwsxfbihddw95lz9w8cy3rpzbyha287swgx8h";
     };
 
@@ -9717,7 +9717,7 @@ in modules // {
     version = "3.0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/futures/${name}.tar.gz";
+      url = "mirror://pypi/f/futures/${name}.tar.gz";
       sha256 = "19485d83f7bd2151c0aeaf88fbba3ee50dadfb222ffc3b66a344ef4952b782a3";
     };
 
@@ -9744,7 +9744,7 @@ in modules // {
     name = "futures-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/futures/${name}.tar.gz";
+      url = "mirror://pypi/f/futures/${name}.tar.gz";
       sha256 = "1lqfzl3z3pkxakgbcrfy6x7x0fp3q18mj5lpz103ljj7fdqha70m";
     };
   };
@@ -9753,7 +9753,7 @@ in modules // {
     name = "gcovr-2.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/gcovr/${name}.tar.gz";
+      url = "mirror://pypi/g/gcovr/${name}.tar.gz";
       sha256 = "2c878e03c2eff2282e64035bec0a30532b2b1173aadf08486401883b79e4dab1";
     };
 
@@ -9833,7 +9833,7 @@ in modules // {
     disabled = isPy3k || isPyPy;  # see https://github.com/surfly/gevent/issues/248
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gevent/${name}.tar.gz";
+      url = "mirror://pypi/g/gevent/${name}.tar.gz";
       sha256 = "0cds7yvwdlqmd590i59vzxaviwxk4js6dkhnmdxb3p1xac7wmq9s";
     };
 
@@ -9860,7 +9860,7 @@ in modules // {
     version = "1.2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/geventhttpclient/${name}.tar.gz";
+      url = "mirror://pypi/g/geventhttpclient/${name}.tar.gz";
       sha256 = "0s1qd1qz0zyzksd5h38ynw06d1012h0k7z8522zhb6mzaq4144yz";
     };
 
@@ -9878,7 +9878,7 @@ in modules // {
     name = "gevent-socketio-0.3.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gevent-socketio/${name}.tar.gz";
+      url = "mirror://pypi/g/gevent-socketio/${name}.tar.gz";
       sha256 = "1zra86hg2l1jcpl9nsnqagy3nl3akws8bvrbpgdxk15x7ywllfak";
     };
 
@@ -9891,7 +9891,7 @@ in modules // {
     name = "gevent-websocket-0.9.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gevent-websocket/${name}.tar.gz";
+      url = "mirror://pypi/g/gevent-websocket/${name}.tar.gz";
       sha256 = "07rqwfpbv13mk6gg8mf0bmvcf6siyffjpgai1xd8ky7r801j4xb4";
     };
 
@@ -9903,7 +9903,7 @@ in modules // {
     name = "genzshcomp-0.5.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/genzshcomp/genzshcomp-0.5.1.tar.gz";
+      url = "mirror://pypi/g/genzshcomp/genzshcomp-0.5.1.tar.gz";
       sha256 = "c77d007cc32cdff836ecf8df6192371767976c108a75b055e057bb6f4a09cd42";
     };
 
@@ -9935,7 +9935,7 @@ in modules // {
     disabled = !isPy26 && !isPy27;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/gipc/${name}.zip";
+      url = "mirror://pypi/g/gipc/${name}.zip";
       sha256 = "08c35xzv7nr12d9xwlywlbyzzz2igy0yy6y52q2nrkmh5d4slbpc";
     };
 
@@ -9961,7 +9961,7 @@ in modules // {
     name = "git-sweep-0.1.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/git-sweep/${name}.tar.gz";
+      url = "mirror://pypi/g/git-sweep/${name}.tar.gz";
       sha256 = "1csp0zd049d643d409rfivbswwzrayb4i6gkypp5mc27fb1z2afd";
     };
 
@@ -10007,7 +10007,7 @@ in modules // {
     version = "1.0.0a2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/github3.py/${name}.tar.gz";
+      url = "mirror://pypi/g/github3.py/${name}.tar.gz";
       sha256 = "11xvwbzfy04vwbjnpc8wcrjjzghbrbdzffrdfk70v0zdnxqg8hc5";
     };
 
@@ -10037,7 +10037,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/g/goobook/${name}.tar.gz";
+      url    = "mirror://pypi/g/goobook/${name}.tar.gz";
       sha256 = "02xmq8sjavza17av44ks510934wrshxnsm6lvhvazs45s92b671i";
     };
 
@@ -10081,7 +10081,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/google-apputils/${name}.tar.gz";
+      url = "mirror://pypi/g/google-apputils/${name}.tar.gz";
       sha256 = "1sxsm5q9vr44qzynj8l7p3l7ffb0zl1jdqhmmzmalkx941nbnj1b";
     };
 
@@ -10110,7 +10110,7 @@ in modules // {
     disabled = isPyPy;  # builtin for pypy
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/greenlet/${name}.zip";
+      url = "mirror://pypi/g/greenlet/${name}.zip";
       sha256 = "1zlmsygjw69xlq56vz1z5ivzy9bwc7knjaykn2yy2hv4w2j4yb7k";
     };
 
@@ -10132,7 +10132,7 @@ in modules // {
     name = "gspread-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gspread/${name}.tar.gz";
+      url = "mirror://pypi/g/gspread/${name}.tar.gz";
       sha256 = "dba45ef9e652dcd8cf561ae65569bd6ecd18fcc77b991521490698fb2d847106";
     };
 
@@ -10148,7 +10148,7 @@ in modules // {
     name = "gssapi-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/gssapi/${name}.tar.gz";
+      url = "mirror://pypi/g/gssapi/${name}.tar.gz";
       sha256 = "0mdl7m6h57n0zkfmm6fqz0hldfxrb2d7d48k2lhc8hqbr3962c7x";
     };
 
@@ -10198,7 +10198,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/guessit/${name}.tar.gz";
+      url = "mirror://pypi/g/guessit/${name}.tar.gz";
       sha256 = "068d3dmyk4v04p2zna0340lsdnpkm10gyza62apd9akgjh9rfs48";
     };
 
@@ -10220,7 +10220,7 @@ in modules // {
     name = "gunicorn-19.1.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/gunicorn/${name}.tar.gz";
+      url = "mirror://pypi/g/gunicorn/${name}.tar.gz";
       sha256 = "ae1dd6452f62b3470bc9acaf62cb5301545fbb9c697d863a5bfe35097ed7a0b3";
     };
 
@@ -10248,7 +10248,7 @@ in modules // {
     name = "hcs_utils-1.5";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/h/hcs_utils/${name}.tar.gz";
+      url    = "mirror://pypi/h/hcs_utils/${name}.tar.gz";
       sha256 = "1d2za9crkgzildx610w3zif2i8phcqhh6n8nzg3yvy2mg0s18mkl";
     };
 
@@ -10293,7 +10293,7 @@ in modules // {
     name = "htmllaundry-2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/htmllaundry/${name}.tar.gz";
+      url = "mirror://pypi/h/htmllaundry/${name}.tar.gz";
       sha256 = "e428cba78d5a965e959f5dac2eb7d5f7d627dd889990d5efa8d4e03f3dd768d9";
     };
 
@@ -10346,7 +10346,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/h/http_signature/${name}.tar.gz";
+      url = "mirror://pypi/h/http_signature/${name}.tar.gz";
       sha256 = "14acc192ef20459d5e11b4e800dd3a4542f6bd2ab191bf5717c696bf30936c62";
     };
 
@@ -10363,7 +10363,7 @@ in modules // {
     name = "httpbin-0.2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/httpbin/${name}.tar.gz";
+      url = "mirror://pypi/h/httpbin/${name}.tar.gz";
       sha256 = "6b57f563900ecfe126015223a259463848daafbdc2687442317c0992773b9054";
     };
 
@@ -10381,7 +10381,7 @@ in modules // {
     name = "httplib2-0.9.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/httplib2/${name}.tar.gz";
+      url = "mirror://pypi/h/httplib2/${name}.tar.gz";
       sha256 = "126rsryvw9vhbf3qmsfw9lf4l4xm2srmgs439lgma4cpag4s3ay3";
     };
 
@@ -10401,7 +10401,7 @@ in modules // {
     doCheck = false;  # no tests in source
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/hypothesis/${name}.tar.gz";
+      url = "mirror://pypi/h/hypothesis/${name}.tar.gz";
       sha256 = "12dxrvn108q2j20brrk6zcb8w00kn3af1c07c0fv572nf2ngyaxy";
     };
 
@@ -10445,7 +10445,7 @@ in modules // {
     name = "colored-${version}";
     version = "1.1.5";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/colored/${name}.tar.gz";
+      url = "mirror://pypi/c/colored/${name}.tar.gz";
       sha256 = "1r1vsypk8v7az82d66bidbxlndx1h7xd4m43hpg1a6hsjr30wrm3";
     };
   };
@@ -10456,7 +10456,7 @@ in modules // {
     version = "0.2.2";
     disabled = isPy3k;
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/lsi/${name}.tar.gz";
+      url = "mirror://pypi/l/lsi/${name}.tar.gz";
       sha256 = "0429iilb06yhsmvj3xp6wyhfh1rp4ndxlhwrm80r97z0w7plrk94";
     };
     propagatedBuildInputs = [
@@ -10480,7 +10480,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/h/httpretty/${name}.tar.gz";
+      url = "mirror://pypi/h/httpretty/${name}.tar.gz";
       sha256 = "0f295zj272plr9lhf80kgz19dxkargwv3ar83rwavrcy516mgg9n";
     };
 
@@ -10512,7 +10512,7 @@ in modules // {
     name = "icalendar-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/icalendar/${name}.tar.gz";
+      url = "mirror://pypi/i/icalendar/${name}.tar.gz";
       sha256 = "93d0b94eab23d08f62962542309916a9681f16de3d5eca1c75497f30f1b07792";
     };
 
@@ -10535,7 +10535,7 @@ in modules // {
     disabled = (!isPy26) || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/i/importlib/importlib-1.0.2.tar.gz";
+      url = "mirror://pypi/i/importlib/importlib-1.0.2.tar.gz";
       sha256 = "131jvp6ahllcqblszjg6fxrzh4k50w8g60sq924b4nb8lxm9dl14";
     };
   };
@@ -10544,7 +10544,7 @@ in modules // {
     name = "influxdb-0.1.12";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/i/influxdb/${name}.tar.gz";
+      url = "mirror://pypi/i/influxdb/${name}.tar.gz";
       sha256 = "6b5ea154454b86d14f2a3960d180e666ba9863da964032dacf2b50628e774a33";
     };
 
@@ -10629,7 +10629,7 @@ in modules // {
 
     /* Hydra fix exists only on github for now.
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/I/INGInious/INGInious-${version}.tar.gz";
+      url = "mirror://pypi/I/INGInious/INGInious-${version}.tar.gz";
       md5 = "40474dd6b6d4fc26e47a1d9c77bcf943";
     };
     */
@@ -10653,7 +10653,7 @@ in modules // {
     version = "0.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/interruptingcow/${name}.tar.gz";
+      url = "mirror://pypi/i/interruptingcow/${name}.tar.gz";
       sha256 = "1cv4pm2h0f87n9w4r3l1f96skwmng95sawn7j00ns0rdp1zshr9d";
     };
 
@@ -10670,7 +10670,7 @@ in modules // {
     name = "iptools-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/i/iptools/iptools-${version}.tar.gz";
+      url = "mirror://pypi/i/iptools/iptools-${version}.tar.gz";
       sha256 = "0f03875a5bed740ba4bf44decb6a78679cca914a1ee8a6cc468114485c4d98e3";
     };
 
@@ -10688,7 +10688,7 @@ in modules // {
     name = "ipy-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/I/IPy/IPy-${version}.tar.gz";
+      url = "mirror://pypi/I/IPy/IPy-${version}.tar.gz";
       sha256 = "5d6abb870c25f946c45c35cf50e66155598660f2765b35cb12e36ed5223c2b89";
     };
 
@@ -10706,7 +10706,7 @@ in modules // {
     name = "ipykernel-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipykernel/${name}.tar.gz";
+      url = "mirror://pypi/i/ipykernel/${name}.tar.gz";
       sha256 = "1av769gbzfm1zy9p94wicwwwxmyc7s7zk1ginq16x0wc69hwc57j";
     };
 
@@ -10736,7 +10736,7 @@ in modules // {
     name = "ipyparallel-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipyparallel/${name}.tar.gz";
+      url = "mirror://pypi/i/ipyparallel/${name}.tar.gz";
       sha256 = "ffa7e2e29fdc4844b3c1721f46b42eee5a1abe5cbb851ccf79d0f4f89b9fe21a";
     };
 
@@ -10762,7 +10762,7 @@ in modules // {
     name = "ipython-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipython/${name}.tar.gz";
+      url = "mirror://pypi/i/ipython/${name}.tar.gz";
       sha256 = "14hnf3m087z39ndn5irj1ficc6l197bmdj6fpvz8bwi7la99cbq5";
     };
 
@@ -10796,7 +10796,7 @@ in modules // {
     name = "ipython_genutils-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipython_genutils/${name}.tar.gz";
+      url = "mirror://pypi/i/ipython_genutils/${name}.tar.gz";
       sha256 = "3a0624a251a26463c9dfa0ffa635ec51c4265380980d9a50d65611c3c2bd82a6";
     };
 
@@ -10821,7 +10821,7 @@ in modules // {
     name = "ipywidgets-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipywidgets/${name}.tar.gz";
+      url = "mirror://pypi/i/ipywidgets/${name}.tar.gz";
       sha256 = "ceeb325e45ade9537c2d115fed9d522e5c6e90bb161592e2f0807375dc661028";
     };
 
@@ -10841,7 +10841,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/i/ipaddr/${name}.tar.gz";
+      url = "mirror://pypi/i/ipaddr/${name}.tar.gz";
       sha256 = "18ycwkfk3ypb1yd09wg20r7j7zq2a73d7j6j10qpgra7a7abzhyj";
     };
 
@@ -10856,7 +10856,7 @@ in modules // {
     name = "ipaddress-1.0.15";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipaddress/${name}.tar.gz";
+      url = "mirror://pypi/i/ipaddress/${name}.tar.gz";
       sha256 = "0dk6ky7akh5j4y3qbpnbi0qby64nyprbkrjm2s32pcfdr77qav5g";
     };
 
@@ -10877,7 +10877,7 @@ in modules // {
 
     disabled = isPyPy;  # setupterm: could not find terminfo database
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/i/ipdb/${name}.zip";
+      url = "mirror://pypi/i/ipdb/${name}.zip";
       sha256 = "1763d1564113f5eb89df77879a8d3213273c4d7ff93dcb37a3070cdf0c34fd7c";
     };
     propagatedBuildInputs = with self; [ ipython ];
@@ -10886,7 +10886,7 @@ in modules // {
   ipdbplugin = buildPythonPackage {
     name = "ipdbplugin-1.4";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/ipdbplugin/ipdbplugin-1.4.tar.gz";
+      url = "mirror://pypi/i/ipdbplugin/ipdbplugin-1.4.tar.gz";
       sha256 = "4778d78b5d0af1a2a6d341aed9e72eb73b1df6b179e145b4845d3a209137029c";
     };
     propagatedBuildInputs = with self; [ self.nose self.ipython ];
@@ -10923,7 +10923,7 @@ in modules // {
     name = "iso8601-${version}";
     version = "0.1.11";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/iso8601/${name}.tar.gz";
+      url = "mirror://pypi/i/iso8601/${name}.tar.gz";
       sha256 = "e8fb52f78880ae063336c94eb5b87b181e6a0cc33a6c008511bac9a6e980ef30";
     };
 
@@ -10944,7 +10944,7 @@ in modules // {
     name = "isort-4.2.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/isort/${name}.tar.gz";
+      url = "mirror://pypi/i/isort/${name}.tar.gz";
       sha256 = "0xqxnkli3j69mj1m0i1r9n68bfkdxfcgxi602lqgy491m21q1rpj";
     };
 
@@ -10962,7 +10962,7 @@ in modules // {
     name = "jedi-0.9.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/j/jedi/${name}.tar.gz";
+      url = "mirror://pypi/j/jedi/${name}.tar.gz";
       sha256 = "0c8x962ynpx001fdvp07m2q5jk4igkxbj3rmnydavphvlgxijk1v";
     };
 
@@ -10988,7 +10988,7 @@ in modules // {
     name = "jellyfish-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jellyfish/${name}.tar.gz";
+      url = "mirror://pypi/j/jellyfish/${name}.tar.gz";
       sha256 = "04p80gwwlhxjp8zpjf70a62x69l9rlvnz1pwi5ar52gyajn8z6z1";
     };
 
@@ -11006,7 +11006,7 @@ in modules // {
     version = "0.3.1-0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/j2cli/${name}.tar.gz";
+      url = "mirror://pypi/j/j2cli/${name}.tar.gz";
       sha256 = "0y3w1x9935qzx8w6m2r6g4ghyjmxn33wryiif6xb56q7cj9w1433";
     };
 
@@ -11033,7 +11033,7 @@ in modules // {
     name = "Jinja2-2.8";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/J/Jinja2/${name}.tar.gz";
+      url = "mirror://pypi/J/Jinja2/${name}.tar.gz";
       sha256 = "1x0v41lp5m1pjix3l46zx02b7lqp2hflgpnxwkywxynvi3zz47xw";
     };
 
@@ -11058,7 +11058,7 @@ in modules // {
     name = "jmespath-0.7.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jmespath/${name}.tar.gz";
+      url = "mirror://pypi/j/jmespath/${name}.tar.gz";
       sha256 = "1lazbx65imassd7h24z49za001rvx1lmx8r0l21h4izs7pp14nnd";
     };
 
@@ -11078,7 +11078,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jrnl/${name}.tar.gz";
+      url = "mirror://pypi/j/jrnl/${name}.tar.gz";
       sha256 = "af599a863ac298533685a7236fb86307eebc00a38eb8bb96f4f67b5d83227ec8";
     };
 
@@ -11099,7 +11099,7 @@ in modules // {
     name = "jupyter_client-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jupyter_client/${name}.tar.gz";
+      url = "mirror://pypi/j/jupyter_client/${name}.tar.gz";
       sha256 = "ff1ef5c6c3031a62db46ec6329867b4cb1595e6102a7819b3b5252b0c524bdb8";
     };
 
@@ -11126,7 +11126,7 @@ in modules // {
     name = "jupyter_core-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jupyter_core/${name}.tar.gz";
+      url = "mirror://pypi/j/jupyter_core/${name}.tar.gz";
       sha256 = "96a68a3b1d018ff7776270b26b7cb0cfd7a18a53ef2061421daff435707d198c";
     };
 
@@ -11155,7 +11155,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jsonpath-rw/${name}.tar.gz";
+      url = "mirror://pypi/j/jsonpath-rw/${name}.tar.gz";
       sha256 = "05c471281c45ae113f6103d1268ec7a4831a2e96aa80de45edc89b11fac4fbec";
     };
 
@@ -11180,7 +11180,7 @@ in modules // {
     name = "keyring-8.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/keyring/${name}.tar.gz";
+      url = "mirror://pypi/k/keyring/${name}.tar.gz";
       sha256 = "1286sh5g53168qxbl4g5bmns9ci0ld0jl3h44b7h8is5nw1421ar";
     };
 
@@ -11228,7 +11228,7 @@ in modules // {
     disabled = pythonOlder "2.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/kombu/${name}.tar.gz";
+      url = "mirror://pypi/k/kombu/${name}.tar.gz";
       sha256 = "09xpxpjz9nk8d14dj361dqdwyjwda3jlf1a7v6jif9wn2xm37ar2";
     };
 
@@ -11278,7 +11278,7 @@ in modules // {
     meta.maintainers = with maintainers; [ mornfall ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/kitchen/kitchen-1.1.1.tar.gz";
+      url = "mirror://pypi/k/kitchen/kitchen-1.1.1.tar.gz";
       sha256 = "0ki840hjk1q19w6icv0dj2jxb00966nwy9b1jib0dgdspj00yrr5";
     };
   });
@@ -11288,7 +11288,7 @@ in modules // {
     version = "0.5.11";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pylast/${name}.tar.gz";
+      url = "mirror://pypi/p/pylast/${name}.tar.gz";
       sha256 = "bf35820be35447d55564d36072d40b09ac8a7fd41a6f1a7a9d408f4d0eaefac4";
     };
 
@@ -11307,7 +11307,7 @@ in modules // {
     version = "1.0.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pylru/${name}.tar.gz";
+      url = "mirror://pypi/p/pylru/${name}.tar.gz";
       sha256 = "0b0pq0l7xv83dfsajsc49jcxzc99kb9jfx1a1dlx22hzcy962dvi";
     };
 
@@ -11325,7 +11325,7 @@ in modules // {
     version = "1.2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/lazy-object-proxy/${name}.tar.gz";
+      url = "mirror://pypi/l/lazy-object-proxy/${name}.tar.gz";
       sha256 = "22ed751a2c63c6cf718674fd7461b1dfc45215bab4751ca32b6c9b8cb2734cb3";
     };
 
@@ -11371,7 +11371,7 @@ in modules // {
     name = "libcloud-0.18.0";
 
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/a/apache-libcloud/apache-libcloud-0.18.0.tar.bz2;
+      url = mirror://pypi/a/apache-libcloud/apache-libcloud-0.18.0.tar.bz2;
       sha256 = "0ahdp14ddly074qg5cksxdhqaws0kj445xmhz1y7lzspsp6fk1xg";
     };
 
@@ -11395,7 +11395,7 @@ in modules // {
     version = "2015.10.04";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/limnoria/${name}.tar.gz";
+      url = "mirror://pypi/l/limnoria/${name}.tar.gz";
       sha256 = "1hwwwr0z2vsirgwd92z17nbhnhsz0m25bpxn5sanqlbcjbwhyk9z";
     };
 
@@ -11420,7 +11420,7 @@ in modules // {
     name = "line_profiler-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/line_profiler/${name}.tar.gz";
+      url = "mirror://pypi/l/line_profiler/${name}.tar.gz";
       sha256 = "a9e0c9ffa814f1215107c86c890afa8e63bec5a37d951f6f9d3668c1df2b1900";
     };
 
@@ -11441,7 +11441,7 @@ in modules // {
     version = "0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/linode/linode-${version}.tar.gz";
+      url = "mirror://pypi/l/linode/linode-${version}.tar.gz";
       sha256 = "db3c2a7fab8966d903a63f16c515bff241533e4ef2d746aa7aae4a49bba5e573";
     };
 
@@ -11459,7 +11459,7 @@ in modules // {
     name = "llfuse-1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/llfuse/${name}.tar.bz2";
+      url = "mirror://pypi/l/llfuse/${name}.tar.bz2";
       sha256 = "1li7q04ljrvwharw4fblcbfhvk6s0l3lnv8yqb4c22lcgbkiqlps";
     };
 
@@ -11487,7 +11487,7 @@ in modules // {
     name = "locustio-0.7.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/locustio/${name}.tar.gz";
+      url = "mirror://pypi/l/locustio/${name}.tar.gz";
       sha256 = "c9ca6fdfe6a6fb187a3d54ddf9b1518196348e8f20537f0a14ca81a264ffafa2";
     };
 
@@ -11507,7 +11507,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/llvmlite/${name}.tar.gz";
+      url = "mirror://pypi/l/llvmlite/${name}.tar.gz";
       sha256 = "a10d8d5e597c6a54ec418baddd31a51a0b7937a895d75b240d890aead946081c";
     };
 
@@ -11563,7 +11563,7 @@ in modules // {
     name = "logilab-common-0.63.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/logilab-common/${name}.tar.gz";
+      url = "mirror://pypi/l/logilab-common/${name}.tar.gz";
       sha256 = "1rr81zlmlgdma3s75i5c1l8q2m25v4ac41i9pniik4mhkc6a0fv0";
     };
 
@@ -11575,7 +11575,7 @@ in modules // {
     version = "0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/logilab-constraint/${name}.tar.gz";
+      url = "mirror://pypi/l/logilab-constraint/${name}.tar.gz";
       sha256 = "1n0xim4ij1n4yvyqqvyc0wllhjs22szglsd5av0j8k2qmck4njcg";
     };
 
@@ -11596,7 +11596,7 @@ in modules // {
     # more work is needed before upgrading
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/l/lxml/${name}.tar.gz";
+      url = "mirror://pypi/l/lxml/${name}.tar.gz";
       sha256 = "16a0fa97hym9ysdk3rmqz32xdjqmy4w34ld3rm3jf5viqjx65lxk";
     };
 
@@ -11615,7 +11615,7 @@ in modules // {
     name = "python-magic-0.4.10";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/python-magic/${name}.tar.gz";
+      url = "mirror://pypi/p/python-magic/${name}.tar.gz";
       sha256 = "1hx2sjd4fdswswj3yydn2azxb59rjmi9b7jzh94lf1wnxijjizbr";
     };
 
@@ -11663,7 +11663,7 @@ in modules // {
     name = "m2crypto-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-${version}.tar.gz";
+      url = "mirror://pypi/M/M2Crypto/M2Crypto-${version}.tar.gz";
       sha256 = "1ac3b6eafa5ff7e2a0796675316d7569b28aada45a7ab74042ad089d15a9567f";
     };
 
@@ -11686,7 +11686,7 @@ in modules // {
     name = "Mako-1.0.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/M/Mako/${name}.tar.gz";
+      url = "mirror://pypi/M/Mako/${name}.tar.gz";
       sha256 = "17k7jy3byi4hj6ksszib6gxbf6n7snnnirnbrdldn848abjc4l15";
     };
 
@@ -11709,7 +11709,7 @@ in modules // {
     version = "0.23";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-${version}.tar.gz";
+      url = "mirror://pypi/M/MarkupSafe/MarkupSafe-${version}.tar.gz";
       sha256 = "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3";
     };
 
@@ -11726,7 +11726,7 @@ in modules // {
     version = "1.8.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/manuel/${name}.tar.gz";
+      url = "mirror://pypi/m/manuel/${name}.tar.gz";
       sha256 = "1diyj6a8bvz2cdf9m0g2bbx9z2yjjnn3ylbg1zinpcjj6vldfx59";
     };
 
@@ -11744,7 +11744,7 @@ in modules // {
     name = "markdown-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/M/Markdown/Markdown-${version}.tar.gz";
+      url = "mirror://pypi/M/Markdown/Markdown-${version}.tar.gz";
       sha256 = "1kll5b35wqkhvniwm2kh6rqc43wakv9ls0qm6g5318pjmbkywdp4";
     };
 
@@ -11812,7 +11812,7 @@ in modules // {
     name = "mccabe-0.4.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/mccabe/${name}.tar.gz";
+      url = "mirror://pypi/m/mccabe/${name}.tar.gz";
       sha256 = "0yr08a36h8lqlif10l4xcikbbig7q8f41gqywir7rrvnv3mi4aws";
     };
 
@@ -11841,7 +11841,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mechanize/${name}.tar.gz";
+      url = "mirror://pypi/m/mechanize/${name}.tar.gz";
       sha256 = "0rj7r166i1dyrq0ihm5rijfmvhs8a04im28lv05c0c3v206v4rrf";
     };
 
@@ -11863,7 +11863,7 @@ in modules // {
     version = "0.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/M/MechanicalSoup/${name}.zip";
+      url = "mirror://pypi/M/MechanicalSoup/${name}.zip";
       sha256 = "02jkwly4gw1jqm55l4wwn0j0ggnysx55inw9j96bif5l49z5cacd";
     };
 
@@ -11882,7 +11882,7 @@ in modules // {
     name = "meld3-1.0.0";
 
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/m/meld3/meld3-1.0.0.tar.gz;
+      url = mirror://pypi/m/meld3/meld3-1.0.0.tar.gz;
       sha256 = "57b41eebbb5a82d4a928608962616442e239ec6d611fe6f46343e765e36f0b2b";
     };
 
@@ -11899,7 +11899,7 @@ in modules // {
     name = "memcached-1.51";
 
     src = if isPy3k then pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python3-memcached/python3-${name}.tar.gz";
+      url = "mirror://pypi/p/python3-memcached/python3-${name}.tar.gz";
       sha256 = "0na8b369q8fivh3y0nvzbvhh3lgvxiyyv9xp93cnkvwfsr8mkgkw";
     } else pkgs.fetchurl {
       url = "http://ftp.tummy.com/pub/python-memcached/old-releases/python-${name}.tar.gz";
@@ -11918,7 +11918,7 @@ in modules // {
     version = "0.39";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/memory_profiler/${name}.tar.gz";
+      url = "mirror://pypi/m/memory_profiler/${name}.tar.gz";
       sha256 = "61021f2dade7edd6cc09d7924bfdccc453bd1949608412a3e021d44a410d3a23";
     };
 
@@ -12005,7 +12005,7 @@ in modules // {
     version = "2.0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/munch/${name}.tar.gz";
+      url = "mirror://pypi/m/munch/${name}.tar.gz";
       sha256 = "1420683a94f3a2ffc77935ddd28aa9ccb540dd02b75e02ed7ea863db437ab8b2";
     };
 
@@ -12051,7 +12051,7 @@ in modules // {
     version = "1.3.3";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/r/rainbowstream/${name}.tar.gz";
+      url    = "mirror://pypi/r/rainbowstream/${name}.tar.gz";
       sha256 = "08598slbn8sm2hjs0q1041fv7m56k2ky4q66rsihacjw0mg7blai";
     };
 
@@ -12097,7 +12097,7 @@ in modules // {
     name = "mistune-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mistune/${name}.tar.gz";
+      url = "mirror://pypi/m/mistune/${name}.tar.gz";
       sha256 = "6076dedf768348927d991f4371e5a799c6a0158b16091df08ee85ee231d929a7";
     };
 
@@ -12146,7 +12146,7 @@ in modules // {
     name = "mock-1.3.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/mock/${name}.tar.gz";
+      url = "mirror://pypi/m/mock/${name}.tar.gz";
       sha256 = "1xm0xkaz8d8d26kdk09f2n9vn543ssd03vmpkqlmgq3crjz7s90y";
     };
 
@@ -12168,7 +12168,7 @@ in modules // {
     name = "ModestMaps-1.4.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/M/ModestMaps/${name}.tar.gz";
+      url = "mirror://pypi/M/ModestMaps/${name}.tar.gz";
       sha256 = "0vyi1m9q4pc34i6rq5agb4x3qicx5sjlbxwmxfk70k2l5mnbjca3";
     };
 
@@ -12205,7 +12205,7 @@ in modules // {
     name = "moretools-0.1a41";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/moretools/${name}.tar.gz";
+      url = "mirror://pypi/m/moretools/${name}.tar.gz";
       sha256 = "1n442wprbl3cmg08233m1sr3g4z0i8hv9g6bhch7kzdmbl21399f";
     };
 
@@ -12265,7 +12265,7 @@ in modules // {
     name = "mpmath-0.19";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mpmath/${name}.tar.gz";
+      url = "mirror://pypi/m/mpmath/${name}.tar.gz";
       sha256 = "08ijsr4ifrqv3cjc26mkw0dbvyygsa99in376hr4b96ddm1gdpb8";
     };
 
@@ -12288,7 +12288,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-mpd/python-mpd-0.3.0.tar.gz";
+      url = "mirror://pypi/p/python-mpd/python-mpd-0.3.0.tar.gz";
       sha256 = "02812eba1d2e0f46e37457f5a6fa23ba203622e4bcab0a19b265e66b08cd21b4";
     };
 
@@ -12304,7 +12304,7 @@ in modules // {
     version = "0.5.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-mpd2/python-mpd2-${version}.tar.bz2";
+      url = "mirror://pypi/p/python-mpd2/python-mpd2-${version}.tar.bz2";
       sha256 = "1gfrxf71xll1w6zb69znqg5c9j0g7036fsalkvqprh2id640cl3a";
     };
 
@@ -12328,7 +12328,7 @@ in modules // {
     name = "mpv-0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mpv/${name}.tar.gz";
+      url = "mirror://pypi/m/mpv/${name}.tar.gz";
       sha256 = "0b9kd70mshdr713f3l1lbnz1q0vlg2y76h5d8liy1bzqm7hjcgfw";
     };
     buildInputs = [ pkgs.mpv ];
@@ -12348,7 +12348,7 @@ in modules // {
     version = "0.1.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/mr.bob/mr.bob-${version}.tar.gz";
+      url = "mirror://pypi/m/mr.bob/mr.bob-${version}.tar.gz";
       sha256 = "6737eaf98aaeae85e07ebef844ee5156df2f06a8b28d7c3dcb056f811c588121";
     };
 
@@ -12372,7 +12372,7 @@ in modules // {
     version = "0.4.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/msgpack-python/${name}.tar.gz";
+      url = "mirror://pypi/m/msgpack-python/${name}.tar.gz";
       sha256 = "bfcc581c9dbbf07cc2f951baf30c3249a57e20dcbd60f7e6ffc43ab3cc614794";
     };
 
@@ -12398,7 +12398,7 @@ in modules // {
     version = "0.4.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/multipledispatch/${name}.tar.gz";
+      url = "mirror://pypi/m/multipledispatch/${name}.tar.gz";
       sha256 = "07d41fb3ed25e8424536e48a8566f88a0f9926ca4b6174bff6aa16c98251b92e";
     };
 
@@ -12414,7 +12414,7 @@ in modules // {
     name = "munkres-1.0.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/munkres/${name}.tar.gz";
+      url = "mirror://pypi/m/munkres/${name}.tar.gz";
       sha256 = "c78f803b9b776bfb20a25c9c7bb44adbf0f9202c2024d51aa5969d21e560208d";
     };
 
@@ -12434,7 +12434,7 @@ in modules // {
     name = "musicbrainzngs-0.5";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/musicbrainzngs/${name}.tar.gz";
+      url = "mirror://pypi/m/musicbrainzngs/${name}.tar.gz";
       sha256 = "281388ab750d2996e9feca4580fd4215d616a698e02cd6719cb9b8562945c489";
     };
 
@@ -12472,7 +12472,7 @@ in modules // {
     name = "mutagen-1.27";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/mutagen/${name}.tar.gz";
+      url = "mirror://pypi/m/mutagen/${name}.tar.gz";
       sha256 = "cc884fe1e20fe220be7ce7c3b269f4cadc69a8310150a3a41162fba1ca9c88bd";
     };
 
@@ -12584,7 +12584,7 @@ in modules // {
     name = "pygraphviz-1.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pygraphviz/${name}.tar.gz";
+      url = "mirror://pypi/p/pygraphviz/${name}.tar.gz";
       sha256 = "7c294cbc9d88946be671cc0d8602aac176d8c56695c0a7d871eadea75a958408";
     };
 
@@ -12625,7 +12625,7 @@ in modules // {
     propagatedBuildInputs = with self; [ pymysql sqlalchemy ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pymysql_sa/pymysql_sa-1.0.tar.gz";
+      url = "mirror://pypi/p/pymysql_sa/pymysql_sa-1.0.tar.gz";
       sha256 = "a2676bce514a29b2d6ab418812259b0c2f7564150ac53455420a20bd7935314a";
     };
 
@@ -12642,7 +12642,7 @@ in modules // {
     __propagatedImpureHostDeps = stdenv.lib.optional stdenv.isDarwin "/usr/lib/libc.dylib";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/monotonic/${name}.tar.gz";
+      url = "mirror://pypi/m/monotonic/${name}.tar.gz";
       sha256 = "1diab6hfh3jpa1f0scpqaqrawk4g97ss4v7gkn2yw8znvdm6abw5";
     };
 
@@ -12661,7 +12661,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/M/MySQL-python/${name}.zip";
+      url = "mirror://pypi/M/MySQL-python/${name}.zip";
       sha256 = "0x0c2jg0bb3pp84njaqiic050qkyd7ymwhfvhipnimg58yv40441";
     };
 
@@ -12681,7 +12681,7 @@ in modules // {
     name = "mysql-connector-repackaged-0.3.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/m/mysql-connector-repackaged/${name}.tar.gz";
+      url = "mirror://pypi/m/mysql-connector-repackaged/${name}.tar.gz";
       sha256 = "170fbf11c54def1b5fcc919be0a890b760bb2eca81f56123a5dda0c69b5b099e";
     };
 
@@ -12739,7 +12739,7 @@ in modules // {
     version = "0.3.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nameparser/${name}.tar.gz";
+      url = "mirror://pypi/n/nameparser/${name}.tar.gz";
       sha256 = "1zi94m99ziwwd6kkip3w2xpnl05r2cfv9iq68inz7np81c3g8vag";
     };
 
@@ -12755,7 +12755,7 @@ in modules // {
     name = "nbconvert-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nbconvert/${name}.tar.gz";
+      url = "mirror://pypi/n/nbconvert/${name}.tar.gz";
       sha256 = "e0296e45293dd127d028f678e3b6aba3f1db3283a134178bdb49eea402d4cf1c";
     };
 
@@ -12783,7 +12783,7 @@ in modules // {
     name = "nbformat-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nbformat/${name}.tar.gz";
+      url = "mirror://pypi/n/nbformat/${name}.tar.gz";
       sha256 = "5261c957589b9dfcd387c338d59375162ba9ca82c69e378961a1f4e641285db5";
     };
 
@@ -12821,7 +12821,7 @@ in modules // {
     propagatedBuildInputs = with self ; [ dns pyasn1 ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sleekxmpp/${name}.tar.gz";
+      url = "mirror://pypi/s/sleekxmpp/${name}.tar.gz";
       sha256 = "1krkhkvj8xw5a6c2xlf7h1rg9xdcm9d8x2niivwjahahpvbl6krr";
     };
 
@@ -12839,7 +12839,7 @@ in modules // {
     disabled = (!isPy34);
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/slixmpp/${name}.tar.gz";
+      url = "mirror://pypi/s/slixmpp/${name}.tar.gz";
       sha256 = "030ca7e71cbb7e17fb48f83db97779fdbac0b4424cef01245f3276a110b30a6c";
     };
 
@@ -12857,7 +12857,7 @@ in modules // {
     disabled = isPy35;  # https://github.com/drkjam/netaddr/issues/117
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/netaddr/${name}.tar.gz";
+      url = "mirror://pypi/n/netaddr/${name}.tar.gz";
       sha256 = "06dxjlbcicq7q3vqy8agq11ra01kvvd47j4mk6dmghjsyzyckxd1";
     };
 
@@ -12875,7 +12875,7 @@ in modules // {
     name = "netifaces-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/netifaces/${name}.tar.gz";
+      url = "mirror://pypi/n/netifaces/${name}.tar.gz";
       sha256 = "1plw237a4zib4z8s62g0mrs8gm3kjfrp5sxh6bbk9nl3rdls2mln";
     };
 
@@ -12890,7 +12890,7 @@ in modules // {
     version = "2.0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/hpack/hpack-${version}.tar.gz";
+      url = "mirror://pypi/h/hpack/hpack-${version}.tar.gz";
       sha256 = "1k4wa8c52bd6x109bn6hc945595w6aqgzj6ipy6c2q7vxkzalzhd";
     };
 
@@ -12915,7 +12915,7 @@ in modules // {
     version = "0.14.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/netlib/${name}.tar.gz";
+      url = "mirror://pypi/n/netlib/${name}.tar.gz";
       sha256 = "0xcfjym780wjr32p3g50w2gifqy3589898idzd3fwgj93akv04ng";
     };
 
@@ -12936,7 +12936,7 @@ in modules // {
     version = "0.11.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/N/Nevow/Nevow-${version}.tar.gz";
+      url = "mirror://pypi/N/Nevow/Nevow-${version}.tar.gz";
       sha256 = "1z0y8a5q4fa2nmh0dap7cs9pp5xs3jm6q0g4vpwcw77q7jagdmw9";
       name = "${name}.tar.gz";
     };
@@ -12977,7 +12977,7 @@ in modules // {
     name = "nibabel-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nibabel/${name}.tar.gz";
+      url = "mirror://pypi/n/nibabel/${name}.tar.gz";
       sha256 = "0k8mv5zmwb6vc8kwrydl3pp0pnw937rf5mz10figkxczrw6dkk7h";
     };
 
@@ -13007,7 +13007,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nipype/${name}.tar.gz";
+      url = "mirror://pypi/n/nipype/${name}.tar.gz";
       sha256 = "7fb143cd4d05f18db1cb7f0b83dba13d3dcf55b4eb3d16df08c97033ccae507b";
     };
 
@@ -13036,7 +13036,7 @@ in modules // {
     name = "nose-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nose/${name}.tar.gz";
+      url = "mirror://pypi/n/nose/${name}.tar.gz";
       sha256 = "f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98";
     };
 
@@ -13060,7 +13060,7 @@ in modules // {
     version = "0.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nose-exclude/${name}.tar.gz";
+      url = "mirror://pypi/n/nose-exclude/${name}.tar.gz";
       sha256 = "44466a9bcb56d2e568750f91504d1278c74eabb259a305b06e975b87b51635da";
     };
 
@@ -13080,7 +13080,7 @@ in modules // {
     name = "nose-selecttests-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nose-selecttests/${name}.zip";
+      url = "mirror://pypi/n/nose-selecttests/${name}.zip";
       sha256 = "0lgrfgp3sq8xi8d9grrg0z8jsyk0wl8a3rxw31hb7vdncin5b7n5";
     };
 
@@ -13095,7 +13095,7 @@ in modules // {
   nose2 = if isPy26 then null else (buildPythonPackage rec {
     name = "nose2-0.5.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nose2/${name}.tar.gz";
+      url = "mirror://pypi/n/nose2/${name}.tar.gz";
       sha256 = "0595rh6b6dncbj0jigsyrgrh6h8fsl6w1fr69h76mxv9nllv0rlr";
     };
     meta = {
@@ -13111,7 +13111,7 @@ in modules // {
     version = "0.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nose-cover3/${name}.tar.gz";
+      url = "mirror://pypi/n/nose-cover3/${name}.tar.gz";
       sha256 = "1la4hhc1yszjpcchvkqk5xmzlb2g1b3fgxj9wwc58qc549whlcc1";
     };
 
@@ -13131,7 +13131,7 @@ in modules // {
     name = "nosexcover-1.0.10";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nosexcover/${name}.tar.gz";
+      url = "mirror://pypi/n/nosexcover/${name}.tar.gz";
       sha256 = "f5b3a7c936c4f703f15418c1f325775098184b69fa572f868edb8a99f8f144a8";
     };
 
@@ -13149,7 +13149,7 @@ in modules // {
   nosejs = buildPythonPackage {
     name = "nosejs-0.9.4";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/N/NoseJS/NoseJS-0.9.4.tar.gz;
+      url = mirror://pypi/N/NoseJS/NoseJS-0.9.4.tar.gz;
       sha256 = "0qrhkd3sga56qf6k0sqyhwfcladwi05gl6aqmr0xriiq1sgva5dy";
     };
     buildInputs = with self; [ nose ];
@@ -13165,7 +13165,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nose-cprof/${name}.tar.gz";
+      url = "mirror://pypi/n/nose-cprof/${name}.tar.gz";
       sha256 = "d1edd5cb3139e897752294d2968bfb066abdd754743fa416e024e5c688893344";
     };
 
@@ -13181,7 +13181,7 @@ in modules // {
     name = "notebook-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/notebook/${name}.tar.gz";
+      url = "mirror://pypi/n/notebook/${name}.tar.gz";
       sha256 = "b597437ba33538221008e21fea71cd01eda9da1515ca3963d7c74e44f4b03d90";
     };
 
@@ -13262,7 +13262,7 @@ in modules // {
     version = "0.3.9";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/emoji/${name}.tar.gz";
+      url = "mirror://pypi/e/emoji/${name}.tar.gz";
       sha256 = "19p5c2nlq0w9972rf9fghyswnijwgig5f8cyzs32kppnmzvzbkxw";
     };
 
@@ -13301,7 +13301,7 @@ in modules // {
   ntplib = buildPythonPackage rec {
     name = "ntplib-0.3.3";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/n/ntplib/ntplib-0.3.3.tar.gz;
+      url = mirror://pypi/n/ntplib/ntplib-0.3.3.tar.gz;
 
       sha256 = "c4621b64d50be9461d9bd9a71ba0b4af06fbbf818bbd483752d95c1a4e273ede";
     };
@@ -13316,7 +13316,7 @@ in modules // {
     name = "numba-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/numba/${name}.tar.gz";
+      url = "mirror://pypi/n/numba/${name}.tar.gz";
       sha256 = "80ce9968591db7c93e36258cc5e6734eb1e42826332799746dc6c073a6d5d317";
     };
 
@@ -13352,7 +13352,7 @@ in modules // {
     name = "numexpr-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/numexpr/${name}.tar.gz";
+      url = "mirror://pypi/n/numexpr/${name}.tar.gz";
       sha256 = "319cdf4e402177a1c8ed4972cffd09f523446f186d347b7c1974787cdabf0294";
     };
 
@@ -13397,7 +13397,7 @@ in modules // {
   numpy_1_10 = self.buildNumpyPackage rec {
     version = "1.10.4";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/numpy/numpy-${version}.tar.gz";
+      url = "mirror://pypi/n/numpy/numpy-${version}.tar.gz";
       sha256 = "7356e98fbcc529e8d540666f5a919912752e569150e9a4f8d869c686f14c720b";
     };
   };
@@ -13405,7 +13405,7 @@ in modules // {
   numpy_1_11 = self.buildNumpyPackage rec {
     version = "1.11.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/numpy/numpy-${version}.tar.gz";
+      url = "mirror://pypi/n/numpy/numpy-${version}.tar.gz";
       sha256 = "0gml1ng7iqk4xcrvspjd5vnfqdwfinvjfyksfawvy5h8426jdld1";
     };
   };
@@ -13415,7 +13415,7 @@ in modules // {
     version = "0.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/numpydoc/${name}.tar.gz";
+      url = "mirror://pypi/n/numpydoc/${name}.tar.gz";
       sha256 = "0d4dnifaxkll50jx6czj05y8cb4ny60njd2wz299sj2jxfy51w4k";
     };
 
@@ -13434,7 +13434,7 @@ in modules // {
     version = "0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/numtraits/${name}.tar.gz";
+      url = "mirror://pypi/n/numtraits/${name}.tar.gz";
       sha256 = "2fca9a6c9334f7358ef1a3e2e64ccaa6a479fc99fc096910e0d5fbe8edcdfd7e";
     };
 
@@ -13453,7 +13453,7 @@ in modules // {
     name = "nwdiag-1.0.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nwdiag/${name}.tar.gz";
+      url = "mirror://pypi/n/nwdiag/${name}.tar.gz";
       sha256 = "0n7ary1fngxk8bk15vabc8fhnmxlh098piciwaviwn7l4a5q1zys";
     };
 
@@ -13509,7 +13509,7 @@ in modules // {
     name = "oauth-1.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/o/oauth/oauth-1.0.1.tar.gz";
+      url = "mirror://pypi/o/oauth/oauth-1.0.1.tar.gz";
       sha256 = "0pdgi35hczsslil4890xqawnbpdazkgf2v1443847h5hy2gq2sg7";
     };
 
@@ -13526,7 +13526,7 @@ in modules // {
     version = "1.9.0.post1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/o/oauth2/${name}.tar.gz";
+      url = "mirror://pypi/o/oauth2/${name}.tar.gz";
       sha256 = "c006a85e7c60107c7cc6da1b184b5c719f6dd7202098196dfa6e55df669b59bf";
     };
 
@@ -13550,7 +13550,7 @@ in modules // {
     name = "oauth2client-1.4.12";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oauth2client/${name}.tar.gz";
+      url = "mirror://pypi/o/oauth2client/${name}.tar.gz";
       sha256 = "0phfk6s8bgpap5xihdk1xv2lakdk1pb3rg6hp2wsg94hxcxnrakl";
     };
 
@@ -13616,7 +13616,7 @@ in modules // {
     version = "2.0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/objgraph/${name}.tar.gz";
+      url = "mirror://pypi/o/objgraph/${name}.tar.gz";
       sha256 = "841de52715774ec1d0e97d9b4462d6e3e10406155f9b61f54ba7db984c45442a";
     };
 
@@ -13637,7 +13637,7 @@ in modules // {
     version= "0.4.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/odo/${name}.tar.gz";
+      url = "mirror://pypi/o/odo/${name}.tar.gz";
       sha256 = "f793df8b212994ea23ce34e90e2048d0237d3b95ecd066ef2cfbb1c2384b79e9";
     };
 
@@ -13661,7 +13661,7 @@ in modules // {
     meta.maintainers = with maintainers; [ mornfall ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/offtrac/${name}.tar.gz";
+      url = "mirror://pypi/o/offtrac/${name}.tar.gz";
       sha256 = "06vd010pa1z7lyfj1na30iqzffr4kzj2k2sba09spik7drlvvl56";
     };
     doCheck = false;
@@ -13672,7 +13672,7 @@ in modules // {
     name = "openpyxl-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/openpyxl/${name}.tar.gz";
+      url = "mirror://pypi/o/openpyxl/${name}.tar.gz";
       sha256 = "1zigyvsq45izkhr1h5gisgi0ag5dm6kz09f01c2cgdfav1bl3mlk";
     };
 
@@ -13719,7 +13719,7 @@ in modules // {
     version = "1.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/o/ordereddict/${name}.tar.gz";
+      url = "mirror://pypi/o/ordereddict/${name}.tar.gz";
       sha256 = "07qvy11nvgxpzarrni3wrww3vpc9yafgi2bch4j2vvvc42nb8d8w";
     };
 
@@ -13759,7 +13759,7 @@ in modules // {
     name = "ply-3.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/ply/${name}.tar.gz";
+      url = "mirror://pypi/p/ply/${name}.tar.gz";
       sha256 = "e7d1bdff026beb159c9942f7a17e102c375638d9478a7ecd4cc0c76afd8de0b8";
     };
 
@@ -13817,7 +13817,7 @@ in modules // {
     name = "oslosphinx-3.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslosphinx/${name}.tar.gz";
+      url = "mirror://pypi/o/oslosphinx/${name}.tar.gz";
       sha256 = "1rjiiahw2y7pg5rl15fvhmfyh26vm433000nwp7c94khx7w85w75";
     };
 
@@ -13833,7 +13833,7 @@ in modules // {
     version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tempest-lib/${name}.tar.gz";
+      url = "mirror://pypi/t/tempest-lib/${name}.tar.gz";
       sha256 = "0x842a67k9f7yk3zr6755s4qldkfngljqy5whd4jb553y4hn5lyj";
     };
 
@@ -13854,7 +13854,7 @@ in modules // {
     version = "0.4.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/os-testr/${name}.tar.gz";
+      url = "mirror://pypi/o/os-testr/${name}.tar.gz";
       sha256 = "0474z0mxb7y3vfk4s097wf1mzji5d135vh27cvlh9q17rq3x9r3w";
     };
 
@@ -13879,7 +13879,7 @@ in modules // {
     doCheck = !isPyPy; # a test fails
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bandit/${name}.tar.gz";
+      url = "mirror://pypi/b/bandit/${name}.tar.gz";
       sha256 = "0qd9kxknac5n5xfl5zjnlmk6jr94krkcx29zgyna8p9lyb828hsk";
     };
 
@@ -13896,7 +13896,7 @@ in modules // {
     version = "1.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.serialization/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.serialization/${name}.tar.gz";
       sha256 = "15k8aql2rx5jzv3hfvmd48vsyw172qa64bs3fmsyx25p37zyfy8a";
     };
 
@@ -13913,7 +13913,7 @@ in modules // {
     version = "0.2.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rfc3986/rfc3986-0.2.2.tar.gz";
+      url = "mirror://pypi/r/rfc3986/rfc3986-0.2.2.tar.gz";
       sha256 = "0yvzz7gp84qqdadbjdh9ch7dz4w19nmhwa704s9m11bljgp3hqmn";
     };
 
@@ -13931,7 +13931,7 @@ in modules // {
     version = "1.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pycadf/pycadf-1.1.0.tar.gz";
+      url = "mirror://pypi/p/pycadf/pycadf-1.1.0.tar.gz";
       sha256 = "0lv9nhbvj1pa8qgn3qvyk9k4q8f7w541074n1rhdjnjkinh4n4dg";
     };
 
@@ -13959,7 +13959,7 @@ in modules // {
     version = "2.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.utils/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.utils/${name}.tar.gz";
       sha256 = "1prgi03nxkcykyja821qkycsqlnpyzw17mpvj8qf3pjmgb9gv1fy";
     };
 
@@ -13976,7 +13976,7 @@ in modules // {
     version = "2.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.middleware/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.middleware/${name}.tar.gz";
       sha256 = "14acinchdpmc1in39mz9kh1h2rd1ygwg3zdhbwzrlhy8wbzzi4w9";
     };
 
@@ -14002,7 +14002,7 @@ in modules // {
      version = "0.11.0";
 
      src = pkgs.fetchurl {
-       url = "https://pypi.python.org/packages/source/o/oslo.versionedobjects/${name}.tar.gz";
+       url = "mirror://pypi/o/oslo.versionedobjects/${name}.tar.gz";
        sha256 = "1ddcb2zf7a3544ay4sxw200a4mz7p0n1f7826h3vibfdqjlc80y7";
      };
 
@@ -14026,7 +14026,7 @@ in modules // {
      disabled = isPyPy;  # a test fails
 
      src = pkgs.fetchurl {
-       url = "https://pypi.python.org/packages/source/c/cachetools/${name}.tar.gz";
+       url = "mirror://pypi/c/cachetools/${name}.tar.gz";
        sha256 = "0js7qx5pa8ibr8487lcf0x3a7w0xml0wa17snd6hjs0857kqhn20";
      };
 
@@ -14040,7 +14040,7 @@ in modules // {
      version = "0.7.0";
 
      src = pkgs.fetchurl {
-       url = "https://pypi.python.org/packages/source/f/futurist/${name}.tar.gz";
+       url = "mirror://pypi/f/futurist/${name}.tar.gz";
        sha256 = "0wf0k9xf5xzmi79418xq8zxwr7w7a4g4alv3dds9afb2l8bh9crg";
      };
 
@@ -14062,7 +14062,7 @@ in modules // {
     version = "2.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.messaging/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.messaging/${name}.tar.gz";
       sha256 = "1af7l4ri3xfjcnjp2yhngz34h3ls00yyj1x8i64dxb86ryy43kd1";
     };
 
@@ -14089,7 +14089,7 @@ in modules // {
    version = "0.5.0";
 
    src = pkgs.fetchurl {
-     url = "https://pypi.python.org/packages/source/o/os-brick/${name}.tar.gz";
+     url = "mirror://pypi/o/os-brick/${name}.tar.gz";
      sha256 = "1q05yk5hada470rwsv3hfjn7pdp9n7pprmnslm723l7cfhf7cgm6";
    };
 
@@ -14115,7 +14115,7 @@ in modules // {
     version = "0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.reports/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.reports/${name}.tar.gz";
       sha256 = "0j27mbsa5y1fn9lxn98xs7p9vipcig47srm5sgbgma0ilv125b65";
     };
 
@@ -14136,7 +14136,7 @@ in modules // {
     version = "1.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-cinderclient/python-cinderclient-${version}.tar.gz";
+      url = "mirror://pypi/p/python-cinderclient/python-cinderclient-${version}.tar.gz";
       sha256 = "1vfcjljfad3034bfhfcrfhphym1ik6qk42nrxzl0gqb9408n6k3l";
     };
 
@@ -14161,7 +14161,7 @@ in modules // {
     version = "3.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-neutronclient/python-neutronclient-${version}.tar.gz";
+      url = "mirror://pypi/p/python-neutronclient/python-neutronclient-${version}.tar.gz";
       sha256 = "0g96x5b8lz407in70j6v7jbj613y6sd61b21j1y03x06b2rk5i02";
     };
 
@@ -14190,7 +14190,7 @@ in modules // {
     version = "1.15.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cliff/${name}.tar.gz";
+      url = "mirror://pypi/c/cliff/${name}.tar.gz";
       sha256 = "1rrbq1nvc84x417hbfm9sc1scia16nilr8nm8ycm8iq5jkh6zfpm";
     };
 
@@ -14211,7 +14211,7 @@ in modules // {
     version = "0.6.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/cmd2/${name}.tar.gz";
+      url = "mirror://pypi/c/cmd2/${name}.tar.gz";
       sha256 = "1a346zcd46c8gwbbp2cxsmvgfkyy26kwxjzdnkv7n47w6660sy5c";
     };
 
@@ -14234,7 +14234,7 @@ in modules // {
     version = "3.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.db/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.db/${name}.tar.gz";
       sha256 = "0jjimsfl53wigzf92dhns813n65qcwilcqlj32m86rxrcz0pjgph";
     };
 
@@ -14252,7 +14252,7 @@ in modules // {
     version = "2.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.rootwrap/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.rootwrap/${name}.tar.gz";
       sha256 = "1711rlmykizw675ihbaqmk3ph6ah0njbygxr9lrdnacy6yrlmbd5";
     };
 
@@ -14277,7 +14277,7 @@ in modules // {
    version = "1.1.0";
 
    src = pkgs.fetchurl {
-     url = "https://pypi.python.org/packages/source/p/python-glanceclient/python-glanceclient-${version}.tar.gz";
+     url = "mirror://pypi/p/python-glanceclient/python-glanceclient-${version}.tar.gz";
      sha256 = "0ppjafsmf29ps23jsw6g2xm66pdi5jdzpywglqqm28b8fj931zsr";
    };
 
@@ -14304,7 +14304,7 @@ in modules // {
    version = "1.2.0";
 
    src = pkgs.fetchurl {
-     url = "https://pypi.python.org/packages/source/w/warlock/${name}.tar.gz";
+     url = "mirror://pypi/w/warlock/${name}.tar.gz";
      sha256 = "0npgi4ks0nww2d6ci791iayab0j6kz6dx3jr7bhpgkql3s4if3bw";
    };
 
@@ -14326,7 +14326,7 @@ in modules // {
     version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.service/oslo.service-0.10.0.tar.gz";
+      url = "mirror://pypi/o/oslo.service/oslo.service-0.10.0.tar.gz";
       sha256 = "1pcnimc2a50arcgq355ad9lramf6y1yv974swgfj6w90v5c6p9gz";
     };
 
@@ -14356,7 +14356,7 @@ in modules // {
     version = "0.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.cache/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.cache/${name}.tar.gz";
       sha256 = "0dzvm5xkfj1alf469d7v3syig9f91kjh4p55k57ykgaww3y4cdjp";
     };
 
@@ -14376,7 +14376,7 @@ in modules // {
     version = "1.0.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pecan/${name}.tar.gz";
+      url = "mirror://pypi/p/pecan/${name}.tar.gz";
       sha256 = "04abmybab8jzbwgmrr0fcpcfhcvvkdsv9q135dss02wyk9q9jv4d";
     };
 
@@ -14398,7 +14398,7 @@ in modules // {
     version = "0.5.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/K/Kajiki/${name}.tar.gz";
+      url = "mirror://pypi/K/Kajiki/${name}.tar.gz";
       sha256 = "1ayhr4g5q2hhh50fd33dkb7l8z8n2hnnx3lmhivzg3paf47b3ssz";
     };
 
@@ -14429,7 +14429,7 @@ in modules // {
     '';
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/ryu/${name}.tar.gz";
+      url = "mirror://pypi/r/ryu/${name}.tar.gz";
       sha256 = "1fhriqi7qnvvx9mbvlfm94i5drh920lg204zy3v0qjz43sinkih6";
     };
   };
@@ -14439,7 +14439,7 @@ in modules // {
     version = "0.8.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/W/WSME/${name}.tar.gz";
+      url = "mirror://pypi/W/WSME/${name}.tar.gz";
       sha256 = "1nw827iz5g9jlfnfbdi8kva565v0kdjzba2lccziimj09r71w900";
     };
 
@@ -14467,7 +14467,7 @@ in modules // {
     version = "1.23.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/taskflow/${name}.tar.gz";
+      url = "mirror://pypi/t/taskflow/${name}.tar.gz";
       sha256 = "15np1rc6g9vksgdj0y930ysx5wbmhvc082g264j5zbj6c479g8qa";
     };
 
@@ -14496,7 +14496,7 @@ in modules // {
     version = "0.9.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/glance_store/${name}.tar.gz";
+      url = "mirror://pypi/g/glance_store/${name}.tar.gz";
       sha256 = "16az3lq9szl0ixna9rd82dmn4sfxqyivhn4z3z79vk8qdfip1sr9";
     };
 
@@ -14525,7 +14525,7 @@ in modules // {
     version = "2.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-swiftclient/python-swiftclient-${version}.tar.gz";
+      url = "mirror://pypi/p/python-swiftclient/python-swiftclient-${version}.tar.gz";
       sha256 = "1j33l4z9vqh0scfncl4fxg01zr1hgqxhhai6gvcih1gccqm4nd7p";
     };
 
@@ -14552,7 +14552,7 @@ in modules // {
     version = "0.2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/castellan/${name}.tar.gz";
+      url = "mirror://pypi/c/castellan/${name}.tar.gz";
       sha256 = "1im9b4qzq4yhn17jjc8927b3hn06h404vsx8chddw2jfp0v4ryfj";
     };
 
@@ -14580,7 +14580,7 @@ in modules // {
     version = "0.2.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/z/zake/${name}.tar.gz";
+      url = "mirror://pypi/z/zake/${name}.tar.gz";
       sha256 = "1rp4xxy7qp0s0wnq3ig4ji8xsl31g901qkdp339ndxn466cqal2s";
     };
 
@@ -14601,7 +14601,7 @@ in modules // {
     version = "0.8.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/automaton/${name}.tar.gz";
+      url = "mirror://pypi/a/automaton/${name}.tar.gz";
       sha256 = "040rw7w92mp34a15vzvbfvhv1cg8zf81s9jbdd9rmwxr0gmgp2ya";
     };
 
@@ -14622,7 +14622,7 @@ in modules // {
     disabled = isPy3k;  # failing tests
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/networking-hyperv/${name}.tar.gz";
+      url = "mirror://pypi/n/networking-hyperv/${name}.tar.gz";
       sha256 = "04wfkl8rffxp6gp7qvhhc8y80cy0akmh3z7k7y2sj6savg9q7jdj";
     };
 
@@ -14648,7 +14648,7 @@ in modules // {
     version = "2.2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/kazoo/${name}.tar.gz";
+      url = "mirror://pypi/k/kazoo/${name}.tar.gz";
       sha256 = "10pb864if9qi2pq9lfb9m8f7z7ss6rml80gf1d9h64lap5crjnjj";
     };
 
@@ -14683,7 +14683,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/osprofiler/${name}.tar.gz";
+      url = "mirror://pypi/o/osprofiler/${name}.tar.gz";
       sha256 = "01rjym49nn4ry1pr2n8fyal1hf17jqhp2yihg8gr15nfjc5iszkx";
     };
 
@@ -14704,7 +14704,7 @@ in modules // {
     version = "1.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/F/FormEncode/${name}.zip";
+      url = "mirror://pypi/F/FormEncode/${name}.zip";
       sha256 = "0y5gywq0l79l85ylr55p4xy0h921zgmfw6zmrvlh83aa4j074xg6";
     };
 
@@ -14729,7 +14729,7 @@ in modules // {
     version = "1.17";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pycountry/${name}.tar.gz";
+      url = "mirror://pypi/p/pycountry/${name}.tar.gz";
       sha256 = "1qvhq0c9xsh6d4apcvjphfzl6xnwhnk4jvhr8x2fdfnmb034lc26";
     };
   };
@@ -14739,7 +14739,7 @@ in modules // {
     version = "0.3.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/nine/${name}.tar.gz";
+      url = "mirror://pypi/n/nine/${name}.tar.gz";
       sha256 = "1zrsbm0hajfvklkhgysp81hy632a3bdakp31m0lcpd9xbp5265zy";
     };
 
@@ -14755,7 +14755,7 @@ in modules // {
     version = "0.3.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/logutils/${name}.tar.gz";
+      url = "mirror://pypi/l/logutils/${name}.tar.gz";
       sha256 = "173w55fg3hp5dhx7xvssmgqkcv5fjlaik11w5dah2fxygkjvhhj0";
     };
   };
@@ -14765,7 +14765,7 @@ in modules // {
     version = "0.12.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.policy/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.policy/${name}.tar.gz";
       sha256 = "06apaj6fwg7f2g5psmxzr5a9apj2l4k2y8kl1hqzyssykblij8ss";
     };
 
@@ -14782,7 +14782,7 @@ in modules // {
     version = "1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/ldappool/${name}.tar.gz";
+      url = "mirror://pypi/l/ldappool/${name}.tar.gz";
       sha256 = "1akmzf51cjfvmd0nvvm562z1w9vq45zsx6fa72kraqgsgxhnrhqz";
     };
 
@@ -14800,7 +14800,7 @@ in modules // {
    version = "2.7.0";
 
    src = pkgs.fetchurl {
-     url = "https://pypi.python.org/packages/source/o/oslo.concurrency/oslo.concurrency-2.7.0.tar.gz";
+     url = "mirror://pypi/o/oslo.concurrency/oslo.concurrency-2.7.0.tar.gz";
      sha256 = "1yp8c87yi6fx1qbq4y1xkx47iiifg7jqzpcghivhxqra8vna185d";
    };
 
@@ -14826,7 +14826,7 @@ in modules // {
     version = "1.3.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/retrying/retrying-1.3.3.tar.gz";
+      url = "mirror://pypi/r/retrying/retrying-1.3.3.tar.gz";
       sha256 = "0fwp86xv0rvkncjdvy2mwcvbglw4w9k0fva25i7zx8kd19b3kh08";
     };
 
@@ -14845,7 +14845,7 @@ in modules // {
     version = "0.13.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/fasteners/fasteners-0.13.0.tar.gz";
+      url = "mirror://pypi/f/fasteners/fasteners-0.13.0.tar.gz";
       sha256 = "0nghdq3zihiqg10dp76ls7yn44m5wjncyz7fk8isagkrspkh9a3n";
     };
 
@@ -14869,7 +14869,7 @@ in modules // {
     version = "0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/a/aioeventlet/aioeventlet-0.4.tar.gz";
+      url = "mirror://pypi/a/aioeventlet/aioeventlet-0.4.tar.gz";
       sha256 = "19krvycaiximchhv1hcfhz81249m3w3jrbp2h4apn1yf4yrc4y7y";
     };
 
@@ -14893,7 +14893,7 @@ in modules // {
     version = "1.12.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.log/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.log/${name}.tar.gz";
       sha256 = "10x596r19zjla5n1bf04j5vncx0c9gpc5wc2jlmgjbl3cyx3vgsv";
     };
 
@@ -14912,7 +14912,7 @@ in modules // {
     version = "0.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.context/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.context/${name}.tar.gz";
       sha256 = "18fmg9dhgngshk63wfb3ddrgx5br8jxkk3x30z40741mslp1fdjy";
     };
 
@@ -14928,7 +14928,7 @@ in modules // {
     version = "2.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.i18n/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.i18n/${name}.tar.gz";
       sha256 = "11jgcvj36g97awh7fpar4xxgwrvzfahq6rw7xxqac32ia790ylcz";
     };
 
@@ -14944,7 +14944,7 @@ in modules // {
     version = "2.5.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslo.config/${name}.tar.gz";
+      url = "mirror://pypi/o/oslo.config/${name}.tar.gz";
       sha256 = "043mavrzj7vjn7kh1dddci4sf67qwqnnn6cm0k1d19alks9hismz";
     };
 
@@ -14960,7 +14960,7 @@ in modules // {
     version = "1.12.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/oslotest/${name}.tar.gz";
+      url = "mirror://pypi/o/oslotest/${name}.tar.gz";
       sha256 = "17i92hymw1dwmmb5yv90m2gam2x21mc960q1pr7bly93x49h8666";
     };
 
@@ -14977,7 +14977,7 @@ in modules // {
     version = "1.8.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/os-client-config/${name}.tar.gz";
+      url = "mirror://pypi/o/os-client-config/${name}.tar.gz";
       sha256 = "10hz4yp594mi1p7v1pvgsmx5w2rnb9y8d0jvb2lfv03ljnwzv8jz";
     };
 
@@ -14999,7 +14999,7 @@ in modules // {
     disabled = isPyPy; # a test fails
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/keystoneauth1/${name}.tar.gz";
+      url = "mirror://pypi/k/keystoneauth1/${name}.tar.gz";
       sha256 = "05fc6xsp5mal52ijvj84sf7mrw706ihadfdf5mnq9zxn7pfl4118";
     };
 
@@ -15017,7 +15017,7 @@ in modules // {
     version = "0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/requests-mock/${name}.tar.gz";
+      url = "mirror://pypi/r/requests-mock/${name}.tar.gz";
       sha256 = "0gmd88c224y53b1ai8cfsrcxm9kw3gdqzysclmnaqspg7zjhxwd1";
     };
 
@@ -15034,7 +15034,7 @@ in modules // {
     version = "0.11.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mox3/${name}.tar.gz";
+      url = "mirror://pypi/m/mox3/${name}.tar.gz";
       sha256 = "09dkgki21v5zqrx575h1aazxsq5akkv0a90z644bk1ry9a4zg1pn";
     };
 
@@ -15051,7 +15051,7 @@ in modules // {
     version = "0.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/debtcollector/${name}.tar.gz";
+      url = "mirror://pypi/d/debtcollector/${name}.tar.gz";
       sha256 = "1mvdxdrnwlgfqg26s5himkjq6f06r2khlrignx36kkbyaix6j9xb";
     };
     patchPhase = ''
@@ -15070,7 +15070,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/wrapt/${name}.tar.gz";
+      url = "mirror://pypi/w/wrapt/${name}.tar.gz";
       sha256 = "0cq8rlpzkxzk48b50yrfhzn1d1hrq4gjcdqlrgq4v5palgiv9jwr";
     };
   };
@@ -15081,7 +15081,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-        url = "https://pypi.python.org/packages/source/p/pagerduty/pagerduty-${version}.tar.gz";
+        url = "mirror://pypi/p/pagerduty/pagerduty-${version}.tar.gz";
         sha256 = "e8c237239d3ffb061069aa04fc5b3d8ae4fb0af16a9713fe0977f02261d323e9";
     };
   };
@@ -15096,7 +15096,7 @@ in modules // {
     version = "0.18.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pandas/${name}.tar.gz";
+      url = "mirror://pypi/p/pandas/${name}.tar.gz";
       sha256 = "050qw0ap5bhyv5flp78x3lcq1dlminl3xaj6kbrm0jqmx0672xf9";
     };
 
@@ -15165,7 +15165,7 @@ in modules // {
 
     version = "0.9.4";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xlrd/xlrd-${version}.tar.gz";
+      url = "mirror://pypi/x/xlrd/xlrd-${version}.tar.gz";
       sha256 = "8e8d3359f39541a6ff937f4030db54864836a06e42988c452db5b6b86d29ea72";
     };
 
@@ -15180,7 +15180,7 @@ in modules // {
     name = "Bottleneck-${version}";
     version = "1.0.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/B/Bottleneck/Bottleneck-${version}.tar.gz";
+      url = "mirror://pypi/B/Bottleneck/Bottleneck-${version}.tar.gz";
       sha256 = "15dl0ll5xmfzj2fsvajzwxsb9dbw5i9fx9i4r6n4i5nzzba7m6wd";
     };
 
@@ -15198,7 +15198,7 @@ in modules // {
     disabled = isPyPy || isPy26;
 
     src = pkgs.fetchurl {
-        url = "https://pypi.python.org/packages/source/p/paho-mqtt/${name}.tar.gz";
+        url = "mirror://pypi/p/paho-mqtt/${name}.tar.gz";
         sha256 = "07i6k9mw66kgbvjgsrcsd2sjji9ckym50dcxnmhjqfkfzsg64yhg";
     };
 
@@ -15215,7 +15215,7 @@ in modules // {
     name = "pamqp-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pamqp/${name}.tar.gz";
+      url = "mirror://pypi/p/pamqp/${name}.tar.gz";
       sha256 = "1vmyvynqzx5zvbipaxff4fnzy3h3dvl3zicyr15yb816j93jl2ca";
     };
 
@@ -15233,7 +15233,7 @@ in modules // {
     version = "1.4";
 
     src = pkgs.fetchurl {
-        url = "https://pypi.python.org/packages/source/p/parsedatetime/${name}.tar.gz";
+        url = "mirror://pypi/p/parsedatetime/${name}.tar.gz";
         sha256 = "09bfcd8f3c239c75e77b3ff05d782ab2c1aed0892f250ce2adf948d4308fe9dc";
     };
   };
@@ -15242,7 +15242,7 @@ in modules // {
     name = "paramiko-1.15.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/paramiko/${name}.tar.gz";
+      url = "mirror://pypi/p/paramiko/${name}.tar.gz";
       sha256 = "6ed97e2281bb48728692cdc621f6b86a65fdc1d46b178ce250cfec10b977a04c";
     };
 
@@ -15277,7 +15277,7 @@ in modules // {
     version = "0.3.0";
 
     src = pkgs.fetchurl{
-      url = "https://pypi.python.org/packages/source/p/patsy/${name}.zip";
+      url = "mirror://pypi/p/patsy/${name}.zip";
       sha256 = "a55dd4ca09af4b9608b81f30322beb450510964c022708ab50e83a065ccf15f0";
     };
 
@@ -15296,7 +15296,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = http://pypi.python.org/packages/source/P/Paste/Paste-1.7.5.1.tar.gz;
+      url = mirror://pypi/P/Paste/Paste-1.7.5.1.tar.gz;
       sha256 = "11645842ba8ec986ae8cfbe4c6cacff5c35f0f4527abf4f5581ae8b4ad49c0b6";
     };
 
@@ -15316,7 +15316,7 @@ in modules // {
     name = "paste-deploy-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/PasteDeploy/PasteDeploy-${version}.tar.gz";
+      url = "mirror://pypi/P/PasteDeploy/PasteDeploy-${version}.tar.gz";
       sha256 = "d5858f89a255e6294e63ed46b73613c56e3b9a2d82a42f1df4d06c8421a9e3cb";
     };
 
@@ -15334,7 +15334,7 @@ in modules // {
     name = "PasterScript-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/PasteScript/${name}.tar.gz";
+      url = "mirror://pypi/P/PasteScript/${name}.tar.gz";
       sha256 = "2b685be69d6ac8bc0fe6f558f119660259db26a15e16a4943c515fbee8093539";
     };
 
@@ -15355,7 +15355,7 @@ in modules // {
     disabled = pythonAtLeast "3.4"; # Was added to std library in Python 3.4
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pathlib/${name}.tar.gz";
+      url = "mirror://pypi/p/pathlib/${name}.tar.gz";
       sha256 = "17zajiw4mjbkkv6ahp3xf025qglkj0805m9s41c45zryzj6p2h39";
     };
 
@@ -15371,7 +15371,7 @@ in modules // {
     name = "path.py-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/path.py/${name}.tar.gz";
+      url = "mirror://pypi/p/path.py/${name}.tar.gz";
       sha256 = "ada95d117c4559abe64080961daf5badda68561afdd34c278f8ca20f2fa466d2";
     };
 
@@ -15394,7 +15394,7 @@ in modules // {
     name = "paypalrestsdk-0.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/paypalrestsdk/${name}.tar.gz";
+      url = "mirror://pypi/p/paypalrestsdk/${name}.tar.gz";
       sha256 = "117kfipzfahf9ysv414bh1mmm5cc9ck5zb6rhpslx1f8gk3frvd6";
     };
 
@@ -15412,7 +15412,7 @@ in modules // {
     version = "1.8.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pbr/${name}.tar.gz";
+      url = "mirror://pypi/p/pbr/${name}.tar.gz";
       sha256 = "0jcny36cf3s8ar5r4a575npz080hndnrfs4np1fqhv0ym4k7c4p2";
     };
 
@@ -15432,7 +15432,7 @@ in modules // {
     name = "fixtures-1.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/fixtures/${name}.tar.gz";
+      url = "mirror://pypi/f/fixtures/${name}.tar.gz";
       sha256 = "0djxvdwm8s60dbfn7bhf40x6g818p3b3mlwijm1c3bqg7msn271y";
     };
 
@@ -15495,7 +15495,7 @@ in modules // {
     version = "1.7.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pep8/${name}.tar.gz";
+      url = "mirror://pypi/p/pep8/${name}.tar.gz";
       sha256 = "a113d5f5ad7a7abacef9df5ec3f2af23a20a28005921577b15dd584d099d5900";
     };
 
@@ -15531,7 +15531,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/percol/${name}.tar.gz";
+      url = "mirror://pypi/p/percol/${name}.tar.gz";
       sha256 = "169s5mhw1s60qbsd6pkf9bb2x6wfgx8hn8nw9d4qgc68qnnpp2cj";
     };
 
@@ -15550,7 +15550,7 @@ in modules // {
     version = "0.15";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pexif/pexif-0.15.tar.gz";
+      url = "mirror://pypi/p/pexif/pexif-0.15.tar.gz";
       sha256 = "45a3be037c7ba8b64bbfc48f3586402cc17de55bb9d7357ef2bc99954a18da3f";
     };
 
@@ -15567,7 +15567,7 @@ in modules // {
     name = "pexpect-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pexpect/${name}.tar.gz";
+      url = "mirror://pypi/p/pexpect/${name}.tar.gz";
       sha256 = "dfea618d43e83cfff21504f18f98019ba520f330e4142e5185ef7c73527de5ba";
     };
 
@@ -15602,7 +15602,7 @@ in modules // {
     name = "pg8000-1.10.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pg8000/${name}.tar.gz";
+      url = "mirror://pypi/p/pg8000/${name}.tar.gz";
       sha256 = "188658db63c2ca931ae1bf0167b34efaac0ecc743b707f0118cc4b87e90ce488";
     };
 
@@ -15674,7 +15674,7 @@ in modules // {
     name = "pickleshare-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pickleshare/${name}.tar.gz";
+      url = "mirror://pypi/p/pickleshare/${name}.tar.gz";
       sha256 = "c0be5745035d437dbf55a96f60b7712345b12423f7d0951bd7d8dc2141ca9286";
     };
 
@@ -15693,7 +15693,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/piep/piep-${version}.tar.gz";
+      url = "mirror://pypi/p/piep/piep-${version}.tar.gz";
       sha256 = "1wgkg1kc28jpya5k4zvbc9jmpa60b3d5c3gwxfbp15hw6smyqirj";
     };
 
@@ -15712,7 +15712,7 @@ in modules // {
     name = "pip-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pip/pip-${version}.tar.gz";
+      url = "mirror://pypi/p/pip/pip-${version}.tar.gz";
       sha256 = "160pa7xg0vybidhszd1n0ik2xah0yz6gsym5hp8k7dmfd83d6y1y";
     };
 
@@ -15728,7 +15728,7 @@ in modules // {
     name = "pika-0.9.12";
     disabled = isPy3k;
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/p/pika/pika-0.9.12.tar.gz;
+      url = mirror://pypi/p/pika/pika-0.9.12.tar.gz;
       sha256 = "670787ee6ade47cadd1ec8220876b9b7ae4df7bc4b9dd1d808261a6b47e9ce5d";
     };
     buildInputs = with self; [ nose mock pyyaml ];
@@ -15743,7 +15743,7 @@ in modules // {
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/platformio/platformio-${version}.tar.gz";
+      url = "mirror://pypi/p/platformio/platformio-${version}.tar.gz";
       sha256 = "1l8jcwf8flmx8xcsvly2my8al8nzjr67h3mg5c9wvdr7a42q7dil";
      };
 
@@ -15762,7 +15762,7 @@ in modules // {
     version = "0.2.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pylibconfig2/${name}.tar.gz";
+      url = "mirror://pypi/p/pylibconfig2/${name}.tar.gz";
       sha256 = "0kyg6gldj6hi2jhc5xhi834bb2mcaiy24dvfik963shnldqr7kqg";
     };
 
@@ -15785,7 +15785,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
       sha256 = "1rxyg9465cp6nc47pqxqf092wmbvv2zhffzvaf2w74laal43pgxw";
     };
 
@@ -15802,7 +15802,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pysftp/${name}.tar.gz";
+      url = "mirror://pypi/p/pysftp/${name}.tar.gz";
       sha256 = "1d69z8yngciksch1i8rivy1xl8f6g6sb7c3kk5cm3pf8304q6hhm";
     };
 
@@ -15825,7 +15825,7 @@ in modules // {
     version = "0.8.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PySoundFile/PySoundFile-${version}.tar.gz";
+      url = "mirror://pypi/P/PySoundFile/PySoundFile-${version}.tar.gz";
       sha256 = "72c3e23b7c9998460ec78176084ea101e3439596ab29df476bc8508708df84df";
     };
 
@@ -15855,7 +15855,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/p/python3-pika/python3-pika-0.9.14.tar.gz;
+      url = mirror://pypi/p/python3-pika/python3-pika-0.9.14.tar.gz;
       sha256 = "1c3hifwvn04kvlja88iawf0awyz726jynwnpcb6gn7376b4nfch7";
     };
     buildInputs = with self; [ nose mock pyyaml ];
@@ -15868,7 +15868,7 @@ in modules // {
     name = "python-jenkins-${version}";
     version = "0.4.11";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-jenkins/${name}.tar.gz";
+      url = "mirror://pypi/p/python-jenkins/${name}.tar.gz";
       sha256 = "153gm7pmmn0bymglsgcr2ya0752r2v1hajkx73gl1pk4jifb2gdf";
     };
     patchPhase = ''
@@ -15890,7 +15890,7 @@ in modules // {
     name = "Pillow-2.9.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/Pillow/${name}.zip";
+      url = "mirror://pypi/P/Pillow/${name}.zip";
       sha256 = "1mal92cwh85z6zqx7lrmg0dbqb2gw2cbb2fm6xh0fivmszz8vnyi";
     };
 
@@ -15947,7 +15947,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pkgconfig/${name}.tar.gz";
+      url = "mirror://pypi/p/pkgconfig/${name}.tar.gz";
       sha256 = "709daaf077aa2b33bedac12706373412c3683576a43013bbaa529fc2769d80df";
     };
 
@@ -15976,7 +15976,7 @@ in modules // {
     buildInputs = with self; [ self.six ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/plumbum/${name}.tar.gz";
+      url = "mirror://pypi/p/plumbum/${name}.tar.gz";
       sha256 = "b759f9e3b6771dff3332f01bc0683d1a56218f44d97942dabd906a0cd1cfb756";
     };
   };
@@ -16047,7 +16047,7 @@ in modules // {
     name = "praw-3.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/praw/${name}.zip";
+      url = "mirror://pypi/p/praw/${name}.zip";
       sha256 = "17s8s4a1yk9rq21f3kmj9k4dbgvfa3650l8b39nhwybvxl3j5nfv";
     };
 
@@ -16076,7 +16076,7 @@ in modules // {
     name = "prettytable-0.7.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/PrettyTable/${name}.tar.bz2";
+      url = "mirror://pypi/P/PrettyTable/${name}.tar.bz2";
       sha256 = "599bc5b4b9602e28294cf795733c889c26dd934aa7e0ee9cff9b905d4fbad188";
     };
 
@@ -16099,7 +16099,7 @@ in modules // {
 
     src = pkgs.fetchurl {
       sha256 = "1yq9nis1b2rgpndi2rqh4divf6j22jjva83r5z8jf7iffywmr8hs";
-      url = "https://pypi.python.org/packages/source/p/prompt_toolkit/${name}.tar.gz";
+      url = "mirror://pypi/p/prompt_toolkit/${name}.tar.gz";
     };
 
     buildInputs = with self; [ jedi ipython pygments ];
@@ -16123,7 +16123,7 @@ in modules // {
     version = "0.52";
     src = pkgs.fetchurl {
       sha256 = "00h9ldqmb33nhg2kpks7paldf3n3023ipp124alwp96yz16s7f1m";
-      url = "https://pypi.python.org/packages/source/p/prompt_toolkit/${name}.tar.gz";
+      url = "mirror://pypi/p/prompt_toolkit/${name}.tar.gz";
     };
 
     #Only <3.4 expressly supported.
@@ -16176,7 +16176,7 @@ in modules // {
     version = "3.4.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/psutil/${name}.tar.gz";
+      url = "mirror://pypi/p/psutil/${name}.tar.gz";
       sha256 = "b17fa01aa766daa388362d0eda5c215d77e03a8d37676b68971f37bf3913b725";
     };
 
@@ -16200,7 +16200,7 @@ in modules // {
   psutil_1 = self.psutil.overrideDerivation (self: rec {
     name = "psutil-1.2.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/psutil/${name}.tar.gz";
+      url = "mirror://pypi/p/psutil/${name}.tar.gz";
       sha256 = "0ibclqy6a4qmkjhlk3g8jhpvnk0v9aywknc61xm3hfi5r124m3jh";
     };
   });
@@ -16213,7 +16213,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/psycopg2/${name}.tar.gz";
+      url = "mirror://pypi/p/psycopg2/${name}.tar.gz";
       sha256 = "07ivzl7bq8bjcq5n90w4bsl29gjfm5l8yamw0paxh25si8r3zfi4";
     };
 
@@ -16232,7 +16232,7 @@ in modules // {
     version = "1.0.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/publicsuffix/${name}.tar.gz";
+      url = "mirror://pypi/p/publicsuffix/${name}.tar.gz";
       sha256 = "f6dfcb8a33fb3ac4f09e644cd26f8af6a09d1a45a019d105c8da58e289ca0096";
     };
 
@@ -16249,7 +16249,7 @@ in modules // {
     version = "1.4.31";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/py/${name}.tar.gz";
+      url = "mirror://pypi/p/py/${name}.tar.gz";
       sha256 = "a6501963c725fc2554dabfece8ae9a8fb5e149c0ac0a42fd2b02c5c1c57fc114";
     };
 
@@ -16268,7 +16268,7 @@ in modules // {
     name = "pyacoustid-1.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyacoustid/${name}.tar.gz";
+      url = "mirror://pypi/p/pyacoustid/${name}.tar.gz";
       sha256 = "0117039cb116af245e6866e8e8bf3c9c8b2853ad087142bd0c2dfc0acc09d452";
     };
 
@@ -16294,7 +16294,7 @@ in modules // {
     name = "pyalogotrade-0.16";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyAlgoTrade/PyAlgoTrade-0.16.tar.gz";
+      url = "mirror://pypi/P/PyAlgoTrade/PyAlgoTrade-0.16.tar.gz";
       sha256 = "a253617254194b91cfebae7bfd184cb109d4e48a8c70051b9560000a2c0f94b3";
     };
 
@@ -16330,7 +16330,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyasn1-modules/${name}.tar.gz";
+      url = "mirror://pypi/p/pyasn1-modules/${name}.tar.gz";
       sha256 = "0hcr6klrzmw4d9j9s5wrhqva5014735pg4zk3rppac4fs87g0rdy";
     };
 
@@ -16349,7 +16349,7 @@ in modules // {
     version = "0.2.9";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyAudio/PyAudio-${version}.tar.gz";
+      url = "mirror://pypi/P/PyAudio/PyAudio-${version}.tar.gz";
       sha256 = "bfd694272b3d1efc51726d0c27650b3c3ba1345f7f8fdada7e86c9751ce0f2a1";
     };
 
@@ -16369,7 +16369,7 @@ in modules // {
     version = "3.0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pysaml2/${name}.tar.gz";
+      url = "mirror://pypi/p/pysaml2/${name}.tar.gz";
       sha256 = "0y2iw1dddcvi13xjh3l52z1mvnrbc41ik9k4nn7lwj8x5kimnk9n";
     };
 
@@ -16398,7 +16398,7 @@ in modules // {
     version = "0.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mongodict/${name}.tar.gz";
+      url = "mirror://pypi/m/mongodict/${name}.tar.gz";
       sha256 = "0nv5amfs337m0gbxpjb0585s20rndqfc3mfrzq1iwgnds5gxcrlw";
     };
 
@@ -16418,7 +16418,7 @@ in modules // {
     version = "2.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/repoze.who/${name}.tar.gz";
+      url = "mirror://pypi/r/repoze.who/${name}.tar.gz";
       sha256 = "12wsviar45nwn35w2y4i8b929dq2219vmwz8013wx7bpgkn2j9ij";
     };
 
@@ -16470,7 +16470,7 @@ in modules // {
     name = "pycarddav-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyCardDAV/pyCardDAV-${version}.tar.gz";
+      url = "mirror://pypi/p/pyCardDAV/pyCardDAV-${version}.tar.gz";
       sha256 = "0avkrcpisfvhz103v7vmq2jd83hvmpqrb4mlbx6ikkk1wcvclsx8";
     };
 
@@ -16490,7 +16490,7 @@ in modules // {
     name = "pycosat-0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pycosat/${name}.tar.gz";
+      url = "mirror://pypi/p/pycosat/${name}.tar.gz";
       sha256 = "02sdn2998jlrm35smn1530hix3kzwyc1jv49cjdcnvfvrqqi3rww";
     };
 
@@ -16511,7 +16511,7 @@ in modules // {
     name = "pygit2-0.23.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pygit2/${name}.tar.gz";
+      url = "mirror://pypi/p/pygit2/${name}.tar.gz";
       sha256 = "04201vcal7jq8lbpk9ylscrhjxdcf2aihiw25k4imjjqgfmvldf7";
     };
 
@@ -16540,7 +16540,7 @@ in modules // {
     name = "Babel-2.2.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/B/Babel/${name}.tar.gz";
+      url = "mirror://pypi/B/Babel/${name}.tar.gz";
       sha256 = "d8cb4c0e78148aee89560f9fe21587aa57739c975bb89ff66b1e842cc697428f";
     };
 
@@ -16561,7 +16561,7 @@ in modules // {
     disabled = isPyPy || isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pybfd/${name}.tar.gz";
+      url = "mirror://pypi/p/pybfd/${name}.tar.gz";
       sha256 = "d99b32ad077e704ddddc0b488c83cae851c14919e5cbc51715d00464a1932df4";
     };
 
@@ -16613,7 +16613,7 @@ in modules // {
     version = "0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/py-bcrypt/py-bcrypt-${version}.tar.gz";
+      url = "mirror://pypi/p/py-bcrypt/py-bcrypt-${version}.tar.gz";
       sha256 = "5fa13bce551468350d66c4883694850570f3da28d6866bb638ba44fe5eabda78";
     };
 
@@ -16651,7 +16651,7 @@ in modules // {
     disabled = isPyPy || isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pycapnp/${name}.tar.gz";
+      url = "mirror://pypi/p/pycapnp/${name}.tar.gz";
       sha256 = "1kp97il34419gcrhn866n6a10lvh8qr13bnllnnh9473n4cq0cvk";
     };
 
@@ -16676,7 +16676,7 @@ in modules // {
     disabled = !isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pycdio/${name}.tar.gz";
+      url = "mirror://pypi/p/pycdio/${name}.tar.gz";
       sha256 = "1mrh233pj584gf7la64d4xlmvdnfl4jwpxs95lnd3i4zd5drid14";
     };
 
@@ -16716,7 +16716,7 @@ in modules // {
     disabled = isPy3k || isPyPy;  # see https://bitbucket.org/pypy/pypy/issue/1190/
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pycryptopp/${name}.tar.gz";
+      url = "mirror://pypi/p/pycryptopp/${name}.tar.gz";
       sha256 = "0n90h1yg7bfvlbhnc54xb6dbqm286ykaksyg04kxlhyjgf8mhq8i";
     };
 
@@ -16815,7 +16815,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pydot/${name}.tar.gz";
+      url = "mirror://pypi/p/pydot/${name}.tar.gz";
       sha256 = "80ea01a7ba75671a3b7890375be0ad8d5321b07bfb6f572192c31409062b59f3";
     };
     propagatedBuildInputs = with self; [pyparsing pkgs.graphviz];
@@ -16829,7 +16829,7 @@ in modules // {
     name = "pydot_ng-1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pydot-ng/${name}.tar.gz";
+      url = "mirror://pypi/p/pydot-ng/${name}.tar.gz";
       sha256 = "0h8k8wlzvnb40v4js7afgfyhp3wasmb1kg4gr6z7ck63iv8fq864";
     };
 
@@ -16853,7 +16853,7 @@ in modules // {
     name = "pyelasticsearch-1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyelasticsearch/${name}.tar.gz";
+      url = "mirror://pypi/p/pyelasticsearch/${name}.tar.gz";
       sha256 = "18wp6llfjv6hvyhr3f6i8dm9wc5rf46wiqsfxwpvnf6mdrvk6xr7";
     };
 
@@ -16875,7 +16875,7 @@ in modules // {
     name = "${pname}-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/${pname}/${name}.tar.gz";
+      url = "mirror://pypi/p/${pname}/${name}.tar.gz";
       sha256 = "1pi1mdzfffgl5qcz0prsa7hlbriycy7mgagi0fdrp3vf17fslmzw";
     };
 
@@ -16899,7 +16899,7 @@ in modules // {
     name = "pyenchant-1.6.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyenchant/pyenchant-1.6.6.tar.gz";
+      url = "mirror://pypi/p/pyenchant/pyenchant-1.6.6.tar.gz";
       sha256 = "25c9d2667d512f8fc4410465fdd2e868377ca07eb3d56e2b6e534a86281d64d3";
     };
 
@@ -16926,7 +16926,7 @@ in modules // {
     name = "pyev-0.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyev/${name}.tar.gz";
+      url = "mirror://pypi/p/pyev/${name}.tar.gz";
       sha256 = "0rf603lc0s6zpa1nb25vhd8g4y337wg2wyz56i0agsdh7jchl0sx";
     };
 
@@ -16970,7 +16970,7 @@ in modules // {
     version = "0.9.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyFFTW/pyFFTW-${version}.tar.gz";
+      url = "mirror://pypi/p/pyFFTW/pyFFTW-${version}.tar.gz";
       sha256 = "f6bbb6afa93085409ab24885a1a3cdb8909f095a142f4d49e346f2bd1b789074";
     };
 
@@ -17002,7 +17002,7 @@ in modules // {
     version = "0.7.2";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/p/pyfiglet/${name}.tar.gz";
+      url    = "mirror://pypi/p/pyfiglet/${name}.tar.gz";
       sha256 = "0v8a18wvaqnb1jksyv5dc5n6zj0vrkyhz0ivmm8gfwpa0ky6n68y";
     };
 
@@ -17020,7 +17020,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyflakes/${name}.tar.gz";
+      url = "mirror://pypi/p/pyflakes/${name}.tar.gz";
       sha256 = "f39e33a4c03beead8774f005bd3ecf0c3f2f264fa0201de965fce0aff1d34263";
     };
 
@@ -17040,7 +17040,7 @@ in modules // {
     name = "pygeoip-0.3.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pygeoip/pygeoip-0.3.2.tar.gz";
+      url = "mirror://pypi/p/pygeoip/pygeoip-0.3.2.tar.gz";
       sha256 = "f22c4e00ddf1213e0fae36dc60b46ee7c25a6339941ec1a975539014c1f9a96d";
     };
 
@@ -17061,7 +17061,7 @@ in modules // {
     version = "1.2.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyglet/pyglet-${version}.tar.gz";
+      url = "mirror://pypi/p/pyglet/pyglet-${version}.tar.gz";
       sha256 = "9f62ffbbcf2b202d084bf158685e77d28b8f4f5f2738f4c5e63a947a07503445";
     };
 
@@ -17085,7 +17085,7 @@ in modules // {
     name = "Pygments-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/Pygments/${name}.tar.gz";
+      url = "mirror://pypi/P/Pygments/${name}.tar.gz";
       sha256 = "10axnp2wpjnq9g8wg53fx0c70dfxqrz498jyz8mrdx9a3flwir48";
     };
 
@@ -17108,7 +17108,7 @@ in modules // {
     name = "Pygments-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/Pygments/${name}.tar.gz";
+      url = "mirror://pypi/P/Pygments/${name}.tar.gz";
       sha256 = "7320919084e6dac8f4540638a46447a3bd730fca172afc17d2c03eed22cf4f51";
     };
   };
@@ -17141,7 +17141,7 @@ in modules // {
     version = "1.5.4";
 
     src = pkgs.fetchurl {
-        url = "https://pypi.python.org/packages/source/p/pylint/${name}.tar.gz";
+        url = "mirror://pypi/p/pylint/${name}.tar.gz";
         sha256 = "2fe3cc2fc66a56fdc35dbbc2bf1dd96a534abfc79ee6b2ad9ae4fe166e570c4b";
     };
 
@@ -17167,7 +17167,7 @@ in modules // {
     version = "0.7.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyrr/pyrr-${version}.tar.gz";
+      url = "mirror://pypi/p/pyrr/pyrr-${version}.tar.gz";
       sha256 = "04a65a9fb5c746b41209f55b21abf47a0ef80a4271159d670ca9579d9be3b4fa";
     };
 
@@ -17186,7 +17186,7 @@ in modules // {
     version = "1.2.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyshp/pyshp-${version}.tar.gz";
+      url = "mirror://pypi/p/pyshp/pyshp-${version}.tar.gz";
       sha256 = "e18cc19659dadc5ddaa891eb780a6958094da0cf105a1efe0f67e75b4fa1cdf9";
     };
 
@@ -17204,7 +17204,7 @@ in modules // {
     version = "0.14.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyX/PyX-${version}.tar.gz";
+      url = "mirror://pypi/P/PyX/PyX-${version}.tar.gz";
       sha256 = "05d1b7fc813379d2c12fcb5bd0195cab522b5aabafac88f72913f1d47becd912";
     };
 
@@ -17242,7 +17242,7 @@ in modules // {
     name = "kaa-base-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/kaa-base/kaa-base-0.99.2dev-384-2b73caca.tar.gz";
+      url = "mirror://pypi/k/kaa-base/kaa-base-0.99.2dev-384-2b73caca.tar.gz";
       sha256 = "0k3zzz84wzz9q1fl3vvqr2ys96z9pcf4viq9q6s2a63zaysmcfd2";
     };
 
@@ -17313,7 +17313,7 @@ in modules // {
     '';
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/kaa-metadata/kaa-metadata-0.7.8dev-r4569-20111003.tar.gz";
+      url = "mirror://pypi/k/kaa-metadata/kaa-metadata-0.7.8dev-r4569-20111003.tar.gz";
       sha256 = "0bkbzfgxvmby8lvzkqjp86anxvv3vjd9nksv2g4l7shsk1n7y27a";
     };
 
@@ -17332,7 +17332,7 @@ in modules // {
     version = "0.9.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/${name}/${name}-${version}.tar.gz";
+      url = "mirror://pypi/p/${name}/${name}-${version}.tar.gz";
       sha256 = "1x3i9wmzw33fpkis203alygfnrkcmq9w1aydcm887jh6frfqm6cw";
     };
 
@@ -17421,7 +17421,7 @@ in modules // {
     name = "pyparsing-2.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyparsing/${name}.tar.gz";
+      url = "mirror://pypi/p/pyparsing/${name}.tar.gz";
       sha256 = "1r742rjbagf2i166k2w0r192adfw7l9lnsqz7wh4mflf00zws1q0";
     };
 
@@ -17439,7 +17439,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyparsing/${name}.tar.gz";
+      url = "mirror://pypi/p/pyparsing/${name}.tar.gz";
       sha256 = "646e14f90b3689b005c19ac9b6b390c9a39bf976481849993e277d7380e6e79f";
     };
 
@@ -17501,7 +17501,7 @@ in modules // {
     doCheck = false;  # No such file or directory errors on 32bit
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyptlib/pyptlib-${version}.tar.gz";
+      url = "mirror://pypi/p/pyptlib/pyptlib-${version}.tar.gz";
       sha256 = "01y6vbwncqb0hxlnin6whd9wrrm5my4qzjhk76fnix78v7ip515r";
     };
     meta = {
@@ -17517,7 +17517,7 @@ in modules // {
     doCheck = false;  # "PyQtGraph requires either PyQt4 or PySide; neither package could be imported."
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyqtgraph/${name}.tar.gz";
+      url = "mirror://pypi/p/pyqtgraph/${name}.tar.gz";
       sha256 = "188pcxf3sxxjf0aipjn820lx2rf9f42zzp0sibmcl90955a3ipf1";
     };
 
@@ -17537,7 +17537,7 @@ in modules // {
     version = "0.5.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pystache/${name}.tar.gz";
+      url = "mirror://pypi/p/pystache/${name}.tar.gz";
       sha256 = "f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a";
     };
 
@@ -17564,7 +17564,7 @@ in modules // {
     name = "PyStemmer-1.3.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/PyStemmer/${name}.tar.gz";
+      url = "mirror://pypi/P/PyStemmer/${name}.tar.gz";
       sha256 = "d1ac14eb64978c1697fcfba76e3ac7ebe24357c9428e775390f634648947cb91";
     };
 
@@ -17585,7 +17585,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/Pyro/${name}.tar.gz";
+      url = "mirror://pypi/P/Pyro/${name}.tar.gz";
       sha256 = "1bed508453ef7a7556b51424a58101af2349b662baab7e7331c5cb85dbe7e578";
     };
 
@@ -17602,7 +17602,7 @@ in modules // {
     name = "pyrsistent-0.11.12";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyrsistent/${name}.tar.gz";
+      url = "mirror://pypi/p/pyrsistent/${name}.tar.gz";
       sha256 = "0jgyhkkq36wn36rymn4jiyqh2vdslmradq4a2mjkxfbk2cz6wpi5";
     };
 
@@ -17624,7 +17624,7 @@ in modules // {
     name = "PyRSS2Gen-1.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/PyRSS2Gen/${name}.tar.gz";
+      url = "mirror://pypi/P/PyRSS2Gen/${name}.tar.gz";
       sha256 = "4929d022713129401160fd47550d5158931e4ea6a7136b5d8dfe3b13ac16f2f0";
     };
 
@@ -17641,7 +17641,7 @@ in modules // {
     name = "pysnmp-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pysnmp/${name}.tar.gz";
+      url = "mirror://pypi/p/pysnmp/${name}.tar.gz";
       sha256 = "0zq7yx8732ad9dxpxqgpqyixj7kfwbvf402q7l5njkv0kbcnavn4";
     };
 
@@ -17661,7 +17661,7 @@ in modules // {
     version = "1.5.0";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/P/PySocks/PySocks-${version}.tar.gz";
+      url    = "mirror://pypi/P/PySocks/PySocks-${version}.tar.gz";
       sha256 = "10wq5311qrnk8rvzsh6gwzxi7h51pgvzw3d7s1mb39fsvf0vyjdk";
     };
 
@@ -17680,7 +17680,7 @@ in modules // {
     meta.maintainers = with maintainers; [ mornfall ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-fedora/${name}.tar.gz";
+      url = "mirror://pypi/p/python-fedora/${name}.tar.gz";
       sha256 = "15m8lvbb5q4rg508i4ah8my872qrq5xjwgcgca4d3kzjv2x6fhim";
     };
     propagatedBuildInputs = with self; [ kitchen requests bunch paver six munch urllib3
@@ -17698,7 +17698,7 @@ in modules // {
     version = "0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-simple-hipchat/python-simple-hipchat-${version}.zip";
+      url = "mirror://pypi/p/python-simple-hipchat/python-simple-hipchat-${version}.zip";
       sha256 = "404e5ff7187abb09c2227f22063d06baf0fd525725e9c9ad280176bed1c94a3f";
     };
 
@@ -17709,7 +17709,7 @@ in modules // {
     name = "python-keyczar-0.71c";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/p/python-keyczar/${name}.tar.gz";
+      url    = "mirror://pypi/p/python-keyczar/${name}.tar.gz";
       sha256 = "18mhiwqq6vp65ykmi8x3i5l3gvrvrrr8z2kv11z1rpixmyr7sw1p";
     };
 
@@ -17729,7 +17729,7 @@ in modules // {
     version = "0.16.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyudev/${name}.tar.gz";
+      url = "mirror://pypi/p/pyudev/${name}.tar.gz";
       sha256 = "765d1c14bd9bd031f64e2612225621984cb2bbb8cbc0c03538bcc4c735ff1c95";
     };
 
@@ -17754,7 +17754,7 @@ in modules // {
     name = "pynzb-0.1.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pynzb/${name}.tar.gz";
+      url = "mirror://pypi/p/pynzb/${name}.tar.gz";
       sha256 = "0735b3889a1174bbb65418ee503629d3f5e4a63f04b16f46ffba18253ec3ef17";
     };
 
@@ -17770,7 +17770,7 @@ in modules // {
     name = "progressbar-2.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/progressbar/${name}.tar.gz";
+      url = "mirror://pypi/p/progressbar/${name}.tar.gz";
       sha256 = "dfee5201237ca0e942baa4d451fee8bf8a54065a337fabe7378b8585aeda56a3";
     };
 
@@ -17790,7 +17790,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/python-ldap/python-${name}.tar.gz";
+      url = "mirror://pypi/p/python-ldap/python-${name}.tar.gz";
       sha256 = "0j5hzaar4d0vhnrlpmkczgwm7ci2wibr99a7zx04xddzrhxdpz82";
     };
 
@@ -17803,7 +17803,7 @@ in modules // {
     name = "ldap3-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/ldap3/${name}.tar.gz";
+      url = "mirror://pypi/l/ldap3/${name}.tar.gz";
       sha256 = "0j4qqj9vq022hy7wfqn8s0j4vm2g6paabbzas1vbyspawvcfai98";
     };
 
@@ -17840,7 +17840,7 @@ in modules // {
     version = "0.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/ptyprocess/${name}.tar.gz";
+      url = "mirror://pypi/p/ptyprocess/${name}.tar.gz";
       sha256= "dcb78fb2197b49ca1b7b2f37b047bc89c0da7a90f90bd5bc17c3ce388bb6ef59";
     };
 
@@ -17918,7 +17918,7 @@ in modules // {
     name = "pyPdf-1.13";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyPdf/${name}.tar.gz";
+      url = "mirror://pypi/p/pyPdf/${name}.tar.gz";
       sha256 = "3aede4c3c9c6ad07c98f059f90db0b09ed383f7c791c46100f649e1cabda0e3b";
     };
 
@@ -17939,7 +17939,7 @@ in modules // {
     version = "1.25.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyPDF2/${name}.tar.gz";
+      url = "mirror://pypi/P/PyPDF2/${name}.tar.gz";
       sha256 = "1sw225j9fgsvg1zm7lrij96fihfmq8pc1vg611dc55491zvj9ls3";
     };
 
@@ -17960,7 +17960,7 @@ in modules // {
     version = "3.1.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/P/PyOpenGL/PyOpenGL-${version}.tar.gz";
+      url = "mirror://pypi/P/PyOpenGL/PyOpenGL-${version}.tar.gz";
       sha256 = "9b47c5c3a094fa518ca88aeed35ae75834d53e4285512c61879f67a48c94ddaf";
     };
     propagatedBuildInputs = [ pkgs.mesa pkgs.freeglut self.pillow ];
@@ -17995,7 +17995,7 @@ in modules // {
     version = "0.15.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz";
+      url = "mirror://pypi/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz";
       sha256 = "0wnnq15rhj7fhdcd8ycwiw6r6g3w9f9lcy6cigg8226vsrq618ph";
     };
 
@@ -18011,7 +18011,7 @@ in modules // {
     version = "1.2.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyquery/${name}.zip";
+      url = "mirror://pypi/p/pyquery/${name}.zip";
       sha256 = "00p6f1dfma65192hc72dxd506491lsq3g5wgxqafi1xpg2w1xia6";
     };
 
@@ -18025,7 +18025,7 @@ in modules // {
     name = "pyrax-1.8.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyrax/${name}.tar.gz";
+      url = "mirror://pypi/p/pyrax/${name}.tar.gz";
       sha256 = "0hvim60bhgfj91m7pp8jfmb49f087xqlgkqa505zw28r7yl0hcfp";
     };
 
@@ -18046,7 +18046,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyreport/${name}.tar.gz";
+      url = "mirror://pypi/p/pyreport/${name}.tar.gz";
       sha256 = "1584607596b7b310bf0b6ce79f424bd44238a017fd870aede11cd6732dbe0d4d";
     };
 
@@ -18065,7 +18065,7 @@ in modules // {
     version = "1.3.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyScss/${name}.tar.gz";
+      url = "mirror://pypi/p/pyScss/${name}.tar.gz";
       sha256 = "03lcp853kgr66aqrw2jd1q9jhs9h049w7zlwp7bfmly7xh832cnh";
     };
 
@@ -18084,7 +18084,7 @@ in modules // {
     name = "pyserial-2.7";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyserial/${name}.tar.gz";
+      url = "mirror://pypi/p/pyserial/${name}.tar.gz";
       sha256 = "3542ec0838793e61d6224e27ff05e8ce4ba5a5c5cc4ec5c6a3e8d49247985477";
     };
 
@@ -18101,7 +18101,7 @@ in modules // {
     name = "pymongo-3.0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pymongo/${name}.tar.gz";
+      url = "mirror://pypi/p/pymongo/${name}.tar.gz";
       sha256 = "3c6b2317f8031bc1e200fd1ea35f00a96f4569e3f3f220a5e66ab6227d96ccaf";
     };
 
@@ -18119,7 +18119,7 @@ in modules // {
     version = "2.9.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pymongo/${name}.tar.gz";
+      url = "mirror://pypi/p/pymongo/${name}.tar.gz";
       sha256 = "1nrr1fxyrlxd69bgxl7bvaj2j4z7v3zaciij5sbhxg0vqiz6ny50";
     };
 
@@ -18138,7 +18138,7 @@ in modules // {
     name = "pyperclip-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyperclip/${name}.zip";
+      url = "mirror://pypi/p/pyperclip/${name}.zip";
       sha256 = "07q8krmi7phizzp192x3j7xbk1gzhc1kc3jp4mxrm32dn84sp1vh";
     };
 
@@ -18173,7 +18173,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pysqlite/${name}.tar.gz";
+      url = "mirror://pypi/p/pysqlite/${name}.tar.gz";
       sha256 = "13djzgnbi71znjjyaw4nybg6smilgszcid646j5qav7mdchkb77y";
     };
 
@@ -18275,7 +18275,7 @@ in modules // {
     disabled = ! (isPy26 || isPy27 );
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-wifi/${name}.tar.bz2";
+      url = "mirror://pypi/p/python-wifi/${name}.tar.bz2";
       sha256 = "504639e5953eaec0e41758900fbe143d33d82ea86762b19b659a118c77d8403d";
     };
 
@@ -18296,7 +18296,7 @@ in modules // {
     version = "2016.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pytz/${name}.tar.gz";
+      url = "mirror://pypi/p/pytz/${name}.tar.gz";
       sha256 = "1a3hjclyylc4m1v1dn04b38wm2vl649ijdswpg0d8m8n0lcxlj9l";
     };
 
@@ -18312,7 +18312,7 @@ in modules // {
     name = "pyutil-2.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyutil/${name}.tar.gz";
+      url = "mirror://pypi/p/pyutil/${name}.tar.gz";
       sha256 = "1fsg9yz5mi2sb0h6c1vvcqchx56i89nbvdb5gfgv1ia3b2w5ra8c";
     };
 
@@ -18448,7 +18448,7 @@ in modules // {
     disabled = !isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyaml/${name}.tar.gz";
+      url = "mirror://pypi/p/pyaml/${name}.tar.gz";
       sha256 = "8dfe1b295116115695752acc84d15ecf5c1c469975fbed7672bf41a6bc6d6d51";
     };
 
@@ -18484,7 +18484,7 @@ in modules // {
     name = "rabbitpy-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rabbitpy/${name}.tar.gz";
+      url = "mirror://pypi/r/rabbitpy/${name}.tar.gz";
       sha256 = "0pgijv7mgxc4sm7p9s716dhl600l8isisxzyg4hz7ng1sk09p1w3";
     };
 
@@ -18503,7 +18503,7 @@ in modules // {
     name = "recaptcha-client-1.0.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/recaptcha-client/${name}.tar.gz";
+      url = "mirror://pypi/r/recaptcha-client/${name}.tar.gz";
       sha256 = "28c6853c1d13d365b7dc71a6b05e5ffb56471f70a850de318af50d3d7c0dea2f";
     };
 
@@ -18560,7 +18560,7 @@ in modules // {
     name = "reportlab-3.2.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/reportlab/${name}.tar.gz";
+      url = "mirror://pypi/r/reportlab/${name}.tar.gz";
       sha256 = "14v212cq2w3p0j5xydfr8rav8c8qas1q845r0xj7fm6q5dk8grkj";
     };
 
@@ -18591,7 +18591,7 @@ in modules // {
     disabled = !pythonOlder "3.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/requests/${name}.tar.gz";
+      url = "mirror://pypi/r/requests/${name}.tar.gz";
       sha256 = "156bf3ec27ba9ec7e0cf8fbe02808718099d218de403eb64a714d73ba1a29ab1";
     };
 
@@ -18607,7 +18607,7 @@ in modules // {
     version = "2.9.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/requests/${name}.tar.gz";
+      url = "mirror://pypi/r/requests/${name}.tar.gz";
       sha256 = "0zsqrzlybf25xscgi7ja4s48y2abf9wvjkn47wh984qgs1fq2xy5";
     };
 
@@ -18666,7 +18666,7 @@ in modules // {
   retry_decorator = buildPythonPackage rec {
     name = "retry_decorator-1.0.0";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/r/retry_decorator/retry_decorator-1.0.0.tar.gz;
+      url = mirror://pypi/r/retry_decorator/retry_decorator-1.0.0.tar.gz;
       sha256 = "086zahyb6yn7ggpc58909c5r5h3jz321i1694l1c28bbpaxnlk88";
     };
     meta = {
@@ -18712,7 +18712,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/q/qserve/${name}.zip";
+      url = "mirror://pypi/q/qserve/${name}.zip";
       sha256 = "0b04b2d4d11b464ff1efd42a9ea9f8136187d59f4076f57c9ba95361d41cd7ed";
     };
 
@@ -18730,7 +18730,7 @@ in modules // {
     name = "qtconsole-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/q/qtconsole/${name}.tar.gz";
+      url = "mirror://pypi/q/qtconsole/${name}.tar.gz";
       sha256 = "741906acae9e02c0df9138ac88b621ef22e438565aa96d783a9ef88faec3de46";
     };
 
@@ -18752,7 +18752,7 @@ in modules // {
     name = "quantities-0.10.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/q/quantities/quantities-0.10.1.tar.gz";
+      url = "mirror://pypi/q/quantities/quantities-0.10.1.tar.gz";
       sha256 = "2d27caf31a5e0c37130ac0c14bfa8f9412a5ff1fbf3378a1d6085594776c4315";
     };
 
@@ -18799,7 +18799,7 @@ in modules // {
     version = "0.4.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/recommonmark/${name}.tar.gz";
+      url = "mirror://pypi/r/recommonmark/${name}.tar.gz";
       sha256 = "6e29c723abcf5533842376d87c4589e62923ecb6002a8e059eb608345ddaff9d";
     };
 
@@ -18819,7 +18819,7 @@ in modules // {
     name = "redis-2.10.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/redis/${name}.tar.gz";
+      url = "mirror://pypi/r/redis/${name}.tar.gz";
       sha256 = "0csmrkxb29x7xs9b51zplwkkq2hwnbh9jns1g85dykn5rxmaxysx";
     };
 
@@ -18873,7 +18873,7 @@ in modules // {
     version = "2.5.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/restview/${name}.tar.gz";
+      url = "mirror://pypi/r/restview/${name}.tar.gz";
       sha256 = "18diqmh6vwz6imcmvwa7s2v4562y73n072d5d7az2r2ks0g2bzdb";
     };
 
@@ -18899,7 +18899,7 @@ in modules // {
     version = "0.6.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/readme/readme-${version}.tar.gz";
+      url = "mirror://pypi/r/readme/readme-${version}.tar.gz";
       sha256 = "08j2w67nilczn1i5r7h22vag9673i6vnfhyq2rv27r1bdmi5a30m";
     };
 
@@ -18926,7 +18926,7 @@ in modules // {
     version = "2.7.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/W/Whoosh/Whoosh-${version}.tar.gz";
+      url = "mirror://pypi/W/Whoosh/Whoosh-${version}.tar.gz";
       sha256 = "1xx8rqk1v2xs7mxvy9q4sgz2qmgvhf6ygbqjng3pl83ka4f0xz6d";
     };
 
@@ -18947,7 +18947,7 @@ in modules // {
     version = "3.3.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pysolr/pysolr-${version}.tar.gz";
+      url = "mirror://pypi/p/pysolr/pysolr-${version}.tar.gz";
       sha256 = "1wapg9n7myn7c82r3nzs2gisfzx52nip8w2mrfy0yih1zn02mnd6";
     };
 
@@ -18969,7 +18969,7 @@ in modules // {
     version = "2.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-haystack/django-haystack-${version}.tar.gz";
+      url = "mirror://pypi/d/django-haystack/django-haystack-${version}.tar.gz";
       sha256 = "04cva8qg79xig4zqhb4dwkpm7734dvhzqclzvrdz70fh59ki5b4f";
     };
 
@@ -18995,7 +18995,7 @@ in modules // {
     version = "0.3.0.dev1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/G/GeoAlchemy2/${name}.tar.gz";
+      url = "mirror://pypi/G/GeoAlchemy2/${name}.tar.gz";
       sha256 = "1j95p860ikpcpcirs5791yjpy8rf18zsz7vvsdy6v3x32hkim0k6";
     };
 
@@ -19014,7 +19014,7 @@ in modules // {
     disabled = !isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/geopy/geopy-${version}.tar.gz";
+      url = "mirror://pypi/g/geopy/geopy-${version}.tar.gz";
       sha256 = "04j1lxcsfyv03h0n0q7p2ig7a4n13x4x20fzxn8bkazpx6lyal22";
     };
 
@@ -19031,7 +19031,7 @@ in modules // {
     version = "0.1.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/django-multiselectfield/django-multiselectfield-${version}.tar.gz";
+      url = "mirror://pypi/d/django-multiselectfield/django-multiselectfield-${version}.tar.gz";
       sha256 = "0v7wf82f8688srdsym9ajv1j54bxfxwvydypc03f8xyl4c1raziv";
     };
 
@@ -19074,7 +19074,7 @@ in modules // {
     name = "rdflib-4.1.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rdflib/${name}.tar.gz";
+      url = "mirror://pypi/r/rdflib/${name}.tar.gz";
       sha256 = "0kvaf332cqbi47rqzlpdx4mbkvw12mkrzkj8n9l19wk713d4py9w";
     };
 
@@ -19094,7 +19094,7 @@ in modules // {
     version = "0.5.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/isodate/${name}.tar.gz";
+      url = "mirror://pypi/i/isodate/${name}.tar.gz";
       sha256 = "42105c41d037246dc1987e36d96f3752ffd5c0c24834dd12e4fdbe1e79544e31";
     };
 
@@ -19108,7 +19108,7 @@ in modules // {
     name = "robomachine-0.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/R/RoboMachine/RoboMachine-0.6.tar.gz";
+      url = "mirror://pypi/R/RoboMachine/RoboMachine-0.6.tar.gz";
       sha256 = "6c9a9bae7bffa272b2a09b05df06c29a3a776542c70cae8041a8975a061d2e54";
     };
 
@@ -19133,7 +19133,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/robotframework/${name}.tar.gz";
+      url = "mirror://pypi/r/robotframework/${name}.tar.gz";
       sha256 = "0mfd0s989j3jrpl8q0lb4wsjy1x280chfr9r74m2dyi9c7rxzc58";
     };
 
@@ -19155,7 +19155,7 @@ in modules // {
     name = "robotframework-selenium2library-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/robotframework-selenium2library/${name}.tar.gz";
+      url = "mirror://pypi/r/robotframework-selenium2library/${name}.tar.gz";
       sha256 = "1asdwrpb4s7q08bx641yrh3yicgba14n3hxmsqs58mqf86ignwly";
     };
 
@@ -19177,7 +19177,7 @@ in modules // {
     name = "robotframework-tools-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/robotframework-tools/${name}.tar.gz";
+      url = "mirror://pypi/r/robotframework-tools/${name}.tar.gz";
       sha256 = "04gkn1zpf3rsvbqdxrrjqqi8sa0md9gqwh6n5w2m03fdwjg4lc7q";
     };
 
@@ -19197,7 +19197,7 @@ in modules // {
     name = "robotsuite-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/robotsuite/${name}.zip";
+      url = "mirror://pypi/r/robotsuite/${name}.zip";
       sha256 = "0sw09vrvwv3gzqb6jvhbrz09l6nzzj3i9av34qjddqfwq7cr1bla";
     };
 
@@ -19254,7 +19254,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/rope/${name}.tar.gz";
+      url = "mirror://pypi/r/rope/${name}.tar.gz";
       sha256 = "0rdlvp8h74qs49wz1hx6qy8mgp2ddwlfs7z13h9139ynq04a3z7z";
     };
 
@@ -19271,7 +19271,7 @@ in modules // {
     name = "ropemacs-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/ropemacs/${name}.tar.gz";
+      url = "mirror://pypi/r/ropemacs/${name}.tar.gz";
       sha256 = "1x5qf1drcdz9jfiiakc60kzqkb3ahsg9j902c5byf3gjfacdrmqj";
     };
 
@@ -19290,7 +19290,7 @@ in modules // {
     name = "ropemode-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/ropemode/${name}.tar.gz";
+      url = "mirror://pypi/r/ropemode/${name}.tar.gz";
       sha256 = "0jw6h1wvk6wk0wknqdf7s9pw76m8472jv546lqdd88jbl2scgcjl";
     };
 
@@ -19310,7 +19310,7 @@ in modules // {
     name = "routes-1.12.3";
 
     src = pkgs.fetchurl {
-      url = http://pypi.python.org/packages/source/R/Routes/Routes-1.12.3.tar.gz;
+      url = mirror://pypi/R/Routes/Routes-1.12.3.tar.gz;
       sha256 = "eacc0dfb7c883374e698cebaa01a740d8c78d364b6e7f3df0312de042f77aa36";
     };
 
@@ -19343,7 +19343,7 @@ in modules // {
     name = "rpy2-2.5.6";
     disabled = isPyPy;
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rpy2/${name}.tar.gz";
+      url = "mirror://pypi/r/rpy2/${name}.tar.gz";
       sha256 = "d0d584c435b5ed376925a95a4525dbe87de7fa9260117e9f208029e0c919ad06";
     };
     buildInputs = with pkgs; [ readline R pcre lzma bzip2 zlib icu ];
@@ -19361,7 +19361,7 @@ in modules // {
     version = "3.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rpyc/${name}.tar.gz";
+      url = "mirror://pypi/r/rpyc/${name}.tar.gz";
       sha256 = "43fa845314f0bf442f5f5fab15bb1d1b5fe2011a8fc603f92d8022575cef8b4b";
     };
 
@@ -19379,7 +19379,7 @@ in modules // {
     version = "3.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/rsa/${name}.tar.gz";
+      url = "mirror://pypi/r/rsa/${name}.tar.gz";
       sha256 = "03f3d9bebad06681771016b8752a40b12f615ff32363c7aa19b3798e73ccd615";
     };
 
@@ -19402,7 +19402,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/SquareMap/SquareMap-1.0.4.tar.gz";
+      url = "mirror://pypi/S/SquareMap/SquareMap-1.0.4.tar.gz";
       sha256 = "feab6cb3b222993df68440e34825d8a16de2c74fdb290ae3974c86b1d5f3eef8";
     };
 
@@ -19418,7 +19418,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/ruamel.base/${name}.tar.gz";
+      url = "mirror://pypi/r/ruamel.base/${name}.tar.gz";
       sha256 = "1wswxrn4givsm917mfl39rafgadimf1sldpbjdjws00g1wx36hf0";
     };
 
@@ -19435,7 +19435,7 @@ in modules // {
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/ruamel.ordereddict/${name}.tar.gz";
+      url = "mirror://pypi/r/ruamel.ordereddict/${name}.tar.gz";
       sha256 = "1xmkl8v9l9inm2pyxgc1fm5005yxm7fkd5gv74q7lj1iy5qc8n3h";
     };
 
@@ -19451,7 +19451,7 @@ in modules // {
     version = "0.10.13";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/ruamel.yaml/${name}.tar.gz";
+      url = "mirror://pypi/r/ruamel.yaml/${name}.tar.gz";
       sha256 = "0r9mn5lm9dcxpy0wpn18cp7i5hkvjvknv3dxg8d9ca6km39m4asn";
     };
 
@@ -19469,7 +19469,7 @@ in modules // {
 
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/R/RunSnakeRun/RunSnakeRun-2.0.4.tar.gz";
+      url = "mirror://pypi/R/RunSnakeRun/RunSnakeRun-2.0.4.tar.gz";
       sha256 = "61d03a13f1dcb3c1829f5a146da1fe0cc0e27947558a51e848b6d469902815ef";
     };
 
@@ -19503,7 +19503,7 @@ in modules // {
     name = "s3transfer-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/s3transfer/${name}.tar.gz";
+      url = "mirror://pypi/s/s3transfer/${name}.tar.gz";
       sha256 = "0ma31zvv7gy240xgd1zw853lpzkdci6mapzpg3x4vycann6yvf9b";
     };
 
@@ -19535,7 +19535,7 @@ in modules // {
     name = "seqdiag-0.9.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/seqdiag/${name}.tar.gz";
+      url = "mirror://pypi/s/seqdiag/${name}.tar.gz";
       sha256 = "1qa7d0m1wahvmrj95rxkb6128cbwd4w3gy8gbzncls66h46bifiz";
     };
 
@@ -19562,7 +19562,7 @@ in modules // {
     version = "2.0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pysendfile/pysendfile-${version}.tar.gz";
+      url = "mirror://pypi/p/pysendfile/pysendfile-${version}.tar.gz";
       sha256 = "05qf0m32isflln1zjgxlpw0wf469lj86vdwwqyizp1h94x5l22ji";
     };
 
@@ -19596,7 +19596,7 @@ in modules // {
     name = "xattr-0.7.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xattr/${name}.tar.gz";
+      url = "mirror://pypi/x/xattr/${name}.tar.gz";
       sha256 = "0nbqfghgy26jyp5q7wl3rj78wr8s39m5042df2jlldg3fx6j0417";
     };
 
@@ -19640,7 +19640,7 @@ in modules // {
   scipy_0_16 = self.buildScipyPackage rec {
     version = "0.16.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/scipy/scipy-${version}.tar.gz";
+      url = "mirror://pypi/s/scipy/scipy-${version}.tar.gz";
       sha256 = "ecd1efbb1c038accb0516151d1e6679809c6010288765eb5da6051550bf52260";
     };
     numpy = self.numpy;
@@ -19649,7 +19649,7 @@ in modules // {
   scipy_0_17 = self.buildScipyPackage rec {
     version = "0.17.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/scipy/scipy-${version}.tar.gz";
+      url = "mirror://pypi/s/scipy/scipy-${version}.tar.gz";
       sha256 = "f600b755fb69437d0f70361f9e560ab4d304b1b66987ed5a28bdd9dd7793e089";
     };
     numpy = self.numpy;
@@ -19660,7 +19660,7 @@ in modules // {
     version = "0.11.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/scikit-image/${name}.tar.gz";
+      url = "mirror://pypi/s/scikit-image/${name}.tar.gz";
       sha256 = "768e568f3299966c294b7eb8cd114fc648f7bfaef422ee9cc750dd8d9d09e44b";
     };
 
@@ -19682,7 +19682,7 @@ in modules // {
     disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/scikit-learn/${name}.tar.gz";
+      url = "mirror://pypi/s/scikit-learn/${name}.tar.gz";
       sha256 = "9f4cf58e57d81783289fc503caaed1f210bab49b7a6f680bf3c04b1e0a96e5f0";
     };
 
@@ -19708,7 +19708,7 @@ in modules // {
     name = "scripttest-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/scripttest/scripttest-${version}.tar.gz";
+      url = "mirror://pypi/s/scripttest/scripttest-${version}.tar.gz";
       sha256 = "951cfc25219b0cd003493a565f2e621fd791beaae9f9a3bdd7024d8626419c38";
     };
 
@@ -19726,7 +19726,7 @@ in modules // {
   seaborn = buildPythonPackage rec {
     name = "seaborn-0.6.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/seaborn/${name}.tar.gz";
+      url = "mirror://pypi/s/seaborn/${name}.tar.gz";
       sha256 = "e078399b56ed0d53a4aa8bd4d6bd4a9a9deebc0b4acad259d0ef81830affdb68";
     };
 
@@ -19751,7 +19751,7 @@ in modules // {
   selenium = buildPythonPackage rec {
     name = "selenium-2.44.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/selenium/${name}.tar.gz";
+      url = "mirror://pypi/s/selenium/${name}.tar.gz";
       sha256 = "0l70pqwg88imbylcd831vg8nj8ipy4zr331f6qjccss7vn56i2h5";
     };
 
@@ -19784,7 +19784,7 @@ in modules // {
     version = "1.10.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/setuptools_scm/${name}.tar.bz2";
+      url = "mirror://pypi/s/setuptools_scm/${name}.tar.bz2";
       sha256 = "1cdea91bbe1ec4d52b3e9c451ab32ae6e1f3aa3fd91e90580490a9eb75bea286";
     };
 
@@ -19803,7 +19803,7 @@ in modules // {
     version = "1.2.11";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/setuptools_darcs/${name}.tar.gz";
+      url = "mirror://pypi/s/setuptools_darcs/${name}.tar.gz";
       sha256 = "1wsh0g1fn10msqk87l5jrvzs0yj5mp6q9ld3gghz6zrhl9kqzdn1";
     };
 
@@ -19828,7 +19828,7 @@ in modules // {
     name = "setuptools-trial-0.5.12";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/setuptools_trial/setuptools_trial-0.5.12.tar.gz";
+      url = "mirror://pypi/s/setuptools_trial/setuptools_trial-0.5.12.tar.gz";
       sha256 = "9cc4ca5fd432944eb95e193f28b5a602e8b07201fea4d7077c0976a40f073432";
     };
 
@@ -19848,7 +19848,7 @@ in modules // {
     name = "simplegeneric-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/simplegeneric/${name}.zip";
+      url = "mirror://pypi/s/simplegeneric/${name}.zip";
       sha256 = "dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173";
     };
 
@@ -19867,7 +19867,7 @@ in modules // {
     disabled = isPy26;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/shortuuid/${name}.tar.gz";
+      url = "mirror://pypi/s/shortuuid/${name}.tar.gz";
       sha256 = "4606dbb19124d98109c00e2cafae2df8117aec02115623e18fb2abe3f766d293";
     };
 
@@ -19886,7 +19886,7 @@ in modules // {
     name = "shouldbe-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/shouldbe/${name}.tar.gz";
+      url = "mirror://pypi/s/shouldbe/${name}.tar.gz";
       sha256 = "07pchxpv1xvjbck0xy44k3a1jrvklg0wbyccn14w0i7d135d4174";
     };
 
@@ -19907,7 +19907,7 @@ in modules // {
     name = "simplejson-3.8.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/simplejson/${name}.tar.gz";
+      url = "mirror://pypi/s/simplejson/${name}.tar.gz";
       sha256 = "14r4l4rcsyf87p2j4ycsbb017n4vzxfmv285rq2gny4w47rwi2j2";
     };
 
@@ -19936,7 +19936,7 @@ in modules // {
     buildInputs = with self; [ pep8 pytest tox ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/simpleldap/simpleldap-${version}.tar.gz";
+      url = "mirror://pypi/s/simpleldap/simpleldap-${version}.tar.gz";
       sha256 = "a5916680a7fe1b2c5d74dc76351be2941d03b7b94a50d8520280e3f588a84e61";
     };
 
@@ -19959,7 +19959,7 @@ in modules // {
     disabled = isPy3k || isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/SimpleParse/SimpleParse-${version}.tar.gz";
+      url = "mirror://pypi/S/SimpleParse/SimpleParse-${version}.tar.gz";
       sha256 = "1n8msk71lpl3kv086xr2sv68ppgz6228575xfnbszc6p1mwr64rg";
     };
 
@@ -19977,7 +19977,7 @@ in modules // {
     name = "sigal-1.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/sigal/${name}.tar.gz";
+      url = "mirror://pypi/s/sigal/${name}.tar.gz";
       sha256 = "198g2r8bii6a0p44mlk1wg07jjv95xpfvnqhhxxziqpizc776b34";
     };
 
@@ -20001,7 +20001,7 @@ in modules // {
     version = "0.1a1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/slowaes/${name}.tar.gz";
+      url = "mirror://pypi/s/slowaes/${name}.tar.gz";
       sha256 = "83658ae54cc116b96f7fdb12fdd0efac3a4e8c7c7064e3fac3f4a881aa54bf09";
     };
 
@@ -20018,7 +20018,7 @@ in modules // {
     name = "snowballstemmer-1.2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/snowballstemmer/${name}.tar.gz";
+      url = "mirror://pypi/s/snowballstemmer/${name}.tar.gz";
       sha256 = "919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128";
     };
 
@@ -20040,7 +20040,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/sqlite3dbm/${name}.tar.gz";
+      url = "mirror://pypi/s/sqlite3dbm/${name}.tar.gz";
       sha256 = "4721607e0b817b89efdba7e79cab881a03164b94777f4cf796ad5dd59a7612c5";
     };
 
@@ -20057,7 +20057,7 @@ in modules // {
     name = "pgpdump-1.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pgpdump/pgpdump-1.5.tar.gz";
+      url = "mirror://pypi/p/pgpdump/pgpdump-1.5.tar.gz";
       sha256 = "1c4700857bf7ba735b08cfe4101aa3a4f5fd839657af249c17b2697c20829668";
     };
 
@@ -20089,7 +20089,7 @@ in modules // {
     version = "1.5.13";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/S/Shapely/${name}.tar.gz";
+      url = "mirror://pypi/S/Shapely/${name}.tar.gz";
       sha256 = "68f8efb43112e8ef1f7e56e2c9eef64e0cbc1c19528c627696fb07345075a348";
     };
 
@@ -20120,7 +20120,7 @@ in modules // {
     version = "1.0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sockjs-tornado/${name}.tar.gz";
+      url = "mirror://pypi/s/sockjs-tornado/${name}.tar.gz";
       sha256 = "15lcy40h2cm0l8aknbrk48p2sni5wzybsqjx1hxwpk9lfa1xryyv";
     };
 
@@ -20140,7 +20140,7 @@ in modules // {
     name = "sopel-6.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sopel/${name}.tar.gz";
+      url = "mirror://pypi/s/sopel/${name}.tar.gz";
       sha256 = "1swvw7xw8n5anb8ah8jilk4vk1y30y62fkibfd9vm9fbk45d1q48";
     };
 
@@ -20165,7 +20165,7 @@ in modules // {
     version = "0.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sounddevice/${name}.tar.gz";
+      url = "mirror://pypi/s/sounddevice/${name}.tar.gz";
       sha256 = "8e5a6816b369c7aea77e06092b2fee99c8b6efbeef4851f53ea3cb208a7607f5";
     };
 
@@ -20190,7 +20190,7 @@ in modules // {
     name = "stevedore-1.7.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/stevedore/${name}.tar.gz";
+      url = "mirror://pypi/s/stevedore/${name}.tar.gz";
       sha256 = "149pjc0c3z6khjisn4yil3f94qjnzwafz093wc8rrzbw828qdkv8";
     };
 
@@ -20212,7 +20212,7 @@ in modules // {
     disabled = isPyPy || pythonOlder "2.6" || (isPy3k && pythonOlder "3.3");
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/T/Theano/${name}.tar.gz";
+      url = "mirror://pypi/T/Theano/${name}.tar.gz";
       sha256 = "17dikk94r8bzkxg976srqlhj5c7phs9gl837iabyfdpixkbrl79g";
     };
 
@@ -20243,7 +20243,7 @@ in modules // {
     propagatedBuildInputs = [ pkgs.html-tidy ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytidylib/pytidylib-${version}.tar.gz";
+      url = "mirror://pypi/p/pytidylib/pytidylib-${version}.tar.gz";
       sha256 = "0af07bd8ebd256af70ca925ada9337faf16d85b3072624f975136a5134150ab6";
     };
 
@@ -20273,7 +20273,7 @@ in modules // {
     version = "1.50.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/T/TileStache/TileStache-${version}.tar.gz";
+      url = "mirror://pypi/T/TileStache/TileStache-${version}.tar.gz";
       sha256 = "1z1j35pz77lhhjdn69sq5rmz62b5m444507d8zjnp0in5xqaj6rj";
     };
 
@@ -20293,7 +20293,7 @@ in modules // {
     name = "timelib-0.2.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/timelib/${name}.zip";
+      url = "mirror://pypi/t/timelib/${name}.zip";
       sha256 = "49142233bdb5971d64a41e05a1f80a408a02be0dc7d9f8c99e7bdd0613ba81cb";
     };
 
@@ -20311,7 +20311,7 @@ in modules // {
     version = "2.0.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pid/${name}.tar.gz";
+      url = "mirror://pypi/p/pid/${name}.tar.gz";
       sha256 = "0cylj8p25nwkdfgy4pzai21wyzmrxdqlwwbzqag9gb5qcjfdwk05";
     };
 
@@ -20332,7 +20332,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pydns/${name}.tar.gz";
+      url = "mirror://pypi/p/pydns/${name}.tar.gz";
       sha256 = "0qnv7i9824nb5h9psj0rwzjyprwgfiwh5s5raa9avbqazy5hv5pi";
     };
 
@@ -20345,7 +20345,7 @@ in modules // {
     version = "2.1.1";
 
     src = pkgs.fetchurl {
-      url = " https://pypi.python.org/packages/source/p/python-daemon/${name}.tar.gz";
+      url = " mirror://pypi/p/python-daemon/${name}.tar.gz";
       sha256 = "17v80qb98p1gv4j9mq6wb55cv7hc4j1hzw5y2f4s5hrpxs3w3a2q";
     };
 
@@ -20367,7 +20367,7 @@ in modules // {
     disabled = isPy34 || isPy35 || isPyPy;  # some tests fail
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/s/sympy/${name}.tar.gz";
+      url    = "mirror://pypi/s/sympy/${name}.tar.gz";
       sha256 = "1fc272b51091aabe7d07f1bf9f0a47f3e28657fb2bec52bf3ef0e8f159f5f564";
     };
 
@@ -20390,7 +20390,7 @@ in modules // {
     name = "pilkit-1.1.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pilkit/${name}.tar.gz";
+      url = "mirror://pypi/p/pilkit/${name}.tar.gz";
       sha256 = "e00585f5466654ea2cdbf7decef9862cb00e16fd363017fa7ef6623a16b0d2c7";
     };
 
@@ -20412,7 +20412,7 @@ in modules // {
     name = "clint-0.5.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/c/clint/${name}.tar.gz";
+      url = "mirror://pypi/c/clint/${name}.tar.gz";
       sha256 = "1an5lkkqk1zha47198p42ji3m94xmzx1a03dn7866m87n4r4q8h5";
     };
 
@@ -20435,7 +20435,7 @@ in modules // {
     name = "argh-0.26.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/a/argh/${name}.tar.gz";
+      url = "mirror://pypi/a/argh/${name}.tar.gz";
       sha256 = "1nqham81ihffc9xmw85dz3rg3v90rw7h0dp3dy0bh3qkp4n499q6";
     };
 
@@ -20455,7 +20455,7 @@ in modules // {
     name = "nose-progressive-1.5.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/n/nose-progressive/${name}.tar.gz";
+      url = "mirror://pypi/n/nose-progressive/${name}.tar.gz";
       sha256 = "0mfbjv3dcg23q0a130670g7xpfyvgza4wxkj991xxh8w9hs43ga4";
     };
 
@@ -20474,7 +20474,7 @@ in modules // {
     name = "blessings-1.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/b/blessings/${name}.tar.gz";
+      url = "mirror://pypi/b/blessings/${name}.tar.gz";
       sha256 = "01rhgn2c3xjf9h1lxij9m05iwf2ba6d0vd7nic26c2gic4q73igd";
     };
 
@@ -20496,7 +20496,7 @@ in modules // {
     propagatedBuildInputs = with self; [ quantities numpy ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/semantic/semantic-1.0.3.tar.gz";
+      url = "mirror://pypi/s/semantic/semantic-1.0.3.tar.gz";
       sha256 = "bbc47dad03dddb1ba5895612fdfa1e43cfb3c497534976cebacd4f3684b505b4";
     };
 
@@ -20523,7 +20523,7 @@ in modules // {
     buildInputs = [ self.pbr ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sandboxlib/sandboxlib-0.3.1.tar.gz";
+      url = "mirror://pypi/s/sandboxlib/sandboxlib-0.3.1.tar.gz";
       sha256 = "0csj8hbpylqdkxcpqkcfs73dfvdqkyj23axi8m9drqdi4dhxb41h";
     };
 
@@ -20537,7 +20537,7 @@ in modules // {
   semantic-version = buildPythonPackage rec {
     name = "semantic_version-2.4.2";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/semantic_version/${name}.tar.gz";
+      url = "mirror://pypi/s/semantic_version/${name}.tar.gz";
       sha256 = "7e8b7fa74a3bc9b6e90b15b83b9bc2377c78eaeae3447516425f475d5d6932d2";
     };
 
@@ -20551,7 +20551,7 @@ in modules // {
   sexpdata = buildPythonPackage rec {
     name = "sexpdata-0.0.2";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/sexpdata/${name}.tar.gz";
+      url = "mirror://pypi/s/sexpdata/${name}.tar.gz";
       sha256 = "eb696bc66b35def5fb356de09481447dff4e9a3ed926823134e1d0f35eade428";
     };
 
@@ -20568,7 +20568,7 @@ in modules // {
     name = "sh-1.11";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/sh/${name}.tar.gz";
+      url = "mirror://pypi/s/sh/${name}.tar.gz";
       sha256 = "590fb9b84abf8b1f560df92d73d87965f1e85c6b8330f8a5f6b336b36f0559a4";
     };
 
@@ -20600,7 +20600,7 @@ in modules // {
     name = "six-1.10.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/six/${name}.tar.gz";
+      url = "mirror://pypi/s/six/${name}.tar.gz";
       sha256 = "0snmb8xffb3vsma0z67i0h0w2g2dy0p3gsgh9gi4i0kgc5l8spqh";
     };
 
@@ -20653,7 +20653,7 @@ in modules // {
     name = "smartdc-0.1.12";
 
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/s/smartdc/smartdc-0.1.12.tar.gz;
+      url = mirror://pypi/s/smartdc/smartdc-0.1.12.tar.gz;
       sha256 = "36206f4fddecae080c66faf756712537e650936b879abb23a8c428731d2415fe";
     };
 
@@ -20669,7 +20669,7 @@ in modules // {
   socksipy-branch = buildPythonPackage rec {
     name = "SocksiPy-branch-1.01";
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/S/SocksiPy-branch/SocksiPy-branch-1.01.tar.gz;
+      url = mirror://pypi/S/SocksiPy-branch/SocksiPy-branch-1.01.tar.gz;
       sha256 = "01l41v4g7fy9fzvinmjxy6zcbhgqaif8dhdqm4w90fwcw9h51a8p";
     };
     meta = {
@@ -20683,7 +20683,7 @@ in modules // {
     name = "sorl-thumbnail-11.12";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sorl-thumbnail/${name}.tar.gz";
+      url = "mirror://pypi/s/sorl-thumbnail/${name}.tar.gz";
       sha256 = "050b9kzbx7jvs3qwfxxshhis090hk128maasy8pi5wss6nx5kyw4";
     };
 
@@ -20703,7 +20703,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/supervisor/${name}.tar.gz";
+      url = "mirror://pypi/s/supervisor/${name}.tar.gz";
       sha256 = "e3c3b35804c24b6325b5ba462553ebee80d5f4d1766274737b5c532cd4a11d59";
     };
 
@@ -20724,7 +20724,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/subprocess32/${name}.tar.gz";
+      url = "mirror://pypi/s/subprocess32/${name}.tar.gz";
       sha256 = "ddf4d46ed2be2c7e7372dfd00c464cabb6b3e29ca4113d85e26f82b3d2c220f6";
     };
 
@@ -20755,7 +20755,7 @@ in modules // {
     # https://github.com/sphinx-doc/sphinx/issues/2394
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/S/Sphinx/${name}.tar.gz";
+      url = "mirror://pypi/S/Sphinx/${name}.tar.gz";
       sha256 = "12pzlfkjjlwgvsj56k0y809jpx5mgcs9548k1l4kdbr028ifjfqb";
     };
 
@@ -20781,7 +20781,7 @@ in modules // {
   sphinx_1_2 = self.sphinx.override rec {
     name = "sphinx-1.2.3";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sphinx/sphinx-1.2.3.tar.gz";
+      url = "mirror://pypi/s/sphinx/sphinx-1.2.3.tar.gz";
       sha256 = "94933b64e2fe0807da0612c574a021c0dac28c7bd3c4a23723ae5a39ea8f3d04";
     };
     patches = [];
@@ -20794,7 +20794,7 @@ in modules // {
     name = "sphinx_rtd_theme-0.1.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/sphinx_rtd_theme/${name}.tar.gz";
+      url = "mirror://pypi/s/sphinx_rtd_theme/${name}.tar.gz";
       sha256 = "18d0r63w7jpdrk4q5qy26n08vdlmnj9sar93akwjphyambw4cf17";
     };
 
@@ -20820,7 +20820,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sphinxcontrib-httpdomain/${name}.tar.gz";
+      url = "mirror://pypi/s/sphinxcontrib-httpdomain/${name}.tar.gz";
       sha256 = "ba8fbe82eddc96cfa9d7b975b0422801a14ace9d7e051b8b2c725b92ea6137b5";
     };
 
@@ -20840,7 +20840,7 @@ in modules // {
     name = "sphinxcontrib-plantuml-0.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sphinxcontrib-plantuml/${name}.tar.gz";
+      url = "mirror://pypi/s/sphinxcontrib-plantuml/${name}.tar.gz";
       sha256 = "011yprqf41dcm1824zgk2w8vi9115286pmli6apwhlrsxc6b6cwv";
     };
 
@@ -20861,7 +20861,7 @@ in modules // {
     name = "Sphinx-PyPI-upload-0.2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/Sphinx-PyPI-upload/${name}.tar.gz";
+      url = "mirror://pypi/S/Sphinx-PyPI-upload/${name}.tar.gz";
       sha256 = "5f919a47ce7a7e6028dba809de81ae1297ac192347cf6fc54efca919d4865159";
     };
 
@@ -20884,7 +20884,7 @@ in modules // {
     doCheck = !isPyPy;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/S/SQLAlchemy/${name}.tar.gz";
+      url = "mirror://pypi/S/SQLAlchemy/${name}.tar.gz";
       sha256 = "0rhxgr85xdhjn467qfs0dkyj8x46zxcv6ad3dfx3w14xbkb3kakp";
     };
 
@@ -20918,7 +20918,7 @@ in modules // {
     doCheck = !isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/SQLAlchemy/${name}.tar.gz";
+      url = "mirror://pypi/S/SQLAlchemy/${name}.tar.gz";
       sha256 = "9edb47d137db42d57fd26673d6c841e189b1aeb9b566cca908962fcc8448c0bc";
     };
 
@@ -20945,7 +20945,7 @@ in modules // {
     version = "1.0.12";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/SQLAlchemy/${name}.tar.gz";
+      url = "mirror://pypi/S/SQLAlchemy/${name}.tar.gz";
       sha256 = "1l8qclhd0s90w3pvwhi5mjxdwr5j7gw7cjka2fx6f2vqmq7f4yb6";
     };
 
@@ -21004,7 +21004,7 @@ in modules // {
     name = "sqlalchemy-migrate-0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sqlalchemy-migrate/${name}.tar.gz";
+      url = "mirror://pypi/s/sqlalchemy-migrate/${name}.tar.gz";
       sha256 = "00z0lzjs4ksr9yr31zs26csyacjvavhpz6r74xaw1r89kk75qg7q";
     };
 
@@ -21040,7 +21040,7 @@ in modules // {
     doCheck = !isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sqlparse/${name}.tar.gz";
+      url = "mirror://pypi/s/sqlparse/${name}.tar.gz";
       sha256 = "108gy82x7davjrn3jqn7yv4r5v4jrzp892ysfx8l00abr8v6r337";
     };
 
@@ -21060,7 +21060,7 @@ in modules // {
     version = "0.6.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/statsmodels/${name}.tar.gz";
+      url = "mirror://pypi/s/statsmodels/${name}.tar.gz";
       sha256 = "be4e44374aec9e848b73e5a230dee190ac0c4519e1d40f69a5813190b13ec676";
     };
 
@@ -21085,7 +21085,7 @@ in modules // {
     disabled = isPy3k;  # next release will be py3k compatible
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-statsd/${name}.tar.gz";
+      url = "mirror://pypi/p/python-statsd/${name}.tar.gz";
       sha256 = "3d2fc153e0d894aa9983531ef47d20d75bd4ee9fd0e46a9d82f452dde58a0a71";
     };
 
@@ -21104,7 +21104,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/stompclient/${name}.tar.gz";
+      url = "mirror://pypi/s/stompclient/${name}.tar.gz";
       sha256 = "95a4e98dd0bba348714439ea11a25ee8a74acb8953f95a683924b5bf2a527e4e";
     };
 
@@ -21202,7 +21202,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/sure/${name}.tar.gz";
+      url = "mirror://pypi/s/sure/${name}.tar.gz";
       sha256 = "1lyjq0rvkbv585dppjdq90lbkm6gyvag3wgrggjzyh7cpyh5c12w";
     };
 
@@ -21221,7 +21221,7 @@ in modules // {
     name = "structlog-15.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/structlog/${name}.tar.gz";
+      url = "mirror://pypi/s/structlog/${name}.tar.gz";
       sha256 = "1h9qz4fsd7ph8rf80rqmlyj2q54xapgrmkpnyca01w1z8ww6f9w7";
     };
 
@@ -21243,7 +21243,7 @@ in modules // {
     version = "1.1.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/svgwrite/${name}.tar.gz";
+      url = "mirror://pypi/s/svgwrite/${name}.tar.gz";
       sha256 = "1f018813072aa4d7e95e58f133acb3f68fa7de0a0d89ec9402cc38406a0ec5b8";
     };
 
@@ -21262,7 +21262,7 @@ in modules // {
     version = "0.3.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/f/freezegun/freezegun-${version}.tar.gz";
+      url = "mirror://pypi/f/freezegun/freezegun-${version}.tar.gz";
       sha256 = "02ly89wwn0plcw8clkkzvxaw6zlpm8qyqpm9x2mfw4a0vppb4ngf";
     };
 
@@ -21336,7 +21336,7 @@ in modules // {
     name = "tabulate-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tabulate/${name}.tar.gz";
+      url = "mirror://pypi/t/tabulate/${name}.tar.gz";
       sha256 = "9071aacbd97a9a915096c1aaf0dc684ac2672904cd876db5904085d6dac9810e";
     };
 
@@ -21429,7 +21429,7 @@ in modules // {
     name = "taskw-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/taskw/${name}.tar.gz";
+      url = "mirror://pypi/t/taskw/${name}.tar.gz";
       sha256 = "1fa7bv5996ppfbryv02lpnlhk5dra63lhlwrb1i4ifqbziqfqh5n";
     };
 
@@ -21459,7 +21459,7 @@ in modules // {
     name = "tempita-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/T/Tempita/Tempita-${version}.tar.gz";
+      url = "mirror://pypi/T/Tempita/Tempita-${version}.tar.gz";
       sha256 = "cacecf0baa674d356641f1d406b8bff1d756d739c46b869a54de515d08e6fc9c";
     };
 
@@ -21478,7 +21478,7 @@ in modules // {
     version = "0.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/terminado/${name}.tar.gz";
+      url = "mirror://pypi/t/terminado/${name}.tar.gz";
       sha256 = "2c0ba1f624067dccaaead7d2247cfe029806355cef124dc2ccb53c83229f0126";
     };
 
@@ -21531,7 +21531,7 @@ in modules // {
     version = "2.4.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/keystonemiddleware/${name}.tar.gz";
+      url = "mirror://pypi/k/keystonemiddleware/${name}.tar.gz";
       sha256 = "0avrn1f897rnam9wfdanpdwsmn8is3ncfh3nnzq3d1m31b1yqqr6";
     };
 
@@ -21554,7 +21554,7 @@ in modules // {
     version = "0.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/testscenarios/${name}.tar.gz";
+      url = "mirror://pypi/t/testscenarios/${name}.tar.gz";
       sha256 = "1671jvrvqlmbnc42j7pc5y6vc37q44aiwrq0zic652pxyy2fxvjg";
     };
 
@@ -21572,7 +21572,7 @@ in modules // {
     version = "0.0.20";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/testrepository/${name}.tar.gz";
+      url = "mirror://pypi/t/testrepository/${name}.tar.gz";
       sha256 = "1ssqb07c277010i6gzzkbdd46gd9mrj0bi0i8vn560n2k2y4j93m";
     };
 
@@ -21595,7 +21595,7 @@ in modules // {
     version = "0.2.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/testresources/${name}.tar.gz";
+      url = "mirror://pypi/t/testresources/${name}.tar.gz";
       sha256 = "0cbj3plbllyz42c4b5xxgwaa7mml54lakslrn4kkhinxhdri22md";
     };
 
@@ -21614,7 +21614,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/testtools/${name}.tar.gz";
+      url = "mirror://pypi/t/testtools/${name}.tar.gz";
       sha256 = "15yxz8d70iy1b1x6gd7spvblq0mjxjardl4vnaqasxafzc069zca";
     };
 
@@ -21634,7 +21634,7 @@ in modules // {
     name = "traitlets-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/traitlets/${name}.tar.gz";
+      url = "mirror://pypi/t/traitlets/${name}.tar.gz";
       sha256 = "440e38dfa5d2a26c086d4b427cfb7aed17d0a2dca78bce90c33354da2592af5b";
     };
 
@@ -21658,7 +21658,7 @@ in modules // {
     version = "0.1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-mimeparse/${name}.tar.gz";
+      url = "mirror://pypi/p/python-mimeparse/${name}.tar.gz";
       sha256 = "1hyxg09kaj02ri0rmwjqi86wk4nd1akvv7n0dx77azz76wga4s9w";
     };
 
@@ -21678,7 +21678,7 @@ in modules // {
     version = "0.0.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/extras/extras-${version}.tar.gz";
+      url = "mirror://pypi/e/extras/extras-${version}.tar.gz";
       sha256 = "1h7zx4dfyclalg0fqnfjijpn0f793a9mx8sy3b27gd31nr6dhq3s";
     };
 
@@ -21696,7 +21696,7 @@ in modules // {
     name = "texttable-0.8.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/texttable/${name}.tar.gz";
+      url = "mirror://pypi/t/texttable/${name}.tar.gz";
       sha256 = "0bkhs4dx9s6g7fpb969hygq56hyz4ncfamlynw72s0n6nqfbd1w5";
     };
 
@@ -21712,7 +21712,7 @@ in modules // {
     version = "0.4.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tlslite/${name}.tar.gz";
+      url = "mirror://pypi/t/tlslite/${name}.tar.gz";
       sha256 = "1fxx6d3nw5r1hqna1h2jvqhcygn9fyshlm0gh3gp0b1ji824gd6r";
     };
 
@@ -21728,7 +21728,7 @@ in modules // {
     version = "5.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/q/qrcode/${name}.tar.gz";
+      url = "mirror://pypi/q/qrcode/${name}.tar.gz";
       sha256 = "0skzrvhjnnacrz52jml4i050vdx5lfcd3np172srxjaghdgfxg9k";
     };
 
@@ -21750,7 +21750,7 @@ in modules // {
     version = "0.6.17";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tmdb3/${name}.zip";
+      url = "mirror://pypi/t/tmdb3/${name}.zip";
       sha256 = "64a6c3f1a60a9d8bf18f96a5403f3735b334040345ac3646064931c209720972";
     };
 
@@ -21766,7 +21766,7 @@ in modules // {
     version = "0.7.4";
 
     src = pkgs.fetchurl{
-      url = "https://pypi.python.org/packages/source/t/toolz/toolz-${version}.tar.gz";
+      url = "mirror://pypi/t/toolz/toolz-${version}.tar.gz";
       sha256 = "43c2c9e5e7a16b6c88ba3088a9bfc82f7db8e13378be7c78d6c14a5f8ed05afd";
     };
 
@@ -21793,7 +21793,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tox/${name}.tar.gz";
+      url = "mirror://pypi/t/tox/${name}.tar.gz";
       sha256 = "1vj73ar4rimq3fwy5r2z3jv4g9qbh8rmpmncsc00g0k310acqzxz";
     };
   };
@@ -21803,7 +21803,7 @@ in modules // {
     version = "3.7.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tqdm/${name}.tar.gz";
+      url = "mirror://pypi/t/tqdm/${name}.tar.gz";
       sha256 = "f12d792685f779e8754e623aff1a25a93b98a90457e3a2b7eb89b4401c2c239e";
     };
 
@@ -21829,7 +21829,7 @@ in modules // {
     buildInputs = with self; [ nosexcover ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/smmap/${name}.tar.gz";
+      url = "mirror://pypi/s/smmap/${name}.tar.gz";
       sha256 = "0qlx25f6n2n9ff37w9gg62f217fzj16xlbh0pkz0lpxxjys64aqf";
     };
   };
@@ -21862,7 +21862,7 @@ in modules // {
     version = "4.5.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/traits/${name}.tar.gz";
+      url = "mirror://pypi/t/traits/${name}.tar.gz";
       sha256 = "5293a8786030b0b243e059f52004355b6939d7c0f1be2eb5a605b63cca484c84";
     };
 
@@ -21893,7 +21893,7 @@ in modules // {
     version = "1.4.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/transaction/${name}.tar.gz";
+      url = "mirror://pypi/t/transaction/${name}.tar.gz";
       sha256 = "1b2304a886a85ad014f73d93346c14350fc214ae22a4f565f42f6761cfb9ecc5";
     };
 
@@ -21911,7 +21911,7 @@ in modules // {
     version = "0.11";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/transmissionrpc/${name}.tar.gz";
+      url = "mirror://pypi/t/transmissionrpc/${name}.tar.gz";
       sha256 = "ec43b460f9fde2faedbfa6d663ef495b3fd69df855a135eebe8f8a741c0dde60";
     };
 
@@ -21929,7 +21929,7 @@ in modules // {
      version = "0.4";
 
      src = pkgs.fetchurl {
-       url = "http://pypi.python.org/packages/source/t/tl.eggdeps/tl.${name}.tar.gz";
+       url = "mirror://pypi/t/tl.eggdeps/tl.${name}.tar.gz";
        sha256 = "a99de5e4652865224daab09b2e2574a4f7c1d0d9a267048f9836aa914a2caf3a";
      };
 
@@ -21950,7 +21950,7 @@ in modules // {
     disabled = isPyPy || isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/turses/${name}.tar.gz";
+      url = "mirror://pypi/t/turses/${name}.tar.gz";
       sha256 = "15mkhm3b5ka42h8qph0mhh8izfc1200v7651c62k7ldcs50ib9j6";
     };
 
@@ -21984,7 +21984,7 @@ in modules // {
     name = "tweepy-3.5.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/tweepy/${name}.tar.gz";
+      url = "mirror://pypi/t/tweepy/${name}.tar.gz";
       sha256 = "0n2shilamgwhzmvf534xg7f6hrnznbixyl5pw2f5a3f391gwy37h";
     };
 
@@ -22004,7 +22004,7 @@ in modules // {
     version = "0.4.5";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/T/Twiggy/Twiggy-0.4.5.tar.gz";
+      url    = "mirror://pypi/T/Twiggy/Twiggy-0.4.5.tar.gz";
       sha256 = "4e8f1894e5aee522db6cb245ccbfde3c5d1aa08d31330c7e3af783b0e66eec23";
     };
 
@@ -22025,7 +22025,7 @@ in modules // {
     version = "1.15.0";
 
     src = pkgs.fetchurl {
-      url    = "https://pypi.python.org/packages/source/t/twitter/${name}.tar.gz";
+      url    = "mirror://pypi/t/twitter/${name}.tar.gz";
       sha256 = "1m6b17irb9klc345k8174pni724jzy2973z2x2jg69h83hipjw2c";
     };
 
@@ -22045,7 +22045,7 @@ in modules // {
 
     name = "Twisted-13.2.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/T/Twisted/${name}.tar.bz2";
+      url = "mirror://pypi/T/Twisted/${name}.tar.bz2";
       sha256 = "1wrcqv5lvgwk2aq83qb2s2ng2vx14hbjjk2gc30cg6h1iiipal89";
     };
 
@@ -22074,7 +22074,7 @@ in modules // {
 
     name = "Twisted-15.5.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/T/Twisted/${name}.tar.bz2";
+      url = "mirror://pypi/T/Twisted/${name}.tar.bz2";
       sha256 = "0zy18lcrris4aaslil5k12i13k56c32hzfdv6h10kbnzl026h158";
     };
 
@@ -22104,7 +22104,7 @@ in modules // {
     propagatedBuildInputs = with self; [ pytz ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tzlocal/${name}.tar.gz";
+      url = "mirror://pypi/t/tzlocal/${name}.tar.gz";
       sha256 = "0paj7vlsb0np8b5sp4bv64wxv7qk2piyp7xg29pkhdjwsbls9fnb";
     };
 
@@ -22123,7 +22123,7 @@ in modules // {
     version = "0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/umalqurra/umalqurra-0.2.tar.gz";
+      url = "mirror://pypi/u/umalqurra/umalqurra-0.2.tar.gz";
       sha256 = "719f6a36f908ada1c29dae0d934dd0f1e1f6e3305784edbec23ad719397de678";
     };
 
@@ -22146,7 +22146,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/umemcache/${name}.zip";
+      url = "mirror://pypi/u/umemcache/${name}.zip";
       sha256 = "211031a03576b7796bf277dbc9c9e3e754ba066bbb7fb601ab5c6291b8ec1918";
     };
 
@@ -22162,7 +22162,7 @@ in modules // {
     name = "unicodecsv-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/unicodecsv/${name}.tar.gz";
+      url = "mirror://pypi/u/unicodecsv/${name}.tar.gz";
       sha256 = "1z7pdwkr6lpsa7xbyvaly7pq3akflbnz8gq62829lr28gl1hi301";
     };
 
@@ -22181,7 +22181,7 @@ in modules // {
     name = "unittest2-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/u/unittest2/unittest2-${version}.tar.gz";
+      url = "mirror://pypi/u/unittest2/unittest2-${version}.tar.gz";
       sha256 = "0y855kmx7a8rnf81d3lh5lyxai1908xjp0laf4glwa4c8472m212";
     };
 
@@ -22208,7 +22208,7 @@ in modules // {
     version = "0.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/uritemplate.py/${name}.tar.gz";
+      url = "mirror://pypi/u/uritemplate.py/${name}.tar.gz";
       sha256 = "0xvvdiwnag2pdi96hjf7v8asdia98flk2rxcjqnwcs3rk99alygx";
     };
 
@@ -22225,7 +22225,7 @@ in modules // {
     name = "traceback2-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/traceback2/traceback2-${version}.tar.gz";
+      url = "mirror://pypi/t/traceback2/traceback2-${version}.tar.gz";
       sha256 = "0c1h3jas1jp1fdbn9z2mrgn3jj0hw1x3yhnkxp7jw34q15xcdb05";
     };
 
@@ -22244,7 +22244,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/linecache2/${name}.tar.gz";
+      url = "mirror://pypi/l/linecache2/${name}.tar.gz";
       sha256 = "0z79g3ds5wk2lvnqw0y2jpakjf32h95bd9zmnvp7dnqhf57gy9jb";
     };
 
@@ -22285,7 +22285,7 @@ in modules // {
     name = "update_checker-0.11";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/update_checker/${name}.tar.gz";
+      url = "mirror://pypi/u/update_checker/${name}.tar.gz";
       sha256 = "681bc7c26cffd1564eb6f0f3170d975a31c2a9f2224a32f80fe954232b86f173";
     };
 
@@ -22330,7 +22330,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/urwid/${name}.tar.gz";
+      url = "mirror://pypi/u/urwid/${name}.tar.gz";
       sha256 = "29f04fad3bf0a79c5491f7ebec2d50fa086e9d16359896c9204c6a92bc07aba2";
     };
 
@@ -22390,7 +22390,7 @@ in modules // {
     propagatedBuildInputs = with self; [ easy-process ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyVirtualDisplay/${name}.tar.gz";
+      url = "mirror://pypi/P/PyVirtualDisplay/${name}.tar.gz";
       sha256 = "aa6aef08995e14c20cc670d933bfa6e70d736d0b555af309b2e989e2faa9ee53";
     };
 
@@ -22406,7 +22406,7 @@ in modules // {
     name = "virtualenv-13.1.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/v/virtualenv/${name}.tar.gz";
+      url = "mirror://pypi/v/virtualenv/${name}.tar.gz";
       sha256 = "1p732accxwqfjbdna39k8w8lp9gyw91vr4kzkhm8mgfxikqqxg5a";
     };
 
@@ -22431,7 +22431,7 @@ in modules // {
     name = "virtualenv-clone-0.2.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/v/virtualenv-clone/${name}.tar.gz";
+      url = "mirror://pypi/v/virtualenv-clone/${name}.tar.gz";
       sha256 = "7087ba4eb48acfd5209a3fd03e15d072f28742619127c98333057e32748d91c4";
     };
 
@@ -22452,7 +22452,7 @@ in modules // {
     name = "virtualenvwrapper-4.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/v/virtualenvwrapper/${name}.tar.gz";
+      url = "mirror://pypi/v/virtualenvwrapper/${name}.tar.gz";
       sha256 = "514cbc22218347bf7b54bdbe49e1a5f550d2d53b1ad2491c10e91ddf48fb528f";
     };
 
@@ -22542,7 +22542,7 @@ in modules // {
     name = "waitress-0.8.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/w/waitress/${name}.tar.gz";
+      url = "mirror://pypi/w/waitress/${name}.tar.gz";
       sha256 = "826527dc9d334ed4ed76cdae672fdcbbccf614186657db71679ab58df869458a";
     };
 
@@ -22559,7 +22559,7 @@ in modules // {
     version = "0.11.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/webassets/${name}.tar.gz";
+      url = "mirror://pypi/w/webassets/${name}.tar.gz";
       sha256 = "0p1qypcbq9b88ipcylxh3bbnby5n6dr421wb4bwmrlcrgvj4r5lz";
     };
 
@@ -22578,7 +22578,7 @@ in modules // {
     name = "webcolors-1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/webcolors/${name}.tar.gz";
+      url = "mirror://pypi/w/webcolors/${name}.tar.gz";
       sha256 = "304fc95dab2848c7bf64f378356766e692c2f8b4a8b15fa3509544e6412936e8";
     };
 
@@ -22598,7 +22598,7 @@ in modules // {
     name = "Wand-0.3.5";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/W/Wand/${name}.tar.gz";
+      url = "mirror://pypi/W/Wand/${name}.tar.gz";
       sha256 = "31e2186ce8d1da0d2ea84d1428fc4d441c2e9d0e25156cc746b35b781026bcff";
     };
 
@@ -22617,7 +22617,7 @@ in modules // {
     version = "0.1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/wcwidth/${name}.tar.gz";
+      url = "mirror://pypi/w/wcwidth/${name}.tar.gz";
       sha256 = "0awx28xi938nv55qlmai3b5ddqd1w5c294gy95xh4xsx0hik2vch";
     };
 
@@ -22644,7 +22644,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/web.py/web.py-${version}.tar.gz";
+      url = "mirror://pypi/w/web.py/web.py-${version}.tar.gz";
       sha256 = "748c7e99ad9e36f62ea19f7965eb7dd7860b530e8f563ed60ce3e53e7409a550";
     };
 
@@ -22665,7 +22665,7 @@ in modules // {
     name = "webob-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/W/WebOb/WebOb-${version}.tar.gz";
+      url = "mirror://pypi/W/WebOb/WebOb-${version}.tar.gz";
       sha256 = "1nz9m6ijf46wfn33zfza13c0k1n4kjnmn3icdlrlgz5yj21vky0j";
     };
 
@@ -22684,7 +22684,7 @@ in modules // {
     name = "websockify-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/w/websockify/websockify-${version}.tar.gz";
+      url = "mirror://pypi/w/websockify/websockify-${version}.tar.gz";
       sha256 = "1v6pmamjprv2x55fvbdaml26ppxdw8v6xz8p0sav3368ajwwgcqc";
     };
 
@@ -22702,7 +22702,7 @@ in modules // {
     name = "webtest-${version}";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/W/WebTest/WebTest-${version}.tar.gz";
+      url = "mirror://pypi/W/WebTest/WebTest-${version}.tar.gz";
       sha256 = "0bv0qhdjakdsdgj4sk21gnpp8xp8bga4x03p6gjb83ihrsb7n4xv";
     };
 
@@ -22740,7 +22740,7 @@ in modules // {
     name = "Werkzeug-0.10.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/W/Werkzeug/${name}.tar.gz";
+      url = "mirror://pypi/W/Werkzeug/${name}.tar.gz";
       sha256 = "9d2771e4c89be127bc4bac056ab7ceaf0e0064c723d6b6e195739c3af4fd5c1d";
     };
 
@@ -22760,7 +22760,7 @@ in modules // {
     version = "0.29.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/wheel/${name}.tar.gz";
+      url = "mirror://pypi/w/wheel/${name}.tar.gz";
       sha256 = "1ebb8ad7e26b448e9caa4773d2357849bf80ff9e313964bcaf79cbf0201a1648";
     };
 
@@ -22779,7 +22779,7 @@ in modules // {
     name = "willie-5.2.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/willie/willie-5.2.0.tar.gz";
+      url = "mirror://pypi/w/willie/willie-5.2.0.tar.gz";
       sha256 = "2da2e91b65c471b4c8e5e5e11471b25887635258d24aaf76b5354147b3ab577d";
     };
 
@@ -22814,7 +22814,7 @@ in modules // {
     name = "WSGIProxy2-0.4.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/W/WSGIProxy2/${name}.zip";
+      url = "mirror://pypi/W/WSGIProxy2/${name}.zip";
       sha256 = "13kf9bdxrc95y9vriaz0viry3ah11nz4rlrykcfvb8nlqpx3dcm4";
     };
 
@@ -22897,7 +22897,7 @@ in modules // {
     name = "xmltodict-0.9.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/x/xmltodict/${name}.tar.gz";
+      url = "mirror://pypi/x/xmltodict/${name}.tar.gz";
       sha256 = "00crqnjh1kbvcgfnn3b8c7vq30lf4ykkxp1xf3pf7mswr5l1wp97";
     };
 
@@ -22915,7 +22915,7 @@ in modules // {
     version = "0.7.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xarray/${name}.tar.gz";
+      url = "mirror://pypi/x/xarray/${name}.tar.gz";
       sha256 = "1swcpq8x0p5pp94r9j4hr2anz1rqh7fnqax16xn9xsgrikdjipj5";
     };
 
@@ -22939,7 +22939,7 @@ in modules // {
     version = "1.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xlwt/${name}.tar.gz";
+      url = "mirror://pypi/x/xlwt/${name}.tar.gz";
       sha256 = "1y8w5imsicp01gn749qhw6j0grh9y19zz57ribwaknn8xqwjjhxc";
     };
 
@@ -22972,7 +22972,7 @@ in modules // {
     name = "zbase32-1.1.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zbase32/${name}.tar.gz";
+      url = "mirror://pypi/z/zbase32/${name}.tar.gz";
       sha256 = "2f44b338f750bd37b56e7887591bf2f1965bfa79f163b6afcbccf28da642ec56";
     };
 
@@ -22993,7 +22993,7 @@ in modules // {
     version = "3.0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/Z/ZConfig/ZConfig-${version}.tar.gz";
+      url = "mirror://pypi/Z/ZConfig/ZConfig-${version}.tar.gz";
       sha256 = "6577da957511d8c2f805fefd2e31cacc4117bb5c54aec03ad8ce374020c021f3";
     };
 
@@ -23013,7 +23013,7 @@ in modules // {
     version = "1.0.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zc.lockfile/${name}.tar.gz";
+      url = "mirror://pypi/z/zc.lockfile/${name}.tar.gz";
       sha256 = "96bb2aa0438f3e29a31e4702316f832ec1482837daef729a92e28c202d8fba5c";
     };
 
@@ -23031,7 +23031,7 @@ in modules // {
     version = "4.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zdaemon/${name}.tar.gz";
+      url = "mirror://pypi/z/zdaemon/${name}.tar.gz";
       sha256 = "82d7eaa4d831ff1ecdcffcb274f3457e095c0cc86e630bc72009a863c341ab9f";
     };
 
@@ -23054,7 +23054,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zfec/${name}.tar.gz";
+      url = "mirror://pypi/z/zfec/${name}.tar.gz";
       sha256 = "1ks94zlpy7n8sb8380gf90gx85qy0p9073wi1wngg6mccxp9xsg3";
     };
 
@@ -23085,7 +23085,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/Z/ZODB3/ZODB3-${version}.tar.gz";
+      url = "mirror://pypi/Z/ZODB3/ZODB3-${version}.tar.gz";
       sha256 = "b5767028e732c619f45c27189dd001e14ec155d7984807991fce751b35b4fcb0";
     };
 
@@ -23106,7 +23106,7 @@ in modules // {
     version = "4.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/Z/ZODB/ZODB-${version}.tar.gz";
+      url = "mirror://pypi/Z/ZODB/ZODB-${version}.tar.gz";
       sha256 = "c5d8ffcca37ab4d0a9bfffead6228d58c00cf1c78135abc98a8dbf05b8c8fb58";
     };
 
@@ -23131,7 +23131,7 @@ in modules // {
     disabled = isPyPy; # https://github.com/zopefoundation/zodbpickle/issues/10
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/z/zodbpickle/${name}.tar.gz";
+      url = "mirror://pypi/z/zodbpickle/${name}.tar.gz";
       sha256 = "f65c00fbc13523fced63de6cc11747aa1a6343aeb2895c89838ed55a5ab12cca";
     };
 
@@ -23150,7 +23150,7 @@ in modules // {
     propagatedBuildInputs = with self; [ persistent zope_interface transaction ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/B/BTrees/${name}.tar.gz";
+      url = "mirror://pypi/B/BTrees/${name}.tar.gz";
       sha256 = "1avvhkd7rvp3rzhw20v6ank8a8m9a1lmh99c4gjjsa1ry0zsri3y";
     };
 
@@ -23169,7 +23169,7 @@ in modules // {
     propagatedBuildInputs = with self; [ zope_interface ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/persistent/${name}.tar.gz";
+      url = "mirror://pypi/p/persistent/${name}.tar.gz";
       sha256 = "678902217c5370d33694c6dc95b89e1e6284b4dc41f04c056326194a3f6f3e22";
     };
 
@@ -23183,7 +23183,7 @@ in modules // {
     name = "xdot-0.6";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xdot/xdot-0.6.tar.gz";
+      url = "mirror://pypi/x/xdot/xdot-0.6.tar.gz";
       sha256 = "c71d82bad0fec696af36af788c2a1dbb5d9975bd70bfbdc14bda15b5c7319e6c";
     };
 
@@ -23200,7 +23200,7 @@ in modules // {
     name = "zope.broken-3.6.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.broken/${name}.zip";
+      url = "mirror://pypi/z/zope.broken/${name}.zip";
       sha256 = "b9b8776002da4f7b6b12dfcce77eb642ae62b39586dbf60e1d9bdc992c9f2999";
     };
 
@@ -23216,7 +23216,7 @@ in modules // {
     name = "zope.browser-2.0.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.browser/${name}.zip";
+      url = "mirror://pypi/z/zope.browser/${name}.zip";
       sha256 = "0f9r5rn9lzgi4hvkhgb6vgw8kpz9sv16jsfb9ws4am8gbqcgv2iy";
     };
 
@@ -23239,7 +23239,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/z/zope.browserresource/zope.browserresource-4.0.1.zip";
+      url = "mirror://pypi/z/zope.browserresource/zope.browserresource-4.0.1.zip";
       sha256 = "d580184562e7098950ae377b5b37fbb88becdaa2256ac2a6760b69a3e86a99b2";
     };
   };
@@ -23250,7 +23250,7 @@ in modules // {
     name = "zope.component-4.2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.component/zope.component-4.2.1.tar.gz";
+      url = "mirror://pypi/z/zope.component/zope.component-4.2.1.tar.gz";
       sha256 = "1gzbr0j6c2h0cqnpi2cjss38wrz1bcwx8xahl3vykgz5laid15l6";
     };
 
@@ -23272,7 +23272,7 @@ in modules // {
     name = "zope.configuration-4.0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.configuration/zope.configuration-4.0.3.tar.gz";
+      url = "mirror://pypi/z/zope.configuration/zope.configuration-4.0.3.tar.gz";
       sha256 = "1x9dfqypgympnlm25p9m43xh4qv3p7d75vksv9pzqibrb4cggw5n";
     };
 
@@ -23288,7 +23288,7 @@ in modules // {
     name = "zope.container-4.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.container/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.container/${name}.tar.gz";
       sha256 = "5c04e61b52fd04d8b7103476532f557c2278c86281aae30d44f88a5fbe888940";
     };
 
@@ -23311,7 +23311,7 @@ in modules // {
     name = "zope.contenttype-4.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.contenttype/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.contenttype/${name}.tar.gz";
       sha256 = "9decc7531ad6925057f1a667ac0ef9d658577a92b0b48dafa7daa97b78a02bbb";
     };
 
@@ -23325,7 +23325,7 @@ in modules // {
     name = "zope.dottedname-3.4.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.dottedname/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.dottedname/${name}.tar.gz";
       sha256 = "331d801d98e539fa6c5d50c3835ecc144c429667f483281505de53fc771e6bf5";
     };
     meta = {
@@ -23339,7 +23339,7 @@ in modules // {
     version = "4.0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.event/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.event/${name}.tar.gz";
       sha256 = "1w858k9kmgzfj36h65kp27m9slrmykvi5cjq6c119xqnaz5gdzgm";
     };
 
@@ -23357,7 +23357,7 @@ in modules // {
      version = "4.0.8";
 
      src = pkgs.fetchurl {
-       url = "http://pypi.python.org/packages/source/z/zope.exceptions/${name}.tar.gz";
+       url = "mirror://pypi/z/zope.exceptions/${name}.tar.gz";
        sha256 = "0zwxaaa66sqxg5k7zcrvs0fbg9ym1njnxnr28dfmchzhwjvwnfzl";
      };
 
@@ -23379,7 +23379,7 @@ in modules // {
     name = "zope.filerepresentation-3.6.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.filerepresentation/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.filerepresentation/${name}.tar.gz";
       sha256 = "d775ebba4aff7687e0381f050ebda4e48ce50900c1438f3f7e901220634ed3e0";
     };
 
@@ -23395,7 +23395,7 @@ in modules // {
     name = "zope.i18n-3.8.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.i18n/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.i18n/${name}.tar.gz";
       sha256 = "045nnimmshibcq71yym2d8yrs6wzzhxq5gl7wxjnkpyjm5y0hfkm";
     };
 
@@ -23411,7 +23411,7 @@ in modules // {
     name = "zope.i18nmessageid-4.0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.i18nmessageid/zope.i18nmessageid-4.0.3.tar.gz";
+      url = "mirror://pypi/z/zope.i18nmessageid/zope.i18nmessageid-4.0.3.tar.gz";
       sha256 = "1rslyph0klk58dmjjy4j0jxy21k03azksixc3x2xhqbkv97cmzml";
     };
 
@@ -23425,7 +23425,7 @@ in modules // {
     name = "zope.lifecycleevent-3.7.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.lifecycleevent/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.lifecycleevent/${name}.tar.gz";
       sha256 = "0s5brphqzzz89cykg61gy7zcmz0ryq1jj2va7gh2n1b3cccllp95";
     };
 
@@ -23441,7 +23441,7 @@ in modules // {
     name = "zope.location-4.0.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.location/zope.location-4.0.3.tar.gz";
+      url = "mirror://pypi/z/zope.location/zope.location-4.0.3.tar.gz";
       sha256 = "1nj9da4ksiyv3h8n2vpzwd0pb03mdsh7zy87hfpx72b6p2zcwg74";
     };
 
@@ -23464,7 +23464,7 @@ in modules // {
     name = "zope.proxy-4.1.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.proxy/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.proxy/${name}.tar.gz";
       sha256 = "0pqwwmvm1prhwv1ziv9lp8iirz7xkwb6n2kyj36p2h0ppyyhjnm4";
     };
 
@@ -23483,7 +23483,7 @@ in modules // {
     name = "zope.publisher-3.12.6";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.publisher/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.publisher/${name}.tar.gz";
       sha256 = "d994d8eddfba504841492115032a9a7d86b1713ebc96d0ca16fbc6ee93168ba4";
     };
 
@@ -23501,7 +23501,7 @@ in modules // {
     name = "zope.schema-4.4.2";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.schema/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.schema/${name}.tar.gz";
       sha256 = "1p943jdxb587dh7php4vx04qvn7b2877hr4qs5zyckvp5afhhank";
     };
 
@@ -23517,7 +23517,7 @@ in modules // {
     name = "zope.security-4.0.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.security/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.security/${name}.tar.gz";
       sha256 = "8da30b03d5491464d59397e03b88192f31f587325ee6c6eb1ca596a1e487e2ec";
     };
 
@@ -23536,7 +23536,7 @@ in modules // {
     name = "zope.size-3.5.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.size/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.size/${name}.tar.gz";
       sha256 = "006xfkhvmypwd3ww9gbba4zly7n9w30bpp1h74d53la7l7fiqk2f";
     };
 
@@ -23554,7 +23554,7 @@ in modules // {
     doCheck = !isPyPy; # https://github.com/zopefoundation/zope.sqlalchemy/issues/12
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.sqlalchemy/${name}.zip";
+      url = "mirror://pypi/z/zope.sqlalchemy/${name}.zip";
       sha256 = "0vxhpdvzihsmg63aralmc7hx62lzrsnlxvskvlcr4mkwzwb22haj";
     };
 
@@ -23573,7 +23573,7 @@ in modules // {
     version = "4.5.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.testing/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.testing/${name}.tar.gz";
       sha256 = "1yvglxhzvhl45mndvn9gskx2ph30zz1bz7rrlyfs62fv2pvih90s";
     };
 
@@ -23595,7 +23595,7 @@ in modules // {
     version = "4.4.10";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.testrunner/${name}.zip";
+      url = "mirror://pypi/z/zope.testrunner/${name}.zip";
       sha256 = "1w09wbqiqmq6hvrammi4fzc7fr129v63gdnzlk4qi2b1xy5qpqab";
     };
 
@@ -23614,7 +23614,7 @@ in modules // {
     name = "zope.traversing-4.0.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.traversing/${name}.zip";
+      url = "mirror://pypi/z/zope.traversing/${name}.zip";
       sha256 = "79d38b92ec1d9a2467966ee954b792d83ac66f22e45e928113d4b5dc1f5e74eb";
     };
 
@@ -23633,7 +23633,7 @@ in modules // {
     name = "zope.interface-4.1.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/z/zope.interface/${name}.tar.gz";
+      url = "mirror://pypi/z/zope.interface/${name}.tar.gz";
       sha256 = "0ks8h73b2g4bkad821qbv0wzjppdrwys33i7ka45ik3wxjg1l8if";
     };
 
@@ -23650,7 +23650,7 @@ in modules // {
   hgsvn = buildPythonPackage rec {
     name = "hgsvn-0.3.11";
     src = pkgs.fetchurl rec {
-      url = "https://pypi.python.org/packages/source/h/hgsvn/${name}-hotfix.zip";
+      url = "mirror://pypi/h/hgsvn/${name}-hotfix.zip";
       sha256 = "0yvhwdh8xx8rvaqd3pnnyb99hfa0zjdciadlc933p27hp9rf880p";
     };
     disabled = isPy3k || isPyPy;
@@ -23715,7 +23715,7 @@ in modules // {
     propagatedBuildInputs = with self; [ backports_ssl_match_hostname_3_4_0_2 certifi ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tornado/${name}.tar.gz";
+      url = "mirror://pypi/t/tornado/${name}.tar.gz";
       sha256 = "a16fcdc4f76b184cb82f4f9eaeeacef6113b524b26a2cb331222e4a7fa6f2969";
     };
   };
@@ -23727,7 +23727,7 @@ in modules // {
     propagatedBuildInputs = with self; [ backports_ssl_match_hostname_3_4_0_2 certifi ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tornado/${name}.tar.gz";
+      url = "mirror://pypi/t/tornado/${name}.tar.gz";
       sha256 = "00crp5vnasxg7qyjv89qgssb69vd7qr13jfghdryrcbnn9l8c1df";
     };
   };
@@ -23804,7 +23804,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/tarman/tarman-${version}.zip";
+      url = "mirror://pypi/t/tarman/tarman-${version}.zip";
       sha256 = "0ri6gj883k042xaxa2d5ymmhbw2bfcxdzhh4bz7700ibxwxxj62h";
     };
 
@@ -23833,7 +23833,7 @@ in modules // {
     name = "libarchive-c-2.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/l/libarchive-c/${name}.tar.gz";
+      url = "mirror://pypi/l/libarchive-c/${name}.tar.gz";
       sha256 = "089lrz6xyrfnk55v35vis6jyqyyl77w093057djyspnd2744wi2n";
     };
 
@@ -23871,7 +23871,7 @@ in modules // {
   pyzmq = buildPythonPackage rec {
     name = "pyzmq-15.2.0";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/p/pyzmq/${name}.tar.gz";
+      url = "mirror://pypi/p/pyzmq/${name}.tar.gz";
       sha256 = "2dafa322670a94e20283aba2a44b92134d425bd326419b68ad4db8d0831a26ec";
     };
     buildInputs = with self; [ pkgs.zeromq3 pytest tornado ];
@@ -23908,7 +23908,7 @@ in modules // {
     version = "4.5.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/testfixtures/testfixtures-${version}.tar.gz";
+      url = "mirror://pypi/t/testfixtures/testfixtures-${version}.tar.gz";
       sha256 = "0my8zq9d27mc7j78pz9971cn5wz6zi4vxlqa50szr2vq9j2xxkll";
     };
 
@@ -23931,7 +23931,7 @@ in modules // {
   tissue = buildPythonPackage rec {
     name = "tissue-0.9.2";
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/tissue/${name}.tar.gz";
+      url = "mirror://pypi/t/tissue/${name}.tar.gz";
       sha256 = "7e34726c3ec8fae358a7faf62de172db15716f5582e5192a109e33348bd76c2e";
     };
 
@@ -23970,7 +23970,7 @@ in modules // {
     name = "translationstring-1.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/t/translationstring/${name}.tar.gz";
+      url = "mirror://pypi/t/translationstring/${name}.tar.gz";
       sha256 = "4ee44cfa58c52ade8910ea0ebc3d2d84bdcad9fa0422405b1801ec9b9a65b72d";
     };
 
@@ -24030,7 +24030,7 @@ in modules // {
     name = "websocket_client-0.32.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/websocket-client/${name}.tar.gz";
+      url = "mirror://pypi/w/websocket-client/${name}.tar.gz";
       sha256 = "cb3ab95617ed2098d24723e3ad04ed06c4fde661400b96daa1859af965bfe040";
     };
 
@@ -24048,7 +24048,7 @@ in modules // {
     name = "WebHelpers-1.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/W/WebHelpers/${name}.tar.gz";
+      url = "mirror://pypi/W/WebHelpers/${name}.tar.gz";
       sha256 = "ea86f284e929366b77424ba9a89341f43ae8dee3cbeb8702f73bcf86058aa583";
     };
 
@@ -24086,7 +24086,7 @@ in modules // {
     version = "0.9.12";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/whisper/${name}.tar.gz";
+      url = "mirror://pypi/w/whisper/${name}.tar.gz";
       sha256 = "0eca66449d6ceb29e2ab5457b01618e0fe525710dd130a286a18282d849ae5b2";
     };
 
@@ -24105,7 +24105,7 @@ in modules // {
     version = "0.9.15";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/carbon/${name}.tar.gz";
+      url = "mirror://pypi/c/carbon/${name}.tar.gz";
       sha256 = "f01db6d37726c6fc0a8aaa66a7bf14436b0dd0d62ef3c20ecb31605a4d365d2e";
     };
 
@@ -24125,7 +24125,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/u/ujson/${name}.zip";
+      url = "mirror://pypi/u/ujson/${name}.zip";
       sha256 = "68cf825f227c82e1ac61e423cfcad923ff734c27b5bdd7174495d162c42c602b";
     };
 
@@ -24141,7 +24141,7 @@ in modules // {
     name = "Unidecode-0.04.18";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/U/Unidecode/${name}.tar.gz";
+      url = "mirror://pypi/U/Unidecode/${name}.tar.gz";
       sha256 = "12hhblqy1ajvidm38im4171x4arg83pfmziyn53nizp29p3m14gi";
     };
 
@@ -24162,7 +24162,7 @@ in modules // {
     name = "pyusb-1.0.0rc1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyusb/${name}.tar.gz";
+      url = "mirror://pypi/p/pyusb/${name}.tar.gz";
       sha256 = "07cjq11qhngzjd746k7688s6y2x7lpj669fxqfsiy985rg0jsn7j";
     };
 
@@ -24190,7 +24190,7 @@ in modules // {
     version = "1.1.8";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/B/BlinkStick/${name}.tar.gz";
+      url = "mirror://pypi/B/BlinkStick/${name}.tar.gz";
       sha256 = "3edf4b83a3fa1a7bd953b452b76542d54285ff6f1145b6e19f9b5438120fa408";
     };
 
@@ -24252,7 +24252,7 @@ in modules // {
     doCheck = (!isPy3k);
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/v/versiontools/${name}.tar.gz";
+      url = "mirror://pypi/v/versiontools/${name}.tar.gz";
       sha256 = "1xhl6kl7f4srgnw6zw4lr8j2z5vmrbaa83nzn2c9r2m1hwl36sd9";
     };
 
@@ -24263,7 +24263,7 @@ in modules // {
     version = "0.8.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/v/veryprettytable/${name}.tar.gz";
+      url = "mirror://pypi/v/veryprettytable/${name}.tar.gz";
       sha256 = "1k1rifz8x6qcicmx2is9vgxcj0qb2f5pvzrp7zhmvbmci3yack3f";
     };
 
@@ -24281,7 +24281,7 @@ in modules // {
     version = "0.9.12";
 
     src = pkgs.fetchurl rec {
-      url = "https://pypi.python.org/packages/source/g/graphite-web/${name}.tar.gz";
+      url = "mirror://pypi/g/graphite-web/${name}.tar.gz";
       sha256 = "472a4403fd5b5364939aee10e78f171b1489e5f6bfe6f150ed9cae8476410114";
     };
 
@@ -24352,7 +24352,7 @@ in modules // {
     name = "graphite_beacon-0.22.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/graphite_beacon/${name}.tar.gz";
+      url = "mirror://pypi/g/graphite_beacon/${name}.tar.gz";
       sha256 = "ebde1aba8030c8aeffaeea39f9d44a2be464b198583ad4a390a2bff5f4172543";
     };
 
@@ -24551,7 +24551,7 @@ in modules // {
     version = "0.11.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/L/Logbook/${name}.tar.gz";
+      url = "mirror://pypi/L/Logbook/${name}.tar.gz";
       sha256 = "0bchn00jj0y4dmrmqsm29ffcx37g79jcxjihadmgz2aj0z6dbsrc";
     };
 
@@ -24619,7 +24619,7 @@ in modules // {
     name = "rpdb-0.1.5";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/r/rpdb/${name}.tar.gz";
+      url = "mirror://pypi/r/rpdb/${name}.tar.gz";
       sha256 = "0rql1hq3lziwcql0h3dy05w074cn866p397ng9bv6qbz85ifw1bk";
     };
 
@@ -24635,7 +24635,7 @@ in modules // {
     name = "grequests-0.2.0";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/g/grequests/${name}.tar.gz";
+      url = "mirror://pypi/g/grequests/${name}.tar.gz";
       sha256 = "0lafzax5igbh8y4x0krizr573wjsxz7bhvwygiah6qwrzv83kv5c";
     };
 
@@ -24653,7 +24653,7 @@ in modules // {
     name = "Flask-Babel-0.9";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/F/Flask-Babel/${name}.tar.gz";
+      url = "mirror://pypi/F/Flask-Babel/${name}.tar.gz";
       sha256 = "0k7vk4k54y55ma0nx2k5s0phfqbriwslhy5shh3b0d046q7ibzaa";
     };
 
@@ -24671,7 +24671,7 @@ in modules // {
     name = "speaklater-1.3";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/speaklater/${name}.tar.gz";
+      url = "mirror://pypi/s/speaklater/${name}.tar.gz";
       sha256 = "1ab5dbfzzgz6cnz4xlwx79gz83id4bhiw67k1cgqrlzfs0va7zjr";
     };
 
@@ -24688,7 +24688,7 @@ in modules // {
     version = "0.10.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pushbullet.py/pushbullet.py-0.10.0.tar.gz";
+      url = "mirror://pypi/p/pushbullet.py/pushbullet.py-0.10.0.tar.gz";
       sha256 = "537d3132e1dbc91e31ade4cccf4c7def6f9d48e904a67f341d35b8a54a9be74d";
     };
 
@@ -24699,7 +24699,7 @@ in modules // {
     name = "power-1.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/power/${name}.tar.gz";
+      url = "mirror://pypi/p/power/${name}.tar.gz";
       sha256 = "7d7d60ec332acbe3a7d00379b45e39abf650bf7ee311d61da5ab921f52f060f0";
     };
 
@@ -24811,7 +24811,7 @@ in modules // {
     name = "toposort-${version}";
     version = "1.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/toposort/toposort-1.1.tar.gz";
+      url = "mirror://pypi/t/toposort/toposort-1.1.tar.gz";
       sha256 = "1izmirbwmd9xrk7rq83p486cvnsslfa5ljvl7rijj1r64zkcnf3a";
     };
     meta = {
@@ -24914,7 +24914,7 @@ in modules // {
     name = "funcy-1.6";
 
     src = pkgs.fetchurl {
-        url = "https://pypi.python.org/packages/source/f/funcy/${name}.tar.gz";
+        url = "mirror://pypi/f/funcy/${name}.tar.gz";
         sha256 = "511495db0c5660af18d3151b008c6ce698ae7fbf60887278e79675e35eed1f01";
     };
 
@@ -24933,7 +24933,7 @@ in modules // {
     name = "boto-2.30.0";
     disabled = ! isPy27;
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/b/boto/boto-2.30.0.tar.gz;
+      url = mirror://pypi/b/boto/boto-2.30.0.tar.gz;
       sha256 = "12gl8azmx1vv8dbv9jhnsbhjpc2dd1ng0jlbcg734k6ggwq1h6hh";
     };
     doCheck = false;
@@ -24948,7 +24948,7 @@ in modules // {
     name = "gcs-oauth2-boto-plugin-1.8";
     disabled = ! isPy27;
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/g/gcs-oauth2-boto-plugin/gcs-oauth2-boto-plugin-1.8.tar.gz;
+      url = mirror://pypi/g/gcs-oauth2-boto-plugin/gcs-oauth2-boto-plugin-1.8.tar.gz;
       sha256 = "0jy62y5bmaf1mb735lqwry1s5nx2qqrxvl5sxip9yg4miih3qkyb";
     };
     propagatedBuildInputs = with self; [ boto-230 httplib2 google_api_python_client retry_decorator pkgs.pyopenssl socksipy-branch ];
@@ -24971,7 +24971,7 @@ in modules // {
     doCheck = false;
 
     src = pkgs.fetchurl {
-      url = https://pypi.python.org/packages/source/g/gsutil/gsutil-4.6.tar.gz;
+      url = mirror://pypi/g/gsutil/gsutil-4.6.tar.gz;
       sha256 = "1i0clm60162rbk45ljr8nsw4ndkzjnwb7r440shcqjrvw8jq49mn";
     };
 
@@ -25067,7 +25067,7 @@ in modules // {
     version = "0.2.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/W/WSGIProxy/WSGIProxy-${version}.tar.gz";
+      url = "mirror://pypi/W/WSGIProxy/WSGIProxy-${version}.tar.gz";
       sha256 = "0wqz1q8cvb81a37gb4kkxxpv4w7k8192a08qzyz67rn68ln2wcig";
     };
 
@@ -25087,7 +25087,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/blist/blist-${version}.tar.gz";
+      url = "mirror://pypi/b/blist/blist-${version}.tar.gz";
       sha256 = "1hqz9pqbwx0czvq9bjdqjqh5bwfksva1is0anfazig81n18c84is";
     };
   };
@@ -25112,7 +25112,7 @@ in modules // {
     version = "2.4.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/daemonize/daemonize-${version}.tar.gz";
+      url = "mirror://pypi/d/daemonize/daemonize-${version}.tar.gz";
       sha256 = "0y139sq657bpzfv6k0aqm4071z4s40i6ybpni9qvngvdcz6r86n2";
     };
   };
@@ -25122,7 +25122,7 @@ in modules // {
     version = "0.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pydenticon/pydenticon-0.2.tar.gz";
+      url = "mirror://pypi/p/pydenticon/pydenticon-0.2.tar.gz";
       sha256 = "035dawcspgjw2rksbnn863s7b0i9ac8cc1nshshvd1l837ir1czp";
     };
     propagatedBuildInputs = with self; [
@@ -25148,7 +25148,7 @@ in modules // {
     version = "0.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/P/PyNaCl/PyNaCl-0.3.0.tar.gz";
+      url = "mirror://pypi/P/PyNaCl/PyNaCl-0.3.0.tar.gz";
       sha256 = "1hknxlp3a3f8njn19w92p8nhzl9jkfwzhv5fmxhmyq2m8hqrfj8j";
     };
 
@@ -25160,7 +25160,7 @@ in modules // {
     version = "14.0.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/service_identity/service_identity-${version}.tar.gz";
+      url = "mirror://pypi/s/service_identity/service_identity-${version}.tar.gz";
       sha256 = "0njg9bklkkp4rl2b9vsfh9aasxy3w2dmjkv9cq34jn65lwcs619i";
     };
 
@@ -25228,7 +25228,7 @@ in modules // {
     ] ++ optionals (!isPy3k) [ futures ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/thumbor/${name}.tar.gz";
+      url = "mirror://pypi/t/thumbor/${name}.tar.gz";
       sha256 = "57b0d7e261e792b2e2c53a79c3d8c722964003d1828331995dc3491dc67db7d8";
     };
 
@@ -25244,7 +25244,7 @@ in modules // {
     disabled = ! isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/thumbor-pexif/${name}.tar.gz";
+      url = "mirror://pypi/t/thumbor-pexif/${name}.tar.gz";
       sha256 = "715cd24760c7c28d6270c79c9e29b55b8d952a24e0e56833d827c2c62451bc3c";
     };
 
@@ -25262,7 +25262,7 @@ in modules // {
     disabled = ! isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/${baseName}/${name}.tar.gz";
+      url = "mirror://pypi/p/${baseName}/${name}.tar.gz";
       sha256 = "0lc1x0pai85avm1r452xnvxc12wijnhz87xv20yp3is9fs6rnkrh";
     };
 
@@ -25309,7 +25309,7 @@ in modules // {
     disabled = ! isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/datadiff/datadiff-1.1.6.zip";
+      url = "mirror://pypi/d/datadiff/datadiff-1.1.6.zip";
       sha256 = "f1402701063998f6a70609789aae8dc05703f3ad0a34882f6199653654c55543";
     };
 
@@ -25326,7 +25326,7 @@ in modules // {
     name = "termcolor-1.1.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/termcolor/termcolor-1.1.0.tar.gz";
+      url = "mirror://pypi/t/termcolor/termcolor-1.1.0.tar.gz";
       sha256 = "1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b";
     };
 
@@ -25342,7 +25342,7 @@ in modules // {
     disabled = ! isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/html2text/${name}.tar.gz";
+      url = "mirror://pypi/h/html2text/${name}.tar.gz";
       sha256 = "021pqcshxajhdy4whkawz95v98m8njv5lknzgac0sp8jzl01qls4";
     };
 
@@ -25393,7 +25393,7 @@ in modules // {
     disabled = isPyPy;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/networkx/${name}.tar.gz";
+      url = "mirror://pypi/n/networkx/${name}.tar.gz";
       sha256 = "ced4095ab83b7451cec1172183eff419ed32e21397ea4e1971d92a5808ed6fb8";
     };
 
@@ -25409,7 +25409,7 @@ in modules // {
   ofxclient = buildPythonPackage rec {
     name = "ofxclient-1.3.8";
 	src = pkgs.fetchurl {
-	  url = "https://pypi.python.org/packages/source/o/ofxclient/${name}.tar.gz";
+	  url = "mirror://pypi/o/ofxclient/${name}.tar.gz";
 	  sha256 = "99ab03bffdb30d9ec98724898f428f8e73129483417d5892799a0f0d2249f233";
 	};
 
@@ -25422,7 +25422,7 @@ in modules // {
   ofxhome = buildPythonPackage rec {
 	name = "ofxhome-0.3.1";
 	src = pkgs.fetchurl {
-	  url = "https://pypi.python.org/packages/source/o/ofxhome/${name}.tar.gz";
+	  url = "mirror://pypi/o/ofxhome/${name}.tar.gz";
 	  sha256 = "0000db437fd1a8c7c65cea5d88ce9d3b54642a1f4844dde04f860e29330ac68d";
 	};
 
@@ -25441,7 +25441,7 @@ in modules // {
   ofxparse = buildPythonPackage rec {
 	name = "ofxparse-0.14";
 	src = pkgs.fetchurl {
-	  url = "https://pypi.python.org/packages/source/o/ofxparse/${name}.tar.gz";
+	  url = "mirror://pypi/o/ofxparse/${name}.tar.gz";
 	  sha256 = "d8c486126a94d912442d040121db44fbc4a646ea70fa935df33b5b4dbfbbe42a";
 	};
 
@@ -25457,7 +25457,7 @@ in modules // {
   ofxtools = buildPythonPackage rec {
     name = "ofxtools-0.3.8";
 	src = pkgs.fetchurl {
-	  url = "https://pypi.python.org/packages/source/o/ofxtools/${name}.tar.gz";
+	  url = "mirror://pypi/o/ofxtools/${name}.tar.gz";
 	  sha256 = "88f289a60f4312a1599c38a8fb3216e2b46d10cc34476f9a16a33ac8aac7ec35";
 	};
     meta = {
@@ -25508,7 +25508,7 @@ in modules // {
     name = "dicttoxml-1.6.4";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dicttoxml/dicttoxml-1.6.4.tar.gz";
+      url = "mirror://pypi/d/dicttoxml/dicttoxml-1.6.4.tar.gz";
       sha256 = "5f29e95fec56680823dc41911c04c2af08727ee53c1b60e83c489212bab71161";
     };
 
@@ -25526,7 +25526,7 @@ in modules // {
     version = "2.3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/markdown2/${name}.zip";
+      url = "mirror://pypi/m/markdown2/${name}.zip";
       sha256 = "073zyx3caqa9zlzxa82k9k2nhhn8c5imqpgp5nwqnh0fgaj9pqn8";
     };
     propagatedBuildInputs = with self; [];
@@ -25545,7 +25545,7 @@ in modules // {
     disabled = ! isPy27; #some dependencies do not work with py3
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/e/evernote/${name}.tar.gz";
+      url = "mirror://pypi/e/evernote/${name}.tar.gz";
       sha256 = "1lwlg6fpi3530245jzham1400a5b855bm4sbdyck229h9kg1v02d";
     };
 
@@ -25564,7 +25564,7 @@ in modules // {
     version = "1.1.9";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/setproctitle/setproctitle-${version}.tar.gz";
+      url = "mirror://pypi/s/setproctitle/setproctitle-${version}.tar.gz";
       sha256 = "1mqadassxcm0m9r1l02m5vr4bbandn48xz8gifvxmb4wiz8i8d0w";
     };
 
@@ -25581,7 +25581,7 @@ in modules // {
     version = "0.9.3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/thrift/${name}.tar.gz";
+      url = "mirror://pypi/t/thrift/${name}.tar.gz";
       sha256 = "dfbc3d3bd19d396718dab05abaf46d93ae8005e2df798ef02e32793cd963877e";
     };
 
@@ -25637,7 +25637,7 @@ in modules // {
     disabled = isPy34;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/trollius/${name}.tar.gz";
+      url = "mirror://pypi/t/trollius/${name}.tar.gz";
       sha256 = "8884cae4ec6a2d593abcffd5e700626ad4618f42b11beb2b75998f2e8247de76";
     };
 
@@ -25695,7 +25695,7 @@ in modules // {
     name = "neovim-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/n/neovim/${name}.tar.gz";
+      url = "mirror://pypi/n/neovim/${name}.tar.gz";
       sha256 = "93f475d5583a053af919ba0729b32b3fefef1dbde4717b5657d806bdc69b76b3";
     };
 
@@ -25743,7 +25743,7 @@ in modules // {
     version = "0.4.1";
     name = "ghp-import-${version}";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/ghp-import/${name}.tar.gz";
+      url = "mirror://pypi/g/ghp-import/${name}.tar.gz";
       sha256 = "6058810e1c46dd3b5b1eee87e203bdfbd566e10cfc77566edda7aa4dbf6a3053";
     };
     disabled = isPyPy;
@@ -25762,7 +25762,7 @@ in modules // {
   typogrify = buildPythonPackage rec {
     name = "typogrify-2.0.7";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/typogrify/${name}.tar.gz";
+      url = "mirror://pypi/t/typogrify/${name}.tar.gz";
       sha256 = "8be4668cda434163ce229d87ca273a11922cb1614cb359970b7dc96eed13cb38";
     };
     disabled = isPyPy;
@@ -25800,7 +25800,7 @@ in modules // {
     name = "pypeg2-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pyPEG2/pyPEG2-${version}.tar.gz";
+      url = "mirror://pypi/p/pyPEG2/pyPEG2-${version}.tar.gz";
       sha256 = "f4814a5f9c84bbb0794bef8d2a5871f4aed25366791c55e2162681873ad8bd21";
     };
 
@@ -25816,7 +25816,7 @@ in modules // {
     disabled = ! (isPy26 || isPy27);
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/j/jenkins-job-builder/${name}.tar.gz";
+      url = "mirror://pypi/j/jenkins-job-builder/${name}.tar.gz";
       sha256 = "10zipq3dyyfhwvrcyk70zky07b0fssiahwig2h8daw977aszsfqb";
     };
 
@@ -25853,7 +25853,7 @@ in modules // {
     name = "dot2tex-2.9.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/dot2tex/dot2tex-2.9.0.tar.gz";
+      url = "mirror://pypi/d/dot2tex/dot2tex-2.9.0.tar.gz";
       sha256 = "7d3e54add7dccdaeb6cc9e61ceaf7b587914cf8ebd6821cfea008acdc1e50d4a";
     };
 
@@ -25907,7 +25907,7 @@ in modules // {
     name = "potr-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-potr/python-${name}.zip";
+      url = "mirror://pypi/p/python-potr/python-${name}.zip";
       sha256 = "1b3vjbv8hvynwj6amw3rg5zj8bagynbj0ipy09xwksf1mb0kz8m8";
     };
 
@@ -25926,7 +25926,7 @@ in modules // {
     version = "0.3.1";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pluggy/${name}.tar.gz";
+      url = "mirror://pypi/p/pluggy/${name}.tar.gz";
       sha256 = "18qfzfm40bgx672lkg8q9x5hdh76n7vax99aank7vh2nw21wg70m";
     };
 
@@ -25943,7 +25943,7 @@ in modules // {
     name = "xcffib-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xcffib/${name}.tar.gz";
+      url = "mirror://pypi/x/xcffib/${name}.tar.gz";
       sha256 = "a84eecd5a1bb7570e26c83aca87a2016578ca4e353e1fa56189e95bdef063e6a";
     };
 
@@ -25967,7 +25967,7 @@ in modules // {
     version = "0.5.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pafy/${name}.tar.gz";
+      url = "mirror://pypi/p/pafy/${name}.tar.gz";
       sha256 = "1q699dcnq34nfgm0bg8mp5krhzk9cyirqdcadhs9al4fa5410igw";
     };
 
@@ -25986,7 +25986,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/suds/suds-0.4.tar.gz";
+      url = "mirror://pypi/s/suds/suds-0.4.tar.gz";
       sha256 = "1w4s9051iv90c0gs73k80c3d51y2wbx1xgfdgg2hk7mv4gjlllnm";
     };
 
@@ -26005,7 +26005,7 @@ in modules // {
     disabled = isPyPy;  # lots of failures
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/suds-jurko/${name}.zip";
+      url = "mirror://pypi/s/suds-jurko/${name}.zip";
       sha256 = "1s4radwf38kdh3jrn5acbidqlr66sx786fkwi0rgq61hn4n2bdqw";
     };
 
@@ -26030,7 +26030,7 @@ in modules // {
     disabled = !isPy27;
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/maildir-deduplicate/${name}.tar.gz";
+      url = "mirror://pypi/m/maildir-deduplicate/${name}.tar.gz";
       sha256 = "1xy5z756alrjgpl9qx2gdx898rw1mryrqkwmipbh39mgrvkl3fz9";
     };
 
@@ -26073,7 +26073,7 @@ in modules // {
 
     buildInputs = with self; [ nose ];
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/d/d2to1/d2to1-${version}.tar.gz";
+      url = "mirror://pypi/d/d2to1/d2to1-${version}.tar.gz";
       sha256 = "1a5z367b7dpd6dgi0w8pymb68aj2pblk8w04l2c8hibhj8dpl2b4";
     };
 
@@ -26093,7 +26093,7 @@ in modules // {
     propagatedBuildInputs = with self; [ requests2 ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/o/ovh/ovh-${version}.tar.gz";
+      url = "mirror://pypi/o/ovh/ovh-${version}.tar.gz";
       sha256 = "1y74lrdlgbb786mwas7ynphimfi00dgr67ncjq20kdf31jg5415n";
     };
 
@@ -26111,7 +26111,7 @@ in modules // {
     disabled = pythonOlder "2.7";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/W/Willow/Willow-${version}.tar.gz";
+      url = "mirror://pypi/W/Willow/Willow-${version}.tar.gz";
       sha256 = "111c82fbfcda2710ce6201b0b7e0cfa1ff3c4f2f0dc788cc8dfc8db933c39c73";
     };
 
@@ -26136,7 +26136,7 @@ in modules // {
     doCheck = false;  # missing json file from tarball
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/i/${simpleName}/${name}.tar.gz";
+      url = "mirror://pypi/i/${simpleName}/${name}.tar.gz";
       sha256 = "194bl8l8sc2ibwi6g5kz6xydkbngdqpaj6r2gcsaw1fc73iswwrj";
     };
 
@@ -26164,7 +26164,7 @@ in modules // {
       xstatic-pygments
     ];
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/b/bepasty/bepasty-${version}.tar.gz";
+      url = "mirror://pypi/b/bepasty/bepasty-${version}.tar.gz";
       sha256 = "0bs79pgrjlnkmjfyj2hllbx3rw757va5w2g2aghi9cydmsl7gyi4";
     };
 
@@ -26180,7 +26180,7 @@ in modules // {
     name = "xkcdpass-${version}";
     version = "1.4.2";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xkcdpass/xkcdpass-1.4.2.tar.gz";
+      url = "mirror://pypi/x/xkcdpass/xkcdpass-1.4.2.tar.gz";
       sha256 = "4c1f8bee886820c42ccc64c15c3a2275dc6d01028cf6af7c481ded87267d8269";
     };
 
@@ -26200,7 +26200,7 @@ in modules // {
     name = "XStatic-${version}";
     version = "1.0.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic/XStatic-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic/XStatic-${version}.tar.gz";
       sha256 = "09npcsyf1ccygjs0qc8kdsv4qqy8gm1m6iv63g9y1fgbcry3vj8f";
     };
     meta = {
@@ -26215,7 +26215,7 @@ in modules // {
     name = "xlsx2csv-${version}";
     version = "0.7.2";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/xlsx2csv/${name}.tar.gz";
+      url = "mirror://pypi/x/xlsx2csv/${name}.tar.gz";
       sha256 = "7c6c8fa6c2774224d03a6a96049e116822484dccfa3634893397212ebcd23866";
     };
     meta = {
@@ -26251,7 +26251,7 @@ in modules // {
     name = "XStatic-Bootbox-${version}";
     version = "4.3.0.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic-Bootbox/XStatic-Bootbox-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic-Bootbox/XStatic-Bootbox-${version}.tar.gz";
       sha256 = "0wks1lsqngn3gvlhzrvaan1zj8w4wr58xi0pfqhrzckbghvvr0gj";
     };
 
@@ -26267,7 +26267,7 @@ in modules // {
     name = "XStatic-Bootstrap-${version}";
     version = "3.3.5.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic-Bootstrap/XStatic-Bootstrap-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic-Bootstrap/XStatic-Bootstrap-${version}.tar.gz";
       sha256 = "0jzjq3d4vp2shd2n20f9y53jnnk1cvphkj1v0awgrf18qsy2bmin";
     };
 
@@ -26283,7 +26283,7 @@ in modules // {
     name = "XStatic-jQuery-${version}";
     version = "1.10.2.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic-jQuery/XStatic-jQuery-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic-jQuery/XStatic-jQuery-${version}.tar.gz";
       sha256 = "018kx4zijflcq8081xx6kmiqf748bsjdq7adij2k91bfp1mnlhc3";
     };
 
@@ -26300,7 +26300,7 @@ in modules // {
     version = "9.7.0.1";
     propagatedBuildInputs = with self;[ xstatic-jquery ];
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic-jQuery-File-Upload/XStatic-jQuery-File-Upload-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic-jQuery-File-Upload/XStatic-jQuery-File-Upload-${version}.tar.gz";
       sha256 = "0d5za18lhzhb54baxq8z73wazq801n3qfj5vgcz7ri3ngx7nb0cg";
     };
 
@@ -26317,7 +26317,7 @@ in modules // {
     version = "1.11.0.1";
     propagatedBuildInputs = with self; [ xstatic-jquery ];
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic-jquery-ui/XStatic-jquery-ui-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic-jquery-ui/XStatic-jquery-ui-${version}.tar.gz";
       sha256 = "0n6sgg9jxrqfz4zg6iqdmx1isqx2aswadf7mk3fbi48dxcv1i6q9";
     };
 
@@ -26333,7 +26333,7 @@ in modules // {
     name = "XStatic-Pygments-${version}";
     version = "1.6.0.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/X/XStatic-Pygments/XStatic-Pygments-${version}.tar.gz";
+      url = "mirror://pypi/X/XStatic-Pygments/XStatic-Pygments-${version}.tar.gz";
       sha256 = "0fjqgg433wfdnswn7fad1g6k2x6mf24wfnay2j82j0fwgkdxrr7m";
     };
 
@@ -26350,7 +26350,7 @@ in modules // {
     name = "hidapi-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/h/hidapi/${name}.tar.gz";
+      url = "mirror://pypi/h/hidapi/${name}.tar.gz";
       sha256 = "1jaj0y5vn5yk033q01wacsz379mf3sy66d6gz072ycfr5rahcp59";
     };
 
@@ -26378,7 +26378,7 @@ in modules // {
     name = "mnemonic-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/m/mnemonic/${name}.tar.gz";
+      url = "mirror://pypi/m/mnemonic/${name}.tar.gz";
       sha256 = "0j5jm4v54135qqw455fw4ix2mhxhzjqvxji9gqkpxagk31cvbnj4";
     };
 
@@ -26397,7 +26397,7 @@ in modules // {
     name = "trezor-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/trezor/${name}.tar.gz";
+      url = "mirror://pypi/t/trezor/${name}.tar.gz";
       sha256 = "0nqbjj0mvkp314hpq36px12hxbyidmhsdflq3121l4g9y3scfbnx";
     };
 
@@ -26421,7 +26421,7 @@ in modules // {
     name = "keepkey-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/k/keepkey/${name}.tar.gz";
+      url = "mirror://pypi/k/keepkey/${name}.tar.gz";
       sha256 = "1ikyp4jpydskznsrlwmxh9sn7b64aldwj2lf0phmb19r5kk06qmp";
     };
 
@@ -26445,7 +26445,7 @@ in modules // {
     version = "2.2.1";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/s/semver/${name}.tar.gz";
+      url = "mirror://pypi/s/semver/${name}.tar.gz";
       sha256 = "161gvsfpw0l8lnf1v19rvqc8b9f8n70cc8ppya4l0n6rwc1c1n4m";
     };
 
@@ -26462,7 +26462,7 @@ in modules // {
     version = "1.4";
 
     src = pkgs.fetchurl {
-      url = "http://pypi.python.org/packages/source/e/ed25519/${name}.tar.gz";
+      url = "mirror://pypi/e/ed25519/${name}.tar.gz";
       sha256 = "0ahx1nkxa0xis3cw0h5c4fpgv8mq4znkq7kajly33lc3317bk499";
     };
 
@@ -26479,7 +26479,7 @@ in modules // {
     name = "trezor_agent-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/t/trezor_agent/${name}.tar.gz";
+      url = "mirror://pypi/t/trezor_agent/${name}.tar.gz";
       sha256 = "0wpppxzld7kqqxdvy80qc8629n047vm3m3nk171i7hijfw285p0b";
     };
 
@@ -26498,7 +26498,7 @@ in modules // {
     name = "x11_hash-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/x/x11_hash/${name}.tar.gz";
+      url = "mirror://pypi/x/x11_hash/${name}.tar.gz";
       sha256 = "172skm9xbbrivy1p4xabxihx9lsnzi53hvzryfw64m799k2fmp22";
     };
 
@@ -26514,7 +26514,7 @@ in modules // {
     name = "python-termstyle-${version}";
     version = "0.1.10";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/p/python-termstyle/${name}.tar.gz";
+      url = "mirror://pypi/p/python-termstyle/${name}.tar.gz";
       sha256 = "1qllzkx1alf14zcfapppf8w87si4cpa7lgjmdp3f5idzdyqnnapl";
     };
 
@@ -26530,7 +26530,7 @@ in modules // {
     name = "green-${version}";
     version = "2.3.0";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/g/green/${name}.tar.gz";
+      url = "mirror://pypi/g/green/${name}.tar.gz";
       sha256 = "1888khfl9yxb8yfxq9b48dxwplqlxx8s0l530z5j7c6bx74v08b4";
     };
 
@@ -26575,7 +26575,7 @@ in modules // {
     buildInputs = with self ; [ six pytest ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/w/w3lib/${name}.tar.gz";
+      url = "mirror://pypi/w/w3lib/${name}.tar.gz";
       sha256 = "bd87eae62d208eef70869951abf05e96a8ee559714074a485168de4c5b190004";
     };
 
@@ -26592,7 +26592,7 @@ in modules // {
     version = "1.4.2";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/q/queuelib/${name}.tar.gz";
+      url = "mirror://pypi/q/queuelib/${name}.tar.gz";
       sha256 = "a6829918157ed433fafa87b0bb1e93e3e63c885270166db5884a02c34c86f914";
     };
 
@@ -26616,7 +26616,7 @@ in modules // {
     propagatedBuildInputs = with self ; [ six twisted w3lib lxml cssselect queuelib pyopenssl service-identity ];
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/S/Scrapy/${name}.tar.gz";
+      url = "mirror://pypi/S/Scrapy/${name}.tar.gz";
       sha256 = "0a51c785a310d65f6e70285a2da56d48ef7d049bd7fd60a08eef05c52328ca96";
     };
 
@@ -26680,7 +26680,7 @@ in modules // {
     version = "0.1a3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/r/repeated-test/${name}.tar.gz";
+      url = "mirror://pypi/r/repeated-test/${name}.tar.gz";
       sha256 = "062syp7kl2g0x6qx3z8zb5sdycpi7qcpxp9iml2v8dqzqnij9bpg";
     };
 
@@ -26703,7 +26703,7 @@ in modules // {
     version = "1.1a3";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/s/sigtools/${name}.tar.gz";
+      url = "mirror://pypi/s/sigtools/${name}.tar.gz";
       sha256 = "190w14vzbiyvxcl9jmyyimpahar5b0bq69v9iv7chi852yi71w6w";
     };
 
@@ -26733,7 +26733,7 @@ in modules // {
     version = "3.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/source/c/clize/${name}.tar.gz";
+      url = "mirror://pypi/c/clize/${name}.tar.gz";
       sha256 = "1xkr3h404d7pgj5gdpg6bddv3v3yq2hgx8qlwkgw5abg218k53hm";
     };
 


### PR DESCRIPTION
Recently PyPI changed their url scheme at https://pypi.python.org. After some complaints they mapped the older urls to the new ones again. This is however done on the upcoming PyPI 2.0 website, and not the current website.

In this PR the new website (https://pypi.io) is added as mirror. The new website works most of the time but can still fail occasionally and is not as reliable as the old one.

cc @domenkozar @wkennington 
