### PR TITLE
Use symlinkJoin for wrappers

### DIFF
--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -11,7 +11,10 @@ let
                    rm $out/logcheck.*
                  '';
 
-  rulesDir = pkgs.symlinkJoin "logcheck-rules-dir" ([ defaultRules ] ++ cfg.extraRulesDirs);
+  rulesDir = pkgs.symlinkJoin
+    { name = "logcheck-rules-dir";
+      paths = ([ defaultRules ] ++ cfg.extraRulesDirs);
+    };
 
   configFile = pkgs.writeText "logcheck.conf" cfg.config;
 

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -63,8 +63,10 @@ let
     cfg.extraConfig
   ];
 
-  modulesDir = pkgs.symlinkJoin "dovecot-modules"
-    (map (pkg: "${pkg}/lib/dovecot") ([ dovecotPkg ] ++ map (module: module.override { dovecot = dovecotPkg; }) cfg.modules));
+  modulesDir = pkgs.symlinkJoin {
+    name = "dovecot-modules";
+    paths = map (pkg: "${pkg}/lib/dovecot") ([ dovecotPkg ] ++ map (module: module.override { dovecot = dovecotPkg; }) cfg.modules);
+  };
 
 in
 {

--- a/pkgs/applications/audio/deadbeef/wrapper.nix
+++ b/pkgs/applications/audio/deadbeef/wrapper.nix
@@ -1,22 +1,14 @@
-{ stdenv, buildEnv, deadbeef, makeWrapper, plugins }:
+{ stdenv, symlinkJoin, deadbeef, makeWrapper, plugins }:
 
-let
-drv = buildEnv {
-  name = "deadbeef-with-plugins-" + (builtins.parseDrvName deadbeef.name).version;
+symlinkJoin {
+  name = "deadbeef-with-plugins-${deadbeef.version}";
 
   paths = [ deadbeef ] ++ plugins;
 
+  buildInputs = [ makeWrapper ];
+
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${deadbeef}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     wrapProgram $out/bin/deadbeef \
       --set DEADBEEF_PLUGIN_DIR "$out/lib/deadbeef"
   '';
-  };
-in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+}

--- a/pkgs/applications/audio/puredata/wrapper.nix
+++ b/pkgs/applications/audio/puredata/wrapper.nix
@@ -1,23 +1,16 @@
-{ stdenv, buildEnv, puredata, makeWrapper, plugins }:
+{ stdenv, symlinkJoin, puredata, makeWrapper, plugins }:
 
 let
 puredataFlags = map (x: "-path ${x}/") plugins;
-drv = buildEnv {
-  name = "puredata-with-plugins-" + (builtins.parseDrvName puredata.name).version;
+in symlinkJoin {
+  name = "puredata-with-plugins-${puredata.version}";
 
   paths = [ puredata ] ++ plugins;
 
+  buildInputs = [ makeWrapper ];
+
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${puredata}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     wrapProgram $out/bin/pd \
       --add-flags "${toString puredataFlags}"
   '';
-  };
-in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+}

--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -4,7 +4,8 @@
 , python, pygtk, libart_lgpl, libexif, gettext, xorg, wrapPython }:
 
 stdenv.mkDerivation rec {
-  name = "gimp-2.8.16";
+  name = "gimp-${version}";
+  version = "2.8.16";
 
   # This declarations for `gimp-with-plugins` wrapper,
   # (used for determining $out/lib/gimp/${majorVersion}/ paths)

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -1,24 +1,18 @@
-{ stdenv, lib, buildEnv, gimp, makeWrapper, gimpPlugins, plugins ? null}:
+{ stdenv, lib, symlinkJoin, gimp, makeWrapper, gimpPlugins, plugins ? null}:
 
 let
 allPlugins = lib.filter (pkg: builtins.isAttrs pkg && pkg.type == "derivation") (lib.attrValues gimpPlugins);
 selectedPlugins = if plugins == null then allPlugins else plugins;
 extraArgs = map (x: x.wrapArgs or "") selectedPlugins;
 
-drv = buildEnv {
-  name = "gimp-with-plugins-" + (builtins.parseDrvName gimp.name).version;
+in symlinkJoin {
+  name = "gimp-with-plugins-${gimp.version}";
 
   paths = [ gimp ] ++ selectedPlugins;
 
+  buildInputs = [ makeWrapper ];
+
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${gimp}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     for each in gimp-2.8 gimp-console-2.8; do
       wrapProgram $out/bin/$each \
         --set GIMP2_PLUGINDIR "$out/lib/gimp/2.0" \
@@ -29,5 +23,4 @@ drv = buildEnv {
       ln -sf "$each-2.8" $out/bin/$each
     done
   '';
-  };
-in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+}

--- a/pkgs/applications/misc/k3b/wrapper.nix
+++ b/pkgs/applications/misc/k3b/wrapper.nix
@@ -1,22 +1,14 @@
-{ lib, buildEnv, k3b-original, cdrtools, makeWrapper }:
+{ lib, symlinkJoin, k3b-original, cdrtools, makeWrapper }:
 
 let
   binPath = lib.makeBinPath [ cdrtools ];
-in buildEnv {
+in symlinkJoin {
   name = "k3b-${k3b-original.version}";
 
   paths = [ k3b-original ];
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${k3b-original}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     wrapProgram $out/bin/k3b \
       --prefix PATH ':' ${binPath}
   '';

--- a/pkgs/applications/misc/rxvt_unicode/wrapper.nix
+++ b/pkgs/applications/misc/rxvt_unicode/wrapper.nix
@@ -1,28 +1,21 @@
-{ stdenv, buildEnv, rxvt_unicode, makeWrapper, plugins }:
+{ stdenv, symlinkJoin, rxvt_unicode, makeWrapper, plugins }:
 
 let
   rxvt = rxvt_unicode.override {
     perlSupport = true;
   };
 
-  drv = buildEnv {
-    name = "${rxvt.name}-with-plugins";
+in symlinkJoin {
+  name = "${rxvt.name}-with-plugins";
 
-    paths = [ rxvt ] ++ plugins;
+  paths = [ rxvt ] ++ plugins;
 
-    postBuild = ''
-      # TODO: This could be avoided if buildEnv could be forced to create all directories
-      if [ -L $out/bin ]; then
-        rm $out/bin
-        mkdir $out/bin
-        for i in ${rxvt}/bin/*; do
-          ln -s $i $out/bin
-        done
-      fi
-      wrapProgram $out/bin/urxvt \
-        --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
-      wrapProgram $out/bin/urxvtd \
-        --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
-    '';
-  };
-in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/urxvt \
+      --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
+    wrapProgram $out/bin/urxvtd \
+      --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
+  '';
+}

--- a/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
@@ -1,24 +1,17 @@
-{ stdenv, buildEnv, pidgin, makeWrapper, plugins }:
+{ stdenv, symlinkJoin, pidgin, makeWrapper, plugins }:
 
 let
 extraArgs = map (x: x.wrapArgs or "") plugins;
-drv = buildEnv {
-  name = "pidgin-with-plugins-" + (builtins.parseDrvName pidgin.name).version;
+in symlinkJoin {
+  name = "pidgin-with-plugins-${pidgin.version}";
 
   paths = [ pidgin ] ++ plugins;
 
+  buildInputs = [ makeWrapper ];
+
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${pidgin}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     wrapProgram $out/bin/pidgin \
       --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion} $out/lib/pidgin" \
       ${toString extraArgs}
   '';
-  };
-in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+}

--- a/pkgs/applications/video/avidemux/wrapper.nix
+++ b/pkgs/applications/video/avidemux/wrapper.nix
@@ -1,4 +1,4 @@
-{ buildEnv, avidemux_unwrapped, makeWrapper
+{ symlinkJoin, avidemux_unwrapped, makeWrapper
 # GTK version is broken upstream, see https://bugzilla.redhat.com/show_bug.cgi?id=1244340
 , withUi ? "qt4"
 }:
@@ -7,24 +7,14 @@ let ui = builtins.getAttr "avidemux_${withUi}" avidemux_unwrapped; in
 
 assert ui.isUi;
 
-buildEnv {
-  name = "avidemux-${withUi}-" + ui.version;
+symlinkJoin {
+  name = "avidemux-${withUi}-${ui.version}";
 
   paths = [ ui avidemux_unwrapped.avidemux_common avidemux_unwrapped.avidemux_settings ];
-
-  ignoreCollisions = true;
 
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${ui}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     for i in $out/bin/*; do
       wrapProgram $i --set ADM_ROOT_DIR $out
     done

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -47,16 +47,24 @@ rec {
 
 
   # Create a forest of symlinks to the files in `paths'.
-  symlinkJoin = name: paths:
+  symlinkJoin =
+    { name
+    , paths
+    , preferLocalBuild ? true
+    , allowSubstitutes ? false
+    , postBuild ? ""
+    , buildInputs ? []
+    , meta ? {}
+    }:
     runCommand name
-      { inherit paths;
-        preferLocalBuild = true; allowSubstitutes = false;
+      { inherit paths preferLocalBuild allowSubstitutes buildInputs meta;
       }
       ''
         mkdir -p $out
         for i in $paths; do
           ${lndir}/bin/lndir $i $out
         done
+        ${postBuild}
       '';
 
 

--- a/pkgs/desktops/kde-5/plasma-5.5/default.nix
+++ b/pkgs/desktops/kde-5/plasma-5.5/default.nix
@@ -51,8 +51,10 @@ let
       let
         version = (builtins.parseDrvName breeze-qt5.name).version;
       in
-        symlinkJoin "breeze-${version}"
-        (map (pkg: pkg.out or pkg) [ breeze-gtk breeze-qt4 breeze-qt5 ]);
+        symlinkJoin {
+          name = "breeze-${version}";
+          paths = map (pkg: pkg.out or pkg) [ breeze-gtk breeze-qt4 breeze-qt5 ];
+        };
     kde-cli-tools = callPackage ./kde-cli-tools.nix {};
     kde-gtk-config = callPackage ./kde-gtk-config {};
     kdecoration = callPackage ./kdecoration.nix {};

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -1,10 +1,8 @@
 { stdenv, fetchFromGitHub, coreutils, qtbase, qtdeclarative, qmakeHook, texlive }:
 
-let
-  version = "37.0.0";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "dwarf-therapist-original-${version}";
+  version = "37.0.0";
 
   src = fetchFromGitHub {
     owner = "splintermind";

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -1,4 +1,4 @@
-{ buildEnv, lib, dwarf-therapist-original, dwarf-fortress-original, makeWrapper }:
+{ symlinkJoin, lib, dwarf-therapist-original, dwarf-fortress-original, makeWrapper }:
 
 let
   df = dwarf-fortress-original;
@@ -6,8 +6,8 @@ let
   inifile = "linux/v0${df.baseVersion}.${df.patchVersion}.ini";
   dfHashFile = "${df}/hash.md5";
 
-in buildEnv {
-  name = "dwarf-therapist-${lib.getVersion dt}";
+in symlinkJoin {
+  name = "dwarf-therapist-${dt.version}";
 
   paths = [ dt ];
 
@@ -16,22 +16,10 @@ in buildEnv {
   postBuild = ''
     # DwarfTherapist assumes it's run in $out/share/dwarftherapist and
     # therefore uses many relative paths.
-    rm $out/bin
-    mkdir $out/bin
-    makeWrapper ${dt}/bin/DwarfTherapist $out/bin/DwarfTherapist \
+    wrapProgram $out/bin/DwarfTherapist \
       --run "cd $out/share/dwarftherapist"
 
-    # Fix checksum of memory access directives. We really need #4621 fixed!
-    recreate_dir() {
-      rm "$out/$1"
-      mkdir -p "$out/$1"
-      for i in "${dt}/$1/"*; do
-        ln -s "$i" "$out/$1"
-      done
-    }
-
-    recreate_dir share
-    recreate_dir share/dwarftherapist
+    rm -rf $out/share/dwarftherapist/memory_layouts/linux
     mkdir -p $out/share/dwarftherapist/memory_layouts/linux
     origmd5=$(cat "${dfHashFile}.orig" | cut -c1-8)
     patchedmd5=$(cat "${dfHashFile}" | cut -c1-8)

--- a/pkgs/tools/cd-dvd/brasero/wrapper.nix
+++ b/pkgs/tools/cd-dvd/brasero/wrapper.nix
@@ -1,22 +1,14 @@
-{ lib, buildEnv, brasero-original, cdrtools, makeWrapper }:
+{ lib, symlinkJoin, brasero-original, cdrtools, makeWrapper }:
 
 let
   binPath = lib.makeBinPath [ cdrtools ];
-in buildEnv {
+in symlinkJoin {
   name = "brasero-${brasero-original.version}";
 
   paths = [ brasero-original ];
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${brasero-original}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     wrapProgram $out/bin/brasero \
       --prefix PATH ':' ${binPath}
   '';

--- a/pkgs/tools/inputmethods/fcitx/wrapper.nix
+++ b/pkgs/tools/inputmethods/fcitx/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildEnv, fcitx, fcitx-configtool, makeWrapper, plugins, kde5 }:
+{ stdenv, symlinkJoin, fcitx, fcitx-configtool, makeWrapper, plugins, kde5 }:
 
 # This is based on the pidgin-with-plugins package.
 # Users should be able to configure what plugins are used
@@ -12,24 +12,16 @@
 #     (fcitx-with-plugins.override { plugins = [ fcitx-anthy ]; })
 # }
 
-let
-drv = buildEnv {
-  name = "fcitx-with-plugins-" + (builtins.parseDrvName fcitx.name).version;
+symlinkJoin {
+  name = "fcitx-with-plugins-${fcitx.version}";
 
   paths = [ fcitx fcitx-configtool kde5.fcitx-qt5 ] ++ plugins;
 
+  buildInputs = [ makeWrapper ];
+
   postBuild = ''
-    # TODO: This could be avoided if buildEnv could be forced to create all directories
-    if [ -L $out/bin ]; then
-      rm $out/bin
-      mkdir $out/bin
-      for i in ${fcitx}/bin/*; do
-        ln -s $i $out/bin
-      done
-    fi
     wrapProgram $out/bin/fcitx \
       --set FCITXDIR "$out/"
   '';
-  };
-in stdenv.lib.overrideDerivation drv (x : { buildInputs = x.buildInputs ++ [ makeWrapper ]; })
+}
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This extends `symlinkJoin` function to accept a set with several additional arguments, and uses that to refactor many buildEnv-and-wrap-style wrappers in the tree. Also fixes `dwarf-therapist`.

cc @magnetophon @avnik @ericsagnes 
