### PR TITLE
php: add default php.ini

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -123,6 +123,7 @@ with lib;
     (mkRemovedOptionModule [ "services" "printing" "cupsFilesConf" ])
     (mkRemovedOptionModule [ "services" "printing" "cupsdConf" ])
     (mkRemovedOptionModule [ "services" "xserver" "startGnuPGAgent" ])
+    (mkRemovedOptionModule [ "services" "phpfpm" "phpIni" ])
 
   ];
 }

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -406,7 +406,7 @@ let
         ([ mainCfg.phpOptions ] ++ (map (svc: svc.phpOptions) allSubservices));
     }
     ''
-      cat ${php}/etc/php-recommended.ini > $out
+      cat ${php}/etc/php.ini > $out
       echo "$options" >> $out
     '';
 

--- a/nixos/modules/services/web-servers/phpfpm.nix
+++ b/nixos/modules/services/web-servers/phpfpm.nix
@@ -19,6 +19,12 @@ let
     ${concatStringsSep "\n" (mapAttrsToList (n: v: "[${n}]\n${v}") cfg.poolConfigs)}
   '';
 
+  phpIni = pkgs.writeText "php.ini" ''
+    ${readFile "${cfg.phpPackage}/etc/php.ini"}
+
+    ${cfg.phpOptions}
+  '';
+
 in {
 
   options = {
@@ -44,10 +50,15 @@ in {
         '';
       };
 
-      phpIni = mkOption {
-        type = types.path;
-        default = "${cfg.phpPackage}/etc/php-recommended.ini";
-        description = "php.ini file to use.";
+      phpOptions = mkOption {
+        type = types.lines;
+        default = "";
+        example =
+          ''
+            date.timezone = "CET"
+          '';
+        description =
+          "Options appended to the PHP configuration file <filename>php.ini</filename>.";
       };
 
       poolConfigs = mkOption {
@@ -84,7 +95,7 @@ in {
         mkdir -p "${stateDir}"
       '';
       serviceConfig = {
-        ExecStart = "${cfg.phpPackage}/sbin/php-fpm -y ${cfgFile} -c ${cfg.phpIni}";
+        ExecStart = "${cfg.phpPackage}/bin/php-fpm -y ${cfgFile} -c ${phpIni}";
         PIDFile = pidFile;
       };
     };

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -265,14 +265,12 @@ let
             --replace '@PHP_LDFLAGS@' ""
         done
 
-        iniFile=$out/etc/php-recommended.ini
         [[ -z "$libxml2" ]] || export PATH=$PATH:$libxml2/bin
         ./configure --with-config-file-scan-dir=/etc --with-config-file-path=$out/etc --prefix=$out $configureFlags
       '';
 
-      installPhase = ''
-        unset installPhase; installPhase;
-        cp php.ini-production $iniFile
+      postInstall = ''
+        cp php.ini-production $out/etc/php.ini
       '';
 
       src = fetchurl {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

PHP had no `php.ini` file set by default.
It is useful to have one so cli mode php can run with sane settings. (see #9625)

The following PR does:
- set the `php.ini` in the php package to the provided `php.ini-production` (for reference Archlinux does the [same](https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/php#n183))
- remove the `php-recommended.ini` as it become meaningless
- update the services that were using `php-recommended.ini` (namely httpd and phpfpm)
- remove the `services.phpfpm.phpIni` option as it redundant and there is no need for another way to override `php.ini`

~~One could consider to have the default `php.ini` immutable in the store could be an issue, but php provides many (too much?) ways to change this functionality so this shouldn't be a problem.
The normal way would be to use `/etc/php.ini` to add or change settings, else it is possible to use no setting file with the `-n` flag, use a different file with the `-c` flag or override it with the `PHPRC` environment variable.~~

**update**
- added a `phpOptions` to the fpm service

cc 
- php maintainer @globin 
- phpfpm module creator @rickynils 
