### PR TITLE
freeradius: fix checkrad paths by providing perl, finger substitution

### DIFF
--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, talloc
+{ stdenv, fetchurl, autoreconfHook, talloc, finger_bsd, perl
 , openssl
 , linkOpenssl? true
 , openldap
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   name = "freeradius-${version}";
   version = "3.0.11";
 
-  buildInputs = [ autoreconfHook openssl talloc ]
+  buildInputs = [ autoreconfHook openssl talloc finger_bsd perl ]
     ++ optional withLdap [ openldap ]
     ++ optional withSqlite [ sqlite ]
     ++ optional withPcap [ libpcap ]
@@ -59,6 +59,10 @@ stdenv.mkDerivation rec {
      "--sysconfdir=/etc"
      "--localstatedir=/var"
   ] ++ optional (!linkOpenssl) "--with-openssl=no";
+
+  postPatch = ''
+    substituteInPlace src/main/checkrad.in --replace "/usr/bin/finger" "${finger_bsd}/bin/finger"
+  '';
 
   installFlags = [
     "sysconfdir=\${out}/etc"


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
