### PR TITLE
containers: test imperative and ipv4 in small-release

### DIFF
--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -31,7 +31,8 @@ in rec {
     inherit (nixos') channel manual iso_minimal dummy;
     tests = {
       inherit (nixos'.tests)
-        containers
+        containers-imperative
+        containers-ipv4
         firewall
         ipv6
         login


### PR DESCRIPTION
I broke the small-release on hydra with this in #14018. Sorry. This here should fix it.

Test imperative containers and declarative containers with ipv4. These two
tests are basically the extraction of the containers test from before.

@fpletz or @edolstra: can you review and merge this?
